### PR TITLE
Fix wrong logs

### DIFF
--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -416,8 +416,8 @@ def train(config: RLTrainerConfig):
         logger.info(f"Saving trace to {trace_file}")
         prof.export_chrome_trace(trace_file)
         logger.info(f"Saved trace to {trace_file}")
+
     # Log final (immutable) distributions to W&B table
-    logger.info("Logging final distributions as W&B table")
     monitor.log_final_distributions()
 
     # Write final checkpoint

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -312,8 +312,8 @@ def train(config: SFTTrainerConfig):
         logger.info(f"Saving trace to {trace_file}")
         prof.export_chrome_trace(trace_file)
         logger.info(f"Saved trace to {trace_file}")
+
     # Log final (immutable) distributions to W&B table
-    logger.info("Logging final distributions as W&B table")
     monitor.log_final_distributions()
 
     # Write final checkpoint

--- a/src/prime_rl/utils/monitor.py
+++ b/src/prime_rl/utils/monitor.py
@@ -35,7 +35,8 @@ class WandbMonitor:
         self.enabled = self.config is not None
         self.is_master = rank == 0
         if not self.enabled or not self.is_master:
-            self.logger.warning(f"Skipping {self.__class__.__name__} initialization from non-master rank ({rank})")
+            if not self.is_master:
+                self.logger.warning(f"Skipping {self.__class__.__name__} initialization from non-master rank ({rank})")
             return
         assert config is not None
         self.logger.info(f"Initializing {self.__class__.__name__} ({config})")
@@ -239,9 +240,10 @@ class WandbMonitor:
 
     def save_final_summary(self, filename: str = "final_summary.json") -> None:
         """Save final summary to W&B table."""
-        if not self.is_master or not self.config:
+        if not self.is_master or not self.enabled:
             return
         self.logger.info("Saving final summary to file")
+        assert self.output_dir is not None, "Output directory is required for saving final summary"
         dir_path = self.output_dir / f"run-{self.wandb.id}"
         dir_path.mkdir(parents=True, exist_ok=True)
         with open(dir_path / filename, "w") as f:


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

This PR fixes two wrong logs:
- We log `Skipping WandbMonitor initialization from non-master rank` when on master rank but wandb is not enabled
- We log `Logging final distributions to W&B table` even if we don't do that (e.g. because wandb is not enabled)

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: #915 
**Linear Issue**: Resolves PRIMERL-100