### PR TITLE
added weave logging and tracing

### DIFF
--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -46,9 +46,51 @@ from prime_rl.utils.pydantic_config import parse_argv
 from prime_rl.utils.utils import clean_exit, to_col_format
 import torch.distributed as dist
 from liger_kernel.transformers.cross_entropy import LigerCrossEntropyLoss
-import weave
-
 from torchtitan.distributed.utils import clip_grad_norm_
+
+
+def log_samples_to_weave(
+    log_sft_samples,
+    tokenizer,
+    input_ids: torch.Tensor,
+    target_ids: torch.Tensor,
+    logits: torch.Tensor,
+    step: int,
+    n_samples: int = 4,
+) -> None:
+    """Log training samples with predictions to Weave.
+    
+    Args:
+        log_sft_samples: The weave op function for logging samples.
+        tokenizer: The tokenizer for decoding.
+        input_ids: Input token IDs tensor.
+        target_ids: Target token IDs tensor.
+        logits: Model output logits tensor.
+        step: Current training step.
+        n_samples: Number of samples to log (default: 4).
+    """
+    n_samples = min(n_samples, input_ids.size(0))
+    
+    samples_data = []
+    for i in range(n_samples):
+        # Decode input and target (ground truth)
+        input_text = tokenizer.decode(input_ids[i], skip_special_tokens=False)
+        target_text = tokenizer.decode(target_ids[i], skip_special_tokens=False)
+
+        # Get model prediction (greedy decoding from logits)
+        pred_ids = logits[i].argmax(dim=-1)
+        pred_text = tokenizer.decode(pred_ids, skip_special_tokens=True)
+
+        samples_data.append({
+            "step": step,
+            "input_text": input_text,
+            "target_text": target_text,
+            "prediction_text": pred_text,
+        })
+
+    logger.info(f"Logging {len(samples_data)} samples (with predictions) to Weave at step {step}")
+    log_sft_samples(samples_data, step)
+    logger.info(f"Successfully logged samples to Weave")
 
 
 @clean_exit
@@ -72,23 +114,20 @@ def train(config: SFTTrainerConfig):
 
     weave_initialized = False
     log_sft_samples = None
-    if world.is_master and config.wandb and config.wandb.project:
+    if world.is_master and config.wandb and config.wandb.weave and config.wandb.project:
         logger.info(f"Initializing Weave ({config.wandb.project})")
-        try:
-            weave.init(project_name=config.wandb.project)
-            weave_initialized = True
-            logger.info(f"Successfully initialized Weave")
-            
-            # Define Weave op for logging samples (only if Weave initialized successfully)
-            @weave.op()
-            def _log_sft_samples(samples_data: list[dict], step: int):
-                """Weave operation to log SFT training samples."""
-                # Weave will automatically track this function call and its inputs/outputs
-                return samples_data
-            
-            log_sft_samples = _log_sft_samples
-        except Exception as e:
-            logger.warning(f"Failed to initialize Weave: {e}", exc_info=True)
+        import weave
+        weave.init(project_name=config.wandb.project)
+        weave_initialized = True
+        logger.info(f"Successfully initialized Weave")
+
+        # Define Weave op for logging samples
+        @weave.op()
+        def _log_sft_samples(samples_data: list[dict], step: int):
+            """Weave operation to log SFT training samples."""
+            return samples_data
+
+        log_sft_samples = _log_sft_samples
 
     # Setup heartbeat (only on rank 0)
     heart = None
@@ -269,41 +308,17 @@ def train(config: SFTTrainerConfig):
             logits = out["logits"]
             B, L, V = logits.shape
 
-            # --- START CHANGE: Log samples to Weave (with predictions) ---
-            # Log every step (adjust frequency as needed)
-            if (world.is_master and config.wandb and config.wandb.project 
+            # Log samples to Weave (with predictions)
+            if (world.is_master and config.wandb and config.wandb.weave
                 and progress.step % 1 == 0 and micro_step == 0 and weave_initialized and log_sft_samples is not None):
-                try:
-                    # Decode the first few samples from the batch
-                    n_samples = min(4, input_ids.size(0))
-
-                    # Create a list of dictionaries for Weave
-                    samples_data = []
-                    for i in range(n_samples):
-                        # Decode input and target (ground truth)
-                        input_text = tokenizer.decode(input_ids[i], skip_special_tokens=False)
-                        target_text = tokenizer.decode(target_ids[i], skip_special_tokens=False)
-                        
-                        # Get model prediction (greedy decoding from logits)
-                        pred_ids = logits[i].argmax(dim=-1)
-                        pred_text = tokenizer.decode(pred_ids, skip_special_tokens=True)
-
-                        samples_data.append({
-                            "step": progress.step,
-                            "input_text": input_text,
-                            "target_text": target_text,
-                            "prediction_text": pred_text,  # Model's actual prediction
-                            # You can add other metadata here
-                        })
-
-                    # Log to Weave using the op function
-                    # This creates a tracked operation in Weave
-                    logger.info(f"Logging {len(samples_data)} samples (with predictions) to Weave at step {progress.step}")
-                    log_sft_samples(samples_data, progress.step)
-                    logger.info(f"Successfully logged samples to Weave")
-
-                except Exception as e:
-                    logger.warning(f"Failed to log samples to Weave: {e}", exc_info=True)
+                log_samples_to_weave(
+                    log_sft_samples=log_sft_samples,
+                    tokenizer=tokenizer,
+                    input_ids=input_ids,
+                    target_ids=target_ids,
+                    logits=logits,
+                    step=progress.step,
+                )
 
             # Compute loss
             loss = ce_loss(logits.view(-1, V), target_ids.view(-1)).view(B, L)

--- a/src/prime_rl/utils/config.py
+++ b/src/prime_rl/utils/config.py
@@ -191,6 +191,13 @@ class WandbConfig(BaseConfig):
         ),
     ] = None
 
+    weave: Annotated[
+        bool,
+        Field(
+            description="Whether to initialize W&B Weave for LLM call tracing. Only takes effect when wandb is enabled.",
+        ),
+    ] = False
+
 
 class WandbWithExtrasConfig(WandbConfig):
     """Configures logging to Weights and Biases with extras."""


### PR DESCRIPTION
Added Weave-based logging and tracing for LLM inputs, outputs
<img width="1789" height="962" alt="Screenshot 2026-01-26 at 11 35 56 AM" src="https://github.com/user-attachments/assets/2f9b48ee-8397-439a-a7f9-109fcba6b525" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional Weave-based logging of training samples with model predictions during SFT.
> 
> - Initializes Weave on master when `wandb.weave` and `wandb.project` are set; defines a `weave.op` to log samples
> - New `log_samples_to_weave` helper decodes inputs/targets, generates greedy predictions from `logits`, and logs up to 4 samples per step
> - Hooks logging after forward pass (micro_step 0) without affecting loss/backward
> - Extends `WandbConfig` with `weave: bool` flag to toggle Weave initialization
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d99a061e2c0b420aa783785fc8362dc5f0d194ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->