### PR TITLE
feat(data): nested per-subset splits with ratio validation (closes #1029)

### DIFF
--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -557,21 +557,22 @@ def setup_dataset(
         probabilities = None
         
         if config.subsets is not None and isinstance(config.subsets, dict):
-            # NEW nested format: subsets = {"subset_name": {"split_name": probability, ...}, ...}
+            # NEW nested format: subsets = {"subset_name": {"split_name": weight, ...}, ...}
+            # Weights are relative and normalized globally across all subset-split combinations
             logger.debug(f"Loading datasets using nested format: {config.subsets}")
             for subset_name, split_dict in config.subsets.items():
-                for split_name, prob in split_dict.items():
+                for split_name, weight in split_dict.items():
                     subsets_and_splits.append((subset_name, split_name))
-            # Probabilities are now embedded in the nested dict
-            # Extract them in the same order as subsets_and_splits
+            # Extract weights in the same order as subsets_and_splits
             probabilities = []
             for subset_name, split_dict in config.subsets.items():
-                for split_name, prob in split_dict.items():
-                    probabilities.append(prob)
-            # Normalize probabilities if they don't sum to 1.0
+                for split_name, weight in split_dict.items():
+                    probabilities.append(weight)
+            # Normalize probabilities globally
             total = sum(probabilities)
-            if total > 0 and abs(total - 1.0) > 1e-6:
+            if total > 0:
                 probabilities = [p / total for p in probabilities]
+                logger.debug(f"Normalized sampling probabilities: {probabilities}")
         elif config.old_subsets is None and config.splits is None:
             # No subsets or splits specified - use default
             subsets_and_splits = [(None, "train")]


### PR DESCRIPTION
Closes #1029

Replaces fragile flat lists (`subsets`/`splits`/`probabilities`) with a clean nested dictionary:

```toml
subsets = {
  wiki  = { train = 0.80, test = 0.20 }
  news  = { train = 0.95, val  = 0.05 }
}

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds nested `subsets` config `{subset: {split: weight}}` with validation and global probability normalization, while keeping backward-compatible flat fields; updates dataset setup to handle both formats.
> 
> - **Data loading/config (SFT)**:
>   - Introduce nested `subsets: {subset: {split: weight}}` with validation (non-empty, positive weights) and clearer field docs.
>   - Deprecate flat fields `subsets`/`splits`/`probabilities` (kept as `old_subsets`, `splits`, `probabilities`) and emit a warning when used.
>   - Update `setup_dataset` to parse nested format, build `[(subset, split)]`, and normalize sampling probabilities globally; retain old-format paths.
>   - Minor doc string improvements for `stopping_strategy`, `shuffle`, and `seed`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4f71f261b43e9410a3ca9eaa878a4f890ee3a3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->