### PR TITLE
Supress Flash Attention dtype warnings from transformers.modeling_utils

### DIFF
--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -1,3 +1,5 @@
+import logging
+
 import torch
 import torch.distributed as dist
 import torch.nn as nn
@@ -14,6 +16,13 @@ from transformers import (
 from transformers.tokenization_utils import PreTrainedTokenizer
 
 from prime_rl.trainer.config import ActivationCheckpointConfig, ModelConfig
+
+# Add filter to the standard logging module for transformers.modeling_utils to supress the
+# flash attention dtype warnings since FSDP is used to handle mixed precision.
+transformers_modeling_utils_logger = logging.getLogger("transformers.modeling_utils")
+transformers_modeling_utils_logger.addFilter(
+    lambda record: "Flash Attention 2 only supports torch.float16 and torch.bfloat16 dtypes" not in record.getMessage()
+)
 
 
 def is_tt_moe_model(model: nn.Module) -> bool:


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

filtering out the flash attention dtype warnings from the `transformers` module since it's not relevant due to  using FSDP to handle mixed precision.

since the warning is getting outputted from the `get_model` and `setup_tokenizer` funcs, it made sense to throw the filter in `src/prime_rl/trainer/model.py`.

## Testing
tested manually using the debug configs for sft/rl training.

before changes:
<img width="1725" height="327" alt="Screenshot 2025-08-22 at 9 52 52 AM" src="https://github.com/user-attachments/assets/dd898798-fa4a-44c3-abf1-f9f1242ac394" />
<img width="1722" height="548" alt="Screenshot 2025-08-22 at 9 53 37 AM" src="https://github.com/user-attachments/assets/c561e9e4-3652-4660-9262-a0508bc7edc5" />

after changes:
<img width="1717" height="268" alt="Screenshot 2025-08-22 at 9 54 31 AM" src="https://github.com/user-attachments/assets/ebdc0ec8-e4d6-4640-9421-2c453dc6c78f" />
<img width="1727" height="491" alt="Screenshot 2025-08-22 at 9 55 05 AM" src="https://github.com/user-attachments/assets/f190e6da-b6fa-4e32-8057-346c1d233531" />


---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: [#746](https://github.com/PrimeIntellect-ai/prime-rl/issues/746)
**Linear Issue**: Resolves [Issue ID]