### PR TITLE
[fix] add epsilon to loss scale division to prevent nan loss for padding batches

### DIFF
--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -260,7 +260,7 @@ def train(config: RLTrainerConfig):
                 entropy = compute_entropy(shifted_logits)
 
             # Reduce the loss
-            loss = (loss * loss_mask).sum() / loss_scale
+            loss = (loss * loss_mask).sum() / (loss_scale + 1e-6)
 
             # Delete logits and shifted_logits before backward pass to avoid memory spike
             del logits, shifted_logits


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Resolves https://github.com/PrimeIntellect-ai/prime-rl/issues/798
---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: https://github.com/PrimeIntellect-ai/prime-rl/issues/798
**Linear Issue**: Resolves [Issue ID]