### PR TITLE
Update FSDP, AC, Compile ordering

### DIFF
--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -24,6 +24,15 @@ class ActivationCheckpointConfig(BaseModel):
     ] = 1
 
 
+class CompileConfig(BaseModel):
+    """Configures model compilation."""
+
+    fullgraph: Annotated[
+        bool,
+        Field(description="Whether to compile the transformer blocks with fullgraph."),
+    ] = False
+
+
 class ModelConfig(BaseConfig):
     """Configures the model for training."""
 
@@ -37,11 +46,11 @@ class ModelConfig(BaseConfig):
     attn: Annotated[AttnImplementation, Field(description="The attention implementation to use.")] = "flash_attention_2"
 
     compile: Annotated[
-        bool,
+        CompileConfig | None,
         Field(
             description="Whether to compile the model using `torch.compile`. Currently discouraged because it was found to destabilize training.",
         ),
-    ] = False
+    ] = None
 
     ac: Annotated[
         ActivationCheckpointConfig | None,

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -31,7 +31,6 @@ class CompileConfig(BaseModel):
         bool,
         Field(description="Whether to compile the transformer blocks with fullgraph."),
     ] = False
-    enable: Annotated[bool, Field(description="Whether to enable model compilation.")] = True
 
 
 class ModelConfig(BaseConfig):

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -31,6 +31,7 @@ class CompileConfig(BaseModel):
         bool,
         Field(description="Whether to compile the transformer blocks with fullgraph."),
     ] = False
+    enable: Annotated[bool, Field(description="Whether to enable model compilation.")] = True
 
 
 class ModelConfig(BaseConfig):

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -12,7 +12,7 @@ from torch.distributed.fsdp import FSDPModule, MixedPrecisionPolicy, fully_shard
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 from transformers.tokenization_utils import PreTrainedTokenizer
 
-from prime_rl.trainer.config import ActivationCheckpointConfig, ModelConfig
+from prime_rl.trainer.config import ActivationCheckpointConfig, CompileConfig, ModelConfig
 from prime_rl.trainer.parallel_dims import ParallelDims
 from prime_rl.utils.logger import get_logger
 
@@ -127,6 +127,11 @@ def apply_ac(model: nn.Module, ac_config: ActivationCheckpointConfig):
         model.model.layers.register_module(layer_name, transformer_block)
 
 
+def apply_compile(model: nn.Module, compile_config: CompileConfig):
+    for layer_id, transformer_block in enumerate(model.model.layers):
+        model.model.layers[layer_id] = torch.compile(transformer_block, fullgraph=compile_config.fullgraph)
+
+
 def setup_model(config: ModelConfig, parallel_dims: ParallelDims) -> nn.Module:
     device = torch.device("cpu")
     model = get_model(config, device=device)
@@ -134,9 +139,8 @@ def setup_model(config: ModelConfig, parallel_dims: ParallelDims) -> nn.Module:
     # the right order is AC -> Compile -> FSDP
     if config.ac is not None:
         apply_ac(model, config.ac)
-    if config.compile.enable:
-        for i, transformer_block in enumerate(model.model.layers):
-            model.model.layers[i] = torch.compile(transformer_block, fullgraph=config.compile.fullgraph)
+    if config.compile is not None:
+        apply_compile(model, config.compile)
 
     setup_fsdp(model, config, parallel_dims)
 

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -76,17 +76,27 @@ def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDim
     mp_policy = MixedPrecisionPolicy(param_dtype=torch.bfloat16, reduce_dtype=torch.float32)
     # TODO: Support dp_replicate
     hsdp_mesh = parallel_dims.world_mesh["dp_shard_cp"]
-    for layer_id, transformer_block in enumerate(model.model.layers):
-        if config.reshard_after_forward:
-            layer_reshard_after_forward = layer_id < len(model.model.layers) - 1
-        else:
-            layer_reshard_after_forward = False
+
+    fully_shard(
+        model.model.embed_tokens,
+        mesh=hsdp_mesh,
+        mp_policy=mp_policy,
+        reshard_after_forward=config.reshard_after_forward,
+    )
+
+    for transformer_block in model.model.layers:
         fully_shard(
             transformer_block,
             mesh=hsdp_mesh,
             mp_policy=mp_policy,
-            reshard_after_forward=layer_reshard_after_forward,
+            reshard_after_forward=config.reshard_after_forward,
         )
+    fully_shard(
+        [model.lm_head, model.model.norm],
+        mesh=hsdp_mesh,
+        mp_policy=mp_policy,
+        reshard_after_forward=config.reshard_after_forward,
+    )
 
     fully_shard(model, mesh=hsdp_mesh, mp_policy=mp_policy, reshard_after_forward=config.reshard_after_forward)
 
@@ -118,16 +128,23 @@ def apply_ac(model: nn.Module, ac_config: ActivationCheckpointConfig):
 
 
 def setup_model(config: ModelConfig, parallel_dims: ParallelDims) -> nn.Module:
-    model = get_model(config, device=torch.device("cpu"))
-    setup_fsdp(model, config, parallel_dims)
-    # TODO: This is used if the model is loaded with meta device to save cpu memory
-    # However, the loading seems to be wrong as the loss and reward curves are different
-    # load_dcp_from_hf(model, config)
+    device = torch.device("cpu")
+    model = get_model(config, device=device)
+
+    # the right order is AC -> Compile -> FSDP
     if config.ac is not None:
         apply_ac(model, config.ac)
     if config.compile:
         model = torch.compile(model)
-    # TODO: This should be type-hinted as FSDP version of the model
+
+    setup_fsdp(model, config, parallel_dims)
+
+    # if device == torch.device("meta"):
+    # TODO: This is used if the model is loaded with meta device to save cpu memory
+    # However, the loading seems to be wrong as the loss and reward curves are different
+    # load_dcp_from_hf(model, config)
+    #     load_dcp_from_hf(model, config)
+
     return model
 
 

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -134,8 +134,9 @@ def setup_model(config: ModelConfig, parallel_dims: ParallelDims) -> nn.Module:
     # the right order is AC -> Compile -> FSDP
     if config.ac is not None:
         apply_ac(model, config.ac)
-    if config.compile:
-        model = torch.compile(model)
+    if config.compile is not None:
+        for i, transformer_block in enumerate(model.model.layers):
+            model.model.layers[i] = torch.compile(transformer_block, fullgraph=config.compile.fullgraph)
 
     setup_fsdp(model, config, parallel_dims)
 

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -134,7 +134,7 @@ def setup_model(config: ModelConfig, parallel_dims: ParallelDims) -> nn.Module:
     # the right order is AC -> Compile -> FSDP
     if config.ac is not None:
         apply_ac(model, config.ac)
-    if config.compile is not None:
+    if config.compile.enable:
         for i, transformer_block in enumerate(model.model.layers):
             model.model.layers[i] = torch.compile(transformer_block, fullgraph=config.compile.fullgraph)
 

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -125,11 +125,13 @@ def apply_ac(model: nn.Module, ac_config: ActivationCheckpointConfig):
         if layer_id % ac_config.freq == 0:
             transformer_block = checkpoint_wrapper(transformer_block, preserve_rng_state=False)
         model.model.layers.register_module(layer_name, transformer_block)
+    get_logger().info(f"Applied activation checkpointing (freq={ac_config.freq})")
 
 
 def apply_compile(model: nn.Module, compile_config: CompileConfig):
     for layer_id, transformer_block in enumerate(model.model.layers):
         model.model.layers[layer_id] = torch.compile(transformer_block, fullgraph=compile_config.fullgraph)
+    get_logger().info(f"Compiled {len(model.model.layers)} layers (fullgraph={compile_config.fullgraph})")
 
 
 def setup_model(config: ModelConfig, parallel_dims: ParallelDims) -> nn.Module:

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -16,6 +16,8 @@ from prime_rl.trainer.optim import setup_optimizer
 from prime_rl.trainer.scheduler import setup_scheduler
 from prime_rl.trainer.model import (
     forward,
+    get_load_balance_stats,
+    is_tt_moe_model,
     setup_tokenizer,
     setup_model,
 )
@@ -149,6 +151,7 @@ def train(config: SFTTrainerConfig):
         )
 
         batch_loss = torch.tensor(0.0).to("cuda")
+        batch_max_vio = torch.tensor(0.0).to("cuda")
         for micro_step in range(grad_accum_steps):
             micro_batch = next(dataiter)
             input_ids = micro_batch["input_ids"].to("cuda")
@@ -175,6 +178,11 @@ def train(config: SFTTrainerConfig):
                 # Compute loss
                 loss = cross_entropy(logits.view(-1, V), target_ids.view(-1), reduction="none").view(B, L)
 
+                if is_tt_moe_model(model):
+                    max_vio = get_load_balance_stats(model)["max_vio"].mean()
+                    dist.all_reduce(max_vio, op=dist.ReduceOp.MAX)
+                    batch_max_vio += max_vio / grad_accum_steps
+
                 # Compute average loss over unmasked tokens
                 loss = loss[loss_mask].mean()
 
@@ -189,6 +197,8 @@ def train(config: SFTTrainerConfig):
 
             # Debug log with *local, micro step* stats
             micro_step_message = f"Micro Step {micro_step} | Loss: {loss.item()} | Dataloader Step: {dataloader.state_dict()['dataset_state']['step']}"
+            if is_tt_moe_model(model):
+                micro_step_message += f" | Max Vio: {max_vio.item():.4f}"
             logger.debug(micro_step_message)
 
         # Optionally, clip the gradients
@@ -223,6 +233,8 @@ def train(config: SFTTrainerConfig):
         step_time = time.time() - step_start_time
         current_lr = optimizer.param_groups[0]["lr"]
         step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {batch_loss.item()} | Grad. Norm: {grad_norm:.4f} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}%"
+        if is_tt_moe_model(model):
+            step_message += f" | Max Vio: {batch_max_vio.item():.4f}"
         logger.success(step_message)
 
         # Log progress metrics
@@ -266,6 +278,13 @@ def train(config: SFTTrainerConfig):
             "step": progress.step,
         }
         monitor.log(time_metrics)
+
+        if is_tt_moe_model(model):
+            max_vio_log_metrics = {
+                "max_vio/mean": batch_max_vio.item(),
+                "step": progress.step,
+            }
+            monitor.log(max_vio_log_metrics)
 
         is_first_step = False
         progress.step += 1

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -16,8 +16,6 @@ from prime_rl.trainer.optim import setup_optimizer
 from prime_rl.trainer.scheduler import setup_scheduler
 from prime_rl.trainer.model import (
     forward,
-    get_load_balance_stats,
-    is_tt_moe_model,
     setup_tokenizer,
     setup_model,
 )
@@ -151,7 +149,6 @@ def train(config: SFTTrainerConfig):
         )
 
         batch_loss = torch.tensor(0.0).to("cuda")
-        batch_max_vio = torch.tensor(0.0).to("cuda")
         for micro_step in range(grad_accum_steps):
             micro_batch = next(dataiter)
             input_ids = micro_batch["input_ids"].to("cuda")
@@ -178,11 +175,6 @@ def train(config: SFTTrainerConfig):
                 # Compute loss
                 loss = cross_entropy(logits.view(-1, V), target_ids.view(-1), reduction="none").view(B, L)
 
-                if is_tt_moe_model(model):
-                    max_vio = get_load_balance_stats(model)["max_vio"].mean()
-                    dist.all_reduce(max_vio, op=dist.ReduceOp.MAX)
-                    batch_max_vio += max_vio / grad_accum_steps
-
                 # Compute average loss over unmasked tokens
                 loss = loss[loss_mask].mean()
 
@@ -197,8 +189,6 @@ def train(config: SFTTrainerConfig):
 
             # Debug log with *local, micro step* stats
             micro_step_message = f"Micro Step {micro_step} | Loss: {loss.item()} | Dataloader Step: {dataloader.state_dict()['dataset_state']['step']}"
-            if is_tt_moe_model(model):
-                micro_step_message += f" | Max Vio: {max_vio.item():.4f}"
             logger.debug(micro_step_message)
 
         # Optionally, clip the gradients
@@ -233,8 +223,6 @@ def train(config: SFTTrainerConfig):
         step_time = time.time() - step_start_time
         current_lr = optimizer.param_groups[0]["lr"]
         step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {batch_loss.item()} | Grad. Norm: {grad_norm:.4f} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}%"
-        if is_tt_moe_model(model):
-            step_message += f" | Max Vio: {batch_max_vio.item():.4f}"
         logger.success(step_message)
 
         # Log progress metrics
@@ -278,13 +266,6 @@ def train(config: SFTTrainerConfig):
             "step": progress.step,
         }
         monitor.log(time_metrics)
-
-        if is_tt_moe_model(model):
-            max_vio_log_metrics = {
-                "max_vio/mean": batch_max_vio.item(),
-                "step": progress.step,
-            }
-            monitor.log(max_vio_log_metrics)
 
         is_first_step = False
         progress.step += 1


### PR DESCRIPTION
couple of thing that I noticed are different between us and torchtitan:

* they do torch compile with full graph on each transformer block https://github.com/pytorch/torchtitan/blob/40a87254ff15dbabebcfe8f70828a872cc6fa009/torchtitan/models/llama3/infra/parallelize.py#L243

* they do ac - > compile -> fsdp  wheras we do ac-> fsdp -> compile which could create graph break https://github.com/pytorch/torchtitan/blob/40a87254ff15dbabebcfe8f70828a872cc6fa009/torchtitan/models/llama3/infra/parallelize.py#L106

* They shard explicitly the lm head and embedding, we don't, potentially meaning we don't shard this layers ? https://github.com/pytorch/torchtitan/blob/40a87254ff15dbabebcfe8f70828a872cc6fa009/torchtitan/models/llama3/infra/parallelize.py#L308

* They don't to the "do not reshard after forward for the last layer" trick, which they used to do (bc we stole it from there) My guess is that it breaks full graph for torchtitan https://github.com/pytorch/torchtitan/blob/40a87254ff15dbabebcfe8f70828a872cc6fa009/torchtitan/models/llama3/infra/parallelize.py#L301



```bash
┏━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┓
┃    Step ┃         MFU          ┃      Throughput      ┃      Step Time       ┃
┡━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━┩
│       1 │        39.50%        │        63.74K        │        2.05s         │
│       2 │        39.39%        │        63.56K        │        2.05s         │
│       3 │        39.32%        │        63.45K        │        2.05s         │
│         │                      │                      │                      │
│ Overall │    39.40% ± 0.09%    │   63.58K ± 147.78    │    2.05s ± 0.00s     │
│         │   [39.32%, 39.50%]   │   [63.45K, 63.74K]   │    [2.05s, 2.05s]    │
└─────────┴──────────────────────┴──────────────────────┴──────────────────────┘
```

branch sami/update_fsdp_orderring

```bash
┏━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┓
┃    Step ┃         MFU          ┃      Throughput      ┃      Step Time       ┃
┡━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━┩
│       1 │        27.29%        │        44.03K        │        2.97s         │
│       2 │        27.32%        │        44.08K        │        2.96s         │
│       3 │        27.32%        │        44.08K        │        2.97s         │
│         │                      │                      │                      │
│ Overall │    27.31% ± 0.02%    │    44.07K ± 27.75    │    2.96s ± 0.00s     │
│         │   [27.29%, 27.32%]   │   [44.03K, 44.08K]   │    [2.96s, 2.97s]    │
└─────────┴──────────────────────┴──────────────────────┴──────────────────────┘
```


reproduce with 

```
srun bash -c '
    source /data/.env
    cd /data/prime-rl
    
    uv run torchrun \
    --nnodes=1 \
    --nproc_per_node=8 \
    --node-rank $SLURM_PROCID \
    src/prime_rl/trainer/sft/train.py \
    --model.name Qwen/Qwen3-8B\
    --model.attn sdpa \
    --model.ac \
    --model.compile \
    --data.type fake \
    --data.seq-len 2048 \
    --data.batch-size 64 \
    --data.micro-batch-size 8 \
    --data.pack-function stack \
    --log.level debug \
    --bench 2>&1 | tee /data/prime-rl/outputs/logs/latest_rank${SLURM_PROCID}.log /data/prime-rl/outputs/logs/torchrun_${SLURM_JOB_ID}_rank${SLURM_PROCID}.log'
    
  ```