### PR TITLE
fix: duplicate imports in server.py

### DIFF
--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -9,11 +9,7 @@ from vllm.entrypoints.openai.utils import validate_json_request
 from vllm.entrypoints.openai.protocol import ChatCompletionResponse, ErrorResponse
 from vllm.entrypoints.utils import load_aware_call, with_cancellation
 
-from fastapi.responses import JSONResponse, StreamingResponse
-from vllm.entrypoints.chat_utils import load_chat_template
-from vllm.entrypoints.logger import RequestLogger
 from vllm.entrypoints.openai.protocol import ChatCompletionRequest, ChatCompletionResponse, ErrorResponse
-from vllm.entrypoints.utils import load_aware_call, with_cancellation
 
 from prime_rl.inference.patches import (
     monkey_patch_prometheus_stat_logger_for_lora_in_dp_mode,


### PR DESCRIPTION
## Summary
Removes duplicate imports

## Changes
Removed 4 duplicate import lines:
- `JSONResponse, StreamingResponse`
- `load_chat_template`
- `RequestLogger`
- `load_aware_call, with_cancellation`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only cleanup with no behavioral changes beyond avoiding potential lint/merge issues from duplicated imports.
> 
> **Overview**
> Cleans up `src/prime_rl/inference/vllm/server.py` by removing redundant import statements (e.g., FastAPI responses, vLLM chat/template/logging utilities) to avoid duplicate declarations and keep the module header consistent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f871177b95a94cd95ee22af4a004c50356c6bf83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->