### PR TITLE
Add docs on multi-node trainer and inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,9 +223,8 @@ We rely on vLLM's internal load balancing for data parallel deployment ([docs](h
 First, ensure that your nodes are in the same private network and can reach each other. If not, a simple solution is to set up a VPN using [Tailscale](https://tailscale.com). Follow their documentation to setup a VPN on each node. Then, configure the GLOO and NCCL network interface
 
 ```bash
-export GLOO_SOCKET_IFNAME=tailscale0
-export NCCL_SOCKET_IFNAME=tailscale0
-```
+export GLOO_SOCKET_IFNAME=eth0
+export NCCL_SOCKET_IFNAME=eth0
 
 *For example, if you have colocated nodes this is often an Ethernet interface `eth0`. If you use Tailscale VPN, it typically installs a new network interface `tailscale0`.*
 

--- a/README.md
+++ b/README.md
@@ -204,26 +204,17 @@ The `torchrun` entrypoint can be used in multi-node distributed training, by spa
 
 In both cases of single-node distributed training or multi-node distributed training, torchrun will launch the given number of processes per node (--nproc-per-node). If used for GPU training, this number needs to be less or equal to the number of GPUs on the current system (nproc_per_node), and each process will be operating on a single GPU from GPU 0 to GPU (nproc_per_node - 1).
 
-For example run a trainer across two full nodes, run
+For example to run a trainer across two full nodes run the following command
 
 ```bash
-# Node 0
+# Node 0 + Node 1
 uv run torchrun \
     --nproc-per-node 8 \
     --nnodes 2 \
     src/prime_rl/trainer/rl/train.py
 ```
 
-```bash
-# Node 1
-uv run torchrun \
-    --nproc-per-node 8 \
-    --nnodes 2 \
-    src/prime_rl/trainer/rl/train.py
-```
-
-
-https://docs.pytorch.org/docs/stable/elastic/run.html
+*It will automatically set up the local and global world information correctly.*
 
 **Multi-Node Inference**
 


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Ports docs from #644 after we have successfully started a training with multi-node inference. Removes the exhaustive section on setting up VPN, as this is only required for non-colocated nodes. Also adds docs for multi-node trainer following https://docs.pytorch.org/docs/stable/elastic/run.html.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: #752 
**Linear Issue**: Resolves PRIMERL-26, PRIMERL-57