### PR TITLE
Deprecate W&B group

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,6 @@ Because we save progress information, resuming from a checkpoint is fully W&B co
 ```bash
 CUDA_VISIBLE_DEVICES=1 uv run trainer @ configs/trainer/reverse_text.toml \
   --monitor.wandb.project <project> \
-  --monitor.wandb.group <group> \
   --ckpt.resume-step 10 \
   --monitor.wandb.id <trainer-run-id> \
   --orchestrator.monitor.wandb.id <orchestrator-run-id>

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ uv run trainer @ configs/trainer/reverse_text.toml --bench --data.fake "{'micro_
 
 **RL**
 
-Often it will be most convenient to benchmark the full RL run. This will automatically set the training batch configuration to match the way the orchestrator would have written it. Also, if W&B is configured for this project, it will synchronize the benchmark results to the project name, but suffixed with `-bench`.
+Often it will be most convenient to benchmark the full RL run. This will automatically set the training batch configuration to match the way the orchestrator would have written it.
 
 ```bash
 uv run rl   \

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -272,7 +272,7 @@ class OrchestratorConfig(BaseSettings):
     @model_validator(mode="after")
     def auto_setup_bench(self):
         if self.bench:
-            self.max_steps = 6  # Run for 1 warmup step + 5 evaluation steps
+            self.max_steps = 4  # Run for 1 warmup step + 3 evaluation steps
             self.async_level = 1e9  # Never wait for RL weight checkpoints
 
             if self.monitor.wandb:

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -275,4 +275,7 @@ class OrchestratorConfig(BaseSettings):
             self.max_steps = 6  # Run for 1 warmup step + 5 evaluation steps
             self.async_level = 1e9  # Never wait for RL weight checkpoints
 
+            if self.monitor.wandb:
+                self.monitor.wandb.project = f"{self.monitor.wandb.project}-bench"
+
         return self

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -278,4 +278,8 @@ class OrchestratorConfig(BaseSettings):
             if self.monitor.wandb:
                 self.monitor.wandb.project = f"{self.monitor.wandb.project}-bench"
 
+            # Disable evaluation
+            self.eval = None
+            self.monitor.wandb.log_samples = None
+
         return self

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -275,9 +275,6 @@ class OrchestratorConfig(BaseSettings):
             self.max_steps = 4  # Run for 1 warmup step + 3 evaluation steps
             self.async_level = 1e9  # Never wait for RL weight checkpoints
 
-            if self.monitor.wandb:
-                self.monitor.wandb.project = f"{self.monitor.wandb.project}-bench"
-
             # Disable evaluation
             self.eval = None
             self.monitor.wandb.log_samples = None

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -96,10 +96,6 @@ class RLConfig(BaseSettings):
                 seq_len=self.orchestrator.seq_len,
             )
 
-            # Disable evaluation
-            self.orchestrator.eval = None
-            self.orchestrator.monitor.wandb.log_samples = None
-
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -122,12 +122,10 @@ class RLConfig(BaseSettings):
                 self.orchestrator.monitor.wandb = WandbMonitorConfig()
             self.orchestrator.monitor.wandb.project = self.trainer.monitor.wandb.project
 
-            # If group is set, use it and auto-generate run names
-            if self.trainer.monitor.wandb.group:
-                self.orchestrator.monitor.wandb.group = self.trainer.monitor.wandb.group
-
-                self.trainer.monitor.wandb.name = f"{self.trainer.monitor.wandb.group}-trainer"
-                self.orchestrator.monitor.wandb.name = f"{self.trainer.monitor.wandb.group}-orchestrator"
+            # If name is set on trainer, copy it and add suffixes
+            if self.trainer.monitor.wandb.name:
+                self.trainer.monitor.wandb.name = f"{self.trainer.monitor.wandb.name}-trainer"
+                self.orchestrator.monitor.wandb.name = f"{self.trainer.monitor.wandb.name}-orchestrator"
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 import time
 import warnings
+from copy import deepcopy
 from pathlib import Path
 from subprocess import Popen
 from threading import Event, Thread
@@ -116,8 +117,9 @@ class RLConfig(BaseSettings):
 
             # If name is set on trainer, copy it and add suffixes
             if self.trainer.monitor.wandb.name:
-                self.trainer.monitor.wandb.name = f"{self.trainer.monitor.wandb.name}-trainer"
-                self.orchestrator.monitor.wandb.name = f"{self.trainer.monitor.wandb.name}-orchestrator"
+                run_name = deepcopy(self.trainer.monitor.wandb.name)
+                self.trainer.monitor.wandb.name = f"{run_name}-trainer"
+                self.orchestrator.monitor.wandb.name = f"{run_name}-orchestrator"
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -96,10 +96,6 @@ class RLConfig(BaseSettings):
                 seq_len=self.orchestrator.seq_len,
             )
 
-            # Suffix the W&B project with "-bench"
-            if self.trainer.monitor.wandb:
-                self.trainer.monitor.wandb.project = f"{self.trainer.monitor.wandb.project}-bench"
-
             # Disable evaluation
             self.orchestrator.eval = None
             self.orchestrator.monitor.wandb.log_samples = None

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -219,7 +219,7 @@ class TrainerConfig(BaseSettings):
     @model_validator(mode="after")
     def auto_setup_bench(self):
         if self.bench:
-            self.max_steps = 6  # 1 Warmup + 5 Benchmark
+            self.max_steps = 4  # 1 Warmup + 3 Benchmark
             if not self.data.fake:
                 self.data.fake = FakeDataLoaderConfig()
 

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -222,4 +222,7 @@ class TrainerConfig(BaseSettings):
             self.max_steps = 6  # 1 Warmup + 5 Benchmark
             if not self.data.fake:
                 self.data.fake = FakeDataLoaderConfig()
+
+            if self.monitor.wandb:
+                self.monitor.wandb.project = f"{self.monitor.wandb.project}-bench"
         return self

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -222,7 +222,4 @@ class TrainerConfig(BaseSettings):
             self.max_steps = 4  # 1 Warmup + 3 Benchmark
             if not self.data.fake:
                 self.data.fake = FakeDataLoaderConfig()
-
-            if self.monitor.wandb:
-                self.monitor.wandb.project = f"{self.monitor.wandb.project}-bench"
         return self

--- a/src/prime_rl/trainer/data.py
+++ b/src/prime_rl/trainer/data.py
@@ -26,7 +26,7 @@ class FakeDataLoader:
     def __init__(self, config: FakeDataLoaderConfig):
         self.batch_size = config.batch_size
         self.micro_batch_size = config.micro_batch_size
-        self.num_micro_batches = self.batch_size // self.micro_batch_size
+        self.num_micro_batches = self.batch_size // self.micro_batch_size // get_world().world_size
         self.seq_len = config.seq_len
 
     def wait_for_batch(self) -> None:

--- a/src/prime_rl/utils/config.py
+++ b/src/prime_rl/utils/config.py
@@ -73,17 +73,10 @@ class WandbMonitorConfig(BaseConfig):
 
     project: Annotated[str, Field(description="The W&B project to log to.")] = "prime-rl"
 
-    group: Annotated[
-        str | None,
-        Field(
-            description="The W&B group to log to. If None, it will not set the group. Use grouping if you want multiple associated runs (e.g. RL training has a training and inference run) log to the same dashboard.",
-        ),
-    ] = None
-
     name: Annotated[
         str | None,
         Field(
-            description="The W&B name to to use for logging. If group and name are set, they will be automatically combined into a single name.",
+            description="The W&B name to to use for logging.",
         ),
     ] = None
 

--- a/src/prime_rl/utils/monitor.py
+++ b/src/prime_rl/utils/monitor.py
@@ -135,7 +135,6 @@ class WandbMonitor(Monitor):
             return
         self.wandb = wandb.init(
             project=config.project,
-            group=config.group,
             name=config.name,
             id=config.id,
             dir=config.dir,

--- a/tests/integration/test_rl.py
+++ b/tests/integration/test_rl.py
@@ -42,10 +42,10 @@ def train_process(vllm_server: str, run_process: Callable[[Command, Environment,
     project = "ci-reverse-text"
     if username != "CI_RUNNER":
         project += "-local"
-    group_name = f"{branch_name}-{commit_hash}"
+    run_name = f"{branch_name}-{commit_hash}"
 
     return run_process(
-        CMD + ["--trainer.monitor.wandb.project", project, "--trainer.monitor.wandb.group", group_name],
+        CMD + ["--trainer.monitor.wandb.project", project, "--trainer.monitor.wandb.name", run_name],
         {},
         TIMEOUT,
     )


### PR DESCRIPTION
This PR removes the ability to set a W&B group via `--monitor.wandb.group` which was previously used to group together runs. We found the UI and handling to be overcomplicated, so now we group experiments runs by using a shared prefix in the run name (which is also editable)