### PR TITLE
Allow configuring tokenizer

### DIFF
--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -276,6 +276,29 @@ class ModelConfig(BaseConfig):
         return self
 
 
+class TokenizerConfig(BaseConfig):
+    """Configuration for the tokenizer."""
+
+    name: Annotated[
+        str | None,
+        Field(description="The name or path of the tokenizer to use. If None, will use the model's default tokenizer."),
+    ] = None
+
+    trust_remote_code: Annotated[
+        bool | None,
+        Field(
+            description="Whether to trust remote code for tokenizer initialization. If None, will use the model's default trust remote code setting.",
+        ),
+    ] = None
+
+    chat_template: Annotated[
+        str | None,
+        Field(
+            description="The chat template to use for the tokenizer. If None, will use the tokenizer's default chat template."
+        ),
+    ] = None
+
+
 class ConstantSchedulerConfig(BaseModel):
     """Configuration for constant learning rate scheduler."""
 

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -18,7 +18,7 @@ from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, Pretra
 from transformers.tokenization_utils import PreTrainedTokenizer
 from transformers.utils.import_utils import is_flash_attn_3_available
 
-from prime_rl.trainer.config import ActivationCheckpointConfig, CompileConfig, ModelConfig
+from prime_rl.trainer.config import ActivationCheckpointConfig, CompileConfig, ModelConfig, TokenizerConfig
 from prime_rl.trainer.lora import apply_lora_to_model
 from prime_rl.trainer.models import AutoModelForCausalLMPrimeRL
 from prime_rl.trainer.parallel_dims import ParallelDims
@@ -121,8 +121,12 @@ def get_model(
     return model
 
 
-def setup_tokenizer(config: ModelConfig) -> PreTrainedTokenizer:
-    tokenizer = AutoTokenizer.from_pretrained(config.name, trust_remote_code=config.trust_remote_code)
+def setup_tokenizer(config: TokenizerConfig) -> PreTrainedTokenizer:
+    tokenizer = AutoTokenizer.from_pretrained(
+        config.name,
+        trust_remote_code=config.trust_remote_code,
+        **{"chat_template": config.chat_template} if config.chat_template is not None else {},
+    )
     tokenizer.pad_token_id = tokenizer.eos_token_id
     return tokenizer
 

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -122,12 +122,11 @@ def get_model(
 
 
 def setup_tokenizer(config: TokenizerConfig) -> PreTrainedTokenizer:
-    tokenizer = AutoTokenizer.from_pretrained(
-        config.name,
-        trust_remote_code=config.trust_remote_code,
-        **{"chat_template": config.chat_template} if config.chat_template is not None else {},
-    )
+    tokenizer = AutoTokenizer.from_pretrained(config.name, trust_remote_code=config.trust_remote_code)
+    if config.chat_template is not None:
+        tokenizer.chat_template = config.chat_template
     tokenizer.pad_token_id = tokenizer.eos_token_id
+
     return tokenizer
 
 

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -10,6 +10,7 @@ from prime_rl.trainer.config import (
     ModelConfig,
     OptimizerConfigType,
     SchedulerConfigType,
+    TokenizerConfig,
 )
 from prime_rl.utils.config import LogConfig, WandbMonitorConfig
 from prime_rl.utils.pydantic_config import BaseConfig, BaseSettings
@@ -83,6 +84,9 @@ class RLTrainerConfig(BaseSettings):
 
     # The model configuration
     model: ModelConfig = ModelConfig()
+
+    # The tokenizer configuration
+    tokenizer: TokenizerConfig = TokenizerConfig()
 
     # The data configuration
     data: DataLoaderConfig = DataLoaderConfig()
@@ -208,4 +212,12 @@ class RLTrainerConfig(BaseSettings):
         if self.weight_broadcast.type == "nccl" and self.weight_broadcast.adapter_only:
             # TODO: Support this
             raise ValueError("NCCL weight broadcast does not support LoRA yet.")
+        return self
+
+    @model_validator(mode="after")
+    def auto_setup_tokenizer(self):
+        if self.tokenizer.name is None:
+            self.tokenizer.name = self.model.name
+        if self.tokenizer.trust_remote_code is None:
+            self.tokenizer.trust_remote_code = self.model.trust_remote_code
         return self

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -79,9 +79,11 @@ def train(config: RLTrainerConfig):
         )
 
     # Initialize the model and tokenizer
-    logger.info(f"Initializing model and tokenizer ({config.model})")
+    logger.info(f"Initializing model ({config.model})")
     model = setup_model(config.model, parallel_dims)
-    tokenizer = setup_tokenizer(config.model)
+
+    logger.info(f"Initializing tokenizer ({config.tokenizer})")
+    tokenizer = setup_tokenizer(config.tokenizer)
 
     # Set up the optimizer
     logger.info(f"Initializing optimizer ({config.optim})")

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -68,9 +68,11 @@ def train(config: SFTTrainerConfig):
     parallel_dims = get_parallel_dims(config.model, config.data.seq_len)
 
     # Initialize the model and tokenizer
-    logger.info(f"Initializing model and tokenizer ({config.model})")
+    logger.info(f"Initializing model ({config.model})")
     model = setup_model(config.model, parallel_dims)
-    tokenizer = setup_tokenizer(config.model)
+
+    logger.info(f"Initializing tokenizer ({config.tokenizer})")
+    tokenizer = setup_tokenizer(config.tokenizer)
 
     # Set up the optimizer
     logger.info(f"Initializing optimizer ({config.optim})")


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `TokenizerConfig` (with optional `chat_template`) and wire it into SFT/RL configs and training, decoupling tokenizer settings from model config.
> 
> - **Config**:
>   - Add `TokenizerConfig` with `name`, `trust_remote_code`, and optional `chat_template` in `trainer/config.py`.
>   - Change `setup_tokenizer` to accept `TokenizerConfig` and apply `chat_template` when provided.
> - **Trainers**:
>   - Add `tokenizer: TokenizerConfig` to `SFTTrainerConfig` and `RLTrainerConfig` with validators to default `name`/`trust_remote_code` from `model`.
>   - Update `sft/train.py` and `rl/train.py` to initialize tokenizer from `config.tokenizer` and adjust logging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7e66b30af0d4afa45ec565f07975eb8bed27bd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->