### PR TITLE
[Refactor] rename Runs -> MultiRunManager and cleanup hooks

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ This directory maintains the documentation for PRIME-RL. It is organized into th
 - [**Environments**](environments.md) - Installing and using verifiers environments from the Environments Hub
 - [**Async Training**](async.md) - Understanding asynchronous off-policy training and step semantics
 - [**Logging**](logging.md) - Logging with loguru, torchrun, and Weights & Biases
-- [**RunsManager**](runs.md) - Multi-run training with the RunsManager object for concurrent LoRA adapters
+- [**MultiRunManager**](runs.md) - Multi-run training with the MultiRunManager object for concurrent LoRA adapters
 - [**Checkpointing**](checkpointing.md) - Saving and resuming training from checkpoints
 - [**Benchmarking**](benchmarking.md) - Performance benchmarking and throughput measurement
 - [**Deployment**](deployment.md) - Training deployment on single-GPU, multi-GPU, and multi-node clusters

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ This directory maintains the documentation for PRIME-RL. It is organized into th
 - [**Environments**](environments.md) - Installing and using verifiers environments from the Environments Hub
 - [**Async Training**](async.md) - Understanding asynchronous off-policy training and step semantics
 - [**Logging**](logging.md) - Logging with loguru, torchrun, and Weights & Biases
-- [**Runs**](runs.md) - Multi-run training with the Runs object for concurrent LoRA adapters
+- [**RunsManager**](runs.md) - Multi-run training with the RunsManager object for concurrent LoRA adapters
 - [**Checkpointing**](checkpointing.md) - Saving and resuming training from checkpoints
 - [**Benchmarking**](benchmarking.md) - Performance benchmarking and throughput measurement
 - [**Deployment**](deployment.md) - Training deployment on single-GPU, multi-GPU, and multi-node clusters

--- a/docs/runs.md
+++ b/docs/runs.md
@@ -53,7 +53,7 @@ Each run's directory follows this structure:
 
 ```
 
-Runs are discovered by scanning the output directory for the pattern `run_*`. Each run must contain a valid orchestrator config at `{run_dir}/configs/orch.toml`before they are added to the active runs otherwise they are ignored. When the maximum number of runs is reached, new `run_*` directories will not be picked up until old ones are deleted.
+Runs are discovered by scanning the output directory for the pattern `run_*`. Each run must contain a valid orchestrator config at `{run_dir}/configs/orch.toml` before they are added to the active runs otherwise they are ignored. When the maximum number of runs is reached, new `run_*` directories will not be picked up until old ones are deleted.
 
 ```python
 # Master rank scans for new/deleted runs

--- a/docs/runs.md
+++ b/docs/runs.md
@@ -60,7 +60,7 @@ Runs are discovered by scanning the output directory for the pattern `run_*`. Ea
 multi_run_manager.discover_runs()
 
 # All ranks synchronize state (must be called after discover_runs)
-multi_run_manager.sync_runs()
+multi_run_manager.synchronize_state()
 ```
 
 The `discover_runs()` method (master only):
@@ -72,7 +72,7 @@ The `discover_runs()` method (master only):
 5. Updates internal mappings and data structures
 6. Calls `discovered_hook` for new runs (master only)
 
-The `sync_runs()` method (all ranks):
+The `synchronize_state()` method (all ranks):
 
 1. Master broadcasts run state to all ranks via the distributed store
 2. Non-master ranks catch up by calling internal `_delete_run_data` / `_create_run_data`
@@ -140,7 +140,7 @@ flowchart TD
     wait1 --> barrier
     waitN --> barrier
 
-    barrier[["sync_runs()"]]
+    barrier[["synchronize_state()"]]
 
     barrier --> deletion["deletion_hooks"]
     deletion --> creation["creation_hooks"]
@@ -156,7 +156,7 @@ flowchart TD
 multi_run_manager.register_discovered_hook(callback)
 multi_run_manager.register_forgotten_hook(callback)
 
-# These hooks are executed by all ranks in the order they were added during `sync_runs()`
+# These hooks are executed by all ranks in the order they were added during `synchronize_state()`
 # This ensures DTensor creations and other distributed operations happen together
 # Calling torch.dist.barrier() in a hook here should work
 multi_run_manager.register_creation_hook(callback)

--- a/docs/runs.md
+++ b/docs/runs.md
@@ -112,6 +112,43 @@ runs.reset_run_parameters(idx)
 ## Hooks
 
 The `RunsManager` object supports several types of hooks for different lifecycle events.
+Deletion hooks are always called before creation hooks.
+
+```mermaid
+flowchart TD
+    subgraph master["<b>MASTER RANK</b>"]
+        discover["<b>discover_runs()</b><br/><i>can be called multiple times</i>"]
+
+        discover --> deleted_check{"deleted runs?"}
+        discover --> new_check{"new runs?"}
+
+        deleted_check -->|yes| forgotten["<b>forgotten_hooks</b>"]
+        new_check -->|yes| validation["<b>config_validation_hooks</b>"]
+        validation -->|valid| discovered["<b>discovered_hooks</b>"]
+    end
+
+    forgotten --> barrier[["<b>dist.barrier()</b>"]]
+    discovered --> barrier
+    deleted_check -->|no| barrier
+    new_check -->|no| barrier
+    validation -->|invalid| barrier
+
+    subgraph all["<b>ALL RANKS</b>"]
+        barrier --> sync["<b>sync_runs()</b>"]
+
+        sync --> sync_deleted{"deleted runs?"}
+        sync --> sync_new{"new runs?"}
+
+        sync_deleted -->|yes| deletion["<b>deletion_hooks</b>"]
+        sync_new -->|yes| creation["<b>creation_hooks</b>"]
+    end
+
+    style master fill:#e1f5fe
+    style all fill:#f3e5f5
+    style barrier fill:#fff9c4
+```
+
+### Hook Registration
 
 ```python
 # These hooks are only called on the master as only master uses `discover_runs()`

--- a/docs/runs.md
+++ b/docs/runs.md
@@ -116,35 +116,35 @@ Deletion hooks are always called before creation hooks.
 
 ```mermaid
 flowchart TD
-    subgraph master["<b>MASTER RANK</b>"]
-        discover["<b>discover_runs()</b><br/><i>can be called multiple times</i>"]
+    subgraph master["Rank 0 (Master)"]
+        discover["discover_runs()"]
+        forgotten["forgotten_hooks"]
+        validation["config_validation_hooks"]
+        discovered["discovered_hooks"]
 
-        discover --> deleted_check{"deleted runs?"}
-        discover --> new_check{"new runs?"}
-
-        deleted_check -->|yes| forgotten["<b>forgotten_hooks</b>"]
-        new_check -->|yes| validation["<b>config_validation_hooks</b>"]
-        validation -->|valid| discovered["<b>discovered_hooks</b>"]
+        discover --> forgotten
+        forgotten --> validation
+        validation --> discovered
+        discovered --> discover
     end
 
-    forgotten --> barrier[["<b>dist.barrier()</b>"]]
+    subgraph rank1["Rank 1"]
+        wait1["waiting..."]
+    end
+
+    subgraph rankN["Rank N"]
+        waitN["waiting..."]
+    end
+
     discovered --> barrier
-    deleted_check -->|no| barrier
-    new_check -->|no| barrier
-    validation -->|invalid| barrier
+    wait1 --> barrier
+    waitN --> barrier
 
-    subgraph all["<b>ALL RANKS</b>"]
-        barrier --> sync["<b>sync_runs()</b>"]
+    barrier[["sync_runs()"]]
 
-        sync --> sync_deleted{"deleted runs?"}
-        sync --> sync_new{"new runs?"}
+    barrier --> deletion["deletion_hooks"]
+    deletion --> creation["creation_hooks"]
 
-        sync_deleted -->|yes| deletion["<b>deletion_hooks</b>"]
-        sync_new -->|yes| creation["<b>creation_hooks</b>"]
-    end
-
-    style master fill:#e1f5fe
-    style all fill:#f3e5f5
     style barrier fill:#fff9c4
 ```
 

--- a/docs/runs.md
+++ b/docs/runs.md
@@ -1,23 +1,174 @@
-# Runs
+# RunsManager
 
-The `Runs` object is a singleton that manages multiple concurrent training runs within a single trainer process. It is the central coordination point for multi-run RL training, enabling a single trainer to serve multiple orchestrator experiments simultaneously with separate LoRA adapters, optimizers, and schedulers.
-
-## Overview
+The `RunsManager` object is a global singleton that manages the parameters and components for multiple concurrent training runs within a single trainer process.
+This allows multiple orchestrator deployments to share the same trainer.
 
 When `max_concurrent_runs > 1`, the trainer can train multiple runs in parallel. Each run:
-- Has its own LoRA adapter weights
+
+- Has its own LoRA adapter parameters
 - Has its own optimizer and scheduler
+- Saves its own checkpoints
 - Tracks its own training progress (step, tokens, samples)
 - Loads its own orchestrator configuration
 
-| Responsibility | Description |
-|---------------|-------------|
-| **Discovery** | Scans for `run_*` directories and loads configs |
-| **Mapping** | Provides bidirectional run ID ↔ index mapping |
-| **Progress** | Tracks per-run training step, tokens, samples |
-| **Synchronization** | Keeps all ranks in sync via distributed store |
-| **Hooks** | Enables lazy initialization of per-run resources |
-| **LoRA Management** | Registers modules for multi-adapter parameter access |
-| **State Access** | Provides per-run parameters and state dicts |
+The `RunsManager` object provides:
 
-This design enables efficient multi-tenant training where a single trainer can serve multiple experiments with independent adapter weights, optimizers, and learning rate schedules.
+- **Bidirectional mapping** between run IDs (e.g., `run_abc123`) and run indices (0, 1, 2, ...)
+- **Progress tracking** per run (step count, total tokens, total samples)
+- **Configuration management** for orchestrator configs
+- **Distributed synchronization** across ranks via the PyTorch distributed store
+- **LoRA module registration** for multi-adapter parameter management
+- **Creation hooks** for initializing per-run resources (optimizers, schedulers)
+
+## **Initialization and run discovery**
+
+The `RunsManager` singleton is set up at the start of training:
+
+```python
+from prime_rl.trainer.runs import setup_runs_manager, get_runs_manager
+
+# Initialize with output directory and max concurrent runs
+setup_runs_manager(output_dir=Path("outputs/my-experiment"), max_runs=4)
+
+# Get the singleton instance anywhere in the codebase
+runs = get_runs_manager()
+```
+
+Each run's directory follows this structure:
+
+```
+{output_dir}/
+├── run_abc123/
+│   ├── configs/
+│   │   └── orch.toml          # Orchestrator configuration
+│   ├── checkpoints/
+│   │   └── step_100/          # Orchestrator checkpoints
+│   ├── rollouts/
+│   │   └── step_100/          # Rollouts
+│   └── broadcast/
+│       └── step_100/          # Broadcasted weights for inference
+├── run_def456/
+│   └── ...
+└── ...
+
+```
+
+Runs are discovered by scanning the output directory for the pattern `run_*`. Each run must contain a valid orchestrator config at `{run_dir}/configs/orch.toml`before they are added to the active runs otherwise they are ignored. When the maximum number of runs is reached, new `run_*` directories will not be picked up until old ones are deleted.
+
+```python
+# Master rank scans for new/deleted runs
+runs.discover_runs()
+
+# All ranks synchronize state (must be called after discover_runs)
+runs.sync_runs()
+```
+
+The `discover_runs()` method (master only):
+
+1. Scans the output directory for `run_*` directories
+2. Detects new runs and deleted runs
+3. Calls `forgotten_hook` for deleted runs (master only)
+4. Loads and validates the orchestrator config for each new run
+5. Updates internal mappings and data structures
+6. Calls `discovered_hook` for new runs (master only)
+
+The `sync_runs()` method (all ranks):
+
+1. Master broadcasts run state to all ranks via the distributed store
+2. Non-master ranks catch up by calling internal `_delete_run_data` / `_create_run_data`
+3. All ranks execute `deletion_hook` for deleted runs
+4. All ranks execute `creation_hook` for new runs (e.g., optimizer setup, LoRA parameter reset)
+
+## LoRA Module Registration
+
+LoRA modules register themselves with `RunsManager` for parameter management:
+
+```python
+# In apply_lora_to_model()
+lora_module = MultiLoRALinear(
+    base_layer=base_module,
+    rank=config.rank,
+    n_adapters=get_runs_manager().max_runs,
+    ...
+)
+lora_module.register_with_runs(get_runs_manager(), module_name)
+
+```
+
+The `RunsManager` object then exposes:
+
+```python
+# Get parameters for a specific run (used by optimizer creation)
+runs.get_named_parameters_for_run(idx)
+
+# Get state dict for a specific run (used by weight broadcast)
+runs.get_state_dict_for_run(idx)
+
+# Reset parameters for a new run
+runs.reset_run_parameters(idx)
+
+```
+
+## Hooks
+
+The `RunsManager` object supports several types of hooks for different lifecycle events.
+
+```python
+# These hooks are only called on the master as only master uses `discover_runs()`
+# These hooks are thus only relevant to master only components (packer)
+runs.register_discovered_hook(callback)
+runs.register_forgotten_hook(callback)
+
+# These hooks are executed by all ranks in the order they were added during `sync_runs()`
+# This ensures DTensor creations and other distributed operations happen together
+# Calling torch.dist.barrier() in a hook here should work
+runs.register_creation_hook(callback)
+runs.register_deletion_hook(callback)
+
+# These hooks validate the orchestrator config when runs are discovered:
+runs.register_config_validation_hook(callback)
+```
+
+The callback signatures:
+
+```python
+def discovered_callback(idx: int, run_id: str, config: OrchestratorConfig) -> None:
+    """Called when a new run is discovered (master only).
+
+    Args:
+        idx: The run's index (0 to max_runs-1)
+        run_id: The run's ID (e.g., "run_abc123")
+        config: The orchestrator config for the run
+    """
+    # Example: Set the scaling factor for the run
+    runs.scaling_factors[idx] = config.model.lora.alpha / config.model.lora.rank
+
+def forgotten_callback(idx: int, run_id: str) -> None:
+    """Called when a run is forgotten/removed (master only).
+    
+    Args:
+        idx: The run's index (0 to max_runs-1)
+        run_id: The run's ID (e.g., "run_abc123")
+    """
+    pass
+
+def callback(idx: int, run_id: str) -> None:
+    """Called when a run is created/deleted.
+
+    Args:
+        idx: The run's index (0 to max_runs-1)
+        run_id: The run's ID (e.g., "run_abc123")
+    """
+    pass
+
+def config_validation_callback(config: OrchestratorConfig) -> tuple[bool, str]:
+    """Validate an orchestrator config.
+
+    Args:
+        config: The orchestrator config to validate
+
+    Returns:
+        (is_valid, error_message): If invalid, error_message is written to config dir
+    """
+    return True, ""
+```

--- a/src/prime_rl/trainer/lora.py
+++ b/src/prime_rl/trainer/lora.py
@@ -8,7 +8,7 @@ from prime_rl.trainer.config import LoRAConfig
 from prime_rl.trainer.models.layers.lora import MultiLoRALinear, MultiLoRAModule
 from prime_rl.trainer.models.layers.lora.multi_moe import MultiLoRAGroupedExperts
 from prime_rl.trainer.models.layers.moe import GroupedExperts
-from prime_rl.trainer.runs import get_runs_manager
+from prime_rl.trainer.runs import get_multi_run_manager
 from prime_rl.utils.logger import get_logger
 
 
@@ -137,7 +137,7 @@ def apply_lora_to_model(model: nn.Module, config: LoRAConfig) -> None:
         config: LoRA configuration
     """
     logger = get_logger()
-    n_loras = get_runs_manager().max_runs
+    n_loras = get_multi_run_manager().max_runs
 
     from torch.distributed.fsdp import FSDPModule
 
@@ -185,7 +185,7 @@ def apply_lora_to_model(model: nn.Module, config: LoRAConfig) -> None:
             )
             continue
 
-        lora_module.register_with_runs(get_runs_manager(), module_name)
+        lora_module.register_with_runs(get_multi_run_manager(), module_name)
         _set_module_by_name(model, module_name, lora_module)
 
     freeze_all_except_lora_and_specified(model, config)

--- a/src/prime_rl/trainer/lora.py
+++ b/src/prime_rl/trainer/lora.py
@@ -8,7 +8,7 @@ from prime_rl.trainer.config import LoRAConfig
 from prime_rl.trainer.models.layers.lora import MultiLoRALinear, MultiLoRAModule
 from prime_rl.trainer.models.layers.lora.multi_moe import MultiLoRAGroupedExperts
 from prime_rl.trainer.models.layers.moe import GroupedExperts
-from prime_rl.trainer.runs import get_runs
+from prime_rl.trainer.runs import get_runs_manager
 from prime_rl.utils.logger import get_logger
 
 
@@ -137,7 +137,7 @@ def apply_lora_to_model(model: nn.Module, config: LoRAConfig) -> None:
         config: LoRA configuration
     """
     logger = get_logger()
-    n_loras = get_runs().max_runs
+    n_loras = get_runs_manager().max_runs
 
     from torch.distributed.fsdp import FSDPModule
 
@@ -185,7 +185,7 @@ def apply_lora_to_model(model: nn.Module, config: LoRAConfig) -> None:
             )
             continue
 
-        lora_module.register_with_runs(get_runs(), module_name)
+        lora_module.register_with_runs(get_runs_manager(), module_name)
         _set_module_by_name(model, module_name, lora_module)
 
     freeze_all_except_lora_and_specified(model, config)

--- a/src/prime_rl/trainer/models/layers/lora/base.py
+++ b/src/prime_rl/trainer/models/layers/lora/base.py
@@ -5,7 +5,7 @@ import torch
 from torch import nn
 
 if TYPE_CHECKING:
-    from prime_rl.trainer.runs import Runs
+    from prime_rl.trainer.runs import RunsManager
 
 _LORA_PREFIX = "base_layer."
 
@@ -123,20 +123,20 @@ class MultiLoRAModule(nn.Module):
         """
         ...
 
-    def register_with_runs(self, runs: "Runs", prefix: str) -> None:
-        """Register this module with the Runs system.
+    def register_with_runs(self, runs: "RunsManager", prefix: str) -> None:
+        """Register this module with the RunsManager system.
 
         This method should be called after FSDP/compile/AC setup as these
         transformations may change the underlying parameters while preserving
         the module.
 
-        The Runs class will use this registration to:
+        The RunsManager class will use this registration to:
         - Get named parameters for specific run indices (for optimizer setup)
         - Reset parameters when new runs are created
         - Construct sliced state dicts for weight broadcast
 
         Args:
-            runs: The Runs instance to register with
+            runs: The RunsManager instance to register with
             prefix: The module's name/prefix in the model (e.g., "model.layers.0.self_attn.q_proj")
         """
         runs.register_module(prefix, self)

--- a/src/prime_rl/trainer/models/layers/lora/base.py
+++ b/src/prime_rl/trainer/models/layers/lora/base.py
@@ -5,7 +5,7 @@ import torch
 from torch import nn
 
 if TYPE_CHECKING:
-    from prime_rl.trainer.runs import RunsManager
+    from prime_rl.trainer.runs import MultiRunManager
 
 _LORA_PREFIX = "base_layer."
 
@@ -123,20 +123,20 @@ class MultiLoRAModule(nn.Module):
         """
         ...
 
-    def register_with_runs(self, runs: "RunsManager", prefix: str) -> None:
-        """Register this module with the RunsManager system.
+    def register_with_runs(self, runs: "MultiRunManager", prefix: str) -> None:
+        """Register this module with the MultiRunManager system.
 
         This method should be called after FSDP/compile/AC setup as these
         transformations may change the underlying parameters while preserving
         the module.
 
-        The RunsManager class will use this registration to:
+        The MultiRunManager class will use this registration to:
         - Get named parameters for specific run indices (for optimizer setup)
         - Reset parameters when new runs are created
         - Construct sliced state dicts for weight broadcast
 
         Args:
-            runs: The RunsManager instance to register with
+            runs: The MultiRunManager instance to register with
             prefix: The module's name/prefix in the model (e.g., "model.layers.0.self_attn.q_proj")
         """
         runs.register_module(prefix, self)

--- a/src/prime_rl/trainer/multi_ckpt.py
+++ b/src/prime_rl/trainer/multi_ckpt.py
@@ -15,7 +15,7 @@ from torch.distributed.checkpoint.stateful import Stateful
 
 from prime_rl.trainer.ckpt import CheckpointManager
 from prime_rl.trainer.config import CheckpointConfig
-from prime_rl.trainer.runs import Progress, get_runs
+from prime_rl.trainer.runs import Progress, get_runs_manager
 from prime_rl.trainer.world import get_world
 from prime_rl.utils.logger import get_logger
 from prime_rl.utils.utils import resolve_latest_ckpt_step
@@ -72,7 +72,7 @@ class MultiCheckpointManager:
 
     def __init__(self, output_dir: Path):
         self.output_dir = output_dir
-        self.runs = get_runs()
+        self.runs = get_runs_manager()
         self.world = get_world()
         self.logger = get_logger()
         self.managers: list[CheckpointManager | None] = [None] * self.runs.max_runs

--- a/src/prime_rl/trainer/multi_ckpt.py
+++ b/src/prime_rl/trainer/multi_ckpt.py
@@ -15,7 +15,7 @@ from torch.distributed.checkpoint.stateful import Stateful
 
 from prime_rl.trainer.ckpt import CheckpointManager
 from prime_rl.trainer.config import CheckpointConfig
-from prime_rl.trainer.runs import Progress, get_runs_manager
+from prime_rl.trainer.runs import Progress, get_multi_run_manager
 from prime_rl.trainer.world import get_world
 from prime_rl.utils.logger import get_logger
 from prime_rl.utils.utils import resolve_latest_ckpt_step
@@ -72,7 +72,7 @@ class MultiCheckpointManager:
 
     def __init__(self, output_dir: Path):
         self.output_dir = output_dir
-        self.runs = get_runs_manager()
+        self.runs = get_multi_run_manager()
         self.world = get_world()
         self.logger = get_logger()
         self.managers: list[CheckpointManager | None] = [None] * self.runs.max_runs

--- a/src/prime_rl/trainer/multi_ckpt.py
+++ b/src/prime_rl/trainer/multi_ckpt.py
@@ -72,12 +72,12 @@ class MultiCheckpointManager:
 
     def __init__(self, output_dir: Path):
         self.output_dir = output_dir
-        self.runs = get_multi_run_manager()
+        self.multi_run_manager = get_multi_run_manager()
         self.world = get_world()
         self.logger = get_logger()
-        self.managers: list[CheckpointManager | None] = [None] * self.runs.max_runs
-        self.runs.register_deletion_hook(self._run_deletion_hook)
-        self.runs.register_creation_hook(self._run_creation_hook)
+        self.managers: list[CheckpointManager | None] = [None] * self.multi_run_manager.max_runs
+        self.multi_run_manager.register_deletion_hook(self._run_deletion_hook)
+        self.multi_run_manager.register_creation_hook(self._run_creation_hook)
 
     def _run_deletion_hook(self, idx: int, run_id: str) -> None:
         self.managers[idx] = None
@@ -86,7 +86,7 @@ class MultiCheckpointManager:
         self.managers[idx] = self._maybe_create_manager(idx)
 
     def _maybe_create_manager(self, idx: int) -> CheckpointManager | None:
-        ckpt_config = self.runs.config[idx].ckpt
+        ckpt_config = self.multi_run_manager.config[idx].ckpt
         if ckpt_config is None:
             return None
 
@@ -95,14 +95,14 @@ class MultiCheckpointManager:
             keep_last=ckpt_config.keep_last,
             keep_interval=ckpt_config.keep_interval,
         )
-        run_dir = self.runs.get_run_dir(idx)
+        run_dir = self.multi_run_manager.get_run_dir(idx)
         manager = CheckpointManager(run_dir, config)
         self.managers[idx] = manager
         return manager
 
     def _should_save(self, idx: int, step: int) -> bool:
         """Determine if a checkpoint should be saved for a given run and step."""
-        ckpt_config = self.runs.config[idx].ckpt
+        ckpt_config = self.multi_run_manager.config[idx].ckpt
         if ckpt_config is None or ckpt_config.interval is None:
             return False
         if step <= 0 or step % ckpt_config.interval != 0:
@@ -115,8 +115,8 @@ class MultiCheckpointManager:
         optimizer: "MultiLoRAOptimizer",
         scheduler: "MultiLoRAScheduler",
     ) -> None:
-        for idx in self.runs.used_idxs:
-            step = self.runs.progress[idx].step
+        for idx in self.multi_run_manager.used_idxs:
+            step = self.multi_run_manager.progress[idx].step
             if not self._should_save(idx, step):
                 continue
 
@@ -124,12 +124,14 @@ class MultiCheckpointManager:
 
             # We have a very wide try-except because we dont want to crash the trainer over one run having issues
             try:
-                model_state_dict = {k: v.data.detach().clone() for k, v in self.runs.get_named_parameters_for_run(idx)}
+                model_state_dict = {
+                    k: v.data.detach().clone() for k, v in self.multi_run_manager.get_named_parameters_for_run(idx)
+                }
                 run_state = RunState(
                     model_state_dict,
                     optimizer.optimizers[idx],
                     scheduler.schedulers[idx],
-                    self.runs.progress[idx],
+                    self.multi_run_manager.progress[idx],
                 )
                 ckpt_path = manager.get_ckpt_path(step)
                 ckpt_path.mkdir(parents=True, exist_ok=True)
@@ -141,7 +143,7 @@ class MultiCheckpointManager:
                 # Copy broadcast folder to checkpoint
                 # This way, we only need to save the checkpoint folder
                 if self.world.is_master:
-                    run_dir = self.runs.get_run_dir(idx)
+                    run_dir = self.multi_run_manager.get_run_dir(idx)
                     broadcast_src = run_dir / "broadcasts" / f"step_{step}"
                     weight_dst = run_dir / "checkpoints" / f"step_{step}" / "weight"
                     try:
@@ -165,26 +167,29 @@ class MultiCheckpointManager:
         optimizer: "MultiLoRAOptimizer",
         scheduler: "MultiLoRAScheduler",
     ) -> bool:
-        if self.runs.config[idx].ckpt is None or self.runs.config[idx].ckpt.resume_step is None:
+        if (
+            self.multi_run_manager.config[idx].ckpt is None
+            or self.multi_run_manager.config[idx].ckpt.resume_step is None
+        ):
             return False
 
         manager = self.managers[idx]
         if manager is None:
             return False
 
-        step = self.runs.config[idx].ckpt.resume_step
+        step = self.multi_run_manager.config[idx].ckpt.resume_step
         if step == -1:
             step = resolve_latest_ckpt_step(manager.ckpt_dir)
             if step is None:
                 return False
 
         try:
-            model_state_dict = dict(self.runs.get_named_parameters_for_run(idx))
+            model_state_dict = dict(self.multi_run_manager.get_named_parameters_for_run(idx))
             run_state = RunState(
                 model_state_dict,
                 optimizer.optimizers[idx],
                 scheduler.schedulers[idx],
-                self.runs.progress[idx],
+                self.multi_run_manager.progress[idx],
             )
             ckpt_path = manager.get_ckpt_path(step)
             if not ckpt_path.exists():
@@ -193,7 +198,7 @@ class MultiCheckpointManager:
             state_dict = torch.load(ckpt_path / f"rank_{self.world.rank}.pt")
             run_state.load_state_dict(state_dict)
 
-            self.logger.info(f"Resumed run {self.runs.idx_2_id[idx]} from step {step}")
+            self.logger.info(f"Resumed run {self.multi_run_manager.idx_2_id[idx]} from step {step}")
             return True
         except Exception as e:
             self.logger.error(f"Error loading checkpoint for run {idx}: {e}")
@@ -202,7 +207,7 @@ class MultiCheckpointManager:
     def maybe_clean(self) -> None:
         if not self.world.is_master:
             return
-        for idx in self.runs.used_idxs:
+        for idx in self.multi_run_manager.used_idxs:
             if self.managers[idx] is None:
                 continue
             self.managers[idx].maybe_clean()

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -19,18 +19,18 @@ def setup_optimizer(
     lora: bool = False,
 ) -> Optimizer:
     if lora:
-        # Wait for run 0 to be created in the runs system
+        # Wait for run 0 to be created in the multi run manager
         # Otherwise, the creation will reset the parameters
-        runs = get_multi_run_manager()
+        multi_run_manager = get_multi_run_manager()
         world = get_world()
         logger = get_logger()
-        while 0 not in runs.idx_2_id:
+        while 0 not in multi_run_manager.idx_2_id:
             if world.is_master:
-                runs.discover_runs()
-            runs.sync_runs()
-            logger.info(f"Waiting for run 0 to be created {runs.id_2_idx=}")
+                multi_run_manager.discover_runs()
+            multi_run_manager.sync_runs()
+            logger.info(f"Waiting for run 0 to be created {multi_run_manager.id_2_idx=}")
             time.sleep(1)
-        named_params = runs.get_named_parameters_for_run(0)
+        named_params = multi_run_manager.get_named_parameters_for_run(0)
 
     return _create_optimizer(config, named_params, parallel_dims)
 
@@ -149,15 +149,15 @@ class MultiLoRAOptimizer:
     def __init__(self, config: OptimizerConfigType, parallel_dims: ParallelDims):
         self.config = config
         self.parallel_dims = parallel_dims
-        self.runs = get_multi_run_manager()
+        self.multi_run_manager = get_multi_run_manager()
         self.logger = get_logger()
 
-        self.optimizers: list[Optimizer | None] = [None] * self.runs.max_runs
+        self.optimizers: list[Optimizer | None] = [None] * self.multi_run_manager.max_runs
         self._post_creation_callbacks: list[Callable[[Optimizer, int], None]] = []
 
         # Register creation hook for optimizer setup
         # The MultiRunManager class handles parameter reset internally when new runs are created
-        self.runs.register_creation_hook(self.optimizer_creation_hook)
+        self.multi_run_manager.register_creation_hook(self.optimizer_creation_hook)
 
     def register_post_creation_callback(
         self, callback: Callable[[Optimizer, int], None], index: int | None = None
@@ -175,9 +175,9 @@ class MultiLoRAOptimizer:
 
     def optimizer_creation_hook(self, idx: int, run_id: str) -> None:
         # Get named parameters for this run from the MultiRunManager system
-        named_params = self.runs.get_named_parameters_for_run(idx)
+        named_params = self.multi_run_manager.get_named_parameters_for_run(idx)
 
-        lr = self.runs.config[idx].optim.lr
+        lr = self.multi_run_manager.config[idx].optim.lr
         self.optimizers[idx] = _create_optimizer(self.config, named_params, self.parallel_dims, lr)
 
         # Call post-creation callbacks in order
@@ -185,16 +185,16 @@ class MultiLoRAOptimizer:
             callback(self.optimizers[idx], idx)
 
     def step(self):
-        for idx in self.runs.ready_to_update_idxs:
+        for idx in self.multi_run_manager.ready_to_update_idxs:
             self.optimizers[idx].step()
 
     def zero_grad(self):
-        for idx in self.runs.ready_to_update_idxs:
+        for idx in self.multi_run_manager.ready_to_update_idxs:
             self.optimizers[idx].zero_grad()
 
     def get_current_lr(self, idx: int | None = None) -> float:
         if idx is None:
-            for idx in self.runs.ready_to_update_idxs:
+            for idx in self.multi_run_manager.ready_to_update_idxs:
                 return self.optimizers[idx].param_groups[0]["lr"]
             else:
                 self.logger.warning("No runs are ready to update. Returning 0.0 for current learning rate.")

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -27,7 +27,7 @@ def setup_optimizer(
         while 0 not in multi_run_manager.idx_2_id:
             if world.is_master:
                 multi_run_manager.discover_runs()
-            multi_run_manager.sync_runs()
+            multi_run_manager.synchronize_state()
             logger.info(f"Waiting for run 0 to be created {multi_run_manager.id_2_idx=}")
             time.sleep(1)
         named_params = multi_run_manager.get_named_parameters_for_run(0)

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -156,7 +156,7 @@ class MultiLoRAOptimizer:
         self._post_creation_callbacks: list[Callable[[Optimizer, int], None]] = []
 
         # Register creation hook for optimizer setup
-        # The Runs class handles parameter reset internally when new runs are created
+        # The RunsManager class handles parameter reset internally when new runs are created
         self.runs.register_creation_hook(self.optimizer_creation_hook)
 
     def register_post_creation_callback(
@@ -174,7 +174,7 @@ class MultiLoRAOptimizer:
             self._post_creation_callbacks.insert(index, callback)
 
     def optimizer_creation_hook(self, idx: int, run_id: str) -> None:
-        # Get named parameters for this run from the Runs system
+        # Get named parameters for this run from the RunsManager system
         named_params = self.runs.get_named_parameters_for_run(idx)
 
         lr = self.runs.config[idx].optim.lr

--- a/src/prime_rl/trainer/rl/broadcast/filesystem.py
+++ b/src/prime_rl/trainer/rl/broadcast/filesystem.py
@@ -51,7 +51,7 @@ class FileSystemWeightBroadcast(WeightBroadcast):
             self.logger.debug(f"Broadcasting weights for run {idx} (ready_to_update={self.runs.ready_to_update[idx]})")
 
             if adapter_only:
-                # For adapter-only, Runs creates state dict directly for each run
+                # For adapter-only, RunsManager creates state dict directly for each run
                 # All ranks must participate in DTensor gathering, but only master saves
                 state_dict = self.runs.get_state_dict_for_run(idx)
                 for key, value in state_dict.items():

--- a/src/prime_rl/trainer/rl/broadcast/filesystem.py
+++ b/src/prime_rl/trainer/rl/broadcast/filesystem.py
@@ -11,7 +11,7 @@ from prime_rl.trainer.lora import save_lora_config
 from prime_rl.trainer.models import PreTrainedModelPrimeRL
 from prime_rl.trainer.rl.broadcast.base import WeightBroadcast
 from prime_rl.trainer.rl.config import FileSystemWeightBroadcastConfig
-from prime_rl.trainer.runs import get_runs_manager
+from prime_rl.trainer.runs import get_multi_run_manager
 from prime_rl.trainer.utils import maybe_clean
 from prime_rl.trainer.weights import (
     gather_weights_on_master,
@@ -31,7 +31,7 @@ class FileSystemWeightBroadcast(WeightBroadcast):
         self.save_format: Literal["safetensors", "torch"] = config.save_format
         self.save_sharded = config.save_sharded if lora_config is None else False
         self.world = get_world()
-        self.runs = get_runs_manager()
+        self.runs = get_multi_run_manager()
         self.logger.debug(
             f"Filesystem broadcast initialized (save_format={config.save_format}, save_sharded={self.save_sharded})"
         )
@@ -51,7 +51,7 @@ class FileSystemWeightBroadcast(WeightBroadcast):
             self.logger.debug(f"Broadcasting weights for run {idx} (ready_to_update={self.runs.ready_to_update[idx]})")
 
             if adapter_only:
-                # For adapter-only, RunsManager creates state dict directly for each run
+                # For adapter-only, MultiRunManager creates state dict directly for each run
                 # All ranks must participate in DTensor gathering, but only master saves
                 state_dict = self.runs.get_state_dict_for_run(idx)
                 for key, value in state_dict.items():

--- a/src/prime_rl/trainer/rl/broadcast/filesystem.py
+++ b/src/prime_rl/trainer/rl/broadcast/filesystem.py
@@ -11,7 +11,7 @@ from prime_rl.trainer.lora import save_lora_config
 from prime_rl.trainer.models import PreTrainedModelPrimeRL
 from prime_rl.trainer.rl.broadcast.base import WeightBroadcast
 from prime_rl.trainer.rl.config import FileSystemWeightBroadcastConfig
-from prime_rl.trainer.runs import get_runs
+from prime_rl.trainer.runs import get_runs_manager
 from prime_rl.trainer.utils import maybe_clean
 from prime_rl.trainer.weights import (
     gather_weights_on_master,
@@ -31,7 +31,7 @@ class FileSystemWeightBroadcast(WeightBroadcast):
         self.save_format: Literal["safetensors", "torch"] = config.save_format
         self.save_sharded = config.save_sharded if lora_config is None else False
         self.world = get_world()
-        self.runs = get_runs()
+        self.runs = get_runs_manager()
         self.logger.debug(
             f"Filesystem broadcast initialized (save_format={config.save_format}, save_sharded={self.save_sharded})"
         )

--- a/src/prime_rl/trainer/rl/broadcast/filesystem.py
+++ b/src/prime_rl/trainer/rl/broadcast/filesystem.py
@@ -31,7 +31,7 @@ class FileSystemWeightBroadcast(WeightBroadcast):
         self.save_format: Literal["safetensors", "torch"] = config.save_format
         self.save_sharded = config.save_sharded if lora_config is None else False
         self.world = get_world()
-        self.runs = get_multi_run_manager()
+        self.multi_run_manager = get_multi_run_manager()
         self.logger.debug(
             f"Filesystem broadcast initialized (save_format={config.save_format}, save_sharded={self.save_sharded})"
         )
@@ -47,13 +47,15 @@ class FileSystemWeightBroadcast(WeightBroadcast):
             if isinstance(model, PreTrainedModelPrimeRL) and model.is_prime_state_dict(state_dict):
                 model.convert_to_hf(state_dict)
 
-        for idx in self.runs.ready_to_update_idxs:
-            self.logger.debug(f"Broadcasting weights for run {idx} (ready_to_update={self.runs.ready_to_update[idx]})")
+        for idx in self.multi_run_manager.ready_to_update_idxs:
+            self.logger.debug(
+                f"Broadcasting weights for run {idx} (ready_to_update={self.multi_run_manager.ready_to_update[idx]})"
+            )
 
             if adapter_only:
                 # For adapter-only, MultiRunManager creates state dict directly for each run
                 # All ranks must participate in DTensor gathering, but only master saves
-                state_dict = self.runs.get_state_dict_for_run(idx)
+                state_dict = self.multi_run_manager.get_state_dict_for_run(idx)
                 for key, value in state_dict.items():
                     if isinstance(value, DTensor):
                         value = value.full_tensor()
@@ -64,7 +66,8 @@ class FileSystemWeightBroadcast(WeightBroadcast):
             if self.world.is_master:
                 try:
                     save_dir = get_step_path(
-                        get_broadcast_dir(self.runs.get_run_dir(idx)), self.runs.progress[idx].step
+                        get_broadcast_dir(self.multi_run_manager.get_run_dir(idx)),
+                        self.multi_run_manager.progress[idx].step,
                     )
                     save_dir.mkdir(parents=True, exist_ok=True)
 
@@ -77,15 +80,15 @@ class FileSystemWeightBroadcast(WeightBroadcast):
 
                     # If the run is deleted, remove the run directory
                     # This is avoid the creation of zombie runs when the directory is deleted while we are broadcasting which recreates the directory
-                    if self.runs.get_orchestrator_config(self.runs.idx_2_id[idx]) is None:
-                        shutil.rmtree(self.runs.get_run_dir(idx))
+                    if self.multi_run_manager.get_orchestrator_config(self.multi_run_manager.idx_2_id[idx]) is None:
+                        shutil.rmtree(self.multi_run_manager.get_run_dir(idx))
 
                 except FileNotFoundError:
                     self.logger.warning(f"Run {idx} is deleted, skipping")
                 except Exception as e:
                     self.logger.error(f"Error broadcasting weights for run {idx}: {e}")
                 finally:
-                    self.runs.ready_to_update[idx] = False
+                    self.multi_run_manager.ready_to_update[idx] = False
 
         if self.world.is_master:
             self.logger.debug(f"Weights broadcasted in {time.perf_counter() - start_time:.2f}s")
@@ -96,10 +99,10 @@ class FileSystemWeightBroadcast(WeightBroadcast):
         stable_file.touch()
 
     def maybe_clean(self, max_async_level: int, interval_to_keep: int | None):
-        for idx in self.runs.used_idxs:
+        for idx in self.multi_run_manager.used_idxs:
             maybe_clean(
-                get_broadcast_dir(self.runs.get_run_dir(idx)),
-                self.runs.progress[idx].step,
+                get_broadcast_dir(self.multi_run_manager.get_run_dir(idx)),
+                self.multi_run_manager.progress[idx].step,
                 max_async_level,
                 interval_to_keep,
             )

--- a/src/prime_rl/trainer/rl/broadcast/nccl.py
+++ b/src/prime_rl/trainer/rl/broadcast/nccl.py
@@ -13,7 +13,7 @@ from vllm.distributed.utils import StatelessProcessGroup
 from prime_rl.trainer.models import PreTrainedModelPrimeRL
 from prime_rl.trainer.rl.broadcast.base import WeightBroadcast
 from prime_rl.trainer.rl.config import NCCLWeightBroadcastConfig
-from prime_rl.trainer.runs import get_runs
+from prime_rl.trainer.runs import get_runs_manager
 from prime_rl.trainer.utils import get_world
 from prime_rl.trainer.weights import get_max_layer_num
 from prime_rl.utils.logger import get_logger
@@ -147,7 +147,7 @@ class NCCLWeightBroadcast(WeightBroadcast):
         super().__init__(output_dir)
         self.logger = get_logger()
         self.world = get_world()
-        self.runs = get_runs()
+        self.runs = get_runs_manager()
         self.nccl_broadcast_sender = NCCLWeightBroadcastSender(
             config.host, config.port, 0, config.inference_world_size + 1, device, config.timeout, dtype
         )

--- a/src/prime_rl/trainer/rl/broadcast/nccl.py
+++ b/src/prime_rl/trainer/rl/broadcast/nccl.py
@@ -13,7 +13,7 @@ from vllm.distributed.utils import StatelessProcessGroup
 from prime_rl.trainer.models import PreTrainedModelPrimeRL
 from prime_rl.trainer.rl.broadcast.base import WeightBroadcast
 from prime_rl.trainer.rl.config import NCCLWeightBroadcastConfig
-from prime_rl.trainer.runs import get_runs_manager
+from prime_rl.trainer.runs import get_multi_run_manager
 from prime_rl.trainer.utils import get_world
 from prime_rl.trainer.weights import get_max_layer_num
 from prime_rl.utils.logger import get_logger
@@ -147,7 +147,7 @@ class NCCLWeightBroadcast(WeightBroadcast):
         super().__init__(output_dir)
         self.logger = get_logger()
         self.world = get_world()
-        self.runs = get_runs_manager()
+        self.runs = get_multi_run_manager()
         self.nccl_broadcast_sender = NCCLWeightBroadcastSender(
             config.host, config.port, 0, config.inference_world_size + 1, device, config.timeout, dtype
         )

--- a/src/prime_rl/trainer/rl/data.py
+++ b/src/prime_rl/trainer/rl/data.py
@@ -156,7 +156,7 @@ class DataLoader:
         if self.world.is_master:
             self.packer.pack()
         self.receiver.wait()
-        self.multi_run_manager.sync_runs()
+        self.multi_run_manager.synchronize_state()
 
     def get_batch(self) -> list[TensorMicroBatch]:
         micro_batches = self.receiver.receive()

--- a/src/prime_rl/trainer/rl/data.py
+++ b/src/prime_rl/trainer/rl/data.py
@@ -41,7 +41,7 @@ class FakeDataLoader:
         self.seq_len = seq_len
         self.generate_samples = config.generate_samples
         self.batch_counter = 0
-        self.runs = get_multi_run_manager()
+        self.multi_run_manager = get_multi_run_manager()
 
     def wait_for_batch(self) -> None:
         return
@@ -84,7 +84,7 @@ class FakeDataLoader:
         loss_mask = torch.ones(input_ids.shape[0], dtype=torch.bool)
         advantages = torch.randn(input_ids.shape[0], generator=generator)
         inference_logprobs = torch.randn(input_ids.shape[0], generator=generator)
-        lora_num_tokens = torch.zeros(self.runs.max_runs, dtype=torch.int32)
+        lora_num_tokens = torch.zeros(self.multi_run_manager.max_runs, dtype=torch.int32)
         lora_num_tokens[0] = input_ids.shape[0]
 
         return {
@@ -99,7 +99,7 @@ class FakeDataLoader:
         }
 
     def _get_micro_batch(self, generator: torch.Generator) -> TensorMicroBatch:
-        lora_num_tokens = torch.zeros(self.runs.max_runs, dtype=torch.int32)
+        lora_num_tokens = torch.zeros(self.multi_run_manager.max_runs, dtype=torch.int32)
         lora_num_tokens[0] = self.seq_len
         return {
             "input_ids": torch.randint(
@@ -148,7 +148,7 @@ class DataLoader:
 
         non_dp_world_size = self.world.world_size // dp_world_size
         dp_rank = self.world.rank // non_dp_world_size
-        self.runs = get_multi_run_manager()
+        self.multi_run_manager = get_multi_run_manager()
 
         self.receiver: MicroBatchReceiver = setup_micro_batch_receiver(output_dir, dp_rank, start_step, config)
 
@@ -156,7 +156,7 @@ class DataLoader:
         if self.world.is_master:
             self.packer.pack()
         self.receiver.wait()
-        self.runs.sync_runs()
+        self.multi_run_manager.sync_runs()
 
     def get_batch(self) -> list[TensorMicroBatch]:
         micro_batches = self.receiver.receive()
@@ -165,7 +165,7 @@ class DataLoader:
     def _micro_batch_to_tensor(self, micro_batch: MicroBatch) -> TensorMicroBatch:
         """Convert a MicroBatch (msgspec struct with lists) to a TensorMicroBatch (dict with tensors)."""
         if micro_batch.lora_num_tokens is None:
-            micro_batch.lora_num_tokens = [0] * self.runs.max_runs
+            micro_batch.lora_num_tokens = [0] * self.multi_run_manager.max_runs
             micro_batch.lora_num_tokens[0] = len(micro_batch.input_ids)
         return TensorMicroBatch(
             input_ids=torch.tensor(micro_batch.input_ids, dtype=torch.long).unsqueeze(0),

--- a/src/prime_rl/trainer/rl/data.py
+++ b/src/prime_rl/trainer/rl/data.py
@@ -8,7 +8,7 @@ from transformers.tokenization_utils import PreTrainedTokenizer
 
 from prime_rl.trainer.rl.config import FakeDataLoaderConfig
 from prime_rl.trainer.rl.packer import BasePacker, setup_packer
-from prime_rl.trainer.runs import get_runs_manager
+from prime_rl.trainer.runs import get_multi_run_manager
 from prime_rl.trainer.world import get_world
 from prime_rl.transport import MicroBatch, MicroBatchReceiver, TransportConfigType, setup_micro_batch_receiver
 
@@ -41,7 +41,7 @@ class FakeDataLoader:
         self.seq_len = seq_len
         self.generate_samples = config.generate_samples
         self.batch_counter = 0
-        self.runs = get_runs_manager()
+        self.runs = get_multi_run_manager()
 
     def wait_for_batch(self) -> None:
         return
@@ -148,7 +148,7 @@ class DataLoader:
 
         non_dp_world_size = self.world.world_size // dp_world_size
         dp_rank = self.world.rank // non_dp_world_size
-        self.runs = get_runs_manager()
+        self.runs = get_multi_run_manager()
 
         self.receiver: MicroBatchReceiver = setup_micro_batch_receiver(output_dir, dp_rank, start_step, config)
 

--- a/src/prime_rl/trainer/rl/data.py
+++ b/src/prime_rl/trainer/rl/data.py
@@ -8,7 +8,7 @@ from transformers.tokenization_utils import PreTrainedTokenizer
 
 from prime_rl.trainer.rl.config import FakeDataLoaderConfig
 from prime_rl.trainer.rl.packer import BasePacker, setup_packer
-from prime_rl.trainer.runs import get_runs
+from prime_rl.trainer.runs import get_runs_manager
 from prime_rl.trainer.world import get_world
 from prime_rl.transport import MicroBatch, MicroBatchReceiver, TransportConfigType, setup_micro_batch_receiver
 
@@ -41,7 +41,7 @@ class FakeDataLoader:
         self.seq_len = seq_len
         self.generate_samples = config.generate_samples
         self.batch_counter = 0
-        self.runs = get_runs()
+        self.runs = get_runs_manager()
 
     def wait_for_batch(self) -> None:
         return
@@ -148,7 +148,7 @@ class DataLoader:
 
         non_dp_world_size = self.world.world_size // dp_world_size
         dp_rank = self.world.rank // non_dp_world_size
-        self.runs = get_runs()
+        self.runs = get_runs_manager()
 
         self.receiver: MicroBatchReceiver = setup_micro_batch_receiver(output_dir, dp_rank, start_step, config)
 

--- a/src/prime_rl/trainer/rl/packer.py
+++ b/src/prime_rl/trainer/rl/packer.py
@@ -6,7 +6,7 @@ from collections import deque
 from transformers.tokenization_utils import PreTrainedTokenizer
 
 from prime_rl.trainer.batch import prepare_batch
-from prime_rl.trainer.runs import get_runs_manager
+from prime_rl.trainer.runs import get_multi_run_manager
 from prime_rl.transport import (
     MicroBatchSender,
     TrainingSample,
@@ -31,7 +31,7 @@ class BasePacker(ABC):
         start_step: int = 0,
     ):
         self.logger = get_logger()
-        self.runs = get_runs_manager()
+        self.runs = get_multi_run_manager()
         self.dp_world_size = dp_world_size
         self.seq_len = seq_len
         self.pad_to_multiple_of = pad_to_multiple_of
@@ -259,7 +259,7 @@ def setup_packer(
     transport_config: TransportConfigType,
     start_step: int = 0,
 ) -> BasePacker:
-    runs = get_runs_manager()
+    runs = get_multi_run_manager()
     if runs.max_runs == 1:
         return SinglePacker(dp_world_size, seq_len, pad_to_multiple_of, tokenizer, transport_config, start_step)
     else:

--- a/src/prime_rl/trainer/rl/packer.py
+++ b/src/prime_rl/trainer/rl/packer.py
@@ -31,15 +31,15 @@ class BasePacker(ABC):
         start_step: int = 0,
     ):
         self.logger = get_logger()
-        self.runs = get_multi_run_manager()
+        self.multi_run_manager = get_multi_run_manager()
         self.dp_world_size = dp_world_size
         self.seq_len = seq_len
         self.pad_to_multiple_of = pad_to_multiple_of
         self.tokenizer = tokenizer
         self.receiver = setup_training_batch_receiver(config)
-        shutil.rmtree(get_rollout_dir(self.runs.output_dir), ignore_errors=True)
+        shutil.rmtree(get_rollout_dir(self.multi_run_manager.output_dir), ignore_errors=True)
         self.sender: MicroBatchSender = setup_micro_batch_sender(
-            self.runs.output_dir, dp_world_size, start_step, config
+            self.multi_run_manager.output_dir, dp_world_size, start_step, config
         )
 
     @abstractmethod
@@ -59,21 +59,21 @@ class SinglePacker(BasePacker):
         start_step: int = 0,
     ):
         super().__init__(dp_world_size, seq_len, pad_to_multiple_of, tokenizer, config, start_step)
-        assert self.runs.max_runs == 1, "SinglePacker only supports one run"
+        assert self.multi_run_manager.max_runs == 1, "SinglePacker only supports one run"
 
     def pack(self):
         # Wait for batch to be available
         batches = []
         while len(batches) == 0:
-            self.runs.discover_runs()
+            self.multi_run_manager.discover_runs()
             batches = self.receiver.receive()
             time.sleep(0.2)
 
         assert len(batches) == 1, "SinglePacker only supports one batch per step"
         batch = batches[0]
 
-        self.runs.ready_to_update[0] = True
-        self.runs.progress[0].step += 1
+        self.multi_run_manager.ready_to_update[0] = True
+        self.multi_run_manager.progress[0].step += 1
         micro_batch_grid = prepare_batch(
             rollouts=batch.examples,
             temperature=batch.temperature,
@@ -81,7 +81,7 @@ class SinglePacker(BasePacker):
             pad_to_multiple_of=self.pad_to_multiple_of,
             num_train_workers=self.dp_world_size,
             idxs=[0] * len(batch.examples),
-            num_loras=self.runs.max_runs,
+            num_loras=self.multi_run_manager.max_runs,
         )
 
         self.sender.send(micro_batch_grid)
@@ -99,14 +99,16 @@ class MultiPacker(BasePacker):
     ):
         super().__init__(dp_world_size, seq_len, pad_to_multiple_of, tokenizer, config, start_step)
         # Per-run buffer: stores (TrainingSample, temperature, step) tuples
-        self.buffers: list[deque[tuple[TrainingSample, float, int]]] = [deque() for _ in range(self.runs.max_runs)]
+        self.buffers: list[deque[tuple[TrainingSample, float, int]]] = [
+            deque() for _ in range(self.multi_run_manager.max_runs)
+        ]
 
         # Round-robin position (persists across pack() calls)
         self._round_robin_position: int = 0
 
-        # Register forgotten hook for receiver reset (master only, runs during discover_runs)
+        # Register forgotten hook for receiver reset (master only, called during discover_runs)
         # This must happen when a run is deleted to prevent stale data from remaining
-        self.runs.register_forgotten_hook(self._on_run_data_deleted)
+        self.multi_run_manager.register_forgotten_hook(self._on_run_data_deleted)
 
     def _on_run_data_deleted(self, idx: int, run_id: str) -> None:
         """Reset run state when run data is deleted (master only)."""
@@ -118,7 +120,7 @@ class MultiPacker(BasePacker):
 
     def _get_batch(self) -> None:
         """Receive batches from orchestrator and buffer samples per run."""
-        self.runs.discover_runs()
+        self.multi_run_manager.discover_runs()
         batches = self.receiver.receive()
 
         for batch in batches:
@@ -131,9 +133,9 @@ class MultiPacker(BasePacker):
     def _count_tokens(self, threshold: int | None = None) -> int:
         tokens = 0
 
-        for run_idx in self.runs.used_idxs:
+        for run_idx in self.multi_run_manager.used_idxs:
             buffer = self.buffers[run_idx]
-            current_step = self.runs.progress[run_idx].step
+            current_step = self.multi_run_manager.progress[run_idx].step
             for sample, _, step in buffer:
                 if step > current_step:
                     continue
@@ -158,7 +160,7 @@ class MultiPacker(BasePacker):
             for _ in range(len(self.buffers)):
                 if len(self.buffers[self._round_robin_position]) > 0:
                     _, _, step = self.buffers[self._round_robin_position][0]
-                    if step <= self.runs.progress[self._round_robin_position].step:
+                    if step <= self.multi_run_manager.progress[self._round_robin_position].step:
                         break
                 self._round_robin_position = (self._round_robin_position + 1) % len(self.buffers)
             else:
@@ -167,7 +169,7 @@ class MultiPacker(BasePacker):
                 break
             run_idx = self._round_robin_position
             self._round_robin_position = (self._round_robin_position + 1) % len(self.buffers)
-            current_step = self.runs.progress[run_idx].step
+            current_step = self.multi_run_manager.progress[run_idx].step
 
             while len(self.buffers[run_idx]) > 0:
                 sample, temperature, step = self.buffers[run_idx][0]
@@ -192,12 +194,15 @@ class MultiPacker(BasePacker):
         # HACK: This fixes the issue with branching rollouts having unpredictable batch size
         # However, it makes us unable to do incremental orchestrator rollouts
         # Removing the len(self.buffers[run_idx]) == 0 check would allow incremental orchestrator rollouts
-        if len(self.buffers[run_idx]) == 0 or self.buffers[run_idx][0][2] > self.runs.progress[run_idx].step:
-            self.runs.progress[run_idx].step += 1
-            self.runs.ready_to_update[run_idx] = True
+        if (
+            len(self.buffers[run_idx]) == 0
+            or self.buffers[run_idx][0][2] > self.multi_run_manager.progress[run_idx].step
+        ):
+            self.multi_run_manager.progress[run_idx].step += 1
+            self.multi_run_manager.ready_to_update[run_idx] = True
 
-        self.runs.progress[run_idx].total_tokens += num_tokens
-        self.runs.progress[run_idx].total_samples += num_samples
+        self.multi_run_manager.progress[run_idx].total_tokens += num_tokens
+        self.multi_run_manager.progress[run_idx].total_samples += num_samples
 
     def pack(self):
         """Pack samples from buffers using round-robin fair scheduling."""
@@ -242,7 +247,7 @@ class MultiPacker(BasePacker):
                 pad_to_multiple_of=self.pad_to_multiple_of,
                 num_train_workers=self.dp_world_size,
                 idxs=[run_idx] * num_samples,
-                num_loras=self.runs.max_runs,
+                num_loras=self.multi_run_manager.max_runs,
             )
 
             for i, micro_batch in enumerate(_micro_batch_grid):
@@ -259,8 +264,8 @@ def setup_packer(
     transport_config: TransportConfigType,
     start_step: int = 0,
 ) -> BasePacker:
-    runs = get_multi_run_manager()
-    if runs.max_runs == 1:
+    multi_run_manager = get_multi_run_manager()
+    if multi_run_manager.max_runs == 1:
         return SinglePacker(dp_world_size, seq_len, pad_to_multiple_of, tokenizer, transport_config, start_step)
     else:
         return MultiPacker(dp_world_size, seq_len, pad_to_multiple_of, tokenizer, transport_config, start_step)

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -112,7 +112,7 @@ def train(config: RLTrainerConfig):
     multi_run_manager = get_multi_run_manager()
 
     # Register validation and scaling hooks for LoRA
-    if config.model.lora:
+    if config.model.lora and world.is_master:
         trainer_lora = config.model.lora
 
         def validate_lora_rank(orch_config) -> tuple[bool, str]:

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -50,7 +50,7 @@ from prime_rl.trainer.utils import (
     get_response_lengths,
 )
 from prime_rl.trainer.world import get_world
-from prime_rl.trainer.runs import setup_runs_manager, Progress, get_runs_manager
+from prime_rl.trainer.runs import setup_multi_run_manager, Progress, get_multi_run_manager
 from prime_rl.trainer.models.layers.lora import set_lora_num_tokens
 from prime_rl.utils.heartbeat import Heartbeat
 from prime_rl.utils.metrics_server import HealthServer, MetricsServer, RunStats
@@ -108,8 +108,8 @@ def train(config: RLTrainerConfig):
     torch.set_float32_matmul_precision("high")
 
     # Setup runs and offsets
-    setup_runs_manager(config.output_dir, config.max_concurrent_runs, torch.device("cuda", world.local_rank))
-    runs = get_runs_manager()
+    setup_multi_run_manager(config.output_dir, config.max_concurrent_runs, torch.device("cuda", world.local_rank))
+    runs = get_multi_run_manager()
 
     # Register validation and scaling hooks for LoRA
     if config.model.lora:
@@ -521,7 +521,7 @@ def train(config: RLTrainerConfig):
                 mismatch_kl=tensor_stats.get("mismatch_kl/mean", 0.0),
             )
             # Update run/LoRA metrics
-            runs = get_runs_manager()
+            runs = get_multi_run_manager()
             runs_discovered = len(list(config.output_dir.glob("run_*")))
             run_stats = []
             for idx in runs.used_idxs:

--- a/src/prime_rl/trainer/runs.py
+++ b/src/prime_rl/trainer/runs.py
@@ -108,6 +108,8 @@ class MultiRunManager:
             hook: A callable that takes (idx: int, run_id: str, config: OrchestratorConfig).
                   Called only on master rank in discover_runs() when a new run is found.
         """
+        if not self.world.is_master:
+            raise RuntimeError("register_discovered_hook() must only be called on the master rank")
         self._discovered_hooks.append(hook)
 
     def register_forgotten_hook(self, hook: Callable[[int, str], None]) -> None:
@@ -117,6 +119,8 @@ class MultiRunManager:
             hook: A callable that takes (idx: int, run_id: str).
                   Called only on master rank in discover_runs() when a run is removed.
         """
+        if not self.world.is_master:
+            raise RuntimeError("register_forgotten_hook() must only be called on the master rank")
         self._forgotten_hooks.append(hook)
 
     def register_config_validation_hook(self, hook: Callable[["OrchestratorConfig"], tuple[bool, str]]) -> None:
@@ -126,6 +130,8 @@ class MultiRunManager:
             hook: A callable that takes (config: OrchestratorConfig) and returns
                   (is_valid: bool, error_message: str). Error message is used when invalid.
         """
+        if not self.world.is_master:
+            raise RuntimeError("register_config_validation_hook() must only be called on the master rank")
         self._config_validation_hooks.append(hook)
 
     # =========================================================================
@@ -302,6 +308,8 @@ class MultiRunManager:
         and updates internal data structures. Hooks and parameter resets for all ranks
         are deferred to sync_runs().
         """
+        if not self.world.is_master:
+            raise RuntimeError("discover_runs() must only be called on the master rank")
         run_ids = {run_path.stem for run_path in self.output_dir.glob("run_*")}
         deleted_runs = self.id_2_idx.keys() - run_ids
         new_runs = run_ids - self.id_2_idx.keys()

--- a/src/prime_rl/trainer/runs.py
+++ b/src/prime_rl/trainer/runs.py
@@ -23,8 +23,12 @@ class Progress:
     total_samples: int = 0
 
 
-class Runs:
+class RunsManager:
     """This class stores information about the runs in the system."""
+
+    # =========================================================================
+    # Initialization
+    # =========================================================================
 
     def __init__(self, output_dir: Path, max_runs: int, device: torch.device = torch.device("cpu")):
         self.output_dir = output_dir
@@ -41,10 +45,9 @@ class Runs:
 
         self._creation_hooks: list[Callable[[int, str], None]] = []
         self._deletion_hooks: list[Callable[[int, str], None]] = []
-        self._create_run_data_hooks: list[Callable[[int, str, "OrchestratorConfig"], None]] = []
-        self._delete_run_data_hooks: list[Callable[[int, str], None]] = []
+        self._discovered_hooks: list[Callable[[int, str, "OrchestratorConfig"], None]] = []
+        self._forgotten_hooks: list[Callable[[int, str], None]] = []
         self._config_validation_hooks: list[Callable[["OrchestratorConfig"], tuple[bool, str]]] = []
-        self._scaling_hook: Callable[["OrchestratorConfig"], float] | None = None
 
         # We use the store to keep other ranks in sync with master
         self.store = c10d._get_default_store()
@@ -76,249 +79,9 @@ class Runs:
         )
         self.scaling_factors = get_multilora_scaling()
 
-    def register_config_validation_hook(self, hook: Callable[["OrchestratorConfig"], tuple[bool, str]]) -> None:
-        """Register a hook to validate orchestrator config when a run is created.
-
-        Args:
-            hook: A callable that takes (config: OrchestratorConfig) and returns
-                  (is_valid: bool, error_message: str). Error message is used when invalid.
-        """
-        self._config_validation_hooks.append(hook)
-
-    def register_scaling_hook(self, hook: Callable[["OrchestratorConfig"], float]) -> None:
-        """Register a hook to compute LoRA scaling factor for a run.
-
-        Args:
-            hook: A callable that takes (config: OrchestratorConfig) and returns the scaling factor.
-        """
-        self._scaling_hook = hook
-
-    def register_create_run_data_hook(self, hook: Callable[[int, str, "OrchestratorConfig"], None]) -> None:
-        """Register a hook to be called when run data is created (master only).
-
-        Args:
-            hook: A callable that takes (idx: int, run_id: str, config: OrchestratorConfig).
-                  Called only on master rank when a new run's data structures are initialized.
-        """
-        self._create_run_data_hooks.append(hook)
-
-    def register_delete_run_data_hook(self, hook: Callable[[int, str], None]) -> None:
-        """Register a hook to be called when run data is deleted (master only).
-
-        Args:
-            hook: A callable that takes (idx: int, run_id: str).
-                  Called only on master rank when a run's data structures are being deleted.
-        """
-        self._delete_run_data_hooks.append(hook)
-
-    def get_orchestrator_config(self, run_id: str) -> Optional["OrchestratorConfig"]:
-        """Load and validate orchestrator config for a run.
-
-        Returns None if config doesn't exist, fails to parse, or fails validation.
-        Writes error to config dir for orchestrator to consume.
-        """
-        config_path = self.output_dir / run_id / "configs" / "orch.toml"
-        config_dir = config_path.parent
-        error_path = config_dir / "error.txt"
-
-        if not config_path.exists():
-            if not error_path.exists():
-                config_dir.mkdir(parents=True, exist_ok=True)
-                with open(error_path, "w") as f:
-                    f.write(f"No orchestrator config found at {config_path}\n")
-            self.logger.error(f"Run {run_id}: No orchestrator config found at {config_path}")
-            return None
-
-        try:
-            with open(config_path, "rb") as f:
-                config_dict = tomli.load(f)
-
-            from prime_rl.orchestrator.config import OrchestratorConfig
-
-            config = OrchestratorConfig(**config_dict)
-        except Exception as e:
-            config_dir.mkdir(parents=True, exist_ok=True)
-            with open(error_path, "w") as f:
-                f.write(f"Error parsing orchestrator config:\n{str(e)}\n")
-            self.logger.error(f"Run {run_id}: Error parsing orchestrator config: {e}")
-            return None
-
-        # Run registered validation hooks
-        for hook in self._config_validation_hooks:
-            is_valid, error_message = hook(config)
-            if not is_valid:
-                self.logger.error(f"Run {run_id}: {error_message}")
-                config_dir.mkdir(parents=True, exist_ok=True)
-                with open(error_path, "w") as f:
-                    f.write(f"{error_message}\n")
-                return None
-
-        # Config is valid, remove any stale error file
-        if error_path.exists():
-            error_path.unlink()
-
-        return config
-
-    def _delete_run_data(self, deleted_run: str, deleted_idx: int) -> None:
-        """Update data structures for a deleted run"""
-        # Call delete hooks before removing data
-        for hook in self._delete_run_data_hooks:
-            hook(deleted_idx, deleted_run)
-
-        del self.progress[deleted_idx]
-        if deleted_idx in self.config:
-            del self.config[deleted_idx]
-
-        # A big value might help make it error loudly
-        self.scaling_factors[deleted_idx] = 1000_000.0
-
-        # Process mappings
-        self.unused_idxs.add(deleted_idx)
-        del self.idx_2_id[deleted_idx]
-        del self.id_2_idx[deleted_run]
-
-    def _create_run_data(self, new_run: str, new_id: int, config: "OrchestratorConfig") -> None:
-        """Update data structures for a new run (no hooks or param reset)."""
-        self.id_2_idx[new_run] = new_id
-        self.unused_idxs.remove(new_id)
-        self.idx_2_id[new_id] = new_run
-
-        # Get progress
-        self.progress[new_id] = Progress()
-
-        prev_ckpt_steps = [
-            int(i.stem.split("_")[-1]) for i in (self.get_run_dir(new_id) / "checkpoints").glob("step_*")
-        ]
-        self.progress[new_id].step = max(prev_ckpt_steps) if prev_ckpt_steps else 0
-
-        # Store the parsed config
-        self.config[new_id] = config
-
-    def _create_run_hooks(self, new_id: int, new_run: str) -> None:
-        """Reset parameters and call creation hooks for a run."""
-        self.reset_run_parameters(new_id)
-        for hook in self._creation_hooks:
-            hook(new_id, new_run)
-
-    def _delete_run_hooks(self, deleted_idx: int, deleted_run: str) -> None:
-        """Call deletion hooks for a run."""
-        for hook in self._deletion_hooks:
-            hook(deleted_idx, deleted_run)
-
-    def check_for_changes(self) -> None:
-        """Detect run changes and update data structures. Must be followed by sync_runs().
-
-        Only updates mappings and data structures. Hooks and parameter resets
-        are deferred to sync_runs() so all ranks execute them together.
-        """
-        run_ids = {run_path.stem for run_path in self.output_dir.glob("run_*")}
-        deleted_runs = self.id_2_idx.keys() - run_ids
-        new_runs = run_ids - self.id_2_idx.keys()
-
-        for deleted_run in deleted_runs:
-            deleted_idx = self.id_2_idx[deleted_run]
-            self._delete_run_data(deleted_run, deleted_idx)
-
-        for new_run in new_runs:
-            try:
-                new_id = next(iter(self.unused_idxs))
-
-                config = self.get_orchestrator_config(new_run)
-                if config is None:
-                    continue
-
-                self._create_run_data(new_run, new_id, config)
-                for hook in self._create_run_data_hooks:
-                    hook(new_id, new_run, config)
-            except StopIteration:
-                continue
-
-    def sync_runs(self) -> None:
-        """Sync run state across ranks and execute hooks.
-
-        Master calculates what changed since last sync using _last_synced_id_2_idx.
-        This matches what non-master ranks will calculate as new/deleted runs.
-        All ranks then execute hooks and parameter resets together.
-        """
-
-        if self.world.is_master:
-            # Compute scaling factors for new runs before sync
-            new_runs = self.id_2_idx.keys() - self._last_synced_id_2_idx.keys()
-            for new_run in new_runs:
-                new_id = self.id_2_idx[new_run]
-                if self._scaling_hook is not None:
-                    self.scaling_factors[new_id] = self._scaling_hook(self.config[new_id])
-
-            # Include configs for new runs so non-master ranks have them
-            new_configs = {new_run: self.config[self.id_2_idx[new_run]] for new_run in new_runs}
-
-            sync_data = {
-                "id_2_idx": self.id_2_idx,
-                "ready_to_update": self.ready_to_update,
-                "scaling_factors": self.scaling_factors.cpu(),
-                "new_configs": new_configs,
-                "progress": self.progress,
-            }
-            self.store.set("runs", pickle.dumps(sync_data))
-        dist.barrier()
-
-        if self.world.is_master:
-            # Calculate changes since last sync (this is what other ranks will see)
-            new_runs = self.id_2_idx.keys() - self._last_synced_id_2_idx.keys()
-            deleted_runs = self._last_synced_id_2_idx.keys() - self.id_2_idx.keys()
-            # Capture deleted indices from last synced state (already removed from id_2_idx)
-            deleted_run_idxs = {run: self._last_synced_id_2_idx[run] for run in deleted_runs}
-        else:
-            sync_data: dict = pickle.loads(self.store.get("runs"))
-            new_id_2_idx: dict[str, int] = sync_data["id_2_idx"]
-            self.ready_to_update = sync_data["ready_to_update"]
-            self.scaling_factors.copy_(sync_data["scaling_factors"])
-            new_configs: dict[str, "OrchestratorConfig"] = sync_data["new_configs"]
-            master_progress: dict[int, Progress] = sync_data["progress"]
-
-            new_runs = new_id_2_idx.keys() - self.id_2_idx.keys()
-            deleted_runs = self.id_2_idx.keys() - new_id_2_idx.keys()
-            # Capture deleted indices before removing from id_2_idx
-            deleted_run_idxs = {run: self.id_2_idx[run] for run in deleted_runs}
-
-            # Other ranks catch up with master's data state
-            for deleted_run in deleted_runs:
-                deleted_idx = deleted_run_idxs[deleted_run]
-                self._delete_run_data(deleted_run, deleted_idx)
-
-            for new_run in new_runs:
-                new_id = new_id_2_idx[new_run]
-                self._create_run_data(new_run, new_id, new_configs[new_run])
-
-            # Sync progress from master
-            self.progress = master_progress
-
-        # Call deletion hooks on all ranks
-        for deleted_run in deleted_runs:
-            deleted_idx = deleted_run_idxs[deleted_run]
-            self._delete_run_hooks(deleted_idx, deleted_run)
-
-        for new_run in new_runs:
-            new_id = self.id_2_idx[new_run]
-            self._create_run_hooks(new_id, new_run)
-
-        # Update last synced state for master
-        if self.world.is_master:
-            self._last_synced_id_2_idx = self.id_2_idx.copy()
-
-    @property
-    def used_idxs(self):
-        return sorted(self.idx_2_id.keys())
-
-    @property
-    def ready_to_update_idxs(self):
-        return [idx for idx, ready in enumerate(self.ready_to_update) if ready]
-
-    def run_dirs(self) -> list[Path]:
-        return [self.output_dir / run_id for run_id in self.id_2_idx.keys()]
-
-    def get_run_dir(self, idx: int) -> Path:
-        return self.output_dir / self.idx_2_id[idx]
+    # =========================================================================
+    # Hook Registration
+    # =========================================================================
 
     def register_creation_hook(self, hook: Callable[[int, str], None]) -> None:
         """Register a hook to be called when a new run is created.
@@ -338,10 +101,41 @@ class Runs:
         """
         self._deletion_hooks.append(hook)
 
+    def register_discovered_hook(self, hook: Callable[[int, str, "OrchestratorConfig"], None]) -> None:
+        """Register a hook to be called when a new run is discovered (master only).
+
+        Args:
+            hook: A callable that takes (idx: int, run_id: str, config: OrchestratorConfig).
+                  Called only on master rank in discover_runs() when a new run is found.
+        """
+        self._discovered_hooks.append(hook)
+
+    def register_forgotten_hook(self, hook: Callable[[int, str], None]) -> None:
+        """Register a hook to be called when a run is forgotten/removed (master only).
+
+        Args:
+            hook: A callable that takes (idx: int, run_id: str).
+                  Called only on master rank in discover_runs() when a run is removed.
+        """
+        self._forgotten_hooks.append(hook)
+
+    def register_config_validation_hook(self, hook: Callable[["OrchestratorConfig"], tuple[bool, str]]) -> None:
+        """Register a hook to validate orchestrator config when a run is created.
+
+        Args:
+            hook: A callable that takes (config: OrchestratorConfig) and returns
+                  (is_valid: bool, error_message: str). Error message is used when invalid.
+        """
+        self._config_validation_hooks.append(hook)
+
+    # =========================================================================
+    # Module Registration and Parameter Management
+    # =========================================================================
+
     def register_module(self, prefix: str, module: "MultiLoRALinear") -> None:
         """Register a MultiLoRALinear module with its FQN prefix.
 
-        This allows Runs to manage parameter access, reset, and state dict slicing
+        This allows RunsManager to manage parameter access, reset, and state dict slicing
         for multi-adapter LoRA modules.
 
         Args:
@@ -399,22 +193,242 @@ class Runs:
         for _, module in self._modules:
             module.reset_parameters(idx)
 
+    # =========================================================================
+    # Config Loading
+    # =========================================================================
+
+    def get_orchestrator_config(self, run_id: str) -> Optional["OrchestratorConfig"]:
+        """Load and validate orchestrator config for a run.
+
+        Returns None if config doesn't exist, fails to parse, or fails validation.
+        Writes error to config dir for orchestrator to consume.
+        """
+        config_path = self.output_dir / run_id / "configs" / "orch.toml"
+        config_dir = config_path.parent
+        error_path = config_dir / "error.txt"
+
+        if not config_path.exists():
+            if not error_path.exists():
+                config_dir.mkdir(parents=True, exist_ok=True)
+                with open(error_path, "w") as f:
+                    f.write(f"No orchestrator config found at {config_path}\n")
+            self.logger.error(f"Run {run_id}: No orchestrator config found at {config_path}")
+            return None
+
+        try:
+            with open(config_path, "rb") as f:
+                config_dict = tomli.load(f)
+
+            from prime_rl.orchestrator.config import OrchestratorConfig
+
+            config = OrchestratorConfig(**config_dict)
+        except Exception as e:
+            config_dir.mkdir(parents=True, exist_ok=True)
+            with open(error_path, "w") as f:
+                f.write(f"Error parsing orchestrator config:\n{str(e)}\n")
+            self.logger.error(f"Run {run_id}: Error parsing orchestrator config: {e}")
+            return None
+
+        # Run registered validation hooks
+        for hook in self._config_validation_hooks:
+            is_valid, error_message = hook(config)
+            if not is_valid:
+                self.logger.error(f"Run {run_id}: {error_message}")
+                config_dir.mkdir(parents=True, exist_ok=True)
+                with open(error_path, "w") as f:
+                    f.write(f"{error_message}\n")
+                return None
+
+        # Config is valid, remove any stale error file
+        if error_path.exists():
+            error_path.unlink()
+
+        return config
+
+    # =========================================================================
+    # Internal Run Data Helpers
+    # =========================================================================
+
+    def _create_run_data(self, new_run: str, new_id: int, config: "OrchestratorConfig") -> None:
+        """Update data structures for a new run (no hooks or param reset)."""
+        self.id_2_idx[new_run] = new_id
+        self.unused_idxs.remove(new_id)
+        self.idx_2_id[new_id] = new_run
+
+        # Get progress
+        self.progress[new_id] = Progress()
+
+        prev_ckpt_steps = [
+            int(i.stem.split("_")[-1]) for i in (self.get_run_dir(new_id) / "checkpoints").glob("step_*")
+        ]
+        self.progress[new_id].step = max(prev_ckpt_steps) if prev_ckpt_steps else 0
+
+        # Store the parsed config
+        self.config[new_id] = config
+
+    def _delete_run_data(self, deleted_run: str, deleted_idx: int) -> None:
+        """Update data structures for a deleted run (internal cleanup only, no hooks)."""
+        del self.progress[deleted_idx]
+        if deleted_idx in self.config:
+            del self.config[deleted_idx]
+
+        # A big value might help make it error loudly
+        self.scaling_factors[deleted_idx] = 1000_000.0
+
+        # Process mappings
+        self.unused_idxs.add(deleted_idx)
+        del self.idx_2_id[deleted_idx]
+        del self.id_2_idx[deleted_run]
+
+    def _create_run_hooks(self, new_id: int, new_run: str) -> None:
+        """Reset parameters and call creation hooks for a run."""
+        self.reset_run_parameters(new_id)
+        for hook in self._creation_hooks:
+            hook(new_id, new_run)
+
+    def _delete_run_hooks(self, deleted_idx: int, deleted_run: str) -> None:
+        """Call deletion hooks for a run."""
+        for hook in self._deletion_hooks:
+            hook(deleted_idx, deleted_run)
+
+    # =========================================================================
+    # Run Discovery and Synchronization
+    # =========================================================================
+
+    def discover_runs(self) -> None:
+        """Detect run changes and update data structures (master only). Must be followed by sync_runs().
+
+        Scans for new/deleted runs, calls forgotten/discovered hooks (master only),
+        and updates internal data structures. Hooks and parameter resets for all ranks
+        are deferred to sync_runs().
+        """
+        run_ids = {run_path.stem for run_path in self.output_dir.glob("run_*")}
+        deleted_runs = self.id_2_idx.keys() - run_ids
+        new_runs = run_ids - self.id_2_idx.keys()
+
+        for deleted_run in deleted_runs:
+            deleted_idx = self.id_2_idx[deleted_run]
+            # Call forgotten hooks (master only) before cleanup
+            for hook in self._forgotten_hooks:
+                hook(deleted_idx, deleted_run)
+            self._delete_run_data(deleted_run, deleted_idx)
+
+        for new_run in new_runs:
+            try:
+                new_id = next(iter(self.unused_idxs))
+
+                config = self.get_orchestrator_config(new_run)
+                if config is None:
+                    continue
+
+                self._create_run_data(new_run, new_id, config)
+                # Call discovered hooks (master only) after data setup
+                for hook in self._discovered_hooks:
+                    hook(new_id, new_run, config)
+            except StopIteration:
+                continue
+
+    def sync_runs(self) -> None:
+        """Sync run state across ranks and execute hooks.
+
+        Master calculates what changed since last sync using _last_synced_id_2_idx.
+        This matches what non-master ranks will calculate as new/deleted runs.
+        All ranks then execute hooks and parameter resets together.
+        """
+
+        if self.world.is_master:
+            # Include configs for new runs so non-master ranks have them
+            new_runs = self.id_2_idx.keys() - self._last_synced_id_2_idx.keys()
+            new_configs = {new_run: self.config[self.id_2_idx[new_run]] for new_run in new_runs}
+
+            sync_data = {
+                "id_2_idx": self.id_2_idx,
+                "ready_to_update": self.ready_to_update,
+                "scaling_factors": self.scaling_factors.cpu(),
+                "new_configs": new_configs,
+                "progress": self.progress,
+            }
+            self.store.set("runs", pickle.dumps(sync_data))
+        dist.barrier()
+
+        if self.world.is_master:
+            # Calculate changes since last sync (this is what other ranks will see)
+            new_runs = self.id_2_idx.keys() - self._last_synced_id_2_idx.keys()
+            deleted_runs = self._last_synced_id_2_idx.keys() - self.id_2_idx.keys()
+            # Capture deleted indices from last synced state (already removed from id_2_idx)
+            deleted_run_idxs = {run: self._last_synced_id_2_idx[run] for run in deleted_runs}
+        else:
+            sync_data: dict = pickle.loads(self.store.get("runs"))
+            new_id_2_idx: dict[str, int] = sync_data["id_2_idx"]
+            self.ready_to_update = sync_data["ready_to_update"]
+            self.scaling_factors.copy_(sync_data["scaling_factors"])
+            new_configs: dict[str, "OrchestratorConfig"] = sync_data["new_configs"]
+            master_progress: dict[int, Progress] = sync_data["progress"]
+
+            new_runs = new_id_2_idx.keys() - self.id_2_idx.keys()
+            deleted_runs = self.id_2_idx.keys() - new_id_2_idx.keys()
+            # Capture deleted indices before removing from id_2_idx
+            deleted_run_idxs = {run: self.id_2_idx[run] for run in deleted_runs}
+
+            # Other ranks catch up with master's data state
+            for deleted_run in deleted_runs:
+                deleted_idx = deleted_run_idxs[deleted_run]
+                self._delete_run_data(deleted_run, deleted_idx)
+
+            for new_run in new_runs:
+                new_id = new_id_2_idx[new_run]
+                self._create_run_data(new_run, new_id, new_configs[new_run])
+
+            # Sync progress from master
+            self.progress = master_progress
+
+        # Call deletion hooks on all ranks
+        for deleted_run in deleted_runs:
+            deleted_idx = deleted_run_idxs[deleted_run]
+            self._delete_run_hooks(deleted_idx, deleted_run)
+
+        for new_run in new_runs:
+            new_id = self.id_2_idx[new_run]
+            self._create_run_hooks(new_id, new_run)
+
+        # Update last synced state for master
+        if self.world.is_master:
+            self._last_synced_id_2_idx = self.id_2_idx.copy()
+
+    # =========================================================================
+    # Properties and Accessors
+    # =========================================================================
+
+    @property
+    def used_idxs(self):
+        return sorted(self.idx_2_id.keys())
+
+    @property
+    def ready_to_update_idxs(self):
+        return [idx for idx, ready in enumerate(self.ready_to_update) if ready]
+
+    def run_dirs(self) -> list[Path]:
+        return [self.output_dir / run_id for run_id in self.id_2_idx.keys()]
+
+    def get_run_dir(self, idx: int) -> Path:
+        return self.output_dir / self.idx_2_id[idx]
+
     def __repr__(self):
-        return f"Runs(max={self.max_runs})[{self.idx_2_id.keys()}]"
+        return f"RunsManager(max={self.max_runs})[{self.idx_2_id.keys()}]"
 
 
-# Singleton instance of Tenants
-_RUNS: Runs | None = None
+# Singleton instance of RunsManager
+_RUNS_MANAGER: RunsManager | None = None
 
 
-def get_runs() -> Runs:
-    """Returns the World. If not initialized, it will initialize."""
-    global _RUNS
-    if _RUNS is None:
-        raise RuntimeError("Runs not initialized. Please call `setup_runs` first.")
-    return _RUNS
+def get_runs_manager() -> RunsManager:
+    """Returns the RunsManager singleton. Must be initialized first via setup_runs_manager()."""
+    global _RUNS_MANAGER
+    if _RUNS_MANAGER is None:
+        raise RuntimeError("RunsManager not initialized. Please call `setup_runs_manager` first.")
+    return _RUNS_MANAGER
 
 
-def setup_runs(output_dir: Path, max_runs: int, device: torch.device):
-    global _RUNS
-    _RUNS = Runs(output_dir, max_runs, device)
+def setup_runs_manager(output_dir: Path, max_runs: int, device: torch.device):
+    global _RUNS_MANAGER
+    _RUNS_MANAGER = RunsManager(output_dir, max_runs, device)

--- a/src/prime_rl/trainer/runs.py
+++ b/src/prime_rl/trainer/runs.py
@@ -52,7 +52,7 @@ class MultiRunManager:
         # We use the store to keep other ranks in sync with master
         self.store = c10d._get_default_store()
         self.world = get_world()
-        # Track id_2_idx state at last sync_runs to calculate diffs
+        # Track id_2_idx state at last synchronize_state to calculate diffs
         self._last_synced_id_2_idx: dict[str, int] = {}
 
         # Store modules with their FQN prefixes for parameter management
@@ -302,11 +302,11 @@ class MultiRunManager:
     # =========================================================================
 
     def discover_runs(self) -> None:
-        """Detect run changes and update data structures (master only). Must be followed by sync_runs().
+        """Detect run changes and update data structures (master only). Must be followed by synchronize_state().
 
         Scans for new/deleted runs, calls forgotten/discovered hooks (master only),
         and updates internal data structures. Hooks and parameter resets for all ranks
-        are deferred to sync_runs().
+        are deferred to synchronize_state().
         """
         if not self.world.is_master:
             raise RuntimeError("discover_runs() must only be called on the master rank")
@@ -336,7 +336,7 @@ class MultiRunManager:
             except StopIteration:
                 continue
 
-    def sync_runs(self) -> None:
+    def synchronize_state(self) -> None:
         """Sync run state across ranks and execute hooks.
 
         Master calculates what changed since last sync using _last_synced_id_2_idx.

--- a/src/prime_rl/trainer/runs.py
+++ b/src/prime_rl/trainer/runs.py
@@ -23,7 +23,7 @@ class Progress:
     total_samples: int = 0
 
 
-class RunsManager:
+class MultiRunManager:
     """This class stores information about the runs in the system."""
 
     # =========================================================================
@@ -135,7 +135,7 @@ class RunsManager:
     def register_module(self, prefix: str, module: "MultiLoRALinear") -> None:
         """Register a MultiLoRALinear module with its FQN prefix.
 
-        This allows RunsManager to manage parameter access, reset, and state dict slicing
+        This allows MultiRunManager to manage parameter access, reset, and state dict slicing
         for multi-adapter LoRA modules.
 
         Args:
@@ -414,21 +414,21 @@ class RunsManager:
         return self.output_dir / self.idx_2_id[idx]
 
     def __repr__(self):
-        return f"RunsManager(max={self.max_runs})[{self.idx_2_id.keys()}]"
+        return f"MultiRunManager(max={self.max_runs})[{self.idx_2_id.keys()}]"
 
 
-# Singleton instance of RunsManager
-_RUNS_MANAGER: RunsManager | None = None
+# Singleton instance of MultiRunManager
+_MULTI_RUN_MANAGER: MultiRunManager | None = None
 
 
-def get_runs_manager() -> RunsManager:
-    """Returns the RunsManager singleton. Must be initialized first via setup_runs_manager()."""
-    global _RUNS_MANAGER
-    if _RUNS_MANAGER is None:
-        raise RuntimeError("RunsManager not initialized. Please call `setup_runs_manager` first.")
-    return _RUNS_MANAGER
+def get_multi_run_manager() -> MultiRunManager:
+    """Returns the MultiRunManager singleton. Must be initialized first via setup_multi_run_manager()."""
+    global _MULTI_RUN_MANAGER
+    if _MULTI_RUN_MANAGER is None:
+        raise RuntimeError("MultiRunManager not initialized. Please call `setup_multi_run_manager` first.")
+    return _MULTI_RUN_MANAGER
 
 
-def setup_runs_manager(output_dir: Path, max_runs: int, device: torch.device):
-    global _RUNS_MANAGER
-    _RUNS_MANAGER = RunsManager(output_dir, max_runs, device)
+def setup_multi_run_manager(output_dir: Path, max_runs: int, device: torch.device):
+    global _MULTI_RUN_MANAGER
+    _MULTI_RUN_MANAGER = MultiRunManager(output_dir, max_runs, device)

--- a/src/prime_rl/trainer/scheduler.py
+++ b/src/prime_rl/trainer/scheduler.py
@@ -126,17 +126,17 @@ class MultiLoRAScheduler:
     ):
         self.scheduler_config = scheduler_config
         self.max_steps = max_steps
-        self.runs = get_multi_run_manager()
+        self.multi_run_manager = get_multi_run_manager()
         self.logger = get_logger()
 
-        self.schedulers: list[LRScheduler | None] = [None] * self.runs.max_runs
+        self.schedulers: list[LRScheduler | None] = [None] * self.multi_run_manager.max_runs
 
     def scheduler_creation_hook(self, optimizer: Optimizer, idx: int) -> None:
         """Create a scheduler for a newly created optimizer.
 
         This should be called after an optimizer is created for a run.
         """
-        lr = self.runs.config[idx].optim.lr
+        lr = self.multi_run_manager.config[idx].optim.lr
         self.schedulers[idx] = setup_scheduler(
             optimizer,
             self.scheduler_config,
@@ -146,7 +146,7 @@ class MultiLoRAScheduler:
 
     def step(self) -> None:
         """Step all active schedulers."""
-        for idx in self.runs.ready_to_update_idxs:
+        for idx in self.multi_run_manager.ready_to_update_idxs:
             self.schedulers[idx].step()
 
     def get_last_lr(self, idx: int) -> list[float]:

--- a/src/prime_rl/trainer/scheduler.py
+++ b/src/prime_rl/trainer/scheduler.py
@@ -4,7 +4,7 @@ from torch.optim import Optimizer
 from torch.optim.lr_scheduler import ConstantLR, CosineAnnealingLR, LinearLR, LRScheduler, SequentialLR
 
 from prime_rl.trainer.config import SchedulerConfigType
-from prime_rl.trainer.runs import get_runs_manager
+from prime_rl.trainer.runs import get_multi_run_manager
 from prime_rl.utils.logger import get_logger
 
 if TYPE_CHECKING:
@@ -126,7 +126,7 @@ class MultiLoRAScheduler:
     ):
         self.scheduler_config = scheduler_config
         self.max_steps = max_steps
-        self.runs = get_runs_manager()
+        self.runs = get_multi_run_manager()
         self.logger = get_logger()
 
         self.schedulers: list[LRScheduler | None] = [None] * self.runs.max_runs

--- a/src/prime_rl/trainer/scheduler.py
+++ b/src/prime_rl/trainer/scheduler.py
@@ -4,7 +4,7 @@ from torch.optim import Optimizer
 from torch.optim.lr_scheduler import ConstantLR, CosineAnnealingLR, LinearLR, LRScheduler, SequentialLR
 
 from prime_rl.trainer.config import SchedulerConfigType
-from prime_rl.trainer.runs import get_runs
+from prime_rl.trainer.runs import get_runs_manager
 from prime_rl.utils.logger import get_logger
 
 if TYPE_CHECKING:
@@ -126,7 +126,7 @@ class MultiLoRAScheduler:
     ):
         self.scheduler_config = scheduler_config
         self.max_steps = max_steps
-        self.runs = get_runs()
+        self.runs = get_runs_manager()
         self.logger = get_logger()
 
         self.schedulers: list[LRScheduler | None] = [None] * self.runs.max_runs

--- a/src/prime_rl/transport/filesystem.py
+++ b/src/prime_rl/transport/filesystem.py
@@ -35,32 +35,32 @@ class FileSystemTrainingBatchReceiver(TrainingBatchReceiver):
 
     def __init__(self) -> None:
         super().__init__()
-        self.runs = get_multi_run_manager()
+        self.multi_run_manager = get_multi_run_manager()
         self._last_logged_paths: list[Path] | None = None
         self._last_logged_time = time()
         self._waiting_since: float | None = None
-        # Track received steps per run independently of runs.progress[idx].step
+        # Track received steps per run independently of multi_run_manager.progress[idx].step
         # This prevents duplicate reads when trainer step != orchestrator step
         self._received_steps: dict[int, int] = {}
 
     def _get_received_step(self, idx: int) -> int:
         """Get the next step to receive for a run, initializing from progress if needed."""
         if idx not in self._received_steps:
-            # Initialize from runs.progress on first access (for checkpoint resume)
-            self._received_steps[idx] = self.runs.progress[idx].step
+            # Initialize from multi_run_manager.progress on first access (for checkpoint resume)
+            self._received_steps[idx] = self.multi_run_manager.progress[idx].step
         return self._received_steps[idx]
 
     def _get_batch_path(self, idx: int) -> Path:
         """Get the batch file path for a specific run at its next step to receive."""
-        run_dir = self.runs.get_run_dir(idx)
+        run_dir = self.multi_run_manager.get_run_dir(idx)
         rollout_dir = get_rollout_dir(run_dir)
         step = self._get_received_step(idx)
         return get_step_path(rollout_dir, step) / BATCH_FILE_NAME
 
     def can_receive(self) -> bool:
         """Check if any run has a batch file available."""
-        for idx in self.runs.used_idxs:
-            if not self.runs.ready_to_update[idx] and self._get_batch_path(idx).exists():
+        for idx in self.multi_run_manager.used_idxs:
+            if not self.multi_run_manager.ready_to_update[idx] and self._get_batch_path(idx).exists():
                 return True
         return False
 
@@ -75,7 +75,7 @@ class FileSystemTrainingBatchReceiver(TrainingBatchReceiver):
         else:
             self._waiting_since = self._waiting_since or now
 
-        current_paths = [self._get_batch_path(idx) for idx in self.runs.used_idxs]
+        current_paths = [self._get_batch_path(idx) for idx in self.multi_run_manager.used_idxs]
         if current_paths != self._last_logged_paths or now - self._last_logged_time > LOG_FREQ_SECONDS:
             if len(current_paths) == 0:
                 self.logger.debug(
@@ -87,8 +87,8 @@ class FileSystemTrainingBatchReceiver(TrainingBatchReceiver):
             self.logger.debug(f"Looking for batches in {current_paths}{waiting_suffix}")
             self._last_logged_paths = current_paths
             self._last_logged_time = now
-        for idx in list(self.runs.used_idxs):
-            if self.runs.ready_to_update[idx]:
+        for idx in self.multi_run_manager.used_idxs:
+            if self.multi_run_manager.ready_to_update[idx]:
                 continue
             batch_path = self._get_batch_path(idx)
             if batch_path.exists():
@@ -107,7 +107,7 @@ class FileSystemTrainingBatchReceiver(TrainingBatchReceiver):
         """Reset received step tracking for a run index.
 
         Called when a run is deleted and a new run takes its place.
-        The next access to _get_received_step will re-initialize from runs.progress.
+        The next access to _get_received_step will re-initialize from multi_run_manager.progress.
         """
         if idx in self._received_steps:
             del self._received_steps[idx]

--- a/src/prime_rl/transport/filesystem.py
+++ b/src/prime_rl/transport/filesystem.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from time import time
 
-from prime_rl.trainer.runs import get_runs
+from prime_rl.trainer.runs import get_runs_manager
 from prime_rl.transport.base import MicroBatchReceiver, MicroBatchSender, TrainingBatchReceiver, TrainingBatchSender
 from prime_rl.transport.types import MicroBatch, TrainingBatch
 from prime_rl.utils.pathing import get_rollout_dir, get_step_path, sync_wait_for_path
@@ -35,7 +35,7 @@ class FileSystemTrainingBatchReceiver(TrainingBatchReceiver):
 
     def __init__(self) -> None:
         super().__init__()
-        self.runs = get_runs()
+        self.runs = get_runs_manager()
         self._last_logged_paths: list[Path] | None = None
         self._last_logged_time = time()
         self._waiting_since: float | None = None

--- a/src/prime_rl/transport/filesystem.py
+++ b/src/prime_rl/transport/filesystem.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from time import time
 
-from prime_rl.trainer.runs import get_runs_manager
+from prime_rl.trainer.runs import get_multi_run_manager
 from prime_rl.transport.base import MicroBatchReceiver, MicroBatchSender, TrainingBatchReceiver, TrainingBatchSender
 from prime_rl.transport.types import MicroBatch, TrainingBatch
 from prime_rl.utils.pathing import get_rollout_dir, get_step_path, sync_wait_for_path
@@ -35,7 +35,7 @@ class FileSystemTrainingBatchReceiver(TrainingBatchReceiver):
 
     def __init__(self) -> None:
         super().__init__()
-        self.runs = get_runs_manager()
+        self.runs = get_multi_run_manager()
         self._last_logged_paths: list[Path] | None = None
         self._last_logged_time = time()
         self._waiting_since: float | None = None

--- a/src/prime_rl/transport/zmq.py
+++ b/src/prime_rl/transport/zmq.py
@@ -3,7 +3,7 @@ from time import time
 
 import zmq
 
-from prime_rl.trainer.runs import get_runs_manager
+from prime_rl.trainer.runs import get_multi_run_manager
 from prime_rl.transport.base import MicroBatchReceiver, MicroBatchSender, TrainingBatchReceiver, TrainingBatchSender
 from prime_rl.transport.config import ZMQTransportConfig
 from prime_rl.transport.types import MicroBatch, TrainingBatch
@@ -57,7 +57,7 @@ class ZMQTrainingBatchReceiver(TrainingBatchReceiver):
 
     def __init__(self, transport: ZMQTransportConfig):
         super().__init__()
-        self.runs = get_runs_manager()
+        self.runs = get_multi_run_manager()
         self._last_logged_time = time()
         self._last_logged_ids: list[str] | None = None
         self._waiting_since: float | None = None

--- a/src/prime_rl/transport/zmq.py
+++ b/src/prime_rl/transport/zmq.py
@@ -3,7 +3,7 @@ from time import time
 
 import zmq
 
-from prime_rl.trainer.runs import get_runs
+from prime_rl.trainer.runs import get_runs_manager
 from prime_rl.transport.base import MicroBatchReceiver, MicroBatchSender, TrainingBatchReceiver, TrainingBatchSender
 from prime_rl.transport.config import ZMQTransportConfig
 from prime_rl.transport.types import MicroBatch, TrainingBatch
@@ -57,7 +57,7 @@ class ZMQTrainingBatchReceiver(TrainingBatchReceiver):
 
     def __init__(self, transport: ZMQTransportConfig):
         super().__init__()
-        self.runs = get_runs()
+        self.runs = get_runs_manager()
         self._last_logged_time = time()
         self._last_logged_ids: list[str] | None = None
         self._waiting_since: float | None = None

--- a/src/prime_rl/transport/zmq.py
+++ b/src/prime_rl/transport/zmq.py
@@ -57,7 +57,7 @@ class ZMQTrainingBatchReceiver(TrainingBatchReceiver):
 
     def __init__(self, transport: ZMQTransportConfig):
         super().__init__()
-        self.runs = get_multi_run_manager()
+        self.multi_run_manager = get_multi_run_manager()
         self._last_logged_time = time()
         self._last_logged_ids: list[str] | None = None
         self._waiting_since: float | None = None
@@ -116,10 +116,10 @@ class ZMQTrainingBatchReceiver(TrainingBatchReceiver):
 
         # Track how long we've been waiting for any runnable batch.
         runnable_available = False
-        for idx in self.runs.used_idxs:
-            if self.runs.ready_to_update[idx]:
+        for idx in self.multi_run_manager.used_idxs:
+            if self.multi_run_manager.ready_to_update[idx]:
                 continue
-            run_id = self.runs.idx_2_id[idx].encode("utf-8")
+            run_id = self.multi_run_manager.idx_2_id[idx].encode("utf-8")
             if self._pending.get(run_id):
                 runnable_available = True
                 break
@@ -129,7 +129,7 @@ class ZMQTrainingBatchReceiver(TrainingBatchReceiver):
         else:
             self._waiting_since = self._waiting_since or now
 
-        current_ids = [self.runs.idx_2_id[idx] for idx in self.runs.used_idxs]
+        current_ids = [self.multi_run_manager.idx_2_id[idx] for idx in self.multi_run_manager.used_idxs]
         if current_ids != self._last_logged_ids or now - self._last_logged_time > LOG_FREQ_SECONDS:
             if len(current_ids) == 0:
                 self.logger.debug(
@@ -142,9 +142,9 @@ class ZMQTrainingBatchReceiver(TrainingBatchReceiver):
             self._last_logged_ids = current_ids
             self._last_logged_time = now
 
-        for idx in list(self.runs.used_idxs):
-            run_id = self.runs.idx_2_id[idx].encode("utf-8")
-            if self.runs.ready_to_update[idx]:
+        for idx in list(self.multi_run_manager.used_idxs):
+            run_id = self.multi_run_manager.idx_2_id[idx].encode("utf-8")
+            if self.multi_run_manager.ready_to_update[idx]:
                 continue
 
             per_id_batches = self._pending.get(run_id)

--- a/tests/unit/train/test_runs.py
+++ b/tests/unit/train/test_runs.py
@@ -5,7 +5,7 @@ import pytest
 import tomli_w
 import torch.distributed as dist
 
-from prime_rl.trainer.runs import RunsManager
+from prime_rl.trainer.runs import MultiRunManager
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -51,8 +51,8 @@ def create_run_with_config(
 
 
 def test_initial_state(tmp_path: Path) -> None:
-    """Test that RunsManager initializes correctly."""
-    runs = RunsManager(output_dir=tmp_path, max_runs=5)
+    """Test that MultiRunManager initializes correctly."""
+    runs = MultiRunManager(output_dir=tmp_path, max_runs=5)
 
     assert runs.output_dir == tmp_path
     assert runs.max_runs == 5
@@ -64,7 +64,7 @@ def test_initial_state(tmp_path: Path) -> None:
 
 def test_detect_new_runs(tmp_path: Path) -> None:
     """Test that new runs are detected correctly."""
-    runs = RunsManager(output_dir=tmp_path, max_runs=5)
+    runs = MultiRunManager(output_dir=tmp_path, max_runs=5)
 
     # Create some run directories with valid configs
     for run_name in ["run_abc123", "run_def456"]:
@@ -93,7 +93,7 @@ def test_detect_new_runs(tmp_path: Path) -> None:
 
 def test_detect_deleted_runs(tmp_path: Path) -> None:
     """Test that deleted runs are detected correctly."""
-    runs = RunsManager(output_dir=tmp_path, max_runs=5)
+    runs = MultiRunManager(output_dir=tmp_path, max_runs=5)
 
     # Create run directories with valid configs
     for run_name in ["run_abc123", "run_def456"]:
@@ -129,7 +129,7 @@ def test_detect_deleted_runs(tmp_path: Path) -> None:
 
 def test_max_runs_limit(tmp_path: Path) -> None:
     """Test that only max_runs are tracked."""
-    runs = RunsManager(output_dir=tmp_path, max_runs=2)
+    runs = MultiRunManager(output_dir=tmp_path, max_runs=2)
 
     # Create more runs than max_runs with valid configs
     for run_name in ["run_001", "run_002", "run_003"]:
@@ -157,7 +157,7 @@ def test_max_runs_limit(tmp_path: Path) -> None:
 
 def test_run_dirs(tmp_path: Path) -> None:
     """Test that run_dirs returns correct paths."""
-    runs = RunsManager(output_dir=tmp_path, max_runs=5)
+    runs = MultiRunManager(output_dir=tmp_path, max_runs=5)
 
     # Create run directories with valid configs
     for run_name in ["run_abc", "run_def"]:
@@ -173,7 +173,7 @@ def test_run_dirs(tmp_path: Path) -> None:
 
 def test_non_run_directories_ignored(tmp_path: Path) -> None:
     """Test that non-run directories are ignored."""
-    runs = RunsManager(output_dir=tmp_path, max_runs=5)
+    runs = MultiRunManager(output_dir=tmp_path, max_runs=5)
 
     # Create mix of run and non-run directories
     create_run_with_config(tmp_path, "run_abc")
@@ -192,7 +192,7 @@ def test_non_run_directories_ignored(tmp_path: Path) -> None:
 
 def test_config_loading(tmp_path: Path) -> None:
     """Test that orchestrator configs are loaded correctly."""
-    runs = RunsManager(output_dir=tmp_path, max_runs=5)
+    runs = MultiRunManager(output_dir=tmp_path, max_runs=5)
 
     # Create a run directory with config
     test_config = {
@@ -221,7 +221,7 @@ def test_config_loading(tmp_path: Path) -> None:
 
 def test_config_missing(tmp_path: Path) -> None:
     """Test that runs without configs are skipped and error.txt is created."""
-    runs = RunsManager(output_dir=tmp_path, max_runs=5)
+    runs = MultiRunManager(output_dir=tmp_path, max_runs=5)
 
     # Create a run directory without config
     run_dir = tmp_path / "run_noconfig"
@@ -243,7 +243,7 @@ def test_config_missing(tmp_path: Path) -> None:
 
 def test_config_cleanup_on_deletion(tmp_path: Path) -> None:
     """Test that configs are cleaned up when runs are deleted."""
-    runs = RunsManager(output_dir=tmp_path, max_runs=5)
+    runs = MultiRunManager(output_dir=tmp_path, max_runs=5)
 
     # Create a run directory with valid config
     test_config = {
@@ -272,7 +272,7 @@ def test_config_cleanup_on_deletion(tmp_path: Path) -> None:
 
 def test_config_invalid(tmp_path: Path) -> None:
     """Test that runs with invalid configs are skipped and error.txt is created."""
-    runs = RunsManager(output_dir=tmp_path, max_runs=5)
+    runs = MultiRunManager(output_dir=tmp_path, max_runs=5)
 
     # Create a run directory with invalid config (invalid type for a field)
     # Invalid config - batch_size should be int, not string

--- a/tests/unit/train/test_runs.py
+++ b/tests/unit/train/test_runs.py
@@ -52,120 +52,120 @@ def create_run_with_config(
 
 def test_initial_state(tmp_path: Path) -> None:
     """Test that MultiRunManager initializes correctly."""
-    runs = MultiRunManager(output_dir=tmp_path, max_runs=5)
+    multi_run_manager = MultiRunManager(output_dir=tmp_path, max_runs=5)
 
-    assert runs.output_dir == tmp_path
-    assert runs.max_runs == 5
-    assert len(runs.idx_2_id) == 0
-    assert len(runs.id_2_idx) == 0
-    assert len(runs.unused_idxs) == 5
-    assert runs.run_dirs() == []
+    assert multi_run_manager.output_dir == tmp_path
+    assert multi_run_manager.max_runs == 5
+    assert len(multi_run_manager.idx_2_id) == 0
+    assert len(multi_run_manager.id_2_idx) == 0
+    assert len(multi_run_manager.unused_idxs) == 5
+    assert multi_run_manager.run_dirs() == []
 
 
 def test_detect_new_runs(tmp_path: Path) -> None:
     """Test that new runs are detected correctly."""
-    runs = MultiRunManager(output_dir=tmp_path, max_runs=5)
+    multi_run_manager = MultiRunManager(output_dir=tmp_path, max_runs=5)
 
     # Create some run directories with valid configs
     for run_name in ["run_abc123", "run_def456"]:
         create_run_with_config(tmp_path, run_name)
 
     # Check for changes
-    runs.discover_runs()
+    multi_run_manager.discover_runs()
 
     # Verify runs were detected
-    assert len(runs.id_2_idx) == 2
-    assert len(runs.idx_2_id) == 2
-    assert "run_abc123" in runs.id_2_idx
-    assert "run_def456" in runs.id_2_idx
+    assert len(multi_run_manager.id_2_idx) == 2
+    assert len(multi_run_manager.idx_2_id) == 2
+    assert "run_abc123" in multi_run_manager.id_2_idx
+    assert "run_def456" in multi_run_manager.id_2_idx
 
     # Verify indices are assigned from available pool
-    assert len(runs.unused_idxs) == 3  # 5 - 2 = 3
-    assert runs.id_2_idx["run_abc123"] in range(5)
-    assert runs.id_2_idx["run_def456"] in range(5)
+    assert len(multi_run_manager.unused_idxs) == 3  # 5 - 2 = 3
+    assert multi_run_manager.id_2_idx["run_abc123"] in range(5)
+    assert multi_run_manager.id_2_idx["run_def456"] in range(5)
 
     # Verify bidirectional mapping
-    idx1 = runs.id_2_idx["run_abc123"]
-    idx2 = runs.id_2_idx["run_def456"]
-    assert runs.idx_2_id[idx1] == "run_abc123"
-    assert runs.idx_2_id[idx2] == "run_def456"
+    idx1 = multi_run_manager.id_2_idx["run_abc123"]
+    idx2 = multi_run_manager.id_2_idx["run_def456"]
+    assert multi_run_manager.idx_2_id[idx1] == "run_abc123"
+    assert multi_run_manager.idx_2_id[idx2] == "run_def456"
 
 
 def test_detect_deleted_runs(tmp_path: Path) -> None:
     """Test that deleted runs are detected correctly."""
-    runs = MultiRunManager(output_dir=tmp_path, max_runs=5)
+    multi_run_manager = MultiRunManager(output_dir=tmp_path, max_runs=5)
 
     # Create run directories with valid configs
     for run_name in ["run_abc123", "run_def456"]:
         create_run_with_config(tmp_path, run_name)
 
     # Detect initial runs
-    runs.discover_runs()
-    initial_idx1 = runs.id_2_idx["run_abc123"]
-    initial_idx2 = runs.id_2_idx["run_def456"]
+    multi_run_manager.discover_runs()
+    initial_idx1 = multi_run_manager.id_2_idx["run_abc123"]
+    initial_idx2 = multi_run_manager.id_2_idx["run_def456"]
 
-    assert len(runs.id_2_idx) == 2
-    assert len(runs.unused_idxs) == 3
+    assert len(multi_run_manager.id_2_idx) == 2
+    assert len(multi_run_manager.unused_idxs) == 3
 
     # Delete one run
     run1 = tmp_path / "run_abc123"
     import shutil
 
     shutil.rmtree(run1)
-    runs.discover_runs()
+    multi_run_manager.discover_runs()
 
     # Verify run was removed
-    assert len(runs.id_2_idx) == 1
-    assert len(runs.idx_2_id) == 1
-    assert "run_abc123" not in runs.id_2_idx
-    assert "run_def456" in runs.id_2_idx
-    assert initial_idx1 not in runs.idx_2_id
+    assert len(multi_run_manager.id_2_idx) == 1
+    assert len(multi_run_manager.idx_2_id) == 1
+    assert "run_abc123" not in multi_run_manager.id_2_idx
+    assert "run_def456" in multi_run_manager.id_2_idx
+    assert initial_idx1 not in multi_run_manager.idx_2_id
 
     # Verify index was returned to unused pool
-    assert len(runs.unused_idxs) == 4
-    assert initial_idx1 in runs.unused_idxs
-    assert initial_idx2 not in runs.unused_idxs
+    assert len(multi_run_manager.unused_idxs) == 4
+    assert initial_idx1 in multi_run_manager.unused_idxs
+    assert initial_idx2 not in multi_run_manager.unused_idxs
 
 
 def test_max_runs_limit(tmp_path: Path) -> None:
     """Test that only max_runs are tracked."""
-    runs = MultiRunManager(output_dir=tmp_path, max_runs=2)
+    multi_run_manager = MultiRunManager(output_dir=tmp_path, max_runs=2)
 
     # Create more runs than max_runs with valid configs
     for run_name in ["run_001", "run_002", "run_003"]:
         create_run_with_config(tmp_path, run_name)
 
-    runs.discover_runs()
+    multi_run_manager.discover_runs()
 
     # Only max_runs should be tracked
-    assert len(runs.id_2_idx) == 2
-    assert len(runs.idx_2_id) == 2
-    assert len(runs.unused_idxs) == 0
+    assert len(multi_run_manager.id_2_idx) == 2
+    assert len(multi_run_manager.idx_2_id) == 2
+    assert len(multi_run_manager.unused_idxs) == 0
 
-    to_delete_run = runs.get_run_dir(0)
+    to_delete_run = multi_run_manager.get_run_dir(0)
     import shutil
 
     shutil.rmtree(to_delete_run)
 
-    runs.discover_runs()
+    multi_run_manager.discover_runs()
 
-    assert len(runs.id_2_idx) == 2
-    assert len(runs.idx_2_id) == 2
-    assert len(runs.unused_idxs) == 0
-    assert to_delete_run not in runs.run_dirs()
+    assert len(multi_run_manager.id_2_idx) == 2
+    assert len(multi_run_manager.idx_2_id) == 2
+    assert len(multi_run_manager.unused_idxs) == 0
+    assert to_delete_run not in multi_run_manager.run_dirs()
 
 
 def test_run_dirs(tmp_path: Path) -> None:
     """Test that run_dirs returns correct paths."""
-    runs = MultiRunManager(output_dir=tmp_path, max_runs=5)
+    multi_run_manager = MultiRunManager(output_dir=tmp_path, max_runs=5)
 
     # Create run directories with valid configs
     for run_name in ["run_abc", "run_def"]:
         create_run_with_config(tmp_path, run_name)
 
-    runs.discover_runs()
+    multi_run_manager.discover_runs()
 
-    run_dirs = runs.run_dirs()
+    run_dirs = multi_run_manager.run_dirs()
     assert len(run_dirs) == 2
     assert tmp_path / "run_abc" in run_dirs
     assert tmp_path / "run_def" in run_dirs
@@ -173,7 +173,7 @@ def test_run_dirs(tmp_path: Path) -> None:
 
 def test_non_run_directories_ignored(tmp_path: Path) -> None:
     """Test that non-run directories are ignored."""
-    runs = MultiRunManager(output_dir=tmp_path, max_runs=5)
+    multi_run_manager = MultiRunManager(output_dir=tmp_path, max_runs=5)
 
     # Create mix of run and non-run directories
     create_run_with_config(tmp_path, "run_abc")
@@ -181,18 +181,18 @@ def test_non_run_directories_ignored(tmp_path: Path) -> None:
     (tmp_path / "other_dir").mkdir()
     (tmp_path / "random").mkdir()
 
-    runs.discover_runs()
+    multi_run_manager.discover_runs()
 
     # Only run_* directories should be tracked
-    assert len(runs.id_2_idx) == 1
-    assert "run_abc" in runs.id_2_idx
-    assert "other_dir" not in runs.id_2_idx
-    assert "random" not in runs.id_2_idx
+    assert len(multi_run_manager.id_2_idx) == 1
+    assert "run_abc" in multi_run_manager.id_2_idx
+    assert "other_dir" not in multi_run_manager.id_2_idx
+    assert "random" not in multi_run_manager.id_2_idx
 
 
 def test_config_loading(tmp_path: Path) -> None:
     """Test that orchestrator configs are loaded correctly."""
-    runs = MultiRunManager(output_dir=tmp_path, max_runs=5)
+    multi_run_manager = MultiRunManager(output_dir=tmp_path, max_runs=5)
 
     # Create a run directory with config
     test_config = {
@@ -205,15 +205,15 @@ def test_config_loading(tmp_path: Path) -> None:
     create_run_with_config(tmp_path, "run_test123", config=test_config)
 
     # Detect the run
-    runs.discover_runs()
+    multi_run_manager.discover_runs()
 
     # Verify config was loaded and parsed as OrchestratorConfig
-    assert len(runs.config) == 1
-    run_idx = runs.id_2_idx["run_test123"]
-    assert run_idx in runs.config
+    assert len(multi_run_manager.config) == 1
+    run_idx = multi_run_manager.id_2_idx["run_test123"]
+    assert run_idx in multi_run_manager.config
 
     # Access config as OrchestratorConfig object
-    config = runs.config[run_idx]
+    config = multi_run_manager.config[run_idx]
     assert config.model.name == "test-model"
     assert config.batch_size == 32
     assert config.max_steps == 1000
@@ -221,18 +221,18 @@ def test_config_loading(tmp_path: Path) -> None:
 
 def test_config_missing(tmp_path: Path) -> None:
     """Test that runs without configs are skipped and error.txt is created."""
-    runs = MultiRunManager(output_dir=tmp_path, max_runs=5)
+    multi_run_manager = MultiRunManager(output_dir=tmp_path, max_runs=5)
 
     # Create a run directory without config
     run_dir = tmp_path / "run_noconfig"
     run_dir.mkdir()
 
     # Detect the run
-    runs.discover_runs()
+    multi_run_manager.discover_runs()
 
     # Verify run was not added
-    assert len(runs.config) == 0
-    assert "run_noconfig" not in runs.id_2_idx
+    assert len(multi_run_manager.config) == 0
+    assert "run_noconfig" not in multi_run_manager.id_2_idx
 
     # Verify error.txt was created
     error_path = run_dir / "configs" / "error.txt"
@@ -243,7 +243,7 @@ def test_config_missing(tmp_path: Path) -> None:
 
 def test_config_cleanup_on_deletion(tmp_path: Path) -> None:
     """Test that configs are cleaned up when runs are deleted."""
-    runs = MultiRunManager(output_dir=tmp_path, max_runs=5)
+    multi_run_manager = MultiRunManager(output_dir=tmp_path, max_runs=5)
 
     # Create a run directory with valid config
     test_config = {
@@ -255,24 +255,24 @@ def test_config_cleanup_on_deletion(tmp_path: Path) -> None:
     run_dir = create_run_with_config(tmp_path, "run_delete_me", config=test_config)
 
     # Detect the run
-    runs.discover_runs()
-    run_idx = runs.id_2_idx["run_delete_me"]
-    assert run_idx in runs.config
+    multi_run_manager.discover_runs()
+    run_idx = multi_run_manager.id_2_idx["run_delete_me"]
+    assert run_idx in multi_run_manager.config
 
     # Delete the run directory
     import shutil
 
     shutil.rmtree(run_dir)
-    runs.discover_runs()
+    multi_run_manager.discover_runs()
 
     # Verify config was cleaned up
-    assert run_idx not in runs.config
-    assert "run_delete_me" not in runs.id_2_idx
+    assert run_idx not in multi_run_manager.config
+    assert "run_delete_me" not in multi_run_manager.id_2_idx
 
 
 def test_config_invalid(tmp_path: Path) -> None:
     """Test that runs with invalid configs are skipped and error.txt is created."""
-    runs = MultiRunManager(output_dir=tmp_path, max_runs=5)
+    multi_run_manager = MultiRunManager(output_dir=tmp_path, max_runs=5)
 
     # Create a run directory with invalid config (invalid type for a field)
     # Invalid config - batch_size should be int, not string
@@ -286,11 +286,11 @@ def test_config_invalid(tmp_path: Path) -> None:
     config_dir = run_dir / "configs"
 
     # Detect the run
-    runs.discover_runs()
+    multi_run_manager.discover_runs()
 
     # Verify run was not added
-    assert len(runs.config) == 0
-    assert "run_invalid" not in runs.id_2_idx
+    assert len(multi_run_manager.config) == 0
+    assert "run_invalid" not in multi_run_manager.id_2_idx
 
     # Verify error.txt was created with error details
     error_path = config_dir / "error.txt"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Modernizes multi-run management and propagates API changes across the codebase.
> 
> - Introduces global singleton `MultiRunManager` replacing `Runs` with explicit `discover_runs()` (master-only) and `synchronize_state()` (all ranks) and new master-only `discovered`/`forgotten` hooks; retains `creation`/`deletion` hooks and config validation
> - Centralizes LoRA rank validation and scaling in `setup_multi_run_manager(..., lora_config)`; modules now `register_with_runs(get_multi_run_manager(), ...)`
> - Updates trainer loop, optimizer/scheduler, checkpointing, broadcasters (filesystem/NCCL), data loader/packer, and transports to use `get_multi_run_manager()` and new ready/progress APIs
> - Simplifies per-run param/state access via `get_named_parameters_for_run()`, `get_state_dict_for_run()`, `reset_run_parameters()`
> - Renames and rewrites docs (`runs.md` → MultiRunManager) and adjusts `docs/index.md`; adds unit tests for run discovery/deletion/config handling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b951de9e43920d569fc6b33bf096cf9e26c795e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->