### PR TITLE
Parse completion tokens for API models

### DIFF
--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -14,7 +14,7 @@ from verifiers.types import GenerateOutputs, Messages
 
 from prime_rl.eval.config import OfflineEvalConfig
 from prime_rl.orchestrator.config import ClientConfig, EvalConfig, EvalSamplingConfig, ModelConfig
-from prime_rl.orchestrator.utils import parse_completion_tokens, parse_truncated_completions
+from prime_rl.orchestrator.utils import parse_is_truncated_completions, parse_num_completion_tokens
 from prime_rl.utils.logger import get_logger
 from prime_rl.utils.monitor import get_monitor
 from prime_rl.utils.utils import capitalize, get_eval_dir, get_step_path
@@ -192,24 +192,9 @@ async def run_eval(
     logger.debug(f"Generated and scored rollouts in {run_eval_time:.2f}s")
 
     rewards = torch.tensor(generate_outputs.reward).reshape(-1, rollouts_per_example).float()
-    if client_config.server_type == "vllm":
-        completion_lens = (
-            torch.tensor(list(map(len, parse_completion_tokens(states=generate_outputs.state))))
-            .reshape(-1, rollouts_per_example)
-            .float()
-        )
-        is_truncated = (
-            torch.tensor(parse_truncated_completions(states=generate_outputs.state))
-            .reshape(-1, rollouts_per_example)
-            .float()
-        )
-    else:
-        # We can probably do a best-effort tokenization to get an approximate token completion length and truncation detection
-        logger.warning(
-            f"Server type {client_config.server_type} not supported for computing completion length and truncated completions."
-        )
-        completion_lens = torch.zeros(len(examples)).reshape(-1, rollouts_per_example).float()
-        is_truncated = torch.zeros(len(examples)).reshape(-1, rollouts_per_example).float()
+    responses = [state["responses"] for state in generate_outputs.state]
+    completion_lens = torch.tensor(parse_num_completion_tokens(responses)).reshape(-1, rollouts_per_example).float()
+    is_truncated = torch.tensor(parse_is_truncated_completions(responses)).reshape(-1, rollouts_per_example).float()
 
     k = rollouts_per_example
     sample_stats = pd.DataFrame({"example_id": example_ids, "reward": rewards.flatten().tolist()})

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -29,7 +29,7 @@ from prime_rl.orchestrator.advantage import compute_advantages
 from prime_rl.orchestrator.utils import (
     wait_for_weight_checkpoint,
     print_benchmark,
-    parse_truncated_completions,
+    parse_is_truncated_completions,
     process_rewards,
 )
 from prime_rl.utils.monitor import setup_monitor
@@ -268,7 +268,8 @@ async def orchestrate(config: OrchestratorConfig):
             )
 
             # Parse whether the completions were truncated
-            is_truncated = parse_truncated_completions(states=generate_outputs.state)
+            responses = [state["responses"] for state in generate_outputs.state]
+            is_truncated = parse_is_truncated_completions(responses=responses)
 
             # Update pool
             rollouts = make_rollouts(

--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -3,6 +3,8 @@ from typing import Any
 
 import pandas as pd
 from openai.types.chat import ChatCompletion
+from openai.types.chat.chat_completion import Choice
+from openai.types.completion_usage import CompletionUsage
 from rich.console import Console
 from rich.table import Table
 from verifiers.types import State
@@ -37,23 +39,35 @@ def parse_completion_tokens(states: list[State]) -> list[list[int]]:
     return completion_tokens
 
 
-def parse_truncated_completions(states: list[State]) -> list[bool]:
-    """
-    Parses the state and, for each rollout, returns whether any completion
-    was truncated. Uses the finish_reason field to determine if the completion
-    was truncated.
-    """
+def parse_num_completion_tokens(responses: list[list[ChatCompletion]]) -> list[int]:
+    """Parses the number of tokens from a list of chat completions returned by OAI API."""
+    all_num_completion_tokens = []
+    for response in responses:
+        num_completion_tokens = 0
+        for chat_completion in response:
+            assert isinstance(chat_completion, ChatCompletion)
+            assert chat_completion.usage is not None, "Usage should be present in the response"
+            usage = chat_completion.usage
+            assert isinstance(usage, CompletionUsage)
+            num_completion_tokens += usage.completion_tokens
+        all_num_completion_tokens.append(num_completion_tokens)
+    assert len(all_num_completion_tokens) == len(responses), (
+        "Number of completion tokens should be the same as the number of states"
+    )
+    return all_num_completion_tokens
+
+
+def parse_is_truncated_completions(responses: list[list[ChatCompletion]]) -> list[bool]:
+    """Parses whether the completions were truncated from a list of (multi-turn) OAI chat completions"""
     all_is_truncated = []
-    for state in states:
-        assert "responses" in state, "Responses should be present in the state"
-        assert all(isinstance(r, ChatCompletion) for r in state["responses"]), (
-            "Responses should be ChatCompletion objects"
-        )
+    for response in responses:
         is_truncated = False
-        for response in state["responses"]:
-            assert len(response.choices) == 1, "Response should always have one choice"
-            choice = response.choices[0]
-            if hasattr(choice, "finish_reason") and choice.finish_reason == "length":
+        for chat_completion in response:
+            assert isinstance(chat_completion, ChatCompletion)
+            assert len(chat_completion.choices) == 1, "Response should always have one choice"
+            choice = chat_completion.choices[0]
+            assert isinstance(choice, Choice)
+            if choice.finish_reason == "length":
                 is_truncated = True
         all_is_truncated.append(is_truncated)
     return all_is_truncated

--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -7,7 +7,6 @@ from openai.types.chat.chat_completion import Choice
 from openai.types.completion_usage import CompletionUsage
 from rich.console import Console
 from rich.table import Table
-from verifiers.types import State
 
 from prime_rl.utils.utils import (
     format_num,
@@ -15,28 +14,6 @@ from prime_rl.utils.utils import (
     get_weight_ckpt_model_path,
     wait_for_path,
 )
-
-
-def parse_completion_tokens(states: list[State]) -> list[list[int]]:
-    """Parses the output token ids from a list of chat completions returned by vLLM OAI server."""
-    completion_tokens = []
-    for state in states:
-        assert "responses" in state, "Responses should be present in the state"
-        assert all(isinstance(r, ChatCompletion) for r in state["responses"]), (
-            "Responses should be ChatCompletion objects"
-        )
-        for chat_completion in state["responses"]:
-            assert len(chat_completion.choices) == 1, "Response should always have one choice"
-            assert chat_completion.choices[0].logprobs is not None, (
-                "Logprobs should not be None. Make sure to set logprobs=True in the extra body when making the request to /v1/chat/completions"
-            )
-            assert chat_completion.choices[0].logprobs.content is not None, (
-                "Logprob content should not be None. Make sure to set logprobs=True in the extra body when making the request to /v1/chat/completions"
-            )
-            completion_tokens.append(
-                [int(token.token.split(":")[-1]) for token in chat_completion.choices[0].logprobs.content]
-            )
-    return completion_tokens
 
 
 def parse_num_completion_tokens(responses: list[list[ChatCompletion]]) -> list[int]:
@@ -52,7 +29,7 @@ def parse_num_completion_tokens(responses: list[list[ChatCompletion]]) -> list[i
             num_completion_tokens += usage.completion_tokens
         all_num_completion_tokens.append(num_completion_tokens)
     assert len(all_num_completion_tokens) == len(responses), (
-        "Number of completion tokens should be the same as the number of states"
+        "Number of completion tokens should be the same as the number of responses"
     )
     return all_num_completion_tokens
 


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Parse information about the number of completion tokens and whether or not a completion was truncated assuming standard OAI responses. Works both for self-hosting models with vLLM (as before), but now also for any API model that follows OAI spec.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: #888 
**Linear Issue**: Resolves PRIMERL-92