### PR TITLE
fix wandb

### DIFF
--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -537,7 +537,7 @@ async def run_eval(
         eval_metrics.update(pd.Series(pass_at_k.mean()).to_dict())
     eval_metrics = {**{f"eval/{env_name_or_id}/{k}": v for k, v in eval_metrics.items()}}
     eval_metrics.update({"progress/ckpt_step": ckpt_step, "step": step or ckpt_step})
-    monitor.log(eval_metrics)
+    monitor.log(eval_metrics, step=None)
 
     # Save results
     if save_config.disk is not None or save_config.hf is not None or save_config.env_hub:

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -273,7 +273,9 @@ def train(config: RLTrainerConfig):
             advantages = micro_batch["advantages"].to("cuda")
             loss_mask = micro_batch["loss_mask"].to("cuda")
             inference_logprobs = micro_batch["inference_logprobs"].to("cuda")
-            teacher_logprobs = micro_batch["teacher_logprobs"].to("cuda") if micro_batch["teacher_logprobs"] is not None else None
+            teacher_logprobs = (
+                micro_batch["teacher_logprobs"].to("cuda") if micro_batch["teacher_logprobs"] is not None else None
+            )
 
             if cp_enabled:
                 input_ids, forward_position_ids = setup_cp_params(input_ids, position_ids, cp_rank, cp_size, cp_group)
@@ -313,7 +315,9 @@ def train(config: RLTrainerConfig):
             loss, loss_tensors = compute_loss(
                 trainer_logprobs=trainer_logprobs.squeeze().split(response_lengths),
                 inference_logprobs=inference_logprobs.squeeze().split(response_lengths),
-                teacher_logprobs=teacher_logprobs.squeeze().split(response_lengths) if teacher_logprobs is not None else None,
+                teacher_logprobs=teacher_logprobs.squeeze().split(response_lengths)
+                if teacher_logprobs is not None
+                else None,
                 advantages=advantages.squeeze().split(response_lengths),
                 loss_mask=loss_mask.squeeze().split(response_lengths),
                 loss_config=config.loss,
@@ -411,7 +415,7 @@ def train(config: RLTrainerConfig):
             "perf/peak_memory": peak_memory,
             "step": progress.step,
         }
-        monitor.log(perf_metrics)
+        monitor.log(perf_metrics, step=progress.step)
 
         # Log optimizer metrics
         optim_metrics = {
@@ -419,11 +423,11 @@ def train(config: RLTrainerConfig):
             "optim/grad_norm": grad_norm.item(),
             "step": progress.step,
         }
-        monitor.log(optim_metrics)
+        monitor.log(optim_metrics, step=progress.step)
 
         # Log tensor stats
         tensor_stats["step"] = progress.step
-        monitor.log(tensor_stats)
+        monitor.log(tensor_stats, step=progress.step)
 
         # Log time metrics
         time_metrics = {
@@ -435,12 +439,12 @@ def train(config: RLTrainerConfig):
             "time/forward_backward": forward_backward_time,
             "step": progress.step,
         }
-        monitor.log(time_metrics)
+        monitor.log(time_metrics, step=progress.step)
 
         # Log disk metrics
         disk_metrics = get_ckpt_disk_metrics(config.output_dir)
         disk_metrics["step"] = progress.step
-        monitor.log(disk_metrics)
+        monitor.log(disk_metrics, step=progress.step)
 
         progress.step += 1
         is_first_step = False

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -342,7 +342,7 @@ def train(config: SFTTrainerConfig):
                     for subset_or_split, num_tokens in dataset.num_tokens.items()
                 },
             )
-        monitor.log(progress_metrics)
+        monitor.log(progress_metrics, step=progress.step)
 
         # Log performance metrics
         perf_metrics = {
@@ -352,7 +352,7 @@ def train(config: SFTTrainerConfig):
             "perf/mfu": mfu,
             "step": progress.step,
         }
-        monitor.log(perf_metrics)
+        monitor.log(perf_metrics, step=progress.step)
 
         # Log optimizer metrics
         optim_metrics = {
@@ -360,7 +360,7 @@ def train(config: SFTTrainerConfig):
             "optim/grad_norm": grad_norm.item(),
             "step": progress.step,
         }
-        monitor.log(optim_metrics)
+        monitor.log(optim_metrics, step=progress.step)
 
         loss_log_metrics = {
             "loss/mean": batch_loss.item(),
@@ -368,7 +368,7 @@ def train(config: SFTTrainerConfig):
             "step": progress.step,
         }
         # Log tensor stats
-        monitor.log(loss_log_metrics)
+        monitor.log(loss_log_metrics, step=progress.step)
 
         # Log time metrics
         time_metrics = {
@@ -377,19 +377,19 @@ def train(config: SFTTrainerConfig):
             "time/forward_backward": forward_backward_time,
             "step": progress.step,
         }
-        monitor.log(time_metrics)
+        monitor.log(time_metrics, step=progress.step)
 
         # Log disk metrics
         disk_metrics = get_ckpt_disk_metrics(config.output_dir)
         disk_metrics["step"] = progress.step
-        monitor.log(disk_metrics)
+        monitor.log(disk_metrics, step=progress.step)
 
         if is_tt_moe_model(model):
             max_vio_log_metrics = {
                 "max_vio/mean": batch_max_vio.item(),
                 "step": progress.step,
             }
-            monitor.log(max_vio_log_metrics)
+            monitor.log(max_vio_log_metrics, step=progress.step)
 
         is_first_step = False
         progress.step += 1

--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -71,13 +71,13 @@ class WandbMonitor(Monitor):
             self.logger.debug(f"Found WANDB_ARGS in environment variables {wandb_args}")
             sys.argv = json.loads(wandb_args)
 
-    def log(self, metrics: dict[str, Any]) -> None:
+    def log(self, metrics: dict[str, Any], step: int | None = None) -> None:
         self.history.append(metrics)
         if not self.is_master:
             return
         if not self.enabled:
             return
-        wandb.log(metrics)
+        wandb.log(metrics, step=step)
 
     def log_samples(self, rollouts: list[vf.State], step: int) -> None:
         """Logs rollouts to W&B table."""


### PR DESCRIPTION
wip fix step wandb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes W&B step handling by making `monitor.log` accept an explicit `step` and propagating it to `wandb.log`.
> 
> - Changes `WandbMonitor.log(metrics, step)` to forward the provided `step` to W&B instead of inferring from `metrics`
> - Updates all call sites to pass `step=progress.step` in RL/SFT trainers and `step=None` in evals (while still including `step` in the metrics payload)
> - No functional training logic changes; minor line-wrap/formatting adjustments
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28e542c9f55c49665341da8615bdbb858d04298c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->