### PR TITLE
refactor: buffer take dataset as input

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -135,10 +135,12 @@ async def orchestrate(config: OrchestratorConfig):
 
     # Setup buffer
     logger.info(f"Setting up buffer ({config.buffer})")
-    buffer = Buffer(env, config.buffer)
+    train_dataset = env.get_dataset(seed=config.buffer.seed)
+    buffer = Buffer(train_dataset, env.env_names, config.buffer)
     if config.val is not None:
         val_buffer_config = BufferConfig(env_ratios=config.buffer.env_ratios)
-        val_buffer = Buffer(env, val_buffer_config, dataset_type="val")
+        val_dataset = env.get_eval_dataset(seed=config.buffer.seed)
+        val_buffer = Buffer(val_dataset, env.env_names, val_buffer_config)
     else:
         val_buffer = None
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -139,7 +139,8 @@ async def orchestrate(config: OrchestratorConfig):
     buffer = Buffer(train_dataset, env.env_names, config.buffer)
     if config.val is not None:
         val_buffer_config = BufferConfig(env_ratios=config.buffer.env_ratios)
-        val_dataset = env.get_eval_dataset(seed=config.buffer.seed)
+        # Preserve historical behavior: validation dataset seeding follows val buffer config (defaults to None).
+        val_dataset = env.get_eval_dataset(seed=val_buffer_config.seed)
         val_buffer = Buffer(val_dataset, env.env_names, val_buffer_config)
     else:
         val_buffer = None


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Refactor: decouple buffer from EnvGroup**
> 
> - `Buffer` now accepts `dataset` and `env_names` in its constructor and no longer fetches datasets internally; removed `dataset_type` and related logging
> - Orchestrator builds train and val datasets via `EnvGroup.get_dataset/get_eval_dataset` and constructs `Buffer` accordingly; preserves prior validation seeding behavior
> - Unit tests updated to pass datasets/env_names directly and to reflect the new API
> - Minor cleanup: removed unused `Literal` import and simplified log messages
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d475c4b0bba73687d668b387d88d0b186346a878. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->