### PR TITLE
Support loading dataset subsets and dynamic up/downsampling in SFT

### DIFF
--- a/src/prime_rl/trainer/sft/config.py
+++ b/src/prime_rl/trainer/sft/config.py
@@ -69,9 +69,6 @@ class SFTDataConfig(BaseDataConfig):
         Field(description=""),
     ] = "all_exhausted"
     shuffle: Annotated[bool, Field(description="Whether to shuffle the dataset at the beginning of each epoch.")] = True
-    max_examples: Annotated[
-        int | None, Field(description="Number of examples to use from the dataset. If None, will use all examples.")
-    ] = None
     seed: Annotated[
         int,
         Field(

--- a/src/prime_rl/trainer/sft/config.py
+++ b/src/prime_rl/trainer/sft/config.py
@@ -22,9 +22,6 @@ class BaseDataConfig(BaseModel):
     micro_batch_size: Annotated[int, Field(ge=1)] = 8
     batch_size: Annotated[int, Field(ge=1)] = 128
     seq_len: Annotated[int, Field(ge=1)] = 128
-    num_examples: Annotated[
-        int | None, Field(description="Number of examples to use from the dataset. If None, will use all examples.")
-    ] = None
     pack_function: Literal["cat", "stack"] = "cat"
 
     @model_validator(mode="after")
@@ -72,6 +69,9 @@ class SFTDataConfig(BaseDataConfig):
         Field(description=""),
     ] = "all_exhausted"
     shuffle: Annotated[bool, Field(description="Whether to shuffle the dataset at the beginning of each epoch.")] = True
+    max_examples: Annotated[
+        int | None, Field(description="Number of examples to use from the dataset. If None, will use all examples.")
+    ] = None
     seed: Annotated[
         int,
         Field(

--- a/src/prime_rl/trainer/sft/config.py
+++ b/src/prime_rl/trainer/sft/config.py
@@ -63,7 +63,14 @@ class SFTDataConfig(BaseDataConfig):
         "PrimeIntellect/Reverse-Text-SFT"
     )
     subsets: Annotated[list[str] | None, Field(description="Subsets to use from the HF dataset.")] = None
-    splits: Annotated[list[str], Field(description="Splits to use from the HF dataset.")] = ["train"]
+    splits: Annotated[list[str] | None, Field(description="Splits to use from the HF dataset.")] = None
+    probabilities: Annotated[list[float] | None, Field(description="Probabilities to use for each subset/split.")] = (
+        None
+    )
+    stopping_strategy: Annotated[
+        Literal["first_exhausted", "all_exhausted"],
+        Field(description=""),
+    ] = "first_exhausted"
     shuffle: Annotated[bool, Field(description="Whether to shuffle the dataset at the beginning of each epoch.")] = True
     seed: Annotated[
         int,
@@ -76,12 +83,23 @@ class SFTDataConfig(BaseDataConfig):
     loss_mask: LossMaskConfig = LossMaskConfig()
 
     @model_validator(mode="after")
-    def validate_subsets(self):
-        if self.subsets is not None:
-            if len(self.subsets) != len(self.splits):
-                raise ValueError(
-                    "Number of subsets must be equal to number of splits. Please specify which split to load for each subset."
-                )
+    def validate_subsets_and_splits(self):
+        if self.subsets is not None or self.splits is not None:
+            if self.subsets is not None and self.splits is not None:
+                if len(self.subsets) != len(self.splits):
+                    raise ValueError(
+                        "Number of subsets must be equal to number of splits. Please specify which split to load for each subset."
+                    )
+            if self.subsets is not None and self.probabilities is not None:
+                if len(self.probabilities) != len(self.subsets):
+                    raise ValueError(
+                        "Number of probabilities must be equal to number of subsets. Please specify a probability for each subset."
+                    )
+            if self.splits is not None and self.probabilities is not None:
+                if len(self.probabilities) != len(self.splits):
+                    raise ValueError(
+                        "Number of probabilities must be equal to number of splits. Please specify a probability for each split."
+                    )
         return self
 
 

--- a/src/prime_rl/trainer/sft/config.py
+++ b/src/prime_rl/trainer/sft/config.py
@@ -70,7 +70,7 @@ class SFTDataConfig(BaseDataConfig):
     stopping_strategy: Annotated[
         Literal["first_exhausted", "all_exhausted"],
         Field(description=""),
-    ] = "first_exhausted"
+    ] = "all_exhausted"
     shuffle: Annotated[bool, Field(description="Whether to shuffle the dataset at the beginning of each epoch.")] = True
     seed: Annotated[
         int,

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -180,9 +180,7 @@ class SFTDataset(StatefulIterableDataset):
             return [
                 {
                     **message,
-                    "tool_calls": [
-                        deserialize_tool_call(tool_call) for tool_call in message.get("tool_calls", []) or []
-                    ],
+                    "tool_calls": [deserialize_tool_call(tool_call) for tool_call in message.get("tool_calls") or []],
                 }
                 for message in messages
             ]

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -530,7 +530,6 @@ def setup_dataset(
             seq_len=config.seq_len,
             loss_mask=config.loss_mask,
             non_dp_size=non_dp_size,
-            max_examples=config.max_examples,
         )
     else:
         raise ValueError(f"Invalid dataset type: {config.type}")

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -319,7 +319,7 @@ class SFTDataset(StatefulIterableDataset):
                 self.logger.debug(
                     f"Yield example {example['index']}"
                     + (f" from {subset_or_split} " if subset_or_split else " ")
-                    + f"with {len(processed_example['input_ids'])} tokens ({sum(processed_example['loss_mask'])} trainable tokens)"
+                    + f"with {len(processed_example.get('input_ids', []))} tokens ({sum(processed_example.get('loss_mask', []))} trainable tokens)"
                 )
                 yield processed_example
 

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -465,9 +465,17 @@ def setup_dataset(
         # Shouldnt matter to handle non_dp_size if dataset is random
         return FakeDataset(tokenizer, config)
     elif config.type == "sft":
-        dataset = concatenate_datasets(
-            [cast(Dataset, load_dataset(config.name, split=split)) for split in config.splits]
-        )
+        if config.subsets is None:
+            dataset = concatenate_datasets(
+                [cast(Dataset, load_dataset(config.name, split=split)) for split in config.splits]
+            )
+        else:
+            dataset = concatenate_datasets(
+                [
+                    cast(Dataset, load_dataset(config.name, subset, split=split))
+                    for subset, split in zip(config.subsets, config.splits)
+                ]
+            )
         return SFTDataset(dataset, tokenizer, config, non_dp_size)
     else:
         raise ValueError(f"Invalid dataset type: {config.type}")

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -471,11 +471,15 @@ def setup_dataset(
             assert isinstance(dataset, Dataset), "Dataset must be a Hugging Face Dataset"
         elif config.subsets is not None and config.splits is None:
             dataset = interleave_datasets(
-                [cast(Dataset, load_dataset(config.name, subset, split="train")) for subset in config.subsets]
+                [cast(Dataset, load_dataset(config.name, subset, split="train")) for subset in config.subsets],
+                probabilities=config.probabilities,
+                seed=0,
             )
         elif config.subsets is None and config.splits is not None:
             dataset = interleave_datasets(
-                [cast(Dataset, load_dataset(config.name, split=split)) for split in config.splits]
+                [cast(Dataset, load_dataset(config.name, split=split)) for split in config.splits],
+                probabilities=config.probabilities,
+                seed=0,
             )
         else:
             assert config.subsets is not None and config.splits is not None
@@ -483,7 +487,9 @@ def setup_dataset(
                 [
                     cast(Dataset, load_dataset(config.name, subset, split=split))
                     for subset, split in zip(config.subsets, config.splits)
-                ]
+                ],
+                probabilities=config.probabilities,
+                seed=0,
             )
         return SFTDataset(dataset, tokenizer, config, non_dp_size)
     else:

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -1,5 +1,4 @@
 import json
-import uuid
 from collections import defaultdict
 from typing import Iterator, TypedDict, cast
 
@@ -95,7 +94,7 @@ class FakeDataset(StatefulIterableDataset):
             position_ids = list(range(seq_len))
             loss_mask = [True] * seq_len
             fake_sample = {
-                "index": self.step,
+                # "index": self.step,
                 "input_ids": input_ids[:-1],
                 "target_ids": input_ids[1:],
                 "position_ids": position_ids,
@@ -115,9 +114,9 @@ class SFTDataset(StatefulIterableDataset):
         self.tokenizer = tokenizer
 
         # Add dataset index
-        self.dataset = dataset.add_column("index", list(range(len(dataset))), new_fingerprint=str(uuid.uuid4()))
+        # self.dataset = dataset.add_column("index", list(range(len(dataset))), new_fingerprint=str(uuid.uuid4()))
 
-        # Assert that the dataset has a 'text' column
+        # Assert that the dataset has a 'prompt' and 'completion' column
         if "prompt" not in self.dataset.column_names or "completion" not in self.dataset.column_names:
             raise ValueError("HF dataset must have a 'prompt' and 'completion' column for SFT")
 
@@ -279,7 +278,7 @@ class SFTDataset(StatefulIterableDataset):
 
             if sum(loss_mask[: self.config.seq_len]) == 0:
                 self.logger.warning(
-                    f"Skipping example with index {self.step} because no trainable tokens were found within the context window ({self.config.seq_len}). This is to prevent NaN loss."
+                    f"Skipping example at step {self.step} because no trainable tokens were found within the context window ({self.config.seq_len}). This is to prevent NaN loss."
                 )
                 continue
 
@@ -291,7 +290,7 @@ class SFTDataset(StatefulIterableDataset):
 
             # Create sample (with one fake target for the last token)
             sample = {
-                "index": example["index"],
+                # "index": example["index"],
                 "input_ids": input_ids,
                 "target_ids": target_ids,
                 "loss_mask": loss_mask,
@@ -323,8 +322,8 @@ class CatDataset(StatefulIterableDataset):
             for key, value in sample.items():
                 if key == "epoch":
                     packed_samples[key] = min(packed_samples.get(key, float("inf")), value)
-                elif key == "index":
-                    indices.append(value)
+                # elif key == "index":
+                #     indices.append(value)
                 else:
                     packed_samples[key].extend(value)
 
@@ -423,8 +422,8 @@ class StackDataset(StatefulIterableDataset):
                     for key, value in bucket_item.items():
                         if key == "epoch":
                             packed_samples[key] = min(packed_samples.get(key, float("inf")), value)
-                        elif key == "index":
-                            indices.append(value)
+                        # elif key == "index":
+                        #     indices.append(value)
                         else:
                             packed_samples[key].append(value + [0] * (self.bucket_sizes[bucket_idx] - len(value)))
                 self.logger.debug(f"Yield batch with dataset indices={indices}")

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -473,12 +473,14 @@ def setup_dataset(
             dataset = interleave_datasets(
                 [cast(Dataset, load_dataset(config.name, subset, split="train")) for subset in config.subsets],
                 probabilities=config.probabilities,
+                stopping_strategy=config.stopping_strategy,
                 seed=0,
             )
         elif config.subsets is None and config.splits is not None:
             dataset = interleave_datasets(
                 [cast(Dataset, load_dataset(config.name, split=split)) for split in config.splits],
                 probabilities=config.probabilities,
+                stopping_strategy=config.stopping_strategy,
                 seed=0,
             )
         else:
@@ -489,6 +491,7 @@ def setup_dataset(
                     for subset, split in zip(config.subsets, config.splits)
                 ],
                 probabilities=config.probabilities,
+                stopping_strategy=config.stopping_strategy,
                 seed=0,
             )
         return SFTDataset(dataset, tokenizer, config, non_dp_size)

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -194,7 +194,7 @@ class SFTDataset(StatefulIterableDataset):
 
         # Parse available tools, if present - assumes OAI format
         # Reference: https://platform.openai.com/docs/guides/function-calling#function-tool-example
-        tools = json.loads(example.get("tools", "[]"))
+        tools = json.loads(example.get("tools") or "[]")
 
         def should_mask(message: dict, loss_mask_config: LossMaskConfig) -> bool:
             assert "role" in message, "Message must have a role"

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -115,8 +115,8 @@ class SFTDataset(StatefulIterableDataset):
         shuffle: bool = True,
         seed: int = 0,
         seq_len: int = 128,
-        loss_mask: LossMaskConfig = LossMaskConfig(),
         non_dp_size: int = 1,
+        loss_mask_config: LossMaskConfig = LossMaskConfig(),
         max_examples: int | None = None,
         max_epochs: int | None = None,
     ):
@@ -125,7 +125,7 @@ class SFTDataset(StatefulIterableDataset):
         self.shuffle = shuffle
         self.seed = seed
         self.seq_len = seq_len
-        self.loss_mask = loss_mask
+        self.loss_mask_config = loss_mask_config
         self.tokenizer = tokenizer
         self.max_epochs = max_epochs
 
@@ -267,7 +267,7 @@ class SFTDataset(StatefulIterableDataset):
 
         if sum(loss_mask[: self.seq_len]) == 0:
             self.logger.warning(
-                f"Skipping example with index {self.step} because no trainable tokens were found within the context window ({self.seq_len}). This is to prevent NaN loss."
+                f"Skipping example with index {example['index']} because no trainable tokens were found within the context window ({self.seq_len}). This is to prevent NaN loss."
             )
             return
 

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -81,11 +81,7 @@ def train(config: SFTTrainerConfig):
     # Set up weight checkpoint manager
     logger.info(f"Initializing weight checkpoint manager ({config.weights})")
     weight_ckpt_manager = setup_weight_ckpt_manager(
-        config.output_dir,
-        config.weights,
-        config.ckpt,
-        0,
-        config.model.experimental.lora
+        config.output_dir, config.weights, config.ckpt, 0, config.model.experimental.lora
     )
 
     # Set up checkpoint manager
@@ -98,7 +94,7 @@ def train(config: SFTTrainerConfig):
     # Set up the dataset and dataloader
     logger.info(f"Initializing data ({config.data})")
     dataset = setup_dataset(tokenizer, config.data, config.model.cp * config.model.tp)
-    dataloader = setup_dataloader(dataset, tokenizer, config.data)
+    dataloader = setup_dataloader(dataset, config.data)
     dataiter = iter(dataloader)
 
     # Check that the world size and batch configuration is compatible

--- a/tests/unit/train/sft/test_dataloader.py
+++ b/tests/unit/train/sft/test_dataloader.py
@@ -3,21 +3,25 @@ import os
 import pytest
 from transformers import AutoTokenizer
 
-from prime_rl.trainer.sft.config import FakeDataConfig, SFTDataConfig
+from prime_rl.trainer.sft.config import FakeDataConfig
 from prime_rl.trainer.sft.data import setup_dataloader, setup_dataset
 from prime_rl.trainer.world import reset_world
 
 pytestmark = [pytest.mark.gpu]
 
 
-def test_stateful_dataloader_single_rank():
+def test_fake_dataset_single_rank_state():
     # Setup stateful dataloader
     tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B")
-    config = FakeDataConfig(length="fixed", input_ids="increasing", num_examples=2, batch_size=1, micro_batch_size=1)
+    config = FakeDataConfig(length="fixed", input_ids="increasing", batch_size=1, micro_batch_size=1)
     dataset = setup_dataset(tokenizer, config)
-    dataloader = setup_dataloader(dataset, tokenizer, config)
+    dataloader = setup_dataloader(dataset, config)
     dataiter = iter(dataloader)
 
+    # Initial state
+    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": -1, "epoch": 0}}
+
+    # Iterate over samples
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 0
     assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 0, "epoch": 0}}
@@ -26,14 +30,14 @@ def test_stateful_dataloader_single_rank():
     assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 1, "epoch": 0}}
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 2
-    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 2, "epoch": 1}}
+    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 2, "epoch": 0}}
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 3
-    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 3, "epoch": 1}}
+    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 3, "epoch": 0}}
 
 
 @pytest.mark.parametrize("rank", [0, 1], ids=["rank0", "rank1"])
-def test_stateful_dataloader_multi_rank(rank: int):
+def test_fake_dataset_multi_rank_state(rank: int):
     # Setup world
     reset_world()
     os.environ["RANK"] = str(rank)
@@ -43,10 +47,13 @@ def test_stateful_dataloader_multi_rank(rank: int):
 
     # Setup stateful dataloader
     tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B")
-    config = FakeDataConfig(length="fixed", input_ids="increasing", num_examples=8, batch_size=1, micro_batch_size=1)
+    config = FakeDataConfig(length="fixed", input_ids="increasing", batch_size=1, micro_batch_size=1)
     dataset = setup_dataset(tokenizer, config)
-    dataloader = setup_dataloader(dataset, tokenizer, config)
+    dataloader = setup_dataloader(dataset, config)
     dataiter = iter(dataloader)
+
+    # Initial state
+    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": -1, "epoch": 0}}
 
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 0 + rank
@@ -62,24 +69,21 @@ def test_stateful_dataloader_multi_rank(rank: int):
     assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 6 + rank, "epoch": 0}}
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 8 + rank
-    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 8 + rank, "epoch": 1}}
+    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 8 + rank, "epoch": 0}}
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 10 + rank
-    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 10 + rank, "epoch": 1}}
+    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 10 + rank, "epoch": 0}}
 
 
-def test_stateful_dataloader_resume_fake():
+def test_fake_dataset_single_rank_resume():
     tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B")
-    num_examples = 8
-    config = FakeDataConfig(
-        length="fixed", input_ids="increasing", num_examples=num_examples, batch_size=1, micro_batch_size=1
-    )
+    config = FakeDataConfig(length="fixed", input_ids="increasing", batch_size=1, micro_batch_size=1)
     dataset = setup_dataset(tokenizer, config)
-    dataloader = setup_dataloader(dataset, tokenizer, config)
+    dataloader = setup_dataloader(dataset, config)
     dataiter = iter(dataloader)
 
-    # First 1/2 epoch
-    for step in range(num_examples // 2):
+    # First 2 samples
+    for step in range(2):
         micro_batch = next(dataiter)
         assert micro_batch["input_ids"].shape == (1, 128)
         assert micro_batch["input_ids"].unique().item() == step
@@ -88,110 +92,30 @@ def test_stateful_dataloader_resume_fake():
 
     # Reload dataloader
     state_dict = dataloader.state_dict()
-    dataloader = setup_dataloader(dataset, tokenizer, config)
+    dataloader = setup_dataloader(dataset, config)
     dataloader.load_state_dict(state_dict)
     dataiter = iter(dataloader)
 
-    # Second 1/2 epoch
-    for step in range(num_examples // 2):
+    # Second two samples
+    for step in range(2, 4):
         micro_batch = next(dataiter)
         assert micro_batch["input_ids"].shape == (1, 128)
-        assert micro_batch["input_ids"].unique().item() == num_examples // 2 + step
-        assert micro_batch["epoch"] == 0
-        assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": num_examples // 2 + step, "epoch": 0}}
-
-    # Reload dataloader
-    state_dict = dataloader.state_dict()
-    dataloader = setup_dataloader(dataset, tokenizer, config)
-    dataloader.load_state_dict(state_dict)
-    dataiter = iter(dataloader)
-
-    # Second epoch
-    for step in range(num_examples):
-        micro_batch = next(dataiter)
-        assert micro_batch["input_ids"].shape == (1, 128)
-        assert micro_batch["input_ids"].unique().item() == num_examples + step
-        assert micro_batch["epoch"] == 1
-        assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": num_examples + step, "epoch": 1}}
-
-
-def test_dataloader_ckpt_with_packing():
-    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B")
-    num_examples = 8
-    config = FakeDataConfig(length="variable", input_ids="increasing", num_examples=8, batch_size=1, micro_batch_size=1)
-    dataset = setup_dataset(tokenizer, config)
-    dataloader = setup_dataloader(dataset, tokenizer, config)
-    dataiter = iter(dataloader)
-
-    step = 0
-    for _ in range(num_examples):
-        micro_batch = next(dataiter)
-        num_packed_examples = len(micro_batch["input_ids"].unique())
-        step += num_packed_examples
-        epoch = (step - 1) // num_examples
-        assert micro_batch["input_ids"].shape == (1, 128)
-        assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": step - 1, "epoch": epoch}}
-
-
-SAMPLE_TEMPLATE = """\
-<|im_start|>user
-Prompt {idx}<|im_end|>
-<|im_start|>assistant
-<think>
-
-</think>
-
-Completion {idx}<|im_end|>\
-"""
-
-
-def test_stateful_dataloader_resume_sft():
-    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B")
-    num_examples = 8
-    config = SFTDataConfig(
-        name="mikasenghaas/test-sft",
-        num_examples=num_examples,
-        seq_len=19,
-        batch_size=1,
-        micro_batch_size=1,
-        shuffle=False,
-    )
-    dataset = setup_dataset(tokenizer, config)
-    dataloader = setup_dataloader(dataset, tokenizer, config)
-    dataiter = iter(dataloader)
-
-    # First 1/2 epoch 0
-    for step in range(num_examples // 2):
-        micro_batch = next(dataiter)
-        assert micro_batch["input_ids"].shape == (1, 19)
-        assert tokenizer.decode(micro_batch["input_ids"][0]) == SAMPLE_TEMPLATE.format(idx=step)
+        assert micro_batch["input_ids"].unique().item() == step
         assert micro_batch["epoch"] == 0
         assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": step, "epoch": 0}}
 
-    # Reload dataloader
-    state_dict = dataloader.state_dict()
-    dataloader = setup_dataloader(dataset, tokenizer, config)
-    dataloader.load_state_dict(state_dict)
+
+def test_fake_dataset_single_rank_state_with_packing():
+    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B")
+    config = FakeDataConfig(length="variable", input_ids="increasing", batch_size=1, micro_batch_size=1)
+    dataset = setup_dataset(tokenizer, config)
+    dataloader = setup_dataloader(dataset, config)
     dataiter = iter(dataloader)
 
-    # Second 1/2 epoch 0
-    for step in range(num_examples // 2):
+    step = 0
+    for _ in range(8):
         micro_batch = next(dataiter)
-        assert micro_batch["input_ids"].shape == (1, 19)
-        assert tokenizer.decode(micro_batch["input_ids"][0]) == SAMPLE_TEMPLATE.format(idx=num_examples // 2 + step)
-        assert micro_batch["epoch"] == 0
-        assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": num_examples // 2 + step, "epoch": 0}}
-
-    # Reload dataloader
-    state_dict = dataloader.state_dict()
-    dataloader = setup_dataloader(dataset, tokenizer, config)
-    dataloader.load_state_dict(state_dict)
-    dataiter = iter(dataloader)
-
-    # Epoch 1
-    for step in range(num_examples):
-        micro_batch = next(dataiter)
-        assert micro_batch["input_ids"].shape == (1, 19)
-        assert tokenizer.decode(micro_batch["input_ids"][0]) == SAMPLE_TEMPLATE.format(idx=step)
-        assert micro_batch["epoch"] == 1
-        assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": num_examples + step, "epoch": 1}}
+        num_packed_examples = len(micro_batch["input_ids"].unique())
+        step += num_packed_examples
+        assert micro_batch["input_ids"].shape == (1, 128)
+        assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": step - 1, "epoch": 0}}

--- a/tests/unit/train/sft/test_fake_dataset.py
+++ b/tests/unit/train/sft/test_fake_dataset.py
@@ -1,25 +1,22 @@
-from transformers import AutoTokenizer
-
-from prime_rl.trainer.sft.config import FakeDataConfig
 from prime_rl.trainer.sft.data import FakeDataset
 
 
 def test_init_fake_dataset():
-    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B")
-    config = FakeDataConfig(length="fixed")
-    fake_dataset = FakeDataset(tokenizer, config)
+    fake_dataset = FakeDataset(vocab_size=10000, seq_len=128)
     assert fake_dataset is not None
 
 
 def test_fake_dataset_state():
-    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B")
-    config = FakeDataConfig(length="fixed", num_examples=2)
-    dataset = FakeDataset(tokenizer, config)
+    dataset = FakeDataset(vocab_size=10000, seq_len=128)
     dataiter = iter(dataset)
-    assert dataset.state_dict() == {"step": -1, "epoch": 0}
-    next(dataiter)
+    # Initial state
+    assert dataset.state_dict() == {"step": 0, "epoch": 0}
+
+    # Iterate
     assert dataset.state_dict() == {"step": 0, "epoch": 0}
     next(dataiter)
     assert dataset.state_dict() == {"step": 1, "epoch": 0}
     next(dataiter)
-    assert dataset.state_dict() == {"step": 2, "epoch": 1}
+    assert dataset.state_dict() == {"step": 2, "epoch": 0}
+    next(dataiter)
+    assert dataset.state_dict() == {"step": 3, "epoch": 0}

--- a/tests/unit/train/sft/test_fake_dataset.py
+++ b/tests/unit/train/sft/test_fake_dataset.py
@@ -9,10 +9,12 @@ def test_init_fake_dataset():
 def test_fake_dataset_state():
     dataset = FakeDataset(vocab_size=10000, seq_len=128)
     dataiter = iter(dataset)
+
     # Initial state
-    assert dataset.state_dict() == {"step": 0, "epoch": 0}
+    assert dataset.state_dict() == {"step": -1, "epoch": 0}
 
     # Iterate
+    next(dataiter)
     assert dataset.state_dict() == {"step": 0, "epoch": 0}
     next(dataiter)
     assert dataset.state_dict() == {"step": 1, "epoch": 0}

--- a/tests/unit/train/sft/test_fake_dataset.py
+++ b/tests/unit/train/sft/test_fake_dataset.py
@@ -1,0 +1,25 @@
+from transformers import AutoTokenizer
+
+from prime_rl.trainer.sft.config import FakeDataConfig
+from prime_rl.trainer.sft.data import FakeDataset
+
+
+def test_init_fake_dataset():
+    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B")
+    config = FakeDataConfig(length="fixed")
+    fake_dataset = FakeDataset(tokenizer, config)
+    assert fake_dataset is not None
+
+
+def test_fake_dataset_state():
+    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B")
+    config = FakeDataConfig(length="fixed", num_examples=2)
+    dataset = FakeDataset(tokenizer, config)
+    dataiter = iter(dataset)
+    assert dataset.state_dict() == {"step": -1, "epoch": 0}
+    next(dataiter)
+    assert dataset.state_dict() == {"step": 0, "epoch": 0}
+    next(dataiter)
+    assert dataset.state_dict() == {"step": 1, "epoch": 0}
+    next(dataiter)
+    assert dataset.state_dict() == {"step": 2, "epoch": 1}

--- a/tests/unit/train/sft/test_sft_dataset.py
+++ b/tests/unit/train/sft/test_sft_dataset.py
@@ -5,30 +5,9 @@ import pytest
 from datasets import Dataset, interleave_datasets, load_dataset
 from transformers import AutoTokenizer
 
-from prime_rl.trainer.sft.config import FakeDataConfig, SFTDataConfig
-from prime_rl.trainer.sft.data import FakeDataset, SFTDataset
+from prime_rl.trainer.sft.config import SFTDataConfig
+from prime_rl.trainer.sft.data import SFTDataset
 from prime_rl.trainer.utils import print_sample
-
-
-def test_init_fake_dataset():
-    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B")
-    config = FakeDataConfig(length="fixed")
-    fake_dataset = FakeDataset(tokenizer, config)
-    assert fake_dataset is not None
-
-
-def test_fake_dataset_state():
-    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B")
-    config = FakeDataConfig(length="fixed", num_examples=2)
-    dataset = FakeDataset(tokenizer, config)
-    dataiter = iter(dataset)
-    assert dataset.state_dict() == {"step": -1, "epoch": 0}
-    next(dataiter)
-    assert dataset.state_dict() == {"step": 0, "epoch": 0}
-    next(dataiter)
-    assert dataset.state_dict() == {"step": 1, "epoch": 0}
-    next(dataiter)
-    assert dataset.state_dict() == {"step": 2, "epoch": 1}
 
 
 def test_init_sft_dataset():


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

This PR allows more configurability to the SFT data mix:
- Specify training on multiple subsets (`--data.subsets`) and/or splits (`--data.splits`). If None is specified, we default to loading the default train split. If one is specified we default to `subset=None` and `split="train"` for the other. If both are specified, we assume that `splits[i]` is the split for `subsets[i]` and so we check for a length match.
- Dynamically define the ratio of each subset/split via `--data.probabilities`. We rely on `datasets.interleave_datasets` to achieve this, here is a minimal example of how it works

```python
from datasets import Dataset, interleave_datasets

a = Dataset.from_dict({"x": ["a1"]})
b = Dataset.from_dict({"x": ["b1", "b2", "b3", "b4", "b5", "b6", "b7", "b8", "b9"]})
ds = [a, b]
d = interleave_datasets(ds, probabilities=[0.5, 0.5], stopping_strategy="all_exhausted")
print("a: ", a["x"])
print("b: ", b["x"])
print("\nSampling order: ", end="")
for x in d:
    print(x["x"], end=" ")
```

```
a:  Column(['a1'])
b:  Column(['b1', 'b2', 'b3', 'b4', 'b5'])

Sampling order: a1 b1 a1 a1 a1 b2 a1 a1 b3 a1 a1 a1 a1 b4 a1 b5 b6 a1 a1 b7 b8 a1 b9
```

Misc changes:
- We use `interleave_datasets` instead of `concatenate_datasets` to support dynamic up- and downsampling via `probabilities`
- The above required some refactoring of our `iter` function because epoch borders are now not specified by the total number of examples (sum of all splits) but by the randomness of the sampling. We now define an epoch border precisely as "the dataset has run out of samples"
- A bunch of updates and improvements to thoroughly test the dataset and dataloader (checkpointing) behavior
- Deprecates `num_examples` on fake data. It's always an infinite dataloader
- Do not pass config object into base data classes to make them easier to unit test

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: #1077,  #1078
**Linear Issue**: Resolves PRIMERL-155, PRIMERL-156