### PR TITLE
[fix] remove max tokens in reverse text config

### DIFF
--- a/configs/reverse_text/orch.toml
+++ b/configs/reverse_text/orch.toml
@@ -10,6 +10,3 @@ name = "willcb/Qwen2.5-0.5B-Reverse-SFT"
 
 [environment]
 id = "vf-reverse-text"
-
-[sampling]
-max_tokens = 128


### PR DESCRIPTION
This fixes the error about max seq len when running
```
uv run rl   --trainer @ configs/reverse_text/train.toml   --orchestrator @ configs/reverse_text/orch.toml   --inference @ configs/reverse_text/infer.toml
```

The issue is that `seq_len` in orch will be passed to `max_model_len` in inference making the inference run at max model len of 128. However, because max_tokens is set, we will request len(input_prompt_tokens) + 128 tokens from the inference server which apparently makes it upset.
