### PR TITLE
simplify adv and loss code

### DIFF
--- a/src/prime_rl/orchestrator/advantage.py
+++ b/src/prime_rl/orchestrator/advantage.py
@@ -1,24 +1,6 @@
 import torch
-from jaxtyping import Float, Int
-from torch import Tensor
 
 from prime_rl.orchestrator.config import AdvantageConfig
-
-
-def compute_advantage(
-    rewards: Float[Tensor, "group"],
-    lengths: Int[Tensor, "group"],
-    advantage_config: AdvantageConfig,
-) -> Float[Tensor, "group"]:
-    """
-    Computes advantages for a single group.
-    """
-    if advantage_config.length_weighted_mean:
-        baseline = (rewards * lengths).sum() / lengths.sum()
-    else:
-        baseline = rewards.mean()
-    advantages = rewards - baseline
-    return advantages
 
 
 def compute_advantages(
@@ -28,29 +10,25 @@ def compute_advantages(
     advantage_config: AdvantageConfig | None,
 ) -> list[float]:
     """
-    Computes advantages and statistics for logging from a flattened list of rewards for a given advantage type.
+    Computes advantages from a flattened list of rewards.
 
     Args:
         rewards: Flattened list of rewards where first `samples_per_problem` rewards are for the first problem
-        samples_per_problem: Number of samples (and thus, rewards) per problem
+        completion_lengths: List of completion lengths for each reward
+        samples_per_problem: Number of samples per problem
         advantage_config: Configuration for advantage computation
-        completion_lengths: List of completion lengths for each reward. Required for OPO advantage computation.
     Returns:
-        Tuple of (advantages, advantage_stats)
+        List of advantages
     """
     if not advantage_config:
         return rewards
-    advantages = []
-    assert len(rewards) % samples_per_problem == 0
-    all_group_rewards = [rewards[i : i + samples_per_problem] for i in range(0, len(rewards), samples_per_problem)]
-    all_group_lengths = [
-        completion_lengths[i : i + samples_per_problem] for i in range(0, len(completion_lengths), samples_per_problem)
-    ]
-    for group_rewards, group_lengths in zip(all_group_rewards, all_group_lengths):
-        group_rewards_tensor = torch.tensor(group_rewards)
-        group_lengths_tensor = torch.tensor(group_lengths)
-        group_advantages_tensor = compute_advantage(group_rewards_tensor, group_lengths_tensor, advantage_config)
-        assert len(group_advantages_tensor) == len(group_rewards_tensor)
-        advantages.extend(group_advantages_tensor.tolist())
-    assert len(rewards) == len(advantages)
-    return advantages
+
+    rewards = torch.tensor(rewards).view(-1, samples_per_problem)
+    lengths = torch.tensor(completion_lengths).view(-1, samples_per_problem)
+
+    if advantage_config.length_weighted_mean:
+        baseline = (rewards * lengths).sum(dim=1, keepdim=True) / lengths.sum(dim=1, keepdim=True)
+    else:
+        baseline = rewards.mean(dim=1, keepdim=True)
+
+    return (rewards - baseline).flatten().tolist()

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -21,20 +21,16 @@ class LossConfig(BaseConfig):
     """Base config for loss."""
 
     ratio_type: Annotated[Literal["token", "sequence"], Field(description="Type of importance ratio to use.")] = "token"
-
     mask_ratio_high: Annotated[float, Field(ge=0)] = 8.0
     mask_ratio_low: Annotated[float, Field(ge=0)] = 0.125
     sequence_mask_ratio_low: Annotated[
         float,
         Field(
             ge=0,
-            description=(
-                "If set, masks entire sequences when any generated token has an importance ratio below this value."
-            ),
+            description="If set, masks entire sequences when any generated token has an importance ratio below this value.",
         ),
     ] = 0.0
     kl_tau: Annotated[float, Field(ge=0)] = 0.0
-    kl_mask_type: Annotated[Literal["masked", "unmasked", "all"], Field(description="Type of KL mask to use.")] = "all"
 
 
 class FakeDataLoaderConfig(BaseConfig):

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -21,17 +21,41 @@ class LossConfig(BaseConfig):
     """Base config for loss."""
 
     ratio_type: Annotated[Literal["token", "sequence"], Field(description="Type of importance ratio to use.")] = "token"
-    mask_ratio_high: Annotated[float, Field(ge=0)] = 8.0
-    mask_ratio_low: Annotated[float, Field(ge=0)] = 0.125
-    sequence_mask_ratio_low: Annotated[
+
+    # Token-level masking thresholds
+    mask_low: Annotated[float, Field(ge=0, description="Mask tokens with importance ratio below this.")] = 0.125
+    mask_high: Annotated[float, Field(ge=0, description="Mask tokens with importance ratio above this.")] = 8.0
+
+    # Sequence-level masking thresholds
+    seq_mask_low: Annotated[
+        float, Field(ge=0, description="Mask sequences with importance ratio below this. Set to 0 to disable.")
+    ] = 0.0
+    seq_mask_high: Annotated[
+        float, Field(ge=0, description="Mask sequences with importance ratio above this. Set to inf to disable.")
+    ] = float("inf")
+    seq_mask_neg_adv: Annotated[
         float,
         Field(
             ge=0,
-            description="If set, masks entire sequences when any generated token has an importance ratio below this value.",
+            description="Mask sequences with importance ratio below this AND negative advantage. Set to 0 to disable.",
         ),
     ] = 0.0
-    kl_tau: Annotated[float, Field(ge=0)] = 0.0
+    seq_mask_pos_adv: Annotated[
+        float,
+        Field(
+            ge=0,
+            description="Mask sequences with importance ratio above this AND positive advantage. Set to inf to disable.",
+        ),
+    ] = float("inf")
 
+    # Sequence mode settings
+    seq_clip: Annotated[
+        float,
+        Field(ge=0, description="Clip unnormalized log sequence ratio to this before exp. Only for ratio_type='sequence'."),
+    ] = 10.0
+
+    kl_tau: Annotated[float, Field(ge=0)] = 0.0
+    constant_norm: Annotated[bool, Field(description="Whether to use a constant norm for the loss.")] = False
 
 class FakeDataLoaderConfig(BaseConfig):
     """Configures a fake data loader sampling random micro batches for debugging."""

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -33,8 +33,7 @@ def compute_loss(
     inference_logprobs: list[Tensor],
     advantages: list[Tensor],
     loss_mask: list[Tensor],
-    loss_config: LossConfig,
-    loss_scale: int,
+    loss_config: LossConfig,    
 ) -> tuple[Tensor, dict[str, Any]]:
     """Compute loss for packed sequences."""
     total_loss = 0
@@ -49,43 +48,49 @@ def compute_loss(
     for trainer_logprobs, inference_logprobs, advantages, loss_mask in zip(
         trainer_logprobs, inference_logprobs, advantages, loss_mask
     ):
-        log_ratio = trainer_logprobs - inference_logprobs
-        token_mismatch_kl = torch.exp(log_ratio) - log_ratio - 1
+        log_importance_ratio = trainer_logprobs - inference_logprobs
+
+        # Compute trainer-inference mismatch KL
+        token_mismatch_kl = torch.exp(log_importance_ratio) - log_importance_ratio - 1
 
         if loss_config.ratio_type == "sequence":
-            seq_log_ratio = log_ratio[loss_mask].sum()
-            log_ratio = trainer_logprobs - trainer_logprobs.detach() + seq_log_ratio.detach()
-            log_ratio = torch.clamp(log_ratio, max=10.0)
+            seq_log_importance_ratio = (log_importance_ratio[loss_mask]).sum()
+            log_importance_ratio = trainer_logprobs - trainer_logprobs.detach() + seq_log_importance_ratio.detach()
+            log_importance_ratio = torch.clamp(log_importance_ratio, max=10.0)
 
-        ratio = torch.exp(log_ratio)
-        is_masked_low = ratio < loss_config.mask_ratio_low
-        is_masked_high = ratio > loss_config.mask_ratio_high
+        importance_ratio = torch.exp(log_importance_ratio)
+        is_masked_low = importance_ratio < loss_config.mask_ratio_low
+        is_masked_high = importance_ratio > loss_config.mask_ratio_high
         is_masked = is_masked_low | is_masked_high
-        seq_min_ratio = ratio.masked_fill(~loss_mask, torch.inf).min()
+        seq_min_ratio = importance_ratio.masked_fill(~loss_mask, torch.inf).min()
         seq_should_mask = seq_min_ratio < loss_config.sequence_mask_ratio_low
         is_masked = is_masked | seq_should_mask
         keep_mask = loss_mask & ~is_masked
+        loss = (-importance_ratio * advantages)[keep_mask].sum()
+        loss = loss + loss_config.kl_tau * (log_importance_ratio[loss_mask]).sum()
 
-        loss = (-ratio * advantages)[keep_mask].sum() + loss_config.kl_tau * log_ratio[loss_mask].sum()
-
+        # Apply sequence-level normalization if configured
         if loss_config.ratio_type == "sequence":
             loss = loss / torch.clamp_min(loss_mask.sum(), 1)
 
         total_loss = total_loss + loss
 
         mismatch_kl = token_mismatch_kl[loss_mask].sum() / torch.clamp_min(loss_mask.sum(), 1)
-        masked_mismatch_kl = token_mismatch_kl[loss_mask & is_masked].sum() / torch.clamp_min((loss_mask & is_masked).sum(), 1)
+        masked_mismatch_kl = token_mismatch_kl[loss_mask & is_masked].sum() / torch.clamp_min(
+            (loss_mask & is_masked).sum(), 1
+        )
         unmasked_mismatch_kl = token_mismatch_kl[keep_mask].sum() / torch.clamp_min(keep_mask.sum(), 1)
 
+        # Aggregate loss tensors
         total_mismatch_kl.append(mismatch_kl)
         total_masked_mismatch_kl.append(masked_mismatch_kl)
         total_unmasked_mismatch_kl.append(unmasked_mismatch_kl)
         total_is_masked.append(is_masked[loss_mask].float())
         total_is_masked_low.append(is_masked_low[loss_mask].float())
         total_is_masked_high.append(is_masked_high[loss_mask].float())
-        total_sequence_masked_low.append(seq_should_mask[loss_mask].float())
+        total_sequence_masked_low.append(seq_should_mask.float())
 
-    return total_loss / loss_scale, {
+    return total_loss, {
         "mismatch_kl": torch.stack(total_mismatch_kl),
         "masked_mismatch_kl": torch.stack(total_masked_mismatch_kl),
         "unmasked_mismatch_kl": torch.stack(total_unmasked_mismatch_kl),

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -1,65 +1,42 @@
 from typing import Any
 
 import torch
-from beartype import beartype as typechecker
-from jaxtyping import Float, Int, jaxtyped
 from torch import Tensor
 
 from prime_rl.trainer.rl.config import LossConfig
 
 
-@jaxtyped(typechecker=typechecker)
 @torch.compile(dynamic=True)
-def selective_log_softmax(
-    logits: Float[Tensor, "batch seq vocab"], index: Int[Tensor, "batch seq"]
-) -> Float[Tensor, "batch seq"]:
+def selective_log_softmax(logits: Tensor, index: Tensor) -> Tensor:
     logprobs = logits.log_softmax(dim=-1)
     return torch.gather(logprobs, dim=-1, index=index.unsqueeze(-1)).squeeze(-1)
 
 
-@jaxtyped(typechecker=typechecker)
 @torch.compile(dynamic=True)
-def compute_entropy(shifted_logits: Float[Tensor, "batch seq vocab"]) -> Float[Tensor, "batch seq"]:
+def compute_entropy(shifted_logits: Tensor) -> Tensor:
     with torch.no_grad():
         pd = torch.nn.functional.softmax(shifted_logits, dim=-1)
         entropy = torch.logsumexp(shifted_logits, dim=-1) - torch.sum(pd * shifted_logits, dim=-1)
     return entropy
 
 
-@jaxtyped(typechecker=typechecker)
-def shift_logits(logits: Float[Tensor, "batch seq vocab"]) -> Float[Tensor, "batch seq vocab"]:
+def shift_logits(logits: Tensor) -> Tensor:
     """Removes final token logits and adds a zero logit for the first token."""
-    # We drop the last logit because it corresponds to the next token that will be sampled but is not here yet
     batch, seq, vocab = logits.shape
-    logits = logits[:, :-1, :]  # (batch, seq-1, vocab)
-    zeros = torch.zeros(batch, 1, vocab, device=logits.device, dtype=logits.dtype)  # (batch, 1, vocab)
-    logits = torch.cat([zeros, logits], dim=1)  # (batch, seq, vocab)
-    return logits
+    logits = logits[:, :-1, :]
+    zeros = torch.zeros(batch, 1, vocab, device=logits.device, dtype=logits.dtype)
+    return torch.cat([zeros, logits], dim=1)
 
 
 def compute_loss(
-    trainer_logprobs: Any,  # list of Float[Tensor, "seq_i"] with potentially different seq_i lengths
-    inference_logprobs: Any,  # list of Float[Tensor, "seq_i"] with potentially different seq_i lengths
-    advantages: Any,  # list of Float[Tensor, "seq_i"] with potentially different seq_i lengths
-    loss_mask: Any,  # list of Bool[Tensor, "seq_i"] with potentially different seq_i lengths
+    trainer_logprobs: list[Tensor],
+    inference_logprobs: list[Tensor],
+    advantages: list[Tensor],
+    loss_mask: list[Tensor],
     loss_config: LossConfig,
     loss_scale: int,
-) -> tuple[Float[Tensor, ""], dict[str, Any]]:
-    """
-    Compute loss for packed sequences (batch size = 1, multiple sequences packed along sequence dimension).
-
-    Args:
-        trainer_logprobs: Log probabilities tensor for packed sequences
-        inference_logprobs: Old log probabilities tensor for packed sequences
-        advantages: Advantages tensor for packed sequences
-        loss_mask: Loss mask tensor for packed sequences
-        loss_config: Loss configuration object
-        loss_scale: Scale factor to normalize the loss
-
-    Returns:
-        Tuple of (scaled_loss, aggregated_loss_tensors)
-    """
-
+) -> tuple[Tensor, dict[str, Any]]:
+    """Compute loss for packed sequences."""
     total_loss = 0
     total_mismatch_kl = []
     total_masked_mismatch_kl = []
@@ -72,60 +49,43 @@ def compute_loss(
     for trainer_logprobs, inference_logprobs, advantages, loss_mask in zip(
         trainer_logprobs, inference_logprobs, advantages, loss_mask
     ):
-        log_importance_ratio = trainer_logprobs - inference_logprobs
-
-        # Compute trainer-inference mismatch KL
-        token_mismatch_kl = torch.exp(log_importance_ratio) - log_importance_ratio - 1
+        log_ratio = trainer_logprobs - inference_logprobs
+        token_mismatch_kl = torch.exp(log_ratio) - log_ratio - 1
 
         if loss_config.ratio_type == "sequence":
-            seq_log_importance_ratio = (log_importance_ratio[loss_mask]).sum()
-            log_importance_ratio = trainer_logprobs - trainer_logprobs.detach() + seq_log_importance_ratio.detach()
-            log_importance_ratio = torch.clamp(log_importance_ratio, max=10.0)
+            seq_log_ratio = log_ratio[loss_mask].sum()
+            log_ratio = trainer_logprobs - trainer_logprobs.detach() + seq_log_ratio.detach()
+            log_ratio = torch.clamp(log_ratio, max=10.0)
 
-        importance_ratio = torch.exp(log_importance_ratio)
-        is_masked_low = importance_ratio < loss_config.mask_ratio_low
-        is_masked_high = importance_ratio > loss_config.mask_ratio_high
+        ratio = torch.exp(log_ratio)
+        is_masked_low = ratio < loss_config.mask_ratio_low
+        is_masked_high = ratio > loss_config.mask_ratio_high
         is_masked = is_masked_low | is_masked_high
-        seq_min_ratio = importance_ratio.masked_fill(~loss_mask, torch.inf).min()
+        seq_min_ratio = ratio.masked_fill(~loss_mask, torch.inf).min()
         seq_should_mask = seq_min_ratio < loss_config.sequence_mask_ratio_low
         is_masked = is_masked | seq_should_mask
         keep_mask = loss_mask & ~is_masked
-        loss = (-importance_ratio * advantages)[keep_mask].sum()
-        if loss_config.kl_mask_type == "masked":
-            kl_mask = loss_mask & is_masked
-        elif loss_config.kl_mask_type == "unmasked":
-            kl_mask = keep_mask
-        elif loss_config.kl_mask_type == "all":
-            kl_mask = loss_mask
-        else:
-            raise ValueError(f"Invalid KL mask type: {loss_config.kl_mask_type}")
-        loss = loss + loss_config.kl_tau * (log_importance_ratio[kl_mask]).sum()
 
-        # Apply sequence-level normalization if configured
+        loss = (-ratio * advantages)[keep_mask].sum() + loss_config.kl_tau * log_ratio[loss_mask].sum()
+
         if loss_config.ratio_type == "sequence":
             loss = loss / torch.clamp_min(loss_mask.sum(), 1)
 
         total_loss = total_loss + loss
 
         mismatch_kl = token_mismatch_kl[loss_mask].sum() / torch.clamp_min(loss_mask.sum(), 1)
-        masked_mismatch_kl = token_mismatch_kl[loss_mask & is_masked].sum() / torch.clamp_min(
-            (loss_mask & is_masked).sum(), 1
-        )
+        masked_mismatch_kl = token_mismatch_kl[loss_mask & is_masked].sum() / torch.clamp_min((loss_mask & is_masked).sum(), 1)
         unmasked_mismatch_kl = token_mismatch_kl[keep_mask].sum() / torch.clamp_min(keep_mask.sum(), 1)
 
-        # Aggregate loss tensors
         total_mismatch_kl.append(mismatch_kl)
         total_masked_mismatch_kl.append(masked_mismatch_kl)
         total_unmasked_mismatch_kl.append(unmasked_mismatch_kl)
         total_is_masked.append(is_masked[loss_mask].float())
         total_is_masked_low.append(is_masked_low[loss_mask].float())
         total_is_masked_high.append(is_masked_high[loss_mask].float())
-        total_sequence_masked_low.append(seq_should_mask.float())
+        total_sequence_masked_low.append(seq_should_mask[loss_mask].float())
 
-    # Apply loss scaling
-    scaled_loss = total_loss / loss_scale
-
-    return scaled_loss, {
+    return total_loss / loss_scale, {
         "mismatch_kl": torch.stack(total_mismatch_kl),
         "masked_mismatch_kl": torch.stack(total_masked_mismatch_kl),
         "unmasked_mismatch_kl": torch.stack(total_unmasked_mismatch_kl),

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -214,7 +214,7 @@ def train(config: RLTrainerConfig):
         # Normalize by the local number of unmasked tokens in the batch (per-batch length normalization)
         if config.loss.ratio_type == "token":
             loss_scale = sum(micro_batch["loss_mask"].sum().item() for micro_batch in micro_batches)
-        elif config.loss.ratio_type == "sequence":
+        elif config.loss.ratio_type == "sequence" or config.loss.constant_norm:
             loss_scale = batch_size
         loss_scale = max(loss_scale, 1)
 

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -244,8 +244,9 @@ def train(config: RLTrainerConfig):
                 advantages=advantages.squeeze().split(response_lengths),
                 loss_mask=loss_mask.squeeze().split(response_lengths),
                 loss_config=config.loss,
-                loss_scale=loss_scale,
             )
+
+            loss = loss / loss_scale
 
             # Compute entropy
             entropy = compute_entropy(shifted_logits)

--- a/tests/unit/train/rl/test_loss.py
+++ b/tests/unit/train/rl/test_loss.py
@@ -19,7 +19,6 @@ def test_grpo_loss():
         advantages,
         loss_mask=loss_mask,
         loss_config=LossConfig(ratio_type="token", mask_ratio_high=10.0),
-        loss_scale=1.0,
     )
     assert loss.shape == ()
 
@@ -37,7 +36,6 @@ def test_gspo_loss():
         advantages,
         loss_mask=loss_mask,
         loss_config=LossConfig(ratio_type="sequence", mask_ratio_high=10.0),
-        loss_scale=1.0,
     )
     assert loss.shape == ()
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Vectorizes advantage computation and overhauls RL loss with new masking/sequence controls, removing loss_scale from compute_loss and updating training/tests accordingly.
> 
> - **Advantage**:
>   - Vectorize `compute_advantages` using tensor reshaping; support length-weighted baseline via `completion_lengths`; remove per-group helper and return flat list.
> - **Loss/Training**:
>   - Introduce new masking config in `LossConfig`: `mask_low/high`, `seq_mask_low/high`, `seq_mask_neg_adv/pos_adv`, `seq_clip`, and `constant_norm`.
>   - Refactor `compute_loss`:
>     - Remove `loss_scale` arg; add sequence- and token-level masking with new thresholds and adv-aware sequence masks; sequence ratio clipping and optional per-sequence normalization.
>     - Return expanded metrics (`token_masked*`, `seq_masked_*`, and KL splits).
>   - Update `train.py` to compute `loss_scale` (batch-size for `sequence` or `constant_norm`) and divide loss after `compute_loss`.
> - **Tests**:
>   - Update unit tests to call `compute_loss` without `loss_scale`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5324fd0aaa5d8c1f00fbd5be5885ff01cc7dd3ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->