### PR TITLE
fix: getting the dockerfile to work

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -82,4 +82,4 @@ RUN rm /app/.venv/bin/python3.12 && ln -s /usr/local/bin/python /app/.venv/bin/p
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"
-ENTRYPOINT ["python", "src/prime_rl/infer.py"]
+ENTRYPOINT ["python", "src/prime_rl/inference/server.py"]

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -22,8 +22,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends --force-yes \
 
 # Download the latest installer
 ADD https://astral.sh/uv/install.sh /uv-installer.sh
-RUN sh /uv-installer.sh && rm /uv-installer.sh
-ENV PATH="/root/.local/bin/:$PATH"
+
+# Set install dir to location accessible to non-root users
+RUN INSTALLER_NO_MODIFY_PATH=1 UV_INSTALL_DIR="/usr/local/bin" sh /uv-installer.sh && rm /uv-installer.sh
+ENV PATH="/usr/local/bin:$PATH"
+ENV UV_PYTHON_INSTALL_DIR="/usr/local/share/uv/python"
+ENV UV_CACHE_DIR="/usr/local/share/uv/cache"
 
 # Install Python dependencies (The gradual copies help with caching)
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -353,10 +353,6 @@ uv run eval --model.name Qwen/Qwen3-0.6B --environment-ids math500,aime2024,aime
 
 To check all available configuration options, run `uv run eval --help`.
 
-## Multi-Node Training
-
-*TBD*
-
 ## Developer
 
 *For now, development is only possible on CUDA-enabled devices.*


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

This PR just has some changes to get the docker container running on my machine, which includes:

- `src/prime_rl/infer.py` used by the `ENTRYPOINT` doesn't exist anymore, seems like it was refactored out at some point:
```bash
~/eexwhyzee/prime-rl$ docker run --gpus all prime-rl:main
python: can't open file '/app/src/prime_rl/infer.py': [Errno 2] No such file or directory
```

- after fixing the entry point, i was still unable to run the container since the `appuser` used at runtime doesn't have permissions to access the uv python install directory since it was installed in the `root` dir:
```bash
~/eexwhyzee/prime-rl$ docker run --gpus all prime-rl:main
INFO 08-27 01:37:49 [__init__.py:235] Automatically detected platform cuda.
Traceback (most recent call last):
  File "/app/src/prime_rl/inference/server.py", line 2, in <module>
    from prime_rl.inference.vllm.server import server
  File "/app/src/prime_rl/inference/vllm/server.py", line 8, in <module>
    from prime_rl.inference.vllm.sampler import Sampler as CustomSampler
  File "/app/src/prime_rl/inference/vllm/sampler.py", line 20, in <module>
    from vllm.v1.sample.ops.topk_topp_sampler import TopKTopPSampler
  File "/app/.venv/lib/python3.12/site-packages/vllm/v1/sample/ops/topk_topp_sampler.py", line 16, in <module>
    import flashinfer.sampling
  File "/app/.venv/lib/python3.12/site-packages/flashinfer/__init__.py", line 23, in <module>
    from . import jit as jit
  File "/app/.venv/lib/python3.12/site-packages/flashinfer/jit/__init__.py", line 22, in <module>
    from . import cubin_loader
  File "/app/.venv/lib/python3.12/site-packages/flashinfer/jit/cubin_loader.py", line 28, in <module>
    from .core import logger
  File "/app/.venv/lib/python3.12/site-packages/flashinfer/jit/core.py", line 10, in <module>
    import torch.utils.cpp_extension as torch_cpp_ext
  File "/app/.venv/lib/python3.12/site-packages/torch/utils/cpp_extension.py", line 28, in <module>
    from setuptools.command.build_ext import build_ext
  File "/app/.venv/lib/python3.12/site-packages/setuptools/command/build_ext.py", line 18, in <module>
    from distutils.sysconfig import customize_compiler, get_config_var
  File "/app/.venv/lib/python3.12/site-packages/setuptools/_distutils/sysconfig.py", line 101, in <module>
    python_build = _python_build()
                   ^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.12/site-packages/setuptools/_distutils/sysconfig.py", line 97, in _python_build
    return _is_python_source_dir(_sys_home)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.12/site-packages/setuptools/_distutils/sysconfig.py", line 65, in _is_python_source_dir
    return any(modules.joinpath(fn).is_file() for fn in ('Setup', 'Setup.local'))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.12/site-packages/setuptools/_distutils/sysconfig.py", line 65, in <genexpr>
    return any(modules.joinpath(fn).is_file() for fn in ('Setup', 'Setup.local'))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/pathlib.py", line 892, in is_file
    return S_ISREG(self.stat().st_mode)
                   ^^^^^^^^^^^
  File "/usr/local/lib/python3.12/pathlib.py", line 840, in stat
    return os.stat(self, follow_symlinks=follow_symlinks)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
PermissionError: [Errno 13] Permission denied: '/root/.local/share/uv/python/cpython-3.12.11-linux-x86_64-gnu/bin/Modules/Setup'
```
you can work around this by passing the arg `--user root` to the `docker run` command, but that pretty much defeats the purpose of using a non-root user at runtime, so instead i updated the builder stage in the dockerfile to install `uv` and its python installation in a directory that is accessible to non-root users.

after these changes, i was able to get the docker container to run the inference server:
```bash
~/eexwhyzee/prime-rl$ docker run --gpus all prime-rl:fix
INFO 08-27 01:47:38 [__init__.py:235] Automatically detected platform cuda.
INFO 08-27 01:47:43 [api_server.py:1755] vLLM API server version 0.10.0
INFO 08-27 01:47:43 [cli_args.py:261] non-default args: {'logprobs_mode': 'processed_logprobs'}
```

also sidenote, in the middle of working on this, i ran into https://github.com/PrimeIntellect-ai/prime-rl/issues/846 , so as a temporary workaround i removed that dependency just to get my docker builds working again, but i expect any docker builds / environment setups happening during ci will also break because of that issue

---
