### PR TITLE
Fix trainer crash on empty micro batches

### DIFF
--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -245,6 +245,12 @@ def train(config: RLTrainerConfig):
         load_data_time = time.perf_counter() - load_data_start_time
         logger.debug(f"Loaded batch in {load_data_time:.2f} seconds")
 
+        # Skip step if no data available (can happen when no rollouts are ready)
+        if not micro_batches:
+            logger.warning("No micro batches available, waiting for rollouts...")
+            time.sleep(1)
+            continue
+
         batch_size = len(micro_batches)
         memory_profiler = None
         if config.memory_profiler_path is not None:


### PR DESCRIPTION
## Summary
- Handles empty micro_batches gracefully instead of crashing with IndexError
- Logs a warning and waits for rollouts when none are available

## Problem
Trainer crashes with `IndexError: list index out of range` at `train.py:254` when accessing `micro_batches[0]` and the list is empty. This happens when no rollouts are ready (e.g., at startup before inference generates completions, or during transient conditions).

## Fix
```python
if not micro_batches:
    logger.warning("No micro batches available, waiting for rollouts...")
    time.sleep(1)
    continue
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents a crash when `micro_batches` is empty during training.
> 
> - In `train.py`, adds a guard after `dataloader.get_batch()` to detect empty `micro_batches`; logs a warning, sleeps 1s, and `continue`s the loop to wait for rollouts
> - Avoids `IndexError` from accessing `micro_batches[0]` when no rollouts are ready
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f67048359fa94565e444a5711e01d4b6d8739b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->