### PR TITLE
Fix external PRs failing on missing W&B API key

### DIFF
--- a/.github/workflows/gpu_tests.yaml
+++ b/.github/workflows/gpu_tests.yaml
@@ -56,9 +56,13 @@ jobs:
         env:
           USERNAME_CI: CI_RUNNER
           WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
+          # Set WANDB_MODE to online only if WANDB_API_KEY is available, otherwise set to offline
+          # This is to allow running tests on forks without WANDB_API_KEY
+          WANDB_MODE: ${{ secrets.WANDB_API_KEY && 'online' || 'offline' }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
           GITHUB_HEAD_REF: ${{ github.head_ref }}
-        run: PYTEST_OUTPUT_DIR=/tmp/outputs uv run pytest tests/integration -m gpu
+          PYTEST_OUTPUT_DIR: /tmp/outputs
+        run: uv run pytest tests/integration -m gpu
       - name: Cleanup output_dir
         run: rm -rf /tmp/outputs


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Currently, integration tests on external PRs are failing because they (correctly) do not have access to our W&B API key. For example, see [these logs](https://github.com/PrimeIntellect-ai/prime-rl/actions/runs/17282584901/job/49074227187?pr=848)

<img width="1093" height="739" alt="Screenshot 2025-08-28 at 4 45 23 PM" src="https://github.com/user-attachments/assets/4b75a046-5f15-44e5-a126-3ce15115d179" />

This PR changes the GH workflow to run W&B in offline mode in case the key cannot be found.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: #850 
**Linear Issue**: Resolves PRIMERL-78