### PR TITLE
Fix weight cleanup with NCCL broadcast

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -116,13 +116,11 @@ async def orchestrate(config: OrchestratorConfig):
     logger.success("Inference pool ready")
 
     # Set up weight broadcast backend
+    logger.info(f"Initializing weight broadcast ({config.weight_broadcast})")
     if config.weight_broadcast.type == "nccl":
-        logger.info(f"Initializing NCCL broadcast ({config.weight_broadcast})")
         await init_nccl_broadcast(
             admin_clients, config.weight_broadcast.host, config.weight_broadcast.port, config.weight_broadcast.timeout
         )
-    else:
-        logger.info("Using filesystem for broadcasting weights into the inference pool.")
 
     # Get checkpoint manager
     logger.info(f"Initializing checkpoint manager ({config.ckpt})")

--- a/src/prime_rl/trainer/rl/broadcast/nccl_broadcast.py
+++ b/src/prime_rl/trainer/rl/broadcast/nccl_broadcast.py
@@ -116,11 +116,7 @@ class NCCLBroadcastSender:
         self.training_rank = get_world().rank
 
         if self.training_rank == 0:
-            self.logger.info(
-                f"Initializing NCCL broadcast ({host}:{port}, rank={get_world().rank}, world_size={world_size})"
-            )
             self.communicator = create_nccl_communicator(host, port, rank, world_size, device, timeout)
-
             self.logger.info(f"NCCL broadcast initialized for rank {rank} and world size {world_size}")
 
         self.device = device
@@ -142,7 +138,7 @@ class NCCLBroadcastSender:
         self.logger.debug(f"Broadcasting {num_state_dict_to_send} layer state dicts")
 
         for i, state_dict in filter_state_dict_by_layers(state_dict, num_layers):
-            self.logger.debug(f"sending layer {i}/{num_state_dict_to_send} state dict")
+            self.logger.debug(f"Sending layer {i}/{num_state_dict_to_send} state dict")
             for key, value in list(state_dict.items()):
                 if isinstance(value, DTensor):
                     value = value.to(self.dtype).full_tensor()
@@ -173,7 +169,7 @@ class NCCLBroadcastReceiver:
     ):
         self.logger = logger
 
-        self.logger.info(f"Initializing NCCL broadcast ({host}:{port}, rank={rank}, world_size={world_size})")
+        self.logger.info(f"Initializing NCCL broadcast receiver ({host}:{port}, rank={rank}, world_size={world_size})")
         self.communicator = create_nccl_communicator(host, port, rank, world_size, device, timeout)
 
         self.device = self.communicator.device

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -189,9 +189,3 @@ class RLTrainerConfig(BaseSettings):
         if self.weight_broadcast.type == "nccl" and self.async_level != 1:
             raise ValueError("NCCL weight broadcast only works with async level 1")
         return self
-
-    @model_validator(mode="after")
-    def ensure_saving_weights_every_step_for_filesystem(self):
-        if self.weight_broadcast.type == "filesystem":
-            self.weights.interval = 1
-        return self

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -99,6 +99,7 @@ def train(config: RLTrainerConfig):
 
     # Set up NCCL broadcast
     nccl_broadcast = None
+    logger.info(f"Initializing weight broadcast ({config.weight_broadcast})")
     if config.weight_broadcast.type == "nccl":
         # we do inferece world size + 1 because we have the trainer broadcaster as rank 0
         nccl_broadcast = NCCLBroadcastSender(
@@ -110,8 +111,6 @@ def train(config: RLTrainerConfig):
             device=torch.cuda.current_device(),
             logger=logger,
         )
-    else:
-        logger.info("Using filesystem for broadcasting weights into the inference pool.")
 
     # Set up checkpoint manager
     logger.info(f"Initializing checkpoint manager ({config.ckpt})")

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -153,9 +153,9 @@ def train(config: RLTrainerConfig):
                 config.weights.interval and progress.step % config.weights.interval == 0
             ):
                 weight_ckpt_manager.save(model, tokenizer, step=progress.step)
-
-            # Always create a stable file to signal to the orchestrator to initialize receiving weights via NCCL
-            weight_ckpt_manager.create_stable_file(progress.step)
+            else:
+                # Always create a stable file to signal to the orchestrator to initialize receiving weights via NCCL
+                weight_ckpt_manager.create_stable_file(progress.step)
             save_weights_time = time.time() - save_weights_start_time
             broadcast_weights_time = save_weights_time
 

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -149,11 +149,14 @@ def train(config: RLTrainerConfig):
         broadcast_weights_time = 0
         if progress.step > 0:
             save_weights_start_time = time.time()
-            if config.weights.interval and progress.step % config.weights.interval == 0:
+            # Save weights to disk at every if using filesystem weight broadcast or at interval step
+            if config.weight_broadcast.type == "filesystem" or (
+                config.weights.interval and progress.step % config.weights.interval == 0
+            ):
                 weight_ckpt_manager.save(model, tokenizer, step=progress.step)
-            else:
-                # Always create a stable file to signal to the orchestrator to initialize receiving weights via NCCL
-                weight_ckpt_manager.create_stable_file(progress.step)
+
+            # Always create a stable file to signal to the orchestrator to initialize receiving weights via NCCL
+            weight_ckpt_manager.create_stable_file(progress.step)
             save_weights_time = time.time() - save_weights_start_time
             broadcast_weights_time = save_weights_time
 

--- a/src/prime_rl/trainer/weights.py
+++ b/src/prime_rl/trainer/weights.py
@@ -381,6 +381,7 @@ class WeightCheckpointManager:
                 model.generation_config.save_pretrained(step_path)
             tokenizer.save_pretrained(step_path)
 
+        (step_path / "STABLE").touch()
         self._logger.debug(f"Saved weight checkpoint to {step_path} in {time.time() - start_time:.2f} seconds")
 
     def create_stable_file(self, step: int):

--- a/src/prime_rl/trainer/weights.py
+++ b/src/prime_rl/trainer/weights.py
@@ -381,7 +381,6 @@ class WeightCheckpointManager:
                 model.generation_config.save_pretrained(step_path)
             tokenizer.save_pretrained(step_path)
 
-        (step_path / "STABLE").touch()  # Signal to the orchestrator that the weight checkpoint is ready
         self._logger.debug(f"Saved weight checkpoint to {step_path} in {time.time() - start_time:.2f} seconds")
 
     def create_stable_file(self, step: int):


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Previously, using the NCCL backend would incorrectly save weight checkpoints to disk and also fail to remove them automatically, leading to exploding disk space. This PR fixes this by:
- Making`--weights.interval` signal only the interval step of saving weights for checkpoint/ evals purposes
- Save at every step automatically when using filesystem broadcast (but not by changing weights interval)

## Before

<img width="281" height="460" alt="Screenshot 2025-11-04 at 5 03 35 PM" src="https://github.com/user-attachments/assets/919455c9-e553-4e1d-a219-27feb56a50fd" />

## After

Cleanup is working, and the weight checkpoints only have the light-weight `STABLE` files

<img width="276" height="155" alt="Screenshot 2025-11-04 at 5 06 24 PM" src="https://github.com/user-attachments/assets/a3f54ad9-424f-4615-9feb-099930a1282c" />


