### PR TITLE
Add optimizer state CPU offload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,3 +44,4 @@ Documenting changes which affect configuration usage patterns (added/moved/remov
 - **`orchestrator.sampling.temp_scheduler`**: Added optional temperature schedule configuration with linear and cosine schedules. Set either `sampling.temperature` (constant) or `sampling.temp_scheduler` (schedule), not both. Default remains 1.0 if neither is set. (2026-01-27)
 - **`model.impl`**: Removed `liger_kernel` model implementation from supported options. The Liger kernel dependency remains for SFT loss. (2026-01-30)
 - **`log.json_logging`**: Added JSON structured logging option for log aggregation systems (Loki, Grafana, etc.). Outputs flat newline-delimited JSON with `timestamp`, `level`, `message`, `module`, `function`, `line` fields. Available on root `log`, `trainer.log`, and `orchestrator.log` (default: False) (2026-01-28)
+- **`model.optim_cpu_offload`**: Added flag to offload optimizer states to CPU without moving parameters (default: False) (2026-01-31)

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -20,6 +20,7 @@ from transformers.tokenization_utils import PreTrainedTokenizer
 from prime_rl.trainer.config import CheckpointConfig, LoRAConfig, WeightCheckpointConfig
 from prime_rl.trainer.lora import has_lora_layers, save_lora_config
 from prime_rl.trainer.models import PreTrainedModelPrimeRL
+from prime_rl.trainer.optim import CPUOffloadOptimizer
 from prime_rl.trainer.runs import Progress
 from prime_rl.trainer.weights import (
     gather_weights_on_master,
@@ -53,9 +54,20 @@ class AppState(Stateful):
         self.scheduler = scheduler
         self.progress = progress
 
+    def _get_base_optimizers(self) -> list[Optimizer]:
+        """Extract base optimizers from wrappers like CPUOffloadOptimizer."""
+        return [opt.base_optimizer if isinstance(opt, CPUOffloadOptimizer) else opt for opt in self.optimizers]
+
     def state_dict(self) -> dict[str, Any]:
+        # Move CPU-offloaded states to GPU before checkpointing
+        for opt in self.optimizers:
+            if isinstance(opt, CPUOffloadOptimizer) and opt._initialized:
+                opt._move_states("cuda")
+                torch.cuda.synchronize()
+
         # Automatically manages FSDP FQN's, as well as sets the default state dict type to FSDP.SHARDED_STATE_DICT
-        model_state_dict, optimizer_state_dict = get_state_dict(self.model, self.optimizers)
+        base_optimizers = self._get_base_optimizers()
+        model_state_dict, optimizer_state_dict = get_state_dict(self.model, base_optimizers)
         state_dict = {
             "model": model_state_dict,
             "optimizers": optimizer_state_dict,
@@ -66,12 +78,26 @@ class AppState(Stateful):
         if self.progress is not None:
             progress_state_dict = asdict(self.progress)
             state_dict["progress"] = progress_state_dict
+
+        # Move states back to CPU
+        for opt in self.optimizers:
+            if isinstance(opt, CPUOffloadOptimizer) and opt._initialized:
+                opt._move_states("cpu")
+
         return state_dict
 
     def load_state_dict(self, state_dict: dict[str, Any]):
+        base_optimizers = self._get_base_optimizers()
         set_state_dict(
-            self.model, self.optimizers, model_state_dict=state_dict["model"], optim_state_dict=state_dict["optimizers"]
+            self.model, base_optimizers, model_state_dict=state_dict["model"], optim_state_dict=state_dict["optimizers"]
         )
+
+        # Re-initialize CPU offload wrappers after loading
+        for opt in self.optimizers:
+            if isinstance(opt, CPUOffloadOptimizer):
+                opt._move_states("cpu")
+                opt._initialized = True
+
         if self.scheduler is not None:
             self.scheduler.load_state_dict(state_dict["scheduler"])
         if self.progress is not None:

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -167,6 +167,13 @@ class ModelConfig(BaseConfig):
         ),
     ] = False
 
+    optim_cpu_offload: Annotated[
+        bool,
+        Field(
+            description="Whether to enable optimizer state CPU offloading. Unlike fsdp_cpu_offload, this only moves optimizer states (momentum, variance) to CPU, keeping weights on GPU. This avoids the H2D all-gather overhead while still saving GPU memory.",
+        ),
+    ] = False
+
     reshard_after_forward: Annotated[
         bool, Field(description="Whether to reshard the model after each forward pass.")
     ] = True

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -301,6 +301,12 @@ class ModelConfig(BaseConfig):
         return self
 
     @model_validator(mode="after")
+    def cpu_offload_mutual_exclusion(self):
+        if self.fsdp_cpu_offload and self.optim_cpu_offload:
+            raise ValueError("Cannot enable both fsdp_cpu_offload and optim_cpu_offload. Use one or the other.")
+        return self
+
+    @model_validator(mode="after")
     def fused_lm_head_chunk_size_is_valid(self):
         if isinstance(self.fused_lm_head_chunk_size, int):
             low = 512

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -4,6 +4,7 @@ from typing import Callable
 import torch
 from dion import Muon
 from torch import nn
+from torch.distributed.tensor import DTensor
 from torch.optim import SGD, AdamW, Optimizer
 
 from prime_rl.trainer.config import OptimizerConfigType
@@ -27,8 +28,6 @@ class CPUOffloadOptimizer:
         self._initialized = False
 
     def _move_states(self, device: str):
-        from torch.distributed.tensor import DTensor
-
         for p in self.optimizer.state:
             state = self.optimizer.state[p]
             for k, v in state.items():

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -29,6 +29,7 @@ class CPUOffloadOptimizer:
         self._initialized = False
 
     def _move_states(self, device: str):
+        """Move optimizer states to CPU or back to GPU (matching each parameter's device)."""
         for p in self.optimizer.state:
             state = self.optimizer.state[p]
             for k, v in state.items():

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -41,10 +41,7 @@ class CPUOffloadOptimizer:
                         if self.pin_memory and not new_local.is_pinned():
                             new_local = new_local.pin_memory()
                     else:
-                        target_device = torch.device("cuda")
-                        if isinstance(p, DTensor):
-                            target_device = p._local_tensor.device
-                        new_local = local_tensor.to(target_device, non_blocking=True)
+                        new_local = local_tensor.to(device, non_blocking=True)
                     new_dtensor = copy.copy(v)
                     new_dtensor._local_tensor = new_local
                     state[k] = new_dtensor
@@ -56,8 +53,7 @@ class CPUOffloadOptimizer:
                             cpu_tensor = cpu_tensor.pin_memory()
                         state[k] = cpu_tensor
                     else:
-                        target_device = p.device if hasattr(p, "device") else "cuda"
-                        state[k] = v.to(target_device, non_blocking=True)
+                        state[k] = v.to(device, non_blocking=True)
 
     def step(self, closure=None):
         # First step initializes states on GPU - offload after

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -34,7 +34,8 @@ class CPUOffloadOptimizer:
                 if isinstance(v, DTensor):
                     local_tensor = v._local_tensor
                     if device == "cpu":
-                        new_local = local_tensor.to("cpu", non_blocking=True)
+                        non_blocking = not self.pin_memory
+                        new_local = local_tensor.to("cpu", non_blocking=non_blocking)
                         if self.pin_memory and not new_local.is_pinned():
                             new_local = new_local.pin_memory()
                         v._local_tensor = new_local
@@ -45,7 +46,8 @@ class CPUOffloadOptimizer:
                         v._local_tensor = local_tensor.to(target_device, non_blocking=True)
                 elif isinstance(v, torch.Tensor):
                     if device == "cpu":
-                        cpu_tensor = v.to("cpu", non_blocking=True)
+                        non_blocking = not self.pin_memory
+                        cpu_tensor = v.to("cpu", non_blocking=non_blocking)
                         if self.pin_memory and not cpu_tensor.is_pinned():
                             cpu_tensor = cpu_tensor.pin_memory()
                         state[k] = cpu_tensor

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -107,6 +107,10 @@ class CPUOffloadOptimizer:
     def state(self):
         return self.optimizer.state
 
+    @property
+    def base_optimizer(self) -> Optimizer:
+        return self.optimizer
+
 
 def setup_optimizer(
     config: OptimizerConfigType,

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -16,16 +16,9 @@ from prime_rl.utils.logger import get_logger
 class CPUOffloadOptimizer:
     """Wraps an optimizer to keep states on CPU, moving to GPU only for step().
 
-    This allows saving GPU memory by storing optimizer states (momentum, variance, etc.)
-    on CPU, while keeping model parameters on GPU. States are moved to GPU before
-    the optimizer step and back to CPU after.
-
-    Unlike FSDP's CPUOffload which also offloads weights (requiring H2D all-gather),
-    this only offloads optimizer states, avoiding the weight transfer overhead.
-
-    Note: There is significant overhead from transferring many small state tensors.
-    This is best suited for memory-constrained scenarios where the memory savings
-    outweigh the throughput cost.
+    Unlike FSDP's CPUOffload which offloads weights too, this keeps weights on GPU.
+    With activation checkpointing, activations and optimizer states are never on GPU
+    at the same time: peak memory becomes max(activations, opt_states) instead of sum.
     """
 
     def __init__(self, optimizer: Optimizer, pin_memory: bool = True):

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -255,6 +255,12 @@ class RLTrainerConfig(BaseSettings):
         return self
 
     @model_validator(mode="after")
+    def validate_optim_cpu_offload_single_run(self):
+        if self.model.optim_cpu_offload and self.max_concurrent_runs > 1:
+            raise ValueError("Optimizer CPU offload is not supported with max_concurrent_runs > 1")
+        return self
+
+    @model_validator(mode="after")
     def validate_lora_broadcast(self):
         if self.model.lora is not None and self.weight_broadcast.type == "nccl":
             # TODO: Support this

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -149,6 +149,7 @@ def train(config: RLTrainerConfig):
             list(model.named_parameters()),
             parallel_dims,
             lora=config.model.lora is not None,
+            cpu_offload=config.model.optim_cpu_offload,
         )
         scheduler = setup_scheduler(optimizer, config.scheduler, config.max_steps, config.optim.lr)
     else:

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -19,7 +19,7 @@ from prime_rl.trainer.sft.config import SFTTrainerConfig
 from prime_rl.utils.cp import setup_cp_params, shard_for_cp
 from prime_rl.trainer.runs import Progress
 from prime_rl.utils.logger import setup_logger
-from prime_rl.trainer.optim import CPUOffloadOptimizer, setup_optimizer
+from prime_rl.trainer.optim import setup_optimizer
 from prime_rl.trainer.scheduler import setup_scheduler
 from prime_rl.trainer.model import (
     forward,
@@ -119,15 +119,11 @@ def train(config: SFTTrainerConfig):
 
     # Set up the optimizer
     logger.info(f"Initializing optimizer ({config.optim})")
-    base_optimizer = setup_optimizer(config.optim, list(model.named_parameters()), parallel_dims)
+    optimizer = setup_optimizer(
+        config.optim, list(model.named_parameters()), parallel_dims, cpu_offload=config.model.optim_cpu_offload
+    )
 
-    if config.model.optim_cpu_offload:
-        logger.info("Wrapping optimizer with CPUOffloadOptimizer for optimizer state CPU offloading")
-        optimizer = CPUOffloadOptimizer(base_optimizer)
-    else:
-        optimizer = base_optimizer
-
-    # Set up the learning rate scheduler (uses base_optimizer for scheduler compatibility)
+    # Set up the learning rate scheduler
     scheduler_steps = (
         config.max_steps - config.ckpt.resume_step
         if config.max_steps is not None
@@ -135,7 +131,7 @@ def train(config: SFTTrainerConfig):
         else config.max_steps
     )
     logger.info(f"Setting up {config.scheduler.type} scheduler with {scheduler_steps} steps ({config.scheduler})")
-    scheduler = setup_scheduler(base_optimizer, config.scheduler, scheduler_steps, config.optim.lr)
+    scheduler = setup_scheduler(optimizer, config.scheduler, scheduler_steps, config.optim.lr)
 
     # Set up the dataset and dataloader
     logger.info(f"Initializing data ({config.data})")


### PR DESCRIPTION
## Summary

Adds `CPUOffloadOptimizer` - keeps optimizer states on CPU, moves to GPU only during `optimizer.step()`.

Unlike FSDP's `CPUOffload`, this keeps weights on GPU (no H2D all-gather on forward pass).

## Key insight

With activation checkpointing, activations and optimizer states are never on GPU simultaneously:
- Forward/backward: activations on GPU, optimizer states on CPU
- Optimizer step: optimizer states on GPU, activations freed

Peak memory becomes `max(activations, optimizer_states)` instead of `activations + optimizer_states`.

## Results

**4B model, 4 GPUs, AC enabled:**
- 2 GB saved per GPU (~8% reduction)
- ~2% slower

Best for memory-constrained scenarios where fitting larger model/batch matters more than throughput.

## Usage

```toml
[model]
optim_cpu_offload = true
```


ckpt  resume tests
<img width="1156" height="325" alt="image" src="https://github.com/user-attachments/assets/3deace63-c7a6-469c-a6da-3031cbcf77fc" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches optimizer stepping, scheduler binding, and checkpoint save/load paths; mistakes could break resume correctness or cause device-transfer/perf issues during training.
> 
> **Overview**
> Adds **optimizer-state CPU offloading** via a new `CPUOffloadOptimizer` wrapper that keeps optimizer states on CPU and transfers them to CUDA only during `step()`.
> 
> Introduces `model.optim_cpu_offload` config (mutually exclusive with `fsdp_cpu_offload`) and wires it into both RL and SFT trainers, with RL additionally disallowing use when `max_concurrent_runs > 1`. Checkpointing and scheduler setup are updated to unwrap/wrap base optimizers so optimizer state save/load works correctly when offloading is enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6a64f1c47f7c0c6c66f3e19775cfb70126b7783. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->