### PR TITLE
Destroy process group on program termination

### DIFF
--- a/src/zeroband/infer.py
+++ b/src/zeroband/infer.py
@@ -14,7 +14,6 @@ import numpy as np
 import pyarrow.parquet as pq
 import requests
 import torch
-import torch.distributed as dist
 from datasets import load_dataset
 from toploc.utils import sha256sum
 from vllm import LLM, SamplingParams, TokensPrompt
@@ -38,8 +37,10 @@ from zeroband.inference.utils import (
 )
 from zeroband.training.mp import EnvWrapper
 from zeroband.utils.logger import get_logger
+from zeroband.utils.utils import ensure_process_group_cleanup
 
 
+@ensure_process_group_cleanup
 def inference(config: InferenceConfig):
     # Initialize the logger
     logger = get_logger("INFER")
@@ -405,9 +406,6 @@ def inference(config: InferenceConfig):
         dataset_offset += problems_per_batch
 
     logger.info(f"Inference finished! Generated {total_samples} samples for {total_problems} problems")
-
-    # Manually destroy vLLM process group to avoid warnings
-    dist.destroy_process_group()
 
 
 def main(config: InferenceConfig) -> list[mp.Process]:

--- a/src/zeroband/train.py
+++ b/src/zeroband/train.py
@@ -38,6 +38,7 @@ from zeroband.utils.logger import get_logger
 from zeroband.utils.models import ModelType, get_model_and_tokenizer
 from zeroband.utils.monitor import setup_monitor
 from zeroband.utils.pydantic_config import parse_argv
+from zeroband.utils.utils import ensure_process_group_cleanup
 
 
 def get_local_batch_size(batch_size: int, micro_bs: int, data_workers: int, world_info: WorldInfo) -> int:
@@ -85,6 +86,7 @@ def get_logprobs(model: ModelType, input_ids: torch.Tensor, position_ids: torch.
     return logprobs
 
 
+@ensure_process_group_cleanup
 def train(config: TrainingConfig):
     if "ZERO_BAND_DEV" not in os.environ:
         torch_log.setLevel(logging.CRITICAL)

--- a/src/zeroband/utils/utils.py
+++ b/src/zeroband/utils/utils.py
@@ -1,0 +1,26 @@
+import functools
+
+import torch.distributed as dist
+
+
+def ensure_process_group_cleanup(func):
+    """
+    A decorator that ensures the a torch.distributed process group is properly
+    cleaned up after the decorated function runs or raises an exception.
+
+    Args:
+        func: The function to decorate
+
+    Returns:
+        The decorated function
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        finally:
+            if dist.is_initialized():
+                dist.destroy_process_group()
+
+    return wrapper


### PR DESCRIPTION
This PR implements a decorator `ensure_process_group_cleanup` which can wrap any function and will destroy  a `torch.dist` process group if it exists (it does nothing else) on regular program termination but also if an exception is raised by using the try..finally syntax. It is shared, so that both training and inference can use it.

**Before**

```bash
❯ uv run torchrun src/zeroband/train.py @ configs/training/debug.toml 
06-16 21:29:11 [TRAIN] [Rank 0] [INFO] [train.py:100] start training on 1 rank(s)
..
06-16 21:29:32 [TRAIN] [Rank 0] [INFO] [train.py:535] Training finished, exiting ...
06-16 21:29:32 [TRAIN] [Rank 0] [INFO] [train.py:536] Max memory: 12.08 GB
[rank0]:[W616 21:29:33.762196891 ProcessGroupNCCL.cpp:1496] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
```

**After**

```bash
❯ uv run torchrun src/zeroband/train.py @ configs/training/debug.toml 
06-16 21:28:25 [TRAIN] [Rank 0] [INFO] [train.py:102] start training on 1 rank(s)
...
06-16 21:28:44 [TRAIN] [Rank 0] [INFO] [train.py:537] Training finished, exiting ...
06-16 21:28:44 [TRAIN] [Rank 0] [INFO] [train.py:538] Max memory: 12.08 GB
```