### PR TITLE
Update math env

### DIFF
--- a/configs/acereason_math/stage1.toml
+++ b/configs/acereason_math/stage1.toml
@@ -23,8 +23,8 @@ temperature = 0.6
 max_tokens = 8192
 
 [[orchestrator.env]]
-id = "single-turn-math"
-args = { dataset_name = "nvidia/AceReason-Math", dataset_subset = "default", question_key = "problem" }
+id = "math-env"
+args = { dataset_name = "nvidia/AceReason-Math", dataset_subset = "default", question_key = "problem", math_verify_max_workers = 128, math_verify_timeout = 60 }
 
 [orchestrator.eval]
 interval = 50

--- a/configs/acereason_math/stage2.toml
+++ b/configs/acereason_math/stage2.toml
@@ -25,7 +25,7 @@ max_tokens = 16384
 
 [[orchestrator.env]]
 id = "math-env"
-args = { dataset_name = "nvidia/AceReason-Math", dataset_subset = "default", question_key = "problem" }
+args = { dataset_name = "nvidia/AceReason-Math", dataset_subset = "default", question_key = "problem", math_verify_max_workers = 128, math_verify_timeout = 60 }
 
 [orchestrator.eval]
 interval = 50

--- a/configs/acereason_math/stage2.toml
+++ b/configs/acereason_math/stage2.toml
@@ -24,7 +24,7 @@ temperature = 0.6
 max_tokens = 16384
 
 [[orchestrator.env]]
-id = "single-turn-math"
+id = "math-env"
 args = { dataset_name = "nvidia/AceReason-Math", dataset_subset = "default", question_key = "problem" }
 
 [orchestrator.eval]

--- a/configs/ci/integration/eval/multi_env.toml
+++ b/configs/ci/integration/eval/multi_env.toml
@@ -5,11 +5,11 @@ rollouts_per_example = 3
 max_tokens = 16
 
 [[env]]
-id = "primeintellect/single-turn-math"
+id = "primeintellect/math-env"
 name = "gsm8k"
 args = { dataset_name = "openai/gsm8k", dataset_subset = "main" }
 
 [[env]]
-id = "primeintellect/single-turn-math"
+id = "primeintellect/math-env"
 name = "hendrycks"
 args = { dataset_name = "PrimeIntellect/Hendrycks-Math", dataset_subset = "default" }

--- a/configs/ci/integration/eval/single_env.toml
+++ b/configs/ci/integration/eval/single_env.toml
@@ -5,5 +5,5 @@ rollouts_per_example = 3
 max_tokens = 16
 
 [[env]]
-id = "primeintellect/single-turn-math"
+id = "primeintellect/math-env"
 args = { dataset_name = "openai/gsm8k", dataset_subset = "main" }

--- a/configs/ci/integration/synthesize/multi_env.toml
+++ b/configs/ci/integration/synthesize/multi_env.toml
@@ -5,11 +5,11 @@ rollouts_per_example = 3
 max_tokens = 16
 
 [[env]]
-id = "primeintellect/single-turn-math"
+id = "primeintellect/math-env"
 name = "gsm8k"
 args = { dataset_name = "openai/gsm8k", dataset_subset = "main" }
 
 [[env]]
-id = "primeintellect/single-turn-math"
+id = "primeintellect/math-env"
 name = "hendrycks"
 args = { dataset_name = "PrimeIntellect/Hendrycks-Math", dataset_subset = "default" }

--- a/configs/ci/integration/synthesize/single_env.toml
+++ b/configs/ci/integration/synthesize/single_env.toml
@@ -5,5 +5,5 @@ rollouts_per_example = 3
 max_tokens = 16
 
 [[env]]
-id = "primeintellect/single-turn-math"
+id = "primeintellect/math-env"
 args = { dataset_name = "openai/gsm8k", dataset_subset = "main" }

--- a/configs/ci/nightly/acereason_math.toml
+++ b/configs/ci/nightly/acereason_math.toml
@@ -21,9 +21,9 @@ temperature = 0.6
 max_tokens = 8192
 
 [[orchestrator.env]]
-id = "primeintellect/single-turn-math"
+id = "primeintellect/math-env"
 name = "acereason-math"
-args = { dataset_name = "nvidia/AceReason-Math", dataset_subset = "default", question_key = "problem" }
+args = { dataset_name = "nvidia/AceReason-Math", dataset_subset = "default", question_key = "problem", math_verify_max_workers = 128, math_verify_timeout = 60 }
 
 [trainer]
 

--- a/configs/ci/nightly/hendrycks_math.toml
+++ b/configs/ci/nightly/hendrycks_math.toml
@@ -15,9 +15,9 @@ rollouts_per_example = 16
 max_tokens = 2048
 
 [[orchestrator.env]]
-id = "primeintellect/single-turn-math"
+id = "primeintellect/math-env"
 name = "hendrycks-math"
-args = { dataset_name = "PrimeIntellect/Hendrycks-Math", dataset_subset = "default" }
+args = { dataset_name = "PrimeIntellect/Hendrycks-Math", dataset_subset = "default", math_verify_max_workers = 128, math_verify_timeout = 60 }
 
 [orchestrator.buffer]
 easy_fraction = 0.0

--- a/configs/debug/eval/multi_env.toml
+++ b/configs/debug/eval/multi_env.toml
@@ -3,11 +3,11 @@ num_examples = 16
 rollouts_per_example = 4
 
 [[env]]
-id = "primeintellect/single-turn-math"
+id = "primeintellect/math-env"
 name = "gsm8k"
 args = { dataset_name = "openai/gsm8k", dataset_subset = "main" }
 
 [[env]]
-id = "primeintellect/single-turn-math"
+id = "primeintellect/math-env"
 name = "hendrycks"
 args = { dataset_name = "PrimeIntellect/Hendrycks-Math", dataset_subset = "default" }

--- a/configs/debug/eval/single_env.toml
+++ b/configs/debug/eval/single_env.toml
@@ -3,5 +3,5 @@ num_examples = 16
 rollouts_per_example = 4
 
 [[env]]
-id = "primeintellect/single-turn-math"
+id = "primeintellect/math-env"
 args = { dataset_name = "openai/gsm8k", dataset_subset = "main" }

--- a/configs/debug/synthesize/multi_env.toml
+++ b/configs/debug/synthesize/multi_env.toml
@@ -3,11 +3,11 @@ num_examples = 16
 rollouts_per_example = 4
 
 [[env]]
-id = "primeintellect/single-turn-math"
+id = "primeintellect/math-env"
 name = "gsm8k"
 args = { dataset_name = "openai/gsm8k", dataset_subset = "main" }
 
 [[env]]
-id = "primeintellect/single-turn-math"
+id = "primeintellect/math-env"
 name = "hendrycks"
 args = { dataset_name = "PrimeIntellect/Hendrycks-Math", dataset_subset = "default" }

--- a/configs/debug/synthesize/single_turn.toml
+++ b/configs/debug/synthesize/single_turn.toml
@@ -3,5 +3,5 @@ num_examples = 16
 rollouts_per_example = 4
 
 [[env]]
-id = "primeintellect/single-turn-math"
+id = "primeintellect/math-env"
 args = { dataset_name = "openai/gsm8k", dataset_subset = "main" }

--- a/configs/deepscaler/stage1.toml
+++ b/configs/deepscaler/stage1.toml
@@ -23,7 +23,8 @@ temperature = 0.6
 max_tokens = 8192
 
 [[orchestrator.env]]
-id = "single-turn-math"
+id = "math-env"
+name = "deepscaler"
 args = {dataset_name= "agentica-org/DeepScaleR-Preview-Dataset", dataset_subset = "default", question_key = "problem", answer_key = "solution"}
 
 [trainer.model.ac]

--- a/configs/deepscaler/stage1.toml
+++ b/configs/deepscaler/stage1.toml
@@ -25,7 +25,7 @@ max_tokens = 8192
 [[orchestrator.env]]
 id = "math-env"
 name = "deepscaler"
-args = {dataset_name= "agentica-org/DeepScaleR-Preview-Dataset", dataset_subset = "default", question_key = "problem", answer_key = "solution"}
+args = { dataset_name= "agentica-org/DeepScaleR-Preview-Dataset", dataset_subset = "default", question_key = "problem", answer_key = "solution", math_verify_max_workers = 128, math_verify_timeout = 60 }
 
 [trainer.model.ac]
 

--- a/configs/deepscaler/stage2.toml
+++ b/configs/deepscaler/stage2.toml
@@ -24,7 +24,8 @@ temperature = 0.6
 max_tokens = 16384
 
 [[orchestrator.env]]
-id = "single-turn-math"
+id = "math-env"
+name = "deepscaler"
 args = {dataset_name= "agentica-org/DeepScaleR-Preview-Dataset", dataset_subset = "default", question_key = "problem", answer_key = "solution"}
 
 [trainer.model.ac]

--- a/configs/deepscaler/stage2.toml
+++ b/configs/deepscaler/stage2.toml
@@ -26,7 +26,7 @@ max_tokens = 16384
 [[orchestrator.env]]
 id = "math-env"
 name = "deepscaler"
-args = {dataset_name= "agentica-org/DeepScaleR-Preview-Dataset", dataset_subset = "default", question_key = "problem", answer_key = "solution"}
+args = { dataset_name= "agentica-org/DeepScaleR-Preview-Dataset", dataset_subset = "default", question_key = "problem", answer_key = "solution", math_verify_max_workers = 128, math_verify_timeout = 60 }
 
 [trainer.model.ac]
 

--- a/configs/deepscaler/stage3.toml
+++ b/configs/deepscaler/stage3.toml
@@ -24,7 +24,8 @@ temperature = 0.6
 max_tokens = 24576
 
 [[orchestrator.env]]
-id = "single-turn-math"
+id = "math-env"
+name = "deepscaler"
 args = {dataset_name= "agentica-org/DeepScaleR-Preview-Dataset", dataset_subset = "default", question_key = "problem", answer_key = "solution"}
 
 [trainer.model.ac]

--- a/configs/deepscaler/stage3.toml
+++ b/configs/deepscaler/stage3.toml
@@ -26,7 +26,7 @@ max_tokens = 24576
 [[orchestrator.env]]
 id = "math-env"
 name = "deepscaler"
-args = {dataset_name= "agentica-org/DeepScaleR-Preview-Dataset", dataset_subset = "default", question_key = "problem", answer_key = "solution"}
+args = { dataset_name= "agentica-org/DeepScaleR-Preview-Dataset", dataset_subset = "default", question_key = "problem", answer_key = "solution", math_verify_max_workers = 128, math_verify_timeout = 60 }
 
 [trainer.model.ac]
 

--- a/configs/gsm8k/README.md
+++ b/configs/gsm8k/README.md
@@ -9,13 +9,13 @@ In this example, we demonstrate how to train `Qwen3-0.6B` to answer math problem
 Install the environment:
 
 ```bash
-prime env install primeintellect/single-turn-math
+prime env install primeintellect/math-env
 ```
 
 Verify installation:
 
 ```bash
-uv run python -c "import single_turn_math"
+uv run python -c "import math_env"
 ```
 
 Start the tmux session:
@@ -37,7 +37,7 @@ Evaluate the base model:
 
 ```bash
 # In the `Trainer` pane
-uv run vf-eval single-turn-math \
+uv run vf-eval math-env \
   -a '{"dataset_name": "openai/gsm8k", "dataset_subset": "main"}' \
   -m PrimeIntellect/Qwen3-0.6B \
   -b http://localhost:8000/v1 \
@@ -74,7 +74,7 @@ uv run inference --model.name <user>/Qwen3-0.6B-GSM8K-RL
 
 ```bash
 # In the `Trainer` pane
-uv run vf-eval single-turn-math \
+uv run vf-eval math-env \
   -a '{"dataset_name": "openai/gsm8k", "dataset_subset": "main"}' \
   -m <user>/Qwen3-0.6B-GSM8K-RL \
   -b http://localhost:8000/v1 \

--- a/configs/gsm8k/rl.toml
+++ b/configs/gsm8k/rl.toml
@@ -21,7 +21,7 @@ max_tokens = 2048
 [[orchestrator.env]]
 id = "primeintellect/math-env"
 name = "gsm8k"
-args = { dataset_name = "openai/gsm8k", dataset_subset = "main" }
+args = { dataset_name = "openai/gsm8k", dataset_subset = "main", math_verify_max_workers = 128, math_verify_timeout = 60 }
 
 [trainer] # Default trainer config
 

--- a/configs/gsm8k/rl.toml
+++ b/configs/gsm8k/rl.toml
@@ -19,7 +19,8 @@ rollouts_per_example = 16
 max_tokens = 2048
 
 [[orchestrator.env]]
-id = "primeintellect/single-turn-math"
+id = "primeintellect/math-env"
+name = "gsm8k"
 args = { dataset_name = "openai/gsm8k", dataset_subset = "main" }
 
 [trainer] # Default trainer config

--- a/configs/hendrycks_math/README.md
+++ b/configs/hendrycks_math/README.md
@@ -9,13 +9,13 @@ In this example, we demonstrate how to train `Qwen/Qwen3-4B-Instruct-2507` to an
 Install the environment:
 
 ```bash
-prime env install primeintellect/single-turn-math
+prime env install primeintellect/math-env
 ```
 
 Verify installation:
 
 ```bash
-uv run python -c "import single_turn_math"
+uv run python -c "import math_env"
 ```
 
 Start the tmux session:
@@ -37,7 +37,7 @@ Evaluate the base model:
 
 ```bash
 # In the `Trainer` pane
-uv run vf-eval single-turn-math \
+uv run vf-eval math-env \
   -a '{"dataset_name": "PrimeIntellect/Hendrycks-Math", "dataset_subset": "default"}' \
   -m Qwen/Qwen3-4B-Instruct-2507 \
   -b http://localhost:8000/v1 \

--- a/configs/hendrycks_math/rl.toml
+++ b/configs/hendrycks_math/rl.toml
@@ -21,7 +21,7 @@ max_tokens = 2048
 [[orchestrator.env]]
 id = "primeintellect/math-env"
 name = "hendrycks-math"
-args = { dataset_name = "PrimeIntellect/Hendrycks-Math", dataset_subset = "default" }
+args = { dataset_name = "PrimeIntellect/Hendrycks-Math", dataset_subset = "default", math_verify_max_workers = 128, math_verify_timeout = 60 }
 
 [orchestrator.buffer]
 easy_threshold = 1.0

--- a/configs/hendrycks_math/rl.toml
+++ b/configs/hendrycks_math/rl.toml
@@ -19,7 +19,8 @@ rollouts_per_example = 16
 max_tokens = 2048
 
 [[orchestrator.env]]
-id = "primeintellect/single-turn-math"
+id = "primeintellect/math-env"
+name = "hendrycks-math"
 args = { dataset_name = "PrimeIntellect/Hendrycks-Math", dataset_subset = "default" }
 
 [orchestrator.buffer]

--- a/src/prime_rl/transport/filesystem.py
+++ b/src/prime_rl/transport/filesystem.py
@@ -62,7 +62,7 @@ class FileSystemTrainingBatchReceiver(TrainingBatchReceiver):
                 self.logger.debug(
                     "Did you set the output dir of the orchestrator to a run_* subdirectory of the trainer output dir?"
                 )
-            self.logger.debug(f"Looking for batches in {', '.join(current_paths)}")
+            self.logger.debug(f"Looking for batches in {current_paths}")
             self._last_logged_paths = current_paths
             self._last_logged_time = time()
         for idx in list(self.runs.used_idxs):

--- a/src/prime_rl/transport/filesystem.py
+++ b/src/prime_rl/transport/filesystem.py
@@ -62,7 +62,7 @@ class FileSystemTrainingBatchReceiver(TrainingBatchReceiver):
                 self.logger.debug(
                     "Did you set the output dir of the orchestrator to a run_* subdirectory of the trainer output dir?"
                 )
-            self.logger.debug(f"Looking for batches in {current_paths}")
+            self.logger.debug(f"Looking for batches in {', '.join(current_paths)}")
             self._last_logged_paths = current_paths
             self._last_logged_time = time()
         for idx in list(self.runs.used_idxs):


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Update `single-turn-math` -> `math-env` and set higher resources for rubric in nightly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames the math environment from `single-turn-math` to `math-env` across configs/docs and adds `math_verify_max_workers`/`math_verify_timeout` to math env args.
> 
> - **Environment migration:** Replaces `single-turn-math` with `math-env` across training, CI, debug, and nightly configs (AceReason-Math, DeepScaleR, GSM8K, Hendrycks) and related READMEs.
> - **Verification resources:** Adds `math_verify_max_workers=128` and `math_verify_timeout=60` to `args` for math envs.
> - **Minor config cleanups:** Sets `name` for some env entries (e.g., `gsm8k`, `hendrycks`, `deepscaler`, `acereason-math`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b451569cfb165a74cb8acc342967d6e6d4677e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->