### PR TITLE
fix(orchestrator): prevent extra padded micro batches

### DIFF
--- a/src/prime_rl/orchestrator/batch.py
+++ b/src/prime_rl/orchestrator/batch.py
@@ -150,7 +150,7 @@ def prepare_batch(
         prepare_micro_batch_packing(micro_batch, max_seq_len, temperature) for micro_batch in micro_batches_list
     ]
 
-    num_padding_batch = num_train_workers - len(micro_batches) % num_train_workers
+    num_padding_batch = -len(micro_batches) % num_train_workers
 
     # because of fsdp we need to make sure that each data ran has the same number of micro batches otherwise training will hang.
     # We create fake micro batches to fill the gap with real data but zero advantages, they would not contribute to the loss.

--- a/tests/unit/orchestrator/test_batch.py
+++ b/tests/unit/orchestrator/test_batch.py
@@ -1,0 +1,59 @@
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+from transformers import PreTrainedTokenizer
+
+from prime_rl.orchestrator.batch import prepare_batch
+from prime_rl.utils.vf import Rollout
+
+
+def _make_rollout(example_id: int) -> Rollout:
+    prompt_ids = [example_id, example_id + 1]
+    completion_ids = [example_id + 2, example_id + 3]
+    return {
+        "example_id": example_id,
+        "task": "dummy-task",
+        "prompt_ids": prompt_ids,
+        "prompt_mask": [1] * len(prompt_ids),
+        "completion_ids": completion_ids,
+        "completion_mask": [1] * len(completion_ids),
+        "completion_logprobs": [0.0] * len(completion_ids),
+        "reward": 0.0,
+        "advantage": 1.0,
+        "is_truncated": False,
+        "metrics": {},
+    }
+
+
+@pytest.mark.parametrize(
+    ("rollout_count", "num_train_workers", "expected_batches_per_worker"), [(4, 2, 2), (5, 2, 3), (7, 1, 7), (11, 4, 3)]
+)
+def test_prepare_batch_balances_micro_batches_across_workers(
+    rollout_count, num_train_workers, expected_batches_per_worker
+):
+    tokenizer = MagicMock(spec=PreTrainedTokenizer)
+    rollouts = [_make_rollout(i) for i in range(rollout_count)]
+
+    batches_per_gpu = prepare_batch(
+        rollouts=rollouts,
+        temperature=0.5,
+        tokenizer=tokenizer,
+        seq_len=4,
+        num_train_workers=num_train_workers,
+    )
+
+    assert all(len(worker_batches) == expected_batches_per_worker for worker_batches in batches_per_gpu)
+
+    flat_batches = [batch for worker_batches in batches_per_gpu for batch in worker_batches]
+    assert len(rollouts) <= len(flat_batches) < len(rollouts) + num_train_workers
+
+    # Verify real rollouts have expected non-zero advantages and loss mask
+    for batch in flat_batches[: len(rollouts)]:
+        assert torch.count_nonzero(batch["advantages"]) == 4
+        assert torch.count_nonzero(batch["loss_mask"]) == 4
+
+    # Verify padded batches have zero advantages and loss mask
+    for batch in flat_batches[len(rollouts) :]:
+        assert torch.count_nonzero(batch["advantages"]) == 0
+        assert torch.count_nonzero(batch["loss_mask"]) == 0


### PR DESCRIPTION
Hey folks, I noticed what appears to be a minor bug that could lead to extra padding batches wasting compute. Currently `num_padding_batch` is calculated as `num_train_workers - len(micro_batches) % num_train_workers` which creates `num_train_workers` extra padding batches if the micro batch count is evenly divisible by the number of train workers since `len(micro_batches) % num_train_workers` would be 0 leaving `num_train_workers - 0 = num_train_workers` padding batches.

This change modifies the calculation to `-len(micro_batches) % num_train_workers` which will find the required count of padding batches for the micro batch count to be divisible by the number of train workers.

Scenarios:

```python
# 4 mb, 2 train workers - fixed
2 - 4 % 2 # = 2
-4 % 2    # = 0

# 5 mb, 2 train workers - no change
2 - 5 % 2 # = 1
-5 % 2    # = 1

# 11 mb, 4 train workers - no change
4 - 11 % 4 # = 1
-11 % 4    # = 1
```

Testing: `uv run pytest -v` 