### PR TITLE
Include system prompt in logged rollouts

### DIFF
--- a/src/prime_rl/utils/monitor.py
+++ b/src/prime_rl/utils/monitor.py
@@ -54,7 +54,7 @@ class WandbMonitor:
         if config is not None and isinstance(config, WandbWithExtrasConfig) and config.log_extras:
             if config.log_extras.samples:
                 self.last_log_samples_step = -1
-                self.samples_cols = ["step", "example_id", "prompt", "messages", "input_ids", "reward"]
+                self.samples_cols = ["step", "example_id", "messages", "input_ids", "reward"]
                 self.samples_table = wandb.Table(
                     columns=self.samples_cols,
                     log_mode="INCREMENTAL",
@@ -96,19 +96,14 @@ class WandbMonitor:
         self.logger.info(f"Logging samples to W&B table at step {step}")
         start_time = time.perf_counter()
         for rollout in rollouts:
-            messages = rollout["trajectory"][-1]["prompt"] + rollout["trajectory"][-1]["completion"]
             tokens = rollout["trajectory"][-1]["tokens"]
-            if tokens is not None and "prompt_ids" in tokens:
-                prompt_text = self.tokenizer.decode(tokens["prompt_ids"])
-            else:
-                prompt = rollout["trajectory"][-1]["prompt"]
-                prompt_text = self.tokenizer.apply_chat_template(prompt, tokenize=False)
+            full_ids = tokens["prompt_ids"] + tokens["completion_ids"]
+            messages_text = self.tokenizer.decode(full_ids)
             sample = {
                 "step": step,
                 "example_id": rollout["example_id"],
-                "prompt": prompt_text,
-                "messages": self.tokenizer.apply_chat_template(messages, tokenize=False),
-                "input_ids": str(self.tokenizer.apply_chat_template(messages)),
+                "messages": messages_text,
+                "input_ids": str(full_ids),
                 "reward": rollout["reward"],
             }
             assert list(sample.keys()) == self.samples_cols, (


### PR DESCRIPTION
Add "prompt" column back to wandb logging. This now includes the system prompt even if it comes from a chat template instead of an environment, which is important for debugging.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reworks W&B sample logging to decode concatenated prompt+completion token IDs, logging the full message text (including system prompt) and raw input ID lists.
> 
> - **W&B Monitoring**:
>   - **Sample logging**:
>     - Derives `messages` by concatenating `tokens.prompt_ids` and `tokens.completion_ids` and decoding via tokenizer.
>     - Logs `input_ids` as the raw concatenated ID list (`full_ids`).
>     - Removes chat-template-based construction (`apply_chat_template`) of messages and input IDs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 699bac6432b2d177c249ee930c3e34b8c13a2c55. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->