### PR TITLE
fix comma in benchmark json

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -84,7 +84,7 @@ jobs:
             {"model":"Qwen/Qwen3-235B-A22B-Instruct-2507","runner":"8xb200","num_gpus":8,"type":"rl","lora_rank":16,"seq_len":16384,"attention":"flash_attention_2","ac":"Recompute","cp":1,"ep":1,"timeout_minutes":120},
             {"model":"Qwen/Qwen3-235B-A22B-Instruct-2507","runner":"8xb200","num_gpus":8,"type":"rl","lora_rank":16,"seq_len":16384,"attention":"flash_attention_2","ac":"Offload","cp":1,"ep":1,"timeout_minutes":120},
             {"model":"Qwen/Qwen3-235B-A22B-Instruct-2507","runner":"8xb200","num_gpus":8,"type":"rl","lora_rank":16,"seq_len":16384,"attention":"flash_attention_2","ac":"Recompute","cp":2,"ep":1,"timeout_minutes":120},
-            {"model":"Qwen/Qwen3-235B-A22B-Instruct-2507","runner":"8xb200","num_gpus":8,"type":"rl","lora_rank":16,"seq_len":16384,"attention":"flash_attention_2","ac":"Recompute","cp":1,"ep":2,"timeout_minutes":120},
+            {"model":"Qwen/Qwen3-235B-A22B-Instruct-2507","runner":"8xb200","num_gpus":8,"type":"rl","lora_rank":16,"seq_len":16384,"attention":"flash_attention_2","ac":"Recompute","cp":1,"ep":2,"timeout_minutes":120}
           ]}'
           echo "matrix=$(echo "$matrix" | jq -c .)" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes malformed JSON in the benchmarks workflow matrix definition.
> 
> - Removes a trailing comma in the `build-matrix` step's `matrix` JSON (last `include` entry for `Qwen/Qwen3-235B-A22B-Instruct-2507`), ensuring the workflow parses correctly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efcac3d9b38e71359b07597bc4619140dc1d99f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->