### PR TITLE
Integrate `verifiers` eval utils

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ prerelease = "allow"
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 reverse-text = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "247491a" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "b97441d" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "main" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e43694bbfeff5d6ad8ac738c067bb90d41" }
 

--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -1,19 +1,18 @@
 import asyncio
-import json
 import time
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 import numpy as np
 import pandas as pd
-import torch
-from datasets import Dataset, DatasetDict, load_from_disk
+from huggingface_hub import whoami
 from openai import AsyncOpenAI
 from verifiers import load_environment
-from verifiers.types import GenerateOutputs, Messages
+from verifiers.types import GenerateOutputs
+from verifiers.utils.eval_utils import get_hf_hub_dataset_name, make_dataset, sanitize_metadata, save_to_disk
 
 from prime_rl.eval.config import OfflineEvalConfig
-from prime_rl.orchestrator.config import ClientConfig, EvalConfig, EvalSamplingConfig, ModelConfig
+from prime_rl.orchestrator.config import ClientConfig, EvalConfig, EvalSamplingConfig, EvalSaveConfig, ModelConfig
 from prime_rl.orchestrator.utils import parse_is_truncated_completions, parse_num_completion_tokens
 from prime_rl.utils.logger import get_logger
 from prime_rl.utils.monitor import get_monitor
@@ -74,99 +73,36 @@ def prepare_sampling_args(sampling_config: EvalSamplingConfig, client_config: Cl
     return sampling_args
 
 
-def normalize_prompt(messages: Messages):
-    if not isinstance(messages, list):
-        return messages
-    sanitized_messages = []
-    for m in messages:
-        if isinstance(m, str):
-            sanitized_messages.append({"role": m["role"], "content": [{"type": "text", "text": m}]})
-        elif "content" in m and isinstance(m["content"], str):
-            sanitized_messages.append({"role": m["role"], "content": [{"type": "text", "text": m["content"]}]})
-        else:
-            sanitized_messages.append(m)
-    return sanitized_messages
-
-
-def normalize_completion(messages: Messages):
-    if not isinstance(messages, list):
-        return messages
-    sanitized_messages = []
-    for m in messages:
-        tool_calls = [
-            json.dumps(tc.model_dump())  # type: ignore
-            for tc in m.get("tool_calls", [])
-        ]
-        # Ensure tool_calls is always a list of strings, never empty with null inference
-        if not tool_calls:
-            tool_calls = [""]  # Add empty string to maintain list<string> type
-
-        new_m = {
-            "role": m["role"],
-            "content": m.get("content", ""),
-            "tool_calls": tool_calls,
-            "tool_call_id": m.get("tool_call_id", ""),
-        }
-        sanitized_messages.append(new_m)
-    return sanitized_messages
-
-
-# Adapted from https://github.com/willccbb/verifiers/blob/b4d851db42cebbab2358b827fd0ed19773631937/verifiers/envs/environment.py#L523
-def make_dataset(results: GenerateOutputs) -> Dataset:
-    """
-    Make a dataset from the evaluation results.
-    """
-    results_dict = {
-        "prompt": [normalize_prompt(prompt) for prompt in results.prompt],
-        "completion": [normalize_completion(completion) for completion in results.completion],
-        "answer": results.answer,
-        "task": results.task,
-        "reward": results.reward,
-        "info": [json.dumps(info) for info in results.info],
-    }
-
-    return Dataset.from_dict(results_dict)
-
-
 async def run_eval(
     clients: list[AsyncOpenAI],
-    eval_id: str,
+    env_id: str,
     env_args: dict,
     num_examples: int,
     rollouts_per_example: int,
     max_concurrent: int,
-    save_to_disk: bool,
     output_dir: Path,
     ckpt_step: int,
     model_config: ModelConfig,
     sampling_config: EvalSamplingConfig,
     client_config: ClientConfig,
+    save_config: EvalSaveConfig,
     step: int | None = None,
 ) -> None:
     # Get the logger
     logger = get_logger()
     monitor = get_monitor()
-    assert logger is not None
     eval_start_time = time.time()
 
     # Load the eval environment
-    load_eval_start_time = time.time()
-    env = load_environment(eval_id, **env_args)
-    load_eval_time = time.time() - load_eval_start_time
-    logger.debug(f"Loaded eval environment in {load_eval_time:.2f}s")
-
-    # Build inputs dataset (mirror Environment.evaluate but async)
+    env = load_environment(env_id, **env_args)
     dataset = env.get_eval_dataset(n=num_examples)
-
-    # Prepare sampling arguments
     sampling_args = prepare_sampling_args(sampling_config, client_config)
 
     logger.debug(
-        f"Evaluating {eval_id} (num_examples={len(dataset)}, rollouts_per_example={rollouts_per_example}) with args {env_args}"
+        f"Evaluating {env_id} (num_examples={len(dataset)}, rollouts_per_example={rollouts_per_example}) with args {env_args}"
     )
     # Run async generation and scoring
-    run_eval_start_time = time.time()
-    generate_outputs: GenerateOutputs = await generate_batch(
+    results: GenerateOutputs = await generate_batch(
         env=env,
         model_name=model_config.name,
         problems=dataset.to_list(),
@@ -176,22 +112,22 @@ async def run_eval(
         max_concurrent=max_concurrent,
     )
 
-    run_eval_time = time.time() - run_eval_start_time
-    logger.debug(f"Generated and scored rollouts in {run_eval_time:.2f}s")
-
-    rewards = torch.tensor(generate_outputs.reward).reshape(-1, rollouts_per_example).float()
-    responses = [state["responses"] for state in generate_outputs.state]
-    completion_lens = torch.tensor(parse_num_completion_tokens(responses)).reshape(-1, rollouts_per_example).float()
-    is_truncated = torch.tensor(parse_is_truncated_completions(responses)).reshape(-1, rollouts_per_example).float()
-
+    # Parse vLLM responses
     k = rollouts_per_example
-    problem_ids = [problem["id"] for problem in dataset.to_list() for _ in range(rollouts_per_example)]
-    sample_stats = pd.DataFrame({"problem_ids": problem_ids, "reward": rewards.flatten().tolist()})
-    unique_rewards = sample_stats.reward.unique()
+    responses = [state["responses"] for state in results.state]
+    results_df = pd.DataFrame(
+        {
+            "example_id": results.example_id,
+            "reward": results.reward,
+            "completion_len": parse_num_completion_tokens(responses),
+            "is_truncated": parse_is_truncated_completions(responses),
+        }
+    )
+    unique_rewards = results_df.reward.unique()
     could_be_binary = set(unique_rewards).issubset({0.0, 1.0})
     if could_be_binary:
         pass_at_k = (
-            sample_stats.groupby("problem_ids")
+            results_df.groupby("example_id")
             .apply(lambda x: compute_pass_at_k(x.reward), include_groups=False)
             .apply(pd.Series)
         )
@@ -201,58 +137,48 @@ async def run_eval(
 
     # Log statistics
     eval_time = time.time() - eval_start_time
-    message = f"Evaluated {eval_id} in {eval_time:.2f}s (Avg@{k}={sample_stats.reward.mean():.4f}"
+    message = f"Evaluated {env_id} in {eval_time:.2f}s (Avg@{k}={results_df.reward.mean():.4f}"
     if could_be_binary:
         assert pass_at_k is not None
         for pass_rate, pass_rate_score in pd.Series(pass_at_k.mean()).items():
             message += f", {capitalize(str(pass_rate))}: {pass_rate_score:.4f}"
-    message += f", Completion Length: {completion_lens.mean():.2f} (±{completion_lens.std():.2f}, ∈[{completion_lens.min():.2f}, {completion_lens.max():.2f}]), Truncated: {is_truncated.mean() * 100:.1f}%)"
+    message += f", Completion Length: {results_df.completion_len.mean():.2f} (±{results_df.completion_len.std():.2f}, ∈[{results_df.completion_len.min():.2f}, {results_df.completion_len.max():.2f}]), Truncated: {results_df.is_truncated.mean() * 100:.1f}%)"
     logger.success(message)
 
     # Log statistics to monitor
     eval_metrics = {
-        f"avg@{k}": rewards.mean().item(),
+        f"avg@{k}": results_df.reward.mean(),
+        "completion_len/avg": results_df.completion_len.mean().item(),
+        "completion_len/max": results_df.completion_len.max().item(),
+        "completion_len/min": results_df.completion_len.min().item(),
+        "time": eval_time,
     }
-
-    eval_completion_len_metrics = {
-        "avg": completion_lens.mean().item(),
-        "max": completion_lens.max().item(),
-        "min": completion_lens.min().item(),
-    }
-    eval_completion_len_metrics = {
-        **{f"eval_completion_len/{eval_id}/{k}": v for k, v in eval_completion_len_metrics.items()}
-    }
-    if step is None:
-        step = ckpt_step
-    eval_completion_len_metrics.update({"progress/ckpt_step": ckpt_step, "step": step})
-    monitor.log(eval_completion_len_metrics)
-
     if could_be_binary:
         assert pass_at_k is not None
         eval_metrics.update(pd.Series(pass_at_k.mean()).to_dict())
-    eval_metrics = {**{f"eval/{eval_id}/{k}": v for k, v in eval_metrics.items()}}
-    if step is None:
-        step = ckpt_step
-    eval_metrics.update({"progress/ckpt_step": ckpt_step, "step": step})
-
+    eval_metrics = {**{f"eval/{env_id}/{k}": v for k, v in eval_metrics.items()}}
+    eval_metrics.update({"progress/ckpt_step": ckpt_step, "step": step or ckpt_step})
     monitor.log(eval_metrics)
 
-    # Log timing metrics to monitor
-    time_metrics = {
-        "step": step,
-        f"time/eval/{eval_id}": eval_time,
-        f"time/eval/{eval_id}/load_environment": load_eval_time,
-        f"time/eval/{eval_id}/generate_and_score_rollouts": run_eval_time,
-    }
-    monitor.log(time_metrics)
+    # Save results
+    if save_config.disk is not None or save_config.hf is not None:
+        dataset = make_dataset(results)
 
-    # If specified, save eval artifacts
-    if save_to_disk:
-        # Save samples as dataset
-        eval_dir = get_step_path(get_eval_dir(output_dir), ckpt_step) / eval_id
-        dataset = make_dataset(generate_outputs)
-        dataset.save_to_disk(eval_dir)
-        logger.info(f"Saved eval results for {eval_id} to disk ({eval_dir})")
+        if save_config.disk is not None:
+            # Save samples as dataset
+            eval_dir = get_step_path(get_eval_dir(output_dir), ckpt_step) / env_id
+            metadata_dict = sanitize_metadata(results.metadata)
+            save_to_disk(dataset, metadata_dict, eval_dir)
+            logger.info(f"Saved eval results for {env_id} to disk ({eval_dir})")
+
+        if save_config.hf is not None:
+            dataset_name = save_config.hf.dataset_name or get_hf_hub_dataset_name(results)
+            dataset_subset = save_config.hf.dataset_subset or env.env_id
+            dataset_split = save_config.hf.dataset_split or "evals"
+            dataset.push_to_hub(dataset_name, dataset_subset, split=dataset_split, private=save_config.hf.private)
+            default_org = whoami().get("name", "")
+            repo_name = dataset_name if "/" in dataset_name else f"{default_org}/{dataset_name}"
+            logger.info(f"Pushed eval results for {env_id} to HF Hub (https://huggingface.co/datasets/{repo_name})")
 
 
 async def run_evals(
@@ -265,25 +191,24 @@ async def run_evals(
     ckpt_step: int,
     step: int | None = None,
 ):
-    logger = get_logger()
     await asyncio.gather(
         *[
             run_eval(
                 clients=clients,
-                eval_id=eval_id,
-                env_args=eval_config.environment_args.get(eval_id, {}),
+                env_id=env_id,
+                env_args=eval_config.environment_args.get(env_id, {}),
                 num_examples=num_examples,
                 rollouts_per_example=rollouts_per_example,
                 max_concurrent=max_concurrent,
                 output_dir=output_dir,
-                save_to_disk=eval_config.save_to_disk,
                 model_config=model_config,
                 sampling_config=sampling_config,
                 client_config=client_config,
+                save_config=eval_config.save,
                 ckpt_step=ckpt_step,
                 step=step,
             )
-            for eval_id, num_examples, rollouts_per_example, max_concurrent in zip(
+            for env_id, num_examples, rollouts_per_example, max_concurrent in zip(
                 eval_config.environment_ids,
                 eval_config.num_examples,
                 eval_config.rollouts_per_example,
@@ -291,14 +216,3 @@ async def run_evals(
             )
         ]
     )
-
-    if eval_config.save_to_hf is not None:
-        logger.info(f"Pushing eval results for {', '.join(eval_config.environment_ids)} to HF Hub")
-        eval_dirs = [
-            get_step_path(get_eval_dir(output_dir), ckpt_step) / eval_id for eval_id in eval_config.environment_ids
-        ]
-        dataset_dict = DatasetDict(
-            {path.name.replace("-", "_"): cast(Dataset, load_from_disk(path)) for path in eval_dirs}
-        )
-        dataset_dict.push_to_hub(eval_config.save_to_hf)
-        logger.info(f"Pushed eval results to HF Hub (https://huggingface.co/datasets/{eval_config.save_to_hf})")

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -118,6 +118,50 @@ class EvalSamplingConfig(BaseConfig):
     ] = None
 
 
+class EvalSaveDiskConfig(BaseConfig):
+    """Configures how to save the eval results to disk."""
+
+    path: Annotated[
+        Path,
+        Field(description="The path to save the eval results to."),
+    ] = Path("outputs")
+
+
+class EvalSaveHFConfig(BaseConfig):
+    """Configures how to save the eval results to HF."""
+
+    dataset_name: Annotated[
+        str | None,
+        Field(
+            description="The name of the HF dataset to save the eval results to. If None, will auto-generate a name."
+        ),
+    ] = None
+
+    dataset_subset: Annotated[
+        str | None,
+        Field(
+            description="The subset name of the HF dataset to save the evaluation results. If None, will default to the environment ID.",
+        ),
+    ] = None
+
+    dataset_split: Annotated[
+        str | None,
+        Field(
+            description="The split name of the HF dataset to save the evaluation results. If None, will default to 'evals'.",
+        ),
+    ] = None
+
+    private: Annotated[
+        bool,
+        Field(description="Whether to save the eval results to a private HF dataset."),
+    ] = False
+
+
+class EvalSaveConfig(BaseConfig):
+    disk: EvalSaveDiskConfig | None = None
+    hf: EvalSaveHFConfig | None = None
+
+
 class EnvironmentConfig(BaseConfig):
     """Configures the environment to be used for inference."""
 
@@ -168,19 +212,10 @@ class EvalConfig(BaseConfig):
         description="Shared sampling configuration for evals; can differ from training sampling.",
     )
 
-    save_to_disk: Annotated[
-        bool,
-        Field(
-            description="Whether to save the evaluation artifacts to the outputs directory.",
-        ),
-    ] = True
-
-    save_to_hf: Annotated[
-        str | None,
-        Field(
-            description="The name of the HF dataset to save the evaluation results to. Defaults to None, which means we do not save to HF Hub. If multiple environments are evaluated, we upload a dataset with one split per environment. If a checkpoint is evaluated, we suffix the HF Hub name with the checkpoint step.",
-        ),
-    ] = None
+    save: EvalSaveConfig = Field(
+        default_factory=EvalSaveConfig,
+        description="Configures how to save the eval results.",
+    )
 
     @model_validator(mode="after")
     def _validate_and_fill_eval_lists(self):
@@ -211,12 +246,6 @@ class EvalConfig(BaseConfig):
         elif len(self.max_concurrent) != len(self.environment_ids):
             raise ValueError("Number of max_concurrent entries must match number of ids")
 
-        return self
-
-    @model_validator(mode="after")
-    def save_to_disk_if_save_to_hf(self):
-        if self.save_to_hf is not None:
-            self.save_to_disk = True
         return self
 
 

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -122,9 +122,11 @@ class EvalSaveDiskConfig(BaseConfig):
     """Configures how to save the eval results to disk."""
 
     path: Annotated[
-        Path,
-        Field(description="The path to save the eval results to."),
-    ] = Path("outputs")
+        Path | None,
+        Field(
+            description="The path to save the eval results to. If None, will default to <output_dir>/evals/<step_path>/<env_id> for online evals and the verifiers default for offline evals."
+        ),
+    ] = None
 
 
 class EvalSaveHFConfig(BaseConfig):

--- a/src/prime_rl/utils/vf.py
+++ b/src/prime_rl/utils/vf.py
@@ -5,7 +5,36 @@ from itertools import cycle
 from datasets import Dataset
 from openai import AsyncOpenAI
 from verifiers import Environment
-from verifiers.types import GenerateOutputs
+from verifiers.types import GenerateMetadata, GenerateOutputs
+
+
+def merge_metadata(generate_metadata_list: list[GenerateMetadata]) -> GenerateMetadata:
+    """Merge multiple GenerateMetadata into a single GenerateMetadata."""
+    num_examples = len(generate_metadata_list)  # Assumes one generate metadata per example
+    time_ms = max(metadata.time_ms for metadata in generate_metadata_list)
+    avg_reward = sum(metadata.avg_reward for metadata in generate_metadata_list) / num_examples
+    avg_metrics = {
+        key: sum(metadata.avg_metrics[key] for metadata in generate_metadata_list) / num_examples
+        for key in generate_metadata_list[0].avg_metrics
+    }
+    state_columns = []
+    for metadata in generate_metadata_list:
+        state_columns.extend(metadata.state_columns)
+    return GenerateMetadata(
+        env_id=generate_metadata_list[0].env_id,
+        env_args=generate_metadata_list[0].env_args,
+        model=generate_metadata_list[0].model,
+        base_url=generate_metadata_list[0].base_url,
+        num_examples=num_examples,
+        rollouts_per_example=generate_metadata_list[0].rollouts_per_example,
+        sampling_args=generate_metadata_list[0].sampling_args,
+        date=generate_metadata_list[0].date,
+        time_ms=time_ms,
+        avg_reward=avg_reward,
+        avg_metrics=avg_metrics,
+        state_columns=state_columns,
+        path_to_save=generate_metadata_list[0].path_to_save,
+    )
 
 
 def merge_outputs(generate_outputs_list: list[GenerateOutputs]) -> GenerateOutputs:
@@ -32,6 +61,7 @@ def merge_outputs(generate_outputs_list: list[GenerateOutputs]) -> GenerateOutpu
         task.extend(generate_output.task)
         for key, value in generate_output.metrics.items():
             metrics[key].extend(value)
+    metadata = merge_metadata([generate_output.metadata for generate_output in generate_outputs_list])
     return GenerateOutputs(
         prompt=prompt,
         completion=completion,
@@ -41,7 +71,7 @@ def merge_outputs(generate_outputs_list: list[GenerateOutputs]) -> GenerateOutpu
         info=info,
         task=task,
         metrics=metrics,
-        metadata=generate_outputs_list[0].metadata,  # TODO
+        metadata=metadata,
         example_id=example_id,
     )
 
@@ -56,11 +86,12 @@ async def generate_group(
     max_concurrent: int,
 ) -> GenerateOutputs:
     """Asynchronously generate and score rollouts for one problem."""
-    return await env.a_generate(
-        inputs=Dataset.from_list([problem] * rollouts_per_example),
+    return await env.generate(
+        inputs=Dataset.from_list([problem]),
         client=client,
         model=model_name,
         sampling_args=sampling_args,
+        rollouts_per_example=rollouts_per_example,
         max_concurrent=max_concurrent,
         use_tqdm=False,
     )

--- a/src/prime_rl/utils/vf.py
+++ b/src/prime_rl/utils/vf.py
@@ -10,8 +10,19 @@ from verifiers.types import GenerateOutputs
 
 def merge_outputs(generate_outputs_list: list[GenerateOutputs]) -> GenerateOutputs:
     """Merge multiple GenerateOutputs into a single GenerateOutputs."""
-    prompt, completion, answer, state, reward, info, task, metrics = [], [], [], [], [], [], [], defaultdict(list)
+    example_id, prompt, completion, answer, state, reward, info, task, metrics = (
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        defaultdict(list),
+    )
     for generate_output in generate_outputs_list:
+        example_id.extend(generate_output.example_id)
         prompt.extend(generate_output.prompt)
         completion.extend(generate_output.completion)
         answer.extend(generate_output.answer)
@@ -30,6 +41,8 @@ def merge_outputs(generate_outputs_list: list[GenerateOutputs]) -> GenerateOutpu
         info=info,
         task=task,
         metrics=metrics,
+        metadata=generate_outputs_list[0].metadata,  # TODO
+        example_id=example_id,
     )
 
 

--- a/src/prime_rl/utils/vf.py
+++ b/src/prime_rl/utils/vf.py
@@ -87,11 +87,10 @@ async def generate_group(
 ) -> GenerateOutputs:
     """Asynchronously generate and score rollouts for one problem."""
     return await env.generate(
-        inputs=Dataset.from_list([problem]),
+        inputs=Dataset.from_list([problem] * rollouts_per_example),
         client=client,
         model=model_name,
         sampling_args=sampling_args,
-        rollouts_per_example=rollouts_per_example,
         max_concurrent=max_concurrent,
         use_tqdm=False,
     )

--- a/uv.lock
+++ b/uv.lock
@@ -2190,7 +2190,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e43694bbfeff5d6ad8ac738c067bb90d41" },
     { name = "transformers", specifier = ">=4.56.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=247491a" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=b97441d" },
     { name = "vllm", specifier = "==0.10.2" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -3501,7 +3501,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.5.post0"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=247491a#247491a1b35e73a8e19c68b3bd3d0987e623153f" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=b97441d#b97441d09f2b3afc8fbc9c125cda2b7117a9f98f" }
 dependencies = [
     { name = "datasets" },
     { name = "jinja2" },


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

This PR integrates the new eval utils exposed by `verifiers` since [#478](https://github.com/PrimeIntellect-ai/verifiers/pull/478) and does some general cleanup and QoL improvements. However, we point to [#496](https://github.com/PrimeIntellect-ai/verifiers/pull/496) as this makes usage in prime-rl easier. We use the same saving logic as `verifiers` for eval results and refactor configuration into `EvalSaveConfig`

Misc changes:
- We use the internal `example_id` maintained by `verifiers`
- We simplify metrics computation by not building  tensors but rely solely on `pd.DataFrame`

Usage:
- Use `--save.disk` to save results to disk in the default path. Specify `--save.disk.path` to specify the save path 
- Use `--save.hf` to save results to HF using defaults (auto-generated dataset name using same pattern as verifiers, env_id as subset, "evals" as split and public dataset). Change any of the defaults with `--save.hf.dataset-name`, `--save-hf.dataset-subset`, `--save.hf.dataset-split` and `--save.hf.private`

```bash
# Basic evals
uv run eval   --client.base-url https://api.openai.com/v1   --client.api-key-var OPENAI_API_KEY --model.name gpt-4.1-mini --environment-ids math500 --num-examples 5 --rollouts-per-example 3
```

```bash
# Save to disk
uv run eval   --client.base-url https://api.openai.com/v1   --client.api-key-var OPENAI_API_KEY --model.name gpt-4.1-mini --environment-ids math500 --num-examples 5 --rollouts-per-example 3 --save.disk [--save.disk.path path/to/outputs]
```

```bash
# Save to HF
uv run eval   --client.base-url https://api.openai.com/v1   --client.api-key-var OPENAI_API_KEY --model.name gpt-4.1-mini --environment-ids math500 --num-examples 5 --rollouts-per-example 3 --save.hf [--save.hf.dataset_name DATASET_NAME] [--save.hf.dataset_subset DATASET_SUBSET] [--save.hf.dataset-split DATASET_SPLIT] [--save.hf.private]
```

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: #1069 
**Linear Issue**: Resolves PRIMERL-153