### PR TITLE
Feat: remove config.load_using_meta and default to it now + remove weight double loading

### DIFF
--- a/configs/debug/moe/sft/train.toml
+++ b/configs/debug/moe/sft/train.toml
@@ -5,7 +5,6 @@ name = "PrimeIntellect/GLM-0.5B"
 moe_use_grouped_mm = false
 impl = "custom"
 attn = "sdpa"
-load_using_meta = true
 
 [model.compile]
 

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -213,13 +213,6 @@ class ModelConfig(BaseConfig):
         ),
     ] = "hf"
 
-    load_using_meta: Annotated[
-        bool,
-        Field(
-            description="Whether to load the model using meta device then load from HF ckpt.",
-        ),
-    ] = False
-
     optimization_dtype: Annotated[
         Literal["bfloat16", "float32"],
         Field(
@@ -268,13 +261,6 @@ class ModelConfig(BaseConfig):
         if self.trust_remote_code:
             if self.impl != "hf":
                 raise ValueError("Trust remote code is only supported with the HF implementation.")
-        return self
-
-    @model_validator(mode="after")
-    def random_init_only_with_meta(self):
-        """Random initialize is only supported with the custom implementation."""
-        if self.debug.random_init and not self.load_using_meta:
-            raise ValueError("Random initialize is only supported when loading with meta.")
         return self
 
 

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -334,6 +334,11 @@ def setup_model(
     model = get_model(config, device=torch.device("meta"), dtype=DTYPE_MAP[config.optimization_dtype])
     possible_to_load_to_meta = can_reinit_empty_buffers(model)
 
+    if config.debug.random_init and not possible_to_load_to_meta:
+        raise ValueError(
+            "It's not possible to load to meta device and random initialize is enabled. Please disable random initialize or use a different model."
+        )
+
     # 1a. We load to CPU if we cannot reinit empty buffers
     if not possible_to_load_to_meta:
         logger.warning("Cannot load model to meta device only, loading to CPU instead.")

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -179,22 +179,6 @@ def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDim
     )
 
 
-def model_init_lora(model: nn.Module, parallel_dims: ParallelDims):
-    lora_modules = [m for m in model.modules() if hasattr(m, "_init_lora_parameters")]
-    if lora_modules:
-        generator: torch.Generator | None = None
-        if parallel_dims.dp_replicate_enabled:
-            # Synchronize LoRA initialization across dp_replicate ranks by broadcasting a seed
-            dp_replicate_mesh = parallel_dims.world_mesh["dp_replicate"]
-            seed_tensor = torch.empty(1, dtype=torch.long, device="cuda")
-            if dp_replicate_mesh.get_local_rank() == 0:
-                seed_tensor.random_()
-            torch.distributed.broadcast(seed_tensor, src=0, group=dp_replicate_mesh.get_group())
-            generator = torch.Generator(device="cuda").manual_seed(seed_tensor.item())
-        for module in lora_modules:
-            module._init_lora_parameters(generator)
-
-
 def load_dcp_from_hf(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDims):
     model.to_empty(device="cuda")
     torch.distributed.barrier()
@@ -265,8 +249,19 @@ def load_dcp_from_hf(model: nn.Module, config: ModelConfig, parallel_dims: Paral
         model.init_buffers_post_meta()
     else:
         fix_model_post_empty(model)
-
-    model_init_lora(model, parallel_dims)
+    lora_modules = [m for m in model.modules() if hasattr(m, "_init_lora_parameters")]
+    if lora_modules:
+        generator: torch.Generator | None = None
+        if parallel_dims.dp_replicate_enabled:
+            # Synchronize LoRA initialization across dp_replicate ranks by broadcasting a seed
+            dp_replicate_mesh = parallel_dims.world_mesh["dp_replicate"]
+            seed_tensor = torch.empty(1, dtype=torch.long, device="cuda")
+            if dp_replicate_mesh.get_local_rank() == 0:
+                seed_tensor.random_()
+            torch.distributed.broadcast(seed_tensor, src=0, group=dp_replicate_mesh.get_group())
+            generator = torch.Generator(device="cuda").manual_seed(seed_tensor.item())
+        for module in lora_modules:
+            module._init_lora_parameters(generator)
     logger.debug(f"Loaded weights using HF DCP in {time.perf_counter() - load_dcp_start_time:.2f} seconds")
 
 
@@ -374,9 +369,6 @@ def setup_model(
                 model.init_buffers_post_meta()
             else:
                 fix_model_post_empty(model)
-
-            # pre-emptively initialize LoRA parameters to avoid empty weights
-            model_init_lora(model, parallel_dims)
         # - or load from HF with dcp
         else:
             load_dcp_from_hf(model, config, parallel_dims)

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -91,7 +91,8 @@ def train(config: RLTrainerConfig):
 
     # Initialize the model and tokenizer
     logger.info(f"Initializing model ({config.model})")
-    model = setup_model(config.model, parallel_dims)
+    loading_from_ckpt_later = config.ckpt and config.ckpt.resume_step
+    model = setup_model(config.model, parallel_dims, loading_from_ckpt_later)
 
     logger.info(f"Initializing tokenizer ({config.tokenizer})")
     tokenizer = setup_tokenizer(config.tokenizer)

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -91,7 +91,7 @@ def train(config: RLTrainerConfig):
 
     # Initialize the model and tokenizer
     logger.info(f"Initializing model ({config.model})")
-    loading_from_ckpt_later = config.ckpt and config.ckpt.resume_step
+    loading_from_ckpt_later = config.ckpt and config.ckpt.resume_step > 0
     model = setup_model(config.model, parallel_dims, loading_from_ckpt_later)
 
     logger.info(f"Initializing tokenizer ({config.tokenizer})")

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -92,9 +92,23 @@ def train(config: RLTrainerConfig):
     # Initialize parallel dimensions
     parallel_dims = get_parallel_dims(config.model)
 
+    # Set up checkpoint manager
+    logger.info(f"Initializing checkpoint managers ({config.ckpt})")
+    ckpt_manager, weight_ckpt_manager = setup_ckpt_managers(
+        config.output_dir, config.ckpt, config.model.experimental.lora
+    )
+
+    # get the checkpoint step to load from
+    checkpoint_step = None
+    if config.ckpt and config.ckpt.resume_step is not None and ckpt_manager is not None:
+        if config.ckpt.resume_step == -1:
+            checkpoint_step = resolve_latest_ckpt_step(ckpt_manager.ckpt_dir)
+        else:
+            checkpoint_step = config.ckpt.resume_step
+
     # Initialize the model and tokenizer
     logger.info(f"Initializing model ({config.model})")
-    loading_from_ckpt_later = config.ckpt and config.ckpt.resume_step and config.ckpt.resume_step > 0
+    loading_from_ckpt_later = config.ckpt and checkpoint_step is not None
     model = setup_model(config.model, parallel_dims, loading_from_ckpt_later)
 
     logger.info(f"Initializing tokenizer ({config.tokenizer})")
@@ -120,20 +134,8 @@ def train(config: RLTrainerConfig):
         substitute_hf_flash_attn(parallel_dims.world_mesh["cp"].get_group(), heads_k_stride=1)
         substitute_prime_rl_flash_attn(parallel_dims.world_mesh["cp"].get_group(), heads_k_stride=1)
 
-    # Set up checkpoint manager
-    logger.info(f"Initializing checkpoint managers ({config.ckpt})")
-    ckpt_manager, weight_ckpt_manager = setup_ckpt_managers(
-        config.output_dir, config.ckpt, config.model.experimental.lora
-    )
-
     # Optionally, resume training from a checkpoint
     progress = Progress()
-    checkpoint_step = None
-    if config.ckpt and config.ckpt.resume_step is not None and ckpt_manager is not None:
-        if config.ckpt.resume_step == -1:
-            checkpoint_step = resolve_latest_ckpt_step(ckpt_manager.ckpt_dir)
-        else:
-            checkpoint_step = config.ckpt.resume_step
     if checkpoint_step is not None:
         ckpt_manager.load(checkpoint_step, model, [optimizer], scheduler, progress)
         logger.info(f"Resuming training from checkpoint step {checkpoint_step}")

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -91,7 +91,7 @@ def train(config: RLTrainerConfig):
 
     # Initialize the model and tokenizer
     logger.info(f"Initializing model ({config.model})")
-    loading_from_ckpt_later = config.ckpt and config.ckpt.resume_step > 0
+    loading_from_ckpt_later = config.ckpt and config.ckpt.resume_step and config.ckpt.resume_step > 0
     model = setup_model(config.model, parallel_dims, loading_from_ckpt_later)
 
     logger.info(f"Initializing tokenizer ({config.tokenizer})")

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -87,8 +87,8 @@ def train(config: SFTTrainerConfig):
 
     # Initialize the model and tokenizer
     logger.info(f"Initializing model ({config.model})")
-    skip_load_weights = config.ckpt and config.ckpt.resume_step
-    model = setup_model(config.model, parallel_dims, skip_load_weights)
+    loading_from_ckpt_later = config.ckpt and config.ckpt.resume_step
+    model = setup_model(config.model, parallel_dims, loading_from_ckpt_later)
 
     logger.info(f"Initializing tokenizer ({config.tokenizer})")
     tokenizer = setup_tokenizer(config.tokenizer)

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -87,7 +87,8 @@ def train(config: SFTTrainerConfig):
 
     # Initialize the model and tokenizer
     logger.info(f"Initializing model ({config.model})")
-    model = setup_model(config.model, parallel_dims)
+    skip_load_weights = config.ckpt and config.ckpt.resume_step
+    model = setup_model(config.model, parallel_dims, skip_load_weights)
 
     logger.info(f"Initializing tokenizer ({config.tokenizer})")
     tokenizer = setup_tokenizer(config.tokenizer)

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -87,7 +87,7 @@ def train(config: SFTTrainerConfig):
 
     # Initialize the model and tokenizer
     logger.info(f"Initializing model ({config.model})")
-    loading_from_ckpt_later = config.ckpt and config.ckpt.resume_step
+    loading_from_ckpt_later = config.ckpt and config.ckpt.resume_step > 0
     model = setup_model(config.model, parallel_dims, loading_from_ckpt_later)
 
     logger.info(f"Initializing tokenizer ({config.tokenizer})")

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -87,7 +87,7 @@ def train(config: SFTTrainerConfig):
 
     # Initialize the model and tokenizer
     logger.info(f"Initializing model ({config.model})")
-    loading_from_ckpt_later = config.ckpt and config.ckpt.resume_step > 0
+    loading_from_ckpt_later = config.ckpt and config.ckpt.resume_step and config.ckpt.resume_step > 0
     model = setup_model(config.model, parallel_dims, loading_from_ckpt_later)
 
     logger.info(f"Initializing tokenizer ({config.tokenizer})")

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -93,9 +93,22 @@ def train(config: SFTTrainerConfig):
         substitute_hf_flash_attn(parallel_dims.world_mesh["cp"].get_group(), heads_k_stride=1)
         substitute_prime_rl_flash_attn(parallel_dims.world_mesh["cp"].get_group(), heads_k_stride=1)
 
+    # Set up checkpoint manager
+    logger.info(f"Initializing checkpoint managers ({config.ckpt})")
+    ckpt_manager, weight_ckpt_manager = setup_ckpt_managers(
+        config.output_dir, config.ckpt, config.model.experimental.lora
+    )
+
+    checkpoint_step = None
+    if config.ckpt and config.ckpt.resume_step is not None and ckpt_manager is not None:
+        if config.ckpt.resume_step == -1:
+            checkpoint_step = resolve_latest_ckpt_step(ckpt_manager.ckpt_dir)
+        else:
+            checkpoint_step = config.ckpt.resume_step
+
     # Initialize the model and tokenizer
     logger.info(f"Initializing model ({config.model})")
-    loading_from_ckpt_later = config.ckpt and config.ckpt.resume_step and config.ckpt.resume_step > 0
+    loading_from_ckpt_later = config.ckpt and checkpoint_step is not None
     model = setup_model(config.model, parallel_dims, loading_from_ckpt_later)
 
     logger.info(f"Initializing tokenizer ({config.tokenizer})")
@@ -115,12 +128,6 @@ def train(config: SFTTrainerConfig):
     logger.info(f"Setting up {config.scheduler.type} scheduler with {scheduler_steps} steps ({config.scheduler})")
     scheduler = setup_scheduler(optimizer, config.scheduler, scheduler_steps, config.optim.lr)
 
-    # Set up checkpoint manager
-    logger.info(f"Initializing checkpoint managers ({config.ckpt})")
-    ckpt_manager, weight_ckpt_manager = setup_ckpt_managers(
-        config.output_dir, config.ckpt, config.model.experimental.lora
-    )
-
     # Set up the dataset and dataloader
     logger.info(f"Initializing data ({config.data})")
     dataset = setup_dataset(tokenizer, config.data, config.model.cp * config.model.tp)
@@ -129,13 +136,6 @@ def train(config: SFTTrainerConfig):
 
     # Optionally, resume training from a checkpoint
     progress = Progress()
-
-    checkpoint_step = None
-    if config.ckpt and config.ckpt.resume_step is not None and ckpt_manager is not None:
-        if config.ckpt.resume_step == -1:
-            checkpoint_step = resolve_latest_ckpt_step(ckpt_manager.ckpt_dir)
-        else:
-            checkpoint_step = config.ckpt.resume_step
 
     if checkpoint_step is not None:
         ckpt_manager.load(


### PR DESCRIPTION
Give feedback on this, can cleanup if agreed on

Proposes to remove config.load_using_meta, defaulting to True and only loading to cpu if not possible to use meta device (some buffers cannot be reinitialized)

Qwen3-30B-A3B and Intellect 3 (30 layers as I can't fit more on 1 node)

<img width="3324" height="1837" alt="image" src="https://github.com/user-attachments/assets/86176ebd-948a-436f-a5fb-09a4eb81a05c" />
<img width="3328" height="1836" alt="image" src="https://github.com/user-attachments/assets/98e3b4cd-f038-4beb-bb1a-4adba5a0d64b" />

<img width="3320" height="1832" alt="image" src="https://github.com/user-attachments/assets/166a1e70-58ba-4713-a42f-13898106e9d5" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Default model init to meta with CPU fallback, remove `model.load_using_meta`, and make trainers init checkpoints earlier to optionally defer weight loading.
> 
> - **Model loading**:
>   - Default to loading models on `meta` with CPU fallback if `can_reinit_empty_buffers` fails; remove `ModelConfig.load_using_meta` and its validator.
>   - Rename/replace `can_load_dcp_from_hf` with `can_reinit_empty_buffers`; use `fix_model_post_empty`/`init_buffers_post_meta` after `to_empty`.
>   - `setup_model(config, parallel_dims, loading_from_checkpoint_later)` now supports deferring weight load when resuming from checkpoints and otherwise loads via HF DCP.
> - **Trainers (RL/SFT)**:
>   - Initialize checkpoint managers before model construction; resolve `checkpoint_step` and pass `loading_from_checkpoint_later` to `setup_model`.
>   - Remove duplicated checkpoint-step resolution and post-optimizer scheduler fixes are handled accordingly.
> - **Config & debug**:
>   - Drop `load_using_meta` option from `ModelConfig` and the random-init/meta constraint validator.
>   - Minor config file tidy in `configs/debug/moe/sft/train.toml` (sequence length retained).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc657f4d30fde64bb9b71c5409a43f665eb8ec85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->