### PR TITLE
[fix] dont norm intermediate toploc proofs

### DIFF
--- a/src/zeroband/infer.py
+++ b/src/zeroband/infer.py
@@ -131,6 +131,7 @@ def inference(config: Config):
     hidden_size = llm.llm_engine.model_executor.driver_worker.model_runner.model.config.hidden_size
     toploc_cache, _ = setup_toploc_cache(
         llm,
+        pipeline_config=config.pp,
         disable=not config.toploc,
         max_seqs=batch_size,
         hidden_size=hidden_size,

--- a/src/zeroband/inference/toploc.py
+++ b/src/zeroband/inference/toploc.py
@@ -197,7 +197,7 @@ def setup_toploc_cache(
     if not disable:
         handle = logits_processor.register_forward_pre_hook(partial(toploc_cache_hook, toploc_cache=toploc_cache))
 
-    if pipeline_config is not None and pipeline_config.world_size > 1 and pipeline_config.rank < pipeline_config.world_size - 1:
+    if pipeline_config is not None and pipeline_config.pipeline_enabled and pipeline_config.rank < pipeline_config.world_size - 1:
         llm.llm_engine.model_executor.driver_worker.model_runner.model.model.norm = ArgsIdentity()
 
     return toploc_cache, handle

--- a/src/zeroband/inference/toploc.py
+++ b/src/zeroband/inference/toploc.py
@@ -9,6 +9,16 @@ from vllm import LLM
 from vllm.model_executor import SamplingMetadata
 from vllm.model_executor.layers.logits_processor import _prune_hidden_states
 
+from zeroband.inference.pipeline import PipelineConfig
+
+
+class ArgsIdentity(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, *args):
+        return args
+
 
 class TopLocCache:
     """A cache implementation for managing sequence data and generating proofs.
@@ -174,7 +184,9 @@ def toploc_cache_hook(_, inputs: tuple, toploc_cache: TopLocCache):
     toploc_cache.add(seq_ids, hidden_states)
 
 
-def setup_toploc_cache(llm: LLM, disable: bool = False, **toploc_kwargs) -> tuple[TopLocCache, RemovableHandle | None]:
+def setup_toploc_cache(
+    llm: LLM, pipeline_config: PipelineConfig, disable: bool = False, **toploc_kwargs
+) -> tuple[TopLocCache, RemovableHandle | None]:
     """Initializes the TOPLOC cache and register a hook to dynamically populate the cache during inference"""
     # Initialize the cache
     toploc_cache = TopLocCache(disable=disable, **toploc_kwargs)
@@ -184,5 +196,8 @@ def setup_toploc_cache(llm: LLM, disable: bool = False, **toploc_kwargs) -> tupl
     handle: RemovableHandle | None = None
     if not disable:
         handle = logits_processor.register_forward_pre_hook(partial(toploc_cache_hook, toploc_cache=toploc_cache))
+
+    if pipeline_config.world_size > 1 and pipeline_config.rank < pipeline_config.world_size - 1:
+        llm.llm_engine.model_executor.driver_worker.model_runner.model.model.norm = ArgsIdentity()
 
     return toploc_cache, handle

--- a/src/zeroband/inference/toploc.py
+++ b/src/zeroband/inference/toploc.py
@@ -185,7 +185,7 @@ def toploc_cache_hook(_, inputs: tuple, toploc_cache: TopLocCache):
 
 
 def setup_toploc_cache(
-    llm: LLM, pipeline_config: PipelineConfig | None = None, disable: bool = False, **toploc_kwargs
+    llm: LLM, pipeline_config: PipelineConfig, disable: bool = False, **toploc_kwargs
 ) -> tuple[TopLocCache, RemovableHandle | None]:
     """Initializes the TOPLOC cache and register a hook to dynamically populate the cache during inference"""
     # Initialize the cache
@@ -197,7 +197,7 @@ def setup_toploc_cache(
     if not disable:
         handle = logits_processor.register_forward_pre_hook(partial(toploc_cache_hook, toploc_cache=toploc_cache))
 
-    if pipeline_config is not None and pipeline_config.pipeline_enabled and pipeline_config.rank < pipeline_config.world_size - 1:
+    if pipeline_config.pipeline_enabled and pipeline_config.rank < pipeline_config.world_size - 1:
         llm.llm_engine.model_executor.driver_worker.model_runner.model.model.norm = ArgsIdentity()
 
     return toploc_cache, handle

--- a/src/zeroband/inference/toploc.py
+++ b/src/zeroband/inference/toploc.py
@@ -185,7 +185,7 @@ def toploc_cache_hook(_, inputs: tuple, toploc_cache: TopLocCache):
 
 
 def setup_toploc_cache(
-    llm: LLM, pipeline_config: PipelineConfig, disable: bool = False, **toploc_kwargs
+    llm: LLM, pipeline_config: PipelineConfig | None = None, disable: bool = False, **toploc_kwargs
 ) -> tuple[TopLocCache, RemovableHandle | None]:
     """Initializes the TOPLOC cache and register a hook to dynamically populate the cache during inference"""
     # Initialize the cache
@@ -197,7 +197,7 @@ def setup_toploc_cache(
     if not disable:
         handle = logits_processor.register_forward_pre_hook(partial(toploc_cache_hook, toploc_cache=toploc_cache))
 
-    if pipeline_config.world_size > 1 and pipeline_config.rank < pipeline_config.world_size - 1:
+    if pipeline_config is not None and pipeline_config.world_size > 1 and pipeline_config.rank < pipeline_config.world_size - 1:
         llm.llm_engine.model_executor.driver_worker.model_runner.model.model.norm = ArgsIdentity()
 
     return toploc_cache, handle

--- a/tests/unit/inference/test_toploc.py
+++ b/tests/unit/inference/test_toploc.py
@@ -3,6 +3,7 @@ import torch
 from toploc import verify_proofs_bytes
 from vllm import SamplingParams, TokensPrompt
 
+from zeroband.inference.pipeline import PipelineConfig
 from zeroband.inference.toploc import TopLocCache, setup_toploc_cache
 
 BYTES_PER_PROOF = 258
@@ -93,7 +94,9 @@ def test_toploc_with_hook(llm, max_seqs: int, num_output_tokens: int):
     model = llm.llm_engine.model_executor.driver_worker.model_runner.model
     hidden_size = model.config.hidden_size
     max_len = 32
-    toploc_cache, hook_handle = setup_toploc_cache(llm, max_seqs=max_seqs, hidden_size=hidden_size, max_len=max_len)
+    toploc_cache, hook_handle = setup_toploc_cache(
+        llm, pipeline_config=PipelineConfig(world_size=1), max_seqs=max_seqs, hidden_size=hidden_size, max_len=max_len
+    )
     assert toploc_cache.disable is False
     assert toploc_cache.proofs == {}
 

--- a/tests/unit/inference/test_toploc.py
+++ b/tests/unit/inference/test_toploc.py
@@ -100,7 +100,7 @@ def test_toploc_with_hook(llm, max_seqs: int, num_output_tokens: int):
     # Generate sequences
     prompts = ["My name is"] * max_seqs
     sampling_params = SamplingParams(min_tokens=num_output_tokens, max_tokens=num_output_tokens, seed=69, temperature=0.0)
-    generations = llm.generate(prompts, sampling_params=sampling_params)
+    generations = llm.generate(prompts, sampling_params=sampling_params, use_tqdm=False)
 
     # Generate proofs for all sequences
     toploc_cache.maybe_generate_proofs_in_background(force_generate=True)
@@ -127,7 +127,7 @@ def test_toploc_with_hook(llm, max_seqs: int, num_output_tokens: int):
         output_tokens = list(generation.outputs[0].token_ids)
 
         token_input = TokensPrompt(prompt_token_ids=prompt_tokens + output_tokens)
-        llm.generate(token_input, sampling_params=SamplingParams(max_tokens=1))
+        llm.generate(token_input, sampling_params=SamplingParams(max_tokens=1), use_tqdm=False)
 
         # Only grab non-prompt tokens (exclude BOS)
         decode_activations = torch.concat(full_activations, dim=0)[len(prompt_tokens) :]


### PR DESCRIPTION
replace norm with identity in earlier pp stages so that the proofs are generated with the unnormed hidden activations which can be easily saved by the toploc-validator validation engine in the fwd prefill 