### PR TITLE
Remove torch.dist warning print when saving weight checkpoint

### DIFF
--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -1,5 +1,6 @@
 import threading
 import time
+import warnings
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
@@ -61,8 +62,14 @@ class CheckpointManager:
 
         # Create checkpoint directory if it doesn't exist
         ckpt_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(ckpt_path, "wb") as f:
-            torch.save(ckpt_state, f)
+        
+        # Suppress torch.distributed warnings during checkpoint saving
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=FutureWarning, module="torch.distributed")
+            warnings.filterwarnings("ignore", category=UserWarning, module="torch.distributed")
+            
+            with open(ckpt_path, "wb") as f:
+                torch.save(ckpt_state, f)
 
         # Append to list of saved steps
         if self._is_master:

--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
 from itertools import chain
 from typing import Any, TypeAlias
-import warnings
 
 import pandas as pd
 import torch
@@ -130,29 +129,24 @@ def flexible_all_gather(tensor: Tensor) -> Tensor:
     if dist.get_world_size() == 1:
         return tensor
 
-    # Suppress torch.distributed warnings during tensor gathering
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=FutureWarning, module="torch.distributed")
-        warnings.filterwarnings("ignore", category=UserWarning, module="torch.distributed")
-        
-        # Find the tensor with the most elements
-        local_numel = tensor.numel()
-        local_numel_tensor = torch.tensor(local_numel, device=tensor.device)
-        all_numel_tensors = [torch.tensor(0, device=tensor.device) for _ in range(dist.get_world_size())]
-        dist.all_gather(all_numel_tensors, local_numel_tensor)
-        all_numels = [numel.item() for numel in all_numel_tensors]
-        max_numel = int(max(all_numels))
+    # Find the tensor with the most elements
+    local_numel = tensor.numel()
+    local_numel_tensor = torch.tensor(local_numel, device=tensor.device)
+    all_numel_tensors = [torch.tensor(0, device=tensor.device) for _ in range(dist.get_world_size())]
+    dist.all_gather(all_numel_tensors, local_numel_tensor)
+    all_numels = [numel.item() for numel in all_numel_tensors]
+    max_numel = int(max(all_numels))
 
-        # Pad the tensor with zeros if it has less elements than the maximum
-        if local_numel < max_numel:
-            tensor = torch.cat([tensor, torch.zeros(max_numel - local_numel, dtype=tensor.dtype, device=tensor.device)])
+    # Pad the tensor with zeros if it has less elements than the maximum
+    if local_numel < max_numel:
+        tensor = torch.cat([tensor, torch.zeros(max_numel - local_numel, dtype=tensor.dtype, device=tensor.device)])
 
-        # All-gather the tensors
-        all_tensors = [
-            torch.zeros(max_numel, dtype=tensor.dtype, device=tensor.device) for _ in range(dist.get_world_size())
-        ]
-        dist.all_gather(all_tensors, tensor)
-        all_tensors_unpadded = torch.cat([tensor[:numel] for tensor, numel in zip(all_tensors, all_numels)])
+    # All-gather the tensors
+    all_tensors = [
+        torch.zeros(max_numel, dtype=tensor.dtype, device=tensor.device) for _ in range(dist.get_world_size())
+    ]
+    dist.all_gather(all_tensors, tensor)
+    all_tensors_unpadded = torch.cat([tensor[:numel] for tensor, numel in zip(all_tensors, all_numels)])
 
     return all_tensors_unpadded
 

--- a/src/prime_rl/trainer/weights.py
+++ b/src/prime_rl/trainer/weights.py
@@ -1,6 +1,7 @@
 import shutil
 import threading
 import time
+import warnings
 from pathlib import Path
 
 import torch
@@ -42,21 +43,27 @@ class WeightCheckpointManager:
         start_time = time.time()
         self._logger.debug("Gathering sharded weights")
 
-        cpu_state = {}
-        for key, value in model.state_dict().items():
-            if isinstance(value, DTensor):
-                value = value.to(dtype)
-                # only gather after the downcast to dtype as it will be faster
-                value = value.full_tensor()
+        # Suppress torch.distributed warnings during checkpoint saving
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=FutureWarning, module="torch.distributed")
+            warnings.filterwarnings("ignore", category=UserWarning, module="torch.distributed")
+            
+            cpu_state = {}
+            for key, value in model.state_dict().items():
+                if isinstance(value, DTensor):
+                    value = value.to(dtype)
+                    # only gather after the downcast to dtype as it will be faster
+                    value = value.full_tensor()
 
-            if self._is_master:
-                key = get_fqns(model, key)
-                assert len(key) == 1
-                key = next(iter(key))
-                # TODO(Sami) Blocking to avoid race condition, should make non-blocking long-term tho
-                cpu_state[key] = value.to("cpu", non_blocking=False)
+                if self._is_master:
+                    key = get_fqns(model, key)
+                    assert len(key) == 1
+                    key = next(iter(key))
+                    # TODO(Sami) Blocking to avoid race condition, should make non-blocking long-term tho
+                    cpu_state[key] = value.to("cpu", non_blocking=False)
 
-        torch.distributed.barrier()
+            torch.distributed.barrier()
+        
         self._logger.debug(f"Gathered sharded weights in {time.time() - start_time:.2f} seconds")
 
         return cpu_state
@@ -69,18 +76,23 @@ class WeightCheckpointManager:
         self._logger.debug(f"Saving weight checkpoint to {step_path}")
         start_time = time.time()
 
-        # Save model weights to temporary file to avoid race condition
-        model_path = self._get_model_path(step)
-        tmp_model_path = model_path.with_suffix(".tmp")
-        torch.save(cpu_state, tmp_model_path)
-        # Rename temporary file to indicate checkpoint is complete
-        tmp_model_path.rename(model_path)
+        # Suppress torch.distributed warnings during checkpoint saving
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=FutureWarning, module="torch.distributed")
+            warnings.filterwarnings("ignore", category=UserWarning, module="torch.distributed")
+            
+            # Save model weights to temporary file to avoid race condition
+            model_path = self._get_model_path(step)
+            tmp_model_path = model_path.with_suffix(".tmp")
+            torch.save(cpu_state, tmp_model_path)
+            # Rename temporary file to indicate checkpoint is complete
+            tmp_model_path.rename(model_path)
 
-        # Save model config, generation arguments and tokenizer
-        model.config.save_pretrained(step_path)
-        if model.generation_config:
-            model.generation_config.save_pretrained(step_path)
-        tokenizer.save_pretrained(step_path)
+            # Save model config, generation arguments and tokenizer
+            model.config.save_pretrained(step_path)
+            if model.generation_config:
+                model.generation_config.save_pretrained(step_path)
+            tokenizer.save_pretrained(step_path)
 
         self._logger.debug(f"Saved weight checkpoint to {step_path} in {time.time() - start_time:.2f} seconds")
 


### PR DESCRIPTION
Remove torch.distributed warning prints when saving weight checkpoints (#747)

This PR suppresses **torch.distributed** warnings that were being printed during checkpoint saving operations.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: [747](https://github.com/PrimeIntellect-ai/prime-rl/issues/747)