### PR TITLE
add watcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,3 +32,4 @@ Documenting changes which affect configuration usage patterns (added/moved/remov
 - **`trainer.metrics_server`**: Added optional Prometheus metrics server for trainer observability. Exposes `/metrics` endpoint with step, loss, throughput, grad_norm, etc. Disabled by default (default: None) (#1547, 2026-01-06)
 - **`model.lora.alpha`**: Changed default from 16.0 to 32.0 (2026-01-10)
 - **`orchestrator.env.log`**: Added logging configuration for environment workers. If set, enables logging with `level` (str, default: "warn") and `vf_level` (str, default: "warn") fields. If None (default), logging is disabled (#1561, 2026-01-13)
+- **`eval.watcher`**: Added flag (default `False`) to watch `weights_dir` for newly-created stable checkpoints and evaluate them as they appear (2026-01-14)

--- a/src/prime_rl/eval/config.py
+++ b/src/prime_rl/eval/config.py
@@ -79,6 +79,16 @@ class OfflineEvalConfig(EvalConfig, BaseSettings):
         ),
     ] = None
 
+    watcher: Annotated[
+        bool,
+        Field(
+            description=(
+                "If True, watch `weights_dir` for newly-created stable checkpoints (folders named `step_{x}` that contain a `STABLE` file) "
+                "and evaluate them as they appear, instead of immediately iterating over all existing checkpoints."
+            ),
+        ),
+    ] = False
+
     @model_validator(mode="after")
     def validate_steps(self):
         if self.steps is not None and self.weights_dir is not None:


### PR DESCRIPTION
this pr add a watcher mode to eval that allow to constantly look for new ckpt in a given folder path and run eval on them, usefull for having a eval deamon during a run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces continuous checkpoint evaluation for offline evals.
> 
> - Adds `eval.watcher` (default `False`) in `OfflineEvalConfig` to enable watch mode
> - In `eval.py`, after evaluating existing checkpoints, if `watcher=True` enters a loop that:
>   - Polls `weights_dir` for new `step_*` checkpoints
>   - Calls `update_weights` and `run_evals` for unseen steps; waits 10s when none
> - Updates `CHANGELOG.md` to document the new flag and behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1734d10841702d2d9381f3491fb4e87976a6b6b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->