### PR TITLE
add more ce impl for sft

### DIFF
--- a/src/prime_rl/trainer/sft/config.py
+++ b/src/prime_rl/trainer/sft/config.py
@@ -160,6 +160,10 @@ class SFTTrainerConfig(BaseSettings):
         ),
     ] = 600
 
+    loss_impl: Annotated[
+        Literal["liger", "torch"], Field(description="Implementation of the cross entropy loss function to use.")
+    ] = "torch"
+
     @model_validator(mode="after")
     def auto_setup_bench(self):
         if self.bench:

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -1,14 +1,14 @@
-from functools import partial
 import time
 from contextlib import nullcontext
 from datetime import timedelta
+
+from torch.nn import CrossEntropyLoss
 
 # Import environment before any other imports
 # ruff: noqa: I001
 
 from prime_rl.utils.act_offloading import maybe_activation_offloading
 import torch
-from torch.nn.functional import cross_entropy
 from torch.distributed.tensor.experimental import context_parallel
 from torch.profiler import profile, ProfilerActivity, record_function
 from loguru import logger
@@ -136,7 +136,7 @@ def train(config: SFTTrainerConfig):
         case "liger":
             ce_loss = LigerCrossEntropyLoss(reduction="none")
         case "torch":
-            ce_loss = partial(cross_entropy, reduction="none")
+            ce_loss = CrossEntropyLoss(reduction="none")
         case _:
             raise ValueError(f"Invalid loss implementation: {config.loss_impl}")
 


### PR DESCRIPTION
Adding ce sft implemention for reducing memory usage:

* Lieger implementation
* default torch implementation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `loss_impl` option to choose torch or Liger cross-entropy and uses the selected implementation during SFT training.
> 
> - **Config (`src/prime_rl/trainer/sft/config.py`)**:
>   - Add `SFTTrainerConfig.loss_impl` (`"liger"|"torch"`, default `"torch"`) to select CE loss implementation.
> - **Training (`src/prime_rl/trainer/sft/train.py`)**:
>   - Import and instantiate `LigerCrossEntropyLoss` or `CrossEntropyLoss` based on `config.loss_impl`.
>   - Replace use of `torch.nn.functional.cross_entropy` with the selected `ce_loss` in loss computation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 859ea1bf629da14887285f6300c05fd016791b0f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->