### PR TITLE
use kimi-k2.5 style loss

### DIFF
--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -149,8 +149,11 @@ def compute_loss(
         advantages = loss_config.adv_tau * advantages
         if teacher_logprobs is not None:
             advantages = advantages + loss_config.teacher_tau * teacher_kl.detach()
-        coeff = importance_ratio * (advantages - loss_config.kl_tau * log_importance_ratio)
+
+        kl = loss_config.kl_tau * (log_importance_ratio) ** 2
+        coeff = importance_ratio * advantages
         loss = -(coeff.detach() * trainer_logprobs)[keep_mask].sum()
+        loss = loss + kl[loss_mask].sum()
 
         if loss_config.ratio_type == "sequence":
             loss = loss / torch.clamp_min(loss_mask.sum(), 1)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core RL loss math, which can materially impact training stability and policy updates even though the code change is small and localized.
> 
> **Overview**
> Updates `compute_loss` in `loss.py` to use a Kimi-style KL regularizer: the policy-gradient term now uses `importance_ratio * advantages` only, and KL is applied separately as `kl_tau * (log_importance_ratio ** 2)` summed over `loss_mask`.
> 
> This changes the optimization behavior by decoupling KL control from the advantage shaping and by penalizing large importance-ratio deviations quadratically rather than linearly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c465bb82049079abf2f462bbf1187e40ac8e03ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->