### PR TITLE
Revert "Single cat dataset"

### DIFF
--- a/src/prime_rl/trainer/sft/config.py
+++ b/src/prime_rl/trainer/sft/config.py
@@ -17,21 +17,12 @@ from prime_rl.utils.config import HeartbeatConfig, LogConfig, WandbConfig
 from prime_rl.utils.pydantic_config import BaseConfig, BaseSettings
 
 
-class ValidationConfig(BaseConfig):
-    """Configures online validation during SFT training."""
-
-    enabled: Annotated[bool, Field(description="Enable online validation during training.")] = False
-    interval: Annotated[int, Field(ge=1, description="Run validation every N training steps.")] = 100
-    split: Annotated[str, Field(description="HuggingFace dataset split to use for validation.")] = "validation"
-    max_samples: Annotated[int | None, Field(ge=1, description="Maximum number of validation samples to use.")] = None
-
-
 class BaseDataConfig(BaseModel):
     """Base config for SFT data."""
 
     batch_size: Annotated[int, Field(ge=1)] = 128
     seq_len: Annotated[int, Field(ge=1)] = 128
-    pack_function: Literal["cat", "stack", "single"] = "cat"
+    pack_function: Literal["cat", "stack"] = "cat"
     micro_batch_size: Annotated[int, Field(ge=1)] = 1
 
     @model_validator(mode="after")
@@ -124,9 +115,6 @@ class SFTTrainerConfig(BaseSettings):
 
     # The data configuration
     data: Annotated[DataConfigType, Field(discriminator="type")] = SFTDataConfig()
-
-    # The validation configuration
-    validation: ValidationConfig = ValidationConfig()
 
     # The optimizer configuration
     optim: Annotated[OptimizerConfigType, Field(discriminator="type")] = AdamWConfig()

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -12,7 +12,7 @@ from torch.utils.data import IterableDataset, get_worker_info
 from torchdata.stateful_dataloader import StatefulDataLoader
 from transformers.tokenization_utils import PreTrainedTokenizer
 
-from prime_rl.trainer.sft.config import DataConfigType, LossMaskConfig, SFTDataConfig, ValidationConfig
+from prime_rl.trainer.sft.config import DataConfigType, LossMaskConfig
 from prime_rl.trainer.world import get_world
 from prime_rl.utils.logger import get_logger
 
@@ -381,48 +381,6 @@ class CatDataset(StatefulIterableDataset):
                 packed_samples, seq_len = defaultdict(list), 0
 
 
-class SingleSampleDataset(StatefulIterableDataset):
-    """A dataset that yields single samples padded to a fixed length.
-
-    Unlike CatDataset which concatenates multiple samples, this yields one sample
-    per iteration, padding the rest of the sequence. This means each microbatch
-    contains only 1 actual sample.
-    """
-
-    def __init__(self, dataset: StatefulIterableDataset, seq_len: int):
-        self.logger = get_logger()
-        self.dataset = dataset
-        self.seq_len = seq_len
-
-    def state_dict(self) -> dict:
-        return {"dataset": self.dataset.state_dict()}
-
-    def load_state_dict(self, state_dict: dict):
-        self.dataset.load_state_dict(state_dict["dataset"])
-
-    def __iter__(self):
-        for sample in self.dataset:
-            sample_len = len(sample["input_ids"])
-
-            if sample_len > self.seq_len:
-                for key, value in sample.items():
-                    assert isinstance(value, list), f"Value for key {key} must be a list"
-                    sample[key] = value[: self.seq_len]
-                yield sample
-            elif sample_len < self.seq_len:
-                pad_len = self.seq_len - sample_len
-                padded_sample = {}
-                for key, value in sample.items():
-                    assert isinstance(value, list), f"Value for key {key} must be a list"
-                    if key == "loss_mask":
-                        padded_sample[key] = value + [False] * pad_len
-                    else:
-                        padded_sample[key] = value + [0] * pad_len
-                yield padded_sample
-            else:
-                yield sample
-
-
 class StackDataset(StatefulIterableDataset):
     """A dataset that stacks samples into batch with a fixed area"""
 
@@ -645,96 +603,5 @@ def setup_dataloader(dataset: StatefulIterableDataset, config: DataConfigType) -
     elif config.pack_function == "cat":
         packing_dataset = CatDataset(dataset, config.seq_len * config.micro_batch_size)
         return StatefulDataLoader(packing_dataset, batch_size=1, collate_fn=cat_collate)
-    elif config.pack_function == "single":
-        single_dataset = SingleSampleDataset(dataset, config.seq_len)
-        return StatefulDataLoader(single_dataset, batch_size=config.micro_batch_size, collate_fn=cat_collate)
     else:
         raise ValueError(f"Invalid pack function: {config.pack_function}")
-
-
-class ValidationCatDataset(StatefulIterableDataset):
-    """Like CatDataset but yields the last batch even if not full (padded)."""
-
-    def __init__(self, dataset: StatefulIterableDataset, seq_len: int):
-        self.logger = get_logger()
-        self.dataset = dataset
-        self.seq_len = seq_len
-
-    def state_dict(self) -> dict:
-        return {"dataset": self.dataset.state_dict()}
-
-    def load_state_dict(self, state_dict: dict):
-        self.dataset.load_state_dict(state_dict["dataset"])
-
-    def __iter__(self):
-        packed_samples, cur_len = defaultdict(list), 0
-
-        for sample in self.dataset:
-            for key, value in sample.items():
-                assert isinstance(value, list), f"Value for key {key} must be a list"
-                packed_samples[key].extend(value)
-
-            cur_len += len(sample["input_ids"])
-
-            if cur_len >= self.seq_len:
-                for key, value in packed_samples.items():
-                    packed_samples[key] = value[: self.seq_len]
-                yield packed_samples
-                packed_samples, cur_len = defaultdict(list), 0
-
-        if cur_len > 0:
-            for key, value in packed_samples.items():
-                pad_len = self.seq_len - len(value)
-                if pad_len > 0:
-                    if key == "loss_mask":
-                        packed_samples[key] = value + [False] * pad_len
-                    else:
-                        packed_samples[key] = value + [0] * pad_len
-            yield packed_samples
-        else:
-            self.logger.warning("No samples yielded, yielding dummy batch")
-            yield {
-                "input_ids": [0] * self.seq_len,
-                "position_ids": list(range(self.seq_len)),
-                "target_ids": [0] * self.seq_len,
-                "loss_mask": [False] * self.seq_len,
-            }
-
-
-def setup_validation_dataloader(
-    tokenizer: PreTrainedTokenizer,
-    data_config: SFTDataConfig,
-    validation_config: ValidationConfig,
-    non_dp_size: int = 1,
-) -> StatefulDataLoader:
-    """Set up a validation dataloader using the same dataset but with the validation split."""
-    logger = get_logger()
-    logger.info(
-        f"Setting up validation dataloader (split={validation_config.split}, max_samples={validation_config.max_samples})"
-    )
-
-    # Load the validation split
-    dataset = setup_and_interleave_datasets(
-        dataset_name=data_config.name,
-        subsets_and_splits=[(None, validation_config.split)],
-        probabilities=None,
-        stopping_strategy="all_exhausted",
-        seed=data_config.seed,
-    )
-
-    # Create SFT dataset without shuffle and with max_epochs=1
-    val_dataset = SFTDataset(
-        dataset,
-        tokenizer,
-        shuffle=False,
-        seed=data_config.seed,
-        seq_len=data_config.seq_len,
-        loss_mask_config=data_config.loss_mask,
-        max_examples=validation_config.max_samples,
-        max_epochs=1,  # Only iterate once through validation set
-        non_dp_size=non_dp_size,
-    )
-
-    # Use ValidationCatDataset which yields the last partial batch (padded)
-    packed_dataset = ValidationCatDataset(val_dataset, data_config.seq_len * data_config.micro_batch_size)
-    return StatefulDataLoader(packed_dataset, batch_size=1, collate_fn=cat_collate)

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -30,7 +30,7 @@ from prime_rl.trainer.model import (
 )
 from prime_rl.trainer.parallel_dims import get_parallel_dims
 from prime_rl.trainer.perf import get_perf_counter
-from prime_rl.trainer.sft.data import setup_dataloader, setup_dataset, setup_validation_dataloader
+from prime_rl.trainer.sft.data import setup_dataloader, setup_dataset
 from prime_rl.trainer.utils import (
     MemoryProfiler,
     export_benchmark_json,
@@ -48,89 +48,6 @@ import torch.distributed as dist
 from liger_kernel.transformers.cross_entropy import LigerCrossEntropyLoss
 
 from torchtitan.distributed.utils import clip_grad_norm_
-
-
-def prepare_batch(batch, cp_enabled, cp_rank, cp_size, cp_group):
-    """Move batch to GPU and apply CP sharding if enabled."""
-    input_ids = batch["input_ids"].to("cuda")
-    position_ids = batch["position_ids"].to("cuda")
-    target_ids = batch["target_ids"].to("cuda")
-    loss_mask = batch["loss_mask"].to("cuda")
-
-    if cp_enabled:
-        input_ids, position_ids = setup_cp_params(input_ids, position_ids, cp_rank, cp_size, cp_group)
-        target_ids = shard_for_cp(target_ids, cp_rank=cp_rank, cp_world_size=cp_size)
-        loss_mask = shard_for_cp(loss_mask, cp_rank=cp_rank, cp_world_size=cp_size)
-
-    return input_ids, position_ids, target_ids, loss_mask
-
-
-def compute_loss(model, input_ids, position_ids, target_ids, loss_mask, ce_loss):
-    """Run forward pass and compute masked loss."""
-    out = forward(model, input_ids, position_ids)
-    logits = out["logits"]
-    B, L, V = logits.shape
-
-    loss = ce_loss(logits.view(-1, V), target_ids.view(-1)).view(B, L)
-    loss = loss[loss_mask].mean()
-
-    del logits
-    return loss, out
-
-
-def validate_step(
-    model,
-    validation_dataloader,
-    ce_loss,
-    parallel_dims,
-    logger,
-):
-    """Run one pass through the validation dataset and return metrics."""
-    model.eval()
-    val_loss = torch.tensor(0.0, device="cuda")
-    num_batches = torch.tensor(0, device="cuda")
-
-    cp_enabled = parallel_dims.cp_enabled
-    cp_rank = parallel_dims.world_mesh["cp"].get_local_rank() if cp_enabled else 0
-    cp_group = parallel_dims.world_mesh["cp"].get_group() if cp_enabled else None
-    cp_size = parallel_dims.cp
-
-    val_iter = iter(validation_dataloader)
-    with torch.no_grad():
-        while True:
-            val_batch = next(val_iter, None)
-
-            # Check if this rank has real data (not exhausted and not a dummy batch)
-            loss_mask_check = val_batch["loss_mask"] if val_batch is not None else None
-            has_real_data = val_batch is not None and loss_mask_check.any().item()
-            has_real_data_tensor = torch.tensor(1 if has_real_data else 0, device="cuda", dtype=torch.long)
-            dist.all_reduce(has_real_data_tensor, op=dist.ReduceOp.MIN)
-
-            # Stop if any rank has no more real data
-            if has_real_data_tensor.item() == 0:
-                break
-
-            input_ids, position_ids, target_ids, loss_mask = prepare_batch(
-                val_batch, cp_enabled, cp_rank, cp_size, cp_group
-            )
-            loss, _ = compute_loss(model, input_ids, position_ids, target_ids, loss_mask, ce_loss)
-
-            if not torch.isnan(loss):
-                val_loss += loss.detach()
-                num_batches += 1
-
-    dist.all_reduce(val_loss, op=dist.ReduceOp.SUM)
-    dist.all_reduce(num_batches, op=dist.ReduceOp.SUM)
-
-    model.train()
-
-    if num_batches > 0:
-        avg_val_loss = (val_loss / num_batches).item()
-    else:
-        avg_val_loss = float("nan")
-        logger.warning("No valid validation batches found")
-
-    return {"val/loss": avg_val_loss, "val/num_batches": num_batches.item()}
 
 
 @clean_exit
@@ -293,28 +210,6 @@ def train(config: SFTTrainerConfig):
         if config.max_steps is not None and progress.step >= config.max_steps:
             break
 
-        if config.validation.enabled and (
-            progress.step % config.validation.interval == 0
-            or (config.max_steps is not None and progress.step == config.max_steps - 1)
-        ):
-            validation_dataloader = setup_validation_dataloader(
-                tokenizer, config.data, config.validation, config.model.cp * config.model.tp
-            )
-            logger.info(f"Running validation at step {progress.step}")
-            val_start_time = time.perf_counter()
-            val_metrics = validate_step(model, validation_dataloader, ce_loss, parallel_dims, logger)
-            val_time = time.perf_counter() - val_start_time
-            val_metrics["val/time"] = val_time
-            val_metrics["step"] = progress.step
-            monitor.log(val_metrics, step=progress.step)
-            logger.success(
-                f"Validation | Loss: {val_metrics['val/loss']:.4f} | Batches: {val_metrics['val/num_batches']} | Time: {val_time:.2f}s"
-            )
-            # Reset the validation dataloader for next validation run
-            validation_dataloader = setup_validation_dataloader(
-                tokenizer, config.data, config.validation, config.model.cp * config.model.tp
-            )
-
         memory_profiler = (
             MemoryProfiler(progress.step, config.memory_profiler_path) if config.memory_profiler_path else None
         )
@@ -327,9 +222,15 @@ def train(config: SFTTrainerConfig):
         batch_max_vio, max_vio = torch.tensor(0.0).to("cuda"), None
         for micro_step in range(grad_accum_steps):
             micro_batch = next(dataiter)
-            input_ids, position_ids, target_ids, loss_mask = prepare_batch(
-                micro_batch, cp_enabled, cp_rank, cp_size, cp_group
-            )
+            input_ids = micro_batch["input_ids"].to("cuda")
+            position_ids = micro_batch["position_ids"].to("cuda")
+            target_ids = micro_batch["target_ids"].to("cuda")
+            loss_mask = micro_batch["loss_mask"].to("cuda")
+
+            if cp_enabled:
+                input_ids, position_ids = setup_cp_params(input_ids, position_ids, cp_rank, cp_size, cp_group)
+                target_ids = shard_for_cp(target_ids, cp_rank=cp_rank, cp_world_size=cp_size)
+                loss_mask = shard_for_cp(loss_mask, cp_rank=cp_rank, cp_world_size=cp_size)
 
             assert input_ids.shape == position_ids.shape == target_ids.shape == loss_mask.shape, (
                 f"input_ids.shape: {input_ids.shape}, position_ids.shape: {position_ids.shape}, target_ids.shape: {target_ids.shape}, loss_mask.shape: {loss_mask.shape}"

--- a/tests/unit/train/sft/test_dataloader.py
+++ b/tests/unit/train/sft/test_dataloader.py
@@ -10,42 +10,6 @@ from prime_rl.trainer.world import reset_world
 pytestmark = [pytest.mark.gpu]
 
 
-def test_fake_dataset_single_pack_function():
-    """Tests the single pack function which yields one sample per batch with padding."""
-    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B")
-    config = FakeDataConfig(length="variable", input_ids="increasing", batch_size=1, pack_function="single")
-    dataset = setup_dataset(tokenizer, config)
-    dataloader = setup_dataloader(dataset, config)
-    dataiter = iter(dataloader)
-
-    for _ in range(4):
-        micro_batch = next(dataiter)
-        # Each micro batch should have exactly seq_len tokens
-        assert micro_batch["input_ids"].shape == (1, 128)
-        assert micro_batch["target_ids"].shape == (1, 128)
-        assert micro_batch["position_ids"].shape == (1, 128)
-        assert micro_batch["loss_mask"].shape == (1, 128)
-
-
-def test_fake_dataset_single_pack_function_micro_batch():
-    """Tests the single pack function with micro_batch_size > 1."""
-    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B")
-    config = FakeDataConfig(
-        length="variable", input_ids="increasing", batch_size=4, micro_batch_size=2, pack_function="single"
-    )
-    dataset = setup_dataset(tokenizer, config)
-    dataloader = setup_dataloader(dataset, config)
-    dataiter = iter(dataloader)
-
-    for _ in range(4):
-        micro_batch = next(dataiter)
-        # Each micro batch should have micro_batch_size samples
-        assert micro_batch["input_ids"].shape == (2, 128)
-        assert micro_batch["target_ids"].shape == (2, 128)
-        assert micro_batch["position_ids"].shape == (2, 128)
-        assert micro_batch["loss_mask"].shape == (2, 128)
-
-
 def test_fake_dataset_single_rank_state():
     # Setup stateful dataloader
     tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B")

--- a/tests/unit/train/sft/test_sft_dataset.py
+++ b/tests/unit/train/sft/test_sft_dataset.py
@@ -4,7 +4,7 @@ import pytest
 from datasets import Dataset, interleave_datasets
 from transformers import AutoTokenizer
 
-from prime_rl.trainer.sft.data import FakeDataset, SFTDataset, SingleSampleDataset
+from prime_rl.trainer.sft.data import SFTDataset
 from prime_rl.trainer.utils import print_sample
 
 
@@ -260,97 +260,3 @@ def test_multiturn_loss_mask_with_tools():
     dataset = SFTDataset(dataset, tokenizer=tokenizer, max_examples=1)
     sample = next(iter(dataset))
     print_sample(sample["input_ids"], sample["loss_mask"], tokenizer)
-
-
-def test_single_sample_dataset_padding():
-    """Tests that SingleSampleDataset pads samples shorter than seq_len."""
-    seq_len = 128
-    fake_dataset = FakeDataset(vocab_size=10000, seq_len=32, length="fixed")
-    single_dataset = SingleSampleDataset(fake_dataset, seq_len=seq_len)
-    dataiter = iter(single_dataset)
-
-    sample = next(dataiter)
-    assert len(sample["input_ids"]) == seq_len
-    assert len(sample["target_ids"]) == seq_len
-    assert len(sample["position_ids"]) == seq_len
-    assert len(sample["loss_mask"]) == seq_len
-
-    # Verify padding: loss_mask should be False for padded positions
-    assert sample["loss_mask"][:32] == [True] * 32
-    assert sample["loss_mask"][32:] == [False] * (seq_len - 32)
-
-    # Verify padding values are 0 for input_ids, target_ids, position_ids
-    assert sample["input_ids"][32:] == [0] * (seq_len - 32)
-    assert sample["target_ids"][32:] == [0] * (seq_len - 32)
-    assert sample["position_ids"][32:] == [0] * (seq_len - 32)
-
-
-def test_single_sample_dataset_truncation():
-    """Tests that SingleSampleDataset truncates samples longer than seq_len."""
-    seq_len = 64
-    fake_dataset = FakeDataset(vocab_size=10000, seq_len=128, length="fixed")
-    single_dataset = SingleSampleDataset(fake_dataset, seq_len=seq_len)
-    dataiter = iter(single_dataset)
-
-    sample = next(dataiter)
-    assert len(sample["input_ids"]) == seq_len
-    assert len(sample["target_ids"]) == seq_len
-    assert len(sample["position_ids"]) == seq_len
-    assert len(sample["loss_mask"]) == seq_len
-
-
-def test_single_sample_dataset_exact_length():
-    """Tests that SingleSampleDataset handles samples with exact seq_len."""
-    seq_len = 128
-    fake_dataset = FakeDataset(vocab_size=10000, seq_len=seq_len, length="fixed")
-    single_dataset = SingleSampleDataset(fake_dataset, seq_len=seq_len)
-    dataiter = iter(single_dataset)
-
-    sample = next(dataiter)
-    assert len(sample["input_ids"]) == seq_len
-    assert len(sample["target_ids"]) == seq_len
-    assert len(sample["position_ids"]) == seq_len
-    assert len(sample["loss_mask"]) == seq_len
-
-
-def test_single_sample_dataset_state():
-    """Tests that SingleSampleDataset correctly delegates state management."""
-    fake_dataset = FakeDataset(vocab_size=10000, seq_len=32, length="fixed")
-    single_dataset = SingleSampleDataset(fake_dataset, seq_len=128)
-
-    # Initial state
-    state = single_dataset.state_dict()
-    assert state == {"dataset": {"step": 0, "epoch": 0}}
-
-    # Iterate and check state
-    dataiter = iter(single_dataset)
-    next(dataiter)
-    state = single_dataset.state_dict()
-    assert state == {"dataset": {"step": 1, "epoch": 0}}
-
-    next(dataiter)
-    state = single_dataset.state_dict()
-    assert state == {"dataset": {"step": 2, "epoch": 0}}
-
-
-def test_single_sample_dataset_resume():
-    """Tests that SingleSampleDataset can resume from checkpoint."""
-    fake_dataset = FakeDataset(vocab_size=10000, seq_len=32, length="fixed", input_ids="increasing")
-    single_dataset = SingleSampleDataset(fake_dataset, seq_len=128)
-    dataiter = iter(single_dataset)
-
-    # Get first sample
-    sample1 = next(dataiter)
-    sample2 = next(dataiter)
-    state_dict = single_dataset.state_dict()
-
-    # Create new dataset and resume
-    fake_dataset2 = FakeDataset(vocab_size=10000, seq_len=32, length="fixed", input_ids="increasing")
-    single_dataset2 = SingleSampleDataset(fake_dataset2, seq_len=128)
-    single_dataset2.load_state_dict(state_dict)
-    dataiter2 = iter(single_dataset2)
-
-    # Should continue from where we left off
-    sample3 = next(dataiter2)
-    assert sample3["input_ids"][:32] != sample1["input_ids"][:32]
-    assert sample3["input_ids"][:32] != sample2["input_ids"][:32]


### PR DESCRIPTION
Reverts PrimeIntellect-ai/prime-rl#1706

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes validation and a data-packing mode, which can change training behavior/observability and potentially break existing configs that relied on `validation.*` or `pack_function="single"`.
> 
> **Overview**
> Reverts the SFT trainer’s online validation feature by removing `ValidationConfig`, the validation dataloader (`setup_validation_dataloader`/`ValidationCatDataset`), and the periodic validation loop/metrics emission in `train.py`.
> 
> Simplifies SFT data packing by deleting `SingleSampleDataset` and the `pack_function="single"` option; configs now only allow `cat` or `stack`, and related unit tests are removed/updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70e712628f1dc94408ac1de7cdd938ba8a4da84f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->