### PR TITLE
Implement file logging

### DIFF
--- a/.tmuxinator.yaml
+++ b/.tmuxinator.yaml
@@ -1,0 +1,15 @@
+name: RL
+enable_pane_titles: true
+windows:
+  - RL:
+      layout: even-horizontal
+      panes:
+        - Inference:
+          - export CUDA_VISIBLE_DEVICES=0
+          - uv run infer @ configs/inference/reverse_text.toml --disable-log-requests
+        - Orchestrator:
+          - less -R +F logs/orchestrator.log
+        - Training:
+          - export CUDA_VISIBLE_DEVICES=1
+          - uv run train @ configs/training/reverse_text.toml > /dev/null & 
+          - less -R +F logs/train.log

--- a/configs/training/reverse_text.toml
+++ b/configs/training/reverse_text.toml
@@ -6,9 +6,6 @@ name = "willcb/Qwen2.5-0.5B-Reverse-SFT"
 [optim]
 lr = 3e-6
 
-[monitor.wandb]
-project = "reverse-text"
-
 [orchestrator]
 batch_size = 128
 micro_batch_size = 128

--- a/src/zeroband/eval/config.py
+++ b/src/zeroband/eval/config.py
@@ -31,7 +31,7 @@ class Config(BaseSettings):
     monitor: Annotated[MultiMonitorConfig, Field(default=MultiMonitorConfig())]
 
     # The logging configuration
-    log: Annotated[LogConfig, Field(default=LogConfig())]
+    log: Annotated[LogConfig, Field(default=LogConfig(path=Path("logs/eval")))]
 
     use_tqdm: Annotated[
         bool,

--- a/src/zeroband/training/config.py
+++ b/src/zeroband/training/config.py
@@ -5,7 +5,7 @@ from typing import Annotated, Literal, TypeAlias, Union
 from pydantic import Field, model_validator
 
 from zeroband.training.orchestrator.config import OrchestratorConfig
-from zeroband.utils.config import MultiMonitorConfig
+from zeroband.utils.config import LogConfig, MultiMonitorConfig
 from zeroband.utils.pydantic_config import BaseConfig, BaseSettings
 
 AttnImplementation: TypeAlias = Literal["sdpa", "flash_attention_2"]
@@ -169,34 +169,6 @@ class DataLoaderConfig(BaseConfig):
     fake: Annotated[FakeDataLoaderConfig | None, Field(default=None)]
 
 
-class LogConfig(BaseConfig):
-    """Configures the training logger."""
-
-    level: Annotated[
-        Literal["debug", "info"],
-        Field(
-            default="info",
-            description="Logging level for the inference run. Will determine the logging verbosity and format.",
-        ),
-    ]
-
-    all_ranks: Annotated[
-        bool,
-        Field(
-            default=False,
-            description="Whether to log from all DP ranks. If False, will only log from the main rank (DP rank 0).",
-        ),
-    ]
-
-    utc: Annotated[
-        bool,
-        Field(
-            default=False,
-            description="Whether to use UTC time in the logger. If False, it will default to the local time. If the local time is wrong, you can set it by setting the `TZ` environment variable. For example, `TZ=America/Los_Angeles` will set the local time to SF time.",
-        ),
-    ]
-
-
 class Config(BaseSettings):
     """Configures training"""
 
@@ -222,7 +194,7 @@ class Config(BaseSettings):
     loss: Annotated[GRPOLossConfig, Field(default=GRPOLossConfig())]
 
     # The logging configuration
-    log: LogConfig = LogConfig()
+    log: Annotated[LogConfig, Field(default=LogConfig(path=Path("logs/train")))]
 
     # The monitor configuration
     monitor: Annotated[MultiMonitorConfig, Field(default=MultiMonitorConfig())]

--- a/src/zeroband/training/logger.py
+++ b/src/zeroband/training/logger.py
@@ -1,56 +1,27 @@
-import sys
+from pathlib import Path
 
-from loguru import logger
+from loguru import logger as loguru_logger
 from loguru._logger import Logger
 
 from zeroband.training.config import LogConfig
 from zeroband.training.world import World
-from zeroband.utils.logger import get_logger, set_logger
-
-NO_BOLD = "\033[22m"
-RESET = "\033[0m"
+from zeroband.utils.logger import format_debug, format_message, format_time, get_logger, set_logger, setup_handlers
 
 
 def setup_logger(log_config: LogConfig, world: World) -> Logger:
     if get_logger() is not None:
         raise RuntimeError("Logger already setup. Call reset_logger first.")
 
-    # Define the time format for the logger.
-    time = "<dim>{time:HH:mm:ss}</dim>"
-    if log_config.utc:
-        time = "<dim>{time:zz HH:mm:ss!UTC}</dim>"
+    message = format_message()
+    time = format_time(log_config)
+    debug = format_debug(log_config)
+    format = time + message + debug
 
-    # Define the colorized log level and message
-    message = "".join(
-        [
-            " <level>{level: >7}</level>",
-            f" <level>{NO_BOLD}",
-            "{message}",
-            f"{RESET}</level>",
-        ]
-    )
-
-    # Add parallel information to the format
+    # Setup the logger handlers
     if world.world_size > 1:
-        format = time + f"[ Rank {world.rank} ]" + message
-    else:
-        format = time + message
-    if log_config.level.upper() == "DEBUG":
-        format += "".join([f"<level>{NO_BOLD}", " [{file}::{line}]", f"{RESET}</level>"])
-
-    # Remove all default handlers
-    logger.remove()
-
-    # Install new handler on all ranks, if specified. Otherwise, only install on the main rank
-    if log_config.all_ranks or world.rank == 0:
-        logger.add(
-            sys.stdout, format=format, level=log_config.level.upper(), enqueue=True, backtrace=True, diagnose=True
-        )
-
-    # Disable critical logging
-    logger.critical = lambda _: None
-
-    # Bind the logger to access the rank
+        log_config.path = Path(log_config.path.as_posix() + str(world.rank))
+    log_config.path = Path(log_config.path.as_posix() + ".log")
+    logger = setup_handlers(loguru_logger, format, log_config, rank=world.rank)
     set_logger(logger)
 
     return logger

--- a/src/zeroband/training/orchestrator/config.py
+++ b/src/zeroband/training/orchestrator/config.py
@@ -4,7 +4,7 @@ from typing import Annotated, Literal
 from pydantic import Field, model_validator
 
 from zeroband.eval.registry import Benchmark
-from zeroband.utils.config import ModelConfig, MultiMonitorConfig
+from zeroband.utils.config import LogConfig, ModelConfig, MultiMonitorConfig
 from zeroband.utils.pydantic_config import BaseConfig, BaseSettings
 
 
@@ -118,34 +118,6 @@ class DataConfig(BaseConfig):
     split: Annotated[str, Field(default="train", description="Split of the dataset to use.")]
 
 
-class LogConfig(BaseConfig):
-    """Configures the logger."""
-
-    level: Annotated[
-        Literal["debug", "info"],
-        Field(
-            default="info",
-            description="Logging level for the inference run. Will determine the logging verbosity and format.",
-        ),
-    ]
-
-    all_ranks: Annotated[
-        bool,
-        Field(
-            default=False,
-            description="Whether to log from all DP ranks. If False, will only log from the main rank (DP rank 0).",
-        ),
-    ]
-
-    utc: Annotated[
-        bool,
-        Field(
-            default=False,
-            description="Whether to use UTC time in the logger. If False, it will default to the local time. If the local time is wrong, you can set it by setting the `TZ` environment variable. For example, `TZ=America/Los_Angeles` will set the local time to SF time.",
-        ),
-    ]
-
-
 class PathConfig(BaseConfig):
     """Configures a path used for input/ output operations"""
 
@@ -222,7 +194,7 @@ class OrchestratorConfig(BaseSettings):
     eval: Annotated[EvalConfig | None, Field(default=None)]
 
     # The logging configuration
-    log: Annotated[LogConfig, Field(default=LogConfig())]
+    log: Annotated[LogConfig, Field(default=LogConfig(path=Path("logs/orchestrator")))]
 
     # The monitor configuration
     monitor: Annotated[MultiMonitorConfig, Field(default=MultiMonitorConfig())]

--- a/src/zeroband/utils/config.py
+++ b/src/zeroband/utils/config.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Literal
 
 from pydantic import Field, model_validator
 
@@ -7,13 +7,41 @@ from zeroband.utils.pydantic_config import BaseConfig
 
 
 class ModelConfig(BaseConfig):
-    """Configures the model to be used for training."""
+    """Configures the model."""
 
     name: Annotated[
         str,
         Field(
             default="Qwen/Qwen3-0.6B",
             description="Name or path of the HF model to use.",
+        ),
+    ]
+
+
+class LogConfig(BaseConfig):
+    """Configures the logger."""
+
+    level: Annotated[
+        Literal["debug", "info"],
+        Field(
+            default="info",
+            description="Logging level for the process. Will determine the logging verbosity and format.",
+        ),
+    ]
+
+    path: Annotated[
+        Path | None,
+        Field(
+            default=Path("logs"),
+            description="The file path to log to. If None, will only log to stdout. This field is particularly useful to distinguish logs when multi-processing.",
+        ),
+    ]
+
+    utc: Annotated[
+        bool,
+        Field(
+            default=False,
+            description="Whether to use UTC time in the logger. If False, it will default to the local time. If the local time is wrong, you can set it by setting the `TZ` environment variable. For example, `TZ=America/Los_Angeles` will set the local time to SF time.",
         ),
     ]
 


### PR DESCRIPTION
We log to `logs/{train | orchestrator | eval}.log` by default. If there is multiple ranks on the trainer they will log to `logs/train{rank}.log`.

To stream the logs with coloring use `less -R +F logs/train.log`