### PR TITLE
Git clone https in `install.sh`

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,11 +23,8 @@ main() {
     log_info "Installing git, tmux, htop, nvtop, cmake, python3-dev, cgroup-tools..."
     sudo apt install git tmux htop nvtop cmake python3-dev cgroup-tools -y
 
-    log_info "Configuring SSH to automatically accept GitHub's host key..."
-    ssh-keyscan github.com >>~/.ssh/known_hosts 2>/dev/null
-
     log_info "Cloning repository..."
-    git clone git@github.com:PrimeIntellect-ai/prime-rl.git
+    git clone https://github.com/PrimeIntellect-ai/prime-rl.git
 
     log_info "Entering project directory..."
     cd prime-rl


### PR DESCRIPTION
switch to `git clone` with https in install script to avoid setting up SSH keys. packages in `pyproject.toml` use https with Github anyway.

will mark for review after test install on fresh machine.

UPDATE: works on fresh machine.

cloned this way the git remote is setup with https, so ppl preferring ssh need to update remote once before pushing.
but as install script is meant for usage and manual install instructions are meant for dev'ing this is fine.