### PR TITLE
add env testing script, bump verifiers version, rename get_env -> load_env

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ prerelease = "allow"
 
 [tool.uv.sources]
 torch = [{ index = "pytorch-cu128" }]
-verifiers = { git = "https://github.com/willccbb/verifiers", rev = "8363357" }
+verifiers = { git = "https://github.com/willccbb/verifiers", rev = "784e1ee" }
 
 [[tool.uv.index]]
 name = "pytorch-cu128"

--- a/scripts/test_env.py
+++ b/scripts/test_env.py
@@ -8,7 +8,7 @@ from prime_rl.environments.registry import REGISTRY, load_environment
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--env", "-e", type=str, default="pydantic-adherence", choices=list(REGISTRY.keys()))
+    parser.add_argument("--env", "-e", type=str, default="gsm8k", choices=list(REGISTRY.keys()))
     parser.add_argument("--model", "-m", type=str, default="gpt-4.1-mini")
     parser.add_argument("--api-key-var", "-k", type=str, default="OPENAI_API_KEY")
     parser.add_argument("--api-base-url", "-b", type=str, default="https://api.openai.com/v1")

--- a/scripts/test_env.py
+++ b/scripts/test_env.py
@@ -1,0 +1,56 @@
+import argparse
+
+import numpy as np
+from openai import OpenAI
+from verifiers.utils.logging_utils import print_prompt_completions_sample
+
+from prime_rl.environments.registry import REGISTRY, load_environment
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--env", "-e", type=str, default="pydantic-adherence", choices=list(REGISTRY.keys()))
+    parser.add_argument("--model", "-m", type=str, default="gpt-4.1-mini")
+    parser.add_argument("--api-key-var", "-k", type=str, default="OPENAI_API_KEY")
+    parser.add_argument("--api-base-url", "-b", type=str, default="https://api.openai.com/v1")
+    parser.add_argument("--num-examples", "-n", type=int, default=5)
+    parser.add_argument("--rollouts-per-example", "-r", type=int, default=3)
+    parser.add_argument("--max-concurrent-requests", "-c", type=int, default=32)
+    parser.add_argument("--max-tokens", "-t", type=int, default=1024)
+    parser.add_argument("--temperature", "-T", type=float, default=0.7)
+    args = parser.parse_args()
+    vf_env = load_environment(args.env)
+    client = OpenAI()
+    sampling_args = {
+        "max_tokens": args.max_tokens,
+        "temperature": args.temperature,
+    }
+    results = vf_env.evaluate(
+        client=client,
+        model=args.model,
+        sampling_args=sampling_args,
+        num_examples=args.num_examples,
+        rollouts_per_example=args.rollouts_per_example,
+        max_concurrent_requests=args.max_concurrent_requests,
+    )
+    rewards = {k: v for k, v in results.items() if "reward" in k}
+    print("--- Evaluation ---")
+    print(f"Environment: {args.env}")
+    print(f"Model: {args.model}")
+    print(f"Provider: {args.api_base_url}")
+    print(f"Examples: {args.num_examples}")
+    print(f"Rollouts per example: {args.rollouts_per_example}")
+
+    print("--- Example ---")
+    print_prompt_completions_sample(results["prompt"], results["completion"], rewards, step=0)
+    print("--- All ---")
+    print("Rewards:")
+    for k, v in results.items():
+        if "reward" in k:
+            print(f"{k}: avg - {sum(v) / len(v):.3f}, std - {np.std(v):.3f}")
+            n = args.num_examples
+            r = args.rollouts_per_example
+            for i in range(r):
+                # rounded to 3 decimal places
+                trials = [round(v[(i * r) + j], 3) for j in range(n)]
+                out = f"r{i + 1}: {trials}"
+                print(out)

--- a/src/prime_rl/environments/registry.py
+++ b/src/prime_rl/environments/registry.py
@@ -21,7 +21,6 @@ def load_gsm8k_environment(env_args: dict = {}) -> Environment:
 
     def correct_answer_reward_func(completion, answer, **kwargs) -> float:
         response = parser.parse_answer(completion) or ""
-        print(response, answer)
         return 1.0 if response == str(answer) else 0.0
 
     rubric = vf.Rubric(

--- a/src/prime_rl/environments/registry.py
+++ b/src/prime_rl/environments/registry.py
@@ -148,6 +148,7 @@ def load_reverse_environment(env_args: dict = {}) -> Environment:
     )
     return vf_env
 
+
 def load_pydantic_adherence_environment(env_args: dict = {}) -> Environment:
     import json
     import re
@@ -182,7 +183,6 @@ def load_pydantic_adherence_environment(env_args: dict = {}) -> Environment:
             i -= 1
         return None
 
-
     def extract_last_json(text: str) -> dict | None:
         """Extract and parse the last JSON object from text."""
         json_str = _find_last_json_block(text)
@@ -200,7 +200,7 @@ def load_pydantic_adherence_environment(env_args: dict = {}) -> Environment:
         """
         Execute code_str in a scratch module namespace and return the
         class named model_name.
-        
+
         Raises RuntimeError if the class is missing or not a BaseModel.
         """
         module = ModuleType("dyn_pydantic_cfg")
@@ -208,11 +208,11 @@ def load_pydantic_adherence_environment(env_args: dict = {}) -> Environment:
             exec(code_str, module.__dict__)
         except Exception as e:
             raise RuntimeError(f"config code failed to execute: {e!r}") from e
-        
+
         cls = getattr(module, model_name, None)
         if cls is None or not issubclass(cls, BaseModel):
             raise RuntimeError(f"{model_name} not found or not a Pydantic BaseModel")
-        
+
         # cheap structural self-check (never instantiates)
         cls.model_json_schema()
         return cls
@@ -221,92 +221,85 @@ def load_pydantic_adherence_environment(env_args: dict = {}) -> Environment:
         """
         Parser for JSON responses that validates against Pydantic models.
         """
-        
-        def __init__(
-            self, 
-            extract_fn: Callable[[str], Optional[dict]] = extract_last_json,
-            **kwargs
-        ):
+
+        def __init__(self, extract_fn: Callable[[str], Optional[dict]] = extract_last_json, **kwargs):
             """
             Initialize the parser.
-            
+
             Args:
                 extract_fn: Function to extract JSON from text (default: extract_last_json)
             """
             super().__init__(**kwargs)
-            
+
             self.extract_fn = extract_fn
-        
+
         def parse(self, text: str) -> dict | None:
             """
             Parse JSON from text and return the parsed payload.
-            
+
             Returns:
                 The extracted JSON payload, or None if extraction fails
-            """       
+            """
             return self.extract_fn(text)
-        
+
         def get_format_reward_func(self) -> Callable:
             """
             Returns a reward function that checks for valid JSON format and Pydantic validation.
-            
+
             Returns 1.0 for valid, 0.0 for invalid.
             """
+
             def format_reward_func(completion: Union[List[Dict[str, str]], str], **kwargs) -> float:
                 parsed = self.parse_answer(completion)
                 if parsed is None:
                     return 0.0
-                
+
                 verification_info = kwargs.get("verification_info")
                 if verification_info is None:
                     raise ValueError("verification_info must be provided in kwargs")
-                
+
                 if "pydantic_config" not in verification_info or "model_name" not in verification_info:
                     raise ValueError("verification_info must contain 'pydantic_config' and 'model_name'")
-                
-                model = _load_model_from_code(
-                    verification_info["pydantic_config"],
-                    verification_info["model_name"]
-                )
-                
+
+                model = _load_model_from_code(verification_info["pydantic_config"], verification_info["model_name"])
+
                 try:
                     model.model_validate(parsed)
                     return 1.0
                 except Exception:
                     return 0.0
-            
-            return format_reward_func 
+
+            return format_reward_func
 
     dataset = load_dataset("justus27/pydantic-adherance-test", split="train")
 
     # Preprocess the dataset to parse verification_info and map prompt to question
-    dataset = dataset.map(lambda x: {
-        'question': x['prompt'],
-        'answer': json.loads(x['verification_info']),
-        'task': 'pydantic-adherence'
-    })
+    dataset = dataset.map(
+        lambda x: {"question": x["prompt"], "answer": json.loads(x["verification_info"]), "task": "pydantic-adherence"}
+    )
 
     dataset = dataset.remove_columns(["prompt", "verification_info"])
 
-    parser = PydanticParser(
-        extract_fn=extract_last_json
-    )
+    parser = PydanticParser(extract_fn=extract_last_json)
 
     format_reward_func = parser.get_format_reward_func()
 
     def pydantic_adherence_reward_func(completion, answer, **kwargs):
         """
         Validate JSON output against a per-sample Pydantic schema.
-        
+
         Args:
             completion: Model output (string or message list)
             answer: Dict containing 'pydantic_config' and 'model_name' for this sample
         """
         return format_reward_func(completion, verification_info=answer)
 
-    rubric = vf.Rubric(funcs=[
-        pydantic_adherence_reward_func,
-    ], weights=[1.0])
+    rubric = vf.Rubric(
+        funcs=[
+            pydantic_adherence_reward_func,
+        ],
+        weights=[1.0],
+    )
 
     vf_env = vf.SingleTurnEnv(
         dataset=dataset,
@@ -315,6 +308,7 @@ def load_pydantic_adherence_environment(env_args: dict = {}) -> Environment:
     )
 
     return vf_env
+
 
 REGISTRY = {
     "gsm8k": load_gsm8k_environment,
@@ -325,7 +319,7 @@ REGISTRY = {
 }
 
 
-def get_environment(env_id: str, env_args: dict = {}) -> Environment:
+def load_environment(env_id: str, env_args: dict = {}) -> Environment:
     if env_id not in REGISTRY:
         raise ValueError(f"Environment {env_id} not found")
     return REGISTRY[env_id](env_args)

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -14,7 +14,7 @@ from transformers import AutoTokenizer
 
 from prime_rl.eval.utils import run_benchmark
 from prime_rl.orchestrator.ckpt import CheckpointManager, Progress
-from prime_rl.environments.registry import get_environment
+from prime_rl.environments.registry import load_environment
 from prime_rl.orchestrator.client import (
     check_has_model,
     check_health,
@@ -85,7 +85,7 @@ async def orchestrate(config: OrchestratorConfig):
 
     # Load environment and extract dataset
     logger.info(f"Loading environment {config.environment.id} with args {config.environment.args}")
-    vf_env = get_environment(config.environment.id, config.environment.args)
+    vf_env = load_environment(config.environment.id, config.environment.args)
     dataset = vf_env.get_dataset(seed=config.seed)
 
     # Load tokenizer -- placeholder until reworking verifiers to use vLLM tokenizer

--- a/uv.lock
+++ b/uv.lock
@@ -2060,7 +2060,7 @@ requires-dist = [
     { name = "torch", specifier = ">=2.7.0", index = "https://download.pytorch.org/whl/test/cu128" },
     { name = "transformers", specifier = ">=4.53.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/willccbb/verifiers?rev=8363357" },
+    { name = "verifiers", git = "https://github.com/willccbb/verifiers?rev=784e1ee" },
     { name = "vllm", specifier = ">=0.9.1" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -3122,7 +3122,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.1"
-source = { git = "https://github.com/willccbb/verifiers?rev=8363357#8363357a75a57ef15805611e0105149617799d94" }
+source = { git = "https://github.com/willccbb/verifiers?rev=784e1ee#784e1ee74ec828d7c1e7cffb8df7bf6584cc847c" }
 dependencies = [
     { name = "datasets" },
     { name = "openai" },


### PR DESCRIPTION
inference-only test for evals
- can use any OpenAI client (OAI, OpenRouter, vLLM, etc.)
- can specify num examples, rollouts per example, sampling args via cli

<img width="1126" height="549" alt="image" src="https://github.com/user-attachments/assets/98678fe0-7529-4507-85c2-6d765ca87c36" />
