### PR TITLE
Add CI test for ckpt resuming

### DIFF
--- a/configs/reverse_text/orch.toml
+++ b/configs/reverse_text/orch.toml
@@ -2,7 +2,7 @@ batch_size = 128
 micro_batch_size = 16
 rollouts_per_prompt = 16
 seq_len = 128
-max_steps = 30
+max_steps = 20
 mask_truncated_completions = false
 
 [model]

--- a/configs/reverse_text/train.toml
+++ b/configs/reverse_text/train.toml
@@ -1,4 +1,4 @@
-max_steps = 30
+max_steps = 20
 
 [model]
 name = "willcb/Qwen2.5-0.5B-Reverse-SFT"

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -98,13 +98,13 @@ async def orchestrate(config: OrchestratorConfig):
     last_eval_step = -1
     is_first_step = True
     while True:
-        # Save checkpoint (if we are not at the first step)
+        # Save checkpoint (if we are at an interval step and not at the first or last step)
+        is_last_step = config.max_steps is not None and progress.step == config.max_steps - 1
         save_ckpt_time = 0
         if (
             config.ckpt
-            and ckpt_manager
             and config.ckpt.interval
-            and not is_first_step
+            and not (is_first_step or is_last_step)
             and progress.step % config.ckpt.interval == 0
         ):
             logger.info(f"Saving checkpoint at step {progress.step}")
@@ -451,7 +451,7 @@ async def orchestrate(config: OrchestratorConfig):
         monitor.wandb.log_final_distributions()
 
     # Write final checkpoint
-    if config.ckpt and ckpt_manager:
+    if config.ckpt:
         logger.info("Writing final checkpoint")
         ckpt_manager.save(progress, step=progress.step)
 

--- a/src/prime_rl/trainer/train.py
+++ b/src/prime_rl/trainer/train.py
@@ -149,9 +149,15 @@ def train(config: TrainerConfig):
             model_path = weight_ckpt_manager.save(model, tokenizer, step=progress.step)
             save_weights_time = time.time() - save_weights_start_time
 
-        # Save the full checkpoint (if we are at an interval step and not at the first step)
+        # Save the full checkpoint (if we are at an interval step and not at the first or last step)
+        is_last_step = config.max_steps is not None and progress.step == config.max_steps - 1
         save_ckpt_time = 0
-        if config.ckpt and config.ckpt.interval and not is_first_step and progress.step % config.ckpt.interval == 0:
+        if (
+            config.ckpt
+            and config.ckpt.interval
+            and not (is_first_step or is_last_step)
+            and progress.step % config.ckpt.interval == 0
+        ):
             logger.info(f"Saving checkpoint at step {progress.step}")
             save_ckpt_start_time = time.time()
             ckpt_manager.save(model, [optimizer], scheduler, progress, step=progress.step)

--- a/tests/integration/eval/test_debug.py
+++ b/tests/integration/eval/test_debug.py
@@ -19,7 +19,7 @@ ENV = {"CUDA_VISIBLE_DEVICES": "1"}
 
 
 @pytest.fixture(scope="module")
-def eval_process(_vllm_server, run_process: Callable[[Command, Environment], ProcessResult]) -> ProcessResult:
+def eval_process(vllm_server, run_process: Callable[[Command, Environment], ProcessResult]) -> ProcessResult:
     return run_process(CMD, ENV)
 
 

--- a/tests/integration/eval/test_debug.py
+++ b/tests/integration/eval/test_debug.py
@@ -19,7 +19,7 @@ ENV = {"CUDA_VISIBLE_DEVICES": "1"}
 
 
 @pytest.fixture(scope="module")
-def eval_process(vllm_server, run_process: Callable[[Command, Environment], ProcessResult]) -> ProcessResult:
+def eval_process(_vllm_server, run_process: Callable[[Command, Environment], ProcessResult]) -> ProcessResult:
     return run_process(CMD, ENV)
 
 

--- a/tests/integration/orchestrator/test_debug.py
+++ b/tests/integration/orchestrator/test_debug.py
@@ -18,9 +18,7 @@ CMD = [
 
 
 @pytest.fixture(scope="module")
-def orchestrator_process(
-    vllm_server: str, run_process: Callable[[Command, Environment], ProcessResult]
-) -> ProcessResult:
+def orchestrator_process(_vllm_server, run_process: Callable[[Command, Environment], ProcessResult]) -> ProcessResult:
     return run_process(CMD, {})
 
 

--- a/tests/integration/orchestrator/test_debug.py
+++ b/tests/integration/orchestrator/test_debug.py
@@ -18,7 +18,7 @@ CMD = [
 
 
 @pytest.fixture(scope="module")
-def orchestrator_process(_vllm_server, run_process: Callable[[Command, Environment], ProcessResult]) -> ProcessResult:
+def orchestrator_process(vllm_server, run_process: Callable[[Command, Environment], ProcessResult]) -> ProcessResult:
     return run_process(CMD, {})
 
 

--- a/tests/integration/test_rl.py
+++ b/tests/integration/test_rl.py
@@ -22,8 +22,7 @@ RL_CMD = [
     "configs/reverse_text/orch.toml",
     "--orchestrator.sampling.max-tokens",
     "128",
-    "--trainer.ckpt",
-    "--orchestrator.ckpt",
+    "--ckpt",
 ]
 RL_RESUME_CMD = [
     "uv",
@@ -37,13 +36,9 @@ RL_RESUME_CMD = [
     "configs/reverse_text/orch.toml",
     "--orchestrator.sampling.max-tokens",
     "128",
-    "--trainer.max-steps",
+    "--max-steps",
     "40",
-    "--orchestrator.max-steps",
-    "40",
-    "--trainer.ckpt.resume-step",
-    "20",
-    "--orchestrator.ckpt.resume-step",
+    "--ckpt.resume-step",
     "20",
 ]
 

--- a/tests/integration/test_rl.py
+++ b/tests/integration/test_rl.py
@@ -70,7 +70,7 @@ def wandb_project(username: str):
     project = "ci-reverse-text"
     if username != "CI_RUNNER":
         project += "-local"
-    return "ci-reverse-text"
+    return project
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_rl.py
+++ b/tests/integration/test_rl.py
@@ -75,7 +75,7 @@ def wandb_project(username: str):
 
 @pytest.fixture(scope="module")
 def rl_process(
-    _vllm_server,  # Can only run with vLLM server
+    vllm_server,  # Can only run with vLLM server
     run_process: Callable[[Command, Environment, int], ProcessResult],
     wandb_project: str,
     branch_name: str,
@@ -92,8 +92,8 @@ def rl_process(
 
 @pytest.fixture
 def rl_resume_process(
-    _vllm_server,  # Can only run with vLLM server
-    _rl_process,  # Resume training can only start when regular RL process is finished
+    vllm_server,  # Can only run with vLLM server
+    rl_process,  # Resume training can only start when regular RL process is finished
     run_process: Callable[[Command, Environment, int], ProcessResult],
     wandb_project: str,
     branch_name: str,

--- a/tests/integration/test_rl.py
+++ b/tests/integration/test_rl.py
@@ -80,7 +80,7 @@ def wandb_project(username: str):
 
 @pytest.fixture(scope="module")
 def rl_process(
-    vllm_server: str,
+    _vllm_server,  # Can only run with vLLM server
     run_process: Callable[[Command, Environment, int], ProcessResult],
     wandb_project: str,
     branch_name: str,
@@ -97,7 +97,8 @@ def rl_process(
 
 @pytest.fixture
 def rl_resume_process(
-    rl_process: ProcessResult,
+    _vllm_server,  # Can only run with vLLM server
+    _rl_process,  # Resume training can only start when regular RL process is finished
     run_process: Callable[[Command, Environment, int], ProcessResult],
     wandb_project: str,
     branch_name: str,

--- a/tests/integration/test_rl.py
+++ b/tests/integration/test_rl.py
@@ -10,7 +10,7 @@ pytestmark = [pytest.mark.gpu, pytest.mark.slow]
 
 
 TIMEOUT = 600  # 10 minutes
-CMD = [
+RL_CMD = [
     "uv",
     "run",
     "rl",
@@ -22,13 +22,39 @@ CMD = [
     "configs/reverse_text/orch.toml",
     "--orchestrator.sampling.max-tokens",
     "128",
+    "--trainer.ckpt",
+    "--orchestrator.ckpt",
+]
+RL_RESUME_CMD = [
+    "uv",
+    "run",
+    "rl",
+    "--trainer",
+    "@",
+    "configs/reverse_text/train.toml",
+    "--orchestrator",
+    "@",
+    "configs/reverse_text/orch.toml",
+    "--orchestrator.sampling.max-tokens",
+    "128",
+    "--trainer.max-steps",
+    "40",
+    "--orchestrator.max-steps",
+    "40",
+    "--trainer.ckpt.resume-step",
+    "20",
+    "--orchestrator.ckpt.resume-step",
+    "20",
 ]
 
 
 @pytest.fixture(scope="module")
-def train_process(vllm_server: str, run_process: Callable[[Command, Environment, int], ProcessResult]) -> ProcessResult:
-    # Parse git information
-    username = os.environ.get("USERNAME_CI", os.getlogin())
+def username():
+    return os.environ.get("USERNAME_CI", os.getlogin())
+
+
+@pytest.fixture(scope="module")
+def branch_name():
     branch_name_ = os.environ.get("GITHUB_REF_NAME", None)
 
     if branch_name_ is None:
@@ -36,21 +62,61 @@ def train_process(vllm_server: str, run_process: Callable[[Command, Environment,
     else:
         branch_name = branch_name_.replace("/merge", "")
         branch_name = f"pr-{branch_name}"
+    return branch_name
 
-    commit_hash = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).decode("utf-8").strip()
 
-    # Setup W&B project and run name
+@pytest.fixture(scope="module")
+def commit_hash():
+    return subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).decode("utf-8").strip()
+
+
+@pytest.fixture(scope="module")
+def wandb_project(username: str):
     project = "ci-reverse-text"
     if username != "CI_RUNNER":
         project += "-local"
-    run_name = f"{branch_name}-{commit_hash}"
+    return "ci-reverse-text"
+
+
+@pytest.fixture(scope="module")
+def rl_process(
+    vllm_server: str,
+    run_process: Callable[[Command, Environment, int], ProcessResult],
+    wandb_project: str,
+    branch_name: str,
+    commit_hash: str,
+) -> ProcessResult:
+    wandb_name = f"{branch_name}-{commit_hash}"
 
     return run_process(
-        CMD + ["--wandb.project", project, "--wandb.name", run_name],
+        RL_CMD + ["--wandb.project", wandb_project, "--wandb.name", wandb_name],
         {},
         TIMEOUT,
     )
 
 
-def test_no_error(train_process: ProcessResult):
-    assert train_process.returncode == 0, f"Train process failed with return code {train_process.returncode}"
+@pytest.fixture
+def rl_resume_process(
+    rl_process: ProcessResult,
+    run_process: Callable[[Command, Environment, int], ProcessResult],
+    wandb_project: str,
+    branch_name: str,
+    commit_hash: str,
+):
+    wandb_name = f"{branch_name}-{commit_hash}-resume"
+
+    return run_process(
+        RL_RESUME_CMD + ["--wandb.project", wandb_project, "--wandb.name", wandb_name],
+        {},
+        TIMEOUT,
+    )
+
+
+def test_no_error(rl_process: ProcessResult):
+    assert rl_process.returncode == 0, f"RL process failed with return code {rl_process.returncode}"
+
+
+def test_no_error_resume(rl_resume_process: ProcessResult):
+    assert rl_resume_process.returncode == 0, (
+        f"RL resume process failed with return code {rl_resume_process.returncode}"
+    )

--- a/tests/integration/test_rl.py
+++ b/tests/integration/test_rl.py
@@ -44,12 +44,12 @@ RL_RESUME_CMD = [
 
 
 @pytest.fixture(scope="module")
-def username():
+def username() -> str:
     return os.environ.get("USERNAME_CI", os.getlogin())
 
 
 @pytest.fixture(scope="module")
-def branch_name():
+def branch_name() -> str:
     branch_name_ = os.environ.get("GITHUB_REF_NAME", None)
 
     if branch_name_ is None:
@@ -61,12 +61,12 @@ def branch_name():
 
 
 @pytest.fixture(scope="module")
-def commit_hash():
+def commit_hash() -> str:
     return subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).decode("utf-8").strip()
 
 
 @pytest.fixture(scope="module")
-def wandb_project(username: str):
+def wandb_project(username: str) -> str:
     project = "ci-reverse-text"
     if username != "CI_RUNNER":
         project += "-local"
@@ -98,7 +98,7 @@ def rl_resume_process(
     wandb_project: str,
     branch_name: str,
     commit_hash: str,
-):
+) -> ProcessResult:
     wandb_name = f"{branch_name}-{commit_hash}-resume"
 
     return run_process(


### PR DESCRIPTION
As advertised. There's quite some intricate logic in the ckpt resuming and I would like to at least catch stupid bugs in CI. We now do 20 steps and write final ckpt for the first run, and then another 20 resumed in CI for a total of steps (before we did 30 steps). Given that server startup takes most of the time and we persist the inference server across the whole session, the total testing time should not be affected much.

Also fixes a minor bug where we write the final checkpoint twice (once inside the loop) and once outside if `ckpt.interval_steps` divides `max_steps`. Now adds a guard that checks that we are not on the last step inside the loop.

<img width="297" height="219" alt="Screenshot 2025-08-09 at 11 50 29 AM" src="https://github.com/user-attachments/assets/c08b1f2a-3a72-4580-abf6-73c1a1c6a06c" />

<img width="306" height="229" alt="Screenshot 2025-08-09 at 11 50 32 AM" src="https://github.com/user-attachments/assets/0ad27f6c-14f9-41e9-8c04-7790f6c27d75" />