### PR TITLE
fix: replace deprecated huggingface-cli login with hf auth login

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ uv run wandb login
 2. If you require gated/ private models or datasets from [HuggingFace](https://huggingface.co), log in
 
 ```bash
-uv run huggingface-cli login
+uv run hf auth login
 # Or set `export HF_TOKEN=...`
 ```
 


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Fix for this warning message while running huggingface-cli login

⚠️  Warning: 'huggingface-cli login' is deprecated. Use 'hf auth login' instead.
---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->