### PR TITLE
Log regular logprob ratio error

### DIFF
--- a/src/prime_rl/trainer/train.py
+++ b/src/prime_rl/trainer/train.py
@@ -198,7 +198,7 @@ def train(config: TrainerConfig):
                     temperature = micro_batch["temperature"]
 
                     recomputed_logprobs = compute_logprobs(logprob_model, input_ids, position_ids, temperature)
-                    recomputed_logprob_error = ((torch.exp(recomputed_logprobs - logprobs).abs()) * loss_mask).sum()
+                    recomputed_logprob_error = (torch.exp(recomputed_logprobs - logprobs) * loss_mask).sum()
 
                     micro_batch["recomputed_logprob_error"] = recomputed_logprob_error.to("cpu")
                     micro_batch["logprobs"] = recomputed_logprobs.to("cpu")


### PR DESCRIPTION
Do not log absolute logprob ratio error to see in which direction we recomputed logprobs differ from vLLM logprobs.