### PR TITLE
Support vLLM multi-api server

### DIFF
--- a/src/prime_rl/inference/config.py
+++ b/src/prime_rl/inference/config.py
@@ -194,6 +194,13 @@ class InferenceConfig(BaseSettings):
                 raise ValueError(f"max_lora_rank={original_rank} exceeds vLLM maximum of {VALID_VLLM_LORA_RANKS[-1]}")
         return self
 
+    @model_validator(mode="after")
+    def ensure_api_server_count_is_at_least_dp_size(self):
+        """Ensures that we have at least as many API servers as data parallel size."""
+        if self.api_server_count < self.parallel.dp:
+            self.api_server_count = self.parallel.dp
+        return self
+
     def to_vllm(self) -> Namespace:
         """Convert InferenceConfig to vLLM-compatible Namespace."""
         namespace = Namespace()

--- a/src/prime_rl/inference/config.py
+++ b/src/prime_rl/inference/config.py
@@ -145,6 +145,14 @@ class InferenceConfig(BaseSettings):
         ),
     ] = 0.9
 
+    api_server_count: Annotated[
+        int,
+        Field(
+            ge=1,
+            description="The number of API servers to use. Passed to vLLM as `--api-server-count`",
+        ),
+    ] = 1
+
     seed: Annotated[
         int | None,
         Field(
@@ -183,9 +191,7 @@ class InferenceConfig(BaseSettings):
                     self.max_lora_rank = valid_rank
                     break
             else:
-                raise ValueError(
-                    f"max_lora_rank={original_rank} exceeds vLLM maximum of {VALID_VLLM_LORA_RANKS[-1]}"
-                )
+                raise ValueError(f"max_lora_rank={original_rank} exceeds vLLM maximum of {VALID_VLLM_LORA_RANKS[-1]}")
         return self
 
     def to_vllm(self) -> Namespace:
@@ -207,6 +213,7 @@ class InferenceConfig(BaseSettings):
             "enable_lora": "enable_lora",
             "max_lora_rank": "max_lora_rank",
             "gpu_memory_utilization": "gpu_memory_utilization",
+            "api_server_count": "api_server_count",
         }
 
         for key in get_all_fields(self):

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -24,12 +24,11 @@ from vllm.entrypoints.openai.api_server import (
     init_app_state,
     load_log_config,
     maybe_register_tokenizer_info_endpoint,
-    setup_server,
 )
 from vllm.entrypoints.openai.cli_args import make_arg_parser, validate_parsed_serve_args
 from vllm.entrypoints.openai.tool_parsers import ToolParserManager
 from vllm.logger import init_logger
-from vllm.utils import FlexibleArgumentParser, decorate_logs, set_process_title
+from vllm.utils import FlexibleArgumentParser
 
 from prime_rl.inference.config import InferenceConfig
 
@@ -65,6 +64,7 @@ async def custom_build_async_engine_client(
 # Only difference is that we inject custom routes and build async engine client differently
 async def custom_run_server_worker(listen_address, sock, args, client_config=None, **uvicorn_kwargs) -> None:
     """Run a single API server worker."""
+    print("running custom_run_server_worker")
 
     if args.tool_parser_plugin and len(args.tool_parser_plugin) > 3:
         ToolParserManager.import_tool_parser(args.tool_parser_plugin)
@@ -142,9 +142,30 @@ async def custom_run_server_worker(listen_address, sock, args, client_config=Non
         sock.close()
 
 
-import vllm.entrypoints.openai.api_server
+def custom_run_api_server_worker_proc(listen_address, sock, args, client_config=None, **uvicorn_kwargs) -> None:
+    """Entrypoint for individual API server worker processes."""
+    # Import our module to ensure monkey patches are applied in child processes
+    # This is critical because child processes start fresh and re-import modules
+    import prime_rl.inference.vllm.server  # noqa: F401
 
+    from vllm.utils import set_process_title, decorate_logs
+
+    # Set process title and add process-specific prefix to stdout and stderr.
+    server_index = client_config.get("client_index", 0) if client_config else 0
+    set_process_title("APIServer", str(server_index))
+    decorate_logs()
+
+    uvloop.run(custom_run_server_worker(listen_address, sock, args, client_config, **uvicorn_kwargs))
+
+
+import vllm.entrypoints.openai.api_server
+import vllm.entrypoints.cli.serve
+
+# Also monkey patch run_api_server_worker_proc for multi-api-server mode
+# This is needed because worker processes spawned by run_multi_api_server
+# re-import modules and would otherwise use the original run_server_worker
 vllm.entrypoints.openai.api_server.run_server_worker = custom_run_server_worker
+vllm.entrypoints.cli.serve.run_api_server_worker_proc = custom_run_api_server_worker_proc
 
 
 # Adapted from vllm/entrypoints/cli/serve.py

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -64,7 +64,6 @@ async def custom_build_async_engine_client(
 # Only difference is that we inject custom routes and build async engine client differently
 async def custom_run_server_worker(listen_address, sock, args, client_config=None, **uvicorn_kwargs) -> None:
     """Run a single API server worker."""
-    print("running custom_run_server_worker")
 
     if args.tool_parser_plugin and len(args.tool_parser_plugin) > 3:
         ToolParserManager.import_tool_parser(args.tool_parser_plugin)


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Previously, our patches to the API server to expose custom routes such as `update_weights` would only work with a single API server worker. This PR changes it such that we can run with any number of API servers.

## Minimal Example

Run with multiple API servers

```bash
uv run inference --api-server-count 2
```

## Training Example

```bash
uv run  rl @ examples/reverse_text/rl.toml --inference.api-server-count 2
```

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: #1409 
**Linear Issue**: Resolves PRIMERL-238

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables vLLM multi-API server mode with custom endpoints via monkey-patched worker entrypoints and adds `api_server_count` to config, ensuring it’s ≥ data parallel size.
> 
> - **Inference Config (`src/prime_rl/inference/config.py`)**:
>   - Add `api_server_count` with validation to be at least `parallel.dp` and map to vLLM args.
>   - Minor: compact error message for `max_lora_rank` and ensure validator returns `self`.
> - **vLLM Server (`src/prime_rl/inference/vllm/server.py`)**:
>   - Introduce `custom_run_api_server_worker_proc` and monkey-patch vLLM to use `custom_run_server_worker` for both single and multi API server workers.
>   - Ensure child worker processes import patched module, set process titles, and decorate logs.
>   - Update `server(...)` to parse config into vLLM args, validate, set custom worker extension, and dispatch to headless/single/multi server modes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ad94c1ca449988d6c69d17dd558f463bace56bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->