### PR TITLE
Assert when only trainer or orchestrator wandb is configured

### DIFF
--- a/src/prime_rl/utils/validation.py
+++ b/src/prime_rl/utils/validation.py
@@ -61,6 +61,16 @@ def validate_shared_wandb_config(
     trainer: RLTrainerConfig,
     orchestrator: OrchestratorConfig,
 ) -> None:
+    if trainer.wandb and not orchestrator.wandb:
+        raise ValueError(
+            "Trainer W&B config is specified, but orchestrator W&B config is not. "
+            "This means only trainer metrics will be logged. Please specify [orchestrator.wandb] to log orchestrator metrics as well."
+        )
+    if orchestrator.wandb and not trainer.wandb:
+        raise ValueError(
+            "Orchestrator W&B config is specified, but trainer W&B config is not. "
+            "This means only orchestrator metrics will be logged. Please specify [trainer.wandb] to log trainer metrics as well."
+        )
     if trainer.wandb and orchestrator.wandb:
         if trainer.wandb.project != orchestrator.wandb.project:
             raise ValueError(

--- a/src/prime_rl/utils/validation.py
+++ b/src/prime_rl/utils/validation.py
@@ -64,12 +64,14 @@ def validate_shared_wandb_config(
     if trainer.wandb and not orchestrator.wandb:
         raise ValueError(
             "Trainer W&B config is specified, but orchestrator W&B config is not. "
-            "This means only trainer metrics will be logged. Please specify [orchestrator.wandb] to log orchestrator metrics as well."
+            "This means only trainer metrics will be logged. Please specify [orchestrator.wandb] to log orchestrator metrics as well, "
+            "or use [wandb] to configure both at once."
         )
     if orchestrator.wandb and not trainer.wandb:
         raise ValueError(
             "Orchestrator W&B config is specified, but trainer W&B config is not. "
-            "This means only orchestrator metrics will be logged. Please specify [trainer.wandb] to log trainer metrics as well."
+            "This means only orchestrator metrics will be logged. Please specify [trainer.wandb] to log trainer metrics as well, "
+            "or use [wandb] to configure both at once."
         )
     if trainer.wandb and orchestrator.wandb:
         if trainer.wandb.project != orchestrator.wandb.project:


### PR DESCRIPTION
Previously, users could specify [trainer.wandb] or [orchestrator.wandb] independently and it would silently log only one of the two wandb run pages. Now, we assert in the case that the user is missing one or the other.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **W&B config validation tightened**
> 
> - In `validate_shared_wandb_config`, now raises if `trainer.wandb` is set without `orchestrator.wandb`, or vice versa, with guidance to configure both or use shared `[wandb]`.
> - Retains check that both `wandb.project` values match when both are present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 398069d61ccb3365039fe6743dabc866d8b4da1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->