### PR TITLE
Disable final checkpoint saving when max_concurrent_runs > 1

### DIFF
--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -541,7 +541,7 @@ def train(config: RLTrainerConfig):
         prof.export_chrome_trace(trace_file)
         logger.info(f"Saved trace to {trace_file}")
 
-    # Write final checkpoint (only for single-run mode; multi-run checkpoints are managed by the orchestrator)
+    # Write final checkpoint (only for single-run mode; multi-run checkpoints are managed by MultiCheckpointManager)
     if config.max_concurrent_runs == 1 and ckpt_manager is not None:
         logger.info("Writing final checkpoint")
         ckpt_manager.save(progress.step, model, [optimizer], scheduler, progress)

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -541,17 +541,17 @@ def train(config: RLTrainerConfig):
         prof.export_chrome_trace(trace_file)
         logger.info(f"Saved trace to {trace_file}")
 
-    # Write final checkpoint
-    if ckpt_manager is not None:
-        logger.info("Writing final checkpoint")
-        ckpt_manager.save(progress.step, model, [optimizer], scheduler, progress)
-        ckpt_manager.maybe_clean()
+    # Write final checkpoint (only for single-run mode; multi-run checkpoints are managed by the orchestrator)
+    if config.max_concurrent_runs == 1:
+        if ckpt_manager is not None:
+            logger.info("Writing final checkpoint")
+            ckpt_manager.save(progress.step, model, [optimizer], scheduler, progress)
+            ckpt_manager.maybe_clean()
 
-    # Write final checkpoint
-    if weight_ckpt_manager is not None:
-        logger.info("Writing final weight checkpoint")
-        weight_ckpt_manager.save(progress.step, model, tokenizer)
-        weight_ckpt_manager.maybe_clean()
+        if weight_ckpt_manager is not None:
+            logger.info("Writing final weight checkpoint")
+            weight_ckpt_manager.save(progress.step, model, tokenizer)
+            weight_ckpt_manager.maybe_clean()
 
     logger.info(f"Peak memory: {max(to_col_format(monitor.history)['perf/peak_memory']):.1f} GiB")
     logger.success("RL trainer finished!")

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -542,16 +542,15 @@ def train(config: RLTrainerConfig):
         logger.info(f"Saved trace to {trace_file}")
 
     # Write final checkpoint (only for single-run mode; multi-run checkpoints are managed by the orchestrator)
-    if config.max_concurrent_runs == 1:
-        if ckpt_manager is not None:
-            logger.info("Writing final checkpoint")
-            ckpt_manager.save(progress.step, model, [optimizer], scheduler, progress)
-            ckpt_manager.maybe_clean()
+    if config.max_concurrent_runs == 1 and ckpt_manager is not None:
+        logger.info("Writing final checkpoint")
+        ckpt_manager.save(progress.step, model, [optimizer], scheduler, progress)
+        ckpt_manager.maybe_clean()
 
-        if weight_ckpt_manager is not None:
-            logger.info("Writing final weight checkpoint")
-            weight_ckpt_manager.save(progress.step, model, tokenizer)
-            weight_ckpt_manager.maybe_clean()
+    if config.max_concurrent_runs == 1 and weight_ckpt_manager is not None:
+        logger.info("Writing final weight checkpoint")
+        weight_ckpt_manager.save(progress.step, model, tokenizer)
+        weight_ckpt_manager.maybe_clean()
 
     logger.info(f"Peak memory: {max(to_col_format(monitor.history)['perf/peak_memory']):.1f} GiB")
     logger.success("RL trainer finished!")


### PR DESCRIPTION
When max_concurrent_runs > 1, checkpoints are managed by the MultiCheckpointManager at the whims of the orchestrator, making the final checkpoint save in the trainer redundant and meaningless.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents redundant final checkpoint writes during multi-run training; final checkpoints are now only saved in single-run mode.
> 
> - Wraps final `ckpt_manager.save` and weight checkpoint `save` calls with `max_concurrent_runs == 1`
> - Clarifies intent with comments that multi-run checkpoints are managed by `MultiCheckpointManager`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d4442b46fd4bb993bb71d5582b0f3a564b407cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->