### PR TITLE
map any model with supported MoEs to the fast version

### DIFF
--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -7,8 +7,9 @@ from prime_rl.utils.pydantic_config import BaseConfig
 AttnImplementation: TypeAlias = Literal["sdpa", "flash_attention_2"]
 
 MOE_MODEL_MAPS = {
-    "Qwen/Qwen3-30B-A3B": "Jackmin108/Qwen3-30B-A3B-Fast",
-    "moonshotai/Moonlight-16B-A3B-Instruct": "Jackmin108/Moonlight-16B-A3B-Instruct-Fast",
+    "Qwen3-30B-A3B": "Jackmin108/Qwen3-30B-A3B-Fast",
+    "Qwen3-30B-A3B-Base": "Jackmin108/Qwen3-30B-A3B-Fast",
+    "Moonlight-16B-A3B-Instruct": "Jackmin108/Moonlight-16B-A3B-Instruct-Fast",
 }
 
 
@@ -159,8 +160,8 @@ class ModelConfig(BaseConfig):
     @model_validator(mode="after")
     def _map_model_name_for_moe(self):
         """Map model name if it exists in MOE_MODEL_MAPS."""
-        if self.name in MOE_MODEL_MAPS:
-            self.name = MOE_MODEL_MAPS[self.name]
+        if self.name.split("/")[-1] in MOE_MODEL_MAPS:
+            self.name = MOE_MODEL_MAPS[self.name.split("/")[-1]]
         return self
 
     @model_validator(mode="after")


### PR DESCRIPTION
This should fix the chat template issue in https://github.com/PrimeIntellect-ai/prime-rl/issues/947