### PR TITLE
Fix inflight task cancellation race condition

### DIFF
--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -139,14 +139,16 @@ class Scheduler:
 
             # Remove cancelled tasks
             for task, client in tasks_to_remove:
-                self.inflight_group_rollouts.pop(task)
-                await self.schedule_group_rollout(client)
+                if self.inflight_group_rollouts.pop(task, None):
+                    await self.schedule_group_rollout(client)
 
             # Update retention steps for remaining tasks
             for task, off_policy_steps, client in tasks_to_update:
-                self.inflight_group_rollouts[task] = InflightRolloutInfo(
-                    off_policy_steps=off_policy_steps, client=client
-                )
+                if self.inflight_group_rollouts.get(task, None):
+                    self.inflight_group_rollouts[task] = InflightRolloutInfo(
+                        off_policy_steps=off_policy_steps, client=client
+                    )
+
             if len(tasks_to_remove) > 0:
                 self.logger.warning(f"Cancelled and re-scheduled {len(tasks_to_remove)} old rollout requests.")
 

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -132,8 +132,7 @@ class Scheduler:
             tasks_to_update = []
 
             for task, (off_policy_steps, client) in self.inflight_group_rollouts.items():
-                if off_policy_steps > self.max_off_policy_steps:
-                    task.cancel()
+                if off_policy_steps > self.max_off_policy_steps and task.cancel():
                     tasks_to_remove.append((task, client))
                 else:
                     tasks_to_update.append((task, off_policy_steps + 1, client))
@@ -153,7 +152,7 @@ class Scheduler:
 
             self.ckpt_step = next_ckpt_step
 
-    async def generate_batch(self, step: int, semaphore: asyncio.Semaphore | None = None) -> list[vf.State]:
+    async def generate_batch(self, step: int) -> list[vf.State]:
         """Continuously schedules group rollouts, allowing them to be in-flight across steps."""
         self.step = step
 


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Fixes an issue where we try to access/ cancel an already cancelled task in between `update_policy` and `generate_batch`. One case was already handled in #1318, the other is handled here.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: #1287 
**Linear Issue**: Resolves PRIMERL-209

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add safety checks around cancelling/removing in-flight rollout tasks to avoid race conditions and remove the unused semaphore parameter from generate_batch.
> 
> - **Scheduler (`src/prime_rl/orchestrator/scheduler.py`)**
>   - **Race-condition safeguards**:
>     - In `update_policy()`, only cancel when `off_policy_steps > max_off_policy_steps` and `task.cancel()` succeeds.
>     - When removing, use `inflight_group_rollouts.pop(task, None)` and only re-schedule if the task existed.
>     - When updating retention steps, ensure the task still exists via `get(task)` before writing back.
>   - **API change**:
>     - Remove `semaphore` parameter from `generate_batch(step)` signature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c82c47260f0541d5b495ae97f8b9c4fe8756173d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->