### PR TITLE
Bump verifiers + runnable math-python debug config

### DIFF
--- a/configs/math_python/math_python.toml
+++ b/configs/math_python/math_python.toml
@@ -17,6 +17,7 @@ max_tokens = 512
 
 [[orchestrator.env]]
 id = "math-python"
+args = {sandbox_timeout_minutes = 10, sandbox_memory_gb = 1, sandbox_disk_size_gb = 1, pip_install_packages = "numpy sympy"}
 
 [trainer] # Default trainer config
 

--- a/configs/math_python/math_python.toml
+++ b/configs/math_python/math_python.toml
@@ -17,7 +17,7 @@ max_tokens = 512
 
 [[orchestrator.env]]
 id = "math-python"
-args = {sandbox_timeout_minutes = 10, sandbox_memory_gb = 1, sandbox_disk_size_gb = 1, pip_install_packages = "numpy sympy"}
+args = { sandbox_client_max_workers = 128, sandbox_timeout_minutes = 10, sandbox_memory_gb = 1, sandbox_disk_size_gb = 1, pip_install_packages = "numpy sympy" }
 
 [trainer] # Default trainer config
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ prerelease = "allow"
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 reverse-text = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "99e0e03" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "5605493" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "main" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ prerelease = "allow"
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 reverse-text = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "dba9f03" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "5605493" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "main" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ prerelease = "allow"
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 reverse-text = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "5605493" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "99e0e03" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "main" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 

--- a/uv.lock
+++ b/uv.lock
@@ -2478,7 +2478,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", specifier = ">=4.56.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=dba9f03" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=5605493" },
     { name = "vllm", specifier = "==0.12.0" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -3813,7 +3813,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.8.post2"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=dba9f03#dba9f0352081794d48d2b57f484a76891f5ca614" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=5605493#560549388f62c6e2f4c5c1a33c4d023fbfbb84a8" }
 dependencies = [
     { name = "datasets" },
     { name = "jinja2" },

--- a/uv.lock
+++ b/uv.lock
@@ -2478,7 +2478,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", specifier = ">=4.56.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=5605493" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=99e0e03" },
     { name = "vllm", specifier = "==0.12.0" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -3013,10 +3013,11 @@ name = "reverse-text"
 version = "0.1.4"
 source = { registry = "https://hub.primeintellect.ai/primeintellect/simple/" }
 dependencies = [
+    { name = "datasets" },
     { name = "verifiers" },
 ]
 wheels = [
-    { url = "https://hub.primeintellect.ai/primeintellect/reverse-text/@7b177065/reverse_text-0.1.4-py2.py3-none-any.whl", hash = "sha256:56c2996dfaa85048469a24f78e3e007ffbbf8ce64710ad3dccc5ca2f27e648bf" },
+    { url = "https://hub.primeintellect.ai/primeintellect/reverse-text/@f5644269/reverse_text-0.1.4-py2.py3-none-any.whl", hash = "sha256:0adc3abcb6ceba3fa82709258c732e95c90400bc899230dce47a2e0f31a74aec" },
 ]
 
 [[package]]
@@ -3813,10 +3814,11 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.8.post2"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=5605493#560549388f62c6e2f4c5c1a33c4d023fbfbb84a8" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=99e0e03#99e0e03f828910ae9d3c6b94493a3c6c2341a56d" }
 dependencies = [
     { name = "datasets" },
     { name = "jinja2" },
+    { name = "math-verify" },
     { name = "nest-asyncio" },
     { name = "openai" },
     { name = "openai-agents" },

--- a/uv.lock
+++ b/uv.lock
@@ -2478,7 +2478,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", specifier = ">=4.56.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=99e0e03" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=5605493" },
     { name = "vllm", specifier = "==0.12.0" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -3013,11 +3013,10 @@ name = "reverse-text"
 version = "0.1.4"
 source = { registry = "https://hub.primeintellect.ai/primeintellect/simple/" }
 dependencies = [
-    { name = "datasets" },
     { name = "verifiers" },
 ]
 wheels = [
-    { url = "https://hub.primeintellect.ai/primeintellect/reverse-text/@f5644269/reverse_text-0.1.4-py2.py3-none-any.whl", hash = "sha256:0adc3abcb6ceba3fa82709258c732e95c90400bc899230dce47a2e0f31a74aec" },
+    { url = "https://hub.primeintellect.ai/primeintellect/reverse-text/@7b177065/reverse_text-0.1.4-py2.py3-none-any.whl", hash = "sha256:56c2996dfaa85048469a24f78e3e007ffbbf8ce64710ad3dccc5ca2f27e648bf" },
 ]
 
 [[package]]
@@ -3814,11 +3813,10 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.8.post2"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=99e0e03#99e0e03f828910ae9d3c6b94493a3c6c2341a56d" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=5605493#560549388f62c6e2f4c5c1a33c4d023fbfbb84a8" }
 dependencies = [
     { name = "datasets" },
     { name = "jinja2" },
-    { name = "math-verify" },
     { name = "nest-asyncio" },
     { name = "openai" },
     { name = "openai-agents" },


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Adds latest changes from verifiers, notably:
- [#648](https://github.com/PrimeIntellect-ai/verifiers/pull/648)
- [#649](https://github.com/PrimeIntellect-ai/verifiers/pull/649)
- [#652](https://github.com/PrimeIntellect-ai/verifiers/pull/652)

Also adds the `math-python` config that ran over 300 steps

<img width="420" height="254" alt="Screenshot 2025-12-22 at 10 12 21 AM" src="https://github.com/user-attachments/assets/9364b3bd-0b41-437a-8b29-a14b830bc27d" />

<img width="1226" height="533" alt="Screenshot 2025-12-22 at 10 12 32 AM" src="https://github.com/user-attachments/assets/c8aa551c-d6f3-4569-b90b-4976d86a2601" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a runnable math-python config and bumps the verifiers git revision.
> 
> - **Config**:
>   - Adds new `configs/math_python/math_python.toml` runnable config with `Qwen3-4B-Instruct-2507`, orchestrator/inference settings, and sandbox args (increased workers, timeouts, memory/disk; pip installs `numpy sympy`).
> - **Dependencies**:
>   - Updates `verifiers` git revision in `pyproject.toml` and `uv.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21efd1184da9cfe19c4c33918f97deb1b1c724c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->