### PR TITLE
Rename optim.lr to optim.learning_rate

### DIFF
--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -348,7 +348,7 @@ SchedulerConfigType: TypeAlias = ConstantSchedulerConfig | LinearSchedulerConfig
 
 
 class BaseOptimizerConfig(BaseModel):
-    lr: Annotated[float, Field(ge=0)] = 1e-6
+    learning_rate: Annotated[float, Field(ge=0, description="Learning rate for the optimizer.")] = 1e-6
     weight_decay: Annotated[float, Field(ge=0)] = 0.01
     max_norm: Annotated[float, Field(ge=0, description="Maximum gradient norm to clip.")] = 1.0
 

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -120,7 +120,7 @@ class MultiLoRAOptimizer:
         # Get named parameters for this run from the Runs system
         named_params = self.runs.get_named_parameters_for_run(idx)
 
-        lr = self.runs.config[idx].optim.lr
+        lr = self.runs.config[idx].optim.learning_rate
         self.optimizers[idx] = _create_optimizer(self.config, named_params, self.device_mesh, lr)
 
         # Call post-creation callbacks (e.g., for scheduler creation)

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -149,7 +149,7 @@ def train(config: RLTrainerConfig):
             parallel_dims.world_mesh["dp_shard_cp"],
             lora=config.model.lora is not None,
         )
-        scheduler = setup_scheduler(optimizer, config.scheduler, config.max_steps, config.optim.lr)
+        scheduler = setup_scheduler(optimizer, config.scheduler, config.max_steps, config.optim.learning_rate)
     else:
         optimizer = setup_multi_optimizer(config.optim, parallel_dims.world_mesh["dp_shard_cp"])
         scheduler = setup_multi_scheduler(optimizer, config.scheduler, config.max_steps)

--- a/src/prime_rl/trainer/scheduler.py
+++ b/src/prime_rl/trainer/scheduler.py
@@ -136,7 +136,7 @@ class MultiLoRAScheduler:
 
         This should be called after an optimizer is created for a run.
         """
-        lr = self.runs.config[idx].optim.lr
+        lr = self.runs.config[idx].optim.learning_rate
         self.schedulers[idx] = setup_scheduler(
             optimizer,
             self.scheduler_config,

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -125,7 +125,7 @@ def train(config: SFTTrainerConfig):
         else config.max_steps
     )
     logger.info(f"Setting up {config.scheduler.type} scheduler with {scheduler_steps} steps ({config.scheduler})")
-    scheduler = setup_scheduler(optimizer, config.scheduler, scheduler_steps, config.optim.lr)
+    scheduler = setup_scheduler(optimizer, config.scheduler, scheduler_steps, config.optim.learning_rate)
 
     # Set up the dataset and dataloader
     logger.info(f"Initializing data ({config.data})")
@@ -148,7 +148,7 @@ def train(config: SFTTrainerConfig):
         logger.info(f"Resuming training from checkpoint step {checkpoint_step}")
         # This redundant setup is necessary because loading the optimizer's state has side effects on the scheduler state dict
         if config.ckpt.skip_scheduler:
-            scheduler = setup_scheduler(optimizer, config.scheduler, scheduler_steps, config.optim.lr)
+            scheduler = setup_scheduler(optimizer, config.scheduler, scheduler_steps, config.optim.learning_rate)
     logger.info(
         f"Starting from step {progress.step} (total_tokens={progress.total_tokens}, total_samples={progress.total_samples}, dataset_state={dataloader.state_dict()['dataset_state']})"
     )


### PR DESCRIPTION
Renames the optimizer learning rate config field from `lr` to `learning_rate` for consistency with platform API.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Config change**
> 
> - Renames `BaseOptimizerConfig` field `lr` to `learning_rate` (adds description)
> 
> **Code updates**
> 
> - Replace `config.optim.lr` with `config.optim.learning_rate` when creating schedulers in `rl/train.py`, `sft/train.py`, and in `MultiLoRAScheduler.scheduler_creation_hook`
> - Use `config.optim.learning_rate` in `MultiLoRAOptimizer.optimizer_creation_hook` during optimizer instantiation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 805be44d5c094867c82099a611abd84d86089ef9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->