### PR TITLE
Fix CI

### DIFF
--- a/configs/reverse_text/infer.toml
+++ b/configs/reverse_text/infer.toml
@@ -1,2 +1,3 @@
 [model]
 name = "willcb/Qwen2.5-0.5B-Reverse-SFT"
+max_model_len = 128

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,7 +106,7 @@ def run_processes() -> Callable[[list[Command], list[Environment], int], list[Pr
 
 
 VLLM_SERVER_ENV = {"CUDA_VISIBLE_DEVICES": "0"}
-VLLM_SERVER_CMD = ["uv", "run", "inference", "@", "configs/reverse_text/infer.toml"]
+VLLM_SERVER_CMD = ["uv", "run", "inference", "@", "configs/reverse_text/infer.toml", "--max-model-len", "None"]
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,7 +106,7 @@ def run_processes() -> Callable[[list[Command], list[Environment], int], list[Pr
 
 
 VLLM_SERVER_ENV = {"CUDA_VISIBLE_DEVICES": "0"}
-VLLM_SERVER_CMD = ["uv", "run", "inference", "@", "configs/reverse_text/infer.toml", "--max-model-len", "None"]
+VLLM_SERVER_CMD = ["uv", "run", "inference", "@", "configs/reverse_text/infer.toml", "--max-model-len", "2048"]
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/test_rl.py
+++ b/tests/integration/test_rl.py
@@ -21,6 +21,8 @@ CMD = [
     "@",
     "configs/reverse_text/orch.toml",
     "--orchestrator.monitor.wandb.log-extras",
+    "--orchestrator.sampling.max-tokens",
+    "128",
 ]
 
 


### PR DESCRIPTION
Sets up correct contexts so that we back to our ~5min of integration test time, and do not risk erroring CI because of timeouts