### PR TITLE
feat: add no_upgrade config option for environment installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,4 @@ Documenting changes which affect configuration usage patterns (added/moved/remov
 - **`orchestrator.env.log`**: Removed. Use `orchestrator.log` for env worker logging instead (2026-01-15)
 - **`orchestrator.eval.retry.reraise`**: Changed default from `True` to `False`. When `False`, raises `tenacity.RetryError` after retries are exhausted instead of the original exception, allowing failed eval environments to be skipped with a warning (#1586, 2026-01-14)
 - **`model.ep`**: Expert parallelism now supported (with auto/custom impl only), changed from the old behaviour when `ep>1` was a no-op to a proper parallelization of the MoE layers. (#1595, 2026-01-15)
+- **`env.no_upgrade`**: Added flag (default `False`) to pass `--no-upgrade` to `prime env install`, preserving locked dependencies instead of upgrading packages (2026-01-19)

--- a/src/prime_rl/eval/eval.py
+++ b/src/prime_rl/eval/eval.py
@@ -32,8 +32,8 @@ async def eval(config: OfflineEvalConfig):
 
     # Install environments
     env_ids_to_install = get_env_ids_to_install(config.env)
-    for env_id in env_ids_to_install:
-        install_env(env_id)
+    for env_id, no_upgrade in env_ids_to_install.items():
+        install_env(env_id, no_upgrade=no_upgrade)
 
     # Initialize the monitor
     logger.info(f"Initializing monitor ({config.wandb})")

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -303,6 +303,10 @@ class EnvConfig(BaseConfig):
     id: Annotated[str, Field(description="ID of the environment to use.")] = "reverse-text"
     args: Annotated[dict, Field(description="Arguments to pass to the environment.")] = {}
     name: Annotated[str | None, Field(description="Name of the environment to use.")] = None
+    no_upgrade: Annotated[
+        bool,
+        Field(description="If True, don't upgrade existing packages during install. Useful with locked dependencies."),
+    ] = False
 
 
 class EvalEnvConfig(EnvConfig):

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -83,13 +83,17 @@ async def orchestrate(config: OrchestratorConfig):
         tomli_w.dump(config.model_dump(exclude_none=True, mode="json"), f)
 
     # Install environments
-    env_ids_to_install = set()
-    env_ids_to_install.update(get_env_ids_to_install(config.env))
+    env_ids_to_install: dict[str, bool] = {}
+    for env_id, no_upgrade in get_env_ids_to_install(config.env).items():
+        existing = env_ids_to_install.get(env_id, False)
+        env_ids_to_install[env_id] = existing or no_upgrade
     if config.eval is not None:
-        env_ids_to_install.update(get_env_ids_to_install(config.eval.env))
+        for env_id, no_upgrade in get_env_ids_to_install(config.eval.env).items():
+            existing = env_ids_to_install.get(env_id, False)
+            env_ids_to_install[env_id] = existing or no_upgrade
 
-    for env_id in env_ids_to_install:
-        install_env(env_id)
+    for env_id, no_upgrade in env_ids_to_install.items():
+        install_env(env_id, no_upgrade=no_upgrade)
 
     # Setup client
     logger.info(

--- a/src/prime_rl/synthesize/synthesize.py
+++ b/src/prime_rl/synthesize/synthesize.py
@@ -30,8 +30,8 @@ async def synthesize(config: SynthesizeConfig):
 
     # Install environments
     env_ids_to_install = get_env_ids_to_install(config.env)
-    for env_id in env_ids_to_install:
-        install_env(env_id)
+    for env_id, no_upgrade in env_ids_to_install.items():
+        install_env(env_id, no_upgrade=no_upgrade)
 
     # Setup clients
     logger.info(


### PR DESCRIPTION
Add a `no_upgrade` field to `EnvConfig` that controls whether the `--no-upgrade` flag is passed to `prime env install`. This prevents the install command from upgrading existing packages, preserving locked dependencies (e.g., from `uv.lock`). A useful option to have for when orchestrator auto-installs the specified environments in config (currently just uses the default behavior of prime env install).

  Follow-up PR to https://github.com/PrimeIntellect-ai/prime/pull/295 (CC @JannikSt)

  ## Changes:
  - Add `no_upgrade: bool = False` to `EnvConfig`
  - Update `install_env()` to accept and pass `--no-upgrade` flag
  - Update `get_env_ids_to_install()` to return dict with no_upgrade settings
  - Update all callers (eval, orchestrator, synthesize) to use new API
  
  ## Usage

  In your `rl.toml` config, add `no_upgrade = true` to any environment that should preserve locked dependencies:

  ```toml
  [[env]]
  id = "will/wordle"
  no_upgrade = true
```

```toml
  [[env]]
  id = "other/env"
  # no_upgrade defaults to false, so this env will use normal upgrade behavior
```

  This is useful when:
  - You have a uv.lock file and want to preserve exact dependency versions
  - An environment's dependencies conflict with your project's pinned versions
  - You need reproducible builds with consistent package versions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a configuration to preserve locked dependencies during environment installation.
> 
> - Adds `env.no_upgrade: bool` to `EnvConfig` and documents it in `CHANGELOG.md`
> - Updates `install_env(env_id, no_upgrade=False)` to pass `--no-upgrade` to `prime env install` when set
> - Changes `get_env_ids_to_install` to return a `{env_id: no_upgrade}` map and merge duplicates preferring `True`
> - Updates callers in `eval`, `orchestrator`, and `synthesize` to use the new API; orchestrator merges train/eval envs with `no_upgrade=True` precedence
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86ec5d927821f80e5bc361e16fc2a43ece4eccd2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->