### PR TITLE
helm: specify `run_*` in orchestrator output directory configuration

### DIFF
--- a/k8s/prime-rl/examples/reverse-text.yaml
+++ b/k8s/prime-rl/examples/reverse-text.yaml
@@ -11,7 +11,7 @@ image:
 orchestrator:
   enabled: true
   autoStart: true
-  command: "uv run orchestrator @ /app/examples/reverse_text/rl/orch.toml --output-dir /data/outputs --client.base-url $INFERENCE_URL ; sleep infinity"
+  command: "uv run orchestrator @ /app/examples/reverse_text/rl/orch.toml --output-dir /data/outputs/run_default --client.base-url $INFERENCE_URL ; sleep infinity"
   resources:
     requests:
       memory: "1Gi"

--- a/k8s/prime-rl/values.yaml
+++ b/k8s/prime-rl/values.yaml
@@ -29,7 +29,7 @@ orchestrator:
   # Auto-start configuration (set to false to use sleep infinity for debugging)
   autoStart: false
   # Example command - use $INFERENCE_URL directly (comma-separated list of all inference server URLs)
-  command: ""  # e.g., 'uv run orchestrator @ /app/examples/reverse_text/rl/orch.toml --output-dir /data/outputs --client.base-url $INFERENCE_URL'
+  command: ""  # e.g., 'uv run orchestrator @ /app/examples/reverse_text/rl/orch.toml --output-dir /data/outputs/run_default --client.base-url $INFERENCE_URL'
   # $INFERENCE_URL is auto-set to: 'http://<release>-inference-0...:8000/v1,http://<release>-inference-1...:8000/v1,...'
 
   resources:


### PR DESCRIPTION
i've been doing training runs on k8s and after a recent update, the trainer started to get stuck waiting for training batches to arrive from the orchestrator.

i dug around a bit and missed this PR: https://github.com/PrimeIntellect-ai/prime-rl/pull/1419 so pretty much my orch wasn't writing to the directory (`run_*`) that the trainer was expecting (easy fix).

but i also wanted to just update the helm values to reflect this too so others don't run into this, since that's what i used for reference to get my k8s deployment running.

## Testing
the issue can be replicated by just running the `reverse-text` example:
```bash
❯ helm install reverse-test ./prime-rl -f ./prime-rl/examples/reverse-text.yaml
```

orch getting stuck:
<img width="696" height="52" alt="Screenshot 2025-12-18 at 4 06 30 PM" src="https://github.com/user-attachments/assets/78ef9694-6c63-4287-87c1-371873a02514" />

trainer getting stuck:
<img width="525" height="79" alt="Screenshot 2025-12-18 at 4 06 02 PM" src="https://github.com/user-attachments/assets/9efeb46b-9678-440d-871c-fb79ca1e0d1c" />

after update the orch output dir to `/data/outputs/run_default`, the `reverse-text` example runs to completion:
<img width="523" height="53" alt="Screenshot 2025-12-18 at 4 17 20 PM" src="https://github.com/user-attachments/assets/c36f2f0e-3431-46bc-8f77-bcc9f8bbeebf" />






<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates orchestrator command to use `/data/outputs/run_default` in `examples/reverse-text.yaml` and aligns the example command in `values.yaml`.
> 
> - **Helm/k8s**:
>   - **Orchestrator**:
>     - Update command in `k8s/prime-rl/examples/reverse-text.yaml` to use `--output-dir /data/outputs/run_default`.
>     - Align example command in `k8s/prime-rl/values.yaml` to reference `--output-dir /data/outputs/run_default`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9db271e451ef63edbfa4eb518be6abc3d5218971. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->