### PR TITLE
Add `flash_infer`

### DIFF
--- a/.github/workflows/gpu_tests.yaml
+++ b/.github/workflows/gpu_tests.yaml
@@ -27,7 +27,7 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
       - name: Install dependencies
-        run: uv sync && uv sync --extra fa
+        run: uv sync && uv sync --all-extras
 
   unit-tests:
     name: Unit tests

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -46,7 +46,7 @@ RUN --mount=type=cache,target=/app/.cache/uv \
     uv sync --locked --no-dev
 
 RUN --mount=type=cache,target=/app/.cache/uv \
-    uv sync --extra fa --locked --no-dev
+    uv sync --all-extras --locked --no-dev
 
 FROM python:3.12-slim
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ source $HOME/.local/bin/env
 3. Synchronize the environment
 
 ```bash
-uv sync && uv sync --extra fa
+uv sync && uv sync --all-extras
 ```
 
 </details>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,8 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project.optional-dependencies]
-fa = ["flash-attn>=2.8.0", "flashinfer-python>=0.2.8rc1"]
+flash-attn = ["flash-attn>=2.8.0"]
+flash-infer = ["flashinfer-python>=0.2.8rc1"]
 
 [tool.uv]
 no-build-isolation-package = ["flash-attn"]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -44,7 +44,7 @@ main() {
     fi
 
     log_info "Installing dependencies in virtual environment..."
-    uv sync && uv sync --extra fa
+    uv sync && uv sync --all-extras
     log_info "Installation completed!"
 }
 

--- a/uv.lock
+++ b/uv.lock
@@ -2072,8 +2072,10 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-fa = [
+flash-attn = [
     { name = "flash-attn" },
+]
+flash-infer = [
     { name = "flashinfer-python" },
 ]
 
@@ -2091,8 +2093,8 @@ requires-dist = [
     { name = "beartype", specifier = ">=0.21.0" },
     { name = "cydifflib", specifier = ">=1.2.0" },
     { name = "datasets", specifier = ">=3.6.0" },
-    { name = "flash-attn", marker = "extra == 'fa'", specifier = ">=2.8.0" },
-    { name = "flashinfer-python", marker = "extra == 'fa'", specifier = ">=0.2.8rc1" },
+    { name = "flash-attn", marker = "extra == 'flash-attn'", specifier = ">=2.8.0" },
+    { name = "flashinfer-python", marker = "extra == 'flash-infer'", specifier = ">=0.2.8rc1" },
     { name = "google-cloud-storage", specifier = ">=3.1.1" },
     { name = "jaxtyping", specifier = ">=0.3.2" },
     { name = "liger-kernel", specifier = ">=0.5.10" },
@@ -2115,7 +2117,7 @@ requires-dist = [
     { name = "vllm", specifier = ">=0.9.1" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
-provides-extras = ["fa"]
+provides-extras = ["flash-attn", "flash-infer"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Adds `flashinfer-python` for optimized attention kernels for vLLM.

## Performance

Flash inference generally seems to be a bit faster across DP setting, but not by a significant margin. 

*NB: Slight deviations are expected because the sampling is not seeded which may lead to different generations lengths which in turn affect throughput. Also comparison might not be 100% fair because done on different machines.*

<img width="315" height="302" alt="Screenshot 2025-07-19 at 6 44 57 PM" src="https://github.com/user-attachments/assets/7904040c-1d5a-4d17-b46e-000cd4095037" />

*W&B View: https://wandb.ai/primeintellect/intellect-math-bench/workspace?nw=57mfkkyig5g*

## Correctness

Matches baseline run on `hendrycks-math` on main for ~450 steps (run out of disk space for ckpts after)

<img width="284" height="254" alt="Screenshot 2025-07-19 at 11 40 16 PM" src="https://github.com/user-attachments/assets/bc774361-9302-4900-b4a8-14b00697be6b" />

