### PR TITLE
[Fix] clean orch dirs

### DIFF
--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -450,6 +450,7 @@ def rl(config: RLConfig):
 
     # Prepare paths to communicate with the trainer
     log_dir = get_log_dir(config.output_dir)
+    orch_log_dir = get_log_dir(config.orchestrator.output_dir)
     rollout_dir = get_rollout_dir(config.orchestrator.output_dir)
     broadcast_dir = get_broadcast_dir(config.orchestrator.output_dir)
 
@@ -461,6 +462,10 @@ def rl(config: RLConfig):
         logger.info(f"Cleaning log dir ({log_dir})")
         shutil.rmtree(log_dir, ignore_errors=True)
         log_dir.mkdir(parents=True, exist_ok=True)
+
+        logger.info(f"Cleaning orchestrator log dir ({orch_log_dir})")
+        shutil.rmtree(orch_log_dir, ignore_errors=True)
+        orch_log_dir.mkdir(parents=True, exist_ok=True)
 
         # Cleaning broadcast dir (so that orchestrator does not pre-maturely update weights)
         if not (

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -450,8 +450,8 @@ def rl(config: RLConfig):
 
     # Prepare paths to communicate with the trainer
     log_dir = get_log_dir(config.output_dir)
-    rollout_dir = get_rollout_dir(config.output_dir)
-    broadcast_dir = get_broadcast_dir(config.output_dir)
+    rollout_dir = get_rollout_dir(config.orchestrator.output_dir)
+    broadcast_dir = get_broadcast_dir(config.orchestrator.output_dir)
 
     # Clean up directories if specified
     if config.clean:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switch rollout/broadcast paths to `config.orchestrator.output_dir` and add cleaning of orchestrator log directory.
> 
> - **RL runner (`src/prime_rl/rl.py`)**:
>   - Use `config.orchestrator.output_dir` for `rollout_dir` and `broadcast_dir`.
>   - Add `orch_log_dir` derived from `config.orchestrator.output_dir` and clean it during startup when `clean` is enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b73ac837a977dade8030fd5c3614b8076c16eab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->