### PR TITLE
feat: Add AMD Instinct MI300X/MI325X peak FLOPS for MFU calculation

### DIFF
--- a/src/prime_rl/trainer/perf.py
+++ b/src/prime_rl/trainer/perf.py
@@ -75,6 +75,15 @@ class PerfCounter:
         if "B200" in device_name:
             # https://nvdam.widen.net/s/wwnsxrhm2w/blackwell-datasheet-3384703
             return 2.25e15  # This is half of the FLOPS reported in torchtitan
+        # AMD Instinct GPUs
+        if "MI300X" in device_name:
+            # https://www.amd.com/en/products/accelerators/instinct/mi300/mi300x.html
+            # Peak BF16: 1307.4 TFLOPS (matrix)
+            return 1307.4e12
+        if "MI325X" in device_name:
+            # https://www.amd.com/en/products/accelerators/instinct/mi300/mi325x.html
+            # Peak BF16: 1307.4 TFLOPS (matrix) - same compute dies as MI300X, more HBM3e
+            return 1307.4e12
         else:
             self._logger.warning(f"Peak FLOPS undefined for `{device_name}`. Falling back to A100 (312 TFLOPS)")
             return 312e12


### PR DESCRIPTION
## Summary
- Add peak BF16 FLOPS specifications for AMD Instinct accelerators
- MI300X: 1307.4 TFLOPS
- MI325X: 1307.4 TFLOPS (same compute dies as MI300X, more HBM3e memory)

This enables accurate MFU reporting when training on AMD GPUs instead of falling back to A100 baseline which produces misleading >100% MFU values.

## Test plan
- [x] Tested on AMD MI325X cluster - MFU now shows realistic ~30-40% instead of >100%

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, data-only change limited to device-name-to-FLOPS mapping used for MFU reporting; no impact on training logic or model outputs beyond reported metrics.
> 
> **Overview**
> MFU peak-throughput estimation now recognizes AMD Instinct `MI300X` and `MI325X` device names and uses their published peak BF16 (matrix) FLOPS (1307.4 TFLOPS) instead of warning and falling back to the A100 baseline.
> 
> This change only affects the `_get_peak_flops` lookup used by `PerfCounter.get_mfu`, improving MFU accuracy on AMD GPUs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d7dab80f1441cbc164ffdfb200e317c576c814b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->