### PR TITLE
Changes to the trainer to minimise potential mismatch with vllm

### DIFF
--- a/src/prime_rl/trainer/models/glm.py
+++ b/src/prime_rl/trainer/models/glm.py
@@ -296,10 +296,11 @@ class Glm4MoeDecoderLayer(GradientCheckpointingLayer):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        position_embeddings: Optional[tuple[torch.Tensor, torch.Tensor]] = None,  # necessary, but kept here for BC
+        cos_sin_cache: torch.Tensor,
         cu_seqlens: Optional[torch.LongTensor] = None,
         max_seqlen: Optional[int] = None,
         residual: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
     ) -> torch.Tensor:
         if residual is None:
             residual = hidden_states
@@ -309,9 +310,10 @@ class Glm4MoeDecoderLayer(GradientCheckpointingLayer):
         # Self Attention
         hidden_states, _ = self.self_attn(
             hidden_states=hidden_states,
-            position_embeddings=position_embeddings,
+            cos_sin_cache=cos_sin_cache,
             cu_seqlens=cu_seqlens,
             max_seqlen=max_seqlen,
+            position_ids=position_ids,
         )
         hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
         hidden_states = self.mlp(hidden_states)
@@ -398,16 +400,17 @@ class Glm4MoeModel(Glm4MoePreTrainedModel):
             cu_seqlens = None
 
         hidden_states = inputs_embeds
-        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+        cos_sin_cache = self.rotary_emb.cos_sin_cache
         residual = None
 
         for decoder_layer in self.layers[: self.config.num_hidden_layers]:
             hidden_states, residual = decoder_layer(
                 hidden_states,
-                position_embeddings=position_embeddings,
+                cos_sin_cache=cos_sin_cache,
                 cu_seqlens=cu_seqlens,
                 max_seqlen=max_seqlen,
                 residual=residual,
+                position_ids=position_ids,
             )
 
         hidden_states, _ = self.norm(hidden_states, residual)

--- a/src/prime_rl/trainer/models/glm.py
+++ b/src/prime_rl/trainer/models/glm.py
@@ -299,9 +299,13 @@ class Glm4MoeDecoderLayer(GradientCheckpointingLayer):
         position_embeddings: Optional[tuple[torch.Tensor, torch.Tensor]] = None,  # necessary, but kept here for BC
         cu_seqlens: Optional[torch.LongTensor] = None,
         max_seqlen: Optional[int] = None,
+        residual: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        residual = hidden_states
-        hidden_states = self.input_layernorm(hidden_states)
+        if residual is None:
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+        else:
+            hidden_states, residual = self.input_layernorm(hidden_states, residual)
         # Self Attention
         hidden_states, _ = self.self_attn(
             hidden_states=hidden_states,
@@ -309,14 +313,9 @@ class Glm4MoeDecoderLayer(GradientCheckpointingLayer):
             cu_seqlens=cu_seqlens,
             max_seqlen=max_seqlen,
         )
-        hidden_states = residual + hidden_states
-
-        # Fully Connected
-        residual = hidden_states
-        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
         hidden_states = self.mlp(hidden_states)
-        hidden_states = residual + hidden_states
-        return hidden_states
+        return hidden_states, residual
 
 
 @auto_docstring
@@ -400,16 +399,18 @@ class Glm4MoeModel(Glm4MoePreTrainedModel):
 
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
+        residual = None
 
         for decoder_layer in self.layers[: self.config.num_hidden_layers]:
-            hidden_states = decoder_layer(
+            hidden_states, residual = decoder_layer(
                 hidden_states,
                 position_embeddings=position_embeddings,
                 cu_seqlens=cu_seqlens,
                 max_seqlen=max_seqlen,
+                residual=residual,
             )
 
-        hidden_states = self.norm(hidden_states)
+        hidden_states, _ = self.norm(hidden_states, residual)
         return BaseModelOutputWithPast(last_hidden_state=hidden_states)
 
 

--- a/src/prime_rl/trainer/models/layers/attn.py
+++ b/src/prime_rl/trainer/models/layers/attn.py
@@ -61,7 +61,7 @@ class FlashAttention(nn.Module):
         cos_sin_cache: torch.Tensor,
         cu_seqlens: torch.LongTensor | None = None,
         max_seqlen: int | None = None,
-        position_ids: Optional[torch.LongTensor] = None,
+        position_ids: torch.LongTensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         input_shape = hidden_states.shape[:-1]
         hidden_shape = (*input_shape, -1, self.head_dim)

--- a/src/prime_rl/trainer/models/layers/attn.py
+++ b/src/prime_rl/trainer/models/layers/attn.py
@@ -134,7 +134,7 @@ class SDPAAttention(nn.Module):
         cos_sin_cache: torch.Tensor,
         cu_seqlens: torch.LongTensor | None = None,
         max_seqlen: int | None = None,
-        position_ids: Optional[torch.LongTensor] = None,
+        position_ids: torch.LongTensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         input_shape = hidden_states.shape[:-1]
         hidden_shape = (*input_shape, -1, self.head_dim)

--- a/src/prime_rl/trainer/models/layers/attn.py
+++ b/src/prime_rl/trainer/models/layers/attn.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import Optional
 import torch
 import torch.nn.functional as F
 from torch import nn

--- a/src/prime_rl/trainer/models/layers/attn.py
+++ b/src/prime_rl/trainer/models/layers/attn.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+
 import torch
 import torch.nn.functional as F
 from torch import nn

--- a/src/prime_rl/trainer/models/layers/rms_norm.py
+++ b/src/prime_rl/trainer/models/layers/rms_norm.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import Optional
 
 import torch
 from torch import nn

--- a/src/prime_rl/trainer/models/layers/rms_norm.py
+++ b/src/prime_rl/trainer/models/layers/rms_norm.py
@@ -20,7 +20,7 @@ class RMSNorm(nn.Module):
         self.weight = nn.Parameter(torch.ones(config.hidden_size))
         self.variance_epsilon = config.eps
 
-    def forward(self, hidden_states: torch.Tensor, residual: Optional[torch.Tensor] = None) -> torch.Tensor:
+    def forward(self, hidden_states: torch.Tensor, residual: torch.Tensor | None = None) -> torch.Tensor:
         input_dtype = hidden_states.dtype
         hidden_states = hidden_states.to(torch.float32)
         if residual is not None:

--- a/src/prime_rl/trainer/models/layers/rms_norm.py
+++ b/src/prime_rl/trainer/models/layers/rms_norm.py
@@ -3,7 +3,6 @@ from typing import Optional
 
 import torch
 from torch import nn
-from transformers.integrations import use_kernel_forward_from_hub
 
 
 @dataclass

--- a/src/prime_rl/trainer/models/layers/rotary_emb.py
+++ b/src/prime_rl/trainer/models/layers/rotary_emb.py
@@ -18,72 +18,50 @@ class RotaryEmbedding(nn.Module):
     def __init__(self, config: RotaryEmbeddingConfig, device=None):
         super().__init__()
         self.rope_type = config.rope_type
-        self.max_seq_len_cached = config.max_position_embeddings
-        self.original_max_seq_len = config.max_position_embeddings
+        self.max_position_embeddings = config.max_position_embeddings
         self.config = config.model_config
+        partial_rotary_factor = getattr(self.config, "partial_rotary_factor", 1.0)
+        head_dim = getattr(self.config, "head_dim", None) or self.config.hidden_size // self.config.num_attention_heads
+        self.rotary_dim = int(head_dim * partial_rotary_factor)
 
         self.rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
 
-        inv_freq, self.attention_scaling = self.rope_init_fn(self.config, device)
-        self.register_buffer("inv_freq", inv_freq, persistent=False)
-        self.original_inv_freq = self.inv_freq
-
+        cos_sin_cache = self._compute_cos_sin_cache()
+        self.register_buffer("cos_sin_cache", cos_sin_cache, persistent=False)
+    
     @torch.no_grad()
-    @dynamic_rope_update  # power user: used with advanced RoPE types (e.g. dynamic rope)
-    def forward(self, x, position_ids):
-        inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
-        position_ids_expanded = position_ids[:, None, :].float()
+    def _compute_cos_sin_cache(self) -> torch.Tensor:
+        """Compute the cos and sin cache."""
+        inv_freq, attention_scaling = self.rope_init_fn(self.config)
+        t = torch.arange(self.max_position_embeddings, dtype=torch.float)
 
-        device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
-        with torch.autocast(device_type=device_type, enabled=False):  # Force float32
-            freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
-            emb = torch.cat((freqs, freqs), dim=-1)
-            cos = emb.cos() * self.attention_scaling
-            sin = emb.sin() * self.attention_scaling
+        freqs = torch.einsum("i,j -> ij", t, inv_freq)
+        cos = freqs.cos() * attention_scaling
+        sin = freqs.sin() * attention_scaling
+        cache = torch.cat((cos, sin), dim=-1)
+        return cache
 
-        return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
+def apply_rotary_emb_torch(x, cos, sin, unsqueeze_dim=1):
+    cos = cos.unsqueeze(unsqueeze_dim).to(x.dtype)
+    sin = sin.unsqueeze(unsqueeze_dim).to(x.dtype)
+    x1, x2 = torch.chunk(x, 2, dim=-1)
+    o1 = x1 * cos - x2 * sin
+    o2 = x2 * cos + x1 * sin
+    return torch.cat((o1, o2), dim=-1)
 
-
-def rotate_half(x):
-    """Rotates half the hidden dims of the input."""
-    x1 = x[..., : x.shape[-1] // 2]
-    x2 = x[..., x.shape[-1] // 2 :]
-    return torch.cat((-x2, x1), dim=-1)
-
-
-def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
-    """Applies Rotary Position Embedding to the query and key tensors.
-
-    Args:
-        q (`torch.Tensor`): The query tensor.
-        k (`torch.Tensor`): The key tensor.
-        cos (`torch.Tensor`): The cosine part of the rotary embedding.
-        sin (`torch.Tensor`): The sine part of the rotary embedding.
-        position_ids (`torch.Tensor`, *optional*):
-            Deprecated and unused.
-        unsqueeze_dim (`int`, *optional*, defaults to 1):
-            The 'unsqueeze_dim' argument specifies the dimension along which to unsqueeze cos[position_ids] and
-            sin[position_ids] so that they can be properly broadcasted to the dimensions of q and k. For example, note
-            that cos[position_ids] and sin[position_ids] have the shape [batch_size, seq_len, head_dim]. Then, if q and
-            k have the shape [batch_size, heads, seq_len, head_dim], then setting unsqueeze_dim=1 makes
-            cos[position_ids] and sin[position_ids] broadcastable to the shapes of q and k. Similarly, if q and k have
-            the shape [batch_size, seq_len, heads, head_dim], then set unsqueeze_dim=2.
-    Returns:
-        `tuple(torch.Tensor)` comprising of the query and key tensors rotated using the Rotary Position Embedding.
-    """
-    cos = cos.unsqueeze(unsqueeze_dim)
-    sin = sin.unsqueeze(unsqueeze_dim)
-
-    # Keep half or full tensor for later concatenation
-    rotary_dim = cos.shape[-1]
+def apply_rotary_pos_emb(q, k, cos_sin_cache, position_ids=None, unsqueeze_dim=1):
+    position_ids = position_ids.flatten()
+    num_tokens = position_ids.shape[0]
+    cos_sin = cos_sin_cache.index_select(0, position_ids)
+    cos, sin = cos_sin.chunk(2, dim=-1)
+    rotary_dim = cos.shape[-1] * 2
+    q_shape, k_shape = q.shape, k.shape
+    q = q.reshape(num_tokens, -1, q_shape[-1])
+    k = k.reshape(num_tokens, -1, k_shape[-1])
     q_rot, q_pass = q[..., :rotary_dim], q[..., rotary_dim:]
     k_rot, k_pass = k[..., :rotary_dim], k[..., rotary_dim:]
-
-    # Apply rotary embeddings on the first half or full tensor
-    q_embed = (q_rot * cos) + (rotate_half(q_rot) * sin)
-    k_embed = (k_rot * cos) + (rotate_half(k_rot) * sin)
-
-    # Concatenate back to full shape
-    q_embed = torch.cat([q_embed, q_pass], dim=-1)
-    k_embed = torch.cat([k_embed, k_pass], dim=-1)
-    return q_embed, k_embed
+    q_embed = apply_rotary_emb_torch(q_rot, cos, sin, unsqueeze_dim)
+    k_embed = apply_rotary_emb_torch(k_rot, cos, sin, unsqueeze_dim)
+    q = torch.cat([q_embed, q_pass], dim=-1).reshape(q_shape)
+    k = torch.cat([k_embed, k_pass], dim=-1).reshape(k_shape)
+    return q, k

--- a/src/prime_rl/trainer/models/layers/rotary_emb.py
+++ b/src/prime_rl/trainer/models/layers/rotary_emb.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 
 import torch
 from torch import nn
-from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
+from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
 
 
 @dataclass

--- a/src/prime_rl/trainer/models/layers/rotary_emb.py
+++ b/src/prime_rl/trainer/models/layers/rotary_emb.py
@@ -28,7 +28,7 @@ class RotaryEmbedding(nn.Module):
 
         cos_sin_cache = self._compute_cos_sin_cache()
         self.register_buffer("cos_sin_cache", cos_sin_cache, persistent=False)
-    
+
     @torch.no_grad()
     def _compute_cos_sin_cache(self) -> torch.Tensor:
         """Compute the cos and sin cache."""
@@ -41,6 +41,7 @@ class RotaryEmbedding(nn.Module):
         cache = torch.cat((cos, sin), dim=-1)
         return cache
 
+
 def apply_rotary_emb_torch(x, cos, sin, unsqueeze_dim=1):
     cos = cos.unsqueeze(unsqueeze_dim).to(x.dtype)
     sin = sin.unsqueeze(unsqueeze_dim).to(x.dtype)
@@ -48,6 +49,7 @@ def apply_rotary_emb_torch(x, cos, sin, unsqueeze_dim=1):
     o1 = x1 * cos - x2 * sin
     o2 = x2 * cos + x1 * sin
     return torch.cat((o1, o2), dim=-1)
+
 
 def apply_rotary_pos_emb(q, k, cos_sin_cache, position_ids=None, unsqueeze_dim=1):
     position_ids = position_ids.flatten()

--- a/src/prime_rl/trainer/models/llama.py
+++ b/src/prime_rl/trainer/models/llama.py
@@ -78,9 +78,13 @@ class LlamaDecoderLayer(GradientCheckpointingLayer):
         position_embeddings: Optional[tuple[torch.Tensor, torch.Tensor]] = None,  # necessary, but kept here for BC
         cu_seqlens: Optional[torch.LongTensor] = None,
         max_seqlen: Optional[int] = None,
+        residual: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        residual = hidden_states
-        hidden_states = self.input_layernorm(hidden_states)
+        if residual is None:
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+        else:
+            hidden_states, residual = self.input_layernorm(hidden_states, residual)
         # Self Attention
         hidden_states, _ = self.self_attn(
             hidden_states=hidden_states,
@@ -88,14 +92,9 @@ class LlamaDecoderLayer(GradientCheckpointingLayer):
             cu_seqlens=cu_seqlens,
             max_seqlen=max_seqlen,
         )
-        hidden_states = residual + hidden_states
-
-        # Fully Connected
-        residual = hidden_states
-        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
         hidden_states = self.mlp(hidden_states)
-        hidden_states = residual + hidden_states
-        return hidden_states
+        return hidden_states, residual
 
 
 @auto_docstring
@@ -174,16 +173,18 @@ class LlamaModel(LlamaPreTrainedModel):
 
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
+        residual = None
 
         for decoder_layer in self.layers[: self.config.num_hidden_layers]:
-            hidden_states = decoder_layer(
+            hidden_states, residual = decoder_layer(
                 hidden_states,
                 position_embeddings=position_embeddings,
                 cu_seqlens=cu_seqlens,
                 max_seqlen=max_seqlen,
+                residual=residual,
             )
 
-        hidden_states = self.norm(hidden_states)
+        hidden_states, _ = self.norm(hidden_states, residual)
         return BaseModelOutputWithPast(
             last_hidden_state=hidden_states,
         )

--- a/src/prime_rl/trainer/models/qwen.py
+++ b/src/prime_rl/trainer/models/qwen.py
@@ -296,10 +296,11 @@ class Qwen3MoeDecoderLayer(GradientCheckpointingLayer):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        cos_sin_cache: torch.Tensor,
         cu_seqlens: torch.LongTensor | None = None,
         max_seqlen: int | None = None,
         residual: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
     ) -> torch.FloatTensor:
         if residual is None:
             residual = hidden_states
@@ -309,9 +310,10 @@ class Qwen3MoeDecoderLayer(GradientCheckpointingLayer):
         # Self Attention
         hidden_states, _ = self.self_attn(
             hidden_states=hidden_states,
-            position_embeddings=position_embeddings,
+            cos_sin_cache=cos_sin_cache,
             cu_seqlens=cu_seqlens,
             max_seqlen=max_seqlen,
+            position_ids=position_ids,
         )
         hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
         hidden_states = self.mlp(hidden_states)
@@ -393,16 +395,17 @@ class Qwen3MoeModel(Qwen3MoePreTrainedModel):
             cu_seqlens = None
 
         hidden_states = inputs_embeds
-        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+        cos_sin_cache = self.rotary_emb.cos_sin_cache
         residual = None
 
         for decoder_layer in self.layers[: self.config.num_hidden_layers]:
             hidden_states, residual = decoder_layer(
                 hidden_states,
-                position_embeddings=position_embeddings,
+                cos_sin_cache=cos_sin_cache,
                 cu_seqlens=cu_seqlens,
                 max_seqlen=max_seqlen,
                 residual=residual,
+                position_ids=position_ids,
             )
 
         hidden_states, _ = self.norm(hidden_states, residual)


### PR DESCRIPTION
Currently have matched rope implementations (seemingly vllm does rope in bf16 instead of fp32 which is weird)
Add residuals in fp32 instead of bf16
Stop using liger kernel for our RMS Norm

Planned:
Check MoE difference
Vllm fuses the residual and rms norm, not sure if we can do the equivalent
torch.topk apparently is unstable so will try to find an alternative
Test actual mismatch_kl difference and mfu difference (although mismatch_kl here might not be perfect as it can have an impact late in training)