### PR TITLE
Minor cleanup of configs

### DIFF
--- a/configs/inference/synthetic-2/debug.toml
+++ b/configs/inference/synthetic-2/debug.toml
@@ -6,8 +6,7 @@ name = "Qwen/Qwen3-0.6B"
 max_model_len = 8192
 
 [monitor.file]
-enable = true
-path = "outputs/file_monitor.jsonl"
+path = "file_monitor.jsonl"
 
 [sampling]
 max_tokens = 1000

--- a/src/zeroband/infer.py
+++ b/src/zeroband/infer.py
@@ -163,7 +163,7 @@ def inference(config: InferenceConfig):
     hidden_size = llm.llm_engine.model_executor.driver_worker.model_runner.model.config.hidden_size
     toploc_cache, _ = setup_toploc_cache(
         llm,
-        pipeline_config=config.parallel.pp,
+        pp_config=config.parallel.pp,
         disable=not config.toploc,
         max_seqs=batch_size,
         hidden_size=hidden_size,

--- a/src/zeroband/inference/config.py
+++ b/src/zeroband/inference/config.py
@@ -12,8 +12,7 @@ from pydantic_settings import (
 
 from zeroband.inference.pipeline import PipelineConfig
 from zeroband.inference.rewards import RewardsConfig
-from zeroband.utils.config import BaseConfig
-from zeroband.utils.monitor import MultiMonitorConfig
+from zeroband.utils.config import BaseConfig, MultiMonitorConfig
 
 # These are two somewhat hacky workarounds inspired by https://github.com/pydantic/pydantic-settings/issues/259 to ensure backwards compatibility with our old CLI system `pydantic_config`
 TOML_PATHS: list[str] = []

--- a/src/zeroband/inference/config.py
+++ b/src/zeroband/inference/config.py
@@ -10,7 +10,6 @@ from pydantic_settings import (
     TomlConfigSettingsSource,
 )
 
-from zeroband.inference.pipeline import PipelineConfig
 from zeroband.inference.rewards import RewardsConfig
 from zeroband.utils.config import BaseConfig, MultiMonitorConfig
 
@@ -102,6 +101,51 @@ class SamplingConfig(BaseConfig):
         return self
 
 
+class PipelineParallelConfig(BaseConfig):
+    """Configures pipeline parallel inference."""
+
+    rank: Annotated[int, Field(default=0, ge=0, description="Rank of the current node in the pipeline")]
+
+    world_size: Annotated[int, Field(default=1, ge=1, description="Total number of pipeline stages.")]
+
+    iroh_seed: Annotated[
+        int | None,
+        Field(
+            default=None,
+            description="Seed used to create the public node address. If None, a random seed will be used.",
+        ),
+    ]
+
+    iroh_peer_id: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description="Peer address to connect to. If None, the user will be prompted to enter it.",
+        ),
+    ]
+
+    # Each retry takes ~30s, so 10 retries is ~300s (5min)
+    connection_num_retries: Annotated[
+        int,
+        Field(default=10, ge=0, description="How many times to retry connection to peer. Each retry takes ~30s."),
+    ]
+
+    @property
+    def is_enabled(self) -> bool:
+        """Returns True if pipeline parallelism is enabled (world_size > 1)."""
+        return self.world_size > 1
+
+    @property
+    def is_first_stage(self) -> bool:
+        """Returns True if the current rank is the first rank."""
+        return self.rank == 0
+
+    @property
+    def is_last_stage(self) -> bool:
+        """Returns True if the current rank is the last rank."""
+        return self.rank == self.world_size - 1
+
+
 class ParallelConfig(BaseConfig):
     """Configures multi-node and multi-GPU setups through different types of parallelism (TP, DP, PP)."""
 
@@ -123,7 +167,7 @@ class ParallelConfig(BaseConfig):
     ]
 
     # The pipeline parallelism configuration
-    pp: Annotated[PipelineConfig, Field(default=PipelineConfig())]
+    pp: Annotated[PipelineParallelConfig, Field(default=PipelineParallelConfig())]
 
     @model_validator(mode="after")
     def assert_valid_parallelism(self):

--- a/src/zeroband/inference/rewards.py
+++ b/src/zeroband/inference/rewards.py
@@ -1,48 +1,16 @@
 import json
 import os
 from concurrent.futures import ThreadPoolExecutor
-from typing import Annotated, Any, Iterator, Literal, Sequence
+from typing import Any, Iterator, Sequence
 
 import numpy as np
 import requests
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 from vllm import RequestOutput
 
+from zeroband.inference.config import RewardsConfig
 from zeroband.inference.genesys import TaskType, get_reward_function
-from zeroband.utils.config import BaseConfig
 from zeroband.utils.logger import get_logger
-
-
-class LenRewardsConfig(BaseConfig):
-    """Configures length reward."""
-
-    reward_type: Annotated[Literal["exact", "max", "clip"], Field(default="max")]
-    target_length_sampling: Annotated[Literal["discrete", "range"], Field(default="discrete")]
-    length_prompt_location: Annotated[Literal["system_prompt", "instruction"], Field(default="system_prompt")]
-
-    # applicable if target_length_sampling == "range"
-    min_length: Annotated[int, Field(default=1000)]
-    max_length: Annotated[int, Field(default=24000)]
-
-    # applicable if target_length_sampling == "discrete"
-    target_lengths: Annotated[list[float], Field(default=[500, 1000, 2000, 3000])]
-
-    # applicable for reward_type max and exact
-    reward_coef: Annotated[float, Field(default=0.0003)]
-
-    # only applicable for reward_type == "max"
-    max_reward_delta: Annotated[float, Field(default=0.5)]
-
-
-class RewardsConfig(BaseConfig):
-    """Configures rewards compuation"""
-
-    len_reward: Annotated[LenRewardsConfig | None, Field(default=None)]
-    advantage_estimation_method: Annotated[Literal["grpo", "dr_grpo", "opo"], Field(default="grpo")]
-
-    def __str__(self) -> str:
-        len_reward_str = "disabled" if self.len_reward is None else self.len_reward
-        return f"len_reward={len_reward_str} advantage_estimation_method={self.advantage_estimation_method}"
 
 
 class ModelCompletion(BaseModel):

--- a/src/zeroband/inference/toploc.py
+++ b/src/zeroband/inference/toploc.py
@@ -9,7 +9,7 @@ from vllm import LLM
 from vllm.model_executor import SamplingMetadata
 from vllm.model_executor.layers.logits_processor import _prune_hidden_states
 
-from zeroband.inference.pipeline import PipelineConfig
+from zeroband.inference.config import PipelineParallelConfig
 from zeroband.utils.logger import get_logger
 
 
@@ -186,7 +186,7 @@ def toploc_cache_hook(_, inputs: tuple, toploc_cache: TopLocCache):
 
 
 def setup_toploc_cache(
-    llm: LLM, pipeline_config: PipelineConfig, disable: bool = False, **toploc_kwargs
+    llm: LLM, pp_config: PipelineParallelConfig, disable: bool = False, **toploc_kwargs
 ) -> tuple[TopLocCache, RemovableHandle | None]:
     """Initializes the TOPLOC cache and register a hook to dynamically populate the cache during inference"""
     # Initialize the cache
@@ -200,7 +200,7 @@ def setup_toploc_cache(
     if not disable:
         handle = logits_processor.register_forward_pre_hook(partial(toploc_cache_hook, toploc_cache=toploc_cache))
 
-    if pipeline_config.is_enabled and pipeline_config.rank < pipeline_config.world_size - 1:
+    if pp_config.is_enabled and pp_config.rank < pp_config.world_size - 1:
         llm.llm_engine.model_executor.driver_worker.model_runner.model.model.norm = ArgsIdentity()
 
     return toploc_cache, handle

--- a/src/zeroband/inference/utils.py
+++ b/src/zeroband/inference/utils.py
@@ -9,7 +9,7 @@ from vllm import LLM
 from vllm.model_executor.model_loader.loader import _process_weights_after_loading
 from vllm.transformers_utils.tokenizer import AnyTokenizer
 
-from zeroband.inference.rewards import LenRewardsConfig
+from zeroband.inference.config import LenRewardsConfig
 from zeroband.inference.work_counting import get_inference_input_output_flops  # noqa: F401
 
 

--- a/src/zeroband/training/config.py
+++ b/src/zeroband/training/config.py
@@ -3,7 +3,6 @@ from typing import Annotated, Literal, TypeAlias, Union
 from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict, TomlConfigSettingsSource
 
-from zeroband.training.data import CollateMode, DataConfig
 from zeroband.utils.config import BaseConfig, MultiMonitorConfig
 from zeroband.utils.models import AttnImpl
 
@@ -117,6 +116,21 @@ class ModelConfig(BaseConfig):
     """Configures the model to be used for training."""
 
     name: Annotated[str, Field(default="Qwen/Qwen3-0.6B", description="Name or path of the HF model to use.")]
+
+
+CollateMode: TypeAlias = Literal["packing", "padding", "balancing"]
+
+
+class DataConfig(BaseConfig):
+    path: Annotated[str, Field(default="datasets/fineweb-edu")]
+    seq_length: Annotated[int, Field(default=1024)]
+    fake: Annotated[bool, Field(default=False)]
+    num_workers: Annotated[int, Field(default=1)]
+    timeout: Annotated[float, Field(default=3600)]
+
+    local_dir: Annotated[str, Field(default="/dev/shm/zeroband/data")]  # only used if path is gcp
+
+    ignore_zero_advantages: Annotated[bool, Field(default=False)]  # don't use in local setup
 
 
 class Config(BaseSettings):

--- a/src/zeroband/training/config.py
+++ b/src/zeroband/training/config.py
@@ -4,9 +4,8 @@ from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict, TomlConfigSettingsSource
 
 from zeroband.training.data import CollateMode, DataConfig
-from zeroband.utils.config import BaseConfig
+from zeroband.utils.config import BaseConfig, MultiMonitorConfig
 from zeroband.utils.models import AttnImpl
-from zeroband.utils.monitor import MultiMonitorConfig
 
 # These are two somewhat hacky workarounds inspired by https://github.com/pydantic/pydantic-settings/issues/259 to ensure backwards compatibility with our old CLI system `pydantic_config`
 TOML_PATHS: list[str] = []

--- a/src/zeroband/training/data.py
+++ b/src/zeroband/training/data.py
@@ -1,33 +1,20 @@
 import time
 from pathlib import Path
-from typing import Annotated, Any, Generator, Literal, TypeAlias, TypedDict
+from typing import Any, Generator, TypedDict
 
 import pyarrow.parquet as pq
 import torch
 import torch.distributed as dist
 from jaxtyping import Float, Int
 from pyarrow import dataset as ds
-from pydantic import Field
 from torch.utils.data import DataLoader, IterableDataset
 
 from zeroband.training import envs
+from zeroband.training.config import CollateMode, DataConfig
 from zeroband.training.data_prefetch import STABLE_FILE, GCPPrefetcher
 from zeroband.training.world_info import get_world_info
-from zeroband.utils.config import BaseConfig
 from zeroband.utils.logger import get_logger
 from zeroband.utils.parquet import pa_schema
-
-
-class DataConfig(BaseConfig):
-    path: Annotated[str, Field(default="datasets/fineweb-edu")]
-    seq_length: Annotated[int, Field(default=1024)]
-    fake: Annotated[bool, Field(default=False)]
-    num_workers: Annotated[int, Field(default=1)]
-    timeout: Annotated[float, Field(default=3600)]
-
-    local_dir: Annotated[str, Field(default="/dev/shm/zeroband/data")]  # only used if path is gcp
-
-    ignore_zero_advantages: Annotated[bool, Field(default=False)]  # don't use in local setup
 
 
 class DatasetOutput(TypedDict):
@@ -676,9 +663,6 @@ def packed_batch_balancing(batch_optim: list[DatasetOutput], max_seq_len: int, p
 
 
 ###########
-
-
-CollateMode: TypeAlias = Literal["packing", "padding", "balancing"]
 
 
 def packed_batch(

--- a/src/zeroband/utils/config.py
+++ b/src/zeroband/utils/config.py
@@ -8,35 +8,31 @@ class BaseConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
-class MonitorConfig(BaseConfig):
-    enable: Annotated[bool, Field(default=False, description="Whether to log to this monitor")]
-
-
-class FileMonitorConfig(MonitorConfig):
+class FileMonitorConfig(BaseConfig):
     """Configures logging to a file."""
 
     path: Annotated[Path | None, Field(default=None, description="The file path to log to")]
 
     @model_validator(mode="after")
     def validate_path(self):
-        if self.enable and self.path is None:
+        if self.path is None:
             raise ValueError("File path must be set when FileMonitor is enabled. Try setting --monitor.file.path")
         return self
 
 
-class SocketMonitorConfig(MonitorConfig):
+class SocketMonitorConfig(BaseConfig):
     """Configures logging to a Unix socket."""
 
     path: Annotated[Path | None, Field(default=None, description="The socket path to log to")]
 
     @model_validator(mode="after")
     def validate_path(self):
-        if self.enable and self.path is None:
+        if self.path is None:
             raise ValueError("Socket path must be set when SocketMonitor is enabled. Try setting --monitor.socket.path")
         return self
 
 
-class APIMonitorConfig(MonitorConfig):
+class APIMonitorConfig(BaseConfig):
     """Configures logging to an API via HTTP."""
 
     url: Annotated[str | None, Field(default=None, description="The API URL to log to")]
@@ -45,13 +41,13 @@ class APIMonitorConfig(MonitorConfig):
 
     @model_validator(mode="after")
     def validate_url(self):
-        if self.enable and self.url is None:
+        if self.url is None:
             raise ValueError("URL must be set when APIMonitor is enabled. Try setting --monitor.api.url")
         return self
 
     @model_validator(mode="after")
     def validate_auth_token(self):
-        if self.enable and self.auth_token is None:
+        if self.auth_token is None:
             raise ValueError("Auth token must be set when APIMonitor is enabled. Try setting --monitor.api.auth_token")
         return self
 
@@ -60,18 +56,18 @@ class MultiMonitorConfig(BaseConfig):
     """Configures the monitoring system."""
 
     # All possible monitors (currently only supports one instance per type)
-    file: Annotated[FileMonitorConfig, Field(default=FileMonitorConfig())]
-    socket: Annotated[SocketMonitorConfig, Field(default=SocketMonitorConfig())]
-    api: Annotated[APIMonitorConfig, Field(default=APIMonitorConfig())]
+    file: Annotated[FileMonitorConfig, Field(default=None)]
+    socket: Annotated[SocketMonitorConfig, Field(default=None)]
+    api: Annotated[APIMonitorConfig, Field(default=None)]
 
     system_log_frequency: Annotated[
         int, Field(default=0, ge=0, description="Interval in seconds to log system metrics. If 0, no system metrics are logged)")
     ]
 
     def __str__(self) -> str:
-        file_str = "disabled" if not self.file.enable else f"path={self.file.path}"
-        socket_str = "disabled" if not self.socket.enable else f"path={self.socket.path}"
-        api_str = "disabled" if not self.api.enable else f"url={self.api.url}"
+        file_str = "disabled" if self.file is None else f"path={self.file.path}"
+        socket_str = "disabled" if self.socket is None else f"path={self.socket.path}"
+        api_str = "disabled" if self.api is None else f"url={self.api.url}"
         return f"file={file_str}, socket={socket_str}, api={api_str}, system_log_frequency={self.system_log_frequency}"
 
 

--- a/src/zeroband/utils/config.py
+++ b/src/zeroband/utils/config.py
@@ -1,8 +1,78 @@
-from pydantic import BaseModel, ConfigDict
+from pathlib import Path
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class BaseConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
+
+
+class MonitorConfig(BaseConfig):
+    enable: Annotated[bool, Field(default=False, description="Whether to log to this monitor")]
+
+
+class FileMonitorConfig(MonitorConfig):
+    """Configures logging to a file."""
+
+    path: Annotated[Path | None, Field(default=None, description="The file path to log to")]
+
+    @model_validator(mode="after")
+    def validate_path(self):
+        if self.enable and self.path is None:
+            raise ValueError("File path must be set when FileMonitor is enabled. Try setting --monitor.file.path")
+        return self
+
+
+class SocketMonitorConfig(MonitorConfig):
+    """Configures logging to a Unix socket."""
+
+    path: Annotated[Path | None, Field(default=None, description="The socket path to log to")]
+
+    @model_validator(mode="after")
+    def validate_path(self):
+        if self.enable and self.path is None:
+            raise ValueError("Socket path must be set when SocketMonitor is enabled. Try setting --monitor.socket.path")
+        return self
+
+
+class APIMonitorConfig(MonitorConfig):
+    """Configures logging to an API via HTTP."""
+
+    url: Annotated[str | None, Field(default=None, description="The API URL to log to")]
+
+    auth_token: Annotated[str | None, Field(default=None, description="The API auth token to use")]
+
+    @model_validator(mode="after")
+    def validate_url(self):
+        if self.enable and self.url is None:
+            raise ValueError("URL must be set when APIMonitor is enabled. Try setting --monitor.api.url")
+        return self
+
+    @model_validator(mode="after")
+    def validate_auth_token(self):
+        if self.enable and self.auth_token is None:
+            raise ValueError("Auth token must be set when APIMonitor is enabled. Try setting --monitor.api.auth_token")
+        return self
+
+
+class MultiMonitorConfig(BaseConfig):
+    """Configures the monitoring system."""
+
+    # All possible monitors (currently only supports one instance per type)
+    file: Annotated[FileMonitorConfig, Field(default=FileMonitorConfig())]
+    socket: Annotated[SocketMonitorConfig, Field(default=SocketMonitorConfig())]
+    api: Annotated[APIMonitorConfig, Field(default=APIMonitorConfig())]
+
+    system_log_frequency: Annotated[
+        int, Field(default=0, ge=0, description="Interval in seconds to log system metrics. If 0, no system metrics are logged)")
+    ]
+
+    def __str__(self) -> str:
+        file_str = "disabled" if not self.file.enable else f"path={self.file.path}"
+        socket_str = "disabled" if not self.socket.enable else f"path={self.socket.path}"
+        api_str = "disabled" if not self.api.enable else f"url={self.api.url}"
+        return f"file={file_str}, socket={socket_str}, api={api_str}, system_log_frequency={self.system_log_frequency}"
 
 
 # Extract config file paths from CLI to pass to pydantic-settings as toml source

--- a/src/zeroband/utils/monitor.py
+++ b/src/zeroband/utils/monitor.py
@@ -11,14 +11,14 @@ import aiohttp
 import psutil
 import pynvml
 
-from zeroband.utils.config import APIMonitorConfig, FileMonitorConfig, MonitorConfig, MultiMonitorConfig, SocketMonitorConfig
+from zeroband.utils.config import APIMonitorConfig, BaseConfig, FileMonitorConfig, MultiMonitorConfig, SocketMonitorConfig
 from zeroband.utils.logger import get_logger
 
 
 class Monitor(ABC):
     """Base class for logging metrics to a single monitoring type (e.g. file, socket, API)."""
 
-    def __init__(self, config: MonitorConfig, task_id: str | None = None):
+    def __init__(self, config: BaseConfig, task_id: str | None = None):
         self.config = config
         self.lock = threading.Lock()
         self.metadata = {"task_id": task_id}
@@ -108,11 +108,11 @@ class MultiMonitor:
         self.logger = get_logger("INFER")
         # Initialize outputs
         self.outputs = []
-        if config.file.enable:
+        if config.file is not None:
             self.outputs.append(FileMonitor(config.file, task_id))
-        if config.socket.enable:
+        if config.socket is not None:
             self.outputs.append(SocketMonitor(config.socket, task_id))
-        if config.api.enable:
+        if config.api is not None:
             self.outputs.append(APIMonitor(config.api, task_id))
 
         self.disabled = len(self.outputs) == 0

--- a/tests/unit/inference/test_pipeline.py
+++ b/tests/unit/inference/test_pipeline.py
@@ -5,7 +5,8 @@ import torch
 from prime_iroh import Node
 
 import zeroband.utils.envs as envs  # noqa
-from zeroband.inference.pipeline import PipelineConfig, all_reduce, setup_comm
+from zeroband.inference.config import PipelineParallelConfig
+from zeroband.inference.pipeline import all_reduce, setup_comm
 
 # Pre-computed node IDs for different seeds (our team's favorite numbers)
 IROH_NODE_ID_MAP = {
@@ -33,7 +34,7 @@ def _test_setup_comm(rank: int, world_size: int, error_queue: Queue):
     seed = SEEDS[rank]
     peer_seed = SEEDS[(rank + 1) % world_size]
     peer_id = IROH_NODE_ID_MAP[peer_seed]
-    config = PipelineConfig(rank=rank, world_size=world_size, iroh_seed=seed, iroh_peer_id=peer_id)
+    config = PipelineParallelConfig(rank=rank, world_size=world_size, iroh_seed=seed, iroh_peer_id=peer_id)
     try:
         node = setup_comm(config)
     except Exception as e:
@@ -48,7 +49,7 @@ def _test_setup_comm(rank: int, world_size: int, error_queue: Queue):
 def test_setup_comm(world_size: int):
     # Test that setup_comm raises an error for 1 stage
     if world_size == 1:
-        assert setup_comm(PipelineConfig(world_size=world_size)) is None
+        assert setup_comm(PipelineParallelConfig(world_size=world_size)) is None
         return
 
     # Setup error queue and processes
@@ -84,7 +85,7 @@ def test_setup_comm(world_size: int):
 
 def test_all_reduce_single_node():
     """Test all_reduce with single node (world_size=1)"""
-    config = PipelineConfig(rank=0, world_size=1)
+    config = PipelineParallelConfig(rank=0, world_size=1)
     test_tensor = torch.tensor(42.0)
 
     # Create a dummy node (won't be used for communication)
@@ -104,7 +105,7 @@ def _test_all_reduce(rank: int, world_size: int, operation: str, error_queue: Qu
 
     try:
         # Create config
-        config = PipelineConfig(rank=rank, world_size=world_size, iroh_seed=seed, iroh_peer_id=peer_id)
+        config = PipelineParallelConfig(rank=rank, world_size=world_size, iroh_seed=seed, iroh_peer_id=peer_id)
 
         # Setup communication
         node = setup_comm(config)

--- a/tests/unit/inference/test_prompts.py
+++ b/tests/unit/inference/test_prompts.py
@@ -1,7 +1,7 @@
 import pytest
 from transformers import AutoTokenizer
 
-from zeroband.inference.rewards import LenRewardsConfig
+from zeroband.inference.config import LenRewardsConfig
 from zeroband.inference.utils import format_prompts
 
 

--- a/tests/unit/inference/test_toploc.py
+++ b/tests/unit/inference/test_toploc.py
@@ -3,7 +3,7 @@ import torch
 from toploc import verify_proofs_bytes
 from vllm import SamplingParams, TokensPrompt
 
-from zeroband.inference.pipeline import PipelineConfig
+from zeroband.inference.config import PipelineParallelConfig
 from zeroband.inference.toploc import TopLocCache, setup_toploc_cache
 
 BYTES_PER_PROOF = 258
@@ -95,7 +95,7 @@ def test_toploc_with_hook(llm, max_seqs: int, num_output_tokens: int):
     hidden_size = model.config.hidden_size
     max_len = 32
     toploc_cache, hook_handle = setup_toploc_cache(
-        llm, pipeline_config=PipelineConfig(world_size=1), max_seqs=max_seqs, hidden_size=hidden_size, max_len=max_len
+        llm, pp_config=PipelineParallelConfig(world_size=1), max_seqs=max_seqs, hidden_size=hidden_size, max_len=max_len
     )
     assert toploc_cache.disable is False
     assert toploc_cache.proofs == {}

--- a/tests/unit/utils/test_monitor.py
+++ b/tests/unit/utils/test_monitor.py
@@ -15,98 +15,82 @@ from zeroband.utils.monitor import (
 
 def test_invalid_file_monitor_config():
     with pytest.raises(ValueError):
-        FileMonitorConfig(enable=True)
-
-    with pytest.raises(ValueError):
-        FileMonitorConfig(enable=True, path=None)
+        FileMonitorConfig()
 
 
 def test_invalid_socket_monitor_config():
     with pytest.raises(ValueError):
-        SocketMonitorConfig(enable=True)
-
-    with pytest.raises(ValueError):
-        SocketMonitorConfig(enable=True, path=None)
+        SocketMonitorConfig()
 
 
 def test_invalid_api_monitor_config():
     with pytest.raises(ValueError):
-        APIMonitorConfig(enable=True)
+        APIMonitorConfig()
 
     with pytest.raises(ValueError):
-        APIMonitorConfig(enable=True, url=None)
+        APIMonitorConfig(url=None, auth_token="test-token")
 
     with pytest.raises(ValueError):
-        APIMonitorConfig(enable=True, url="http://localhost:8000/api/v1/metrics", auth_token=None)
+        APIMonitorConfig(url="http://localhost:8000/api/v1/metrics", auth_token=None)
 
 
 def test_valid_file_monitor_config(tmp_path):
     file_path = tmp_path / "file_monitor.jsonl"
-    file_monitor_config = FileMonitorConfig(enable=True, path=file_path)
+    file_monitor_config = FileMonitorConfig(path=file_path)
     assert file_monitor_config is not None
     assert file_monitor_config.path == file_path
-    assert file_monitor_config.enable
 
 
 def test_valid_file_monitor_config_with_env(tmp_path):
     file_path = tmp_path / "file_monitor.jsonl"
-    os.environ["PRIME_MONITOR__FILE__ENABLE"] = "true"
     os.environ["PRIME_MONITOR__FILE__PATH"] = file_path.as_posix()
     config = InferenceConfig()
     assert config.monitor.file is not None
     assert config.monitor.file.path == file_path
-    assert config.monitor.file.enable
 
 
 def test_valid_socket_monitor_config(tmp_path):
     socket_path = tmp_path / "socket_monitor.sock"
-    socket_monitor_config = SocketMonitorConfig(enable=True, path=socket_path)
+    socket_monitor_config = SocketMonitorConfig(path=socket_path)
     assert socket_monitor_config is not None
     assert socket_monitor_config.path == socket_path
-    assert socket_monitor_config.enable
 
 
 def test_valid_socket_monitor_config_with_env(tmp_path):
     socket_path = tmp_path / "socket_monitor.sock"
-    os.environ["PRIME_MONITOR__SOCKET__ENABLE"] = "true"
     os.environ["PRIME_MONITOR__SOCKET__PATH"] = socket_path.as_posix()
     config = InferenceConfig()
     assert config.monitor.socket is not None
     assert config.monitor.socket.path == socket_path
-    assert config.monitor.socket.enable
 
 
 def test_valid_api_monitor_config():
     url = "http://localhost:8000/api/v1/metrics"
     auth_token = "test_token"
-    api_monitor_config = APIMonitorConfig(enable=True, url=url, auth_token=auth_token)
+    api_monitor_config = APIMonitorConfig(url=url, auth_token=auth_token)
     assert api_monitor_config is not None
     assert api_monitor_config.url == url
     assert api_monitor_config.auth_token == auth_token
-    assert api_monitor_config.enable
 
 
 def test_valid_api_monitor_config_with_env():
     url = "http://localhost:8000/api/v1/metrics"
     auth_token = "test_token"
-    os.environ["PRIME_MONITOR__API__ENABLE"] = "true"
     os.environ["PRIME_MONITOR__API__URL"] = url
     os.environ["PRIME_MONITOR__API__AUTH_TOKEN"] = auth_token
     config = InferenceConfig()
     assert config.monitor.api is not None
     assert config.monitor.api.url == url
     assert config.monitor.api.auth_token == auth_token
-    assert config.monitor.api.enable
 
 
 def test_file_monitor(tmp_path):
     # Create file output
     file_path = tmp_path / "file_monitor.jsonl"
-    file_monitor_config = FileMonitorConfig(enable=True, path=file_path)
+    file_monitor_config = FileMonitorConfig(path=file_path)
     file_monitor = FileMonitor(file_monitor_config)
     assert file_monitor_config is not None
     assert file_monitor_config.path == file_path
-    assert file_monitor_config.enable
 
     # Test logging metrics
     test_metrics = {"step": 1, "loss": 3.14}
@@ -129,7 +113,7 @@ def mock_socket():
 def test_socket_monitor(mock_socket):
     # Create socket output
     test_task_id = "test-task-123"
-    socket_monitor_config = SocketMonitorConfig(enable=True, path="/test/socket.sock")
+    socket_monitor_config = SocketMonitorConfig(path="/test/socket.sock")
     socket_monitor = SocketMonitor(socket_monitor_config, task_id=test_task_id)
 
     # Test logging metrics
@@ -157,7 +141,7 @@ def mock_api():
 @pytest.mark.skip(reason="Does not work yet with async context")
 def test_api_monitor(mock_api):
     # Create API output
-    api_monitor_config = APIMonitorConfig(enable=True, url="http://localhost:8000/api/v1/metrics", auth_token="test_token")
+    api_monitor_config = APIMonitorConfig(url="http://localhost:8000/api/v1/metrics", auth_token="test_token")
     api_monitor = APIMonitor(api_monitor_config)
 
     # Test logging metrics

--- a/tests/unit/utils/test_monitor.py
+++ b/tests/unit/utils/test_monitor.py
@@ -5,13 +5,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from zeroband.inference.config import Config as InferenceConfig
+from zeroband.utils.config import APIMonitorConfig, FileMonitorConfig, SocketMonitorConfig
 from zeroband.utils.monitor import (
     APIMonitor,
-    APIMonitorConfig,
     FileMonitor,
-    FileMonitorConfig,
     SocketMonitor,
-    SocketMonitorConfig,
 )
 
 


### PR DESCRIPTION
Two cosmetic changes to the way we structure configs:
- Define all configs in `config.py` files, not in submodules (moved `PipelineParallelConfig`, `DataConfig`, `RewardsConfig`, `MonitorConfig`
- Use the `Config | None` pattern consistently across the codebase (affected the `MonitorConfig`)
There should be no breaking changes, so should be safe to merge.