### PR TITLE
Add geo-rs and some other rl algo options

### DIFF
--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -22,9 +22,13 @@ class LossConfig(BaseConfig):
 
     ratio_type: Annotated[Literal["token", "sequence"], Field(description="Type of importance ratio to use.")] = "token"
 
-    mask_ratio_high: Annotated[float, Field(ge=0)] = 8.0
-    mask_ratio_low: Annotated[float, Field(ge=0)] = 0.125
-    sequence_mask_ratio_low: Annotated[
+    token_mask_high: Annotated[float, Field(ge=0)] = 8.0
+    token_mask_low: Annotated[float, Field(ge=0)] = 0.125
+    sequence_clip_high: Annotated[float, Field(ge=0)] = 10.0
+    geo_mask_high: Annotated[float, Field(ge=0)] = 10.0
+    geo_mask_low: Annotated[float, Field(ge=0)] = 0.1
+    kl_tau: Annotated[float, Field(ge=0)] = 0.0
+    sequence_mask_low: Annotated[
         float,
         Field(
             ge=0,
@@ -33,8 +37,15 @@ class LossConfig(BaseConfig):
             ),
         ),
     ] = 0.0
-    kl_tau: Annotated[float, Field(ge=0)] = 0.0
-    kl_mask_type: Annotated[Literal["masked", "unmasked", "all"], Field(description="Type of KL mask to use.")] = "all"
+    sequence_mask_high: Annotated[
+        float,
+        Field(
+            ge=0,
+            description=(
+                "If set, masks entire sequences when any generated token has an importance ratio above this value."
+            ),
+        ),
+    ] = 100.0
 
 
 class FakeDataLoaderConfig(BaseConfig):
@@ -132,7 +143,7 @@ class RLTrainerConfig(BaseSettings):
         int,
         Field(
             ge=0,
-            description="Maximum number of steps that inference can be ahead of training. Determines how 'off-policy' the inference engines can be. Higher values yield better throughput through async execution, but may yield lower powerofrmance. If 0, will be fully synchronous.",
+            description="Maximum number of steps that inference can be ahead of training. Determines how 'off-policy' the inference engines can be. Higher values yield better throughput through async execution, but may yield lower performance. If 0, will be fully synchronous.",
         ),
     ] = 1
 

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -22,29 +22,23 @@ class LossConfig(BaseConfig):
 
     ratio_type: Annotated[Literal["token", "sequence"], Field(description="Type of importance ratio to use.")] = "token"
 
-    token_mask_high: Annotated[float, Field(ge=0)] = 8.0
-    token_mask_low: Annotated[float, Field(ge=0)] = 0.125
-    sequence_clip_high: Annotated[float, Field(ge=0)] = 10.0
-    geo_mask_high: Annotated[float, Field(ge=0)] = 10.0
-    geo_mask_low: Annotated[float, Field(ge=0)] = 0.1
-    kl_tau: Annotated[float, Field(ge=0)] = 0.0
+    token_mask_high: Annotated[
+        float, 
+        Field(ge=0, description="The high threshold for token importance ratio to mask.")] = 8.0 
+    token_mask_low: Annotated[
+        float, 
+        Field(ge=0, description="The low threshold for token importance ratio to mask.")] = 0.125
+    sequence_clip_high: Annotated[float, Field(ge=0, description="The high threshold for sequence importance ratio to clip.")] = 10.0
+    geo_mask_high: Annotated[float, Field(ge=0, description="The high threshold for geo importance ratio to mask.")] = 10.0
+    geo_mask_low: Annotated[float, Field(ge=0, description="The low threshold for geo importance ratio to mask.")] = 0.1
+    kl_tau: Annotated[float, Field(ge=0, description="The tau for KL divergence.")] = 0.0
     sequence_mask_low: Annotated[
         float,
-        Field(
-            ge=0,
-            description=(
-                "If set, masks entire sequences when any generated token has an importance ratio below this value."
-            ),
-        ),
+        Field(ge=0, description="If set, masks entire sequences when any generated token has an importance ratio below this value."),
     ] = 0.0
     sequence_mask_high: Annotated[
         float,
-        Field(
-            ge=0,
-            description=(
-                "If set, masks entire sequences when any generated token has an importance ratio above this value."
-            ),
-        ),
+        Field(ge=0, description="If set, masks entire sequences when any generated token has an importance ratio above this value."),
     ] = 100.0
 
     @model_validator(mode="after")

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -47,6 +47,22 @@ class LossConfig(BaseConfig):
         ),
     ] = 100.0
 
+    @model_validator(mode="after")
+    def validate_mask_bounds(self):
+        if self.token_mask_low >= self.token_mask_high:
+            raise ValueError(
+                f"token_mask_low ({self.token_mask_low}) must be less than token_mask_high ({self.token_mask_high})"
+            )
+        if self.geo_mask_low >= self.geo_mask_high:
+            raise ValueError(
+                f"geo_mask_low ({self.geo_mask_low}) must be less than geo_mask_high ({self.geo_mask_high})"
+            )
+        if self.sequence_mask_low >= self.sequence_mask_high:
+            raise ValueError(
+                f"sequence_mask_low ({self.sequence_mask_low}) must be less than sequence_mask_high ({self.sequence_mask_high})"
+            )
+        return self
+
 
 class FakeDataLoaderConfig(BaseConfig):
     """Configures a fake data loader sampling random micro batches for debugging."""

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -113,7 +113,7 @@ def compute_loss(
         loss = -(coeff.detach() * trainer_logprobs)[keep_mask].sum()
 
         if loss_config.ratio_type == "sequence":
-            loss = _safe_mean(loss, loss_mask)
+            loss = loss / torch.clamp_min(loss_mask.sum(), 1)
 
         total_loss = total_loss + loss
 

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -37,6 +37,12 @@ def shift_logits(logits: Float[Tensor, "batch seq vocab"]) -> Float[Tensor, "bat
     return logits
 
 
+def _safe_mean(values: Tensor, mask: Tensor) -> Tensor:
+    """Mean of values over a boolean mask; returns 0 when mask is empty."""
+    denom = torch.clamp_min(mask.sum(), 1)
+    return values[mask].sum() / denom
+
+
 def compute_loss(
     trainer_logprobs: Any,  # list of Float[Tensor, "seq_i"] with potentially different seq_i lengths
     inference_logprobs: Any,  # list of Float[Tensor, "seq_i"] with potentially different seq_i lengths
@@ -60,7 +66,7 @@ def compute_loss(
         Tuple of (scaled_loss, aggregated_loss_tensors)
     """
 
-    total_loss = 0
+    total_loss = 0.0
     total_mismatch_kl = []
     total_masked_mismatch_kl = []
     total_unmasked_mismatch_kl = []
@@ -68,59 +74,61 @@ def compute_loss(
     total_is_masked_low = []
     total_is_masked_high = []
     total_sequence_masked_low = []
+    total_sequence_masked_high = []
+    total_geo_masked_low = []
+    total_geo_masked_high = []
+    total_geo_seq_ratio = []
 
     for trainer_logprobs, inference_logprobs, advantages, loss_mask in zip(
         trainer_logprobs, inference_logprobs, advantages, loss_mask
     ):
         log_importance_ratio = trainer_logprobs - inference_logprobs
 
-        # Compute trainer-inference mismatch KL
-        token_mismatch_kl = torch.exp(log_importance_ratio) - log_importance_ratio - 1
+        # Trainer-inference mismatch KL per token
+        token_importance_ratio = torch.exp(log_importance_ratio)
+        geo_seq_ratio = torch.exp(_safe_mean(log_importance_ratio, loss_mask))
+        token_mismatch_kl = token_importance_ratio - log_importance_ratio - 1
 
-        if loss_config.ratio_type == "sequence":
-            seq_log_importance_ratio = (log_importance_ratio[loss_mask]).sum()
-            log_importance_ratio = trainer_logprobs - trainer_logprobs.detach() + seq_log_importance_ratio.detach()
-            log_importance_ratio = torch.clamp(log_importance_ratio, max=10.0)
+        seq_log_importance_ratio = log_importance_ratio[loss_mask].sum().detach()
+        seq_log_importance_ratio = torch.clamp(trainer_logprobs - trainer_logprobs.detach() + seq_log_importance_ratio, max=10.0)
+        seq_importance_ratio = torch.clamp(torch.exp(seq_log_importance_ratio), max=loss_config.sequence_clip_high)
 
-        importance_ratio = torch.exp(log_importance_ratio)
-        is_masked_low = importance_ratio < loss_config.mask_ratio_low
-        is_masked_high = importance_ratio > loss_config.mask_ratio_high
-        is_masked = is_masked_low | is_masked_high
-        seq_min_ratio = importance_ratio.masked_fill(~loss_mask, torch.inf).min()
-        seq_should_mask = seq_min_ratio < loss_config.sequence_mask_ratio_low
-        is_masked = is_masked | seq_should_mask
+        seq_min_ratio = torch.where(loss_mask, token_importance_ratio, torch.inf).min()
+        seq_max_ratio = torch.where(loss_mask, token_importance_ratio, -torch.inf).max()
+        seq_mask_low = seq_min_ratio < loss_config.sequence_mask_low
+        seq_mask_high = seq_max_ratio > loss_config.sequence_mask_high
+
+        token_mask_low = token_importance_ratio < loss_config.token_mask_low
+        token_mask_high = token_importance_ratio > loss_config.token_mask_high
+
+        geo_mask_low = geo_seq_ratio < loss_config.geo_mask_low
+        geo_mask_high = geo_seq_ratio > loss_config.geo_mask_high
+
+        is_masked = token_mask_low | token_mask_high | geo_mask_low | geo_mask_high | seq_mask_low | seq_mask_high
         keep_mask = loss_mask & ~is_masked
-        loss = (-importance_ratio * advantages)[keep_mask].sum()
-        if loss_config.kl_mask_type == "masked":
-            kl_mask = loss_mask & is_masked
-        elif loss_config.kl_mask_type == "unmasked":
-            kl_mask = keep_mask
-        elif loss_config.kl_mask_type == "all":
-            kl_mask = loss_mask
-        else:
-            raise ValueError(f"Invalid KL mask type: {loss_config.kl_mask_type}")
-        loss = loss + loss_config.kl_tau * (log_importance_ratio[kl_mask]).sum()
 
-        # Apply sequence-level normalization if configured
+        importance_ratio = seq_importance_ratio if loss_config.ratio_type == "sequence" else token_importance_ratio
+
+        coeff = importance_ratio * (advantages - loss_config.kl_tau * log_importance_ratio)
+        loss = -(coeff.detach() * trainer_logprobs)[keep_mask].sum()
+
         if loss_config.ratio_type == "sequence":
-            loss = loss / torch.clamp_min(loss_mask.sum(), 1)
+            loss = _safe_mean(loss, loss_mask)
 
         total_loss = total_loss + loss
 
-        mismatch_kl = token_mismatch_kl[loss_mask].sum() / torch.clamp_min(loss_mask.sum(), 1)
-        masked_mismatch_kl = token_mismatch_kl[loss_mask & is_masked].sum() / torch.clamp_min(
-            (loss_mask & is_masked).sum(), 1
-        )
-        unmasked_mismatch_kl = token_mismatch_kl[keep_mask].sum() / torch.clamp_min(keep_mask.sum(), 1)
-
         # Aggregate loss tensors
-        total_mismatch_kl.append(mismatch_kl)
-        total_masked_mismatch_kl.append(masked_mismatch_kl)
-        total_unmasked_mismatch_kl.append(unmasked_mismatch_kl)
+        total_mismatch_kl.append(_safe_mean(token_mismatch_kl, loss_mask))
+        total_masked_mismatch_kl.append(_safe_mean(token_mismatch_kl, loss_mask & is_masked))
+        total_unmasked_mismatch_kl.append(_safe_mean(token_mismatch_kl, keep_mask))
         total_is_masked.append(is_masked[loss_mask].float())
-        total_is_masked_low.append(is_masked_low[loss_mask].float())
-        total_is_masked_high.append(is_masked_high[loss_mask].float())
-        total_sequence_masked_low.append(seq_should_mask.float())
+        total_is_masked_low.append(token_mask_low[loss_mask].float())
+        total_is_masked_high.append(token_mask_high[loss_mask].float())
+        total_sequence_masked_low.append(seq_mask_low.float())
+        total_sequence_masked_high.append(seq_mask_high.float())
+        total_geo_masked_low.append(geo_mask_low.float())
+        total_geo_masked_high.append(geo_mask_high.float())
+        total_geo_seq_ratio.append(geo_seq_ratio)
 
     # Apply loss scaling
     scaled_loss = total_loss / loss_scale
@@ -133,4 +141,8 @@ def compute_loss(
         "is_masked_low": torch.cat(total_is_masked_low),
         "is_masked_high": torch.cat(total_is_masked_high),
         "sequence_masked_low": torch.stack(total_sequence_masked_low),
+        "sequence_masked_high": torch.stack(total_sequence_masked_high),
+        "geo_masked_low": torch.stack(total_geo_masked_low),
+        "geo_masked_high": torch.stack(total_geo_masked_high),
+        "geo_seq_ratio": torch.stack(total_geo_seq_ratio),
     }

--- a/tests/unit/train/rl/test_loss.py
+++ b/tests/unit/train/rl/test_loss.py
@@ -18,7 +18,7 @@ def test_grpo_loss():
         inference_logprobs,
         advantages,
         loss_mask=loss_mask,
-        loss_config=LossConfig(ratio_type="token", mask_ratio_high=10.0),
+        loss_config=LossConfig(ratio_type="token", token_mask_high=10.0),
         loss_scale=1.0,
     )
     assert loss.shape == ()
@@ -36,7 +36,7 @@ def test_gspo_loss():
         inference_logprobs,
         advantages,
         loss_mask=loss_mask,
-        loss_config=LossConfig(ratio_type="sequence", mask_ratio_high=10.0),
+        loss_config=LossConfig(ratio_type="sequence", token_mask_high=10.0),
         loss_scale=1.0,
     )
     assert loss.shape == ()


### PR DESCRIPTION
Adds geo-rs from https://yingru.notion.site/Part-3-When-Math-Meets-Reality-Toxic-Tails-and-Length-Traps-2b4211a558b780efbb30f09bd646b37c, adds double sided masking for dangerous tokens, and fixes the KL implementation.
Also now allows flexibility with the masking and importance sampling, for example can use token level masking with sequence level importance sampling, or token level masking with geo-level masking, ...



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces geo-level ratio masking and sequence clipping with double-sided token/sequence masks, refactors loss computation/metrics, and updates config/tests accordingly.
> 
> - **RL Loss/Algorithm**:
>   - Implement geo-level importance ratio and masking (`geo_seq_ratio`, `geo_masked_low/high`).
>   - Add double-sided masking at token and sequence levels (`token_mask_low/high`, `sequence_mask_low/high`) and sequence ratio clipping (`sequence_clip_high`).
>   - Refactor loss to combine importance ratio with KL term (`kl_tau`) and detach coefficients; add `_safe_mean` for robust masked reductions.
>   - Expand logged metrics: `sequence_masked_high`, `geo_masked_*`, `geo_seq_ratio`; use safe means for KL stats.
> - **Config** (`LossConfig`):
>   - Replace `mask_ratio_*` with `token_mask_low/high`; add `sequence_clip_high`, `geo_mask_low/high`, `sequence_mask_low/high`, and validators for bounds.
> - **Tests**:
>   - Update to new config fields (`token_mask_high`) and keep shapes checks for loss/entropy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f888672127292fc5460666aa2e302b0650bd40d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->