### PR TITLE
Make no recompute the default

### DIFF
--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -235,7 +235,7 @@ class TrainerConfig(BaseSettings):
         Field(
             description="Whether to recompute the logprobs. If True, will always recompute logprobs and overwrite those found in the training batch.",
         ),
-    ] = True
+    ] = False
 
     bench: Annotated[
         bool,


### PR DESCRIPTION
No recompute is giving us very stable runs and allows us to use vllm v1.
Also is technically recompute but with the mismatch fix from https://fengyao.notion.site/off-policy-rl