### PR TITLE
threaded OpenAI client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@ Documenting changes which affect configuration usage patterns (added/moved/remov
 - **`trainer.loss.sequence_clip_high`**: Added sequence-level importance ratio clipping threshold (2025-12-19)
 - **`trainer.loss.geo_mask_high`** and **`trainer.loss.geo_mask_low`**: Added geometric importance ratio masking thresholds (2025-12-19)
 - **`{orchestrator,trainer}.transport.zmq`**: Added ZMQ transport for training batches and micro batches (#1446, 2025-12-22)
+- **`orchestrator.client.max_workers_per_client`**: Added thread pool configuration to client; dispatches API calls to thread pool to avoid event loop flooding. Auto-configured from `max_concurrent / num_clients` if not set (2025-12-23)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,4 +16,5 @@ Documenting changes which affect configuration usage patterns (added/moved/remov
 - **`trainer.loss.sequence_clip_high`**: Added sequence-level importance ratio clipping threshold (2025-12-19)
 - **`trainer.loss.geo_mask_high`** and **`trainer.loss.geo_mask_low`**: Added geometric importance ratio masking thresholds (2025-12-19)
 - **`{orchestrator,trainer}.transport.zmq`**: Added ZMQ transport for training batches and micro batches (#1446, 2025-12-22)
-- **`orchestrator.client.max_workers_per_client`**: Added thread pool configuration to client; dispatches API calls to thread pool to avoid event loop flooding. Auto-configured from `max_concurrent / num_clients` if not set (2025-12-23)
+- **`orchestrator.max_concurrent`**: Now auto-configured from `batch_size * oversampling_factor` if not set (2025-12-23)
+- **`orchestrator.client.max_workers_per_client`** and **`orchestrator.client.max_connections`**: Added thread pool configuration to client; dispatches API calls to thread pool to avoid event loop flooding. Auto-configured from `max_concurrent // (num_clients * max_connections)`. `max_connections` defaults to 128 (2025-12-23)

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field, model_validator
 
 from prime_rl.transport.config import FileSystemTransportConfig, TransportConfigType
 from prime_rl.utils.config import (
+    ClientConfig,  # noqa
     HeartbeatConfig,
     LogConfig,
     ModelConfig,

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -6,7 +6,6 @@ from pydantic import BaseModel, Field, model_validator
 
 from prime_rl.transport.config import FileSystemTransportConfig, TransportConfigType
 from prime_rl.utils.config import (
-    ClientConfig,
     HeartbeatConfig,
     LogConfig,
     ModelConfig,
@@ -486,11 +485,8 @@ WeightBroadcastConfigType: TypeAlias = FileSystemWeightBroadcastConfig | NCCLWei
 class OrchestratorConfig(BaseSettings):
     """Configures the orchestrator for RL training."""
 
-    # The OAI client configuration
-    client: ClientConfig = ClientConfig()
-
-    # The threaded client configuration
-    threaded_client: ThreadedClientConfig = ThreadedClientConfig()
+    # The threaded OpenAI client configuration
+    client: ThreadedClientConfig = ThreadedClientConfig()
 
     # The model configuration
     model: ModelConfig = ModelConfig()
@@ -676,8 +672,8 @@ class OrchestratorConfig(BaseSettings):
 
     @model_validator(mode="after")
     def auto_setup_max_workers_per_client(self):
-        if self.threaded_client.max_workers_per_client is None:
+        if self.client.max_workers_per_client is None:
             num_clients = len(self.client.base_url)
             if self.max_concurrent is not None:
-                self.threaded_client.max_workers_per_client = math.ceil(self.max_concurrent / num_clients)
+                self.client.max_workers_per_client = math.ceil(self.max_concurrent / num_clients)
         return self

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -674,6 +674,6 @@ class OrchestratorConfig(BaseSettings):
     def auto_setup_max_workers_per_client(self):
         if self.client.max_workers_per_client is None:
             num_clients = len(self.client.base_url)
-            if self.max_concurrent is None:
+            if self.max_concurrent is not None:
                 self.client.max_workers_per_client = math.ceil(self.max_concurrent / num_clients)
         return self

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -1,4 +1,3 @@
-import math
 from pathlib import Path
 from typing import Annotated, Any, Literal, TypeAlias
 
@@ -675,5 +674,5 @@ class OrchestratorConfig(BaseSettings):
         if self.client.max_workers_per_client is None:
             num_clients = len(self.client.base_url)
             if self.max_concurrent is not None:
-                self.client.max_workers_per_client = math.ceil(self.max_concurrent / num_clients)
+                self.client.max_workers_per_client = self.max_concurrent // (num_clients * self.client.max_connections)
         return self

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -11,6 +11,7 @@ from prime_rl.utils.config import (
     LogConfig,
     ModelConfig,
     PrimeMonitorConfig,
+    ThreadedClientConfig,
     WandbWithExtrasConfig,
 )
 from prime_rl.utils.pydantic_config import BaseConfig, BaseSettings
@@ -488,6 +489,9 @@ class OrchestratorConfig(BaseSettings):
     # The OAI client configuration
     client: ClientConfig = ClientConfig()
 
+    # The threaded client configuration
+    threaded_client: ThreadedClientConfig = ThreadedClientConfig()
+
     # The model configuration
     model: ModelConfig = ModelConfig()
 
@@ -672,8 +676,8 @@ class OrchestratorConfig(BaseSettings):
 
     @model_validator(mode="after")
     def auto_setup_max_workers_per_client(self):
-        if self.client.max_workers_per_client is None:
+        if self.threaded_client.max_workers_per_client is None:
             num_clients = len(self.client.base_url)
             if self.max_concurrent is not None:
-                self.client.max_workers_per_client = math.ceil(self.max_concurrent / num_clients)
+                self.threaded_client.max_workers_per_client = math.ceil(self.max_concurrent / num_clients)
         return self

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -670,9 +670,14 @@ class OrchestratorConfig(BaseSettings):
         return self
 
     @model_validator(mode="after")
+    def auto_setup_max_concurrent(self):
+        if self.max_concurrent is None:
+            self.max_concurrent = self.batch_size * self.oversampling_factor
+        return self
+
+    @model_validator(mode="after")
     def auto_setup_max_workers_per_client(self):
         if self.client.max_workers_per_client is None:
             num_clients = len(self.client.base_url)
-            if self.max_concurrent is not None:
-                self.client.max_workers_per_client = self.max_concurrent // (num_clients * self.client.max_connections)
+            self.client.max_workers_per_client = self.max_concurrent // (num_clients * self.client.max_connections)
         return self

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -672,7 +672,7 @@ class OrchestratorConfig(BaseSettings):
     @model_validator(mode="after")
     def auto_setup_max_concurrent(self):
         if self.max_concurrent is None:
-            self.max_concurrent = self.batch_size * self.oversampling_factor
+            self.max_concurrent = int(self.batch_size * self.oversampling_factor)
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -679,5 +679,7 @@ class OrchestratorConfig(BaseSettings):
     def auto_setup_max_workers_per_client(self):
         if self.client.max_workers_per_client is None:
             num_clients = len(self.client.base_url)
-            self.client.max_workers_per_client = self.max_concurrent // (num_clients * self.client.max_connections)
+            self.client.max_workers_per_client = max(
+                1, self.max_concurrent // (num_clients * self.client.max_connections)
+            )
         return self

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -6,7 +6,6 @@ from pydantic import BaseModel, Field, model_validator
 
 from prime_rl.transport.config import FileSystemTransportConfig, TransportConfigType
 from prime_rl.utils.config import (
-    ClientConfig,  # noqa
     HeartbeatConfig,
     LogConfig,
     ModelConfig,

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -1,3 +1,4 @@
+import math
 from pathlib import Path
 from typing import Annotated, Any, Literal, TypeAlias
 
@@ -667,4 +668,12 @@ class OrchestratorConfig(BaseSettings):
             if self.prime_monitor:
                 self.prime_monitor.log_extras = None
 
+        return self
+
+    @model_validator(mode="after")
+    def auto_setup_max_workers_per_client(self):
+        if self.client.max_workers_per_client is None:
+            num_clients = len(self.client.base_url)
+            if self.max_concurrent is None:
+                self.client.max_workers_per_client = math.ceil(self.max_concurrent / num_clients)
         return self

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -94,9 +94,9 @@ async def orchestrate(config: OrchestratorConfig):
 
     # Setup client
     logger.info(
-        f"Initializing OpenAI client (base_url={', '.join(config.client.base_url)}, api_key_var={config.client.api_key_var}, headers={config.client.headers}, max_workers_per_client={config.threaded_client.max_workers_per_client})"
+        f"Initializing OpenAI client (base_url={', '.join(config.client.base_url)}, api_key_var={config.client.api_key_var}, headers={config.client.headers}, max_workers_per_client={config.client.max_workers_per_client})"
     )
-    clients = setup_threaded_clients(config.client, config.threaded_client.max_workers_per_client)
+    clients = setup_threaded_clients(config.client)
     admin_clients = setup_admin_clients(config.client)
     evals_client = setup_evals_client()
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -39,7 +39,6 @@ from prime_rl.utils.client import (
     init_nccl_broadcast,
     reload_weights,
     setup_admin_clients,
-    setup_clients,
     setup_evals_client,
     setup_threaded_clients,
     teardown_clients,
@@ -97,10 +96,7 @@ async def orchestrate(config: OrchestratorConfig):
     logger.info(
         f"Initializing OpenAI client (base_url={', '.join(config.client.base_url)}, api_key_var={config.client.api_key_var}, headers={config.client.headers}, threaded={config.client.threaded})"
     )
-    if config.client.threaded:
-        clients = setup_threaded_clients(config.client, config.client.max_workers_per_client)
-    else:
-        clients = setup_clients(config.client)
+    clients = setup_threaded_clients(config.client, config.client.max_workers_per_client)
     admin_clients = setup_admin_clients(config.client)
     evals_client = setup_evals_client()
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -41,6 +41,8 @@ from prime_rl.utils.client import (
     setup_admin_clients,
     setup_clients,
     setup_evals_client,
+    setup_threaded_clients,
+    teardown_clients,
     update_weights,
 )
 from prime_rl.utils.heartbeat import Heartbeat
@@ -93,9 +95,12 @@ async def orchestrate(config: OrchestratorConfig):
 
     # Setup client
     logger.info(
-        f"Initializing OpenAI client (base_url={', '.join(config.client.base_url)}, api_key_var={config.client.api_key_var}, headers={config.client.headers})"
+        f"Initializing OpenAI client (base_url={', '.join(config.client.base_url)}, api_key_var={config.client.api_key_var}, headers={config.client.headers}, threaded={config.client.threaded})"
     )
-    clients = setup_clients(config.client)
+    if config.client.threaded:
+        clients = setup_threaded_clients(config.client, config.client.max_workers_per_client)
+    else:
+        clients = setup_clients(config.client)
     admin_clients = setup_admin_clients(config.client)
     evals_client = setup_evals_client()
 
@@ -525,6 +530,9 @@ async def orchestrate(config: OrchestratorConfig):
 
     # Cancel event loop lag monitor task
     event_loop_lag_monitor_task.cancel()
+
+    # Teardown clients
+    teardown_clients(clients)
 
     logger.success("Orchestrator finished.")
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -94,9 +94,9 @@ async def orchestrate(config: OrchestratorConfig):
 
     # Setup client
     logger.info(
-        f"Initializing OpenAI client (base_url={', '.join(config.client.base_url)}, api_key_var={config.client.api_key_var}, headers={config.client.headers}, threaded={config.client.threaded})"
+        f"Initializing OpenAI client (base_url={', '.join(config.client.base_url)}, api_key_var={config.client.api_key_var}, headers={config.client.headers}, max_workers_per_client={config.threaded_client.max_workers_per_client})"
     )
-    clients = setup_threaded_clients(config.client, config.client.max_workers_per_client)
+    clients = setup_threaded_clients(config.client, config.threaded_client.max_workers_per_client)
     admin_clients = setup_admin_clients(config.client)
     evals_client = setup_evals_client()
 

--- a/src/prime_rl/synthesize/utils.py
+++ b/src/prime_rl/synthesize/utils.py
@@ -11,7 +11,8 @@ from tqdm.asyncio import tqdm
 from verifiers import load_environment
 from verifiers.envs.environment import get_results_path
 
-from prime_rl.orchestrator.config import ClientConfig, EvalSamplingConfig, ModelConfig
+from prime_rl.orchestrator.config import EvalSamplingConfig, ModelConfig
+from prime_rl.utils.config import ClientConfig
 from prime_rl.utils.logger import get_logger
 from prime_rl.utils.vf import generate_group
 

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -47,6 +47,7 @@ def setup_threaded_clients(
             api_key=api_key,
             max_workers=client_config.max_workers_per_client,
             timeout=client_config.timeout,
+            max_connections=client_config.max_connections,
             headers=client_config.headers,
         )
         for base_url in client_config.base_url

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -7,7 +7,7 @@ from httpx import AsyncClient
 from openai import AsyncOpenAI, NotFoundError
 from prime_evals import AsyncEvalsClient
 
-from prime_rl.utils.config import ClientConfig
+from prime_rl.utils.config import ClientConfig, ThreadedClientConfig
 from prime_rl.utils.logger import get_logger
 from prime_rl.utils.threaded_client import ThreadedAsyncOpenAIClient
 
@@ -34,8 +34,7 @@ def setup_clients(client_config: ClientConfig) -> list[AsyncOpenAI]:
 
 
 def setup_threaded_clients(
-    client_config: ClientConfig,
-    max_workers_per_client: int,
+    client_config: ThreadedClientConfig,
 ) -> list[ThreadedAsyncOpenAIClient]:
     """Create threaded OpenAI clients - one per base_url.
 
@@ -46,7 +45,7 @@ def setup_threaded_clients(
         ThreadedAsyncOpenAIClient(
             base_url=base_url,
             api_key=api_key,
-            max_workers=max_workers_per_client,
+            max_workers=client_config.max_workers_per_client,
             timeout=client_config.timeout,
             headers=client_config.headers,
         )

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -12,6 +12,7 @@ from prime_rl.utils.logger import get_logger
 from prime_rl.utils.threaded_client import ThreadedAsyncOpenAIClient
 
 
+# TODO: consider deprecating in synthesize and eval endpoints too
 def setup_clients(client_config: ClientConfig) -> list[AsyncOpenAI]:
     def _setup_client(base_url: str) -> AsyncOpenAI:
         # We use a longer request timeout than default, but if more than 20min, we probably need faster inference deployment
@@ -34,7 +35,7 @@ def setup_clients(client_config: ClientConfig) -> list[AsyncOpenAI]:
 
 def setup_threaded_clients(
     client_config: ClientConfig,
-    max_workers_per_client: int = 64,
+    max_workers_per_client: int,
 ) -> list[ThreadedAsyncOpenAIClient]:
     """Create threaded OpenAI clients - one per base_url.
 

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -9,6 +9,7 @@ from prime_evals import AsyncEvalsClient
 
 from prime_rl.utils.config import ClientConfig
 from prime_rl.utils.logger import get_logger
+from prime_rl.utils.threaded_client import ThreadedAsyncOpenAIClient
 
 
 def setup_clients(client_config: ClientConfig) -> list[AsyncOpenAI]:
@@ -29,6 +30,34 @@ def setup_clients(client_config: ClientConfig) -> list[AsyncOpenAI]:
         )
 
     return [_setup_client(base_url) for base_url in client_config.base_url]
+
+
+def setup_threaded_clients(
+    client_config: ClientConfig,
+    max_workers_per_client: int = 64,
+) -> list[ThreadedAsyncOpenAIClient]:
+    """Create threaded OpenAI clients - one per base_url.
+
+    Each client dispatches API calls to a thread pool, avoiding event loop flooding.
+    """
+    api_key = os.getenv(client_config.api_key_var, "EMPTY")
+    return [
+        ThreadedAsyncOpenAIClient(
+            base_url=base_url,
+            api_key=api_key,
+            max_workers=max_workers_per_client,
+            timeout=client_config.timeout,
+            headers=client_config.headers,
+        )
+        for base_url in client_config.base_url
+    ]
+
+
+def teardown_clients(clients: list[ThreadedAsyncOpenAIClient | AsyncOpenAI]) -> None:
+    """Shutdown threaded clients (no-op for regular AsyncOpenAI)."""
+    for client in clients:
+        if hasattr(client, "teardown"):
+            client.teardown(wait=False)
 
 
 def setup_evals_client() -> AsyncEvalsClient:

--- a/src/prime_rl/utils/config.py
+++ b/src/prime_rl/utils/config.py
@@ -52,19 +52,16 @@ class ClientConfig(BaseConfig):
         ),
     ] = {}
 
-    threaded: Annotated[
-        bool,
-        Field(
-            description="Use threaded clients to offload API calls from the main event loop. Recommended for high-throughput scenarios.",
-        ),
-    ] = True
+
+class ThreadedClientConfig(BaseConfig):
+    """Configures the threaded OpenAI client."""
 
     max_workers_per_client: Annotated[
-        int,
+        int | None,
         Field(
-            description="Number of worker threads per client (only used when threaded=True).",
+            description="Number of worker threads per client. If None, will be auto-configured based on max_concurrent and number of clients ceil(max_concurrent / num_clients).",
         ),
-    ] = 64
+    ] = None
 
 
 class LogConfig(BaseConfig):

--- a/src/prime_rl/utils/config.py
+++ b/src/prime_rl/utils/config.py
@@ -52,6 +52,20 @@ class ClientConfig(BaseConfig):
         ),
     ] = {}
 
+    threaded: Annotated[
+        bool,
+        Field(
+            description="Use threaded clients to offload API calls from the main event loop. Recommended for high-throughput scenarios.",
+        ),
+    ] = True
+
+    max_workers_per_client: Annotated[
+        int,
+        Field(
+            description="Number of worker threads per client (only used when threaded=True).",
+        ),
+    ] = 64
+
 
 class LogConfig(BaseConfig):
     """Configures the logger."""

--- a/src/prime_rl/utils/config.py
+++ b/src/prime_rl/utils/config.py
@@ -59,9 +59,16 @@ class ThreadedClientConfig(ClientConfig):
     max_workers_per_client: Annotated[
         int | None,
         Field(
-            description="Number of worker threads per client. If None, will be auto-configured based on max_concurrent and number of clients ceil(max_concurrent / num_clients).",
+            description="Number of worker threads per client. If None, will be auto-configured based on max_workers_per_client = max_concurrent // (num_clients * max_connections).",
         ),
     ] = None
+
+    max_connections: Annotated[
+        int,
+        Field(
+            description="Maximum number of connections per httpx client. Each worker thread maintains its own client with this connection limit.",
+        ),
+    ] = 128
 
 
 class LogConfig(BaseConfig):

--- a/src/prime_rl/utils/config.py
+++ b/src/prime_rl/utils/config.py
@@ -59,7 +59,7 @@ class ThreadedClientConfig(ClientConfig):
     max_workers_per_client: Annotated[
         int | None,
         Field(
-            description="Number of worker threads per client. If None, will be auto-configured based on max_workers_per_client = max_concurrent // (num_clients * max_connections).",
+            description="Number of worker threads per client. If None, will be auto-configured based on max_workers_per_client = max(1, max_concurrent // (num_clients * max_connections)).",
         ),
     ] = None
 

--- a/src/prime_rl/utils/config.py
+++ b/src/prime_rl/utils/config.py
@@ -53,7 +53,7 @@ class ClientConfig(BaseConfig):
     ] = {}
 
 
-class ThreadedClientConfig(BaseConfig):
+class ThreadedClientConfig(ClientConfig):
     """Configures the threaded OpenAI client."""
 
     max_workers_per_client: Annotated[

--- a/src/prime_rl/utils/threaded_client.py
+++ b/src/prime_rl/utils/threaded_client.py
@@ -1,0 +1,118 @@
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import httpx
+from openai import AsyncOpenAI
+from verifiers.utils.thread_utils import (
+    get_or_create_thread_attr,
+    get_or_create_thread_loop,
+)
+
+
+class ThreadedAsyncOpenAIClient:
+    """
+    Wraps AsyncOpenAI, dispatching calls to a ThreadPoolExecutor.
+    Each thread maintains its own event loop and client via thread-local storage.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str,
+        max_workers: int = 64,
+        timeout: int = 1200,
+        max_connections: int = 8192,
+        max_keepalive_connections: int = 8192,
+        max_retries: int = 10,
+        headers: dict[str, str] | None = None,
+    ):
+        self.executor = ThreadPoolExecutor(
+            max_workers=max_workers,
+            thread_name_prefix="oai-client",
+        )
+        self._base_url = base_url
+        self._api_key = api_key
+        self._timeout = timeout
+        self._max_connections = max_connections
+        self._max_keepalive_connections = max_keepalive_connections
+        self._max_retries = max_retries
+        self._headers = headers or {}
+        self._tls_key = f"oai_client_{id(self)}"
+
+    @property
+    def base_url(self) -> str:
+        return self._base_url
+
+    def _create_client(self) -> AsyncOpenAI:
+        timeout = httpx.Timeout(self._timeout)
+        limits = httpx.Limits(
+            max_connections=self._max_connections,
+            max_keepalive_connections=self._max_keepalive_connections,
+        )
+        http_client = httpx.AsyncClient(limits=limits, timeout=timeout, headers=self._headers)
+        return AsyncOpenAI(
+            base_url=self._base_url,
+            api_key=self._api_key,
+            max_retries=self._max_retries,
+            http_client=http_client,
+        )
+
+    def _get_thread_client(self) -> AsyncOpenAI:
+        return get_or_create_thread_attr(self._tls_key, self._create_client)
+
+    async def _run_in_thread(self, coro_fn) -> Any:
+        def run():
+            loop = get_or_create_thread_loop()
+            client = self._get_thread_client()
+            return loop.run_until_complete(coro_fn(client))
+
+        return await asyncio.get_event_loop().run_in_executor(self.executor, run)
+
+    @property
+    def chat(self) -> "_Chat":
+        return _Chat(self)
+
+    @property
+    def completions(self) -> "_Completions":
+        return _Completions(self)
+
+    @property
+    def models(self) -> "_Models":
+        return _Models(self)
+
+    def teardown(self, wait: bool = True) -> None:
+        self.executor.shutdown(wait=wait)
+
+
+class _Chat:
+    def __init__(self, parent: ThreadedAsyncOpenAIClient):
+        self._parent = parent
+
+    @property
+    def completions(self) -> "_ChatCompletions":
+        return _ChatCompletions(self._parent)
+
+
+class _ChatCompletions:
+    def __init__(self, parent: ThreadedAsyncOpenAIClient):
+        self._parent = parent
+
+    async def create(self, **kwargs) -> Any:
+        return await self._parent._run_in_thread(lambda c: c.chat.completions.create(**kwargs))
+
+
+class _Completions:
+    def __init__(self, parent: ThreadedAsyncOpenAIClient):
+        self._parent = parent
+
+    async def create(self, **kwargs) -> Any:
+        return await self._parent._run_in_thread(lambda c: c.completions.create(**kwargs))
+
+
+class _Models:
+    def __init__(self, parent: ThreadedAsyncOpenAIClient):
+        self._parent = parent
+
+    async def list(self) -> Any:
+        return await self._parent._run_in_thread(lambda c: c.models.list())

--- a/src/prime_rl/utils/threaded_client.py
+++ b/src/prime_rl/utils/threaded_client.py
@@ -20,10 +20,8 @@ class ThreadedAsyncOpenAIClient:
         self,
         base_url: str,
         api_key: str,
-        max_workers: int = 64,
+        max_workers: int,
         timeout: int = 1200,
-        max_connections: int = 8192,
-        max_keepalive_connections: int = 8192,
         max_retries: int = 10,
         headers: dict[str, str] | None = None,
     ):
@@ -34,8 +32,6 @@ class ThreadedAsyncOpenAIClient:
         self._base_url = base_url
         self._api_key = api_key
         self._timeout = timeout
-        self._max_connections = max_connections
-        self._max_keepalive_connections = max_keepalive_connections
         self._max_retries = max_retries
         self._headers = headers or {}
         self._tls_key = f"oai_client_{id(self)}"
@@ -46,11 +42,7 @@ class ThreadedAsyncOpenAIClient:
 
     def _create_client(self) -> AsyncOpenAI:
         timeout = httpx.Timeout(self._timeout)
-        limits = httpx.Limits(
-            max_connections=self._max_connections,
-            max_keepalive_connections=self._max_keepalive_connections,
-        )
-        http_client = httpx.AsyncClient(limits=limits, timeout=timeout, headers=self._headers)
+        http_client = httpx.AsyncClient(timeout=timeout, headers=self._headers)
         return AsyncOpenAI(
             base_url=self._base_url,
             api_key=self._api_key,

--- a/src/prime_rl/utils/threaded_client.py
+++ b/src/prime_rl/utils/threaded_client.py
@@ -40,7 +40,10 @@ class ThreadedAsyncOpenAIClient:
 
     def _create_client(self) -> AsyncOpenAI:
         timeout = httpx.Timeout(self.timeout)
-        limits = httpx.Limits(max_connections=self.max_connections)
+        limits = httpx.Limits(
+            max_connections=self.max_connections,
+            max_keepalive_connections=self.max_connections,
+        )
         http_client = httpx.AsyncClient(timeout=timeout, limits=limits, headers=self.headers)
         return AsyncOpenAI(
             base_url=self.base_url,

--- a/src/prime_rl/utils/threaded_client.py
+++ b/src/prime_rl/utils/threaded_client.py
@@ -23,6 +23,7 @@ class ThreadedAsyncOpenAIClient:
         max_workers: int,
         timeout: int = 1200,
         max_retries: int = 10,
+        max_connections: int = 100,
         headers: dict[str, str] | None = None,
     ):
         self.executor = ThreadPoolExecutor(
@@ -33,12 +34,14 @@ class ThreadedAsyncOpenAIClient:
         self.api_key = api_key
         self.timeout = timeout
         self.max_retries = max_retries
+        self.max_connections = max_connections
         self.headers = headers or {}
         self.tls_key = f"oai_client_{id(self)}"
 
     def _create_client(self) -> AsyncOpenAI:
         timeout = httpx.Timeout(self.timeout)
-        http_client = httpx.AsyncClient(timeout=timeout, headers=self.headers)
+        limits = httpx.Limits(max_connections=self.max_connections)
+        http_client = httpx.AsyncClient(timeout=timeout, limits=limits, headers=self.headers)
         return AsyncOpenAI(
             base_url=self.base_url,
             api_key=self.api_key,

--- a/src/prime_rl/utils/threaded_client.py
+++ b/src/prime_rl/utils/threaded_client.py
@@ -29,29 +29,25 @@ class ThreadedAsyncOpenAIClient:
             max_workers=max_workers,
             thread_name_prefix="oai-client",
         )
-        self._base_url = base_url
-        self._api_key = api_key
-        self._timeout = timeout
-        self._max_retries = max_retries
-        self._headers = headers or {}
-        self._tls_key = f"oai_client_{id(self)}"
-
-    @property
-    def base_url(self) -> str:
-        return self._base_url
+        self.base_url = base_url
+        self.api_key = api_key
+        self.timeout = timeout
+        self.max_retries = max_retries
+        self.headers = headers or {}
+        self.tls_key = f"oai_client_{id(self)}"
 
     def _create_client(self) -> AsyncOpenAI:
-        timeout = httpx.Timeout(self._timeout)
-        http_client = httpx.AsyncClient(timeout=timeout, headers=self._headers)
+        timeout = httpx.Timeout(self.timeout)
+        http_client = httpx.AsyncClient(timeout=timeout, headers=self.headers)
         return AsyncOpenAI(
-            base_url=self._base_url,
-            api_key=self._api_key,
-            max_retries=self._max_retries,
+            base_url=self.base_url,
+            api_key=self.api_key,
+            max_retries=self.max_retries,
             http_client=http_client,
         )
 
     def _get_thread_client(self) -> AsyncOpenAI:
-        return get_or_create_thread_attr(self._tls_key, self._create_client)
+        return get_or_create_thread_attr(self.tls_key, self._create_client)
 
     def __getattr__(self, name: str) -> Callable[..., Any]:
         """Dynamically proxy attribute access to dispatch method calls to the thread pool."""

--- a/tests/integration/test_rl.py
+++ b/tests/integration/test_rl.py
@@ -10,7 +10,9 @@ from tests.utils import check_no_error, check_number_goes_up_or_down, check_numb
 pytestmark = [pytest.mark.gpu, pytest.mark.slow]
 
 
-TIMEOUT = 600  # 10 minutes
+# RL integration includes launching inference + orchestrator + trainer and may spend additional time
+# on finalization (e.g. syncing W&B artifacts). Keep this comfortably above typical runtime to reduce CI flakiness.
+TIMEOUT = 900  # 15 minutes
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_rl.py
+++ b/tests/integration/test_rl.py
@@ -10,8 +10,6 @@ from tests.utils import check_no_error, check_number_goes_up_or_down, check_numb
 pytestmark = [pytest.mark.gpu, pytest.mark.slow]
 
 
-# RL integration includes launching inference + orchestrator + trainer and may spend additional time
-# on finalization (e.g. syncing W&B artifacts). Keep this comfortably above typical runtime to reduce CI flakiness.
 TIMEOUT = 900  # 15 minutes
 
 

--- a/tests/integration/test_rl_lora.py
+++ b/tests/integration/test_rl_lora.py
@@ -10,8 +10,6 @@ from tests.utils import check_no_error, check_number_goes_up_or_down, check_numb
 pytestmark = [pytest.mark.gpu, pytest.mark.slow]
 
 
-# RL LoRA integration includes launching inference + orchestrator + trainer and may spend additional time
-# on finalization (e.g. syncing W&B artifacts). Keep this comfortably above typical runtime to reduce CI flakiness.
 TIMEOUT = 900  # 15 minutes
 
 

--- a/tests/integration/test_rl_lora.py
+++ b/tests/integration/test_rl_lora.py
@@ -10,7 +10,9 @@ from tests.utils import check_no_error, check_number_goes_up_or_down, check_numb
 pytestmark = [pytest.mark.gpu, pytest.mark.slow]
 
 
-TIMEOUT = 600  # 10 minutes
+# RL LoRA integration includes launching inference + orchestrator + trainer and may spend additional time
+# on finalization (e.g. syncing W&B artifacts). Keep this comfortably above typical runtime to reduce CI flakiness.
+TIMEOUT = 900  # 15 minutes
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

introduce similar threading pattern from threaded sandbox client in verifiers for OpenAI client to relieve event loop

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: [Issue ID]
**Linear Issue**: Resolves [Issue ID]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a threaded OpenAI client and wires it into RL orchestration to avoid event loop flooding.
> 
> - Adds `ThreadedAsyncOpenAIClient` (thread pool per base URL; per-thread `AsyncOpenAI` with isolated event loops) and `teardown()` in `utils/threaded_client.py`
> - New `ThreadedClientConfig` with `max_workers_per_client` and `max_connections`; `OrchestratorConfig` now uses it and auto-sets `max_concurrent` and derives `max_workers_per_client`
> - Orchestrator switches to `setup_threaded_clients(...)` and calls `teardown_clients(...)`; logs include `max_workers_per_client`
> - Client helpers: add `setup_threaded_clients(...)` and `teardown_clients(...)` in `utils/client.py` (legacy `setup_clients(...)` retained)
> - Minor: adjust import in `synthesize/utils.py`; increase RL integration test timeouts to 15 minutes
> - Update `CHANGELOG.md` to document new/auto-configured fields
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d10ea3fb1feec2276ad20ad235d92d6a9101a09. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->