### PR TITLE
Improve benchmark suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ uv run orchestrator @ configs/reverse_text/orch.toml --bench
 
 **Trainer**
 
-To benchmark the trainer, simply run the trainer against a fake data loader matching the way the orchestrator would write the training batch.
+To benchmark the RL trainer, simply run the trainer against a fake data loader with batch certain specifications.
 
 ```bash
 uv run trainer @ configs/reverse_text/train.toml --bench --data.fake.micro_batch_size 8 --data.fake.batch_size 128 --data.fake.seq_len 128
@@ -521,13 +521,22 @@ uv run trainer @ configs/reverse_text/train.toml --bench --data.fake.micro_batch
 
 **RL**
 
-Often it will be most convenient to benchmark the full RL run. This will automatically set the training batch configuration to match the way the orchestrator would have written it.
+You can benchmark both the RL trainer and inference at the same time with the `rl.py` entrypoint. Note, that the benchmarking is still decoupled.
 
 ```bash
 uv run rl   \
   --trainer @ configs/reverse_text/train.toml  \
   --orchestrator @ configs/reverse_text/orch.toml \
-  --inference @ configs/reverse_text/infer.toml
+  --inference @ configs/reverse_text/infer.toml \
+  --bench
+```
+
+**SFT**
+
+Benchmark the SFT trainer against `fixed` or `variable` length fake data by specifyin `--data.fake.type`
+
+```bash
+uv run sft --bench --data.fake.type fixed --data.micro-batch-size 8 --data.batch-size 8 --data.seq-len 128
 ```
 
 ### Tests

--- a/configs/acereason_math/stage1/train.toml
+++ b/configs/acereason_math/stage1/train.toml
@@ -4,7 +4,8 @@ max_steps = 500
 
 [model]
 name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"
-ac = true
+
+[model.ac]
 
 [optim]
 lr = 1e-6

--- a/configs/acereason_math/stage2/train.toml
+++ b/configs/acereason_math/stage2/train.toml
@@ -4,7 +4,8 @@ max_steps = 1000
 
 [model]
 name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"
-ac = true
+
+[model.ac]
 
 [optim]
 lr = 1e-6

--- a/configs/debug/sft.toml
+++ b/configs/debug/sft.toml
@@ -4,7 +4,9 @@ max_steps = 5
 name = "PrimeIntellect/Qwen3-0.6B" 
 
 [data]
-fake = true
 batch_size = 16
 micro_batch_size = 8
 seq_len = 128
+
+[data.fake]
+type = "fixed"

--- a/configs/deepscaler_math/stage2/train.toml
+++ b/configs/deepscaler_math/stage2/train.toml
@@ -4,7 +4,8 @@ max_steps = 1000
 
 [model]
 name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
-ac = true
+
+[model.ac]
 
 [optim]
 lr = 1e-6

--- a/configs/deepscaler_math/stage3/train.toml
+++ b/configs/deepscaler_math/stage3/train.toml
@@ -4,7 +4,8 @@ max_steps = 1500
 
 [model]
 name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
-ac = true
+
+[model.ac]
 
 [optim]
 lr = 1e-6

--- a/configs/hendrycks_math/14b/train.toml
+++ b/configs/hendrycks_math/14b/train.toml
@@ -2,7 +2,8 @@
 
 [model]
 name = "willcb/DeepSeek-R1-Distill-Qwen-14B"
-ac = true
+
+[model.ac]
 
 [optim]
 lr = 1e-6

--- a/configs/hendrycks_math/32b/train.toml
+++ b/configs/hendrycks_math/32b/train.toml
@@ -2,7 +2,8 @@
 
 [model]
 name = "willcb/DeepSeek-R1-Distill-Qwen-32B"
-ac = true
+
+[model.ac]
 
 [optim]
 lr = 1e-6

--- a/configs/hendrycks_math/7b/train.toml
+++ b/configs/hendrycks_math/7b/train.toml
@@ -2,7 +2,8 @@
 
 [model]
 name = "willcb/DeepSeek-R1-Distill-Qwen-7B"
-ac = true
+
+[model.ac]
 
 [optim]
 lr = 1e-6

--- a/configs/intellect_math/7b/train.toml
+++ b/configs/intellect_math/7b/train.toml
@@ -4,7 +4,8 @@ max_steps = 1000
 
 [model]
 name = "willcb/DeepSeek-R1-Distill-Qwen-7B"
-ac = true
+
+[model.ac]
 
 [optim]
 lr = 1e-6

--- a/configs/skywork_math/32b/stage1/train.toml
+++ b/configs/skywork_math/32b/stage1/train.toml
@@ -4,7 +4,8 @@ max_steps = 760
 
 [model]
 name = "willcb/DeepSeek-R1-Distill-Qwen-32B"
-ac = true
+
+[model.ac]
 
 [optim]
 lr = 1e-6

--- a/configs/skywork_math/32b/stage2/train.toml
+++ b/configs/skywork_math/32b/stage2/train.toml
@@ -4,7 +4,8 @@ max_steps = 1130
 
 [model]
 name = "willcb/DeepSeek-R1-Distill-Qwen-32B"
-ac = true
+
+[model.ac]
 
 [optim]
 lr = 1e-6

--- a/configs/skywork_math/7b/ablation/train.toml
+++ b/configs/skywork_math/7b/ablation/train.toml
@@ -4,7 +4,8 @@ max_steps = 660
 
 [model]
 name = "willcb/DeepSeek-R1-Distill-Qwen-7B"
-ac = true
+
+[model.ac]
 
 [optim]
 lr = 1e-6

--- a/configs/skywork_math/7b/stage1/train.toml
+++ b/configs/skywork_math/7b/stage1/train.toml
@@ -4,7 +4,8 @@ max_steps = 660
 
 [model]
 name = "willcb/DeepSeek-R1-Distill-Qwen-7B"
-ac = true
+
+[model.ac]
 
 [optim]
 lr = 1e-6

--- a/configs/skywork_math/7b/stage2/train.toml
+++ b/configs/skywork_math/7b/stage2/train.toml
@@ -4,7 +4,8 @@ max_steps = 1320
 
 [model]
 name = "willcb/DeepSeek-R1-Distill-Qwen-7B"
-ac = true
+
+[model.ac]
 
 [optim]
 lr = 1e-6

--- a/configs/wordle/14b/train.toml
+++ b/configs/wordle/14b/train.toml
@@ -5,7 +5,8 @@ project = "wordle"
 
 [model]
 name = "willcb/Qwen3-14B"
-ac = true
+
+[model.ac]
 
 [optim]
 lr = 1e-6

--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -137,8 +137,8 @@ def print_benchmark(history: dict[str, list[Any]]) -> None:
     # Turn metric history into pd.DataFrame
     df = pd.DataFrame(dict(history.items()))
     columns = {
-        "perf/infer/throughput": "Throughput",
-        "time/orchestrator": "Step Time",
+        "perf/throughput": "Throughput",
+        "time/step": "Step Time",
     }
     df = df[columns.keys()].rename(columns=columns)
     df = df.iloc[1:]  # Exclude first row

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -29,7 +29,7 @@ class CheckpointManager:
         self.ckpt_dir = get_ckpt_dir(outputs_dir)
         self._logger = get_logger()
         self._world = get_world()
-        self._is_master = self._world.rank == 0
+        self._is_master = self._world.is_master
         self.ckpt_steps: list[int] = []  # Sorted list of steps that have been checkpointed, only used on master rank
 
     def _get_step_path(self, step: int) -> Path:

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -7,6 +7,18 @@ from prime_rl.utils.pydantic_config import BaseConfig
 AttnImplementation: TypeAlias = Literal["sdpa", "flash_attention_2"]
 
 
+class ActivationCheckpointConfig(BaseModel):
+    """Configures activation checkpointing."""
+
+    freq: Annotated[
+        int,
+        Field(
+            ge=1,
+            description="Applies activation checkpointing to every `freq` layers. Defaults to 1, which will is full activation checkpointing.",
+        ),
+    ] = 1
+
+
 class ModelConfig(BaseConfig):
     """Configures the model for training."""
 
@@ -27,11 +39,11 @@ class ModelConfig(BaseConfig):
     ] = False
 
     ac: Annotated[
-        bool,
+        ActivationCheckpointConfig | None,
         Field(
-            description="Whether to apply activation checkpointing to the model.",
+            description="Whether to apply activation checkpointing to the model. If None, will not apply activation checkpointing.",
         ),
-    ] = False
+    ] = None
 
     reshard_after_forward: Annotated[
         bool, Field(description="Whether to reshard the model after each forward pass.")

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -77,6 +77,6 @@ def setup_model(config: ModelConfig) -> Model:
 
 @jaxtyped(typechecker=typechecker)
 def forward(
-    model: Model, input_ids: Int[Tensor, "batch seq"], position_ids: Int[Tensor, "batch seq"]
+    model: nn.Module, input_ids: Int[Tensor, "batch seq"], position_ids: Int[Tensor, "batch seq"]
 ) -> Float[Tensor, "batch seq vocab"]:
     return model(input_ids=input_ids, position_ids=position_ids).logits.float()

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -17,7 +17,7 @@ from transformers import (
 )
 from transformers.tokenization_utils import PreTrainedTokenizer
 
-from prime_rl.trainer.config import ModelConfig
+from prime_rl.trainer.config import ActivationCheckpointConfig, ModelConfig
 
 Model: TypeAlias = LlamaForCausalLM | Qwen2ForCausalLM | Qwen3ForCausalLM
 
@@ -57,18 +57,18 @@ def reshard_module(model: nn.Module):
             module.reshard()
 
 
-def setup_ac(model: Model, config: ModelConfig) -> None:
-    if not config.ac:
-        return
-    for layer_id, transformer_block in model.model.layers.named_children():
-        transformer_block = checkpoint_wrapper(transformer_block, preserve_rng_state=False)
-        model.model.layers.register_module(layer_id, transformer_block)
+def apply_ac(model: Model, ac_config: ActivationCheckpointConfig):
+    for layer_id, (layer_name, transformer_block) in enumerate(model.model.layers.named_children()):
+        if layer_id % ac_config.freq == 0:
+            transformer_block = checkpoint_wrapper(transformer_block, preserve_rng_state=False)
+        model.model.layers.register_module(layer_name, transformer_block)
 
 
-def setup_model(config: ModelConfig) -> Model:
+def setup_model(config: ModelConfig) -> nn.Module:
     model = get_model(config)
     setup_fsdp(model, config)
-    setup_ac(model, config)
+    if config.ac is not None:
+        apply_ac(model, config.ac)
     if config.compile:
         model = torch.compile(model)
     # TODO: This should be type-hinted as FSDP version of the model

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -135,6 +135,10 @@ class RLTrainerConfig(BaseSettings):
             self.max_steps = 4  # 1 Warmup + 3 Benchmark
             if not self.data.fake:
                 self.data.fake = FakeDataLoaderConfig()
+            if self.monitor.wandb: # Do not log extras
+                self.monitor.wandb.log_extras = None
+            if self.ckpt: # Do not checkpoint
+                self.ckpt = None
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -52,7 +52,7 @@ def train(config: RLTrainerConfig):
 
     # Print warning if running in benchmark mode
     if config.bench:
-        logger.warning(f"Running in benchmark mode (max_steps={config.max_steps}, {config.data.fake=})")
+        logger.warning(f"Running in benchmark mode (max_steps={config.max_steps})")
 
     # Setup the monitor
     logger.info(f"Initializing monitor ({config.monitor})")

--- a/src/prime_rl/trainer/sft/config.py
+++ b/src/prime_rl/trainer/sft/config.py
@@ -100,6 +100,10 @@ class SFTTrainerConfig(BaseSettings):
     def auto_setup_bench(self):
         if self.bench:
             self.max_steps = 4  # 1 Warmup + 3 Benchmark
+            if self.monitor.wandb: # Do not log extras
+                self.monitor.wandb.log_extras = None
+            if self.ckpt: # Do not checkpoint
+                self.ckpt = None
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/trainer/sft/config.py
+++ b/src/prime_rl/trainer/sft/config.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Annotated, Literal, TypeAlias
+from typing import Annotated, Literal
 
 from pydantic import Field, model_validator
 
@@ -16,21 +16,6 @@ from prime_rl.utils.config import LogConfig, MultiMonitorConfig
 from prime_rl.utils.pydantic_config import BaseConfig, BaseSettings
 
 
-class FixedLengthFakeDataConfig(BaseConfig):
-    """Configures fixed-length fake data. Will generate sequences of length `seq_len`."""
-
-    type: Literal["fixed"] = "fixed"
-
-
-class VariableLengthFakeDataConfig(BaseConfig):
-    """Configures variable-length fake data with uniform distribution from [0,seq_len]."""
-
-    type: Literal["variable"] = "variable"
-
-
-FakeDataConfigType: TypeAlias = FixedLengthFakeDataConfig | VariableLengthFakeDataConfig
-
-
 class DataConfig(BaseConfig):
     """Configures the data used for training."""
 
@@ -45,9 +30,9 @@ class DataConfig(BaseConfig):
     shuffle: Annotated[bool, Field(description="Whether to shuffle the dataset at the beginning of each epoch.")] = True
 
     fake: Annotated[
-        FakeDataConfigType | None,
+        Literal["fixed", "variable"] | None,
         Field(
-            description="How to generate fake data, mostly used for benchmarking. If None, will use the regular dataset."
+            description="How to generate fake data, mostly used for benchmarking. If fixed, each fake sample will be of length `seq_len`. If variable, each fake sample will be of length `seq_len` with uniform distribution from [0,seq_len]. If None, will use the regular dataset."
         ),
     ] = None
 

--- a/src/prime_rl/trainer/sft/config.py
+++ b/src/prime_rl/trainer/sft/config.py
@@ -39,6 +39,14 @@ class DataConfig(BaseConfig):
             raise ValueError("Batch size must be greater than or equal to micro batch size")
         return self
 
+    def __str__(self):
+        if self.fake:
+            data_str = f"fake={self.fake}"
+        else:
+            data_str = f"name={self.name}, splits={self.splits}, collate_mode={self.collate_mode}, shuffle={self.shuffle}"
+
+        return f"{data_str}, micro_batch_size={self.micro_batch_size}, batch_size={self.batch_size}, seq_len={self.seq_len}"
+
 
 class SFTTrainerConfig(BaseSettings):
     """Configures the SFT trainer"""
@@ -92,8 +100,6 @@ class SFTTrainerConfig(BaseSettings):
     def auto_setup_bench(self):
         if self.bench:
             self.max_steps = 4  # 1 Warmup + 3 Benchmark
-            if not self.data.fake:
-                self.data.fake = True
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -51,7 +51,7 @@ class FakeDataset(IterableDataset):
                 "target_ids": input_ids[1:] + [0],
                 "epoch": 0,
             }
-            return fake_sample
+            yield fake_sample
 
 
 class SFTDataset(IterableDataset):

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -34,11 +34,18 @@ class FakeDataset(IterableDataset):
 
     def __init__(self, tokenizer: PreTrainedTokenizer, config: DataConfig):
         self.config = config
+        assert self.config.fake is not None, "Fake dataset must be specified"
+        self.fake_config = self.config.fake
         self.vocab_size = tokenizer.vocab_size
 
     def __iter__(self) -> Iterator[Sample]:
         while True:
-            input_ids = torch.randint(0, self.vocab_size, (self.config.seq_len+1,)).long().tolist()
+            seq_len = (
+                int(torch.randint(0, self.config.seq_len, (1,)).item())
+                if self.fake_config.type == "variable"
+                else self.config.seq_len
+            )
+            input_ids = torch.randint(0, self.vocab_size, (seq_len + 1,)).long().tolist()
             position_ids = list(range(self.config.seq_len))
             loss_mask = [True] * self.config.seq_len
             fake_sample = {
@@ -59,7 +66,9 @@ class SFTDataset(IterableDataset):
         self._logger = get_logger()
 
         # Load dataset
-        self.dataset: Dataset = concatenate_datasets([load_dataset(config.name, split=split) for split in config.splits])
+        self.dataset: Dataset = concatenate_datasets(
+            [load_dataset(config.name, split=split) for split in config.splits]
+        )
 
         # Assert that the dataset has a 'text' column
         if "prompt" not in self.dataset.column_names or "completion" not in self.dataset.column_names:
@@ -186,10 +195,12 @@ class PaddingDataset(IterableDataset):
 
 def collate(samples: list[Sample]) -> Batch:
     return {
-        "input_ids": torch.stack([torch.tensor(sample["input_ids"]) for sample in samples], dim=0).long(),
-        "position_ids": torch.stack([torch.tensor(sample["position_ids"]) for sample in samples], dim=0).long(),
-        "loss_mask": torch.stack([torch.tensor(sample["loss_mask"]) for sample in samples], dim=0).bool(),
-        "target_ids": torch.stack([torch.tensor(sample["target_ids"]) for sample in samples], dim=0).long(),
+        "input_ids": torch.stack([torch.tensor(sample["input_ids"]) for sample in samples], dim=0).long().to("cuda"),
+        "position_ids": torch.stack([torch.tensor(sample["position_ids"]) for sample in samples], dim=0)
+        .long()
+        .to("cuda"),
+        "loss_mask": torch.stack([torch.tensor(sample["loss_mask"]) for sample in samples], dim=0).bool().to("cuda"),
+        "target_ids": torch.stack([torch.tensor(sample["target_ids"]) for sample in samples], dim=0).long().to("cuda"),
         "epoch": min([sample["epoch"] for sample in samples]),
     }
 

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -38,17 +38,14 @@ class FakeDataset(IterableDataset):
 
     def __iter__(self) -> Iterator[Sample]:
         while True:
-            rand_seq_len = int(torch.randint(1, self.config.seq_len + 1, (1,)).item())
-            # simulate different sequence lengths
-            input_ids = torch.randint(0, self.vocab_size, (rand_seq_len + 1,)).long().tolist()
-            position_ids = torch.arange(len(input_ids)).long()
-            loss_mask = torch.ones(len(input_ids)).bool()
-            loss_mask[-1] = False
+            input_ids = torch.randint(0, self.vocab_size, (self.config.seq_len+1,)).long().tolist()
+            position_ids = list(range(self.config.seq_len))
+            loss_mask = [True] * self.config.seq_len
             fake_sample = {
-                "input_ids": input_ids,
+                "input_ids": input_ids[:-1],
+                "target_ids": input_ids[1:],
                 "position_ids": position_ids,
                 "loss_mask": loss_mask,
-                "target_ids": input_ids[1:] + [0],
                 "epoch": 0,
             }
             yield fake_sample

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -35,14 +35,14 @@ class FakeDataset(IterableDataset):
     def __init__(self, tokenizer: PreTrainedTokenizer, config: DataConfig):
         self.config = config
         assert self.config.fake is not None, "Fake dataset must be specified"
-        self.fake_config = self.config.fake
+        self.fake_type = self.config.fake
         self.vocab_size = tokenizer.vocab_size
 
     def __iter__(self) -> Iterator[Sample]:
         while True:
             seq_len = (
                 int(torch.randint(0, self.config.seq_len, (1,)).item())
-                if self.fake_config.type == "variable"
+                if self.fake_type == "variable"
                 else self.config.seq_len
             )
             input_ids = torch.randint(0, self.vocab_size, (seq_len + 1,)).long().tolist()

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -39,7 +39,7 @@ def train(config: SFTTrainerConfig):
 
     # Print warning if running in benchmark mode
     if config.bench:
-        logger.warning(f"Running in benchmark mode (max_steps={config.max_steps}, {config.data.fake=})")
+        logger.warning(f"Running in benchmark mode (max_steps={config.max_steps})")
 
     # Setup the monitor
     logger.info(f"Initializing monitor ({config.monitor})")

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -1,4 +1,5 @@
 import time
+from time import perf_counter as timer
 
 # Import environment before any other imports
 # ruff: noqa: I001
@@ -91,83 +92,101 @@ def train(config: SFTTrainerConfig):
     is_first_step = True
     while True:
         # Save the full checkpoint (if we are at an interval step and not at the first or last step)
-        is_last_step = config.max_steps is not None and progress.step == config.max_steps - 1
-        save_ckpt_time = 0
-        if (
-            ckpt_manager is not None
-            and weight_ckpt_manager is not None
-            and config.ckpt
-            and config.ckpt.interval
-            and not (is_first_step or is_last_step)
-            and progress.step % config.ckpt.interval == 0
-        ):
-            logger.info(f"Saving checkpoint at step {progress.step}")
-            save_ckpt_start_time = time.time()
-            ckpt_manager.save(model, [optimizer], scheduler, progress, step=progress.step)
-            weight_ckpt_manager.save(model, tokenizer, step=progress.step)
-            save_ckpt_time = time.time() - save_ckpt_start_time
+        # is_last_step = config.max_steps is not None and progress.step == config.max_steps - 1
+        # save_ckpt_time = 0
+        # if (
+        #     ckpt_manager is not None
+        #     and weight_ckpt_manager is not None
+        #     and config.ckpt
+        #     and config.ckpt.interval
+        #     and not (is_first_step or is_last_step)
+        #     and progress.step % config.ckpt.interval == 0
+        # ):
+        #     logger.info(f"Saving checkpoint at step {progress.step}")
+        #     save_ckpt_start_time = time.time()
+        #     ckpt_manager.save(model, [optimizer], scheduler, progress, step=progress.step)
+        #     weight_ckpt_manager.save(model, tokenizer, step=progress.step)
+        #     save_ckpt_time = time.time() - save_ckpt_start_time
 
-            # Maybe clean up old trainer checkpoints
-            ckpt_manager.maybe_clean()
+        #     # Maybe clean up old trainer checkpoints
+        #     ckpt_manager.maybe_clean()
 
         # Break if we have reached the maximum number of steps
         if config.max_steps is not None and progress.step >= config.max_steps:
             break
 
-        if config.profile_path and world.rank == 0:
-            torch.cuda.memory._record_memory_history()
+        # if config.profile_path and world.rank == 0:
+        #     torch.cuda.memory._record_memory_history()
 
         step_start_time = time.time()
         forward_backward_start_time = time.time()
-        tensors = Tensors()  # Used to accumulate tensor statistics across grad acc and ranks for logging
+        # tensors = Tensors()  # Used to accumulate tensor statistics across grad acc and ranks for logging
         grad_accum_steps = config.data.batch_size // (config.data.micro_batch_size * world.world_size)
         for micro_step in range(grad_accum_steps):
+            t0 = timer()
             micro_batch = next(dataloader)
+            t1 = timer()
             input_ids = micro_batch["input_ids"].to("cuda")
             position_ids = micro_batch["position_ids"].to("cuda")
             target_ids = micro_batch["target_ids"].to("cuda")
             loss_mask = micro_batch["loss_mask"].to("cuda")
             epoch = micro_batch["epoch"]
+            torch.cuda.synchronize()
+            t2 = timer()
             assert input_ids.shape[0] == position_ids.shape[0]
 
             # Forward pass
             logits = forward(model, input_ids, position_ids).contiguous()
+            torch.cuda.synchronize()
+            t3 = timer()
             B, L, V = logits.shape
 
             # Compute loss
             loss = cross_entropy(logits.view(-1, V), target_ids.view(-1), reduction="none").view(B, L)
+            torch.cuda.synchronize()
+            t4 = timer()
 
             # Compute accuracy
-            probs = softmax(logits, dim=-1)
-            pred_ids = probs.argmax(dim=-1)
-            accuracy = torch.eq(pred_ids, target_ids).float()
+            with torch.no_grad():
+                probs = softmax(logits, dim=-1)
+                pred_ids = probs.argmax(dim=-1)
+                accuracy = torch.eq(pred_ids, target_ids).float()
+            torch.cuda.synchronize()
+            t5 = timer()
 
             # Add tensors to tensor dict for logging purposes
-            tensors["loss"].append(loss[loss_mask].detach().to("cpu"))
-            tensors["accuracy"].append(accuracy[loss_mask].detach().to("cpu"))
+            # tensors["loss"].append(loss[loss_mask].detach().to("cpu"))
+            # tensors["accuracy"].append(accuracy[loss_mask].detach().to("cpu"))
 
             # Mean reduction of unmasked tokens
             loss = loss[loss_mask].mean()
 
             # Scale loss by number of gradient accumulation steps
             loss /= grad_accum_steps
+            t6 = timer()
 
             # Delete logits before backward pass to avoid memory spike
             del logits
+            t7 = timer()
 
             # Backward pass
             loss.backward()
+            torch.cuda.synchronize()
+            t8 = timer()
+
+            logger.debug(f"Total: {1000 * (t8 - t0):.2f}ms | Load micro batch: {1000 * (t1 - t0):.2f}ms | Move to GPU: {1000 * (t2 - t1):.2f}ms | Forward pass: {1000 * (t3 - t2):.2f}ms | Compute loss: {1000 * (t4 - t3):.2f}ms | Compute accuracy: {1000 * (t5 - t4):.2f}ms | Scale loss: {1000 * (t6 - t5):.2f}ms | Delete logits: {1000 * (t7 - t6):.2f}ms | Backward pass: {1000 * (t8 - t7):.2f}ms")
 
             # Debug log with *local, micro step* stats
-            logger.debug(
-                f"Micro Step {micro_step} | Loss: {tensors['loss'][-1].mean().item():.4f} | Accuracy: {tensors['accuracy'][-1].mean().item():.4f}"
-            )
+            # logger.debug(
+            #     f"Micro Step {micro_step} | Loss: {tensors['loss'][-1].mean().item():.4f} | Accuracy: {tensors['accuracy'][-1].mean().item():.4f}"
+            # )
 
         # Optionally, clip the gradients
         logger.debug(f"Clipping gradients to {config.optim.max_norm}")
         grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=config.optim.max_norm).full_tensor()
 
         # Update the model parameters
+        logger.debug(f"Optmizer step")
         optimizer.step()
         optimizer.zero_grad()
 
@@ -177,16 +196,16 @@ def train(config: SFTTrainerConfig):
         forward_backward_time = time.time() - forward_backward_start_time
 
         # Optionally, dump memory snapshot
-        if config.profile_path and progress.step == 2 and world.rank == 0:
-            logger.debug("Dumping memory snapshot")
-            profile_path = config.profile_path
-            if not profile_path.suffix == ".pickle":
-                profile_path = profile_path.with_suffix(".pickle")
-            torch.cuda.memory._dump_snapshot(profile_path.as_posix())
-            torch.cuda.memory._record_memory_history(enabled=None)
+        # if config.profile_path and progress.step == 2 and world.rank == 0:
+        #     logger.debug("Dumping memory snapshot")
+        #     profile_path = config.profile_path
+        #     if not profile_path.suffix == ".pickle":
+        #         profile_path = profile_path.with_suffix(".pickle")
+        #     torch.cuda.memory._dump_snapshot(profile_path.as_posix())
+        #     torch.cuda.memory._record_memory_history(enabled=None)
 
         # Synchronize the tensor metrics across all steps and ranks
-        tensor_stats = tensors.compute_stats()
+        # tensor_stats = tensors.compute_stats()
 
         # Compute step metrics
         num_tokens = config.data.batch_size * config.data.seq_len
@@ -199,20 +218,20 @@ def train(config: SFTTrainerConfig):
 
         # Log step metrics
         step_time = time.time() - step_start_time
-        current_lr = optimizer.param_groups[0]["lr"]
-        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {tensor_stats['loss/mean']:.4f} | Accuracy: {tensor_stats['accuracy/mean']:.4f} | Grad. Norm: {grad_norm:.4f} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}%"
-        logger.success(step_message)
+        # current_lr = optimizer.param_groups[0]["lr"]
+        # step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {tensor_stats['loss/mean']:.4f} | Accuracy: {tensor_stats['accuracy/mean']:.4f} | Grad. Norm: {grad_norm:.4f} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}%"
+        # logger.success(step_message)
 
-        # Log progress metrics
-        progress_metrics = {
-            "progress/epoch": epoch,
-            "progress/total_samples": progress.total_samples,
-            "progress/total_tokens": progress.total_tokens,
-            "step": progress.step,
-        }
-        monitor.log(progress_metrics)
+        # # Log progress metrics
+        # progress_metrics = {
+        #     "progress/epoch": epoch,
+        #     "progress/total_samples": progress.total_samples,
+        #     "progress/total_tokens": progress.total_tokens,
+        #     "step": progress.step,
+        # }
+        # monitor.log(progress_metrics)
 
-        # Log performance metrics
+        # # Log performance metrics
         perf_metrics = {
             "perf/throughput": throughput,
             "perf/mfu": mfu,
@@ -220,49 +239,49 @@ def train(config: SFTTrainerConfig):
         }
         monitor.log(perf_metrics)
 
-        # Log optimizer metrics
-        optim_metrics = {
-            "optim/lr": current_lr,
-            "optim/grad_norm": grad_norm.item(),
-            "step": progress.step,
-        }
-        monitor.log(optim_metrics)
+        # # Log optimizer metrics
+        # optim_metrics = {
+        #     "optim/lr": current_lr,
+        #     "optim/grad_norm": grad_norm.item(),
+        #     "step": progress.step,
+        # }
+        # monitor.log(optim_metrics)
 
-        # Log tensor stats
-        tensor_stats["step"] = progress.step
-        monitor.log(tensor_stats)
+        # # Log tensor stats
+        # tensor_stats["step"] = progress.step
+        # monitor.log(tensor_stats)
 
-        # Log time metrics
+        # # Log time metrics
         time_metrics = {
             "time/step": step_time,
-            "time/save_ckpt": save_ckpt_time,
+            # "time/save_ckpt": save_ckpt_time,
             "time/forward_backward": forward_backward_time,
             "step": progress.step,
         }
         monitor.log(time_metrics)
 
-        # Log distributions to W&B table if enabled
-        if monitor.wandb:
-            assert all(len(tensors) == 1 for tensors in tensors.values()), "Tensors must be lists of length 1"
-            distributions = {key: tensors[key][0] for key in tensors.keys()}
-            monitor.wandb.log_distributions(
-                distributions=distributions,
-                step=progress.step,
-            )
+        # # Log distributions to W&B table if enabled
+        # if monitor.wandb:
+        #     assert all(len(tensors) == 1 for tensors in tensors.values()), "Tensors must be lists of length 1"
+        #     distributions = {key: tensors[key][0] for key in tensors.keys()}
+        #     monitor.wandb.log_distributions(
+        #         distributions=distributions,
+        #         step=progress.step,
+        #     )
 
-        is_first_step = False
+        # is_first_step = False
         progress.step += 1
 
     # Log final (immutable) distributions to W&B table
-    if monitor.wandb:
-        logger.info("Logging final distributions as W&B table")
-        monitor.wandb.log_final_distributions()
+    # if monitor.wandb:
+    #     logger.info("Logging final distributions as W&B table")
+    #     monitor.wandb.log_final_distributions()
 
-    # Write final checkpoint
-    if config.ckpt and ckpt_manager is not None and weight_ckpt_manager is not None:
-        logger.info("Writing final checkpoint")
-        ckpt_manager.save(model, [optimizer], scheduler, progress, step=progress.step)
-        weight_ckpt_manager.save(model, tokenizer, step=progress.step)
+    # # Write final checkpoint
+    # if config.ckpt and ckpt_manager is not None and weight_ckpt_manager is not None:
+    #     logger.info("Writing final checkpoint")
+    #     ckpt_manager.save(model, [optimizer], scheduler, progress, step=progress.step)
+    #     weight_ckpt_manager.save(model, tokenizer, step=progress.step)
 
     logger.info(f"Peak memory: {torch.cuda.max_memory_allocated() / 1024**3:.2f} GB")
     logger.success("SFT trainer finished!")

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -83,13 +83,8 @@ def train(config: SFTTrainerConfig):
     )
 
     # Set up the dataset and dataloader (optionaly, use a fake dataset for debugging)
-    logger.info(f"Initializing dataset (name={config.data.name}, splits={config.data.splits})")
+    logger.info(f"Initializing data ({config.data})")
     dataset = setup_dataset(tokenizer, config.data)
-
-    # Set up the dataloader over micro batches
-    logger.info(
-        f"Initializing dataloader (micro_batch_size={config.data.micro_batch_size}, batch_size={config.data.batch_size}, collate_mode={config.data.collate_mode})"
-    )
     dataloader = iter(setup_dataloader(dataset, tokenizer, config.data))
 
     logger.info(f"Starting training loop ({config.max_steps=})")

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -268,7 +268,7 @@ def train(config: SFTTrainerConfig):
     logger.success("SFT trainer finished!")
 
     # Optionally, print benchmark table
-    if config.bench:
+    if config.bench and world.is_master:
         print_benchmark(to_col_format(monitor.history))
 
 

--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -76,8 +76,8 @@ def print_benchmark(history: dict[str, list[Any]]) -> None:
     # Turn metric history into pd.DataFrame
     df = pd.DataFrame(dict(history.items()))
     columns = {
-        "perf/train/throughput": "Throughput",
-        "time/train": "Step Time",
+        "perf/throughput": "Throughput",
+        "time/step": "Step Time",
     }
     df = df[columns.keys()].rename(columns=columns)
     df = df.iloc[1:]  # Exclude first row

--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -76,6 +76,7 @@ def print_benchmark(history: dict[str, list[Any]]) -> None:
     # Turn metric history into pd.DataFrame
     df = pd.DataFrame(dict(history.items()))
     columns = {
+        "perf/mfu": "MFU",
         "perf/throughput": "Throughput",
         "time/step": "Step Time",
     }
@@ -93,8 +94,9 @@ def print_benchmark(history: dict[str, list[Any]]) -> None:
 
     # Add formatted rows
     formatted_df = pd.DataFrame(columns=df.columns)
+    formatted_df["MFU"] = df["MFU"].apply(lambda x: f"{format_num(x, precision=2)}%")
+    formatted_df["Throughput"] = df["Throughput"].apply(lambda x: format_num(x, precision=2))
     formatted_df["Step Time"] = df["Step Time"].apply(format_time)
-    formatted_df["Throughput"] = df["Throughput"].apply(format_num, precision=2)
     for step, row in formatted_df.iterrows():
         table.add_row(*([str(step)] + [str(x) for x in row]))
 
@@ -104,8 +106,9 @@ def print_benchmark(history: dict[str, list[Any]]) -> None:
     # Add row for formatted, aggregated statistics
     mean_df = df.describe().loc[["mean", "std", "min", "max"], :]
     formatted_mean_df = pd.DataFrame(columns=mean_df.columns)
-    formatted_mean_df["Step Time"] = mean_df["Step Time"].apply(format_time)
+    formatted_mean_df["MFU"] = mean_df["MFU"].apply(lambda x: f"{format_num(x, precision=2)}%")
     formatted_mean_df["Throughput"] = mean_df["Throughput"].apply(format_num, precision=2)
+    formatted_mean_df["Step Time"] = mean_df["Step Time"].apply(format_time)
     mean_row = ["Overall"] + formatted_mean_df.T.apply(
         lambda row: f"{row['mean']} ± {row['std']} [{row['min']}, {row['max']}]", axis=1
     ).tolist()

--- a/src/prime_rl/trainer/weights.py
+++ b/src/prime_rl/trainer/weights.py
@@ -29,7 +29,7 @@ class WeightCheckpointManager:
         self.async_level = async_level
         self._logger = get_logger()
         self._world = get_world()
-        self._is_master = self._world.rank == 0
+        self._is_master = self._world.is_master
 
     def _get_model_path(self, step: int) -> Path:
         return get_weight_ckpt_model_path(self.weights_dir, step)

--- a/src/prime_rl/trainer/world.py
+++ b/src/prime_rl/trainer/world.py
@@ -19,6 +19,10 @@ class World:
         # TODO: This is only true if we have evenly distributed node groups, which is probably a fair assumption (maybe at some point we want to run uneven node groups for pipelined inference)
         assert self.world_size % self.local_world_size == 0
 
+    @property
+    def is_master(self):
+        return self.rank == 0
+
     def __repr__(self):
         return f"World(world_size={self.world_size}, rank={self.rank}, local_rank={self.local_rank}, local_world_size={self.local_world_size}, num_nodes={self.num_nodes})"
 


### PR DESCRIPTION
Fixes and improvements to the benchmark suite on the SFT trainer (some also apply to RL trainer):
- Fix `print_benchmark` trying to parse outdates logging keys
- Also print MFU in benchmark table
- Bring back layer-wise partial activation checkpointing with `--model.ac.freq` which is an integer specifying that ever `freq`-th layer will be ACd. Confirmed that in specific settings checkpointing half the layers gives best MFU.
- More sophisticated fake data loader for benchmarking with mode `fixed` (all samples will be exactly `seq_len`) and `variable` (all samples have uniformly random length in interval [0, seq_len])