### PR TITLE
Colorized, piped file logs instead of loguru file logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ weights/*
 *.ipynb
 *.jsonl
 .pydantic_config/*
-*.loguru
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ uv run inference @ configs/inference/reverse_text.toml
 ```bash
 uv run rl \
   --trainer @ configs/trainer/reverse_text.toml \
-  --orchestrator @ configs/orchestrator/reverse_text.toml \
+  --orchestrator @ configs/orchestrator/reverse_text.toml
 ```
 
 To kill the tmux session when you're done:

--- a/src/prime_rl/eval/config.py
+++ b/src/prime_rl/eval/config.py
@@ -64,7 +64,7 @@ class EvalConfig(BaseSettings):
     monitor: MultiMonitorConfig = MultiMonitorConfig()
 
     # The logging configuration
-    log: LogConfig = LogConfig(path="logs/eval")
+    log: LogConfig = LogConfig()
 
     use_tqdm: Annotated[
         bool,

--- a/src/prime_rl/orchestrator/logger.py
+++ b/src/prime_rl/orchestrator/logger.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 from loguru import logger as loguru_logger
 from loguru._logger import Logger
 
@@ -17,8 +15,6 @@ def setup_logger(log_config: LogConfig) -> Logger:
     format = time + message + debug
 
     # Setup the logger handlers
-    if log_config.path:
-        log_config.path = Path(log_config.path.as_posix() + ".loguru")
     logger = setup_handlers(loguru_logger, format, log_config, rank=0)
     set_logger(logger)
 

--- a/src/prime_rl/trainer/logger.py
+++ b/src/prime_rl/trainer/logger.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 from loguru import logger as loguru_logger
 from loguru._logger import Logger
 
@@ -18,10 +16,6 @@ def setup_logger(log_config: LogConfig, world: World) -> Logger:
     format = time + message + debug
 
     # Setup the logger handlers
-    if log_config.path:
-        if world.world_size > 1 and world.local_rank > 0:
-            log_config.path = Path(log_config.path.as_posix() + str(world.local_rank))
-        log_config.path = Path(log_config.path.as_posix() + ".loguru")
     logger = setup_handlers(loguru_logger, format, log_config, rank=world.rank)
     set_logger(logger)
 

--- a/src/prime_rl/utils/config.py
+++ b/src/prime_rl/utils/config.py
@@ -20,13 +20,6 @@ class LogConfig(BaseConfig):
         Field(description="Logging level for the process. Will determine the logging verbosity and format."),
     ] = "info"
 
-    path: Annotated[
-        Path | None,
-        Field(
-            description="The file path to log to. If None, will only log to stdout. This field is particularly useful to distinguish logs when multi-processing."
-        ),
-    ] = Path("logs")
-
     utc: Annotated[
         bool,
         Field(

--- a/src/prime_rl/utils/logger.py
+++ b/src/prime_rl/utils/logger.py
@@ -44,12 +44,6 @@ def setup_handlers(logger: Logger, format: str, config: LogConfig, rank: int) ->
     if rank == 0:
         logger.add(sys.stdout, format=format, level=config.level.upper(), colorize=True)
 
-    # Install file handler on all ranks, erase file by default
-    if config.path:
-        if config.path.exists():
-            config.path.unlink()
-        logger.add(config.path, format=format, level=config.level.upper(), colorize=True)
-
     # Disable critical logging
     logger.critical = lambda _: None
 

--- a/tmux.sh
+++ b/tmux.sh
@@ -44,9 +44,9 @@ if [ -n "$TMUX" ]; then
         # Pane 2: Orchestrator
         tmux send-keys -t "$SESSION_NAME:RL.1" 'while true; do
   echo "Waiting for orchestrator log file..."
-  while [ ! -f logs/orchestrator.loguru ]; do sleep 1; done
-  echo "Following orchestrator.loguru..."
-  tail -F logs/orchestrator.loguru
+  while [ ! -f logs/orchestrator.log ]; do sleep 1; done
+  echo "Following orchestrator.log..."
+  tail -F logs/orchestrator.log
 done' C-m
         
         # Pane 3: Inference
@@ -113,9 +113,9 @@ else
         # Pane 2: Orchestrator
         tmux send-keys -t "$SESSION_NAME:RL.1" 'while true; do
   echo "Waiting for orchestrator log file..."
-  while [ ! -f logs/orchestrator.loguru ]; do sleep 1; done
-  echo "Following orchestrator.loguru..."
-  tail -F logs/orchestrator.loguru
+  while [ ! -f logs/orchestrator.log ]; do sleep 1; done
+  echo "Following orchestrator.log..."
+  tail -F logs/orchestrator.log
 done' C-m
         
         # Pane 3: Inference


### PR DESCRIPTION
Replaces loguru file logging with piping stdout logs from `rl.py` while setting the `LOGURU_FORCE_COLORS` env var. This retains color in the logs when doing `tail -F file.log` on it but also logs wandb logs, tqdm bars and rich tables.

<img width="1496" height="928" alt="Screenshot 2025-07-12 at 10 38 33 PM" src="https://github.com/user-attachments/assets/98a48e13-6ebb-4155-85ee-116b9ff18034" />
