### PR TITLE
Copy local environment registry in Docker CI

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -32,6 +32,7 @@ COPY ./pyproject.toml ./pyproject.toml
 COPY ./uv.lock ./uv.lock
 COPY ./README.md ./README.md
 COPY ./src/ ./src/
+COPY ./environments/ ./environments/
 
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 


### PR DESCRIPTION
Should fix CI failing because locally registered environments are not copied in docker build