### PR TITLE
Revert "handle empty trajectory in logging (#1474)"

### DIFF
--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -101,10 +101,7 @@ class WandbMonitor(Monitor):
         start_time = time.perf_counter()
 
         for rollout in rollouts:
-            last_step = rollout["trajectory"][-1]
-            if not last_step:
-                continue
-            tokens = last_step["tokens"]
+            tokens = rollout["trajectory"][-1]["tokens"]
             full_ids = tokens["prompt_ids"] + tokens["completion_ids"]
             messages_text = self.tokenizer.decode(full_ids)
             sample = {


### PR DESCRIPTION
revert

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Reverts prior empty-trajectory handling** in sample logging.
> 
> - Removes checks for empty `trajectory` in `PrimeMonitor.log_samples` and `WandbMonitor.log_samples`, now directly indexing the last step
> - Minor cleanups: single-line logger messages, compact dict construction, and whitespace tweaks (no API changes)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45fe468913d5e291d7c2557dbd201da7086583de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->