### PR TITLE
handle missing trajectories and log turns + `generation_ms` and `scoring_ms`

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -348,6 +348,9 @@ async def orchestrate(config: OrchestratorConfig):
                 "completion_len": [get_completion_len(rollout) for rollout in train_rollouts],
                 "prompt_len": [get_prompt_len(rollout) for rollout in train_rollouts],
                 "seq_len": [get_seq_len(rollout) for rollout in train_rollouts],
+                "num_turns": [len(rollout["trajectory"]) for rollout in train_rollouts],
+                "generation_ms": [rollout["timing"]["generation_ms"] for rollout in train_rollouts],
+                "scoring_ms": [rollout["timing"]["scoring_ms"] for rollout in train_rollouts],
             }
         )
 
@@ -405,6 +408,17 @@ async def orchestrate(config: OrchestratorConfig):
             "is_truncated/mean": results_df.groupby("example_id").is_truncated.mean().mean(),
             "is_truncated/max": results_df.groupby("example_id").is_truncated.mean().max(),
             "is_truncated/min": results_df.groupby("example_id").is_truncated.mean().min(),
+            # Turn metrics
+            "num_turns/mean": results_df.groupby("example_id").num_turns.mean().mean(),
+            "num_turns/max": results_df.groupby("example_id").num_turns.mean().max(),
+            "num_turns/min": results_df.groupby("example_id").num_turns.mean().min(),
+            # Verifier timing metrics
+            "generation_ms/mean": results_df.groupby("example_id").generation_ms.mean().mean(),
+            "generation_ms/max": results_df.groupby("example_id").generation_ms.mean().max(),
+            "generation_ms/min": results_df.groupby("example_id").generation_ms.mean().min(),
+            "scoring_ms/mean": results_df.groupby("example_id").scoring_ms.mean().mean(),
+            "scoring_ms/max": results_df.groupby("example_id").scoring_ms.mean().max(),
+            "scoring_ms/min": results_df.groupby("example_id").scoring_ms.mean().min(),
             # Performance metrics
             "perf/throughput": throughput,
             # Train reward

--- a/src/prime_rl/utils/vf.py
+++ b/src/prime_rl/utils/vf.py
@@ -79,6 +79,8 @@ async def generate_batch(
 
 def get_prompt_len(state: vf.State) -> int:
     """Compute the number of prompt tokens from vf.State. Defined as the number of prompt IDs from the first trajectory step. If raw tokens are not available, falls back to checking the usage of the first response."""
+    if not state["trajectory"]:
+        return 0
     first_step = state["trajectory"][0]
     if first_step["tokens"] is not None:
         return len(first_step["tokens"]["prompt_ids"])
@@ -88,6 +90,8 @@ def get_prompt_len(state: vf.State) -> int:
 
 def get_seq_len(state: vf.State) -> int:
     """Compute the number of tokens from vf.State. Defined as the sum of prompt and completion tokens from the last trajectory step. If raw tokens are not available, falls back to checking the usage of the last response."""
+    if not state["trajectory"]:
+        return 0
     last_step = state["trajectory"][-1]
     if last_step["tokens"] is not None:
         return len(last_step["tokens"]["prompt_ids"]) + len(last_step["tokens"]["completion_ids"])
@@ -102,6 +106,8 @@ def get_completion_len(state: vf.State) -> int:
 
 def get_is_truncated(state: vf.State) -> bool:
     """Check if the rollout is truncated. If raw tokens are not available, falls back to checking the finish reason of the last response."""
+    if not state["trajectory"]:
+        return False
     last_step = state["trajectory"][-1]
     if last_step["tokens"] is not None:
         return last_step["tokens"]["is_truncated"]


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

handles edge case of missing trajectories. adds turn and `generation_ms` and `scoring_ms` stats logging to wandb.
---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: [Issue ID]
**Linear Issue**: Resolves [Issue ID]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `num_turns` and `generation_ms`/`scoring_ms` metrics with aggregated stats, and guards vf token/truncation helpers against missing trajectories.
> 
> - **Metrics & logging**:
>   - Collect and log `num_turns` plus `generation_ms` and `scoring_ms` in `src/prime_rl/orchestrator/orchestrator.py` (`results_df` + aggregated mean/max/min entries).
> - **Robustness**:
>   - In `src/prime_rl/utils/vf.py`, handle empty `state["trajectory"]` in `get_prompt_len`, `get_seq_len`, and `get_is_truncated` (return 0/False).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 475a96643011249d2c2e6da96f342b213046756d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->