### PR TITLE
Fix computing prefix tokens wrong

### DIFF
--- a/src/prime_rl/orchestrator/trajectories.py
+++ b/src/prime_rl/orchestrator/trajectories.py
@@ -55,7 +55,7 @@ def interleave_rollout(state: vf.State) -> list[TrainingExample]:
         interleaved_rollout["completion_logprobs"].extend(completion_logprobs)
 
         # New prefix is the the current prompt and completion ids concatenated
-        prefix_tokens = prompt_ids + completion_ids
+        prefix_tokens = tokens["prompt_ids"] + tokens["completion_ids"]
 
     return [interleaved_rollout]
 


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Fix critical bug that occurs for multi-turn envs with >2 turns because prefix tokens does not include previous trajectory history. Snuck in very late in #1315 because of a variable redefinition..

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes `interleave_rollout` prefix update to use the full step `prompt_ids + completion_ids`, preserving full multi-turn history.
> 
> - **Orchestrator / trajectories**:
>   - `interleave_rollout`: update `prefix_tokens` to `tokens["prompt_ids"] + tokens["completion_ids"]` to correctly carry forward full prompt+completion history across steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 186e64db072b7a722cae201e9b2dc54c3b1ba79b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->