### PR TITLE
Fix broadcast alpha rank

### DIFF
--- a/examples/alphabet_sort/rl.toml
+++ b/examples/alphabet_sort/rl.toml
@@ -19,6 +19,9 @@ freq = 1
 
 [trainer.model.lora]
 rank = 32
+
+[orchestrator.model.lora]
+rank = 32
 alpha = 64
 
 [trainer.optim]

--- a/examples/alphabet_sort/rl.toml
+++ b/examples/alphabet_sort/rl.toml
@@ -19,9 +19,6 @@ freq = 1
 
 [trainer.model.lora]
 rank = 32
-
-[orchestrator.model.lora]
-rank = 32
 alpha = 64
 
 [trainer.optim]

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -48,12 +48,12 @@ class LoRAConfig(BaseConfig):
     ] = None
 
     alpha: Annotated[
-        float,
+        float | None,
         Field(
             ge=0,
-            description="LoRA alpha for this run.",
+            description="LoRA alpha for this run. If None, uses trainer's alpha.",
         ),
-    ] = 32.0
+    ] = None
 
 
 class ModelConfig(BaseModelConfig):

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -433,9 +433,39 @@ class RLConfig(BaseSettings):
 
                 self.orchestrator.model.lora = LoRAConfig()
 
+            # Validate orchestrator LoRA rank/alpha don't conflict with trainer
+            if (
+                self.orchestrator.model.lora.rank is not None
+                and self.orchestrator.model.lora.rank != self.trainer.model.lora.rank
+            ):
+                raise ValueError(
+                    f"orchestrator.model.lora.rank ({self.orchestrator.model.lora.rank}) conflicts with "
+                    f"trainer.model.lora.rank ({self.trainer.model.lora.rank}). "
+                    f"Remove orchestrator.model.lora.rank to inherit from trainer, or update trainer.model.lora.rank to match."
+                )
+
+            if (
+                self.orchestrator.model.lora.alpha is not None
+                and self.orchestrator.model.lora.alpha != self.trainer.model.lora.alpha
+            ):
+                raise ValueError(
+                    f"orchestrator.model.lora.alpha ({self.orchestrator.model.lora.alpha}) conflicts with "
+                    f"trainer.model.lora.alpha ({self.trainer.model.lora.alpha}). "
+                    f"Remove orchestrator.model.lora.alpha to inherit from trainer, or update trainer.model.lora.alpha to match."
+                )
+
+            # Propagate rank/alpha from trainer when not explicitly set
+            if self.orchestrator.model.lora.rank is None:
+                self.orchestrator.model.lora.rank = self.trainer.model.lora.rank
+
+            if self.orchestrator.model.lora.alpha is None:
+                self.orchestrator.model.lora.alpha = self.trainer.model.lora.alpha
+
             # Auto-generate name if not provided
             if self.orchestrator.model.lora.name is None:
-                self.orchestrator.model.lora.name = f"r{self.trainer.model.lora.rank}-a{self.trainer.model.lora.alpha}"
+                self.orchestrator.model.lora.name = (
+                    f"r{self.orchestrator.model.lora.rank}-a{self.orchestrator.model.lora.alpha}"
+                )
 
             if self.inference is not None:
                 self.inference.enable_lora = True

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -328,7 +328,13 @@ class WeightCheckpointManager:
             adapter_path.mkdir(parents=True, exist_ok=True)
             torch.save(lora_state_dict, adapter_path / "adapter_model.bin")
             if self.lora_config:
-                save_lora_config(self.lora_config, model, adapter_path)  # Pass model
+                save_lora_config(
+                    model,
+                    adapter_path,
+                    rank=self.lora_config.rank,
+                    alpha=self.lora_config.alpha,
+                    dropout=self.lora_config.dropout,
+                )
         self.logger.debug(f"Saved weight checkpoint to {path} in {time.perf_counter() - start_time:.2f} seconds")
 
     def save(

--- a/src/prime_rl/trainer/lora.py
+++ b/src/prime_rl/trainer/lora.py
@@ -234,14 +234,16 @@ def clean_lora_state_dict(state_dict: Dict[str, torch.Tensor]) -> Dict[str, torc
     return clean_state_dict
 
 
-def save_lora_config(config: LoRAConfig, model: nn.Module, save_path) -> None:
+def save_lora_config(model: nn.Module, save_path, rank: int, alpha: float, dropout: float) -> None:
     """
     Save LoRA configuration as JSON for adapter portability.
 
     Args:
-        config: LoRA configuration to save
         model: Model with LoRA layers to introspect
         save_path: Path object or string pointing to directory where adapter_config.json will be saved
+        rank: LoRA rank
+        alpha: LoRA alpha scaling parameter
+        dropout: LoRA dropout rate
     """
     import json
     from pathlib import Path
@@ -266,9 +268,9 @@ def save_lora_config(config: LoRAConfig, model: nn.Module, save_path) -> None:
         "peft_type": "LORA",
         "task_type": "CAUSAL_LM",
         "base_model_name_or_path": model.config._name_or_path,
-        "r": config.rank,
-        "lora_alpha": config.alpha,
-        "lora_dropout": config.dropout,
+        "r": rank,
+        "lora_alpha": alpha,
+        "lora_dropout": dropout,
         "bias": "none",
         "target_modules": sorted(list(target_modules)),
         "modules_to_save": sorted(list(modules_to_save)) if modules_to_save else None,

--- a/src/prime_rl/trainer/rl/broadcast/filesystem.py
+++ b/src/prime_rl/trainer/rl/broadcast/filesystem.py
@@ -74,7 +74,14 @@ class FileSystemWeightBroadcast(WeightBroadcast):
                     self.logger.debug(f"Saving weights for run {idx} to {save_dir}")
                     save_state_dict(state_dict, save_dir, self.save_format, self.save_sharded, adapter=adapter_only)
                     if adapter_only:
-                        save_lora_config(self.lora_config, model, save_dir)
+                        orch_lora = self.multi_run_manager.config[idx].model.lora
+                        save_lora_config(
+                            model,
+                            save_dir,
+                            rank=orch_lora.rank,
+                            alpha=orch_lora.alpha,
+                            dropout=self.lora_config.dropout,
+                        )
 
                     self._notify_orchestrator(save_dir)
 

--- a/src/prime_rl/trainer/runs.py
+++ b/src/prime_rl/trainer/runs.py
@@ -496,9 +496,11 @@ def setup_multi_run_manager(
         trainer_lora = lora_config
 
         def validate_lora_rank(orch_config: "OrchestratorConfig") -> tuple[bool, str]:
-            # Default to trainer's rank if not specified
+            # Default to trainer's rank/alpha if not specified
             if orch_config.model.lora.rank is None:
                 orch_config.model.lora.rank = trainer_lora.rank
+            if orch_config.model.lora.alpha is None:
+                orch_config.model.lora.alpha = trainer_lora.alpha
             if orch_config.model.lora.rank > trainer_lora.rank:
                 return (
                     False,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches LoRA configuration propagation and adapter checkpoint/broadcast metadata, which can affect multi-run scaling behavior and checkpoint compatibility if misconfigured.
> 
> **Overview**
> Aligns per-run LoRA `rank`/`alpha` handling between trainer and orchestrator so multi-run broadcasts and adapter metadata use the correct values.
> 
> `orchestrator.model.lora.alpha` is now optional (inherits trainer by default), `RLConfig.auto_setup_lora` validates that orchestrator LoRA settings don’t conflict with the trainer, propagates missing `rank`/`alpha` from the trainer, and generates adapter names from the effective (possibly inherited) values.
> 
> LoRA adapter config saving is refactored to pass explicit `rank`/`alpha`/`dropout` values, and filesystem broadcast now writes `adapter_config.json` using each run’s orchestrator LoRA `rank`/`alpha` (while `runs.py` also defaults missing alpha before computing scaling factors).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2a37e1b76e23f45e6dc8a2e1a05affb711f0ed3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->