### PR TITLE
Keep only latest checkpoint by default

### DIFF
--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -180,7 +180,7 @@ class CheckpointConfig(BaseConfig):
             ge=1,
             description="Keep at most this many recent step checkpoints on disk. If None, never clean old checkpoints.",
         ),
-    ] = None
+    ] = 1
 
 
 class WeightCheckpointConfig(BaseConfig):


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

This PR changes the default value of `--ckpt.keep` from `None` to `1`, meaning that by default we only keep the latest *full checkpoint*. This applies both to the RL and SFT trainer. The reason we do this is because it is very easy to run out of disk, e.g. a single 32B checkpoint is ~300GB. This operation should be safe in the sense that it should guarantee that at least 1 checkpoint is present at any point in time, because deletion can only be triggered after a new checkpoint has been written, even if the checkpoint is saved asynchronously.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: #786 
**Linear Issue**: Resolves PRIMERL-47