### PR TITLE
Fix health check logs

### DIFF
--- a/src/prime_rl/orchestrator/client.py
+++ b/src/prime_rl/orchestrator/client.py
@@ -37,11 +37,11 @@ async def check_health(client: AsyncOpenAI, interval: int = 1, log_interval: int
     logger.debug(f"Starting pinging {url} to check health")
     while wait_time < timeout:
         try:
-            await client.get(url, cast_to=Response)
+            await client.get(url, cast_to=Response, options={"max_retries": 0})
             logger.debug(f"Inference pool is ready after {wait_time} seconds")
             return
         except Exception as e:
-            if wait_time % log_interval == 0:
+            if wait_time % log_interval == 0 and wait_time > 0:
                 logger.warning(f"Inference pool was not reached after {wait_time} seconds (Error: {e})")
             await asyncio.sleep(interval)
             wait_time += interval


### PR DESCRIPTION
Before, timeout logs were not accurate because the OAI client was doing retries. Also, we don't log "waited for 0 seconds" which is a bit silly.

<img width="683" height="446" alt="Screenshot 2025-07-19 at 6 37 11 PM" src="https://github.com/user-attachments/assets/fa0102e0-7be4-47a2-b688-d2d18a251de7" />
