### PR TITLE
Pre-download model weights

### DIFF
--- a/src/zeroband/infer.py
+++ b/src/zeroband/infer.py
@@ -19,6 +19,7 @@ from datasets import load_dataset
 from pydantic_config import parse_argv
 from toploc.utils import sha256sum
 from vllm import LLM, SamplingParams, TokensPrompt
+from huggingface_hub import snapshot_download
 
 from zeroband.inference.config import Config
 from zeroband.inference.parquet import get_parquet_table
@@ -53,6 +54,12 @@ def inference(config: Config):
     if config.clean_output_path and config.output_path is not None:
         logger.info(f"Cleaning output path {config.output_path}")
         shutil.rmtree(config.output_path, ignore_errors=True)
+
+    # Pre-download the model weights
+    logger.info(f"Downloading model weights for {config.model_name}")
+    start_time = time.time()
+    snapshot_download(config.model_name)
+    logger.info(f"Downloaded model weights in {time.time() - start_time:.2f}s")
 
     # Initialize metrics
     monitor = setup_monitor(config.monitor)

--- a/src/zeroband/inference/envs.py
+++ b/src/zeroband/inference/envs.py
@@ -12,6 +12,10 @@ if TYPE_CHECKING:
     VLLM_USE_V1: str
     VLLM_CONFIGURE_LOGGING: str
 
+    # HF
+    HF_HUB_CACHE: str
+    HF_HUB_DISABLE_PROGRESS_BARS: str
+
     # Rust
     RUST_LOG: str
 
@@ -22,9 +26,11 @@ if TYPE_CHECKING:
 _INFERENCE_ENV_PARSERS = {
     "VLLM_USE_V1": str,
     "VLLM_CONFIGURE_LOGGING": str,
+    "HF_HUB_CACHE": str,
+    "HF_HUB_DISABLE_PROGRESS_BARS": str,
+    "RUST_LOG": str,
     "SHARDCAST_SERVERS": lambda x: x.split(","),
     "SHARDCAST_BACKLOG_VERSION": int,
-    "RUST_LOG": str,
     **_BASE_ENV_PARSERS,
 }
 
@@ -33,6 +39,7 @@ _INFERENCE_ENV_DEFAULTS = {
     "VLLM_CONFIGURE_LOGGING": "0",  # Disable vLLM logging unless explicitly enabled
     "VLLM_USE_V1": "0",  # Use v0 engine (TOPLOC and PP do not support v1 yet)
     "RUST_LOG": "off",  # Disable Rust logs (from prime-iroh)
+    "HF_HUB_DISABLE_PROGRESS_BARS": "1",  # Disable HF progress bars
 }
 
 set_defaults(_INFERENCE_ENV_DEFAULTS)


### PR DESCRIPTION
We download model weights from the main process to not rely on vLLM's internal model weights download, which in production has hung a couple of times when downloading large models while using tensor paralelism. Also makes the HF environment variables `HF_HUB_CACHE` and `HF_HUB_DISABLE_PROGRESS_BARS` more visible by adding them to the inference envs, and disables progress bars by default.

*At some point we should move this before splitting into the DP subprocesses, but that should be part of a general DP refactor so will keep like this for now.*