### PR TITLE
wip add process

### DIFF
--- a/src/prime_rl/orchestrator/buffer.py
+++ b/src/prime_rl/orchestrator/buffer.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Literal, cast
 
 import verifiers as vf
+from datasets import Dataset
 
 from prime_rl.orchestrator.config import BufferConfig
 from prime_rl.utils.logger import get_logger
@@ -20,24 +21,20 @@ class Buffer:
     POOLS = ["easy", "normal", "hard"]
 
     def __init__(
-        self, env_group: vf.EnvGroup, buffer_config: BufferConfig, dataset_type: Literal["train", "val"] = "train"
+        self,
+        dataset: Dataset,
+        env_names: list[str],
+        buffer_config: BufferConfig,
+        dataset_type: Literal["train", "val"] = "train",
     ):
-        self.env_group = env_group
+        self.dataset = dataset
+        self.env_names = env_names
         self.config = buffer_config
         self.dataset_type = dataset_type
         self.logger = get_logger()
 
         if self.config.seed is not None:
             random.seed(self.config.seed)
-
-        if self.dataset_type == "train":
-            self.dataset = env_group.get_dataset(seed=self.config.seed)
-        elif self.dataset_type == "val":
-            self.dataset = env_group.get_eval_dataset(seed=self.config.seed)
-        else:
-            raise ValueError(f"Invalid dataset type: {self.dataset_type}")
-
-        self.env_names = env_group.env_names
 
         # Basic assertions
         assert "example_id" in self.dataset.column_names, "The dataset must contain a `example_id` column."

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -635,6 +635,14 @@ class OrchestratorConfig(BaseSettings):
         HeartbeatConfig | None, Field(description="The heartbeat config for monitoring training progress.")
     ] = None
 
+    env_workers: Annotated[
+        int,
+        Field(
+            ge=1,
+            description="Number of worker processes for environment rollouts. Each worker has its own event loop.",
+        ),
+    ] = 8
+
     @model_validator(mode="after")
     def nccl_max_async_level(self):
         if self.weight_broadcast.type == "nccl":

--- a/src/prime_rl/orchestrator/process_env.py
+++ b/src/prime_rl/orchestrator/process_env.py
@@ -8,6 +8,7 @@ from openai import AsyncOpenAI
 
 from prime_rl.utils.vf import from_serializable_state, to_serializable_state
 
+# Main process globals
 _process_pool: ProcessPoolExecutor | None = None
 
 
@@ -23,6 +24,32 @@ def shutdown_process_pool():
     if _process_pool is not None:
         _process_pool.shutdown(wait=True)
         _process_pool = None
+
+
+# Worker process globals (each worker has its own copy)
+_worker_envs: dict[str, vf.Environment] = {}
+
+
+def _get_or_create_env(
+    env_id: str,
+    env_args: dict[str, Any],
+    max_seq_len: int | None,
+    interleaved_rollouts: bool,
+) -> vf.Environment:
+    """Get cached env or create new one. Cache is per-worker process."""
+    # Create a hashable cache key from env config
+    args_key = tuple(sorted((k, str(v)) for k, v in env_args.items()))
+    cache_key = f"{env_id}:{args_key}:{max_seq_len}:{interleaved_rollouts}"
+
+    if cache_key not in _worker_envs:
+        env = vf.load_environment(env_id, **env_args)
+        if max_seq_len:
+            env.set_max_seq_len(max_seq_len)
+        if interleaved_rollouts:
+            env.set_interleaved_rollouts(True)
+        _worker_envs[cache_key] = env
+
+    return _worker_envs[cache_key]
 
 
 @dataclass
@@ -46,12 +73,12 @@ def _run_group_in_subprocess(request: RolloutRequest) -> list[dict]:
 
     async def _generate():
         client = AsyncOpenAI(base_url=request.base_url, api_key=request.api_key)
-        env = vf.load_environment(request.env_id, **request.env_args)
-
-        if request.max_seq_len:
-            env.set_max_seq_len(request.max_seq_len)
-        if request.interleaved_rollouts:
-            env.set_interleaved_rollouts(True)
+        env = _get_or_create_env(
+            request.env_id,
+            request.env_args,
+            request.max_seq_len,
+            request.interleaved_rollouts,
+        )
 
         group_inputs = [vf.RolloutInput(**request.example) for _ in range(request.rollouts_per_example)]
 

--- a/src/prime_rl/orchestrator/process_env.py
+++ b/src/prime_rl/orchestrator/process_env.py
@@ -1,0 +1,80 @@
+import asyncio
+from concurrent.futures import ProcessPoolExecutor
+from dataclasses import dataclass
+from typing import Any
+
+import verifiers as vf
+from openai import AsyncOpenAI
+
+from prime_rl.utils.vf import from_serializable_state, to_serializable_state
+
+_process_pool: ProcessPoolExecutor | None = None
+
+
+def get_process_pool(max_workers: int = 8) -> ProcessPoolExecutor:
+    global _process_pool
+    if _process_pool is None:
+        _process_pool = ProcessPoolExecutor(max_workers=max_workers)
+    return _process_pool
+
+
+def shutdown_process_pool():
+    global _process_pool
+    if _process_pool is not None:
+        _process_pool.shutdown(wait=True)
+        _process_pool = None
+
+
+@dataclass
+class RolloutRequest:
+    """Picklable request for subprocess."""
+
+    env_id: str
+    env_args: dict[str, Any]
+    model_name: str
+    example: dict
+    rollouts_per_example: int
+    sampling_args: dict
+    base_url: str
+    api_key: str
+    max_seq_len: int | None = None
+    interleaved_rollouts: bool = False
+
+
+def _run_group_in_subprocess(request: RolloutRequest) -> list[dict]:
+    """Runs in separate process with its own event loop."""
+
+    async def _generate():
+        client = AsyncOpenAI(base_url=request.base_url, api_key=request.api_key)
+        env = vf.load_environment(request.env_id, **request.env_args)
+
+        if request.max_seq_len:
+            env.set_max_seq_len(request.max_seq_len)
+        if request.interleaved_rollouts:
+            env.set_interleaved_rollouts(True)
+
+        group_inputs = [vf.RolloutInput(**request.example) for _ in range(request.rollouts_per_example)]
+
+        states = await env.run_group(
+            group_inputs=group_inputs,
+            client=client,
+            model=request.model_name,
+            gen_sampling_args=request.sampling_args,
+        )
+
+        return [to_serializable_state(s) for s in states]
+
+    return asyncio.run(_generate())
+
+
+async def run_group_in_process(
+    request: RolloutRequest,
+    pool: ProcessPoolExecutor | None = None,
+) -> list[vf.State]:
+    """Submit rollout to process pool, await result."""
+    loop = asyncio.get_event_loop()
+    pool = pool or get_process_pool()
+
+    serialized = await loop.run_in_executor(pool, _run_group_in_subprocess, request)
+
+    return [from_serializable_state(s) for s in serialized]


### PR DESCRIPTION
```
┌─────────────────────────────────────────────────────────────────────────────┐
│                        MAIN PROCESS (Orchestrator)                          │
│                                                                             │
│  Event Loop (asyncio)                                                       │
│    │                                                                        │
│    ├── Scheduler                                                            │
│    │     ├── process_pool: ProcessPoolExecutor(max_workers=env_workers)     │
│    │     ├── env_configs: {task_name -> EnvConfig}                          │
│    │     ├── cycle_base_urls: round-robin inference endpoints               │
│    │     │                                                                  │
│    │     └── schedule_group_rollout():                                      │
│    │           │                                                            │
│    │           │  1. buffer.sample_examples(1) → get prompt                 │
│    │           │  2. Build RolloutRequest(env_id, example, base_url, ...)   │
│    │           │  3. Submit to ProcessPoolExecutor                          │
│    │           ▼                                                            │
│    │     ┌─────────────────────────────────────────┐                        │
│    │     │  asyncio.create_task(                   │                        │
│    │     │    run_group_in_process(request, pool)  │                        │
│    │     │  )                                      │                        │
│    │     └─────────────────────────────────────────┘                        │
│    │                                                                        │
│    ├── Buffer (stores vf.State objects after deserialization)               │
│    └── Monitor, Checkpointing, Weight Updates, etc.                         │
│                                                                             │
└─────────────────────────────────────────────────────────────────────────────┘
                                    │
                                    │ pickle serialization (via OS pipe)
                                    │ RolloutRequest dataclass (~1-10 KB)
                                    ▼
┌─────────────────────────────────────────────────────────────────────────────┐
│              WORKER PROCESS (1 of env_workers, managed by ProcessPool)      │
│                                                                             │
│  Process-local globals (persisted across calls to same worker):             │
│    _worker_envs: dict[str, Environment] = {                                 │
│        "math-500:...:4096:True": <cached_env>,   ← CREATED ONCE             │
│    }                                                                        │
│                                                                             │
│  _run_group_in_subprocess(request: RolloutRequest):                         │
│    │                                                                        │
│    │  1. asyncio.run(_generate())  ← fresh event loop per call              │
│    │                                                                        │
│    │  2. Create OpenAI client (lightweight, no persistent connection):      │
│    │     client = AsyncOpenAI(base_url=req.base_url, api_key=req.api_key)   │
│    │                                                                        │
│    │  3. Get or create cached environment:                                  │
│    │     env = _get_or_create_env(env_id, env_args, ...)                    │
│    │           │                                                            │
│    │           ├── cache hit? → return _worker_envs[key]                    │
│    │           └── cache miss? → vf.load_environment(), cache, return       │
│    │                                                                        │
│    │  4. Run rollout (I/O + CPU in this process's event loop):              │
│    │     states = await env.run_group(group_inputs, client, ...)            │
│    │                                                                        │
│    │  5. Serialize for transfer back:                                       │
│    │     return [to_serializable_state(s) for s in states]                  │
│    │                                                                        │
└─────────────────────────────────────────────────────────────────────────────┘
                                    │
                                    │ pickle serialization (via OS pipe)
                                    │ list[dict] (~100KB - 10MB depending on logprobs)
                                    ▼
┌─────────────────────────────────────────────────────────────────────────────┐
│                        MAIN PROCESS (receives result)                       │
│                                                                             │
│  run_group_in_process():                                                    │
│    serialized = await loop.run_in_executor(pool, _run_group_in_subprocess)  │
│    return [from_serializable_state(s) for s in serialized]                  │
│                                                                             │
│  Then in Scheduler.generate_batch():                                        │
│    group_states = finished_task.result()                                    │
│    buffer.update(group_states)          ← curriculum filtering              │
│    batch_rollouts.extend(buffer.sample_rollouts(n))                         │
│                                                                             │
└─────────────────────────────────────────────────────────────────────────────┘


═══════════════════════════════════════════════════════════════════════════════
                          WITH env_workers=4 EXAMPLE
═══════════════════════════════════════════════════════════════════════════════

┌─────────────────┐
│  MAIN PROCESS   │
│                 │         ┌─────────────────────────────────────┐
│  Orchestrator   │         │  WORKER 1: _worker_envs = {env}     │
│  Event Loop     │◄───────►│  Own event loop per call            │
│                 │         └─────────────────────────────────────┘
│  Scheduler      │         ┌─────────────────────────────────────┐
│    └─ pool ─────┼────────►│  WORKER 2: _worker_envs = {env}     │
│                 │         │  Own event loop per call            │
│  Buffer         │         └─────────────────────────────────────┘
│                 │         ┌─────────────────────────────────────┐
│                 │◄───────►│  WORKER 3: _worker_envs = {env}     │
│                 │         │  Own event loop per call            │
│                 │         └─────────────────────────────────────┘
│                 │         ┌─────────────────────────────────────┐
│                 │◄───────►│  WORKER 4: _worker_envs = {env}     │
│                 │         │  Own event loop per call            │
└─────────────────┘         └─────────────────────────────────────┘

Total env instances: 4 (one per worker, cached on first use)
Total event loops: 1 persistent (main) + N temporary (workers create per call)
```