### PR TITLE
fix checkpoint resume with NCCL broadcast mode

### DIFF
--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -167,13 +167,23 @@ async def compute_teacher_logprobs(
     return await asyncio.gather(*[_compute_single(client, sample) for client, sample in zip(cycle(clients), samples)])
 
 
-def get_weight_dir(output_dir: Path, step: int) -> Path:
-    """Get the weight directory for a given checkpoint step."""
+def get_weight_dir(output_dir: Path, step: int, check_exists: bool = True) -> Path:
+    """Get the weight directory for a given checkpoint step.
+
+    Args:
+        output_dir: The output directory for the run.
+        step: The checkpoint step.
+        check_exists: If True, raises FileNotFoundError if no weight directory exists.
+            If False, returns the broadcast directory path without checking existence
+            (useful for NCCL mode where weights are broadcasted, not stored on disk).
+    """
     ckpt_weight_dir = get_step_path(get_ckpt_dir(output_dir), step) / "weight"
     broadcast_weight_dir = get_step_path(get_broadcast_dir(output_dir), step)
     if ckpt_weight_dir.exists():
         return ckpt_weight_dir
     if broadcast_weight_dir.exists():
+        return broadcast_weight_dir
+    if not check_exists:
         return broadcast_weight_dir
     raise FileNotFoundError(
         f"No weight directory found for checkpoint step {step}. Expected to find it in {ckpt_weight_dir} or {broadcast_weight_dir}."


### PR DESCRIPTION
The `.exists()` check introduced in d7b0be7e broke checkpoint resume with NCCL broadcast mode. In NCCL mode, weights are broadcasted directly from trainer to inference servers, not stored on disk. When resuming from checkpoint, `get_weight_dir()` would raise `FileNotFoundError` because the broadcast directory doesn't exist yet.

Changes:
- Add `signal_nccl_ready()` function to decouple NCCL readiness signaling from `update_weights()` - this separates the coordination concern from the weight loading concern
- Remove NCCL_READY marker creation from `update_weights()` since it's now handled explicitly where needed
- Add `check_exists` parameter to `get_weight_dir()` - when False, returns the broadcast directory path without checking existence (for NCCL mode)
- Update orchestrator checkpoint resume logic to skip existence check and only signal NCCL readiness in NCCL mode (no weight loading needed)
- Update scheduler to explicitly call `signal_nccl_ready()` before `update_weights()` in NCCL mode during normal training

The NCCL_READY marker path remains unchanged:
`output_dir/broadcasts/step_{step}/NCCL_READY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures checkpoint resume works in NCCL broadcast mode by separating readiness signaling from weight loading and avoiding premature filesystem checks.
> 
> - Add `signal_nccl_ready()` to create `NCCL_READY` marker independently of weight updates
> - Remove NCCL marker creation from `update_weights()`; call `signal_nccl_ready()` explicitly where needed
> - Extend `get_weight_dir(output_dir, step, check_exists)` to allow bypassing existence checks in NCCL mode
> - Orchestrator: on resume, skip weight dir existence check; in NCCL mode only signal readiness (no disk load); otherwise load from filesystem
> - Scheduler: before `update_weights()` in NCCL mode, signal readiness for the current step
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32f2bd781e066eadc27c8d17a033777e8ae4048e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->