### PR TITLE
Cleanup HF models and datasets and port baseline environments

### DIFF
--- a/configs/inference/hendrycks_math/1b.toml
+++ b/configs/inference/hendrycks_math/1b.toml
@@ -1,5 +1,5 @@
 [model]
-name = "willcb/DeepSeek-R1-Distill-Qwen-1.5B"
+name = "PrimeIntellect/DeepSeek-R1-Distill-Qwen-1.5B"
 max_model_len = 2048 
 
 [parallel]

--- a/configs/inference/hendrycks_math/7b.toml
+++ b/configs/inference/hendrycks_math/7b.toml
@@ -1,5 +1,5 @@
 [model]
-name = "willcb/DeepSeek-R1-Distill-Qwen-7B"
+name = "PrimeIntellect/DeepSeek-R1-Distill-Qwen-7B"
 max_model_len = 2048
 
 [parallel]

--- a/configs/inference/intellect_math/1b.toml
+++ b/configs/inference/intellect_math/1b.toml
@@ -1,5 +1,5 @@
 [model]
-name = "willcb/DeepSeek-R1-Distill-Qwen-1.5B"
+name = "PrimeIntellect/DeepSeek-R1-Distill-Qwen-1.5B"
 max_model_len = 8192 
 
 [parallel]

--- a/configs/inference/intellect_math/7b.toml
+++ b/configs/inference/intellect_math/7b.toml
@@ -1,5 +1,5 @@
 [model]
-name = "willcb/DeepSeek-R1-Distill-Qwen-7B"
+name = "PrimeIntellect/DeepSeek-R1-Distill-Qwen-7B"
 max_model_len = 8192 
 
 [parallel]

--- a/configs/inference/reverse_text.toml
+++ b/configs/inference/reverse_text.toml
@@ -1,2 +1,2 @@
 [model]
-name = "willcb/Qwen2.5-0.5B-Reverse-SFT"
+name = "PrimeIntellect/Qwen2.5-0.5B-Reverse-Text-SFT"

--- a/configs/orchestrator/hendrycks_math/1b.toml
+++ b/configs/orchestrator/hendrycks_math/1b.toml
@@ -6,7 +6,7 @@ seq_len = 2048
 mask_truncated_completions = false
 
 [model]
-name = "willcb/DeepSeek-R1-Distill-Qwen-1.5B"
+name = "PrimeIntellect/DeepSeek-R1-Distill-Qwen-1.5B"
 
 [monitor.wandb]
 

--- a/configs/orchestrator/hendrycks_math/7b.toml
+++ b/configs/orchestrator/hendrycks_math/7b.toml
@@ -5,7 +5,7 @@ seq_len = 2048
 mask_truncated_completions = false
 
 [model]
-name = "willcb/DeepSeek-R1-Distill-Qwen-7B"
+name = "PrimeIntellect/DeepSeek-R1-Distill-Qwen-7B"
 
 [monitor.wandb]
 

--- a/configs/orchestrator/intellect_math/1b.toml
+++ b/configs/orchestrator/intellect_math/1b.toml
@@ -6,7 +6,7 @@ rollouts_per_prompt = 16
 mask_truncated_completions = false
 
 [model]
-name = "willcb/DeepSeek-R1-Distill-Qwen-1.5B"
+name = "PrimeIntellect/DeepSeek-R1-Distill-Qwen-1.5B"
 
 [monitor.wandb]
 

--- a/configs/orchestrator/intellect_math/7b.toml
+++ b/configs/orchestrator/intellect_math/7b.toml
@@ -6,7 +6,7 @@ rollouts_per_prompt = 16
 mask_truncated_completions = false
 
 [model]
-name = "willcb/DeepSeek-R1-Distill-Qwen-7B"
+name = "PrimeIntellect/DeepSeek-R1-Distill-Qwen-7B"
 
 [monitor.wandb]
 

--- a/configs/orchestrator/reverse_text.toml
+++ b/configs/orchestrator/reverse_text.toml
@@ -6,7 +6,7 @@ max_steps = 30
 mask_truncated_completions = false
 
 [model]
-name = "willcb/Qwen2.5-0.5B-Reverse-SFT"
+name = "PrimeIntellect/Qwen2.5-0.5B-Reverse-Text-SFT"
 
 [environment]
 id = "reverse-text"

--- a/configs/trainer/hendrycks_math/1b.toml
+++ b/configs/trainer/hendrycks_math/1b.toml
@@ -3,7 +3,7 @@ max_steps = 500
 [monitor.wandb]
 
 [model]
-name = "willcb/DeepSeek-R1-Distill-Qwen-1.5B"
+name = "PrimeIntellect/DeepSeek-R1-Distill-Qwen-1.5B"
 
 [optim]
 lr = 1e-6

--- a/configs/trainer/hendrycks_math/7b.toml
+++ b/configs/trainer/hendrycks_math/7b.toml
@@ -1,7 +1,7 @@
 [monitor.wandb]
 
 [model]
-name = "willcb/DeepSeek-R1-Distill-Qwen-7B"
+name = "PrimeIntellect/DeepSeek-R1-Distill-Qwen-7B"
 ac = true
 
 [optim]

--- a/configs/trainer/intellect_math/1b.toml
+++ b/configs/trainer/intellect_math/1b.toml
@@ -2,7 +2,7 @@
 [monitor.wandb]
 
 [model]
-name = "willcb/DeepSeek-R1-Distill-Qwen-1.5B"
+name = "PrimeIntellect/DeepSeek-R1-Distill-Qwen-1.5B"
 
 [optim]
 lr = 1e-6

--- a/configs/trainer/intellect_math/7b.toml
+++ b/configs/trainer/intellect_math/7b.toml
@@ -2,7 +2,7 @@
 [monitor.wandb]
 
 [model]
-name = "willcb/DeepSeek-R1-Distill-Qwen-7B"
+name = "PrimeIntellect/DeepSeek-R1-Distill-Qwen-7B"
 ac = true
 
 [optim]

--- a/configs/trainer/reverse_text.toml
+++ b/configs/trainer/reverse_text.toml
@@ -1,7 +1,7 @@
 max_steps = 30
 
 [model]
-name = "willcb/Qwen2.5-0.5B-Reverse-SFT"
+name = "PrimeIntellect/Qwen2.5-0.5B-Reverse-Text-SFT"
 
 [optim]
 lr = 3e-6


### PR DESCRIPTION
> This PR is not ready because the `hendrycks_math` port is behaving crazily. Will have to investigate more.

Cleans up the models and environment datasets used:
- Copies all models (SFT finetunes, chat template changes, ...) to the PrimeIntellect HF org and collects them in the [PRIME-RL](https://huggingface.co/collections/PrimeIntellect/prime-rl-687560f61d766320424a7df3) collection.
- Ports the `reverse_text` environment to verifiers format (+[dataset](https://huggingface.co/datasets/PrimeIntellect/reverse_text))
- Ports the `hendrycks_math` environment to verifiers format (using default Eleuther [dataset](https://huggingface.co/datasets/EleutherAI/hendrycks_math))

**Reverse Text**

<img width="322" height="248" alt="Screenshot 2025-07-14 at 11 14 04 PM" src="https://github.com/user-attachments/assets/fdc88b2f-3214-41aa-9c07-dc2100ad2f4a" />

**Hendryck's Math**

*TBD*
