### PR TITLE
Define the batch size at the token level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@ Documenting changes which affect configuration usage patterns (added/moved/remov
 - **`trainer.loss.sequence_clip_high`**: Added sequence-level importance ratio clipping threshold (2025-12-19)
 - **`trainer.loss.geo_mask_high`** and **`trainer.loss.geo_mask_low`**: Added geometric importance ratio masking thresholds (2025-12-19)
 - **`{orchestrator,trainer}.transport.zmq`**: Added ZMQ transport for training batches and micro batches (#1446, 2025-12-22)
+- **`orchestrator.tokens_per_step`**: Replaced `batch_size` with `tokens_per_step`. This field specifies the number of tokens to generate per training step (default: 262144). Rollouts are now collected until at least this many tokens are generated, rather than specifying a fixed batch size (2025-12-23)

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -547,7 +547,13 @@ class OrchestratorConfig(BaseSettings):
         ),
     ] = None
 
-    batch_size: Annotated[int, Field(ge=1, description="Number of samples to train on per step.")] = 128
+    tokens_per_step: Annotated[
+        int,
+        Field(
+            ge=1,
+            description="Number of tokens to generate per training step. Rollouts will be collected until at least this many tokens are generated.",
+        ),
+    ] = 262144 
 
     oversampling_factor: Annotated[
         float,
@@ -642,11 +648,6 @@ class OrchestratorConfig(BaseSettings):
                 raise ValueError("max_async_level must be 1 for NCCL broadcast")
         return self
 
-    @model_validator(mode="after")
-    def validate_batch_size(self):
-        if self.batch_size % self.rollouts_per_example != 0:
-            raise ValueError("Batch size must be divisible by the number of samples per problem")
-        return self
 
     @model_validator(mode="after")
     def validate_env_ratios(self):

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -371,9 +371,11 @@ async def orchestrate(config: OrchestratorConfig):
 
         # Update progress metrics and throughput
         num_tokens = int(results_df.seq_len.sum())
+        actual_batch_size = len(train_rollouts)
+        actual_num_problems = results_df.example_id.nunique()
         progress.total_tokens += num_tokens
-        progress.total_samples += config.batch_size
-        progress.total_problems += config.batch_size // config.rollouts_per_example
+        progress.total_samples += actual_batch_size
+        progress.total_problems += actual_num_problems
         throughput = num_tokens / generate_completions_time
 
         # Compute solve all and none tensors
@@ -389,8 +391,8 @@ async def orchestrate(config: OrchestratorConfig):
         to_log = {
             # Progress metrics
             "progress/tokens": num_tokens,
-            "progress/samples": config.batch_size,
-            "progress/problems": config.batch_size // config.rollouts_per_example,
+            "progress/samples": actual_batch_size,
+            "progress/problems": actual_num_problems,
             "progress/total_tokens": progress.total_tokens,
             "progress/total_samples": progress.total_samples,
             "progress/total_problems": progress.total_problems,

--- a/src/prime_rl/utils/vf.py
+++ b/src/prime_rl/utils/vf.py
@@ -104,6 +104,23 @@ def get_completion_len(state: vf.State) -> int:
     return get_seq_len(state) - get_prompt_len(state)
 
 
+def get_training_tokens(state: vf.State, strategy: str = "interleaved") -> int:
+    """Compute the number of training tokens based on trajectory strategy.
+    
+    For interleaved: returns get_seq_len() (single concatenated sequence)
+    For branching: returns sum of all trajectory steps (each step is a separate training sample)
+    """
+    if not state["trajectory"]:
+        return 0
+    if strategy == "interleaved":
+        return get_seq_len(state)
+    return sum(
+        len(step["tokens"]["prompt_ids"]) + len(step["tokens"]["completion_ids"])
+        for step in state["trajectory"]
+        if step["tokens"] is not None
+    )
+
+
 def get_is_truncated(state: vf.State) -> bool:
     """Check if the rollout is truncated. If raw tokens are not available, falls back to checking the finish reason of the last response."""
     if not state["trajectory"]:

--- a/src/prime_rl/utils/vf.py
+++ b/src/prime_rl/utils/vf.py
@@ -88,15 +88,19 @@ def get_prompt_len(state: vf.State) -> int:
     return getattr(first_step_response.usage, "prompt_tokens", 0)
 
 
+def get_step_tokens(step: vf.TrajectoryStep) -> int:
+    """Compute the number of tokens from a trajectory step. If raw tokens are not available, falls back to checking the usage of the response."""
+    if step["tokens"] is not None:
+        return len(step["tokens"]["prompt_ids"]) + len(step["tokens"]["completion_ids"])
+    step_response = cast(ChatCompletion, step["response"])
+    return getattr(step_response.usage, "total_tokens", 0)
+
+
 def get_seq_len(state: vf.State) -> int:
     """Compute the number of tokens from vf.State. Defined as the sum of prompt and completion tokens from the last trajectory step. If raw tokens are not available, falls back to checking the usage of the last response."""
     if not state["trajectory"]:
         return 0
-    last_step = state["trajectory"][-1]
-    if last_step["tokens"] is not None:
-        return len(last_step["tokens"]["prompt_ids"]) + len(last_step["tokens"]["completion_ids"])
-    last_step_response = cast(ChatCompletion, last_step["response"])
-    return getattr(last_step_response.usage, "total_tokens", 0)
+    return get_step_tokens(state["trajectory"][-1])
 
 
 def get_completion_len(state: vf.State) -> int:
@@ -114,11 +118,7 @@ def get_training_tokens(state: vf.State, strategy: str = "interleaved") -> int:
         return 0
     if strategy == "interleaved":
         return get_seq_len(state)
-    return sum(
-        len(step["tokens"]["prompt_ids"]) + len(step["tokens"]["completion_ids"])
-        for step in state["trajectory"]
-        if step["tokens"] is not None
-    )
+    return sum(get_step_tokens(step) for step in state["trajectory"])
 
 
 def get_is_truncated(state: vf.State) -> bool:


### PR DESCRIPTION
Makes the trainer step time much more uniform for lower idle time, also used in https://arxiv.org/abs/2512.18552 and https://www.arxiv.org/abs/2510.02387
Approximates the initial number of problems to spawn with "batch_size / seq_len"
In this case we might overshoot the token amount sent to the trainer by a maximum of one groups entire token length, we could make it so we overshoot by max one rollouts token length but the difference shouldn't be big

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces token-targeted batching for training and removes fixed sample-based batching.
> 
> - Adds `orchestrator.tokens_per_step` (default `262144`) and removes `batch_size` and its validator in `OrchestratorConfig`
> - Scheduler now estimates initial in-flight work via `tokens_per_step / seq_len`, accumulates rollouts until `tokens_per_step` using `get_training_tokens`, and updates the progress bar in tokens
> - Orchestrator logging now uses actual batch/sample/problem counts instead of config-based assumptions
> - Utils: adds `get_step_tokens` and `get_training_tokens`, and refactors `get_seq_len` to use `get_step_tokens`
> - Updates `CHANGELOG.md` to document the config change
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0d449efdd0595be4ceebf0168414dd7ff6a0a93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->