### PR TITLE
Implement WSD without cooldown

### DIFF
--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -145,15 +145,19 @@ class LinearSchedulerConfig(BaseModel):
 
     type: Literal["linear"] = "linear"
 
-    warmup_steps: Annotated[int, Field(ge=0, description="Number of warmup steps for the learning rate scheduler.")] = 0
+    warmup_steps: Annotated[int, Field(ge=0, description="Number of warmup steps for the learning rate scheduler.")] = (
+        10
+    )
 
     decay_steps: Annotated[
-        int | None,
+        int,
         Field(
-            ge=1,
-            description="Number of steps to decay the learning rate during the final portion of training. If None, will use remaining steps after warmup.",
+            ge=0,
+            description="Number of steps to decay the learning rate during the final portion of training.",
         ),
-    ] = None
+    ] = 10
+
+    min_lr: Annotated[float, Field(ge=0, description="Minimum learning rate to converge to.")] = 0.0
 
 
 class CosineSchedulerConfig(BaseModel):
@@ -161,17 +165,11 @@ class CosineSchedulerConfig(BaseModel):
 
     type: Literal["cosine"] = "cosine"
 
-    warmup_steps: Annotated[int, Field(ge=0, description="Number of warmup steps for the learning rate scheduler.")] = 0
+    warmup_steps: Annotated[int, Field(ge=0, description="Number of warmup steps for the learning rate scheduler.")] = (
+        10
+    )
 
     min_lr: Annotated[float, Field(ge=0, description="Minimum learning rate to converge to.")] = 0.0
-
-    decay_steps: Annotated[
-        int | None,
-        Field(
-            ge=1,
-            description="Number of steps to decay the learning rate during the final portion of training. If None, will use remaining steps after warmup.",
-        ),
-    ] = None
 
 
 SchedulerConfigType: TypeAlias = ConstantSchedulerConfig | LinearSchedulerConfig | CosineSchedulerConfig

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -136,33 +136,6 @@ class RLTrainerConfig(BaseSettings):
         return self
 
     @model_validator(mode="after")
-    def validate_scheduler(self):
-        # Constant scheduler does not require any validation/ setup
-        if self.scheduler.type == "constant":
-            return self
-
-        # Must specify max_steps when using a scheduler other than `constant`
-        if self.max_steps is None:
-            raise ValueError("Must specify max_steps when using a scheduler other than `constant`")
-
-        # If decay_steps is not specified, use remaining steps after warmup
-        if self.scheduler.decay_steps is None:
-            if not (self.scheduler.warmup_steps <= self.max_steps):
-                raise ValueError("config.scheduler.warmup_steps must be less than or equal to config.max_steps")
-
-            self.scheduler.decay_steps = self.max_steps - self.scheduler.warmup_steps
-            assert self.scheduler.decay_steps >= 0, "config.scheduler.decay_steps must be positive"
-
-        # If decay_steps is specified, validate it
-        else:
-            if not (self.scheduler.warmup_steps + self.scheduler.decay_steps <= self.max_steps):
-                raise ValueError(
-                    "config.scheduler.warmup_steps + config.scheduler.decay_steps must be less than or equal to config.max_steps"
-                )
-
-        return self
-
-    @model_validator(mode="after")
     def disable_logging_wandb_samples(self):
         if self.wandb and self.wandb.log_extras:
             self.wandb.log_extras.samples = False

--- a/src/prime_rl/trainer/scheduler.py
+++ b/src/prime_rl/trainer/scheduler.py
@@ -16,9 +16,14 @@ def setup_linear_scheduler(
     # Create schedulers for each phase
     schedulers, milestones = [], []
 
+    assert warmup_steps > 0 or decay_steps > 0, (
+        "Either warmup steps or decay steps must be specified for a linear scheduler"
+    )
+
     # Add warmup (if any)
+    min_lr_factor = min_lr / lr if min_lr > 0 else 1e-8
     if warmup_steps > 0:
-        warmup_scheduler = LinearLR(optimizer, start_factor=min_lr / lr, end_factor=1.0, total_iters=warmup_steps)
+        warmup_scheduler = LinearLR(optimizer, start_factor=min_lr_factor, end_factor=1.0, total_iters=warmup_steps)
         schedulers.append(warmup_scheduler)
         milestones.append(warmup_steps)
 
@@ -30,7 +35,7 @@ def setup_linear_scheduler(
         constant_steps = decay_start_step - warmup_steps
         assert constant_steps >= 0
         constant_scheduler = LinearLR(optimizer, start_factor=1.0, end_factor=1.0, total_iters=constant_steps)
-        decay_scheduler = LinearLR(optimizer, start_factor=1.0, end_factor=min_lr / lr, total_iters=decay_steps)
+        decay_scheduler = LinearLR(optimizer, start_factor=1.0, end_factor=min_lr_factor, total_iters=decay_steps - 1)
         schedulers.append(constant_scheduler)
         schedulers.append(decay_scheduler)
         milestones.append(decay_start_step)
@@ -51,16 +56,16 @@ def setup_cosine_scheduler(
 
     # Add warmup (if any)
     if warmup_steps > 0:
-        warmup_scheduler = LinearLR(optimizer, start_factor=min_lr / lr, end_factor=1.0, total_iters=warmup_steps)
+        min_lr_factor = min_lr / lr if min_lr > 0 else 1e-8
+        warmup_scheduler = LinearLR(optimizer, start_factor=min_lr_factor, end_factor=1.0, total_iters=warmup_steps)
         schedulers.append(warmup_scheduler)
         milestones.append(warmup_steps)
 
-    assert max_steps is not None, "max_steps must be specified when specifying decay_steps"
-    decay_start_step = max_steps - decay_steps
-    assert decay_start_step >= warmup_steps
-    cosine_scheduler = CosineAnnealingLR(optimizer, T_max=decay_steps, eta_min=min_lr)
-    schedulers.append(cosine_scheduler)
-    milestones.append(decay_start_step)
+    if decay_steps > 0:
+        assert max_steps is not None, "max_steps must be specified when specifying decay_steps"
+        decay_steps = max_steps - warmup_steps
+        cosine_scheduler = CosineAnnealingLR(optimizer, T_max=decay_steps, eta_min=min_lr)
+        schedulers.append(cosine_scheduler)
 
     # Return single scheduler if only one phase, otherwise combine with SequentialLR
     if len(schedulers) == 1:

--- a/src/prime_rl/trainer/scheduler.py
+++ b/src/prime_rl/trainer/scheduler.py
@@ -1,67 +1,101 @@
 from torch.optim import Optimizer
-from torch.optim.lr_scheduler import CosineAnnealingLR, LinearLR, LRScheduler, SequentialLR
+from torch.optim.lr_scheduler import ConstantLR, CosineAnnealingLR, LinearLR, LRScheduler, SequentialLR
 
 from prime_rl.trainer.config import SchedulerConfigType
 
 
-class ConstantLRScheduler(LRScheduler):
-    """A scheduler that keeps the learning rate constant."""
-
-    def __init__(self, optimizer: Optimizer):
-        self.optimizer = optimizer
-        super().__init__(optimizer, last_epoch=-1)
-
-    def get_lr(self):
-        return [group["lr"] for group in self.optimizer.param_groups]
+def setup_constant_scheduler(optimizer: Optimizer) -> LRScheduler:
+    """Create a constant learning rate scheduler."""
+    return ConstantLR(optimizer, factor=1.0)
 
 
-def setup_scheduler(optimizer: Optimizer, config: SchedulerConfigType, max_steps: int | None) -> LRScheduler:
-    """Create learning rate scheduler based on config."""
-
-    if config.type == "constant":
-        return ConstantLRScheduler(optimizer)
-
-    assert max_steps is not None, "max_steps must be specified when using a scheduler other than `constant`"
-
-    warmup_steps = config.warmup_steps
-    decay_steps = config.decay_steps
-
-    if decay_steps is None:
-        # Fallback: decay for remaining steps after warmup
-        decay_steps = max_steps - warmup_steps
-
-    # Calculate when final decay starts
-    decay_start_step = max_steps - decay_steps
-    constant_steps = decay_start_step - warmup_steps
-
+def setup_linear_scheduler(
+    optimizer: Optimizer, max_steps: int | None, warmup_steps: int, decay_steps: int, lr: float, min_lr: float
+) -> LRScheduler:
+    """Create a linear (WSD) learning rate scheduler."""
     # Create schedulers for each phase
-    schedulers = []
-    milestones = []
+    schedulers, milestones = [], []
 
-    # Phase 1: Warmup (if any)
+    # Add warmup (if any)
     if warmup_steps > 0:
-        warmup_scheduler = LinearLR(optimizer, start_factor=1e-8, end_factor=1.0, total_iters=warmup_steps)
+        warmup_scheduler = LinearLR(optimizer, start_factor=min_lr / lr, end_factor=1.0, total_iters=warmup_steps)
         schedulers.append(warmup_scheduler)
         milestones.append(warmup_steps)
 
-    # Phase 2: Constant (if any)
-    if constant_steps > 0:
+    # Add decay (if any)
+    if decay_steps > 0:
+        assert max_steps is not None, "max_steps must be specified when specifying decay_steps"
+        decay_start_step = max_steps - decay_steps
+        assert decay_start_step >= warmup_steps
+        constant_steps = decay_start_step - warmup_steps
+        assert constant_steps >= 0
         constant_scheduler = LinearLR(optimizer, start_factor=1.0, end_factor=1.0, total_iters=constant_steps)
+        decay_scheduler = LinearLR(optimizer, start_factor=1.0, end_factor=min_lr / lr, total_iters=decay_steps)
         schedulers.append(constant_scheduler)
+        schedulers.append(decay_scheduler)
         milestones.append(decay_start_step)
-
-    # Phase 3: Final decay
-    if config.type == "linear":
-        decay_scheduler = LinearLR(optimizer, start_factor=1.0, end_factor=0.0, total_iters=decay_steps)
-    elif config.type == "cosine":
-        decay_scheduler = CosineAnnealingLR(optimizer, T_max=decay_steps, eta_min=config.min_lr)
-    else:
-        raise ValueError(f"Invalid scheduler type: {config.type}")
-
-    schedulers.append(decay_scheduler)
 
     # Return single scheduler if only one phase, otherwise combine with SequentialLR
     if len(schedulers) == 1:
         return schedulers[0]
 
     return SequentialLR(optimizer, schedulers, milestones=milestones)
+
+
+def setup_cosine_scheduler(
+    optimizer: Optimizer, max_steps: int | None, warmup_steps: int, decay_steps: int, lr: float, min_lr: float
+) -> LRScheduler:
+    """Create a cosine learning rate scheduler."""
+    # Create schedulers for each phase
+    schedulers, milestones = [], []
+
+    # Add warmup (if any)
+    if warmup_steps > 0:
+        warmup_scheduler = LinearLR(optimizer, start_factor=min_lr / lr, end_factor=1.0, total_iters=warmup_steps)
+        schedulers.append(warmup_scheduler)
+        milestones.append(warmup_steps)
+
+    assert max_steps is not None, "max_steps must be specified when specifying decay_steps"
+    decay_start_step = max_steps - decay_steps
+    assert decay_start_step >= warmup_steps
+    cosine_scheduler = CosineAnnealingLR(optimizer, T_max=decay_steps, eta_min=min_lr)
+    schedulers.append(cosine_scheduler)
+    milestones.append(decay_start_step)
+
+    # Return single scheduler if only one phase, otherwise combine with SequentialLR
+    if len(schedulers) == 1:
+        return schedulers[0]
+
+    return SequentialLR(optimizer, schedulers, milestones=milestones)
+
+
+def setup_scheduler(
+    optimizer: Optimizer,
+    scheduler_config: SchedulerConfigType,
+    max_steps: int | None,
+    lr: float,
+) -> LRScheduler:
+    """Create learning rate scheduler based on config."""
+    match scheduler_config.type:
+        case "constant":
+            return setup_constant_scheduler(optimizer)
+        case "linear":
+            return setup_linear_scheduler(
+                optimizer,
+                max_steps=max_steps,
+                warmup_steps=scheduler_config.warmup_steps,
+                decay_steps=scheduler_config.decay_steps,
+                lr=lr,
+                min_lr=scheduler_config.min_lr,
+            )
+        case "cosine":
+            return setup_cosine_scheduler(
+                optimizer,
+                max_steps=max_steps,
+                warmup_steps=scheduler_config.warmup_steps,
+                decay_steps=scheduler_config.decay_steps,
+                lr=lr,
+                min_lr=scheduler_config.min_lr,
+            )
+        case _:
+            raise ValueError(f"Invalid scheduler type: {scheduler_config.type}")

--- a/src/prime_rl/trainer/sft/config.py
+++ b/src/prime_rl/trainer/sft/config.py
@@ -133,33 +133,6 @@ class SFTTrainerConfig(BaseSettings):
         return self
 
     @model_validator(mode="after")
-    def validate_scheduler(self):
-        # Constant scheduler does not require any validation/ setup
-        if self.scheduler.type == "constant":
-            return self
-
-        # Must specify max_steps when using a scheduler other than `constant`
-        if self.max_steps is None:
-            raise ValueError("Must specify max_steps when using a scheduler other than `constant`")
-
-        # If decay_steps is not specified, use remaining steps after warmup
-        if self.scheduler.decay_steps is None:
-            if not (self.scheduler.warmup_steps <= self.max_steps):
-                raise ValueError("config.scheduler.warmup_steps must be less than or equal to config.max_steps")
-
-            self.scheduler.decay_steps = self.max_steps - self.scheduler.warmup_steps
-            assert self.scheduler.decay_steps >= 0, "config.scheduler.decay_steps must be positive"
-
-        # If decay_steps is specified, validate it
-        else:
-            if not (self.scheduler.warmup_steps + self.scheduler.decay_steps <= self.max_steps):
-                raise ValueError(
-                    "config.scheduler.warmup_steps + config.scheduler.decay_steps must be less than or equal to config.max_steps"
-                )
-
-        return self
-
-    @model_validator(mode="after")
     def disable_logging_wandb_samples(self):
         if self.wandb and self.wandb.log_extras:
             self.wandb.log_extras.samples = False

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -234,6 +234,7 @@ def train(config: SFTTrainerConfig):
         optimizer.zero_grad()
 
         # Update learning rate scheduler
+        current_lr = optimizer.param_groups[0]["lr"]
         scheduler.step()
 
         forward_backward_time = time.time() - forward_backward_start_time
@@ -257,7 +258,6 @@ def train(config: SFTTrainerConfig):
 
         # Log step metrics
         step_time = time.time() - step_start_time
-        current_lr = optimizer.param_groups[0]["lr"]
         step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {batch_loss.item():.4f} | Grad. Norm: {grad_norm:.4f} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}% | Peak Mem.: {peak_memory:.1f}/{max_memory:.1f} GiB ({peak_memory / max_memory * 100:.1f}%)"
         if is_tt_moe_model(model) and max_vio is not None:
             step_message += f" | Max Vio: {batch_max_vio.item():.4f}"

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -74,7 +74,7 @@ def train(config: SFTTrainerConfig):
     optimizer = setup_optimizer(config.optim, model, parallel_dims.world_mesh["dp_shard_cp"])
 
     # Set up the learning rate scheduler
-    scheduler = setup_scheduler(optimizer, config.scheduler, config.max_steps)
+    scheduler = setup_scheduler(optimizer, config.scheduler, config.max_steps, config.optim.lr)
     logger.info(f"Using `{config.scheduler.type}` scheduler ({config.scheduler})")
 
     # Set up the checkpoint manager


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Refactors the setup of LR schedulers a little bit with the main intention to support WSD without cooldown with infinite training. Also fixes a reporting issue where we call `scheduler.step()` before logging the current learning rate (i.e. we report the LR one step off). Also fixes a bug from before when `max_steps == warmup_steps`.

Check the schedules on [W&B](https://wandb.ai/primeintellect/mika/workspace?nw=0rkxwwyka9es).

<img width="319" height="231" alt="Screenshot 2025-09-22 at 11 38 50 PM" src="https://github.com/user-attachments/assets/9b731d18-7dc3-4f0a-9bb9-198059bd01c0" />

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: #968, #985
**Linear Issue**: Resolves PRIMERL-121, PRIMERL-129