### PR TITLE
Fix Pydantic serialization overhead

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -5,6 +5,10 @@ from loguru import logger
 # Import environment before any other imports
 # ruff: noqa: I001,F401
 from prime_rl.orchestrator import envs
+from prime_rl.orchestrator.utils import monkey_patch_chat_completion_logprobs
+
+# This monkey patch is necessary to avoid heavy CPU overhead from constructing the OAI ChatCompletion Pydantic model with logprobs
+monkey_patch_chat_completion_logprobs()
 
 import lovely_tensors as lt
 import torch
@@ -51,9 +55,6 @@ import numpy as np
 @clean_exit
 @logger.catch(reraise=True)
 async def orchestrate(config: OrchestratorConfig):
-    # This monkey patch is necessary to avoid heavy CPU overhead from constructing the OAI ChatCompletion Pydantic model with logprobs
-    monkey_patch_chat_completion_logprobs()
-
     # Initialize the logger
     logger = setup_logger(
         config.log.level, log_file=config.output_dir / "logs" / "orchestrator.log" if config.log.file else None

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -30,6 +30,7 @@ from prime_rl.orchestrator.batch import prepare_batch
 from prime_rl.utils.logger import setup_logger
 from prime_rl.orchestrator.advantage import compute_advantages
 from prime_rl.orchestrator.utils import (
+    monkey_patch_chat_completion_logprobs,
     print_benchmark,
     parse_is_truncated_completions,
 )
@@ -50,6 +51,9 @@ import numpy as np
 @clean_exit
 @logger.catch(reraise=True)
 async def orchestrate(config: OrchestratorConfig):
+    # This monkey patch is necessary to avoid heavy CPU overhead from constructing the OAI ChatCompletion Pydantic model with logprobs
+    monkey_patch_chat_completion_logprobs()
+
     # Initialize the logger
     logger = setup_logger(
         config.log.level, log_file=config.output_dir / "logs" / "orchestrator.log" if config.log.file else None

--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -23,7 +23,7 @@ def monkey_patch_chat_completion_logprobs():
 
     # Patch the logprob field which is causing CPU overhead
     openai.types.chat.chat_completion.Choice = ChoiceAny
-    openai.types.chat.ChatCompletion = ChatCompletionAny
+    openai.types.chat.chat_completion.ChatCompletion = ChatCompletionAny
 
     # Patch verifiers parse_chat_completion_logprobs
     def patched_parse_chat_completion_logprobs(chat_completion: ChatCompletionAny) -> list[float]:

--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -1,8 +1,9 @@
-from typing import Any
+from typing import Any, List, Optional
 
+import openai.types.chat
 import pandas as pd
-from openai.types.chat import ChatCompletion
-from openai.types.chat.chat_completion import Choice
+import verifiers as vf
+from openai.types.chat.chat_completion import ChatCompletion, Choice
 from openai.types.completion_usage import CompletionUsage
 from rich.console import Console
 from rich.table import Table
@@ -11,6 +12,33 @@ from prime_rl.utils.utils import (
     format_num,
     format_time,
 )
+
+
+def monkey_patch_chat_completion_logprobs():
+    class ChoiceAny(Choice):
+        logprobs: Optional[Any] = None
+
+    class ChatCompletionAny(ChatCompletion):
+        choices: List[ChoiceAny]  # type: ignore
+
+    # Patch the logprob field which is causing CPU overhead
+    openai.types.chat.chat_completion.Choice = ChoiceAny
+    openai.types.chat.ChatCompletion = ChatCompletionAny
+
+    # Patch verifiers parse_chat_completion_logprobs
+    def patched_parse_chat_completion_logprobs(chat_completion: ChatCompletionAny) -> list[float]:
+        """Parses the completion logprobs from a vLLM chat completion"""
+        assert len(chat_completion.choices) == 1, "Response should always have one choice"
+        assert chat_completion.choices[0].logprobs is not None, (
+            "Logprobs should not be None. Make sure to set logprobs=True in the extra body when making the request to /v1/chat/completions"
+        )
+        assert chat_completion.choices[0].logprobs["content"] is not None, (
+            "Logprob content should not be None. Make sure to set logprobs=True in the extra body when making the request to /v1/chat/completions"
+        )
+        logprobs = [logprob["logprob"] for logprob in chat_completion.choices[0].logprobs["content"]]
+        return logprobs
+
+    vf.utils.processing_utils.parse_chat_completion_logprobs = patched_parse_chat_completion_logprobs
 
 
 def parse_num_completion_tokens(responses: list[list[ChatCompletion]]) -> list[int]:


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

At large batch sizes and context, constructing OAI's Pydantic model `ChatCompletion` with logprobs is causing heavy CPU overhead (~200ms per object at 32K context, which translates to >10min overhead at 4K batch size). This PR monkeypatches the OAI type and the post-processing utils in `verifiers` to make this fast.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: #1191 
**Linear Issue**: Resolves PRIMERL-189