### PR TITLE
Save sharded weight checkpoints and enable `safetensors` format

### DIFF
--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -19,7 +19,6 @@ confirm_cleanup() {
     echo "  - **/rollouts"
     echo "  - **/wandb"
     echo "  - **/evals"
-    echo "  - **/evals"
     echo "  - .pydantic_config"
     while true; do
         read -r -p "Proceed? [y/N]: " response

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -67,8 +67,7 @@ async def custom_run_server_worker(listen_address, sock, args, client_config=Non
         @app.post("/update_weights")
         async def _update_weights(request: Request):
             data = await request.json()
-            model_path = data.get("model_path")
-            await engine_client.collective_rpc("update_weights", args=(model_path,))
+            await engine_client.collective_rpc("update_weights", args=(data.get("weight_dir"),))
             return {"status": "ok"}
 
         @app.post("/reload_weights")

--- a/src/prime_rl/inference/vllm/worker.py
+++ b/src/prime_rl/inference/vllm/worker.py
@@ -1,9 +1,19 @@
-from pathlib import Path
+from typing import TYPE_CHECKING
 
-import torch
+from torch.nn import Module
+from vllm.model_executor.model_loader import DefaultModelLoader, get_model_loader
+from vllm.model_executor.model_loader.utils import process_weights_after_loading
+
+# This is to get type hints for the Worker class but not actually extend it at runtime as this is required by vLLM worker extension
+if TYPE_CHECKING:
+    from vllm.v1.worker.gpu_worker import Worker
+
+    Worker = Worker
+else:
+    Worker = object
 
 
-class CheckpointWorker:
+class CheckpointWorker(Worker):
     """
     This is an extension of a vLLM worker that allows for loading checkpoints
     from a specified directory via RPC calls from the AsyncLLMEngine class, exposed
@@ -11,20 +21,26 @@ class CheckpointWorker:
     recent policy model from a checkpoint directory.
     """
 
-    def update_weights(self, model_path: Path) -> None:
+    def update_weights(self, weight_path: str) -> None:
         """Update weights from a specified path pointing to a .pt file."""
-        state_dict = torch.load(model_path, map_location="cpu", mmap=True)
+        # Get vLLM model runner and model
+        model_runner = self.model_runner
+        model = model_runner.model
+        assert isinstance(model, Module)
 
-        def weights_iterator():
-            for key, value in state_dict.items():
-                if not key:
-                    continue
-                yield key, value
-
-        self.model_runner.model.load_weights(weights_iterator())
+        # Get vLLM model loader
+        model_loader = get_model_loader(self.load_config)
+        assert isinstance(model_loader, DefaultModelLoader)
+        local_source = DefaultModelLoader.Source(
+            weight_path,
+            revision=None,  # TODO: Check that this is correct or if we should use the default (model_config.revision)
+            prefix="",
+            fall_back_to_pt=getattr(model, "fall_back_to_pt_during_load", True),
+            allow_patterns_overrides=getattr(model, "allow_patterns_overrides", None),
+        )
+        weights_iterator = model_loader._get_weights_iterator(local_source)
+        model.load_weights(weights_iterator)  # type: ignore
 
         # Process weights after loading (important for some models)
-        from vllm.model_executor.model_loader.utils import process_weights_after_loading
-
-        device = next(self.model_runner.model.parameters()).device
-        process_weights_after_loading(self.model_runner.model, self.model_runner.model_config, device)
+        device = next(model.parameters()).device
+        process_weights_after_loading(model, self.model_runner.model_config, device)

--- a/src/prime_rl/orchestrator/client.py
+++ b/src/prime_rl/orchestrator/client.py
@@ -8,7 +8,6 @@ from openai import AsyncOpenAI, NotFoundError
 
 from prime_rl.orchestrator.config import ClientConfig
 from prime_rl.utils.logger import get_logger
-from prime_rl.utils.utils import get_weight_ckpt_model_path
 
 
 def setup_client(client_config: ClientConfig) -> AsyncOpenAI:
@@ -60,14 +59,13 @@ async def check_has_model(client: AsyncOpenAI, model_name: str) -> None:
     logger.debug(f"Model {model_name} was found in the inference pool")
 
 
-async def update_weights(client: AsyncOpenAI, path: Path, step: int) -> None:
+async def update_weights(client: AsyncOpenAI, weight_dir: Path) -> None:
     """Make a HTTP post request to the vLLM server to update the weights."""
     logger = get_logger()
     url = str(client.base_url).strip()[:-4] + "/update_weights"
     try:
-        model_path = get_weight_ckpt_model_path(path, step).absolute()
-        logger.debug(f"Sending request to {url} to update weights from {model_path}")
-        await client.post(url, cast_to=Response, body={"model_path": model_path.as_posix()})
+        logger.debug(f"Sending request to {url} to update weights from {weight_dir}")
+        await client.post(url, cast_to=Response, body={"weight_dir": weight_dir.as_posix()})
     except NotFoundError:
         logger.warning(f"The route {url} does not exist. Skipping weight update.")
         return

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -37,8 +37,10 @@ from prime_rl.utils.utils import (
     clean_exit,
     format_num,
     get_rollout_dir,
+    get_step_path,
     get_weights_dir,
     to_col_format,
+    wait_for_path,
 )
 import numpy as np
 
@@ -151,14 +153,14 @@ async def orchestrate(config: OrchestratorConfig):
             ckpt_step = progress.step - config.async_level
             logger.info(f"Waiting for weight checkpoint {ckpt_step}")
             wait_for_weight_ckpt_start_time = time.time()
-            wait_for_weight_checkpoint(get_weights_dir(config.output_dir), ckpt_step)
+            wait_for_path(get_step_path(get_weights_dir(config.output_dir), ckpt_step) / "STABLE")
             wait_for_weight_ckpt_time = time.time() - wait_for_weight_ckpt_start_time
             logger.debug(f"Waited {wait_for_weight_ckpt_time:.2f}s for weight checkpoint")
 
             # Update the weights
             logger.info(f"Updating weights to weight checkpoint {ckpt_step}")
             update_weights_start_time = time.time()
-            await update_weights(client, get_weights_dir(config.output_dir), ckpt_step)
+            await update_weights(client, get_step_path(get_weights_dir(config.output_dir), ckpt_step))
             update_weights_time = time.time() - update_weights_start_time
             logger.debug(f"Updated weights in {update_weights_time:.2f}s")
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -106,7 +106,7 @@ async def orchestrate(config: OrchestratorConfig):
         logger.info(f"Resuming training from checkpoint step `{config.ckpt.resume_step}`")
         ckpt_manager.load(progress, buffer, step=config.ckpt.resume_step)
         ckpt_step = max(progress.step - config.async_level, 0)
-        await update_weights(client, get_weights_dir(config.output_dir), ckpt_step)
+        await update_weights(client, get_step_path(get_weights_dir(config.output_dir), ckpt_step))
     else:
         logger.info("Training from scratch. Resetting weights to base model")
         await reload_weights(client)

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -371,6 +371,13 @@ class WeightCheckpointConfig(BaseConfig):
         ),
     ] = None
 
+    safe_serialization: Annotated[
+        bool,
+        Field(
+            description="Whether to save the weight checkpoint in using HuggingFace (safe) or PyTorch (unsafe) serialization format.",
+        ),
+    ] = True
+
     save_async: Annotated[
         bool,
         Field(

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -371,12 +371,19 @@ class WeightCheckpointConfig(BaseConfig):
         ),
     ] = None
 
-    safe_serialization: Annotated[
+    sharded: Annotated[
         bool,
         Field(
-            description="Whether to save the weight checkpoint in using HuggingFace (safe) or PyTorch (unsafe) serialization format.",
+            description="Whether to save the weight checkpoint in sharded format.",
         ),
-    ] = True
+    ] = False
+
+    format: Annotated[
+        Literal["safetensors", "torch"],
+        Field(
+            description="The format to save the weight checkpoint in.",
+        ),
+    ] = "torch"
 
     save_async: Annotated[
         bool,

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -371,14 +371,14 @@ class WeightCheckpointConfig(BaseConfig):
         ),
     ] = None
 
-    sharded: Annotated[
+    save_sharded: Annotated[
         bool,
         Field(
             description="Whether to save the weight checkpoint in sharded format.",
         ),
     ] = False
 
-    format: Annotated[
+    save_format: Annotated[
         Literal["safetensors", "torch"],
         Field(
             description="The format to save the weight checkpoint in.",

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -161,7 +161,13 @@ def train(config: RLTrainerConfig):
         save_weights_time = 0
         if progress.step > 0:
             save_weights_start_time = time.time()
-            weight_ckpt_manager.save(model, tokenizer, step=progress.step)
+            weight_ckpt_manager.save(
+                model,
+                tokenizer,
+                save_format=config.weights.format,
+                save_sharded=config.weights.sharded,
+                step=progress.step,
+            )
             save_weights_time = time.time() - save_weights_start_time
 
         # Save the full checkpoint (if we are at an interval step and not at the first or last step)

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -164,8 +164,8 @@ def train(config: RLTrainerConfig):
             weight_ckpt_manager.save(
                 model,
                 tokenizer,
-                save_format=config.weights.format,
-                save_sharded=config.weights.sharded,
+                save_format=config.weights.save_format,
+                save_sharded=config.weights.save_sharded,
                 step=progress.step,
             )
             save_weights_time = time.time() - save_weights_start_time

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -144,7 +144,13 @@ def train(config: SFTTrainerConfig):
         ):
             logger.info(f"Saving weight checkpoint at step {progress.step}")
             save_weights_start_time = time.time()
-            weight_ckpt_manager.save(model, tokenizer, step=progress.step)
+            weight_ckpt_manager.save(
+                model,
+                tokenizer,
+                save_format=config.weights.format,
+                save_sharded=config.weights.sharded,
+                step=progress.step,
+            )
             save_weights_time = time.time() - save_weights_start_time
 
         # Save the full checkpoint (if we are at an interval step and not at the first or last step)
@@ -349,8 +355,15 @@ def train(config: SFTTrainerConfig):
 
     # Write final weight checkpoint
     if weight_ckpt_manager is not None:
+        assert config.weights is not None
         logger.info("Writing final weight checkpoint")
-        weight_ckpt_manager.save(model, tokenizer, step=progress.step)
+        weight_ckpt_manager.save(
+            model,
+            tokenizer,
+            save_format=config.weights.format,
+            save_sharded=config.weights.sharded,
+            step=progress.step,
+        )
 
     # Write final checkpoint
     if ckpt_manager is not None:

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -147,8 +147,8 @@ def train(config: SFTTrainerConfig):
             weight_ckpt_manager.save(
                 model,
                 tokenizer,
-                save_format=config.weights.format,
-                save_sharded=config.weights.sharded,
+                save_format=config.weights.save_format,
+                save_sharded=config.weights.save_sharded,
                 step=progress.step,
             )
             save_weights_time = time.time() - save_weights_start_time
@@ -360,8 +360,8 @@ def train(config: SFTTrainerConfig):
         weight_ckpt_manager.save(
             model,
             tokenizer,
-            save_format=config.weights.format,
-            save_sharded=config.weights.sharded,
+            save_format=config.weights.save_format,
+            save_sharded=config.weights.save_sharded,
             step=progress.step,
         )
 

--- a/src/prime_rl/trainer/weights.py
+++ b/src/prime_rl/trainer/weights.py
@@ -218,7 +218,7 @@ class WeightCheckpointManager:
         else:
             self._logger.debug(f"Saving unsharded weights to {weights_name}")
 
-        # Save weights (Ref: https://github.com/huggingface/transformers/blob/cd74917ffc3e8f84e4a886052c5ab32b7ac623cc/src/transformers/modeling_utils.py#L4252)
+        # Save weights (https://github.com/huggingface/transformers/blob/cd74917ffc3e8f84e4a886052c5ab32b7ac623cc/src/transformers/modeling_utils.py#L4252)
         filename_to_tensors = state_dict_split.filename_to_tensors.items()
         for shard_file, tensors in filename_to_tensors:
             shard = {}
@@ -233,8 +233,7 @@ class WeightCheckpointManager:
                 torch.save(shard, save_dir / shard_file)
         del state_dict
 
-        # Save index
-        # Ref: https://github.com/huggingface/transformers/blob/cd74917ffc3e8f84e4a886052c5ab32b7ac623cc/src/transformers/modeling_utils.py#L4301
+        # Save index (https://github.com/huggingface/transformers/blob/cd74917ffc3e8f84e4a886052c5ab32b7ac623cc/src/transformers/modeling_utils.py#L4301)
         if state_dict_split.is_sharded:
             index = {
                 "metadata": {**state_dict_split.metadata},


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

This PR gives more flexibility in saving weight checkpoints on the RL and SFT trainer, specifically:
- Save sharded checkpoint (e.g. `model-00001-of-00004.safetensors`, ..., and `model.safetensors.index.json`
- Save in `safetensors` format
This should improve the save/ load times to/ from disk, as well as upload and downloads from HF hub as those can be parallalized across shards.

The changes needed for this the following:
- Trainer: Add config flags `--weights.save-sharded` and `--weights.save-format {torch,safetensors}` which are consumed by the `WeightCkptManager` which uses`hugginggface_hub.split_torch_state_dict_into_shards` utility to generate shards of default size 5GB in safetensors or torch format
- Inference: Our worker extension now reuses its internal loading utility class `DefaultModelLoader` to reload the RL weight checkpoints. Since the loading utility supports any HF-compatible format, we support all cases out of the box.
 
## Experiments

### Debug

Unsharded PyTorch (Default) ✅

```bash
uv run rl  \
  --trainer @ examples/reverse_text/rl/train.toml \
  --orchestrator @ examples/reverse_text/rl/orch.toml \
  --inference @ examples/reverse_text/rl/infer.toml \
  --inference.gpu-memory-utilization 0.5 \
  --trainer-gpu-ids 0 \
  --log.level debug
```

Sharded PyTorch ✅

```bash
uv run rl  \
  --trainer @ examples/reverse_text/rl/train.toml \
  --orchestrator @ examples/reverse_text/rl/orch.toml \
  --inference @ examples/reverse_text/rl/infer.toml \
  --inference.gpu-memory-utilization 0.5 \
  --trainer-gpu-ids 0 \
  --log.level debug \
  --trainer.weights.save-sharded
```

Unsharded safetensors ✅

```bash
uv run rl  \
  --trainer @ examples/reverse_text/rl/train.toml \
  --orchestrator @ examples/reverse_text/rl/orch.toml \
  --inference @ examples/reverse_text/rl/infer.toml \
  --inference.gpu-memory-utilization 0.5 \
  --trainer-gpu-ids 0 \
  --log.level debug \
  --trainer.weights.save-format safetensors
```

Sharded safetensors ✅

```bash
uv run rl  \
  --trainer @ examples/reverse_text/rl/train.toml \
  --orchestrator @ examples/reverse_text/rl/orch.toml \
  --inference @ examples/reverse_text/rl/infer.toml \
  --inference.gpu-memory-utilization 0.5 \
  --trainer-gpu-ids 0 \
  --log.level debug \
  --trainer.weights.save-sharded \
  --trainer.weights.save-format safetensors
```

### Hendryck's Math

Run on a 7B model (4 shards) with async weight safetensors checkpointing

[W&B run](https://wandb.ai/primeintellect/mika/workspace?nw=sp8xwehokdf)

<img width="663" height="253" alt="Screenshot 2025-10-02 at 8 16 00 PM" src="https://github.com/user-attachments/assets/4e984bae-a488-4742-8d32-1e20d9a18080" />

Weight checkpoints now look like this

```txt
├── chat_template.jinja
├── config.json
├── generation_config.json
├── model-00001-of-00004.safetensors
├── model-00002-of-00004.safetensors
├── model-00003-of-00004.safetensors
├── model-00004-of-00004.safetensors
├── model.safetensors.index.json
├── special_tokens_map.json
├── STABLE
├── tokenizer_config.json
└── tokenizer.json
```

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: #821 
**Linear Issue**: Resolves PRIMERL-63