### PR TITLE
Fix finding latest checkpoint and make RL compatible

### DIFF
--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -288,8 +288,8 @@ class CheckpointConfig(BaseConfig):
     resume_step: Annotated[
         int | None,
         Field(
-            ge=1,
-            description="Step to resume orchestrator from. If None, will start from scratch.",
+            ge=-1,
+            description="Step to resume orchestrator from. If None, will start from scratch. If -1, will restart from latest checkpoint available.",
         ),
     ] = None
 

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -340,7 +340,7 @@ class CheckpointConfig(BaseConfig):
         int | None,
         Field(
             ge=-1,
-            description="Step to resume training from. If None, will start from scratch. if -1, will restart from latest checkpoint available.",
+            description="Step to resume training from. If None, will start from scratch. If -1, will restart from latest checkpoint available.",
         ),
     ] = None
 


### PR DESCRIPTION

<!-- Provide a brief description of the changes in this PR -->

Fixes an issue where resuming from "latest" checkpoint (`--resume-step -1`) did not actually resume from the latest checkpoint. Also, copies the "load from latest" behavior to the orchestrator, so that this feature is also available for resuming RL training runs.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: #1083 
**Linear Issue**: Resolves PRIMERL-157