### PR TITLE
Allow simpler pattern-matching for lora module names

### DIFF
--- a/configs/wiki_search/rl.toml
+++ b/configs/wiki_search/rl.toml
@@ -18,18 +18,18 @@ rank = 8
 alpha = 32
 dropout = 0.0
 target_modules = [
-    ".*\\.q_proj$",
-    ".*\\.k_proj$",
-    ".*\\.v_proj$",
-    ".*\\.o_proj$",
-    ".*\\.gate_proj$",
-    ".*\\.up_proj$",
-    ".*\\.down_proj$"
+    "q_proj",
+    "k_proj",
+    "v_proj",
+    "o_proj",
+    "gate_proj",
+    "up_proj",
+    "down_proj"
 ]
 modules_to_save = [
-    ".*embed_tokens$",
-    ".*norm$",
-    ".*layernorm$",
+    "embed_tokens",
+    "norm",
+    "layernorm",
     "lm_head$"
 ]
 

--- a/examples/alphabet_sort/rl/train.toml
+++ b/examples/alphabet_sort/rl/train.toml
@@ -12,18 +12,18 @@ rank = 32
 alpha = 64
 dropout = 0.0
 target_modules = [
-    ".*\\.q_proj$",
-    ".*\\.k_proj$",
-    ".*\\.v_proj$",
-    ".*\\.o_proj$",
-    ".*\\.gate_proj$",
-    ".*\\.up_proj$",
-    ".*\\.down_proj$"
+    "q_proj",
+    "k_proj",
+    "v_proj",
+    "o_proj",
+    "gate_proj",
+    "up_proj",
+    "down_proj"
 ]
 modules_to_save = [
-    ".*embed_tokens$",
-    ".*norm$",
-    ".*layernorm$",
+    "embed_tokens",
+    "norm",
+    "layernorm",
     "lm_head$"
 ]
 

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -80,24 +80,24 @@ class LoRAConfig(BaseModel):
     target_modules: Annotated[
         list[str],
         Field(
-            description="Regex patterns for modules to apply LoRA to.",
+            description="Module names or regex patterns for modules to apply LoRA to. Simple names (e.g., 'q_proj') match any component in the module path. Regex patterns match anywhere in the name.",
         ),
     ] = [
-        r".*\.q_proj$",
-        r".*\.k_proj$",
-        r".*\.v_proj$",
-        r".*\.o_proj$",
-        r".*\.gate_proj$",
-        r".*\.up_proj$",
-        r".*\.down_proj$",
+        "q_proj",
+        "k_proj",
+        "v_proj",
+        "o_proj",
+        "gate_proj",
+        "up_proj",
+        "down_proj",
     ]
 
     modules_to_save: Annotated[
         list[str],
         Field(
-            description="Regex patterns for modules to keep fully trainable (not freeze).",
+            description="Module names or regex patterns for modules to keep fully trainable (not freeze). Simple names match any component in the module path. Regex patterns match anywhere in the name.",
         ),
-    ] = [r".*embed_tokens$", r".*norm$", r".*layernorm$", r"lm_head$"]
+    ] = []
 
 
 class ExperimentalConfig(BaseModel):


### PR DESCRIPTION
Adds "PEFT-style" name matching so that configs can set e.g. "q_proj" without needing regex.

Also, sets default modules_to_save = [] -- most users won't expect LoRA to keep embeddings + norms trainable by default; we should surface this in the example configs.