### PR TITLE
Monkey-patch OAI models using `typing.Iterable` to avoid serialization bug

### DIFF
--- a/configs/wiki_search/rl.toml
+++ b/configs/wiki_search/rl.toml
@@ -6,10 +6,6 @@ max_steps = 500
 [model]
 name = "Qwen/Qwen3-4B-Instruct-2507"
 
-[wandb]
-project = "wiki-search-debug"
-name = "wiki-search-4b"
-
 [trainer.optim]
 lr = 1e-6
 weight_decay = 0.0
@@ -23,9 +19,6 @@ zero_truncated_completions = true
 
 [orchestrator.sampling]
 max_tokens = 512
-
-[orchestrator.buffer]
-type = "online-difficulty"
 
 [[orchestrator.env]]
 id = "wiki-search"

--- a/configs/wiki_search/rl.toml
+++ b/configs/wiki_search/rl.toml
@@ -6,6 +6,10 @@ max_steps = 500
 [model]
 name = "Qwen/Qwen3-4B-Instruct-2507"
 
+[wandb]
+project = "wiki-search-debug"
+name = "wiki-search-4b"
+
 [trainer.optim]
 lr = 1e-6
 weight_decay = 0.0
@@ -19,6 +23,9 @@ zero_truncated_completions = true
 
 [orchestrator.sampling]
 max_tokens = 512
+
+[orchestrator.buffer]
+type = "online-difficulty"
 
 [[orchestrator.env]]
 id = "wiki-search"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ prerelease = "allow"
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 reverse-text = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "3f04e63" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "d453785" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "main" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e43694bbfeff5d6ad8ac738c067bb90d41" }
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -6,10 +6,17 @@ from loguru import logger
 # Import environment before any other imports
 # ruff: noqa: I001,F401
 from prime_rl.orchestrator import envs
-from prime_rl.orchestrator.utils import get_train_sampling_args, monkey_patch_chat_completion_logprobs
+from prime_rl.orchestrator.utils import (
+    get_train_sampling_args,
+    monkey_patch_chat_completion_logprobs,
+    monkey_patch_oai_iterable_types,
+)
 
 # This monkey patch is necessary to avoid heavy CPU overhead from constructing the OAI ChatCompletion Pydantic model with logprobs
 monkey_patch_chat_completion_logprobs()
+
+# This monkey patch is necessary to avoid Pydantic validating iterable fields (e.g. in multimodal or tool call messages) lazily because they are typed as typing.Iterable, leading to tokenization errors
+monkey_patch_oai_iterable_types()
 
 import lovely_tensors as lt
 import torch
@@ -37,7 +44,6 @@ from prime_rl.orchestrator.batch import prepare_batch
 from prime_rl.utils.logger import setup_logger
 from prime_rl.orchestrator.advantage import compute_advantages
 from prime_rl.orchestrator.utils import (
-    monkey_patch_chat_completion_logprobs,
     print_benchmark,
     parse_is_truncated_completions,
 )

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -3,20 +3,21 @@ import asyncio
 import time
 from loguru import logger
 
+from prime_rl.orchestrator.patches import monkey_patch_oai_iterable_types
+
+# This monkey patch is necessary to avoid Pydantic validating fields using typing.Iterable (e.g. in multimodal or tool call messages) lazily which leads to tokenization errors, for more info see https://github.com/PrimeIntellect-ai/prime-rl/pull/1249
+monkey_patch_oai_iterable_types()
+
 # Import environment before any other imports
 # ruff: noqa: I001,F401
 from prime_rl.orchestrator import envs
 from prime_rl.orchestrator.utils import (
     get_train_sampling_args,
     monkey_patch_chat_completion_logprobs,
-    monkey_patch_oai_iterable_types,
 )
 
-# This monkey patch is necessary to avoid heavy CPU overhead from constructing the OAI ChatCompletion Pydantic model with logprobs
+# This monkey patch is necessary to avoid heavy CPU overhead from constructing the OAI ChatCompletion Pydantic model with logprobs, for more info see https://github.com/PrimeIntellect-ai/prime-rl/pull/1189
 monkey_patch_chat_completion_logprobs()
-
-# This monkey patch is necessary to avoid Pydantic validating iterable fields (e.g. in multimodal or tool call messages) lazily because they are typed as typing.Iterable, leading to tokenization errors
-monkey_patch_oai_iterable_types()
 
 import lovely_tensors as lt
 import torch

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -15,9 +15,7 @@ monkey_patch_chat_completion_logprobs()
 # Import environment before any other imports
 # ruff: noqa: I001,F401
 from prime_rl.orchestrator import envs
-from prime_rl.orchestrator.utils import (
-    get_train_sampling_args,
-)
+from prime_rl.orchestrator.utils import get_train_sampling_args
 
 import lovely_tensors as lt
 import torch

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -3,21 +3,21 @@ import asyncio
 import time
 from loguru import logger
 
-from prime_rl.orchestrator.patches import monkey_patch_oai_iterable_types
+from prime_rl.orchestrator.patches import monkey_patch_oai_iterable_types, monkey_patch_chat_completion_logprobs
 
 # This monkey patch is necessary to avoid Pydantic validating fields using typing.Iterable (e.g. in multimodal or tool call messages) lazily which leads to tokenization errors, for more info see https://github.com/PrimeIntellect-ai/prime-rl/pull/1249
 monkey_patch_oai_iterable_types()
+
+
+# This monkey patch is necessary to avoid heavy CPU overhead from constructing the OAI ChatCompletion Pydantic model with logprobs, for more info see https://github.com/PrimeIntellect-ai/prime-rl/pull/1189
+monkey_patch_chat_completion_logprobs()
 
 # Import environment before any other imports
 # ruff: noqa: I001,F401
 from prime_rl.orchestrator import envs
 from prime_rl.orchestrator.utils import (
     get_train_sampling_args,
-    monkey_patch_chat_completion_logprobs,
 )
-
-# This monkey patch is necessary to avoid heavy CPU overhead from constructing the OAI ChatCompletion Pydantic model with logprobs, for more info see https://github.com/PrimeIntellect-ai/prime-rl/pull/1189
-monkey_patch_chat_completion_logprobs()
 
 import lovely_tensors as lt
 import torch

--- a/src/prime_rl/orchestrator/patches.py
+++ b/src/prime_rl/orchestrator/patches.py
@@ -1,0 +1,83 @@
+from typing import Optional, TypedDict, Union
+
+import openai.types.chat
+from openai.types.chat.chat_completion_assistant_message_param import (
+    Audio,
+    ContentArrayOfContentPart,
+)
+from openai.types.chat.chat_completion_content_part_param import ChatCompletionContentPartParam
+from openai.types.chat.chat_completion_content_part_text_param import ChatCompletionContentPartTextParam
+from openai.types.chat.chat_completion_developer_message_param import ChatCompletionDeveloperMessageParam
+from openai.types.chat.chat_completion_function_message_param import ChatCompletionFunctionMessageParam
+from openai.types.chat.chat_completion_message import FunctionCall
+from openai.types.chat.chat_completion_message_tool_call_union_param import ChatCompletionMessageToolCallUnionParam
+from openai.types.chat.chat_completion_system_message_param import ChatCompletionSystemMessageParam
+from openai.types.chat.chat_completion_user_message_param import ChatCompletionUserMessageParam
+from typing_extensions import Literal, Required
+
+
+def monkey_patch_oai_iterable_types():
+    class ModdedChatCompletionDeveloperMessageParam(TypedDict, total=False):
+        """Same as openai.types.chat.chat_completion_developer_message_param.ChatCompletionDeveloperMessageParam, but replacing typing.Iterable with list to not mess up Pydantic."""
+
+        content: Required[Union[str, list[ChatCompletionContentPartTextParam]]]
+        role: Required[Literal["developer"]]
+        name: str
+
+    class ModdedChatCompletionSystemMessageParam(TypedDict, total=False):
+        """Same as openai.types.chat.chat_completion_system_message_param.ChatCompletionSystemMessageParam, but replacing typing.Iterable with list to not mess up Pydantic."""
+
+        content: Required[Union[str, list[ChatCompletionContentPartTextParam]]]
+        role: Required[Literal["system"]]
+        name: str
+
+    class ModdedChatCompletionUserMessageParam(TypedDict, total=False):
+        """Same as openai.types.chat.chat_completion_user_message_param.ChatCompletionUserMessageParam, but replacing typing.Iterable with list to not mess up Pydantic."""
+
+        content: Required[Union[str, list[ChatCompletionContentPartParam]]]
+        role: Required[Literal["user"]]
+        name: str
+
+    class ModdedChatCompletionAssistantMessageParam(TypedDict, total=False):
+        """Same as openai.types.chat.chat_completion_assistant_message_param.ChatCompletionAssistantMessageParam, but replacing typing.Iterable with list to not mess up Pydantic."""
+
+        role: Required[Literal["assistant"]]
+        audio: Optional[Audio]
+        content: Union[str, list[ContentArrayOfContentPart], None]
+        function_call: Optional[FunctionCall]
+        name: str
+        refusal: Optional[str]
+        tool_calls: list[ChatCompletionMessageToolCallUnionParam]
+
+    class ModdedChatCompletionToolMessageParam(TypedDict, total=False):
+        """Same as openai.types.chat.chat_completion_tool_message_param.ChatCompletionToolMessageParam, but replacing typing.Iterable with list to not mess up Pydantic."""
+
+        content: Required[Union[str, list[ChatCompletionContentPartTextParam]]]
+        role: Required[Literal["tool"]]
+        tool_call_id: Required[str]
+
+    # Patch OAI types
+    openai.types.chat.chat_completion_developer_message_param.ChatCompletionDeveloperMessageParam = (
+        ModdedChatCompletionDeveloperMessageParam
+    )
+    openai.types.chat.chat_completion_system_message_param.ChatCompletionSystemMessageParam = (
+        ModdedChatCompletionSystemMessageParam
+    )
+    openai.types.chat.chat_completion_user_message_param.ChatCompletionUserMessageParam = (
+        ModdedChatCompletionUserMessageParam
+    )
+    openai.types.chat.chat_completion_assistant_message_param.ChatCompletionAssistantMessageParam = (
+        ModdedChatCompletionAssistantMessageParam
+    )
+    openai.types.chat.chat_completion_tool_message_param.ChatCompletionToolMessageParam = (
+        ModdedChatCompletionToolMessageParam
+    )
+
+    openai.types.chat.chat_completion_message_param.ChatCompletionMessageParam = Union[
+        ChatCompletionDeveloperMessageParam,
+        ChatCompletionSystemMessageParam,
+        ChatCompletionUserMessageParam,
+        ModdedChatCompletionAssistantMessageParam,
+        ModdedChatCompletionToolMessageParam,
+        ChatCompletionFunctionMessageParam,
+    ]

--- a/src/prime_rl/orchestrator/patches.py
+++ b/src/prime_rl/orchestrator/patches.py
@@ -1,6 +1,7 @@
-from typing import Optional, TypedDict, Union
+from typing import Any, Optional, TypedDict, Union
 
 import openai.types.chat
+from openai.types.chat.chat_completion import ChatCompletion, Choice
 from openai.types.chat.chat_completion_assistant_message_param import (
     Audio,
     ContentArrayOfContentPart,
@@ -17,6 +18,13 @@ from typing_extensions import Literal, Required
 
 
 def monkey_patch_oai_iterable_types():
+    """
+    This monkey patch is necessary to avoid Pydantic validating fields using
+    typing.Iterable (e.g. in multimodal or tool call messages) lazily which
+    leads to tokenization errors, for more info see
+    https://github.com/PrimeIntellect-ai/prime-rl/pull/1249
+    """
+
     class ModdedChatCompletionDeveloperMessageParam(TypedDict, total=False):
         """Same as openai.types.chat.chat_completion_developer_message_param.ChatCompletionDeveloperMessageParam, but replacing typing.Iterable with list to not mess up Pydantic."""
 
@@ -81,3 +89,63 @@ def monkey_patch_oai_iterable_types():
         ModdedChatCompletionToolMessageParam,
         ChatCompletionFunctionMessageParam,
     ]
+
+
+def monkey_patch_chat_completion_logprobs():
+    """
+    At large batch sizes and context, constructing OAI's Pydantic model
+    ChatCompletion with logprobs is causing heavy CPU overhead (~200ms per
+    object at 32K context, which translates to >10min overhead at 4K batch
+    size). This function monkey-patches the OAI type and verifiers'
+    post-processing utils to avoid validating the complex logprobs field.
+    """
+
+    class ChoiceAny(Choice):
+        """Same as openai.types.chat.chat_completion.Choice, but without type validation for logprobs field."""
+
+        logprobs: Optional[Any] = None
+
+    class ModdedChatCompletion(ChatCompletion):
+        """Same as openai.types.chat.chat_completion.ChatCompletion, but but using ChoiceAny instead of Choice."""
+
+        choices: list[ChoiceAny]  # type: ignore
+
+    # Patch OAI types
+    openai.types.chat.chat_completion.Choice = ChoiceAny
+    openai.types.chat.chat_completion.ChatCompletion = ModdedChatCompletion
+
+    # Patch verifiers parse_chat_completion_logprobs
+    def patched_parse_chat_completion_logprobs(chat_completion: ModdedChatCompletion) -> list[float]:
+        """Same as verifiers.utils.processing_utils.parse_chat_completion_logprobs, but using arbitrary logprobs type."""
+        assert len(chat_completion.choices) == 1, "Response should always have one choice"
+        assert chat_completion.choices[0].logprobs is not None, (
+            "Logprobs should not be None. Make sure to set logprobs=True in the extra body when making the request to /v1/chat/completions"
+        )
+        assert chat_completion.choices[0].logprobs["content"] is not None, (
+            "Logprob content should not be None. Make sure to set logprobs=True in the extra body when making the request to /v1/chat/completions"
+        )
+        logprobs = [logprob["logprob"] for logprob in chat_completion.choices[0].logprobs["content"]]
+        return logprobs
+
+    # Patch verifiers parse_chat_completion_logprobs
+    def patched_parse_chat_completion_tokens(chat_completion: ModdedChatCompletion) -> list[int]:
+        """Same as verifiers.utils.processing_utils.parse_chat_completion_tokens, but using arbitrary logprobs type."""
+        assert len(chat_completion.choices) == 1, "Response should always have one choice"
+        assert chat_completion.choices[0].logprobs is not None, (
+            "Logprobs should not be None. Make sure to set logprobs=True in the extra body when making the request to /v1/chat/completions"
+        )
+        assert chat_completion.choices[0].logprobs["content"] is not None, (
+            "Logprob content should not be None. Make sure to set logprobs=True in the extra body when making the request to /v1/chat/completions"
+        )
+        tokens = [
+            # tokens are token_id:<int> because we request `return_tokens_as_token_ids` from vllm in GRPOTrainer
+            int(token["token"].split(":")[-1])
+            for token in chat_completion.choices[0].logprobs["content"]
+        ]
+        return tokens
+
+    # Import verifiers here (after patching OpenAI types) so verifiers picks up the patched types
+    import verifiers as vf
+
+    vf.utils.processing_utils.parse_chat_completion_logprobs = patched_parse_chat_completion_logprobs
+    vf.utils.processing_utils.parse_chat_completion_tokens = patched_parse_chat_completion_tokens

--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -1,18 +1,8 @@
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional
 
 import openai.types.chat
 import pandas as pd
-import verifiers as vf
 from openai.types.chat.chat_completion import ChatCompletion, Choice
-from openai.types.chat.chat_completion_assistant_message_param import (
-    ChatCompletionAssistantMessageParam,
-    ContentArrayOfContentPart,
-)
-from openai.types.chat.chat_completion_developer_message_param import ChatCompletionDeveloperMessageParam
-from openai.types.chat.chat_completion_message_tool_call_union_param import ChatCompletionMessageToolCallUnionParam
-from openai.types.chat.chat_completion_system_message_param import ChatCompletionSystemMessageParam
-from openai.types.chat.chat_completion_tool_message_param import ChatCompletionToolMessageParam
-from openai.types.chat.chat_completion_user_message_param import ChatCompletionUserMessageParam
 from openai.types.completion_usage import CompletionUsage
 from rich.console import Console
 from rich.table import Table
@@ -38,52 +28,6 @@ def get_train_sampling_args(sampling_config: SamplingConfig) -> dict:
     sampling_args["extra_body"]["min_tokens"] = sampling_args.pop("min_tokens")
     sampling_args["extra_body"]["repetition_penalty"] = sampling_args.pop("repetition_penalty")
     return sampling_args
-
-
-def monkey_patch_oai_iterable_types():
-    class ModdedChatCompletionDeveloperMessageParam(ChatCompletionDeveloperMessageParam):
-        """Same as openai.types.chat.chat_completion_developer_message_param.ChatCompletionDeveloperMessageParam, but replacing typing.Iterable with list to not mess up Pydantic."""
-
-        content: Union[str, list[ContentArrayOfContentPart], None]  # type: ignore[incompatible-variable-override]
-
-    class ModdedChatCompletionSystemMessageParam(ChatCompletionSystemMessageParam):
-        """Same as openai.types.chat.chat_completion_system_message_param.ChatCompletionSystemMessageParam, but replacing typing.Iterable with list to not mess up Pydantic."""
-
-        content: Union[str, list[ContentArrayOfContentPart], None]  # type: ignore[incompatible-variable-override]
-
-    class ModdedChatCompletionUserMessageParam(ChatCompletionUserMessageParam):
-        """Same as openai.types.chat.chat_completion_user_message_param.ChatCompletionUserMessageParam, but replacing typing.Iterable with list to not mess up Pydantic."""
-
-        content: Union[str, list[ContentArrayOfContentPart], None]  # type: ignore[incompatible-variable-override]
-
-    class ModdedChatCompletionAssistantMessageParam(ChatCompletionAssistantMessageParam):
-        """Same as openai.types.chat.chat_completion_assistant_message_param.ChatCompletionAssistantMessageParam, but replacing typing.Iterable with list to not mess up Pydantic."""
-
-        content: Union[str, list[ContentArrayOfContentPart], None]  # type: ignore[incompatible-variable-override]
-
-        tool_calls: list[ChatCompletionMessageToolCallUnionParam]  # type: ignore[incompatible-variable-override]
-
-    class ModdedChatCompletionToolMessageParam(ChatCompletionToolMessageParam):
-        """Same as openai.types.chat.chat_completion_tool_message_param.ChatCompletionToolMessageParam, but replacing typing.Iterable with list to not mess up Pydantic."""
-
-        tool_calls: list[ChatCompletionMessageToolCallUnionParam]  # type: ignore[incompatible-variable-override]
-
-    # Patch OAI types
-    openai.types.chat.chat_completion_developer_message_param.ChatCompletionDeveloperMessageParam = (
-        ModdedChatCompletionDeveloperMessageParam
-    )
-    openai.types.chat.chat_completion_system_message_param.ChatCompletionSystemMessageParam = (
-        ModdedChatCompletionSystemMessageParam
-    )
-    openai.types.chat.chat_completion_user_message_param.ChatCompletionUserMessageParam = (
-        ModdedChatCompletionUserMessageParam
-    )
-    openai.types.chat.chat_completion_assistant_message_param.ChatCompletionAssistantMessageParam = (
-        ModdedChatCompletionAssistantMessageParam
-    )
-    openai.types.chat.chat_completion_tool_message_param.ChatCompletionToolMessageParam = (
-        ModdedChatCompletionToolMessageParam
-    )
 
 
 def monkey_patch_chat_completion_logprobs():
@@ -138,6 +82,9 @@ def monkey_patch_chat_completion_logprobs():
             for token in chat_completion.choices[0].logprobs["content"]
         ]
         return tokens
+
+    # Import verifiers here (after patching OpenAI types) so verifiers picks up the patched types
+    import verifiers as vf
 
     vf.utils.processing_utils.parse_chat_completion_logprobs = patched_parse_chat_completion_logprobs
     vf.utils.processing_utils.parse_chat_completion_tokens = patched_parse_chat_completion_tokens

--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -1,6 +1,5 @@
-from typing import Any, List, Optional
+from typing import Any
 
-import openai.types.chat
 import pandas as pd
 from openai.types.chat.chat_completion import ChatCompletion, Choice
 from openai.types.completion_usage import CompletionUsage
@@ -28,66 +27,6 @@ def get_train_sampling_args(sampling_config: SamplingConfig) -> dict:
     sampling_args["extra_body"]["min_tokens"] = sampling_args.pop("min_tokens")
     sampling_args["extra_body"]["repetition_penalty"] = sampling_args.pop("repetition_penalty")
     return sampling_args
-
-
-def monkey_patch_chat_completion_logprobs():
-    """
-    At large batch sizes and context, constructing OAI's Pydantic model
-    ChatCompletion with logprobs is causing heavy CPU overhead (~200ms per
-    object at 32K context, which translates to >10min overhead at 4K batch
-    size). This function monkey-patches the OAI type and verifiers'
-    post-processing utils to avoid validating the complex logprobs field.
-    """
-
-    class ChoiceAny(Choice):
-        """Same as openai.types.chat.chat_completion.Choice, but without type validation for logprobs field."""
-
-        logprobs: Optional[Any] = None
-
-    class ModdedChatCompletion(ChatCompletion):
-        """Same as openai.types.chat.chat_completion.ChatCompletion, but but using ChoiceAny instead of Choice."""
-
-        choices: List[ChoiceAny]  # type: ignore
-
-    # Patch OAI types
-    openai.types.chat.chat_completion.Choice = ChoiceAny
-    openai.types.chat.chat_completion.ChatCompletion = ModdedChatCompletion
-
-    # Patch verifiers parse_chat_completion_logprobs
-    def patched_parse_chat_completion_logprobs(chat_completion: ModdedChatCompletion) -> list[float]:
-        """Same as verifiers.utils.processing_utils.parse_chat_completion_logprobs, but using arbitrary logprobs type."""
-        assert len(chat_completion.choices) == 1, "Response should always have one choice"
-        assert chat_completion.choices[0].logprobs is not None, (
-            "Logprobs should not be None. Make sure to set logprobs=True in the extra body when making the request to /v1/chat/completions"
-        )
-        assert chat_completion.choices[0].logprobs["content"] is not None, (
-            "Logprob content should not be None. Make sure to set logprobs=True in the extra body when making the request to /v1/chat/completions"
-        )
-        logprobs = [logprob["logprob"] for logprob in chat_completion.choices[0].logprobs["content"]]
-        return logprobs
-
-    # Patch verifiers parse_chat_completion_logprobs
-    def patched_parse_chat_completion_tokens(chat_completion: ModdedChatCompletion) -> list[int]:
-        """Same as verifiers.utils.processing_utils.parse_chat_completion_tokens, but using arbitrary logprobs type."""
-        assert len(chat_completion.choices) == 1, "Response should always have one choice"
-        assert chat_completion.choices[0].logprobs is not None, (
-            "Logprobs should not be None. Make sure to set logprobs=True in the extra body when making the request to /v1/chat/completions"
-        )
-        assert chat_completion.choices[0].logprobs["content"] is not None, (
-            "Logprob content should not be None. Make sure to set logprobs=True in the extra body when making the request to /v1/chat/completions"
-        )
-        tokens = [
-            # tokens are token_id:<int> because we request `return_tokens_as_token_ids` from vllm in GRPOTrainer
-            int(token["token"].split(":")[-1])
-            for token in chat_completion.choices[0].logprobs["content"]
-        ]
-        return tokens
-
-    # Import verifiers here (after patching OpenAI types) so verifiers picks up the patched types
-    import verifiers as vf
-
-    vf.utils.processing_utils.parse_chat_completion_logprobs = patched_parse_chat_completion_logprobs
-    vf.utils.processing_utils.parse_chat_completion_tokens = patched_parse_chat_completion_tokens
 
 
 def parse_num_completion_tokens(responses: list[list[ChatCompletion]]) -> list[int]:

--- a/uv.lock
+++ b/uv.lock
@@ -2200,7 +2200,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e43694bbfeff5d6ad8ac738c067bb90d41" },
     { name = "transformers", specifier = ">=4.56.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=3f04e63" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=d453785" },
     { name = "vllm", specifier = "==0.10.2" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -3510,7 +3510,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.6.post0"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=3f04e63#3f04e6365ebdfddc5b97de852f1a71335ec6f1b3" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=d453785#d4537852c01671cc0db8e5bd1931667cd17023f3" }
 dependencies = [
     { name = "datasets" },
     { name = "jinja2" },


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

As described in this [issue](https://github.com/PrimeIntellect-ai/verifiers/issues/432), Pydantic weirdly validates `typing.Iterable` types lazily (also documented in this [Pydantic issue](https://github.com/pydantic/pydantic/issues/9541), funnily this seems to be [expected behavior given their docs](https://docs.pydantic.dev/1.10/usage/types/#infinite-generators))  which leads to Pydantic `SerializationIterator` leaking when building `vf.GenerateOutputs` (and `vf.GenerateInputs` for that matter).

This PR fixes this by patching all OAI message types (almost all bc any `content` field may be multi-modal) from `typing.Iterable` to a simple `list` type.

## Minimal Repro

```python
from openai.types.chat.chat_completion_assistant_message_param import ChatCompletionAssistantMessageParam
from pydantic import BaseModel

class GenerateOutputs(BaseModel):
    messages: list[ChatCompletionAssistantMessageParam]

tool_calls = [{"id": "1", "function": {"name": "add", "arguments": "1+1"}, "type": "function"}]
messages = [{"role": "assistant", "content": "Calling add function", "tool_calls": tool_calls}]
obj = GenerateOutputs(messages=messages)

print(obj.model_dump())
# {'messages': [{'role': 'assistant', 'content': 'Calling add function', 'tool_calls': SerializationIterator(index=0, iterator=ValidatorIterator(index=0, schema=Some(Union(UnionValidator { mode: Smart, choices: [(TypedDict(TypedDictValidator { fields: [TypedDictField { name: "id", lookup_key_collection: LookupKeyCollection { by_name: Simple(LookupPath { first_item: PathItemString { key: "id", py_key: Py(0x7fab98972550) }, rest: [] }), by_alias: None, by_alias_then_name: None }, name_py: Py(0x17234a0), required: true, validator: Str(StrValidator { strict: false, coerce_numbers_to_str: false }) }, TypedDictField { name: "function", lookup_key_collection: LookupKeyCollection { by_name: Simple(LookupPath { first_item: PathItemString { key: "function", py_key: Py(0x7fab9896faf0) }, rest: [] }), by_alias: None, by_alias_then_name: None }, name_py: Py(0x7fab9a512ef0), required: true, validator: TypedDict(TypedDictValidator { fields: [TypedDictField { name: "arguments", lookup_key_collection: LookupKeyCollection { by_name: Simple(LookupPath { first_item: PathItemString { key: "arguments", py_key: Py(0x7fab9896f430) }, rest: [] }), by_alias: None, by_alias_then_name: None }, name_py: Py(0x17210c0), required: true, validator: Str(StrValidator { strict: false, coerce_numbers_to_str: false }) }, TypedDictField { name: "name", lookup_key_collection: LookupKeyCollection { by_name: Simple(LookupPath { first_item: PathItemString { key: "name", py_key: Py(0x7fab989725b0) }, rest: [] }), by_alias: None, by_alias_then_name: None }, name_py: Py(0x1724738), required: true, validator: Str(StrValidator { strict: false, coerce_numbers_to_str: false }) }], extra_behavior: Ignore, extras_validator: None, strict: false, loc_by_alias: true, validate_by_alias: None, validate_by_name: None, cls_name: Some("Function") }) }, TypedDictField { name: "type", lookup_key_collection: LookupKeyCollection { by_name: Simple(LookupPath { first_item: PathItemString { key: "type", py_key: Py(0x7fab989726a0) }, rest: [] }), by_alias: None, by_alias_then_name: None }, name_py: Py(0x1726950), required: true, validator: Literal(LiteralValidator { lookup: LiteralLookup { expected_bool: None, expected_int: None, expected_str: Some({"function": 0}), expected_py_dict: None, expected_py_values: None, expected_py_primitives: Some(Py(0x7fab9879a280)), values: [Py(0x7fab9a512ef0)] }, expected_repr: "'function'", name: "literal['function']" }) }], extra_behavior: Ignore, extras_validator: None, strict: false, loc_by_alias: true, validate_by_alias: None, validate_by_name: None, cls_name: Some("ChatCompletionMessageFunctionToolCallParam") }), None), (TypedDict(TypedDictValidator { fields: [TypedDictField { name: "id", lookup_key_collection: LookupKeyCollection { by_name: Simple(LookupPath { first_item: PathItemString { key: "id", py_key: Py(0x7fab98972580) }, rest: [] }), by_alias: None, by_alias_then_name: None }, name_py: Py(0x17234a0), required: true, validator: Str(StrValidator { strict: false, coerce_numbers_to_str: false }) }, TypedDictField { name: "custom", lookup_key_collection: LookupKeyCollection { by_name: Simple(LookupPath { first_item: PathItemString { key: "custom", py_key: Py(0x7fab989726d0) }, rest: [] }), by_alias: None, by_alias_then_name: None }, name_py: Py(0x7fab98eeea30), required: true, validator: TypedDict(TypedDictValidator { fields: [TypedDictField { name: "input", lookup_key_collection: LookupKeyCollection { by_name: Simple(LookupPath { first_item: PathItemString { key: "input", py_key: Py(0x7fab98972640) }, rest: [] }), by_alias: None, by_alias_then_name: None }, name_py: Py(0x17237e0), required: true, validator: Str(StrValidator { strict: false, coerce_numbers_to_str: false }) }, TypedDictField { name: "name", lookup_key_collection: LookupKeyCollection { by_name: Simple(LookupPath { first_item: PathItemString { key: "name", py_key: Py(0x7fab98972670) }, rest: [] }), by_alias: None, by_alias_then_name: None }, name_py: Py(0x1724738), required: true, validator: Str(StrValidator { strict: false, coerce_numbers_to_str: false }) }], extra_behavior: Ignore, extras_validator: None, strict: false, loc_by_alias: true, validate_by_alias: None, validate_by_name: None, cls_name: Some("Custom") }) }, TypedDictField { name: "type", lookup_key_collection: LookupKeyCollection { by_name: Simple(LookupPath { first_item: PathItemString { key: "type", py_key: Py(0x7fab98972730) }, rest: [] }), by_alias: None, by_alias_then_name: None }, name_py: Py(0x1726950), required: true, validator: Literal(LiteralValidator { lookup: LiteralLookup { expected_bool: None, expected_int: None, expected_str: Some({"custom": 0}), expected_py_dict: None, expected_py_values: None, expected_py_primitives: Some(Py(0x7fab9879a240)), values: [Py(0x7fab98eeea30)] }, expected_repr: "'custom'", name: "literal['custom']" }) }], extra_behavior: Ignore, extras_validator: None, strict: false, loc_by_alias: true, validate_by_alias: None, validate_by_name: None, cls_name: Some("ChatCompletionMessageCustomToolCallParam") }), None)], custom_error: None, name: "union[ChatCompletionMessageFunctionToolCallParam,ChatCompletionMessageCustomToolCallParam]" }))))}]}
```

With the patch on the message param, we serialize as expected

```python
from openai.types.chat.chat_completion_assistant_message_param import ChatCompletionAssistantMessageParam
from openai.types.chat.chat_completion_message_tool_call_union_param import ChatCompletionMessageToolCallUnionParam
from pydantic import BaseModel

class ModdedChatCompletionAssistantMessageParam(ChatCompletionAssistantMessageParam):
    tool_calls: list[ChatCompletionMessageToolCallUnionParam]  # type: ignore[incompatible-variable-override]

class GenerateOutputs(BaseModel):
    messages: list[ModdedChatCompletionAssistantMessageParam]

tool_calls = [{"id": "1", "function": {"name": "add", "arguments": "1+1"}, "type": "function"}]
messages = [{"role": "assistant", "content": "Calling add function", "tool_calls": tool_calls}]
obj = GenerateOutputs(messages=messages)

print(obj.model_dump())
# {'messages': [{'role': 'assistant', 'content': 'Calling add function', 'tool_calls': [{'id': '1', 'function': {'arguments': '1+1', 'name': 'add'}, 'type': 'function'}]}]}
```

## Before

Any tool call environment doesn't run, e.g. `wiki-search`

```bash
uv run rl @ configs/wiki_search/rl.toml
```

Leads to `AssertionError: Token prefix mismatch.`

## After

Works now

<img width="1316" height="605" alt="Screenshot 2025-11-06 at 4 10 21 PM" src="https://github.com/user-attachments/assets/f0cbcad0-c5c3-40f2-b7b6-0eb6150f8676" />

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: #1250 
**Linear Issue**: Resolves PRIMERL-199