### PR TITLE
VLLM metrics integration

### DIFF
--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -378,35 +378,6 @@ class CheckpointConfig(BaseConfig):
     ] = False
 
 
-class VllmMetricsConfig(BaseConfig):
-    """Configures polling vLLM `/metrics` and logging to the monitor(s)."""
-
-    interval_seconds: Annotated[
-        float,
-        Field(ge=0.1, description="Minimum time between polls."),
-    ] = 10.0
-
-    timeout_seconds: Annotated[
-        float,
-        Field(ge=0.1, description="HTTP timeout for `/metrics` requests."),
-    ] = 2.0
-
-    log_all_vllm_metrics: Annotated[
-        bool,
-        Field(
-            description=(
-                "If true, logs many vLLM metrics (prefixed `vllm:`/`vllm_`) in addition to a small curated set. "
-                "Can create a lot of W&B keys."
-            )
-        ),
-    ] = True
-
-    max_metrics_per_endpoint: Annotated[
-        int,
-        Field(ge=1, description="Cap on the number of extra vLLM metric names to log per endpoint."),
-    ] = 250
-
-
 class BufferConfig(BaseConfig):
     """Configures the buffer for the orchestrator."""
 
@@ -546,7 +517,10 @@ class OrchestratorConfig(BaseSettings):
     # The checkpoint configuration
     ckpt: CheckpointConfig | None = None
 
-    vllm_metrics: VllmMetricsConfig | None = None
+    vllm_metrics: Annotated[
+        bool,
+        Field(description="If true, poll inference endpoints' `/metrics` and log Prometheus metrics to the monitor(s)."),
+    ] = False
 
     # The validation configuration
     val: ValConfig | None = None

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -399,7 +399,7 @@ class VllmMetricsConfig(BaseConfig):
                 "Can create a lot of W&B keys."
             )
         ),
-    ] = False
+    ] = True
 
     max_metrics_per_endpoint: Annotated[
         int,

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -381,11 +381,6 @@ class CheckpointConfig(BaseConfig):
 class VllmMetricsConfig(BaseConfig):
     """Configures polling vLLM `/metrics` and logging to the monitor(s)."""
 
-    enabled: Annotated[
-        bool,
-        Field(description="Whether to poll `/metrics` from each inference endpoint."),
-    ] = True
-
     interval_seconds: Annotated[
         float,
         Field(ge=0.1, description="Minimum time between polls."),

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -378,6 +378,40 @@ class CheckpointConfig(BaseConfig):
     ] = False
 
 
+class VllmMetricsConfig(BaseConfig):
+    """Configures polling vLLM `/metrics` and logging to the monitor(s)."""
+
+    enabled: Annotated[
+        bool,
+        Field(description="Whether to poll `/metrics` from each inference endpoint."),
+    ] = True
+
+    interval_seconds: Annotated[
+        float,
+        Field(ge=0.1, description="Minimum time between polls."),
+    ] = 10.0
+
+    timeout_seconds: Annotated[
+        float,
+        Field(ge=0.1, description="HTTP timeout for `/metrics` requests."),
+    ] = 2.0
+
+    log_all_vllm_metrics: Annotated[
+        bool,
+        Field(
+            description=(
+                "If true, logs many vLLM metrics (prefixed `vllm:`/`vllm_`) in addition to a small curated set. "
+                "Can create a lot of W&B keys."
+            )
+        ),
+    ] = False
+
+    max_metrics_per_endpoint: Annotated[
+        int,
+        Field(ge=1, description="Cap on the number of extra vLLM metric names to log per endpoint."),
+    ] = 250
+
+
 class BufferConfig(BaseConfig):
     """Configures the buffer for the orchestrator."""
 
@@ -516,6 +550,8 @@ class OrchestratorConfig(BaseSettings):
 
     # The checkpoint configuration
     ckpt: CheckpointConfig | None = None
+
+    vllm_metrics: VllmMetricsConfig | None = None
 
     # The validation configuration
     val: ValConfig | None = None

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -114,11 +114,7 @@ async def orchestrate(config: OrchestratorConfig):
         run_config=config,
     )
 
-    vllm_metrics_collector = (
-        VllmMetricsCollector(admin_clients=admin_clients, config=config.vllm_metrics)
-        if config.vllm_metrics is not None
-        else None
-    )
+    vllm_metrics_collector = VllmMetricsCollector(admin_clients=admin_clients) if config.vllm_metrics else None
 
     # Setup heartbeat (only on rank 0, orchestrator is single process)
     heart = None

--- a/src/prime_rl/orchestrator/vllm_metrics.py
+++ b/src/prime_rl/orchestrator/vllm_metrics.py
@@ -4,8 +4,7 @@ from typing import Any
 from urllib.parse import urlparse
 from uuid import uuid4
 
-import httpx
-from httpx import AsyncClient
+from httpx import AsyncClient, Timeout
 
 from prime_rl.orchestrator.config import VllmMetricsConfig
 from prime_rl.utils.logger import get_logger
@@ -138,7 +137,7 @@ class VllmMetricsCollector:
         async def _fetch_one(i: int, client: AsyncClient) -> tuple[str, str | None]:
             endpoint_id = _endpoint_id_from_base_url(str(client.base_url), i)
             try:
-                resp = await client.get("/metrics", timeout=httpx.Timeout(self.config.timeout_seconds))
+                resp = await client.get("/metrics", timeout=Timeout(self.config.timeout_seconds))
                 resp.raise_for_status()
                 return endpoint_id, resp.text
             except Exception as e:

--- a/src/prime_rl/orchestrator/vllm_metrics.py
+++ b/src/prime_rl/orchestrator/vllm_metrics.py
@@ -1,0 +1,241 @@
+import re
+import time
+from typing import Any
+from urllib.parse import urlparse
+from uuid import uuid4
+
+import httpx
+from httpx import AsyncClient
+
+from prime_rl.orchestrator.config import VllmMetricsConfig
+from prime_rl.utils.logger import get_logger
+
+
+_METRIC_LINE_RE = re.compile(
+    r"^(?P<name>[a-zA-Z_:][a-zA-Z0-9_:]*)"
+    r"(?:\{(?P<labels>[^}]*)\})?\s+"
+    r"(?P<value>[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?)"
+    r"(?:\s+(?P<ts>\d+))?\s*$"
+)
+
+
+def parse_prometheus_text(text: str) -> dict[str, list[tuple[dict[str, str], float]]]:
+    """Parse Prometheus exposition format (text) into a dict of metric -> samples.
+
+    Notes:
+    - Ignores comments and HELP/TYPE lines.
+    - Preserves labels as dict[str, str].
+    - Drops timestamps (if present).
+    """
+    out: dict[str, list[tuple[dict[str, str], float]]] = {}
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        m = _METRIC_LINE_RE.match(line)
+        if not m:
+            continue
+
+        name = m.group("name")
+        value = float(m.group("value"))
+        labels_raw = m.group("labels")
+        labels: dict[str, str] = {}
+        if labels_raw:
+            # Very small parser: split on commas not inside quotes (prometheus uses quoted label values).
+            parts: list[str] = []
+            buf = []
+            in_quotes = False
+            esc = False
+            for ch in labels_raw:
+                if esc:
+                    buf.append(ch)
+                    esc = False
+                    continue
+                if ch == "\\":
+                    buf.append(ch)
+                    esc = True
+                    continue
+                if ch == '"':
+                    buf.append(ch)
+                    in_quotes = not in_quotes
+                    continue
+                if ch == "," and not in_quotes:
+                    parts.append("".join(buf).strip())
+                    buf = []
+                    continue
+                buf.append(ch)
+            if buf:
+                parts.append("".join(buf).strip())
+
+            for part in parts:
+                if not part:
+                    continue
+                if "=" not in part:
+                    continue
+                k, v = part.split("=", 1)
+                k = k.strip()
+                v = v.strip()
+                if len(v) >= 2 and v[0] == '"' and v[-1] == '"':
+                    # Keep it simple: unescape common sequences
+                    v = v[1:-1]
+                    v = v.replace(r"\\", "\\").replace(r"\n", "\n").replace(r"\"", '"')
+                labels[k] = v
+
+        out.setdefault(name, []).append((labels, value))
+    return out
+
+
+def _sanitize_wandb_key(s: str) -> str:
+    # W&B supports "/" as a namespace; keep it, but avoid punctuation that creates messy keys.
+    return re.sub(r"[^a-zA-Z0-9/_\-\.]+", "_", s)
+
+
+def _endpoint_id_from_base_url(base_url: str, index: int) -> str:
+    # Prefer host:port-ish stable id; fall back to index.
+    try:
+        p = urlparse(base_url)
+        host = p.hostname or ""
+        port = f":{p.port}" if p.port else ""
+        scheme = p.scheme or "http"
+        if host:
+            return _sanitize_wandb_key(f"{scheme}__{host}{port}")
+    except Exception:
+        pass
+    return f"endpoint_{index}"
+
+
+def _metric_sum(metrics: dict[str, list[tuple[dict[str, str], float]]], name: str) -> float | None:
+    samples = metrics.get(name)
+    if not samples:
+        return None
+    return float(sum(v for _, v in samples))
+
+
+class VllmMetricsCollector:
+    """Poll vLLM `/metrics` from each inference endpoint and return metrics for logging."""
+
+    def __init__(self, admin_clients: list[AsyncClient], config: VllmMetricsConfig):
+        self.admin_clients = admin_clients
+        self.config = config
+        self.logger = get_logger()
+
+        self._last_poll_t = 0.0
+        self._last_token_counters: dict[str, tuple[float, float, float]] = {}
+        # endpoint_id -> (t, prompt_total, gen_total)
+
+        self._collector_id = uuid4().hex[:8]
+
+    async def maybe_collect(self, *, step: int) -> dict[str, Any]:
+        if not self.config.enabled:
+            return {}
+
+        now = time.monotonic()
+        if self._last_poll_t and (now - self._last_poll_t) < self.config.interval_seconds:
+            return {}
+
+        self._last_poll_t = now
+
+        async def _fetch_one(i: int, client: AsyncClient) -> tuple[str, str | None]:
+            endpoint_id = _endpoint_id_from_base_url(str(client.base_url), i)
+            try:
+                resp = await client.get("/metrics", timeout=httpx.Timeout(self.config.timeout_seconds))
+                resp.raise_for_status()
+                return endpoint_id, resp.text
+            except Exception as e:
+                self.logger.debug(f"Failed to fetch /metrics from {client.base_url}: {e}")
+                return endpoint_id, None
+
+        results = await asyncio_gather_safe([_fetch_one(i, c) for i, c in enumerate(self.admin_clients)])
+
+        out: dict[str, Any] = {}
+        for endpoint_id, text in results:
+            prefix = f"vllm/{endpoint_id}"
+            if text is None:
+                out[f"{prefix}/up"] = 0
+                continue
+            out[f"{prefix}/up"] = 1
+
+            metrics = parse_prometheus_text(text)
+
+            # --- tokens/sec (derived from counters) ---
+            prompt_total = (
+                _metric_sum(metrics, "vllm:prompt_tokens_total")
+                or _metric_sum(metrics, "vllm_prompt_tokens_total")
+                or _metric_sum(metrics, "prompt_tokens_total")
+            )
+            gen_total = (
+                _metric_sum(metrics, "vllm:generated_tokens_total")
+                or _metric_sum(metrics, "vllm_generated_tokens_total")
+                or _metric_sum(metrics, "generated_tokens_total")
+            )
+
+            if prompt_total is not None and gen_total is not None:
+                prev = self._last_token_counters.get(endpoint_id)
+                if prev is not None:
+                    prev_t, prev_prompt, prev_gen = prev
+                    dt = max(1e-6, now - prev_t)
+                    out[f"{prefix}/prompt_tokens_per_sec"] = (prompt_total - prev_prompt) / dt
+                    out[f"{prefix}/generated_tokens_per_sec"] = (gen_total - prev_gen) / dt
+                    out[f"{prefix}/tokens_per_sec"] = (prompt_total - prev_prompt + gen_total - prev_gen) / dt
+                self._last_token_counters[endpoint_id] = (now, prompt_total, gen_total)
+
+            # --- kv-cache utilization (best-effort; metric names vary by vLLM version) ---
+            kv_candidates = [
+                "vllm:gpu_kv_cache_usage_percent",
+                "vllm:kv_cache_usage_percent",
+                "vllm:gpu_cache_usage_percent",
+                "vllm:gpu_cache_usage_perc",
+                "vllm_gpu_kv_cache_usage_percent",
+                "vllm_kv_cache_usage_percent",
+                "vllm_gpu_cache_usage_percent",
+            ]
+            kv_val = None
+            for name in kv_candidates:
+                kv_val = _metric_sum(metrics, name)
+                if kv_val is not None:
+                    break
+            if kv_val is not None:
+                out[f"{prefix}/kv_cache_utilization_percent"] = kv_val
+
+            # --- request queue / load signals (commonly present) ---
+            common_gauges = [
+                "vllm:num_requests_running",
+                "vllm:num_requests_waiting",
+                "vllm:gpu_cache_usage_percent",
+                "vllm:cpu_cache_usage_percent",
+            ]
+            for name in common_gauges:
+                v = _metric_sum(metrics, name)
+                if v is not None:
+                    out[f"{prefix}/metrics/{_sanitize_wandb_key(name)}"] = v
+
+            # --- optionally log as many vLLM metrics as possible ---
+            if self.config.log_all_vllm_metrics:
+                emitted = 0
+                for name, samples in metrics.items():
+                    if not (name.startswith("vllm:") or name.startswith("vllm_")):
+                        continue
+                    # Aggregate across labelsets by summing, but expose the number of series too.
+                    out[f"{prefix}/metrics/{_sanitize_wandb_key(name)}"] = float(sum(v for _, v in samples))
+                    out[f"{prefix}/metrics/{_sanitize_wandb_key(name)}__series"] = len(samples)
+                    emitted += 1
+                    if emitted >= self.config.max_metrics_per_endpoint:
+                        out[f"{prefix}/metrics/_truncated"] = 1
+                        out[f"{prefix}/metrics/_max_metrics_per_endpoint"] = self.config.max_metrics_per_endpoint
+                        out[f"{prefix}/metrics/_collector_id"] = self._collector_id
+                        break
+
+            # Always include collector metadata for debugging (cheap).
+            out[f"{prefix}/collector_id"] = self._collector_id
+
+        # Tie to orchestrator step for W&B x-axis consistency.
+        out["step"] = step
+        return out
+
+
+async def asyncio_gather_safe(awaitables: list[Any]) -> list[Any]:
+    """Gather awaitables (no return_exceptions)."""
+    import asyncio
+
+    return await asyncio.gather(*awaitables, return_exceptions=False)
+

--- a/src/prime_rl/orchestrator/vllm_metrics.py
+++ b/src/prime_rl/orchestrator/vllm_metrics.py
@@ -10,7 +10,6 @@ from httpx import AsyncClient, Timeout
 from prime_rl.orchestrator.config import VllmMetricsConfig
 from prime_rl.utils.logger import get_logger
 
-
 _METRIC_LINE_RE = re.compile(
     r"^(?P<name>[a-zA-Z_:][a-zA-Z0-9_:]*)"
     r"(?:\{(?P<labels>[^}]*)\})?\s+"

--- a/src/prime_rl/orchestrator/vllm_metrics.py
+++ b/src/prime_rl/orchestrator/vllm_metrics.py
@@ -1,3 +1,4 @@
+import asyncio
 import re
 import time
 from typing import Any
@@ -234,7 +235,5 @@ class VllmMetricsCollector:
 
 async def asyncio_gather_safe(awaitables: list[Any]) -> list[Any]:
     """Gather awaitables (no return_exceptions)."""
-    import asyncio
-
     return await asyncio.gather(*awaitables, return_exceptions=False)
 

--- a/src/prime_rl/orchestrator/vllm_metrics.py
+++ b/src/prime_rl/orchestrator/vllm_metrics.py
@@ -125,9 +125,6 @@ class VllmMetricsCollector:
         self._collector_id = uuid4().hex[:8]
 
     async def maybe_collect(self, *, step: int) -> dict[str, Any]:
-        if not self.config.enabled:
-            return {}
-
         now = time.monotonic()
         if self._last_poll_t and (now - self._last_poll_t) < self.config.interval_seconds:
             return {}

--- a/src/prime_rl/orchestrator/vllm_metrics.py
+++ b/src/prime_rl/orchestrator/vllm_metrics.py
@@ -5,7 +5,6 @@ from urllib.parse import urlparse
 from uuid import uuid4
 
 from httpx import AsyncClient, Timeout
-
 from prime_rl.orchestrator.config import VllmMetricsConfig
 from prime_rl.utils.logger import get_logger
 

--- a/src/prime_rl/orchestrator/vllm_metrics.py
+++ b/src/prime_rl/orchestrator/vllm_metrics.py
@@ -5,6 +5,7 @@ from urllib.parse import urlparse
 from uuid import uuid4
 
 from httpx import AsyncClient, Timeout
+
 from prime_rl.orchestrator.config import VllmMetricsConfig
 from prime_rl.utils.logger import get_logger
 

--- a/tests/unit/orchestrator/test_vllm_metrics.py
+++ b/tests/unit/orchestrator/test_vllm_metrics.py
@@ -1,0 +1,19 @@
+from prime_rl.orchestrator.vllm_metrics import parse_prometheus_text
+
+
+def test_parse_prometheus_text_parses_counters_and_labels():
+    text = """
+# HELP vllm:generated_tokens_total Total generated tokens
+# TYPE vllm:generated_tokens_total counter
+vllm:generated_tokens_total{model="m",worker="0"} 10
+vllm:generated_tokens_total{model="m",worker="1"} 7
+vllm:prompt_tokens_total 3
+vllm:gpu_kv_cache_usage_percent 42
+"""
+    m = parse_prometheus_text(text)
+
+    assert "vllm:generated_tokens_total" in m
+    assert sum(v for _, v in m["vllm:generated_tokens_total"]) == 17
+    assert m["vllm:prompt_tokens_total"][0][1] == 3
+    assert m["vllm:gpu_kv_cache_usage_percent"][0][1] == 42
+

--- a/tests/unit/orchestrator/test_vllm_metrics.py
+++ b/tests/unit/orchestrator/test_vllm_metrics.py
@@ -1,4 +1,4 @@
-from prime_rl.orchestrator.vllm_metrics import parse_prometheus_text
+from prime_rl.orchestrator.vllm_metrics import parse_prometheus_text_sums
 
 
 def test_parse_prometheus_text_parses_counters_and_labels():
@@ -10,10 +10,10 @@ vllm:generated_tokens_total{model="m",worker="1"} 7
 vllm:prompt_tokens_total 3
 vllm:gpu_kv_cache_usage_percent 42
 """
-    m = parse_prometheus_text(text)
+    sums, series_counts = parse_prometheus_text_sums(text)
 
-    assert "vllm:generated_tokens_total" in m
-    assert sum(v for _, v in m["vllm:generated_tokens_total"]) == 17
-    assert m["vllm:prompt_tokens_total"][0][1] == 3
-    assert m["vllm:gpu_kv_cache_usage_percent"][0][1] == 42
+    assert sums["vllm:generated_tokens_total"] == 17
+    assert series_counts["vllm:generated_tokens_total"] == 2
+    assert sums["vllm:prompt_tokens_total"] == 3
+    assert sums["vllm:gpu_kv_cache_usage_percent"] == 42
 

--- a/tests/unit/orchestrator/test_vllm_metrics.py
+++ b/tests/unit/orchestrator/test_vllm_metrics.py
@@ -10,10 +10,9 @@ vllm:generated_tokens_total{model="m",worker="1"} 7
 vllm:prompt_tokens_total 3
 vllm:gpu_kv_cache_usage_percent 42
 """
-    sums, series_counts = parse_prometheus_text_sums(text)
+    sums = parse_prometheus_text_sums(text)
 
     assert sums["vllm:generated_tokens_total"] == 17
-    assert series_counts["vllm:generated_tokens_total"] == 2
     assert sums["vllm:prompt_tokens_total"] == 3
     assert sums["vllm:gpu_kv_cache_usage_percent"] == 42
 


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Integrates vLLM `/metrics` polling into the orchestrator to log per-endpoint performance (e.g., tokens/sec, KV cache utilization) to W&B. This provides real-time visibility into vLLM server health and performance during orchestration.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: [Issue ID]
**Linear Issue**: Resolves [Issue ID]

---
<a href="https://cursor.com/background-agent?bcId=bc-8b558ee6-a454-4bce-ad2b-c68db0a6ba70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8b558ee6-a454-4bce-ad2b-c68db0a6ba70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

