### PR TITLE
[ci] skip openai integ tests if key not set

### DIFF
--- a/tests/integration/test_eval.py
+++ b/tests/integration/test_eval.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from typing import Callable
 
@@ -5,7 +6,10 @@ import pytest
 
 from tests.conftest import Command, Environment, ProcessResult
 
-pytestmark = [pytest.mark.slow]
+pytestmark = [
+    pytest.mark.slow,
+    pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"),
+]
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_synthesize.py
+++ b/tests/integration/test_synthesize.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from typing import Callable
 
@@ -5,7 +6,10 @@ import pytest
 
 from tests.conftest import Command, Environment, ProcessResult
 
-pytestmark = [pytest.mark.slow]
+pytestmark = [
+    pytest.mark.slow,
+    pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"),
+]
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
This should make it that external contributors PRing from forks dont see the error about not having openai key set

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds conditional skipping for OpenAI-dependent integration tests to avoid CI failures when the API key is absent.
> 
> - In `tests/integration/test_eval.py` and `tests/integration/test_synthesize.py`, add `pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set")` to `pytestmark`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f05ecf43dbea65a3961dc084aee1458cfd663396. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->