### PR TITLE
[feat] Multi run ckpt

### DIFF
--- a/configs/ci/integration/rl_multi_run/orchestrator.toml
+++ b/configs/ci/integration/rl_multi_run/orchestrator.toml
@@ -17,3 +17,6 @@ max_tokens = 128
 [[env]]
 id = "reverse-text"
 
+[ckpt]
+interval = 10
+resume_step = -1

--- a/configs/ci/integration/rl_multi_run/trainer.toml
+++ b/configs/ci/integration/rl_multi_run/trainer.toml
@@ -5,6 +5,13 @@ max_async_level = 5
 
 [model]
 name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
+seq_len = 65536
 
 [model.lora]
 rank = 8
+
+[model.ac]
+freq = 1
+
+[model.compile]
+fullgraph = false

--- a/configs/ci/integration/rl_multi_run/trainer.toml
+++ b/configs/ci/integration/rl_multi_run/trainer.toml
@@ -1,5 +1,4 @@
 # Trainer config for multi-run RL integration test
-max_steps = 100000
 max_concurrent_runs = 2
 max_async_level = 5
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -239,6 +239,7 @@ async def orchestrate(config: OrchestratorConfig):
             raise ValueError(f"No weight directory found for checkpoint step {scheduler.ckpt_step}")
         await update_weights(
             admin_clients,
+            weight_dir,
             lora_name=config.model.lora.name if config.model.lora else None,
         )
     else:

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -234,7 +234,7 @@ async def orchestrate(config: OrchestratorConfig):
 
         weight_dir = get_step_path(get_ckpt_dir(config.output_dir), scheduler.ckpt_step) / "weight"
         if not weight_dir.exists():
-            weight_dir = (get_step_path(get_broadcast_dir(config.output_dir), scheduler.ckpt_step),)
+            weight_dir = get_step_path(get_broadcast_dir(config.output_dir), scheduler.ckpt_step)
         if not weight_dir.exists():
             raise ValueError(f"No weight directory found for checkpoint step {scheduler.ckpt_step}")
         await update_weights(

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -31,6 +31,7 @@ from prime_rl.orchestrator.scheduler import Scheduler
 from prime_rl.orchestrator.utils import (
     compute_teacher_logprobs,
     get_sampling_args,
+    get_weight_dir,
     print_benchmark,
     set_semaphore,
 )
@@ -49,10 +50,7 @@ from prime_rl.utils.monitor import setup_monitor
 from prime_rl.utils.pydantic_config import parse_argv
 from prime_rl.utils.utils import (
     clean_exit,
-    get_broadcast_dir,
-    get_ckpt_dir,
     get_env_ids_to_install,
-    get_step_path,
     install_env,
     resolve_latest_ckpt_step,
     to_col_format,
@@ -232,14 +230,9 @@ async def orchestrate(config: OrchestratorConfig):
             last_eval_step = scheduler.ckpt_step
             logger.info(f"Skipping online eval on resume (ckpt_step={scheduler.ckpt_step})")
 
-        weight_dir = get_step_path(get_ckpt_dir(config.output_dir), scheduler.ckpt_step) / "weight"
-        if not weight_dir.exists():
-            weight_dir = get_step_path(get_broadcast_dir(config.output_dir), scheduler.ckpt_step)
-        if not weight_dir.exists():
-            raise ValueError(f"No weight directory found for checkpoint step {scheduler.ckpt_step}")
         await update_weights(
             admin_clients,
-            weight_dir,
+            get_weight_dir(config.output_dir, scheduler.ckpt_step),
             lora_name=config.model.lora.name if config.model.lora else None,
         )
     else:

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -196,24 +196,6 @@ class CheckpointManager:
         self.save_to_path(ckpt_path, model, optimizers, scheduler, progress, dataloader)
         self.ckpt_steps.append(step)
 
-    def save_stateful(self, step: int, stateful: Stateful) -> None:
-        """Save a custom Stateful object for a specified step."""
-        ckpt_path = self.get_ckpt_path(step)
-        ckpt_path.parent.mkdir(parents=True, exist_ok=True)
-        self.logger.debug(f"Saving checkpoint to {ckpt_path}")
-        dcp_save({"app": stateful}, checkpoint_id=ckpt_path)
-        if self.world.is_master:
-            (ckpt_path / "STABLE").touch()
-        self.ckpt_steps.append(step)
-
-    def load_stateful(self, step: int, stateful: Stateful) -> None:
-        """Load into a custom Stateful object from a specified step."""
-        ckpt_path = self.get_ckpt_path(step)
-        if not ckpt_path.exists():
-            raise FileNotFoundError(f"Checkpoint not found at {ckpt_path}")
-        self.logger.debug(f"Loading checkpoint from {ckpt_path}")
-        dcp_load({"app": stateful}, checkpoint_id=ckpt_path)
-
     def maybe_clean(self) -> None:
         """Deletes past checkpoints based on keep_last and keep_interval policies. No-op if both are None."""
         if self.config.keep_last is None and self.config.keep_interval is None:

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -98,6 +98,12 @@ class CheckpointManager:
         """Get the path to write the trainer checkpoint for a given step."""
         return get_step_path(self.ckpt_dir, step) / "trainer"
 
+    def mark_stable(self, step: int) -> None:
+        """Write STABLE file to indicate checkpoint is complete (for eval to safely read)."""
+        if self.world.is_master:
+            step_path = get_step_path(self.ckpt_dir, step)
+            (step_path / "STABLE").touch()
+
     def save_to_path(
         self,
         path: Path,

--- a/src/prime_rl/trainer/multi_ckpt.py
+++ b/src/prime_rl/trainer/multi_ckpt.py
@@ -159,10 +159,10 @@ class MultiCheckpointManager:
                 self.logger.warning(f"Run {idx} deleted during checkpoint, skipping")
             except Exception as e:
                 self.logger.error(f"Error checkpointing run {idx}: {e}")
-
+            dist.barrier()
+            manager.mark_stable(step)
+            manager.ckpt_steps.append(step)
         dist.barrier()
-        manager.mark_stable(step)
-        manager.ckpt_steps.append(step)
 
     def load_run(
         self,

--- a/src/prime_rl/trainer/multi_ckpt.py
+++ b/src/prime_rl/trainer/multi_ckpt.py
@@ -142,9 +142,11 @@ class MultiCheckpointManager:
                     scheduler.schedulers[idx],
                     self.runs.progress[idx],
                 )
-                self.logger.info(f"Saving checkpoint for run {idx} at step {step}")
                 ckpt_path = manager.get_ckpt_path(step)
                 ckpt_path.mkdir(parents=True, exist_ok=True)
+                self.logger.info(
+                    f"Saving checkpoint for run {idx} at step {step} to {ckpt_path / f'rank_{self.world.rank}.pt'}"
+                )
                 torch.save(app_state.state_dict(), ckpt_path / f"rank_{self.world.rank}.pt")
                 if self.world.is_master:
                     (ckpt_path / "STABLE").touch()

--- a/src/prime_rl/trainer/multi_ckpt.py
+++ b/src/prime_rl/trainer/multi_ckpt.py
@@ -137,10 +137,11 @@ class MultiCheckpointManager:
                 manager.save_stateful(step, app_state)
 
                 # Copy broadcast folder to checkpoint
-                run_dir = self.runs.get_run_dir(idx)
-                broadcast_src = run_dir / "broadcasts" / f"step_{step}"
-                weight_dst = run_dir / "checkpoints" / f"step_{step}" / "weight"
-                shutil.copytree(broadcast_src, weight_dst)
+                if self.world.is_master:
+                    run_dir = self.runs.get_run_dir(idx)
+                    broadcast_src = run_dir / "broadcasts" / f"step_{step}"
+                    weight_dst = run_dir / "checkpoints" / f"step_{step}" / "weight"
+                    shutil.copytree(broadcast_src, weight_dst)
             except FileNotFoundError:
                 self.logger.warning(f"Run {idx} deleted during checkpoint, skipping")
             except Exception as e:

--- a/src/prime_rl/trainer/multi_ckpt.py
+++ b/src/prime_rl/trainer/multi_ckpt.py
@@ -78,6 +78,10 @@ class MultiCheckpointManager:
         self.world = get_world()
         self.logger = get_logger()
         self.managers: dict[int, CheckpointManager] = {}
+        self.runs.register_deletion_hook(self._delete_run_data_hook)
+
+    def _delete_run_data_hook(self, idx: int, run_id: str) -> None:
+        del self.managers[idx]
 
     def _get_or_create_manager(self, idx: int) -> CheckpointManager | None:
         if idx in self.managers:

--- a/src/prime_rl/trainer/multi_ckpt.py
+++ b/src/prime_rl/trainer/multi_ckpt.py
@@ -122,6 +122,7 @@ class MultiCheckpointManager:
 
             manager = self.managers[idx]
 
+            # We have a very wide try-except because we dont want to crash the trainer over one run having issues
             try:
                 model_state_dict = {k: v.data.detach().clone() for k, v in self.runs.get_named_parameters_for_run(idx)}
                 run_state = RunState(

--- a/src/prime_rl/trainer/multi_ckpt.py
+++ b/src/prime_rl/trainer/multi_ckpt.py
@@ -148,7 +148,6 @@ class MultiCheckpointManager:
                     f"Saving checkpoint for run {idx} at step {step} to {ckpt_path / f'rank_{self.world.rank}.pt'}"
                 )
                 torch.save(app_state.state_dict(), ckpt_path / f"rank_{self.world.rank}.pt")
-                manager.ckpt_steps.append(step)
 
                 # Copy broadcast folder to checkpoint
                 if self.world.is_master:
@@ -163,6 +162,7 @@ class MultiCheckpointManager:
 
         dist.barrier()
         manager.mark_stable(step)
+        manager.ckpt_steps.append(step)
 
     def load_run(
         self,

--- a/src/prime_rl/trainer/multi_ckpt.py
+++ b/src/prime_rl/trainer/multi_ckpt.py
@@ -156,14 +156,13 @@ class MultiCheckpointManager:
                     broadcast_src = run_dir / "broadcasts" / f"step_{step}"
                     weight_dst = run_dir / "checkpoints" / f"step_{step}" / "weight"
                     shutil.copytree(broadcast_src, weight_dst)
-                dist.barrier()
-                manager.mark_stable(step)
             except FileNotFoundError:
                 self.logger.warning(f"Run {idx} deleted during checkpoint, skipping")
             except Exception as e:
                 self.logger.error(f"Error checkpointing run {idx}: {e}")
 
         dist.barrier()
+        manager.mark_stable(step)
 
     def load_run(
         self,

--- a/src/prime_rl/trainer/multi_ckpt.py
+++ b/src/prime_rl/trainer/multi_ckpt.py
@@ -65,9 +65,8 @@ class RunAppState(Stateful):
         # Load scheduler
         if "scheduler" in state_dict and self.scheduler is not None:
             self.scheduler.load_state_dict(state_dict["scheduler"])
-        # Load progress
-        for key, value in state_dict["progress"].items():
-            setattr(self.progress, key, value)
+        # Don't load progress because it resets packers count
+        # There will be a step issue if we load progress
 
 
 class MultiCheckpointManager:

--- a/src/prime_rl/trainer/multi_ckpt.py
+++ b/src/prime_rl/trainer/multi_ckpt.py
@@ -82,7 +82,8 @@ class MultiCheckpointManager:
         self.runs.register_deletion_hook(self._delete_run_data_hook)
 
     def _delete_run_data_hook(self, idx: int, run_id: str) -> None:
-        del self.managers[idx]
+        if idx in self.managers:
+            del self.managers[idx]
 
     def _get_or_create_manager(self, idx: int) -> CheckpointManager | None:
         if idx in self.managers:

--- a/src/prime_rl/trainer/multi_ckpt.py
+++ b/src/prime_rl/trainer/multi_ckpt.py
@@ -4,6 +4,7 @@ MultiCheckpointManager owns per-run CheckpointManagers and AppStates,
 each saving to its own run directory.
 """
 
+import shutil
 from dataclasses import asdict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -134,6 +135,12 @@ class MultiCheckpointManager:
                 )
                 self.logger.info(f"Saving checkpoint for run {idx} at step {step}")
                 manager.save_stateful(step, app_state)
+
+                # Copy broadcast folder to checkpoint
+                run_dir = self.runs.get_run_dir(idx)
+                broadcast_src = run_dir / "broadcasts" / f"step_{step}"
+                weight_dst = run_dir / "checkpoints" / f"step_{step}" / "weight"
+                shutil.copytree(broadcast_src, weight_dst)
             except FileNotFoundError:
                 self.logger.warning(f"Run {idx} deleted during checkpoint, skipping")
             except Exception as e:

--- a/src/prime_rl/trainer/multi_ckpt.py
+++ b/src/prime_rl/trainer/multi_ckpt.py
@@ -201,10 +201,10 @@ class MultiCheckpointManager:
     def maybe_clean(self) -> None:
         if not self.world.is_master:
             return
-        for idx in list(self.runs.used_idxs):
-            manager = self.managers.get(idx)
-            if manager is not None:
-                manager.maybe_clean()
+        for idx in self.runs.used_idxs:
+            if self.managers[idx] is None:
+                continue
+            self.managers[idx].maybe_clean()
 
 
 def setup_multi_checkpoint_manager(output_dir: Path) -> tuple[MultiCheckpointManager, None]:

--- a/src/prime_rl/trainer/rl/broadcast/filesystem.py
+++ b/src/prime_rl/trainer/rl/broadcast/filesystem.py
@@ -68,6 +68,7 @@ class FileSystemWeightBroadcast(WeightBroadcast):
                     )
                     save_dir.mkdir(parents=True, exist_ok=True)
 
+                    self.logger.debug(f"Saving weights for run {idx} to {save_dir}")
                     save_state_dict(state_dict, save_dir, self.save_format, self.save_sharded, adapter=adapter_only)
                     if adapter_only:
                         save_lora_config(self.lora_config, model, save_dir)

--- a/src/prime_rl/trainer/rl/packer.py
+++ b/src/prime_rl/trainer/rl/packer.py
@@ -194,9 +194,6 @@ class MultiPacker(BasePacker):
         # Removing the len(self.buffers[run_idx]) == 0 check would allow incremental orchestrator rollouts
         if len(self.buffers[run_idx]) == 0 or self.buffers[run_idx][0][2] > self.runs.progress[run_idx].step:
             self.runs.progress[run_idx].step += 1
-            self.logger.debug(
-                f"Run {run_idx} has seen {self.samples_consumed_this_step[run_idx]} samples and is ready to update and going to step {self.runs.progress[run_idx].step}"
-            )
             self.runs.ready_to_update[run_idx] = True
 
         self.runs.progress[run_idx].total_tokens += num_tokens

--- a/src/prime_rl/trainer/rl/packer.py
+++ b/src/prime_rl/trainer/rl/packer.py
@@ -194,6 +194,9 @@ class MultiPacker(BasePacker):
         # Removing the len(self.buffers[run_idx]) == 0 check would allow incremental orchestrator rollouts
         if len(self.buffers[run_idx]) == 0 or self.buffers[run_idx][0][2] > self.runs.progress[run_idx].step:
             self.runs.progress[run_idx].step += 1
+            self.logger.debug(
+                f"Run {run_idx} has seen {self.samples_consumed_this_step[run_idx]} samples and is ready to update and going to step {self.runs.progress[run_idx].step}"
+            )
             self.runs.ready_to_update[run_idx] = True
 
         self.runs.progress[run_idx].total_tokens += num_tokens

--- a/src/prime_rl/trainer/scheduler.py
+++ b/src/prime_rl/trainer/scheduler.py
@@ -173,6 +173,6 @@ def setup_multi_scheduler(
 ) -> MultiLoRAScheduler:
     """Create a MultiLoRAScheduler for managing per-run schedulers."""
     scheduler = MultiLoRAScheduler(scheduler_config, max_steps)
-    # Register callback so schedulers are created when optimizers are created
-    optimizer.register_post_creation_callback(scheduler.scheduler_creation_hook)
+    # Register callback at index 0 so schedulers are created before other callbacks
+    optimizer.register_post_creation_callback(scheduler.scheduler_creation_hook, index=0)
     return scheduler

--- a/tests/integration/test_rl_multi_run_lora.py
+++ b/tests/integration/test_rl_multi_run_lora.py
@@ -203,7 +203,7 @@ def start_orchestrator(
 @pytest.fixture(scope="module")
 def multi_run_result(
     output_dir: Path, wandb_project: str, wandb_name: str, tmp_path_factory
-) -> Generator[tuple[dict[str, ProcessResult], str], None, None]:
+) -> Generator[dict[str, ProcessResult], None, None]:
     """
     Test multi-run RL with LoRA adapters.
     """

--- a/tests/integration/test_rl_multi_run_lora.py
+++ b/tests/integration/test_rl_multi_run_lora.py
@@ -89,7 +89,7 @@ def start_inference_and_trainer(
                 "run",
                 "torchrun",
                 "--nproc-per-node",
-                "1",
+                "2",
                 "-m",
                 "prime_rl.trainer.rl.train",
                 "@",
@@ -105,7 +105,7 @@ def start_inference_and_trainer(
             ],
             stdout=f,
             stderr=f,
-            env={**os.environ, "CUDA_VISIBLE_DEVICES": "1"},
+            env={**os.environ, "CUDA_VISIBLE_DEVICES": "2,3"},
         )
 
     # Wait for inference to be ready

--- a/tests/integration/test_rl_multi_run_lora.py
+++ b/tests/integration/test_rl_multi_run_lora.py
@@ -61,7 +61,7 @@ def multi_run_result(
                 "run",
                 "torchrun",
                 "--nproc-per-node",
-                "2",
+                "1",
                 "-m",
                 "prime_rl.trainer.rl.train",
                 "@",
@@ -77,7 +77,7 @@ def multi_run_result(
             ],
             stdout=f,
             stderr=f,
-            env={**env_base, "CUDA_VISIBLE_DEVICES": "2,3"},
+            env={**env_base, "CUDA_VISIBLE_DEVICES": "1"},
         )
     processes.append(trainer_proc)
     time.sleep(10)

--- a/tests/integration/test_rl_multi_run_lora.py
+++ b/tests/integration/test_rl_multi_run_lora.py
@@ -35,11 +35,11 @@ def wait_for_file(
     Raises:
         TimeoutError: If the file does not appear within timeout.
     """
+    print(f"Waiting for {file_path} to exist")
     start_time = time.time()
     while not file_path.exists():
         if time.time() - start_time > timeout:
             raise TimeoutError(f"Timed out waiting for {file_path} to exist after {timeout}s")
-        print(f"Waiting for {file_path} to exist")
         time.sleep(poll_interval)
 
 

--- a/tests/integration/test_rl_multi_run_lora.py
+++ b/tests/integration/test_rl_multi_run_lora.py
@@ -61,7 +61,7 @@ def multi_run_result(
                 "run",
                 "torchrun",
                 "--nproc-per-node",
-                "1",
+                "2",
                 "-m",
                 "prime_rl.trainer.rl.train",
                 "@",
@@ -77,7 +77,7 @@ def multi_run_result(
             ],
             stdout=f,
             stderr=f,
-            env={**env_base, "CUDA_VISIBLE_DEVICES": "1"},
+            env={**env_base, "CUDA_VISIBLE_DEVICES": "2,3"},
         )
     processes.append(trainer_proc)
     time.sleep(10)

--- a/tests/integration/test_rl_multi_run_lora.py
+++ b/tests/integration/test_rl_multi_run_lora.py
@@ -350,7 +350,8 @@ def test_reward_goes_up(multi_run_result: dict[str, ProcessResult], output_dir: 
 
     print("Test reward goes up", multi_run_result.keys())
     for name in multi_run_result.keys():
-        if name == "beta_resume":  # Beta is resumed after saturation
+        # The resumes are close to saturation so might not go up
+        if "resume" in name:
             continue
         log_file = log_dir / f"{name}_orchestrator.stdout"
         with open(log_file, "r") as f:

--- a/tests/integration/test_rl_multi_run_lora.py
+++ b/tests/integration/test_rl_multi_run_lora.py
@@ -195,7 +195,7 @@ def multi_run_result(
     # Start orchestrators
     orch_procs: dict[str, subprocess.Popen] = {}
     for name in ORCHESTRATOR_NAMES:
-        start_orchestrator(
+        orch_procs[name] = start_orchestrator(
             name, max_steps=20, output_dir=output_dir, wandb_project=wandb_project, wandb_name=wandb_name
         )
         time.sleep(5)
@@ -239,7 +239,7 @@ def multi_run_result(
     ckpt_dir.parent.mkdir(parents=True, exist_ok=True)
     shutil.copytree(tmp_path / "alpha_ckpt_step_10", ckpt_dir)
     print(f"Copied alpha checkpoint to {ckpt_dir}")
-    start_orchestrator(
+    orch_procs["alpha_resume"] = start_orchestrator(
         "alpha_resume", max_steps=20, output_dir=output_dir, wandb_project=wandb_project, wandb_name=wandb_name
     )
 
@@ -274,7 +274,7 @@ def multi_run_result(
     ckpt_dir.parent.mkdir(parents=True, exist_ok=True)
     shutil.copytree(tmp_path / "beta_ckpt_step_20", ckpt_dir)
     print(f"Copied beta checkpoint to {ckpt_dir}")
-    start_orchestrator(
+    orch_procs["beta_resume"] = start_orchestrator(
         "beta_resume", max_steps=25, output_dir=output_dir, wandb_project=wandb_project, wandb_name=wandb_name
     )
 

--- a/tests/integration/test_rl_multi_run_lora.py
+++ b/tests/integration/test_rl_multi_run_lora.py
@@ -25,15 +25,15 @@ def wait_for_file(
     timeout: int = 300,
     poll_interval: float = 1.0,
 ) -> None:
-    """Wait for STABLE file to exist in checkpoint directory.
+    """Wait for file to exist.
 
     Args:
-        ckpt_dir: Path to the checkpoint directory.
-        timeout: Timeout waiting for STABLE file in seconds.
+        file_path: Path to the file.
+        timeout: Timeout waiting for file to exist in seconds.
         poll_interval: Interval in seconds to poll for the file.
 
     Raises:
-        TimeoutError: If the STABLE file does not appear within timeout.
+        TimeoutError: If the file does not appear within timeout.
     """
     start_time = time.time()
     while not file_path.exists() and time.time() - start_time < timeout:
@@ -52,7 +52,7 @@ def wait_for_log(
     sigterm: bool = False,
     kill: bool = False,
 ) -> None:
-    """Wait for any of the conditions to appear in log file, then optionally send SIGTERM and kill the process.
+    """Wait for any of the conditions to appear in log file, then optionally send SIGTERM or kill the process.
 
     Args:
         log_file: Path to the log file.
@@ -71,6 +71,8 @@ def wait_for_log(
             if any(cond in content for cond in conditions):
                 break
         time.sleep(poll_interval)
+    else:
+        raise TimeoutError(f"Timed out waiting for conditions {conditions} in {log_file} after {timeout}s")
 
     if sigterm:
         print(f"Sending SIGTERM to process {proc.pid}")

--- a/tests/integration/test_rl_multi_run_lora.py
+++ b/tests/integration/test_rl_multi_run_lora.py
@@ -142,9 +142,9 @@ def start_inference_and_trainer(
 def start_orchestrator(
     name: str, max_steps: int, output_dir: Path, wandb_project: str, wandb_name: str, proc_name: str | None = None
 ):
-    print(f"Starting orchestrator {name} with proc name {proc_name}")
     if proc_name is None:
         proc_name = name
+    print(f"Starting orchestrator {name} with proc name {proc_name}")
     run_dir = output_dir / f"run_{name}"
     run_dir.mkdir(parents=True, exist_ok=True)
     orch_log_dir = run_dir / "logs"

--- a/tests/integration/test_rl_multi_run_lora.py
+++ b/tests/integration/test_rl_multi_run_lora.py
@@ -61,7 +61,7 @@ def multi_run_result(
                 "run",
                 "torchrun",
                 "--nproc-per-node",
-                "1",
+                "2",
                 "-m",
                 "prime_rl.trainer.rl.train",
                 "@",
@@ -77,7 +77,7 @@ def multi_run_result(
             ],
             stdout=f,
             stderr=f,
-            env={**env_base, "CUDA_VISIBLE_DEVICES": "1"},
+            env={**env_base, "CUDA_VISIBLE_DEVICES": "2,3"},
         )
     processes.append(trainer_proc)
     time.sleep(10)
@@ -179,6 +179,8 @@ def multi_run_result(
     # Queue alpha's resume proc
     # We cant use the same dir in case the trainer misses the change
     run_dir = output_dir / "run_alpha_resume"
+    while not (run_dir / "checkpoints" / "step_10" / "trainer").exists():
+        time.sleep(1)
     shutil.copytree(tmp_path / "alpha_ckpt_step_10", run_dir / "checkpoints" / "step_10")
     print(f"Copied alpha checkpoint to {run_dir / 'checkpoints' / 'step_10'}")
     start_orchestrator("alpha_resume", max_steps=20)
@@ -191,7 +193,10 @@ def multi_run_result(
 
     run_dir = output_dir / "run_beta"
     beta_ckpt_dir = run_dir / "checkpoints" / "step_20"
+    while not (beta_ckpt_dir / "trainer").exists():
+        time.sleep(1)
     shutil.copytree(beta_ckpt_dir, tmp_path / "beta_ckpt_step_20")
+    print(f"Copied {beta_ckpt_dir} to {tmp_path / 'beta_ckpt_step_20'}")
     shutil.rmtree(run_dir)
 
     # Queue beta's resume

--- a/tests/integration/test_rl_multi_run_lora.py
+++ b/tests/integration/test_rl_multi_run_lora.py
@@ -213,13 +213,10 @@ def multi_run_result(
         sigterm=True,
     )
 
-    # Wait for trainer checkpoints to be saved
+    # Wait for trainer checkpoints to be saved (STABLE file indicates checkpoint is complete)
     alpha_ckpt_dir = output_dir / "run_alpha" / "checkpoints" / "step_10"
-    while not (alpha_ckpt_dir / "trainer").exists():
-        print(f"Waiting for {alpha_ckpt_dir / 'trainer'} to exist")
-        time.sleep(1)
-    while not (alpha_ckpt_dir / "weight").exists():
-        print(f"Waiting for {alpha_ckpt_dir / 'weight'} to exist")
+    while not (alpha_ckpt_dir / "STABLE").exists():
+        print(f"Waiting for {alpha_ckpt_dir / 'STABLE'} to exist")
         time.sleep(1)
 
     # Stash alpha checkpoint and logs
@@ -255,12 +252,9 @@ def multi_run_result(
 
     run_dir = output_dir / "run_beta"
     beta_ckpt_dir = run_dir / "checkpoints" / "step_20"
-    while not (beta_ckpt_dir / "trainer").exists():
+    while not (beta_ckpt_dir / "STABLE").exists():
         time.sleep(1)
-        print(f"Waiting for {beta_ckpt_dir / 'trainer'} to exist")
-    while not (beta_ckpt_dir / "weight").exists():
-        time.sleep(1)
-        print(f"Waiting for {beta_ckpt_dir / 'weight'} to exist")
+        print(f"Waiting for {beta_ckpt_dir / 'STABLE'} to exist")
     shutil.copy(run_dir / "logs" / "orchestrator.stdout", log_dir / "beta_orchestrator.stdout")
     shutil.copytree(beta_ckpt_dir, tmp_path / "beta_ckpt_step_20")
     print(f"Copied {beta_ckpt_dir} to {tmp_path / 'beta_ckpt_step_20'}")

--- a/tests/integration/test_rl_multi_run_lora.py
+++ b/tests/integration/test_rl_multi_run_lora.py
@@ -36,11 +36,11 @@ def wait_for_file(
         TimeoutError: If the file does not appear within timeout.
     """
     start_time = time.time()
-    while not file_path.exists() and time.time() - start_time < timeout:
+    while not file_path.exists():
+        if time.time() - start_time > timeout:
+            raise TimeoutError(f"Timed out waiting for {file_path} to exist after {timeout}s")
         print(f"Waiting for {file_path} to exist")
         time.sleep(poll_interval)
-    else:
-        raise TimeoutError(f"Timed out waiting for {file_path} to exist after {timeout}s")
 
 
 def wait_for_log(
@@ -65,14 +65,14 @@ def wait_for_log(
     """
     start_time = time.time()
     print(f"Waiting for conditions {conditions} in {proc.pid}")
-    while time.time() - start_time < timeout:
+    while True:
+        if time.time() - start_time > timeout:
+            raise TimeoutError(f"Timed out waiting for conditions {conditions} in {log_file} after {timeout}s")
         if log_file.exists():
             content = log_file.read_text()
             if any(cond in content for cond in conditions):
                 break
         time.sleep(poll_interval)
-    else:
-        raise TimeoutError(f"Timed out waiting for conditions {conditions} in {log_file} after {timeout}s")
 
     if sigterm:
         print(f"Sending SIGTERM to process {proc.pid}")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces per-run checkpointing for multi-run RL and updates orchestration/training flows to save, resume, and clean checkpoints safely.
> 
> - New `MultiCheckpointManager` with per-run `RunState` to save adapter weights, optimizer, and scheduler; supports resume via latest or specified step
> - Trainer splits single-run vs multi-run paths: keeps existing full checkpoints for single-run; uses `MultiCheckpointManager.save()` and per-run resume callbacks for multi-run; scheduler/optimizer add ordered post-creation hooks
> - Orchestrator resumes from checkpoints and now derives weight directory via `get_weight_dir`, preferring `checkpoints/step_*/weight` then `broadcasts/step_*`
> - Runs system enhanced with deletion hooks and progress syncing across ranks; improves run lifecycle handling and cleanup
> - Filesystem weight broadcast adds debug logging and cleans up run dirs when deleted
> - CI configs add `[ckpt]` to orchestrator and extend model settings; integration test rewritten to start/kill/resume orchestrators, verify STABLE checkpoints, and assert reward behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6aa808958d56706a3abd293dc32e4665d2284a73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->