### PR TITLE
Better pass@k metric

### DIFF
--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -16,8 +16,23 @@ from prime_rl.utils.utils import capitalize, get_eval_dir
 
 
 def compute_pass_at_k(rewards: list[int]) -> dict[str, float]:
-    k = len(rewards)
-    return {f"pass@{k}": float(any(reward == 1.0 for reward in rewards))}
+    total_attempts = len(rewards)
+    k = total_attempts // 2
+
+    if k == 0:
+        return {"pass@1": float(any(reward == 1.0 for reward in rewards))}
+
+    num_trials = 100
+    pass_rates = []
+
+    for _ in range(num_trials):
+        sampled_rewards = np.random.choice(rewards, size=k, replace=False)
+        pass_rate = float(any(reward == 1.0 for reward in sampled_rewards))
+        pass_rates.append(pass_rate)
+
+    avg_pass_rate = np.mean(pass_rates)
+
+    return {f"pass@{k}": avg_pass_rate}
 
 
 async def run_eval(


### PR DESCRIPTION
Currently the way pass@k is measured is naive and very noisy, this way we compute pass@k where k is half the rollouts per response we actually use.
This method is also used in https://arxiv.org/abs/2506.13284