### PR TITLE
skip failed eval envs with warning

### DIFF
--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -292,9 +292,9 @@ class RetryConfig(BaseConfig):
     reraise: Annotated[
         bool,
         Field(
-            description="Whether to reraise the exception after all retries are exhausted.",
+            description="Whether to reraise the original exception after all retries are exhausted. If False, raises tenacity.RetryError instead.",
         ),
-    ] = True
+    ] = False
 
 
 class EnvLogConfig(BaseConfig):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves eval robustness by skipping environments that exceed retry limits and reporting them.
> 
> - Wraps `run_eval` with `run_eval_safe` to catch `tenacity.RetryError`, log the last exception, and continue; logs count of skipped envs in `run_evals`
> - Imports `RetryError` and adds warning logs for exhausted retries
> - Updates `RetryConfig.reraise` description and default to `False` so exhausted retries raise `RetryError` instead of the original exception
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 184a3492de5246fd766d3a3f7f96aa1f6b064eec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->