### PR TITLE
Increase ulimit for sandbox environments

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-# Set higher ulimit for file descriptors to prevent API timeout issues
-ulimit -n 32000 2>/dev/null || echo "Warning: Could not set ulimit (may need --ulimit flag in docker run)"
+# Set higher ulimit for file descriptors for sandbox environments (need >= 65536)
+ulimit -n 1048576 2>/dev/null || ulimit -n 65536 2>/dev/null || echo "Warning: Could not set ulimit (may need --ulimit flag in docker run)"
 
 # Execute the main command
 exec "$@"


### PR DESCRIPTION
## Summary
- Increase file descriptor limit from 32000 to 1048576 (with fallback to 65536)
- Required for sandbox environments like i3-code that need >= 65536 file descriptors
- Fixes "File descriptor limit (RLIMIT_NOFILE) is set to 65535" errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Raises file descriptor limit used by the Docker entrypoint to support sandbox environments requiring high `RLIMIT_NOFILE` values.
> 
> - Updates `scripts/docker-entrypoint.sh` to attempt `ulimit -n 1048576`, falling back to `65536`, with a warning if neither can be set
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aefd35fa3a8ee7403e9d943e7b0c36493e0867f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->