### PR TITLE
fix skipped eval env log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,4 @@ Documenting changes which affect configuration usage patterns (added/moved/remov
 - **`model.lora.alpha`**: Changed default from 16.0 to 32.0 (2026-01-10)
 - **`orchestrator.env.log`**: Added logging configuration for environment workers. If set, enables logging with `level` (str, default: "warn") and `vf_level` (str, default: "warn") fields. If None (default), logging is disabled (#1561, 2026-01-13)
 - **`eval.watcher`**: Added flag (default `False`) to watch `weights_dir` for newly-created stable checkpoints and evaluate them as they appear (2026-01-14)
+- **`orchestrator.eval.retry.reraise`**: Changed default from `True` to `False`. When `False`, raises `tenacity.RetryError` after retries are exhausted instead of the original exception, allowing failed eval environments to be skipped with a warning (#1586, 2026-01-14)

--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -639,7 +639,7 @@ async def run_evals(
     async def run_eval_safe(env):
         """Wrapper to catch RetryError and skip env."""
         try:
-            return await run_eval(
+            await run_eval(
                 clients=clients,
                 env_id=env.id,
                 env_name=env.name,
@@ -658,6 +658,7 @@ async def run_evals(
                 step=step,
                 resume_path=resume_path,
             )
+            return True
         except RetryError as e:
             env_name = env.name or env.id
             logger.warning(


### PR DESCRIPTION
fix return value so skipped eval envs get logged correctly.
update changelog.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix eval env skipping/logging**
> 
> - In `run_evals` (`utils.py`), change `run_eval_safe` to `await run_eval(...)` then `return True` on success; continue catching `RetryError` to skip env with a warning. This makes the skipped count accurate when summarizing results.
> 
> **Changelog update**
> 
> - Document default change for `orchestrator.eval.retry.reraise` from `True` to `False` to allow skipping failed eval environments with a `RetryError`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d78a0eabcdc7268ec64cc89b0e010c316509282. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->