### PR TITLE
feat: Add reward field to TrainingSample

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -344,6 +344,7 @@ async def orchestrate(config: OrchestratorConfig):
             if train_example is not None:
                 for te in train_example:
                     te.advantage = advantage
+                    te.reward = train_rollout["reward"]
                 train_examples.extend(train_example)
         logger.debug(
             f"Converted {len(train_rollouts)} training rollouts to {len(train_examples)} training examples using {config.trajectory_strategy} strategy"

--- a/src/prime_rl/transport/types.py
+++ b/src/prime_rl/transport/types.py
@@ -12,6 +12,7 @@ class TrainingSample(msgspec.Struct, array_like=True, gc=False, omit_defaults=Tr
     completion_logprobs: list[float]
     teacher_logprobs: list[float] | None = None
     advantage: float | None = None
+    reward: float | None = None
 
 
 class TrainingBatch(msgspec.Struct, array_like=True, gc=False, omit_defaults=True):


### PR DESCRIPTION
Will be convenient for TUI reasons / the ability to inspect on disk rollouts in a granular fashion without wandb logging overhead.

<img width="1195" height="504" alt="image" src="https://github.com/user-attachments/assets/921a8f01-5fc2-4953-80ec-5c65bd4376b1" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds per-example reward to training payloads and populates it during rollout processing.
> 
> - Extends `TrainingSample` with `reward: float | None` in `src/prime_rl/transport/types.py`
> - In `src/prime_rl/orchestrator/orchestrator.py`, assigns `te.reward = train_rollout["reward"]` when constructing training examples (`interleaved` or `branch` strategies)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 993fe8b5e0da5624c828bb7f8ba83b72cd9dede1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->