### PR TITLE
Remove redundant dist.barrier

### DIFF
--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -198,8 +198,6 @@ def load_dcp_from_hf(model: nn.Module, config: ModelConfig):
                 convert_hf_to_tt_moe(snapshot_state_dict)
                 save_state_dict(snapshot_state_dict, snapshot_path)
 
-        # All ranks wait for master rank to finish conversion
-        torch.distributed.barrier()
     elif has_tt_moe_layers(snapshot_state_dict) and has_hf_moe_layers(model_state_dict):
         logger.warning(
             "Found TT weight format in snapshot state dict and HF weight format in model state dict. Trying to auto-convert..."
@@ -215,8 +213,8 @@ def load_dcp_from_hf(model: nn.Module, config: ModelConfig):
                 convert_tt_to_hf_moe(snapshot_state_dict)
                 save_state_dict(snapshot_state_dict, snapshot_path)
 
-        # All ranks wait for master rank to finish conversion
-        torch.distributed.barrier()
+    # All ranks wait for master rank to finish conversion
+    torch.distributed.barrier()
 
     logger.info(f"Loading weights using HF DCP from {snapshot_path}")
     load_dcp_start_time = time.time()


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

One less `torch.dist.barrier`, that's what I originally intended to do but clearly I cannot read indentation properly.

*Edit: Also seems to prevent a deadlock (?)*
