### PR TITLE
refactor online eval

### DIFF
--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -645,10 +645,10 @@ async def run_evals(
 
 
 def _run_evals_in_subprocess(
-    client_config_dict: dict,
-    eval_config_dict: dict,
-    model_config_dict: dict,
-    sampling_config_dict: dict,
+    client_config: ClientConfig,
+    eval_config: EvalConfig,
+    model_config: ModelConfig,
+    sampling_config: EvalSamplingConfig,
     reasoning_field: str,
     output_dir: str,
     ckpt_step: int,
@@ -660,12 +660,6 @@ def _run_evals_in_subprocess(
     reset_logger()
     logger = setup_logger("info")
     logger.info(f"Eval subprocess started for checkpoint step {ckpt_step}")
-
-    # Reconstruct configs from dicts
-    client_config = ClientConfig(**client_config_dict)
-    eval_config = EvalConfig(**eval_config_dict)
-    model_config = ModelConfig(**model_config_dict)
-    sampling_config = EvalSamplingConfig(**sampling_config_dict)
 
     # Create fresh clients in subprocess
     clients = setup_clients(client_config)
@@ -711,10 +705,10 @@ async def run_evals_subprocess(
     process = Process(
         target=_run_evals_in_subprocess,
         args=(
-            client_config.model_dump(),
-            eval_config.model_dump(),
-            model_config.model_dump(),
-            sampling_config.model_dump(),
+            client_config,
+            eval_config,
+            model_config,
+            sampling_config,
             reasoning_field,
             str(output_dir),
             ckpt_step,

--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -4,6 +4,7 @@ import re
 import time
 from copy import deepcopy
 from itertools import cycle
+from multiprocessing import Process
 from pathlib import Path
 from typing import Any
 
@@ -21,8 +22,11 @@ from verifiers.utils.eval_utils import get_hf_hub_dataset_name, make_dataset, sa
 
 from prime_rl.eval.config import OfflineEvalConfig
 from prime_rl.orchestrator.config import EvalConfig, EvalSamplingConfig, EvalSaveConfig, ModelConfig, RetryConfig
+from prime_rl.orchestrator.utils import set_semaphore
 from prime_rl.synthesize.utils import merge_reasoning_content, save_result
-from prime_rl.utils.logger import get_logger
+from prime_rl.utils.client import setup_clients, setup_evals_client
+from prime_rl.utils.config import ClientConfig
+from prime_rl.utils.logger import get_logger, setup_logger
 from prime_rl.utils.monitor import get_monitor
 from prime_rl.utils.utils import capitalize, get_eval_dir, get_step_path
 from prime_rl.utils.vf import (
@@ -638,3 +642,93 @@ async def run_evals(
             for env in eval_config.env
         ]
     )
+
+
+def _run_evals_in_subprocess(
+    client_config_dict: dict,
+    eval_config_dict: dict,
+    model_config_dict: dict,
+    sampling_config_dict: dict,
+    reasoning_field: str,
+    output_dir: str,
+    ckpt_step: int,
+    step: int | None,
+    max_concurrent: int,
+):
+    """Entry point for eval subprocess. Creates its own event loop and clients."""
+    # Setup logger for subprocess
+    logger = setup_logger("info")
+    logger.info(f"Eval subprocess started for checkpoint step {ckpt_step}")
+
+    # Reconstruct configs from dicts
+    client_config = ClientConfig(**client_config_dict)
+    eval_config = EvalConfig(**eval_config_dict)
+    model_config = ModelConfig(**model_config_dict)
+    sampling_config = EvalSamplingConfig(**sampling_config_dict)
+
+    # Create fresh clients in subprocess
+    clients = setup_clients(client_config)
+    evals_client = setup_evals_client()
+
+    async def _run():
+        await set_semaphore(max_concurrent)
+        await run_evals(
+            clients=clients,
+            eval_config=eval_config,
+            model_config=model_config,
+            sampling_config=sampling_config,
+            evals_client=evals_client,
+            reasoning_field=reasoning_field,
+            output_dir=Path(output_dir),
+            ckpt_step=ckpt_step,
+            step=step,
+        )
+
+    asyncio.run(_run())
+    logger.info(f"Eval subprocess finished for checkpoint step {ckpt_step}")
+
+
+async def run_evals_subprocess(
+    client_config: ClientConfig,
+    eval_config: EvalConfig | OfflineEvalConfig,
+    model_config: ModelConfig,
+    sampling_config: EvalSamplingConfig,
+    reasoning_field: str,
+    output_dir: Path,
+    ckpt_step: int,
+    step: int | None = None,
+    max_concurrent: int = -1,
+):
+    """Run evals in a separate subprocess to isolate the event loop.
+
+    This prevents eval's async work from causing event loop lag in the
+    orchestrator's main loop. The orchestrator blocks until eval completes.
+    """
+    logger = get_logger()
+    logger.info(f"Spawning eval subprocess for checkpoint step {ckpt_step}")
+
+    process = Process(
+        target=_run_evals_in_subprocess,
+        args=(
+            client_config.model_dump(),
+            eval_config.model_dump(),
+            model_config.model_dump(),
+            sampling_config.model_dump(),
+            reasoning_field,
+            str(output_dir),
+            ckpt_step,
+            step,
+            max_concurrent,
+        ),
+        daemon=True,
+    )
+    process.start()
+
+    # Wait for process to complete without blocking the event loop
+    while process.is_alive():
+        await asyncio.sleep(0.5)
+
+    if process.exitcode != 0:
+        logger.error(f"Eval subprocess failed with exit code {process.exitcode}")
+    else:
+        logger.success(f"Eval subprocess completed for checkpoint step {ckpt_step}")

--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -26,7 +26,7 @@ from prime_rl.orchestrator.utils import set_semaphore
 from prime_rl.synthesize.utils import merge_reasoning_content, save_result
 from prime_rl.utils.client import setup_clients, setup_evals_client
 from prime_rl.utils.config import ClientConfig
-from prime_rl.utils.logger import get_logger, setup_logger
+from prime_rl.utils.logger import get_logger, reset_logger, setup_logger
 from prime_rl.utils.monitor import get_monitor
 from prime_rl.utils.utils import capitalize, get_eval_dir, get_step_path
 from prime_rl.utils.vf import (
@@ -656,7 +656,8 @@ def _run_evals_in_subprocess(
     max_concurrent: int,
 ):
     """Entry point for eval subprocess. Creates its own event loop and clients."""
-    # Setup logger for subprocess
+    # Setup logger for subprocess (reset first since we inherit parent's global state when forked)
+    reset_logger()
     logger = setup_logger("info")
     logger.info(f"Eval subprocess started for checkpoint step {ckpt_step}")
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -23,7 +23,7 @@ import verifiers as vf
 from loguru import logger
 from transformers import AutoTokenizer
 
-from prime_rl.eval.utils import run_evals
+from prime_rl.eval.utils import run_evals_subprocess
 from prime_rl.orchestrator.buffer import Buffer
 from prime_rl.orchestrator.ckpt import Progress, setup_ckpt_manager
 from prime_rl.orchestrator.config import BufferConfig, OrchestratorConfig
@@ -40,7 +40,6 @@ from prime_rl.utils.client import (
     reload_weights,
     setup_admin_clients,
     setup_clients,
-    setup_evals_client,
     update_weights,
 )
 from prime_rl.utils.heartbeat import Heartbeat
@@ -97,7 +96,6 @@ async def orchestrate(config: OrchestratorConfig):
     )
     clients = setup_clients(config.client)
     admin_clients = setup_admin_clients(config.client)
-    evals_client = setup_evals_client()
 
     # Load tokenizer
     logger.info(f"Initializing tokenizer for {config.model.name}")
@@ -257,11 +255,40 @@ async def orchestrate(config: OrchestratorConfig):
         logger.info(f"Starting orchestrator step {progress.step}")
         step_start_time = time.perf_counter()
 
+        # Run evals BEFORE training (blocking, in subprocess to isolate event loop)
+        # This ensures weights don't change during eval and eval doesn't cause event loop lag
+        if (
+            config.eval
+            and ckpt_step % config.eval.interval == 0
+            and ckpt_step > last_eval_step
+            and ((ckpt_step == 0 and config.eval.eval_base_model) or ckpt_step > 0)
+        ):
+            last_eval_step = ckpt_step
+            logger.info(f"Running evals for checkpoint step {ckpt_step} (blocking, subprocess)")
+
+            # Pause weight updates during eval
+            scheduler.checkpoint_ready.clear()
+
+            await run_evals_subprocess(
+                client_config=config.client,
+                eval_config=config.eval,
+                model_config=config.model,
+                sampling_config=config.eval.sampling,
+                reasoning_field=config.eval.reasoning_field,
+                output_dir=config.output_dir,
+                ckpt_step=ckpt_step,
+                step=progress.step,
+                max_concurrent=config.max_concurrent or -1,
+            )
+
+            # Resume weight updates
+            scheduler.checkpoint_ready.set()
+
         # Schedule generating the training batch
         generate_completions_start_time = time.perf_counter()
         train_task = asyncio.create_task(scheduler.generate_batch(step=progress.step))
 
-        # Schedule running evals at the specified interval
+        # Schedule running validation at the specified interval
         if val_buffer and config.val and progress.step % config.val.interval == 0:
             logger.info(f"Running validation for step {progress.step}")
             val_examples = val_buffer.sample_examples(config.val.num_examples)
@@ -278,31 +305,6 @@ async def orchestrate(config: OrchestratorConfig):
             )
         else:
             val_task = asyncio.create_task(asyncio.sleep(0))  # Dummy task
-
-        # Schedule running evals at the specified interval
-        if (
-            config.eval
-            and ckpt_step % config.eval.interval == 0
-            and ckpt_step > last_eval_step
-            and ((ckpt_step == 0 and config.eval.eval_base_model) or ckpt_step > 0)
-        ):
-            last_eval_step = ckpt_step
-            logger.info(f"Running evals for checkpoint step {ckpt_step}")
-            eval_task = asyncio.create_task(
-                run_evals(
-                    clients=clients,
-                    eval_config=config.eval,
-                    model_config=config.model,
-                    sampling_config=config.eval.sampling,
-                    evals_client=evals_client,
-                    reasoning_field=config.eval.reasoning_field,
-                    output_dir=config.output_dir,
-                    ckpt_step=ckpt_step,
-                    step=progress.step,
-                )
-            )
-        else:
-            eval_task = asyncio.create_task(asyncio.sleep(0))  # Dummy task
 
         # Await train rollouts, process results and write batch to disk to consume by trainer
         await train_task
@@ -342,9 +344,6 @@ async def orchestrate(config: OrchestratorConfig):
         # Await and process val results
         await val_task
         val_outputs = val_task.result()
-
-        # Await eval results
-        await eval_task
 
         # Gather metrics in dataframes
         results_df = pd.DataFrame(
@@ -507,17 +506,17 @@ async def orchestrate(config: OrchestratorConfig):
             heart.beat()
 
     if config.eval:
-        logger.info("Running final evals")
-        await run_evals(
-            clients=clients,
+        logger.info("Running final evals (subprocess)")
+        await run_evals_subprocess(
+            client_config=config.client,
             eval_config=config.eval,
             model_config=config.model,
             sampling_config=config.eval.sampling,
-            evals_client=evals_client,
             reasoning_field=config.eval.reasoning_field,
             output_dir=config.output_dir,
             ckpt_step=scheduler.ckpt_step,
             step=progress.step,
+            max_concurrent=config.max_concurrent or -1,
         )
 
     # Log final (immutable) samples and distributions to monitor(s)


### PR DESCRIPTION
## Run online eval in isolated subprocess, blocking training

### Problem

**Event loop lag**: Eval runs async tasks (LLM calls, code execution) in the same event loop as the orchestrator, causing lag that affects training rollout generationl

** eval overlap with training**" while this use to be a feature we wanted its no the case anymore because we are doing pipelineRL, so we want a discting eval inference phase


### Solution

Run online eval in a **separate subprocess** with its own event loop, **blocking training** until eval completes:


### Changes

**`src/prime_rl/eval/utils.py`**
- Added `run_evals_subprocess()` - spawns eval in separate process, waits for completion
- Added `_run_evals_in_subprocess()` - subprocess entry point, creates own event loop and clients

**`src/prime_rl/orchestrator/orchestrator.py`**
- Eval now runs **before** training batch generation (blocking)
- Weight updates paused during eval via `scheduler.checkpoint_ready.clear()`
- Removed concurrent `eval_task` pattern

### why

-  **No event loop lag** - eval's async work isolated in separate process
- **Stable weights during eval** - training and weight updates blocked
-  **Consistent eval results** - all rollouts use same model weights
- **Cleaner semantics** - eval is a distinct phase, not interleaved with training


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a dedicated subprocess for online eval to isolate async work from the orchestrator and ensure stable, consistent evals.
> 
> - Add `run_evals_subprocess()` and `_run_evals_in_subprocess()` in `src/prime_rl/eval/utils.py` to spawn a subprocess, create fresh clients, set semaphore, run `run_evals`, and await completion with exit-code handling
> - Update `src/prime_rl/orchestrator/orchestrator.py` to run evals BEFORE training as a blocking phase via `run_evals_subprocess`, pausing/resuming weight updates with `scheduler.checkpoint_ready.clear()/set()`
> - Remove concurrent `eval_task` usage and direct `evals_client` setup in orchestrator; final eval also runs via subprocess
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5ca1bcf1b9aea6bae75378670b424869bbcd1cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->