### PR TITLE
fix: remove duplicate logger message in train.py

### DIFF
--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -70,8 +70,6 @@ def train(config: RLTrainerConfig):
         config.log.level,
         log_file=config.output_dir / "logs" / "trainer" / f"rank_{world.rank}.log" if config.log.file else None,
     )
-    logger.info(f"Starting RL trainer in {world}")
-
     logger.info(f"Starting RL trainer in {world} in {config.output_dir}")
 
     # Print warning if running in benchmark mode


### PR DESCRIPTION
**Description:**
Removes duplicate logger message at startup. Line 73 duplicates line 75 with less information

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Cleans up startup logging in the RL trainer.
> 
> - Removes a duplicate `logger.info` call in `train.py` and consolidates to a single message that includes `config.output_dir`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5d97d18139baa6780a87eb84258b080479c9f33. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->