### PR TITLE
Fix checkpoint cleaning condition

### DIFF
--- a/src/prime_rl/trainer/weights.py
+++ b/src/prime_rl/trainer/weights.py
@@ -427,11 +427,10 @@ class WeightCheckpointManager:
         """Synchronous helper of `clean`."""
         step = max(step - (self.async_level + 1), 0)  # Consider deleting async_level + 1 steps ago
         candidate_path_to_delete = self._get_step_path(step)
-        keep_for_eval = self.config.interval and step % self.config.interval == 0
-        keep_for_ckpt = (
-            self.ckpt_config
-            and self.ckpt_config.interval
-            and self.ckpt_config.interval % self.ckpt_config.interval == 0
+        keep_for_eval = bool(self.config.interval and step % self.config.interval == 0)
+        keep_for_ckpt = bool(self.ckpt_config and self.ckpt_config.interval and step % self.ckpt_config.interval == 0)
+        self._logger.debug(
+            f"Considering deleting weight checkpoint {candidate_path_to_delete} ({keep_for_eval=}, {keep_for_ckpt=})"
         )
         if not (keep_for_eval or keep_for_ckpt):
             self._logger.debug(


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Whenever any `--ckpt` config was set on RL trainer, we'd never delete weight checkpoints because we had `ckpt.interval % ckpt.interval == 0` condition which is always True, hence we never delete because we always think we need to keep this for full checkpoint.
