### PR TITLE
delay evals client setup until env hub push

### DIFF
--- a/src/prime_rl/eval/eval.py
+++ b/src/prime_rl/eval/eval.py
@@ -8,7 +8,6 @@ from prime_rl.utils.client import (
     reload_weights,
     setup_admin_clients,
     setup_clients,
-    setup_evals_client,
     update_weights,
 )
 from prime_rl.utils.logger import setup_logger
@@ -42,7 +41,6 @@ async def eval(config: OfflineEvalConfig):
     )
     clients = setup_clients(config.client)
     admin_clients = setup_admin_clients(config.client)
-    evals_client = setup_evals_client()
 
     # Check health of the client
     logger.info("Waiting for inference pool to be ready")
@@ -63,7 +61,6 @@ async def eval(config: OfflineEvalConfig):
             model_config=config.model,
             sampling_config=config.sampling,
             client_config=config.client,
-            evals_client=evals_client,
             output_dir=config.output_dir,
             ckpt_step=0,
         )
@@ -91,7 +88,6 @@ async def eval(config: OfflineEvalConfig):
                 model_config=config.model,
                 sampling_config=config.sampling,
                 client_config=config.client,
-                evals_client=evals_client,
                 output_dir=config.output_dir,
                 ckpt_step=ckpt_step,
             )

--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -7,7 +7,6 @@ import numpy as np
 import pandas as pd
 from huggingface_hub import whoami
 from openai import AsyncOpenAI
-from prime_evals import AsyncEvalsClient
 from verifiers import load_environment
 from verifiers.types import GenerateOutputs
 from verifiers.utils.eval_utils import get_hf_hub_dataset_name, make_dataset, sanitize_metadata, save_to_disk
@@ -15,6 +14,7 @@ from verifiers.utils.eval_utils import get_hf_hub_dataset_name, make_dataset, sa
 from prime_rl.eval.config import OfflineEvalConfig
 from prime_rl.orchestrator.config import ClientConfig, EvalConfig, EvalSamplingConfig, EvalSaveConfig, ModelConfig
 from prime_rl.orchestrator.utils import parse_is_truncated_completions, parse_num_completion_tokens
+from prime_rl.utils.client import setup_evals_client
 from prime_rl.utils.logger import get_logger
 from prime_rl.utils.monitor import get_monitor
 from prime_rl.utils.utils import capitalize, get_eval_dir, get_step_path
@@ -87,7 +87,6 @@ async def run_eval(
     sampling_config: EvalSamplingConfig,
     client_config: ClientConfig,
     save_config: EvalSaveConfig,
-    evals_client: AsyncEvalsClient,
     step: int | None = None,
 ) -> None:
     # Get the logger
@@ -194,6 +193,7 @@ async def run_eval(
             eval_name = f"{env_id}--{model_config.name.replace('/', '--')}"
 
             # Create evaluation for environment
+            evals_client = setup_evals_client()
             create_response = await evals_client.create_evaluation(
                 name=eval_name,
                 environments=[{"id": env_id}],
@@ -220,7 +220,6 @@ async def run_evals(
     model_config: ModelConfig,
     sampling_config: EvalSamplingConfig,
     client_config: ClientConfig,
-    evals_client: AsyncEvalsClient,
     output_dir: Path,
     ckpt_step: int,
     step: int | None = None,
@@ -240,7 +239,6 @@ async def run_evals(
                 sampling_config=sampling_config,
                 client_config=client_config,
                 save_config=eval_config.save,
-                evals_client=evals_client,
                 ckpt_step=ckpt_step,
                 step=step,
             )

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -21,7 +21,6 @@ from prime_rl.utils.client import (
     reload_weights,
     setup_admin_clients,
     setup_clients,
-    setup_evals_client,
     update_weights,
 )
 from prime_rl.orchestrator.config import OrchestratorConfig
@@ -69,7 +68,6 @@ async def orchestrate(config: OrchestratorConfig):
     )
     clients = setup_clients(config.client)
     admin_clients = setup_admin_clients(config.client)
-    evals_client = setup_evals_client()
 
     # Load tokenizer
     logger.info(f"Initializing tokenizer for {config.model.name}")
@@ -187,7 +185,6 @@ async def orchestrate(config: OrchestratorConfig):
                 model_config=config.model,
                 sampling_config=config.eval.sampling,
                 client_config=config.client,
-                evals_client=evals_client,
                 output_dir=config.output_dir,
                 ckpt_step=ckpt_step,
                 step=progress.step,
@@ -486,7 +483,6 @@ async def orchestrate(config: OrchestratorConfig):
             model_config=config.model,
             sampling_config=config.eval.sampling,
             client_config=config.client,
-            evals_client=evals_client,
             output_dir=config.output_dir,
             ckpt_step=ckpt_step,
             step=progress.step,


### PR DESCRIPTION
resolves #1179 by delaying the call to setup_evals_client until it is actually required.

One potential issue with this change is that if there is any problem with the env hub setup, it won't get thrown until the client is built. Could instead make `evals_client` type `AsyncEvalsClient | None` and (optionally) build back with the other clients? This felt cleaner but happy to change.

---

**GitHub Issue**:  #1179