### PR TITLE
report peak memory reserved instead of allocated

### DIFF
--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -294,7 +294,7 @@ def train(config: RLTrainerConfig):
         perf_counter.count_tokens(num_tokens)
         throughput = perf_counter.get_tokens_per_second() or 0
         mfu = perf_counter.get_mfu() or 0
-        peak_memory = torch.cuda.max_memory_allocated() / 1024**3  # GiB
+        peak_memory = torch.cuda.max_memory_reserved() / 1024**3  # GiB
 
         # Log step metrics
         step_time = time.time() - step_start_time

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -302,7 +302,7 @@ def train(config: SFTTrainerConfig):
         perf_counter.count_tokens(num_tokens)
         throughput = perf_counter.get_tokens_per_second() or 0
         mfu = perf_counter.get_mfu() or 0
-        peak_memory = torch.cuda.max_memory_allocated() / 1024**3  # GiB
+        peak_memory = torch.cuda.max_memory_reserved() / 1024**3  # GiB
 
         # Log step metrics
         step_time = time.time() - step_start_time


### PR DESCRIPTION
fixing https://github.com/PrimeIntellect-ai/prime-rl/issues/1118

moving from allocated to reserve memory for the memory usage reporting.

before 

```bash
12:51:09 SUCCESS Step 1 | Time: 1.35s | Loss: 12.3125 | Grad. Norm: 28.4771 | LR: 1.00e-06 | Throughput: 1507 tokens/s | MFU: 0.4% | Peak Mem.: 5.2/23.7 GiB (22.1%) | Max Vio: 0.9891
```

after

```bash
12:54:25 SUCCESS Step 1 | Time: 0.58s | Loss: 12.3125 | Grad. Norm: 28.4825 | LR: 1.00e-06 | Throughput: 3537 tokens/s | MFU: 1.0% | Peak Mem.: 7.8/23.7 GiB (32.9%) | Max Vio: 0.9892
```

running

```bash
uv run torchrun --local-ranks-filter 0 --nproc_per_node=2 src/prime_rl/trainer/sft/train.py @ configs/debug/moe/sft/train.toml
```