### PR TITLE
Sami/fix memory monitor

### DIFF
--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -105,7 +105,7 @@ class RLTrainerConfig(BaseSettings):
         ),
     ] = 2
 
-    profile_path: Annotated[Path | None, Field(description="Path to write memory profile to.")] = None
+    memory_profiler_path: Annotated[Path | None, Field(description="Path to write memory profile to.")] = None
 
     recompute_logprobs: Annotated[
         bool,

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -30,6 +30,7 @@ from prime_rl.trainer.model import (
 from prime_rl.trainer.parallel_dims import get_parallel_dims
 from prime_rl.trainer.perf import get_perf_counter
 from prime_rl.trainer.utils import (
+    MemoryProfiler,
     OffloadedTensor,
     Tensors,
     copy_model_to_cpu,
@@ -228,8 +229,8 @@ def train(config: RLTrainerConfig):
             compute_logprobs_time = time.time() - compute_logprobs_start_time
             logger.debug(f"Recomputed logprobs in {compute_logprobs_time:.2f} seconds")
 
-        if config.profile_path and world.rank == 0:
-            torch.cuda.memory._record_memory_history()
+        if config.memory_profiler_path:
+            memory_profiler = MemoryProfiler(progress.step, 1, config.memory_profiler_path)
 
         forward_backward_start_time = time.time()
         micro_batch_size, seq_len = micro_batches[0]["input_ids"].shape
@@ -322,13 +323,8 @@ def train(config: RLTrainerConfig):
         weight_ckpt_manager.maybe_clean(progress.step)
 
         # Optionally, dump memory snapshot
-        if config.profile_path and progress.step == 2 and world.rank == 0:
-            logger.debug("Dumping memory snapshot")
-            profile_path = config.profile_path
-            if not profile_path.suffix == ".pickle":
-                profile_path = profile_path.with_suffix(".pickle")
-            torch.cuda.memory._dump_snapshot(profile_path.as_posix())
-            torch.cuda.memory._record_memory_history(enabled=None)
+        if config.memory_profiler_path:
+            memory_profiler.step()
 
         # Synchronize the tensor metrics across all steps and ranks
         tensor_stats = tensors.compute_stats()

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -230,7 +230,7 @@ def train(config: RLTrainerConfig):
             logger.debug(f"Recomputed logprobs in {compute_logprobs_time:.2f} seconds")
 
         if config.memory_profiler_path:
-            memory_profiler = MemoryProfiler(progress.step, 1, config.memory_profiler_path)
+            memory_profiler = MemoryProfiler(progress.step, config.memory_profiler_path)
 
         forward_backward_start_time = time.time()
         micro_batch_size, seq_len = micro_batches[0]["input_ids"].shape

--- a/src/prime_rl/trainer/sft/config.py
+++ b/src/prime_rl/trainer/sft/config.py
@@ -99,7 +99,7 @@ class SFTTrainerConfig(BaseSettings):
         Field(description="Maximum number of steps to run training for. If None, will run indefinitely."),
     ] = None
 
-    profile_path: Annotated[Path | None, Field(description="Path to write memory profile to.")] = None
+    memory_profiler_path: Annotated[Path | None, Field(description="Path to write memory profile to.")] = None
 
     bench: Annotated[
         bool,

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -137,7 +137,7 @@ def train(config: SFTTrainerConfig):
             break
 
         memory_profiler = (
-            MemoryProfiler(progress.step, 1, config.memory_profiler_path) if config.memory_profiler_path else None
+            MemoryProfiler(progress.step, config.memory_profiler_path) if config.memory_profiler_path else None
         )
 
         step_start_time = time.time()

--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -242,9 +242,10 @@ class MemoryProfiler:
         self.step_num = step_num
 
     def step(self):
-        self.logger.info(f"Dumping memory snapshot at step {self.step_num} at {self.snapshot_path}")
-        begin = time.monotonic()
-        file_path = self.snapshot_path / f"step_{self.step_num}_rank{get_world().rank}.pickle"
-        with open(file_path, "wb") as output:
-            pickle.dump(torch.cuda.memory._snapshot(), output)
-        self.logger.info(f"Finished dumping memory snapshot in {time.monotonic() - begin:.2f} seconds")
+        if self.step_num % self.freq != 0:
+            self.logger.info(f"Dumping memory snapshot at step {self.step_num} at {self.snapshot_path}")
+            begin = time.monotonic()
+            file_path = self.snapshot_path / f"step_{self.step_num}_rank{get_world().rank}.pickle"
+            with open(file_path, "wb") as output:
+                pickle.dump(torch.cuda.memory._snapshot(), output)
+            self.logger.info(f"Finished dumping memory snapshot in {time.monotonic() - begin:.2f} seconds")

--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -1,5 +1,8 @@
+import pickle
+import time
 from collections import defaultdict
 from itertools import chain
+from pathlib import Path
 from typing import Any, TypeAlias
 
 import pandas as pd
@@ -11,6 +14,7 @@ from torch import Tensor, nn
 from torch.distributed.tensor import DTensor
 
 from prime_rl.trainer.world import get_world
+from prime_rl.utils.logger import get_logger
 from prime_rl.utils.utils import format_num, format_time
 
 
@@ -221,3 +225,26 @@ class Tensors(defaultdict):
             self[key].append(tensors.tolist())
 
         return metrics
+
+
+MEMORY_SNAPSHOT_MAX_ENTRIES = 100000
+
+
+class MemoryProfiler:
+    def __init__(self, step_num: int, freq: int, snapshot_path: Path):
+        torch.cuda.memory._record_memory_history(max_entries=MEMORY_SNAPSHOT_MAX_ENTRIES)
+        self.freq = freq
+
+        snapshot_path.mkdir(parents=True, exist_ok=True)
+        self.snapshot_path = snapshot_path
+        self.logger = get_logger()
+
+        self.step_num = step_num
+
+    def step(self):
+        self.logger.info(f"Dumping memory snapshot at step {self.step_num} at {self.snapshot_path}")
+        begin = time.monotonic()
+        file_path = self.snapshot_path / f"step_{self.step_num}_rank{get_world().rank}.pickle"
+        with open(file_path, "wb") as output:
+            pickle.dump(torch.cuda.memory._snapshot(), output)
+        self.logger.info(f"Finished dumping memory snapshot in {time.monotonic() - begin:.2f} seconds")

--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -231,9 +231,8 @@ MEMORY_SNAPSHOT_MAX_ENTRIES = 100000
 
 
 class MemoryProfiler:
-    def __init__(self, step_num: int, freq: int, snapshot_path: Path):
+    def __init__(self, step_num: int, snapshot_path: Path):
         torch.cuda.memory._record_memory_history(max_entries=MEMORY_SNAPSHOT_MAX_ENTRIES)
-        self.freq = freq
 
         snapshot_path.mkdir(parents=True, exist_ok=True)
         self.snapshot_path = snapshot_path
@@ -242,10 +241,10 @@ class MemoryProfiler:
         self.step_num = step_num
 
     def step(self):
-        if self.step_num % self.freq != 0:
-            self.logger.info(f"Dumping memory snapshot at step {self.step_num} at {self.snapshot_path}")
-            begin = time.monotonic()
-            file_path = self.snapshot_path / f"step_{self.step_num}_rank{get_world().rank}.pickle"
-            with open(file_path, "wb") as output:
-                pickle.dump(torch.cuda.memory._snapshot(), output)
-            self.logger.info(f"Finished dumping memory snapshot in {time.monotonic() - begin:.2f} seconds")
+        self.step_num + 1
+        self.logger.info(f"Dumping memory snapshot at step {self.step_num} at {self.snapshot_path}")
+        begin = time.monotonic()
+        file_path = self.snapshot_path / f"step_{self.step_num}_rank{get_world().rank}.pickle"
+        with open(file_path, "wb") as output:
+            pickle.dump(torch.cuda.memory._snapshot(), output)
+        self.logger.info(f"Finished dumping memory snapshot in {time.monotonic() - begin:.2f} seconds")

--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -247,4 +247,6 @@ class MemoryProfiler:
         file_path = self.snapshot_path / f"step_{self.step_num}_rank{get_world().rank}.pickle"
         with open(file_path, "wb") as output:
             pickle.dump(torch.cuda.memory._snapshot(), output)
-        self.logger.info(f"Finished dumping memory snapshot in {time.monotonic() - begin:.2f} seconds")
+        self.logger.info(
+            f"Finished dumping memory snapshot in {time.monotonic() - begin:.2f} seconds, load {file_path} at https://docs.pytorch.org/memory_viz to visualize the memory usage"
+        )

--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -244,7 +244,7 @@ class MemoryProfiler:
         self.step_num + 1
         self.logger.info(f"Dumping memory snapshot at step {self.step_num} at {self.snapshot_path}")
         begin = time.monotonic()
-        file_path = self.snapshot_path / f"step_{self.step_num}_rank{get_world().rank}.pickle"
+        file_path = self.snapshot_path / f"step_{self.step_num}" / f"rank_{get_world().rank}.pickle"
         with open(file_path, "wb") as output:
             pickle.dump(torch.cuda.memory._snapshot(), output)
         self.logger.info(


### PR DESCRIPTION

For some reason previous pickle was empty on the PyTorch profiler this pr fix it.

Also add per rank profiler and nice logging

<img width="2553" height="973" alt="Screenshot from 2025-09-09 18-48-20" src="https://github.com/user-attachments/assets/8cd101d8-fb04-4f45-98cd-5ded5b838f2b" />
