### PR TITLE
Chunked logits calculation

### DIFF
--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -176,6 +176,18 @@ class RLTrainerConfig(BaseSettings):
 
     memory_profiler_path: Annotated[Path | None, Field(description="Path to write memory profile to.")] = None
 
+    logits_vocab_chunk_size: Annotated[
+        int | None,
+        Field(
+            ge=1,
+            description=(
+                "If set, compute gathered token logprobs (and entropy) by chunking the vocabulary dimension "
+                "to reduce peak memory usage for large vocab / long sequences. "
+                "Set to e.g. 2048/4096/8192 depending on available memory."
+            ),
+        ),
+    ] = None
+
     bench: Annotated[
         bool,
         Field(


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Implements vocab-dimension chunking for gathered token logprob and entropy calculations. This significantly reduces peak GPU memory usage by avoiding the materialization of full `[batch, seq, vocab]` tensors, which is crucial for large vocabularies or long sequences.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: [Issue ID]
**Linear Issue**: Resolves [Issue ID]

---
<a href="https://cursor.com/background-agent?bcId=bc-41aab1f6-f928-4389-832d-1119f3145b94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-41aab1f6-f928-4389-832d-1119f3145b94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

