### PR TITLE
Allow arbitrary seq len in `StackDataset`

### DIFF
--- a/src/prime_rl/trainer/sft/config.py
+++ b/src/prime_rl/trainer/sft/config.py
@@ -145,6 +145,13 @@ class SFTTrainerConfig(BaseSettings):
         return self
 
     @model_validator(mode="after")
+    def validate_seq_len(self):
+        if self.data.pack_function == "stack":
+            if self.data.seq_len % 256 != 0:
+                raise ValueError("The sequence length must be divisible by 256 when using pack function stack")
+        return self
+
+    @model_validator(mode="after")
     def dont_do_massive_traces(self):
         if self.trace_path:
             if self.max_steps is None:

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -113,6 +113,7 @@ class SFTDataset(StatefulIterableDataset):
 
     def __init__(self, dataset: Dataset, tokenizer: PreTrainedTokenizer, config: SFTDataConfig, non_dp_size: int = 1):
         super().__init__()
+        self.logger = get_logger()
         self.config = config
         self.tokenizer = tokenizer
 
@@ -270,7 +271,7 @@ class SFTDataset(StatefulIterableDataset):
 
             # If EOS token is not found, manually append it
             if not self.tokenizer.eos_token_id in input_ids:
-                self._logger.warning(
+                self.logger.warning(
                     f"Did not find EOS token ID {self.tokenizer.eos_token_id} in input_ids. Is something wrong with the chat template? Manually appending EOS token..."
                 )
                 input_ids.append(cast(int, self.tokenizer.eos_token_id))
@@ -282,7 +283,7 @@ class SFTDataset(StatefulIterableDataset):
             input_ids = input_ids[:-1]
 
             if sum(loss_mask[: self.config.seq_len]) == 0:
-                self._logger.warning(
+                self.logger.warning(
                     f"Skipping example with index {self.step} because no trainable tokens were found within the context window ({self.config.seq_len}). This is to prevent NaN loss."
                 )
                 continue

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -377,7 +377,7 @@ class StackDataset(StatefulIterableDataset):
             len_sample = len(sample["input_ids"])
             if len_sample > self.max_area:
                 for key, value in sample.items():
-                    if key != "epoch":
+                    if isinstance(value, list):
                         sample[key] = sample[key][: self.max_area]
                 len_sample = self.max_area
 


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Previously, we asserted the `max_area` that can be yielded from the `StackDataset` to be a power of 2. This PR defines three fixed-sized buckets that we sort samples into. We then yield if the bucket is full or hasn't been released after some timeout number of steps. If a timeout is reached we merge a smaller bucket with a larger bucket.

- Bucket 0: `[0, max_area//4]`
- Bucket 1: `]max_area//4, max_area//2]`
- Bucket 2: `]max_area//2, max_area]`

This PR also adds debug logs for dataset indices which can help to pin down "bad samples", as we experienced with some of our tool call samples. This has to live in the `CatDataset` and `StackDataset` as these "pack" the batches.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->
