### PR TITLE
add logging for clip ratio

### DIFF
--- a/src/zeroband/train.py
+++ b/src/zeroband/train.py
@@ -382,7 +382,7 @@ def train(config: Config):
                 "clip_seq_lens": clip_seq_lens.item(),
             }
 
-            log = f"step: {training_progress.step}, rollout_step: {training_progress.step // config.optim.step_per_rollout}, loss: {loss_batch.item():.4f}, average_rewards: {average_rewards.item():.4f}"
+            log = f"step: {training_progress.step}, rollout_step: {training_progress.step // config.optim.step_per_rollout}, loss: {loss_batch.item():.4f}, average_rewards: {average_rewards.item():.4f}, clip_ratio: {clip_ratio_batch.item():.4f}"
 
             del loss_batch, average_rewards, grad_norm, pg_loss_batch, entropy_loss_batch
 


### PR DESCRIPTION
## Summary

- Fix dead embeddings in the Nemotron 3 Super base BF16 checkpoint before SFT
- Bump prime-rl to pick up Nemotron state-dict fixes required for Super training

## The bug

The Super base BF16 checkpoint has **1188 embedding rows with norm ~1e-17** (effectively zero), driven there by weight decay during pretraining. This includes critical chat-template tokens — `<|im_start|>` (id 10), `<|im_end|>` (id 11), `[INST]`, etc. — which appear in every SFT sample.

If you SFT without fixing this, **step 0 grad norm hits ~1e18**. With grad clipping at 1.0, the entire gradient gets rescaled by ~1e-18, so non-embedding parameters get effectively-zero updates while the embeddings catch up. The first few steps are wasted.

Confirmed by NVIDIA — known issue with the base checkpoint.

## The fix

`int5/scripts/fix_super_embeddings.py`:

1. Identifies embedding rows with L2 norm < 1e-6 (~1188 of 131072)
2. Re-initializes them with `normal(0, init_method_std)` where `init_method_std = config.initializer_range = 0.02`
3. Writes a new snapshot at `/beegfs/konstantin/nemotron_super_base_emb_fixed/`:
   - The embedding shard (`model-00001-of-00050.safetensors`) is rewritten with the fix
   - All other files are symlinked to the original — saves ~245GB of duplication

`int5/sft/ablations/nemotron_super/sft.toml` is updated to point at the fixed snapshot.

The README documents the issue, the fix, and a critical footgun: prime-rl caches its weight conversion at `<snapshot>/prime/`. If a stale `prime/` exists from a prior run, the fix is silently ignored. Always `rm -rf` it before submitting.

## Verification

Step 0 grad norms (LR=1e-5):

| Snapshot | Step 0 grad norm | Step 0 loss |
|---|---|---|
| Original | 9.1e18 | 1.04 |
| **Embedding-fixed** | **2.7** | **0.72** |

Full 250-step run completed cleanly with no grad norm spikes (final loss 0.39, grad norm 0.10).

## Files

- `int5/scripts/fix_super_embeddings.py` — embedding fix script with CLI args
- `int5/sft/ablations/nemotron_super/README.md` — embedding fix section added
- `int5/sft/ablations/nemotron_super/sft.toml` — model path → fixed snapshot
- `prime-rl` submodule bumped to `20454ec` (10 commits ahead of main's pin), adding `f1bbdf9 missed patch for nemotron state dict` and `9bbed30 [Fix] nemotron fixes` which are required for Super training to even load weights correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)