### PR TITLE
set multinear linear cumsum dtype to int32

### DIFF
--- a/src/prime_rl/trainer/models/layers/lora/multi_linear.py
+++ b/src/prime_rl/trainer/models/layers/lora/multi_linear.py
@@ -147,7 +147,7 @@ class MultiLoRALinear(MultiLoRAModule):
         ori_shape = x.shape
         new_shape = ori_shape[:-1] + (self.out_features,)
         x = x.view(-1, x.shape[-1])
-        offsets = self._lora_num_tokens.cumsum(dim=0)
+        offsets = self._lora_num_tokens.cumsum(dim=0, dtype=torch.int32)
         assert offsets[-1] == x.shape[0], f"offsets: {offsets}, x.shape: {x.shape}"
 
         base_out = self.base_layer(x)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Sets an explicit dtype for LoRA token offsets to standardize grouped/loop matmul behavior.
> 
> - In `MultiLoRALinear.forward`, computes `offsets = self._lora_num_tokens.cumsum(dim=0, dtype=torch.int32)` instead of default dtype
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a483a528aba5be04a667749508436f009977dab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->