### PR TITLE
fix relative links `docs/README.md`

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,12 +2,12 @@
 
 This directory maintains the documentation for PRIME-RL. It is organized into the following sections:
 
-- [**Entrypoints**](docs/entrypoints.md) - Overview of the main components (orchestrator, trainer, inference) and how to run SFT, RL, and evals
-- [**Configs**](docs/configs.md) - Configuration system using TOML files, CLI arguments, and environment variables
-- [**Environments**](docs/environments.md) - Installing and using verifiers environments from the Environments Hub
-- [**Async Training**](docs/async.md) - Understanding asynchronous off-policy training and step semantics
-- [**Logging**](docs/logging.md) - Logging with loguru, torchrun, and Weights & Biases
-- [**Checkpointing**](docs/checkpointing.md) - Saving and resuming training from checkpoints
-- [**Benchmarking**](docs/benchmarking.md) - Performance benchmarking and throughput measurement
-- [**Deployment**](docs/deployment.md) - Training deployment on single-GPU, multi-GPU, and multi-node clusters
-- [**Troubleshooting**](docs/troubleshooting.md) - Common issues and their solutions
+- [**Entrypoints**](entrypoints.md) - Overview of the main components (orchestrator, trainer, inference) and how to run SFT, RL, and evals
+- [**Configs**](configs.md) - Configuration system using TOML files, CLI arguments, and environment variables
+- [**Environments**](environments.md) - Installing and using verifiers environments from the Environments Hub
+- [**Async Training**](async.md) - Understanding asynchronous off-policy training and step semantics
+- [**Logging**](logging.md) - Logging with loguru, torchrun, and Weights & Biases
+- [**Checkpointing**](checkpointing.md) - Saving and resuming training from checkpoints
+- [**Benchmarking**](benchmarking.md) - Performance benchmarking and throughput measurement
+- [**Deployment**](deployment.md) - Training deployment on single-GPU, multi-GPU, and multi-node clusters
+- [**Troubleshooting**](troubleshooting.md) - Common issues and their solutions


### PR DESCRIPTION
fix markdown links inside `docs/README.md` to be relative to `docs/` dir
---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: [Issue ID]
**Linear Issue**: Resolves [Issue ID]