### PR TITLE
Add Sanskrit Morphology Reward System (रूपशिक्षा)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "setuptools",
     "reasoning-gym @ git+https://github.com/open-thought/reasoning-gym.git",
     "tomli>=2.2.1",
+    "vidyut",
 ] 
 
 [project.optional-dependencies]

--- a/scripts/create_sanskrit_morphology_dataset.py
+++ b/scripts/create_sanskrit_morphology_dataset.py
@@ -1,0 +1,101 @@
+import os
+import random
+from typing import List
+import itertools
+
+import vidyut
+from vidyut.prakriya import Data, Dhatu, Lakara, Prayoga, Purusha, Vacana
+from datasets import Dataset
+from datasets.dataset_dict import DatasetDict
+from src.zeroband.inference.genesys.sanskrit_morphology import VerbMorphologySpecification
+
+# --- Constants ---
+RANDOM_SEED = 108
+DATA_DIR = "vidyut-data"
+PRAKRIYA_DIR = os.path.join(DATA_DIR, "prakriya")
+HF_REPO_NAME = "saahily/sanskrit-morphology"
+
+# --- Data Utilities ---
+def load_dhatupatha() -> List[Dhatu]:
+    dhatupatha_path = os.path.join(PRAKRIYA_DIR, "dhatupatha.tsv")
+    if not os.path.exists(dhatupatha_path):
+        vidyut.download_data(DATA_DIR)
+
+    return [d.dhatu for d in Data(PRAKRIYA_DIR).load_dhatu_entries()]
+
+def generate_examples(num_examples) -> List[VerbMorphologySpecification]:
+    # NB: this will run indefinitely if num_examples is greater than the number of unique combinations
+    random.seed(RANDOM_SEED)
+    dhatus = load_dhatupatha()
+    print(f"✅ Loaded {len(dhatus)} dhatus")
+
+    def _generate_unique_specs():
+        """Generator that yields unique morphological specifications"""
+        seen = set()
+        for _ in itertools.count():
+            spec = VerbMorphologySpecification(
+                dhatu=(dhatu := random.choice(dhatus)).aupadeshika,
+                gana=dhatu.gana,
+                lakara=random.choice(Lakara.choices()),
+                prayoga=random.choice(Prayoga.choices()),
+                purusha=random.choice(Purusha.choices()),
+                vacana=random.choice(Vacana.choices())
+            )
+            
+            spec_key = tuple(sorted(spec.to_dict().items()))
+            if spec_key not in seen:
+                seen.add(spec_key)
+                yield spec
+
+    examples = list(itertools.islice(_generate_unique_specs(), num_examples))
+    print(f"✅ Generated {len(examples)} unique examples")
+    return examples
+
+# --- Prompt Builder ---
+def create_morphology_prompt(spec: VerbMorphologySpecification) -> str:
+    return (
+        "Generate the correct Sanskrit surface form for the following morphological specification:\n\n"
+        f"Dhātu: {spec.dhatu}\n"
+        f"Gaṇa: {spec.gana}\n"
+        f"Lakāra: {spec.lakara}\n"
+        f"Prayoga: {spec.prayoga}\n"
+        f"Puruṣa: {spec.purusha}\n"
+        f"Vacana: {spec.vacana}\n\n"
+        "Please provide the correct surface form following Pāṇinian grammar rules, and in the format: [[surface_form]]"
+    )
+
+# --- Dataset Builder ---
+def create_datasets(size: int = 75000, test_size: float = 0.1) -> DatasetDict:
+    print(f"\n🔄 Generating {size} Sanskrit morphology examples...")
+    examples = generate_examples(size)
+
+    dataset_rows = []
+    for spec in examples:
+        row = {
+            "prompt": create_morphology_prompt(spec),
+            "task_type": "sanskrit_morphology",
+            "verification_info": spec.to_dict(),
+        }
+        dataset_rows.append(row)
+
+    dataset = Dataset.from_list(dataset_rows)
+    print(f"📊 Created dataset with {len(dataset)} examples")
+
+    datasets = dataset.train_test_split(test_size=test_size, seed=RANDOM_SEED)
+    print(f"✂️ Split into train ({len(datasets['train'])}) and test ({len(datasets['test'])}) sets")
+
+    return datasets
+
+# --- Upload Utility ---
+def push_datasets_to_hub(datasets: DatasetDict):
+    print(f"\n🚀 Uploading dataset to Hugging Face: {HF_REPO_NAME}")
+    datasets.push_to_hub(
+        HF_REPO_NAME,
+        commit_message="Add Sanskrit morphology dataset for tinantas"
+    )
+    print(f"✅ Upload complete: https://huggingface.co/datasets/{HF_REPO_NAME}")
+
+# --- Main ---
+if __name__ == "__main__":
+    datasets = create_datasets()
+    push_datasets_to_hub(datasets)

--- a/scripts/create_sanskrit_morphology_dataset.py
+++ b/scripts/create_sanskrit_morphology_dataset.py
@@ -65,7 +65,7 @@ def create_morphology_prompt(spec: VerbMorphologySpecification) -> str:
     )
 
 # --- Dataset Builder ---
-def create_datasets(size: int = 75000, test_size: float = 0.1) -> DatasetDict:
+def create_datasets(size: int = 200000, test_size: float = 0.1) -> DatasetDict:
     print(f"\n🔄 Generating {size} Sanskrit morphology examples...")
     examples = generate_examples(size)
 

--- a/src/zeroband/inference/genesys/__init__.py
+++ b/src/zeroband/inference/genesys/__init__.py
@@ -4,8 +4,9 @@ from zeroband.inference.genesys.code import evaluate_code
 from zeroband.inference.genesys.code_output_prediction import verify_code_output_prediction
 from zeroband.inference.genesys.math import compute_math_reward
 from zeroband.inference.genesys.reasoning_gym import verify_reasoning_gym
+from zeroband.inference.genesys.sanskrit_morphology import compute_sanskrit_morphology_reward
 
-TaskType = Literal["verifiable_math", "prime_rl_code", "reasoning_gym", "code_output_prediction"]
+TaskType = Literal["verifiable_math", "prime_rl_code", "reasoning_gym", "code_output_prediction", "sanskrit_morphology"]
 
 
 def get_reward_function(task_type: TaskType) -> Callable[[str, dict], float]:
@@ -20,4 +21,5 @@ _REWARD_FUNCTIONS: dict[TaskType, Callable] = {
     "prime_rl_code": evaluate_code,
     "reasoning_gym": verify_reasoning_gym,
     "code_output_prediction": verify_code_output_prediction,
+    "sanskrit_morphology": compute_sanskrit_morphology_reward,
 }

--- a/src/zeroband/inference/genesys/sanskrit_morphology.py
+++ b/src/zeroband/inference/genesys/sanskrit_morphology.py
@@ -1,0 +1,162 @@
+"""
+Sanskrit morphology reward computation using Paninian grammar rules.
+
+Call compute_sanskrit_morphology_reward(completion: str, verification_info: Dict).
+"""
+
+from typing import Dict, List, Optional
+from dataclasses import dataclass
+import re
+
+from vidyut.prakriya import Dhatu, Gana, Lakara, Prayoga, Purusha, Vacana, Pada, Vyakarana, Prakriya
+from vidyut.lipi import Scheme, transliterate, detect
+
+
+# --- Main Reward Function ---
+def compute_sanskrit_morphology_reward(completion: str, verification_info: Dict) -> float:
+    """
+    Compute reward for Sanskrit morphology generation task.
+    
+    Args:
+        completion: The model's generated Sanskrit surface form
+        verification_info: Dictionary containing morphological specification
+    
+    Returns:
+        float: Reward score between 1.0 and 0.0
+    """
+    try:
+        # Extract the generated form from completion
+        generated_form = _extract_answer(completion)
+
+        # Convert to SLP1 scheme
+        generated_form = _convert_to_slp1(generated_form)
+        if not generated_form:
+            return 0.0
+        
+        # Get all possible derivations using Vidyut-Prakriya
+        derivations = _paninian_surface_form_derivations(verification_info)
+        
+        # Verify the generated form against derivations
+        return _verify_generated_form_with_score(generated_form, derivations)
+        
+    except Exception:
+        return 0.0
+
+
+# --- Text Processing Utilities ---
+def _extract_answer(completion: str) -> Optional[str]:
+    """
+    Extract the Sanskrit form from the model's completion. Expects the answer to be in [[surface_form]] format.
+    
+    Args:
+        completion: Full model output text
+        
+    Returns:
+        Optional[str]: Extracted Sanskrit form, or None if not found or invalid
+    """
+    matches = re.findall(r'\[\[([^\]]*)\]\]', completion)
+    content = matches[-1].strip() if matches else ""
+    return content if content and ' ' not in content else None
+
+
+def _convert_to_slp1(sanskrit_text: str) -> Optional[str]:
+    """
+    Convert the given text to SLP1 (Sanskrit Language Processing 1) romanization.
+    
+    Args:
+        sanskrit_text: The text to convert
+    
+    Returns:
+        Optional[str]: The converted text in SLP1 romanization, or None if detection fails
+    """
+    if not sanskrit_text:
+        return None
+    
+    input_scheme = detect(sanskrit_text)
+    if input_scheme is None:
+        return None
+    
+    return transliterate(sanskrit_text, input_scheme, Scheme.Slp1)
+
+
+# --- Paninian Grammar ---
+def _paninian_surface_form_derivations(verification_info: Dict) -> List[Prakriya]:
+    """
+    Generate all possible Sanskrit surface forms using Vidyut-Prakriya.
+    NB: Vidyut uses SLP1 romanization internally.
+    
+    Args:
+        verification_info: Dictionary containing morphological specification
+        
+    Returns:
+        List[Prakriya]: List of derivation objects containing surface forms and derivation steps
+    """
+    spec = VerbMorphologySpecification.from_dict(verification_info)
+    v = Vyakarana()
+    
+    mula_dhatu = Dhatu.mula(aupadeshika=spec.dhatu, gana=spec.gana)
+    prakriyas = v.derive(Pada.Tinanta(
+        dhatu=mula_dhatu,
+        prayoga=spec.prayoga,
+        lakara=spec.lakara,
+        purusha=spec.purusha,
+        vacana=spec.vacana,
+    ))
+    
+    # Return all derivations
+    return prakriyas
+
+
+def _verify_generated_form_with_score(generated_form: str, prakriyas: List[Prakriya]) -> float:
+    """
+    Verify if the generated form matches any of the derivations.
+    
+    Args:
+        generated_form: The generated Sanskrit form in SLP1 romanization
+        prakriyas: List of possible derivations
+    
+    Returns:
+        float: Correctness score (1.0 for exact match, scaled partial score for intermediate form matches)
+    """
+    # Check for exact match with correct forms
+    correct_forms = {prakriya.text for prakriya in prakriyas}
+    if generated_form in correct_forms:
+        return 1.0
+
+    # Check for partial correctness (intermediate forms in derivation steps)
+    max_score = 0.0
+    for prakriya in prakriyas:
+        steps = prakriya.history or []
+        for i, step in enumerate(steps):
+            intermediate_form = ''.join(step.result)
+            if generated_form == intermediate_form:
+                score = (i + 1) / len(steps)
+                max_score = max(max_score, score)
+    
+    return max_score
+
+
+# --- Data Class ---
+@dataclass
+class VerbMorphologySpecification:
+    """Contains all the grammatical parameters to specify a tinanta pada (finite verb surface form)"""
+    dhatu: str          # Root verb (aupadeshika form)
+    gana: Gana          # Verb class 
+    lakara: Lakara      # Tense/mood
+    prayoga: Prayoga    # Voice 
+    purusha: Purusha    # Person 
+    vacana: Vacana      # Number 
+    
+    def to_dict(self) -> dict:
+        return {k: str(v) for k, v in vars(self).items()}
+    
+    @classmethod
+    def from_dict(cls, d: dict) -> "VerbMorphologySpecification":
+        return cls(
+            dhatu=d["dhatu"],
+            gana=Gana(d["gana"]),
+            lakara=Lakara(d["lakara"]),
+            prayoga=Prayoga(d["prayoga"]),
+            purusha=Purusha(d["purusha"]),
+            vacana=Vacana(d["vacana"]),
+        )

--- a/tests/unit/inference/test_sanskrit_morphology.py
+++ b/tests/unit/inference/test_sanskrit_morphology.py
@@ -1,6 +1,6 @@
 import pytest
 
-from src.zeroband.inference.genesys.sanskrit_morphology import compute_sanskrit_morphology_reward
+from zeroband.inference.genesys.sanskrit_morphology import compute_sanskrit_morphology_reward
 
 # --- Test Data ---
 @pytest.fixture

--- a/tests/unit/inference/test_sanskrit_morphology.py
+++ b/tests/unit/inference/test_sanskrit_morphology.py
@@ -1,0 +1,314 @@
+import pytest
+
+from src.zeroband.inference.genesys.sanskrit_morphology import compute_sanskrit_morphology_reward
+
+# --- Test Data ---
+@pytest.fixture
+def sample_verification_info():
+    # Bhvādi dhātu -> present (Laṭ) active 1sg"
+    return {
+        "dhatu": "BU",
+        "gana": "BvAdi", 
+        "lakara": "la~w",
+        "prayoga": "kartari",
+        "purusha": "uttama",
+        "vacana": "eka",
+    }
+
+# --- Test Reward Correctness ---
+class TestRewardCorrectness:
+    """Test the core reward computation logic for correct, incorrect, and partially correct answers."""
+    
+    # Correct answer cases
+    FULL_REWARD_CASES = [
+        (
+            "Bhvādi dhātu -> present (Laṭ) active 3sg",
+            {
+                "dhatu": "BU",  # √भू 'to be, become'
+                "gana": "BvAdi",
+                "lakara": "la~w",
+                "prayoga": "kartari",
+                "purusha": "praTama",
+                "vacana": "eka",
+            },
+            "[[Bavati]]", # correct form (भवति)
+        ),
+        (
+            "Adādi dhātu -> perfect past (Liṭ) passive 1du",
+            {
+                "dhatu": "dA",  # √दा 'to give'
+                "gana": "adAdi",
+                "lakara": "li~w",
+                "prayoga": "karmaRi",
+                "purusha": "uttama",
+                "vacana": "dvi",
+            },
+            "[[dadivahe]]", # correct form (ददिवहे)
+        ),
+        (
+            "Juhotyādi ubhayapadī dhātu -> periphrastic future (Luṭ) active 3pl",
+            {
+                "dhatu": "pF",  # √पॄ 'to fill'
+                "gana": "juhotyAdi",
+                "lakara": "lu~w",
+                "prayoga": "kartari",
+                "purusha": "praTama",
+                "vacana": "bahu",
+            },
+            "[[parItAraH]]", # correct parasmaipada form (परीतारः)
+        )
+    ]
+    
+    @pytest.mark.parametrize("case_description,verification_info,completion", FULL_REWARD_CASES)
+    def test_full_reward_for_correct_answers(self, case_description, verification_info, completion):
+        """Test that correct Sanskrit forms receive full reward (1.0)."""
+        result = compute_sanskrit_morphology_reward(completion, verification_info)
+        assert result == 1.0, f"Failed for case: {case_description}"
+    
+    # Incorrect answer cases
+    NO_REWARD_CASES = [
+        (
+            "Divādi ubhayapadī dhātu -> simple future (Lṛṭ) active 3pl",
+            {
+                "dhatu": "jFz",  # √जॄष् 'to age'
+                "gana": "divAdi",
+                "lakara": "lf~w",
+                "prayoga": "kartari",
+                "purusha": "praTama",
+                "vacana": "bahu",
+            },
+            "[[jFzyanti]]", # incorrect form (जॄष्यन्ति); correct forms: parasmaipada jarIzyanti (जरीष्यन्ति) or ātmanepada jarizyanti (जरिष्यन्ति)
+        ),
+        (
+            "Svādi ubhayapadī dhātu -> Vedic subjunctive (Leṭ) active 3sg",
+            {
+                "dhatu": "vfY",  # √वृञ् 'to choose'
+                "gana": "svAdi",
+                "lakara": "le~w",
+                "prayoga": "kartari",
+                "purusha": "praTama",
+                "vacana": "eka",
+            },
+            "[[varaYAte]]", # incorrect form (वरञाते); correct forms: parasmaipada vfRuvAte (वृणुवाते) or ātmanepada vfRuvAti (वृणुवाति)
+        ),
+        (
+            "Tudādi dhātu -> imperative (Loṭ) active 1sg",
+            {
+                "dhatu": "RU",  # √णू 'to praise'
+                "gana": "tudAdi",
+                "lakara": "lo~w",
+                "prayoga": "kartari",
+                "purusha": "uttama",
+                "vacana": "eka",
+            },
+            "[[nUvani]]", # incorrect form (नूवनि); correct form: nuvAni (नुवानि) 
+        ),
+    ]
+    
+    @pytest.mark.parametrize("case_description,verification_info,completion", NO_REWARD_CASES)
+    def test_no_reward_for_incorrect_answers(self, case_description, verification_info, completion):
+        """Test that incorrect answers receive no reward (0.0)."""
+        result = compute_sanskrit_morphology_reward(completion, verification_info)
+        assert result == 0.0, f"Failed for case: {case_description}"
+
+    # Partially correct answer cases
+    """
+    Correct derivation of apfcyAvahi (अपृच्यावहि):
+    ===================
+    1.3.1     : pfcI~
+    1.3.2     : pfcI~
+    1.3.9     : pfc
+    3.2.111   : pfc + laN
+    1.3.3     : pfc + laN
+    1.3.9     : pfc + la
+    1.3.13    : pfc + la
+    3.4.78    : pfc + vahi
+    3.4.113   : pfc + vahi
+    3.1.67    : pfc + yak + vahi
+    1.3.3     : pfc + yak + vahi
+    1.3.9     : pfc + ya + vahi
+    3.4.114   : pfc + ya + vahi
+    1.2.4     : pfc + ya + vahi
+    1.4.13    : pfc + ya + vahi <---------- partial credit (15/22)
+    6.4.71    : aw + pfc + ya + vahi
+    1.3.3     : aw + pfc + ya + vahi
+    1.3.9     : a + pfc + ya + vahi
+    1.1.5     : a + pfc + ya + vahi
+    1.4.14    : a + pfc + ya + vahi
+    7.3.101   : a + pfc + yA + vahi
+    8.4.68    : a + pfc + yA + vahi
+    """
+    apṛcyāvahi_case = (
+        "Rudhādi dhātu -> imperfect (Laṅ) passive 1du",
+        {
+            "dhatu": "pfcI~",  # √पृच् 'to mix'
+            "gana": "ruDAdi",
+            "lakara": "la~N",
+            "prayoga": "karmaRi",
+            "purusha": "uttama",
+            "vacana": "dvi",
+        },
+        "[[pfcyavahi]]", # partially correct form (पृच्यावहि); correct form: apfcyAvahi (अपृच्यावहि)
+        0.68, # rounded to 2 decimal places
+    )
+
+    """
+    Correct derivation of kriyAstam (क्रियास्तम्):
+    ===================
+    1.3.1     : kf
+    3.3.173   : kf + li~N
+    1.3.2     : kf + li~N
+    1.3.3     : kf + li~N
+    1.3.9     : kf + l
+    1.3.78    : kf + l
+    3.4.78    : kf + Tas
+    1.3.4     : kf + Tas
+    3.4.116   : kf + Tas
+    3.4.101   : kf + tam
+    1.3.4     : kf + tam <---------- partial credit (11/23)
+    3.4.104   : kf + yAsu~w + tam
+    1.3.2     : kf + yAsu~w + tam
+    1.3.3     : kf + yAsu~w + tam
+    1.3.9     : kf + yAs + tam
+    3.4.107   : kf + yAs + stam
+    3.4.116   : kf + yAs + stam
+    1.4.13    : kf + yAs + stam
+    1.1.5     : kf + yAs + stam
+    7.4.28    : kri + yAs + stam
+    1.4.14    : kri + yAs + stam
+    8.2.29    : kri + yA + stam
+    8.4.68    : kri + yA + stam
+    """
+    kriyāstam_case = (
+        "Tanādi dhātu -> benedictive (Aśir-Liṅ) active 2du",
+        {
+            "dhatu": "kf",  # √कृ 'to do'
+            "gana": "tanAdi",
+            "lakara": "ASIrli~N",
+            "prayoga": "kartari",
+            "purusha": "maDyama",
+            "vacana": "dvi",
+        },
+        "[[kftam]]", # partially correct form (कृतम्); correct form: kriyAstam (क्रियास्तम्)
+        0.48, # rounded to 2 decimal places
+    )
+
+    """
+    Correct derivation of Baveta (भवेत):
+    ===================
+    1.3.1     : BU
+    3.3.161   : BU + li~N
+    1.3.2     : BU + li~N
+    1.3.3     : BU + li~N
+    1.3.9     : BU + l
+    1.3.78    : BU + l
+    3.4.78    : BU + Ta
+    3.4.113   : BU + Ta <---------- partial credit (8/29)
+    3.1.68    : BU + Sap + Ta
+    1.3.3     : BU + Sap + Ta
+    1.3.8     : BU + Sap + Ta
+    1.3.9     : BU + a + Ta
+    3.4.113   : BU + a + Ta
+    3.4.101   : BU + a + ta
+    3.4.103   : BU + a + yAsu~w + ta
+    1.3.2     : BU + a + yAsu~w + ta
+    1.3.3     : BU + a + yAsu~w + ta
+    1.3.9     : BU + a + yAs + ta
+    3.4.107   : BU + a + yAs + sta
+    1.2.4     : BU + a + yAs + sta
+    1.4.13    : BU + a + yAs + sta
+    7.2.79    : BU + a + yA + ta
+    7.2.80    : BU + a + iy + ta
+    6.1.66    : BU + a + i + ta
+    7.3.84    : Bo + a + i + ta
+    1.4.14    : Bo + a + i + ta
+    6.1.78    : Bav + a + i + ta
+    6.1.87    : Bav +  + e + ta
+    8.4.68    : Bav +  + e + ta
+    """
+    bhaveta_case = (
+        "Bhvādi dhātu -> optative (Vidhi-Liṅ) active 2pl",
+        {
+            "dhatu": "BU",  # √भू 'to be, become'
+            "gana": "BvAdi",
+            "lakara": "viDili~N",
+            "prayoga": "kartari",
+            "purusha": "maDyama",
+            "vacana": "bahu",
+        },
+        "[[BUTa]]", # partially correct form (भूथ); correct form: Baveta (भवेत)
+        0.28, # rounded to 2 decimal places
+    )
+
+    PARTIAL_REWARD_CASES = [apṛcyāvahi_case, kriyāstam_case, bhaveta_case]
+    
+    @pytest.mark.parametrize("case_description,verification_info,completion,expected_reward", PARTIAL_REWARD_CASES)
+    def test_partial_reward_for_partially_correct_answer(self, case_description, verification_info, completion, expected_reward):
+        """Test cases with specific expected partial scores."""
+        result = compute_sanskrit_morphology_reward(completion, verification_info)
+        rounded_result = round(result, 2)
+        assert rounded_result == expected_reward, f"Failed for case: {case_description}, expected {expected_reward}, got {result}"
+
+
+# --- Test Input Handling ---
+class TestInputHandling:
+    """Test edge cases around input formats, positions, and transliteration schemes."""
+    
+    # Answer position cases
+    ANSWER_POSITION_CASES = [
+        ("[[BavAmi]] is the correct form according to Panini.", "Answer at beginning"),
+        ("The correct form [[BavAmi]] follows these rules.", "Answer in middle"),
+        ("According to Panini, the correct form is [[BavAmi]]", "Answer at end"),
+        ("First [[wrong]] then [[BavAmi]] is correct.", "Multiple brackets - takes last"),
+    ]
+    
+    @pytest.mark.parametrize("completion,case_description", ANSWER_POSITION_CASES)
+    def test_answer_positions_within_completions(self, completion, case_description, sample_verification_info):
+        """Test that answer position within completion doesn't affect correctness."""
+        result = compute_sanskrit_morphology_reward(completion, sample_verification_info)
+        assert result == 1.0, f"Failed for case: {case_description}"
+    
+    # Answer whitespace cases
+    WHITESPACE_CASES = [
+        ("[[ BavAmi ]]", "Whitespace before and after answer", 1.0),
+        ("[[Bav Ami]]", "Whitespace within answer", 0.0),
+    ]
+    
+    @pytest.mark.parametrize("completion,case_description,expected_reward", WHITESPACE_CASES)
+    def test_answers_with_whitespaces(self, completion, case_description, expected_reward, sample_verification_info):
+        """Test that extra whitespace around answers is handled correctly."""
+        result = compute_sanskrit_morphology_reward(completion, sample_verification_info)
+        assert result == expected_reward, f"Failed for case: {case_description}"
+    
+    # Transliteration scheme test cases
+    TRANSLITERATION_CASES = [
+        ("[[BavAmi]]", "SLP1", 1.0),
+        ("[[bhavāmi]]", "IAST", 1.0),
+        ("[[bhavAmi]]", "Harvard-Kyoto", 1.0),
+        ("[[bhavaami]]", "Velthuis", 1.0),
+        ("[[भवामि]]", "Devanagari", 1.0),
+        ("[[భవామి]]", "Telugu", 1.0),
+        ("[[ଭଵାମି]]", "Odia", 1.0),
+        ("[[ભવામિ]]", "Gujarati", 1.0),
+        ("[[ภวามิ]]", "Thai", 1.0),
+        ("[[ಭವಾಮಿ]]", "Kannada", 1.0),
+        ("[[ഭവാമി]]", "Malayalam", 1.0),
+        ("[[𑖥𑖪𑖯𑖦𑖰]]", "Siddham", 1.0),
+        ("[[𑀪𑀯𑀸𑀫𑀺]]", "Brahmi", 1.0),
+        ("[[ភវាមិ]]", "Khmer", 1.0),
+        ("[[ᏥᎨᏎᏍᏗ]]", "Unsupported scheme (Cherokee)", 0.0),
+    ]
+    
+    @pytest.mark.parametrize("completion,case_description,expected_reward", TRANSLITERATION_CASES)
+    def test_answers_with_multiple_transliteration_schemes(self, completion, case_description, expected_reward, sample_verification_info):
+        """Test that different transliteration schemes are handled correctly."""
+        result = compute_sanskrit_morphology_reward(completion, sample_verification_info)
+        assert result == expected_reward, f"Failed for case: {case_description}"
+    
+    def test_very_long_completion(self, sample_verification_info):
+        """Test handling of very long completion text."""
+        long_text = "This is a very long completion. " * 100
+        completion = f"{long_text} The answer is [[BavAmi]]"
+        
+        result = compute_sanskrit_morphology_reward(completion, sample_verification_info)
+        assert result == 1.0


### PR DESCRIPTION
### Overview

Can LLMs learn Pāṇinian generativity? This PR introduces a Sanskrit morphology reward system for reinforcement learning to see if language models can master the systematic rules that generate Sanskrit surface forms - hence रूपशिक्षा (_rūpaśikṣā_): learning proper forms.

This enables evaluating models on generating correct Sanskrit words following Pāṇinian grammar rules, using the `Vidyut` library for authentic verification according to Pāṇini's Aṣṭādhyāyī.

The reward computation focuses on _tiṅantas_ (finite verb forms) as an MVP to test in an RL environment. We could eventually expand this to include other Sanskrit word forms such as _subantas_ (nominals), _kṛdantas_ (participles), and _taddhitāntas_ (secondary derivatives), which would provide a more comprehensive way to evaluate morphological competency.

### Files added
- **Task Reward Computation** (src/zeroband/inference/genesys/sanskrit_morphology.py):
    - Main reward computation function that scores LLM completions based on the _prakriyas_ (derivations) for their morphology specifications. 
    - Checks if the answer matches any of the correct _padas_ (surface forms) before checking for matches with 
intermediate derivation forms for partial credit.
    - Supports multiple transliteration schemes (SLP1, IAST, Devanagari, Telugu, etc.)
    - API: `compute_sanskrit_morphology_reward(completion: str, verification_info: Dict) -> float`
- **Dataset Generation Utility** (scripts/create_sanskrit_morphology_dataset.py):
    - Generates verification data for the RL environment.
    - Uses the Dhātupāṭha to create 200,000 unique Sanskrit morphology specifications - which is ~30% of all possible combinations without using _sanādi pratyayas_ (derivational suffixes) or _upasargas_ (prefixes). 
- **Unit Tests** (tests/unit/inference/test_sanskrit_morphology.py):
    - Full test coverage for the reward computation.
    - Tests correct forms (score = 1.0), incorrect forms (score = 0.0), and partially correct forms (0.0 < score < 1.0).
    - Validates multiple transliteration schemes and other edge cases.

### Future Improvements
- Support for _subantas_, _kṛdantas_, _taddhitāntas_, ...
- Support more verbal complexity with more morphological features (i.e. _sanādi pratyayas_ & _upasargas_)