### PR TITLE
[Feat] multi run optim args

### DIFF
--- a/configs/ci/integration/rl_lora/resume.toml
+++ b/configs/ci/integration/rl_lora/resume.toml
@@ -22,7 +22,9 @@ save_adapter_separately = true
 [orchestrator]
 batch_size = 128
 rollouts_per_example = 16
-lora_name = "r8-1e-4"
+
+[orchestrator.model.lora]
+name = "r8-1e-4"
 
 [orchestrator.sampling]
 max_tokens = 128

--- a/configs/ci/integration/rl_lora/resume.toml
+++ b/configs/ci/integration/rl_lora/resume.toml
@@ -34,3 +34,4 @@ id = "reverse-text"
 
 [inference]
 enable_lora = true
+gpu_memory_utilization = 0.7

--- a/configs/ci/integration/rl_lora/start.toml
+++ b/configs/ci/integration/rl_lora/start.toml
@@ -21,7 +21,9 @@ save_adapter_separately = true
 [orchestrator]
 batch_size = 128
 rollouts_per_example = 16
-lora_name = "r8-1e-4"
+
+[orchestrator.model.lora]
+name = "r8-1e-4"
 
 [orchestrator.sampling]
 max_tokens = 128

--- a/configs/ci/integration/rl_lora/start.toml
+++ b/configs/ci/integration/rl_lora/start.toml
@@ -33,3 +33,4 @@ id = "reverse-text"
 
 [inference]
 enable_lora = true
+gpu_memory_utilization = 0.7

--- a/configs/ci/integration/rl_multi_run/orchestrator.toml
+++ b/configs/ci/integration/rl_multi_run/orchestrator.toml
@@ -1,5 +1,5 @@
 # Orchestrator config for multi-run RL integration test
-# lora_name and output_dir are set via CLI
+# model.lora.name and output_dir are set via CLI
 batch_size = 128
 rollouts_per_example = 16
 seq_len = 2048

--- a/examples/wiki_search/rl.toml
+++ b/examples/wiki_search/rl.toml
@@ -33,7 +33,9 @@ target_modules = [
 batch_size = 512
 rollouts_per_example = 16
 oversampling_factor = 2.0
-lora_name = "qwen3-4b-wiki-search"
+
+[orchestrator.model.lora]
+name = "qwen3-4b-wiki-search"
 
 [orchestrator.sampling]
 max_tokens = 512

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -26,7 +26,7 @@ class OptimizerConfig(BaseConfig):
             ge=0,
             description="Learning rate for this run.",
         ),
-    ] = 1e-6
+    ] = 1e-4
 
 
 class LoRAConfig(BaseConfig):

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -8,11 +8,63 @@ from prime_rl.utils.config import (
     ClientConfig,
     HeartbeatConfig,
     LogConfig,
-    ModelConfig,
     PrimeMonitorConfig,
     WandbWithExtrasConfig,
 )
+from prime_rl.utils.config import (
+    ModelConfig as BaseModelConfig,
+)
 from prime_rl.utils.pydantic_config import BaseConfig, BaseSettings
+
+
+class OptimizerConfig(BaseConfig):
+    """Per-run optimizer configuration for multi-run training."""
+
+    lr: Annotated[
+        float,
+        Field(
+            ge=0,
+            description="Learning rate for this run.",
+        ),
+    ] = 1e-6
+
+
+class LoRAConfig(BaseConfig):
+    """Per-run LoRA configuration for multi-run training."""
+
+    name: Annotated[
+        str | None,
+        Field(
+            description="Name of the LoRA adapter. If None, auto-generated from rank and alpha.",
+        ),
+    ] = None
+
+    rank: Annotated[
+        int | None,
+        Field(
+            ge=1,
+            description="LoRA rank for this run. Must be <= trainer's max rank. If None, uses trainer's rank.",
+        ),
+    ] = None
+
+    alpha: Annotated[
+        float,
+        Field(
+            ge=0,
+            description="LoRA alpha for this run.",
+        ),
+    ] = 16.0
+
+
+class ModelConfig(BaseModelConfig):
+    """Extended model configuration with per-run LoRA settings."""
+
+    lora: Annotated[
+        LoRAConfig | None,
+        Field(
+            description="LoRA configuration. If None, LoRA is not used.",
+        ),
+    ] = None
 
 
 class SamplingConfig(BaseConfig):
@@ -555,6 +607,9 @@ class OrchestratorConfig(BaseSettings):
     # The model configuration
     model: ModelConfig = ModelConfig()
 
+    # The optimizer configuration (per-run LR for multi-run training)
+    optim: OptimizerConfig = OptimizerConfig()
+
     # The teacher model configuration (optional)
     teacher_model: Annotated[
         TeacherModelConfig | None,
@@ -706,13 +761,6 @@ class OrchestratorConfig(BaseSettings):
     ] = False
 
     seed: Annotated[int | None, Field(description="Random seed for the orchestrator.")] = 42
-
-    lora_name: Annotated[
-        str | None,
-        Field(
-            description="Name of the LoRA to use for the orchestrator. If None, will not use any LoRA.",
-        ),
-    ] = None
 
     heartbeat: Annotated[
         HeartbeatConfig | None, Field(description="The heartbeat config for monitoring training progress.")

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -179,14 +179,14 @@ async def orchestrate(config: OrchestratorConfig):
         max_async_level=config.max_async_level,
         max_off_policy_steps=config.max_off_policy_steps,
         strict_async_level=config.strict_async_level,
-        lora_name=config.lora_name,
+        lora_name=config.model.lora.name if config.model.lora else None,
     )
 
-    if checkpoint_step is not None and config.lora_name is not None:
-        scheduler.model_name = config.lora_name
+    if checkpoint_step is not None and config.model.lora is not None:
+        scheduler.model_name = config.model.lora.name
         for workers in scheduler.workers.values():
             for worker in workers:
-                worker.model_name = config.lora_name
+                worker.model_name = config.model.lora.name
 
     await scheduler.start()
 
@@ -223,11 +223,11 @@ async def orchestrate(config: OrchestratorConfig):
         await update_weights(
             admin_clients,
             get_step_path(get_broadcast_dir(config.output_dir), scheduler.ckpt_step),
-            lora_name=config.lora_name,
+            lora_name=config.model.lora.name if config.model.lora else None,
         )
     else:
         logger.info("Training from scratch. Resetting weights to base model")
-        if config.lora_name is None:
+        if config.model.lora is None:
             await reload_weights(admin_clients)
 
     # Iterate over dataset in batches

--- a/src/prime_rl/trainer/models/layers/lora/__init__.py
+++ b/src/prime_rl/trainer/models/layers/lora/__init__.py
@@ -1,4 +1,10 @@
-from prime_rl.trainer.models.layers.lora.base import MultiLoRAModule, set_multilora_offsets
+from prime_rl.trainer.models.layers.lora.base import (
+    MultiLoRAModule,
+    get_lora_num_tokens,
+    get_multilora_scaling,
+    set_lora_num_tokens,
+    set_multilora_scaling,
+)
 from prime_rl.trainer.models.layers.lora.multi_linear import MultiLoRALinear
 from prime_rl.trainer.models.layers.lora.multi_moe import MultiLoRAGroupedExperts
 
@@ -6,5 +12,8 @@ __all__ = [
     "MultiLoRAModule",
     "MultiLoRALinear",
     "MultiLoRAGroupedExperts",
-    "set_multilora_offsets",
+    "set_lora_num_tokens",
+    "get_lora_num_tokens",
+    "set_multilora_scaling",
+    "get_multilora_scaling",
 ]

--- a/src/prime_rl/trainer/models/layers/lora/base.py
+++ b/src/prime_rl/trainer/models/layers/lora/base.py
@@ -23,7 +23,7 @@ def set_lora_num_tokens(num_tokens: torch.Tensor, reset_reference: bool = False)
     """
     global LORA_NUM_TOKENS
     if LORA_NUM_TOKENS is None or reset_reference:
-        if SCALING_FACTORS is not None:
+        if SCALING_FACTORS is not None and num_tokens is not None:
             assert num_tokens.shape == SCALING_FACTORS.shape, (
                 f"lora_num_tokens shape {num_tokens.shape} != scaling_factors shape {SCALING_FACTORS.shape}"
             )
@@ -51,7 +51,7 @@ def set_multilora_scaling(scaling_factors: torch.Tensor, reset_reference: bool =
     """
     global SCALING_FACTORS
     if SCALING_FACTORS is None or reset_reference:
-        if LORA_NUM_TOKENS is not None:
+        if LORA_NUM_TOKENS is not None and scaling_factors is not None:
             assert scaling_factors.shape == LORA_NUM_TOKENS.shape, (
                 f"scaling_factors shape {scaling_factors.shape} != lora_num_tokens shape {LORA_NUM_TOKENS.shape}"
             )

--- a/src/prime_rl/trainer/models/layers/lora/base.py
+++ b/src/prime_rl/trainer/models/layers/lora/base.py
@@ -9,14 +9,65 @@ if TYPE_CHECKING:
 
 _LORA_PREFIX = "base_layer."
 
+# Global state for multilora - initialized once in train.py, referenced by modules
+LORA_NUM_TOKENS: torch.Tensor | None = None  # [n_adapters] token counts per adapter
+SCALING_FACTORS: torch.Tensor | None = None  # [max_runs] scaling factors per run
 
-def set_multilora_offsets(offsets: torch.Tensor, reset_reference: bool = False) -> None:
-    """Set offsets for all LoRA modules."""
-    from prime_rl.trainer.models.layers.lora.multi_linear import set_multilora_offsets as set_multilora_offsets_linear
-    from prime_rl.trainer.models.layers.lora.multi_moe import set_multilora_offsets as set_multilora_offsets_moe
 
-    set_multilora_offsets_linear(offsets, reset_reference)
-    set_multilora_offsets_moe(offsets, reset_reference)
+def set_lora_num_tokens(num_tokens: torch.Tensor, reset_reference: bool = False) -> None:
+    """Set the number of tokens per adapter.
+
+    Args:
+        num_tokens: Tensor of shape [n_adapters] with token counts per adapter.
+        reset_reference: If True, replace the tensor reference. If False, copy values in-place.
+    """
+    global LORA_NUM_TOKENS
+    if LORA_NUM_TOKENS is None or reset_reference:
+        if SCALING_FACTORS is not None:
+            assert num_tokens.shape == SCALING_FACTORS.shape, (
+                f"lora_num_tokens shape {num_tokens.shape} != scaling_factors shape {SCALING_FACTORS.shape}"
+            )
+        LORA_NUM_TOKENS = num_tokens
+    else:
+        LORA_NUM_TOKENS.copy_(num_tokens)
+
+
+def get_lora_num_tokens() -> torch.Tensor:
+    """Get the current lora_num_tokens tensor.
+
+    Raises:
+        AssertionError: If called before set_lora_num_tokens() has been called.
+    """
+    assert LORA_NUM_TOKENS is not None, "LORA_NUM_TOKENS not initialized. Call set_lora_num_tokens() first."
+    return LORA_NUM_TOKENS
+
+
+def set_multilora_scaling(scaling_factors: torch.Tensor, reset_reference: bool = False) -> None:
+    """Set per-run scaling factors (alpha / rank).
+
+    Args:
+        scaling_factors: Tensor of shape [max_runs] with scaling factors per run.
+        reset_reference: If True, replace the tensor reference. If False, copy values in-place.
+    """
+    global SCALING_FACTORS
+    if SCALING_FACTORS is None or reset_reference:
+        if LORA_NUM_TOKENS is not None:
+            assert scaling_factors.shape == LORA_NUM_TOKENS.shape, (
+                f"scaling_factors shape {scaling_factors.shape} != lora_num_tokens shape {LORA_NUM_TOKENS.shape}"
+            )
+        SCALING_FACTORS = scaling_factors
+    else:
+        SCALING_FACTORS.copy_(scaling_factors)
+
+
+def get_multilora_scaling() -> torch.Tensor:
+    """Get the current scaling factors tensor.
+
+    Raises:
+        AssertionError: If called before set_multilora_scaling() has been called.
+    """
+    assert SCALING_FACTORS is not None, "SCALING_FACTORS not initialized. Call set_multilora_scaling() first."
+    return SCALING_FACTORS
 
 
 class MultiLoRAModule(nn.Module):

--- a/src/prime_rl/trainer/runs.py
+++ b/src/prime_rl/trainer/runs.py
@@ -26,7 +26,7 @@ class Progress:
 class Runs:
     """This class stores information about the runs in the system."""
 
-    def __init__(self, output_dir: Path, max_runs: int, device: torch.device):
+    def __init__(self, output_dir: Path, max_runs: int, device: torch.device = torch.device("cpu")):
         self.output_dir = output_dir
         self.max_runs = max_runs
         self.logger = get_logger()
@@ -59,6 +59,11 @@ class Runs:
             set_lora_num_tokens,
             set_multilora_scaling,
         )
+
+        # We first set to None so we dont check the shape
+        # Might be better to not have the check at all but this will do for now
+        set_lora_num_tokens(None, reset_reference=True)
+        set_multilora_scaling(None, reset_reference=True)
 
         set_lora_num_tokens(torch.zeros(max_runs, dtype=torch.int32, device=device), reset_reference=True)
         self.lora_num_tokens = get_lora_num_tokens()

--- a/src/prime_rl/trainer/runs.py
+++ b/src/prime_rl/trainer/runs.py
@@ -64,7 +64,7 @@ class Runs:
         self.lora_num_tokens = get_lora_num_tokens()
 
         set_multilora_scaling(
-            torch.ones(max_runs, dtype=torch.float32, device=device) * 1000_000.0, reset_reference=True
+            torch.ones(max_runs, dtype=torch.bfloat16, device=device) * 1000_000.0, reset_reference=True
         )
         self.scaling_factors = get_multilora_scaling()
 

--- a/src/prime_rl/trainer/scheduler.py
+++ b/src/prime_rl/trainer/scheduler.py
@@ -123,11 +123,9 @@ class MultiLoRAScheduler:
         self,
         scheduler_config: SchedulerConfigType,
         max_steps: int | None,
-        lr: float,
     ):
         self.scheduler_config = scheduler_config
         self.max_steps = max_steps
-        self.lr = lr
         self.runs = get_runs()
         self.logger = get_logger()
 
@@ -138,11 +136,12 @@ class MultiLoRAScheduler:
 
         This should be called after an optimizer is created for a run.
         """
+        lr = self.runs.config[idx].optim.lr
         self.schedulers[idx] = setup_scheduler(
             optimizer,
             self.scheduler_config,
             self.max_steps,
-            self.lr,
+            lr,
         )
 
     def step(self) -> None:
@@ -171,10 +170,9 @@ def setup_multi_scheduler(
     optimizer: "MultiLoRAOptimizer",
     scheduler_config: SchedulerConfigType,
     max_steps: int | None,
-    lr: float,
 ) -> MultiLoRAScheduler:
     """Create a MultiLoRAScheduler for managing per-run schedulers."""
-    scheduler = MultiLoRAScheduler(scheduler_config, max_steps, lr)
+    scheduler = MultiLoRAScheduler(scheduler_config, max_steps)
     # Register callback so schedulers are created when optimizers are created
     optimizer.register_post_creation_callback(scheduler.scheduler_creation_hook)
     return scheduler

--- a/tests/integration/test_rl_multi_run_lora.py
+++ b/tests/integration/test_rl_multi_run_lora.py
@@ -129,7 +129,7 @@ def multi_run_result(
                     "configs/ci/integration/rl_multi_run/orchestrator.toml",
                     "--output-dir",
                     run_dir.as_posix(),
-                    "--lora.name",
+                    "--model.lora.name",
                     name,
                     "--wandb.project",
                     wandb_project,

--- a/tests/integration/test_rl_multi_run_lora.py
+++ b/tests/integration/test_rl_multi_run_lora.py
@@ -129,7 +129,7 @@ def multi_run_result(
                     "configs/ci/integration/rl_multi_run/orchestrator.toml",
                     "--output-dir",
                     run_dir.as_posix(),
-                    "--lora-name",
+                    "--lora.name",
                     name,
                     "--wandb.project",
                     wandb_project,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enables per-run configuration and correct scaling for multi-run LoRA training, and standardizes LoRA naming.
> 
> - Add per-run `optim.lr` and `model.lora` (with `name`, optional `rank`, `alpha`) to orchestrator config; trainer auto-fills/validates and auto-names when missing
> - Refactor usages from `lora_name` to `model.lora.name` (configs, CLI, orchestrator code, tests)
> - Introduce global `lora_num_tokens` and per-run `scaling_factors` tensors; update MultiLoRA layers (`multi_linear`, `multi_moe`) to consume them and apply per-token/per-adapter scaling
> - Extend `Runs` to own these tensors on-device, validate new run configs, compute/sync scaling factors, and expose per-run named params/state dicts
> - Update trainer loop to set `lora_num_tokens` (incl. CP adjustments), initialize `Runs` with device, and register LoRA rank validation/scaling hooks
> - Make optimizer/scheduler per-run aware: create optimizers/schedulers with each run’s LR; remove global LR from multi-scheduler setup
> - Minor config tweaks (add `inference.gpu_memory_utilization`, wiki/CI TOMLs)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5486e029dc2ed1728d40d7fdbf403a11f11457e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->