### PR TITLE
Add optional Prometheus metrics server for trainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,4 @@ Documenting changes which affect configuration usage patterns (added/moved/remov
 - **`ckpt.keep`**: Renamed to `ckpt.keep_last`. Added `ckpt.keep_interval` to keep checkpoints at every N steps permanently (2025-12-31)
 - **`MultiLoRAMoE`**: QwenMoE now supports training expert loras and this is enabled by default in the `target_modules`. (2026-01-01)
 - **`model.fused_lm_head_chunk_size`**: Added chunk size configuration for fused LM head to enable memory-efficient chunked logprob computation. When set, splits vocabulary into chunks to avoid materializing full [N, V] logit tensor (default: None) (#1525, 2026-01-03)
+- **`trainer.metrics_server`**: Added optional Prometheus metrics server for trainer observability. Exposes `/metrics` endpoint with step, loss, throughput, grad_norm, etc. Disabled by default (default: None) (#1547, 2026-01-06)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,9 @@ synthesize = "prime_rl.synthesize.synthesize:main"
 flash-attn = [
     "flash-attn @ https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.6.8/flash_attn-2.8.3+cu128torch2.9-cp312-cp312-linux_x86_64.whl",
 ]
+metrics = [
+    "prometheus_client>=0.20.0",
+]
 
 [dependency-groups]
 dev = [

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -13,7 +13,7 @@ from prime_rl.trainer.config import (
     TokenizerConfig,
 )
 from prime_rl.transport.config import FileSystemTransportConfig, TransportConfigType
-from prime_rl.utils.config import HeartbeatConfig, LogConfig, WandbConfig
+from prime_rl.utils.config import HeartbeatConfig, LogConfig, MetricsServerConfig, WandbConfig
 from prime_rl.utils.pydantic_config import BaseConfig, BaseSettings
 
 
@@ -194,6 +194,11 @@ class RLTrainerConfig(BaseSettings):
 
     heartbeat: Annotated[
         HeartbeatConfig | None, Field(description="The heartbeat config for monitoring training progress.")
+    ] = None
+
+    metrics_server: Annotated[
+        MetricsServerConfig | None,
+        Field(description="Prometheus metrics server config. If set, exposes /metrics endpoint for scraping."),
     ] = None
 
     max_concurrent_runs: Annotated[

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -186,6 +186,10 @@ def train(config: RLTrainerConfig):
         prof = profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA], record_shapes=True).__enter__()
         maybe_record_function = record_function
     while True:
+        # Heartbeat for health check (signals main thread is alive)
+        if metrics_server is not None:
+            metrics_server.heartbeat()
+
         # Reset peak memory stats
         torch.cuda.reset_peak_memory_stats()
         is_last_step = config.max_steps is not None and progress.step == config.max_steps

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -465,6 +465,7 @@ def train(config: RLTrainerConfig):
                 learning_rate=current_lr,
                 mfu=mfu,
                 entropy=tensor_stats.get("entropy/mean", 0.0),
+                mismatch_kl=tensor_stats.get("mismatch_kl/mean", 0.0),
             )
 
         progress.step += 1

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -186,10 +186,6 @@ def train(config: RLTrainerConfig):
         prof = profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA], record_shapes=True).__enter__()
         maybe_record_function = record_function
     while True:
-        # Heartbeat for health check (signals main thread is alive)
-        if metrics_server is not None:
-            metrics_server.heartbeat()
-
         # Reset peak memory stats
         torch.cuda.reset_peak_memory_stats()
         is_last_step = config.max_steps is not None and progress.step == config.max_steps

--- a/src/prime_rl/utils/config.py
+++ b/src/prime_rl/utils/config.py
@@ -176,20 +176,20 @@ class HeartbeatConfig(BaseConfig):
 class HealthCheckConfig(BaseConfig):
     """Configures /health endpoint for Kubernetes liveness probes."""
 
-    max_step_age_seconds: Annotated[
+    timeout_seconds: Annotated[
         int,
         Field(
             ge=1,
-            description="Maximum seconds since last training step before /health returns unhealthy.",
+            description="Maximum seconds since last heartbeat before /health returns unhealthy.",
         ),
-    ] = 300
+    ] = 60
 
     startup_grace_seconds: Annotated[
         int,
         Field(
             ge=0,
-            description="Grace period in seconds after server start before enforcing step age check. "
-            "Allows time for model loading and first training step.",
+            description="Grace period in seconds after server start before enforcing heartbeat check. "
+            "Allows time for model loading and initialization.",
         ),
     ] = 600
 

--- a/src/prime_rl/utils/config.py
+++ b/src/prime_rl/utils/config.py
@@ -173,27 +173,6 @@ class HeartbeatConfig(BaseConfig):
     url: Annotated[str, Field(description="The URL to send the heartbeat to.")]
 
 
-class HealthCheckConfig(BaseConfig):
-    """Configures /health endpoint for Kubernetes liveness probes."""
-
-    timeout_seconds: Annotated[
-        int,
-        Field(
-            ge=1,
-            description="Maximum seconds since last heartbeat before /health returns unhealthy.",
-        ),
-    ] = 60
-
-    startup_grace_seconds: Annotated[
-        int,
-        Field(
-            ge=0,
-            description="Grace period in seconds after server start before enforcing heartbeat check. "
-            "Allows time for model loading and initialization.",
-        ),
-    ] = 600
-
-
 class MetricsServerConfig(BaseConfig):
     """Configures the Prometheus metrics server for trainer observability."""
 
@@ -212,10 +191,3 @@ class MetricsServerConfig(BaseConfig):
             description="Host to bind the server to. Defaults to 0.0.0.0.",
         ),
     ] = "0.0.0.0"
-
-    health: Annotated[
-        HealthCheckConfig | None,
-        Field(
-            description="Health check configuration. If None, /health always returns healthy.",
-        ),
-    ] = None

--- a/src/prime_rl/utils/config.py
+++ b/src/prime_rl/utils/config.py
@@ -171,3 +171,23 @@ class HeartbeatConfig(BaseConfig):
     """Configures the heartbeat for BetterStack."""
 
     url: Annotated[str, Field(description="The URL to send the heartbeat to.")]
+
+
+class MetricsServerConfig(BaseConfig):
+    """Configures the Prometheus metrics server for trainer observability."""
+
+    port: Annotated[
+        int,
+        Field(
+            ge=1,
+            le=65535,
+            description="Port to expose Prometheus metrics on. Defaults to 8000.",
+        ),
+    ] = 8000
+
+    host: Annotated[
+        str,
+        Field(
+            description="Host to bind the metrics server to. Defaults to 0.0.0.0.",
+        ),
+    ] = "0.0.0.0"

--- a/src/prime_rl/utils/config.py
+++ b/src/prime_rl/utils/config.py
@@ -173,6 +173,27 @@ class HeartbeatConfig(BaseConfig):
     url: Annotated[str, Field(description="The URL to send the heartbeat to.")]
 
 
+class HealthCheckConfig(BaseConfig):
+    """Configures /health endpoint for Kubernetes liveness probes."""
+
+    max_step_age_seconds: Annotated[
+        int,
+        Field(
+            ge=1,
+            description="Maximum seconds since last training step before /health returns unhealthy.",
+        ),
+    ] = 300
+
+    startup_grace_seconds: Annotated[
+        int,
+        Field(
+            ge=0,
+            description="Grace period in seconds after server start before enforcing step age check. "
+            "Allows time for model loading and first training step.",
+        ),
+    ] = 600
+
+
 class MetricsServerConfig(BaseConfig):
     """Configures the Prometheus metrics server for trainer observability."""
 
@@ -181,13 +202,20 @@ class MetricsServerConfig(BaseConfig):
         Field(
             ge=1,
             le=65535,
-            description="Port to expose Prometheus metrics on. Defaults to 8000.",
+            description="Port to expose metrics and health endpoints. Defaults to 8000.",
         ),
     ] = 8000
 
     host: Annotated[
         str,
         Field(
-            description="Host to bind the metrics server to. Defaults to 0.0.0.0.",
+            description="Host to bind the server to. Defaults to 0.0.0.0.",
         ),
     ] = "0.0.0.0"
+
+    health: Annotated[
+        HealthCheckConfig | None,
+        Field(
+            description="Health check configuration. If None, /health always returns healthy.",
+        ),
+    ] = None

--- a/src/prime_rl/utils/metrics_server.py
+++ b/src/prime_rl/utils/metrics_server.py
@@ -1,0 +1,128 @@
+"""Prometheus metrics server for trainer observability.
+
+Exposes training metrics at /metrics in Prometheus format.
+Runs in a background thread to avoid blocking the training loop.
+"""
+
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from prime_rl.utils.config import MetricsServerConfig
+
+try:
+    from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry, Gauge, generate_latest
+
+    PROMETHEUS_AVAILABLE = True
+except ImportError:
+    PROMETHEUS_AVAILABLE = False
+
+
+class MetricsServer:
+    """Prometheus metrics server for trainer observability.
+
+    Uses an isolated CollectorRegistry to avoid global state pollution.
+    Disabled by default - enable by setting `metrics_server` in trainer config.
+    """
+
+    def __init__(self, config: "MetricsServerConfig"):
+        self.config = config
+        self._server: HTTPServer | None = None
+        self._thread: threading.Thread | None = None
+        self._started = False
+
+        if PROMETHEUS_AVAILABLE:
+            self._registry = CollectorRegistry()
+            self._step = Gauge("rft_trainer_step", "Current training step", registry=self._registry)
+            self._loss = Gauge("rft_trainer_loss", "Current training loss", registry=self._registry)
+            self._throughput = Gauge(
+                "rft_trainer_throughput_tokens_per_sec", "Training throughput in tokens/sec", registry=self._registry
+            )
+            self._last_step_ts = Gauge(
+                "rft_trainer_last_step_timestamp_seconds", "Unix timestamp of last step", registry=self._registry
+            )
+            self._grad_norm = Gauge("rft_trainer_grad_norm", "Gradient norm", registry=self._registry)
+            self._peak_mem = Gauge("rft_trainer_peak_memory_gib", "Peak GPU memory in GiB", registry=self._registry)
+            self._lr = Gauge("rft_trainer_learning_rate", "Current learning rate", registry=self._registry)
+            self._mfu = Gauge("rft_trainer_mfu_percent", "Model FLOPS utilization %", registry=self._registry)
+            self._entropy = Gauge("rft_trainer_entropy", "Mean entropy", registry=self._registry)
+        else:
+            self._registry = None
+
+    def _make_handler(self):
+        """Create handler class with access to our registry."""
+        registry = self._registry
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                if self.path == "/metrics":
+                    self.send_response(200)
+                    if registry is not None:
+                        self.send_header("Content-Type", CONTENT_TYPE_LATEST)
+                        self.end_headers()
+                        self.wfile.write(generate_latest(registry))
+                    else:
+                        self.send_header("Content-Type", "text/plain")
+                        self.end_headers()
+                        self.wfile.write(b"# prometheus_client not installed\n")
+                else:
+                    self.send_response(404)
+                    self.end_headers()
+
+            def log_message(self, format, *args):
+                pass
+
+        return Handler
+
+    def start(self) -> None:
+        """Start the metrics server in a background thread."""
+        if self._started:
+            logger.warning("Metrics server already started")
+            return
+
+        if not PROMETHEUS_AVAILABLE:
+            logger.warning("prometheus_client not installed. Install with: uv sync --extra metrics")
+
+        self._server = HTTPServer((self.config.host, self.config.port), self._make_handler())
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        self._started = True
+        logger.info(f"Metrics server started at http://{self.config.host}:{self.config.port}/metrics")
+
+    def stop(self) -> None:
+        """Stop the metrics server."""
+        if self._server is not None:
+            self._server.shutdown()
+            self._server = None
+            self._thread = None
+            self._started = False
+            logger.info("Metrics server stopped")
+
+    def update(
+        self,
+        step: int,
+        loss: float,
+        throughput: float,
+        grad_norm: float,
+        peak_memory_gib: float,
+        learning_rate: float,
+        mfu: float = 0.0,
+        entropy: float = 0.0,
+    ) -> None:
+        """Update metrics after a training step."""
+        if not PROMETHEUS_AVAILABLE:
+            return
+
+        self._step.set(step)
+        self._loss.set(loss)
+        self._throughput.set(throughput)
+        self._grad_norm.set(grad_norm)
+        self._peak_mem.set(peak_memory_gib)
+        self._lr.set(learning_rate)
+        self._mfu.set(mfu)
+        self._entropy.set(entropy)
+        self._last_step_ts.set(time.time())

--- a/src/prime_rl/utils/metrics_server.py
+++ b/src/prime_rl/utils/metrics_server.py
@@ -37,19 +37,22 @@ class MetricsServer:
 
         if PROMETHEUS_AVAILABLE:
             self._registry = CollectorRegistry()
-            self._step = Gauge("rft_trainer_step", "Current training step", registry=self._registry)
-            self._loss = Gauge("rft_trainer_loss", "Current training loss", registry=self._registry)
+            self._step = Gauge("trainer_step", "Current training step", registry=self._registry)
+            self._loss = Gauge("trainer_loss", "Current training loss", registry=self._registry)
             self._throughput = Gauge(
-                "rft_trainer_throughput_tokens_per_sec", "Training throughput in tokens/sec", registry=self._registry
+                "trainer_throughput_tokens_per_sec", "Training throughput in tokens/sec", registry=self._registry
             )
             self._last_step_ts = Gauge(
-                "rft_trainer_last_step_timestamp_seconds", "Unix timestamp of last step", registry=self._registry
+                "trainer_last_step_timestamp_seconds", "Unix timestamp of last step", registry=self._registry
             )
-            self._grad_norm = Gauge("rft_trainer_grad_norm", "Gradient norm", registry=self._registry)
-            self._peak_mem = Gauge("rft_trainer_peak_memory_gib", "Peak GPU memory in GiB", registry=self._registry)
-            self._lr = Gauge("rft_trainer_learning_rate", "Current learning rate", registry=self._registry)
-            self._mfu = Gauge("rft_trainer_mfu_percent", "Model FLOPS utilization %", registry=self._registry)
-            self._entropy = Gauge("rft_trainer_entropy", "Mean entropy", registry=self._registry)
+            self._grad_norm = Gauge("trainer_grad_norm", "Gradient norm", registry=self._registry)
+            self._peak_mem = Gauge("trainer_peak_memory_gib", "Peak GPU memory in GiB", registry=self._registry)
+            self._lr = Gauge("trainer_learning_rate", "Current learning rate", registry=self._registry)
+            self._mfu = Gauge("trainer_mfu_percent", "Model FLOPS utilization %", registry=self._registry)
+            self._entropy = Gauge("trainer_entropy", "Mean entropy", registry=self._registry)
+            self._mismatch_kl = Gauge(
+                "trainer_mismatch_kl", "KL divergence between trainer and inference model", registry=self._registry
+            )
         else:
             self._registry = None
 
@@ -112,6 +115,7 @@ class MetricsServer:
         learning_rate: float,
         mfu: float = 0.0,
         entropy: float = 0.0,
+        mismatch_kl: float = 0.0,
     ) -> None:
         """Update metrics after a training step."""
         if not PROMETHEUS_AVAILABLE:
@@ -125,4 +129,5 @@ class MetricsServer:
         self._lr.set(learning_rate)
         self._mfu.set(mfu)
         self._entropy.set(entropy)
+        self._mismatch_kl.set(mismatch_kl)
         self._last_step_ts.set(time.time())

--- a/src/prime_rl/utils/pathing.py
+++ b/src/prime_rl/utils/pathing.py
@@ -1,5 +1,6 @@
 import asyncio
 import time
+from collections.abc import Callable
 from pathlib import Path
 
 from prime_rl.utils.logger import get_logger
@@ -52,11 +53,18 @@ def resolve_latest_ckpt_step(ckpt_dir: Path) -> int | None:
     return latest_step
 
 
-def sync_wait_for_path(path: Path, interval: int = 1, log_interval: int = 10) -> None:
+def sync_wait_for_path(
+    path: Path,
+    interval: int = 1,
+    log_interval: int = 10,
+    on_wait: Callable[[], None] | None = None,
+) -> None:
     logger = get_logger()
     wait_time = 0
     logger.debug(f"Waiting for path `{path}`")
     while True:
+        if on_wait is not None:
+            on_wait()
         if path.exists():
             logger.debug(f"Found path `{path}`")
             break

--- a/src/prime_rl/utils/pathing.py
+++ b/src/prime_rl/utils/pathing.py
@@ -1,6 +1,5 @@
 import asyncio
 import time
-from collections.abc import Callable
 from pathlib import Path
 
 from prime_rl.utils.logger import get_logger
@@ -53,18 +52,11 @@ def resolve_latest_ckpt_step(ckpt_dir: Path) -> int | None:
     return latest_step
 
 
-def sync_wait_for_path(
-    path: Path,
-    interval: int = 1,
-    log_interval: int = 10,
-    on_wait: Callable[[], None] | None = None,
-) -> None:
+def sync_wait_for_path(path: Path, interval: int = 1, log_interval: int = 10) -> None:
     logger = get_logger()
     wait_time = 0
     logger.debug(f"Waiting for path `{path}`")
     while True:
-        if on_wait is not None:
-            on_wait()
         if path.exists():
             logger.debug(f"Found path `{path}`")
             break

--- a/tests/unit/utils/test_metrics_server.py
+++ b/tests/unit/utils/test_metrics_server.py
@@ -12,136 +12,140 @@ from prime_rl.utils.metrics_server import PROMETHEUS_AVAILABLE, MetricsServer
 
 
 def find_free_port() -> int:
-    """Find a free port on localhost."""
     with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
         s.bind(("", 0))
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         return s.getsockname()[1]
 
 
-class TestMetricsServerConfig:
-    def test_default_values(self):
-        config = MetricsServerConfig()
-        assert config.port == 8000
-        assert config.host == "0.0.0.0"
-
-    def test_custom_port(self):
-        config = MetricsServerConfig(port=9090)
-        assert config.port == 9090
-
-    def test_invalid_port_low(self):
-        with pytest.raises(ValueError):
-            MetricsServerConfig(port=0)
-
-    def test_invalid_port_high(self):
-        with pytest.raises(ValueError):
-            MetricsServerConfig(port=65536)
+def test_config_default_values():
+    config = MetricsServerConfig()
+    assert config.port == 8000
+    assert config.host == "0.0.0.0"
 
 
-class TestMetricsServer:
-    def test_start_stop(self):
-        port = find_free_port()
-        server = MetricsServer(MetricsServerConfig(port=port))
+def test_config_custom_port():
+    config = MetricsServerConfig(port=9090)
+    assert config.port == 9090
 
-        server.start()
-        assert server._started
-        time.sleep(0.1)
 
-        response = urllib.request.urlopen(f"http://localhost:{port}/metrics", timeout=2)
-        assert response.status == 200
+def test_config_invalid_port_low():
+    with pytest.raises(ValueError):
+        MetricsServerConfig(port=0)
 
-        server.stop()
-        assert not server._started
 
-    def test_404_on_unknown_path(self):
-        port = find_free_port()
-        server = MetricsServer(MetricsServerConfig(port=port))
-        server.start()
-        time.sleep(0.1)
+def test_config_invalid_port_high():
+    with pytest.raises(ValueError):
+        MetricsServerConfig(port=65536)
 
-        try:
-            urllib.request.urlopen(f"http://localhost:{port}/unknown", timeout=2)
-            pytest.fail("Expected 404")
-        except urllib.error.HTTPError as e:
-            assert e.code == 404
-        finally:
-            server.stop()
 
-    def test_double_start_is_safe(self):
-        port = find_free_port()
-        server = MetricsServer(MetricsServerConfig(port=port))
-        server.start()
-        server.start()  # Should not raise
+def test_server_start_stop():
+    port = find_free_port()
+    server = MetricsServer(MetricsServerConfig(port=port))
+
+    server.start()
+    assert server._started
+    time.sleep(0.1)
+
+    response = urllib.request.urlopen(f"http://localhost:{port}/metrics", timeout=2)
+    assert response.status == 200
+
+    server.stop()
+    assert not server._started
+
+
+def test_server_returns_404_on_unknown_path():
+    port = find_free_port()
+    server = MetricsServer(MetricsServerConfig(port=port))
+    server.start()
+    time.sleep(0.1)
+
+    try:
+        urllib.request.urlopen(f"http://localhost:{port}/unknown", timeout=2)
+        pytest.fail("Expected 404")
+    except urllib.error.HTTPError as e:
+        assert e.code == 404
+    finally:
         server.stop()
 
-    def test_update_metrics(self):
-        port = find_free_port()
-        server = MetricsServer(MetricsServerConfig(port=port))
-        server.start()
-        time.sleep(0.1)
 
-        server.update(step=42, loss=0.5, throughput=1000.0, grad_norm=1.5, peak_memory_gib=10.0, learning_rate=1e-4)
+def test_server_double_start_is_safe():
+    port = find_free_port()
+    server = MetricsServer(MetricsServerConfig(port=port))
+    server.start()
+    server.start()  # Should not raise
+    server.stop()
 
-        response = urllib.request.urlopen(f"http://localhost:{port}/metrics", timeout=2)
-        content = response.read().decode()
 
-        if PROMETHEUS_AVAILABLE:
-            assert "rft_trainer_step" in content
-            assert "rft_trainer_loss" in content
-            assert "rft_trainer_last_step_timestamp_seconds" in content
+def test_server_update_metrics():
+    port = find_free_port()
+    server = MetricsServer(MetricsServerConfig(port=port))
+    server.start()
+    time.sleep(0.1)
 
-        server.stop()
+    server.update(step=42, loss=0.5, throughput=1000.0, grad_norm=1.5, peak_memory_gib=10.0, learning_rate=1e-4)
 
-    @pytest.mark.skipif(not PROMETHEUS_AVAILABLE, reason="prometheus_client not installed")
-    def test_metrics_values(self):
-        port = find_free_port()
-        server = MetricsServer(MetricsServerConfig(port=port))
-        server.start()
-        time.sleep(0.1)
+    response = urllib.request.urlopen(f"http://localhost:{port}/metrics", timeout=2)
+    content = response.read().decode()
 
-        server.update(step=100, loss=0.123, throughput=5000.0, grad_norm=2.5, peak_memory_gib=16.0, learning_rate=3e-5)
+    if PROMETHEUS_AVAILABLE:
+        assert "rft_trainer_step" in content
+        assert "rft_trainer_loss" in content
+        assert "rft_trainer_last_step_timestamp_seconds" in content
 
-        response = urllib.request.urlopen(f"http://localhost:{port}/metrics", timeout=2)
-        content = response.read().decode()
+    server.stop()
 
-        assert "rft_trainer_step 100.0" in content
-        assert "rft_trainer_loss 0.123" in content
 
-        server.stop()
+@pytest.mark.skipif(not PROMETHEUS_AVAILABLE, reason="prometheus_client not installed")
+def test_server_metrics_values_are_correct():
+    port = find_free_port()
+    server = MetricsServer(MetricsServerConfig(port=port))
+    server.start()
+    time.sleep(0.1)
 
-    def test_isolated_registry(self):
-        """Each MetricsServer instance should have its own registry."""
-        port1 = find_free_port()
-        port2 = find_free_port()
+    server.update(step=100, loss=0.123, throughput=5000.0, grad_norm=2.5, peak_memory_gib=16.0, learning_rate=3e-5)
 
-        server1 = MetricsServer(MetricsServerConfig(port=port1))
-        server2 = MetricsServer(MetricsServerConfig(port=port2))
+    response = urllib.request.urlopen(f"http://localhost:{port}/metrics", timeout=2)
+    content = response.read().decode()
 
-        server1.start()
+    assert "rft_trainer_step 100.0" in content
+    assert "rft_trainer_loss 0.123" in content
+
+    server.stop()
+
+
+def test_server_isolated_registry():
+    """Each MetricsServer instance should have its own registry."""
+    port1 = find_free_port()
+    port2 = find_free_port()
+
+    server1 = MetricsServer(MetricsServerConfig(port=port1))
+    server2 = MetricsServer(MetricsServerConfig(port=port2))
+
+    server1.start()
+    server2.start()
+    time.sleep(0.1)
+
+    server1.update(step=999, loss=0.1, throughput=100, grad_norm=1, peak_memory_gib=1, learning_rate=1e-3)
+
+    if PROMETHEUS_AVAILABLE:
+        resp1 = urllib.request.urlopen(f"http://localhost:{port1}/metrics", timeout=2).read().decode()
+        resp2 = urllib.request.urlopen(f"http://localhost:{port2}/metrics", timeout=2).read().decode()
+        assert "999.0" in resp1
+        assert "999.0" not in resp2
+
+    server1.stop()
+    server2.stop()
+
+
+def test_server_port_conflict_raises():
+    port = find_free_port()
+    server1 = MetricsServer(MetricsServerConfig(port=port))
+    server1.start()
+    time.sleep(0.1)
+
+    server2 = MetricsServer(MetricsServerConfig(port=port))
+    with pytest.raises(OSError):
         server2.start()
-        time.sleep(0.1)
 
-        # Update only server1
-        server1.update(step=999, loss=0.1, throughput=100, grad_norm=1, peak_memory_gib=1, learning_rate=1e-3)
-
-        # server2 should not have server1's values
-        if PROMETHEUS_AVAILABLE:
-            resp1 = urllib.request.urlopen(f"http://localhost:{port1}/metrics", timeout=2).read().decode()
-            resp2 = urllib.request.urlopen(f"http://localhost:{port2}/metrics", timeout=2).read().decode()
-            assert "999.0" in resp1
-            assert "999.0" not in resp2
-
-        server1.stop()
-        server2.stop()
-
-    def test_port_conflict_raises(self):
-        port = find_free_port()
-        server1 = MetricsServer(MetricsServerConfig(port=port))
-        server1.start()
-        time.sleep(0.1)
-
-        server2 = MetricsServer(MetricsServerConfig(port=port))
-        with pytest.raises(OSError):
-            server2.start()
-
-        server1.stop()
+    server1.stop()

--- a/tests/unit/utils/test_metrics_server.py
+++ b/tests/unit/utils/test_metrics_server.py
@@ -1,0 +1,147 @@
+"""Tests for the Prometheus metrics server."""
+
+import socket
+import time
+import urllib.request
+from contextlib import closing
+
+import pytest
+
+from prime_rl.utils.config import MetricsServerConfig
+from prime_rl.utils.metrics_server import PROMETHEUS_AVAILABLE, MetricsServer
+
+
+def find_free_port() -> int:
+    """Find a free port on localhost."""
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(("", 0))
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        return s.getsockname()[1]
+
+
+class TestMetricsServerConfig:
+    def test_default_values(self):
+        config = MetricsServerConfig()
+        assert config.port == 8000
+        assert config.host == "0.0.0.0"
+
+    def test_custom_port(self):
+        config = MetricsServerConfig(port=9090)
+        assert config.port == 9090
+
+    def test_invalid_port_low(self):
+        with pytest.raises(ValueError):
+            MetricsServerConfig(port=0)
+
+    def test_invalid_port_high(self):
+        with pytest.raises(ValueError):
+            MetricsServerConfig(port=65536)
+
+
+class TestMetricsServer:
+    def test_start_stop(self):
+        port = find_free_port()
+        server = MetricsServer(MetricsServerConfig(port=port))
+
+        server.start()
+        assert server._started
+        time.sleep(0.1)
+
+        response = urllib.request.urlopen(f"http://localhost:{port}/metrics", timeout=2)
+        assert response.status == 200
+
+        server.stop()
+        assert not server._started
+
+    def test_404_on_unknown_path(self):
+        port = find_free_port()
+        server = MetricsServer(MetricsServerConfig(port=port))
+        server.start()
+        time.sleep(0.1)
+
+        try:
+            urllib.request.urlopen(f"http://localhost:{port}/unknown", timeout=2)
+            pytest.fail("Expected 404")
+        except urllib.error.HTTPError as e:
+            assert e.code == 404
+        finally:
+            server.stop()
+
+    def test_double_start_is_safe(self):
+        port = find_free_port()
+        server = MetricsServer(MetricsServerConfig(port=port))
+        server.start()
+        server.start()  # Should not raise
+        server.stop()
+
+    def test_update_metrics(self):
+        port = find_free_port()
+        server = MetricsServer(MetricsServerConfig(port=port))
+        server.start()
+        time.sleep(0.1)
+
+        server.update(step=42, loss=0.5, throughput=1000.0, grad_norm=1.5, peak_memory_gib=10.0, learning_rate=1e-4)
+
+        response = urllib.request.urlopen(f"http://localhost:{port}/metrics", timeout=2)
+        content = response.read().decode()
+
+        if PROMETHEUS_AVAILABLE:
+            assert "rft_trainer_step" in content
+            assert "rft_trainer_loss" in content
+            assert "rft_trainer_last_step_timestamp_seconds" in content
+
+        server.stop()
+
+    @pytest.mark.skipif(not PROMETHEUS_AVAILABLE, reason="prometheus_client not installed")
+    def test_metrics_values(self):
+        port = find_free_port()
+        server = MetricsServer(MetricsServerConfig(port=port))
+        server.start()
+        time.sleep(0.1)
+
+        server.update(step=100, loss=0.123, throughput=5000.0, grad_norm=2.5, peak_memory_gib=16.0, learning_rate=3e-5)
+
+        response = urllib.request.urlopen(f"http://localhost:{port}/metrics", timeout=2)
+        content = response.read().decode()
+
+        assert "rft_trainer_step 100.0" in content
+        assert "rft_trainer_loss 0.123" in content
+
+        server.stop()
+
+    def test_isolated_registry(self):
+        """Each MetricsServer instance should have its own registry."""
+        port1 = find_free_port()
+        port2 = find_free_port()
+
+        server1 = MetricsServer(MetricsServerConfig(port=port1))
+        server2 = MetricsServer(MetricsServerConfig(port=port2))
+
+        server1.start()
+        server2.start()
+        time.sleep(0.1)
+
+        # Update only server1
+        server1.update(step=999, loss=0.1, throughput=100, grad_norm=1, peak_memory_gib=1, learning_rate=1e-3)
+
+        # server2 should not have server1's values
+        if PROMETHEUS_AVAILABLE:
+            resp1 = urllib.request.urlopen(f"http://localhost:{port1}/metrics", timeout=2).read().decode()
+            resp2 = urllib.request.urlopen(f"http://localhost:{port2}/metrics", timeout=2).read().decode()
+            assert "999.0" in resp1
+            assert "999.0" not in resp2
+
+        server1.stop()
+        server2.stop()
+
+    def test_port_conflict_raises(self):
+        port = find_free_port()
+        server1 = MetricsServer(MetricsServerConfig(port=port))
+        server1.start()
+        time.sleep(0.1)
+
+        server2 = MetricsServer(MetricsServerConfig(port=port))
+        with pytest.raises(OSError):
+            server2.start()
+
+        server1.stop()

--- a/tests/unit/utils/test_metrics_server.py
+++ b/tests/unit/utils/test_metrics_server.py
@@ -89,9 +89,10 @@ def test_server_update_metrics():
     content = response.read().decode()
 
     if PROMETHEUS_AVAILABLE:
-        assert "rft_trainer_step" in content
-        assert "rft_trainer_loss" in content
-        assert "rft_trainer_last_step_timestamp_seconds" in content
+        assert "trainer_step" in content
+        assert "trainer_loss" in content
+        assert "trainer_last_step_timestamp_seconds" in content
+        assert "trainer_mismatch_kl" in content
 
     server.stop()
 
@@ -103,13 +104,22 @@ def test_server_metrics_values_are_correct():
     server.start()
     time.sleep(0.1)
 
-    server.update(step=100, loss=0.123, throughput=5000.0, grad_norm=2.5, peak_memory_gib=16.0, learning_rate=3e-5)
+    server.update(
+        step=100,
+        loss=0.123,
+        throughput=5000.0,
+        grad_norm=2.5,
+        peak_memory_gib=16.0,
+        learning_rate=3e-5,
+        mismatch_kl=0.045,
+    )
 
     response = urllib.request.urlopen(f"http://localhost:{port}/metrics", timeout=2)
     content = response.read().decode()
 
-    assert "rft_trainer_step 100.0" in content
-    assert "rft_trainer_loss 0.123" in content
+    assert "trainer_step 100.0" in content
+    assert "trainer_loss 0.123" in content
+    assert "trainer_mismatch_kl 0.045" in content
 
     server.stop()
 

--- a/uv.lock
+++ b/uv.lock
@@ -2432,6 +2432,9 @@ dependencies = [
 flash-attn = [
     { name = "flash-attn" },
 ]
+metrics = [
+    { name = "prometheus-client" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -2461,6 +2464,7 @@ requires-dist = [
     { name = "openai", specifier = ">=1.106.1" },
     { name = "prime", specifier = ">=0.5.0" },
     { name = "prime-evals", specifier = ">=0.1.5" },
+    { name = "prometheus-client", marker = "extra == 'metrics'", specifier = ">=0.20.0" },
     { name = "pydantic", specifier = ">=1.10.13" },
     { name = "pydantic-settings", specifier = ">=2.10.1" },
     { name = "pylatexenc", specifier = ">=2.10" },
@@ -2482,7 +2486,7 @@ requires-dist = [
     { name = "vllm", specifier = "==0.12.0" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
-provides-extras = ["flash-attn"]
+provides-extras = ["flash-attn", "metrics"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Adds `/metrics` endpoint to trainer for Prometheus scraping.

- disabled by default, enable with `--metrics-server.port 8000`
- exposes: step, loss, throughput, grad_norm, peak_memory, lr, mfu, entropy, last_step_timestamp
- `prometheus_client` is optional dep (`uv sync --extra metrics`)
- isolated registry per instance, no global state

useful for alerting on stuck trainers via `time() - rft_trainer_last_step_timestamp > 600`

**No event loop blocking**: HTTPServer runs in separate daemon thread, `.update()` just sets floats (nanoseconds), scrapes happen every 15-30s outside training hot path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces opt-in trainer observability via Prometheus, without affecting the training hot path.
> 
> - New `MetricsServer` (`utils/metrics_server.py`): background `HTTPServer` exposing `/metrics` and `/health`; isolated `CollectorRegistry`; gauges for `trainer_step`, `trainer_loss`, `trainer_throughput_tokens_per_sec`, `trainer_grad_norm`, `trainer_peak_memory_gib`, `trainer_learning_rate`, `trainer_mfu_percent`, `trainer_entropy`, `trainer_mismatch_kl`, plus per-run metrics (`trainer_run_*`) with label cleanup
> - Config: adds `trainer.metrics_server` and `MetricsServerConfig` (`port`, `host`); `train.py` starts/stops server on master and updates metrics each step including run/LoRA stats via `update_runs`
> - Packaging: new optional extra `metrics` with `prometheus_client`; lockfile and `pyproject.toml` updated; CHANGELOG updated
> - Tests: `tests/unit/utils/test_metrics_server.py` covering config defaults/validation, server lifecycle, metric updates/values, port conflicts, per-run metrics, and cleanup
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dbda7533081834951656a3515ed084296187a1c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->