### PR TITLE
log unfiltered_reward if difficulty filtering enabled

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -443,7 +443,7 @@ async def orchestrate(config: OrchestratorConfig):
         if isinstance(buffer, OnlineDifficultyBuffer):
             unfiltered_reward_mean = buffer.get_unfiltered_reward_mean()
             if unfiltered_reward_mean is not None:
-                reward_metrics["unfiltered_reward/mean"] = unfiltered_reward_mean
+                reward_metrics["reward/unfiltered_reward/mean"] = unfiltered_reward_mean
 
         monitor.log(reward_metrics)
 


### PR DESCRIPTION
If online difficulty filtering is used, we currently log the reward only for the train batch, which can make reward curves harder to interpret. This PR adds additional logging for the reward before overly easy/hard samples are dropped, which gives a (nearly*) unbiased estimator of the current distribution-level reward.

(*slightly biased estimator when multiple rounds of sampling are needed to fill the batch if oversampling level is insufficient for single pass)