### PR TITLE
Update LoRA layer default alpha from 16.0 to 32.0

### DIFF
--- a/src/prime_rl/trainer/models/layers/lora/multi_linear.py
+++ b/src/prime_rl/trainer/models/layers/lora/multi_linear.py
@@ -45,7 +45,7 @@ class MultiLoRALinear(MultiLoRAModule):
         base_layer: nn.Linear,
         rank: int,
         n_adapters: int,
-        alpha: float = 16.0,
+        alpha: float = 32.0,
         dropout: float = 0.0,
         use_grouped_mm: bool = True,
     ):

--- a/src/prime_rl/trainer/models/layers/lora/multi_moe.py
+++ b/src/prime_rl/trainer/models/layers/lora/multi_moe.py
@@ -78,7 +78,7 @@ class MultiLoRAGroupedExperts(MultiLoRAModule):
         base_layer: GroupedExperts,
         rank: int,
         n_adapters: int,
-        alpha: float = 16.0,
+        alpha: float = 32.0,
         dropout: float = 0.0,
     ):
         super().__init__(base_layer)


### PR DESCRIPTION
Ensures consistency with the config default changed in #1567. The MultiLoRALinear and MultiLoRAGroupedExperts classes had stale defaults that should match the orchestrator and trainer configs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Update LoRA defaults**
> 
> - Change default `alpha` to `32.0` in `multi_linear.py` (`MultiLoRALinear`) and `multi_moe.py` (`MultiLoRAGroupedExperts`) to match trainer/orchestrator configs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 299fc480d65def8c8cb84e6df3829b8421d14af0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->