### PR TITLE
RLOO and OPO baselines

### DIFF
--- a/src/prime_rl/orchestrator/advantage.py
+++ b/src/prime_rl/orchestrator/advantage.py
@@ -2,12 +2,12 @@ from typing import Callable, Literal
 
 import torch
 from beartype import beartype as typechecker
-from jaxtyping import Float, jaxtyped
+from jaxtyping import Float, Int, jaxtyped
 from torch import Tensor
 
 
 @jaxtyped(typechecker=typechecker)
-def compute_advantage_drgrpo(rewards: Float[Tensor, "group"], _: Float[Tensor, "group"]) -> Float[Tensor, "group"]:
+def compute_advantage_drgrpo(rewards: Float[Tensor, "group"], _: Int[Tensor, "group"]) -> Float[Tensor, "group"]:
     """
     Computes DR.GRPO advantages for a single group.
     For example:
@@ -19,7 +19,7 @@ def compute_advantage_drgrpo(rewards: Float[Tensor, "group"], _: Float[Tensor, "
 
 
 @jaxtyped(typechecker=typechecker)
-def compute_advantage_drgrpo_negclipped(rewards: Float[Tensor, "group"], _: Float[Tensor, "group"]) -> Float[Tensor, "group"]:
+def compute_advantage_drgrpo_negclipped(rewards: Float[Tensor, "group"], _: Int[Tensor, "group"]) -> Float[Tensor, "group"]:
     """
     Computes DR.GRPO advantages for a single group, but clips all negative advantages to zero.
     For example:
@@ -31,7 +31,7 @@ def compute_advantage_drgrpo_negclipped(rewards: Float[Tensor, "group"], _: Floa
 
 
 @jaxtyped(typechecker=typechecker)
-def compute_advantage_rloo(rewards: Float[Tensor, "group"], _: Float[Tensor, "group"]) -> Float[Tensor, "group"]:
+def compute_advantage_rloo(rewards: Float[Tensor, "group"], _: Int[Tensor, "group"]) -> Float[Tensor, "group"]:
     """
     Computes RLOO (rescaled leave-one-out) advantages for a single group by
     scaling the standard DR.GRPO advantage by the factor G / (G - 1).
@@ -42,7 +42,7 @@ def compute_advantage_rloo(rewards: Float[Tensor, "group"], _: Float[Tensor, "gr
 
 
 @jaxtyped(typechecker=typechecker)
-def compute_advantage_opo(rewards: Float[Tensor, "group"], response_lengths: Float[Tensor, "group"]) -> Float[Tensor, "group"]:
+def compute_advantage_opo(rewards: Float[Tensor, "group"], response_lengths: Int[Tensor, "group"]) -> Float[Tensor, "group"]:
     """
     Computes OPO advantages for a single group.
     The baseline is the *weighted* mean of rewards where each reward is
@@ -55,7 +55,7 @@ def compute_advantage_opo(rewards: Float[Tensor, "group"], response_lengths: Flo
 AdvantageType = Literal["drgrpo", "drgrpo-negclipped", "rloo", "opo"]
 
 # Map of advantage types to their corresponding functions
-REGISTRY: dict[AdvantageType, Callable[[Float[Tensor, "group"], Float[Tensor, "group"]], Float[Tensor, "group"]]] = {
+REGISTRY: dict[AdvantageType, Callable[[Float[Tensor, "group"], Int[Tensor, "group"]], Float[Tensor, "group"]]] = {
     "drgrpo": compute_advantage_drgrpo,
     "drgrpo-negclipped": compute_advantage_drgrpo_negclipped,
     "rloo": compute_advantage_rloo,

--- a/src/prime_rl/orchestrator/advantage.py
+++ b/src/prime_rl/orchestrator/advantage.py
@@ -7,7 +7,7 @@ from torch import Tensor
 
 
 @jaxtyped(typechecker=typechecker)
-def compute_advantage_drgrpo(rewards: Float[Tensor, "group"]) -> Float[Tensor, "group"]:
+def compute_advantage_drgrpo(rewards: Float[Tensor, "group"], _: Float[Tensor, "group"]) -> Float[Tensor, "group"]:
     """
     Computes DR.GRPO advantages for a single group.
     For example:
@@ -19,7 +19,7 @@ def compute_advantage_drgrpo(rewards: Float[Tensor, "group"]) -> Float[Tensor, "
 
 
 @jaxtyped(typechecker=typechecker)
-def compute_advantage_drgrpo_negclipped(rewards: Float[Tensor, "group"]) -> Float[Tensor, "group"]:
+def compute_advantage_drgrpo_negclipped(rewards: Float[Tensor, "group"], _: Float[Tensor, "group"]) -> Float[Tensor, "group"]:
     """
     Computes DR.GRPO advantages for a single group, but clips all negative advantages to zero.
     For example:
@@ -30,16 +30,45 @@ def compute_advantage_drgrpo_negclipped(rewards: Float[Tensor, "group"]) -> Floa
     return torch.maximum(rewards - rewards.mean(), torch.zeros_like(rewards))
 
 
-AdvantageType = Literal["drgrpo", "drgrpo-negclipped"]
+@jaxtyped(typechecker=typechecker)
+def compute_advantage_rloo(rewards: Float[Tensor, "group"], _: Float[Tensor, "group"]) -> Float[Tensor, "group"]:
+    """
+    Computes RLOO (rescaled leave-one-out) advantages for a single group by
+    scaling the standard DR.GRPO advantage by the factor G / (G - 1).
+    """
+    group_size = rewards.shape[0]
+    advantages = rewards - rewards.mean()
+    return advantages * group_size / (group_size - 1)
+
+
+@jaxtyped(typechecker=typechecker)
+def compute_advantage_opo(rewards: Float[Tensor, "group"], response_lengths: Float[Tensor, "group"]) -> Float[Tensor, "group"]:
+    """
+    Computes OPO advantages for a single group.
+    The baseline is the *weighted* mean of rewards where each reward is
+    weighted by the length of the corresponding model response (in tokens).
+    """
+    weights = response_lengths.to(dtype=rewards.dtype)
+    baseline = (rewards * weights).sum() / weights.sum()
+    return rewards - baseline
+
+AdvantageType = Literal["drgrpo", "drgrpo-negclipped", "rloo", "opo"]
 
 # Map of advantage types to their corresponding functions
-REGISTRY: dict[AdvantageType, Callable[[Float[Tensor, "group"]], Float[Tensor, "group"]]] = {
+REGISTRY: dict[AdvantageType, Callable[[Float[Tensor, "group"], Float[Tensor, "group"]], Float[Tensor, "group"]]] = {
     "drgrpo": compute_advantage_drgrpo,
     "drgrpo-negclipped": compute_advantage_drgrpo_negclipped,
+    "rloo": compute_advantage_rloo,
+    "opo": compute_advantage_opo,
 }
 
 
-def compute_advantages(rewards: list[float], samples_per_problem: int, advantage_type: AdvantageType) -> list[float]:
+def compute_advantages(
+    rewards: list[float],
+    samples_per_problem: int,
+    advantage_type: AdvantageType,
+    response_lengths: list[int] | None = None,
+) -> list[float]:
     """
     Computes advantages and statistics for logging from a flattened list of rewards for a given advantage type.
 
@@ -47,6 +76,7 @@ def compute_advantages(rewards: list[float], samples_per_problem: int, advantage
         rewards: Flattened list of rewards where first `samples_per_problem` rewards are for the first problem
         samples_per_problem: Number of samples (and thus, rewards) per problem
         advantage_type: Type of advantage computation to use
+        response_lengths: List of response lengths for each reward. Required for OPO advantage computation.
 
     Returns:
         Tuple of (advantages, advantage_stats)
@@ -55,9 +85,11 @@ def compute_advantages(rewards: list[float], samples_per_problem: int, advantage
     assert len(rewards) % samples_per_problem == 0
     all_group_rewards = [rewards[i : i + samples_per_problem] for i in range(0, len(rewards), samples_per_problem)]
     compute_advantage = REGISTRY[advantage_type]
-    for group_rewards in all_group_rewards:
+    all_group_lengths = [response_lengths[i : i + samples_per_problem] for i in range(0, len(response_lengths), samples_per_problem)]
+    for group_rewards, group_lengths in zip(all_group_rewards, all_group_lengths):
         group_rewards_tensor = torch.tensor(group_rewards)
-        group_advantages_tensor = compute_advantage(group_rewards_tensor)
+        group_lengths_tensor = torch.tensor(group_lengths)
+        group_advantages_tensor = compute_advantage(group_rewards_tensor, group_lengths_tensor)
         assert len(group_advantages_tensor) == len(group_rewards_tensor)
         advantages.extend(group_advantages_tensor.tolist())
     assert len(rewards) == len(advantages)

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -229,12 +229,11 @@ async def orchestrate(config: OrchestratorConfig):
                 mask_truncated_completions=config.mask_truncated_completions,
             )
 
-            completion_lengths = [len(tokens) for tokens in results["completion_ids"]]
             advantages = compute_advantages(
                 rewards=outputs.reward,
+                completion_lengths=list(map(len, results.completion_ids)),
                 samples_per_problem=config.rollouts_per_prompt,
                 advantage_type=config.advantage_type,
-                response_lengths=completion_lengths,
             )
 
             # Update pool

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -229,10 +229,12 @@ async def orchestrate(config: OrchestratorConfig):
                 mask_truncated_completions=config.mask_truncated_completions,
             )
 
+            completion_lengths = [len(tokens) for tokens in results["completion_ids"]]
             advantages = compute_advantages(
                 rewards=outputs.reward,
                 samples_per_problem=config.rollouts_per_prompt,
                 advantage_type=config.advantage_type,
+                response_lengths=completion_lengths,
             )
 
             # Update pool


### PR DESCRIPTION
Added support for RLOO (used by DeepSWE) and OPO (shown promising results for stability) baselines in advantage computation