### PR TITLE
mmap added to vllm worker

### DIFF
--- a/src/prime_rl/inference/vllm/worker.py
+++ b/src/prime_rl/inference/vllm/worker.py
@@ -13,7 +13,7 @@ class CheckpointWorker:
 
     def reload_weights(self, model_path: Path) -> None:
         """Reload the weights from a specified path."""
-        state_dict = torch.load(model_path, map_location="cpu")
+        state_dict = torch.load(model_path, map_location="cpu", mmap=True)
 
         def weights_iterator():
             for key, value in state_dict.items():


### PR DESCRIPTION
Extremely simple change that uses mmap for reloading weights in the vllm worker.

<img width="764" height="974" alt="image" src="https://github.com/user-attachments/assets/f4dae84a-62f4-41a8-9429-07a02b0b13e8" />

Pictured is Qwen2.5-0.5b's logged reloading times for `async_level = 0` before and after; for this model it's roughly ~2.5x faster for the reloading operation (~10s per step down to ~4s per step)