### PR TITLE
Add prompts and completions to output parquet

### DIFF
--- a/src/zeroband/infer.py
+++ b/src/zeroband/infer.py
@@ -220,12 +220,12 @@ def inference(config: Config):
         for target_length, verification_info in zip(target_lengths, verification_infos):
             verification_info["target_length"] = target_length
 
-        prompts = format_prompts(
+        formatted_prompts = format_prompts(
             prompts, target_lengths, config.rewards.len_reward, tokenizer=tokenizer, enable_thinking=config.enable_thinking
         )
 
         start_time = time.time()
-        request_outputs = llm.generate(prompts, sampling_params, use_tqdm=False)
+        request_outputs = llm.generate(formatted_prompts, sampling_params, use_tqdm=False)
         end_time = time.time()
 
         # Dropping like this isn't ideal. But in practice, we shouldn't have any prompts that are too long.
@@ -299,6 +299,7 @@ def inference(config: Config):
         table = get_parquet_table(
             request_outputs,
             request_rewards,
+            prompts,
             proofs,
             ckpt_step,
             target_lengths,

--- a/src/zeroband/inference/parquet.py
+++ b/src/zeroband/inference/parquet.py
@@ -8,6 +8,7 @@ from zeroband.utils.parquet import pa_schema
 def get_parquet_table(
     request_outputs: list[RequestOutput],
     request_rewards: list[RequestRewards],
+    prompts: list[str],
     proofs: list[bytes],
     step: int,
     target_lengths: list[int],
@@ -17,7 +18,7 @@ def get_parquet_table(
 
     # Create flattened list of records for PyArrow table
     records = []
-    for request_output, request_rewards, target_length in zip(request_outputs, request_rewards, target_lengths):
+    for request_output, request_rewards, prompt, target_length in zip(request_outputs, request_rewards, prompts, target_lengths):
         assert request_output.request_id == request_rewards.request_id
         for output, reward in zip(request_output.outputs, request_rewards.rewards):
             assert output.index == reward.completion_id
@@ -25,7 +26,7 @@ def get_parquet_table(
                 {
                     "input_tokens": request_output.prompt_token_ids,
                     "output_tokens": output.token_ids,
-                    "prompt": request_output.prompt,
+                    "prompt": prompt,
                     "completion": output.text,
                     "advantages": reward.advantage,
                     "rewards": reward.reward,

--- a/src/zeroband/inference/parquet.py
+++ b/src/zeroband/inference/parquet.py
@@ -25,6 +25,8 @@ def get_parquet_table(
                 {
                     "input_tokens": request_output.prompt_token_ids,
                     "output_tokens": output.token_ids,
+                    "prompt": request_output.prompt,
+                    "completion": output.text,
                     "advantages": reward.advantage,
                     "rewards": reward.reward,
                     "task_rewards": reward.task_reward,

--- a/src/zeroband/utils/parquet.py
+++ b/src/zeroband/utils/parquet.py
@@ -4,6 +4,8 @@ pa_schema = pa.schema(
     [
         ("input_tokens", pa.list_(pa.int32())),
         ("output_tokens", pa.list_(pa.int32())),
+        ("prompt", pa.string()),
+        ("completion", pa.string()),
         ("advantages", pa.float32()),
         ("rewards", pa.float32()),
         ("task_rewards", pa.float32()),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,6 +94,8 @@ def create_dummy_parquet_table(batch_size: int, seq_len: int) -> Table:
     data = {
         "input_tokens": pa.array([[1] * seq_len for _ in range(batch_size)], type=pa.list_(pa.int32())),
         "output_tokens": pa.array([[1] * seq_len for _ in range(batch_size)], type=pa.list_(pa.int32())),
+        "prompt": pa.array(["prompt" for _ in range(batch_size)], type=pa.string()),
+        "completion": pa.array(["completion" for _ in range(batch_size)], type=pa.string()),
         "advantages": pa.array([1] * batch_size, type=pa.float32()),
         "rewards": pa.array([1] * batch_size, type=pa.float32()),
         "task_rewards": pa.array([0] * batch_size, type=pa.float32()),


### PR DESCRIPTION
Adds fields `prompt` (`str`) and `completion` (`str`) to the output parquet written by the output worker. Uses the `prompt` before formatting (e.g. adding "thinking budget" information, applying chat template, etc.). Convenience feature to display generated samples on the dashboard without requiring a tokenizer.

*Note: This require `toploc-validator` to check for a match between `input_tokens` and `prompt` as well as `output_tokens` and `completion`.*

Based on PR #346, which should be merged before.