### PR TITLE
More informative sample logging

### DIFF
--- a/configs/orchestrator/hendrycks_math/14b.toml
+++ b/configs/orchestrator/hendrycks_math/14b.toml
@@ -15,7 +15,6 @@ id = "hendrycks-math"
 
 [monitor.wandb.log_samples]
 interval = 10
-num_samples = 16
 
 [eval]
 interval = 50

--- a/configs/orchestrator/hendrycks_math/1b.toml
+++ b/configs/orchestrator/hendrycks_math/1b.toml
@@ -15,7 +15,6 @@ id = "hendrycks-math"
 
 [monitor.wandb.log_samples]
 interval = 10
-num_samples = 16
 
 [eval]
 interval = 50

--- a/configs/orchestrator/hendrycks_math/32b.toml
+++ b/configs/orchestrator/hendrycks_math/32b.toml
@@ -15,7 +15,6 @@ id = "hendrycks-math"
 
 [monitor.wandb.log_samples]
 interval = 10
-num_samples = 16
 
 [eval]
 interval = 50

--- a/configs/orchestrator/hendrycks_math/7b.toml
+++ b/configs/orchestrator/hendrycks_math/7b.toml
@@ -15,7 +15,6 @@ id = "hendrycks-math"
 
 [monitor.wandb.log_samples]
 interval = 10
-num_samples = 16
 
 [eval]
 interval = 50

--- a/configs/orchestrator/intellect_math/1b.toml
+++ b/configs/orchestrator/intellect_math/1b.toml
@@ -20,7 +20,6 @@ max_solve_rate = 0.9
 
 [monitor.wandb.log_samples]
 interval = 50
-num_samples = 16
 
 [eval]
 interval = 50

--- a/configs/orchestrator/intellect_math/7b.toml
+++ b/configs/orchestrator/intellect_math/7b.toml
@@ -20,7 +20,6 @@ max_solve_rate = 0.9
 
 [monitor.wandb.log_samples]
 interval = 50
-num_samples = 16
 
 [eval]
 interval = 50

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -241,6 +241,7 @@ async def orchestrate(config: OrchestratorConfig):
                 output_tokens=completion_tokens,
                 rewards=rewards,
                 advantages=advantages,
+                rollouts_per_problem=config.rollouts_per_prompt,
                 step=progress.step,
             )
 

--- a/src/prime_rl/utils/config.py
+++ b/src/prime_rl/utils/config.py
@@ -59,14 +59,6 @@ class SampleLoggingConfig(BaseConfig):
         ),
     ] = 10
 
-    num_samples: Annotated[
-        int,
-        Field(
-            ge=1,
-            description="Number of samples to randomly select and log from each batch.",
-        ),
-    ] = 8
-
 
 class WandbMonitorConfig(BaseConfig):
     """Configures logging to Weights and Biases."""


### PR DESCRIPTION
Minor changes to the the way we log problems/ samples to W&B as discussed with @faresobeid. Instead of randomly sampling rollouts, we compute the *problem* with the minimum/ maximum average sequence length (tagged `min_len`, `max_len`) and one `random` problem. For each, we log **all** rollouts.

The PR also logs a string version of the raw tokens so that we can actually read the token sequences (before they were logged as a distribution).

<img width="1333" height="573" alt="Screenshot 2025-07-21 at 8 58 54 PM" src="https://github.com/user-attachments/assets/140b2232-d5e4-4f75-ac5f-a4073e5e2471" />

<img width="1332" height="568" alt="Screenshot 2025-07-21 at 8 59 03 PM" src="https://github.com/user-attachments/assets/89701e67-86d8-4b3e-9961-9d2ed688ff03" />

<img width="1332" height="566" alt="Screenshot 2025-07-21 at 8 59 09 PM" src="https://github.com/user-attachments/assets/01e45b99-0b60-4df2-91cb-1348df8e353d" />
