### PR TITLE
Fix loss scale bias for packing collate mode

### DIFF
--- a/src/prime_rl/orchestrator/batch.py
+++ b/src/prime_rl/orchestrator/batch.py
@@ -204,9 +204,10 @@ def prepare_batch_packing(
 
     # because of fsdp we need to make sure that each data ran has the same number of micro batches otherwise training will hang.
     # We create fake micro batches to fill the gap with real data but zero advantages, they would not contribute to the loss.
-    if num_padding_batch > 0:
+    if num_train_workers > 1 and num_padding_batch > 0:
         padded_batch = copy.deepcopy(micro_batches[0])
         padded_batch["advantages"] = torch.zeros_like(padded_batch["advantages"])
+        padded_batch["loss_mask"] = torch.zeros_like(padded_batch["loss_mask"])
         micro_batches.extend([padded_batch for _ in range(num_padding_batch)])
 
     assert len(micro_batches) % num_train_workers == 0, (


### PR DESCRIPTION
This PR fixes an issue where the packing collate mode on the orchestratror leads to bias in the loss scale because do not zero out the loss mask, which we use to compute the number of unmasked tokens. We now zero-out the loss mask and also only do padding when there are at least two trainers.

<img width="524" height="475" alt="Screenshot 2025-08-06 at 2 22 05 PM" src="https://github.com/user-attachments/assets/eac0305d-bcdb-4917-a662-b616833c18a2" />
<img width="248" height="244" alt="Screenshot 2025-08-06 at 2 22 13 PM" src="https://github.com/user-attachments/assets/e549078d-a60f-4616-9eab-41b3ed7fd10d" />
