### PR TITLE
Do not double load weights on resume

### DIFF
--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -80,7 +80,8 @@ def train(config: RLTrainerConfig):
 
     # Initialize the model and tokenizer
     logger.info(f"Initializing model ({config.model})")
-    model = setup_model(config.model, parallel_dims)
+    skip_load_weights = config.ckpt is not None and config.ckpt.resume_step is not None
+    model = setup_model(config.model, parallel_dims, skip_load_weights=skip_load_weights)
 
     logger.info(f"Initializing tokenizer ({config.tokenizer})")
     tokenizer = setup_tokenizer(config.tokenizer)

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -110,7 +110,7 @@ def train(config: RLTrainerConfig):
 
     # Optionally, resume training from a checkpoint
     progress = Progress()
-    if config.ckpt and ckpt_manager is not None and config.ckpt.resume_step:
+    if config.ckpt and ckpt_manager is not None and config.ckpt.resume_step is not None:
         logger.info(f"Resuming training from checkpoint step {config.ckpt.resume_step}")
         ckpt_manager.load(config.ckpt.resume_step, model, [optimizer], scheduler, progress)
     logger.info(

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -116,7 +116,7 @@ def train(config: SFTTrainerConfig):
 
     # Optionally, resume training from a checkpoint
     progress = Progress()
-    if ckpt_manager is not None and config.ckpt and config.ckpt.resume_step:
+    if ckpt_manager is not None and config.ckpt and config.ckpt.resume_step is not None:
         logger.info(f"Resuming training from checkpoint step {config.ckpt.resume_step}")
         ckpt_manager.load(
             config.ckpt.resume_step,

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -71,7 +71,8 @@ def train(config: SFTTrainerConfig):
 
     # Initialize the model and tokenizer
     logger.info(f"Initializing model ({config.model})")
-    model = setup_model(config.model, parallel_dims)
+    skip_load_weights = config.ckpt is not None and config.ckpt.resume_step is not None
+    model = setup_model(config.model, parallel_dims, skip_load_weights=skip_load_weights)
 
     logger.info(f"Initializing tokenizer ({config.tokenizer})")
     tokenizer = setup_tokenizer(config.tokenizer)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> On checkpoint resume, initialize the model on the meta device and skip base HF weight loading (use to_empty + checkpoint), with stricter resume checks in trainers.
> 
> - **Model setup (`trainer/model.py`)**:
>   - Add `skip_load_weights` to `setup_model` and compute `use_meta = config.load_using_meta or skip_load_weights`.
>   - When `skip_load_weights`: move to GPU with `model.to_empty(device="cuda")`, barrier, then `fix_model_post_empty`; otherwise load via HF DCP if supported.
>   - Fallback to CPU load if meta path unsupported and not skipping.
> - **Trainers (`trainer/rl/train.py`, `trainer/sft/train.py`)**:
>   - Pass `skip_load_weights` when `config.ckpt.resume_step is not None` to avoid double-loading base weights on resume.
>   - Use explicit `is not None` checks for `resume_step` in resume logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3fb676cfa1b3edb2c9450c967a261e955aa1b85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->