### PR TITLE
docs: add changelog entry for ckpt.keep_last and ckpt.keep_interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@ Documenting changes which affect configuration usage patterns (added/moved/remov
 - **`model.impl`**: Changed default from `hf` to `auto`. With `auto`, the implementation automatically selects `custom` if supported for the model, otherwise falls back to `hf` (#1488, 2025-12-27)
 - **`orchestrator.eval.skip_eval_on_resume`**: Added flag (default `True`) to skip the first potentially redundant online eval immediately after resuming from a checkpoint (#1491, 2025-12-27)
 - **`trainer.weight_broadcast.adapter_only`**: Removed. Adapter-only behavior is now automatically derived from the presence of LoRA configuration (2025-12-27)
+- **`ckpt.keep`**: Renamed to `ckpt.keep_last`. Added `ckpt.keep_interval` to keep checkpoints at every N steps permanently (2025-12-31)


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

I was too lazy to explain my changes, decreasing my chances of this ever getting merged.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: [Issue ID]
**Linear Issue**: Resolves [Issue ID]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Documents checkpoint retention config changes.
> 
> - Renames `ckpt.keep` to `ckpt.keep_last` and adds `ckpt.keep_interval` to keep checkpoints every N steps permanently in `CHANGELOG.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8d004eaefa5562a53534ba0597fe7d91be1c309. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->