### PR TITLE
Refactor tensor class API

### DIFF
--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -50,7 +50,7 @@ def get_model(config: ModelConfig) -> nn.Module:
         config.name, attn_implementation=config.attn, trust_remote_code=config.trust_remote_code
     )
     config_model.use_cache = False
-    
+
     model_cls = AutoLigerKernelForCausalLM if config.liger_kernel else AutoModelForCausalLM
     model = model_cls.from_pretrained(
         pretrained_model_name_or_path=config.name,
@@ -114,4 +114,4 @@ def setup_model(config: ModelConfig, parallel_dims: ParallelDims) -> nn.Module:
 def forward(
     model: nn.Module, input_ids: Int[Tensor, "batch seq"], position_ids: Int[Tensor, "batch seq"]
 ) -> Float[Tensor, "batch seq vocab"]:
-    return model(input_ids=input_ids, position_ids=position_ids).logits.float()
+    return model(input_ids=input_ids, position_ids=position_ids).logits

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -114,4 +114,4 @@ def setup_model(config: ModelConfig, parallel_dims: ParallelDims) -> nn.Module:
 def forward(
     model: nn.Module, input_ids: Int[Tensor, "batch seq"], position_ids: Int[Tensor, "batch seq"]
 ) -> Float[Tensor, "batch seq vocab"]:
-    return model(input_ids=input_ids, position_ids=position_ids).logits
+    return model(input_ids=input_ids, position_ids=position_ids).logits.float()

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -328,8 +328,13 @@ def train(config: RLTrainerConfig):
             memory_profiler.step()
 
         # Synchronize the tensor metrics across all steps and ranks
-        tensor_distributions, tensor_metrics = tensors.compute_stats()
+        log_distributions = (
+            config.wandb and config.wandb.log_extras and config.wandb.log_extras.distributions
+        ) or False
+        tensor_distributions, tensor_metrics = tensors.compute_stats(log_distributions=log_distributions)
         assert len(tensors) == 0, "Tensors should be empty before the next step"
+        if not log_distributions:
+            assert len(tensor_distributions) == 0, "Tensors should be empty before the next step"
 
         # Compute step metrics
         num_local_tokens = micro_batch_size * seq_len * num_micro_batches

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -186,7 +186,7 @@ def train(config: SFTTrainerConfig):
                 # Scale loss by number of gradient accumulation steps
                 loss /= grad_accum_steps
 
-                batch_loss += loss.sum()
+                batch_loss += loss
 
                 # Delete logits before backward pass to avoid memory spike
                 del logits

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -182,7 +182,7 @@ def train(config: SFTTrainerConfig):
                         tensors[k].append(v)
 
                 # Add tensors to tensor dict for logging purposes
-                tensors["loss"].append(loss[loss_mask].detach().to("cpu"))
+                tensors["loss"].append(loss[loss_mask].detach().to("cpu", non_blocking=True))
 
                 # Mean reduction of unmasked tokens
                 loss = loss[loss_mask].mean()

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -219,8 +219,13 @@ def train(config: SFTTrainerConfig):
             memory_profiler.step()
 
         # Synchronize the tensor metrics across all steps and ranks
-        tensor_distributions, tensor_metrics = tensors.compute_stats()
+        log_distributions = (
+            config.wandb and config.wandb.log_extras and config.wandb.log_extras.distributions
+        ) or False
+        tensor_distributions, tensor_metrics = tensors.compute_stats(log_distributions=log_distributions)
         assert len(tensors) == 0, "Tensors should be empty before the next step"
+        if not log_distributions:
+            assert len(tensor_distributions) == 0, "Tensors should be empty before the next step"
 
         # Compute step metrics
         num_tokens = config.data.batch_size * config.data.seq_len

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -1,4 +1,5 @@
 import time
+import asyncio
 from contextlib import nullcontext
 
 # Import environment before any other imports
@@ -33,9 +34,10 @@ from prime_rl.trainer.utils import (
 from prime_rl.trainer.world import get_world
 from prime_rl.utils.monitor import setup_monitor
 from prime_rl.utils.pydantic_config import parse_argv
-from prime_rl.utils.utils import clean_exit, to_col_format
+from prime_rl.utils.utils import clean_exit, to_col_format, ensure_event_loop
 
 
+@ensure_event_loop
 @clean_exit
 @logger.catch(reraise=True)
 def train(config: SFTTrainerConfig):
@@ -202,6 +204,13 @@ def train(config: SFTTrainerConfig):
                 micro_step_message += f" | Max Vio: {tensors['max_vio'][-1].mean().item():.4f}"
             logger.debug(micro_step_message)
 
+        # Start asynchronously gathering tensor metrics across all steps and ranks
+        log_distributions = (
+            config.wandb and config.wandb.log_extras and config.wandb.log_extras.distributions
+        ) or False
+        loop = asyncio.get_event_loop()
+        compute_stats_task = loop.create_task(tensors.compute_stats(log_distributions=log_distributions))
+
         # Optionally, clip the gradients
         grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=config.optim.max_norm).full_tensor()
 
@@ -218,15 +227,6 @@ def train(config: SFTTrainerConfig):
         if memory_profiler is not None:
             memory_profiler.step()
 
-        # Synchronize the tensor metrics across all steps and ranks
-        log_distributions = (
-            config.wandb and config.wandb.log_extras and config.wandb.log_extras.distributions
-        ) or False
-        tensor_distributions, tensor_metrics = tensors.compute_stats(log_distributions=log_distributions)
-        assert len(tensors) == 0, "Tensors should be empty before the next step"
-        if not log_distributions:
-            assert len(tensor_distributions) == 0, "Tensors should be empty before the next step"
-
         # Compute step metrics
         num_tokens = config.data.batch_size * config.data.seq_len
         progress.total_tokens += num_tokens
@@ -235,6 +235,12 @@ def train(config: SFTTrainerConfig):
         perf_counter.count_tokens(num_tokens)
         throughput = perf_counter.get_tokens_per_second() or 0
         mfu = perf_counter.get_mfu() or 0
+
+        # Wait for the compute stats thread to finish
+        tensor_distributions, tensor_metrics = loop.run_until_complete(compute_stats_task)
+        assert len(tensors) == 0, "Tensors should be empty before the next step"
+        if not log_distributions:
+            assert len(tensor_distributions) == 0, "Tensors should be empty before the next step"
 
         # Log step metrics
         step_time = time.time() - step_start_time

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -182,7 +182,7 @@ def train(config: SFTTrainerConfig):
                         tensors[k].append(v)
 
                 # Add tensors to tensor dict for logging purposes
-                tensors["loss"].append(loss[loss_mask].detach().to("cpu", non_blocking=True))
+                tensors["loss"].append(loss[loss_mask].detach().to("cpu"))
 
                 # Mean reduction of unmasked tokens
                 loss = loss[loss_mask].mean()

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -15,7 +15,6 @@ from prime_rl.trainer.logger import setup_logger
 from prime_rl.trainer.optim import setup_optimizer
 from prime_rl.trainer.scheduler import setup_scheduler
 from prime_rl.trainer.model import (
-    forward,
     setup_tokenizer,
     setup_model,
     is_tt_moe_model,
@@ -170,7 +169,7 @@ def train(config: SFTTrainerConfig):
 
             with maybe_context_parallel:
                 # Forward pass
-                logits = forward(model, input_ids, position_ids).contiguous()
+                logits = model(input_ids=input_ids, position_ids=position_ids).logits
                 B, L, V = logits.shape
 
                 # Compute loss

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -15,16 +15,18 @@ from prime_rl.trainer.logger import setup_logger
 from prime_rl.trainer.optim import setup_optimizer
 from prime_rl.trainer.scheduler import setup_scheduler
 from prime_rl.trainer.model import (
-    get_load_balance_stats,
-    is_tt_moe_model,
+    forward,
     setup_tokenizer,
     setup_model,
+    is_tt_moe_model,
+    get_load_balance_stats,
 )
 from prime_rl.trainer.parallel_dims import get_parallel_dims
 from prime_rl.trainer.perf import get_perf_counter
 from prime_rl.trainer.sft.data import setup_dataloader, setup_dataset
 from prime_rl.trainer.utils import (
     MemoryProfiler,
+    Tensors,
     setup_torch_distributed,
     print_benchmark,
 )
@@ -32,7 +34,6 @@ from prime_rl.trainer.world import get_world
 from prime_rl.utils.monitor import setup_monitor
 from prime_rl.utils.pydantic_config import parse_argv
 from prime_rl.utils.utils import clean_exit, to_col_format
-import torch.distributed as dist
 
 
 @clean_exit
@@ -142,15 +143,13 @@ def train(config: SFTTrainerConfig):
         step_start_time = time.time()
         forward_backward_start_time = time.time()
         epoch = 0
+        tensors = Tensors()  # Used to accumulate tensor statistics across grad acc and ranks for logging
         grad_accum_steps = (
             config.data.batch_size
             * config.model.cp
             * config.model.tp
             // (config.data.micro_batch_size * world.world_size)
         )
-
-        batch_loss = torch.tensor(0.0).to("cuda")
-        batch_max_vio = torch.tensor(0.0).to("cuda")
         for micro_step in range(grad_accum_steps):
             micro_batch = next(dataiter)
             input_ids = micro_batch["input_ids"].to("cuda")
@@ -171,17 +170,21 @@ def train(config: SFTTrainerConfig):
 
             with maybe_context_parallel:
                 # Forward pass
-                logits = model(input_ids=input_ids, position_ids=position_ids).logits
+                logits = forward(model, input_ids, position_ids).contiguous()
                 B, L, V = logits.shape
 
                 # Compute loss
                 loss = cross_entropy(logits.view(-1, V), target_ids.view(-1), reduction="none").view(B, L)
 
                 if is_tt_moe_model(model):
-                    max_vio = get_load_balance_stats(model)["max_vio"] / grad_accum_steps
-                    # TODO(sami): Check with Jackmin if we should do a max or avg here
-                    batch_max_vio += max_vio
+                    load_balance_stats = get_load_balance_stats(model)
+                    for k, v in load_balance_stats.items():
+                        tensors[k].append(v)
 
+                # Add tensors to tensor dict for logging purposes
+                tensors["loss"].append(loss[loss_mask].detach().to("cpu"))
+
+                # Mean reduction of unmasked tokens
                 loss = loss[loss_mask].mean()
 
                 # Scale loss by number of gradient accumulation steps
@@ -194,9 +197,9 @@ def train(config: SFTTrainerConfig):
                 loss.backward()
 
             # Debug log with *local, micro step* stats
-            micro_step_message = f"Micro Step {micro_step} | Loss: {loss.item()} | Dataloader Step: {dataloader.state_dict()['dataset_state']['step']}"
-            if is_tt_moe_model(model):
-                micro_step_message += f" | Max Vio: {batch_max_vio.item():.4f}"
+            micro_step_message = f"Micro Step {micro_step} | Loss: {tensors['loss'][-1].mean().item():.4f} | Dataloader Step: {dataloader.state_dict()['dataset_state']['step']}"
+            if "max_vio" in tensors:
+                micro_step_message += f" | Max Vio: {tensors['max_vio'][-1].mean().item():.4f}"
             logger.debug(micro_step_message)
 
         # Optionally, clip the gradients
@@ -216,12 +219,7 @@ def train(config: SFTTrainerConfig):
             memory_profiler.step()
 
         # Synchronize the tensor metrics across all steps and ranks
-
-        dist.all_reduce(batch_loss, op=dist.ReduceOp.AVG)
-
-        if is_tt_moe_model(model):
-            # TODO(sami): Check with Jackmin if we should do a max or avg here
-            dist.all_reduce(batch_max_vio, op=dist.ReduceOp.AVG)
+        tensor_stats = tensors.compute_stats()
 
         # Compute step metrics
         num_tokens = config.data.batch_size * config.data.seq_len
@@ -235,9 +233,9 @@ def train(config: SFTTrainerConfig):
         # Log step metrics
         step_time = time.time() - step_start_time
         current_lr = optimizer.param_groups[0]["lr"]
-        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {batch_loss.item()} | Grad. Norm: {grad_norm:.4f} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}%"
-        if is_tt_moe_model(model):
-            step_message += f" | Max Vio: {batch_max_vio.item():.4f}"
+        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {tensor_stats['loss/mean']:.4f} | Grad. Norm: {grad_norm:.4f} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}%"
+        if "max_vio/mean" in tensor_stats:
+            step_message += f" | Max Vio: {tensor_stats['max_vio/mean']:.4f}"
         logger.success(step_message)
 
         # Log progress metrics
@@ -266,12 +264,9 @@ def train(config: SFTTrainerConfig):
         }
         monitor.log(optim_metrics)
 
-        loss_log_metrics = {
-            "loss/mean": batch_loss.item(),
-            "step": progress.step,
-        }
         # Log tensor stats
-        monitor.log(loss_log_metrics)
+        tensor_stats["step"] = progress.step
+        monitor.log(tensor_stats)
 
         # Log time metrics
         time_metrics = {
@@ -282,12 +277,13 @@ def train(config: SFTTrainerConfig):
         }
         monitor.log(time_metrics)
 
-        if is_tt_moe_model(model):
-            max_vio_log_metrics = {
-                "max_vio/mean": batch_max_vio.item(),
-                "step": progress.step,
-            }
-            monitor.log(max_vio_log_metrics)
+        # Log distributions to W&B table if enabled
+        assert all(len(tensors) == 1 for tensors in tensors.values()), "Tensors must be lists of length 1"
+        distributions = {key: tensors[key][0] for key in tensors.keys()}
+        monitor.log_distributions(
+            distributions=distributions,
+            step=progress.step,
+        )
 
         is_first_step = False
         progress.step += 1

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -150,7 +150,7 @@ def train(config: SFTTrainerConfig):
         )
 
         batch_loss = torch.tensor(0.0).to("cuda")
-        batch_max_vio = torch.tensor(0.0).to("cuda") if is_tt_moe_model(model) else None
+        batch_max_vio = torch.tensor(0.0).to("cuda")
         for micro_step in range(grad_accum_steps):
             micro_batch = next(dataiter)
             input_ids = micro_batch["input_ids"].to("cuda")
@@ -175,21 +175,17 @@ def train(config: SFTTrainerConfig):
                 B, L, V = logits.shape
 
                 # Compute loss
-                # todo(sami): check that the ignore index doesn't impact the eos prediction it should not as the eos is a target of the last non eos token
-                loss = cross_entropy(
-                    logits.view(-1, V), target_ids.view(-1), reduction="mean", ignore_index=tokenizer.pad_token_id
-                )
+                loss = cross_entropy(logits.view(-1, V), target_ids.view(-1), reduction="none").view(B, L)
 
-                # todo(sami): bring back tt model load balance stats
                 if is_tt_moe_model(model):
                     max_vio = get_load_balance_stats(model)["max_vio"] / grad_accum_steps
+                    # TODO(sami): Check with Jackmin if we should do a max or avg here
                     batch_max_vio += max_vio
-                    # todo(sami): need to check with Jackmin if we should do a max or avg here
+
+                loss = loss[loss_mask].mean()
 
                 # Scale loss by number of gradient accumulation steps
                 loss /= grad_accum_steps
-
-                batch_loss += loss
 
                 # Delete logits before backward pass to avoid memory spike
                 del logits
@@ -221,15 +217,11 @@ def train(config: SFTTrainerConfig):
 
         # Synchronize the tensor metrics across all steps and ranks
 
-        dist.all_reduce(batch_loss, op=dist.ReduceOp.AVG)  # todo(sami): I am always confuse but here is my cot
-        # <think> in the one gpu scenerio we have M grad accums steps. In distributed they have N = M / W per gpu. So when we normaliez the loss by / N we are missing the W
-        # so we need do to an AVG instead of sum <think/> Answers: Need to use AVG instead of SUM
+        dist.all_reduce(batch_loss, op=dist.ReduceOp.AVG)
 
         if is_tt_moe_model(model):
-            dist.all_reduce(
-                batch_max_vio, op=dist.ReduceOp.AVG
-            )  # todo(sami): need to check with Jackmin if we should do a max or avg here
-            # <think> need to ask jackmin <tool/> Ask jackmin :
+            # TODO(sami): Check with Jackmin if we should do a max or avg here
+            dist.all_reduce(batch_max_vio, op=dist.ReduceOp.AVG)
 
         # Compute step metrics
         num_tokens = config.data.batch_size * config.data.seq_len

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -15,6 +15,8 @@ from prime_rl.trainer.logger import setup_logger
 from prime_rl.trainer.optim import setup_optimizer
 from prime_rl.trainer.scheduler import setup_scheduler
 from prime_rl.trainer.model import (
+    get_load_balance_stats,
+    is_tt_moe_model,
     setup_tokenizer,
     setup_model,
 )
@@ -148,6 +150,7 @@ def train(config: SFTTrainerConfig):
         )
 
         batch_loss = torch.tensor(0.0).to("cuda")
+        batch_max_vio = torch.tensor(0.0).to("cuda") if is_tt_moe_model(model) else None
         for micro_step in range(grad_accum_steps):
             micro_batch = next(dataiter)
             input_ids = micro_batch["input_ids"].to("cuda")
@@ -178,10 +181,11 @@ def train(config: SFTTrainerConfig):
                 )
 
                 # todo(sami): bring back tt model load balance stats
-                # if is_tt_moe_model(model):
-                #     load_balance_stats = get_load_balance_stats(model)
-                #     for k, v in load_balance_stats.items():
-                #         tensors[k].append(v)
+                if is_tt_moe_model(model):
+                    load_balance_stats = get_load_balance_stats(model)
+                    batch_max_vio += (
+                        load_balance_stats["max_vio"] / grad_accum_steps
+                    )  # todo(sami): need to check with Jackmin if we should do a max or avg here
 
                 # Scale loss by number of gradient accumulation steps
                 loss /= grad_accum_steps
@@ -222,6 +226,11 @@ def train(config: SFTTrainerConfig):
         # <think> in the one gpu scenerio we have M grad accums steps. In distributed they have N = M / W per gpu. So when we normaliez the loss by / N we are missing the W
         # so we need do to an AVG instead of sum <think/> Answers: Need to use AVG instead of SUM
 
+        dist.all_reduce(
+            batch_max_vio, op=dist.ReduceOp.AVG
+        )  # todo(sami): need to check with Jackmin if we should do a max or avg here
+        # <think> need to ask jackmin <tool/> Ask jackmin :
+
         # Compute step metrics
         num_tokens = config.data.batch_size * config.data.seq_len
         progress.total_tokens += num_tokens
@@ -235,8 +244,8 @@ def train(config: SFTTrainerConfig):
         step_time = time.time() - step_start_time
         current_lr = optimizer.param_groups[0]["lr"]
         step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {batch_loss.item()} | Grad. Norm: {grad_norm:.4f} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}%"
-        # if "max_vio/mean" in tensor_stats:
-        #     step_message += f" | Max Vio: {tensor_stats['max_vio/mean']:.4f}"
+        if is_tt_moe_model(model):
+            step_message += f" | Max Vio: {batch_max_vio.item():.4f}"
         logger.success(step_message)
 
         # Log progress metrics
@@ -280,6 +289,13 @@ def train(config: SFTTrainerConfig):
             "step": progress.step,
         }
         monitor.log(time_metrics)
+
+        if is_tt_moe_model(model):
+            max_vio_log_metrics = {
+                "max_vio/mean": batch_max_vio.item(),
+                "step": progress.step,
+            }
+            monitor.log(max_vio_log_metrics)
 
         is_first_step = False
         progress.step += 1

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -182,10 +182,9 @@ def train(config: SFTTrainerConfig):
 
                 # todo(sami): bring back tt model load balance stats
                 if is_tt_moe_model(model):
-                    load_balance_stats = get_load_balance_stats(model)
-                    batch_max_vio += (
-                        load_balance_stats["max_vio"] / grad_accum_steps
-                    )  # todo(sami): need to check with Jackmin if we should do a max or avg here
+                    max_vio = get_load_balance_stats(model)["max_vio"] / grad_accum_steps
+                    batch_max_vio += max_vio
+                    # todo(sami): need to check with Jackmin if we should do a max or avg here
 
                 # Scale loss by number of gradient accumulation steps
                 loss /= grad_accum_steps
@@ -199,9 +198,9 @@ def train(config: SFTTrainerConfig):
                 loss.backward()
 
             # Debug log with *local, micro step* stats
-            micro_step_message = f"Micro Step {micro_step} | Loss: {batch_loss.item()} | Dataloader Step: {dataloader.state_dict()['dataset_state']['step']}"
-            # if "max_vio" in tensors:
-            #     micro_step_message += f" | Max Vio: {tensors['max_vio'][-1].mean().item():.4f}"
+            micro_step_message = f"Micro Step {micro_step} | Loss: {loss.item()} | Dataloader Step: {dataloader.state_dict()['dataset_state']['step']}"
+            if is_tt_moe_model(model):
+                micro_step_message += f" | Max Vio: {batch_max_vio.item():.4f}"
             logger.debug(micro_step_message)
 
         # Optionally, clip the gradients
@@ -226,10 +225,11 @@ def train(config: SFTTrainerConfig):
         # <think> in the one gpu scenerio we have M grad accums steps. In distributed they have N = M / W per gpu. So when we normaliez the loss by / N we are missing the W
         # so we need do to an AVG instead of sum <think/> Answers: Need to use AVG instead of SUM
 
-        dist.all_reduce(
-            batch_max_vio, op=dist.ReduceOp.AVG
-        )  # todo(sami): need to check with Jackmin if we should do a max or avg here
-        # <think> need to ask jackmin <tool/> Ask jackmin :
+        if is_tt_moe_model(model):
+            dist.all_reduce(
+                batch_max_vio, op=dist.ReduceOp.AVG
+            )  # todo(sami): need to check with Jackmin if we should do a max or avg here
+            # <think> need to ask jackmin <tool/> Ask jackmin :
 
         # Compute step metrics
         num_tokens = config.data.batch_size * config.data.seq_len

--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -203,7 +203,7 @@ class Tensors(defaultdict):
         assert dist.is_initialized(), "Tensors requires a distributed environment"
         super().__init__(list)
 
-    def compute_stats(self) -> tuple[dict[str, list[float | int]], dict[str, float | int]]:
+    def compute_stats(self, log_distributions: bool) -> tuple[dict[str, list[float | int]], dict[str, float | int]]:
         """Synchronize the tensor statistic across all ranks for each key and compute relevant statistics."""
 
         metrics = {}
@@ -223,7 +223,8 @@ class Tensors(defaultdict):
             metrics[f"{key}/max"] = tensors.max().item()
 
             # Add back all-gathered tensors as list to distributions
-            distributions[key] = tensors.tolist()
+            if log_distributions:
+                distributions[key] = tensors.tolist()
 
         return distributions, metrics
 

--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -1,4 +1,3 @@
-import asyncio
 import pickle
 import time
 from collections import defaultdict
@@ -204,35 +203,16 @@ class Tensors(defaultdict):
         assert dist.is_initialized(), "Tensors requires a distributed environment"
         super().__init__(list)
 
-    async def compute_stats(
-        self, log_distributions: bool
-    ) -> tuple[dict[str, list[float | int]], dict[str, float | int]]:
+    def compute_stats(self, log_distributions: bool) -> tuple[dict[str, list[float | int]], dict[str, float | int]]:
         """Synchronize the tensor statistic across all ranks for each key and compute relevant statistics."""
-
-        # Create tasks for all the all-gather operations
-        loop = asyncio.get_event_loop()
-        gather_tasks = []
 
         metrics = {}
         distributions = {}
         for key in list(self.keys()):
-            # Prepare tensors for all-gather
+            # All-gather tensors across steps and ranks (get global distribution)
             tensors = torch.cat(self.pop(key), dim=0).to("cuda")
             assert tensors.ndim == 1, "Can only aggregate 1D tensors"
-
-            # Start all-gather operation asynchronously
-            async def gather_key(k: str, t: torch.Tensor) -> tuple[str, torch.Tensor]:
-                # Run the all-gather in a thread pool executor since it's a blocking operation
-                gathered = await loop.run_in_executor(None, flexible_all_gather, t)
-                return k, gathered
-
-            gather_tasks.append(gather_key(key, tensors))
-
-        # Wait for all all-gather operations to complete
-        gather_results = await asyncio.gather(*gather_tasks)
-
-        # Process the results
-        for key, tensors in gather_results:
+            tensors = flexible_all_gather(tensors)
             assert tensors.ndim == 1, "Can only aggregate 1D tensors"
 
             # Compute relevant tensor statistics

--- a/src/prime_rl/utils/config.py
+++ b/src/prime_rl/utils/config.py
@@ -88,4 +88,4 @@ class WandbMonitorConfig(BaseConfig):
         Field(
             description="Configuration for logging extras to W&B tables. If None, no extras are logged.",
         ),
-    ] = LogExtrasConfig()
+    ] = None

--- a/src/prime_rl/utils/utils.py
+++ b/src/prime_rl/utils/utils.py
@@ -1,4 +1,3 @@
-import asyncio
 import functools
 import os
 import time
@@ -89,27 +88,16 @@ def capitalize(s: str) -> str:
     return s[0].upper() + s[1:]
 
 
-def ensure_event_loop(func):
-    """
-    A decorator that ensures an event loop is created if one is not already running.
-    """
-
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-        return func(*args, **kwargs)
-
-    return wrapper
-
-
 def clean_exit(func):
     """
     A decorator that ensures the a torch.distributed process group is properly
     cleaned up after the decorated function runs or raises an exception.
+
+    Args:
+        func: The function to decorate
+
+    Returns:
+        The decorated function
     """
 
     @functools.wraps(func)

--- a/src/prime_rl/utils/utils.py
+++ b/src/prime_rl/utils/utils.py
@@ -1,3 +1,4 @@
+import asyncio
 import functools
 import os
 import time
@@ -88,16 +89,27 @@ def capitalize(s: str) -> str:
     return s[0].upper() + s[1:]
 
 
+def ensure_event_loop(func):
+    """
+    A decorator that ensures an event loop is created if one is not already running.
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
 def clean_exit(func):
     """
     A decorator that ensures the a torch.distributed process group is properly
     cleaned up after the decorated function runs or raises an exception.
-
-    Args:
-        func: The function to decorate
-
-    Returns:
-        The decorated function
     """
 
     @functools.wraps(func)


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

This PR is a change the API of the `Tensors` class. Previously, we would add back the accumulated distribution and then grab it as `tensors[key][-1]`. This is somewhat unelegant, so now `compute_stats` clears all accumulated tensors and returns the distributions as a flattened list alongside the point statistics

Also, we do not log distributions by default anymore if wandb is enabled.
