### PR TITLE
make nccl broadcast compatbile with dp

### DIFF
--- a/src/prime_rl/inference/config.py
+++ b/src/prime_rl/inference/config.py
@@ -189,12 +189,6 @@ class InferenceConfig(BaseSettings):
     )
 
     @model_validator(mode="after")
-    def nccl_and_dp(self):
-        if self.weight_broadcast.type == "nccl" and self.parallel.dp != 1:
-            raise ValueError("NCCL broadcast backend requires data parallel size to be 1")
-        return self
-
-    @model_validator(mode="after")
     def auto_setup_dynamic_lora_updating(self):
         if self.enable_lora:
             os.environ["VLLM_ALLOW_RUNTIME_LORA_UPDATING"] = "True"


### PR DESCRIPTION
this pr makes nccl broadcast work with vllm dp

<img width="1177" height="320" alt="image" src="https://github.com/user-attachments/assets/4d6b03ab-1fae-40d6-864c-bbee63108fd8" />

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Enables NCCL weight updates across different process-group topologies; incorrect rank/world-size math could cause hangs or mis-broadcasted weights in multi-GPU/multi-node runs.
> 
> **Overview**
> Updates NCCL-based weight broadcasting to support data-parallel inference workers by incorporating DP group size/rank into the global rank/world-size calculations used to initialize the NCCL communicator.
> 
> Removes the `InferenceConfig` validator that previously blocked using the `nccl` broadcast backend when `parallel.dp != 1`, allowing NCCL broadcast to be configured with DP enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72e31717465050f8127f386f07eeaef57ad6fb0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->