### PR TITLE
Chunked loprob calculation to save memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@ Documenting changes which affect configuration usage patterns (added/moved/remov
 - **`{orchestrator,trainer}.transport.zmq`**: Added ZMQ transport for training batches and micro batches (#1446, 2025-12-22)
 - **`model.impl`**: Changed default from `hf` to `auto`. With `auto`, the implementation automatically selects `custom` if supported for the model, otherwise falls back to `hf` (#1488, 2025-12-27)
 - **`trainer.weight_broadcast.adapter_only`**: Removed. Adapter-only behavior is now automatically derived from the presence of LoRA configuration (2025-12-27)
+- **`trainer.logprob_chunk_size`**: Added chunked log probability computation from logits to reduce peak memory usage (2025-12-27)

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -191,6 +191,11 @@ class RLTrainerConfig(BaseSettings):
         ),
     ] = 4
 
+    logprob_chunk_size: Annotated[
+        int,
+        Field(description="Chunk size for computing log probabilities from logits."),
+    ] = -1
+
     @model_validator(mode="after")
     def auto_setup_bench(self):
         if self.bench:

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -24,7 +24,7 @@ from prime_rl.utils.cp import (
 from prime_rl.utils.logger import setup_logger
 from prime_rl.trainer.rl.loss import (
     shift_logits,
-    selective_log_softmax,
+    chunked_selective_log_softmax,
     compute_entropy,
     compute_loss,
 )
@@ -279,7 +279,7 @@ def train(config: RLTrainerConfig):
 
             shifted_logits = shift_logits(logits, left_pad_logit=left_pad_logit)
             shifted_logits = shifted_logits / temperature
-            trainer_logprobs = selective_log_softmax(shifted_logits, input_ids)
+            trainer_logprobs = chunked_selective_log_softmax(shifted_logits, input_ids, config.logprob_chunk_size)
 
             if cp_enabled:
                 trainer_logprobs = dist_nn.all_gather(trainer_logprobs, group=cp_group)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces chunked computation of token log probabilities to lower peak memory in RL training.
> 
> - New `trainer.logprob_chunk_size` config controls chunk size for logprob computation (default `-1` disables)
> - Adds `chunked_selective_log_softmax` in `loss.py` and uses it in `train.py` in place of `selective_log_softmax`
> - Updates `CHANGELOG.md` documenting the new config and behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11e42bedbd275fe4bb071af86bc0111b2d2dcc86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->