### PR TITLE
Allow evaling API models

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,8 +314,8 @@ CUDA_VISIBLE_DEVICES=2,3 uv run rl \
   --trainer @ configs/reverse_text/train.toml \
   --orchestrator @ configs/reverse_text/orch.toml \
   --inference @ configs/reverse_text/infer.toml \
-  --inference.server.port 8001 \
-  --orchestrator.client.port 8001 \
+  --inference.server.port http://localhost:8001 \
+  --orchestrator.client.base-url http://localhost:8001 \
   --output-dir outputs2
 ```
 

--- a/src/prime_rl/eval/eval.py
+++ b/src/prime_rl/eval/eval.py
@@ -34,7 +34,7 @@ async def eval(config: OfflineEvalConfig):
 
     # Setup client
     logger.info(
-        f"Initializing OpenAI client (base_url={config.client.base_url}, api_key={config.client.api_key}, server_type={config.client.server_type})"
+        f"Initializing OpenAI client (base_url={config.client.base_url}, api_key_var={config.client.api_key_var}, server_type={config.client.server_type})"
     )
     client = setup_client(config.client)
 

--- a/src/prime_rl/eval/eval.py
+++ b/src/prime_rl/eval/eval.py
@@ -95,6 +95,7 @@ async def eval(config: OfflineEvalConfig):
                         env_args=config.environment_args.get(eval_id, {}),
                         model_config=config.model,
                         sampling_config=config.sampling,
+                        client_config=config.client,
                         num_examples=num_examples,
                         rollouts_per_example=rollouts_per_example,
                         output_dir=config.output_dir,

--- a/src/prime_rl/eval/eval.py
+++ b/src/prime_rl/eval/eval.py
@@ -33,7 +33,9 @@ async def eval(config: OfflineEvalConfig):
     )
 
     # Setup client
-    logger.info(f"Initializing OpenAI client (base_url={config.client.base_url}, api_key={config.client.api_key})")
+    logger.info(
+        f"Initializing OpenAI client (base_url={config.client.base_url}, api_key={config.client.api_key}, server_type={config.client.server_type})"
+    )
     client = setup_client(config.client)
 
     # Check health of the client

--- a/src/prime_rl/eval/eval.py
+++ b/src/prime_rl/eval/eval.py
@@ -57,6 +57,7 @@ async def eval(config: OfflineEvalConfig):
                     env_args=config.environment_args.get(eval_id, {}),
                     model_config=config.model,
                     sampling_config=config.sampling,
+                    client_config=config.client,
                     num_examples=num_examples,
                     rollouts_per_example=rollouts_per_example,
                     output_dir=config.output_dir,

--- a/src/prime_rl/eval/eval.py
+++ b/src/prime_rl/eval/eval.py
@@ -1,7 +1,7 @@
 import asyncio
 
 from prime_rl.eval.config import OfflineEvalConfig
-from prime_rl.eval.utils import maybe_save_all_eval_results, run_eval
+from prime_rl.eval.utils import run_eval
 from prime_rl.orchestrator.client import (
     check_has_model,
     check_health,
@@ -49,7 +49,7 @@ async def eval(config: OfflineEvalConfig):
     # Run benchmarks on base model
     if config.eval_base:
         logger.info(f"Running evals on base model {config.model.name}")
-        eval_dirs = await asyncio.gather(
+        await asyncio.gather(
             *[
                 run_eval(
                     client=client,
@@ -70,9 +70,6 @@ async def eval(config: OfflineEvalConfig):
             ]
         )
 
-        # Maybe, combine all eval results into single dataset with split and save to disk
-        maybe_save_all_eval_results(eval_dirs)
-
     # If specified, evaluate all checkpoints found in the weights directory
     if config.weights_dir is not None:
         logger.info(f"Evaluating weight checkpoints in {config.weights_dir}")
@@ -90,7 +87,7 @@ async def eval(config: OfflineEvalConfig):
             await update_weights(client, config.weights_dir, ckpt_step)
 
             # Run evals on checkpoint
-            eval_dirs = await asyncio.gather(
+            await asyncio.gather(
                 *[
                     run_eval(
                         client=client,
@@ -98,7 +95,6 @@ async def eval(config: OfflineEvalConfig):
                         env_args=config.environment_args.get(eval_id, {}),
                         model_config=config.model,
                         sampling_config=config.sampling,
-                        client_config=config.client,
                         num_examples=num_examples,
                         rollouts_per_example=rollouts_per_example,
                         output_dir=config.output_dir,
@@ -110,9 +106,6 @@ async def eval(config: OfflineEvalConfig):
                     )
                 ]
             )
-
-            # Maybe, combine all eval results into single dataset with split and save to disk
-            maybe_save_all_eval_results(eval_dirs)
 
     logger.info("Evaluation finished!")
 

--- a/src/prime_rl/eval/eval.py
+++ b/src/prime_rl/eval/eval.py
@@ -33,7 +33,7 @@ async def eval(config: OfflineEvalConfig):
     )
 
     # Setup client
-    logger.info(f"Initializing OpenAI client ({config.client.host}:{config.client.port})")
+    logger.info(f"Initializing OpenAI client (base_url={config.client.base_url}, api_key={config.client.api_key})")
     client = setup_client(config.client)
 
     # Check health of the client

--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -40,7 +40,7 @@ def compute_pass_at_k(rewards: list[int]) -> dict[str, float]:
 def prepare_sampling_args(sampling_config: EvalSamplingConfig, client_config: ClientConfig) -> dict[str, Any]:
     """Prepare sampling args for the client."""
     # Initialize sampling args
-    sampling_args: dict[str, Any] = {"logprobs": True}
+    sampling_args: dict[str, Any] = {}
 
     # Apply sampling arguments, if specified
     if sampling_config.temperature is not None:

--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -10,7 +10,7 @@ from openai import AsyncOpenAI
 from verifiers import load_environment
 from verifiers.types import GenerateOutputs
 
-from prime_rl.orchestrator.config import EvalSamplingConfig, ModelConfig
+from prime_rl.orchestrator.config import ClientConfig, EvalSamplingConfig, ModelConfig
 from prime_rl.orchestrator.utils import parse_completion_tokens, parse_truncated_completions
 from prime_rl.utils.logger import get_logger
 from prime_rl.utils.monitor import get_monitor
@@ -37,12 +37,43 @@ def compute_pass_at_k(rewards: list[int]) -> dict[str, float]:
     return {f"pass@{k}": avg_pass_rate}
 
 
+def prepare_sampling_args(sampling_config: EvalSamplingConfig, client_config: ClientConfig) -> dict[str, Any]:
+    """Prepare sampling args for the client."""
+    # Initialize sampling args
+    sampling_args: dict[str, Any] = {"logprobs": True}
+
+    # Apply sampling arguments, if specified
+    if sampling_config.temperature is not None:
+        sampling_args["temperature"] = sampling_config.temperature
+    if sampling_config.max_tokens is not None:
+        sampling_args["max_tokens"] = sampling_config.max_tokens
+    if sampling_config.top_p is not None:
+        sampling_args["top_p"] = sampling_config.top_p
+
+    if client_config.server_type == "vllm":
+        # Always return token IDs from vLLM server
+        extra_body: dict[str, Any] = {"return_tokens_as_token_ids": True}
+
+        # Apply vLLM-specific sampling arguments, if specified
+        if sampling_config.top_k is not None:
+            extra_body["top_k"] = sampling_config.top_k
+        if sampling_config.min_p is not None:
+            extra_body["min_p"] = sampling_config.min_p
+        if sampling_config.min_tokens is not None:
+            extra_body["min_tokens"] = sampling_config.min_tokens
+
+        sampling_args["extra_body"] = extra_body
+
+    return sampling_args
+
+
 async def run_eval(
     client: AsyncOpenAI,
     eval_id: str,
     env_args: dict,
     model_config: ModelConfig,
     sampling_config: EvalSamplingConfig,
+    client_config: ClientConfig,
     num_examples: int,
     rollouts_per_example: int,
     save: bool,
@@ -87,31 +118,12 @@ async def run_eval(
         "answer": [example.get("answer", "") for example in examples],
     }
 
+    # Prepare sampling arguments
+    sampling_args = prepare_sampling_args(sampling_config, client_config)
+
     logger.debug(
         f"Evaluating {eval_id} (num_examples={len(examples)}, rollouts_per_example={rollouts_per_example}) with args {env_args}"
     )
-
-    # Always return logprobs to parser response length
-    sampling_args: dict[str, Any] = {
-        "logprobs": True,
-        "extra_body": {
-            "return_tokens_as_token_ids": True,
-        },
-    }
-
-    # Apply sampling config only if specified
-    if sampling_config.temperature is not None:
-        sampling_args["temperature"] = sampling_config.temperature
-    if sampling_config.max_tokens is not None:
-        sampling_args["max_tokens"] = sampling_config.max_tokens
-    if sampling_config.top_p is not None:
-        sampling_args["top_p"] = sampling_config.top_p
-    if sampling_config.top_k is not None:
-        sampling_args["extra_body"]["top_k"] = sampling_config.top_k
-    if sampling_config.min_p is not None:
-        sampling_args["extra_body"]["min_p"] = sampling_config.min_p
-    if sampling_config.min_tokens is not None:
-        sampling_args["extra_body"]["min_tokens"] = sampling_config.min_tokens
 
     # Run async generation and scoring
     run_eval_start_time = time.time()
@@ -126,8 +138,16 @@ async def run_eval(
     logger.debug(f"Generated and scored rollouts in {run_eval_time:.2f}s")
 
     rewards = torch.tensor(generate_outputs.reward).reshape(-1, rollouts_per_example).float()
-    completion_lens = torch.tensor(list(map(len, parse_completion_tokens(states=generate_outputs.state)))).reshape(-1, rollouts_per_example).float()
-    is_truncated = torch.tensor(parse_truncated_completions(states=generate_outputs.state)).reshape(-1, rollouts_per_example).float()
+    completion_lens = (
+        torch.tensor(list(map(len, parse_completion_tokens(states=generate_outputs.state))))
+        .reshape(-1, rollouts_per_example)
+        .float()
+    )
+    is_truncated = (
+        torch.tensor(parse_truncated_completions(states=generate_outputs.state))
+        .reshape(-1, rollouts_per_example)
+        .float()
+    )
 
     k = rollouts_per_example
     sample_stats = pd.DataFrame({"example_id": example_ids, "reward": rewards.flatten().tolist()})
@@ -150,9 +170,7 @@ async def run_eval(
         assert pass_at_k is not None
         for pass_rate, pass_rate_score in pd.Series(pass_at_k.mean()).items():
             message += f", {capitalize(str(pass_rate))}: {pass_rate_score:.4f}"
-    message += (
-        f", Completion Length: {completion_lens.mean():.2f} (±{completion_lens.std():.2f}, ∈[{completion_lens.min():.2f}, {completion_lens.max():.2f}]), Truncated: {is_truncated.mean() * 100:.1f}%)"
-    )
+    message += f", Completion Length: {completion_lens.mean():.2f} (±{completion_lens.std():.2f}, ∈[{completion_lens.min():.2f}, {completion_lens.max():.2f}]), Truncated: {is_truncated.mean() * 100:.1f}%)"
     logger.success(message)
 
     # Log statistics to monitor

--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -6,6 +6,7 @@ from typing import Any
 import numpy as np
 import pandas as pd
 import torch
+from datasets import DatasetDict, load_from_disk
 from openai import AsyncOpenAI
 from verifiers import load_environment
 from verifiers.types import GenerateOutputs
@@ -80,7 +81,7 @@ async def run_eval(
     output_dir: Path,
     ckpt_step: int,
     step: int | None = None,
-) -> None:
+) -> None | Path:
     # Get the logger
     logger = get_logger()
     monitor = get_monitor()
@@ -219,6 +220,7 @@ async def run_eval(
     monitor.log(time_metrics)
 
     # If specified, save eval artifacts
+    eval_dir = None
     if save:
         # Save samples as dataset
         eval_dir = get_eval_dir(output_dir) / f"step_{ckpt_step}" / eval_id
@@ -243,3 +245,19 @@ async def run_eval(
             json.dump(report, f, indent=2)
 
         logger.info(f"Saved samples and report to {eval_dir}")
+
+    return eval_dir
+
+
+def maybe_save_all_eval_results(eval_dirs: list):
+    assert len(set(map(type, eval_dirs))) == 1, "All eval dirs should have the same type"
+    if eval_dirs[0] is None:
+        return
+    assert all(isinstance(eval_dir, Path) for eval_dir in eval_dirs), "All eval dirs should be Path objects"
+
+    all_eval_dir = eval_dirs[0].parent / "all_evals"
+    splits = {}
+    for eval_dir in eval_dirs:
+        splits[eval_dir.name] = load_from_disk(eval_dir)
+
+    DatasetDict(splits).save_to_disk(all_eval_dir)

--- a/src/prime_rl/orchestrator/client.py
+++ b/src/prime_rl/orchestrator/client.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 from pathlib import Path
 
 import httpx

--- a/src/prime_rl/orchestrator/client.py
+++ b/src/prime_rl/orchestrator/client.py
@@ -22,7 +22,7 @@ def setup_client(client_config: ClientConfig) -> AsyncOpenAI:
     http_client = httpx.AsyncClient(limits=limits, timeout=timeout)
     return AsyncOpenAI(
         base_url=client_config.base_url,
-        api_key=os.getenv(client_config.api_key, "EMPTY"),
+        api_key=os.getenv(client_config.api_key_var, "EMPTY"),
         max_retries=10,  # OAI default: 2 (does exponential backoff and reasonable timeout in between retries)
         http_client=http_client,
     )

--- a/src/prime_rl/orchestrator/client.py
+++ b/src/prime_rl/orchestrator/client.py
@@ -21,10 +21,9 @@ def setup_client(client_config: ClientConfig) -> AsyncOpenAI:
         max_keepalive_connections=28000,  # OAI default: 100
     )
     http_client = httpx.AsyncClient(limits=limits, timeout=timeout)
-    base_url = f"http://{client_config.host}:{client_config.port}/v1"
     return AsyncOpenAI(
-        base_url=base_url,
-        api_key=client_config.api_key,
+        base_url=client_config.base_url,
+        api_key=os.getenv(client_config.api_key, "EMPTY"),
         max_retries=10,  # OAI default: 2 (does exponential backoff and reasonable timeout in between retries)
         http_client=http_client,
     )

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -7,6 +7,8 @@ from prime_rl.orchestrator.advantage import AdvantageType
 from prime_rl.utils.config import LogConfig, ModelConfig, MultiMonitorConfig
 from prime_rl.utils.pydantic_config import BaseConfig, BaseSettings
 
+ServerType = Literal["vllm", "openai"]
+
 
 class ClientConfig(BaseConfig):
     """Configures the client to be used for inference."""
@@ -31,6 +33,19 @@ class ClientConfig(BaseConfig):
             description="Name of environment varaible containing the API key to use for the OpenAI API. Will parse using `os.getenv(client_config.api_key)`. Can be set to an arbitrary string if the inference server is not protected by an API key .",
         ),
     ] = "OPENAI_API_KEY"
+
+    server_type: Annotated[
+        ServerType,
+        Field(
+            description="Type of inference server that the client is connected to. Can be 'vllm' or 'openai'. Defaults to vLLM, which is our default client for training.",
+        ),
+    ] = "vllm"
+
+    @model_validator(mode="after")
+    def auto_setup_server_type(self):
+        if self.base_url == "https://api.openai.com/v1":
+            self.server_type = "openai"
+        return self
 
 
 class SamplingConfig(BaseConfig):

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -18,7 +18,7 @@ class ClientConfig(BaseConfig):
         ),
     ] = 1200
 
-    host: Annotated[
+    base_url: Annotated[
         str,
         Field(
             description="Base URL to use for the OpenAI API. By default, it is set to None, which means ",
@@ -28,9 +28,9 @@ class ClientConfig(BaseConfig):
     api_key: Annotated[
         str,
         Field(
-            description="API key to use for the OpenAI API. An arbitrary string can be passed if the inference server is not protected by an API key.",
+            description="Name of environment varaible containing the API key to use for the OpenAI API. Will parse using `os.getenv(client_config.api_key)`. Can be set to an arbitrary string if the inference server is not protected by an API key .",
         ),
-    ] = "insecure"
+    ] = "OPENAI_API_KEY"
 
 
 class SamplingConfig(BaseConfig):

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -21,16 +21,9 @@ class ClientConfig(BaseConfig):
     host: Annotated[
         str,
         Field(
-            description="Host to use for the OpenAI API. By default, it is set to a local inference server.",
+            description="Base URL to use for the OpenAI API. By default, it is set to None, which means ",
         ),
-    ] = "localhost"
-
-    port: Annotated[
-        int,
-        Field(
-            description="Port to use for the OpenAI API. By default, it is set to a local inference server.",
-        ),
-    ] = 8000
+    ] = "http://localhost:8000/v1"
 
     api_key: Annotated[
         str,

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -27,10 +27,10 @@ class ClientConfig(BaseConfig):
         ),
     ] = "http://localhost:8000/v1"
 
-    api_key: Annotated[
+    api_key_var: Annotated[
         str,
         Field(
-            description="Name of environment varaible containing the API key to use for the OpenAI API. Will parse using `os.getenv(client_config.api_key)`. Can be set to an arbitrary string if the inference server is not protected by an API key .",
+            description="Name of environment varaible containing the API key to use for the OpenAI API. Will parse using `os.getenv(client_config.api_key_var)`. Can be set to an arbitrary string if the inference server is not protected by an API key .",
         ),
     ] = "OPENAI_API_KEY"
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -58,7 +58,10 @@ async def orchestrate(config: OrchestratorConfig):
         )
 
     # Setup client
-    logger.info(f"Initializing OpenAI client (base_url={config.client.base_url}, api_key={config.client.api_key})")
+    assert config.client.server_type == "vllm", "Orchestrator only supports vLLM server type."
+    logger.info(
+        f"Initializing OpenAI client (base_url={config.client.base_url}, api_key={config.client.api_key}, server_type={config.client.server_type})"
+    )
     client = setup_client(config.client)
 
     # Load tokenizer

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -58,7 +58,7 @@ async def orchestrate(config: OrchestratorConfig):
         )
 
     # Setup client
-    logger.info(f"Initializing OpenAI client ({config.client.host}:{config.client.port})")
+    logger.info(f"Initializing OpenAI client (base_url={config.client.base_url}, api_key={config.client.api_key})")
     client = setup_client(config.client)
 
     # Load tokenizer

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -60,7 +60,7 @@ async def orchestrate(config: OrchestratorConfig):
     # Setup client
     assert config.client.server_type == "vllm", "Orchestrator only supports vLLM server type."
     logger.info(
-        f"Initializing OpenAI client (base_url={config.client.base_url}, api_key={config.client.api_key}, server_type={config.client.server_type})"
+        f"Initializing OpenAI client (base_url={config.client.base_url}, api_key_var={config.client.api_key_var}, server_type={config.client.server_type})"
     )
     client = setup_client(config.client)
 


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Previously, some of the logic in the eval script assumed that the OAI client is talking to our custom vLLM server (e.g. it would hit the `/health` or `/upload_weight` routes or try parse completion token IDs). This PR adds the necessary alternative paths to allow evaling API models, e.g. GPT-5 from `https://api.openai.com/v1`. All of the changes are non-breaking for the orchestrator and RL training - here we simply assert that the inference server type is `vllm` (can later be extended by `sglang`) because we require weight reload for RL.

The specific changes are:
- Use `client_config.base_url` instead of `client_config.host` and `client_config.port` - **this is a breaking config change!**
- Pass `client_config.api_key` as OAI key, similar to how done it `verifiers` (more secure than passing this in plain-text)
- Have fallbacks for non-standard routes (e.g. `/health` and `/reload_weights`)
- Add auto-inferred `client.config.server_type` (either `vllm` or `openai` for conditional execution)
- Do not attempt to compute completion length and truncation info from OAI models (because we only get text and unclear how to tokenize this)

## Example

Eval `gpt-5-mini` on three environments with one command

```bash
export OPENAI_API_KEY=...
```

```bash
uv run eval \
  --client.base_url https://api.openai.com/v1 \
  --client.api_key OPENAI_API_KEY \
  --model.name gpt-5-mini-2025-08-07  \
  --sampling.max-tokens 65536 \
  --environment_ids math500,aime2024,aime2025 \
  --environment_args '{"math500": {"use_think": false}, "aime2024": {"use_think": false}, "aime2025": {"use_think": false}, "gpqa": {"use_diamond": true, "use_think": true}}'
```

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: #867 
**Linear Issue**: Resolves PRIMERL-84