### PR TITLE
add support for top-p and top-k inference and training

### DIFF
--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -59,8 +59,6 @@ def prepare_sampling_args(sampling_config: EvalSamplingConfig) -> dict[str, Any]
         extra_body["top_k"] = sampling_config.top_k
     if sampling_config.min_p is not None:
         extra_body["min_p"] = sampling_config.min_p
-    if sampling_config.min_tokens is not None:
-        extra_body["min_tokens"] = sampling_config.min_tokens
     if sampling_config.repetition_penalty is not None:
         extra_body["repetition_penalty"] = sampling_config.repetition_penalty
 

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -51,14 +51,6 @@ class SamplingConfig(BaseConfig):
         ),
     ] = None
 
-    min_tokens: Annotated[
-        int,
-        Field(
-            ge=0,
-            description="Minimum number of output tokens to generate per sequence.",
-        ),
-    ] = 0
-
     seed: Annotated[
         int | None,
         Field(
@@ -120,13 +112,6 @@ class EvalSamplingConfig(BaseConfig):
         int | None,
         Field(
             description="Maximum number of output tokens to generate per turn. If None, will generate until maximum context length or EOS token is hit.",
-        ),
-    ] = None
-
-    min_tokens: Annotated[
-        int | None,
-        Field(
-            description="Minimum number of output tokens to generate per sequence. Defaults to None, which means we fall back to the inference server's default value.",
         ),
     ] = None
 

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -19,6 +19,23 @@ class SamplingConfig(BaseConfig):
         ),
     ] = 1.0
 
+    top_p: Annotated[
+        float,
+        Field(
+            ge=0,
+            le=1,
+            description="Cumulative probability of the top tokens to consider (nucleus sampling). If 1.0, all tokens are considered (no filtering).",
+        ),
+    ] = 1.0
+
+    top_k: Annotated[
+        int,
+        Field(
+            ge=-1,
+            description="Number of top tokens to consider. If -1, all tokens are considered (no filtering).",
+        ),
+    ] = -1
+
     repetition_penalty: Annotated[
         float,
         Field(

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -293,6 +293,8 @@ async def orchestrate(config: OrchestratorConfig):
         all_data_ranks_batches = prepare_batch(
             train_examples,
             temperature=config.sampling.temperature,
+            top_p=config.sampling.top_p,
+            top_k=config.sampling.top_k,
             num_train_workers=config.num_train_workers,
             seq_len=config.seq_len,
         )

--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -31,13 +31,12 @@ def get_sampling_args(sampling_config: SamplingConfig) -> dict:
     # Convert SamplingConfig to vLLM OAI sampling args
     # https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html#extra-parameters_2
     sampling_args = dict(sampling_config)
-    sampling_args["top_p"] = 1.0
     sampling_args["logprobs"] = True
     sampling_args["extra_body"] = {
         **sampling_config.extra_body,
         "return_token_ids": True,  # Always return token IDs
         "prompt_logprobs": True,  # Always return prompt logprobs
-        "top_k": -1,
+        "top_k": sampling_args.pop("top_k"),
         "min_p": 0.0,
     }
     sampling_args["extra_body"]["min_tokens"] = sampling_args.pop("min_tokens")

--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -32,15 +32,10 @@ def get_sampling_args(sampling_config: SamplingConfig) -> dict:
     # https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html#extra-parameters_2
     sampling_args = dict(sampling_config)
     sampling_args["logprobs"] = True
-    sampling_args["extra_body"] = {
-        **sampling_config.extra_body,
-        "return_token_ids": True,  # Always return token IDs
-        "prompt_logprobs": True,  # Always return prompt logprobs
-        "top_k": sampling_args.pop("top_k"),
-        "min_p": 0.0,
-    }
-    sampling_args["extra_body"]["min_tokens"] = sampling_args.pop("min_tokens")
-    sampling_args["extra_body"]["repetition_penalty"] = sampling_args.pop("repetition_penalty")
+    sampling_args["extra_body"] = dict(sampling_config.extra_body)
+    sampling_args["extra_body"]["return_token_ids"] = True  # Always return token IDs
+    sampling_args["extra_body"]["prompt_logprobs"] = True  # Always return prompt logprobs
+    sampling_args["extra_body"]["top_k"] = sampling_config.top_k if sampling_config.top_k is not None else -1
     return sampling_args
 
 

--- a/src/prime_rl/synthesize/utils.py
+++ b/src/prime_rl/synthesize/utils.py
@@ -40,8 +40,6 @@ def prepare_sampling_args(sampling_config: EvalSamplingConfig, client_config: Cl
         extra_body["top_k"] = sampling_config.top_k
     if sampling_config.min_p is not None:
         extra_body["min_p"] = sampling_config.min_p
-    if sampling_config.min_tokens is not None:
-        extra_body["min_tokens"] = sampling_config.min_tokens
     if sampling_config.repetition_penalty is not None:
         extra_body["repetition_penalty"] = sampling_config.repetition_penalty
 

--- a/src/prime_rl/trainer/rl/data.py
+++ b/src/prime_rl/trainer/rl/data.py
@@ -20,6 +20,8 @@ class MicroBatch(TypedDict):
 
     # Batch level
     temperature: float
+    top_p: float
+    top_k: int
 
 
 class FakeDataLoader:
@@ -48,6 +50,8 @@ class FakeDataLoader:
             "advantages": torch.randn(self.seq_len).unsqueeze(0),
             "inference_logprobs": torch.randn(self.seq_len).unsqueeze(0),
             "temperature": 1.0,
+            "top_p": 1.0,
+            "top_k": -1,
             "loss_mask": torch.ones(self.seq_len, dtype=torch.bool).unsqueeze(0),
         }
 

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -8,15 +8,6 @@ from torch import Tensor
 from prime_rl.trainer.rl.config import LossConfig
 
 
-@jaxtyped(typechecker=typechecker)
-@torch.compile(dynamic=True)
-def selective_log_softmax(
-    logits: Float[Tensor, "batch seq vocab"], index: Int[Tensor, "batch seq"]
-) -> Float[Tensor, "batch seq"]:
-    logprobs = logits.log_softmax(dim=-1)
-    return torch.gather(logprobs, dim=-1, index=index.unsqueeze(-1)).squeeze(-1)
-
-
 def _apply_top_k_top_p(
     logits: Float[Tensor, "batch seq vocab"],
     top_k: int,
@@ -60,7 +51,7 @@ def _apply_top_k_top_p(
 
 @jaxtyped(typechecker=typechecker)
 @torch.compile(dynamic=True)
-def selective_log_softmax_with_filtering(
+def selective_log_softmax(
     logits: Float[Tensor, "batch seq vocab"],
     index: Int[Tensor, "batch seq"],
     top_p: float,

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -18,7 +18,7 @@ from prime_rl.trainer.rl.data import DataLoader, FakeDataLoader
 from prime_rl.utils.logger import setup_logger
 from prime_rl.trainer.rl.loss import (
     shift_logits,
-    selective_log_softmax_with_filtering,
+    selective_log_softmax,
     compute_entropy,
     compute_loss,
 )
@@ -236,7 +236,7 @@ def train(config: RLTrainerConfig):
 
             shifted_logits = shift_logits(logits)
             shifted_logits = shifted_logits / temperature
-            trainer_logprobs = selective_log_softmax_with_filtering(shifted_logits, input_ids, top_p, top_k)
+            trainer_logprobs = selective_log_softmax(shifted_logits, input_ids, top_p, top_k)
 
             # Compute loss
             response_lengths = get_response_lengths(position_ids)

--- a/tests/unit/orchestrator/test_batch.py
+++ b/tests/unit/orchestrator/test_batch.py
@@ -31,6 +31,8 @@ def test_prepare_batch_balances_micro_batches_across_workers(
     batches_per_gpu = prepare_batch(
         rollouts=examples,
         temperature=0.5,
+        top_p=1.0,
+        top_k=-1,
         seq_len=4,
         num_train_workers=num_train_workers,
     )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds configurable top-p/top-k sampling end-to-end (config → orchestrator → batches → trainer) and masks logits accordingly during loss computation; removes min_tokens handling and cleans up sampling args.
> 
> - **Config**:
>   - Add `top_p` and `top_k` to `SamplingConfig`; expose in `EvalSamplingConfig`.
>   - Remove `min_tokens` fields/usages.
> - **Orchestrator**:
>   - Pass `sampling.top_p`/`top_k` into `prepare_batch` and persist in saved micro-batches.
>   - Simplify `get_sampling_args`: always enable `logprobs`, `return_token_ids`, `prompt_logprobs`; set `extra_body['top_k']` from config; drop hardcoded `top_p` and `min_tokens` mapping.
> - **Batch/Data**:
>   - Thread `top_p`/`top_k` through `prepare_micro_batch(_packing)` and `MicroBatch` schema.
> - **Trainer**:
>   - `selective_log_softmax` now accepts `top_p`/`top_k` and applies `_apply_top_k_top_p` masking before log-softmax; training loop supplies these per micro-batch.
> - **Eval/Synthesis**:
>   - Build sampling args with optional `top_k`, `min_p`, `repetition_penalty`; stop setting `min_tokens`.
> - **Tests**:
>   - Update batch test to pass `top_p`/`top_k` and assert padding behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ecac8f5e2e4860e1ed41bebe54ea735f2acd478. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->