### PR TITLE
Log sequence information in separate section

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -28,7 +28,6 @@ from prime_rl.orchestrator.batch import prepare_batch
 from prime_rl.orchestrator.logger import setup_logger
 from prime_rl.orchestrator.advantage import compute_advantages
 from prime_rl.orchestrator.utils import (
-    parse_finish_reason,
     wait_for_weight_checkpoint,
     print_benchmark,
 )

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 import asyncio
 import time
 from loguru import logger
@@ -29,7 +28,7 @@ from prime_rl.orchestrator.batch import prepare_batch
 from prime_rl.orchestrator.logger import setup_logger
 from prime_rl.orchestrator.advantage import compute_advantages
 from prime_rl.orchestrator.utils import (
-    process_env_results,
+    parse_finish_reason,
     wait_for_weight_checkpoint,
     print_benchmark,
 )
@@ -267,8 +266,8 @@ async def orchestrate(config: OrchestratorConfig):
         progress.total_problems += config.batch_size // config.rollouts_per_prompt
         throughput = num_tokens / (generate_completions_time)
 
-        seq_lengths = np.array([len(p) + len(c) for p, c in zip(prompt_tokens, completion_tokens)])
-        problem_avg_seqlens = seq_lengths.reshape(-1, config.rollouts_per_prompt).mean(axis=-1)
+        seq_lens = np.array([len(p) + len(c) for p, c in zip(prompt_tokens, completion_tokens)])
+        problem_seqlens = seq_lens.reshape(-1, config.rollouts_per_prompt).mean(axis=-1)
 
         # Compute solve all/ none and critical batch size
         grouped_rewards = [
@@ -319,7 +318,7 @@ async def orchestrate(config: OrchestratorConfig):
 
         # Log step metrics
         step_time = time.time() - step_start_time
-        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Reward: {np.mean(rewards):.2f} | Advantage: {np.mean(advantages):.2f} | Throughput: {throughput:.1f} tokens/s | Seq. Length: {float(problem_avg_seqlens.mean()):.1f} tokens/sample"
+        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Reward: {np.mean(rewards):.2f} | Advantage: {np.mean(advantages):.2f} | Throughput: {throughput:.1f} tokens/s | Seq. Length: {float(problem_seqlens.mean()):.1f} tokens/sample"
         logger.success(step_message)
 
         # Log progress metrics to monitor
@@ -334,10 +333,10 @@ async def orchestrate(config: OrchestratorConfig):
 
         # Log sequence length metrics to monitor
         seq_metrics = {
-            "seq/len": float(problem_avg_seqlens.mean()),
-            "seq/max_len": float(problem_avg_seqlens.max()),
-            "seq/min_len": float(problem_avg_seqlens.min()),
-            "seq/std_len": float(problem_avg_seqlens.std()),
+            "seq/len": float(problem_seqlens.mean()),
+            "seq/len/max": float(problem_seqlens.max()),
+            "seq/len/min": float(problem_seqlens.min()),
+            "seq/len/std": float(problem_seqlens.std()),
             "step": progress.step,
         }
         monitor.log(seq_metrics)

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -332,13 +332,19 @@ async def orchestrate(config: OrchestratorConfig):
         }
         monitor.log(progress_metrics)
 
-        # Log perfrmance metrics to monitor
+        # Log sequence length metrics to monitor
+        seq_metrics = {
+            "seq/len": float(problem_avg_seqlens.mean()),
+            "seq/max_len": float(problem_avg_seqlens.max()),
+            "seq/min_len": float(problem_avg_seqlens.min()),
+            "seq/std_len": float(problem_avg_seqlens.std()),
+            "step": progress.step,
+        }
+        monitor.log(seq_metrics)
+
+        # Log performance metrics to monitor
         perf_metrics = {
             "perf/infer/throughput": throughput,
-            "perf/infer/seq_len": float(problem_avg_seqlens.mean()),
-            "perf/infer/max_seq_len": float(problem_avg_seqlens.max()),
-            "perf/infer/min_seq_len": float(problem_avg_seqlens.min()),
-            "perf/infer/std_seq_len": float(problem_avg_seqlens.std()),
             "step": progress.step,
         }
         monitor.log(perf_metrics)

--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -90,6 +90,15 @@ def parse_completions(chat_completions: list[ChatCompletion]) -> list[str]:
     return completions
 
 
+def parse_finish_reason(states: list[dict[str, Any]]) -> list[str]:
+    """Parses the finish reasons from a list of vLLM chat completions returned by vLLM OAI server."""
+    finish_reasons = []
+    for state in states:
+        assert len(chat_completion.choices) == 1, "Response should always have one choice"
+        finish_reasons.append(chat_completion.choices[0].finish_reason == "length")
+    return finish_reasons
+
+
 def wait_for_weight_checkpoint(path: Path, step: int, interval: int = 1, log_interval: int = 10) -> None:
     model_path = get_weight_ckpt_model_path(path, step)
     wait_for_path(model_path, interval, log_interval)

--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -90,15 +90,6 @@ def parse_completions(chat_completions: list[ChatCompletion]) -> list[str]:
     return completions
 
 
-def parse_finish_reason(states: list[dict[str, Any]]) -> list[str]:
-    """Parses the finish reasons from a list of vLLM chat completions returned by vLLM OAI server."""
-    finish_reasons = []
-    for state in states:
-        assert len(chat_completion.choices) == 1, "Response should always have one choice"
-        finish_reasons.append(chat_completion.choices[0].finish_reason == "length")
-    return finish_reasons
-
-
 def wait_for_weight_checkpoint(path: Path, step: int, interval: int = 1, log_interval: int = 10) -> None:
     model_path = get_weight_ckpt_model_path(path, step)
     wait_for_path(model_path, interval, log_interval)


### PR DESCRIPTION
Small PR to log sequence information in `seq/` instead of `perf/` section in W&B. We log:
 - `seq/len`: The average of the average sequence length per problem
 - `seq/len/max`: The maximum sequence length of all average sequence lengths per problem
 - `seq/len/min`: The maximum sequence length of all average sequence lengths per problem
 - `seq/len/std`: The standard deviation of all average sequence lengths per problem

<img width="946" height="584" alt="Screenshot 2025-07-25 at 10 10 38 AM" src="https://github.com/user-attachments/assets/f5a99362-730b-4aea-b7d2-3cc54343fbcc" />

This section will sooner or later also contain a `seq/truncated` field which is the ratio of sequences that went to maximum context, but for this we need to parse `outputs["state"]` (contains the raw vLLM respones) which doesn't play very nicely with the buffer implementation atm (the buffer would have to consume the entire outputs and results) but before I implement this I would like proper output types from verifiers side, so blocking this until then.