### PR TITLE
[fix] orchestrator shouldnt have null batch

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -370,9 +370,7 @@ async def orchestrate(config: OrchestratorConfig):
             temperature=config.sampling.temperature,
             step=progress.step,
         )
-        assert len(training_batch.examples) == config.batch_size, (
-            f"Batch size mismatch: {len(training_batch.examples)} != {config.batch_size}"
-        )
+        assert len(training_batch.examples) != 0, "Step with no samples is not allowed"
         training_batch_sender.send(training_batch)
 
         # Await and process val results

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -370,6 +370,9 @@ async def orchestrate(config: OrchestratorConfig):
             temperature=config.sampling.temperature,
             step=progress.step,
         )
+        assert len(training_batch.examples) == config.batch_size, (
+            f"Batch size mismatch: {len(training_batch.examples)} != {config.batch_size}"
+        )
         training_batch_sender.send(training_batch)
 
         # Await and process val results


### PR DESCRIPTION
I believe errored samples count as completed samples and thus an environment that does nothing but error will create an empty batch. This currently crashes the RFT trainer. This change should make it that the orchestrator will error instead (which is the correct behavior). They will then be evicted from the cluster.

You can repro with this env:
```bash
uv run orchestrator --rollouts-per-example 4 \
    --seq-len 512 \
    --max-steps 100 \
    --batch-size 128 \
    --model.name PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT \
    --output-dir outputs/run_woof \
    --model.lora.name 'rft-pn5ooeqh' \
    --env '[{"id": "kyleskutt/code-repair-env", "name": null, "args": {}}]' \
    --sampling.max-tokens 512 \
    --trajectory-strategy interleaved
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the orchestrator does not emit empty training batches.
> 
> - Adds `assert len(training_batch.examples) != 0` in `orchestrator.py` before sending `TrainingBatch` to enforce non-empty batches
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b820802bad7dcf98e5776162b8628d825dc37c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->