### PR TITLE
Fix logprob packing

### DIFF
--- a/src/prime_rl/orchestrator/data.py
+++ b/src/prime_rl/orchestrator/data.py
@@ -14,7 +14,7 @@ class Sample(TypedDict):
     position_ids: Int[Tensor, "seq"]
     loss_mask: Int[Tensor, "seq"]
     advantages: Float[Tensor, "seq"]
-    logprobs: Float[Tensor, "seq_minus_1"]
+    logprobs: Float[Tensor, "seq"]
 
 
 def prepare_sample(

--- a/src/prime_rl/orchestrator/data.py
+++ b/src/prime_rl/orchestrator/data.py
@@ -170,7 +170,6 @@ def packed_samples_into_micro_bs(samples: list[Sample], max_seq_len: int) -> lis
             bin_len = sum(len(s["input_ids"]) for s in bin_content)
             # Check if sequence fits in this bin
             if bin_len + len(sample["input_ids"]) <= max_seq_len:
-                sample["logprobs"] = torch.cat([torch.tensor([0.0]), sample["logprobs"]])
                 micro_batches[bin_idx].append(sample)
                 bin_found = True
                 break

--- a/src/prime_rl/orchestrator/data.py
+++ b/src/prime_rl/orchestrator/data.py
@@ -44,7 +44,7 @@ def prepare_sample(
     # Prepare input_ids, loss_mask, position_ids, logprobs, and advantages
     input_ids = torch.cat([prompt_token_ids, completion_token_ids]).long()
     loss_mask = torch.cat([prompt_token_mask, completion_token_mask]).long()
-    logprobs = torch.cat([torch.zeros(len(prompt_token_ids) - 1), torch.tensor(completion_logprobs)]).float()
+    logprobs = torch.cat([torch.zeros(len(prompt_token_ids)), torch.tensor(completion_logprobs)]).float()
     position_ids = torch.arange(len(input_ids)).long()
     advantages = torch.tensor(advantage).repeat(len(input_ids)).float()
 
@@ -64,7 +64,7 @@ def prepare_sample(
         logprobs = torch.cat([logprobs, torch.zeros(num_padding_tokens)]).float()
         advantages = torch.cat([advantages, torch.zeros(num_padding_tokens)]).float()
 
-    assert len(input_ids) == len(advantages) == len(loss_mask) == len(position_ids) == len(logprobs) + 1, (
+    assert len(input_ids) == len(advantages) == len(loss_mask) == len(position_ids) == len(logprobs), (
         f"input_ids: {len(input_ids)}, advantages: {len(advantages)}, loss_mask: {len(loss_mask)}, position_ids: {len(position_ids)}, logprobs: {len(logprobs)}"
     )
     return {

--- a/src/prime_rl/trainer/data.py
+++ b/src/prime_rl/trainer/data.py
@@ -14,7 +14,7 @@ class MicroBatch(TypedDict):
     input_ids: Int[torch.Tensor, "micro_bs seq"]
     position_ids: Int[torch.Tensor, "micro_bs seq"]
     advantages: Float[torch.Tensor, "micro_bs seq"]
-    logprobs: Float[torch.Tensor, "micro_bs seq_minus_1"]
+    logprobs: Float[torch.Tensor, "micro_bs seq"]
     loss_mask: Int[torch.Tensor, "micro_bs seq"]
 
     # Batch level
@@ -40,7 +40,7 @@ class FakeDataLoader:
             "input_ids": torch.randint(0, 100, (self.micro_batch_size, self.seq_len)),
             "position_ids": torch.stack([torch.arange(self.seq_len)] * self.micro_batch_size, dim=0),
             "advantages": torch.randn(self.micro_batch_size, self.seq_len),
-            "logprobs": torch.randn(self.micro_batch_size, self.seq_len - 1),
+            "logprobs": torch.randn(self.micro_batch_size, self.seq_len),
             "temperature": 1.0,
             "loss_mask": torch.ones(self.micro_batch_size, self.seq_len, dtype=torch.int32),
         }

--- a/src/prime_rl/trainer/loss.py
+++ b/src/prime_rl/trainer/loss.py
@@ -2,9 +2,10 @@ import torch
 from beartype import beartype as typechecker
 from jaxtyping import Float, Int, jaxtyped
 from torch import Tensor
+from torch.nn import functional as F
 
 from prime_rl.trainer.config import ClippingConfig, GRPOVariantsConfig, RatioConfig
-from prime_rl.trainer.model import selective_log_softmax
+from prime_rl.trainer.model import Model, forward
 
 
 @jaxtyped(typechecker=typechecker)
@@ -174,3 +175,69 @@ def highest_entropy_mask(
 
     mask = (entropy >= threshold) & (loss_mask.bool())
     return mask
+
+
+@jaxtyped(typechecker=typechecker)
+def shift_logits(logits: Float[Tensor, "batch seq vocab"]) -> Float[Tensor, "batch seq vocab"]:
+    """Removes final token logits and adds a zero logit for the first token."""
+    # We drop the last logit because it corresponds to the next token that will be sampled but is not here yet
+    B, _, V = logits.shape
+    logits = logits[:, :-1, :]  # (B, L-1, V)
+    zeros = torch.zeros(B, 1, V, device=logits.device, dtype=logits.dtype)  # (B, 1, V)
+    logits = torch.cat([zeros, logits], dim=1)  # (B, L, V)
+    return logits
+
+
+@jaxtyped(typechecker=typechecker)
+def selective_log_softmax(
+    logits: Float[Tensor, "batch seq vocab"], index: Int[Tensor, "batch seq"]
+) -> Float[Tensor, "batch seq"]:
+    """
+    credits to https://github.com/huggingface/trl/blob/07cfe1677e552b7d5c92b7740e5b2f0b057661d8/trl/trainer/utils.py#L1659
+
+    A memory-efficient implementation of the common `log_softmax -> gather` operation.
+
+    This function is equivalent to the following naive implementation:
+    ```python
+    logps = torch.gather(logits.log_softmax(-1), dim=-1, index=index.unsqueeze(-1)).squeeze(-1)
+    ```
+
+    Args:
+        logits (`torch.Tensor`):
+            Logits tensor of shape `(..., num_classes)`.
+        index (`torch.Tensor`):
+            Index tensor of shape `(...)`, specifying the positions to gather from the log-softmax output.
+
+    Returns:
+        `torch.Tensor`:
+            Gathered log probabilities with the same shape as `index`.
+    """
+    if logits.dtype in [torch.float32, torch.float64]:
+        selected_logits = torch.gather(logits, dim=-1, index=index.unsqueeze(-1)).squeeze(-1)
+        # loop to reduce peak mem consumption
+        logsumexp_values = torch.stack([torch.logsumexp(lg, dim=-1) for lg in logits])
+        per_token_logps = selected_logits - logsumexp_values  # log_softmax(x_i) = x_i - logsumexp(x)
+    else:
+        # logsumexp approach is unstable with bfloat16, fall back to slightly less efficient approach
+        per_token_logps = []
+        for row_logits, row_labels in zip(logits, index):  # loop to reduce peak mem consumption
+            row_logps = F.log_softmax(row_logits, dim=-1)
+            row_per_token_logps = row_logps.gather(dim=-1, index=row_labels.unsqueeze(-1)).squeeze(-1)
+            per_token_logps.append(row_per_token_logps)
+        per_token_logps = torch.stack(per_token_logps)
+    return per_token_logps
+
+
+@jaxtyped(typechecker=typechecker)
+def compute_logprobs(
+    model: Model,
+    input_ids: Int[Tensor, "batch seq"],
+    position_ids: Int[Tensor, "batch seq"],
+    temperature: float,
+) -> Float[Tensor, "batch seq"]:
+    logits = forward(model, input_ids, position_ids).contiguous()
+    shifted_logits = shift_logits(logits)
+    shifted_logits = shifted_logits / temperature
+    logprobs = selective_log_softmax(shifted_logits, input_ids)
+    del logits, shifted_logits
+    return logprobs

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -137,7 +137,7 @@ def compute_logprobs(
     input_ids: Int[Tensor, "batch seq"],
     position_ids: Int[Tensor, "batch seq"],
     temperature: float,
-) -> Float[Tensor, "batch seq vocab"]:
+) -> Float[Tensor, "batch seq"]:
     logits = forward(model, input_ids, position_ids).contiguous()
     shifted_logits = shift_logits(logits)
     shifted_logits = shifted_logits / temperature

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -86,9 +86,10 @@ def forward(
 def shift_logits(logits: Float[Tensor, "batch seq vocab"]) -> Float[Tensor, "batch seq vocab"]:
     """Removes final token logits and adds a zero logit for the first token."""
     # We drop the last logit because it corresponds to the next token that will be sampled but is not here yet
+    B, _, V = logits.shape
     logits = logits[:, :-1, :]  # (B, L-1, V)
-    # We add a zero logit for the first token, indicating that no probability is assigned to it
-    logits = torch.cat([torch.zeros(logits.shape[0], 1, logits.shape[2]).to(logits.device), logits], dim=1)  # (B, L, V)
+    zeros = torch.zeros(B, 1, V, device=logits.device, dtype=logits.dtype)  # (B, 1, V)
+    logits = torch.cat([zeros, logits], dim=1)  # (B, L, V)
     return logits
 
 

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -79,3 +79,68 @@ def forward(
     model: Model, input_ids: Int[Tensor, "batch seq"], position_ids: Int[Tensor, "batch seq"]
 ) -> Float[Tensor, "batch seq vocab"]:
     return model(input_ids=input_ids, position_ids=position_ids).logits
+
+
+@jaxtyped(typechecker=typechecker)
+def shift_logits(logits: Float[Tensor, "batch seq vocab"]) -> Float[Tensor, "batch seq vocab"]:
+    """Removes final token logits and adds a zero logit for the first token."""
+    # We drop the last logit because it corresponds to the next token that will be sampled but is not here yet
+    logits = logits[:, :-1, :]  # (B, L-1, V)
+    # We add a zero logit for the first token, indicating that no probability is assigned to it
+    logits = torch.cat([torch.zeros(logits.shape[0], 1, logits.shape[2]).to(logits.device), logits], dim=1)  # (B, L, V)
+    return logits
+
+
+@jaxtyped(typechecker=typechecker)
+def selective_log_softmax(
+    logits: Float[Tensor, "batch seq vocab"], index: Int[Tensor, "batch seq"]
+) -> Float[Tensor, "batch seq"]:
+    """
+    credits to https://github.com/huggingface/trl/blob/07cfe1677e552b7d5c92b7740e5b2f0b057661d8/trl/trainer/utils.py#L1659
+
+    A memory-efficient implementation of the common `log_softmax -> gather` operation.
+
+    This function is equivalent to the following naive implementation:
+    ```python
+    logps = torch.gather(logits.log_softmax(-1), dim=-1, index=index.unsqueeze(-1)).squeeze(-1)
+    ```
+
+    Args:
+        logits (`torch.Tensor`):
+            Logits tensor of shape `(..., num_classes)`.
+        index (`torch.Tensor`):
+            Index tensor of shape `(...)`, specifying the positions to gather from the log-softmax output.
+
+    Returns:
+        `torch.Tensor`:
+            Gathered log probabilities with the same shape as `index`.
+    """
+    if logits.dtype in [torch.float32, torch.float64]:
+        selected_logits = torch.gather(logits, dim=-1, index=index.unsqueeze(-1)).squeeze(-1)
+        # loop to reduce peak mem consumption
+        logsumexp_values = torch.stack([torch.logsumexp(lg, dim=-1) for lg in logits])
+        per_token_logps = selected_logits - logsumexp_values  # log_softmax(x_i) = x_i - logsumexp(x)
+    else:
+        # logsumexp approach is unstable with bfloat16, fall back to slightly less efficient approach
+        per_token_logps = []
+        for row_logits, row_labels in zip(logits, index):  # loop to reduce peak mem consumption
+            row_logps = F.log_softmax(row_logits, dim=-1)
+            row_per_token_logps = row_logps.gather(dim=-1, index=row_labels.unsqueeze(-1)).squeeze(-1)
+            per_token_logps.append(row_per_token_logps)
+        per_token_logps = torch.stack(per_token_logps)
+    return per_token_logps
+
+
+@jaxtyped(typechecker=typechecker)
+def compute_logprobs(
+    model: Model,
+    input_ids: Int[Tensor, "batch seq"],
+    position_ids: Int[Tensor, "batch seq"],
+    temperature: float,
+) -> Float[Tensor, "batch seq vocab"]:
+    logits = forward(model, input_ids, position_ids).contiguous()
+    shifted_logits = shift_logits(logits)
+    shifted_logits = shifted_logits / temperature
+    logprobs = selective_log_softmax(shifted_logits, input_ids)
+    del logits, shifted_logits
+    return logprobs

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -2,6 +2,7 @@ from typing import TypeAlias
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 from beartype import beartype as typechecker
 from jaxtyping import Float, Int, jaxtyped
 from torch import Tensor

--- a/src/prime_rl/trainer/train.py
+++ b/src/prime_rl/trainer/train.py
@@ -18,8 +18,15 @@ from prime_rl.trainer.weights import WeightCheckpointManager
 from prime_rl.trainer.config import TrainerConfig
 from prime_rl.trainer.data import DataLoader, FakeDataLoader
 from prime_rl.trainer.logger import setup_logger
-from prime_rl.trainer.loss import compute_logprobs, entropy_loss, grpo_loss, shift_logits
-from prime_rl.trainer.model import forward, get_tokenizer, reshard_module, setup_model
+from prime_rl.trainer.loss import grpo_loss, compute_entropy
+from prime_rl.trainer.model import (
+    forward,
+    get_tokenizer,
+    reshard_module,
+    setup_model,
+    shift_logits,
+    compute_logprobs,
+)
 from prime_rl.trainer.perf import get_perf_counter
 from prime_rl.trainer.utils import (
     OffloadedTensor,
@@ -248,7 +255,7 @@ def train(config: TrainerConfig):
 
             # Compute entropy
             with torch.no_grad():
-                entropy = entropy_loss(
+                entropy = compute_entropy(
                     logits=shifted_logits,
                     loss_mask=loss_mask,
                     temperature=temperature,

--- a/src/prime_rl/trainer/train.py
+++ b/src/prime_rl/trainer/train.py
@@ -19,14 +19,12 @@ from prime_rl.trainer.weights import WeightCheckpointManager
 from prime_rl.trainer.config import TrainerConfig
 from prime_rl.trainer.data import DataLoader, FakeDataLoader
 from prime_rl.trainer.logger import setup_logger
-from prime_rl.trainer.loss import grpo_loss, compute_entropy
+from prime_rl.trainer.loss import grpo_loss, compute_entropy, shift_logits, compute_logprobs
 from prime_rl.trainer.model import (
     forward,
     get_tokenizer,
     reshard_module,
     setup_model,
-    shift_logits,
-    compute_logprobs,
 )
 from prime_rl.trainer.perf import get_perf_counter
 from prime_rl.trainer.utils import (

--- a/src/prime_rl/trainer/train.py
+++ b/src/prime_rl/trainer/train.py
@@ -10,6 +10,7 @@ from prime_rl.trainer import envs
 
 import shardcast
 import torch
+from torch import Tensor
 import torch.distributed as dist
 from torch._guards import log as torch_log
 from loguru import logger
@@ -258,13 +259,13 @@ def train(config: TrainerConfig):
                 )
 
             # Accumulate unnormalized local metrics
-            loss_metrics["loss/loss"] += loss.detach().clone().float()
-            loss_metrics["loss/entropy"] += entropy.detach().clone().float()
-            loss_metrics["loss/importance_ratio"] += importance_ratio.detach().clone().float()
-            loss_metrics["loss/clipped_ratio"] += clipped_token_count.detach().clone().float()
+            loss_metrics["loss/loss"] += loss.detach().float()
+            loss_metrics["loss/entropy"] += entropy.detach().float()
+            loss_metrics["loss/importance_ratio"] += importance_ratio.detach().float()
+            loss_metrics["loss/clipped_ratio"] += clipped_token_count.detach().float()
 
-            recomputed_logprob_error = micro_batch.get("recomputed_logprob_error", torch.tensor(0.0))
-            loss_metrics["loss/recomputed_logprob_error"] += recomputed_logprob_error.clone().float()
+            recomputed_logprob_error: Tensor = micro_batch.get("recomputed_logprob_error", torch.tensor(0.0))
+            loss_metrics["loss/recomputed_logprob_error"] += recomputed_logprob_error.detach().float()
 
             # Scale loss by scale factor before backward pass
             loss = loss / loss_scale

--- a/src/prime_rl/trainer/train.py
+++ b/src/prime_rl/trainer/train.py
@@ -277,9 +277,6 @@ def train(config: TrainerConfig):
                 f"Completed micro batch {micro_step}/{num_micro_batches} (loss={(loss.item() / loss_mask.sum()):.2f}, entropy={(entropy.item() / loss_mask.sum()):.2f}, importance_ratio={(importance_ratio.item() / loss_mask.sum()):.2f})"
             )
 
-            del micro_batch, logits, input_ids, position_ids, advantages, logprobs, loss_mask
-            del loss, entropy, importance_ratio, clipped_token_count
-
         # Normalize all loss metrics globally before reporting
         for key, value in loss_metrics.items():
             loss_metrics[key] = value / loss_scale

--- a/src/prime_rl/trainer/train.py
+++ b/src/prime_rl/trainer/train.py
@@ -244,7 +244,7 @@ def train(config: TrainerConfig):
 
             # Compute loss
             loss, importance_ratio, clipped_token_count = grpo_loss(
-                logits=shifted_logits,
+                shifted_logits=shifted_logits,
                 input_ids=input_ids,
                 advantages=advantages,
                 original_logprobs=logprobs,
@@ -256,7 +256,7 @@ def train(config: TrainerConfig):
             # Compute entropy
             with torch.no_grad():
                 entropy = compute_entropy(
-                    logits=shifted_logits,
+                    shifted_logits=shifted_logits,
                     loss_mask=loss_mask,
                     temperature=temperature,
                 )

--- a/src/prime_rl/trainer/train.py
+++ b/src/prime_rl/trainer/train.py
@@ -238,6 +238,7 @@ def train(config: TrainerConfig):
             # Forward pass
             logits = forward(model, input_ids, position_ids).contiguous()
             shifted_logits = shift_logits(logits)
+            del logits
 
             # Compute loss
             loss, importance_ratio, clipped_token_count = grpo_loss(

--- a/tests/integration/trainer/test_debug_path.py
+++ b/tests/integration/trainer/test_debug_path.py
@@ -20,7 +20,7 @@ def create_sample(seq_len: int) -> Sample:
         "position_ids": torch.zeros(seq_len).long(),
         "advantages": torch.randn(seq_len).float(),
         "loss_mask": torch.ones(seq_len).long(),
-        "logprobs": torch.randn(seq_len - 1).float(),
+        "logprobs": torch.randn(seq_len).float(),
         "total_tokens": seq_len,
     }
 

--- a/tests/unit/training/test_loss.py
+++ b/tests/unit/training/test_loss.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from prime_rl.trainer.loss import entropy_loss, grpo_loss_clip, grpo_loss_ratio
+from prime_rl.trainer.loss import compute_entropy, grpo_loss_clip, grpo_loss_ratio
 
 pytestmark = [pytest.mark.gpu]
 
@@ -58,7 +58,7 @@ def test_grpo_loss_ratio(dtype):
 def test_entropy_loss(dtype):
     logits = torch.randn(10, 10, 10, dtype=dtype).cuda()
     loss_mask = torch.ones(10, 10).int().cuda()
-    entropy = entropy_loss(logits, loss_mask, temperature=0.6)
+    entropy = compute_entropy(logits, loss_mask, temperature=0.6)
     assert entropy.shape == ()
     assert entropy.item() is not None
 

--- a/tests/unit/training/test_loss.py
+++ b/tests/unit/training/test_loss.py
@@ -9,7 +9,7 @@ pytestmark = [pytest.mark.gpu]
 @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
 def test_grpo_loss(dtype):
     logits = torch.randn(10, 10, 10, dtype=dtype).cuda()
-    original_logprobs = torch.randn(10, 9, dtype=dtype).cuda()
+    original_logprobs = torch.randn(10, 10, dtype=dtype).cuda()
     advantages = torch.randn(10, 10).cuda()
     loss_mask = torch.ones(10, 10).int().cuda()
     input_ids = torch.randint(0, 10, (10, 10)).cuda()
@@ -37,7 +37,7 @@ def test_grpo_loss(dtype):
 @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
 def test_grpo_loss_ratio(dtype):
     logits = torch.randn(10, 10, 10, dtype=dtype).cuda()
-    original_logprobs = torch.randn(10, 9, dtype=dtype).cuda()
+    original_logprobs = torch.randn(10, 10, dtype=dtype).cuda()
     advantages = torch.randn(10, 10).cuda()
     loss_mask = torch.ones(10, 10).int().cuda()
     input_ids = torch.randint(0, 10, (10, 10)).cuda()
@@ -66,7 +66,7 @@ def test_entropy_loss(dtype):
 @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
 def test_grpo_loss_padding(dtype):
     logits = torch.randn(10, 10, 10, dtype=dtype).cuda()
-    original_logprobs = torch.randn(10, 9, dtype=dtype).cuda()
+    original_logprobs = torch.randn(10, 10, dtype=dtype).cuda()
     advantages = torch.randn(10, 10).cuda()
     loss_mask = torch.ones(10, 10).int().cuda()
     input_ids = torch.randint(0, 10, (10, 10)).cuda()


### PR DESCRIPTION
This is what I think is the proper fix to a shape mismatch problem arising from packing logprobs. The trainer computes logprobs with tensor shape `(B, L-1, V)`, but when packing k samples into a batch the orchestratror writes a tensor of shape `(B, L-k, V)`. This PR changes the orchestrator batch packing to assert that for each sample from the orchestrator we have `len(input_ids) == len(logprobs)` and `logprobs[0] == 0`. This maintains the simpler equivariance that for every index `i` `logprob[i]` is the logprob associated to the token ID `input_ids[i]`.
