### PR TITLE
Sort imports

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -13,5 +13,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: chartboost/ruff-action@v1
-
+      - uses: astral-sh/ruff-action@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ allow-direct-references = true # allow direct references to git repos in depende
 line-length = 140
 
 [tool.ruff.lint]
+select = ["F", "I"]
 ignore = ["F722", "F821"]
 
 [tool.uv]

--- a/src/zeroband/infer.py
+++ b/src/zeroband/infer.py
@@ -1,30 +1,30 @@
-import requests
+import json
+import multiprocessing as mp
 import os
-from pathlib import Path
-import uuid
-import numpy as np
-import torch
-from vllm import LLM, SamplingParams
-from pydantic_config import parse_argv
 import time
-from toploc.utils import sha256sum
+import uuid
+from pathlib import Path
+
+import numpy as np
+import pyarrow.parquet as pq
+import requests
+import torch
 import torch.distributed as dist
 from datasets import load_dataset
-import pyarrow.parquet as pq
-import multiprocessing as mp
-import json
+from pydantic_config import parse_argv
+from toploc.utils import sha256sum
+from vllm import LLM, SamplingParams
 
 from zeroband.inference import envs
-from zeroband.utils.logger import get_logger
-from zeroband.utils.metrics import PrimeMetric
 from zeroband.inference.config import Config
-from zeroband.inference.utils import generate_target_length_prompts, reload_model_weights, fake_chat_template
-from zeroband.inference.toploc import setup_toploc_cache
+from zeroband.inference.parquet import get_parquet_table
 from zeroband.inference.pipeline import setup_pipeline
 from zeroband.inference.rewards import compute_rewards
-from zeroband.inference.parquet import get_parquet_table
-
+from zeroband.inference.toploc import setup_toploc_cache
+from zeroband.inference.utils import fake_chat_template, generate_target_length_prompts, reload_model_weights
 from zeroband.training.mp import EnvWrapper
+from zeroband.utils.logger import get_logger
+from zeroband.utils.metrics import PrimeMetric
 
 # Global logger
 logger = get_logger("INFER")

--- a/src/zeroband/inference/config.py
+++ b/src/zeroband/inference/config.py
@@ -1,7 +1,7 @@
 from typing import Literal
-from pydantic_config import BaseConfig
-from pydantic import model_validator
 
+from pydantic import model_validator
+from pydantic_config import BaseConfig
 
 from zeroband.inference.pipeline import PipelineConfig
 from zeroband.inference.rewards import LenRewardsConfig

--- a/src/zeroband/inference/genesys/__init__.py
+++ b/src/zeroband/inference/genesys/__init__.py
@@ -1,6 +1,7 @@
-from typing import Literal, Callable
-from zeroband.inference.genesys.math import compute_math_reward
+from typing import Callable, Literal
+
 from zeroband.inference.genesys.code import evaluate_code
+from zeroband.inference.genesys.math import compute_math_reward
 
 TaskType = Literal["verifiable_math", "prime_rl_code"]
 

--- a/src/zeroband/inference/genesys/code.py
+++ b/src/zeroband/inference/genesys/code.py
@@ -1,7 +1,7 @@
 import json
 import re
-from typing import Dict
 import traceback
+from typing import Dict
 
 from zeroband.inference.genesys.code_utils import check_correctness
 

--- a/src/zeroband/inference/genesys/code_utils.py
+++ b/src/zeroband/inference/genesys/code_utils.py
@@ -1,22 +1,22 @@
 # Borrowed from PRIME-RL and Codeparrot: https://github.com/PRIME-RL/PRIME/tree/main/training/verl/utils/reward_score/evaluation_utils/code_util, https://huggingface.co/spaces/codeparrot/apps_metric/blob/main/utils.py
 
 
-import multiprocessing
-import traceback
-import os
-import sys
 import ast
-import json
 import faulthandler
+import json
+import multiprocessing
+import os
 import platform
-from datetime import datetime
 import signal
-import numpy as np
-
-from io import StringIO
-from unittest.mock import patch, mock_open
-from pyext import RuntimeModule
+import sys
+import traceback
+from datetime import datetime
 from enum import Enum
+from io import StringIO
+from unittest.mock import mock_open, patch
+
+import numpy as np
+from pyext import RuntimeModule
 
 
 def truncatefn(s, length=300):

--- a/src/zeroband/inference/genesys/math.py
+++ b/src/zeroband/inference/genesys/math.py
@@ -1,4 +1,5 @@
 from typing import Dict
+
 from zeroband.inference.genesys.math_utils import extract_answer, grade_answer_mathd, grade_answer_sympy
 
 

--- a/src/zeroband/inference/genesys/math_utils.py
+++ b/src/zeroband/inference/genesys/math_utils.py
@@ -5,8 +5,9 @@ Call grade_answer(given_answer: str, ground_truth: str).
 """
 
 import re
-from pylatexenc import latex2text
+
 import sympy
+from pylatexenc import latex2text
 from sympy.parsing import sympy_parser
 
 

--- a/src/zeroband/inference/pipeline.py
+++ b/src/zeroband/inference/pipeline.py
@@ -1,15 +1,15 @@
-import time
 import pickle
-from typing import Tuple
+import time
 from functools import partial
+from typing import Tuple
 
 import torch
 import torch.nn as nn
-from vllm.model_executor.layers.sampler import SamplerOutput
+from prime_iroh import Node
 from pydantic_config import BaseConfig
 from vllm import LLM
+from vllm.model_executor.layers.sampler import SamplerOutput
 
-from prime_iroh import Node
 from zeroband.utils.logger import get_logger
 
 # Global logger

--- a/src/zeroband/inference/rewards.py
+++ b/src/zeroband/inference/rewards.py
@@ -1,12 +1,12 @@
-from typing import Literal
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
+from typing import Literal
 
 import numpy as np
 from pydantic_config import BaseConfig
-from vllm import RequestOutput, CompletionOutput
-from concurrent.futures import ThreadPoolExecutor
+from vllm import CompletionOutput, RequestOutput
 
-from zeroband.inference.genesys import get_reward_function, TaskType
+from zeroband.inference.genesys import TaskType, get_reward_function
 from zeroband.utils.logger import get_logger
 
 # Global logger

--- a/src/zeroband/inference/shardcast_downloader.py
+++ b/src/zeroband/inference/shardcast_downloader.py
@@ -1,9 +1,10 @@
 import argparse
-from shardcast import ClientNode
-import time
 import logging
-from pathlib import Path
 import multiprocessing as mp
+import time
+from pathlib import Path
+
+from shardcast import ClientNode
 
 POLL_INTERVAL = 5
 logger = logging.getLogger(__name__)

--- a/src/zeroband/inference/toploc.py
+++ b/src/zeroband/inference/toploc.py
@@ -1,13 +1,13 @@
+from concurrent.futures import Future, ThreadPoolExecutor, wait
+from functools import partial
+
 import torch
 import torch.nn as nn
-from torch.utils.hooks import RemovableHandle
 from toploc import build_proofs_bytes
-from concurrent.futures import ThreadPoolExecutor, Future, wait
+from torch.utils.hooks import RemovableHandle
+from vllm import LLM
 from vllm.model_executor import SamplingMetadata
 from vllm.model_executor.layers.logits_processor import _prune_hidden_states
-from vllm import LLM
-
-from functools import partial
 
 
 class TopLocCache:

--- a/src/zeroband/inference/utils.py
+++ b/src/zeroband/inference/utils.py
@@ -1,6 +1,6 @@
 import torch
-from vllm import LLM
 from safetensors import safe_open
+from vllm import LLM
 from vllm.model_executor.model_loader.loader import _process_weights_after_loading
 
 from zeroband.inference.rewards import LenRewardsConfig

--- a/src/zeroband/training/checkpoint.py
+++ b/src/zeroband/training/checkpoint.py
@@ -1,12 +1,14 @@
-from dataclasses import dataclass
 import os
-from pathlib import Path
 import threading
 import time
+from dataclasses import dataclass
+from pathlib import Path
+
 import torch
 from safetensors.torch import save_file
-from torch.distributed.tensor import DTensor
 from torch.distributed.checkpoint.state_dict import _get_fqns as get_fqns
+from torch.distributed.tensor import DTensor
+
 from zeroband.utils.logger import get_logger
 from zeroband.utils.models import ModelType
 from zeroband.utils.world_info import get_world_info

--- a/src/zeroband/training/config.py
+++ b/src/zeroband/training/config.py
@@ -1,8 +1,10 @@
 from typing import Literal
-from pydantic_config import BaseConfig
+
 from pydantic import model_validator
-from zeroband.utils.models import ModelName, AttnImpl
+from pydantic_config import BaseConfig
+
 from zeroband.training.data import CollateMode, DataConfig
+from zeroband.utils.models import AttnImpl, ModelName
 
 
 class AdamConfig(BaseConfig):

--- a/src/zeroband/training/data.py
+++ b/src/zeroband/training/data.py
@@ -1,24 +1,20 @@
-from pathlib import Path
 import time
+from pathlib import Path
 from typing import Any, Generator, Literal, TypeAlias, TypedDict
 
-from pydantic_config import BaseConfig
-
-
-import torch
-from torch.utils.data import IterableDataset, DataLoader
-import torch.distributed as dist
-
-from jaxtyping import Float, Int
-
-from pyarrow import dataset as ds
 import pyarrow.parquet as pq
+import torch
+import torch.distributed as dist
+from jaxtyping import Float, Int
+from pyarrow import dataset as ds
+from pydantic_config import BaseConfig
+from torch.utils.data import DataLoader, IterableDataset
 
-from zeroband.utils.logger import get_logger
-from zeroband.training.data_prefetch import GCPPrefetcher, STABLE_FILE
-from zeroband.utils.world_info import get_world_info
 from zeroband.training import envs
+from zeroband.training.data_prefetch import STABLE_FILE, GCPPrefetcher
+from zeroband.utils.logger import get_logger
 from zeroband.utils.parquet import pa_schema
+from zeroband.utils.world_info import get_world_info
 
 
 class DataConfig(BaseConfig):

--- a/src/zeroband/training/data_prefetch.py
+++ b/src/zeroband/training/data_prefetch.py
@@ -1,12 +1,11 @@
+import multiprocessing as mp
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, wait
 from pathlib import Path
+
 from google.cloud import storage
-from concurrent.futures import ThreadPoolExecutor
-from concurrent.futures import wait
 
 from zeroband.utils.logger import get_logger
-import multiprocessing as mp
-
 
 STABLE_FILE = "stable"
 

--- a/src/zeroband/training/loss.py
+++ b/src/zeroband/training/loss.py
@@ -1,8 +1,8 @@
 import torch
-from torch import Tensor
-from jaxtyping import Float, Int, jaxtyped
-from beartype import beartype as typechecker
 import torch.nn.functional as F
+from beartype import beartype as typechecker
+from jaxtyping import Float, Int, jaxtyped
+from torch import Tensor
 
 
 # beartype here just make sure we have the correct shape

--- a/src/zeroband/training/lr_scheduler.py
+++ b/src/zeroband/training/lr_scheduler.py
@@ -1,9 +1,8 @@
-from typing import Callable
-from functools import partial
 import math
+from functools import partial
+from typing import Callable
 
-from torch.optim.lr_scheduler import LRScheduler, LambdaLR
-
+from torch.optim.lr_scheduler import LambdaLR, LRScheduler
 from transformers.optimization import get_cosine_schedule_with_warmup, get_linear_schedule_with_warmup
 
 

--- a/src/zeroband/training/utils.py
+++ b/src/zeroband/training/utils.py
@@ -1,23 +1,24 @@
-from itertools import chain
-from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import checkpoint_wrapper
-from zeroband.utils.logger import get_logger
 import socket
 import time
+from itertools import chain
+from typing import Any
+
+import pandas as pd
 import torch
+import torch.distributed as dist
+import wandb
+from torch.distributed._composable.fsdp import FSDPModule
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import checkpoint_wrapper
+from torch.distributed.tensor import DTensor
 from transformers import (
     LlamaConfig,
     LlamaForCausalLM,
     PreTrainedTokenizer,
 )
-from torch.distributed.tensor import DTensor
-from typing import Any
 
+from zeroband.utils.logger import get_logger
 from zeroband.utils.models import ModelType
 from zeroband.utils.world_info import get_world_info
-import torch.distributed as dist
-from torch.distributed._composable.fsdp import FSDPModule
-import pandas as pd
-import wandb
 
 
 def apply_ac_ckpt(model: ModelType, num: int):

--- a/src/zeroband/utils/envs.py
+++ b/src/zeroband/utils/envs.py
@@ -1,5 +1,5 @@
-from typing import TYPE_CHECKING, Any, Dict, List
 import os
+from typing import TYPE_CHECKING, Any, Dict, List
 
 # Force using vLLM v0
 os.environ["VLLM_USE_V1"] = "0"

--- a/src/zeroband/utils/http_monitor.py
+++ b/src/zeroband/utils/http_monitor.py
@@ -1,8 +1,10 @@
-from typing import Any
-import aiohttp
-from zeroband.utils.logger import get_logger
 import asyncio
+from typing import Any
+
+import aiohttp
+
 from zeroband.training import envs
+from zeroband.utils.logger import get_logger
 
 
 class HttpMonitor:

--- a/src/zeroband/utils/logger.py
+++ b/src/zeroband/utils/logger.py
@@ -1,9 +1,9 @@
 import logging
-from logging import Logger, Formatter
+from logging import Formatter, Logger
 from typing import Literal
 
 from zeroband.utils import envs
-from zeroband.utils.world_info import get_world_info, WorldInfo
+from zeroband.utils.world_info import WorldInfo, get_world_info
 
 
 class PrimeFormatter(Formatter):

--- a/src/zeroband/utils/metrics.py
+++ b/src/zeroband/utils/metrics.py
@@ -1,11 +1,12 @@
-import socket
-import platform
 import json
 import os
-from typing import Any
-import psutil
+import platform
+import socket
 import threading
 import time
+from typing import Any
+
+import psutil
 import pynvml
 
 

--- a/src/zeroband/utils/models.py
+++ b/src/zeroband/utils/models.py
@@ -1,5 +1,6 @@
 from typing import Literal, TypeAlias
-from transformers import AutoTokenizer, LlamaForCausalLM, Qwen2ForCausalLM, Qwen3ForCausalLM, AutoConfig, AutoModelForCausalLM
+
+from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, LlamaForCausalLM, Qwen2ForCausalLM, Qwen3ForCausalLM
 
 from zeroband.utils.logger import get_logger
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,13 @@
+import os
+from functools import lru_cache
+from pathlib import Path
+
 import pyarrow as pa
 import pyarrow.parquet as pq
-from zeroband.utils.parquet import pa_schema
-from pathlib import Path
-import os
 import pytest
-from functools import lru_cache
 
 from zeroband.training.data import STABLE_FILE
+from zeroband.utils.parquet import pa_schema
 
 
 @lru_cache(maxsize=None)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,12 +4,13 @@ Need to be run from the root folder
 """
 
 import os
-from zeroband.train import Config as TrainingConfig
-from zeroband.infer import Config as InferenceConfig
 
-from pydantic import ValidationError
 import pytest
 import tomli
+from pydantic import ValidationError
+
+from zeroband.infer import Config as InferenceConfig
+from zeroband.train import Config as TrainingConfig
 
 
 def get_all_toml_files(directory):

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1,6 +1,7 @@
 import subprocess
-import pytest
+
 import pyarrow.parquet as pq
+import pytest
 
 
 def _test_torchrun(config, extra_args=[]):

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,4 +1,5 @@
 import subprocess
+
 import pytest
 
 

--- a/tests/units/test_envs.py
+++ b/tests/units/test_envs.py
@@ -1,4 +1,5 @@
 import os
+
 import pytest
 
 from zeroband.inference import envs as inference_env

--- a/tests/units/test_logger.py
+++ b/tests/units/test_logger.py
@@ -1,8 +1,10 @@
-import os
 import logging
+import os
+
 import pytest
+
+from zeroband.utils.logger import ALLOWED_LEVELS, LoggerName, PrimeFormatter, get_logger, reset_logger
 from zeroband.utils.world_info import reset_world_info
-from zeroband.utils.logger import ALLOWED_LEVELS, get_logger, reset_logger, PrimeFormatter, LoggerName
 
 
 @pytest.fixture(autouse=True)

--- a/tests/units/test_loss.py
+++ b/tests/units/test_loss.py
@@ -1,6 +1,7 @@
-from zeroband.training.loss import grpo_loss, entropy_loss, kl_penalty
-import torch
 import pytest
+import torch
+
+from zeroband.training.loss import entropy_loss, grpo_loss, kl_penalty
 
 
 @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])

--- a/tests/units/test_model.py
+++ b/tests/units/test_model.py
@@ -1,5 +1,5 @@
-import torch
 import pytest
+import torch
 
 from zeroband.utils.models import get_model_and_tokenizer
 

--- a/tests/units/test_models.py
+++ b/tests/units/test_models.py
@@ -1,6 +1,8 @@
+from typing import get_args
+
 import pytest
 from huggingface_hub import HfApi
-from typing import get_args
+
 from zeroband.utils.models import ModelName
 
 

--- a/tests/units/test_pipeline.py
+++ b/tests/units/test_pipeline.py
@@ -1,10 +1,10 @@
-import pytest
 from multiprocessing import Process, Queue
+
+import pytest
+from prime_iroh import Node
 
 import zeroband.utils.envs as envs  # noqa
 from zeroband.inference.pipeline import setup_comm
-
-from prime_iroh import Node
 
 # Pre-computed node IDs for different seeds (our team's favorite numbers)
 IROH_NODE_ID_MAP = {

--- a/tests/units/test_pq_dataset.py
+++ b/tests/units/test_pq_dataset.py
@@ -1,17 +1,18 @@
+import random
+
 import pytest
+import torch
+from torch.utils.data import DataLoader
+
 from zeroband.training.data import (
+    FakeTokenizedDataset,
     ParquetDataset,
     _should_skip_index,
     collate_fn,
-    FakeTokenizedDataset,
+    pack_datatset_outputs_balancing,
     pack_datatset_outputs_efficiently,
     packed_batch,
-    pack_datatset_outputs_balancing,
 )
-from torch.utils.data import DataLoader
-
-import torch
-import random
 
 
 def test_pq_dataset(fake_rollout_files_dir):

--- a/tests/units/test_rewards.py
+++ b/tests/units/test_rewards.py
@@ -1,7 +1,8 @@
 import pickle
+
 import pytest
 
-from zeroband.inference.rewards import RequestRewards, CompletionReward, compute_rewards
+from zeroband.inference.rewards import CompletionReward, RequestRewards, compute_rewards
 
 
 @pytest.fixture

--- a/tests/units/test_toploc.py
+++ b/tests/units/test_toploc.py
@@ -2,9 +2,9 @@ import pytest
 import torch
 import torch.distributed as dist
 from toploc import verify_proofs_bytes
+from vllm import SamplingParams, TokensPrompt
 
 from zeroband.inference.toploc import TopLocCache, setup_toploc_cache
-from vllm import SamplingParams, TokensPrompt
 
 BYTES_PER_PROOF = 258
 


### PR DESCRIPTION
Enables import sorting via `ruff` by setting the `"I"` flag in `pyproject.toml`. In this way running 

```bash
uv run ruff check --fix .
```

will lint, check format and sort imports across the entirely project. The ruff pre-commit hook automatically sorts imports.