### PR TITLE
More graceful fallback for dynamic world restarts

### DIFF
--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -144,8 +144,6 @@ class CheckpointManager:
         dcp.load(state_dict=state_dict, checkpoint_id=ckpt_path)
 
         # Load the dataloader
-        # TODO: Is there a way we can make this so one can restart in any world
-
         if self.config.skip_dataloader:
             get_logger().warning("Skipping dataloader checkpointing")
 
@@ -155,7 +153,6 @@ class CheckpointManager:
                 self._logger.warning(
                     f"Did not find local dataloader checkpoint at path {dataloader_path}. This might be because you tried restarting the trainer with a different world size. Falling back to using the master rank's dataloader checkpoint. Note, that this may cause training inconsistencies."
                 )
-            else:
                 dataloader_path = ckpt_path / "dataloader" / "rank_0.pt"
                 if not dataloader_path.exists():
                     raise RuntimeError(


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Previously we would error when trying to resume SFT training in a larger world size because the dataloader checkpoint cannot be found in the filesystem. We now catch this error, print a warning and fallback to using the master ranks dataloader checkpoint which should be ~fine in most scenarios.

Downscale: Run in world size 2, resume in world size 1

<img width="327" height="239" alt="Screenshot 2025-10-11 at 11 57 54 AM" src="https://github.com/user-attachments/assets/1d7c783d-56b0-40a8-bb03-57e71eb73814" />

Upscale: Run in world size 1, resume in world size 2

<img width="325" height="237" alt="Screenshot 2025-10-11 at 12 03 52 PM" src="https://github.com/user-attachments/assets/455465a5-1c64-4622-961f-62627c91984c" />
