### PR TITLE
Bump verifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ prerelease = "allow"
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 reverse-text = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "d98c139" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "a793bf6deb3896d2844bcae6de4dcddb6436fac1" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "main" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e43694bbfeff5d6ad8ac738c067bb90d41" }
 

--- a/uv.lock
+++ b/uv.lock
@@ -2190,7 +2190,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e43694bbfeff5d6ad8ac738c067bb90d41" },
     { name = "transformers", specifier = ">=4.56.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=d98c139" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=a793bf6deb3896d2844bcae6de4dcddb6436fac1" },
     { name = "vllm", specifier = "==0.10.2" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -3501,7 +3501,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.6.post0"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=d98c139#d98c139607e7e62026aac0a394a8ffaeb36e08bf" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=a793bf6deb3896d2844bcae6de4dcddb6436fac1#a793bf6deb3896d2844bcae6de4dcddb6436fac1" }
 dependencies = [
     { name = "datasets" },
     { name = "jinja2" },
@@ -3513,6 +3513,7 @@ dependencies = [
     { name = "requests" },
     { name = "rich" },
     { name = "textual" },
+    { name = "wget" },
 ]
 
 [[package]]
@@ -3698,6 +3699,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/9f/69/83029f1f6300c5fb2
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/24/ab44c871b0f07f491e5d2ad12c9bd7358e527510618cb1b803a88e986db1/werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e", size = 224498, upload-time = "2024-11-08T15:52:16.132Z" },
 ]
+
+[[package]]
+name = "wget"
+version = "3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/6a/62e288da7bcda82b935ff0c6cfe542970f04e29c756b0e147251b2fb251f/wget-3.2.zip", hash = "sha256:35e630eca2aa50ce998b9b1a127bb26b30dfee573702782aa982f875e3f16061", size = 10857, upload-time = "2015-10-22T15:26:37.51Z" }
 
 [[package]]
 name = "widgetsnbextension"


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Up to date with latest main (`a793bf6deb3896d2844bcae6de4dcddb6436fac1`), namely including [#502](https://github.com/PrimeIntellect-ai/verifiers/pull/502) which contains fixes for overlong multiturn prompts.