### PR TITLE
improvement: avoid blocking orchestrator event loop with sync barrier

### DIFF
--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -181,14 +181,14 @@ class Scheduler:
                     # and eventually reduce self.async_level.
                     if not was_waiting:
                         self.logger.info(
-                            f"Async barrier active (async level={self.async_level} > max level={self.max_async_level}). No longer scheduling group rollouts. Waiting for trainer to catch up..."
+                            f"Async barrier active (async_level={self.async_level} > max_level={self.max_async_level}). No longer scheduling group rollouts. Waiting for trainer to catch up..."
                         )
                         was_waiting = True
-                        pbar.set_description(f"Waiting for trainer (level {self.async_level})")
+                        pbar.set_description("Waiting for trainer")
                     await asyncio.sleep(0.1)
                     continue
                 elif was_waiting:
-                    self.logger.info(f"Async barrier cleared (level {self.async_level}). Resuming rollout generation.")
+                    self.logger.info("Async barrier cleared. Resuming rollout generation.")
                     pbar.set_description("Generating rollouts (train)")
                     was_waiting = False
 

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -185,7 +185,7 @@ class Scheduler:
                     now = time.time()
                     if now - wait_log_last_time > 60:
                         self.logger.info(
-                            f"Async barrier active (level {self.async_level} > {self.max_async_level}). No longer scheduling group rollouts. Waiting for trainer to catch up..."
+                            f"Async barrier active (async level={self.async_level} > max level={self.max_async_level}). No longer scheduling group rollouts. Waiting for trainer to catch up..."
                         )
                         wait_log_last_time = now
                     await asyncio.sleep(0.1)

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -183,7 +183,7 @@ class Scheduler:
                     # the concurrent update_policy_loop to run, fetch new checkpoints,
                     # and eventually reduce self.async_level.
                     now = time.time()
-                    if now - wait_log_last_time > 5:
+                    if now - wait_log_last_time > 60:
                         self.logger.info(
                             f"Async barrier active (level {self.async_level} > {self.max_async_level}). No longer scheduling group rollouts. Waiting for trainer to catch up..."
                         )


### PR DESCRIPTION
This PR avoids blocking the orchestrator event loop (sync looking for file and `time.sleep` usage). 
Instead we async look for the file and automatically stop scheduling group rollouts.  

**Key Changes:**
- Non-Blocking Barrier: Replaced time.sleep() blocking calls with await asyncio.sleep(). The Orchestrator event loop now remains active while waiting for the Trainer, preventing ZMQ timeouts and keeping network buffers flowing. 
-  Smart Draining Strategy: instead of hard-stopping, the scheduler now drains in-flight rollouts when the max_async_level is hit, but pauses scheduling new ones. This maximizes GPU utilization without violating async limits.
- Race Condition Safety: Added safe popping of tasks to prevent KeyError crashes when update_policy cancels stale rollouts concurrently with generate_batch processing. 

**I have also adjusted the logging. The policy loop no longer logs (it essentially just waits until a file arrives), but instead the generate_batch function now tells us if it schedules rollouts or not.** 

You now see logs like this (which are also a bit easier to understand for a novice):

``` 
INFO Async barrier active (async level=3 > max level=1). No longer scheduling group rollouts. Waiting for trainer to catch up... 

 INFO Async barrier cleared (level 1). Resuming rollout generation.
``` 

Tested on reverse-text, alphabet-sort, wordle


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces blocking waits with async waits and adds async-level barrier logic to pause/resume rollout scheduling safely, with race-safe task handling and clearer logging.
> 
> - **Scheduler (orchestrator)**:
>   - **Non-blocking checkpoint wait**: Replace `sync_wait_for_path` with `await wait_for_path` when enforcing strict async level.
>   - **Async barrier handling**:
>     - Pause initial fill and ongoing scheduling when `async_level > max_async_level`; resume once cleared.
>     - Use `await asyncio.sleep(...)` to yield while waiting; update progress bar description accordingly.
>   - **Race-safe rollout management**:
>     - Safely `pop` finished tasks with default `None` to avoid errors if concurrently cancelled by `update_policy`.
>     - Only reschedule next rollout when within async limits.
>   - **Logging tweaks**: Info logs on barrier activation/clearance; debug logs for waited checkpoint and policy updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e418aafccdfb89b4e0831eec7ad99a61852791c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->