### PR TITLE
fix: resolve all checkpoints for proper cleanup on resume and cancelled rollout metric

### DIFF
--- a/src/prime_rl/orchestrator/ckpt.py
+++ b/src/prime_rl/orchestrator/ckpt.py
@@ -32,7 +32,6 @@ class CheckpointManager:
     def _save_to_path(
         self,
         ckpt_path: Path,
-        ckpt_step: int,
         progress: Progress,
         buffer: Buffer,
     ):
@@ -88,7 +87,7 @@ class CheckpointManager:
         """Saves the full checkpoint state for a specified step."""
         ckpt_path = self.get_ckpt_path(step)
         ckpt_path.mkdir(parents=True, exist_ok=True)
-        self._save_to_path(ckpt_path, step, progress, buffer)
+        self._save_to_path(ckpt_path, progress, buffer)
 
 
 def setup_ckpt_manager(output_dir: Path, config: CheckpointConfig | None) -> CheckpointManager | None:

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -87,7 +87,14 @@ class CheckpointManager:
         self.ckpt_dir = get_ckpt_dir(output_dir)
         self.logger = get_logger()
         self.world = get_world()
-        self.ckpt_steps: list[int] = get_all_ckpt_steps(self.ckpt_dir) if self.world.is_master else []
+        if self.world.is_master:
+            all_steps = get_all_ckpt_steps(self.ckpt_dir)
+            if config.resume_step is not None and config.resume_step >= 0:
+                self.ckpt_steps = [s for s in all_steps if s <= config.resume_step]
+            else:
+                self.ckpt_steps = all_steps
+        else:
+            self.ckpt_steps = []
 
     def get_ckpt_path(self, step: int) -> Path:
         """Get the path to write the trainer checkpoint for a given step."""
@@ -237,13 +244,21 @@ class WeightCheckpointManager:
         save_async: bool = False,
         keep_last: int | None = None,
         keep_interval: int | None = None,
+        resume_step: int | None = None,
     ):
         self.weights_dir = get_weights_dir(output_dir)
         self.config = config
         self.lora_config = lora_config
         self.logger = get_logger()
         self.world = get_world()
-        self.ckpt_steps: list[int] = get_all_ckpt_steps(self.weights_dir) if self.world.is_master else []
+        if self.world.is_master:
+            all_steps = get_all_ckpt_steps(self.weights_dir)
+            if resume_step is not None and resume_step >= 0:
+                self.ckpt_steps = [s for s in all_steps if s <= resume_step]
+            else:
+                self.ckpt_steps = all_steps
+        else:
+            self.ckpt_steps = []
         self.keep_last = keep_last
         self.keep_interval = keep_interval
 
@@ -370,6 +385,7 @@ def setup_ckpt_managers(
             lora_config=lora_config,
             keep_last=ckpt_config.keep_last,
             keep_interval=ckpt_config.keep_interval,
+            resume_step=ckpt_config.resume_step,
         )
     else:
         weight_ckpt_manager = None

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -29,7 +29,7 @@ from prime_rl.trainer.weights import (
 from prime_rl.trainer.world import get_world
 from prime_rl.utils.logger import get_logger
 from prime_rl.utils.tensor_hashing import get_module_signature, get_optimizer_signature
-from prime_rl.utils.utils import get_ckpt_dir, get_step_path, get_weights_dir
+from prime_rl.utils.utils import get_all_ckpt_steps, get_ckpt_dir, get_step_path, get_weights_dir
 
 
 class AppState(Stateful):
@@ -87,7 +87,7 @@ class CheckpointManager:
         self.ckpt_dir = get_ckpt_dir(output_dir)
         self.logger = get_logger()
         self.world = get_world()
-        self.ckpt_steps: list[int] = []  # Sorted list of steps that have been checkpointed, only used on master rank
+        self.ckpt_steps: list[int] = get_all_ckpt_steps(self.ckpt_dir) if self.world.is_master else []
 
     def get_ckpt_path(self, step: int) -> Path:
         """Get the path to write the trainer checkpoint for a given step."""
@@ -243,7 +243,7 @@ class WeightCheckpointManager:
         self.lora_config = lora_config
         self.logger = get_logger()
         self.world = get_world()
-        self.ckpt_steps: list[int] = []  # Sorted list of steps that have been checkpointed, only used on master rank
+        self.ckpt_steps: list[int] = get_all_ckpt_steps(self.weights_dir) if self.world.is_master else []
         self.keep_last = keep_last
         self.keep_interval = keep_interval
 

--- a/src/prime_rl/utils/pathing.py
+++ b/src/prime_rl/utils/pathing.py
@@ -33,14 +33,19 @@ def get_step_path(path: Path, step: int) -> Path:
     return path / f"step_{step}"
 
 
+def get_all_ckpt_steps(ckpt_dir: Path) -> list[int]:
+    """Gets all checkpoint steps from the checkpoint directory, sorted in ascending order."""
+    step_dirs = list(ckpt_dir.glob("step_*"))
+    return sorted([int(step_dir.name.split("_")[-1]) for step_dir in step_dirs])
+
+
 def resolve_latest_ckpt_step(ckpt_dir: Path) -> int | None:
     """Gets the latest checkpoint step from the checkpoint directory. Returns None if no checkpoints are found."""
-    step_dirs = list(ckpt_dir.glob("step_*"))
-    if len(step_dirs) == 0:
+    steps = get_all_ckpt_steps(ckpt_dir)
+    if len(steps) == 0:
         logger = get_logger()
         logger.warning(f"No checkpoints found in {ckpt_dir}. Starting from scratch.")
         return None
-    steps = sorted([int(step_dir.name.split("_")[-1]) for step_dir in step_dirs])
     latest_step = steps[-1]
     logger = get_logger()
     logger.info(f"Found latest checkpoint in {ckpt_dir}: {latest_step}")

--- a/src/prime_rl/utils/utils.py
+++ b/src/prime_rl/utils/utils.py
@@ -17,6 +17,7 @@ from prime_rl.utils.logger import get_logger
 # TODO: Change all imports to use utils.pathing
 # ruff: noqa: F401
 from prime_rl.utils.pathing import (
+    get_all_ckpt_steps,
     get_broadcast_dir,
     get_ckpt_dir,
     get_eval_dir,


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

fixes checkpoint resuming and deletion

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: [Issue ID]
**Linear Issue**: Resolves [Issue ID]


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Trainer checkpoints**: Initialize `ckpt_steps` from disk via `get_all_ckpt_steps` (trainer and weight managers), filtering by `resume_step` when provided; wire `resume_step` through `setup_ckpt_managers`. Ensures `maybe_clean` deletes the correct historical checkpoints after resuming.
> - **Pathing utilities**: Add `get_all_ckpt_steps` and reuse it in `resolve_latest_ckpt_step`.
> - **Orchestrator**: Simplify `_save_to_path` signature (remove unused `ckpt_step` arg).
> - **Scheduler metrics**: Track and expose `batch/cancelled_rollouts` and reset it after reporting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e40131392014bb76fd23b07cf94b2eff7d904bdf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->