### PR TITLE
Explicitly pass step to monitor in orch

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -508,7 +508,7 @@ async def orchestrate(config: OrchestratorConfig):
                 to_log.update({f"val_batch/{env}": ratio for env, ratio in per_env_ratio.items()})
 
         # Log metrics to monitor(s)
-        monitor.log(to_log)
+        monitor.log(to_log, step=progress.step)
 
         # Log samples to monitor(s) if enabled
         subset_train_rollouts = random.sample(train_rollouts, min(8, len(train_rollouts)))


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures metric logs are associated with the correct training step.
> 
> - In `orchestrator.py`, `monitor.log` now explicitly receives `step=progress.step` when logging metrics
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e0f648db2499d9f02d9b156aa317ecfd0e9a0b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->