### PR TITLE
Mika/buffer refactor

### DIFF
--- a/src/prime_rl/orchestrator/buffer.py
+++ b/src/prime_rl/orchestrator/buffer.py
@@ -154,7 +154,7 @@ class Buffer:
 
         pool_counts = Counter(m.get("difficulty", "normal") for m in self.metadata.values())
         pool_ratio = mean_normalize(list(pool_counts.values()))
-        metrics.update({f"buffer/pool/{key}": value for key, value in zip(self.DIFFICULTY_LEVELS, pool_ratio)})
+        metrics.update({f"buffer/pool/{key}": value for key, value in zip(pool_counts.keys(), pool_ratio)})
 
         # Reset per-step metrics
         self.num_sampled_problems_per_pool = defaultdict(int)

--- a/src/prime_rl/orchestrator/buffer.py
+++ b/src/prime_rl/orchestrator/buffer.py
@@ -108,7 +108,6 @@ class Buffer:
 
         for problem_id, example_rollouts in rollouts_by_example.items():
             avg_reward = sum(rollout["reward"] for rollout in example_rollouts) / len(example_rollouts)
-            has_zero_advantage = all(rollout["advantage"] == 0.0 for rollout in example_rollouts)
 
             if self.config.easy_threshold is not None and avg_reward >= self.config.easy_threshold:
                 new_difficulty = "easy"
@@ -120,10 +119,8 @@ class Buffer:
             self.metadata[problem_id]["difficulty"] = new_difficulty
             self.rollout_metrics[new_difficulty] += 1
 
-            if (
-                has_zero_advantage
-                or (self.config.filter_min_threshold is not None and avg_reward <= self.config.filter_min_threshold)
-                or (self.config.filter_max_threshold is not None and avg_reward >= self.config.filter_max_threshold)
+            if (self.config.filter_min_threshold is not None and avg_reward <= self.config.filter_min_threshold) or (
+                self.config.filter_max_threshold is not None and avg_reward >= self.config.filter_max_threshold
             ):
                 continue
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -37,9 +37,9 @@ from prime_rl.utils.client import (
     setup_evals_client,
     update_weights,
 )
-from prime_rl.orchestrator.config import OrchestratorConfig, SimpleBufferConfig
-from prime_rl.orchestrator.buffer import setup_buffer
+from prime_rl.orchestrator.config import OrchestratorConfig, BufferConfig
 from prime_rl.orchestrator.batch import prepare_batch
+from prime_rl.orchestrator.buffer import Buffer
 from prime_rl.utils.logger import setup_logger
 from prime_rl.orchestrator.utils import (
     print_benchmark,
@@ -113,8 +113,8 @@ async def orchestrate(config: OrchestratorConfig):
 
     # Setup buffer
     logger.info(f"Setting up buffer ({config.buffer})")
-    buffer = setup_buffer(dataset, config.buffer)
-    val_buffer = setup_buffer(val_dataset, SimpleBufferConfig()) if val_dataset else None
+    buffer = Buffer(dataset, config.buffer)
+    val_buffer = Buffer(val_dataset, BufferConfig()) if val_dataset else None
 
     # Setup scheduler
     scheduler = Scheduler(

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -361,9 +361,9 @@ async def orchestrate(config: OrchestratorConfig):
             "time/generate_completions": generate_completions_time,
             "time/save_ckpt": save_ckpt_time,
             # Scheduler metrics
-            **scheduler.metrics(),
+            **scheduler.get_metrics(),
             # Buffer metrics
-            **buffer.metrics(),
+            **buffer.get_metrics(),
             # W&B axis
             "step": progress.step,
         }

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -362,6 +362,8 @@ async def orchestrate(config: OrchestratorConfig):
             "time/save_ckpt": save_ckpt_time,
             # Scheduler metrics
             **scheduler.metrics(),
+            # Buffer metrics
+            **buffer.metrics(),
             # W&B axis
             "step": progress.step,
         }

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -247,7 +247,7 @@ class Scheduler:
     def async_level(self) -> int:
         return self.step - self.ckpt_step
 
-    def metrics(self) -> dict:
+    def get_metrics(self) -> dict[str, float]:
         return {
             "time/wait_for_ckpt": self.wait_for_ckpt_time,
             "time/update_weights": self.update_weights_time,

--- a/src/prime_rl/utils/utils.py
+++ b/src/prime_rl/utils/utils.py
@@ -285,3 +285,15 @@ def get_latest_ckpt_step(weights_dir: Path) -> int | None:
         if Path(weights_dir / f"step_{latest_step}" / "STABLE").exists():
             return latest_step
     return None
+
+
+def mean(values: list[float] | list[int]) -> float:
+    """Compute the mean of a list of values."""
+    num_values = len(values)
+    return sum(values) / num_values if num_values > 0 else 0
+
+
+def mean_normalize(values: list[float] | list[int]) -> list[float]:
+    """Mean-Normalize a list of values to 0-1."""
+    sum_values = sum(values)
+    return [value / sum_values if sum_values > 0 else 0 for value in values]

--- a/src/prime_rl/utils/utils.py
+++ b/src/prime_rl/utils/utils.py
@@ -8,8 +8,8 @@ from typing import Any
 
 import torch
 import torch.distributed as dist
-import wandb
 
+import wandb
 from prime_rl.utils.logger import get_logger
 
 
@@ -285,12 +285,6 @@ def get_latest_ckpt_step(weights_dir: Path) -> int | None:
         if Path(weights_dir / f"step_{latest_step}" / "STABLE").exists():
             return latest_step
     return None
-
-
-def mean(values: list[float] | list[int]) -> float:
-    """Compute the mean of a list of values."""
-    num_values = len(values)
-    return sum(values) / num_values if num_values > 0 else 0
 
 
 def mean_normalize(values: list[float] | list[int]) -> list[float]:

--- a/tests/unit/orchestrator/test_buffer.py
+++ b/tests/unit/orchestrator/test_buffer.py
@@ -87,13 +87,13 @@ def test_buffer_sample_problems(dataset):
 
 
 def test_buffer_sample_problems_with_difficulty_pools(difficulty_dataset, make_rollouts):
-    buffer = Buffer(difficulty_dataset, BufferConfig(easy_fraction=0.5, hard_fraction=0.5, easy_threshold=1.0, hard_threshold=0.0))
+    buffer = Buffer(
+        difficulty_dataset, BufferConfig(easy_fraction=0.5, hard_fraction=0.5, easy_threshold=1.0, hard_threshold=0.0)
+    )
     # First, set up difficulties by updating with rollouts
     # Set problems 0,1 to easy (advantage=0, reward=1.0), problem 4 to hard (advantage=0, reward=0.0)
     rollouts = make_rollouts(
-        difficulty_dataset,
-        rewards=[1.0, 1.0, 0.5, 0.5, 0.0],
-        advantages=[0.0, 0.0, 1.0, 1.0, 0.0]
+        difficulty_dataset, rewards=[1.0, 1.0, 0.5, 0.5, 0.0], advantages=[0.0, 0.0, 1.0, 1.0, 0.0]
     )
     buffer.update(rollouts)
     sampled_problems = buffer.sample_problems(3)
@@ -109,9 +109,7 @@ def test_buffer_sample_problems_only_easy(difficulty_dataset, make_rollouts):
     buffer = Buffer(difficulty_dataset, BufferConfig(easy_fraction=1.0, hard_fraction=0.0, easy_threshold=1.0))
     # Set problems 0,1 to easy (advantage=0, reward=1.0)
     rollouts = make_rollouts(
-        difficulty_dataset,
-        rewards=[1.0, 1.0, 0.5, 0.5, 0.5],
-        advantages=[0.0, 0.0, 1.0, 1.0, 1.0]
+        difficulty_dataset, rewards=[1.0, 1.0, 0.5, 0.5, 0.5], advantages=[0.0, 0.0, 1.0, 1.0, 1.0]
     )
     buffer.update(rollouts)
     sampled_problems = buffer.sample_problems(2)
@@ -125,9 +123,7 @@ def test_buffer_sample_problems_only_hard(difficulty_dataset, make_rollouts):
     buffer = Buffer(difficulty_dataset, BufferConfig(easy_fraction=0.0, hard_fraction=1.0, hard_threshold=0.0))
     # Set problems 2,4 to hard (advantage=0, reward=0.0)
     rollouts = make_rollouts(
-        difficulty_dataset,
-        rewards=[0.5, 0.5, 0.0, 0.5, 0.0],
-        advantages=[1.0, 1.0, 0.0, 1.0, 0.0]
+        difficulty_dataset, rewards=[0.5, 0.5, 0.0, 0.5, 0.0], advantages=[1.0, 1.0, 0.0, 1.0, 0.0]
     )
     buffer.update(rollouts)
     sampled_problems = buffer.sample_problems(2)
@@ -177,25 +173,15 @@ def test_buffer_sample_rollouts_more_than_available(dataset, make_rollouts):
     assert len(buffer.rollout_buffer) == 0
 
 
-def test_buffer_update_with_advantage_zero(difficulty_dataset, make_rollouts):
-    buffer = Buffer(difficulty_dataset, BufferConfig())
-    # Rollouts with advantage=0 should set difficulty based on thresholds, but not be added to buffer
-    rollouts = make_rollouts(difficulty_dataset, rewards=[1.0, 1.0, 1.0, 1.0, 1.0], advantages=[0.0, 0.0, 0.0, 0.0, 0.0])
-    buffer.update(rollouts)
-    # All should be marked as normal (thresholds are None by default)
-    assert all(metadata["difficulty"] == "normal" for metadata in buffer.metadata.values())
-    # But none should be in the rollout buffer (advantage == 0)
-    assert len(buffer.rollout_buffer) == 0
-
-
 def test_buffer_update_with_advantage_nonzero(difficulty_dataset, make_rollouts):
     buffer = Buffer(difficulty_dataset, BufferConfig())
     # Rollouts with advantage != 0 should be added to buffer and marked as normal
-    rollouts = make_rollouts(difficulty_dataset, rewards=[0.5, 0.5, 0.5, 0.5, 0.5], advantages=[1.0, 1.0, 1.0, 1.0, 1.0])
+    rollouts = make_rollouts(
+        difficulty_dataset, rewards=[0.5, 0.5, 0.5, 0.5, 0.5], advantages=[1.0, 1.0, 1.0, 1.0, 1.0]
+    )
     buffer.update(rollouts)
     sampled_rollouts = buffer.sample_rollouts(10)
     assert sampled_rollouts == rollouts
     assert len(sampled_rollouts) == 10
     # All should be marked as normal (advantage != 0)
     assert all(metadata["difficulty"] == "normal" for metadata in buffer.metadata.values())
-


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Did some changes to the buffer that I have been wanting to do for a while, figured now is a good time:
- Simplified checkpoint load logic (do not use shared `_init_buffer` method which overcomplicated things)
- Fixed some minor things in metrics export -- now we always log the ratio of problems/rollouts per pool per step and the total ratio of problems per pools at every step and for all pools independent of the buffer setup
- Deprecated filtering out zero advantage rollouts as the same can be achieved 

## Examples

By default, we only sample from the `normal`, never move samples and do not have any filtering on which rollouts make it into the batch. This is equivalent to what was the `SimpleBuffer` was doing before. Also, resuming still works

<img width="1019" height="711" alt="Screenshot 2025-11-12 at 12 12 05 PM" src="https://github.com/user-attachments/assets/b55299c6-c88a-4568-aa86-fbf3f85f7cf7" />

<img width="343" height="238" alt="Screenshot 2025-11-12 at 12 00 55 PM" src="https://github.com/user-attachments/assets/88764a0d-3ff5-40d6-9b26-d6731fb63fa6" />

With `--orchestrator.buffer.easy-threshold 0.6 --orchestrator.buffer.hard-threshold 0.4` we move samples to pools based on  their avg reward

<img width="1018" height="707" alt="Screenshot 2025-11-12 at 12 07 12 PM" src="https://github.com/user-attachments/assets/704191e4-b90c-4ae8-b1ee-e842a8bfee3c" />

With `--orchestrator.buffer.easy-threshold 0.8 --orchestrator.buffer.hard-threshold 0.2 --orchestrator.buffer.filter-min-threshold 0.2 --orchestrator.buffer.filter-max-threshold 0.8` we do online filtering


