### PR TITLE
Implement chunked generation

### DIFF
--- a/src/zeroband/infer.py
+++ b/src/zeroband/infer.py
@@ -144,7 +144,7 @@ def inference(config: InferenceConfig):
 
     # Compute the maximum batch size
     max_batch_size = config.max_batch_size
-    if max_batch_size == "auto" or (config.syn2 and config.parallel.pp.is_enabled):
+    if max_batch_size == "auto":
         # Automatically compute the maximum batch size
         logger.info("Auto-computing maximum batch size")
         local_max_batch_size = compute_max_batch_size(llm)

--- a/src/zeroband/infer.py
+++ b/src/zeroband/infer.py
@@ -318,7 +318,6 @@ def inference(config: InferenceConfig):
                     {prompt_id: unordered_token_prompts[prompt_id] for prompt_id in micro_batch_prompt_ids}
                     for micro_batch_prompt_ids in micro_batch_prompt_ids
                 ]
-                logger.info(f"Computed {len(micro_batches)} micro-batches for context {context}")
                 finish_sequence = i == len(config.contexts) - 1
                 for j, mb_unordered_tokens_prompts in enumerate(micro_batches):
                     if max_batch_size > len(mb_unordered_tokens_prompts):

--- a/src/zeroband/inference/config.py
+++ b/src/zeroband/inference/config.py
@@ -394,6 +394,8 @@ class Config(BaseSettings):
         ),
     ]
 
+    contexts: Annotated[list[int] | None, Field(default=None, description="List of contexts to use for chunked inference.")]
+
     scale_factor: Annotated[
         float,
         Field(

--- a/src/zeroband/inference/utils.py
+++ b/src/zeroband/inference/utils.py
@@ -142,7 +142,7 @@ def format_prompts(
     return formatted_prompts
 
 
-def compute_max_batch_size(llm: LLM) -> int:
+def compute_max_batch_size(llm: LLM, max_model_len: int | None = None) -> int:
     """
     Automatically computes the maximum batch size (number of sequences decoded in
     parallel) without exceeding the GPU memory to prevent cache eviction. We use vLLM's
@@ -164,7 +164,7 @@ def compute_max_batch_size(llm: LLM) -> int:
     """
     num_gpu_blocks = llm.llm_engine.model_executor.cache_config.num_gpu_blocks
     block_size = llm.llm_engine.model_executor.cache_config.block_size
-    max_model_len = llm.llm_engine.model_config.max_model_len
+    max_model_len = max_model_len or llm.llm_engine.model_config.max_model_len
     max_cache_tokens = num_gpu_blocks * block_size
     max_batch_size = max_cache_tokens // max_model_len
 


### PR DESCRIPTION
This PR implements a (hacky) way to achieve higher throughput by implementing chunked generation. The idea is to start generating with a high batch size (higher than we could go conservatively without triggering cache eviction) with a reduced context length and then incrementally (in powers of 2) increase the context length until we hit the max model length. To enable this configuration, set the `--contexts` flag which defines the list of context lengths to chunk.

Note: This implementation assumes that we only generate one sample per problem, which is fine because this is our SYNTHETIC-2 config anyways.

