### PR TITLE
Implement GFPO

### DIFF
--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -453,6 +453,14 @@ class OrchestratorConfig(BaseSettings):
         ),
     ] = "drgrpo"
 
+    advantage_keep_n_shortest: Annotated[
+        int | None,
+        Field(
+            ge=1,
+            description="If set, compute advantage baselines using only the N shortest completions per problem group. Advantages are still produced for all rollouts, but baselines (and scaling for RLOO) are computed from these N shortest.",
+        ),
+    ] = None
+
     seq_len: Annotated[
         int,
         Field(

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -260,6 +260,7 @@ async def orchestrate(config: OrchestratorConfig):
                 completion_lengths=list(map(len, processed_outputs.completion_ids)),
                 samples_per_problem=config.rollouts_per_example,
                 advantage_type=config.advantage_type,
+                keep_n_shortest=config.advantage_keep_n_shortest,
             )
 
             # Parse whether the completions were truncated


### PR DESCRIPTION
https://www.arxiv.org/abs/2508.09726
Basically to bias the model to generate shorter reasoning traces, it basically only keeps the shortest N rollouts in a group. This way the other rollouts are not penalised, but the model is just naturally pushed to generate shorter traces