### PR TITLE
chunk the logits materialization for rl loss function to decrease peak memory usage

### DIFF
--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -160,24 +160,24 @@ def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDim
             reshard_after_forward=config.reshard_after_forward,
         )
 
-    if hasattr(model, "config") and not model.config.tie_word_embeddings:
-        # This optimization breaks weight tying
-        fully_shard(
-            model.model.embed_tokens,
-            mesh=hsdp_mesh,
-            mp_policy=mp_policy,
-            offload_policy=offload_policy,
-            reshard_after_forward=config.reshard_after_forward,
-        )
-        fully_shard(
-            [model.lm_head, model.model.norm],
-            mesh=hsdp_mesh,
-            mp_policy=mp_policy,
-            offload_policy=offload_policy,
-            reshard_after_forward=False,
-        )
-    else:
-        get_logger().warning("Model is tied word embeddings, so not doing the last layer not resharding optimization")
+    # if hasattr(model, "config") and not model.config.tie_word_embeddings:
+    #     # This optimization breaks weight tying
+    #     fully_shard(
+    #         model.model.embed_tokens,
+    #         mesh=hsdp_mesh,
+    #         mp_policy=mp_policy,
+    #         offload_policy=offload_policy,
+    #         reshard_after_forward=config.reshard_after_forward,
+    #     )
+    #     fully_shard(
+    #         [model.lm_head, model.model.norm],
+    #         mesh=hsdp_mesh,
+    #         mp_policy=mp_policy,
+    #         offload_policy=offload_policy,
+    #         reshard_after_forward=False,
+    #     )
+    # else:
+    #     get_logger().warning("Model is tied word embeddings, so not doing the last layer not resharding optimization")
 
     fully_shard(
         model.model,
@@ -185,6 +185,13 @@ def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDim
         mp_policy=mp_policy,
         offload_policy=offload_policy,
         reshard_after_forward=config.reshard_after_forward,
+    )
+    fully_shard(
+        model.lm_head,
+        mesh=hsdp_mesh,
+        mp_policy=mp_policy,
+        offload_policy=offload_policy,
+        reshard_after_forward=False,
     )
 
 

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -180,7 +180,7 @@ def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDim
         get_logger().warning("Model is tied word embeddings, so not doing the last layer not resharding optimization")
 
     fully_shard(
-        model,
+        model.model,
         mesh=hsdp_mesh,
         mp_policy=mp_policy,
         offload_policy=offload_policy,

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -201,6 +201,14 @@ class RLTrainerConfig(BaseSettings):
         ),
     ] = 1
 
+    logits_chunks: Annotated[
+        int,
+        Field(
+            ge=1,
+            description="Number of chunks to split the sequence into for logits materialization. Higher values reduce memory usage but may increase computation time. Default is 1 (no chunking).",
+        ),
+    ] = 1
+
     @model_validator(mode="after")
     def auto_setup_bench(self):
         if self.bench:

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -201,13 +201,13 @@ class RLTrainerConfig(BaseSettings):
         ),
     ] = 1
 
-    logits_chunks: Annotated[
+    logits_chunk_size: Annotated[
         int,
         Field(
             ge=1,
-            description="Number of chunks to split the sequence into for logits materialization. Higher values reduce memory usage but may increase computation time. Default is 1 (no chunking).",
+            description="Size of each chunk for logits materialization. The sequence is split into ceil(seq_len / logits_chunk_size) chunks. Smaller values reduce memory usage but may increase computation time.",
         ),
-    ] = 1
+    ] = 4096
 
     @model_validator(mode="after")
     def auto_setup_bench(self):

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -312,6 +312,7 @@ def train(config: RLTrainerConfig):
             for chunk_idx in range(num_logits_chunks):
                 if chunk_idx == num_logits_chunks - 1:
                     model.lm_head._get_fsdp_state()._modules_to_run_forward.remove("blocker")
+                    model.lm_head._get_fsdp_state()._modules_to_run_forward.add(model.lm_head)
                     model.lm_head.set_reshard_after_backward(True)
                 hidden_states_chunk = hidden_states_list[chunk_idx]
                 input_ids_chunk = input_ids_list[chunk_idx]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Reduces peak memory during RL training by chunking logits computation and refines FSDP sharding for models with tied embeddings.
> 
> - Introduces `logits_chunk_size` in `RLTrainerConfig` to control per-sequence chunking for logits materialization
> - In `train.py`, replaces single-shot logits with chunked application of `lm_head` over `hidden_states`, computing loss/entropy and backward per chunk, then backpropagating through the backbone; handles CP all-gather per chunk and configures `lm_head` FSDP resharding/blocking accordingly
> - In `model.py`, updates FSDP setup: if `config.tie_word_embeddings`, shard `[model.model.embed_tokens, model.lm_head]`; else shard `model.lm_head`; and shard `model.model` (not the entire `model`), consistently using `config.reshard_after_forward`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1313a42f79920a4a911e307b760a5c0f64856d38. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->