### PR TITLE
fix eval order

### DIFF
--- a/src/prime_rl/eval/eval.py
+++ b/src/prime_rl/eval/eval.py
@@ -125,7 +125,7 @@ async def eval(config: OfflineEvalConfig):
                 return False
 
         logger.info(f"Evaluating {len(ckpt_steps)} weight checkpoints (steps: {', '.join(map(str, ckpt_steps))})")
-        for ckpt_step in ckpt_steps[::-1]:
+        for ckpt_step in ckpt_steps:
             await _eval_ckpt(ckpt_step)
 
         if config.watcher:


### PR DESCRIPTION
order need to be increasing for eval or it break wandb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Eval sequencing**
> 
> - Updates `eval.py` to iterate `ckpt_steps` in ascending order (removes reverse iteration), changing the evaluation sequence of stable checkpoints.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a02b185af347a0b6b480cdfaaefc8114e6055db7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->