### PR TITLE
swap gpu testrunner

### DIFF
--- a/.github/workflows/gpu_tests.yaml
+++ b/.github/workflows/gpu_tests.yaml
@@ -15,8 +15,8 @@ jobs:
     name: Unit tests
     runs-on: vm-runner
     container:
-      image: pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel
-      options: --gpus all
+      image: nvcr.io/nvidia/pytorch:25.11-py3
+      options: --gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864
     timeout-minutes: 45
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     steps:
@@ -55,8 +55,8 @@ jobs:
     name: Integration tests
     runs-on: vm-runner
     container:
-      image: pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel
-      options: --gpus all
+      image: nvcr.io/nvidia/pytorch:25.11-py3
+      options: --gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864
     timeout-minutes: 60
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     steps:

--- a/.github/workflows/gpu_tests.yaml
+++ b/.github/workflows/gpu_tests.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Unit tests
     runs-on: vm-runner
     container:
-      image: pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel
+      image: pytorch/pytorch:2.8.0-cuda12.8-cudnn9-devel
       options: --gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864
       env:
         NVIDIA_DRIVER_CAPABILITIES: all
@@ -57,7 +57,7 @@ jobs:
     name: Integration tests
     runs-on: vm-runner
     container:
-      image: pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel
+      image: pytorch/pytorch:2.8.0-cuda12.8-cudnn9-devel
       options: --gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864
       env:
         NVIDIA_DRIVER_CAPABILITIES: all

--- a/.github/workflows/gpu_tests.yaml
+++ b/.github/workflows/gpu_tests.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Unit tests
     runs-on: vm-runner
     container:
-      image: nvcr.io/nvidia/pytorch:25.11-py3
+      image: nvcr.io/nvidia/pytorch:25.05-py3
       options: --gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864
     timeout-minutes: 45
     if: github.event_name == 'push' || github.event.pull_request.draft == false
@@ -55,7 +55,7 @@ jobs:
     name: Integration tests
     runs-on: vm-runner
     container:
-      image: nvcr.io/nvidia/pytorch:25.11-py3
+      image: nvcr.io/nvidia/pytorch:25.05-py3
       options: --gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864
     timeout-minutes: 60
     if: github.event_name == 'push' || github.event.pull_request.draft == false

--- a/.github/workflows/gpu_tests.yaml
+++ b/.github/workflows/gpu_tests.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Unit tests
     runs-on: vm-runner
     container:
-      image: pytorch/pytorch:2.8.0-cuda12.8-cudnn9-devel
+      image: pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel
       options: --gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864
       env:
         NVIDIA_DRIVER_CAPABILITIES: all
@@ -57,7 +57,7 @@ jobs:
     name: Integration tests
     runs-on: vm-runner
     container:
-      image: pytorch/pytorch:2.8.0-cuda12.8-cudnn9-devel
+      image: pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel
       options: --gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864
       env:
         NVIDIA_DRIVER_CAPABILITIES: all

--- a/.github/workflows/gpu_tests.yaml
+++ b/.github/workflows/gpu_tests.yaml
@@ -17,6 +17,8 @@ jobs:
     container:
       image: pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel
       options: --gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864
+      env:
+        NVIDIA_DRIVER_CAPABILITIES: all
     timeout-minutes: 45
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     steps:
@@ -57,6 +59,8 @@ jobs:
     container:
       image: pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel
       options: --gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864
+      env:
+        NVIDIA_DRIVER_CAPABILITIES: all
     timeout-minutes: 60
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     steps:

--- a/.github/workflows/gpu_tests.yaml
+++ b/.github/workflows/gpu_tests.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Unit tests
     runs-on: vm-runner
     container:
-      image: nvcr.io/nvidia/pytorch:25.05-py3
+      image: pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel
       options: --gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864
       env:
         NVIDIA_DRIVER_CAPABILITIES: all
@@ -57,7 +57,7 @@ jobs:
     name: Integration tests
     runs-on: vm-runner
     container:
-      image: nvcr.io/nvidia/pytorch:25.05-py3
+      image: pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel
       options: --gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864
       env:
         NVIDIA_DRIVER_CAPABILITIES: all

--- a/.github/workflows/gpu_tests.yaml
+++ b/.github/workflows/gpu_tests.yaml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   unit-tests:
     name: Unit tests
-    runs-on: vm
+    runs-on: vm-runner
     container:
       image: pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel
       options: --gpus all
@@ -53,7 +53,7 @@ jobs:
 
   integration-tests:
     name: Integration tests
-    runs-on: vm
+    runs-on: vm-runner
     container:
       image: pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel
       options: --gpus all

--- a/.github/workflows/gpu_tests.yaml
+++ b/.github/workflows/gpu_tests.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Unit tests
     runs-on: vm-runner
     container:
-      image: pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel
+      image: nvcr.io/nvidia/pytorch:25.05-py3
       options: --gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864
       env:
         NVIDIA_DRIVER_CAPABILITIES: all
@@ -57,7 +57,7 @@ jobs:
     name: Integration tests
     runs-on: vm-runner
     container:
-      image: pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel
+      image: nvcr.io/nvidia/pytorch:25.05-py3
       options: --gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864
       env:
         NVIDIA_DRIVER_CAPABILITIES: all

--- a/.github/workflows/gpu_tests.yaml
+++ b/.github/workflows/gpu_tests.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Unit tests
     runs-on: vm-runner
     container:
-      image: nvcr.io/nvidia/pytorch:25.05-py3
+      image: pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel
       options: --gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864
     timeout-minutes: 45
     if: github.event_name == 'push' || github.event.pull_request.draft == false
@@ -55,7 +55,7 @@ jobs:
     name: Integration tests
     runs-on: vm-runner
     container:
-      image: nvcr.io/nvidia/pytorch:25.05-py3
+      image: pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel
       options: --gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864
     timeout-minutes: 60
     if: github.event_name == 'push' || github.event.pull_request.draft == false


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches GPU CI to run on vm-runner using nvcr.io/nvidia/pytorch:25.05-py3 with enhanced GPU container options and env.
> 
> - **CI/GitHub Actions**:
>   - **GPU tests workflow** (`.github/workflows/gpu_tests.yaml`):
>     - Runner: `vm` → `vm-runner`.
>     - Container image: `pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel` → `nvcr.io/nvidia/pytorch:25.05-py3`.
>     - Container options: add `--ipc=host`, `--ulimit memlock=-1`, `--ulimit stack=67108864` (retains `--gpus all`).
>     - Environment: set `NVIDIA_DRIVER_CAPABILITIES=all`.
>     - Applied to both `unit-tests` and `integration-tests` jobs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit baed8698a9b62518e80d0b635ebacf119bc8a36c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->