### PR TITLE
More performant buffer re-sampling 

### DIFF
--- a/src/prime_rl/orchestrator/buffer.py
+++ b/src/prime_rl/orchestrator/buffer.py
@@ -398,7 +398,7 @@ class OnlineDifficultyBuffer(Buffer):
 
         if len(sampled_problem_ids) < n:
             self.logger.warning(
-                f"Only {len(sampled_problem_ids)} (<{n}) problems with rollouts available ({num_too_easy=}, {num_too_hard=})"
+                f"Only {len(sampled_problem_ids)} (<{n}) valid problems with rollouts available ({num_too_easy=}, {num_too_hard=})"
             )
 
         return sampled_rollouts

--- a/src/prime_rl/orchestrator/buffer.py
+++ b/src/prime_rl/orchestrator/buffer.py
@@ -206,7 +206,7 @@ class DifficultyPoolBuffer(Buffer):
             difficulties = self.dataset[self.config.difficulty_field]
             self.logger.info(f"Found difficulty field {self.config.difficulty_field} in dataset")
         else:
-            self.logger.info("No difficulty field specified, initalizing all problems as `normal` difficulty")
+            self.logger.warning("No difficulty field specified, initalizing all problems as `normal` difficulty")
             difficulties = ["normal"] * len(self.problem_ids)
 
         assert len(difficulties) == len(self.problem_ids)

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -247,7 +247,7 @@ class OnlineDifficultyBufferConfig(BaseModel):
             gt=0,
             description="Factor by which to oversample during filtering to ensure sufficient samples.",
         ),
-    ] = 1.0
+    ] = 1.5
 
 
 DataBufferConfig: TypeAlias = SimpleBufferConfig | DifficultyPoolBufferConfig | OnlineDifficultyBufferConfig

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -171,10 +171,11 @@ async def orchestrate(config: OrchestratorConfig):
             logger.info(f"Evaluated in {eval_time:.2f}s")
 
         accepted_rollouts: list[Rollout] = []
+        problems_per_batch = config.batch_size // config.rollouts_per_prompt
+        problems_to_sample = problems_per_batch
         while True:
             # Get the batch
-            problems_per_batch = config.batch_size // config.rollouts_per_prompt
-            problem_ids, problems = buffer.sample_problems(problems_per_batch)
+            problem_ids, problems = buffer.sample_problems(problems_to_sample)
 
             # Duplicate problems `rollouts_per_prompt` times
             problem_ids = [problem_id for problem_id in problem_ids for _ in range(config.rollouts_per_prompt)]
@@ -239,11 +240,16 @@ async def orchestrate(config: OrchestratorConfig):
                 advantages=advantages,
             )
             buffer.update(rollouts)
-            accepted_rollouts.extend(buffer.sample_rollouts(problems_per_batch))
+            accepted_rollouts.extend(buffer.sample_rollouts(problems_to_sample))
 
+            # Break if we have enough rollouts to fill the batch
             if len(accepted_rollouts) >= config.batch_size:
                 accepted_rollouts = accepted_rollouts[: config.batch_size]
                 break
+
+            # On next iteration, sample the remaining problems to fill the batch
+            problems_sampled = len(accepted_rollouts) // config.rollouts_per_prompt
+            problems_to_sample = problems_per_batch - problems_sampled
 
         # Unpack accepted rollouts
         rewards = [rollout.reward for rollout in accepted_rollouts]


### PR DESCRIPTION
This PR sets more performant defaults for buffer types which do not guarantee that `sample_rollouts(n)` will actually return rollouts for `n` problems, i.e. because they have some constraint on which rollouts can be sampled (e.g. the `online-difficulty` buffer only allows problems where the average reward is in range `[min_reward, max_reward]`). 

The previous logic is: While not enough rollouts are sampled to fill the batch, sample `problems_per_batch` problems, generate rollouts and fill the batch.

Clearly, this is quite wasteful, e.g. if we are missing only one problem we request another full batch which we immediately throw away. Thus, we change the logic to:

While not enough rollouts are available to fill the batch, sample and generate rollouts for as many problems as are left, subject to a default oversampling factor of 1.5.

Ideally, the oversampling factor is set exactly right so that (a) its not too low, i.e. we almost never run the inner orchestratror loop and (b) its not too high, i.e. we generate rollouts for more completions than we can use.

From small experimentation the new defaults are more performant than the old, but the oversampling factor is a hyperparameter that depends on the likelihood of problems falling within the sampling criteria. 

<img width="287" height="243" alt="Screenshot 2025-07-25 at 11 14 56 AM" src="https://github.com/user-attachments/assets/ea788f4c-69f9-4d2e-a790-29e4891176a7" />

For the future we can consider two more things to optimize more:
- "Adaptive oversampling factor": This is based on the observation that the sampling criteria of online difficulty filtering is harder to fulfill in earlier steps (too many hard problems) and later steps (too many easy problems) but easy to fulfill in the meantime. Ideally, we wanna oversample more on the problematic earlier and later steps but not so much in the intermediate steps
- "Reuse old rollouts": This is more of a research question: To what extend can we use/ mix rollouts from older generations. For now we use the conservative default that we cannot use them, and hence throw everything away. 

Would be curious to hear what you think @samsja @faresobeid 