### PR TITLE
[feat] support per-run lora_rank with zero-padded initialization

### DIFF
--- a/src/prime_rl/trainer/models/layers/lora/base.py
+++ b/src/prime_rl/trainer/models/layers/lora/base.py
@@ -91,12 +91,16 @@ class MultiLoRAModule(nn.Module):
         self.register_load_state_dict_pre_hook(self._pre_load_state_dict_hook)
 
     @abstractmethod
-    def reset_parameters(self, index: int | None = None) -> None:
+    def reset_parameters(self, index: int | None = None, lora_rank: int | None = None) -> None:
         """Reset LoRA parameters.
 
         Args:
             index: If provided, reset only the parameters for that adapter index.
                    If None, reset all adapter parameters.
+            lora_rank: If provided, only initialize the first lora_rank dimensions
+                       of lora_A matrices (zero-padding the rest). This enables
+                       lower-rank computation while maintaining tensor shape for batching.
+                       If None, uses the full rank.
         """
         ...
 

--- a/src/prime_rl/trainer/runs.py
+++ b/src/prime_rl/trainer/runs.py
@@ -337,12 +337,24 @@ class Runs:
         """Reset parameters for a specific run index.
 
         Called when a new run is created to initialize fresh adapter weights.
+        If the run's config specifies a lora_rank, uses that for initialization
+        (zero-padding higher dimensions). Otherwise uses the full module rank.
 
         Args:
             idx: The run index to reset parameters for
         """
+        # Get lora_rank from run config if available
+        lora_rank = None
+        if idx in self.config:
+            config = self.config[idx]
+            if config.model.lora is not None and config.model.lora.rank is not None:
+                lora_rank = config.model.lora.rank
+
+        if lora_rank is not None:
+            self.logger.info(f"Run {self.idx_2_id.get(idx, idx)}: Initializing LoRA with rank {lora_rank}")
+
         for _, module in self._modules:
-            module.reset_parameters(idx)
+            module.reset_parameters(idx, lora_rank=lora_rank)
 
     def __repr__(self):
         return f"Runs(max={self.max_runs})[{self.idx_2_id.keys()}]"


### PR DESCRIPTION
Add lora_rank parameter to reset_parameters() in LoRA modules. When a run specifies a lower rank than the trainer's max rank, only the first lora_rank dimensions of lora_A matrices are initialized with Kaiming uniform, while the rest are zero-padded.

This enables true lower-rank computation while maintaining consistent tensor shapes for batching multiple adapters together. The gradient flow naturally preserves the zero structure since gradients through zero elements remain zero.

Changes:
- Update abstract reset_parameters signature in base.py to accept optional lora_rank parameter
- Modify MultiLoRALinear.reset_parameters to zero-pad lora_A when lora_rank < self.rank
- Modify MultiLoRAGroupedExperts.reset_parameters similarly for all w1/w2/w3 lora_A matrices
- Update Runs.reset_run_parameters to pass lora_rank from run config to module reset_parameters
- Add logging when initializing LoRA with a specific rank

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables per-run LoRA rank selection while keeping tensor shapes stable for batching.
> 
> - Extend `reset_parameters` in `lora/base.py` to accept optional `lora_rank`
> - Implement zero-padded init for `lora_A` (only first `lora_rank` rows Kaiming-init) and zero `lora_B` in `multi_linear.py` and `multi_moe.py`; validate `lora_rank <= rank`
> - Update `Runs.reset_run_parameters` to read `config.model.lora.rank`, log, and pass `lora_rank` to registered modules
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac2369b5bc288ab4d352fad06e8329d3502282f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->