### PR TITLE
Revert "Inference readiness handshake (#1506)"

### DIFF
--- a/src/prime_rl/trainer/rl/broadcast/nccl.py
+++ b/src/prime_rl/trainer/rl/broadcast/nccl.py
@@ -17,10 +17,7 @@ from prime_rl.trainer.runs import get_runs
 from prime_rl.trainer.utils import get_world
 from prime_rl.trainer.weights import get_max_layer_num
 from prime_rl.utils.logger import get_logger
-from prime_rl.utils.pathing import sync_wait_for_path
 from prime_rl.utils.utils import get_broadcast_dir, get_step_path
-
-NCCL_READY_MARKER = "NCCL_READY"
 
 
 def broadcast_integer(integer: int, communicator: PyNcclCommunicator) -> None:
@@ -150,7 +147,7 @@ class NCCLWeightBroadcast(WeightBroadcast):
         self.world = get_world()
         self.runs = get_runs()
         self.nccl_broadcast_sender = NCCLWeightBroadcastSender(
-            config.host, config.port, 0, config.inference_world_size + 1, device, config.timeout, dtype
+            config.host, config.port, 0, config.inference_world_size + 1, device, config.timeout
         )
 
     @torch.no_grad()
@@ -158,21 +155,13 @@ class NCCLWeightBroadcast(WeightBroadcast):
         """Broadcast the state dict of a model into the inference pool using NCCL and notifies the orchestrator."""
         self.logger.debug("Starting broadcasting weights to inference engine via NCCL")
         start_time = time.perf_counter()
-        notified_runs: list[tuple[int, Path]] = []
         if self.world.is_master:
-            notified_runs = self._notify_orchestrator()
-            # Wait for inference workers to signal readiness before starting NCCL broadcast
-            self._wait_for_nccl_ready(notified_runs)
+            self._notify_orchestrator()
         self.nccl_broadcast_sender.broadcast_weights(model, step)
         self.logger.debug(f"Weights broadcasted in {time.perf_counter() - start_time:.2f}s")
 
-    def _notify_orchestrator(self) -> list[tuple[int, Path]]:
-        """Notify the orchestrator to initiate weight broadcast.
-
-        Returns:
-            List of (run_idx, save_dir) tuples for runs that were notified.
-        """
-        notified_runs: list[tuple[int, Path]] = []
+    def _notify_orchestrator(self):
+        """Notify the orchestrator to initiate weight broadcast."""
         if self.world.is_master:
             for idx in self.runs.used_idxs:
                 if not self.runs.ready_to_update[idx]:
@@ -186,19 +175,9 @@ class NCCLWeightBroadcast(WeightBroadcast):
 
                     stable_file = save_dir / "STABLE"
                     stable_file.touch()
-                    notified_runs.append((idx, save_dir))
                 except FileNotFoundError:
                     self.logger.warning(f"Run {idx} is deleted, skipping")
                 except Exception as e:
                     self.logger.error(f"Error broadcasting weights for run {idx}: {e}")
                 finally:
                     self.runs.ready_to_update[idx] = False
-        return notified_runs
-
-    def _wait_for_nccl_ready(self, notified_runs: list[tuple[int, Path]]):
-        """Wait for inference workers to signal they are ready to receive NCCL broadcast."""
-        for idx, save_dir in notified_runs:
-            nccl_ready_file = save_dir / NCCL_READY_MARKER
-            self.logger.debug(f"Waiting for NCCL_READY marker at {nccl_ready_file}")
-            sync_wait_for_path(nccl_ready_file, interval=0.1, log_interval=10)
-            self.logger.debug(f"Inference workers ready for NCCL broadcast (run {idx})")

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -101,20 +101,10 @@ async def check_health(
     await asyncio.gather(*[_check_health(admin_client) for admin_client in admin_clients])
 
 
-NCCL_READY_MARKER = "NCCL_READY"
-
-
 async def update_weights(
-    admin_clients: list[AsyncClient],
-    weight_dir: Path | None,
-    lora_name: str | None = None,
+    admin_clients: list[AsyncClient], weight_dir: Path | None, lora_name: str | None = None
 ) -> None:
-    """Make a HTTP post request to the vLLM server to update the weights.
-
-    Creates a NCCL_READY marker file before calling the update endpoint to signal
-    to the trainer that inference workers are about to enter the receive path.
-    This marker is only used in NCCL broadcast mode but is harmless in filesystem mode.
-    """
+    """Make a HTTP post request to the vLLM server to update the weights."""
     logger = get_logger()
 
     weight_dir_posix = weight_dir.as_posix() if weight_dir is not None else None
@@ -132,12 +122,6 @@ async def update_weights(
                     logger.warning("The route /update_weights does not exist. Skipping weight update.")
                     return
                 raise
-
-        # Create ready marker before servers enter receive path (used by NCCL broadcast)
-        if weight_dir is not None:
-            nccl_ready_file = weight_dir / NCCL_READY_MARKER
-            nccl_ready_file.touch()
-            logger.debug(f"Created NCCL_READY marker at {nccl_ready_file}")
 
         await asyncio.gather(*[_update_weights(admin_client, weight_dir_posix) for admin_client in admin_clients])
 


### PR DESCRIPTION
revert inference readiness handshake as it breaks restart from checkpoint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts the inference readiness handshake so broadcasting proceeds without waiting for readiness markers.
> 
> - Drops `NCCL_READY` marker creation/checks and the `_wait_for_nccl_ready` path in `nccl.py`; `_notify_orchestrator` no longer returns run info
> - Removes `NCCL_READY` handling from `utils/client.update_weights` and simplifies the docstring/signature
> - Keeps NCCL broadcast flow intact; sender is constructed without explicitly passing `dtype`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1fcaff41db941b52f5106a0ca55324a0a1fae85d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->