### PR TITLE
Run evals on final checkpoint

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -480,6 +480,7 @@ async def orchestrate(config: OrchestratorConfig):
         progress.step += 1
         is_first_step = False
 
+    eval_tasks = None
     if config.eval:
         logger.info("Running final evals")
         eval_tasks = [
@@ -517,7 +518,8 @@ async def orchestrate(config: OrchestratorConfig):
         ckpt_manager.save(progress, buffer, step=progress.step)
 
     # Await evals
-    await asyncio.gather(*eval_tasks)
+    if eval_tasks is not None:
+        await asyncio.gather(*eval_tasks)
 
     logger.success("Orchestrator finished.")
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -480,6 +480,31 @@ async def orchestrate(config: OrchestratorConfig):
         progress.step += 1
         is_first_step = False
 
+    if config.eval:
+        logger.info("Running final evals")
+        eval_tasks = [
+            asyncio.create_task(
+                run_eval(
+                    client=client,
+                    eval_id=eval_id,
+                    env_args=config.eval.environment_args.get(eval_id, {}),
+                    model_config=config.model,
+                    sampling_config=config.eval.sampling,
+                    num_examples=num_examples,
+                    rollouts_per_example=rollouts_per_example,
+                    ckpt_step=ckpt_step,
+                    output_dir=config.output_dir,
+                    save=config.eval.save,
+                    step=progress.step,
+                )
+            )
+            for eval_id, num_examples, rollouts_per_example in zip(
+                config.eval.environment_ids,
+                config.eval.num_examples,
+                config.eval.rollouts_per_example,
+            )
+        ]
+
     # Log final (immutable) samples and distributions to W&B table
     if monitor.wandb:
         logger.info("Logging final samples and distributions as W&B table")
@@ -490,6 +515,9 @@ async def orchestrate(config: OrchestratorConfig):
     if ckpt_manager is not None:
         logger.info("Writing final checkpoint")
         ckpt_manager.save(progress, buffer, step=progress.step)
+
+    # Await evals
+    await asyncio.gather(*eval_tasks)
 
     logger.success("Orchestrator finished.")
 


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Previously, if `max_steps` was not a multiple of `eval.interval`, then we would not run evals on the final checkpoint which is kind of annoying. This PR fixes this.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: #835 
**Linear Issue**: Resolves PRIMERL-72