### PR TITLE
[Fix] test in container

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,7 +64,7 @@ def hf_api() -> HfApi:
 
 @pytest.fixture(scope="module")
 def username() -> str:
-    return os.environ.get("USERNAME_CI", os.getlogin())
+    return os.environ.get("USERNAME_CI", os.environ.get("USER", "none"))
 
 
 @pytest.fixture(scope="module")

--- a/uv.lock
+++ b/uv.lock
@@ -159,12 +159,9 @@ wheels = [
 
 [[package]]
 name = "antlr4-python3-runtime"
-version = "4.13.2"
+version = "4.9.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/33/5f/2cdf6f7aca3b20d3f316e9f505292e1f256a32089bd702034c29ebde6242/antlr4_python3_runtime-4.13.2.tar.gz", hash = "sha256:909b647e1d2fc2b70180ac586df3933e38919c85f98ccc656a96cd3f25ef3916", size = 117467, upload-time = "2024-08-03T19:00:12.757Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/03/a851e84fcbb85214dc637b6378121ef9a0dd61b4c65264675d8a5c9b1ae7/antlr4_python3_runtime-4.13.2-py3-none-any.whl", hash = "sha256:fe3835eb8d33daece0e799090eda89719dbccee7aa39ef94eed3818cafa5a7e8", size = 144462, upload-time = "2024-08-03T19:00:11.134Z" },
-]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/38/7859ff46355f76f8d19459005ca000b6e7012f2f1ca597746cbcd1fbfe5e/antlr4-python3-runtime-4.9.3.tar.gz", hash = "sha256:f224469b4168294902bb1efa80a8bf7855f24c99aef99cbefc1bcd3cce77881b", size = 117034, upload-time = "2021-11-06T17:52:23.524Z" }
 
 [[package]]
 name = "anyio"


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->


Using os.getlogin() doesnt work in containers and we get some omegaconf dep issue with antlr4. Not rlly sure what its about honestly but rolling back to 4.9 seems to fix it. Wouldnt add it to dep since i seems how it ended up in the lock is somewhat arbitrary.

Ok turns out this is used by latex2sympy so its a dep of one of the envs I guess.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: [Issue ID]
**Linear Issue**: Resolves [Issue ID]