### PR TITLE
Fix deletion of older checkpoints

### DIFF
--- a/src/prime_rl/orchestrator/ckpt.py
+++ b/src/prime_rl/orchestrator/ckpt.py
@@ -1,8 +1,8 @@
+import shutil
 import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
-import shutil
 import torch
 
 from prime_rl.orchestrator.buffer import Buffer


### PR DESCRIPTION
Fixed issue 933.

Removing older checkpoint caused failure due to attempting to delete a directory rather than a file. Modified code so that deletion can happen with no issue even when kept_path is a directory.


---

**GitHub Issue**: #933 