### PR TITLE
[feat] auto impl selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@ Documenting changes which affect configuration usage patterns (added/moved/remov
 - **`trainer.loss.sequence_clip_high`**: Added sequence-level importance ratio clipping threshold (2025-12-19)
 - **`trainer.loss.geo_mask_high`** and **`trainer.loss.geo_mask_low`**: Added geometric importance ratio masking thresholds (2025-12-19)
 - **`{orchestrator,trainer}.transport.zmq`**: Added ZMQ transport for training batches and micro batches (#1446, 2025-12-22)
+- **`model.impl`**: Changed default from `hf` to `auto`. With `auto`, the implementation automatically selects `custom` if supported for the model, otherwise falls back to `hf` (#1488, 2025-12-27)

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -196,11 +196,11 @@ class ModelConfig(BaseConfig):
     ] = 1
 
     impl: Annotated[
-        Literal["hf", "liger_kernel", "custom"],
+        Literal["hf", "liger_kernel", "custom", "auto"],
         Field(
-            description="Whether to use Liger Kernel.",
+            description="Model implementation to use. 'auto' (default) selects 'custom' if supported by the model, otherwise 'hf'.",
         ),
-    ] = "hf"
+    ] = "auto"
 
     optimization_dtype: Annotated[
         Literal["bfloat16", "float32"],
@@ -248,8 +248,8 @@ class ModelConfig(BaseConfig):
     def trust_remote_code_only_with_hf(self):
         """Trust remote code only if the model is from HF."""
         if self.trust_remote_code:
-            if self.impl != "hf":
-                raise ValueError("Trust remote code is only supported with the HF implementation.")
+            if self.impl not in ("hf", "auto"):
+                raise ValueError("Trust remote code is only supported with the HF implementation or auto mode.")
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/trainer/models/__init__.py
+++ b/src/prime_rl/trainer/models/__init__.py
@@ -3,6 +3,7 @@
 from collections import OrderedDict
 
 from transformers import AutoConfig
+from transformers.configuration_utils import PretrainedConfig
 from transformers.models.auto.auto_factory import _BaseAutoModelClass, _LazyAutoMapping, auto_class_update
 from transformers.models.auto.configuration_auto import CONFIG_MAPPING_NAMES
 from transformers.models.llama.configuration_llama import LlamaConfig
@@ -29,4 +30,16 @@ class AutoModelForCausalLMPrimeRL(_BaseAutoModelClass):
 AutoModelForCausalLMPrimeRL = auto_class_update(AutoModelForCausalLMPrimeRL, head_doc="causal language modeling")
 
 
-__all__ = ["AutoModelForCausalLMPrimeRL", "PreTrainedModelPrimeRL"]
+def supports_custom_impl(model_config: PretrainedConfig) -> bool:
+    """Check if the model configuration supports the custom PrimeRL implementation.
+
+    Args:
+        model_config: The model configuration to check.
+
+    Returns:
+        True if the model supports custom implementation, False otherwise.
+    """
+    return type(model_config) in _CUSTOM_CAUSAL_LM_MAPPING
+
+
+__all__ = ["AutoModelForCausalLMPrimeRL", "PreTrainedModelPrimeRL", "supports_custom_impl"]


### PR DESCRIPTION
A pretty common footgun in the codebase rn is to run the MoE models with HF impl accidentally which causes the code to hang at either model loading or first backward.

This PR makes the default model.impl auto. With auto, we always use the custom impl if we support it, otherwise, we fallback to hf.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes model implementation selection automatic to avoid accidentally using incompatible implementations.
> 
> - **Config**: `model.impl` adds `"auto"` and becomes the default; validator updated to allow `trust_remote_code` with `"hf"` or `"auto"` (`config.py`)
> - **Model loading**: Auto-detects support via `supports_custom_impl` and selects `custom` or `hf` accordingly; logging added; switch uses `impl_to_use` (`model.py`)
> - **Models registry**: Adds `supports_custom_impl(model_config: PretrainedConfig)` to check if custom implementation is available; exports updated (`models/__init__.py`)
> - **Changelog**: Documents the new default and behavior for `model.impl`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51d95061ce1c43b17f0e099f92312cbb3e7ab73f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->