### PR TITLE
change LoRA alpha default to 32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,4 @@ Documenting changes which affect configuration usage patterns (added/moved/remov
 - **`model.fused_lm_head_chunk_size`**: Added chunk size configuration for fused LM head to enable memory-efficient chunked logprob computation. When set, splits vocabulary into chunks to avoid materializing full [N, V] logit tensor (default: None) (#1525, 2026-01-03)
 - **`model.fused_lm_head_chunk_size`**: RL training now auto-sets this to 2048 if not specified (except when `impl='liger_kernel'`). SFT training continues to use None (2026-01-05)
 - **`trainer.metrics_server`**: Added optional Prometheus metrics server for trainer observability. Exposes `/metrics` endpoint with step, loss, throughput, grad_norm, etc. Disabled by default (default: None) (#1547, 2026-01-06)
+- **`model.lora.alpha`**: Changed default from 16.0 to 32.0 (2026-01-10)

--- a/configs/ci/integration/rl_lora/resume.toml
+++ b/configs/ci/integration/rl_lora/resume.toml
@@ -11,7 +11,7 @@ resume_step = 20
 name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
 
 [trainer.optim]
-lr = 1e-4
+lr = 5e-5
 
 [trainer.model.lora]
 rank = 8

--- a/configs/ci/integration/rl_lora/start.toml
+++ b/configs/ci/integration/rl_lora/start.toml
@@ -10,7 +10,7 @@ seq_len = 2048
 name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
 
 [trainer.optim]
-lr = 1e-4
+lr = 5e-5
 
 [trainer.model.lora]
 rank = 8

--- a/configs/ci/integration/rl_multi_run/orchestrator.toml
+++ b/configs/ci/integration/rl_multi_run/orchestrator.toml
@@ -8,6 +8,9 @@ max_steps = 20
 [model]
 name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
 
+[optim]
+lr = 2e-5
+
 [sampling]
 max_tokens = 128
 

--- a/configs/ci/integration/rl_multi_run/trainer.toml
+++ b/configs/ci/integration/rl_multi_run/trainer.toml
@@ -9,9 +9,6 @@ name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
 [model.lora]
 rank = 8
 
-[optim]
-lr = 1e-5
-
 [weight_broadcast]
 adapter_only = true
 

--- a/configs/ci/integration/rl_multi_run/trainer.toml
+++ b/configs/ci/integration/rl_multi_run/trainer.toml
@@ -10,7 +10,7 @@ name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
 rank = 8
 
 [optim]
-lr = 1e-4
+lr = 5e-5
 
 [weight_broadcast]
 adapter_only = true

--- a/configs/ci/integration/rl_multi_run/trainer.toml
+++ b/configs/ci/integration/rl_multi_run/trainer.toml
@@ -10,7 +10,7 @@ name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
 rank = 8
 
 [optim]
-lr = 5e-5
+lr = 1e-5
 
 [weight_broadcast]
 adapter_only = true

--- a/configs/wiki_search/rl.toml
+++ b/configs/wiki_search/rl.toml
@@ -17,7 +17,6 @@ weight_decay = 0.0
 
 [trainer.model.lora]
 rank = 8
-alpha = 32
 dropout = 0.0
 target_modules = [
     "q_proj",

--- a/examples/alphabet_sort/rl.toml
+++ b/examples/alphabet_sort/rl.toml
@@ -19,10 +19,9 @@ freq = 1
 
 [trainer.model.lora]
 rank = 32
-alpha = 64
 
 [trainer.optim]
-lr = 1e-5
+lr = 2e-5
 
 [orchestrator]
 batch_size = 512

--- a/examples/alphabet_sort/rl.toml
+++ b/examples/alphabet_sort/rl.toml
@@ -21,7 +21,7 @@ freq = 1
 rank = 32
 
 [trainer.optim]
-lr = 5e-6
+lr = 2e-5
 
 [orchestrator]
 batch_size = 512

--- a/examples/alphabet_sort/rl.toml
+++ b/examples/alphabet_sort/rl.toml
@@ -21,7 +21,7 @@ freq = 1
 rank = 32
 
 [trainer.optim]
-lr = 2e-5
+lr = 5e-6
 
 [orchestrator]
 batch_size = 512

--- a/examples/alphabet_sort/rl.toml
+++ b/examples/alphabet_sort/rl.toml
@@ -19,9 +19,10 @@ freq = 1
 
 [trainer.model.lora]
 rank = 32
+alpha = 64
 
 [trainer.optim]
-lr = 2e-5
+lr = 1e-5
 
 [orchestrator]
 batch_size = 512

--- a/examples/wiki_search/rl.toml
+++ b/examples/wiki_search/rl.toml
@@ -17,7 +17,6 @@ weight_decay = 0.0
 
 [trainer.model.lora]
 rank = 8
-alpha = 32
 dropout = 0.0
 target_modules = [
     "q_proj",

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -53,7 +53,7 @@ class LoRAConfig(BaseConfig):
             ge=0,
             description="LoRA alpha for this run.",
         ),
-    ] = 16.0
+    ] = 32.0
 
 
 class ModelConfig(BaseModelConfig):

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -80,7 +80,7 @@ class LoRAConfig(BaseConfig):
             ge=0,
             description="LoRA scaling parameter.",
         ),
-    ] = 16.0
+    ] = 32.0
 
     dropout: Annotated[
         float,

--- a/tests/integration/test_rl_multi_run_lora.py
+++ b/tests/integration/test_rl_multi_run_lora.py
@@ -227,5 +227,5 @@ def test_reward_in_range(multi_run_result: tuple[dict[str, ProcessResult], str],
         log_file = output_dir / f"run_{name}" / "logs" / "orchestrator.stdout"
         with open(log_file, "r") as f:
             lines = strip_escape_codes(f.read()).splitlines()
-        check_number_in_range(lines, step=5, min_threshold=0.2, max_threshold=0.6, pattern=r"Reward:\s*(\d+\.\d{4})")
+        check_number_in_range(lines, step=9, min_threshold=0.2, max_threshold=0.6, pattern=r"Reward:\s*(\d+\.\d{4})")
         check_number_in_range(lines, min_threshold=0.65, pattern=r"Reward:\s*(\d+\.\d{4})")


### PR DESCRIPTION
Sets default lora_alpha = 32, which is used and referenced as "standard practice from other implementations" in [LoRA Without Regret](https://thinkingmachines.ai/blog/lora/), and which we'd been using in a few of the example configs already.

LR is adjusted accordlingly in the one example config with a different value.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Config defaults**
> 
> - Set default `model.lora.alpha` to `32.0` in `trainer.config.LoRAConfig` and `orchestrator.config.LoRAConfig`
> - Documented in `CHANGELOG.md`
> 
> **CI/example configs**
> 
> - Lower RL LoRA LR from `1e-4` to `5e-5` in `configs/ci/integration/rl_lora/{start,resume}.toml`
> - Add per-run optimizer block `orchestrator.toml` with `optim.lr=2e-5`; remove `[optim]` from multi-run `trainer.toml`
> - Remove explicit `alpha` from wiki-search RL configs to rely on new default
> 
> **Tests**
> 
> - Update `test_rl_multi_run_lora.py` to check final reward at `step=9` instead of `step=5`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 498f73700a47ff82970edd761c2971de32576cb4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->