### PR TITLE
Make NCCL beautiful

### DIFF
--- a/src/prime_rl/inference/config.py
+++ b/src/prime_rl/inference/config.py
@@ -118,11 +118,11 @@ class InferenceConfig(BaseSettings):
     ] = None
 
     broadcast_backend: Annotated[
-        Literal["nccl", "filesystem"], Field(description="The backend to use for broadcast.")
+        Literal["nccl", "filesystem"], Field(description="The backend to use for updating the weights.")
     ] = "filesystem"
 
     @model_validator(mode="after")
-    def nccl_and_dp(self) -> bool:
+    def nccl_and_dp(self):
         if self.broadcast_backend == "nccl" and self.parallel.dp != 1:
             raise ValueError("NCCL broadcast backend requires data parallel size to be 1")
         return self

--- a/src/prime_rl/inference/config.py
+++ b/src/prime_rl/inference/config.py
@@ -91,6 +91,14 @@ class ModelConfig(BaseConfig):
     ] = "hermes"
 
 
+class WeightBroadcastConfig(BaseSettings):
+    """Configures weight broadcast settings."""
+
+    type: Annotated[Literal["nccl", "filesystem"], Field(description="The type of weight broadcast to use.")] = (
+        "filesystem"
+    )
+
+
 class InferenceConfig(BaseSettings):
     """Configures inference."""
 
@@ -117,13 +125,13 @@ class InferenceConfig(BaseSettings):
         ),
     ] = None
 
-    broadcast_backend: Annotated[
-        Literal["nccl", "filesystem"], Field(description="The backend to use for updating the weights.")
-    ] = "filesystem"
+    weight_broadcast: Annotated[WeightBroadcastConfig, Field(description="The weight broadcast config.")] = (
+        WeightBroadcastConfig()
+    )
 
     @model_validator(mode="after")
     def nccl_and_dp(self):
-        if self.broadcast_backend == "nccl" and self.parallel.dp != 1:
+        if self.weight_broadcast.type == "nccl" and self.parallel.dp != 1:
             raise ValueError("NCCL broadcast backend requires data parallel size to be 1")
         return self
 

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -142,7 +142,7 @@ def server(config: InferenceConfig, vllm_args: list[str]):
     validate_parsed_serve_args(args)
 
     # Set the worker extension class based on the broadcast backend
-    args.worker_extension_cls = WORKER_EXTENSION_CLS[args.broadcast_backend]
+    args.worker_extension_cls = WORKER_EXTENSION_CLS[config.weight_broadcast.type]
 
     # Raise error if logprobs_mode is not set to processed_logprobs
     if args.logprobs_mode != "processed_logprobs":

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -29,8 +29,8 @@ logger = init_logger("vllm.entrypoints.openai.api_server")
 
 
 WORKER_EXTENSION_CLS = {
-    "nccl": "prime_rl.inference.vllm.worker_nccl.NCCLBroadcastWorker",
-    "filesystem": "prime_rl.inference.vllm.worker.CheckpointWorker",
+    "nccl": "prime_rl.inference.vllm.worker.nccl.NCCLWeightUpdateWorker",
+    "filesystem": "prime_rl.inference.vllm.worker.filesystem.FileSystemWeightUpdateWorker",
 }
 
 
@@ -138,8 +138,10 @@ def server(config: InferenceConfig, vllm_args: list[str]):
     parser = FlexibleArgumentParser(description="vLLM OpenAI-Compatible RESTful API server.")
     parser = make_arg_parser(parser)
     args = parser.parse_args(args=vllm_args, namespace=config.to_vllm())
+    assert args is not None
     validate_parsed_serve_args(args)
 
+    # Set the worker extension class based on the broadcast backend
     args.worker_extension_cls = WORKER_EXTENSION_CLS[args.broadcast_backend]
 
     # Raise error if logprobs_mode is not set to processed_logprobs

--- a/src/prime_rl/inference/vllm/worker/filesystem.py
+++ b/src/prime_rl/inference/vllm/worker/filesystem.py
@@ -13,12 +13,9 @@ else:
     Worker = object
 
 
-class CheckpointWorker(Worker):
+class FileSystemWeightUpdateWorker(Worker):
     """
-    This is an extension of a vLLM worker that allows for loading checkpoints
-    from a specified directory via RPC calls from the AsyncLLMEngine class, exposed
-    by the vLLM server. This is useful in RL training, where we want to load the
-    recent policy model from a checkpoint directory.
+    This is an vLLM worker extension for updating weights to an updated RL policy model via filesystem.
     """
 
     def init_broadcaster(self) -> None:

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -158,7 +158,7 @@ async def orchestrate(config: OrchestratorConfig):
         if config.max_steps and progress.step >= config.max_steps:
             break
 
-        logger.info(f"Starting orchestrator step {progress.step} ({ckpt_step=})")
+        logger.info(f"Starting orchestrator step {progress.step}")
         step_start_time = time.time()
 
         # If we hit the async barrier, update the inference pool weights with the correct policy

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -103,15 +103,16 @@ async def orchestrate(config: OrchestratorConfig):
     logger.info("Waiting for inference pool to be ready")
     await check_health(admin_clients)
     await check_has_model(clients, config.model.name)
-
-    # Set up NCCL broadcast
-    if config.broadcast_backend == "nccl":
-        logger.info(f"Initializing NCCL broadcast ({config.broadcast_backend})")
-        await init_nccl_broadcast(
-            admin_clients, config.nccl_broadcast.host, config.nccl_broadcast.port, config.nccl_broadcast.timeout
-        )
-
     logger.success("Inference pool ready")
+
+    # Set up weight broadcast backend
+    if config.weight_broadcast.type == "nccl":
+        logger.info(f"Initializing NCCL broadcast ({config.weight_broadcast})")
+        await init_nccl_broadcast(
+            admin_clients, config.weight_broadcast.host, config.weight_broadcast.port, config.weight_broadcast.timeout
+        )
+    else:
+        logger.info("Using filesystem for broadcasting weights into the inference pool.")
 
     # Get checkpoint manager
     logger.info(f"Initializing checkpoint manager ({config.ckpt})")
@@ -123,12 +124,8 @@ async def orchestrate(config: OrchestratorConfig):
     if config.ckpt and ckpt_manager and config.ckpt.resume_step:
         ckpt_manager.load(progress, buffer, step=config.ckpt.resume_step)
         logger.info(f"Resuming training from checkpoint step `{config.ckpt.resume_step}`")
-        if config.broadcast_backend == "filesystem":
-            ckpt_step = max(progress.step - config.async_level, 0)
-            await update_weights(admin_clients, get_step_path(get_weights_dir(config.output_dir), ckpt_step))
-        if config.broadcast_backend == "nccl":
-            ckpt_step = progress.step
-            await update_weights(admin_clients, None)
+        ckpt_step = max(progress.step - config.async_level, 0)
+        await update_weights(admin_clients, get_step_path(get_weights_dir(config.output_dir), ckpt_step))
     else:
         logger.info("Training from scratch. Resetting weights to base model")
         await reload_weights(admin_clients)
@@ -164,42 +161,29 @@ async def orchestrate(config: OrchestratorConfig):
         logger.info(f"Starting orchestrator step {progress.step} ({ckpt_step=})")
         step_start_time = time.time()
 
+        # If we hit the async barrier, update the inference pool weights with the correct policy
         wait_for_weight_ckpt_time, update_weights_time = 0, 0
+        if progress.step - ckpt_step > config.async_level:
+            logger.debug(
+                f"Hit async barrier because step {progress.step} is {progress.step - ckpt_step} (>{config.async_level}) steps ahead of checkpoint step {ckpt_step}."
+            )
+            ckpt_step = progress.step - config.async_level
 
-        if config.broadcast_backend == "filesystem":
-            # Optionally, wait for the next checkpoint to be available
-            if progress.step - ckpt_step > config.async_level:
-                logger.debug(
-                    f"Hit async barrier because step {progress.step} is {progress.step - ckpt_step} (>{config.async_level}) steps ahead of checkpoint step {ckpt_step}."
-                )
-
-                # Wait for the checkpoint to be available
-                ckpt_step = progress.step - config.async_level
+            # Wait for the checkpoint to be available on disk
+            if config.weight_broadcast.type == "filesystem":
                 logger.info(f"Waiting for weight checkpoint {ckpt_step}")
                 wait_for_weight_ckpt_start_time = time.time()
-
                 await wait_for_path(get_step_path(get_weights_dir(config.output_dir), ckpt_step) / "STABLE")
-
                 wait_for_weight_ckpt_time = time.time() - wait_for_weight_ckpt_start_time
                 logger.debug(f"Waited {wait_for_weight_ckpt_time:.2f}s for weight checkpoint")
 
-                # Update the weights
-                logger.info(f"Updating weights to weight checkpoint {ckpt_step}")
-                update_weights_start_time = time.time()
-                await update_weights(admin_clients, get_step_path(get_weights_dir(config.output_dir), ckpt_step))
-                update_weights_time = time.time() - update_weights_start_time
-                logger.debug(f"Updated weights in {update_weights_time:.2f}s")
-
-        elif config.broadcast_backend == "nccl":
-            if progress.step - ckpt_step > 1:
-                logger.info("Getting latest weights from NCCL broadcast")
-                update_weights_start_time = time.time()
-                ckpt_step = progress.step - 1
-                await update_weights(admin_clients, None)
-                update_weights_time = time.time() - update_weights_start_time
-                logger.debug(f"Updated weights in {update_weights_time:.2f}s")
-        else:
-            raise ValueError(f"Invalid broadcast backend: {config.broadcast_backend}")
+            # Update the weights
+            logger.info(f"Updating weights to weight checkpoint {ckpt_step}")
+            update_weights_start_time = time.time()
+            weight_dir = get_step_path(get_weights_dir(config.output_dir), ckpt_step)
+            await update_weights(admin_clients, weight_dir if config.weight_broadcast.type == "filesystem" else None)
+            update_weights_time = time.time() - update_weights_start_time
+            logger.debug(f"Updated weights in {update_weights_time:.2f}s")
 
         # Optionally, run online evals at the specified interval
         eval_time = 0

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -124,7 +124,7 @@ async def orchestrate(config: OrchestratorConfig):
     if config.ckpt and ckpt_manager and config.ckpt.resume_step:
         ckpt_manager.load(progress, buffer, step=config.ckpt.resume_step)
         logger.info(f"Resuming training from checkpoint step `{config.ckpt.resume_step}`")
-        ckpt_step = max(progress.step - config.async_level, 0)
+        ckpt_step = progress.step  # Always resume from the latest checkpoint
         await update_weights(admin_clients, get_step_path(get_weights_dir(config.output_dir), ckpt_step))
     else:
         logger.info("Training from scratch. Resetting weights to base model")

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -15,10 +15,15 @@ import tomli_w
 from pydantic import Field, model_validator
 
 from prime_rl.inference.config import InferenceConfig
+from prime_rl.inference.config import WeightBroadcastConfig as InferenceWeightBroadcastConfig
 from prime_rl.orchestrator.config import CheckpointConfig as OrchestratorCheckpointConfig
+from prime_rl.orchestrator.config import FileSystemWeightBroadcastConfig as OrchestratorFileSystemWeightBroadcastConfig
+from prime_rl.orchestrator.config import NCCLWeightBroadcastConfig as OrchestratorNCCLWeightBroadcastConfig
 from prime_rl.orchestrator.config import OrchestratorConfig
 from prime_rl.trainer.config import CheckpointConfig as TrainerCheckpointConfig
 from prime_rl.trainer.rl.config import FakeDataLoaderConfig
+from prime_rl.trainer.rl.config import FileSystemWeightBroadcastConfig as TrainerFileSystemWeightBroadcastConfig
+from prime_rl.trainer.rl.config import NCCLWeightBroadcastConfig as TrainerNCCLWeightBroadcastConfig
 from prime_rl.trainer.rl.config import RLTrainerConfig as TrainerConfig
 from prime_rl.utils.config import WandbMonitorConfig
 from prime_rl.utils.logger import setup_logger
@@ -38,6 +43,7 @@ from prime_rl.utils.validation import (
     validate_shared_model_name,
     validate_shared_output_dir,
     validate_shared_wandb_config,
+    validate_shared_weight_broadcast,
 )
 
 
@@ -84,6 +90,14 @@ class ModelConfig(BaseSettings):
         str,
         Field(description="The name of the model to use."),
     ] = "Qwen/Qwen3-0.6B"
+
+
+class WeightBroadcastConfig(BaseSettings):
+    """Configures shared weight broadcast settings."""
+
+    type: Annotated[Literal["nccl", "filesystem"], Field(description="The type of weight broadcast to use.")] = (
+        "filesystem"
+    )
 
 
 class RLConfig(BaseSettings):
@@ -175,16 +189,7 @@ class RLConfig(BaseSettings):
         ),
     ] = False
 
-    broadcast_backend: Annotated[
-        Literal["nccl", "filesystem"], Field(description="The backend to use for broadcast.")
-    ] = "filesystem"
-
-    @model_validator(mode="after")
-    def ascyn_nccl(self):
-        if self.broadcast_backend == "nccl" and self.async_level is not None:
-            if not self.async_level == 1:
-                raise ValueError("Async level must be 1 for NCCL broadcast")
-        return self
+    weight_broadcast: Annotated[WeightBroadcastConfig | None, Field(description="The weight broadcast config.")] = None
 
     @model_validator(mode="after")
     def validate_device(self):
@@ -352,6 +357,27 @@ class RLConfig(BaseSettings):
         return self
 
     @model_validator(mode="after")
+    def auto_setup_weight_broadcast(self):
+        if self.weight_broadcast:
+            if self.weight_broadcast.type == "nccl":
+                inference_world_size = self.inference.parallel.dp * self.inference.parallel.tp if self.inference else 1
+                self.trainer.weight_broadcast = TrainerNCCLWeightBroadcastConfig(
+                    type=self.weight_broadcast.type, inference_world_size=inference_world_size
+                )
+                self.orchestrator.weight_broadcast = OrchestratorNCCLWeightBroadcastConfig(
+                    type=self.weight_broadcast.type
+                )
+            elif self.weight_broadcast.type == "filesystem":
+                self.trainer.weight_broadcast = TrainerFileSystemWeightBroadcastConfig()
+                self.orchestrator.weight_broadcast = OrchestratorFileSystemWeightBroadcastConfig()
+            if self.inference:
+                self.inference.weight_broadcast = InferenceWeightBroadcastConfig(type=self.weight_broadcast.type)
+
+        validate_shared_weight_broadcast(self.trainer, self.orchestrator, self.inference)
+
+        return self
+
+    @model_validator(mode="after")
     def warn_wandb_resume_id_missing(self):
         if self.trainer.ckpt and self.trainer.ckpt.resume_step:
             if self.trainer.wandb and not self.trainer.wandb.id:
@@ -363,21 +389,6 @@ class RLConfig(BaseSettings):
                 warnings.warn(
                     "W&B run ID is not set for orchestrator even though resuming training. The current run will be created as a new run."
                 )
-        return self
-
-    @model_validator(mode="after")
-    def auto_setup_broadcast_backend(self):
-        self.trainer.broadcast_backend = self.broadcast_backend
-        self.orchestrator.broadcast_backend = self.broadcast_backend
-        if self.inference:
-            self.inference.broadcast_backend = self.broadcast_backend
-
-        return self
-
-    @model_validator(mode="after")
-    def auto_setup_nccl_inference_world_size(self):
-        if self.inference and self.broadcast_backend == "nccl":
-            self.trainer.nccl_broadcast.inference_world_size = self.inference.parallel.dp * self.inference.parallel.tp
         return self
 
 

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -391,6 +391,14 @@ class RLConfig(BaseSettings):
                 )
         return self
 
+    @model_validator(mode="after")
+    def validate_enough_devices_for_nccl(self):
+        if self.trainer.weight_broadcast.type == "nccl":
+            num_gpus = len(set(self.trainer_gpu_ids + self.inference_gpu_ids))
+            if num_gpus < 2:
+                raise ValueError("NCCL weight broadcast requires at least 2 GPUs to build the broadcast process group.")
+        return self
+
 
 def cleanup_threads(threads: list[Thread]):
     for thread in threads:

--- a/src/prime_rl/trainer/weights.py
+++ b/src/prime_rl/trainer/weights.py
@@ -428,13 +428,10 @@ class WeightCheckpointManager:
         step = max(step - (self.async_level + 1), 0)  # Consider deleting async_level + 1 steps ago
         candidate_path_to_delete = self._get_step_path(step)
         keep_for_eval = self.config.interval and step % self.config.interval == 0
-        # For checkpointing step x, we need all weight checkpoints in [x-async_level, x] (for logprob model)
-        # To get [n-k, n] with interval n and buffer k over all natural numbers x, we use the condition (n - (x % n)) % n <= k
         keep_for_ckpt = (
             self.ckpt_config
             and self.ckpt_config.interval
-            and (self.ckpt_config.interval - (step % self.ckpt_config.interval)) % self.ckpt_config.interval
-            <= self.async_level
+            and self.ckpt_config.interval % self.ckpt_config.interval == 0
         )
         if not (keep_for_eval or keep_for_ckpt):
             self._logger.debug(

--- a/src/prime_rl/utils/validation.py
+++ b/src/prime_rl/utils/validation.py
@@ -86,3 +86,21 @@ def validate_shared_async_level(
         raise ValueError(
             f"Trainer async level ({trainer.async_level}) and orchestrator async level ({orchestrator.async_level}) are not the same. Please specify the same async level for both."
         )
+
+
+def validate_shared_weight_broadcast(
+    trainer: RLTrainerConfig,
+    orchestrator: OrchestratorConfig,
+    inference: Optional[InferenceConfig] = None,
+) -> None:
+    if (
+        inference
+        and trainer.weight_broadcast.type != orchestrator.weight_broadcast.type != inference.weight_broadcast.type
+    ):
+        raise ValueError(
+            f"Inference weight broadcast type ({inference.weight_broadcast.type}) and orchestrator weight broadcast type ({orchestrator.weight_broadcast.type}) are not the same. Please specify the same weight broadcast type for both."
+        )
+    elif trainer.weight_broadcast.type != orchestrator.weight_broadcast.type:
+        raise ValueError(
+            f"Trainer weight broadcast type ({trainer.weight_broadcast.type}) and orchestrator weight broadcast type ({orchestrator.weight_broadcast.type}) are not the same. Please specify the same weight broadcast type for both."
+        )


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

A couple of improvements to bring NCCL into a more mergable state:
- Merge the redundant `broadcast_backend` and `nccl_broadcast` config into a single `weight_broadcast` config with a discriminated union, matching our general config system
- Simplify the checkpoint/ async resume logic for `filesystem` and `nccl` broadcast on the orchestrator. We can basically reuse the same logic, just have to enforce `async_level=1` for NCCL with pydantic
- Only set `--weight.interval 1` when filesystem is used on RL trainer, else use the default (None) which only saves at the checkpoint interval and at the end of training
- Validate from `rl.py` that the weight broadcast config aligns across all three components
- Add a guard that NCCL broadcast only works on at least 2 GPU (trainer and inference have to be on distinct devices)
- Minor file restructures
- Simplify checkpoint resume logic (do not save last async_level steps with either backend to simplify things) - needs some changes on trainer weight checkpointing and orchestrator resume