### PR TITLE
Add InfiniBand libraries for NCCL multi-node support

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -62,6 +62,9 @@ RUN apt-get update && apt-get install -y \
     net-tools \
     curl \
     vim \
+    # InfiniBand/RDMA libraries for NCCL multi-node communication
+    libibverbs1 \
+    ibverbs-providers \
     && apt-get clean autoclean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
## Summary
- Add libibverbs1 and ibverbs-providers packages to Docker image
- Enables NCCL to use InfiniBand for inter-node GPU communication
- Without these, NCCL falls back to TCP sockets (~40x slower)

## Context
Found that multi-node training on Nebius MK8S cluster was using TCP sockets instead of InfiniBand because libibverbs.so was missing from the container. This was causing 0.2% MFU on 235B model training.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds required RDMA libraries to the runtime image to enable high-speed NCCL multi-node communication over InfiniBand.
> 
> - Installs `libibverbs1` and `ibverbs-providers` in `Dockerfile.cuda`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 693d6bbddc21ab7e905132db6c54a3f19fa0d59b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->