### PR TITLE
[feat] Enable loss chunking for non-custom HuggingFace models

### DIFF
--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -274,14 +274,6 @@ class ModelConfig(BaseConfig):
         return self
 
     @model_validator(mode="after")
-    def fused_lm_head_chunk_size_requires_custom_impl(self):
-        if self.fused_lm_head_chunk_size is not None and self.impl not in ("custom", "auto"):
-            raise ValueError(
-                "Fused LM head chunk size is only supported with the custom implementation or auto mode (if the model doesn't support custom implementation and chunk size is provided, it will be ignored)"
-            )
-        return self
-
-    @model_validator(mode="after")
     def fused_lm_head_chunk_size_is_valid(self):
         if self.fused_lm_head_chunk_size is not None:
             low = 512

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -67,6 +67,7 @@ def wrap_lm_head_for_hf_model(model: nn.Module, chunk_size: int | None = None) -
     assert isinstance(model.model, nn.Module), f"model.model is not a nn.Module: {type(model.model)}\n{model}"
     assert hasattr(model, "lm_head"), f"model doesnt have lm_head in model.lm_head:\n{model}"
     assert isinstance(model.lm_head, nn.Linear), f"model.lm_head is not a nn.Linear: {type(model.lm_head)}\n{model}"
+    assert not hasattr(model.lm_head.bias), f"model.lm_head.bias is not supported: {model.lm_head}\n{model}"
 
     logger = get_logger()
 

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -25,6 +25,7 @@ from prime_rl.trainer.models import (
     AutoModelForCausalLMPrimeRL,
     PreTrainedModelPrimeRL,
     PrimeLmOutput,
+    cast_float_and_contiguous,
     supports_custom_impl,
 )
 from prime_rl.trainer.models.layers.lm_head import FusedOutputLinear, VanillaOutputLinear
@@ -484,7 +485,8 @@ def forward(
 ) -> PrimeLmOutput:
     out = model(input_ids=input_ids, position_ids=position_ids, labels=labels, temperature=temperature)
 
-    if isinstance(out, PrimeLmOutput):
-        return out.cast_float_and_contiguous()
+    # PrimeLmOutput is a TypedDict (dict at runtime), HF outputs are dataclass-like objects
+    if isinstance(out, dict):
+        return cast_float_and_contiguous(out)
 
-    return PrimeLmOutput(logits=out.logits).cast_float_and_contiguous()
+    return cast_float_and_contiguous(PrimeLmOutput(logits=out.logits))

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -1,5 +1,6 @@
 import logging
 import time
+import types
 from pathlib import Path
 from typing import cast
 
@@ -26,6 +27,7 @@ from prime_rl.trainer.models import (
     PrimeLmOutput,
     supports_custom_impl,
 )
+from prime_rl.trainer.models.layers.lm_head import FusedOutputLinear, VanillaOutputLinear
 from prime_rl.trainer.parallel_dims import ParallelDims
 from prime_rl.trainer.weights import (
     load_state_dict,
@@ -50,6 +52,80 @@ DTYPE_MAP = {
 
 def is_tt_moe_model(model: nn.Module) -> bool:
     return hasattr(model.config, "num_experts") or hasattr(model.config, "n_routed_experts")
+
+
+def wrap_lm_head_for_hf_model(model: nn.Module, chunk_size: int | None = None) -> None:
+    """
+    Wrap the lm_head of a HuggingFace model with FusedOutputLinear or VanillaOutputLinear,
+    and override the forward method to use it with labels and temperature.
+
+    This enables chunked loss computation for non-custom (HuggingFace) models.
+    """
+    logger = get_logger()
+    old_lm_head = model.lm_head
+
+    logger.info(f"Wrapping LM head for HF model with chunk size {chunk_size}")
+
+    if chunk_size is not None:
+        model.lm_head = FusedOutputLinear(
+            in_features=old_lm_head.in_features, out_features=old_lm_head.out_features, chunk_size=chunk_size
+        )
+    else:
+        model.lm_head = VanillaOutputLinear(
+            in_features=old_lm_head.in_features, out_features=old_lm_head.out_features
+        )
+
+    model.lm_head.weight = old_lm_head.weight
+    del old_lm_head
+
+    # Create a new forward method that uses the wrapped lm_head
+    def new_forward(
+        self,
+        input_ids=None,
+        attention_mask=None,
+        position_ids=None,
+        past_key_values=None,
+        inputs_embeds=None,
+        labels=None,
+        use_cache=None,
+        output_attentions=None,
+        output_hidden_states=None,
+        return_dict=None,
+        cache_position=None,
+        logits_to_keep=0,
+        temperature=1.0,
+        **kwargs,
+    ) -> PrimeLmOutput:
+        # Run through base model to get hidden states
+        # Most HF models have self.model as the base transformer
+        outputs = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=True,
+            cache_position=cache_position,
+            **kwargs,
+        )
+
+        hidden_states = outputs.last_hidden_state
+
+        # Slice hidden states for logits_to_keep
+        slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) and logits_to_keep > 0 else slice(None)
+
+        # Pass through the wrapped lm_head
+        return self.lm_head(
+            hidden_states[:, slice_indices, :],
+            labels[:, slice_indices] if labels is not None else None,
+            temperature=temperature,
+        )
+
+    # Bind the new forward to the model
+    model.forward = types.MethodType(new_forward, model)
 
 
 def get_load_balance_stats(
@@ -359,11 +435,11 @@ def setup_model(
         logger.warning("Cannot load model to meta device only, loading to CPU instead.")
         model = get_model(config, device=torch.device("cpu"), dtype=DTYPE_MAP[config.optimization_dtype])
 
-    if not isinstance(model, PreTrainedModelPrimeRL) and config.fused_lm_head_chunk_size is not None:
-        logger.warning("Fused LM head chunk size was specified but model is not a PrimeRL model, ignoring chunk size.")
-
     if isinstance(model, PreTrainedModelPrimeRL):
         model.wrap_lm_head(chunk_size=config.fused_lm_head_chunk_size)
+    else:
+        # For non-custom (HuggingFace) models, wrap the lm_head to enable chunked loss computation
+        wrap_lm_head_for_hf_model(model, chunk_size=config.fused_lm_head_chunk_size)
 
     # Apply LoRA before FSDP setup
     if config.lora is not None:

--- a/src/prime_rl/trainer/models/__init__.py
+++ b/src/prime_rl/trainer/models/__init__.py
@@ -11,7 +11,7 @@ from transformers.models.llama.configuration_llama import LlamaConfig
 from prime_rl.trainer.models.afmoe import AfmoeConfig, AfmoeForCausalLM
 from prime_rl.trainer.models.base import PreTrainedModelPrimeRL
 from prime_rl.trainer.models.glm4_moe import Glm4MoeConfig, Glm4MoeForCausalLM
-from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput
+from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput, cast_float_and_contiguous
 from prime_rl.trainer.models.llama import LlamaForCausalLM
 from prime_rl.trainer.models.qwen3_moe import Qwen3MoeConfig, Qwen3MoeForCausalLM
 
@@ -46,4 +46,4 @@ def supports_custom_impl(model_config: PretrainedConfig) -> bool:
     return type(model_config) in _CUSTOM_CAUSAL_LM_MAPPING
 
 
-__all__ = ["AutoModelForCausalLMPrimeRL", "PreTrainedModelPrimeRL", "supports_custom_impl", "PrimeLmOutput"]
+__all__ = ["AutoModelForCausalLMPrimeRL", "PreTrainedModelPrimeRL", "supports_custom_impl", "PrimeLmOutput", "cast_float_and_contiguous"]

--- a/src/prime_rl/trainer/models/base.py
+++ b/src/prime_rl/trainer/models/base.py
@@ -1,9 +1,6 @@
 from torch import Tensor
 from transformers.modeling_utils import PreTrainedModel
 
-from prime_rl.trainer.models.layers.lm_head import FusedOutputLinear, VanillaOutputLinear
-from prime_rl.utils.logger import get_logger
-
 
 class PreTrainedModelPrimeRL(PreTrainedModel):
     """
@@ -103,24 +100,6 @@ class PreTrainedModelPrimeRL(PreTrainedModel):
         This is called after loading the model from a checkpoint with meta device.
         """
         raise NotImplementedError(f"init_buffers_post_meta is not implemented for {self.__class__.__name__}")
-
-    def wrap_lm_head(self, chunk_size: int | None = None) -> None:
-        old_lm_head = self.lm_head
-
-        logger = get_logger()
-        logger.info(f"Wrapping LM head with chunk size {chunk_size}")
-
-        if chunk_size is not None:
-            self.lm_head = FusedOutputLinear(
-                in_features=old_lm_head.in_features, out_features=old_lm_head.out_features, chunk_size=chunk_size
-            )
-        else:
-            self.lm_head = VanillaOutputLinear(
-                in_features=old_lm_head.in_features, out_features=old_lm_head.out_features
-            )
-
-        self.lm_head.weight = old_lm_head.weight
-        del old_lm_head
 
 
 __all__ = ["PreTrainedModelPrimeRL"]

--- a/src/prime_rl/trainer/models/layers/lm_head.py
+++ b/src/prime_rl/trainer/models/layers/lm_head.py
@@ -231,30 +231,19 @@ def inject_prime_lm_head(model: nn.Module, chunk_size: int | None = None) -> Non
     def new_forward(
         self: nn.Module,
         input_ids: torch.Tensor | None = None,
-        attention_mask: torch.Tensor | None = None,
         position_ids: torch.Tensor | None = None,
-        past_key_values: torch.Tensor | None = None,
         inputs_embeds: torch.Tensor | None = None,
         labels: torch.Tensor | None = None,
-        use_cache: bool | None = None,
-        output_attentions: bool | None = None,
-        output_hidden_states: bool | None = None,
-        cache_position: torch.Tensor | None = None,
         logits_to_keep: int = 0,
         temperature: float = 1.0,
         **kwargs: object,
     ) -> PrimeLmOutput:
+        if position_ids is None:
+            position_ids = torch.arange(1, input_ids.shape[1] + 1, device=input_ids.device).unsqueeze(0)
         outputs = self.model(
             input_ids=input_ids,
-            attention_mask=attention_mask,
             position_ids=position_ids,
-            past_key_values=past_key_values,
             inputs_embeds=inputs_embeds,
-            use_cache=use_cache,
-            output_attentions=output_attentions,
-            output_hidden_states=output_hidden_states,
-            return_dict=True,
-            cache_position=cache_position,
             **kwargs,
         )
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/models/layers/lm_head.py
+++ b/src/prime_rl/trainer/models/layers/lm_head.py
@@ -239,7 +239,8 @@ def inject_prime_lm_head(model: nn.Module, chunk_size: int | None = None) -> Non
         **kwargs: object,
     ) -> PrimeLmOutput:
         if position_ids is None:
-            position_ids = torch.arange(1, input_ids.shape[1] + 1, device=input_ids.device).unsqueeze(0)
+            reference_tensor = input_ids if input_ids is not None else inputs_embeds
+            position_ids = torch.arange(1, reference_tensor.shape[1] + 1, device=reference_tensor.device).unsqueeze(0)
         outputs = self.model(
             input_ids=input_ids,
             position_ids=position_ids,

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -242,7 +242,7 @@ def train(config: SFTTrainerConfig):
             with maybe_record_function("forward"), maybe_activation_offloading(config.model.ac_offloading):
                 out = forward(model, input_ids, position_ids)
 
-            logits = out.logits
+            logits = out["logits"]
             B, L, V = logits.shape
 
             # Compute loss

--- a/tests/unit/train/models/test_afmoe.py
+++ b/tests/unit/train/models/test_afmoe.py
@@ -3,6 +3,7 @@ import torch
 from torch import nn
 
 from prime_rl.trainer.models.afmoe import AfmoeForCausalLM as PrimeRLAfmoeForCausalLM
+from prime_rl.trainer.models.layers.lm_head import inject_prime_lm_head
 from prime_rl.utils.utils import default_dtype
 from tests.unit.train.models.afmoe_hf_modeling.configuration_afmoe import AfmoeConfig
 from tests.unit.train.models.afmoe_hf_modeling.modeling_afmoe import (
@@ -64,7 +65,7 @@ def get_model_pairs():
         prime_state_keys = prime_model.state_dict().keys()
         prime_model.convert_to_prime(state_dict)
         prime_model.load_state_dict(state_dict)
-        prime_model.wrap_lm_head(chunk_size=None)
+        inject_prime_lm_head(prime_model, chunk_size=None)
     assert set(prime_state_keys) - set(state_dict.keys()) == set()
     return hf_model, prime_model
 

--- a/tests/unit/train/models/test_afmoe.py
+++ b/tests/unit/train/models/test_afmoe.py
@@ -83,9 +83,9 @@ def test_afmoe_attn_only() -> None:
     hf_output = hf_model(input_ids, position_ids=position_ids)
     prime_output = prime_model(input_ids, position_ids=position_ids)
     hf_output.logits.sum().backward()
-    prime_output.logits.sum().backward()
+    prime_output["logits"].sum().backward()
 
-    logits_diff = prime_output.logits - hf_output.logits
+    logits_diff = prime_output["logits"] - hf_output.logits
     assert torch.allclose(logits_diff, torch.zeros_like(logits_diff), atol=2e-2), (
         f"Max logits diff: {logits_diff.abs().max()}"
     )
@@ -116,9 +116,9 @@ def test_afmoe_mlp_only() -> None:
     hf_output = hf_model(input_ids, position_ids=position_ids)
     prime_output = prime_model(input_ids, position_ids=position_ids)
     hf_output.logits.sum().backward()
-    prime_output.logits.sum().backward()
+    prime_output["logits"].sum().backward()
 
-    logits_diff = prime_output.logits - hf_output.logits
+    logits_diff = prime_output["logits"] - hf_output.logits
     assert torch.allclose(logits_diff, torch.zeros_like(logits_diff), atol=2e-2), (
         f"Max logits diff: {logits_diff.abs().max()}"
     )
@@ -136,9 +136,9 @@ def test_afmoe() -> None:
     hf_output = hf_model(input_ids, position_ids=position_ids)
     prime_output = prime_model(input_ids, position_ids=position_ids)
     hf_output.logits.sum().backward()
-    prime_output.logits.sum().backward()
+    prime_output["logits"].sum().backward()
 
-    logits_diff = prime_output.logits - hf_output.logits
+    logits_diff = prime_output["logits"] - hf_output.logits
     assert torch.allclose(logits_diff, torch.zeros_like(logits_diff), atol=2e-2), (
         f"Max logits diff: {logits_diff.abs().max()}"
     )

--- a/tests/unit/train/models/test_glm4_moe.py
+++ b/tests/unit/train/models/test_glm4_moe.py
@@ -5,6 +5,7 @@ from transformers import Glm4MoeForCausalLM as HFGlm4MoeForCausalLM
 
 from prime_rl.trainer.models.glm4_moe import Glm4MoeConfig
 from prime_rl.trainer.models.glm4_moe import Glm4MoeForCausalLM as PrimeRLGlm4MoeForCausalLM
+from prime_rl.trainer.models.layers.lm_head import inject_prime_lm_head
 from prime_rl.utils.utils import default_dtype
 
 pytestmark = [pytest.mark.gpu]
@@ -41,7 +42,7 @@ def get_model_pairs() -> tuple[HFGlm4MoeForCausalLM, PrimeRLGlm4MoeForCausalLM]:
         prime_model.convert_to_prime(state_dict)
         prime_model.load_state_dict(state_dict)
     # Training code wraps the LM head; tests should mirror that (so forward can accept labels/temperature).
-    prime_model.wrap_lm_head(chunk_size=None)
+    inject_prime_lm_head(prime_model, chunk_size=None)
     assert set(prime_state_keys) - set(state_dict.keys()) == set()
     return hf_model, prime_model
 

--- a/tests/unit/train/models/test_glm4_moe.py
+++ b/tests/unit/train/models/test_glm4_moe.py
@@ -60,9 +60,9 @@ def test_glm4_moe_attn_only() -> None:
     hf_output = hf_model(input_ids, position_ids)
     prime_output = prime_model(input_ids, position_ids)
     hf_output.logits.sum().backward()
-    prime_output.logits.sum().backward()
+    prime_output["logits"].sum().backward()
 
-    logits_diff = prime_output.logits - hf_output.logits
+    logits_diff = prime_output["logits"] - hf_output.logits
     assert torch.allclose(logits_diff, torch.zeros_like(logits_diff), atol=2e-2), (
         f"Max logits diff: {logits_diff.abs().max()}"
     )
@@ -88,9 +88,9 @@ def test_glm4_moe_mlp_only() -> None:
     hf_output = hf_model(input_ids, position_ids)
     prime_output = prime_model(input_ids, position_ids)
     hf_output.logits.sum().backward()
-    prime_output.logits.sum().backward()
+    prime_output["logits"].sum().backward()
 
-    logits_diff = prime_output.logits - hf_output.logits
+    logits_diff = prime_output["logits"] - hf_output.logits
     assert torch.allclose(logits_diff, torch.zeros_like(logits_diff), atol=2e-2), (
         f"Max logits diff: {logits_diff.abs().max()}"
     )
@@ -108,9 +108,9 @@ def test_glm4_moe() -> None:
     hf_output = hf_model(input_ids, position_ids)
     prime_output = prime_model(input_ids, position_ids)
     hf_output.logits.sum().backward()
-    prime_output.logits.sum().backward()
+    prime_output["logits"].sum().backward()
 
-    logits_diff = prime_output.logits - hf_output.logits
+    logits_diff = prime_output["logits"] - hf_output.logits
     assert torch.allclose(logits_diff, torch.zeros_like(logits_diff), atol=2e-2), (
         f"Max logits diff: {logits_diff.abs().max()}"
     )

--- a/tests/unit/train/models/test_llama.py
+++ b/tests/unit/train/models/test_llama.py
@@ -53,9 +53,9 @@ def test_llama_attn_only():
     hf_output = hf_model(input_ids, position_ids)
     prime_output = prime_model(input_ids, position_ids)
     hf_output.logits.sum().backward()
-    prime_output.logits.sum().backward()
+    prime_output["logits"].sum().backward()
 
-    logits_diff = prime_output.logits - hf_output.logits
+    logits_diff = prime_output["logits"] - hf_output.logits
     assert torch.allclose(logits_diff, torch.zeros_like(logits_diff), atol=2e-2), (
         f"Max logits diff: {logits_diff.abs().max()}"
     )
@@ -81,9 +81,9 @@ def test_llama_mlp_only():
     hf_output = hf_model(input_ids, position_ids)
     prime_output = prime_model(input_ids, position_ids)
     hf_output.logits.sum().backward()
-    prime_output.logits.sum().backward()
+    prime_output["logits"].sum().backward()
 
-    logits_diff = prime_output.logits - hf_output.logits
+    logits_diff = prime_output["logits"] - hf_output.logits
     assert torch.allclose(logits_diff, torch.zeros_like(logits_diff), atol=2e-2), (
         f"Max logits diff: {logits_diff.abs().max()}"
     )
@@ -101,9 +101,9 @@ def test_llama():
     hf_output = hf_model(input_ids, position_ids)
     prime_output = prime_model(input_ids, position_ids)
     hf_output.logits.sum().backward()
-    prime_output.logits.sum().backward()
+    prime_output["logits"].sum().backward()
 
-    logits_diff = prime_output.logits - hf_output.logits
+    logits_diff = prime_output["logits"] - hf_output.logits
     assert torch.allclose(logits_diff, torch.zeros_like(logits_diff), atol=2e-2), (
         f"Max logits diff: {logits_diff.abs().max()}"
     )

--- a/tests/unit/train/models/test_llama.py
+++ b/tests/unit/train/models/test_llama.py
@@ -4,6 +4,7 @@ from torch import nn
 from transformers import LlamaForCausalLM as HFLlamaForCausalLM
 from transformers.models.llama.configuration_llama import LlamaConfig
 
+from prime_rl.trainer.models.layers.lm_head import inject_prime_lm_head
 from prime_rl.trainer.models.llama import LlamaForCausalLM as PrimeRLLlamaForCausalLM
 from prime_rl.utils.utils import default_dtype
 
@@ -34,7 +35,7 @@ def get_model_pairs():
         prime_model.convert_to_prime(state_dict)
         prime_model.load_state_dict(state_dict)
     # Training code wraps the LM head; tests should mirror that (so forward can accept labels/temperature).
-    prime_model.wrap_lm_head(chunk_size=None)
+    inject_prime_lm_head(prime_model, chunk_size=None)
     assert set(prime_state_keys) - set(state_dict.keys()) == set()
     return hf_model, prime_model
 

--- a/tests/unit/train/models/test_qwen3_moe.py
+++ b/tests/unit/train/models/test_qwen3_moe.py
@@ -59,9 +59,9 @@ def test_qwen3_moe_attn_only():
     hf_output = hf_model(input_ids, position_ids)
     prime_output = prime_model(input_ids, position_ids)
     hf_output.logits.sum().backward()
-    prime_output.logits.sum().backward()
+    prime_output["logits"].sum().backward()
 
-    logits_diff = prime_output.logits - hf_output.logits
+    logits_diff = prime_output["logits"] - hf_output.logits
     assert torch.allclose(logits_diff, torch.zeros_like(logits_diff), atol=2e-2), (
         f"Max logits diff: {logits_diff.abs().max()}"
     )
@@ -87,9 +87,9 @@ def test_qwen3_moe_mlp_only():
     hf_output = hf_model(input_ids, position_ids)
     prime_output = prime_model(input_ids, position_ids)
     hf_output.logits.sum().backward()
-    prime_output.logits.sum().backward()
+    prime_output["logits"].sum().backward()
 
-    logits_diff = prime_output.logits - hf_output.logits
+    logits_diff = prime_output["logits"] - hf_output.logits
     assert torch.allclose(logits_diff, torch.zeros_like(logits_diff), atol=2e-2), (
         f"Max logits diff: {logits_diff.abs().max()}"
     )
@@ -107,9 +107,9 @@ def test_qwen3_moe():
     hf_output = hf_model(input_ids, position_ids)
     prime_output = prime_model(input_ids, position_ids)
     hf_output.logits.sum().backward()
-    prime_output.logits.sum().backward()
+    prime_output["logits"].sum().backward()
 
-    logits_diff = prime_output.logits - hf_output.logits
+    logits_diff = prime_output["logits"] - hf_output.logits
     assert torch.allclose(logits_diff, torch.zeros_like(logits_diff), atol=2e-2), (
         f"Max logits diff: {logits_diff.abs().max()}"
     )

--- a/tests/unit/train/models/test_qwen3_moe.py
+++ b/tests/unit/train/models/test_qwen3_moe.py
@@ -3,6 +3,7 @@ import torch
 from torch import nn
 from transformers import Qwen3MoeForCausalLM as HFQwen3MoeForCausalLM
 
+from prime_rl.trainer.models.layers.lm_head import inject_prime_lm_head
 from prime_rl.trainer.models.qwen3_moe import Qwen3MoeConfig
 from prime_rl.trainer.models.qwen3_moe import Qwen3MoeForCausalLM as PrimeRLQwen3MoeForCausalLM
 from prime_rl.utils.utils import default_dtype
@@ -40,7 +41,7 @@ def get_model_pairs():
         prime_model.convert_to_prime(state_dict)
         prime_model.load_state_dict(state_dict)
     # Training code wraps the LM head; tests should mirror that (so forward can accept labels/temperature).
-    prime_model.wrap_lm_head(chunk_size=None)
+    inject_prime_lm_head(prime_model, chunk_size=None)
     assert set(prime_state_keys) - set(state_dict.keys()) == set()
     return hf_model, prime_model
 

--- a/tests/unit/train/test_model.py
+++ b/tests/unit/train/test_model.py
@@ -3,6 +3,7 @@ import torch
 
 from prime_rl.trainer.config import AttnImplementation, ModelConfig
 from prime_rl.trainer.model import get_model
+from prime_rl.trainer.models.layers.lm_head import inject_prime_lm_head
 
 BS = 1
 SEQ_LEN = 8
@@ -114,7 +115,7 @@ def test_moe_custom_impl():
     model = get_model(config)
     model = model.to("cuda")
     # we need to wrap the lm head as custom forward only works with it, this is done in setup_model
-    model.wrap_lm_head(chunk_size=None)
+    inject_prime_lm_head(model, chunk_size=None)
     with torch.autocast("cuda", dtype=torch.bfloat16):
         inputs_ids = torch.randint(0, 100, (BS, SEQ_LEN)).to("cuda")
         outputs = model(input_ids=inputs_ids)
@@ -129,7 +130,7 @@ def test_model_forward_custom_impl(model_name):
     config = ModelConfig(name=model_name, impl="custom", attn="sdpa")
     model = get_model(config)
     # we need to wrap the lm head as custom forward only works with it, this is done in setup_model
-    model.wrap_lm_head(chunk_size=None)
+    inject_prime_lm_head(model, chunk_size=None)
     model = model.to("cuda")
     with torch.autocast("cuda", dtype=torch.bfloat16):
         inputs_ids = torch.randint(0, 100, (BS, SEQ_LEN)).to("cuda")

--- a/tests/unit/train/test_model.py
+++ b/tests/unit/train/test_model.py
@@ -41,7 +41,7 @@ def test_model_forward(model):
     with torch.autocast("cuda", dtype=torch.bfloat16):
         inputs_ids = torch.randint(0, 100, (BS, SEQ_LEN)).to("cuda")
         outputs = model(input_ids=inputs_ids)
-        logits = outputs["logits"] if isinstance(outputs, dict) else outputs.logits
+        logits = outputs["logits"]
 
         assert logits.shape == (BS, SEQ_LEN, model.config.vocab_size)
 
@@ -53,7 +53,7 @@ def test_model_with_position_ids(model):
         position_ids = torch.arange(SEQ_LEN).unsqueeze(0).repeat(BS, 1).to("cuda")
 
         outputs = model(input_ids=inputs_ids, position_ids=position_ids)
-        logits = outputs["logits"] if isinstance(outputs, dict) else outputs.logits
+        logits = outputs["logits"]
 
         assert logits.shape == (BS, SEQ_LEN, model.config.vocab_size)
 
@@ -78,7 +78,7 @@ def test_model_with_sequence_packing(model, correct_position_ids):
     with torch.autocast("cuda", dtype=torch.bfloat16):
         inputs_ids = torch.Tensor(inputs).repeat(1, 1).int().to("cuda")
         outputs = model(input_ids=inputs_ids)
-        output_base = outputs["logits"] if isinstance(outputs, dict) else outputs.logits
+        output_base = outputs["logits"]
 
         assert output_base.shape == (1, len(inputs), model.config.vocab_size)
 
@@ -91,7 +91,7 @@ def test_model_with_sequence_packing(model, correct_position_ids):
             position_ids = torch.Tensor([0, 1, 2, 3, 4, 5, 6, 7]).repeat(1, 1).int().to("cuda")
             # should fail
         outputs = model(input_ids=inputs_ids, position_ids=position_ids)
-        outputs_packed = outputs["logits"] if isinstance(outputs, dict) else outputs.logits
+        outputs_packed = outputs["logits"]
 
         assert outputs_packed.shape == (1, 2 * len(inputs), model.config.vocab_size)
 
@@ -118,7 +118,7 @@ def test_moe_custom_impl():
     with torch.autocast("cuda", dtype=torch.bfloat16):
         inputs_ids = torch.randint(0, 100, (BS, SEQ_LEN)).to("cuda")
         outputs = model(input_ids=inputs_ids)
-        logits = outputs["logits"] if isinstance(outputs, dict) else outputs.logits
+        logits = outputs["logits"]
 
         assert logits.shape == (BS, SEQ_LEN, model.config.vocab_size)
 
@@ -134,6 +134,6 @@ def test_model_forward_custom_impl(model_name):
     with torch.autocast("cuda", dtype=torch.bfloat16):
         inputs_ids = torch.randint(0, 100, (BS, SEQ_LEN)).to("cuda")
         outputs = model(input_ids=inputs_ids)
-        logits = outputs["logits"] if isinstance(outputs, dict) else outputs.logits
+        logits = outputs["logits"]
 
         assert logits.shape == (BS, SEQ_LEN, model.config.vocab_size)

--- a/tests/unit/train/test_model.py
+++ b/tests/unit/train/test_model.py
@@ -40,9 +40,10 @@ def test_model_forward(model):
     model = model.to("cuda")
     with torch.autocast("cuda", dtype=torch.bfloat16):
         inputs_ids = torch.randint(0, 100, (BS, SEQ_LEN)).to("cuda")
-        outputs = model(input_ids=inputs_ids).logits
+        outputs = model(input_ids=inputs_ids)
+        logits = outputs["logits"] if isinstance(outputs, dict) else outputs.logits
 
-        assert outputs.shape == (BS, SEQ_LEN, model.config.vocab_size)
+        assert logits.shape == (BS, SEQ_LEN, model.config.vocab_size)
 
 
 def test_model_with_position_ids(model):
@@ -51,9 +52,10 @@ def test_model_with_position_ids(model):
         inputs_ids = torch.randint(0, 100, (BS, SEQ_LEN)).to("cuda")
         position_ids = torch.arange(SEQ_LEN).unsqueeze(0).repeat(BS, 1).to("cuda")
 
-        outputs = model(input_ids=inputs_ids, position_ids=position_ids).logits
+        outputs = model(input_ids=inputs_ids, position_ids=position_ids)
+        logits = outputs["logits"] if isinstance(outputs, dict) else outputs.logits
 
-        assert outputs.shape == (BS, SEQ_LEN, model.config.vocab_size)
+        assert logits.shape == (BS, SEQ_LEN, model.config.vocab_size)
 
 
 @pytest.mark.skip(reason="Sequence packing for Qwen not working.")
@@ -75,7 +77,8 @@ def test_model_with_sequence_packing(model, correct_position_ids):
 
     with torch.autocast("cuda", dtype=torch.bfloat16):
         inputs_ids = torch.Tensor(inputs).repeat(1, 1).int().to("cuda")
-        output_base = model(input_ids=inputs_ids).logits
+        outputs = model(input_ids=inputs_ids)
+        output_base = outputs["logits"] if isinstance(outputs, dict) else outputs.logits
 
         assert output_base.shape == (1, len(inputs), model.config.vocab_size)
 
@@ -87,7 +90,8 @@ def test_model_with_sequence_packing(model, correct_position_ids):
         else:
             position_ids = torch.Tensor([0, 1, 2, 3, 4, 5, 6, 7]).repeat(1, 1).int().to("cuda")
             # should fail
-        outputs_packed = model(input_ids=inputs_ids, position_ids=position_ids).logits
+        outputs = model(input_ids=inputs_ids, position_ids=position_ids)
+        outputs_packed = outputs["logits"] if isinstance(outputs, dict) else outputs.logits
 
         assert outputs_packed.shape == (1, 2 * len(inputs), model.config.vocab_size)
 
@@ -113,9 +117,10 @@ def test_moe_custom_impl():
     model.wrap_lm_head(chunk_size=None)
     with torch.autocast("cuda", dtype=torch.bfloat16):
         inputs_ids = torch.randint(0, 100, (BS, SEQ_LEN)).to("cuda")
-        outputs = model(input_ids=inputs_ids).logits
+        outputs = model(input_ids=inputs_ids)
+        logits = outputs["logits"] if isinstance(outputs, dict) else outputs.logits
 
-        assert outputs.shape == (BS, SEQ_LEN, model.config.vocab_size)
+        assert logits.shape == (BS, SEQ_LEN, model.config.vocab_size)
 
 
 @pytest.mark.skip(reason="need special token for meta stuff in ci")
@@ -128,6 +133,7 @@ def test_model_forward_custom_impl(model_name):
     model = model.to("cuda")
     with torch.autocast("cuda", dtype=torch.bfloat16):
         inputs_ids = torch.randint(0, 100, (BS, SEQ_LEN)).to("cuda")
-        outputs = model(input_ids=inputs_ids).logits
+        outputs = model(input_ids=inputs_ids)
+        logits = outputs["logits"] if isinstance(outputs, dict) else outputs.logits
 
-        assert outputs.shape == (BS, SEQ_LEN, model.config.vocab_size)
+        assert logits.shape == (BS, SEQ_LEN, model.config.vocab_size)


### PR DESCRIPTION
Add support for chunked loss computation (via FusedOutputLinear) for any HuggingFace CausalLM model, not just custom PrimeRL implementations.

Changes:
- Add wrap_lm_head_for_hf_model() function in model.py that:
  - Wraps the lm_head with FusedOutputLinear or VanillaOutputLinear
  - Overrides the model's forward method to accept labels and temperature
  - Returns PrimeLmOutput with logprobs/entropy for chunked mode
- Update setup_model() to call wrap_lm_head_for_hf_model for non-PrimeRL models
- Remove config validator restriction that limited fused_lm_head_chunk_size to custom/auto implementations
- Add tests for HF model wrapping with both vanilla and fused modes

<!-- Provide a brief description of the changes in this PR -->

I was too lazy to explain my changes, decreasing my chances of this ever getting merged.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: [Issue ID]
**Linear Issue**: Resolves [Issue ID]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces universal LM head injection to support chunked loss on HuggingFace models and standardizes model outputs.
> 
> - New `inject_prime_lm_head` replaces manual wrapping, enabling `VanillaOutputLinear` or `FusedOutputLinear(chunk_size)` on any `CausalLM`; used in `setup_model`
> - `PrimeLmOutput` now a `TypedDict`; new `cast_float_and_contiguous` utility; `forward(...)` updated to handle dict outputs and cast tensors
> - Removed model-level `wrap_lm_head` and the config validator restricting `fused_lm_head_chunk_size` to custom/auto impls
> - RL/SFT trainers refactored to access outputs via dict (`out["logits"|"logprobs"|"entropy"]`) and to compute logprobs/entropy when needed
> - Expose `cast_float_and_contiguous` in `models.__init__`
> - Added unit tests for HF and PrimeRL models (Llama, Afmoe, Glm4Moe, Qwen3Moe) covering vanilla vs fused paths, forward/backward parity, and HF AutoModel integration
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d70d17a3a6114fe99923650ceea5d619a779e149. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->