### PR TITLE
Use environment.id as task if not set in environment 

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -212,7 +212,7 @@ async def orchestrate(config: OrchestratorConfig):
             inputs = {
                 "prompt": [problem["prompt"] for problem in problems],
                 "info": [problem.get("info", {}) for problem in problems],
-                "task": [problem.get("task", "default") for problem in problems],
+                "task": [problem.get("task", config.environment.id) for problem in problems],
                 "answer": [problem.get("answer", "") for problem in problems],
             }
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -212,7 +212,7 @@ async def orchestrate(config: OrchestratorConfig):
             inputs = {
                 "prompt": [problem["prompt"] for problem in problems],
                 "info": [problem.get("info", {}) for problem in problems],
-                "task": [problem["task"] for problem in problems],
+                "task": [problem.get("task", "default") for problem in problems],
                 "answer": [problem.get("answer", "") for problem in problems],
             }
 


### PR DESCRIPTION
Datasets may not have the task column pre-set by verifiers. If so, fall back to environment.id (errors otherwise; e.g. wordle 1b currently crashes). 
