### PR TITLE
Implement serialization to make buffer checkpoint-compliant

### DIFF
--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -220,13 +220,6 @@ class CheckpointConfig(BaseConfig):
         ),
     ] = None
 
-    resume_buffer_from_checkpoint: Annotated[
-        bool,
-        Field(
-            description="Whether to resume the data buffer from the checkpoint.",
-        ),
-    ] = True
-
     keep: Annotated[
         int | None,
         Field(
@@ -238,10 +231,22 @@ class CheckpointConfig(BaseConfig):
 
 class SimpleBufferConfig(BaseModel):
     type: Literal["simple"] = "simple"
+    resume: Annotated[
+        bool,
+        Field(
+            description="Whether to resume the data buffer from the checkpoint.",
+        ),
+    ] = True
 
 
 class DifficultyPoolBufferConfig(BaseModel):
     type: Literal["difficulty-pool"] = "difficulty-pool"
+    resume: Annotated[
+        bool,
+        Field(
+            description="Whether to resume the data buffer from the checkpoint.",
+        ),
+    ] = True
 
     difficulty_field: Annotated[
         str | None,
@@ -290,6 +295,12 @@ class DifficultyPoolBufferConfig(BaseModel):
 
 class OnlineDifficultyBufferConfig(BaseModel):
     type: Literal["online-difficulty"] = "online-difficulty"
+    resume: Annotated[
+        bool,
+        Field(
+            description="Whether to resume the data buffer from the checkpoint.",
+        ),
+    ] = True
 
     min_reward: Annotated[
         float | None,

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -22,7 +22,7 @@ from prime_rl.orchestrator.client import (
     setup_client,
 )
 from prime_rl.orchestrator.config import OrchestratorConfig
-from prime_rl.orchestrator.buffer import setup_buffer, make_rollouts, Rollout, load_buffer
+from prime_rl.orchestrator.buffer import setup_buffer, make_rollouts, Rollout
 from prime_rl.orchestrator.batch import prepare_batch
 from prime_rl.orchestrator.logger import setup_logger
 from prime_rl.orchestrator.advantage import compute_advantages
@@ -84,10 +84,6 @@ async def orchestrate(config: OrchestratorConfig):
     logger.info(f"Initializing checkpoint manager ({config.ckpt})")
     ckpt_manager = setup_ckpt_manager(config.output_dir, config.ckpt)
 
-    logger.info(f"Loading environment {config.environment.id} with args {config.environment.args}")
-    vf_env = load_environment(config.environment.id, **config.environment.args)
-    dataset = vf_env.get_dataset(seed=config.seed)
-
     # Reset weights to base model if starting from scratch
     progress = Progress()
     ckpt_step = 0
@@ -96,22 +92,22 @@ async def orchestrate(config: OrchestratorConfig):
         ckpt_manager.load(progress, step=config.ckpt.resume_step)
         ckpt_step = max(progress.step - config.async_level, 0)
         await update_weights(client, get_weights_dir(config.output_dir), ckpt_step)
-        
-        # Load buffer from checkpoint
-        if config.ckpt.resume_buffer_from_checkpoint:
-            logger.info("Resuming buffer from checkpoint")
-            buffer_path = ckpt_manager.get_ckpt_path(config.ckpt.resume_step) / "buffer"
-            buffer = load_buffer(str(buffer_path), config.buffer)
-        else:
-            logger.info("Initializing buffer from scratch")
-            buffer = setup_buffer(dataset, config.buffer)
     else:
         logger.info("Training from scratch. Resetting weights to base model")
         await reload_weights(client)
-        
-        # Setup buffer for fresh training
-        logger.info(f"Setting up buffer ({config.buffer})")
-        buffer = setup_buffer(dataset, config.buffer)
+
+    # Load environment and extract dataset
+    logger.info(f"Loading environment {config.environment.id} with args {config.environment.args}")
+    vf_env = load_environment(config.environment.id, **config.environment.args)
+    dataset = vf_env.get_dataset(seed=config.seed)
+
+    logger.info(f"Setting up buffer ({config.buffer})")
+    buffer = setup_buffer(dataset, config.buffer)
+
+    if config.buffer.resume:
+        logger.info("Resuming buffer from checkpoint")
+        buffer_path = ckpt_manager.get_ckpt_path(config.ckpt.resume_step) / "buffer"
+        buffer.load(buffer_path)
 
     # Iterate over dataset in batches
     max_steps = config.max_steps or int(1e9)
@@ -131,8 +127,7 @@ async def orchestrate(config: OrchestratorConfig):
         ):
             logger.info(f"Saving checkpoint at step {progress.step}")
             save_ckpt_start_time = time.time()
-            
-            ckpt_manager.save(progress, step=progress.step, buffer=buffer)
+            ckpt_manager.save(progress, buffer, step=progress.step)
             save_ckpt_time = time.time() - save_ckpt_start_time
 
             # Maybe clean up old orchestrator checkpoints
@@ -498,7 +493,7 @@ async def orchestrate(config: OrchestratorConfig):
     # Write final checkpoint
     if ckpt_manager is not None:
         logger.info("Writing final checkpoint")
-        ckpt_manager.save(progress, step=progress.step, buffer=buffer)
+        ckpt_manager.save(progress, buffer, step=progress.step)
 
     logger.success("Orchestrator finished.")
 


### PR DESCRIPTION
Resuming data buffer properly from a checkpoint. When saving, it stores the rollout buffer, metadata, and the dataset to disk. Whether to restore from a checkpoint or start fresh is controlled by a simple config flag just like we had with **resume_step**.

---

**GitHub Issue**: https://github.com/PrimeIntellect-ai/prime-rl/issues/748