### PR TITLE
Do not sync SFT MoE debug run to W&B

### DIFF
--- a/tests/integration/test_sft.py
+++ b/tests/integration/test_sft.py
@@ -33,7 +33,7 @@ def wandb_project(username: str) -> str:
 
 @pytest.fixture(scope="module")
 def sft_process(
-    run_process: Callable[[Command, Environment], ProcessResult],
+    run_process: Callable[[Command, Environment, int], ProcessResult],
     output_dir: Path,
     wandb_project: str,
     branch_name: str,
@@ -85,6 +85,7 @@ def sft_resume_process(
 SFT_CMD_MOE = ["uv", "run", "sft", "@", "configs/debug/moe/sft/train.toml"]
 
 
+@pytest.fixture
 def sft_moe_process(
     run_process: Callable[[Command, Environment, int], ProcessResult],
     output_dir: Path,

--- a/tests/integration/test_sft.py
+++ b/tests/integration/test_sft.py
@@ -82,6 +82,24 @@ def sft_resume_process(
     )
 
 
+SFT_CMD_MOE = ["uv", "run", "sft", "@", "configs/debug/moe/sft/train.toml"]
+
+
+def sft_moe_process(
+    run_process: Callable[[Command, Environment, int], ProcessResult],
+    output_dir: Path,
+) -> ProcessResult:
+    return run_process(
+        SFT_CMD_MOE
+        + [
+            "--output-dir",
+            output_dir.as_posix(),
+        ],
+        ENV,
+        TIMEOUT,
+    )
+
+
 def test_no_error(sft_process: ProcessResult):
     assert sft_process.returncode == 0, f"SFT process failed with return code {sft_process.returncode}"
 
@@ -92,31 +110,5 @@ def test_no_error_resume(sft_resume_process: ProcessResult):
     )
 
 
-SFT_CMD_MOE = ["uv", "run", "sft", "@", "configs/debug/moe/sft/train.toml"]
-
-
-def test_sft_moe(
-    run_process: Callable[[Command, Environment], ProcessResult],
-    output_dir: Path,
-    wandb_project: str,
-    branch_name: str,
-    commit_hash: str,
-) -> ProcessResult:
-    wandb_name = f"{branch_name}-{commit_hash}"
-
-    assert (
-        run_process(
-            SFT_CMD_MOE
-            + [
-                "--wandb.project",
-                wandb_project,
-                "--wandb.name",
-                wandb_name,
-                "--output-dir",
-                output_dir.as_posix(),
-            ],
-            ENV,
-            TIMEOUT,
-        ).returncode
-        == 0
-    ), f"SFT  mpeprocess failed with return code {sft_process.returncode}"
+def test_no_error_moe(sft_moe_process: ProcessResult):
+    assert sft_moe_process.returncode == 0, f"SFT MOE process failed with return code {sft_moe_process.returncode}"


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

As advertised. On current main we also log the MoE SFT which is running on fake data to W&B, which is unncessary.

<img width="367" height="250" alt="Screenshot 2025-09-24 at 12 58 30 PM" src="https://github.com/user-attachments/assets/f6cde582-d537-4c5f-8632-00f1fd72c1e2" />

<img width="376" height="238" alt="Screenshot 2025-09-24 at 12 59 06 PM" src="https://github.com/user-attachments/assets/584ae3ad-dc14-425b-a300-2f1ba2195270" />


---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: #993 
**Linear Issue**: Resolves PRIMERL-131