### PR TITLE
Add InfiniBand libraries for NCCL multi-node support

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -62,6 +62,9 @@ RUN apt-get update && apt-get install -y \
     net-tools \
     curl \
     vim \
+    # InfiniBand/RDMA libraries for NCCL multi-node communication
+    libibverbs1 \
+    ibverbs-providers \
     && apt-get clean autoclean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -62,7 +62,6 @@ RUN apt-get update && apt-get install -y \
     net-tools \
     curl \
     vim \
-    # InfiniBand/RDMA libraries for NCCL multi-node communication
     libibverbs1 \
     ibverbs-providers \
     && apt-get clean autoclean \


### PR DESCRIPTION
Add libibverbs1 and ibverbs-providers to enable NCCL IB transport for multi-node training.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds InfiniBand userspace libraries to the runtime image to enable NCCL over IB for multi-node training.
> 
> - Updates `Dockerfile.cuda` to install `libibverbs1` and `ibverbs-providers` in the final stage
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0766ae0f74ab658190ed65392f4f71d1374a3239. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->