### PR TITLE
Set writer batch size defensively

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ prerelease = "allow"
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 reverse-text = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "af3a25d1c14d2d3887d22186832986ff4c850056" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "616cf20" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "main" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e43694bbfeff5d6ad8ac738c067bb90d41" }
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -100,6 +100,7 @@ async def orchestrate(config: OrchestratorConfig):
     env = vf.EnvGroup(
         envs=[vf.load_environment(env.id, **env.args) for env in config.env],
         env_names=[env.name or env.id for env in config.env],
+        map_kwargs=dict(writer_batch_size=1),  # Set defensively to not error on map operations on large datasets
     )
     dataset = env.get_dataset(seed=config.seed)
     val_dataset = env.get_eval_dataset(config.val.num_examples, seed=config.seed) if config.val else None

--- a/uv.lock
+++ b/uv.lock
@@ -2200,7 +2200,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e43694bbfeff5d6ad8ac738c067bb90d41" },
     { name = "transformers", specifier = ">=4.56.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=af3a25d1c14d2d3887d22186832986ff4c850056" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=616cf20" },
     { name = "vllm", specifier = "==0.10.2" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -3510,7 +3510,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.6.post0"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=af3a25d1c14d2d3887d22186832986ff4c850056#af3a25d1c14d2d3887d22186832986ff4c850056" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=616cf20#616cf2016524a491f328586753be1aee5da0818d" }
 dependencies = [
     { name = "datasets" },
     { name = "jinja2" },


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

We were erroring on with `offset while concatenating dataset` inside the `Dataset.map` inside `EnvGroup`. Since this [PR](https://github.com/PrimeIntellect-ai/verifiers/pull/530) we allow passing map kwargs and we set them defensively in prime-rl to avoid such errors in the future. 