### PR TITLE
Fix TOPLOC crash when trying to generate one token

### DIFF
--- a/src/zeroband/inference/toploc.py
+++ b/src/zeroband/inference/toploc.py
@@ -47,6 +47,7 @@ class TopLocCache:
         self.disable = disable
 
         self._cache: torch.Tensor | None = None
+        self._seq_id_2_cache_index: dict[int, int] = {}
         self.proofs: dict[int, list[bytes]] = {}
 
         if not disable:


### PR DESCRIPTION
Quick fix for an issue with the TOPLOC cache being not initialized when we only generate a single token

```bash
uv run src/zeroband/infer.py @ configs/inference/debug.toml --sampling.max-tokens 1
```