### PR TITLE
Support tool call SFT data

### DIFF
--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from typing import Iterator, TypedDict
 
 import torch
+import json
 from datasets import Dataset, concatenate_datasets, load_dataset
 from jaxtyping import Bool, Int
 from torch import Tensor
@@ -174,14 +175,45 @@ class SFTDataset(StatefulIterableDataset):
                 "Prompt and completion must be lists"
             )
 
+            def deserialize_tool_calls(messages: list[dict]) -> list[dict]:
+                """
+                Deserialize tool calls in messages, if any are present. Iterates
+                over all messages in a message list and tries to find
+                "tool_calls" key. If found, assumes it is a OAI format and has
+                key "function" with "arguments" key which is stringified. It
+                will then deserialize the argument so that chat tmeplates like
+                Qwen3's can be used.
+                """
+                def deserialize_tool_call(tool_call: dict) -> dict:
+                    return {
+                        **tool_call,
+                        "function": {**tool_call["function"], "arguments": json.loads(tool_call["function"]["arguments"])},
+                    }
+                return  [
+                    {
+                        **message,
+                        "tool_calls": [deserialize_tool_call(tool_call) for tool_call in message.get("tool_calls", []) or []],
+                    }
+                    for message in messages
+                ]
+
+            # Deserialize tool call arguments from message list, if present - assumes OAI format
+            # Reference: https://platform.openai.com/docs/guides/function-calling#handling-function-calls
+            prompt = deserialize_tool_calls(example["prompt"])
+            completion = deserialize_tool_calls(example["completion"])
+
+            # Parse available tools, if present - assumes OAI format
+            # Reference: https://platform.openai.com/docs/guides/function-calling#function-tool-example
+            tools = json.loads(example.get("tools", "[]"))
+
             prompt_ids = self.tokenizer.apply_chat_template(
-                example["prompt"],
-                tools=example.get("tools"),
+                prompt,
+                tools=tools,
                 **example.get("chat_template_kwargs", {}),
             )
             prompt_completion_ids = self.tokenizer.apply_chat_template(
-                example["prompt"] + example["completion"],
-                tools=example.get("tools"),
+                prompt + completion
+                tools=tools,
                 **example.get("chat_template_kwargs", {}),
             )
 

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -212,7 +212,7 @@ class SFTDataset(StatefulIterableDataset):
                 **example.get("chat_template_kwargs", {}),
             )
             prompt_completion_ids = self.tokenizer.apply_chat_template(
-                prompt + completion
+                prompt + completion,
                 tools=tools,
                 **example.get("chat_template_kwargs", {}),
             )

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -1,9 +1,9 @@
+import json
 import math
 from collections import defaultdict
 from typing import Iterator, TypedDict
 
 import torch
-import json
 from datasets import Dataset, concatenate_datasets, load_dataset
 from jaxtyping import Bool, Int
 from torch import Tensor


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

This PR adds the necessary logic in the SFT dataset to correctly insert tool call information for any model whose chat template follows the OAI spec. This required two main changes:
- We assume that the list of available tools is JSON-serialized and as such we have to deserialize it before tokenizing the example. This serialization step is necessary because PyArrow would complain if we tried uploading a non-serialized version of the tool list
- We have to deserialize the tool call arguments (the arguments to the function the LLM scores). In standard OAI spec these arguments are serialized but chat templates such as Qwen3's which our chat template is based on require this field to already be deserialized to correctly format the tool calls of the model. Hence we introduce the (somewhat ugly) helper function `deserialize_tool_calls` which we apply to both the `prompt` and `completion`.

I have started a run with `Qwen3-8B` (similar tool calling functionality as our chat template) on the debug SFT datasets which includes 1K samples from each split to demonstrate that we correctly tokenize the tool calls.

Check the [W&B run](https://wandb.ai/primeintellect/intellect3-sft?nw=rr02lxlz3jb) here. Run looking solid a couple steps in. Note, that we expect high accuracy very quickly because we only have 6K samples in total so we will quickly do epochs here.

<img width="1048" height="261" alt="Screenshot 2025-09-10 at 6 02 39 PM" src="https://github.com/user-attachments/assets/f4ea0aca-db20-4091-8ac3-4d07878370e0" />