### PR TITLE
[Fix] ac lora

### DIFF
--- a/src/prime_rl/trainer/rl/broadcast/filesystem.py
+++ b/src/prime_rl/trainer/rl/broadcast/filesystem.py
@@ -48,7 +48,9 @@ class FileSystemWeightBroadcast(WeightBroadcast):
 
             # Save weights to shared filesystem
             save_dir = get_step_path(self.broadcast_dir, step)
-            save_state_dict(state_dict, save_dir, self.save_format, self.save_sharded, adapter=adapter_only)
+            save_state_dict(
+                state_dict, save_dir, self.save_format, self.save_sharded and not adapter_only, adapter=adapter_only
+            )
 
             if adapter_only:
                 save_lora_config(self.lora_config, model, save_dir)

--- a/src/prime_rl/trainer/weights.py
+++ b/src/prime_rl/trainer/weights.py
@@ -167,6 +167,6 @@ def get_adapter_state_dict(model: nn.Module, is_master: bool) -> dict[str, Tenso
             lora_state[peft_key] = value.to("cpu", non_blocking=False)
 
     torch.distributed.barrier()
-    if len(lora_state) == 0:
+    if is_master and len(lora_state) == 0:
         raise ValueError("The LoRA state dict is empty. Something went wrong.")
     return lora_state

--- a/src/prime_rl/trainer/weights.py
+++ b/src/prime_rl/trainer/weights.py
@@ -24,6 +24,14 @@ from prime_rl.trainer.lora import (
 )
 from prime_rl.utils.logger import get_logger
 
+PYTORCH_WRAPPER_PREFIXES = ["_fsdp_wrapped_module.", "_orig_module.", "_checkpoint_wrapped_module."]
+
+
+def _strip_pytorch_wrapper_prefix(key: str) -> str:
+    for prefix in PYTORCH_WRAPPER_PREFIXES:
+        key = key.replace(prefix, "")
+    return key
+
 
 def get_max_layer_num(state_dict: dict[str, Tensor]) -> int:
     """Get the maximum number of layers in the model."""
@@ -136,8 +144,9 @@ def get_adapter_state_dict(model: nn.Module, is_master: bool) -> dict[str, Tenso
     """Get adapter weights with clean keys for PEFT compatibility."""
     lora_state = {}
 
+    named_params = {_strip_pytorch_wrapper_prefix(key): value for key, value in model.named_parameters()}
     for key, value in model.state_dict().items():
-        param = dict(model.named_parameters()).get(key)
+        param = named_params.get(key)
         if param is None or not param.requires_grad:
             continue
 

--- a/src/prime_rl/trainer/weights.py
+++ b/src/prime_rl/trainer/weights.py
@@ -167,4 +167,6 @@ def get_adapter_state_dict(model: nn.Module, is_master: bool) -> dict[str, Tenso
             lora_state[peft_key] = value.to("cpu", non_blocking=False)
 
     torch.distributed.barrier()
+    if len(lora_state) == 0:
+        raise ValueError("The LoRA state dict is empty. Something went wrong.")
     return lora_state


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Stops sharding adapter-only checkpoints and fixes LoRA adapter export by stripping wrapper prefixes and validating non-empty state.
> 
> - **Weights/LoRA export**:
>   - Add `_strip_pytorch_wrapper_prefix` to align `named_parameters()` with `state_dict()` keys for LoRA extraction.
>   - Use cleaned param map in `get_adapter_state_dict`; raise if resulting LoRA state is empty.
> - **Broadcast/Filesystem**:
>   - When `adapter_only=True`, save checkpoints unsharded; full-model saves remain sharded per config.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2077fc8f828ff91297c918d74f5fecc694e80711. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->