### PR TITLE
Integrate token-in route with vLLM v0.12.0

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -1,0 +1,11 @@
+# BugBot Instructions
+
+## Changelog Enforcement
+
+Any PR that modifies configuration structures or usage patterns must update `CHANGELOG.md`. This includes changes to config fields (added, removed, renamed, moved, or default value changes) in:
+
+- `src/prime_rl/*/config.py`
+- `src/prime_rl/rl.py`
+- `src/prime_rl/utils/config.py`
+
+If such changes are detected without a corresponding `CHANGELOG.md` update, request that the author add an entry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+Documenting changes which affect configuration usage patterns (added/moved/removed/renamed fields, notable logic changes).
+
+- **`model.lora`**: Moved from `model.experimental.lora` to `model.lora` (no longer experimental) (#1440, 2025-12-16)

--- a/configs/alphabet_sort/rl.toml
+++ b/configs/alphabet_sort/rl.toml
@@ -1,5 +1,10 @@
 max_steps = 100
 
+[wandb]
+project = "alphabet-sort-debug"
+name = "alphabet-sort"
+
+
 [model]
 name = "Qwen/Qwen3-4B-Instruct-2507"
 
@@ -12,7 +17,8 @@ seq_len = 2048
 max_tokens = 512
 
 [[orchestrator.env]]
-id = "alphabet-sort"
+id = "primeintellect/alphabet-sort"
+name = "alphabet-sort"
 args = { min_turns = 2, max_turns = 2 }
 
 [trainer]

--- a/configs/alphabet_sort/rl.toml
+++ b/configs/alphabet_sort/rl.toml
@@ -1,6 +1,3 @@
-inference_gpu_ids = [0]
-trainer_gpu_ids = [1]
-
 max_steps = 100
 
 [model]
@@ -19,3 +16,5 @@ id = "alphabet-sort"
 args = { min_turns = 2, max_turns = 2 }
 
 [trainer]
+
+[inference]

--- a/configs/ci/integration/rl_lora/resume.toml
+++ b/configs/ci/integration/rl_lora/resume.toml
@@ -12,7 +12,7 @@ name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
 [trainer.optim]
 lr = 1e-4
 
-[trainer.model.experimental.lora]
+[trainer.model.lora]
 rank = 8
 
 [trainer.ckpt.weights]

--- a/configs/ci/integration/rl_lora/start.toml
+++ b/configs/ci/integration/rl_lora/start.toml
@@ -11,7 +11,7 @@ name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
 [trainer.optim]
 lr = 1e-4
 
-[trainer.model.experimental.lora]
+[trainer.model.lora]
 rank = 8
 
 [trainer.ckpt.weights]

--- a/configs/wiki_search/rl.toml
+++ b/configs/wiki_search/rl.toml
@@ -14,7 +14,7 @@ name = "wiki-search-4b"
 lr = 1e-5
 weight_decay = 0.0
 
-[trainer.model.experimental.lora]
+[trainer.model.lora]
 rank = 8
 alpha = 32
 dropout = 0.0

--- a/examples/alphabet_sort/rl.toml
+++ b/examples/alphabet_sort/rl.toml
@@ -16,7 +16,7 @@ impl = "liger_kernel"
 [trainer.model.ac]
 freq = 1
 
-[trainer.model.experimental.lora]
+[trainer.model.lora]
 rank = 32
 alpha = 64
 

--- a/examples/wiki_search/rl.toml
+++ b/examples/wiki_search/rl.toml
@@ -14,7 +14,7 @@ name = "wiki-search"
 lr = 1e-5
 weight_decay = 0.0
 
-[trainer.model.experimental.lora]
+[trainer.model.lora]
 rank = 8
 alpha = 32
 dropout = 0.0

--- a/examples/wordle/rl.toml
+++ b/examples/wordle/rl.toml
@@ -27,5 +27,4 @@ max_tokens = 1024
 [trainer] # Default trainer config
 
 [inference.parallel]
-dp = 3
-tp = 2
+dp = 6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ prerelease = "allow"
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 reverse-text = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "3759f7f" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "75fa695" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "main" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ prerelease = "allow"
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 reverse-text = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "8d79234" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "b1e36bc" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "main" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ prerelease = "allow"
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 reverse-text = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "a8af1e9" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "01eaa84" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "main" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ prerelease = "allow"
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 reverse-text = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "260d808" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "63162e4" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "main" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ prerelease = "allow"
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 reverse-text = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "01eaa84" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "30d89b4" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "main" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ prerelease = "allow"
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 reverse-text = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "b1e36bc" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "edb9412" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "main" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ prerelease = "allow"
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 reverse-text = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "ca6aca7" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "cd51f38" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "main" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ prerelease = "allow"
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 reverse-text = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "e92d25a" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "1181c27" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "main" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ prerelease = "allow"
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 reverse-text = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "30d89b4" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "e92d25a" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "main" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ prerelease = "allow"
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 reverse-text = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "cd51f38" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "6c6af33" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "main" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ prerelease = "allow"
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 reverse-text = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "6c6af33" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "ca48ce9" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "main" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ prerelease = "allow"
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 reverse-text = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "06c5e59" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "a8af1e9" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "main" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ prerelease = "allow"
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 reverse-text = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "75fa695" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "0dd0645" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "main" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ prerelease = "allow"
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 reverse-text = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "edb9412" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "67b2b1a" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "main" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ prerelease = "allow"
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 reverse-text = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "442a74a" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "c596bb9" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "main" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ prerelease = "allow"
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 reverse-text = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "c596bb9" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "3759f7f" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "main" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ prerelease = "allow"
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 reverse-text = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "67b2b1a" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "260d808" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "main" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ prerelease = "allow"
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 reverse-text = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "1181c27" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "8d79234" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "main" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ prerelease = "allow"
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 reverse-text = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "ca48ce9" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "06c5e59" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "main" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ prerelease = "allow"
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 reverse-text = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "63162e4" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "442a74a" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "main" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -167,7 +167,7 @@ async def custom_run_server_worker(listen_address, sock, args, client_config=Non
             return request.app.state.openai_serving_chat_completion_with_tokens
 
         @app.post(
-            "/generate",
+            "/v1/chat/completions/tokens",
             dependencies=[Depends(validate_json_request)],
             responses={
                 HTTPStatus.OK.value: {"content": {"text/event-stream": {}}},
@@ -178,7 +178,7 @@ async def custom_run_server_worker(listen_address, sock, args, client_config=Non
         )
         @with_cancellation
         @load_aware_call
-        async def generate(request: ChatCompletionRequestWithTokens, raw_request: Request):
+        async def chat_completions_with_tokens(request: ChatCompletionRequestWithTokens, raw_request: Request):
             handler = chat_with_tokens(raw_request)
             if handler is None:
                 return base(raw_request).create_error_response(

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -1,9 +1,17 @@
 from argparse import Namespace
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from http import HTTPStatus
 from typing import Any, Optional
 
+from fastapi.responses import JSONResponse, StreamingResponse
+from vllm.entrypoints.chat_utils import load_chat_template
+from vllm.entrypoints.logger import RequestLogger
+from vllm.entrypoints.openai.protocol import ChatCompletionRequest, ChatCompletionResponse, ErrorResponse
+from vllm.entrypoints.utils import load_aware_call, with_cancellation
+
 from prime_rl.inference.patches import monkey_patch_prometheus_stat_logger_for_lora_in_dp_mode
+from prime_rl.inference.vllm.serving_chat_tokens import OpenAIServingChatTokens
 
 # Monkeypatch PrometheusStatLogger to avoid NotImplementedError for LoRA in DP mode
 monkey_patch_prometheus_stat_logger_for_lora_in_dp_mode()
@@ -13,17 +21,20 @@ import vllm.entrypoints.openai.api_server
 
 import uvloop
 import vllm.envs as envs
-from fastapi import Request
-from vllm.config import LogprobsMode
+from fastapi import Depends, HTTPException, Request
+from vllm.config import LogprobsMode, VllmConfig
+from starlette.datastructures import State
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.launcher import serve_http
 from vllm.entrypoints.openai.api_server import (
+    base,
     build_app,
     build_async_engine_client_from_engine_args,
     init_app_state,
     load_log_config,
     maybe_register_tokenizer_info_endpoint,
+    validate_json_request,
 )
 from vllm.entrypoints.openai.cli_args import make_arg_parser, validate_parsed_serve_args
 from vllm.entrypoints.openai.tool_parsers import ToolParserManager
@@ -58,6 +69,49 @@ async def custom_build_async_engine_client(
         engine_args, disable_frontend_multiprocessing=args.disable_frontend_multiprocessing, client_config=client_config
     ) as engine:
         yield engine
+
+
+async def custom_init_app_state(engine_client: EngineClient, vllm_config: VllmConfig, state: State, args: Namespace):
+    await init_app_state(engine_client, vllm_config, state, args)
+
+    # Repeat from init_app_state to have
+    if args.enable_log_requests:
+        request_logger = RequestLogger(max_log_len=args.max_log_len)
+    else:
+        request_logger = None
+
+    model_config = vllm_config.model_config
+
+    if envs.VLLM_USE_V1:
+        supported_tasks = await engine_client.get_supported_tasks()  # type: ignore
+    else:
+        supported_tasks = model_config.supported_tasks
+
+    resolved_chat_template = load_chat_template(args.chat_template)
+
+    # Also serve OAI chat completion tokens
+    state.openai_serving_chat_tokens = (
+        OpenAIServingChatTokens(
+            engine_client,
+            model_config,
+            state.openai_serving_models,
+            args.response_role,
+            request_logger=request_logger,
+            chat_template=resolved_chat_template,
+            chat_template_content_format=args.chat_template_content_format,
+            return_tokens_as_token_ids=args.return_tokens_as_token_ids,
+            enable_auto_tools=args.enable_auto_tool_choice,
+            exclude_tools_when_tool_choice_none=args.exclude_tools_when_tool_choice_none,
+            tool_parser=args.tool_call_parser,
+            reasoning_parser=args.reasoning_parser,
+            enable_prompt_tokens_details=args.enable_prompt_tokens_details,
+            enable_force_include_usage=args.enable_force_include_usage,
+            enable_log_outputs=args.enable_log_outputs,
+            log_error_stack=args.log_error_stack,
+        )
+        if "generate" in supported_tasks
+        else None
+    )
 
 
 # Copied from vllm/entrypoints/openai/api_server.py
@@ -106,8 +160,41 @@ async def custom_run_server_worker(listen_address, sock, args, client_config=Non
             )
             return {"status": "ok"}
 
+        def chat_tokens(request: Request) -> Optional[OpenAIServingChatTokens]:
+            return request.app.state.openai_serving_chat_tokens
+
+        @app.post(
+            "/generate",
+            dependencies=[Depends(validate_json_request)],
+            responses={
+                HTTPStatus.OK.value: {"content": {"text/event-stream": {}}},
+                HTTPStatus.BAD_REQUEST.value: {"model": ErrorResponse},
+                HTTPStatus.NOT_FOUND.value: {"model": ErrorResponse},
+                HTTPStatus.INTERNAL_SERVER_ERROR.value: {"model": ErrorResponse},
+            },
+        )
+        @with_cancellation
+        @load_aware_call
+        async def create_chat_completion_tokens(request: ChatCompletionRequest, raw_request: Request):
+            handler = chat_tokens(raw_request)
+            if handler is None:
+                return base(raw_request).create_error_response(
+                    message="The model does not support Chat Completions API"
+                )
+            try:
+                generator = await handler.create_chat_completion(request, raw_request)
+            except Exception as e:
+                raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value, detail=str(e)) from e
+            if isinstance(generator, ErrorResponse):
+                return JSONResponse(content=generator.model_dump(), status_code=generator.error.code)
+
+            elif isinstance(generator, ChatCompletionResponse):
+                return JSONResponse(content=generator.model_dump())
+
+            return StreamingResponse(content=generator, media_type="text/event-stream")
+
         vllm_config = await engine_client.get_vllm_config()
-        await init_app_state(engine_client, vllm_config, app.state, args)
+        await custom_init_app_state(engine_client, vllm_config, app.state, args)
 
         # This hack allows us to update lora adapters in-place by skipping the check for already loaded adapters.
         async def do_nothing(*args, **kwargs):

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -1,13 +1,11 @@
 from argparse import Namespace
-from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
 from http import HTTPStatus
-from typing import Any, Optional
 
 from fastapi.responses import JSONResponse, StreamingResponse
 from vllm.entrypoints.chat_utils import load_chat_template
 from vllm.entrypoints.logger import RequestLogger
-from vllm.entrypoints.openai.protocol import ChatCompletionRequest, ChatCompletionResponse, ErrorResponse
+from vllm.entrypoints.openai.utils import validate_json_request
+from vllm.entrypoints.openai.protocol import ChatCompletionResponse, ErrorResponse
 from vllm.entrypoints.utils import load_aware_call, with_cancellation
 
 from prime_rl.inference.patches import monkey_patch_prometheus_stat_logger_for_lora_in_dp_mode
@@ -16,7 +14,7 @@ from prime_rl.inference.vllm.serving_chat_with_tokens import (
     OpenAIServingChatWithTokens,
 )
 
-# Monkeypatch PrometheusStatLogger to avoid NotImplementedError for LoRA in DP mode
+# NOTE: Monkeypatch PrometheusStatLogger to avoid NotImplementedError for LoRA in DP mode
 monkey_patch_prometheus_stat_logger_for_lora_in_dp_mode()
 
 # ruff: noqa
@@ -26,25 +24,17 @@ import uvloop
 import vllm.envs as envs
 from fastapi import Request
 from fastapi import Depends, HTTPException, Request
-from vllm.config import LogprobsMode, VllmConfig
 from starlette.datastructures import State
-from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.engine.protocol import EngineClient
-from vllm.entrypoints.launcher import serve_http
 from vllm.entrypoints.openai.api_server import (
+    router,
+    engine_client,
     base,
-    build_app,
-    build_async_engine_client_from_engine_args,
     init_app_state,
-    load_log_config,
-    maybe_register_tokenizer_info_endpoint,
-    validate_json_request,
 )
 from vllm.entrypoints.openai.cli_args import make_arg_parser, validate_parsed_serve_args
-from vllm.entrypoints.openai.tool_parsers import ToolParserManager
 from vllm.logger import init_logger
 from vllm.utils.argparse_utils import FlexibleArgumentParser
-from vllm.utils.system_utils import decorate_logs
 
 from prime_rl.inference.config import InferenceConfig
 
@@ -57,57 +47,98 @@ WORKER_EXTENSION_CLS = {
 }
 
 
-# Copied from vllm/entrypoints/openai/api_server.py
-# Only difference is that we extend the engine args with our custom worker extension
-@asynccontextmanager
-async def custom_build_async_engine_client(
-    args: Namespace,
-    client_config: Optional[dict[str, Any]] = None,
-) -> AsyncIterator[EngineClient]:
-    # Context manager to handle engine_client lifecycle
-    # Ensures everything is shutdown and cleaned up on error/exit
-    engine_args = AsyncEngineArgs.from_cli_args(args)
-    engine_args.worker_extension_cls = args.worker_extension_cls
-
-    async with build_async_engine_client_from_engine_args(
-        engine_args, disable_frontend_multiprocessing=args.disable_frontend_multiprocessing, client_config=client_config
-    ) as engine:
-        yield engine
+def chat_with_tokens(request: Request) -> OpenAIServingChatWithTokens | None:
+    return request.app.state.openai_serving_chat_with_tokens
 
 
-async def custom_init_app_state(engine_client: EngineClient, vllm_config: VllmConfig, state: State, args: Namespace):
-    await init_app_state(engine_client, vllm_config, state, args)
+@router.post("/update_weights")
+async def update_weights(request: Request):
+    data = await request.json()
+    await engine_client(request).collective_rpc("update_weights", args=(data.get("weight_dir"),))
+    return {"status": "ok"}
 
-    # Repeat from init_app_state to have
+
+@router.post("/reload_weights")
+async def reload_weights(request: Request):
+    await engine_client(request).collective_rpc("reload_weights")
+    return {"status": "ok"}
+
+
+@router.post("/init_broadcaster")
+async def init_broadcaster(request: Request):
+    data = await request.json()
+    host = data.get("host")
+    port = data.get("port")
+    timeout = data.get("timeout")
+    # Support both legacy and new field names
+    server_rank = data.get("server_rank")
+    num_inference_server = data.get("num_inference_server")
+    await engine_client(request).collective_rpc(
+        "init_broadcaster",
+        args=(host, port, server_rank, num_inference_server, timeout),
+    )
+    return {"status": "ok"}
+
+
+@router.post(
+    "/v1/chat/completions/tokens",
+    dependencies=[Depends(validate_json_request)],
+    responses={
+        HTTPStatus.OK.value: {"content": {"text/event-stream": {}}},
+        HTTPStatus.BAD_REQUEST.value: {"model": ErrorResponse},
+        HTTPStatus.NOT_FOUND.value: {"model": ErrorResponse},
+        HTTPStatus.INTERNAL_SERVER_ERROR.value: {"model": ErrorResponse},
+    },
+)
+@with_cancellation
+@load_aware_call
+async def _chat_with_tokens(request: ChatCompletionRequestWithTokens, raw_request: Request):
+    handler = chat_with_tokens(raw_request)
+    if handler is None:
+        return base(raw_request).create_error_response(message="The model does not support Chat Completions API")
+    try:
+        generator = await handler.create_chat_completion_with_tokens(request, raw_request)
+    except Exception as e:
+        raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value, detail=str(e)) from e
+    if isinstance(generator, ErrorResponse):
+        return JSONResponse(content=generator.model_dump(), status_code=generator.error.code)
+
+    elif isinstance(generator, ChatCompletionResponse):
+        return JSONResponse(content=generator.model_dump())
+
+    return StreamingResponse(content=generator, media_type="text/event-stream")
+
+
+async def custom_init_app_state(engine_client: EngineClient, state: State, args: Namespace):
+    # Setup the regular app state first (in-place)
+    await init_app_state(engine_client, state, args)
+
+    # NOTE: Initialize the custom OpenAIServingChatWithTokens state here
+    # TODO: Here, we repeat some calls done in init_app_state to be able to
+    # correctly set up the OpenAIServingChatWithTokens state, which is a bit
+    # brittle, and could probably be made nicer
     if args.enable_log_requests:
         request_logger = RequestLogger(max_log_len=args.max_log_len)
     else:
         request_logger = None
 
-    model_config = vllm_config.model_config
-
-    if envs.VLLM_USE_V1:
-        supported_tasks = await engine_client.get_supported_tasks()  # type: ignore
-    else:
-        supported_tasks = model_config.supported_tasks
-
+    supported_tasks = await engine_client.get_supported_tasks()
     resolved_chat_template = load_chat_template(args.chat_template)
 
-    # Also serve OAI chat completion tokens
     state.openai_serving_chat_with_tokens = (
         OpenAIServingChatWithTokens(
             engine_client,
-            model_config,
             state.openai_serving_models,
             args.response_role,
             request_logger=request_logger,
             chat_template=resolved_chat_template,
             chat_template_content_format=args.chat_template_content_format,
+            trust_request_chat_template=args.trust_request_chat_template,
             return_tokens_as_token_ids=args.return_tokens_as_token_ids,
             enable_auto_tools=args.enable_auto_tool_choice,
             exclude_tools_when_tool_choice_none=args.exclude_tools_when_tool_choice_none,
             tool_parser=args.tool_call_parser,
-            reasoning_parser=args.reasoning_parser,
+            reasoning_parser=args.structured_outputs_config.reasoning_parser,
             enable_prompt_tokens_details=args.enable_prompt_tokens_details,
             enable_force_include_usage=args.enable_force_include_usage,
             enable_log_outputs=args.enable_log_outputs,
@@ -117,145 +148,20 @@ async def custom_init_app_state(engine_client: EngineClient, vllm_config: VllmCo
         else None
     )
 
+    # NOTE: This hack allows us to update lora adapters in-place by skipping the
+    # check for already loaded adapters.
+    async def do_nothing(*args, **kwargs):
+        return None
 
-# Copied from vllm/entrypoints/openai/api_server.py
-# Only difference is that we inject custom routes and build async engine client differently
-async def custom_run_server_worker(listen_address, sock, args, client_config=None, **uvicorn_kwargs) -> None:
-    """Run a single API server worker."""
-
-    if args.tool_parser_plugin and len(args.tool_parser_plugin) > 3:
-        ToolParserManager.import_tool_parser(args.tool_parser_plugin)
-
-    server_index = client_config.get("client_index", 0) if client_config else 0
-
-    # Load logging config for uvicorn if specified
-    log_config = load_log_config(args.log_config_file)
-    if log_config is not None:
-        uvicorn_kwargs["log_config"] = log_config
-
-    async with custom_build_async_engine_client(args, client_config) as engine_client:
-        maybe_register_tokenizer_info_endpoint(args)
-        app = build_app(args)
-
-        ### CUSTOM ENDPOINTS ###
-        @app.post("/update_weights")
-        async def _update_weights(request: Request):
-            data = await request.json()
-            await engine_client.collective_rpc("update_weights", args=(data.get("weight_dir"),))
-            return {"status": "ok"}
-
-        @app.post("/reload_weights")
-        async def _reload_weights(request: Request):
-            await engine_client.collective_rpc("reload_weights")
-            return {"status": "ok"}
-
-        @app.post("/init_broadcaster")
-        async def _init_broadcaster(request: Request):
-            data = await request.json()
-            host = data.get("host")
-            port = data.get("port")
-            timeout = data.get("timeout")
-            # Support both legacy and new field names
-            server_rank = data.get("server_rank")
-            num_inference_server = data.get("num_inference_server")
-            await engine_client.collective_rpc(
-                "init_broadcaster",
-                args=(host, port, server_rank, num_inference_server, timeout),
-            )
-            return {"status": "ok"}
-
-        def chat_with_tokens(request: Request) -> Optional[OpenAIServingChatWithTokens]:
-            return request.app.state.openai_serving_chat_with_tokens
-
-        @app.post(
-            "/v1/chat/completions/tokens",
-            dependencies=[Depends(validate_json_request)],
-            responses={
-                HTTPStatus.OK.value: {"content": {"text/event-stream": {}}},
-                HTTPStatus.BAD_REQUEST.value: {"model": ErrorResponse},
-                HTTPStatus.NOT_FOUND.value: {"model": ErrorResponse},
-                HTTPStatus.INTERNAL_SERVER_ERROR.value: {"model": ErrorResponse},
-            },
-        )
-        @with_cancellation
-        @load_aware_call
-        async def _chat_with_tokens(request: ChatCompletionRequestWithTokens, raw_request: Request):
-            handler = chat_with_tokens(raw_request)
-            if handler is None:
-                return base(raw_request).create_error_response(
-                    message="The model does not support Chat Completions API"
-                )
-            try:
-                generator = await handler.create_chat_completion_with_tokens(request, raw_request)
-            except Exception as e:
-                raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value, detail=str(e)) from e
-            if isinstance(generator, ErrorResponse):
-                return JSONResponse(content=generator.model_dump(), status_code=generator.error.code)
-
-            elif isinstance(generator, ChatCompletionResponse):
-                return JSONResponse(content=generator.model_dump())
-
-            return StreamingResponse(content=generator, media_type="text/event-stream")
-
-        vllm_config = await engine_client.get_vllm_config()
-        await custom_init_app_state(engine_client, vllm_config, app.state, args)
-
-        # This hack allows us to update lora adapters in-place by skipping the check for already loaded adapters.
-        async def do_nothing(*args, **kwargs):
-            return None
-
-        app.state.openai_serving_models._check_load_lora_adapter_request = do_nothing
-
-        logger.info("Starting vLLM API server %d on %s", server_index, listen_address)
-        shutdown_task = await serve_http(
-            app,
-            sock=sock,
-            enable_ssl_refresh=args.enable_ssl_refresh,
-            host=args.host,
-            port=args.port,
-            log_level=args.uvicorn_log_level,
-            # NOTE: When the 'disable_uvicorn_access_log' value is True,
-            # no access log will be output.
-            access_log=not args.disable_uvicorn_access_log,
-            timeout_keep_alive=envs.VLLM_HTTP_TIMEOUT_KEEP_ALIVE,
-            ssl_keyfile=args.ssl_keyfile,
-            ssl_certfile=args.ssl_certfile,
-            ssl_ca_certs=args.ssl_ca_certs,
-            ssl_cert_reqs=args.ssl_cert_reqs,
-            **uvicorn_kwargs,
-        )
-
-    # NB: Await server shutdown only after the backend context is exited
-    try:
-        await shutdown_task
-    finally:
-        sock.close()
-
-
-def custom_run_api_server_worker_proc(listen_address, sock, args, client_config=None, **uvicorn_kwargs) -> None:
-    """Entrypoint for individual API server worker processes."""
-    # Import our module to ensure monkey patches are applied in child processes
-    # This is critical because child processes start fresh and re-import modules
-    import prime_rl.inference.vllm.server  # noqa: F401
-
-    from vllm.utils import set_process_title, decorate_logs
-
-    # Set process title and add process-specific prefix to stdout and stderr.
-    server_index = client_config.get("client_index", 0) if client_config else 0
-    set_process_title("APIServer", str(server_index))
-    decorate_logs()
-
-    uvloop.run(custom_run_server_worker(listen_address, sock, args, client_config, **uvicorn_kwargs))
+    state.openai_serving_models._check_load_lora_adapter_request = do_nothing
 
 
 import vllm.entrypoints.openai.api_server
-import vllm.entrypoints.cli.serve
 
 # Also monkey patch run_api_server_worker_proc for multi-api-server mode
 # This is needed because worker processes spawned by run_multi_api_server
 # re-import modules and would otherwise use the original run_server_worker
-vllm.entrypoints.openai.api_server.run_server_worker = custom_run_server_worker
-vllm.entrypoints.cli.serve.run_api_server_worker_proc = custom_run_api_server_worker_proc
+vllm.entrypoints.openai.api_server.init_app_state = custom_init_app_state
 
 
 # Adapted from vllm/entrypoints/cli/serve.py
@@ -273,10 +179,6 @@ def server(config: InferenceConfig, vllm_args: list[str]):
 
     # Set the worker extension class based on the broadcast backend
     args.worker_extension_cls = WORKER_EXTENSION_CLS[config.weight_broadcast.type]
-
-    # Raise error if logprobs_mode is not set to processed_logprobs
-    if args.logprobs_mode != "processed_logprobs":
-        raise ValueError("logprobs_mode must be 'processed_logprobs' to be compatible with the orchestrator.")
 
     if args.headless or args.api_server_count < 1:
         run_headless(args)

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -185,7 +185,7 @@ async def custom_run_server_worker(listen_address, sock, args, client_config=Non
                     message="The model does not support Chat Completions API"
                 )
             try:
-                generator = await handler.create_chat_completion_with_tokens(request, raw_request)
+                generator = await handler.create_chat_completion(request, raw_request)
             except Exception as e:
                 raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value, detail=str(e)) from e
             if isinstance(generator, ErrorResponse):

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -13,7 +13,7 @@ from vllm.entrypoints.utils import load_aware_call, with_cancellation
 from prime_rl.inference.patches import monkey_patch_prometheus_stat_logger_for_lora_in_dp_mode
 from prime_rl.inference.vllm.serving_chat_with_tokens import (
     ChatCompletionRequestWithTokens,
-    OpenAIServingChatCompletionWithTokens,
+    OpenAIServingChatWithTokens,
 )
 
 # Monkeypatch PrometheusStatLogger to avoid NotImplementedError for LoRA in DP mode
@@ -93,8 +93,8 @@ async def custom_init_app_state(engine_client: EngineClient, vllm_config: VllmCo
     resolved_chat_template = load_chat_template(args.chat_template)
 
     # Also serve OAI chat completion tokens
-    state.openai_serving_chat_completion_with_tokens = (
-        OpenAIServingChatCompletionWithTokens(
+    state.openai_serving_chat_with_tokens = (
+        OpenAIServingChatWithTokens(
             engine_client,
             model_config,
             state.openai_serving_models,
@@ -163,8 +163,8 @@ async def custom_run_server_worker(listen_address, sock, args, client_config=Non
             )
             return {"status": "ok"}
 
-        def chat_with_tokens(request: Request) -> Optional[OpenAIServingChatCompletionWithTokens]:
-            return request.app.state.openai_serving_chat_completion_with_tokens
+        def chat_with_tokens(request: Request) -> Optional[OpenAIServingChatWithTokens]:
+            return request.app.state.openai_serving_chat_with_tokens
 
         @app.post(
             "/v1/chat/completions/tokens",
@@ -178,7 +178,7 @@ async def custom_run_server_worker(listen_address, sock, args, client_config=Non
         )
         @with_cancellation
         @load_aware_call
-        async def chat_completions_with_tokens(request: ChatCompletionRequestWithTokens, raw_request: Request):
+        async def _chat_with_tokens(request: ChatCompletionRequestWithTokens, raw_request: Request):
             handler = chat_with_tokens(raw_request)
             if handler is None:
                 return base(raw_request).create_error_response(

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -185,7 +185,7 @@ async def custom_run_server_worker(listen_address, sock, args, client_config=Non
                     message="The model does not support Chat Completions API"
                 )
             try:
-                generator = await handler.create_chat_completion(request, raw_request)
+                generator = await handler.create_chat_completion_with_tokens(request, raw_request)
             except Exception as e:
                 raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value, detail=str(e)) from e
             if isinstance(generator, ErrorResponse):

--- a/src/prime_rl/inference/vllm/serving_chat_tokens.py
+++ b/src/prime_rl/inference/vllm/serving_chat_tokens.py
@@ -1,3 +1,0 @@
-from vllm.entrypoints.openai.serving_chat import OpenAIServingChat
-
-OpenAIServingChatTokens = OpenAIServingChat

--- a/src/prime_rl/inference/vllm/serving_chat_tokens.py
+++ b/src/prime_rl/inference/vllm/serving_chat_tokens.py
@@ -1,0 +1,3 @@
+from vllm.entrypoints.openai.serving_chat import OpenAIServingChat
+
+OpenAIServingChatTokens = OpenAIServingChat

--- a/src/prime_rl/inference/vllm/serving_chat_with_tokens.py
+++ b/src/prime_rl/inference/vllm/serving_chat_with_tokens.py
@@ -1,5 +1,4 @@
 from collections.abc import AsyncGenerator
-from copy import deepcopy
 from typing import Optional, Union
 
 import jinja2
@@ -121,11 +120,11 @@ class OpenAIServingChatCompletionWithTokens(OpenAIServingChat):
 
         # In-place override the engine_prompts with the tokens from the request
         assert len(engine_prompts) == 1
-        if engine_prompts[0]["prompt_token_ids"] != request.tokens:
-            logger.warning(
-                f"Prompt tokens provided in request do not match the engine prompt tokens\nengine_prompt_tokens={engine_prompts[0]['prompt_token_ids']}\nrequest_tokens={request.tokens}\nThis may happen due to retokenization discrepancies in multi-turn conversations. Since you are using the /generate endpoint, we assume you want this behavior and use the provided prompt tokens. If this is undesired, use the standard /v1/chat/completions endpoint instead."
-            )
-        engine_prompts[0]["prompt_token_ids"] = deepcopy(request.tokens)
+        # if engine_prompts[0]["prompt_token_ids"] != request.tokens:
+        #     logger.warning(
+        #         f"Prompt tokens provided in request do not match the engine prompt tokens\nengine_prompt_tokens={engine_prompts[0]['prompt_token_ids']}\nrequest_tokens={request.tokens}\nThis may happen due to retokenization discrepancies in multi-turn conversations. Since you are using the /generate endpoint, we assume you want this behavior and use the provided prompt tokens. If this is undesired, use the standard /v1/chat/completions endpoint instead."
+        #     )
+        engine_prompts[0]["prompt_token_ids"] = request.tokens
 
         request_id = f"chatcmpl-{self._base_request_id(raw_request, request.request_id)}"
 

--- a/src/prime_rl/inference/vllm/serving_chat_with_tokens.py
+++ b/src/prime_rl/inference/vllm/serving_chat_with_tokens.py
@@ -121,10 +121,10 @@ class OpenAIServingChatCompletionWithTokens(OpenAIServingChat):
 
         # In-place override the engine_prompts with the tokens from the request
         assert len(engine_prompts) == 1
-        # if engine_prompts[0]["prompt_token_ids"] != request.tokens:
-        #     logger.warning(
-        #         f"Prompt tokens provided in request do not match the engine prompt tokens\nengine_prompt_tokens={engine_prompts[0]['prompt_token_ids']}\nrequest_tokens={request.tokens}\nThis may happen due to retokenization discrepancies in multi-turn conversations. Since you are using the /generate endpoint, we assume you want this behavior and use the provided prompt tokens. If this is undesired, use the standard /v1/chat/completions endpoint instead."
-        #     )
+        if engine_prompts[0]["prompt_token_ids"] != request.tokens:
+            logger.warning(
+                f"Prompt tokens provided in request do not match the engine prompt tokens\nengine_prompt_tokens={engine_prompts[0]['prompt_token_ids']}\nrequest_tokens={request.tokens}\nThis may happen due to retokenization discrepancies in multi-turn conversations. Since you are using the /generate endpoint, we assume you want this behavior and use the provided prompt tokens. If this is undesired, use the standard /v1/chat/completions endpoint instead."
+            )
         engine_prompts[0]["prompt_token_ids"] = deepcopy(request.tokens)
 
         request_id = f"chatcmpl-{self._base_request_id(raw_request, request.request_id)}"

--- a/src/prime_rl/inference/vllm/serving_chat_with_tokens.py
+++ b/src/prime_rl/inference/vllm/serving_chat_with_tokens.py
@@ -123,7 +123,7 @@ class OpenAIServingChatCompletionWithTokens(OpenAIServingChat):
         assert len(engine_prompts) == 1
         if engine_prompts[0]["prompt_token_ids"] != request.tokens:
             logger.warning(
-                f"Prompt tokens provided in request do not match the engine prompt tokens {engine_prompts[0]['prompt_token_ids']} != {request.tokens}. This may happen due to retokenization discrepancies in multi-turn conversations. Since you are using the /generate endpoint, we assume you want this behavior and use the provided prompt tokens. If this is undesired, use the standard /v1/chat/completions endpoint instead."
+                f"Prompt tokens provided in request do not match the engine prompt tokens\nengine_prompt_tokens={engine_prompts[0]['prompt_token_ids']}\nrequest_tokens={request.tokens}\nThis may happen due to retokenization discrepancies in multi-turn conversations. Since you are using the /generate endpoint, we assume you want this behavior and use the provided prompt tokens. If this is undesired, use the standard /v1/chat/completions endpoint instead."
             )
         engine_prompts[0]["prompt_token_ids"] = deepcopy(request.tokens)
 

--- a/src/prime_rl/inference/vllm/serving_chat_with_tokens.py
+++ b/src/prime_rl/inference/vllm/serving_chat_with_tokens.py
@@ -1,25 +1,26 @@
-from typing import Any, Callable, ClassVar, Optional, Sequence, Union
+from collections.abc import AsyncGenerator
+from typing import ClassVar, Optional, Union
 
+import jinja2
+from fastapi import Request
 from pydantic import Field
-from vllm.entrypoints.chat_utils import (
-    ChatCompletionMessageParam,
-    ChatTemplateContentFormatOption,
-    ConversationMessage,
-    apply_hf_chat_template,
-    apply_mistral_chat_template,
-    parse_chat_messages_futures,
-    resolve_chat_template_content_format,
-)
 from vllm.entrypoints.openai.protocol import (
     ChatCompletionRequest,
+    ChatCompletionResponse,
+    ErrorResponse,
+    RequestResponseMetadata,
 )
 from vllm.entrypoints.openai.serving_chat import OpenAIServingChat
-from vllm.entrypoints.openai.serving_engine import RequestPrompt, TextTokensPrompt
-from vllm.entrypoints.openai.tool_parsers import ToolParser
-from vllm.inputs.data import TokensPrompt as EngineTokensPrompt
+from vllm.entrypoints.utils import get_max_tokens
 from vllm.logger import init_logger
-from vllm.transformers_utils.tokenizer import AnyTokenizer, MistralTokenizer
-from vllm.utils import is_list_of
+from vllm.outputs import RequestOutput
+from vllm.sampling_params import BeamSearchParams, SamplingParams
+from vllm.transformers_utils.tokenizer import MistralTokenizer
+from vllm.transformers_utils.tokenizers import (
+    maybe_serialize_tool_calls,
+    truncate_tool_call_ids,
+    validate_request_params,
+)
 
 logger = init_logger(__name__)
 
@@ -32,123 +33,175 @@ class ChatCompletionRequestWithTokens(ChatCompletionRequest):
 class OpenAIServingChatCompletionWithTokens(OpenAIServingChat):
     """OpenAI-compatible generate API that allows token-in."""
 
-    async def _preprocess_chat(
+    async def create_chat_completion_with_tokens(
         self,
         request: ChatCompletionRequestWithTokens,
-        tokenizer: AnyTokenizer,
-        messages: list[ChatCompletionMessageParam],
-        chat_template: Optional[str],
-        chat_template_content_format: ChatTemplateContentFormatOption,
-        add_generation_prompt: bool = True,
-        continue_final_message: bool = False,
-        tool_dicts: Optional[list[dict[str, Any]]] = None,
-        documents: Optional[list[dict[str, str]]] = None,
-        chat_template_kwargs: Optional[dict[str, Any]] = None,
-        tool_parser: Optional[Callable[[AnyTokenizer], ToolParser]] = None,
-        add_special_tokens: bool = False,
-    ) -> tuple[
-        list[ConversationMessage],
-        Sequence[RequestPrompt],
-        list[EngineTokensPrompt],
-    ]:
-        model_config = self.model_config
+        raw_request: Optional[Request] = None,
+    ) -> Union[AsyncGenerator[str, None], ChatCompletionResponse, ErrorResponse]:
+        """
+        Copy of OpenAIServingChat.create_chat_completion, adapted to use prompt
+        ids directly via ChatCompletionRequestWithTokens.
+        """
+        logger.info("Generating with tokens: %s", request.tokens)
+        error_check_ret = await self._check_model(request)
+        if error_check_ret is not None:
+            logger.error("Error with model %s", error_check_ret)
+            return error_check_ret
 
-        resolved_content_format = resolve_chat_template_content_format(
-            chat_template,
-            tool_dicts,
-            chat_template_content_format,
-            tokenizer,
-            model_config=model_config,
-        )
-        conversation, mm_data_future, mm_uuids = parse_chat_messages_futures(
-            messages,
-            model_config,
-            tokenizer,
-            content_format=resolved_content_format,
-        )
+        # If the engine is dead, raise the engine's DEAD_ERROR.
+        # This is required for the streaming case, where we return a
+        # success status before we actually start generating text :).
+        if self.engine_client.errored:
+            raise self.engine_client.dead_error
 
-        _chat_template_kwargs: dict[str, Any] = dict(
-            chat_template=chat_template,
-            add_generation_prompt=add_generation_prompt,
-            continue_final_message=continue_final_message,
-            tools=tool_dicts,
-            documents=documents,
-        )
-        _chat_template_kwargs.update(chat_template_kwargs or {})
+        try:
+            lora_request = self._maybe_get_adapters(request, supports_default_mm_loras=True)
 
-        request_prompt: Union[str, list[int]]
+            model_name = self.models.model_name(lora_request)
 
-        if tokenizer is None:
-            request_prompt = "placeholder"
-        elif isinstance(tokenizer, MistralTokenizer):
-            request_prompt = apply_mistral_chat_template(
+            tokenizer = await self.engine_client.get_tokenizer(lora_request)
+
+            tool_parser = self.tool_parser
+
+            if isinstance(tokenizer, MistralTokenizer):
+                # because of issues with pydantic we need to potentially
+                # re-serialize the tool_calls field of the request
+                # for more info: see comment in `maybe_serialize_tool_calls`
+                maybe_serialize_tool_calls(request)
+                truncate_tool_call_ids(request)
+                validate_request_params(request)
+
+            if (
+                request.tool_choice == "auto"
+                and not (self.enable_auto_tools and tool_parser is not None)
+                and not isinstance(tokenizer, MistralTokenizer)
+                and not self.use_harmony
+            ):
+                # for hf tokenizers, "auto" tools requires
+                # --enable-auto-tool-choice and --tool-call-parser
+                return self.create_error_response(
+                    '"auto" tool choice requires --enable-auto-tool-choice and --tool-call-parser to be set'
+                )
+
+            if request.tools is None or (request.tool_choice == "none" and self.exclude_tools_when_tool_choice_none):
+                tool_dicts = None
+            else:
+                tool_dicts = [tool.model_dump() for tool in request.tools]
+
+            if not self.use_harmony:
+                # Common case.
+                (
+                    conversation,
+                    request_prompts,
+                    engine_prompts,
+                ) = await self._preprocess_chat(
+                    request,
+                    tokenizer,
+                    request.messages,
+                    chat_template=request.chat_template or self.chat_template,
+                    chat_template_content_format=self.chat_template_content_format,
+                    add_generation_prompt=request.add_generation_prompt,
+                    continue_final_message=request.continue_final_message,
+                    tool_dicts=tool_dicts,
+                    documents=request.documents,
+                    chat_template_kwargs=request.chat_template_kwargs,
+                    tool_parser=tool_parser,
+                    add_special_tokens=request.add_special_tokens,
+                )
+            else:
+                # For GPT-OSS.
+                (
+                    conversation,
+                    request_prompts,
+                    engine_prompts,
+                ) = self._make_request_with_harmony(request)
+        except (ValueError, TypeError, RuntimeError, jinja2.TemplateError) as e:
+            logger.exception("Error in preprocessing prompt inputs")
+            return self.create_error_response(f"{e} {e.__cause__}")
+
+        # In-place override the engine_prompts with the tokens from the request
+        assert len(engine_prompts) == 1
+        # if engine_prompts[0]["prompt_token_ids"] != request.tokens:
+        #     logger.warning(
+        #         f"Prompt tokens provided in request do not match the engine prompt tokens\nengine_prompt_tokens={engine_prompts[0]['prompt_token_ids']}\nrequest_tokens={request.tokens}\nThis may happen due to retokenization discrepancies in multi-turn conversations. Since you are using the /generate endpoint, we assume you want this behavior and use the provided prompt tokens. If this is undesired, use the standard /v1/chat/completions endpoint instead."
+        #     )
+        engine_prompts[0]["prompt_token_ids"] = request.tokens
+
+        request_id = f"chatcmpl-{self._base_request_id(raw_request, request.request_id)}"
+
+        request_metadata = RequestResponseMetadata(request_id=request_id)
+        if raw_request:
+            raw_request.state.request_metadata = request_metadata
+
+        # Schedule the request and get the result generator.
+        generators: list[AsyncGenerator[RequestOutput, None]] = []
+        try:
+            for i, engine_prompt in enumerate(engine_prompts):
+                sampling_params: Union[SamplingParams, BeamSearchParams]
+
+                if self.default_sampling_params is None:
+                    self.default_sampling_params = {}
+
+                max_tokens = get_max_tokens(
+                    max_model_len=self.max_model_len,
+                    request=request,
+                    input_length=len(engine_prompt["prompt_token_ids"]),
+                    default_sampling_params=self.default_sampling_params,
+                )
+
+                if request.use_beam_search:
+                    sampling_params = request.to_beam_search_params(max_tokens, self.default_sampling_params)
+                else:
+                    sampling_params = request.to_sampling_params(
+                        max_tokens, self.model_config.logits_processor_pattern, self.default_sampling_params
+                    )
+
+                self._log_inputs(request_id, request_prompts[i], params=sampling_params, lora_request=lora_request)
+
+                trace_headers = None if raw_request is None else await self._get_trace_headers(raw_request.headers)
+
+                if isinstance(sampling_params, BeamSearchParams):
+                    generator = self.engine_client.beam_search(
+                        prompt=engine_prompt,
+                        request_id=request_id,
+                        params=sampling_params,
+                        lora_request=lora_request,
+                    )
+                else:
+                    generator = self.engine_client.generate(
+                        engine_prompt,
+                        sampling_params,
+                        request_id,
+                        lora_request=lora_request,
+                        trace_headers=trace_headers,
+                        priority=request.priority,
+                    )
+
+                generators.append(generator)
+        except ValueError as e:
+            # TODO: Use a vllm-specific Validation Error
+            return self.create_error_response(str(e))
+
+        assert len(generators) == 1
+        (result_generator,) = generators
+
+        # Streaming response
+        if request.stream:
+            return self.chat_completion_stream_generator(
+                request,
+                result_generator,
+                request_id,
+                model_name,
+                conversation,
                 tokenizer,
-                messages=messages,
-                **_chat_template_kwargs,
-            )
-        else:
-            request_prompt = apply_hf_chat_template(
-                tokenizer=tokenizer,
-                conversation=conversation,
-                model_config=model_config,
-                **_chat_template_kwargs,
+                request_metadata,
+                enable_force_include_usage=self.enable_force_include_usage,
             )
 
-        mm_data = await mm_data_future
-
-        # tool parsing is done only if a tool_parser has been set and if
-        # tool_choice is not "none" (if tool_choice is "none" but a tool_parser
-        # is set, we want to prevent parsing a tool_call hallucinated by the LLM
-        should_parse_tools = tool_parser is not None and (
-            hasattr(request, "tool_choice") and request.tool_choice != "none"
-        )
-
-        if should_parse_tools:
-            if not isinstance(request, ChatCompletionRequest):
-                msg = "Tool usage is only supported for Chat Completions API"
-                raise NotImplementedError(msg)
-
-            request = tool_parser(tokenizer).adjust_request(  # type: ignore
-                request=request
+        try:
+            return await self.chat_completion_full_generator(
+                request, result_generator, request_id, model_name, conversation, tokenizer, request_metadata
             )
-
-        if tokenizer is None:
-            assert isinstance(request_prompt, str), (
-                "Prompt has to be a string",
-                "when the tokenizer is not initialised",
-            )
-            prompt_inputs = TextTokensPrompt(prompt=request_prompt, prompt_token_ids=[1])
-        elif isinstance(request_prompt, str):
-            # NOTE: Main change from the parent class is that we skip the call
-            # to _tokenize_prompt_input_async and directly use the tokens from
-            # the request body
-
-            # prompt_inputs = await self._tokenize_prompt_input_async(
-            #     request,
-            #     tokenizer,
-            #     request_prompt,
-            #     add_special_tokens=add_special_tokens,
-            # )
-            prompt_inputs = TextTokensPrompt(prompt=request_prompt, prompt_token_ids=request.tokens)
-        else:
-            # For MistralTokenizer
-            assert is_list_of(request_prompt, int), "Prompt has to be either a string or a list of token ids"
-            prompt_inputs = TextTokensPrompt(
-                prompt=tokenizer.decode(request_prompt),
-                prompt_token_ids=request_prompt,
-            )
-
-        engine_prompt = EngineTokensPrompt(prompt_token_ids=prompt_inputs["prompt_token_ids"])
-        if mm_data is not None:
-            engine_prompt["multi_modal_data"] = mm_data
-
-        if mm_uuids is not None:
-            engine_prompt["multi_modal_uuids"] = mm_uuids
-
-        if request.mm_processor_kwargs is not None:
-            engine_prompt["mm_processor_kwargs"] = request.mm_processor_kwargs
-
-        if hasattr(request, "cache_salt") and request.cache_salt is not None:
-            engine_prompt["cache_salt"] = request.cache_salt
-
-        return conversation, [request_prompt], [engine_prompt]
+        except ValueError as e:
+            # TODO: Use a vllm-specific Validation Error
+            return self.create_error_response(str(e))

--- a/src/prime_rl/inference/vllm/serving_chat_with_tokens.py
+++ b/src/prime_rl/inference/vllm/serving_chat_with_tokens.py
@@ -121,10 +121,13 @@ class OpenAIServingChatCompletionWithTokens(OpenAIServingChat):
 
         # In-place override the engine_prompts with the tokens from the request
         assert len(engine_prompts) == 1
-        # if engine_prompts[0]["prompt_token_ids"] != request.tokens:
-        #     logger.warning(
-        #         f"Prompt tokens provided in request do not match the engine prompt tokens\nengine_prompt_tokens={engine_prompts[0]['prompt_token_ids']}\nrequest_tokens={request.tokens}\nThis may happen due to retokenization discrepancies in multi-turn conversations. Since you are using the /generate endpoint, we assume you want this behavior and use the provided prompt tokens. If this is undesired, use the standard /v1/chat/completions endpoint instead."
-        #     )
+        if engine_prompts[0]["prompt_token_ids"] != request.tokens:
+            logger.warning(
+                "Prompt tokens provided in request do not match the engine prompt tokens\nThis may happen due to retokenization discrepancies in multi-turn conversations. Since you are using the /generate endpoint, we assume you want this behavior and use the provided prompt tokens. If this is undesired, use the standard /v1/chat/completions endpoint instead."
+            )
+            logger.debug(f"engine_prompt_tokens:\n{engine_prompts[0]['prompt_token_ids']}")
+            logger.debug(f"request_tokens:\n{request.tokens}")
+
         engine_prompts[0]["prompt_token_ids"] = request.tokens
 
         request_id = f"chatcmpl-{self._base_request_id(raw_request, request.request_id)}"

--- a/src/prime_rl/inference/vllm/serving_chat_with_tokens.py
+++ b/src/prime_rl/inference/vllm/serving_chat_with_tokens.py
@@ -4,6 +4,7 @@ from typing import Optional, Union
 
 import jinja2
 from fastapi import Request
+from pydantic import Field
 from vllm.entrypoints.openai.protocol import (
     ChatCompletionRequest,
     ChatCompletionResponse,
@@ -26,7 +27,7 @@ logger = init_logger(__name__)
 
 
 class ChatCompletionRequestWithTokens(ChatCompletionRequest):
-    tokens: list[int]
+    tokens: list[int] = Field(description=("Prompt tokens to use for the request."))
 
 
 class OpenAIServingChatCompletionWithTokens(OpenAIServingChat):

--- a/src/prime_rl/inference/vllm/serving_chat_with_tokens.py
+++ b/src/prime_rl/inference/vllm/serving_chat_with_tokens.py
@@ -1,0 +1,206 @@
+from collections.abc import AsyncGenerator
+from copy import deepcopy
+from typing import Optional, Union
+
+import jinja2
+from fastapi import Request
+from vllm.entrypoints.openai.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ErrorResponse,
+    RequestResponseMetadata,
+)
+from vllm.entrypoints.openai.serving_chat import OpenAIServingChat
+from vllm.entrypoints.utils import get_max_tokens
+from vllm.logger import init_logger
+from vllm.outputs import RequestOutput
+from vllm.sampling_params import BeamSearchParams, SamplingParams
+from vllm.transformers_utils.tokenizer import MistralTokenizer
+from vllm.transformers_utils.tokenizers import (
+    maybe_serialize_tool_calls,
+    truncate_tool_call_ids,
+    validate_request_params,
+)
+
+logger = init_logger(__name__)
+
+
+class ChatCompletionRequestWithTokens(ChatCompletionRequest):
+    tokens: list[int]
+
+
+class OpenAIServingChatCompletionWithTokens(OpenAIServingChat):
+    """OpenAI-compatible generate API that allows token-in."""
+
+    async def create_chat_completion_with_tokens(
+        self,
+        request: ChatCompletionRequestWithTokens,
+        raw_request: Optional[Request] = None,
+    ) -> Union[AsyncGenerator[str, None], ChatCompletionResponse, ErrorResponse]:
+        """
+        Copy of OpenAIServingChat.create_chat_completion, adapted to use prompt
+        ids directly via ChatCompletionRequestWithTokens.
+        """
+        logger.info("Generating with tokens: %s", request.tokens)
+        error_check_ret = await self._check_model(request)
+        if error_check_ret is not None:
+            logger.error("Error with model %s", error_check_ret)
+            return error_check_ret
+
+        # If the engine is dead, raise the engine's DEAD_ERROR.
+        # This is required for the streaming case, where we return a
+        # success status before we actually start generating text :).
+        if self.engine_client.errored:
+            raise self.engine_client.dead_error
+
+        try:
+            lora_request = self._maybe_get_adapters(request, supports_default_mm_loras=True)
+
+            model_name = self.models.model_name(lora_request)
+
+            tokenizer = await self.engine_client.get_tokenizer(lora_request)
+
+            tool_parser = self.tool_parser
+
+            if isinstance(tokenizer, MistralTokenizer):
+                # because of issues with pydantic we need to potentially
+                # re-serialize the tool_calls field of the request
+                # for more info: see comment in `maybe_serialize_tool_calls`
+                maybe_serialize_tool_calls(request)
+                truncate_tool_call_ids(request)
+                validate_request_params(request)
+
+            if (
+                request.tool_choice == "auto"
+                and not (self.enable_auto_tools and tool_parser is not None)
+                and not isinstance(tokenizer, MistralTokenizer)
+                and not self.use_harmony
+            ):
+                # for hf tokenizers, "auto" tools requires
+                # --enable-auto-tool-choice and --tool-call-parser
+                return self.create_error_response(
+                    '"auto" tool choice requires --enable-auto-tool-choice and --tool-call-parser to be set'
+                )
+
+            if request.tools is None or (request.tool_choice == "none" and self.exclude_tools_when_tool_choice_none):
+                tool_dicts = None
+            else:
+                tool_dicts = [tool.model_dump() for tool in request.tools]
+
+            if not self.use_harmony:
+                # Common case.
+                (
+                    conversation,
+                    request_prompts,
+                    engine_prompts,
+                ) = await self._preprocess_chat(
+                    request,
+                    tokenizer,
+                    request.messages,
+                    chat_template=request.chat_template or self.chat_template,
+                    chat_template_content_format=self.chat_template_content_format,
+                    add_generation_prompt=request.add_generation_prompt,
+                    continue_final_message=request.continue_final_message,
+                    tool_dicts=tool_dicts,
+                    documents=request.documents,
+                    chat_template_kwargs=request.chat_template_kwargs,
+                    tool_parser=tool_parser,
+                    add_special_tokens=request.add_special_tokens,
+                )
+            else:
+                # For GPT-OSS.
+                (
+                    conversation,
+                    request_prompts,
+                    engine_prompts,
+                ) = self._make_request_with_harmony(request)
+        except (ValueError, TypeError, RuntimeError, jinja2.TemplateError) as e:
+            logger.exception("Error in preprocessing prompt inputs")
+            return self.create_error_response(f"{e} {e.__cause__}")
+
+        # In-place override the engine_prompts with the tokens from the request
+        assert len(engine_prompts) == 1
+        if engine_prompts[0]["prompt_token_ids"] != request.tokens:
+            logger.warning(
+                f"Prompt tokens provided in request do not match the engine prompt tokens {engine_prompts[0]['prompt_token_ids']} != {request.tokens}. This may happen due to retokenization discrepancies in multi-turn conversations. Since you are using the /generate endpoint, we assume you want this behavior and use the provided prompt tokens. If this is undesired, use the standard /v1/chat/completions endpoint instead."
+            )
+        engine_prompts[0]["prompt_token_ids"] = deepcopy(request.tokens)
+
+        request_id = f"chatcmpl-{self._base_request_id(raw_request, request.request_id)}"
+
+        request_metadata = RequestResponseMetadata(request_id=request_id)
+        if raw_request:
+            raw_request.state.request_metadata = request_metadata
+
+        # Schedule the request and get the result generator.
+        generators: list[AsyncGenerator[RequestOutput, None]] = []
+        try:
+            for i, engine_prompt in enumerate(engine_prompts):
+                sampling_params: Union[SamplingParams, BeamSearchParams]
+
+                if self.default_sampling_params is None:
+                    self.default_sampling_params = {}
+
+                max_tokens = get_max_tokens(
+                    max_model_len=self.max_model_len,
+                    request=request,
+                    input_length=len(engine_prompt["prompt_token_ids"]),
+                    default_sampling_params=self.default_sampling_params,
+                )
+
+                if request.use_beam_search:
+                    sampling_params = request.to_beam_search_params(max_tokens, self.default_sampling_params)
+                else:
+                    sampling_params = request.to_sampling_params(
+                        max_tokens, self.model_config.logits_processor_pattern, self.default_sampling_params
+                    )
+
+                self._log_inputs(request_id, request_prompts[i], params=sampling_params, lora_request=lora_request)
+
+                trace_headers = None if raw_request is None else await self._get_trace_headers(raw_request.headers)
+
+                if isinstance(sampling_params, BeamSearchParams):
+                    generator = self.engine_client.beam_search(
+                        prompt=engine_prompt,
+                        request_id=request_id,
+                        params=sampling_params,
+                        lora_request=lora_request,
+                    )
+                else:
+                    generator = self.engine_client.generate(
+                        engine_prompt,
+                        sampling_params,
+                        request_id,
+                        lora_request=lora_request,
+                        trace_headers=trace_headers,
+                        priority=request.priority,
+                    )
+
+                generators.append(generator)
+        except ValueError as e:
+            # TODO: Use a vllm-specific Validation Error
+            return self.create_error_response(str(e))
+
+        assert len(generators) == 1
+        (result_generator,) = generators
+
+        # Streaming response
+        if request.stream:
+            return self.chat_completion_stream_generator(
+                request,
+                result_generator,
+                request_id,
+                model_name,
+                conversation,
+                tokenizer,
+                request_metadata,
+                enable_force_include_usage=self.enable_force_include_usage,
+            )
+
+        try:
+            return await self.chat_completion_full_generator(
+                request, result_generator, request_id, model_name, conversation, tokenizer, request_metadata
+            )
+        except ValueError as e:
+            # TODO: Use a vllm-specific Validation Error
+            return self.create_error_response(str(e))

--- a/src/prime_rl/inference/vllm/serving_chat_with_tokens.py
+++ b/src/prime_rl/inference/vllm/serving_chat_with_tokens.py
@@ -30,7 +30,7 @@ class ChatCompletionRequestWithTokens(ChatCompletionRequest):
     tokens: list[int] = Field(description=("Prompt tokens to use for the request."))
 
 
-class OpenAIServingChatCompletionWithTokens(OpenAIServingChat):
+class OpenAIServingChatWithTokens(OpenAIServingChat):
     """OpenAI-compatible generate API that allows token-in."""
 
     async def create_chat_completion_with_tokens(

--- a/src/prime_rl/inference/vllm/serving_chat_with_tokens.py
+++ b/src/prime_rl/inference/vllm/serving_chat_with_tokens.py
@@ -51,17 +51,6 @@ class OpenAIServingChatCompletionWithTokens(OpenAIServingChat):
         Sequence[RequestPrompt],
         list[EngineTokensPrompt],
     ]:
-        # Early exit when tokens are pre-supplied - skip expensive chat template
-        # and message parsing since client already did this work
-        if hasattr(request, "tokens") and request.tokens:
-            prompt_inputs = TextTokensPrompt(prompt="", prompt_token_ids=request.tokens)
-            engine_prompt = EngineTokensPrompt(prompt_token_ids=request.tokens)
-            if request.mm_processor_kwargs is not None:
-                engine_prompt["mm_processor_kwargs"] = request.mm_processor_kwargs
-            if hasattr(request, "cache_salt") and request.cache_salt is not None:
-                engine_prompt["cache_salt"] = request.cache_salt
-            return [], [prompt_inputs], [engine_prompt]
-
         model_config = self.model_config
 
         resolved_content_format = resolve_chat_template_content_format(

--- a/src/prime_rl/inference/vllm/serving_chat_with_tokens.py
+++ b/src/prime_rl/inference/vllm/serving_chat_with_tokens.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Optional, Sequence, Union
+from typing import Any, Callable, ClassVar, Optional, Sequence, Union
 
 from pydantic import Field
 from vllm.entrypoints.chat_utils import (
@@ -25,6 +25,7 @@ logger = init_logger(__name__)
 
 
 class ChatCompletionRequestWithTokens(ChatCompletionRequest):
+    field_names: ClassVar[Optional[set[str]]] = None
     tokens: list[int] = Field(description=("Prompt tokens to use for the request."))
 
 

--- a/src/prime_rl/inference/vllm/serving_chat_with_tokens.py
+++ b/src/prime_rl/inference/vllm/serving_chat_with_tokens.py
@@ -121,10 +121,10 @@ class OpenAIServingChatCompletionWithTokens(OpenAIServingChat):
 
         # In-place override the engine_prompts with the tokens from the request
         assert len(engine_prompts) == 1
-        if engine_prompts[0]["prompt_token_ids"] != request.tokens:
-            logger.warning(
-                f"Prompt tokens provided in request do not match the engine prompt tokens\nengine_prompt_tokens={engine_prompts[0]['prompt_token_ids']}\nrequest_tokens={request.tokens}\nThis may happen due to retokenization discrepancies in multi-turn conversations. Since you are using the /generate endpoint, we assume you want this behavior and use the provided prompt tokens. If this is undesired, use the standard /v1/chat/completions endpoint instead."
-            )
+        # if engine_prompts[0]["prompt_token_ids"] != request.tokens:
+        #     logger.warning(
+        #         f"Prompt tokens provided in request do not match the engine prompt tokens\nengine_prompt_tokens={engine_prompts[0]['prompt_token_ids']}\nrequest_tokens={request.tokens}\nThis may happen due to retokenization discrepancies in multi-turn conversations. Since you are using the /generate endpoint, we assume you want this behavior and use the provided prompt tokens. If this is undesired, use the standard /v1/chat/completions endpoint instead."
+        #     )
         engine_prompts[0]["prompt_token_ids"] = deepcopy(request.tokens)
 
         request_id = f"chatcmpl-{self._base_request_id(raw_request, request.request_id)}"

--- a/src/prime_rl/inference/vllm/serving_chat_with_tokens.py
+++ b/src/prime_rl/inference/vllm/serving_chat_with_tokens.py
@@ -123,7 +123,7 @@ class OpenAIServingChatCompletionWithTokens(OpenAIServingChat):
         assert len(engine_prompts) == 1
         if engine_prompts[0]["prompt_token_ids"] != request.tokens:
             logger.warning(
-                "Prompt tokens provided in request do not match the engine prompt tokens\nThis may happen due to retokenization discrepancies in multi-turn conversations. Since you are using the /generate endpoint, we assume you want this behavior and use the provided prompt tokens. If this is undesired, use the standard /v1/chat/completions endpoint instead."
+                "Prompt tokens provided in request do not match the engine prompt tokens. This may happen due to retokenization discrepancies in multi-turn conversations. Since you are using the /v1/chat/completions/tokens endpoint, we assume you want this behavior and use the provided prompt tokens. If this is undesired, use the standard /v1/chat/completions endpoint instead."
             )
             logger.debug(f"engine_prompt_tokens:\n{engine_prompts[0]['prompt_token_ids']}")
             logger.debug(f"request_tokens:\n{request.tokens}")

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -618,6 +618,13 @@ class OrchestratorConfig(BaseSettings):
         HeartbeatConfig | None, Field(description="The heartbeat config for monitoring training progress.")
     ] = None
 
+    use_token_prompts: Annotated[
+        bool,
+        Field(
+            description="Whether the environment should use token prompts for rollouts. Disabling this feature may lead to retokenization discrepancies in multi-turn conversations. For more details read docs/trajectories.md",
+        ),
+    ] = False
+
     @model_validator(mode="after")
     def nccl_max_async_level(self):
         if self.weight_broadcast.type == "nccl":

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -621,9 +621,9 @@ class OrchestratorConfig(BaseSettings):
     use_token_prompts: Annotated[
         bool,
         Field(
-            description="Whether the environment should use token prompts for rollouts. Disabling this feature may lead to retokenization discrepancies in multi-turn conversations. For more details read docs/trajectories.md",
+            description="Whether the environment should use token prompts for rollouts. Disabling this feature may lead to retokenization discrepancies in multi-turn conversations.",
         ),
-    ] = False
+    ] = True
 
     tokenize_method: Annotated[
         Literal["local", "vllm"] | None,

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -635,7 +635,7 @@ class OrchestratorConfig(BaseSettings):
     exact_tokenization: Annotated[
         bool | None,
         Field(
-            description="Whether to use exact tokenization for token prompts. Exact tokenization is more precise, but also more costly. Only applicable if using token prompts. If None, will use exact tokenization by default."
+            description="Whether to use exact tokenization for token prompts. Exact tokenization is more precise, but also more costly. Only applicable if using token prompts. If None, will not use exact tokenization by default."
         ),
     ] = None
 
@@ -645,7 +645,7 @@ class OrchestratorConfig(BaseSettings):
             if self.tokenize_method is None:
                 self.tokenize_method = "vllm"
             if self.exact_tokenization is None:
-                self.exact_tokenization = True
+                self.exact_tokenization = False
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -625,6 +625,29 @@ class OrchestratorConfig(BaseSettings):
         ),
     ] = False
 
+    tokenize_method: Annotated[
+        Literal["local", "vllm"] | None,
+        Field(
+            description="Method to use for tokenizing the environment responses. Only applicable if using token prompts. If None, will use vLLM tokenization by default."
+        ),
+    ] = None
+
+    exact_tokenization: Annotated[
+        bool | None,
+        Field(
+            description="Whether to use exact tokenization for token prompts. Exact tokenization is more precise, but also more costly. Only applicable if using token prompts. If None, will use exact tokenization by default."
+        ),
+    ] = None
+
+    @model_validator(mode="after")
+    def auto_setup_token_prompts(self):
+        if self.use_token_prompts:
+            if self.tokenize_method is None:
+                self.tokenize_method = "vllm"
+            if self.exact_tokenization is None:
+                self.exact_tokenization = True
+        return self
+
     @model_validator(mode="after")
     def nccl_max_async_level(self):
         if self.weight_broadcast.type == "nccl":

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -618,36 +618,6 @@ class OrchestratorConfig(BaseSettings):
         HeartbeatConfig | None, Field(description="The heartbeat config for monitoring training progress.")
     ] = None
 
-    use_token_prompts: Annotated[
-        bool,
-        Field(
-            description="Whether the environment should use token prompts for rollouts. Disabling this feature may lead to retokenization discrepancies in multi-turn conversations.",
-        ),
-    ] = True
-
-    tokenize_method: Annotated[
-        Literal["local", "vllm"] | None,
-        Field(
-            description="Method to use for tokenizing the environment responses. Only applicable if using token prompts. If None, will use vLLM tokenization by default."
-        ),
-    ] = None
-
-    exact_tokenization: Annotated[
-        bool | None,
-        Field(
-            description="Whether to use exact tokenization for token prompts. Exact tokenization is more precise, but also more costly. Only applicable if using token prompts. If None, will not use exact tokenization by default."
-        ),
-    ] = None
-
-    @model_validator(mode="after")
-    def auto_setup_token_prompts(self):
-        if self.use_token_prompts:
-            if self.tokenize_method is None:
-                self.tokenize_method = "vllm"
-            if self.exact_tokenization is None:
-                self.exact_tokenization = False
-        return self
-
     @model_validator(mode="after")
     def nccl_max_async_level(self):
         if self.weight_broadcast.type == "nccl":

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -133,7 +133,10 @@ async def orchestrate(config: OrchestratorConfig):
     if config.use_token_prompts:
         logger.info("Using token prompts in environment to avoid retokenization discrepancies in multi-turn rollouts")
         env.set_use_token_prompts(config.use_token_prompts)
-        env.set_tokenize_method("vllm")
+        if config.tokenize_method is not None:
+            env.set_tokenize_method(config.tokenize_method)
+        if config.exact_tokenization is not None:
+            env.set_exact_tokenization(config.exact_tokenization)
     dataset = env.get_dataset(seed=config.seed)
     val_dataset = env.get_eval_dataset(seed=config.seed) if config.val else None
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -131,12 +131,14 @@ async def orchestrate(config: OrchestratorConfig):
     )
     env.set_max_seq_len(config.seq_len)
     if config.use_token_prompts:
-        logger.info("Using token prompts in environment to avoid retokenization discrepancies in multi-turn rollouts")
+        logger.info(
+            f"Using token prompts in environment to avoid retokenization discrepancies in multi-turn rollouts (tokenize_method={config.tokenize_method}, exact_tokenization={config.exact_tokenization})"
+        )
+        assert config.tokenize_method is not None
+        assert config.exact_tokenization is not None
         env.set_use_token_prompts(config.use_token_prompts)
-        if config.tokenize_method is not None:
-            env.set_tokenize_method(config.tokenize_method)
-        if config.exact_tokenization is not None:
-            env.set_exact_tokenization(config.exact_tokenization)
+        env.set_tokenize_method(config.tokenize_method)
+        env.set_exact_tokenization(config.exact_tokenization)
     dataset = env.get_dataset(seed=config.seed)
     val_dataset = env.get_eval_dataset(seed=config.seed) if config.val else None
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -130,15 +130,9 @@ async def orchestrate(config: OrchestratorConfig):
         ),
     )
     env.set_max_seq_len(config.seq_len)
-    if config.use_token_prompts:
-        logger.info(
-            f"Using token prompts in environment to avoid retokenization discrepancies in multi-turn rollouts (tokenize_method={config.tokenize_method}, exact_tokenization={config.exact_tokenization})"
-        )
-        assert config.tokenize_method is not None
-        assert config.exact_tokenization is not None
-        env.set_use_token_prompts(config.use_token_prompts)
-        env.set_tokenize_method(config.tokenize_method)
-        env.set_exact_tokenization(config.exact_tokenization)
+    if config.trajectory_strategy == "interleaved":
+        logger.info("Using token prompts in environment to avoid retokenization discrepancies in multi-turn rollouts")
+        env.interleaved_rollouts = True
     dataset = env.get_dataset(seed=config.seed)
     val_dataset = env.get_eval_dataset(seed=config.seed) if config.val else None
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -132,7 +132,7 @@ async def orchestrate(config: OrchestratorConfig):
     env.set_max_seq_len(config.seq_len)
     if config.trajectory_strategy == "interleaved":
         logger.info("Using token prompts in environment to avoid retokenization discrepancies in multi-turn rollouts")
-        env.interleaved_rollouts = True
+        env.set_interleaved_rollouts(True)
     dataset = env.get_dataset(seed=config.seed)
     val_dataset = env.get_eval_dataset(seed=config.seed) if config.val else None
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -130,7 +130,9 @@ async def orchestrate(config: OrchestratorConfig):
         ),
     )
     env.set_max_seq_len(config.seq_len)
-    env.use_token_prompts = config.use_token_prompts
+    if config.use_token_prompts:
+        logger.info("Using token prompts in environment to avoid retokenization discrepancies in multi-turn rollouts")
+        env.set_use_token_prompts(config.use_token_prompts)
     dataset = env.get_dataset(seed=config.seed)
     val_dataset = env.get_eval_dataset(seed=config.seed) if config.val else None
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -130,6 +130,7 @@ async def orchestrate(config: OrchestratorConfig):
         ),
     )
     env.set_max_seq_len(config.seq_len)
+    env.use_token_prompts = config.use_token_prompts
     dataset = env.get_dataset(seed=config.seed)
     val_dataset = env.get_eval_dataset(seed=config.seed) if config.val else None
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -133,6 +133,7 @@ async def orchestrate(config: OrchestratorConfig):
     if config.use_token_prompts:
         logger.info("Using token prompts in environment to avoid retokenization discrepancies in multi-turn rollouts")
         env.set_use_token_prompts(config.use_token_prompts)
+        env.set_tokenize_method("vllm")
     dataset = env.get_dataset(seed=config.seed)
     val_dataset = env.get_eval_dataset(seed=config.seed) if config.val else None
 

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -368,18 +368,18 @@ class RLConfig(BaseSettings):
 
     @model_validator(mode="after")
     def auto_setup_lora(self):
-        if self.trainer.model.experimental.lora is not None:
+        if self.trainer.model.lora is not None:
             if self.trainer.weight_broadcast.type == "nccl":
                 raise ValueError("NCCL weight broadcast does not support LoRA yet.")
             self.trainer.weight_broadcast.adapter_only = True
             if self.orchestrator.lora_name is None:
                 lora_name = (
-                    f"r{self.trainer.model.experimental.lora.rank}-a{self.trainer.model.experimental.lora.alpha}"
+                    f"r{self.trainer.model.lora.rank}-a{self.trainer.model.lora.alpha}"
                 )
                 self.orchestrator.lora_name = lora_name
             if self.inference is not None:
                 self.inference.enable_lora = True
-                self.inference.max_lora_rank = self.trainer.model.experimental.lora.rank
+                self.inference.max_lora_rank = self.trainer.model.lora.rank
             else:
                 warnings.warn(
                     "LoRA is enabled, but inference is not configured. When manually starting the inference server, make sure to set `--enable_lora` and `--max-lora-rank`."

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -114,17 +114,6 @@ class LoRAConfig(BaseConfig):
     ] = []
 
 
-class ExperimentalConfig(BaseConfig):
-    """Experimental modeling features."""
-
-    lora: Annotated[
-        LoRAConfig | None,
-        Field(
-            description="Whether to apply LoRA to the model. If None, will not apply LoRA.",
-        ),
-    ] = None
-
-
 class ModelConfig(BaseConfig):
     """Configures the model for training."""
 
@@ -234,19 +223,19 @@ class ModelConfig(BaseConfig):
         ),
     ] = True
 
+    lora: Annotated[
+        LoRAConfig | None,
+        Field(
+            description="Whether to apply LoRA to the model. If None, will not apply LoRA.",
+        ),
+    ] = None
+
     debug: Annotated[
         DebugModelConfig,
         Field(
             description="Debugging feature around model and distributed training.",
         ),
     ] = DebugModelConfig()
-
-    experimental: Annotated[
-        ExperimentalConfig,
-        Field(
-            description="Experimental modeling features.",
-        ),
-    ] = ExperimentalConfig()
 
     @model_validator(mode="after")
     def _map_model_name_for_moe(self):

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -345,8 +345,8 @@ def setup_model(
         model = get_model(config, device=torch.device("cpu"), dtype=DTYPE_MAP[config.optimization_dtype])
 
     # Apply LoRA before FSDP setup
-    if config.experimental.lora is not None:
-        apply_lora_to_model(model, config.experimental.lora)
+    if config.lora is not None:
+        apply_lora_to_model(model, config.lora)
 
     # the right order is AC -> Compile -> FSDP
     if config.ac is not None:

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -195,11 +195,11 @@ class RLTrainerConfig(BaseSettings):
     @model_validator(mode="after")
     def validate_lora_adapter_saving(self):
         if self.ckpt and self.ckpt.weights and self.ckpt.weights.save_adapter_separately:
-            lora_enabled = self.model and self.model.experimental and self.model.experimental.lora
+            lora_enabled = self.model and self.model.lora
             if not lora_enabled:
                 raise ValueError(
                     "save_adapter_separately=True requires LoRA to be enabled. "
-                    "Set model.experimental.lora or disable save_adapter_separately."
+                    "Set model.lora or disable save_adapter_separately."
                 )
         return self
 
@@ -217,7 +217,7 @@ class RLTrainerConfig(BaseSettings):
 
     @model_validator(mode="after")
     def validate_lora_broadcast(self):
-        if self.weight_broadcast.adapter_only and not self.model.experimental.lora:
+        if self.weight_broadcast.adapter_only and not self.model.lora:
             raise ValueError("Adapter only weight broadcast requires LoRA to be enabled.")
         if self.weight_broadcast.type == "nccl" and self.weight_broadcast.adapter_only:
             # TODO: Support this

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -95,7 +95,7 @@ def train(config: RLTrainerConfig):
     # Set up checkpoint manager
     logger.info(f"Initializing checkpoint managers ({config.ckpt})")
     ckpt_manager, weight_ckpt_manager = setup_ckpt_managers(
-        config.output_dir, config.ckpt, config.model.experimental.lora
+        config.output_dir, config.ckpt, config.model.lora
     )
 
     # get the checkpoint step to load from
@@ -127,7 +127,7 @@ def train(config: RLTrainerConfig):
     # Set up weight broadcast
     logger.info(f"Initializing weight broadcast ({config.weight_broadcast})")
     weight_broadcast = setup_weight_broadcast(
-        config.output_dir, config.weight_broadcast, config.model.experimental.lora
+        config.output_dir, config.weight_broadcast, config.model.lora
     )
 
     if parallel_dims.cp_enabled:

--- a/src/prime_rl/trainer/sft/config.py
+++ b/src/prime_rl/trainer/sft/config.py
@@ -216,11 +216,11 @@ class SFTTrainerConfig(BaseSettings):
     @model_validator(mode="after")
     def validate_lora_adapter_saving(self):
         if self.ckpt and self.ckpt.weights and self.ckpt.weights.save_adapter_separately:
-            lora_enabled = self.model and self.model.experimental and self.model.experimental.lora
+            lora_enabled = self.model and self.model.lora
             if not lora_enabled:
                 raise ValueError(
                     "save_adapter_separately=True requires LoRA to be enabled. "
-                    "Set model.experimental.lora or disable save_adapter_separately."
+                    "Set model.lora or disable save_adapter_separately."
                 )
         return self
 

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -95,9 +95,7 @@ def train(config: SFTTrainerConfig):
 
     # Set up checkpoint manager
     logger.info(f"Initializing checkpoint managers ({config.ckpt})")
-    ckpt_manager, weight_ckpt_manager = setup_ckpt_managers(
-        config.output_dir, config.ckpt, config.model.experimental.lora
-    )
+    ckpt_manager, weight_ckpt_manager = setup_ckpt_managers(config.output_dir, config.ckpt, config.model.lora)
 
     checkpoint_step = None
     if config.ckpt and config.ckpt.resume_step is not None and ckpt_manager is not None:

--- a/uv.lock
+++ b/uv.lock
@@ -2294,7 +2294,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", specifier = ">=4.56.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=30d89b4" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=e92d25a" },
     { name = "vllm", specifier = "==0.10.2" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -3641,7 +3641,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.8.post2"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=30d89b4#30d89b4cecf8a909beff3b4d5b51ac3ef46789c7" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=e92d25a#e92d25a95c8c97ff0026f89b6538ae4d76e1e0ee" }
 dependencies = [
     { name = "datasets" },
     { name = "jinja2" },

--- a/uv.lock
+++ b/uv.lock
@@ -2294,7 +2294,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", specifier = ">=4.56.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=6c6af33" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=ca48ce9" },
     { name = "vllm", specifier = "==0.10.2" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -3641,7 +3641,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.8.post2"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=6c6af33#6c6af33a94a8c4b89050bbfc18955f889e4d015c" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=ca48ce9#ca48ce9a838101363eef72152e4c0633278f27cf" }
 dependencies = [
     { name = "datasets" },
     { name = "jinja2" },

--- a/uv.lock
+++ b/uv.lock
@@ -2294,7 +2294,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", specifier = ">=4.56.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=ca6aca7" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=cd51f38" },
     { name = "vllm", specifier = "==0.10.2" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -3640,8 +3640,8 @@ wheels = [
 
 [[package]]
 name = "verifiers"
-version = "0.1.8.post1"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=ca6aca7#ca6aca7389a09df5305a8751b4edf34ab4e06f91" }
+version = "0.1.8.post2"
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=cd51f38#cd51f38db631e01a5b61944364bcfbebbddae8ed" }
 dependencies = [
     { name = "datasets" },
     { name = "jinja2" },
@@ -3652,6 +3652,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "requests" },
     { name = "rich" },
+    { name = "tenacity" },
     { name = "textual" },
     { name = "wget" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -2294,7 +2294,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", specifier = ">=4.56.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=e92d25a" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=1181c27" },
     { name = "vllm", specifier = "==0.10.2" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -3641,7 +3641,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.8.post2"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=e92d25a#e92d25a95c8c97ff0026f89b6538ae4d76e1e0ee" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=1181c27#1181c2795cc66df6e867f2d2c9a23cf2e8020c97" }
 dependencies = [
     { name = "datasets" },
     { name = "jinja2" },

--- a/uv.lock
+++ b/uv.lock
@@ -2294,7 +2294,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", specifier = ">=4.56.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=cd51f38" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=6c6af33" },
     { name = "vllm", specifier = "==0.10.2" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -3641,7 +3641,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.8.post2"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=cd51f38#cd51f38db631e01a5b61944364bcfbebbddae8ed" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=6c6af33#6c6af33a94a8c4b89050bbfc18955f889e4d015c" }
 dependencies = [
     { name = "datasets" },
     { name = "jinja2" },

--- a/uv.lock
+++ b/uv.lock
@@ -2294,7 +2294,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", specifier = ">=4.56.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=ca48ce9" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=06c5e59" },
     { name = "vllm", specifier = "==0.10.2" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -3641,7 +3641,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.8.post2"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=ca48ce9#ca48ce9a838101363eef72152e4c0633278f27cf" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=06c5e59#06c5e591d4900d15ea8e9cccd07058266ef6a659" }
 dependencies = [
     { name = "datasets" },
     { name = "jinja2" },

--- a/uv.lock
+++ b/uv.lock
@@ -2294,7 +2294,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", specifier = ">=4.56.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=3759f7f" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=75fa695" },
     { name = "vllm", specifier = "==0.10.2" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -3641,7 +3641,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.8.post2"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=3759f7f#3759f7fc4b75a779379846c4e70c0d8173a63538" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=75fa695#75fa6954ac3d46b0b7bdda4581242633c0a66f58" }
 dependencies = [
     { name = "datasets" },
     { name = "jinja2" },

--- a/uv.lock
+++ b/uv.lock
@@ -2294,7 +2294,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", specifier = ">=4.56.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=06c5e59" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=a8af1e9" },
     { name = "vllm", specifier = "==0.10.2" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -3641,7 +3641,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.8.post2"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=06c5e59#06c5e591d4900d15ea8e9cccd07058266ef6a659" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=a8af1e9#a8af1e9c7924942bc5e2ad2b2917d0c2ecfe6708" }
 dependencies = [
     { name = "datasets" },
     { name = "jinja2" },

--- a/uv.lock
+++ b/uv.lock
@@ -2294,7 +2294,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", specifier = ">=4.56.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=75fa695" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=0dd0645" },
     { name = "vllm", specifier = "==0.10.2" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -3641,7 +3641,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.8.post2"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=75fa695#75fa6954ac3d46b0b7bdda4581242633c0a66f58" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=0dd0645#0dd06450aed7f1a78a8eb7807b5b836575376c40" }
 dependencies = [
     { name = "datasets" },
     { name = "jinja2" },

--- a/uv.lock
+++ b/uv.lock
@@ -2294,7 +2294,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", specifier = ">=4.56.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=67b2b1a" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=260d808" },
     { name = "vllm", specifier = "==0.10.2" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -3641,7 +3641,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.8.post2"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=67b2b1a#67b2b1aa0fb21c8dba99677d64d991803c2f8ff8" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=260d808#260d808b9ee4c75fe84847ff047c13aef9414171" }
 dependencies = [
     { name = "datasets" },
     { name = "jinja2" },

--- a/uv.lock
+++ b/uv.lock
@@ -2294,7 +2294,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", specifier = ">=4.56.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=edb9412" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=67b2b1a" },
     { name = "vllm", specifier = "==0.10.2" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -3641,7 +3641,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.8.post2"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=edb9412#edb9412102fb27691c7e19e214c8f5473f790ec8" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=67b2b1a#67b2b1aa0fb21c8dba99677d64d991803c2f8ff8" }
 dependencies = [
     { name = "datasets" },
     { name = "jinja2" },

--- a/uv.lock
+++ b/uv.lock
@@ -2294,7 +2294,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", specifier = ">=4.56.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=01eaa84" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=30d89b4" },
     { name = "vllm", specifier = "==0.10.2" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -3641,7 +3641,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.8.post2"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=01eaa84#01eaa84c3af1d1b864f995aef2f9b791b55f98ea" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=30d89b4#30d89b4cecf8a909beff3b4d5b51ac3ef46789c7" }
 dependencies = [
     { name = "datasets" },
     { name = "jinja2" },

--- a/uv.lock
+++ b/uv.lock
@@ -2294,7 +2294,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", specifier = ">=4.56.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=442a74a" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=c596bb9" },
     { name = "vllm", specifier = "==0.10.2" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -3641,7 +3641,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.8.post2"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=442a74a#442a74a712bc94b4acb23fda8626629ced6a841b" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=c596bb9#c596bb976ce3a36403579bd4991c856f3a818e3f" }
 dependencies = [
     { name = "datasets" },
     { name = "jinja2" },

--- a/uv.lock
+++ b/uv.lock
@@ -2294,7 +2294,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", specifier = ">=4.56.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=b1e36bc" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=edb9412" },
     { name = "vllm", specifier = "==0.10.2" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -3641,7 +3641,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.8.post2"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=b1e36bc#b1e36bc280dd098f7aede2e0eee62582b9f71885" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=edb9412#edb9412102fb27691c7e19e214c8f5473f790ec8" }
 dependencies = [
     { name = "datasets" },
     { name = "jinja2" },

--- a/uv.lock
+++ b/uv.lock
@@ -2294,7 +2294,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", specifier = ">=4.56.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=1181c27" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=8d79234" },
     { name = "vllm", specifier = "==0.10.2" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -3641,7 +3641,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.8.post2"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=1181c27#1181c2795cc66df6e867f2d2c9a23cf2e8020c97" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=8d79234#8d79234b0cb6151e2b87057575a1c5a3fc609ec0" }
 dependencies = [
     { name = "datasets" },
     { name = "jinja2" },

--- a/uv.lock
+++ b/uv.lock
@@ -2294,7 +2294,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", specifier = ">=4.56.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=260d808" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=63162e4" },
     { name = "vllm", specifier = "==0.10.2" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -3641,7 +3641,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.8.post2"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=260d808#260d808b9ee4c75fe84847ff047c13aef9414171" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=63162e4#63162e42544d8ea1ec58050e3a14f9220c6be4d7" }
 dependencies = [
     { name = "datasets" },
     { name = "jinja2" },

--- a/uv.lock
+++ b/uv.lock
@@ -2294,7 +2294,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", specifier = ">=4.56.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=a8af1e9" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=01eaa84" },
     { name = "vllm", specifier = "==0.10.2" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -3641,7 +3641,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.8.post2"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=a8af1e9#a8af1e9c7924942bc5e2ad2b2917d0c2ecfe6708" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=01eaa84#01eaa84c3af1d1b864f995aef2f9b791b55f98ea" }
 dependencies = [
     { name = "datasets" },
     { name = "jinja2" },

--- a/uv.lock
+++ b/uv.lock
@@ -2294,7 +2294,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", specifier = ">=4.56.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=8d79234" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=b1e36bc" },
     { name = "vllm", specifier = "==0.10.2" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -3641,7 +3641,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.8.post2"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=8d79234#8d79234b0cb6151e2b87057575a1c5a3fc609ec0" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=b1e36bc#b1e36bc280dd098f7aede2e0eee62582b9f71885" }
 dependencies = [
     { name = "datasets" },
     { name = "jinja2" },

--- a/uv.lock
+++ b/uv.lock
@@ -2294,7 +2294,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", specifier = ">=4.56.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=c596bb9" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=3759f7f" },
     { name = "vllm", specifier = "==0.10.2" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -3641,7 +3641,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.8.post2"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=c596bb9#c596bb976ce3a36403579bd4991c856f3a818e3f" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=3759f7f#3759f7fc4b75a779379846c4e70c0d8173a63538" }
 dependencies = [
     { name = "datasets" },
     { name = "jinja2" },

--- a/uv.lock
+++ b/uv.lock
@@ -2294,7 +2294,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", specifier = ">=4.56.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=63162e4" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=442a74a" },
     { name = "vllm", specifier = "==0.10.2" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -3641,7 +3641,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.8.post2"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=63162e4#63162e42544d8ea1ec58050e3a14f9220c6be4d7" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=442a74a#442a74a712bc94b4acb23fda8626629ced6a841b" }
 dependencies = [
     { name = "datasets" },
     { name = "jinja2" },


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Contains recent changes on main + token-in PR (#1422) + migration to vLLM v0.12.0 for this endpoint and some general cleanup that should make future maintenance easier

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a token-in chat completions endpoint to the vLLM server and promotes `model.experimental.lora` to `model.lora`, updating code, configs, and validations.
> 
> - **Inference (vLLM server)**:
>   - Add `/v1/chat/completions/tokens` endpoint with `OpenAIServingChatWithTokens` handler and wiring (router, validation, streaming, error handling).
>   - Patch `init_app_state` to register token-in handler; delegate worker proc via vLLM’s `run_api_server_worker_proc`.
>   - Adjust `InferenceConfig`: auto-set `api_server_count` to `dp` and force `1` when `enable_lora=true`.
> - **Orchestrator**:
>   - When `trajectory_strategy="interleaved"`, enable token prompts in environments to avoid retokenization discrepancies.
> - **Trainer/Config Refactor**:
>   - Move `model.experimental.lora` to `model.lora`; remove `ExperimentalConfig`; update all usages (validators, model setup, ckpt/weight broadcast paths) in RL and SFT trainers and `rl.py`.
>   - Update CI/example TOMLs to `[trainer.model.lora]` and related fields.
> - **Docs**:
>   - Update trajectories guidance; streamline around chat template behavior.
> - **Dependencies/Configs**:
>   - Bump `verifiers` revision; minor example/config tweaks (env IDs, W&B names, parallel settings).
> - **Changelog**:
>   - Document `model.lora` move out of experimental.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e512cc3996e14a3c89684759e067e4f55783fd2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->