### PR TITLE
fallback to eval dataset in syn data endpoint

### DIFF
--- a/src/prime_rl/synthesize/utils.py
+++ b/src/prime_rl/synthesize/utils.py
@@ -153,10 +153,8 @@ async def generate_synthetic_data(
     try:
         dataset = env.get_dataset(n=num_examples + skip_first)
     except ValueError:
-        logger.error(
-            f"Could not find a training dataset for {env_name_or_id}. Generating synthetic data is only supported for environments with a training dataset."
-        )
-        raise
+        logger.warning(f"Could not find a training dataset for {env_name_or_id}. Falling back to eval dataset.")
+        dataset = env.get_eval_dataset(n=num_examples + skip_first)
     if skip_first > 0:
         dataset = dataset.skip(skip_first)
     sampling_args = prepare_sampling_args(sampling_config, client_config)


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

in synthetic data generation endpoint only warn the user when their env dataset has no train split and fall back to env's `eval_dataset`.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: [Issue ID]
**Linear Issue**: Resolves [Issue ID]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use eval dataset as a fallback when the training dataset is unavailable, logging a warning instead of failing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a923f2f1bc80f1e625dc1ea3dbb021309c365c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->