### PR TITLE
Fix W&B eval logs

### DIFF
--- a/src/prime_rl/eval/eval.py
+++ b/src/prime_rl/eval/eval.py
@@ -49,7 +49,7 @@ async def eval(config: EvalConfig):
             benchmark,
             config.model,
             config.sampling,
-            step=0,
+            ckpt_step=0,
             monitor=monitor,
         )
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -156,8 +156,9 @@ async def orchestrate(config: OrchestratorConfig):
                     benchmark,
                     config.model,
                     config.sampling,
-                    ckpt_step,
+                    ckpt_step=ckpt_step,
                     monitor=monitor,
+                    step=progress.step,
                 )
             time_eval = time.time() - time_before_evals
             logger.info(f"Evaluated in {time_eval:.2f}s")
@@ -267,7 +268,7 @@ async def orchestrate(config: OrchestratorConfig):
             "progress/orchestrator/total_tokens": progress.total_tokens,
             "progress/orchestrator/total_samples": progress.total_samples,
             "progress/orchestrator/epoch": progress.epoch,
-            "progress/orchestrator/step": ckpt_step,  # Shared W&B axis
+            "progress/ckpt_step": ckpt_step,  # Shared W&B axis
             "step": progress.step,
         }
         monitor.log(progress_metrics)

--- a/src/prime_rl/utils/monitor.py
+++ b/src/prime_rl/utils/monitor.py
@@ -253,7 +253,6 @@ class MultiMonitor:
     def log(
         self,
         metrics: dict[str, Any],
-        wandb_prefix: str | None = None,
         exclude: list[MonitorType] = [],
     ) -> None:
         """Logs metrics to all outputs."""
@@ -263,12 +262,6 @@ class MultiMonitor:
         self.logger.debug(f"Logging metrics: {metrics}")
         for output_type, output in self.outputs.items():
             if output_type not in exclude:
-                if output_type == "wandb" and wandb_prefix is not None:
-                    step = metrics.pop("step", None)
-                    metrics = {
-                        **{f"{wandb_prefix}/{k}": v for k, v in metrics.items()},
-                        "step": step,
-                    }
                 output.log(metrics)
 
     def _set_has_gpu(self) -> bool:


### PR DESCRIPTION
Fixes an issue where only the ckpt_step=0 eval logs would appear in W&B. This was caused by us using (somewhat correctly) trying to log with the `ckpt_step` as x-axis, but because the inference step is async_level ahead it's an outdated step which is not allowed by W&B. No idea why it fails silently tho. Now we log with inferece step, so we log at `0`, `interval+async_level`, `2*interval+async_level`, ... and we also log the ckpt step as `progress/ckpt_step` so that we can change the x-axis in W&B if we want to

<img width="288" height="244" alt="Screenshot 2025-07-12 at 7 28 26 AM" src="https://github.com/user-attachments/assets/bdb15fab-ba0f-4e77-88be-00a5b436e338" />
