### PR TITLE
Adapt swebench example to prime-rl verifier

### DIFF
--- a/environments/vf_swebench/README.md
+++ b/environments/vf_swebench/README.md
@@ -1,0 +1,24 @@
+# vf-swebench
+
+### Overview
+- **Environment ID**: `vf-swebench`
+- **Short description**: Single-turn SWE-bench style tasks; the model outputs a unified diff patch inside XML tags; graded by structure and similarity.
+- **Tags**: code, patch, single-turn, xml, swebench
+
+### Quickstart
+
+```bash
+uv run vf-eval vf-swebench
+```
+
+With custom args (limit rows, pick a split):
+
+```bash
+uv run vf-eval vf-swebench \
+  -a '{"hf_dataset_path": "princeton-nlp/SWE-bench_Lite", "split": "train", "limit": 100}'
+```
+
+<!-- Do not edit below this line. Content is auto-generated. -->
+<!-- vf:begin:reports -->
+<p>No reports found. Run <code>uv run vf-eval vf-swebench -a '{"key": "value"}'</code> to generate one.</p>
+<!-- vf:end:reports -->

--- a/environments/vf_swebench/pyproject.toml
+++ b/environments/vf_swebench/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "vf-swebench"
+version = "0.1.0"
+tags = ["code", "patch", "single-turn", "xml", "swebench"]
+license = "Apache-2.0"
+description = "SWE-bench style environment where the model outputs a unified diff patch inside XML tags."
+dependencies = [
+    "verifiers>=0.1.2",
+    "datasets",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+include = ["vf_swebench.py"]

--- a/environments/vf_swebench/vf_swebench.py
+++ b/environments/vf_swebench/vf_swebench.py
@@ -1,0 +1,169 @@
+import difflib
+import json
+from typing import Any
+
+import verifiers as vf
+from datasets import Dataset, load_dataset
+
+
+def load_environment(
+    hf_dataset_path: str = "princeton-nlp/SWE-bench_Lite",
+    split: str = "train",
+    limit: int | None = None,
+    max_concurrent: int = 8,
+    **kwargs: Any,
+) -> vf.Environment:
+    """
+    SWE-bench style environment.
+
+    The model is prompted with a bug description and should return a unified diff patch inside
+    <patch>...</patch> XML tags (optionally preceded by <think>...</think> thought).
+
+    Reward combines:
+      - format/structure checks for unified diff-like output
+      - text similarity to the ground-truth patch when available
+    """
+
+    def build_prompt(example: dict) -> str:
+        repo = example.get("repo") or example.get("repository") or "<unknown-repo>"
+        base = example.get("base_commit") or example.get("commit") or "<unknown-commit>"
+        problem = (
+            example.get("problem_statement")
+            or example.get("prompt")
+            or example.get("issue")
+            or example.get("task")
+            or "Fix the bug described below and return a unified diff patch."
+        )
+        hint = example.get("hints") or example.get("hints_text")
+
+        # Light, self-contained instruction that matches our XMLParser usage
+        instruction = [
+            "You are given a repository and base commit.",
+            f"Repository: {repo}",
+            f"Base commit: {base}",
+            "Problem:",
+            str(problem).strip(),
+        ]
+        if hint:
+            instruction += ["Hints:", str(hint).strip()]
+
+        instruction += [
+            "Produce only a patch in unified diff format inside <patch>...</patch>.",
+            "You may optionally reason in <think>...</think> before the patch.",
+            "Do not include commands to run. Only the patch content.",
+        ]
+        return "\n".join(instruction)
+
+    def load_or_build_dataset() -> Dataset:
+        try:
+            ds = load_dataset(hf_dataset_path, split=split)
+        except Exception:
+            # Fall back to a tiny in-memory demo if HF dataset is unavailable
+            data = [
+                {
+                    "repo": "example/project",
+                    "base_commit": "deadbeef",
+                    "problem_statement": "A function returns an incorrect sum when inputs are negative.",
+                    "patch": """diff --git a/math.py b/math.py
+index e69de29..b1f2c00 100644
+--- a/math.py
++++ b/math.py
+@@ -1,4 +1,4 @@
+-def add(a, b):
+-    return a - b
++def add(a, b):
++    return a + b
+""",
+                }
+            ]
+            return Dataset.from_list(data)
+
+        if limit is not None:
+            ds = ds.select(range(min(limit, len(ds))))
+
+        return ds
+
+    raw_ds = load_or_build_dataset()
+
+    def to_env_example(x: dict) -> dict:
+        # Ground-truth patch field varies across SWE-bench variants; try common keys
+        gt_patch = (
+            x.get("patch")
+            or x.get("diff")
+            or x.get("ground_truth_patch")
+            or x.get("solution_patch")
+            or ""
+        )
+        return {
+            "prompt": [{"role": "user", "content": build_prompt(x)}],
+            "answer": gt_patch,
+            "task": "swebench",
+            "info": {
+                k: x.get(k)
+                for k in (
+                    "repo",
+                    "repository",
+                    "base_commit",
+                    "commit",
+                    "instance_id",
+                    "tests",
+                    "test_commands",
+                )
+                if k in x
+            },
+        }
+
+    dataset = raw_ds.map(to_env_example)
+
+    parser = vf.XMLParser(["think", "patch"], answer_field="patch")
+
+    def patch_structure_reward(completion, **kwargs) -> float:
+        parsed = parser.parse_answer(completion)
+        if not parsed:
+            return 0.0
+        try:
+            text = parsed.strip()
+        except Exception:
+            return 0.0
+
+        score = 1.0
+        # Basic unified diff markers
+        has_file_headers = ("--- " in text) and ("+++ " in text)
+        has_hunks = "@@" in text
+        has_git_header = "diff --git" in text or text.startswith("Index: ")
+
+        if not has_file_headers:
+            score *= 0.5
+        if not has_hunks:
+            score *= 0.7
+        if not has_git_header:
+            score *= 0.8
+
+        # Penalize extremely short patches
+        if len(text.splitlines()) < 4:
+            score *= 0.5
+
+        return float(max(0.0, min(1.0, score)))
+
+    def patch_similarity_reward(completion, answer: str, **kwargs) -> float:
+        parsed = parser.parse_answer(completion)
+        if not parsed:
+            return 0.0
+        if not isinstance(answer, str) or not answer:
+            # If we don't have a ground truth patch, fall back to structure only
+            return patch_structure_reward(completion)
+        try:
+            matcher = difflib.SequenceMatcher(None, parsed, answer)
+            return float(matcher.ratio())
+        except Exception:
+            return 0.0
+
+    rubric = vf.Rubric(
+        funcs=[
+            patch_structure_reward,
+            patch_similarity_reward,
+        ],
+        weights=[0.3, 0.7],
+    )
+
+    return vf.SingleTurnEnv(dataset=dataset, parser=parser, rubric=rubric, max_concurrent=max_concurrent)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ vf = [
     "vf-skywork-math",
     "vf-unscramble",
     "vf-alphabet-sort",
+    "vf-swebench",
 ]
 
 [tool.uv]
@@ -79,6 +80,7 @@ vf-hendrycks-math = { workspace = true }
 vf-skywork-math = { workspace = true }
 vf-unscramble = { workspace = true }
 vf-alphabet-sort = { workspace = true }
+vf-swebench = { workspace = true }
 
 [[tool.uv.index]]
 name = "pytorch-cu128"

--- a/uv.lock
+++ b/uv.lock
@@ -20,6 +20,7 @@ members = [
     "vf-reverse-text",
     "vf-skywork-math",
     "vf-unscramble",
+    "vf-swebench",
 ]
 
 [[package]]
@@ -2100,6 +2101,7 @@ requires-dist = [
     { name = "vf-reverse-text", marker = "extra == 'vf'", editable = "environments/vf_reverse_text" },
     { name = "vf-skywork-math", marker = "extra == 'vf'", editable = "environments/vf_skywork_math" },
     { name = "vf-unscramble", marker = "extra == 'vf'", editable = "environments/vf_unscramble" },
+    { name = "vf-swebench", marker = "extra == 'vf'", editable = "environments/vf_swebench" },
     { name = "vllm", specifier = "==0.10.0" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -3371,6 +3373,11 @@ requires-dist = [{ name = "verifiers", git = "https://github.com/willccbb/verifi
 name = "vf-unscramble"
 version = "0.1.1"
 source = { editable = "environments/vf_unscramble" }
+
+[[package]]
+name = "vf-swebench"
+version = "0.1.0"
+source = { editable = "environments/vf_swebench" }
 dependencies = [
     { name = "datasets" },
     { name = "verifiers" },


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Implemented a new `vf-swebench` environment plugin to enable evaluation of models on SWE-bench style patch generation tasks. This verifier parses model output for unified diffs and scores based on patch structure and similarity to ground truth, aligning with existing `prime-rl` verifier patterns.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: [Issue ID]
**Linear Issue**: Resolves [Issue ID]

---
<a href="https://cursor.com/background-agent?bcId=bc-98c75ab4-5b29-476e-8221-822d653db166">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-98c75ab4-5b29-476e-8221-822d653db166">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

