### PR TITLE
fix: compute capability check in grouped_mm to match comment

### DIFF
--- a/src/prime_rl/trainer/models/layers/lora/multi_linear.py
+++ b/src/prime_rl/trainer/models/layers/lora/multi_linear.py
@@ -56,7 +56,7 @@ class MultiLoRALinear(MultiLoRAModule):
         # Set use_grouped_mm to False if CUDA compute capability < 9.0
         if torch.cuda.is_available():
             cc_major, _ = torch.cuda.get_device_capability()
-            if cc_major != 9:
+            if cc_major < 9:
                 use_grouped_mm = False
         else:
             use_grouped_mm = False


### PR DESCRIPTION
## Summary
Aligns code with comment for grouped_mm compute capability check

## Change
- **Before:** `if cc_major != 9:` (only enables for cc=9.0)
- **After:** `if cc_major < 9:` (enables for cc>=9.0)

## Reason
Comment says "< 9.0" but code was using "!= 9"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized conditional change that only affects whether a performance path (`grouped_mm`) is used on newer GPUs; no API or data handling changes.
> 
> **Overview**
> Aligns the `MultiLoRALinear` `use_grouped_mm` CUDA capability gate with the inline comment by switching from `cc_major != 9` to `cc_major < 9`, so `grouped_mm` remains enabled on newer architectures (cc>=9.0) rather than only exactly 9.0.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e701ec6ff8eeca114449bee4d69114b8b705e1fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->