### PR TITLE
Fix asyncio concurrency

### DIFF
--- a/src/prime_rl/eval/eval.py
+++ b/src/prime_rl/eval/eval.py
@@ -53,7 +53,6 @@ async def eval(config: OfflineEvalConfig):
     await reload_weights(admin_clients)
 
     # Run benchmarks on base model
-    semaphore = asyncio.Semaphore(config.max_concurrent)
     if config.eval_base:
         logger.info(f"Evaluating model {config.model.name}")
         await run_evals(
@@ -64,7 +63,6 @@ async def eval(config: OfflineEvalConfig):
             client_config=config.client,
             output_dir=config.output_dir,
             ckpt_step=0,
-            semaphore=semaphore,
         )
 
     # If specified, evaluate all checkpoints found in the weights directory

--- a/src/prime_rl/eval/eval.py
+++ b/src/prime_rl/eval/eval.py
@@ -53,6 +53,7 @@ async def eval(config: OfflineEvalConfig):
     await reload_weights(admin_clients)
 
     # Run benchmarks on base model
+    semaphore = asyncio.Semaphore(config.max_concurrent)
     if config.eval_base:
         logger.info(f"Evaluating model {config.model.name}")
         await run_evals(
@@ -63,6 +64,7 @@ async def eval(config: OfflineEvalConfig):
             client_config=config.client,
             output_dir=config.output_dir,
             ckpt_step=0,
+            semaphore=semaphore,
         )
 
     # If specified, evaluate all checkpoints found in the weights directory

--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -81,7 +81,7 @@ async def run_eval(
     rollouts_per_example: int,
     output_dir: Path,
     ckpt_step: int,
-    semaphore: asyncio.Semaphore,
+    semaphore: asyncio.Semaphore | None,
     model_config: ModelConfig,
     sampling_config: EvalSamplingConfig,
     client_config: ClientConfig,
@@ -197,9 +197,9 @@ async def run_evals(
     client_config: ClientConfig,
     output_dir: Path,
     ckpt_step: int,
-    semaphore: asyncio.Semaphore,
     step: int | None = None,
 ):
+    semaphore = asyncio.Semaphore(eval_config.max_concurrent) if eval_config.max_concurrent else None
     await asyncio.gather(
         *[
             run_eval(

--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -79,9 +79,9 @@ async def run_eval(
     env_args: dict,
     num_examples: int,
     rollouts_per_example: int,
-    max_concurrent: int,
     output_dir: Path,
     ckpt_step: int,
+    semaphore: asyncio.Semaphore,
     model_config: ModelConfig,
     sampling_config: EvalSamplingConfig,
     client_config: ClientConfig,
@@ -109,7 +109,7 @@ async def run_eval(
         clients=clients,
         rollouts_per_example=rollouts_per_example,
         sampling_args=sampling_args,
-        max_concurrent=max_concurrent,
+        semaphore=semaphore,
     )
 
     # Parse vLLM responses
@@ -197,6 +197,7 @@ async def run_evals(
     client_config: ClientConfig,
     output_dir: Path,
     ckpt_step: int,
+    semaphore: asyncio.Semaphore,
     step: int | None = None,
 ):
     await asyncio.gather(
@@ -207,7 +208,7 @@ async def run_evals(
                 env_args=eval_config.environment_args.get(env_id, {}),
                 num_examples=num_examples,
                 rollouts_per_example=rollouts_per_example,
-                max_concurrent=max_concurrent,
+                semaphore=semaphore,
                 output_dir=output_dir,
                 model_config=model_config,
                 sampling_config=sampling_config,
@@ -216,11 +217,10 @@ async def run_evals(
                 ckpt_step=ckpt_step,
                 step=step,
             )
-            for env_id, num_examples, rollouts_per_example, max_concurrent in zip(
+            for env_id, num_examples, rollouts_per_example in zip(
                 eval_config.environment_ids,
                 eval_config.num_examples,
                 eval_config.rollouts_per_example,
-                eval_config.max_concurrent,
             )
         ]
     )

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -203,9 +203,9 @@ class EvalConfig(BaseConfig):
     ] = []
 
     max_concurrent: Annotated[
-        int,
+        int | None,
         Field(
-            description="Maximum number of concurrent rollouts to generate and score. If empty, will default to -1 for all environments.",
+            description="Maximum number of concurrent rollouts to generate and score. Will create a global semaphore and pass to verifiers Environment. If None, will not limit concurrency.",
         ),
     ] = 1024
 
@@ -421,10 +421,9 @@ class OrchestratorConfig(BaseSettings):
     ] = Path("outputs")
 
     max_concurrent: Annotated[
-        int,
+        int | None,
         Field(
-            ge=1,
-            description="Maximum number of concurrent rollouts to generate and score.",
+            description="Maximum number of concurrent rollouts to generate and score. Will create a global semaphore and pass to verifiers Environment. If None, will not limit concurrency.",
         ),
     ] = 1024
 

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -203,11 +203,11 @@ class EvalConfig(BaseConfig):
     ] = []
 
     max_concurrent: Annotated[
-        list[int],
+        int,
         Field(
             description="Maximum number of concurrent rollouts to generate and score. If empty, will default to -1 for all environments.",
         ),
-    ] = []
+    ] = 1024
 
     sampling: EvalSamplingConfig = Field(
         default_factory=EvalSamplingConfig,
@@ -238,15 +238,6 @@ class EvalConfig(BaseConfig):
 
         if len(self.num_examples) != len(self.environment_ids):
             raise ValueError("Number of num_examples entries must match number of ids")
-
-        # max_concurrent: if empty/unspecified, default to -1 for all; else length must match ids
-        if len(self.max_concurrent) == 0:
-            self.max_concurrent = [-1 for _ in self.environment_ids]
-        elif len(self.max_concurrent) == 1:
-            self.max_concurrent = [self.max_concurrent[0] for _ in self.environment_ids]
-
-        elif len(self.max_concurrent) != len(self.environment_ids):
-            raise ValueError("Number of max_concurrent entries must match number of ids")
 
         return self
 
@@ -428,6 +419,14 @@ class OrchestratorConfig(BaseSettings):
             description="Directory to write outputs to. Will be populated with checkpoints, weights, rollouts and logs as subdirectories. Should be set to a persistent directory with enough disk space. This value should be distinct across experiments running on a single node. See the README for more details."
         ),
     ] = Path("outputs")
+
+    max_concurrent: Annotated[
+        int,
+        Field(
+            ge=1,
+            description="Maximum number of concurrent rollouts to generate and score.",
+        ),
+    ] = 1024
 
     batch_size: Annotated[int, Field(ge=1, description="Number of samples to train on per step.")] = 128
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -215,7 +215,7 @@ async def orchestrate(config: OrchestratorConfig):
 
             # Generate completions + rewards with verifiers
             generate_completions_start_time = time.time()
-            semaphore = asyncio.Semaphore(config.max_concurrent)
+            semaphore = asyncio.Semaphore(config.max_concurrent) if config.max_concurrent is not None else None
             generate_outputs: GenerateOutputs = await generate_batch(
                 clients=clients,
                 env=vf_env,

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -215,6 +215,7 @@ async def orchestrate(config: OrchestratorConfig):
 
             # Generate completions + rewards with verifiers
             generate_completions_start_time = time.time()
+            semaphore = asyncio.Semaphore(config.max_concurrent)
             generate_outputs: GenerateOutputs = await generate_batch(
                 clients=clients,
                 env=vf_env,
@@ -222,6 +223,7 @@ async def orchestrate(config: OrchestratorConfig):
                 problems=problems,
                 rollouts_per_example=config.rollouts_per_example,
                 sampling_args=sampling_args,
+                semaphore=semaphore,
             )
             generate_completions_time = time.time() - generate_completions_start_time
             problem_requests += problems_to_sample

--- a/src/prime_rl/utils/vf.py
+++ b/src/prime_rl/utils/vf.py
@@ -83,17 +83,17 @@ async def generate_group(
     problem: dict,
     rollouts_per_example: int,
     sampling_args: dict,
-    semaphore: asyncio.Semaphore,
+    semaphore: asyncio.Semaphore | None,
 ) -> GenerateOutputs:
     """Asynchronously generate and score rollouts for one problem."""
-    async with semaphore:
-        return await env.generate(
-            inputs=Dataset.from_list([problem] * rollouts_per_example),
-            client=client,
-            model=model_name,
-            sampling_args=sampling_args,
-            use_tqdm=False,
-        )
+    return await env.generate(
+        inputs=Dataset.from_list([problem] * rollouts_per_example),
+        client=client,
+        model=model_name,
+        sampling_args=sampling_args,
+        semaphore=semaphore,
+        use_tqdm=False,
+    )
 
 
 async def generate_batch(
@@ -103,7 +103,7 @@ async def generate_batch(
     problems: list[dict],
     rollouts_per_example: int,
     sampling_args: dict,
-    semaphore: asyncio.Semaphore,
+    semaphore: asyncio.Semaphore | None,
 ) -> GenerateOutputs:
     """Asynchronously generate and score rollouts for a list of problems."""
     from tqdm import tqdm

--- a/src/prime_rl/utils/vf.py
+++ b/src/prime_rl/utils/vf.py
@@ -83,17 +83,17 @@ async def generate_group(
     problem: dict,
     rollouts_per_example: int,
     sampling_args: dict,
-    max_concurrent: int,
+    semaphore: asyncio.Semaphore,
 ) -> GenerateOutputs:
     """Asynchronously generate and score rollouts for one problem."""
-    return await env.generate(
-        inputs=Dataset.from_list([problem] * rollouts_per_example),
-        client=client,
-        model=model_name,
-        sampling_args=sampling_args,
-        max_concurrent=max_concurrent,
-        use_tqdm=False,
-    )
+    async with semaphore:
+        return await env.generate(
+            inputs=Dataset.from_list([problem] * rollouts_per_example),
+            client=client,
+            model=model_name,
+            sampling_args=sampling_args,
+            use_tqdm=False,
+        )
 
 
 async def generate_batch(
@@ -103,7 +103,7 @@ async def generate_batch(
     problems: list[dict],
     rollouts_per_example: int,
     sampling_args: dict,
-    max_concurrent: int = -1,
+    semaphore: asyncio.Semaphore,
 ) -> GenerateOutputs:
     """Asynchronously generate and score rollouts for a list of problems."""
     from tqdm import tqdm
@@ -112,9 +112,7 @@ async def generate_batch(
 
     async def generate_group_with_progress(client, problem):
         """Generate rollouts for one problem and update progress."""
-        result = await generate_group(
-            client, env, model_name, problem, rollouts_per_example, sampling_args, max_concurrent
-        )
+        result = await generate_group(client, env, model_name, problem, rollouts_per_example, sampling_args, semaphore)
         pbar.update(rollouts_per_example)
         return result
 


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Because we now schedule "group rollout requests" the `max_concurrent` argument of `env.generate` does not limit the global concurrency anymore. Since [#504](https://github.com/PrimeIntellect-ai/verifiers/pull/504) of verifiers, we support explicitly passing a semaphore which prime-rl uses to limit the global asyncio concurrency. This PR makes the necessary code changes to support this in prime-rl as well.