### PR TITLE
[PRI2-588] Add number of retries for PP connection to CLI arguments

### DIFF
--- a/src/zeroband/infer.py
+++ b/src/zeroband/infer.py
@@ -70,13 +70,7 @@ def inference(config: Config):
 
     # Create communication for pipeline
     if config.pp.world_size > 1:
-        setup_pipeline(
-            llm=llm,
-            rank=config.pp.rank,
-            world_size=config.pp.world_size,
-            iroh_seed=config.pp.iroh_seed,
-            iroh_peer_id=config.pp.iroh_peer_id,
-        )
+        setup_pipeline(config=config.pp, llm=llm)
 
     # Load  dataset
     dataset = load_dataset(config.dataset, split="train")


### PR DESCRIPTION
Exposes the number of connection retries for establishing P2P connection via `prime-iroh` as a CLI argument as `--pp.connection_num_retries`.

Ticket: PRI2-588