### PR TITLE
Fix MoE weight loading

### DIFF
--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -5,9 +5,10 @@ from pathlib import Path
 from typing import Any
 
 import torch
-import torch.distributed.checkpoint as dcp
 from torch import nn
 from torch.distributed.checkpoint.state_dict import get_state_dict, set_state_dict
+from torch.distributed.checkpoint.state_dict_loader import load as dcp_load
+from torch.distributed.checkpoint.state_dict_saver import save as dcp_save
 from torch.distributed.checkpoint.stateful import Stateful
 from torch.nn import Module
 from torch.optim.lr_scheduler import LRScheduler
@@ -119,7 +120,7 @@ class CheckpointManager:
             torch.save(dataloader.state_dict(), dataloader_dir / f"rank_{self._world.rank}.pt")
 
         # Save sharded state
-        dcp.save(state_dict, checkpoint_id=ckpt_path)
+        dcp_save(state_dict, checkpoint_id=ckpt_path)
 
         # Append to list of saved steps
         if self._is_master:
@@ -143,7 +144,7 @@ class CheckpointManager:
         # Load sharded state
         app_state = AppState(model, optimizers, scheduler, progress)
         state_dict = {"app": app_state}
-        dcp.load(state_dict=state_dict, checkpoint_id=ckpt_path)
+        dcp_load(state_dict=state_dict, checkpoint_id=ckpt_path)
 
         # Load the dataloader
         if dataloader is not None:

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -4,13 +4,15 @@ from pathlib import Path
 from typing import cast
 
 import torch
-import torch.distributed.checkpoint as dcp
 import torch.nn as nn
 from beartype import beartype as typechecker
+from huggingface_hub import snapshot_download
 from jaxtyping import Float, Int, jaxtyped
 from liger_kernel.transformers import AutoLigerKernelForCausalLM
 from torch import Tensor
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import checkpoint_wrapper
+from torch.distributed.checkpoint.hf_storage import HuggingFaceStorageReader
+from torch.distributed.checkpoint.state_dict_loader import load as dcp_load
 from torch.distributed.fsdp import FSDPModule, MixedPrecisionPolicy, fully_shard
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, PretrainedConfig
 from transformers.tokenization_utils import PreTrainedTokenizer
@@ -19,6 +21,14 @@ from prime_rl.trainer.config import ActivationCheckpointConfig, CompileConfig, M
 from prime_rl.trainer.lora import apply_lora_to_model
 from prime_rl.trainer.models import AutoModelForCausalLMPrimeRL
 from prime_rl.trainer.parallel_dims import ParallelDims
+from prime_rl.trainer.weights import (
+    convert_hf_to_tt_moe,
+    convert_tt_to_hf_moe,
+    has_hf_moe_layers,
+    has_tt_moe_layers,
+    load_state_dict,
+    save_state_dict,
+)
 from prime_rl.utils.logger import get_logger
 from prime_rl.utils.tensor_hashing import get_module_signature
 
@@ -152,9 +162,6 @@ def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDim
 
 
 def load_dcp_from_hf(model: nn.Module, config: ModelConfig):
-    from huggingface_hub import snapshot_download
-    from torch.distributed.checkpoint import HuggingFaceStorageReader
-
     model.to_empty(device="cuda")
 
     logger = get_logger()
@@ -166,16 +173,46 @@ def load_dcp_from_hf(model: nn.Module, config: ModelConfig):
     load_dcp_start_time = time.time()
 
     if not Path(config.name).exists():
-        path_snapshot = snapshot_download(repo_id=config.name, repo_type="model")
+        snapshot_path = Path(snapshot_download(repo_id=config.name, repo_type="model"))
     else:
         logger.info(
-            f"Loading model weights from {config.name} directly, skipping snapshot download, if this is not expected please remove the directory {config.name} and run again"
+            f"Loading model weights from path {config.name}, skipping snapshot download. If this is not expected, please remove the directory {config.name} and run again"
         )
-        path_snapshot = config.name
+        snapshot_path = Path(config.name)
 
-    dcp.load(
+    # Load the snapshot state
+    snapshot_state_dict = load_state_dict(snapshot_path)
+    model_state_dict = model.state_dict()
+
+    # Dynamically convert between different weight formats if needed
+    if snapshot_state_dict.keys() != model_state_dict.keys():
+        logger.warning(
+            "Found mismatch between snapshot and model state dict keys. Will try to auto-convert the snapshot to match the model state dict."
+        )
+        if has_hf_moe_layers(snapshot_state_dict) and has_tt_moe_layers(model_state_dict):
+            logger.info("Found HF format in snapshot and TT format in model.")
+            snapshot_path = snapshot_path / "tt"
+            if snapshot_path.exists():
+                logger.info(f"Conversion already done. Loading from {snapshot_path}")
+            else:
+                logger.info(f"Converting snapshot state dict to TT format and saving to {snapshot_path}")
+                convert_hf_to_tt_moe(snapshot_state_dict)
+                save_state_dict(snapshot_state_dict, snapshot_path)
+        elif has_tt_moe_layers(snapshot_state_dict) and has_hf_moe_layers(model_state_dict):
+            snapshot_path = snapshot_path / "hf"
+            if snapshot_path.exists():
+                logger.info(f"Conversion already done. Loading from {snapshot_path}")
+            else:
+                logger.info(f"Converting snapshot state dict to HF format and saving to {snapshot_path}")
+                convert_tt_to_hf_moe(snapshot_state_dict)
+                save_state_dict(snapshot_state_dict, snapshot_path)
+
+        # Reload the snapshot state dict
+        snapshot_state_dict = load_state_dict(snapshot_path)
+
+    dcp_load(
         model.state_dict(),
-        storage_reader=HuggingFaceStorageReader(path=path_snapshot),
+        storage_reader=HuggingFaceStorageReader(path=snapshot_path.as_posix()),
         # Note: This allow is needed by weight tying but could cause silent issues
         # planner=DefaultLoadPlanner(allow_partial_load=True),
     )

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -153,7 +153,7 @@ def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDim
 
 def load_dcp_from_hf(model: nn.Module, config: ModelConfig):
     from huggingface_hub import snapshot_download
-    from torch.distributed.checkpoint import DefaultLoadPlanner, HuggingFaceStorageReader
+    from torch.distributed.checkpoint import HuggingFaceStorageReader
 
     model.to_empty(device="cuda")
 
@@ -162,7 +162,7 @@ def load_dcp_from_hf(model: nn.Module, config: ModelConfig):
         logger.warning("Randomly initializing model. Skipping loading weights from HF.")
         return
 
-    logger.info("Loading model weights from HF")
+    logger.info("Loading weights using HF DCP")
     load_dcp_start_time = time.time()
 
     if not Path(config.name).exists():
@@ -177,10 +177,10 @@ def load_dcp_from_hf(model: nn.Module, config: ModelConfig):
         model.state_dict(),
         storage_reader=HuggingFaceStorageReader(path=path_snapshot),
         # Note: This allow is needed by weight tying but could cause silent issues
-        planner=DefaultLoadPlanner(allow_partial_load=True),
+        # planner=DefaultLoadPlanner(allow_partial_load=True),
     )
     fix_model_post_empty(model)
-    logger.debug(f"Loaded model weights from HF in {time.time() - load_dcp_start_time:.2f} seconds")
+    logger.debug(f"Loaded weights using HF DCP in {time.time() - load_dcp_start_time:.2f} seconds")
 
 
 def can_load_dcp_from_hf(model: nn.Module):

--- a/src/prime_rl/trainer/weights.py
+++ b/src/prime_rl/trainer/weights.py
@@ -80,13 +80,13 @@ def convert_hf_to_tt_moe(state_dict: dict[str, Tensor]):
 
         state_dict[f"model.layers.{i}.mlp.shared_expert.w1"] = state_dict[
             f"model.layers.{i}.mlp.shared_experts.gate_proj.weight"
-        ].unsqueeze(0)
+        ]
         state_dict[f"model.layers.{i}.mlp.shared_expert.w2"] = state_dict[
             f"model.layers.{i}.mlp.shared_experts.down_proj.weight"
-        ].unsqueeze(0)
+        ]
         state_dict[f"model.layers.{i}.mlp.shared_expert.w3"] = state_dict[
             f"model.layers.{i}.mlp.shared_experts.up_proj.weight"
-        ].unsqueeze(0)
+        ]
 
         del state_dict[f"model.layers.{i}.mlp.shared_experts.gate_proj.weight"]
         del state_dict[f"model.layers.{i}.mlp.shared_experts.down_proj.weight"]

--- a/src/prime_rl/trainer/weights.py
+++ b/src/prime_rl/trainer/weights.py
@@ -163,7 +163,8 @@ def convert_tt_to_hf_moe(state_dict: dict[str, Tensor]):
 def load_state_dict(save_dir: Path) -> dict[str, Tensor]:
     """Load a state dict from a local directory with safetensor files."""
     safetensors_paths = list(save_dir.glob("*.safetensors"))
-    safetensors_paths.sort(key=lambda x: int(x.stem.split("-")[1].split("of")[0]))
+    if len(safetensors_paths) > 1:
+        safetensors_paths.sort(key=lambda x: int(x.stem.split("-")[1].split("of")[0]))
     state_dict = {}
     for safetensor_path in safetensors_paths:
         with safe_open(safetensor_path, framework="pt", device="cpu") as f:


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

This PR fixes a weight loading issue that occurs when we try to load a custom (MoE) model (`--model.impl custom`) from meta device (`--model.load-using-meta`). Our custom model uses the TT format for MoE layers. When trying to load a HF MoE model (e.g. `zai-org/GLM-4.5-Air`) the FQNs do not match leading to wrongly loading the weights. Because we had `DefaultLoadPlanner(allow_partial_load=True)` this would error siltently and would manifest in high loss on the SFT trainer and high trainer-inference mismatch on the RL trainer.

Changes made:
- Use the default planner (`allow_partial_load=False`) to get explicit logs
- Automatically detect and convert if there is a mismatch between the snapshot weights and the model weights and do a best-effort attempt at conversion. This only happens on the master rank (all non-master ranks wait), and is "cached", i.e. we write the converted weights to disk for subsequent operations.

Note: The bug will still occur if one tries to load with `--model.impl custom` on CPU device.
