### PR TITLE
Deprecate logging distributions

### DIFF
--- a/configs/alphabet_sort/rl/orch.toml
+++ b/configs/alphabet_sort/rl/orch.toml
@@ -10,8 +10,6 @@ name = "Qwen/Qwen2.5-3B-Instruct"
 project = "alphabet-sort"
 
 [wandb.log_extras]
-samples = true
-distributions = true
 interval = 2
 
 [[env]]

--- a/src/prime_rl/eval/config.py
+++ b/src/prime_rl/eval/config.py
@@ -4,7 +4,7 @@ from typing import Annotated
 from pydantic import Field, model_validator
 
 from prime_rl.orchestrator.config import EvalConfig
-from prime_rl.utils.config import ClientConfig, LogConfig, ModelConfig, WandbMonitorConfig
+from prime_rl.utils.config import ClientConfig, LogConfig, ModelConfig, WandbConfig
 from prime_rl.utils.pydantic_config import BaseSettings
 
 
@@ -18,7 +18,7 @@ class OfflineEvalConfig(EvalConfig, BaseSettings):
     model: ModelConfig = ModelConfig()
 
     # The wandb configuration
-    wandb: WandbMonitorConfig | None = None
+    wandb: WandbConfig | None = None
 
     # The logging configuration
     log: LogConfig = LogConfig()

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -4,7 +4,7 @@ from typing import Annotated, Literal, TypeAlias
 from pydantic import BaseModel, Field, model_validator
 
 from prime_rl.trainer.config import HeartbeatConfig
-from prime_rl.utils.config import ClientConfig, LogConfig, ModelConfig, WandbMonitorConfig
+from prime_rl.utils.config import ClientConfig, LogConfig, ModelConfig, WandbWithExtrasConfig
 from prime_rl.utils.pydantic_config import BaseConfig, BaseSettings
 
 
@@ -404,7 +404,7 @@ class OrchestratorConfig(BaseSettings):
     log: LogConfig = LogConfig()
 
     # The wandb configuration
-    wandb: WandbMonitorConfig | None = None
+    wandb: WandbWithExtrasConfig | None = None
 
     # The checkpoint configuration
     ckpt: CheckpointConfig | None = None

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -420,17 +420,9 @@ async def orchestrate(config: OrchestratorConfig):
         # Log metrics to W&B
         monitor.log(to_log)
 
-        # Log samples and distributions to W&B table if enabled
+        # Log samples to W&B table if enabled
         subset_train_rollouts = random.sample(train_rollouts, min(8, len(train_rollouts)))
         monitor.log_samples(subset_train_rollouts, step=progress.step)
-
-        distributions = {
-            "rewards": results_df.reward.tolist(),
-            "problem_rewards": results_df.groupby("example_id").reward.mean().tolist(),
-        }
-
-        # Log distributions to W&B table
-        monitor.log_distributions(distributions=distributions, step=progress.step)
 
         step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Reward: {results_df.reward.mean():.4f} |{f' Val. Reward: {val_results_df.reward.mean():.4f} |' if val_results_df is not None else ''} Throughput: {throughput:.1f} tokens/s | Seq. Length: {results_df.groupby('example_id').seq_len.mean().mean():.1f} tokens/sample | Async Level: {scheduler.async_level} | Max. Off-Policy Level: {scheduler.max_off_policy_level}"
         logger.success(step_message)
@@ -457,9 +449,8 @@ async def orchestrate(config: OrchestratorConfig):
             step=progress.step,
         )
 
-    # Log final (immutable) samples and distributions to W&B table
+    # Log final (immutable) samples to W&B table
     monitor.log_final_samples()
-    monitor.log_final_distributions()
     monitor.save_final_summary()
 
     # Write final checkpoint

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -13,7 +13,7 @@ from prime_rl.trainer.config import (
     SchedulerConfigType,
     TokenizerConfig,
 )
-from prime_rl.utils.config import LogConfig, WandbMonitorConfig
+from prime_rl.utils.config import LogConfig, WandbConfig
 from prime_rl.utils.pydantic_config import BaseConfig, BaseSettings
 
 
@@ -112,7 +112,7 @@ class RLTrainerConfig(BaseSettings):
     log: LogConfig = LogConfig()
 
     # The wandb configuration
-    wandb: WandbMonitorConfig | None = None
+    wandb: WandbConfig | None = None
 
     output_dir: Annotated[
         Path,
@@ -164,16 +164,8 @@ class RLTrainerConfig(BaseSettings):
             self.max_steps = 4  # 1 Warmup + 3 Benchmark
             if not self.data.fake:
                 self.data.fake = FakeDataLoaderConfig()
-            if self.wandb:  # Do not log extras
-                self.wandb.log_extras = None
             if self.ckpt:  # Do not checkpoint
                 self.ckpt = None
-        return self
-
-    @model_validator(mode="after")
-    def disable_logging_wandb_samples(self):
-        if self.wandb and self.wandb.log_extras:
-            self.wandb.log_extras.samples = False
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -358,14 +358,6 @@ def train(config: RLTrainerConfig):
         }
         monitor.log(time_metrics)
 
-        # Log distributions to W&B table if enabled
-        assert all(len(tensors) == 1 for tensors in tensors.values()), "Tensors must be lists of length 1"
-        distributions = {key: tensors[key][0] for key in tensors.keys()}
-        monitor.log_distributions(
-            distributions=distributions,
-            step=progress.step,
-        )
-
         progress.step += 1
         is_first_step = False
 
@@ -380,9 +372,6 @@ def train(config: RLTrainerConfig):
         logger.info(f"Saving trace to {trace_file}")
         prof.export_chrome_trace(trace_file)
         logger.info(f"Saved trace to {trace_file}")
-
-    # Log final (immutable) distributions to W&B table
-    monitor.log_final_distributions()
 
     # Write final checkpoint
     if ckpt_manager is not None:

--- a/src/prime_rl/trainer/sft/config.py
+++ b/src/prime_rl/trainer/sft/config.py
@@ -13,7 +13,7 @@ from prime_rl.trainer.config import (
     SchedulerConfigType,
     TokenizerConfig,
 )
-from prime_rl.utils.config import LogConfig, WandbMonitorConfig
+from prime_rl.utils.config import LogConfig, WandbConfig
 from prime_rl.utils.pydantic_config import BaseConfig, BaseSettings
 
 
@@ -129,7 +129,7 @@ class SFTTrainerConfig(BaseSettings):
     log: LogConfig = LogConfig()
 
     # The wandb configuration
-    wandb: WandbMonitorConfig | None = None
+    wandb: WandbConfig | None = None
 
     output_dir: Annotated[
         Path,
@@ -173,16 +173,8 @@ class SFTTrainerConfig(BaseSettings):
     def auto_setup_bench(self):
         if self.bench:
             self.max_steps = 4  # 1 Warmup + 3 Benchmark
-            if self.wandb:  # Do not log extras
-                self.wandb.log_extras = None
             if self.ckpt:  # Do not checkpoint
                 self.ckpt = None
-        return self
-
-    @model_validator(mode="after")
-    def disable_logging_wandb_samples(self):
-        if self.wandb and self.wandb.log_extras:
-            self.wandb.log_extras.samples = False
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -383,9 +383,6 @@ def train(config: SFTTrainerConfig):
         prof.export_chrome_trace(trace_file)
         logger.info(f"Saved trace to {trace_file}")
 
-    # Log final (immutable) distributions to W&B table
-    monitor.log_final_distributions()
-
     # Write final checkpoint
     if ckpt_manager is not None:
         logger.info("Writing final checkpoint")

--- a/src/prime_rl/utils/config.py
+++ b/src/prime_rl/utils/config.py
@@ -94,20 +94,13 @@ class LogConfig(BaseConfig):
     ] = False
 
 
-class LogExtrasConfig(BaseConfig):
+class WandbExtrasConfig(BaseConfig):
     """Configures extra logging for W&B tables."""
 
     samples: Annotated[
         bool,
         Field(
             description="Whether to log prompt/response samples to W&B tables.",
-        ),
-    ] = True
-
-    distributions: Annotated[
-        bool,
-        Field(
-            description="Whether to log distributions (like rewards, advantages, etc.) to W&B tables.",
         ),
     ] = True
 
@@ -120,7 +113,7 @@ class LogExtrasConfig(BaseConfig):
     ] = 10
 
 
-class WandbMonitorConfig(BaseConfig):
+class WandbConfig(BaseConfig):
     """Configures logging to Weights and Biases."""
 
     # Shared configs (May be overwritten by WandbConfig from `rl.py`)
@@ -143,9 +136,8 @@ class WandbMonitorConfig(BaseConfig):
         ),
     ] = None
 
-    log_extras: Annotated[
-        LogExtrasConfig | None,
-        Field(
-            description="Configuration for logging extras to W&B tables. If None, no extras are logged.",
-        ),
-    ] = None
+
+class WandbWithExtrasConfig(WandbConfig):
+    """Configures logging to Weights and Biases with extras."""
+
+    log_extras: WandbExtrasConfig | None = WandbExtrasConfig()


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Deprecate logging distributions because we never look at them and they are super costly (especially on the trainer). This also means there is on extras to log anymore from the SFT and RL trainer, so I remove this from the configs explicitly by differentiating between a `WandbConfig` (used by trainers) and a `WandbWithExtras` config.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Deprecates W&B distribution logging, keeps sample logging via a new WandbWithExtras config, and updates orchestrator/trainers/monitor and configs to use simplified WandbConfig types.
> 
> - **Logging/Monitoring**:
>   - Remove distribution logging (step-wise and final) from orchestrator and both trainers; retain sample logging only.
>   - Split W&B configs: introduce `WandbConfig` (base) and `WandbWithExtrasConfig` (with `log_extras` for samples); rename `LogExtrasConfig` → `WandbExtrasConfig` and drop `distributions` option.
>   - Update `WandbMonitor` to handle extras only when using `WandbWithExtrasConfig`; remove distribution-table logic.
> - **Configs**:
>   - Replace `WandbMonitorConfig` with `WandbConfig`/`WandbWithExtrasConfig` across `orchestrator`, `trainer` (RL/SFT), and `eval`.
>   - Adjust RL shared config class names to `Shared*` variants and propagate new W&B types; simplify bench validators (remove extras toggles).
>   - Update example TOML (`configs/alphabet_sort/rl/orch.toml`) to drop `distributions` and keep `[wandb.log_extras].interval`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3475ba82b9d61a2e2efd6e99971f297f2d225755. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->