### PR TITLE
Ensure eval results upload before exiting subproc

### DIFF
--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -816,6 +816,7 @@ def _run_evals_in_subprocess(
         )
 
     asyncio.run(_run())
+    get_monitor().close()
     logger.info(f"Eval subprocess finished for checkpoint step {ckpt_step}")
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves reliability of Prime Intellect uploads during evals and subprocess shutdown.
> 
> - Add `get_monitor().close()` after `asyncio.run(_run())` in `eval/utils.py` to explicitly close the monitor when the eval subprocess finishes
> - Enhance `PrimeMonitor` to track pending async requests via `_pending_futures`, add `_flush()` to wait for completion, and invoke it in `close()`
> - Update `_make_request` to store futures and periodically clean completed ones; initialize tracking in `_init_async_client()`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3842b64548497e4cda3f9338b040c954430bb62b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->