### PR TITLE
quick fix for running ibm's granite moe models

### DIFF
--- a/src/prime_rl/trainer/perf.py
+++ b/src/prime_rl/trainer/perf.py
@@ -119,13 +119,16 @@ class PerfCounter:
 
         dense_mlp_params = num_dense_layers * 3 * intermediate_size * hidden_size
         sparse_mlp_params = 0
+
+        # Some MoE models (e.g. DeepSeek) use moe_intermediate_size, others (e.g. Granite) just use intermediate_size
+        moe_intermediate_size = getattr(config, "moe_intermediate_size", intermediate_size)
         if hasattr(config, "num_shared_experts"):  # Shared experts
             sparse_mlp_params += (
-                num_sparse_layers * config.num_shared_experts * 3 * config.moe_intermediate_size * hidden_size
+                num_sparse_layers * config.num_shared_experts * 3 * moe_intermediate_size * hidden_size
             )
         if hasattr(config, "num_experts_per_tok"):  # Routed experts
             sparse_mlp_params += (
-                num_sparse_layers * config.num_experts_per_tok * 3 * config.moe_intermediate_size * hidden_size
+                num_sparse_layers * config.num_experts_per_tok * 3 * moe_intermediate_size * hidden_size
             )
         if hasattr(config, "n_routed_experts"):  # DeepSeek Router
             sparse_mlp_params += num_sparse_layers * config.n_routed_experts * hidden_size


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

I was too lazy to explain my changes, decreasing my chances of this ever getting merged.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: [Issue ID]
**Linear Issue**: Resolves [Issue ID]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use moe_intermediate_size when present, otherwise fall back to intermediate_size in sparse MLP parameter computation for MoE models.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 780c7ba839efe38da667c94d32d1741bb202e34e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->