### PR TITLE
Implementation of sequence level importance ratio without length normalisation

### DIFF
--- a/src/prime_rl/trainer/custom_models/layers/moe.py
+++ b/src/prime_rl/trainer/custom_models/layers/moe.py
@@ -61,6 +61,7 @@ class FeedForward(nn.Module):
         for linear in (self.w2, self.w3):
             nn.init.trunc_normal_(linear.weight, mean=0.0, std=init_std)
 
+
 class BCFeedForward(nn.Module):
     def __init__(
         self,
@@ -73,7 +74,7 @@ class BCFeedForward(nn.Module):
         self.w3 = nn.Parameter(torch.empty(hidden_dim, dim))
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        #return torch.matmul(self.w2, F.silu(torch.matmul(self.w1, x.T)) * torch.matmul(self.w3, x.T))
+        # return torch.matmul(self.w2, F.silu(torch.matmul(self.w1, x.T)) * torch.matmul(self.w3, x.T))
         return torch.matmul(F.silu(torch.matmul(x, self.w1.T)) * torch.matmul(x, self.w3.T), self.w2.T)
 
     def init_weights(self, init_std: float):

--- a/src/prime_rl/trainer/custom_models/layers/moe.py
+++ b/src/prime_rl/trainer/custom_models/layers/moe.py
@@ -61,7 +61,6 @@ class FeedForward(nn.Module):
         for linear in (self.w2, self.w3):
             nn.init.trunc_normal_(linear.weight, mean=0.0, std=init_std)
 
-
 class BCFeedForward(nn.Module):
     def __init__(
         self,
@@ -74,7 +73,7 @@ class BCFeedForward(nn.Module):
         self.w3 = nn.Parameter(torch.empty(hidden_dim, dim))
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        # return torch.matmul(self.w2, F.silu(torch.matmul(self.w1, x.T)) * torch.matmul(self.w3, x.T))
+        #return torch.matmul(self.w2, F.silu(torch.matmul(self.w1, x.T)) * torch.matmul(self.w3, x.T))
         return torch.matmul(F.silu(torch.matmul(x, self.w1.T)) * torch.matmul(x, self.w3.T), self.w2.T)
 
     def init_weights(self, init_std: float):

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -134,12 +134,13 @@ def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDim
 def load_dcp_from_hf(model: nn.Module, config: ModelConfig):
     from huggingface_hub import snapshot_download
     from torch.distributed.checkpoint import DefaultLoadPlanner, HuggingFaceStorageReader
+
     model.to_empty(device="cuda")
 
     if config.debug.random_init:
         get_logger().warning("Zero initialization model. skipping HF checkpoint loading.")
-        return 
-    
+        return
+
     path_snapshot = snapshot_download(repo_id=config.name, repo_type="model")
     dcp.load(
         model.state_dict(),

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -26,7 +26,8 @@ class LossConfig(BaseModel):
         ),
     ] = "token"
 
-    type: Annotated[Literal["gspo", "grpo", "deepseek_grpo"], Field(description="Type of loss to use.")] = "grpo"
+    ratio_type: Annotated[Literal["sequence", "token"], Field(description="Type of ratio to use.")] = "token"
+    ratio_length_norm: Annotated[bool, Field(description="Whether to normalize the ratio by the length of the sequence.")] = False
 
     clip_ratio: Annotated[float, Field(ge=0)] = 8.0
 

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -26,7 +26,7 @@ class LossConfig(BaseModel):
         ),
     ] = "token"
 
-    ratio_type: Annotated[Literal["sequence", "token"], Field(description="Type of ratio to use.")] = "token"
+    ratio_type: Annotated[Literal["token", "sequence"], Field(description="Type of ratio to use.")] = "token"
     ratio_length_norm: Annotated[bool, Field(description="Whether to normalize the ratio by the length of the sequence.")] = False
 
     clip_ratio: Annotated[float, Field(ge=0)] = 8.0

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -19,15 +19,10 @@ from prime_rl.utils.pydantic_config import BaseConfig, BaseSettings
 class LossConfig(BaseModel):
     """Base config for loss."""
 
-    norm_type: Annotated[
-        Literal["token", "sequence"],
-        Field(
-            description="Normalization type for loss scaling. 'token' normalizes by the total number of unmasked tokens in the batch, 'sequence' normalizes by the total tokens within a sequence."
-        ),
-    ] = "token"
-
-    ratio_type: Annotated[Literal["token", "sequence"], Field(description="Type of ratio to use.")] = "token"
-    ratio_length_norm: Annotated[bool, Field(description="Whether to normalize the ratio by the length of the sequence.")] = False
+    ratio_type: Annotated[Literal["token", "sequence"], Field(description="Type of importance ratio to use.")] = "token"
+    ratio_length_norm: Annotated[
+        bool, Field(description="Whether to normalize the importance ratio by the sequence length.")
+    ] = False
 
     clip_ratio: Annotated[float, Field(ge=0)] = 8.0
 

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -26,7 +26,7 @@ class LossConfig(BaseModel):
         ),
     ] = "token"
 
-    type: Annotated[Literal["gspo", "grpo"], Field(description="Type of loss to use.")] = "grpo"
+    type: Annotated[Literal["gspo", "grpo", "deepseek_grpo"], Field(description="Type of loss to use.")] = "grpo"
 
     clip_ratio: Annotated[float, Field(ge=0)] = 8.0
 

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -89,7 +89,7 @@ def compute_loss(
     for logprobs, old_logprobs, advantages, loss_mask in zip(logprobs, old_logprobs, advantages, loss_mask):
         log_importance_ratio = logprobs - old_logprobs
 
-        if loss_config.ratio_type == "sequence"
+        if loss_config.ratio_type == "sequence":
             if loss_config.ratio_length_norm:
                 seq_log_importance_ratio = (log_importance_ratio[loss_mask]).sum() / torch.clamp_min(loss_mask.sum(), 1)
             else:

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -105,7 +105,7 @@ def compute_loss(
         loss = (loss[loss_mask]).sum()
 
         # Apply sequence-level normalization if configured
-        if loss_config.norm_type == "sequence" and loss_config.ratio_type == "sequence":
+        if loss_config.ratio_type == "sequence":
             loss = loss / torch.clamp_min(loss_mask.sum(), 1)
 
         total_loss = total_loss + loss

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -90,10 +90,9 @@ def compute_loss(
         log_importance_ratio = logprobs - old_logprobs
 
         if loss_config.ratio_type == "sequence":
+            seq_log_importance_ratio = (log_importance_ratio[loss_mask]).sum()
             if loss_config.ratio_length_norm:
-                seq_log_importance_ratio = (log_importance_ratio[loss_mask]).sum() / torch.clamp_min(loss_mask.sum(), 1)
-            else:
-                seq_log_importance_ratio = (log_importance_ratio[loss_mask]).sum()
+                seq_log_importance_ratio = seq_log_importance_ratio / torch.clamp_min(loss_mask.sum(), 1)
             log_importance_ratio = torch.clamp(seq_log_importance_ratio.unsqueeze(0), max=10.0)
 
         importance_ratio = torch.exp(log_importance_ratio)

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -89,8 +89,8 @@ def compute_loss(
     for logprobs, old_logprobs, advantages, loss_mask in zip(logprobs, old_logprobs, advantages, loss_mask):
         log_importance_ratio = logprobs - old_logprobs
 
-        if loss_config.type == "gspo" or loss_config.type == "deepseek_grpo":
-            if loss_config.type == "gspo":
+        if loss_config.ratio_type == "sequence"
+            if loss_config.ratio_length_norm:
                 seq_log_importance_ratio = (log_importance_ratio[loss_mask]).sum() / torch.clamp_min(loss_mask.sum(), 1)
             else:
                 seq_log_importance_ratio = (log_importance_ratio[loss_mask]).sum()
@@ -105,7 +105,7 @@ def compute_loss(
         loss = (loss[loss_mask]).sum()
 
         # Apply sequence-level normalization if configured
-        if loss_config.norm_type == "sequence":
+        if loss_config.norm_type == "sequence" and loss_config.ratio_type == "sequence":
             loss = loss / torch.clamp_min(loss_mask.sum(), 1)
 
         total_loss = total_loss + loss

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -85,7 +85,7 @@ def train(config: RLTrainerConfig):
 
     # Set up the optimizer
     logger.info(f"Initializing optimizer ({config.optim})")
-    logger.info(f"Using `{config.loss.type}` loss ({config.loss})")
+    logger.info(f"Using `{config.loss.ratio_type}` importance ratio ({config.loss})")
 
     optimizer = setup_optimizer(config.optim, model, parallel_dims.world_mesh["dp_shard_cp"])
 

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -253,9 +253,9 @@ def train(config: RLTrainerConfig):
         batch_size = micro_batch_size * num_micro_batches
 
         # Normalize by the local number of unmasked tokens in the batch (per-batch length normalization)
-        if config.loss.norm_type == "token":
+        if config.loss.ratio_type == "token":
             loss_scale = sum(micro_batch["loss_mask"].sum().item() for micro_batch in micro_batches)
-        elif config.loss.norm_type == "sequence":
+        elif config.loss.ratio_type == "sequence":
             loss_scale = batch_size
 
         logger.info(f"Starting forward and backward pass ({num_micro_batches=})")

--- a/src/prime_rl/utils/config.py
+++ b/src/prime_rl/utils/config.py
@@ -32,7 +32,7 @@ class LogConfig(BaseConfig):
             description="Whether to log to a file. If True, will log to a file in the output directory.",
         ),
     ] = True
-    
+
     log_data: Annotated[
         bool,
         Field(

--- a/tests/unit/train/rl/test_loss.py
+++ b/tests/unit/train/rl/test_loss.py
@@ -18,7 +18,7 @@ def test_grpo_loss():
         old_logprobs,
         advantages,
         loss_mask=loss_mask,
-        loss_config=LossConfig(type="grpo", clip_ratio=10.0),
+        loss_config=LossConfig(ratio_type="token", clip_ratio=10.0),
         loss_scale=1.0,
     )
     assert loss.shape == ()
@@ -36,7 +36,7 @@ def test_gspo_loss():
         old_logprobs,
         advantages,
         loss_mask=loss_mask,
-        loss_config=LossConfig(type="gspo", clip_ratio=10.0),
+        loss_config=LossConfig(ratio_type="sequence", clip_ratio=10.0),
         loss_scale=1.0,
     )
     assert loss.shape == ()


### PR DESCRIPTION
Adds implementation of sequence level importance ratio without length normalisation, used in deepseek R1 and https://yingru.notion.site/When-Speed-Kills-Stability-Demystifying-RL-Collapse-from-the-Training-Inference-Mismatch-271211a558b7808d8b12d403fd15edda