### PR TITLE
Log distributions as W&B table

### DIFF
--- a/configs/orchestrator/hendrycks_math/14b.toml
+++ b/configs/orchestrator/hendrycks_math/14b.toml
@@ -13,7 +13,7 @@ name = "willcb/DeepSeek-R1-Distill-Qwen-14B"
 [environment]
 id = "hendrycks-math"
 
-[monitor.wandb.log_samples]
+[monitor.wandb.log_extras]
 interval = 10
 
 [eval]

--- a/configs/orchestrator/hendrycks_math/1b.toml
+++ b/configs/orchestrator/hendrycks_math/1b.toml
@@ -13,7 +13,7 @@ name = "willcb/DeepSeek-R1-Distill-Qwen-1.5B"
 [environment]
 id = "hendrycks-math"
 
-[monitor.wandb.log_samples]
+[monitor.wandb.log_extras]
 interval = 10
 
 [eval]

--- a/configs/orchestrator/hendrycks_math/32b.toml
+++ b/configs/orchestrator/hendrycks_math/32b.toml
@@ -13,7 +13,7 @@ name = "willcb/DeepSeek-R1-Distill-Qwen-32B"
 [environment]
 id = "hendrycks-math"
 
-[monitor.wandb.log_samples]
+[monitor.wandb.log_extras]
 interval = 10
 
 [eval]

--- a/configs/orchestrator/hendrycks_math/7b.toml
+++ b/configs/orchestrator/hendrycks_math/7b.toml
@@ -13,7 +13,7 @@ name = "willcb/DeepSeek-R1-Distill-Qwen-7B"
 [environment]
 id = "hendrycks-math"
 
-[monitor.wandb.log_samples]
+[monitor.wandb.log_extras]
 interval = 10
 
 [eval]

--- a/configs/orchestrator/intellect_math/1b.toml
+++ b/configs/orchestrator/intellect_math/1b.toml
@@ -18,7 +18,7 @@ solve_rate_field = "solve_rate_qwen_r1_distill_7b"
 min_solve_rate = 0.4
 max_solve_rate = 0.9
 
-[monitor.wandb.log_samples]
+[monitor.wandb.log_extras]
 interval = 50
 
 [eval]

--- a/configs/orchestrator/intellect_math/7b.toml
+++ b/configs/orchestrator/intellect_math/7b.toml
@@ -18,7 +18,7 @@ solve_rate_field = "solve_rate_qwen_r1_distill_7b"
 min_solve_rate = 0.4
 max_solve_rate = 0.9
 
-[monitor.wandb.log_samples]
+[monitor.wandb.log_extras]
 interval = 50
 
 [eval]

--- a/configs/orchestrator/wordle/14b.toml
+++ b/configs/orchestrator/wordle/14b.toml
@@ -18,7 +18,7 @@ id = "wordle"
 [sampling]
 max_tokens = 1024
 
-[monitor.wandb.log_samples]
+[monitor.wandb.log_extras]
 interval = 10
 
 [ckpt]

--- a/configs/orchestrator/wordle/1b.toml
+++ b/configs/orchestrator/wordle/1b.toml
@@ -18,7 +18,7 @@ id = "wordle"
 [sampling]
 max_tokens = 1024
 
-[monitor.wandb.log_samples]
+[monitor.wandb.log_extras]
 interval = 10
 
 [ckpt]

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -299,6 +299,6 @@ class OrchestratorConfig(BaseSettings):
 
             # Disable evaluation
             self.eval = None
-            self.monitor.wandb.log_samples = None
+            self.monitor.wandb.log_extras = None
 
         return self

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -254,6 +254,7 @@ async def orchestrate(config: OrchestratorConfig):
                 rollouts_per_problem=config.rollouts_per_prompt,
                 step=progress.step,
             )
+            monitor.wandb.log_distributions(rewards, advantages, step=progress.step)
 
         # Write serialized batch to disk for trainer workers to consume
         all_data_ranks_batches = prepare_batch(

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -339,6 +339,11 @@ async def orchestrate(config: OrchestratorConfig):
         # Increment progress
         progress.step += 1
 
+    # Log final (immutable) samples and distributions to W&B table
+    if monitor.wandb:
+        monitor.wandb.log_final_samples()
+        monitor.wandb.log_final_distributions()
+
     logger.success("Orchestrator finished.")
 
     # Optionally, print benchmark table

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -254,7 +254,12 @@ async def orchestrate(config: OrchestratorConfig):
                 rollouts_per_problem=config.rollouts_per_prompt,
                 step=progress.step,
             )
-            monitor.wandb.log_distributions(rewards, advantages, step=progress.step)
+            monitor.wandb.log_distributions(
+                rewards,
+                advantages,
+                rollouts_per_problem=config.rollouts_per_prompt,
+                step=progress.step,
+            )
 
         # Write serialized batch to disk for trainer workers to consume
         all_data_ranks_batches = prepare_batch(

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -54,7 +54,12 @@ class RLConfig(BaseSettings):
 
     log: LogConfig = LogConfig()
 
-    exp_id: Annotated[str | None, Field(description="The experiment ID. If set, will be used to identify shared resources, like log files, weight and rollout directories, etc.")] = "rl" # This value has to match the `DEFAULT_EXPERIMENT_ID` in `tmux.sh`
+    exp_id: Annotated[
+        str | None,
+        Field(
+            description="The experiment ID. If set, will be used to identify shared resources, like log files, weight and rollout directories, etc."
+        ),
+    ] = "rl"  # This value has to match the `DEFAULT_EXPERIMENT_ID` in `tmux.sh`
 
     trainer_gpus: Annotated[int, Field(description="The number of GPUs to use for trainer.")] = 1
 

--- a/src/prime_rl/utils/config.py
+++ b/src/prime_rl/utils/config.py
@@ -58,6 +58,13 @@ class LogExtrasConfig(BaseConfig):
         ),
     ] = True
 
+    distributions: Annotated[
+        bool,
+        Field(
+            description="Whether to log distributions, like rewards, advantages, etc. to W&B tables.",
+        ),
+    ] = True
+
     interval: Annotated[
         int,
         Field(

--- a/src/prime_rl/utils/config.py
+++ b/src/prime_rl/utils/config.py
@@ -48,14 +48,21 @@ class APIMonitorConfig(BaseConfig):
     auth_token: Annotated[str, Field(description="The API auth token to use")]
 
 
-class SampleLoggingConfig(BaseConfig):
-    """Configures sample logging for W&B tables."""
+class LogExtrasConfig(BaseConfig):
+    """Configures extra logging for W&B tables."""
+
+    samples: Annotated[
+        bool,
+        Field(
+            description="Whether to log prompt/response samples to W&B tables.",
+        ),
+    ] = True
 
     interval: Annotated[
         int,
         Field(
             ge=1,
-            description="Step interval at which to log samples to W&B table.",
+            description="Step interval at which to log extras to W&B table.",
         ),
     ] = 10
 
@@ -88,10 +95,10 @@ class WandbMonitorConfig(BaseConfig):
 
     offline: Annotated[bool, Field(description="Whether to run W&B in offline mode.")] = False
 
-    log_samples: Annotated[
-        SampleLoggingConfig | None,
+    log_extras: Annotated[
+        LogExtrasConfig | None,
         Field(
-            description="Configuration for logging prompt/response samples to W&B tables. If None, no samples are logged.",
+            description="Configuration for logging extras to W&B tables. If None, no extras are logged.",
         ),
     ] = None
 

--- a/src/prime_rl/utils/monitor.py
+++ b/src/prime_rl/utils/monitor.py
@@ -13,9 +13,9 @@ import aiohttp
 import pandas as pd
 import psutil
 import pynvml
+import wandb
 from transformers.tokenization_utils import PreTrainedTokenizer
 
-import wandb
 from prime_rl.utils.config import (
     APIMonitorConfig,
     BaseConfig,

--- a/src/prime_rl/utils/monitor.py
+++ b/src/prime_rl/utils/monitor.py
@@ -231,7 +231,7 @@ class WandbMonitor(Monitor):
         # Log to W&B table at configured intervals
         df = pd.DataFrame(self.samples)
         table = wandb.Table(dataframe=df)
-        wandb.log({"completions": table}, step=step)
+        wandb.log({"samples": table}, step=step)
         self.last_log_step = step
         self.logger.debug(f"Logged {len(self.samples)} samples to W&B table in {time.time() - start_time:.2f}s")
 

--- a/src/prime_rl/utils/monitor.py
+++ b/src/prime_rl/utils/monitor.py
@@ -13,9 +13,9 @@ import aiohttp
 import pandas as pd
 import psutil
 import pynvml
-import wandb
 from transformers.tokenization_utils import PreTrainedTokenizer
 
+import wandb
 from prime_rl.utils.config import (
     APIMonitorConfig,
     BaseConfig,
@@ -145,7 +145,7 @@ class WandbMonitor(Monitor):
         )
 
         # Optionally, initialize sample logging attributes
-        if config.log_samples:
+        if config.log_extras:
             assert tokenizer is not None, "Tokenizer is required for sample logging"
             self.tokenizer = tokenizer
             self.last_log_step = -1
@@ -174,7 +174,11 @@ class WandbMonitor(Monitor):
             task_rewards: Optional list of task-specific rewards
             step: Current training step
         """
-        if not self.config.log_samples or step % self.config.log_samples.interval != 0:
+        if (
+            not self.config.log_extras
+            or not self.config.log_extras.samples
+            or step % self.config.log_extras.interval != 0
+        ):
             # Do not log samples if not enabled or not log interval step
             return
         assert self.tokenizer is not None, "Tokenizer is required for sample logging"

--- a/src/prime_rl/utils/utils.py
+++ b/src/prime_rl/utils/utils.py
@@ -7,8 +7,8 @@ from typing import Any
 
 import torch
 import torch.distributed as dist
-
 import wandb
+
 from prime_rl.utils.logger import get_logger
 
 

--- a/src/prime_rl/utils/utils.py
+++ b/src/prime_rl/utils/utils.py
@@ -7,8 +7,8 @@ from typing import Any
 
 import torch
 import torch.distributed as dist
-import wandb
 
+import wandb
 from prime_rl.utils.logger import get_logger
 
 
@@ -220,15 +220,17 @@ def get_step_path(path: Path, step: int) -> Path:
 def get_weight_ckpt_model_path(weight_dir: Path, step: int) -> Path:
     return weight_dir / f"step_{step}" / "pytorch_model.bin"
 
+
 def get_free_port() -> int:
     """Find and return a free port"""
     import socket
-    
+
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(('', 0))  # Bind to any available port
+        s.bind(("", 0))  # Bind to any available port
         s.listen(1)
         port = s.getsockname()[1]
     return port
+
 
 def get_cuda_visible_devices() -> list[int]:
     """Returns the list of availble CUDA devices, taking into account the CUDA_VISIBLE_DEVICES environment variable."""

--- a/tests/integration/test_rl.py
+++ b/tests/integration/test_rl.py
@@ -20,7 +20,7 @@ CMD = [
     "--orchestrator",
     "@",
     "configs/orchestrator/reverse_text.toml",
-    "--orchestrator.monitor.wandb.log_samples",
+    "--orchestrator.monitor.wandb.log-extras",
 ]
 
 


### PR DESCRIPTION
Adds functionality for logging distributions (e.g. reward/ advantage distribution) as W&B tables. Adds a call from the orchestrator to `monitor.log_distribution` which will log a W&B table `distributions` (similar logic-wise to the sample logging):
- `step`: The logging step
- `rewards`: Histogram of all rewards (irrespective of group size)
- `advantages`: Histogram of all advantages (irrespective of group size)
- `problem_rewards`: Histogram of the mean reward per problem
- `problem_advantages`: Histogram of the mean advantage per problem (always 0 for `drgrpo`)

<img width="939" height="529" alt="Screenshot 2025-07-23 at 5 37 41 PM" src="https://github.com/user-attachments/assets/6e2ff031-c41d-4153-be2b-c09ac359103a" />

## Misc Changes

- Figured out how to log incremental (not immutable) tables with rows coming in on the fly. However, it has a max row limit (for whatever reason), so we also still log a final table at the end of the run
- Changed the config key `--monitor.wandb.log-samples` to `--monitor.wandb.log-extras` which boolean flags for logging samples and distributions, i.e. `--monitor.wandb.log-extras.samples` and `--monitor.wandb.log-extras.distributions`. This is mainly so that both of these tables are logged at the same step interval
- The samples table was renamed from `completions` to `samples`