### PR TITLE
Run at manual batch size for single nodes

### DIFF
--- a/configs/inference/synthetic-2/base.toml
+++ b/configs/inference/synthetic-2/base.toml
@@ -1,6 +1,8 @@
 rollout_path = "/data"
 rl = "None"
 use_tqdm = true
+syn2 = true
+max_batch_size = 256
 
 [toploc]
 enable_toploc1 = true

--- a/configs/inference/synthetic-2/debug.toml
+++ b/configs/inference/synthetic-2/debug.toml
@@ -1,6 +1,7 @@
 max_steps = 5
 rl = "None"
 use_tqdm = true
+syn2 = true
 
 [toploc]
 enable_toploc1 = true

--- a/src/zeroband/infer.py
+++ b/src/zeroband/infer.py
@@ -139,7 +139,7 @@ def inference(config: InferenceConfig):
 
     # Compute the maximum batch size
     max_batch_size = config.max_batch_size
-    if max_batch_size == "auto":
+    if max_batch_size == "auto" or (config.syn2 and config.parallel.pp.is_enabled):
         # Automatically compute the maximum batch size
         logger.info("Auto-computing maximum batch size")
         local_max_batch_size = compute_max_batch_size(llm)

--- a/src/zeroband/inference/config.py
+++ b/src/zeroband/inference/config.py
@@ -382,6 +382,8 @@ class Config(BaseSettings):
 
     toploc: Annotated[TopLocConfig, Field(default=TopLocConfig())]
 
+    syn2: Annotated[bool, Field(default=False, description="A flag for SYNTHETIC-2 run. Will enforce auto-computing the max batch size for groups.")]
+
     max_batch_size: Annotated[
         int | Literal["auto"],
         Field(


### PR DESCRIPTION
Run at large max batch size by default, but disable for groups during synthetic-2