### PR TITLE
Fix auto-configure LoRA 

### DIFF
--- a/examples/alphabet_sort/rl.toml
+++ b/examples/alphabet_sort/rl.toml
@@ -13,6 +13,8 @@ impl = "liger_kernel"
 freq = 1
 
 [trainer.model.experimental.lora]
+rank = 32
+alpha = 64
 
 [trainer.optim]
 lr = 1e-5

--- a/examples/alphabet_sort/rl.toml
+++ b/examples/alphabet_sort/rl.toml
@@ -13,24 +13,6 @@ impl = "liger_kernel"
 freq = 1
 
 [trainer.model.experimental.lora]
-rank = 32
-alpha = 64
-dropout = 0.0
-target_modules = [
-    "q_proj",
-    "k_proj",
-    "v_proj",
-    "o_proj",
-    "gate_proj",
-    "up_proj",
-    "down_proj"
-]
-modules_to_save = [
-    "embed_tokens",
-    "norm",
-    "layernorm",
-    "lm_head$"
-]
 
 [trainer.optim]
 lr = 1e-5
@@ -44,7 +26,8 @@ seq_len = 2048
 max_tokens = 768
 
 [[orchestrator.env]]
-id = "alphabet-sort"
+id = "primeintellect/alphabet-sort"
+name = "alphabet-sort"
 args = { min_turns = 3, max_turns = 3, min_names_per_turn = 1, max_names_per_turn = 4, similarity_power = 8, power_per_turn = false }
 
 [inference] # Default inference config

--- a/examples/wiki_search/rl.toml
+++ b/examples/wiki_search/rl.toml
@@ -44,9 +44,6 @@ online_difficulty_filtering = true
 [[orchestrator.env]]
 id = "primeintellect/wiki-search"
 
-[inference]
-enable_lora = true
-
 [inference.model]
 enable_auto_tool_choice = true
 tool_call_parser = "hermes"

--- a/src/prime_rl/inference/config.py
+++ b/src/prime_rl/inference/config.py
@@ -126,6 +126,13 @@ class InferenceConfig(BaseSettings):
         ),
     ] = False
 
+    max_lora_rank: Annotated[
+        int | None,
+        Field(
+            description="The maximum LoRA rank to use. Passed to vLLM as `--max-lora-rank`",
+        ),
+    ] = None
+
     gpu_memory_utilization: Annotated[
         float,
         Field(
@@ -173,6 +180,7 @@ class InferenceConfig(BaseSettings):
             "parallel.tp": "tensor_parallel_size",
             "parallel.dp": "data_parallel_size",
             "enable_lora": "enable_lora",
+            "max_lora_rank": "max_lora_rank",
             "gpu_memory_utilization": "gpu_memory_utilization",
         }
 

--- a/src/prime_rl/inference/config.py
+++ b/src/prime_rl/inference/config.py
@@ -151,7 +151,7 @@ class InferenceConfig(BaseSettings):
         return self
 
     @model_validator(mode="after")
-    def set_env_var_for_lora(self):
+    def auto_setup_dynamic_lora_updating(self):
         if self.enable_lora:
             os.environ["VLLM_ALLOW_RUNTIME_LORA_UPDATING"] = "True"
         return self

--- a/src/prime_rl/inference/server.py
+++ b/src/prime_rl/inference/server.py
@@ -1,10 +1,13 @@
 from prime_rl.inference.config import InferenceConfig
-from prime_rl.inference.vllm.server import server
 from prime_rl.utils.pydantic_config import parse_argv
 
 
 def main():
     config = parse_argv(InferenceConfig, allow_extras=True)
+
+    # We import here to be able to set environment variables before importing vLLM
+    from prime_rl.inference.vllm.server import server  # pyright: ignore
+
     server(config, vllm_args=config.get_unknown_args())
 
 

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -3,6 +3,9 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any, Optional
 
+# ruff: noqa
+import vllm.entrypoints.openai.api_server
+
 import uvloop
 import vllm.envs as envs
 from fastapi import Request

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -19,12 +19,13 @@ from vllm.entrypoints.openai.api_server import (
     build_async_engine_client_from_engine_args,
     init_app_state,
     load_log_config,
+    maybe_register_tokenizer_info_endpoint,
     setup_server,
 )
 from vllm.entrypoints.openai.cli_args import make_arg_parser, validate_parsed_serve_args
 from vllm.entrypoints.openai.tool_parsers import ToolParserManager
 from vllm.logger import init_logger
-from vllm.utils import FlexibleArgumentParser
+from vllm.utils import FlexibleArgumentParser, decorate_logs
 
 from prime_rl.inference.config import InferenceConfig
 
@@ -59,6 +60,8 @@ async def custom_build_async_engine_client(
 # Copied from vllm/entrypoints/openai/api_server.py
 # Only difference is that we inject custom routes and build async engine client differently
 async def custom_run_server_worker(listen_address, sock, args, client_config=None, **uvicorn_kwargs) -> None:
+    """Run a single API server worker."""
+
     if args.tool_parser_plugin and len(args.tool_parser_plugin) > 3:
         ToolParserManager.import_tool_parser(args.tool_parser_plugin)
 
@@ -70,6 +73,7 @@ async def custom_run_server_worker(listen_address, sock, args, client_config=Non
         uvicorn_kwargs["log_config"] = log_config
 
     async with custom_build_async_engine_client(args, client_config) as engine_client:
+        maybe_register_tokenizer_info_endpoint(args)
         app = build_app(args)
 
         ### CUSTOM ENDPOINTS ###
@@ -136,7 +140,12 @@ async def custom_run_server_worker(listen_address, sock, args, client_config=Non
 
 # Copied from vllm/entrypoints/openai/api_server.py
 # Only difference is that we call `custom_run_server_worker` instead of `run_server_worker`
-async def custom_run_server(args: Namespace, **uvicorn_kwargs) -> None:
+async def custom_run_server(args, **uvicorn_kwargs) -> None:
+    """Run a single-worker API server."""
+
+    # Add process-specific prefix to stdout and stderr.
+    decorate_logs("APIServer")
+
     listen_address, sock = setup_server(args)
     await custom_run_server_worker(listen_address, sock, args, **uvicorn_kwargs)
 

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -378,7 +378,7 @@ class RLConfig(BaseSettings):
                 self.inference.max_lora_rank = self.trainer.model.experimental.lora.rank
             else:
                 warnings.warn(
-                    "LoRA is enabled, but inference is not configured. When manually starting the inference server, make sure to set `--enable_lora`."
+                    "LoRA is enabled, but inference is not configured. When manually starting the inference server, make sure to set `--enable_lora` and `--max-lora-rank`."
                 )
 
         return self

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -201,6 +201,22 @@ class RLConfig(BaseSettings):
         return self
 
     @model_validator(mode="after")
+    def auto_setup_lora(self):
+        if self.trainer.model.experimental.lora is not None:
+            # Setup orchestrator
+            if self.orchestrator.lora_name is None:
+                self.orchestrator.lora_name = "default"
+            # Setup inference
+            if self.inference is not None:
+                self.inference.enable_lora = True
+            else:
+                warnings.warn(
+                    "LoRA is enabled, but inference is not configured. When manually starting the inference server, make sure to set `--enable_lora`."
+                )
+
+        return self
+
+    @model_validator(mode="after")
     def auto_setup_num_train_workers(self):
         if len(self.trainer_gpu_ids) > 1:
             self.orchestrator.num_train_workers = len(self.trainer_gpu_ids)

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -375,6 +375,7 @@ class RLConfig(BaseSettings):
                 self.orchestrator.lora_name = lora_name
             if self.inference is not None:
                 self.inference.enable_lora = True
+                self.inference.max_lora_rank = self.trainer.model.experimental.lora.rank
             else:
                 warnings.warn(
                     "LoRA is enabled, but inference is not configured. When manually starting the inference server, make sure to set `--enable_lora`."

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -367,6 +367,8 @@ class RLConfig(BaseSettings):
     @model_validator(mode="after")
     def auto_setup_lora(self):
         if self.trainer.model.experimental.lora is not None:
+            if self.trainer.weight_broadcast.type == "nccl":
+                raise ValueError("NCCL weight broadcast does not support LoRA yet.")
             self.trainer.weight_broadcast.adapter_only = True
             if self.orchestrator.lora_name is None:
                 lora_name = (

--- a/src/prime_rl/utils/pydantic_config.py
+++ b/src/prime_rl/utils/pydantic_config.py
@@ -225,6 +225,7 @@ def parse_unknown_args(args: list[str], config_cls: type) -> tuple[list[str], li
             key = args[i][2:]
         else:
             key = args[i][1:]
+        key = key.replace("-", "_")
         if key in known_fields:
             known_args.append(args[i])
             if has_value:


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

This PR enables auto-configuring LoRA from the trainer with `--model.experimental.lora`. It will automatically set up:
- Broadcasting adapter-only weights (on trainer)
- LoRA name which is required for vLLM (on orchestrator)
- Enabling LoRA (including setting env vars) and max rank (on inference, if specified)

Also adapt the `alphabet-sort` and `wiki-search` examples to use these patterns. 

Misc. changes:
- Had to update imports in our custom server extension for dynamic LoRA updating routes to be injected
- Had to update pass-through and vLLM imports for env var `VLLM_ALLOW_RUNTIME_LORA_UPDATING` to be respected

These two changes together now mean that `uv run inference --enable-lora` correctly sets up the inference server to be able to dynamically load/unload adapters.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Auto-configures LoRA across trainer/orchestrator/inference, adds max_lora_rank and server import/registration tweaks, and updates examples.
> 
> - **RL**:
>   - Auto-setup LoRA when `trainer.model.experimental.lora` is set: enable adapter-only broadcast, generate default `orchestrator.lora_name`, propagate `inference.enable_lora` and `inference.max_lora_rank`; disallow NCCL with LoRA.
> - **Inference**:
>   - Add `InferenceConfig.max_lora_rank` and pass through to vLLM.
>   - Automatically enable runtime LoRA updating via env var when `enable_lora` is true.
>   - Delay vLLM server import to apply env vars; add imports/registration for tokenizer endpoint and log decoration.
> - **Server (vLLM extension)**:
>   - Register tokenizer info endpoint, decorate logs, and ensure custom dynamic weight routes run with the async engine client.
> - **CLI/Config utils**:
>   - Normalize CLI keys (`-` to `_`) when separating known/unknown args.
> - **Examples**:
>   - `alphabet_sort`: switch env id to `primeintellect/alphabet-sort`, add `name`, and simplify LoRA config.
>   - `wiki_search`: remove manual `[inference] enable_lora` (now auto), keep tool-choice settings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e968412cde0dfeb5a1ca1f40c655250a9d5a791. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->