### PR TITLE
fix opd

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -379,6 +379,7 @@ async def orchestrate(config: OrchestratorConfig):
             temperature=config.sampling.temperature,
             step=progress.step,
         )
+        assert len(training_batch.examples) != 0, "Step with no samples is not allowed"
         training_batch_sender.send(training_batch)
 
         # Await and process val results


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds readiness checks for the optional teacher inference server.
> 
> - Initialize `teacher_admin_clients` via `setup_admin_clients` when `config.teacher_model` is set
> - Block startup until teacher pool passes `check_health` and `check_has_model` (mirrors primary client checks)
> - Minor logging updates around teacher client initialization and readiness
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 996d18717a8b3036ed9bf4f1719b8f3f01a6aac2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->