### PR TITLE
Replace clipping with masking, and double sided masking

### DIFF
--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -28,7 +28,7 @@ class LossConfig(BaseModel):
 
     type: Annotated[Literal["gspo", "grpo"], Field(description="Type of loss to use.")] = "grpo"
 
-    clip_ratio: Annotated[float, Field(ge=0)] = 8.0
+    mask_ratio: Annotated[float, Field(ge=0)] = 8.0
 
 
 class FakeDataLoaderConfig(BaseConfig):

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -28,7 +28,8 @@ class LossConfig(BaseModel):
 
     type: Annotated[Literal["gspo", "grpo"], Field(description="Type of loss to use.")] = "grpo"
 
-    mask_ratio: Annotated[float, Field(ge=0)] = 8.0
+    mask_ratio_high: Annotated[float, Field(ge=0)] = 8.0
+    mask_ratio_low: Annotated[float, Field(ge=0)] = 0.0
 
 
 class FakeDataLoaderConfig(BaseConfig):

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -96,9 +96,12 @@ def compute_loss(
             log_importance_ratio = torch.clamp(log_importance_ratio, max=10.0)
 
         importance_ratio = torch.exp(log_importance_ratio)
-        masked_importance_ratio = importance_ratio * (importance_ratio <= loss_config.mask_ratio).float()
+        keep_mask = (importance_ratio >= loss_config.mask_ratio_low) & (
+            importance_ratio <= loss_config.mask_ratio_high
+        )
+        masked_importance_ratio = importance_ratio * keep_mask.float()
         loss = -masked_importance_ratio * advantages
-        is_masked = (importance_ratio > loss_config.mask_ratio).float()
+        is_masked = (~keep_mask).float()
 
         # Apply loss mask and sum
         loss = (loss[loss_mask]).sum()

--- a/tests/unit/train/rl/test_loss.py
+++ b/tests/unit/train/rl/test_loss.py
@@ -18,7 +18,7 @@ def test_grpo_loss():
         old_logprobs,
         advantages,
         loss_mask=loss_mask,
-        loss_config=LossConfig(type="grpo", clip_ratio=10.0),
+        loss_config=LossConfig(type="grpo", mask_ratio=10.0),
         loss_scale=1.0,
     )
     assert loss.shape == ()
@@ -36,7 +36,7 @@ def test_gspo_loss():
         old_logprobs,
         advantages,
         loss_mask=loss_mask,
-        loss_config=LossConfig(type="gspo", clip_ratio=10.0),
+        loss_config=LossConfig(type="gspo", mask_ratio=10.0),
         loss_scale=1.0,
     )
     assert loss.shape == ()

--- a/tests/unit/train/rl/test_loss.py
+++ b/tests/unit/train/rl/test_loss.py
@@ -18,7 +18,7 @@ def test_grpo_loss():
         old_logprobs,
         advantages,
         loss_mask=loss_mask,
-        loss_config=LossConfig(type="grpo", mask_ratio=10.0),
+        loss_config=LossConfig(type="grpo", mask_ratio_high=10.0, mask_ratio_low=0.0),
         loss_scale=1.0,
     )
     assert loss.shape == ()
@@ -36,7 +36,7 @@ def test_gspo_loss():
         old_logprobs,
         advantages,
         loss_mask=loss_mask,
-        loss_config=LossConfig(type="gspo", mask_ratio=10.0),
+        loss_config=LossConfig(type="gspo", mask_ratio_high=10.0, mask_ratio_low=0.0),
         loss_scale=1.0,
     )
     assert loss.shape == ()


### PR DESCRIPTION
Proposed in https://yingru.notion.site/When-Speed-Kills-Stability-Demystifying-RL-Collapse-from-the-Training-Inference-Mismatch-271211a558b7808d8b12d403fd15edda and https://ringtech.notion.site/icepop.
Intuition is that an excessively high ratio signals a trainer inference mismatch which should be treated similar to an error.
Also adds double sided masking where ratios under a certain amount are masked out, intuition again is that the ratio is excessively low because of a mismatch/error so the updates will be noisy