### PR TITLE
all-in-one uv sync for fa2

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ source $HOME/.local/bin/env
 3. Install dependencies from the lock file
 
 ```bash
-uv sync && uv sync --all-extras
+uv sync
 ```
 
 </details>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "reverse-text",
     "verifiers>=0.1.5",
     "prime-evals>=0.1.2",
+    "flash-attn>=2.8.3",
 ]
 
 [project.scripts]
@@ -46,9 +47,6 @@ orchestrator = "prime_rl.orchestrator.orchestrator:main"
 inference = "prime_rl.inference.server:main"
 sft = "prime_rl.trainer.sft.train:main"
 eval = "prime_rl.eval.eval:main"
-
-[project.optional-dependencies]
-flash-attn = ["flash-attn>=2.8.3"]
 
 [dependency-groups]
 dev = [
@@ -70,6 +68,12 @@ reverse-text = { index = "primeintellect" }
 verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "a793bf6deb3896d2844bcae6de4dcddb6436fac1" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "main" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e43694bbfeff5d6ad8ac738c067bb90d41" }
+
+[tool.uv.extra-build-dependencies]
+flash-attn = [{ requirement = "torch", match-runtime = true }]
+
+[tool.uv.extra-build-variables]
+flash-attn = { FLASH_ATTENTION_SKIP_CUDA_BUILD = "TRUE" }
 
 [[tool.uv.index]]
 name = "primeintellect"

--- a/uv.lock
+++ b/uv.lock
@@ -2131,6 +2131,7 @@ dependencies = [
     { name = "cydifflib" },
     { name = "datasets" },
     { name = "dion" },
+    { name = "flash-attn" },
     { name = "jaxtyping" },
     { name = "liger-kernel" },
     { name = "loguru" },
@@ -2158,11 +2159,6 @@ dependencies = [
     { name = "wandb" },
 ]
 
-[package.optional-dependencies]
-flash-attn = [
-    { name = "flash-attn" },
-]
-
 [package.dev-dependencies]
 dev = [
     { name = "ipykernel" },
@@ -2180,7 +2176,7 @@ requires-dist = [
     { name = "cydifflib", specifier = ">=1.2.0" },
     { name = "datasets", specifier = ">=4.0.0" },
     { name = "dion", git = "https://github.com/samsja/dion.git?rev=main" },
-    { name = "flash-attn", marker = "extra == 'flash-attn'", specifier = ">=2.8.3" },
+    { name = "flash-attn", specifier = ">=2.8.3" },
     { name = "jaxtyping", specifier = ">=0.3.2" },
     { name = "liger-kernel", specifier = ">=0.5.10" },
     { name = "loguru", specifier = ">=0.7.3" },
@@ -2208,7 +2204,6 @@ requires-dist = [
     { name = "vllm", specifier = "==0.10.2" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
-provides-extras = ["flash-attn"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Uses tool.uv.extra_build_dependencies to match runtime for torch + flash-attn, enables single-command `uv sync` without `--all-extras`