### PR TITLE
remove advantage calculation options, and gspo

### DIFF
--- a/src/prime_rl/orchestrator/advantage.py
+++ b/src/prime_rl/orchestrator/advantage.py
@@ -8,27 +8,16 @@ from prime_rl.orchestrator.config import AdvantageConfig
 def compute_advantage(
     rewards: Float[Tensor, "group"],
     lengths: Int[Tensor, "group"],
-    global_std: float,
     advantage_config: AdvantageConfig,
 ) -> Float[Tensor, "group"]:
     """
     Computes advantages for a single group.
     """
-    group_size = rewards.shape[0]
     if advantage_config.length_weighted_mean:
         baseline = (rewards * lengths).sum() / lengths.sum()
     else:
         baseline = rewards.mean()
     advantages = rewards - baseline
-    if advantage_config.leave_one_out:
-        if advantage_config.length_weighted_mean:
-            advantages = advantages * lengths.sum() / (lengths.sum() - lengths)
-        else:
-            advantages = advantages * group_size / (group_size - 1)
-    if advantage_config.neg_clipped:
-        advantages = torch.maximum(advantages, torch.zeros_like(advantages))
-    if advantage_config.std_norm:
-        advantages = advantages / (rewards.std() + 1e-8)
     return advantages
 
 
@@ -46,7 +35,6 @@ def compute_advantages(
         samples_per_problem: Number of samples (and thus, rewards) per problem
         advantage_config: Configuration for advantage computation
         completion_lengths: List of completion lengths for each reward. Required for OPO advantage computation.
-        global_std_norm: Whether to normalize the advantages by the global standard deviation of the rewards.
     Returns:
         Tuple of (advantages, advantage_stats)
     """
@@ -58,12 +46,11 @@ def compute_advantages(
     all_group_lengths = [
         completion_lengths[i : i + samples_per_problem] for i in range(0, len(completion_lengths), samples_per_problem)
     ]
-    global_std = torch.tensor(rewards).std().item()
     for group_rewards, group_lengths in zip(all_group_rewards, all_group_lengths):
         group_rewards_tensor = torch.tensor(group_rewards)
         group_lengths_tensor = torch.tensor(group_lengths)
         group_advantages_tensor = compute_advantage(
-            group_rewards_tensor, group_lengths_tensor, global_std, advantage_config
+            group_rewards_tensor, group_lengths_tensor, advantage_config
         )
         assert len(group_advantages_tensor) == len(group_rewards_tensor)
         advantages.extend(group_advantages_tensor.tolist())

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -345,10 +345,7 @@ class BufferConfig(BaseConfig):
 
 
 class AdvantageConfig(BaseConfig):
-    std_norm: Literal["local", "global"] | None = None
     length_weighted_mean: bool = False
-    leave_one_out: bool = False
-    neg_clipped: bool = False
 
 
 class FileSystemWeightBroadcastConfig(BaseModel):

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -20,9 +20,6 @@ class LossConfig(BaseConfig):
     """Base config for loss."""
 
     ratio_type: Annotated[Literal["token", "sequence"], Field(description="Type of importance ratio to use.")] = "token"
-    ratio_length_norm: Annotated[
-        bool, Field(description="Whether to normalize the importance ratio by the sequence length.")
-    ] = False
 
     mask_ratio_high: Annotated[float, Field(ge=0)] = 8.0
     mask_ratio_low: Annotated[float, Field(ge=0)] = 0.125

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -79,8 +79,6 @@ def compute_loss(
 
         if loss_config.ratio_type == "sequence":
             seq_log_importance_ratio = (log_importance_ratio[loss_mask]).sum()
-            if loss_config.ratio_length_norm:
-                seq_log_importance_ratio = seq_log_importance_ratio / torch.clamp_min(loss_mask.sum(), 1)
             log_importance_ratio = trainer_logprobs - trainer_logprobs.detach() + seq_log_importance_ratio.detach()
             log_importance_ratio = torch.clamp(log_importance_ratio, max=10.0)
 


### PR DESCRIPTION
Removing neg_clipped, leave_one_out, and normalising in the advantage calculation as they are either not well supported with pipelineRL or have not been used and not planned to.
Keeping length weighted mean as an option as it seems like a good option as also reported by https://www.arxiv.org/abs/2510.02387, although not ablated internally enough yet to make default (will consider soon)
Also removed GSPO as we've observed sudden crashes, as has also been reported in https://arxiv.org/abs/2510.13786 and https://arxiv.org/abs/2510.26788. We keep masked sequence importance sampling as an option as it seems stable internally and reported by other works although haven't ablated enough internally yet to make it the default (will consider soon)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes unused/unsupported advantage options and ratio_length_norm, simplifying advantage and loss calculations.
> 
> - **Advantage (orchestrator)**:
>   - Simplify `compute_advantage` in `src/prime_rl/orchestrator/advantage.py` to baseline-minus-reward with optional `length_weighted_mean` only.
>   - Remove global/std normalization and related params; `compute_advantages` no longer computes or passes `global_std`.
>   - Trim `AdvantageConfig` in `src/prime_rl/orchestrator/config.py` to only `length_weighted_mean` (remove `std_norm`, `leave_one_out`, `neg_clipped`).
> - **Loss/Trainer**:
>   - Remove `ratio_length_norm` from `LossConfig` in `src/prime_rl/trainer/rl/config.py` and its usage in `src/prime_rl/trainer/rl/loss.py` when `ratio_type == "sequence"`.
>   - No functional changes elsewhere; configs and loss logic otherwise unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ded6212da5fa48f1975c22c7ec893a2049a68c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->