### PR TITLE
Fix: load optimizer states in trainer/ckpt.py

### DIFF
--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -66,7 +66,9 @@ class AppState(Stateful):
         return state_dict
 
     def load_state_dict(self, state_dict: dict[str, Any]):
-        set_state_dict(self.model, [], model_state_dict=state_dict["model"], optim_state_dict=state_dict["optimizers"])
+        set_state_dict(
+            self.model, self.optimizers, model_state_dict=state_dict["model"], optim_state_dict=state_dict["optimizers"]
+        )
         if self.scheduler is not None:
             self.scheduler.load_state_dict(state_dict["scheduler"])
         if self.progress is not None:


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

I was too lazy to explain my changes, decreasing my chances of this ever getting merged.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: [Issue ID]
**Linear Issue**: Resolves [Issue ID]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pass `self.optimizers` to `set_state_dict` in `AppState.load_state_dict` to restore optimizer states during checkpoint load.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f2aaf24ce4f3f750f2d3d5e9d1f98e4919ca2ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->