### PR TITLE
Revert "take out step in wandb monitor (#1516)"

### DIFF
--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -77,7 +77,7 @@ class WandbMonitor(Monitor):
             return
         if not self.enabled:
             return
-        wandb.log(metrics)
+        wandb.log(metrics, step=metrics.get("step", None))
 
     def log_samples(self, rollouts: list[vf.State], step: int) -> None:
         """Logs rollouts to W&B table."""


### PR DESCRIPTION
fix wandb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures W&B logs are aligned to the intended training step.
> 
> - Update `WandbMonitor.log` to call `wandb.log(metrics, step=metrics.get("step", None))` instead of relying on implicit step
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 134fca5dd0a10f268c79fa934942ad75fabf54c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->