### PR TITLE
Fix slow CI time

### DIFF
--- a/configs/debug/moe/sft/train.toml
+++ b/configs/debug/moe/sft/train.toml
@@ -11,6 +11,6 @@ load_using_meta = true
 
 [data]
 type = "fake"
-batch_size = 16
-seq_len = 128
+batch_size = 2
+seq_len = 1024
 fake = "fixed"

--- a/configs/debug/orch.toml
+++ b/configs/debug/orch.toml
@@ -1,7 +1,6 @@
 max_steps = 5
 async_level = 5
 batch_size = 16
-seq_len = 2048
 
 [sampling]
 max_tokens = 16

--- a/configs/debug/rl/train.toml
+++ b/configs/debug/rl/train.toml
@@ -2,5 +2,5 @@ max_steps = 5
 async_level = 5
 
 [data.fake]
-batch_size = 16
-seq_len = 128
+batch_size = 2
+seq_len = 1024

--- a/configs/debug/sft/train.toml
+++ b/configs/debug/sft/train.toml
@@ -5,5 +5,5 @@ name = "PrimeIntellect/Qwen3-0.6B"
 
 [data]
 type = "fake"
-batch_size = 16
-seq_len = 128
+batch_size = 2
+seq_len = 1024

--- a/configs/reverse_text/rl/orch.toml
+++ b/configs/reverse_text/rl/orch.toml
@@ -1,6 +1,6 @@
 batch_size = 128
 rollouts_per_example = 16
-seq_len = 128
+seq_len = 2048
 max_steps = 20
 mask_truncated_completions = false
 

--- a/configs/reverse_text/sft/train.toml
+++ b/configs/reverse_text/sft/train.toml
@@ -6,7 +6,7 @@ name = "PrimeIntellect/Qwen3-0.6B"
 [data]
 name = "PrimeIntellect/Reverse-Text-SFT"
 batch_size = 16
-seq_len = 128
+seq_len = 1024
 
 [optim]
 lr = 2e-5

--- a/configs/reverse_text/sft/train.toml
+++ b/configs/reverse_text/sft/train.toml
@@ -5,7 +5,7 @@ name = "PrimeIntellect/Qwen3-0.6B"
 
 [data]
 name = "PrimeIntellect/Reverse-Text-SFT"
-batch_size = 16
+batch_size = 2
 seq_len = 1024
 
 [optim]

--- a/examples/reverse_text/rl/orch.toml
+++ b/examples/reverse_text/rl/orch.toml
@@ -1,6 +1,6 @@
 batch_size = 128
 rollouts_per_example = 16
-seq_len = 128
+seq_len = 2048
 max_steps = 20
 mask_truncated_completions = false
 

--- a/tests/integration/test_trainer_path.py
+++ b/tests/integration/test_trainer_path.py
@@ -69,7 +69,7 @@ def train_process(
     run_process: Callable[[Command, Environment], ProcessResult],
     fake_rollout_dir: Callable[[list[int], int, int], Path],
 ):
-    output_dir = fake_rollout_dir(list(range(5)), 16, 16)
+    output_dir = fake_rollout_dir(list(range(5)), 2, 1024)
     return run_process(
         CMD + ["--output-dir", output_dir.as_posix(), "--data.fake", "None", "--log.level", "debug"], ENV
     )


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

#1129 removed the `micro_batch_size` argument from the codebase. Unfortunately, this has slowed down a lot of the integration tests in our CI which depended on the micro batch size to pack more tokens into micro batches, leading to faster parallel processing. This PR increases the sequence length and decreases batch size to match the tensor shapes from before and to reduce the CI time again.