### PR TITLE
Decouple full and weight-only checkpoint on SFT trainer

### DIFF
--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -118,7 +118,7 @@ class ModelConfig(BaseConfig):
             description="The dtype to use for the model optimization.",
         ),
     ] = "float32"
-    
+
     reduce_dtype: Annotated[
         Literal["bfloat16", "float32"],
         Field(
@@ -218,7 +218,7 @@ class CheckpointConfig(BaseConfig):
         int | None,
         Field(
             ge=1,
-            description="Interval at which to save the checkpoint. If None, will only checkpoint at the end of training.",
+            description="Interval at which to save the training checkpoint. If None, will only checkpoint at the end of training.",
         ),
     ] = None
 
@@ -246,13 +246,13 @@ class WeightCheckpointConfig(BaseConfig):
         int | None,
         Field(
             ge=1,
-            description="Interval at which to save the weights. If None, will only keep necessary weight checkpoints for resuming training.",
+            description="Interval at which to save weight checkpoint. If None, will save all necessary weight checkpoints on RL trainer and only final weight checkpoint on SFT trainer.",
         ),
     ] = None
 
     save_async: Annotated[
         bool,
         Field(
-            description="Whether to save the weights asynchronously.",
+            description="Whether to save the weight checkpoint asynchronously.",
         ),
     ] = True

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -93,10 +93,12 @@ def train(config: RLTrainerConfig):
     scheduler = setup_scheduler(optimizer, config.scheduler, config.max_steps, config.optim.lr)
     logger.info(f"Using `{config.scheduler.type}` scheduler ({config.scheduler})")
 
-    # Get checkpoint managers
+    # Set up weight checkpoint manager
     logger.info(f"Initializing weight checkpoint manager ({config.weights})")
     weight_ckpt_manager = setup_weight_ckpt_manager(config.output_dir, config.weights, config.ckpt, config.async_level)
+    assert weight_ckpt_manager is not None, "Weight checkpoint manager must be set on RL trainer"
 
+    # Set up checkpoint manager
     logger.info(f"Initializing checkpoint manager ({config.ckpt})")
     ckpt_manager = setup_ckpt_manager(config.output_dir, config.ckpt)
 

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -77,13 +77,13 @@ def train(config: SFTTrainerConfig):
     scheduler = setup_scheduler(optimizer, config.scheduler, config.max_steps, config.optim.lr)
     logger.info(f"Using `{config.scheduler.type}` scheduler ({config.scheduler})")
 
-    # Set up the checkpoint manager
-    logger.info(f"Initializing checkpoint manager ({config.ckpt})")
-    ckpt_manager = setup_ckpt_manager(config.output_dir, config.ckpt)
-
-    # Set up the weight checkpoint manager
+    # Set up weight checkpoint manager
     logger.info(f"Initializing weight checkpoint manager ({config.weights})")
     weight_ckpt_manager = setup_weight_ckpt_manager(config.output_dir, config.weights, config.ckpt, async_level=0)
+
+    # Set up checkpoint manager
+    logger.info(f"Initializing checkpoint manager ({config.ckpt})")
+    ckpt_manager = setup_ckpt_manager(config.output_dir, config.ckpt)
     assert ckpt_manager is None or (ckpt_manager is not None and weight_ckpt_manager is not None), (
         "If ckpt_manager is set, weight_ckpt_manager must also be set"
     )
@@ -125,9 +125,22 @@ def train(config: SFTTrainerConfig):
     while True:
         # Reset peak memory stats
         torch.cuda.reset_peak_memory_stats()
+        is_last_step = config.max_steps is not None and progress.step == config.max_steps
+
+        # Save the weight checkpoint (if we are at an interval step and not at the first or last step)
+        save_weights_time = 0
+        if (
+            weight_ckpt_manager is not None
+            and (config.weights and config.weights.interval)
+            and not (is_first_step or is_last_step)
+            and progress.step % config.weights.interval == 0
+        ):
+            logger.info(f"Saving weight checkpoint at step {progress.step}")
+            save_weights_start_time = time.time()
+            weight_ckpt_manager.save(model, tokenizer, step=progress.step)
+            save_weights_time = time.time() - save_weights_start_time
 
         # Save the full checkpoint (if we are at an interval step and not at the first or last step)
-        is_last_step = config.max_steps is not None and progress.step == config.max_steps
         save_ckpt_time = 0
         if (
             ckpt_manager is not None
@@ -144,19 +157,6 @@ def train(config: SFTTrainerConfig):
 
             # Maybe clean up old trainer checkpoints
             ckpt_manager.maybe_clean()
-
-        # Save the weight checkpoint (if we are at an interval step and not at the first or last step)
-        save_weights_time = 0
-        if (
-            weight_ckpt_manager is not None
-            and (config.weights and config.weights.interval)
-            and not (is_first_step or is_last_step)
-            and progress.step % config.weights.interval == 0
-        ):
-            logger.info(f"Saving weight checkpoint at step {progress.step}")
-            save_weights_start_time = time.time()
-            weight_ckpt_manager.save(model, tokenizer, step=progress.step)
-            save_weights_time = time.time() - save_weights_start_time
 
         # Break if we have reached the maximum number of steps
         if config.max_steps is not None and progress.step >= config.max_steps:

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -140,11 +140,23 @@ def train(config: SFTTrainerConfig):
             logger.info(f"Saving checkpoint at step {progress.step}")
             save_ckpt_start_time = time.time()
             ckpt_manager.save(model, [optimizer], scheduler, progress, step=progress.step, dataloader=dataloader)
-            weight_ckpt_manager.save(model, tokenizer, step=progress.step)
             save_ckpt_time = time.time() - save_ckpt_start_time
 
             # Maybe clean up old trainer checkpoints
             ckpt_manager.maybe_clean()
+
+        # Save the weight checkpoint (if we are at an interval step and not at the first or last step)
+        save_weights_time = 0
+        if (
+            weight_ckpt_manager is not None
+            and (config.weights and config.weights.interval)
+            and not (is_first_step or is_last_step)
+            and progress.step % config.weights.interval == 0
+        ):
+            logger.info(f"Saving weight checkpoint at step {progress.step}")
+            save_weights_start_time = time.time()
+            weight_ckpt_manager.save(model, tokenizer, step=progress.step)
+            save_weights_time = time.time() - save_weights_start_time
 
         # Break if we have reached the maximum number of steps
         if config.max_steps is not None and progress.step >= config.max_steps:
@@ -300,6 +312,7 @@ def train(config: SFTTrainerConfig):
         time_metrics = {
             "time/step": step_time,
             "time/save_ckpt": save_ckpt_time,
+            "time/save_weights": save_weights_time,
             "time/forward_backward": forward_backward_time,
             "step": progress.step,
         }
@@ -326,11 +339,15 @@ def train(config: SFTTrainerConfig):
     # Log final (immutable) distributions to W&B table
     monitor.log_final_distributions()
 
+    # Write final weight checkpoint
+    if weight_ckpt_manager is not None:
+        logger.info("Writing final weight checkpoint")
+        weight_ckpt_manager.save(model, tokenizer, step=progress.step)
+
     # Write final checkpoint
-    if config.ckpt and ckpt_manager is not None and weight_ckpt_manager is not None:
+    if ckpt_manager is not None:
         logger.info("Writing final checkpoint")
         ckpt_manager.save(model, [optimizer], scheduler, progress, step=progress.step, dataloader=dataloader)
-        weight_ckpt_manager.save(model, tokenizer, step=progress.step)
         ckpt_manager.maybe_clean()
 
     logger.info(f"Peak memory: {max(to_col_format(monitor.history)['perf/peak_memory']):.1f} GiB")

--- a/src/prime_rl/trainer/weights.py
+++ b/src/prime_rl/trainer/weights.py
@@ -217,8 +217,10 @@ class WeightCheckpointManager:
 
 def setup_weight_ckpt_manager(
     output_dir: Path,
-    weight_ckpt_config: WeightCheckpointConfig,
+    weight_ckpt_config: WeightCheckpointConfig | None,
     ckpt_config: CheckpointConfig | None,
     async_level: int,
-) -> WeightCheckpointManager:
+) -> WeightCheckpointManager | None:
+    if weight_ckpt_config is None:
+        return None
     return WeightCheckpointManager(output_dir, weight_ckpt_config, ckpt_config, async_level=async_level)


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Previously, we wouldn't have the option to save weight-only checkpoints at a higher frequency than the full checkpoint which is kind of annoying because one probably wants to save more weight checkpoints for evals than full checkpoints for recovery (especially since weight-checkpoints are some oom smaller than the full checkpoints). This PR enables this on the SFT trainer. The RL trainer already supported this.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: #963 
**Linear Issue**: Resolves PRIMERL-119