### PR TITLE
Revert "Feat: fa3 (#1302)"

### DIFF
--- a/.github/workflows/gpu_tests.yaml
+++ b/.github/workflows/gpu_tests.yaml
@@ -27,7 +27,7 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
       - name: Install dependencies
-        run: uv sync --locked
+        run: uv sync --locked && uv sync --all-extras --locked
       - name: Cleanup GPU processes
         run: |
           echo "Checking for stray GPU processes..."

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -44,6 +44,9 @@ COPY examples /app/examples
 RUN --mount=type=cache,target=/app/.cache/uv \
     uv sync --locked --no-dev
 
+RUN --mount=type=cache,target=/app/.cache/uv \
+    uv sync --all-extras --locked --no-dev
+
 FROM python:3.12-slim
 
 RUN apt-get update && apt-get install -y \

--- a/README.md
+++ b/README.md
@@ -79,14 +79,6 @@ source $HOME/.local/bin/env
 uv sync
 ```
 
-3.1. Optional: Install Flash Attention 3 (on Hopper GPUs only, for flash_attention_3 attention backend)
-
-> *NOTE*: This step will take a while, as it builds the Flash Attention 3 extension from source, as it has no wheels prebuilt.
-
-```bash
-uv sync --extra flash-attn-3
-```
-
 </details>
 
 <details>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,11 +41,6 @@ dependencies = [
     "flash-attn>=2.8.3",
 ]
 
-[project.optional-dependencies]
-flash-attn-3 = [
-    "flash_attn_3",
-]
-
 [project.scripts]
 rl = "prime_rl.rl:main"
 trainer = "prime_rl.trainer.rl.train:main"
@@ -74,11 +69,9 @@ reverse-text = { index = "primeintellect" }
 verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "91f436d" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "main" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
-flash_attn_3 = { git = "https://github.com/Dao-AILab/flash-attention.git", subdirectory = "hopper", rev = "main" }
 
 [tool.uv.extra-build-dependencies]
 flash-attn = [{ requirement = "torch", match-runtime = true }]
-flash-attn-3 = ["setuptools", {requirement = "torch", match-runtime = true}]
 
 [tool.uv.extra-build-variables]
 flash-attn = { FLASH_ATTENTION_SKIP_CUDA_BUILD = "TRUE" }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -78,7 +78,7 @@ main() {
     uv tool install prime
 
     log_info "Syncing virtual environment..."
-    uv sync
+    uv sync && uv sync --all-extras
 
     log_info "Installing pre-commit hooks..."
     uv run pre-commit install

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, Field, model_validator
 
 from prime_rl.utils.pydantic_config import BaseConfig
 
-AttnImplementation: TypeAlias = Literal["sdpa", "flash_attention_2", "flash_attention_3"]
+AttnImplementation: TypeAlias = Literal["sdpa", "flash_attention_2"]
 
 MOE_MODEL_MAPS = {
     "Qwen/Qwen3-30B-A3B": "Jackmin108/Qwen3-30B-A3B-Fast",

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -16,7 +16,6 @@ from torch.distributed.checkpoint.state_dict_loader import load as dcp_load
 from torch.distributed.fsdp import CPUOffloadPolicy, FSDPModule, MixedPrecisionPolicy, OffloadPolicy, fully_shard
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, PretrainedConfig
 from transformers.tokenization_utils import PreTrainedTokenizer
-from transformers.utils.import_utils import is_flash_attn_3_available
 
 from prime_rl.trainer.config import ActivationCheckpointConfig, CompileConfig, ModelConfig
 from prime_rl.trainer.lora import apply_lora_to_model
@@ -298,11 +297,6 @@ def apply_compile(model: nn.Module, compile_config: CompileConfig):
 
 
 def setup_model(config: ModelConfig, parallel_dims: ParallelDims) -> nn.Module:
-    if config.attn == "flash_attention_3" and not is_flash_attn_3_available():
-        raise ValueError(
-            "Flash attention 3 is only supported if the flash_attn_3 package is installed. Install with `uv sync --extra flash-attn-3`"
-        )
-
     logger = get_logger()
     # Get model from specified device
     model = get_model(

--- a/src/prime_rl/trainer/models/glm.py
+++ b/src/prime_rl/trainer/models/glm.py
@@ -382,7 +382,7 @@ class Glm4MoeModel(Glm4MoePreTrainedModel):
         if inputs_embeds is None:
             inputs_embeds: torch.Tensor = self.embed_tokens(input_ids)
 
-        if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3"):
+        if self.config._attn_implementation == "flash_attention_2":
             flat_position_ids = position_ids.view(-1)
             seqlens = torch.cat(
                 [

--- a/src/prime_rl/trainer/models/layers/attn.py
+++ b/src/prime_rl/trainer/models/layers/attn.py
@@ -1,4 +1,3 @@
-import functools
 from dataclasses import dataclass
 
 import torch
@@ -12,11 +11,6 @@ try:
     from flash_attn import flash_attn_varlen_func
 except ImportError:
     flash_attn_varlen_func = None
-
-try:
-    from flash_attn_interface import flash_attn_varlen_func as flash_attn_3_varlen_func
-except ImportError:
-    flash_attn_3_varlen_func = None
 
 
 @dataclass
@@ -39,7 +33,7 @@ class AttentionConfig:
 class FlashAttention(nn.Module):
     """Flash Attention"""
 
-    def __init__(self, config: AttentionConfig, flash_attn_version: int = 2):
+    def __init__(self, config: AttentionConfig):
         super().__init__()
         self.head_dim = config.head_dim
         self.num_key_value_groups = config.num_attention_heads // config.num_key_value_heads
@@ -60,8 +54,6 @@ class FlashAttention(nn.Module):
         if self.use_qk_norm:
             self.q_norm = RMSNorm(RMSNormConfig(hidden_size=self.head_dim, eps=config.rms_norm_eps))
             self.k_norm = RMSNorm(RMSNormConfig(hidden_size=self.head_dim, eps=config.rms_norm_eps))
-
-        self.func = flash_attn_3_varlen_func if flash_attn_version == 3 else flash_attn_varlen_func
 
     def forward(
         self,
@@ -92,7 +84,7 @@ class FlashAttention(nn.Module):
         query_states = query_states.transpose(1, 2)
         key_states = key_states.transpose(1, 2)
         value_states = value_states.transpose(1, 2)
-        out = self.func(
+        out = flash_attn_varlen_func(
             query_states[0],
             key_states[0],
             value_states[0],
@@ -102,9 +94,6 @@ class FlashAttention(nn.Module):
             max_seqlen,
             causal=True,
         )
-        if isinstance(out, tuple):
-            out = out[0]
-
         out = out.contiguous()
         attn_output = out.view(1, out.shape[0], -1)
         attn_weights = None
@@ -178,7 +167,6 @@ class SDPAAttention(nn.Module):
 
 
 ATTN_IMPL2CLASS = {
-    "flash_attention_2": functools.partial(FlashAttention, flash_attn_version=2),
+    "flash_attention_2": FlashAttention,
     "sdpa": SDPAAttention,
-    "flash_attention_3": functools.partial(FlashAttention, flash_attn_version=3),
 }

--- a/src/prime_rl/trainer/models/llama.py
+++ b/src/prime_rl/trainer/models/llama.py
@@ -156,7 +156,7 @@ class LlamaModel(LlamaPreTrainedModel):
         if inputs_embeds is None:
             inputs_embeds: torch.Tensor = self.embed_tokens(input_ids)
 
-        if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3"):
+        if self.config._attn_implementation == "flash_attention_2":
             flat_position_ids = position_ids.view(-1)
             seqlens = torch.cat(
                 [

--- a/src/prime_rl/trainer/models/qwen.py
+++ b/src/prime_rl/trainer/models/qwen.py
@@ -377,7 +377,7 @@ class Qwen3MoeModel(Qwen3MoePreTrainedModel):
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
 
-        if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3"):
+        if self.config._attn_implementation == "flash_attention_2":
             flat_position_ids = position_ids.view(-1)
             seqlens = torch.cat(
                 [

--- a/uv.lock
+++ b/uv.lock
@@ -687,17 +687,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3b/b2/8d76c41ad7974ee264754709c22963447f7f8134613fd9ce80984ed0dab7/flash_attn-2.8.3.tar.gz", hash = "sha256:1e71dd64a9e0280e0447b8a0c2541bad4bf6ac65bdeaa2f90e51a9e57de0370d", size = 8447812, upload-time = "2025-08-15T08:28:12.911Z" }
 
 [[package]]
-name = "flash-attn-3"
-version = "3.0.0b1"
-source = { git = "https://github.com/Dao-AILab/flash-attention.git?subdirectory=hopper&rev=main#5d2cd3bcbaeff6fe1bfc5d0ff489451b0d4827a6" }
-dependencies = [
-    { name = "einops" },
-    { name = "ninja" },
-    { name = "packaging" },
-    { name = "torch" },
-]
-
-[[package]]
 name = "fonttools"
 version = "4.59.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2180,11 +2169,6 @@ dependencies = [
     { name = "wandb" },
 ]
 
-[package.optional-dependencies]
-flash-attn-3 = [
-    { name = "flash-attn-3" },
-]
-
 [package.dev-dependencies]
 dev = [
     { name = "ipykernel" },
@@ -2203,7 +2187,6 @@ requires-dist = [
     { name = "datasets", specifier = ">=4.0.0" },
     { name = "dion", git = "https://github.com/samsja/dion.git?rev=main" },
     { name = "flash-attn", specifier = ">=2.8.3" },
-    { name = "flash-attn-3", marker = "extra == 'flash-attn-3'", git = "https://github.com/Dao-AILab/flash-attention.git?subdirectory=hopper&rev=main" },
     { name = "jaxtyping", specifier = ">=0.3.2" },
     { name = "liger-kernel", specifier = ">=0.5.10" },
     { name = "loguru", specifier = ">=0.7.3" },
@@ -2232,7 +2215,6 @@ requires-dist = [
     { name = "vllm", specifier = "==0.10.2" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
-provides-extras = ["flash-attn-3"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
revert fa3 as it failed to uv sync when fa3 can't be build 

<img src="https://media.discordapp.net/attachments/1383934516812316884/1440173967003357285/Screenshot_2025-11-17_at_6.56.19_PM.png?ex=691d3206&amp;is=691be086&amp;hm=551f2fd11f1b6a641dfa7cfffeeb41e7cb796a0717c21503f03636e3df896f19&amp;=&amp;format=webp&amp;quality=lossless&amp;width=3419&amp;height=189" alt="Image"/>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes all flash-attn-3 support/config, leaving only SDPA and flash-attn-2, and updates CI/Docker/install to `uv sync --all-extras`, with docs adjusted accordingly.
> 
> - **Core/Modeling**:
>   - Limit `AttnImplementation` to `"sdpa" | "flash_attention_2"`; remove all flash-attn-3 code paths, imports, and checks.
>   - Simplify `FlashAttention` to always use `flash_attn_varlen_func`; drop version switching and `functools.partial`; update `ATTN_IMPL2CLASS`.
>   - Update `glm`, `llama`, and `qwen` models to compute varlen inputs only for `flash_attention_2`.
> - **Build/Config**:
>   - Remove flash-attn-3 extras/sources from `pyproject.toml` and `uv.lock`.
> - **CI/Docker/Install**:
>   - Use `uv sync --all-extras` in `.github/workflows/gpu_tests.yaml`, `Dockerfile.cuda`, and `scripts/install.sh`.
> - **Docs**:
>   - Drop README instructions for installing flash-attn-3.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22e06697e28fd0f94dc86440bb85f08b9386bb78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->