### PR TITLE
seed debug

### DIFF
--- a/src/zeroband/inference.py
+++ b/src/zeroband/inference.py
@@ -5,6 +5,7 @@ import json
 from pathlib import Path
 from typing import Literal
 import uuid
+import numpy as np
 from pydantic import model_validator
 import torch
 from vllm import LLM, SamplingParams
@@ -228,7 +229,7 @@ def inference(config: Config):
     tokenizer = llm.get_tokenizer()
     logger = get_logger(f"INFERENCE {os.environ.get('RANK', '')}")
     sampling_params = SamplingParams(**config.sampling.model_dump())
-    dataset = load_dataset(config.dataset, split="train").shuffle()  # todo never set seed otherwise this will be fucked
+    dataset = load_dataset(config.dataset, split="train").shuffle(generator=np.random.default_rng())
     max_samples = config.max_samples or len(dataset)
 
     ckpt_step = 0


### PR DESCRIPTION
before

```
04:07:29 [INFO] [INFERENCE 0] [Rank 0] Batch throughput: 7449.41 tok/sec (4536 tokens in 0.61s, avg seq len: 70.9)
04:07:30 [INFO] [INFERENCE 1] [Rank 0] Batch throughput: 8683.23 tok/sec (4536 tokens in 0.52s, avg seq len: 70.9)
```

(see the avg_seq len showing that it's the same data)


after

```
04:04:53 [INFO] [INFERENCE 1] [Rank 0] Batch throughput: 6797.81 tok/sec (4698 tokens in 0.69s, avg seq len: 73.4)
04:04:55 [INFO] [INFERENCE 0] [Rank 0] Batch throughput: 7218.13 tok/sec (5022 tokens in 0.70s, avg seq len: 78.5)
```