### PR TITLE
Re-raise `vf.SandboxError` in eval to trigger rollout rescheduling

### DIFF
--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -231,7 +231,11 @@ async def generate_and_save_rollout(
         """Asynchronously generate and score a single rollout."""
         logger = get_logger()
         try:
-            return await generate_rollout(client, env, model_name, example, sampling_args)
+            state = await generate_rollout(client, env, model_name, example, sampling_args)
+            # Re-raise infrastructure errors to trigger retry
+            if state.get("error") and isinstance(state["error"], vf.SandboxError):
+                raise state["error"]
+            return state
         except BadRequestError as e:
             # Check if this is a context length error and retry with adjusted max_tokens
             error_message = str(e)
@@ -240,7 +244,10 @@ async def generate_and_save_rollout(
             if new_max_tokens is not None:
                 logger.warning(f"Context length error: reducing max_tokens to {new_max_tokens}.")
                 sampling_args["max_tokens"] = new_max_tokens
-                return await generate_rollout(client, env, model_name, example, sampling_args)
+                state = await generate_rollout(client, env, model_name, example, sampling_args)
+                if state.get("error") and isinstance(state["error"], vf.SandboxError):
+                    raise state["error"]
+                return state
             raise
 
     try:
@@ -303,7 +310,12 @@ async def generate_and_save_group(
         """Asynchronously generate and score a group of rollouts."""
         logger = get_logger()
         try:
-            return await generate_group(client, env, model_name, example, rollouts_per_example, sampling_args)
+            states = await generate_group(client, env, model_name, example, rollouts_per_example, sampling_args)
+            # Re-raise infrastructure errors to trigger retry (check all states in group)
+            for state in states:
+                if state.get("error") and isinstance(state["error"], vf.SandboxError):
+                    raise state["error"]
+            return states
         except BadRequestError as e:
             error_message = str(e)
             new_max_tokens = parse_and_calculate_max_tokens(error_message)
@@ -311,7 +323,11 @@ async def generate_and_save_group(
             if new_max_tokens is not None:
                 logger.warning(f"Context length error: reducing max_tokens to {new_max_tokens}.")
                 sampling_args["max_tokens"] = new_max_tokens
-                return await generate_group(client, env, model_name, example, rollouts_per_example, sampling_args)
+                states = await generate_group(client, env, model_name, example, rollouts_per_example, sampling_args)
+                for state in states:
+                    if state.get("error") and isinstance(state["error"], vf.SandboxError):
+                        raise state["error"]
+                return states
             raise
 
     try:

--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -233,7 +233,7 @@ async def generate_and_save_rollout(
         try:
             state = await generate_rollout(client, env, model_name, example, sampling_args)
             # Re-raise infrastructure errors to trigger retry
-            if state.get("error") and isinstance(state["error"], vf.SandboxError):
+            if state.get("error") and isinstance(state["error"], vf.InfraError):
                 raise state["error"]
             return state
         except BadRequestError as e:
@@ -245,7 +245,7 @@ async def generate_and_save_rollout(
                 logger.warning(f"Context length error: reducing max_tokens to {new_max_tokens}.")
                 sampling_args["max_tokens"] = new_max_tokens
                 state = await generate_rollout(client, env, model_name, example, sampling_args)
-                if state.get("error") and isinstance(state["error"], vf.SandboxError):
+                if state.get("error") and isinstance(state["error"], vf.InfraError):
                     raise state["error"]
                 return state
             raise
@@ -313,7 +313,7 @@ async def generate_and_save_group(
             states = await generate_group(client, env, model_name, example, rollouts_per_example, sampling_args)
             # Re-raise infrastructure errors to trigger retry (check all states in group)
             for state in states:
-                if state.get("error") and isinstance(state["error"], vf.SandboxError):
+                if state.get("error") and isinstance(state["error"], vf.InfraError):
                     raise state["error"]
             return states
         except BadRequestError as e:
@@ -325,7 +325,7 @@ async def generate_and_save_group(
                 sampling_args["max_tokens"] = new_max_tokens
                 states = await generate_group(client, env, model_name, example, rollouts_per_example, sampling_args)
                 for state in states:
-                    if state.get("error") and isinstance(state["error"], vf.SandboxError):
+                    if state.get("error") and isinstance(state["error"], vf.InfraError):
                         raise state["error"]
                 return states
             raise


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

So online-evals may never crash again.

  - Check state["error"] after rollout completion in _generate_rollout and _generate_group
  - Re-raise vf.SandboxError to trigger existing @retry decorator
  - Enables automatic rescheduling of rollouts with sandbox infrastructure failures

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: [Issue ID]
**Linear Issue**: Resolves [Issue ID]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures infra failures reschedule rollouts by surfacing errors from returned states to the retry mechanism.
> 
> - In `_generate_rollout` and `_generate_group`, check `state["error"]` (or each in `states`) and re-raise if it's a `vf.InfraError` to trigger `@retry`
> - Preserve context-length handling: on `BadRequestError`, parse max tokens, retry with reduced `max_tokens`, and still re-raise `vf.InfraError` if present
> - Applies to both per-rollout and group generation paths without altering saving/progress behavior (`results.jsonl`, progress bar)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8d8cbe19c48d1bd1e0cdab9de203d29488f0036. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->