### PR TITLE
chore: allow setting trainer packing len independently of max context

### DIFF
--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -598,10 +598,10 @@ def setup_dataset(
 
 def setup_dataloader(dataset: StatefulIterableDataset, config: DataConfigType) -> StatefulDataLoader:
     if config.pack_function == "stack":
-        stacking_dataset = StackDataset(dataset, config.seq_len * config.micro_batch_size)
+        stacking_dataset = StackDataset(dataset, config.packing_seq_len * config.micro_batch_size)
         return StatefulDataLoader(stacking_dataset, batch_size=1, collate_fn=stack_collate)
     elif config.pack_function == "cat":
-        packing_dataset = CatDataset(dataset, config.seq_len * config.micro_batch_size)
+        packing_dataset = CatDataset(dataset, config.packing_seq_len * config.micro_batch_size)
         return StatefulDataLoader(packing_dataset, batch_size=1, collate_fn=cat_collate)
     else:
         raise ValueError(f"Invalid pack function: {config.pack_function}")

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -74,7 +74,7 @@ def train(config: SFTTrainerConfig):
     torch.set_float32_matmul_precision("high")
 
     # Initialize parallel dimensions
-    parallel_dims = get_parallel_dims(config.model, config.data.seq_len)
+    parallel_dims = get_parallel_dims(config.model, config.data.packing_seq_len)
 
     total_micro_batches = config.data.batch_size * config.model.cp * config.model.tp
     micro_batches_per_step = world.world_size * config.data.micro_batch_size
@@ -287,10 +287,10 @@ def train(config: SFTTrainerConfig):
 
         # Compute step metrics
         # Divide by CP and TP since those ranks process the same data
-        num_tokens = config.data.batch_size * config.data.seq_len // (config.model.cp * config.model.tp)
+        num_tokens = config.data.batch_size * config.data.packing_seq_len // (config.model.cp * config.model.tp)
         progress.total_tokens += num_tokens
         progress.total_samples = dataset.step
-        perf_counter = get_perf_counter(model, config.data.seq_len)
+        perf_counter = get_perf_counter(model, config.data.packing_seq_len)
         perf_counter.count_tokens(num_tokens)
         throughput = perf_counter.get_tokens_per_second() or 0
         mfu = perf_counter.get_mfu() or 0


### PR DESCRIPTION
- Separates `packing_seq_len` from `seq_len` in `BaseDataConfig` to allow controlling the packed batch sequence length independently of the context window used for filtering/validation. `packing_seq_len` defaults to `seq_len` if not specified.
- Updated `setup_dataloader` and `train` loop to use `packing_seq_len` for tensor operations while keeping `seq_len` for dataset operations.

**GitHub Issue**: https://github.com/PrimeIntellect-ai/prime-rl/issues/1376

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `packing_seq_len` (defaults to `seq_len`) and use it for packing datasets and training metrics, with stack-mode validation.
> 
> - **Config**:
>   - Add `data.packing_seq_len` (defaults to `seq_len`) with resolver.
>   - Validate `packing_seq_len % 256 == 0` when `pack_function == "stack"`.
> - **Data Loading**:
>   - Use `packing_seq_len * micro_batch_size` for `StackDataset` and `CatDataset` in `setup_dataloader`.
> - **Training**:
>   - Use `packing_seq_len` for `get_parallel_dims`, perf counter init, and token counting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8679047ab14863c6a384f54c4574f5daabe4622. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->