### PR TITLE
Implement outputs directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,15 @@
 .vscode/*
 *.ipynb
 *.jsonl
-.pydantic_config/*
 configs/endpoints.py
+
+# Artifacts
 **/weights
 **/checkpoints
 **/rollouts
 **/logs
+**/wandb
+.pydantic_config
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,10 @@
 *.jsonl
 .pydantic_config/*
 configs/endpoints.py
-exp-*
+**/weights
+**/checkpoints
+**/rollouts
+**/logs
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,9 @@
 .vscode/*
-logs/*
-wandb/*
-wandb_logs/*
-datasets/*
-output/*
-outputs/*
-data/*
-rollouts/*
-checkpoints/*
-weights/*
 *.ipynb
 *.jsonl
 .pydantic_config/*
 configs/endpoints.py
+exp-*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ ulimit -n 32000
 bash scripts/tmux.sh
 ```
 
-Then, paste the experiment entrypoints detailed below in the `Trainer` pane to start your run!
+The default session name is `prime-rl` and outputs directory is `outputs`. They are configurable, as described in `bash scripts/tmux.sh -h`.
 
 ## RL
 
@@ -186,7 +186,7 @@ For small models/ quick ablations, it can be more efficient to parallelize exper
 Start the first experiment as normal, but specify a unique experiment identifier (*will use the first 2 GPUs*)
 
 ```bash
-bash scripts/tmux.sh exp-1
+bash scripts/tmux.sh -s exp-1 -o outputs1
 ```
 
 ```bash
@@ -195,13 +195,13 @@ uv run rl \
   --trainer @ configs/reverse_text/train.toml \
   --orchestrator @ configs/reverse_text/orch.toml \
   --inference @ configs/reverse_text/infer.toml \
-  --exp-id exp-1
+  --outputs-dir outputs1
 ```
 
 For the second experiment, configure a new server port for the inference engine and orchestrator and choose a new experiment identifier (*will use the first 2 GPUs*)
 
 ```bash
-bash scripts/tmux.sh exp-2
+bash scripts/tmux.sh -s exp-2 -o outputs2
 ```
 
 ```bash
@@ -212,7 +212,7 @@ CUDA_VISIBLE_DEVICES=2,3 uv run rl \
   --inference @ configs/reverse_text/infer.toml \
   --inference.server.port 8001 \
   --orchestrator.client.port 8001 \
-  --exp-id exp-2
+  --outputs-dir outputs2
 ```
 
 ## Evals
@@ -305,7 +305,7 @@ uv run rl \
 To kill the tmux session when you're done:
 
 ```bash
-bash scripts/tmux.sh kill
+tmux kill-session -t prime-rl
 ```
 
 ### Environments
@@ -412,10 +412,7 @@ checkpoints
     └── trainer.pt
 ```
 
-Checkpointing is configured by the `CheckpointConfig`, with the config key `--ckpt`. One can specify:
-- `--ckpt.path` to change the checkpoint directory (default: `checkpoints`)
-- `--ckpt.interval` to change the interval frequency (default: `50`)
-- `--ckpt.save-async` to save the checkpoint asynchronously (default: `False`)
+Checkpointing is configured by the `CheckpointConfig`, with the config key `--ckpt`. One can specify the interval (`--ckpt.interval`, defaults to `50`) and whether to save checkpoints asynchronoously  (`--ckpt.save-async`, defaults to `False`)
 
 By default, runs do no write checkpoints to save disk space. To checkpoint every 10 steps on our debug RL run, run the following command
 
@@ -447,7 +444,7 @@ uv run orchestrator @ configs/reverse_text/orch.toml \
   --monitor.wandb.id <orchestrator-run-id>
 ```
 
-If you started your run using the rl.py script, you can resume the same run by passing the same W&B run ID for both the trainer and the orchestrator, e.g.
+If you started your run using `rl.py`, you can resume the same run by passing the same W&B run ID for both the trainer and the orchestrator, e.g.
 
 ```bash
 uv run rl \

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ uv run rl \
 
 For small models/ quick ablations, it can be more efficient to parallelize experiments within a node (e.g. split your GPUs to run two experiments in parallel). Because the trainer communicates with the orchestrator via a shared file system, and the orchestrator communicates with the inference engine via an OAI-compatible API, the connection points have to be uniquely set. For example, if you have access to 4 GPUs you can run two 2 GPU training runs in parallel as follows:
 
-Start the first experiment as normal, but specify a unique experiment identifier (*will use the first 2 GPUs*)
+Start the first experiment in a tmux session `exp-1` with outputs directory `outputs`. Specify it both in the tmux script, as well as in the start command (*will use the first 2 GPUs*)
 
 ```bash
 bash scripts/tmux.sh -s exp-1 -o outputs1
@@ -198,7 +198,7 @@ uv run rl \
   --outputs-dir outputs1
 ```
 
-For the second experiment, configure a new server port for the inference engine and orchestrator and choose a new experiment identifier (*will use the first 2 GPUs*)
+For the second experiment, start a second tmux session named `exp-2` with outputs directory `outputs2`. In addition, specify a new server port for the inference engine and orchestrator (*will use the first 2 GPUs*)
 
 ```bash
 bash scripts/tmux.sh -s exp-2 -o outputs2

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -10,6 +10,25 @@ log_info() {
     echo -e "${GREEN}[INFO]${NC} $1"
 }
 
+# Confirm destructive action
+confirm_cleanup() {
+    echo "This will remove the following paths recursively:"
+    echo "  - **/logs"
+    echo "  - **/checkpoints"
+    echo "  - **/weights"
+    echo "  - **/rollouts"
+    echo "  - .pydantic_config"
+    while true; do
+        read -r -p "Proceed? [y/N]: " response
+        case "$response" in
+            [yY]|[yY][eE][sS]) break ;;
+            [nN]|[nN][oO]|"") echo "Aborted."; exit 1 ;;
+            *) echo "Please answer y or n." ;;
+        esac
+    done
+}
+
 # Remove logs, checkpoints, weights, rollouts
-rm -rf logs checkpoints weights rollouts .pydantic_config
+confirm_cleanup
+rm -rf **/logs **/checkpoints **/weights **/rollouts .pydantic_config
 log_info "Cleaned up!"

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -17,6 +17,7 @@ confirm_cleanup() {
     echo "  - **/checkpoints"
     echo "  - **/weights"
     echo "  - **/rollouts"
+    echo "  - **/wandb"
     echo "  - .pydantic_config"
     while true; do
         read -r -p "Proceed? [y/N]: " response
@@ -28,7 +29,7 @@ confirm_cleanup() {
     done
 }
 
-# Remove logs, checkpoints, weights, rollouts
+# Remove logs, checkpoints, weights, rollouts, wandb
 confirm_cleanup
-rm -rf **/logs **/checkpoints **/weights **/rollouts .pydantic_config
+rm -rf **/logs **/checkpoints **/weights **/rollouts **/wandb .pydantic_config
 log_info "Cleaned up!"

--- a/scripts/tmux.sh
+++ b/scripts/tmux.sh
@@ -1,177 +1,108 @@
 #!/bin/bash
 
-# Default session name
-DEFAULT_OUTPUTS_DIR="exp-1"
+SESSION_NAME="prime-rl"
+OUTPUTS_DIR="outputs"
 
-# Parse arguments
-EXPERIMENT_NAME="$DEFAULT_OUTPUTS_DIR"
-KILL_SESSION=false
-
-# Parse command line arguments
+# Optional CLI parsing
+# Supports:
+#   -s|--session-name NAME
+#   -o|--outputs-dir DIR
+#   Positional: [SESSION_NAME [OUTPUTS_DIR]]
+POSITIONAL=()
 while [[ $# -gt 0 ]]; do
-    case $1 in
-        kill)
-            KILL_SESSION=true
-            shift
-            ;;
-        *)
-            # If it's not 'kill', treat it as session name
-            EXPERIMENT_NAME="$1"
-            shift
-            ;;
-    esac
+  case "$1" in
+    -s|--session-name)
+      if [[ -z "$2" ]]; then
+        echo "Error: --session-name requires a value" >&2
+        exit 1
+      fi
+      SESSION_NAME="$2"
+      shift 2
+      ;;
+    -o|--outputs-dir)
+      if [[ -z "$2" ]]; then
+        echo "Error: --outputs-dir requires a value" >&2
+        exit 1
+      fi
+      OUTPUTS_DIR="$2"
+      shift 2
+      ;;
+    -h|--help)
+      echo "Usage: $0 [-s SESSION_NAME] [-o OUTPUTS_DIR] [SESSION_NAME [OUTPUTS_DIR]]"
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      POSITIONAL+=("$1")
+      shift
+      ;;
+  esac
 done
 
-# Handle kill command
-if [ "$KILL_SESSION" = true ]; then
-    if tmux has-session -t "$EXPERIMENT_NAME" 2>/dev/null; then
-        echo "Killing tmux session: $EXPERIMENT_NAME"
-        tmux kill-session -t "$EXPERIMENT_NAME"
-        echo "Session '$EXPERIMENT_NAME' terminated."
-    else
-        echo "Session '$EXPERIMENT_NAME' not found."
-    fi
-    exit 0
+if [[ ${#POSITIONAL[@]} -ge 1 ]]; then
+  SESSION_NAME="${POSITIONAL[0]}"
+fi
+if [[ ${#POSITIONAL[@]} -ge 2 ]]; then
+  OUTPUTS_DIR="${POSITIONAL[1]}"
 fi
 
-# Check if we're already inside a tmux session
-if [ -n "$TMUX" ]; then
-    # We're inside tmux, so switch to the session instead of attaching
-    if tmux has-session -t "$EXPERIMENT_NAME" 2>/dev/null; then
-        echo "Session '$EXPERIMENT_NAME' already exists. Switching..."
-        tmux switch-client -t "$EXPERIMENT_NAME"
-    else
-        echo "Creating new tmux session: $EXPERIMENT_NAME"
-        tmux new-session -d -s "$EXPERIMENT_NAME" -n "RL"
-        
-        # Window 1: RL - Create the layout first
-        # Create 2 more panes for a total of 3
-        tmux split-window -v -t "$EXPERIMENT_NAME:RL.0"
-        tmux split-window -v -t "$EXPERIMENT_NAME:RL.1"
-        
-        # Apply even-vertical layout to distribute panes evenly
-        tmux select-layout -t "$EXPERIMENT_NAME:RL" even-vertical
-        
-        # Set pane titles
-        tmux select-pane -t "$EXPERIMENT_NAME:RL.0" -T "Trainer"
-        tmux select-pane -t "$EXPERIMENT_NAME:RL.1" -T "Orchestrator"
-        tmux select-pane -t "$EXPERIMENT_NAME:RL.2" -T "Inference"
-        
-        # Send commands to panes
-        # Pane 1: Trainer - stays empty
-        
-        # Pane 2: Orchestrator
-  tmux send-keys -t "$EXPERIMENT_NAME:RL.1" 'while true; do
-  echo "Waiting for orchestrator log file..."
-  while [ ! -f '"$EXPERIMENT_NAME"'/logs/orchestrator.log ]; do sleep 1; done
-  echo "Following orchestrator.log..."
-  tail -F '"$EXPERIMENT_NAME"'/logs/orchestrator.log
-done' C-m
-        
-        # Pane 3: Inference
-  tmux send-keys -t "$EXPERIMENT_NAME:RL.2" 'while true; do
-  echo "Waiting for inference log file..."
-  while [ ! -f '"$EXPERIMENT_NAME"'/logs/inference.log ]; do sleep 1; done
-  echo "Following inference.log..."
-  tail -F '"$EXPERIMENT_NAME"'/logs/inference.log
-done' C-m
-        
-        # Create second window
-        tmux new-window -t "$EXPERIMENT_NAME:2" -n "Monitor"
-        
-        # Window 2: Monitor - Create horizontal split
-        tmux split-window -h -t "$EXPERIMENT_NAME:Monitor"
-        tmux select-layout -t "$EXPERIMENT_NAME:Monitor" even-horizontal
-        
-        # Set pane titles and run commands
-        tmux select-pane -t "$EXPERIMENT_NAME:Monitor.0" -T "GPU"
-        tmux send-keys -t "$EXPERIMENT_NAME:Monitor.0" "nvtop" C-m
-        
-        tmux select-pane -t "$EXPERIMENT_NAME:Monitor.1" -T "CPU"
-        tmux send-keys -t "$EXPERIMENT_NAME:Monitor.1" "htop" C-m
-        
-        # Enable pane titles for all windows
-        tmux set-option -t "$EXPERIMENT_NAME" -g pane-border-status top
-        tmux set-option -t "$EXPERIMENT_NAME" -g pane-border-format " #{pane_title} "
-        
-        # Also set for each window explicitly
-        tmux set-window-option -t "$EXPERIMENT_NAME:RL" pane-border-status top
-        tmux set-window-option -t "$EXPERIMENT_NAME:Monitor" pane-border-status
-        
-        # Select first window and first pane
-        tmux select-window -t "$EXPERIMENT_NAME:RL"
-        tmux select-pane -t "$EXPERIMENT_NAME:RL.0"
-        
-        # Switch to the new session
-        tmux switch-client -t "$EXPERIMENT_NAME"
-    fi
+if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+  echo "Attaching to tmux session: $SESSION_NAME"
+  exec tmux attach-session -t "$SESSION_NAME"
 else
-    # Not inside tmux, use attach
-    if tmux has-session -t "$EXPERIMENT_NAME" 2>/dev/null; then
-        echo "Session '$EXPERIMENT_NAME' already exists. Attaching..."
-        tmux attach-session -t "$EXPERIMENT_NAME"
-    else
-        echo "Creating new tmux session: $EXPERIMENT_NAME"
-        
-        # Start new tmux session with first window
-        tmux new-session -d -s "$EXPERIMENT_NAME" -n "RL"
-        
-        # Window 1: RL - Create 2 more panes for a total of 3
-        tmux split-window -v -t "$EXPERIMENT_NAME:RL.0"
-        tmux split-window -v -t "$EXPERIMENT_NAME:RL.1"
-        
-        # Apply even-vertical layout
-        tmux select-layout -t "$EXPERIMENT_NAME:RL" even-vertical
-        
-        # Set pane titles
-        tmux select-pane -t "$EXPERIMENT_NAME:RL.0" -T "Trainer"
-        tmux select-pane -t "$EXPERIMENT_NAME:RL.1" -T "Orchestrator"
-        tmux select-pane -t "$EXPERIMENT_NAME:RL.2" -T "Inference"
-        
-        # Send commands to panes
-        # Pane 2: Orchestrator
-        tmux send-keys -t "$EXPERIMENT_NAME:RL.1" 'while true; do
-  echo "Waiting for orchestrator log file..."
-  while [ ! -f '"$EXPERIMENT_NAME"'/logs/orchestrator.log ]; do sleep 1; done
-  echo "Following orchestrator.log..."
-  tail -F '"$EXPERIMENT_NAME"'/logs/orchestrator.log
+  echo "Creating new tmux session: $SESSION_NAME"
+
+  # Start new tmux session with first window
+  tmux new-session -d -s "$SESSION_NAME" -n "RL"
+
+  # Window 1: RL - 3 vertical panes
+  tmux split-window -v -t "$SESSION_NAME:RL.0"
+  tmux split-window -v -t "$SESSION_NAME:RL.1"
+  tmux select-layout -t "$SESSION_NAME:RL" even-vertical
+
+  # Pane titles
+  tmux select-pane -t "$SESSION_NAME:RL.0" -T "Trainer"
+  tmux select-pane -t "$SESSION_NAME:RL.1" -T "Orchestrator"
+  tmux select-pane -t "$SESSION_NAME:RL.2" -T "Inference"
+
+  # Logs: Orchestrator
+  tmux send-keys -t "$SESSION_NAME:RL.1" 'while true; do
+echo "Waiting for orchestrator log file..."
+while [ ! -f '"$OUTPUTS_DIR"'/logs/orchestrator.log ]; do sleep 1; done
+echo "Following orchestrator.log..."
+tail -F '"$OUTPUTS_DIR"'/logs/orchestrator.log
 done' C-m
-        
-        # Pane 3: Inference
-        tmux send-keys -t "$EXPERIMENT_NAME:RL.2" 'while true; do
-  echo "Waiting for inference log file..."
-  while [ ! -f '"$EXPERIMENT_NAME"'/logs/inference.log ]; do sleep 1; done
-  echo "Following inference.log..."
-  tail -F '"$EXPERIMENT_NAME"'/logs/inference.log
+
+  # Logs: Inference
+  tmux send-keys -t "$SESSION_NAME:RL.2" 'while true; do
+echo "Waiting for inference log file..."
+while [ ! -f '"$OUTPUTS_DIR"'/logs/inference.log ]; do sleep 1; done
+echo "Following inference.log..."
+tail -F '"$OUTPUTS_DIR"'/logs/inference.log
 done' C-m
-        
-        # Create second window
-        tmux new-window -t "$EXPERIMENT_NAME" -n "Monitor"
-        
-        # Window 2: Monitor
-        tmux split-window -h -t "$EXPERIMENT_NAME:Monitor"
-        tmux select-layout -t "$EXPERIMENT_NAME:Monitor" even-horizontal
-        
-        # Set pane titles and run commands
-        tmux select-pane -t "$EXPERIMENT_NAME:Monitor.0" -T "GPU"
-        tmux send-keys -t "$EXPERIMENT_NAME:Monitor.0" "nvtop" C-m
-        
-        tmux select-pane -t "$EXPERIMENT_NAME:Monitor.1" -T "CPU"
-        tmux send-keys -t "$EXPERIMENT_NAME:Monitor.1" "htop" C-m
-        
-        # Enable pane titles for all windows
-        tmux set-option -t "$EXPERIMENT_NAME" -g pane-border-status top
-        tmux set-option -t "$EXPERIMENT_NAME" -g pane-border-format " #{pane_title} "
-        
-        # Also set for each window explicitly
-        tmux set-window-option -t "$EXPERIMENT_NAME:RL" pane-border-status top
-        tmux set-window-option -t "$EXPERIMENT_NAME:Monitor" pane-border-status top
-        
-        # Select first window and first pane
-        tmux select-window -t "$EXPERIMENT_NAME:RL"
-        tmux select-pane -t "$EXPERIMENT_NAME:RL.0"
-        
-        # Attach to the session
-        tmux attach-session -t "$EXPERIMENT_NAME"
-    fi
-fi 
+
+  # Window 2: Monitor
+  tmux new-window -t "$SESSION_NAME" -n "Monitor"
+  tmux split-window -h -t "$SESSION_NAME:Monitor"
+  tmux select-layout -t "$SESSION_NAME:Monitor" even-horizontal
+
+  tmux select-pane -t "$SESSION_NAME:Monitor.0" -T "GPU"
+  tmux send-keys -t "$SESSION_NAME:Monitor.0" "nvtop" C-m
+
+  tmux select-pane -t "$SESSION_NAME:Monitor.1" -T "CPU"
+  tmux send-keys -t "$SESSION_NAME:Monitor.1" "htop" C-m
+
+  # Pane title styling
+  tmux set-option -t "$SESSION_NAME" -g pane-border-status top
+  tmux set-option -t "$SESSION_NAME" -g pane-border-format " #{pane_title} "
+  tmux set-window-option -t "$SESSION_NAME:RL" pane-border-status top
+  tmux set-window-option -t "$SESSION_NAME:Monitor" pane-border-status top
+
+  # Focus trainer pane and attach
+  tmux select-window -t "$SESSION_NAME:RL"
+  tmux select-pane -t "$SESSION_NAME:RL.0"
+  exec tmux attach-session -t "$SESSION_NAME"
+fi

--- a/scripts/tmux.sh
+++ b/scripts/tmux.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # Default session name
-DEFAULT_EXPERIMENT_ID="rl"
+DEFAULT_OUTPUTS_DIR="exp-1"
 
 # Parse arguments
-EXPERIMENT_NAME="$DEFAULT_EXPERIMENT_ID"
+EXPERIMENT_NAME="$DEFAULT_OUTPUTS_DIR"
 KILL_SESSION=false
 
 # Parse command line arguments
@@ -61,19 +61,19 @@ if [ -n "$TMUX" ]; then
         # Pane 1: Trainer - stays empty
         
         # Pane 2: Orchestrator
-        tmux send-keys -t "$EXPERIMENT_NAME:RL.1" 'while true; do
+  tmux send-keys -t "$EXPERIMENT_NAME:RL.1" 'while true; do
   echo "Waiting for orchestrator log file..."
-  while [ ! -f logs/'"$EXPERIMENT_NAME"'/orchestrator.log ]; do sleep 1; done
+  while [ ! -f '"$EXPERIMENT_NAME"'/logs/orchestrator.log ]; do sleep 1; done
   echo "Following orchestrator.log..."
-  tail -F logs/'"$EXPERIMENT_NAME"'/orchestrator.log
+  tail -F '"$EXPERIMENT_NAME"'/logs/orchestrator.log
 done' C-m
         
         # Pane 3: Inference
-        tmux send-keys -t "$EXPERIMENT_NAME:RL.2" 'while true; do
+  tmux send-keys -t "$EXPERIMENT_NAME:RL.2" 'while true; do
   echo "Waiting for inference log file..."
-  while [ ! -f logs/'"$EXPERIMENT_NAME"'/inference.log ]; do sleep 1; done
+  while [ ! -f '"$EXPERIMENT_NAME"'/logs/inference.log ]; do sleep 1; done
   echo "Following inference.log..."
-  tail -F logs/'"$EXPERIMENT_NAME"'/inference.log
+  tail -F '"$EXPERIMENT_NAME"'/logs/inference.log
 done' C-m
         
         # Create second window
@@ -132,17 +132,17 @@ else
         # Pane 2: Orchestrator
         tmux send-keys -t "$EXPERIMENT_NAME:RL.1" 'while true; do
   echo "Waiting for orchestrator log file..."
-  while [ ! -f logs/'"$EXPERIMENT_NAME"'/orchestrator.log ]; do sleep 1; done
+  while [ ! -f '"$EXPERIMENT_NAME"'/logs/orchestrator.log ]; do sleep 1; done
   echo "Following orchestrator.log..."
-  tail -F logs/'"$EXPERIMENT_NAME"'/orchestrator.log
+  tail -F '"$EXPERIMENT_NAME"'/logs/orchestrator.log
 done' C-m
         
         # Pane 3: Inference
         tmux send-keys -t "$EXPERIMENT_NAME:RL.2" 'while true; do
   echo "Waiting for inference log file..."
-  while [ ! -f logs/'"$EXPERIMENT_NAME"'/inference.log ]; do sleep 1; done
+  while [ ! -f '"$EXPERIMENT_NAME"'/logs/inference.log ]; do sleep 1; done
   echo "Following inference.log..."
-  tail -F logs/'"$EXPERIMENT_NAME"'/inference.log
+  tail -F '"$EXPERIMENT_NAME"'/logs/inference.log
 done' C-m
         
         # Create second window

--- a/src/prime_rl/orchestrator/ckpt.py
+++ b/src/prime_rl/orchestrator/ckpt.py
@@ -6,6 +6,7 @@ import torch
 
 from prime_rl.orchestrator.config import CheckpointConfig
 from prime_rl.utils.logger import get_logger
+from prime_rl.utils.utils import get_ckpt_dir
 
 
 @dataclass
@@ -19,12 +20,12 @@ class Progress:
 class CheckpointManager:
     """Utility class to save and load orchestrator checkpoints to resume orchestrator."""
 
-    def __init__(self, output_dir: Path, config: CheckpointConfig):
-        self.path = output_dir / "checkpoints"
+    def __init__(self, outputs_dir: Path, config: CheckpointConfig):
+        self.ckpt_dir = get_ckpt_dir(outputs_dir)
         self._logger = get_logger()
 
     def _get_step_path(self, step: int) -> Path:
-        return self.path / f"step_{step}"
+        return self.ckpt_dir / f"step_{step}"
 
     def _get_ckpt_path(self, step: int) -> Path:
         return self._get_step_path(step) / "orchestrator.pt"

--- a/src/prime_rl/orchestrator/ckpt.py
+++ b/src/prime_rl/orchestrator/ckpt.py
@@ -19,8 +19,8 @@ class Progress:
 class CheckpointManager:
     """Utility class to save and load orchestrator checkpoints to resume orchestrator."""
 
-    def __init__(self, config: CheckpointConfig):
-        self.path = config.path
+    def __init__(self, output_dir: Path, config: CheckpointConfig):
+        self.path = output_dir / "checkpoints"
         self._logger = get_logger()
 
     def _get_step_path(self, step: int) -> Path:

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Annotated, Literal, TypeAlias
 
 from pydantic import BaseModel, Field, model_validator
@@ -241,6 +242,13 @@ class OrchestratorConfig(BaseSettings):
 
     # The checkpoint configuration
     ckpt: CheckpointConfig | None = None
+
+    outputs_dir: Annotated[
+        Path,
+        Field(
+            description="Directory to write outputs to. Will be populated with checkpoints, weights, rollouts and logs as subdirectories. Should be set to a persistent directory with enough disk space. This value should be distinct across experiments running on a single node. See the README for more details."
+        ),
+    ] = Path("outputs")
 
     collate_mode: Annotated[Literal["packing", "padding"], Field(description="Collate mode to use.")] = "packing"
 

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import Annotated, Literal, TypeAlias
 
 from pydantic import BaseModel, Field, model_validator
@@ -75,19 +74,6 @@ class EnvironmentConfig(BaseConfig):
     args: Annotated[dict, Field(description="Arguments to pass to the environment.")] = {}
 
 
-class PathConfig(BaseConfig):
-    """Configures a path used for input/ output operations"""
-
-    path: Annotated[Path, Field(description="Path to write to.")]
-
-    clean: Annotated[
-        bool,
-        Field(
-            description="Whether to clean the path at the beginning of the run. If True, will delete the entire directory.",
-        ),
-    ] = False
-
-
 class EvalConfig(BaseConfig):
     """Configures evaluation."""
 
@@ -129,8 +115,6 @@ class EvalConfig(BaseConfig):
 
 class CheckpointConfig(BaseConfig):
     """Configures checkpointing the orchestrator."""
-
-    path: Annotated[Path, Field(description="Directory to write checkpoints to.")] = Path("checkpoints")
 
     interval: Annotated[int, Field(ge=1, description="Interval at which to save the checkpoint.")] = 50
 
@@ -333,20 +317,6 @@ class OrchestratorConfig(BaseSettings):
             description="Maximum number of async levels to use. If 0, will do synchronous RL. Else, it will allow to go `async_level` steps ahead of training.",
         ),
     ] = 2
-
-    rollout_path: Annotated[
-        Path,
-        Field(
-            description="Path to write inference outputs to. Will be populated by the orchestrator with responses from inference pool.",
-        ),
-    ] = Path("rollouts")
-
-    weights_path: Annotated[
-        Path,
-        Field(
-            description="Path to read updated model weights from. Will be populated by the trainer.",
-        ),
-    ] = Path("weights")
 
     bench: Annotated[
         bool,

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -56,7 +56,7 @@ async def orchestrate(config: OrchestratorConfig):
 
     # Setup monitor
     logger.info(f"Initializing monitor ({config.monitor})")
-    monitor = setup_monitor(config.monitor, None, tokenizer, config)
+    monitor = setup_monitor(config.monitor, outputs_dir=config.outputs_dir, tokenizer=tokenizer, run_config=config)
 
     # Check health of the client
     logger.info("Waiting for inference pool to be ready")

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -30,7 +30,7 @@ from prime_rl.orchestrator.advantage import compute_advantages
 from prime_rl.orchestrator.utils import wait_for_weight_checkpoint, print_benchmark, parse_truncated_completions
 from prime_rl.utils.monitor import setup_monitor
 from prime_rl.utils.pydantic_config import parse_argv
-from prime_rl.utils.utils import clean_exit, to_col_format, format_num
+from prime_rl.utils.utils import clean_exit, format_num, get_rollout_dir, get_weights_dir, to_col_format
 
 
 @clean_exit
@@ -77,7 +77,7 @@ async def orchestrate(config: OrchestratorConfig):
         logger.info(f"Resuming training from checkpoint step `{config.ckpt.resume_step}`")
         ckpt_manager.load(progress, step=config.ckpt.resume_step)
         ckpt_step = max(progress.step - config.async_level, 0)
-        await update_weights(client, config.outputs_dir / "weights", ckpt_step)
+        await update_weights(client, get_weights_dir(config.outputs_dir), ckpt_step)
     else:
         logger.info("Training from scratch. Resetting weights to base model")
         await reload_weights(client)
@@ -130,14 +130,14 @@ async def orchestrate(config: OrchestratorConfig):
             ckpt_step = progress.step - config.async_level
             logger.info(f"Waiting for weight checkpoint {ckpt_step}")
             wait_for_weight_ckpt_start_time = time.time()
-            wait_for_weight_checkpoint(config.outputs_dir / "weights", ckpt_step)
+            wait_for_weight_checkpoint(get_weights_dir(config.outputs_dir), ckpt_step)
             wait_for_weight_ckpt_time = time.time() - wait_for_weight_ckpt_start_time
             logger.debug(f"Waited {wait_for_weight_ckpt_time:.2f}s for weight checkpoint")
 
             # Update the weights
             logger.info(f"Updating weights to weight checkpoint {ckpt_step}")
             update_weights_start_time = time.time()
-            await update_weights(client, config.outputs_dir / "weights", ckpt_step)
+            await update_weights(client, get_weights_dir(config.outputs_dir), ckpt_step)
             update_weights_time = time.time() - update_weights_start_time
             logger.debug(f"Updated weights in {update_weights_time:.2f}s")
 
@@ -322,7 +322,7 @@ async def orchestrate(config: OrchestratorConfig):
             collate_mode=config.collate_mode,
         )
 
-        step_path = config.outputs_dir / "rollouts" / f"step_{progress.step}"
+        step_path = get_rollout_dir(config.outputs_dir) / f"step_{progress.step}"
         step_path.mkdir(parents=True, exist_ok=True)
         for i, batches in enumerate(all_data_ranks_batches):
             batch_path = step_path / f"rank_{i}.pt"

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -322,7 +322,7 @@ async def orchestrate(config: OrchestratorConfig):
             collate_mode=config.collate_mode,
         )
 
-        step_path = Path(config.rollout_path) / f"step_{progress.step}"
+        step_path = config.outputs_dir / "rollouts" / f"step_{progress.step}"
         step_path.mkdir(parents=True, exist_ok=True)
         for i, batches in enumerate(all_data_ranks_batches):
             batch_path = step_path / f"rank_{i}.pt"

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -68,7 +68,7 @@ async def orchestrate(config: OrchestratorConfig):
     ckpt_manager = None
     if config.ckpt:
         logger.info(f"Initializing checkpoint manager ({config.ckpt})")
-        ckpt_manager = CheckpointManager(config.ckpt)
+        ckpt_manager = CheckpointManager(config.outputs_dir, config.ckpt)
 
     # Reset weights to base model if starting from scratch
     progress = Progress()

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -77,7 +77,7 @@ async def orchestrate(config: OrchestratorConfig):
         logger.info(f"Resuming training from checkpoint step `{config.ckpt.resume_step}`")
         ckpt_manager.load(progress, step=config.ckpt.resume_step)
         ckpt_step = max(progress.step - config.async_level, 0)
-        await update_weights(client, config.weights_path, ckpt_step)
+        await update_weights(client, config.outputs_dir / "weights", ckpt_step)
     else:
         logger.info("Training from scratch. Resetting weights to base model")
         await reload_weights(client)
@@ -130,14 +130,14 @@ async def orchestrate(config: OrchestratorConfig):
             ckpt_step = progress.step - config.async_level
             logger.info(f"Waiting for weight checkpoint {ckpt_step}")
             wait_for_weight_ckpt_start_time = time.time()
-            wait_for_weight_checkpoint(config.weights_path, ckpt_step)
+            wait_for_weight_checkpoint(config.outputs_dir / "weights", ckpt_step)
             wait_for_weight_ckpt_time = time.time() - wait_for_weight_ckpt_start_time
             logger.debug(f"Waited {wait_for_weight_ckpt_time:.2f}s for weight checkpoint")
 
-            # Reload the weights
+            # Update the weights
             logger.info(f"Updating weights to weight checkpoint {ckpt_step}")
             update_weights_start_time = time.time()
-            await update_weights(client, config.weights_path, ckpt_step)
+            await update_weights(client, config.outputs_dir / "weights", ckpt_step)
             update_weights_time = time.time() - update_weights_start_time
             logger.debug(f"Updated weights in {update_weights_time:.2f}s")
 

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -114,12 +114,12 @@ class RLConfig(BaseSettings):
     inference_gpus: Annotated[int, Field(description="The number of GPUs to use for inference.")] = 1
 
     ### Shared configurations
+
+    # NOTE: This value should match the `DEFAULT_OUTPUTS_DIR` in `scripts/tmux.sh` to properly stream file logs
     outputs_dir: Annotated[
         Path,
         Field(description="The directory to store the outputs. Should typically be set to an experiment identifier."),
-    ] = Path(
-        "exp-1"
-    )  # NOTE: This value should match the `EXPERIMENT_NAME` in `scripts/tmux.sh` to properly stream file logs
+    ] = Path("outputs")
 
     ckpt: Annotated[
         CheckpointConfig | None,

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -113,11 +113,10 @@ class RLConfig(BaseSettings):
 
     ### Shared configurations
 
-    # NOTE: This value should match the `DEFAULT_OUTPUTS_DIR` in `scripts/tmux.sh` to properly stream file logs
     outputs_dir: Annotated[
         Path,
         Field(description="The directory to store the outputs. Should typically be set to an experiment identifier."),
-    ] = Path("outputs")
+    ] = Path("outputs")  # NOTE: Must match `OUTPUTS_DIR` in `tmux.sh` to see logs
 
     ckpt: Annotated[
         CheckpointConfig | None,

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -4,6 +4,7 @@ import shutil
 import subprocess
 import sys
 import time
+import uuid
 import warnings
 from pathlib import Path
 from subprocess import Popen
@@ -31,15 +32,13 @@ from prime_rl.utils.validation import (
     validate_shared_max_model_len,
     validate_shared_max_steps,
     validate_shared_model_name,
-    validate_shared_paths,
+    validate_shared_outputs_dir,
     validate_shared_wandb_config,
 )
 
 
 class LogConfig(BaseSettings):
     """Configures shared logging."""
-
-    path: Annotated[Path | None, Field(description="The path to the logs directory.")] = Path("logs")
 
     level: Annotated[str | None, Field(description="The log level to use.")] = "info"
 
@@ -114,13 +113,6 @@ class RLConfig(BaseSettings):
 
     inference_gpus: Annotated[int, Field(description="The number of GPUs to use for inference.")] = 1
 
-    exp_id: Annotated[
-        str | None,
-        Field(
-            description="The experiment ID. If set, will be used to identify shared resources, like log files, weight and rollout directories, etc."
-        ),
-    ] = "rl"  # This value has to match the `DEFAULT_EXPERIMENT_ID` in `tmux.sh`
-
     ### Shared configurations
     ckpt: Annotated[
         CheckpointConfig | None,
@@ -161,20 +153,6 @@ class RLConfig(BaseSettings):
         int | None,
         Field(
             description="The async level to use. If None, will fallback to the async level specified on submodule configs."
-        ),
-    ] = None
-
-    rollout_path: Annotated[
-        Path | None,
-        Field(
-            description="The path to the rollout directory. If None, will fallback to the rollout path specified on submodule configs."
-        ),
-    ] = None
-
-    weights_path: Annotated[
-        Path | None,
-        Field(
-            description="The path to the weights directory. If None, will fallback to the weights path specified on submodule configs."
         ),
     ] = None
 
@@ -224,11 +202,6 @@ class RLConfig(BaseSettings):
                 self.trainer.ckpt = TrainerCheckpointConfig()
             if not self.orchestrator.ckpt:
                 self.orchestrator.ckpt = OrchestratorCheckpointConfig()
-
-            # If specified, use the same ckpt path
-            if self.ckpt.path:
-                self.trainer.ckpt.path = self.ckpt.path
-                self.orchestrator.ckpt.path = self.ckpt.path
 
             # If specified, use the same ckpt interval
             if self.ckpt.interval:
@@ -344,33 +317,14 @@ class RLConfig(BaseSettings):
         return self
 
     @model_validator(mode="after")
-    def auto_setup_paths(self):
+    def auto_setup_output_dir(self):
         # If specified, use the same paths for communicating data and weights
-        if self.rollout_path:
-            self.trainer.data.path = self.rollout_path
-            self.orchestrator.rollout_path = self.rollout_path
+        if self.outputs_dir:
+            self.trainer.outputs_dir = self.outputs_dir
+            self.orchestrator.outputs_dir = self.outputs_dir
 
-        if self.weights_path:
-            self.trainer.weights.path = self.weights_path
-            self.orchestrator.weights_path = self.weights_path
+        validate_shared_outputs_dir(self.trainer, self.orchestrator)
 
-        validate_shared_paths(self.trainer, self.orchestrator)
-
-        return self
-
-    @model_validator(mode="after")
-    def auto_setup_exp_id(self):
-        if self.exp_id:
-            # Create subdirectories for logs, rollouts, weights and checkpoints
-            self.log.path = self.log.path / self.exp_id
-            self.trainer.data.path = self.trainer.data.path / self.exp_id
-            self.orchestrator.rollout_path = self.orchestrator.rollout_path / self.exp_id
-            self.trainer.weights.path = self.trainer.weights.path / self.exp_id
-            self.orchestrator.weights_path = self.orchestrator.weights_path / self.exp_id
-            if self.trainer.ckpt:
-                self.trainer.ckpt.path = self.trainer.ckpt.path / self.exp_id
-            if self.orchestrator.ckpt:
-                self.orchestrator.ckpt.path = self.orchestrator.ckpt.path / self.exp_id
         return self
 
     @model_validator(mode="after")
@@ -441,28 +395,29 @@ def rl(config: RLConfig):
 
     # Prepare paths to communicate with the trainer
     if config.clean:
-        logger.info("Cleaning checkpoint, logs, checkpoint weights and rollout directories")
+        logger.info("Cleaning checkpoint, logs, weights and rollout directories")
 
         # Cleaning logs
-        logger.info(f"Cleaning logs ({config.log.path})")
-        shutil.rmtree(config.log.path, ignore_errors=True)
-        config.log.path.mkdir(parents=True, exist_ok=True)
+        log_dir = config.outputs_dir / "logs"
+        logger.info(f"Cleaning log dir ({log_dir})")
+        shutil.rmtree(log_dir, ignore_errors=True)
+        log_dir.mkdir(parents=True, exist_ok=True)
 
-        # Cleaning checkpoints
-        if config.trainer.ckpt and not config.trainer.ckpt.resume_step:  # Only clean if we don't resume
-            logger.info(f"Cleaning trainer checkpoint path ({config.trainer.ckpt.path})")
-            shutil.rmtree(config.trainer.ckpt.path, ignore_errors=True)
+        # Cleaning checkpoints and weights, unless resuming
+        do_resume = config.trainer.ckpt and config.trainer.ckpt.resume_step
+        if not do_resume:  # Only clean if we don't resume
+            ckpt_dir = config.outputs_dir / "checkpoints"
+            logger.info(f"Cleaning checkpoint directory ({ckpt_dir})")
+            shutil.rmtree(ckpt_dir, ignore_errors=True)
 
-        if config.orchestrator.ckpt and not config.orchestrator.ckpt.resume_step:  # Only clean if we don't resume
-            logger.info(f"Cleaning orchestrator checkpoint path ({config.orchestrator.ckpt.path})")
-            shutil.rmtree(config.orchestrator.ckpt.path, ignore_errors=True)
+            weights_dir = config.outputs_dir / "weights"
+            logger.info(f"Cleaning checkpoint weights directory ({weights_dir})")
+            shutil.rmtree(weights_dir, ignore_errors=True)
 
-        if not (config.orchestrator.ckpt and config.orchestrator.ckpt.resume_step):  # Only clean if we don't resume
-            logger.info(f"Cleaning checkpoint weights path ({config.orchestrator.weights_path})")
-            shutil.rmtree(config.orchestrator.weights_path, ignore_errors=True)
-
-        logger.info(f"Cleaning rollout path ({config.trainer.data.path})")
-        shutil.rmtree(config.trainer.data.path, ignore_errors=True)
+        # Cleaning rollouts
+        rollout_dir = config.outputs_dir / "rollouts"
+        logger.info(f"Cleaning rollout dir ({rollout_dir})")
+        shutil.rmtree(rollout_dir, ignore_errors=True)
 
     # Start processes
     processes: list[Popen] = []
@@ -558,7 +513,7 @@ def rl(config: RLConfig):
             "run",
             "torchrun",
             f"--rdzv-endpoint=localhost:{get_free_port()}",
-            f"--rdzv-id={config.exp_id}",
+            f"--rdzv-id={uuid.uuid4().hex}",
             "--nproc-per-node",
             str(config.trainer_gpus),
             "src/prime_rl/trainer/train.py",

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -23,8 +23,8 @@ class Progress:
 class CheckpointManager:
     """Utility class to save and load training checkpoints to resume training."""
 
-    def __init__(self, config: CheckpointConfig):
-        self.path = config.path
+    def __init__(self, output_dir: Path, config: CheckpointConfig):
+        self.path = output_dir / "checkpoints"
         self.save_async = config.save_async
         self._logger = get_logger()
         self._world = get_world()

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -11,6 +11,7 @@ from prime_rl.trainer.config import CheckpointConfig
 from prime_rl.trainer.model import Model
 from prime_rl.trainer.world import get_world
 from prime_rl.utils.logger import get_logger
+from prime_rl.utils.utils import get_ckpt_dir
 
 
 @dataclass
@@ -23,14 +24,14 @@ class Progress:
 class CheckpointManager:
     """Utility class to save and load training checkpoints to resume training."""
 
-    def __init__(self, output_dir: Path, config: CheckpointConfig):
-        self.path = output_dir / "checkpoints"
+    def __init__(self, outputs_dir: Path, config: CheckpointConfig):
+        self.ckpt_dir = get_ckpt_dir(outputs_dir)
         self.save_async = config.save_async
         self._logger = get_logger()
         self._world = get_world()
 
     def _get_step_path(self, step: int) -> Path:
-        return self.path / f"step_{step}"
+        return self.ckpt_dir / f"step_{step}"
 
     def _get_ckpt_path(self, step: int) -> Path:
         ckpt_name = f"trainer_{self._world.local_rank}.pt" if self._world.world_size > 1 else "trainer.pt"

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -96,8 +96,6 @@ class OptimizerConfig(BaseConfig):
 class CheckpointConfig(BaseConfig):
     """Configures checkpointing the full model, optimizer and training state for resuming training."""
 
-    path: Annotated[Path, Field(description="Directory to write checkpoints to.")] = Path("checkpoints")
-
     interval: Annotated[int, Field(ge=1, description="Interval at which to save the checkpoint.")] = 50
 
     save_async: Annotated[
@@ -118,13 +116,6 @@ class CheckpointConfig(BaseConfig):
 
 class WeightCheckpointConfig(BaseConfig):
     """Configures checkpointing the model weights for updating the inference engines."""
-
-    path: Annotated[
-        Path,
-        Field(
-            description="Path to write weights to. Will write to `{path}/step_{step}` at every training step, which will be read by the orchestrator to update the inference engines.",
-        ),
-    ] = Path("weights")
 
     interval: Annotated[
         int | None,
@@ -184,8 +175,6 @@ class FakeDataLoaderConfig(BaseConfig):
 
 class DataLoaderConfig(BaseConfig):
     """Configures the data loader used for training."""
-
-    path: Annotated[Path, Field(description="Path to read rollouts from.")] = Path("rollouts")
 
     fake: Annotated[FakeDataLoaderConfig | None, Field(description="Whether to use a fake data loader.")] = None
 

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -206,6 +206,13 @@ class TrainerConfig(BaseSettings):
     # The monitor configuration
     monitor: MultiMonitorConfig = MultiMonitorConfig()
 
+    outputs_dir: Annotated[
+        Path,
+        Field(
+            description="Directory to write outputs to. Will be populated with checkpoints, weights, rollouts and logs as subdirectories. Should be set to a persistent directory with enough disk space. This value should be distinct across experiments running on a single node. See the README for more details."
+        ),
+    ] = Path("outputs")
+
     max_steps: Annotated[
         int | None,
         Field(

--- a/src/prime_rl/trainer/data.py
+++ b/src/prime_rl/trainer/data.py
@@ -49,18 +49,18 @@ class FakeDataLoader:
 class DataLoader:
     """Loads serialized data from a data path written by the orchestrator."""
 
-    def __init__(self, data_path: Path, start_step: int):
-        self.data_path = data_path
+    def __init__(self, output_dir: Path, start_step: int):
+        self.rollout_dir = output_dir / "rollouts"
         self.current_step = start_step
         self.world = get_world()
 
-    def get_batch_path(self) -> Path:
-        return self.data_path / f"step_{self.current_step}" / f"rank_{self.world.rank}.pt"
+    def get_rollout_path(self) -> Path:
+        return self.rollout_dir / f"step_{self.current_step}" / f"rank_{self.world.rank}.pt"
 
     def wait_for_batch(self) -> None:
-        wait_for_path(self.get_batch_path())
+        wait_for_path(self.get_rollout_path())
 
     def get_batch(self) -> list[MicroBatch]:
-        batches = torch.load(self.get_batch_path())
+        batches = torch.load(self.get_rollout_path())
         self.current_step += 1
         return batches

--- a/src/prime_rl/trainer/data.py
+++ b/src/prime_rl/trainer/data.py
@@ -6,7 +6,7 @@ from jaxtyping import Float, Int
 
 from prime_rl.trainer.config import FakeDataLoaderConfig
 from prime_rl.trainer.world import get_world
-from prime_rl.utils.utils import wait_for_path
+from prime_rl.utils.utils import get_rollout_dir, wait_for_path
 
 
 class MicroBatch(TypedDict):
@@ -49,8 +49,8 @@ class FakeDataLoader:
 class DataLoader:
     """Loads serialized data from a data path written by the orchestrator."""
 
-    def __init__(self, output_dir: Path, start_step: int):
-        self.rollout_dir = output_dir / "rollouts"
+    def __init__(self, outputs_dir: Path, start_step: int):
+        self.rollout_dir = get_rollout_dir(outputs_dir)
         self.current_step = start_step
         self.world = get_world()
 

--- a/src/prime_rl/trainer/train.py
+++ b/src/prime_rl/trainer/train.py
@@ -136,7 +136,7 @@ def train(config: TrainerConfig):
 
     # Set up the data loader (Optionally, use a fake data loader for debugging)
     logger.info(f"Initializing data loader ({config.data})")
-    dataloader = DataLoader(config.data.path, progress.step)
+    dataloader = DataLoader(config.outputs_dir, progress.step)
     if config.data.fake:
         dataloader = FakeDataLoader(config.data.fake)
 

--- a/src/prime_rl/trainer/train.py
+++ b/src/prime_rl/trainer/train.py
@@ -126,7 +126,7 @@ def train(config: TrainerConfig):
                 model_name_or_path = (
                     config.model.name
                     if not (config.ckpt and config.ckpt.resume_step)
-                    else weight_ckpt_manager.path / f"step_{step}"
+                    else weight_ckpt_manager._get_step_path(step)
                 )
                 model_config = deepcopy(config.model)
                 model_config.name = model_name_or_path

--- a/src/prime_rl/trainer/train.py
+++ b/src/prime_rl/trainer/train.py
@@ -58,7 +58,7 @@ def train(config: TrainerConfig):
 
     # Setup the monitor
     logger.info(f"Initializing monitor ({config.monitor})")
-    monitor = setup_monitor(config.monitor, run_config=config)
+    monitor = setup_monitor(config.monitor, outputs_dir=config.outputs_dir, run_config=config)
 
     # TODO(Mika): Move this to typed env var
     # Allow eager fallback during production so that training runs don't die if compile fails

--- a/src/prime_rl/trainer/train.py
+++ b/src/prime_rl/trainer/train.py
@@ -99,10 +99,10 @@ def train(config: TrainerConfig):
 
     # Get checkpoint managers
     logger.info(f"Initializing weight checkpoint manager ({config.weights})")
-    weight_ckpt_manager = WeightCheckpointManager(config.weights, config.ckpt, config.async_level)
+    weight_ckpt_manager = WeightCheckpointManager(config.outputs_dir, config.weights, config.ckpt, config.async_level)
     if config.ckpt:
         logger.info(f"Initializing checkpoint manager ({config.ckpt})")
-        ckpt_manager = CheckpointManager(config.ckpt)
+        ckpt_manager = CheckpointManager(config.outputs_dir, config.ckpt)
 
     # Optionally, resume training from a checkpoint
     progress = Progress()

--- a/src/prime_rl/trainer/weights.py
+++ b/src/prime_rl/trainer/weights.py
@@ -19,7 +19,10 @@ from prime_rl.utils.utils import get_step_path, get_weight_ckpt_model_path
 class WeightCheckpointManager:
     """Utility class to save and cleanup HF-compatible weight checkpoints."""
 
-    def __init__(self, config: WeightCheckpointConfig, ckpt_config: CheckpointConfig, async_level: int):
+    def __init__(
+        self, output_dir: Path, config: WeightCheckpointConfig, ckpt_config: CheckpointConfig, async_level: int
+    ):
+        self.path = output_dir / "weights"
         self.config = config
         self.ckpt_config = ckpt_config
         self.async_level = async_level
@@ -28,10 +31,10 @@ class WeightCheckpointManager:
         self._is_master = self._world.rank == 0
 
     def _get_model_path(self, step: int) -> Path:
-        return get_weight_ckpt_model_path(self.config.path, step)
+        return get_weight_ckpt_model_path(self.path, step)
 
     def _get_step_path(self, step: int) -> Path:
-        return get_step_path(self.config.path, step)
+        return get_step_path(self.path, step)
 
     def _gather_weights(self, model: Model, dtype: torch.dtype = torch.bfloat16) -> dict[str, Tensor]:
         """Gather distributed weights for weight checkpoint."""

--- a/src/prime_rl/trainer/weights.py
+++ b/src/prime_rl/trainer/weights.py
@@ -13,16 +13,16 @@ from prime_rl.trainer.config import CheckpointConfig, WeightCheckpointConfig
 from prime_rl.trainer.model import Model
 from prime_rl.trainer.world import get_world
 from prime_rl.utils.logger import get_logger
-from prime_rl.utils.utils import get_step_path, get_weight_ckpt_model_path
+from prime_rl.utils.utils import get_step_path, get_weight_ckpt_model_path, get_weights_dir
 
 
 class WeightCheckpointManager:
     """Utility class to save and cleanup HF-compatible weight checkpoints."""
 
     def __init__(
-        self, output_dir: Path, config: WeightCheckpointConfig, ckpt_config: CheckpointConfig, async_level: int
+        self, outputs_dir: Path, config: WeightCheckpointConfig, ckpt_config: CheckpointConfig, async_level: int
     ):
-        self.path = output_dir / "weights"
+        self.weights_dir = get_weights_dir(outputs_dir)
         self.config = config
         self.ckpt_config = ckpt_config
         self.async_level = async_level
@@ -31,10 +31,10 @@ class WeightCheckpointManager:
         self._is_master = self._world.rank == 0
 
     def _get_model_path(self, step: int) -> Path:
-        return get_weight_ckpt_model_path(self.path, step)
+        return get_weight_ckpt_model_path(self.weights_dir, step)
 
     def _get_step_path(self, step: int) -> Path:
-        return get_step_path(self.path, step)
+        return get_step_path(self.weights_dir, step)
 
     def _gather_weights(self, model: Model, dtype: torch.dtype = torch.bfloat16) -> dict[str, Tensor]:
         """Gather distributed weights for weight checkpoint."""

--- a/src/prime_rl/utils/config.py
+++ b/src/prime_rl/utils/config.py
@@ -87,13 +87,6 @@ class WandbMonitorConfig(BaseConfig):
         ),
     ] = None
 
-    dir: Annotated[
-        Path | None,
-        Field(
-            description="Path to the directory to keep local logs. It will automatically create a `wandb` subdirectory to store run logs.",
-        ),
-    ] = Path("logs")
-
     offline: Annotated[bool, Field(description="Whether to run W&B in offline mode.")] = False
 
     # Individual configs (can only be specified on trainer or orchestrator)

--- a/src/prime_rl/utils/monitor.py
+++ b/src/prime_rl/utils/monitor.py
@@ -8,6 +8,7 @@ import threading
 import time
 from abc import ABC, abstractmethod
 from collections import defaultdict
+from pathlib import Path
 from typing import Any, Literal
 
 import aiohttp
@@ -124,6 +125,7 @@ class WandbMonitor(Monitor):
     def __init__(
         self,
         config: WandbMonitorConfig,
+        outputs_dir: Path,
         tokenizer: PreTrainedTokenizer | None = None,
         task_id: str | None = None,
         run_config: BaseSettings | None = None,
@@ -140,7 +142,7 @@ class WandbMonitor(Monitor):
             project=config.project,
             name=config.name,
             id=config.id,
-            dir=config.dir,
+            dir=outputs_dir / "wandb",
             resume="allow",
             config=run_config.model_dump() if run_config else None,
             mode="offline" if config.offline else None,
@@ -328,12 +330,14 @@ class MultiMonitor:
     def __init__(
         self,
         config: MultiMonitorConfig,
+        outputs_dir: Path,
         task_id: str | None = None,
         tokenizer: PreTrainedTokenizer | None = None,
         run_config: BaseSettings | None = None,
     ):
         self.logger = get_logger()
         self.history: list[dict[str, Any]] = []
+        self.outputs_dir = outputs_dir
         # Initialize outputs
         self.outputs: dict[MonitorType, Monitor] = {}
         self.wandb = None
@@ -344,7 +348,7 @@ class MultiMonitor:
         if config.api:
             self.outputs["api"] = APIMonitor(config.api, task_id)
         if config.wandb:
-            self.wandb = WandbMonitor(config.wandb, tokenizer, task_id, run_config=run_config)
+            self.wandb = WandbMonitor(config.wandb, outputs_dir, tokenizer, task_id, run_config=run_config)
             self.outputs["wandb"] = self.wandb
 
         self.disabled = len(self.outputs) == 0
@@ -443,6 +447,7 @@ def get_monitor() -> MultiMonitor:
 
 def setup_monitor(
     config: MultiMonitorConfig,
+    outputs_dir: Path,
     task_id: str | None = None,
     tokenizer: PreTrainedTokenizer | None = None,
     run_config: BaseSettings | None = None,
@@ -451,5 +456,5 @@ def setup_monitor(
     global _MONITOR
     if _MONITOR is not None:
         raise RuntimeError("Monitor already initialized. Please call `setup_monitor` only once.")
-    _MONITOR = MultiMonitor(config, task_id, tokenizer, run_config)
+    _MONITOR = MultiMonitor(config, outputs_dir, task_id, tokenizer, run_config)
     return _MONITOR

--- a/src/prime_rl/utils/monitor.py
+++ b/src/prime_rl/utils/monitor.py
@@ -142,7 +142,7 @@ class WandbMonitor(Monitor):
             project=config.project,
             name=config.name,
             id=config.id,
-            dir=outputs_dir / "wandb",
+            dir=outputs_dir,
             resume="allow",
             config=run_config.model_dump() if run_config else None,
             mode="offline" if config.offline else None,

--- a/src/prime_rl/utils/utils.py
+++ b/src/prime_rl/utils/utils.py
@@ -213,14 +213,6 @@ def format_num(num: float | int, precision: int = 2) -> str:
         return f"{sign}{num / 1e9:.{precision}f}B"
 
 
-def get_step_path(path: Path, step: int) -> Path:
-    return path / f"step_{step}"
-
-
-def get_weight_ckpt_model_path(weight_dir: Path, step: int) -> Path:
-    return weight_dir / f"step_{step}" / "pytorch_model.bin"
-
-
 def get_free_port() -> int:
     """Find and return a free port"""
     import socket
@@ -239,3 +231,31 @@ def get_cuda_visible_devices() -> list[int]:
         # Default to all devices if the environment variable is not set
         return list(range(torch.cuda.device_count()))
     return list(sorted([int(device) for device in cuda_visible.split(",")]))
+
+
+def get_log_dir(outputs_dir: Path) -> Path:
+    return outputs_dir / "logs"
+
+
+def get_ckpt_dir(outputs_dir: Path) -> Path:
+    return outputs_dir / "checkpoints"
+
+
+def get_weights_dir(outputs_dir: Path) -> Path:
+    return outputs_dir / "weights"
+
+
+def get_rollout_dir(outputs_dir: Path) -> Path:
+    return outputs_dir / "rollouts"
+
+
+def get_wandb_dir(outputs_dir: Path) -> Path:
+    return outputs_dir / "wandb"
+
+
+def get_step_path(path: Path, step: int) -> Path:
+    return path / f"step_{step}"
+
+
+def get_weight_ckpt_model_path(weights_dir: Path, step: int) -> Path:
+    return weights_dir / f"step_{step}" / "pytorch_model.bin"

--- a/src/prime_rl/utils/utils.py
+++ b/src/prime_rl/utils/utils.py
@@ -249,10 +249,6 @@ def get_rollout_dir(outputs_dir: Path) -> Path:
     return outputs_dir / "rollouts"
 
 
-def get_wandb_dir(outputs_dir: Path) -> Path:
-    return outputs_dir / "wandb"
-
-
 def get_step_path(path: Path, step: int) -> Path:
     return path / f"step_{step}"
 

--- a/src/prime_rl/utils/validation.py
+++ b/src/prime_rl/utils/validation.py
@@ -59,18 +59,13 @@ def validate_shared_max_model_len(
         )
 
 
-def validate_shared_paths(
+def validate_shared_outputs_dir(
     trainer: TrainerConfig,
     orchestrator: OrchestratorConfig,
 ) -> None:
-    if trainer.data.path != orchestrator.rollout_path:
+    if trainer.outputs_dir != orchestrator.outputs_dir:
         raise ValueError(
-            f"Trainer data path ({trainer.data.path}) and orchestrator rollout path ({orchestrator.rollout_path}) are not the same. Please specify the same path for both."
-        )
-
-    if trainer.weights.path != orchestrator.weights_path:
-        raise ValueError(
-            f"Trainer weights path ({trainer.weights.path}) and orchestrator weights path ({orchestrator.weights_path}) are not the same. Please specify the same path for both."
+            f"Trainer outputs directory ({trainer.outputs_dir}) and orchestrator outputs directory ({orchestrator.outputs_dir}) are not the same. Please specify the same outputs directory for both."
         )
 
 

--- a/src/prime_rl/utils/validation.py
+++ b/src/prime_rl/utils/validation.py
@@ -19,10 +19,6 @@ def validate_shared_ckpt_config(
         raise ValueError(
             "Orchestrator checkpoint config is specified, but trainer checkpoint config is not. Please setup checkpointing on both for checkpointing to work properly."
         )
-    if trainer.ckpt and orchestrator.ckpt and trainer.ckpt.path != orchestrator.ckpt.path:
-        raise ValueError(
-            f"Trainer checkpoint path ({trainer.ckpt.path}) and orchestrator checkpoint path ({orchestrator.ckpt.path}) are not the same. Please specify the same checkpoint path for both."
-        )
     if trainer.ckpt and orchestrator.ckpt and trainer.ckpt.interval != orchestrator.ckpt.interval:
         raise ValueError(
             f"Trainer checkpoint interval ({trainer.ckpt.interval}) and orchestrator checkpoint interval ({orchestrator.ckpt.interval}) are not the same. Please specify the same checkpoint interval for both."

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -15,7 +15,7 @@ from prime_rl.utils.validation import (
     validate_shared_max_model_len,
     validate_shared_max_steps,
     validate_shared_model_name,
-    validate_shared_paths,
+    validate_shared_outputs_dir,
     validate_shared_wandb_config,
 )
 
@@ -93,7 +93,7 @@ def test_shared_config_validation(config_dir: Path, monkeypatch: pytest.MonkeyPa
     assert trainer and orchestrator and inference
     validate_shared_ckpt_config(trainer, orchestrator)
     validate_shared_model_name(trainer, orchestrator, inference)
-    validate_shared_paths(trainer, orchestrator)
+    validate_shared_outputs_dir(trainer, orchestrator)
     validate_shared_wandb_config(trainer, orchestrator)
     validate_shared_max_model_len(orchestrator, inference)
     validate_shared_async_level(trainer, orchestrator)


### PR DESCRIPTION
This PR implements @willccbb suggestions of using a single unified directory for outputs which stores artifacts such as checkpoints, rollouts, weights, console and wandb logs. It is defined as a shared config key `--outputs-dir` on the trainer and orchestrator, as well as in `rl.py`. By default it is set to `outputs`.

It hardcodes the artifact paths using shared util functions as:

- Checkpoints: `{outputs_dir}/checkpoints`
- Rollouts: `{outputs_dir}/rollouts`
- Weights: `{outputs_dir}/weights`
- Logs: `{outputs_dir}/logs`
- W&B: `{outputs_dir}/wandb`

This PR also deprecates the `exp-id` config key as it is not needed anymore and removes the somewhat akward subdirectory structure for experiments, e.g. having `rollouts/{exp_id}`, `weights/{exp_id}` etc. Now, a new experiment should simply be associated with a new outputs dir and all its artifacts are in one place.

This change required some changes to the `tmux.sh` and `install.sh` script, namely the `tmux.sh` now discriminates between the session name (can be specified by `-s` or `--session-name` and defaults to `prime-rl`) and outputs dir (can be specified by `-o` or `--outputs-dir`). There is also small   helper menu as `bash scripts/tmux.sh -h` to explain the (kw)args. The cleanup script deletes all artifact directories recursively, but prompts interactively before taking action.