### PR TITLE
Use add_column instead of map to add SFT dataset indices

### DIFF
--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 from collections import defaultdict
 from typing import Iterator, TypedDict, cast
 
@@ -118,7 +119,7 @@ class SFTDataset(StatefulIterableDataset):
         self.tokenizer = tokenizer
 
         # Add dataset index
-        self.dataset = dataset.map(lambda _, index: {"index": index}, with_indices=True)
+        self.dataset = dataset.add_column("index", list(range(len(dataset))), new_fingerprint=str(uuid.uuid4()))
 
         # Assert that the dataset has a 'text' column
         if "prompt" not in self.dataset.column_names or "completion" not in self.dataset.column_names:


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Adding the unshuffled dataset indices using `.map` was too slow for large datasets. This PR changes it to use `.add_column` which should be a lot quicker, see screenshot of a timing comparison on 10K samples

<img width="750" height="497" alt="Screenshot 2025-09-24 at 12 55 55 PM" src="https://github.com/user-attachments/assets/5a542817-3f4e-46f7-96ec-e920e453bceb" />


---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: #1006 
**Linear Issue**: Resolves PRIMERL-135