### PR TITLE
Add dev/prod image builds with digest output

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,15 +2,15 @@ name: Release
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
     tags:
       - "*"
   workflow_dispatch:
     inputs:
       environment:
-        description: "Environment tag (dev/prod)"
+        description: "Environment tag (dev/prod) - defaults to prod"
         required: false
-        default: ""
+        default: "prod"
 
 jobs:
   cuda:
@@ -38,15 +38,11 @@ jobs:
         run: |
           SHORT_SHA="${GITHUB_SHA::7}"
 
-          # Determine environment based on branch or input
+          # Use input if provided, otherwise default to prod
           if [[ "${{ github.event.inputs.environment }}" != "" ]]; then
             ENV="${{ github.event.inputs.environment }}"
-          elif [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
-            ENV="prod"
-          elif [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
-            ENV="dev"
           else
-            ENV="dev"
+            ENV="prod"
           fi
 
           echo "short_sha=${SHORT_SHA}" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,13 +2,23 @@ name: Release
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     tags:
       - "*"
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Environment tag (dev/prod)"
+        required: false
+        default: ""
+
 jobs:
   cuda:
     name: Push CUDA image to Docker
     runs-on: image-builder
+    outputs:
+      digest: ${{ steps.docker_build.outputs.digest }}
+      image_tag: ${{ steps.vars.outputs.image_tag }}
     steps:
       - name: Remove unnecessary packages
         run: |
@@ -20,46 +30,90 @@ jobs:
           echo "=== After pruning ==="
           df -h
 
-      # Link to discussion: https://github.com/orgs/community/discussions/25678
-
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Set environment variables
+        id: vars
+        run: |
+          SHORT_SHA="${GITHUB_SHA::7}"
+
+          # Determine environment based on branch or input
+          if [[ "${{ github.event.inputs.environment }}" != "" ]]; then
+            ENV="${{ github.event.inputs.environment }}"
+          elif [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            ENV="prod"
+          elif [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
+            ENV="dev"
+          else
+            ENV="dev"
+          fi
+
+          echo "short_sha=${SHORT_SHA}" >> $GITHUB_OUTPUT
+          echo "env=${ENV}" >> $GITHUB_OUTPUT
+          echo "image_tag=${ENV}-${SHORT_SHA}" >> $GITHUB_OUTPUT
+
       - name: Docker meta
         id: meta
-        uses: crazy-max/ghaction-docker-meta@v2
+        uses: docker/metadata-action@v5
         with:
           images: |
             primeintellect/prime-rl
           tags: |
+            # Environment + short SHA (primary tag for deployments)
+            type=raw,value=${{ steps.vars.outputs.env }}-${{ steps.vars.outputs.short_sha }}
+            # Environment latest (dev-latest or prod-latest)
+            type=raw,value=${{ steps.vars.outputs.env }}-latest
+            # Branch name
             type=ref,event=branch
-            type=ref,event=pr
+            # Full commit SHA for traceability
+            type=sha,prefix=commit-,format=long
+            # Semver for tags
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha,prefix=commit-
+            # Latest only for semver tags
             type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
+
       - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile.cuda
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Test import
-        run: docker run --entrypoint python primeintellect/prime-rl:main -c "import prime_rl"
+        if: github.event_name != 'pull_request'
+        run: docker run --entrypoint python primeintellect/prime-rl:${{ steps.vars.outputs.env }}-${{ steps.vars.outputs.short_sha }} -c "import prime_rl"
 
-      - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+      - name: Output image info
+        run: |
+          echo "## Image Build Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Property | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| **Environment** | ${{ steps.vars.outputs.env }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Image Tag** | \`${{ steps.vars.outputs.env }}-${{ steps.vars.outputs.short_sha }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Digest** | \`${{ steps.docker_build.outputs.digest }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Commit** | ${{ github.sha }} |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Pull command" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull primeintellect/prime-rl@${{ steps.docker_build.outputs.digest }}" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
- Build on both `main` (prod) and `develop` (dev) branches
- Tag images as `dev-{sha}` or `prod-{sha}` for clear environment separation
- Output digest SHA in job summary for exact reproducibility
- Add workflow_dispatch for manual builds with environment override
- Update to latest action versions (v4/v5)
- Add GHA build cache

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes the Docker release workflow with environment-aware tagging and improved build metadata.
> 
> - Adds `workflow_dispatch` with `environment` input; computes `env` and `short_sha` to tag images as `dev|prod-{sha}` and `{env}-latest`
> - Upgrades actions (`checkout@v4`, `metadata-action@v5`, `setup-buildx@v3`, `login-action@v3`, `build-push-action@v5`) and enables GHA cache (`cache-from/cache-to`)
> - Adds OCI labels, publishes job `outputs` (`digest`, `image_tag`), and replaces test run to use `{env}-{short_sha}` tag
> - Generates a step summary with environment, tag, digest, commit, and a ready-to-use `docker pull` command
> - Removes PR-based tagging; adds full `sha` tag and semver `latest` only on tag refs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5be0d3e148b5848c6c30dd63fd57b6e295adebb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->