### PR TITLE
Log tensor distributions on trainer

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -310,26 +310,6 @@ async def orchestrate(config: OrchestratorConfig):
         solve_none = rewards.sum(-1).eq(0).float().mean().item()
         effective_batch_size = 1 - solve_none - solve_all
 
-        # Log samples to W&B table if enabled
-        if monitor.wandb:
-            monitor.wandb.log_samples(
-                input_tokens=prompt_tokens,
-                output_tokens=completion_tokens,
-                rewards=rewards.flatten().tolist(),
-                advantages=advantages.flatten().tolist(),
-                rollouts_per_problem=config.rollouts_per_prompt,
-                step=progress.step,
-            )
-            monitor.wandb.log_distributions(
-                distributions={
-                    "rewards": rewards.flatten().tolist(),
-                    "advantages": advantages.flatten().tolist(),
-                    "problem_rewards": rewards.mean(-1).tolist(),
-                    "problem_advantages": advantages.mean(-1).tolist(),
-                },
-                step=progress.step,
-            )
-
         # Write serialized batch to disk for trainer workers to consume
         all_data_ranks_batches = prepare_batch(
             rollouts=rollouts,
@@ -439,6 +419,26 @@ async def orchestrate(config: OrchestratorConfig):
             "step": progress.step,
         }
         monitor.log(time_metrics)
+
+        # Log samples and distributions to W&B table if enabled
+        if monitor.wandb:
+            monitor.wandb.log_samples(
+                input_tokens=prompt_tokens,
+                output_tokens=completion_tokens,
+                rewards=rewards.flatten().tolist(),
+                advantages=advantages.flatten().tolist(),
+                rollouts_per_problem=config.rollouts_per_prompt,
+                step=progress.step,
+            )
+            monitor.wandb.log_distributions(
+                distributions={
+                    "rewards": rewards.flatten().tolist(),
+                    "advantages": advantages.flatten().tolist(),
+                    "problem_rewards": rewards.mean(-1).tolist(),
+                    "problem_advantages": advantages.mean(-1).tolist(),
+                },
+                step=progress.step,
+            )
 
         # Increment progress
         progress.step += 1

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -321,9 +321,12 @@ async def orchestrate(config: OrchestratorConfig):
                 step=progress.step,
             )
             monitor.wandb.log_distributions(
-                rewards=rewards.flatten().tolist(),
-                advantages=advantages.flatten().tolist(),
-                rollouts_per_problem=config.rollouts_per_prompt,
+                distributions={
+                    "rewards": rewards.flatten().tolist(),
+                    "advantages": advantages.flatten().tolist(),
+                    "problem_rewards": rewards.mean(-1).tolist(),
+                    "problem_advantages": advantages.mean(-1).tolist(),
+                },
                 step=progress.step,
             )
 

--- a/src/prime_rl/trainer/train.py
+++ b/src/prime_rl/trainer/train.py
@@ -380,6 +380,15 @@ def train(config: TrainerConfig):
         }
         monitor.log(time_metrics)
 
+        # Log distributions to W&B table if enabled
+        if monitor.wandb:
+            assert all(len(tensors) == 1 for tensors in tensors.values()), "Tensors must be lists of length 1"
+            distributions = {key: tensors[key][0] for key in tensors.keys()}
+            monitor.wandb.log_distributions(
+                distributions=distributions,
+                step=progress.step,
+            )
+
         progress.step += 1
         is_first_step = False
 

--- a/src/prime_rl/trainer/train.py
+++ b/src/prime_rl/trainer/train.py
@@ -392,6 +392,11 @@ def train(config: TrainerConfig):
         progress.step += 1
         is_first_step = False
 
+    # Log final (immutable) distributions to W&B table
+    if monitor.wandb:
+        logger.info("Logging final distributions as W&B table")
+        monitor.wandb.log_final_distributions()
+
     # Write final checkpoint
     if config.ckpt:
         logger.info("Writing final checkpoint")

--- a/src/prime_rl/utils/monitor.py
+++ b/src/prime_rl/utils/monitor.py
@@ -174,17 +174,8 @@ class WandbMonitor(Monitor):
 
             if config.log_extras.distributions:
                 self.last_log_distributions_step = -1
-                self.distributions_cols = [
-                    "step",
-                    "rewards",
-                    "advantages",
-                    "problem_rewards",
-                    "problem_advantages",
-                ]
-                self.distributions_table = wandb.Table(
-                    columns=self.distributions_cols,
-                    log_mode="INCREMENTAL",
-                )
+                # Incremental table is initialized dynamically in `log_distributions`
+                self.distributions_table = None
                 self.distributions = []
 
     def _maybe_overwrite_wandb_command(self) -> None:
@@ -278,9 +269,7 @@ class WandbMonitor(Monitor):
         self.last_log_samples_step = step
         self.logger.debug(f"Logged samples at step {step} to W&B table in {time.time() - start_time:.2f}s")
 
-    def log_distributions(
-        self, rewards: list[float], advantages: list[float], rollouts_per_problem: int, step: int
-    ) -> None:
+    def log_distributions(self, distributions: dict[str, list[float]], step: int) -> None:
         if (
             not self.config.log_extras
             or not self.config.log_extras.distributions
@@ -290,32 +279,22 @@ class WandbMonitor(Monitor):
         assert self.last_log_distributions_step <= step, "Step must be greater than last logged step"
         self.logger.debug(f"Logging distributions to W&B table at step {step}")
 
-        # Group by problem
-        problem_rewards = defaultdict(list)
-        problem_advantages = defaultdict(list)
-        for i, (reward, advantage) in enumerate(zip(rewards, advantages)):
-            problem_id = i // rollouts_per_problem
-            problem_rewards[problem_id].append(reward)
-            problem_advantages[problem_id].append(advantage)
-
-        # Compute mean per-problem
-        problem_mean_rewards = [sum(rewards) / len(rewards) for rewards in problem_rewards.values()]
-        problem_mean_advantages = [sum(advantages) / len(advantages) for advantages in problem_advantages.values()]
+        # Initialize incremental table if not already done
+        if self.distributions_table is None:
+            self.distributions_cols = list(distributions.keys())
+            self.distributions_table = wandb.Table(
+                columns=self.distributions_cols,
+                log_mode="INCREMENTAL",
+            )
+        assert self.distributions_cols == list(distributions.keys()), (
+            "Columns in the table must be the same across all steps"
+        )
 
         # Append to distributions
         start_time = time.time()
-        distribution = {
-            "step": step,
-            "rewards": rewards,
-            "advantages": advantages,
-            "problem_rewards": problem_mean_rewards,
-            "problem_advantages": problem_mean_advantages,
-        }
-        assert list(distribution.keys()) == self.distributions_cols, (
-            "Order of columns in the table must be the same as order of the keys here"
-        )
-        self.distributions.append(distribution)
-        self.distributions_table.add_data(*distribution.values())
+        distributions = {"step": step, **distributions}
+        self.distributions.append(distributions)
+        self.distributions_table.add_data(*distributions.values())
         wandb.log({"distributions": self.distributions_table}, step=step)
         self.last_log_distributions_step = step
         self.logger.debug(f"Logged distributions at step {step} to W&B table in {time.time() - start_time:.2f}s")

--- a/src/prime_rl/utils/monitor.py
+++ b/src/prime_rl/utils/monitor.py
@@ -276,13 +276,13 @@ class WandbMonitor(Monitor):
         ):
             return
         assert self.last_log_distributions_step <= step, "Step must be greater than last logged step"
-        self.logger.debug(f"Logging distributions to W&B table at step {step}")
+        self.logger.debug(f"Logging distributions for keys {list(distributions.keys())} to W&B table at step {step}")
 
         # Initialize incremental table if not already done
         if self.distributions_table is None:
             self.distributions_cols = list(distributions.keys())
             self.distributions_table = wandb.Table(
-                columns=self.distributions_cols,
+                columns=["step"] + self.distributions_cols,
                 log_mode="INCREMENTAL",
             )
         assert self.distributions_cols == list(distributions.keys()), (

--- a/src/prime_rl/utils/monitor.py
+++ b/src/prime_rl/utils/monitor.py
@@ -217,7 +217,7 @@ class WandbMonitor(Monitor):
         assert self.tokenizer is not None, "Tokenizer is required for sample logging"
         assert self.last_log_samples_step <= step, "Step must be greater than last logged step"
 
-        self.logger.debug(f"Logging samples to W&B table at step {step}")
+        self.logger.info(f"Logging samples to W&B table at step {step}")
         start_time = time.time()
         batch_size = len(input_tokens)
         num_problems = batch_size // rollouts_per_problem
@@ -276,7 +276,7 @@ class WandbMonitor(Monitor):
         ):
             return
         assert self.last_log_distributions_step <= step, "Step must be greater than last logged step"
-        self.logger.debug(f"Logging distributions for keys {list(distributions.keys())} to W&B table at step {step}")
+        self.logger.info(f"Logging distributions for keys {list(distributions.keys())} to W&B table at step {step}")
 
         # Initialize incremental table if not already done
         if self.distributions_table is None:

--- a/src/prime_rl/utils/monitor.py
+++ b/src/prime_rl/utils/monitor.py
@@ -149,7 +149,6 @@ class WandbMonitor(Monitor):
         # Optionally, initialize sample logging attributes
         if config.log_extras:
             if config.log_extras.samples:
-                assert tokenizer is not None, "Tokenizer is required for sample logging"
                 self.last_log_samples_step = -1
                 self.samples_cols = [
                     "step",


### PR DESCRIPTION
This PR adds support to log all tensor distributions using the shared `monitor.log_distributions()` utility that is also used on the orchestrator to log samples and reward/ advantage distributions. We log all tensors accumulated in the `Tensors` class at specified steps `--trainer.monitor.wandb.log-extras.interval`. By default, this feature is disabled.

<img width="1293" height="532" alt="Screenshot 2025-08-07 at 3 12 47 PM" src="https://github.com/user-attachments/assets/bee9527f-a90d-4ca6-ad82-492637a480fe" />

[W&B View](https://wandb.ai/primeintellect/mika-testing?nw=x1shqw8jrb) with example run. It is recommended to view the tables from the run view (not the workspace view) because the table is larger and more legible, and also wandb mixes tables across runs which is quite buggy..