### PR TITLE
feat: add standalone eval with watcher and wandb support

### DIFF
--- a/configs/eval/example.toml
+++ b/configs/eval/example.toml
@@ -1,0 +1,40 @@
+# Example offline evaluation config
+# Usage: uv run eval @ configs/eval/example.toml
+
+[model]
+name = "Qwen/Qwen3-0.6B"
+
+[client]
+base_url = ["http://localhost:8000/v1"]
+
+[[env]]
+env_id = "reverse-text"
+name = "reverse-text"
+
+[sampling]
+max_tokens = 2048
+temperature = 0.7
+
+# Global eval settings
+num_examples = 100
+rollouts_per_example = 1
+max_concurrent = 32
+
+# Watcher mode (disabled by default)
+[watcher]
+enabled = false
+# weights_dir = "/path/to/checkpoints"
+# poll_interval = 10
+
+# WandB logging (optional)
+# [wandb]
+# project = "prime-rl"
+# name = "eval-run"
+# [wandb.log_extras]
+# rollouts = false
+# rewards = false
+
+[log]
+level = "info"
+
+output_dir = "outputs/eval"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ trainer = "prime_rl.trainer.rl.train:main"
 orchestrator = "prime_rl.orchestrator.orchestrator:main"
 inference = "prime_rl.inference.server:main"
 sft = "prime_rl.trainer.sft.train:main"
+eval = "prime_rl.eval.eval:main"
 
 [project.optional-dependencies]
 flash-attn = [

--- a/src/prime_rl/eval/config.py
+++ b/src/prime_rl/eval/config.py
@@ -1,0 +1,142 @@
+from pathlib import Path
+from typing import Annotated, Any
+
+from pydantic import Field
+
+from prime_rl.utils.config import ClientConfig, LogConfig, ModelConfig, WandbWithExtrasConfig
+from prime_rl.utils.pydantic_config import BaseConfig, BaseSettings
+
+
+class EvalSamplingConfig(BaseConfig):
+    """Sampling configuration for evaluation."""
+
+    temperature: Annotated[
+        float | None,
+        Field(description="Temperature for sampling. If None, uses server default."),
+    ] = None
+
+    max_tokens: Annotated[
+        int | None,
+        Field(description="Maximum tokens to generate. If None, uses server default."),
+    ] = None
+
+    top_p: Annotated[
+        float | None,
+        Field(description="Top-p sampling. If None, uses server default."),
+    ] = None
+
+    top_k: Annotated[
+        int | None,
+        Field(description="Top-k sampling. If None, uses server default."),
+    ] = None
+
+    min_p: Annotated[
+        float | None,
+        Field(description="Min-p sampling. If None, uses server default."),
+    ] = None
+
+    repetition_penalty: Annotated[
+        float | None,
+        Field(description="Repetition penalty. If None, uses server default."),
+    ] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dict, excluding None values."""
+        return {k: v for k, v in self.model_dump().items() if v is not None}
+
+
+class EvalEnvConfig(BaseConfig):
+    """Configuration for a single evaluation environment."""
+
+    env_id: Annotated[str, Field(description="Environment ID (e.g., 'gsm8k', 'math-python').")] = "reverse-text"
+
+    env_args: Annotated[
+        dict[str, Any],
+        Field(description="Arguments to pass to the environment constructor."),
+    ] = {}
+
+    name: Annotated[
+        str | None,
+        Field(description="Display name for the environment. If None, uses env_id."),
+    ] = None
+
+    num_examples: Annotated[
+        int | None,
+        Field(description="Number of examples to evaluate. If None, uses global default."),
+    ] = None
+
+    rollouts_per_example: Annotated[
+        int | None,
+        Field(description="Number of rollouts per example. If None, uses global default."),
+    ] = None
+
+
+class WatcherConfig(BaseConfig):
+    """Configuration for checkpoint watching mode."""
+
+    enabled: Annotated[
+        bool,
+        Field(description="Whether to enable watcher mode."),
+    ] = False
+
+    weights_dir: Annotated[
+        Path | None,
+        Field(description="Directory to watch for checkpoints. Required if enabled."),
+    ] = None
+
+    poll_interval: Annotated[
+        int,
+        Field(ge=1, description="Seconds between checkpoint scans."),
+    ] = 10
+
+
+class OfflineEvalConfig(BaseSettings):
+    """Configuration for offline evaluation with verifiers."""
+
+    # Model configuration
+    model: ModelConfig = Field(default_factory=ModelConfig)
+
+    # Client configuration (supports multiple URLs for load balancing)
+    client: ClientConfig = Field(default_factory=ClientConfig)
+
+    # Environment configurations
+    env: Annotated[
+        list[EvalEnvConfig],
+        Field(description="List of environments to evaluate."),
+    ] = [EvalEnvConfig()]
+
+    # Sampling configuration
+    sampling: EvalSamplingConfig = Field(default_factory=EvalSamplingConfig)
+
+    # Evaluation parameters
+    num_examples: Annotated[
+        int,
+        Field(description="Default number of examples per environment. -1 for all."),
+    ] = -1
+
+    rollouts_per_example: Annotated[
+        int,
+        Field(ge=1, description="Default number of rollouts per example."),
+    ] = 1
+
+    max_concurrent: Annotated[
+        int,
+        Field(description="Maximum concurrent requests. -1 for unlimited."),
+    ] = 32
+
+    # Watcher configuration
+    watcher: WatcherConfig = Field(default_factory=WatcherConfig)
+
+    # Logging configuration
+    wandb: Annotated[
+        WandbWithExtrasConfig | None,
+        Field(description="Weights & Biases configuration. If None, wandb is disabled."),
+    ] = None
+
+    log: LogConfig = Field(default_factory=LogConfig)
+
+    # Output configuration
+    output_dir: Annotated[
+        Path,
+        Field(description="Directory for output files."),
+    ] = Path("outputs")

--- a/src/prime_rl/eval/eval.py
+++ b/src/prime_rl/eval/eval.py
@@ -1,0 +1,210 @@
+import asyncio
+import time
+from pathlib import Path
+
+import numpy as np
+import verifiers as vf
+from loguru import logger
+
+from prime_rl.eval.config import EvalEnvConfig, OfflineEvalConfig
+from prime_rl.utils.client import setup_inference_pool
+from prime_rl.utils.logger import setup_logger
+from prime_rl.utils.monitor import get_monitor, setup_monitor
+from prime_rl.utils.pydantic_config import parse_argv
+from prime_rl.utils.utils import clean_exit, install_env
+
+
+def get_sampling_args(config: OfflineEvalConfig) -> dict:
+    """Build sampling args dict from config."""
+    return config.sampling.to_dict()
+
+
+async def run_eval(
+    env: vf.Environment,
+    env_config: EvalEnvConfig,
+    config: OfflineEvalConfig,
+    ckpt_step: int | None = None,
+) -> dict:
+    """Run evaluation on a single environment and return metrics."""
+    env_name = env_config.name or env_config.env_id
+    num_examples = env_config.num_examples or config.num_examples
+    rollouts_per_example = env_config.rollouts_per_example or config.rollouts_per_example
+
+    logger.info(f"Evaluating {env_name} ({num_examples=}, {rollouts_per_example=})")
+
+    # Build client config for verifiers
+    base_urls = config.client.base_url
+    vf_client = vf.ClientConfig(
+        api_base_url=base_urls[0],  # verifiers only supports single URL
+        api_key_var=config.client.api_key_var,
+        timeout=float(config.client.timeout),
+        extra_headers=config.client.headers,
+    )
+
+    sampling_args = get_sampling_args(config)
+    eval_start = time.perf_counter()
+
+    outputs = await env.evaluate(
+        client=vf_client,
+        model=config.model.name,
+        sampling_args=sampling_args,
+        num_examples=num_examples,
+        rollouts_per_example=rollouts_per_example,
+        max_concurrent=config.max_concurrent,
+        use_tqdm=True,
+    )
+
+    eval_time = time.perf_counter() - eval_start
+
+    # Extract metrics
+    rewards = [o["reward"] for o in outputs["outputs"]]
+    completion_lens = []
+    truncated_count = 0
+
+    for o in outputs["outputs"]:
+        if o.get("completion"):
+            completion_lens.append(len(o["completion"]))
+        if o.get("is_truncated"):
+            truncated_count += 1
+
+    avg_reward = np.mean(rewards) if rewards else 0.0
+    std_reward = np.std(rewards) if rewards else 0.0
+    avg_completion_len = np.mean(completion_lens) if completion_lens else 0.0
+    truncated_pct = (truncated_count / len(outputs["outputs"]) * 100) if outputs["outputs"] else 0.0
+
+    logger.success(
+        f"Evaluated {env_name} in {eval_time:.2f}s "
+        f"(Avg: {avg_reward:.4f}, Std: {std_reward:.4f}, "
+        f"Completion Len: {avg_completion_len:.1f}, Truncated: {truncated_pct:.1f}%)"
+    )
+
+    # Build metrics dict
+    metrics = {
+        f"eval/{env_name}/avg": avg_reward,
+        f"eval/{env_name}/std": std_reward,
+        f"eval/{env_name}/completion_len": avg_completion_len,
+        f"eval/{env_name}/truncated_pct": truncated_pct,
+        f"eval/{env_name}/time": eval_time,
+    }
+
+    if ckpt_step is not None:
+        metrics["progress/ckpt_step"] = ckpt_step
+
+    return metrics
+
+
+async def run_evals(
+    envs: list[vf.Environment],
+    env_configs: list[EvalEnvConfig],
+    config: OfflineEvalConfig,
+    ckpt_step: int | None = None,
+) -> None:
+    """Run evaluations on all environments and log to monitor."""
+    all_metrics = {}
+
+    for env, env_config in zip(envs, env_configs):
+        metrics = await run_eval(env, env_config, config, ckpt_step)
+        all_metrics.update(metrics)
+
+    # Log all metrics
+    monitor = get_monitor()
+    monitor.log(all_metrics, step=None)
+
+
+def get_stable_checkpoints(weights_dir: Path) -> list[int]:
+    """Get sorted list of checkpoint steps that have STABLE marker."""
+    ckpt_steps = []
+    for step_path in weights_dir.glob("step_*"):
+        if (step_path / "STABLE").exists():
+            try:
+                step = int(step_path.name.split("_")[-1])
+                ckpt_steps.append(step)
+            except ValueError:
+                continue
+    return sorted(ckpt_steps)
+
+
+@clean_exit
+async def eval(config: OfflineEvalConfig):
+    """Main evaluation function."""
+    # Setup logger
+    setup_logger(
+        config.log.level,
+        log_file=config.output_dir / "logs" / "eval.log" if config.log.file else None,
+        json_logging=config.log.json_logging,
+    )
+    logger.info("Starting offline evaluation")
+
+    # Setup monitor (wandb)
+    setup_monitor(
+        wandb_config=config.wandb,
+        output_dir=config.output_dir,
+        run_config=config,
+    )
+
+    # Install environments
+    for env_config in config.env:
+        install_env(env_config.env_id)
+
+    # Load environments
+    logger.info(f"Loading {len(config.env)} environment(s)")
+    envs: list[vf.Environment] = []
+    for env_config in config.env:
+        env = vf.load_environment(env_config.env_id, **env_config.env_args)
+        await env.start_server()
+        envs.append(env)
+
+    # Setup inference pool if watcher mode (for weight reloading)
+    inference_pool = None
+    if config.watcher.enabled:
+        if config.watcher.weights_dir is None:
+            raise ValueError("weights_dir is required when watcher is enabled")
+        inference_pool = await setup_inference_pool(config.client, model_name=config.model.name)
+        await inference_pool.wait_for_ready(config.model.name)
+
+    try:
+        if not config.watcher.enabled:
+            # Single evaluation run
+            await run_evals(envs, config.env, config)
+        else:
+            # Watcher mode
+            weights_dir = config.watcher.weights_dir
+            assert weights_dir is not None
+
+            logger.info(f"Watching {weights_dir} for new checkpoints")
+            max_evaluated_step = -1
+
+            while True:
+                ckpt_steps = get_stable_checkpoints(weights_dir)
+                new_steps = [s for s in ckpt_steps if s > max_evaluated_step]
+
+                if new_steps:
+                    logger.info(f"New checkpoints to evaluate: {new_steps}")
+                    for ckpt_step in new_steps:
+                        # Reload weights
+                        weights_path = weights_dir / f"step_{ckpt_step}"
+                        logger.info(f"Reloading weights from {weights_path}")
+
+                        assert inference_pool is not None
+                        await inference_pool.update_weights(weights_path, step=ckpt_step)
+
+                        # Run evals
+                        await run_evals(envs, config.env, config, ckpt_step)
+                        max_evaluated_step = ckpt_step
+                else:
+                    logger.info(f"No new checkpoints, waiting {config.watcher.poll_interval}s")
+                    await asyncio.sleep(config.watcher.poll_interval)
+
+    finally:
+        # Cleanup
+        for env in envs:
+            await env.stop_server()
+
+
+def main():
+    config = parse_argv(OfflineEvalConfig)
+    asyncio.run(eval(config))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a new standalone `eval` CLI command that wraps verifiers evaluation with:
- **Checkpoint watcher mode** - continuously monitors a directory for new checkpoints and evaluates them as they appear
- **WandB integration** - logs evaluation metrics to Weights & Biases  
- **Prime-rl style config/CLI** - uses the same pydantic-settings pattern as other commands

## Usage

```bash
# Single evaluation
uv run eval @ configs/eval/example.toml

# With watcher mode
uv run eval @ configs/eval/example.toml --watcher.enabled --watcher.weights-dir /path/to/checkpoints

# With wandb
uv run eval @ configs/eval/example.toml --wandb.project my-project
```

## Example config

```toml
[model]
name = "Qwen/Qwen3-0.6B"

[client]
base_url = ["http://localhost:8000/v1"]

[[env]]
env_id = "reverse-text"

[sampling]
max_tokens = 2048

num_examples = 100
rollouts_per_example = 1

[watcher]
enabled = true
weights_dir = "/path/to/checkpoints"
poll_interval = 10

[wandb]
project = "prime-rl"
```

## Test plan

- [ ] Test single evaluation run
- [ ] Test watcher mode with checkpoint directory
- [ ] Test wandb logging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new evaluation entrypoint that drives async environment servers, external inference endpoints, and optional checkpoint hot-reloading; misconfiguration or long-running watcher loops could cause operational issues but it’s isolated from training/auth paths.
> 
> **Overview**
> Adds a new standalone `eval` CLI command (via `pyproject.toml`) for running offline evaluations through `verifiers`, driven by a new pydantic-settings config (`OfflineEvalConfig`) and an example TOML config.
> 
> The evaluator supports per-environment overrides and sampling controls, computes and logs aggregate reward/completion metrics, and can optionally run in *watcher mode* that polls a weights directory for `step_*` checkpoints marked `STABLE`, reloads inference server weights, and re-runs evals while logging metrics via the existing monitor/W&B integration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0753be0dbf777b359906fe9e99f657c241c5eb73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->