### PR TITLE
fix: think splitting in `git_diff` reward

### DIFF
--- a/src/zeroband/inference/genesys/git_diff.py
+++ b/src/zeroband/inference/genesys/git_diff.py
@@ -70,11 +70,9 @@ def compute_git_diff_reward(completion: str, verification_info: Dict) -> float:
     Returns:
         Float score (0.0 to 1.0) representing diff similarity
     """
-    # Extract the response after thinking (if present)
-    if "</think>" in completion:
-        response = completion.split("</think>")[1].strip()
-    else:
-        response = completion.strip()
+    # Extract the response after thinking
+    think_splits = completion.split("</think>")
+    response = think_splits[1].strip() if len(think_splits) == 2 else ""
 
     if not response:
         return 0.0


### PR DESCRIPTION
If `</think>` is not present in the completion the last fenced diff block got rewarded no matter what.

During training this led to intermediate patches in the unfinished reasoning trace being rewarded.
The fix now ensures proper splitting of the final answer.

The change drops support for models not using `</think>`, in favor of the fix.