### PR TITLE
handle empty completion_temperatures in prepare_sample

### DIFF
--- a/src/prime_rl/trainer/batch.py
+++ b/src/prime_rl/trainer/batch.py
@@ -15,7 +15,8 @@ def prepare_sample(training_example: TrainingSample, seq_len: int) -> MicroBatch
     position_ids = list(range(len(input_ids)))
 
     # Per-token temperatures: prompt tokens use first completion temp (masked out anyway)
-    prompt_temp = training_example.completion_temperatures[0]
+    # Default to 1.0 if completion is empty (e.g., model generated only tool calls with no text)
+    prompt_temp = training_example.completion_temperatures[0] if training_example.completion_temperatures else 1.0
     temperatures = [prompt_temp] * len(training_example.prompt_ids) + training_example.completion_temperatures
 
     # Teacher logprobs already cover the full sequence (prompt + completion),


### PR DESCRIPTION
4fc312b0 introduced per-token temperatures but didn't handle empty completions. if a model only outputs tool calls (no text), completion_ids is empty, so completion_temperatures is [] and training crashes.

defaulting to 1.0 since that's the previous default and prompt tokens are masked anyway.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change in batch construction that only affects an edge case (empty completions) and preserves the prior default temperature behavior.
> 
> **Overview**
> Fixes a crash in `prepare_sample` when `completion_temperatures` is empty (e.g., rollouts with tool-only outputs and no completion tokens).
> 
> The prompt-side temperature now falls back to `1.0` instead of indexing `[0]`, keeping per-token `temperatures` construction valid while leaving masked prompt tokens unaffected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0581c1a4c70ea1d5ff93de08af882d3dab15aa67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->