### PR TITLE
square kl term and apply on all tokens

### DIFF
--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -190,7 +190,7 @@ def compute_loss(
         "geo_masked_low": torch.stack(total_geo_masked_low),
         "geo_masked_high": torch.stack(total_geo_masked_high),
         "geo_seq_ratio": torch.stack(total_geo_seq_ratio),
-        "kl_loss": torch.stack(total_kl_loss),
+        "kl_loss": torch.cat(total_kl_loss),
     }
     if total_teacher_kl:
         result["teacher_kl"] = torch.stack(total_teacher_kl)

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -151,7 +151,7 @@ def compute_loss(
             advantages = advantages + loss_config.teacher_tau * teacher_kl.detach()
         coeff = importance_ratio * advantages * keep_mask
         pg_loss = coeff.detach() * trainer_logprobs
-        kl_loss = log_importance_ratio ** 2
+        kl_loss = log_importance_ratio**2
         loss = (loss_config.kl_tau * kl_loss * loss_mask - pg_loss).sum()
 
         if loss_config.ratio_type == "sequence":

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -112,7 +112,7 @@ def compute_loss(
     total_geo_masked_high = []
     total_geo_seq_ratio = []
     total_teacher_kl = []
-
+    total_kl_loss = []
     if teacher_logprobs is None:
         teacher_logprobs = [None] * len(trainer_logprobs)
 
@@ -149,8 +149,10 @@ def compute_loss(
         advantages = loss_config.adv_tau * advantages
         if teacher_logprobs is not None:
             advantages = advantages + loss_config.teacher_tau * teacher_kl.detach()
-        coeff = importance_ratio * (advantages - loss_config.kl_tau * log_importance_ratio)
-        loss = -(coeff.detach() * trainer_logprobs)[keep_mask].sum()
+        coeff = importance_ratio * advantages
+        pg_loss = coeff.detach() * trainer_logprobs[keep_mask]
+        kl_loss = log_importance_ratio[loss_mask] ** 2
+        loss = (loss_config.kl_tau * kl_loss - pg_loss).sum()
 
         if loss_config.ratio_type == "sequence":
             loss = loss / torch.clamp_min(loss_mask.sum(), 1)
@@ -169,6 +171,7 @@ def compute_loss(
         total_geo_masked_low.append(geo_mask_low.float())
         total_geo_masked_high.append(geo_mask_high.float())
         total_geo_seq_ratio.append(geo_seq_ratio)
+        total_kl_loss.append(kl_loss)
         if teacher_logprobs is not None:
             total_teacher_kl.append(_safe_mean(teacher_kl, loss_mask))
 
@@ -187,6 +190,7 @@ def compute_loss(
         "geo_masked_low": torch.stack(total_geo_masked_low),
         "geo_masked_high": torch.stack(total_geo_masked_high),
         "geo_seq_ratio": torch.stack(total_geo_seq_ratio),
+        "kl_loss": torch.stack(total_kl_loss),
     }
     if total_teacher_kl:
         result["teacher_kl"] = torch.stack(total_teacher_kl)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core RL training loss math and masking behavior, which can materially affect optimization stability and model performance even though the change is localized.
> 
> **Overview**
> **Updates RL loss to use a squared KL penalty and apply it across all unmasked tokens.** The policy-gradient term is now computed only on `keep_mask` tokens, while the KL regularizer is computed as `log_importance_ratio**2` and applied over `loss_mask`.
> 
> Adds `kl_loss` to returned metrics (concatenated per-token values) to make the new KL term observable during training.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30a7e256b8460147dc76964afd8d5ddb4847f2cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->