### PR TITLE
[WIP] add mismatch-KL stability checks for nightlies

### DIFF
--- a/tests/integration/test_rl.py
+++ b/tests/integration/test_rl.py
@@ -5,7 +5,7 @@ from typing import Callable
 import pytest
 
 from tests.conftest import ProcessResult
-from tests.utils import check_no_error, check_number_goes_up_or_down, check_number_in_range, strip_escape_codes
+from tests.utils import check_no_error, check_number_goes_up_or_down, check_reward_in_range, strip_escape_codes
 
 pytestmark = [pytest.mark.gpu, pytest.mark.slow]
 
@@ -71,7 +71,6 @@ def rl_resume_process(
 
 
 check_reward_goes_up = partial(check_number_goes_up_or_down, go_up=True, pattern=r"Reward:\s*(\d+\.\d{4})")
-check_reward_in_range = partial(check_number_in_range, pattern=r"Reward:\s*(\d+\.\d{4})")
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_rl_lora.py
+++ b/tests/integration/test_rl_lora.py
@@ -5,7 +5,7 @@ from typing import Callable
 import pytest
 
 from tests.conftest import ProcessResult
-from tests.utils import check_no_error, check_number_goes_up_or_down, check_number_in_range, strip_escape_codes
+from tests.utils import check_no_error, check_number_goes_up_or_down, check_reward_in_range, strip_escape_codes
 
 pytestmark = [pytest.mark.gpu, pytest.mark.slow]
 
@@ -71,7 +71,6 @@ def rl_resume_process(
 
 
 check_reward_goes_up = partial(check_number_goes_up_or_down, go_up=True, pattern=r"Reward:\s*(\d+\.\d{4})")
-check_reward_in_range = partial(check_number_in_range, pattern=r"Reward:\s*(\d+\.\d{4})")
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_rl_multi_run_lora.py
+++ b/tests/integration/test_rl_multi_run_lora.py
@@ -12,7 +12,7 @@ from typing import Generator
 import pytest
 
 from tests.conftest import ProcessResult
-from tests.utils import check_number_goes_up_or_down, check_number_in_range, strip_escape_codes
+from tests.utils import check_number_goes_up_or_down, check_reward_in_range, strip_escape_codes
 
 pytestmark = [pytest.mark.gpu, pytest.mark.slow]
 
@@ -385,13 +385,11 @@ def test_reward_in_range(multi_run_result: dict[str, ProcessResult], output_dir:
         with open(log_file, "r") as f:
             lines = strip_escape_codes(f.read()).splitlines()
         if name in ["beta", "gamma"]:
-            check_number_in_range(
-                lines, step=7, min_threshold=0.2, max_threshold=0.6, pattern=r"Reward:\s*(\d+\.\d{4})"
-            )
-            check_number_in_range(lines, min_threshold=0.65, pattern=r"Reward:\s*(\d+\.\d{4})")
+            check_reward_in_range(lines, step=7, min_threshold=0.2, max_threshold=0.6)
+            check_reward_in_range(lines, min_threshold=0.65)
         elif name in ["alpha_resume", "beta_resume"]:
-            check_number_in_range(lines, min_threshold=0.65, pattern=r"Reward:\s*(\d+\.\d{4})")
+            check_reward_in_range(lines, min_threshold=0.65)
         elif name == "alpha":  # Only had 10 steps, so it's lower
-            check_number_in_range(lines, min_threshold=0.4, pattern=r"Reward:\s*(\d+\.\d{4})")
+            check_reward_in_range(lines, min_threshold=0.4)
         else:
             pytest.fail(f"Unknown orchestrator {name}")

--- a/tests/nightly/test_acereason_math.py
+++ b/tests/nightly/test_acereason_math.py
@@ -5,7 +5,7 @@ from typing import Callable
 import pytest
 
 from tests.conftest import ProcessResult
-from tests.utils import check_no_error, check_number_goes_up_or_down, strip_escape_codes
+from tests.utils import check_mismatch_kl_in_range, check_no_error, check_number_goes_up_or_down, strip_escape_codes
 
 pytestmark = [pytest.mark.gpu, pytest.mark.slow]
 
@@ -40,6 +40,8 @@ def rl_process(
 
 
 check_reward_goes_up = partial(check_number_goes_up_or_down, go_up=True, pattern=r"Reward:\s*(\d+\.\d{4})")
+MISMATCH_KL_MIN = 0.0
+MISMATCH_KL_MAX = 0.0015
 
 
 @pytest.fixture(scope="module")
@@ -53,3 +55,10 @@ def test_reward_goes_up(rl_process: ProcessResult, test_no_error, output_dir: Pa
     with open(output_dir / "logs" / "orchestrator.stdout", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_reward_goes_up(orchestrator_stdout)
+
+
+def test_mismatch_kl_in_band(rl_process: ProcessResult, test_no_error, output_dir: Path):
+    """Tests that mismatch KL stays within the expected band."""
+    with open(output_dir / "logs" / "trainer.stdout", "r") as f:
+        trainer_stdout = strip_escape_codes(f.read()).splitlines()
+    check_mismatch_kl_in_range(trainer_stdout, min_threshold=MISMATCH_KL_MIN, max_threshold=MISMATCH_KL_MAX)

--- a/tests/nightly/test_hendrycks_math.py
+++ b/tests/nightly/test_hendrycks_math.py
@@ -5,7 +5,7 @@ from typing import Callable
 import pytest
 
 from tests.conftest import ProcessResult
-from tests.utils import check_no_error, check_number_goes_up_or_down, strip_escape_codes
+from tests.utils import check_mismatch_kl_in_range, check_no_error, check_number_goes_up_or_down, strip_escape_codes
 
 pytestmark = [pytest.mark.gpu, pytest.mark.slow]
 
@@ -40,6 +40,8 @@ def rl_process(
 
 
 check_reward_goes_up = partial(check_number_goes_up_or_down, go_up=True, pattern=r"Reward:\s*(\d+\.\d{4})")
+MISMATCH_KL_MIN = 0.0
+MISMATCH_KL_MAX = 0.0004
 
 
 @pytest.fixture(scope="module")
@@ -53,3 +55,10 @@ def test_reward_goes_up(rl_process: ProcessResult, test_no_error, output_dir: Pa
     with open(output_dir / "logs" / "orchestrator.stdout", "r") as f:
         orchestrator_stdout = strip_escape_codes(f.read()).splitlines()
     check_reward_goes_up(orchestrator_stdout)
+
+
+def test_mismatch_kl_in_band(rl_process: ProcessResult, test_no_error, output_dir: Path):
+    """Tests that mismatch KL stays within the expected band."""
+    with open(output_dir / "logs" / "trainer.stdout", "r") as f:
+        trainer_stdout = strip_escape_codes(f.read()).splitlines()
+    check_mismatch_kl_in_range(trainer_stdout, min_threshold=MISMATCH_KL_MIN, max_threshold=MISMATCH_KL_MAX)

--- a/tests/nightly/test_reverse_text.py
+++ b/tests/nightly/test_reverse_text.py
@@ -5,7 +5,7 @@ from typing import Callable
 import pytest
 
 from tests.conftest import ProcessResult
-from tests.utils import check_no_error, check_number_goes_up_or_down, check_number_in_range, strip_escape_codes
+from tests.utils import check_no_error, check_number_goes_up_or_down, check_reward_in_range, strip_escape_codes
 
 pytestmark = [pytest.mark.gpu, pytest.mark.slow]
 
@@ -40,7 +40,6 @@ def rl_process(
 
 
 check_reward_goes_up = partial(check_number_goes_up_or_down, go_up=True, pattern=r"Reward:\s*(\d+\.\d{4})")
-check_reward_in_range = partial(check_number_in_range, pattern=r"Reward:\s*(\d+\.\d{4})")
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
adding more metrics to be checked automatically in the nightly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens RL test coverage and refactors test utilities.
> 
> - Refactors `tests/utils.py`: replaces `check_number_in_range` with generic `check_metric_in_range`; adds wrappers `check_reward_in_range` and `check_mismatch_kl_in_range`
> - Updates integration tests (`test_rl*.py`) to use `check_reward_in_range` and simplify regex usage
> - Adds nightly stability checks for mismatch KL in `acereason_math` and `hendrycks_math` with defined min/max bands, parsing from `trainer.stdout`
> - Keeps reward progression checks and adjusts range assertions in multi-run LoRA tests
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cbe2ffaeca8444fae2598dfc4bb850ce7e9c6073. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->