### PR TITLE
Fix micro step logging

### DIFF
--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -187,7 +187,7 @@ def train(config: SFTTrainerConfig):
                 loss = loss[loss_mask].mean()
 
                 # Accumulate average loss over gradient accumulation steps
-                batch_loss += loss / grad_accum_steps
+                batch_loss += loss.detach() / grad_accum_steps
 
                 # Delete logits before backward pass to avoid memory spike
                 del logits

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -183,24 +183,22 @@ def train(config: SFTTrainerConfig):
                     dist.all_reduce(max_vio, op=dist.ReduceOp.MAX)
                     batch_max_vio += max_vio / grad_accum_steps
 
+                # Compute average loss over unmasked tokens
                 loss = loss[loss_mask].mean()
 
-                # Scale loss by number of gradient accumulation steps
-                loss /= grad_accum_steps
-
-                # Accumulate loss
-                batch_loss += loss
+                # Accumulate average loss over gradient accumulation steps
+                batch_loss += loss / grad_accum_steps
 
                 # Delete logits before backward pass to avoid memory spike
                 del logits
 
                 # Backward pass
-                loss.backward()
+                (loss / grad_accum_steps).backward()
 
             # Debug log with *local, micro step* stats
             micro_step_message = f"Micro Step {micro_step} | Loss: {loss.item()} | Dataloader Step: {dataloader.state_dict()['dataset_state']['step']}"
             if is_tt_moe_model(model):
-                micro_step_message += f" | Max Vio: {batch_max_vio.item():.4f}"
+                micro_step_message += f" | Max Vio: {max_vio.item():.4f}"
             logger.debug(micro_step_message)
 
         # Optionally, clip the gradients


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

```bash
uv run sft @ configs/debug/sft.toml --log.level debug
```

**Previous**

We reported the scaled micro step loss

<img width="1098" height="86" alt="Screenshot 2025-09-13 at 9 22 59 PM" src="https://github.com/user-attachments/assets/3118cbd6-2d8a-4bc0-b0dd-c93c083e93dd" />


**Now**

We report the unscaled micro step loss, which matches the batch loss scale

<img width="1095" height="93" alt="Screenshot 2025-09-13 at 9 24 41 PM" src="https://github.com/user-attachments/assets/e1467cfe-ef15-4cb4-8ae9-85d1d664d546" />

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: #908 
**Linear Issue**: Resolves PRIMERL-99