### PR TITLE
[fix] use discovery in eval

### DIFF
--- a/src/prime_rl/eval/eval.py
+++ b/src/prime_rl/eval/eval.py
@@ -68,7 +68,7 @@ async def eval(config: OfflineEvalConfig):
         await run_evals(
             clients=clients,
             eval_config=config,
-            model_config=config.model,
+            model_name=config.model.name,
             sampling_config=config.sampling,
             evals_client=evals_client,
             reasoning_field=config.reasoning_field,
@@ -109,7 +109,7 @@ async def eval(config: OfflineEvalConfig):
                 await run_evals(
                     clients=clients,
                     eval_config=config,
-                    model_config=config.model,
+                    model_name=config.model.name,
                     sampling_config=config.sampling,
                     evals_client=evals_client,
                     reasoning_field=config.reasoning_field,

--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -779,7 +779,7 @@ async def run_evals(
         logger.warning(f"Skipped {skipped}/{len(eval_config.env)} environments due to retry exhaustion")
 
 
-async def _discover_clients(client_config: ClientConfig, model_config: ModelConfig):
+async def _discover_clients(client_config: ClientConfig, model_config: ModelConfig) -> tuple[list[AsyncOpenAI], str]:
     """Discover inference clients via elastic discovery or static config.
 
     For elastic mode, tries LoRA adapter first if configured, falls back to base model.

--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -782,21 +782,11 @@ async def run_evals(
 
 async def _get_clients(client_config: ClientConfig, model_name: str) -> list[AsyncOpenAI]:
     """Discover inference clients via elastic discovery or static config."""
-    logger = get_logger()
-
     if not client_config.is_elastic:
         return setup_clients(client_config)
 
     discovery = ServerDiscovery.from_config(client_config, model_name)
-
-    # Wait for servers to be discovered
-    while not discovery.has_clients:
-        await discovery.refresh()
-        if not discovery.has_clients:
-            logger.debug(f"Waiting for inference servers with model {model_name}...")
-            await asyncio.sleep(discovery.sync_interval)
-
-    return discovery.clients
+    return await discovery.wait_for_clients()
 
 
 def _run_evals_in_subprocess(

--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -515,7 +515,7 @@ async def run_eval(
 
         total_rollouts = len(all_rollouts)
         logger.info(
-            f"Evaluating {env_name_or_id} ({num_examples=}, {rollouts_per_example=}) "
+            f"Evaluating {model_name} on {env_name_or_id} ({num_examples=}, {rollouts_per_example=}) "
             f"{'with default args' if env_args == {} else f'with args {env_args}'} and extra_body {sampling_args['extra_body']}\n"
             f"{'Saving results to ' + str(path_to_save) if save_config.stream else 'Results will be saved at end of evaluation'}"
         )
@@ -633,7 +633,7 @@ async def run_eval(
     no_response_rate = (
         float((results_df.rollout_status == "no_response").mean()) if "rollout_status" in results_df else 0.0
     )
-    message = f"Evaluated {env_name_or_id} in {eval_time:.2f}s (Avg@{k}={results_df.reward.mean():.4f}"
+    message = f"Evaluated {model_name} on {env_name_or_id} in {eval_time:.2f}s (Avg@{k}={results_df.reward.mean():.4f}"
     if could_be_binary:
         assert pass_at_k is not None
         for pass_rate, pass_rate_score in pd.Series(pass_at_k.mean()).items():
@@ -732,7 +732,6 @@ async def run_evals(
     clients: list[AsyncOpenAI],
     eval_config: EvalConfig | OfflineEvalConfig,
     model_name: str,
-    model_config: ModelConfig,
     sampling_config: EvalSamplingConfig,
     evals_client: AsyncEvalsClient,
     reasoning_field: str,

--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -789,21 +789,12 @@ async def _get_clients(client_config: ClientConfig, model_name: str) -> list[Asy
 
     discovery = ServerDiscovery.from_config(client_config, model_name)
 
-    # Wait for servers to be discovered (with timeout)
-    max_wait = 60
-    waited = 0
-    while not discovery.has_clients and waited < max_wait:
+    # Wait for servers to be discovered
+    while not discovery.has_clients:
         await discovery.refresh()
         if not discovery.has_clients:
-            logger.debug(f"Waiting for inference servers... ({waited}s)")
+            logger.debug(f"Waiting for inference servers with model {model_name}...")
             await asyncio.sleep(discovery.sync_interval)
-            waited += discovery.sync_interval
-
-    if not discovery.has_clients:
-        raise RuntimeError(
-            f"No inference servers found with model {model_name} "
-            f"via elastic discovery (hostname={client_config.elastic.hostname}) after {max_wait}s"
-        )
 
     return discovery.clients
 

--- a/src/prime_rl/utils/elastic.py
+++ b/src/prime_rl/utils/elastic.py
@@ -17,6 +17,7 @@ from typing import Literal
 
 import httpx
 from httpx import AsyncClient
+from openai import AsyncOpenAI
 
 from prime_rl.utils.client import load_lora_adapter, setup_admin_clients, setup_clients
 from prime_rl.utils.config import ClientConfig
@@ -94,7 +95,7 @@ class ServerDiscovery:
         self.client_config = client_config
         self.sync_interval = sync_interval
 
-        self._clients: list = []
+        self._clients: list[AsyncOpenAI] = []
         self._urls: list[str] = []
         self._client_index = 0
         self._last_refresh = 0.0
@@ -114,11 +115,11 @@ class ServerDiscovery:
         return len(self._clients) > 0
 
     @property
-    def clients(self) -> list:
+    def clients(self) -> list[AsyncOpenAI]:
         """Get the current list of clients."""
         return self._clients
 
-    def get_next_client(self):
+    def get_next_client(self) -> AsyncOpenAI | None:
         """Get next client in round-robin fashion."""
         if not self._clients:
             return None
@@ -211,7 +212,7 @@ class ElasticInferencePool:
         self._lock = asyncio.Lock()
         self._desired: AdapterState = AdapterState()
 
-        self._clients: list = []
+        self._clients: list[AsyncOpenAI] = []
         self._client_urls: list[str] = []
 
         self._sync_task: asyncio.Task | None = None
@@ -240,7 +241,7 @@ class ElasticInferencePool:
         return [self._build_inference_url(ip) for ip, s in self._servers.items() if s.status == "ready"]
 
     @property
-    def clients(self) -> list:
+    def clients(self) -> list[AsyncOpenAI]:
         urls = self.ready_urls
         if set(urls) != set(self._client_urls):
             self._client_urls = urls

--- a/src/prime_rl/utils/elastic.py
+++ b/src/prime_rl/utils/elastic.py
@@ -154,6 +154,16 @@ class ServerDiscovery:
         self._client_index = 0
         return True
 
+    async def wait_for_clients(self) -> list[AsyncOpenAI]:
+        """Wait for clients to be available and return them."""
+        while not self.has_clients:
+            await self.refresh()
+            if not self.has_clients:
+                self.logger.debug(f"Waiting for inference servers with model {self.model_name}...")
+                await asyncio.sleep(self.sync_interval)
+
+        return self._clients
+
     async def stop(self) -> None:
         for client in self._clients:
             await client.close()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> - **Elastic discovery in eval subprocess**: adds `_get_clients` using `ServerDiscovery` (when `client_config.is_elastic`) with `wait_for_clients`; subprocess now selects LoRA `model_name` for checkpoints and logs number of clients.
> - **API refactor**: replaces `model_config` with `model_name` across `run_eval`/`run_evals` and callers; updates all usages accordingly.
> - **Consistent identifiers**: result paths, messages, HF/Env Hub names now use `model_name` (e.g., `get_results_path`, eval name, `model` metadata).
> - **Minor cleanups**: typing improvements (`AsyncOpenAI`), small logging/formatting adjustments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f99ad3b9bebcde57bb430363112faabe4f855f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->