### PR TITLE
Implement elastic reasoning

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ uv run python src/zeroband/infer.py @ configs/inference/simple_math.toml --paral
 ```bash
 # Start trainer
 ulimit -n 4096
-export CUDA_VISIBLE_DEVICES=1
 uv  run torchrun src/zeroband/train.py @ configs/training/simple_math.toml
 ```
 
@@ -85,23 +84,22 @@ If you have 4 GPUs, run the following commands:
 
 ```bash
 # Start inference workers
-export CUDA_VISIBLE_DEVICES=0,1
+export CUDA_VISIBLE_DEVICES=1,2,3
 export VLLM_WORKER_MULTIPROC_METHOD=spawn
-uv run python src/zeroband/infer.py @ configs/inference/simple_math.toml --parallel.dp 2 --max-batch-size 256
+uv run python src/zeroband/infer.py @ configs/inference/simple_math.toml --parallel.dp 2 --max-batch-size 192
 ```
 
 ```bash
 # Start trainer
 ulimit -n 4096
-export CUDA_VISIBLE_DEVICES=2
-uv  run torchrun src/zeroband/train.py @ configs/training/simple_math.toml
+uv run torchrun src/zeroband/train.py @ configs/training/simple_math.toml
 ```
 
 If you have 8 GPUs, run the following commands:
 
 ```bash
 # Start inference workers
-export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5
+export CUDA_VISIBLE_DEVICES=2,3,4,5,6,7
 export VLLM_WORKER_MULTIPROC_METHOD=spawn
 uv run python src/zeroband/infer.py @ configs/inference/simple_math.toml
 ```
@@ -109,7 +107,7 @@ uv run python src/zeroband/infer.py @ configs/inference/simple_math.toml
 ```bash
 # Start trainer
 ulimit -n 4096
-export CUDA_VISIBLE_DEVICES=6,7
+export CUDA_VISIBLE_DEVICES=0,1
 uv  run torchrun --nproc_per_node=2 src/zeroband/train.py @ configs/training/simple_math.toml --data.num_workers 2
 ```
 

--- a/src/zeroband/infer.py
+++ b/src/zeroband/infer.py
@@ -137,7 +137,7 @@ def inference(config: InferenceConfig):
     # Setup elastic reasoning
     # Note: This hook has to be set up before the PP communication hooks to ensure that possibly modified sampler outputs are propagated to group peers
     if config.sampling.elastic_reasoning_enabled:
-        setup_elastic_reasoning(config.sampling, llm=llm)
+        setup_elastic_reasoning(config.sampling, llm)
 
     # Setup pipeline parallel communication and hook
     node = setup_comm(config.parallel.pp)

--- a/src/zeroband/infer.py
+++ b/src/zeroband/infer.py
@@ -136,7 +136,8 @@ def inference(config: InferenceConfig):
 
     # Setup elastic reasoning
     # Note: This hook has to be set up before the PP communication hooks to ensure that possibly modified sampler outputs are propagated to group peers
-    setup_elastic_reasoning(config.elastic_reasoning, llm=llm)
+    if config.sampling.elastic_reasoning_enabled:
+        setup_elastic_reasoning(config.sampling, llm=llm)
 
     # Setup pipeline parallel communication and hook
     node = setup_comm(config.parallel.pp)

--- a/src/zeroband/infer.py
+++ b/src/zeroband/infer.py
@@ -26,6 +26,7 @@ from zeroband.inference.pipeline import all_reduce, patch_model_load, setup_comm
 from zeroband.inference.rewards import compute_vllm_rewards
 from zeroband.inference.toploc import setup_toploc_cache
 from zeroband.inference.toploc2 import Toploc2Sampler
+from zeroband.inference.elastic_reasoning import setup_elastic_reasoning
 from zeroband.utils.monitor import setup_monitor
 from zeroband.inference.utils import (
     filter_data_by_prompt_length,
@@ -132,6 +133,10 @@ def inference(config: InferenceConfig):
     # Initialize sampling parameters
     logger.info(f"Initializing sampling parameters ({config.sampling})")
     sampling_params = SamplingParams(**config.sampling.model_dump())
+
+    # Setup elastic reasoning
+    # Note: This hook has to be set up before the PP communication hooks to ensure that possibly modified sampler outputs are propagated to group peers
+    setup_elastic_reasoning(config.elastic_reasoning, llm=llm)
 
     # Setup pipeline parallel communication and hook
     node = setup_comm(config.parallel.pp)

--- a/src/zeroband/infer.py
+++ b/src/zeroband/infer.py
@@ -312,6 +312,11 @@ def inference(config: InferenceConfig):
         total_samples += batch_samples
         logger.success(f"Generated {batch_samples} samples for {batch_problems} problems in {end_time - start_time:.2f}s")
 
+        # Give a warning about sequences that did not terminate
+        batch_unterminated_samples = sum(sum(1 for output in req.outputs if output.finish_reason != "stop") for req in request_outputs)
+        if batch_unterminated_samples > 0:
+            logger.warning(f"{batch_unterminated_samples}/{batch_samples} samples did not terminate.")
+
         # Print example
         first_prompt = tokenizer.decode(request_outputs[0].prompt_token_ids)
         first_completion = tokenizer.decode(request_outputs[0].outputs[0].token_ids)

--- a/src/zeroband/inference/config.py
+++ b/src/zeroband/inference/config.py
@@ -341,6 +341,7 @@ class RLConfig(BaseConfig):
         int,
         Field(
             default=2,
+            ge=0,
             description="Maximum number of steps that inference can be ahead of training.",
         ),
     ]

--- a/src/zeroband/inference/config.py
+++ b/src/zeroband/inference/config.py
@@ -503,10 +503,3 @@ class Config(BaseSettings):
         if self.model.dtype == "float32":
             self.toploc.enable_toploc1 = False
         return self
-
-    @model_validator(mode="after")
-    def adjust_token_budget(self):
-        # If elastic reasoning is enabled, we overwrite the maximum tokens to sample to be the sum of the thinking and solution budget
-        if self.elastic_reasoning.enable:
-            self.sampling.max_tokens = self.elastic_reasoning.think_budget + self.elastic_reasoning.solution_budget
-        return self

--- a/src/zeroband/inference/config.py
+++ b/src/zeroband/inference/config.py
@@ -107,13 +107,6 @@ class SamplingConfig(BaseConfig):
         """Whether elastic reasoning is enabled."""
         return self.max_solution_tokens is not None
 
-    @property
-    def max_think_tokens(self) -> int:
-        """The number of tokens the model is allowed to think for."""
-        if self.max_solution_tokens is None:
-            return self.max_tokens
-        return self.max_tokens - self.max_solution_tokens
-
 
 class PipelineParallelConfig(BaseConfig):
     """Configures pipeline parallel inference."""

--- a/src/zeroband/inference/config.py
+++ b/src/zeroband/inference/config.py
@@ -403,22 +403,6 @@ class Config(BaseSettings):
     # The RL configuration. If None, inference will run in a non-RL setting.
     rl: Annotated[RLConfig | None, Field(default=RLConfig())]
 
-    toploc: Annotated[
-        bool,
-        Field(
-            default=False,
-            description="Whether to produce TOPLOC proofs for the inference outputs.",
-        ),
-    ]
-
-    toploc2: Annotated[
-        bool,
-        Field(
-            default=True,
-            description="Whether to use the TOPLOC2 Sampler",
-        ),
-    ]
-
     max_batch_size: Annotated[
         int | Literal["auto"],
         Field(

--- a/src/zeroband/inference/config.py
+++ b/src/zeroband/inference/config.py
@@ -403,6 +403,9 @@ class Config(BaseSettings):
     # The RL configuration. If None, inference will run in a non-RL setting.
     rl: Annotated[RLConfig | None, Field(default=RLConfig())]
 
+    # The TOPLOC configuration
+    toploc: Annotated[TopLocConfig, Field(default=TopLocConfig())]
+
     max_batch_size: Annotated[
         int | Literal["auto"],
         Field(

--- a/src/zeroband/inference/elastic_reasoning.py
+++ b/src/zeroband/inference/elastic_reasoning.py
@@ -1,3 +1,4 @@
+import math
 from functools import partial
 
 import torch.nn as nn
@@ -8,7 +9,9 @@ from zeroband.inference.config import SamplingConfig
 from zeroband.utils.logger import get_logger
 
 
-def swap_think_token(_, __, kwargs, outputs, config: SamplingConfig, stop_think_token_id: int) -> SamplerOutput | None:
+def swap_think_token(
+    _, __, kwargs, outputs, sampling_config: SamplingConfig, max_model_len: int, stop_think_token_id: int
+) -> SamplerOutput | None:
     """
     A post-hook that swaps the last sampled token with the stop_think_token_id
     if the thinking budget is exceeded.
@@ -31,10 +34,12 @@ def swap_think_token(_, __, kwargs, outputs, config: SamplingConfig, stop_think_
     if sampling_metadata:
         for seq_group, seq_outputs in zip(sampling_metadata.seq_groups, sampling_output.outputs):
             for seq_id, seq_data, seq_output in zip(seq_group.seq_data.keys(), seq_group.seq_data.values(), seq_outputs.samples):
+                max_output_tokens = min(sampling_config.max_tokens or math.inf, max_model_len - len(seq_data.prompt_token_ids))
                 num_output_tokens = len(seq_data.output_token_ids) + 1  # Increment by 1 because the current token is not yet in the output
-                if num_output_tokens == config.max_think_tokens:
+                num_think_tokens = max_output_tokens - sampling_config.max_solution_tokens
+                if num_output_tokens == num_think_tokens:
                     get_logger("INFER").debug(
-                        f"Thinking budget reached for sequence {seq_id} after {num_output_tokens} tokens. Replacing sampled token {seq_output.output_token} with {stop_think_token_id}"
+                        f"Thinking budget reached for sequence {seq_id} after {num_think_tokens} tokens. Replacing sampled token {seq_output.output_token} with {stop_think_token_id}"
                     )
                     seq_output.logprobs = {stop_think_token_id: seq_output.logprobs[seq_output.output_token]}
                     seq_output.output_token = stop_think_token_id
@@ -42,7 +47,7 @@ def swap_think_token(_, __, kwargs, outputs, config: SamplingConfig, stop_think_
     return sampling_output
 
 
-def setup_elastic_reasoning(config: SamplingConfig, llm: LLM) -> None:
+def setup_elastic_reasoning(sampling_config: SamplingConfig, llm: LLM) -> None:
     """
     Sets up elastic reasoning by registering a post-hook on the sampler to swap
     the last sampled token with the stop_think_token_id if the thinking budget
@@ -52,8 +57,10 @@ def setup_elastic_reasoning(config: SamplingConfig, llm: LLM) -> None:
         config: The sampling configuration.
         llm: The LLM model.
     """
-    assert config.max_think_tokens is not None, "`max_think_tokens` must be set for elastic reasoning"
-    get_logger("INFER").info(f"Enabling elastic reasoning with max_think_tokens={config.max_think_tokens} (max_tokens={config.max_tokens})")
+    assert sampling_config.max_solution_tokens is not None, "`max_solution_tokens` must be set for elastic reasoning"
+    get_logger("INFER").info(
+        f"Enabling elastic reasoning with max_solution_tokens={sampling_config.max_solution_tokens} (max_tokens={sampling_config.max_tokens})"
+    )
 
     # Dynamically get the token ID of the `</think>` token from model's tokenizer
     tokenizer = llm.get_tokenizer()
@@ -62,6 +69,10 @@ def setup_elastic_reasoning(config: SamplingConfig, llm: LLM) -> None:
 
     # Register the post-hook on the sampler
     sampler: nn.Module = llm.llm_engine.model_executor.driver_worker.model_runner.sampler
-    sampler.register_forward_hook(partial(swap_think_token, config=config, stop_think_token_id=stop_think_token_id), with_kwargs=True)
+    max_model_len = llm.llm_engine.model_config.max_model_len
+    sampler.register_forward_hook(
+        partial(swap_think_token, sampling_config=sampling_config, max_model_len=max_model_len, stop_think_token_id=stop_think_token_id),
+        with_kwargs=True,
+    )
 
     get_logger("INFER").debug("Set up post-hook swap_think_token on sampler")

--- a/src/zeroband/inference/elastic_reasoning.py
+++ b/src/zeroband/inference/elastic_reasoning.py
@@ -65,7 +65,9 @@ def setup_elastic_reasoning(sampling_config: SamplingConfig, llm: LLM) -> None:
     # Dynamically get the token ID of the `</think>` token from model's tokenizer
     tokenizer = llm.get_tokenizer()
     stop_think_token_id = tokenizer.convert_tokens_to_ids("</think>")
-    assert type(stop_think_token_id) == int, "`</think>` token must be a single token"
+    assert type(stop_think_token_id) == int, (
+        f"`</think>` token must be a single token, but has type {type(stop_think_token_id)} ({stop_think_token_id})"
+    )
 
     # Register the post-hook on the sampler
     sampler: nn.Module = llm.llm_engine.model_executor.driver_worker.model_runner.sampler

--- a/src/zeroband/inference/elastic_reasoning.py
+++ b/src/zeroband/inference/elastic_reasoning.py
@@ -64,10 +64,12 @@ def setup_elastic_reasoning(sampling_config: SamplingConfig, llm: LLM) -> None:
 
     # Dynamically get the token ID of the `</think>` token from model's tokenizer
     tokenizer = llm.get_tokenizer()
+    model_name = llm.llm_engine.model_config.model
     stop_think_token_id = tokenizer.convert_tokens_to_ids("</think>")
-    assert type(stop_think_token_id) == int, (
-        f"`</think>` token must be a single token, but has type {type(stop_think_token_id)} ({stop_think_token_id})"
-    )
+    if stop_think_token_id is None:
+        raise ValueError(
+            f"`</think>` token not found in tokenizer for {model_name}, so we cannot support elastic reasoning. Try running without elastic reasoning by setting `--sampling.max-solution-tokens=None`."
+        )
 
     # Register the post-hook on the sampler
     sampler: nn.Module = llm.llm_engine.model_executor.driver_worker.model_runner.sampler

--- a/src/zeroband/inference/elastic_reasoning.py
+++ b/src/zeroband/inference/elastic_reasoning.py
@@ -6,6 +6,7 @@ from vllm import LLM
 from vllm.model_executor.layers.sampler import SamplerOutput, SamplingMetadata
 
 from zeroband.inference.config import SamplingConfig
+from zeroband.inference.mask import get_mask_cache
 from zeroband.utils.logger import get_logger
 
 
@@ -22,6 +23,7 @@ def swap_think_token(
         kwargs: The named arguments to the module
         outputs: The outputs of the module
         config: The sampling configuration.
+        max_model_len: The maximum length of the model.
         stop_think_token_id: The token ID of the `</think>` token.
 
     Returns:
@@ -44,6 +46,7 @@ def swap_think_token(
                     )
                     seq_output.logprobs = {stop_think_token_id: seq_output.logprobs[seq_output.output_token]}
                     seq_output.output_token = stop_think_token_id
+                    get_mask_cache().mask_token(seq_id, num_output_tokens - 1)
 
     return sampling_output
 

--- a/src/zeroband/inference/elastic_reasoning.py
+++ b/src/zeroband/inference/elastic_reasoning.py
@@ -1,0 +1,77 @@
+from functools import partial
+from typing import Annotated
+
+import torch.nn as nn
+from pydantic import Field
+from vllm import LLM
+from vllm.model_executor.layers.sampler import SamplerOutput, SamplingMetadata
+
+from zeroband.utils.config import BaseConfig
+from zeroband.utils.logger import get_logger
+
+
+class ElasticReasoningConfig(BaseConfig):
+    """Configures elastic reasoning from `Scalable Chain of Thoughts via Elastic Reasoning` (https://arxiv.org/abs/2505.05315)."""
+
+    enable: Annotated[bool, Field(default=False, description="Whether to enable elastic reasoning.")]
+    think_budget: Annotated[
+        int,
+        Field(
+            default=1024,
+            description="Number of tokens to allow for thinking. If thinking is not done after this amount of tokens, overwrites the last sampled token with the stop_think_token_id to force the model to produce a solution.",
+        ),
+    ]
+    solution_budget: Annotated[int, Field(default=1024, description="Number of tokens to allow for solution.")]
+    stop_think_token_id: Annotated[
+        int,
+        Field(
+            default=151668, description="The token ID of the `</think>` token which is swapped in to force the model to produce a solution."
+        ),
+    ]  # </think
+
+
+def swap_think_token(_, __, kwargs, outputs, config: ElasticReasoningConfig) -> SamplerOutput | None:
+    """
+    A post-hook that swaps the last sampled token with the stop_think_token_id if the thinking budget is exceeded.
+
+    Args:
+        _: The module that is being hooked
+        inputs: The arguments to the module
+        outputs: The outputs of the module
+
+    Returns:
+        None
+    """
+    print(f"sampling_output: {outputs}")
+
+    sampling_metadata: SamplingMetadata = kwargs.get("sampling_metadata", None)
+    assert sampling_metadata is not None, "Sampling metadata is required for the `swap_think_token` post-hook"
+    sampling_output: SamplerOutput | None = outputs
+
+    if sampling_metadata:
+        for seq_group, seq_outputs in zip(sampling_metadata.seq_groups, sampling_output.outputs):
+            for seq_id, seq_data, seq_output in zip(seq_group.seq_data.keys(), seq_group.seq_data.values(), seq_outputs.samples):
+                num_output_tokens = len(seq_data.output_token_ids) + 1  # Increment by 1 because the current token is not yet in the output
+                if num_output_tokens == config.think_budget:
+                    get_logger("INFER").debug(
+                        f"Thinking budget reached for sequence {seq_id}. Replacing sampled token {seq_output.output_token} with {config.stop_think_token_id}"
+                    )
+                    seq_output.logprobs = {config.stop_think_token_id: seq_output.logprobs[seq_output.output_token]}
+                    seq_output.output_token = config.stop_think_token_id
+
+    print(f"sampling_output: {sampling_output}")
+
+    return sampling_output
+
+
+def setup_elastic_reasoning(config: ElasticReasoningConfig, llm: LLM):
+    # Skip if disabled
+    if not config.enable:
+        return
+
+    get_logger("INFER").info(
+        f"Enabling elastic reasoning with think_budget={config.think_budget} and solution_budget={config.solution_budget}"
+    )
+    sampler: nn.Module = llm.llm_engine.model_executor.driver_worker.model_runner.sampler
+    sampler.register_forward_hook(partial(swap_think_token, config=config), with_kwargs=True)
+    get_logger("INFER").debug("Set up post-hook swap_think_token on sampler")

--- a/src/zeroband/inference/elastic_reasoning.py
+++ b/src/zeroband/inference/elastic_reasoning.py
@@ -42,8 +42,6 @@ def swap_think_token(_, __, kwargs, outputs, config: ElasticReasoningConfig) -> 
     Returns:
         None
     """
-    print(f"sampling_output: {outputs}")
-
     sampling_metadata: SamplingMetadata = kwargs.get("sampling_metadata", None)
     assert sampling_metadata is not None, "Sampling metadata is required for the `swap_think_token` post-hook"
     sampling_output: SamplerOutput | None = outputs
@@ -58,8 +56,6 @@ def swap_think_token(_, __, kwargs, outputs, config: ElasticReasoningConfig) -> 
                     )
                     seq_output.logprobs = {config.stop_think_token_id: seq_output.logprobs[seq_output.output_token]}
                     seq_output.output_token = config.stop_think_token_id
-
-    print(f"sampling_output: {sampling_output}")
 
     return sampling_output
 

--- a/src/zeroband/inference/elastic_reasoning.py
+++ b/src/zeroband/inference/elastic_reasoning.py
@@ -37,7 +37,8 @@ def swap_think_token(
                 max_output_tokens = min(sampling_config.max_tokens or math.inf, max_model_len - len(seq_data.prompt_token_ids))
                 num_output_tokens = len(seq_data.output_token_ids) + 1  # Increment by 1 because the current token is not yet in the output
                 num_think_tokens = max_output_tokens - sampling_config.max_solution_tokens
-                if num_output_tokens == num_think_tokens:
+                has_stopped_thinking = stop_think_token_id in seq_data.output_token_ids
+                if num_output_tokens == num_think_tokens and not has_stopped_thinking:
                     get_logger("INFER").debug(
                         f"Thinking budget reached for sequence {seq_id} after {num_think_tokens} tokens. Replacing sampled token {seq_output.output_token} with {stop_think_token_id}"
                     )

--- a/src/zeroband/inference/mask.py
+++ b/src/zeroband/inference/mask.py
@@ -30,8 +30,6 @@ class MaskCache:
         Returns:
             A list of masks, where each mask is a list of booleans indicating whether each token should be masked out.
         """
-        print(self._mask_cache)
-        print(request_outputs)
         output_masks = []
         for request_output in request_outputs:
             request_id = int(request_output.request_id)

--- a/src/zeroband/inference/mask.py
+++ b/src/zeroband/inference/mask.py
@@ -1,0 +1,65 @@
+from collections import defaultdict
+
+from vllm import RequestOutput
+
+
+class MaskCache:
+    def __init__(self):
+        """Initializes the mask cache for output tokens"""
+        # Stores a list of output token_ids that should be masked out for each sequence (identified by seq_id)
+        self._mask_cache: dict[int, list[int]] = defaultdict(list)
+
+    def mask_token(self, seq_id: int, token_id: int) -> None:
+        """
+        Adds a token to the mask cache for a given sequence.
+
+        Args:
+            seq_id: The sequence ID.
+            token_id: The token ID to mask out.
+        """
+        self._mask_cache[seq_id].append(token_id)
+
+    def construct_masks(self, request_outputs: list[RequestOutput]) -> list[list[bool]]:
+        """
+        Constructs the mask for all sequences in the cache given the request
+        outputs as a list of list of booleans.
+
+        Args:
+            request_outputs: The request outputs.
+
+        Returns:
+            A list of masks, where each mask is a list of booleans indicating whether each token should be masked out.
+        """
+        print(self._mask_cache)
+        print(request_outputs)
+        output_masks = []
+        for request_output in request_outputs:
+            request_id = int(request_output.request_id)
+            for completion_output in request_output.outputs:
+                # We dynamically compute the sequence ID from the request ID and the completion index
+                # This will only be true if all completions are returned (e.g. sampling.best_of = sampling.n)
+                # If not, the assertion below will catch the error though because after each batch, the mask cache should be automatically cleared
+                seq_id = request_id * len(request_output.outputs) + completion_output.index
+                # By default, all tokens are included in the mask
+                output_mask = [True] * len(completion_output.token_ids)
+                # Mask out the tokens from the cache
+                for token_id in self._mask_cache.pop(seq_id, []):
+                    output_mask[token_id] = False
+                output_masks.append(output_mask)
+
+        assert len(self._mask_cache) == 0, (
+            "Mask cache is not empty (remaining keys: "
+            + ", ".join(str(seq_id) for seq_id in self._mask_cache.keys())
+            + "). It is likely that there is a mismatch between the request ID and the sequence IDs used to populate the mask cache."
+        )
+        return output_masks
+
+
+_MASK_CACHE: MaskCache | None = None
+
+
+def get_mask_cache() -> MaskCache:
+    global _MASK_CACHE
+    if _MASK_CACHE is None:
+        _MASK_CACHE = MaskCache()
+    return _MASK_CACHE

--- a/src/zeroband/training/config.py
+++ b/src/zeroband/training/config.py
@@ -190,7 +190,7 @@ class Config(BaseSettings):
 
     gpus_ids: Annotated[list[int] | None, Field(default=None)]
 
-    async_level: Annotated[int, Field(default=2, ge=1)]
+    async_level: Annotated[int, Field(default=2, ge=0)]
 
     collate_mode: Annotated[CollateMode, Field(default="padding")]
 

--- a/src/zeroband/utils/parquet.py
+++ b/src/zeroband/utils/parquet.py
@@ -4,8 +4,10 @@ pa_schema = pa.schema(
     [
         ("input_tokens", pa.list_(pa.int32())),
         ("output_tokens", pa.list_(pa.int32())),
-        ("input_logprobs", pa.list_(pa.float32())),  # Optional - can be null
-        ("output_logprobs", pa.list_(pa.float32())),  # Optional - can be null
+        ("input_logprobs", pa.list_(pa.float32())),  # Optional - can be null (set to list of zeros)
+        ("output_logprobs", pa.list_(pa.float32())),  # Optional - can be null (set to list of zeros)
+        ("input_mask", pa.list_(pa.bool_())),
+        ("output_mask", pa.list_(pa.bool_())),
         ("prompt", pa.string()),
         ("problem_id", pa.string()),
         ("completion", pa.string()),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,6 +111,10 @@ def create_dummy_parquet_table(batch_size: int, seq_len: int) -> Table:
     data = {
         "input_tokens": pa.array([[1] * seq_len for _ in range(batch_size)], type=pa.list_(pa.int32())),
         "output_tokens": pa.array([[1] * seq_len for _ in range(batch_size)], type=pa.list_(pa.int32())),
+        "input_logprobs": pa.array([[0.1] * seq_len for _ in range(batch_size)], type=pa.list_(pa.float32())),
+        "output_logprobs": pa.array([[0.1] * seq_len for _ in range(batch_size)], type=pa.list_(pa.float32())),
+        "input_mask": pa.array([[True] * seq_len for _ in range(batch_size)], type=pa.list_(pa.bool_())),
+        "output_mask": pa.array([[True] * seq_len for _ in range(batch_size)], type=pa.list_(pa.bool_())),
         "prompt": pa.array(["prompt" for _ in range(batch_size)], type=pa.string()),
         "completion": pa.array(["completion" for _ in range(batch_size)], type=pa.string()),
         "advantages": pa.array([1] * batch_size, type=pa.float32()),
@@ -122,8 +126,6 @@ def create_dummy_parquet_table(batch_size: int, seq_len: int) -> Table:
         "target_lengths": pa.array([seq_len] * batch_size, type=pa.int32()),
         "task_type": pa.array(["test_task"] * batch_size, type=pa.string()),
         "problem_id": pa.array(["0"] * batch_size, type=pa.string()),
-        "input_logprobs": pa.array([[0.1] * seq_len for _ in range(batch_size)], type=pa.list_(pa.float32())),
-        "output_logprobs": pa.array([[0.1] * seq_len for _ in range(batch_size)], type=pa.list_(pa.float32())),
         "seed": pa.array([42] * batch_size, type=pa.int64()),
         "temperature": pa.array([1.0] * batch_size, type=pa.float32()),
     }


### PR DESCRIPTION
This PR implements configuring a "thinking" and "solution" budget as defined in the paper Scalable Chain of Thoughts via Elastic Reasoning ([arXiv](https://arxiv.org/pdf/2505.05315)). The main idea is that we want to force a model to produce a solution even if the CoT is unfinished, with the hope being that an unfinished thinking trace still has value.

In the original paper the authors propose appending a `</think>` token if the thinking budget is reached. In their official code ([link](https://github.com/SalesforceAIResearch/Elastic-Reasoning/blob/8dacccd1ff60e82caa9033844cb0f07b97884259/verl/verl/workers/rollout/vllm_rollout/vllm_rollout.py#L303)) they do two separate calls to the inference engine, one with the think budget and one with the solution budget. If the last sampled token in the first stage is not `</think` they append it manually. In our implementation we use a post-hook on the sampler which replaces the token sampled when reaching the thinking budget by `</think`. This is more elegant because we do not require any other code changes to our inference script - we still do a single call to `.generate()` during an inference step.

One can configure the elastic reasoning by setting the `--sampling.max-solution-tokens` configuration which will dyncamilly compute the think budget as `sampling.max-tokens - sampling.max-solution-tokens`. We chose this API because we can set a constant default value for the solution budget and scale the thinking budget with the context length of the model

## Examples

1. No thinking budget set (default)

```bash
uv run src/zeroband/infer.py @ configs/inference/debug.toml --sampling.max-tokens 10 --log-level debug
```

This produces the following output

```txt
<|im_start|>assistant
<think>
Okay, let me try to solve this
```

2. Thinking budget is set

We dynamically compute the thinking budget as the difference of the maximum number of output tokens (this is `min(context length - num input tokens, max output tokens)`). In this example, the context length is 40k by default and we set the max number of output tokens to 10, so here we will almost always hit the thinking budget after 5 output tokens

```bash
uv run src/zeroband/infer.py @ configs/inference/debug.toml --sampling.max-tokens 10 --sampling.max-solution-tokens 5 --log-level debug
```

This produces the following output

```txt
<|im_start|>assistant
<think>
Okay,</think>

We are given a
```

In the second example, we do not set `--sampling.max-tokens`and so the thinking budget is dynamically computed as the difference between the context length (2k)  and the number of input tokens for each sequence, leading to a dynamic thinking budget.

```bash
uv run src/zeroband/infer.py @ configs/inference/debug.toml --model.max-model-len 2048 --sampling.max-tokens None  --sampling.max-solution-tokens 5 --log-level debug
```