### PR TITLE
adjust multi run test args to be less flaky

### DIFF
--- a/configs/ci/integration/rl_multi_run/orchestrator.toml
+++ b/configs/ci/integration/rl_multi_run/orchestrator.toml
@@ -9,7 +9,7 @@ max_steps = 20
 name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
 
 [optim]
-lr = 2e-5
+lr = 3e-5
 
 [sampling]
 max_tokens = 128

--- a/tests/integration/test_rl_multi_run_lora.py
+++ b/tests/integration/test_rl_multi_run_lora.py
@@ -227,5 +227,5 @@ def test_reward_in_range(multi_run_result: tuple[dict[str, ProcessResult], str],
         log_file = output_dir / f"run_{name}" / "logs" / "orchestrator.stdout"
         with open(log_file, "r") as f:
             lines = strip_escape_codes(f.read()).splitlines()
-        check_number_in_range(lines, step=9, min_threshold=0.2, max_threshold=0.6, pattern=r"Reward:\s*(\d+\.\d{4})")
+        check_number_in_range(lines, step=7, min_threshold=0.2, max_threshold=0.6, pattern=r"Reward:\s*(\d+\.\d{4})")
         check_number_in_range(lines, min_threshold=0.65, pattern=r"Reward:\s*(\d+\.\d{4})")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjusts RL multi-run config and test expectations.
> 
> - Bumps `optim.lr` in `configs/ci/integration/rl_multi_run/orchestrator.toml` from `2e-5` to `3e-5`
> - Updates `test_reward_in_range` in `tests/integration/test_rl_multi_run_lora.py` to check reward at `step=7` (was 9) while keeping final reward bounds checks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d3ec3b170cbaf3c3732b70698f3bc77bd11330c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
