### PR TITLE
[Fix] meta loading with compile

### DIFF
--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -126,6 +126,13 @@ class ModelConfig(BaseConfig):
             self.name = MOE_MODEL_MAPS[self.name]
         return self
 
+    @model_validator(mode="after")
+    def compile_doesnt_work_with_meta_loading(self):
+        # TODO: Remove this once this is fixed
+        if self.compile:
+            self.load_using_meta = False
+        return self
+
 
 class ConstantSchedulerConfig(BaseModel):
     """Configuration for constant learning rate scheduler."""

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -126,13 +126,6 @@ class ModelConfig(BaseConfig):
             self.name = MOE_MODEL_MAPS[self.name]
         return self
 
-    @model_validator(mode="after")
-    def compile_doesnt_work_with_meta_loading(self):
-        # TODO: Remove this once this is fixed
-        if self.compile:
-            self.load_using_meta = False
-        return self
-
 
 class ConstantSchedulerConfig(BaseModel):
     """Configuration for constant learning rate scheduler."""

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -183,7 +183,7 @@ def apply_ac(model: nn.Module, ac_config: ActivationCheckpointConfig):
 
 def apply_compile(model: nn.Module, compile_config: CompileConfig):
     for layer_id in range(len(model.model.layers)):
-        # Doing it inplace avoids mangled fqn which can break ckpt loading
+        # Doing it in-place avoids mangled fqn which can break checkpoint loading
         model.model.layers[layer_id].compile(fullgraph=compile_config.fullgraph)
     get_logger().info(f"Compiled {len(model.model.layers)} layers (fullgraph={compile_config.fullgraph})")
 

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -182,8 +182,9 @@ def apply_ac(model: nn.Module, ac_config: ActivationCheckpointConfig):
 
 
 def apply_compile(model: nn.Module, compile_config: CompileConfig):
-    for layer_id, transformer_block in enumerate(model.model.layers):
-        model.model.layers[layer_id] = torch.compile(transformer_block, fullgraph=compile_config.fullgraph)
+    for layer_id in range(len(model.model.layers)):
+        # Doing it inplace avoids mangled fqn which can break ckpt loading
+        model.model.layers[layer_id].compile(fullgraph=compile_config.fullgraph)
     get_logger().info(f"Compiled {len(model.model.layers)} layers (fullgraph={compile_config.fullgraph})")
 
 


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

If we do `model.layers[i] = torch.compile`, we get a module with `_orig_mod` in the fqn. This breaks the dcp loading logic.
However, if we do `model.layers[i].compile` we compile the fwd call inplace and the dcp loading logic is happy.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: https://github.com/PrimeIntellect-ai/prime-rl/issues/951
**Linear Issue**: Resolves [Issue ID]