### PR TITLE
simplify online filtering

### DIFF
--- a/configs/wiki_search/rl.toml
+++ b/configs/wiki_search/rl.toml
@@ -40,8 +40,7 @@ oversampling_factor = 2.0
 max_tokens = 512
 
 [orchestrator.buffer]
-filter_min_threshold = 0.0
-filter_max_threshold = 1.0
+online_difficulty_filtering = true
 
 [[orchestrator.env]]
 id = "primeintellect/wiki-search"

--- a/src/prime_rl/orchestrator/buffer.py
+++ b/src/prime_rl/orchestrator/buffer.py
@@ -114,12 +114,13 @@ class Buffer:
             self.num_sampled_rollouts_per_pool[new_difficulty] += 1
 
             self.num_rollouts += len(example_rollouts)
-            if self.config.filter_min_threshold is not None and avg_reward <= self.config.filter_min_threshold:
-                self.num_filtered_rollouts_per_difficulty["hard"] += len(example_rollouts)
-                continue
-            elif self.config.filter_max_threshold is not None and avg_reward >= self.config.filter_max_threshold:
-                self.num_filtered_rollouts_per_difficulty["easy"] += len(example_rollouts)
-                continue
+            if self.config.online_difficulty_filtering:
+                if avg_reward == 0.0:
+                    self.num_filtered_rollouts_per_difficulty["hard"] += len(example_rollouts)
+                    continue
+                elif avg_reward == 1.0:
+                    self.num_filtered_rollouts_per_difficulty["easy"] += len(example_rollouts)
+                    continue
             self.rollout_buffer.extend(example_rollouts)
 
     def sample_rollouts(self, n: int) -> list[Rollout]:

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -329,19 +329,12 @@ class BufferConfig(BaseConfig):
         ),
     ] = None
 
-    filter_min_threshold: Annotated[
-        float | None,
+    online_difficulty_filtering: Annotated[
+        bool,
         Field(
-            description="Minimum reward threshold for adding rollouts to buffer. If average reward <= this threshold, rollouts are not added to buffer.",
+            description="Whether to filter rollouts based on their average reward. If True, rollouts with average reward == 0.0 will be marked as hard and rollouts with average reward == 1.0 will be marked as easy.",
         ),
-    ] = None
-
-    filter_max_threshold: Annotated[
-        float | None,
-        Field(
-            description="Maximum reward threshold for adding rollouts to buffer. If average reward >= this threshold, rollouts are not added to buffer.",
-        ),
-    ] = None
+    ] = False
 
 
 class AdvantageConfig(BaseConfig):

--- a/tests/unit/orchestrator/test_buffer.py
+++ b/tests/unit/orchestrator/test_buffer.py
@@ -75,10 +75,6 @@ def test_buffer_init(dataset):
     Buffer(dataset, BufferConfig())
 
 
-def test_buffer_init_with_difficulty_dataset(difficulty_dataset):
-    Buffer(difficulty_dataset, BufferConfig())
-
-
 def test_buffer_sample_problems(dataset):
     buffer = Buffer(dataset, BufferConfig())
     sampled_problems = buffer.sample_problems(2)
@@ -105,68 +101,20 @@ def test_buffer_sample_problems_with_difficulty_pools(difficulty_dataset, make_r
     assert 4 in sampled_ids  # At least one hard
 
 
-def test_buffer_sample_problems_only_easy(difficulty_dataset, make_rollouts):
-    buffer = Buffer(difficulty_dataset, BufferConfig(easy_fraction=1.0, hard_fraction=0.0, easy_threshold=1.0))
-    # Set problems 0,1 to easy (advantage=0, reward=1.0)
-    rollouts = make_rollouts(
-        difficulty_dataset, rewards=[1.0, 1.0, 0.5, 0.5, 0.5], advantages=[0.0, 0.0, 1.0, 1.0, 1.0]
-    )
-    buffer.update(rollouts)
-    sampled_problems = buffer.sample_problems(2)
-    assert sampled_problems[0]["example_id"] == 0
-    assert sampled_problems[0]["problem"] == "0"
-    assert sampled_problems[1]["example_id"] == 1
-    assert sampled_problems[1]["problem"] == "1"
-
-
-def test_buffer_sample_problems_only_hard(difficulty_dataset, make_rollouts):
-    buffer = Buffer(difficulty_dataset, BufferConfig(easy_fraction=0.0, hard_fraction=1.0, hard_threshold=0.0))
-    # Set problems 2,4 to hard (advantage=0, reward=0.0)
-    rollouts = make_rollouts(
-        difficulty_dataset, rewards=[0.5, 0.5, 0.0, 0.5, 0.0], advantages=[1.0, 1.0, 0.0, 1.0, 0.0]
-    )
-    buffer.update(rollouts)
-    sampled_problems = buffer.sample_problems(2)
-    assert sampled_problems[0]["example_id"] == 2
-    assert sampled_problems[0]["problem"] == "2"
-    assert sampled_problems[1]["example_id"] == 4
-    assert sampled_problems[1]["problem"] == "4"
-
-
-def test_buffer_sample_problems_multiple_epochs(dataset):
-    buffer = Buffer(dataset, BufferConfig())
-    sampled_problems = buffer.sample_problems(2)
-    assert sampled_problems[0] == {"example_id": 0, "problem": "0"}
-    assert sampled_problems[1] == {"example_id": 4, "problem": "4"}
-    sampled_problems = buffer.sample_problems(2)
-    assert sampled_problems[0] == {"example_id": 2, "problem": "2"}
-    assert sampled_problems[1] == {"example_id": 1, "problem": "1"}
-    sampled_problems = buffer.sample_problems(2)
-    assert sampled_problems[0] == {"example_id": 1, "problem": "1"}
-    assert sampled_problems[1] == {"example_id": 4, "problem": "4"}
-
-
 def test_buffer_sample_rollouts(dataset, make_rollouts):
-    buffer = Buffer(dataset, BufferConfig())
-    rollouts = make_rollouts(dataset)
+    buffer = Buffer(dataset, BufferConfig(online_difficulty_filtering=False))
+    # Use rewards that won't be filtered (0.5 instead of 1.0)
+    rollouts = make_rollouts(dataset, rewards=[0.5] * len(dataset))
     buffer.update(rollouts)
     sampled_rollouts = buffer.sample_rollouts(10)
     assert sampled_rollouts == rollouts
     assert len(sampled_rollouts) == 10
 
 
-def test_buffer_sample_rollouts_partial(dataset, make_rollouts):
-    buffer = Buffer(dataset, BufferConfig())
-    rollouts = make_rollouts(dataset)
-    buffer.update(rollouts)
-    sampled_rollouts = buffer.sample_rollouts(5)
-    assert len(sampled_rollouts) == 5
-    assert len(buffer.rollout_buffer) == 5
-
-
 def test_buffer_sample_rollouts_more_than_available(dataset, make_rollouts):
-    buffer = Buffer(dataset, BufferConfig())
-    rollouts = make_rollouts(dataset)
+    buffer = Buffer(dataset, BufferConfig(online_difficulty_filtering=False))
+    # Use rewards that won't be filtered (0.5 instead of 1.0)
+    rollouts = make_rollouts(dataset, rewards=[0.5] * len(dataset))
     buffer.update(rollouts)
     sampled_rollouts = buffer.sample_rollouts(20)
     assert len(sampled_rollouts) == 10
@@ -185,3 +133,22 @@ def test_buffer_update_with_advantage_nonzero(difficulty_dataset, make_rollouts)
     assert len(sampled_rollouts) == 10
     # All should be marked as normal (advantage != 0)
     assert all(metadata["difficulty"] == "normal" for metadata in buffer.metadata.values())
+
+
+def test_buffer_online_difficulty_filtering(dataset, make_rollouts):
+    """Test that only rollouts with avg_reward == 0.0 or 1.0 are filtered."""
+    buffer = Buffer(
+        dataset,
+        BufferConfig(online_difficulty_filtering=True, easy_threshold=1.0, hard_threshold=0.0),
+    )
+    # Mix of rewards: 1.0 (filtered), 0.5 (kept), 0.0 (filtered), 0.5 (kept), 0.5 (kept)
+    rollouts = make_rollouts(dataset, rewards=[1.0, 0.5, 0.0, 0.5, 0.5])
+    buffer.update(rollouts)
+    # Only rollouts with reward 0.5 should be in buffer (3 problems * 2 rollouts = 6)
+    assert len(buffer.rollout_buffer) == 6
+    # Check that difficulties are set correctly
+    assert buffer.metadata[0]["difficulty"] == "easy"
+    assert buffer.metadata[1]["difficulty"] == "normal"
+    assert buffer.metadata[2]["difficulty"] == "hard"
+    assert buffer.metadata[3]["difficulty"] == "normal"
+    assert buffer.metadata[4]["difficulty"] == "normal"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces min/max rollout filtering thresholds with a boolean `online_difficulty_filtering` that filters only avg_reward==0.0 or 1.0; updates buffer logic, config, defaults, and tests.
> 
> - **Orchestrator Buffer**:
>   - Simplifies filtering in `src/prime_rl/orchestrator/buffer.py`: remove min/max threshold checks; when `online_difficulty_filtering` is enabled, drop rollouts with avg_reward==0.0 (counted as hard) or avg_reward==1.0 (counted as easy).
>   - Maintains difficulty assignment via `easy_threshold`/`hard_threshold`; updates per-step metrics accordingly.
> - **Config**:
>   - In `src/prime_rl/orchestrator/config.py`, remove `filter_min_threshold`/`filter_max_threshold`; add `online_difficulty_filtering: bool` with description.
>   - Enable `online_difficulty_filtering = true` in `configs/wiki_search/rl.toml` under `[orchestrator.buffer]`.
> - **Tests**:
>   - Update `tests/unit/orchestrator/test_buffer.py` to reflect new filtering behavior; add `test_buffer_online_difficulty_filtering` and adjust rollouts to avoid unintended filtering when disabled; remove now-irrelevant tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90cfd082c4e40cf5e42c8d3112d6742d5458d6d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->