### PR TITLE
Logging tmux script panes

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -2,6 +2,21 @@
 
 prime-rl uses [loguru](https://loguru.readthedocs.io/en/stable/) for logging with a global logger pattern. Logs are written to both console and files under `{output_dir}/logs/`. For RL training, we recommend streaming file logs into tmux panes (as set up by `tmux.sh`).
 
+## tmux helper (`scripts/tmux.sh`)
+
+`scripts/tmux.sh` sets up a tmux session for RL runs with **three panes (one per subprocess)**:
+
+- **Trainer**: run `uv run rl ...` here
+- **Orchestrator**: follows `{output_dir}/logs/orchestrator.stdout`
+- **Inference**: follows `{output_dir}/logs/inference.stdout`
+
+Run it with defaults (`prime-rl` session, `outputs` dir), or override:
+
+```bash
+./scripts/tmux.sh
+./scripts/tmux.sh -s my-session -o my-outputs
+```
+
 ## Logger Architecture
 
 ### `setup_logger` and `get_logger`

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -10,13 +10,6 @@ prime-rl uses [loguru](https://loguru.readthedocs.io/en/stable/) for logging wit
 - **Orchestrator**: follows `{output_dir}/logs/orchestrator.stdout`
 - **Inference**: follows `{output_dir}/logs/inference.stdout`
 
-Run it with defaults (`prime-rl` session, `outputs` dir), or override:
-
-```bash
-./scripts/tmux.sh
-./scripts/tmux.sh -s my-session -o my-outputs
-```
-
 ## Logger Architecture
 
 ### `setup_logger` and `get_logger`


### PR DESCRIPTION
Add documentation to `logging.md` explaining the `tmux.sh` script's 3-pane layout and usage for monitoring subprocess logs.

---
<a href="https://cursor.com/background-agent?bcId=bc-ad95a926-988f-4632-8736-5add4b08dc7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ad95a926-988f-4632-8736-5add4b08dc7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds documentation to `docs/logging.md` for the `scripts/tmux.sh` helper.
> 
> - Describes the tmux session with three panes mapped to subprocesses: `Trainer` (run `uv run rl ...`), `Orchestrator` (follows `logs/orchestrator.stdout`), and `Inference` (follows `logs/inference.stdout`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad3b9f440812a3059dfe216d213fe9639353fd79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->