### PR TITLE
fix: add step param to Monitor.log() interface

### DIFF
--- a/src/prime_rl/utils/monitor/base.py
+++ b/src/prime_rl/utils/monitor/base.py
@@ -12,7 +12,7 @@ class Monitor(ABC):
     """
 
     @abstractmethod
-    def log(self, metrics: dict[str, Any]) -> None:
+    def log(self, metrics: dict[str, Any], step: int | None = None) -> None:
         pass
 
     @abstractmethod
@@ -42,7 +42,7 @@ class NoOpMonitor(Monitor):
     def __init__(self):
         self.history: list[dict[str, Any]] = []
 
-    def log(self, metrics: dict[str, Any]) -> None:
+    def log(self, metrics: dict[str, Any], step: int | None = None) -> None:
         self.history.append(metrics)
 
     def log_samples(self, rollouts: list[vf.State], step: int) -> None:

--- a/src/prime_rl/utils/monitor/multi.py
+++ b/src/prime_rl/utils/monitor/multi.py
@@ -19,10 +19,10 @@ class MultiMonitor(Monitor):
             return []
         return self.monitors[0].history
 
-    def log(self, metrics: dict[str, Any]) -> None:
+    def log(self, metrics: dict[str, Any], step: int | None = None) -> None:
         for monitor in self.monitors:
             try:
-                monitor.log(metrics)
+                monitor.log(metrics, step=step)
             except Exception as e:
                 self.logger.warning(f"Failed to log metrics to {monitor.__class__.__name__}: {e}")
 

--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -75,7 +75,7 @@ class PrimeMonitor(Monitor):
             if config.log_extras.distributions:
                 self.last_log_distributions_step = -1
 
-    def log(self, metrics: dict[str, Any]) -> None:
+    def log(self, metrics: dict[str, Any], step: int | None = None) -> None:
         self.history.append(metrics)
         if not self.is_master:
             return


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

I was too lazy to explain my changes, decreasing my chances of this ever getting merged.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: [Issue ID]
**Linear Issue**: Resolves [Issue ID]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an optional `step` parameter to the monitoring interface and propagates it through implementations.
> 
> - Adds `step: int | None` to `Monitor.log` in `base.py`; updates `NoOpMonitor.log` accordingly
> - Updates `MultiMonitor.log` to accept and forward `step` to child monitors
> - Adjusts `PrimeMonitor.log` signature to include `step` (no change to sent metrics payload)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86657bd160e7fee3e424f4118ae591e77b46c4d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->