### PR TITLE
Fix RL logs streaming weirdly to tmux panes

### DIFF
--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -19,6 +19,7 @@ confirm_cleanup() {
     echo "  - **/rollouts"
     echo "  - **/wandb"
     echo "  - **/evals"
+    echo "  - **/evals"
     echo "  - .pydantic_config"
     while true; do
         read -r -p "Proceed? [y/N]: " response
@@ -32,5 +33,5 @@ confirm_cleanup() {
 
 # Remove logs, checkpoints, weights, rollouts, wandb
 confirm_cleanup
-rm -rf **/logs **/checkpoints **/weights **/rollouts **/wandb .pydantic_config
+rm -rf **/logs **/checkpoints **/weights **/rollouts **/wandb **/evals **/torchrun *.pydantic_config
 log_info "Cleaned up!"

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -398,7 +398,6 @@ def rl(config: RLConfig):
     ckpt_dir = get_ckpt_dir(config.output_dir)
     weights_dir = get_weights_dir(config.output_dir)
     rollout_dir = get_rollout_dir(config.output_dir)
-    log_dir.mkdir(parents=True, exist_ok=True)
 
     # Clean up directories if specified
     if config.clean:

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -515,8 +515,6 @@ def rl(config: RLConfig):
             # Pipe all logs to file, and only master rank logs to stdout
             f"--log-dir={config.output_dir / 'torchrun'}",
             "--local-ranks-filter=0",
-            "--redirects=3",
-            "--tee=3",
             f"--nproc-per-node={len(config.trainer_gpu_ids)}",
             "-m",
             "prime_rl.trainer.rl.train",


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

The log configuration on the `torchrun` run from `rl.py` would stream the logs in a very chunked, ugly way, i.e. only refresh every 10s or so. This PR fixes this by taking away the flags that caused it. We still filter console logs for the master trainer rank and forward stdout and stderr to a torchrun log dir so im not even sure why we had these two flags there before.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: #1010 
**Linear Issue**: Resolves PRIMERL-137