### PR TITLE
Fix unifying monitor format

### DIFF
--- a/src/zeroband/utils/monitor.py
+++ b/src/zeroband/utils/monitor.py
@@ -65,9 +65,18 @@ class Monitor(ABC):
     def __init__(self, config: MonitorConfig):
         self.config = config
         self.lock = threading.Lock()
+        self.metadata = {
+            "run_id": envs.PRIME_RUN_ID,
+            "task_id": envs.PRIME_TASK_ID,
+        }
+        self.has_metadata = any(self.metadata.values())
+        if not self.has_metadata:
+            logger.warning("No run metadata found. This is fine for local runs, but unexpected when contributing to a public run.")
         logger.debug(f"Initializing {self.__class__.__name__} ({str(self.config).replace(' ', ', ')})")
 
     def _serialize_metrics(self, metrics: dict[str, Any]) -> str:
+        if self.has_metadata:
+            metrics.update(self.metadata)
         return json.dumps(metrics)
 
     @abstractmethod
@@ -107,20 +116,10 @@ class SocketMonitor(Monitor):
 
     def log(self, metrics: dict[str, Any]) -> None:
         with self.lock:
-            task_id = os.getenv("PRIME_TASK_ID", None)
-            if task_id is None:
-                logger.warning("No task ID found, skipping logging")
-                return
-
             try:
                 with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
                     sock.connect(self.socket_path)
-                    
-                    msg_buffer = []
-                    for key, value in metrics.items():
-                        msg_buffer.append(json.dumps({"label": key, "value": value, "task_id": task_id}))
-                    sock.sendall("\n".join(msg_buffer).encode())
-                    
+                    sock.sendall(self._serialize_metrics(metrics).encode())
                 logger.debug(f"Logged successfully to {self.socket_path}")
             except Exception as e:
                 logger.error(f"Failed to log metrics to {self.socket_path}: {e}")
@@ -143,9 +142,9 @@ class APIMonitor(Monitor):
     def log(self, metrics: dict[str, Any]) -> None:
         """Logs metrics to the server"""
         headers = {"Content-Type": "application/json", "Authorization": f"Bearer {self.auth_token}"}
-        payload = {"metrics": self._serialize_metrics(metrics), "operation_type": "append"}
+        payload = {"metrics": self._serialize_metrics(metrics)}
 
-        async def _send_batch():
+        async def _post_metrics():
             try:
                 async with aiohttp.ClientSession() as session:
                     async with session.post(self.url, json=payload, headers=headers) as response:
@@ -153,9 +152,9 @@ class APIMonitor(Monitor):
                             response.raise_for_status()
                     logger.debug(f"Logged successfully to server {self.url}")
             except Exception as e:
-                logger.error(f"Error sending batch to server: {str(e)}")
+                logger.error(f"Failed to log metrics to {self.url}: {e}")
 
-        asyncio.run(_send_batch())
+        asyncio.run(_post_metrics())
 
 
 class MultiMonitor:

--- a/tests/unit/utils/test_monitor.py
+++ b/tests/unit/utils/test_monitor.py
@@ -105,12 +105,14 @@ def mock_socket():
 
 
 def test_socket_monitor(mock_socket):
-    # Create socket output
-    output = SocketMonitor(SocketMonitorConfig(enable=True, path="/test/socket.sock"))
-
     # Set task ID in environment
     test_task_id = "test-task-123"
+    test_run_id = "test-run-123"
     os.environ["PRIME_TASK_ID"] = test_task_id
+    os.environ["PRIME_RUN_ID"] = test_run_id
+
+    # Create socket output
+    output = SocketMonitor(SocketMonitorConfig(enable=True, path="/test/socket.sock"))
 
     # Test logging metrics
     test_metrics = {"step": 1, "loss": 3.14}
@@ -121,13 +123,7 @@ def test_socket_monitor(mock_socket):
 
     # Get the data that was sent
     sent_data = mock_socket.sendall.call_args[0][0].decode("utf-8")
-    # Verify each metric is sent as a separate JSON object with task_id
-    expected_data = "\n".join(
-        [
-            json.dumps({"label": "step", "value": 1, "task_id": test_task_id}),
-            json.dumps({"label": "loss", "value": 3.14, "task_id": test_task_id}),
-        ]
-    )
+    expected_data = json.dumps({**test_metrics, "task_id": test_task_id, "run_id": test_run_id})
     assert sent_data.strip() == expected_data
 
 


### PR DESCRIPTION
Reverts change to old logging format introduced in #328 for `SocketMonitor`

*Old Format*

```txt
{"key": "progress/batch_problems", "value", 8, "task_id": "dskfjs"}
{"key": "progress/batch_samples", "value": 64, "task_id": "dskfjs"}
{"key": "progress/batch_tokens", "value": 1831, "task_id": "dskfjs"}
```

*New Format*

```txt
{"progress/batch_problems": 8, "progress/batch_samples": 64, "progress/batch_tokens": 1831, "task_id": "dskfjs"}
```

**This PR should only be merged once the protocol worker (opens the socket port which handles aggregating and relaying the logs) supports the new format.**

Also moves adding prime metadata (e.g. `PRIME_TASK_ID` or `PRIME_RUN_ID` into the base class's `_serialize_metrics` method. This means that, if available, all public run metadata will be logged to all sources (file, socket, api, ...) on every call to `.log`. While this might be redundant (and some sources might not need all the logs), this is keeps the clean abstraction that all sources mirror the same logs.