### PR TITLE
feat: truncated importance sampling

### DIFF
--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -23,7 +23,20 @@ class LossConfig(BaseModel):
     ratio_length_norm: Annotated[
         bool, Field(description="Whether to normalize the importance ratio by the sequence length.")
     ] = False
-
+    tis_clip: Annotated[
+        float | None,
+        Field(
+            ge=0,
+            description="If set, applies truncated importance sampling by clamping the importance ratio to this value.",
+        ),
+    ] = None
+    sequence_ratio_clamp: Annotated[
+        float,
+        Field(
+            ge=0,
+            description="Maximum value for clamping the log importance ratio when using sequence-level ratios.",
+        ),
+    ] = 10.0
     mask_ratio_high: Annotated[float, Field(ge=0)] = 8.0
     mask_ratio_low: Annotated[float, Field(ge=0)] = 0.125
     sequence_mask_ratio_low: Annotated[

--- a/tests/unit/train/rl/test_loss.py
+++ b/tests/unit/train/rl/test_loss.py
@@ -1,3 +1,5 @@
+import math
+
 import pytest
 import torch
 
@@ -8,8 +10,14 @@ pytestmark = [pytest.mark.gpu]
 
 
 def test_grpo_loss():
-    trainer_logprobs = [torch.randn(50, dtype=torch.float32).cuda(), torch.randn(30, dtype=torch.float32).cuda()]
-    inference_logprobs = [torch.randn(50, dtype=torch.float32).cuda(), torch.randn(30, dtype=torch.float32).cuda()]
+    trainer_logprobs = [
+        torch.randn(50, dtype=torch.float32).cuda(),
+        torch.randn(30, dtype=torch.float32).cuda(),
+    ]
+    inference_logprobs = [
+        torch.randn(50, dtype=torch.float32).cuda(),
+        torch.randn(30, dtype=torch.float32).cuda(),
+    ]
     advantages = [torch.randn(50).cuda(), torch.randn(30).cuda()]
     loss_mask = [torch.ones(50, dtype=torch.bool).cuda(), torch.ones(30, dtype=torch.bool).cuda()]
 
@@ -26,8 +34,14 @@ def test_grpo_loss():
 
 def test_gspo_loss():
     # Create list of tensors as expected by compute_loss (simulating split sequences)
-    trainer_logprobs = [torch.randn(40, dtype=torch.float32).cuda(), torch.randn(60, dtype=torch.float32).cuda()]
-    inference_logprobs = [torch.randn(40, dtype=torch.float32).cuda(), torch.randn(60, dtype=torch.float32).cuda()]
+    trainer_logprobs = [
+        torch.randn(40, dtype=torch.float32).cuda(),
+        torch.randn(60, dtype=torch.float32).cuda(),
+    ]
+    inference_logprobs = [
+        torch.randn(40, dtype=torch.float32).cuda(),
+        torch.randn(60, dtype=torch.float32).cuda(),
+    ]
     advantages = [torch.randn(40).cuda(), torch.randn(60).cuda()]
     loss_mask = [torch.ones(40, dtype=torch.bool).cuda(), torch.ones(60, dtype=torch.bool).cuda()]
 
@@ -46,3 +60,44 @@ def test_entropy_loss():
     shifted_logits = torch.randn(10, 10, 10, dtype=torch.float32).cuda()
     entropy = compute_entropy(shifted_logits)
     assert entropy.shape == (10, 10)
+
+
+def test_tis_truncates_token_ratios():
+    trainer_logprobs = [torch.tensor([math.log(16.0)], dtype=torch.float32).cuda()]
+    inference_logprobs = [torch.zeros(1, dtype=torch.float32).cuda()]
+    advantages = [torch.ones(1, dtype=torch.float32).cuda()]
+    loss_mask = [torch.ones(1, dtype=torch.bool).cuda()]
+
+    loss, metrics = compute_loss(
+        trainer_logprobs,
+        inference_logprobs,
+        advantages,
+        loss_mask=loss_mask,
+        loss_config=LossConfig(ratio_type="token", tis_clip=2.0, mask_ratio_high=100.0),
+        loss_scale=1.0,
+    )
+
+    assert torch.isclose(loss, torch.tensor(-2.0, device=loss.device)).item()
+    assert "tis_trunc_ratio_mean" in metrics
+    assert torch.isclose(metrics["tis_trunc_ratio_mean"].squeeze(), torch.tensor(2.0, device=loss.device)).item()
+    assert metrics["tis_clipped_fraction"].squeeze().item() == pytest.approx(1.0, rel=0, abs=1e-6)
+
+
+def test_tis_sequence_ratio_broadcasts():
+    trainer_logprobs = [torch.zeros(3, dtype=torch.float32).cuda()]
+    inference_logprobs = [torch.full((3,), -math.log(4.0), dtype=torch.float32).cuda()]
+    advantages = [torch.tensor([1.0, 2.0, 3.0], dtype=torch.float32).cuda()]
+    loss_mask = [torch.ones(3, dtype=torch.bool).cuda()]
+
+    loss, metrics = compute_loss(
+        trainer_logprobs,
+        inference_logprobs,
+        advantages,
+        loss_mask=loss_mask,
+        loss_config=LossConfig(ratio_type="sequence", tis_clip=2.0, mask_ratio_high=100.0),
+        loss_scale=1.0,
+    )
+
+    assert torch.isclose(loss, torch.tensor(-12.0, device=loss.device)).item()
+    assert metrics["tis_clipped_fraction"].squeeze().item() == pytest.approx(1.0, rel=0, abs=1e-6)
+    assert metrics["tis_trunc_ratio_mean"].squeeze().item() == pytest.approx(2.0, rel=1e-5)


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

# Add Configurable Truncated Importance Sampling for Off-Policy RL Training

## Summary
Adds support for Truncated Importance Sampling (TIS) to handle the rollout-training mismatch problem in prime-rl, based on [Yao et al.'s findings](https://fengyao.notion.site/off-policy-rl).

## Problem
Modern RL frameworks use different backends for rollout generation (e.g., vLLM) and training (e.g., FSDP) to maximize throughput. However, these backends can produce significantly different token probabilities despite using the same model parameters, secretly turning on-policy RL into off-policy RL. This mismatch can lead to:
- Entropy collapse
- Training instability
- Degraded downstream performance

## Solution
This PR implements Truncated Importance Sampling (TIS) to correct for the distribution mismatch:

```python
importance_ratio = π_learner(a, θ) / π_sampler(a, θ)
truncated_ratio = min(importance_ratio, C)  # C is configurable via tis_clip
```

## Changes

### Configuration
- **`tis_clip`**: Controls truncation of the importance ratio (default: `None` - disabled)
- **`sequence_ratio_clamp`**: Configurable clamping for sequence-level log importance ratios (default: `10.0` - preserves existing behavior)

### Usage
```toml
# train.toml
[loss]
tis_clip = 1.5  # Enable TIS with clipping at 1.5
sequence_ratio_clamp = 15.0  # Custom clamp for sequence ratios
```

### Metrics
When TIS is enabled, the following metrics are tracked:
- `tis_raw_ratio_mean`: Mean importance ratio before truncation
- `tis_trunc_ratio_mean`: Mean importance ratio after truncation  
- `tis_clipped_fraction`: Fraction of tokens that were clipped

## Testing
Added unit tests covering:
- Token-level TIS truncation
- Sequence-level ratio broadcasting with TIS
- Metric tracking validation

## Notes
- TIS is disabled by default to maintain backward compatibility
- The `sequence_ratio_clamp` default of 10.0 preserves the original hardcoded value
- Compatible with both token-level and sequence-level importance ratios

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: [Issue ID]
**Linear Issue**: Resolves [Issue ID]