### PR TITLE
Mask out entire sequences with dangerous tokens

### DIFF
--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -31,7 +31,7 @@ class LossConfig(BaseModel):
         Field(
             ge=0,
             description=(
-                "If set, masks entire sequences when any loss-masked token has an importance ratio below this value."
+                "If set, masks entire sequences when any generated token has an importance ratio below this value."
             ),
         ),
     ] = 1e-4

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -26,6 +26,15 @@ class LossConfig(BaseModel):
 
     mask_ratio_high: Annotated[float, Field(ge=0)] = 8.0
     mask_ratio_low: Annotated[float, Field(ge=0)] = 0.125
+    sequence_mask_ratio_low: Annotated[
+        float,
+        Field(
+            ge=0,
+            description=(
+                "If set, masks entire sequences when any loss-masked token has an importance ratio below this value."
+            ),
+        ),
+    ] = 1e-4
 
 
 class FakeDataLoaderConfig(BaseConfig):

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -88,6 +88,7 @@ def compute_loss(
     total_is_masked = []
     total_is_masked_low = []
     total_is_masked_high = []
+    total_sequence_masked_low = []
 
     for trainer_logprobs, inference_logprobs, advantages, loss_mask in zip(
         trainer_logprobs, inference_logprobs, advantages, loss_mask
@@ -108,6 +109,9 @@ def compute_loss(
         is_masked_low = importance_ratio < loss_config.mask_ratio_low
         is_masked_high = importance_ratio > loss_config.mask_ratio_high
         is_masked = is_masked_low | is_masked_high
+        seq_min_ratio = importance_ratio.masked_fill(~loss_mask, torch.inf).min()
+        seq_should_mask = seq_min_ratio < loss_config.sequence_mask_ratio_low
+        is_masked = is_masked | seq_should_mask
         keep_mask = loss_mask & ~is_masked
         loss = (-importance_ratio * advantages)[keep_mask].sum()
 
@@ -130,6 +134,7 @@ def compute_loss(
         total_is_masked.append(is_masked[loss_mask].float())
         total_is_masked_low.append(is_masked_low[loss_mask].float())
         total_is_masked_high.append(is_masked_high[loss_mask].float())
+        total_sequence_masked_low.append(seq_should_mask.float())
 
     # Apply loss scaling
     scaled_loss = total_loss / loss_scale
@@ -141,4 +146,5 @@ def compute_loss(
         "is_masked": torch.cat(total_is_masked),
         "is_masked_low": torch.cat(total_is_masked_low),
         "is_masked_high": torch.cat(total_is_masked_high),
+        "sequence_masked_low": torch.stack(total_sequence_masked_low),
     }


### PR DESCRIPTION
Have a threshold sequence_mask_ratio_low where if any token in a sequence falls under this, the entire sequence is masked.
Should handle dangerous sequences as mentioned in https://www.arxiv.org/abs/2510.02387
<img width="1002" height="246" alt="Screenshot 2025-10-27 at 17 59 23" src="https://github.com/user-attachments/assets/0cdb058c-6b53-458e-ba00-b9b7e6195197" />

Borrowed from the slime repo https://github.com/THUDM/slime/blob/83a3c964d68eb7f5cc8b2d05ef165d4ede4df813/examples/train_infer_mismatch_helper/mis.yaml#L24