### PR TITLE
[fix] dont create config dir on trainer during config validation

### DIFF
--- a/src/prime_rl/trainer/runs.py
+++ b/src/prime_rl/trainer/runs.py
@@ -216,10 +216,6 @@ class MultiRunManager:
         error_path = config_dir / "config_validation_error.txt"
 
         if not config_path.exists():
-            if not error_path.exists():
-                config_dir.mkdir(parents=True, exist_ok=True)
-                with open(error_path, "w") as f:
-                    f.write(f"No orchestrator config found at {config_path}\n")
             self.logger.error(f"Run {run_id}: No orchestrator config found at {config_path}")
             return None
 
@@ -231,9 +227,6 @@ class MultiRunManager:
 
             config = OrchestratorConfig(**config_dict)
         except Exception as e:
-            config_dir.mkdir(parents=True, exist_ok=True)
-            with open(error_path, "w") as f:
-                f.write(f"Error parsing orchestrator config:\n{str(e)}\n")
             self.logger.error(f"Run {run_id}: Error parsing orchestrator config: {e}")
             return None
 
@@ -242,9 +235,9 @@ class MultiRunManager:
             is_valid, error_message = hook(config)
             if not is_valid:
                 self.logger.error(f"Run {run_id}: {error_message}")
-                config_dir.mkdir(parents=True, exist_ok=True)
-                with open(error_path, "w") as f:
-                    f.write(f"{error_message}\n")
+                if error_path.parent.exists():
+                    with open(error_path, "w") as f:
+                        f.write(f"{error_message}\n")
                 return None
 
         # Config is valid, remove any stale error file

--- a/src/prime_rl/trainer/runs.py
+++ b/src/prime_rl/trainer/runs.py
@@ -227,6 +227,9 @@ class MultiRunManager:
 
             config = OrchestratorConfig(**config_dict)
         except Exception as e:
+            if error_path.parent.exists():
+                with open(error_path, "w") as f:
+                    f.write(f"Error parsing orchestrator config:\n{str(e)}\n")
             self.logger.error(f"Run {run_id}: Error parsing orchestrator config: {e}")
             return None
 

--- a/tests/unit/train/test_runs.py
+++ b/tests/unit/train/test_runs.py
@@ -234,12 +234,6 @@ def test_config_missing(tmp_path: Path) -> None:
     assert len(multi_run_manager.config) == 0
     assert "run_noconfig" not in multi_run_manager.id_2_idx
 
-    # Verify config_validation_error.txt was created
-    error_path = run_dir / "control" / "config_validation_error.txt"
-    assert error_path.exists()
-    error_content = error_path.read_text()
-    assert "No orchestrator config found" in error_content
-
 
 def test_config_cleanup_on_deletion(tmp_path: Path) -> None:
     """Test that configs are cleaned up when runs are deleted."""


### PR DESCRIPTION
this creates a race between the orchestrator and trainer to create the control directory. this if fine if trainer and orchestrator are the same user but we might want trainer using root and orchs using appuser. if trainer wins, it gets created by root, if orchestrator wins it gets created by appuser. the orchestrator will then fail on permission errors because it cant write to the directory.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Small but behavior-changing update to run discovery/validation that can affect how/when `config_validation_error.txt` is produced, which may alter orchestrator/troubleshooting flows in edge cases.
> 
> **Overview**
> Prevents `MultiRunManager.get_orchestrator_config()` from creating the run `control/` directory during config validation, avoiding a race/ownership issue where the trainer could create directories with different permissions than the orchestrator.
> 
> Behavior changes: missing `orch.toml` no longer triggers creation of `config_validation_error.txt`, and parse/validation errors only write `config_validation_error.txt` if the `control/` directory already exists. Unit tests are updated to stop asserting error-file creation for the missing-config case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa3f1f501cd842a4c1f431a91f57e2deb5893c04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->