### PR TITLE
[fix] runnable nccl worker

### DIFF
--- a/src/prime_rl/inference/vllm/worker/nccl.py
+++ b/src/prime_rl/inference/vllm/worker/nccl.py
@@ -109,7 +109,7 @@ class NCCLWeightUpdateWorker(Worker):
     def update_weights(self, weight_dir: str) -> None:
         """Update weights with the nccl communicator."""
         model_runner = self.model_runner
-        model = model_runner.model
+        model = model_runner.model.runnable
         assert isinstance(model, Module)
 
         state_iter = self.nccl_broadcast_receiver.receive_state_dict()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches weight loading to use `model_runner.model.runnable` in `NCCLWeightUpdateWorker.update_weights`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 502a2cd2f26ee450e8e40b4daf6d665b18dc3f11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->