### PR TITLE
Fix race condition in PrimeMetric initialization causing AttributeError

### DIFF
--- a/src/zeroband/utils/metrics.py
+++ b/src/zeroband/utils/metrics.py
@@ -58,6 +58,10 @@ class PrimeMetric:
     def log_prime(self, metric: dict[str, Any]) -> None:
         if self.disable:
             return
+        if self.socket_path is None:
+            logger.warning("Socket path not initialized, skipping logging")
+            return
+
         logger.debug(f"Trying to log {metric}")
 
         task_id = os.getenv("PRIME_TASK_ID", None)

--- a/src/zeroband/utils/metrics.py
+++ b/src/zeroband/utils/metrics.py
@@ -35,6 +35,9 @@ class PrimeMetric:
         self.period = period
         self.has_gpu = False
         self._thread = None
+        default = "/tmp/com.prime.miner/metrics.sock" if platform.system() == "Darwin" else "/var/run/com.prime.miner/metrics.sock"
+        self.socket_path = os.getenv("PRIME_TASK_BRIDGE_SOCKET", default=default)
+
 
         if self.disable:
             return
@@ -47,9 +50,6 @@ class PrimeMetric:
             self.has_gpu = True
         except pynvml.NVMLError:
             pass
-
-        default = "/tmp/com.prime.miner/metrics.sock" if platform.system() == "Darwin" else "/var/run/com.prime.miner/metrics.sock"
-        self.socket_path = os.getenv("PRIME_TASK_BRIDGE_SOCKET", default=default)
 
         logger.info(f"Initialized PrimeMetrics (period={self.period}, has_gpu={self.has_gpu})")
 


### PR DESCRIPTION
Fixes a race condition in PrimeMetric.__init__() where the background metrics thread was starting before socket_path was initialized, causing "AttributeError: 'PrimeMetric' object has no attribute 'socket_path'".
