### PR TITLE
Fix dataset shuffling with orchestrator seed

### DIFF
--- a/environments/vf_acereason_math/vf_acereason_math.py
+++ b/environments/vf_acereason_math/vf_acereason_math.py
@@ -18,7 +18,6 @@ def load_environment(
         }
     )
     train_dataset = train_dataset.remove_columns(["problem", "answer"])
-    train_dataset = train_dataset.shuffle(seed=42)
 
     def correct_answer_reward_func(completion, info, **kwargs) -> float:
         completion_text = completion[-1]["content"]

--- a/environments/vf_ascii_tree/vf_ascii_tree.py
+++ b/environments/vf_ascii_tree/vf_ascii_tree.py
@@ -17,7 +17,6 @@ def load_environment(**kwargs) -> vf.Environment:
         return example
 
     dataset = dataset.map(process_dataset)
-    dataset = dataset.shuffle(seed=42)
 
     parser = vf.XMLParser(["think", "ascii_formatted"], answer_field="ascii_formatted")
 

--- a/environments/vf_deepscaler_math/vf_deepscaler_math.py
+++ b/environments/vf_deepscaler_math/vf_deepscaler_math.py
@@ -18,7 +18,6 @@ def load_environment(
         }
     )
     train_dataset = train_dataset.remove_columns(["problem", "solution", "answer"])
-    train_dataset = train_dataset.shuffle(seed=42)
 
     def correct_answer_reward_func(completion, info, **kwargs) -> float:
         completion_text = completion[-1]["content"]

--- a/environments/vf_hendrycks_math/vf_hendrycks_math.py
+++ b/environments/vf_hendrycks_math/vf_hendrycks_math.py
@@ -17,7 +17,6 @@ def load_environment(**kwargs) -> vf.Environment:
         }
     )
     train_dataset = train_dataset.remove_columns(["prompt", "verification_info"])
-    train_dataset = train_dataset.shuffle(seed=42)
 
     parser = vf.ThinkParser(extract_fn=extract_boxed_answer)
 

--- a/environments/vf_intellect_math/vf_intellect_math.py
+++ b/environments/vf_intellect_math/vf_intellect_math.py
@@ -25,7 +25,6 @@ def load_environment(
         if max_solve_rate is not None:
             train_dataset = train_dataset.filter(lambda x: x[solve_rate_field] <= max_solve_rate)
     train_dataset = train_dataset.remove_columns(["prompt", "verification_info"])
-    train_dataset = train_dataset.shuffle(seed=42)
 
     def correct_answer_reward_func(completion, info, **kwargs) -> float:
         completion_text = completion[-1]["content"]

--- a/environments/vf_pydantic_adherence/vf_pydantic_adherence.py
+++ b/environments/vf_pydantic_adherence/vf_pydantic_adherence.py
@@ -146,7 +146,6 @@ def load_environment() -> vf.Environment:
     )
 
     dataset = dataset.remove_columns(["prompt", "verification_info"])
-    dataset = dataset.shuffle(seed=42)
 
     parser = PydanticParser(extract_fn=extract_last_json)
 

--- a/environments/vf_reverse_text/vf_reverse_text.py
+++ b/environments/vf_reverse_text/vf_reverse_text.py
@@ -13,8 +13,7 @@ def load_environment() -> vf.Environment:
             "task": x["task_type"],
         }
     )
-    train_dataset = train_dataset.remove_columns(["prompt", "verification_info", "task_type"])
-    train_dataset = train_dataset.shuffle(seed=42)
+    train_dataset = train_dataset.remove_columns(["prompt", "verification_info", "task_type"]) 
 
     parser = vf.XMLParser(["answer"], answer_field="answer")
 

--- a/environments/vf_skywork_math/vf_skywork_math.py
+++ b/environments/vf_skywork_math/vf_skywork_math.py
@@ -25,7 +25,6 @@ def load_environment(
         if max_solve_rate is not None:
             train_dataset = train_dataset.filter(lambda x: x[solve_rate_field] <= max_solve_rate)
     train_dataset = train_dataset.remove_columns(["prompt", "verification_info"])
-    train_dataset = train_dataset.shuffle(seed=42)
 
     def correct_answer_reward_func(completion, info, **kwargs) -> float:
         completion_text = completion[-1]["content"]

--- a/environments/vf_unscramble/vf_unscramble.py
+++ b/environments/vf_unscramble/vf_unscramble.py
@@ -17,7 +17,6 @@ def load_environment(**kwargs) -> vf.Environment:
         return example
 
     dataset = dataset.map(process_dataset)
-    dataset = dataset.shuffle(seed=42)
 
     parser = vf.XMLParser(["think", "unscrambled_text"], answer_field="unscrambled_text")
 

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -333,7 +333,7 @@ class OrchestratorConfig(BaseSettings):
         ),
     ] = False
 
-    seed: Annotated[int | None, Field(description="Random seed for the orchestrator.")] = 0
+    seed: Annotated[int | None, Field(description="Random seed for the orchestrator.")] = 42
 
     @model_validator(mode="after")
     def validate_batch_size(self):

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -333,7 +333,7 @@ class OrchestratorConfig(BaseSettings):
         ),
     ] = False
 
-    seed: Annotated[int | None, Field(description="Random seed for the orchestrator.")] = None
+    seed: Annotated[int | None, Field(description="Random seed for the orchestrator.")] = 0
 
     @model_validator(mode="after")
     def validate_batch_size(self):


### PR DESCRIPTION
> Note: My first issue PR with Cursor agents from Linear ticket. Quite cool

Centralize dataset shuffling by removing pre-shuffling in environment loaders and setting a default seed in the orchestrator config for reproducibility. To not shuffle the dataset, pass `--seed None`.

---
Linear Issue: [RES-879](https://linear.app/primeintellect/issue/RES-879/shuffle-dataset-dynamically-not-in-the-env-definition)

<a href="https://cursor.com/background-agent?bcId=bc-eba9ef84-95d1-4eb7-a82f-d2d7645ad546">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eba9ef84-95d1-4eb7-a82f-d2d7645ad546">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

