### PR TITLE
Claude/fix multi lora comments 3 nbx k

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@ Documenting changes which affect configuration usage patterns (added/moved/remov
 - **`{orchestrator,trainer}.transport.zmq`**: Added ZMQ transport for training batches and micro batches (#1446, 2025-12-22)
 - **`model.impl`**: Changed default from `hf` to `auto`. With `auto`, the implementation automatically selects `custom` if supported for the model, otherwise falls back to `hf` (#1488, 2025-12-27)
 - **`trainer.weight_broadcast.adapter_only`**: Removed. Adapter-only behavior is now automatically derived from the presence of LoRA configuration (2025-12-27)
+- **`trainer.max_concurrent_runs`**: Changed default from 4 to 1 (#1433, 2025-12-28)

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -40,8 +40,10 @@ def setup_optimizer(
                     return False
                 return True
 
-            muon_params = [p for n, p in named_params if p.requires_grad and muon_enabled(n, p)]
-            adamw_params = [p for n, p in named_params if p.requires_grad and not muon_enabled(n, p)]
+            # Convert to list to allow multiple iterations (in case named_params is a generator)
+            named_params_list = list(named_params)
+            muon_params = [p for n, p in named_params_list if p.requires_grad and muon_enabled(n, p)]
+            adamw_params = [p for n, p in named_params_list if p.requires_grad and not muon_enabled(n, p)]
 
             optimizer = Muon(
                 [


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

I was too lazy to explain my changes, decreasing my chances of this ever getting merged.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: [Issue ID]
**Linear Issue**: Resolves [Issue ID]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Optimizer robustness**
> 
> - In `optim.py`, materializes `named_params` to a list before splitting into Muon vs AdamW groups to support generator inputs and avoid multiple-iteration issues.
> 
> **Changelog update**
> 
> - Notes `trainer.max_concurrent_runs` default changed from 4 to 1.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c24e73a8c25c0ae9b04f64c4461c356fa685ee1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->