### PR TITLE
[Fix] lora inplace load

### DIFF
--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -117,6 +117,9 @@ def monkey_patch_LRUCacheWorkerLoRAManager():
             # This may cause the # of loaded lora adapters to very temporarily
             # exceed `--max-cpu-loras`.
             lora = self._load_adapter(lora_request)
+            ## START PATCHED CODE
+            self._adapter_manager.remove_adapter(lora.id)
+            ## END PATCHED CODE
 
             # Loading succeeded, now check if we will exceed cache capacity and
             # evict if the oldest adapter if so
@@ -124,10 +127,6 @@ def monkey_patch_LRUCacheWorkerLoRAManager():
                 assert isinstance(self._adapter_manager, LRUCacheLoRAModelManager)
                 self._adapter_manager.remove_oldest_adapter()
             # Then add the new adapter to the cache
-            # self._adapter_manager.remove_adapter(lora.id)
-            ## START PATCHED CODE
-            self._adapter_manager.remove_adapter(lora.id)
-            ## END PATCHED CODE
             loaded = self._adapter_manager.add_adapter(lora)
         else:
             # If the lora is already loaded, just touch it to

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -30,3 +30,54 @@ def monkey_patch_prometheus_stat_logger_for_lora_in_dp_mode():
             )
 
     vllm_metrics_loggers.PrometheusStatLogger.__init__ = _patched_prometheus_stat_logger_init
+
+
+# Monkeypatch LoadLoRAAdapter to allow loading the same adapter multiple times
+def monkey_patch_load_lora_adapter():
+    from vllm.entrypoints.openai.serving_models import (
+        ErrorResponse,
+        HTTPStatus,
+        LoadLoRAAdapterRequest,
+        LoRARequest,
+        OpenAIServingModels,
+        create_error_response,
+        logger,
+    )
+
+    async def _patched_load_lora_adapter(
+        self: OpenAIServingModels, request: LoadLoRAAdapterRequest, base_model_name: str | None = None
+    ) -> ErrorResponse | str:
+        lora_name = request.lora_name
+
+        # Ensure atomicity based on the lora name
+        async with self.lora_resolver_lock[lora_name]:
+            lora_path = request.lora_path
+            ## START PATCHED CODE
+            if lora_name in self.lora_requests:
+                lora_request = self.lora_requests[lora_name]
+                lora_request.lora_path = lora_path
+            else:
+                unique_id = self.lora_id_counter.inc(1)
+                lora_request = LoRARequest(lora_name=lora_name, lora_int_id=unique_id, lora_path=lora_path)
+            ## END PATCHED CODE
+            if base_model_name is not None and self.is_base_model(base_model_name):
+                lora_request.base_model_name = base_model_name
+
+            # Validate that the adapter can be loaded into the engine
+            # This will also preload it for incoming requests
+            try:
+                await self.engine_client.add_lora(lora_request)
+            except Exception as e:
+                error_type = "BadRequestError"
+                status_code = HTTPStatus.BAD_REQUEST
+                if "No adapter found" in str(e):
+                    error_type = "NotFoundError"
+                    status_code = HTTPStatus.NOT_FOUND
+
+                return create_error_response(message=str(e), err_type=error_type, status_code=status_code)
+
+            self.lora_requests[lora_name] = lora_request
+            logger.info("Loaded new LoRA adapter: name '%s', path '%s'", lora_name, lora_path)
+            return f"Success: LoRA adapter '{lora_name}' added successfully."
+
+    OpenAIServingModels.load_lora_adapter = _patched_load_lora_adapter

--- a/src/prime_rl/inference/vllm/worker/__init__.py
+++ b/src/prime_rl/inference/vllm/worker/__init__.py
@@ -1,0 +1,4 @@
+from prime_rl.inference.patches import monkey_patch_LRUCacheWorkerLoRAManager
+
+# Monkeypatch LRUCacheWorkerLoRAManager to allow loading adapter inplace without doing it every request
+monkey_patch_LRUCacheWorkerLoRAManager()


### PR DESCRIPTION
Previously, we would keep incrementing the loras. This is fine but sometimes causes weird behavior when old requests are still in the scheduler. This PR patches the load lora logic such that we replace the old lora model in the LoRACacheModelManager.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allow in-place LoRA adapter updates and avoid redundant loads by patching OpenAI serving model and worker LoRA manager, wired into server and worker init.
> 
> - **LoRA loading (server-side)**:
>   - Patch `OpenAIServingModels.load_lora_adapter` to reuse existing `LoRARequest` per `lora_name`, updating `lora_path` and validating via `engine_client.add_lora(...)`.
>   - Remove prior hack overriding `_check_load_lora_adapter_request`.
> - **LoRA cache (worker-side)**:
>   - Patch `LRUCacheWorkerLoRAManager`:
>     - `_apply_adapters`: call `add_adapter(..., force_load=False)` for requested adapters.
>     - `add_adapter`: only load if not present or `force_load`; reload path removes existing adapter, evicts LRU if needed, re-adds, and activates.
>   - Apply patch at import via `prime_rl.inference.vllm.worker.__init__`.
> - **Server wiring**:
>   - Import and invoke `monkey_patch_load_lora_adapter()` in `src/prime_rl/inference/vllm/server.py` alongside existing Prometheus patch.
>   - Ensure child workers receive patches by re-importing module in `custom_run_api_server_worker_proc`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efc9f27839f097a5ebdbb83e4e927002d4a90bd8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->