### PR TITLE
Do not set default W&B project

### DIFF
--- a/configs/orchestrator/hendrycks_math/1b.toml
+++ b/configs/orchestrator/hendrycks_math/1b.toml
@@ -9,7 +9,6 @@ mask_truncated_completions = false
 name = "willcb/DeepSeek-R1-Distill-Qwen-1.5B"
 
 [monitor.wandb]
-project = "hendrycks-math"
 
 [environment]
 id = "hendrycks-math"

--- a/configs/orchestrator/hendrycks_math/7b.toml
+++ b/configs/orchestrator/hendrycks_math/7b.toml
@@ -8,7 +8,6 @@ mask_truncated_completions = false
 name = "willcb/DeepSeek-R1-Distill-Qwen-7B"
 
 [monitor.wandb]
-project = "hendrycks-math"
 
 [environment]
 id = "hendrycks-math"

--- a/configs/orchestrator/intellect_math/1b.toml
+++ b/configs/orchestrator/intellect_math/1b.toml
@@ -9,7 +9,6 @@ mask_truncated_completions = false
 name = "willcb/DeepSeek-R1-Distill-Qwen-1.5B"
 
 [monitor.wandb]
-project = "intellect-math"
 
 [environment]
 id = "intellect-math"

--- a/configs/orchestrator/intellect_math/7b.toml
+++ b/configs/orchestrator/intellect_math/7b.toml
@@ -9,7 +9,6 @@ mask_truncated_completions = false
 name = "willcb/DeepSeek-R1-Distill-Qwen-7B"
 
 [monitor.wandb]
-project = "intellect-math"
 
 [environment]
 id = "intellect-math"

--- a/configs/trainer/hendrycks_math/1b.toml
+++ b/configs/trainer/hendrycks_math/1b.toml
@@ -1,7 +1,6 @@
 max_steps = 500
 
 [monitor.wandb]
-project = "hendrycks-math"
 
 [model]
 name = "willcb/DeepSeek-R1-Distill-Qwen-1.5B"

--- a/configs/trainer/hendrycks_math/7b.toml
+++ b/configs/trainer/hendrycks_math/7b.toml
@@ -1,5 +1,4 @@
 [monitor.wandb]
-project = "hendrycks-math"
 
 [model]
 name = "willcb/DeepSeek-R1-Distill-Qwen-7B"

--- a/configs/trainer/intellect_math/1b.toml
+++ b/configs/trainer/intellect_math/1b.toml
@@ -1,6 +1,5 @@
 
 [monitor.wandb]
-project = "intellect-math"
 
 [model]
 name = "willcb/DeepSeek-R1-Distill-Qwen-1.5B"

--- a/configs/trainer/intellect_math/7b.toml
+++ b/configs/trainer/intellect_math/7b.toml
@@ -1,6 +1,5 @@
 
 [monitor.wandb]
-project = "intellect-math"
 
 [model]
 name = "willcb/DeepSeek-R1-Distill-Qwen-7B"


### PR DESCRIPTION
Avoids W&B mess. Unless explicitly set, all logs will go to a single default project (rn `prime-rl`)