### PR TITLE
More conservative OAI client limits

### DIFF
--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -16,8 +16,8 @@ def setup_clients(client_config: ClientConfig) -> list[AsyncOpenAI]:
         timeout = httpx.Timeout(timeout=client_config.timeout, connect=5.0)
         # We use as many concurrent connections as possible, but lower than available ports
         limits = httpx.Limits(
-            max_connections=28000,  # OAI default: 1000
-            max_keepalive_connections=28000,  # OAI default: 100
+            max_connections=1024,  # OAI default: 1000
+            max_keepalive_connections=1024,  # OAI default: 100
         )
         http_client = httpx.AsyncClient(limits=limits, timeout=timeout)
         return AsyncOpenAI(


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

We decrease the (alive) connection limit to 1024 to avoid unnecessarily using system resources. Previously we used 28000 which was fine for a single client setup, but now that we have multiple clients it may lead to resource contention. Also, the vLLM server by default only processes 1024 sequences in parallel (which is already above the critical batch size for most inference workloads), so we are not losing performance here.