### PR TITLE
Update examples

### DIFF
--- a/examples/alphabet_sort/rl.toml
+++ b/examples/alphabet_sort/rl.toml
@@ -34,6 +34,6 @@ max_tokens = 768
 [[orchestrator.env]]
 id = "primeintellect/alphabet-sort"
 name = "alphabet-sort"
-args = { min_turns = 3, max_turns = 3, min_names_per_turn = 1, max_names_per_turn = 4, similarity_power = 8, power_per_turn = false }
+args = { min_turns = 3, max_turns = 5, power_per_turn = false }
 
 [inference] # Default inference config

--- a/examples/alphabet_sort/rl.toml
+++ b/examples/alphabet_sort/rl.toml
@@ -6,6 +6,10 @@ max_steps = 100
 [model]
 name = "Qwen/Qwen3-4B-Instruct-2507"
 
+[wandb]
+project = "alphabet-sort"
+name = "alphabet-sort"
+
 [trainer.model]
 impl = "liger_kernel"
 

--- a/examples/alphabet_sort/rl.toml
+++ b/examples/alphabet_sort/rl.toml
@@ -1,5 +1,5 @@
 
-max_steps = 100 
+max_steps = 200 
 
 [ckpt] # Checkpoint at the end of training
 

--- a/examples/reverse_text/rl.toml
+++ b/examples/reverse_text/rl.toml
@@ -3,6 +3,10 @@ max_steps = 20
 [model]
 name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
 
+[wandb]
+project = "reverse-text"
+name = "reverse-text"
+
 [orchestrator]
 batch_size = 128
 rollouts_per_example = 16

--- a/examples/wiki_search/rl.toml
+++ b/examples/wiki_search/rl.toml
@@ -1,7 +1,7 @@
 inference_gpu_ids = [0,1,2,3,4,5]
 trainer_gpu_ids = [6,7]
 
-max_steps = 500
+max_steps = 200
 
 [model]
 name = "Qwen/Qwen3-4B-Instruct-2507"

--- a/examples/wiki_search/rl.toml
+++ b/examples/wiki_search/rl.toml
@@ -1,5 +1,5 @@
-inference_gpu_ids = [0]
-trainer_gpu_ids = [1]
+inference_gpu_ids = [0,1,2,3,4,5]
+trainer_gpu_ids = [6,7]
 
 max_steps = 500
 

--- a/examples/wiki_search/rl.toml
+++ b/examples/wiki_search/rl.toml
@@ -8,7 +8,7 @@ name = "Qwen/Qwen3-4B-Instruct-2507"
 
 [wandb]
 project = "wiki-search"
-name = "wiki-search-4b"
+name = "wiki-search"
 
 [trainer.optim]
 lr = 1e-5

--- a/examples/wordle/rl.toml
+++ b/examples/wordle/rl.toml
@@ -13,7 +13,7 @@ name = "wordle"
 name = "PrimeIntellect/Qwen3-1.7B-Wordle-SFT"
 
 [orchestrator]
-seq_len = 4096
+seq_len = 8192
 batch_size = 1024
 rollouts_per_example = 16
 
@@ -26,5 +26,4 @@ max_tokens = 1024
 
 [trainer] # Default trainer config
 
-[inference.model] # Default inference config
-max_model_len = 4096
+[inference] # Default inference config

--- a/examples/wordle/rl.toml
+++ b/examples/wordle/rl.toml
@@ -1,3 +1,6 @@
+inference_gpu_ids = [0,1,2,3,4,5]
+trainer_gpu_ids = [6,7]
+
 max_steps = 100
 
 [wandb]
@@ -23,4 +26,5 @@ max_tokens = 1024
 
 [trainer] # Default trainer config
 
-[inference] # Default inference config
+[inference.model] # Default inference config
+max_model_len = 4096

--- a/examples/wordle/rl.toml
+++ b/examples/wordle/rl.toml
@@ -1,5 +1,9 @@
 max_steps = 100
 
+[wandb]
+project = "wordle"
+name = "wordle"
+
 [ckpt] # Checkpoint at the end of training
 
 [model]

--- a/examples/wordle/rl.toml
+++ b/examples/wordle/rl.toml
@@ -26,4 +26,6 @@ max_tokens = 1024
 
 [trainer] # Default trainer config
 
-[inference] # Default inference config
+[inference.parallel]
+dp = 3
+tp = 2

--- a/examples/wordle/rl.toml
+++ b/examples/wordle/rl.toml
@@ -1,7 +1,7 @@
 inference_gpu_ids = [0,1,2,3,4,5]
 trainer_gpu_ids = [6,7]
 
-max_steps = 100
+max_steps = 200
 
 [wandb]
 project = "wordle"


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Updates:
- Setup W&B with default project and name using env name
- Run all for <=200 steps to finish in reasonable time
- Use 8 GPUs for `wordle` and `wiki-search` (possible after #1393)
- Use 3-5 turns in `alphabet-sort` to increase inference step time a bit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes example RL configs: add W&B, set/adjust max_steps (≤200), enable multi-GPU for wordle/wiki-search, and tweak env/seq/inference settings.
> 
> - **Examples**:
>   - **wordle (`examples/wordle/rl.toml`)**:
>     - Add multi-GPU: `inference_gpu_ids = [0,1,2,3,4,5]`, `trainer_gpu_ids = [6,7]`.
>     - Set `max_steps = 200`.
>     - Add W&B: `project = "wordle"`, `name = "wordle"`.
>     - Increase `orchestrator.seq_len` to `8192`.
>     - Add `inference.parallel`: `dp = 3`, `tp = 2`.
>   - **wiki-search (`examples/wiki_search/rl.toml`)**:
>     - Add multi-GPU: `inference_gpu_ids = [0,1,2,3,4,5]`, `trainer_gpu_ids = [6,7]`.
>     - Reduce `max_steps` to `200`.
>     - Normalize W&B run name to `"wiki-search"`.
>   - **alphabet-sort (`examples/alphabet_sort/rl.toml`)**:
>     - Increase `max_steps` to `200`.
>     - Add W&B: `project = "alphabet-sort"`, `name = "alphabet-sort"`.
>     - Adjust env args: `min_turns = 3`, `max_turns = 5`, `power_per_turn = false`.
>   - **reverse-text (`examples/reverse_text/rl.toml`)**:
>     - Add W&B: `project = "reverse-text"`, `name = "reverse-text"`.}
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc5a45951192266bc54f0ecfec0f6c2f135edc55. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->