### PR TITLE
Sami/fix logging env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,6 @@ Documenting changes which affect configuration usage patterns (added/moved/remov
 - **`model.lora.alpha`**: Changed default from 16.0 to 32.0 (2026-01-10)
 - **`orchestrator.env.log`**: Added logging configuration for environment workers. If set, enables logging with `level` (str, default: "warn") and `vf_level` (str, default: "warn") fields. If None (default), logging is disabled (#1561, 2026-01-13)
 - **`eval.watcher`**: Added flag (default `False`) to watch `weights_dir` for newly-created stable checkpoints and evaluate them as they appear (2026-01-14)
-- **`orchestrator.log.env_worker_logs`**: Added flag (default `True`) to write env worker logs to `logs/env_workers/{env_name}.log` (2026-01-15)
+- **`orchestrator.log.env_worker_logs`**: Added flag (default `False`) to write env worker logs to `logs/env_workers/{env_name}.log` (2026-01-15)
 - **`orchestrator.env.log`**: Removed. Use `orchestrator.log` for env worker logging instead (2026-01-15)
 - **`orchestrator.eval.retry.reraise`**: Changed default from `True` to `False`. When `False`, raises `tenacity.RetryError` after retries are exhausted instead of the original exception, allowing failed eval environments to be skipped with a warning (#1586, 2026-01-14)

--- a/src/prime_rl/utils/config.py
+++ b/src/prime_rl/utils/config.py
@@ -78,7 +78,7 @@ class LogConfig(BaseConfig):
         Field(
             description="Whether env workers log to files. If True, workers write to logs/env_workers/{env_name}.log.",
         ),
-    ] = True
+    ] = False
 
     log_data: Annotated[
         bool,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Logging defaults**
> 
> - Changes default of `orchestrator.log.env_worker_logs` to `False` in `src/prime_rl/utils/config.py`.
> - Updates `CHANGELOG.md` to reflect the new default and note use of `orchestrator.log` for env worker logging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bee65b08f2a4674a2a18ae267cb7d5806dd0d65a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->