### PR TITLE
dont return prompt logprobs

### DIFF
--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -36,7 +36,6 @@ def get_sampling_args(sampling_config: SamplingConfig) -> dict:
     sampling_args["extra_body"] = {
         **sampling_config.extra_body,
         "return_token_ids": True,  # Always return token IDs
-        "prompt_logprobs": True,  # Always return prompt logprobs
         "top_k": -1,
         "min_p": 0.0,
     }


### PR DESCRIPTION
I dont think we actually use them anywhere and making vllm return them seems to be bursing the vram usage for multi-turn when the prompts get long

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes returning prompt logprobs from vLLM sampling configuration.
> 
> - In `utils.py#get_sampling_args`, drops `extra_body["prompt_logprobs"]` so prompt logprobs are no longer requested while retaining other sampling args and token/ID returns
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b61969f16180bbf18545a16cefaedfdd01401edd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->