### PR TITLE
[PRI2-533] Support MOE models with pipelined inference 

### DIFF
--- a/src/zeroband/utils/models.py
+++ b/src/zeroband/utils/models.py
@@ -40,11 +40,15 @@ ModelName: TypeAlias = Literal[
     "Qwen/Qwen3-8B",
     "Qwen/Qwen3-14B",
     "Qwen/Qwen3-32B",
+    "Qwen/Qwen3-30B-A3B",
+    "Qwen/Qwen3-235B-A22B",
     # Shards
     "mikasenghaas/Llama-3.2-1B-Instruct-0.2",
     "mikasenghaas/Llama-3.2-1B-Instruct-1.2",
     "mikasenghaas/Qwen3-14B-0.2",
     "mikasenghaas/Qwen3-14B-1.2",
+    "mikasenghaas/Qwen3-30B-A3B-0.2",
+    "mikasenghaas/Qwen3-30B-A3B-1.2",
 ]
 
 ModelType: TypeAlias = LlamaForCausalLM | Qwen2ForCausalLM | Qwen3ForCausalLM


### PR DESCRIPTION
This PR adds MOE models for inference and confirms that pipelined inference still works. Tested using `Qwen/Qwen3-30B-A3B` ([HF](https://huggingface.co/Qwen/Qwen3-30B-A3B)).

Test MOE for single-node

```bash
uv run python src/zeroband/infer.py @ configs/inference/debug.toml \
	--model-name Qwen/Qwen3-30B-A3B \
	--download-dir /ephemeral
```

Test MOE for multi-node using pipelined inference

```bash
CUDA_VISIBLE_DEVICES=0 uv run python src/zeroband/infer.py @ configs/inference/debug.toml \
	--model-name mikasenghaas/Qwen3-30B-A3B-0.2 \
	--download-dir /ephemeral \
	--pp.rank 0 \
	--pp.world-size 2 \
	--pp.iroh-seed 0 \
	--pp.iroh-peer-id ff87a0b0a3c7c0ce827e9cada5ff79e75a44a0633bfcb5b50f99307ddb26b337 \
	--seed 69
```

```bash
CUDA_VISIBLE_DEVICES=1 uv run python src/zeroband/infer.py @ configs/inference/debug.toml \
	--model-name mikasenghaas/Qwen3-30B-A3B-1.2 \
	--download-dir /ephemeral \
	--pp.rank 1 \
	--pp.world-size 2 \
	--pp.iroh-seed 1 \
	--pp.iroh-peer-id ee1aa49a4459dfe813a3cf6eb882041230c7b2558469de81f87c9bf23bf10a03 \
	--seed 69
```

For both settings, I manually inspected the generations over multiple batches and can confirm coherent output.