### PR TITLE
Log extras by default if W&B enabled

### DIFF
--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -282,3 +282,9 @@ class TrainerConfig(BaseSettings):
                 )
 
         return self
+
+    @model_validator(mode="after")
+    def disable_logging_wandb_samples(self):
+        if self.monitor.wandb and self.monitor.wandb.log_extras:
+            self.monitor.wandb.log_extras.samples = False
+        return self

--- a/src/prime_rl/utils/config.py
+++ b/src/prime_rl/utils/config.py
@@ -61,7 +61,7 @@ class LogExtrasConfig(BaseConfig):
     distributions: Annotated[
         bool,
         Field(
-            description="Whether to log distributions, like rewards, advantages, etc. to W&B tables.",
+            description="Whether to log distributions (like rewards, advantages, etc.) to W&B tables.",
         ),
     ] = True
 
@@ -107,7 +107,7 @@ class WandbMonitorConfig(BaseConfig):
         Field(
             description="Configuration for logging extras to W&B tables. If None, no extras are logged.",
         ),
-    ] = None
+    ] = LogExtrasConfig()
 
 
 class MultiMonitorConfig(BaseConfig):


### PR DESCRIPTION
Changes the default config to log extras like samples and distributions to W&B, if W&B is enabled. Will programmatically disable sample logging from trainer, as this is not supported.