### PR TITLE
Wandb async RL inflight

### DIFF
--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -365,6 +365,7 @@ class Scheduler:
             "time/wait_for_ckpt": self.wait_for_ckpt_time,
             "time/update_weights": self.update_weights_time,
             "batch/async_level": self.async_level,
+            "batch/inflight_rollouts": len(self.inflight_group_rollouts),
             "batch/off_policy_level/max": self.max_off_policy_level,
             "batch/off_policy_level/mean": self.mean_off_policy_level,
             "batch/off_policy_level/min": self.min_off_policy_level,

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -366,6 +366,7 @@ class Scheduler:
             "time/update_weights": self.update_weights_time,
             "batch/async_level": self.async_level,
             "batch/inflight_rollouts": len(self.inflight_group_rollouts),
+            "batch/inflight_samples": len(self.inflight_group_rollouts) * self.rollouts_per_example,
             "batch/off_policy_level/max": self.max_off_policy_level,
             "batch/off_policy_level/mean": self.mean_off_policy_level,
             "batch/off_policy_level/min": self.min_off_policy_level,


### PR DESCRIPTION
Add `batch/inflight_rollouts` W&B metric to track the number of in-progress group rollouts during async RL.

---
<a href="https://cursor.com/background-agent?bcId=bc-1211d505-6e17-4821-a230-1d5fb7c0226f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1211d505-6e17-4821-a230-1d5fb7c0226f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds new W&B metrics to monitor async RL progress.
> 
> - Exposes `batch/inflight_rollouts` and `batch/inflight_samples` in `Scheduler.get_metrics` to track in-progress group rollouts and derived sample counts
> - No other behavior changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f23161def909987d03acc890b263341a56842312. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->