### PR TITLE
Add health probes for inference and trainer

### DIFF
--- a/k8s/prime-rl/templates/deployment.yaml
+++ b/k8s/prime-rl/templates/deployment.yaml
@@ -196,6 +196,29 @@ spec:
             memory: {{ .Values.inference.resources.limits.memory }}
             cpu: {{ .Values.inference.resources.limits.cpu }}
             {{- end }}
+        {{- if and .Values.inference.probes .Values.inference.probes.enabled }}
+        startupProbe:
+          httpGet:
+            path: /health
+            port: {{ .Values.inference.service.port }}
+          periodSeconds: {{ .Values.inference.probes.startup.periodSeconds }}
+          failureThreshold: {{ .Values.inference.probes.startup.failureThreshold }}
+          timeoutSeconds: {{ .Values.inference.probes.startup.timeoutSeconds }}
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: {{ .Values.inference.service.port }}
+          periodSeconds: {{ .Values.inference.probes.liveness.periodSeconds }}
+          failureThreshold: {{ .Values.inference.probes.liveness.failureThreshold }}
+          timeoutSeconds: {{ .Values.inference.probes.liveness.timeoutSeconds }}
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: {{ .Values.inference.service.port }}
+          periodSeconds: {{ .Values.inference.probes.readiness.periodSeconds }}
+          failureThreshold: {{ .Values.inference.probes.readiness.failureThreshold }}
+          timeoutSeconds: {{ .Values.inference.probes.readiness.timeoutSeconds }}
+        {{- end }}
         {{- if .Values.storage.enabled }}
         volumeMounts:
         - name: shared-data
@@ -318,6 +341,29 @@ spec:
             memory: {{ .Values.trainer.resources.limits.memory }}
             cpu: {{ .Values.trainer.resources.limits.cpu }}
             {{- end }}
+        {{- if and .Values.trainer.probes .Values.trainer.probes.enabled }}
+        startupProbe:
+          httpGet:
+            path: /health
+            port: {{ .Values.trainer.service.port }}
+          periodSeconds: {{ .Values.trainer.probes.startup.periodSeconds }}
+          failureThreshold: {{ .Values.trainer.probes.startup.failureThreshold }}
+          timeoutSeconds: {{ .Values.trainer.probes.startup.timeoutSeconds }}
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: {{ .Values.trainer.service.port }}
+          periodSeconds: {{ .Values.trainer.probes.liveness.periodSeconds }}
+          failureThreshold: {{ .Values.trainer.probes.liveness.failureThreshold }}
+          timeoutSeconds: {{ .Values.trainer.probes.liveness.timeoutSeconds }}
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: {{ .Values.trainer.service.port }}
+          periodSeconds: {{ .Values.trainer.probes.readiness.periodSeconds }}
+          failureThreshold: {{ .Values.trainer.probes.readiness.failureThreshold }}
+          timeoutSeconds: {{ .Values.trainer.probes.readiness.timeoutSeconds }}
+        {{- end }}
         {{- if .Values.storage.enabled }}
         volumeMounts:
         - name: shared-data

--- a/k8s/prime-rl/values.yaml
+++ b/k8s/prime-rl/values.yaml
@@ -75,9 +75,9 @@ inference:
 
   runtimeClassName: nvidia
 
-  # Health probes for inference server
+  # Health probes for inference server (requires /health endpoint)
   probes:
-    enabled: true
+    enabled: false
     # Startup probe: allows long model loading time (up to 45 min by default)
     startup:
       periodSeconds: 10
@@ -123,9 +123,9 @@ trainer:
 
   runtimeClassName: nvidia
 
-  # Health probes for trainer
+  # Health probes for trainer (requires metrics_server config)
   probes:
-    enabled: true
+    enabled: false
     # Startup probe: allows time for model loading
     startup:
       periodSeconds: 10

--- a/k8s/prime-rl/values.yaml
+++ b/k8s/prime-rl/values.yaml
@@ -75,6 +75,23 @@ inference:
 
   runtimeClassName: nvidia
 
+  # Health probes for inference server
+  probes:
+    enabled: true
+    # Startup probe: allows long model loading time (up to 45 min by default)
+    startup:
+      periodSeconds: 10
+      failureThreshold: 270  # 270 * 10s = 45 min max startup time
+      timeoutSeconds: 5
+    liveness:
+      periodSeconds: 10
+      failureThreshold: 3
+      timeoutSeconds: 60
+    readiness:
+      periodSeconds: 5
+      failureThreshold: 2
+      timeoutSeconds: 5
+
 # Trainer component
 trainer:
   enabled: true
@@ -105,6 +122,23 @@ trainer:
   env: []
 
   runtimeClassName: nvidia
+
+  # Health probes for trainer
+  probes:
+    enabled: true
+    # Startup probe: allows time for model loading
+    startup:
+      periodSeconds: 10
+      failureThreshold: 60  # 60 * 10s = 10 min max startup time
+      timeoutSeconds: 30
+    liveness:
+      periodSeconds: 30
+      failureThreshold: 6   # 6 * 30s = 3 min before restart
+      timeoutSeconds: 30
+    readiness:
+      periodSeconds: 10
+      failureThreshold: 3
+      timeoutSeconds: 30
 
 # Additional configuration
 config:


### PR DESCRIPTION
- Adds startup, liveness, and readiness probes to inference and trainer StatefulSets
- Inference: 45 min startup timeout (for large models), 10s liveness, 5s readiness
- Trainer: 10 min startup timeout, 30s liveness/readiness
- Probes hit /health endpoint on service port
- Enabled by default, can be disabled via `probes.enabled: false`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Helm-only changes gated behind `*.probes.enabled` (default off), so impact is limited to clusters that opt in; main risk is misconfigured probe timings causing unintended restarts if enabled.
> 
> **Overview**
> Adds optional `startupProbe`, `livenessProbe`, and `readinessProbe` to the inference and trainer `StatefulSet` templates, all hitting `GET /health` on each component’s service port.
> 
> Introduces new `values.yaml` knobs under `inference.probes` and `trainer.probes` (disabled by default) with tuned timeouts/thresholds to support long model start times (inference ~45m, trainer ~10m) and configurable liveness/readiness checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ad1e37c62504319204f1d121ea0319a710aadb0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->