### PR TITLE
Multiple benchmarks

### DIFF
--- a/configs/orchestrator/hendrycks_math/1b.toml
+++ b/configs/orchestrator/hendrycks_math/1b.toml
@@ -20,6 +20,6 @@ num_samples = 16
 
 [eval]
 interval = 50
-benchmarks = ["math500"]
+benchmarks = ["math500", "aime24", "aime25"]
 
 [ckpt]

--- a/configs/orchestrator/hendrycks_math/7b.toml
+++ b/configs/orchestrator/hendrycks_math/7b.toml
@@ -19,6 +19,6 @@ num_samples = 16
 
 [eval]
 interval = 50
-benchmarks = ["math500"]
+benchmarks = ["math500", "aime24", "aime25"]
 
 [ckpt]

--- a/configs/orchestrator/intellect_math/1b.toml
+++ b/configs/orchestrator/intellect_math/1b.toml
@@ -25,7 +25,6 @@ num_samples = 16
 
 [eval]
 interval = 50
-benchmarks = ["math500"]
-eval_base_model = true
+benchmarks = ["math500", "aime24", "aime25"]
 
 [ckpt]

--- a/configs/orchestrator/intellect_math/7b.toml
+++ b/configs/orchestrator/intellect_math/7b.toml
@@ -25,6 +25,6 @@ num_samples = 16
 
 [eval]
 interval = 50
-benchmarks = ["math500"]
+benchmarks = ["math500", "aime24", "aime25"]
 
 [ckpt]

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -128,7 +128,7 @@ class EvalConfig(BaseConfig):
         Field(
             description="Whether to evaluate the base model we are training on.",
         ),
-    ] = False
+    ] = True
 
 
 class CheckpointConfig(BaseConfig):


### PR DESCRIPTION
- Runs the benchmarks in parallel, effectively enabling running arbitrarily many eval benchmarks at no time penalty (*at sampling.n for some reasonable number of benchmarks). For example, additionally evaluating AIME-24 and AIME-25 takes no more time because we can batch in the requests easily. For 1.5B at 2k context, takes ~30-40s and at 8k context ~2min. 
- I argue that with this little time penalty we always want to evaluate the base models as well for good measure (it's like doing one additional inference step), otherwise we are blind to the jump in performance we do in the first `interval` step. Hence, I set evaluate the base model by default, if evals are enabled. 
- We eval on all standard math benchmarks for `hendrycks-math` and `intellect-math`