### PR TITLE
fix gradio

### DIFF
--- a/scripts/chat.py
+++ b/scripts/chat.py
@@ -1,7 +1,7 @@
 # /// script
-# requires-python = ">=3.12"
+# requires-python = ">=3.10"
 # dependencies = [
-#     "gradio",
+#     "gradio==5.49.1",
 #     "openai",
 # ]
 # ///
@@ -203,7 +203,6 @@ def create_demo():
                 # Create chat interface with custom settings
                 chat_interface = gr.ChatInterface(  # noqa: F841
                     fn=chat_function,
-                    type="messages",
                     additional_inputs=[
                         endpoint_input,
                         model_input,
@@ -214,9 +213,7 @@ def create_demo():
                     ],
                     chatbot=gr.Chatbot(
                         height=500,
-                        show_copy_button=True,
                         placeholder="Start chatting with the AI assistant...",
-                        type="messages",
                         render_markdown=True,
                     ),
                     textbox=gr.Textbox(placeholder="Type your message here...", container=False, scale=7),
@@ -242,7 +239,6 @@ def main():
         server_name="0.0.0.0",  # Bind to all interfaces
         server_port=args.port,
         share=not args.no_share,  # Share by default unless --no-share is specified
-        show_api=False,
     )
 
 


### PR DESCRIPTION
fixing chatui to work with latest gradio version

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pin Gradio to 5.49.1, lower Python requirement to 3.10, and adjust ChatInterface/launch options for the updated Gradio API.
> 
> - **Dependencies & metadata**:
>   - Pin `gradio` to `5.49.1` and lower Python requirement to `>=3.10` in `scripts/chat.py`.
> - **Gradio API adjustments in `scripts/chat.py`**:
>   - Update `gr.ChatInterface`/`gr.Chatbot` usage by removing `type="messages"` and `show_copy_button` options.
>   - Drop `show_api=False` from `demo.launch`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b13d0df122683203a4303561b90d157b53d5e57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->