### PR TITLE
Do not cast to FP32 on SFT trainer

### DIFF
--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -50,7 +50,7 @@ def get_model(config: ModelConfig) -> nn.Module:
         config.name, attn_implementation=config.attn, trust_remote_code=config.trust_remote_code
     )
     config_model.use_cache = False
-    
+
     model_cls = AutoLigerKernelForCausalLM if config.liger_kernel else AutoModelForCausalLM
     model = model_cls.from_pretrained(
         pretrained_model_name_or_path=config.name,
@@ -114,4 +114,4 @@ def setup_model(config: ModelConfig, parallel_dims: ParallelDims) -> nn.Module:
 def forward(
     model: nn.Module, input_ids: Int[Tensor, "batch seq"], position_ids: Int[Tensor, "batch seq"]
 ) -> Float[Tensor, "batch seq vocab"]:
-    return model(input_ids=input_ids, position_ids=position_ids).logits.float()
+    return model(input_ids=input_ids, position_ids=position_ids).logits

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -210,7 +210,7 @@ def train(config: RLTrainerConfig):
                     temperature = micro_batch["temperature"]
 
                     # Compute the logprobs
-                    logits = forward(logprob_model, input_ids, position_ids).contiguous()
+                    logits = forward(logprob_model, input_ids, position_ids).float().contiguous()
                     shifted_logits = shift_logits(logits)
                     shifted_logits = shifted_logits / temperature
                     recomputed_logprobs = selective_log_softmax(shifted_logits, input_ids)
@@ -255,7 +255,7 @@ def train(config: RLTrainerConfig):
             micro_batch_size, seq_len = input_ids.shape
 
             # Forward pass
-            logits = forward(model, input_ids, position_ids).contiguous()
+            logits = forward(model, input_ids, position_ids).float().contiguous()
             shifted_logits = shift_logits(logits)
             shifted_logits = shifted_logits / temperature
             logprobs = selective_log_softmax(shifted_logits, input_ids)

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -15,7 +15,6 @@ from prime_rl.trainer.logger import setup_logger
 from prime_rl.trainer.optim import setup_optimizer
 from prime_rl.trainer.scheduler import setup_scheduler
 from prime_rl.trainer.model import (
-    forward,
     setup_tokenizer,
     setup_model,
     is_tt_moe_model,
@@ -170,7 +169,7 @@ def train(config: SFTTrainerConfig):
 
             with maybe_context_parallel:
                 # Forward pass
-                logits = forward(model, input_ids, position_ids).contiguous()
+                logits = model(input_ids=input_ids, position_ids=position_ids).logits
                 B, L, V = logits.shape
 
                 # Compute loss

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -15,6 +15,7 @@ from prime_rl.trainer.logger import setup_logger
 from prime_rl.trainer.optim import setup_optimizer
 from prime_rl.trainer.scheduler import setup_scheduler
 from prime_rl.trainer.model import (
+    forward,
     setup_tokenizer,
     setup_model,
     is_tt_moe_model,
@@ -169,7 +170,7 @@ def train(config: SFTTrainerConfig):
 
             with maybe_context_parallel:
                 # Forward pass
-                logits = model(input_ids=input_ids, position_ids=position_ids).logits
+                logits = forward(model, input_ids, position_ids)
                 B, L, V = logits.shape
 
                 # Compute loss


### PR DESCRIPTION
# fix memory issue

This remove the float32 casting from sft. It fix memory usage and we don't need fp32 logits for sft only for RL

**Command**

```bash
uv run sft --model.name Qwen/Qwen3-0.6B --model.compile --model.liger-kernel --data.type fake --data.seq-len 2048 --data.batch-size 64 --data.micro-batch-size 1 --bench 
```

**Previous**

<img width="787" height="175" alt="Screenshot 2025-09-12 at 12 02 51 PM" src="https://github.com/user-attachments/assets/a07c7237-d911-47b6-99d7-92f374910874" />


**Now**

<img width="789" height="175" alt="Screenshot 2025-09-12 at 12 00 56 PM" src="https://github.com/user-attachments/assets/74fc02fa-070e-4ddd-9ffb-a1d79c61e22d" />
