### PR TITLE
Add cgroup-tools

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,8 +20,8 @@ main() {
     log_info "Updating apt..."
     sudo apt update
 
-    log_info "Installing git, tmux, htop, nvtop, cmake, python3-dev..."
-    sudo apt install git tmux htop nvtop cmake python3-dev -y
+    log_info "Installing git, tmux, htop, nvtop, cmake, python3-dev, cgroup-tools..."
+    sudo apt install git tmux htop nvtop cmake python3-dev cgroup-tools -y
 
     log_info "Cloning repository..."
     git clone git@github.com:PrimeIntellect-ai/prime-rl.git


### PR DESCRIPTION
I exposed the resource limits in the code sandbox (Codeforces evals care about this, answers must not use more than a certain amount of cpu time or memory). On a whim I decided to write tests, only to find that said resource limits don't actually work. They've never worked. Fun.

This is likely because SandboxFusion was written with cgroups v1, but modern linux comes with cgroups v2, which works completely differently. So I'm writing a cgroups v2 implementation, and detecting which one to use.

But v2 also requires external libraries/commands to interact with the kernel. So to get the code sandbox to work locally, you may have to `sudo apt install cgroup-tools`. Hence the change.