### PR TITLE
for dp replicate dim

### DIFF
--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -128,11 +128,8 @@ def setup_tokenizer(config: ModelConfig) -> PreTrainedTokenizer:
 
 def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDims):
     mp_policy = MixedPrecisionPolicy(param_dtype=torch.bfloat16, reduce_dtype=DTYPE_MAP[config.reduce_dtype])
-    # TODO: Support dp_replicate
-    if config.dp_replicate > 1:
-        hsdp_mesh = parallel_dims.world_mesh["dp_replicate", "dp_shard_cp"]
-    else:
-        hsdp_mesh = parallel_dims.world_mesh["dp_shard_cp"]
+    # Always use 2D mesh format for consistency (dp_replicate dimension always present)
+    hsdp_mesh = parallel_dims.world_mesh["dp_replicate", "dp_shard_cp"]
 
     for transformer_block in model.model.layers:
         fully_shard(

--- a/src/prime_rl/trainer/parallel_dims.py
+++ b/src/prime_rl/trainer/parallel_dims.py
@@ -101,7 +101,7 @@ class ParallelDims:
         ):
             # dp_shard_mod_ep is needed even if it's 1, whose FSDP wrapping
             # helps the MoE layers do mixed precision training
-            if d > 1 or name == "dp_shard_mod_ep":
+            if d > 1 or name == "dp_shard_mod_ep" or name == "dp_replicate":
                 dims.append(d)
                 names.append(name)
 
@@ -119,9 +119,8 @@ class ParallelDims:
         # Mesh for ep
         ep_mesh_dim_names = []
 
-        if self.dp_replicate_enabled:
-            dp_mesh_dim_names.append("dp_replicate")
-            dp_cp_mesh_dim_names.append("dp_replicate")
+        dp_mesh_dim_names.append("dp_replicate")
+        dp_cp_mesh_dim_names.append("dp_replicate")
         # dp_shard_mod_ep is always needed, even if it's 1
         dp_mesh_dim_names.append("dp_shard_mod_ep")
         dp_shard_cp_mesh_dim_names.append("dp_shard_mod_ep")
@@ -150,7 +149,7 @@ class ParallelDims:
             [self.pp, self.dp_replicate, self.dp_shard, self.cp, self.tp],
             ["pp", "dp_replicate", "dp_shard", "cp", "tp"],
         ):
-            if d > 1 or name == "dp_shard":
+            if d > 1 or name == "dp_shard" or name == "dp_replicate":
                 dims.append(d)
                 names.append(name)
 
@@ -166,9 +165,8 @@ class ParallelDims:
         # Mesh for loss all-reduce
         dp_cp_mesh_dim_names = []
 
-        if self.dp_replicate_enabled:
-            dp_mesh_dim_names.append("dp_replicate")
-            dp_cp_mesh_dim_names.append("dp_replicate")
+        dp_mesh_dim_names.append("dp_replicate")
+        dp_cp_mesh_dim_names.append("dp_replicate")
         dp_mesh_dim_names.append("dp_shard")
         dp_shard_cp_mesh_dim_names.append("dp_shard")
         dp_cp_mesh_dim_names.append("dp_shard")


### PR DESCRIPTION
This pr force the device mesh to be 2d even if we only have 1 hsdp replica. This somehow solve the issue we have with muon and only using one dp replicate.

Pretty sure this force under the hood some kind of resharding that make the muon optimizer work as expected, so its a bit of a  patch but at least its working