### PR TITLE
Prevent DCP load race condition

### DIFF
--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -164,6 +164,7 @@ def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDim
 
 def load_dcp_from_hf(model: nn.Module, config: ModelConfig):
     model.to_empty(device="cuda")
+    torch.distributed.barrier()
 
     logger = get_logger()
     if config.debug.random_init:


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Not 100% sure if it was coincidence, but this barrier prevented the following race condition in DCP weight loading (n=1, lol)

```
RuntimeError: Missing key in checkpoint state_dict: lm_head.weight.
```
