### PR TITLE
Implement resume from checkpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ CUDA_VISIBLE_DEVICES=1 uv run train @ configs/training/simple_math.toml
 
 *TBD*
 
-## Contributing
+## Developer
 
 *For now, development is only possible on CUDA-enabled devices. However, we build production-ready images for both CUDA (NVIDIA) and ROCM (AMD) GPUs that should work out of the box.*
 
@@ -142,7 +142,7 @@ CUDA_VISIBLE_DEVICES=1 uv run train @ configs/training/simple_math.toml
 uv run pre-commit install
 ```
 
-### Config System
+### Configs
 
 We use `pydantic-settings` to configure `prime-rl`. To get an overview of the available configurations, run the following command:
 
@@ -187,6 +187,59 @@ PRIME_MODEL__NAME=Qwen/Qwen3-4B uv run src/zeroband/inference/server.py @qwen8b.
 ```
 
 In this example, the CLI argument `--model.name Qwen/Qwen3-32B` will take precendence and the script will use `Qwen/Qwen3-32B` as the model name. If the CLI argument wasn't set, then the second config file would take precedence and the script would use `Qwen/Qwen-14B` as the model name. If the second config file wasn't set, then the first config file would take precedence and the script would use `Qwen/Qwen3-8B` as the model name. Finally, if the first config file wasn't set, then the environment variable would take precedence and the script would use `Qwen/Qwen-4B` as the model name. If the environment variable wasn't set, then the default value would be used and the script would use `Qwen/Qwen3-0.6B` as the model name.
+
+### Checkpointing
+
+Our codebase supports checkpointing. Because of the trainer/ orchestrator design, as well as the natural asynchrony checkpointing is non-standard.
+
+- Trainer (`src/zeroband/training/ckpt.py`): Checkpoints FSDP model shard, optimizer state and progress (training step, total samples, total tokens)
+- Orchestrator (`src/zeroband/training/ckpt.py`): Checkpoints orchestrator progress
+
+*NB: Each run with asynchrony level `async_level` and some checkpoint step `x`, requires weight checkpoints in the step range `[x-async_level, x]`. Currently we do not duplicate weight checkpoints into the `checkpoints` directory but simply keep them around in `weights`, by keeping the trainer from cleaning up weight checkpoints that are required for resuming training. This way, the orchestrator only needs to checkpoint its progress (read: step) to load the correct weights into the inference engine upon resuming.*
+
+The default checkpoint directory is `checkpoints` and each checkpoint step will live in a subdirectory enumerated by the step, i.e. `checkpoints/step_{step}`. The trainer checkpoint is called `trainer.pt` for single GPU workloads, else `trainer_{local_rank}.pt`. The orchestrator checkpoint is callec `orchestrator.pt`. Thus, this is a typical directory structure:
+
+```bash
+checkpoints
+├── step_10
+│   ├── orchestrator.pt
+│   └── trainer.pt
+├── step_25
+│   ├── orchestrator.pt
+│   └── trainer.pt
+└── step_30
+    ├── orchestrator.pt
+    └── trainer.pt
+```
+
+Checkpointing is configured by the `CheckpointConfig`, with the config key `--ckpt`. One can specify:
+- `--ckpt.path` to change the checkpoint directory (default: `checkpoints`)
+- `--ckpt.interval` to change the interval frequency (default: `50`)
+- `--ckpt.save-async` to save the checkpoint asynchronously (default: `False`)
+
+By default, runs do no write checkpoints to save disk space. To checkpoint every 10 steps on our debug RL run, run the following command
+
+```bash
+CUDA_VISIBLE_DEVICES=1 uv run train @ configs/training/reverse_text.toml --ckpt.interval 10 
+```
+
+To resume a run use the `--ckpt.resume-step` flag. To resume from the checkpoint stpe 10 from the previous command, run the following command
+
+```bash
+CUDA_VISIBLE_DEVICES=1 uv run train @ configs/training/reverse_text.toml --ckpt.resume_step 10
+```
+
+Because we save progress information, resuming from a checkpoint is fully W&B compatible. By default, resuming from a checkpoint, will simply create a new run. To resume the same W&B run, you'd have to pass the same W&B run ID for both the trainer and the orchestrator, e.g.
+
+```bash
+CUDA_VISIBLE_DEVICES=1 uv run train @ configs/training/reverse_text.toml \
+  --monitor.wandb.project <project> \
+  --monitor.wandb.group <group> \
+  --ckpt.resume-step 10 \
+  --monitor.wandb.id <trainer-run-id> \
+  --orchestrator.monitor.wandb.id <orchestrator-run-id>
+```
+
 
 ### Tests
 

--- a/src/zeroband/training/ckpt.py
+++ b/src/zeroband/training/ckpt.py
@@ -104,8 +104,3 @@ class CheckpointManager:
         else:
             # Run save synchronously
             self._save_to_path(ckpt_path, model, optimizers, progress)
-
-
-def get_ckpt_manager(config: CheckpointConfig) -> CheckpointManager:
-    """Returns a checkpoint manager for a given checkpoint directory."""
-    return CheckpointManager(config)

--- a/src/zeroband/training/ckpt.py
+++ b/src/zeroband/training/ckpt.py
@@ -29,7 +29,8 @@ class CheckpointManager:
         return self.path / f"step_{step}"
 
     def _get_ckpt_path(self, step: int) -> Path:
-        return self._get_step_path(step) / f"{self._world.local_rank}.pt"
+        ckpt_name = f"trainer_{self._world.local_rank}.pt" if self._world.world_size > 1 else "trainer.pt"
+        return self._get_step_path(step) / ckpt_name
 
     def _save_to_path(self, ckpt_path: Path, model: Model, optimizers: list[Optimizer], progress: Progress):
         self._logger.debug(f"Saving checkpoint to {ckpt_path}")

--- a/src/zeroband/training/ckpt.py
+++ b/src/zeroband/training/ckpt.py
@@ -1,4 +1,5 @@
 import time
+from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -35,11 +36,16 @@ class CheckpointManager:
     def _save_to_path(self, ckpt_path: Path, model: Model, optimizers: list[Optimizer], progress: Progress):
         self._logger.debug(f"Saving checkpoint to {ckpt_path}")
         start_time = time.time()
+
+        # Increment the
+        progress_copy = deepcopy(progress)
+        progress_copy.step += 1
+
         # Create checkpoint state
         ckpt_state = {
             "model": model.state_dict(),
             "optimizers": [optimizer.state_dict() for optimizer in optimizers],
-            "progress": progress,
+            "progress": progress_copy,
         }
         # Create checkpoint directory if it doesn't exist
         with open(ckpt_path, "wb") as f:

--- a/src/zeroband/training/ckpt.py
+++ b/src/zeroband/training/ckpt.py
@@ -1,13 +1,9 @@
-import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
 
 import torch
-from torch.distributed.checkpoint.state_dict import _get_fqns as get_fqns
-from torch.distributed.tensor import DTensor
 from torch.optim.optimizer import Optimizer
-from transformers import AutoTokenizer
 
 from zeroband.training.model import Model
 from zeroband.training.world import get_world
@@ -78,73 +74,3 @@ def load_full_checkpoint(
     progress.total_samples = state["progress"].total_samples
 
     logger.debug(f"Checkpoint loaded in {time.time() - start_time:.2f} seconds")
-
-
-def save_weight_checkpoint(
-    model: Model,
-    tokenizer: AutoTokenizer,
-    path: Path,
-    dtype: torch.dtype = torch.bfloat16,
-    async_save: bool = False,
-) -> Path:
-    """
-    Save a HF-compatible weight-only checkpoint to the specified path. Saves the
-    model weights as `model.pt`, the model config, generation arguments and tokenizer
-    using HF's `save_pretrained` method.
-    """
-    # Get logger and world info
-    logger = get_logger()
-    is_master = get_world().rank == 0
-
-    # Create checkpoint directory if it doesn't exist
-    if not path.exists():
-        path.mkdir(parents=True, exist_ok=True)
-
-    # Gather distributed weights for weight checkpoint
-    start_time = time.time()
-    logger.debug("Gathering sharded weights")
-    cpu_state = {}
-    for key, value in model.state_dict().items():
-        if isinstance(value, DTensor):
-            value = value.to(dtype)
-            # only gather after the downcast to dtype as it will be faster
-            value = value.full_tensor()
-
-        if is_master:
-            key = get_fqns(model, key)
-            assert len(key) == 1
-            key = next(iter(key))
-            # TODO(Sami) Blocking to avoid race condition, should make non-blocking long-term tho
-            cpu_state[key] = value.to("cpu", non_blocking=False)
-
-    torch.distributed.barrier()
-    logger.debug(f"Gathered sharded weights in {time.time() - start_time:.2f} seconds")
-
-    model_path = path / "model.pt"
-
-    def _save_weight_checkpoint():
-        if is_master:
-            start_time = time.time()
-            logger.debug(f"Saving weights to {path}")
-
-            # Save model weights to temporary file to avoid race condition
-            tmp_model_path = path / "model.pt.tmp"
-            torch.save(cpu_state, tmp_model_path)
-
-            # Rename temporary file to indicate checkpoint is complete
-            tmp_model_path.rename(model_path)
-
-            # Save model config, generation arguments and tokenizer
-            model.config.save_pretrained(path)
-            model.generation_config.save_pretrained(path)
-            tokenizer.save_pretrained(path)
-
-            logger.debug(f"Saved weights to {path} in {time.time() - start_time:.2f} seconds")
-
-    if async_save:
-        thread = threading.Thread(target=_save_weight_checkpoint)
-        thread.start()
-    else:
-        _save_weight_checkpoint()
-
-    return model_path

--- a/src/zeroband/training/ckpt.py
+++ b/src/zeroband/training/ckpt.py
@@ -41,14 +41,15 @@ class CheckpointManager:
             "progress": progress,
         }
         # Create checkpoint directory if it doesn't exist
-        ckpt_path.mkdir(parents=True, exist_ok=True)
         with open(ckpt_path, "wb") as f:
             torch.save(ckpt_state, f)
         self._logger.debug(f"Checkpoint saved in {time.time() - start_time:.2f} seconds")
 
     def load_from_path(self, ckpt_path: Path, model: Model, optimizers: list[Optimizer], progress: Progress):
+        """Loads a checkpoint from a given path in-place."""
         self._logger.debug(f"Loading checkpoint from {ckpt_path}")
         start_time = time.time()
+
         # Load checkpoint state
         with open(ckpt_path, "rb") as f:
             state = torch.load(f, weights_only=False)

--- a/src/zeroband/training/config.py
+++ b/src/zeroband/training/config.py
@@ -176,7 +176,7 @@ class TrainingConfig(BaseSettings):
     optim: OptimizerConfig = OptimizerConfig()
 
     # The checkpoint configuration
-    ckpt: CheckpointConfig = CheckpointConfig(path=Path("checkpoints"))
+    ckpt: CheckpointConfig | None = None
 
     # The weight checkpoint configuration
     weights: WeightCheckpointConfig = WeightCheckpointConfig()
@@ -262,7 +262,7 @@ class TrainingConfig(BaseSettings):
 
     @model_validator(mode="after")
     def warn_wandb_resume_id_missing(self):
-        if self.ckpt.resume_step:
+        if self.ckpt and self.ckpt.resume_step:
             if self.monitor.wandb and not self.monitor.wandb.id:
                 warnings.warn(
                     "W&B run ID is not set for trainer even though resuming training. The current run will be created as a new run."

--- a/src/zeroband/training/config.py
+++ b/src/zeroband/training/config.py
@@ -244,7 +244,7 @@ class TrainingConfig(BaseSettings):
 
     @model_validator(mode="after")
     def auto_setup_max_step(self):
-        if self.max_steps is not None:
+        if self.max_steps is not None and self.orchestrator:
             self.orchestrator.max_steps = self.max_steps
         return self
 

--- a/src/zeroband/training/config.py
+++ b/src/zeroband/training/config.py
@@ -60,6 +60,7 @@ class CheckpointConfig(BaseConfig):
     resume_step: Annotated[
         int | None,
         Field(
+            ge=1,
             description="Step to resume training from. If None, will start from scratch.",
         ),
     ] = None
@@ -247,6 +248,6 @@ class TrainingConfig(BaseSettings):
             self.orchestrator.ckpt.path = self.ckpt.path
             self.orchestrator.ckpt.interval = self.ckpt.interval
 
-            if self.ckpt.resume_step:
+            if self.ckpt.resume_step and self.orchestrator.ckpt.resume_step is None:
                 self.orchestrator.ckpt.resume_step = self.ckpt.resume_step
         return self

--- a/src/zeroband/training/config.py
+++ b/src/zeroband/training/config.py
@@ -53,7 +53,7 @@ class OptimizerConfig(BaseConfig):
 class CheckpointConfig(BaseConfig):
     """Configures checkpointing the full model, optimizer and training state for resuming training."""
 
-    path: Annotated[Path, Field(description="Path to write checkpoints to.")] = Path("checkpoints")
+    path: Annotated[Path, Field(description="Directory to write checkpoints to.")] = Path("checkpoints")
 
     clean: Annotated[
         bool,

--- a/src/zeroband/training/config.py
+++ b/src/zeroband/training/config.py
@@ -239,3 +239,9 @@ class TrainingConfig(BaseSettings):
         if self.orchestrator:
             self.orchestrator.log.level = self.log.level
         return self
+
+    @model_validator(mode="after")
+    def auto_setup_max_step(self):
+        if self.max_steps is not None:
+            self.orchestrator.max_steps = self.max_steps
+        return self

--- a/src/zeroband/training/config.py
+++ b/src/zeroband/training/config.py
@@ -245,3 +245,12 @@ class TrainingConfig(BaseSettings):
         if self.max_steps is not None:
             self.orchestrator.max_steps = self.max_steps
         return self
+
+    @model_validator(mode="after")
+    def auto_setup_orchestrator_ckpt(self):
+        # Ensures that trainer and orchestrator checkpoints are synchronized
+        if self.ckpt:
+            self.orchestrator.ckpt = CheckpointConfig()
+            self.orchestrator.ckpt.path = self.ckpt.path
+            self.orchestrator.ckpt.interval = self.ckpt.interval
+        return self

--- a/src/zeroband/training/config.py
+++ b/src/zeroband/training/config.py
@@ -174,7 +174,7 @@ class TrainingConfig(BaseSettings):
     optim: OptimizerConfig = OptimizerConfig()
 
     # The checkpoint configuration
-    ckpt: CheckpointConfig = CheckpointConfig(path=Path("checkpoints"), clean=True)
+    ckpt: CheckpointConfig = CheckpointConfig(path=Path("checkpoints"))
 
     # The weight checkpoint configuration
     weights: WeightCheckpointConfig = WeightCheckpointConfig()

--- a/src/zeroband/training/config.py
+++ b/src/zeroband/training/config.py
@@ -58,6 +58,13 @@ class CheckpointConfig(BaseConfig):
 
     interval: Annotated[int, Field(ge=1, description="Interval at which to save the checkpoint.")] = 50
 
+    save_async: Annotated[
+        bool,
+        Field(
+            description="Whether to save the checkpoint asynchronously.",
+        ),
+    ] = False
+
     resume_step: Annotated[
         int | None,
         Field(

--- a/src/zeroband/training/orchestrator/ckpt.py
+++ b/src/zeroband/training/orchestrator/ckpt.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import torch
 
+from zeroband.training.orchestrator.config import CheckpointConfig
 from zeroband.utils.logger import get_logger
 
 
@@ -20,8 +21,8 @@ class Progress:
 class CheckpointManager:
     """Utility class to save and load orchestrator checkpoints to resume orchestrator."""
 
-    def __init__(self, path: Path):
-        self.path = path
+    def __init__(self, config: CheckpointConfig):
+        self.path = config.path
         self._logger = get_logger()
 
     def _get_step_path(self, step: int) -> Path:
@@ -81,6 +82,6 @@ class CheckpointManager:
         self._save_to_path(ckpt_path, progress)
 
 
-def get_ckpt_manager(path: Path) -> CheckpointManager:
+def get_ckpt_manager(config: CheckpointConfig) -> CheckpointManager:
     """Returns a checkpoint manager for a given checkpoint directory."""
-    return CheckpointManager(path)
+    return CheckpointManager(config)

--- a/src/zeroband/training/orchestrator/ckpt.py
+++ b/src/zeroband/training/orchestrator/ckpt.py
@@ -1,0 +1,87 @@
+import time
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+
+from zeroband.utils.logger import get_logger
+
+
+@dataclass
+class Progress:
+    step: int = 0
+    total_tokens: int = 0
+    total_samples: int = 0
+    total_problems: int = 0
+
+
+class CheckpointManager:
+    """Utility class to save and load orchestrator checkpoints to resume orchestrator."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        self._logger = get_logger()
+
+    def _get_step_path(self, step: int) -> Path:
+        return self.path / f"step_{step}"
+
+    def _get_ckpt_path(self, step: int) -> Path:
+        return self._get_step_path(step) / "orchestrator.pt"
+
+    def _save_to_path(self, ckpt_path: Path, weight_ckpt_path: Path, progress: Progress):
+        self._logger.debug(f"Saving orchestrator checkpoint to {ckpt_path}")
+        start_time = time.time()
+
+        # Increment the progress step that is going to be saved
+        progress_copy = deepcopy(progress)
+        progress_copy.step += 1
+
+        # Create checkpoint state
+        ckpt_state = {
+            "weight_ckpt_path": weight_ckpt_path,
+            "progress": progress,
+        }
+
+        # Save checkpoint state
+        with open(ckpt_path, "wb") as f:
+            torch.save(ckpt_state, f)
+
+        self._logger.debug(f"Orchestrator checkpoint saved in {time.time() - start_time:.2f} seconds")
+
+    def load_from_path(self, ckpt_path: Path, progress: Progress) -> Path:
+        """Loads a checkpoint from a given path in-place."""
+        self._logger.debug(f"Loading checkpoint from {ckpt_path}")
+        start_time = time.time()
+
+        # Load checkpoint state
+        with open(ckpt_path, "rb") as f:
+            state = torch.load(f, weights_only=False)
+
+        # Load checkpoint state in-place
+        progress.step = state["progress"].step
+        progress.total_tokens = state["progress"].total_tokens
+        progress.total_samples = state["progress"].total_samples
+        progress.total_problems = state["progress"].total_problems
+
+        self._logger.debug(f"Orchestrator checkpoint loaded in {time.time() - start_time:.2f} seconds")
+        self._logger.info(f"Resuming from {progress=}")
+
+        return state["weight_ckpt_path"]
+
+    def save(
+        self,
+        weight_ckpt_path: Path,
+        progress: Progress,
+        step: int,
+    ):
+        """Saves the full checkpoint state for a specified step."""
+        step_path = self._get_step_path(step)
+        step_path.mkdir(parents=True, exist_ok=True)
+        ckpt_path = self._get_ckpt_path(step)
+        self._save_to_path(ckpt_path, weight_ckpt_path, progress)
+
+
+def get_ckpt_manager(path: Path) -> CheckpointManager:
+    """Returns a checkpoint manager for a given checkpoint directory."""
+    return CheckpointManager(path)

--- a/src/zeroband/training/orchestrator/ckpt.py
+++ b/src/zeroband/training/orchestrator/ckpt.py
@@ -39,7 +39,7 @@ class CheckpointManager:
         progress_copy.step += 1
 
         # Create checkpoint state
-        ckpt_state = {"progress": progress}
+        ckpt_state = {"progress": progress_copy}
 
         # Save checkpoint state
         with open(ckpt_path, "wb") as f:

--- a/src/zeroband/training/orchestrator/ckpt.py
+++ b/src/zeroband/training/orchestrator/ckpt.py
@@ -80,8 +80,3 @@ class CheckpointManager:
         step_path.mkdir(parents=True, exist_ok=True)
         ckpt_path = self._get_ckpt_path(step)
         self._save_to_path(ckpt_path, progress)
-
-
-def get_ckpt_manager(config: CheckpointConfig) -> CheckpointManager:
-    """Returns a checkpoint manager for a given checkpoint directory."""
-    return CheckpointManager(config)

--- a/src/zeroband/training/orchestrator/client.py
+++ b/src/zeroband/training/orchestrator/client.py
@@ -61,7 +61,7 @@ async def reload_weights(client: AsyncOpenAI, path: Path, step: int) -> None:
     """Make a HTTP post request to the vLLM server to reload the weights."""
     logger = get_logger()
     url = str(client.base_url)[:-4] + "/reload_weights"
-    model_path = path / f"step_{step}" / "model.pt"
+    model_path = path / f"step_{step}" / "pytorch_model.bin"
     logger.debug(f"Sending request to {url} to reload weights from {model_path}")
     await client.post(url, cast_to=Response, body={"model_path": model_path.as_posix()})
 

--- a/src/zeroband/training/orchestrator/config.py
+++ b/src/zeroband/training/orchestrator/config.py
@@ -195,7 +195,7 @@ class OrchestratorConfig(BaseSettings):
     monitor: MultiMonitorConfig = MultiMonitorConfig()
 
     # The checkpoint configuration
-    ckpt: CheckpointConfig = CheckpointConfig()
+    ckpt: CheckpointConfig | None = None
 
     collate_mode: Annotated[Literal["packing", "padding"], Field(description="Collate mode to use.")] = "padding"
 

--- a/src/zeroband/training/orchestrator/config.py
+++ b/src/zeroband/training/orchestrator/config.py
@@ -164,6 +164,7 @@ class CheckpointConfig(BaseConfig):
     resume_step: Annotated[
         int | None,
         Field(
+            ge=1,
             description="Step to resume orchestrator from. If None, will start from scratch.",
         ),
     ] = None

--- a/src/zeroband/training/orchestrator/config.py
+++ b/src/zeroband/training/orchestrator/config.py
@@ -214,7 +214,7 @@ class OrchestratorConfig(BaseSettings):
         Field(
             description="Sequence length to use for training. If a sample is shorter than this, it will be padded. If a sequence is longer than this, it will be truncated.",
         ),
-    ] = 1024
+    ] = 2048
 
     # TODO(Mika): This should be automatic from the number of ZMQ connections
     num_train_workers: Annotated[

--- a/src/zeroband/training/orchestrator/config.py
+++ b/src/zeroband/training/orchestrator/config.py
@@ -236,14 +236,14 @@ class OrchestratorConfig(BaseSettings):
         Field(
             description="Path to write inference outputs to. Will be populated by the orchestrator with responses from inference pool.",
         ),
-    ] = PathConfig(path=Path("rollouts"), clean=True)
+    ] = PathConfig(path=Path("rollouts"))
 
     weights: Annotated[
         PathConfig,
         Field(
             description="Path to read updated model weights from. Will be populated by the trainer.",
         ),
-    ] = PathConfig(path=Path("weights"), clean=True)
+    ] = PathConfig(path=Path("weights"))
 
     seed: Annotated[int | None, Field(description="Random seed for the orchestrator.")] = None
 

--- a/src/zeroband/training/orchestrator/config.py
+++ b/src/zeroband/training/orchestrator/config.py
@@ -115,19 +115,6 @@ class DataConfig(BaseConfig):
     split: Annotated[str, Field(description="Split of the dataset to use.")] = "train"
 
 
-class PathConfig(BaseConfig):
-    """Configures a path used for input/ output operations"""
-
-    path: Annotated[Path, Field(description="Path to write to.")]
-
-    clean: Annotated[
-        bool,
-        Field(
-            description="Whether to clean the path at the beginning of the run. If True, will delete the entire directory.",
-        ),
-    ] = False
-
-
 class OnlineEvalConfig(BaseConfig):
     """Configures online evaluation."""
 
@@ -174,10 +161,10 @@ class CheckpointConfig(BaseConfig):
 
     interval: Annotated[int, Field(ge=1, description="Interval at which to save the checkpoint.")] = 50
 
-    resume_path: Annotated[
-        Path | None,
+    resume_step: Annotated[
+        int | None,
         Field(
-            description="Checkpoint path to resume orchestrator from. If None, will start from scratch.",
+            description="Step to resume orchestrator from. If None, will start from scratch.",
         ),
     ] = None
 
@@ -249,19 +236,26 @@ class OrchestratorConfig(BaseSettings):
         ),
     ] = 2
 
-    rollout: Annotated[
-        PathConfig,
+    rollout_path: Annotated[
+        Path,
         Field(
             description="Path to write inference outputs to. Will be populated by the orchestrator with responses from inference pool.",
         ),
-    ] = PathConfig(path=Path("rollouts"))
+    ] = Path("rollouts")
 
-    weights: Annotated[
-        PathConfig,
+    weights_path: Annotated[
+        Path,
         Field(
             description="Path to read updated model weights from. Will be populated by the trainer.",
         ),
-    ] = PathConfig(path=Path("weights"))
+    ] = Path("weights")
+
+    clean: Annotated[
+        bool,
+        Field(
+            description="Whether to clean the rollouts, checkpoint, checkpoint weights and logs directories at the beginning of the run. If True, will forceably, and irreversibly, delete all directories.",
+        ),
+    ] = False
 
     seed: Annotated[int | None, Field(description="Random seed for the orchestrator.")] = None
 

--- a/src/zeroband/training/orchestrator/config.py
+++ b/src/zeroband/training/orchestrator/config.py
@@ -167,6 +167,21 @@ class EvalConfig(BaseConfig):
     online: Annotated[OnlineEvalConfig | None, Field(description="Whether to do online evaluation.")] = None
 
 
+class CheckpointConfig(BaseConfig):
+    """Configures checkpointing the orchestrator."""
+
+    path: Annotated[Path, Field(description="Directory to write checkpoints to.")] = Path("checkpoints")
+
+    interval: Annotated[int, Field(ge=1, description="Interval at which to save the checkpoint.")] = 50
+
+    resume_path: Annotated[
+        Path | None,
+        Field(
+            description="Checkpoint path to resume orchestrator from. If None, will start from scratch.",
+        ),
+    ] = None
+
+
 class OrchestratorConfig(BaseSettings):
     """Configures the orchestrator for RL training."""
 
@@ -190,6 +205,9 @@ class OrchestratorConfig(BaseSettings):
 
     # The monitor configuration
     monitor: MultiMonitorConfig = MultiMonitorConfig()
+
+    # The checkpoint configuration
+    ckpt: CheckpointConfig = CheckpointConfig()
 
     collate_mode: Annotated[Literal["packing", "padding"], Field(description="Collate mode to use.")] = "padding"
 

--- a/src/zeroband/training/orchestrator/orchestrator.py
+++ b/src/zeroband/training/orchestrator/orchestrator.py
@@ -119,7 +119,7 @@ async def orchestrate(config: OrchestratorConfig, setup_queue: Queue | None = No
     max_steps = config.max_steps - progress.step if config.max_steps else None
     steps_per_epoch = len(dataset) // (config.batch_size // config.sampling.n)
     logger.info(f"Starting training loop ({max_steps=}, {steps_per_epoch=})")
-    ckpt_step = progress.step - config.async_level
+    ckpt_step = max(progress.step - config.async_level, 0)
     last_eval_step = -1
     while True:
         if max_steps and progress.step >= max_steps:
@@ -255,8 +255,7 @@ async def orchestrate(config: OrchestratorConfig, setup_queue: Queue | None = No
         if config.ckpt and config.ckpt.interval and (progress.step + 1) % config.ckpt.interval == 0:
             logger.debug(f"Saving checkpoint at step {progress.step}")
             save_ckpt_start_time = time.time()
-            model_path = config.weights_path / f"step_{ckpt_step}" / "model.pt"
-            ckpt_manager.save(model_path, progress, step=progress.step + 1)
+            ckpt_manager.save(progress, step=progress.step + 1)
             save_ckpt_time = time.time() - save_ckpt_start_time
 
         step_path = Path(config.rollout_path) / f"step_{progress.step}"

--- a/src/zeroband/training/orchestrator/orchestrator.py
+++ b/src/zeroband/training/orchestrator/orchestrator.py
@@ -16,7 +16,7 @@ from datasets import Dataset, load_dataset
 from transformers import AutoTokenizer
 
 from zeroband.eval.utils import run_benchmark
-from zeroband.training.orchestrator.ckpt import get_ckpt_manager, Progress
+from zeroband.training.orchestrator.ckpt import CheckpointManager, Progress
 from zeroband.training.orchestrator.client import (
     check_has_model,
     check_health,
@@ -89,7 +89,7 @@ async def orchestrate(config: OrchestratorConfig, setup_queue: Queue | None = No
 
     # Get checkpoint manager
     if config.ckpt:
-        ckpt_manager = get_ckpt_manager(config.ckpt)
+        ckpt_manager = CheckpointManager(config.ckpt)
 
     # Reset weights to base model if starting from scratch
     progress = Progress()

--- a/src/zeroband/training/orchestrator/orchestrator.py
+++ b/src/zeroband/training/orchestrator/orchestrator.py
@@ -56,8 +56,9 @@ async def orchestrate(config: OrchestratorConfig, setup_queue: Queue | None = No
     # Prepare paths to communicate with the trainer
     if config.clean:
         logger.info("Cleaning checkpoint, logs, checkpoint weights and rollout directories")
-        logger.debug(f"Cleaning checkpoint path ({config.ckpt.path})")
-        shutil.rmtree(config.ckpt.path, ignore_errors=True)
+        if config.ckpt:
+            logger.debug(f"Cleaning checkpoint path ({config.ckpt.path})")
+            shutil.rmtree(config.ckpt.path, ignore_errors=True)
 
         logger.debug(f"Cleaning logs path ({config.log.path})")
         shutil.rmtree(config.log.path, ignore_errors=True)
@@ -87,12 +88,13 @@ async def orchestrate(config: OrchestratorConfig, setup_queue: Queue | None = No
     logger.success("Inference pool ready")
 
     # Get checkpoint manager
-    ckpt_manager = get_ckpt_manager(config.ckpt.path)
+    if config.ckpt:
+        ckpt_manager = get_ckpt_manager(config.ckpt)
 
     # Reset weights to base model if starting from scratch
     progress = Progress()
     ckpt_step = 0
-    if config.ckpt.resume_step:
+    if config.ckpt and config.ckpt.resume_step:
         logger.info(f"Resuming training from checkpoint step `{config.ckpt.resume_step}`")
         ckpt_manager.load(progress, step=config.ckpt.resume_step)
         ckpt_step = max(progress.step - config.async_level, 0)

--- a/src/zeroband/training/orchestrator/orchestrator.py
+++ b/src/zeroband/training/orchestrator/orchestrator.py
@@ -56,15 +56,16 @@ async def orchestrate(config: OrchestratorConfig, setup_queue: Queue | None = No
     # Prepare paths to communicate with the trainer
     if config.clean:
         logger.info("Cleaning checkpoint, logs, checkpoint weights and rollout directories")
-        if config.ckpt:
+        if not (config.ckpt and config.ckpt.resume_step): # Only clean if we don't resume
             logger.debug(f"Cleaning checkpoint path ({config.ckpt.path})")
             shutil.rmtree(config.ckpt.path, ignore_errors=True)
 
         logger.debug(f"Cleaning logs path ({config.log.path})")
         shutil.rmtree(config.log.path, ignore_errors=True)
 
-        logger.debug(f"Cleaning checkpoint weights path ({config.weights_path})")
-        shutil.rmtree(config.weights_path, ignore_errors=True)
+        if not (config.ckpt and config.ckpt.resume_step): # Only clean if we don't resume
+            logger.debug(f"Cleaning checkpoint weights path ({config.weights_path})")
+            shutil.rmtree(config.weights_path, ignore_errors=True)
 
         logger.debug(f"Cleaning rollout path ({config.rollout_path})")
         shutil.rmtree(config.rollout_path, ignore_errors=True)

--- a/src/zeroband/training/orchestrator/utils.py
+++ b/src/zeroband/training/orchestrator/utils.py
@@ -48,7 +48,7 @@ def parse_completions(chat_completions: list[ChatCompletion]) -> list[str]:
 
 
 def wait_for_weight_checkpoint(path: Path, step: int, interval: int = 1, log_interval: int = 10) -> None:
-    model_path = Path(path) / f"step_{step}" / "model.pt"
+    model_path = Path(path) / f"step_{step}" / "pytorch_model.bin"
     wait_for_path(model_path, interval, log_interval)
 
 

--- a/src/zeroband/training/train.py
+++ b/src/zeroband/training/train.py
@@ -301,7 +301,7 @@ def train(config: TrainingConfig):
 
         # Optionally, save the full checkpoint
         save_ckpt_time = 0
-        if config.ckpt and config.ckpt.interval and progress.step % config.ckpt.interval == 0:
+        if config.ckpt and config.ckpt.interval and progress.step > 0 and progress.step % config.ckpt.interval == 0:
             logger.debug(f"Saving checkpoint at step {progress.step}")
             save_ckpt_start_time = time.time()
             ckpt_manager.save(model, [optimizer], progress, progress.step)

--- a/src/zeroband/training/train.py
+++ b/src/zeroband/training/train.py
@@ -122,15 +122,16 @@ def train(config: TrainingConfig):
     if config.recompute_logprobs:
         logger.info(f"Initializing logprob model ({config.model})")
         infer_step = max(progress.step - config.async_level, 0)
-        model_name = (
-            config.model if not config.ckpt.resume_step else config.weights.path / f"step_{infer_step}" / "model.pt"
+        model_name_or_path = (
+            config.model.name if not config.ckpt.resume_step else config.weights.path / f"step_{infer_step}"
         )
-        model.config.name = model_name
-        logprob_model = setup_model(model.config)
+        config.model.name = model_name_or_path
+        logprob_model = setup_model(config.model)
 
         # Offload the logprob model to CPU
         tensor_offloaded_repository: dict[int, OffloadedTensor] = {}
-        tensor_offloaded_repository[infer_step] = offload_model_to_cpu(logprob_model)
+        for async_step in range(infer_step, progress.step):
+            tensor_offloaded_repository[async_step] = offload_model_to_cpu(logprob_model)
 
     # Set up the data loader (Optionally, use a fake data loader for debugging)
     logger.info(f"Initializing data loader ({config.data})")

--- a/src/zeroband/training/train.py
+++ b/src/zeroband/training/train.py
@@ -304,7 +304,8 @@ def train(config: TrainingConfig):
         if config.ckpt and config.ckpt.interval and progress.step > 0 and progress.step % config.ckpt.interval == 0:
             logger.debug(f"Saving checkpoint at step {progress.step}")
             save_ckpt_start_time = time.time()
-            ckpt_manager.save(model, [optimizer], progress, progress.step)
+            # We increment because the model is already updated, but the step doesn't reflect that yet
+            ckpt_manager.save(model, [optimizer], progress, progress.step + 1)
             save_ckpt_time = time.time() - save_ckpt_start_time
 
         # Update the CPU logprob model to updated model

--- a/src/zeroband/training/train.py
+++ b/src/zeroband/training/train.py
@@ -19,8 +19,8 @@ from zeroband.training.ckpt import (
     TrainingProgress,
     load_full_checkpoint,
     save_full_checkpoint,
-    save_weight_checkpoint,
 )
+from zeroband.training.weights import save_weight_checkpoint
 from zeroband.training.config import TrainingConfig
 from zeroband.training.data import DataLoader, FakeDataLoader
 from zeroband.training.logger import setup_logger

--- a/src/zeroband/training/train.py
+++ b/src/zeroband/training/train.py
@@ -111,11 +111,12 @@ def train(config: TrainingConfig):
     )
 
     # Get checkpoint manager
-    ckpt_manager = get_ckpt_manager(config.ckpt)
+    if config.ckpt:
+        ckpt_manager = get_ckpt_manager(config.ckpt)
 
     # Optionally, resume training from a checkpoint
     progress = Progress()
-    if config.ckpt.resume_step:
+    if config.ckpt and config.ckpt.resume_step:
         logger.info(f"Resuming training from checkpoint step `{config.ckpt.resume_step}`")
         ckpt_manager.load(model, [optimizer], progress, step=config.ckpt.resume_step)
 
@@ -127,7 +128,9 @@ def train(config: TrainingConfig):
         for async_step in range(infer_step, progress.step + 1):
             logger.info(f"Initializing logprob model ({config.model}) for step {async_step}")
             model_name_or_path = (
-                config.model.name if not config.ckpt.resume_step else config.weights.path / f"step_{async_step}"
+                config.model.name
+                if not (config.ckpt and config.ckpt.resume_step)
+                else config.weights.path / f"step_{async_step}"
             )
             model_config = deepcopy(config.model)
             model_config.name = model_name_or_path

--- a/src/zeroband/training/train.py
+++ b/src/zeroband/training/train.py
@@ -123,12 +123,13 @@ def train(config: TrainingConfig):
         betas=(config.optim.betas1, config.optim.betas2),
     )
 
+    # Get checkpoint manager
     ckpt_manager = get_ckpt_manager(config.ckpt.path)
 
     # Optionally, resume training from a checkpoint
     progress = Progress()
     if config.ckpt.resume_path:
-        logger.info(f"Resuming training from checkpoint path `{config.ckpt.resume_path.as_posix()}`")
+        logger.info(f"Resuming training from checkpoint path `{config.ckpt.resume_path}`")
         ckpt_manager.load_from_path(config.ckpt.resume_path, model, [optimizer], progress)
 
     # Set up the data loader (Optionally, use a fake data loader for debugging)

--- a/src/zeroband/training/train.py
+++ b/src/zeroband/training/train.py
@@ -16,7 +16,7 @@ import torch
 import torch.distributed as dist
 from torch._guards import log as torch_log
 
-from zeroband.training.ckpt import get_ckpt_manager, Progress
+from zeroband.training.ckpt import CheckpointManager, Progress
 from zeroband.training.weights import save_weight_checkpoint
 from zeroband.training.config import TrainingConfig
 from zeroband.training.data import DataLoader, FakeDataLoader
@@ -112,7 +112,7 @@ def train(config: TrainingConfig):
 
     # Get checkpoint manager
     if config.ckpt:
-        ckpt_manager = get_ckpt_manager(config.ckpt)
+        ckpt_manager = CheckpointManager(config.ckpt)
 
     # Optionally, resume training from a checkpoint
     progress = Progress()

--- a/src/zeroband/training/train.py
+++ b/src/zeroband/training/train.py
@@ -101,6 +101,14 @@ def train(config: TrainingConfig):
     model = setup_model(config.model)
     tokenizer = get_tokenizer(config.model)
 
+    # Set up the optimizer
+    optimizer = torch.optim.AdamW(
+        params=model.parameters(),
+        lr=config.optim.lr,
+        weight_decay=config.optim.weight_decay,
+        betas=(config.optim.betas1, config.optim.betas2),
+    )
+
     # Get checkpoint manager
     ckpt_manager = get_ckpt_manager(config.ckpt.path)
 
@@ -118,14 +126,6 @@ def train(config: TrainingConfig):
         # Offload the logprob model to CPU
         tensor_offloaded_repository: dict[int, OffloadedTensor] = {}
         tensor_offloaded_repository[progress.step] = offload_model_to_cpu(logprob_model)
-
-    # Set up the optimizer
-    optimizer = torch.optim.AdamW(
-        params=model.parameters(),
-        lr=config.optim.lr,
-        weight_decay=config.optim.weight_decay,
-        betas=(config.optim.betas1, config.optim.betas2),
-    )
 
     # Set up the data loader (Optionally, use a fake data loader for debugging)
     logger.info(f"Initializing data loader ({config.data})")

--- a/src/zeroband/training/train.py
+++ b/src/zeroband/training/train.py
@@ -124,7 +124,7 @@ def train(config: TrainingConfig):
         # Offload the logprob model to CPU
         tensor_offloaded_repository: dict[int, OffloadedTensor] = {}
         infer_step = max(progress.step - config.async_level, 0)
-        for async_step in range(infer_step, progress.step):
+        for async_step in range(infer_step, progress.step + 1):
             logger.info(f"Initializing logprob model ({config.model}) for step {async_step}")
             model_name_or_path = (
                 config.model.name if not config.ckpt.resume_step else config.weights.path / f"step_{async_step}"

--- a/src/zeroband/training/train.py
+++ b/src/zeroband/training/train.py
@@ -111,7 +111,7 @@ def train(config: TrainingConfig):
     )
 
     # Get checkpoint manager
-    ckpt_manager = get_ckpt_manager(config.ckpt.path)
+    ckpt_manager = get_ckpt_manager(config.ckpt)
 
     # Optionally, resume training from a checkpoint
     progress = Progress()

--- a/src/zeroband/training/train.py
+++ b/src/zeroband/training/train.py
@@ -291,11 +291,11 @@ def train(config: TrainingConfig):
         logger.debug(f"Considering to delete weight checkpoint {candidate_path_to_delete}")
         candidate_weight_step_to_delete = int(candidate_path_to_delete.name.split("_")[-1])
         keep_for_eval = config.weights.interval and candidate_weight_step_to_delete % config.weights.interval == 0
-        # For checkpointing step x, we need all checkpoints in [x-async_level, x]
-        # To get [n-k, n] for all n in natural numbers, we do (n - (n % k)) % n
+        # For checkpointing step x, we need all weight checkpoints in [x-async_level, x] (for logprob model)
+        # To get [n-k, n] with interval n and buffer k over all natural numbers x, we use the condition (n - (x % n)) % n <= k
         keep_for_ckpt = config.ckpt and (config.ckpt.interval - (candidate_weight_step_to_delete % config.ckpt.interval)) % config.ckpt.interval <= config.async_level 
         if not (keep_for_eval or keep_for_ckpt):
-            logger.debug(f"Removing past weight checkpoint {candidate_path_to_delete}")
+            logger.debug(f"Removing past weight checkpoint {candidate_path_to_delete} ({keep_for_eval=}, {keep_for_ckpt=})")
             shutil.rmtree(candidate_path_to_delete, ignore_errors=True)
 
         # Optionally, dump memory snapshot

--- a/src/zeroband/training/weights.py
+++ b/src/zeroband/training/weights.py
@@ -1,0 +1,82 @@
+import threading
+import time
+from pathlib import Path
+
+import torch
+from torch.distributed.checkpoint.state_dict import _get_fqns as get_fqns
+from torch.distributed.tensor import DTensor
+from transformers import AutoTokenizer
+
+from zeroband.training.model import Model
+from zeroband.training.world import get_world
+from zeroband.utils.logger import get_logger
+
+
+def save_weight_checkpoint(
+    model: Model,
+    tokenizer: AutoTokenizer,
+    path: Path,
+    dtype: torch.dtype = torch.bfloat16,
+    async_save: bool = False,
+) -> Path:
+    """
+    Save a HF-compatible weight-only checkpoint to the specified path. Saves the
+    model weights as `model.pt`, the model config, generation arguments and tokenizer
+    using HF's `save_pretrained` method.
+    """
+    # Get logger and world info
+    logger = get_logger()
+    is_master = get_world().rank == 0
+
+    # Create checkpoint directory if it doesn't exist
+    if not path.exists():
+        path.mkdir(parents=True, exist_ok=True)
+
+    # Gather distributed weights for weight checkpoint
+    start_time = time.time()
+    logger.debug("Gathering sharded weights")
+    cpu_state = {}
+    for key, value in model.state_dict().items():
+        if isinstance(value, DTensor):
+            value = value.to(dtype)
+            # only gather after the downcast to dtype as it will be faster
+            value = value.full_tensor()
+
+        if is_master:
+            key = get_fqns(model, key)
+            assert len(key) == 1
+            key = next(iter(key))
+            # TODO(Sami) Blocking to avoid race condition, should make non-blocking long-term tho
+            cpu_state[key] = value.to("cpu", non_blocking=False)
+
+    torch.distributed.barrier()
+    logger.debug(f"Gathered sharded weights in {time.time() - start_time:.2f} seconds")
+
+    model_path = path / "model.pt"
+
+    def _save_weight_checkpoint():
+        if is_master:
+            start_time = time.time()
+            logger.debug(f"Saving weights to {path}")
+
+            # Save model weights to temporary file to avoid race condition
+            tmp_model_path = path / "model.pt.tmp"
+            torch.save(cpu_state, tmp_model_path)
+
+            # Rename temporary file to indicate checkpoint is complete
+            tmp_model_path.rename(model_path)
+
+            # Save model config, generation arguments and tokenizer
+            model.config.save_pretrained(path)
+            model.generation_config.save_pretrained(path)
+            tokenizer.save_pretrained(path)
+
+            logger.debug(f"Saved weights to {path} in {time.time() - start_time:.2f} seconds")
+
+    if async_save:
+        thread = threading.Thread(target=_save_weight_checkpoint)
+        thread.start()
+    else:
+        _save_weight_checkpoint()
+
+    return model_path

--- a/src/zeroband/training/weights.py
+++ b/src/zeroband/training/weights.py
@@ -21,7 +21,7 @@ def save_weight_checkpoint(
 ) -> Path:
     """
     Save a HF-compatible weight-only checkpoint to the specified path. Saves the
-    model weights as `model.pt`, the model config, generation arguments and tokenizer
+    model weights as `pytorch_model.bin`, the model config, generation arguments and tokenizer
     using HF's `save_pretrained` method.
     """
     # Get logger and world info
@@ -52,7 +52,7 @@ def save_weight_checkpoint(
     torch.distributed.barrier()
     logger.debug(f"Gathered sharded weights in {time.time() - start_time:.2f} seconds")
 
-    model_path = path / "model.pt"
+    model_path = path / "pytorch_model.bin"
 
     def _save_weight_checkpoint():
         if is_master:
@@ -60,7 +60,7 @@ def save_weight_checkpoint(
             logger.debug(f"Saving weights to {path}")
 
             # Save model weights to temporary file to avoid race condition
-            tmp_model_path = path / "model.pt.tmp"
+            tmp_model_path = model_path.with_suffix(".tmp")
             torch.save(cpu_state, tmp_model_path)
 
             # Rename temporary file to indicate checkpoint is complete

--- a/src/zeroband/utils/config.py
+++ b/src/zeroband/utils/config.py
@@ -94,6 +94,13 @@ class WandbMonitorConfig(BaseConfig):
         ),
     ] = None
 
+    id: Annotated[
+        str | None,
+        Field(
+            description="The W&B run ID to log to. If None, a random ID will be generated. If you want to resume a run, you can set the ID to the run ID you want to resume.",
+        ),
+    ] = None
+
     dir: Annotated[
         Path | None,
         Field(

--- a/src/zeroband/utils/monitor.py
+++ b/src/zeroband/utils/monitor.py
@@ -137,7 +137,9 @@ class WandbMonitor(Monitor):
             project=config.project,
             group=config.group,
             name=config.name,
+            id=config.id,
             dir=config.dir,
+            resume="allow",
             config=run_config.model_dump() if run_config else None,
             mode="offline" if config.offline else None,
         )


### PR DESCRIPTION
This PR implements resuming training from a checkpoint. This requires writing checkpoints from both the trainer and orchestrator:
- Trainer checkpoint includes full (FSDP) weights, optimizer states and progress information
- Orchestrator checkpoint just includes progress information
- Implicitly, an `async_level + 1`-sized buffer of the weights checkpoints (which is written by default) is assumed to be present to reload the inference engine's model weights and initialize the CPU-offloaded logprob models

We build the `CheckpointManager` abstraction for both submodules that keeps state and logic about how to write and read from checkpoint paths:
- The main public methods are `save` and `load` which take the checkpoint elements (model, optimizer, etc.) as args and a step
- It converts the step into a specified ckpt path format, e.g. for the trainer it is `{config.ckpt.path}/step_{x}/trainer.pt`  for single GPU and  `{config.ckpt.path}/step_{x}/trainer_{local_rank}.pt` for multi-GPU training
- We use simply `torch.load` and `torch.save` for (de)serialization, with saving being optionally async for the trainer 

To resume a training we pass the `ckpt.resume_step` which will use the internal logic of the ckpt manager to resolve the ckpt path and load the checkpoint. If no checkpoint is present, we raise.

Other misc things that were changed in the meantime:
- The orchestrator loop is now also `while` loop incrementing and breaking based on `progress.step`
- Logging some timing metrics as `time/orchestrator/...` instead of `time/infer` where appropriate 
- The orchestrator is now in charge of cleaning up all runtime directories, e.g. `rollouts`, `checkpoints`, `weights` and `logs` with a single configurable flag `--clean` (set to False by default)

<img width="302" alt="Screenshot 2025-07-08 at 3 38 07 PM" src="https://github.com/user-attachments/assets/870c94cd-1ab7-4a12-9373-2de95e35cdb0" />

<img width="283" alt="Screenshot 2025-07-08 at 3 38 33 PM" src="https://github.com/user-attachments/assets/b75577eb-6c14-44f2-88f3-335c10f424d6" />

### Example

**Without W&B**

Train for 10 steps and asve a final checkpoint

```bash
CUDA_VISIBLE_DEVICES=1 uv run train @ configs/training/reverse_text.toml --ckpt.path checkpoints --ckpt.interval 10 --max-steps 10 --log.level debug --orchestrator.clean
```

Then, resume from the step 10 checkpoints

```bash
CUDA_VISIBLE_DEVICES=1 uv run train @ configs/training/reverse_text.toml --ckpt.resume_step 10 --log.level debug
```

**With W&B** (https://wandb.ai/primeintellect/mika-testing?nw=nwusermikasenghaas_)

Train for 10 steps and save a checkpoint

```bash
CUDA_VISIBLE_DEVICES=1 uv run train @ configs/training/reverse_text.toml --ckpt.path checkpoints --ckpt.interval 10 --max-steps 10 --log.level debug --orchestrator.clean --monitor.wandb.project mika-testing --monitor.wandb.group resume
```

```bash
CUDA_VISIBLE_DEVICES=1 uv run train @ configs/training/reverse_text.toml --log.level debug --monitor.wandb.project mika-testing --monitor.wandb.group resume --ckpt.resume-step 10 --monitor.wandb.id em8ezjtg --orchestrator.monitor.wandb.id 5f62qtix
```

**Large Run** (https://wandb.ai/primeintellect/math-debug/groups/resume-baseline/workspace?nw=nwusermikasenghaas_)

Replicating training from ckpt on simple math run. Baseline is training cleanly for 200 steps and writing a checkpoint at 100 steps. Then, training off the checkpoint and hoping to match the training trajectory of the baseline.

```bash
# Trainer
CUDA_VISIBLE_DEVICES=6,7 uv run torchrun --nproc-per-node 2 src/zeroband/training/train.py @ configs/training/simple_math.toml --max-steps 50 --ckpt.interval 10 --log.level debug --monitor.wandb.group resume-baseline --orchestrator.clean --orchestrator.sampling.seed 10 
```

```bash
# Inference
uv run infer @ configs/inference/simple_math.toml --parallel.dp 6
```

Then, resume the training from checkpoint step 10

```
CUDA_VISIBLE_DEVICES=6,7 uv run torchrun --nproc-per-node 2 src/zeroband/training/train.py @ configs/training/simple_math.toml --max-steps 50 --ckpt.resume-step 10 --log.level debug --monitor.wandb.group resume-from-10 --orchestrator.sampling.seed 10 --orchestrator.clean 
```

TODOs:
- [x] Save train checkpoint asynchronously
- [x] Implement orchestrator checkpoint
- [x] Integrate with `wandb` resume logic
- [x] Validate on larger run with two trainers