### PR TITLE
Unique rollout request ids to avoid collisions

### DIFF
--- a/src/prime_rl/orchestrator/env_worker.py
+++ b/src/prime_rl/orchestrator/env_worker.py
@@ -135,7 +135,7 @@ async def worker_loop(
             task = asyncio.create_task(
                 process_request(request, env, client_cycle, semaphore, example_lookup, sampling_args)
             )
-            pending_tasks[task] = request.id
+            pending_tasks[task] = request.request_id
         return True
 
     try:

--- a/src/prime_rl/orchestrator/env_worker.py
+++ b/src/prime_rl/orchestrator/env_worker.py
@@ -6,6 +6,7 @@ Runs environment rollouts in a separate process to isolate event loop lag.
 
 import asyncio
 import queue
+import uuid
 from dataclasses import dataclass
 from itertools import cycle
 from multiprocessing import Process, Queue
@@ -21,7 +22,8 @@ from prime_rl.utils.config import ClientConfig
 class RolloutRequest:
     """Request to generate rollouts for an example."""
 
-    id: int  # example_id
+    request_id: str
+    example_id: int
     rollouts_per_example: int
     model_name: str  # Model name to use for this request (may change for LoRA)
 
@@ -30,7 +32,7 @@ class RolloutRequest:
 class RolloutResponse:
     """Response containing rollout results."""
 
-    id: str
+    request_id: str
     results: list[dict]  # Simplified state dicts
     lag_metrics: dict | None = None  # Event loop lag metrics from worker
 
@@ -82,7 +84,7 @@ async def process_request(
 ) -> RolloutResponse:
     """Process a single rollout request."""
     client = next(client_cycle)
-    example = example_lookup[request.id]
+    example = example_lookup[request.example_id]
     group_inputs = [vf.RolloutInput(**example) for _ in range(request.rollouts_per_example)]
 
     states = await env.run_group(
@@ -95,7 +97,7 @@ async def process_request(
     )
 
     results = [extract_result(state) for state in states]
-    return RolloutResponse(id=str(request.id), results=results)
+    return RolloutResponse(request_id=request.request_id, results=results)
 
 
 async def worker_loop(
@@ -269,20 +271,22 @@ class EnvWorker:
         self,
         example_id: int,
         rollouts_per_example: int,
-    ) -> asyncio.Future:
-        """Submit a rollout request and return a future for the response."""
+    ) -> tuple[asyncio.Future, str]:
+        """Submit a rollout request and return a (future, request_id) tuple."""
+        request_id = uuid.uuid4().hex
         request = RolloutRequest(
-            id=example_id,
+            request_id=request_id,
+            example_id=example_id,
             rollouts_per_example=rollouts_per_example,
             model_name=self.model_name,
         )
 
         loop = asyncio.get_event_loop()
         future = loop.create_future()
-        self.pending_futures[str(example_id)] = future
+        self.pending_futures[request_id] = future
 
         self.request_queue.put(request)
-        return future
+        return future, request_id
 
     async def collect_responses(self):
         """Background task to collect responses and resolve futures."""
@@ -296,8 +300,8 @@ class EnvWorker:
                 # Store latest lag metrics from worker
                 if response.lag_metrics:
                     self.latest_lag_metrics = response.lag_metrics
-                if response.id in self.pending_futures:
-                    future = self.pending_futures.pop(response.id)
+                if response.request_id in self.pending_futures:
+                    future = self.pending_futures.pop(response.request_id)
                     # Check if future was cancelled (e.g., by update_policy)
                     if not future.done():
                         future.set_result(response.results)

--- a/src/prime_rl/orchestrator/env_worker.py
+++ b/src/prime_rl/orchestrator/env_worker.py
@@ -271,8 +271,8 @@ class EnvWorker:
         self,
         example_id: int,
         rollouts_per_example: int,
-    ) -> asyncio.Future:
-        """Submit a rollout request and return a future for the response."""
+    ) -> tuple[asyncio.Future, str]:
+        """Submit a rollout request and return a (future, request_id) tuple."""
         request_id = uuid.uuid4().hex
         request = RolloutRequest(
             request_id=request_id,
@@ -283,11 +283,10 @@ class EnvWorker:
 
         loop = asyncio.get_event_loop()
         future = loop.create_future()
-        future.request_id = request_id
         self.pending_futures[request_id] = future
 
         self.request_queue.put(request)
-        return future
+        return future, request_id
 
     async def collect_responses(self):
         """Background task to collect responses and resolve futures."""

--- a/src/prime_rl/orchestrator/env_worker.py
+++ b/src/prime_rl/orchestrator/env_worker.py
@@ -271,8 +271,8 @@ class EnvWorker:
         self,
         example_id: int,
         rollouts_per_example: int,
-    ) -> tuple[asyncio.Future, str]:
-        """Submit a rollout request and return a (future, request_id) tuple."""
+    ) -> asyncio.Future:
+        """Submit a rollout request and return a future for the response."""
         request_id = uuid.uuid4().hex
         request = RolloutRequest(
             request_id=request_id,
@@ -283,10 +283,11 @@ class EnvWorker:
 
         loop = asyncio.get_event_loop()
         future = loop.create_future()
+        future.request_id = request_id
         self.pending_futures[request_id] = future
 
         self.request_queue.put(request)
-        return future, request_id
+        return future
 
     async def collect_responses(self):
         """Background task to collect responses and resolve futures."""

--- a/src/prime_rl/orchestrator/env_worker.py
+++ b/src/prime_rl/orchestrator/env_worker.py
@@ -121,7 +121,7 @@ async def worker_loop(
     lag_monitor_task = asyncio.create_task(lag_monitor.run())
 
     # Track in-flight tasks
-    pending_tasks: dict[asyncio.Task, int] = {}
+    pending_tasks: dict[asyncio.Task, str] = {}
 
     def check_for_requests():
         """Non-blocking check for new requests."""

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -143,13 +143,10 @@ class Scheduler:
         workers = self.workers[task]
         worker = min(workers, key=lambda w: w.pending_count)
 
-        future = await worker.submit_request(
+        future, request_id = await worker.submit_request(
             example_id=example["example_id"],
             rollouts_per_example=self.config.rollouts_per_example,
         )
-
-        # Extract request_id from the future's pending tracking
-        request_id = [k for k, v in worker.pending_futures.items() if v is future][0]
 
         self.inflight_group_rollouts[future] = InflightRolloutInfo(
             off_policy_steps=0,

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -143,7 +143,7 @@ class Scheduler:
         workers = self.workers[task]
         worker = min(workers, key=lambda w: w.pending_count)
 
-        future, request_id = await worker.submit_request(
+        future = await worker.submit_request(
             example_id=example["example_id"],
             rollouts_per_example=self.config.rollouts_per_example,
         )
@@ -151,7 +151,7 @@ class Scheduler:
         self.inflight_group_rollouts[future] = InflightRolloutInfo(
             off_policy_steps=0,
             worker=worker,
-            request_id=request_id,
+            request_id=future.request_id,
         )
 
     async def update_policy_loop(self):

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -143,7 +143,7 @@ class Scheduler:
         workers = self.workers[task]
         worker = min(workers, key=lambda w: w.pending_count)
 
-        future = await worker.submit_request(
+        future, request_id = await worker.submit_request(
             example_id=example["example_id"],
             rollouts_per_example=self.config.rollouts_per_example,
         )
@@ -151,7 +151,7 @@ class Scheduler:
         self.inflight_group_rollouts[future] = InflightRolloutInfo(
             off_policy_steps=0,
             worker=worker,
-            request_id=future.request_id,
+            request_id=request_id,
         )
 
     async def update_policy_loop(self):


### PR DESCRIPTION
avoid orphaning future from example by overwriting the future with newly submitted rollout from that same example. Fixed with specific `request_id`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures rollout tracking uses unique identifiers to prevent future collisions when multiple rollouts originate from the same example.
> 
> - Introduces `request_id` (UUID) in `RolloutRequest`/`RolloutResponse`; separates `example_id`
> - `EnvWorker`: keys `pending_futures` by `request_id`; `submit_request` returns `(future, request_id)`; worker loop maps tasks to `request_id`
> - `Scheduler`: captures `request_id` directly from `EnvWorker.submit_request` and stores it in `InflightRolloutInfo`
> - Improves response matching and avoids orphaned/overwritten futures during concurrent rollouts
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f72421457f381d6353e2ac5bc35ee502ee80ec6d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->