### PR TITLE
fix graph break moe

### DIFF
--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -191,6 +191,7 @@ def apply_ac(model: nn.Module, ac_config: ActivationCheckpointConfig):
 
 
 def apply_compile(model: nn.Module, compile_config: CompileConfig):
+    torch._dynamo.config.capture_scalar_outputs = True
     for layer_id in range(len(model.model.layers)):
         # Doing it in-place avoids mangled fqn which can break checkpoint loading
         model.model.layers[layer_id].compile(fullgraph=compile_config.fullgraph)


### PR DESCRIPTION
This pr avoid graph break when using moe

command
```
uv run torchrun --local-ranks-filter 0 --nproc_per_node=2 src/prime_rl/trainer/sft/train.py @ configs/debug/moe/sft/train.toml --model.compile
```

before 

```
02:40:47    INFO Initializing optimizer (lr=1e-06 weight_decay=0.01 max_norm=1.0 type='adamw' betas1=0.9 betas2=0.999)
02:40:47    INFO Using `constant` scheduler (type='constant')
02:40:47    INFO Initializing weight checkpoint manager (None)
02:40:47    INFO Initializing checkpoint manager (None)
02:40:47    INFO Initializing data (micro_batch_size=8 batch_size=16 seq_len=128 num_examples=None pack_function='cat' type='fake' length='fixed' input_ids='increasing')
02:40:47    INFO Starting from step 0 (total_tokens=0, total_samples=0, dataloader_state={'step': 0, 'epoch': 0})
02:40:47    INFO Starting training loop (config.max_steps=5)
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2] Backend compiler exception
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]   Explanation: Backend compiler `inductor` failed with aten._local_scalar_dense.default
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2] 
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]     While executing %item : [num_users=2] = call_method[target=item](args = (%getitem,), kwargs = {})
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]     GraphModule: class GraphModule(torch.nn.Module):
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]         def forward(self, L_num_tokens_per_expert_: "i32[8][1]"):
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             l_num_tokens_per_expert_ = L_num_tokens_per_expert_
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]         
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]              # File: /home/samsja/workspace/pi/prime-rl/src/prime_rl/trainer/custom_models/layers/moe.py:76 in _run_experts_for_loop, code: num_tokens_per_expert = num_tokens_per_expert.tolist()
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             getitem = l_num_tokens_per_expert_[0]
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             item: "Sym(u0)" = getitem.item();  getitem = None
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             getitem_1 = l_num_tokens_per_expert_[1]
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             item_1: "Sym(u1)" = getitem_1.item();  getitem_1 = None
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             getitem_2 = l_num_tokens_per_expert_[2]
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             item_2: "Sym(u2)" = getitem_2.item();  getitem_2 = None
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             getitem_3 = l_num_tokens_per_expert_[3]
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             item_3: "Sym(u3)" = getitem_3.item();  getitem_3 = None
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             getitem_4 = l_num_tokens_per_expert_[4]
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             item_4: "Sym(u4)" = getitem_4.item();  getitem_4 = None
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             getitem_5 = l_num_tokens_per_expert_[5]
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             item_5: "Sym(u5)" = getitem_5.item();  getitem_5 = None
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             getitem_6 = l_num_tokens_per_expert_[6]
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             item_6: "Sym(u6)" = getitem_6.item();  getitem_6 = None
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             getitem_7 = l_num_tokens_per_expert_[7];  l_num_tokens_per_expert_ = None
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             item_7: "Sym(u7)" = getitem_7.item();  getitem_7 = None
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]         
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]              # File: /home/samsja/workspace/pi/prime-rl/src/prime_rl/trainer/custom_models/layers/moe.py:79 in _run_experts_for_loop, code: num_padding = x.shape[0] - sum(num_tokens_per_expert)
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             sym_sum: "Sym(u0 + u1 + u2 + u3 + u4 + u5 + u6 + u7)" = torch.sym_sum((item, item_1, item_2, item_3, item_4, item_5, item_6, item_7))
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             sub: "Sym(-u0 - u1 - u2 - u3 - u4 - u5 - u6 - u7 + 4160)" = 4160 - sym_sum;  sym_sum = None
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             return (item, item_1, item_2, item_3, item_4, item_5, item_6, item_7, sub)
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]         
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2] 
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]     Original traceback:
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]       File "/home/samsja/workspace/pi/prime-rl/src/prime_rl/trainer/custom_models/layers/moe.py", line 76, in _run_experts_for_loop
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]         num_tokens_per_expert = num_tokens_per_expert.tolist()
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]     . Adding a graph break.
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]   Hint: Report an issue to the backend compiler repo.
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2] 
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]   Developer debug context: Backend: inductor
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]     Exception:aten._local_scalar_dense.default
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2] 
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]     While executing %item : [num_users=2] = call_method[target=item](args = (%getitem,), kwargs = {})
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]     GraphModule: class GraphModule(torch.nn.Module):
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]         def forward(self, L_num_tokens_per_expert_: "i32[8][1]"):
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             l_num_tokens_per_expert_ = L_num_tokens_per_expert_
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]         
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]              # File: /home/samsja/workspace/pi/prime-rl/src/prime_rl/trainer/custom_models/layers/moe.py:76 in _run_experts_for_loop, code: num_tokens_per_expert = num_tokens_per_expert.tolist()
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             getitem = l_num_tokens_per_expert_[0]
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             item: "Sym(u0)" = getitem.item();  getitem = None
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             getitem_1 = l_num_tokens_per_expert_[1]
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             item_1: "Sym(u1)" = getitem_1.item();  getitem_1 = None
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             getitem_2 = l_num_tokens_per_expert_[2]
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             item_2: "Sym(u2)" = getitem_2.item();  getitem_2 = None
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             getitem_3 = l_num_tokens_per_expert_[3]
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             item_3: "Sym(u3)" = getitem_3.item();  getitem_3 = None
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             getitem_4 = l_num_tokens_per_expert_[4]
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             item_4: "Sym(u4)" = getitem_4.item();  getitem_4 = None
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             getitem_5 = l_num_tokens_per_expert_[5]
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             item_5: "Sym(u5)" = getitem_5.item();  getitem_5 = None
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             getitem_6 = l_num_tokens_per_expert_[6]
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             item_6: "Sym(u6)" = getitem_6.item();  getitem_6 = None
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             getitem_7 = l_num_tokens_per_expert_[7];  l_num_tokens_per_expert_ = None
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             item_7: "Sym(u7)" = getitem_7.item();  getitem_7 = None
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]         
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]              # File: /home/samsja/workspace/pi/prime-rl/src/prime_rl/trainer/custom_models/layers/moe.py:79 in _run_experts_for_loop, code: num_padding = x.shape[0] - sum(num_tokens_per_expert)
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             sym_sum: "Sym(u0 + u1 + u2 + u3 + u4 + u5 + u6 + u7)" = torch.sym_sum((item, item_1, item_2, item_3, item_4, item_5, item_6, item_7))
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             sub: "Sym(-u0 - u1 - u2 - u3 - u4 - u5 - u6 - u7 + 4160)" = 4160 - sym_sum;  sym_sum = None
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]             return (item, item_1, item_2, item_3, item_4, item_5, item_6, item_7, sub)
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]         
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2] 
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]     Original traceback:
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]       File "/home/samsja/workspace/pi/prime-rl/src/prime_rl/trainer/custom_models/layers/moe.py", line 76, in _run_experts_for_loop
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]         num_tokens_per_expert = num_tokens_per_expert.tolist()
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2] 
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]     Traceback:
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]       File "/home/samsja/workspace/pi/prime-rl/src/prime_rl/trainer/custom_models/layers/moe.py", line 83, in _run_experts_for_loop
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2]         x = torch.split(
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2] 
[rank0]:W0924 02:40:50.243000 546904 torch/_dynamo/exc.py:525] [5/0_2] 
02:40:52 WARNING Peak FLOPS undefined for `NVIDIA GeForce RTX 3090`. Falling back to A100 (312 TFLOPS)
02:40:52 SUCCESS Step 0 | Time: 5.13s | Loss: 12.2500 | Grad. Norm: 28.2032 | LR: 1.00e-06 | Throughput: 0 tokens/s | MFU: 0.0% | Peak Mem.: 5.1/23.7 GiB (21.4%) | Max Vio: 1.0000
02:40:53 SUCCESS Step 1 | Time: 0.60s | Loss: 12.3125 | Grad. Norm: 28.4812 | LR: 1.00e-06 | Throughput: 3324 tokens/s | MFU: 1.0% | Peak Mem.: 5.2/23.7 GiB (22.1%) | Max Vio: 0.9891
02:40:53 SUCCESS Step 2 | Time: 0.35s | Loss: 12.4375 | Grad. Norm: 25.8257 | LR: 1.00e-06 | Throughput: 4175 tokens/s | MFU: 1.2% | Peak Mem.: 5.2/23.7 GiB (22.1%) | Max Vio: 1.0000
02:40:54 SUCCESS Step 3 | Time: 0.36s | Loss: 12.2188 | Grad. Norm: 25.4577 | LR: 1.00e-06 | Throughput: 4547 tokens/s | MFU: 1.3% | Peak Mem.: 5.2/23.7 GiB (22.1%) | Max Vio: 1.0000
02:40:54 SUCCESS Step 4 | Time: 0.36s | Loss: 12.2812 | Grad. Norm: 27.4523 | LR: 1.00e-06 | Throughput: 4771 tokens/s | MFU: 1.4% | Peak Mem.: 5.2/23.7 GiB (22.1%) | Max Vio: 1.0000
02:40:54    INFO Peak memory: 5.2 GiB
02:40:54 SUCCESS SFT trainer finished!
```


after


```
02:35:34 SUCCESS Step 4 | Time: 0.35s | Loss: 12.3125 | Grad. Norm: 27.4481 | LR: 1.00e-06 | Throughput: 4737 tokens/s | MFU: 1.4% | Peak Mem.: 5.2/23.7 GiB (22.1%) | Max Vio: 1.0000
02:35:34    INFO Peak memory: 5.2 GiB
02:35:34 SUCCESS SFT trainer finished!
```