### PR TITLE
Misc SFT improvements

### DIFF
--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -67,6 +67,8 @@ class CosineSchedulerConfig(BaseModel):
 
     warmup_steps: Annotated[int, Field(ge=0, description="Number of warmup steps for the learning rate scheduler.")] = 0
 
+    min_lr: Annotated[float, Field(ge=0, description="Minimum learning rate to converge to.")] = 0.0
+
     decay_steps: Annotated[
         int | None,
         Field(

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -149,7 +149,7 @@ class RLTrainerConfig(BaseSettings):
 
         # If decay_steps is not specified, use remaining steps after warmup
         if self.scheduler.decay_steps is None:
-            if not (self.warmup_steps <= self.max_steps):
+            if not (self.scheduler.warmup_steps <= self.max_steps):
                 raise ValueError("config.scheduler.warmup_steps must be less than or equal to config.max_steps")
 
             self.scheduler.decay_steps = self.max_steps - self.scheduler.warmup_steps

--- a/src/prime_rl/trainer/scheduler.py
+++ b/src/prime_rl/trainer/scheduler.py
@@ -52,7 +52,7 @@ def setup_scheduler(optimizer: Optimizer, config: SchedulerConfigType, max_steps
     if config.type == "linear":
         decay_scheduler = LinearLR(optimizer, start_factor=1.0, end_factor=0.0, total_iters=decay_steps)
     elif config.type == "cosine":
-        decay_scheduler = CosineAnnealingLR(optimizer, T_max=decay_steps, eta_min=0.0)
+        decay_scheduler = CosineAnnealingLR(optimizer, T_max=decay_steps, eta_min=config.min_lr)
 
     schedulers.append(decay_scheduler)
 

--- a/src/prime_rl/trainer/sft/config.py
+++ b/src/prime_rl/trainer/sft/config.py
@@ -22,7 +22,7 @@ class DataConfig(BaseConfig):
     name: Annotated[str, Field(description="Name or path of the HF dataset to use.")] = (
         "PrimeIntellect/Reverse-Text-SFT"
     )
-    split: Annotated[str, Field(description="Split to use from the HF dataset.")] = "train"
+    splits: Annotated[list[str], Field(description="Splits to use from the HF dataset.")] = ["train"]
     collate_mode: Annotated[Literal["padding", "packing"], Field(description="Collate mode to use.")] = "packing"
     micro_batch_size: Annotated[int, Field(ge=1)] = 8
     batch_size: Annotated[int, Field(ge=1)] = 128

--- a/src/prime_rl/trainer/sft/config.py
+++ b/src/prime_rl/trainer/sft/config.py
@@ -108,7 +108,7 @@ class SFTTrainerConfig(BaseSettings):
 
         # If decay_steps is not specified, use remaining steps after warmup
         if self.scheduler.decay_steps is None:
-            if not (self.warmup_steps <= self.max_steps):
+            if not (self.scheduler.warmup_steps <= self.max_steps):
                 raise ValueError("config.scheduler.warmup_steps must be less than or equal to config.max_steps")
 
             self.scheduler.decay_steps = self.max_steps - self.scheduler.warmup_steps

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -78,7 +78,7 @@ def train(config: SFTTrainerConfig):
     )
 
     # Set up the dataset and dataloader (optionaly, use a fake dataset for debugging)
-    logger.info(f"Initializing dataset (name={config.data.name}, split={config.data.split})")
+    logger.info(f"Initializing dataset (name={config.data.name}, splits={config.data.splits})")
     dataset = setup_dataset(tokenizer, config.data)
 
     # Set up the dataloader over micro batches


### PR DESCRIPTION
Misc fixes/ improvements to SFT trainer in the process of getting a larger run going, changes include:
- Supports specifying multiple splits to train on (`--splits nemotron_math,nemotron_code`)
- Add `min_lr` to cosine learning rate scheduler
- Shuffle data at beginning of each epoch to avoid oscillations
- Pass data config to dataset directly (less renaming)
- Fix a attribute not defined but caused by moving scheduler config to root level