### PR TITLE
Revert "Do not double load weights on resume (#1351)"

### DIFF
--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -300,26 +300,22 @@ def apply_compile(model: nn.Module, compile_config: CompileConfig):
     get_logger().info(f"Compiled {len(model.model.layers)} layers (fullgraph={compile_config.fullgraph})")
 
 
-def setup_model(config: ModelConfig, parallel_dims: ParallelDims, skip_load_weights: bool = False) -> nn.Module:
+def setup_model(config: ModelConfig, parallel_dims: ParallelDims) -> nn.Module:
     if config.attn == "flash_attention_3" and not is_flash_attn_3_available():
         raise ValueError(
             "Flash attention 3 is only supported if the flash_attn_3 package is installed. Install with `uv pip install 'flash-attn-3 @ git+https://github.com/Dao-AILab/flash-attention.git@main#subdirectory=hopper' --no-build-isolation`"
         )
 
     logger = get_logger()
-
-    # When resuming from checkpoint, always use meta device to avoid double loading weights
-    use_meta = config.load_using_meta or skip_load_weights
-
     # Get model from specified device
     model = get_model(
         config,
-        device=torch.device("meta" if use_meta else "cpu"),
+        device=torch.device("meta" if config.load_using_meta else "cpu"),
         dtype=DTYPE_MAP[config.optimization_dtype],
     )
 
-    # Reload the model to CPU if we cannot load from meta device (only when not skipping weight loading)
-    if use_meta and not can_load_dcp_from_hf(model) and not skip_load_weights:
+    # Reload the model to CPU if we cannot load from
+    if config.load_using_meta and not can_load_dcp_from_hf(model):
         logger.warning("Cannot load model from meta device. Loading model to CPU instead.")
         model = get_model(config, device=torch.device("cpu"), dtype=DTYPE_MAP[config.optimization_dtype])
 
@@ -335,15 +331,8 @@ def setup_model(config: ModelConfig, parallel_dims: ParallelDims, skip_load_weig
 
     setup_fsdp(model, config, parallel_dims)
 
-    if use_meta:
-        if skip_load_weights:
-            # Move model to GPU but skip loading base weights - checkpoint will load them
-            logger.info("Skipping base weight loading - weights will be loaded from checkpoint")
-            model.to_empty(device="cuda")
-            torch.distributed.barrier()
-            fix_model_post_empty(model)
-        elif can_load_dcp_from_hf(model):
-            load_dcp_from_hf(model, config)
+    if config.load_using_meta and can_load_dcp_from_hf(model):
+        load_dcp_from_hf(model, config)
 
     logger.debug(f"Model signature: {get_module_signature(model, compress=True)}")
     return model

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -87,8 +87,7 @@ def train(config: RLTrainerConfig):
 
     # Initialize the model and tokenizer
     logger.info(f"Initializing model ({config.model})")
-    skip_load_weights = config.ckpt is not None and config.ckpt.resume_step is not None
-    model = setup_model(config.model, parallel_dims, skip_load_weights=skip_load_weights)
+    model = setup_model(config.model, parallel_dims)
 
     logger.info(f"Initializing tokenizer ({config.tokenizer})")
     tokenizer = setup_tokenizer(config.tokenizer)
@@ -117,7 +116,7 @@ def train(config: RLTrainerConfig):
 
     # Optionally, resume training from a checkpoint
     progress = Progress()
-    if config.ckpt and ckpt_manager is not None and config.ckpt.resume_step is not None:
+    if config.ckpt and ckpt_manager is not None and config.ckpt.resume_step:
         logger.info(f"Resuming training from checkpoint step {config.ckpt.resume_step}")
         ckpt_manager.load(config.ckpt.resume_step, model, [optimizer], scheduler, progress)
     logger.info(

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -86,8 +86,7 @@ def train(config: SFTTrainerConfig):
 
     # Initialize the model and tokenizer
     logger.info(f"Initializing model ({config.model})")
-    skip_load_weights = config.ckpt is not None and config.ckpt.resume_step is not None
-    model = setup_model(config.model, parallel_dims, skip_load_weights=skip_load_weights)
+    model = setup_model(config.model, parallel_dims)
 
     logger.info(f"Initializing tokenizer ({config.tokenizer})")
     tokenizer = setup_tokenizer(config.tokenizer)
@@ -120,7 +119,7 @@ def train(config: SFTTrainerConfig):
 
     # Optionally, resume training from a checkpoint
     progress = Progress()
-    if ckpt_manager is not None and config.ckpt and config.ckpt.resume_step is not None:
+    if ckpt_manager is not None and config.ckpt and config.ckpt.resume_step:
         logger.info(f"Resuming training from checkpoint step {config.ckpt.resume_step}")
         ckpt_manager.load(
             config.ckpt.resume_step,


### PR DESCRIPTION
This reverts commit cf119093fa8c70a85f0152a1dc20d4c24688b6bf.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `skip_load_weights` from `setup_model`, relies on `config.load_using_meta` for meta-loading, and simplifies checkpoint resume checks in RL/SFT trainers.
> 
> - **Model**:
>   - Update `setup_model` to remove `skip_load_weights` parameter and base-weight skip path; use `config.load_using_meta` to decide `meta` vs `cpu` load.
>   - Reload to CPU if `load_using_meta` is set but `can_load_dcp_from_hf(model)` is false.
>   - Only call `load_dcp_from_hf(model, config)` when `load_using_meta` and supported.
> - **Trainers**:
>   - Update RL (`src/prime_rl/trainer/rl/train.py`) and SFT (`src/prime_rl/trainer/sft/train.py`) to call `setup_model(config.model, parallel_dims)` without `skip_load_weights`.
>   - Simplify resume logic: use truthy `config.ckpt.resume_step` checks for loading checkpoints.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0781177504670bf5fb326fc1f79101ae9725bde6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->