### PR TITLE
Allow trainer to evict runs that write bad batches

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ This directory maintains the documentation for PRIME-RL. It is organized into th
 - [**Environments**](environments.md) - Installing and using verifiers environments from the Environments Hub
 - [**Async Training**](async.md) - Understanding asynchronous off-policy training and step semantics
 - [**Logging**](logging.md) - Logging with loguru, torchrun, and Weights & Biases
-- [**MultiRunManager**](runs.md) - Multi-run training with the MultiRunManager object for concurrent LoRA adapters
+- [**MultiRunManager**](multi_run_manager.md) - Multi-run training with the MultiRunManager object for concurrent LoRA adapters
 - [**Checkpointing**](checkpointing.md) - Saving and resuming training from checkpoints
 - [**Benchmarking**](benchmarking.md) - Performance benchmarking and throughput measurement
 - [**Deployment**](deployment.md) - Training deployment on single-GPU, multi-GPU, and multi-node clusters

--- a/docs/multi_run_manager.md
+++ b/docs/multi_run_manager.md
@@ -19,6 +19,7 @@ The `MultiRunManager` object provides:
 - **Distributed synchronization** across ranks via the PyTorch distributed store
 - **LoRA module registration** for multi-adapter parameter management
 - **Creation hooks** for initializing per-run resources (optimizers, schedulers)
+- **Run eviction** for removing runs that are misbehaving
 
 ## **Initialization and run discovery**
 
@@ -40,7 +41,9 @@ Each run's directory follows this structure:
 {output_dir}/
 ├── run_abc123/
 │   ├── configs/
-│   │   └── orch.toml          # Orchestrator configuration
+│   │   ├── orch.toml          # Orchestrator configuration
+│   │   ├── error.txt          # Config validation errors (if any)
+│   │   └── evicted.txt        # Eviction reason (if evicted)
 │   ├── checkpoints/
 │   │   └── step_100/          # Orchestrator checkpoints
 │   ├── rollouts/
@@ -66,11 +69,12 @@ multi_run_manager.synchronize_state()
 The `discover_runs()` method (master only):
 
 1. Scans the output directory for `run_*` directories
-2. Detects new runs and deleted runs
-3. Calls `forgotten_hook` for deleted runs (master only)
-4. Loads and validates the orchestrator config for each new run
-5. Updates internal mappings and data structures
-6. Calls `discovered_hook` for new runs (master only)
+2. Filters out evicted runs (those with `configs/evicted.txt`)
+3. Detects new runs and deleted runs
+4. Calls `forgotten_hook` for deleted runs (master only)
+5. Loads and validates the orchestrator config for each new run
+6. Updates internal mappings and data structures
+7. Calls `discovered_hook` for new runs (master only)
 
 The `synchronize_state()` method (all ranks):
 
@@ -78,6 +82,34 @@ The `synchronize_state()` method (all ranks):
 2. Non-master ranks catch up by calling internal `_delete_run_data` / `_create_run_data`
 3. All ranks execute `deletion_hook` for deleted runs
 4. All ranks execute `creation_hook` for new runs (e.g., optimizer setup, LoRA parameter reset)
+
+## Run Eviction
+
+The master proc on the trainer can evict a run using the `evict_run(idx: int, reason: str)` method.
+This is useful when the trainer detects an issue with a run that requires it to be stopped (e.g., invalid data, resource constraints, or policy violations).
+
+```python
+# Evict a run by its index (master only)
+multi_run_manager.evict_run(idx=0, reason="Run exceeded memory limits")
+```
+
+The `evict_run()` method (master only):
+
+1. Writes the eviction reason to `{run_dir}/configs/evicted.txt`
+2. Logs a warning with the eviction details
+3. The run is **not** immediately removed from the manager's data structures
+
+The eviction takes effect through two mechanisms:
+
+**On the trainer side:**
+- The next `discover_runs()` call will filter out the evicted run (it checks for `evicted.txt`)
+- The run will then be treated as deleted, triggering forgotten/deletion hooks
+- The run index is returned to the unused pool
+
+**On the orchestrator side:**
+- The orchestrator checks for `evicted.txt` at the start of each iteration in its main loop
+- If found, it raises a `RuntimeError` with the eviction reason, causing the orchestrator to exit
+- This surfaces the eviction reason to the user
 
 ## LoRA Module Registration
 
@@ -182,7 +214,7 @@ def discovered_callback(idx: int, run_id: str, config: OrchestratorConfig) -> No
 
 def forgotten_callback(idx: int, run_id: str) -> None:
     """Called when a run is forgotten/removed (master only).
-    
+
     Args:
         idx: The run's index (0 to max_runs-1)
         run_id: The run's ID (e.g., "run_abc123")

--- a/docs/multi_run_manager.md
+++ b/docs/multi_run_manager.md
@@ -40,10 +40,10 @@ Each run's directory follows this structure:
 ```
 {output_dir}/
 ├── run_abc123/
-│   ├── configs/
-│   │   ├── orch.toml          # Orchestrator configuration
-│   │   ├── error.txt          # Config validation errors (if any)
-│   │   └── evicted.txt        # Eviction reason (if evicted)
+│   ├── control/
+│   │   ├── orch.toml                    # Orchestrator configuration
+│   │   ├── config_validation_error.txt  # Config validation errors (if any)
+│   │   └── evicted.txt                  # Eviction reason (if evicted)
 │   ├── checkpoints/
 │   │   └── step_100/          # Orchestrator checkpoints
 │   ├── rollouts/
@@ -56,7 +56,7 @@ Each run's directory follows this structure:
 
 ```
 
-Runs are discovered by scanning the output directory for the pattern `run_*`. Each run must contain a valid orchestrator config at `{run_dir}/configs/orch.toml` before they are added to the active runs otherwise they are ignored. When the maximum number of runs is reached, new `run_*` directories will not be picked up until old ones are deleted.
+Runs are discovered by scanning the output directory for the pattern `run_*`. Each run must contain a valid orchestrator config at `{run_dir}/control/orch.toml` before they are added to the active runs otherwise they are ignored. When the maximum number of runs is reached, new `run_*` directories will not be picked up until old ones are deleted.
 
 ```python
 # Master rank scans for new/deleted runs
@@ -69,7 +69,7 @@ multi_run_manager.synchronize_state()
 The `discover_runs()` method (master only):
 
 1. Scans the output directory for `run_*` directories
-2. Filters out evicted runs (those with `configs/evicted.txt`)
+2. Filters out evicted runs (those with `control/evicted.txt`)
 3. Detects new runs and deleted runs
 4. Calls `forgotten_hook` for deleted runs (master only)
 5. Loads and validates the orchestrator config for each new run
@@ -95,7 +95,7 @@ multi_run_manager.evict_run(idx=0, reason="Run exceeded memory limits")
 
 The `evict_run()` method (master only):
 
-1. Writes the eviction reason to `{run_dir}/configs/evicted.txt`
+1. Writes the eviction reason to `{run_dir}/control/evicted.txt`
 2. Logs a warning with the eviction details
 3. The run is **not** immediately removed from the manager's data structures
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -76,7 +76,7 @@ async def orchestrate(config: OrchestratorConfig):
         logger.warning(f"Running in benchmark mode (max_steps={config.max_steps})")
 
     # Save configs to output directory
-    config_dir = config.output_dir / "configs"
+    config_dir = config.output_dir / "control"
     config_dir.mkdir(parents=True, exist_ok=True)
     with open(config_dir / "orch.toml", "wb") as f:
         tomli_w.dump(config.model_dump(exclude_none=True, mode="json"), f)
@@ -255,7 +255,7 @@ async def orchestrate(config: OrchestratorConfig):
 
     while True:
         # Check if this run has been evicted by the trainer
-        evicted_path = config.output_dir / "configs" / "evicted.txt"
+        evicted_path = config.output_dir / "control" / "evicted.txt"
         if evicted_path.exists():
             reason = evicted_path.read_text().strip()
             raise RuntimeError(f"Run evicted by trainer: {reason}")

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -254,6 +254,12 @@ async def orchestrate(config: OrchestratorConfig):
     max_empty_batch_retries = 5
 
     while True:
+        # Check if this run has been evicted by the trainer
+        evicted_path = config.output_dir / "configs" / "evicted.txt"
+        if evicted_path.exists():
+            reason = evicted_path.read_text().strip()
+            raise RuntimeError(f"Run evicted by trainer: {reason}")
+
         # Check if update_policy_task has failed and propagate the exception
         if update_policy_task.done():
             # End all other tasks

--- a/src/prime_rl/trainer/rl/packer.py
+++ b/src/prime_rl/trainer/rl/packer.py
@@ -118,6 +118,33 @@ class MultiPacker(BasePacker):
         # Reset run state
         self.buffers[idx].clear()
 
+    def _validate_sample(self, sample: TrainingSample) -> tuple[bool, str | None]:
+        """Validate a sample to ensure it won't crash the trainer."""
+        sample_length = len(sample.prompt_ids) + len(sample.completion_ids)
+        if len(sample.prompt_mask) != len(sample.prompt_ids):
+            return (
+                False,
+                f"Run wrote a sample with prompt mask length != prompt ids length ({len(sample.prompt_mask)} != {len(sample.prompt_ids)})",
+            )
+        if len(sample.completion_mask) != len(sample.completion_ids):
+            return (
+                False,
+                f"Run wrote a sample with completion mask length != completion ids length ({len(sample.completion_mask)} != {len(sample.completion_ids)})",
+            )
+        if len(sample.completion_logprobs) != len(sample.completion_ids):
+            return (
+                False,
+                f"Run wrote a sample with completion logprobs length != completion ids length ({len(sample.completion_logprobs)} != {len(sample.completion_ids)})",
+            )
+        if sample_length == 0:
+            return False, "Run wrote a sample with no tokens"
+        if sample_length > self.seq_len:
+            return (
+                False,
+                f"Run wrote a sample with length {sample_length} which exceeds max sequence length {self.seq_len}",
+            )
+        return True, None
+
     def _get_batch(self) -> None:
         """Receive batches from orchestrator and buffer samples per run."""
         self.multi_run_manager.discover_runs()
@@ -127,8 +154,18 @@ class MultiPacker(BasePacker):
             if batch.run_idx is None:
                 self.logger.warning("Received batch with no run index")
                 continue
+            if len(batch.examples) == 0:
+                self.multi_run_manager.evict_run(batch.run_idx, "Run wrote a batch with no samples")
+                continue
             for sample in batch.examples:
+                valid, reason = self._validate_sample(sample)
+                if not valid:
+                    self.multi_run_manager.evict_run(batch.run_idx, f"Run wrote a sample with invalid data: {reason}")
+                    break
                 self.buffers[batch.run_idx].append((sample, batch.temperature, batch.step))
+
+        # This is necessary to forget evicted runs
+        self.multi_run_manager.discover_runs()
 
     def _count_tokens(self, threshold: int | None = None) -> int:
         tokens = 0
@@ -136,9 +173,10 @@ class MultiPacker(BasePacker):
         for run_idx in self.multi_run_manager.used_idxs:
             buffer = self.buffers[run_idx]
             current_step = self.multi_run_manager.progress[run_idx].step
+
             for sample, _, step in buffer:
                 if step > current_step:
-                    continue
+                    break
                 tokens += len(sample.prompt_ids) + len(sample.completion_ids)
                 if threshold is not None and tokens >= threshold:
                     return tokens

--- a/src/prime_rl/trainer/rl/packer.py
+++ b/src/prime_rl/trainer/rl/packer.py
@@ -143,6 +143,11 @@ class MultiPacker(BasePacker):
                 False,
                 f"Run wrote a sample with length {sample_length} which exceeds max sequence length {self.seq_len}",
             )
+        if sample.teacher_logprobs is not None and len(sample.teacher_logprobs) != sample_length:
+            return (
+                False,
+                f"Run wrote a sample with teacher logprobs length != sample length ({len(sample.teacher_logprobs)} != {sample_length})",
+            )
         return True, None
 
     def _get_batch(self) -> None:

--- a/src/prime_rl/trainer/runs.py
+++ b/src/prime_rl/trainer/runs.py
@@ -345,7 +345,6 @@ class MultiRunManager:
 
         # Filter out evicted runs
         evicted_runs = {run_id for run_id in run_ids if (self.output_dir / run_id / "configs" / "evicted.txt").exists()}
-        self.logger.debug(f"Ignoring evicted runs: {evicted_runs}")
         run_ids = run_ids - evicted_runs
 
         deleted_runs = self.id_2_idx.keys() - run_ids

--- a/src/prime_rl/trainer/runs.py
+++ b/src/prime_rl/trainer/runs.py
@@ -210,9 +210,9 @@ class MultiRunManager:
         Returns None if config doesn't exist, fails to parse, or fails validation.
         Writes error to config dir for orchestrator to consume.
         """
-        config_path = self.output_dir / run_id / "configs" / "orch.toml"
+        config_path = self.output_dir / run_id / "control" / "orch.toml"
         config_dir = config_path.parent
-        error_path = config_dir / "error.txt"
+        error_path = config_dir / "config_validation_error.txt"
 
         if not config_path.exists():
             if not error_path.exists():
@@ -323,7 +323,7 @@ class MultiRunManager:
 
         run_id = self.idx_2_id[idx]
         run_dir = self.output_dir / run_id
-        config_dir = run_dir / "configs"
+        config_dir = run_dir / "control"
         config_dir.mkdir(parents=True, exist_ok=True)
 
         evicted_path = config_dir / "evicted.txt"
@@ -344,7 +344,7 @@ class MultiRunManager:
         run_ids = {run_path.stem for run_path in self.output_dir.glob("run_*")}
 
         # Filter out evicted runs
-        evicted_runs = {run_id for run_id in run_ids if (self.output_dir / run_id / "configs" / "evicted.txt").exists()}
+        evicted_runs = {run_id for run_id in run_ids if (self.output_dir / run_id / "control" / "evicted.txt").exists()}
         run_ids = run_ids - evicted_runs
 
         deleted_runs = self.id_2_idx.keys() - run_ids

--- a/src/prime_rl/trainer/runs.py
+++ b/src/prime_rl/trainer/runs.py
@@ -318,7 +318,8 @@ class MultiRunManager:
             raise RuntimeError("evict_run() must only be called on the master rank")
 
         if idx not in self.idx_2_id:
-            raise ValueError(f"Run index {idx} not found")
+            self.logger.warning(f"Run index {idx} not found, cannot evict")
+            return
 
         run_id = self.idx_2_id[idx]
         run_dir = self.output_dir / run_id

--- a/src/prime_rl/trainer/runs.py
+++ b/src/prime_rl/trainer/runs.py
@@ -299,8 +299,37 @@ class MultiRunManager:
             hook(deleted_idx, deleted_run)
 
     # =========================================================================
-    # Run Discovery and Synchronization
+    # Run Discovery, Synchronization, and Eviction
     # =========================================================================
+
+    def evict_run(self, idx: int, reason: str) -> None:
+        """Evict a run by writing the reason to a file for the orchestrator to read.
+
+        The orchestrator will error and surface this reason. The run will be
+        ignored by future discover_runs() calls.
+        Note that the run is not deleted on master until the next discover_runs() call.
+        And not deleted on other ranks until the next synchronize_state() call.
+
+        Args:
+            idx: The run index to evict
+            reason: The reason for eviction (will be shown to user)
+        """
+        if not self.world.is_master:
+            raise RuntimeError("evict_run() must only be called on the master rank")
+
+        if idx not in self.idx_2_id:
+            raise ValueError(f"Run index {idx} not found")
+
+        run_id = self.idx_2_id[idx]
+        run_dir = self.output_dir / run_id
+        config_dir = run_dir / "configs"
+        config_dir.mkdir(parents=True, exist_ok=True)
+
+        evicted_path = config_dir / "evicted.txt"
+        with open(evicted_path, "w") as f:
+            f.write(reason)
+
+        self.logger.warning(f"Evicted run {run_id} (idx={idx}): {reason}")
 
     def discover_runs(self) -> None:
         """Detect run changes and update data structures (master only). Must be followed by synchronize_state().
@@ -312,6 +341,12 @@ class MultiRunManager:
         if not self.world.is_master:
             raise RuntimeError("discover_runs() must only be called on the master rank")
         run_ids = {run_path.stem for run_path in self.output_dir.glob("run_*")}
+
+        # Filter out evicted runs
+        evicted_runs = {run_id for run_id in run_ids if (self.output_dir / run_id / "configs" / "evicted.txt").exists()}
+        self.logger.debug(f"Ignoring evicted runs: {evicted_runs}")
+        run_ids = run_ids - evicted_runs
+
         deleted_runs = self.id_2_idx.keys() - run_ids
         new_runs = run_ids - self.id_2_idx.keys()
 

--- a/tests/unit/train/test_runs.py
+++ b/tests/unit/train/test_runs.py
@@ -320,15 +320,6 @@ def test_evict_run_writes_file(tmp_path: Path) -> None:
     assert evicted_path.read_text() == eviction_reason
 
 
-def test_evict_run_invalid_idx(tmp_path: Path) -> None:
-    """Test that evict_run raises ValueError for invalid index."""
-    multi_run_manager = MultiRunManager(output_dir=tmp_path, max_runs=5)
-
-    # Try to evict a non-existent run
-    with pytest.raises(ValueError, match="Run index 2 not found"):
-        multi_run_manager.evict_run(2, "This should fail")
-
-
 def test_discover_runs_ignores_evicted(tmp_path: Path) -> None:
     """Test that discover_runs ignores runs with evicted.txt."""
     multi_run_manager = MultiRunManager(output_dir=tmp_path, max_runs=5)

--- a/tests/unit/train/test_runs.py
+++ b/tests/unit/train/test_runs.py
@@ -33,7 +33,7 @@ def create_run_with_config(
     """
     run_dir = output_dir / run_name
     run_dir.mkdir()
-    config_dir = run_dir / "configs"
+    config_dir = run_dir / "control"
     config_dir.mkdir()
 
     if config is None:
@@ -220,7 +220,7 @@ def test_config_loading(tmp_path: Path) -> None:
 
 
 def test_config_missing(tmp_path: Path) -> None:
-    """Test that runs without configs are skipped and error.txt is created."""
+    """Test that runs without configs are skipped and config_validation_error.txt is created."""
     multi_run_manager = MultiRunManager(output_dir=tmp_path, max_runs=5)
 
     # Create a run directory without config
@@ -234,8 +234,8 @@ def test_config_missing(tmp_path: Path) -> None:
     assert len(multi_run_manager.config) == 0
     assert "run_noconfig" not in multi_run_manager.id_2_idx
 
-    # Verify error.txt was created
-    error_path = run_dir / "configs" / "error.txt"
+    # Verify config_validation_error.txt was created
+    error_path = run_dir / "control" / "config_validation_error.txt"
     assert error_path.exists()
     error_content = error_path.read_text()
     assert "No orchestrator config found" in error_content
@@ -271,7 +271,7 @@ def test_config_cleanup_on_deletion(tmp_path: Path) -> None:
 
 
 def test_config_invalid(tmp_path: Path) -> None:
-    """Test that runs with invalid configs are skipped and error.txt is created."""
+    """Test that runs with invalid configs are skipped and config_validation_error.txt is created."""
     multi_run_manager = MultiRunManager(output_dir=tmp_path, max_runs=5)
 
     # Create a run directory with invalid config (invalid type for a field)
@@ -283,7 +283,7 @@ def test_config_invalid(tmp_path: Path) -> None:
         "env": [{"id": "test-env"}],
     }
     run_dir = create_run_with_config(tmp_path, "run_invalid", config=invalid_config)
-    config_dir = run_dir / "configs"
+    config_dir = run_dir / "control"
 
     # Detect the run
     multi_run_manager.discover_runs()
@@ -292,8 +292,8 @@ def test_config_invalid(tmp_path: Path) -> None:
     assert len(multi_run_manager.config) == 0
     assert "run_invalid" not in multi_run_manager.id_2_idx
 
-    # Verify error.txt was created with error details
-    error_path = config_dir / "error.txt"
+    # Verify config_validation_error.txt was created with error details
+    error_path = config_dir / "config_validation_error.txt"
     assert error_path.exists()
     error_content = error_path.read_text()
     assert "Error parsing orchestrator config" in error_content
@@ -315,7 +315,7 @@ def test_evict_run_writes_file(tmp_path: Path) -> None:
     multi_run_manager.evict_run(run_idx, eviction_reason)
 
     # Verify evicted.txt was created with the reason
-    evicted_path = tmp_path / "run_to_evict" / "configs" / "evicted.txt"
+    evicted_path = tmp_path / "run_to_evict" / "control" / "evicted.txt"
     assert evicted_path.exists()
     assert evicted_path.read_text() == eviction_reason
 
@@ -329,7 +329,7 @@ def test_discover_runs_ignores_evicted(tmp_path: Path) -> None:
     create_run_with_config(tmp_path, "run_evicted")
 
     # Mark one as evicted by creating evicted.txt
-    evicted_path = tmp_path / "run_evicted" / "configs" / "evicted.txt"
+    evicted_path = tmp_path / "run_evicted" / "control" / "evicted.txt"
     evicted_path.write_text("Previously evicted")
 
     # Discover runs


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a robust eviction mechanism and standardizes run control paths.
> 
> - Trainer (`MultiPacker`): validates samples, evicts runs on empty/invalid batches via `evict_run`, and re-discovers to drop evicted runs
> - Orchestrator: saves config to `control/orch.toml` and exits loop if `control/evicted.txt` is present (surfacing reason)
> - MultiRunManager: loads configs from `control/orch.toml`, writes `control/config_validation_error.txt` on failures, implements `evict_run()` (writes `control/evicted.txt`), and `discover_runs()` now ignores evicted runs
> - Tests: updated to new `control/` layout; added tests for eviction file creation and ignoring evicted runs
> - Docs: new `multi_run_manager.md` with run eviction details; index link fixed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 870ab514cdcd0347ca583a55bedcffa2bed56f82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->