### PR TITLE
fix: support NCCL mode when resuming from checkpoint

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -232,7 +232,9 @@ async def orchestrate(config: OrchestratorConfig):
             last_eval_step = scheduler.ckpt_step
             logger.info(f"Skipping online eval on resume (ckpt_step={scheduler.ckpt_step})")
 
-        weights_path = get_weight_dir(config.output_dir, scheduler.ckpt_step)
+        # In NCCL mode, skip existence check - weights are broadcasted, not stored on disk
+        check_exists = config.weight_broadcast.type != "nccl"
+        weights_path = get_weight_dir(config.output_dir, scheduler.ckpt_step, check_exists=check_exists)
         lora_name = config.model.lora.name if config.model.lora else None
         await inference_pool.update_weights(weights_path, lora_name=lora_name, step=scheduler.ckpt_step)
     else:

--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -167,13 +167,23 @@ async def compute_teacher_logprobs(
     return await asyncio.gather(*[_compute_single(client, sample) for client, sample in zip(cycle(clients), samples)])
 
 
-def get_weight_dir(output_dir: Path, step: int) -> Path:
-    """Get the weight directory for a given checkpoint step."""
+def get_weight_dir(output_dir: Path, step: int, check_exists: bool = True) -> Path:
+    """Get the weight directory for a given checkpoint step.
+
+    Args:
+        output_dir: The output directory for the run.
+        step: The checkpoint step.
+        check_exists: If True, raises FileNotFoundError if no weight directory exists.
+            If False, returns the broadcast directory path without checking existence
+            (useful for NCCL mode where weights are broadcasted, not stored on disk).
+    """
     ckpt_weight_dir = get_step_path(get_ckpt_dir(output_dir), step) / "weight"
     broadcast_weight_dir = get_step_path(get_broadcast_dir(output_dir), step)
     if ckpt_weight_dir.exists():
         return ckpt_weight_dir
     if broadcast_weight_dir.exists():
+        return broadcast_weight_dir
+    if not check_exists:
         return broadcast_weight_dir
     raise FileNotFoundError(
         f"No weight directory found for checkpoint step {step}. Expected to find it in {ckpt_weight_dir} or {broadcast_weight_dir}."


### PR DESCRIPTION
Add `check_exists` parameter to `get_weight_dir()` to handle NCCL weight broadcast mode where weights are transmitted via NCCL rather than stored on disk.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables resuming training when weights are broadcast via NCCL instead of stored on disk.
> 
> - Adds `check_exists` to `get_weight_dir()` to optionally skip on-disk existence checks and return the broadcast path
> - Orchestrator uses this when `weight_broadcast.type == "nccl"` during checkpoint resume to update inference weights
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d88f2214b82740ad896a4adef907f97700e9e11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->