### PR TITLE
fix: wait for checkpoint completion in eval watcher

### DIFF
--- a/src/prime_rl/eval/config.py
+++ b/src/prime_rl/eval/config.py
@@ -92,10 +92,17 @@ class OfflineEvalConfig(EvalConfig, BaseSettings):
     @model_validator(mode="after")
     def validate_steps(self):
         if self.steps is not None and self.weights_dir is not None:
-            ckpt_steps = sorted([int(step_path.name.split("_")[-1]) for step_path in self.weights_dir.glob("step_*")])
+            # Only consider checkpoints with STABLE file (indicating save completed)
+            ckpt_steps = sorted(
+                [
+                    int(step_path.name.split("_")[-1])
+                    for step_path in self.weights_dir.glob("step_*")
+                    if (step_path / "STABLE").exists()
+                ]
+            )
             for step in self.steps:
                 if step not in ckpt_steps:
-                    raise ValueError(f"Step {step} not found in weights directory {self.weights_dir}")
+                    raise ValueError(f"Step {step} not found (or not stable) in weights directory {self.weights_dir}")
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/eval/eval.py
+++ b/src/prime_rl/eval/eval.py
@@ -82,8 +82,15 @@ async def eval(config: OfflineEvalConfig):
     # If specified, evaluate all checkpoints found in the weights directory
     if config.weights_dir is not None:
         logger.info(f"Evaluating weight checkpoints in {config.weights_dir}")
-        ckpt_steps = sorted([int(step_path.name.split("_")[-1]) for step_path in config.weights_dir.glob("step_*")])
-        logger.info(f"Found {len(ckpt_steps)} weight checkpoints (steps: {', '.join(map(str, ckpt_steps))})")
+        # Only include checkpoints that have a STABLE file (indicating save completed)
+        ckpt_steps = sorted(
+            [
+                int(step_path.name.split("_")[-1])
+                for step_path in config.weights_dir.glob("step_*")
+                if (step_path / "STABLE").exists()
+            ]
+        )
+        logger.info(f"Found {len(ckpt_steps)} stable weight checkpoints (steps: {', '.join(map(str, ckpt_steps))})")
 
         # Filter the steps to evaluate
         if config.steps is not None:
@@ -112,8 +119,13 @@ async def eval(config: OfflineEvalConfig):
             already_evaluated_ckpt_steps = ckpt_steps
 
             while True:
+                # Only include checkpoints that have a STABLE file (indicating save completed)
                 all_ckpt_steps = sorted(
-                    [int(step_path.name.split("_")[-1]) for step_path in config.weights_dir.glob("step_*")]
+                    [
+                        int(step_path.name.split("_")[-1])
+                        for step_path in config.weights_dir.glob("step_*")
+                        if (step_path / "STABLE").exists()
+                    ]
                 )
                 new_ckpt_steps = [step for step in all_ckpt_steps if step not in already_evaluated_ckpt_steps]
                 if len(new_ckpt_steps) > 0:

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -337,6 +337,8 @@ class WeightCheckpointManager:
         # Save weight checkpoint on master rank
         if self.world.is_master:
             self.save_to_path(step_path, state_dict, lora_state_dict, model, tokenizer)
+            # Write STABLE file to indicate checkpoint is complete (for eval to safely read)
+            (step_path / "STABLE").touch()
             self.ckpt_steps.append(step)
 
     def maybe_clean(self) -> None:


### PR DESCRIPTION
writes and waits for `STABLE` file in `weights/` (similar to `broadcast/`) so we don't try to eval on an incomplete checkpoint.

fixes https://github.com/PrimeIntellect-ai/prime-rl/pull/1581#discussion_r2688527877

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures evals run only on fully saved checkpoints.
> 
> - Trainer now touches `STABLE` in `weights/step_{x}` after successfully saving a weight checkpoint
> - Eval scans and watcher logic filter to checkpoints that contain `STABLE` and update logs accordingly
> - Config validation for `steps` now checks against stable checkpoints and improves the error message
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58170d4f3df50dae3240b9dc5de3af0f3a6fdc7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->