### PR TITLE
Implement scaling auto-computed batch size

### DIFF
--- a/src/zeroband/infer.py
+++ b/src/zeroband/infer.py
@@ -144,6 +144,9 @@ def inference(config: InferenceConfig):
         logger.info("Auto-computing maximum batch size")
         local_max_batch_size = compute_max_batch_size(llm)
         max_batch_size = all_reduce(node, torch.tensor(local_max_batch_size), config=config.parallel.pp, op=torch.min).item()
+        logger.info(f"Auto-computed maximum batch size: {max_batch_size}")
+        max_batch_size = int(max_batch_size * config.scale_factor)
+        logger.info(f"Scaled maximum batch size by {config.scale_factor} to {max_batch_size}")
 
     logger.info(f"Using maximum batch size: {max_batch_size}")
 

--- a/src/zeroband/inference/config.py
+++ b/src/zeroband/inference/config.py
@@ -386,7 +386,16 @@ class Config(BaseSettings):
         int | Literal["auto"],
         Field(
             default="auto",
-            description="Maximum number of of sequences to decode in parallel. If 'auto', the maximum batch size is automatically computed.",
+            description="Maximum number of of sequences to decode in parallel. If 'auto', it will compute a conservative estimate that never triggers cache eviction assuming that all sequences reach the maximum context length.",
+        ),
+    ]
+
+    scale_factor: Annotated[
+        float,
+        Field(
+            default=1.0,
+            ge=1,
+            description="Scale factor for the automatically computed maximum batch size. By default, we use the maximum batch size as is which will never trigger cache eviction. Can be set >1 to allow for more sequences to be decoded in parallel in case sequences are typically shorter than the maximum context length.",
         ),
     ]
 


### PR DESCRIPTION
This PR adds `scale_factor` to the inference config which will scale the automatically computed batch size as `int(max_batch_size * scale_factor)`. It is set to 1.0 by default and will only run if the auto-computing batch size is supported.