### PR TITLE
Improve eval suite

### DIFF
--- a/configs/orchestrator/hendrycks_math/14b.toml
+++ b/configs/orchestrator/hendrycks_math/14b.toml
@@ -19,3 +19,4 @@ interval = 10
 [eval]
 interval = 50
 benchmarks = ["math500", "aime24", "aime25"]
+rollouts_per_prompt = [1, 16, 16]

--- a/configs/orchestrator/hendrycks_math/1b.toml
+++ b/configs/orchestrator/hendrycks_math/1b.toml
@@ -19,6 +19,7 @@ interval = 10
 [eval]
 interval = 50
 benchmarks = ["math500", "aime24", "aime25"]
+rollouts_per_prompt = [1, 16, 16]
 
 [ckpt]
 interval = 100

--- a/configs/orchestrator/hendrycks_math/32b.toml
+++ b/configs/orchestrator/hendrycks_math/32b.toml
@@ -19,3 +19,4 @@ interval = 10
 [eval]
 interval = 50
 benchmarks = ["math500", "aime24", "aime25"]
+rollouts_per_prompt = [1, 16, 16]

--- a/configs/orchestrator/hendrycks_math/7b.toml
+++ b/configs/orchestrator/hendrycks_math/7b.toml
@@ -19,6 +19,7 @@ interval = 10
 [eval]
 interval = 50
 benchmarks = ["math500", "aime24", "aime25"]
+rollouts_per_prompt = [1, 16, 16]
 
 [ckpt]
 interval = 200 

--- a/configs/orchestrator/intellect_math/1b.toml
+++ b/configs/orchestrator/intellect_math/1b.toml
@@ -24,5 +24,6 @@ interval = 50
 [eval]
 interval = 50
 benchmarks = ["math500", "aime24", "aime25"]
+rollouts_per_prompt = [1, 16, 16]
 
 [ckpt]

--- a/configs/orchestrator/intellect_math/7b.toml
+++ b/configs/orchestrator/intellect_math/7b.toml
@@ -24,5 +24,6 @@ interval = 50
 [eval]
 interval = 50
 benchmarks = ["math500", "aime24", "aime25"]
+rollouts_per_prompt = [1, 16, 16]
 
 [ckpt]

--- a/src/prime_rl/orchestrator/client.py
+++ b/src/prime_rl/orchestrator/client.py
@@ -101,7 +101,6 @@ async def generate_completion(
         top_p=sampling_config.top_p,
         max_tokens=sampling_config.max_tokens,
         seed=sampling_config.seed,
-        n=sampling_config.n,
         logprobs=True,
         extra_body={
             "top_k": sampling_config.top_k,
@@ -110,4 +109,5 @@ async def generate_completion(
             "return_tokens_as_token_ids": True,
         },
     )
+    assert len(response.choices) == 1, "Response should always have one choice"
     return response

--- a/src/prime_rl/orchestrator/client.py
+++ b/src/prime_rl/orchestrator/client.py
@@ -101,6 +101,7 @@ async def generate_completion(
         top_p=sampling_config.top_p,
         max_tokens=sampling_config.max_tokens,
         seed=sampling_config.seed,
+        n=sampling_config.n,
         logprobs=True,
         extra_body={
             "top_k": sampling_config.top_k,
@@ -109,5 +110,4 @@ async def generate_completion(
             "return_tokens_as_token_ids": True,
         },
     )
-    assert len(response.choices) == 1, "Response should always have one choice"
     return response

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -92,6 +92,14 @@ class SamplingConfig(BaseConfig):
         ),
     ] = None
 
+    n: Annotated[
+        int,
+        Field(
+            ge=1,
+            description="Number of samples to generate for each problem.",
+        ),
+    ] = 1
+
 
 class EnvironmentConfig(BaseConfig):
     """Configures the environment to be used for inference."""
@@ -123,6 +131,13 @@ class EvalConfig(BaseConfig):
         ),
     ] = ["math500"]
 
+    rollouts_per_prompt: Annotated[
+        list[int],
+        Field(
+            description="Number of samples to generate for each benchmark.",
+        ),
+    ] = [1]
+
     interval: Annotated[
         int,
         Field(
@@ -137,6 +152,12 @@ class EvalConfig(BaseConfig):
             description="Whether to evaluate the base model we are training on.",
         ),
     ] = True
+
+    @model_validator(mode="after")
+    def validate_rollouts_per_prompt(self):
+        if len(self.rollouts_per_prompt) != len(self.benchmarks):
+            raise ValueError("Number of rollouts per prompt must be the same as the number of benchmarks")
+        return self
 
 
 class CheckpointConfig(BaseConfig):


### PR DESCRIPTION
- Allow setting `rollouts_per_prompts` for each benchmark to get more robust eval estimates, especially for small benchmarks like AIME (30 problem)
- Changes defaults in TOML configs (AIME-24/25: 16, MATH-500: 1)
- Rename `score` -> `avg@k`