### PR TITLE
take out step in wandb monitor

### DIFF
--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -77,7 +77,7 @@ class WandbMonitor(Monitor):
             return
         if not self.enabled:
             return
-        wandb.log(metrics, step=metrics.get("step", None))
+        wandb.log(metrics)
 
     def log_samples(self, rollouts: list[vf.State], step: int) -> None:
         """Logs rollouts to W&B table."""


### PR DESCRIPTION
it seems to make wandb push metrics a lot slower

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies W&B metric logging in `WandbMonitor.log` by removing the explicit `step` argument, relying on default step handling.
> 
> - Replace `wandb.log(metrics, step=metrics.get("step", None))` with `wandb.log(metrics)`; no other files or behaviors changed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93f12a357a9cdb49994f6ab6a74d3601be773666. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->