### PR TITLE
ENG-2765: Fix bug where hosted RL rollouts were missing final msg

### DIFF
--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -116,13 +116,12 @@ class PrimeMonitor(Monitor):
         # Prepare samples for API
         samples = []
         for rollout in rollouts:
-            # Extract prompt and completion separately from the last trajectory step
-            trajectory = rollout["trajectory"]
-            if not trajectory:
+            # Extract prompt and completion from the rollout state, which includes final_env_response
+            prompt_messages = rollout.get("prompt")
+            completion_messages = rollout.get("completion")
+            trajectory = rollout.get("trajectory") or []
+            if prompt_messages is None or completion_messages is None or not trajectory:
                 continue
-            last_step = trajectory[-1]
-            prompt_messages = last_step["prompt"]
-            completion_messages = last_step["completion"]
 
             # Serialize full trajectory array (excluding large response objects and token arrays)
             trajectory_data = []


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small change to sample serialization for Prime uploads; main risk is skipping samples if upstream rollouts don’t populate top-level `prompt`/`completion` as expected.
> 
> **Overview**
> Fixes Prime sample uploads in `PrimeMonitor.log_samples` by sourcing `prompt`/`completion` from the rollout state (instead of the last trajectory step), ensuring the final message is included.
> 
> Tightens filtering to skip rollouts missing top-level `prompt`/`completion` and normalizes `trajectory` access with a safe default.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f55bd740a7f449cb5dead3fb3195a7de48142bde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->