### PR TITLE
Adds pattern for setting per-model defaults for rl.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 Documenting changes which affect configuration usage patterns (added/moved/removed/renamed fields, notable logic changes).
 
+- **Per-model defaults**: Added `MODEL_DEFAULTS` registry in `rl.py` that automatically applies model-specific configuration (trajectory strategy, trainer impl, inference settings) based on model name. Supported models include Qwen3 4B/30B/235B Instruct and Thinking variants. The `[inference]` section is no longer required in rl.toml when model defaults provide inference settings. (2025-12-16)
 - **`model.lora`**: Moved from `model.experimental.lora` to `model.lora` (no longer experimental) (#1440, 2025-12-16)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 Documenting changes which affect configuration usage patterns (added/moved/removed/renamed fields, notable logic changes).
 
-- **Per-model defaults**: Added `MODEL_DEFAULTS` registry in `rl.py` that automatically applies model-specific configuration (trajectory strategy, trainer impl, inference settings) based on model name. Supported models include Qwen3 4B/30B/235B Instruct and Thinking variants. The `[inference]` section is no longer required in rl.toml when model defaults provide inference settings. (2025-12-16)
+- **Per-model defaults**: Added `MODEL_DEFAULTS` registry in `rl.py` that automatically applies model-specific configuration (trajectory strategy, trainer impl, inference settings) based on model name. Supported models include Qwen3 4B/30B/235B Instruct and Thinking variants. The `[inference]` section is no longer required in rl.toml when model defaults provide inference settings. (#1442, 2025-12-16)
 - **`model.lora`**: Moved from `model.experimental.lora` to `model.lora` (no longer experimental) (#1440, 2025-12-16)

--- a/src/prime_rl/utils/pydantic_config.py
+++ b/src/prime_rl/utils/pydantic_config.py
@@ -2,7 +2,7 @@ import sys
 import uuid
 import warnings
 from pathlib import Path
-from typing import Annotated, ClassVar, Type, TypeVar
+from typing import Annotated, Any, ClassVar, Type, TypeVar
 
 import tomli
 import tomli_w
@@ -281,3 +281,23 @@ def get_temp_toml_file() -> Path:
     root_path = Path(".pydantic_config")
     root_path.mkdir(exist_ok=True)
     return root_path / f"temp_{temp_uuid}.toml"
+
+
+def merge_nested_dicts(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    """
+    Recursively merge two nested dicts. Values from override take precedence.
+
+    For nested dicts, merges recursively. For all other values, override replaces base.
+
+    Example:
+        base = {"a": {"x": 1, "y": 2}, "b": 3}
+        override = {"a": {"x": 10}, "c": 4}
+        merge_nested_dicts(base, override) -> {"a": {"x": 10, "y": 2}, "b": 3, "c": 4}
+    """
+    result = base.copy()
+    for key, value in override.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = merge_nested_dicts(result[key], value)
+        else:
+            result[key] = value
+    return result

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -7,7 +7,7 @@ from pydantic import ValidationError
 from prime_rl.eval.config import OfflineEvalConfig
 from prime_rl.inference.config import InferenceConfig
 from prime_rl.orchestrator.config import OrchestratorConfig
-from prime_rl.rl import RLConfig
+from prime_rl.rl import MODEL_DEFAULTS, RLConfig
 from prime_rl.trainer.rl.config import RLTrainerConfig
 from prime_rl.trainer.sft.config import SFTTrainerConfig
 from prime_rl.utils.pydantic_config import parse_argv
@@ -44,3 +44,98 @@ def test_load_configs(config_file: Path, monkeypatch: pytest.MonkeyPatch):
         except ValidationError:
             could_parse.append(False)
     assert any(could_parse), f"No config class could be parsed from {config_file}"
+
+
+class TestModelDefaults:
+    """Tests for per-model default configuration."""
+
+    def test_model_defaults_applied_when_user_does_not_set(self):
+        """Model defaults should be applied when user doesn't explicitly set values."""
+        config = RLConfig(
+            model={"name": "Qwen/Qwen3-4B-Instruct-2507"},
+            trainer={},
+            orchestrator={},
+        )
+        assert config.orchestrator.trajectory_strategy == "interleaved"
+        assert config.inference is not None
+        assert config.inference.model.enable_auto_tool_choice is True
+        assert config.inference.model.tool_call_parser == "hermes"
+
+    def test_user_config_overrides_model_defaults(self):
+        """User-provided config should override model defaults."""
+        config = RLConfig(
+            model={"name": "Qwen/Qwen3-4B-Instruct-2507"},
+            trainer={},
+            orchestrator={"trajectory_strategy": "branching"},
+        )
+        assert config.orchestrator.trajectory_strategy == "branching"
+
+    def test_inference_created_from_defaults_when_not_provided(self):
+        """Inference config should be created from defaults when user doesn't provide it."""
+        config = RLConfig(
+            model={"name": "Qwen/Qwen3-4B-Instruct-2507"},
+            trainer={},
+            orchestrator={},
+        )
+        assert config.inference is not None
+        assert config.inference.model.enable_auto_tool_choice is True
+
+    def test_inference_defaults_applied_to_user_provided_inference(self):
+        """Model defaults should be applied to user-provided inference config for unset fields."""
+        config = RLConfig(
+            model={"name": "Qwen/Qwen3-4B-Instruct-2507"},
+            trainer={},
+            orchestrator={},
+            inference={"gpu_memory_utilization": 0.8},
+        )
+        assert config.inference is not None
+        assert config.inference.gpu_memory_utilization == 0.8
+        assert config.inference.model.enable_auto_tool_choice is True
+
+    def test_user_inference_model_overrides_defaults(self):
+        """User-provided inference.model settings should override model defaults."""
+        config = RLConfig(
+            model={"name": "Qwen/Qwen3-4B-Instruct-2507"},
+            trainer={},
+            orchestrator={},
+            inference={"model": {"enable_auto_tool_choice": False}},
+        )
+        assert config.inference is not None
+        assert config.inference.model.enable_auto_tool_choice is False
+
+    def test_no_defaults_for_unknown_model(self):
+        """No defaults should be applied for models not in MODEL_DEFAULTS."""
+        config = RLConfig(
+            model={"name": "some/unknown-model"},
+            trainer={},
+            orchestrator={},
+        )
+        assert config.inference is None
+        assert config.orchestrator.trajectory_strategy == "interleaved"  # global default
+
+    def test_trainer_impl_default_applied(self):
+        """Trainer model impl default should be applied for MoE models."""
+        config = RLConfig(
+            model={"name": "Qwen/Qwen3-30B-A3B-Instruct-2507"},
+            trainer={},
+            orchestrator={},
+        )
+        assert config.trainer.model.impl == "custom"
+
+    def test_trainer_impl_user_override(self):
+        """User can override trainer model impl."""
+        config = RLConfig(
+            model={"name": "Qwen/Qwen3-30B-A3B-Instruct-2507"},
+            trainer={"model": {"impl": "hf"}},
+            orchestrator={},
+        )
+        assert config.trainer.model.impl == "hf"
+
+    def test_thinking_model_uses_branching(self):
+        """Thinking models should default to branching trajectory strategy."""
+        config = RLConfig(
+            model={"name": "Qwen/Qwen3-4B-Thinking-2507"},
+            trainer={},
+            orchestrator={},
+        )
+        assert config.orchestrator.trajectory_strategy == "branching"

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -7,7 +7,7 @@ from pydantic import ValidationError
 from prime_rl.eval.config import OfflineEvalConfig
 from prime_rl.inference.config import InferenceConfig
 from prime_rl.orchestrator.config import OrchestratorConfig
-from prime_rl.rl import MODEL_DEFAULTS, RLConfig
+from prime_rl.rl import RLConfig
 from prime_rl.trainer.rl.config import RLTrainerConfig
 from prime_rl.trainer.sft.config import SFTTrainerConfig
 from prime_rl.utils.pydantic_config import parse_argv


### PR DESCRIPTION
Allows custom per-model configuration for fields which always have a desired non-global value for a given model, e.g. tool parsers + branching/loading strategies 

Flexible types are allowed because defaults are applied before validation. Order of precedence:
- User config (highest)
- Model default config
- Global default config 

**GitHub Issue**: #1439 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a per-model defaults registry that auto-applies orchestrator/trainer/inference settings by model name (overridable by user), plus merge utility, validators, tests, and changelog updates.
> 
> - **RL config (`src/prime_rl/rl.py`)**:
>   - Introduces `ModelDefaults` and `MODEL_DEFAULTS` to auto-apply per-model settings (e.g., `orchestrator.trajectory_strategy`, `trainer.model.impl`, `inference.model.*`).
>   - Adds pre-validation `apply_model_defaults` to merge defaults with user config (user overrides), enabling omission of `[inference]` when defaults cover it.
> - **Utilities (`src/prime_rl/utils/pydantic_config.py`)**:
>   - Adds `merge_nested_dicts` for recursive default→user config merging.
> - **Tests (`tests/unit/test_configs.py`)**:
>   - New tests verifying defaults application, user override precedence, inference creation, trainer impl defaults, and Thinking-model branching strategy.
> - **Changelog**:
>   - Documents per-model defaults and inference section no longer required when provided by defaults.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b3034f95cefc08e88ee2353382ad56f9031969c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->