### PR TITLE
auto-install envs in user/env-id format in rl.py

### DIFF
--- a/configs/wiki_search/rl.toml
+++ b/configs/wiki_search/rl.toml
@@ -11,8 +11,22 @@ project = "wiki-search-debug"
 name = "wiki-search-4b"
 
 [trainer.optim]
-lr = 1e-6
+lr = 1e-5
 weight_decay = 0.0
+
+[trainer.model.experimental.lora]
+rank = 8
+alpha = 32
+dropout = 0.0
+target_modules = [
+    "q_proj",
+    "k_proj",
+    "v_proj",
+    "o_proj",
+    "gate_proj",
+    "up_proj",
+    "down_proj"
+]
 
 [orchestrator]
 batch_size = 512
@@ -26,9 +40,10 @@ max_tokens = 512
 
 [orchestrator.buffer]
 type = "online-difficulty"
+oversampling_factor = 2.0
 
 [[orchestrator.env]]
-id = "wiki-search"
+id = "primeintellect/wiki-search"
 
 [inference.model]
 enable_auto_tool_choice = true

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -458,7 +458,7 @@ def rl(config: RLConfig):
     # Install each environment
     for env_id in env_ids_to_install:
         logger.info(f"Installing environment: {env_id}")
-        install_cmd = ["uv", "run", "prime", "env", "install", env_id]
+        install_cmd = ["uv", "run", "--no-sync", "prime", "env", "install", env_id]
         result = subprocess.run(install_cmd, capture_output=True, text=True)
         if result.returncode != 0:
             logger.error(f"Failed to install environment {env_id}: {result.stderr}")

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -458,7 +458,7 @@ def rl(config: RLConfig):
     # Install each environment
     for env_id in env_ids_to_install:
         logger.info(f"Installing environment: {env_id}")
-        install_cmd = ["prime", "env", "install", env_id]
+        install_cmd = ["uv", "run", "prime", "env", "install", env_id]
         result = subprocess.run(install_cmd, capture_output=True, text=True)
         if result.returncode != 0:
             logger.error(f"Failed to install environment {env_id}: {result.stderr}")

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -441,6 +441,30 @@ def rl(config: RLConfig):
     logger.info("Starting RL run")
     logger.debug(f"RL start command: {' '.join(start_command)}")
 
+    # Install any environments given in user/env-id format
+    env_ids_to_install = set()
+
+    # Collect training environment IDs
+    for env_config in config.orchestrator.env:
+        if "/" in env_config.id:
+            env_ids_to_install.add(env_config.id)
+
+    # Collect evaluation environment IDs
+    if config.orchestrator.eval:
+        for eval_env_config in config.orchestrator.eval.env:
+            if "/" in eval_env_config.id:
+                env_ids_to_install.add(eval_env_config.id)
+
+    # Install each environment
+    for env_id in env_ids_to_install:
+        logger.info(f"Installing environment: {env_id}")
+        install_cmd = ["prime", "env", "install", env_id]
+        result = subprocess.run(install_cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            logger.error(f"Failed to install environment {env_id}: {result.stderr}")
+            raise RuntimeError(f"Failed to install environment {env_id}")
+        logger.info(f"Successfully installed environment: {env_id}")
+
     # Prepare paths to communicate with the trainer
     log_dir = get_log_dir(config.output_dir)
     ckpt_dir = get_ckpt_dir(config.output_dir)


### PR DESCRIPTION
Convenience feature: if train/eval envs are given in config as `user/env-id`, install via `prime env install ...` subprocess inside of `rl.py`

Minimizes commands needed to launch a run, and allows users to be more explicit about which environment source is intended to be used with a config.

(Also re-adding LoRA for wiki-search config for 2-GPU training without OOMing)