### PR TITLE
Fix async barrier blocking eventloop

### DIFF
--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -19,7 +19,7 @@ from prime_rl.utils.utils import (
     get_broadcast_dir,
     get_latest_ckpt_step,
     get_step_path,
-    sync_wait_for_path,
+    wait_for_path,
 )
 from prime_rl.utils.vf import generate_group
 
@@ -71,6 +71,8 @@ class Scheduler:
         self.inflight_group_rollouts: dict[asyncio.Task, InflightRolloutInfo] = {}
         self.cycle_clients = cycle(self.clients)
         self.step, self.ckpt_step = 0, 0
+        self.checkpoint_ready = asyncio.Event()
+        self.checkpoint_ready.set()  # Initially ready
         self.update_weights_time, self.wait_for_ckpt_time = 0, 0
         self.sampling_args = get_sampling_args(config.sampling)
         self.model_name = self.config.model.name
@@ -111,8 +113,9 @@ class Scheduler:
                 self.logger.info(
                     f"Hit async barrier because we are >{self.max_async_level} step(s) async. Waiting for checkpoint {next_ckpt_step}"
                 )
+                self.checkpoint_ready.clear()
                 wait_for_ckpt_start_time = time.perf_counter()
-                sync_wait_for_path(get_step_path(get_broadcast_dir(self.config.output_dir), next_ckpt_step) / "STABLE")
+                await wait_for_path(get_step_path(get_broadcast_dir(self.config.output_dir), next_ckpt_step) / "STABLE")
                 self.wait_for_ckpt_time = time.perf_counter() - wait_for_ckpt_start_time
                 self.logger.debug(f"Waited for checkpoint {next_ckpt_step} for {self.wait_for_ckpt_time:.2f}s")
             self.logger.debug(
@@ -129,6 +132,7 @@ class Scheduler:
             self.logger.debug(f"Updated weights to step {next_ckpt_step} in {self.update_weights_time:.2f}s")
             if self.lora_name is not None:
                 self.model_name = self.lora_name
+            self.checkpoint_ready.set()
 
             # Cancel old rollout requests
             tasks_to_remove = []
@@ -172,6 +176,8 @@ class Scheduler:
             finished_group_rollouts, _ = await asyncio.wait(
                 self.inflight_group_rollouts, return_when=asyncio.FIRST_COMPLETED
             )
+
+            await self.checkpoint_ready.wait()
 
             for finished_group_rollout in finished_group_rollouts:
                 if len(batch_rollouts) >= self.config.batch_size:


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Uses async instead of sync wait at the async barrier to not block the event loop. Uses `asyncio.Event` to stop processing batches to not change the default behavior

<img width="1184" height="535" alt="Screenshot 2025-12-22 at 10 04 30 AM" src="https://github.com/user-attachments/assets/7c089ade-1d67-4579-b03b-63735a38c2ce" />

<img width="391" height="251" alt="Screenshot 2025-12-22 at 10 04 42 AM" src="https://github.com/user-attachments/assets/7f98a623-38af-40fc-9466-5352e754e751" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces blocking checkpoint wait with an async wait and uses an asyncio.Event to pause rollout processing until weights are updated.
> 
> - **Scheduler (`src/prime_rl/orchestrator/scheduler.py`)**
>   - **Async barrier**: Replace `sync_wait_for_path` with `await wait_for_path(...)` to avoid blocking the event loop when waiting for `STABLE` checkpoints.
>   - **Checkpoint gating**: Introduce `asyncio.Event` (`checkpoint_ready`) to pause rollout handling during policy updates:
>     - Clear before awaiting checkpoint; set after `update_weights` completes and model name updates.
>     - In `generate_batch`, `await checkpoint_ready.wait()` before processing finished group rollouts.
>   - **Behavioral impact**: Maintains continuous scheduling while preventing processing with stale weights; cancels/reschedules old in-flight rollouts unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08043f686bb18c8835ad70d6cfde6516c59e1db9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->