### PR TITLE
exclude top k from max vio calculation to try and skip the "padding experts"

### DIFF
--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -64,7 +64,7 @@ def get_load_balance_stats(
         max_vio = (tokens_per_expert.max() - balanced_load) / balanced_load
         per_layer_max_vio.append(max_vio.item())
         if reset_stats:
-            tokens_per_expert.zero_()
+            transformer_block.mlp.tokens_per_expert.zero_()
     if len(per_layer_max_vio) == 0:
         return {"max_vio": None}
     return {"max_vio": torch.tensor(per_layer_max_vio, device=torch.device("cuda"))}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates `get_load_balance_stats` to optionally ignore top-k routed experts (avoiding padding experts) when computing max violation, with proper buffer reset.
> 
> - **MoE Load Balance Stats (`src/prime_rl/trainer/model.py`)**:
>   - Add `try_to_avoid_padding_experts: bool = True` to `get_load_balance_stats`.
>   - When enabled, sort `mlp.tokens_per_expert` desc and slice off `router.top_k` to exclude top-k routed experts from mean/max calc.
>   - Ensure reset zeros the original `mlp.tokens_per_expert` buffer.
>   - Add explicit tensor type annotation for `tokens_per_expert`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1d15ea339d19e448be2f45cec017b5527219e99. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->