### PR TITLE
add env worker logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,4 @@ Documenting changes which affect configuration usage patterns (added/moved/remov
 - **`model.fused_lm_head_chunk_size`**: RL training now auto-sets this to 2048 if not specified (except when `impl='liger_kernel'`). SFT training continues to use None (2026-01-05)
 - **`trainer.metrics_server`**: Added optional Prometheus metrics server for trainer observability. Exposes `/metrics` endpoint with step, loss, throughput, grad_norm, etc. Disabled by default (default: None) (#1547, 2026-01-06)
 - **`model.lora.alpha`**: Changed default from 16.0 to 32.0 (2026-01-10)
+- **`orchestrator.env.log`**: Added logging configuration for environment workers. Contains `enabled` (bool, default: False), `level` (str, default: "warn"), and `vf_level` (str, default: "warn") fields (#1561, 2026-01-13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,4 +31,4 @@ Documenting changes which affect configuration usage patterns (added/moved/remov
 - **`model.fused_lm_head_chunk_size`**: RL training now auto-sets this to 2048 if not specified (except when `impl='liger_kernel'`). SFT training continues to use None (2026-01-05)
 - **`trainer.metrics_server`**: Added optional Prometheus metrics server for trainer observability. Exposes `/metrics` endpoint with step, loss, throughput, grad_norm, etc. Disabled by default (default: None) (#1547, 2026-01-06)
 - **`model.lora.alpha`**: Changed default from 16.0 to 32.0 (2026-01-10)
-- **`orchestrator.env.log`**: Added logging configuration for environment workers. Contains `enabled` (bool, default: False), `level` (str, default: "warn"), and `vf_level` (str, default: "warn") fields (#1561, 2026-01-13)
+- **`orchestrator.env.log`**: Added logging configuration for environment workers. If set, enables logging with `level` (str, default: "warn") and `vf_level` (str, default: "warn") fields. If None (default), logging is disabled (#1561, 2026-01-13)

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -297,12 +297,32 @@ class RetryConfig(BaseConfig):
     ] = True
 
 
+class EnvLogConfig(BaseConfig):
+    """Configures logging for an environment worker."""
+
+    enabled: Annotated[
+        bool,
+        Field(description="Whether to enable logging for this environment's workers."),
+    ] = False
+
+    level: Annotated[
+        str,
+        Field(description="Log level for prime-rl logger in worker (debug, info, warn, error)."),
+    ] = "warn"
+
+    vf_level: Annotated[
+        str,
+        Field(description="Log level for verifiers logger in worker (debug, info, warn, error)."),
+    ] = "warn"
+
+
 class EnvConfig(BaseConfig):
     """Configures an environment for training."""
 
     id: Annotated[str, Field(description="ID of the environment to use.")] = "reverse-text"
     args: Annotated[dict, Field(description="Arguments to pass to the environment.")] = {}
     name: Annotated[str | None, Field(description="Name of the environment to use.")] = None
+    log: Annotated[EnvLogConfig, Field(description="Logging config for this env's workers.")] = EnvLogConfig()
 
 
 class EvalEnvConfig(EnvConfig):

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -300,11 +300,6 @@ class RetryConfig(BaseConfig):
 class EnvLogConfig(BaseConfig):
     """Configures logging for an environment worker."""
 
-    enabled: Annotated[
-        bool,
-        Field(description="Whether to enable logging for this environment's workers."),
-    ] = False
-
     level: Annotated[
         str,
         Field(description="Log level for prime-rl logger in worker (debug, info, warn, error)."),
@@ -322,7 +317,10 @@ class EnvConfig(BaseConfig):
     id: Annotated[str, Field(description="ID of the environment to use.")] = "reverse-text"
     args: Annotated[dict, Field(description="Arguments to pass to the environment.")] = {}
     name: Annotated[str | None, Field(description="Name of the environment to use.")] = None
-    log: Annotated[EnvLogConfig, Field(description="Logging config for this env's workers.")] = EnvLogConfig()
+    log: Annotated[
+        EnvLogConfig | None,
+        Field(description="Logging config for this env's workers. If None, logging is disabled."),
+    ] = None
 
 
 class EvalEnvConfig(EnvConfig):

--- a/src/prime_rl/orchestrator/env_worker.py
+++ b/src/prime_rl/orchestrator/env_worker.py
@@ -199,7 +199,9 @@ def worker_main(
         # Redirect verifiers to file instead of inherited stderr
         vf_logger = logging.getLogger("verifiers")
         vf_logger.handlers.clear()
-        vf_logger.addHandler(logging.FileHandler(log_file))
+        vf_handler = logging.FileHandler(log_file)
+        vf_handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)7s %(message)s", datefmt="%H:%M:%S"))
+        vf_logger.addHandler(vf_handler)
     else:
         # Set up a silent logger to avoid RuntimeError when EventLoopLagMonitor calls get_logger()
         # Using CRITICAL level + disabled critical logging (in setup_logger) = silent logger

--- a/src/prime_rl/orchestrator/env_worker.py
+++ b/src/prime_rl/orchestrator/env_worker.py
@@ -202,11 +202,6 @@ def worker_main(
         vf_handler = logging.FileHandler(log_file)
         vf_handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)7s %(message)s", datefmt="%H:%M:%S"))
         vf_logger.addHandler(vf_handler)
-    else:
-        # Set up a silent logger to avoid RuntimeError when EventLoopLagMonitor calls get_logger()
-        # Using CRITICAL level + disabled critical logging (in setup_logger) = silent logger
-        reset_logger()
-        setup_logger("CRITICAL")
 
     # Load environment
     env = vf.load_environment(env_id, **env_args)

--- a/src/prime_rl/orchestrator/env_worker.py
+++ b/src/prime_rl/orchestrator/env_worker.py
@@ -205,6 +205,7 @@ def worker_main(
     else:
         # Set up a silent logger to avoid RuntimeError when EventLoopLagMonitor calls get_logger()
         # Using CRITICAL level + disabled critical logging (in setup_logger) = silent logger
+        reset_logger()
         setup_logger("CRITICAL")
 
     # Load environment

--- a/src/prime_rl/orchestrator/env_worker.py
+++ b/src/prime_rl/orchestrator/env_worker.py
@@ -185,14 +185,13 @@ def worker_main(
     max_concurrent: int,
     example_lookup: dict[int, dict],
     sampling_args: dict,
-    log_enabled: bool,
     log_level: str,
     vf_log_level: str,
     log_file: str | None,
 ):
     """Main entry point for worker process."""
     # Reset logger inherited from parent process, then setup fresh logger for this worker
-    if log_enabled and log_file:
+    if log_file:
         reset_logger()
         setup_logger(log_level, log_file=Path(log_file))
         vf.setup_logging(level=vf_log_level.upper())
@@ -242,7 +241,6 @@ class EnvWorker:
         example_lookup: dict[int, dict],
         sampling_args: dict,
         worker_name: str | None = None,
-        log_enabled: bool = False,
         log_level: str = "warn",
         vf_log_level: str = "warn",
         log_file: str | None = None,
@@ -258,7 +256,6 @@ class EnvWorker:
         self.sampling_args = sampling_args
         self.worker_name = worker_name or env_id
 
-        self.log_enabled = log_enabled
         self.log_level = log_level
         self.vf_log_level = vf_log_level
         self.log_file = log_file
@@ -293,7 +290,6 @@ class EnvWorker:
                 self.max_concurrent,
                 self.example_lookup,
                 self.sampling_args,
-                self.log_enabled,
                 self.log_level,
                 self.vf_log_level,
                 self.log_file,

--- a/src/prime_rl/orchestrator/env_worker.py
+++ b/src/prime_rl/orchestrator/env_worker.py
@@ -192,8 +192,8 @@ def worker_main(
 ):
     """Main entry point for worker process."""
     # Reset logger inherited from parent process, then setup fresh logger for this worker
-    reset_logger()
     if log_enabled and log_file:
+        reset_logger()
         setup_logger(log_level, log_file=Path(log_file))
         vf.setup_logging(level=vf_log_level.upper())
         # Redirect verifiers to file instead of inherited stderr

--- a/src/prime_rl/orchestrator/env_worker.py
+++ b/src/prime_rl/orchestrator/env_worker.py
@@ -200,6 +200,10 @@ def worker_main(
         vf_logger = logging.getLogger("verifiers")
         vf_logger.handlers.clear()
         vf_logger.addHandler(logging.FileHandler(log_file))
+    else:
+        # Set up a silent logger to avoid RuntimeError when EventLoopLagMonitor calls get_logger()
+        # Using CRITICAL level + disabled critical logging (in setup_logger) = silent logger
+        setup_logger("CRITICAL")
 
     # Load environment
     env = vf.load_environment(env_id, **env_args)

--- a/src/prime_rl/orchestrator/env_worker.py
+++ b/src/prime_rl/orchestrator/env_worker.py
@@ -17,7 +17,7 @@ from openai import AsyncOpenAI
 
 from prime_rl.utils.client import setup_clients
 from prime_rl.utils.config import ClientConfig
-from prime_rl.utils.logger import setup_logger
+from prime_rl.utils.logger import reset_logger, setup_logger
 
 
 class WorkerDiedError(Exception):
@@ -190,6 +190,8 @@ def worker_main(
     log_file: str | None,
 ):
     """Main entry point for worker process."""
+    # Reset logger inherited from parent process, then setup fresh logger for this worker
+    reset_logger()
     if log_enabled and log_file:
         setup_logger(log_level, log_file=Path(log_file))
         vf.setup_logging(level=vf_log_level.upper())

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -180,6 +180,7 @@ async def orchestrate(config: OrchestratorConfig):
         max_off_policy_steps=config.max_off_policy_steps,
         strict_async_level=config.strict_async_level,
         lora_name=config.model.lora.name if config.model.lora else None,
+        output_dir=config.output_dir,
     )
 
     if checkpoint_step is not None and config.model.lora is not None:

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -6,6 +6,7 @@ Isolates event loop lag from environment execution.
 
 import asyncio
 import time
+from pathlib import Path
 from typing import NamedTuple
 
 from httpx import AsyncClient
@@ -18,6 +19,7 @@ from prime_rl.orchestrator.utils import get_sampling_args
 from prime_rl.utils.client import update_weights
 from prime_rl.utils.config import ClientConfig
 from prime_rl.utils.logger import get_logger
+from prime_rl.utils.pathing import get_env_worker_log_dir
 from prime_rl.utils.utils import (
     get_broadcast_dir,
     get_latest_ckpt_step,
@@ -57,6 +59,7 @@ class Scheduler:
         max_off_policy_steps: int,
         strict_async_level: bool,
         lora_name: str | None = None,
+        output_dir: Path | None = None,
     ):
         self.logger = get_logger()
         self.admin_clients = admin_clients
@@ -88,6 +91,14 @@ class Scheduler:
             env_name = env_config.name or env_config.id
             self.env_names.append(env_name)
             self.workers[env_name] = []
+
+            # Setup log directory if logging is enabled for this env
+            env_log = env_config.log
+            env_log_dir = None
+            if env_log.enabled and output_dir is not None:
+                env_log_dir = get_env_worker_log_dir(output_dir, env_name)
+                env_log_dir.mkdir(parents=True, exist_ok=True)
+
             for worker_idx in range(self.workers_per_env):
                 worker = EnvWorker(
                     env_id=env_config.id,
@@ -100,6 +111,10 @@ class Scheduler:
                     example_lookup=self.example_lookups[env_name],
                     sampling_args=self.sampling_args,
                     worker_name=f"{env_name}_{worker_idx}",
+                    log_enabled=env_log.enabled,
+                    log_level=env_log.level,
+                    vf_log_level=env_log.vf_level,
+                    log_file=str(env_log_dir / f"worker_{worker_idx}.log") if env_log_dir else None,
                 )
                 self.workers[env_name].append(worker)
 

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -95,7 +95,7 @@ class Scheduler:
             # Setup log directory if logging is enabled for this env
             env_log = env_config.log
             env_log_dir = None
-            if env_log.enabled and output_dir is not None:
+            if env_log is not None and output_dir is not None:
                 env_log_dir = get_env_worker_log_dir(output_dir, env_name)
                 env_log_dir.mkdir(parents=True, exist_ok=True)
 
@@ -111,9 +111,8 @@ class Scheduler:
                     example_lookup=self.example_lookups[env_name],
                     sampling_args=self.sampling_args,
                     worker_name=f"{env_name}_{worker_idx}",
-                    log_enabled=env_log.enabled,
-                    log_level=env_log.level,
-                    vf_log_level=env_log.vf_level,
+                    log_level=env_log.level if env_log else "warn",
+                    vf_log_level=env_log.vf_level if env_log else "warn",
                     log_file=str(env_log_dir / f"worker_{worker_idx}.log") if env_log_dir else None,
                 )
                 self.workers[env_name].append(worker)

--- a/src/prime_rl/utils/pathing.py
+++ b/src/prime_rl/utils/pathing.py
@@ -29,6 +29,10 @@ def get_broadcast_dir(output_dir: Path) -> Path:
     return output_dir / "broadcasts"
 
 
+def get_env_worker_log_dir(output_dir: Path, env_name: str) -> Path:
+    return output_dir / "logs" / "env_workers" / env_name
+
+
 def get_step_path(path: Path, step: int) -> Path:
     return path / f"step_{step}"
 


### PR DESCRIPTION
enable in `orch.toml` like this

writes to `run_0/env_workers/ENV_NAME/worker_X.log`

```
[env.log]
level = "debug"
vf_level = "debug"
```

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces optional, per-environment worker logging and routes both `prime-rl` and `verifiers` logs to per-worker files.
> 
> - **Config**: New `EnvLogConfig` and `orchestrator.env.log` field with `level` and `vf_level`; if unset, logging stays disabled
> - **Scheduler/Orchestrator**: `Scheduler` now receives `output_dir`; creates `get_env_worker_log_dir(output_dir, env_name)` and passes `log_level`, `vf_log_level`, `log_file` to `EnvWorker`
> - **EnvWorker**: Worker process resets and sets up logger; redirects `verifiers` to the same log file; accepts new logging args
> - **Utils**: Added `get_env_worker_log_dir` in `utils/pathing.py`
> - **Docs**: Updated `CHANGELOG.md` with `orchestrator.env.log` entry
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 347d19c926b340b3fe5efaad6cb6887ee0a37c3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->