### PR TITLE
Allow evaling only a subset of steps

### DIFF
--- a/src/prime_rl/eval/eval.py
+++ b/src/prime_rl/eval/eval.py
@@ -74,6 +74,12 @@ async def eval(config: OfflineEvalConfig):
         logger.info(f"Evaluating weight checkpoints in {config.weights_dir}")
         ckpt_steps = sorted([int(step_path.name.split("_")[-1]) for step_path in config.weights_dir.glob("step_*")])
         logger.info(f"Found {len(ckpt_steps)} weight checkpoints (steps: {', '.join(map(str, ckpt_steps))})")
+
+        # Filter the steps to evaluate
+        if config.steps is not None:
+            ckpt_steps = [step for step in ckpt_steps if step in config.steps]
+
+        logger.info(f"Evaluating {len(ckpt_steps)} weight checkpoints (steps: {', '.join(map(str, ckpt_steps))})")
         for ckpt_step in ckpt_steps[::-1]:
             # Update the weights
             logger.info(f"Evaluating weight checkpoint {ckpt_step}")


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Currently, the only way to eval on disk checkpoint is to specify an entire weights directory using `--weights-dir` which evals any step directory it finds. However, during RL training we may have a lot more weight checkpoints on disk than we want to run evals on. This PR adds the `--steps` config key to offline evals which allows to specify a subset of the weight checkpoints to run evals on. It checks at config init time that all entered steps are actually present in the weight directory.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: #837 
**Linear Issue**: Resolves PRIMERL-74