### PR TITLE
Allow RL on single GPU from `rl` entrypoint

### DIFF
--- a/src/prime_rl/inference/config.py
+++ b/src/prime_rl/inference/config.py
@@ -84,7 +84,6 @@ class ModelConfig(BaseConfig):
     ] = False
 
     tool_call_parser: Annotated[
-
         str,
         Field(
             description="The tool call parser to use. Passed to vLLM as `--tool-call-parser`",
@@ -104,6 +103,13 @@ class InferenceConfig(BaseSettings):
     # The parallel configuration
     parallel: ParallelConfig = ParallelConfig()
 
+    gpu_memory_utilization: Annotated[
+        float,
+        Field(
+            description="The GPU memory utilization to use. Passed to vLLM as `--gpu-memory-utilization`",
+        ),
+    ] = 0.9
+
     seed: Annotated[
         int | None,
         Field(
@@ -122,10 +128,11 @@ class InferenceConfig(BaseSettings):
             "model.max_model_len": "max_model_len",
             "model.enforce_eager": "enforce_eager",
             "model.trust_remote_code": "trust_remote_code",
-            "model.enable_auto_tool_choice": "enable_auto_tool_choice",  # requires underscores (unlike on CLI)
-            "model.tool_call_parser": "tool_call_parser",                # requires underscores (unlike on CLI)
+            "model.enable_auto_tool_choice": "enable_auto_tool_choice",
+            "model.tool_call_parser": "tool_call_parser",
             "parallel.tp": "tensor_parallel_size",
             "parallel.dp": "data_parallel_size",
+            "gpu_memory_utilization": "gpu_memory_utilization",
         }
 
         for key in get_all_fields(self):

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -185,7 +185,7 @@ class RLConfig(BaseSettings):
     @model_validator(mode="after")
     def validate_device(self):
         available_gpu_ids = get_cuda_visible_devices()
-        requested_gpu_ids = set(self.trainer_gpu_ids + self.inference_gpu_ids)
+        requested_gpu_ids = sorted(set(self.trainer_gpu_ids + self.inference_gpu_ids))
         if len(requested_gpu_ids) > len(available_gpu_ids):
             raise ValueError(
                 f"The number of requested GPUs ({len(requested_gpu_ids)}) exceeds available GPUs ({len(available_gpu_ids)})"

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -12,7 +12,6 @@ from threading import Event, Thread
 from typing import Annotated
 
 import tomli_w
-import torch
 from loguru import logger as loguru_logger
 from loguru._logger import Logger
 from pydantic import Field, model_validator
@@ -125,9 +124,8 @@ class RLConfig(BaseSettings):
         ),
     ] = True
 
-    trainer_gpus: Annotated[int, Field(description="The number of GPUs to use for trainer.")] = 1
-
-    inference_gpus: Annotated[int, Field(description="The number of GPUs to use for inference.")] = 1
+    inference_gpu_ids: Annotated[list[int], Field(description="The GPU IDs to use for inference.")] = [0]
+    trainer_gpu_ids: Annotated[list[int], Field(description="The GPU IDs to use for trainer.")] = [1]
 
     ### Shared configurations
 
@@ -187,21 +185,26 @@ class RLConfig(BaseSettings):
 
     @model_validator(mode="after")
     def validate_device(self):
-        available_gpus = torch.cuda.device_count()
-        if self.trainer_gpus + self.inference_gpus > available_gpus:
+        available_gpu_ids = get_cuda_visible_devices()
+        requested_gpu_ids = set(self.trainer_gpu_ids + self.inference_gpu_ids)
+        if len(requested_gpu_ids) > len(available_gpu_ids):
             raise ValueError(
-                f"Total number of GPUs ({self.trainer_gpus + self.inference_gpus}) exceeds available GPUs ({available_gpus})"
+                f"The number of requested GPUs ({len(requested_gpu_ids)}) exceeds available GPUs ({len(available_gpu_ids)})"
             )
-        if self.inference and self.inference_gpus != self.inference.parallel.dp * self.inference.parallel.tp:
+        if any(not (gpu_id in available_gpu_ids) for gpu_id in requested_gpu_ids):
             raise ValueError(
-                f"Total number of inference GPUs ({self.inference_gpus}) does not match the local sharding strategy ({self.inference.parallel.dp} DP + {self.inference.parallel.tp} TP)"
+                f"Some requested GPU IDs are not available. Available GPUs: {available_gpu_ids}, Requested GPUs: {requested_gpu_ids}"
+            )
+        if self.inference and len(self.inference_gpu_ids) != self.inference.parallel.dp * self.inference.parallel.tp:
+            raise ValueError(
+                f"Total number of inference GPUs ({len(self.inference_gpu_ids)}) does not match the local sharding strategy (DP={self.inference.parallel.dp}, TP={self.inference.parallel.tp})"
             )
         return self
 
     @model_validator(mode="after")
     def auto_setup_num_train_workers(self):
-        if self.trainer_gpus > 1:
-            self.orchestrator.num_train_workers = self.trainer_gpus
+        if len(self.trainer_gpu_ids) > 1:
+            self.orchestrator.num_train_workers = len(self.trainer_gpu_ids)
         return self
 
     @model_validator(mode="after")
@@ -445,9 +448,6 @@ def rl(config: RLConfig):
     monitor_threads: list[Thread] = []
     error_queue: list[Exception] = []
     stop_events: dict[str, Event] = {}
-    all_devices = get_cuda_visible_devices()
-    devices = all_devices[: config.trainer_gpus + config.inference_gpus]
-    logger.info(f"Available GPUs: {', '.join(map(str, all_devices))} (using: {', '.join(map(str, devices))})")
 
     try:
         # Optionally, start inference process
@@ -457,14 +457,13 @@ def rl(config: RLConfig):
                 tomli_w.dump(config.inference.model_dump(exclude_none=True, mode="json"), f)
 
             inference_cmd = ["uv", "run", "inference", "@", inference_file.as_posix()]
-            inference_gpu_ids = devices[: config.inference_gpus]
-            logger.info(f"Starting inference process on GPU(s) {' '.join(map(str, inference_gpu_ids))}")
+            logger.info(f"Starting inference process on GPU(s) {' '.join(map(str, config.inference_gpu_ids))}")
             logger.debug(f"Inference start command: {' '.join(inference_cmd)}")
             # If we don't log stdout, the server hangs
             with open(log_dir / "inference.log", "w") as log_file:
                 inference_process = Popen(
                     inference_cmd,
-                    env={**os.environ, "CUDA_VISIBLE_DEVICES": ",".join(map(str, inference_gpu_ids))},
+                    env={**os.environ, "CUDA_VISIBLE_DEVICES": ",".join(map(str, config.inference_gpu_ids))},
                     stdout=log_file,
                     stderr=log_file,
                 )
@@ -536,21 +535,20 @@ def rl(config: RLConfig):
             f"--rdzv-endpoint=localhost:{get_free_port()}",
             f"--rdzv-id={uuid.uuid4().hex}",
             "--nproc-per-node",
-            str(config.trainer_gpus),
+            str(len(config.trainer_gpu_ids)),
             "-m",
             "prime_rl.trainer.rl.train",
             "@",
             trainer_file.as_posix(),
         ]
-        train_gpu_ids = devices[config.inference_gpus :]
-        logger.info(f"Starting trainer process on GPU(s) {' '.join(map(str, train_gpu_ids))}")
+        logger.info(f"Starting trainer process on GPU(s) {' '.join(map(str, config.trainer_gpu_ids))}")
         logger.debug(f"Training start command: {' '.join(trainer_cmd)}")
         with open(log_dir / "trainer.log", "w") as log_file:
             trainer_process = Popen(
                 trainer_cmd,
                 env={
                     **os.environ,
-                    "CUDA_VISIBLE_DEVICES": ",".join(map(str, train_gpu_ids)),
+                    "CUDA_VISIBLE_DEVICES": ",".join(map(str, config.trainer_gpu_ids)),
                     "LOGURU_FORCE_COLORS": "1",
                     "WANDB_PROGRAM": "uv run rl",
                     "WANDB_ARGS": json.dumps(start_command),

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -36,7 +36,6 @@ from prime_rl.utils.utils import (
 from prime_rl.utils.validation import (
     validate_shared_async_level,
     validate_shared_ckpt_config,
-    validate_shared_max_model_len,
     validate_shared_max_steps,
     validate_shared_model_name,
     validate_shared_output_dir,
@@ -316,17 +315,6 @@ class RLConfig(BaseSettings):
             self.orchestrator.max_steps = self.max_steps
 
         validate_shared_max_steps(self.trainer, self.orchestrator)
-
-        return self
-
-    @model_validator(mode="after")
-    def auto_setup_max_model_len(self):
-        if self.max_model_len:
-            self.orchestrator.seq_len = self.max_model_len
-            if self.inference:
-                self.inference.model.max_model_len = self.max_model_len
-
-        validate_shared_max_model_len(self.orchestrator, self.inference)
 
         return self
 

--- a/src/prime_rl/utils/validation.py
+++ b/src/prime_rl/utils/validation.py
@@ -47,16 +47,6 @@ def validate_shared_model_name(
         )
 
 
-def validate_shared_max_model_len(
-    orchestrator: OrchestratorConfig,
-    inference: Optional[InferenceConfig] = None,
-) -> None:
-    if inference and inference.model.max_model_len and orchestrator.seq_len != inference.model.max_model_len:
-        raise ValueError(
-            f"Orchestrator sequence length ({orchestrator.seq_len}) and inference model max model length ({inference.model.max_model_len}) are not the same. Please specify the same max model length for both."
-        )
-
-
 def validate_shared_output_dir(
     trainer: RLTrainerConfig,
     orchestrator: OrchestratorConfig,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -13,7 +13,6 @@ from prime_rl.utils.pydantic_config import parse_argv
 from prime_rl.utils.validation import (
     validate_shared_async_level,
     validate_shared_ckpt_config,
-    validate_shared_max_model_len,
     validate_shared_max_steps,
     validate_shared_model_name,
     validate_shared_output_dir,
@@ -97,6 +96,5 @@ def test_rl_configs(config_dir: Path, monkeypatch: pytest.MonkeyPatch):
     validate_shared_model_name(trainer, orchestrator, inference)
     validate_shared_output_dir(trainer, orchestrator)
     validate_shared_wandb_config(trainer, orchestrator)
-    validate_shared_max_model_len(orchestrator, inference)
     validate_shared_async_level(trainer, orchestrator)
     validate_shared_max_steps(trainer, orchestrator)


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

This PR changes the hardware allocation patterns for the`rl` entrypoint to allow running RL training run on a single GPU. For example, `reverse-text` can be run on a single GPU with as little as ~48GB like so

```bash
uv run rl \
  --trainer @ configs/reverse_text/train.toml \
  --orchestrator @ configs/reverse_text/orch.toml \
  --inference @ configs/reverse_text/infer.toml \
  --trainer-gpu-ids 0 \
  --inference-gpu-ids 0 \
  --inference.gpu-memory-utilization 0.5 \
  --inference.model.max-model-len 256
```

Change `gpu_memory_utilization` so that you use roughly ~8GB on inference for model weights and KV cache.

The changes necessary are:
- The trainer and inference GPU IDs are now directly configured, with overlap allowed
- We add `gpu_memory_utilization` into the inference config so that it can be controlled from `rl.py`
- Remove the strict check that orchestrator seq len = inference max model len

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: #970 
**Linear Issue**: Resolves PRIMERL-123