### PR TITLE
prevent OAI API key leak to wandb config

### DIFF
--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -42,7 +42,7 @@ def setup_admin_clients(client_config: ClientConfig) -> list[AsyncClient]:
     """
 
     def _setup_admin_client(base_url: str) -> httpx.AsyncClient:
-        headers = client_config.headers
+        headers = client_config.headers.copy()  # avoid mutating config
         api_key = os.getenv(client_config.api_key_var, "EMPTY")
         if api_key and api_key != "EMPTY":
             headers["Authorization"] = f"Bearer {api_key}"


### PR DESCRIPTION
The setup_admin_clients function was mutating the shared headers dict from ClientConfig when adding the Authorization header. Since this dict is part of the config object that gets serialized to wandb, the value of `OPENAI_API_KEY` was being logged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Copy admin request headers before adding Authorization to avoid mutating shared config and leaking API key.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d468fb7bd17d79ca160ff1c10f9e1b3b3e7b8a34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->