### PR TITLE
Fix int64 JSON serialization in Chinese character metrics

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -601,14 +601,14 @@ async def orchestrate(config: OrchestratorConfig):
             },
             # Env metrics
             **{f"metrics/{metric}": metrics_df[metric].mean() for metric in metrics_df.columns},
-            # Chinese character metrics
-            "chinese/char_count": chinese_df.chinese_chars.sum(),
+            # Chinese character metrics (cast to native Python types for JSON serialization)
+            "chinese/char_count": int(chinese_df.chinese_chars.sum()),
             "chinese/char_ratio": (
-                chinese_df.chinese_chars.sum() / chinese_df.total_chars.sum()
+                float(chinese_df.chinese_chars.sum() / chinese_df.total_chars.sum())
                 if chinese_df.total_chars.sum() > 0
                 else 0.0
             ),
-            "chinese/rollout_ratio": chinese_df.has_chinese.mean(),
+            "chinese/rollout_ratio": float(chinese_df.has_chinese.mean()),
             # Time metrics
             "time/step": step_time,
             "time/generate_completions": generate_completions_time,


### PR DESCRIPTION
Pandas .sum() and .mean() return numpy int64/float64, which json.dumps() can't serialize. This breaks the metrics upload to the Prime Intellect API.

- Cast chinese char metrics to native Python int/float before logging

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to metrics logging that only affects types of logged values and not training behavior.
> 
> **Overview**
> Fixes metrics logging in `orchestrator.py` by casting the Chinese-character related aggregates (`chinese/char_count`, `chinese/char_ratio`, `chinese/rollout_ratio`) to native Python `int`/`float` so they can be JSON-serialized for monitor/Prime API uploads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e25671fb8e71535008be4968ad6445e38b0f2360. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->