### PR TITLE
add correct loss scaling

### DIFF
--- a/src/prime_rl/trainer/data.py
+++ b/src/prime_rl/trainer/data.py
@@ -19,7 +19,7 @@ class MicroBatch(TypedDict):
 
     # Batch level
     temperature: float
-    total_tokens: int
+    completion_tokens_count: int
 
 
 class FakeDataLoader:
@@ -43,6 +43,7 @@ class FakeDataLoader:
             "logprobs": torch.randn(self.micro_batch_size, self.seq_len),
             "temperature": 1.0,
             "loss_mask": torch.ones(self.micro_batch_size, self.seq_len, dtype=torch.int32),
+            "completion_tokens_count": self.micro_batch_size * self.micro_batch_size,
         }
 
 

--- a/tests/integration/trainer/test_debug_path.py
+++ b/tests/integration/trainer/test_debug_path.py
@@ -21,7 +21,7 @@ def create_sample(seq_len: int) -> BatchSample:
         "advantages": torch.randn(seq_len).float(),
         "loss_mask": torch.ones(seq_len).long(),
         "logprobs": torch.randn(seq_len).float(),
-        "total_tokens": seq_len,
+        "completion_tokens_count": seq_len,
     }
 
 
@@ -30,8 +30,8 @@ def create_dummy_batch(batch_size: int, seq_len: int) -> MicroBatch:
     samples = [create_sample(seq_len) for _ in range(batch_size)]
     for key in ["input_ids", "advantages", "loss_mask", "logprobs", "position_ids"]:
         micro_batch[key] = torch.stack([sample[key] for sample in samples], dim=0)
+    micro_batch["completion_tokens_count"] = sum([sample["completion_tokens_count"] for sample in samples])
     micro_batch["temperature"] = 1.0
-    micro_batch["total_tokens"] = batch_size * seq_len
     return micro_batch
 
 


### PR DESCRIPTION
We currently have a bug where the we count the padded token in the loss_scale. This is because we are using the loss_mask  for counting generated token.

This pr fix it by keeping track of the total generated token at the batching level