### PR TITLE
Revert "add dp replicate forcing (#1245)"

### DIFF
--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -128,8 +128,11 @@ def setup_tokenizer(config: TokenizerConfig) -> PreTrainedTokenizer:
 
 def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDims):
     mp_policy = MixedPrecisionPolicy(param_dtype=torch.bfloat16, reduce_dtype=DTYPE_MAP[config.reduce_dtype])
-    # Always use 2D mesh format for consistency (dp_replicate dimension always present)
-    hsdp_mesh = parallel_dims.world_mesh["dp_replicate", "dp_shard_cp"]
+    # TODO: Support dp_replicate
+    if config.dp_replicate > 1:
+        hsdp_mesh = parallel_dims.world_mesh["dp_replicate", "dp_shard_cp"]
+    else:
+        hsdp_mesh = parallel_dims.world_mesh["dp_shard_cp"]
 
     offload_policy: OffloadPolicy = CPUOffloadPolicy(pin_memory=True) if config.fsdp_cpu_offload else OffloadPolicy()
 

--- a/src/prime_rl/trainer/parallel_dims.py
+++ b/src/prime_rl/trainer/parallel_dims.py
@@ -101,7 +101,7 @@ class ParallelDims:
         ):
             # dp_shard_mod_ep is needed even if it's 1, whose FSDP wrapping
             # helps the MoE layers do mixed precision training
-            if d > 1 or name == "dp_shard_mod_ep" or name == "dp_replicate":
+            if d > 1 or name == "dp_shard_mod_ep":
                 dims.append(d)
                 names.append(name)
 
@@ -119,8 +119,9 @@ class ParallelDims:
         # Mesh for ep
         ep_mesh_dim_names = []
 
-        dp_mesh_dim_names.append("dp_replicate")
-        dp_cp_mesh_dim_names.append("dp_replicate")
+        if self.dp_replicate_enabled:
+            dp_mesh_dim_names.append("dp_replicate")
+            dp_cp_mesh_dim_names.append("dp_replicate")
         # dp_shard_mod_ep is always needed, even if it's 1
         dp_mesh_dim_names.append("dp_shard_mod_ep")
         dp_shard_cp_mesh_dim_names.append("dp_shard_mod_ep")
@@ -149,7 +150,7 @@ class ParallelDims:
             [self.pp, self.dp_replicate, self.dp_shard, self.cp, self.tp],
             ["pp", "dp_replicate", "dp_shard", "cp", "tp"],
         ):
-            if d > 1 or name == "dp_shard" or name == "dp_replicate":
+            if d > 1 or name == "dp_shard":
                 dims.append(d)
                 names.append(name)
 
@@ -165,8 +166,9 @@ class ParallelDims:
         # Mesh for loss all-reduce
         dp_cp_mesh_dim_names = []
 
-        dp_mesh_dim_names.append("dp_replicate")
-        dp_cp_mesh_dim_names.append("dp_replicate")
+        if self.dp_replicate_enabled:
+            dp_mesh_dim_names.append("dp_replicate")
+            dp_cp_mesh_dim_names.append("dp_replicate")
         dp_mesh_dim_names.append("dp_shard")
         dp_shard_cp_mesh_dim_names.append("dp_shard")
         dp_cp_mesh_dim_names.append("dp_shard")


### PR DESCRIPTION
This PR seems to have significantly bumped our VRAM usage for qwen30b-a3b

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Conditionally include `dp_replicate` only when >1 across mesh construction and FSDP sharding selection.
> 
> - **Parallelism/Mesh**:
>   - Only include `dp_replicate` in world mesh dims and submeshes when `dp_replicate > 1` (both with and without EP).
>   - Keep always-included `dp_shard`/`dp_shard_mod_ep` for FSDP/MoE behavior; remove unconditional `dp_replicate` handling.
> - **FSDP Setup**:
>   - Select `hsdp_mesh` as `world_mesh["dp_shard_cp"]` when `dp_replicate == 1`; otherwise use `world_mesh["dp_replicate", "dp_shard_cp"]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fdc3adbc6e5ffcbabdf7b1a491918e584529d370. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->