### PR TITLE
Revert non-blocking async barrier

### DIFF
--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -19,7 +19,7 @@ from prime_rl.utils.utils import (
     get_broadcast_dir,
     get_latest_ckpt_step,
     get_step_path,
-    wait_for_path,
+    sync_wait_for_path,
 )
 from prime_rl.utils.vf import generate_group
 
@@ -108,8 +108,11 @@ class Scheduler:
         )
         if next_ckpt_step > self.ckpt_step:
             if next_ckpt_step == async_away_ckpt_step:
+                self.logger.info(
+                    f"Hit async barrier because we are >{self.max_async_level} step(s) async. Waiting for checkpoint {next_ckpt_step}"
+                )
                 wait_for_ckpt_start_time = time.perf_counter()
-                await wait_for_path(get_step_path(get_broadcast_dir(self.config.output_dir), next_ckpt_step) / "STABLE")
+                sync_wait_for_path(get_step_path(get_broadcast_dir(self.config.output_dir), next_ckpt_step) / "STABLE")
                 self.wait_for_ckpt_time = time.perf_counter() - wait_for_ckpt_start_time
                 self.logger.debug(f"Waited for checkpoint {next_ckpt_step} for {self.wait_for_ckpt_time:.2f}s")
             self.logger.debug(
@@ -161,40 +164,11 @@ class Scheduler:
         # Schedule initial tasks
         self.logger.debug("Starting to generate batch rollouts")
         while len(self.inflight_group_rollouts) < self.problems_per_batch:
-            if self.async_level > self.max_async_level:
-                self.logger.debug(
-                    f"Initial fill paused at {len(self.inflight_group_rollouts)} due to async barrier (level {self.async_level})."
-                )
-                break
             await self.schedule_group_rollout()  # Schedule requests in round-robin fashion
 
         batch_rollouts: list[vf.State] = []
         pbar = tqdm(total=self.config.batch_size, desc="Generating rollouts (train)")
-        was_waiting = False
-
         while len(batch_rollouts) < self.config.batch_size:
-            if not self.inflight_group_rollouts:
-                if self.async_level > self.max_async_level:
-                    # Async barrier active: We are too far ahead of the trainer.
-                    # We have no inflight rollouts to process, so we must wait.
-                    # We use asyncio.sleep to yield control to the event loop, allowing
-                    # the concurrent update_policy_loop to run, fetch new checkpoints,
-                    # and eventually reduce self.async_level.
-                    if not was_waiting:
-                        self.logger.info(
-                            f"Async barrier active (async_level={self.async_level} > max_level={self.max_async_level}). No longer scheduling group rollouts. Waiting for trainer to catch up..."
-                        )
-                        was_waiting = True
-                        pbar.set_description("Waiting for trainer")
-                    await asyncio.sleep(0.1)
-                    continue
-                elif was_waiting:
-                    self.logger.info("Async barrier cleared. Resuming rollout generation.")
-                    pbar.set_description("Generating rollouts (train)")
-                    was_waiting = False
-
-                await self.schedule_group_rollout()
-
             finished_group_rollouts, _ = await asyncio.wait(
                 self.inflight_group_rollouts, return_when=asyncio.FIRST_COMPLETED
             )
@@ -204,14 +178,7 @@ class Scheduler:
                     batch_rollouts = batch_rollouts[: self.config.batch_size]
                     break
 
-                # Safely pop the task info. If it returns None, the task was removed externally.
-                # This handles the race condition where update_policy() might have concurrently
-                # cancelled the task and removed it from inflight_group_rollouts.
-                popped_info = self.inflight_group_rollouts.pop(finished_group_rollout, None)
-                if popped_info is None:
-                    continue
-                _, client = popped_info
-
+                _, client = self.inflight_group_rollouts.pop(finished_group_rollout)
                 group_states: list[vf.State] = finished_group_rollout.result()
 
                 self.buffer.update(group_states)
@@ -220,8 +187,7 @@ class Scheduler:
                 batch_rollouts.extend(accepted_rollouts)
                 pbar.update(len(accepted_rollouts))
 
-                if self.async_level <= self.max_async_level:
-                    await self.schedule_group_rollout(client)
+                await self.schedule_group_rollout(client)
 
             self.logger.debug(
                 f"Got {len(batch_rollouts)} rollout(s) in batch. Need {self.config.batch_size - len(batch_rollouts)} more."

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -193,10 +193,7 @@ class Scheduler:
                     pbar.set_description("Generating rollouts (train)")
                     was_waiting = False
 
-                while len(self.inflight_group_rollouts) < self.problems_per_batch:
-                    if self.async_level > self.max_async_level:
-                        break
-                    await self.schedule_group_rollout()
+                await self.schedule_group_rollout()
 
             finished_group_rollouts, _ = await asyncio.wait(
                 self.inflight_group_rollouts, return_when=asyncio.FIRST_COMPLETED


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Our attempt to make the async barrier non-blocking and handle it explicitly in `generate_batch` in #1318 led to significant starvation of inference. For now it is fine to block the event loop at the async barrier, so we revert all PRs associated it, i.e. #1318 and #1372. We add back the safe pop to not reintroduce the cancellation race condition.

Here is a side-by-side comparison before and after (green)

<img width="262" height="229" alt="Screenshot 2025-12-02 at 8 32 27 PM" src="https://github.com/user-attachments/assets/4bd4fbc1-32c3-42e9-9530-e5f4e226a377" />

Some examples from the nightly CI

<img width="257" height="248" alt="Screenshot 2025-12-02 at 6 29 07 PM" src="https://github.com/user-attachments/assets/a48eca29-5f4a-46a2-b68e-4167b1dc1c1e" />

<img width="254" height="233" alt="Screenshot 2025-12-02 at 6 29 26 PM" src="https://github.com/user-attachments/assets/928ff5d5-f470-4dde-8096-4d78fa9d52c8" />

<img width="252" height="235" alt="Screenshot 2025-12-02 at 6 29 46 PM" src="https://github.com/user-attachments/assets/37b9df05-20f9-4833-b775-c05bde627693" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores blocking async barrier by synchronously waiting for checkpoints and removes async-level gating in rollout scheduling.
> 
> - **Orchestrator `scheduler.py`**:
>   - **Policy Update**:
>     - Log when hitting async barrier and synchronously wait for `STABLE` checkpoint using `sync_wait_for_path` (replacing `await wait_for_path`).
>   - **Rollout Generation**:
>     - Remove async-level barrier handling and waiting loops; no longer pause initial fill or progress when ahead.
>     - Always reschedule next group rollout upon completion (unconditionally calls `schedule_group_rollout`).
>   - **Stability**:
>     - Retain safe pop when handling finished tasks to avoid cancellation race conditions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8b5d727d7a0ca986d50e4eddc7d61a34fc0d000. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->