### PR TITLE
[feat] AReaL multi-step rollout

### DIFF
--- a/src/prime_rl/eval/eval.py
+++ b/src/prime_rl/eval/eval.py
@@ -6,6 +6,7 @@ from prime_rl.orchestrator.client import (
     check_has_model,
     check_health,
     reload_weights,
+    setup_admin_client,
     setup_client,
     update_weights,
 )
@@ -39,6 +40,8 @@ async def eval(config: OfflineEvalConfig):
         f"Initializing OpenAI client (base_url={config.client.base_url}, api_key_var={config.client.api_key_var}, server_type={config.client.server_type})"
     )
     client = setup_client(config.client)
+    admin_client = setup_admin_client(config.client)
+
 
     # Check health of the client
     logger.info("Waiting for inference pool to be ready")
@@ -48,7 +51,7 @@ async def eval(config: OfflineEvalConfig):
 
     # Reset weights to base model to allow reusing inference server across runs
     logger.info("Resetting weights to base model")
-    await reload_weights(client)
+    await reload_weights(admin_client)
 
     # Run benchmarks on base model
     if config.eval_base:

--- a/src/prime_rl/orchestrator/buffer.py
+++ b/src/prime_rl/orchestrator/buffer.py
@@ -229,11 +229,11 @@ class SimpleBuffer(Buffer):
         return sampled_problem_ids, sampled_problems
 
     def sample_problem(self) -> tuple[list[int], list[dict]]:
-        sampled_problem_id = random.sample(self.problem_ids, 1)
-        while sampled_problem_id not in self.rollout_buffer:
+        sampled_problem_id = random.sample(self.problem_ids, 1)[0]
+        while sampled_problem_id in self.rollout_buffer:
             with open("rollout_buffer.txt", "a") as f:
                 f.write("disaster averted\n")
-            sampled_problem_id = random.sample(self.problem_ids, 1)
+            sampled_problem_id = random.sample(self.problem_ids, 1)[0]
         sampled_problem = self.problem_buffer[sampled_problem_id]
 
         return [sampled_problem_id], [sampled_problem]

--- a/src/prime_rl/orchestrator/buffer.py
+++ b/src/prime_rl/orchestrator/buffer.py
@@ -228,6 +228,16 @@ class SimpleBuffer(Buffer):
 
         return sampled_problem_ids, sampled_problems
 
+    def sample_problem(self) -> tuple[list[int], list[dict]]:
+        sampled_problem_id = random.sample(self.problem_ids, 1)
+        while sampled_problem_id not in self.rollout_buffer:
+            with open("rollout_buffer.txt", "a") as f:
+                f.write("disaster averted\n")
+            sampled_problem_id = random.sample(self.problem_ids, 1)
+        sampled_problem = self.problem_buffer[sampled_problem_id]
+
+        return [sampled_problem_id], [sampled_problem]
+
     def update(self, rollouts: list[Rollout]):
         # Group rollouts by problem_id
         rollouts_by_problem_id = defaultdict(list)
@@ -240,8 +250,12 @@ class SimpleBuffer(Buffer):
     def sample_rollouts(self, n: int) -> list[Rollout]:
         # Take the first n problems from the rollout buffer
         available_problem_ids = list(self.rollout_buffer.keys())
+        with open("rollout_buffer.txt", "a") as f:
+            _print_dict = {k: len(v) for k, v in self.rollout_buffer.items()}
+            f.write(json.dumps(_print_dict) + "\n")
         assert len(available_problem_ids) == n, (
             "The number of available problems should always be equal to the requested number of problems"
+            f"{len(available_problem_ids)=}, {n=}"
         )
         sampled_problem_ids = available_problem_ids[:n]
         assert len(sampled_problem_ids) == n, (

--- a/src/prime_rl/orchestrator/buffer.py
+++ b/src/prime_rl/orchestrator/buffer.py
@@ -234,6 +234,7 @@ class SimpleBuffer(Buffer):
             with open("rollout_buffer.txt", "a") as f:
                 f.write("disaster averted\n")
             sampled_problem_id = random.sample(self.problem_ids, 1)[0]
+        self.rollout_buffer[sampled_problem_id] = []
         sampled_problem = self.problem_buffer[sampled_problem_id]
 
         return [sampled_problem_id], [sampled_problem]
@@ -249,7 +250,7 @@ class SimpleBuffer(Buffer):
 
     def sample_rollouts(self, n: int) -> list[Rollout]:
         # Take the first n problems from the rollout buffer
-        available_problem_ids = list(self.rollout_buffer.keys())
+        available_problem_ids = [k for k in self.rollout_buffer.keys() if len(self.rollout_buffer[k]) > 0]
         with open("rollout_buffer.txt", "a") as f:
             _print_dict = {k: len(v) for k, v in self.rollout_buffer.items()}
             f.write(json.dumps(_print_dict) + "\n")

--- a/src/prime_rl/orchestrator/client.py
+++ b/src/prime_rl/orchestrator/client.py
@@ -11,6 +11,27 @@ from prime_rl.utils.logger import get_logger
 from prime_rl.utils.utils import get_weight_ckpt_model_path
 
 
+def setup_admin_client(client_config: ClientConfig) -> httpx.AsyncClient:
+    """Create a dedicated admin client for weight update operations.
+
+    Uses a separate connection pool to avoid queueing behind streaming requests.
+    """
+    headers = {}
+    api_key = os.getenv(client_config.api_key_var, "EMPTY")
+    if api_key and api_key != "EMPTY":
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    # Strip /v1 suffix since admin endpoints are at root level
+    base_url = client_config.base_url.rstrip('/').removesuffix('/v1')
+
+    return httpx.AsyncClient(
+        base_url=base_url,
+        limits=httpx.Limits(max_connections=1, max_keepalive_connections=0),
+        headers=headers,
+        timeout=httpx.Timeout(connect=5.0, read=30.0, write=30.0, pool=None),
+    )
+
+
 def setup_client(client_config: ClientConfig) -> AsyncOpenAI:
     # We use a longer request timeout than default, but if more than 20min, we probably need faster inference deployment
     timeout = httpx.Timeout(timeout=client_config.timeout, connect=5.0)
@@ -60,27 +81,30 @@ async def check_has_model(client: AsyncOpenAI, model_name: str) -> None:
     logger.debug(f"Model {model_name} was found in the inference pool")
 
 
-async def update_weights(client: AsyncOpenAI, path: Path, step: int) -> None:
+async def update_weights(admin_client: httpx.AsyncClient, path: Path, step: int) -> None:
     """Make a HTTP post request to the vLLM server to update the weights."""
     logger = get_logger()
-    url = str(client.base_url).strip()[:-4] + "/update_weights"
+    model_path = get_weight_ckpt_model_path(path, step).absolute()
+    logger.debug(f"Sending request to update weights from {model_path}")
     try:
-        model_path = get_weight_ckpt_model_path(path, step).absolute()
-        logger.debug(f"Sending request to {url} to update weights from {model_path}")
-        await client.post(url, cast_to=Response, body={"model_path": model_path.as_posix()})
-    except NotFoundError:
-        logger.warning(f"The route {url} does not exist. Skipping weight update.")
-        return
+        response = await admin_client.post("/update_weights", json={"model_path": model_path.as_posix()})
+        response.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 404:
+            logger.warning("The route /update_weights does not exist. Skipping weight update.")
+            return
+        raise
 
 
-async def reload_weights(client: AsyncOpenAI) -> None:
+async def reload_weights(admin_client: httpx.AsyncClient) -> None:
     """Make a HTTP post request to the vLLM server to reload weights (reset to base model)."""
     logger = get_logger()
-    url = str(client.base_url).strip()[:-4] + "/reload_weights"
+    logger.debug("Sending request to reload weights (reset to base model)")
     try:
-        logger.debug(f"Sending request to {url} to reload weights (reset to base model)")
-        await client.post(url, cast_to=Response, body={})
-    except NotFoundError:
-        logger.warning(f"The route {url} does not exist. Skipping weight reload.")
-        return
-    await client.post(url, cast_to=Response, body={})
+        response = await admin_client.post("/reload_weights", json={})
+        response.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 404:
+            logger.warning("The route /reload_weights does not exist. Skipping weight reload.")
+            return
+        raise

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -27,7 +27,7 @@ from prime_rl.orchestrator.batch import prepare_batch
 from prime_rl.utils.logger import setup_logger
 from prime_rl.orchestrator.advantage import compute_advantages
 from prime_rl.orchestrator.utils import (
-    wait_for_weight_checkpoint,
+    async_wait_for_weight_checkpoint,
     print_benchmark,
     parse_is_truncated_completions,
 )
@@ -115,6 +115,51 @@ async def orchestrate(config: OrchestratorConfig):
     ckpt_step = 0
     last_eval_step = -1
     is_first_step = True
+
+    problems_per_batch = config.batch_size // config.rollouts_per_example
+    MAX_INFLIGHT_PROBLEMS = int(problems_per_batch * 1.5)
+    inflight_tasks: list[asyncio.Task] = []
+    task_to_problem_id: dict[asyncio.Task, int] = {}
+
+    def generate_call():
+        problem_ids, problems = buffer.sample_problems(1)
+
+        # Duplicate problems `rollouts_per_example` times
+        problem_ids = [problem_id for problem_id in problem_ids for _ in range(config.rollouts_per_example)]
+        problems = [problem for problem in problems for _ in range(config.rollouts_per_example)]
+
+        # Prepare inputs for verifiers generation
+        # TODO: Can we use `prime_rl.utils.utils.to_col_format` here?
+        inputs = {
+            "prompt": [problem["prompt"] for problem in problems],
+            "info": [problem.get("info", {}) for problem in problems],
+            "task": [problem.get("task", config.environment.id) for problem in problems],
+            "answer": [problem.get("answer", "") for problem in problems],
+        }
+
+        # Convert SamplingConfig to vLLM OAI sampling args
+        # https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html#extra-parameters_2
+        sampling_args = dict(config.sampling)
+        sampling_args["top_p"] = 1.0
+        sampling_args["logprobs"] = True
+        sampling_args["extra_body"] = {
+            "return_tokens_as_token_ids": True,
+            "top_k": -1,
+            "min_p": 0.0,
+        }
+        sampling_args["extra_body"]["min_tokens"] = sampling_args.pop("min_tokens")
+        sampling_args["extra_body"]["repetition_penalty"] = sampling_args.pop("repetition_penalty")
+
+        # Generate completions + rewards with verifiers
+        logger.info(f"Sending {len(problems)} requests to environments")
+        task = vf_env.a_generate(
+            inputs=inputs,
+            client=client,
+            model=config.model.name,
+            sampling_args=sampling_args,
+        )
+        return problem_ids, task
+
     while True:
         # Save checkpoint (if we are at an interval step and not at the first or last step)
         is_last_step = config.max_steps is not None and progress.step == config.max_steps - 1
@@ -151,7 +196,7 @@ async def orchestrate(config: OrchestratorConfig):
             ckpt_step = progress.step - config.async_level
             logger.info(f"Waiting for weight checkpoint {ckpt_step}")
             wait_for_weight_ckpt_start_time = time.time()
-            wait_for_weight_checkpoint(get_weights_dir(config.output_dir), ckpt_step)
+            await async_wait_for_weight_checkpoint(get_weights_dir(config.output_dir), ckpt_step)
             wait_for_weight_ckpt_time = time.time() - wait_for_weight_ckpt_start_time
             logger.debug(f"Waited {wait_for_weight_ckpt_time:.2f}s for weight checkpoint")
 
@@ -189,47 +234,58 @@ async def orchestrate(config: OrchestratorConfig):
 
         accepted_rollouts: list[Rollout] = []
         problem_requests, completion_requests, calls_to_generate = 0, 0, 0
-        problems_per_batch = config.batch_size // config.rollouts_per_example
         problems_to_sample = problems_per_batch
+
         while True:
-            # Get the batch
-            problem_ids, problems = buffer.sample_problems(problems_to_sample)
-
-            # Duplicate problems `rollouts_per_example` times
-            problem_ids = [problem_id for problem_id in problem_ids for _ in range(config.rollouts_per_example)]
-            problems = [problem for problem in problems for _ in range(config.rollouts_per_example)]
-
-            # Prepare inputs for verifiers generation
-            # TODO: Can we use `prime_rl.utils.utils.to_col_format` here?
-            inputs = {
-                "prompt": [problem["prompt"] for problem in problems],
-                "info": [problem.get("info", {}) for problem in problems],
-                "task": [problem.get("task", config.environment.id) for problem in problems],
-                "answer": [problem.get("answer", "") for problem in problems],
-            }
-
-            # Convert SamplingConfig to vLLM OAI sampling args
-            # https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html#extra-parameters_2
-            sampling_args = dict(config.sampling)
-            sampling_args["top_p"] = 1.0
-            sampling_args["logprobs"] = True
-            sampling_args["extra_body"] = {
-                "return_tokens_as_token_ids": True,
-                "top_k": -1,
-                "min_p": 0.0,
-            }
-            sampling_args["extra_body"]["min_tokens"] = sampling_args.pop("min_tokens")
-            sampling_args["extra_body"]["repetition_penalty"] = sampling_args.pop("repetition_penalty")
-
-            # Generate completions + rewards with verifiers
-            logger.info(f"Sending {len(problems)} requests to environments")
             generate_completions_start_time = time.time()
-            generate_outputs: GenerateOutputs = await vf_env.a_generate(
-                inputs=inputs,
-                client=client,
-                model=config.model.name,
-                sampling_args=sampling_args,
+            while len(inflight_tasks) < MAX_INFLIGHT_PROBLEMS:
+                problem_id, coro = generate_call()
+                task = asyncio.create_task(coro)
+                await asyncio.sleep(0)
+                inflight_tasks.append(task)
+                task_to_problem_id[task] = problem_id
+
+            generate_outputs = GenerateOutputs(
+                prompt=[],
+                completion=[],
+                answer=[],
+                state=[],
+                info=[],
+                task=[],
+                reward=[],
+                metrics={},
             )
+
+            problem_ids = []
+            while len(problem_ids) < config.batch_size:
+                done, _ = await asyncio.wait(inflight_tasks, return_when=asyncio.FIRST_COMPLETED)
+                with open("done.txt", "a") as f:
+                    f.write(f"Done: {len(done)}\n")
+                for task in done:
+                    if len(problem_ids) == config.batch_size:
+                        break
+                    inflight_tasks.remove(task)
+                    problem_ids.extend(task_to_problem_id[task])
+                    del task_to_problem_id[task]
+                    problem_id, coro = generate_call()
+                    new_task = asyncio.create_task(coro)
+                    await asyncio.sleep(0)
+                    inflight_tasks.append(new_task)
+                    task_to_problem_id[new_task] = problem_id
+
+                    _generate_outputs: GenerateOutputs = task.result()
+                    generate_outputs.prompt.extend(_generate_outputs.prompt)
+                    generate_outputs.completion.extend(_generate_outputs.completion)
+                    generate_outputs.answer.extend(_generate_outputs.answer)
+                    generate_outputs.state.extend(_generate_outputs.state)
+                    generate_outputs.info.extend(_generate_outputs.info)
+                    generate_outputs.task.extend(_generate_outputs.task)
+                    generate_outputs.reward.extend(_generate_outputs.reward)
+                    generate_outputs.metrics.update(_generate_outputs.metrics)
+
+            with open("done.txt", "a") as f:
+                f.write(f"Generated {len(problem_ids)} completions\n")
+            logger.info(f"Generated {len(problem_ids)} completions")
             generate_completions_time = time.time() - generate_completions_start_time
             problem_requests += problems_to_sample
             completion_requests += problems_to_sample * config.rollouts_per_example

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -122,7 +122,7 @@ async def orchestrate(config: OrchestratorConfig):
     task_to_problem_id: dict[asyncio.Task, int] = {}
 
     def generate_call():
-        problem_ids, problems = buffer.sample_problems(1)
+        problem_ids, problems = buffer.sample_problem()
 
         # Duplicate problems `rollouts_per_example` times
         problem_ids = [problem_id for problem_id in problem_ids for _ in range(config.rollouts_per_example)]

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -18,8 +18,9 @@ from prime_rl.orchestrator.client import (
     check_has_model,
     check_health,
     reload_weights,
-    update_weights,
+    setup_admin_client,
     setup_client,
+    update_weights,
 )
 from prime_rl.orchestrator.config import OrchestratorConfig
 from prime_rl.orchestrator.buffer import setup_buffer, make_rollouts, Rollout
@@ -64,6 +65,7 @@ async def orchestrate(config: OrchestratorConfig):
         f"Initializing OpenAI client (base_url={config.client.base_url}, api_key_var={config.client.api_key_var}, server_type={config.client.server_type})"
     )
     client = setup_client(config.client)
+    admin_client = setup_admin_client(config.client)
 
     # Load tokenizer
     logger.info(f"Initializing tokenizer for {config.model.name}")
@@ -104,10 +106,10 @@ async def orchestrate(config: OrchestratorConfig):
         logger.info(f"Resuming training from checkpoint step `{config.ckpt.resume_step}`")
         ckpt_manager.load(progress, buffer, step=config.ckpt.resume_step)
         ckpt_step = max(progress.step - config.async_level, 0)
-        await update_weights(client, get_weights_dir(config.output_dir), ckpt_step)
+        await update_weights(admin_client, get_weights_dir(config.output_dir), ckpt_step)
     else:
         logger.info("Training from scratch. Resetting weights to base model")
-        await reload_weights(client)
+        await reload_weights(admin_client)
 
     # Iterate over dataset in batches
     max_steps = config.max_steps or int(1e9)
@@ -203,7 +205,7 @@ async def orchestrate(config: OrchestratorConfig):
             # Update the weights
             logger.info(f"Updating weights to weight checkpoint {ckpt_step}")
             update_weights_start_time = time.time()
-            await update_weights(client, get_weights_dir(config.output_dir), ckpt_step)
+            await update_weights(admin_client, get_weights_dir(config.output_dir), ckpt_step)
             update_weights_time = time.time() - update_weights_start_time
             logger.debug(f"Updated weights in {update_weights_time:.2f}s")
 

--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -9,10 +9,10 @@ from rich.console import Console
 from rich.table import Table
 
 from prime_rl.utils.utils import (
+    async_wait_for_path,
     format_num,
     format_time,
     get_weight_ckpt_model_path,
-    wait_for_path,
 )
 
 
@@ -50,9 +50,9 @@ def parse_is_truncated_completions(responses: list[list[ChatCompletion]]) -> lis
     return all_is_truncated
 
 
-def wait_for_weight_checkpoint(path: Path, step: int, interval: int = 1, log_interval: int = 10) -> None:
+async def async_wait_for_weight_checkpoint(path: Path, step: int, interval: int = 1, log_interval: int = 10) -> None:
     model_path = get_weight_ckpt_model_path(path, step)
-    wait_for_path(model_path, interval, log_interval)
+    await async_wait_for_path(model_path, interval, log_interval)
 
 
 def print_benchmark(history: dict[str, list[Any]]) -> None:

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -7,6 +7,7 @@ from datetime import timedelta
 # ruff: noqa: I001
 
 import torch
+import torch.distributed as dist
 from torch.profiler import profile, ProfilerActivity, record_function
 from loguru import logger
 from prime_rl.trainer.ckpt import Progress, setup_ckpt_manager

--- a/src/prime_rl/utils/utils.py
+++ b/src/prime_rl/utils/utils.py
@@ -1,3 +1,4 @@
+import asyncio
 import functools
 import os
 import time
@@ -127,6 +128,20 @@ def wait_for_path(path: Path, interval: int = 1, log_interval: int = 10) -> None
         if wait_time % log_interval == 0 and wait_time > 0:  # Every log_interval seconds
             logger.debug(f"Waiting for path `{path}` for {wait_time} seconds")
         time.sleep(interval)
+        wait_time += interval
+
+
+async def async_wait_for_path(path: Path, interval: int = 1, log_interval: int = 10) -> None:
+    logger = get_logger()
+    wait_time = 0
+    logger.debug(f"Waiting for path `{path}`")
+    while True:
+        if path.exists():
+            logger.debug(f"Found path `{path}`")
+            break
+        if wait_time % log_interval == 0 and wait_time > 0:  # Every log_interval seconds
+            logger.debug(f"Waiting for path `{path}` for {wait_time} seconds")
+        await asyncio.sleep(interval)
         wait_time += interval
 
 


### PR DESCRIPTION
This implements the idea in https://arxiv.org/abs/2505.24298 to allow long rollouts to span multiple RL steps.

<img width="929" height="260" alt="image" src="https://github.com/user-attachments/assets/edb02fd8-d644-4289-a9c7-9173c124958a" />

The orchestrator keeps a set number of problems inflight and batches rollouts for the trainers once the correct number of inflight problems have been completed.

## KV cache refresh
Its currently unclear in the literature whether or not not KV cache entries should be refreshed when update_model is called.

Without it, no changes need to be made to inference server.

With it, we need to make the scheduler re-prefill all the requests it is holding. Two methods in order of niceness to me, though im not sure which ones works:
1. Pre-empt all requests. Pretend we evicted the sequences by pre-emption, which should make them get prefilled without messing up `prompt_token` `completion_token` separation.
2. Abort sequences and resend. This would require new logic to manage `prompt_token` `completion_token` separation. Otherwise, the abort and resend will make the previous completion tokens go into the prompt tokens for the response.

## Async inflight logic
<details>
<summary> Async PoC</summary>
Below is a small example showcasing the mechanism being used

```python
import asyncio, random

RL_STEP = 0

async def foo(time_taken_seconds: int) -> list[int]:
    global RL_STEP

    ret = []
    for _ in range(time_taken_seconds):
        await asyncio.sleep(1)
        ret.append(RL_STEP)
    print(ret)
    return ret

async def main():
    global RL_STEP
    inflight_generate_calls = []
    max_inflight = 8
    num_problems_per_batch = 4
    results: list[int] = []

    for step in range(10):
        # fill buffer
        while len(inflight_generate_calls) < max_inflight:
            task = asyncio.create_task(foo(random.randint(1, 10)))
            inflight_generate_calls.append(task)

        # drain until we have `wait_for`
        while len(results) < num_problems_per_batch:
            done, _ = await asyncio.wait(inflight_generate_calls, return_when=asyncio.FIRST_COMPLETED)
            for task in done:
                inflight_generate_calls.remove(task)
                new_task = asyncio.create_task(foo(random.randint(1, 10)))
                inflight_generate_calls.append(new_task)

                results.append(task.result())
                # We need to break here to prevent overfilling the batch
                if len(results) == num_problems_per_batch:
                    break


        print(f"Step {step}: (bs={len(results)}) {results}")
        results = []
        RL_STEP += 1

asyncio.run(main())
```

Output

```python
❯ uv run python woof.py 
[0]
[0]
[0, 0]
[0, 0, 0, 0, 0]
[0, 0, 0, 0, 0]
Step 0: (bs=4) [[0], [0], [0, 0], [0, 0, 0, 0, 0]]
[0, 0, 0, 0, 0, 1]
[0, 0, 0, 0, 0, 1]
[1]
Step 1: (bs=4) [[0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 1], [0, 0, 0, 0, 0, 1], [1]]
[0, 0, 0, 0, 0, 1, 1, 2, 2]
[0, 0, 0, 0, 1, 1, 2, 2]
[1, 2, 2]
[0, 0, 0, 0, 0, 1, 1, 2, 2, 2]
[2]
Step 2: (bs=4) [[0, 0, 0, 0, 1, 1, 2, 2], [0, 0, 0, 0, 0, 1, 1, 2, 2], [1, 2, 2], [2]]
[0, 0, 1, 1, 2, 2, 2, 3]
[2, 3, 3]
[2, 3, 3, 3]
Step 3: (bs=4) [[0, 0, 0, 0, 0, 1, 1, 2, 2, 2], [0, 0, 1, 1, 2, 2, 2, 3], [2, 3, 3], [2, 3, 3, 3]]
[1, 1, 2, 2, 2, 3, 3, 3, 4, 4]
[1, 1, 2, 2, 2, 3, 3, 3, 4, 4]
[3, 3, 3, 4, 4, 4]
[2, 2, 2, 3, 3, 3, 4, 4, 4, 4]
Step 4: (bs=4) [[1, 1, 2, 2, 2, 3, 3, 3, 4, 4], [1, 1, 2, 2, 2, 3, 3, 3, 4, 4], [3, 3, 3, 4, 4, 4], [2, 2, 2, 3, 3, 3, 4, 4, 4, 4]]
[3, 3, 4, 4, 4, 4, 5]
[3, 3, 3, 4, 4, 4, 4, 5, 5]
[3, 4, 4, 4, 4, 5, 5]
[4, 5, 5, 5]
[5]
Step 5: (bs=4) [[3, 3, 4, 4, 4, 4, 5], [3, 4, 4, 4, 4, 5, 5], [3, 3, 3, 4, 4, 4, 4, 5, 5], [5]]
[4, 4, 4, 4, 5, 5, 5, 6]
[6]
[5, 5, 5, 6, 6, 6]
Step 6: (bs=4) [[4, 5, 5, 5], [6], [4, 4, 4, 4, 5, 5, 5, 6], [5, 5, 5, 6, 6, 6]]
[4, 4, 5, 5, 5, 6, 6, 6, 7]
[4, 4, 5, 5, 5, 6, 6, 6, 7, 7]
[5, 6, 6, 6, 7, 7, 7, 7]
[5, 5, 6, 6, 6, 7, 7, 7, 7, 7]
Step 7: (bs=4) [[4, 4, 5, 5, 5, 6, 6, 6, 7], [4, 4, 5, 5, 5, 6, 6, 6, 7, 7], [5, 6, 6, 6, 7, 7, 7, 7], [5, 5, 6, 6, 6, 7, 7, 7, 7, 7]]
[6, 6, 6, 7, 7, 7, 7, 7, 8]
[6, 6, 7, 7, 7, 7, 7, 8, 8]
[7, 7, 7, 7, 7, 8, 8]
[6, 6, 7, 7, 7, 7, 7, 8, 8, 8]
[7, 8, 8, 8]
[8]
Step 8: (bs=4) [[6, 6, 6, 7, 7, 7, 7, 7, 8], [6, 6, 7, 7, 7, 7, 7, 8, 8], [7, 7, 7, 7, 7, 8, 8], [7, 8, 8, 8]]
[8, 8, 9]
[7, 7, 7, 7, 8, 8, 8, 9, 9]
Step 9: (bs=4) [[8], [6, 6, 7, 7, 7, 7, 7, 8, 8, 8], [8, 8, 9], [7, 7, 7, 7, 8, 8, 8, 9, 9]]
```

</details>
