### PR TITLE
Move scheduler arg validation to Pydantic

### DIFF
--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -217,12 +217,6 @@ class RLConfig(BaseSettings):
             self.inference.model.max_model_len = self.orchestrator.seq_len
         return self
 
-    @model_validator(mode="after")
-    def auto_setup_max_steps(self):
-        if self.orchestrator.max_steps is not None:
-            self.trainer.max_steps = self.orchestrator.max_steps
-        return self
-
 
 def setup_logger(log_config: LogConfig) -> Logger:
     if get_logger():

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -218,11 +218,11 @@ class TrainerConfig(BaseSettings):
     monitor: MultiMonitorConfig = MultiMonitorConfig()
 
     max_steps: Annotated[
-        int,
+        int | None,
         Field(
-            description="Maximum number of steps to run training for.",
+            description="Maximum number of steps to run training for. If None, will run indefinitely.",
         ),
-    ] = 100000000000000
+    ] = None
 
     async_level: Annotated[
         int,

--- a/src/prime_rl/trainer/scheduler.py
+++ b/src/prime_rl/trainer/scheduler.py
@@ -15,32 +15,8 @@ class ConstantLRScheduler(LRScheduler):
         return [group["lr"] for group in self.optimizer.param_groups]
 
 
-def validate_scheduler_config(config: SchedulerConfig, max_steps: int | None) -> None:
-    """Validate scheduler configuration against max_steps."""
-    if max_steps is None:
-        raise ValueError("Must specify max_steps when using a scheduler")
-
-    if config.type == "constant":
-        return
-
-    warmup_steps = config.warmup_steps
-    decay_steps = config.decay_steps
-
-    if decay_steps is None:
-        # Will use remaining steps after warmup
-        decay_steps = max_steps - warmup_steps
-
-    if decay_steps <= 0:
-        raise ValueError(f"decay_steps must be positive, got {decay_steps}")
-
-    if warmup_steps + decay_steps > max_steps:
-        raise ValueError(f"Warmup steps ({warmup_steps}) + decay steps ({decay_steps}) exceeds max_steps ({max_steps})")
-
-
 def create_lr_scheduler(optimizer: Optimizer, config: SchedulerConfig, max_steps: int | None) -> LRScheduler:
     """Create learning rate scheduler based on config."""
-    # Validate configuration
-    validate_scheduler_config(config, max_steps)
 
     if config.type == "constant":
         return ConstantLRScheduler(optimizer)

--- a/src/prime_rl/trainer/train.py
+++ b/src/prime_rl/trainer/train.py
@@ -156,7 +156,7 @@ def train(config: TrainerConfig):
             save_ckpt_time = time.time() - save_ckpt_start_time
 
         # Break if we have reached the maximum number of steps
-        if progress.step >= config.max_steps:
+        if config.max_steps is not None and progress.step >= config.max_steps:
             break
 
         logger.info(f"Starting training step {progress.step}")


### PR DESCRIPTION
This PR partially reverts #673, which introduced `max_steps: int` instead of `max_steps: int | None` on the trainer (but not orchestrator). I advocate that we actually want to use `None` type for infinite training and make it very clear (i.e. fail loudly in the config validation) that certain scheduler types which allow auto-computing decay steps have undefined behavior if training forever. Hence, this PR moves the scheduler validation into a Pydantic class and enforces that `max_steps` are set on the trainer unless the `constant` LR scheduler is used. If a non-constant scheduler is used, we auto-compute the decay steps if they are not specified, else we validate that the sum of warmup and decay does not exceed the total steps (as before).