### PR TITLE
Use module-level logger instance

### DIFF
--- a/src/prime_rl/utils/logger.py
+++ b/src/prime_rl/utils/logger.py
@@ -1,8 +1,6 @@
 import sys
 from pathlib import Path
 
-from loguru import logger
-
 # Global logger instance
 _LOGGER = None
 
@@ -31,8 +29,23 @@ def setup_logger(log_level: str, log_file: Path | None = None):
         debug = "".join([f"<level>{NO_BOLD}", " [{file}::{line}]", f"{RESET}</level>"])
     format = time + message + debug
 
-    # Remove all default handlers
-    logger.remove()
+    # NOTE: We are creating a new "module-level" logger instance for prime-rl so that third-party code cannot "hijack" our logger
+    # This is a bit hacky because loguru does not publicly expose the logger class, but oh well, it works
+    from loguru._logger import Core as _Core
+    from loguru._logger import Logger as _Logger
+
+    logger = _Logger(
+        core=_Core(),
+        exception=None,
+        depth=0,
+        record=False,
+        lazy=False,
+        colors=False,
+        raw=False,
+        capture=True,
+        patchers=[],
+        extra={},
+    )
 
     # Install console handler
     logger.add(sys.stdout, format=format, level=log_level.upper(), colorize=True)


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

This is to protect against third-party deps hikacking/ removing the our logger instance with `logger.remove()` or similar.

```bash
uv run eval --environment-ids tau2-bench --client.base-url https://api.openai.com/v1 --model.name gpt-4.1-mini --num-examples 1
```

## Before

Logs after loading the environment are gone

<img width="1364" height="357" alt="Screenshot 2025-10-21 at 8 34 09 PM" src="https://github.com/user-attachments/assets/931f9875-126d-4676-84a6-6428b07cd157" />

## After

Logs are not gone

<img width="1363" height="320" alt="Screenshot 2025-10-21 at 8 35 04 PM" src="https://github.com/user-attachments/assets/b43ed1a6-e6ea-49b5-be55-b779a02fe91e" />
