### PR TITLE
allow to use resume step -1 even without checkpoint

### DIFF
--- a/src/prime_rl/orchestrator/ckpt.py
+++ b/src/prime_rl/orchestrator/ckpt.py
@@ -81,18 +81,19 @@ class CheckpointManager:
 
         self.logger.debug(f"Orchestrator checkpoint loaded in {time.perf_counter() - start_time:.2f} seconds")
 
-    def load(self, progress: Progress, buffer: Buffer, step: int) -> None:
-        """Loads a checkpoint from a given path."""
+    def load(self, progress: Progress, buffer: Buffer, step: int) -> bool:
+        """Loads a checkpoint from a given path. Returns True if checkpoint was loaded, False otherwise."""
         if step == -1:
             step = self.get_latest_step()
             if step is None:
                 self.logger.warning(f"No checkpoints found in {self.ckpt_dir}. Starting from scratch.")
-                return
+                return False
 
         ckpt_path = self.get_ckpt_path(step)
         if not ckpt_path.exists():
             raise FileNotFoundError(f"Checkpoint not found at {ckpt_path}")
         self._load_from_path(ckpt_path, progress, buffer)
+        return True
 
     def save(
         self,

--- a/src/prime_rl/orchestrator/ckpt.py
+++ b/src/prime_rl/orchestrator/ckpt.py
@@ -29,15 +29,6 @@ class CheckpointManager:
     def get_ckpt_path(self, step: int) -> Path:
         return get_step_path(self.ckpt_dir, step) / "orchestrator"
 
-    def get_latest_step(self) -> int | None:
-        step_dirs = list(self.ckpt_dir.glob("step_*"))
-        if len(step_dirs) == 0:
-            return None
-        steps = sorted([int(step_dir.name.split("_")[-1]) for step_dir in step_dirs])
-        latest_step = steps[-1]
-        self.logger.info(f"Found latest checkpoint in {self.ckpt_dir}: {latest_step}")
-        return latest_step
-
     def _save_to_path(
         self,
         ckpt_path: Path,
@@ -81,19 +72,12 @@ class CheckpointManager:
 
         self.logger.debug(f"Orchestrator checkpoint loaded in {time.perf_counter() - start_time:.2f} seconds")
 
-    def load(self, progress: Progress, buffer: Buffer, step: int) -> bool:
-        """Loads a checkpoint from a given path. Returns True if checkpoint was loaded, False otherwise."""
-        if step == -1:
-            step = self.get_latest_step()
-            if step is None:
-                self.logger.warning(f"No checkpoints found in {self.ckpt_dir}. Starting from scratch.")
-                return False
-
+    def load(self, progress: Progress, buffer: Buffer, step: int) -> None:
+        """Loads a checkpoint from a given path."""
         ckpt_path = self.get_ckpt_path(step)
         if not ckpt_path.exists():
             raise FileNotFoundError(f"Checkpoint not found at {ckpt_path}")
         self._load_from_path(ckpt_path, progress, buffer)
-        return True
 
     def save(
         self,

--- a/src/prime_rl/orchestrator/ckpt.py
+++ b/src/prime_rl/orchestrator/ckpt.py
@@ -29,10 +29,10 @@ class CheckpointManager:
     def get_ckpt_path(self, step: int) -> Path:
         return get_step_path(self.ckpt_dir, step) / "orchestrator"
 
-    def get_latest_step(self) -> int:
+    def get_latest_step(self) -> int | None:
         step_dirs = list(self.ckpt_dir.glob("step_*"))
         if len(step_dirs) == 0:
-            raise ValueError(f"No checkpoints found in {self.ckpt_dir}")
+            return None
         steps = sorted([int(step_dir.name.split("_")[-1]) for step_dir in step_dirs])
         latest_step = steps[-1]
         self.logger.info(f"Found latest checkpoint in {self.ckpt_dir}: {latest_step}")
@@ -85,6 +85,9 @@ class CheckpointManager:
         """Loads a checkpoint from a given path."""
         if step == -1:
             step = self.get_latest_step()
+            if step is None:
+                self.logger.warning(f"No checkpoints found in {self.ckpt_dir}. Starting from scratch.")
+                return
 
         ckpt_path = self.get_ckpt_path(step)
         if not ckpt_path.exists():

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -178,9 +178,9 @@ async def orchestrate(config: OrchestratorConfig):
     progress = Progress()
 
     checkpoint_step = None
-    if config.ckpt and config.ckpt.resume_step is not None:
+    if config.ckpt and config.ckpt.resume_step is not None and ckpt_manager is not None:
         if config.ckpt.resume_step == -1:
-            checkpoint_step = resolve_latest_ckpt_step(ckpt_manager.ckpt_dir if ckpt_manager is not None else None)
+            checkpoint_step = resolve_latest_ckpt_step(ckpt_manager.ckpt_dir)
         else:
             checkpoint_step = config.ckpt.resume_step
 

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -93,16 +93,6 @@ class CheckpointManager:
         """Get the path to write the trainer checkpoint for a given step."""
         return get_step_path(self.ckpt_dir, step) / "trainer"
 
-    def get_latest_step(self) -> int | None:
-        """Get the latest checkpoint step from the checkpoint directory."""
-        step_dirs = list(self.ckpt_dir.glob("step_*"))
-        if len(step_dirs) == 0:
-            return None
-        steps = sorted([int(step_dir.name.split("_")[-1]) for step_dir in step_dirs])
-        latest_step = steps[-1]
-        self.logger.info(f"Found latest checkpoint in {self.ckpt_dir}: {latest_step}")
-        return latest_step
-
     def save_to_path(
         self,
         path: Path,
@@ -172,19 +162,12 @@ class CheckpointManager:
         scheduler: LRScheduler | None,
         progress: Progress | None,
         dataloader: StatefulDataLoader | None = None,
-    ) -> bool:
-        """Load the trainer checkpoint for a given step (in-place). Returns True if checkpoint was loaded, False otherwise."""
-        if step == -1:
-            step = self.get_latest_step()
-            if step is None:
-                self.logger.warning(f"No checkpoints found in {self.ckpt_dir}. Starting from scratch.")
-                return False
-
+    ) -> None:
+        """Load the trainer checkpoint for a given step (in-place)."""
         ckpt_path = self.get_ckpt_path(step)
         if not ckpt_path.exists():
             raise FileNotFoundError(f"Checkpoint not found at {ckpt_path}")
         self.load_from_path(ckpt_path, model, optimizers, scheduler, progress, dataloader)
-        return True
         self.logger.debug(
             f"Signatures after loading training checkpoint: model={get_module_signature(model, compress=True)}, optimizers={', '.join(get_optimizer_signature(optimizer, compress=True) for optimizer in optimizers)}"
         )

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -93,11 +93,11 @@ class CheckpointManager:
         """Get the path to write the trainer checkpoint for a given step."""
         return get_step_path(self.ckpt_dir, step) / "trainer"
 
-    def get_latest_step(self) -> int:
+    def get_latest_step(self) -> int | None:
         """Get the latest checkpoint step from the checkpoint directory."""
         step_dirs = list(self.ckpt_dir.glob("step_*"))
         if len(step_dirs) == 0:
-            raise ValueError(f"No checkpoints found in {self.ckpt_dir}")
+            return None
         steps = sorted([int(step_dir.name.split("_")[-1]) for step_dir in step_dirs])
         latest_step = steps[-1]
         self.logger.info(f"Found latest checkpoint in {self.ckpt_dir}: {latest_step}")
@@ -176,6 +176,9 @@ class CheckpointManager:
         """Load the trainer checkpoint for a given step (in-place)."""
         if step == -1:
             step = self.get_latest_step()
+            if step is None:
+                self.logger.warning(f"No checkpoints found in {self.ckpt_dir}. Starting from scratch.")
+                return
 
         ckpt_path = self.get_ckpt_path(step)
         if not ckpt_path.exists():

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -172,18 +172,19 @@ class CheckpointManager:
         scheduler: LRScheduler | None,
         progress: Progress | None,
         dataloader: StatefulDataLoader | None = None,
-    ) -> None:
-        """Load the trainer checkpoint for a given step (in-place)."""
+    ) -> bool:
+        """Load the trainer checkpoint for a given step (in-place). Returns True if checkpoint was loaded, False otherwise."""
         if step == -1:
             step = self.get_latest_step()
             if step is None:
                 self.logger.warning(f"No checkpoints found in {self.ckpt_dir}. Starting from scratch.")
-                return
+                return False
 
         ckpt_path = self.get_ckpt_path(step)
         if not ckpt_path.exists():
             raise FileNotFoundError(f"Checkpoint not found at {ckpt_path}")
         self.load_from_path(ckpt_path, model, optimizers, scheduler, progress, dataloader)
+        return True
         self.logger.debug(
             f"Signatures after loading training checkpoint: model={get_module_signature(model, compress=True)}, optimizers={', '.join(get_optimizer_signature(optimizer, compress=True) for optimizer in optimizers)}"
         )

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -121,8 +121,9 @@ def train(config: RLTrainerConfig):
     # Optionally, resume training from a checkpoint
     progress = Progress()
     if config.ckpt and ckpt_manager is not None and config.ckpt.resume_step:
-        logger.info(f"Resuming training from checkpoint step {config.ckpt.resume_step}")
-        ckpt_manager.load(config.ckpt.resume_step, model, [optimizer], scheduler, progress)
+        checkpoint_loaded = ckpt_manager.load(config.ckpt.resume_step, model, [optimizer], scheduler, progress)
+        if checkpoint_loaded:
+            logger.info(f"Resuming training from checkpoint step {config.ckpt.resume_step}")
     logger.info(
         f"Starting from step {progress.step} (total_tokens={progress.total_tokens}, total_samples={progress.total_samples})"
     )

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -44,7 +44,7 @@ from prime_rl.trainer.runs import setup_runs, Progress, get_runs
 from prime_rl.utils.heartbeat import Heartbeat
 from prime_rl.utils.monitor import setup_monitor
 from prime_rl.utils.pydantic_config import parse_argv
-from prime_rl.utils.utils import clean_exit, to_col_format
+from prime_rl.utils.utils import clean_exit, resolve_latest_ckpt_step, to_col_format
 
 
 @clean_exit
@@ -120,10 +120,16 @@ def train(config: RLTrainerConfig):
 
     # Optionally, resume training from a checkpoint
     progress = Progress()
-    if config.ckpt and ckpt_manager is not None and config.ckpt.resume_step:
-        checkpoint_loaded = ckpt_manager.load(config.ckpt.resume_step, model, [optimizer], scheduler, progress)
-        if checkpoint_loaded:
-            logger.info(f"Resuming training from checkpoint step {config.ckpt.resume_step}")
+    checkpoint_step = None
+    if config.ckpt and config.ckpt.resume_step is not None and ckpt_manager is not None:
+        if config.ckpt.resume_step == -1:
+            checkpoint_step = resolve_latest_ckpt_step(ckpt_manager.ckpt_dir)
+        else:
+            checkpoint_step = config.ckpt.resume_step
+    if checkpoint_step is not None:
+        ckpt_manager.load(checkpoint_step, model, [optimizer], scheduler, progress)
+        logger.info(f"Resuming training from checkpoint step {checkpoint_step}")
+
     logger.info(
         f"Starting from step {progress.step} (total_tokens={progress.total_tokens}, total_samples={progress.total_samples})"
     )

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -123,7 +123,7 @@ def train(config: SFTTrainerConfig):
     progress = Progress()
 
     checkpoint_step = None
-    if config.ckpt and config.ckpt.resume_step is not None:
+    if config.ckpt and config.ckpt.resume_step is not None and ckpt_manager is not None:
         if config.ckpt.resume_step == -1:
             checkpoint_step = resolve_latest_ckpt_step(ckpt_manager.ckpt_dir)
         else:

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -121,8 +121,7 @@ def train(config: SFTTrainerConfig):
     # Optionally, resume training from a checkpoint
     progress = Progress()
     if ckpt_manager is not None and config.ckpt and config.ckpt.resume_step:
-        logger.info(f"Resuming training from checkpoint step {config.ckpt.resume_step}")
-        ckpt_manager.load(
+        checkpoint_loaded = ckpt_manager.load(
             config.ckpt.resume_step,
             model,
             [optimizer],
@@ -130,6 +129,8 @@ def train(config: SFTTrainerConfig):
             progress if not config.ckpt.skip_progress else None,
             dataloader=dataloader if not config.ckpt.skip_dataloader else None,
         )
+        if checkpoint_loaded:
+            logger.info(f"Resuming training from checkpoint step {config.ckpt.resume_step}")
         # This redundant setup is necessary because loading the optimizer's state has side effects on the scheduler state dict
         if config.ckpt.skip_scheduler:
             scheduler = setup_scheduler(optimizer, config.scheduler, scheduler_steps, config.optim.lr)

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -13,6 +13,7 @@ from torch.distributed.tensor.experimental import context_parallel
 from torch.profiler import profile, ProfilerActivity, record_function
 from loguru import logger
 from prime_rl.trainer.ckpt import setup_ckpt_managers
+from prime_rl.utils.pathing import resolve_latest_ckpt_step
 from prime_rl.trainer.sft.config import SFTTrainerConfig
 from prime_rl.trainer.runs import Progress
 from prime_rl.utils.logger import setup_logger
@@ -120,17 +121,24 @@ def train(config: SFTTrainerConfig):
 
     # Optionally, resume training from a checkpoint
     progress = Progress()
-    if ckpt_manager is not None and config.ckpt and config.ckpt.resume_step:
-        checkpoint_loaded = ckpt_manager.load(
-            config.ckpt.resume_step,
+
+    checkpoint_step = None
+    if config.ckpt and config.ckpt.resume_step is not None:
+        if config.ckpt.resume_step == -1:
+            checkpoint_step = resolve_latest_ckpt_step(ckpt_manager.ckpt_dir)
+        else:
+            checkpoint_step = config.ckpt.resume_step
+
+    if checkpoint_step is not None:
+        ckpt_manager.load(
+            checkpoint_step,
             model,
             [optimizer],
             scheduler if not config.ckpt.skip_scheduler else None,
             progress if not config.ckpt.skip_progress else None,
             dataloader=dataloader if not config.ckpt.skip_dataloader else None,
         )
-        if checkpoint_loaded:
-            logger.info(f"Resuming training from checkpoint step {config.ckpt.resume_step}")
+        logger.info(f"Resuming training from checkpoint step {checkpoint_step}")
         # This redundant setup is necessary because loading the optimizer's state has side effects on the scheduler state dict
         if config.ckpt.skip_scheduler:
             scheduler = setup_scheduler(optimizer, config.scheduler, scheduler_steps, config.optim.lr)

--- a/src/prime_rl/utils/pathing.py
+++ b/src/prime_rl/utils/pathing.py
@@ -33,6 +33,20 @@ def get_step_path(path: Path, step: int) -> Path:
     return path / f"step_{step}"
 
 
+def resolve_latest_ckpt_step(ckpt_dir: Path) -> int | None:
+    """Gets the latest checkpoint step from the checkpoint directory. Returns None if no checkpoints are found."""
+    step_dirs = list(ckpt_dir.glob("step_*"))
+    if len(step_dirs) == 0:
+        logger = get_logger()
+        logger.warning(f"No checkpoints found in {ckpt_dir}. Starting from scratch.")
+        return None
+    steps = sorted([int(step_dir.name.split("_")[-1]) for step_dir in step_dirs])
+    latest_step = steps[-1]
+    logger = get_logger()
+    logger.info(f"Found latest checkpoint in {ckpt_dir}: {latest_step}")
+    return latest_step
+
+
 def sync_wait_for_path(path: Path, interval: int = 1, log_interval: int = 10) -> None:
     logger = get_logger()
     wait_time = 0

--- a/src/prime_rl/utils/utils.py
+++ b/src/prime_rl/utils/utils.py
@@ -24,6 +24,7 @@ from prime_rl.utils.pathing import (
     get_rollout_dir,
     get_step_path,
     get_weights_dir,
+    resolve_latest_ckpt_step,
     sync_wait_for_path,
     wait_for_path,
 )


### PR DESCRIPTION
in prod run we usually use `ckpt.resume-step -1` in the slurm script to allow automatic restart.

The issue is that so far this was not compatible with restarting from scratch as it would fail if no ckpt were present. This pr allow to start from 0 even with this flag on. 

This allow to use the same script for start and restart making it easier to maintain 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds resolve_latest_ckpt_step and updates orchestrator/RL/SFT trainers to resolve -1 to the latest checkpoint or start from scratch if none exist.
> 
> - **Checkpointing**:
>   - Introduce `utils.pathing.resolve_latest_ckpt_step(ckpt_dir)` returning latest step or `None` with warning if no checkpoints.
>   - Remove `get_latest_step` and `-1` handling from `orchestrator.CheckpointManager.load` and `trainer.CheckpointManager.load`; callers now resolve steps.
> - **Orchestrator/Trainer startup**:
>   - When `ckpt.resume_step == -1`, use `resolve_latest_ckpt_step`; load if found, otherwise start from scratch.
>   - Update imports in `orchestrator.py`, `trainer/rl/train.py`, and `trainer/sft/train.py` to use the new helper; add concise resume logging.
>   - Orchestrator: if starting from scratch and no `lora_name`, call `reload_weights(admin_clients)` to reset to base model.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e52260572ac323da685ac73c7868a246d132687b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->