### PR TITLE
Log ratio of truncated completions

### DIFF
--- a/src/prime_rl/orchestrator/buffer.py
+++ b/src/prime_rl/orchestrator/buffer.py
@@ -22,6 +22,7 @@ class Rollout:
     completion_tokens: list[int]
     completion_mask: list[int]
     completion_logprobs: list[float]
+    is_truncated: bool
     reward: float
     advantage: float
 
@@ -33,6 +34,7 @@ def make_rollouts(
     completion_tokens: list[list[int]],
     completion_masks: list[list[int]],
     completion_logprobs: list[list[float]],
+    is_truncated: list[bool],
     rewards: list[float],
     advantages: list[float],
 ) -> list[Rollout]:
@@ -43,10 +45,11 @@ def make_rollouts(
         == len(completion_tokens)
         == len(completion_masks)
         == len(completion_logprobs)
+        == len(is_truncated)
         == len(rewards)
         == len(advantages)
     ), (
-        f"The number of problem_ids, prompt_tokens, prompt_masks, completion_tokens, completion_masks, completion_logprobs, rewards, and advantages must be equal, but got ({len(problem_ids)=}, {len(prompt_tokens)=}, {len(prompt_masks)=}, {len(completion_tokens)=}, {len(completion_masks)=}, {len(completion_logprobs)=}, {len(rewards)=}, {len(advantages)=})"
+        f"The number of problem_ids, prompt_tokens, prompt_masks, completion_tokens, completion_masks, completion_logprobs, is_truncated, rewards, and advantages must be equal, but got ({len(problem_ids)=}, {len(prompt_tokens)=}, {len(prompt_masks)=}, {len(completion_tokens)=}, {len(completion_masks)=}, {len(completion_logprobs)=}, {len(is_truncated)=}, {len(rewards)=}, {len(advantages)=})"
     )
     return [
         Rollout(
@@ -56,16 +59,18 @@ def make_rollouts(
             completion_tokens=completion_tokens,
             completion_mask=completion_mask,
             completion_logprobs=completion_logprobs,
+            is_truncated=is_truncated,
             reward=reward,
             advantage=advantage,
         )
-        for problem_id, prompt_tokens, prompt_mask, completion_tokens, completion_mask, completion_logprobs, reward, advantage in zip(
+        for problem_id, prompt_tokens, prompt_mask, completion_tokens, completion_mask, completion_logprobs, is_truncated, reward, advantage in zip(
             problem_ids,
             prompt_tokens,
             prompt_masks,
             completion_tokens,
             completion_masks,
             completion_logprobs,
+            is_truncated,
             rewards,
             advantages,
         )

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -311,7 +311,7 @@ class OrchestratorConfig(BaseSettings):
         Field(
             description="Whether to override reward scores with 0 for truncated completions.",
         ),
-    ] = True
+    ] = False
 
     # TODO(Mika): This should be automatic from the number of ZMQ connections
     num_train_workers: Annotated[

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -392,9 +392,9 @@ async def orchestrate(config: OrchestratorConfig):
         monitor.log(completion_len_metrics)
 
         truncated_metrics = {
-            "truncated/mean": is_truncated.mean(-1).mean().item(),
-            "truncated/max": is_truncated.mean(-1).max().item(),
-            "truncated/min": is_truncated.mean(-1).min().item(),
+            "is_truncated/mean": is_truncated.mean(-1).mean().item(),
+            "is_truncated/max": is_truncated.mean(-1).max().item(),
+            "is_truncated/min": is_truncated.mean(-1).min().item(),
             "step": progress.step,
         }
         monitor.log(truncated_metrics)

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -94,9 +94,6 @@ async def orchestrate(config: OrchestratorConfig):
     logger.info(f"Setting up buffer ({config.buffer})")
     buffer = setup_buffer(dataset, config.buffer)
 
-    # Load tokenizer -- placeholder until reworking verifiers to use vLLM tokenizer
-    tokenizer = AutoTokenizer.from_pretrained(config.model.name)
-
     # Iterate over dataset in batches
     max_steps = config.max_steps or int(1e9)
     logger.info(f"Starting orchestrator loop ({max_steps=}")

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -315,14 +315,14 @@ async def orchestrate(config: OrchestratorConfig):
             monitor.wandb.log_samples(
                 input_tokens=prompt_tokens,
                 output_tokens=completion_tokens,
-                rewards=rewards,
-                advantages=advantages,
+                rewards=rewards.flatten().tolist(),
+                advantages=advantages.flatten().tolist(),
                 rollouts_per_problem=config.rollouts_per_prompt,
                 step=progress.step,
             )
             monitor.wandb.log_distributions(
-                rewards.flatten().tolist(),
-                advantages.flatten().tolist(),
+                rewards=rewards.flatten().tolist(),
+                advantages=advantages.flatten().tolist(),
                 rollouts_per_problem=config.rollouts_per_prompt,
                 step=progress.step,
             )

--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -92,10 +92,18 @@ def parse_completions(chat_completions: list[ChatCompletion]) -> list[str]:
 
 
 def parse_truncated_completions(states: list[State]) -> list[bool]:
-    print(states[0])
     is_truncated = []
     for state in states:
-        is_truncated.append(True)
+        assert "responses" in state, "Responses should be present in the state"
+        assert all(isinstance(r, ChatCompletion) for r in state["responses"]), (
+            "Responses should be ChatCompletion objects"
+        )
+        for chat_completion in state["responses"]:
+            assert len(chat_completion.choices) == 1, "Response should always have one choice"
+            if chat_completion.choices[0].finish_reason == "length":
+                is_truncated.append(True)
+            else:
+                is_truncated.append(False)
     return is_truncated
 
 

--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -5,6 +5,7 @@ import pandas as pd
 from openai.types.chat import ChatCompletion
 from rich.console import Console
 from rich.table import Table
+from verifiers.types import State
 
 from prime_rl.orchestrator.client import tokenize
 from prime_rl.orchestrator.genesys import TaskType, get_reward_function
@@ -88,6 +89,14 @@ def parse_completions(chat_completions: list[ChatCompletion]) -> list[str]:
         assert len(chat_completion.choices) == 1, "Response should always have one choice"
         completions.append(chat_completion.choices[0].message.content)
     return completions
+
+
+def parse_truncated_completions(states: list[State]) -> list[bool]:
+    print(states[0])
+    is_truncated = []
+    for state in states:
+        is_truncated.append(True)
+    return is_truncated
 
 
 def wait_for_weight_checkpoint(path: Path, step: int, interval: int = 1, log_interval: int = 10) -> None:

--- a/tests/unit/orchestrator/test_buffer.py
+++ b/tests/unit/orchestrator/test_buffer.py
@@ -53,6 +53,7 @@ def make_rollouts():
                     completion_tokens=[1],
                     completion_mask=[1],
                     completion_logprobs=[0.0],
+                    is_truncated=False,
                     reward=reward,
                     advantage=advantage,
                 )


### PR DESCRIPTION
This PR adds logging the **min/max/mean of the ratio of truncated completions within a group** by adding a utility function `parse_truncated_completions` that parses the state containing vLLM respones from verifiers for whether the stop reason of the response is `length`. 

Also does some minor convenience refactors for storing rewards, advantages, seq len and is_truncated as tensors of shape `(problems_per_batch, rollouts_per_prompt)` which makes reductions across the group dimension super easy and standardized for all types of logged metrics.

See this [W&B view](https://wandb.ai/primeintellect/mika-testing/workspace?nw=lsbqrzw01b) with example run

<img width="926" height="304" alt="Screenshot 2025-08-06 at 5 44 02 PM" src="https://github.com/user-attachments/assets/12360769-83de-4d12-8e5d-0ceb6496d142" />


