### PR TITLE
Add INFO log when orchestrator resumes

### DIFF
--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -196,7 +196,7 @@ class Scheduler:
                 wait_for_ckpt_start_time = time.perf_counter()
                 await wait_for_path(get_step_path(get_broadcast_dir(self.config.output_dir), next_ckpt_step) / "STABLE")
                 self.wait_for_ckpt_time = time.perf_counter() - wait_for_ckpt_start_time
-                self.logger.debug(f"Waited for checkpoint {next_ckpt_step} for {self.wait_for_ckpt_time:.2f}s")
+                self.logger.info(f"Orchestrator resumed: checkpoint {next_ckpt_step} ready (after {self.wait_for_ckpt_time:.2f}s)")
 
             self.logger.debug(
                 f"Got new policy with step {next_ckpt_step}. Updating weights and cancelling old rollout requests."


### PR DESCRIPTION
Adds a corresponding INFO-level log message when the orchestrator resumes after waiting for a checkpoint.

- Before: only "Orchestrator paused" message, no indication when it resumes
- After: "Orchestrator resumed: checkpoint X ready (after Y.YYs)"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds visibility when resuming after checkpoint wait.
> 
> - In `scheduler.py` `update_policy`, after waiting for `STABLE` on the next checkpoint, logs `INFO` "Orchestrator resumed: checkpoint X ready (after Y.YYs)" (replacing the previous debug-only message).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ce5bdf45930606497e8fc4d934dbf45541fe7cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->