### PR TITLE
Nccl broadcast synchronization

### DIFF
--- a/configs/ci/integration/rl_lora/resume.toml
+++ b/configs/ci/integration/rl_lora/resume.toml
@@ -19,9 +19,6 @@ rank = 8
 [trainer.ckpt.weights]
 save_adapter_separately = true
 
-[trainer.weight_broadcast]
-adapter_only = true
-
 [orchestrator]
 batch_size = 128
 rollouts_per_example = 16

--- a/configs/ci/integration/rl_lora/start.toml
+++ b/configs/ci/integration/rl_lora/start.toml
@@ -18,9 +18,6 @@ rank = 8
 [trainer.ckpt.weights]
 save_adapter_separately = true
 
-[trainer.weight_broadcast]
-adapter_only = true
-
 [orchestrator]
 batch_size = 128
 rollouts_per_example = 16

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -393,7 +393,6 @@ class RLConfig(BaseSettings):
         if self.trainer.model.lora is not None:
             if self.trainer.weight_broadcast.type == "nccl":
                 raise ValueError("NCCL weight broadcast does not support LoRA yet.")
-            self.trainer.weight_broadcast.adapter_only = True
             if self.orchestrator.lora_name is None:
                 lora_name = f"r{self.trainer.model.lora.rank}-a{self.trainer.model.lora.alpha}"
                 self.orchestrator.lora_name = lora_name

--- a/src/prime_rl/trainer/rl/broadcast/filesystem.py
+++ b/src/prime_rl/trainer/rl/broadcast/filesystem.py
@@ -35,10 +35,11 @@ class FileSystemWeightBroadcast(WeightBroadcast):
             f"Filesystem broadcast initialized (save_format={config.save_format}, save_sharded={self.save_sharded})"
         )
 
-    def broadcast_weights(self, model: nn.Module, step: int, adapter_only: bool = False):
+    def broadcast_weights(self, model: nn.Module, step: int) -> None:
         """Broadcast weights by saving a HF-compatible checkpoint to shared filesystem and notifies the orchestrator."""
         self.logger.debug("Starting broadcasting weights to inference engine via shared filesystem")
         start_time = time.perf_counter()
+        adapter_only = self.lora_config is not None
         if adapter_only:
             state_dict = get_adapter_state_dict(model, is_master=self.world.is_master)
         else:

--- a/src/prime_rl/trainer/rl/broadcast/nccl.py
+++ b/src/prime_rl/trainer/rl/broadcast/nccl.py
@@ -173,10 +173,10 @@ class NCCLWeightBroadcast(WeightBroadcast):
         )
 
     @torch.no_grad()
-    def broadcast_weights(self, model: nn.Module, step: int, adapter_only: bool = False) -> None:
+    def broadcast_weights(self, model: nn.Module, step: int) -> None:
         """Broadcast the state dict of a model into the inference pool using NCCL and notifies the orchestrator."""
-        if adapter_only:
-            raise NotImplementedError("NCCL weight broadcast does not support adapter only yet")
+        if self.lora_config is not None:
+            raise NotImplementedError("NCCL weight broadcast does not support LoRA yet")
 
         # Only broadcast when at least one run has requested an update.
         # (Otherwise we'd enter NCCL collectives without receivers.)

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -75,8 +75,7 @@ class DataLoaderConfig(BaseConfig):
 
 class BaseWeightBroadcastConfig(BaseModel):
     """Configures the base weight broadcast."""
-
-    adapter_only: Annotated[bool, Field(description="Whether to save LoRA adapters only for weight broadcast.")] = False
+    pass
 
 
 class FileSystemWeightBroadcastConfig(BaseWeightBroadcastConfig):
@@ -237,11 +236,7 @@ class RLTrainerConfig(BaseSettings):
 
     @model_validator(mode="after")
     def validate_lora_broadcast(self):
-        if self.model.lora is not None:
-            self.weight_broadcast.adapter_only = True
-        if self.weight_broadcast.adapter_only and not self.model.lora:
-            raise ValueError("Adapter only weight broadcast requires LoRA to be enabled.")
-        if self.weight_broadcast.type == "nccl" and self.weight_broadcast.adapter_only:
+        if self.model.lora is not None and self.weight_broadcast.type == "nccl":
             # TODO: Support this
             raise ValueError("NCCL weight broadcast does not support LoRA yet.")
         return self

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -23,22 +23,32 @@ class LossConfig(BaseConfig):
     ratio_type: Annotated[Literal["token", "sequence"], Field(description="Type of importance ratio to use.")] = "token"
 
     token_mask_high: Annotated[
-        float, 
-        Field(ge=0, description="The high threshold for token importance ratio to mask.")] = 8.0 
+        float, Field(ge=0, description="The high threshold for token importance ratio to mask.")
+    ] = 8.0
     token_mask_low: Annotated[
-        float, 
-        Field(ge=0, description="The low threshold for token importance ratio to mask.")] = 0.125
-    sequence_clip_high: Annotated[float, Field(ge=0, description="The high threshold for sequence importance ratio to clip.")] = 10.0
-    geo_mask_high: Annotated[float, Field(ge=0, description="The high threshold for geo importance ratio to mask.")] = 10.0
+        float, Field(ge=0, description="The low threshold for token importance ratio to mask.")
+    ] = 0.125
+    sequence_clip_high: Annotated[
+        float, Field(ge=0, description="The high threshold for sequence importance ratio to clip.")
+    ] = 10.0
+    geo_mask_high: Annotated[float, Field(ge=0, description="The high threshold for geo importance ratio to mask.")] = (
+        10.0
+    )
     geo_mask_low: Annotated[float, Field(ge=0, description="The low threshold for geo importance ratio to mask.")] = 0.1
     kl_tau: Annotated[float, Field(ge=0, description="The tau for KL divergence.")] = 0.0
     sequence_mask_low: Annotated[
         float,
-        Field(ge=0, description="If set, masks entire sequences when any generated token has an importance ratio below this value."),
+        Field(
+            ge=0,
+            description="If set, masks entire sequences when any generated token has an importance ratio below this value.",
+        ),
     ] = 0.0
     sequence_mask_high: Annotated[
         float,
-        Field(ge=0, description="If set, masks entire sequences when any generated token has an importance ratio above this value."),
+        Field(
+            ge=0,
+            description="If set, masks entire sequences when any generated token has an importance ratio above this value.",
+        ),
     ] = 100.0
 
     @model_validator(mode="after")
@@ -188,7 +198,7 @@ class RLTrainerConfig(BaseSettings):
             ge=1,
             description="The maximum number of concurrent runs to allow. If 1, then only one run will be allowed at a time.",
         ),
-    ] = 4
+    ] = 1
 
     @model_validator(mode="after")
     def auto_setup_bench(self):

--- a/src/prime_rl/trainer/rl/data.py
+++ b/src/prime_rl/trainer/rl/data.py
@@ -8,6 +8,7 @@ from transformers.tokenization_utils import PreTrainedTokenizer
 
 from prime_rl.trainer.rl.config import FakeDataLoaderConfig
 from prime_rl.trainer.rl.packer import Packer
+from prime_rl.trainer.runs import get_runs
 from prime_rl.trainer.world import get_world
 from prime_rl.transport import MicroBatch, MicroBatchReceiver, TransportConfigType, setup_micro_batch_receiver
 
@@ -24,10 +25,15 @@ class TensorMicroBatch(TypedDict):
 
     # Batch level
     temperature: float
+    lora_num_tokens: Int[Tensor, "n_loras"]
 
 
 def micro_batch_to_tensor(micro_batch: MicroBatch) -> TensorMicroBatch:
     """Convert a MicroBatch (msgspec struct with lists) to a TensorMicroBatch (dict with tensors)."""
+    runs = get_runs()
+    if micro_batch.lora_num_tokens is None:
+        micro_batch.lora_num_tokens = [0] * runs.max_runs
+        micro_batch.lora_num_tokens[0] = len(micro_batch.input_ids)
     return TensorMicroBatch(
         input_ids=torch.tensor(micro_batch.input_ids, dtype=torch.long).unsqueeze(0),
         position_ids=torch.tensor(micro_batch.position_ids, dtype=torch.long).unsqueeze(0),
@@ -35,12 +41,14 @@ def micro_batch_to_tensor(micro_batch: MicroBatch) -> TensorMicroBatch:
         inference_logprobs=torch.tensor(micro_batch.inference_logprobs, dtype=torch.float).unsqueeze(0),
         loss_mask=torch.tensor(micro_batch.loss_mask, dtype=torch.bool).unsqueeze(0),
         temperature=micro_batch.temperature if micro_batch.temperature is not None else 1.0,
+        lora_num_tokens=torch.tensor(micro_batch.lora_num_tokens, dtype=torch.int32),
     )
 
 
 class FakeDataLoader:
     def __init__(self, config: FakeDataLoaderConfig, seq_len: int, dp_world_size: int):
         self.world = get_world()
+        self.runs = get_runs()
         self.dp_world_size = dp_world_size
         self.non_dp_world_size = self.world.world_size // self.dp_world_size
         self.dp_rank = self.world.rank // self.non_dp_world_size
@@ -92,6 +100,8 @@ class FakeDataLoader:
         loss_mask = torch.ones(input_ids.shape[0], dtype=torch.bool)
         advantages = torch.randn(input_ids.shape[0], generator=generator)
         inference_logprobs = torch.randn(input_ids.shape[0], generator=generator)
+        lora_num_tokens = torch.zeros(self.runs.max_runs, dtype=torch.int32)
+        lora_num_tokens[0] = input_ids.shape[0]
 
         return {
             "input_ids": input_ids.unsqueeze(0),
@@ -100,9 +110,12 @@ class FakeDataLoader:
             "inference_logprobs": inference_logprobs.unsqueeze(0),
             "temperature": 1.0,
             "loss_mask": loss_mask.unsqueeze(0),
+            "lora_num_tokens": lora_num_tokens,
         }
 
     def _get_micro_batch(self, generator: torch.Generator) -> TensorMicroBatch:
+        lora_num_tokens = torch.zeros(self.runs.max_runs, dtype=torch.int32)
+        lora_num_tokens[0] = self.seq_len
         return {
             "input_ids": torch.randint(
                 0,
@@ -118,6 +131,7 @@ class FakeDataLoader:
             "inference_logprobs": torch.randn(self.seq_len, generator=generator).unsqueeze(0),
             "temperature": 1.0,
             "loss_mask": torch.ones(self.seq_len, dtype=torch.bool).unsqueeze(0),
+            "lora_num_tokens": lora_num_tokens,
         }
 
 
@@ -148,6 +162,7 @@ class DataLoader:
 
         non_dp_world_size = self.world.world_size // dp_world_size
         dp_rank = self.world.rank // non_dp_world_size
+        self.runs = get_runs()
 
         self.receiver: MicroBatchReceiver = setup_micro_batch_receiver(output_dir, dp_rank, start_step, config)
 
@@ -155,6 +170,7 @@ class DataLoader:
         if self.world.is_master:
             self.packer.pack()
         self.receiver.wait()
+        self.runs.sync_runs()
 
     def get_batch(self) -> list[TensorMicroBatch]:
         micro_batches = self.receiver.receive()

--- a/src/prime_rl/trainer/rl/packer.py
+++ b/src/prime_rl/trainer/rl/packer.py
@@ -61,6 +61,7 @@ class Packer:
             return False
 
     def pack(self):
+        assert all(not i for i in self.runs.ready_to_update), "No runs should be ready to update at start of pack."
         training_batches: dict[int, TrainingBatch] = self.get_batch()
         start_time = time.time()
         while not self.has_enough_tokens(training_batches):
@@ -90,7 +91,8 @@ class Packer:
             seq_len=self.seq_len,
             pad_to_multiple_of=self.pad_to_multiple_of,
             num_train_workers=self.dp_world_size,
-            # idxs=train_idxs, # Needed for lora later
+            idxs=train_idxs,
+            num_loras=self.runs.max_runs,
         )
 
         self.sender.send(micro_batch_grid)

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -172,9 +172,7 @@ def train(config: RLTrainerConfig):
         last_async_level_steps = config.max_steps and progress.step >= config.max_steps - config.max_async_level
         if progress.step > 0 and (not last_async_level_steps or config.weight_broadcast.type == "filesystem"):
             broadcast_weights_start_time = time.perf_counter()
-            weight_broadcast.broadcast_weights(
-                model, step=progress.step, adapter_only=config.weight_broadcast.adapter_only
-            )
+            weight_broadcast.broadcast_weights(model, step=progress.step)
             broadcast_weights_time = time.perf_counter() - broadcast_weights_start_time
             # Clean up old broadcast directories (unless at ckpt interval if using filesystem weight broadcast)
             ckpt_interval = config.ckpt and config.ckpt.interval

--- a/src/prime_rl/trainer/runs.py
+++ b/src/prime_rl/trainer/runs.py
@@ -1,13 +1,19 @@
+import pickle
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Optional
 
 import tomli
+import torch
+import torch.distributed as dist
+import torch.distributed.distributed_c10d as c10d
 
+from prime_rl.trainer.world import get_world
 from prime_rl.utils.logger import get_logger
 
 if TYPE_CHECKING:
     from prime_rl.orchestrator.config import OrchestratorConfig
+    from prime_rl.trainer.models.layers.lora import MultiLoRALinear
 
 
 @dataclass
@@ -33,8 +39,16 @@ class Runs:
         self.config: dict[int, "OrchestratorConfig"] = {}
         self.ready_to_update = [False] * max_runs
 
-        self._deletion_hooks: list[Callable[[int, str], None]] = []
         self._creation_hooks: list[Callable[[int, str], None]] = []
+
+        # We use the store to keep other ranks in sync with master
+        self.store = c10d._get_default_store()
+        self.world = get_world()
+        # Track id_2_idx state at last sync_runs to calculate diffs
+        self._last_synced_id_2_idx: dict[str, int] = {}
+
+        # Store modules with their FQN prefixes for parameter management
+        self._modules: list[tuple[str, "MultiLoRALinear"]] = []
 
     def get_orchestrator_config(self, run_id: str) -> Optional["OrchestratorConfig"]:
         # Load orchestrator config first to validate it
@@ -76,27 +90,53 @@ class Runs:
 
         return config
 
+    def _delete_run_data(self, deleted_run: str, deleted_idx: int) -> None:
+        """Update data structures for a deleted run"""
+        del self.progress[deleted_idx]
+        if deleted_idx in self.config:
+            del self.config[deleted_idx]
+
+        # Process mappings
+        self.unused_idxs.add(deleted_idx)
+        del self.idx_2_id[deleted_idx]
+        del self.id_2_idx[deleted_run]
+
+    def _create_run_data(self, new_run: str, new_id: int, config: "OrchestratorConfig") -> None:
+        """Update data structures for a new run (no hooks or param reset)."""
+        self.id_2_idx[new_run] = new_id
+        self.unused_idxs.remove(new_id)
+        self.idx_2_id[new_id] = new_run
+
+        # Get progress
+        self.progress[new_id] = Progress()
+
+        prev_ckpt_steps = [
+            int(i.stem.split("_")[-1]) for i in (self.get_run_dir(new_id) / "checkpoints").glob("step_*")
+        ]
+        self.progress[new_id].step = max(prev_ckpt_steps) if prev_ckpt_steps else 0
+
+        # Store the parsed config
+        self.config[new_id] = config
+
+    def _create_run_hooks(self, new_id: int, new_run: str) -> None:
+        """Reset parameters and call creation hooks for a run."""
+        self.reset_run_parameters(new_id)
+        for hook in self._creation_hooks:
+            hook(new_id, new_run)
+
     def check_for_changes(self) -> None:
+        """Detect run changes and update data structures. Must be followed by sync_runs().
+
+        Only updates mappings and data structures. Hooks and parameter resets
+        are deferred to sync_runs() so all ranks execute them together.
+        """
         run_ids = {run_path.stem for run_path in self.output_dir.glob("run_*")}
         deleted_runs = self.id_2_idx.keys() - run_ids
         new_runs = run_ids - self.id_2_idx.keys()
 
         for deleted_run in deleted_runs:
             deleted_idx = self.id_2_idx[deleted_run]
-
-            # Call deletion hooks
-            for hook in self._deletion_hooks:
-                hook(deleted_idx, deleted_run)
-
-            del self.progress[deleted_idx]
-            if deleted_idx in self.config:
-                del self.config[deleted_idx]
-            self.ready_to_update[deleted_idx] = False
-
-            # Process mappings
-            self.unused_idxs.add(deleted_idx)
-            del self.idx_2_id[deleted_idx]
-            del self.id_2_idx[deleted_run]
+            self._delete_run_data(deleted_run, deleted_idx)
 
         for new_run in new_runs:
             try:
@@ -107,46 +147,69 @@ class Runs:
                 if config is None:
                     continue
 
-                # Now that config is valid, proceed with run setup
-                self.id_2_idx[new_run] = new_id
-                self.unused_idxs.remove(new_id)
-                self.idx_2_id[new_id] = new_run
-
-                # Get progress
-                self.progress[new_id] = Progress()
-
-                prev_ckpt_steps = [
-                    int(i.stem.split("_")[-1]) for i in (self.get_run_dir(new_id) / "checkpoints").glob("step_*")
-                ]
-                self.progress[new_id].step = max(prev_ckpt_steps) if prev_ckpt_steps else 0
-
-                # Store the parsed config
-                self.config[new_id] = config
-
-                # Call creation hooks
-                for hook in self._creation_hooks:
-                    hook(new_id, new_run)
+                self._create_run_data(new_run, new_id, config)
             except StopIteration:
                 continue
 
+    def sync_runs(self) -> None:
+        """Sync run state across ranks and execute hooks.
+
+        Master calculates what changed since last sync using _last_synced_id_2_idx.
+        This matches what non-master ranks will calculate as new/deleted runs.
+        All ranks then execute hooks and parameter resets together.
+        """
+
+        if self.world.is_master:
+            sync_data = {
+                "id_2_idx": self.id_2_idx,
+                "ready_to_update": self.ready_to_update,
+            }
+            self.store.set("runs", pickle.dumps(sync_data))
+        dist.barrier()
+
+        if self.world.is_master:
+            # Calculate changes since last sync (this is what other ranks will see)
+            new_runs = self.id_2_idx.keys() - self._last_synced_id_2_idx.keys()
+            deleted_runs = self._last_synced_id_2_idx.keys() - self.id_2_idx.keys()
+        else:
+            sync_data: dict = pickle.loads(self.store.get("runs"))
+            new_id_2_idx: dict[str, int] = sync_data["id_2_idx"]
+            self.ready_to_update = sync_data["ready_to_update"]
+
+            new_runs = new_id_2_idx.keys() - self.id_2_idx.keys()
+            deleted_runs = self.id_2_idx.keys() - new_id_2_idx.keys()
+
+            # Other ranks catch up with master's data state
+            for deleted_run in deleted_runs:
+                deleted_idx = self.id_2_idx[deleted_run]
+                self._delete_run_data(deleted_run, deleted_idx)
+
+            for new_run in new_runs:
+                new_id = new_id_2_idx[new_run]
+                config = {}  # The other ranks dont need them for now
+                self._create_run_data(new_run, new_id, config)  # type: ignore[arg-type]
+
+        for new_run in new_runs:
+            new_id = self.id_2_idx[new_run]
+            self._create_run_hooks(new_id, new_run)
+
+        # Update last synced state for master
+        if self.world.is_master:
+            self._last_synced_id_2_idx = self.id_2_idx.copy()
+
     @property
     def used_idxs(self):
-        return self.idx_2_id.keys()
+        return sorted(self.idx_2_id.keys())
+
+    @property
+    def ready_to_update_idxs(self):
+        return [idx for idx, ready in enumerate(self.ready_to_update) if ready]
 
     def run_dirs(self) -> list[Path]:
         return [self.output_dir / run_id for run_id in self.id_2_idx.keys()]
 
     def get_run_dir(self, idx: int) -> Path:
         return self.output_dir / self.idx_2_id[idx]
-
-    def register_deletion_hook(self, hook: Callable[[int, str], None]) -> None:
-        """Register a hook to be called when a run is deleted.
-
-        Args:
-            hook: A callable that takes (idx: int, run_id: str) as arguments.
-                  Called when a run is deleted from the system.
-        """
-        self._deletion_hooks.append(hook)
 
     def register_creation_hook(self, hook: Callable[[int, str], None]) -> None:
         """Register a hook to be called when a new run is created.
@@ -156,6 +219,56 @@ class Runs:
                   Called when a new run is added to the system.
         """
         self._creation_hooks.append(hook)
+
+    def register_module(self, prefix: str, module: "MultiLoRALinear") -> None:
+        """Register a MultiLoRALinear module with its FQN prefix.
+
+        This allows Runs to manage parameter access, reset, and state dict slicing
+        for multi-adapter LoRA modules.
+
+        Args:
+            prefix: The module's fully qualified name in the model
+                   (e.g., "model.layers.0.self_attn.q_proj")
+            module: The MultiLoRALinear module to register
+        """
+        self._modules.append((prefix, module))
+
+    def get_named_parameters_for_run(self, idx: int) -> list[tuple[str, torch.nn.Parameter]]:
+        """Get named parameters for a specific run index.
+
+        Args:
+            idx: The run index to get parameters for
+
+        Returns:
+            List of (name, parameter) tuples for the specified run index
+        """
+        params = []
+        for prefix, module in self._modules:
+            for name, param in module.named_parameters_for_adapter(idx):
+                params.append((f"{prefix}.{name}.weight", param))
+        return params
+
+    def get_state_dict_for_run(self, idx: int) -> dict[str, torch.Tensor]:
+        """Get state dict for a specific run index.
+
+        Args:
+            idx: The run index to get state dict for
+
+        Returns:
+            State dict for the specified run index
+        """
+        return {name: param.detach() for name, param in self.get_named_parameters_for_run(idx)}
+
+    def reset_run_parameters(self, idx: int) -> None:
+        """Reset parameters for a specific run index.
+
+        Called when a new run is created to initialize fresh adapter weights.
+
+        Args:
+            idx: The run index to reset parameters for
+        """
+        for _, module in self._modules:
+            module.reset_parameters(idx)
 
     def __repr__(self):
         return f"Runs(max={self.max_runs})[{self.idx_2_id.keys()}]"


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Introduces a file-based handshake (`NCCL_READY` marker) to prevent NCCL broadcast timeouts. The orchestrator now signals readiness before inference workers enter the receive path, and the trainer waits for this signal before initiating NCCL broadcasts.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: [Issue ID]
**Linear Issue**: Resolves [Issue ID]

---
<a href="https://cursor.com/background-agent?bcId=bc-2a6c1c52-a4bb-4c5b-930b-921a56c16642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2a6c1c52-a4bb-4c5b-930b-921a56c16642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements a safer NCCL broadcast flow and refactors multi-run/LoRA integration.
> 
> - **NCCL handshake**: Orchestrator writes `NCCL_READY` before `/update_weights`; trainer waits for this per-run marker (with timeout) and only broadcasts when runs requested updates. `_notify_orchestrator` now returns notified runs; skips broadcast if none.
> - **Weight broadcast refactor**: Remove `adapter_only` flag; filesystem path infers adapter-only when LoRA is enabled and saves per-run adapter weights via `Runs.get_state_dict_for_run` (handles `DTensor`), plus `save_lora_config`. NCCL path now guarded by readiness and request checks. Unified `broadcast_weights(model, step)` signature; trainer calls updated API.
> - **Runs synchronization**: Add store/barrier–based `sync_runs()` to propagate run mappings and `ready_to_update` across ranks; execute creation hooks and reset per-run parameters; expose `used_idxs` (sorted) and `ready_to_update_idxs` helpers; add per-run param/state helpers for MultiLoRA.
> - **Batching/data**: Packer asserts clean update flags, sets `idxs` and `num_loras`; DataLoader syncs runs each batch; micro-batches carry `lora_num_tokens`; FakeDataLoader populates it.
> - **Configs**: Remove `[trainer.weight_broadcast].adapter_only` from CI configs; default `max_concurrent_runs` to `1`; minor config formatting tidy-ups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a251971d008a20141dd78f9089004167aaebff0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->