### PR TITLE
Add retry with exponential backoff for empty training batches

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -249,6 +249,10 @@ async def orchestrate(config: OrchestratorConfig):
     # Start update policy loop
     update_policy_task = asyncio.create_task(scheduler.update_policy_loop())
 
+    # Track consecutive empty batches for retry logic
+    empty_batch_retries = 0
+    max_empty_batch_retries = 5
+
     while True:
         # Check if update_policy_task has failed and propagate the exception
         if update_policy_task.done():
@@ -380,7 +384,24 @@ async def orchestrate(config: OrchestratorConfig):
             temperature=config.sampling.temperature,
             step=progress.step,
         )
-        assert len(training_batch.examples) != 0, "Step with no samples is not allowed"
+
+        # Retry with exponential backoff if batch is empty (e.g., inference temporarily unavailable)
+        if len(training_batch.examples) == 0:
+            empty_batch_retries += 1
+            if empty_batch_retries > max_empty_batch_retries:
+                raise RuntimeError(
+                    f"Step {progress.step} failed after {max_empty_batch_retries} consecutive empty batches"
+                )
+            backoff = min(30 * (2 ** (empty_batch_retries - 1)), 300)  # 30s, 60s, 120s, 240s, 300s cap
+            logger.warning(
+                f"Step {progress.step} produced 0 training samples "
+                f"(attempt {empty_batch_retries}/{max_empty_batch_retries}). Retrying in {backoff}s..."
+            )
+            await asyncio.sleep(backoff)
+            continue
+
+        # Reset retry counter on successful batch
+        empty_batch_retries = 0
         training_batch_sender.send(training_batch)
 
         # Await and process val results

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -397,6 +397,8 @@ async def orchestrate(config: OrchestratorConfig):
                 f"Step {progress.step} produced 0 training samples "
                 f"(attempt {empty_batch_retries}/{max_empty_batch_retries}). Retrying in {backoff}s..."
             )
+            # Cancel validation task to avoid accumulating background tasks
+            val_task.cancel()
             await asyncio.sleep(backoff)
             continue
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -388,7 +388,7 @@ async def orchestrate(config: OrchestratorConfig):
         # Retry with exponential backoff if batch is empty (e.g., inference temporarily unavailable)
         if len(training_batch.examples) == 0:
             empty_batch_retries += 1
-            if empty_batch_retries > max_empty_batch_retries:
+            if empty_batch_retries >= max_empty_batch_retries:
                 raise RuntimeError(
                     f"Step {progress.step} failed after {max_empty_batch_retries} consecutive empty batches"
                 )


### PR DESCRIPTION
## Summary
- Replaces hard crash assertion with retry logic when batch has 0 samples
- Retries up to 5 times with exponential backoff (30s -> 300s cap)
- Handles transient inference unavailability (DNS failures, connection errors)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces resilient handling when a training step yields no samples to avoid hard crashes and transient inference outages.
> 
> - Replaces assert with retry logic when `TrainingBatch.examples` is empty, tracking `empty_batch_retries` (max 5)
> - Exponential backoff between retries: 30s, 60s, 120s, 240s, capped at 300s; raises `RuntimeError` after max attempts
> - Cancels in-flight `val_task` during retry to prevent background task buildup; resets retry counter on success
> - No other functional changes outside `src/prime_rl/orchestrator/orchestrator.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45ae66eb28ab97dad6bb59b692eff99bce2c3908. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->