### PR TITLE
Add HF Hub timeout defaults for resilience

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -97,6 +97,10 @@ RUN rm /app/.venv/bin/python3.12 && ln -s /usr/local/bin/python /app/.venv/bin/p
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"
 
+# HuggingFace Hub timeouts (defaults are 10s which causes issues on slow networks)
+ENV HF_HUB_ETAG_TIMEOUT=500
+ENV HF_HUB_DOWNLOAD_TIMEOUT=300
+
 # Use entrypoint for setup (ulimit, etc) but default to sleep infinity for K8s
 ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["sleep", "infinity"]


### PR DESCRIPTION
## Summary
- Move `HF_HUB_ETAG_TIMEOUT=500` from eval-only to base envs so all entrypoints get it
- Add `HF_HUB_DOWNLOAD_TIMEOUT=300` for large model downloads

Both have 10s defaults in huggingface_hub which causes timeout issues on slow networks or when downloading large models.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: Docker-only environment variable changes that affect download behavior but do not modify application logic or security.
> 
> **Overview**
> Updates `Dockerfile.cuda` to bake in HuggingFace Hub timeout environment variables for all container entrypoints, increasing `HF_HUB_ETAG_TIMEOUT` to `500` and adding `HF_HUB_DOWNLOAD_TIMEOUT=300` to better support slow networks and large model downloads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f2d83ad370c8136b834df547f0d5226eec1385e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->