### PR TITLE
Fix distributed dataloader checkpointing

### DIFF
--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -17,6 +17,7 @@ from torchdata.stateful_dataloader import StatefulDataLoader
 from prime_rl.trainer.config import CheckpointConfig
 from prime_rl.trainer.world import get_world
 from prime_rl.utils.logger import get_logger
+from prime_rl.utils.tensor_hashing import get_module_signature, get_optimizer_signature
 from prime_rl.utils.utils import get_ckpt_dir
 
 
@@ -159,6 +160,9 @@ class CheckpointManager:
         if not ckpt_path.exists():
             raise FileNotFoundError(f"Checkpoint not found at {ckpt_path}")
         self._load_from_path(ckpt_path, model, optimizers, scheduler, progress, dataloader)
+        self._logger.debug(
+            f"Signatures after loading training checkpoint: model={get_module_signature(model, compress=True)}, optimizers={', '.join(get_optimizer_signature(optimizer, compress=True) for optimizer in optimizers)}"
+        )
 
     def save(
         self,
@@ -172,6 +176,9 @@ class CheckpointManager:
         """Saves the full checkpoint state for a specified step."""
         ckpt_path = self._get_ckpt_path(step)
         ckpt_path.parent.mkdir(parents=True, exist_ok=True)
+        self._logger.debug(
+            f"Signatures before saving training checkpoint: model={get_module_signature(model, compress=True)}, optimizers={', '.join(get_optimizer_signature(optimizer, compress=True) for optimizer in optimizers)}"
+        )
         self._save_to_path(ckpt_path, step, model, optimizers, scheduler, progress, dataloader)
 
     def maybe_clean(self) -> None:

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -136,7 +136,11 @@ class CheckpointManager:
 
         # Load the dataloader
         # TODO: Is there a way we can make this so one can restart in any world
-        if dataloader is not None:
+        
+        if self.config.skip_dataloader:
+            get_logger().warning("Skipping dataloader checkpointing")
+        
+        if dataloader is not None and not self.config.skip_dataloader:
             dataloader_path = ckpt_path / "dataloader" / f"rank_{self._world.rank}.pt"
             if not dataloader_path.exists():
                 raise RuntimeError(

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -4,6 +4,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
+import torch
 import torch.distributed.checkpoint as dcp
 from torch import nn
 from torch.distributed.checkpoint.state_dict import get_state_dict, set_state_dict
@@ -41,13 +42,11 @@ class AppState(Stateful):
         optimizers: list[Optimizer],
         scheduler: LRScheduler,
         progress: Progress,
-        dataloader: StatefulDataLoader | None = None,
     ):
         self.model = model
         self.optimizers = optimizers
         self.scheduler = scheduler
         self.progress = progress
-        self.dataloader = dataloader
 
     def state_dict(self) -> dict[str, Any]:
         # Automatically manages FSDP FQN's, as well as sets the default state dict type to FSDP.SHARDED_STATE_DICT
@@ -60,8 +59,6 @@ class AppState(Stateful):
             "scheduler": scheduler_state_dict,
             "progress": progress_state_dict,
         }
-        if self.dataloader is not None:
-            state_dict["dataloader"] = self.dataloader.state_dict()
         return state_dict
 
     def load_state_dict(self, state_dict: dict[str, Any]):
@@ -71,9 +68,6 @@ class AppState(Stateful):
         self.scheduler.load_state_dict(state_dict["scheduler"])
         for key, value in state_dict["progress"].items():
             setattr(self.progress, key, value)
-        if self.dataloader is not None:
-            assert "dataloader" in state_dict
-            self.dataloader.load_state_dict(state_dict["dataloader"])
 
 
 class CheckpointManager:
@@ -104,7 +98,13 @@ class CheckpointManager:
         start_time = time.time()
 
         # Create checkpoint state
-        state_dict = {"app": AppState(model, optimizers, scheduler, progress, dataloader)}
+        state_dict = {"app": AppState(model, optimizers, scheduler, progress)}
+
+        # Checkpoint the local dataloader
+        if dataloader is not None:
+            dataloader_dir = ckpt_path / "dataloader"
+            dataloader_dir.mkdir(parents=True, exist_ok=True)
+            torch.save(dataloader.state_dict(), dataloader_dir / f"rank_{self._world.rank}.pt")
 
         # Save sharded state
         dcp.save(state_dict, checkpoint_id=ckpt_path)
@@ -129,9 +129,19 @@ class CheckpointManager:
         start_time = time.time()
 
         # Load sharded state
-        app_state = AppState(model, optimizers, scheduler, progress, dataloader)
+        app_state = AppState(model, optimizers, scheduler, progress)
         state_dict = {"app": app_state}
         dcp.load(state_dict=state_dict, checkpoint_id=ckpt_path)
+
+        # Load the dataloader
+        # TODO: Is there a way we can make this so one can restart in any world
+        if dataloader is not None:
+            dataloader_path = ckpt_path / "dataloader" / f"rank_{self._world.rank}.pt"
+            if not dataloader_path.exists():
+                raise RuntimeError(
+                    f"Did not find local dataloader checkpoint at path {dataloader_path}. This might be because you tried restarting the trainer with a different world size. This is currently not supported."
+                )
+            dataloader.load_state_dict(torch.load(dataloader_path))
 
         self._logger.debug(f"Training checkpoint loaded in {time.time() - start_time:.2f} seconds")
 

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -282,6 +282,13 @@ class CheckpointConfig(BaseConfig):
             description="Keep at most this many recent step checkpoints on disk. If None, never clean old checkpoints.",
         ),
     ] = None
+    
+    skip_dataloader: Annotated[
+        bool,
+        Field(
+            description="Whether to skip checkpointing the dataloader. If True, will not checkpoint the dataloader.",
+        ),
+    ] = False
 
 
 class WeightCheckpointConfig(BaseConfig):

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -158,7 +158,7 @@ class SFTDataset(StatefulIterableDataset):
 
             # Update stored epoch if new epoch is reached, optionall shuffle
             if epoch > self.epoch:
-                dataset = self.dataset.shuffle(seed=self.epoch) if self.config.shuffle else self.dataset
+                dataset = self.dataset.shuffle(seed=epoch) if self.config.shuffle else self.dataset
                 self.epoch = epoch
 
             assert "prompt" in example and "completion" in example, (

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -43,13 +43,11 @@ class StatefulIterableDataset(Stateful, IterableDataset):
         self._setup_world_info()
 
     def state_dict(self) -> dict:
-        # +1 because the stateful dataloader expects uses 1-based counting while we start at 0
-        return {"step": self.step + 1, "epoch": self.epoch}
+        return {"step": self.step, "epoch": self.epoch}
 
     def load_state_dict(self, state_dict: dict):
         assert "step" in state_dict and "epoch" in state_dict
-        # -1 because the stateful dataloader expects uses 1-based counting while we start at 0
-        self.step = state_dict["step"] - 1
+        self.step = state_dict["step"]
         self.epoch = state_dict["epoch"]
 
     def _setup_world_info(self):
@@ -74,8 +72,6 @@ class FakeDataset(StatefulIterableDataset):
 
     def __iter__(self):
         while True:
-            # Increment the step counter (0, 1, 2, ...)
-            # This has to be done before yielding the sample for the dataloader to checkpoint correctly
             self.step += 1
 
             # Skip samples that don't belong to this data rank
@@ -148,8 +144,6 @@ class SFTDataset(StatefulIterableDataset):
         """
         dataset = self.dataset.shuffle(seed=self.epoch) if self.config.shuffle else self.dataset
         while True:
-            # Increment the step counter (0, 1, 2, ...)
-            # This has to be done before yielding the sample for the dataloader to checkpoint correctly
             self.step += 1
 
             # Get example from dataset

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -232,7 +232,7 @@ def train(config: SFTTrainerConfig):
                         batch_max_vio += max_vio / grad_accum_steps
 
             # Debug log with *local, micro step* stats
-            micro_step_message = f"Micro Step {micro_step}/{grad_accum_steps} | Loss: {loss.item():.4f} | Dataloader Step: {dataloader.state_dict()['dataset_state']['step']}"
+            micro_step_message = f"Micro Step {micro_step}/{grad_accum_steps} | Loss: {loss.item():.4f} | Dataloader Step: {dataloader.state_dict()['dataset_state']['dataset']['step']}"
             if is_tt_moe_model(model) and max_vio is not None:
                 micro_step_message += f" | Max Vio: {max_vio.item():.4f}"
             logger.debug(micro_step_message)
@@ -261,7 +261,7 @@ def train(config: SFTTrainerConfig):
         # Compute step metrics
         num_tokens = config.data.batch_size * config.data.seq_len
         progress.total_tokens += num_tokens
-        progress.total_samples = dataloader.state_dict()["dataset_state"]["step"]
+        progress.total_samples = dataloader.state_dict()["dataset_state"]["dataset"]["step"]
         perf_counter = get_perf_counter(model, config.data.seq_len)
         perf_counter.count_tokens(num_tokens)
         throughput = perf_counter.get_tokens_per_second() or 0

--- a/src/prime_rl/utils/tensor_hashing.py
+++ b/src/prime_rl/utils/tensor_hashing.py
@@ -2,14 +2,12 @@ import hashlib
 
 import torch
 from torch.distributed.tensor import DTensor
+from torch.optim.optimizer import Optimizer
 
 TENSOR_SIG_SAMPLE_SIZE = 1000
 
 
 def get_tensor_signature(a: torch.Tensor | torch.nn.Parameter) -> str:
-    """
-    Get the tensor signature
-    """
     while isinstance(a, torch.nn.Parameter):
         a = a.data
 
@@ -29,14 +27,31 @@ def get_tensor_signature(a: torch.Tensor | torch.nn.Parameter) -> str:
     return f"{a.dtype}{a.shape}{a.stride()}<{element_hash}>"
 
 
+def get_signature(state_dict, compress: bool = True) -> str:
+    if compress:
+        return hashlib.md5(str(state_dict).encode("utf-8")).hexdigest()
+    else:
+        return "\n".join(f"{name}: {sig}" for name, sig in state_dict.items())
+
+
+def get_optimizer_signature(optimizer: Optimizer, compress: bool = True) -> str:
+    def unwrap_tensor(state_dict: dict) -> dict:
+        new_dict = {}
+        for key, value in state_dict.items():
+            if isinstance(value, dict):
+                new_dict[key] = unwrap_tensor(value)
+            elif isinstance(value, torch.Tensor):
+                new_dict[key] = get_tensor_signature(value)
+            else:
+                new_dict[key] = str(value)
+        return new_dict
+
+    state_dict_sig = unwrap_tensor(optimizer.state_dict())
+    return get_signature(state_dict_sig, compress)
+
+
 def get_module_signature(module: torch.nn.Module, compress: bool = True) -> str:
-    """
-    Get the module signature
-    """
     param_sig = {name: get_tensor_signature(param) for name, param in module.named_parameters()}
     buffer_sig = {name: get_tensor_signature(buffer) for name, buffer in module.named_buffers()}
     state_dict_sig = {**param_sig, **buffer_sig}
-    if compress:
-        return hashlib.md5(str(state_dict_sig).encode("utf-8")).hexdigest()
-    else:
-        return "\n".join(f"{name}: {sig}" for name, sig in state_dict_sig.items())
+    return get_signature(state_dict_sig, compress)

--- a/tests/unit/train/sft/test_dataloader.py
+++ b/tests/unit/train/sft/test_dataloader.py
@@ -7,8 +7,6 @@ from prime_rl.trainer.sft.config import FakeDataConfig, SFTDataConfig
 from prime_rl.trainer.sft.data import setup_dataloader, setup_dataset
 from prime_rl.trainer.world import reset_world
 
-pytestmark = [pytest.mark.gpu]
-
 
 def test_stateful_dataloader_single_rank():
     # Setup stateful dataloader
@@ -20,16 +18,16 @@ def test_stateful_dataloader_single_rank():
 
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 0
-    assert dataloader.state_dict()["dataset_state"] == {"step": 1, "epoch": 0}
+    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 0, "epoch": 0}}
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 1
-    assert dataloader.state_dict()["dataset_state"] == {"step": 2, "epoch": 0}
+    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 1, "epoch": 0}}
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 2
-    assert dataloader.state_dict()["dataset_state"] == {"step": 3, "epoch": 1}
+    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 2, "epoch": 1}}
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 3
-    assert dataloader.state_dict()["dataset_state"] == {"step": 4, "epoch": 1}
+    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 3, "epoch": 1}}
 
 
 @pytest.mark.parametrize("rank", [0, 1], ids=["rank0", "rank1"])
@@ -50,22 +48,22 @@ def test_stateful_dataloader_multi_rank(rank: int):
 
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 0 + rank
-    assert dataloader.state_dict()["dataset_state"] == {"step": 1 + rank, "epoch": 0}
+    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 0 + rank, "epoch": 0}}
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 2 + rank
-    assert dataloader.state_dict()["dataset_state"] == {"step": 3 + rank, "epoch": 0}
+    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 2 + rank, "epoch": 0}}
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 4 + rank
-    assert dataloader.state_dict()["dataset_state"] == {"step": 5 + rank, "epoch": 0}
+    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 4 + rank, "epoch": 0}}
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 6 + rank
-    assert dataloader.state_dict()["dataset_state"] == {"step": 7 + rank, "epoch": 0}
+    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 6 + rank, "epoch": 0}}
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 8 + rank
-    assert dataloader.state_dict()["dataset_state"] == {"step": 9 + rank, "epoch": 1}
+    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 8 + rank, "epoch": 1}}
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 10 + rank
-    assert dataloader.state_dict()["dataset_state"] == {"step": 11 + rank, "epoch": 1}
+    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 10 + rank, "epoch": 1}}
 
 
 def test_stateful_dataloader_resume_fake():
@@ -84,7 +82,7 @@ def test_stateful_dataloader_resume_fake():
         assert micro_batch["input_ids"].shape == (1, 128)
         assert micro_batch["input_ids"].unique().item() == step
         assert micro_batch["epoch"] == 0
-        assert dataloader.state_dict()["dataset_state"] == {"step": step + 1, "epoch": 0}
+        assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": step, "epoch": 0}}
 
     # Reload dataloader
     state_dict = dataloader.state_dict()
@@ -98,7 +96,7 @@ def test_stateful_dataloader_resume_fake():
         assert micro_batch["input_ids"].shape == (1, 128)
         assert micro_batch["input_ids"].unique().item() == num_examples // 2 + step
         assert micro_batch["epoch"] == 0
-        assert dataloader.state_dict()["dataset_state"] == {"step": num_examples // 2 + step + 1, "epoch": 0}
+        assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": num_examples // 2 + step, "epoch": 0}}
 
     # Reload dataloader
     state_dict = dataloader.state_dict()
@@ -112,7 +110,7 @@ def test_stateful_dataloader_resume_fake():
         assert micro_batch["input_ids"].shape == (1, 128)
         assert micro_batch["input_ids"].unique().item() == num_examples + step
         assert micro_batch["epoch"] == 1
-        assert dataloader.state_dict()["dataset_state"] == {"step": num_examples + step + 1, "epoch": 1}
+        assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": num_examples + step, "epoch": 1}}
 
 
 def test_dataloader_ckpt_with_packing():
@@ -130,7 +128,7 @@ def test_dataloader_ckpt_with_packing():
         step += num_packed_examples
         epoch = (step - 1) // num_examples
         assert micro_batch["input_ids"].shape == (1, 128)
-        assert dataloader.state_dict()["dataset_state"] == {"step": step, "epoch": epoch}
+        assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": step - 1, "epoch": epoch}}
 
 
 SAMPLE_TEMPLATE = """\
@@ -166,7 +164,7 @@ def test_stateful_dataloader_resume_sft():
         assert micro_batch["input_ids"].shape == (1, 19)
         assert tokenizer.decode(micro_batch["input_ids"][0]) == SAMPLE_TEMPLATE.format(idx=step)
         assert micro_batch["epoch"] == 0
-        assert dataloader.state_dict()["dataset_state"] == {"step": step + 1, "epoch": 0}
+        assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": step, "epoch": 0}}
 
     # Reload dataloader
     state_dict = dataloader.state_dict()
@@ -180,7 +178,7 @@ def test_stateful_dataloader_resume_sft():
         assert micro_batch["input_ids"].shape == (1, 19)
         assert tokenizer.decode(micro_batch["input_ids"][0]) == SAMPLE_TEMPLATE.format(idx=num_examples // 2 + step)
         assert micro_batch["epoch"] == 0
-        assert dataloader.state_dict()["dataset_state"] == {"step": num_examples // 2 + step + 1, "epoch": 0}
+        assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": num_examples // 2 + step, "epoch": 0}}
 
     # Reload dataloader
     state_dict = dataloader.state_dict()
@@ -194,4 +192,4 @@ def test_stateful_dataloader_resume_sft():
         assert micro_batch["input_ids"].shape == (1, 19)
         assert tokenizer.decode(micro_batch["input_ids"][0]) == SAMPLE_TEMPLATE.format(idx=step)
         assert micro_batch["epoch"] == 1
-        assert dataloader.state_dict()["dataset_state"] == {"step": num_examples + step + 1, "epoch": 1}
+        assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": num_examples + step, "epoch": 1}}

--- a/tests/unit/train/sft/test_dataloader.py
+++ b/tests/unit/train/sft/test_dataloader.py
@@ -7,6 +7,8 @@ from prime_rl.trainer.sft.config import FakeDataConfig, SFTDataConfig
 from prime_rl.trainer.sft.data import setup_dataloader, setup_dataset
 from prime_rl.trainer.world import reset_world
 
+pytestmark = [pytest.mark.gpu]
+
 
 def test_stateful_dataloader_single_rank():
     # Setup stateful dataloader

--- a/tests/unit/train/sft/test_dataset.py
+++ b/tests/unit/train/sft/test_dataset.py
@@ -21,13 +21,13 @@ def test_fake_dataset_state():
     config = FakeDataConfig(length="fixed", num_examples=2)
     dataset = FakeDataset(tokenizer, config)
     dataiter = iter(dataset)
+    assert dataset.state_dict() == {"step": -1, "epoch": 0}
+    next(dataiter)
     assert dataset.state_dict() == {"step": 0, "epoch": 0}
     next(dataiter)
     assert dataset.state_dict() == {"step": 1, "epoch": 0}
     next(dataiter)
-    assert dataset.state_dict() == {"step": 2, "epoch": 0}
-    next(dataiter)
-    assert dataset.state_dict() == {"step": 3, "epoch": 1}
+    assert dataset.state_dict() == {"step": 2, "epoch": 1}
 
 
 def test_init_sft_dataset():
@@ -156,19 +156,19 @@ def test_sft_dataset_state():
     dataset = cast(Dataset, load_dataset("mikasenghaas/test-sft", split="train"))
     dataset = SFTDataset(dataset, tokenizer, config)
     dataiter = iter(dataset)
-    assert dataset.state_dict() == {"step": 0, "epoch": 0}
+    assert dataset.state_dict() == {"step": -1, "epoch": 0}
 
     # Step 1
     micro_batch = next(dataiter)
     assert tokenizer.decode(micro_batch["input_ids"]) == SAMPLE_TEMPLATE.format(idx=0)
-    assert dataset.state_dict() == {"step": 1, "epoch": 0}
+    assert dataset.state_dict() == {"step": 0, "epoch": 0}
 
     # Step 2
     micro_batch = next(dataiter)
     assert tokenizer.decode(micro_batch["input_ids"]) == SAMPLE_TEMPLATE.format(idx=1)
-    assert dataset.state_dict() == {"step": 2, "epoch": 0}
+    assert dataset.state_dict() == {"step": 1, "epoch": 0}
 
     # Step 3 (next epoch)
     micro_batch = next(dataiter)
     assert tokenizer.decode(micro_batch["input_ids"]) == SAMPLE_TEMPLATE.format(idx=0)
-    assert dataset.state_dict() == {"step": 3, "epoch": 1}
+    assert dataset.state_dict() == {"step": 2, "epoch": 1}


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

This PR fixes an inconsistency in the SFT dataloader checkpointing logic on multi-GPU. The fix is to save the local dataloader checkpoint outside of the DCP to correctly resume the dataloader state.

## Debug Runs

```bash
uv run torchrun --nproc-per-node 2 \
  src/prime_rl/trainer/sft/train.py \
  @ configs/reverse_text/sft/train.toml \
  --no-data.shuffle \
  --log.level debug \
  --ckpt.interval 10 # Change this to `--ckpt.resume-step 10` to restart
```

### Before

Resuming a training on 1 GPU perfectly matches curves, but not on multi-GPU.

<img width="670" height="248" alt="Screenshot 2025-09-29 at 5 03 07 PM" src="https://github.com/user-attachments/assets/3482e9db-83c4-4857-9118-f736cfaa0f5d" />

<img width="669" height="252" alt="Screenshot 2025-09-29 at 5 05 37 PM" src="https://github.com/user-attachments/assets/5d78670a-fb8d-4579-80ff-0091e2d0a921" />

Checking the debug logs, we can understand why. Before checkpointing, we see the the following dataset indices in the last micro batch

```bash
Rank 0: [202, 204, 206, 208, 210, 212, 214, 216, 218, 220, 222] -> Dataloader step 223
Rank 1: [201, 203, 205, 207, 209, 211, 213, 215, 217, 219] -> Dataloader step 220
```

And on the next micro batch after checkpointing, we get the expected indices

```bash
Rank 0: [224, 226, 228, 230, 232, 234, 236, 238, 240, 242, 244]
Rank 1: [221, 223, 225, 227, 229, 231, 233, 235, 237, 239, 241]
```

However, on the resumed run both ranks load the dataloader checkpoint from rank 0, i.e. `dataloader_state={'step': 220, 'epoch': 0}` which leads to the following samples in the first micro upon after restarting

```bash
Rank 0: [*220*, *222*, 224, 226, 228, 230, 232, 234, 236, 238, 240]
Rank 1:  [221, 223, 225, 227, 229, 231, 233, 235, 237, 239, 241]
```

We see that the first two samples of rank 0 are duplicated because a wrong data loader step was loaded. Here it is fairly small offset because all samples in this particular dataset all samples are roughly equal length and we are not deep into the training. However, because different ranks essentially operate on entirely different shards of the data, it is, in theory, possible that the dataloader steps *vastly diverge*. I argue in the discussion why our current sharding and packing strategy does not allow for perfectly deterministic training resumption in dynamic worlds.

## Now

Running the same command as in the previous section but for single and multi-GPU gives matching curves again.

<img width="660" height="250" alt="Screenshot 2025-09-29 at 5 04 15 PM" src="https://github.com/user-attachments/assets/d77c297a-f19a-4a8c-99d5-fef0dab3bd26" />

<img width="665" height="253" alt="Screenshot 2025-09-29 at 5 04 40 PM" src="https://github.com/user-attachments/assets/695c06ec-ee75-4896-ac7d-bbc22e9f88f7" />

## Large Run

```bash
# Full run
uv run torchrun --local-ranks-filter 0 --nproc-per-node 8 \
  src/prime_rl/trainer/sft/train.py \
  --model.name Qwen/Qwen3-0.6B \
  --data.name PrimeIntellect/INTELLECT-3-SFT-10K \
  --data.splits math,code \
  --data.seq-len 16384 \
  --data.batch-size 64 \
  --data.micro-batch-size 1 \
  --data.pack-function cat \
  --log.level debug \
  --max-steps 100 \
  --optim.lr 1e-4 \
  --scheduler.type linear \
  --scheduler.warmup-steps 10 \
  --ckpt.interval 50 # Change this to `--ckpt.resume-step 50` to restart
```

### Before

<img width="663" height="250" alt="Screenshot 2025-09-29 at 5 30 46 PM" src="https://github.com/user-attachments/assets/411fe2cd-48e8-4150-8a20-9e67cda91f21" />

### Now

<img width="662" height="250" alt="Screenshot 2025-09-29 at 4 36 02 PM" src="https://github.com/user-attachments/assets/9db0321f-c45b-4077-8f57-446fd664eb48" />

## Discussion

The current solution comes at the cost of not allowing to restart in dynamic world sizes, i.e. restarting with less GPUs will lead to wrong results and error with more GPUs. In fact, I think its impossible to support both **deterministic restarts** and **dynamic world sizes**, given our current batching + truncation logic. Note, that both the `CatDataset` and `StackDataset`, in one way or the other, assemble rank-specific samples into a batches until they overflow and truncate the overflowing tokens to match the seq len.

Consider this simple minimal example as an example: Let `micro_batch_size=2` and `seq_len=4096` and consider a dataset with $n$ samples $i=0,...,n-1$ where all sample with even indices are 3k tokens long, and all odd indices 1k tokens. We assume no shuffling and the `CatDataset` (wlg):

On a single GPU:
- MB0_0:  [0,1] (sample 0 has 2k tokens and sample 1 has 1k tokens, so no truncation)
- MB1_0: [2,3] (sample 2 has 2k tokens and sample 3 has 1k tokens, so no truncation)

On 2 GPUs:
- MB0_0: [0,2] (sample 0 has 2k tokens and sample 2 has 2k tokens, so sample 2 gets truncated)
- MB0_1: [1,3,5,7] (all samples have 1k tokens length, so no truncation)

On 1 GPU truncation never occurs but on 2 GPUs truncation. The two runs can never have the same loss curves because they do not see the same tokens. This is true even without restarts, so there is really no hope to get exactly matching loss curves in dynamic worlds. 

That said, we may be able to do a "best-effort" approach. If we believe that instabilities upon restart occur because samples are seen twice we could all-reduce the maximum dataloader step across all ranks for checkpointing. This would ensure that we do not see a sample redundantly but comes at the cost the we skip some samples unnecessarily.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: #1036 
**Linear Issue**: Resolves PRIMERL-143