### PR TITLE
reasoning_parser option; fix wiki-search config

### DIFF
--- a/examples/wiki_search/rl.toml
+++ b/examples/wiki_search/rl.toml
@@ -1,5 +1,5 @@
-inference_gpu_ids = [0,1,2,3,4,5]
-trainer_gpu_ids = [6,7]
+inference_gpu_ids = [0]
+trainer_gpu_ids = [1]
 
 max_steps = 500
 
@@ -33,6 +33,7 @@ batch_size = 512
 rollouts_per_example = 16
 seq_len = 4096
 oversampling_factor = 2.0
+lora_name = "qwen3-4b-wiki-search"
 
 [orchestrator.sampling]
 max_tokens = 512
@@ -42,6 +43,9 @@ online_difficulty_filtering = true
 
 [[orchestrator.env]]
 id = "primeintellect/wiki-search"
+
+[inference]
+enable_lora = true
 
 [inference.model]
 enable_auto_tool_choice = true

--- a/src/prime_rl/inference/config.py
+++ b/src/prime_rl/inference/config.py
@@ -91,6 +91,13 @@ class ModelConfig(BaseConfig):
         ),
     ] = "hermes"
 
+    reasoning_parser: Annotated[
+        str | None,
+        Field(
+            description="Parser for extracting reasoning content from model outputs. Passed to vLLM as `--reasoning-parser`. Setting this enables reasoning mode.",
+        ),
+    ] = None
+
 
 class WeightBroadcastConfig(BaseSettings):
     """Configures weight broadcast settings."""
@@ -162,6 +169,7 @@ class InferenceConfig(BaseSettings):
             "model.trust_remote_code": "trust_remote_code",
             "model.enable_auto_tool_choice": "enable_auto_tool_choice",
             "model.tool_call_parser": "tool_call_parser",
+            "model.reasoning_parser": "reasoning_parser",
             "parallel.tp": "tensor_parallel_size",
             "parallel.dp": "data_parallel_size",
             "enable_lora": "enable_lora",
@@ -174,5 +182,9 @@ class InferenceConfig(BaseSettings):
 
         # Set `logprobs_mode` to `processed_logprobs` by default
         rsetattr(namespace, "logprobs_mode", "processed_logprobs")
+
+        # Remove reasoning_parser if not set (vLLM doesn't accept None)
+        if namespace.reasoning_parser is None:
+            delattr(namespace, "reasoning_parser")
 
         return namespace


### PR DESCRIPTION
- reasoning_parser pass-thru for inference config
- LoRA fields to wiki-search example 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `reasoning_parser` passthrough to inference config and updates the wiki-search example to enable LoRA, set a LoRA name, and simplify GPU IDs.
> 
> - **Inference config (`src/prime_rl/inference/config.py`)**:
>   - Add `model.reasoning_parser` option; map to vLLM and strip if `None`.
> - **Example config (`examples/wiki_search/rl.toml`)**:
>   - Set `inference_gpu_ids = [0]`, `trainer_gpu_ids = [1]`.
>   - Add `orchestrator.lora_name = "qwen3-4b-wiki-search"`.
>   - Add `[inference]` with `enable_lora = true`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 288ead5265043eca134a171af177641e9f00e1b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->