### PR TITLE
add `rope_scaling` to inference config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 Documenting changes which affect configuration usage patterns (added/moved/removed/renamed fields, notable logic changes).
 
-- **`inference.model.rope_scaling`**: Added RoPE scaling configuration passthrough to vLLM via `--rope-scaling` (2025-12-17)
 - **`model.lora`**: Moved from `model.experimental.lora` to `model.lora` (no longer experimental) (#1440, 2025-12-16)
+- **`inference.model.rope_scaling`**: Added RoPE scaling configuration passthrough to vLLM (#1447 2025-12-17)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 Documenting changes which affect configuration usage patterns (added/moved/removed/renamed fields, notable logic changes).
 
+- **`inference.model.rope_scaling`**: Added RoPE scaling configuration passthrough to vLLM via `--rope-scaling` (2025-12-17)
 - **`model.lora`**: Moved from `model.experimental.lora` to `model.lora` (no longer experimental) (#1440, 2025-12-16)

--- a/src/prime_rl/inference/config.py
+++ b/src/prime_rl/inference/config.py
@@ -1,6 +1,6 @@
 import os
 from argparse import Namespace
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import Field, model_validator
 
@@ -95,6 +95,13 @@ class ModelConfig(BaseConfig):
         str | None,
         Field(
             description="Parser for extracting reasoning content from model outputs. Passed to vLLM as `--reasoning-parser`. Setting this enables reasoning mode.",
+        ),
+    ] = None
+
+    rope_scaling: Annotated[
+        dict[str, Any] | str | None,
+        Field(
+            description='RoPE scaling configuration as a dict. For YaRN, use: {rope_type="yarn", factor=4.0, original_max_position_embeddings=32768} or. Passed to vLLM as `--rope-scaling`.',
         ),
     ] = None
 
@@ -222,6 +229,7 @@ class InferenceConfig(BaseSettings):
             "model.enable_auto_tool_choice": "enable_auto_tool_choice",
             "model.tool_call_parser": "tool_call_parser",
             "model.reasoning_parser": "reasoning_parser",
+            "model.rope_scaling": "rope_scaling",
             "parallel.tp": "tensor_parallel_size",
             "parallel.dp": "data_parallel_size",
             "enable_lora": "enable_lora",
@@ -241,5 +249,10 @@ class InferenceConfig(BaseSettings):
         # Remove reasoning_parser if not set (vLLM doesn't accept None)
         if namespace.reasoning_parser is None:
             delattr(namespace, "reasoning_parser")
+
+        # Remove rope_scaling if not set (vLLM doesn't accept None)
+        if hasattr(namespace, "rope_scaling"):
+            if namespace.rope_scaling is None:
+                delattr(namespace, "rope_scaling")
 
         return namespace


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

adds `rope_scaling` to inference config to pass on to vLLM.
allows inferencing Qwen3 [with long context](https://huggingface.co/Qwen/Qwen3-14B#processing-long-texts)

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: [Issue ID]
**Linear Issue**: Resolves [Issue ID]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `inference.model.rope_scaling` and forwards it to vLLM, omitting the flag when unset.
> 
> - **Inference config (`src/prime_rl/inference/config.py`)**:
>   - Add `model.rope_scaling: dict[str, Any] | str | None` to `ModelConfig`.
>   - Map `model.rope_scaling` to vLLM `--rope-scaling` in `to_vllm()` and omit when `None`.
> - **Changelog**:
>   - Document new config: `inference.model.rope_scaling`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 900b6845ca534d876ae2a1748c7998b1bf1e3f1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->