### PR TITLE
Add repetition penalty sampler

### DIFF
--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -61,6 +61,8 @@ def prepare_sampling_args(sampling_config: EvalSamplingConfig, client_config: Cl
             extra_body["min_p"] = sampling_config.min_p
         if sampling_config.min_tokens is not None:
             extra_body["min_tokens"] = sampling_config.min_tokens
+        if sampling_config.repetition_penalty is not None:
+            extra_body["repetition_penalty"] = sampling_config.repetition_penalty
 
         sampling_args["extra_body"] = extra_body
 

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -59,6 +59,14 @@ class SamplingConfig(BaseConfig):
         ),
     ] = 1.0
 
+    repetition_penalty: Annotated[
+        float,
+        Field(
+            ge=0,
+            description="Penalty for repeating tokens. Values > 1.0 discourage repetition, values < 1.0 encourage repetition, and 1.0 means no penalty.",
+        ),
+    ] = 1.0
+
     max_tokens: Annotated[
         int | None,
         Field(
@@ -90,6 +98,14 @@ class EvalSamplingConfig(BaseConfig):
         Field(
             ge=0,
             description="Scales the output probability distribution. Lower values => more deterministic, higher values => more random. If 0, will sample greedily. Defaults to None, which means we fall back to the inference server's default value.",
+        ),
+    ] = None
+
+    repetition_penalty: Annotated[
+        float | None,
+        Field(
+            ge=0,
+            description="Penalty for repeating tokens. Values > 1.0 discourage repetition, values < 1.0 encourage repetition, and 1.0 means no penalty. Defaults to None, which means we fall back to the inference server's default value.",
         ),
     ] = None
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -230,6 +230,7 @@ async def orchestrate(config: OrchestratorConfig):
                 "min_p": 0.0,
             }
             sampling_args["extra_body"]["min_tokens"] = sampling_args.pop("min_tokens")
+            sampling_args["extra_body"]["repetition_penalty"] = sampling_args.pop("repetition_penalty")
 
             # Generate completions + rewards with verifiers
             logger.info(f"Sending {len(problems)} requests to environments")


### PR DESCRIPTION
Only adding this because Qwen2.5 instruct models come with a default chat template that is pretty terrible/unprincipled for RL training, and vllm will default to the generation configuration setting for the penalty if it isn't specified outright.

In some contexts, the differences can be significant. (Orange line is vanilla probability distribution, blue line is vanilla probability distribution except with 1.05 repetition penalty from the Qwen Instruct chat template).

<img width="1128" height="1064" alt="image" src="https://github.com/user-attachments/assets/9719fa11-6069-458a-96d9-480fe5f5f69f" />
