### PR TITLE
Fix out-of-sync W&B step

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -509,11 +509,13 @@ async def orchestrate(config: OrchestratorConfig):
                 to_log.update({f"val_batch/{env}": ratio for env, ratio in per_env_ratio.items()})
 
         # Log metrics to monitor(s)
-        monitor.log(to_log)
+        monitor.log(to_log, step=progress.step)
 
         # Log samples to monitor(s) if enabled
         subset_train_rollouts = random.sample(train_rollouts, min(8, len(train_rollouts)))
-        monitor.log_samples(subset_train_rollouts, step=progress.step)
+        monitor.log_samples(
+            subset_train_rollouts, step=progress.step, commit=True
+        )  # this is the last place we log to w&b from orch, so commit
 
         # Log distributions (rewards, advantages) if enabled
         monitor.log_distributions(

--- a/src/prime_rl/utils/monitor/base.py
+++ b/src/prime_rl/utils/monitor/base.py
@@ -6,17 +6,17 @@ import verifiers as vf
 
 class Monitor(ABC):
     """Base class for all monitoring implementations.
-    
+
     Subclasses should initialize a `history` attribute as a list of dictionaries
     to store logged metrics.
     """
 
     @abstractmethod
-    def log(self, metrics: dict[str, Any], step: int | None = None) -> None:
+    def log(self, metrics: dict[str, Any], step: int | None = None, commit: bool | None = None) -> None:
         pass
 
     @abstractmethod
-    def log_samples(self, rollouts: list[vf.State], step: int) -> None:
+    def log_samples(self, rollouts: list[vf.State], step: int, commit: bool | None = None) -> None:
         pass
 
     @abstractmethod
@@ -42,10 +42,10 @@ class NoOpMonitor(Monitor):
     def __init__(self):
         self.history: list[dict[str, Any]] = []
 
-    def log(self, metrics: dict[str, Any], step: int | None = None) -> None:
+    def log(self, metrics: dict[str, Any], step: int | None = None, commit: bool | None = None) -> None:
         self.history.append(metrics)
 
-    def log_samples(self, rollouts: list[vf.State], step: int) -> None:
+    def log_samples(self, rollouts: list[vf.State], step: int, commit: bool | None = None) -> None:
         pass
 
     def log_final_samples(self) -> None:
@@ -56,4 +56,3 @@ class NoOpMonitor(Monitor):
 
     def log_distributions(self, distributions: dict[str, list[float]], step: int) -> None:
         pass
-

--- a/src/prime_rl/utils/monitor/multi.py
+++ b/src/prime_rl/utils/monitor/multi.py
@@ -19,17 +19,17 @@ class MultiMonitor(Monitor):
             return []
         return self.monitors[0].history
 
-    def log(self, metrics: dict[str, Any], step: int | None = None) -> None:
+    def log(self, metrics: dict[str, Any], step: int | None = None, commit: bool | None = None) -> None:
         for monitor in self.monitors:
             try:
-                monitor.log(metrics, step=step)
+                monitor.log(metrics, step=step, commit=commit)
             except Exception as e:
                 self.logger.warning(f"Failed to log metrics to {monitor.__class__.__name__}: {e}")
 
-    def log_samples(self, rollouts: list[vf.State], step: int) -> None:
+    def log_samples(self, rollouts: list[vf.State], step: int, commit: bool | None = None) -> None:
         for monitor in self.monitors:
             try:
-                monitor.log_samples(rollouts=rollouts, step=step)
+                monitor.log_samples(rollouts=rollouts, step=step, commit=commit)
             except Exception as e:
                 self.logger.warning(f"Failed to log samples to {monitor.__class__.__name__}: {e}")
 

--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -75,7 +75,7 @@ class PrimeMonitor(Monitor):
             if config.log_extras.distributions:
                 self.last_log_distributions_step = -1
 
-    def log(self, metrics: dict[str, Any], step: int | None = None) -> None:
+    def log(self, metrics: dict[str, Any], step: int | None = None, commit: bool | None = None) -> None:
         self.history.append(metrics)
         if not self.is_master:
             return
@@ -89,7 +89,7 @@ class PrimeMonitor(Monitor):
             },
         )
 
-    def log_samples(self, rollouts: list[vf.State], step: int) -> None:
+    def log_samples(self, rollouts: list[vf.State], step: int, commit: bool | None = None) -> None:
         """Logs rollouts to Prime Intellect API."""
         if not self.is_master:
             return

--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -71,15 +71,15 @@ class WandbMonitor(Monitor):
             self.logger.debug(f"Found WANDB_ARGS in environment variables {wandb_args}")
             sys.argv = json.loads(wandb_args)
 
-    def log(self, metrics: dict[str, Any], step: int | None = None) -> None:
+    def log(self, metrics: dict[str, Any], step: int | None = None, commit: bool | None = None) -> None:
         self.history.append(metrics)
         if not self.is_master:
             return
         if not self.enabled:
             return
-        wandb.log(metrics, step=step)
+        wandb.log(metrics, step=step, commit=commit)
 
-    def log_samples(self, rollouts: list[vf.State], step: int) -> None:
+    def log_samples(self, rollouts: list[vf.State], step: int, commit: bool | None = None) -> None:
         """Logs rollouts to W&B table."""
         if not self.is_master:
             return
@@ -122,7 +122,7 @@ class WandbMonitor(Monitor):
             self.samples_table.add_data(*sample.values())
             self.samples.append(sample)
 
-        wandb.log({"samples": self.samples_table}, step=step)
+        wandb.log({"samples": self.samples_table}, step=step, commit=commit)
         self.last_log_samples_step = step
         self.logger.debug(f"Logged samples at step {step} to W&B table in {time.perf_counter() - start_time:.2f}s")
 


### PR DESCRIPTION
#1529 and #1538 made `step` an explicit method arg in the monitors (as opposed to just being popped by the W&B monitor), but didn't include the arg when logging the main orchestrator metrics. This would lead to the following out-of-sync behavior:
1. Log metrics at step t (but no step provided), so auto-increments to t+1
2. Log samples at step t (step provided) now conflicts because W&B counter is already at t+1

This PR passes the correct step, and commits on the final log call of the step. This required adding the `commit` flag to the logging calls.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures logging step alignment and proper step commits, especially for W&B.
> 
> - Orchestrator: pass `step=progress.step` to `monitor.log`; call `monitor.log_samples(..., commit=True)` as the final log per step
> - Monitor interfaces: add optional `commit` to `log` and `log_samples`; update `NoOpMonitor`, `MultiMonitor`, `WandbMonitor`, and `PrimeMonitor` to accept/forward it
> - W&B: forward `commit` to `wandb.log` for metrics and samples
> - No changes to distribution logging behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc6d3ee58da594725cdb1f8f7be9af3ea5d2388d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->