### PR TITLE
Small fixes

### DIFF
--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -199,10 +199,10 @@ class ValConfig(BaseConfig):
     """Configures the validation of the model."""
 
     num_examples: Annotated[
-        int, Field(description="Number of examples to use for validation. If -1, will use all examples.")
-    ] = -1
+        int, Field(ge=1, description="Number of examples to use for validation. If -1, will use all examples.")
+    ] = 16
     rollouts_per_example: Annotated[
-        int, Field(description="Number of samples to generate per example for validation.")
+        int, Field(ge=1, description="Number of samples to generate per example for validation.")
     ] = 1
     interval: Annotated[int, Field(description="Interval at which to validate the model.")] = 10
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -283,7 +283,7 @@ async def orchestrate(config: OrchestratorConfig):
             # Update pool
             rollouts = make_rollouts(
                 processed_outputs,
-                [problem["id"] for problem in problems],
+                [problem["id"] for problem in problems for _ in range(config.rollouts_per_example)],
                 advantages,
                 generate_outputs.task,
                 is_truncated,

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -283,7 +283,7 @@ async def orchestrate(config: OrchestratorConfig):
             # Update pool
             rollouts = make_rollouts(
                 processed_outputs,
-                generate_outputs.example_id,
+                [problem["id"] for problem in problems],
                 advantages,
                 generate_outputs.task,
                 is_truncated,


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Found two edges in the recent PRs:
- `--val.num-examples` should never be negative because we cannot sample -1 examples from the buffer using `random.sample`. Should behave more like defining a "train step"
- The `example_id` from `vf.EnvGroup` may be overlapping leading to distinct rollouts being treated as one. Now, we use the ID column that the buffer maintains