### PR TITLE
Add task-specific reward tracking and logging

### DIFF
--- a/src/zeroband/inference/parquet.py
+++ b/src/zeroband/inference/parquet.py
@@ -32,6 +32,7 @@ def get_parquet_table(
                     "proofs": next(proof_iter) if len(output.token_ids) > 1 else b"",
                     "step": step,
                     "target_lengths": target_length,
+                    "task_type": request_rewards.task_type,
                 }
             )
 

--- a/src/zeroband/train.py
+++ b/src/zeroband/train.py
@@ -2,7 +2,6 @@ import logging
 import os
 import shutil
 import time
-from collections import defaultdict
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -300,14 +299,8 @@ def train(config: Config):
                     metric_averager.update("length_penalties", length_penalties)
                 for target_lengths in batch["target_lengths"]:
                     metric_averager.update("target_lengths", target_lengths)
-
-                task_rewards_by_type = defaultdict(list)
                 for reward, task_type in zip(batch["task_rewards"], batch["task_types"]):
-                    task_rewards_by_type[task_type].append(reward.item())
-
-                for task_type, rewards in task_rewards_by_type.items():
-                    avg_reward = sum(rewards) / len(rewards)
-                    metric_averager.update(f"{task_type}", torch.tensor(avg_reward))
+                    metric_averager.update(f"task_{task_type}", torch.tensor(reward))
 
                 # Forward
                 logits: Float[torch.Tensor, "batch seq vocab"] = model(

--- a/src/zeroband/train.py
+++ b/src/zeroband/train.py
@@ -2,6 +2,7 @@ import logging
 import os
 import shutil
 import time
+from collections import defaultdict
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -301,11 +302,9 @@ def train(config: Config):
                 # Task-specific metrics with proper grouping
                 if "task_types" in batch:
                     # Group rewards by task type
-                    task_type_rewards = {}
+                    task_type_rewards = defaultdict(list)
                     for i, task_type in enumerate(batch["task_types"]):
                         task_key = f"individual_task_{task_type}"
-                        if task_key not in task_type_rewards:
-                            task_type_rewards[task_key] = []
                         task_type_rewards[task_key].append(batch["task_rewards"][i].item())
 
                     # Update metrics with task-specific averages

--- a/src/zeroband/train.py
+++ b/src/zeroband/train.py
@@ -288,10 +288,9 @@ def train(config: Config):
 
                 loss_mask = batch["loss_mask"]
 
-                # Update all metrics consistently - one call per individual value
+                # Update general metrics
                 for rewards in batch["rewards"]:
                     metric_averager.update("sample_reward", rewards)
-
                 for seq_lens in batch["seq_lens"]:
                     metric_averager.update("seq_lens", seq_lens)
                 for length_penalties in batch["length_penalties"]:
@@ -304,7 +303,7 @@ def train(config: Config):
                     # Group rewards by task type
                     task_type_rewards = {}
                     for i, task_type in enumerate(batch["task_types"]):
-                        task_key = f"task_{task_type}"
+                        task_key = f"individual_task_{task_type}"
                         if task_key not in task_type_rewards:
                             task_type_rewards[task_key] = []
                         task_type_rewards[task_key].append(batch["task_rewards"][i].item())

--- a/src/zeroband/training/utils.py
+++ b/src/zeroband/training/utils.py
@@ -275,7 +275,7 @@ def log_to_wandb(
             if k in metrics_dict and metrics_dict[k] is not None:
                 wandb_metrics[f"{prefix}{k}"] = metrics_dict[k]
 
-    # Handle task-specific metrics based on the prefiz
+    # Handle task-specific metrics based on the prefix
     for key, value in metrics_dict.items():
         if key.startswith("task_"):
             wandb_metrics[f"task_rewards/{key}"] = value

--- a/src/zeroband/training/utils.py
+++ b/src/zeroband/training/utils.py
@@ -277,8 +277,8 @@ def log_to_wandb(
 
     # Handle task-specific metrics based on the prefix
     for key, value in metrics_dict.items():
-        if key.startswith("task_") and key != "task_reward":  # Exclude task_reward
-            wandb_metrics[f"task_rewards/{key}"] = value
+        if key.startswith("individual_task_"):
+            wandb_metrics[f"task_rewards/{key.replace('individual_task_', '')}"] = value
 
     # Log everything
     wandb.log(wandb_metrics, step=metrics_dict.get("step", step))

--- a/src/zeroband/training/utils.py
+++ b/src/zeroband/training/utils.py
@@ -275,9 +275,9 @@ def log_to_wandb(
             if k in metrics_dict and metrics_dict[k] is not None:
                 wandb_metrics[f"{prefix}{k}"] = metrics_dict[k]
 
-    # Handle task-specific metrics dynamically
+    # Handle task-specific metrics based on the prefiz
     for key, value in metrics_dict.items():
-        if key.startswith("task_") and "_reward" in key:
+        if key.startswith("task_"):
             wandb_metrics[f"task_rewards/{key}"] = value
 
     # Log everything

--- a/src/zeroband/training/utils.py
+++ b/src/zeroband/training/utils.py
@@ -277,7 +277,7 @@ def log_to_wandb(
 
     # Handle task-specific metrics based on the prefix
     for key, value in metrics_dict.items():
-        if key.startswith("task_"):
+        if key.startswith("task_") and key != "task_reward":  # Exclude task_reward
             wandb_metrics[f"task_rewards/{key}"] = value
 
     # Log everything

--- a/src/zeroband/training/utils.py
+++ b/src/zeroband/training/utils.py
@@ -266,6 +266,7 @@ def log_to_wandb(
             "time_data_loading",
             "time_packing",
         ],
+        "task_rewards/": [],
     }
 
     # Add metrics to respective groups
@@ -273,6 +274,11 @@ def log_to_wandb(
         for k in keys:
             if k in metrics_dict and metrics_dict[k] is not None:
                 wandb_metrics[f"{prefix}{k}"] = metrics_dict[k]
+
+    # Handle task-specific metrics dynamically
+    for key, value in metrics_dict.items():
+        if key.startswith("task_") and "_reward" in key:
+            wandb_metrics[f"task_rewards/{key}"] = value
 
     # Log everything
     wandb.log(wandb_metrics, step=metrics_dict.get("step", step))

--- a/src/zeroband/utils/parquet.py
+++ b/src/zeroband/utils/parquet.py
@@ -11,5 +11,6 @@ pa_schema = pa.schema(
         ("proofs", pa.binary()),
         ("step", pa.int32()),
         ("target_lengths", pa.int32()),
+        ("task_type", pa.string()),
     ]
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,6 +101,7 @@ def create_dummy_parquet_table(batch_size: int, seq_len: int) -> Table:
         "proofs": pa.array([b"I am toploc proof, handcrafted by jack"] * batch_size, type=pa.binary()),
         "step": pa.array([0] * batch_size, type=pa.int32()),
         "target_lengths": pa.array([seq_len] * batch_size, type=pa.int32()),
+        "task_type": pa.array(["test_task"] * batch_size, type=pa.string()),  # ADD THIS LINE
     }
 
     # Create table directly from dictionary

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,7 +101,7 @@ def create_dummy_parquet_table(batch_size: int, seq_len: int) -> Table:
         "proofs": pa.array([b"I am toploc proof, handcrafted by jack"] * batch_size, type=pa.binary()),
         "step": pa.array([0] * batch_size, type=pa.int32()),
         "target_lengths": pa.array([seq_len] * batch_size, type=pa.int32()),
-        "task_type": pa.array(["test_task"] * batch_size, type=pa.string()),  # ADD THIS LINE
+        "task_type": pa.array(["test_task"] * batch_size, type=pa.string()),
     }
 
     # Create table directly from dictionary

--- a/tests/unit/training/test_data.py
+++ b/tests/unit/training/test_data.py
@@ -1,106 +1,3 @@
-import random
-
-import pytest
-import torch
-from torch.utils.data import DataLoader
-
-from zeroband.training.data import (
-    FakeTokenizedDataset,
-    ParquetDataset,
-    _should_skip_index,
-    collate_fn,
-    pack_datatset_outputs_balancing,
-    pack_datatset_outputs_efficiently,
-    packed_batch,
-)
-
-
-def test_pq_dataset(fake_rollout_files_dir):
-    path = fake_rollout_files_dir(steps=[0, 1, 2, 3], num_files=4, batch_size=8)
-
-    dataset = ParquetDataset(path, 8 * 4, timeout=2, step_count_init=0, ignore_zero_advantages=False)
-
-    dataloader = DataLoader(dataset, batch_size=10, num_workers=2)
-
-    with pytest.raises(TimeoutError, match="Timeout waiting for step 4 to be created"):
-        for _ in dataloader:
-            ...
-
-
-@pytest.mark.parametrize("rank", [0, 1, 2, 3])
-@pytest.mark.parametrize("workers_id", [0, 1, 2, 3])
-def test_should_skip_index(rank, workers_id):
-    world_size = 4
-    num_workers = 4
-
-    full_index = list(range(100))
-
-    expected_results = full_index[rank::world_size][workers_id::num_workers]
-
-    results = []
-    for index in full_index:
-        # If we should not skip this index, add it to results
-        if not _should_skip_index(index, world_size, rank, num_workers, workers_id):
-            results.append(index)
-
-    assert results == expected_results
-
-
-def test_pack_datatset_outputs_efficiently():
-    BS = 16
-
-    batch = []
-
-    dataset = FakeTokenizedDataset(64, 128)
-
-    for i in range(BS):
-        batch.append(next(iter(dataset)))
-
-    packed_batch = pack_datatset_outputs_efficiently(batch, 64)
-
-    assert len(packed_batch) >= 1
-
-
-def test_pack_dataset_2():
-    BS = 16
-    SEQ_LEN = 2048
-
-    batch = []
-
-    for i in range(BS):
-        seq_len = SEQ_LEN - 1
-        input_ids = torch.randint(3, 128, (seq_len,))
-        advantages = torch.randn(seq_len)
-        batch.append(
-            {
-                "input_ids": input_ids,
-                "advantages": advantages,
-                "rewards": 0.5,
-                "loss_mask": torch.ones(seq_len).int(),
-                "logprobs": torch.randn(seq_len),
-            }
-        )
-    packed_batch = pack_datatset_outputs_efficiently(batch, max_seq_len=seq_len)
-
-    assert len(packed_batch) == BS
-
-
-def test_pack_bin_packing():
-    bin_size = 3
-    SEQ_LEN = 64
-
-    bin = []
-
-    dataset = FakeTokenizedDataset(seq_len=SEQ_LEN, vocab_size=128)
-
-    for i in range(bin_size):
-        bin.append(next(iter(dataset)))
-
-    micro_batch = collate_fn(bin, 2048, 128)
-
-    assert micro_batch["input_ids"].shape == (1, 2048)
-
-
 def test_packing_vs_padding():
     """
     Here we test that we don't lose any rewards or data when doing the different packing modes
@@ -125,6 +22,7 @@ def test_packing_vs_padding():
             "task_rewards": torch.ones(1),
             "length_penalties": torch.ones(1),
             "target_lengths": torch.ones(1),
+            "task_type": "test_task",
         }
 
         batch_rollout.append(data)
@@ -159,27 +57,3 @@ def test_packing_vs_padding():
 
     assert total_padded_tokens_packed < total_padded_tokens_padded
     assert total_padded_tokens_balancing <= total_padded_tokens_padded
-
-
-@pytest.mark.parametrize(
-    "seq_lens,packed_output",
-    [
-        [[3, 3, 3, 3, 4, 4, 4, 4, 7, 7, 8, 8, 9, 9], [[3, 3, 3, 3], [4, 4, 4, 4], [7, 7], [8, 8], [9], [9]]],
-        [[2, 2, 2, 2, 4, 4, 32], [[2, 2, 2, 2], [4, 4], [32]]],
-        [[1, 1, 1, 1, 2, 2, 2, 2, 4, 32], [[1, 1, 1, 1, 2, 2, 2, 2], [4], [32]]],
-    ],
-)
-def test_pack_datatset_outputs_balancing(seq_lens, packed_output):
-    max_seq_len = 8
-    micro_bs = 2
-
-    # batch_size = 32
-
-    samples = [{"input_ids": torch.arange(seq)} for seq in seq_lens]
-
-    micro_batches = pack_datatset_outputs_balancing(samples, max_seq_len=max_seq_len, micro_bs=micro_bs)
-
-    micro_batches_len = [[len(sample["input_ids"]) for sample in batch[0]] for batch in micro_batches]
-
-    print(micro_batches_len)
-    assert micro_batches_len == packed_output

--- a/tests/unit/training/test_data.py
+++ b/tests/unit/training/test_data.py
@@ -1,3 +1,106 @@
+import random
+
+import pytest
+import torch
+from torch.utils.data import DataLoader
+
+from zeroband.training.data import (
+    FakeTokenizedDataset,
+    ParquetDataset,
+    _should_skip_index,
+    collate_fn,
+    pack_datatset_outputs_balancing,
+    pack_datatset_outputs_efficiently,
+    packed_batch,
+)
+
+
+def test_pq_dataset(fake_rollout_files_dir):
+    path = fake_rollout_files_dir(steps=[0, 1, 2, 3], num_files=4, batch_size=8)
+
+    dataset = ParquetDataset(path, 8 * 4, timeout=2, step_count_init=0, ignore_zero_advantages=False)
+
+    dataloader = DataLoader(dataset, batch_size=10, num_workers=2)
+
+    with pytest.raises(TimeoutError, match="Timeout waiting for step 4 to be created"):
+        for _ in dataloader:
+            ...
+
+
+@pytest.mark.parametrize("rank", [0, 1, 2, 3])
+@pytest.mark.parametrize("workers_id", [0, 1, 2, 3])
+def test_should_skip_index(rank, workers_id):
+    world_size = 4
+    num_workers = 4
+
+    full_index = list(range(100))
+
+    expected_results = full_index[rank::world_size][workers_id::num_workers]
+
+    results = []
+    for index in full_index:
+        # If we should not skip this index, add it to results
+        if not _should_skip_index(index, world_size, rank, num_workers, workers_id):
+            results.append(index)
+
+    assert results == expected_results
+
+
+def test_pack_datatset_outputs_efficiently():
+    BS = 16
+
+    batch = []
+
+    dataset = FakeTokenizedDataset(64, 128)
+
+    for i in range(BS):
+        batch.append(next(iter(dataset)))
+
+    packed_batch = pack_datatset_outputs_efficiently(batch, 64)
+
+    assert len(packed_batch) >= 1
+
+
+def test_pack_dataset_2():
+    BS = 16
+    SEQ_LEN = 2048
+
+    batch = []
+
+    for i in range(BS):
+        seq_len = SEQ_LEN - 1
+        input_ids = torch.randint(3, 128, (seq_len,))
+        advantages = torch.randn(seq_len)
+        batch.append(
+            {
+                "input_ids": input_ids,
+                "advantages": advantages,
+                "rewards": 0.5,
+                "loss_mask": torch.ones(seq_len).int(),
+                "logprobs": torch.randn(seq_len),
+            }
+        )
+    packed_batch = pack_datatset_outputs_efficiently(batch, max_seq_len=seq_len)
+
+    assert len(packed_batch) == BS
+
+
+def test_pack_bin_packing():
+    bin_size = 3
+    SEQ_LEN = 64
+
+    bin = []
+
+    dataset = FakeTokenizedDataset(seq_len=SEQ_LEN, vocab_size=128)
+
+    for i in range(bin_size):
+        bin.append(next(iter(dataset)))
+
+    micro_batch = collate_fn(bin, 2048, 128)
+
+    assert micro_batch["input_ids"].shape == (1, 2048)
+
+
 def test_packing_vs_padding():
     """
     Here we test that we don't lose any rewards or data when doing the different packing modes
@@ -57,3 +160,27 @@ def test_packing_vs_padding():
 
     assert total_padded_tokens_packed < total_padded_tokens_padded
     assert total_padded_tokens_balancing <= total_padded_tokens_padded
+
+
+@pytest.mark.parametrize(
+    "seq_lens,packed_output",
+    [
+        [[3, 3, 3, 3, 4, 4, 4, 4, 7, 7, 8, 8, 9, 9], [[3, 3, 3, 3], [4, 4, 4, 4], [7, 7], [8, 8], [9], [9]]],
+        [[2, 2, 2, 2, 4, 4, 32], [[2, 2, 2, 2], [4, 4], [32]]],
+        [[1, 1, 1, 1, 2, 2, 2, 2, 4, 32], [[1, 1, 1, 1, 2, 2, 2, 2], [4], [32]]],
+    ],
+)
+def test_pack_datatset_outputs_balancing(seq_lens, packed_output):
+    max_seq_len = 8
+    micro_bs = 2
+
+    # batch_size = 32
+
+    samples = [{"input_ids": torch.arange(seq)} for seq in seq_lens]
+
+    micro_batches = pack_datatset_outputs_balancing(samples, max_seq_len=max_seq_len, micro_bs=micro_bs)
+
+    micro_batches_len = [[len(sample["input_ids"]) for sample in batch[0]] for batch in micro_batches]
+
+    print(micro_batches_len)
+    assert micro_batches_len == packed_output


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a44afa8d-12ef-409d-8001-8403ec7cc2ed)

Individually logs rewards by task type under `task_rewards` on wandb, and changes the parquet data structure to make this information easily accessible within the trainer.