### PR TITLE
Mask SFT loss by message type + skip samples without trainable tokens

### DIFF
--- a/configs/debug/sft_moe.toml
+++ b/configs/debug/sft_moe.toml
@@ -1,7 +1,7 @@
 max_steps = 5
 
 [model]
-name = "Jackmin108/glm-0.5B" 
+name = "PrimeIntellect/GLM-0.5B" 
 moe_use_grouped_mm = false
 impl = "custom"
 attn = "sdpa"

--- a/src/prime_rl/trainer/sft/config.py
+++ b/src/prime_rl/trainer/sft/config.py
@@ -46,12 +46,12 @@ class FakeDataConfig(BaseDataConfig):
 
 
 class LossMaskConfig(BaseModel):
-    """Configures which message types contribute to the loss. If True, the loss_mask will be True for this message type and the message type will contribute to the loss."""
+    """Configures which message types contribute to the loss. If True, the loss_mask will be True and the message type will contribute to the loss."""
 
-    system: Annotated[bool, Field(description="Whether to mask system messages.")] = False
-    user: Annotated[bool, Field(description="Whether to mask user messages.")] = False
-    assistant: Annotated[bool, Field(description="Whether to mask assistant messages.")] = True
-    tool: Annotated[bool, Field(description="Whether to mask tool messages.")] = False
+    system: Annotated[bool, Field(description="Whether system messages contribute to the loss.")] = False
+    user: Annotated[bool, Field(description="Whether user messages contribute to the loss.")] = False
+    assistant: Annotated[bool, Field(description="Whether assistant messages contribute to the loss.")] = True
+    tool: Annotated[bool, Field(description="Whether tool messages contribute to the loss.")] = False
 
 
 class SFTDataConfig(BaseDataConfig):

--- a/src/prime_rl/trainer/sft/config.py
+++ b/src/prime_rl/trainer/sft/config.py
@@ -45,6 +45,15 @@ class FakeDataConfig(BaseDataConfig):
     input_ids: Literal["increasing", "random"] = "increasing"
 
 
+class LossMaskConfig(BaseModel):
+    """Configures which message types contribute to the loss. If True, the loss_mask will be True for this message type and the message type will contribute to the loss."""
+
+    system: Annotated[bool, Field(description="Whether to mask system messages.")] = False
+    user: Annotated[bool, Field(description="Whether to mask user messages.")] = False
+    assistant: Annotated[bool, Field(description="Whether to mask assistant messages.")] = True
+    tool: Annotated[bool, Field(description="Whether to mask tool messages.")] = False
+
+
 class SFTDataConfig(BaseDataConfig):
     """Configures the data used for training."""
 
@@ -55,6 +64,9 @@ class SFTDataConfig(BaseDataConfig):
     )
     splits: Annotated[list[str], Field(description="Splits to use from the HF dataset.")] = ["train"]
     shuffle: Annotated[bool, Field(description="Whether to shuffle the dataset at the beginning of each epoch.")] = True
+
+    # Configuring
+    loss_mask: LossMaskConfig = LossMaskConfig()
 
 
 DataConfigType: TypeAlias = FakeDataConfig | SFTDataConfig

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -264,6 +264,12 @@ class SFTDataset(StatefulIterableDataset):
                 ),
             )
 
+            if len(input_ids) > self.config.seq_len:
+                self._logger.warning(
+                    f"Skipping example {self.step} because the number of input tokens {len(input_ids)} is greater than sequence length {self.config.seq_len}. This is to prevent having a micro batch with no trainable tokens causing NaN loss."
+                )
+                continue
+
             # Build loss_mask
             loss_mask = build_loss_mask(prompt, completion, self.tokenizer, self.config.loss_mask)
 

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -274,7 +274,7 @@ class SFTDataset(StatefulIterableDataset):
 
             if sum(loss_mask[: self.config.seq_len]) == 0:
                 self._logger.warning(
-                    f"Skipping example {self.step} because the number no trainable tokens found within the context window of length {self.config.seq_len}. This is to prevent having a micro batch with no trainable tokens causing NaN loss."
+                    f"Skipping example with index {self.step} because no trainable tokens were found within the context window ({self.config.seq_len}). This is to prevent NaN loss."
                 )
                 continue
 

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -256,11 +256,6 @@ class SFTDataset(StatefulIterableDataset):
                 ),
             )
 
-            self._logger.debug(f"Input IDs: {input_ids}")
-            self._logger.debug(
-                f"Loss Mask: {self.tokenizer.apply_chat_template(prompt + completion, tools=tools, **example.get('chat_template_kwargs', {}), tokenize=False)}"
-            )
-
             # Build loss_mask
             loss_mask = build_loss_mask(prompt, completion, self.tokenizer, self.config.loss_mask)
 

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -261,8 +261,8 @@ class SFTDataset(StatefulIterableDataset):
 
             # Prepare inputs
             target_ids = input_ids.copy()[1:]
+            loss_mask = loss_mask[1:]
             input_ids = input_ids[:-1]
-            loss_mask = loss_mask[:-1]
 
             assert len(input_ids) == len(loss_mask) == len(target_ids), (
                 f"input_ids, loss_mask and target_ids must have the same length, but got {len(input_ids)=}, {len(loss_mask)=}, {len(target_ids)=}"

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from typing import Iterator, TypedDict, cast
 
 import torch
-from datasets import Dataset, concatenate_datasets, load_dataset
+from datasets import Dataset
 from jaxtyping import Bool, Int
 from torch import Tensor
 from torch.distributed.checkpoint.stateful import Stateful

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -27,6 +27,7 @@ from prime_rl.trainer.perf import get_perf_counter
 from prime_rl.trainer.sft.data import setup_dataloader, setup_dataset
 from prime_rl.trainer.utils import (
     MemoryProfiler,
+    print_sample,
     setup_torch_distributed,
     print_benchmark,
 )
@@ -169,7 +170,14 @@ def train(config: SFTTrainerConfig):
             target_ids = micro_batch["target_ids"].to("cuda")
             loss_mask = micro_batch["loss_mask"].to("cuda")
             epoch = micro_batch["epoch"]
-            assert input_ids.shape[0] == position_ids.shape[0]
+            assert input_ids.shape == position_ids.shape == target_ids.shape == loss_mask.shape, (
+                f"input_ids.shape: {input_ids.shape}, position_ids.shape: {position_ids.shape}, target_ids.shape: {target_ids.shape}, loss_mask.shape: {loss_mask.shape}"
+            )
+
+            # In debug mode, print the loss mask of the first micro batch
+            if config.log.level.upper() == "DEBUG" and progress.step == 0 and micro_step == 0:
+                logger.debug("Printing samples of the first micro batch")
+                print_sample(input_ids.flatten().tolist(), loss_mask.flatten().tolist(), tokenizer)
 
             if config.model.cp > 1:
                 maybe_context_parallel = context_parallel(

--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -8,10 +8,13 @@ from typing import Any, TypeAlias
 import pandas as pd
 import torch
 import torch.distributed as dist
+from rich import print as rich_print
 from rich.console import Console
 from rich.table import Table
+from rich.text import Text
 from torch import Tensor, nn
 from torch.distributed.tensor import DTensor
+from transformers.tokenization_utils import PreTrainedTokenizer
 
 from prime_rl.trainer.world import get_world
 from prime_rl.utils.logger import get_logger
@@ -109,6 +112,17 @@ def wake_up_model_from_cpu(model: nn.Module, tensors: OffloadedTensor):
     torch.cuda.synchronize()
 
 
+def print_sample(input_ids: list[int], loss_mask: list[bool], tokenizer: PreTrainedTokenizer):
+    """
+    Visualize the loss mask of a tokenized sample using rich.
+    Reference: https://huggingface.co/Qwen/Qwen3-8B/discussions/14
+    """
+    text = Text()
+    for token, mask in zip(tokenizer.convert_ids_to_tokens(input_ids), loss_mask):
+        text.append(token.replace("Ġ", " ").replace("Ċ", "\n"), style="cyan" if mask else "white")
+    rich_print(text)
+
+
 def print_benchmark(history: dict[str, list[Any]]) -> None:
     """
     Print benchmark results as rich table. Shows formatted values for the
@@ -156,9 +170,15 @@ def print_benchmark(history: dict[str, list[Any]]) -> None:
     formatted_mean_df["MFU"] = mean_df["MFU"].apply(lambda x: f"{format_num(x, precision=2)}%")
     formatted_mean_df["Throughput"] = mean_df["Throughput"].apply(format_num, precision=2)
     formatted_mean_df["Step Time"] = mean_df["Step Time"].apply(format_time)
-    mean_row = ["Overall"] + formatted_mean_df.T.apply(
-        lambda row: f"{row['mean']} ± {row['std']} [{row['min']}, {row['max']}]", axis=1
-    ).tolist() + [f"{format_num(mean_df['Peak Memory']["mean"], precision=1)} GiB ({mean_df['Peak Memory']["mean"]/(torch.cuda.mem_get_info()[1]/1024**3)*100:.1f}%)"]
+    mean_row = (
+        ["Overall"]
+        + formatted_mean_df.T.apply(
+            lambda row: f"{row['mean']} ± {row['std']} [{row['min']}, {row['max']}]", axis=1
+        ).tolist()
+        + [
+            f"{format_num(mean_df['Peak Memory']['mean'], precision=1)} GiB ({mean_df['Peak Memory']['mean'] / (torch.cuda.mem_get_info()[1] / 1024**3) * 100:.1f}%)"
+        ]
+    )
     table.add_row(*mean_row)
 
     # Display table

--- a/tests/unit/train/sft/test_dataloader.py
+++ b/tests/unit/train/sft/test_dataloader.py
@@ -141,7 +141,7 @@ Prompt {idx}<|im_end|>
 
 </think>
 
-Completion {idx}<|im_end|>
+Completion {idx}<|im_end|>\
 """
 
 
@@ -151,7 +151,7 @@ def test_stateful_dataloader_resume_sft():
     config = SFTDataConfig(
         name="mikasenghaas/test-sft",
         num_examples=num_examples,
-        seq_len=20,
+        seq_len=19,
         batch_size=1,
         micro_batch_size=1,
         shuffle=False,
@@ -163,7 +163,7 @@ def test_stateful_dataloader_resume_sft():
     # First 1/2 epoch 0
     for step in range(num_examples // 2):
         micro_batch = next(dataiter)
-        assert micro_batch["input_ids"].shape == (1, 20)
+        assert micro_batch["input_ids"].shape == (1, 19)
         assert tokenizer.decode(micro_batch["input_ids"][0]) == SAMPLE_TEMPLATE.format(idx=step)
         assert micro_batch["epoch"] == 0
         assert dataloader.state_dict()["dataset_state"] == {"step": step + 1, "epoch": 0}
@@ -177,7 +177,7 @@ def test_stateful_dataloader_resume_sft():
     # Second 1/2 epoch 0
     for step in range(num_examples // 2):
         micro_batch = next(dataiter)
-        assert micro_batch["input_ids"].shape == (1, 20)
+        assert micro_batch["input_ids"].shape == (1, 19)
         assert tokenizer.decode(micro_batch["input_ids"][0]) == SAMPLE_TEMPLATE.format(idx=num_examples // 2 + step)
         assert micro_batch["epoch"] == 0
         assert dataloader.state_dict()["dataset_state"] == {"step": num_examples // 2 + step + 1, "epoch": 0}
@@ -191,7 +191,7 @@ def test_stateful_dataloader_resume_sft():
     # Epoch 1
     for step in range(num_examples):
         micro_batch = next(dataiter)
-        assert micro_batch["input_ids"].shape == (1, 20)
+        assert micro_batch["input_ids"].shape == (1, 19)
         assert tokenizer.decode(micro_batch["input_ids"][0]) == SAMPLE_TEMPLATE.format(idx=step)
         assert micro_batch["epoch"] == 1
         assert dataloader.state_dict()["dataset_state"] == {"step": num_examples + step + 1, "epoch": 1}

--- a/tests/unit/train/sft/test_dataset.py
+++ b/tests/unit/train/sft/test_dataset.py
@@ -1,7 +1,12 @@
+from typing import cast
+
+import pytest
+from datasets import Dataset, load_dataset
 from transformers import AutoTokenizer
 
 from prime_rl.trainer.sft.config import FakeDataConfig, SFTDataConfig
 from prime_rl.trainer.sft.data import FakeDataset, SFTDataset
+from prime_rl.trainer.utils import print_sample
 
 
 def test_init_fake_dataset():
@@ -27,9 +32,46 @@ def test_fake_dataset_state():
 
 def test_init_sft_dataset():
     tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B")
-    config = SFTDataConfig(num_examples=2)
-    dataset = SFTDataset(tokenizer, config)
+    config = SFTDataConfig(name="mikasenghaas/test-sft", num_examples=2)
+    dataset = cast(Dataset, load_dataset("mikasenghaas/test-sft", split="train"))
+    dataset = SFTDataset(dataset, tokenizer, config)
     assert dataset is not None
+
+
+def test_raise_error_if_no_prompt_and_completion():
+    dataset = Dataset.from_list([{"text": "Text 0"}])
+    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B")
+    config = SFTDataConfig(num_examples=1)
+    with pytest.raises(ValueError):
+        SFTDataset(dataset, tokenizer, config)
+
+
+def test_raise_error_if_wrong_format():
+    dataset = Dataset.from_list([{"completion": ["Completion 0"]}])
+    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B")
+    config = SFTDataConfig(num_examples=1)
+    with pytest.raises(ValueError):
+        SFTDataset(dataset, tokenizer, config)
+
+
+def test_multiturn_loss_mask():
+    dataset = Dataset.from_list(
+        [
+            {
+                "prompt": [{"role": "system", "content": "System 0"}, {"role": "user", "content": "Prompt 0"}],
+                "completion": [
+                    {"role": "assistant", "content": "Completion 0"},
+                    {"role": "user", "content": "Prompt 1"},
+                    {"role": "assistant", "content": "Completion 1"},
+                ],
+            },
+        ]
+    )
+    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B")
+    config = SFTDataConfig(num_examples=1)
+    dataset = SFTDataset(dataset, tokenizer, config)
+    sample = next(iter(dataset))
+    print_sample(sample["input_ids"], sample["loss_mask"], tokenizer)
 
 
 SAMPLE_TEMPLATE = """\
@@ -47,21 +89,22 @@ Completion {idx}<|im_end|>
 def test_sft_dataset_state():
     tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B")
     config = SFTDataConfig(name="mikasenghaas/test-sft", num_examples=2)
-    dataset = SFTDataset(tokenizer, config)
+    dataset = cast(Dataset, load_dataset("mikasenghaas/test-sft", split="train"))
+    dataset = SFTDataset(dataset, tokenizer, config)
     dataiter = iter(dataset)
     assert dataset.state_dict() == {"step": 0, "epoch": 0}
 
     # Step 1
     micro_batch = next(dataiter)
-    assert tokenizer.decode(micro_batch["input_ids"]) == SAMPLE_TEMPLATE.format(idx=0)
+    assert tokenizer.decode(micro_batch["input_ids"]) == SAMPLE_TEMPLATE.format(idx=0).strip()
     assert dataset.state_dict() == {"step": 1, "epoch": 0}
 
     # Step 2
     micro_batch = next(dataiter)
-    assert tokenizer.decode(micro_batch["input_ids"]) == SAMPLE_TEMPLATE.format(idx=1)
+    assert tokenizer.decode(micro_batch["input_ids"]) == SAMPLE_TEMPLATE.format(idx=1).strip()
     assert dataset.state_dict() == {"step": 2, "epoch": 0}
 
     # Step 3 (next epoch)
     micro_batch = next(dataiter)
-    assert tokenizer.decode(micro_batch["input_ids"]) == SAMPLE_TEMPLATE.format(idx=0)
+    assert tokenizer.decode(micro_batch["input_ids"]) == SAMPLE_TEMPLATE.format(idx=0).strip()
     assert dataset.state_dict() == {"step": 3, "epoch": 1}

--- a/tests/unit/train/sft/test_dataset.py
+++ b/tests/unit/train/sft/test_dataset.py
@@ -146,7 +146,7 @@ Prompt {idx}<|im_end|>
 
 </think>
 
-Completion {idx}<|im_end|>
+Completion {idx}<|im_end|>\
 """
 
 
@@ -160,15 +160,15 @@ def test_sft_dataset_state():
 
     # Step 1
     micro_batch = next(dataiter)
-    assert tokenizer.decode(micro_batch["input_ids"]) == SAMPLE_TEMPLATE.format(idx=0).strip()
+    assert tokenizer.decode(micro_batch["input_ids"]) == SAMPLE_TEMPLATE.format(idx=0)
     assert dataset.state_dict() == {"step": 1, "epoch": 0}
 
     # Step 2
     micro_batch = next(dataiter)
-    assert tokenizer.decode(micro_batch["input_ids"]) == SAMPLE_TEMPLATE.format(idx=1).strip()
+    assert tokenizer.decode(micro_batch["input_ids"]) == SAMPLE_TEMPLATE.format(idx=1)
     assert dataset.state_dict() == {"step": 2, "epoch": 0}
 
     # Step 3 (next epoch)
     micro_batch = next(dataiter)
-    assert tokenizer.decode(micro_batch["input_ids"]) == SAMPLE_TEMPLATE.format(idx=0).strip()
+    assert tokenizer.decode(micro_batch["input_ids"]) == SAMPLE_TEMPLATE.format(idx=0)
     assert dataset.state_dict() == {"step": 3, "epoch": 1}

--- a/tests/unit/train/test_model.py
+++ b/tests/unit/train/test_model.py
@@ -106,7 +106,7 @@ def test_model_with_sequence_packing(model, correct_position_ids):
 
 
 def test_moe_custom_impl():
-    config = ModelConfig(name="Jackmin108/glm-0.5B", attn="sdpa", impl="custom", moe_use_grouped_mm=False)
+    config = ModelConfig(name="PrimeIntellect/GLM-0.5B", attn="sdpa", impl="custom", moe_use_grouped_mm=False)
     model = get_model(config)
     model = model.to("cuda")
     with torch.autocast("cuda", dtype=torch.bfloat16):


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Previously, the `SFTDataset` would would train on all completion tokens and only mask out prompt tokens. This is the HF `SFTTrainer` default but not flexible enough, especially for multi-turn interactions with tool calls. This PR implements building the `loss_mask` for the SFT trainer incrementally by message type, e.g. one can specify whether to include the system message (`--data.loss_mask.system`, default: `False`), user message (`--data.loss_mask.user`, default: `False`) tool message (`--data.loss_mask.tool`, default: `False`), and assistant message (`--data.loss_mask.assistant`, default: `True`). By default, we only train on assistant messages.

**Misc. Changes**:
-  We include a new utility `print_sample` which prints a colored output indicating which tokens are masked and which are not. If `log.level=debug`, we print out the first micro batch using this helper
- We slightly change the signature of the `SFTDataset` to make it easier to unit test. Loading of the dataset now happens outside the dataset. We add some unit tests for the processing of multi-turn tool call data
- We skip samples without trainable tokens within the context window to prevent NaN losses
- Switch `Jackmin108/glm-0.5b` -> `PrimeIntellect/GLM-0.5B` with updated EOS token for SFT integration test to pass

## Multi-Turn w/ Parallel Tool Calls

<img width="705" height="707" alt="Screenshot 2025-09-22 at 12 17 09 PM" src="https://github.com/user-attachments/assets/8b61c7dd-77e6-4ef7-bedd-9e1313ffeb2c" />

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: #974 
**Linear Issue**: Resolves PRIMERL-124