### PR TITLE
Handle empty trajectory case everywhere

### DIFF
--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -44,7 +44,9 @@ class PrimeMonitor(Monitor):
         # Get API key from environment variable
         api_key = os.getenv(config.api_key_var)
         if not api_key:
-            self.logger.warning(f"API key not found. Set {config.api_key_var} environment variable. PrimeMonitor will not be able to upload data.")
+            self.logger.warning(
+                f"API key not found. Set {config.api_key_var} environment variable. PrimeMonitor will not be able to upload data."
+            )
             self.enabled = False
             return
 
@@ -113,22 +115,30 @@ class PrimeMonitor(Monitor):
         for rollout in rollouts:
             # Extract prompt and completion separately from the last trajectory step
             last_step = rollout["trajectory"][-1]
+            if not last_step:
+                continue
             prompt_messages = last_step["prompt"]
             completion_messages = last_step["completion"]
-            
+
             # Serialize full trajectory array (excluding large response objects and token arrays)
             trajectory_data = []
             for traj_step in rollout["trajectory"]:
-                trajectory_data.append({
-                    "prompt": traj_step["prompt"],
-                    "completion": traj_step["completion"],
-                    "reward": traj_step.get("reward"),
-                    "advantage": traj_step.get("advantage"),
-                    "extras": traj_step.get("extras", {}),
-                    "num_input_tokens": len(traj_step.get("tokens", {}).get("prompt_ids", [])) if traj_step.get("tokens") else None,
-                    "num_output_tokens": len(traj_step.get("tokens", {}).get("completion_ids", [])) if traj_step.get("tokens") else None,
-                })
-            
+                trajectory_data.append(
+                    {
+                        "prompt": traj_step["prompt"],
+                        "completion": traj_step["completion"],
+                        "reward": traj_step.get("reward"),
+                        "advantage": traj_step.get("advantage"),
+                        "extras": traj_step.get("extras", {}),
+                        "num_input_tokens": len(traj_step.get("tokens", {}).get("prompt_ids", []))
+                        if traj_step.get("tokens")
+                        else None,
+                        "num_output_tokens": len(traj_step.get("tokens", {}).get("completion_ids", []))
+                        if traj_step.get("tokens")
+                        else None,
+                    }
+                )
+
             # Get info, timing, and metrics fields - send raw data, backend will serialize
             info = rollout.get("info")
             timing = rollout.get("timing")
@@ -160,7 +170,9 @@ class PrimeMonitor(Monitor):
             },
         )
         self.last_log_samples_step = step
-        self.logger.debug(f"Logged samples at step {step} to Prime Intellect API in {time.perf_counter() - start_time:.2f}s")
+        self.logger.debug(
+            f"Logged samples at step {step} to Prime Intellect API in {time.perf_counter() - start_time:.2f}s"
+        )
 
     def log_final_samples(self) -> None:
         """Log final samples (no-op - samples are logged per-step only)."""
@@ -197,7 +209,9 @@ class PrimeMonitor(Monitor):
             },
         )
         self.last_log_distributions_step = step
-        self.logger.debug(f"Logged distributions at step {step} to Prime Intellect API in {time.perf_counter() - start_time:.2f}s")
+        self.logger.debug(
+            f"Logged distributions at step {step} to Prime Intellect API in {time.perf_counter() - start_time:.2f}s"
+        )
 
     def save_final_summary(self, filename: str = "final_summary.json") -> None:
         """Save final summary to Prime Intellect API."""
@@ -248,7 +262,7 @@ class PrimeMonitor(Monitor):
             "Content-Type": "application/json",
         }
         full_endpoint = f"{self.base_url}/{endpoint}"
-        
+
         for attempt in range(max_retries):
             try:
                 response = await self._client.post(
@@ -261,11 +275,15 @@ class PrimeMonitor(Monitor):
             except Exception as e:
                 is_last_attempt = attempt == max_retries - 1
                 if is_last_attempt:
-                    self.logger.warning(f"Failed to upload to Prime Intellect API ({endpoint}) after {max_retries} attempts: {type(e).__name__}: {e}")
+                    self.logger.warning(
+                        f"Failed to upload to Prime Intellect API ({endpoint}) after {max_retries} attempts: {type(e).__name__}: {e}"
+                    )
                 else:
                     # Exponential backoff: 1s, 2s, 4s...
-                    delay = 2 ** attempt
-                    self.logger.debug(f"Retrying {endpoint} upload in {delay}s (attempt {attempt + 1}/{max_retries}): {type(e).__name__}: {e}")
+                    delay = 2**attempt
+                    self.logger.debug(
+                        f"Retrying {endpoint} upload in {delay}s (attempt {attempt + 1}/{max_retries}): {type(e).__name__}: {e}"
+                    )
                     await asyncio.sleep(delay)
 
     def _make_request(self, endpoint: str, data: dict[str, Any]) -> None:

--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -101,7 +101,10 @@ class WandbMonitor(Monitor):
         start_time = time.perf_counter()
 
         for rollout in rollouts:
-            tokens = rollout["trajectory"][-1]["tokens"]
+            last_step = rollout["trajectory"][-1]
+            if not last_step:
+                continue
+            tokens = last_step["tokens"]
             full_ids = tokens["prompt_ids"] + tokens["completion_ids"]
             messages_text = self.tokenizer.decode(full_ids)
             sample = {


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

We missed two places for handling empty trajectories

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents errors when rollouts have empty trajectories during sample logging.
> 
> - In `PrimeMonitor.log_samples` and `WandbMonitor.log_samples`, add a guard for the last trajectory step and skip if empty before accessing `prompt/completion/tokens`
> - Minor non-functional changes: reformat long log lines and unify exponent/backoff expression spacing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15334ce74d22e176929cec3bbaeb8fdc2579b1b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->