### PR TITLE
Flatten state inputs + log env hub URL

### DIFF
--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -214,7 +214,9 @@ async def run_eval(
             # Finalize evaluation
             await evals_client.finalize_evaluation(eval_id, metrics=eval_metrics)
 
-            logger.info(f"Pushed eval results for {env_id} to Environment Hub (eval_id: {eval_id})")
+            logger.info(
+                f"Pushed eval results for {env_id} to Environments Hub (https://app.primeintellect.ai/dashboard/evaluations/{eval_id})"
+            )
 
 
 async def run_evals(

--- a/src/prime_rl/utils/vf.py
+++ b/src/prime_rl/utils/vf.py
@@ -132,6 +132,8 @@ def from_serializable_state(serializable_state: dict) -> vf.State:
     # Reverse of the logic in `to_serializable_state`
     for field in state.INPUT_FIELDS:
         if field in state:
+            if "input" not in state:
+                state["input"] = {}
             state["input"][field] = state.pop(field)
 
     if "trajectory" in state:

--- a/src/prime_rl/utils/vf.py
+++ b/src/prime_rl/utils/vf.py
@@ -1,6 +1,6 @@
 import asyncio
 from itertools import cycle
-from typing import cast
+from typing import Any, cast
 
 import verifiers as vf
 from openai import AsyncOpenAI
@@ -113,11 +113,13 @@ def to_serializable_state(state: vf.State) -> dict:
     """Returns a serializable copy of vf.State."""
     serializable_state = cast(dict, state.copy())
 
-    # This is a little bit of a hacky workaround to accommodate verifier's backwards compatibility with the old state object. Because we serialize, we cannot forward inputs anymore, so we populate the flatten input fields into the serialized state as-is
+    # Flatten input fields to top level for serialization
+    # This is necessary because the dict object cannot forward access to input fields anymore, e.g. state["prompt"] will automatically forward to state["input"]["prompt"] in vf.State but not in dict. We solve this by populating the inputs into the top-level explicitly
     if "input" in state:
-        input = serializable_state.pop("input")
-        for field, value in input.items():
-            serializable_state[field] = value
+        input_dict = serializable_state.pop("input")
+        for field in vf.State.INPUT_FIELDS:
+            if field in input_dict:
+                serializable_state[field] = input_dict[field]
 
     if "trajectory" in state:
         serializable_state["trajectory"] = [to_serializable_trajectory_step(step) for step in state["trajectory"]]
@@ -127,14 +129,16 @@ def to_serializable_state(state: vf.State) -> dict:
 
 def from_serializable_state(serializable_state: dict) -> vf.State:
     """Inverse of to_serializable_state."""
-    state = vf.State(**serializable_state)
+    # Extract input fields from top level and reconstruct input dict
+    input_dict: dict[str, Any] = {}
+    for field in vf.State.INPUT_FIELDS:
+        if field in serializable_state:
+            input_dict[field] = serializable_state.pop(field)
 
-    # Reverse of the logic in `to_serializable_state`
-    for field in state.INPUT_FIELDS:
-        if field in state:
-            if "input" not in state:
-                state["input"] = {}
-            state["input"][field] = state.pop(field)
+    if input_dict:
+        serializable_state["input"] = input_dict
+
+    state = vf.State(**serializable_state)
 
     if "trajectory" in state:
         state["trajectory"] = [from_serializable_trajectory_step(step) for step in state["trajectory"]]


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Flatten `vf.State` input fields during serialization and restore them on deserialization; update eval logging to include Environments Hub URL.
> 
> - **Serialization/Deserialization (`src/prime_rl/utils/vf.py`)**:
>   - Flatten `vf.State` input fields from `state["input"]` to top-level in `to_serializable_state`.
>   - Reconstruct `state["input"]` from top-level fields in `from_serializable_state`.
>   - Preserve trajectory (de)serialization, validating `ChatCompletion` responses.
>   - Minor typing/param tweaks (import `Any`; rename arg for clarity).
> - **Eval Logging (`src/prime_rl/eval/utils.py`)**:
>   - Update log to reference "Environments Hub" and include evaluation URL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12fb006423132389e149f3cdbc57b58ff08f593a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->