### PR TITLE
Tail f vs F investigation

### DIFF
--- a/scripts/tmux.sh
+++ b/scripts/tmux.sh
@@ -69,20 +69,14 @@ else
   tmux select-pane -t "$SESSION_NAME:RL.2" -T "Inference"
 
   # Logs: Orchestrator
-  tmux send-keys -t "$SESSION_NAME:RL.1" 'while true; do
-echo "Waiting for orchestrator log file..."
-while [ ! -f '"$OUTPUT_DIR"'/logs/orchestrator.stdout ]; do sleep 1; done
-echo "Following orchestrator.stdout..."
-tail -F '"$OUTPUT_DIR"'/logs/orchestrator.stdout
-done' C-m
+  tmux send-keys -t "$SESSION_NAME:RL.1" \
+    "echo \"Following orchestrator.stdout (tail -F; waits for rotate/create)...\"; tail -F \"${OUTPUT_DIR}/logs/orchestrator.stdout\" 2>/dev/null" \
+    C-m
 
   # Logs: Inference
-  tmux send-keys -t "$SESSION_NAME:RL.2" 'while true; do
-echo "Waiting for inference log file..."
-while [ ! -f '"$OUTPUT_DIR"'/logs/inference.stdout ]; do sleep 1; done
-echo "Following inference.stdout..."
-tail -F '"$OUTPUT_DIR"'/logs/inference.stdout
-done' C-m
+  tmux send-keys -t "$SESSION_NAME:RL.2" \
+    "echo \"Following inference.stdout (tail -F; waits for rotate/create)...\"; tail -F \"${OUTPUT_DIR}/logs/inference.stdout\" 2>/dev/null" \
+    C-m
 
   # Window 2: Monitor
   tmux new-window -t "$SESSION_NAME" -n "Monitor"


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Simplify tmux log following in `scripts/tmux.sh` by removing redundant `while true` and file existence checks. `tail -F` inherently handles file creation and rotation, making the wrapper unnecessary. Also, silence `tail`'s stderr to prevent "file missing" messages.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: [Issue ID]
**Linear Issue**: Resolves [Issue ID]

---
<a href="https://cursor.com/background-agent?bcId=bc-4e011cd7-0e3c-43de-a76a-71d447d0af3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4e011cd7-0e3c-43de-a76a-71d447d0af3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors `scripts/tmux.sh` to simplify log following in the RL window.
> 
> - Replace custom `while true`/file-existence loops with `tail -F` for `orchestrator.stdout` and `inference.stdout`, relying on `tail` to handle file creation/rotation
> - Add concise echo messages and redirect `tail` stderr to `/dev/null` to avoid noisy "file missing" warnings
> - No changes to tmux layout, pane titles, or monitor window behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0cabaf076dd8fdec3d3431a588f7e482c924c54d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->