### PR TITLE
Refactor advantage type computation

### DIFF
--- a/src/prime_rl/orchestrator/advantage.py
+++ b/src/prime_rl/orchestrator/advantage.py
@@ -1,0 +1,47 @@
+from typing import Callable, Literal
+
+import torch
+from beartype import beartype as typechecker
+from jaxtyping import Float, jaxtyped
+from torch import Tensor
+
+
+@jaxtyped(typechecker=typechecker)
+def compute_advantage_drgrpo(rewards: Float[Tensor, "group"]) -> Float[Tensor, "group"]:
+    """Compute DR.GRPO advantages for a single group."""
+    return rewards - rewards.mean()
+
+
+@jaxtyped(typechecker=typechecker)
+def compute_advantage_drgrpo_negclipped(rewards: Float[Tensor, "group"]) -> Float[Tensor, "group"]:
+    """Compute DR.GRPO advantages but clips all negative advantages to zero for a single group."""
+    return torch.maximum(rewards - rewards.mean(), torch.zeros_like(rewards))
+
+
+AdvantageType = Literal["drgrpo", "drgrpo-negclipped"]
+
+# Map of advantage types to their corresponding functions
+_ADVANTAGE_REGISTRY: dict[AdvantageType, Callable[[Float[Tensor, "group"]], Float[Tensor, "group"]]] = {
+    "drgrpo": compute_advantage_drgrpo,
+    "drgrpo-negclipped": compute_advantage_drgrpo_negclipped,
+}
+
+
+def compute_advantages(rewards: list[float], samples_per_problem: int, advantage_type: AdvantageType) -> list[float]:
+    advantages = []
+    solve_none, solve_all = 0, 0
+    problem_rewards = [rewards[i : i + samples_per_problem] for i in range(0, len(rewards), samples_per_problem)]
+    compute_advantage = _ADVANTAGE_REGISTRY[advantage_type]
+    for rewards in problem_rewards:
+        rewards_tensor = torch.tensor(rewards)
+        advantages_tensor = compute_advantage(rewards_tensor)
+        assert len(advantages_tensor) == len(rewards_tensor)
+        advantages.extend(advantages_tensor.tolist())
+        if torch.all(rewards_tensor == 0):
+            solve_none += 1
+        if torch.all(rewards_tensor == 1):
+            solve_all += 1
+    solve_none_ratio = solve_none / len(problem_rewards)
+    solve_all_ratio = solve_all / len(problem_rewards)
+    effective_batch_size_ratio = 1 - solve_none_ratio - solve_all_ratio
+    return advantages, solve_none_ratio, solve_all_ratio, effective_batch_size_ratio

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -4,6 +4,7 @@ from typing import Annotated, Literal
 from pydantic import Field, model_validator
 
 from prime_rl.eval.registry import Benchmark
+from prime_rl.orchestrator.advantage import AdvantageType
 from prime_rl.utils.config import LogConfig, ModelConfig, MultiMonitorConfig
 from prime_rl.utils.pydantic_config import BaseConfig, BaseSettings
 
@@ -201,10 +202,10 @@ class OrchestratorConfig(BaseSettings):
         ),
     ] = 1
 
-    advantage_style: Annotated[
-        Literal["drgrpo", "drgrpo-negclipped"],
+    advantage_type: Annotated[
+        AdvantageType,
         Field(
-            description="Style of advantage computation to use. 'drgrpo' uses standard mean-centered advantages, 'drgrpo-negclipped' clips negative advantages to zero."
+            description="Type of advantage computation to use. For details on the variants please refer directly to their docstrings."
         ),
     ] = "drgrpo"
 

--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from typing import Any
 
-import numpy as np
 import pandas as pd
 from openai.types.chat import ChatCompletion
 from rich.console import Console
@@ -107,60 +106,6 @@ def compute_rewards(
         reward = compute_reward(completion, verification_info)
         rewards.append(reward)
     return rewards
-
-
-def compute_advantages(rewards: list[float], samples_per_problem: int) -> list[float]:
-    per_problem_rewards = [rewards[i : i + samples_per_problem] for i in range(0, len(rewards), samples_per_problem)]
-    advantages = []
-    solve_none = 0
-    solve_all = 0
-    for problem_rewards in per_problem_rewards:
-        reward_array = np.array(problem_rewards)
-        problem_advantages = reward_array - reward_array.mean()
-        advantages.extend(problem_advantages.tolist())
-        if np.all(problem_rewards == 0):
-            solve_none += 1
-        if np.all(problem_rewards == 1):
-            solve_all += 1
-    solve_none_ratio = solve_none / len(per_problem_rewards)
-    solve_all_ratio = solve_all / len(per_problem_rewards)
-    effective_batch_size_ratio = 1 - solve_none_ratio - solve_all_ratio
-    return advantages, solve_none_ratio, solve_all_ratio, effective_batch_size_ratio
-
-
-def compute_negclipped_advantages(
-    rewards: list[float], samples_per_problem: int
-) -> tuple[list[float], float, float, float]:
-    """
-    Compute advantages where negative values are clipped to zero.
-
-    This clips all negative advantages to 0, which can help reduce the impact
-    of overly penalizing below-average samples in policy gradient methods.
-
-    Args:
-        rewards: List of reward values
-        samples_per_problem: Number of samples/rollouts per problem
-
-    Returns:
-        Tuple of (advantages, solve_none_ratio, solve_all_ratio, effective_batch_size_ratio)
-    """
-    per_problem_rewards = [rewards[i : i + samples_per_problem] for i in range(0, len(rewards), samples_per_problem)]
-    advantages = []
-    solve_none = 0
-    solve_all = 0
-    for problem_rewards in per_problem_rewards:
-        reward_array = np.array(problem_rewards)
-        problem_advantages = reward_array - reward_array.mean()
-        clipped_advantages = np.maximum(problem_advantages, 0.0)
-        advantages.extend(clipped_advantages.tolist())
-        if np.all(problem_rewards == 0):
-            solve_none += 1
-        if np.all(problem_rewards == 1):
-            solve_all += 1
-    solve_none_ratio = solve_none / len(per_problem_rewards)
-    solve_all_ratio = solve_all / len(per_problem_rewards)
-    effective_batch_size_ratio = 1 - solve_none_ratio - solve_all_ratio
-    return advantages, solve_none_ratio, solve_all_ratio, effective_batch_size_ratio
 
 
 def print_benchmark(history: dict[str, list[Any]]) -> None:


### PR DESCRIPTION
Code style refactor for #610. Includes:
- Defines advantage type factory in `prime_rl.orchestrator.advantage`. Each variant can be implemented as a simple function with (jaxtype-enforced) type `Float[Tensor["group"]] -> Float[Tensor["group"]]`, i.e. it is only responsible for computing the advantage for each rollout of a group
- The logic for nesting the per problem rewards, iteratively calling the correct advantage type function and collecting statistics such as `solve_none` and `solve_all` is ony handled *once* in `compute_advantages` which is 
- The config arg changed to `advantage_type` and is tied to the registry via a literal `AdvantageType`

Also fixes a bug from #602 where the `solve_none` and `solve_all` ratios are always zero because of a wrong type being passed.