### PR TITLE
bump vf (dfc473c)

### DIFF
--- a/examples/reverse_text/rl/orch.toml
+++ b/examples/reverse_text/rl/orch.toml
@@ -11,3 +11,5 @@ max_tokens = 128
 
 [[env]]
 id = "reverse-text"
+
+[ckpt]

--- a/examples/reverse_text/rl/train.toml
+++ b/examples/reverse_text/rl/train.toml
@@ -6,4 +6,4 @@ name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
 [optim]
 lr = 3e-6
 
-[ckpt] # Checkpoint at the end of training
+[ckpt]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ override-dependencies = ["nvidia-cudnn-cu12>=9.15"]
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 reverse-text = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "209774a" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "dfc473c" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eebbd950a6ff11d9b5f806282e33df83df9d" }
 

--- a/src/prime_rl/eval/eval.py
+++ b/src/prime_rl/eval/eval.py
@@ -2,7 +2,6 @@ import asyncio
 
 from prime_rl.eval.config import OfflineEvalConfig
 from prime_rl.eval.utils import run_evals
-from prime_rl.orchestrator.utils import set_semaphore
 from prime_rl.utils.client import (
     check_health,
     maybe_check_has_model,
@@ -64,7 +63,6 @@ async def eval(config: OfflineEvalConfig):
     await reload_weights(admin_clients)
 
     # Run benchmarks on base model
-    await set_semaphore(config.max_concurrent or -1)
     if config.eval_base:
         logger.info(f"Evaluating model {config.model.name}")
         await run_evals(

--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -16,8 +16,8 @@ from openai import AsyncOpenAI, BadRequestError
 from prime_evals import AsyncEvalsClient
 from tenacity import RetryCallState, RetryError, retry, stop_after_attempt, wait_exponential
 from verifiers import load_environment
-from verifiers.envs.environment import get_results_path
-from verifiers.utils.eval_utils import get_hf_hub_dataset_name, make_dataset, sanitize_metadata, save_to_disk
+from verifiers.utils.path_utils import get_results_path
+from verifiers.utils.save_utils import get_hf_hub_dataset_name, make_dataset, sanitize_metadata, save_to_disk
 
 from prime_rl.eval.config import OfflineEvalConfig
 from prime_rl.orchestrator.config import EvalConfig, EvalSamplingConfig, EvalSaveConfig, ModelConfig, RetryConfig

--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -12,7 +12,6 @@ import verifiers as vf
 from huggingface_hub import whoami
 from openai import AsyncOpenAI
 from prime_evals import AsyncEvalsClient
-from tenacity import RetryError
 from verifiers import load_environment
 from verifiers.utils.path_utils import get_results_path
 from verifiers.utils.save_utils import get_hf_hub_dataset_name, make_dataset, sanitize_metadata, save_to_disk

--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -159,7 +159,7 @@ def make_result(state: vf.State, reasoning_field: str, rollout_idx: int) -> dict
     for metric_name, metric_value in state["metrics"].items():
         result_dict[metric_name] = metric_value
 
-    result_dict["oai_tools"] = json.dumps(state["oai_tools"])
+    result_dict["oai_tools"] = json.dumps(state.get("oai_tools", "[]"))
 
     return result_dict
 

--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -157,7 +157,7 @@ def make_result(output: vf.RolloutOutput, reasoning_field: str, rollout_idx: int
     for metric_name, metric_value in output["metrics"].items():
         result_dict[metric_name] = metric_value
 
-    result_dict["oai_tools"] = output.get("oai_tools", [])
+    result_dict["oai_tools"] = json.dumps(output.get("oai_tools", []))
 
     return result_dict
 

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -824,8 +824,11 @@ class OrchestratorConfig(BaseSettings):
 
     @model_validator(mode="after")
     def validate_max_concurrent(self):
-        if self.max_concurrent is not None and self.max_concurrent < self.rollouts_per_example:
-            raise ValueError("max_concurrent must be at least the number of rollouts per example")
+        min_concurrent = self.rollouts_per_example * (self.workers_per_env or 1)
+        if self.max_concurrent is not None and self.max_concurrent < min_concurrent:
+            raise ValueError(
+                f"max_concurrent must be at least rollouts_per_example * workers_per_env ({min_concurrent})"
+            )
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -721,7 +721,7 @@ class OrchestratorConfig(BaseSettings):
     max_concurrent: Annotated[
         int | None,
         Field(
-            description="Maximum number of concurrent rollouts to generate and score. Will create a global semaphore and pass to verifiers Environment. If None, will not limit concurrency.",
+            description="Maximum number of concurrent rollouts to generate and score. If None, will not limit concurrency.",
         ),
     ] = None
 
@@ -821,6 +821,12 @@ class OrchestratorConfig(BaseSettings):
     heartbeat: Annotated[
         HeartbeatConfig | None, Field(description="The heartbeat config for monitoring training progress.")
     ] = None
+
+    @model_validator(mode="after")
+    def validate_max_concurrent(self):
+        if self.max_concurrent is not None and self.max_concurrent < self.rollouts_per_example:
+            raise ValueError("max_concurrent must be at least the number of rollouts per example")
+        return self
 
     @model_validator(mode="after")
     def nccl_max_async_level(self):

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -721,7 +721,7 @@ class OrchestratorConfig(BaseSettings):
     max_concurrent: Annotated[
         int | None,
         Field(
-            description="Maximum number of concurrent rollouts to generate and score. If None, will not limit concurrency.",
+            description="Maximum number of concurrent rollouts to generate and score per-environment. If None, will not limit concurrency.",
         ),
     ] = None
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -506,8 +506,8 @@ async def orchestrate(config: OrchestratorConfig):
         val_results_df = (
             pd.DataFrame(
                 {
-                    "example_id": [rollout["input"]["example_id"] for rollout in val_outputs],
-                    "task": [rollout["input"]["task"] for rollout in val_outputs],
+                    "example_id": [rollout["example_id"] for rollout in val_outputs],
+                    "task": [rollout["task"] for rollout in val_outputs],
                     "reward": [rollout["reward"] for rollout in val_outputs],
                 }
             )

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -111,7 +111,9 @@ class Scheduler:
                     model_name=self.model_name,
                     seq_len=config.seq_len,
                     interleaved_rollouts=config.trajectory_strategy == "interleaved",
-                    max_concurrent=config.max_concurrent or -1,
+                    max_concurrent_groups=(config.max_concurrent // self.rollouts_per_example)
+                    if config.max_concurrent is not None
+                    else -1,
                     example_lookup=self.example_lookups[env_name],
                     worker_name=f"{env_name}_{worker_idx}",
                     log_level=config.log.level,

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -111,7 +111,7 @@ class Scheduler:
                     model_name=self.model_name,
                     seq_len=config.seq_len,
                     interleaved_rollouts=config.trajectory_strategy == "interleaved",
-                    max_concurrent_groups=(config.max_concurrent // self.rollouts_per_example)
+                    max_concurrent_groups=(config.max_concurrent // (self.rollouts_per_example * self.workers_per_env))
                     if config.max_concurrent is not None
                     else -1,
                     example_lookup=self.example_lookups[env_name],

--- a/src/prime_rl/synthesize/synthesize.py
+++ b/src/prime_rl/synthesize/synthesize.py
@@ -1,8 +1,5 @@
 import asyncio
 
-from prime_rl.orchestrator.utils import (
-    set_semaphore,
-)
 from prime_rl.synthesize.config import SynthesizeConfig
 from prime_rl.synthesize.utils import generate_synthetic_data
 from prime_rl.utils.client import (
@@ -47,9 +44,6 @@ async def synthesize(config: SynthesizeConfig):
     await check_health(admin_clients)
     await maybe_check_has_model(clients, config.model.name, skip_model_check=config.client.skip_model_check)
     logger.success(f"Inference pool is healthy and serves {config.model.name}")
-
-    # Set global semaphore
-    await set_semaphore(config.max_concurrent or -1)
 
     # Generate synthetic data
     logger.info("Starting synthetic data generation")

--- a/src/prime_rl/synthesize/utils.py
+++ b/src/prime_rl/synthesize/utils.py
@@ -8,7 +8,7 @@ import aiofiles
 import verifiers as vf
 from openai import AsyncOpenAI
 from verifiers import load_environment
-from verifiers.envs.environment import get_results_path
+from verifiers.utils.path_utils import get_results_path
 
 from prime_rl.orchestrator.config import ClientConfig, EvalSamplingConfig, ModelConfig
 from prime_rl.utils.logger import ProgressTracker, get_logger

--- a/src/prime_rl/synthesize/utils.py
+++ b/src/prime_rl/synthesize/utils.py
@@ -89,7 +89,7 @@ def make_result(state: vf.State, reasoning_field: str) -> dict:
     for metric_name, metric_value in state["metrics"].items():
         result_dict[metric_name] = metric_value
 
-    result_dict["oai_tools"] = json.dumps(state["oai_tools"])
+    result_dict["oai_tools"] = json.dumps(state.get("oai_tools", []))
 
     return result_dict
 

--- a/src/prime_rl/utils/vf.py
+++ b/src/prime_rl/utils/vf.py
@@ -6,7 +6,6 @@ import verifiers as vf
 from openai import AsyncOpenAI
 from openai.types.chat.chat_completion import ChatCompletion
 
-from prime_rl.orchestrator.utils import get_semaphore
 from prime_rl.utils.logger import ProgressTracker
 
 
@@ -17,17 +16,16 @@ async def generate_group(
     example: dict,
     rollouts_per_example: int,
     sampling_args: dict,
-) -> list[vf.State]:
+    state_columns: list[str] = ["trajectory"],
+) -> list[vf.RolloutOutput]:
     """Asynchronously generate and score rollouts for a single group."""
-    semaphore = await get_semaphore()
     group_inputs = [vf.RolloutInput(**example) for _ in range(rollouts_per_example)]
     return await env.run_group(
         group_inputs=group_inputs,
         client=client,
         model=model_name,
-        gen_sampling_args=sampling_args,
-        gen_sem=semaphore,
-        score_sem=semaphore,
+        sampling_args=sampling_args,
+        state_columns=state_columns,
     )
 
 
@@ -37,14 +35,11 @@ async def generate_rollout(
     model_name: str,
     example: dict,
     sampling_args: dict,
-) -> vf.State:
+    state_columns: list[str] = ["trajectory"],
+) -> vf.RolloutOutput:
     """Asynchronously generate and score a single rollout."""
-    semaphore = await get_semaphore()
     rollout_input = vf.RolloutInput(**example)
-
-    state = await env.run_rollout(semaphore, rollout_input, client, model_name, sampling_args)
-    await env.rubric.score_rollout(state, score_sem=semaphore)
-    return state
+    return await env.run_rollout(rollout_input, client, model_name, sampling_args, state_columns=state_columns)
 
 
 async def generate_batch(
@@ -55,7 +50,7 @@ async def generate_batch(
     rollouts_per_example: int,
     sampling_args: dict,
     pbar_description: str = "Generating rollouts",
-) -> list[vf.State]:
+) -> list[vf.RolloutOutput]:
     """Asynchronously generate and score rollouts for a list of groups (batch)."""
 
     total_rollouts = len(examples) * rollouts_per_example
@@ -68,13 +63,13 @@ async def generate_batch(
         return result
 
     try:
-        group_states_list: list[list[vf.State]] = await asyncio.gather(
+        group_outputs_list: list[list[vf.RolloutOutput]] = await asyncio.gather(
             *[generate_group_with_progress(client, example) for client, example in zip(cycle(clients), examples)]
         )
     finally:
         pbar.close()
 
-    return [state for group_states in group_states_list for state in group_states]
+    return [output for group_outputs in group_outputs_list for output in group_outputs]
 
 
 def get_prompt_len(state: vf.State) -> int:

--- a/src/prime_rl/utils/vf.py
+++ b/src/prime_rl/utils/vf.py
@@ -16,6 +16,7 @@ async def generate_group(
     example: dict,
     rollouts_per_example: int,
     sampling_args: dict,
+    max_retries: int = 0,
     state_columns: list[str] = ["trajectory"],
 ) -> list[vf.RolloutOutput]:
     """Asynchronously generate and score rollouts for a single group."""
@@ -25,6 +26,7 @@ async def generate_group(
         client=client,
         model=model_name,
         sampling_args=sampling_args,
+        max_retries=max_retries,
         state_columns=state_columns,
     )
 
@@ -35,11 +37,14 @@ async def generate_rollout(
     model_name: str,
     example: dict,
     sampling_args: dict,
+    max_retries: int = 0,
     state_columns: list[str] = ["trajectory"],
 ) -> vf.RolloutOutput:
     """Asynchronously generate and score a single rollout."""
     rollout_input = vf.RolloutInput(**example)
-    return await env.run_rollout(rollout_input, client, model_name, sampling_args, state_columns=state_columns)
+    return await env.run_rollout(
+        rollout_input, client, model_name, sampling_args, max_retries=max_retries, state_columns=state_columns
+    )
 
 
 async def generate_batch(

--- a/tests/unit/orchestrator/test_env_worker.py
+++ b/tests/unit/orchestrator/test_env_worker.py
@@ -42,7 +42,7 @@ def env_worker(mock_client_config):
         model_name="test-model",
         seq_len=1024,
         interleaved_rollouts=False,
-        max_concurrent=1,
+        max_concurrent_groups=1,
         example_lookup={},
         worker_name="test_worker",
     )
@@ -188,7 +188,7 @@ def test_full_restart_cycle(mock_client_config):
         model_name="test-model",
         seq_len=1024,
         interleaved_rollouts=False,
-        max_concurrent=1,
+        max_concurrent_groups=1,
         example_lookup={},
         worker_name="test_worker",
     )

--- a/uv.lock
+++ b/uv.lock
@@ -935,6 +935,15 @@ http = [
 ]
 
 [[package]]
+name = "gepa"
+version = "0.0.27"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/99/6840f84498f2dcbfd27e8a15eeb4e637e84e9dbbd6331977b71f6ffad9c7/gepa-0.0.27.tar.gz", hash = "sha256:02ecb19e4aa6a1f5bb2994cd54b2057f25cd5e8cd662fee514303b2a8ba0a738", size = 155106, upload-time = "2026-01-28T00:33:51.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/bd/f9e83519099a9fd5d090520ab0c51a6278e473b914a9b32d1e812662dd3b/gepa-0.0.27-py3-none-any.whl", hash = "sha256:592beb084fd638d525edae84ca75ad8e9e9c3758e5498b933c17153addf5dd2d", size = 146454, upload-time = "2026-01-28T00:33:50.262Z" },
+]
+
+[[package]]
 name = "gguf"
 version = "0.17.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1806,20 +1815,19 @@ wheels = [
 
 [[package]]
 name = "msgpack"
-version = "1.1.1"
+version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/45/b1/ea4f68038a18c77c9467400d166d74c4ffa536f34761f7983a104357e614/msgpack-1.1.1.tar.gz", hash = "sha256:77b79ce34a2bdab2594f490c8e80dd62a02d650b91a75159a63ec413b8d104cd", size = 173555, upload-time = "2025-06-13T06:52:51.324Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/f2/bfb55a6236ed8725a96b0aa3acbd0ec17588e6a2c3b62a93eb513ed8783f/msgpack-1.1.2.tar.gz", hash = "sha256:3b60763c1373dd60f398488069bcdc703cd08a711477b5d480eecc9f9626f47e", size = 173581, upload-time = "2025-10-08T09:15:56.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/26/389b9c593eda2b8551b2e7126ad3a06af6f9b44274eb3a4f054d48ff7e47/msgpack-1.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ae497b11f4c21558d95de9f64fff7053544f4d1a17731c866143ed6bb4591238", size = 82359, upload-time = "2025-06-13T06:52:03.909Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/65/7d1de38c8a22cf8b1551469159d4b6cf49be2126adc2482de50976084d78/msgpack-1.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:33be9ab121df9b6b461ff91baac6f2731f83d9b27ed948c5b9d1978ae28bf157", size = 79172, upload-time = "2025-06-13T06:52:05.246Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/bd/cacf208b64d9577a62c74b677e1ada005caa9b69a05a599889d6fc2ab20a/msgpack-1.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6f64ae8fe7ffba251fecb8408540c34ee9df1c26674c50c4544d72dbf792e5ce", size = 425013, upload-time = "2025-06-13T06:52:06.341Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/ec/fd869e2567cc9c01278a736cfd1697941ba0d4b81a43e0aa2e8d71dab208/msgpack-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a494554874691720ba5891c9b0b39474ba43ffb1aaf32a5dac874effb1619e1a", size = 426905, upload-time = "2025-06-13T06:52:07.501Z" },
-    { url = "https://files.pythonhosted.org/packages/55/2a/35860f33229075bce803a5593d046d8b489d7ba2fc85701e714fc1aaf898/msgpack-1.1.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cb643284ab0ed26f6957d969fe0dd8bb17beb567beb8998140b5e38a90974f6c", size = 407336, upload-time = "2025-06-13T06:52:09.047Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/16/69ed8f3ada150bf92745fb4921bd621fd2cdf5a42e25eb50bcc57a5328f0/msgpack-1.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d275a9e3c81b1093c060c3837e580c37f47c51eca031f7b5fb76f7b8470f5f9b", size = 409485, upload-time = "2025-06-13T06:52:10.382Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/b6/0c398039e4c6d0b2e37c61d7e0e9d13439f91f780686deb8ee64ecf1ae71/msgpack-1.1.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:4fd6b577e4541676e0cc9ddc1709d25014d3ad9a66caa19962c4f5de30fc09ef", size = 412182, upload-time = "2025-06-13T06:52:11.644Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/d0/0cf4a6ecb9bc960d624c93effaeaae75cbf00b3bc4a54f35c8507273cda1/msgpack-1.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb29aaa613c0a1c40d1af111abf025f1732cab333f96f285d6a93b934738a68a", size = 419883, upload-time = "2025-06-13T06:52:12.806Z" },
-    { url = "https://files.pythonhosted.org/packages/62/83/9697c211720fa71a2dfb632cad6196a8af3abea56eece220fde4674dc44b/msgpack-1.1.1-cp312-cp312-win32.whl", hash = "sha256:870b9a626280c86cff9c576ec0d9cbcc54a1e5ebda9cd26dab12baf41fee218c", size = 65406, upload-time = "2025-06-13T06:52:14.271Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/23/0abb886e80eab08f5e8c485d6f13924028602829f63b8f5fa25a06636628/msgpack-1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:5692095123007180dca3e788bb4c399cc26626da51629a31d40207cb262e67f4", size = 72558, upload-time = "2025-06-13T06:52:15.252Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/bd/8b0d01c756203fbab65d265859749860682ccd2a59594609aeec3a144efa/msgpack-1.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:70a0dff9d1f8da25179ffcf880e10cf1aad55fdb63cd59c9a49a1b82290062aa", size = 81939, upload-time = "2025-10-08T09:15:01.472Z" },
+    { url = "https://files.pythonhosted.org/packages/34/68/ba4f155f793a74c1483d4bdef136e1023f7bcba557f0db4ef3db3c665cf1/msgpack-1.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:446abdd8b94b55c800ac34b102dffd2f6aa0ce643c55dfc017ad89347db3dbdb", size = 85064, upload-time = "2025-10-08T09:15:03.764Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/60/a064b0345fc36c4c3d2c743c82d9100c40388d77f0b48b2f04d6041dbec1/msgpack-1.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c63eea553c69ab05b6747901b97d620bb2a690633c77f23feb0c6a947a8a7b8f", size = 417131, upload-time = "2025-10-08T09:15:05.136Z" },
+    { url = "https://files.pythonhosted.org/packages/65/92/a5100f7185a800a5d29f8d14041f61475b9de465ffcc0f3b9fba606e4505/msgpack-1.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:372839311ccf6bdaf39b00b61288e0557916c3729529b301c52c2d88842add42", size = 427556, upload-time = "2025-10-08T09:15:06.837Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/87/ffe21d1bf7d9991354ad93949286f643b2bb6ddbeab66373922b44c3b8cc/msgpack-1.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2929af52106ca73fcb28576218476ffbb531a036c2adbcf54a3664de124303e9", size = 404920, upload-time = "2025-10-08T09:15:08.179Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/41/8543ed2b8604f7c0d89ce066f42007faac1eaa7d79a81555f206a5cdb889/msgpack-1.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:be52a8fc79e45b0364210eef5234a7cf8d330836d0a64dfbb878efa903d84620", size = 415013, upload-time = "2025-10-08T09:15:09.83Z" },
+    { url = "https://files.pythonhosted.org/packages/41/0d/2ddfaa8b7e1cee6c490d46cb0a39742b19e2481600a7a0e96537e9c22f43/msgpack-1.1.2-cp312-cp312-win32.whl", hash = "sha256:1fff3d825d7859ac888b0fbda39a42d59193543920eda9d9bea44d958a878029", size = 65096, upload-time = "2025-10-08T09:15:11.11Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/ec/d431eb7941fb55a31dd6ca3404d41fbb52d99172df2e7707754488390910/msgpack-1.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1de460f0403172cff81169a30b9a92b260cb809c4cb7e2fc79ae8d0510c78b6b", size = 72708, upload-time = "2025-10-08T09:15:12.554Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/31/5b1a1f70eb0e87d1678e9624908f86317787b536060641d6798e3cf70ace/msgpack-1.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:be5980f3ee0e6bd44f3a9e9dea01054f175b50c3e6cdb692bc9424c0bbb8bf69", size = 64119, upload-time = "2025-10-08T09:15:13.589Z" },
 ]
 
 [[package]]
@@ -2544,7 +2552,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", specifier = ">=4.57.6" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=209774a" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=dfc473c" },
     { name = "vllm", specifier = "==0.14.0" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -2572,6 +2580,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/59/55/e6c855074af9ef027f3601396d4e5e0b464f26f724c074253dd0dd2f47b7/prime_sandboxes-0.2.9.tar.gz", hash = "sha256:af4ad06d205a95f4c54778ecac8492f3f382c850528072df79252e7fd0f3fa08", size = 45538, upload-time = "2026-01-07T20:24:15.352Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/ae/5d38212ff0cbad2c468e9b5cf1e3235af04d123b55c4adaa8812abdeabbb/prime_sandboxes-0.2.9-py3-none-any.whl", hash = "sha256:dab4dd9c1f4f633386593cfb08f7a3dacb2de4eb6e75f4a2ec7f5f1c6ea2207b", size = 18824, upload-time = "2026-01-07T20:24:14.133Z" },
+]
+
+[[package]]
+name = "prime-tunnel"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "tenacity" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/c0/8ac67976d94d548076bdd840312d78957e9f9234d37b7a5cc7798caa34ce/prime_tunnel-0.1.0.tar.gz", hash = "sha256:bcf2a15770b2aa60b9f1aa696911c8f63b283fc195af6ba2fc66ce0f0bede041", size = 10617, upload-time = "2026-02-01T08:19:24.21Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/d5/42652ac36d57f2a9e781ed75c5770a47c08a16b2af4ec94aad8e9c065af7/prime_tunnel-0.1.0-py3-none-any.whl", hash = "sha256:dbf4ed8c2b7a61e0b37e97ce1466470be759d05cbb9e88f804ad2344c59bb0eb", size = 13042, upload-time = "2026-02-01T08:19:22.673Z" },
 ]
 
 [[package]]
@@ -3874,18 +3896,23 @@ wheels = [
 
 [[package]]
 name = "verifiers"
-version = "0.1.9.post3"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=209774a#209774a22b6915eeff2091a1ce2782ecbe580ae7" }
+version = "0.1.10.dev0"
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=dfc473c#dfc473ceea9cd062414ec706cda281bd04dda4d8" }
 dependencies = [
     { name = "datasets" },
+    { name = "gepa" },
     { name = "jinja2" },
     { name = "math-verify" },
     { name = "mcp" },
+    { name = "msgpack" },
     { name = "nest-asyncio" },
+    { name = "numpy" },
     { name = "openai" },
     { name = "openai-agents" },
     { name = "prime-sandboxes" },
+    { name = "prime-tunnel" },
     { name = "pydantic" },
+    { name = "pyzmq" },
     { name = "requests" },
     { name = "rich" },
     { name = "tenacity" },


### PR DESCRIPTION
this pr bumps verifiers to commit `dfc473c` (latest as of 2/6/26). main changs are:
- changes in api for `run_rollout` and `run_group`, mainly due to the introduction of the `vf.EnvServer` (not yet integrated):
   * `gen_sampling_args` renamed to`sampling_args`
   * dropped semaphores
   * return type changed from `vf.State` (arbitratry objects) to serializable `vf.RolloutOutput` -- need to pass `state_columns=["trajectory"]` explicitly to get trajectory but otherwise behaves ~the same
- some util imports changed

note that because semaphores are not passed to `run_group` anymore, we can only control concurrency at group-granularity. this is slightly unoptimal because we might have up to `group_size` rollouts in-flight but it's the simplest way to not change the meaning of the arg for now.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core rollout generation and concurrency limiting semantics; mis-scaling `max_concurrent` or missing `state_columns` could change throughput or result contents across training/eval.
> 
> **Overview**
> Updates the codebase to `verifiers` @ `dfc473c` and refactors rollout generation to use the new `sampling_args` API and the new `vf.RolloutOutput` return type (instead of `vf.State`), including explicitly requesting `state_columns=["trajectory"]` where needed.
> 
> Concurrency control is reworked: the previous global semaphore wiring is removed from eval/synthesis and rollout helpers, and `max_concurrent` is now enforced **per-environment at group granularity** via `EnvWorker` (new `max_concurrent_groups`), with scheduler-side scaling and a config validator ensuring `max_concurrent >= rollouts_per_example * workers_per_env`.
> 
> Eval/synthesis utilities are simplified accordingly (retry handling delegated to verifiers via `max_retries`; error handling now logs failed rollouts but no longer synthesizes placeholder “no_response” states), and imports/paths are updated to match verifiers’ new utils layout. Example TOMLs are tweaked to include `[ckpt]`, and dependency locks are updated (new transitive deps like `gepa`, `prime-tunnel`, `msgpack` bump).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c93b2eb825783e3d544553a1b0b858748888649. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->