### PR TITLE
[fix] handle weight update when enforce_eager=True for vllm

### DIFF
--- a/src/prime_rl/inference/vllm/worker/filesystem.py
+++ b/src/prime_rl/inference/vllm/worker/filesystem.py
@@ -23,8 +23,12 @@ class FileSystemWeightUpdateWorker(Worker):
     def update_weights(self, weight_path: str) -> None:
         """Update weights from a specified path in shared filesystem containing a HF-compatible checkpoint."""
         # Get vLLM model runner and model
+        # When enforce_eager=True, model isn't wrapped by torch.compile so no .runnable attr
         model_runner = self.model_runner
-        model = model_runner.model.runnable
+        if hasattr(model_runner.model, "runnable"):
+            model = model_runner.model.runnable
+        else:
+            model = model_runner.model
         assert isinstance(model, Module)
 
         # Get vLLM model loader


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Fixes weight update path when `enforce_eager=True`.**
> 
> - In `FileSystemWeightUpdateWorker.update_weights`, if `model_runner.model` lacks `runnable`, fall back to using the model directly, ensuring weight loading works when the model isn't torch.compile-wrapped.
> - No behavioral changes to loading logic beyond this conditional; existing post-load processing remains the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 360dbaca2d06a23c2d914d044c312812758c0338. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->