### PR TITLE
Explicitly catch env errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 Documenting changes which affect configuration usage patterns (added/moved/removed/renamed fields, notable logic changes).
 
+- Auto-set `api_server_count=1` on inference when LoRA is enabled, because vLLM doesn't support hotloading for multiple API servers (#1422, 2025-12-17)
 - **`model.lora`**: Moved from `model.experimental.lora` to `model.lora` (no longer experimental) (#1440, 2025-12-16)

--- a/configs/math_python/README.md
+++ b/configs/math_python/README.md
@@ -2,16 +2,16 @@
 
 ## Setup
 
-CLone `research-environments`
+CLone `verifiers`
 
 ```bash
-cd ~ && curl -sSL https://raw.githubusercontent.com/PrimeIntellect-ai/research-environments/main/scripts/install.sh | bash && cd -
+cd ~ && curl -sSL https://raw.githubusercontent.com/PrimeIntellect-ai/verifiers/main/scripts/install.sh | bash && cd -
 ```
 
 Install the environment as local packages
 
 ```bash
-uv pip install -e ~/research-environments/environments/math_python
+uv pip install -e ~/verifiers/environments/math_python
 ```
 
 This will automatically install the environment, and a pinned verifiers commit (`71006c`) which includes necessary changes to the PythonEnv.
@@ -30,10 +30,10 @@ uv run --no-sync vf-eval math-python -n 16 -r 1 -c -1 -v -m Qwen/Qwen3-4B-Instru
 
 ## RL
 
-Again, make sure to have installed the environment as local packages from research-environments
+Again, make sure to have installed the environment as local packages from verifiers
 
 ```bash
-uv pip install -e ~/research-environments/environments/math_python
+uv pip install -e ~/verifiers/environments/math_python
 ```
 
 Then, run RL in debug mode (small batch size, limited turns, 2 GPUs, etc.)

--- a/configs/math_python/README.md
+++ b/configs/math_python/README.md
@@ -30,8 +30,14 @@ uv run --no-sync vf-eval math-python -n 16 -r 1 -v -m Qwen/Qwen3-4B-Instruct-250
 
 ## RL
 
+Again, make sure to have installed the environment as local packages from research-environments
+
+```bash
+uv pip install -e ~/research-environments/environments/math_python
+```
+
 Then, run RL in debug mode (small batch size, limited turns, 2 GPUs, etc.)
 
 ```bash
-uv run rl @ configs/math_python/math_python_debug.toml
+uv run --no-sync rl @ configs/math_python/math_python.toml --log.level debug
 ```

--- a/configs/math_python/README.md
+++ b/configs/math_python/README.md
@@ -1,0 +1,37 @@
+# math-python
+
+## Setup
+
+CLone `research-environments`
+
+```bash
+cd ~ && curl -sSL https://raw.githubusercontent.com/PrimeIntellect-ai/research-environments/main/scripts/install.sh | bash && cd -
+```
+
+Install the environment as local packages
+
+```bash
+uv pip install -e ~/research-environments/environments/math_python
+```
+
+This will automatically install the environment, and a pinned verifiers commit (`71006c`) which includes necessary changes to the PythonEnv.
+
+## Eval
+
+Get a quick vibe-check of the model
+
+```bash
+vllm serve Qwen/Qwen3-4B-Instruct-2507
+```
+
+```bash
+uv run --no-sync vf-eval math-python -n 16 -r 1 -v -m Qwen/Qwen3-4B-Instruct-2507 -b http://localhost:8000/v1 -a '{"max_turns": 10, "difficulty_key": "avg@8_qwen3_4b_thinking_2507", "min_avg_reward": 0.5}' -t 4096
+```
+
+## RL
+
+Then, run RL in debug mode (small batch size, limited turns, 2 GPUs, etc.)
+
+```bash
+uv run rl @ configs/math_python/math_python_debug.toml
+```

--- a/configs/math_python/README.md
+++ b/configs/math_python/README.md
@@ -21,11 +21,11 @@ This will automatically install the environment, and a pinned verifiers commit (
 Get a quick vibe-check of the model
 
 ```bash
-vllm serve Qwen/Qwen3-4B-Instruct-2507
+vllm serve Qwen/Qwen3-4B-Instruct-2507 --enable-auto-tool-choice --tool-call-parser hermes --max-model-len 8192
 ```
 
 ```bash
-uv run --no-sync vf-eval math-python -n 16 -r 1 -v -m Qwen/Qwen3-4B-Instruct-2507 -b http://localhost:8000/v1 -a '{"max_turns": 10, "difficulty_key": "avg@8_qwen3_4b_thinking_2507", "min_avg_reward": 0.5}' -t 4096
+uv run --no-sync vf-eval math-python -n 16 -r 1 -c -1 -v -m Qwen/Qwen3-4B-Instruct-2507 -b http://localhost:8000/v1 -a '{"dataset_name": "PrimeIntellect/Hendrycks-Math", "dataset_subset": "default"}' -t 512
 ```
 
 ## RL

--- a/configs/math_python/math_python.toml
+++ b/configs/math_python/math_python.toml
@@ -1,0 +1,24 @@
+max_steps = 100
+
+[wandb]
+project = "math-python-debug"
+name = "math-python"
+
+[model]
+name = "Qwen/Qwen3-4B-Instruct-2507"
+
+[orchestrator]
+seq_len = 8192
+batch_size = 512
+rollouts_per_example = 16
+
+[[orchestrator.env]]
+id = "math-python"
+args = { difficulty_key = "avg@8_qwen3_4b_instruct_2507", min_avg_reward = 0.5 }
+
+[trainer] # Default trainer config
+
+[inference.model] # Default inference config
+enable_auto_tool_choice = true
+tool_call_parser = "hermes"
+max_model_len = 8192

--- a/configs/math_python/math_python.toml
+++ b/configs/math_python/math_python.toml
@@ -1,6 +1,3 @@
-inference_gpu_ids = [0,1,2,3,4,5]
-trainer_gpu_ids = [6,7]
-
 max_steps = 300
 
 [wandb]
@@ -11,27 +8,20 @@ name = "math-python"
 name = "Qwen/Qwen3-4B-Instruct-2507"
 
 [orchestrator]
-seq_len = 8192
+seq_len = 4096
 batch_size = 512
 rollouts_per_example = 16
 
 [orchestrator.sampling]
 max_tokens = 512
 
-[orchestrator.buffer]
-online_difficulty_filtering = true
-
-[orchestrator.val]
-interval = 1
-num_examples = 128
-
 [[orchestrator.env]]
 id = "math-python"
-args = { dataset_name = "PrimeIntellect/Hendrycks-Math", dataset_subset = "default" }
 
 [trainer] # Default trainer config
 
 [inference.model] # Default inference config
 enable_auto_tool_choice = true
 tool_call_parser = "hermes"
-max_model_len = 8192
+api_server_count = 4
+max_model_len = 4096

--- a/configs/math_python/math_python.toml
+++ b/configs/math_python/math_python.toml
@@ -15,6 +15,13 @@ seq_len = 8192
 batch_size = 512
 rollouts_per_example = 16
 
+[orchestrator.buffer]
+online_difficulty_filtering = true
+
+[orchestrator.val]
+interval = 1
+num_examples = 128
+
 [[orchestrator.env]]
 id = "math-python"
 args = { difficulty_key = "avg@8_qwen3_4b_instruct_2507", min_avg_reward = 0.5 }

--- a/configs/math_python/math_python.toml
+++ b/configs/math_python/math_python.toml
@@ -1,3 +1,6 @@
+inference_gpu_ids = [0,1,2,3,4,5]
+trainer_gpu_ids = [6,7]
+
 max_steps = 100
 
 [wandb]
@@ -16,7 +19,7 @@ rollouts_per_example = 16
 id = "math-python"
 args = { difficulty_key = "avg@8_qwen3_4b_instruct_2507", min_avg_reward = 0.5 }
 
-[trainer.model.ac]
+[trainer] # Default trainer config
 
 [inference.model] # Default inference config
 enable_auto_tool_choice = true

--- a/configs/math_python/math_python.toml
+++ b/configs/math_python/math_python.toml
@@ -11,12 +11,12 @@ name = "math-python"
 name = "Qwen/Qwen3-4B-Instruct-2507"
 
 [orchestrator]
-seq_len = 12288
+seq_len = 8192
 batch_size = 512
 rollouts_per_example = 16
 
 [orchestrator.sampling]
-max_tokens = 2048
+max_tokens = 512
 
 [orchestrator.buffer]
 online_difficulty_filtering = true
@@ -27,7 +27,7 @@ num_examples = 128
 
 [[orchestrator.env]]
 id = "math-python"
-args = { difficulty_key = "avg@8_qwen3_4b_instruct_2507", min_avg_reward = 0.5 }
+args = { dataset_name = "PrimeIntellect/Hendrycks-Math", dataset_subset = "default" }
 
 [trainer] # Default trainer config
 

--- a/configs/math_python/math_python.toml
+++ b/configs/math_python/math_python.toml
@@ -16,7 +16,7 @@ rollouts_per_example = 16
 id = "math-python"
 args = { difficulty_key = "avg@8_qwen3_4b_instruct_2507", min_avg_reward = 0.5 }
 
-[trainer] # Default trainer config
+[trainer.model.ac]
 
 [inference.model] # Default inference config
 enable_auto_tool_choice = true

--- a/configs/math_python/math_python.toml
+++ b/configs/math_python/math_python.toml
@@ -20,8 +20,10 @@ id = "math-python"
 
 [trainer] # Default trainer config
 
-[inference.model] # Default inference config
+[inference]
+api_server_count = 4
+
+[inference.model]
 enable_auto_tool_choice = true
 tool_call_parser = "hermes"
-api_server_count = 4
 max_model_len = 4096

--- a/configs/math_python/math_python.toml
+++ b/configs/math_python/math_python.toml
@@ -1,7 +1,7 @@
 inference_gpu_ids = [0,1,2,3,4,5]
 trainer_gpu_ids = [6,7]
 
-max_steps = 100
+max_steps = 300
 
 [wandb]
 project = "math-python-debug"
@@ -11,9 +11,12 @@ name = "math-python"
 name = "Qwen/Qwen3-4B-Instruct-2507"
 
 [orchestrator]
-seq_len = 8192
+seq_len = 12288
 batch_size = 512
 rollouts_per_example = 16
+
+[orchestrator.sampling]
+max_tokens = 2048
 
 [orchestrator.buffer]
 online_difficulty_filtering = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ prerelease = "allow"
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 reverse-text = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "0149248" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "ca75d04" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "main" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ prerelease = "allow"
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 reverse-text = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "0dd0645" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "0149248" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "main" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -340,7 +340,8 @@ async def orchestrate(config: OrchestratorConfig):
                 "reward": [rollout["reward"] for rollout in train_rollouts],
                 "is_truncated": [rollout["is_truncated"] for rollout in train_rollouts],
                 "error": [
-                    rollout["error"].__name__ if rollout["error"] is not None else None for rollout in train_rollouts
+                    type(rollout["error"]).__name__ if rollout["error"] is not None else None
+                    for rollout in train_rollouts
                 ],
                 "completion_len": [get_completion_len(rollout) for rollout in train_rollouts],
                 "prompt_len": [get_prompt_len(rollout) for rollout in train_rollouts],

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -420,7 +420,7 @@ async def orchestrate(config: OrchestratorConfig):
             "error/mean": (~results_df.error.isna()).mean(),
             **{
                 f"error/{error}": error_rate
-                for error, error_rate in results_df.dropna().error.value_counts(normalize=True).items()
+                for error, error_rate in results_df.error.dropna().value_counts(normalize=True).items()
             },
             # Env metrics
             **{f"metrics/{metric}": metrics_df[metric].mean() for metric in metrics_df.columns},

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -342,6 +342,7 @@ async def orchestrate(config: OrchestratorConfig):
                 "completion_len": [get_completion_len(rollout) for rollout in train_rollouts],
                 "prompt_len": [get_prompt_len(rollout) for rollout in train_rollouts],
                 "seq_len": [get_seq_len(rollout) for rollout in train_rollouts],
+                "has_error": [rollout["error"] is not None for rollout in train_rollouts],
             }
         )
 
@@ -412,6 +413,7 @@ async def orchestrate(config: OrchestratorConfig):
             "batch/solve_none": solve_none,
             "batch/solve_all": solve_all,
             "batch/effective_batch_size": effective_batch_size,
+            "batch/has_error": results_df.has_error.mean(),
             # Env metrics
             **{f"metrics/{metric}": metrics_df[metric].mean() for metric in metrics_df.columns},
             # Time metrics

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -311,9 +311,10 @@ async def orchestrate(config: OrchestratorConfig):
         train_examples: list[TrainingSample] = []
         for train_rollout, advantage in zip(train_rollouts, advantages):
             train_example = make_train_example(train_rollout)
-            for te in train_example:
-                te.advantage = advantage
-            train_examples.extend(train_example)
+            if train_example is not None:
+                for te in train_example:
+                    te.advantage = advantage
+                train_examples.extend(train_example)
         logger.debug(
             f"Converted {len(train_rollouts)} training rollouts to {len(train_examples)} training examples using {config.trajectory_strategy} strategy"
         )

--- a/src/prime_rl/orchestrator/trajectories.py
+++ b/src/prime_rl/orchestrator/trajectories.py
@@ -6,7 +6,7 @@ from prime_rl.transport import TrainingSample
 from prime_rl.utils.logger import get_logger
 
 
-def interleave_rollout(state: vf.State) -> list[TrainingSample]:
+def interleave_rollout(state: vf.State) -> list[TrainingSample] | None:
     """
     Convert vf.State to a *single* trainable rollout by interleaving the trajectory.
 
@@ -19,7 +19,7 @@ def interleave_rollout(state: vf.State) -> list[TrainingSample]:
     trajectory = state["trajectory"]
     if len(trajectory) == 0:
         logger.warning(f"No trajectory steps for example {state['example_id']}. Skipping rollout.")
-        return []
+        return None
 
     has_error = state["error"] is not None
 
@@ -73,7 +73,7 @@ def interleave_rollout(state: vf.State) -> list[TrainingSample]:
     return [interleaved_rollout]
 
 
-def branch_rollout(state: vf.State) -> list[TrainingSample]:
+def branch_rollout(state: vf.State) -> list[TrainingSample] | None:
     """Convert vf.State to *multiple* trainable rollouts using branching trajectories strategy."""
     logger = get_logger()
 
@@ -81,7 +81,7 @@ def branch_rollout(state: vf.State) -> list[TrainingSample]:
     trajectory = state["trajectory"]
     if len(trajectory) == 0:
         logger.warning(f"No trajectory steps for example {state['example_id']}. Skipping rollout.")
-        return rollouts
+        return None
 
     has_error = state["error"] is not None
     for step in state["trajectory"]:

--- a/src/prime_rl/orchestrator/trajectories.py
+++ b/src/prime_rl/orchestrator/trajectories.py
@@ -54,9 +54,9 @@ def interleave_rollout(state: vf.State) -> list[TrainingSample]:
         completion_logprobs = deepcopy(tokens["completion_logprobs"])
         interleaved_rollout.completion_ids.extend(completion_ids)
         if has_error:
-            interleaved_rollout.completion_mask.extend([0] * len(tokens["completion_mask"]))
+            interleaved_rollout.completion_mask.extend([False] * len(tokens["completion_mask"]))
         else:
-            interleaved_rollout.completion_mask.extend(deepcopy(tokens["completion_mask"]))
+            interleaved_rollout.completion_mask.extend([bool(i) for i in tokens["completion_mask"]])
         interleaved_rollout.completion_logprobs.extend(completion_logprobs)
 
         # New prefix is the current prompt and completion ids concatenated

--- a/src/prime_rl/orchestrator/trajectories.py
+++ b/src/prime_rl/orchestrator/trajectories.py
@@ -16,8 +16,12 @@ def interleave_rollout(state: vf.State) -> list[TrainingSample]:
     """
     logger = get_logger()
 
-    # Initialize the rollout with prompt and completion from first trajectory step
     trajectory = state["trajectory"]
+    if len(trajectory) == 0:
+        logger.warning(f"No trajectory steps for example {state['example_id']}. Skipping rollout.")
+        return []
+
+    # Initialize the rollout with prompt and completion from first trajectory step
     first_step = trajectory[0]
     interleaved_rollout = TrainingSample(
         prompt_ids=deepcopy(first_step["tokens"]["prompt_ids"]),
@@ -67,7 +71,14 @@ def interleave_rollout(state: vf.State) -> list[TrainingSample]:
 
 def branch_rollout(state: vf.State) -> list[TrainingSample]:
     """Convert vf.State to *multiple* trainable rollouts using branching trajectories strategy."""
+    logger = get_logger()
+
     rollouts = []
+    trajectory = state["trajectory"]
+    if len(trajectory) == 0:
+        logger.warning(f"No trajectory steps for example {state['example_id']}. Skipping rollout.")
+        return rollouts
+
     has_error = state["error"] is not None
     for step in state["trajectory"]:
         assert "tokens" in step

--- a/tests/unit/orchestrator/test_trajectories.py
+++ b/tests/unit/orchestrator/test_trajectories.py
@@ -28,6 +28,7 @@ def single_step_trajectory_state():
                 extras={},
             )
         ],
+        error=None,
     )
     return state
 
@@ -75,6 +76,7 @@ def multi_step_trajectory_state():
                 extras={},
             ),
         ],
+        error=None,
     )
     return state
 
@@ -126,6 +128,7 @@ def multi_step_trajectory_with_tool_calls():
         advantage=None,
         stop_condition=None,
         metrics={"has_error": 0.0, "tool_calls": 1.0},
+        error=None,
     )
     return state
 

--- a/uv.lock
+++ b/uv.lock
@@ -2294,7 +2294,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", specifier = ">=4.56.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=0dd0645" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=0149248" },
     { name = "vllm", specifier = "==0.10.2" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -3641,7 +3641,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.8.post2"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=0dd0645#0dd06450aed7f1a78a8eb7807b5b836575376c40" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=0149248#0149248d126d8e8fb2061dae318f139dbd7e3c4d" }
 dependencies = [
     { name = "datasets" },
     { name = "jinja2" },

--- a/uv.lock
+++ b/uv.lock
@@ -2294,7 +2294,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", specifier = ">=4.56.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=0149248" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=ca75d04" },
     { name = "vllm", specifier = "==0.10.2" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -3641,7 +3641,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.8.post2"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=0149248#0149248d126d8e8fb2061dae318f139dbd7e3c4d" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=ca75d04#ca75d04002c8e8d4eb766720ecd19e91abc02f20" }
 dependencies = [
     { name = "datasets" },
     { name = "jinja2" },


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

This PR integrates the changes in [#609](https://github.com/PrimeIntellect-ai/verifiers/pull/609). It introduces explicitly defined and per-env configurable exceptions (e.g. infra failures) which can abrupt rollouts gracefully and set an `error` field in state. 

These are now handled in PRIME-RL by
- masking out such rollouts (e.g. zeroing out`completion_mask` (which are the only ones with non-zero entries))
- logging the error ratio has occurred as `error/mean`  + distribution over error types (e.g. 0.4 tool call error and 0.6 infra error)

We also use the changes in [#637](https://github.com/PrimeIntellect-ai/verifiers/pull/637) to now rely on vf to correctly parse if a rollout has been truncated at any point. If _any_ of the following conditions is set in _any turn_, we mark the rollout as truncated:
1. We truncate based on max_seq_len in environment
2. The response is truncated based on the maximum context (typically max_model_len on the inference server)
3. The response is truncated based on the a user-defined token limit (per turn, e.g. max_tokens or max_completion_tokens)
4. We could not obtain a response because the previous turn's tokens + token/ turn exceeds the maximum context (hence, we get a BadRequestError back

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: #1418 
**Linear Issue**: Resolves PRIMERL-242

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Masks errored rollouts and logs per-type error metrics, switches truncation to vf-provided flags, adds math-python RL config, and updates verifiers revision.
> 
> - **Orchestrator**:
>   - Mask errored rollouts in training examples; safely skip empty/invalid rollouts.
>   - Log `error/mean` and per-error-type rates to monitoring.
>   - Use `rollout["is_truncated"]` (from vf) instead of internal truncation helper.
> - **Trajectories**:
>   - `interleave_rollout`/`branch_rollout` return `None` on empty trajectories and zero out `completion_mask` when `state["error"]` is set.
> - **Configs**:
>   - Add `configs/math_python` with README and `math_python.toml` (eval/RL settings, inference options).
> - **Dependencies**:
>   - Bump `verifiers` to `ca75d04`.
> - **Docs**:
>   - Changelog: note auto-setting `inference.api_server_count=1` when LoRA is enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bacd171280fe9a4a08ab86804574af32812d6565. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->