### PR TITLE
fix: route examples to correct environment workers

### DIFF
--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -95,9 +95,6 @@ class Scheduler:
                 )
                 self.workers[env_name].append(worker)
 
-        # Round-robin through envs, least-pending within env
-        self._env_idx = 0
-
         # Track in-flight requests: future -> info
         self.inflight_group_rollouts: dict[asyncio.Future, InflightRolloutInfo] = {}
 
@@ -128,20 +125,14 @@ class Scheduler:
             for worker in workers:
                 worker.stop()
 
-    def _get_next_worker(self) -> EnvWorker:
-        """Round-robin through envs, least-pending within each env."""
-        env_name = self.env_names[self._env_idx % len(self.env_names)]
-        self._env_idx += 1
-
-        # Select worker with fewest pending requests (least-pending routing)
-        workers = self.workers[env_name]
-        return min(workers, key=lambda w: w.pending_count)
-
-    async def schedule_group_rollout(self, worker: EnvWorker | None = None):
+    async def schedule_group_rollout(self):
         """Asynchronously schedules a group rollout request."""
         example = self.buffer.sample_examples(n=1)[0]
-        if worker is None:
-            worker = self._get_next_worker()
+
+        # Route to worker for this example's environment
+        task = example["task"]
+        workers = self.workers[task]
+        worker = min(workers, key=lambda w: w.pending_count)
 
         future = await worker.submit_request(
             example=example,
@@ -267,12 +258,9 @@ class Scheduler:
                     batch_rollouts = batch_rollouts[: self.config.batch_size]
                     break
 
-                # Safely pop the future info
-                popped_info = self.inflight_group_rollouts.pop(finished_future, None)
-                if popped_info is None:
+                # Safely pop the future from tracking
+                if self.inflight_group_rollouts.pop(finished_future, None) is None:
                     continue
-
-                worker = popped_info.worker
 
                 try:
                     group_results: list[dict] = finished_future.result()
@@ -289,7 +277,7 @@ class Scheduler:
                 except Exception as e:
                     self.logger.warning(f"Rollout failed: {e}")
 
-                await self.schedule_group_rollout(worker)
+                await self.schedule_group_rollout()
 
         pbar.close()
         return batch_rollouts


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

  Examples were being sent to workers via round-robin, ignoring the
  example's task field. This caused mini-swe-agent-plus examples to be
  processed by deepdive workers (with deepdive's tools), and vice versa.

  Now examples are routed to the worker pool for their specific
  environment, with least-pending load balancing within that pool.
  env_ratios is respected for environment selection.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: [Issue ID]
**Linear Issue**: Resolves [Issue ID]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures rollouts are executed by workers for their matching environment, improving correctness and load balancing.
> 
> - Routes `schedule_group_rollout` to the env-specific pool via `example["task"]`, selecting the least-pending worker within that pool
> - Removes round-robin routing (`_get_next_worker`, `_env_idx`) in favor of per-env least-pending selection
> - Simplifies inflight tracking in `generate_batch` by safely popping futures and rescheduling without passing a specific worker
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8372758e06b2c2ce372850e725116d2f7e3ecdc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->