### PR TITLE
Reduce memory usage during accuracy computation in SFT trainer

### DIFF
--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -5,7 +5,7 @@ from contextlib import nullcontext
 # ruff: noqa: I001
 
 import torch
-from torch.nn.functional import cross_entropy
+from torch.nn.functional import cross_entropy, softmax
 from torch.distributed.tensor.experimental import context_parallel
 from loguru import logger
 from prime_rl.trainer.ckpt import Progress, setup_ckpt_manager
@@ -176,6 +176,9 @@ def train(config: SFTTrainerConfig):
                 # Compute loss
                 loss = cross_entropy(logits.view(-1, V), target_ids.view(-1), reduction="none").view(B, L)
 
+                # Compute accuracy
+                accuracy = torch.eq(softmax(logits, dim=-1).argmax(dim=-1), target_ids).float()
+
                 if is_tt_moe_model(model):
                     load_balance_stats = get_load_balance_stats(model)
                     for k, v in load_balance_stats.items():
@@ -183,6 +186,7 @@ def train(config: SFTTrainerConfig):
 
                 # Add tensors to tensor dict for logging purposes
                 tensors["loss"].append(loss[loss_mask].detach().to("cpu"))
+                tensors["accuracy"].append(accuracy[loss_mask].detach().to("cpu"))
 
                 # Mean reduction of unmasked tokens
                 loss = loss[loss_mask].mean()
@@ -197,7 +201,7 @@ def train(config: SFTTrainerConfig):
                 loss.backward()
 
             # Debug log with *local, micro step* stats
-            micro_step_message = f"Micro Step {micro_step} | Loss: {tensors['loss'][-1].mean().item():.4f} | Dataloader Step: {dataloader.state_dict()['dataset_state']['step']}"
+            micro_step_message = f"Micro Step {micro_step} | Loss: {tensors['loss'][-1].mean().item():.4f} | Accuracy: {tensors['accuracy'][-1].mean().item():.4f} | Dataloader Step: {dataloader.state_dict()['dataset_state']['step']}"
             if "max_vio" in tensors:
                 micro_step_message += f" | Max Vio: {tensors['max_vio'][-1].mean().item():.4f}"
             logger.debug(micro_step_message)
@@ -233,7 +237,7 @@ def train(config: SFTTrainerConfig):
         # Log step metrics
         step_time = time.time() - step_start_time
         current_lr = optimizer.param_groups[0]["lr"]
-        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {tensor_stats['loss/mean']:.4f} | Grad. Norm: {grad_norm:.4f} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}%"
+        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {tensor_stats['loss/mean']:.4f} | Accuracy: {tensor_stats['accuracy/mean']:.4f} | Grad. Norm: {grad_norm:.4f} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}%"
         if "max_vio/mean" in tensor_stats:
             step_message += f" | Max Vio: {tensor_stats['max_vio/mean']:.4f}"
         logger.success(step_message)


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

> Should merge either this PR or #887 

Previously, we compute accuracy on each micro batch we not only materialize the `logits` but also the `probs` tensor, leading to unnecessary GPU memory usage which slightly decreases throughput.

This PR **changes the accuracy** computation such that we don't materialize the `probs` tensor in memory, reducing the peak GPU memory usage. However, compared to #887, we do not gain much in throughput because we still do the accuracy computation.

**Benchmarking command**

```bash
uv run sft @ configs/debug/sft.toml \
  --data.type fake \
  --data.length variable \
  --data.seq-len 4096 \
  --data.batch-size 4 \
  --data.micro-batch-size 1 \
  --bench
```

**Current**

Peak GPU mem: 26.20 GB

<img width="776" height="144" alt="Screenshot 2025-09-11 at 1 24 17 PM" src="https://github.com/user-attachments/assets/cdf2384e-8234-4297-98df-3c46e32dd112" />

**This PR**

Peak GPU mem: 23.88 GB

<img width="709" height="210" alt="Screenshot 2025-09-11 at 1 32 16 PM" src="https://github.com/user-attachments/assets/41c28e64-ddb5-4eb8-b052-074204074a10" />

**Comparison**

<img width="707" height="253" alt="Screenshot 2025-09-11 at 1 32 38 PM" src="https://github.com/user-attachments/assets/ac58e5bd-4e0d-4380-ac71-75b412fa6216" />

