### PR TITLE
Use discriminated union for loss config

### DIFF
--- a/src/prime_rl/trainer/train.py
+++ b/src/prime_rl/trainer/train.py
@@ -81,6 +81,7 @@ def train(config: TrainerConfig):
 
     # Set up the optimizer
     logger.info(f"Initializing optimizer ({config.optim})")
+    logger.info(f"Using `{config.loss.type}` loss ({config.loss})")
     optimizer = torch.optim.AdamW(
         params=model.parameters(),
         lr=config.optim.lr,
@@ -247,7 +248,7 @@ def train(config: TrainerConfig):
                 original_logprobs=logprobs,
                 loss_mask=loss_mask,
                 temperature=temperature,
-                grpo_loss_config=config.loss.variant,
+                loss_config=config.loss,
             )
 
             # Compute entropy


### PR DESCRIPTION
Previously, loss types were not set up as Pydantic discrimainted unions, so Pydantic would not be able to validate config variants correctly, leading to errors when trying to switch to deviate from the default config (e.g. use `clip` loss)

```
pydantic_core._pydantic_core.ValidationError: 2 validation errors for RLConfig
trainer.loss.variant.ClippingConfig
  Input should be a valid dictionary or instance of ClippingConfig [type=model_type, input_value='clip', input_type=str]
    For further information visit https://errors.pydantic.dev/2.11/v/model_type
trainer.loss.variant.RatioConfig
  Input should be a valid dictionary or instance of RatioConfig [type=model_type, input_value='clip', input_type=str]
    For further information visit https://errors.pydantic.dev/2.11/v/model_type
```

This PR slightly restructures the loss configs to correctly use Pydantic's disciminated unions to correctly type checking config variants with differing keys (e.g. `ClipLossConfig` has the epsilon params, whereas the `RatioLossConfig` does not have this). Now we can do:

Specify to run with `RatioLossConfig` (default):

```bash
uv run trainer ... --loss.type ratio
```

Run with clip loss config

```bash
uv run trainer ... --loss.type clip
```

Also adds a info log print on trainer on the loss config used

<img width="761" height="33" alt="Screenshot 2025-07-28 at 1 48 32 PM" src="https://github.com/user-attachments/assets/63cffdee-070d-4f03-b499-aab71054191b" />

