### PR TITLE
Chunk cross entropy rl

### DIFF
--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -50,6 +50,13 @@ class LossConfig(BaseConfig):
             description="If set, masks entire sequences when any generated token has an importance ratio above this value.",
         ),
     ] = 100.0
+    chunk_size: Annotated[
+        int | None,
+        Field(
+            ge=1,
+            description="Chunk size for memory-efficient log softmax computation. If None, uses standard (non-chunked) implementation. Lower values reduce peak memory but may be slower.",
+        ),
+    ] = None
 
     @model_validator(mode="after")
     def validate_mask_bounds(self):


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Implements chunked selective log-softmax for RL loss to significantly reduce memory usage, especially for long sequences, by processing logits in smaller chunks.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: [Issue ID]
**Linear Issue**: Resolves [Issue ID]

---
<a href="https://cursor.com/background-agent?bcId=bc-98dabbd7-aa4d-44cd-b1ac-eb501be59125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-98dabbd7-aa4d-44cd-b1ac-eb501be59125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

