### PR TITLE
[fix] zombie guard on checkpoint

### DIFF
--- a/src/prime_rl/trainer/multi_ckpt.py
+++ b/src/prime_rl/trainer/multi_ckpt.py
@@ -212,9 +212,6 @@ class MultiCheckpointManager:
             state_dict = torch.load(ckpt_path / f"rank_{self.world.rank}.pt")
             run_state.load_state_dict(state_dict)
 
-            # Set progress.step to match the loaded checkpoint
-            self.multi_run_manager.progress[idx].step = step
-
             self.logger.info(f"Resumed run {self.multi_run_manager.idx_2_id[idx]} from step {step}")
             return True
         except Exception as e:

--- a/src/prime_rl/trainer/multi_ckpt.py
+++ b/src/prime_rl/trainer/multi_ckpt.py
@@ -18,7 +18,6 @@ from prime_rl.trainer.config import CheckpointConfig
 from prime_rl.trainer.runs import Progress, get_multi_run_manager
 from prime_rl.trainer.world import get_world
 from prime_rl.utils.logger import get_logger
-from prime_rl.utils.utils import resolve_latest_multi_run_trainer_ckpt_step
 
 if TYPE_CHECKING:
     from prime_rl.trainer.optim import MultiLoRAOptimizer
@@ -192,8 +191,8 @@ class MultiCheckpointManager:
 
         step = self.multi_run_manager.config[idx].ckpt.resume_step
         if step == -1:
-            step = resolve_latest_multi_run_trainer_ckpt_step(manager.ckpt_dir)
-            if step is None:
+            step = self.multi_run_manager.progress[idx].step
+            if step == 0:
                 return False
 
         try:

--- a/src/prime_rl/trainer/multi_ckpt.py
+++ b/src/prime_rl/trainer/multi_ckpt.py
@@ -18,7 +18,7 @@ from prime_rl.trainer.config import CheckpointConfig
 from prime_rl.trainer.runs import Progress, get_multi_run_manager
 from prime_rl.trainer.world import get_world
 from prime_rl.utils.logger import get_logger
-from prime_rl.utils.utils import resolve_latest_ckpt_step
+from prime_rl.utils.utils import resolve_latest_multi_run_trainer_ckpt_step
 
 if TYPE_CHECKING:
     from prime_rl.trainer.optim import MultiLoRAOptimizer
@@ -192,7 +192,7 @@ class MultiCheckpointManager:
 
         step = self.multi_run_manager.config[idx].ckpt.resume_step
         if step == -1:
-            step = resolve_latest_ckpt_step(manager.ckpt_dir)
+            step = resolve_latest_multi_run_trainer_ckpt_step(manager.ckpt_dir)
             if step is None:
                 return False
 
@@ -210,6 +210,9 @@ class MultiCheckpointManager:
             self.logger.info(f"Loading checkpoint from {ckpt_path}")
             state_dict = torch.load(ckpt_path / f"rank_{self.world.rank}.pt")
             run_state.load_state_dict(state_dict)
+
+            # Set progress.step to match the loaded checkpoint
+            self.multi_run_manager.progress[idx].step = step
 
             self.logger.info(f"Resumed run {self.multi_run_manager.idx_2_id[idx]} from step {step}")
             return True

--- a/src/prime_rl/trainer/multi_ckpt.py
+++ b/src/prime_rl/trainer/multi_ckpt.py
@@ -18,6 +18,7 @@ from prime_rl.trainer.config import CheckpointConfig
 from prime_rl.trainer.runs import Progress, get_multi_run_manager
 from prime_rl.trainer.world import get_world
 from prime_rl.utils.logger import get_logger
+from prime_rl.utils.pathing import get_stable_ckpt_steps
 
 if TYPE_CHECKING:
     from prime_rl.trainer.optim import MultiLoRAOptimizer
@@ -191,9 +192,10 @@ class MultiCheckpointManager:
 
         step = self.multi_run_manager.config[idx].ckpt.resume_step
         if step == -1:
-            step = self.multi_run_manager.progress[idx].step
-            if step == 0:
+            stable_steps = get_stable_ckpt_steps(manager.ckpt_dir)
+            if not stable_steps:
                 return False
+            step = max(stable_steps)
 
         try:
             model_state_dict = dict(self.multi_run_manager.get_named_parameters_for_run(idx))

--- a/src/prime_rl/trainer/runs.py
+++ b/src/prime_rl/trainer/runs.py
@@ -262,13 +262,8 @@ class MultiRunManager:
         self.unused_idxs.remove(new_id)
         self.idx_2_id[new_id] = new_run
 
-        # Get progress
+        # Initialize progress to 0; checkpoint loading will set the correct step if resuming
         self.progress[new_id] = Progress()
-
-        prev_ckpt_steps = [
-            int(i.stem.split("_")[-1]) for i in (self.get_run_dir(new_id) / "checkpoints").glob("step_*")
-        ]
-        self.progress[new_id].step = max(prev_ckpt_steps) if prev_ckpt_steps else 0
 
         # Store the parsed config
         self.config[new_id] = config

--- a/src/prime_rl/trainer/runs.py
+++ b/src/prime_rl/trainer/runs.py
@@ -265,8 +265,14 @@ class MultiRunManager:
 
         # Get progress from stable checkpoints (only checkpoints with STABLE file are considered)
         self.progress[new_id] = Progress()
-        stable_steps = get_stable_ckpt_steps(self.get_run_dir(new_id) / "checkpoints")
-        self.progress[new_id].step = max(stable_steps) if stable_steps else 0
+        if self.max_runs == 1:
+            prev_ckpt_steps = [
+                int(i.stem.split("_")[-1]) for i in (self.get_run_dir(new_id) / "checkpoints").glob("step_*")
+            ]
+            self.progress[new_id].step = max(prev_ckpt_steps) if prev_ckpt_steps else 0
+        else:
+            stable_steps = get_stable_ckpt_steps(self.get_run_dir(new_id) / "checkpoints")
+            self.progress[new_id].step = max(stable_steps) if stable_steps else 0
 
         # Store the parsed config
         self.config[new_id] = config

--- a/src/prime_rl/trainer/runs.py
+++ b/src/prime_rl/trainer/runs.py
@@ -11,6 +11,7 @@ import torch.distributed.distributed_c10d as c10d
 from prime_rl.trainer.config import LoRAConfig
 from prime_rl.trainer.world import get_world
 from prime_rl.utils.logger import get_logger
+from prime_rl.utils.pathing import get_stable_ckpt_steps
 
 if TYPE_CHECKING:
     from prime_rl.orchestrator.config import OrchestratorConfig
@@ -262,8 +263,10 @@ class MultiRunManager:
         self.unused_idxs.remove(new_id)
         self.idx_2_id[new_id] = new_run
 
-        # Initialize progress to 0; checkpoint loading will set the correct step if resuming
+        # Get progress from stable checkpoints (only checkpoints with STABLE file are considered)
         self.progress[new_id] = Progress()
+        stable_steps = get_stable_ckpt_steps(self.get_run_dir(new_id) / "checkpoints")
+        self.progress[new_id].step = max(stable_steps) if stable_steps else 0
 
         # Store the parsed config
         self.config[new_id] = config

--- a/src/prime_rl/utils/pathing.py
+++ b/src/prime_rl/utils/pathing.py
@@ -62,23 +62,6 @@ def resolve_latest_ckpt_step(ckpt_dir: Path) -> int | None:
     return latest_step
 
 
-def resolve_latest_multi_run_trainer_ckpt_step(ckpt_dir: Path) -> int | None:
-    """Gets the latest stable checkpoint step for multi-run trainer checkpoints.
-
-    Multi-run trainer checkpoints use STABLE files to mark completed checkpoints.
-    Returns None if no stable checkpoints are found.
-    """
-    steps = get_stable_ckpt_steps(ckpt_dir)
-    if len(steps) == 0:
-        logger = get_logger()
-        logger.warning(f"No stable checkpoints found in {ckpt_dir}. Starting from scratch.")
-        return None
-    latest_step = steps[-1]
-    logger = get_logger()
-    logger.info(f"Found latest stable checkpoint in {ckpt_dir}: {latest_step}")
-    return latest_step
-
-
 def sync_wait_for_path(path: Path, interval: int = 1, log_interval: int = 10) -> None:
     logger = get_logger()
     wait_time = 0

--- a/src/prime_rl/utils/pathing.py
+++ b/src/prime_rl/utils/pathing.py
@@ -43,6 +43,12 @@ def get_all_ckpt_steps(ckpt_dir: Path) -> list[int]:
     return sorted([int(step_dir.name.split("_")[-1]) for step_dir in step_dirs])
 
 
+def get_stable_ckpt_steps(ckpt_dir: Path) -> list[int]:
+    """Gets checkpoint steps that have STABLE file, sorted in ascending order."""
+    steps = get_all_ckpt_steps(ckpt_dir)
+    return [s for s in steps if (ckpt_dir / f"step_{s}" / "STABLE").exists()]
+
+
 def resolve_latest_ckpt_step(ckpt_dir: Path) -> int | None:
     """Gets the latest checkpoint step from the checkpoint directory. Returns None if no checkpoints are found."""
     steps = get_all_ckpt_steps(ckpt_dir)
@@ -53,6 +59,23 @@ def resolve_latest_ckpt_step(ckpt_dir: Path) -> int | None:
     latest_step = steps[-1]
     logger = get_logger()
     logger.info(f"Found latest checkpoint in {ckpt_dir}: {latest_step}")
+    return latest_step
+
+
+def resolve_latest_multi_run_trainer_ckpt_step(ckpt_dir: Path) -> int | None:
+    """Gets the latest stable checkpoint step for multi-run trainer checkpoints.
+
+    Multi-run trainer checkpoints use STABLE files to mark completed checkpoints.
+    Returns None if no stable checkpoints are found.
+    """
+    steps = get_stable_ckpt_steps(ckpt_dir)
+    if len(steps) == 0:
+        logger = get_logger()
+        logger.warning(f"No stable checkpoints found in {ckpt_dir}. Starting from scratch.")
+        return None
+    latest_step = steps[-1]
+    logger = get_logger()
+    logger.info(f"Found latest stable checkpoint in {ckpt_dir}: {latest_step}")
     return latest_step
 
 

--- a/src/prime_rl/utils/utils.py
+++ b/src/prime_rl/utils/utils.py
@@ -23,9 +23,11 @@ from prime_rl.utils.pathing import (
     get_eval_dir,
     get_log_dir,
     get_rollout_dir,
+    get_stable_ckpt_steps,
     get_step_path,
     get_weights_dir,
     resolve_latest_ckpt_step,
+    resolve_latest_multi_run_trainer_ckpt_step,
     sync_wait_for_path,
     wait_for_path,
 )

--- a/src/prime_rl/utils/utils.py
+++ b/src/prime_rl/utils/utils.py
@@ -27,7 +27,6 @@ from prime_rl.utils.pathing import (
     get_step_path,
     get_weights_dir,
     resolve_latest_ckpt_step,
-    resolve_latest_multi_run_trainer_ckpt_step,
     sync_wait_for_path,
     wait_for_path,
 )


### PR DESCRIPTION
Fixes two issues:
1. If a run gets deleted while we are checkpointing, the trainer will crash because it will try to write stable file into non-existent directory. We need to include the stable writing in the try except that ignores this and also try to cleanup the run directory if we created it while it was being deleted.
2. If the trainer crashes when a step has orchestrator ckpt but not trainer ckpt, the respawned trainer will try to resume from this step and fail because it doesnt have trainer ckpt. We thus need to check trainer ckpt stable file before resuming in the trainer.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches distributed checkpoint save/resume ordering and run lifecycle cleanup; race conditions or incorrect barriers could cause missed checkpoints or accidental directory deletion.
> 
> **Overview**
> Fixes multi-run checkpoint stability and cleanup behavior. Multi-run resume/progress discovery now only considers *stable* checkpoints (those with a `STABLE` marker) via new `get_stable_ckpt_steps`, avoiding resuming from partially-written steps.
> 
> During `MultiCheckpointManager.save`, the `STABLE` marker is now written only after all ranks synchronize, and master additionally deletes a run directory if the run was removed mid-checkpoint to prevent recreating “zombie” runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1501d04e99b658cdc78faae209677d530d60146. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->