### PR TITLE
fix json util for reward function

### DIFF
--- a/src/zeroband/inference/genesys/format_utils.py
+++ b/src/zeroband/inference/genesys/format_utils.py
@@ -37,6 +37,9 @@ def extract_last_json(completion: str) -> dict | None:
     if json_str is None:
         return None
     try:
-        return json.loads(json_str)
+        loaded_json = json.loads(json_str)
+        if type(loaded_json) == dict:
+            return loaded_json
+        return None
     except json.JSONDecodeError:
         return None


### PR DESCRIPTION
small fix: when a string is inside of a json markdown hint, json.loads() will not throw an error and instead just return a string. This is unwanted of course