### PR TITLE
add support for Liger Kernel

### DIFF
--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -68,6 +68,13 @@ class ModelConfig(BaseConfig):
         ),
     ] = 1
 
+    liger_kernel: Annotated[
+        bool,
+        Field(
+            description="Whether to use Liger Kernel.",
+        ),
+    ] = False
+
     @model_validator(mode="after")
     def _map_model_name_for_moe(self):
         """Map model name if it exists in MOE_MODEL_MAPS."""

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -51,18 +51,12 @@ def get_model(config: ModelConfig) -> nn.Module:
     )
     config_model.use_cache = False
     
-    if config.liger_kernel:
-        model = AutoLigerKernelForCausalLM.from_pretrained(
-            pretrained_model_name_or_path=config.name,
-            config=config_model,
-            trust_remote_code=config.trust_remote_code,
-        )
-    else:
-        model = AutoModelForCausalLM.from_pretrained(
-            pretrained_model_name_or_path=config.name,
-            config=config_model,
-            trust_remote_code=config.trust_remote_code,
-        )
+    model_cls = AutoLigerKernelForCausalLM if config.liger_kernel else AutoModelForCausalLM
+    model = model_cls.from_pretrained(
+        pretrained_model_name_or_path=config.name,
+        config=config_model,
+        trust_remote_code=config.trust_remote_code,
+    )
 
     return model
 

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -5,14 +5,11 @@ import torch.distributed as dist
 import torch.nn as nn
 from beartype import beartype as typechecker
 from jaxtyping import Float, Int, jaxtyped
+from liger_kernel.transformers import AutoLigerKernelForCausalLM
 from torch import Tensor
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import checkpoint_wrapper
 from torch.distributed.fsdp import FSDPModule, MixedPrecisionPolicy, fully_shard
-from transformers import (
-    AutoConfig,
-    AutoModelForCausalLM,
-    AutoTokenizer,
-)
+from transformers import AutoConfig, AutoTokenizer
 from transformers.tokenization_utils import PreTrainedTokenizer
 
 from prime_rl.trainer.config import ActivationCheckpointConfig, ModelConfig
@@ -53,11 +50,20 @@ def get_model(config: ModelConfig) -> nn.Module:
         config.name, attn_implementation=config.attn, trust_remote_code=config.trust_remote_code
     )
     config_model.use_cache = False
-    model = AutoModelForCausalLM.from_pretrained(
-        pretrained_model_name_or_path=config.name,
-        config=config_model,
-        trust_remote_code=config.trust_remote_code,
-    )
+    
+    if config.liger_kernel:
+        model = AutoLigerKernelForCausalLM.from_pretrained(
+            pretrained_model_name_or_path=config.name,
+            config=config_model,
+            trust_remote_code=config.trust_remote_code,
+        )
+    else:
+        from transformers import AutoModelForCausalLM
+        model = AutoModelForCausalLM.from_pretrained(
+            pretrained_model_name_or_path=config.name,
+            config=config_model,
+            trust_remote_code=config.trust_remote_code,
+        )
 
     return model
 

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -9,7 +9,7 @@ from liger_kernel.transformers import AutoLigerKernelForCausalLM
 from torch import Tensor
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import checkpoint_wrapper
 from torch.distributed.fsdp import FSDPModule, MixedPrecisionPolicy, fully_shard
-from transformers import AutoConfig, AutoTokenizer
+from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 from transformers.tokenization_utils import PreTrainedTokenizer
 
 from prime_rl.trainer.config import ActivationCheckpointConfig, ModelConfig
@@ -58,7 +58,6 @@ def get_model(config: ModelConfig) -> nn.Module:
             trust_remote_code=config.trust_remote_code,
         )
     else:
-        from transformers import AutoModelForCausalLM
         model = AutoModelForCausalLM.from_pretrained(
             pretrained_model_name_or_path=config.name,
             config=config_model,

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -165,9 +165,3 @@ class RLTrainerConfig(BaseSettings):
         if self.monitor.wandb and self.monitor.wandb.log_extras:
             self.monitor.wandb.log_extras.samples = False
         return self
-
-    @model_validator(mode="after")
-    def validate_liger_compatibility(self):
-        if self.model.liger_kernel and self.loss.type != "grpo":
-            raise ValueError("Liger Kernel only supports GRPO, not GSPO")
-        return self

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -165,3 +165,9 @@ class RLTrainerConfig(BaseSettings):
         if self.monitor.wandb and self.monitor.wandb.log_extras:
             self.monitor.wandb.log_extras.samples = False
         return self
+
+    @model_validator(mode="after")
+    def validate_liger_compatibility(self):
+        if self.model.liger_kernel and self.loss.type != "grpo":
+            raise ValueError("Liger Kernel only supports GRPO, not GSPO")
+        return self

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -250,69 +250,31 @@ def train(config: RLTrainerConfig):
             # Compute loss
             response_lengths = get_response_lengths(position_ids)
             
-            if config.model.liger_kernel and config.loss.type == "grpo":
-                from liger_kernel.transformers.grpo_loss import triton_grpo_loss
-                # Liger GRPO path
-                per_token_loss, kl, is_clipped = triton_grpo_loss(
-                    logits=logits,
-                    old_logp=old_logprobs.squeeze(),
-                    ref_logp=None,
-                    completion_ids=input_ids,
-                    advantages=advantages.squeeze(),
-                    completion_mask=loss_mask.squeeze().int(),
-                    temperature=temperature,
-                    beta=0.0,
-                    eps_low=1.0 - config.loss.clip_ratio,
-                    eps_high=config.loss.clip_ratio - 1.0,
-                    inplace=True,
-                )
-                
-                # Apply loss mask and scaling
-                shifted_loss_mask = loss_mask[:, 1:]
-                loss = (per_token_loss * shifted_loss_mask.squeeze()).sum() / max(loss_scale, 1)
-                
-                # Skip logprobs computation for memory efficiency
-                shifted_logits = None
-                logprobs = None
-                loss_tensors = {
-                    "is_clipped": is_clipped,
-                }
-            else:
-                shifted_logits = shift_logits(logits)
-                shifted_logits = shifted_logits / temperature
-                logprobs = selective_log_softmax(shifted_logits, input_ids)
-                
-                loss, loss_tensors = compute_loss(
-                    logprobs=logprobs.squeeze().split(response_lengths),
-                    old_logprobs=old_logprobs.squeeze().split(response_lengths),
-                    advantages=advantages.squeeze().split(response_lengths),
-                    loss_mask=loss_mask.squeeze().split(response_lengths),
-                    loss_config=config.loss,
-                    loss_scale=loss_scale,
-                )
-
+            shifted_logits = shift_logits(logits)
+            shifted_logits = shifted_logits / temperature
+            logprobs = selective_log_softmax(shifted_logits, input_ids)
+            
+            loss, loss_tensors = compute_loss(
+                logprobs=logprobs.squeeze().split(response_lengths),
+                old_logprobs=old_logprobs.squeeze().split(response_lengths),
+                advantages=advantages.squeeze().split(response_lengths),
+                loss_mask=loss_mask.squeeze().split(response_lengths),
+                loss_config=config.loss,
+                loss_scale=loss_scale,
+            )
 
             # Compute entropy
             with torch.no_grad():
-                if shifted_logits is not None:
-                    entropy = compute_entropy(shifted_logits)
-                else:
-                    entropy = torch.zeros_like(loss_mask.float())
+                entropy = compute_entropy(shifted_logits)
 
             # Delete logits and shifted_logits before backward pass to avoid memory spike
-            if shifted_logits is not None:
-                del logits, shifted_logits
-            else:
-                del logits
+            del logits, shifted_logits
 
             # Backward pass
             loss.backward()
 
             # Add relevant tensors to tensor dict for logging purposes
-            if logprobs is not None:
-                tensors["probs"].append(torch.exp(logprobs)[loss_mask].detach().to("cpu"))
-            else:
-                tensors["probs"].append(torch.zeros(loss_mask.sum().item()).to("cpu"))
+            tensors["probs"].append(torch.exp(logprobs)[loss_mask].detach().to("cpu"))
             
             tensors["old_probs"].append(torch.exp(old_logprobs)[loss_mask].detach().to("cpu"))
             tensors["entropy"].append(entropy[loss_mask].detach().to("cpu"))
@@ -328,15 +290,7 @@ def train(config: RLTrainerConfig):
 
             # Add loss tensors to tensor dict for logging purposes
             for key, loss_tensor in loss_tensors.items():
-                if config.model.liger_kernel and config.loss.type == "grpo":
-                    if loss_tensor.dim() > 1:
-                        mask_for_logging = loss_mask[:, 1:]
-                        loss_tensor = loss_tensor.detach()[mask_for_logging].detach().to("cpu")
-                    else:
-                        mask_for_logging = loss_mask[:, 1:].squeeze()
-                        loss_tensor = loss_tensor.detach()[mask_for_logging].detach().to("cpu")
-                else:
-                    loss_tensor = loss_tensor.detach()[loss_mask.squeeze()].detach().to("cpu")
+                loss_tensor = loss_tensor.detach()[loss_mask.squeeze()].detach().to("cpu")
                 tensors[key].append(loss_tensor)
 
             # Debug log with *local, micro step* stats


### PR DESCRIPTION
Adds a `model.liger_kernel` option to the trainer config. When enabled, `AutoModelForCausalLM` is swapped out with `AutoLigerKernelForCausalLM` and GRPO loss computation uses `triton_grpo_loss`.

Liger Kernel doesn't support GSPO, so if you try to simultaneously set `model.liger_kernel = true` and `loss.type = "gspo"` you'll get a validation error.