### PR TITLE
round up max_lora_rank to valid vLLM values

### DIFF
--- a/src/prime_rl/inference/config.py
+++ b/src/prime_rl/inference/config.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from argparse import Namespace
 from typing import Annotated, Literal
 
@@ -107,6 +108,10 @@ class WeightBroadcastConfig(BaseSettings):
     )
 
 
+# Valid vLLM max_lora_rank values (from vllm/config/lora.py)
+VALID_VLLM_LORA_RANKS = (8, 16, 32, 64, 128, 256, 320, 512)
+
+
 class InferenceConfig(BaseSettings):
     """Configures inference."""
 
@@ -161,6 +166,30 @@ class InferenceConfig(BaseSettings):
     def auto_setup_dynamic_lora_updating(self):
         if self.enable_lora:
             os.environ["VLLM_ALLOW_RUNTIME_LORA_UPDATING"] = "True"
+        return self
+
+    @model_validator(mode="after")
+    def round_up_max_lora_rank(self):
+        """Round up max_lora_rank to the nearest valid vLLM value.
+
+        vLLM only accepts specific values for max_lora_rank: (1, 8, 16, 32, 64, 128, 256, 320, 512).
+        This validator ensures that any configured rank is rounded up to the minimum valid value
+        that can serve adapters of the requested rank.
+        """
+        if self.max_lora_rank is not None:
+            original_rank = self.max_lora_rank
+            for valid_rank in VALID_VLLM_LORA_RANKS:
+                if valid_rank >= self.max_lora_rank:
+                    self.max_lora_rank = valid_rank
+                    break
+            else:
+                raise ValueError(
+                    f"max_lora_rank={original_rank} exceeds vLLM maximum of {VALID_VLLM_LORA_RANKS[-1]}"
+                )
+            if self.max_lora_rank != original_rank:
+                warnings.warn(
+                    f"vLLM max_lora_rank {original_rank} -> {self.max_lora_rank} (serving allocation only, adapter rank unchanged)"
+                )
         return self
 
     def to_vllm(self) -> Namespace:

--- a/src/prime_rl/inference/config.py
+++ b/src/prime_rl/inference/config.py
@@ -1,5 +1,4 @@
 import os
-import warnings
 from argparse import Namespace
 from typing import Annotated, Literal
 
@@ -185,10 +184,6 @@ class InferenceConfig(BaseSettings):
             else:
                 raise ValueError(
                     f"max_lora_rank={original_rank} exceeds vLLM maximum of {VALID_VLLM_LORA_RANKS[-1]}"
-                )
-            if self.max_lora_rank != original_rank:
-                warnings.warn(
-                    f"vLLM max_lora_rank {original_rank} -> {self.max_lora_rank} (serving allocation only, adapter rank unchanged)"
                 )
         return self
 

--- a/src/prime_rl/inference/config.py
+++ b/src/prime_rl/inference/config.py
@@ -108,6 +108,7 @@ class WeightBroadcastConfig(BaseSettings):
 
 
 # Valid vLLM max_lora_rank values (from vllm/config/lora.py)
+# TODO: on newer vLLM, can import via `get_args(vllm.config.lora.MaxLoRARanks)`
 VALID_VLLM_LORA_RANKS = (8, 16, 32, 64, 128, 256, 320, 512)
 
 


### PR DESCRIPTION
vLLM only accepts specific values for max_lora_rank: (8, 16, 32, 64, 128, 256, 320, 512).
When using LoRA ranks like 4 that aren't in this list, vLLM would reject them

This adds a validator that automatically rounds up to the minimum valid value that can serve adapters of the requested rank (e.g., rank 4 -> max_lora_rank 8). A warning is emitted when rounding occurs.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Automatically rounds configured `max_lora_rank` up to the nearest supported vLLM rank and errors if it exceeds the maximum.
> 
> - **Config (`src/prime_rl/inference/config.py`)**
>   - **LoRA rank handling**:
>     - Add `VALID_VLLM_LORA_RANKS` constant defining supported ranks.
>     - Add `InferenceConfig.round_up_max_lora_rank` validator to round `max_lora_rank` up to the nearest valid vLLM value; raises if above max.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fe47b5bb2a1be11e0dae9a0af4a487ece4a73d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->