### PR TITLE
fix logging

### DIFF
--- a/src/prime_rl/utils/logger.py
+++ b/src/prime_rl/utils/logger.py
@@ -67,14 +67,13 @@ def setup_logger(log_level: str, log_file: Path | None = None, append: bool = Fa
         extra={},
     )
 
-    # Install console handler
-    logger.add(sys.stdout, format=format, level=log_level.upper(), colorize=True)
-
-    # If specified, install file handler
+    # If log_file is specified, write only to file (used by workers); otherwise write to stdout
     if log_file is not None:
         if not append and log_file.exists():
             log_file.unlink()
-        logger.add(log_file, format=format, level=log_level.upper(), colorize=True)
+        logger.add(log_file, format=format, level=log_level.upper(), colorize=False)
+    else:
+        logger.add(sys.stdout, format=format, level=log_level.upper(), colorize=True)
 
     # Disable critical logging
     logger.critical = lambda _: None


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refines logger setup to avoid duplicate handlers and ensure correct output targets.
> 
> - When `log_file` is provided, logs now go only to that file (no stdout), with `colorize=False`
> - When no `log_file` is provided, logs go to `stdout` with `colorize=True`
> - Removes unconditional stdout handler to prevent duplicate logs, especially for worker processes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e9cfa3ef2768c57452db1ae6ea2b59b4fd57c74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->