### PR TITLE
QoL: Checkpoint warnings + Upload CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "prime>=0.5.0",
     "tenacity>=8.2.0",
     "pyzmq>=27.1.0",
+    "huggingface_hub>=0.32.0",
 ]
 
 [project.scripts]
@@ -51,6 +52,7 @@ inference = "prime_rl.inference.server:main"
 sft = "prime_rl.trainer.sft.train:main"
 eval = "prime_rl.eval.eval:main"
 synthesize = "prime_rl.synthesize.synthesize:main"
+upload-ckpt = "prime_rl.utils.upload:main"
 
 [project.optional-dependencies]
 flash-attn = [

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -55,6 +55,7 @@ from prime_rl.utils.utils import (
     install_env,
     resolve_latest_ckpt_step,
     to_col_format,
+    warn_if_ckpts_inconsistent,
 )
 from prime_rl.utils.vf import generate_batch, get_completion_len, get_prompt_len, get_seq_len
 
@@ -163,6 +164,9 @@ async def orchestrate(config: OrchestratorConfig):
 
     checkpoint_step = None
     if config.ckpt and config.ckpt.resume_step is not None and ckpt_manager is not None:
+        warn_if_ckpts_inconsistent(
+            config.output_dir.parent, config.ckpt.resume_step
+        )  # output_dir=run_0, parent=$OUTPUT_DIR
         if config.ckpt.resume_step == -1:
             checkpoint_step = resolve_latest_ckpt_step(ckpt_manager.ckpt_dir)
         else:

--- a/src/prime_rl/utils/pathing.py
+++ b/src/prime_rl/utils/pathing.py
@@ -52,6 +52,52 @@ def resolve_latest_ckpt_step(ckpt_dir: Path) -> int | None:
     return latest_step
 
 
+def get_common_ckpt_steps(dirs: list[Path]) -> list[int]:
+    """Returns sorted intersection of checkpoint steps across directories."""
+    sets = [set(get_all_ckpt_steps(d)) for d in dirs if d.exists()]
+    if not sets:
+        return []
+    return sorted(set.intersection(*sets))
+
+
+def warn_if_ckpts_inconsistent(output_dir: Path, resume_step: int) -> None:
+    """Warns if resume_step is not safe given checkpoint state across directories."""
+    logger = get_logger()
+    orch_dirs = list(output_dir.glob("run_*"))
+    if len(orch_dirs) > 1:
+        return  # Multi-tenant: orchestrators may legitimately differ
+
+    all_dirs_and_steps = {
+        get_ckpt_dir(output_dir): get_all_ckpt_steps(get_ckpt_dir(output_dir)),
+        get_weights_dir(output_dir): get_all_ckpt_steps(get_weights_dir(output_dir)),
+    }
+    if orch_dirs:
+        all_dirs_and_steps[get_ckpt_dir(orch_dirs[0])] = get_all_ckpt_steps(get_ckpt_dir(orch_dirs[0]))
+
+    if not all(all_dirs_and_steps.values()):  # no checkpoints found
+        return
+
+    common_steps = get_common_ckpt_steps(all_dirs_and_steps.keys())
+    if not common_steps:
+        logger.error(f"No common checkpoint steps across dirs: {all_dirs_and_steps}. Cannot safely resume.")
+        return
+    latest_common_step = max(common_steps)
+    latest_steps_all_equal = all(
+        all_dirs_and_steps[_dir][-1] == latest_common_step for _dir in all_dirs_and_steps.keys()
+    )
+
+    if resume_step == -1 and not latest_steps_all_equal:
+        logger.warning(
+            f"Checkpoint mismatch detected with resume_step=-1. Check: {all_dirs_and_steps.keys()}. "
+            f"Consider setting resume_step={latest_common_step} explicitly."
+        )
+    elif resume_step >= 0 and resume_step not in common_steps:
+        logger.warning(
+            f"resume_step={resume_step} not found in all checkpoint dirs: {all_dirs_and_steps.keys()}. "
+            f"Latest common step: {latest_common_step}."
+        )
+
+
 def sync_wait_for_path(path: Path, interval: int = 1, log_interval: int = 10) -> None:
     logger = get_logger()
     wait_time = 0

--- a/src/prime_rl/utils/upload.py
+++ b/src/prime_rl/utils/upload.py
@@ -1,0 +1,246 @@
+"""
+Checkpoint upload utility for uploading training checkpoints to HuggingFace Hub.
+
+Usage:
+    uv run upload-ckpt /path/to/output
+    uv run upload-ckpt /path/to/output --type weights --steps 100 200 300
+    uv run upload-ckpt /path/to/output --public
+"""
+
+import os
+from contextlib import contextmanager
+from enum import Enum
+from pathlib import Path
+from typing import Annotated
+
+from huggingface_hub import HfApi
+from pydantic import Field
+from pydantic_settings import BaseSettings, CliApp, CliPositionalArg
+
+from prime_rl.utils.logger import get_logger
+from prime_rl.utils.pathing import (
+    get_all_ckpt_steps,
+    get_ckpt_dir,
+    get_common_ckpt_steps,
+    get_step_path,
+    get_weights_dir,
+)
+
+
+class CheckpointType(str, Enum):
+    TRAINER = "trainer"
+    WEIGHTS = "weights"
+    ORCHESTRATOR = "orchestrator"
+    ALL = "all"
+
+
+@contextmanager
+def offline_disabled():
+    """Temporarily disable HF offline mode for uploads."""
+    offline_vars = ["HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE", "HF_DATASETS_OFFLINE"]
+    saved = {k: os.environ.pop(k, None) for k in offline_vars}
+    try:
+        yield
+    finally:
+        for k, v in saved.items():
+            if v is not None:
+                os.environ[k] = v
+
+
+class CheckpointUploader:
+    """Handles uploading checkpoints to HuggingFace Hub."""
+
+    def __init__(
+        self,
+        output_dir: Path,
+        org: str = "PrimeIntellect",
+        repo_prefix: str = "INTELLECT-4",
+        num_workers: int = 8,
+        public: bool = False,
+        dry_run: bool = False,
+    ):
+        self.output_dir = output_dir
+        self.org = org
+        self.repo_prefix = repo_prefix
+        self.num_workers = num_workers
+        self.public = public
+        self.dry_run = dry_run
+        self.api = HfApi()
+        self.logger = get_logger()
+
+    def _weights_repo_id(self, step: int) -> str:
+        """Repo ID for weights: {org}/{prefix}-{step}"""
+        return f"{self.org}/{self.repo_prefix}-{step}"
+
+    def _ckpt_repo_id(self, step: int) -> str:
+        """Repo ID for checkpoints: {org}/{prefix}-{step}-Ckpt"""
+        return f"{self.org}/{self.repo_prefix}-{step}-Ckpt"
+
+    def _ensure_repo(self, repo_id: str) -> None:
+        """Create repo if it doesn't exist."""
+        if self.dry_run:
+            self.logger.info(f"[DRY-RUN] Would create repo: {repo_id}")
+            return
+        try:
+            self.api.create_repo(
+                repo_id=repo_id,
+                repo_type="model",
+                private=not self.public,
+                exist_ok=True,
+            )
+            self.logger.info(f"Ensured repo exists: {repo_id}")
+        except Exception as e:
+            self.logger.error(f"Failed to create repo {repo_id}: {e}")
+            raise
+
+    def _upload_folder(self, folder_path: Path, repo_id: str) -> None:
+        """Upload a folder using upload_large_folder."""
+        if not folder_path.exists():
+            self.logger.warning(f"Folder does not exist, skipping: {folder_path}")
+            return
+
+        if self.dry_run:
+            self.logger.info(f"[DRY-RUN] Would upload {folder_path} -> {repo_id}")
+            return
+
+        self.logger.info(f"Uploading {folder_path} -> {repo_id}")
+
+        # Enable high performance mode for Xet backend
+        os.environ["HF_XET_HIGH_PERFORMANCE"] = "1"
+
+        self.api.upload_large_folder(
+            repo_id=repo_id,
+            repo_type="model",
+            folder_path=str(folder_path),
+            num_workers=self.num_workers,
+        )
+        self.logger.info(f"Completed upload: {folder_path} -> {repo_id}")
+
+    def upload_weights(self, step: int) -> None:
+        """Upload weights checkpoint for a step."""
+        weights_dir = get_weights_dir(self.output_dir)
+        step_dir = get_step_path(weights_dir, step)
+        repo_id = self._weights_repo_id(step)
+
+        with offline_disabled():
+            self._ensure_repo(repo_id)
+            self._upload_folder(step_dir, repo_id)
+
+    def upload_trainer(self, step: int) -> None:
+        """Upload trainer checkpoint for a step."""
+        ckpt_dir = get_ckpt_dir(self.output_dir)
+        step_dir = get_step_path(ckpt_dir, step)
+        trainer_dir = step_dir / "trainer"
+        repo_id = self._ckpt_repo_id(step)
+
+        with offline_disabled():
+            self._ensure_repo(repo_id)
+            self._upload_folder(trainer_dir, repo_id)
+
+    def upload_orchestrator(self, step: int) -> None:
+        """Upload orchestrator checkpoint for a step."""
+        # Find orchestrator dir - could be run_0, run_1, etc.
+        orch_dirs = list(self.output_dir.glob("run_*"))
+        if not orch_dirs:
+            self.logger.warning(f"No orchestrator directories found in {self.output_dir}")
+            return
+
+        # Use first orchestrator dir (single-tenant assumption for uploads)
+        orch_dir = sorted(orch_dirs)[0]
+        ckpt_dir = get_ckpt_dir(orch_dir)
+        step_dir = get_step_path(ckpt_dir, step)
+        orch_ckpt_dir = step_dir / "orchestrator"
+        repo_id = self._ckpt_repo_id(step)
+
+        with offline_disabled():
+            self._ensure_repo(repo_id)
+            self._upload_folder(orch_ckpt_dir, repo_id)
+
+    def upload_step(self, step: int, ckpt_type: CheckpointType) -> None:
+        """Upload checkpoint(s) for a specific step."""
+        self.logger.info(f"Uploading step {step}, type={ckpt_type.value}")
+
+        if ckpt_type == CheckpointType.WEIGHTS:
+            self.upload_weights(step)
+        elif ckpt_type == CheckpointType.TRAINER:
+            self.upload_trainer(step)
+        elif ckpt_type == CheckpointType.ORCHESTRATOR:
+            self.upload_orchestrator(step)
+        elif ckpt_type == CheckpointType.ALL:
+            self.upload_weights(step)
+            self.upload_trainer(step)
+            self.upload_orchestrator(step)
+
+    def get_uploadable_steps(self, ckpt_type: CheckpointType) -> list[int]:
+        """Get steps that can be uploaded based on checkpoint type. Returns sorted list."""
+        if ckpt_type == CheckpointType.WEIGHTS:
+            return get_all_ckpt_steps(get_weights_dir(self.output_dir))
+        elif ckpt_type == CheckpointType.TRAINER:
+            return get_all_ckpt_steps(get_ckpt_dir(self.output_dir))
+        elif ckpt_type == CheckpointType.ORCHESTRATOR:
+            orch_dirs = list(self.output_dir.glob("run_*"))
+            if not orch_dirs:
+                return []
+            return get_all_ckpt_steps(get_ckpt_dir(sorted(orch_dirs)[0]))
+        else:  # ALL - use common steps
+            dirs = [get_weights_dir(self.output_dir), get_ckpt_dir(self.output_dir)]
+            orch_dirs = list(self.output_dir.glob("run_*"))
+            if orch_dirs:
+                dirs.append(get_ckpt_dir(sorted(orch_dirs)[0]))
+            return get_common_ckpt_steps(dirs)
+
+    def upload_all(self, ckpt_type: CheckpointType, steps: list[int] | None = None) -> None:
+        """Upload all (or specified) steps.
+
+        If steps is None, auto-discover and sort ascending (oldest first).
+        If steps is provided, use the order as-is.
+        """
+        if steps is None:
+            steps = self.get_uploadable_steps(ckpt_type)
+            # Auto-discovered steps are already sorted by get_all_ckpt_steps/get_common_ckpt_steps
+
+        if not steps:
+            self.logger.warning(f"No steps to upload for type={ckpt_type.value}")
+            return
+
+        self.logger.info(f"Uploading {len(steps)} steps: {steps}")
+
+        for step in steps:
+            self.upload_step(step, ckpt_type)
+
+
+class UploadConfig(BaseSettings):
+    """Configuration for checkpoint upload CLI."""
+
+    output_dir: Annotated[Path, CliPositionalArg()] = Field(description="Output directory containing checkpoints")
+    org: str = Field(default="PrimeIntellect", description="HuggingFace organization")
+    repo_prefix: str = Field(default="INTELLECT-4", description="Repository name prefix")
+    type: CheckpointType = Field(default=CheckpointType.ALL, description="Checkpoint type to upload")
+    steps: list[int] | None = Field(default=None, description="Specific steps to upload in given order")
+    num_workers: int = Field(default=8, description="Number of upload workers")
+    public: bool = Field(default=False, description="Create public repositories")
+    dry_run: bool = Field(default=False, description="Show what would be uploaded without actually uploading")
+
+
+def main():
+    """CLI entry point for checkpoint upload."""
+    config = CliApp.run(UploadConfig)
+
+    logger = get_logger()
+    logger.info(f"Upload config: {config}")
+
+    uploader = CheckpointUploader(
+        output_dir=config.output_dir,
+        org=config.org,
+        repo_prefix=config.repo_prefix,
+        num_workers=config.num_workers,
+        public=config.public,
+        dry_run=config.dry_run,
+    )
+
+    uploader.upload_all(config.type, config.steps)
+    logger.info("Upload complete!")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/prime_rl/utils/utils.py
+++ b/src/prime_rl/utils/utils.py
@@ -20,6 +20,7 @@ from prime_rl.utils.pathing import (
     get_all_ckpt_steps,
     get_broadcast_dir,
     get_ckpt_dir,
+    get_common_ckpt_steps,
     get_eval_dir,
     get_log_dir,
     get_rollout_dir,
@@ -28,6 +29,7 @@ from prime_rl.utils.pathing import (
     resolve_latest_ckpt_step,
     sync_wait_for_path,
     wait_for_path,
+    warn_if_ckpts_inconsistent,
 )
 
 


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

  Checkpoint Upload CLI (upload-ckpt):
  - Upload checkpoints to HuggingFace Hub with configurable org/repo prefix
  - Supports three checkpoint types: weights, trainer, orchestrator, or all
  - Auto-discovers available steps or accepts explicit --steps list
  - Uses upload_large_folder with configurable worker count for performance
  - Includes --dry-run mode and --public flag for repo visibility
  - Temporarily disables HF offline mode environment variables during upload
  - Can be turned into `maybe_save()` down the line

  Checkpoint Consistency Warnings:
  - New warn_if_ckpts_inconsistent() called on orchestrator resume
  - Warns if resume_step=-1 but latest steps differ across checkpoint directories
  - Warns if explicit resume_step doesn't exist in all checkpoint directories
  - Skips warning for multi-tenant setups (multiple run_* directories)

To be tested in prod.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: [Issue ID]
**Linear Issue**: Resolves [Issue ID]