### PR TITLE
fix: set model seq len

### DIFF
--- a/configs/ci/nightly/acereason_math.toml
+++ b/configs/ci/nightly/acereason_math.toml
@@ -11,6 +11,9 @@ max_steps = 300
 [model]
 name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"
 
+[trainer.model]
+seq_len = 8192
+
 [orchestrator]
 batch_size = 1024
 seq_len = 8192

--- a/examples/wiki_search/rl.toml
+++ b/examples/wiki_search/rl.toml
@@ -6,6 +6,9 @@ max_steps = 200
 [model]
 name = "Qwen/Qwen3-4B-Instruct-2507"
 
+[trainer.model]
+seq_len = 4096
+
 [wandb]
 project = "wiki-search"
 name = "wiki-search"

--- a/examples/wordle/rl.toml
+++ b/examples/wordle/rl.toml
@@ -12,6 +12,9 @@ name = "wordle"
 [model]
 name = "PrimeIntellect/Qwen3-1.7B-Wordle-SFT"
 
+[trainer.model]
+seq_len = 8192
+
 [orchestrator]
 seq_len = 8192
 batch_size = 1024


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Set `trainer.model.seq_len` in `acereason_math`, `wiki_search`, and `wordle` RL configs.
> 
> - **Configs**:
>   - `configs/ci/nightly/acereason_math.toml`: add `[trainer.model]` with `seq_len = 8192`.
>   - `examples/wiki_search/rl.toml`: add `[trainer.model]` with `seq_len = 4096`.
>   - `examples/wordle/rl.toml`: add `[trainer.model]` with `seq_len = 8192`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0bbc2be6e96c7cecd18cc3ff4f0951987388656. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->