### PR TITLE
Fix timeout overcounting

### DIFF
--- a/src/prime_rl/trainer/rl/packer.py
+++ b/src/prime_rl/trainer/rl/packer.py
@@ -132,10 +132,7 @@ class MultiPacker(BasePacker):
             for sample in batch.examples:
                 self.buffers[batch.run_idx].append((sample, batch.temperature, batch.step))
 
-    def _has_enough_tokens(self) -> bool:
-        """Check if we have enough samples in buffer to pack a step"""
-        # When not using small batch granularity, require at least one full batch
-        threshold = self.seq_len * self.dp_world_size
+    def _count_tokens(self, threshold: int | None = None) -> int:
         tokens = 0
 
         for run_idx in self.runs.used_idxs:
@@ -145,9 +142,15 @@ class MultiPacker(BasePacker):
                 if step != current_step:
                     continue
                 tokens += len(sample.prompt_ids) + len(sample.completion_ids)
-                if tokens >= threshold:
-                    return True
-        return False
+                if threshold is not None and tokens >= threshold:
+                    return tokens
+        return tokens
+
+    def _has_enough_tokens(self) -> bool:
+        """Check if we have enough samples in buffer to pack a step"""
+        # When not using small batch granularity, require at least one full batch
+        threshold = self.seq_len * self.dp_world_size
+        return self._count_tokens(threshold) >= threshold
 
     def _select_samples_round_robin(self, token_budget: int) -> list[tuple[int, TrainingSample, float]]:
         """Select samples using round-robin from runs with buffered work."""
@@ -208,7 +211,7 @@ class MultiPacker(BasePacker):
         start_time = time.time()
 
         while not self._has_enough_tokens():
-            if time.time() - start_time > TIMEOUT_SECONDS and any(len(i) > 0 for i in self.buffers):
+            if time.time() - start_time > TIMEOUT_SECONDS and self._count_tokens() > 0:
                 self.logger.warning("Timeout waiting for enough tokens to pack")
                 break
             time.sleep(1)

--- a/src/prime_rl/trainer/rl/packer.py
+++ b/src/prime_rl/trainer/rl/packer.py
@@ -17,7 +17,7 @@ from prime_rl.transport import (
 from prime_rl.utils.logger import get_logger
 from prime_rl.utils.pathing import get_rollout_dir
 
-TIMEOUT_SECONDS = 10
+TIMEOUT_SECONDS = 0.1
 
 
 class BasePacker(ABC):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes token accounting in `MultiPacker` to consider only current-step tokens and adjusts timeout behavior.
> 
> - Add `_count_tokens()` and use it in `_has_enough_tokens()` to gate packing by accurate token thresholds
> - Change timeout condition in `pack()` to use `_count_tokens() > 0` (instead of any buffered samples) to avoid overcounting
> - Reduce `TIMEOUT_SECONDS` from 10 to 0.1 for faster timeout handling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a4fef63e5b15af40902d4a91c877203dbc86ebe5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->