### PR TITLE
cancel all rollout before eval

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -308,8 +308,10 @@ async def orchestrate(config: OrchestratorConfig):
             last_eval_step = ckpt_step
             logger.info(f"Running evals for checkpoint step {ckpt_step} (blocking, subprocess)")
 
-            # Pause weight updates during eval
+            # Pause weight updates during eval and cancel inflight rollouts
+            # this avoid doing eval across different checkpoints and avoid congestion
             scheduler.checkpoint_ready.clear()
+            scheduler.cancel_all_inflight_rollouts()
 
             await run_evals_subprocess(
                 client_config=config.client,

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -152,6 +152,18 @@ class Scheduler:
             for worker in workers:
                 worker.stop()
 
+    def cancel_all_inflight_rollouts(self):
+        """Cancel all in-flight rollout requests.
+
+        Used when weights are updated to discard stale rollouts generated with old weights.
+        """
+        count = len(self.inflight_group_rollouts)
+        for future in list(self.inflight_group_rollouts.keys()):
+            if not future.done():
+                future.cancel()
+        self.inflight_group_rollouts.clear()
+        self.cancelled_rollouts_count += count
+
     async def schedule_group_rollout(self):
         """Asynchronously schedules a group rollout request."""
         example = self.buffer.sample_examples(n=1)[0]


### PR DESCRIPTION
THis pr introduce a major change in online eval. It cancel all the inflight rollout before doing an eval. This is the extension of pausing the brackground broadcas logic.


This fix a notorious deadlock we have in prime-rl during online eval. The issue is that we stop the ckpt update when the eval is in process. But we don't stop the current in flight rollout, so there is a chance we get a full step down (lets call it N) during the time we eval (so eval is N-1), in which case we would skip loading the N-1 checkpoint which would stale the trainer forever. Hence the deadlock 

the solution we suggest is to cancel all the inflight rollout before eval to avoid this issue



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures online eval runs against a consistent checkpoint and prevents rollout congestion.
> 
> - Orchestrator now pauses weight updates and calls `scheduler.cancel_all_inflight_rollouts()` before running evals
> - Adds `Scheduler.cancel_all_inflight_rollouts()` to cancel and clear all `inflight_group_rollouts`, updating `batch/cancelled_rollouts` metric accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 977d2b34086c9e94d3c0246ce64b82c65ec249ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->