### PR TITLE
Improve log message on orchestrator for hosted rl

### DIFF
--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -184,7 +184,8 @@ class Scheduler:
         if next_ckpt_step > self.ckpt_step:
             if next_ckpt_step == async_away_ckpt_step:
                 self.logger.info(
-                    f"Hit async barrier because we are >{self.max_async_level} step(s) async. Waiting for checkpoint {next_ckpt_step}"
+                    f"Orchestrator paused: waiting for trainer process to complete checkpoint {next_ckpt_step} "
+                    f"(>{self.max_async_level} step(s) ahead). Training is progressing normally."
                 )
                 self.checkpoint_ready.clear()
                 wait_for_ckpt_start_time = time.perf_counter()


### PR DESCRIPTION
Previous message made it seem like training was blocked, since user could only see orchestrator logs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves clarity of orchestrator logging during async checkpoint waits.
> 
> - Updates the info-level message in `Scheduler.update_policy` when hitting the async barrier to state the orchestrator is paused waiting for checkpoint `next_ckpt_step` and that training is progressing normally
> - No functional changes; only log wording adjusted
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4a5142a8aff55a859b75034e7dbd61cd9db45b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->