### PR TITLE
remove all reduce hook

### DIFF
--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -214,9 +214,6 @@ def train(config: RLTrainerConfig):
         logger.info(f"Starting forward and backward pass ({batch_size=})")
         tensors = Tensors()  # Used to accumulate tensor statistics across micro-batches and ranks for logging
         for micro_step, micro_batch in enumerate(micro_batches):
-            # we only all reduce at the last grad acc step
-            model.set_requires_all_reduce(micro_step == len(micro_batches) - 1)
-
             input_ids = micro_batch["input_ids"].to("cuda")
             position_ids = micro_batch["position_ids"].to("cuda")
             advantages = micro_batch["advantages"].to("cuda")

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -198,8 +198,6 @@ def train(config: SFTTrainerConfig):
         nan_loss_count = torch.tensor(0).to("cuda")
         batch_max_vio, max_vio = torch.tensor(0.0).to("cuda"), None
         for micro_step in range(grad_accum_steps):
-            model.set_requires_all_reduce(micro_step == grad_accum_steps - 1)
-
             micro_batch = next(dataiter)
             input_ids = micro_batch["input_ids"].to("cuda")
             position_ids = micro_batch["position_ids"].to("cuda")


### PR DESCRIPTION
removing all redeuce hook as it messed up with torch compile and some odd behavior we saw 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove `model.set_requires_all_reduce(...)` calls from RL and SFT training loops.
> 
> - **Training loops**:
>   - **RL (`src/prime_rl/trainer/rl/train.py`)**: Removed `model.set_requires_all_reduce(...)` call inside micro-batch loop.
>   - **SFT (`src/prime_rl/trainer/sft/train.py`)**: Removed `model.set_requires_all_reduce(...)` call inside gradient accumulation loop.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b1d30ab314dc6e0ce70a40d87a65c17cdfb84cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->