### PR TITLE
Sebastian/fix/time

### DIFF
--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -93,7 +93,7 @@ async def run_eval(
     # Get the logger
     logger = get_logger()
     monitor = get_monitor()
-    eval_start_time = time.time()
+    eval_start_time = time.perf_counter()
 
     # Load the eval environment
     env_name_or_id = env_name or env_id
@@ -139,7 +139,7 @@ async def run_eval(
         logger.warning("Skipping computing pass@k rates because the task rewards appear to be non-binary")
 
     # Log statistics to console
-    eval_time = time.time() - eval_start_time
+    eval_time = time.perf_counter() - eval_start_time
     message = f"Evaluated {env_name_or_id} in {eval_time:.2f}s (Avg@{k}={results_df.reward.mean():.4f}"
     if could_be_binary:
         assert pass_at_k is not None

--- a/src/prime_rl/orchestrator/advantage.py
+++ b/src/prime_rl/orchestrator/advantage.py
@@ -49,9 +49,7 @@ def compute_advantages(
     for group_rewards, group_lengths in zip(all_group_rewards, all_group_lengths):
         group_rewards_tensor = torch.tensor(group_rewards)
         group_lengths_tensor = torch.tensor(group_lengths)
-        group_advantages_tensor = compute_advantage(
-            group_rewards_tensor, group_lengths_tensor, advantage_config
-        )
+        group_advantages_tensor = compute_advantage(group_rewards_tensor, group_lengths_tensor, advantage_config)
         assert len(group_advantages_tensor) == len(group_rewards_tensor)
         advantages.extend(group_advantages_tensor.tolist())
     assert len(rewards) == len(advantages)

--- a/src/prime_rl/orchestrator/ckpt.py
+++ b/src/prime_rl/orchestrator/ckpt.py
@@ -46,7 +46,7 @@ class CheckpointManager:
         buffer: Buffer,
     ):
         self.logger.debug(f"Saving orchestrator checkpoint to {ckpt_path}")
-        start_time = time.time()
+        start_time = time.perf_counter()
 
         # Save progress
         with open(ckpt_path / "progress.pt", "wb") as f:
@@ -55,12 +55,12 @@ class CheckpointManager:
         # Save buffer
         buffer.save(ckpt_path / "buffer")
 
-        self.logger.debug(f"Orchestrator checkpoint saved in {time.time() - start_time:.2f} seconds")
+        self.logger.debug(f"Orchestrator checkpoint saved in {time.perf_counter() - start_time:.2f} seconds")
 
     def _load_from_path(self, ckpt_path: Path, progress: Progress, buffer: Buffer) -> None:
         """Loads a checkpoint from a given path in-place."""
         self.logger.debug(f"Loading checkpoint from {ckpt_path}")
-        start_time = time.time()
+        start_time = time.perf_counter()
 
         # Load progress
         if self.config.skip_progress:
@@ -79,7 +79,7 @@ class CheckpointManager:
         else:
             buffer.load(ckpt_path / "buffer")
 
-        self.logger.debug(f"Orchestrator checkpoint loaded in {time.time() - start_time:.2f} seconds")
+        self.logger.debug(f"Orchestrator checkpoint loaded in {time.perf_counter() - start_time:.2f} seconds")
 
     def load(self, progress: Progress, buffer: Buffer, step: int) -> None:
         """Loads a checkpoint from a given path."""

--- a/src/prime_rl/orchestrator/ckpt.py
+++ b/src/prime_rl/orchestrator/ckpt.py
@@ -51,7 +51,7 @@ class CheckpointManager:
         buffer: Buffer,
     ):
         self._logger.debug(f"Saving orchestrator checkpoint to {ckpt_path}")
-        start_time = time.time()
+        start_time = time.perf_counter()
 
         # Save progress
         with open(ckpt_path / "progress.pt", "wb") as f:
@@ -63,12 +63,12 @@ class CheckpointManager:
         # Append to list of saved steps
         self.ckpt_steps.append(ckpt_step)
 
-        self._logger.debug(f"Orchestrator checkpoint saved in {time.time() - start_time:.2f} seconds")
+        self._logger.debug(f"Orchestrator checkpoint saved in {time.perf_counter() - start_time:.2f} seconds")
 
     def _load_from_path(self, ckpt_path: Path, progress: Progress, buffer: Buffer) -> None:
         """Loads a checkpoint from a given path in-place."""
         self._logger.debug(f"Loading checkpoint from {ckpt_path}")
-        start_time = time.time()
+        start_time = time.perf_counter()
 
         # Load progress
         if self.config.skip_progress:
@@ -87,7 +87,7 @@ class CheckpointManager:
         else:
             buffer.load(ckpt_path / "buffer")
 
-        self._logger.debug(f"Orchestrator checkpoint loaded in {time.time() - start_time:.2f} seconds")
+        self._logger.debug(f"Orchestrator checkpoint loaded in {time.perf_counter() - start_time:.2f} seconds")
 
     def load(self, progress: Progress, buffer: Buffer, step: int) -> None:
         """Loads a checkpoint from a given path."""

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -178,19 +178,19 @@ async def orchestrate(config: OrchestratorConfig):
             and progress.step % config.ckpt.interval == 0
         ):
             logger.info(f"Saving checkpoint at step {progress.step}")
-            save_ckpt_start_time = time.time()
+            save_ckpt_start_time = time.perf_counter()
             ckpt_manager.save(progress, buffer, step=progress.step)
-            save_ckpt_time = time.time() - save_ckpt_start_time
+            save_ckpt_time = time.perf_counter() - save_ckpt_start_time
 
         # Break if we have reached the maximum number of steps
         if config.max_steps and progress.step >= config.max_steps:
             break
 
         logger.info(f"Starting orchestrator step {progress.step}")
-        step_start_time = time.time()
+        step_start_time = time.perf_counter()
 
         # Schedule generating the training batch
-        generate_completions_start_time = time.time()
+        generate_completions_start_time = time.perf_counter()
         train_task = asyncio.create_task(scheduler.generate_batch(step=progress.step))
 
         # Schedule running evals at the specified interval
@@ -238,7 +238,7 @@ async def orchestrate(config: OrchestratorConfig):
 
         # Await train rollouts, process results and write batch to disk to consume by trainer
         await train_task
-        generate_completions_time = time.time() - generate_completions_start_time
+        generate_completions_time = time.perf_counter() - generate_completions_start_time
         train_rollouts = train_task.result()
         all_data_ranks_batches = prepare_batch(
             rollouts=train_rollouts,
@@ -314,7 +314,7 @@ async def orchestrate(config: OrchestratorConfig):
         per_env_reward = results_df.groupby("task").reward.mean().to_dict() if num_envs_in_batch > 1 else None
         per_env_count = results_df.task.value_counts().to_dict() if num_envs_in_batch > 1 else None
 
-        step_time = time.time() - step_start_time
+        step_time = time.perf_counter() - step_start_time
         to_log = {
             # Progress metrics
             "progress/tokens": num_tokens,

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -179,7 +179,6 @@ async def orchestrate(config: OrchestratorConfig):
         ):
             logger.info(f"Saving checkpoint at step {progress.step}")
             save_ckpt_start_time = time.perf_counter()
-            save_ckpt_start_time = time.perf_counter()
             ckpt_manager.save(progress, buffer, step=progress.step)
             save_ckpt_time = time.perf_counter() - save_ckpt_start_time
 
@@ -189,10 +188,8 @@ async def orchestrate(config: OrchestratorConfig):
 
         logger.info(f"Starting orchestrator step {progress.step}")
         step_start_time = time.perf_counter()
-        step_start_time = time.perf_counter()
 
         # Schedule generating the training batch
-        generate_completions_start_time = time.perf_counter()
         generate_completions_start_time = time.perf_counter()
         train_task = asyncio.create_task(scheduler.generate_batch(step=progress.step))
 
@@ -241,7 +238,6 @@ async def orchestrate(config: OrchestratorConfig):
 
         # Await train rollouts, process results and write batch to disk to consume by trainer
         await train_task
-        generate_completions_time = time.perf_counter() - generate_completions_start_time
         generate_completions_time = time.perf_counter() - generate_completions_start_time
         train_rollouts = train_task.result()
         all_data_ranks_batches = prepare_batch(
@@ -318,7 +314,6 @@ async def orchestrate(config: OrchestratorConfig):
         per_env_reward = results_df.groupby("task").reward.mean().to_dict() if num_envs_in_batch > 1 else None
         per_env_count = results_df.task.value_counts().to_dict() if num_envs_in_batch > 1 else None
 
-        step_time = time.perf_counter() - step_start_time
         step_time = time.perf_counter() - step_start_time
         to_log = {
             # Progress metrics

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -184,9 +184,9 @@ async def orchestrate(config: OrchestratorConfig):
             and progress.step % config.ckpt.interval == 0
         ):
             logger.info(f"Saving checkpoint at step {progress.step}")
-            save_ckpt_start_time = time.time()
+            save_ckpt_start_time = time.perf_counter()
             ckpt_manager.save(progress, buffer, step=progress.step)
-            save_ckpt_time = time.time() - save_ckpt_start_time
+            save_ckpt_time = time.perf_counter() - save_ckpt_start_time
 
             # Maybe clean up old orchestrator checkpoints
             ckpt_manager.maybe_clean()
@@ -196,10 +196,10 @@ async def orchestrate(config: OrchestratorConfig):
             break
 
         logger.info(f"Starting orchestrator step {progress.step}")
-        step_start_time = time.time()
+        step_start_time = time.perf_counter()
 
         # Schedule generating the training batch
-        generate_completions_start_time = time.time()
+        generate_completions_start_time = time.perf_counter()
         train_task = asyncio.create_task(scheduler.generate_batch(step=progress.step))
 
         # Schedule running evals at the specified interval
@@ -247,7 +247,7 @@ async def orchestrate(config: OrchestratorConfig):
 
         # Await train rollouts, process results and write batch to disk to consume by trainer
         await train_task
-        generate_completions_time = time.time() - generate_completions_start_time
+        generate_completions_time = time.perf_counter() - generate_completions_start_time
         train_rollouts = train_task.result()
         all_data_ranks_batches = prepare_batch(
             rollouts=train_rollouts,
@@ -323,7 +323,7 @@ async def orchestrate(config: OrchestratorConfig):
         per_env_reward = results_df.groupby("task").reward.mean().to_dict() if num_envs_in_batch > 1 else None
         per_env_count = results_df.task.value_counts().to_dict() if num_envs_in_batch > 1 else None
 
-        step_time = time.time() - step_start_time
+        step_time = time.perf_counter() - step_start_time
         to_log = {
             # Progress metrics
             "progress/tokens": num_tokens,

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -147,19 +147,19 @@ class Scheduler:
                 self.logger.info(
                     f"Hit async barrier because we are >{self.max_async_level} step(s) async. Waiting for checkpoint {next_ckpt_step}"
                 )
-                wait_for_ckpt_start_time = time.time()
+                wait_for_ckpt_start_time = time.perf_counter()
                 sync_wait_for_path(get_step_path(get_weights_dir(self.config.output_dir), next_ckpt_step) / "STABLE")
-                self.wait_for_ckpt_time = time.time() - wait_for_ckpt_start_time
+                self.wait_for_ckpt_time = time.perf_counter() - wait_for_ckpt_start_time
                 self.logger.debug(f"Waited for checkpoint {next_ckpt_step} for {self.wait_for_ckpt_time:.2f}s")
             self.logger.debug(
                 f"Got new policy with step {next_ckpt_step}. Updating weights and cancelling old rollout requests."
             )
 
-            update_weights_start_time = time.time()
+            update_weights_start_time = time.perf_counter()
             await update_weights(
                 self.admin_clients, get_step_path(get_weights_dir(self.config.output_dir), next_ckpt_step)
             )
-            self.update_weights_time = time.time() - update_weights_start_time
+            self.update_weights_time = time.perf_counter() - update_weights_start_time
             self.logger.debug(f"Updated weights to step {next_ckpt_step} in {self.update_weights_time:.2f}s")
 
             # Cancel old rollout requests

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -161,11 +161,9 @@ class Scheduler:
             )
 
             update_weights_start_time = time.perf_counter()
-            update_weights_start_time = time.perf_counter()
             await update_weights(
                 self.admin_clients, get_step_path(get_broadcast_dir(self.config.output_dir), next_ckpt_step)
             )
-            self.update_weights_time = time.perf_counter() - update_weights_start_time
             self.update_weights_time = time.perf_counter() - update_weights_start_time
             self.logger.debug(f"Updated weights to step {next_ckpt_step} in {self.update_weights_time:.2f}s")
 

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -152,19 +152,19 @@ class Scheduler:
                 self.logger.info(
                     f"Hit async barrier because we are >{self.max_async_level} step(s) async. Waiting for checkpoint {next_ckpt_step}"
                 )
-                wait_for_ckpt_start_time = time.time()
+                wait_for_ckpt_start_time = time.perf_counter()
                 sync_wait_for_path(get_step_path(get_broadcast_dir(self.config.output_dir), next_ckpt_step) / "STABLE")
-                self.wait_for_ckpt_time = time.time() - wait_for_ckpt_start_time
+                self.wait_for_ckpt_time = time.perf_counter() - wait_for_ckpt_start_time
                 self.logger.debug(f"Waited for checkpoint {next_ckpt_step} for {self.wait_for_ckpt_time:.2f}s")
             self.logger.debug(
                 f"Got new policy with step {next_ckpt_step}. Updating weights and cancelling old rollout requests."
             )
 
-            update_weights_start_time = time.time()
+            update_weights_start_time = time.perf_counter()
             await update_weights(
                 self.admin_clients, get_step_path(get_broadcast_dir(self.config.output_dir), next_ckpt_step)
             )
-            self.update_weights_time = time.time() - update_weights_start_time
+            self.update_weights_time = time.perf_counter() - update_weights_start_time
             self.logger.debug(f"Updated weights to step {next_ckpt_step} in {self.update_weights_time:.2f}s")
 
             # Cancel old rollout requests

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -110,7 +110,7 @@ class CheckpointManager:
         dataloader: StatefulDataLoader | None = None,
     ):
         self._logger.debug(f"Saving training checkpoint to {ckpt_path}")
-        start_time = time.time()
+        start_time = time.perf_counter()
 
         # Create checkpoint state
         state_dict = {"app": AppState(model, optimizers, scheduler, progress)}
@@ -128,7 +128,7 @@ class CheckpointManager:
         if self._is_master:
             self.ckpt_steps.append(ckpt_step)
 
-        self._logger.debug(f"Training checkpoint saved in {time.time() - start_time:.2f} seconds")
+        self._logger.debug(f"Training checkpoint saved in {time.perf_counter() - start_time:.2f} seconds")
 
     def _load_from_path(
         self,
@@ -141,7 +141,7 @@ class CheckpointManager:
     ):
         """Loads a checkpoint from a given path in-place."""
         self._logger.debug(f"Loading training checkpoint from {ckpt_path}")
-        start_time = time.time()
+        start_time = time.perf_counter()
 
         # Load sharded state
         app_state = AppState(model, optimizers, scheduler, progress)
@@ -162,7 +162,7 @@ class CheckpointManager:
                     )
             dataloader.load_state_dict(torch.load(dataloader_path))
 
-        self._logger.debug(f"Training checkpoint loaded in {time.time() - start_time:.2f} seconds")
+        self._logger.debug(f"Training checkpoint loaded in {time.perf_counter() - start_time:.2f} seconds")
 
     def load(
         self,

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -101,7 +101,7 @@ def get_model(
             case "custom":
                 model_cls = AutoModelForCausalLMPrimeRL
 
-        load_model_start_time = time.time()
+        load_model_start_time = time.perf_counter()
         if device == torch.device("meta"):
             logger.info(f"Loading model {config.name} using {model_cls.__name__} to meta device")
             model = model_cls.from_config(model_config, trust_remote_code=config.trust_remote_code, dtype=dtype)
@@ -113,7 +113,7 @@ def get_model(
                 trust_remote_code=config.trust_remote_code,
                 dtype=dtype,
             )
-        logger.debug(f"Loaded model {config.name} in {time.time() - load_model_start_time:.2f} seconds")
+        logger.debug(f"Loaded model {config.name} in {time.perf_counter() - load_model_start_time:.2f} seconds")
 
     assert model.lm_head.weight.dtype == dtype, (
         f"LM head dtype wasnt loaded correctly {model.lm_head.weight.dtype} != {dtype}"
@@ -227,7 +227,7 @@ def load_dcp_from_hf(model: nn.Module, config: ModelConfig):
     torch.distributed.barrier()
 
     logger.info(f"Loading weights using HF DCP from {snapshot_path}")
-    load_dcp_start_time = time.time()
+    load_dcp_start_time = time.perf_counter()
     dcp_load(
         model.state_dict(),
         storage_reader=HuggingFaceStorageReader(path=snapshot_path.as_posix()),
@@ -235,7 +235,7 @@ def load_dcp_from_hf(model: nn.Module, config: ModelConfig):
         # planner=DefaultLoadPlanner(allow_partial_load=True),
     )
     fix_model_post_empty(model)
-    logger.debug(f"Loaded weights using HF DCP in {time.time() - load_dcp_start_time:.2f} seconds")
+    logger.debug(f"Loaded weights using HF DCP in {time.perf_counter() - load_dcp_start_time:.2f} seconds")
 
 
 def can_load_dcp_from_hf(model: nn.Module):

--- a/src/prime_rl/trainer/rl/broadcast/filesystem.py
+++ b/src/prime_rl/trainer/rl/broadcast/filesystem.py
@@ -27,7 +27,7 @@ class FileSystemWeightBroadcast(WeightBroadcast):
     def broadcast_weights(self, model: nn.Module, step: int):
         """Broadcast weights by saving a HF-compatible checkpoint to shared filesystem and notifies the orchestrator."""
         self.logger.debug("Starting broadcasting weights to inference engine via shared filesystem")
-        start_time = time.time()
+        start_time = time.perf_counter()
         has_lora = has_lora_layers(model)
         state_dict = gather_weights_on_master(model, is_master=self.world.is_master, has_lora_layers=has_lora)
         if self.world.is_master:
@@ -41,4 +41,4 @@ class FileSystemWeightBroadcast(WeightBroadcast):
 
             # Notify the orchestrator at the end of step to signal that it is safe to load weights from shared filesystem
             self.notify_orchestrator(step)
-            self.logger.debug(f"Weights broadcasted in {time.time() - start_time:.2f}s")
+            self.logger.debug(f"Weights broadcasted in {time.perf_counter() - start_time:.2f}s")

--- a/src/prime_rl/trainer/rl/broadcast/nccl.py
+++ b/src/prime_rl/trainer/rl/broadcast/nccl.py
@@ -149,8 +149,8 @@ class NCCLWeightBroadcast(WeightBroadcast):
     def broadcast_weights(self, model: nn.Module, step: int) -> None:
         """Broadcast the state dict of a model into the inference pool using NCCL and notifies the orchestrator."""
         self.logger.debug("Starting broadcasting weights to inference engine via NCCL")
-        start_time = time.time()
+        start_time = time.perf_counter()
         if self.world.is_master:
             self.notify_orchestrator(step)
         self.nccl_broadcast_sender.broadcast_weights(model, step)
-        self.logger.debug(f"Weights broadcasted in {time.time() - start_time:.2f}s")
+        self.logger.debug(f"Weights broadcasted in {time.perf_counter() - start_time:.2f}s")

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -181,14 +181,12 @@ def train(config: RLTrainerConfig):
         wait_for_batch_start_time = time.perf_counter()
         dataloader.wait_for_batch()
         wait_for_batch_time = time.perf_counter() - wait_for_batch_start_time
-        wait_for_batch_time = time.perf_counter() - wait_for_batch_start_time
         logger.debug(f"Waited for batch to arrive for {wait_for_batch_time:.2f} seconds")
 
         # Load the training batch
         logger.debug("Loading batch")
         load_data_start_time = time.perf_counter()
         micro_batches = dataloader.get_batch()
-        load_data_time = time.perf_counter() - load_data_start_time
         load_data_time = time.perf_counter() - load_data_start_time
         logger.debug(f"Loaded batch in {load_data_time:.2f} seconds")
 

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -175,11 +175,9 @@ def train(config: RLTrainerConfig):
 
         logger.info(f"Starting training step {progress.step}")
         step_start_time = time.perf_counter()
-        step_start_time = time.perf_counter()
 
         # Wait for the batch to be available
         logger.info("Waiting for training batch to arrive")
-        wait_for_batch_start_time = time.perf_counter()
         wait_for_batch_start_time = time.perf_counter()
         dataloader.wait_for_batch()
         wait_for_batch_time = time.perf_counter() - wait_for_batch_start_time
@@ -188,7 +186,6 @@ def train(config: RLTrainerConfig):
 
         # Load the training batch
         logger.debug("Loading batch")
-        load_data_start_time = time.perf_counter()
         load_data_start_time = time.perf_counter()
         micro_batches = dataloader.get_batch()
         load_data_time = time.perf_counter() - load_data_start_time
@@ -200,7 +197,6 @@ def train(config: RLTrainerConfig):
         if config.memory_profiler_path is not None:
             memory_profiler = MemoryProfiler(progress.step, config.memory_profiler_path)
 
-        forward_backward_start_time = time.perf_counter()
         forward_backward_start_time = time.perf_counter()
         seq_len = micro_batches[0]["input_ids"].shape[1]
 
@@ -292,7 +288,6 @@ def train(config: RLTrainerConfig):
         scheduler.step()
 
         forward_backward_time = time.perf_counter() - forward_backward_start_time
-        forward_backward_time = time.perf_counter() - forward_backward_start_time
 
         # TODO: Broadcast weight checkpoint via shardcast
 
@@ -315,7 +310,6 @@ def train(config: RLTrainerConfig):
         peak_memory = torch.cuda.max_memory_reserved() / 1024**3  # GiB
 
         # Log step metrics
-        step_time = time.perf_counter() - step_start_time
         step_time = time.perf_counter() - step_start_time
         step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {tensor_stats['loss/mean']:.4f} | Entropy: {tensor_stats['entropy/mean']:.4f} | Mismatch KL: {tensor_stats['mismatch_kl/mean']:.4f} | Grad. Norm: {grad_norm:.4f} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}% | Peak Mem.: {peak_memory:.1f} GiB"
         if "max_vio/mean" in tensor_stats:

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -150,7 +150,7 @@ def train(config: RLTrainerConfig):
         save_weights_time = 0
         broadcast_weights_time = 0
         if progress.step > 0:
-            save_weights_start_time = time.time()
+            save_weights_start_time = time.perf_counter()
             # Save weights to disk at every if using filesystem weight broadcast or at interval step
             if config.weight_broadcast.type == "filesystem" or (
                 config.weights.interval and progress.step % config.weights.interval == 0
@@ -159,15 +159,15 @@ def train(config: RLTrainerConfig):
             else:
                 # Always create a stable file to signal to the orchestrator to initialize receiving weights via NCCL
                 weight_ckpt_manager.create_stable_file(progress.step)
-            save_weights_time = time.time() - save_weights_start_time
+            save_weights_time = time.perf_counter() - save_weights_start_time
             broadcast_weights_time = save_weights_time
 
             # Do not NCCL broadcast the last async level steps because the inference server is not receiving anymore
             is_second_to_last_step = config.max_steps is not None and progress.step >= config.max_steps - 1
             if nccl_broadcast is not None and not is_second_to_last_step:
-                broadcast_weights_start_time = time.time()
+                broadcast_weights_start_time = time.perf_counter()
                 nccl_broadcast.broadcast_state_dict(model)
-                broadcast_weights_time = time.time() - broadcast_weights_start_time
+                broadcast_weights_time = time.perf_counter() - broadcast_weights_start_time
 
         # Save the full checkpoint (if we are at an interval step and not at the first or last step)
         save_ckpt_time = 0
@@ -178,9 +178,9 @@ def train(config: RLTrainerConfig):
             and progress.step % config.ckpt.interval == 0
         ):
             logger.info(f"Saving checkpoint at step {progress.step}")
-            save_ckpt_start_time = time.time()
+            save_ckpt_start_time = time.perf_counter()
             ckpt_manager.save(model, [optimizer], scheduler, progress, step=progress.step)
-            save_ckpt_time = time.time() - save_ckpt_start_time
+            save_ckpt_time = time.perf_counter() - save_ckpt_start_time
 
             # Maybe clean up old trainer checkpoints
             ckpt_manager.maybe_clean()
@@ -190,20 +190,20 @@ def train(config: RLTrainerConfig):
             break
 
         logger.info(f"Starting training step {progress.step}")
-        step_start_time = time.time()
+        step_start_time = time.perf_counter()
 
         # Wait for the batch to be available
         logger.info("Waiting for training batch to arrive")
-        wait_for_batch_start_time = time.time()
+        wait_for_batch_start_time = time.perf_counter()
         dataloader.wait_for_batch()
-        wait_for_batch_time = time.time() - wait_for_batch_start_time
+        wait_for_batch_time = time.perf_counter() - wait_for_batch_start_time
         logger.debug(f"Waited for batch to arrive for {wait_for_batch_time:.2f} seconds")
 
         # Load the training batch
         logger.debug("Loading batch")
-        load_data_start_time = time.time()
+        load_data_start_time = time.perf_counter()
         micro_batches = dataloader.get_batch()
-        load_data_time = time.time() - load_data_start_time
+        load_data_time = time.perf_counter() - load_data_start_time
         logger.debug(f"Loaded batch in {load_data_time:.2f} seconds")
 
         batch_size = len(micro_batches)
@@ -211,7 +211,7 @@ def train(config: RLTrainerConfig):
         if config.memory_profiler_path is not None:
             memory_profiler = MemoryProfiler(progress.step, config.memory_profiler_path)
 
-        forward_backward_start_time = time.time()
+        forward_backward_start_time = time.perf_counter()
         seq_len = micro_batches[0]["input_ids"].shape[1]
 
         # Normalize by the local number of unmasked tokens in the batch (per-batch length normalization)
@@ -301,7 +301,7 @@ def train(config: RLTrainerConfig):
         current_lr = optimizer.param_groups[0]["lr"]
         scheduler.step()
 
-        forward_backward_time = time.time() - forward_backward_start_time
+        forward_backward_time = time.perf_counter() - forward_backward_start_time
 
         # TODO: Broadcast weight checkpoint via shardcast
 
@@ -327,7 +327,7 @@ def train(config: RLTrainerConfig):
         peak_memory = torch.cuda.max_memory_reserved() / 1024**3  # GiB
 
         # Log step metrics
-        step_time = time.time() - step_start_time
+        step_time = time.perf_counter() - step_start_time
         step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {tensor_stats['loss/mean']:.4f} | Entropy: {tensor_stats['entropy/mean']:.4f} | Mismatch KL: {tensor_stats['mismatch_kl/mean']:.4f} | Grad. Norm: {grad_norm:.4f} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}% | Peak Mem.: {peak_memory:.1f} GiB"
         if "max_vio/mean" in tensor_stats:
             step_message += f" | Max Vio: {tensor_stats['max_vio/mean']:.4f}"

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -149,9 +149,9 @@ def train(config: SFTTrainerConfig):
         ):
             # Save full checkpoint
             logger.info(f"Saving checkpoint at step {progress.step}")
-            save_ckpt_start_time = time.time()
+            save_ckpt_start_time = time.perf_counter()
             ckpt_manager.save(progress.step, model, [optimizer], scheduler, progress, dataloader=dataloader)
-            save_ckpt_time = time.time() - save_ckpt_start_time
+            save_ckpt_time = time.perf_counter() - save_ckpt_start_time
 
             # Maybe clean up old checkpoints
             ckpt_manager.maybe_clean()
@@ -173,8 +173,8 @@ def train(config: SFTTrainerConfig):
             MemoryProfiler(progress.step, config.memory_profiler_path) if config.memory_profiler_path else None
         )
 
-        step_start_time = time.time()
-        forward_backward_start_time = time.time()
+        step_start_time = time.perf_counter()
+        forward_backward_start_time = time.perf_counter()
         grad_accum_steps = (
             config.data.batch_size
             * config.model.cp
@@ -266,7 +266,7 @@ def train(config: SFTTrainerConfig):
         current_lr = optimizer.param_groups[0]["lr"]
         scheduler.step()
 
-        forward_backward_time = time.time() - forward_backward_start_time
+        forward_backward_time = time.perf_counter() - forward_backward_start_time
 
         # Optionally, dump memory snapshot
         if memory_profiler is not None:
@@ -288,7 +288,7 @@ def train(config: SFTTrainerConfig):
         peak_memory = torch.cuda.max_memory_reserved() / 1024**3  # GiB
 
         # Log step metrics
-        step_time = time.time() - step_start_time
+        step_time = time.perf_counter() - step_start_time
         step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {batch_loss.item():.4f} | Grad. Norm: {grad_norm:.4f} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}% | Peak Mem.: {peak_memory:.1f}/{max_memory:.1f} GiB ({peak_memory / max_memory * 100:.1f}%)"
         if is_tt_moe_model(model) and max_vio is not None:
             step_message += f" | Max Vio: {batch_max_vio.item():.4f}"

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -175,8 +175,6 @@ def train(config: SFTTrainerConfig):
 
         step_start_time = time.perf_counter()
         forward_backward_start_time = time.perf_counter()
-        step_start_time = time.perf_counter()
-        forward_backward_start_time = time.perf_counter()
         grad_accum_steps = (
             config.data.batch_size
             * config.model.cp
@@ -269,7 +267,6 @@ def train(config: SFTTrainerConfig):
         scheduler.step()
 
         forward_backward_time = time.perf_counter() - forward_backward_start_time
-        forward_backward_time = time.perf_counter() - forward_backward_start_time
 
         # Optionally, dump memory snapshot
         if memory_profiler is not None:
@@ -291,7 +288,6 @@ def train(config: SFTTrainerConfig):
         peak_memory = torch.cuda.max_memory_reserved() / 1024**3  # GiB
 
         # Log step metrics
-        step_time = time.perf_counter() - step_start_time
         step_time = time.perf_counter() - step_start_time
         step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {batch_loss.item():.4f} | Grad. Norm: {grad_norm:.4f} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}% | Peak Mem.: {peak_memory:.1f}/{max_memory:.1f} GiB ({peak_memory / max_memory * 100:.1f}%)"
         if is_tt_moe_model(model) and max_vio is not None:

--- a/src/prime_rl/trainer/weights.py
+++ b/src/prime_rl/trainer/weights.py
@@ -366,7 +366,7 @@ class WeightCheckpointManager:
         step_path.mkdir(parents=True, exist_ok=True)
 
         self._logger.debug(f"Saving weight checkpoint to {step_path}")
-        start_time = time.time()
+        start_time = time.perf_counter()
         # Suppress torch.distributed warnings during checkpoint saving
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=FutureWarning, module="torch.distributed")
@@ -382,7 +382,7 @@ class WeightCheckpointManager:
             tokenizer.save_pretrained(step_path)
 
         (step_path / "STABLE").touch()
-        self._logger.debug(f"Saved weight checkpoint to {step_path} in {time.time() - start_time:.2f} seconds")
+        self._logger.debug(f"Saved weight checkpoint to {step_path} in {time.perf_counter() - start_time:.2f} seconds")
 
     def create_stable_file(self, step: int):
         step_path = self._get_step_path(step)

--- a/src/prime_rl/utils/monitor.py
+++ b/src/prime_rl/utils/monitor.py
@@ -129,7 +129,7 @@ class WandbMonitor:
         assert self.last_log_samples_step <= step, "Step must be greater than last logged step"
         assert self.logger is not None, "Logger is required for sample logging"
         self.logger.info(f"Logging samples to W&B table at step {step}")
-        start_time = time.time()
+        start_time = time.perf_counter()
         batch_size = len(input_tokens)
         num_problems = batch_size // rollouts_per_problem
 
@@ -181,7 +181,7 @@ class WandbMonitor:
                 self.samples.append(sample)
         wandb.log({"samples": self.samples_table}, step=step)
         self.last_log_samples_step = step
-        self.logger.debug(f"Logged samples at step {step} to W&B table in {time.time() - start_time:.2f}s")
+        self.logger.debug(f"Logged samples at step {step} to W&B table in {time.perf_counter() - start_time:.2f}s")
 
     def log_distributions(self, distributions: dict[str, list[float]], step: int) -> None:
         if not self.is_master:
@@ -208,13 +208,15 @@ class WandbMonitor:
         )
 
         # Append to distributions
-        start_time = time.time()
+        start_time = time.perf_counter()
         row = {"step": step, **distributions}
         self.distributions.append(row)
         self.distributions_table.add_data(*row.values())
         wandb.log({"distributions": self.distributions_table}, step=step)
         self.last_log_distributions_step = step
-        self.logger.debug(f"Logged distributions at step {step} to W&B table in {time.time() - start_time:.2f}s")
+        self.logger.debug(
+            f"Logged distributions at step {step} to W&B table in {time.perf_counter() - start_time:.2f}s"
+        )
 
     def log_final_samples(self) -> None:
         """Log final samples to W&B table."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -177,9 +177,9 @@ def vllm_server() -> Generator[None, None, None]:
     async def wait_for_server_health(timeout: int = 180, interval: int = 1) -> bool:
         """Wait for the server to be healthy by checking the /health endpoint."""
         health_url = f"{base_url}/health"
-        start_time = time.time()
+        start_time = time.perf_counter()
 
-        while time.time() - start_time < timeout:
+        while time.perf_counter() - start_time < timeout:
             try:
                 with urllib.request.urlopen(health_url, timeout=5) as response:
                     if response.status == 200:


### PR DESCRIPTION
Change `time.time()` to `time.perf_counter()` where it's just used for measuring the time that an operation takes. That's because:

- `time.time()` is slightly less accurate than `time.perf_counter()`
- More importantly, `time.time()` could theoretically cause wrong timing measurements if the user for example changed their time-zone during a run. `time.perf_counter()` is immune to such issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace time.time() with time.perf_counter() wherever measuring elapsed time across eval, orchestrator, trainer (RL/SFT), broadcasting, checkpoints, monitor logging, and tests.
> 
> - **Timing refactor**:
>   - Replace `time.time()` with `time.perf_counter()` for elapsed-time measurements in:
>     - `eval`: `src/prime_rl/eval/utils.py` (eval start/end)
>     - **Orchestrator**: `orchestrator.py` (step, ckpt, generation timings), `ckpt.py` (save/load), `scheduler.py` (ckpt wait, weight update)
>     - **Trainer**:
>       - RL: `trainer/rl/train.py` (broadcast, ckpt, step, wait/load, fwd/bwd)
>       - SFT: `trainer/sft/train.py` (ckpt, step, fwd/bwd)
>       - Checkpoints: `trainer/ckpt.py` (save/load, weights save/gather/convert)
>       - Model: `trainer/model.py` (model load, HF DCP load)
>       - Broadcast: `trainer/rl/broadcast/{filesystem,nccl}.py` (broadcast timings)
>     - **Utils/Monitoring**: `utils/monitor.py` (samples/distributions logging)
>     - **Tests**: `tests/conftest.py` (vLLM health wait loop)
> - Minor: formatting cleanup in `orchestrator/advantage.py` (inline `compute_advantage` call).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad36c6b7a6d79f5010953cc90ce266e7054fa3e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->