### PR TITLE
fix nccl update

### DIFF
--- a/src/prime_rl/inference/vllm/worker/nccl.py
+++ b/src/prime_rl/inference/vllm/worker/nccl.py
@@ -89,9 +89,9 @@ class NCCLWeightUpdateWorker(Worker):
     def init_broadcaster(self, host: str, port: int, server_rank: int, num_inference_server: int, timeout: int) -> None:
         """Initialize the NCCL broadcast receiver."""
         tp_size = get_tp_group().world_size
-        tp_rank = get_tp_group().rank
+        tp_rank = get_tp_group().rank_in_group
         dp_size = get_dp_group().world_size
-        dp_rank = get_dp_group().rank
+        dp_rank = get_dp_group().rank_in_group
         global_rank_inference = (server_rank * tp_size * dp_size) + (dp_rank * tp_size) + tp_rank
         global_inference_world_size = num_inference_server * tp_size * dp_size
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change to rank computation for NCCL weight updates; risk is limited to distributed inference setups if group semantics differ from expectations.
> 
> **Overview**
> Fixes NCCL in-place weight update rank calculation by switching TP/DP rank derivation from `.rank` to `.rank_in_group` when computing `global_rank_inference` in `NCCLWeightUpdateWorker.init_broadcaster`.
> 
> This aligns the worker’s NCCL broadcaster rank/world-size mapping with vLLM’s process-group semantics, preventing misaddressed broadcasts in multi-TP/DP setups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bbd5c1006b4a69b188ac6e63067579f6896ea7d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->