### PR TITLE
move log to debug

### DIFF
--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -94,9 +94,7 @@ def train(config: RLTrainerConfig):
 
     # Set up checkpoint manager
     logger.info(f"Initializing checkpoint managers ({config.ckpt})")
-    ckpt_manager, weight_ckpt_manager = setup_ckpt_managers(
-        config.output_dir, config.ckpt, config.model.lora
-    )
+    ckpt_manager, weight_ckpt_manager = setup_ckpt_managers(config.output_dir, config.ckpt, config.model.lora)
 
     # get the checkpoint step to load from
     checkpoint_step = None
@@ -126,9 +124,7 @@ def train(config: RLTrainerConfig):
 
     # Set up weight broadcast
     logger.info(f"Initializing weight broadcast ({config.weight_broadcast})")
-    weight_broadcast = setup_weight_broadcast(
-        config.output_dir, config.weight_broadcast, config.model.lora
-    )
+    weight_broadcast = setup_weight_broadcast(config.output_dir, config.weight_broadcast, config.model.lora)
 
     if parallel_dims.cp_enabled:
         substitute_hf_flash_attn(parallel_dims.world_mesh["cp"].get_group(), heads_k_stride=1)
@@ -220,11 +216,11 @@ def train(config: RLTrainerConfig):
         if config.max_steps is not None and progress.step >= config.max_steps:
             break
 
-        logger.info(f"Starting training step {progress.step}")
+        logger.debug(f"Starting training step {progress.step}")
         step_start_time = time.perf_counter()
 
         # Wait for the batch to be available
-        logger.info("Waiting for training batch to arrive")
+        logger.debug("Waiting for training batch to arrive")
         wait_for_batch_start_time = time.perf_counter()
         dataloader.wait_for_batch()
         wait_for_batch_time = time.perf_counter() - wait_for_batch_start_time
@@ -252,7 +248,7 @@ def train(config: RLTrainerConfig):
             loss_scale = batch_size
         loss_scale = max(loss_scale, 1)
 
-        logger.info(f"Starting forward and backward pass ({batch_size=})")
+        logger.debug(f"Starting forward and backward pass ({batch_size=})")
         tensors = Tensors()  # Used to accumulate tensor statistics across micro-batches and ranks for logging
         cp_enabled = parallel_dims.cp_enabled
         cp_rank = parallel_dims.world_mesh["cp"].get_local_rank() if cp_enabled else 0


### PR DESCRIPTION
Before
<img width="1379" height="771" alt="image" src="https://github.com/user-attachments/assets/41a3dac5-b2b3-4eda-97f0-df6a6edce75f" />

After
<img width="1399" height="715" alt="screenshot-2025-12-22_11-17-24" src="https://github.com/user-attachments/assets/fc99b8cc-121b-4340-91c3-a74b394439ee" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Lower the verbosity of per-step training messages in rl trainer by moving several info logs to debug.
> 
> - **Trainer (RL)**:
>   - Adjust log levels in `src/prime_rl/trainer/rl/train.py`:
>     - `Starting training step`, `Waiting for training batch to arrive`, and `Starting forward and backward pass` moved from `info` to `debug` to reduce log noise.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba9583af3c0943c6ade6bc81be724a632d10a914. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->