### PR TITLE
add per gpu tps

### DIFF
--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -355,6 +355,7 @@ def train(config: RLTrainerConfig):
         # Log performance metrics
         perf_metrics = {
             "perf/throughput": throughput,
+            "perf/throughput_per_gpu": throughput / world.world_size,
             "perf/mfu": mfu,
             "step": progress.step,
         }

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -259,6 +259,7 @@ def train(config: SFTTrainerConfig):
         # Log performance metrics
         perf_metrics = {
             "perf/throughput": throughput,
+            "perf/throughput_per_gpu": throughput / world.world_size,
             "perf/mfu": mfu,
             "step": progress.step,
         }


### PR DESCRIPTION
# Add per gpu througput in tps

this pr add per gpu throughput in tps. This allow for fair comparison with other lib like torchtitan

<img width="660" height="464" alt="Screenshot from 2025-09-09 17-05-26" src="https://github.com/user-attachments/assets/d1903ac4-a4b9-40ad-8352-83cfae771f21" />
<img width="677" height="491" alt="Screenshot from 2025-09-09 17-05-06" src="https://github.com/user-attachments/assets/f9c31393-c720-4a5e-be92-ecf8f1e478e7" />
