### PR TITLE
fix rac e condition

### DIFF
--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -366,13 +366,14 @@ class WeightCheckpointManager:
                 if step % self.keep_interval == 0:
                     steps_to_keep.add(step)
 
-        # Delete steps not in steps_to_keep
+        # Delete steps not in steps_to_keep (only master rank deletes to avoid race condition)
         ckpt_steps_to_delete = [step for step in self.ckpt_steps if step not in steps_to_keep]
-        for ckpt_step in ckpt_steps_to_delete:
-            ckpt_path = self.get_step_path(ckpt_step)
-            if ckpt_path.exists():
-                self.logger.debug(f"Removing past checkpoint for step {ckpt_step} ({ckpt_path})")
-                shutil.rmtree(ckpt_path)
+        if self.world.is_master:
+            for ckpt_step in ckpt_steps_to_delete:
+                ckpt_path = self.get_step_path(ckpt_step)
+                if ckpt_path.exists():
+                    self.logger.debug(f"Removing past checkpoint for step {ckpt_step} ({ckpt_path})")
+                    shutil.rmtree(ckpt_path)
 
         # Update checkpoint steps
         self.ckpt_steps = [step for step in self.ckpt_steps if step in steps_to_keep]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change to checkpoint retention/cleanup logic; main risk is leaving stale checkpoints behind if master behavior is misconfigured.
> 
> **Overview**
> Fixes a distributed race in checkpoint cleanup by ensuring only the master rank deletes old checkpoint directories during `maybe_clean()`.
> 
> This prevents multiple ranks from concurrently `rmtree`-ing the same checkpoint path while still updating the in-memory `ckpt_steps` retention list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 916fc57c8bee575d4a24665a7e3c34ba6ae93649. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->