### PR TITLE
Include peak memory in step logs and benchmark table

### DIFF
--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -358,6 +358,7 @@ def train(config: RLTrainerConfig):
             "perf/throughput": throughput,
             "perf/throughput_per_gpu": throughput / world.world_size,
             "perf/mfu": mfu,
+            "perf/peak_memory": peak_memory,
             "step": progress.step,
         }
         monitor.log(perf_metrics)

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -135,6 +135,9 @@ def train(config: RLTrainerConfig):
     logger.info(f"Starting training loop ({config.max_steps=})")
     is_first_step = True
     while True:
+        # Reset peak memory stats
+        torch.cuda.reset_peak_memory_stats()
+
         # Save the weight checkpoint (if we are not at the first step, because no updates to the model have been made yet)
         save_weights_time = 0
         if progress.step > 0:
@@ -340,11 +343,12 @@ def train(config: RLTrainerConfig):
         perf_counter.count_tokens(num_tokens)
         throughput = perf_counter.get_tokens_per_second() or 0
         mfu = perf_counter.get_mfu() or 0
+        peak_memory = torch.cuda.max_memory_allocated() / 1e9 # GB
 
         # Log step metrics
         step_time = time.time() - step_start_time
         current_lr = optimizer.param_groups[0]["lr"]
-        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {tensor_stats['loss/mean']:.4f} | Entropy: {tensor_stats['entropy/mean']:.4f} | Importance Ratio: {tensor_stats['importance_ratio/mean']:.4f} | Grad. Norm: {grad_norm:.4f} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}%"
+        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {tensor_stats['loss/mean']:.4f} | Entropy: {tensor_stats['entropy/mean']:.4f} | Importance Ratio: {tensor_stats['importance_ratio/mean']:.4f} | Grad. Norm: {grad_norm:.4f} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}% | Peak Memory: {peak_memory:.1f}/ GB"
         if "max_vio/mean" in tensor_stats:
             step_message += f" | Max Vio: {tensor_stats['max_vio/mean']:.4f}"
         logger.success(step_message)
@@ -404,7 +408,7 @@ def train(config: RLTrainerConfig):
         ckpt_manager.save(model, [optimizer], scheduler, progress, step=progress.step)
         ckpt_manager.maybe_clean()
 
-    logger.info(f"Peak memory: {torch.cuda.max_memory_allocated() / 1024**3:.2f} GB")
+    logger.info(f"Peak memory: {max(to_col_format(monitor.history)['perf/peak_memory']):.1f} GB")
     logger.success("RL trainer finished!")
 
     # Optionally, print benchmark table

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -348,7 +348,7 @@ def train(config: RLTrainerConfig):
         # Log step metrics
         step_time = time.time() - step_start_time
         current_lr = optimizer.param_groups[0]["lr"]
-        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {tensor_stats['loss/mean']:.4f} | Entropy: {tensor_stats['entropy/mean']:.4f} | Importance Ratio: {tensor_stats['importance_ratio/mean']:.4f} | Grad. Norm: {grad_norm:.4f} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}% | Peak Memory: {peak_memory:.1f}/ GB"
+        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {tensor_stats['loss/mean']:.4f} | Entropy: {tensor_stats['entropy/mean']:.4f} | Importance Ratio: {tensor_stats['importance_ratio/mean']:.4f} | Grad. Norm: {grad_norm:.4f} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}% | Peak Mem.: {peak_memory:.1f} GB"
         if "max_vio/mean" in tensor_stats:
             step_message += f" | Max Vio: {tensor_stats['max_vio/mean']:.4f}"
         logger.success(step_message)

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -236,7 +236,7 @@ def train(config: SFTTrainerConfig):
         # Log step metrics
         step_time = time.time() - step_start_time
         current_lr = optimizer.param_groups[0]["lr"]
-        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {batch_loss.item()} | Grad. Norm: {grad_norm:.4f} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}% | Peak Memory: {peak_memory:.1f}/ GB"
+        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {batch_loss.item()} | Grad. Norm: {grad_norm:.4f} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}% | Peak Mem.: {peak_memory:.1f} GB"
         if is_tt_moe_model(model):
             step_message += f" | Max Vio: {batch_max_vio.item():.4f}"
         logger.success(step_message)

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -199,7 +199,7 @@ def train(config: SFTTrainerConfig):
                 (loss / grad_accum_steps).backward()
 
             # Debug log with *local, micro step* stats
-            micro_step_message = f"Micro Step {micro_step} | Loss: {loss.item()} | Dataloader Step: {dataloader.state_dict()['dataset_state']['step']}"
+            micro_step_message = f"Micro Step {micro_step} | Loss: {loss.item():.4f} | Dataloader Step: {dataloader.state_dict()['dataset_state']['step']}"
             if is_tt_moe_model(model):
                 micro_step_message += f" | Max Vio: {max_vio.item():.4f}"
             logger.debug(micro_step_message)
@@ -236,7 +236,7 @@ def train(config: SFTTrainerConfig):
         # Log step metrics
         step_time = time.time() - step_start_time
         current_lr = optimizer.param_groups[0]["lr"]
-        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {batch_loss.item()} | Grad. Norm: {grad_norm:.4f} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}% | Peak Mem.: {peak_memory:.1f} GB"
+        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {batch_loss.item():.4f} | Grad. Norm: {grad_norm:.4f} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}% | Peak Mem.: {peak_memory:.1f} GB"
         if is_tt_moe_model(model):
             step_message += f" | Max Vio: {batch_max_vio.item():.4f}"
         logger.success(step_message)

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -112,6 +112,9 @@ def train(config: SFTTrainerConfig):
     logger.info(f"Starting training loop ({config.max_steps=})")
     is_first_step = True
     while True:
+        # Reset peak memory stats
+        torch.cuda.reset_peak_memory_stats()
+
         # Save the full checkpoint (if we are at an interval step and not at the first or last step)
         is_last_step = config.max_steps is not None and progress.step == config.max_steps
         save_ckpt_time = 0
@@ -228,11 +231,12 @@ def train(config: SFTTrainerConfig):
         perf_counter.count_tokens(num_tokens)
         throughput = perf_counter.get_tokens_per_second() or 0
         mfu = perf_counter.get_mfu() or 0
+        peak_memory = torch.cuda.max_memory_allocated() / 1e9 # GB
 
         # Log step metrics
         step_time = time.time() - step_start_time
         current_lr = optimizer.param_groups[0]["lr"]
-        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {batch_loss.item()} | Grad. Norm: {grad_norm:.4f} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}%"
+        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {batch_loss.item()} | Grad. Norm: {grad_norm:.4f} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}% | Peak Memory: {peak_memory:.1f}/ GB"
         if is_tt_moe_model(model):
             step_message += f" | Max Vio: {batch_max_vio.item():.4f}"
         logger.success(step_message)
@@ -250,6 +254,7 @@ def train(config: SFTTrainerConfig):
         perf_metrics = {
             "perf/throughput": throughput,
             "perf/throughput_per_gpu": throughput / world.world_size,
+            "perf/peak_memory": peak_memory,
             "perf/mfu": mfu,
             "step": progress.step,
         }
@@ -299,7 +304,7 @@ def train(config: SFTTrainerConfig):
         weight_ckpt_manager.save(model, tokenizer, step=progress.step)
         ckpt_manager.maybe_clean()
 
-    logger.info(f"Peak memory: {torch.cuda.max_memory_allocated() / 1024**3:.2f} GB")
+    logger.info(f"Peak memory: {max(to_col_format(monitor.history)['perf/peak_memory']):.1f} GB")
     logger.success("SFT trainer finished!")
 
     # Optionally, print benchmark table

--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -123,8 +123,8 @@ def print_benchmark(history: dict[str, list[Any]]) -> None:
     columns = {
         "perf/mfu": "MFU",
         "perf/throughput": "Throughput",
-        "perf/peak_memory": "Peak Memory",
         "time/step": "Step Time",
+        "perf/peak_memory": "Peak Memory",
     }
     df = df[columns.keys()].rename(columns=columns)
     df = df.iloc[1:]  # Exclude first row
@@ -142,8 +142,8 @@ def print_benchmark(history: dict[str, list[Any]]) -> None:
     formatted_df = pd.DataFrame(columns=df.columns)
     formatted_df["MFU"] = df["MFU"].apply(lambda x: f"{format_num(x, precision=2)}%")
     formatted_df["Throughput"] = df["Throughput"].apply(lambda x: format_num(x, precision=2))
-    formatted_df["Peak Memory"] = df["Peak Memory"].apply(lambda x: f"{format_num(x, precision=1)} GB")
     formatted_df["Step Time"] = df["Step Time"].apply(format_time)
+    formatted_df["Peak Memory"] = df["Peak Memory"].apply(lambda x: f"{format_num(x, precision=1)} GiB")
     for step, row in formatted_df.iterrows():
         table.add_row(*([str(step)] + [str(x) for x in row]))
 
@@ -152,14 +152,13 @@ def print_benchmark(history: dict[str, list[Any]]) -> None:
 
     # Add row for formatted, aggregated statistics
     mean_df = df.describe().loc[["mean", "std", "min", "max"], :]
-    formatted_mean_df = pd.DataFrame(columns=mean_df.columns)
+    formatted_mean_df = pd.DataFrame()
     formatted_mean_df["MFU"] = mean_df["MFU"].apply(lambda x: f"{format_num(x, precision=2)}%")
     formatted_mean_df["Throughput"] = mean_df["Throughput"].apply(format_num, precision=2)
-    formatted_mean_df["Peak Memory"] = mean_df["Peak Memory"].apply(lambda x: f"{format_num(x, precision=1)} GB")
     formatted_mean_df["Step Time"] = mean_df["Step Time"].apply(format_time)
     mean_row = ["Overall"] + formatted_mean_df.T.apply(
         lambda row: f"{row['mean']} ± {row['std']} [{row['min']}, {row['max']}]", axis=1
-    ).tolist()
+    ).tolist() + [f"{format_num(mean_df['Peak Memory']["mean"], precision=1)} GiB ({mean_df['Peak Memory']["mean"]/(torch.cuda.mem_get_info()[1]/1024**3)*100:.1f}%)"]
     table.add_row(*mean_row)
 
     # Display table

--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -123,6 +123,7 @@ def print_benchmark(history: dict[str, list[Any]]) -> None:
     columns = {
         "perf/mfu": "MFU",
         "perf/throughput": "Throughput",
+        "perf/peak_memory": "Peak Memory",
         "time/step": "Step Time",
     }
     df = df[columns.keys()].rename(columns=columns)
@@ -141,6 +142,7 @@ def print_benchmark(history: dict[str, list[Any]]) -> None:
     formatted_df = pd.DataFrame(columns=df.columns)
     formatted_df["MFU"] = df["MFU"].apply(lambda x: f"{format_num(x, precision=2)}%")
     formatted_df["Throughput"] = df["Throughput"].apply(lambda x: format_num(x, precision=2))
+    formatted_df["Peak Memory"] = df["Peak Memory"].apply(lambda x: f"{format_num(x, precision=2)} GB")
     formatted_df["Step Time"] = df["Step Time"].apply(format_time)
     for step, row in formatted_df.iterrows():
         table.add_row(*([str(step)] + [str(x) for x in row]))
@@ -153,6 +155,7 @@ def print_benchmark(history: dict[str, list[Any]]) -> None:
     formatted_mean_df = pd.DataFrame(columns=mean_df.columns)
     formatted_mean_df["MFU"] = mean_df["MFU"].apply(lambda x: f"{format_num(x, precision=2)}%")
     formatted_mean_df["Throughput"] = mean_df["Throughput"].apply(format_num, precision=2)
+    formatted_mean_df["Peak Memory"] = mean_df["Peak Memory"].apply(lambda x: f"{format_num(x, precision=2)} GB")
     formatted_mean_df["Step Time"] = mean_df["Step Time"].apply(format_time)
     mean_row = ["Overall"] + formatted_mean_df.T.apply(
         lambda row: f"{row['mean']} ± {row['std']} [{row['min']}, {row['max']}]", axis=1

--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -142,7 +142,7 @@ def print_benchmark(history: dict[str, list[Any]]) -> None:
     formatted_df = pd.DataFrame(columns=df.columns)
     formatted_df["MFU"] = df["MFU"].apply(lambda x: f"{format_num(x, precision=2)}%")
     formatted_df["Throughput"] = df["Throughput"].apply(lambda x: format_num(x, precision=2))
-    formatted_df["Peak Memory"] = df["Peak Memory"].apply(lambda x: f"{format_num(x, precision=2)} GB")
+    formatted_df["Peak Memory"] = df["Peak Memory"].apply(lambda x: f"{format_num(x, precision=1)} GB")
     formatted_df["Step Time"] = df["Step Time"].apply(format_time)
     for step, row in formatted_df.iterrows():
         table.add_row(*([str(step)] + [str(x) for x in row]))
@@ -155,7 +155,7 @@ def print_benchmark(history: dict[str, list[Any]]) -> None:
     formatted_mean_df = pd.DataFrame(columns=mean_df.columns)
     formatted_mean_df["MFU"] = mean_df["MFU"].apply(lambda x: f"{format_num(x, precision=2)}%")
     formatted_mean_df["Throughput"] = mean_df["Throughput"].apply(format_num, precision=2)
-    formatted_mean_df["Peak Memory"] = mean_df["Peak Memory"].apply(lambda x: f"{format_num(x, precision=2)} GB")
+    formatted_mean_df["Peak Memory"] = mean_df["Peak Memory"].apply(lambda x: f"{format_num(x, precision=1)} GB")
     formatted_mean_df["Step Time"] = mean_df["Step Time"].apply(format_time)
     mean_row = ["Overall"] + formatted_mean_df.T.apply(
         lambda row: f"{row['mean']} ± {row['std']} [{row['min']}, {row['max']}]", axis=1


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

This PR tracks the per-step peak memory (in GiB, like `nvtop`) using the W&B monitor (similar to other performance metrics) which allows us to easily report it in the step console logs and benchmark results. 

```bash
uv run sft @ configs/debug/sft.toml --bench
```

**Previous**

<img width="930" height="228" alt="Screenshot 2025-09-16 at 1 36 23 PM" src="https://github.com/user-attachments/assets/094c4d2b-0924-418e-87da-6a3ed372428d" />

**Now**

<img width="1158" height="238" alt="Screenshot 2025-09-16 at 4 31 27 PM" src="https://github.com/user-attachments/assets/91de85a3-921d-4f03-8ac6-e4e55b3781a7" />


---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: #924
**Linear Issue**: Resolves PRIMERL-104