### PR TITLE
Align setup naming logic

### DIFF
--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -21,14 +21,7 @@ from prime_rl.trainer.config import ModelConfig
 Model: TypeAlias = LlamaForCausalLM | Qwen2ForCausalLM | Qwen3ForCausalLM
 
 
-def get_model(config: ModelConfig) -> Model:
-    config_model = AutoConfig.from_pretrained(config.name, attn_implementation=config.attn)
-    config_model.use_cache = False
-    model = AutoModelForCausalLM.from_pretrained(pretrained_model_name_or_path=config.name, config=config_model)
-    return model
-
-
-def get_tokenizer(config: ModelConfig) -> AutoTokenizer:
+def setup_tokenizer(config: ModelConfig) -> AutoTokenizer:
     tokenizer = AutoTokenizer.from_pretrained(config.name)
     tokenizer.pad_token_id = tokenizer.eos_token_id
     return tokenizer
@@ -65,7 +58,9 @@ def setup_ac(model: Model, config: ModelConfig) -> None:
 
 
 def setup_model(config: ModelConfig) -> Model:
-    model = get_model(config)
+    config_model = AutoConfig.from_pretrained(config.name, attn_implementation=config.attn)
+    config_model.use_cache = False
+    model = AutoModelForCausalLM.from_pretrained(pretrained_model_name_or_path=config.name, config=config_model)
     setup_fsdp(model, config)
     setup_ac(model, config)
     if config.compile:

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -21,6 +21,13 @@ from prime_rl.trainer.config import ModelConfig
 Model: TypeAlias = LlamaForCausalLM | Qwen2ForCausalLM | Qwen3ForCausalLM
 
 
+def get_model(config: ModelConfig) -> Model:
+    config_model = AutoConfig.from_pretrained(config.name, attn_implementation=config.attn)
+    config_model.use_cache = False
+    model = AutoModelForCausalLM.from_pretrained(pretrained_model_name_or_path=config.name, config=config_model)
+    return model
+
+
 def setup_tokenizer(config: ModelConfig) -> AutoTokenizer:
     tokenizer = AutoTokenizer.from_pretrained(config.name)
     tokenizer.pad_token_id = tokenizer.eos_token_id
@@ -58,9 +65,7 @@ def setup_ac(model: Model, config: ModelConfig) -> None:
 
 
 def setup_model(config: ModelConfig) -> Model:
-    config_model = AutoConfig.from_pretrained(config.name, attn_implementation=config.attn)
-    config_model.use_cache = False
-    model = AutoModelForCausalLM.from_pretrained(pretrained_model_name_or_path=config.name, config=config_model)
+    model = get_model(config)
     setup_fsdp(model, config)
     setup_ac(model, config)
     if config.compile:

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -20,10 +20,10 @@ from prime_rl.trainer.rl.loss import (
     selective_log_softmax,
     compute_entropy,
 )
-from prime_rl.trainer.scheduler import create_lr_scheduler
+from prime_rl.trainer.scheduler import setup_scheduler
 from prime_rl.trainer.model import (
     forward,
-    get_tokenizer,
+    setup_tokenizer,
     reshard_module,
     setup_model,
 )
@@ -73,7 +73,7 @@ def train(config: RLTrainerConfig):
     # Initialize the model and tokenizer
     logger.info(f"Initializing model and tokenizer ({config.model})")
     model = setup_model(config.model)
-    tokenizer = get_tokenizer(config.model)
+    tokenizer = setup_tokenizer(config.model)
 
     # Set up the optimizer
     logger.info(f"Initializing optimizer ({config.optim})")
@@ -82,7 +82,7 @@ def train(config: RLTrainerConfig):
     optimizer = setup_optimizer(config.optim, model)
 
     # Set up the learning rate scheduler
-    scheduler = create_lr_scheduler(optimizer, config.scheduler, config.max_steps)
+    scheduler = setup_scheduler(optimizer, config.scheduler, config.max_steps)
     logger.info(f"Using `{config.scheduler.type}` scheduler ({config.scheduler})")
 
     # Get checkpoint managers

--- a/src/prime_rl/trainer/scheduler.py
+++ b/src/prime_rl/trainer/scheduler.py
@@ -15,7 +15,7 @@ class ConstantLRScheduler(LRScheduler):
         return [group["lr"] for group in self.optimizer.param_groups]
 
 
-def create_lr_scheduler(optimizer: Optimizer, config: SchedulerConfigType, max_steps: int | None) -> LRScheduler:
+def setup_scheduler(optimizer: Optimizer, config: SchedulerConfigType, max_steps: int | None) -> LRScheduler:
     """Create learning rate scheduler based on config."""
 
     if config.type == "constant":

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -11,10 +11,10 @@ from prime_rl.trainer.weights import WeightCheckpointManager
 from prime_rl.trainer.sft.config import SFTTrainerConfig
 from prime_rl.trainer.logger import setup_logger
 from prime_rl.trainer.optim import setup_optimizer
-from prime_rl.trainer.scheduler import create_lr_scheduler
+from prime_rl.trainer.scheduler import setup_scheduler
 from prime_rl.trainer.model import (
     forward,
-    get_tokenizer,
+    setup_tokenizer,
     setup_model,
 )
 from prime_rl.trainer.perf import get_perf_counter
@@ -52,14 +52,14 @@ def train(config: SFTTrainerConfig):
     # Initialize the model and tokenizer
     logger.info(f"Initializing model and tokenizer ({config.model})")
     model = setup_model(config.model)
-    tokenizer = get_tokenizer(config.model)
+    tokenizer = setup_tokenizer(config.model)
 
     # Set up the optimizer
     logger.info(f"Initializing optimizer ({config.optim})")
     optimizer = setup_optimizer(config.optim, model)
 
     # Set up the learning rate scheduler
-    scheduler = create_lr_scheduler(optimizer, config.scheduler, config.max_steps)
+    scheduler = setup_scheduler(optimizer, config.scheduler, config.max_steps)
     logger.info(f"Using `{config.scheduler.type}` scheduler ({config.scheduler})")
 
     # Get checkpoint manager


### PR DESCRIPTION
Rename any function that initializes an object to `setup_{x}`, e.g. `setup_logger`, `setup_optimizer`, `setup_model`, etc.