### PR TITLE
Wandb online eval logging

### DIFF
--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -663,7 +663,7 @@ async def run_eval(
         eval_metrics.update(pd.Series(pass_at_k.mean()).to_dict())
     eval_metrics = {**{f"eval/{env_name_or_id}/{k}": v for k, v in eval_metrics.items()}}
     eval_metrics.update({"progress/ckpt_step": ckpt_step, "step": step or ckpt_step})
-    monitor.log(eval_metrics, step=None)
+    monitor.log(eval_metrics, step=eval_metrics["step"])
 
     # Save results
     if save_config.disk is not None or save_config.hf is not None or save_config.env_hub:

--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -1,4 +1,5 @@
 import json
+import numbers
 import os
 import sys
 import time
@@ -77,7 +78,12 @@ class WandbMonitor(Monitor):
             return
         if not self.enabled:
             return
-        wandb.log(metrics, step=step)
+        log_step = step
+        if log_step is None:
+            metrics_step = metrics.get("step")
+            if isinstance(metrics_step, numbers.Integral):
+                log_step = int(metrics_step)
+        wandb.log(metrics, step=log_step)
 
     def log_samples(self, rollouts: list[vf.State], step: int) -> None:
         """Logs rollouts to W&B table."""


### PR DESCRIPTION
Use explicit step from metrics for W&B logging when `step` is `None` to ensure monotonic steps during online evaluation.

Online evaluation runs in a forked subprocess but reuses the orchestrator's W&B run. Previously, eval logs used implicit steps (`step=None`), which auto-advanced the W&B run's internal step counter. Later, explicit step logs (e.g., for samples) would sometimes attempt to log to a step less than the current auto-advanced step, causing W&B to ignore them. This change ensures that if a 'step' is provided within the `metrics` dictionary, it is used, thereby synchronizing steps between the orchestrator and evaluation logs and maintaining monotonicity.

---
<a href="https://cursor.com/background-agent?bcId=bc-71f5f5a3-c099-4e13-b29b-6dab829248a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-71f5f5a3-c099-4e13-b29b-6dab829248a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures W&B logs use a consistent, explicit step to avoid non-monotonic step issues during online evals.
> 
> - `WandbMonitor.log`: when `step` is `None`, derives `step` from `metrics['step']` if it’s an integer
> - `eval/utils.py`: passes `eval_metrics["step"]` explicitly to `monitor.log`
> 
> This aligns eval and orchestrator logging to maintain monotonic W&B steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1ed02000d3330600a93fc17fba27464497834f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->