### PR TITLE
Do one generation per prompt for synthetic data gen

### DIFF
--- a/configs/inference/synthetic-2/base.toml
+++ b/configs/inference/synthetic-2/base.toml
@@ -12,3 +12,6 @@ connection_num_retries = 100
 
 [rewards]
 compute_reward = false
+
+[sampling]
+n = 1

--- a/configs/inference/synthetic-2/deepseek-r1-0528-qwen3-8b.toml
+++ b/configs/inference/synthetic-2/deepseek-r1-0528-qwen3-8b.toml
@@ -3,6 +3,5 @@ name = "deepseek-ai/DeepSeek-R1-0528-Qwen3-8B"
 max_model_len = 16384
 
 [sampling]
-n = 8
 temperature = 0.6
 top_p = 0.95

--- a/configs/inference/synthetic-2/deepseek-r1-0528.toml
+++ b/configs/inference/synthetic-2/deepseek-r1-0528.toml
@@ -3,6 +3,5 @@ name = "deepseek-ai/DeepSeek-R1-0528"
 max_model_len = 32768
 
 [sampling]
-n = 8
 temperature = 0.6
 top_p = 0.95

--- a/configs/inference/synthetic-2/qwen3-32b.toml
+++ b/configs/inference/synthetic-2/qwen3-32b.toml
@@ -3,7 +3,6 @@ name = "Qwen/Qwen3-32B"
 max_model_len = 16384
 
 [sampling]
-n = 8
 temperature = 0.6
 top_p = 0.95
 top_k = 20

--- a/configs/inference/synthetic-2/qwen3-4b.toml
+++ b/configs/inference/synthetic-2/qwen3-4b.toml
@@ -3,7 +3,6 @@ name = "Qwen/Qwen3-4B"
 max_model_len = 16384
 
 [sampling]
-n = 8
 temperature = 0.6
 top_p = 0.95
 top_k = 20


### PR DESCRIPTION
This PR ensures that we will never run into the issue where `sampling.n` > `max_batch_size` which is auto-computed. Previously, some model-topology groups could not fit a large enough batch size to sample 8 sequnces at the same time. This will also lead to better throughput because we will never truncate the true batch size in the case where `max_batch_size` is not a multiple of `sampling.n`