### PR TITLE
[DO NOT MERGE] make ready for verifiers main

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ override-dependencies = ["nvidia-cudnn-cu12>=9.15"]
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 reverse-text = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "209774a" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "cedfe600734f91d357b54bdb2ceca8051e35821a" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eebbd950a6ff11d9b5f806282e33df83df9d" }
 

--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -17,8 +17,8 @@ from prime_evals import AsyncEvalsClient
 from tenacity import RetryCallState, RetryError, retry, stop_after_attempt, wait_exponential
 from tqdm.asyncio import tqdm
 from verifiers import load_environment
-from verifiers.envs.environment import get_results_path
-from verifiers.utils.eval_utils import get_hf_hub_dataset_name, make_dataset, sanitize_metadata, save_to_disk
+from verifiers.utils.path_utils import get_results_path
+from verifiers.utils.save_utils import get_hf_hub_dataset_name, make_dataset, sanitize_metadata, save_to_disk
 
 from prime_rl.eval.config import OfflineEvalConfig
 from prime_rl.orchestrator.config import EvalConfig, EvalSamplingConfig, EvalSaveConfig, ModelConfig, RetryConfig

--- a/src/prime_rl/synthesize/utils.py
+++ b/src/prime_rl/synthesize/utils.py
@@ -9,7 +9,7 @@ import verifiers as vf
 from openai import AsyncOpenAI
 from tqdm.asyncio import tqdm
 from verifiers import load_environment
-from verifiers.envs.environment import get_results_path
+from verifiers.utils.path_utils import get_results_path
 
 from prime_rl.orchestrator.config import ClientConfig, EvalSamplingConfig, ModelConfig
 from prime_rl.utils.logger import get_logger

--- a/src/prime_rl/utils/vf.py
+++ b/src/prime_rl/utils/vf.py
@@ -7,8 +7,6 @@ from openai import AsyncOpenAI
 from openai.types.chat.chat_completion import ChatCompletion
 from tqdm import tqdm
 
-from prime_rl.orchestrator.utils import get_semaphore
-
 
 async def generate_group(
     client: AsyncOpenAI,
@@ -17,17 +15,14 @@ async def generate_group(
     example: dict,
     rollouts_per_example: int,
     sampling_args: dict,
-) -> list[vf.State]:
+) -> list[vf.RolloutOutput]:
     """Asynchronously generate and score rollouts for a single group."""
-    semaphore = await get_semaphore()
     group_inputs = [vf.RolloutInput(**example) for _ in range(rollouts_per_example)]
     return await env.run_group(
         group_inputs=group_inputs,
         client=client,
         model=model_name,
-        gen_sampling_args=sampling_args,
-        gen_sem=semaphore,
-        score_sem=semaphore,
+        sampling_args=sampling_args,
     )
 
 
@@ -37,14 +32,15 @@ async def generate_rollout(
     model_name: str,
     example: dict,
     sampling_args: dict,
-) -> vf.State:
+) -> vf.RolloutOutput:
     """Asynchronously generate and score a single rollout."""
-    semaphore = await get_semaphore()
     rollout_input = vf.RolloutInput(**example)
-
-    state = await env.run_rollout(semaphore, rollout_input, client, model_name, sampling_args)
-    await env.rubric.score_rollout(state, score_sem=semaphore)
-    return state
+    return await env.run_rollout(
+        input=rollout_input,
+        client=client,
+        model=model_name,
+        sampling_args=sampling_args,
+    )
 
 
 async def generate_batch(
@@ -55,7 +51,7 @@ async def generate_batch(
     rollouts_per_example: int,
     sampling_args: dict,
     pbar_description: str = "Generating rollouts",
-) -> list[vf.State]:
+) -> list[vf.RolloutOutput]:
     """Asynchronously generate and score rollouts for a list of groups (batch)."""
 
     total_rollouts = len(examples) * rollouts_per_example
@@ -68,13 +64,13 @@ async def generate_batch(
         return result
 
     try:
-        group_states_list: list[list[vf.State]] = await asyncio.gather(
+        group_outputs_list: list[list[vf.RolloutOutput]] = await asyncio.gather(
             *[generate_group_with_progress(client, example) for client, example in zip(cycle(clients), examples)]
         )
     finally:
         pbar.close()
 
-    return [state for group_states in group_states_list for state in group_states]
+    return [output for group_outputs in group_outputs_list for output in group_outputs]
 
 
 def get_prompt_len(state: vf.State) -> int:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core rollout generation/worker IPC plumbing and error extraction, so API mismatches could break training/eval execution despite the changes being largely mechanical.
> 
> **Overview**
> Preps `prime-rl` for a newer `verifiers` API by updating the pinned `verifiers` git rev and switching imports to the new `verifiers.utils.*` modules.
> 
> Rollout generation is migrated to the new `verifiers` calling conventions and types: `vf.State` is replaced with `vf.RolloutOutput`, `env.run_group` now uses `sampling_args` (dropping `gen_sampling_args` + semaphores), `env.run_rollout` is called directly without manual scoring, and worker result extraction adapts to the new structured error payload.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c774a06672d9631c47a266aafdcce45c9e6fe1bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->