### PR TITLE
Implement checkpoint cleanup logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ checkpoints
     └── trainer.pt
 ```
 
-Checkpointing is configured by the `CheckpointConfig`, with the config key `--ckpt`. One can specify the interval (`--ckpt.interval`, defaults to `50`) and whether to save checkpoints asynchronoously  (`--ckpt.save-async`, defaults to `False`)
+Checkpointing is configured by the `CheckpointConfig`, with the config key `--ckpt`. One can specify the interval (`--ckpt.interval`, defaults to `50`), whether to save checkpoints asynchronoously  (`--ckpt.save-async`, defaults to `False`), and how many recent step checkpoints to keep on disk (`--ckpt.keep`, defaults to `None` which means no cleanup).
 
 By default, runs do no write checkpoints to save disk space. To checkpoint every 10 steps on our debug RL run, run the following command
 

--- a/src/prime_rl/orchestrator/ckpt.py
+++ b/src/prime_rl/orchestrator/ckpt.py
@@ -21,14 +21,10 @@ class CheckpointManager:
     """Utility class to save and load orchestrator checkpoints to resume orchestrator."""
 
     def __init__(self, outputs_dir: Path, config: CheckpointConfig):
+        self.config = config
         self.ckpt_dir = get_ckpt_dir(outputs_dir)
         self._logger = get_logger()
-        self.keep = config.keep
-        # Track saved checkpoint steps to avoid scanning directory
-        import threading
-
-        self._saved_steps: list[int] = []
-        self._lock = threading.Lock()
+        self.ckpt_steps: list[int] = []
 
     def _get_step_path(self, step: int) -> Path:
         return self.ckpt_dir / f"step_{step}"
@@ -36,7 +32,7 @@ class CheckpointManager:
     def _get_ckpt_path(self, step: int) -> Path:
         return self._get_step_path(step) / "orchestrator.pt"
 
-    def _save_to_path(self, ckpt_path: Path, progress: Progress):
+    def _save_to_path(self, ckpt_path: Path, ckpt_step: int, progress: Progress):
         self._logger.debug(f"Saving orchestrator checkpoint to {ckpt_path}")
         start_time = time.time()
 
@@ -47,16 +43,8 @@ class CheckpointManager:
         with open(ckpt_path, "wb") as f:
             torch.save(ckpt_state, f)
 
-        # Record saved step after successful write
-        try:
-            step_str = ckpt_path.parent.name.split("_")[-1]
-            step_num = int(step_str)
-            with self._lock:
-                self._saved_steps.append(step_num)
-                self._saved_steps.sort()
-        except Exception:
-            # Best-effort: ignore if parsing fails
-            pass
+        # Append to list of saved steps
+        self.ckpt_steps.append(ckpt_step)
 
         self._logger.debug(f"Orchestrator checkpoint saved in {time.time() - start_time:.2f} seconds")
 
@@ -75,31 +63,7 @@ class CheckpointManager:
 
         self._logger.debug(f"Orchestrator checkpoint loaded in {time.time() - start_time:.2f} seconds")
 
-    def maybe_clean(self, step: int):
-        """Delete past orchestrator checkpoints beyond the most recent `keep` steps. No-op if `keep` is None."""
-        if self.keep is None:
-            return
-        try:
-            with self._lock:
-                # Ensure sorted ascending
-                self._saved_steps.sort()
-                num_to_delete = max(0, len(self._saved_steps) - self.keep)
-                steps_to_delete = [self._saved_steps.pop(0) for _ in range(num_to_delete)]
-            for old_step in steps_to_delete:
-                path = self._get_ckpt_path(old_step)
-                if path.exists():
-                    self._logger.debug(f"Removing past orchestrator checkpoint {path}")
-                    try:
-                        path.unlink(missing_ok=True)
-                    except TypeError:
-                        try:
-                            path.unlink()
-                        except FileNotFoundError:
-                            pass
-        except Exception as e:
-            self._logger.warning(f"Failed to cleanup old orchestrator checkpoints: {e}")
-
-    def load(self, progress: Progress, step: int) -> Path:
+    def load(self, progress: Progress, step: int) -> None:
         """Loads a checkpoint from a given path."""
         ckpt_path = self._get_ckpt_path(step)
         if not ckpt_path.exists():
@@ -110,9 +74,29 @@ class CheckpointManager:
         self,
         progress: Progress,
         step: int,
-    ):
+    ) -> None:
         """Saves the full checkpoint state for a specified step."""
         step_path = self._get_step_path(step)
         step_path.mkdir(parents=True, exist_ok=True)
         ckpt_path = self._get_ckpt_path(step)
-        self._save_to_path(ckpt_path, progress)
+        self._save_to_path(ckpt_path, step, progress)
+
+    def maybe_clean(self) -> None:
+        """Deletes past orchestrator checkpoints beyond the most recent `keep` steps. No-op if `keep` is None."""
+        if self.config.keep is None:
+            return
+
+        # Get all the checkpoint steps to delete
+        assert list(self.ckpt_steps) == sorted(self.ckpt_steps)
+        ckpt_steps_to_keep = self.ckpt_steps[-self.config.keep :]
+        ckpt_steps_to_delete = self.ckpt_steps[: -self.config.keep]
+        for ckpt_step in ckpt_steps_to_delete:
+            ckpt_path = self._get_ckpt_path(ckpt_step)
+            if ckpt_path.exists():
+                self._logger.debug(
+                    f"Removing past orchestrator checkpoint for step {ckpt_step} ({ckpt_path}), because got checkpoints for {ckpt_steps_to_keep} ({len(self.ckpt_steps)} > {self.config.keep})"
+                )
+                ckpt_path.unlink(missing_ok=True)
+
+        # Update checkpoint steps
+        self.ckpt_steps = self.ckpt_steps[-self.config.keep :]

--- a/src/prime_rl/orchestrator/ckpt.py
+++ b/src/prime_rl/orchestrator/ckpt.py
@@ -23,6 +23,7 @@ class CheckpointManager:
     def __init__(self, outputs_dir: Path, config: CheckpointConfig):
         self.ckpt_dir = get_ckpt_dir(outputs_dir)
         self._logger = get_logger()
+        self._keep = getattr(config, "keep", None)
 
     def _get_step_path(self, step: int) -> Path:
         return self.ckpt_dir / f"step_{step}"
@@ -58,6 +59,32 @@ class CheckpointManager:
 
         self._logger.debug(f"Orchestrator checkpoint loaded in {time.time() - start_time:.2f} seconds")
 
+    def _cleanup_old_checkpoints(self):
+        if not self._keep:
+            return
+        try:
+            # Collect step directories of the form step_<int>
+            step_dirs = []
+            if self.ckpt_dir.exists():
+                for child in self.ckpt_dir.iterdir():
+                    if child.is_dir() and child.name.startswith("step_"):
+                        try:
+                            step_num = int(child.name.split("_")[-1])
+                            step_dirs.append((step_num, child))
+                        except ValueError:
+                            continue
+            # Sort by step number descending (newest first)
+            step_dirs.sort(key=lambda x: x[0], reverse=True)
+            # Determine which to delete beyond the first `keep`
+            to_delete = step_dirs[self._keep :]
+            for step_num, path in to_delete:
+                self._logger.debug(f"Removing past orchestrator checkpoint {path}")
+                import shutil
+
+                shutil.rmtree(path, ignore_errors=True)
+        except Exception as e:
+            self._logger.warning(f"Failed to cleanup old orchestrator checkpoints: {e}")
+
     def load(self, progress: Progress, step: int) -> Path:
         """Loads a checkpoint from a given path."""
         ckpt_path = self._get_ckpt_path(step)
@@ -75,3 +102,6 @@ class CheckpointManager:
         step_path.mkdir(parents=True, exist_ok=True)
         ckpt_path = self._get_ckpt_path(step)
         self._save_to_path(ckpt_path, progress)
+
+        # Cleanup old checkpoints after saving
+        self._cleanup_old_checkpoints()

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -127,6 +127,14 @@ class CheckpointConfig(BaseConfig):
         ),
     ] = None
 
+    keep: Annotated[
+        int | None,
+        Field(
+            ge=1,
+            description="Keep at most this many recent step checkpoints on disk. If None, never clean old checkpoints.",
+        ),
+    ] = None
+
 
 class SimpleBufferConfig(BaseModel):
     type: Literal["simple"] = "simple"

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -111,6 +111,8 @@ async def orchestrate(config: OrchestratorConfig):
             save_ckpt_start_time = time.time()
             ckpt_manager.save(progress, step=progress.step)
             save_ckpt_time = time.time() - save_ckpt_start_time
+            # Maybe clean up old orchestrator checkpoints
+            ckpt_manager.maybe_clean(progress.step)
 
         # Break if we have reached the maximum number of steps
         if config.max_steps and progress.step >= config.max_steps:

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -111,8 +111,9 @@ async def orchestrate(config: OrchestratorConfig):
             save_ckpt_start_time = time.time()
             ckpt_manager.save(progress, step=progress.step)
             save_ckpt_time = time.time() - save_ckpt_start_time
+
             # Maybe clean up old orchestrator checkpoints
-            ckpt_manager.maybe_clean(progress.step)
+            ckpt_manager.maybe_clean()
 
         # Break if we have reached the maximum number of steps
         if config.max_steps and progress.step >= config.max_steps:

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -76,6 +76,14 @@ class CheckpointConfig(BaseSettings):
         int | None, Field(description="The step to resume from. If None, will not resume from a checkpoint.")
     ] = None
 
+    keep: Annotated[
+        int | None,
+        Field(
+            ge=1,
+            description="Keep at most this many recent step checkpoints on disk. If None, never clean old checkpoints.",
+        ),
+    ] = None
+
 
 class RLConfig(BaseSettings):
     """Configures an RL training run."""
@@ -216,6 +224,11 @@ class RLConfig(BaseSettings):
             if self.ckpt.resume_step:
                 self.trainer.ckpt.resume_step = self.ckpt.resume_step
                 self.orchestrator.ckpt.resume_step = self.ckpt.resume_step
+
+            # If specified, propagate keep policy
+            if self.ckpt.keep:
+                self.trainer.ckpt.keep = self.ckpt.keep
+                self.orchestrator.ckpt.keep = self.ckpt.keep
 
         validate_shared_ckpt_config(self.trainer, self.orchestrator)
 

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -29,6 +29,8 @@ class CheckpointManager:
         self.save_async = config.save_async
         self._logger = get_logger()
         self._world = get_world()
+        self._is_master = self._world.rank == 0
+        self._keep = getattr(config, "keep", None)
 
     def _get_step_path(self, step: int) -> Path:
         return self.ckpt_dir / f"step_{step}"
@@ -88,6 +90,36 @@ class CheckpointManager:
             raise FileNotFoundError(f"Checkpoint not found at {ckpt_path}")
         self._load_from_path(ckpt_path, model, optimizers, scheduler, progress)
 
+    def _cleanup_old_checkpoints(self):
+        if not self._keep:
+            return
+        # Only master rank should perform cleanup to avoid races between ranks
+        if not getattr(self, "_is_master", True):
+            return
+        try:
+            # Collect step directories of the form step_<int>
+            step_dirs = []
+            if self.ckpt_dir.exists():
+                for child in self.ckpt_dir.iterdir():
+                    if child.is_dir() and child.name.startswith("step_"):
+                        try:
+                            step_num = int(child.name.split("_")[-1])
+                            step_dirs.append((step_num, child))
+                        except ValueError:
+                            continue
+            # Sort by step number descending (newest first)
+            step_dirs.sort(key=lambda x: x[0], reverse=True)
+            # Determine which to delete beyond the first `keep`
+            to_delete = step_dirs[self._keep :]
+            for step_num, path in to_delete:
+                self._logger.debug(f"Removing past full checkpoint {path}")
+                # Remove directory tree safely
+                import shutil
+
+                shutil.rmtree(path, ignore_errors=True)
+        except Exception as e:
+            self._logger.warning(f"Failed to cleanup old checkpoints: {e}")
+
     def save(
         self,
         model: Model,
@@ -112,3 +144,6 @@ class CheckpointManager:
         else:
             # Run save synchronously
             self._save_to_path(ckpt_path, model, optimizers, scheduler, progress)
+
+        # Cleanup old checkpoints after saving
+        self._cleanup_old_checkpoints()

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -25,14 +25,12 @@ class CheckpointManager:
     """Utility class to save and load training checkpoints to resume training."""
 
     def __init__(self, outputs_dir: Path, config: CheckpointConfig):
+        self.config = config
         self.ckpt_dir = get_ckpt_dir(outputs_dir)
-        self.save_async = config.save_async
         self._logger = get_logger()
         self._world = get_world()
         self._is_master = self._world.rank == 0
-        self.keep = config.keep
-        self._saved_steps: list[int] = []
-        self._lock = threading.Lock()
+        self.ckpt_steps: list[int] = []  # Sorted list of steps that have been checkpointed, only used on master rank
 
     def _get_step_path(self, step: int) -> Path:
         return self.ckpt_dir / f"step_{step}"
@@ -42,7 +40,13 @@ class CheckpointManager:
         return self._get_step_path(step) / ckpt_name
 
     def _save_to_path(
-        self, ckpt_path: Path, model: Model, optimizers: list[Optimizer], scheduler: LRScheduler, progress: Progress
+        self,
+        ckpt_path: Path,
+        ckpt_step: int,
+        model: Model,
+        optimizers: list[Optimizer],
+        scheduler: LRScheduler,
+        progress: Progress,
     ):
         self._logger.debug(f"Saving training checkpoint to {ckpt_path}")
         start_time = time.time()
@@ -58,16 +62,11 @@ class CheckpointManager:
         ckpt_path.parent.mkdir(parents=True, exist_ok=True)
         with open(ckpt_path, "wb") as f:
             torch.save(ckpt_state, f)
-        # Record saved step after successful write
-        try:
-            step_str = ckpt_path.parent.name.split("_")[-1]
-            step_num = int(step_str)
-            with self._lock:
-                self._saved_steps.append(step_num)
-                self._saved_steps.sort()
-        except Exception:
-            # Best-effort: ignore if parsing fails
-            pass
+
+        # Append to list of saved steps
+        if self._is_master:
+            self.ckpt_steps.append(ckpt_step)
+
         self._logger.debug(f"Training checkpoint saved in {time.time() - start_time:.2f} seconds")
 
     def _load_from_path(
@@ -102,37 +101,6 @@ class CheckpointManager:
             raise FileNotFoundError(f"Checkpoint not found at {ckpt_path}")
         self._load_from_path(ckpt_path, model, optimizers, scheduler, progress)
 
-    def maybe_clean(self, step: int):
-        """Delete this rank's past trainer checkpoints beyond the most recent `keep` steps.
-        No-op if `keep` is None. Only executes on master rank to avoid races.
-        """
-        if self.keep is None:
-            return
-        if not self._is_master:
-            return
-        try:
-            with self._lock:
-                # Ensure sorted ascending
-                self._saved_steps.sort()
-                # Determine how many to delete
-                num_to_delete = max(0, len(self._saved_steps) - self.keep)
-                steps_to_delete = [self._saved_steps.pop(0) for _ in range(num_to_delete)]
-            # Delete only this rank's trainer checkpoint file for those steps
-            for old_step in steps_to_delete:
-                path = self._get_ckpt_path(old_step)
-                if path.exists():
-                    self._logger.debug(f"Removing past trainer checkpoint {path}")
-                    try:
-                        path.unlink(missing_ok=True)
-                    except TypeError:
-                        # For Python versions without missing_ok
-                        try:
-                            path.unlink()
-                        except FileNotFoundError:
-                            pass
-        except Exception as e:
-            self._logger.warning(f"Failed to cleanup old trainer checkpoints: {e}")
-
     def save(
         self,
         model: Model,
@@ -140,20 +108,40 @@ class CheckpointManager:
         scheduler: LRScheduler,
         progress: Progress,
         step: int,
-    ):
+    ) -> None:
         """Saves the full checkpoint state for a specified step."""
         step_path = self._get_step_path(step)
         step_path.mkdir(parents=True, exist_ok=True)
         ckpt_path = self._get_ckpt_path(step)
 
-        if self.save_async:
+        if self.config.save_async:
             # Run save in a separate thread
             thread = threading.Thread(
                 target=self._save_to_path,
-                args=(ckpt_path, model, optimizers, scheduler, progress),
+                args=(ckpt_path, step, model, optimizers, scheduler, progress),
                 name=f"ckpt-save-{step}",
             )
             thread.start()
         else:
             # Run save synchronously
-            self._save_to_path(ckpt_path, model, optimizers, scheduler, progress)
+            self._save_to_path(ckpt_path, step, model, optimizers, scheduler, progress)
+
+    def maybe_clean(self) -> None:
+        """Deletes past local checkpoints beyond the most recent `config.keep` steps. No-op if `config.keep` is None."""
+        if self.config.keep is None:
+            return
+
+        # Get all the checkpoint steps to delete
+        assert list(self.ckpt_steps) == sorted(self.ckpt_steps)
+        ckpt_steps_to_keep = self.ckpt_steps[-self.config.keep :]
+        ckpt_steps_to_delete = self.ckpt_steps[: -self.config.keep]
+        for ckpt_step in ckpt_steps_to_delete:
+            ckpt_path = self._get_ckpt_path(ckpt_step)
+            if ckpt_path.exists():
+                self._logger.debug(
+                    f"Removing past trainer checkpoint for step {ckpt_step} ({ckpt_path}), because got checkpoints for {ckpt_steps_to_keep} ({len(self.ckpt_steps)} > {self.config.keep})"
+                )
+                ckpt_path.unlink(missing_ok=True)
+
+        # Update checkpoint steps
+        self.ckpt_steps = self.ckpt_steps[-self.config.keep :]

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -113,6 +113,14 @@ class CheckpointConfig(BaseConfig):
         ),
     ] = None
 
+    keep: Annotated[
+        int | None,
+        Field(
+            ge=1,
+            description="Keep at most this many recent step checkpoints on disk. If None, never clean old checkpoints.",
+        ),
+    ] = None
+
 
 class WeightCheckpointConfig(BaseConfig):
     """Configures checkpointing the model weights for updating the inference engines."""

--- a/src/prime_rl/trainer/train.py
+++ b/src/prime_rl/trainer/train.py
@@ -162,6 +162,8 @@ def train(config: TrainerConfig):
             save_ckpt_start_time = time.time()
             ckpt_manager.save(model, [optimizer], scheduler, progress, step=progress.step)
             save_ckpt_time = time.time() - save_ckpt_start_time
+            # Maybe clean up old trainer checkpoints
+            ckpt_manager.maybe_clean(progress.step)
 
         # Break if we have reached the maximum number of steps
         if config.max_steps is not None and progress.step >= config.max_steps:

--- a/src/prime_rl/trainer/train.py
+++ b/src/prime_rl/trainer/train.py
@@ -162,8 +162,9 @@ def train(config: TrainerConfig):
             save_ckpt_start_time = time.time()
             ckpt_manager.save(model, [optimizer], scheduler, progress, step=progress.step)
             save_ckpt_time = time.time() - save_ckpt_start_time
+
             # Maybe clean up old trainer checkpoints
-            ckpt_manager.maybe_clean(progress.step)
+            ckpt_manager.maybe_clean()
 
         # Break if we have reached the maximum number of steps
         if config.max_steps is not None and progress.step >= config.max_steps:

--- a/src/prime_rl/trainer/weights.py
+++ b/src/prime_rl/trainer/weights.py
@@ -109,7 +109,6 @@ class WeightCheckpointManager:
         """Synchronous helper of `clean`."""
         step = max(step - (self.async_level + 1), 0)  # Consider deleting async_level + 1 steps ago
         candidate_path_to_delete = self._get_step_path(step)
-        self._logger.debug(f"Considering to delete weight checkpoint {candidate_path_to_delete}")
         keep_for_eval = self.config.interval and step % self.config.interval == 0
         # For checkpointing step x, we need all weight checkpoints in [x-async_level, x] (for logprob model)
         # To get [n-k, n] with interval n and buffer k over all natural numbers x, we use the condition (n - (x % n)) % n <= k


### PR DESCRIPTION
Implement checkpoint cleanup logic with a new `--ckpt.keep` option to retain a specified number of recent step checkpoints.

This PR adds an optional `--ckpt.keep` configuration key (int | None) to the `CheckpointManager` for both trainer and orchestrator. If set to an integer, it will automatically delete older `step_{x}` checkpoint directories, ensuring only the `keep` most recent ones are preserved. This addresses the lack of cleanup logic and helps manage disk space. The default behavior (`None`) is to keep all checkpoints. Each local trainer and orchestrator is responsible for managing its own checkpoint. This also means that we never delete the parent step directory, but this should be fine imo

Here is an example of only retaining two checkpoints:

```bash
uv run rl  \
  --trainer @ configs/reverse_text/train.toml \
   --orchestrator @ configs/reverse_text/orch.toml \
   --ckpt.keep 2 \
   --ckpt.interval 2 \
   --log.level debug \
   --outputs-dir /workspace/outputs
```

<img width="338" height="164" alt="Screenshot 2025-08-10 at 4 17 42 PM" src="https://github.com/user-attachments/assets/2c4a7d4e-a1da-46e6-b3f8-de136ac99194" />


---
Linear Issue: [RES-784](https://linear.app/primeintellect/issue/RES-784/implement-cleaning-checkpoint-logic)

