### PR TITLE
Integrate GEPA via rl --gepa with acceptance gate and Pareto selection

### DIFF
--- a/configs/reverse_text/gepa.toml
+++ b/configs/reverse_text/gepa.toml
@@ -1,0 +1,34 @@
+[model]
+name = "Qwen/Qwen3-0.6B"
+
+[evaluate]
+benchmarks = ["math500"]
+subset_size = 32
+rollouts_per_prompt = 1
+max_tokens = 64
+min_tokens = 0
+
+[operators]
+mutation_rate = 0.7
+crossover_rate = 0.3
+max_prompt_chars = 2000
+enforce_diversity = true
+min_levenshtein_distance = 40
+
+[selection]
+strategy = "top-k"
+k = 6
+keep_elite = 2
+
+population_size = 8
+generations = 3
+seed = 42
+
+[log]
+level = "info"
+
+[monitor]
+# Enable W&B by adding a [monitor.wandb] section externally if desired
+system_log_frequency = 0
+
+

--- a/environments/vf_acereason_math/vf_acereason_math.py
+++ b/environments/vf_acereason_math/vf_acereason_math.py
@@ -8,6 +8,7 @@ def load_environment(
     solve_rate_field: str | None = None,
     min_solve_rate: float | None = None,
     max_solve_rate: float | None = None,
+    system_prompt: str | None = None,
     **kwargs,
 ) -> vf.Environment:
     train_dataset = load_dataset("nvidia/AceReason-Math", split="train").map(
@@ -30,5 +31,9 @@ def load_environment(
         weights=[1.0],
     )
 
-    vf_env = vf.SingleTurnEnv(dataset=train_dataset, rubric=rubric)
+    vf_env = (
+        vf.SingleTurnEnv(dataset=train_dataset, rubric=rubric, system_prompt=system_prompt)
+        if system_prompt is not None
+        else vf.SingleTurnEnv(dataset=train_dataset, rubric=rubric)
+    )
     return vf_env

--- a/environments/vf_deepscaler_math/vf_deepscaler_math.py
+++ b/environments/vf_deepscaler_math/vf_deepscaler_math.py
@@ -8,6 +8,7 @@ def load_environment(
     solve_rate_field: str | None = None,
     min_solve_rate: float | None = None,
     max_solve_rate: float | None = None,
+    system_prompt: str | None = None,
     **kwargs,
 ) -> vf.Environment:
     train_dataset = load_dataset("agentica-org/DeepScaleR-Preview-Dataset", split="train").map(
@@ -30,5 +31,9 @@ def load_environment(
         weights=[1.0],
     )
 
-    vf_env = vf.SingleTurnEnv(dataset=train_dataset, rubric=rubric)
+    vf_env = (
+        vf.SingleTurnEnv(dataset=train_dataset, rubric=rubric, system_prompt=system_prompt)
+        if system_prompt is not None
+        else vf.SingleTurnEnv(dataset=train_dataset, rubric=rubric)
+    )
     return vf_env

--- a/environments/vf_hendrycks_math/vf_hendrycks_math.py
+++ b/environments/vf_hendrycks_math/vf_hendrycks_math.py
@@ -2,7 +2,7 @@ import verifiers as vf
 from datasets import load_dataset
 
 
-def load_environment(**kwargs) -> vf.Environment:
+def load_environment(system_prompt: str | None = None, **kwargs) -> vf.Environment:
     import json
 
     from verifiers.utils.data_utils import extract_boxed_answer
@@ -31,5 +31,9 @@ def load_environment(**kwargs) -> vf.Environment:
         weights=[1.0],
     )
 
-    vf_env = vf.SingleTurnEnv(dataset=train_dataset, parser=parser, rubric=rubric)
+    # Pass optional system prompt if provided (SingleTurnEnv supports it)
+    if system_prompt is not None:
+        vf_env = vf.SingleTurnEnv(dataset=train_dataset, parser=parser, rubric=rubric, system_prompt=system_prompt)
+    else:
+        vf_env = vf.SingleTurnEnv(dataset=train_dataset, parser=parser, rubric=rubric)
     return vf_env

--- a/environments/vf_intellect_math/vf_intellect_math.py
+++ b/environments/vf_intellect_math/vf_intellect_math.py
@@ -6,6 +6,7 @@ def load_environment(
     solve_rate_field: str | None = None,
     min_solve_rate: float | None = None,
     max_solve_rate: float | None = None,
+    system_prompt: str | None = None,
     **kwargs,
 ) -> vf.Environment:
     import json
@@ -37,5 +38,9 @@ def load_environment(
         weights=[1.0],
     )
 
-    vf_env = vf.SingleTurnEnv(dataset=train_dataset, rubric=rubric)
+    vf_env = (
+        vf.SingleTurnEnv(dataset=train_dataset, rubric=rubric, system_prompt=system_prompt)
+        if system_prompt is not None
+        else vf.SingleTurnEnv(dataset=train_dataset, rubric=rubric)
+    )
     return vf_env

--- a/environments/vf_pydantic_adherence/vf_pydantic_adherence.py
+++ b/environments/vf_pydantic_adherence/vf_pydantic_adherence.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 from verifiers import Messages, Parser
 
 
-def load_environment() -> vf.Environment:
+def load_environment(system_prompt: str | None = None) -> vf.Environment:
     """
     Loads a custom environment.
     """
@@ -169,10 +169,6 @@ def load_environment() -> vf.Environment:
         weights=[1.0],
     )
 
-    vf_env = vf.SingleTurnEnv(
-        dataset=dataset,
-        parser=parser,
-        rubric=rubric,
-    )
+    vf_env = vf.SingleTurnEnv(dataset=dataset, parser=parser, rubric=rubric, system_prompt=system_prompt) if system_prompt is not None else vf.SingleTurnEnv(dataset=dataset, parser=parser, rubric=rubric)
 
     return vf_env

--- a/environments/vf_reverse_text/vf_reverse_text.py
+++ b/environments/vf_reverse_text/vf_reverse_text.py
@@ -2,7 +2,7 @@ import verifiers as vf
 from datasets import load_dataset
 
 
-def load_environment() -> vf.Environment:
+def load_environment(system_prompt: str | None = None) -> vf.Environment:
     train_dataset = load_dataset("PrimeIntellect/Reverse-Text-RL", split="train").map(
         lambda x: {
             "question": x["prompt"],
@@ -38,7 +38,8 @@ def load_environment() -> vf.Environment:
         weights=[1.0],
     )
 
-    system_prompt = "Reverse the text character-by-character. Put your answer in <reversed_text> tags."
+    base_system_prompt = "Reverse the text character-by-character. Put your answer in <reversed_text> tags."
+    system_prompt = system_prompt or base_system_prompt
 
     vf_env = vf.SingleTurnEnv(
         dataset=train_dataset,

--- a/environments/vf_skywork_math/vf_skywork_math.py
+++ b/environments/vf_skywork_math/vf_skywork_math.py
@@ -10,6 +10,7 @@ def load_environment(
     solve_rate_field: str | None = None,
     min_solve_rate: float | None = None,
     max_solve_rate: float | None = None,
+    system_prompt: str | None = None,
     **kwargs,
 ) -> vf.Environment:
     train_dataset = load_dataset("PrimeIntellect/Skywork-OR1-RL-Data-v1-math-prime-rl-format", split="train").map(
@@ -37,5 +38,9 @@ def load_environment(
         weights=[1.0],
     )
 
-    vf_env = vf.SingleTurnEnv(dataset=train_dataset, rubric=rubric)
+    vf_env = (
+        vf.SingleTurnEnv(dataset=train_dataset, rubric=rubric, system_prompt=system_prompt)
+        if system_prompt is not None
+        else vf.SingleTurnEnv(dataset=train_dataset, rubric=rubric)
+    )
     return vf_env

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ orchestrator = "prime_rl.orchestrator.orchestrator:main"
 inference = "prime_rl.inference.server:main"
 sft = "prime_rl.trainer.sft.train:main"
 eval = "prime_rl.eval.eval:main"
+gepa = "prime_rl.optimizer.gepa.gepa:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/prime_rl/optimizer/__init__.py
+++ b/src/prime_rl/optimizer/__init__.py
@@ -1,0 +1,8 @@
+"""
+Optimization utilities and algorithms (e.g., GEPA) for prompt and policy search.
+
+This namespace houses optimizers that orchestrate search procedures using the
+existing inference, evaluation, and monitoring infrastructures.
+"""
+
+

--- a/src/prime_rl/optimizer/gepa/config.py
+++ b/src/prime_rl/optimizer/gepa/config.py
@@ -3,9 +3,9 @@ from typing import Annotated, Literal
 
 from pydantic import Field
 
-from prime_rl.utils.config import LogConfig, MultiMonitorConfig, ModelConfig
 from prime_rl.inference.config import InferenceConfig
 from prime_rl.orchestrator.config import ClientConfig
+from prime_rl.utils.config import LogConfig, MultiMonitorConfig, ModelConfig
 from prime_rl.utils.pydantic_config import BaseConfig, BaseSettings
 
 

--- a/src/prime_rl/optimizer/gepa/config.py
+++ b/src/prime_rl/optimizer/gepa/config.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+from typing import Annotated, Literal
+
+from pydantic import Field
+
+from prime_rl.utils.config import LogConfig, MultiMonitorConfig, ModelConfig
+from prime_rl.inference.config import InferenceConfig
+from prime_rl.orchestrator.config import ClientConfig
+from prime_rl.utils.pydantic_config import BaseConfig, BaseSettings
+
+
+class EvaluateConfig(BaseConfig):
+    """Evaluation settings for GEPA prompt scoring."""
+
+    benchmark: Annotated[str, Field(description="Benchmark/dataset to evaluate on.")] = "math500"
+    rollouts_per_prompt: Annotated[int, Field(ge=1)] = 1
+    pareto_size: Annotated[int, Field(ge=1, description="Number of instances in D_pareto.")] = 64
+    feedback_pool_size: Annotated[int, Field(ge=1, description="Number of instances in D_feedback pool.")] = 256
+    max_tokens: Annotated[int | None, Field(description="Max generated tokens per completion.")] = None
+    min_tokens: Annotated[int, Field(ge=0)] = 0
+
+
+class OperatorsConfig(BaseConfig):
+    """Mutation/crossover operator rates and constraints."""
+
+    mutation_rate: Annotated[float, Field(ge=0, le=1)] = 0.7
+    crossover_rate: Annotated[float, Field(ge=0, le=1)] = 0.3
+    max_prompt_chars: Annotated[int, Field(ge=1)] = 4000
+    enforce_diversity: Annotated[bool, Field(description="Avoid near-duplicate prompts via distance checks.")] = True
+    min_levenshtein_distance: Annotated[int, Field(ge=0)] = 40
+
+
+class SelectionConfig(BaseConfig):
+    """Selection policy settings."""
+
+    strategy: Annotated[Literal["top-k", "tournament"], Field()] = "top-k"
+    k: Annotated[int, Field(ge=1)] = 8
+    tournament_size: Annotated[int, Field(ge=1)] = 3
+    keep_elite: Annotated[int, Field(ge=0)] = 2
+
+
+class GEPAConfig(BaseSettings):
+    """Top-level configuration for the GEPA optimizer."""
+
+    # Model/Client
+    model: ModelConfig = ModelConfig()
+
+    # Evaluation
+    evaluate: EvaluateConfig = EvaluateConfig()
+
+    # Evolution
+    population_size: Annotated[int, Field(ge=2)] = 16
+    generations: Annotated[int, Field(ge=1)] = 10
+    seed: Annotated[int | None, Field(description="Random seed for reproducibility.")] = 42
+
+    # Operators & selection
+    operators: OperatorsConfig = OperatorsConfig()
+    selection: SelectionConfig = SelectionConfig()
+
+    # Budget & minibatch
+    budget_rollouts: Annotated[int, Field(ge=1, description="Total rollout budget for evolution.")] = 200
+    minibatch_size: Annotated[int, Field(ge=1, description="Minibatch size b for acceptance test.")] = 8
+
+    # Logging/monitoring
+    log: LogConfig = LogConfig()
+    monitor: MultiMonitorConfig = MultiMonitorConfig()
+
+    # IO
+    outputs_dir: Annotated[Path, Field(description="Directory for GEPA outputs.")] = Path("outputs")
+    run_name: Annotated[str | None, Field(description="Optional run name for outputs/W&B.")] = None
+
+    # Dev
+    dry_run: Annotated[bool, Field(description="If True, skip real inference and fabricate scores.")] = False
+
+    # Inference server (optional auto-spawn) and client
+    inference: InferenceConfig | None = None
+    client: ClientConfig = ClientConfig()
+
+

--- a/src/prime_rl/optimizer/gepa/config.py
+++ b/src/prime_rl/optimizer/gepa/config.py
@@ -5,7 +5,7 @@ from pydantic import Field
 
 from prime_rl.inference.config import InferenceConfig
 from prime_rl.orchestrator.config import ClientConfig
-from prime_rl.utils.config import LogConfig, MultiMonitorConfig, ModelConfig
+from prime_rl.utils.config import LogConfig, ModelConfig, MultiMonitorConfig
 from prime_rl.utils.pydantic_config import BaseConfig, BaseSettings
 
 

--- a/src/prime_rl/optimizer/gepa/evaluate.py
+++ b/src/prime_rl/optimizer/gepa/evaluate.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any
+
+from openai import AsyncOpenAI
+
+from prime_rl.eval.registry import get_benchmark_dataset
+from prime_rl.orchestrator.client import generate_completion, setup_client
+from prime_rl.orchestrator.config import ClientConfig, ModelConfig as OrchestratorModelConfig, SamplingConfig
+from prime_rl.orchestrator.utils import compute_rewards, parse_completion_tokens, parse_completions
+from prime_rl.utils.logger import get_logger
+
+
+@dataclass
+class PromptScore:
+    prompt: str
+    avg_reward: float
+    pass_at_k: float | None
+    avg_completion_len: float
+    meta: dict[str, Any]
+
+
+async def _score_on_benchmark(
+    client: AsyncOpenAI,
+    benchmark: str,
+    system_prompt: str,
+    model_config: OrchestratorModelConfig,
+    sampling: SamplingConfig,
+    subset_size: int,
+    rollouts_per_prompt: int,
+) -> tuple[float, float | None, float]:
+    logger = get_logger()
+    dataset = get_benchmark_dataset(benchmark)
+    dataset = dataset.select(range(min(len(dataset), subset_size)))
+
+    prompts = [item["prompt"] for item in dataset]
+    prompts = [p for p in prompts for _ in range(rollouts_per_prompt)]
+    problem_ids = list(range(len(dataset)))
+    problem_ids = [pid for pid in problem_ids for _ in range(rollouts_per_prompt)]
+
+    batch_messages = [[{"role": "system", "content": system_prompt}, {"role": "user", "content": p}]
+                      for p in prompts]
+
+    # Generate
+    chat_completions = await asyncio.gather(
+        *(generate_completion(client, model_config, sampling, messages) for messages in batch_messages)
+    )
+
+    # Stats
+    completion_lengths = [len(parse_completion_tokens(c)) for c in chat_completions]
+    avg_completion_len = sum(completion_lengths) / max(1, len(completion_lengths))
+
+    completions = parse_completions(chat_completions)
+    task_types = [item.get("task_type", "") for item in dataset]
+    verification_infos = [item.get("verification_info", "{}") for item in dataset]
+    # Duplicate for k samples
+    task_types = [t for t in task_types for _ in range(rollouts_per_prompt)]
+    verification_infos = [v for v in verification_infos for _ in range(rollouts_per_prompt)]
+
+    try:
+        import json
+        verification_infos = [json.loads(v) if isinstance(v, str) else v for v in verification_infos]
+    except Exception:
+        logger.warning("Failed to parse some verification_info entries; using raw values.")
+
+    rewards = compute_rewards(completions, task_types, verification_infos)
+
+    # pass@k for binary rewards
+    unique = set(rewards)
+    pass_at_k = None
+    if unique.issubset({0, 1, 0.0, 1.0}):
+        k = rollouts_per_prompt
+        rows: dict[int, list[float]] = {}
+        for pid, r in zip(problem_ids, rewards):
+            rows.setdefault(pid, []).append(float(r))
+        solved = [any(x == 1.0 for x in rs) for rs in rows.values()]
+        pass_at_k = sum(solved) / max(1, len(solved))
+
+    avg_reward = float(sum(map(float, rewards)) / max(1, len(rewards)))
+    return avg_reward, pass_at_k, float(avg_completion_len)
+
+
+async def score_prompt(
+    system_prompt: str,
+    client_cfg: ClientConfig,
+    model_cfg: OrchestratorModelConfig,
+    benchmark: str,
+    subset_size: int,
+    rollouts_per_prompt: int,
+    max_tokens: int | None,
+    min_tokens: int,
+) -> PromptScore:
+    logger = get_logger()
+    client = setup_client(client_cfg)
+
+    sampling = SamplingConfig(
+        temperature=1.0,
+        max_tokens=max_tokens,
+        min_tokens=min_tokens,
+        seed=None,
+    )
+
+    # Single benchmark specified by caller
+    avg_reward, pass_at_k, avg_len = await _score_on_benchmark(
+        client,
+        benchmark=benchmark,
+        system_prompt=system_prompt,
+        model_config=model_cfg,
+        sampling=sampling,
+        subset_size=subset_size,
+        rollouts_per_prompt=rollouts_per_prompt,
+    )
+
+    return PromptScore(
+        prompt=system_prompt,
+        avg_reward=avg_reward,
+        pass_at_k=pass_at_k,
+        avg_completion_len=avg_len,
+        meta={},
+    )
+
+
+async def score_prompt_dry_run(system_prompt: str, subset_size: int) -> PromptScore:
+    # Deterministic-ish fake scoring for local CPU testing without dependencies
+    base = sum(ord(c) for c in system_prompt) % 1000 / 1000.0
+    avg_reward = 0.3 + 0.5 * base
+    pass_at_k = None
+    avg_completion_len = 20.0 + (len(system_prompt) % 17)
+    return PromptScore(system_prompt, avg_reward, pass_at_k, avg_completion_len, meta={"dry_run": True})
+
+
+async def score_prompt_instances(
+    system_prompt: str,
+    client_cfg: ClientConfig,
+    model_cfg: OrchestratorModelConfig,
+    benchmark: str,
+    num_instances: int,
+    rollouts_per_prompt: int,
+    max_tokens: int | None,
+    min_tokens: int,
+    offset: int = 0,
+) -> list[float]:
+    """Return per-instance average reward for a contiguous slice of the dataset."""
+    logger = get_logger()
+    client = setup_client(client_cfg)
+    sampling = SamplingConfig(
+        temperature=1.0,
+        max_tokens=max_tokens,
+        min_tokens=min_tokens,
+        seed=None,
+    )
+
+    dataset = get_benchmark_dataset(benchmark)
+    start = max(0, offset)
+    end = min(len(dataset), start + num_instances)
+    dataset = dataset.select(range(start, end))
+
+    prompts = [item["prompt"] for item in dataset]
+    prompts = [p for p in prompts for _ in range(rollouts_per_prompt)]
+    problem_ids = list(range(len(dataset)))
+    problem_ids = [pid for pid in problem_ids for _ in range(rollouts_per_prompt)]
+    batch_messages = [[{"role": "system", "content": system_prompt}, {"role": "user", "content": p}] for p in prompts]
+
+    chat_completions = await asyncio.gather(
+        *(generate_completion(client, model_cfg, sampling, messages) for messages in batch_messages)
+    )
+    completions = parse_completions(chat_completions)
+    task_types = [item.get("task_type", "") for item in dataset]
+    verification_infos = [item.get("verification_info", "{}") for item in dataset]
+    task_types = [t for t in task_types for _ in range(rollouts_per_prompt)]
+    try:
+        import json
+        verification_infos = [json.loads(v) if isinstance(v, str) else v for v in verification_infos]
+    except Exception:
+        pass
+    verification_infos = [v for v in verification_infos for _ in range(rollouts_per_prompt)]
+    rewards = compute_rewards(completions, task_types, verification_infos)
+
+    per_problem: dict[int, list[float]] = {}
+    for pid, r in zip(problem_ids, rewards):
+        per_problem.setdefault(pid, []).append(float(r))
+    return [sum(rs) / len(rs) for _, rs in sorted(per_problem.items())]
+
+
+async def score_prompt_instances_dry_run(system_prompt: str, num_instances: int) -> list[float]:
+    base = (sum(ord(c) for c in system_prompt) % 1000) / 1000.0
+    return [0.3 + 0.5 * ((base + i * 0.013) % 1.0) for i in range(num_instances)]
+
+

--- a/src/prime_rl/optimizer/gepa/evaluate.py
+++ b/src/prime_rl/optimizer/gepa/evaluate.py
@@ -8,8 +8,16 @@ from openai import AsyncOpenAI
 
 from prime_rl.eval.registry import get_benchmark_dataset
 from prime_rl.orchestrator.client import generate_completion, setup_client
-from prime_rl.orchestrator.config import ClientConfig, ModelConfig as OrchestratorModelConfig, SamplingConfig
-from prime_rl.orchestrator.utils import compute_rewards, parse_completion_tokens, parse_completions
+from prime_rl.orchestrator.config import (
+    ClientConfig,
+    ModelConfig as OrchestratorModelConfig,
+    SamplingConfig,
+)
+from prime_rl.orchestrator.utils import (
+    compute_rewards,
+    parse_completion_tokens,
+    parse_completions,
+)
 from prime_rl.utils.logger import get_logger
 
 
@@ -71,7 +79,6 @@ async def _score_on_benchmark(
     unique = set(rewards)
     pass_at_k = None
     if unique.issubset({0, 1, 0.0, 1.0}):
-        k = rollouts_per_prompt
         rows: dict[int, list[float]] = {}
         for pid, r in zip(problem_ids, rewards):
             rows.setdefault(pid, []).append(float(r))
@@ -92,7 +99,6 @@ async def score_prompt(
     max_tokens: int | None,
     min_tokens: int,
 ) -> PromptScore:
-    logger = get_logger()
     client = setup_client(client_cfg)
 
     sampling = SamplingConfig(
@@ -143,7 +149,6 @@ async def score_prompt_instances(
     offset: int = 0,
 ) -> list[float]:
     """Return per-instance average reward for a contiguous slice of the dataset."""
-    logger = get_logger()
     client = setup_client(client_cfg)
     sampling = SamplingConfig(
         temperature=1.0,

--- a/src/prime_rl/optimizer/gepa/evaluate.py
+++ b/src/prime_rl/optimizer/gepa/evaluate.py
@@ -10,8 +10,10 @@ from prime_rl.eval.registry import get_benchmark_dataset
 from prime_rl.orchestrator.client import generate_completion, setup_client
 from prime_rl.orchestrator.config import (
     ClientConfig,
-    ModelConfig as OrchestratorModelConfig,
     SamplingConfig,
+)
+from prime_rl.orchestrator.config import (
+    ModelConfig as OrchestratorModelConfig,
 )
 from prime_rl.orchestrator.utils import (
     compute_rewards,

--- a/src/prime_rl/optimizer/gepa/gepa.py
+++ b/src/prime_rl/optimizer/gepa/gepa.py
@@ -16,11 +16,10 @@ from prime_rl.optimizer.gepa.evaluate import (
 )
 from prime_rl.optimizer.gepa.operators import crossover, mutate
 from prime_rl.optimizer.gepa.reflection import reflect, reflect_llm
-from prime_rl.optimizer.gepa.selection import select_indices
-from prime_rl.orchestrator.config import ClientConfig, ModelConfig as OrchestratorModelConfig
+from prime_rl.orchestrator.config import ModelConfig as OrchestratorModelConfig
 from prime_rl.utils.monitor import setup_monitor
 from prime_rl.utils.pydantic_config import parse_argv
-from prime_rl.utils.logger import format_message, format_time, set_logger, setup_handlers, get_logger
+from prime_rl.utils.logger import format_message, format_time, get_logger, set_logger, setup_handlers
 from prime_rl.utils.config import LogConfig
 from prime_rl.utils.utils import clean_exit
 

--- a/src/prime_rl/optimizer/gepa/gepa.py
+++ b/src/prime_rl/optimizer/gepa/gepa.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 import asyncio
 import json
 import random
-from pathlib import Path
-from typing import Any
 
+# (std imports pruned)
 from prime_rl.optimizer.gepa.config import GEPAConfig
 from prime_rl.optimizer.gepa.evaluate import (
     PromptScore,
@@ -17,11 +16,12 @@ from prime_rl.optimizer.gepa.evaluate import (
 from prime_rl.optimizer.gepa.operators import crossover, mutate
 from prime_rl.optimizer.gepa.reflection import reflect, reflect_llm
 from prime_rl.orchestrator.config import ModelConfig as OrchestratorModelConfig
+from prime_rl.utils.config import LogConfig
+from prime_rl.utils.logger import format_message, format_time, get_logger, set_logger, setup_handlers
 from prime_rl.utils.monitor import setup_monitor
 from prime_rl.utils.pydantic_config import parse_argv
-from prime_rl.utils.logger import format_message, format_time, get_logger, set_logger, setup_handlers
-from prime_rl.utils.config import LogConfig
-from prime_rl.utils.utils import clean_exit
+
+# (no clean_exit usage)
 
 
 async def _evaluate_population(

--- a/src/prime_rl/optimizer/gepa/gepa.py
+++ b/src/prime_rl/optimizer/gepa/gepa.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import random
+from pathlib import Path
+from typing import Any
+
+from prime_rl.optimizer.gepa.config import GEPAConfig
+from prime_rl.optimizer.gepa.evaluate import (
+    PromptScore,
+    score_prompt,
+    score_prompt_dry_run,
+    score_prompt_instances,
+    score_prompt_instances_dry_run,
+)
+from prime_rl.optimizer.gepa.operators import crossover, mutate
+from prime_rl.optimizer.gepa.reflection import reflect
+from prime_rl.optimizer.gepa.selection import select_indices
+from prime_rl.orchestrator.config import ClientConfig, ModelConfig as OrchestratorModelConfig
+from prime_rl.utils.monitor import setup_monitor
+from prime_rl.utils.pydantic_config import parse_argv
+from prime_rl.utils.logger import format_message, format_time, set_logger, setup_handlers, get_logger
+from prime_rl.utils.config import LogConfig
+from prime_rl.utils.utils import clean_exit
+
+
+async def _evaluate_population(
+    population: list[str],
+    cfg: GEPAConfig,
+) -> list[PromptScore]:
+    if cfg.dry_run:
+        tasks = [score_prompt_dry_run(p, cfg.evaluate.subset_size) for p in population]
+        return await asyncio.gather(*tasks)
+    else:
+        client_cfg = cfg.client
+        model_cfg = OrchestratorModelConfig(name=cfg.model.name)
+        tasks = [
+            score_prompt(
+                system_prompt=p,
+                client_cfg=client_cfg,
+                model_cfg=model_cfg,
+                benchmark=cfg.evaluate.benchmark,
+                subset_size=cfg.evaluate.pareto_size,
+                rollouts_per_prompt=cfg.evaluate.rollouts_per_prompt,
+                max_tokens=cfg.evaluate.max_tokens,
+                min_tokens=cfg.evaluate.min_tokens,
+            )
+            for p in population
+        ]
+        return await asyncio.gather(*tasks)
+
+
+def _default_seed_population(base_prompt: str, n: int) -> list[str]:
+    variants = [
+        base_prompt,
+        base_prompt + "\nBe concise and avoid unnecessary verbosity.",
+        base_prompt + "\nUse <final_answer> tags to present only the final answer.",
+        base_prompt + "\nThink step-by-step inside <think>...</think> before answering.",
+    ]
+    while len(variants) < n:
+        variants.append(base_prompt)
+    return variants[:n]
+
+
+async def gepa(cfg: GEPAConfig) -> None:
+    # Setup logger
+    _setup_logger(cfg.log)
+    logger = get_logger()
+    rng = random.Random(cfg.seed)
+    monitor = setup_monitor(cfg.monitor, outputs_dir=cfg.outputs_dir, run_config=cfg)
+
+    run_dir = cfg.outputs_dir / (cfg.run_name or "gepa")
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    # Seed population from reverse-text system prompt as reasonable default baseline
+    base_prompt = (
+        "Follow the task precisely. Use <think>...</think> for internal reasoning. "
+        "Output only the final answer inside <final_answer>...</final_answer>."
+    )
+    population = _default_seed_population(base_prompt, cfg.population_size)
+
+    hall_of_fame: list[tuple[PromptScore, int]] = []
+
+    rollouts_used = 0
+    for gen in range(cfg.generations):
+        logger.info(f"[GEPA] Generation {gen}: evaluating {len(population)} prompts")
+        results = await _evaluate_population(population, cfg)
+
+        # Persist population snapshot
+        snap_path = run_dir / f"gen_{gen}.json"
+        with open(snap_path, "w") as f:
+            json.dump([r.__dict__ for r in results], f)
+
+        # Log summary
+        avg_scores = [r.avg_reward for r in results]
+        best_idx = max(range(len(results)), key=lambda i: results[i].avg_reward)
+        best = results[best_idx]
+        logger.success(
+            f"[GEPA] Gen {gen}: best={best.avg_reward:.3f} pass@k={best.pass_at_k} len={best.avg_completion_len:.1f}"
+        )
+        monitor.log({
+            "gepa/gen": gen,
+            "gepa/best": best.avg_reward,
+            "gepa/avg": sum(avg_scores) / max(1, len(avg_scores)),
+            "step": gen,
+        })
+
+        # Update Hall of Fame
+        hall_of_fame.append((best, gen))
+        hall_of_fame = sorted(hall_of_fame, key=lambda x: x[0].avg_reward, reverse=True)[: cfg.selection.keep_elite]
+
+        # Early exit on final gen
+        if gen == cfg.generations - 1:
+            break
+
+        # Compute Pareto scores matrix S for D_pareto
+        if cfg.dry_run:
+            S = [
+                await score_prompt_instances_dry_run(p, cfg.evaluate.pareto_size)
+                for p in population
+            ]
+        else:
+            S = []
+            for p in population:
+                S.append(
+                    await score_prompt_instances(
+                        p,
+                        cfg.client,
+                        OrchestratorModelConfig(name=cfg.model.name),
+                        cfg.evaluate.benchmark,
+                        cfg.evaluate.pareto_size,
+                        cfg.evaluate.rollouts_per_prompt,
+                        cfg.evaluate.max_tokens,
+                        cfg.evaluate.min_tokens,
+                        offset=0,
+                    )
+                )
+
+        # Pareto-front selection: choose one survivor index
+        def pareto_select_index(scores: list[list[float]]) -> int:
+            import math
+            num_c = len(scores)
+            num_i = len(scores[0]) if scores else 0
+            if num_c == 0 or num_i == 0:
+                return 0
+            # For each instance, find max value and candidates achieving it
+            max_per_i = [max(scores[c][i] for c in range(num_c)) for i in range(num_i)]
+            top_sets = [
+                {c for c in range(num_c) if math.isclose(scores[c][i], max_per_i[i], rel_tol=1e-9)}
+                for i in range(num_i)
+            ]
+            union = set().union(*top_sets)
+            # Non-dominated filtering within union
+            def dominates(a: int, b: int) -> bool:
+                ge_all = all(scores[a][i] >= scores[b][i] for i in range(num_i))
+                gt_any = any(scores[a][i] > scores[b][i] for i in range(num_i))
+                return ge_all and gt_any
+            non_dominated = set(union)
+            for a in list(union):
+                for b in list(union):
+                    if a != b and dominates(b, a) and a in non_dominated:
+                        non_dominated.remove(a)
+            # Coverage weights f: how many instances where candidate is top
+            cover = {c: 0 for c in non_dominated}
+            for i, tops in enumerate(top_sets):
+                for c in non_dominated:
+                    if c in tops:
+                        cover[c] += 1
+            # Weighted random choice over non_dominated by coverage
+            total = sum(cover.values()) or 1
+            r = rng.random() * total
+            acc = 0
+            for c, w in cover.items():
+                acc += w
+                if r <= acc:
+                    return c
+            return next(iter(non_dominated))
+
+        parent_idx = pareto_select_index(S)
+        survivors = [parent_idx]
+
+        # Failures: placeholder summaries (TODO: use μ_f feedback)
+        failures: list[str] = []
+        if best.avg_reward < 1.0:
+            failures.append("answers deviated from correct format or content")
+
+        # Produce next generation with minibatch acceptance gate
+        next_population: list[str] = []
+        # Elites
+        for score, _gen in hall_of_fame:
+            next_population.append(score.prompt)
+
+        # Breed survivors
+        while len(next_population) < cfg.population_size and rollouts_used < cfg.budget_rollouts:
+            if rng.random() < cfg.operators.crossover_rate and len(survivors) >= 2:
+                a_idx, b_idx = rng.sample(survivors, 2)
+                child = crossover(population[a_idx], population[b_idx], cfg.operators, rng)
+            else:
+                a_idx = rng.choice(survivors)
+                child = population[a_idx]
+            # Reflect then mutate
+            child = reflect(child, failures, cfg.operators, rng)
+            if rng.random() < cfg.operators.mutation_rate:
+                child = mutate(child, cfg.operators, rng)
+            # Acceptance: compare on a minibatch from feedback pool
+            if cfg.dry_run:
+                parent_scores = await score_prompt_instances_dry_run(population[a_idx], cfg.minibatch_size)
+                child_scores = await score_prompt_instances_dry_run(child, cfg.minibatch_size)
+            else:
+                parent_scores = await score_prompt_instances(
+                    population[a_idx], cfg.client, OrchestratorModelConfig(name=cfg.model.name),
+                    cfg.evaluate.benchmark, cfg.minibatch_size, cfg.evaluate.rollouts_per_prompt,
+                    cfg.evaluate.max_tokens, cfg.evaluate.min_tokens, offset=cfg.evaluate.pareto_size,
+                )
+                child_scores = await score_prompt_instances(
+                    child, cfg.client, OrchestratorModelConfig(name=cfg.model.name),
+                    cfg.evaluate.benchmark, cfg.minibatch_size, cfg.evaluate.rollouts_per_prompt,
+                    cfg.evaluate.max_tokens, cfg.evaluate.min_tokens, offset=cfg.evaluate.pareto_size,
+                )
+
+            rollouts_used += cfg.minibatch_size
+            if sum(child_scores) / len(child_scores) > sum(parent_scores) / len(parent_scores):
+                next_population.append(child)
+
+        population = next_population[: cfg.population_size]
+
+        if rollouts_used >= cfg.budget_rollouts:
+            logger.info("[GEPA] Budget exhausted; stopping evolution")
+            break
+
+    # Export best prompt
+    best_overall = hall_of_fame[0][0] if hall_of_fame else results[0]
+    out_path = run_dir / "best_prompt.txt"
+    with open(out_path, "w") as f:
+        f.write(best_overall.prompt)
+    logger.success(f"[GEPA] Exported best prompt to {out_path}")
+
+
+def main():
+    asyncio.run(gepa(parse_argv(GEPAConfig)))
+
+
+if __name__ == "__main__":
+    main()
+
+
+def _setup_logger(log_config: LogConfig):
+    if get_logger():
+        return
+    fmt = format_time(log_config) + format_message()
+    logger = setup_handlers(__import__("loguru").logger, fmt, log_config, rank=0)
+    set_logger(logger)
+
+

--- a/src/prime_rl/optimizer/gepa/operators.py
+++ b/src/prime_rl/optimizer/gepa/operators.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import random
+import re
+from typing import Callable
+
+from prime_rl.optimizer.gepa.config import OperatorsConfig
+
+
+def _truncate(text: str, max_chars: int) -> str:
+    return text if len(text) <= max_chars else text[:max_chars]
+
+
+def op_tighten_instruction(prompt: str) -> str:
+    return re.sub(r"(?i)please |kindly ", "", prompt)
+
+
+def op_enforce_format_tags(prompt: str) -> str:
+    if "<final_answer>" not in prompt:
+        prompt += "\nAlways put the final answer inside <final_answer>...</final_answer>."
+    return prompt
+
+
+def op_add_reasoning_hint(prompt: str) -> str:
+    if "</think>" not in prompt and "<think>" not in prompt:
+        prompt += "\nThink step-by-step inside <think>...</think> before writing the final answer."
+    return prompt
+
+
+def op_remove_vagueness(prompt: str) -> str:
+    prompt = re.sub(r"(?i)try to|attempt to|maybe|possibly|could you ", "", prompt)
+    return prompt
+
+
+def mutate(prompt: str, cfg: OperatorsConfig, rng: random.Random) -> str:
+    ops: list[Callable[[str], str]] = [
+        op_tighten_instruction,
+        op_enforce_format_tags,
+        op_add_reasoning_hint,
+        op_remove_vagueness,
+    ]
+    num_ops = 1 + (rng.random() < 0.5)
+    for _ in range(num_ops):
+        op = rng.choice(ops)
+        prompt = op(prompt)
+    return _truncate(prompt, cfg.max_prompt_chars)
+
+
+def crossover(a: str, b: str, cfg: OperatorsConfig, rng: random.Random) -> str:
+    if len(a) < 16 or len(b) < 16:
+        return a if rng.random() < 0.5 else b
+    ia = rng.randrange(len(a) // 4, 3 * len(a) // 4)
+    ib = rng.randrange(len(b) // 4, 3 * len(b) // 4)
+    child = a[:ia] + "\n" + b[ib:]
+    return _truncate(child, cfg.max_prompt_chars)
+
+

--- a/src/prime_rl/optimizer/gepa/reflection.py
+++ b/src/prime_rl/optimizer/gepa/reflection.py
@@ -4,6 +4,8 @@ import random
 from typing import Sequence
 
 from prime_rl.optimizer.gepa.config import OperatorsConfig
+from openai import AsyncOpenAI
+from prime_rl.orchestrator.config import ModelConfig as OrchestratorModelConfig, ClientConfig
 
 
 REFLECT_TEMPLATE = (
@@ -28,5 +30,40 @@ def reflect(prompt: str, failures: Sequence[str], cfg: OperatorsConfig, rng: ran
     if len(edited) > cfg.max_prompt_chars:
         edited = edited[: cfg.max_prompt_chars]
     return edited
+
+
+async def reflect_llm(
+    client_cfg: ClientConfig,
+    model_cfg: OrchestratorModelConfig,
+    current_prompt: str,
+    feedbacks: list[str],
+    max_chars: int,
+) -> str:
+    """Use the model to propose an edited instruction given feedback examples."""
+    client = AsyncOpenAI(base_url=f"http://{client_cfg.host}:{client_cfg.port}/v1", api_key=client_cfg.api_key)
+
+    system = (
+        "You are an expert instruction engineer.\n"
+        "Given the current system instruction and a few failure summaries, propose an improved instruction.\n"
+        "Constraints: keep it concise, deterministic, preserve required tags/formatting, and stay under the character limit."
+    )
+    fb_text = "\n- ".join([f for f in feedbacks[:5]]) if feedbacks else "(no feedback provided)"
+    user = (
+        f"Current instruction:\n" 
+        f"-----\n{current_prompt}\n-----\n"
+        f"Failures:\n- {fb_text}\n"
+        f"Return only the full edited instruction (no commentary), max {max_chars} characters."
+    )
+    resp = await client.chat.completions.create(
+        model=model_cfg.name,
+        messages=[{"role": "system", "content": system}, {"role": "user", "content": user}],
+        temperature=0.2,
+        max_tokens=512,
+    )
+    text = resp.choices[0].message.content or current_prompt
+    text = text.strip()
+    if len(text) > max_chars:
+        text = text[:max_chars]
+    return text
 
 

--- a/src/prime_rl/optimizer/gepa/reflection.py
+++ b/src/prime_rl/optimizer/gepa/reflection.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import random
 from typing import Sequence
 
-from prime_rl.optimizer.gepa.config import OperatorsConfig
 from openai import AsyncOpenAI
-from prime_rl.orchestrator.config import ModelConfig as OrchestratorModelConfig, ClientConfig
+
+from prime_rl.optimizer.gepa.config import OperatorsConfig
+from prime_rl.orchestrator.config import ClientConfig, ModelConfig as OrchestratorModelConfig
 
 
 REFLECT_TEMPLATE = (

--- a/src/prime_rl/optimizer/gepa/reflection.py
+++ b/src/prime_rl/optimizer/gepa/reflection.py
@@ -6,8 +6,8 @@ from typing import Sequence
 from openai import AsyncOpenAI
 
 from prime_rl.optimizer.gepa.config import OperatorsConfig
-from prime_rl.orchestrator.config import ClientConfig, ModelConfig as OrchestratorModelConfig
-
+from prime_rl.orchestrator.config import ClientConfig
+from prime_rl.orchestrator.config import ModelConfig as OrchestratorModelConfig
 
 REFLECT_TEMPLATE = (
     "You are optimizing a system instruction for a model on a benchmark.\n"

--- a/src/prime_rl/optimizer/gepa/reflection.py
+++ b/src/prime_rl/optimizer/gepa/reflection.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import random
+from typing import Sequence
+
+from prime_rl.optimizer.gepa.config import OperatorsConfig
+
+
+REFLECT_TEMPLATE = (
+    "You are optimizing a system instruction for a model on a benchmark.\n"
+    "Given a list of failure examples (short summaries), propose concise edits to the instruction\n"
+    "that will improve accuracy without adding verbosity or vagueness.\n"
+    "Return only the edited instruction text. Keep it under the specified character limit."
+)
+
+
+def reflect(prompt: str, failures: Sequence[str], cfg: OperatorsConfig, rng: random.Random) -> str:
+    # Placeholder: lightweight heuristic reflection combining failures into a short clause
+    if not failures:
+        return prompt
+    clause = "; ".join(failures[:3])
+    edited = (
+        prompt
+        + "\nConstraints: Avoid previous mistakes such as: "
+        + clause
+        + ". Be explicit, deterministic, and adhere to required answer format."
+    )
+    if len(edited) > cfg.max_prompt_chars:
+        edited = edited[: cfg.max_prompt_chars]
+    return edited
+
+

--- a/src/prime_rl/optimizer/gepa/selection.py
+++ b/src/prime_rl/optimizer/gepa/selection.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import random
+from typing import Iterable
+
+from prime_rl.optimizer.gepa.config import SelectionConfig
+
+
+def top_k(scores: list[tuple[int, float]], k: int) -> list[int]:
+    return [i for i, _ in sorted(scores, key=lambda x: x[1], reverse=True)[:k]]
+
+
+def tournament(scores: list[tuple[int, float]], k: int, t_size: int, rng: random.Random) -> list[int]:
+    winners: list[int] = []
+    indices = [i for i, _ in scores]
+    for _ in range(k):
+        pool = rng.sample(indices, min(t_size, len(indices)))
+        pool_scores = [(i, dict(scores)[i]) for i in pool]
+        winners.append(max(pool_scores, key=lambda x: x[1])[0])
+    return winners
+
+
+def select_indices(cfg: SelectionConfig, fitness: Iterable[float], rng: random.Random) -> list[int]:
+    scores = list(enumerate(fitness))
+    if cfg.strategy == "top-k":
+        idxs = top_k(scores, cfg.k)
+    else:
+        idxs = tournament(scores, cfg.k, cfg.tournament_size, rng)
+    # Add elites (ensure uniqueness, preserve order)
+    elites = top_k(scores, cfg.keep_elite)
+    seen = set()
+    ordered = []
+    for i in elites + idxs:
+        if i not in seen:
+            seen.add(i)
+            ordered.append(i)
+    return ordered
+
+

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -24,7 +24,7 @@ from prime_rl.trainer.config import CheckpointConfig as TrainerCheckpointConfig
 from prime_rl.trainer.rl.config import FakeDataLoaderConfig
 from prime_rl.trainer.rl.config import RLTrainerConfig as TrainerConfig
 from prime_rl.utils.config import WandbMonitorConfig
-from prime_rl.utils.logger import format_message, format_time, get_logger, set_logger, setup_handlers
+from prime_rl.utils.logger import get_logger
 from prime_rl.utils.pydantic_config import BaseSettings, get_temp_toml_file, parse_argv
 from prime_rl.utils.utils import (
     get_ckpt_dir,

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -24,7 +24,13 @@ from prime_rl.trainer.config import CheckpointConfig as TrainerCheckpointConfig
 from prime_rl.trainer.rl.config import FakeDataLoaderConfig
 from prime_rl.trainer.rl.config import RLTrainerConfig as TrainerConfig
 from prime_rl.utils.config import WandbMonitorConfig
-from prime_rl.utils.logger import get_logger
+from prime_rl.utils.logger import (
+    format_message,
+    format_time,
+    get_logger,
+    set_logger,
+    setup_handlers,
+)
 from prime_rl.utils.pydantic_config import BaseSettings, get_temp_toml_file, parse_argv
 from prime_rl.utils.utils import (
     get_ckpt_dir,
@@ -411,8 +417,8 @@ def rl(config: RLConfig):
 
     # Redirect to GEPA optimizer if requested
     if getattr(config, "gepa", False):
-        from prime_rl.optimizer.gepa.gepa import gepa as run_gepa
         from prime_rl.optimizer.gepa.config import GEPAConfig
+        from prime_rl.optimizer.gepa.gepa import gepa as run_gepa
         from prime_rl.utils.pydantic_config import parse_argv as parse_gepa_argv
         logger.info("GEPA flag set; launching GEPA optimizer")
         import asyncio


### PR DESCRIPTION
## Description
- Add GEPA optimizer integrated into main runner (`rl --gepa`) with repo-native configs.
- Implement minibatch acceptance (σ′ > σ), per-instance scoring helpers, and simple Pareto-front selection over fixed D_pareto.
- Add `system_prompt` overrides to `vf_reverse_text` and `vf_hendrycks_math` to consume evolved prompts.

[2507.19457v1.pdf](https://github.com/user-attachments/files/21776056/2507.19457v1.pdf) — Agrawal et al., “GEPA: Reflective Prompt Evolution Can Outperform Reinforcement Learning,” 2025
