### PR TITLE
remove loggign event loop

### DIFF
--- a/src/prime_rl/orchestrator/event_loop_lag.py
+++ b/src/prime_rl/orchestrator/event_loop_lag.py
@@ -71,10 +71,6 @@ class EventLoopLagMonitor:
             self.logger.warning(
                 f"Detected busy event loop. Measured {mean_lag:.1f}s (min={min_lag:.1f}s, med={med_lag:.1f}s, p90={p90_lag:.1f}s, max={max_lag:.1f}s) event loop lag over the last {len(last_lags)} measurement(s)"
             )
-        else:
-            self.logger.debug(
-                f"Event loop is running smoothly. Measured {mean_lag:.1f}s (min={min_lag:.1f}s, med={med_lag:.1f}s, p90={p90_lag:.1f}s, max={max_lag:.1f}s) event loop lag over the last {len(last_lags)} measurement(s)"
-            )
 
         return {
             "event_loop_lag/min": min_lag,


### PR DESCRIPTION
no need to log when the event loop is healthy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reduces log noise in `EventLoopLagMonitor` by removing the "running smoothly" debug log path; warnings still emit when lag exceeds thresholds.
> 
> - Update `src/prime_rl/orchestrator/event_loop_lag.py` to only log `warning` on threshold breaches; no `debug` log on healthy state
> - No changes to lag measurement logic or returned metrics
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eaeef755a3ee2e38e39456571488c4eb6c32eb74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->