### PR TITLE
Serialize current inference step

### DIFF
--- a/src/zeroband/infer.py
+++ b/src/zeroband/infer.py
@@ -187,6 +187,16 @@ def inference(config: InferenceConfig):
         llm = reload_model_weights(llm, path_file)
         real_step = ckpt_step
 
+    # Check if we should resume from step_path file
+    if config.step_path is not None and config.step_path.exists():
+        try:
+            saved_step = int(config.step_path.read_text().strip())
+            logger.info(f"Found existing step file at {config.step_path} with step {saved_step}")
+            real_step = saved_step
+            logger.info(f"Resuming from step {real_step} (loaded from {config.step_path})")
+        except (ValueError, IOError) as e:
+            logger.warning(f"Failed to read step from {config.step_path}: {e}")
+
     # This is used by the seeding logic to make sure we dont generate the same samples twice if we do multiple batches for a step
     current_step_batch_counter = 1
     total_problems = 0

--- a/src/zeroband/infer.py
+++ b/src/zeroband/infer.py
@@ -229,6 +229,12 @@ def inference(config: InferenceConfig):
                 time.sleep(1)
                 attempt_count += 1
 
+        if config.step_path is not None:
+            if not config.step_path.exists():
+                config.step_path.parent.mkdir(parents=True, exist_ok=True)
+            config.step_path.write_text(str(real_step))
+            logger.info(f"Wrote current inference step ({real_step}) to {config.step_path}")
+
         # Get batch
         if node_address_int is not None:
             # TODO: What if we have multiple sample per real step?

--- a/src/zeroband/inference/config.py
+++ b/src/zeroband/inference/config.py
@@ -451,6 +451,14 @@ class Config(BaseSettings):
         ),
     ]
 
+    step_path: Annotated[
+        Path | None,
+        Field(
+            default=None,
+            description="Path to file to write the current inference step to. Used in production by protocol worker for restarting a task after re-grouping. The file will be automatically created and and only contain a single integer.",
+        ),
+    ]
+
     @model_validator(mode="after")
     def set_log_level(self):
         os.environ["PRIME_LOG_LEVEL"] = self.log_level


### PR DESCRIPTION
This PR adds the `--step-path` config (`Path | None`, defaults to None) which writes the current inference step (the one the inference worker is working on right now if the program is running/ the last inference step before termination) to the file path specified. If the path is not set, we do not write create or write to the file.

Should be set by protocol to a file in a different volume to ensure persistent group restarts.

For example, the below command will create a file in `step` in the `rollouts` directly with a *single line and a single integer* indicating the current inference step, e.g. at step 0 the file would read `0` and there is no work submissions yet. At step 1 the file would read `1` and there is a subdirectory `rollouts/step_0` with the outputs of the finished step 0, and so on..

```bash
uv run src/zeroband/infer.py @ configs/inference/debug.toml --step-path rollouts/step
```