### PR TITLE
Incomplete evaluation results

### DIFF
--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -55,10 +55,10 @@ def read_existing_results(results_file: Path) -> pd.DataFrame:
     with open(results_file, "r") as f:
         for line in f:
             result = json.loads(line)
-            info = result.get("info", {}) or {}
-            prime_info = info.get("prime_rl", {}) if isinstance(info, dict) else {}
+            info = result.get("info", {})
+            prime_info = info.get("prime_rl", {})
             rollout_status = (
-                prime_info.get("rollout_status", "ok") if isinstance(prime_info, dict) else "ok"
+                prime_info.get("rollout_status", "ok")
             )
             results.append(
                 {

--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -55,7 +55,7 @@ def read_existing_results(results_file: Path) -> pd.DataFrame:
     with open(results_file, "r") as f:
         for line in f:
             result = json.loads(line)
-            info = result.get("info", {}) or {}
+            info = result.get("info", {})
             prime_info = info.get("prime_rl", {})
             rollout_status = prime_info.get("rollout_status", "ok")
             results.append(

--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -641,7 +641,7 @@ async def run_eval(
     # Log statistics to monitor
     eval_metrics = {
         f"avg@{k}": results_df.reward.mean(),
-        "no_response/mean": no_response_rate,
+        "no_response/pct": no_response_rate * 100.0,
         "no_response/count": int((results_df.rollout_status == "no_response").sum()) if "rollout_status" in results_df else 0,
         "completion_len/avg": results_df.completion_len.mean().item(),
         "completion_len/max": results_df.completion_len.max().item(),

--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -232,7 +232,7 @@ def _make_no_response_state(
     }
 
 
-def _mark_save_failed(state: vf.State, *, env_name_or_id: str, rollout_idx: int, error: Exception) -> None:
+def _mark_save_failed(state: dict, *, env_name_or_id: str, rollout_idx: int, error: Exception) -> None:
     """Annotate a successful rollout state when persistence fails."""
     info = state.get("info")
     if not isinstance(info, dict):
@@ -348,7 +348,9 @@ async def generate_and_save_rollout(
                 f"(env={env_name_or_id}, example_id={example.get('example_id')}, rollout_idx={rollout_idx})",
                 exc_info=(type(save_e), save_e, save_e.__traceback__),
             )
-            _mark_save_failed(state, env_name_or_id=env_name_or_id, rollout_idx=rollout_idx, error=save_e)
+            _mark_save_failed(
+                state, env_name_or_id=env_name_or_id, rollout_idx=rollout_idx, error=save_e  # type: ignore[arg-type]
+            )
 
     # Update running average immediately.
     async with rewards_lock:

--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -232,7 +232,7 @@ def _make_no_response_state(
     }
 
 
-def _mark_save_failed(state: dict, *, env_name_or_id: str, rollout_idx: int, error: Exception) -> None:
+def _mark_save_failed(state: vf.State, *, env_name_or_id: str, rollout_idx: int, error: Exception) -> None:
     """Annotate a successful rollout state when persistence fails."""
     info = state.get("info")
     if not isinstance(info, dict):
@@ -348,9 +348,7 @@ async def generate_and_save_rollout(
                 f"(env={env_name_or_id}, example_id={example.get('example_id')}, rollout_idx={rollout_idx})",
                 exc_info=(type(save_e), save_e, save_e.__traceback__),
             )
-            _mark_save_failed(
-                state, env_name_or_id=env_name_or_id, rollout_idx=rollout_idx, error=save_e  # type: ignore[arg-type]
-            )
+            _mark_save_failed(state, env_name_or_id=env_name_or_id, rollout_idx=rollout_idx, error=save_e)
 
     # Update running average immediately.
     async with rewards_lock:

--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -56,8 +56,8 @@ def read_existing_results(results_file: Path) -> pd.DataFrame:
         for line in f:
             result = json.loads(line)
             info = result.get("info", {}) or {}
-            prime_info = info.get("prime_rl", {}) if isinstance(info, dict) else {}
-            rollout_status = prime_info.get("rollout_status", "ok") if isinstance(prime_info, dict) else "ok"
+            prime_info = info.get("prime_rl", {})
+            rollout_status = prime_info.get("rollout_status", "ok")
             results.append(
                 {
                     "example_id": result["example_id"],
@@ -603,8 +603,6 @@ async def run_eval(
             "is_truncated": [get_is_truncated(state) for state in all_states],
             "rollout_status": [
                 (state.get("info", {}) or {}).get("prime_rl", {}).get("rollout_status", "ok")
-                if isinstance(state.get("info", {}), dict)
-                else "ok"
                 for state in all_states
             ],
         }


### PR DESCRIPTION
Record "no response" for failed rollouts instead of aborting the entire evaluation to ensure evaluations always complete and report numeric accuracy.

Previously, if a single rollout exhausted its retries, it would raise an exception that cancelled the entire evaluation run. This change ensures the evaluation continues, and results include a clear "no_response" rate.

---
<a href="https://cursor.com/background-agent?bcId=bc-909f2db7-b92e-49c3-9f59-4a82c50b4ab6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-909f2db7-b92e-49c3-9f59-4a82c50b4ab6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces resilient evaluation that records `no_response` rollouts/groups and continues execution, with proper saving and metrics.
> 
> - New `_make_no_response_state` plus `_is_valid_reward` and `_format_avg_reward` to handle missing/NaN rewards without skewing averages (shows `N/A` when none valid)
> - `generate_and_save_rollout`/`generate_and_save_group` catch `RetryError`/exceptions, save placeholder rows when streaming, update progress, and return sentinel states instead of raising; signatures now include `env_name_or_id`
> - Results and resume flows now include `rollout_status`; pass@k and unique reward calculations ignore `NaN` via `dropna()`
> - Logs and monitor metrics report `no_response` rate and counts alongside Avg@k, completion length, and truncation; progress bar shows formatted Avg Reward
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ef6e883cbca4201643eaa103182823b00ea0582. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->