### PR TITLE
run ci in vm

### DIFF
--- a/.github/workflows/gpu_tests.yaml
+++ b/.github/workflows/gpu_tests.yaml
@@ -24,7 +24,7 @@ jobs:
         run: |
           apt-get update
           apt-get install -y git
-          git config --global --add safe.directory /__w/prime-rl/prime-rl
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -52,7 +52,7 @@ jobs:
         run: |
           apt-get update
           apt-get install -y git
-          git config --global --add safe.directory /__w/prime-rl/prime-rl
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/gpu_tests.yaml
+++ b/.github/workflows/gpu_tests.yaml
@@ -11,33 +11,6 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  setup:
-    name: Setup environment
-    runs-on: vm
-    container:
-      image: pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel
-      options: --gpus all
-    timeout-minutes: 30
-    if: github.event_name == 'push' || github.event.pull_request.draft == false
-    steps:
-      - name: Install Git
-        run: |
-          apt-get update
-          apt-get install -y git
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
-      - name: Install dependencies
-        run: uv sync --locked
-      - name: Verify GPU access
-        run: nvidia-smi
-
   unit-tests:
     name: Unit tests
     runs-on: vm
@@ -45,13 +18,13 @@ jobs:
       image: pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel
       options: --gpus all
     timeout-minutes: 15
-    needs: setup
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     steps:
       - name: Install Git
         run: |
           apt-get update
           apt-get install -y git
+          git config --global --add safe.directory /__w/prime-rl/prime-rl
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -73,13 +46,13 @@ jobs:
       image: pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel
       options: --gpus all
     timeout-minutes: 15
-    needs: setup
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     steps:
       - name: Install Git
         run: |
           apt-get update
           apt-get install -y git
+          git config --global --add safe.directory /__w/prime-rl/prime-rl
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/gpu_tests.yaml
+++ b/.github/workflows/gpu_tests.yaml
@@ -13,7 +13,10 @@ concurrency:
 jobs:
   setup:
     name: Setup environment
-    runs-on: self-hosted
+    runs-on: vm
+    container:
+      image: pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel
+      options: --gpus all
     timeout-minutes: 30
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     steps:
@@ -28,42 +31,54 @@ jobs:
           cache-dependency-glob: "uv.lock"
       - name: Install dependencies
         run: uv sync --locked
-      - name: Cleanup GPU processes
-        run: |
-          echo "Checking for stray GPU processes..."
-          pids=$(nvidia-smi --query-compute-apps=pid --format=csv,noheader 2>/dev/null | xargs)
-          if [ -n "$pids" ]; then
-            echo "Forcefully killing stray GPU processes: $pids"
-            kill -9 "$pids" 2>/dev/null || true
-          else
-            echo "No stray GPU processes found. All good!"
-          fi
-          echo "GPU status after cleanup:"
-          nvidia-smi || true
+      - name: Verify GPU access
+        run: nvidia-smi
 
   unit-tests:
     name: Unit tests
-    runs-on: self-hosted
+    runs-on: vm
+    container:
+      image: pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel
+      options: --gpus all
     timeout-minutes: 15
     needs: setup
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: Install uv
         uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+      - name: Install dependencies
+        run: uv sync --locked
       - name: Run unit tests
         run: PYTEST_OUTPUT_DIR=/tmp/outputs uv run pytest tests/unit -m gpu
-      - name: Cleanup output_dir
-        run: rm -rf /tmp/outputs
 
   integration-tests:
     name: Integration tests
-    runs-on: self-hosted
+    runs-on: vm
+    container:
+      image: pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel
+      options: --gpus all
     timeout-minutes: 15
     needs: setup
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: Install uv
         uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+      - name: Install dependencies
+        run: uv sync --locked
       - name: Run integration tests
         env:
           USERNAME_CI: CI_RUNNER
@@ -77,5 +92,3 @@ jobs:
           GITHUB_HEAD_REF: ${{ github.head_ref }}
           PYTEST_OUTPUT_DIR: /tmp/outputs
         run: uv run pytest tests/integration -m gpu
-      - name: Cleanup output_dir
-        run: rm -rf /tmp/outputs

--- a/.github/workflows/gpu_tests.yaml
+++ b/.github/workflows/gpu_tests.yaml
@@ -17,7 +17,7 @@ jobs:
     container:
       image: pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel
       options: --gpus all
-    timeout-minutes: 15
+    timeout-minutes: 45
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     steps:
       - name: Install Git
@@ -45,7 +45,7 @@ jobs:
     container:
       image: pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel
       options: --gpus all
-    timeout-minutes: 15
+    timeout-minutes: 60
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     steps:
       - name: Install Git

--- a/.github/workflows/gpu_tests.yaml
+++ b/.github/workflows/gpu_tests.yaml
@@ -20,6 +20,10 @@ jobs:
     timeout-minutes: 30
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     steps:
+      - name: Install Git
+        run: |
+          apt-get update
+          apt-get install -y git
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -44,6 +48,10 @@ jobs:
     needs: setup
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     steps:
+      - name: Install Git
+        run: |
+          apt-get update
+          apt-get install -y git
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -68,6 +76,10 @@ jobs:
     needs: setup
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     steps:
+      - name: Install Git
+        run: |
+          apt-get update
+          apt-get install -y git
       - name: Checkout repository
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Migrate GPU unit/integration tests to a CUDA-enabled container on VM, remove separate setup/cleanup, add caching and dependency install steps, and increase timeouts.
> 
> - **CI: GPU test workflow (`.github/workflows/gpu_tests.yaml`)**
>   - Run `unit-tests` and `integration-tests` on `runs-on: vm` inside `pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel` with `--gpus all`.
>   - Remove separate `setup` job and GPU/output cleanup steps; add explicit Git install and `actions/checkout` with `submodules: true`.
>   - Use `astral-sh/setup-uv@v5` with caching and `uv sync --locked` for dependencies.
>   - Increase timeouts (unit: 45m; integration: 60m).
>   - Preserve and set test env vars (e.g., `WANDB_*`, `HF_TOKEN`, `PRIME_API_KEY`, `PYTEST_OUTPUT_DIR`) and run `pytest` with `-m gpu`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13440f7c047f0c43ee0541e0f6d75c9bed45bfe0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->