### PR TITLE
Do not strictly enforce async level

### DIFF
--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -528,7 +528,7 @@ class OrchestratorConfig(BaseSettings):
         Field(
             description="Whether to strictly enforce the max async level. If True, will always ensure that the policy used for generating rollouts is exactly `max_async_level` steps ahead of training. If False, any policy that is at most `max_async_level` steps ahead of training is allowed, i.e. we always use the latest available policy.",
         ),
-    ] = True
+    ] = False
 
     bench: Annotated[
         bool,


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Right now we are not immediately updating when a new policy becomes available by default. We had this to be more backwards compatible but really there's not reason to enforce this.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Change default of `strict_async_level` to `False` in `src/prime_rl/orchestrator/config.py` (`OrchestratorConfig`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9cd9af21d239c05c91f3f4eea1a45323080b5685. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->