### PR TITLE
Log all reward functions belonging to vf_env.rubric independently

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -262,7 +262,7 @@ async def orchestrate(config: OrchestratorConfig):
             logger.debug(f"Found {len(generate_outputs.metrics)} individual reward functions")
             for func_name, func_rewards in generate_outputs.metrics.items():
                 individual_reward_outputs[func_name] = torch.tensor(func_rewards)
-                logger.debug(f"Collected {len(func_rewards)} rewards for {func_name}, mean: {torch.tensor(func_rewards).mean().item():.6f}")
+                logger.debug(f"Collected {len(func_rewards)} rewards for {func_name}")
 
             rewards = process_rewards(
                 rewards=processed_outputs.rewards,

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -82,9 +82,6 @@ async def orchestrate(config: OrchestratorConfig):
     vf_env = load_environment(config.environment.id, **config.environment.args)
     dataset = vf_env.get_dataset(seed=config.seed)
 
-    logger.info(f"Environment has rubric: {hasattr(vf_env, 'rubric')}")
-    if hasattr(vf_env, 'rubric'):
-        logger.info(f"Rubric type: {type(vf_env.rubric)}")
     # Setup buffer
     logger.info(f"Setting up buffer ({config.buffer})")
     buffer = setup_buffer(dataset, config.buffer)

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -446,7 +446,7 @@ async def orchestrate(config: OrchestratorConfig):
         
         # Add individual reward function metrics
         for func_name, func_rewards in individual_reward_outputs.items():
-            reward_metrics[f"reward/{func_name}_mean"] = func_rewards.mean().item()
+            reward_metrics[f"reward/{func_name}/mean"] = func_rewards.mean().item()
 
         monitor.log(reward_metrics)
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -82,20 +82,9 @@ async def orchestrate(config: OrchestratorConfig):
     vf_env = load_environment(config.environment.id, **config.environment.args)
     dataset = vf_env.get_dataset(seed=config.seed)
 
-    # DEBUG: Log environment structure
-    logger.info(f"Environment type: {type(vf_env)}")
     logger.info(f"Environment has rubric: {hasattr(vf_env, 'rubric')}")
     if hasattr(vf_env, 'rubric'):
         logger.info(f"Rubric type: {type(vf_env.rubric)}")
-        logger.info(f"Rubric has reward_funcs: {hasattr(vf_env.rubric, 'reward_funcs')}")
-        if hasattr(vf_env.rubric, 'reward_funcs'):
-            logger.info(f"Number of reward functions: {len(vf_env.rubric.reward_funcs)}")
-            for i, func in enumerate(vf_env.rubric.reward_funcs):
-                logger.info(f"Reward function {i}: {func.__name__}")
-        logger.info(f"Rubric has reward_weights: {hasattr(vf_env.rubric, 'reward_weights')}")
-        if hasattr(vf_env.rubric, 'reward_weights'):
-            logger.info(f"Weights: {vf_env.rubric.reward_weights}")
-
     # Setup buffer
     logger.info(f"Setting up buffer ({config.buffer})")
     buffer = setup_buffer(dataset, config.buffer)
@@ -271,31 +260,12 @@ async def orchestrate(config: OrchestratorConfig):
                 mask_truncated_completions=config.mask_truncated_completions,
             )
 
-            # Compute individual reward function outputs
+            # Extract individual reward function metrics from generate_outputs
             individual_reward_outputs = {}
-            if hasattr(vf_env, 'rubric') and hasattr(vf_env.rubric, 'reward_funcs'):
-                logger.info(f"Computing individual rewards for {len(vf_env.rubric.reward_funcs)} functions")
-                
-                for func_idx, func in enumerate(vf_env.rubric.reward_funcs):
-                    func_name = func.__name__.replace('_reward', '').replace('_func', '')
-                    func_rewards = []
-                    
-                    for i in range(len(processed_outputs.prompt_ids)):
-                        try:
-                            # Call individual reward function
-                            reward = func(
-                                prompt=generate_outputs.prompt[i],
-                                completion=generate_outputs.completion[i], 
-                                answer=inputs["answer"][i],
-                                state=generate_outputs.state[i]
-                            )
-                            func_rewards.append(float(reward))
-                        except Exception as e:
-                            logger.warning(f"Error computing individual reward for {func_name}, sample {i}: {e}")
-                            func_rewards.append(0.0)
-                    
-                    individual_reward_outputs[func_name] = torch.tensor(func_rewards)
-                    logger.info(f"Collected {len(func_rewards)} rewards for {func_name}, mean: {torch.tensor(func_rewards).mean().item():.6f}")
+            logger.debug(f"Found {len(generate_outputs.metrics)} individual reward functions")
+            for func_name, func_rewards in generate_outputs.metrics.items():
+                individual_reward_outputs[func_name] = torch.tensor(func_rewards)
+                logger.debug(f"Collected {len(func_rewards)} rewards for {func_name}, mean: {torch.tensor(func_rewards).mean().item():.6f}")
 
             rewards = process_rewards(
                 rewards=processed_outputs.rewards,
@@ -480,8 +450,6 @@ async def orchestrate(config: OrchestratorConfig):
         # Add individual reward function metrics
         for func_name, func_rewards in individual_reward_outputs.items():
             reward_metrics[f"reward/{func_name}_mean"] = func_rewards.mean().item()
-            reward_metrics[f"reward/{func_name}_std"] = func_rewards.std().item()
-            logger.info(f"Logging reward/{func_name}_mean: {func_rewards.mean().item():.6f}")
 
         monitor.log(reward_metrics)
 


### PR DESCRIPTION
A simple way to log all the individual reward functions that belong to the Rubric (along with the existing mean) for logging additional metrics, such as those logging any "perfect" attempts, tracking per-turn accuracies independently, etc.

<img width="1047" height="504" alt="image" src="https://github.com/user-attachments/assets/263db0d5-224f-4e16-8aa9-1ea05617aff7" />

We should also remove the hardcoded logic for `solve_none` and `solve_all` in the orchestrator, and directly incorporate this logic into the environments where these are interpretable metrics. Also, there isn't any coherent interpretation of these metrics for continuous rewards (such as BTRM / Bradley-Terry reward model scalars), but they are also incoherent if we are to change our rewards to be negative.

## Side Note

There is potential value in having rewards exist as negatives where maximization is driving the rewards towards zero due to Dr. GRPO's normalization not being scale invariant, and because this ensures that relative differences get smaller as the reward increases (rather than the magnitude growing according to the scale, which may exaggerate small relative differences depending on the problem setup).

<img width="724" height="1168" alt="image" src="https://github.com/user-attachments/assets/21a330c3-33bc-4b6e-a153-77673b17e081" />
