### PR TITLE
Fp8 inference 

### DIFF
--- a/scripts/convert_to_fp8.py
+++ b/scripts/convert_to_fp8.py
@@ -1,0 +1,60 @@
+#! /usr/bin/env python3
+#
+# Example Usage:
+# uv run python scripts/convert_to_fp8.py \
+#     /tmp/PrimeIntellect_Qwen3-0.6B-Reverse-Text-RL-safetensors \
+#     /root/prime-rl/models/Qwen3-0.6B-Reverse-Text-RL-fp8 \
+#     --max-workers 2
+#
+# options:
+#   input_path          Path to the input model directory (HF format with safetensors)
+#   output_path         Path to save the FP8 quantized model
+#   --max-workers MAX_WORKERS
+#                       Number of worker threads for parallel processing (default: 4)
+
+import argparse
+from pathlib import Path
+
+from loguru import logger
+
+from prime_rl.trainer.weights import convert_model_to_fp8
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert a HuggingFace model to FP8 format using blockwise (128x128) quantization"
+    )
+    parser.add_argument("input_path", type=Path, help="Path to the input model directory (HF format with safetensors)")
+    parser.add_argument("output_path", type=Path, help="Path to save the FP8 quantized model")
+    parser.add_argument(
+        "--max-workers",
+        type=int,
+        default=4,
+        help="Number of worker threads for parallel processing (default: 4)",
+    )
+
+    args = parser.parse_args()
+
+    if not args.input_path.exists():
+        logger.error(f"Input path does not exist: {args.input_path}")
+        return 1
+
+    if not args.input_path.is_dir():
+        logger.error(f"Input path is not a directory: {args.input_path}")
+        return 1
+
+    logger.info(f"Converting model from {args.input_path} to {args.output_path}")
+    logger.info(f"Using {args.max_workers} worker threads")
+
+    try:
+        convert_model_to_fp8(args.input_path, args.output_path, max_workers=args.max_workers)
+        logger.info(f"Successfully converted model to FP8 format: {args.output_path}")
+        return 0
+    except Exception as e:
+        logger.error(f"Error converting model: {e}")
+        raise
+
+
+if __name__ == "__main__":
+    exit(main())
+

--- a/scripts/convert_to_fp8.py
+++ b/scripts/convert_to_fp8.py
@@ -98,7 +98,7 @@ def main():
             output_path=str(output_path),
             max_workers=args.max_workers,
         )
-        print(f"\n✓ Successfully converted model to FP8 format!")
+        print("\n✓ Successfully converted model to FP8 format!")
         print(f"  Output directory: {output_path}")
     except Exception as e:
         print(f"\n✗ Error during conversion: {e}", file=sys.stderr)

--- a/scripts/convert_to_fp8.py
+++ b/scripts/convert_to_fp8.py
@@ -1,60 +1,110 @@
-#! /usr/bin/env python3
-#
-# Example Usage:
-# uv run python scripts/convert_to_fp8.py \
-#     /tmp/PrimeIntellect_Qwen3-0.6B-Reverse-Text-RL-safetensors \
-#     /root/prime-rl/models/Qwen3-0.6B-Reverse-Text-RL-fp8 \
-#     --max-workers 2
-#
-# options:
-#   input_path          Path to the input model directory (HF format with safetensors)
-#   output_path         Path to save the FP8 quantized model
-#   --max-workers MAX_WORKERS
-#                       Number of worker threads for parallel processing (default: 4)
+#!/usr/bin/env python3
+"""
+Convert a HuggingFace model to FP8 format using blockwise (128x128) quantization.
+
+Usage:
+    python scripts/convert_to_fp8.py <model_path_or_id> <output_path> [--max-workers N]
+
+Examples:
+    # Convert a local model
+    python scripts/convert_to_fp8.py /path/to/model /path/to/output
+
+    # Convert a HuggingFace model (will download first)
+    python scripts/convert_to_fp8.py Qwen/Qwen3-0.6B /path/to/output
+
+    # Use custom number of workers
+    python scripts/convert_to_fp8.py /path/to/model /path/to/output --max-workers 4
+"""
 
 import argparse
+import sys
 from pathlib import Path
 
-from loguru import logger
-
 from prime_rl.trainer.weights import convert_model_to_fp8
+from prime_rl.utils.logger import setup_logger
 
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Convert a HuggingFace model to FP8 format using blockwise (128x128) quantization"
+        description="Convert a HuggingFace model to FP8 format",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
     )
-    parser.add_argument("input_path", type=Path, help="Path to the input model directory (HF format with safetensors)")
-    parser.add_argument("output_path", type=Path, help="Path to save the FP8 quantized model")
+    parser.add_argument(
+        "model_path",
+        type=str,
+        help="Path to the input model directory (HF format) or HuggingFace model ID",
+    )
+    parser.add_argument(
+        "output_path",
+        type=str,
+        help="Path to save the FP8 quantized model",
+    )
     parser.add_argument(
         "--max-workers",
         type=int,
         default=4,
         help="Number of worker threads for parallel processing (default: 4)",
     )
+    parser.add_argument(
+        "--log-level",
+        type=str,
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        help="Logging level (default: INFO)",
+    )
 
     args = parser.parse_args()
 
-    if not args.input_path.exists():
-        logger.error(f"Input path does not exist: {args.input_path}")
-        return 1
+    # Setup logger
+    setup_logger(args.log_level)
 
-    if not args.input_path.is_dir():
-        logger.error(f"Input path is not a directory: {args.input_path}")
-        return 1
+    model_path = Path(args.model_path)
+    output_path = Path(args.output_path)
 
-    logger.info(f"Converting model from {args.input_path} to {args.output_path}")
-    logger.info(f"Using {args.max_workers} worker threads")
+    # Check if model_path is a HuggingFace model ID (contains '/')
+    # If it doesn't exist as a local path, try downloading from HF
+    if "/" in args.model_path and not model_path.exists():
+        try:
+            from huggingface_hub import snapshot_download
+
+            print(f"Model path '{args.model_path}' not found locally. Downloading from HuggingFace...")
+            download_path = Path("/tmp") / args.model_path.replace("/", "_")
+            snapshot_download(
+                repo_id=args.model_path,
+                local_dir=str(download_path),
+                local_dir_use_symlinks=False,
+            )
+            model_path = download_path
+            print(f"Downloaded model to {model_path}")
+        except ImportError:
+            print("Error: huggingface_hub not available. Please install it or provide a local model path.")
+            sys.exit(1)
+        except Exception as e:
+            print(f"Error downloading model: {e}")
+            sys.exit(1)
+
+    if not model_path.exists():
+        print(f"Error: Model path '{model_path}' does not exist.")
+        sys.exit(1)
+
+    print(f"Converting model from {model_path} to FP8 format...")
+    print(f"Output will be saved to {output_path}")
+    print(f"Using {args.max_workers} worker threads")
 
     try:
-        convert_model_to_fp8(args.input_path, args.output_path, max_workers=args.max_workers)
-        logger.info(f"Successfully converted model to FP8 format: {args.output_path}")
-        return 0
+        convert_model_to_fp8(
+            model_path=str(model_path),
+            output_path=str(output_path),
+            max_workers=args.max_workers,
+        )
+        print(f"\n✓ Successfully converted model to FP8 format!")
+        print(f"  Output directory: {output_path}")
     except Exception as e:
-        logger.error(f"Error converting model: {e}")
-        raise
+        print(f"\n✗ Error during conversion: {e}", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":
-    exit(main())
+    main()
 

--- a/src/prime_rl/inference/config.py
+++ b/src/prime_rl/inference/config.py
@@ -1,8 +1,10 @@
+import os
 from argparse import Namespace
 from typing import Annotated, Literal
 
 from pydantic import Field, model_validator
 
+from prime_rl.trainer.weights import FP8_BLOCK_QUANT_KWARGS
 from prime_rl.utils.pydantic_config import BaseConfig, BaseSettings, get_all_fields
 from prime_rl.utils.utils import rgetattr, rsetattr
 
@@ -129,6 +131,16 @@ class InferenceConfig(BaseSettings):
         WeightBroadcastConfig()
     )
 
+    quantization: Annotated[
+        bool,
+        Field(description="Whether to use FP8 quantization for inference."),
+    ] = False
+
+    use_deep_gemm: Annotated[
+        bool,
+        Field(description="Whether to use deep GEMM optimization in vLLM."),
+    ] = False
+
     @model_validator(mode="after")
     def nccl_and_dp(self):
         if self.weight_broadcast.type == "nccl" and self.parallel.dp != 1:
@@ -153,11 +165,22 @@ class InferenceConfig(BaseSettings):
             "gpu_memory_utilization": "gpu_memory_utilization",
         }
 
+        excluded_fields = {"quantization", "use_deep_gemm"}
+
         for key in get_all_fields(self):
+            if key in excluded_fields:
+                continue
             value = rgetattr(self, key.replace("-", "_"))
             rsetattr(namespace, to_vllm.get(key, key), value)
 
         # Set `logprobs_mode` to `processed_logprobs` by default
         rsetattr(namespace, "logprobs_mode", "processed_logprobs")
+
+        if self.quantization:
+            rsetattr(namespace, "quantization", "fp8")
+            rsetattr(namespace, "hf_overrides", {"quantization_config": FP8_BLOCK_QUANT_KWARGS})
+
+        if self.use_deep_gemm:
+            os.environ["VLLM_USE_DEEP_GEMM"] = "1"
 
         return namespace

--- a/src/prime_rl/inference/vllm/worker/filesystem.py
+++ b/src/prime_rl/inference/vllm/worker/filesystem.py
@@ -4,6 +4,8 @@ from torch.nn import Module
 from vllm.model_executor.model_loader import DefaultModelLoader, get_model_loader
 from vllm.model_executor.model_loader.utils import process_weights_after_loading
 
+from prime_rl.inference.vllm.worker.utils import quantize_weights_iterator
+
 # This is to get type hints for the Worker class but not actually extend it at runtime as this is required by vLLM worker extension
 if TYPE_CHECKING:
     from vllm.v1.worker.gpu_worker import Worker
@@ -38,6 +40,10 @@ class FileSystemWeightUpdateWorker(Worker):
             allow_patterns_overrides=getattr(model, "allow_patterns_overrides", None),
         )
         weights_iterator = model_loader._get_weights_iterator(local_source)
+        
+        if self.model_runner.model_config.quantization == "fp8":
+            weights_iterator = quantize_weights_iterator(weights_iterator)
+            
         model.load_weights(weights_iterator)  # type: ignore
 
         # Process weights after loading (important for some models)

--- a/src/prime_rl/inference/vllm/worker/utils.py
+++ b/src/prime_rl/inference/vllm/worker/utils.py
@@ -1,0 +1,15 @@
+from typing import Iterator, Tuple
+
+import torch
+from prime_rl.trainer.weights import quantize_param, should_quantize_weight
+
+def quantize_weights_iterator(iterator: Iterator[Tuple[str, torch.Tensor]]) -> Iterator[Tuple[str, torch.Tensor]]:
+    """Iterate over weights and quantize them if needed."""
+    for key, value in iterator:
+        if should_quantize_weight(key):
+             qweight, scale, scale_name = quantize_param(key, value)
+             yield key, qweight
+             yield scale_name, scale
+        else:
+             yield key, value
+

--- a/src/prime_rl/trainer/fp8_triton.py
+++ b/src/prime_rl/trainer/fp8_triton.py
@@ -1,0 +1,66 @@
+from typing import Tuple
+
+import torch
+import triton
+import triton.language as tl
+
+fp8_dtype = torch.float8_e4m3fn
+fp8_max = torch.finfo(fp8_dtype).max
+fp8_min = -fp8_max
+
+
+def ceil_div(x: int, y: int) -> int:
+    return (x + y - 1) // y
+
+
+@triton.jit
+def _blockwise_cast_to_fp8_triton(
+    X,
+    Y,
+    S,
+    stride_xm,
+    stride_xn,
+    stride_ym,
+    stride_yn,
+    stride_sm,
+    stride_sn,
+    M,
+    N,
+    eps,
+    fp8_min,
+    fp8_max,
+    BLOCK_M: tl.constexpr = 32,
+    BLOCK_N: tl.constexpr = 128,
+):
+    pid_m = tl.cast(tl.program_id(axis=0), tl.int64)
+    pid_n = tl.cast(tl.program_id(axis=1), tl.int64)
+    off_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    off_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    mask_m = off_m < M
+    mask_n = off_n < N
+    mask = mask_m[:, None] & mask_n[None, :]
+
+    x = tl.load(X + off_m[:, None] * stride_xm + off_n[None, :] * stride_xn, mask=mask, other=0.0).to(tl.float32)
+    _absmax = tl.maximum(tl.max(tl.abs(x)), eps)
+    x_s = _absmax / fp8_max
+    s_inv = 1.0 / x_s
+    y_q = tl.clamp(x * s_inv, fp8_min, fp8_max).to(Y.dtype.element_ty)
+
+    tl.store(Y + off_m[:, None] * stride_ym + off_n[None, :] * stride_yn, y_q, mask=mask)
+    tl.store(S + pid_m * stride_sm + pid_n * stride_sn, x_s)
+
+
+def blockwise_cast_to_fp8_triton(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    BLOCK_M, BLOCK_N = 128, 128
+    M, N = x.shape
+    y = torch.empty(M, N, device=x.device, dtype=torch.float8_e4m3fn)
+    s = torch.empty(ceil_div(M, BLOCK_M), ceil_div(N, BLOCK_N), dtype=torch.float32, device=x.device)
+    grid = lambda meta: (triton.cdiv(M, meta["BLOCK_M"]), triton.cdiv(N, meta["BLOCK_N"]))
+    if x.is_contiguous():
+        kwargs = {"BLOCK_M": BLOCK_M, "BLOCK_N": BLOCK_N, "num_warps": 8, "num_stages": 2}
+    else:
+        kwargs = {"BLOCK_M": BLOCK_M, "BLOCK_N": BLOCK_N, "num_warps": 1, "num_stages": 4}
+    _blockwise_cast_to_fp8_triton[grid](
+        x, y, s, *x.stride(), *y.stride(), *s.stride(), M, N, 1e-10, fp8_min, fp8_max, **kwargs
+    )
+    return y, s

--- a/src/prime_rl/trainer/rl/broadcast/filesystem.py
+++ b/src/prime_rl/trainer/rl/broadcast/filesystem.py
@@ -36,9 +36,6 @@ class FileSystemWeightBroadcast(WeightBroadcast):
             if has_tt_moe_layers(state_dict):
                 convert_tt_to_hf_moe(state_dict)
                 
-            if self.use_fp8:
-                quantize_layer_params(state_dict)
-
             # Save weights to shared filesystem
             save_dir = get_step_path(self.broadcast_dir, step)
             save_state_dict(state_dict, save_dir, self.save_format, self.save_sharded)

--- a/src/prime_rl/trainer/rl/broadcast/filesystem.py
+++ b/src/prime_rl/trainer/rl/broadcast/filesystem.py
@@ -1,5 +1,5 @@
-import time
 from pathlib import Path
+import time
 from typing import Literal
 
 from torch import nn

--- a/src/prime_rl/trainer/rl/broadcast/filesystem.py
+++ b/src/prime_rl/trainer/rl/broadcast/filesystem.py
@@ -2,7 +2,7 @@ import time
 from pathlib import Path
 from typing import Literal
 
-import torch.nn as nn
+from torch import nn
 
 from prime_rl.trainer.lora import has_lora_layers
 from prime_rl.trainer.rl.broadcast.base import WeightBroadcast

--- a/src/prime_rl/trainer/rl/broadcast/nccl.py
+++ b/src/prime_rl/trainer/rl/broadcast/nccl.py
@@ -127,8 +127,6 @@ class NCCLWeightBroadcastSender:
                 convert_tt_layer_to_hf(state_dict, layer_id)
 
             if self.world.is_master:
-                if self.use_fp8:
-                    quantize_layer_params(state_dict)
                 broadcast_state_dict(state_dict, self.communicator)
 
 

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -56,7 +56,7 @@ class FileSystemWeightBroadcastConfig(BaseModel):
     save_format: Annotated[
         Literal["safetensors", "torch"], Field(description="The format to save the weight checkpoint in.")
     ] = "safetensors"
-
+    use_fp8: Annotated[bool, Field(description="Whether to use FP8 quantization for inference.")] = False
 
 class NCCLWeightBroadcastConfig(BaseModel):
     """Configures the NCCL broadcast."""
@@ -67,6 +67,7 @@ class NCCLWeightBroadcastConfig(BaseModel):
     timeout: Annotated[int, Field(description="The timeout in seconds to use for the NCCL broadcast.")] = 1200
     # TODO: Should not be configurable, but auto-inferred
     inference_world_size: Annotated[int, Field(description="The number of GPUs used for inference.")] = 1
+    use_fp8: Annotated[bool, Field(description="Whether to use FP8 quantization for inference.")] = False
 
 
 WeightBroadcastConfigType: TypeAlias = FileSystemWeightBroadcastConfig | NCCLWeightBroadcastConfig

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -56,7 +56,6 @@ class FileSystemWeightBroadcastConfig(BaseModel):
     save_format: Annotated[
         Literal["safetensors", "torch"], Field(description="The format to save the weight checkpoint in.")
     ] = "safetensors"
-    use_fp8: Annotated[bool, Field(description="Whether to use FP8 quantization for inference.")] = False
 
 class NCCLWeightBroadcastConfig(BaseModel):
     """Configures the NCCL broadcast."""
@@ -67,8 +66,6 @@ class NCCLWeightBroadcastConfig(BaseModel):
     timeout: Annotated[int, Field(description="The timeout in seconds to use for the NCCL broadcast.")] = 1200
     # TODO: Should not be configurable, but auto-inferred
     inference_world_size: Annotated[int, Field(description="The number of GPUs used for inference.")] = 1
-    use_fp8: Annotated[bool, Field(description="Whether to use FP8 quantization for inference.")] = False
-
 
 WeightBroadcastConfigType: TypeAlias = FileSystemWeightBroadcastConfig | NCCLWeightBroadcastConfig
 

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -44,7 +44,6 @@ from prime_rl.trainer.world import get_world
 from prime_rl.utils.monitor import setup_monitor
 from prime_rl.utils.pydantic_config import parse_argv
 from prime_rl.utils.utils import clean_exit, to_col_format
-from prime_rl.trainer.weights import FP8_BLOCK_QUANT_KWARGS
 
 
 @clean_exit

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -44,6 +44,7 @@ from prime_rl.trainer.world import get_world
 from prime_rl.utils.monitor import setup_monitor
 from prime_rl.utils.pydantic_config import parse_argv
 from prime_rl.utils.utils import clean_exit, to_col_format
+from prime_rl.trainer.weights import FP8_BLOCK_QUANT_KWARGS
 
 
 @clean_exit

--- a/src/prime_rl/trainer/weights.py
+++ b/src/prime_rl/trainer/weights.py
@@ -55,7 +55,7 @@ class ConversionResult:
 _QUANTIZATION_EXCLUSIONS = {"layernorm", "embed", "router", "mlp.gate.", "norm", "lm_head", "eh_proj"}
 
 
-def _should_quantize_weight(key: str) -> bool:
+def should_quantize_weight(key: str) -> bool:
     """Check if a weight key should be quantized."""
     if "weight" not in key:
         return False
@@ -78,7 +78,7 @@ def _process_safetensors_file(
     with safe_open(input_path / filename, framework="pt", device="cuda") as f:
         for key in f.keys():
             weight = f.get_tensor(key)
-            if _should_quantize_weight(key):
+            if should_quantize_weight(key):
                 qw, s = blockwise_cast_to_fp8_triton(weight)
                 q_weights[key] = qw
                 q_weights[key.replace(".weight", ".weight_scale_inv")] = s
@@ -166,7 +166,7 @@ def quantize_layer_params(state_dict: dict[str, Tensor]) -> None:
             not key.endswith(".weight")
             or key.endswith("_scale")
             or key.endswith("_scale_inv")
-            or not _should_quantize_weight(key)
+            or not should_quantize_weight(key)
         ):
             continue
         

--- a/src/prime_rl/trainer/weights.py
+++ b/src/prime_rl/trainer/weights.py
@@ -15,8 +15,8 @@ from safetensors.torch import save_file
 from torch import Tensor, nn
 from torch.distributed.checkpoint.state_dict import _get_fqns as get_fqns
 from torch.distributed.tensor import DTensor
-from transformers.utils import SAFE_WEIGHTS_INDEX_NAME, SAFE_WEIGHTS_NAME, WEIGHTS_INDEX_NAME, WEIGHTS_NAME
 from tqdm import tqdm
+from transformers.utils import SAFE_WEIGHTS_INDEX_NAME, SAFE_WEIGHTS_NAME, WEIGHTS_INDEX_NAME, WEIGHTS_NAME
 
 from prime_rl.trainer.fp8_triton import blockwise_cast_to_fp8_triton
 from prime_rl.trainer.lora import (

--- a/src/prime_rl/utils/validation.py
+++ b/src/prime_rl/utils/validation.py
@@ -34,7 +34,7 @@ def validate_shared_model_name(
     orchestrator: OrchestratorConfig,
     inference: Optional[InferenceConfig] = None,
 ) -> None:
-    if trainer.model.name.startswith("Jackmin108/"):  # The TT MoE models will have a different name on the orchestrator
+    if trainer.model.name.startswith("Jackmin108/") or orchestrator.model.name.endswith("-fp8"):  # The TT MoE models will have a different name on the orchestrator
         return
     if trainer.model.name != orchestrator.model.name:
         raise ValueError(


### PR DESCRIPTION
First have to convert your model to fp8 by running:
```
python scripts/convert_to_fp8.py <model_name_or_path> <output_path>
```
Then to run inference:
```
uv run inference --model.name <output_path> --quantization
```
Can optionally use 
```
uv run inference --model.name <output_path> --quantization --use_deep_gemm
```
for potentially faster inference.
For training, you would set the orchestrator and inference model names to the fp8 model, and keep the trainer on the original bf16 model