### PR TITLE
fix wording in warning

### DIFF
--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -205,7 +205,7 @@ def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDim
             reshard_after_forward=False,
         )
     else:
-        get_logger().warning("Model uses tied word embeddings, so skipping the last-layer resharding optimization.")
+        get_logger().warning("Model uses tied word embeddings, so skipping the last-layer no-reshard optimization.")
 
     fully_shard(
         model,


### PR DESCRIPTION
Change warning from 

> Model is tied word embeddings, so not doing the last layer not resharding optimization

to

> Model uses tied word embeddings, so skipping the last-layer no-reshard optimization.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the logging message in `setup_fsdp` to clearly state that when a model uses tied word embeddings, the last-layer resharding optimization is skipped. No functional code changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b64a0cf9341efcedbc6a62e2fcaa6aa9430745a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->