### PR TITLE
Re-raise vf.SandboxError in eval to trigger rollout rescheduling

### DIFF
--- a/src/prime_rl/eval/eval.py
+++ b/src/prime_rl/eval/eval.py
@@ -6,7 +6,7 @@ from prime_rl.eval.config import OfflineEvalConfig
 from prime_rl.eval.utils import run_evals
 from prime_rl.orchestrator.utils import set_semaphore
 from prime_rl.utils.client import (
-    check_has_model,
+    maybe_check_has_model,
     check_health,
     reload_weights,
     setup_admin_clients,
@@ -56,7 +56,7 @@ async def eval(config: OfflineEvalConfig):
     # Check health of the client
     logger.info("Waiting for inference pool to be ready")
     await check_health(admin_clients)
-    await check_has_model(clients, config.model.name)
+    await maybe_check_has_model(clients, config)
     logger.success(f"Inference pool is healthy and serves {config.model.name}")
 
     # Reset weights to base model to allow reusing inference server across runs

--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -231,7 +231,11 @@ async def generate_and_save_rollout(
         """Asynchronously generate and score a single rollout."""
         logger = get_logger()
         try:
-            return await generate_rollout(client, env, model_name, example, sampling_args)
+            state = await generate_rollout(client, env, model_name, example, sampling_args)
+            # Re-raise infrastructure errors to trigger retry
+            if state.get("error") and isinstance(state["error"], vf.SandboxError):
+                raise state["error"]
+            return state
         except BadRequestError as e:
             # Check if this is a context length error and retry with adjusted max_tokens
             error_message = str(e)
@@ -240,7 +244,10 @@ async def generate_and_save_rollout(
             if new_max_tokens is not None:
                 logger.warning(f"Context length error: reducing max_tokens to {new_max_tokens}.")
                 sampling_args["max_tokens"] = new_max_tokens
-                return await generate_rollout(client, env, model_name, example, sampling_args)
+                state = await generate_rollout(client, env, model_name, example, sampling_args)
+                if state.get("error") and isinstance(state["error"], vf.SandboxError):
+                    raise state["error"]
+                return state
             raise
 
     try:
@@ -303,7 +310,12 @@ async def generate_and_save_group(
         """Asynchronously generate and score a group of rollouts."""
         logger = get_logger()
         try:
-            return await generate_group(client, env, model_name, example, rollouts_per_example, sampling_args)
+            states = await generate_group(client, env, model_name, example, rollouts_per_example, sampling_args)
+            # Re-raise infrastructure errors to trigger retry (check all states in group)
+            for state in states:
+                if state.get("error") and isinstance(state["error"], vf.SandboxError):
+                    raise state["error"]
+            return states
         except BadRequestError as e:
             error_message = str(e)
             new_max_tokens = parse_and_calculate_max_tokens(error_message)
@@ -311,7 +323,11 @@ async def generate_and_save_group(
             if new_max_tokens is not None:
                 logger.warning(f"Context length error: reducing max_tokens to {new_max_tokens}.")
                 sampling_args["max_tokens"] = new_max_tokens
-                return await generate_group(client, env, model_name, example, rollouts_per_example, sampling_args)
+                states = await generate_group(client, env, model_name, example, rollouts_per_example, sampling_args)
+                for state in states:
+                    if state.get("error") and isinstance(state["error"], vf.SandboxError):
+                        raise state["error"]
+                return states
             raise
 
     try:

--- a/src/prime_rl/orchestrator/ckpt.py
+++ b/src/prime_rl/orchestrator/ckpt.py
@@ -32,7 +32,6 @@ class CheckpointManager:
     def _save_to_path(
         self,
         ckpt_path: Path,
-        ckpt_step: int,
         progress: Progress,
         buffer: Buffer,
     ):
@@ -88,7 +87,7 @@ class CheckpointManager:
         """Saves the full checkpoint state for a specified step."""
         ckpt_path = self.get_ckpt_path(step)
         ckpt_path.mkdir(parents=True, exist_ok=True)
-        self._save_to_path(ckpt_path, step, progress, buffer)
+        self._save_to_path(ckpt_path, progress, buffer)
 
 
 def setup_ckpt_manager(output_dir: Path, config: CheckpointConfig | None) -> CheckpointManager | None:

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -35,7 +35,7 @@ from prime_rl.orchestrator.utils import (
     set_semaphore,
 )
 from prime_rl.utils.client import (
-    check_has_model,
+    maybe_check_has_model,
     check_health,
     init_nccl_broadcast,
     reload_weights,
@@ -193,7 +193,7 @@ async def orchestrate(config: OrchestratorConfig):
     # Check health of the client
     logger.info("Waiting for inference pool to be ready")
     await check_health(admin_clients)
-    await check_has_model(clients, config.model.name)
+    await maybe_check_has_model(clients, config)
     logger.success("Inference pool ready")
 
     # Set up weight broadcast backend

--- a/src/prime_rl/synthesize/synthesize.py
+++ b/src/prime_rl/synthesize/synthesize.py
@@ -8,7 +8,7 @@ from prime_rl.orchestrator.utils import (
 from prime_rl.synthesize.config import SynthesizeConfig
 from prime_rl.synthesize.utils import generate_synthetic_data
 from prime_rl.utils.client import (
-    check_has_model,
+    maybe_check_has_model,
     check_health,
     setup_admin_clients,
     setup_clients,
@@ -45,7 +45,7 @@ async def synthesize(config: SynthesizeConfig):
     # Check health of the client
     logger.info("Waiting for inference pool to be ready")
     await check_health(admin_clients)
-    await check_has_model(clients, config.model.name)
+    await maybe_check_has_model(clients, config)
     logger.success(f"Inference pool is healthy and serves {config.model.name}")
 
     # Set global semaphore

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -87,7 +87,14 @@ class CheckpointManager:
         self.ckpt_dir = get_ckpt_dir(output_dir)
         self.logger = get_logger()
         self.world = get_world()
-        self.ckpt_steps: list[int] = get_all_ckpt_steps(self.ckpt_dir) if self.world.is_master else []
+        if self.world.is_master:
+            all_steps = get_all_ckpt_steps(self.ckpt_dir)
+            if config.resume_step is not None and config.resume_step >= 0:
+                self.ckpt_steps = [s for s in all_steps if s <= config.resume_step]
+            else:
+                self.ckpt_steps = all_steps
+        else:
+            self.ckpt_steps = []
 
     def get_ckpt_path(self, step: int) -> Path:
         """Get the path to write the trainer checkpoint for a given step."""
@@ -237,13 +244,21 @@ class WeightCheckpointManager:
         save_async: bool = False,
         keep_last: int | None = None,
         keep_interval: int | None = None,
+        resume_step: int | None = None,
     ):
         self.weights_dir = get_weights_dir(output_dir)
         self.config = config
         self.lora_config = lora_config
         self.logger = get_logger()
         self.world = get_world()
-        self.ckpt_steps: list[int] = get_all_ckpt_steps(self.weights_dir) if self.world.is_master else []
+        if self.world.is_master:
+            all_steps = get_all_ckpt_steps(self.weights_dir)
+            if resume_step is not None and resume_step >= 0:
+                self.ckpt_steps = [s for s in all_steps if s <= resume_step]
+            else:
+                self.ckpt_steps = all_steps
+        else:
+            self.ckpt_steps = []
         self.keep_last = keep_last
         self.keep_interval = keep_interval
 
@@ -370,6 +385,7 @@ def setup_ckpt_managers(
             lora_config=lora_config,
             keep_last=ckpt_config.keep_last,
             keep_interval=ckpt_config.keep_interval,
+            resume_step=ckpt_config.resume_step,
         )
     else:
         weight_ckpt_manager = None

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -29,7 +29,7 @@ from prime_rl.trainer.weights import (
 from prime_rl.trainer.world import get_world
 from prime_rl.utils.logger import get_logger
 from prime_rl.utils.tensor_hashing import get_module_signature, get_optimizer_signature
-from prime_rl.utils.utils import get_ckpt_dir, get_step_path, get_weights_dir
+from prime_rl.utils.utils import get_all_ckpt_steps, get_ckpt_dir, get_step_path, get_weights_dir
 
 
 class AppState(Stateful):
@@ -87,7 +87,7 @@ class CheckpointManager:
         self.ckpt_dir = get_ckpt_dir(output_dir)
         self.logger = get_logger()
         self.world = get_world()
-        self.ckpt_steps: list[int] = []  # Sorted list of steps that have been checkpointed, only used on master rank
+        self.ckpt_steps: list[int] = get_all_ckpt_steps(self.ckpt_dir) if self.world.is_master else []
 
     def get_ckpt_path(self, step: int) -> Path:
         """Get the path to write the trainer checkpoint for a given step."""
@@ -243,7 +243,7 @@ class WeightCheckpointManager:
         self.lora_config = lora_config
         self.logger = get_logger()
         self.world = get_world()
-        self.ckpt_steps: list[int] = []  # Sorted list of steps that have been checkpointed, only used on master rank
+        self.ckpt_steps: list[int] = get_all_ckpt_steps(self.weights_dir) if self.world.is_master else []
         self.keep_last = keep_last
         self.keep_interval = keep_interval
 

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -9,6 +9,9 @@ from prime_evals import AsyncEvalsClient
 from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
 from prime_rl.utils.config import ClientConfig
+from prime_rl.orchestrator.config import OrchestratorConfig
+from prime_rl.synthesize.config import SynthesizeConfig
+from prime_rl.eval.config import OfflineEvalConfig
 from prime_rl.utils.logger import get_logger
 
 
@@ -61,7 +64,10 @@ def setup_admin_clients(client_config: ClientConfig) -> list[AsyncClient]:
     return [_setup_admin_client(base_url) for base_url in client_config.base_url]
 
 
-async def check_has_model(clients: list[AsyncOpenAI], model_name: str) -> None:
+async def maybe_check_has_model(clients: list[AsyncOpenAI], config: OrchestratorConfig | SynthesizeConfig | OfflineEvalConfig) -> None:
+    if config.client.skip_model_check:
+        return
+    model_name = config.model.name
     logger = get_logger()
     logger.debug(f"Checking if model {model_name} is in the inference pool")
     results = await asyncio.gather(*[client.models.list() for client in clients])

--- a/src/prime_rl/utils/config.py
+++ b/src/prime_rl/utils/config.py
@@ -52,6 +52,13 @@ class ClientConfig(BaseConfig):
         ),
     ] = {}
 
+    skip_model_check: Annotated[
+        bool,
+        Field(
+            description="Whether to skip checking if the model is available in the inference pool. Useful for external APIs or API Keys that don't support the /models endpoint.",
+        ),
+    ] = False
+
 
 class LogConfig(BaseConfig):
     """Configures the logger."""

--- a/src/prime_rl/utils/pathing.py
+++ b/src/prime_rl/utils/pathing.py
@@ -33,14 +33,19 @@ def get_step_path(path: Path, step: int) -> Path:
     return path / f"step_{step}"
 
 
+def get_all_ckpt_steps(ckpt_dir: Path) -> list[int]:
+    """Gets all checkpoint steps from the checkpoint directory, sorted in ascending order."""
+    step_dirs = list(ckpt_dir.glob("step_*"))
+    return sorted([int(step_dir.name.split("_")[-1]) for step_dir in step_dirs])
+
+
 def resolve_latest_ckpt_step(ckpt_dir: Path) -> int | None:
     """Gets the latest checkpoint step from the checkpoint directory. Returns None if no checkpoints are found."""
-    step_dirs = list(ckpt_dir.glob("step_*"))
-    if len(step_dirs) == 0:
+    steps = get_all_ckpt_steps(ckpt_dir)
+    if len(steps) == 0:
         logger = get_logger()
         logger.warning(f"No checkpoints found in {ckpt_dir}. Starting from scratch.")
         return None
-    steps = sorted([int(step_dir.name.split("_")[-1]) for step_dir in step_dirs])
     latest_step = steps[-1]
     logger = get_logger()
     logger.info(f"Found latest checkpoint in {ckpt_dir}: {latest_step}")

--- a/src/prime_rl/utils/utils.py
+++ b/src/prime_rl/utils/utils.py
@@ -17,6 +17,7 @@ from prime_rl.utils.logger import get_logger
 # TODO: Change all imports to use utils.pathing
 # ruff: noqa: F401
 from prime_rl.utils.pathing import (
+    get_all_ckpt_steps,
     get_broadcast_dir,
     get_ckpt_dir,
     get_eval_dir,


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->
So online-evals may never crash again.

  - Check state["error"] after rollout completion in _generate_rollout and _generate_group
  - Re-raise vf.SandboxError to trigger existing @retry decorator
  - Enables automatic rescheduling of rollouts with sandbox infrastructure failures
---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: [Issue ID]
**Linear Issue**: Resolves [Issue ID]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves reliability, configurability, and observability across eval and training.
> 
> - **Eval robustness**: After `generate_rollout`/`generate_group`, re-raise `vf.SandboxError` (including after context-length retries) to trigger `@retry` and reschedule rollouts.
> - **Client config**: Add `ClientConfig.skip_model_check`; replace `check_has_model` with `maybe_check_has_model` in `eval`, `orchestrator`, and `synthesize` to optionally skip `/models` checks.
> - **Checkpointing (trainer/weights)**: Initialize `ckpt_steps` from `get_all_ckpt_steps(...)` and filter by `resume_step`; plumb `resume_step` into `WeightCheckpointManager`; add `utils.pathing.get_all_ckpt_steps` and reuse in `resolve_latest_ckpt_step`.
> - **Scheduler metrics**: Track/report `batch/cancelled_rollouts` when off-policy requests are cancelled.
> - **Cleanup**: Remove unused `ckpt_step` param from orchestrator checkpoint save path API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d793efffb848c37e745d7b06d4d6a15e4824ad1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->