### PR TITLE
Add INTELLECT-3 eval configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ configs/endpoints.py
 **/logs
 **/wandb
 **/evals
+!configs/**/evals
 final_summary.json
 .pydantic_config
 .chroma_db

--- a/configs/intellect-3/evals/api/deepseek.toml
+++ b/configs/intellect-3/evals/api/deepseek.toml
@@ -1,0 +1,5 @@
+max_concurrent = 128
+
+[client]
+base_url = ["https://api.deepseek.com"]
+api_key_var = "DEEPSEEK_API_KEY"

--- a/configs/intellect-3/evals/api/fireworks.toml
+++ b/configs/intellect-3/evals/api/fireworks.toml
@@ -1,0 +1,6 @@
+max_concurrent = 128
+
+[client]
+base_url = ["https://api.fireworks.ai/inference/v1"]
+
+api_key_var = "FIREWORKS_API_KEY"

--- a/configs/intellect-3/evals/api/localhost.toml
+++ b/configs/intellect-3/evals/api/localhost.toml
@@ -1,0 +1,4 @@
+max_concurrent = 1024
+
+[client]
+base_url = [ "http://localhost:8000/v1" ]

--- a/configs/intellect-3/evals/api/openrouter/deepseek.toml
+++ b/configs/intellect-3/evals/api/openrouter/deepseek.toml
@@ -1,0 +1,8 @@
+max_concurrent = 256
+
+[client]
+base_url = ["https://openrouter.ai/api/v1"]
+api_key_var = "OPENROUTER_API_KEY"
+
+[client.extra_body]
+provider = { order = ["deepseek", "novita/fp8", "atlas-cloud/fp8", "siliconflow/fp8"] }

--- a/configs/intellect-3/evals/api/openrouter/zai.toml
+++ b/configs/intellect-3/evals/api/openrouter/zai.toml
@@ -1,0 +1,8 @@
+max_concurrent = 128
+
+[client]
+base_url = ["https://openrouter.ai/api/v1"]
+api_key_var = "OPENROUTER_API_KEY"
+
+[client.extra_body]
+provider = { order = ["z-ai"], allow_fallbacks = false}

--- a/configs/intellect-3/evals/api/together.toml
+++ b/configs/intellect-3/evals/api/together.toml
@@ -1,0 +1,5 @@
+max_concurrent = 128
+
+[client]
+base_url = ["https://api.together.ai/v1"]
+api_key_var = "TOGETHER_API_KEY"

--- a/configs/intellect-3/evals/envs/aime2024.toml
+++ b/configs/intellect-3/evals/envs/aime2024.toml
@@ -1,0 +1,3 @@
+[[env]]
+id = "aime2024"
+rollouts_per_example = 32 # 30 examples * 32 rollouts = 960 rollouts

--- a/configs/intellect-3/evals/envs/aime2025.toml
+++ b/configs/intellect-3/evals/envs/aime2025.toml
@@ -1,0 +1,3 @@
+[[env]]
+id = "aime2025"
+rollouts_per_example = 32 # 30 examples * 32 rollouts = 960 rollouts

--- a/configs/intellect-3/evals/envs/gpqa.toml
+++ b/configs/intellect-3/evals/envs/gpqa.toml
@@ -1,0 +1,3 @@
+[[env]]
+id = "gpqa"
+rollouts_per_example = 4 # 198 examples * 4 rollouts = 792 rollouts

--- a/configs/intellect-3/evals/envs/hle.toml
+++ b/configs/intellect-3/evals/envs/hle.toml
@@ -1,0 +1,3 @@
+[[env]]
+id = "hle"
+rollouts_per_example = 1 # 2158 examples * 1 rollouts = 2158 rollouts

--- a/configs/intellect-3/evals/envs/livecodebench.toml
+++ b/configs/intellect-3/evals/envs/livecodebench.toml
@@ -1,0 +1,4 @@
+[[env]]
+id = "livecodebench"
+args = { pool_size = 128 }
+rollouts_per_example = 2 # 454 examples * 2 rollouts = 908 rollouts

--- a/configs/intellect-3/evals/envs/mmlu_pro.toml
+++ b/configs/intellect-3/evals/envs/mmlu_pro.toml
@@ -1,0 +1,3 @@
+[[env]]
+id = "mmlu-pro"
+rollouts_per_example = 1 # 12K examples * 1 rollouts = 12000 rollouts

--- a/configs/intellect-3/evals/models/README.md
+++ b/configs/intellect-3/evals/models/README.md
@@ -1,0 +1,1 @@
+The model names in this directory match the names on OpenRouter. If you try hitting the model on a different provider, you might have to change the model name.

--- a/configs/intellect-3/evals/models/deepseek-r1-0528.toml
+++ b/configs/intellect-3/evals/models/deepseek-r1-0528.toml
@@ -1,0 +1,2 @@
+[model]
+name = "deepseek/deepseek-r1-0528"

--- a/configs/intellect-3/evals/models/deepseek-v3.2.toml
+++ b/configs/intellect-3/evals/models/deepseek-v3.2.toml
@@ -1,0 +1,2 @@
+[model]
+name = "deepseek/deepseek-v3.2-exp"

--- a/configs/intellect-3/evals/models/glm-4.5-air.toml
+++ b/configs/intellect-3/evals/models/glm-4.5-air.toml
@@ -1,0 +1,2 @@
+[model]
+name = "z-ai/glm-4.5-air"

--- a/configs/intellect-3/evals/models/glm-4.6.toml
+++ b/configs/intellect-3/evals/models/glm-4.6.toml
@@ -1,0 +1,2 @@
+[model]
+name = "z-ai/glm-4.6"

--- a/configs/intellect-3/evals/models/gpt-oss-120b.toml
+++ b/configs/intellect-3/evals/models/gpt-oss-120b.toml
@@ -1,0 +1,2 @@
+[model]
+name = "openai/gpt-oss-120b"

--- a/configs/intellect-3/evals/models/intellect-3.toml
+++ b/configs/intellect-3/evals/models/intellect-3.toml
@@ -1,0 +1,2 @@
+[model]
+name = "PrimeIntellect/INTELLECT-3"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -37,6 +37,12 @@ def get_config_files(config_type: ConfigType) -> list[Path]:
     """Any TOML file inside `configs/` or `examples/`"""
     config_files = list(Path("configs").glob(f"**/{config_type}.toml"))
     example_files = list(Path("examples").glob(f"**/{config_type}.toml"))
+    
+    # Special handling for eval configs: also search evals/ subdirectories
+    if config_type == "eval":
+        config_files.extend(Path("configs").glob("**/evals/**/*.toml"))
+        example_files.extend(Path("examples").glob("**/evals/**/*.toml"))
+    
     return config_files + example_files
 
 


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

TOML config files for eval suite of INTELLECT-3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds INTELLECT-3 eval configs (APIs, envs, models), ensures they’re tracked and discovered by tests.
> 
> - **Configs (INTELLECT-3 evals)**:
>   - **APIs**: Add `deepseek`, `fireworks`, `together`, `localhost`, and OpenRouter (`openrouter/deepseek`, `openrouter/zai`) in `configs/intellect-3/evals/api/*` with `max_concurrent`, `base_url`, and `api_key_var`/`extra_body` settings.
>   - **Envs**: Add `aime2024`, `aime2025`, `gpqa`, `hle`, `livecodebench` (with `args.pool_size`), and `mmlu-pro` in `configs/intellect-3/evals/envs/*` with `rollouts_per_example`.
>   - **Models**: Add model descriptors in `configs/intellect-3/evals/models/*` (`deepseek-r1-0528`, `deepseek-v3.2-exp`, `glm-4.5-air`, `glm-4.6`, `gpt-oss-120b`, `PrimeIntellect/INTELLECT-3`) and README.
> - **Tests**:
>   - Extend `tests/unit/test_config.py` to discover `**/evals/**/*.toml` for `eval` configs.
> - **Repo**:
>   - Update `.gitignore` to include `configs/**/evals` under version control.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46690388c7746fbba3cc9a54f9f8f904d49a9389. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->