### PR TITLE
Update validation commands to point to correct config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ uv run python -c "import flash_attn"
 3. Check that you can run SFT trainer in debug model (*this requires 1 GPU)
 
 ```bash
-uv run sft @ configs/debug/train.toml
+uv run sft @ configs/debug/sft.toml
 ```
 
 4. Check that you can run the RL trainer debug mode (*this requires 1 GPU*)


### PR DESCRIPTION
I think this is supposed to be `sft.toml` not `train.toml`

BEFORE (error):

```
[jrcummings@devvm4767.pnb0 ~/projects/prime-rl (main)]$ uv run sft @ configs/debug/train.toml
Traceback (most recent call last):
  File "/home/jrcummings/projects/prime-rl/.venv/bin/sft", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/jrcummings/projects/prime-rl/src/prime_rl/trainer/sft/train.py", line 274, in main
    train(parse_argv(SFTTrainerConfig))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jrcummings/projects/prime-rl/src/prime_rl/utils/pydantic_config.py", line 269, in parse_argv
    config = config_cls(_cli_parse_args=to_kebab_case(cli_args))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jrcummings/projects/prime-rl/.venv/lib/python3.12/site-packages/pydantic_settings/main.py", line 188, in __init__
    super().__init__(
  File "/home/jrcummings/projects/prime-rl/.venv/lib/python3.12/site-packages/pydantic/main.py", line 253, in __init__
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 2 validation errors for SFTTrainerConfig
data.fake
  Input should be a valid boolean [type=bool_type, input_value={'batch_size': 16, 'micro...ize': 8, 'seq_len': 128}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.11/v/bool_type
async_level
  Extra inputs are not permitted [type=extra_forbidden, input_value=5, input_type=int]
    For further information visit https://errors.pydantic.dev/2.11/v/extra_forbidden
```

AFTER (hooray 2% MFU):

```
[jrcummings@devvm4767.pnb0 ~/projects/prime-rl (main)]$ uv run sft @ configs/debug/sft.toml
11:36:35    INFO Starting SFT trainer in World(world_size=1, rank=0, local_rank=0, local_world_size=1, num_nodes=1)
11:36:35    INFO Initializing monitor (file=disabled, socket=disabled, api=disabled, wandb=disabled, system_log_frequency=0)
11:36:36    INFO Initializing model and tokenizer (name='PrimeIntellect/Qwen3-0.6B' attn='flash_attention_2' compile=False ac=False reshard_after_forward=True)
You are attempting to use Flash Attention 2.0 without specifying a torch dtype. This might lead to unexpected behaviour
You are attempting to use Flash Attention 2.0 with a model not initialized on GPU. Make sure to move the model to GPU after initializing it on CPU with `model.to('cuda')`.
11:36:39    INFO Initializing optimizer (lr=0.0004 weight_decay=0.01 max_norm=1.0 type='adamw' betas1=0.9 betas2=0.999)
11:36:39    INFO Using `constant` scheduler (type='constant')
11:36:39    INFO Starting from step 0 (total_tokens=0, total_samples=0)
11:36:39    INFO Initializing dataset (name=PrimeIntellect/Reverse-Text-SFT, split=train)
11:36:39    INFO Initializing dataloader (micro_batch_size=8, batch_size=16, collate_mode=packing)
11:36:39    INFO Starting training loop (config.max_steps=5)
NCCL version 2.26.2+cuda12.2
11:36:43 WARNING Peak FLOPS undefined for `NVIDIA PG509-210`. Falling back to A100 (312 TFLOPS)
11:36:43 SUCCESS Step 0 | Time: 3.51s | Loss: 14.3244 | Accuracy: 0.0000 | Grad. Norm: 80.9217 | LR: 4.00e-04 | Throughput: 0 tokens/s | MFU: 0.0%
11:36:44 SUCCESS Step 1 | Time: 0.90s | Loss: 12.5202 | Accuracy: 0.0000 | Grad. Norm: 65.4769 | LR: 4.00e-04 | Throughput: 2264 tokens/s | MFU: 2.0%
11:36:44 SUCCESS Step 2 | Time: 0.74s | Loss: 12.7759 | Accuracy: 0.0000 | Grad. Norm: 27.9819 | LR: 4.00e-04 | Throughput: 2485 tokens/s | MFU: 2.1%
11:36:45 SUCCESS Step 3 | Time: 0.75s | Loss: 12.4309 | Accuracy: 0.0000 | Grad. Norm: 9.1706 | LR: 4.00e-04 | Throughput: 2561 tokens/s | MFU: 2.2%
11:36:46 SUCCESS Step 4 | Time: 0.81s | Loss: 12.1576 | Accuracy: 0.0000 | Grad. Norm: 4.5774 | LR: 4.00e-04 | Throughput: 2553 tokens/s | MFU: 2.2%
11:36:46    INFO Peak memory: 13.47 GB
11:36:46 SUCCESS SFT trainer finished!
```