### PR TITLE
Align dataset state definition, fix progress logging and multi-rank resume

### DIFF
--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -114,7 +114,7 @@ def train(config: SFTTrainerConfig):
         logger.info(f"Resuming training from checkpoint step {config.ckpt.resume_step}")
         ckpt_manager.load(model, [optimizer], scheduler, progress, step=config.ckpt.resume_step, dataloader=dataloader)
     logger.info(
-        f"Starting from step {progress.step} (total_tokens={progress.total_tokens}, total_samples={progress.total_samples}, dataloader_state={dataloader.state_dict()['dataset_state']})"
+        f"Starting from step {progress.step} (total_tokens={progress.total_tokens}, total_samples={progress.total_samples}, dataset_state={dataloader.state_dict()['dataset_state']})"
     )
 
     logger.info(f"Starting training loop ({config.max_steps=})")
@@ -287,20 +287,11 @@ def train(config: SFTTrainerConfig):
         total_tokens = sum(dataset.num_tokens.values())
         progress_metrics = {
             "progress/epoch": dataset.epoch,
-            "progress/dataset_step": dataset.step,
-            "progress/num_samples": total_samples,
-            "progress/num_tokens": total_tokens,
-            **{
-                f"progress/{subset_or_split}/num_samples": num_samples
-                for subset_or_split, num_samples in dataset.num_samples.items()
-            },
+            "progress/num_samples": progress.total_samples,
+            "progress/num_tokens": progress.total_tokens,
             **{
                 f"progress/{subset_or_split}/ratio_samples": num_samples / total_samples
                 for subset_or_split, num_samples in dataset.num_samples.items()
-            },
-            **{
-                f"progress/{subset_or_split}/num_tokens": num_tokens
-                for subset_or_split, num_tokens in dataset.num_tokens.items()
             },
             **{
                 f"progress/{subset_or_split}/ratio_tokens": num_tokens / total_tokens

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -289,16 +289,20 @@ def train(config: SFTTrainerConfig):
             "progress/epoch": dataset.epoch,
             "progress/num_samples": progress.total_samples,
             "progress/num_tokens": progress.total_tokens,
-            **{
-                f"progress/{subset_or_split}/ratio_samples": num_samples / total_samples
-                for subset_or_split, num_samples in dataset.num_samples.items()
-            },
-            **{
-                f"progress/{subset_or_split}/ratio_tokens": num_tokens / total_tokens
-                for subset_or_split, num_tokens in dataset.num_tokens.items()
-            },
             "step": progress.step,
         }
+        # At least two subsets/splits
+        if len(dataset.num_samples) > 1:
+            progress_metrics.update(
+                **{
+                    f"progress/{subset_or_split}/ratio_samples": num_samples / total_samples
+                    for subset_or_split, num_samples in dataset.num_samples.items()
+                },
+                **{
+                    f"progress/{subset_or_split}/ratio_tokens": num_tokens / total_tokens
+                    for subset_or_split, num_tokens in dataset.num_tokens.items()
+                },
+            )
         monitor.log(progress_metrics)
 
         # Log performance metrics

--- a/tests/unit/train/sft/test_dataloader.py
+++ b/tests/unit/train/sft/test_dataloader.py
@@ -19,21 +19,22 @@ def test_fake_dataset_single_rank_state():
     dataiter = iter(dataloader)
 
     # Initial state
-    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": -1, "epoch": 0}}
+    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 0, "epoch": 0}}
 
     # Iterate over samples
     micro_batch = next(dataiter)
+    print(micro_batch)
     assert micro_batch["input_ids"].unique().item() == 0
-    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 0, "epoch": 0}}
-    micro_batch = next(dataiter)
-    assert micro_batch["input_ids"].unique().item() == 1
     assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 1, "epoch": 0}}
     micro_batch = next(dataiter)
-    assert micro_batch["input_ids"].unique().item() == 2
+    assert micro_batch["input_ids"].unique().item() == 1
     assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 2, "epoch": 0}}
     micro_batch = next(dataiter)
-    assert micro_batch["input_ids"].unique().item() == 3
+    assert micro_batch["input_ids"].unique().item() == 2
     assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 3, "epoch": 0}}
+    micro_batch = next(dataiter)
+    assert micro_batch["input_ids"].unique().item() == 3
+    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 4, "epoch": 0}}
 
 
 @pytest.mark.parametrize("rank", [0, 1], ids=["rank0", "rank1"])
@@ -53,26 +54,26 @@ def test_fake_dataset_multi_rank_state(rank: int):
     dataiter = iter(dataloader)
 
     # Initial state
-    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": -1, "epoch": 0}}
+    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 0, "epoch": 0}}
 
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 0 + rank
-    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 0 + rank, "epoch": 0}}
+    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 1 + rank, "epoch": 0}}
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 2 + rank
-    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 2 + rank, "epoch": 0}}
+    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 3 + rank, "epoch": 0}}
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 4 + rank
-    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 4 + rank, "epoch": 0}}
+    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 5 + rank, "epoch": 0}}
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 6 + rank
-    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 6 + rank, "epoch": 0}}
+    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 7 + rank, "epoch": 0}}
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 8 + rank
-    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 8 + rank, "epoch": 0}}
+    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 9 + rank, "epoch": 0}}
     micro_batch = next(dataiter)
     assert micro_batch["input_ids"].unique().item() == 10 + rank
-    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 10 + rank, "epoch": 0}}
+    assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": 11 + rank, "epoch": 0}}
 
 
 def test_fake_dataset_single_rank_resume():
@@ -87,7 +88,7 @@ def test_fake_dataset_single_rank_resume():
         micro_batch = next(dataiter)
         assert micro_batch["input_ids"].shape == (1, 128)
         assert micro_batch["input_ids"].unique().item() == step
-        assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": step, "epoch": 0}}
+        assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": step + 1, "epoch": 0}}
 
     # Reload dataloader
     state_dict = dataloader.state_dict()
@@ -100,7 +101,7 @@ def test_fake_dataset_single_rank_resume():
         micro_batch = next(dataiter)
         assert micro_batch["input_ids"].shape == (1, 128)
         assert micro_batch["input_ids"].unique().item() == step
-        assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": step, "epoch": 0}}
+        assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": step + 1, "epoch": 0}}
 
 
 def test_fake_dataset_single_rank_state_with_packing():
@@ -116,4 +117,4 @@ def test_fake_dataset_single_rank_state_with_packing():
         num_packed_examples = len(micro_batch["input_ids"].unique())
         step += num_packed_examples
         assert micro_batch["input_ids"].shape == (1, 128)
-        assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": step - 1, "epoch": 0}}
+        assert dataloader.state_dict()["dataset_state"] == {"dataset": {"step": step, "epoch": 0}}

--- a/tests/unit/train/sft/test_fake_dataset.py
+++ b/tests/unit/train/sft/test_fake_dataset.py
@@ -11,14 +11,14 @@ def test_fake_dataset_state():
     dataiter = iter(dataset)
 
     # Initial state
-    assert dataset.state_dict() == {"step": -1, "epoch": 0}
+    assert dataset.state_dict() == {"step": 0, "epoch": 0}
 
     # Iterate
-    next(dataiter)
-    assert dataset.state_dict() == {"step": 0, "epoch": 0}
     next(dataiter)
     assert dataset.state_dict() == {"step": 1, "epoch": 0}
     next(dataiter)
     assert dataset.state_dict() == {"step": 2, "epoch": 0}
     next(dataiter)
     assert dataset.state_dict() == {"step": 3, "epoch": 0}
+    next(dataiter)
+    assert dataset.state_dict() == {"step": 4, "epoch": 0}

--- a/tests/unit/train/sft/test_sft_dataset.py
+++ b/tests/unit/train/sft/test_sft_dataset.py
@@ -100,19 +100,19 @@ def test_sft_dataset_state(build_dummy_dataset):
     dataiter = iter(dataset)
 
     # Initial state
-    assert dataset.state_dict() == {"step": -1, "epoch": 0}
+    assert dataset.state_dict() == {"step": 0, "epoch": 0}
 
     # Epoch 1
     for i in range(4):
         sample = next(dataiter)
         assert sample["text"] == str(i)
-        assert dataset.state_dict() == {"epoch": 0, "step": i}
+        assert dataset.state_dict() == {"epoch": 0, "step": i + 1}
 
     # Epoch 2
     for i in range(4):
         sample = next(dataiter)
         assert sample["text"] == str(i)
-        assert dataset.state_dict() == {"epoch": 1, "step": i}
+        assert dataset.state_dict() == {"epoch": 1, "step": 4 + i + 1}
 
     with pytest.raises(StopIteration):
         next(dataiter)
@@ -124,14 +124,14 @@ def test_sft_dataset_state_resume(build_dummy_dataset):
     dataiter = iter(dataset)
 
     # Initial state
-    assert dataset.state_dict() == {"step": -1, "epoch": 0}
+    assert dataset.state_dict() == {"step": 0, "epoch": 0}
 
     # Epoch 1
     for i in range(4):
         sample = next(dataiter)
         print(sample["text"])
         assert sample["text"] == str(i)
-        assert dataset.state_dict() == {"epoch": 0, "step": i}
+        assert dataset.state_dict() == {"epoch": 0, "step": i + 1}
 
     # Resuming from checkpoint cross epoch
     state_dict = dataset.state_dict()
@@ -145,7 +145,7 @@ def test_sft_dataset_state_resume(build_dummy_dataset):
         sample = next(dataiter)
         print(sample["text"])
         assert sample["text"] == str(i)
-        assert dataset.state_dict() == {"epoch": 1, "step": i}
+        assert dataset.state_dict() == {"epoch": 1, "step": 4 + i + 1}
 
     # Resuming from checkpoint mid epoch
     state_dict = dataset.state_dict()
@@ -159,7 +159,7 @@ def test_sft_dataset_state_resume(build_dummy_dataset):
         sample = next(dataiter)
         print(sample["text"])
         assert sample["text"] == str(i)
-        assert dataset.state_dict() == {"epoch": 1, "step": i}
+        assert dataset.state_dict() == {"epoch": 1, "step": 4 + i + 1}
 
     with pytest.raises(StopIteration):
         next(dataiter)


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

#1085 introduced reporting `progress/num_samples` and `progress/num_tokens` directly from the statistics the dataset would keep. However, these are local metrics and so we are reporting the wrong thing. To revert to reporting a proxy of the global number of samples trained on (without introducing additional comm) was to revert the dataset step definition to be strictly increasing (technically, this is not the true number of samples trained on, but "seen" but ideally these two are close to each other). This PR also fixes an inconsistency in how we handled step and epoch increments. Now, we increment the epoch counter *at the beginning of entering a loop* (instead of at the end) to make it checkpoint compatible.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->