### PR TITLE
refactor logging on environment in orch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,5 +33,5 @@ Documenting changes which affect configuration usage patterns (added/moved/remov
 - **`model.lora.alpha`**: Changed default from 16.0 to 32.0 (2026-01-10)
 - **`orchestrator.env.log`**: Added logging configuration for environment workers. If set, enables logging with `level` (str, default: "warn") and `vf_level` (str, default: "warn") fields. If None (default), logging is disabled (#1561, 2026-01-13)
 - **`eval.watcher`**: Added flag (default `False`) to watch `weights_dir` for newly-created stable checkpoints and evaluate them as they appear (2026-01-14)
-- **`orchestrator.log.per_worker_logs`**: Added flag (default `True`) to write env worker logs to `logs/env_workers/{env_name}.log` (2026-01-15)
+- **`orchestrator.log.env_worker_logs`**: Added flag (default `True`) to write env worker logs to `logs/env_workers/{env_name}.log` (2026-01-15)
 - **`orchestrator.env.log`**: Removed. Use `orchestrator.log` for env worker logging instead (2026-01-15)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,5 @@ Documenting changes which affect configuration usage patterns (added/moved/remov
 - **`model.lora.alpha`**: Changed default from 16.0 to 32.0 (2026-01-10)
 - **`orchestrator.env.log`**: Added logging configuration for environment workers. If set, enables logging with `level` (str, default: "warn") and `vf_level` (str, default: "warn") fields. If None (default), logging is disabled (#1561, 2026-01-13)
 - **`eval.watcher`**: Added flag (default `False`) to watch `weights_dir` for newly-created stable checkpoints and evaluate them as they appear (2026-01-14)
+- **`orchestrator.log.per_worker_logs`**: Added flag (default `True`) to write env worker logs to `logs/env_workers/{env_name}.log` (2026-01-15)
+- **`orchestrator.env.log`**: Removed. Use `orchestrator.log` for env worker logging instead (2026-01-15)

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -49,32 +49,27 @@ For RL training, logs are organized by component:
 
 ## Per-Environment Worker Logging
 
-Environment workers run in **separate subprocesses** to isolate event loop lag. By default, they don't write to separate log files. To enable per-env logging, set the `log` field on the environment config:
+Environment workers run in **separate subprocesses** to isolate event loop lag. Worker logging is controlled at the orchestrator level via `orchestrator.log`:
 
 ```toml
-[[orchestrator.env]]
-id = "math-env"
-name = "math"
-log = { level = "debug", vf_level = "info" }
+[orchestrator.log]
+level = "debug"           # Log level for prime-rl logger
+vf_level = "info"         # Log level for verifiers library
+per_worker_logs = true    # Enable file logging for env workers
 ```
 
-This produces:
+When `per_worker_logs = true`, logs are written to:
 ```
 output_dir/
 └── logs/
     └── env_workers/
-        └── math/
+        └── {env_name}/
             ├── worker_0.log
             ├── worker_1.log
             └── ...
 ```
 
-### Configuration Options
-
-| Field | Description | Default |
-|-------|-------------|---------|
-| `level` | Log level for prime-rl logger (`debug`, `info`, `warn`, `error`) | `warn` |
-| `vf_level` | Log level for verifiers library logger | `warn` |
+Set `per_worker_logs = false` to disable worker file logging (workers inherit parent process logging).
 
 ## Torchrun
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -63,11 +63,12 @@ When `per_worker_logs = true`, logs are written to:
 output_dir/
 └── logs/
     └── env_workers/
-        └── {env_name}/
-            ├── worker_0.log
-            ├── worker_1.log
-            └── ...
+        ├── {env_name_1}.log
+        ├── {env_name_2}.log
+        └── ...
 ```
+
+All workers for an environment share the same log file.
 
 Set `per_worker_logs = false` to disable worker file logging (workers inherit parent process logging).
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -55,10 +55,10 @@ Environment workers run in **separate subprocesses** to isolate event loop lag. 
 [orchestrator.log]
 level = "debug"           # Log level for prime-rl logger
 vf_level = "info"         # Log level for verifiers library
-per_worker_logs = true    # Enable file logging for env workers
+env_worker_logs = true    # Enable file logging for env workers
 ```
 
-When `per_worker_logs = true`, logs are written to:
+When `env_worker_logs = true`, logs are written to:
 ```
 output_dir/
 └── logs/
@@ -70,7 +70,7 @@ output_dir/
 
 All workers for an environment share the same log file.
 
-Set `per_worker_logs = false` to disable worker file logging (workers inherit parent process logging).
+Set `env_worker_logs = false` to disable worker file logging (workers inherit parent process logging).
 
 ## Torchrun
 

--- a/src/prime_rl/eval/eval.py
+++ b/src/prime_rl/eval/eval.py
@@ -1,7 +1,5 @@
 import asyncio
 
-import verifiers as vf
-
 from prime_rl.eval.config import OfflineEvalConfig
 from prime_rl.eval.utils import run_evals
 from prime_rl.orchestrator.utils import set_semaphore
@@ -14,7 +12,7 @@ from prime_rl.utils.client import (
     setup_evals_client,
     update_weights,
 )
-from prime_rl.utils.logger import setup_logger
+from prime_rl.utils.logger import intercept_verifiers_logging, setup_logger
 from prime_rl.utils.monitor import setup_monitor
 from prime_rl.utils.pydantic_config import parse_argv
 from prime_rl.utils.utils import clean_exit, get_env_ids_to_install, get_step_path, install_env
@@ -26,7 +24,7 @@ async def eval(config: OfflineEvalConfig):
     logger = setup_logger(
         config.log.level, log_file=config.output_dir / "logs" / "eval.log" if config.log.file else None
     )
-    vf.setup_logging(level=config.log.vf_level.upper())
+    intercept_verifiers_logging(level=config.log.vf_level)
 
     env_names = [env.name or env.id for env in config.env]
     logger.info(f"Starting evals for {config.model.name} in environments {', '.join(env_names)}")

--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -26,7 +26,7 @@ from prime_rl.orchestrator.utils import set_semaphore
 from prime_rl.synthesize.utils import merge_reasoning_content, save_result
 from prime_rl.utils.client import setup_clients, setup_evals_client
 from prime_rl.utils.config import ClientConfig
-from prime_rl.utils.logger import get_logger, reset_logger, setup_logger
+from prime_rl.utils.logger import get_logger, intercept_verifiers_logging, reset_logger, setup_logger
 from prime_rl.utils.monitor import get_monitor
 from prime_rl.utils.utils import capitalize, get_eval_dir, get_step_path
 from prime_rl.utils.vf import (
@@ -688,6 +688,7 @@ def _run_evals_in_subprocess(
     # Setup logger for subprocess (reset first since we inherit parent's global state when forked)
     reset_logger()
     logger = setup_logger("info")
+    intercept_verifiers_logging(level="info")
     logger.info(f"Eval subprocess started for checkpoint step {ckpt_step}")
 
     # Create fresh clients in subprocess

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -297,30 +297,12 @@ class RetryConfig(BaseConfig):
     ] = False
 
 
-class EnvLogConfig(BaseConfig):
-    """Configures logging for an environment worker."""
-
-    level: Annotated[
-        str,
-        Field(description="Log level for prime-rl logger in worker (debug, info, warn, error)."),
-    ] = "warn"
-
-    vf_level: Annotated[
-        str,
-        Field(description="Log level for verifiers logger in worker (debug, info, warn, error)."),
-    ] = "warn"
-
-
 class EnvConfig(BaseConfig):
     """Configures an environment for training."""
 
     id: Annotated[str, Field(description="ID of the environment to use.")] = "reverse-text"
     args: Annotated[dict, Field(description="Arguments to pass to the environment.")] = {}
     name: Annotated[str | None, Field(description="Name of the environment to use.")] = None
-    log: Annotated[
-        EnvLogConfig | None,
-        Field(description="Logging config for this env's workers. If None, logging is disabled."),
-    ] = None
 
 
 class EvalEnvConfig(EnvConfig):

--- a/src/prime_rl/orchestrator/env_worker.py
+++ b/src/prime_rl/orchestrator/env_worker.py
@@ -5,7 +5,6 @@ Runs environment rollouts in a separate process to isolate event loop lag.
 """
 
 import asyncio
-import logging
 import queue
 import uuid
 from dataclasses import dataclass
@@ -18,7 +17,7 @@ from openai import AsyncOpenAI
 
 from prime_rl.utils.client import setup_clients
 from prime_rl.utils.config import ClientConfig
-from prime_rl.utils.logger import reset_logger, setup_logger
+from prime_rl.utils.logger import intercept_verifiers_logging, reset_logger, setup_logger
 
 
 class WorkerDiedError(Exception):
@@ -194,13 +193,7 @@ def worker_main(
     if log_file:
         reset_logger()
         setup_logger(log_level, log_file=Path(log_file), append=True)
-        vf.setup_logging(level=vf_log_level.upper())
-        # Redirect verifiers to file instead of inherited stderr (append mode for shared file)
-        vf_logger = logging.getLogger("verifiers")
-        vf_logger.handlers.clear()
-        vf_handler = logging.FileHandler(log_file, mode="a")
-        vf_handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)7s %(message)s", datefmt="%H:%M:%S"))
-        vf_logger.addHandler(vf_handler)
+        intercept_verifiers_logging(level=vf_log_level)
 
     # Load environment
     env = vf.load_environment(env_id, **env_args)

--- a/src/prime_rl/orchestrator/env_worker.py
+++ b/src/prime_rl/orchestrator/env_worker.py
@@ -187,12 +187,13 @@ def worker_main(
     log_level: str,
     vf_log_level: str,
     log_file: str | None,
+    worker_name: str | None = None,
 ):
     """Main entry point for worker process."""
     # Reset logger inherited from parent process, then setup fresh logger for this worker
     if log_file:
         reset_logger()
-        setup_logger(log_level, log_file=Path(log_file), append=True)
+        setup_logger(log_level, log_file=Path(log_file), append=True, tag=worker_name)
         intercept_verifiers_logging(level=vf_log_level)
 
     # Load environment
@@ -286,6 +287,7 @@ class EnvWorker:
                 self.log_level,
                 self.vf_log_level,
                 self.log_file,
+                self.worker_name,
             ),
             daemon=True,
         )

--- a/src/prime_rl/orchestrator/env_worker.py
+++ b/src/prime_rl/orchestrator/env_worker.py
@@ -193,12 +193,12 @@ def worker_main(
     # Reset logger inherited from parent process, then setup fresh logger for this worker
     if log_file:
         reset_logger()
-        setup_logger(log_level, log_file=Path(log_file))
+        setup_logger(log_level, log_file=Path(log_file), append=True)
         vf.setup_logging(level=vf_log_level.upper())
-        # Redirect verifiers to file instead of inherited stderr
+        # Redirect verifiers to file instead of inherited stderr (append mode for shared file)
         vf_logger = logging.getLogger("verifiers")
         vf_logger.handlers.clear()
-        vf_handler = logging.FileHandler(log_file)
+        vf_handler = logging.FileHandler(log_file, mode="a")
         vf_handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)7s %(message)s", datefmt="%H:%M:%S"))
         vf_logger.addHandler(vf_handler)
 

--- a/src/prime_rl/orchestrator/event_loop_lag.py
+++ b/src/prime_rl/orchestrator/event_loop_lag.py
@@ -71,10 +71,6 @@ class EventLoopLagMonitor:
             self.logger.warning(
                 f"Detected busy event loop. Measured {mean_lag:.1f}s (min={min_lag:.1f}s, med={med_lag:.1f}s, p90={p90_lag:.1f}s, max={max_lag:.1f}s) event loop lag over the last {len(last_lags)} measurement(s)"
             )
-        else:
-            self.logger.debug(
-                f"Event loop is running smoothly. Measured {mean_lag:.1f}s (min={min_lag:.1f}s, med={med_lag:.1f}s, p90={p90_lag:.1f}s, max={max_lag:.1f}s) event loop lag over the last {len(last_lags)} measurement(s)"
-            )
 
         return {
             "event_loop_lag/min": min_lag,

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -44,7 +44,7 @@ from prime_rl.utils.client import (
     update_weights,
 )
 from prime_rl.utils.heartbeat import Heartbeat
-from prime_rl.utils.logger import setup_logger
+from prime_rl.utils.logger import intercept_verifiers_logging, setup_logger
 from prime_rl.utils.monitor import setup_monitor
 from prime_rl.utils.pydantic_config import parse_argv
 from prime_rl.utils.utils import (
@@ -66,7 +66,7 @@ async def orchestrate(config: OrchestratorConfig):
     logger = setup_logger(
         config.log.level, log_file=config.output_dir / "logs" / "orchestrator.log" if config.log.file else None
     )
-    vf.setup_logging(level=config.log.vf_level.upper())
+    intercept_verifiers_logging(level=config.log.vf_level)
     logger.info("Starting orchestrator")
 
     event_loop_lag_monitor = EventLoopLagMonitor()

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -19,7 +19,7 @@ from prime_rl.orchestrator.utils import get_sampling_args
 from prime_rl.utils.client import update_weights
 from prime_rl.utils.config import ClientConfig
 from prime_rl.utils.logger import get_logger
-from prime_rl.utils.pathing import get_env_worker_log_dir
+from prime_rl.utils.pathing import get_env_worker_log_file
 from prime_rl.utils.utils import (
     get_broadcast_dir,
     get_latest_ckpt_step,
@@ -92,11 +92,11 @@ class Scheduler:
             self.env_names.append(env_name)
             self.workers[env_name] = []
 
-            # Setup log directory if env worker file logging is enabled
-            env_log_dir = None
+            # Setup log file if env worker file logging is enabled (all workers share one file)
+            env_log_file = None
             if config.log.per_worker_logs and output_dir is not None:
-                env_log_dir = get_env_worker_log_dir(output_dir, env_name)
-                env_log_dir.mkdir(parents=True, exist_ok=True)
+                env_log_file = get_env_worker_log_file(output_dir, env_name)
+                env_log_file.parent.mkdir(parents=True, exist_ok=True)
 
             for worker_idx in range(self.workers_per_env):
                 worker = EnvWorker(
@@ -112,7 +112,7 @@ class Scheduler:
                     worker_name=f"{env_name}_{worker_idx}",
                     log_level=config.log.level,
                     vf_log_level=config.log.vf_level,
-                    log_file=str(env_log_dir / f"worker_{worker_idx}.log") if env_log_dir else None,
+                    log_file=str(env_log_file) if env_log_file else None,
                 )
                 self.workers[env_name].append(worker)
 

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -92,10 +92,9 @@ class Scheduler:
             self.env_names.append(env_name)
             self.workers[env_name] = []
 
-            # Setup log directory if logging is enabled for this env
-            env_log = env_config.log
+            # Setup log directory if env worker file logging is enabled
             env_log_dir = None
-            if env_log is not None and output_dir is not None:
+            if config.log.per_worker_logs and output_dir is not None:
                 env_log_dir = get_env_worker_log_dir(output_dir, env_name)
                 env_log_dir.mkdir(parents=True, exist_ok=True)
 
@@ -111,8 +110,8 @@ class Scheduler:
                     example_lookup=self.example_lookups[env_name],
                     sampling_args=self.sampling_args,
                     worker_name=f"{env_name}_{worker_idx}",
-                    log_level=env_log.level if env_log else "warn",
-                    vf_log_level=env_log.vf_level if env_log else "warn",
+                    log_level=config.log.level,
+                    vf_log_level=config.log.vf_level,
                     log_file=str(env_log_dir / f"worker_{worker_idx}.log") if env_log_dir else None,
                 )
                 self.workers[env_name].append(worker)

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -94,7 +94,7 @@ class Scheduler:
 
             # Setup log file if env worker file logging is enabled (all workers share one file)
             env_log_file = None
-            if config.log.per_worker_logs and output_dir is not None:
+            if config.log.env_worker_logs and output_dir is not None:
                 env_log_file = get_env_worker_log_file(output_dir, env_name)
                 env_log_file.parent.mkdir(parents=True, exist_ok=True)
 

--- a/src/prime_rl/synthesize/synthesize.py
+++ b/src/prime_rl/synthesize/synthesize.py
@@ -1,7 +1,5 @@
 import asyncio
 
-import verifiers as vf
-
 from prime_rl.orchestrator.utils import (
     set_semaphore,
 )
@@ -13,7 +11,7 @@ from prime_rl.utils.client import (
     setup_admin_clients,
     setup_clients,
 )
-from prime_rl.utils.logger import setup_logger
+from prime_rl.utils.logger import intercept_verifiers_logging, setup_logger
 from prime_rl.utils.pydantic_config import parse_argv
 from prime_rl.utils.utils import clean_exit, get_env_ids_to_install, install_env
 
@@ -24,7 +22,7 @@ async def synthesize(config: SynthesizeConfig):
     logger = setup_logger(
         config.log.level, log_file=config.output_dir / "logs" / "synthesize.log" if config.log.file else None
     )
-    vf.setup_logging(level=config.log.vf_level.upper())
+    intercept_verifiers_logging(level=config.log.vf_level)
 
     env_names = [env.name or env.id for env in config.env]
     logger.info(f"Starting synthetic data generation for {config.model.name} in environments {', '.join(env_names)}")

--- a/src/prime_rl/utils/config.py
+++ b/src/prime_rl/utils/config.py
@@ -76,7 +76,7 @@ class LogConfig(BaseConfig):
     per_worker_logs: Annotated[
         bool,
         Field(
-            description="Whether env workers log to separate files. If True, each worker writes to logs/env_workers/{env_name}/worker_{N}.log.",
+            description="Whether env workers log to files. If True, workers write to logs/env_workers/{env_name}.log.",
         ),
     ] = True
 

--- a/src/prime_rl/utils/config.py
+++ b/src/prime_rl/utils/config.py
@@ -73,6 +73,13 @@ class LogConfig(BaseConfig):
         ),
     ] = True
 
+    per_worker_logs: Annotated[
+        bool,
+        Field(
+            description="Whether env workers log to separate files. If True, each worker writes to logs/env_workers/{env_name}/worker_{N}.log.",
+        ),
+    ] = True
+
     log_data: Annotated[
         bool,
         Field(

--- a/src/prime_rl/utils/config.py
+++ b/src/prime_rl/utils/config.py
@@ -73,7 +73,7 @@ class LogConfig(BaseConfig):
         ),
     ] = True
 
-    per_worker_logs: Annotated[
+    env_worker_logs: Annotated[
         bool,
         Field(
             description="Whether env workers log to files. If True, workers write to logs/env_workers/{env_name}.log.",

--- a/src/prime_rl/utils/logger.py
+++ b/src/prime_rl/utils/logger.py
@@ -8,7 +8,7 @@ NO_BOLD = "\033[22m"
 RESET = "\033[0m"
 
 
-def setup_logger(log_level: str, log_file: Path | None = None):
+def setup_logger(log_level: str, log_file: Path | None = None, append: bool = False):
     global _LOGGER
     if _LOGGER is not None:
         raise RuntimeError("Logger already set. Please call `setup_logger` only once.")
@@ -52,7 +52,7 @@ def setup_logger(log_level: str, log_file: Path | None = None):
 
     # If specified, install file handler
     if log_file is not None:
-        if log_file.exists():
+        if not append and log_file.exists():
             log_file.unlink()
         logger.add(log_file, format=format, level=log_level.upper(), colorize=True)
 

--- a/src/prime_rl/utils/logger.py
+++ b/src/prime_rl/utils/logger.py
@@ -27,17 +27,18 @@ class _VerifiersInterceptHandler(logging.Handler):
         logger.opt(depth=depth, exception=record.exc_info).log(level, f"[verifiers] {record.getMessage()}")
 
 
-def setup_logger(log_level: str, log_file: Path | None = None, append: bool = False):
+def setup_logger(log_level: str, log_file: Path | None = None, append: bool = False, tag: str | None = None):
     global _LOGGER
     if _LOGGER is not None:
         raise RuntimeError("Logger already set. Please call `setup_logger` only once.")
 
-    # Format message
+    # Format message with optional tag prefix
+    tag_prefix = f"[{tag}] " if tag else ""
     message = "".join(
         [
             " <level>{level: >7}</level>",
             f" <level>{NO_BOLD}",
-            "{message}",
+            f"{tag_prefix}{{message}}",
             f"{RESET}</level>",
         ]
     )

--- a/src/prime_rl/utils/pathing.py
+++ b/src/prime_rl/utils/pathing.py
@@ -29,8 +29,8 @@ def get_broadcast_dir(output_dir: Path) -> Path:
     return output_dir / "broadcasts"
 
 
-def get_env_worker_log_dir(output_dir: Path, env_name: str) -> Path:
-    return output_dir / "logs" / "env_workers" / env_name
+def get_env_worker_log_file(output_dir: Path, env_name: str) -> Path:
+    return output_dir / "logs" / "env_workers" / f"{env_name}.log"
 
 
 def get_step_path(path: Path, step: int) -> Path:


### PR DESCRIPTION
* [x] refactor ui, add per_worker_logs instead of log = {} 
* [x] https://github.com/PrimeIntellect-ai/prime-rl/pull/1592
* [x] log all worker to one file instead of per worker log file
* [x] intercept all verifier log and turn them into loguru one with verifer tag


example of verifier interception
```
01:26:31 WARNING [verifiers] LoggingDebugEnv WARNING: this is a test warning
01:26:31    INFO [verifiers] Successfully loaded environment 'prime_rl.debug_env'
01:26:31 WARNING [verifiers] LoggingDebugEnv is configured to use interleaved rollouts. All model responses after the first turn will be pre-tokenized before being sent to the model. Currently, this is a hand-crafted feature for PRIME-RL's vLLM server extension.
01:26:31    INFO [verifiers] Loading environment: prime_rl.debug_env
01:26:31    INFO [verifiers] Using provided args: fail_rate=0.2, retry_rate=0.3, slow_rate=0.1, num_examples=20
01:26:31    INFO [verifiers] Using default args: error_rate=0.3
01:26:31    INFO [verifiers] Initialized RubricGroup with 2 rubrics
01:26:31    INFO [verifiers] LoggingDebugEnv INFO: ready to process examples
01:26:31 WARNING [verifiers] LoggingDebugEnv WARNING: this is a test warning
01:26:31    INFO [verifiers] Successfully loaded environment 'prime_rl.debug_env'
01:26:31 WARNING [verifiers] LoggingDebugEnv is configured to use interleaved rollouts. All model responses after the first turn will be pre-tokenized before being sent to the model. Currently, this is a hand-crafted feature for PRIME-RL's vLLM server extension.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes logging across orchestrator, eval, and synthesize.
> 
> - Introduces `orchestrator.log.env_worker_logs` and removes `orchestrator.env.log`; env workers now write to a single file per env: `logs/env_workers/{env_name}.log`
> - Adds `intercept_verifiers_logging` to route stdlib `verifiers` logs into our loguru logger (tagged `[verifiers]`); applied in orchestrator, eval, synthesize, and eval subprocesses
> - Updates worker logging: pass shared log file, append mode, and optional per-worker tag; scheduler wires levels from `orchestrator.log`
> - Replaces `get_env_worker_log_dir` with `get_env_worker_log_file`; docs and CHANGELOG updated accordingly; removes `EnvLogConfig` and related fields
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6578743380fed55019c138fa700dd3571647c77c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->