### PR TITLE
Fix temperature scaling of vLLM logprobs

### DIFF
--- a/src/prime_rl/inference/config.py
+++ b/src/prime_rl/inference/config.py
@@ -107,4 +107,7 @@ class InferenceConfig(BaseSettings):
             value = rgetattr(self, key.replace("-", "_"))
             rsetattr(namespace, to_vllm.get(key, key), value)
 
+        # Set `logprobs_mode` to `processed_logprobs` by default
+        rsetattr(namespace, "logprobs_mode", "processed_logprobs")
+
         return namespace

--- a/src/prime_rl/inference/vllm/sampler.py
+++ b/src/prime_rl/inference/vllm/sampler.py
@@ -1,0 +1,242 @@
+"""
+This file is almost a 1-1 copy of vllm/v1/sample/sampler.py from v0.10.0, with
+the one difference that the temperature scaling is done before exporting the
+`processed_logprobs`. We need this to support RL runs with temperature scaling.
+"""
+
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""A layer that samples the next tokens from the model's outputs."""
+
+import torch
+import torch.nn as nn
+from vllm.config import LogprobsMode
+from vllm.utils import is_pin_memory_available
+from vllm.v1.outputs import LogprobsTensors, SamplerOutput
+from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.sample.ops.bad_words import apply_bad_words
+from vllm.v1.sample.ops.logprobs import batched_count_greater_than
+from vllm.v1.sample.ops.penalties import apply_all_penalties
+from vllm.v1.sample.ops.topk_topp_sampler import TopKTopPSampler
+
+_SAMPLING_EPS = 1e-5
+
+
+class Sampler(nn.Module):
+    def __init__(self, logprobs_mode: LogprobsMode = "raw_logprobs"):
+        super().__init__()
+        self.topk_topp_sampler = TopKTopPSampler()
+        self.pin_memory = is_pin_memory_available()
+        self.logprobs_mode = logprobs_mode
+
+    def forward(
+        self,
+        logits: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+    ) -> SamplerOutput:
+        # NOTE(woosuk): Use the original logits (before any penalties or
+        # temperature scaling) for the top-k logprobs.
+        # This is different from the V0 sampler, which uses the logits that
+        # is used for sampling (after penalties and temperature scaling).
+        # TODO(rob): provide option for logprobs post sampling.
+        # See https://vllm-dev.slack.com/archives/C07UUL8E61Z/p1735907856007919 # noqa: E501
+        num_logprobs = sampling_metadata.max_num_logprobs
+        if num_logprobs is not None:
+            if self.logprobs_mode == "raw_logprobs":
+                raw_logprobs = self.compute_logprobs(logits)
+            elif self.logprobs_mode == "raw_logits":
+                raw_logprobs = logits.clone()
+
+        # Use float32 for the logits.
+        logits = logits.to(torch.float32)
+        # Apply allowed token ids.
+        logits = self.apply_allowed_token_ids(logits, sampling_metadata)
+        # Apply bad words exclusion.
+        logits = self.apply_bad_words(logits, sampling_metadata)
+
+        # Apply logits processors which can impact greedy sampling
+        for processor in sampling_metadata.logitsprocs.non_argmax_invariant:
+            logits = processor.apply(logits)
+
+        # Apply penalties (e.g., min_tokens, freq_penalties).
+        logits = self.apply_penalties(logits, sampling_metadata)
+
+        # Apply temperature.
+        # Note(Mika): Moved out of `sample` method to export temperature-scaled logits and logprobs.
+        logits = self.apply_temperature(logits, sampling_metadata.temperature)
+
+        # Get the process logprobs or logits.
+        if num_logprobs is not None:
+            if self.logprobs_mode == "processed_logprobs":
+                raw_logprobs = self.compute_logprobs(logits)
+            elif self.logprobs_mode == "processed_logits":
+                raw_logprobs = logits.clone()
+
+        # Sample the next token.
+        sampled = self.sample(logits, sampling_metadata)
+        # Convert sampled token ids to int64 (long) type to ensure compatibility
+        # with subsequent operations that may use these values as indices.
+        # This conversion is necessary because FlashInfer sampling operations
+        # return int32 (while PyTorch argmax and topk return int64).
+        sampled = sampled.long()
+
+        # Gather the logprobs of the topk and sampled token (if requested).
+        # Get logprobs and rank tensors (if requested)
+        logprobs_tensors = (
+            None if num_logprobs is None else self.gather_logprobs(raw_logprobs, num_logprobs, token_ids=sampled)
+        )
+
+        # Use int32 to reduce the tensor size.
+        sampled = sampled.to(torch.int32)
+
+        # These are GPU tensors.
+        sampler_output = SamplerOutput(
+            # The sampled tokens are expanded to 2D tensor with shape
+            # [num_requests, 1], where each row represents one generated
+            # token per request.
+            sampled_token_ids=sampled.unsqueeze(-1),
+            logprobs_tensors=logprobs_tensors,
+        )
+        return sampler_output
+
+    def apply_temperature(
+        self,
+        logits: torch.Tensor,
+        temp: torch.Tensor,
+    ) -> torch.Tensor:
+        # Use in-place division to avoid creating a new tensor.
+        return logits.div_(temp.unsqueeze(dim=1))
+
+    def greedy_sample(self, logits: torch.Tensor) -> torch.Tensor:
+        return logits.argmax(dim=-1).view(-1)
+
+    def sample(
+        self,
+        logits: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+    ) -> torch.Tensor:
+        """Sample logits based on sampling metadata.
+
+        The various logits processing functions called in this method
+        may update the logits tensor in-place.
+        """
+
+        assert not (sampling_metadata.all_greedy and sampling_metadata.all_random)
+        if sampling_metadata.all_random:
+            greedy_sampled = None
+        else:
+            greedy_sampled = self.greedy_sample(logits)
+            if sampling_metadata.all_greedy:
+                return greedy_sampled
+
+        assert sampling_metadata.temperature is not None
+
+        # Apply logits processors that only apply to random sampling
+        # (argmax invariant)
+        for processor in sampling_metadata.logitsprocs.argmax_invariant:
+            logits = processor.apply(logits)
+
+        # Apply top_k and/or top_p.
+        random_sampled = self.topk_topp_sampler(
+            logits,
+            sampling_metadata.generators,
+            sampling_metadata.top_k,
+            sampling_metadata.top_p,
+        )
+
+        if greedy_sampled is None:
+            return random_sampled
+
+        sampled = torch.where(
+            sampling_metadata.temperature < _SAMPLING_EPS,
+            greedy_sampled,
+            random_sampled,
+            out=greedy_sampled,  # Reuse tensor
+        )
+        return sampled
+
+    def compute_logprobs(self, logits: torch.Tensor) -> torch.Tensor:
+        return logits.log_softmax(dim=-1, dtype=torch.float32)
+
+    def gather_logprobs(
+        self,
+        logprobs: torch.Tensor,
+        num_logprobs: int,
+        token_ids: torch.Tensor,
+    ) -> LogprobsTensors:
+        """
+        Gather logprobs for topk and sampled/prompt token.
+
+        Args:
+          logprobs: (num tokens) x (vocab) tensor
+          num_logprobs: minimum number of logprobs to
+                        retain per token
+          token_ids: prompt tokens (if prompt logprobs)
+                     or sampled tokens (if sampled
+                     logprobs); 1D token ID tensor
+                     with (num tokens) elements
+                     Must be int64.
+
+        Returns:
+          Top-k int indices tensor, (num tokens) x (num_logprobs + 1)
+          Top-k float logprobs tensor, (num tokens) x (num_logprobs + 1)
+          Sampled token rank tensor, (num tokens)
+        """
+        assert token_ids.dtype == torch.int64
+        # Find the topK values.
+        topk_logprobs, topk_indices = torch.topk(logprobs, num_logprobs, dim=-1)
+
+        # Get with the logprob of the prompt or sampled token.
+        token_ids = token_ids.unsqueeze(-1)
+        token_logprobs = logprobs.gather(-1, token_ids)
+
+        # Compute the ranks of the actual token.
+        token_ranks = batched_count_greater_than(logprobs, token_logprobs)
+
+        # Concatenate together with the topk.
+        indices = torch.cat((token_ids, topk_indices), dim=1)
+        logprobs = torch.cat((token_logprobs, topk_logprobs), dim=1)
+
+        # Use int32 to reduce the tensor size.
+        indices = indices.to(torch.int32)
+
+        return LogprobsTensors(indices, logprobs, token_ranks)
+
+    def apply_penalties(
+        self,
+        logits: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+    ) -> torch.Tensor:
+        if not sampling_metadata.no_penalties:
+            assert sampling_metadata.prompt_token_ids is not None
+            logits = apply_all_penalties(
+                logits,
+                sampling_metadata.prompt_token_ids,
+                sampling_metadata.presence_penalties,
+                sampling_metadata.frequency_penalties,
+                sampling_metadata.repetition_penalties,
+                sampling_metadata.output_token_ids,
+            )
+        return logits
+
+    def apply_allowed_token_ids(
+        self,
+        logits: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+    ) -> torch.Tensor:
+        if sampling_metadata.allowed_token_ids_mask is not None:
+            logits.masked_fill_(sampling_metadata.allowed_token_ids_mask, float("-inf"))
+        return logits
+
+    def apply_bad_words(
+        self,
+        logits: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+    ) -> torch.Tensor:
+        if sampling_metadata.bad_words_token_ids:
+            apply_bad_words(
+                logits,
+                sampling_metadata.bad_words_token_ids,
+                sampling_metadata.output_token_ids,
+            )
+        return logits

--- a/src/prime_rl/inference/vllm/sampler.py
+++ b/src/prime_rl/inference/vllm/sampler.py
@@ -62,7 +62,7 @@ class Sampler(nn.Module):
         logits = self.apply_penalties(logits, sampling_metadata)
 
         # Apply temperature.
-        # Note(Mika): Moved out of `sample` method to export temperature-scaled logits and logprobs.
+        # NOTE(Mika): Moved out of `sample` method to export temperature-scaled logits and logprobs.
         logits = self.apply_temperature(logits, sampling_metadata.temperature)
 
         # Get the process logprobs or logits.

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -3,12 +3,13 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any, Optional
 
-# Overwrite sampler import before any other imports
+# Monkeypatch vLLM Sampler before importing any vLLM modules
 # ruff: noqa: I001
-import vllm
 from prime_rl.inference.vllm.sampler import Sampler as CustomSampler
 
-vllm.v1.sample.Sampler = CustomSampler
+import importlib
+
+setattr(importlib.import_module("vllm.v1.sample.sampler"), "Sampler", CustomSampler)
 
 import uvloop
 import vllm.envs as envs

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -3,6 +3,13 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any, Optional
 
+# Overwrite sampler import before any other imports
+# ruff: noqa: I001
+import vllm
+from prime_rl.inference.vllm.sampler import Sampler as CustomSampler
+
+vllm.v1.sample.Sampler = CustomSampler
+
 import uvloop
 import vllm.envs as envs
 from fastapi import Request

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -117,6 +117,11 @@ def server(config: InferenceConfig, vllm_args: list[str]):
     parser = make_arg_parser(parser)
     args = parser.parse_args(args=vllm_args, namespace=config.to_vllm())
     validate_parsed_serve_args(args)
+
+    # Raise error if logprobs_mode is not set to processed_logprobs
+    if args.logprobs_mode != "processed_logprobs":
+        raise ValueError("logprobs_mode must be 'processed_logprobs' to be compatible with the orchestrator.")
+
     if args.headless or args.api_server_count < 1:
         run_headless(args)
     else:

--- a/src/prime_rl/orchestrator/batch.py
+++ b/src/prime_rl/orchestrator/batch.py
@@ -78,8 +78,6 @@ def prepare_micro_batch(samples: list[MicroBatch], temperature: float):
     for key in ["input_ids", "advantages", "loss_mask", "logprobs", "position_ids"]:
         micro_batch[key] = torch.stack([sample[key] for sample in samples], dim=0)
 
-    # Scale logprobs by temperature
-    micro_batch["logprobs"] /= temperature
     micro_batch["temperature"] = temperature
 
     return micro_batch
@@ -166,8 +164,6 @@ def prepare_micro_batch_packing(samples: list[BatchSample], max_seq_len: int, te
     for key in ["input_ids", "advantages", "loss_mask", "position_ids", "logprobs"]:
         micro_batch[key] = torch.cat([sample[key] for sample in samples], dim=0).unsqueeze(0)
 
-    # Scale logprobs by temperature
-    micro_batch["logprobs"] /= temperature
     micro_batch["temperature"] = temperature
 
     return micro_batch

--- a/src/prime_rl/trainer/train.py
+++ b/src/prime_rl/trainer/train.py
@@ -213,7 +213,6 @@ def train(config: TrainerConfig):
                     shifted_logits = shift_logits(logits)
                     shifted_logits = shifted_logits / temperature
                     recomputed_logprobs = selective_log_softmax(shifted_logits, input_ids)
-                    del logits, shifted_logits
 
                     # Compute the recomputed logprob error
                     recomputed_logprob_error = torch.exp(recomputed_logprobs - logprobs)


### PR DESCRIPTION
> This PR is based on #696 and should not be merged before

This PR fixes a bug in our temperature-scaling of raw vLLM logprobs. Previously we did `logprobs /= temperature` for scaling, which is just plain wrong. Temperature scaling is applied before the softmax, but because we only have access to chosen token logprobs, we cannot reverse this process. Luckily, v0.10.0 allows us to specify processed logprobs via `--logprob-mode processed_logprobs` which we now set as a default, and raise if any other value is set . Funnily, vLLM's definition of "processed" does not include temperature scaling so we also have to monkeypatch the `Sampler` class to apply temperature scaling before (not after) exporting the `processed_logprobs` . With this we get the expected behavior of the importance ratio at lower temperature levels for `hendrycks-math`

<img width="597" height="264" alt="Screenshot 2025-08-08 at 5 39 06 PM" src="https://github.com/user-attachments/assets/e5a2bba4-0f7f-4901-a145-e65ea476fdd0" />

All runs are 10 steps on `hendrycks-math` with 1B model with no recompute, ie. using vLLM logprobs:
- Green: How the importance ratio should look (around 1) at temperature 1.0 (baseline)
- Pink: What we have on current main, completely wrong temperature scaling (we scaled logprobs, not logits oops)
- Blue: After bump to v0.10.0 exproting `processed_logprobs` (new vllm feature), still off because "processed" does not include temperature scaling in vllm's mind (wtf?)
- Orange: After a one-line patch to the sampler we are finally good