### PR TITLE
fix: handle skipped eval intervals when ckpt_step jumps

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -196,8 +196,8 @@ async def orchestrate(config: OrchestratorConfig):
 
     # Track last online eval checkpoint step for this process
     last_eval_step = -1
-    # Track previous ckpt_step to detect skipped steps
-    prev_ckpt_step = 0
+    # Track previous ckpt_step to detect skipped steps (-1 so step 0 is included)
+    prev_ckpt_step = -1
 
     # Reset weights to base model if starting from scratch
     progress = Progress()

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -296,9 +296,11 @@ async def orchestrate(config: OrchestratorConfig):
             # Formula: largest multiple of interval <= ckpt_step that is > prev_ckpt_step
             highest_interval_step = (ckpt_step // interval) * interval
             if highest_interval_step > prev_ckpt_step and highest_interval_step > last_eval_step:
-                # Check base model eval condition for step 0
-                if highest_interval_step == 0 and not config.eval.eval_base_model:
-                    pass  # Skip step 0 if eval_base_model is False
+                # Base model eval (step 0) only runs when ckpt_step is also 0
+                # Otherwise we'd eval non-base weights and label them as base
+                if highest_interval_step == 0:
+                    if ckpt_step == 0 and config.eval.eval_base_model:
+                        eval_ckpt_step = 0
                 else:
                     eval_ckpt_step = highest_interval_step
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -304,10 +304,14 @@ async def orchestrate(config: OrchestratorConfig):
 
         if eval_ckpt_step is not None:
             if eval_ckpt_step != ckpt_step:
-                logger.info(f"Running evals for skipped checkpoint step {eval_ckpt_step} (current ckpt_step={ckpt_step})")
+                logger.info(
+                    f"Interval step {eval_ckpt_step} was skipped, running eval at current ckpt_step={ckpt_step}"
+                )
             else:
-                logger.info(f"Running evals for checkpoint step {eval_ckpt_step}")
-            last_eval_step = eval_ckpt_step
+                logger.info(f"Running evals for checkpoint step {ckpt_step}")
+            # Use actual ckpt_step for labeling (not the skipped interval step) since
+            # weights are already updated to ckpt_step
+            last_eval_step = ckpt_step
             eval_task = asyncio.create_task(
                 run_evals(
                     clients=clients,
@@ -317,7 +321,7 @@ async def orchestrate(config: OrchestratorConfig):
                     evals_client=evals_client,
                     reasoning_field=config.eval.reasoning_field,
                     output_dir=config.output_dir,
-                    ckpt_step=eval_ckpt_step,
+                    ckpt_step=ckpt_step,
                     step=progress.step,
                 )
             )


### PR DESCRIPTION
## Problem

When `strict_async_level=False` (default), the scheduler can jump checkpoint steps. If ckpt_step jumps over a multiple of the eval interval, that eval is silently skipped.

## Example

With `eval.interval=10`, here's what happens when ckpt_step jumps:

```
Step 10 | Async Level: 1 -> ckpt_step = 9  (9 % 10 != 0, no eval)
Step 11 | Async Level: 0 -> ckpt_step = 11 (11 % 10 != 0, no eval)
```

Checkpoint 10 was skipped, so eval at interval=10 never ran. Only the base model eval at step 0 executed.

## Root cause

In `scheduler.py`, when `strict_async_level=False`:
```python
next_ckpt_step = max(async_away_ckpt_step, latest_ckpt_step)
```

This allows jumping from ckpt_step 9 directly to 11 if checkpoints 10 and 11 are both available.

The eval check in `orchestrator.py` only tested the current ckpt_step:
```python
if ckpt_step % config.eval.interval == 0:  # misses skipped steps
```

## Fix

Track previous ckpt_step and find the highest interval step in range (prev, current] that should trigger eval:
```python
highest_interval_step = (ckpt_step // interval) * interval
if highest_interval_step > prev_ckpt_step and highest_interval_step > last_eval_step:
    eval_ckpt_step = highest_interval_step
```

Now if ckpt_step jumps from 9->11, we detect that step 10 was skipped and run eval at step 10.

New log message when this happens:
```
Running evals for skipped checkpoint step 10 (current ckpt_step=11)
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the orchestrator’s online-eval scheduling logic and resume behavior; mistakes here could cause evals to run too often/too rarely or be labeled against the wrong checkpoint step, but it doesn’t touch training data or model updates directly.
> 
> **Overview**
> Fixes missed online evaluations when `scheduler.ckpt_step` jumps over multiples of `eval.interval` by tracking `prev_ckpt_step` and triggering an eval if any interval boundary was crossed since the prior loop iteration.
> 
> Adjusts resume behavior so `skip_eval_on_resume` correctly suppresses the immediate eval at the resumed checkpoint, and adds logging when an interval step was skipped but eval is run at the current checkpoint (while still labeling results with the current `ckpt_step`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1a4fb5560690ac2f1e1c7963cdaf2a55ce69864. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->