### PR TITLE
Offline model download issue

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -113,7 +113,9 @@ async def orchestrate(config: OrchestratorConfig):
 
     # Load tokenizer
     logger.info(f"Initializing tokenizer for {config.model.name}")
-    tokenizer = AutoTokenizer.from_pretrained(config.model.name, trust_remote_code=config.model.trust_remote_code)
+    tokenizer = AutoTokenizer.from_pretrained(
+        config.model.name, trust_remote_code=config.model.trust_remote_code, local_files_only=config.model.local_files_only
+    )
 
     # Setup monitor
     logger.info(f"Initializing monitor (wandb={config.wandb}, prime_monitor={config.prime_monitor})")

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -124,6 +124,13 @@ class ModelConfig(BaseConfig):
         ),
     ] = "Qwen/Qwen3-0.6B"
 
+    local_files_only: Annotated[
+        bool,
+        Field(
+            description="Whether to only use local files and not connect to HuggingFace Hub. Useful for offline mode.",
+        ),
+    ] = False
+
     seq_len: Annotated[int, Field(description="The sequence length to use for the model.")] = 2048
 
     attn: Annotated[AttnImplementation, Field(description="The attention implementation to use.")] = "flash_attention_2"
@@ -278,6 +285,13 @@ class TokenizerConfig(BaseConfig):
         bool | None,
         Field(
             description="Whether to trust remote code for tokenizer initialization. If None, will use the model's default trust remote code setting.",
+        ),
+    ] = None
+
+    local_files_only: Annotated[
+        bool | None,
+        Field(
+            description="Whether to only use local files and not connect to HuggingFace Hub. If None, will use the model's setting.",
         ),
     ] = None
 

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -116,7 +116,7 @@ def train(config: RLTrainerConfig):
     model = setup_model(config.model, parallel_dims, loading_from_ckpt_later)
 
     logger.info(f"Initializing tokenizer ({config.tokenizer})")
-    tokenizer = setup_tokenizer(config.tokenizer)
+    tokenizer = setup_tokenizer(config.tokenizer, local_files_only=config.model.local_files_only)
 
     # Set up the optimizer
     logger.info(f"Initializing optimizer ({config.optim})")

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -111,7 +111,7 @@ def train(config: SFTTrainerConfig):
     model = setup_model(config.model, parallel_dims, loading_from_ckpt_later)
 
     logger.info(f"Initializing tokenizer ({config.tokenizer})")
-    tokenizer = setup_tokenizer(config.tokenizer)
+    tokenizer = setup_tokenizer(config.tokenizer, local_files_only=config.model.local_files_only)
 
     # Set up the optimizer
     logger.info(f"Initializing optimizer ({config.optim})")

--- a/src/prime_rl/utils/config.py
+++ b/src/prime_rl/utils/config.py
@@ -17,6 +17,13 @@ class ModelConfig(BaseConfig):
         ),
     ] = False
 
+    local_files_only: Annotated[
+        bool,
+        Field(
+            description="Whether to only use local files and not connect to HuggingFace Hub. Useful for offline mode.",
+        ),
+    ] = False
+
 
 ServerType = Literal["vllm", "openai"]
 


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Enables explicit offline mode for HuggingFace model and tokenizer loading by introducing and propagating a `local_files_only` configuration option. This resolves `OSError` and `LocalEntryNotFoundError` when attempting offline operations.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: [Issue ID]
**Linear Issue**: Resolves [Issue ID]

---
<a href="https://cursor.com/background-agent?bcId=bc-ce4ff375-11b1-470f-8cbc-38e37ab6199c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ce4ff375-11b1-470f-8cbc-38e37ab6199c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

