### PR TITLE
Fix LR scheduler checkpoint resume

### DIFF
--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -41,8 +41,8 @@ class AppState(Stateful):
         self,
         model: Module,
         optimizers: list[Optimizer],
-        scheduler: LRScheduler,
-        progress: Progress,
+        scheduler: LRScheduler | None,
+        progress: Progress | None,
     ):
         self.model = model
         self.optimizers = optimizers
@@ -52,23 +52,28 @@ class AppState(Stateful):
     def state_dict(self) -> dict[str, Any]:
         # Automatically manages FSDP FQN's, as well as sets the default state dict type to FSDP.SHARDED_STATE_DICT
         model_state_dict, optimizer_state_dict = get_state_dict(self.model, self.optimizers)
-        scheduler_state_dict = self.scheduler.state_dict()
-        progress_state_dict = asdict(self.progress)
         state_dict = {
             "model": model_state_dict,
             "optimizers": optimizer_state_dict,
-            "scheduler": scheduler_state_dict,
-            "progress": progress_state_dict,
         }
+        if self.scheduler is not None:
+            scheduler_state_dict = self.scheduler.state_dict()
+            state_dict["scheduler"] = scheduler_state_dict
+        if self.progress is not None:
+            progress_state_dict = asdict(self.progress)
+            state_dict["progress"] = progress_state_dict
         return state_dict
 
     def load_state_dict(self, state_dict: dict[str, Any]):
         set_state_dict(
             self.model, self.optimizers, model_state_dict=state_dict["model"], optim_state_dict=state_dict["optimizers"]
         )
-        self.scheduler.load_state_dict(state_dict["scheduler"])
-        for key, value in state_dict["progress"].items():
-            setattr(self.progress, key, value)
+        if self.scheduler is not None:
+            print("loading scheduler")
+            self.scheduler.load_state_dict(state_dict["scheduler"])
+        if self.progress is not None:
+            for key, value in state_dict["progress"].items():
+                setattr(self.progress, key, value)
 
 
 class CheckpointManager:
@@ -130,8 +135,8 @@ class CheckpointManager:
         ckpt_path: Path,
         model: nn.Module,
         optimizers: list[Optimizer],
-        scheduler: LRScheduler,
-        progress: Progress,
+        scheduler: LRScheduler | None,
+        progress: Progress | None,
         dataloader: StatefulDataLoader | None = None,
     ):
         """Loads a checkpoint from a given path in-place."""
@@ -144,10 +149,7 @@ class CheckpointManager:
         dcp.load(state_dict=state_dict, checkpoint_id=ckpt_path)
 
         # Load the dataloader
-        if self.config.skip_dataloader:
-            get_logger().warning("Skipping dataloader checkpointing")
-
-        if dataloader is not None and not self.config.skip_dataloader:
+        if dataloader is not None:
             dataloader_path = ckpt_path / "dataloader" / f"rank_{self._world.rank}.pt"
             if not dataloader_path.exists():
                 self._logger.warning(
@@ -166,8 +168,8 @@ class CheckpointManager:
         self,
         model: nn.Module,
         optimizers: list[Optimizer],
-        scheduler: LRScheduler,
-        progress: Progress,
+        scheduler: LRScheduler | None,
+        progress: Progress | None,
         step: int,
         dataloader: StatefulDataLoader | None = None,
     ) -> None:

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -65,11 +65,8 @@ class AppState(Stateful):
         return state_dict
 
     def load_state_dict(self, state_dict: dict[str, Any]):
-        set_state_dict(
-            self.model, self.optimizers, model_state_dict=state_dict["model"], optim_state_dict=state_dict["optimizers"]
-        )
+        set_state_dict(self.model, [], model_state_dict=state_dict["model"], optim_state_dict=state_dict["optimizers"])
         if self.scheduler is not None:
-            print("loading scheduler")
             self.scheduler.load_state_dict(state_dict["scheduler"])
         if self.progress is not None:
             for key, value in state_dict["progress"].items():

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -352,10 +352,24 @@ class CheckpointConfig(BaseConfig):
         ),
     ] = None
 
+    skip_progress: Annotated[
+        bool,
+        Field(
+            description="Whether to skip loading the progress from checkpoint.",
+        ),
+    ] = False
+
+    skip_scheduler: Annotated[
+        bool,
+        Field(
+            description="Whether to skip loading the scheduler from checkpoint.",
+        ),
+    ] = False
+
     skip_dataloader: Annotated[
         bool,
         Field(
-            description="Whether to skip checkpointing the dataloader. If True, will not checkpoint the dataloader.",
+            description="Whether to skip loading the dataloader from checkpoint.",
         ),
     ] = False
 

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -112,7 +112,14 @@ def train(config: SFTTrainerConfig):
     progress = Progress()
     if ckpt_manager is not None and config.ckpt and config.ckpt.resume_step:
         logger.info(f"Resuming training from checkpoint step {config.ckpt.resume_step}")
-        ckpt_manager.load(model, [optimizer], scheduler, progress, step=config.ckpt.resume_step, dataloader=dataloader)
+        ckpt_manager.load(
+            model,
+            [optimizer],
+            scheduler if not config.ckpt.skip_scheduler else None,
+            progress if not config.ckpt.skip_progress else None,
+            step=config.ckpt.resume_step,
+            dataloader=dataloader if not config.ckpt.skip_dataloader else None,
+        )
     logger.info(
         f"Starting from step {progress.step} (total_tokens={progress.total_tokens}, total_samples={progress.total_samples}, dataset_state={dataloader.state_dict()['dataset_state']})"
     )

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -129,7 +129,6 @@ def train(config: SFTTrainerConfig):
         # This redundant setup is necessary because loading the optimizer's state has side effects on the scheduler state dict
         if config.ckpt.skip_scheduler:
             scheduler = setup_scheduler(optimizer, config.scheduler, scheduler_steps, config.optim.lr)
-        print(scheduler.state_dict())
     logger.info(
         f"Starting from step {progress.step} (total_tokens={progress.total_tokens}, total_samples={progress.total_samples}, dataset_state={dataloader.state_dict()['dataset_state']})"
     )

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -126,6 +126,10 @@ def train(config: SFTTrainerConfig):
             step=config.ckpt.resume_step,
             dataloader=dataloader if not config.ckpt.skip_dataloader else None,
         )
+        # This redundant setup is necessary because loading the optimizer's state has side effects on the scheduler state dict
+        if config.ckpt.skip_scheduler:
+            scheduler = setup_scheduler(optimizer, config.scheduler, scheduler_steps, config.optim.lr)
+        print(scheduler.state_dict())
     logger.info(
         f"Starting from step {progress.step} (total_tokens={progress.total_tokens}, total_samples={progress.total_samples}, dataset_state={dataloader.state_dict()['dataset_state']})"
     )


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

This PR fixes setting up WSD LR scheduling across resuming borders. It makes sure that we can skip loading the LR scheduler from a checkpoint but setup a fresh instance, or load the exact same scheduler from the DCP checkpoint. 

In this [W&B project](https://wandb.ai/primeintellect/mika?nw=wqmcynf32x) is an example of a stage 1 with warmup+constant, a stage 2 with constant + decay and the stage 2 being resumed.

<img width="333" height="253" alt="Screenshot 2025-10-13 at 11 42 25 AM" src="https://github.com/user-attachments/assets/71c0689e-1b98-4ce4-8b1b-d243435dfd50" />

<img width="331" height="250" alt="Screenshot 2025-10-13 at 11 42 33 AM" src="https://github.com/user-attachments/assets/00f58997-b759-4093-b039-29a18dad698e" />