### PR TITLE
Match the verl default for beta2

### DIFF
--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -87,7 +87,7 @@ class OptimizerConfig(BaseConfig):
     lr: Annotated[float, Field(ge=0)] = 4e-4
     weight_decay: Annotated[float, Field(ge=0)] = 0.01
     betas1: Annotated[float, Field(ge=0)] = 0.9
-    betas2: Annotated[float, Field(ge=0)] = 0.99
+    betas2: Annotated[float, Field(ge=0)] = 0.999
 
     # LR Scheduler configuration
     scheduler: SchedulerConfig = Field(discriminator="type", default=ConstantSchedulerConfig())


### PR DESCRIPTION
<img width="846" height="205" alt="Screenshot 2025-08-04 at 18 34 49" src="https://github.com/user-attachments/assets/c6b9549d-1833-4786-9265-05507d44bc90" />
Our current beta2 default doesn't match verl