### PR TITLE
Add replica bootstrap for fast autoscaling via NCCL

### DIFF
--- a/src/prime_rl/inference/vllm/peer_broadcast.py
+++ b/src/prime_rl/inference/vllm/peer_broadcast.py
@@ -39,7 +39,9 @@ DEFAULT_TIMEOUT = 120
 MAX_RETRIES = 3
 RETRY_DELAY = 5
 
-# Lock to prevent concurrent broadcasts from the same source
+# Lock to serialize peer broadcasts from a single source pod.
+# Without this, concurrent bootstrap requests from multiple replicas would
+# collide on the same NCCL port, causing deadlocks or connection failures.
 _broadcast_lock = threading.Lock()
 
 

--- a/src/prime_rl/inference/vllm/peer_broadcast.py
+++ b/src/prime_rl/inference/vllm/peer_broadcast.py
@@ -1,0 +1,398 @@
+"""
+Peer-to-peer weight broadcasting for fast autoscaling.
+
+When a new inference pod starts with --load-format dummy, it can discover
+healthy peers via K8s DNS and request weights via NCCL instead of loading
+from disk. This dramatically speeds up pod scaling.
+
+Flow:
+1. New pod starts with dummy weights (fast, no disk I/O)
+2. Discovers healthy peers via K8s headless service DNS
+3. Requests weights from a healthy peer via HTTP
+4. Receives weights via NCCL broadcast
+5. Loads weights into model and becomes ready
+"""
+
+import os
+import socket
+import threading
+import time
+from typing import TYPE_CHECKING
+
+import requests
+import torch
+from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
+from vllm.distributed.utils import StatelessProcessGroup
+from vllm.logger import init_logger
+
+from prime_rl.inference.vllm.worker.nccl import receive_integer, receive_state_dict
+from prime_rl.trainer.rl.broadcast.nccl import broadcast_integer, broadcast_state_dict
+
+if TYPE_CHECKING:
+    from torch.nn import Module
+
+logger = init_logger("prime_rl.inference.peer_broadcast")
+
+DEFAULT_NCCL_PORT = 29600
+DEFAULT_HTTP_PORT = 8000
+DEFAULT_TIMEOUT = 120
+MAX_RETRIES = 3
+RETRY_DELAY = 5
+
+# Lock to prevent concurrent broadcasts from the same source
+_broadcast_lock = threading.Lock()
+
+
+def get_pod_ip() -> str:
+    """Get the current pod's IP address."""
+    return os.environ.get("POD_IP", socket.gethostbyname(socket.gethostname()))
+
+
+def get_namespace() -> str | None:
+    """Get the current K8s namespace from service account or env var."""
+    # Try env var first (can be set via downward API)
+    if ns := os.environ.get("POD_NAMESPACE"):
+        return ns
+
+    # Try service account mount
+    sa_namespace_path = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+    try:
+        with open(sa_namespace_path) as f:
+            return f.read().strip()
+    except FileNotFoundError:
+        return None
+
+
+def discover_peers(headless_service: str, namespace: str) -> list[str]:
+    """
+    Discover peer pod IPs via K8s headless service DNS.
+
+    Args:
+        headless_service: Name of the headless service (e.g., "my-app-inference-headless")
+        namespace: K8s namespace
+
+    Returns:
+        List of peer IP addresses (excluding self)
+    """
+    my_ip = get_pod_ip()
+    dns_name = f"{headless_service}.{namespace}.svc.cluster.local"
+
+    logger.info(f"Discovering peers via DNS: {dns_name}")
+
+    try:
+        _, _, ips = socket.gethostbyname_ex(dns_name)
+        peers = [ip for ip in ips if ip != my_ip]
+        logger.info(f"Found {len(peers)} peers: {peers}")
+        return peers
+    except socket.gaierror as e:
+        logger.warning(f"DNS lookup failed for {dns_name}: {e}")
+        return []
+
+
+def find_healthy_peer(
+    peers: list[str],
+    http_port: int = DEFAULT_HTTP_PORT,
+    timeout: float = 5.0,
+) -> str | None:
+    """
+    Find a peer that is healthy and has model loaded.
+
+    Args:
+        peers: List of peer IP addresses
+        http_port: HTTP port to check health on
+        timeout: Request timeout in seconds
+
+    Returns:
+        IP of healthy peer, or None if no healthy peer found
+    """
+    for ip in peers:
+        try:
+            resp = requests.get(f"http://{ip}:{http_port}/health", timeout=timeout)
+            if resp.status_code == 200:
+                data = resp.json()
+                # Check if peer has model loaded (not using dummy weights)
+                if data.get("model_loaded", False):
+                    logger.info(f"Found healthy peer with model: {ip}")
+                    return ip
+        except requests.RequestException as e:
+            logger.debug(f"Peer {ip} not ready: {e}")
+        except Exception as e:
+            logger.warning(f"Unexpected error checking peer {ip}: {e}")
+
+    logger.warning("No healthy peer with model found")
+    return None
+
+
+def receive_weights_from_peer(
+    peer_ip: str,
+    http_port: int = DEFAULT_HTTP_PORT,
+    nccl_port: int = DEFAULT_NCCL_PORT,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> dict[str, torch.Tensor]:
+    """
+    Request and receive weights from a peer via NCCL.
+
+    The peer acts as rank 0 (TCP store master), we are rank 1.
+
+    Args:
+        peer_ip: IP address of the peer to receive from
+        http_port: HTTP port for triggering broadcast on peer
+        nccl_port: Port for NCCL communication
+        timeout: Timeout for NCCL operations
+
+    Returns:
+        State dict with received weights
+
+    Raises:
+        RuntimeError: If weight transfer fails
+    """
+    import concurrent.futures
+
+    logger.info(f"Requesting weights from peer {peer_ip}:{nccl_port}")
+
+    received_weights: dict[str, torch.Tensor] = {}
+    receive_error: Exception | None = None
+    receiver_ready = threading.Event()
+
+    def do_receive():
+        nonlocal received_weights, receive_error
+
+        pg = None
+        comm = None
+        try:
+            # Connect to peer's TCP store (peer is rank 0 master, we're rank 1)
+            logger.info(f"Connecting to NCCL at {peer_ip}:{nccl_port}...")
+            pg = StatelessProcessGroup.create(
+                host=peer_ip,
+                port=nccl_port,
+                rank=1,
+                world_size=2,
+                store_timeout=timeout,
+            )
+            comm = PyNcclCommunicator(pg, device=torch.cuda.current_device())
+            logger.info("NCCL connected!")
+
+            # Signal that we're ready to receive
+            receiver_ready.set()
+
+            start = time.time()
+            num_chunks = receive_integer(comm)
+            logger.info(f"Expecting {num_chunks} weight chunks")
+
+            for i in range(num_chunks):
+                for key, tensor in receive_state_dict(comm):
+                    received_weights[key] = tensor
+                logger.debug(f"Received chunk {i + 1}/{num_chunks}")
+
+            torch.cuda.synchronize()
+            elapsed = time.time() - start
+            size_gb = sum(p.numel() * p.element_size() for p in received_weights.values()) / 1e9
+            logger.info(f"Received {len(received_weights)} tensors ({size_gb:.2f}GB) in {elapsed:.2f}s")
+
+        except Exception as e:
+            receive_error = e
+            receiver_ready.set()  # Unblock main thread even on error
+            raise
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        recv_future = executor.submit(do_receive)
+
+        # Wait for receiver to be ready (with timeout)
+        if not receiver_ready.wait(timeout=30):
+            raise RuntimeError("Timeout waiting for NCCL receiver to initialize")
+
+        # Check for early errors
+        if receive_error:
+            raise RuntimeError(f"Receiver failed during setup: {receive_error}")
+
+        # Trigger peer to start broadcasting
+        logger.info("Triggering broadcast on peer...")
+        try:
+            resp = requests.post(
+                f"http://{peer_ip}:{http_port}/broadcast_weights_to_peer",
+                json={"nccl_port": nccl_port},
+                timeout=600,  # Weight transfer can take a while for large models
+            )
+
+            if resp.status_code != 200:
+                raise RuntimeError(f"Peer broadcast failed: {resp.text}")
+
+            logger.info("Peer broadcast request accepted")
+
+        except requests.RequestException as e:
+            raise RuntimeError(f"Failed to trigger broadcast on peer: {e}")
+
+        # Wait for receive to complete
+        try:
+            recv_future.result(timeout=timeout)
+        except concurrent.futures.TimeoutError:
+            raise RuntimeError(f"Weight transfer timed out after {timeout}s")
+
+    return received_weights
+
+
+def broadcast_weights_to_peer(
+    model: "Module",
+    nccl_port: int = DEFAULT_NCCL_PORT,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> None:
+    """
+    Broadcast model weights to a requesting peer via NCCL.
+
+    We act as rank 0 (TCP store master), peer is rank 1.
+    Uses a lock to prevent concurrent broadcasts.
+
+    Args:
+        model: The model to broadcast weights from
+        nccl_port: Port for NCCL communication
+        timeout: Timeout for NCCL operations
+
+    Raises:
+        RuntimeError: If another broadcast is in progress
+    """
+    if not _broadcast_lock.acquire(blocking=False):
+        raise RuntimeError("Another broadcast is already in progress")
+
+    try:
+        my_ip = get_pod_ip()
+        logger.info(f"Broadcasting weights on {my_ip}:{nccl_port}")
+
+        # Create TCP store as master (rank 0)
+        pg = StatelessProcessGroup.create(
+            host=my_ip,
+            port=nccl_port,
+            rank=0,
+            world_size=2,
+            store_timeout=timeout,
+        )
+        comm = PyNcclCommunicator(pg, device=torch.cuda.current_device())
+        logger.info("NCCL connected, starting broadcast...")
+
+        state_dict = model.state_dict()
+
+        # Count layers for chunked transfer
+        layer_keys = [k for k in state_dict if "model.layers." in k]
+        if layer_keys:
+            num_layers = max(int(k.split(".")[2]) for k in layer_keys) + 1
+        else:
+            num_layers = 0
+
+        num_chunks = num_layers + 1  # layers + non-layer weights
+
+        start = time.time()
+
+        # Broadcast number of chunks
+        broadcast_integer(num_chunks, comm)
+
+        # Broadcast non-layer weights first
+        non_layer = {k: v for k, v in state_dict.items() if "model.layers." not in k}
+        broadcast_state_dict(non_layer, comm)
+
+        # Broadcast each layer
+        for i in range(num_layers):
+            layer_dict = {k: v for k, v in state_dict.items() if f"model.layers.{i}." in k}
+            broadcast_state_dict(layer_dict, comm)
+
+        torch.cuda.synchronize()
+        elapsed = time.time() - start
+        size_gb = sum(p.numel() * p.element_size() for p in state_dict.values()) / 1e9
+        logger.info(f"Broadcast complete: {size_gb:.2f}GB in {elapsed:.2f}s ({size_gb / elapsed:.1f} GB/s)")
+
+    finally:
+        _broadcast_lock.release()
+
+
+def fetch_weights_from_peer(
+    model: "Module",
+    headless_service: str | None = None,
+    namespace: str | None = None,
+    peer_ip: str | None = None,
+    http_port: int = DEFAULT_HTTP_PORT,
+    nccl_port: int = DEFAULT_NCCL_PORT,
+    retries: int = MAX_RETRIES,
+) -> bool:
+    """
+    Discover a healthy peer and fetch weights from it via NCCL.
+
+    This is the main entry point for new pods starting with --load-format dummy.
+    Call this after the model is initialized with dummy weights.
+
+    Can use either K8s DNS discovery OR direct peer IP:
+    - K8s mode: provide headless_service and namespace
+    - Direct mode: provide peer_ip
+
+    Args:
+        model: The model to load weights into
+        headless_service: K8s headless service name for peer discovery (optional)
+        namespace: K8s namespace (optional)
+        peer_ip: Direct peer IP address to fetch from (optional, skips discovery)
+        http_port: HTTP port for health checks and broadcast trigger
+        nccl_port: Port for NCCL communication
+        retries: Number of retry attempts on failure
+
+    Returns:
+        True if weights were fetched from peer, False if no peer available
+    """
+    target_ip = peer_ip
+
+    # If no direct peer IP, use K8s DNS discovery
+    if not target_ip:
+        if not headless_service:
+            logger.error("Must provide either peer_ip or headless_service")
+            return False
+
+        # Auto-detect namespace if not provided
+        resolved_namespace = namespace or get_namespace()
+        if not resolved_namespace:
+            logger.error("Namespace not provided and could not be auto-detected")
+            return False
+
+        # Discover peers via DNS
+        peers = discover_peers(headless_service, resolved_namespace)
+        if not peers:
+            logger.info("No peers found, will need to load from disk")
+            return False
+
+        # Find a healthy peer with model loaded
+        target_ip = find_healthy_peer(peers, http_port=http_port)
+        if not target_ip:
+            logger.info("No healthy peer with model, will need to load from disk")
+            return False
+    else:
+        # Direct mode - verify peer is healthy
+        logger.info(f"Using direct peer IP: {target_ip}")
+        if not find_healthy_peer([target_ip], http_port=http_port):
+            logger.warning(f"Peer {target_ip} not healthy or model not loaded")
+            return False
+
+    # Receive weights from peer with retries
+    last_error: Exception | None = None
+    for attempt in range(retries):
+        try:
+            logger.info(f"Fetching weights from peer {target_ip} (attempt {attempt + 1}/{retries})")
+            weights = receive_weights_from_peer(
+                target_ip,
+                http_port=http_port,
+                nccl_port=nccl_port,
+            )
+
+            # Validate we got weights
+            if not weights:
+                raise RuntimeError("Received empty weight dict")
+
+            # Load weights into model
+            logger.info(f"Loading {len(weights)} tensors into model...")
+            model.load_weights(weights.items())
+
+            logger.info("Weights loaded from peer successfully!")
+            return True
+
+        except Exception as e:
+            last_error = e
+            logger.warning(f"Attempt {attempt + 1} failed: {e}")
+            if attempt < retries - 1:
+                logger.info(f"Retrying in {RETRY_DELAY}s...")
+                time.sleep(RETRY_DELAY)
+
+    logger.error(f"Failed to fetch weights after {retries} attempts: {last_error}")
+    return False

--- a/src/prime_rl/inference/vllm/worker/filesystem.py
+++ b/src/prime_rl/inference/vllm/worker/filesystem.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 from torch.nn import Module
+from vllm.logger import init_logger
 from vllm.model_executor.model_loader import DefaultModelLoader, get_model_loader
 from vllm.model_executor.model_loader.utils import process_weights_after_loading
 
@@ -11,6 +12,8 @@ if TYPE_CHECKING:
     Worker = Worker
 else:
     Worker = object
+
+logger = init_logger("prime_rl.inference.vllm.worker.filesystem")
 
 
 class FileSystemWeightUpdateWorker(Worker):
@@ -47,3 +50,91 @@ class FileSystemWeightUpdateWorker(Worker):
         # Process weights after loading (important for some models)
         device = next(model.parameters()).device
         process_weights_after_loading(model, self.model_runner.model_config, device)
+
+    def broadcast_to_peer(self, nccl_port: int = 29600) -> None:
+        """
+        Broadcast model weights to a peer pod via NCCL.
+
+        Called when a newly scaled pod requests weights. This pod acts as the
+        TCP store master (rank 0), the requesting peer is rank 1.
+
+        Uses NCCL which auto-detects the best transport:
+        - NVLink for same-node (~900 GB/s)
+        - InfiniBand for cross-node with RDMA (~400 GB/s)
+        - TCP sockets as fallback (~1-25 GB/s depending on network)
+
+        Args:
+            nccl_port: Port for NCCL communication
+        """
+        from prime_rl.inference.vllm.peer_broadcast import broadcast_weights_to_peer
+
+        # Get model from worker
+        model_runner = self.model_runner
+        if hasattr(model_runner.model, "runnable"):
+            model = model_runner.model.runnable
+        else:
+            model = model_runner.model
+        assert isinstance(model, Module)
+
+        logger.info(f"Broadcasting weights to peer on port {nccl_port}")
+        broadcast_weights_to_peer(model, nccl_port=nccl_port)
+
+    def fetch_weights_from_peer(
+        self,
+        headless_service: str | None = None,
+        namespace: str | None = None,
+        peer_ip: str | None = None,
+        http_port: int = 8000,
+        nccl_port: int = 29600,
+    ) -> bool:
+        """
+        Fetch model weights from a healthy peer pod via NCCL.
+
+        Called when starting with --load-format dummy to quickly receive weights
+        from an existing pod instead of loading from disk.
+
+        Can use either K8s DNS discovery OR direct peer IP:
+        - K8s mode: provide headless_service and namespace
+        - Direct mode: provide peer_ip
+
+        Args:
+            headless_service: K8s headless service name for peer discovery (optional)
+            namespace: K8s namespace (optional)
+            peer_ip: Direct peer IP address to fetch from (optional)
+            http_port: HTTP port for health checks and broadcast trigger
+            nccl_port: Port for NCCL communication
+
+        Returns:
+            True if weights were fetched, False if no peer available
+        """
+        from prime_rl.inference.vllm.peer_broadcast import fetch_weights_from_peer
+
+        # Get model from worker
+        model_runner = self.model_runner
+        if hasattr(model_runner.model, "runnable"):
+            model = model_runner.model.runnable
+        else:
+            model = model_runner.model
+        assert isinstance(model, Module)
+
+        if peer_ip:
+            logger.info(f"Attempting to fetch weights from peer {peer_ip}")
+        else:
+            logger.info(f"Attempting to fetch weights from peer in {namespace}/{headless_service}")
+
+        success = fetch_weights_from_peer(
+            model,
+            headless_service=headless_service,
+            namespace=namespace,
+            peer_ip=peer_ip,
+            http_port=http_port,
+            nccl_port=nccl_port,
+        )
+
+        if success:
+            # Process weights after loading
+            device = next(model.parameters()).device
+            process_weights_after_loading(model, self.model_runner.model_config, device)
+            logger.info("Weights from peer loaded and processed successfully")
+
+        return success


### PR DESCRIPTION
Adds replica bootstrap - new inference replicas can fetch weights from existing peers via NCCL instead of loading from disk.

## How it works
- New pod starts with `--load-format dummy` (fast init, no disk I/O)
- Discovers healthy peers via K8s headless service DNS or direct IP
- Fetches weights via NCCL (auto-selects NVLink/InfiniBand/TCP)
- Loads weights and becomes ready

## Performance
- 30B model: ~30s via InfiniBand vs ~7min from NFS
- 1.5GB test model: 0.36s transfer (~4.2 GB/s cross-node)

## Usage

### Single node, multiple GPUs
```bash
# Terminal 1 - Source (GPU 0, normal load)
export POD_IP=$(hostname -I | awk '{print $1}')
export CUDA_VISIBLE_DEVICES=0
uv run inference --model.name your-model --server.port 8000

# Terminal 2 - Target (GPU 1, bootstrap from peer)
export POD_IP=$(hostname -I | awk '{print $1}')
export CUDA_VISIBLE_DEVICES=1
uv run inference --model.name your-model --server.port 8001   --replica-bootstrap.enabled   --replica-bootstrap.peer-ip $POD_IP   --replica-bootstrap.http-port 8000   --load-format dummy
```

### Kubernetes with headless service
```bash
uv run inference --model.name your-model   --replica-bootstrap.enabled   --replica-bootstrap.headless-service my-inference-headless   --load-format dummy
```
Namespace is auto-detected from service account.

## Config options
- `--replica-bootstrap.enabled` - Enable bootstrap on startup
- `--replica-bootstrap.peer-ip` - Direct peer IP (non-K8s)
- `--replica-bootstrap.headless-service` - K8s headless service name
- `--replica-bootstrap.namespace` - K8s namespace (auto-detected)
- `--replica-bootstrap.nccl-port` - NCCL port (default: 29600)
- `--replica-bootstrap.http-port` - HTTP port for health check (default: 8000)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches inference server startup and adds new network/RPC paths that coordinate NCCL + HTTP between pods; failures or misconfiguration could leave replicas running with dummy weights or impact availability during scaling.
> 
> **Overview**
> Adds **replica bootstrap** so new inference replicas started with `--load-format dummy` can pull model weights from an existing healthy peer over NCCL instead of loading from disk.
> 
> This introduces `ReplicaBootstrapConfig` in `InferenceConfig`, adds a new `peer_broadcast.py` implementation for K8s DNS peer discovery + health checking + chunked NCCL transfer, and wires it into the vLLM API server via new `/broadcast_weights_to_peer` and `/fetch_weights_from_peer` routes plus startup auto-fetch when enabled. The `FileSystemWeightUpdateWorker` now implements `broadcast_to_peer`/`fetch_weights_from_peer` RPCs to serve and consume these transfers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41e04fc922dc51eb3d115141eb13f66f1c54b5bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->