### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+## Description
+
+<!-- Provide a brief description of the changes in this PR -->
+
+---
+
+<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->
+
+**GitHub Issue**: <Issue ID>
+**Linear Issue**: Resolves <Ticket ID>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,8 @@
 
 I was too lazy to explain my changes, decreasing my chances of this ever getting merged.
 
+---
+
 <!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->
 
 **GitHub Issue**: [Issue ID]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,5 +6,5 @@
 
 <!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->
 
-**GitHub Issue**: <Issue ID>
-**Linear Issue**: Resolves <Ticket ID>
+**GitHub Issue**: [Issue ID]
+**Linear Issue**: Resolves [Issue ID]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,6 @@
-## Description
-
 <!-- Provide a brief description of the changes in this PR -->
 
----
+I was too lazy to explain my changes, decreasing my chances of this ever getting merged.
 
 <!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->
 


### PR DESCRIPTION
Adds a minimalistic PR template to nudge people to properly link their PRs to GH and Linear issues.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: #756 
**Linear Issue**: Resolves PRIMERL-38