### PR TITLE
Add skywork configs

### DIFF
--- a/configs/inference/skywork_math/32b/stage1.toml
+++ b/configs/inference/skywork_math/32b/stage1.toml
@@ -1,0 +1,6 @@
+[model]
+name = "willcb/DeepSeek-R1-Distill-Qwen-32B"
+max_model_len = 16384 
+
+[parallel]
+dp = 6

--- a/configs/inference/skywork_math/32b/stage2.toml
+++ b/configs/inference/skywork_math/32b/stage2.toml
@@ -1,0 +1,6 @@
+[model]
+name = "willcb/DeepSeek-R1-Distill-Qwen-32B"
+max_model_len = 32768
+
+[parallel]
+dp = 6

--- a/configs/inference/skywork_math/7b/ablation.toml
+++ b/configs/inference/skywork_math/7b/ablation.toml
@@ -1,0 +1,6 @@
+[model]
+name = "willcb/DeepSeek-R1-Distill-Qwen-7B"
+max_model_len = 16384
+
+[parallel]
+dp = 6

--- a/configs/inference/skywork_math/7b/stage1.toml
+++ b/configs/inference/skywork_math/7b/stage1.toml
@@ -1,0 +1,6 @@
+[model]
+name = "willcb/DeepSeek-R1-Distill-Qwen-7B"
+max_model_len = 16384
+
+[parallel]
+dp = 6

--- a/configs/inference/skywork_math/7b/stage2.toml
+++ b/configs/inference/skywork_math/7b/stage2.toml
@@ -1,0 +1,6 @@
+[model]
+name = "willcb/DeepSeek-R1-Distill-Qwen-7B"
+max_model_len = 32768
+
+[parallel]
+dp = 6

--- a/configs/orchestrator/skywork_math/32b/stage1.toml
+++ b/configs/orchestrator/skywork_math/32b/stage1.toml
@@ -1,0 +1,29 @@
+max_steps = 760
+batch_size = 4096
+micro_batch_size = 1
+seq_len = 16384
+rollouts_per_prompt = 16
+mask_truncated_completions = false
+
+[model]
+name = "willcb/DeepSeek-R1-Distill-Qwen-32B"
+
+[monitor.wandb]
+
+[environment]
+id = "skywork-math"
+
+[environment.args]
+solve_rate_field = "solve_rate_qwen_r1_distill_32b"
+min_solve_rate = 0.000001
+max_solve_rate = 0.999999
+
+[monitor.wandb.log_extras]
+interval = 50
+
+[eval]
+interval = 50
+benchmarks = ["math500", "aime24", "aime25"]
+rollouts_per_prompt = [1, 16, 16]
+
+[ckpt]

--- a/configs/orchestrator/skywork_math/32b/stage2.toml
+++ b/configs/orchestrator/skywork_math/32b/stage2.toml
@@ -1,0 +1,31 @@
+max_steps = 370
+batch_size = 5120
+micro_batch_size = 1
+seq_len = 32768
+rollouts_per_prompt = 32
+mask_truncated_completions = false
+
+[model]
+name = "willcb/DeepSeek-R1-Distill-Qwen-32B"
+
+[monitor.wandb]
+
+[environment]
+id = "skywork-math"
+
+[environment.args]
+solve_rate_field = "solve_rate_qwen_r1_distill_32b"
+min_solve_rate = 0.000001
+max_solve_rate = 0.999999
+
+[monitor.wandb.log_extras]
+interval = 50
+
+[eval]
+interval = 50
+benchmarks = ["math500", "aime24", "aime25"]
+rollouts_per_prompt = [1, 16, 16]
+
+[ckpt]
+interval = 200
+resume_step = 760

--- a/configs/orchestrator/skywork_math/7b/ablation.toml
+++ b/configs/orchestrator/skywork_math/7b/ablation.toml
@@ -1,0 +1,30 @@
+max_steps = 660
+batch_size = 1024
+micro_batch_size = 1
+seq_len = 16384
+rollouts_per_prompt = 16
+mask_truncated_completions = false
+
+[model]
+name = "willcb/DeepSeek-R1-Distill-Qwen-7B"
+
+[monitor.wandb]
+
+[environment]
+id = "skywork-math"
+
+[environment.args]
+solve_rate_field = "solve_rate_qwen_r1_distill_7b"
+min_solve_rate = 0.000001
+max_solve_rate = 0.999999
+
+[monitor.wandb.log_extras]
+interval = 50
+
+[eval]
+interval = 50
+benchmarks = ["math500", "aime24", "aime25"]
+rollouts_per_prompt = [1, 16, 16]
+
+[ckpt]
+interval = 200

--- a/configs/orchestrator/skywork_math/7b/stage1.toml
+++ b/configs/orchestrator/skywork_math/7b/stage1.toml
@@ -1,0 +1,30 @@
+max_steps = 660
+batch_size = 4096
+micro_batch_size = 1
+seq_len = 16384
+rollouts_per_prompt = 16
+mask_truncated_completions = false
+
+[model]
+name = "willcb/DeepSeek-R1-Distill-Qwen-7B"
+
+[monitor.wandb]
+
+[environment]
+id = "skywork-math"
+
+[environment.args]
+solve_rate_field = "solve_rate_qwen_r1_distill_7b"
+min_solve_rate = 0.000001
+max_solve_rate = 0.999999
+
+[monitor.wandb.log_extras]
+interval = 50
+
+[eval]
+interval = 50
+benchmarks = ["math500", "aime24", "aime25"]
+rollouts_per_prompt = [1, 16, 16]
+
+[ckpt]
+interval = 200

--- a/configs/orchestrator/skywork_math/7b/stage2.toml
+++ b/configs/orchestrator/skywork_math/7b/stage2.toml
@@ -1,0 +1,31 @@
+max_steps = 660
+batch_size = 5120
+micro_batch_size = 1
+seq_len = 32768
+rollouts_per_prompt = 32
+mask_truncated_completions = false
+
+[model]
+name = "willcb/DeepSeek-R1-Distill-Qwen-7B"
+
+[monitor.wandb]
+
+[environment]
+id = "skywork-math"
+
+[environment.args]
+solve_rate_field = "solve_rate_qwen_r1_distill_7b"
+min_solve_rate = 0.000001
+max_solve_rate = 0.999999
+
+[monitor.wandb.log_extras]
+interval = 50
+
+[eval]
+interval = 50
+benchmarks = ["math500", "aime24", "aime25"]
+rollouts_per_prompt = [1, 16, 16]
+
+[ckpt]
+interval = 200
+resume_step = 660

--- a/configs/trainer/skywork_math/32b/stage1.toml
+++ b/configs/trainer/skywork_math/32b/stage1.toml
@@ -1,0 +1,12 @@
+
+[monitor.wandb]
+
+[model]
+name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B"
+ac = true
+
+[optim]
+lr = 1e-6
+
+[ckpt]
+interval = 200

--- a/configs/trainer/skywork_math/32b/stage2.toml
+++ b/configs/trainer/skywork_math/32b/stage2.toml
@@ -1,0 +1,13 @@
+
+[monitor.wandb]
+
+[model]
+name = "willcb/DeepSeek-R1-Distill-Qwen-32B"
+ac = true
+
+[optim]
+lr = 1e-6
+
+[ckpt]
+interval = 200
+resume_step = 760

--- a/configs/trainer/skywork_math/7b/ablation.toml
+++ b/configs/trainer/skywork_math/7b/ablation.toml
@@ -1,0 +1,12 @@
+
+[monitor.wandb]
+
+[model]
+name = "willcb/DeepSeek-R1-Distill-Qwen-7B"
+ac = true
+
+[optim]
+lr = 1e-6
+
+[ckpt]
+interval = 200

--- a/configs/trainer/skywork_math/7b/stage1.toml
+++ b/configs/trainer/skywork_math/7b/stage1.toml
@@ -1,0 +1,12 @@
+
+[monitor.wandb]
+
+[model]
+name = "willcb/DeepSeek-R1-Distill-Qwen-7B"
+ac = true
+
+[optim]
+lr = 1e-6
+
+[ckpt]
+interval = 200

--- a/configs/trainer/skywork_math/7b/stage2.toml
+++ b/configs/trainer/skywork_math/7b/stage2.toml
@@ -1,0 +1,13 @@
+
+[monitor.wandb]
+
+[model]
+name = "willcb/DeepSeek-R1-Distill-Qwen-7B"
+ac = true
+
+[optim]
+lr = 1e-6
+
+[ckpt]
+interval = 200
+resume_step = 660


### PR DESCRIPTION
Added skywork configs to reproduce the skywork OR1 7B and 32B models (without code and data filtering from the previous stage)
Added skywork 7B config as a good testing ground for ablations