### PR TITLE
Move infer.max_model_len config values to orch.sampling.max_tokens

### DIFF
--- a/configs/acereason_math/stage1/infer.toml
+++ b/configs/acereason_math/stage1/infer.toml
@@ -1,6 +1,5 @@
 [model]
 name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"
-max_model_len = 8192
 
 [parallel]
 dp = 6

--- a/configs/acereason_math/stage1/orch.toml
+++ b/configs/acereason_math/stage1/orch.toml
@@ -7,6 +7,7 @@ mask_truncated_completions = false
 
 [sampling]
 temperature = 0.6
+max_tokens = 8192
 
 [model]
 name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"

--- a/configs/acereason_math/stage2/infer.toml
+++ b/configs/acereason_math/stage2/infer.toml
@@ -1,6 +1,5 @@
 [model]
 name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"
-max_model_len = 16384
 
 [parallel]
 dp = 6

--- a/configs/acereason_math/stage2/orch.toml
+++ b/configs/acereason_math/stage2/orch.toml
@@ -7,6 +7,7 @@ mask_truncated_completions = false
 
 [sampling]
 temperature = 0.6
+max_tokens = 16384
 
 [model]
 name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"

--- a/configs/alphabet_sort/3b/infer.toml
+++ b/configs/alphabet_sort/3b/infer.toml
@@ -1,6 +1,5 @@
 [model]
 name = "Qwen/Qwen2.5-3B-Instruct"
-max_model_len = 2048
 
 [parallel]
 dp = 6

--- a/configs/deepscaler_math/stage1/infer.toml
+++ b/configs/deepscaler_math/stage1/infer.toml
@@ -1,6 +1,5 @@
 [model]
 name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
-max_model_len = 8192
 
 [parallel]
 dp = 6

--- a/configs/deepscaler_math/stage1/orch.toml
+++ b/configs/deepscaler_math/stage1/orch.toml
@@ -7,6 +7,7 @@ mask_truncated_completions = false
 
 [sampling]
 temperature = 0.6
+max_tokens = 8192
 
 [model]
 name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"

--- a/configs/deepscaler_math/stage2/infer.toml
+++ b/configs/deepscaler_math/stage2/infer.toml
@@ -1,6 +1,5 @@
 [model]
 name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
-max_model_len = 16384
 
 [parallel]
 dp = 6

--- a/configs/deepscaler_math/stage2/orch.toml
+++ b/configs/deepscaler_math/stage2/orch.toml
@@ -7,6 +7,7 @@ mask_truncated_completions = false
 
 [sampling]
 temperature = 0.6
+max_tokens = 16384
 
 [model]
 name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"

--- a/configs/hendrycks_math/14b/infer.toml
+++ b/configs/hendrycks_math/14b/infer.toml
@@ -1,6 +1,5 @@
 [model]
 name = "willcb/DeepSeek-R1-Distill-Qwen-14B"
-max_model_len = 2048
 
 [parallel]
 dp = 2

--- a/configs/hendrycks_math/14b/orch.toml
+++ b/configs/hendrycks_math/14b/orch.toml
@@ -10,6 +10,9 @@ name = "willcb/DeepSeek-R1-Distill-Qwen-14B"
 
 [monitor.wandb]
 
+[sampling]
+max_tokens = 2048
+
 [environment]
 id = "hendrycks-math"
 

--- a/configs/hendrycks_math/16b-a3b/infer.toml
+++ b/configs/hendrycks_math/16b-a3b/infer.toml
@@ -1,6 +1,5 @@
 [model]
 name = "moonshotai/Moonlight-16B-A3B-Instruct"
-max_model_len = 2048
 trust_remote_code = true
 
 [parallel]

--- a/configs/hendrycks_math/16b-a3b/orch.toml
+++ b/configs/hendrycks_math/16b-a3b/orch.toml
@@ -9,6 +9,9 @@ mask_truncated_completions = false
 name = "moonshotai/Moonlight-16B-A3B-Instruct"
 trust_remote_code = true
 
+[sampling]
+max_tokens = 2048
+
 [monitor.wandb]
 
 [environment]

--- a/configs/hendrycks_math/1b/infer.toml
+++ b/configs/hendrycks_math/1b/infer.toml
@@ -1,6 +1,5 @@
 [model]
 name = "willcb/DeepSeek-R1-Distill-Qwen-1.5B"
-max_model_len = 2048 
 
 [parallel]
 dp = 6

--- a/configs/hendrycks_math/1b/orch.toml
+++ b/configs/hendrycks_math/1b/orch.toml
@@ -10,6 +10,9 @@ name = "willcb/DeepSeek-R1-Distill-Qwen-1.5B"
 
 [monitor.wandb]
 
+[sampling]
+max_tokens = 2048
+
 [environment]
 id = "hendrycks-math"
 

--- a/configs/hendrycks_math/30b-a3b/infer.toml
+++ b/configs/hendrycks_math/30b-a3b/infer.toml
@@ -1,6 +1,5 @@
 [model]
 name = "Qwen/Qwen3-30B-A3B"
-max_model_len = 2048
 
 [parallel]
 dp = 4

--- a/configs/hendrycks_math/30b-a3b/orch.toml
+++ b/configs/hendrycks_math/30b-a3b/orch.toml
@@ -8,6 +8,9 @@ mask_truncated_completions = false
 [model]
 name = "Qwen/Qwen3-30B-A3B"
 
+[sampling]
+max_tokens = 2048
+
 [monitor.wandb]
 
 [environment]

--- a/configs/hendrycks_math/32b/infer.toml
+++ b/configs/hendrycks_math/32b/infer.toml
@@ -1,6 +1,5 @@
 [model]
 name = "willcb/DeepSeek-R1-Distill-Qwen-32B"
-max_model_len = 2048
 
 [parallel]
 dp = 4

--- a/configs/hendrycks_math/32b/orch.toml
+++ b/configs/hendrycks_math/32b/orch.toml
@@ -8,6 +8,9 @@ mask_truncated_completions = false
 [model]
 name = "willcb/DeepSeek-R1-Distill-Qwen-32B"
 
+[sampling]
+max_tokens = 2048
+
 [monitor.wandb]
 
 [environment]

--- a/configs/hendrycks_math/7b/infer.toml
+++ b/configs/hendrycks_math/7b/infer.toml
@@ -1,6 +1,5 @@
 [model]
 name = "willcb/DeepSeek-R1-Distill-Qwen-7B"
-max_model_len = 2048
 
 [parallel]
 dp = 3

--- a/configs/hendrycks_math/7b/orch.toml
+++ b/configs/hendrycks_math/7b/orch.toml
@@ -8,6 +8,9 @@ mask_truncated_completions = false
 [model]
 name = "willcb/DeepSeek-R1-Distill-Qwen-7B"
 
+[sampling]
+max_tokens = 8192
+
 [monitor.wandb]
 
 [environment]

--- a/configs/intellect_math/1b/infer.toml
+++ b/configs/intellect_math/1b/infer.toml
@@ -1,6 +1,5 @@
 [model]
 name = "willcb/DeepSeek-R1-Distill-Qwen-1.5B"
-max_model_len = 8192 
 
 [parallel]
 dp = 6

--- a/configs/intellect_math/1b/orch.toml
+++ b/configs/intellect_math/1b/orch.toml
@@ -8,6 +8,9 @@ mask_truncated_completions = false
 [model]
 name = "willcb/DeepSeek-R1-Distill-Qwen-1.5B"
 
+[sampling]
+max_tokens = 8192
+
 [monitor.wandb]
 
 [environment]

--- a/configs/intellect_math/7b/infer.toml
+++ b/configs/intellect_math/7b/infer.toml
@@ -1,6 +1,5 @@
 [model]
 name = "willcb/DeepSeek-R1-Distill-Qwen-7B"
-max_model_len = 8192 
 
 [parallel]
 dp = 6

--- a/configs/intellect_math/7b/orch.toml
+++ b/configs/intellect_math/7b/orch.toml
@@ -8,6 +8,9 @@ mask_truncated_completions = false
 [model]
 name = "willcb/DeepSeek-R1-Distill-Qwen-7B"
 
+[sampling]
+max_tokens = 8192
+
 [monitor.wandb]
 
 [environment]

--- a/configs/reverse_text/16b-a3b/infer.toml
+++ b/configs/reverse_text/16b-a3b/infer.toml
@@ -1,6 +1,5 @@
 [model]
 name = "moonshotai/Moonlight-16B-A3B-Instruct"
-max_model_len = 128
 trust_remote_code = true
 
 [parallel]

--- a/configs/reverse_text/16b-a3b/orch.toml
+++ b/configs/reverse_text/16b-a3b/orch.toml
@@ -10,6 +10,8 @@ mask_truncated_completions = false
 name = "moonshotai/Moonlight-16B-A3B-Instruct"
 trust_remote_code = true
 
+[sampling]
+max_tokens = 128
 
 [environment]
 id = "reverse-text"

--- a/configs/reverse_text/infer.toml
+++ b/configs/reverse_text/infer.toml
@@ -1,3 +1,2 @@
 [model]
 name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
-max_model_len = 128

--- a/configs/reverse_text/orch.toml
+++ b/configs/reverse_text/orch.toml
@@ -8,5 +8,8 @@ mask_truncated_completions = false
 [model]
 name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
 
+[sampling]
+max_tokens = 128
+
 [environment]
 id = "reverse-text"

--- a/configs/skywork_math/32b/stage1/infer.toml
+++ b/configs/skywork_math/32b/stage1/infer.toml
@@ -1,6 +1,5 @@
 [model]
 name = "willcb/DeepSeek-R1-Distill-Qwen-32B"
-max_model_len = 16384 
 
 [parallel]
 dp = 6

--- a/configs/skywork_math/32b/stage1/orch.toml
+++ b/configs/skywork_math/32b/stage1/orch.toml
@@ -8,6 +8,9 @@ mask_truncated_completions = false
 [model]
 name = "willcb/DeepSeek-R1-Distill-Qwen-32B"
 
+[sampling]
+max_tokens = 16384
+
 [monitor.wandb]
 
 [environment]

--- a/configs/skywork_math/32b/stage2/infer.toml
+++ b/configs/skywork_math/32b/stage2/infer.toml
@@ -1,6 +1,5 @@
 [model]
 name = "willcb/DeepSeek-R1-Distill-Qwen-32B"
-max_model_len = 32768
 
 [parallel]
 dp = 6

--- a/configs/skywork_math/32b/stage2/orch.toml
+++ b/configs/skywork_math/32b/stage2/orch.toml
@@ -8,6 +8,9 @@ mask_truncated_completions = false
 [model]
 name = "willcb/DeepSeek-R1-Distill-Qwen-32B"
 
+[sampling]
+max_tokens = 32768
+
 [monitor.wandb]
 
 [environment]

--- a/configs/skywork_math/7b/ablation/infer.toml
+++ b/configs/skywork_math/7b/ablation/infer.toml
@@ -1,6 +1,5 @@
 [model]
 name = "willcb/DeepSeek-R1-Distill-Qwen-7B"
-max_model_len = 16384
 
 [parallel]
 dp = 6

--- a/configs/skywork_math/7b/ablation/orch.toml
+++ b/configs/skywork_math/7b/ablation/orch.toml
@@ -7,6 +7,7 @@ mask_truncated_completions = false
 
 [sampling]
 temperature = 0.8
+max_tokens = 16384
 
 [model]
 name = "willcb/DeepSeek-R1-Distill-Qwen-7B"

--- a/configs/skywork_math/7b/stage1/infer.toml
+++ b/configs/skywork_math/7b/stage1/infer.toml
@@ -1,6 +1,5 @@
 [model]
 name = "willcb/DeepSeek-R1-Distill-Qwen-7B"
-max_model_len = 16384
 
 [parallel]
 dp = 6

--- a/configs/skywork_math/7b/stage1/orch.toml
+++ b/configs/skywork_math/7b/stage1/orch.toml
@@ -8,6 +8,9 @@ mask_truncated_completions = false
 [model]
 name = "willcb/DeepSeek-R1-Distill-Qwen-7B"
 
+[sampling]
+max_tokens = 16384
+
 [monitor.wandb]
 
 [environment]

--- a/configs/skywork_math/7b/stage2/infer.toml
+++ b/configs/skywork_math/7b/stage2/infer.toml
@@ -1,6 +1,5 @@
 [model]
 name = "willcb/DeepSeek-R1-Distill-Qwen-7B"
-max_model_len = 32768
 
 [parallel]
 dp = 6

--- a/configs/skywork_math/7b/stage2/orch.toml
+++ b/configs/skywork_math/7b/stage2/orch.toml
@@ -8,6 +8,9 @@ mask_truncated_completions = false
 [model]
 name = "willcb/DeepSeek-R1-Distill-Qwen-7B"
 
+[sampling]
+max_tokens = 32768
+
 [monitor.wandb]
 
 [environment]

--- a/configs/wordle/14b/infer.toml
+++ b/configs/wordle/14b/infer.toml
@@ -1,6 +1,5 @@
 [model]
 name = "willcb/Qwen3-14B"
-max_model_len = 4096
 
 [parallel]
 dp = 6

--- a/configs/wordle/1b/infer.toml
+++ b/configs/wordle/1b/infer.toml
@@ -1,6 +1,5 @@
 [model]
 name = "willcb/Qwen3-1.7B-Wordle"
-max_model_len = 4096
 
 [parallel]
 dp = 6


### PR DESCRIPTION
Changes configs to control request sequence length via orch.sampling.max_tokens (passed per-request via sampling_args thru environment) instead of infer.max_model_len (hard limit for vLLM server).

As a general rule, we should probably not assume that prompt lengths are known in advance. While this is possible in single-turn cases, it generally isn't for multi-turn, as the environment doesn't know max_model_len or how many tokens are in intermediate env responses. This can lead to crashes in the middle of the run:

```
openai.BadRequestError: Error code: 400 - {'object': 'error', 'message': "This model's maximum context length is 4096 tokens. However, you requested 4344 tokens (3320 in the messages, 1024 in the completion). Please reduce the length of the messages or completion. None", 'type': 'BadRequestError', 'param': None, 'code': 400}
```

Relying on the default max_model_len is a good safeguard, as this is generally quite large, and not really any efficiency savings in an absolute sense by limiting it. IMO `max_tokens` is the best place to control how many tokens we want a model to be able to generate, though we should also probably add better error handling for the case where this goes beyond max_model_len anyway (separate PR to verifiers, need to think about the best non-hacky way to do it -- naive way is parsing the error message). 