### PR TITLE
bring back mbs

### DIFF
--- a/src/prime_rl/trainer/sft/config.py
+++ b/src/prime_rl/trainer/sft/config.py
@@ -22,6 +22,15 @@ class BaseDataConfig(BaseModel):
     batch_size: Annotated[int, Field(ge=1)] = 128
     seq_len: Annotated[int, Field(ge=1)] = 128
     pack_function: Literal["cat", "stack"] = "cat"
+    micro_batch_size: Annotated[int, Field(ge=1)] = 1
+
+    @model_validator(mode="after")
+    def validate_batch_size(self):
+        if self.batch_size % self.micro_batch_size != 0:
+            raise ValueError("Batch size must be divisible by micro batch size")
+        if self.batch_size < self.micro_batch_size:
+            raise ValueError("Batch size must be greater than or equal to micro batch size")
+        return self
 
 
 class FakeDataConfig(BaseDataConfig):

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -597,12 +597,11 @@ def setup_dataset(
 
 
 def setup_dataloader(dataset: StatefulIterableDataset, config: DataConfigType) -> StatefulDataLoader:
-    seq_len = config.seq_len
     if config.pack_function == "stack":
-        stacking_dataset = StackDataset(dataset, seq_len)
-        return StatefulDataLoader(stacking_dataset, batch_size=1, collate_fn=stack_collate)
+        stacking_dataset = StackDataset(dataset, config.seq_len)
+        return StatefulDataLoader(stacking_dataset, batch_size=config.micro_batch_size, collate_fn=stack_collate)
     elif config.pack_function == "cat":
-        packing_dataset = CatDataset(dataset, seq_len)
+        packing_dataset = CatDataset(dataset, config.seq_len * config.micro_batch_size)
         return StatefulDataLoader(packing_dataset, batch_size=1, collate_fn=cat_collate)
     else:
         raise ValueError(f"Invalid pack function: {config.pack_function}")

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -598,8 +598,8 @@ def setup_dataset(
 
 def setup_dataloader(dataset: StatefulIterableDataset, config: DataConfigType) -> StatefulDataLoader:
     if config.pack_function == "stack":
-        stacking_dataset = StackDataset(dataset, config.seq_len)
-        return StatefulDataLoader(stacking_dataset, batch_size=config.micro_batch_size, collate_fn=stack_collate)
+        stacking_dataset = StackDataset(dataset, config.seq_len * config.micro_batch_size)
+        return StatefulDataLoader(stacking_dataset, batch_size=1, collate_fn=stack_collate)
     elif config.pack_function == "cat":
         packing_dataset = CatDataset(dataset, config.seq_len * config.micro_batch_size)
         return StatefulDataLoader(packing_dataset, batch_size=1, collate_fn=cat_collate)

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -107,12 +107,12 @@ def train(config: SFTTrainerConfig):
     dataiter = iter(dataloader)
 
     # Check that the world size and batch configuration is compatible
-    batch_size = config.data.batch_size
-    if world.world_size > batch_size:
+    num_micro_batches = config.data.batch_size // config.data.micro_batch_size
+    if world.world_size > num_micro_batches:
         raise ValueError(
-            f"There must be at least one micro batch per rank, but only have {batch_size} micro batches for {world.world_size} ranks."
+            f"There must be at least one micro batch per rank, but only have {num_micro_batches} micro batches for {world.world_size} ranks."
         )
-    if batch_size % world.world_size != 0:
+    if num_micro_batches % world.world_size != 0:
         raise ValueError(
             f"The number of micro batches ({num_micro_batches}) must be divisible by the world size ({world.world_size})."
         )
@@ -190,7 +190,12 @@ def train(config: SFTTrainerConfig):
 
         step_start_time = time.time()
         forward_backward_start_time = time.time()
-        grad_accum_steps = config.data.batch_size * config.model.cp * config.model.tp // world.world_size
+        grad_accum_steps = (
+            config.data.batch_size
+            * config.model.cp
+            * config.model.tp
+            // (world.world_size * config.data.micro_batch_size)
+        )
 
         batch_loss = torch.tensor(0.0).to("cuda")
         nan_loss_count = torch.tensor(0).to("cuda")


### PR DESCRIPTION
uv run torchrun --local-ranks-filter 0 --nproc_per_node=2 src/prime_rl/trainer/sft/train.py @ configs/debug/sft/train.toml
```
05:06:22 SUCCESS Step 0 | Time: 2.51s | Loss: 9.0938 | Grad. Norm: 645.1948 | LR: 1.00e-06 | Throughput: 0 tokens/s | MFU: 0.0% | Peak Mem.: 6.4/23.7 GiB (27.1%) [train.py::305]
05:06:22   DEBUG Starting forward pass [train.py::225]
05:06:23   DEBUG Starting backward pass [train.py::251]
05:06:23   DEBUG Micro Step 0/2 | Loss: 8.3125 | Dataloader Step: 5 [train.py::266]
05:06:23   DEBUG Starting forward pass [train.py::225]
05:06:23   DEBUG Starting backward pass [train.py::251]
05:06:23   DEBUG Micro Step 1/2 | Loss: 10.1875 | Dataloader Step: 7 [train.py::266]
05:06:23   DEBUG Clipping gradients with max norm 1.0 [train.py::268]
05:06:23   DEBUG Optimizer step [train.py::271]
05:06:23   DEBUG Synchronizing tensor metrics across all steps and ranks [train.py::286]
```
uv run torchrun --local-ranks-filter 0 --nproc_per_node=2 src/prime_rl/trainer/sft/train.py @ configs/debug/sft/train.toml --data.micro_batch_size 2 --log.level debug --data.batch_size 4
```
05:05:29 SUCCESS Step 0 | Time: 2.30s | Loss: 8.5000 | Grad. Norm: 715.4716 | LR: 1.00e-06 | Throughput: 0 tokens/s | MFU: 0.0% | Peak Mem.: 6.1/23.7 GiB (25.7%) [train.py::305]
05:05:29   DEBUG Starting forward pass [train.py::225]
05:05:29   DEBUG Starting backward pass [train.py::251]
05:05:29   DEBUG Micro Step 0/1 | Loss: 8.1875 | Dataloader Step: 3 [train.py::266]
05:05:29   DEBUG Clipping gradients with max norm 1.0 [train.py::268]
05:05:29   DEBUG Optimizer step [train.py::271]
05:05:29   DEBUG Synchronizing tensor metrics across all steps and ranks [train.py::286]
````