### PR TITLE
log env id to wandb samples table

### DIFF
--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -56,7 +56,7 @@ class WandbMonitor(Monitor):
         if config is not None and isinstance(config, WandbWithExtrasConfig) and config.log_extras:
             if config.log_extras.samples:
                 self.last_log_samples_step = -1
-                self.samples_cols = ["step", "example_id", "messages", "input_ids", "reward"]
+                self.samples_cols = ["step", "task", "example_id", "messages", "input_ids", "reward"]
                 self.samples_table = wandb.Table(
                     columns=self.samples_cols,
                     log_mode="INCREMENTAL",
@@ -110,6 +110,7 @@ class WandbMonitor(Monitor):
             messages_text = self.tokenizer.decode(full_ids)
             sample = {
                 "step": step,
+                "task": rollout.get("task"),
                 "example_id": rollout["example_id"],
                 "messages": messages_text,
                 "input_ids": str(full_ids),


### PR DESCRIPTION
log env id to wandb samples table for multi environment training

example:
<img width="2116" height="618" alt="Screenshot 2025-12-28 at 03 11 38" src="https://github.com/user-attachments/assets/629d4b35-bc48-4f59-a1f0-958eec9ea44a" />

`rl.toml`:
```
max_steps = 20
seq_len = 2048

[model]
name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"

[wandb]
project = "reverse-text"
name = "multi-env-reverse-text"

[orchestrator]
batch_size = 128
rollouts_per_example = 16

[orchestrator.sampling]
max_tokens = 128

[[orchestrator.env]]
id = "reverse-text"

[[orchestrator.env]]
id = "chinese-reverse-text"

[trainer.optim]
lr = 3e-6

[inference]
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds per-sample task/env identification to W&B logging for multi-environment runs.
> 
> - Extends `WandbMonitor` samples schema to include `task` in `samples_cols`
> - Populates `task` from `rollout.get("task")` when building samples and logs it to the W&B table (`src/prime_rl/utils/monitor/wandb.py`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f19c55aa0fdd47a4efd9efab13be0217ee2b89f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->