### PR TITLE
Trainer nccl broadcast log

### DIFF
--- a/src/prime_rl/trainer/rl/broadcast/nccl.py
+++ b/src/prime_rl/trainer/rl/broadcast/nccl.py
@@ -121,8 +121,6 @@ class NCCLWeightBroadcastSender:
         self.logger.debug(f"Broadcasting {num_state_dict_to_send} layer state dicts")
 
         for layer_id, state_dict in filter_state_dict_by_layers(state_dict, num_layers):
-            if layer_id > 0:
-                self.logger.debug(f"Sending layer {layer_id} state dict")
             for key, value in list(state_dict.items()):
                 if isinstance(value, DTensor):
                     value = cast(DTensor, value.to(self.dtype)).full_tensor()

--- a/src/prime_rl/trainer/rl/broadcast/nccl.py
+++ b/src/prime_rl/trainer/rl/broadcast/nccl.py
@@ -118,10 +118,10 @@ class NCCLWeightBroadcastSender:
         if self.world.is_master:
             broadcast_integer(num_state_dict_to_send, self.communicator)
 
+        self.logger.debug(f"Broadcasting {num_state_dict_to_send} layer state dicts")
+
         for layer_id, state_dict in filter_state_dict_by_layers(state_dict, num_layers):
-            if layer_id == 0:
-                self.logger.debug("Sending non-layer weights state dict")
-            else:
+            if layer_id > 0:
                 self.logger.debug(f"Sending layer {layer_id} state dict")
             for key, value in list(state_dict.items()):
                 if isinstance(value, DTensor):

--- a/src/prime_rl/trainer/rl/broadcast/nccl.py
+++ b/src/prime_rl/trainer/rl/broadcast/nccl.py
@@ -118,10 +118,11 @@ class NCCLWeightBroadcastSender:
         if self.world.is_master:
             broadcast_integer(num_state_dict_to_send, self.communicator)
 
-        self.logger.debug(f"Broadcasting {num_state_dict_to_send} layer state dicts")
-
         for layer_id, state_dict in filter_state_dict_by_layers(state_dict, num_layers):
-            self.logger.debug(f"Sending layer {layer_id + 1}/{num_state_dict_to_send} state dict")
+            if layer_id == 0:
+                self.logger.debug("Sending non-layer weights state dict")
+            else:
+                self.logger.debug(f"Sending layer {layer_id} state dict")
             for key, value in list(state_dict.items()):
                 if isinstance(value, DTensor):
                     value = cast(DTensor, value.to(self.dtype)).full_tensor()


### PR DESCRIPTION
Remove logging of NCCL broadcast layer count from the trainer.

---
<a href="https://cursor.com/background-agent?bcId=bc-03193be0-df46-449c-a514-c163cf0c9328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-03193be0-df46-449c-a514-c163cf0c9328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reduces logging noise during NCCL weight broadcast.
> 
> - Removes per-layer debug log inside `broadcast_weights` loop in `trainer/rl/broadcast/nccl.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a4bcecf1c1b85cae6356bd678e075bffa1adbffb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->