### PR TITLE
[ci] make multi run test do 2 gpu trainer and 2 inference servers

### DIFF
--- a/.github/workflows/gpu_tests.yaml
+++ b/.github/workflows/gpu_tests.yaml
@@ -53,7 +53,7 @@ jobs:
 
   integration-tests:
     name: Integration tests (${{ matrix.test }})
-    runs-on: vm
+    runs-on: ${{ matrix.runner }}
     container:
       image: pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel
       options: --gpus all
@@ -64,10 +64,13 @@ jobs:
       matrix:
         include:
           - test: base
+            runner: vm
             pytest_args: "tests/integration -m gpu --ignore=tests/integration/test_rl_lora.py --ignore=tests/integration/test_rl_multi_run_lora.py"
           - test: rl_lora
+            runner: vm
             pytest_args: "tests/integration/test_rl_lora.py -m gpu"
           - test: rl_multi_run
+            runner: 4xa6000
             pytest_args: "tests/integration/test_rl_multi_run_lora.py -m gpu"
     steps:
       - name: Install Git


### PR DESCRIPTION
this better reflects the deployment scenario and should catch more issues with syncing stuff across ranks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect GPU CI execution and the multi-process integration test harness (process spawning, port/GPU allocation), which can introduce flakes or resource/port conflicts but does not touch production runtime logic.
> 
> **Overview**
> Updates GPU CI to parameterize the integration-test runner per matrix entry and run the `rl_multi_run` integration test on a larger `4xa6000` runner.
> 
> Refactors `test_rl_multi_run_lora.py` to start **two** inference servers (separate ports/GPU bindings), run the trainer via `torchrun` with `--nproc-per-node 2` on two GPUs, and pass multiple `--client.base-url` values to orchestrators; readiness/cleanup logic is updated to handle multiple inference processes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93e3e2ab34a2050ccd8c427b5973d2c5be8bcd2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->