### PR TITLE
Fix WandB error metric keys

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -598,7 +598,10 @@ async def orchestrate(config: OrchestratorConfig):
             "error/mean": (~results_df.error.isna()).mean(),
             **{
                 f"error/{error}": error_rate
-                for error, error_rate in results_df.error.dropna().value_counts(normalize=True).items()
+                for error, error_rate in results_df.error.dropna()
+                .apply(lambda e: e.get("error") if isinstance(e, dict) else e)
+                .value_counts(normalize=True)
+                .items()
             },
             # Env metrics
             **{f"metrics/{metric}": metrics_df[metric].mean() for metric in metrics_df.columns},


### PR DESCRIPTION
## Summary
- Extract error type string from error dict before logging to WandB
- Fixes ugly metric keys like `error/{'error': 'SandboxNotReadyError', ...}` → `error/SandboxNotReadyError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small logging-only change that affects metric key names/aggregation but not training or rollout behavior.
> 
> **Overview**
> Fixes W&B error metric tagging by normalizing `results_df.error` values before counting/logging them: if an error entry is a dict, it now logs by the dict’s `"error"` field instead of the full dict, preventing metric keys like `error/{...}` and producing stable `error/<ErrorType>` series.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d38e1168dc172e1480ff657b4c7dfdb3bed02e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->