### PR TITLE
dont reschedule requests immediatly after canceling

### DIFF
--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -217,10 +217,9 @@ class Scheduler:
                 else:
                     futures_to_update.append((future, info.off_policy_steps + 1, info.worker, info.request_id))
 
-            # Remove cancelled and reschedule
+            # Remove cancelled
             for future, worker in futures_to_remove:
                 self.inflight_group_rollouts.pop(future, None)
-                await self.schedule_group_rollout()
 
             # Update off-policy steps for remaining
             for future, off_policy_steps, worker, request_id in futures_to_update:
@@ -232,7 +231,9 @@ class Scheduler:
                     )
 
             if len(futures_to_remove) > 0:
-                self.logger.warning(f"Cancelled and re-scheduled {len(futures_to_remove)} old rollout requests.")
+                self.logger.warning(
+                    f"Cancelled {len(futures_to_remove)} old rollout requests (will refill naturally). Consider increasing max_off_policy_steps to avoid this."
+                )
 
             self.ckpt_step = next_ckpt_step
 


### PR DESCRIPTION
follow up of https://github.com/PrimeIntellect-ai/prime-rl/pull/1504

# What this pr do:

previously when rollout that were too long and hit the max_off_policy limit we were canceling the rollout and reschedule it immediately. THis pr change the behavior and do not reschedule them as they will let the rollout to be reschedule naturally.

The reason of this change is that we notice accumulation in rollout that never finish and end up taking most of the time of inference while never making into into the batch, staling the training and leading to crash

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents runaway accumulation of long-running rollouts when policy updates occur.
> 
> - In `scheduler.py:update_policy`, remove immediate rescheduling after cancelling over-`max_off_policy_steps` rollouts; allow natural refill via existing scheduling loop
> - Update warning log to reflect new behavior and suggest increasing `max_off_policy_steps` if needed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0480fcb1dd6105b089399a33bad934bead80ac8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->