### PR TITLE
[Fix] patch vllm statslogger to be ok with lora dp and helm chart to support multi-client for inference replicas

### DIFF
--- a/k8s/prime-rl/examples/reverse-text.yaml
+++ b/k8s/prime-rl/examples/reverse-text.yaml
@@ -11,7 +11,7 @@ image:
 orchestrator:
   enabled: true
   autoStart: true
-  command: "uv run orchestrator @ /app/examples/reverse_text/rl/orch.toml --output-dir /data/outputs --client.base-url '[\"'$INFERENCE_URL'\"]' ; sleep infinity"
+  command: "uv run orchestrator @ /app/examples/reverse_text/rl/orch.toml --output-dir /data/outputs --client.base-url $INFERENCE_URL ; sleep infinity"
   resources:
     requests:
       memory: "1Gi"

--- a/k8s/prime-rl/templates/deployment.yaml
+++ b/k8s/prime-rl/templates/deployment.yaml
@@ -64,14 +64,14 @@ spec:
         - name: INFERENCE_URL
           {{- $releaseName := .Release.Name }}
           {{- $namespace := .Values.namespace }}
-          {{- $port := .Values.inference.service.port }}
+          {{- $port := int .Values.inference.service.port }}
           {{- $replicas := int .Values.inference.replicas }}
           {{- $urls := list }}
           {{- range $i := until $replicas }}
           {{- $url := printf "http://%s-inference-%d.%s-inference-headless.%s.svc.cluster.local:%d/v1" $releaseName $i $releaseName $namespace $port }}
           {{- $urls = append $urls $url }}
           {{- end }}
-          value: {{ $urls | toJson | quote }}
+          value: {{ $urls | join "," | quote }}
         {{- with .Values.orchestrator.env }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -274,14 +274,14 @@ spec:
         - name: INFERENCE_URL
           {{- $releaseName := .Release.Name }}
           {{- $namespace := .Values.namespace }}
-          {{- $port := .Values.inference.service.port }}
+          {{- $port := int .Values.inference.service.port }}
           {{- $replicas := int .Values.inference.replicas }}
           {{- $urls := list }}
           {{- range $i := until $replicas }}
           {{- $url := printf "http://%s-inference-%d.%s-inference-headless.%s.svc.cluster.local:%d/v1" $releaseName $i $releaseName $namespace $port }}
           {{- $urls = append $urls $url }}
           {{- end }}
-          value: {{ $urls | toJson | quote }}
+          value: {{ $urls | join "," | quote }}
         {{- with .Values.trainer.env }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/k8s/prime-rl/templates/deployment.yaml
+++ b/k8s/prime-rl/templates/deployment.yaml
@@ -62,7 +62,16 @@ spec:
         - name: HEADLESS_SERVICE
           value: "{{ .Release.Name }}-orchestrator-headless.{{ .Values.namespace }}.svc.cluster.local"
         - name: INFERENCE_URL
-          value: "http://{{ .Release.Name }}-inference-0.{{ .Release.Name }}-inference-headless.{{ .Values.namespace }}.svc.cluster.local:8000/v1"
+          {{- $releaseName := .Release.Name }}
+          {{- $namespace := .Values.namespace }}
+          {{- $port := .Values.inference.service.port }}
+          {{- $replicas := int .Values.inference.replicas }}
+          {{- $urls := list }}
+          {{- range $i := until $replicas }}
+          {{- $url := printf "http://%s-inference-%d.%s-inference-headless.%s.svc.cluster.local:%d/v1" $releaseName $i $releaseName $namespace $port }}
+          {{- $urls = append $urls $url }}
+          {{- end }}
+          value: {{ $urls | toJson | quote }}
         {{- with .Values.orchestrator.env }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -263,7 +272,16 @@ spec:
         - name: HEADLESS_SERVICE
           value: "{{ .Release.Name }}-trainer-headless.{{ .Values.namespace }}.svc.cluster.local"
         - name: INFERENCE_URL
-          value: "http://{{ .Release.Name }}-inference-0.{{ .Release.Name }}-inference-headless.{{ .Values.namespace }}.svc.cluster.local:8000/v1"
+          {{- $releaseName := .Release.Name }}
+          {{- $namespace := .Values.namespace }}
+          {{- $port := .Values.inference.service.port }}
+          {{- $replicas := int .Values.inference.replicas }}
+          {{- $urls := list }}
+          {{- range $i := until $replicas }}
+          {{- $url := printf "http://%s-inference-%d.%s-inference-headless.%s.svc.cluster.local:%d/v1" $releaseName $i $releaseName $namespace $port }}
+          {{- $urls = append $urls $url }}
+          {{- end }}
+          value: {{ $urls | toJson | quote }}
         {{- with .Values.trainer.env }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/k8s/prime-rl/values.yaml
+++ b/k8s/prime-rl/values.yaml
@@ -28,8 +28,9 @@ orchestrator:
 
   # Auto-start configuration (set to false to use sleep infinity for debugging)
   autoStart: false
-  command: ""  # e.g., "uv run orchestrator @ /app/examples/reverse_text/rl/orch.toml --output-dir /data/outputs --client.base-url '$INFERENCE_URL'"
-  # Note: $INFERENCE_URL is a JSON array of all inference server URLs, e.g., '["http://<release>-inference-0...:8000/v1","http://<release>-inference-1...:8000/v1"]'
+  # Example command - use $INFERENCE_URL directly (comma-separated list of all inference server URLs)
+  command: ""  # e.g., 'uv run orchestrator @ /app/examples/reverse_text/rl/orch.toml --output-dir /data/outputs --client.base-url $INFERENCE_URL'
+  # $INFERENCE_URL is auto-set to: 'http://<release>-inference-0...:8000/v1,http://<release>-inference-1...:8000/v1,...'
 
   resources:
     requests:

--- a/k8s/prime-rl/values.yaml
+++ b/k8s/prime-rl/values.yaml
@@ -28,8 +28,8 @@ orchestrator:
 
   # Auto-start configuration (set to false to use sleep infinity for debugging)
   autoStart: false
-  command: ""  # e.g., "uv run orchestrator @ /app/examples/reverse_text/rl/orch.toml --output-dir /data/outputs --client.base-url '[\"'$INFERENCE_URL'\"]'"
-  # Note: $INFERENCE_URL is automatically set to http://<release-name>-inference-0.<release-name>-inference-headless.<namespace>.svc.cluster.local:8000/v1
+  command: ""  # e.g., "uv run orchestrator @ /app/examples/reverse_text/rl/orch.toml --output-dir /data/outputs --client.base-url '$INFERENCE_URL'"
+  # Note: $INFERENCE_URL is a JSON array of all inference server URLs, e.g., '["http://<release>-inference-0...:8000/v1","http://<release>-inference-1...:8000/v1"]'
 
   resources:
     requests:

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -1,0 +1,32 @@
+# Monkeypatch PrometheusStatLogger to avoid NotImplementedError for LoRA in DP mode
+def monkey_patch_prometheus_stat_logger_for_lora_in_dp_mode():
+    from vllm.v1.metrics import loggers as vllm_metrics_loggers
+
+    _original_prometheus_stat_logger_init = vllm_metrics_loggers.PrometheusStatLogger.__init__
+
+    def _patched_prometheus_stat_logger_init(self, vllm_config, engine_indexes=None):
+        """Patched init that temporarily disables lora_config to skip the DP mode check."""
+        original_lora_config = vllm_config.lora_config
+        vllm_config.lora_config = None
+        try:
+            _original_prometheus_stat_logger_init(self, vllm_config, engine_indexes)
+        finally:
+            vllm_config.lora_config = original_lora_config
+        # Re-initialize LoRA metrics if needed (after the DP check is bypassed)
+        if original_lora_config is not None:
+            self.labelname_max_lora = "max_lora"
+            self.labelname_waiting_lora_adapters = "waiting_lora_adapters"
+            self.labelname_running_lora_adapters = "running_lora_adapters"
+            self.max_lora = original_lora_config.max_loras
+            self.gauge_lora_info = vllm_metrics_loggers.PrometheusStatLogger._gauge_cls(
+                name="vllm:lora_requests_info",
+                documentation="Running stats on lora requests.",
+                multiprocess_mode="sum",
+                labelnames=[
+                    self.labelname_max_lora,
+                    self.labelname_waiting_lora_adapters,
+                    self.labelname_running_lora_adapters,
+                ],
+            )
+
+    vllm_metrics_loggers.PrometheusStatLogger.__init__ = _patched_prometheus_stat_logger_init

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -3,6 +3,11 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any, Optional
 
+from prime_rl.inference.patches import monkey_patch_prometheus_stat_logger_for_lora_in_dp_mode
+
+# Monkeypatch PrometheusStatLogger to avoid NotImplementedError for LoRA in DP mode
+monkey_patch_prometheus_stat_logger_for_lora_in_dp_mode()
+
 # ruff: noqa
 import vllm.entrypoints.openai.api_server
 

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -131,10 +131,6 @@ class RLConfig(BaseSettings):
     inference_gpu_ids: Annotated[list[int], Field(description="The GPU IDs to use for inference.")] = [0]
     trainer_gpu_ids: Annotated[list[int], Field(description="The GPU IDs to use for trainer.")] = [1]
 
-    # Computed at runtime - number of inference servers to spawn
-    _num_inference_servers: int = 1
-    _inference_ports: list[int] = []
-
     ### Shared configurations
 
     output_dir: Annotated[
@@ -197,18 +193,11 @@ class RLConfig(BaseSettings):
 
     @model_validator(mode="after")
     def auto_setup_dp(self):
-        """
-        Instead of using VLLM's internal DP, we spawn multiple independent inference servers.
-        Each server has DP=1, and we calculate how many servers to spawn based on the GPU count.
-        """
-        if self.inference:
+        if self.inference and len(self.inference_gpu_ids) != self.inference.parallel.dp * self.inference.parallel.tp:
             assert len(self.inference_gpu_ids) % self.inference.parallel.tp == 0, (
                 "Number of inference GPUs must be divisible by the tensor parallel size"
             )
-            # Calculate number of servers to spawn (this is our "external DP")
-            self._num_inference_servers = len(self.inference_gpu_ids) // self.inference.parallel.tp
-            # Force VLLM DP to 1 - we handle parallelism by spawning multiple servers
-            self.inference.parallel.dp = 1
+            self.inference.parallel.dp = len(self.inference_gpu_ids) // self.inference.parallel.tp
         return self
 
     @model_validator(mode="after")
@@ -358,8 +347,7 @@ class RLConfig(BaseSettings):
     def auto_setup_weight_broadcast(self):
         if self.weight_broadcast is not None:
             if self.weight_broadcast.type == "nccl":
-                # Use _num_inference_servers * tp for total inference world size
-                inference_world_size = self._num_inference_servers * self.inference.parallel.tp if self.inference else 1
+                inference_world_size = self.inference.parallel.dp * self.inference.parallel.tp if self.inference else 1
                 self.trainer.weight_broadcast = TrainerNCCLWeightBroadcastConfig(
                     type=self.weight_broadcast.type, inference_world_size=inference_world_size
                 )
@@ -461,18 +449,6 @@ def rl(config: RLConfig):
     logger.info("Starting RL run")
     logger.debug(f"RL start command: {' '.join(start_command)}")
 
-    # Pre-allocate ports for all inference servers and configure orchestrator client
-    if config.inference:
-        base_port = config.inference.server.port
-        config._inference_ports = [base_port + i for i in range(config._num_inference_servers)]
-
-        # Auto-configure orchestrator client to connect to all inference servers
-        host = config.inference.server.host or "localhost"
-        config.orchestrator.client.base_url = [f"http://{host}:{port}/v1" for port in config._inference_ports]
-        logger.info(
-            f"Configured {config._num_inference_servers} inference server(s) at ports: {config._inference_ports}"
-        )
-
     # Prepare paths to communicate with the trainer
     log_dir = get_log_dir(config.output_dir)
     rollout_dir = get_rollout_dir(config.output_dir)
@@ -508,55 +484,35 @@ def rl(config: RLConfig):
     stop_events: dict[str, Event] = {}
 
     try:
-        # Optionally, start inference process(es)
+        # Optionally, start inference process
         if config.inference:
-            tp = config.inference.parallel.tp
-            num_servers = config._num_inference_servers
+            inference_file = get_temp_toml_file()
+            with open(inference_file, "wb") as f:
+                tomli_w.dump(config.inference.model_dump(exclude_none=True, mode="json"), f)
 
-            for server_idx in range(num_servers):
-                # Create a copy of the inference config with updated port
-                server_config = config.inference.model_copy(deep=True)
-                server_config.server.port = config._inference_ports[server_idx]
-
-                inference_file = get_temp_toml_file()
-                with open(inference_file, "wb") as f:
-                    tomli_w.dump(server_config.model_dump(exclude_none=True, mode="json"), f)
-
-                # Assign GPUs for this server based on TP
-                gpu_start = server_idx * tp
-                gpu_end = gpu_start + tp
-                server_gpu_ids = config.inference_gpu_ids[gpu_start:gpu_end]
-
-                inference_cmd = ["uv", "run", "inference", "@", inference_file.as_posix()]
-                logger.info(
-                    f"Starting inference server {server_idx + 1}/{num_servers} on GPU(s) "
-                    f"{' '.join(map(str, server_gpu_ids))} at port {server_config.server.port}"
+            inference_cmd = ["uv", "run", "inference", "@", inference_file.as_posix()]
+            logger.info(f"Starting inference process on GPU(s) {' '.join(map(str, config.inference_gpu_ids))}")
+            logger.debug(f"Inference start command: {' '.join(inference_cmd)}")
+            # If we don't log stdout, the server hangs
+            with open(log_dir / "inference.stdout", "w") as log_file:
+                inference_process = Popen(
+                    inference_cmd,
+                    env={**os.environ, "CUDA_VISIBLE_DEVICES": ",".join(map(str, config.inference_gpu_ids))},
+                    stdout=log_file,
+                    stderr=log_file,
                 )
-                logger.debug(f"Inference start command: {' '.join(inference_cmd)}")
+            processes.append(inference_process)
 
-                # If we don't log stdout, the server hangs
-                log_suffix = f".{server_idx}" if num_servers > 1 else ""
-                with open(log_dir / f"inference{log_suffix}.stdout", "w") as log_file:
-                    inference_process = Popen(
-                        inference_cmd,
-                        env={**os.environ, "CUDA_VISIBLE_DEVICES": ",".join(map(str, server_gpu_ids))},
-                        stdout=log_file,
-                        stderr=log_file,
-                    )
-                processes.append(inference_process)
-
-                # Start monitoring thread for this inference server
-                stop_event = Event()
-                stop_events[f"inference_{server_idx}"] = stop_event
-                monitor_thread = Thread(
-                    target=monitor_process,
-                    args=(inference_process, stop_event, error_queue, f"inference_{server_idx}"),
-                    daemon=True,
-                )
-                monitor_thread.start()
-                monitor_threads.append(monitor_thread)
-
-            logger.info(f"Started {num_servers} inference server(s)")
+            # Start monitoring thread
+            stop_event = Event()
+            stop_events["inference"] = stop_event
+            monitor_thread = Thread(
+                target=monitor_process,
+                args=(inference_process, stop_event, error_queue, "inference"),
+                daemon=True,
+            )
+            monitor_thread.start()
+            monitor_threads.append(monitor_thread)
         else:
             logger.warning(
                 "No inference config specified, skipping starting inference server. Is your inference server running?"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Builds INFERENCE_URL as a comma-separated list of all inference replicas and applies a vLLM Prometheus logger monkeypatch to enable LoRA in DP mode.
> 
> - **Kubernetes/Helm**:
>   - `INFERENCE_URL` for `orchestrator` and `trainer` now expands to all inference replicas (comma-separated), instead of a single pod URL, using values from `inference.service.port` and `inference.replicas` in `templates/deployment.yaml`.
>   - Example `reverse-text.yaml` updated to pass `--client.base-url $INFERENCE_URL` (no JSON quoting); `values.yaml` docs updated accordingly.
> - **Inference Server**:
>   - New `src/prime_rl/inference/patches.py` monkeypatches `vllm.v1.metrics.loggers.PrometheusStatLogger` to bypass LoRA DP mode check and reinitialize LoRA metrics.
>   - `src/prime_rl/inference/vllm/server.py` imports and applies the monkeypatch at startup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 642bed2a0fb444f9f4cb0f4b190dd9c70ebb2e7c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->