### PR TITLE
[fix] use max for max vio

### DIFF
--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -179,9 +179,9 @@ def train(config: SFTTrainerConfig):
                 loss = cross_entropy(logits.view(-1, V), target_ids.view(-1), reduction="none").view(B, L)
 
                 if is_tt_moe_model(model):
-                    max_vio = get_load_balance_stats(model)["max_vio"] / grad_accum_steps
+                    max_vio = get_load_balance_stats(model)["max_vio"]
                     dist.all_reduce(max_vio, op=dist.ReduceOp.MAX)
-                    batch_max_vio += max_vio
+                    batch_max_vio += max_vio / grad_accum_steps
 
                 loss = loss[loss_mask].mean()
 

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -221,8 +221,7 @@ def train(config: SFTTrainerConfig):
         dist.all_reduce(batch_loss, op=dist.ReduceOp.AVG)
 
         if is_tt_moe_model(model):
-            # TODO(sami): Check with Jackmin if we should do a max or avg here
-            dist.all_reduce(batch_max_vio, op=dist.ReduceOp.AVG)
+            dist.all_reduce(batch_max_vio, op=dist.ReduceOp.MAX)
 
         # Compute step metrics
         num_tokens = config.data.batch_size * config.data.seq_len

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -180,7 +180,6 @@ def train(config: SFTTrainerConfig):
 
                 if is_tt_moe_model(model):
                     max_vio = get_load_balance_stats(model)["max_vio"] / grad_accum_steps
-                    # TODO(sami): Check with Jackmin if we should do a max or avg here
                     batch_max_vio += max_vio
 
                 loss = loss[loss_mask].mean()


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

the idea with max vio is it measures distance from balanced. 0 means balanced. 0.5 means it has an expert with 50% more token than the balanced amount which theoretically makes u 50% slower.

across layers its thus avg. if i have a layer thats 100% slower and one that is 0%, i am 50% slower

across dp its max because all the dps wait for each other so thats the slowdown. if one is balanced and one is 20% slower, everyone is 20% slower

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: [Issue ID]
**Linear Issue**: Resolves [Issue ID]