### PR TITLE
Hotfix logprob packing 

### DIFF
--- a/src/prime_rl/orchestrator/data.py
+++ b/src/prime_rl/orchestrator/data.py
@@ -170,6 +170,7 @@ def packed_samples_into_micro_bs(samples: list[Sample], max_seq_len: int) -> lis
             bin_len = sum(len(s["input_ids"]) for s in bin_content)
             # Check if sequence fits in this bin
             if bin_len + len(sample["input_ids"]) <= max_seq_len:
+                sample["logprobs"] = torch.cat([torch.tensor([0.0]), sample["logprobs"]])
                 micro_batches[bin_idx].append(sample)
                 bin_found = True
                 break


### PR DESCRIPTION
This is one line fix to a shape mismatch problem arising from packing logprobs. The trainer computes logprobs with tensor shape `(B, L-1, V)`, but when packing `k` samples into a batch the orchestratror writes a tensor of shape `(B, L-k, V)`. This PR adds a zero logprob for all but the first sample within each packed batch.