### PR TITLE
[DO NOT MERGE] vLLM v0 on new main

### DIFF
--- a/environments/vf_intellect_math/vf_intellect_math.py
+++ b/environments/vf_intellect_math/vf_intellect_math.py
@@ -8,23 +8,14 @@ def load_environment(
     max_solve_rate: float | None = None,
     **kwargs,
 ) -> vf.Environment:
-    import json
-
     from prime_rl.orchestrator.genesys.math import compute_math_reward
 
-    train_dataset = load_dataset("PrimeIntellect/INTELLECT-2-only-math", split="train").map(
-        lambda x: {
-            "question": x["prompt"],
-            "info": json.loads(x["verification_info"]),
-            "task": "simple-math",
-        }
-    )
+    train_dataset = load_dataset("PrimeIntellect/INTELLECT-2-only-math", split="train")
     if solve_rate_field is not None:
         if min_solve_rate is not None:
             train_dataset = train_dataset.filter(lambda x: x[solve_rate_field] >= min_solve_rate)
         if max_solve_rate is not None:
             train_dataset = train_dataset.filter(lambda x: x[solve_rate_field] <= max_solve_rate)
-    train_dataset = train_dataset.remove_columns(["prompt", "verification_info"])
     train_dataset = train_dataset.shuffle(seed=42)
 
     def correct_answer_reward_func(completion, info, **kwargs) -> float:

--- a/environments/vf_reverse_text/vf_reverse_text.py
+++ b/environments/vf_reverse_text/vf_reverse_text.py
@@ -1,19 +1,9 @@
-import json
-
 import verifiers as vf
 from datasets import load_dataset
 
 
 def load_environment() -> vf.Environment:
-    train_dataset = load_dataset("mikasenghaas/reverse_text_dataset_debug_50_seq_len", split="train").map(
-        lambda x: {
-            "question": x["prompt"],
-            "answer": json.loads(x["verification_info"])["ground_truth"],
-            "info": {},
-            "task": x["task_type"],
-        }
-    )
-    train_dataset = train_dataset.remove_columns(["prompt", "verification_info", "task_type"])
+    train_dataset = load_dataset("mikasenghaas/reverse_text_dataset_debug_50_seq_len", split="train")
     train_dataset = train_dataset.shuffle(seed=42)
 
     parser = vf.XMLParser(["answer"], answer_field="answer")

--- a/src/prime_rl/orchestrator/advantage.py
+++ b/src/prime_rl/orchestrator/advantage.py
@@ -56,7 +56,7 @@ def compute_advantages(rewards: list[float], samples_per_problem: int, advantage
     all_group_rewards = [rewards[i : i + samples_per_problem] for i in range(0, len(rewards), samples_per_problem)]
     compute_advantage = REGISTRY[advantage_type]
     for group_rewards in all_group_rewards:
-        group_rewards_tensor = torch.tensor(group_rewards)
+        group_rewards_tensor = torch.tensor(group_rewards).float()
         group_advantages_tensor = compute_advantage(group_rewards_tensor)
         assert len(group_advantages_tensor) == len(group_rewards_tensor)
         advantages.extend(group_advantages_tensor.tolist())

--- a/src/prime_rl/orchestrator/batch.py
+++ b/src/prime_rl/orchestrator/batch.py
@@ -204,7 +204,7 @@ def prepare_batch_packing(
 
     # because of fsdp we need to make sure that each data ran has the same number of micro batches otherwise training will hang.
     # We create fake micro batches to fill the gap with real data but zero advantages, they would not contribute to the loss.
-    if num_train_workers > 2 and num_padding_batch > 0:
+    if num_train_workers > 1 and num_padding_batch > 0:
         padded_batch = copy.deepcopy(micro_batches[0])
         padded_batch["advantages"] = torch.zeros_like(padded_batch["advantages"])
         padded_batch["loss_mask"] = torch.zeros_like(padded_batch["loss_mask"])

--- a/src/prime_rl/orchestrator/batch.py
+++ b/src/prime_rl/orchestrator/batch.py
@@ -204,9 +204,10 @@ def prepare_batch_packing(
 
     # because of fsdp we need to make sure that each data ran has the same number of micro batches otherwise training will hang.
     # We create fake micro batches to fill the gap with real data but zero advantages, they would not contribute to the loss.
-    if num_padding_batch > 0:
+    if num_train_workers > 2 and num_padding_batch > 0:
         padded_batch = copy.deepcopy(micro_batches[0])
         padded_batch["advantages"] = torch.zeros_like(padded_batch["advantages"])
+        padded_batch["loss_mask"] = torch.zeros_like(padded_batch["loss_mask"])
         micro_batches.extend([padded_batch for _ in range(num_padding_batch)])
 
     assert len(micro_batches) % num_train_workers == 0, (

--- a/src/prime_rl/orchestrator/genesys/__init__.py
+++ b/src/prime_rl/orchestrator/genesys/__init__.py
@@ -1,6 +1,7 @@
 from typing import Callable, Literal
 
 from prime_rl.orchestrator.genesys.math import math_verify_reward_function
+from prime_rl.orchestrator.genesys.reverse_text import reverse_text
 
 
 def null_reward(*args, **kwargs):
@@ -8,6 +9,7 @@ def null_reward(*args, **kwargs):
 
 
 TaskType = Literal[
+    "reverse_text",
     "verifiable_math",
     "null_reward",
 ]
@@ -21,6 +23,7 @@ def get_reward_function(task_type: TaskType) -> Callable[[str, dict], float]:
 
 
 _REWARD_FUNCTIONS: dict[TaskType, Callable] = {
+    "reverse_text": reverse_text,
     "verifiable_math": math_verify_reward_function,
     "null_reward": null_reward,
 }

--- a/src/prime_rl/orchestrator/genesys/reverse_text.py
+++ b/src/prime_rl/orchestrator/genesys/reverse_text.py
@@ -1,0 +1,26 @@
+import re
+from difflib import SequenceMatcher
+
+
+def lcs_ratio(x: str, y: str) -> float:
+    """
+    Return the longest common subsequence ratio of x and y.
+    """
+    return SequenceMatcher(None, x, y).ratio()
+
+
+def reverse_text(completion: str, verification_info: dict) -> int:
+    """
+    LCS ratio of the reversed prompt and the parsed completion.
+    """
+
+    # Extract solution between <answer> and </answer> tags
+    answer_text = re.search(r"<answer>(.*?)</answer>", completion, re.DOTALL)
+    if not answer_text:
+        return 0
+
+    ground_truth = verification_info.get("ground_truth")
+    if not ground_truth:
+        return 0
+
+    return lcs_ratio(answer_text.group(1).strip(), ground_truth)

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -415,12 +415,12 @@ async def orchestrate(config: OrchestratorConfig):
 
         # Log time metrics to monitor
         time_metrics = {
-            "time/orchestrator": step_time,
-            "time/orchestrator/wait_for_weight_ckpt": wait_for_weight_ckpt_time,
-            "time/orchestrator/generate_completions": generate_completions_time,
-            "time/orchestrator/reload_weights": reload_weights_time,
-            "time/orchestrator/save_ckpt": save_ckpt_time,
-            "time/orchestrator/eval": eval_time,
+            "time/step": step_time,
+            "time/wait_for_weight_ckpt": wait_for_weight_ckpt_time,
+            "time/generate_completions": generate_completions_time,
+            "time/reload_weights": reload_weights_time,
+            "time/save_ckpt": save_ckpt_time,
+            "time/eval": eval_time,
             "step": progress.step,
         }
         monitor.log(time_metrics)

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -233,12 +233,12 @@ async def orchestrate(config: OrchestratorConfig):
             completions, completion_ids, completion_logprobs, completion_masks = [], [], [], []
             for request_output in request_outputs:
                 prompts.append(request_output.prompt)
-                prompt_ids.append(request_output.prompt_token_ids)
+                prompt_ids.append(list(request_output.prompt_token_ids))
                 prompt_masks.append([0] * len(request_output.prompt_token_ids))
                 assert len(request_output.outputs) == 1, "Response should always have one choice"
                 completion_output = request_output.outputs[0]
                 completions.append(completion_output.text)
-                completion_ids.append(completion_output.token_ids)
+                completion_ids.append(list(completion_output.token_ids))
                 completion_output_logprobs = []
                 for logprobs in completion_output.logprobs:
                     assert len(list(logprobs.values())) == 1, "There should be only one logprob"

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -55,7 +55,6 @@ async def orchestrate(config: OrchestratorConfig):
         disable_async_output_proc=True,
         enable_chunked_prefill=True,
         max_model_len=config.seq_len,
-        enforce_eager=True,
     )
 
     # Load tokenizer
@@ -196,13 +195,9 @@ async def orchestrate(config: OrchestratorConfig):
             problems = [problem for problem in problems for _ in range(config.rollouts_per_prompt)]
 
             # Get relevant columns
-            print(f"{problems=}")
             prompts = [problem["prompt"] for problem in problems]
             task_types = [problem["task_type"] for problem in problems]
             verification_infos = [json.loads(problem.get("verification_info", "{}")) for problem in problems]
-            print(f"{prompts[:config.rollouts_per_prompt]=}")
-            print(f"{task_types[:config.rollouts_per_prompt]=}")
-            print(f"{verification_infos[:config.rollouts_per_prompt]=}")
 
             # Format prompts
             formatted_prompts = format_prompts(
@@ -261,12 +256,9 @@ async def orchestrate(config: OrchestratorConfig):
                 == len(completion_masks)
                 == len(request_outputs)
             )
-            print(f"{completions[:config.rollouts_per_prompt]=}")
-            print()
 
             # Compute rewards
             rewards = compute_rewards(completions, task_types, verification_infos)
-            print(f"{rewards=}")
 
             # sampling_args = dict(config.sampling)
             # sampling_args["logprobs"] = True
@@ -305,7 +297,6 @@ async def orchestrate(config: OrchestratorConfig):
                 samples_per_problem=config.rollouts_per_prompt,
                 advantage_type=config.advantage_type,
             )
-            print(f"{advantages=}")
 
             # Update pool
             rollouts = make_rollouts(

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -351,6 +351,7 @@ async def orchestrate(config: OrchestratorConfig):
             "seq_len/max": seq_lens.max().item(),
             "seq_len/min": seq_lens.min().item(),
             "seq_len/std": seq_lens.std().item(),
+            "seq_len/sum": seq_lens.sum().item(),
             "step": progress.step,
         }
         monitor.log(seq_len_metrics)
@@ -360,6 +361,7 @@ async def orchestrate(config: OrchestratorConfig):
             "prompt_len/max": prompt_lens.max().item(),
             "prompt_len/min": prompt_lens.min().item(),
             "prompt_len/std": prompt_lens.std().item(),
+            "prompt_len/sum": prompt_lens.sum().item(),
             "step": progress.step,
         }
         monitor.log(prompt_len_metrics)
@@ -369,6 +371,7 @@ async def orchestrate(config: OrchestratorConfig):
             "completion_len/max": completion_lens.max().item(),
             "completion_len/min": completion_lens.min().item(),
             "completion_len/std": completion_lens.std().item(),
+            "completion_len/sum": completion_lens.sum().item(),
             "step": progress.step,
         }
         monitor.log(completion_len_metrics)

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -303,8 +303,8 @@ async def orchestrate(config: OrchestratorConfig):
                 step=progress.step,
             )
             monitor.wandb.log_distributions(
-                rewards,
-                advantages,
+                rewards.tolist(),
+                advantages.tolist(),
                 rollouts_per_problem=config.rollouts_per_prompt,
                 step=progress.step,
             )

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -359,7 +359,7 @@ async def orchestrate(config: OrchestratorConfig):
 
         # Log performance metrics to monitor
         perf_metrics = {
-            "perf/infer/throughput": throughput,
+            "perf/throughput": throughput,
             "perf/problem_requests": problem_requests,
             "perf/completion_requests": completion_requests,
             "perf/calls_to_generate": calls_to_generate,

--- a/src/prime_rl/trainer/train.py
+++ b/src/prime_rl/trainer/train.py
@@ -232,8 +232,8 @@ def train(config: TrainerConfig):
         batch_size = micro_batch_size * num_micro_batches
 
         # Normalize by the number of unmasked tokens in the batch (per-batch length normalization)
-        total_non_masked_tokens = sum(micro_batch["loss_mask"].sum().item() for micro_batch in micro_batches)
-        loss_scale = total_non_masked_tokens
+        loss_scale = torch.tensor(sum(micro_batch["loss_mask"].sum().item() for micro_batch in micro_batches), device="cuda")
+        dist.all_reduce(loss_scale, op=torch.distributed.ReduceOp.SUM)
 
         logger.info(f"Starting forward and backward pass ({num_micro_batches=}, {loss_scale=})")
         for micro_step, micro_batch in enumerate(micro_batches):

--- a/src/prime_rl/trainer/train.py
+++ b/src/prime_rl/trainer/train.py
@@ -352,8 +352,8 @@ def train(config: TrainerConfig):
 
         # Log performance metrics
         perf_metrics = {
-            "perf/train/throughput": throughput,
-            "perf/train/mfu": mfu,
+            "perf/throughput": throughput,
+            "perf/mfu": mfu,
             "step": progress.step,
         }
         monitor.log(perf_metrics)

--- a/src/prime_rl/trainer/train.py
+++ b/src/prime_rl/trainer/train.py
@@ -364,7 +364,7 @@ def train(config: TrainerConfig):
         # Log step metrics
         step_time = time.time() - step_start_time
         current_lr = optimizer.param_groups[0]["lr"]
-        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {tensor_metrics['loss/mean']:.4f} | Entropy: {tensor_metrics['entropy/mean']:.4f} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}%"
+        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {tensor_metrics['loss/mean']:.4f} | Grad. Norm: {grad_norm:.4f} | Entropy: {tensor_metrics['entropy/mean']:.4f} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}%"
         logger.success(step_message)
 
         # Log performance metrics

--- a/src/prime_rl/trainer/train.py
+++ b/src/prime_rl/trainer/train.py
@@ -318,8 +318,6 @@ def train(config: TrainerConfig):
         for key in loss_tensors.keys():
             if f"{key}/sum" in tensor_metrics and f"{key}/numel" in tensor_metrics:
                 tensor_metrics[f"{key}/mean"] = tensor_metrics[f"{key}/sum"] / tensor_metrics[f"{key}/numel"]
-                del tensor_metrics[f"{key}/sum"]
-                del tensor_metrics[f"{key}/numel"]
 
         # Optionally, clip the gradients
         logger.debug(f"Clipping gradients to {config.loss.max_norm}")

--- a/src/prime_rl/trainer/train.py
+++ b/src/prime_rl/trainer/train.py
@@ -269,6 +269,7 @@ def train(config: TrainerConfig):
                 tensor_metrics[f"{key}/max"] = max(tensor_metrics.get(f"{key}/max", float("-inf")), value.max().item())
                 tensor_metrics[f"{key}/sum"] += value.sum().item()
                 tensor_metrics[f"{key}/mean"] += value.sum().item() / loss_scale
+                tensor_metrics[f"{key}/numel"] += loss_mask.sum().item()
 
             # Scale loss by scale factor before backward pass
             loss = loss / loss_scale
@@ -290,7 +291,7 @@ def train(config: TrainerConfig):
                 dist.all_reduce(tensor_value, op=dist.ReduceOp.MIN)
             elif "max" in key:
                 dist.all_reduce(tensor_value, op=dist.ReduceOp.MAX)
-            elif "sum" in key:
+            elif "sum" in key or "numel" in key:
                 dist.all_reduce(tensor_value, op=dist.ReduceOp.SUM)
             elif "mean" in key:
                 dist.all_reduce(tensor_value, op=dist.ReduceOp.AVG)

--- a/src/prime_rl/trainer/train.py
+++ b/src/prime_rl/trainer/train.py
@@ -376,14 +376,13 @@ def train(config: TrainerConfig):
 
         # Log time metrics
         time_metrics = {
-            "time/train": step_time,
-            "time/train/wait_for_batch": wait_for_batch_time,
-            "time/train/load_data": load_data_time,
-            "time/train/save_weights": save_weights_time,
-            "time/train/compute/logprobs": compute_logprobs_time,
-            "time/train/save_ckpt": save_ckpt_time,
-            "time/train/compute/forward_backward": forward_backward_time,
-            "time/train/compute": forward_backward_time + compute_logprobs_time,
+            "time/step": step_time,
+            "time/wait_for_batch": wait_for_batch_time,
+            "time/load_data": load_data_time,
+            "time/save_weights": save_weights_time,
+            "time/save_ckpt": save_ckpt_time,
+            "time/compute_logprobs": compute_logprobs_time,
+            "time/forward_backward": forward_backward_time,
             "step": progress.step,
         }
         monitor.log(time_metrics)

--- a/src/prime_rl/trainer/train.py
+++ b/src/prime_rl/trainer/train.py
@@ -211,8 +211,8 @@ def train(config: TrainerConfig):
                     recomputed_logprobs = compute_logprobs(logprob_model, input_ids, position_ids, temperature)
                     recomputed_logprob_error = torch.exp(recomputed_logprobs - logprobs) * loss_mask
 
-                    micro_batch["logprobs"] = recomputed_logprobs.to("cpu")
-                    recomputed_logprob_errors.append(recomputed_logprob_error.to("cpu"))
+                    micro_batch["logprobs"] = recomputed_logprobs.cpu()
+                    recomputed_logprob_errors[micro_step] = recomputed_logprob_error.detach().cpu()
                     logger.debug(
                         f"Recomputed logprob error for micro batch {micro_step + 1}/{num_micro_batches} (recomputed_logprob_error={recomputed_logprob_error.sum().item() / loss_mask.sum().item():.2f})"
                     )


### PR DESCRIPTION
> ⚠️ For debugging purposes, should not be merged!

This PR rewrites the orchestrator to use the synchronous `vllm.LLM` class to rule out a possible regression associated with moving to vLLM v1 AsyncLLM via the API server during the refactor. Brings back prompt preprocessing, reward and advantage computation and entirely swaps out the asynchronous OAI client for the sync LLM class. Tried my best to reuse the components from old main.

Note, because the LLM class does not support DP out of the box and TP is not sensible for small models, we can currently on run inference on a single GPU here.

**Reverse Text**

```bash
uv run trainer @ configs/reverse_text/train.toml --log.level debug
```

```bash
CUDA_VISIBLE_DEVICES=1 uv run orchestrator @ configs/reverse_text/orch.toml
```

**Intellect Math**

```bash
CUDA_VISIBLE_DEVICES=0 uv run trainer \
   @ configs/intellect_math/1b/train.toml \
   --log.level debug \
   --model.ac \
   --ckpt None \
   --monitor.wandb.project stability \
   --monitor.wandb.name intellect-math-1b-v0-llm-detailed-logs-trainer
```

```bash
CUDA_VISIBLE_DEVICES=1 uv run orchestrator \
   @ configs/intellect_math/1b/orch.toml \
   --log.level debug \
   --eval None \
   --monitor.wandb.project stability \
   --monitor.wandb.name intellect-math-1b-v0-llm-detailed-logs-orchestrator
```