### PR TITLE
[fix] error if train seq len too short and add arg for setting in rl.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@ Documenting changes which affect configuration usage patterns (added/moved/remov
 - **`orchestrator.buffer.env_ratios`**: Added environment ratio configuration for buffer sampling (#1450, 2025-12-18)
 - **`orchestrator.ckpt.buffer_path`**: Deprecated (#1450, 2025-12-18)
 - **`orchestrator.buffer.easy_fraction`** and **`orchestrator.buffer.hard_fraction`**: Easy and hard fraction now defines the fraction of easy and hard problems to convert to normal when resuming, whereas previously it was the ratio of easy/ hard samples to sample per step (#1450, 2025-12-18)
+- **`seq_len`**: Added root-level `seq_len` config that sets both `trainer.model.seq_len` and `orchestrator.seq_len`. Added validation that `trainer.model.seq_len >= orchestrator.seq_len` (2025-12-18)

--- a/configs/acereason_math/stage1.toml
+++ b/configs/acereason_math/stage1.toml
@@ -2,6 +2,7 @@ inference_gpu_ids = [0,1,2,3,4,5]
 trainer_gpu_ids = [6,7]
 
 max_steps = 500
+seq_len = 8192
 
 [model]
 name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"
@@ -15,7 +16,6 @@ name = "stage1"
 
 [orchestrator]
 batch_size = 1024
-seq_len = 8192
 rollouts_per_example = 8
 
 [orchestrator.sampling]

--- a/configs/acereason_math/stage2.toml
+++ b/configs/acereason_math/stage2.toml
@@ -2,6 +2,7 @@ inference_gpu_ids = [0,1,2,3,4,5]
 trainer_gpu_ids = [6,7]
 
 max_steps = 1000
+seq_len = 16384
 
 [model]
 name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"
@@ -16,7 +17,6 @@ name = "stage2"
 
 [orchestrator]
 batch_size = 2048
-seq_len = 16384
 rollouts_per_example = 16
 
 [orchestrator.sampling]

--- a/configs/alphabet_sort/rl.toml
+++ b/configs/alphabet_sort/rl.toml
@@ -1,4 +1,5 @@
 max_steps = 100
+seq_len = 2048
 
 [wandb]
 project = "alphabet-sort-debug"
@@ -11,7 +12,6 @@ name = "Qwen/Qwen3-4B-Instruct-2507"
 [orchestrator]
 batch_size = 512
 rollouts_per_example = 16
-seq_len = 2048
 
 [orchestrator.sampling]
 max_tokens = 512

--- a/configs/ci/integration/rl/resume.toml
+++ b/configs/ci/integration/rl/resume.toml
@@ -2,6 +2,7 @@ inference_gpu_ids = [0]
 trainer_gpu_ids = [1]
 
 max_steps = 25
+seq_len = 2048
 
 [ckpt]
 resume_step = 20
@@ -15,7 +16,6 @@ lr = 3e-6
 [orchestrator]
 batch_size = 128
 rollouts_per_example = 16
-seq_len = 2048
 
 [orchestrator.sampling]
 max_tokens = 128

--- a/configs/ci/integration/rl/start.toml
+++ b/configs/ci/integration/rl/start.toml
@@ -2,6 +2,7 @@ inference_gpu_ids = [0]
 trainer_gpu_ids = [1]
 
 max_steps = 20
+seq_len = 2048
 
 [ckpt]
 
@@ -14,7 +15,6 @@ lr = 3e-6
 [orchestrator]
 batch_size = 128
 rollouts_per_example = 16
-seq_len = 2048
 
 [orchestrator.sampling]
 max_tokens = 128

--- a/configs/ci/integration/rl_lora/resume.toml
+++ b/configs/ci/integration/rl_lora/resume.toml
@@ -2,6 +2,7 @@ inference_gpu_ids = [0]
 trainer_gpu_ids = [1]
 
 max_steps = 25
+seq_len = 2048
 
 [ckpt]
 resume_step = 20
@@ -24,7 +25,6 @@ adapter_only = true
 [orchestrator]
 batch_size = 128
 rollouts_per_example = 16
-seq_len = 2048
 lora_name = "r8-1e-4"
 
 [orchestrator.sampling]

--- a/configs/ci/integration/rl_lora/start.toml
+++ b/configs/ci/integration/rl_lora/start.toml
@@ -2,6 +2,7 @@ inference_gpu_ids = [0]
 trainer_gpu_ids = [1]
 
 max_steps = 20
+seq_len = 2048
 
 [ckpt]
 
@@ -23,7 +24,6 @@ adapter_only = true
 [orchestrator]
 batch_size = 128
 rollouts_per_example = 16
-seq_len = 2048
 lora_name = "r8-1e-4"
 
 [orchestrator.sampling]

--- a/configs/ci/nightly/acereason_math.toml
+++ b/configs/ci/nightly/acereason_math.toml
@@ -7,16 +7,13 @@ inference_gpu_ids = [0,1,2,3]
 trainer_gpu_ids = [4,5,6,7]
 
 max_steps = 300
+seq_len = 8192
 
 [model]
 name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"
 
-[trainer.model]
-seq_len = 8192
-
 [orchestrator]
 batch_size = 1024
-seq_len = 8192
 rollouts_per_example = 8
 
 [orchestrator.sampling]

--- a/configs/ci/nightly/hendrycks_math.toml
+++ b/configs/ci/nightly/hendrycks_math.toml
@@ -2,6 +2,7 @@ inference_gpu_ids = [0,1,2,3]
 trainer_gpu_ids = [4,5,6,7]
 
 max_steps = 300
+seq_len = 2048
 
 [model]
 name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
@@ -9,7 +10,6 @@ name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
 [orchestrator]
 batch_size = 1024
 rollouts_per_example = 16
-seq_len = 2048
 
 [orchestrator.sampling]
 max_tokens = 2048

--- a/configs/deepscaler/stage1.toml
+++ b/configs/deepscaler/stage1.toml
@@ -2,6 +2,7 @@ inference_gpu_ids = [0,1,2,3,4,5]
 trainer_gpu_ids = [6,7]
 
 max_steps = 500
+seq_len = 8192
 
 [model]
 name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
@@ -15,7 +16,6 @@ interval = 100
 
 [orchestrator]
 batch_size = 1024
-seq_len = 8192
 rollouts_per_example = 8
 
 [orchestrator.sampling]

--- a/configs/deepscaler/stage2.toml
+++ b/configs/deepscaler/stage2.toml
@@ -2,6 +2,7 @@ inference_gpu_ids = [0,1,2,3,4,5]
 trainer_gpu_ids = [6,7]
 
 max_steps = 1000
+seq_len = 16384
 
 [model]
 name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
@@ -16,7 +17,6 @@ resume_step = 500
 
 [orchestrator]
 batch_size = 1024
-seq_len = 16384
 rollouts_per_example = 8
 
 [orchestrator.sampling]

--- a/configs/deepscaler/stage3.toml
+++ b/configs/deepscaler/stage3.toml
@@ -2,6 +2,7 @@ inference_gpu_ids = [0,1,2,3,4,5]
 trainer_gpu_ids = [6,7]
 
 max_steps = 1500
+seq_len = 24576
 
 [model]
 name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
@@ -16,7 +17,6 @@ resume_step = 1000
 
 [orchestrator]
 batch_size = 1024
-seq_len = 24576
 rollouts_per_example = 8
 
 [orchestrator.sampling]

--- a/configs/gsm8k/rl.toml
+++ b/configs/gsm8k/rl.toml
@@ -2,6 +2,7 @@ inference_gpu_ids = [0]
 trainer_gpu_ids = [1]
 
 max_steps = 100
+seq_len = 2048
 
 [wandb]
 project = "gsm8k-debug"
@@ -13,7 +14,6 @@ name = "PrimeIntellect/Qwen3-0.6B"
 [orchestrator]
 batch_size = 512
 rollouts_per_example = 16
-seq_len = 2048
 
 [orchestrator.sampling]
 max_tokens = 2048

--- a/configs/hendrycks_math/rl.toml
+++ b/configs/hendrycks_math/rl.toml
@@ -2,6 +2,7 @@ trainer_gpu_ids = [0]
 inference_gpu_ids = [1]
 
 max_steps = 500
+seq_len = 2048
 
 [wandb]
 project = "hendrycks-math-debug"
@@ -13,7 +14,6 @@ name = "Qwen/Qwen3-4B-Instruct-2507"
 [orchestrator]
 batch_size = 512
 rollouts_per_example = 16
-seq_len = 2048
 
 [orchestrator.sampling]
 max_tokens = 2048

--- a/configs/math_python/math_python.toml
+++ b/configs/math_python/math_python.toml
@@ -1,4 +1,5 @@
 max_steps = 300
+seq_len = 4096
 
 [wandb]
 project = "math-python-debug"
@@ -8,7 +9,6 @@ name = "math-python"
 name = "Qwen/Qwen3-4B-Instruct-2507"
 
 [orchestrator]
-seq_len = 4096
 batch_size = 512
 rollouts_per_example = 16
 

--- a/configs/multi_reverse_text/rl.toml
+++ b/configs/multi_reverse_text/rl.toml
@@ -1,4 +1,5 @@
 max_steps = 20
+seq_len = 2048
 
 [model]
 name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
@@ -6,7 +7,6 @@ name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
 [orchestrator]
 batch_size = 128
 rollouts_per_example = 16
-seq_len = 2048
 
 [orchestrator.sampling]
 max_tokens = 128

--- a/configs/wiki_search/rl.toml
+++ b/configs/wiki_search/rl.toml
@@ -2,6 +2,7 @@ inference_gpu_ids = [0]
 trainer_gpu_ids = [1]
 
 max_steps = 500
+seq_len = 4096
 
 [model]
 name = "Qwen/Qwen3-4B-Instruct-2507"
@@ -31,7 +32,6 @@ target_modules = [
 [orchestrator]
 batch_size = 512
 rollouts_per_example = 16
-seq_len = 4096
 oversampling_factor = 2.0
 
 [orchestrator.sampling]

--- a/examples/alphabet_sort/rl.toml
+++ b/examples/alphabet_sort/rl.toml
@@ -1,5 +1,6 @@
 
-max_steps = 200 
+max_steps = 200
+seq_len = 2048
 
 [ckpt] # Checkpoint at the end of training
 
@@ -26,7 +27,6 @@ lr = 1e-5
 [orchestrator]
 batch_size = 512
 rollouts_per_example = 8
-seq_len = 2048
 
 [orchestrator.sampling]
 max_tokens = 768

--- a/examples/reverse_text/rl.toml
+++ b/examples/reverse_text/rl.toml
@@ -1,4 +1,5 @@
 max_steps = 20
+seq_len = 2048
 
 [model]
 name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
@@ -10,7 +11,6 @@ name = "reverse-text"
 [orchestrator]
 batch_size = 128
 rollouts_per_example = 16
-seq_len = 2048
 
 [orchestrator.sampling]
 max_tokens = 128

--- a/examples/wiki_search/rl.toml
+++ b/examples/wiki_search/rl.toml
@@ -2,12 +2,10 @@ inference_gpu_ids = [0,1,2,3,4,5]
 trainer_gpu_ids = [6,7]
 
 max_steps = 200
+seq_len = 4096
 
 [model]
 name = "Qwen/Qwen3-4B-Instruct-2507"
-
-[trainer.model]
-seq_len = 4096
 
 [wandb]
 project = "wiki-search"
@@ -34,7 +32,6 @@ target_modules = [
 [orchestrator]
 batch_size = 512
 rollouts_per_example = 16
-seq_len = 4096
 oversampling_factor = 2.0
 lora_name = "qwen3-4b-wiki-search"
 

--- a/examples/wordle/rl.toml
+++ b/examples/wordle/rl.toml
@@ -2,6 +2,7 @@ inference_gpu_ids = [0,1,2,3,4,5]
 trainer_gpu_ids = [6,7]
 
 max_steps = 200
+seq_len = 8192
 
 [wandb]
 project = "wordle"
@@ -12,11 +13,7 @@ name = "wordle"
 [model]
 name = "PrimeIntellect/Qwen3-1.7B-Wordle-SFT"
 
-[trainer.model]
-seq_len = 8192
-
 [orchestrator]
-seq_len = 8192
 batch_size = 1024
 rollouts_per_example = 16
 

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -40,7 +40,6 @@ from prime_rl.utils.validation import (
     validate_shared_max_steps,
     validate_shared_model_name,
     validate_shared_output_dir,
-    validate_shared_seq_len,
     validate_shared_wandb_config,
     validate_shared_weight_broadcast,
 )
@@ -360,7 +359,11 @@ class RLConfig(BaseSettings):
             self.trainer.model.seq_len = self.seq_len
             self.orchestrator.seq_len = self.seq_len
 
-        validate_shared_seq_len(self.trainer, self.orchestrator)
+        if self.trainer.model.seq_len < self.orchestrator.seq_len:
+            raise ValueError(
+                f"Trainer model seq_len ({self.trainer.model.seq_len}) must be >= orchestrator seq_len ({self.orchestrator.seq_len}). "
+                f"The trainer needs to be able to handle sequences at least as long as those produced by the orchestrator."
+            )
 
         return self
 

--- a/src/prime_rl/utils/validation.py
+++ b/src/prime_rl/utils/validation.py
@@ -104,14 +104,3 @@ def validate_shared_weight_broadcast(
         raise ValueError(
             f"Trainer weight broadcast type ({trainer.weight_broadcast.type}) and orchestrator weight broadcast type ({orchestrator.weight_broadcast.type}) are not the same. Please specify the same weight broadcast type for both."
         )
-
-
-def validate_shared_seq_len(
-    trainer: RLTrainerConfig,
-    orchestrator: OrchestratorConfig,
-) -> None:
-    if trainer.model.seq_len < orchestrator.seq_len:
-        raise ValueError(
-            f"Trainer model seq_len ({trainer.model.seq_len}) must be >= orchestrator seq_len ({orchestrator.seq_len}). "
-            f"The trainer needs to be able to handle sequences at least as long as those produced by the orchestrator."
-        )

--- a/src/prime_rl/utils/validation.py
+++ b/src/prime_rl/utils/validation.py
@@ -104,3 +104,14 @@ def validate_shared_weight_broadcast(
         raise ValueError(
             f"Trainer weight broadcast type ({trainer.weight_broadcast.type}) and orchestrator weight broadcast type ({orchestrator.weight_broadcast.type}) are not the same. Please specify the same weight broadcast type for both."
         )
+
+
+def validate_shared_seq_len(
+    trainer: RLTrainerConfig,
+    orchestrator: OrchestratorConfig,
+) -> None:
+    if trainer.model.seq_len < orchestrator.seq_len:
+        raise ValueError(
+            f"Trainer model seq_len ({trainer.model.seq_len}) must be >= orchestrator seq_len ({orchestrator.seq_len}). "
+            f"The trainer needs to be able to handle sequences at least as long as those produced by the orchestrator."
+        )


### PR DESCRIPTION
We accidentally hit this in the nightly CI recently and it would be nice to have an error here instead of silently truncating.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce root-level `seq_len` that sets both trainer and orchestrator lengths with validation, and update configs to use it.
> 
> - **Core (RLConfig in `src/prime_rl/rl.py`)**:
>   - Add root-level `seq_len` field; auto-propagates to `trainer.model.seq_len` and `orchestrator.seq_len`.
>   - Validate `trainer.model.seq_len >= orchestrator.seq_len`; raise error otherwise.
>   - Minor cleanup: inline LoRA `lora_name` formatting.
> - **Configs**:
>   - Migrate many TOML files to use root-level `seq_len` and remove per-module `orchestrator.seq_len`/`trainer.model.seq_len` entries.
> - **Changelog**:
>   - Document new root-level `seq_len` and the validation behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 791f876ac7442d598cf007fc7e34cb9fbe2bd6e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->