### PR TITLE
add multiple off

### DIFF
--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -215,8 +215,8 @@ class CheckpointManager:
         ckpt_steps_to_delete = self.ckpt_steps[: -self.config.keep]
 
         # Filter out checkpoints that are multiples of keep_multiple_of
-        if self.config.keep_multiple_of is not None:
-            ckpt_steps_to_delete = [step for step in ckpt_steps_to_delete if step % self.config.keep_multiple_of != 0]
+        if self.config.keep_interval is not None:
+            ckpt_steps_to_delete = [step for step in ckpt_steps_to_delete if step % self.config.keep_interval != 0]
 
         for ckpt_step in ckpt_steps_to_delete:
             trainer_ckpt_path = self.get_ckpt_path(ckpt_step)
@@ -227,9 +227,9 @@ class CheckpointManager:
 
         # Update checkpoint steps - keep recent ones and multiples
         kept_steps = self.ckpt_steps[-self.config.keep :]
-        if self.config.keep_multiple_of is not None:
+        if self.config.keep_interval is not None:
             kept_steps.extend(
-                [step for step in self.ckpt_steps[: -self.config.keep] if step % self.config.keep_multiple_of == 0]
+                [step for step in self.ckpt_steps[: -self.config.keep] if step % self.config.keep_interval == 0]
             )
             kept_steps = sorted(set(kept_steps))
         self.ckpt_steps = kept_steps
@@ -372,7 +372,7 @@ def setup_ckpt_managers(
             ckpt_config.weights,
             lora_config=lora_config,
             keep=ckpt_config.keep,
-            keep_multiple_of=ckpt_config.keep_multiple_of,
+            keep_multiple_of=ckpt_config.keep_interval,
         )
     else:
         weight_ckpt_manager = None

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -425,7 +425,7 @@ class CheckpointConfig(BaseConfig):
         ),
     ] = None
 
-    keep_multiple_of: Annotated[
+    keep_interval: Annotated[
         int | None,
         Field(
             ge=1,

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -425,6 +425,14 @@ class CheckpointConfig(BaseConfig):
         ),
     ] = None
 
+    keep_multiple_of: Annotated[
+        int | None,
+        Field(
+            ge=1,
+            description="Always keep checkpoints whose step numbers are multiples of this value, even if they would otherwise be deleted by the keep limit. If None, no special preservation is applied.",
+        ),
+    ] = None
+
     skip_progress: Annotated[
         bool,
         Field(


### PR DESCRIPTION
# Checkpoint

add an option to keep last ckpt as a multiple of.

Example

```
uv run torchrun --local-ranks-filter 0 --nproc_per_node=2 src/prime_rl/trainer/sft/train.py @ configs/debug/sft/train.toml  --max-steps 5  --ckpt.interval 1  --ckpt.keep 1 --ckpt.keep_multiple_of 2
```

will keep
```
❯ ls outputs/checkpoints
step_2  step_4  step_5
```

