### PR TITLE
Log num samples/tokens per subset/split in SFT trainer

### DIFF
--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 from collections import defaultdict
-from typing import Iterator, Literal, TypedDict, cast
+from typing import Literal, TypedDict, cast
 
 import torch
 from datasets import Dataset, interleave_datasets, load_dataset
@@ -20,7 +20,6 @@ STACKING_DATASET_BUCKET_TIMEOUT = 10
 
 
 class Sample(TypedDict):
-    epoch: int  # TODO: Argh, can we find a way to export epoch metainformation in a nicer way?
     input_ids: list[int]
     position_ids: list[int]
     loss_mask: list[bool]
@@ -28,7 +27,6 @@ class Sample(TypedDict):
 
 
 class Batch(TypedDict):
-    epoch: int
     input_ids: Int[Tensor, "batch seq"]
     position_ids: Int[Tensor, "batch seq"]
     target_ids: Int[Tensor, "batch seq"]
@@ -40,6 +38,7 @@ class StatefulIterableDataset(Stateful, IterableDataset):
 
     def __init__(self):
         self.step, self.epoch = -1, 0
+        self.num_samples = defaultdict(int)
         self._setup_world_info()
 
     def state_dict(self) -> dict:
@@ -99,8 +98,8 @@ class FakeDataset(StatefulIterableDataset):
                 "target_ids": input_ids[1:],
                 "position_ids": position_ids,
                 "loss_mask": loss_mask,
-                "epoch": self.epoch,
             }
+            self.num_samples["fake"] += 1
             yield fake_sample
 
 
@@ -282,7 +281,6 @@ class SFTDataset(StatefulIterableDataset):
             "target_ids": target_ids,
             "loss_mask": loss_mask,
             "position_ids": list(range(len(input_ids))),
-            "epoch": self.epoch,
         }
 
     def __iter__(self):
@@ -315,12 +313,13 @@ class SFTDataset(StatefulIterableDataset):
 
                 # Yield the example
                 example = cast(dict, example)
-                subset_or_split = example.get("subset", example.get("split"))
+                subset_or_split = example.get("subset", example.get("split")) or "train"
                 self.logger.debug(
                     f"Yield example {example['index']}"
                     + (f" from {subset_or_split} " if subset_or_split else " ")
                     + f"with {len(processed_example.get('input_ids', []))} tokens ({sum(processed_example.get('loss_mask', []))} trainable tokens)"
                 )
+                self.num_samples[subset_or_split] += 1
                 yield processed_example
 
             # Reset step count and increment epoch
@@ -345,15 +344,13 @@ class CatDataset(StatefulIterableDataset):
     def load_state_dict(self, state_dict: dict):
         self.dataset.load_state_dict(state_dict["dataset"])
 
-    def __iter__(self) -> Iterator[Sample]:
+    def __iter__(self):
         packed_samples, seq_len = defaultdict(list), 0
         for sample in self.dataset:
             # Add sample to packed samples
             for key, value in sample.items():
-                if key == "epoch":
-                    packed_samples[key] = min(packed_samples.get(key, float("inf")), value)
-                else:
-                    packed_samples[key].extend(value)
+                assert isinstance(value, list), f"Value for key {key} must be a list"
+                packed_samples[key].extend(value)
 
             # Update sequence length
             seq_len += len(sample["input_ids"])
@@ -361,8 +358,8 @@ class CatDataset(StatefulIterableDataset):
             # If batch is full, truncate and yield it
             if seq_len >= self.seq_len:
                 for key, value in packed_samples.items():
-                    if isinstance(value, list):
-                        packed_samples[key] = value[: self.seq_len]
+                    assert isinstance(value, list), f"Value for key {key} must be a list"
+                    packed_samples[key] = value[: self.seq_len]
                 yield packed_samples
                 packed_samples, seq_len = defaultdict(list), 0
 
@@ -395,14 +392,14 @@ class StackDataset(StatefulIterableDataset):
         self.buckets = state_dict["buckets"]
         self.bucket_timers = state_dict["bucket_timers"]
 
-    def __iter__(self) -> Iterator[Sample]:
+    def __iter__(self):
         for sample in self.dataset:
             # Truncate sample if it's longer than max area
             len_sample = len(sample["input_ids"])
             if len_sample > self.max_area:
                 for key, value in sample.items():
-                    if isinstance(value, list):
-                        sample[key] = sample[key][: self.max_area]
+                    assert isinstance(value, list)
+                    sample[key] = sample[key][: self.max_area]
                 len_sample = self.max_area
 
             # Add sample to bucket
@@ -446,10 +443,7 @@ class StackDataset(StatefulIterableDataset):
                 packed_samples = defaultdict(list)
                 for bucket_item in self.buckets[bucket_idx]:
                     for key, value in bucket_item.items():
-                        if key == "epoch":
-                            packed_samples[key] = min(packed_samples.get(key, float("inf")), value)
-                        else:
-                            packed_samples[key].append(value + [0] * (self.bucket_sizes[bucket_idx] - len(value)))
+                        packed_samples[key].append(value + [0] * (self.bucket_sizes[bucket_idx] - len(value)))
                 yield packed_samples
                 self.step += 1
                 self.buckets[bucket_idx] = []
@@ -465,7 +459,6 @@ def stack_collate(samples: list[Sample]) -> Batch:
         "position_ids": torch.tensor(samples[0]["position_ids"], dtype=torch.long, device="cuda"),
         "loss_mask": torch.tensor(samples[0]["loss_mask"], dtype=torch.bool, device="cuda"),
         "target_ids": torch.tensor(samples[0]["target_ids"], dtype=torch.long, device="cuda"),
-        "epoch": min([sample["epoch"] for sample in samples]),
     }
 
 
@@ -477,7 +470,6 @@ def cat_collate(samples: list[Sample]) -> Batch:
         .to("cuda"),
         "loss_mask": torch.stack([torch.tensor(sample["loss_mask"]) for sample in samples], dim=0).bool().to("cuda"),
         "target_ids": torch.stack([torch.tensor(sample["target_ids"]) for sample in samples], dim=0).long().to("cuda"),
-        "epoch": min([sample["epoch"] for sample in samples]),
     }
 
 

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -39,6 +39,7 @@ class StatefulIterableDataset(Stateful, IterableDataset):
     def __init__(self):
         self.step, self.epoch = -1, 0
         self.num_samples = defaultdict(int)
+        self.num_tokens = defaultdict(int)
         self._setup_world_info()
 
     def state_dict(self) -> dict:
@@ -100,6 +101,7 @@ class FakeDataset(StatefulIterableDataset):
                 "loss_mask": loss_mask,
             }
             self.num_samples["fake"] += 1
+            self.num_tokens["fake"] += len(input_ids)
             yield fake_sample
 
 
@@ -320,6 +322,7 @@ class SFTDataset(StatefulIterableDataset):
                     + f"with {len(processed_example.get('input_ids', []))} tokens ({sum(processed_example.get('loss_mask', []))} trainable tokens)"
                 )
                 self.num_samples[subset_or_split] += 1
+                self.num_tokens[subset_or_split] += len(processed_example.get("input_ids", []))
                 yield processed_example
 
             # Reset step count and increment epoch

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -177,7 +177,6 @@ def train(config: SFTTrainerConfig):
 
         step_start_time = time.time()
         forward_backward_start_time = time.time()
-        epoch = 0
         grad_accum_steps = (
             config.data.batch_size
             * config.model.cp
@@ -193,7 +192,6 @@ def train(config: SFTTrainerConfig):
             position_ids = micro_batch["position_ids"].to("cuda")
             target_ids = micro_batch["target_ids"].to("cuda")
             loss_mask = micro_batch["loss_mask"].to("cuda")
-            epoch = micro_batch["epoch"]
             assert input_ids.shape == position_ids.shape == target_ids.shape == loss_mask.shape, (
                 f"input_ids.shape: {input_ids.shape}, position_ids.shape: {position_ids.shape}, target_ids.shape: {target_ids.shape}, loss_mask.shape: {loss_mask.shape}"
             )
@@ -270,7 +268,7 @@ def train(config: SFTTrainerConfig):
         # Compute step metrics
         num_tokens = config.data.batch_size * config.data.seq_len
         progress.total_tokens += num_tokens
-        progress.total_samples = dataloader.state_dict()["dataset_state"]["dataset"]["step"]
+        progress.total_samples = dataset.step
         perf_counter = get_perf_counter(model, config.data.seq_len)
         perf_counter.count_tokens(num_tokens)
         throughput = perf_counter.get_tokens_per_second() or 0
@@ -286,9 +284,13 @@ def train(config: SFTTrainerConfig):
 
         # Log progress metrics
         progress_metrics = {
-            "progress/epoch": epoch,
-            "progress/total_samples": progress.total_samples,
-            "progress/total_tokens": progress.total_tokens,
+            "progress/epoch": dataset.epoch,
+            "progress/dataset_step": dataset.step,
+            "progress/num_samples": sum(dataset.num_samples.values()),
+            **{
+                f"progress/{subset_or_split}/num_samples": num_samples
+                for subset_or_split, num_samples in dataset.num_samples.items()
+            },
             "step": progress.step,
         }
         monitor.log(progress_metrics)

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -283,17 +283,27 @@ def train(config: SFTTrainerConfig):
         logger.success(step_message)
 
         # Log progress metrics
+        total_samples = sum(dataset.num_samples.values())
+        total_tokens = sum(dataset.num_tokens.values())
         progress_metrics = {
             "progress/epoch": dataset.epoch,
             "progress/dataset_step": dataset.step,
-            "progress/num_samples": sum(dataset.num_samples.values()),
+            "progress/num_samples": total_samples,
+            "progress/num_tokens": total_tokens,
             **{
                 f"progress/{subset_or_split}/num_samples": num_samples
                 for subset_or_split, num_samples in dataset.num_samples.items()
             },
-            "progress/num_tokens": sum(dataset.num_tokens.values()),
+            **{
+                f"progress/{subset_or_split}/ratio_samples": num_samples / total_samples
+                for subset_or_split, num_samples in dataset.num_samples.items()
+            },
             **{
                 f"progress/{subset_or_split}/num_tokens": num_tokens
+                for subset_or_split, num_tokens in dataset.num_tokens.items()
+            },
+            **{
+                f"progress/{subset_or_split}/ratio_tokens": num_tokens / total_tokens
                 for subset_or_split, num_tokens in dataset.num_tokens.items()
             },
             "step": progress.step,

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -291,6 +291,11 @@ def train(config: SFTTrainerConfig):
                 f"progress/{subset_or_split}/num_samples": num_samples
                 for subset_or_split, num_samples in dataset.num_samples.items()
             },
+            "progress/num_tokens": sum(dataset.num_tokens.values()),
+            **{
+                f"progress/{subset_or_split}/num_tokens": num_tokens
+                for subset_or_split, num_tokens in dataset.num_tokens.items()
+            },
             "step": progress.step,
         }
         monitor.log(progress_metrics)

--- a/tests/unit/train/sft/test_dataloader.py
+++ b/tests/unit/train/sft/test_dataloader.py
@@ -87,7 +87,6 @@ def test_fake_dataset_single_rank_resume():
         micro_batch = next(dataiter)
         assert micro_batch["input_ids"].shape == (1, 128)
         assert micro_batch["input_ids"].unique().item() == step
-        assert micro_batch["epoch"] == 0
         assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": step, "epoch": 0}}
 
     # Reload dataloader
@@ -101,7 +100,6 @@ def test_fake_dataset_single_rank_resume():
         micro_batch = next(dataiter)
         assert micro_batch["input_ids"].shape == (1, 128)
         assert micro_batch["input_ids"].unique().item() == step
-        assert micro_batch["epoch"] == 0
         assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": step, "epoch": 0}}
 
 


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

FINALLY, removes the atrocity of passing the epoch count through our batch for logging purposes. Now, the epoch, number of samples and tokens per subset/split are all directly accessed from the underlying dataset class from the main training loop and logged to W&B.
- Epoch: `progress/epoch`
- Dataset Step: `progress/dataset_step`
- #Samples: `progress/num_samples`
- #Samples/Split: `progress/{split}/num_samples`
- #Samples: `progress/num_tokens`
- #Tokens/Split: `progress/{split}/num_samples`

```bash
uv run torchrun src/prime_rl/trainer/sft/train.py   --model.name PrimeIntellect/Qwen3-1.7B   --model.compile   --data.name PrimeIntellect/INTELLECT-3-SFT-Stage-2-1K   --data.subsets am_if,am_chat   --data.seq-len 32768   --data.batch-size 8   --data.micro-batch-size 1   --max-steps 1000   --optim.lr 1e-4   --scheduler.type cosine   --scheduler.warmup-steps 100   --scheduler.min-lr 1e-7 --wandb.project mika --wandb.name epoch-debug --log.level debug --max-steps 30
```

[W&B Project](https://wandb.ai/primeintellect/mika?nw=9h9zvwo4726)

<img width="1002" height="510" alt="Screenshot 2025-10-09 at 9 24 36 PM" src="https://github.com/user-attachments/assets/521260fb-c0b4-4c84-8879-b08841932de0" />
