### PR TITLE
feat: set default fused_lm_head_chunk_size to 2048 for RL training

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,4 @@ Documenting changes which affect configuration usage patterns (added/moved/remov
 - **`ckpt.keep`**: Renamed to `ckpt.keep_last`. Added `ckpt.keep_interval` to keep checkpoints at every N steps permanently (2025-12-31)
 - **`MultiLoRAMoE`**: QwenMoE now supports training expert loras and this is enabled by default in the `target_modules`. (2026-01-01)
 - **`model.fused_lm_head_chunk_size`**: Added chunk size configuration for fused LM head to enable memory-efficient chunked logprob computation. When set, splits vocabulary into chunks to avoid materializing full [N, V] logit tensor (default: None) (#1525, 2026-01-03)
+- **`model.fused_lm_head_chunk_size`**: RL training now auto-sets this to 2048 if not specified. SFT training continues to use None (2026-01-05)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,4 +28,4 @@ Documenting changes which affect configuration usage patterns (added/moved/remov
 - **`ckpt.keep`**: Renamed to `ckpt.keep_last`. Added `ckpt.keep_interval` to keep checkpoints at every N steps permanently (2025-12-31)
 - **`MultiLoRAMoE`**: QwenMoE now supports training expert loras and this is enabled by default in the `target_modules`. (2026-01-01)
 - **`model.fused_lm_head_chunk_size`**: Added chunk size configuration for fused LM head to enable memory-efficient chunked logprob computation. When set, splits vocabulary into chunks to avoid materializing full [N, V] logit tensor (default: None) (#1525, 2026-01-03)
-- **`model.fused_lm_head_chunk_size`**: RL training now auto-sets this to 2048 if not specified. SFT training continues to use None (2026-01-05)
+- **`model.fused_lm_head_chunk_size`**: RL training now auto-sets this to 2048 if not specified (except when `impl='liger_kernel'`). SFT training continues to use None (2026-01-05)

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -241,7 +241,7 @@ class ModelConfig(BaseConfig):
     fused_lm_head_chunk_size: Annotated[
         int | None,
         Field(
-            description="The chunk size to use for the fused LM head. If None, will not use chunking. RL training auto-sets this to 2048 if not specified.",
+            description="The chunk size to use for the fused LM head. If None, will not use chunking. RL training auto-sets this to 2048 if not specified (except when impl='liger_kernel').",
         ),
     ] = None
 

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -241,7 +241,7 @@ class ModelConfig(BaseConfig):
     fused_lm_head_chunk_size: Annotated[
         int | None,
         Field(
-            description="The chunk size to use for the model. If None, will not use chunking.",
+            description="The chunk size to use for the fused LM head. If None, will not use chunking. RL training auto-sets this to 2048 if not specified.",
         ),
     ] = None
 

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -265,6 +265,6 @@ class RLTrainerConfig(BaseSettings):
 
     @model_validator(mode="after")
     def auto_setup_fused_lm_head_chunk_size(self):
-        if self.model.fused_lm_head_chunk_size is None:
+        if self.model.fused_lm_head_chunk_size is None and self.model.impl != "liger_kernel":
             self.model.fused_lm_head_chunk_size = 2048
         return self

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -262,3 +262,9 @@ class RLTrainerConfig(BaseSettings):
         if self.tokenizer.trust_remote_code is None:
             self.tokenizer.trust_remote_code = self.model.trust_remote_code
         return self
+
+    @model_validator(mode="after")
+    def auto_setup_fused_lm_head_chunk_size(self):
+        if self.model.fused_lm_head_chunk_size is None:
+            self.model.fused_lm_head_chunk_size = 2048
+        return self

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -73,11 +73,16 @@ def check_number_in_range(
     """Helper to assert that a number in step logs is within a threshold"""
     step_lines = [line for line in lines if "Step" in line]
     assert len(step_lines) > 0, f"No step lines found in output ({lines})"
-    try:
-        step_line = step_lines[step]
-    except IndexError:
-        step_line = ""
-    assert step_line, f"Could not find step {step} in output ({lines})"
+    
+    # Search for the specific step number in the lines
+    if step == -1:
+        step_line = step_lines[-1]
+    else:
+        step_pattern = rf"Step {step}\b"
+        matching_lines = [line for line in step_lines if re.search(step_pattern, line)]
+        assert len(matching_lines) > 0, f"Could not find step {step} in output ({step_lines})"
+        step_line = matching_lines[0]
+    
     step_reward = re.search(pattern, step_line)
     assert step_reward is not None, f"Could not find reward for step {step}. Line: {step_line} ({lines})"
     step_reward = float(step_reward.group(1))


### PR DESCRIPTION
Auto-configures model.fused_lm_head_chunk_size to 2048 for RL training when not explicitly set. SFT training continues to use None (no chunking) as it doesn't support chunked loss yet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces default chunking for fused LM head in RL to reduce memory without explicit config.
> 
> - Adds `auto_setup_fused_lm_head_chunk_size` validator in RL config to set `model.fused_lm_head_chunk_size=2048` when unset and `impl!='liger_kernel'`
> - Updates `ModelConfig.fused_lm_head_chunk_size` field description to document RL default behavior
> - Updates `CHANGELOG.md` accordingly
> - Improves `tests/utils.py::check_number_in_range` to match a specific `Step {n}` line (falls back to latest when `step=-1`) instead of relying on line index
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d99066946c5d756c3f39224747b25068b2172a57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->