### PR TITLE
Auto-accept GH host key

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,6 +23,9 @@ main() {
     log_info "Installing git, tmux, htop, nvtop, cmake, python3-dev, cgroup-tools..."
     sudo apt install git tmux htop nvtop cmake python3-dev cgroup-tools -y
 
+    log_info "Configuring SSH to automatically accept GitHub's host key..."
+    ssh-keyscan github.com >>~/.ssh/known_hosts 2>/dev/null
+
     log_info "Cloning repository..."
     git clone git@github.com:PrimeIntellect-ai/prime-rl.git
 


### PR DESCRIPTION
This is to avoid the one interactive prompt from SSH when trying to clone the repo from `install.sh`.

Tested working on new machine by simply installing 

```bash
curl -sSL https://raw.githubusercontent.com/PrimeIntellect-ai/prime-rl/7d283775b47cc55c5d9bc43ffa7b5f25265a0cc6/scripts/install.sh | bash
```