### PR TITLE
[fix] use inference pool client instead of starting one for validation

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -97,7 +97,6 @@ async def orchestrate(config: OrchestratorConfig):
     # Setup inference pool (handles both static and elastic modes)
     inference_pool = await setup_inference_pool(config.client, base_model=config.model.name)
 
-    clients = inference_pool.clients
     admin_clients = inference_pool.admin_clients
 
     # Setup teacher model client if configured
@@ -208,7 +207,6 @@ async def orchestrate(config: OrchestratorConfig):
     logger.info("Waiting for inference pool to be ready")
     await inference_pool.wait_for_ready(config.model.name)
     # Refresh clients after waiting (elastic mode may have discovered new servers)
-    clients = inference_pool.clients
     admin_clients = inference_pool.admin_clients
     logger.success("Inference pool ready")
 
@@ -356,7 +354,7 @@ async def orchestrate(config: OrchestratorConfig):
             val_examples = val_buffer.sample_examples(config.val.num_examples)
             val_task = asyncio.create_task(
                 generate_batch(
-                    clients=clients,
+                    clients=inference_pool.clients,
                     env=env,
                     model_name=config.model.name,
                     examples=val_examples,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small wiring change limited to validation client selection; primary risk is validation hitting a different/updated backend than before, but no auth/data-path logic changes.
> 
> **Overview**
> Validation rollouts now use `inference_pool.clients` directly instead of a cached `clients` variable, ensuring validation always targets the current inference pool (including newly discovered servers in elastic mode).
> 
> This also removes redundant local reassignments of `clients` after inference pool setup/ready checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6a7b28edb74aa03ff940fd23adff0b78fa87809. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->