### PR TITLE
Add custom advantage computation support + negative clipping to zero

### DIFF
--- a/src/prime_rl/orchestrator/advantage.py
+++ b/src/prime_rl/orchestrator/advantage.py
@@ -39,7 +39,20 @@ _ADVANTAGE_REGISTRY: dict[AdvantageType, Callable[[Float[Tensor, "group"]], Floa
 }
 
 
-def compute_advantages(rewards: list[float], samples_per_problem: int, advantage_type: AdvantageType) -> list[float]:
+def compute_advantages(
+    rewards: list[float], samples_per_problem: int, advantage_type: AdvantageType
+) -> tuple[list[float], dict[str, float]]:
+    """
+    Computes advantages and various statistics for logging from a flattened list of rewards for a given advantage computation type.
+
+    Args:
+        rewards: Flattened list of rewards where first `samples_per_problem` rewards are for the first problem
+        samples_per_problem: Number of samples (and thus, rewards) per problem
+        advantage_type: Type of advantage computation to use
+
+    Returns:
+        Tuple of (advantages, advantage_stats)
+    """
     advantages = []
     solve_none, solve_all = 0, 0
     problem_rewards = [rewards[i : i + samples_per_problem] for i in range(0, len(rewards), samples_per_problem)]
@@ -50,10 +63,13 @@ def compute_advantages(rewards: list[float], samples_per_problem: int, advantage
         assert len(advantages_tensor) == len(rewards_tensor)
         advantages.extend(advantages_tensor.tolist())
         if torch.all(rewards_tensor == 0):
-            solve_none += 1
+            solve_none += 1 / len(problem_rewards)
         if torch.all(rewards_tensor == 1):
-            solve_all += 1
-    solve_none_ratio = solve_none / len(problem_rewards)
-    solve_all_ratio = solve_all / len(problem_rewards)
-    effective_batch_size_ratio = 1 - solve_none_ratio - solve_all_ratio
-    return advantages, solve_none_ratio, solve_all_ratio, effective_batch_size_ratio
+            solve_all += 1 / len(problem_rewards)
+    effective_batch_size = 1 - solve_none - solve_all
+    advantage_stats = {
+        "solve_none": solve_none,
+        "solve_all": solve_all,
+        "effective_batch_size": effective_batch_size,
+    }
+    return advantages, advantage_stats

--- a/src/prime_rl/orchestrator/advantage.py
+++ b/src/prime_rl/orchestrator/advantage.py
@@ -8,13 +8,25 @@ from torch import Tensor
 
 @jaxtyped(typechecker=typechecker)
 def compute_advantage_drgrpo(rewards: Float[Tensor, "group"]) -> Float[Tensor, "group"]:
-    """Compute DR.GRPO advantages for a single group."""
+    """
+    Compute DR.GRPO advantages for a single group.
+    For example:
+    - `[0.0, 0.0, 1.0, 1.0]` -> `[-0.5, -0.5, 0.5, 0.5]`
+    - `[0.0, 0.0, 0.0, 0.0]` -> `[0.0, 0.0, 0.0, 0.0]`
+    - `[1.0, 1.0, 1.0, 1.0]` -> `[0.0, 0.0, 0.0, 0.0]`
+    """
     return rewards - rewards.mean()
 
 
 @jaxtyped(typechecker=typechecker)
 def compute_advantage_drgrpo_negclipped(rewards: Float[Tensor, "group"]) -> Float[Tensor, "group"]:
-    """Compute DR.GRPO advantages but clips all negative advantages to zero for a single group."""
+    """
+    Compute DR.GRPO advantages for a single group, but clips all negative advantages to zero.
+    For example:
+    - `[0.0, 0.0, 1.0, 1.0]` -> `[0.0, 0.0, 0.5, 0.5]`
+    - `[0.0, 0.0, 0.0, 0.0]` -> `[0.0, 0.0, 0.0, 0.0]`
+    - `[1.0, 1.0, 1.0, 1.0]` -> `[0.0, 0.0, 0.0, 0.0]`
+    """
     return torch.maximum(rewards - rewards.mean(), torch.zeros_like(rewards))
 
 

--- a/src/prime_rl/orchestrator/advantage.py
+++ b/src/prime_rl/orchestrator/advantage.py
@@ -33,7 +33,7 @@ def compute_advantage_drgrpo_negclipped(rewards: Float[Tensor, "group"]) -> Floa
 AdvantageType = Literal["drgrpo", "drgrpo-negclipped"]
 
 # Map of advantage types to their corresponding functions
-_ADVANTAGE_REGISTRY: dict[AdvantageType, Callable[[Float[Tensor, "group"]], Float[Tensor, "group"]]] = {
+REGISTRY: dict[AdvantageType, Callable[[Float[Tensor, "group"]], Float[Tensor, "group"]]] = {
     "drgrpo": compute_advantage_drgrpo,
     "drgrpo-negclipped": compute_advantage_drgrpo_negclipped,
 }
@@ -57,7 +57,7 @@ def compute_advantages(
     solve_none, solve_all = 0, 0
     assert len(rewards) % samples_per_problem == 0
     problem_rewards = [rewards[i : i + samples_per_problem] for i in range(0, len(rewards), samples_per_problem)]
-    compute_advantage = _ADVANTAGE_REGISTRY[advantage_type]
+    compute_advantage = REGISTRY[advantage_type]
     for rewards in problem_rewards:
         rewards_tensor = torch.tensor(rewards)
         advantages_tensor = compute_advantage(rewards_tensor)

--- a/src/prime_rl/orchestrator/advantage.py
+++ b/src/prime_rl/orchestrator/advantage.py
@@ -56,17 +56,17 @@ def compute_advantages(
     advantages = []
     solve_none, solve_all = 0, 0
     assert len(rewards) % samples_per_problem == 0
-    problem_rewards = [rewards[i : i + samples_per_problem] for i in range(0, len(rewards), samples_per_problem)]
+    all_group_rewards = [rewards[i : i + samples_per_problem] for i in range(0, len(rewards), samples_per_problem)]
     compute_advantage = REGISTRY[advantage_type]
-    for rewards in problem_rewards:
-        rewards_tensor = torch.tensor(rewards)
-        advantages_tensor = compute_advantage(rewards_tensor)
-        assert len(advantages_tensor) == len(rewards_tensor)
-        advantages.extend(advantages_tensor.tolist())
-        if torch.all(rewards_tensor == 0):
-            solve_none += 1 / len(problem_rewards)
-        if torch.all(rewards_tensor == 1):
-            solve_all += 1 / len(problem_rewards)
+    for group_rewards in all_group_rewards:
+        group_rewards_tensor = torch.tensor(group_rewards)
+        group_advantages_tensor = compute_advantage(group_rewards_tensor)
+        assert len(group_advantages_tensor) == len(group_rewards_tensor)
+        advantages.extend(group_advantages_tensor.tolist())
+        if torch.all(group_rewards_tensor == 0):
+            solve_none += 1 / len(all_group_rewards)
+        if torch.all(group_rewards_tensor == 1):
+            solve_all += 1 / len(all_group_rewards)
     assert len(rewards) == len(advantages)
     effective_batch_size = 1 - solve_none - solve_all
     advantage_stats = {"solve_none": solve_none, "solve_all": solve_all, "effective_batch_size": effective_batch_size}

--- a/src/prime_rl/orchestrator/advantage.py
+++ b/src/prime_rl/orchestrator/advantage.py
@@ -1,0 +1,47 @@
+from typing import Callable, Literal
+
+import torch
+from beartype import beartype as typechecker
+from jaxtyping import Float, jaxtyped
+from torch import Tensor
+
+
+@jaxtyped(typechecker=typechecker)
+def compute_advantage_drgrpo(rewards: Float[Tensor, "group"]) -> Float[Tensor, "group"]:
+    """Compute DR.GRPO advantages for a single group."""
+    return rewards - rewards.mean()
+
+
+@jaxtyped(typechecker=typechecker)
+def compute_advantage_drgrpo_negclipped(rewards: Float[Tensor, "group"]) -> Float[Tensor, "group"]:
+    """Compute DR.GRPO advantages but clips all negative advantages to zero for a single group."""
+    return torch.maximum(rewards - rewards.mean(), torch.zeros_like(rewards))
+
+
+AdvantageType = Literal["drgrpo", "drgrpo-negclipped"]
+
+# Map of advantage types to their corresponding functions
+_ADVANTAGE_REGISTRY: dict[AdvantageType, Callable[[Float[Tensor, "group"]], Float[Tensor, "group"]]] = {
+    "drgrpo": compute_advantage_drgrpo,
+    "drgrpo-negclipped": compute_advantage_drgrpo_negclipped,
+}
+
+
+def compute_advantages(rewards: list[float], samples_per_problem: int, advantage_type: AdvantageType) -> list[float]:
+    advantages = []
+    solve_none, solve_all = 0, 0
+    problem_rewards = [rewards[i : i + samples_per_problem] for i in range(0, len(rewards), samples_per_problem)]
+    compute_advantage = _ADVANTAGE_REGISTRY[advantage_type]
+    for rewards in problem_rewards:
+        rewards_tensor = torch.tensor(rewards)
+        advantages_tensor = compute_advantage(rewards_tensor)
+        assert len(advantages_tensor) == len(rewards_tensor)
+        advantages.extend(advantages_tensor.tolist())
+        if torch.all(rewards_tensor == 0):
+            solve_none += 1
+        if torch.all(rewards_tensor == 1):
+            solve_all += 1
+    solve_none_ratio = solve_none / len(problem_rewards)
+    solve_all_ratio = solve_all / len(problem_rewards)
+    effective_batch_size_ratio = 1 - solve_none_ratio - solve_all_ratio
+    return advantages, solve_none_ratio, solve_all_ratio, effective_batch_size_ratio

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -4,6 +4,7 @@ from typing import Annotated, Literal
 from pydantic import Field, model_validator
 
 from prime_rl.eval.registry import Benchmark
+from prime_rl.orchestrator.advantage import AdvantageType
 from prime_rl.utils.config import LogConfig, ModelConfig, MultiMonitorConfig
 from prime_rl.utils.pydantic_config import BaseConfig, BaseSettings
 
@@ -201,10 +202,10 @@ class OrchestratorConfig(BaseSettings):
         ),
     ] = 1
 
-    advantage_style: Annotated[
-        Literal["drgrpo", "drgrpo-negclipped"],
+    advantage_type: Annotated[
+        AdvantageType,
         Field(
-            description="Style of advantage computation to use. 'drgrpo' uses standard mean-centered advantages, 'drgrpo-negclipped' clips negative advantages to zero."
+            description="Type of advantage computation to use. For details on the variants please refer directly to their docstrings."
         ),
     ] = "drgrpo"
 

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -201,6 +201,13 @@ class OrchestratorConfig(BaseSettings):
         ),
     ] = 1
 
+    advantage_style: Annotated[
+        Literal["drgrpo", "drgrpo-negclipped"],
+        Field(
+            description="Style of advantage computation to use. 'drgrpo' uses standard mean-centered advantages, 'drgrpo-negclipped' clips negative advantages to zero."
+        ),
+    ] = "drgrpo"
+
     seq_len: Annotated[
         int,
         Field(

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -214,7 +214,7 @@ async def orchestrate(config: OrchestratorConfig):
         completion_masks = results["completion_masks"]
         rewards = outputs["reward"]  # TODO: Align naming between prime-rl <> verifiers
 
-        advantages, solve_none_ratio, solve_all_ratio, effective_batch_size_ratio = compute_advantages(
+        advantages, advantage_stats = compute_advantages(
             rewards=rewards, samples_per_problem=config.rollouts_per_prompt, advantage_type=config.advantage_type
         )
 
@@ -300,9 +300,9 @@ async def orchestrate(config: OrchestratorConfig):
         # Log rewards metrics to monitor
         reward_metrics = {
             "reward/reward": np.mean(rewards),
-            "reward/solve_none": solve_none_ratio,
-            "reward/solve_all": solve_all_ratio,
-            "reward/effective_batch_size": effective_batch_size_ratio,
+            "reward/solve_none": advantage_stats["solve_none"],
+            "reward/solve_all": advantage_stats["solve_all"],
+            "reward/effective_batch_size": advantage_stats["effective_batch_size"],
             "step": progress.step,
         }
         monitor.log(reward_metrics)

--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from typing import Any
 
-import numpy as np
 import pandas as pd
 from openai.types.chat import ChatCompletion
 from rich.console import Console
@@ -107,60 +106,6 @@ def compute_rewards(
         reward = compute_reward(completion, verification_info)
         rewards.append(reward)
     return rewards
-
-
-def compute_advantages(rewards: list[float], samples_per_problem: int) -> list[float]:
-    per_problem_rewards = [rewards[i : i + samples_per_problem] for i in range(0, len(rewards), samples_per_problem)]
-    advantages = []
-    solve_none = 0
-    solve_all = 0
-    for problem_rewards in per_problem_rewards:
-        reward_array = np.array(problem_rewards)
-        problem_advantages = reward_array - reward_array.mean()
-        advantages.extend(problem_advantages.tolist())
-        if np.all(problem_rewards == 0):
-            solve_none += 1
-        if np.all(problem_rewards == 1):
-            solve_all += 1
-    solve_none_ratio = solve_none / len(per_problem_rewards)
-    solve_all_ratio = solve_all / len(per_problem_rewards)
-    effective_batch_size_ratio = 1 - solve_none_ratio - solve_all_ratio
-    return advantages, solve_none_ratio, solve_all_ratio, effective_batch_size_ratio
-
-
-def compute_negclipped_advantages(
-    rewards: list[float], samples_per_problem: int
-) -> tuple[list[float], float, float, float]:
-    """
-    Compute advantages where negative values are clipped to zero.
-
-    This clips all negative advantages to 0, which can help reduce the impact
-    of overly penalizing below-average samples in policy gradient methods.
-
-    Args:
-        rewards: List of reward values
-        samples_per_problem: Number of samples/rollouts per problem
-
-    Returns:
-        Tuple of (advantages, solve_none_ratio, solve_all_ratio, effective_batch_size_ratio)
-    """
-    per_problem_rewards = [rewards[i : i + samples_per_problem] for i in range(0, len(rewards), samples_per_problem)]
-    advantages = []
-    solve_none = 0
-    solve_all = 0
-    for problem_rewards in per_problem_rewards:
-        reward_array = np.array(problem_rewards)
-        problem_advantages = reward_array - reward_array.mean()
-        clipped_advantages = np.maximum(problem_advantages, 0.0)
-        advantages.extend(clipped_advantages.tolist())
-        if np.all(problem_rewards == 0):
-            solve_none += 1
-        if np.all(problem_rewards == 1):
-            solve_all += 1
-    solve_none_ratio = solve_none / len(per_problem_rewards)
-    solve_all_ratio = solve_all / len(per_problem_rewards)
-    effective_batch_size_ratio = 1 - solve_none_ratio - solve_all_ratio
-    return advantages, solve_none_ratio, solve_all_ratio, effective_batch_size_ratio
 
 
 def print_benchmark(history: dict[str, list[Any]]) -> None:

--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -123,7 +123,42 @@ def compute_advantages(rewards: list[float], samples_per_problem: int) -> list[f
         if np.all(problem_rewards == 1):
             solve_all += 1
     solve_none_ratio = solve_none / len(per_problem_rewards)
-    solve_all_ratio = solve_all / len(per_problem_rewards)   
+    solve_all_ratio = solve_all / len(per_problem_rewards)
+    effective_batch_size_ratio = 1 - solve_none_ratio - solve_all_ratio
+    return advantages, solve_none_ratio, solve_all_ratio, effective_batch_size_ratio
+
+
+def compute_negclipped_advantages(
+    rewards: list[float], samples_per_problem: int
+) -> tuple[list[float], float, float, float]:
+    """
+    Compute advantages where negative values are clipped to zero.
+
+    This clips all negative advantages to 0, which can help reduce the impact
+    of overly penalizing below-average samples in policy gradient methods.
+
+    Args:
+        rewards: List of reward values
+        samples_per_problem: Number of samples/rollouts per problem
+
+    Returns:
+        Tuple of (advantages, solve_none_ratio, solve_all_ratio, effective_batch_size_ratio)
+    """
+    per_problem_rewards = [rewards[i : i + samples_per_problem] for i in range(0, len(rewards), samples_per_problem)]
+    advantages = []
+    solve_none = 0
+    solve_all = 0
+    for problem_rewards in per_problem_rewards:
+        reward_array = np.array(problem_rewards)
+        problem_advantages = reward_array - reward_array.mean()
+        clipped_advantages = np.maximum(problem_advantages, 0.0)
+        advantages.extend(clipped_advantages.tolist())
+        if np.all(problem_rewards == 0):
+            solve_none += 1
+        if np.all(problem_rewards == 1):
+            solve_all += 1
+    solve_none_ratio = solve_none / len(per_problem_rewards)
+    solve_all_ratio = solve_all / len(per_problem_rewards)
     effective_batch_size_ratio = 1 - solve_none_ratio - solve_all_ratio
     return advantages, solve_none_ratio, solve_all_ratio, effective_batch_size_ratio
 


### PR DESCRIPTION
This PR adds an optional `advantage_style` field that defaults to `drgrpo`.
Included is @justusmattern27's proposal for a variant where negative advantages are clipped to zero (`drgrpo-negclipped`).

<img width="1035" height="406" alt="image" src="https://github.com/user-attachments/assets/162d29b3-882a-4bf4-ae23-0795a17f821a" />

Shown is the `reverse-text` config on `willcb/Qwen2.5-0.5B-Reverse-SFT`.
The only modifications made were in setting `max_norm = 0.2`, `lr = 5e-6`.

Due to the seemingly more stable gradients of `drgrpo-negclipped`, I'm able to successfully continue training on this task for ~5000 steps without any observed collapse. I use more aggressive clipping (`max_norm = 0.00001`) and a larger learning rate to compensate (~1e-5 to ~4e-5 all seemed functional at this threshold for the model).

<img width="2334" height="1128" alt="image" src="https://github.com/user-attachments/assets/fce9b28f-38fa-4382-87c5-40346ca2d9c6" />
