### PR TITLE
[Fix] Error on update fail

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -204,6 +204,9 @@ async def orchestrate(config: OrchestratorConfig):
     while True:
         # Check if update_policy_task has failed and propagate the exception
         if update_policy_task.done():
+            # End all other tasks
+            for task in asyncio.all_tasks():
+                task.cancel()
             update_policy_task.result()  # Raises if the task failed
         # Capture ckpt_step once for consistency (it's updated by update_policy_loop concurrently)
         ckpt_step = scheduler.ckpt_step

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -199,9 +199,12 @@ async def orchestrate(config: OrchestratorConfig):
     await set_semaphore(config.max_concurrent or -1)
 
     # Start update policy loop
-    asyncio.create_task(scheduler.update_policy_loop())
+    update_policy_task = asyncio.create_task(scheduler.update_policy_loop())
 
     while True:
+        # Check if update_policy_task has failed and propagate the exception
+        if update_policy_task.done():
+            update_policy_task.result()  # Raises if the task failed
         # Capture ckpt_step once for consistency (it's updated by update_policy_loop concurrently)
         ckpt_step = scheduler.ckpt_step
 


### PR DESCRIPTION
Previously failing update will silently fail and the orch just carries on

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Track `scheduler.update_policy_loop()` task; if it finishes (fails), cancel all tasks and re-raise to halt the orchestrator.
> 
> - **Orchestrator (`src/prime_rl/orchestrator/orchestrator.py`)**:
>   - Track `scheduler.update_policy_loop()` via `update_policy_task` instead of fire-and-forget.
>   - On each loop iteration, if `update_policy_task.done()`, cancel all running tasks and call `update_policy_task.result()` to propagate exceptions and stop execution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 856a3eadefd2d601a02c818d844dc085bb25ef72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->