### PR TITLE
Make HTTP requests more resilient

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,8 @@ dev = [
 
 
 [tool.ruff.lint]
-ignore = ["F722", "F821"] # need to ignore this for jaxtyping https://docs.kidger.site/jaxtyping/faq/
+select = ["F", "I"]
+ignore = ["F722", "F821"] # Need to ignore for jaxtyping (https://docs.kidger.site/jaxtyping/faq/)
 
 [tool.ruff]
 line-length = 120

--- a/src/zeroband/training/config.py
+++ b/src/zeroband/training/config.py
@@ -213,7 +213,7 @@ class TrainingConfig(BaseSettings):
     ] = True
 
     @model_validator(mode="after")
-    def auto_name_wandb(self):
+    def auto_setup_orchestrator_wandb(self):
         # Automatically use same W&B project
         if self.orchestrator and self.monitor.wandb:
             self.orchestrator.monitor.wandb.project = self.monitor.wandb.project
@@ -227,7 +227,13 @@ class TrainingConfig(BaseSettings):
         return self
 
     @model_validator(mode="after")
-    def check_model_name_orchestrator(self):
+    def auto_setup_orchestrator_model(self):
         if self.orchestrator:
             self.orchestrator.model.name = self.model.name
+        return self
+
+    @model_validator(mode="after")
+    def auto_setup_orchestrator_log_level(self):
+        if self.orchestrator:
+            self.orchestrator.log.level = self.log.level
         return self

--- a/src/zeroband/training/orchestrator/client.py
+++ b/src/zeroband/training/orchestrator/client.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import httpx
 from httpx import Response
-from openai import AsyncOpenAI
+from openai import AsyncOpenAI, BaseModel
 from openai.types.chat import ChatCompletion
 from vllm.entrypoints.openai.api_server import TokenizeResponse
 
@@ -76,8 +76,12 @@ async def reset_weights(client: AsyncOpenAI) -> None:
 
 async def tokenize(client: AsyncOpenAI, model_config: ModelConfig, messages: list[dict[str, str]]) -> list[int]:
     url = str(client.base_url)[:-4] + "/tokenize"
+
+    class OAITokenizeResponse(BaseModel, TokenizeResponse):
+        """Make vLLM's TokenizeResponse compatible with OAI client."""
+
     tokenize_response = await client.post(
-        url, cast_to=TokenizeResponse, body={"model": model_config.name, "messages": messages}
+        url, cast_to=OAITokenizeResponse, body={"model": model_config.name, "messages": messages}
     )
     return tokenize_response.tokens
 

--- a/src/zeroband/training/orchestrator/client.py
+++ b/src/zeroband/training/orchestrator/client.py
@@ -33,7 +33,7 @@ async def check_health(client: AsyncOpenAI, interval: int = 1, log_interval: int
     logger.debug(f"Starting pinging {url} to check health")
     while wait_time < timeout:
         try:
-            await client._client.get(url=url)
+            await client.get(url=url)
             logger.debug(f"Inference pool is ready after {wait_time} seconds")
             return
         except Exception as e:
@@ -61,7 +61,7 @@ async def reload_weights(client: AsyncOpenAI, path: Path, step: int) -> None:
     url = str(client.base_url)[:-4] + "/reload_weights"
     model_path = path / f"step_{step}" / "model.pt"
     logger.debug(f"Sending request to {url} to reload weights from {model_path}")
-    await client._client.post(url=url, json={"model_path": model_path.as_posix()})
+    await client.post(url=url, json={"model_path": model_path.as_posix()})
 
 
 async def reset_weights(client: AsyncOpenAI) -> None:
@@ -69,12 +69,12 @@ async def reset_weights(client: AsyncOpenAI) -> None:
     logger = get_logger()
     url = str(client.base_url)[:-4] + "/reset_weights"
     logger.debug(f"Sending request to {url} to reset weights to base model")
-    await client._client.post(url=url, json={})
+    await client.post(url=url, json={})
 
 
 async def tokenize(client: AsyncOpenAI, model_config: ModelConfig, messages: list[dict[str, str]]) -> list[int]:
     url = str(client.base_url)[:-4] + "/tokenize"
-    res = await client._client.post(url=url, json={"model": model_config.name, "messages": messages})
+    res = await client.post(url=url, json={"model": model_config.name, "messages": messages})
     return res.json()["tokens"]
 
 

--- a/src/zeroband/training/orchestrator/envs.py
+++ b/src/zeroband/training/orchestrator/envs.py
@@ -1,0 +1,31 @@
+from typing import TYPE_CHECKING, Any
+
+from zeroband.utils.envs import _ENV_PARSERS as _BASE_ENV_PARSERS, get_env_value, get_dir, set_defaults
+
+if TYPE_CHECKING:
+    # Enable type checking for shared envs
+    # ruff: noqa
+    from zeroband.utils.envs import *
+
+    # vLLM
+    VLLM_CONFIGURE_LOGGING: int
+
+
+_ORCHESTRATOR_ENV_PARSERS = {
+    "VLLM_CONFIGURE_LOGGING": int,
+    **_BASE_ENV_PARSERS,
+}
+
+_ORCHESTRATOR_ENV_DEFAULTS = {
+    "VLLM_CONFIGURE_LOGGING": "0",
+}
+
+set_defaults(_ORCHESTRATOR_ENV_DEFAULTS)
+
+
+def __getattr__(name: str) -> Any:
+    return get_env_value(_ORCHESTRATOR_ENV_PARSERS, name)
+
+
+def __dir__() -> list[str]:
+    return get_dir(_ORCHESTRATOR_ENV_PARSERS)

--- a/src/zeroband/training/orchestrator/orchestrator.py
+++ b/src/zeroband/training/orchestrator/orchestrator.py
@@ -5,6 +5,10 @@ import time
 from multiprocessing.queues import Queue
 from pathlib import Path
 
+# Import environment before any other imports
+# ruff: noqa: I001,F401
+from zeroband.training.orchestrator import envs
+
 import lovely_tensors as lt
 import numpy as np
 import torch

--- a/src/zeroband/training/orchestrator/orchestrator.py
+++ b/src/zeroband/training/orchestrator/orchestrator.py
@@ -171,7 +171,8 @@ async def orchestrate(config: OrchestratorConfig, setup_queue: Queue | None = No
         # TODO: Integrate with async (multi-turn) rollout function from verifiers
         logger.debug(f"Sending {len(batch_messages)} inference requests for step {step}")
         generate_completions_start_time = time.time()
-        input_tokens = await asyncio.gather(*(tokenize(client, config.model, messages) for messages in batch_messages))
+        # These calls are intentionally non-concurrent because we found that /tokenize is sometimes returning a httpx.ReadError when calling this endpoint concurrently
+        input_tokens = [await tokenize(client, config.model, messages) for messages in batch_messages]
         chat_completions = await asyncio.gather(
             *(
                 generate_completion(client, config.model, config.sampling, messages, len(input_tokens))

--- a/src/zeroband/training/train.py
+++ b/src/zeroband/training/train.py
@@ -6,12 +6,15 @@ import time
 from collections import defaultdict
 from pathlib import Path
 
+# Import environment before any other imports
+# ruff: noqa: I001
+from zeroband.training import envs
+
 import shardcast
 import torch
 import torch.distributed as dist
 from torch._guards import log as torch_log
 
-from zeroband.training import envs
 from zeroband.training.ckpt import (
     TrainingProgress,
     load_full_checkpoint,


### PR DESCRIPTION
This PR ~solves the `asyncio.gather` call to the `/tokenize` endpoint of our vLLM server occassionally returning a `httpx.ReadError`. It is believed that this endpoint is not fully async/thread-safe and can therefore randomly crash if too many tokenization requests are made relative to the server capacity (this is believed, because the error ocurred more frequently on weaker machines, e.g. CI machine).

The bug made me look deeper into the OAI and HTTPX client and let me to set more sane timeouts/ limits for our kind of workloads, in particular:
- We set the httpx timeout to 20min per request (default: 5 min)
- We set the max number of connections/ alive connections to 28k (max available ports) - this is just to ensure we can have >= batch size connections opens
- The OAI client will retyr 10 times instead of 2 times 

*None of these fixed the `httpx.ReadError`.*

Hence, the hotfix for now is to *fully synchronously*, i.e. one after the other tokenize the prompts which is not much of a performance hit for now. Alternative solutions we discussed and that we might want to implement at a later stage are retries on our `tokenize` function (e.g. through `tenacity`) or actually fixing the root bug which seems to be in vLLM's tokenize endpoint.