### PR TITLE
Improve checkpointing

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -70,6 +70,7 @@ async def orchestrate(config: OrchestratorConfig):
 
     # Get checkpoint manager
     if config.ckpt:
+        logger.info(f"Initializing checkpoint manager ({config.ckpt})")
         ckpt_manager = CheckpointManager(config.ckpt)
 
     # Reset weights to base model if starting from scratch
@@ -106,7 +107,7 @@ async def orchestrate(config: OrchestratorConfig):
         # Save checkpoint (if we are not at the first step)
         save_ckpt_time = 0
         if config.ckpt and config.ckpt.interval and not is_first_step and progress.step % config.ckpt.interval == 0:
-            logger.debug(f"Saving checkpoint at step {progress.step}")
+            logger.info(f"Saving checkpoint at step {progress.step}")
             save_ckpt_start_time = time.time()
             ckpt_manager.save(progress, step=progress.step)
             save_ckpt_time = time.time() - save_ckpt_start_time
@@ -367,8 +368,14 @@ async def orchestrate(config: OrchestratorConfig):
 
     # Log final (immutable) samples and distributions to W&B table
     if monitor.wandb:
+        logger.info("Logging final samples and distributions as W&B table")
         monitor.wandb.log_final_samples()
         monitor.wandb.log_final_distributions()
+
+    # Write final checkpoint
+    if config.ckpt:
+        logger.info("Writing final checkpoint")
+        ckpt_manager.save(progress, step=progress.step)
 
     logger.success("Orchestrator finished.")
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -101,10 +101,11 @@ async def orchestrate(config: OrchestratorConfig):
     logger.info(f"Starting orchestrator loop ({max_steps=}")
     ckpt_step = 0
     last_eval_step = -1
+    is_first_step = True
     while True:
         # Save checkpoint (if we are not at the first step)
         save_ckpt_time = 0
-        if config.ckpt and config.ckpt.interval and progress.step > 0 and progress.step % config.ckpt.interval == 0:
+        if config.ckpt and config.ckpt.interval and not is_first_step and progress.step % config.ckpt.interval == 0:
             logger.debug(f"Saving checkpoint at step {progress.step}")
             save_ckpt_start_time = time.time()
             ckpt_manager.save(progress, step=progress.step)

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -162,11 +162,12 @@ class RLConfig(BaseSettings):
     def auto_setup_exp(self):
         if self.exp_id:
             self.log.path = self.log.path / self.exp_id
-            # Will be shared to orchestrator via `auto_setup_ckpt`
-            self.trainer.ckpt.path = self.trainer.ckpt.path / self.exp_id
             # Will be shared to orchestrator via `auto_setup_paths`
             self.trainer.data.path = self.trainer.data.path / self.exp_id
             self.trainer.weights.path = self.trainer.weights.path / self.exp_id
+            # Will be shared to orchestrator via `auto_setup_ckpt`
+            if self.trainer.ckpt:
+                self.trainer.ckpt.path = self.trainer.ckpt.path / self.exp_id
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -162,9 +162,11 @@ class RLConfig(BaseSettings):
     def auto_setup_exp(self):
         if self.exp_id:
             self.log.path = self.log.path / self.exp_id
+            # Will be shared to orchestrator via `auto_setup_ckpt`
+            self.trainer.ckpt.path = self.trainer.ckpt.path / self.exp_id
+            # Will be shared to orchestrator via `auto_setup_paths`
             self.trainer.data.path = self.trainer.data.path / self.exp_id
             self.trainer.weights.path = self.trainer.weights.path / self.exp_id
-            # Note: Will be shared to orchestrator via `auto_setup_paths`
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/trainer/train.py
+++ b/src/prime_rl/trainer/train.py
@@ -132,6 +132,7 @@ def train(config: TrainerConfig):
         dataloader = FakeDataLoader(config.data.fake)
 
     logger.info(f"Starting training loop ({config.max_steps=})")
+    is_first_step = True
     while True:
         # Save the weight checkpoint (if we are not at the first step, because no updates to the model have been made yet)
         save_weights_time = 0
@@ -142,7 +143,7 @@ def train(config: TrainerConfig):
 
         # Save the full checkpoint (if we are at an interval step and not at the first step)
         save_ckpt_time = 0
-        if config.ckpt and config.ckpt.interval and progress.step > 0 and progress.step % config.ckpt.interval == 0:
+        if config.ckpt and config.ckpt.interval and not is_first_step and progress.step % config.ckpt.interval == 0:
             logger.debug(f"Saving checkpoint {progress.step}")
             save_ckpt_start_time = time.time()
             ckpt_manager.save(model, [optimizer], progress, step=progress.step)
@@ -360,6 +361,7 @@ def train(config: TrainerConfig):
         monitor.log(time_metrics)
 
         progress.step += 1
+        is_first_step = False
 
     logger.info(f"Peak memory: {torch.cuda.max_memory_allocated() / 1024**3:.2f} GB")
     logger.success("Trainer finished!")

--- a/src/prime_rl/trainer/train.py
+++ b/src/prime_rl/trainer/train.py
@@ -92,7 +92,7 @@ def train(config: TrainerConfig):
     logger.info(f"Initializing weight checkpoint manager ({config.weights})")
     weight_ckpt_manager = WeightCheckpointManager(config.weights, config.ckpt, config.async_level)
     if config.ckpt:
-        logger.info(f"Initializing checkpoint manager ({config.ckpt})")  # TODO: Remove this
+        logger.info(f"Initializing checkpoint manager ({config.ckpt})")
         ckpt_manager = CheckpointManager(config.ckpt)
 
     # Optionally, resume training from a checkpoint
@@ -144,7 +144,7 @@ def train(config: TrainerConfig):
         # Save the full checkpoint (if we are at an interval step and not at the first step)
         save_ckpt_time = 0
         if config.ckpt and config.ckpt.interval and not is_first_step and progress.step % config.ckpt.interval == 0:
-            logger.debug(f"Saving checkpoint {progress.step}")
+            logger.info(f"Saving checkpoint at step {progress.step}")
             save_ckpt_start_time = time.time()
             ckpt_manager.save(model, [optimizer], progress, step=progress.step)
             save_ckpt_time = time.time() - save_ckpt_start_time
@@ -362,6 +362,11 @@ def train(config: TrainerConfig):
 
         progress.step += 1
         is_first_step = False
+
+    # Write final checkpoint
+    if config.ckpt:
+        logger.info("Writing final checkpoint")
+        ckpt_manager.save(model, [optimizer], progress, step=progress.step)
 
     logger.info(f"Peak memory: {torch.cuda.max_memory_allocated() / 1024**3:.2f} GB")
     logger.success("Trainer finished!")

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 2
-requires-python = ">=3.12.0, <3.13"
+requires-python = "==3.12.*"
 resolution-markers = [
     "sys_platform == 'linux'",
     "sys_platform != 'linux'",
@@ -619,13 +619,13 @@ wheels = [
 
 [[package]]
 name = "flash-attn"
-version = "2.8.1"
+version = "2.8.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "einops" },
     { name = "torch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e8/6d/7066d160bdffa2f9da29a8c3957f266b17a03ca0b3bdc8fdae86d9881fe7/flash_attn-2.8.1.tar.gz", hash = "sha256:0ff003899fcb244f357905b04f622d5c9736887126dd6675f8f4bc52954e3923", size = 8166563, upload-time = "2025-07-10T05:16:39.729Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/91/91bcbd7424877fa8da4e7cc04b8a777247a33037b9c1fd976a5ad426c047/flash_attn-2.8.2.tar.gz", hash = "sha256:740a5370f406cbe16155cc6d078ec543a97a137501f32cba89198295e6b80e54", size = 8167111, upload-time = "2025-07-24T16:06:45.953Z" }
 
 [[package]]
 name = "flashinfer-python"


### PR DESCRIPTION
This PR includes various improvements to resuming from a checkpoint:
- Save checkpoints in `{checkpoint_dir}/{exp_id}` to allow to checkpoint parallel runs
- Do not save checkpoint on first step (for regular runs, this is equivalent to not checkpointing the base model; for resumed runs, this means not checkpointing the step we resumed from)
- Always checkpoint the final step (even if `max_steps` is not a multiple of `ckpt.interval`) to allow for smooth continued training (e.g. stage 1 -> stage 2)

Checked that this works on `reverse-text`. Did an initial run with 100 steps, checkpointing every 25 steps. Checked:
1. Can resume resumed (arbitrarily many times) from any of the interval steps (25, 50, 75, ...)
2. Continue from final checkpoint (100) to train to non-multiple (here 140) and get checkpoint

<img width="922" height="270" alt="Screenshot 2025-07-24 at 1 03 42 PM" src="https://github.com/user-attachments/assets/05a2184f-d601-4b6e-a600-38e59cdd2625" />
