### PR TITLE
LR scheduler config cosmetics

### DIFF
--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -4,6 +4,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 
 import torch
+from torch.optim.lr_scheduler import LRScheduler
 from torch.optim.optimizer import Optimizer
 
 from prime_rl.trainer.config import CheckpointConfig
@@ -35,7 +36,9 @@ class CheckpointManager:
         ckpt_name = f"trainer_{self._world.local_rank}.pt" if self._world.world_size > 1 else "trainer.pt"
         return self._get_step_path(step) / ckpt_name
 
-    def _save_to_path(self, ckpt_path: Path, model: Model, optimizers: list[Optimizer], progress: Progress, scheduler):
+    def _save_to_path(
+        self, ckpt_path: Path, model: Model, optimizers: list[Optimizer], progress: Progress, scheduler: LRScheduler
+    ):
         self._logger.debug(f"Saving training checkpoint to {ckpt_path}")
         start_time = time.time()
 
@@ -52,7 +55,9 @@ class CheckpointManager:
             torch.save(ckpt_state, f)
         self._logger.debug(f"Training checkpoint saved in {time.time() - start_time:.2f} seconds")
 
-    def _load_from_path(self, ckpt_path: Path, model: Model, optimizers: list[Optimizer], progress: Progress, scheduler):
+    def _load_from_path(
+        self, ckpt_path: Path, model: Model, optimizers: list[Optimizer], progress: Progress, scheduler: LRScheduler
+    ):
         """Loads a checkpoint from a given path in-place."""
         self._logger.debug(f"Loading training checkpoint from {ckpt_path}")
         start_time = time.time()
@@ -73,7 +78,9 @@ class CheckpointManager:
 
         self._logger.debug(f"Training checkpoint loaded in {time.time() - start_time:.2f} seconds")
 
-    def load(self, model: Model, optimizers: list[Optimizer], progress: Progress, step: int, scheduler) -> None:
+    def load(
+        self, model: Model, optimizers: list[Optimizer], progress: Progress, step: int, scheduler: LRScheduler
+    ) -> None:
         """Loads a checkpoint from a given path in-place."""
         ckpt_path = self._get_ckpt_path(step)
         if not ckpt_path.exists():
@@ -86,7 +93,7 @@ class CheckpointManager:
         optimizers: list[Optimizer],
         progress: Progress,
         step: int,
-        scheduler,
+        scheduler: LRScheduler,
     ):
         """Saves the full checkpoint state for a specified step."""
         step_path = self._get_step_path(step)
@@ -96,7 +103,9 @@ class CheckpointManager:
         if self.save_async:
             # Run save in a separate thread
             thread = threading.Thread(
-                target=self._save_to_path, args=(ckpt_path, model, optimizers, progress, scheduler), name=f"ckpt-save-{step}"
+                target=self._save_to_path,
+                args=(ckpt_path, model, optimizers, progress, scheduler),
+                name=f"ckpt-save-{step}",
             )
             thread.start()
         else:

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -90,7 +90,7 @@ class OptimizerConfig(BaseConfig):
     betas2: Annotated[float, Field(ge=0)] = 0.99
 
     # LR Scheduler configuration
-    scheduler_config: SchedulerConfig = Field(discriminator="type", default=ConstantSchedulerConfig())
+    scheduler: SchedulerConfig = Field(discriminator="type", default=ConstantSchedulerConfig())
 
 
 class CheckpointConfig(BaseConfig):

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -42,20 +42,20 @@ class ModelConfig(BaseConfig):
 
 class BaseSchedulerConfig(BaseModel):
     """Base configuration for learning rate schedulers."""
-    
+
     warmup_steps: Annotated[int, Field(ge=0, description="Number of warmup steps for the learning rate scheduler.")] = 0
 
 
 class ConstantSchedulerConfig(BaseSchedulerConfig):
     """Configuration for constant learning rate scheduler."""
-    
-    scheduler: Literal["constant"] = "constant"
+
+    type: Literal["constant"] = "constant"
 
 
 class LinearSchedulerConfig(BaseSchedulerConfig):
     """Configuration for linear learning rate scheduler."""
-    
-    scheduler: Literal["linear"] = "linear"
+
+    type: Literal["linear"] = "linear"
     decay_steps: Annotated[
         int | None,
         Field(
@@ -63,18 +63,18 @@ class LinearSchedulerConfig(BaseSchedulerConfig):
             description="Number of steps to decay the learning rate during the final portion of training. If None, will use remaining steps after warmup.",
         ),
     ] = None
-    
+
     @model_validator(mode="after")
     def validate_decay_steps(self):
-        if self.scheduler == "linear" and self.decay_steps is not None and self.decay_steps <= 0:
+        if self.type == "linear" and self.decay_steps is not None and self.decay_steps <= 0:
             raise ValueError(f"decay_steps must be positive for linear scheduler, got {self.decay_steps}")
         return self
 
 
 class CosineSchedulerConfig(BaseSchedulerConfig):
     """Configuration for cosine learning rate scheduler."""
-    
-    scheduler: Literal["cosine"] = "cosine"
+
+    type: Literal["cosine"] = "cosine"
     decay_steps: Annotated[
         int | None,
         Field(
@@ -82,10 +82,10 @@ class CosineSchedulerConfig(BaseSchedulerConfig):
             description="Number of steps to decay the learning rate during the final portion of training. If None, will use remaining steps after warmup.",
         ),
     ] = None
-    
+
     @model_validator(mode="after")
     def validate_decay_steps(self):
-        if self.scheduler == "cosine" and self.decay_steps is not None and self.decay_steps <= 0:
+        if self.type == "cosine" and self.decay_steps is not None and self.decay_steps <= 0:
             raise ValueError(f"decay_steps must be positive for cosine scheduler, got {self.decay_steps}")
         return self
 
@@ -102,7 +102,7 @@ class OptimizerConfig(BaseConfig):
     betas2: Annotated[float, Field(ge=0)] = 0.99
 
     # LR Scheduler configuration
-    scheduler_config: SchedulerConfig = Field(discriminator="scheduler", default=ConstantSchedulerConfig())
+    scheduler_config: SchedulerConfig = Field(discriminator="type", default=ConstantSchedulerConfig())
 
 
 class CheckpointConfig(BaseConfig):

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -64,12 +64,6 @@ class LinearSchedulerConfig(BaseSchedulerConfig):
         ),
     ] = None
 
-    @model_validator(mode="after")
-    def validate_decay_steps(self):
-        if self.type == "linear" and self.decay_steps is not None and self.decay_steps <= 0:
-            raise ValueError(f"decay_steps must be positive for linear scheduler, got {self.decay_steps}")
-        return self
-
 
 class CosineSchedulerConfig(BaseSchedulerConfig):
     """Configuration for cosine learning rate scheduler."""
@@ -82,12 +76,6 @@ class CosineSchedulerConfig(BaseSchedulerConfig):
             description="Number of steps to decay the learning rate during the final portion of training. If None, will use remaining steps after warmup.",
         ),
     ] = None
-
-    @model_validator(mode="after")
-    def validate_decay_steps(self):
-        if self.type == "cosine" and self.decay_steps is not None and self.decay_steps <= 0:
-            raise ValueError(f"decay_steps must be positive for cosine scheduler, got {self.decay_steps}")
-        return self
 
 
 SchedulerConfig: TypeAlias = ConstantSchedulerConfig | LinearSchedulerConfig | CosineSchedulerConfig

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -40,22 +40,19 @@ class ModelConfig(BaseConfig):
     ] = True
 
 
-class BaseSchedulerConfig(BaseModel):
-    """Base configuration for learning rate schedulers."""
-
-    warmup_steps: Annotated[int, Field(ge=0, description="Number of warmup steps for the learning rate scheduler.")] = 0
-
-
-class ConstantSchedulerConfig(BaseSchedulerConfig):
+class ConstantSchedulerConfig(BaseModel):
     """Configuration for constant learning rate scheduler."""
 
     type: Literal["constant"] = "constant"
 
 
-class LinearSchedulerConfig(BaseSchedulerConfig):
+class LinearSchedulerConfig(BaseModel):
     """Configuration for linear learning rate scheduler."""
 
     type: Literal["linear"] = "linear"
+
+    warmup_steps: Annotated[int, Field(ge=0, description="Number of warmup steps for the learning rate scheduler.")] = 0
+
     decay_steps: Annotated[
         int | None,
         Field(
@@ -65,10 +62,13 @@ class LinearSchedulerConfig(BaseSchedulerConfig):
     ] = None
 
 
-class CosineSchedulerConfig(BaseSchedulerConfig):
+class CosineSchedulerConfig(BaseModel):
     """Configuration for cosine learning rate scheduler."""
 
     type: Literal["cosine"] = "cosine"
+
+    warmup_steps: Annotated[int, Field(ge=0, description="Number of warmup steps for the learning rate scheduler.")] = 0
+
     decay_steps: Annotated[
         int | None,
         Field(

--- a/src/prime_rl/trainer/scheduler.py
+++ b/src/prime_rl/trainer/scheduler.py
@@ -15,7 +15,7 @@ class ConstantLRScheduler(LRScheduler):
         return [group["lr"] for group in self.optimizer.param_groups]
 
 
-def validate_scheduler_config(config: SchedulerConfig, max_steps: int) -> None:
+def validate_scheduler_config(config: SchedulerConfig, max_steps: int | None) -> None:
     """Validate scheduler configuration against max_steps."""
     if max_steps is None:
         raise ValueError("Must specify max_steps when using a scheduler")
@@ -37,7 +37,7 @@ def validate_scheduler_config(config: SchedulerConfig, max_steps: int) -> None:
         raise ValueError(f"Warmup steps ({warmup_steps}) + decay steps ({decay_steps}) exceeds max_steps ({max_steps})")
 
 
-def create_lr_scheduler(optimizer: Optimizer, config: SchedulerConfig, max_steps: int) -> LRScheduler:
+def create_lr_scheduler(optimizer: Optimizer, config: SchedulerConfig, max_steps: int | None) -> LRScheduler:
     """Create learning rate scheduler based on config."""
     # Validate configuration
     validate_scheduler_config(config, max_steps)

--- a/src/prime_rl/trainer/scheduler.py
+++ b/src/prime_rl/trainer/scheduler.py
@@ -6,45 +6,43 @@ from prime_rl.trainer.config import SchedulerConfig
 
 class ConstantLRScheduler(LRScheduler):
     """A scheduler that keeps the learning rate constant."""
-    
+
     def __init__(self, optimizer: Optimizer):
         self.optimizer = optimizer
         super().__init__(optimizer, last_epoch=-1)
-    
+
     def get_lr(self):
-        return [group['lr'] for group in self.optimizer.param_groups]
+        return [group["lr"] for group in self.optimizer.param_groups]
 
 
 def validate_scheduler_config(config: SchedulerConfig, max_steps: int) -> None:
     """Validate scheduler configuration against max_steps."""
     if max_steps is None:
         raise ValueError("Must specify max_steps when using a scheduler")
-    
-    if config.scheduler == "constant":
+
+    if config.type == "constant":
         return
-    
+
     warmup_steps = config.warmup_steps
     decay_steps = config.decay_steps
-    
+
     if decay_steps is None:
         # Will use remaining steps after warmup
         decay_steps = max_steps - warmup_steps
-    
+
     if decay_steps <= 0:
         raise ValueError(f"decay_steps must be positive, got {decay_steps}")
-    
+
     if warmup_steps + decay_steps > max_steps:
-        raise ValueError(
-            f"Warmup steps ({warmup_steps}) + decay steps ({decay_steps}) exceeds max_steps ({max_steps})"
-        )
+        raise ValueError(f"Warmup steps ({warmup_steps}) + decay steps ({decay_steps}) exceeds max_steps ({max_steps})")
 
 
 def create_lr_scheduler(optimizer: Optimizer, config: SchedulerConfig, max_steps: int) -> LRScheduler:
     """Create learning rate scheduler based on config."""
     # Validate configuration
     validate_scheduler_config(config, max_steps)
-    
-    if config.scheduler == "constant":
+
+    if config.type == "constant":
         return ConstantLRScheduler(optimizer)
 
     warmup_steps = config.warmup_steps
@@ -75,12 +73,10 @@ def create_lr_scheduler(optimizer: Optimizer, config: SchedulerConfig, max_steps
         milestones.append(decay_start_step)
 
     # Phase 3: Final decay
-    if config.scheduler == "linear":
+    if config.type == "linear":
         decay_scheduler = LinearLR(optimizer, start_factor=1.0, end_factor=0.0, total_iters=decay_steps)
-    elif config.scheduler == "cosine":
+    elif config.type == "cosine":
         decay_scheduler = CosineAnnealingLR(optimizer, T_max=decay_steps, eta_min=0.0)
-    else:
-        raise ValueError(f"Unknown scheduler type: {config.scheduler}")
 
     schedulers.append(decay_scheduler)
 

--- a/src/prime_rl/trainer/train.py
+++ b/src/prime_rl/trainer/train.py
@@ -93,7 +93,7 @@ def train(config: TrainerConfig):
     # Set up the learning rate scheduler
     scheduler = create_lr_scheduler(optimizer, config.optim.scheduler_config, config.max_steps)
     logger.info(
-        f"Using `{config.optim.scheduler_config.scheduler}` scheduler (warmup_steps={config.optim.scheduler_config.warmup_steps}, decay_steps={getattr(config.optim.scheduler_config, 'decay_steps', None)})"
+        f"Using `{config.optim.scheduler_config.type}` scheduler (warmup_steps={config.optim.scheduler_config.warmup_steps}, decay_steps={getattr(config.optim.scheduler_config, 'decay_steps', None)})"
     )
 
     # Get checkpoint managers

--- a/src/prime_rl/trainer/train.py
+++ b/src/prime_rl/trainer/train.py
@@ -91,10 +91,8 @@ def train(config: TrainerConfig):
     )
 
     # Set up the learning rate scheduler
-    scheduler = create_lr_scheduler(optimizer, config.optim.scheduler_config, config.max_steps)
-    logger.info(
-        f"Using `{config.optim.scheduler_config.type}` scheduler (warmup_steps={config.optim.scheduler_config.warmup_steps}, decay_steps={getattr(config.optim.scheduler_config, 'decay_steps', None)})"
-    )
+    scheduler = create_lr_scheduler(optimizer, config.optim.scheduler, config.max_steps)
+    logger.info(f"Using `{config.optim.scheduler.type}` scheduler ({config.optim.scheduler})")
 
     # Get checkpoint managers
     logger.info(f"Initializing weight checkpoint manager ({config.weights})")


### PR DESCRIPTION
Some code cosmetics stuff:
- Rename `config.optim.scheduler_config` -> `config.optim.scheduler`
- Rename discriminator field `scheduler` -> `type` (consistent with other discriminated union types), s.t. `config.optim.scheduler.type` instead of duplicate `config.optim.scheduler.scheduler`
- Removed unnecessary non-negative checks in Pydantic class
- Removed base class and moved `warmup_steps` into cosine and linear scheduler configs (should not exist on constant scheduler)