### PR TITLE
Checkpoint saving interval

### DIFF
--- a/docs/checkpointing.md
+++ b/docs/checkpointing.md
@@ -8,7 +8,7 @@ Checkpointing is non-standard due to trainer/orchestrator separation and natural
 
 The default checkpoint directory is `checkpoints` and each checkpoint step will live in a step subdirectory, i.e. `checkpoints/step_{step}`.
 
-Checkpointing is configured with the config key `--ckpt`. One can specify the interval (`--ckpt.interval`), whether to save checkpoints asynchronoously  (`--ckpt.save-async`), and how many recent step checkpoints to keep on disk (`--ckpt.keep`). By default, we do not checkpoint to save disk space. 
+Checkpointing is configured with the config key `--ckpt`. One can specify the interval (`--ckpt.interval`), whether to save checkpoints asynchronoously  (`--ckpt.save-async`), how many recent step checkpoints to keep on disk (`--ckpt.keep-last`), and keep checkpoints at every N steps permanently (`--ckpt.keep-interval`). By default, we do not checkpoint to save disk space. 
 
 ## SFT
 

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -366,11 +366,19 @@ class CheckpointConfig(BaseConfig):
         ),
     ] = None
 
-    keep: Annotated[
+    keep_last: Annotated[
         int | None,
         Field(
             ge=1,
-            description="Keep at most this many recent step checkpoints on disk. If None, never clean old checkpoints.",
+            description="Keep at most this many recent step checkpoints on disk. If None, never clean old checkpoints based on recency.",
+        ),
+    ] = None
+
+    keep_interval: Annotated[
+        int | None,
+        Field(
+            ge=1,
+            description="Keep checkpoints at every N steps permanently (e.g., keep_interval=100 keeps step 100, 200, ...). If None, no interval-based keeping.",
         ),
     ] = None
 

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -72,11 +72,19 @@ class SharedCheckpointConfig(BaseSettings):
         int | None, Field(description="The step to resume from. If None, will not resume from a checkpoint.")
     ] = None
 
-    keep: Annotated[
+    keep_last: Annotated[
         int | None,
         Field(
             ge=1,
-            description="Keep at most this many recent step checkpoints on disk. If None, never clean old checkpoints.",
+            description="Keep at most this many recent step checkpoints on disk. If None, never clean old checkpoints based on recency.",
+        ),
+    ] = None
+
+    keep_interval: Annotated[
+        int | None,
+        Field(
+            ge=1,
+            description="Keep checkpoints at every N steps permanently (e.g., keep_interval=100 keeps step 100, 200, ...). If None, no interval-based keeping.",
         ),
     ] = None
 
@@ -252,9 +260,13 @@ class RLConfig(BaseSettings):
                 self.orchestrator.ckpt.resume_step = self.ckpt.resume_step
 
             # If specified, propagate keep policy
-            if self.ckpt.keep is not None:
-                self.trainer.ckpt.keep = self.ckpt.keep
-                self.orchestrator.ckpt.keep = self.ckpt.keep
+            if self.ckpt.keep_last is not None:
+                self.trainer.ckpt.keep_last = self.ckpt.keep_last
+                self.orchestrator.ckpt.keep_last = self.ckpt.keep_last
+
+            if self.ckpt.keep_interval is not None:
+                self.trainer.ckpt.keep_interval = self.ckpt.keep_interval
+                self.orchestrator.ckpt.keep_interval = self.ckpt.keep_interval
 
         validate_shared_ckpt_config(self.trainer, self.orchestrator)
 

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -405,11 +405,19 @@ class CheckpointConfig(BaseConfig):
         ),
     ] = None
 
-    keep: Annotated[
+    keep_last: Annotated[
         int | None,
         Field(
             ge=1,
-            description="Keep at most this many recent step checkpoints on disk. If None, never clean old checkpoints.",
+            description="Keep at most this many recent step checkpoints on disk. If None, never clean old checkpoints based on recency.",
+        ),
+    ] = None
+
+    keep_interval: Annotated[
+        int | None,
+        Field(
+            ge=1,
+            description="Keep checkpoints at every N steps permanently (e.g., keep_interval=100 keeps step 100, 200, ...). If None, no interval-based keeping.",
         ),
     ] = None
 


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Renames `ckpt.keep` to `ckpt.keep_last` and introduces `ckpt.keep_interval` to allow keeping checkpoints at specified step intervals in addition to the most recent ones.

tested 

 uv run rl @ examples/reverse_text/rl.toml --inference.gpu_memory_utilization 0.5 --ckpt.keep_interval 3 --ckpt.keep_last 2 --ckpt.interval 1

<img width="1294" height="62" alt="image" src="https://github.com/user-attachments/assets/6f1f2a55-c9c6-4633-ae55-5eebf03fec04" />


---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: [Issue ID]
**Linear Issue**: Resolves [Issue ID]

---
<a href="https://cursor.com/background-agent?bcId=bc-b4af6325-7d60-4d2c-9aca-9fd6e24d764d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b4af6325-7d60-4d2c-9aca-9fd6e24d764d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces flexible checkpoint retention and updates naming across configs and code.
> 
> - Rename `ckpt.keep` to `ckpt.keep_last`; add `ckpt.keep_interval` in trainer, orchestrator, and shared RL configs
> - Update cleanup logic to retain the most recent `keep_last` steps and permanently keep every `keep_interval` step for both full and weight checkpoints
> - Propagate new options via `RLConfig.auto_setup_ckpt` and `setup_ckpt_managers`; adjust weight manager constructor
> - Refresh docs to reflect `--ckpt.keep-last` and `--ckpt.keep-interval` flags
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11ec0060b63569b71da6023b6617a2e6c9bd231f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->