### PR TITLE
Bugbot changelog reminder

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -1,0 +1,11 @@
+# BugBot Instructions
+
+## Changelog Enforcement
+
+Any PR that modifies configuration structures or usage patterns must update `CHANGELOG.md`. This includes changes to config fields (added, removed, renamed, moved, or default value changes) in:
+
+- `src/prime_rl/*/config.py`
+- `src/prime_rl/rl.py`
+- `src/prime_rl/utils/config.py`
+
+If such changes are detected without a corresponding `CHANGELOG.md` update, request that the author add an entry.


### PR DESCRIPTION
Introduces `BUGBOT.md` to enforce `CHANGELOG.md` updates for any PR modifying configuration structures or usage patterns, ensuring better documentation and maintainability.

---

**GitHub Issue**: [Issue ID]
**Linear Issue**: Resolves [Issue ID]

---
<a href="https://cursor.com/background-agent?bcId=bc-11a6f0dc-1033-45e5-8cb4-b5fe8ff30207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-11a6f0dc-1033-45e5-8cb4-b5fe8ff30207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `.cursor/BUGBOT.md` with rules requiring `CHANGELOG.md` updates when config structures or usage patterns change.
> 
> - **Docs/Tooling**:
>   - Add `/.cursor/BUGBOT.md` detailing changelog enforcement for config changes.
>     - Applies to `src/prime_rl/*/config.py`, `src/prime_rl/rl.py`, `src/prime_rl/utils/config.py`.
>     - Instructs requesting a `CHANGELOG.md` entry when such changes are present without an update.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35a2a4c1f62c652b640a13159bf508c2b3c6ff30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->