### PR TITLE
Log tensor stats into two sections

### DIFF
--- a/src/prime_rl/trainer/train.py
+++ b/src/prime_rl/trainer/train.py
@@ -364,7 +364,7 @@ def train(config: TrainerConfig):
         monitor.log(optim_metrics)
 
         # Log tensor stats
-        for key in tensor_stats.keys():
+        for key in list(tensor_stats.keys()):
             value = tensor_stats.pop(key)
             if "mean" in key:
                 tensor_stats[f"tensor/{key.replace('/mean', '')}"] = value

--- a/src/prime_rl/trainer/train.py
+++ b/src/prime_rl/trainer/train.py
@@ -364,6 +364,12 @@ def train(config: TrainerConfig):
         monitor.log(optim_metrics)
 
         # Log tensor stats
+        for key in tensor_stats.keys():
+            value = tensor_stats.pop(key)
+            if "mean" in key:
+                tensor_stats[f"tensor/{key.replace('/mean', '')}"] = value
+            else:
+                tensor_stats[f"tensor_details/{key}"] = value
         tensor_stats["step"] = progress.step
         monitor.log(tensor_stats)
 


### PR DESCRIPTION
On top of #680, but logs all mean stats into section `tensor/...` and all others into `tensor_details/...`