### PR TITLE
Sft with lora test

### DIFF
--- a/configs/ci/integration/sft_lora/resume.toml
+++ b/configs/ci/integration/sft_lora/resume.toml
@@ -1,0 +1,18 @@
+max_steps = 20
+
+[ckpt]
+resume_step = 10
+
+[model]
+name = "PrimeIntellect/Qwen3-0.6B"
+
+[model.lora]
+rank = 8
+
+[ckpt.weights]
+save_adapter_separately = true
+
+[data]
+name = "PrimeIntellect/Reverse-Text-SFT"
+batch_size = 4
+seq_len = 1024

--- a/configs/ci/integration/sft_lora/resume.toml
+++ b/configs/ci/integration/sft_lora/resume.toml
@@ -12,6 +12,9 @@ rank = 8
 [ckpt.weights]
 save_adapter_separately = true
 
+[optim]
+lr = 1e-4
+
 [data]
 name = "PrimeIntellect/Reverse-Text-SFT"
 batch_size = 4

--- a/configs/ci/integration/sft_lora/start.toml
+++ b/configs/ci/integration/sft_lora/start.toml
@@ -11,6 +11,9 @@ rank = 8
 [ckpt.weights]
 save_adapter_separately = true
 
+[optim]
+lr = 1e-4
+
 [data]
 name = "PrimeIntellect/Reverse-Text-SFT"
 batch_size = 4

--- a/configs/ci/integration/sft_lora/start.toml
+++ b/configs/ci/integration/sft_lora/start.toml
@@ -1,0 +1,17 @@
+max_steps = 10
+
+[ckpt]
+
+[model]
+name = "PrimeIntellect/Qwen3-0.6B"
+
+[model.lora]
+rank = 8
+
+[ckpt.weights]
+save_adapter_separately = true
+
+[data]
+name = "PrimeIntellect/Reverse-Text-SFT"
+batch_size = 4
+seq_len = 1024

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -119,7 +119,12 @@ def train(config: SFTTrainerConfig):
 
     # Set up the optimizer
     logger.info(f"Initializing optimizer ({config.optim})")
-    optimizer = setup_optimizer(config.optim, list(model.named_parameters()), parallel_dims.world_mesh["dp_shard_cp"])
+    optimizer = setup_optimizer(
+        config.optim,
+        list(model.named_parameters()),
+        parallel_dims.world_mesh["dp_shard_cp"],
+        lora=config.model.lora is not None,
+    )
 
     # Set up the learning rate scheduler
     scheduler_steps = (

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -17,7 +17,7 @@ from prime_rl.trainer.ckpt import setup_ckpt_managers
 from prime_rl.utils.pathing import resolve_latest_ckpt_step
 from prime_rl.trainer.sft.config import SFTTrainerConfig
 from prime_rl.utils.cp import setup_cp_params, shard_for_cp
-from prime_rl.trainer.runs import Progress
+from prime_rl.trainer.runs import Progress, setup_runs
 from prime_rl.utils.logger import setup_logger
 from prime_rl.trainer.optim import setup_optimizer
 from prime_rl.trainer.scheduler import setup_scheduler
@@ -77,6 +77,9 @@ def train(config: SFTTrainerConfig):
         timeout=timedelta(seconds=config.dist_timeout_seconds), enable_gloo=config.model.fsdp_cpu_offload
     )
     torch.set_float32_matmul_precision("high")
+
+    # Setup runs (SFT always uses max_concurrent_runs=1)
+    setup_runs(config.output_dir, max_runs=1)
 
     # Initialize parallel dimensions
     parallel_dims = get_parallel_dims(config.model, config.data.seq_len)

--- a/tests/integration/test_sft_lora.py
+++ b/tests/integration/test_sft_lora.py
@@ -102,12 +102,3 @@ def test_loss_goes_down(sft_lora_process: ProcessResult, output_dir: Path) -> No
 def test_no_error_resume(sft_lora_resume_process: ProcessResult) -> None:
     """Tests that the SFT LoRA resume process does not fail."""
     assert sft_lora_resume_process.returncode == 0, f"Process has non-zero return code ({sft_lora_resume_process})"
-
-
-def test_loss_goes_down_resume(sft_lora_resume_process: ProcessResult, output_dir: Path) -> None:
-    """Tests that the loss goes down in the SFT LoRA resume process"""
-    trainer_log_path = output_dir / "logs" / "trainer" / "rank_0.log"
-    print(f"Checking trainer path in {trainer_log_path}")
-    with open(trainer_log_path, "r") as f:
-        trainer_stdout = strip_escape_codes(f.read()).splitlines()
-    check_loss_goes_down(trainer_stdout)

--- a/tests/integration/test_sft_lora.py
+++ b/tests/integration/test_sft_lora.py
@@ -57,6 +57,8 @@ def sft_lora_resume_process(
     output_dir: Path,
 ) -> ProcessResult:
     """Fixture for resuming SFT LoRA CI integration test"""
+    if sft_lora_process.returncode != 0:
+        pytest.skip("SFT LoRA process failed")
     wandb_name += "-resume"
     cmd = [
         "uv",

--- a/tests/integration/test_sft_lora.py
+++ b/tests/integration/test_sft_lora.py
@@ -102,3 +102,12 @@ def test_loss_goes_down(sft_lora_process: ProcessResult, output_dir: Path) -> No
 def test_no_error_resume(sft_lora_resume_process: ProcessResult) -> None:
     """Tests that the SFT LoRA resume process does not fail."""
     assert sft_lora_resume_process.returncode == 0, f"Process has non-zero return code ({sft_lora_resume_process})"
+
+
+def test_loss_goes_down_resume(sft_lora_resume_process: ProcessResult, output_dir: Path) -> None:
+    """Tests that the loss goes down in the SFT LoRA resume process"""
+    trainer_log_path = output_dir / "logs" / "trainer" / "rank_0.log"
+    print(f"Checking trainer path in {trainer_log_path}")
+    with open(trainer_log_path, "r") as f:
+        trainer_stdout = strip_escape_codes(f.read()).splitlines()
+    check_loss_goes_down(trainer_stdout)

--- a/tests/integration/test_sft_lora.py
+++ b/tests/integration/test_sft_lora.py
@@ -1,0 +1,111 @@
+from functools import partial
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+from tests.conftest import ProcessResult
+from tests.utils import check_number_goes_up_or_down, strip_escape_codes
+
+pytestmark = [pytest.mark.slow, pytest.mark.gpu]
+
+TIMEOUT = 300  # 5 minutes
+
+
+@pytest.fixture(scope="module")
+def wandb_name(branch_name: str) -> str:
+    """Fixture for W&B name for SFT LoRA CI integration tests."""
+    return f"test-sft-lora-{branch_name}"
+
+
+@pytest.fixture(scope="module")
+def sft_lora_process(
+    run_process: Callable[..., ProcessResult],
+    wandb_project: str,
+    wandb_name: str,
+    output_dir: Path,
+) -> ProcessResult:
+    """Fixture for running SFT LoRA CI integration test"""
+    cmd = [
+        "uv",
+        "run",
+        "torchrun",
+        "--local-ranks-filter",
+        "0",
+        "--nproc-per-node",
+        "2",
+        "src/prime_rl/trainer/sft/train.py",
+        "@",
+        "configs/ci/integration/sft_lora/start.toml",
+        "--wandb.project",
+        wandb_project,
+        "--wandb.name",
+        wandb_name,
+        "--output-dir",
+        output_dir.as_posix(),
+    ]
+
+    return run_process(cmd, timeout=TIMEOUT)
+
+
+@pytest.fixture(scope="module")
+def sft_lora_resume_process(
+    sft_lora_process: ProcessResult,  # Resume training can only start when regular SFT LoRA process is finished
+    run_process: Callable[..., ProcessResult],
+    wandb_project: str,
+    wandb_name: str,
+    output_dir: Path,
+) -> ProcessResult:
+    """Fixture for resuming SFT LoRA CI integration test"""
+    wandb_name += "-resume"
+    cmd = [
+        "uv",
+        "run",
+        "torchrun",
+        "--local-ranks-filter",
+        "0",
+        "--nproc-per-node",
+        "2",
+        "src/prime_rl/trainer/sft/train.py",
+        "@",
+        "configs/ci/integration/sft_lora/resume.toml",
+        "--wandb.project",
+        wandb_project,
+        "--wandb.name",
+        wandb_name,
+        "--output-dir",
+        output_dir.as_posix(),
+    ]
+
+    return run_process(cmd, timeout=TIMEOUT)
+
+
+check_loss_goes_down = partial(check_number_goes_up_or_down, go_up=False, pattern=r"Loss:\s*(\d+\.\d{4})")
+
+
+def test_no_error(sft_lora_process: ProcessResult) -> None:
+    """Tests that the SFT LoRA process does not fail."""
+    assert sft_lora_process.returncode == 0, f"Process has non-zero return code ({sft_lora_process})"
+
+
+def test_loss_goes_down(sft_lora_process: ProcessResult, output_dir: Path) -> None:
+    """Tests that the loss goes down in the SFT LoRA process"""
+    trainer_log_path = output_dir / "logs" / "trainer" / "rank_0.log"
+    print(f"Checking trainer path in {trainer_log_path}")
+    with open(trainer_log_path, "r") as f:
+        trainer_stdout = strip_escape_codes(f.read()).splitlines()
+    check_loss_goes_down(trainer_stdout)
+
+
+def test_no_error_resume(sft_lora_resume_process: ProcessResult) -> None:
+    """Tests that the SFT LoRA resume process does not fail."""
+    assert sft_lora_resume_process.returncode == 0, f"Process has non-zero return code ({sft_lora_resume_process})"
+
+
+def test_loss_goes_down_resume(sft_lora_resume_process: ProcessResult, output_dir: Path) -> None:
+    """Tests that the loss goes down in the SFT LoRA resume process"""
+    trainer_log_path = output_dir / "logs" / "trainer" / "rank_0.log"
+    print(f"Checking trainer path in {trainer_log_path}")
+    with open(trainer_log_path, "r") as f:
+        trainer_stdout = strip_escape_codes(f.read()).splitlines()
+    check_loss_goes_down(trainer_stdout)


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Adds integration tests for SFT with LoRA, covering initial training and resuming from a checkpoint to ensure functionality and loss reduction.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: [Issue ID]
**Linear Issue**: Resolves [Issue ID]

---
<a href="https://cursor.com/background-agent?bcId=bc-7c7bbfbd-22a9-4f7d-8762-390f312292d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7c7bbfbd-22a9-4f7d-8762-390f312292d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds CI coverage for SFT with LoRA and aligns the trainer with LoRA-aware execution.
> 
> - New integration configs `configs/ci/integration/sft_lora/start.toml` and `resume.toml` to start and resume LoRA SFT runs
> - New test `tests/integration/test_sft_lora.py` runs 2-GPU jobs, verifies success and that `Loss` decreases for both fresh and resumed training
> - Trainer updates in `sft/train.py`: initialize run directory management with `setup_runs(max_runs=1)`, pass `lora` flag to `setup_optimizer`, and call `set_multilora_offsets` per micro-batch before forward; minor import/initialization tweaks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24218867a7e0c39ebd83340b9c1dccee48d86f30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->