### PR TITLE
feat: add distillation config for teacher model support  #1339

### DIFF
--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -462,6 +462,35 @@ class AdvantageConfig(BaseConfig):
     length_weighted_mean: bool = False
 
 
+class DistillationConfig(BaseConfig):
+    """Configures on-policy distillation from a teacher/reference model.
+
+    When enabled, the teacher client is passed to verifiers during rollout generation,
+    and verifiers computes KL divergence between student and teacher logprobs as the reward.
+    """
+
+    enabled: Annotated[
+        bool,
+        Field(
+            description="Whether to enable distillation. Set to false to temporarily disable without removing config.",
+        ),
+    ] = True
+
+    client: Annotated[
+        ClientConfig,
+        Field(
+            description="Client configuration for connecting to the teacher/reference model server.",
+        ),
+    ] = ClientConfig()
+
+    model: Annotated[
+        ModelConfig,
+        Field(
+            description="Model configuration for the teacher/reference model.",
+        ),
+    ] = ModelConfig()
+
+
 class FileSystemWeightBroadcastConfig(BaseModel):
     """Configures the filesystem weight broadcast."""
 
@@ -519,6 +548,16 @@ class OrchestratorConfig(BaseSettings):
 
     # The validation configuration
     val: ValConfig | None = None
+
+    # The distillation configuration (for on-policy distillation from teacher model)
+    distillation: Annotated[
+        DistillationConfig | None,
+        Field(
+            description="Configuration for on-policy distillation from a teacher/reference model. "
+            "When enabled, passes teacher client to verifiers which computes KL divergence as reward. "
+            "If None, distillation is disabled.",
+        ),
+    ] = None
 
     weight_broadcast: Annotated[WeightBroadcastConfigType, Field(discriminator="type")] = (
         FileSystemWeightBroadcastConfig()


### PR DESCRIPTION
 #1339

## Summary

Adds prime-rl side support for on-policy distillation from a teacher/reference model. When enabled, passes teacher client to verifiers for KL divergence reward computation.

## Changes

- Added `DistillationConfig` with `enabled`, `client`, and `model` options
- Setup teacher clients in orchestrator when distillation is enabled
- Pass teacher client through Scheduler → generate_group → env.run_group()
- Support round-robin load balancing across multiple teacher servers

## Usage
ml
[distillation]
enabled = true

[distillation.client]
base_url = ["http://localhost:8001/v1"]

[distillation.model]
name = "Qwen/Qwen3-8B"## Note

This PR implements the prime-rl side only. Teacher params are passed via `**kwargs` to `env.run_group()`, which will be used once verifiers implements KL reward computation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds on-policy distillation support by introducing `DistillationConfig` and passing a teacher client/model through orchestrator → scheduler → verifiers with round‑robin load balancing.
> 
> - **Config**:
>   - Adds `DistillationConfig` with `enabled`, `client`, and `model` fields; integrates as optional `OrchestratorConfig.distillation`.
> - **Orchestrator** (`src/prime_rl/orchestrator/orchestrator.py`):
>   - Initializes teacher clients/model when `distillation.enabled` and passes them to `Scheduler` and validation `generate_batch()`.
> - **Scheduler** (`src/prime_rl/orchestrator/scheduler.py`):
>   - Accepts `teacher_clients` and `teacher_model_name`; cycles teacher clients and forwards to `generate_group()`.
> - **Utils/Verifiers Bridge** (`src/prime_rl/utils/vf.py`):
>   - `generate_group()`/`generate_batch()` accept optional `teacher_client` and `teacher_model_name` and forward via `env.run_group(**kwargs)`; supports round‑robin across multiple teacher servers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8f982f042eeabf25fd6ddb22fd95cf5e55e2770. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->