### PR TITLE
Add podManagementPolicy: Parallel for faster pod startup

### DIFF
--- a/k8s/prime-rl/templates/deployment.yaml
+++ b/k8s/prime-rl/templates/deployment.yaml
@@ -117,6 +117,7 @@ metadata:
 spec:
   serviceName: {{ .Release.Name }}-inference-headless
   replicas: {{ .Values.inference.replicas }}
+  podManagementPolicy: Parallel
   selector:
     matchLabels:
       {{- include "prime-rl.componentLabels" . | nindent 6 }}
@@ -222,6 +223,7 @@ metadata:
 spec:
   serviceName: {{ .Release.Name }}-trainer-headless
   replicas: {{ .Values.trainer.replicas }}
+  podManagementPolicy: Parallel
   selector:
     matchLabels:
       {{- include "prime-rl.componentLabels" . | nindent 6 }}


### PR DESCRIPTION
- Adds `podManagementPolicy: Parallel` to inference and trainer StatefulSets
- Pods now start simultaneously instead of sequentially (OrderedReady default)
- Reduces deployment time for multi-replica setups

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Helm manifest change limited to rollout behavior; potential risk is increased simultaneous load during startup, but no app logic or security changes.
> 
> **Overview**
> **Speeds up StatefulSet rollouts** by setting `podManagementPolicy: Parallel` on the `inference` and `trainer` Helm-managed StatefulSets, allowing replicas to start concurrently instead of waiting for ordered readiness.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 696a1f1106ca3635b157edb1a03316d89c72bf39. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->