### PR TITLE
Step check runtime context

### DIFF
--- a/src/prime_rl/eval/config.py
+++ b/src/prime_rl/eval/config.py
@@ -90,22 +90,6 @@ class OfflineEvalConfig(EvalConfig, BaseSettings):
     ] = False
 
     @model_validator(mode="after")
-    def validate_steps(self):
-        if self.steps is not None and self.weights_dir is not None:
-            # Only consider checkpoints with STABLE file (indicating save completed)
-            ckpt_steps = sorted(
-                [
-                    int(step_path.name.split("_")[-1])
-                    for step_path in self.weights_dir.glob("step_*")
-                    if (step_path / "STABLE").exists()
-                ]
-            )
-            for step in self.steps:
-                if step not in ckpt_steps:
-                    raise ValueError(f"Step {step} not found (or not stable) in weights directory {self.weights_dir}")
-        return self
-
-    @model_validator(mode="after")
     def validate_eval_base(self):
         if self.weights_dir is None and not self.eval_base:
             raise ValueError(

--- a/src/prime_rl/eval/eval.py
+++ b/src/prime_rl/eval/eval.py
@@ -92,7 +92,6 @@ async def eval(config: OfflineEvalConfig):
         )
         logger.info(f"Found {len(ckpt_steps)} stable weight checkpoints (steps: {', '.join(map(str, ckpt_steps))})")
 
-        # Runtime validation: if explicit steps requested, ensure they exist and are stable
         if config.steps is not None:
             missing_steps = [step for step in config.steps if step not in ckpt_steps]
             if missing_steps:

--- a/src/prime_rl/eval/eval.py
+++ b/src/prime_rl/eval/eval.py
@@ -92,6 +92,14 @@ async def eval(config: OfflineEvalConfig):
         )
         logger.info(f"Found {len(ckpt_steps)} stable weight checkpoints (steps: {', '.join(map(str, ckpt_steps))})")
 
+        # Runtime validation: if explicit steps requested, ensure they exist and are stable
+        if config.steps is not None:
+            missing_steps = [step for step in config.steps if step not in ckpt_steps]
+            if missing_steps:
+                raise ValueError(
+                    f"Step {missing_steps[0]} not found (or not stable) in weights directory {config.weights_dir}"
+                )
+
         # Filter the steps to evaluate
         if config.steps is not None:
             ckpt_steps = [step for step in ckpt_steps if step in config.steps]


### PR DESCRIPTION
Move checkpoint step validation from config-time to runtime.

The check for requested evaluation steps existing as stable checkpoints was previously performed during config parsing, which is incorrect for a filesystem-dependent validation. This change relocates the exact same logic to the `eval` function, ensuring it runs after stable checkpoints have been discovered.

---
<a href="https://cursor.com/background-agent?bcId=bc-c037cab7-4bf2-46ff-9a1b-63e4f4b27276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c037cab7-4bf2-46ff-9a1b-63e4f4b27276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shifts filesystem-dependent step validation to execution time for correctness.
> 
> - Removes `validate_steps` from `OfflineEvalConfig` (no longer checks steps during config parsing)
> - In `eval.py`, after discovering stable checkpoints, validates `config.steps` against available checkpoints and raises a concise error for missing steps
> - Subsequent filtering and evaluation of checkpoints remains unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eebb03031df8149a8607bcbdab800fa0a0fea642. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->