### PR TITLE
Add eval artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ configs/endpoints.py
 **/rollouts
 **/logs
 **/wandb
+**/evals
 .pydantic_config
 
 # Byte-compiled / optimized / DLL files

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -18,6 +18,7 @@ confirm_cleanup() {
     echo "  - **/weights"
     echo "  - **/rollouts"
     echo "  - **/wandb"
+    echo "  - **/evals"
     echo "  - .pydantic_config"
     while true; do
         read -r -p "Proceed? [y/N]: " response

--- a/src/prime_rl/eval/config.py
+++ b/src/prime_rl/eval/config.py
@@ -30,13 +30,6 @@ class OfflineEvalConfig(EvalConfig, BaseSettings):
         ),
     ] = Path("outputs")
 
-    save: Annotated[
-        bool,
-        Field(
-            description="Whether to save the evaluation artifacts to the outputs directory.",
-        ),
-    ] = False
-
     use_tqdm: Annotated[
         bool,
         Field(

--- a/src/prime_rl/eval/config.py
+++ b/src/prime_rl/eval/config.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Annotated
 
 from pydantic import Field
@@ -21,6 +22,20 @@ class OfflineEvalConfig(EvalConfig, BaseSettings):
 
     # The logging configuration
     log: LogConfig = LogConfig()
+
+    outputs_dir: Annotated[
+        Path,
+        Field(
+            description="Directory to write outputs to. Will be populated with artifacts such as reports and HF datasets as subdirectories. Should be set to a persistent directory with enough disk space."
+        ),
+    ] = Path("outputs")
+
+    save: Annotated[
+        bool,
+        Field(
+            description="Whether to save the evaluation artifacts to the outputs directory.",
+        ),
+    ] = False
 
     use_tqdm: Annotated[
         bool,

--- a/src/prime_rl/eval/eval.py
+++ b/src/prime_rl/eval/eval.py
@@ -57,6 +57,8 @@ async def eval(config: OfflineEvalConfig):
                 sampling_config=config.sampling,
                 num_examples=num_examples,
                 rollouts_per_example=rollouts_per_example,
+                save=config.save,
+                outputs_dir=config.outputs_dir,
                 ckpt_step=0,
                 monitor=monitor,
             )

--- a/src/prime_rl/eval/eval.py
+++ b/src/prime_rl/eval/eval.py
@@ -57,10 +57,9 @@ async def eval(config: OfflineEvalConfig):
                 sampling_config=config.sampling,
                 num_examples=num_examples,
                 rollouts_per_example=rollouts_per_example,
-                save=config.save,
                 outputs_dir=config.outputs_dir,
+                save=config.save,
                 ckpt_step=0,
-                monitor=monitor,
             )
             for eval_id, num_examples, rollouts_per_example in zip(
                 config.environment_ids, config.num_examples, config.rollouts_per_example

--- a/src/prime_rl/eval/eval.py
+++ b/src/prime_rl/eval/eval.py
@@ -25,7 +25,7 @@ async def eval(config: OfflineEvalConfig):
 
     # Initialize the monitor
     logger.info(f"Initializing monitor ({config.monitor})")
-    monitor = setup_monitor(
+    setup_monitor(
         config=config.monitor,
         outputs_dir=None,
         run_config=config,

--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -141,9 +141,6 @@ async def run_eval(
     # Log statistics to monitor
     eval_metrics = {
         f"avg@{k}": float(sample_stats.reward.mean()),
-        "completion_len": float(avg_completion_len),
-        "max_completion_len": float(max_avg_completion_len),
-        "min_completion_len": float(min_avg_completion_len),
     }
     if could_be_binary:
         assert pass_at_k is not None
@@ -174,5 +171,13 @@ async def run_eval(
         # Save "report"
         # TODO: Make this into an actually nice report, for now just JSON-dump eval metrics
         report_path = eval_dir / "report.json"
+        report = {
+            "metrics": eval_metrics,
+            "completion_len": {
+                "avg": float(avg_completion_len),
+                "max": float(max_avg_completion_len),
+                "min": float(min_avg_completion_len),
+            },
+        }
         with open(report_path, "w") as f:
-            json.dump(eval_metrics, f, indent=2)
+            json.dump(report, f, indent=2)

--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -127,11 +127,11 @@ async def run_eval(
 
     # Log statistics
     eval_time = time.time() - eval_start_time
-    message = f"Evaluated {eval_id} in {eval_time:.2f}s (Avg@{k}={sample_stats.reward.mean():.2f}"
+    message = f"Evaluated {eval_id} in {eval_time:.2f}s (Avg@{k}={sample_stats.reward.mean():.4f}"
     if could_be_binary:
         assert pass_at_k is not None
         for pass_rate, pass_rate_score in pd.Series(pass_at_k.mean()).items():
-            message += f", {capitalize(str(pass_rate))}: {pass_rate_score:.2f}"
+            message += f", {capitalize(str(pass_rate))}: {pass_rate_score:.4f}"
     message += (
         f", Seq. Len: {avg_completion_len:.2f}, Max Seq. Len: {max_avg_completion_len:.2f}, "
         f"Min Seq. Len: {min_avg_completion_len:.2f}"

--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -11,7 +11,7 @@ from verifiers import load_environment
 from prime_rl.orchestrator.config import EvalSamplingConfig, ModelConfig
 from prime_rl.orchestrator.utils import parse_completion_tokens
 from prime_rl.utils.logger import get_logger
-from prime_rl.utils.monitor import MultiMonitor
+from prime_rl.utils.monitor import get_monitor
 from prime_rl.utils.utils import capitalize, get_eval_dir
 
 
@@ -31,11 +31,11 @@ async def run_eval(
     save: bool,
     outputs_dir: Path,
     ckpt_step: int,
-    monitor: MultiMonitor,
     step: int | None = None,
 ) -> None:
     # Get the logger
     logger = get_logger()
+    monitor = get_monitor()
     assert logger is not None
     eval_start_time = time.time()
 

--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -164,7 +164,7 @@ async def run_eval(
     # If specified, save eval artifacts
     if save:
         # Save samples as dataset
-        eval_dir = get_eval_dir(outputs_dir) / eval_id
+        eval_dir = get_eval_dir(outputs_dir) / f"step_{ckpt_step}" / eval_id
         dataset = vf_eval.make_dataset(results)
         dataset.save_to_disk(eval_dir)
 

--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -181,3 +181,5 @@ async def run_eval(
         }
         with open(report_path, "w") as f:
             json.dump(report, f, indent=2)
+
+        logger.info(f"Saved samples and report to {eval_dir}")

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -169,7 +169,7 @@ class EvalConfig(BaseConfig):
         Field(
             description="Whether to save the evaluation artifacts to the outputs directory.",
         ),
-    ] = False
+    ] = True
 
     @model_validator(mode="after")
     def _validate_and_fill_eval_lists(self):

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -164,6 +164,13 @@ class EvalConfig(BaseConfig):
         description="Shared sampling configuration for evals; can differ from training sampling.",
     )
 
+    save: Annotated[
+        bool,
+        Field(
+            description="Whether to save the evaluation artifacts to the outputs directory.",
+        ),
+    ] = False
+
     @model_validator(mode="after")
     def _validate_and_fill_eval_lists(self):
         # If rollouts_per_example is empty, default to 1 for all ids

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -180,7 +180,8 @@ async def orchestrate(config: OrchestratorConfig):
                         num_examples=num_examples,
                         rollouts_per_example=rollouts_per_example,
                         ckpt_step=ckpt_step,
-                        monitor=monitor,
+                        outputs_dir=config.outputs_dir,
+                        save=config.eval.save,
                         step=progress.step,
                     )
                     for eval_id, num_examples, rollouts_per_example in zip(

--- a/src/prime_rl/utils/utils.py
+++ b/src/prime_rl/utils/utils.py
@@ -249,6 +249,10 @@ def get_rollout_dir(outputs_dir: Path) -> Path:
     return outputs_dir / "rollouts"
 
 
+def get_eval_dir(outputs_dir: Path) -> Path:
+    return outputs_dir / "evals"
+
+
 def get_step_path(path: Path, step: int) -> Path:
     return path / f"step_{step}"
 


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

This PR adds the option to save eval artifacts, including a HF dataset of the eval samples (useful to push to hub to use conversation view to manually inspect the completions) and a JSON-dump of the computed metrics.

- Added `--outputs-dir` to `OfflineEvalConfig` which defaults to `outputs` as everywhere
- Added boolean `--save` to `EvalConfig` used in both online and offline evals, which defaults to `True`

The path is auto-generated as `{output_dir}/evals/step_{x}/{eval_id}` where `eval_id` is the ID of the environment we eval against. 

Misc:
- I removed all the completion length logs from W&B and moved to the offline report to declutter the `eval` W&B log section. We should only see scores there by default, especially as the number of our evals grows

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: #744 
**Linear Issue**: Resolves PRIMERL-18