### PR TITLE
Add RL tmuxinator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ data/*
 rollouts/*
 checkpoints/*
 *.ipynb
+*.jsonl
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.tmuxinator.yaml
+++ b/.tmuxinator.yaml
@@ -4,12 +4,14 @@ windows:
   - RL:
       layout: even-horizontal
       panes:
-        - Training:
-            - export CUDA_VISIBLE_DEVICES=0
-            - uv run torchrun src/zeroband/train.py @ configs/training/simple_reverse_two_gpu.toml --monitor.file.enable --monitor.file.path outputs/training_monitor.jsonl
+        - Training: 
+          - export CUDA_VISIBLE_DEVICES=0 
+          - clear
+          - uv run torchrun src/zeroband/train.py @ configs/training/simple_reverse_two_gpu.toml --monitor.file.enable --monitor.file.path outputs/training_monitor.jsonl
         - Inference:
-            - export CUDA_VISIBLE_DEVICES=1
-            - uv run src/zeroband/infer.py @ configs/inference/simple_reverse_two_gpus.toml --monitor.file.enable --monitor.file.path outputs/inference_monitor.jsonl
+          - export CUDA_VISIBLE_DEVICES=1 
+          - clear
+          - uv run src/zeroband/infer.py @ configs/inference/simple_reverse_two_gpus.toml --monitor.file.enable --monitor.file.path outputs/inference_monitor.jsonl
   - Monitor:
       layout: even-horizontal
       panes:

--- a/.tmuxinator.yaml
+++ b/.tmuxinator.yaml
@@ -9,4 +9,4 @@ windows:
           - uv run src/zeroband/infer.py ${INFER_ARGS:-@configs/inference/simple_reverse_two_gpus.toml} --monitor.wandb.group ${WANDB_GROUP:-$(date +%y%m%d-%H%M%S)} --monitor.wandb.prefix infer
         - Training: 
           - export CUDA_VISIBLE_DEVICES=${TRAIN_GPUS:-1}
-          - uv run torchrun src/zeroband/train.py ${TRAIN_ARGS:-@configs/training/simple_reverse_two_gpu.toml} --monitor.wandb.group ${WANDB_GROUP:-$(date +%y%m%d-%H%M%S)}
+          - uv run torchrun --nproc_per_node=$(echo ${TRAIN_GPUS:-1} | tr ',' '\n' | wc -l) src/zeroband/train.py ${TRAIN_ARGS:-@configs/training/simple_reverse_two_gpu.toml} --monitor.wandb.group ${WANDB_GROUP:-$(date +%y%m%d-%H%M%S)}

--- a/.tmuxinator.yaml
+++ b/.tmuxinator.yaml
@@ -1,0 +1,22 @@
+name: RL
+enable_pane_titles: true
+windows:
+  - RL:
+      layout: even-horizontal
+      panes:
+        - Training:
+            - export CUDA_VISIBLE_DEVICES=0
+            - uv run torchrun src/zeroband/train.py @ configs/training/simple_reverse_two_gpu.toml --monitor.file.enable --monitor.file.path outputs/training_monitor.jsonl
+        - Inference:
+            - export CUDA_VISIBLE_DEVICES=1
+            - uv run src/zeroband/infer.py @ configs/inference/simple_reverse_two_gpus.toml --monitor.file.enable --monitor.file.path outputs/inference_monitor.jsonl
+  - Monitor:
+      layout: even-horizontal
+      panes:
+        - Training Logs: watch -n 1 "cat outputs/training_monitor.jsonl | tail -n 10"
+        - Inference Logs: watch -n 1 "cat outputs/inference_monitor.jsonl | tail -n 10"
+  - System:
+      layout: even-horizontal
+      panes:
+        - CPU Monitor: htop
+        - GPU Monitor: nvtop

--- a/.tmuxinator.yaml
+++ b/.tmuxinator.yaml
@@ -7,16 +7,16 @@ windows:
         - Training: 
           - export CUDA_VISIBLE_DEVICES=0 
           - clear
-          - uv run torchrun src/zeroband/train.py @ configs/training/simple_reverse_two_gpu.toml --monitor.file.enable --monitor.file.path outputs/training_monitor.jsonl
+          - uv run torchrun src/zeroband/train.py @ configs/training/simple_reverse_two_gpu.toml --monitor.file.path train-monitor.jsonl
         - Inference:
           - export CUDA_VISIBLE_DEVICES=1 
           - clear
-          - uv run src/zeroband/infer.py @ configs/inference/simple_reverse_two_gpus.toml --monitor.file.enable --monitor.file.path outputs/inference_monitor.jsonl
+          - uv run src/zeroband/infer.py @ configs/inference/simple_reverse_two_gpus.toml --monitor.file.path infer-monitor.jsonl --monitor.wandb.prefix infer
   - Monitor:
       layout: even-horizontal
       panes:
-        - Training Logs: watch -n 1 "cat outputs/training_monitor.jsonl | tail -n 10"
-        - Inference Logs: watch -n 1 "cat outputs/inference_monitor.jsonl | tail -n 10"
+        - Training Logs: watch -n 1 "cat train-monitor.jsonl | tail -n 10"
+        - Inference Logs: watch -n 1 "cat infer-monitor.jsonl | tail -n 10"
   - System:
       layout: even-horizontal
       panes:

--- a/.tmuxinator.yaml
+++ b/.tmuxinator.yaml
@@ -6,17 +6,7 @@ windows:
       panes:
         - Inference:
           - export CUDA_VISIBLE_DEVICES=${INFER_GPUS:-0}
-          - uv run src/zeroband/infer.py ${INFER_ARGS:-@configs/inference/simple_reverse_two_gpus.toml} --monitor.file.path infer-monitor.jsonl --monitor.wandb.group ${WANDB_GROUP:-$(date +%y%m%d-%H%M%S)} --monitor.wandb.prefix infer
+          - uv run src/zeroband/infer.py ${INFER_ARGS:-@configs/inference/simple_reverse_two_gpus.toml} --monitor.wandb.group ${WANDB_GROUP:-$(date +%y%m%d-%H%M%S)} --monitor.wandb.prefix infer
         - Training: 
           - export CUDA_VISIBLE_DEVICES=${TRAIN_GPUS:-1}
-          - uv run torchrun src/zeroband/train.py ${TRAIN_ARGS:-@configs/training/simple_reverse_two_gpu.toml} --monitor.file.path train-monitor.jsonl --monitor.wandb.group ${WANDB_GROUP:-$(date +%y%m%d-%H%M%S)}
-  - Monitor:
-      layout: even-horizontal
-      panes:
-        - Training Logs: watch -n 1 "cat train-monitor.jsonl | tail -n 10"
-        - Inference Logs: watch -n 1 "cat infer-monitor.jsonl | tail -n 10"
-  - System:
-      layout: even-horizontal
-      panes:
-        - CPU Monitor: htop
-        - GPU Monitor: nvtop
+          - uv run torchrun src/zeroband/train.py ${TRAIN_ARGS:-@configs/training/simple_reverse_two_gpu.toml} --monitor.wandb.group ${WANDB_GROUP:-$(date +%y%m%d-%H%M%S)}

--- a/.tmuxinator.yaml
+++ b/.tmuxinator.yaml
@@ -4,14 +4,12 @@ windows:
   - RL:
       layout: even-horizontal
       panes:
-        - Training: 
-          - export CUDA_VISIBLE_DEVICES=0 
-          - clear
-          - uv run torchrun src/zeroband/train.py @ configs/training/simple_reverse_two_gpu.toml --monitor.file.path train-monitor.jsonl
         - Inference:
-          - export CUDA_VISIBLE_DEVICES=1 
-          - clear
-          - uv run src/zeroband/infer.py @ configs/inference/simple_reverse_two_gpus.toml --monitor.file.path infer-monitor.jsonl --monitor.wandb.prefix infer
+          - export CUDA_VISIBLE_DEVICES=${INFER_GPUS:-0}
+          - uv run src/zeroband/infer.py ${INFER_ARGS:-@configs/inference/simple_reverse_two_gpus.toml} --monitor.file.path infer-monitor.jsonl --monitor.wandb.group ${WANDB_GROUP:-$(date +%y%m%d-%H%M%S)} --monitor.wandb.prefix infer
+        - Training: 
+          - export CUDA_VISIBLE_DEVICES=${TRAIN_GPUS:-1}
+          - uv run torchrun src/zeroband/train.py ${TRAIN_ARGS:-@configs/training/simple_reverse_two_gpu.toml} --monitor.file.path train-monitor.jsonl --monitor.wandb.group ${WANDB_GROUP:-$(date +%y%m%d-%H%M%S)}
   - Monitor:
       layout: even-horizontal
       panes:

--- a/configs/inference/debug.toml
+++ b/configs/inference/debug.toml
@@ -1,6 +1,7 @@
 max_steps = 2
 max_batch_size = 16
 clean_rollout_path = true
+rl = "None"
 
 [toploc]
 enable_toploc1 = true

--- a/configs/inference/formatask.toml
+++ b/configs/inference/formatask.toml
@@ -5,6 +5,9 @@ clean_rollout_path = true
 name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"
 max_model_len = 2048
 
+[monitor.wandb]
+project = "formatask-debug"
+
 [data]
 name = "kalomaze/general-formatask-it2"
 

--- a/configs/inference/math_only_1b.toml
+++ b/configs/inference/math_only_1b.toml
@@ -5,6 +5,9 @@ clean_rollout_path = true
 name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
 max_model_len = 8192
 
+[monitor.wandb]
+project = "math-ablation"
+
 [data]
 name = "PrimeIntellect/INTELLECT-2-only-math"
 

--- a/configs/inference/math_only_7b.toml
+++ b/configs/inference/math_only_7b.toml
@@ -5,6 +5,9 @@ clean_rollout_path = true
 name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"
 max_model_len = 16384
 
+[monitor.wandb]
+project = "math-ablation"
+
 [data]
 name = "PrimeIntellect/INTELLECT-2-only-math"
 

--- a/configs/inference/simple_ascii_tree.toml
+++ b/configs/inference/simple_ascii_tree.toml
@@ -1,6 +1,9 @@
 max_batch_size = 256
 clean_rollout_path = true
 
+[monitor.wandb]
+project = "ascii-tree-debug"
+
 [model]
 name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"
 max_model_len = 2048

--- a/configs/inference/simple_math.toml
+++ b/configs/inference/simple_math.toml
@@ -1,6 +1,9 @@
 clean_rollout_path = true
 max_batch_size = 96
 
+[monitor.wandb]
+project = "math-debug"
+
 [model]
 name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
 max_model_len = 2048

--- a/configs/inference/simple_math_7b.toml
+++ b/configs/inference/simple_math_7b.toml
@@ -1,6 +1,9 @@
 clean_rollout_path = true
 max_batch_size = 96
 
+[monitor.wandb]
+project = "math-debug"
+
 [model]
 name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"
 max_model_len = 2048

--- a/configs/inference/simple_multitask.toml
+++ b/configs/inference/simple_multitask.toml
@@ -1,6 +1,9 @@
 max_batch_size = 256
 clean_rollout_path = true
 
+[monitor.wandb]
+project = "multitask-debug"
+
 [model]
 name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"
 max_model_len = 2048

--- a/configs/inference/simple_reverse_two_gpus.toml
+++ b/configs/inference/simple_reverse_two_gpus.toml
@@ -2,6 +2,9 @@ max_steps = 50
 max_batch_size = 128
 clean_rollout_path = true
 
+[monitor.wandb]
+project = "reverse-debug"
+
 [model]
 name = "willcb/Qwen2.5-0.5B-Reverse-SFT"
 max_model_len = 128

--- a/configs/inference/simple_reverse_two_gpus.toml
+++ b/configs/inference/simple_reverse_two_gpus.toml
@@ -1,4 +1,4 @@
-max_steps = 100
+max_steps = 50
 max_batch_size = 128
 clean_rollout_path = true
 

--- a/configs/inference/simple_reverse_two_gpus.toml
+++ b/configs/inference/simple_reverse_two_gpus.toml
@@ -1,4 +1,4 @@
-max_steps = 50
+max_steps = 100
 max_batch_size = 128
 clean_rollout_path = true
 

--- a/configs/inference/simple_unscramble.toml
+++ b/configs/inference/simple_unscramble.toml
@@ -1,6 +1,9 @@
 max_batch_size = 256
 clean_rollout_path = true
 
+[monitor.wandb]
+project = "unscramble-debug"
+
 [model]
 name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"
 max_model_len = 2048

--- a/configs/inference/simple_unscramble.toml
+++ b/configs/inference/simple_unscramble.toml
@@ -5,6 +5,9 @@ clean_rollout_path = true
 name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"
 max_model_len = 2048
 
+[monitor.wandb]
+project = "unscramble-debug"
+
 [data]
 name = "kalomaze/fwedu-unscramble-mix-it1"
 

--- a/configs/inference/simple_unscramble.toml
+++ b/configs/inference/simple_unscramble.toml
@@ -8,9 +8,6 @@ project = "unscramble-debug"
 name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"
 max_model_len = 2048
 
-[monitor.wandb]
-project = "unscramble-debug"
-
 [data]
 name = "kalomaze/fwedu-unscramble-mix-it1"
 

--- a/configs/training/debug.toml
+++ b/configs/training/debug.toml
@@ -1,4 +1,3 @@
-wandb = false
 collate_mode = "padding"
 stop_after_steps = 2
 

--- a/configs/training/formatask.toml
+++ b/configs/training/formatask.toml
@@ -1,3 +1,4 @@
+[monitor.wandb]
 project = "formatask-debug"
 
 [model]

--- a/configs/training/math_only_1b.toml
+++ b/configs/training/math_only_1b.toml
@@ -1,9 +1,10 @@
-project = "math-ablation"
-
 collate_mode = "packing"
 
 [model]
 name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
+
+[monitor.wandb]
+project = "math-ablation"
 
 [train]
 micro_bs = 1 # change to 8 for H200

--- a/configs/training/math_only_7b.toml
+++ b/configs/training/math_only_7b.toml
@@ -1,9 +1,10 @@
-project = "math-ablation"
-
 collate_mode = "packing"
 recompute_logprobs = true
 
 normalize_batch_to_token_count = true
+
+[monitor.wandb]
+project = "math-ablation"
 
 [model]
 name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"

--- a/configs/training/simple_ascii_tree.toml
+++ b/configs/training/simple_ascii_tree.toml
@@ -1,3 +1,4 @@
+[monitor.wandb]
 project = "ascii-tree-debug"
 
 [model]

--- a/configs/training/simple_math.toml
+++ b/configs/training/simple_math.toml
@@ -1,3 +1,4 @@
+[monitor.wandb]
 project = "math-debug"
 
 [model]

--- a/configs/training/simple_math_7b.toml
+++ b/configs/training/simple_math_7b.toml
@@ -1,3 +1,4 @@
+[monitor.wandb]
 project = "math-debug"
 
 [model]

--- a/configs/training/simple_multitask.toml
+++ b/configs/training/simple_multitask.toml
@@ -1,3 +1,4 @@
+[monitor.wandb]
 project = "multitask-debug"
 
 [model]

--- a/configs/training/simple_reverse_two_gpu.toml
+++ b/configs/training/simple_reverse_two_gpu.toml
@@ -1,4 +1,4 @@
-stop_after_steps = 100
+stop_after_steps = 50
 
 [monitor.wandb]
 project = "reverse-debug"

--- a/configs/training/simple_reverse_two_gpu.toml
+++ b/configs/training/simple_reverse_two_gpu.toml
@@ -1,5 +1,7 @@
-project = "reverse-debug"
 stop_after_steps = 100
+
+[monitor.wandb]
+project = "reverse-debug"
 
 [model]
 name = "willcb/Qwen2.5-0.5B-Reverse-SFT"

--- a/configs/training/simple_reverse_two_gpu.toml
+++ b/configs/training/simple_reverse_two_gpu.toml
@@ -12,7 +12,6 @@ reshard_after_forward = true
 
 [optim]
 batch_size = 64
-step_per_rollout = 2
 
 [optim.optim]
 lr = 3e-6

--- a/configs/training/simple_unscramble.toml
+++ b/configs/training/simple_unscramble.toml
@@ -1,3 +1,4 @@
+[monitor.wandb]
 project = "unscramble-debug"
 
 [model]

--- a/install.sh
+++ b/install.sh
@@ -20,8 +20,9 @@ main() {
     log_info "Updating apt..."
     sudo apt update
 
-    log_info "Installing git, tmux, htop, nvtop, cmake, python3-dev, cgroup-tools..."
-    sudo apt install git tmux htop nvtop cmake python3-dev cgroup-tools -y
+    log_info "Installing git, tmux, htop, nvtop, gem, cmake, python3-dev, cgroup-tools..."
+    sudo apt install git tmux htop nvtop gem cmake python3-dev cgroup-tools -y
+    sudo gem install tmuxinator
 
     log_info "Cloning repository..."
     git clone git@github.com:PrimeIntellect-ai/prime-rl.git

--- a/src/zeroband/infer.py
+++ b/src/zeroband/infer.py
@@ -36,11 +36,11 @@ from zeroband.inference.utils import (
     format_prompts,
 )
 from zeroband.training.mp import EnvWrapper
-from zeroband.utils.utils import ensure_process_group_cleanup
+from zeroband.utils.utils import clean_exit
 from zeroband.inference.logger import setup_logger
 
 
-@ensure_process_group_cleanup
+@clean_exit
 def inference(config: InferenceConfig):
     # Initialize the logger
     dp_rank = int(os.environ.get("DP_RANK", 0))

--- a/src/zeroband/infer.py
+++ b/src/zeroband/infer.py
@@ -59,7 +59,7 @@ def inference(config: InferenceConfig):
     logger.success(f"Downloaded model weights in {time.time() - start_time:.2f}s")
 
     # Initialize metrics
-    monitor = setup_monitor(config.monitor, config.task_id)
+    monitor = setup_monitor(config.monitor, config.task_id, config)
 
     # Patch vLLM's model loading to load model shard
     patch_model_load(config=config.parallel.pp)
@@ -314,6 +314,7 @@ def inference(config: InferenceConfig):
             "progress/batch_problems": batch_problems,
             "progress/batch_samples": batch_samples,
             "progress/batch_tokens": batch_tokens,
+            "step": real_step,
         }
         monitor.log(progress_metrics)
 
@@ -330,6 +331,7 @@ def inference(config: InferenceConfig):
             "performance/batch_tokens_per_second": batch_tokens_per_second,
             "performance/batch_samples_per_minute": batch_samples_per_minute,
             "performance/batch_avg_seq_length": batch_avg_seq_length,
+            "step": real_step,
         }
         monitor.log(perf_metrics)
 
@@ -346,7 +348,7 @@ def inference(config: InferenceConfig):
         request_rewards = compute_vllm_rewards(request_outputs, verification_infos, task_types, config.rewards)
         batch_rewards = sum(sum(r.reward for r in req.rewards) for req in request_rewards) / batch_samples
         logger.info(f"Average reward of the batch: {batch_rewards:.2f}")
-        monitor.log({"rewards/batch_rewards": batch_rewards})
+        monitor.log({"rewards/batch_rewards": batch_rewards, "step": real_step})
 
         if sampling_params.seed is not None:
             sampling_seeds = [sampling_params.seed + i for i in range(sampling_params.n)] * problems_per_batch
@@ -381,14 +383,13 @@ def inference(config: InferenceConfig):
             for input_tokens, output_tokens in zip(table.column("input_tokens").to_pylist(), table.column("output_tokens").to_pylist())
         ]
 
-        monitor.log(
-            {
-                "output/save_path": save_path.as_posix(),
-                "output/sha256": sha256,
-                "output/output_flops": sum(output_flops for _, output_flops in flop_counts) // config.parallel.pp.world_size,
-                "output/input_flops": sum(input_flops for input_flops, _ in flop_counts) // config.parallel.pp.world_size,
-            }
-        )
+        outputs_metrics = {
+            "output/output_flops": sum(output_flops for _, output_flops in flop_counts) // config.parallel.pp.world_size,
+            "output/input_flops": sum(input_flops for input_flops, _ in flop_counts) // config.parallel.pp.world_size,
+            "step": real_step,
+        }
+        monitor.log(outputs_metrics)
+        monitor.log({"output/save_path": save_path.as_posix(), "output/sha256": sha256, "step": real_step}, exclude=["wandb"])
 
         real_step += 1
 

--- a/src/zeroband/train.py
+++ b/src/zeroband/train.py
@@ -10,7 +10,6 @@ import shardcast
 import torch
 import torch.distributed as dist
 import torch.distributed.tensor
-import wandb
 from jaxtyping import Float
 from liger_kernel.transformers import apply_liger_kernel_to_qwen2
 from torch._guards import log as torch_log
@@ -29,7 +28,6 @@ from zeroband.training.utils import (
     apply_ac_ckpt,
     copy_model_to_cpu,
     log_prompt_response_samples,
-    log_to_wandb,
     offload_model_to_cpu,
     reshard_module,
     wake_up_model_from_cpu,
@@ -150,11 +148,8 @@ def train(config: TrainingConfig):
     total_samples = config.start_total_samples if config.start_total_samples is not None else 0
     training_progress = TrainingProgress(total_tokens=0, step=config.start_step, total_samples=total_samples)
 
-    if world_info.rank == 0 and config.wandb:
-        wandb.init(project=config.project, config=config.model_dump(), dir="wandb_logs", name=config.wandb_run_name)
-
     # Setup the monitor
-    monitor = setup_monitor(config.monitor)
+    monitor = setup_monitor(config.monitor, run_config=config)
 
     if config.train.torch_compile:
         model = torch.compile(model) if not TYPE_CHECKING else model
@@ -299,7 +294,7 @@ def train(config: TrainingConfig):
             num_grad_acc_steps = len(data_per_rollout)
 
             # Collect samples for WandB logging - do this ONCE per step
-            if world_info.rank == 0 and config.wandb:
+            if world_info.rank == 0 and config.monitor.wandb:
                 # Use the first batch for logging (could be configurable if needed)
                 batch = data_per_rollout[0]
 
@@ -325,33 +320,32 @@ def train(config: TrainingConfig):
 
                 # Update general metrics
                 for rewards in batch["rewards"]:
-                    metric_averager.update("sample_reward", rewards)
+                    metric_averager.update("rewards/sample_reward", rewards)
                 for seq_lens in batch["seq_lens"]:
-                    metric_averager.update("seq_lens", seq_lens)
+                    metric_averager.update("lengths/seq_lens", seq_lens)
                 for length_penalties in batch["length_penalties"]:
-                    metric_averager.update("length_penalties", length_penalties)
+                    metric_averager.update("lengths/length_penalties", length_penalties)
                 for target_lengths in batch["target_lengths"]:
-                    metric_averager.update("target_lengths", target_lengths)
+                    metric_averager.update("lengths/target_lengths", target_lengths)
 
                 # Task-specific metrics with proper grouping
                 if "task_types" in batch:
                     # Group rewards by task type
                     task_type_rewards = defaultdict(list)
                     for i, task_type in enumerate(batch["task_types"]):
-                        task_key = f"individual_task_{task_type}"
-                        task_type_rewards[task_key].append(batch["task_rewards"][i].item())
+                        task_type_rewards[task_type].append(batch["task_rewards"][i].item())
 
                     # Update metrics with task-specific averages
                     for task_key, rewards in task_type_rewards.items():
                         if rewards:
                             avg_reward = sum(rewards) / len(rewards)
-                            metric_averager.update(task_key, torch.tensor(avg_reward))
+                            metric_averager.update(f"task_rewards/{task_key}", torch.tensor(avg_reward))
 
                     # Add aggregate task_reward metric
                     all_task_rewards = [reward.item() for reward in batch["task_rewards"]]
                     if all_task_rewards:
                         avg_task_reward = sum(all_task_rewards) / len(all_task_rewards)
-                        metric_averager.update("task_reward", torch.tensor(avg_task_reward))
+                        metric_averager.update("rewards/task_reward", torch.tensor(avg_task_reward))
 
                 # Forward
                 logits: Float[torch.Tensor, "batch seq vocab"] = model(
@@ -383,7 +377,7 @@ def train(config: TrainingConfig):
                 if config.grpo.kl_coef is not None:
                     kl = kl_penalty(original_logprobs, batch["ref_logprobs"].to("cuda"), loss_mask, max_tokens)
                     kl_scaled = kl * config.grpo.kl_coef
-                    metric_averager.update("kl", kl_scaled)
+                    metric_averager.update("losses/kl", kl_scaled)
                     loss = loss + kl_scaled
 
                 loss = loss / num_grad_acc_steps
@@ -397,11 +391,11 @@ def train(config: TrainingConfig):
                 loss.backward()
                 loss_batch += loss.detach().clone()
 
-                metric_averager.update("pg_loss", pg_loss.detach().clone())
-                metric_averager.update("entropy_loss", entropy.detach().clone())
+                metric_averager.update("losses/pg_loss", pg_loss.detach().clone())
+                metric_averager.update("losses/entropy_loss", entropy.detach().clone())
 
                 if clip_ratio is not None:
-                    metric_averager.update("clip_ratio", clip_ratio.detach().clone())
+                    metric_averager.update("losses/clip_ratio", clip_ratio.detach().clone())
 
                 del loss, pg_loss, entropy, clip_ratio
 
@@ -427,19 +421,17 @@ def train(config: TrainingConfig):
             training_progress.total_tokens += new_tokens
             training_progress.total_samples += config.optim.batch_size
 
-            padding_proportion = (config.data.seq_length - metric_averager["seq_lens"].item() - 1) / config.data.seq_length
+            padding_proportion = (config.data.seq_length - metric_averager["lengths/seq_lens"].item() - 1) / config.data.seq_length
 
             metrics = {
-                "Loss": loss_batch.item(),
                 "step": training_progress.step,
-                "rollout_step": rollout_step,
-                "inner_lr": inner_lr,
-                "total_tokens": training_progress.total_tokens,
-                "time": time.time(),
-                "grad_norm": grad_norm.item(),
-                "padding_proportion": padding_proportion,
-                "grad_acc_steps": num_grad_acc_steps,
-                "total_samples": training_progress.total_samples,
+                "losses/Loss": loss_batch.item(),
+                "train/rollout_step": rollout_step,
+                "train/inner_lr": inner_lr,
+                "train/total_tokens": training_progress.total_tokens,
+                "train/total_samples": training_progress.total_samples,
+                "losses/grad_norm": grad_norm.item(),
+                "lengths/padding_proportion": padding_proportion,
             }
 
             for key, value in metric_averager.items():
@@ -449,7 +441,7 @@ def train(config: TrainingConfig):
                 f"step: {training_progress.step}, "
                 f"rollout_step: {training_progress.step // config.optim.step_per_rollout}, "
                 f"loss: {loss_batch.item():.4f}, "
-                f"sample_reward: {metric_averager['sample_reward'].item():.4f}, "
+                f"sample_reward: {metric_averager['rewards/sample_reward'].item():.4f}, "
             )
 
             del loss_batch, grad_norm
@@ -457,24 +449,18 @@ def train(config: TrainingConfig):
             tokens_per_second = perf_counter.get_tokens_per_second()
             if tokens_per_second is not None:
                 tokens_per_second_per_gpu = tokens_per_second / world_info.world_size
-                metrics["tokens_per_second"] = tokens_per_second
-                metrics["tokens_per_second_per_gpu"] = tokens_per_second_per_gpu
+                mfu = perf_counter.get_mfu()
+                metrics.update(
+                    {
+                        "perf/tokens_per_second": tokens_per_second,
+                        "perf/tokens_per_second_per_gpu": tokens_per_second_per_gpu,
+                        "perf/mfu": mfu,
+                    }
+                )
 
-                metrics["mfu"] = perf_counter.get_mfu()
-
-                log += f", tokens_per_second: {tokens_per_second:.2f}, tokens_per_second_per_gpu: {tokens_per_second_per_gpu:.2f}, mfu: {metrics['mfu']:.2f}"
+                log += f", tokens_per_second: {tokens_per_second:.2f}, tokens_per_second_per_gpu: {tokens_per_second_per_gpu:.2f}, mfu: {mfu:.2f}"
 
             if world_info.rank == 0:
-                if config.wandb:
-                    log_to_wandb(metrics)
-
-                # Lowercase metrics before logging
-                metrics = {k.lower(): v for k, v in metrics.items()}
-
-                # Filter metrics to only include the ones we want to send to the API
-                metrics = {k: metrics[k] for k in ("step", "seq_lens", "sample_reward", "total_samples")}
-
-                # TODO(Mika): Maybe need to ensure not logging duplicates?
                 monitor.log(metrics)
 
             logger.info(log)
@@ -517,16 +503,15 @@ def train(config: TrainingConfig):
 
         time_rollout_step = time.time() - time_start
         logger.success(f"Finished training step {training_progress.step} in {time_rollout_step:.2f}s")
-        if world_info.rank == 0 and config.wandb:
-            new_metrics = {
-                "rollout_step": rollout_step,
+        if world_info.rank == 0:
+            time_metrics = {
                 "step": training_progress.step,
-                "time_rollout_step": time_rollout_step,
-                "time_logprob": time_logprob,
-                "time_data_loading": total_time_data_loading,
-                "time_packing": total_time_packing,
+                "perf/time_rollout_step": time_rollout_step,
+                "perf/time_logprob": time_logprob,
+                "perf/time_data_loading": total_time_data_loading,
+                "perf/time_packing": total_time_packing,
             }
-            log_to_wandb(new_metrics)
+            monitor.log(time_metrics)
 
         if config.stop_after_steps is not None and training_progress.step >= config.stop_after_steps:
             break

--- a/src/zeroband/train.py
+++ b/src/zeroband/train.py
@@ -38,7 +38,7 @@ from zeroband.training.world_info import WorldInfo, get_world_info
 from zeroband.utils.models import ModelType, get_model_and_tokenizer
 from zeroband.utils.monitor import setup_monitor
 from zeroband.utils.pydantic_config import parse_argv
-from zeroband.utils.utils import ensure_process_group_cleanup
+from zeroband.utils.utils import clean_exit
 
 
 def get_local_batch_size(batch_size: int, micro_bs: int, data_workers: int, world_info: WorldInfo) -> int:
@@ -86,7 +86,7 @@ def get_logprobs(model: ModelType, input_ids: torch.Tensor, position_ids: torch.
     return logprobs
 
 
-@ensure_process_group_cleanup
+@clean_exit
 def train(config: TrainingConfig):
     if "ZERO_BAND_DEV" not in os.environ:
         torch_log.setLevel(logging.CRITICAL)

--- a/src/zeroband/training/config.py
+++ b/src/zeroband/training/config.py
@@ -187,13 +187,6 @@ class Config(BaseSettings):
     # The monitor configuration
     monitor: MultiMonitorConfig = MultiMonitorConfig()
 
-    # W&B configurations
-    wandb: Annotated[bool, Field(default=True)]
-
-    project: Annotated[str, Field(default="prime_simple")]
-
-    wandb_run_name: Annotated[str | None, Field(default=None)]
-
     gpus_ids: Annotated[list[int] | None, Field(default=None)]
 
     async_level: Annotated[int, Field(default=2, ge=1)]

--- a/src/zeroband/utils/config.py
+++ b/src/zeroband/utils/config.py
@@ -50,6 +50,35 @@ class APIMonitorConfig(BaseConfig):
         return self
 
 
+class WandbMonitorConfig(BaseConfig):
+    """Configures logging to Weights and Biases."""
+
+    project: Annotated[str, Field(default="prime-rl", description="The W&B project to log to.")]
+    group: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description="The W&B group to log to. If None, it will not set the group. Use grouping if you want multiple associated runs (e.g. RL training has a training and inference run) log to the same dashboard.",
+        ),
+    ]
+    name: Annotated[str | None, Field(default=None, description="The W&B name to to use for logging.")]
+    dir: Annotated[
+        Path | None,
+        Field(
+            default=Path("logs"),
+            description="Path to the directory to keep local logs. It will automatically create a `wandb` subdirectory to store run logs.",
+        ),
+    ]
+
+    prefix: Annotated[
+        str,
+        Field(
+            default="",
+            description="The prefix to add to each key in the metrics dictionary before logging to W&B. Useful for distinguishing between different runs in the same group (e.g. training and inference)",
+        ),
+    ]
+
+
 class MultiMonitorConfig(BaseConfig):
     """Configures the monitoring system."""
 
@@ -57,13 +86,19 @@ class MultiMonitorConfig(BaseConfig):
     file: Annotated[FileMonitorConfig, Field(default=None)]
     socket: Annotated[SocketMonitorConfig, Field(default=None)]
     api: Annotated[APIMonitorConfig, Field(default=None)]
+    wandb: Annotated[WandbMonitorConfig, Field(default=None)]
 
     system_log_frequency: Annotated[
         int, Field(default=0, ge=0, description="Interval in seconds to log system metrics. If 0, no system metrics are logged)")
     ]
 
     def __str__(self) -> str:
-        file_str = "disabled" if self.file is None else f"path={self.file.path}"
-        socket_str = "disabled" if self.socket is None else f"path={self.socket.path}"
-        api_str = "disabled" if self.api is None else f"url={self.api.url}"
-        return f"file={file_str}, socket={socket_str}, api={api_str}, system_log_frequency={self.system_log_frequency}"
+        file_str = "disabled" if self.file is None else f"(path={self.file.path})"
+        socket_str = "disabled" if self.socket is None else f"(path={self.socket.path})"
+        api_str = "disabled" if self.api is None else f"(url={self.api.url})"
+        wandb_str = (
+            "disabled"
+            if self.wandb is None
+            else f"(project={self.wandb.project}, group={self.wandb.group}, name={self.wandb.name}, dir={self.wandb.dir})"
+        )
+        return f"file={file_str}, socket={socket_str}, api={api_str}, wandb={wandb_str}, system_log_frequency={self.system_log_frequency}"

--- a/src/zeroband/utils/config.py
+++ b/src/zeroband/utils/config.py
@@ -93,12 +93,5 @@ class MultiMonitorConfig(BaseConfig):
     ]
 
     def __str__(self) -> str:
-        file_str = "disabled" if self.file is None else f"(path={self.file.path})"
-        socket_str = "disabled" if self.socket is None else f"(path={self.socket.path})"
-        api_str = "disabled" if self.api is None else f"(url={self.api.url})"
-        wandb_str = (
-            "disabled"
-            if self.wandb is None
-            else f"(project={self.wandb.project}, group={self.wandb.group}, name={self.wandb.name}, dir={self.wandb.dir})"
-        )
-        return f"file={file_str}, socket={socket_str}, api={api_str}, wandb={wandb_str}, system_log_frequency={self.system_log_frequency}"
+        is_enabled = lambda x: "enabled" if x is not None else "disabled"
+        return f"file={is_enabled(self.file)}, socket={is_enabled(self.socket)}, api={is_enabled(self.api)}, wandb={is_enabled(self.wandb)}, system_log_frequency={self.system_log_frequency}"

--- a/src/zeroband/utils/monitor.py
+++ b/src/zeroband/utils/monitor.py
@@ -169,7 +169,7 @@ class MultiMonitor:
         """Logs metrics to all outputs."""
         if self.disabled:
             return
-        self.logger.info(f"Logging metrics: {metrics}")
+        self.logger.debug(f"Logging metrics: {metrics}")
         for output_type, output in self.outputs.items():
             if output_type not in exclude:
                 output.log(metrics)

--- a/src/zeroband/utils/utils.py
+++ b/src/zeroband/utils/utils.py
@@ -1,9 +1,10 @@
 import functools
 
 import torch.distributed as dist
+import wandb
 
 
-def ensure_process_group_cleanup(func):
+def clean_exit(func):
     """
     A decorator that ensures the a torch.distributed process group is properly
     cleaned up after the decorated function runs or raises an exception.
@@ -18,7 +19,12 @@ def ensure_process_group_cleanup(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         try:
-            return func(*args, **kwargs)
+            ret = func(*args, **kwargs)
+            wandb.finish()
+            return ret
+        except Exception as e:
+            wandb.finish(exit_code=1)
+            raise e
         finally:
             if dist.is_initialized():
                 dist.destroy_process_group()

--- a/tests/e2e/test_rl.py
+++ b/tests/e2e/test_rl.py
@@ -47,7 +47,7 @@ def processes(run_processes: Callable[[list[Command], list[Environment]], list[P
         project = "ci_run_prime_rl_local"
         wandb_run_name = f"{username}-{branch_name}-{commit_hash}"
 
-    training_cmd = TRAINING_CMD + ["--wandb_run_name", wandb_run_name, "--project", project]
+    training_cmd = TRAINING_CMD + ["--monitor.wandb.name", wandb_run_name, "--monitor.wandb.project", project]
     inference_cmd = INFERENCE_CMD
 
     return run_processes([training_cmd, inference_cmd], [TRAINING_ENV, INFERENCE_ENV], timeout=600)


### PR DESCRIPTION
This PR proposes to use `tmuxinator` as a general entrypoint for local-only RL experiments that require starting a training and inference process. I think this will be super useful and clear for new users to get started with using prime-rl and streamline our internal experimentation workflow.

The tmuxinator script should be viewed as an entrypoint that consumes a configuration for training and inference as well as a GPU allocation. It then automatically starts a tmux session with three windows: 
- `RL`: Training and inerence process in two panes
- `Monitor`: File monitor logs from training and inference in two pane
- `System`: Runs `htop` and `nvtop`

## Default

By default, it will run our CI RL run which is very minimal, completes fast but has includes all the functionality you would want from a local RL run.

```bash
tmuxinator
```

<img width="2343" alt="Screenshot 2025-06-17 at 10 00 45 PM" src="https://github.com/user-attachments/assets/c67b8045-da73-412c-b0a1-aa83dbd03d2a" />

<img width="2343" alt="Screenshot 2025-06-17 at 10 01 12 PM" src="https://github.com/user-attachments/assets/3c4c7e2a-14e2-44f5-b16f-c6d1a2e5d888" />
 
## Running an experiment

Most experiments, should be uniquely identifiyed by three things:
1. A training script (ideally this is as little as a single config file, say `@configs/training/exp1.toml`) and the number of GPUs to run on
2. An inference script (again, a single (matching) config file, say @configs/inference/exp1.toml`) and the number of GPUs to run on
3. Optionally, a name for the experiment

All of these can be set in the tmuxinator script via environment variables when starting the tmuxinator script. For example, to run the 2 GPU simple math run from the README:

```
TRAIN_ARGS=@configs/training/simple_math.toml INFER_ARGS="@configs/inference/simple_math.toml --parallel.dp 1 --max-batch-size 512" WANDB_GROUP=simple-math-test tmuxinator
```