### PR TITLE
add support for local ckpt loading hf

### DIFF
--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 import time
 from typing import cast
 
@@ -163,7 +164,13 @@ def load_dcp_from_hf(model: nn.Module, config: ModelConfig):
 
     logger.info("Loading model weights from HF")
     load_dcp_start_time = time.time()
-    path_snapshot = snapshot_download(repo_id=config.name, repo_type="model")
+    
+    if not Path(config.name).exists():
+        path_snapshot = snapshot_download(repo_id=config.name, repo_type="model")
+    else:
+        logger.info(f"Loading model weights from {config.name} directly, skipping snapshot download, if this is not expected please remove the directory {config.name} and run again")
+        path_snapshot = config.name
+        
     dcp.load(
         model.state_dict(),
         storage_reader=HuggingFaceStorageReader(path=path_snapshot),

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -1,6 +1,6 @@
 import logging
-from pathlib import Path
 import time
+from pathlib import Path
 from typing import cast
 
 import torch
@@ -164,13 +164,15 @@ def load_dcp_from_hf(model: nn.Module, config: ModelConfig):
 
     logger.info("Loading model weights from HF")
     load_dcp_start_time = time.time()
-    
+
     if not Path(config.name).exists():
         path_snapshot = snapshot_download(repo_id=config.name, repo_type="model")
     else:
-        logger.info(f"Loading model weights from {config.name} directly, skipping snapshot download, if this is not expected please remove the directory {config.name} and run again")
+        logger.info(
+            f"Loading model weights from {config.name} directly, skipping snapshot download, if this is not expected please remove the directory {config.name} and run again"
+        )
         path_snapshot = config.name
-        
+
     dcp.load(
         model.state_dict(),
         storage_reader=HuggingFaceStorageReader(path=path_snapshot),


### PR DESCRIPTION
# Add support for local ckpt loading hf

previously we could not just point to a local folder with the hf model and load it to start the training and had to first push  to hub and re download which is expensive for large model and slow for local debugging.

This pr skip the snapshot download if the model.name is a a local directory

example

first ckpt
```
uv run torchrun --local-ranks-filter 0 --nproc_per_node=2 src/prime_rl/trainer/sft/train.py @ configs/debug/moe/sft/train.toml --model.load_using_meta --model.compile --weights.interval 2 --output_dir output_sft --weights.save_format safetensors
```

then try to load from it
```
uv run torchrun --local-ranks-filter 0 --nproc_per_node=2 src/prime_rl/trainer/sft/train.py @ configs/debug/moe/sft/train.toml --model.load_using_meta --model.compile --model.name output_sft/weights/step_2
```