### PR TITLE
refactor toml rl.pu

### DIFF
--- a/configs/debug/eventloop_lag.toml
+++ b/configs/debug/eventloop_lag.toml
@@ -1,0 +1,37 @@
+# Debug config for event loop lag testing
+# Usage: EVENTLOOP_LAG_BLOCK_MS=100 uv run rl @ configs/debug/eventloop_lag.toml
+
+# Never update weights (async level infinity)
+max_async_level = 1000000000
+
+# Small batch for fast iteration
+batch_size = 16
+rollouts_per_example = 4
+seq_len = 512
+max_steps = 100
+
+# Multiple workers per env - uses least-pending routing
+# If one worker drifts/slows, others maintain throughput
+workers_per_env = 2
+
+[model]
+name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
+
+[sampling]
+max_tokens = 64
+
+[[env]]
+id = "eventloop-lag-env"
+# block_ms: fixed base blocking time
+# block_growth_ms: increase per call (simulates growing lag)
+# block_max_ms: cap on total blocking time
+# alloc_mb: allocate memory per call to trigger GC
+args = { block_ms = 0, block_growth_ms = 5, block_max_ms = 60000 }
+
+[log]
+level = "debug"
+
+
+[wandb]
+project = "eventloop-lag-debug"
+name = "orch"

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -27,7 +27,7 @@ from prime_rl.trainer.rl.config import NCCLWeightBroadcastConfig as TrainerNCCLW
 from prime_rl.trainer.rl.config import RLTrainerConfig as TrainerConfig
 from prime_rl.utils.config import WandbConfig, WandbWithExtrasConfig
 from prime_rl.utils.logger import setup_logger
-from prime_rl.utils.pydantic_config import BaseSettings, get_temp_toml_file, parse_argv
+from prime_rl.utils.pydantic_config import BaseSettings, parse_argv
 from prime_rl.utils.utils import (
     get_broadcast_dir,
     get_free_port,
@@ -469,16 +469,18 @@ def monitor_process(process: Popen, stop_event: Event, error_queue: list, proces
 
 
 def create_sub_config_toml(config: RLConfig):
+    config_dir = config.output_dir / "configs"
+    config_dir.mkdir(parents=True, exist_ok=True)
     if config.inference is not None:
-        inference_file = get_temp_toml_file()
+        inference_file = config_dir / "infer.toml"
         with open(inference_file, "wb") as f:
             tomli_w.dump(config.inference.model_dump(exclude_none=True, mode="json"), f)
     if config.orchestrator is not None:
-        orchestrator_file = get_temp_toml_file()
+        orchestrator_file = config_dir / "orch.toml"
         with open(orchestrator_file, "wb") as f:
             tomli_w.dump(config.orchestrator.model_dump(exclude_none=True, mode="json"), f)
     if config.trainer is not None:
-        trainer_file = get_temp_toml_file()
+        trainer_file = config_dir / "train.toml"
         with open(trainer_file, "wb") as f:
             tomli_w.dump(config.trainer.model_dump(exclude_none=True, mode="json"), f)
     return inference_file, orchestrator_file, trainer_file

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -198,6 +198,13 @@ class RLConfig(BaseSettings):
         SharedWeightBroadcastConfig | None, Field(description="The weight broadcast config.")
     ] = None
 
+    only_sub_toml: Annotated[
+        bool,
+        Field(
+            description="Whether to only create a sub-config.toml file on start. If True, will only create a sub-config.toml file in the output directory with the current config.",
+        ),
+    ] = False
+
     @model_validator(mode="after")
     def auto_setup_dp(self):
         if self.inference and len(self.inference_gpu_ids) != self.inference.parallel.dp * self.inference.parallel.tp:
@@ -526,6 +533,10 @@ def rl(config: RLConfig):
     stop_events: dict[str, Event] = {}
 
     inference_file, orchestrator_file, trainer_file = create_sub_config_toml(config)
+
+    if config.only_sub_toml:
+        logger.success("Sub-config.toml file created successfully, exiting...")
+        return
 
     try:
         # Optionally, start inference process

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -493,6 +493,11 @@ def rl(config: RLConfig):
     logger.info("Starting RL run")
     logger.debug(f"RL start command: {' '.join(start_command)}")
 
+    inference_file, orchestrator_file, trainer_file = create_sub_config_toml(config)
+    if config.only_sub_toml:
+        logger.success("Sub-config.toml file created successfully, exiting...")
+        return
+
     # Prepare paths to communicate with the trainer
     log_dir = get_log_dir(config.output_dir)
     orch_log_dir = get_log_dir(config.orchestrator.output_dir)
@@ -531,12 +536,6 @@ def rl(config: RLConfig):
     monitor_threads: list[Thread] = []
     error_queue: list[Exception] = []
     stop_events: dict[str, Event] = {}
-
-    inference_file, orchestrator_file, trainer_file = create_sub_config_toml(config)
-
-    if config.only_sub_toml:
-        logger.success("Sub-config.toml file created successfully, exiting...")
-        return
 
     try:
         # Optionally, start inference process


### PR DESCRIPTION
currently we create a toml file for orch/train/infer from the rl.toml in rl.py. THis is save in a .pydantic_config. This pr change this and put them into output_dir / config folder. 

It also allow to only save the toml file instead of actually doing rl. its a first step into making rl.py -> slurm/k8s execution easier

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes and persists run-time TOMLs and enables config-only workflows.
> 
> - Writes `infer.toml`, `orch.toml`, and `train.toml` to `output_dir/configs` via new `create_sub_config_toml` and uses them to launch processes (removes temp `.pydantic_config` files)
> - Adds `RLConfig.only_sub_toml` to generate sub-configs and exit without starting RL
> - New debug config `configs/debug/eventloop_lag.toml` for event loop lag testing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cabed5e883b1136819ff6765350a4ed3028a3e1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->