### PR TITLE
Fix: Replace invalid `--weights` flag with `--ckpt` in example READMEs

### DIFF
--- a/examples/reverse_text/README.md
+++ b/examples/reverse_text/README.md
@@ -46,7 +46,7 @@ To train on a single GPU, run
 uv run sft @ examples/reverse_text/sft/train.toml \
   --wandb.project ... \
   --wandb.name ... \
-  --weights
+  --ckpt
 ```
 
 To train on multiple GPUs, run
@@ -58,7 +58,7 @@ uv run torchrun \
   src/prime_rl/trainer/sft/train.py @ examples/reverse_text/sft/train.toml \
   --wandb.project ... \
   --wandb.name ... \
-  --weights
+  --ckpt
 ```
 
 This should write a weight checkpoint in `outputs/weights/step_100`. Upload it to HF to be able to use it as the base model for RL.

--- a/examples/wordle/README.md
+++ b/examples/wordle/README.md
@@ -54,7 +54,7 @@ To train on a single GPU, run
 uv run sft @ examples/wordle/sft/train.toml \
   --wandb.project ... \
   --wandb.name ... \
-  --weights
+  --ckpt
 ```
 
 To train on multiple GPUs, run
@@ -66,7 +66,7 @@ uv run torchrun \
   src/prime_rl/trainer/sft/train.py @ examples/wordle/sft/train.toml \
   --wandb.project ... \
   --wandb.name ... \
-  --weights
+  --ckpt
 ```
 
 After training completes, you will find the final weight checkpoint in `outputs/weights/step_20`. Upload it to HF to be able to use it as the base model for RL we will do in the next section.


### PR DESCRIPTION
## Problem

Example READMEs (`examples/reverse_text/README.md` and `examples/wordle/README.md`) document `--weights` as a command-line flag, but it is not a valid argument and causes:

```
train.py: error: unrecognized arguments: --weights
```

## Solution

Replaced `--weights` with `--ckpt` in both READMEs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace invalid `--weights` flag with `--ckpt` in SFT command snippets in reverse_text and wordle READMEs.
> 
> - **Docs**:
>   - Update SFT commands in `examples/reverse_text/README.md` and `examples/wordle/README.md`:
>     - Replace `--weights` with `--ckpt` in single- and multi-GPU instructions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 653c3cfec580d198cd44c7534dfad2f98370b81f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->