### PR TITLE
correct K2 KL implementation, and apply importance sampling to it

### DIFF
--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -99,7 +99,7 @@ def compute_loss(
             kl_mask = loss_mask
         else:
             raise ValueError(f"Invalid KL mask type: {loss_config.kl_mask_type}")
-	loss = loss + loss_config.kl_tau * (log_importance_ratio[kl_mask].sum().detach() * importance_ratio[kl_mask]).sum()
+        loss = loss + loss_config.kl_tau * (log_importance_ratio[kl_mask].sum().detach() * importance_ratio[kl_mask]).sum()
 
         # Apply sequence-level normalization if configured
         if loss_config.ratio_type == "sequence":


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

This corrects the Kimi K2 KL implementation. 

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: #1390 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjust KL regularizer in `compute_loss` to an importance-sampled K2 KL using a detached summed log-ratio scaled by per-token importance ratios.
> 
> - **RL Loss** (`src/prime_rl/trainer/rl/loss.py`):
>   - Update KL term in `compute_loss` to importance-sampled form: `kl_tau * (log_importance_ratio[kl_mask].sum().detach() * importance_ratio[kl_mask]).sum()` replacing simple sum of `log_importance_ratio`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 761aef48f3b4a7f8d92f7860d412f4fb455651fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->