### PR TITLE
Performance benchmarking

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,43 @@ CUDA_VISIBLE_DEVICES=1 uv run trainer @ configs/trainer/reverse_text.toml \
   --orchestrator.monitor.wandb.id <orchestrator-run-id>
 ```
 
+### Benchmarking
+
+We provide a convenient way to benchmark the performance of the inference engine and trainer using the `--bench` flag. It will run each module in isolation for a few steps and log performance statistics to the console and, optionally, W&B.
+
+**Inference**
+
+To benchmark inference, first spin up the inference server with an experiment configuration
+
+```bash
+uv run inference @ configs/inference/reverse_text.toml
+```
+
+Then, start the orchestrator with the matching configuration file in benchmark mode
+
+```bash
+uv run orchestrator @ configs/orchestrator/reverse_text.toml --bench
+```
+
+**Trainer**
+
+To benchmark the trainer, simply run the trainer against a fake data loader matching the way the orchestrator would write the training batch.
+
+```bash
+uv run trainer @ configs/trainer/reverse_text.toml --bench --data.fake "{'micro_batch_size': 8, 'batch_size': 128, 'seq_len': 128}"
+```
+
+**RL**
+
+Often it will be most convenient to benchmark the full RL run. This will automatically set the training batch configuration to match the way the orchestrator would have written it. Also, if W&B is configured for this project, it will synchronize the benchmark results to the project name, but suffixed with `-bench`.
+
+```bash
+uv run rl   \
+  --trainer @ configs/trainer/reverse_text.toml  \
+  --orchestrator @ configs/orchestrator/reverse_text.toml \
+  --inference @ configs/inference/reverse_text.toml \
+  --bench
+```
 
 ### Tests
 

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -270,7 +270,7 @@ class OrchestratorConfig(BaseSettings):
         return self
 
     @model_validator(mode="after")
-    def validate_bench(self):
+    def auto_setup_bench(self):
         if self.bench:
             self.max_steps = 6  # Run for 1 warmup step + 5 evaluation steps
             self.async_level = 1e9  # Never wait for RL weight checkpoints

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -16,7 +16,6 @@ from prime_rl.eval.utils import run_benchmark
 from prime_rl.orchestrator.ckpt import CheckpointManager, Progress
 from prime_rl.environments.registry import get_environment
 from prime_rl.orchestrator.client import (
-    tokenize,
     check_has_model,
     check_health,
     reload_weights,
@@ -47,7 +46,7 @@ async def orchestrate(config: OrchestratorConfig):
     # Print warning if running in benchmark mode
     if config.bench:
         logger.warning(
-            f"Running in benchmark model (max_steps={config.max_steps}, async_level={format_num(config.async_level, precision=0)})"
+            f"Running in benchmark mode (max_steps={config.max_steps}, async_level={format_num(config.async_level, precision=0)})"
         )
 
     # Setup client

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -34,7 +34,7 @@ from prime_rl.orchestrator.utils import (
 )
 from prime_rl.utils.monitor import setup_monitor
 from prime_rl.utils.pydantic_config import parse_argv
-from prime_rl.utils.utils import clean_exit, to_col_format
+from prime_rl.utils.utils import clean_exit, to_col_format, format_num
 
 
 @clean_exit
@@ -43,6 +43,12 @@ async def orchestrate(config: OrchestratorConfig):
     # Initialize the logger
     logger = setup_logger(config.log)
     logger.info("Starting orchestrator")
+
+    # Print warning if running in benchmark mode
+    if config.bench:
+        logger.warning(
+            f"Running in benchmark model (max_steps={config.max_steps}, async_level={format_num(config.async_level, precision=0)})"
+        )
 
     # Setup client
     logger.info(f"Initializing OpenAI client ({config.client.base_url})")

--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -132,7 +132,7 @@ def print_benchmark(history: dict[str, list[Any]]) -> None:
     df = pd.DataFrame(dict(history.items()))
     columns = {
         "perf/infer/throughput": "Throughput",
-        "time/infer": "Step Time",
+        "time/orchestrator": "Step Time",
     }
     df = df[columns.keys()].rename(columns=columns)
     df = df.iloc[1:]  # Exclude first row

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -17,7 +17,7 @@ from pydantic import Field, model_validator
 
 from prime_rl.inference.config import InferenceConfig
 from prime_rl.orchestrator.config import OrchestratorConfig
-from prime_rl.trainer.config import CheckpointConfig, TrainerConfig
+from prime_rl.trainer.config import CheckpointConfig, FakeDataLoaderConfig, TrainerConfig
 from prime_rl.utils.config import WandbMonitorConfig
 from prime_rl.utils.logger import format_message, format_time, get_logger, set_logger, setup_handlers
 from prime_rl.utils.pydantic_config import BaseSettings, get_temp_toml_file, parse_argv
@@ -55,6 +55,13 @@ class RLConfig(BaseSettings):
     trainer_gpus: Annotated[int, Field(description="The number of GPUs to use for trainer.")] = 1
     inference_gpus: Annotated[int, Field(description="The number of GPUs to use for inference.")] = 1
 
+    bench: Annotated[
+        bool,
+        Field(
+            description="Whether to run in benchmark mode. It will automatically set the trainer and orchestrator to benchmark mode and, if present, configure the W&B project to `<project>-bench`",
+        ),
+    ] = False
+
     clean: Annotated[
         bool,
         Field(
@@ -73,6 +80,26 @@ class RLConfig(BaseSettings):
             raise ValueError(
                 f"Total number of inference GPUs ({self.inference_gpus}) does not match the local sharding strategy ({self.inference.parallel.dp} DP + {self.inference.parallel.tp} TP)"
             )
+        return self
+
+    @model_validator(mode="after")
+    def auto_setup_bench(self):
+        if self.bench:
+            # Set trainer and orchestrator to benchmark mode
+            self.trainer.bench = True
+            self.orchestrator.bench = True
+
+            # Configure the trainer fake data to match the orchestrator config
+            self.trainer.data.fake = FakeDataLoaderConfig(
+                micro_batch_size=self.orchestrator.micro_batch_size,
+                batch_size=self.orchestrator.batch_size,
+                seq_len=self.orchestrator.seq_len,
+            )
+
+            # Suffix the W&B project with "-bench"
+            if self.trainer.monitor.wandb:
+                self.trainer.monitor.wandb.project = f"{self.trainer.monitor.wandb.project}-bench"
+
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -58,7 +58,7 @@ class RLConfig(BaseSettings):
     bench: Annotated[
         bool,
         Field(
-            description="Whether to run in benchmark mode. It will automatically set the trainer and orchestrator to benchmark mode and, if present, configure the W&B project to `<project>-bench`",
+            description="Whether to run in benchmark mode. It will automatically set the trainer and orchestrator to benchmark mode and, if present, configure the W&B project by suffixing the project with `-bench`.",
         ),
     ] = False
 
@@ -99,6 +99,11 @@ class RLConfig(BaseSettings):
             # Suffix the W&B project with "-bench"
             if self.trainer.monitor.wandb:
                 self.trainer.monitor.wandb.project = f"{self.trainer.monitor.wandb.project}-bench"
+                self.trainer.monitor.wandb.group = f"{torch.cuda.get_device_name(0)}"
+
+            # Disable evaluation
+            self.orchestrator.eval = None
+            self.orchestrator.monitor.wandb.log_samples = None
 
         return self
 

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -99,7 +99,6 @@ class RLConfig(BaseSettings):
             # Suffix the W&B project with "-bench"
             if self.trainer.monitor.wandb:
                 self.trainer.monitor.wandb.project = f"{self.trainer.monitor.wandb.project}-bench"
-                self.trainer.monitor.wandb.group = f"{torch.cuda.get_device_name(0)}"
 
             # Disable evaluation
             self.orchestrator.eval = None

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -208,3 +208,17 @@ class TrainerConfig(BaseSettings):
             description="Whether to recompute the logprobs. If True, will always recompute logprobs and overwrite those found in the training batch.",
         ),
     ] = True
+
+    bench: Annotated[
+        bool,
+        Field(
+            description="Whether to run in benchmark mode. It will automatically set the maximum number of steps to run to 5 and use fake data.",
+        ),
+    ] = False
+
+    @model_validator(mode="after")
+    def validate_bench(self):
+        if self.bench:
+            self.max_steps = 6  # 1 Warmup + 5 Benchmark
+            self.data.fake = FakeDataLoaderConfig()
+        return self

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -217,7 +217,7 @@ class TrainerConfig(BaseSettings):
     ] = False
 
     @model_validator(mode="after")
-    def validate_bench(self):
+    def auto_setup_bench(self):
         if self.bench:
             self.max_steps = 6  # 1 Warmup + 5 Benchmark
             self.data.fake = FakeDataLoaderConfig()

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -220,5 +220,6 @@ class TrainerConfig(BaseSettings):
     def auto_setup_bench(self):
         if self.bench:
             self.max_steps = 6  # 1 Warmup + 5 Benchmark
-            self.data.fake = FakeDataLoaderConfig()
+            if not self.data.fake:
+                self.data.fake = FakeDataLoaderConfig()
         return self

--- a/src/prime_rl/trainer/train.py
+++ b/src/prime_rl/trainer/train.py
@@ -26,11 +26,12 @@ from prime_rl.trainer.utils import (
     copy_model_to_cpu,
     offload_model_to_cpu,
     wake_up_model_from_cpu,
+    print_benchmark,
 )
 from prime_rl.trainer.world import get_world
 from prime_rl.utils.monitor import setup_monitor
 from prime_rl.utils.pydantic_config import parse_argv
-from prime_rl.utils.utils import clean_exit
+from prime_rl.utils.utils import clean_exit, to_col_format
 
 
 @clean_exit
@@ -40,6 +41,10 @@ def train(config: TrainerConfig):
     world = get_world()
     logger = setup_logger(config.log, world)
     logger.info(f"Starting trainer in {world}")
+
+    # Print warning if running in benchmark mode
+    if config.bench:
+        logger.warning(f"Running in benchmark mode (max_steps={config.max_steps}, {config.data.fake=})")
 
     # Setup the monitor
     logger.info(f"Initializing monitor ({config.monitor})")
@@ -349,6 +354,10 @@ def train(config: TrainerConfig):
 
     logger.info(f"Peak memory: {torch.cuda.max_memory_allocated() / 1024**3:.2f} GB")
     logger.success("Trainer finished!")
+
+    # Optionally, print benchmark table
+    if config.bench:
+        print_benchmark(to_col_format(monitor.history))
 
 
 def main():

--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -1,11 +1,15 @@
 from itertools import chain
-from typing import TypeAlias
+from typing import Any, TypeAlias
 
+import pandas as pd
 import torch
+from rich.console import Console
+from rich.table import Table
 from torch import Tensor
 from torch.distributed.tensor import DTensor
 
 from prime_rl.trainer.model import Model
+from prime_rl.utils.utils import format_num, format_time
 
 
 class FakeTokenizer:
@@ -67,3 +71,54 @@ def wake_up_model_from_cpu(model: Model, tensors: OffloadedTensor):
         data.untyped_storage().resize_(storage_size)
         data.copy_(cpu_data, non_blocking=True)
     torch.cuda.synchronize()
+
+
+def print_benchmark(history: dict[str, list[Any]]) -> None:
+    """
+    Print benchmark results as rich table. Shows formatted values for the
+    training throughput and overall step time. First first N rows show the
+    per-step values, and the last row shows the mean, std, min, and max values.
+    """
+    history.pop("step")
+    assert all(len(v) for v in history.values()), "All metrics must have logged the same number of steps"
+
+    # Turn metric history into pd.DataFrame
+    df = pd.DataFrame(dict(history.items()))
+    columns = {
+        "perf/train/throughput": "Throughput",
+        "time/train": "Step Time",
+    }
+    df = df[columns.keys()].rename(columns=columns)
+    df = df.iloc[1:]  # Exclude first row
+
+    # Setup console
+    console = Console()
+    table = Table(title="Benchmark")
+
+    # Add columns
+    table.add_column("Step", justify="right")
+    for col in df.columns:
+        table.add_column(col, justify="center", style="magenta")
+
+    # Add formatted rows
+    formatted_df = pd.DataFrame(columns=df.columns)
+    formatted_df["Step Time"] = df["Step Time"].apply(format_time)
+    formatted_df["Throughput"] = df["Throughput"].apply(format_num, precision=2)
+    for step, row in formatted_df.iterrows():
+        table.add_row(*([str(step)] + [str(x) for x in row]))
+
+    # Separator
+    table.add_row(*([""] * len(row)))
+
+    # Add row for formatted, aggregated statistics
+    mean_df = df.describe().loc[["mean", "std", "min", "max"], :]
+    formatted_mean_df = pd.DataFrame(columns=mean_df.columns)
+    formatted_mean_df["Step Time"] = mean_df["Step Time"].apply(format_time)
+    formatted_mean_df["Throughput"] = mean_df["Throughput"].apply(format_num, precision=2)
+    mean_row = ["Overall"] + formatted_mean_df.T.apply(
+        lambda row: f"{row['mean']} ± {row['std']} [{row['min']}, {row['max']}]", axis=1
+    ).tolist()
+    table.add_row(*mean_row)
+
+    # Display table
+    console.print(table)


### PR DESCRIPTION
This PR improves the ability to semi-automatically benchmark the orchestrator, trainer and both together in an RL run - usually tied to experiment TOML files.

## Features

- Convenient flag `--bench` on all components which will automatically set configs to run the benchmark correctly (e.g. run 1 warmup step and 5 benchmark steps)
- Prints a nicely formatted `rich` table showing the results locally
- Fully integrated with W&B, such that benchmark results are written to the project name, suffixed with `-bench`. Example for `hendrycks-math` here https://wandb.ai/primeintellect/hendrycks-math-bench/workspace?nw=nwusermikasenghaas_

## Examples

Spin up an inference server

```bash
uv run inference @ configs/inference/reverse_text.toml
```

Benchmark the inference with the orchestrator

```bash
uv run orchestrator @ configs/orchestrator/reverse_text.toml --bench
```

<img width="1028" height="644" alt="Screenshot 2025-07-12 at 9 53 40 PM" src="https://github.com/user-attachments/assets/db52cf8a-37cc-44db-a520-e8a834ae066a" />

Benchmark the trainer 

```bash
CUDA_VISIBLE_DEVICES=1 uv run trainer @ configs/trainer/reverse_text.toml --bench
```

<img width="1049" height="654" alt="Screenshot 2025-07-12 at 9 50 48 PM" src="https://github.com/user-attachments/assets/48926365-a491-4ab9-bdad-52a7f6b25462" />

Benchmark an RL run

```bash
uv run rl   \
  --trainer @ configs/trainer/reverse_text.toml  \
  --orchestrator @ configs/orchestrator/reverse_text.toml \
  --bench
```

<img width="1496" height="928" alt="Screenshot 2025-07-12 at 10 51 07 PM" src="https://github.com/user-attachments/assets/a6be6915-ae14-4d43-b515-e6c2434158cd" />

