### PR TITLE
Pin Ruff in pre-commit + add Ruff format to CI

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -20,3 +20,11 @@ jobs:
           submodules: true
       - name: Run ruff
         uses: astral-sh/ruff-action@v3
+        with:
+          version: "0.13.0"
+          args: "check --config=pyproject.toml"
+      - name: Run ruff format (check)
+        uses: astral-sh/ruff-action@v3
+        with:
+          version: "0.13.0"
+          args: "format --check --config=pyproject.toml"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.9.3
+  rev: v0.13.0
   hooks:
     # Run the linter.
-    - id: ruff
+    - id: ruff-check
       args: [ --fix, --config=pyproject.toml ]
     # Run the formatter.
     - id: ruff-format

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -650,9 +650,7 @@ class OrchestratorConfig(BaseSettings):
     # Whether to reset inference weights to base model when starting from scratch
     reload_weights_on_start: Annotated[
         bool,
-        Field(
-            description="Whether to reset inference weights to the base model when starting from scratch."
-        ),
+        Field(description="Whether to reset inference weights to the base model when starting from scratch."),
     ] = True
 
     # The validation configuration

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -196,7 +196,9 @@ class Scheduler:
                 wait_for_ckpt_start_time = time.perf_counter()
                 await wait_for_path(get_step_path(get_broadcast_dir(self.config.output_dir), next_ckpt_step) / "STABLE")
                 self.wait_for_ckpt_time = time.perf_counter() - wait_for_ckpt_start_time
-                self.logger.info(f"Orchestrator resumed: checkpoint {next_ckpt_step} ready (after {self.wait_for_ckpt_time:.2f}s)")
+                self.logger.info(
+                    f"Orchestrator resumed: checkpoint {next_ckpt_step} ready (after {self.wait_for_ckpt_time:.2f}s)"
+                )
 
             self.logger.debug(
                 f"Got new policy with step {next_ckpt_step}. Updating weights and cancelling old rollout requests."

--- a/src/prime_rl/orchestrator/trajectories.py
+++ b/src/prime_rl/orchestrator/trajectories.py
@@ -71,7 +71,6 @@ def interleave_rollout(state: vf.State) -> list[TrainingSample] | None:
         # New prefix is the current prompt and completion ids concatenated
         prefix_tokens = tokens["prompt_ids"] + tokens["completion_ids"]
 
-
     return [interleaved_rollout]
 
 

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -324,7 +324,6 @@ class RLConfig(BaseSettings):
                 batch_size=self.orchestrator.batch_size,
             )
 
-        
         trainer_bench_enabled = self.trainer.bench is not None
         if trainer_bench_enabled != self.orchestrator.bench:
             raise ValueError(

--- a/src/prime_rl/trainer/batch.py
+++ b/src/prime_rl/trainer/batch.py
@@ -33,13 +33,7 @@ def prepare_sample(
         if teacher_logprobs is not None:
             teacher_logprobs = teacher_logprobs[:seq_len]
 
-    assert (
-        len(input_ids)
-        == len(advantages)
-        == len(loss_mask)
-        == len(position_ids)
-        == len(inference_logprobs)
-    ), (
+    assert len(input_ids) == len(advantages) == len(loss_mask) == len(position_ids) == len(inference_logprobs), (
         f"input_ids: {len(input_ids)}, advantages: {len(advantages)}, loss_mask: {len(loss_mask)}, position_ids: {len(position_ids)}, inference_logprobs: {len(inference_logprobs)}"
     )
     if teacher_logprobs is not None:

--- a/src/prime_rl/trainer/models/__init__.py
+++ b/src/prime_rl/trainer/models/__init__.py
@@ -46,4 +46,10 @@ def supports_custom_impl(model_config: PretrainedConfig) -> bool:
     return type(model_config) in _CUSTOM_CAUSAL_LM_MAPPING
 
 
-__all__ = ["AutoModelForCausalLMPrimeRL", "PreTrainedModelPrimeRL", "supports_custom_impl", "PrimeLmOutput", "cast_float_and_contiguous"]
+__all__ = [
+    "AutoModelForCausalLMPrimeRL",
+    "PreTrainedModelPrimeRL",
+    "supports_custom_impl",
+    "PrimeLmOutput",
+    "cast_float_and_contiguous",
+]

--- a/src/prime_rl/trainer/models/afmoe/__init__.py
+++ b/src/prime_rl/trainer/models/afmoe/__init__.py
@@ -11,4 +11,3 @@ __all__ = [
     "AfmoeModel",
     "AfmoePreTrainedModel",
 ]
-

--- a/src/prime_rl/trainer/models/afmoe/configuration_afmoe.py
+++ b/src/prime_rl/trainer/models/afmoe/configuration_afmoe.py
@@ -4,8 +4,10 @@ from transformers.utils import logging
 
 logger = logging.get_logger(__name__)
 
+
 class AfmoeConfig(PretrainedConfig):
     """Configuration for AFMoE."""
+
     model_type = "afmoe"
     base_model_pp_plan = {
         "embed_tokens": (["input_ids"], ["inputs_embeds"]),
@@ -88,7 +90,8 @@ class AfmoeConfig(PretrainedConfig):
         self.layer_types = layer_types
         if self.layer_types is None:
             self.layer_types = [
-                "sliding_attention" if bool((i + 1) % global_attn_every_n_layers) else "full_attention" for i in range(self.num_hidden_layers)
+                "sliding_attention" if bool((i + 1) % global_attn_every_n_layers) else "full_attention"
+                for i in range(self.num_hidden_layers)
             ]
         layer_type_validation(self.layer_types)
 

--- a/src/prime_rl/trainer/models/qwen3_moe/configuration_qwen3_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_moe/configuration_qwen3_moe.py
@@ -206,7 +206,7 @@ class Qwen3MoeConfig(PretrainedConfig):
         self.mlp_only_layers = [] if mlp_only_layers is None else mlp_only_layers
         self.load_balance_coeff = load_balance_coeff
         self.use_grouped_mm = use_grouped_mm
-        
+
         super().__init__(
             tie_word_embeddings=tie_word_embeddings,
             **kwargs,

--- a/src/prime_rl/utils/monitor/__init__.py
+++ b/src/prime_rl/utils/monitor/__init__.py
@@ -80,4 +80,3 @@ def setup_monitor(
         _MONITOR = MultiMonitor(monitors)
 
     return _MONITOR
-

--- a/src/prime_rl/utils/monitor/base.py
+++ b/src/prime_rl/utils/monitor/base.py
@@ -6,7 +6,7 @@ import verifiers as vf
 
 class Monitor(ABC):
     """Base class for all monitoring implementations.
-    
+
     Subclasses should initialize a `history` attribute as a list of dictionaries
     to store logged metrics.
     """
@@ -56,4 +56,3 @@ class NoOpMonitor(Monitor):
 
     def log_distributions(self, distributions: dict[str, list[float]], step: int) -> None:
         pass
-

--- a/tests/unit/train/models/afmoe_hf_modeling/configuration_afmoe.py
+++ b/tests/unit/train/models/afmoe_hf_modeling/configuration_afmoe.py
@@ -18,6 +18,7 @@ from transformers.utils import logging
 
 logger = logging.get_logger(__name__)
 
+
 class AfmoeConfig(PretrainedConfig):
     """
     n_group (`int`, *optional*, defaults to 1):
@@ -25,6 +26,7 @@ class AfmoeConfig(PretrainedConfig):
     topk_group (`int`, *optional*, defaults to 1):
         Number of selected groups for each token(for each token, ensuring the selected experts is only within `topk_group` groups).
     """
+
     model_type = "afmoe"
     base_model_pp_plan = {
         "embed_tokens": (["input_ids"], ["inputs_embeds"]),
@@ -84,8 +86,7 @@ class AfmoeConfig(PretrainedConfig):
         self.use_cache = use_cache
         self.rope_theta = rope_theta
         self.rope_scaling = rope_scaling
-        
-        
+
         # MoE specific
         self.moe_intermediate_size = moe_intermediate_size
         self.num_experts_per_tok = num_experts_per_tok
@@ -101,7 +102,6 @@ class AfmoeConfig(PretrainedConfig):
         self.load_balance_coeff = load_balance_coeff
         self.use_grouped_mm = use_grouped_mm
 
-
         # Attention specific
         self.attention_dropout = attention_dropout
         self.global_attn_every_n_layers = global_attn_every_n_layers
@@ -109,7 +109,8 @@ class AfmoeConfig(PretrainedConfig):
         self.layer_types = layer_types
         if self.layer_types is None:
             self.layer_types = [
-                "sliding_attention" if bool((i + 1) % global_attn_every_n_layers) else "full_attention" for i in range(self.num_hidden_layers)
+                "sliding_attention" if bool((i + 1) % global_attn_every_n_layers) else "full_attention"
+                for i in range(self.num_hidden_layers)
             ]
         layer_type_validation(self.layer_types)
 
@@ -120,7 +121,6 @@ class AfmoeConfig(PretrainedConfig):
             num_key_value_heads = num_attention_heads
 
         self.num_key_value_heads = num_key_value_heads
-
 
         # Validate rope configs
         if self.rope_scaling is not None and "type" in self.rope_scaling:


### PR DESCRIPTION
This PR pins Ruff in `.pre-commit-config.yaml` to match uv.lock & adds a ruff format check to the CI workflow (`.github/workflows/style.yaml`), matching the pre-commit hooks. Also runs `ruff format` to make repo pass the new CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates style tooling and aligns repository formatting.
> 
> - Pin Ruff to `v0.13.0` and add `ruff format --check` step in `/.github/workflows/style.yaml`
> - Update pre-commit to `v0.13.0` and switch hook to `ruff-check` in `/.pre-commit-config.yaml`
> - Apply `ruff format` changes across `orchestrator`, `trainer`, `models`, `utils`, and `tests` (line wrapping, list/args layout, logging string wrapping)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86212e5addedcccef4d10f8ded95d8d6a6206f3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->