### PR TITLE
Bump verifiers (v0.1.9.post0)

### DIFF
--- a/configs/math_python/math_env_with_python.toml
+++ b/configs/math_python/math_env_with_python.toml
@@ -1,0 +1,30 @@
+max_steps = 300
+seq_len = 4096
+
+[wandb]
+project = "math-python-debug"
+name = "math-env-with-python"
+
+[model]
+name = "Qwen/Qwen3-4B-Instruct-2507"
+
+[orchestrator]
+batch_size = 512
+rollouts_per_example = 16
+
+[orchestrator.sampling]
+max_tokens = 512
+
+[[orchestrator.env]]
+id = "math-env"
+args = { dataset_name="openai/gsm8k", dataset_subset="main", python_tool = true, sandbox_client_max_workers = 128 }
+
+[trainer] # Default trainer config
+
+[inference]
+api_server_count = 4
+
+[inference.model]
+enable_auto_tool_choice = true
+tool_call_parser = "hermes"
+max_model_len = 4096

--- a/configs/math_python/math_env_with_python.toml
+++ b/configs/math_python/math_env_with_python.toml
@@ -17,9 +17,11 @@ max_tokens = 512
 
 [[orchestrator.env]]
 id = "math-env"
-args = { dataset_name="openai/gsm8k", dataset_subset="main", python_tool = true, sandbox_client_max_workers = 128 }
+args = { dataset_name="openai/gsm8k", dataset_subset="main", python_tool = true, sandbox_client_max_workers = 128, max_startup_wait_seconds = 120 }
 
 [trainer] # Default trainer config
+
+[trainer.model.ac]
 
 [inference]
 api_server_count = 4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ prerelease = "allow"
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 reverse-text = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "15f68ca" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "2d3439b" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "main" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ prerelease = "allow"
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 reverse-text = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "eb3bae36c93b2f574e13a39da2908609d4ec4b2f" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "c7a8088" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "main" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ prerelease = "allow"
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 reverse-text = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "c7a8088" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "15f68ca" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "main" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 

--- a/uv.lock
+++ b/uv.lock
@@ -2481,7 +2481,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", specifier = ">=4.56.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=c7a8088" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=15f68ca" },
     { name = "vllm", specifier = "==0.12.0" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -3832,7 +3832,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.8.post2"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=c7a8088#c7a8088aacb5dc73757632157bbad41ffcc35836" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=15f68ca#15f68ca35ef2653bb184693ec905ee20ab651971" }
 dependencies = [
     { name = "datasets" },
     { name = "jinja2" },

--- a/uv.lock
+++ b/uv.lock
@@ -1612,7 +1612,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.13.1"
+version = "1.25.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1621,15 +1621,18 @@ dependencies = [
     { name = "jsonschema" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "sse-starlette" },
     { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/3c/82c400c2d50afdac4fbefb5b4031fd327e2ad1f23ccef8eee13c5909aa48/mcp-1.13.1.tar.gz", hash = "sha256:165306a8fd7991dc80334edd2de07798175a56461043b7ae907b279794a834c5", size = 438198, upload-time = "2025-08-22T09:22:16.061Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/2d/649d80a0ecf6a1f82632ca44bec21c0461a9d9fc8934d38cb5b319f2db5e/mcp-1.25.0.tar.gz", hash = "sha256:56310361ebf0364e2d438e5b45f7668cbb124e158bb358333cd06e49e83a6802", size = 605387, upload-time = "2025-12-19T10:19:56.985Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/3f/d085c7f49ade6d273b185d61ec9405e672b6433f710ea64a90135a8dd445/mcp-1.13.1-py3-none-any.whl", hash = "sha256:c314e7c8bd477a23ba3ef472ee5a32880316c42d03e06dcfa31a1cc7a73b65df", size = 161494, upload-time = "2025-08-22T09:22:14.705Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/fc/6dc7659c2ae5ddf280477011f4213a74f806862856b796ef08f028e664bf/mcp-1.25.0-py3-none-any.whl", hash = "sha256:b37c38144a666add0862614cc79ec276e97d72aa8ca26d622818d4e278b9721a", size = 233076, upload-time = "2025-12-19T10:19:55.416Z" },
 ]
 
 [[package]]
@@ -2478,7 +2481,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", specifier = ">=4.56.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=eb3bae36c93b2f574e13a39da2908609d4ec4b2f" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=c7a8088" },
     { name = "vllm", specifier = "==0.12.0" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -2790,6 +2793,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.10.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785, upload-time = "2024-11-28T03:43:29.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997, upload-time = "2024-11-28T03:43:27.893Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -3815,11 +3832,12 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.8.post2"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=eb3bae36c93b2f574e13a39da2908609d4ec4b2f#eb3bae36c93b2f574e13a39da2908609d4ec4b2f" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=c7a8088#c7a8088aacb5dc73757632157bbad41ffcc35836" }
 dependencies = [
     { name = "datasets" },
     { name = "jinja2" },
     { name = "math-verify" },
+    { name = "mcp" },
     { name = "nest-asyncio" },
     { name = "openai" },
     { name = "openai-agents" },

--- a/uv.lock
+++ b/uv.lock
@@ -2481,7 +2481,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", specifier = ">=4.56.0" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=15f68ca" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=2d3439b" },
     { name = "vllm", specifier = "==0.12.0" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -3831,8 +3831,8 @@ wheels = [
 
 [[package]]
 name = "verifiers"
-version = "0.1.8.post2"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=15f68ca#15f68ca35ef2653bb184693ec905ee20ab651971" }
+version = "0.1.9.post0"
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=2d3439b#2d3439b818843d7e3ba51e63efb6965b58a0a922" }
 dependencies = [
     { name = "datasets" },
     { name = "jinja2" },


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Bumps verifiers to commit of new release `v0.1.9.post0`. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a math environment config with Python tool support and updates related dependencies.
> 
> - Adds `configs/math_python/math_env_with_python.toml` configuring `math-env` (GSM8K, Python tool enabled) with Qwen 4B, sampling, orchestrator, trainer, and inference settings
> - Upgrades dependencies: `verifiers` (new git rev -> `0.1.9.post0`) and `mcp` (`1.25.0`), pulling in `pyjwt[crypto]` and typing deps; updates `uv.lock` accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94f7ab361ac75b556b7ac5be3903b5c9f295f028. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->