### PR TITLE
Measure event loop lag

### DIFF
--- a/src/prime_rl/orchestrator/event_loop_lag.py
+++ b/src/prime_rl/orchestrator/event_loop_lag.py
@@ -13,9 +13,9 @@ class EventLoopLagMonitor:
         self,
         interval: float = 1.0,
         max_window_size: int = 10000,
-        warn_med_lag_threshold: float = 1.0,
-        warn_p90_lag_threshold: float = 2.0,
-        warn_max_lag_threshold: float = 10.0,
+        warn_med_lag_threshold: float = 0.5,
+        warn_p90_lag_threshold: float = 1.0,
+        warn_max_lag_threshold: float = 5.0,
     ):
         assert (
             interval > 0

--- a/src/prime_rl/orchestrator/event_loop_lag.py
+++ b/src/prime_rl/orchestrator/event_loop_lag.py
@@ -55,6 +55,8 @@ class EventLoopLagMonitor:
     def get_metrics(self) -> dict[str, float]:
         """Compute metrics for the event loop lag over the last window_size measurements."""
         window_size = int(min(self.max_window_size, len(self.lags)))
+        if window_size <= 0:
+            return {}
         last_lags = np.array(self.lags[-window_size:])
         mean_lag = float(np.mean(last_lags))
         med_lag = float(np.median(last_lags))

--- a/src/prime_rl/orchestrator/event_loop_lag.py
+++ b/src/prime_rl/orchestrator/event_loop_lag.py
@@ -81,14 +81,3 @@ class EventLoopLagMonitor:
             "event_loop_lag/p90": p90_lag,
             "event_loop_lag/max": max_lag,
         }
-
-
-_EVENT_LOOP_LAG_MONITOR: EventLoopLagMonitor | None = None
-
-
-def get_event_loop_lag_monitor() -> EventLoopLagMonitor:
-    global _EVENT_LOOP_LAG_MONITOR
-    if _EVENT_LOOP_LAG_MONITOR is None:
-        _EVENT_LOOP_LAG_MONITOR = EventLoopLagMonitor()
-
-    return _EVENT_LOOP_LAG_MONITOR

--- a/src/prime_rl/orchestrator/event_loop_lag.py
+++ b/src/prime_rl/orchestrator/event_loop_lag.py
@@ -48,14 +48,3 @@ class EventLoopLagMonitor:
 
     def reset(self):
         self.lags = []
-
-
-_EVENT_LOOP_LAG_MONITOR: EventLoopLagMonitor | None = None
-
-
-def get_event_loop_lag_monitor(interval: float = 1.0, max_lag: float = 1.0) -> EventLoopLagMonitor:
-    global _EVENT_LOOP_LAG_MONITOR
-    if _EVENT_LOOP_LAG_MONITOR is None:
-        _EVENT_LOOP_LAG_MONITOR = EventLoopLagMonitor(interval, max_lag)
-
-    return _EVENT_LOOP_LAG_MONITOR

--- a/src/prime_rl/orchestrator/event_loop_lag.py
+++ b/src/prime_rl/orchestrator/event_loop_lag.py
@@ -12,8 +12,8 @@ class EventLoopLagMonitor:
     def __init__(
         self,
         interval: float = 1.0,
-        max_window_size: int = 1000,
-        warn_median_lag_threshold: float = 1.0,
+        max_window_size: int = 10000,
+        warn_med_lag_threshold: float = 1.0,
         warn_p90_lag_threshold: float = 2.0,
         warn_max_lag_threshold: float = 10.0,
     ):
@@ -21,14 +21,14 @@ class EventLoopLagMonitor:
             interval > 0
             and max_window_size > 0
             and warn_max_lag_threshold > 0
-            and warn_median_lag_threshold > 0
+            and warn_med_lag_threshold > 0
             and warn_p90_lag_threshold > 0
         )
         self.interval = interval
-        self.warn_max_lag_threshold = warn_max_lag_threshold
-        self.warn_median_lag_threshold = warn_median_lag_threshold
-        self.warn_p90_lag_threshold = warn_p90_lag_threshold
         self.max_window_size = max_window_size
+        self.warn_max_lag_threshold = warn_max_lag_threshold
+        self.warn_med_lag_threshold = warn_med_lag_threshold
+        self.warn_p90_lag_threshold = warn_p90_lag_threshold
         self.logger = get_logger()
         self.lags = []
 
@@ -54,7 +54,7 @@ class EventLoopLagMonitor:
 
     def get_metrics(self) -> dict[str, float]:
         """Compute metrics for the event loop lag over the last window_size measurements."""
-        window_size = min(self.max_window_size, len(self.lags))
+        window_size = int(min(self.max_window_size, len(self.lags)))
         last_lags = np.array(self.lags[-window_size:])
         mean_lag = float(np.mean(last_lags))
         med_lag = float(np.median(last_lags))
@@ -62,7 +62,7 @@ class EventLoopLagMonitor:
         min_lag = float(np.min(last_lags))
         max_lag = float(np.max(last_lags))
         if (
-            med_lag > self.warn_median_lag_threshold
+            med_lag > self.warn_med_lag_threshold
             or p90_lag > self.warn_p90_lag_threshold
             or max_lag > self.warn_max_lag_threshold
         ):

--- a/src/prime_rl/orchestrator/event_loop_lag.py
+++ b/src/prime_rl/orchestrator/event_loop_lag.py
@@ -48,3 +48,14 @@ class EventLoopLagMonitor:
 
     def reset(self):
         self.lags = []
+
+
+_EVENT_LOOP_LAG_MONITOR: EventLoopLagMonitor | None = None
+
+
+def get_event_loop_lag_monitor(interval: float = 1.0, max_lag: float = 1.0) -> EventLoopLagMonitor:
+    global _EVENT_LOOP_LAG_MONITOR
+    if _EVENT_LOOP_LAG_MONITOR is None:
+        _EVENT_LOOP_LAG_MONITOR = EventLoopLagMonitor(interval, max_lag)
+
+    return _EVENT_LOOP_LAG_MONITOR

--- a/src/prime_rl/orchestrator/event_loop_lag.py
+++ b/src/prime_rl/orchestrator/event_loop_lag.py
@@ -1,0 +1,61 @@
+import asyncio
+from time import perf_counter
+
+from prime_rl.utils.logger import get_logger
+
+
+class EventLoopLagMonitor:
+    """A class to monitor how busy the main event loop is."""
+
+    def __init__(self, interval: float = 1.0, warn_lag_threshold: float = 1.0, max_window_size: int = 1000):
+        assert interval > 0 and warn_lag_threshold > 0 and max_window_size > 0
+        self.interval = interval
+        self.warn_lag_threshold = warn_lag_threshold
+        self.max_window_size = max_window_size
+        self.logger = get_logger()
+        self.lags = []
+
+    async def measure_lag(self, interval: float | None = None):
+        """Measures event loop lag by asynchronously sleeping for interval seconds"""
+        if interval is None:
+            interval = self.interval
+        assert interval > 0
+        next_time = perf_counter() + interval
+        await asyncio.sleep(interval)
+        now = perf_counter()
+        lag = now - next_time
+        return lag
+
+    async def run(self):
+        """Infinite loop to periodically measure event loop lag. Should be started as background task."""
+        while True:
+            lag = await self.measure_lag()
+            self.lags.append(lag)
+            if len(self.lags) > self.max_window_size:
+                self.lags.pop(0)
+
+    def get_avg_lag(self, window_size: int | None = None) -> float:
+        """Get the average event loop lag over the last window_size measurements."""
+        if window_size is None:
+            window_size = self.max_window_size
+        assert window_size > 0
+        avg_lag = sum(self.lags[-window_size:]) / min(window_size, len(self.lags))
+        if avg_lag > self.warn_lag_threshold:
+            self.logger.warning(
+                f"Detected busy event loop. Measured {avg_lag:.1f}s event loop lag over the last {window_size} measurement(s)"
+            )
+        return avg_lag
+
+    def reset(self):
+        self.lags = []
+
+
+_EVENT_LOOP_LAG_MONITOR: EventLoopLagMonitor | None = None
+
+
+def get_event_loop_lag_monitor(interval: float = 1.0, max_lag: float = 1.0) -> EventLoopLagMonitor:
+    global _EVENT_LOOP_LAG_MONITOR
+    if _EVENT_LOOP_LAG_MONITOR is None:
+        _EVENT_LOOP_LAG_MONITOR = EventLoopLagMonitor(interval, max_lag)
+
+    return _EVENT_LOOP_LAG_MONITOR

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -5,7 +5,7 @@ import time
 import tomli_w
 
 from prime_rl.orchestrator.advantage import compute_advantages
-from prime_rl.orchestrator.event_loop_lag import get_event_loop_lag_monitor
+from prime_rl.orchestrator.event_loop_lag import EventLoopLagMonitor
 from prime_rl.orchestrator.patches import monkey_patch_chat_completion_logprobs, monkey_patch_oai_iterable_types
 from prime_rl.orchestrator.trajectories import branch_rollout, interleave_rollout
 from prime_rl.transport import TrainingBatch, TrainingSample, setup_training_batch_sender
@@ -69,7 +69,7 @@ async def orchestrate(config: OrchestratorConfig):
     vf.setup_logging(level=config.log.vf_level.upper())
     logger.info("Starting orchestrator")
 
-    event_loop_lag_monitor = get_event_loop_lag_monitor()
+    event_loop_lag_monitor = EventLoopLagMonitor()
     asyncio.create_task(event_loop_lag_monitor.run())
 
     # Print warning if running in benchmark mode

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -70,7 +70,7 @@ async def orchestrate(config: OrchestratorConfig):
     logger.info("Starting orchestrator")
 
     event_loop_lag_monitor = EventLoopLagMonitor()
-    asyncio.create_task(event_loop_lag_monitor.run())
+    event_loop_lag_monitor_task = asyncio.create_task(event_loop_lag_monitor.run())
 
     # Print warning if running in benchmark mode
     if config.bench:
@@ -467,6 +467,8 @@ async def orchestrate(config: OrchestratorConfig):
         progress.step += 1
         is_first_step = False
 
+        event_loop_lag_monitor.reset()
+
         # Send heartbeat if configured
         if heart is not None:
             heart.beat()
@@ -497,7 +499,8 @@ async def orchestrate(config: OrchestratorConfig):
     # Close training batch sender
     training_batch_sender.close()
 
-    event_loop_lag_monitor.reset()
+    # Cancel event loop lag monitor task
+    event_loop_lag_monitor_task.cancel()
 
     logger.success("Orchestrator finished.")
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -497,6 +497,8 @@ async def orchestrate(config: OrchestratorConfig):
     # Close training batch sender
     training_batch_sender.close()
 
+    event_loop_lag_monitor.reset()
+
     logger.success("Orchestrator finished.")
 
     # Optionally, print benchmark table


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Adds helper `EventLoopLagMonitor` on the orchestrator which measures and logs min/median/p90/max lag in the event loop. Warns on console if lags exceed specified thresholds and logs to W&B.

Example on debug run with `configs/hendrycks_math/rl.toml`

<img width="1186" height="504" alt="Screenshot 2025-12-21 at 10 06 56 AM" src="https://github.com/user-attachments/assets/ff0654f7-1f5b-4fb1-af97-3af51f0730ca" />

Note, that the max lag is coming from the inference being faster than trainer, hence we hit the sync async barrier which blocks the eventloop.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: #1443 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `EventLoopLagMonitor` and integrates it into the orchestrator to track event-loop lag, log metrics to W&B, warn on thresholds, and manage its lifecycle.
> 
> - **Monitoring**:
>   - Adds `prime_rl/orchestrator/event_loop_lag.py` implementing `EventLoopLagMonitor` with periodic lag sampling, windowed stats (`min/mean/med/p90/max`), and warning/debug logs based on thresholds.
> - **Orchestrator** (`prime_rl/orchestrator/orchestrator.py`):
>   - Starts background `EventLoopLagMonitor` task at launch and cancels it on shutdown.
>   - Logs lag metrics via `event_loop_lag/*` in `to_log` for W&B.
>   - Resets monitor each step to bound the measurement window.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1ee72780809af3ebfa2831efd7bd8afc431590b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->