### PR TITLE
PEFT-compatible LoRA adapter saving

### DIFF
--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -377,3 +377,10 @@ class WeightCheckpointConfig(BaseConfig):
             description="Whether to save the weight checkpoint asynchronously.",
         ),
     ] = True
+
+    save_adapter_separately: Annotated[
+        bool,
+        Field(
+            description="Whether to save LoRA adapters separately before merging into full model weights.",
+        ),
+    ] = False

--- a/src/prime_rl/trainer/lora.py
+++ b/src/prime_rl/trainer/lora.py
@@ -321,3 +321,48 @@ def load_lora_state_dict(model: nn.Module, lora_state_dict: Dict[str, torch.Tens
             loaded_params += 1
         else:
             logger.warning(f"LoRA parameter {name} not found in model")
+
+
+def save_lora_config(config: LoRAConfig, model: nn.Module, save_path) -> None:
+    """
+    Save LoRA configuration as JSON for adapter portability.
+    
+    Args:
+        config: LoRA configuration to save
+        model: Model with LoRA layers to introspect
+        save_path: Path object or string pointing to directory where adapter_config.json will be saved
+    """
+    import json
+    from pathlib import Path
+    
+    save_path = Path(save_path)
+    
+    # Extract actual target modules from the model
+    target_modules = set()
+    modules_to_save = set()
+    
+    for name, module in model.named_modules():
+        if isinstance(module, LoRALinear):
+            module_suffix = name.split(".")[-1]
+            target_modules.add(module_suffix)
+    
+    for name, param in model.named_parameters():
+        if param.requires_grad and "lora_A" not in name and "lora_B" not in name:
+            module_name = name.rsplit(".", 1)[0].split(".")[-1]
+            modules_to_save.add(module_name)
+    
+    adapter_config = {
+        "peft_type": "LORA",
+        "task_type": "CAUSAL_LM",
+        "base_model_name_or_path": model.config._name_or_path,
+        "r": config.rank,
+        "lora_alpha": config.alpha,
+        "lora_dropout": config.dropout,
+        "bias": "none",
+        "target_modules": sorted(list(target_modules)),
+        "modules_to_save": sorted(list(modules_to_save)) if modules_to_save else None,
+    }
+    
+    config_path = save_path / "adapter_config.json"
+    with open(config_path, "w") as f:
+        json.dump(adapter_config, f, indent=2)

--- a/src/prime_rl/trainer/lora.py
+++ b/src/prime_rl/trainer/lora.py
@@ -288,21 +288,6 @@ def restore_lora_weights_inplace(model: nn.Module, original_lora_state: Dict[str
             restored_count += 1
 
 
-def get_lora_state_dict(model: nn.Module) -> Dict[str, torch.Tensor]:
-    """
-    Extract only LoRA parameters from model state dict.
-
-    Returns:
-        Dictionary containing only LoRA parameters
-    """
-    lora_state_dict = {}
-    for name, param in model.named_parameters():
-        if "lora_A" in name or "lora_B" in name:
-            lora_state_dict[name] = param.data.clone()
-
-    return lora_state_dict
-
-
 def load_lora_state_dict(model: nn.Module, lora_state_dict: Dict[str, torch.Tensor]) -> None:
     """
     Load LoRA parameters into model.

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -154,3 +154,18 @@ class RLTrainerConfig(BaseSettings):
                     "Tracing more than 10 steps is not recommended as your trace will be massive. Remove this line if you really want to trace more steps."
                 )
         return self
+
+    @model_validator(mode="after")
+    def validate_lora_adapter_saving(self):
+        if self.weights and self.weights.save_adapter_separately:
+            lora_enabled = (
+                self.model 
+                and self.model.experimental 
+                and self.model.experimental.lora
+            )
+            if not lora_enabled:
+                raise ValueError(
+                    "save_adapter_separately=True requires LoRA to be enabled. "
+                    "Set model.experimental.lora or disable save_adapter_separately."
+                )
+        return self

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -96,7 +96,13 @@ def train(config: RLTrainerConfig):
 
     # Set up weight checkpoint manager
     logger.info(f"Initializing weight checkpoint manager ({config.weights})")
-    weight_ckpt_manager = setup_weight_ckpt_manager(config.output_dir, config.weights, config.ckpt, config.async_level)
+    weight_ckpt_manager = setup_weight_ckpt_manager(
+        config.output_dir,
+        config.weights,
+        config.ckpt,
+        config.async_level,
+        config.model.experimental.lora
+    )
     assert weight_ckpt_manager is not None, "Weight checkpoint manager must be set on RL trainer"
 
     # Set up checkpoint manager

--- a/src/prime_rl/trainer/sft/config.py
+++ b/src/prime_rl/trainer/sft/config.py
@@ -189,3 +189,18 @@ class SFTTrainerConfig(BaseSettings):
                     "Use a weight checkpoint interval that ensures that a weight checkpoint is saved with every full checkpoint"
                 )
         return self
+
+    @model_validator(mode="after")
+    def validate_lora_adapter_saving(self):
+        if self.weights and self.weights.save_adapter_separately:
+            lora_enabled = (
+                self.model 
+                and self.model.experimental 
+                and self.model.experimental.lora
+            )
+            if not lora_enabled:
+                raise ValueError(
+                    "save_adapter_separately=True requires LoRA to be enabled. "
+                    "Set model.experimental.lora or disable save_adapter_separately."
+                )
+        return self

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -80,7 +80,13 @@ def train(config: SFTTrainerConfig):
 
     # Set up weight checkpoint manager
     logger.info(f"Initializing weight checkpoint manager ({config.weights})")
-    weight_ckpt_manager = setup_weight_ckpt_manager(config.output_dir, config.weights, config.ckpt, async_level=0)
+    weight_ckpt_manager = setup_weight_ckpt_manager(
+        config.output_dir,
+        config.weights,
+        config.ckpt,
+        async_level=0,
+        config.model.experimental.lora
+    )
 
     # Set up checkpoint manager
     logger.info(f"Initializing checkpoint manager ({config.ckpt})")

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -84,7 +84,7 @@ def train(config: SFTTrainerConfig):
         config.output_dir,
         config.weights,
         config.ckpt,
-        async_level=0,
+        0,
         config.model.experimental.lora
     )
 

--- a/src/prime_rl/trainer/weights.py
+++ b/src/prime_rl/trainer/weights.py
@@ -13,7 +13,6 @@ from transformers.tokenization_utils import PreTrainedTokenizer
 from prime_rl.trainer.config import CheckpointConfig, LoRAConfig
 from prime_rl.trainer.lora import (
     clean_lora_state_dict,
-    get_lora_state_dict,
     has_lora_layers,
     merge_lora_weights_inplace,
     restore_lora_weights_inplace,

--- a/src/prime_rl/trainer/weights.py
+++ b/src/prime_rl/trainer/weights.py
@@ -10,12 +10,14 @@ from torch.distributed.checkpoint.state_dict import _get_fqns as get_fqns
 from torch.distributed.tensor import DTensor
 from transformers.tokenization_utils import PreTrainedTokenizer
 
-from prime_rl.trainer.config import CheckpointConfig
+from prime_rl.trainer.config import CheckpointConfig, LoRAConfig
 from prime_rl.trainer.lora import (
     clean_lora_state_dict,
+    get_lora_state_dict,
     has_lora_layers,
     merge_lora_weights_inplace,
     restore_lora_weights_inplace,
+    save_lora_config,
 )
 from prime_rl.trainer.rl.config import WeightCheckpointConfig
 from prime_rl.trainer.world import get_world
@@ -97,12 +99,18 @@ class WeightCheckpointManager:
     """Utility class to save and cleanup HF-compatible weight checkpoints."""
 
     def __init__(
-        self, output_dir: Path, config: WeightCheckpointConfig, ckpt_config: CheckpointConfig | None, async_level: int
+        self,
+        output_dir: Path,
+        config: WeightCheckpointConfig,
+        ckpt_config: CheckpointConfig | None,
+        async_level: int,
+        lora_config: LoRAConfig | None = None,
     ):
         self.weights_dir = get_weights_dir(output_dir)
         self.config = config
         self.ckpt_config = ckpt_config
         self.async_level = async_level
+        self.lora_config = lora_config
         self._logger = get_logger()
         self._world = get_world()
         self._is_master = self._world.is_master
@@ -112,6 +120,46 @@ class WeightCheckpointManager:
 
     def _get_step_path(self, step: int) -> Path:
         return get_step_path(self.weights_dir, step)
+        
+    def _get_adapter_state_dict(self, model: nn.Module) -> dict[str, Tensor]:
+        """Get adapter weights with clean keys for PEFT compatibility."""
+        lora_state = {}
+        
+        for key, value in model.state_dict().items():
+            param = dict(model.named_parameters()).get(key)
+            if param is None or not param.requires_grad:
+                continue
+                
+            if isinstance(value, DTensor):
+                value = value.full_tensor()
+            
+            if self._is_master:
+                clean_key = next(iter(get_fqns(model, key)))
+                clean_key = clean_key.replace(".base_layer.", ".")
+                
+                # Add PEFT-expected prefix
+                peft_key = f"base_model.model.{clean_key}"
+                
+                # Add .weight suffix for LoRA parameters if missing
+                if ("lora_A" in peft_key or "lora_B" in peft_key) and not peft_key.endswith(".weight"):
+                    peft_key = f"{peft_key}.weight"
+                
+                lora_state[peft_key] = value.to("cpu", non_blocking=False)
+        
+        torch.distributed.barrier()
+        return lora_state
+
+    def _save_lora_adapters(self, lora_state: dict[str, Tensor], model: nn.Module, step: int):
+        """Save LoRA adapters to separate directory."""
+        adapter_path = self._get_step_path(step) / "lora_adapters"
+        adapter_path.mkdir(parents=True, exist_ok=True)
+
+        torch.save(lora_state, adapter_path / "adapter_model.bin")
+
+        if self.lora_config:
+            save_lora_config(self.lora_config, model, adapter_path)  # Pass model
+
+        self._logger.debug(f"Saved LoRA adapters to {adapter_path}")
 
     def _gather_weights(
         self, model: nn.Module, dtype: torch.dtype = torch.bfloat16, has_lora_layers: bool = False
@@ -191,6 +239,11 @@ class WeightCheckpointManager:
         """Save a HF-compatible weight-only checkpoint for a given step."""
         has_lora = has_lora_layers(model)
 
+        # Save LoRA adapters separately if configured
+        if self.config.save_adapter_separately and has_lora and self._is_master:
+            lora_state = self._get_adapter_state_dict(model)
+            self._save_lora_adapters(lora_state, model, step)
+
         cpu_state = self._gather_weights(model, dtype, has_lora_layers=has_lora)
         if _has_tt_moe_layers(cpu_state):
             _convert_tt_moe_to_hf_(cpu_state)
@@ -249,7 +302,17 @@ def setup_weight_ckpt_manager(
     weight_ckpt_config: WeightCheckpointConfig | None,
     ckpt_config: CheckpointConfig | None,
     async_level: int,
+    lora_config: LoRAConfig | None = None,
 ) -> WeightCheckpointManager | None:
     if weight_ckpt_config is None:
         return None
-    return WeightCheckpointManager(output_dir, weight_ckpt_config, ckpt_config, async_level=async_level)
+    
+    if weight_ckpt_config.save_adapter_separately and lora_config is None:
+        raise ValueError(
+            "save_adapter_separately=True requires LoRA to be enabled. "
+            "Set model.experimental.lora or disable save_adapter_separately."
+        )
+    
+    return WeightCheckpointManager(
+        output_dir, weight_ckpt_config, ckpt_config, async_level=async_level, lora_config=lora_config
+    )


### PR DESCRIPTION
- adds a `save_adapter_separately` variable to the configuration save_lora_config() produces a peft-compatible lora adapter config JSON, extracts + detects both the target lora modules (target_modules) & fully trainable modules (modules_to_save)
- weights.py has `_get_adapter_state_dict`, it only triggers when: `save_adapter_separately=True`, the process is master rank, and lora layers are found. this function transforms/serializes the keys to PEFT format. we specifically must add the .weight suffix to the A/B lora matrices, while the `base_model.model.*` prefix is added to everything that requires_grad (all trainable parameters) and is not None in `named_parameters()`
- adapters are saved to `{step}/lora_adapters/adapter_model.bin` and `adapter_config.json` via `_save_lora_adapters()`
- we raise ValueError if save adapter is set to True but LoRA is disabled
- both train.py scripts in SFT and RL paths pass the lora config to `setup_weight_ckpt_manager()`
- removed obsolete/unused stray function `get_lora_state_dict()`
