### PR TITLE
Strip @version from env IDs before module loading

### DIFF
--- a/src/prime_rl/eval/utils.py
+++ b/src/prime_rl/eval/utils.py
@@ -25,7 +25,7 @@ from prime_rl.utils.config import ClientConfig
 from prime_rl.utils.elastic import ServerDiscovery
 from prime_rl.utils.logger import ProgressTracker, get_logger, intercept_verifiers_logging, reset_logger, setup_logger
 from prime_rl.utils.monitor import get_monitor
-from prime_rl.utils.utils import capitalize, get_eval_dir, get_step_path
+from prime_rl.utils.utils import capitalize, get_eval_dir, get_step_path, strip_env_version
 from prime_rl.utils.vf import (
     generate_group,
     generate_rollout,
@@ -302,7 +302,7 @@ async def run_eval(
 
     # Load the eval environment
     env_name_or_id = env_name or env_id
-    env = load_environment(env_id, **env_args)
+    env = load_environment(strip_env_version(env_id), **env_args)
     dataset = env.get_eval_dataset(n=num_examples)
     sampling_args = prepare_sampling_args(sampling_config)
 

--- a/src/prime_rl/orchestrator/env_worker.py
+++ b/src/prime_rl/orchestrator/env_worker.py
@@ -21,6 +21,7 @@ from prime_rl.utils.client import setup_clients
 from prime_rl.utils.config import ClientConfig
 from prime_rl.utils.elastic import ServerDiscovery
 from prime_rl.utils.logger import get_logger, intercept_verifiers_logging, reset_logger, setup_logger
+from prime_rl.utils.utils import strip_env_version
 
 
 class WorkerDiedError(Exception):
@@ -240,7 +241,7 @@ def worker_main(
         intercept_verifiers_logging(level=vf_log_level)
 
     # Load environment
-    env = vf.load_environment(env_id, **env_args)
+    env = vf.load_environment(strip_env_version(env_id), **env_args)
     env.set_max_seq_len(seq_len)
     env.set_interleaved_rollouts(interleaved_rollouts)
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -57,6 +57,7 @@ from prime_rl.utils.utils import (
     get_env_ids_to_install,
     install_env,
     resolve_latest_ckpt_step,
+    strip_env_version,
     to_col_format,
 )
 from prime_rl.utils.vf import generate_batch, get_completion_len, get_prompt_len, get_seq_len
@@ -155,7 +156,7 @@ async def orchestrate(config: OrchestratorConfig):
         f"Loading {len(config.env)} training environment(s) ({', '.join(env.name or env.id for env in config.env)})"
     )
     env = vf.EnvGroup(
-        envs=[vf.load_environment(env.id, **env.args) for env in config.env],
+        envs=[vf.load_environment(strip_env_version(env.id), **env.args) for env in config.env],
         env_names=[env.name or env.id for env in config.env],
         map_kwargs=dict(writer_batch_size=1),  # Set defensively to not error on map operations on large datasets
     )

--- a/src/prime_rl/synthesize/utils.py
+++ b/src/prime_rl/synthesize/utils.py
@@ -12,6 +12,7 @@ from verifiers.utils.path_utils import get_results_path
 
 from prime_rl.orchestrator.config import ClientConfig, EvalSamplingConfig, ModelConfig
 from prime_rl.utils.logger import ProgressTracker, get_logger
+from prime_rl.utils.utils import strip_env_version
 from prime_rl.utils.vf import generate_group
 
 WRITE_LOCK = asyncio.Lock()
@@ -148,7 +149,7 @@ async def generate_synthetic_data(
 
     # Load the environment
     env_name_or_id = env_name or env_id
-    env = load_environment(env_id, **env_args)
+    env = load_environment(strip_env_version(env_id), **env_args)
     try:
         dataset = env.get_dataset(n=num_examples + skip_first)
     except ValueError:

--- a/src/prime_rl/utils/utils.py
+++ b/src/prime_rl/utils/utils.py
@@ -282,6 +282,15 @@ def default_dtype(dtype):
         torch.set_default_dtype(prev)
 
 
+def strip_env_version(env_id: str) -> str:
+    """Strip the @version suffix from an environment ID.
+
+    Environment IDs may include a version (e.g. 'd42me/meow@0.1.5') for installation,
+    but the version must be stripped before loading as a Python module.
+    """
+    return env_id.split("@")[0]
+
+
 def install_env(env_id: str) -> None:
     """Install an environment in subprocess."""
     logger = get_logger()


### PR DESCRIPTION
## Summary
- Platform sends versioned env IDs like `jack/meow@0.1.5` for installation
- `vf.load_environment()` internally calls `importlib.import_module()` which fails on `@version`
- Added `strip_env_version()` utility to strip the version suffix at all 4 `load_environment()` call sites
- `install_env()` still receives the full versioned ID as expected