### PR TITLE
Lora weight broadcast removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@ Documenting changes which affect configuration usage patterns (added/moved/remov
 - **`trainer.loss.sequence_clip_high`**: Added sequence-level importance ratio clipping threshold (2025-12-19)
 - **`trainer.loss.geo_mask_high`** and **`trainer.loss.geo_mask_low`**: Added geometric importance ratio masking thresholds (2025-12-19)
 - **`{orchestrator,trainer}.transport.zmq`**: Added ZMQ transport for training batches and micro batches (#1446, 2025-12-22)
+- **`trainer.weight_broadcast.adapter_only`**: Removed. Adapter-only behavior is now automatically derived from the presence of LoRA configuration (2025-12-27)

--- a/configs/ci/integration/rl_lora/resume.toml
+++ b/configs/ci/integration/rl_lora/resume.toml
@@ -19,9 +19,6 @@ rank = 8
 [trainer.ckpt.weights]
 save_adapter_separately = true
 
-[trainer.weight_broadcast]
-adapter_only = true
-
 [orchestrator]
 batch_size = 128
 rollouts_per_example = 16

--- a/configs/ci/integration/rl_lora/start.toml
+++ b/configs/ci/integration/rl_lora/start.toml
@@ -18,9 +18,6 @@ rank = 8
 [trainer.ckpt.weights]
 save_adapter_separately = true
 
-[trainer.weight_broadcast]
-adapter_only = true
-
 [orchestrator]
 batch_size = 128
 rollouts_per_example = 16

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -393,7 +393,6 @@ class RLConfig(BaseSettings):
         if self.trainer.model.lora is not None:
             if self.trainer.weight_broadcast.type == "nccl":
                 raise ValueError("NCCL weight broadcast does not support LoRA yet.")
-            self.trainer.weight_broadcast.adapter_only = True
             if self.orchestrator.lora_name is None:
                 lora_name = f"r{self.trainer.model.lora.rank}-a{self.trainer.model.lora.alpha}"
                 self.orchestrator.lora_name = lora_name

--- a/src/prime_rl/trainer/rl/broadcast/filesystem.py
+++ b/src/prime_rl/trainer/rl/broadcast/filesystem.py
@@ -35,10 +35,11 @@ class FileSystemWeightBroadcast(WeightBroadcast):
             f"Filesystem broadcast initialized (save_format={config.save_format}, save_sharded={self.save_sharded})"
         )
 
-    def broadcast_weights(self, model: nn.Module, step: int, adapter_only: bool = False):
+    def broadcast_weights(self, model: nn.Module, step: int) -> None:
         """Broadcast weights by saving a HF-compatible checkpoint to shared filesystem and notifies the orchestrator."""
         self.logger.debug("Starting broadcasting weights to inference engine via shared filesystem")
         start_time = time.perf_counter()
+        adapter_only = self.lora_config is not None
         if adapter_only:
             state_dict = get_adapter_state_dict(model, is_master=self.world.is_master)
         else:

--- a/src/prime_rl/trainer/rl/broadcast/nccl.py
+++ b/src/prime_rl/trainer/rl/broadcast/nccl.py
@@ -151,10 +151,8 @@ class NCCLWeightBroadcast(WeightBroadcast):
         )
 
     @torch.no_grad()
-    def broadcast_weights(self, model: nn.Module, step: int, adapter_only: bool = False) -> None:
+    def broadcast_weights(self, model: nn.Module, step: int) -> None:
         """Broadcast the state dict of a model into the inference pool using NCCL and notifies the orchestrator."""
-        if adapter_only:
-            raise NotImplementedError("NCCL weight broadcast does not support adapter only yet")
         self.logger.debug("Starting broadcasting weights to inference engine via NCCL")
         start_time = time.perf_counter()
         if self.world.is_master:

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -76,7 +76,7 @@ class DataLoaderConfig(BaseConfig):
 class BaseWeightBroadcastConfig(BaseModel):
     """Configures the base weight broadcast."""
 
-    adapter_only: Annotated[bool, Field(description="Whether to save LoRA adapters only for weight broadcast.")] = False
+    pass
 
 
 class FileSystemWeightBroadcastConfig(BaseWeightBroadcastConfig):
@@ -237,11 +237,7 @@ class RLTrainerConfig(BaseSettings):
 
     @model_validator(mode="after")
     def validate_lora_broadcast(self):
-        if self.model.lora is not None:
-            self.weight_broadcast.adapter_only = True
-        if self.weight_broadcast.adapter_only and not self.model.lora:
-            raise ValueError("Adapter only weight broadcast requires LoRA to be enabled.")
-        if self.weight_broadcast.type == "nccl" and self.weight_broadcast.adapter_only:
+        if self.model.lora is not None and self.weight_broadcast.type == "nccl":
             # TODO: Support this
             raise ValueError("NCCL weight broadcast does not support LoRA yet.")
         return self

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -172,9 +172,7 @@ def train(config: RLTrainerConfig):
         last_async_level_steps = config.max_steps and progress.step >= config.max_steps - config.max_async_level
         if progress.step > 0 and (not last_async_level_steps or config.weight_broadcast.type == "filesystem"):
             broadcast_weights_start_time = time.perf_counter()
-            weight_broadcast.broadcast_weights(
-                model, step=progress.step, adapter_only=config.weight_broadcast.adapter_only
-            )
+            weight_broadcast.broadcast_weights(model, step=progress.step)
             broadcast_weights_time = time.perf_counter() - broadcast_weights_start_time
             # Clean up old broadcast directories (unless at ckpt interval if using filesystem weight broadcast)
             ckpt_interval = config.ckpt and config.ckpt.interval


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Removes the `weight_broadcast.adapter_only` configuration option. This flag was redundant as it was always enabled when LoRA was used. The `adapter_only` behavior is now implicitly determined by the presence of a LoRA configuration, simplifying the codebase.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: [Issue ID]
**Linear Issue**: Resolves [Issue ID]

---
<a href="https://cursor.com/background-agent?bcId=bc-ebfcb095-4214-4193-9925-27e71f2d9121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ebfcb095-4214-4193-9925-27e71f2d9121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies LoRA weight broadcasting by removing explicit `adapter_only` config and deriving behavior from the presence of `model.lora`.
> 
> - Removes `trainer.weight_broadcast.adapter_only` and its validators; NCCL still rejects LoRA
> - Updates `broadcast_weights(model, step)` API in `trainer/rl/broadcast/{filesystem,nccl}.py` and callers (no `adapter_only` arg)
> - Filesystem broadcast now auto-saves adapters only when `lora_config` is set; NCCL path unchanged aside from signature
> - Cleans CI configs (`configs/ci/integration/rl_lora/{start,resume}.toml`) by deleting `[trainer.weight_broadcast]` block
> - Adds changelog entry documenting removal and implicit behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b2c3cbf7db6f3e107f2fa2c5e629633beef2b56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->