### PR TITLE
Fix monitor step

### DIFF
--- a/src/zeroband/train.py
+++ b/src/zeroband/train.py
@@ -428,6 +428,7 @@ def train(config: TrainingConfig):
             padding_proportion = (config.data.seq_length - metric_averager["lengths/seq_lens"].item() - 1) / config.data.seq_length
 
             metrics = {
+                "step": training_progress.step,
                 "losses/Loss": loss_batch.item(),
                 "train/rollout_step": rollout_step,
                 "train/inner_lr": inner_lr,

--- a/src/zeroband/utils/monitor.py
+++ b/src/zeroband/utils/monitor.py
@@ -127,9 +127,8 @@ class WandbMonitor(Monitor):
     def log(self, metrics: dict[str, Any]) -> None:
         if not self.enabled:
             return
-        step = metrics.pop("step", None)
         metrics = {f"{self.prefix}{k}": v for k, v in metrics.items()}
-        wandb.log(metrics, step=step)
+        wandb.log(metrics, step=metrics.get("step", None))
 
 
 MonitorType = Literal["file", "socket", "api", "wandb"]


### PR DESCRIPTION
Backwards compatibitliy change that logs the train/infert/eval step via argument to `wandb.log` (will show as `Step` in wandb) and as "metric" (will show as small `step`)