### PR TITLE
Fix trainer crash when all rollouts in a batch fail

### DIFF
--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -215,6 +215,10 @@ class Tensors(defaultdict):
             tensors = flexible_all_gather(tensors)
             assert tensors.ndim == 1, "Can only aggregate 1D tensors"
 
+            # Skip empty tensors (can happen when all rollouts in a batch fail)
+            if tensors.numel() == 0:
+                continue
+
             # Compute relevant tensor statistics
             metrics[f"{key}/mean"] = tensors.mean().item()
             metrics[f"{key}/median"] = torch.median(tensors).item()

--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -215,8 +215,13 @@ class Tensors(defaultdict):
             tensors = flexible_all_gather(tensors)
             assert tensors.ndim == 1, "Can only aggregate 1D tensors"
 
-            # Skip empty tensors (can happen when all rollouts in a batch fail)
+            # Handle empty tensors (can happen when all rollouts in a batch fail)
             if tensors.numel() == 0:
+                metrics[f"{key}/mean"] = float("nan")
+                metrics[f"{key}/median"] = float("nan")
+                metrics[f"{key}/std"] = float("nan")
+                metrics[f"{key}/min"] = float("nan")
+                metrics[f"{key}/max"] = float("nan")
                 continue
 
             # Compute relevant tensor statistics


### PR DESCRIPTION
## Summary
- Fixes crash when all rollouts fail and tensor is empty
- Adds guard to skip stats computation for empty tensors

## Context
Discovered while testing diplomacy environment - multi-turn conversations can exceed context limits, causing all rollouts to fail occasionally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents a crash during distributed stats aggregation when batches produce no valid rollouts.
> 
> - In `Tensors.compute_stats`, after `flexible_all_gather`, detect empty 1D tensors and record `NaN` for `mean/median/std/min/max`, skipping computation
> - Leaves non-empty path unchanged; still gathers tensors and appends aggregated values back to the accumulator
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13ea8f9df1c84c1ed31a08937f9cc46c6a80d646. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->