### PR TITLE
Revert "Do not double load weights on resume (#1369)"

### DIFF
--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -300,29 +300,24 @@ def apply_compile(model: nn.Module, compile_config: CompileConfig):
     get_logger().info(f"Compiled {len(model.model.layers)} layers (fullgraph={compile_config.fullgraph})")
 
 
-def setup_model(config: ModelConfig, parallel_dims: ParallelDims, skip_load_weights: bool = False) -> nn.Module:
+def setup_model(config: ModelConfig, parallel_dims: ParallelDims) -> nn.Module:
     if config.attn == "flash_attention_3" and not is_flash_attn_3_available():
         raise ValueError(
             "Flash attention 3 is only supported if the flash_attn_3 package is installed. Install with `uv pip install 'flash-attn-3 @ git+https://github.com/Dao-AILab/flash-attention.git@main#subdirectory=hopper' --no-build-isolation`"
         )
 
     logger = get_logger()
-
-    # When resuming from checkpoint, always use meta device to skip loading base weights
-    use_meta = config.load_using_meta or skip_load_weights
-
     # Get model from specified device
     model = get_model(
         config,
-        device=torch.device("meta" if use_meta else "cpu"),
+        device=torch.device("meta" if config.load_using_meta else "cpu"),
         dtype=DTYPE_MAP[config.optimization_dtype],
     )
 
-    # Reload the model to CPU if we cannot load from meta device
-    if use_meta and not can_load_dcp_from_hf(model):
+    # Reload the model to CPU if we cannot load from
+    if config.load_using_meta and not can_load_dcp_from_hf(model):
         logger.warning("Cannot load model from meta device. Loading model to CPU instead.")
         model = get_model(config, device=torch.device("cpu"), dtype=DTYPE_MAP[config.optimization_dtype])
-        use_meta = False
 
     # Apply LoRA before FSDP setup
     if config.experimental.lora is not None:
@@ -336,19 +331,8 @@ def setup_model(config: ModelConfig, parallel_dims: ParallelDims, skip_load_weig
 
     setup_fsdp(model, config, parallel_dims)
 
-    if use_meta:
-        if skip_load_weights:
-            # When resuming from checkpoint, just allocate empty tensors on GPU
-            # The checkpoint loading will fill in the weights
-            logger.info("Skipping base weight loading (will load from checkpoint)")
-            model.to_empty(device="cuda")
-            torch.distributed.barrier()
-            if isinstance(model, PreTrainedModelPrimeRL):
-                model.init_buffers_post_meta()
-            else:
-                fix_model_post_empty(model)
-        else:
-            load_dcp_from_hf(model, config)
+    if config.load_using_meta and can_load_dcp_from_hf(model):
+        load_dcp_from_hf(model, config)
 
     logger.debug(f"Model signature: {get_module_signature(model, compress=True)}")
     return model

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -87,8 +87,7 @@ def train(config: RLTrainerConfig):
 
     # Initialize the model and tokenizer
     logger.info(f"Initializing model ({config.model})")
-    skip_load_weights = config.ckpt and config.ckpt.resume_step
-    model = setup_model(config.model, parallel_dims, skip_load_weights=skip_load_weights)
+    model = setup_model(config.model, parallel_dims)
 
     logger.info(f"Initializing tokenizer ({config.tokenizer})")
     tokenizer = setup_tokenizer(config.tokenizer)

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -86,8 +86,7 @@ def train(config: SFTTrainerConfig):
 
     # Initialize the model and tokenizer
     logger.info(f"Initializing model ({config.model})")
-    skip_load_weights = config.ckpt and config.ckpt.resume_step
-    model = setup_model(config.model, parallel_dims, skip_load_weights=skip_load_weights)
+    model = setup_model(config.model, parallel_dims)
 
     logger.info(f"Initializing tokenizer ({config.tokenizer})")
     tokenizer = setup_tokenizer(config.tokenizer)


### PR DESCRIPTION
This reverts commit df488b66a3bc9bf0a0a07460ac9a255230b55621.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies model initialization by removing the resume-based skip-load path, relying solely on config.load_using_meta with HF DCP when supported, and updates RL/SFT trainers to the new signature.
> 
> - **Model setup (`trainer/model.py`)**:
>   - Remove `skip_load_weights` from `setup_model` and associated resume logic (no `to_empty`, barriers, or post-empty fixes path).
>   - Load to `meta` only if `config.load_using_meta`; fallback to CPU if `can_load_dcp_from_hf` is false.
>   - Conditionally load weights via HF DCP only when `config.load_using_meta` and `can_load_dcp_from_hf(model)`.
> - **Trainers**:
>   - RL (`trainer/rl/train.py`): Call `setup_model(config.model, parallel_dims)` without `skip_load_weights`.
>   - SFT (`trainer/sft/train.py`): Same update to `setup_model` call.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89bf11a74531152f9b64bbe870fb32f662c061ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->