### PR TITLE
fix: pass explicit step to wandb.log to prevent monotonicity warnings

### DIFF
--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -663,7 +663,7 @@ async def run_eval(
         eval_metrics.update(pd.Series(pass_at_k.mean()).to_dict())
     eval_metrics = {**{f"eval/{env_name_or_id}/{k}": v for k, v in eval_metrics.items()}}
     eval_metrics.update({"progress/ckpt_step": ckpt_step, "step": step or ckpt_step})
-    monitor.log(eval_metrics, step=None)
+    monitor.log(eval_metrics, step=step or ckpt_step)
 
     # Save results
     if save_config.disk is not None or save_config.hf is not None or save_config.env_hub:


### PR DESCRIPTION
When wandb.log() is called without a step parameter, it auto-increments its internal counter. With async training, this can cause the counter to drift ahead, resulting in "Steps must be monotonically increasing" warnings when later calls use explicit step numbers.


see below eval every 2 steps correctly log 
<img width="1100" height="384" alt="image" src="https://github.com/user-attachments/assets/5281b4c4-a855-4e2d-8f3b-f90379b4c3be" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 1ecc2bd2ee54bf0f0d1f2713e8644103cfeb791c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->