### PR TITLE
[fix] remove cc check for grouped mm

### DIFF
--- a/src/prime_rl/trainer/models/layers/lora/multi_linear.py
+++ b/src/prime_rl/trainer/models/layers/lora/multi_linear.py
@@ -53,13 +53,6 @@ class MultiLoRALinear(MultiLoRAModule):
         if rank <= 0 or n_adapters <= 0:
             raise ValueError("rank and n_adapters must be > 0")
 
-        # Set use_grouped_mm to False if CUDA compute capability < 9.0
-        if torch.cuda.is_available():
-            cc_major, _ = torch.cuda.get_device_capability()
-            if cc_major != 9:
-                use_grouped_mm = False
-        else:
-            use_grouped_mm = False
         if rank % 8 != 0 or base_layer.in_features % 8 != 0 or base_layer.out_features % 8 != 0:
             use_grouped_mm = False
 

--- a/src/prime_rl/trainer/models/layers/lora/multi_moe.py
+++ b/src/prime_rl/trainer/models/layers/lora/multi_moe.py
@@ -80,6 +80,7 @@ class MultiLoRAGroupedExperts(MultiLoRAModule):
         n_adapters: int,
         alpha: float = 32.0,
         dropout: float = 0.0,
+        use_grouped_mm: bool = True,
     ):
         super().__init__(base_layer)
         if rank <= 0 or n_adapters <= 0:
@@ -88,12 +89,6 @@ class MultiLoRAGroupedExperts(MultiLoRAModule):
         self.num_experts = base_layer.num_experts
         self.dim = base_layer.w1.shape[2]
         self.hidden_dim = base_layer.w1.shape[1]
-
-        use_grouped_mm = False
-        if torch.cuda.is_available():
-            cc_major, _ = torch.cuda.get_device_capability()
-            if cc_major == 9:  # Hopper GPUs (H100, H200)
-                use_grouped_mm = True
 
         # grouped_mm requires 8-byte alignment
         if rank % 8 != 0 or self.dim % 8 != 0 or self.hidden_dim % 8 != 0:

--- a/src/prime_rl/trainer/models/layers/moe.py
+++ b/src/prime_rl/trainer/models/layers/moe.py
@@ -322,11 +322,6 @@ class MoE(nn.Module):
         super().__init__()
 
         num_experts = moe_args.num_experts
-        if torch.cuda.is_available():
-            cc_major, _ = torch.cuda.get_device_capability()
-            # As of PyTorch 2.9, grouped_mm is supported on Hopper and Blackwell.
-            if cc_major < 9:
-                moe_args.use_grouped_mm = False
         self.experts = GroupedExperts(
             dim=dim,
             hidden_dim=hidden_dim,


### PR DESCRIPTION
grouped mm support CC >= 8 which is basically all the cards we care about. ppl who are still running v100 probably have a lot more troubles than just this grouped mm being unhappy with them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the runtime selection of the grouped GEMM code path in core MoE/LoRA compute; on unsupported GPU/PyTorch combinations this could surface as performance regressions or runtime errors rather than falling back to the for-loop.
> 
> **Overview**
> Removes CUDA compute capability checks that previously disabled `use_grouped_mm` on non-Hopper GPUs for MoE and multi-LoRA layers, relying instead on the existing 8-byte alignment constraints to decide whether to use grouped GEMM.
> 
> `MultiLoRAGroupedExperts` now accepts a `use_grouped_mm` constructor flag (defaulting to `True`) rather than hard-forcing a per-GPU override, and `MoE` no longer mutates `moe_args.use_grouped_mm` based on detected device capability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e980ff323e3d56666256a0b7197253ca610b8b08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->