### PR TITLE
bump prime to 0.5.24

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "verifiers>=0.1.8",
     "prime-evals>=0.1.5",
     "ring-flash-attn>=0.1.8",
-    "prime>=0.5.0",
+    "prime>=0.5.24",
     "tenacity>=8.2.0",
     "pyzmq>=27.1.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -2411,7 +2411,7 @@ wheels = [
 
 [[package]]
 name = "prime"
-version = "0.5.0"
+version = "0.5.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "build" },
@@ -2425,9 +2425,9 @@ dependencies = [
     { name = "typer" },
     { name = "verifiers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5d/6f/0cd7ee178b600b95b110f88c4c9892dac6668ea5c4eab917bed6bae27c49/prime-0.5.0.tar.gz", hash = "sha256:bb7bade9a0bb36c72a7a6420b5138144c29e8a56c497a9521d133337fbbeca4a", size = 226349, upload-time = "2025-12-02T03:48:24.942Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/2d/34bca0e5c89c878e6c55e5b09cc138f19b884ddc1029ca8e5bad6dda4c78/prime-0.5.24.tar.gz", hash = "sha256:e50549b6bbade836b802af92065f1914157f130053d903e731eaaaef3917b7b6", size = 262874, upload-time = "2026-01-27T05:31:31.109Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/a2/e4ac530ad0853e8c190c9ccb17345604c7c6098ed626e8ca8c7c0f9e7d8a/prime-0.5.0-py3-none-any.whl", hash = "sha256:dbf806e65d241446eaf92030d63384bd602b8395fdb7489d5917231f582b416b", size = 78332, upload-time = "2025-12-02T03:48:23.785Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f6/69729926e31164da3756078727b3c6766035e00233fa9d27f3ba07e236ed/prime-0.5.24-py3-none-any.whl", hash = "sha256:acdbd5e1950cd7688294ac2f325ace10acc8721d2074f1474e892214974a3ec7", size = 116123, upload-time = "2026-01-27T05:31:29.443Z" },
 ]
 
 [[package]]
@@ -2520,7 +2520,7 @@ requires-dist = [
     { name = "nltk", specifier = ">=3.9.1" },
     { name = "numpy", specifier = ">=2.2.6" },
     { name = "openai", specifier = ">=1.106.1" },
-    { name = "prime", specifier = ">=0.5.0" },
+    { name = "prime", specifier = ">=0.5.24" },
     { name = "prime-evals", specifier = ">=0.1.5" },
     { name = "pydantic", specifier = ">=1.10.13" },
     { name = "pydantic-settings", specifier = ">=2.10.1" },


### PR DESCRIPTION
Bump prime package from >=0.5.0 to >=0.5.24 (latest on PyPI).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates dependency version for `prime` across project config.
> 
> - Bumps `prime` from `>=0.5.0` to `>=0.5.24` in `pyproject.toml`
> - Refreshes `uv.lock` for `prime` (new version, sdist/wheel URLs, hashes, sizes) and updates internal specifiers referencing `prime`
> 
> No application code changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68c0a8f8dd3dd8fe687a0f61608b8659591dd6ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->