### PR TITLE
Pr feedback and fixes

### DIFF
--- a/src/prime_rl/trainer/models/glm4_moe/modeling_glm4_moe.py
+++ b/src/prime_rl/trainer/models/glm4_moe/modeling_glm4_moe.py
@@ -264,7 +264,7 @@ class Glm4MoeForCausalLM(Glm4MoePreTrainedModel, GenerationMixin):
         use_cache: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
         logits_to_keep: Union[int, torch.Tensor] = 0,
-        temperature: Optional[float] = None,
+        temperature: float = 1.0,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""

--- a/src/prime_rl/trainer/models/llama/modeling_llama.py
+++ b/src/prime_rl/trainer/models/llama/modeling_llama.py
@@ -248,7 +248,7 @@ class LlamaForCausalLM(LlamaPreTrainedModel, GenerationMixin):
         use_cache: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
         logits_to_keep: Union[int, torch.Tensor] = 0,
-        temperature: Optional[float] = None,
+        temperature: float = 1.0,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""

--- a/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
@@ -360,7 +360,7 @@ class Qwen3MoeForCausalLM(Qwen3MoePreTrainedModel, GenerationMixin):
         output_router_logits: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
         logits_to_keep: Union[int, torch.Tensor] = 0,
-        temperature: Optional[float] = None,
+        temperature: float = 1.0,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""


### PR DESCRIPTION
This PR addresses review comments from PR #1525 ("Fused LM Head implementation").

Key changes include:
-   Fixing an RL packing bug to prevent context leakage across sequence boundaries.
-   Hardening the `forward()` output contract to ensure `logprobs` and `entropy` are always present when `labels` are provided.
-   Resolving `temperature=None` and `labels=None` crash paths in various model implementations and `FusedOutputLinear`.
-   Simplifying `PrimeLmOutput.postprocess()` for improved readability.

---

**GitHub Issue**: #1525

---
[Slack Thread](https://personal-b9t5249.slack.com/archives/C0A5U691YQP/p1767446715877589?thread_ts=1767446715.877589&cid=C0A5U691YQP)

<a href="https://cursor.com/background-agent?bcId=bc-9c3326fb-6c4b-4669-9894-f42b3e5dc40f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9c3326fb-6c4b-4669-9894-f42b3e5dc40f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

