### PR TITLE
Add learning rate command line alias

### DIFF
--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -610,6 +610,15 @@ class OrchestratorConfig(BaseSettings):
     # The optimizer configuration (per-run LR for multi-run training)
     optim: OptimizerConfig = OptimizerConfig()
 
+    # Convenience alias for optim.lr
+    learning_rate: Annotated[
+        float | None,
+        Field(
+            ge=0,
+            description="Top-level alias for optim.lr. If set, overrides optim.lr.",
+        ),
+    ] = None
+
     # The teacher model configuration (optional)
     teacher_model: Annotated[
         TeacherModelConfig | None,
@@ -798,4 +807,11 @@ class OrchestratorConfig(BaseSettings):
             if self.prime_monitor:
                 self.prime_monitor.log_extras = None
 
+        return self
+
+    @model_validator(mode="after")
+    def apply_learning_rate_alias(self):
+        """Apply the top-level learning_rate alias to optim.lr if set."""
+        if self.learning_rate is not None:
+            self.optim.lr = self.learning_rate
         return self

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -44,3 +44,29 @@ def test_load_configs(config_file: Path, monkeypatch: pytest.MonkeyPatch):
         except ValidationError:
             could_parse.append(False)
     assert any(could_parse), f"No config class could be parsed from {config_file}"
+
+
+def test_orchestrator_learning_rate_alias():
+    """Tests that the learning_rate alias correctly sets optim.lr."""
+    # Test that learning_rate sets optim.lr
+    config = OrchestratorConfig(learning_rate=0.001)
+    assert config.learning_rate == 0.001
+    assert config.optim.lr == 0.001
+
+    # Test that optim.lr default works when learning_rate is not set
+    config_default = OrchestratorConfig()
+    assert config_default.learning_rate is None
+    assert config_default.optim.lr == 1e-4  # default value
+
+
+def test_orchestrator_learning_rate_cli(monkeypatch: pytest.MonkeyPatch):
+    """Tests that --learning-rate CLI argument sets optim.lr."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["dummy.py", "--learning-rate", "0.002"],
+        raising=False,
+    )
+    config = parse_argv(OrchestratorConfig)
+    assert config.learning_rate == 0.002
+    assert config.optim.lr == 0.002


### PR DESCRIPTION
Add a top-level `learning_rate` field to OrchestratorConfig that serves as a convenience alias for `optim.lr`. When set, it overrides the nested optim.lr value via a model validator.

@JannikSt I saw u close a PR that was doing something like this?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a top-level learning rate alias and tests for config/CLI parsing.
> 
> - Introduces `learning_rate` in `OrchestratorConfig` as a convenience alias for `optim.lr`; applied via a `model_validator` to override `optim.lr` when set
> - Adds unit tests verifying alias behavior and `--learning-rate` CLI parsing; confirms default `optim.lr` remains `1e-4` when unset
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9304d6f6b60e847566512bc8df4f8c8ab66dbd74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->