### PR TITLE
[ci] Fa4 benchmarks

### DIFF
--- a/benchmarks/baselines/benchmark-8xb200-PrimeIntellect--INTELLECT-3-rl-16-8gpu-Recompute-flash_attention_4-16384-cp1-ep1.json
+++ b/benchmarks/baselines/benchmark-8xb200-PrimeIntellect--INTELLECT-3-rl-16-8gpu-Recompute-flash_attention_4-16384-cp1-ep1.json
@@ -1,0 +1,49 @@
+{
+  "config": {
+    "type": "rl",
+    "num_gpus": 8,
+    "model_name": "PrimeIntellect/INTELLECT-3",
+    "lora_rank": 16,
+    "seq_len": 16384,
+    "ac": "Recompute",
+    "attention": "flash_attention_4",
+    "impl": "custom",
+    "output": "benchmarks/fa4_comparison_results/benchmark-8xb200-PrimeIntellect--INTELLECT-3-rl-16-8gpu-Recompute-flash_attention_4-16384-cp1-ep1.json",
+    "dry_run": false,
+    "timeout": 1500,
+    "micro_batches": 2,
+    "ep": 1,
+    "cp": 1,
+    "docker_image": null,
+    "device_name": "NVIDIA B200",
+    "commit_sha": "664e34fd",
+    "timestamp": "2026-02-07T02:47:09.300367+00:00",
+    "success": true,
+    "error_reason": null,
+    "time_taken": 618.4848574409989
+  },
+  "metrics": {
+    "mfu": {
+      "mean": 13.330373330722104,
+      "std": 0.00246909734407454,
+      "min": 13.327529963252488,
+      "max": 13.33197636430958
+    },
+    "throughput": {
+      "mean": 25557.501796768152,
+      "std": 4.733847900731252,
+      "min": 25552.050383862403,
+      "max": 25560.575194097382
+    },
+    "step_time": {
+      "mean": 10.258239714000714,
+      "std": 0.005872488647215474,
+      "min": 10.253997296000307,
+      "max": 10.264942139001505
+    },
+    "peak_memory": {
+      "gib": 91.9375,
+      "pct": 51.54857489769364
+    }
+  }
+}

--- a/benchmarks/baselines/benchmark-8xb200-PrimeIntellect--INTELLECT-3-rl-16-8gpu-Recompute-flash_attention_4-65536-cp1-ep1.json
+++ b/benchmarks/baselines/benchmark-8xb200-PrimeIntellect--INTELLECT-3-rl-16-8gpu-Recompute-flash_attention_4-65536-cp1-ep1.json
@@ -1,0 +1,49 @@
+{
+  "config": {
+    "type": "rl",
+    "num_gpus": 8,
+    "model_name": "PrimeIntellect/INTELLECT-3",
+    "lora_rank": 16,
+    "seq_len": 65536,
+    "ac": "Recompute",
+    "attention": "flash_attention_4",
+    "impl": "custom",
+    "output": "benchmarks/fa4_comparison_results/benchmark-8xb200-PrimeIntellect--INTELLECT-3-rl-16-8gpu-Recompute-flash_attention_4-65536-cp1-ep1.json",
+    "dry_run": false,
+    "timeout": 1500,
+    "micro_batches": 2,
+    "ep": 1,
+    "cp": 1,
+    "docker_image": null,
+    "device_name": "NVIDIA B200",
+    "commit_sha": "664e34fd",
+    "timestamp": "2026-02-07T02:57:35.942272+00:00",
+    "success": true,
+    "error_reason": null,
+    "time_taken": 350.92937005600106
+  },
+  "metrics": {
+    "mfu": {
+      "mean": 19.6062772819723,
+      "std": 0.010024783148607344,
+      "min": 19.598071954788125,
+      "max": 19.61745106510284
+    },
+    "throughput": {
+      "mean": 17360.854999577685,
+      "std": 8.876688018954612,
+      "min": 17353.589393087484,
+      "max": 17370.74909757172
+    },
+    "step_time": {
+      "mean": 60.42359069333179,
+      "std": 0.0516385013101082,
+      "min": 60.36403028299901,
+      "max": 60.455810766998184
+    },
+    "peak_memory": {
+      "gib": 161.658203125,
+      "pct": 90.6403806022095
+    }
+  }
+}

--- a/benchmarks/baselines/benchmark-8xb200-Qwen--Qwen3-30B-A3B-Instruct-2507-rl-16-8gpu-Recompute-flash_attention_2-16384-cp1-ep1.json
+++ b/benchmarks/baselines/benchmark-8xb200-Qwen--Qwen3-30B-A3B-Instruct-2507-rl-16-8gpu-Recompute-flash_attention_2-16384-cp1-ep1.json
@@ -7,40 +7,42 @@
     "seq_len": 16384,
     "ac": "Recompute",
     "attention": "flash_attention_2",
-    "output": "/tmp/benchmark_result.json",
+    "output": "benchmarks/fa4_comparison_results/benchmark-8xb200-Qwen--Qwen3-30B-A3B-Instruct-2507-rl-16-8gpu-Recompute-flash_attention_2-16384-cp1-ep1/benchmark_result.json",
     "dry_run": false,
     "timeout": 1500,
     "micro_batches": 2,
-    "docker_image": "primeintellect/prime-rl-jackmin@sha256:5a146f7dfdcdf6b0e90fd3f1ed0874d22a3a0641378dc8dad46ce213d02fa2e6",
+    "ep": 1,
+    "cp": 1,
+    "docker_image": null,
     "device_name": "NVIDIA B200",
-    "commit_sha": "unknown",
-    "timestamp": "2026-01-15T23:32:10.654918+00:00",
+    "commit_sha": "bd087277",
+    "timestamp": "2026-02-06T20:34:34.603713+00:00",
     "success": true,
     "error_reason": null,
-    "time_taken": 244.50675971500004
+    "time_taken": 107.42502358699949
   },
   "metrics": {
     "mfu": {
-      "mean": 1.8819492849425725,
-      "std": 0.018657004256960857,
-      "min": 1.8647429725679725,
-      "max": 1.9017792358057817
+      "mean": 7.336588744578702,
+      "std": 0.0017483896720874093,
+      "min": 7.33491126506731,
+      "max": 7.338400322096878
     },
     "throughput": {
-      "mean": 9266.367565195435,
-      "std": 91.86361210349598,
-      "min": 9181.646889574527,
-      "max": 9364.006547801635
+      "mean": 36123.995755824246,
+      "std": 8.608744921224927,
+      "min": 36115.736159319706,
+      "max": 36132.915625924135
     },
     "step_time": {
-      "mean": 28.328965114333794,
-      "std": 0.6755728629253066,
-      "min": 27.88586488400142,
-      "max": 29.106523622000168
+      "mean": 7.256334914666695,
+      "std": 0.004395670274658206,
+      "min": 7.25336341000002,
+      "max": 7.261384307999833
     },
     "peak_memory": {
-      "gib": 32.041666666666664,
-      "pct": 17.96443277014256
+      "gib": 32.900390625,
+      "pct": 18.44696941178725
     }
   }
 }

--- a/benchmarks/baselines/benchmark-8xb200-Qwen--Qwen3-30B-A3B-Instruct-2507-rl-16-8gpu-Recompute-flash_attention_2-65536-cp1-ep1.json
+++ b/benchmarks/baselines/benchmark-8xb200-Qwen--Qwen3-30B-A3B-Instruct-2507-rl-16-8gpu-Recompute-flash_attention_2-65536-cp1-ep1.json
@@ -7,40 +7,42 @@
     "seq_len": 65536,
     "ac": "Recompute",
     "attention": "flash_attention_2",
-    "output": "/tmp/benchmark_result.json",
+    "output": "benchmarks/fa4_comparison_results/benchmark-8xb200-Qwen--Qwen3-30B-A3B-Instruct-2507-rl-16-8gpu-Recompute-flash_attention_2-65536-cp1-ep1/benchmark_result.json",
     "dry_run": false,
     "timeout": 1500,
     "micro_batches": 2,
-    "docker_image": "primeintellect/prime-rl-jackmin@sha256:5a146f7dfdcdf6b0e90fd3f1ed0874d22a3a0641378dc8dad46ce213d02fa2e6",
+    "ep": 1,
+    "cp": 1,
+    "docker_image": null,
     "device_name": "NVIDIA B200",
-    "commit_sha": "unknown",
-    "timestamp": "2026-01-15T23:51:34.679404+00:00",
+    "commit_sha": "bd087277",
+    "timestamp": "2026-02-06T20:36:29.904199+00:00",
     "success": true,
     "error_reason": null,
-    "time_taken": 449.1452536000015
+    "time_taken": 298.95180840800003
   },
   "metrics": {
     "mfu": {
-      "mean": 6.946321930899347,
-      "std": 0.04943793567535021,
-      "min": 6.907147510672552,
-      "max": 7.001869300686485
+      "mean": 10.00912470993744,
+      "std": 0.001690276334522835,
+      "min": 10.00729986112157,
+      "max": 10.010636700177008
     },
     "throughput": {
-      "mean": 13225.618902255133,
-      "std": 94.1285622896153,
-      "min": 13151.031810296197,
-      "max": 13331.379670491255
+      "mean": 19057.1168851137,
+      "std": 3.2182428142968225,
+      "min": 19053.6424197444,
+      "max": 19059.99567577319
     },
     "step_time": {
-      "mean": 79.47065850533363,
-      "std": 1.170419801192356,
-      "min": 78.65436104000037,
-      "max": 80.81161287000032
+      "mean": 55.032155715666704,
+      "std": 0.021275177496498245,
+      "min": 55.01402732899987,
+      "max": 55.05557798600057
     },
     "peak_memory": {
-      "gib": 64.82161458333333,
-      "pct": 36.34278919847233
+      "gib": 64.337890625,
+      "pct": 36.073708482854485
     }
   }
 }

--- a/benchmarks/baselines/benchmark-8xb200-Qwen--Qwen3-30B-A3B-Instruct-2507-rl-16-8gpu-Recompute-flash_attention_4-16384-cp1-ep1.json
+++ b/benchmarks/baselines/benchmark-8xb200-Qwen--Qwen3-30B-A3B-Instruct-2507-rl-16-8gpu-Recompute-flash_attention_4-16384-cp1-ep1.json
@@ -1,0 +1,49 @@
+{
+  "config": {
+    "type": "rl",
+    "num_gpus": 8,
+    "model_name": "Qwen/Qwen3-30B-A3B-Instruct-2507",
+    "lora_rank": 16,
+    "seq_len": 16384,
+    "ac": "Recompute",
+    "attention": "flash_attention_4",
+    "impl": "custom",
+    "output": "benchmarks/fa4_comparison_results/benchmark-8xb200-Qwen--Qwen3-30B-A3B-Instruct-2507-rl-16-8gpu-Recompute-flash_attention_4-16384-cp1-ep1.json",
+    "dry_run": false,
+    "timeout": 1500,
+    "micro_batches": 2,
+    "ep": 1,
+    "cp": 1,
+    "docker_image": null,
+    "device_name": "NVIDIA B200",
+    "commit_sha": "bd087277",
+    "timestamp": "2026-02-07T01:13:24.327203+00:00",
+    "success": true,
+    "error_reason": null,
+    "time_taken": 107.52978444999826
+  },
+  "metrics": {
+    "mfu": {
+      "mean": 9.978467137707392,
+      "std": 0.0011074422830388453,
+      "min": 9.977196339374219,
+      "max": 9.979225955298716
+    },
+    "throughput": {
+      "mean": 49132.11263184588,
+      "std": 5.452839422393473,
+      "min": 49125.85545767512,
+      "max": 49135.84890825482
+    },
+    "step_time": {
+      "mean": 5.333801225666927,
+      "std": 0.0023580947096176375,
+      "min": 5.332222320997971,
+      "max": 5.336511851000978
+    },
+    "peak_memory": {
+      "gib": 32.900390625,
+      "pct": 18.44696941178725
+    }
+  }
+}

--- a/benchmarks/baselines/benchmark-8xb200-Qwen--Qwen3-30B-A3B-Instruct-2507-rl-16-8gpu-Recompute-flash_attention_4-65536-cp1-ep1.json
+++ b/benchmarks/baselines/benchmark-8xb200-Qwen--Qwen3-30B-A3B-Instruct-2507-rl-16-8gpu-Recompute-flash_attention_4-65536-cp1-ep1.json
@@ -1,0 +1,49 @@
+{
+  "config": {
+    "type": "rl",
+    "num_gpus": 8,
+    "model_name": "Qwen/Qwen3-30B-A3B-Instruct-2507",
+    "lora_rank": 16,
+    "seq_len": 65536,
+    "ac": "Recompute",
+    "attention": "flash_attention_4",
+    "impl": "custom",
+    "output": "benchmarks/fa4_comparison_results/benchmark-8xb200-Qwen--Qwen3-30B-A3B-Instruct-2507-rl-16-8gpu-Recompute-flash_attention_4-65536-cp1-ep1.json",
+    "dry_run": false,
+    "timeout": 1500,
+    "micro_batches": 2,
+    "ep": 1,
+    "cp": 1,
+    "docker_image": null,
+    "device_name": "NVIDIA B200",
+    "commit_sha": "bd087277",
+    "timestamp": "2026-02-07T00:11:02.359509+00:00",
+    "success": true,
+    "error_reason": null,
+    "time_taken": 208.74448642399875
+  },
+  "metrics": {
+    "mfu": {
+      "mean": 19.658480142225958,
+      "std": 0.009186679808702346,
+      "min": 19.652442577637213,
+      "max": 19.669052463180137
+    },
+    "throughput": {
+      "mean": 37429.242287503504,
+      "std": 17.491202874785223,
+      "min": 37417.746919286656,
+      "max": 37449.371715601315
+    },
+    "step_time": {
+      "mean": 28.018691487999604,
+      "std": 0.026650956497433063,
+      "min": 27.993292347000533,
+      "max": 28.04643885599944
+    },
+    "peak_memory": {
+      "gib": 64.337890625,
+      "pct": 36.073708482854485
+    }
+  }
+}

--- a/benchmarks/baselines/benchmark-8xb200-Qwen--Qwen3-30B-A3B-Instruct-2507-rl-full-8gpu-Recompute-flash_attention_2-16384-cp1-ep1.json
+++ b/benchmarks/baselines/benchmark-8xb200-Qwen--Qwen3-30B-A3B-Instruct-2507-rl-full-8gpu-Recompute-flash_attention_2-16384-cp1-ep1.json
@@ -1,0 +1,48 @@
+{
+  "config": {
+    "type": "rl",
+    "num_gpus": 8,
+    "model_name": "Qwen/Qwen3-30B-A3B-Instruct-2507",
+    "lora_rank": null,
+    "seq_len": 16384,
+    "ac": "Recompute",
+    "attention": "flash_attention_2",
+    "output": "benchmarks/fa4_comparison_results/benchmark-8xb200-Qwen--Qwen3-30B-A3B-Instruct-2507-rl-full-8gpu-Recompute-flash_attention_2-16384-cp1-ep1/benchmark_result.json",
+    "dry_run": false,
+    "timeout": 1500,
+    "micro_batches": 2,
+    "ep": 1,
+    "cp": 1,
+    "docker_image": null,
+    "device_name": "NVIDIA B200",
+    "commit_sha": "bd087277",
+    "timestamp": "2026-02-06T20:24:50.087811+00:00",
+    "success": true,
+    "error_reason": null,
+    "time_taken": 262.2045556060002
+  },
+  "metrics": {
+    "mfu": {
+      "mean": 2.83205183041118,
+      "std": 0.005714015144022222,
+      "min": 2.8266133532651225,
+      "max": 2.838006373268967
+    },
+    "throughput": {
+      "mean": 13565.887204693578,
+      "std": 27.370856739744045,
+      "min": 13539.836209886034,
+      "max": 13594.410219666966
+    },
+    "step_time": {
+      "mean": 5.419250779666679,
+      "std": 0.008676875602596218,
+      "min": 5.412691587000154,
+      "max": 5.429089408999971
+    },
+    "peak_memory": {
+      "gib": 85.623046875,
+      "pct": 48.00811469536013
+    }
+  }
+}

--- a/benchmarks/baselines/benchmark-8xb200-Qwen--Qwen3-30B-A3B-Instruct-2507-rl-full-8gpu-Recompute-flash_attention_2-65536-cp1-ep1.json
+++ b/benchmarks/baselines/benchmark-8xb200-Qwen--Qwen3-30B-A3B-Instruct-2507-rl-full-8gpu-Recompute-flash_attention_2-65536-cp1-ep1.json
@@ -1,0 +1,48 @@
+{
+  "config": {
+    "type": "rl",
+    "num_gpus": 8,
+    "model_name": "Qwen/Qwen3-30B-A3B-Instruct-2507",
+    "lora_rank": null,
+    "seq_len": 65536,
+    "ac": "Recompute",
+    "attention": "flash_attention_2",
+    "output": "benchmarks/fa4_comparison_results/benchmark-8xb200-Qwen--Qwen3-30B-A3B-Instruct-2507-rl-full-8gpu-Recompute-flash_attention_2-65536-cp1-ep1/benchmark_result.json",
+    "dry_run": false,
+    "timeout": 1500,
+    "micro_batches": 2,
+    "ep": 1,
+    "cp": 1,
+    "docker_image": null,
+    "device_name": "NVIDIA B200",
+    "commit_sha": "bd087277",
+    "timestamp": "2026-02-06T20:29:20.155480+00:00",
+    "success": true,
+    "error_reason": null,
+    "time_taken": 306.68673951599976
+  },
+  "metrics": {
+    "mfu": {
+      "mean": 8.784324583651397,
+      "std": 0.00565761087453944,
+      "min": 8.77779380857552,
+      "max": 8.787732426406633
+    },
+    "throughput": {
+      "mean": 16546.558622146713,
+      "std": 10.656936581223418,
+      "min": 16534.256953235006,
+      "max": 16552.97779181509
+    },
+    "step_time": {
+      "mean": 47.92894584100031,
+      "std": 0.041455834752998105,
+      "min": 47.88356878900049,
+      "max": 47.96483582899964
+    },
+    "peak_memory": {
+      "gib": 101.296875,
+      "pct": 56.79629691736029
+    }
+  }
+}

--- a/benchmarks/baselines/benchmark-8xb200-Qwen--Qwen3-30B-A3B-Instruct-2507-rl-full-8gpu-Recompute-flash_attention_4-16384-cp1-ep1.json
+++ b/benchmarks/baselines/benchmark-8xb200-Qwen--Qwen3-30B-A3B-Instruct-2507-rl-full-8gpu-Recompute-flash_attention_4-16384-cp1-ep1.json
@@ -1,0 +1,49 @@
+{
+  "config": {
+    "type": "rl",
+    "num_gpus": 8,
+    "model_name": "Qwen/Qwen3-30B-A3B-Instruct-2507",
+    "lora_rank": null,
+    "seq_len": 16384,
+    "ac": "Recompute",
+    "attention": "flash_attention_4",
+    "impl": "custom",
+    "output": "benchmarks/fa4_comparison_results/benchmark-8xb200-Qwen--Qwen3-30B-A3B-Instruct-2507-rl-full-8gpu-Recompute-flash_attention_4-16384-cp1-ep1.json",
+    "dry_run": false,
+    "timeout": 1500,
+    "micro_batches": 2,
+    "ep": 1,
+    "cp": 1,
+    "docker_image": null,
+    "device_name": "NVIDIA B200",
+    "commit_sha": "bd087277",
+    "timestamp": "2026-02-07T01:07:11.585283+00:00",
+    "success": true,
+    "error_reason": null,
+    "time_taken": 134.4868883659983
+  },
+  "metrics": {
+    "mfu": {
+      "mean": 2.4781020510027205,
+      "std": 0.023688379397205254,
+      "min": 2.451820207007711,
+      "max": 2.497807104750307
+    },
+    "throughput": {
+      "mean": 11870.422901385185,
+      "std": 113.47033960103064,
+      "min": 11744.529537662429,
+      "max": 11964.812606273947
+    },
+    "step_time": {
+      "mean": 5.637309388333961,
+      "std": 0.2058205588204501,
+      "min": 5.40161963400169,
+      "max": 5.781609080000635
+    },
+    "peak_memory": {
+      "gib": 86.580078125,
+      "pct": 48.54471398368163
+    }
+  }
+}

--- a/benchmarks/baselines/benchmark-8xb200-Qwen--Qwen3-30B-A3B-Instruct-2507-rl-full-8gpu-Recompute-flash_attention_4-65536-cp1-ep1.json
+++ b/benchmarks/baselines/benchmark-8xb200-Qwen--Qwen3-30B-A3B-Instruct-2507-rl-full-8gpu-Recompute-flash_attention_4-65536-cp1-ep1.json
@@ -1,0 +1,49 @@
+{
+  "config": {
+    "type": "rl",
+    "num_gpus": 8,
+    "model_name": "Qwen/Qwen3-30B-A3B-Instruct-2507",
+    "lora_rank": null,
+    "seq_len": 65536,
+    "ac": "Recompute",
+    "attention": "flash_attention_4",
+    "impl": "custom",
+    "output": "benchmarks/fa4_comparison_results/benchmark-8xb200-Qwen--Qwen3-30B-A3B-Instruct-2507-rl-full-8gpu-Recompute-flash_attention_4-65536-cp1-ep1.json",
+    "dry_run": false,
+    "timeout": 1500,
+    "micro_batches": 2,
+    "ep": 1,
+    "cp": 1,
+    "docker_image": null,
+    "device_name": "NVIDIA B200",
+    "commit_sha": "bd087277",
+    "timestamp": "2026-02-07T01:09:34.311497+00:00",
+    "success": true,
+    "error_reason": null,
+    "time_taken": 221.9706921549987
+  },
+  "metrics": {
+    "mfu": {
+      "mean": 12.74645922095939,
+      "std": 0.05230333416273128,
+      "min": 12.694926523432327,
+      "max": 12.799500550542833
+    },
+    "throughput": {
+      "mean": 24009.818024818214,
+      "std": 98.52097069227595,
+      "min": 23912.74866080862,
+      "max": 24109.729117696366
+    },
+    "step_time": {
+      "mean": 27.301947842667385,
+      "std": 0.02858026206326918,
+      "min": 27.271587307997834,
+      "max": 27.32833122700322
+    },
+    "peak_memory": {
+      "gib": 108.837890625,
+      "pct": 61.024480289216065
+    }
+  }
+}

--- a/benchmarks/baselines/benchmark-8xb200-Qwen--Qwen3-30B-A3B-Instruct-2507-sft-full-8gpu-Recompute-flash_attention_2-16384-cp1-ep1.json
+++ b/benchmarks/baselines/benchmark-8xb200-Qwen--Qwen3-30B-A3B-Instruct-2507-sft-full-8gpu-Recompute-flash_attention_2-16384-cp1-ep1.json
@@ -1,0 +1,48 @@
+{
+  "config": {
+    "type": "sft",
+    "num_gpus": 8,
+    "model_name": "Qwen/Qwen3-30B-A3B-Instruct-2507",
+    "lora_rank": null,
+    "seq_len": 16384,
+    "ac": "Recompute",
+    "attention": "flash_attention_2",
+    "output": "benchmarks/fa4_comparison_results/benchmark-8xb200-Qwen--Qwen3-30B-A3B-Instruct-2507-sft-full-8gpu-Recompute-flash_attention_2-16384-cp1-ep1/benchmark_result.json",
+    "dry_run": false,
+    "timeout": 1500,
+    "micro_batches": 2,
+    "ep": 1,
+    "cp": 1,
+    "docker_image": null,
+    "device_name": "NVIDIA B200",
+    "commit_sha": "bd087277",
+    "timestamp": "2026-02-06T20:41:36.814703+00:00",
+    "success": true,
+    "error_reason": null,
+    "time_taken": 58.00446012900011
+  },
+  "metrics": {
+    "mfu": {
+      "mean": 11.621098751556891,
+      "std": 0.019947342983285134,
+      "min": 11.604304694764593,
+      "max": 11.643147381853023
+    },
+    "throughput": {
+      "mean": 55666.5358894004,
+      "std": 95.55030103573148,
+      "min": 55586.09022887009,
+      "max": 55772.15162298389
+    },
+    "step_time": {
+      "mean": 4.687511330333412,
+      "std": 0.002982946404314349,
+      "min": 4.684588344000076,
+      "max": 4.690550823000194
+    },
+    "peak_memory": {
+      "gib": 111.833984375,
+      "pct": 62.7043645918389
+    }
+  }
+}

--- a/benchmarks/baselines/benchmark-8xb200-Qwen--Qwen3-30B-A3B-Instruct-2507-sft-full-8gpu-Recompute-flash_attention_4-16384-cp1-ep1.json
+++ b/benchmarks/baselines/benchmark-8xb200-Qwen--Qwen3-30B-A3B-Instruct-2507-sft-full-8gpu-Recompute-flash_attention_4-16384-cp1-ep1.json
@@ -1,0 +1,49 @@
+{
+  "config": {
+    "type": "sft",
+    "num_gpus": 8,
+    "model_name": "Qwen/Qwen3-30B-A3B-Instruct-2507",
+    "lora_rank": null,
+    "seq_len": 16384,
+    "ac": "Recompute",
+    "attention": "flash_attention_4",
+    "impl": "custom",
+    "output": "benchmarks/fa4_comparison_results/benchmark-8xb200-Qwen--Qwen3-30B-A3B-Instruct-2507-sft-full-8gpu-Recompute-flash_attention_4-16384-cp1-ep1.json",
+    "dry_run": false,
+    "timeout": 1500,
+    "micro_batches": 2,
+    "ep": 1,
+    "cp": 1,
+    "docker_image": null,
+    "device_name": "NVIDIA B200",
+    "commit_sha": "bd087277",
+    "timestamp": "2026-02-07T01:15:19.761295+00:00",
+    "success": true,
+    "error_reason": null,
+    "time_taken": 62.902863907998835
+  },
+  "metrics": {
+    "mfu": {
+      "mean": 11.623906940005833,
+      "std": 0.013734320559792085,
+      "min": 11.612295063499975,
+      "max": 11.639067278520065
+    },
+    "throughput": {
+      "mean": 55679.987467983396,
+      "std": 65.7891361826495,
+      "min": 55624.36510781973,
+      "max": 55752.607410902725
+    },
+    "step_time": {
+      "mean": 4.683860810999856,
+      "std": 0.007342272066295946,
+      "min": 4.678657461001421,
+      "max": 4.692259280000144
+    },
+    "peak_memory": {
+      "gib": 111.84375,
+      "pct": 62.70984009478096
+    }
+  }
+}

--- a/benchmarks/baselines/benchmark-8xb200-Qwen--Qwen3-4B-Instruct-2507-rl-16-8gpu-Recompute-flash_attention_2-16384-cp1-ep1.json
+++ b/benchmarks/baselines/benchmark-8xb200-Qwen--Qwen3-4B-Instruct-2507-rl-16-8gpu-Recompute-flash_attention_2-16384-cp1-ep1.json
@@ -7,40 +7,42 @@
     "seq_len": 16384,
     "ac": "Recompute",
     "attention": "flash_attention_2",
-    "output": "/tmp/benchmark_result.json",
+    "output": "benchmarks/fa4_comparison_results/benchmark-8xb200-Qwen--Qwen3-4B-Instruct-2507-rl-16-8gpu-Recompute-flash_attention_2-16384-cp1-ep1/benchmark_result.json",
     "dry_run": false,
     "timeout": 1500,
     "micro_batches": 2,
-    "docker_image": "primeintellect/prime-rl-jackmin@sha256:5a146f7dfdcdf6b0e90fd3f1ed0874d22a3a0641378dc8dad46ce213d02fa2e6",
+    "ep": 1,
+    "cp": 1,
+    "docker_image": null,
     "device_name": "NVIDIA B200",
-    "commit_sha": "unknown",
-    "timestamp": "2026-01-15T22:10:45.595226+00:00",
+    "commit_sha": "bd087277",
+    "timestamp": "2026-02-06T20:17:36.572818+00:00",
     "success": true,
     "error_reason": null,
-    "time_taken": 106.1217524460003
+    "time_taken": 84.25718453799982
   },
   "metrics": {
     "mfu": {
-      "mean": 8.808826116109998,
-      "std": 0.004229053216833396,
-      "min": 8.80401218210114,
-      "max": 8.811943308874014
+      "mean": 9.789609298367118,
+      "std": 0.002130234713217652,
+      "min": 9.787355245158038,
+      "max": 9.79158916319276
     },
     "throughput": {
-      "mean": 46083.769889207404,
-      "std": 22.1244820507199,
-      "min": 46058.58557699578,
-      "max": 46100.0776233077
+      "mean": 51214.781205196625,
+      "std": 11.144418681895658,
+      "min": 51202.98902448649,
+      "max": 51225.13895705073
     },
     "step_time": {
-      "mean": 5.686930948999968,
-      "std": 0.005284924202613482,
-      "min": 5.680966203000025,
-      "max": 5.691029913999955
+      "mean": 5.11819438266654,
+      "std": 0.004382178368867937,
+      "min": 5.115601149000213,
+      "max": 5.123253955999644
     },
     "peak_memory": {
-      "gib": 10.216796875,
-      "pct": 5.728134010521928
+      "gib": 11.068359375,
+      "pct": 6.205935034526468
     }
   }
 }

--- a/benchmarks/baselines/benchmark-8xb200-Qwen--Qwen3-4B-Instruct-2507-rl-16-8gpu-Recompute-flash_attention_2-65536-cp1-ep1.json
+++ b/benchmarks/baselines/benchmark-8xb200-Qwen--Qwen3-4B-Instruct-2507-rl-16-8gpu-Recompute-flash_attention_2-65536-cp1-ep1.json
@@ -7,40 +7,42 @@
     "seq_len": 65536,
     "ac": "Recompute",
     "attention": "flash_attention_2",
-    "output": "/tmp/benchmark_result.json",
+    "output": "benchmarks/fa4_comparison_results/benchmark-8xb200-Qwen--Qwen3-4B-Instruct-2507-rl-16-8gpu-Recompute-flash_attention_2-65536-cp1-ep1/benchmark_result.json",
     "dry_run": false,
     "timeout": 1500,
     "micro_batches": 2,
-    "docker_image": "primeintellect/prime-rl-jackmin@sha256:5a146f7dfdcdf6b0e90fd3f1ed0874d22a3a0641378dc8dad46ce213d02fa2e6",
+    "ep": 1,
+    "cp": 1,
+    "docker_image": null,
     "device_name": "NVIDIA B200",
-    "commit_sha": "unknown",
-    "timestamp": "2026-01-15T23:47:04.725977+00:00",
+    "commit_sha": "bd087277",
+    "timestamp": "2026-02-06T20:19:08.615075+00:00",
     "success": true,
     "error_reason": null,
-    "time_taken": 254.2014976369992
+    "time_taken": 226.88302387399926
   },
   "metrics": {
     "mfu": {
-      "mean": 12.348302496931252,
-      "std": 0.006805052347726637,
-      "min": 12.34074166489301,
-      "max": 12.353936045871244
+      "mean": 12.77083708415158,
+      "std": 0.0013283850725893515,
+      "min": 12.769944595401295,
+      "max": 12.772363701043053
     },
     "throughput": {
-      "mean": 25040.256927943043,
-      "std": 13.799488572419822,
-      "min": 25024.924846721864,
-      "max": 25051.680806885804
+      "mean": 25897.085194627376,
+      "std": 2.6937389592706285,
+      "min": 25895.275379260605,
+      "max": 25900.180913994667
     },
     "step_time": {
-      "mean": 41.85612941899914,
-      "std": 0.03884213222620387,
-      "min": 41.831036413999755,
-      "max": 41.90087012999902
+      "mean": 40.49232029866653,
+      "std": 0.0070406002411538176,
+      "min": 40.484626874999776,
+      "max": 40.49844263700015
     },
     "peak_memory": {
-      "gib": 28.810546875,
-      "pct": 16.152877994496077
+      "gib": 31.6875,
+      "pct": 17.766911946383875
     }
   }
 }

--- a/benchmarks/baselines/benchmark-8xb200-Qwen--Qwen3-4B-Instruct-2507-rl-full-8gpu-Recompute-flash_attention_2-16384-cp1-ep1.json
+++ b/benchmarks/baselines/benchmark-8xb200-Qwen--Qwen3-4B-Instruct-2507-rl-full-8gpu-Recompute-flash_attention_2-16384-cp1-ep1.json
@@ -7,40 +7,42 @@
     "seq_len": 16384,
     "ac": "Recompute",
     "attention": "flash_attention_2",
-    "output": "/tmp/benchmark_result.json",
+    "output": "benchmarks/fa4_comparison_results/benchmark-8xb200-Qwen--Qwen3-4B-Instruct-2507-rl-full-8gpu-Recompute-flash_attention_2-16384-cp1-ep1/benchmark_result.json",
     "dry_run": false,
     "timeout": 1500,
     "micro_batches": 2,
-    "docker_image": "primeintellect/prime-rl-jackmin@sha256:5a146f7dfdcdf6b0e90fd3f1ed0874d22a3a0641378dc8dad46ce213d02fa2e6",
+    "ep": 1,
+    "cp": 1,
+    "docker_image": null,
     "device_name": "NVIDIA B200",
-    "commit_sha": "unknown",
-    "timestamp": "2026-01-15T22:52:34.912968+00:00",
+    "commit_sha": "bd087277",
+    "timestamp": "2026-02-06T20:12:55.350377+00:00",
     "success": true,
     "error_reason": null,
-    "time_taken": 77.61734246100059
+    "time_taken": 77.1885415099996
   },
   "metrics": {
     "mfu": {
-      "mean": 6.465139069561914,
-      "std": 0.04130725425852038,
-      "min": 6.418776595758626,
-      "max": 6.498024945638078
+      "mean": 9.436945714917204,
+      "std": 0.018865202477855416,
+      "min": 9.42459178390404,
+      "max": 9.458660735511923
     },
     "throughput": {
-      "mean": 27541.81564064197,
-      "std": 175.970968167648,
-      "min": 27344.3091844938,
-      "max": 27681.911116752446
+      "mean": 40201.86051598853,
+      "std": 80.36670566216903,
+      "min": 40149.23215227648,
+      "max": 40294.36758929623
     },
     "step_time": {
-      "mean": 4.634802302666685,
-      "std": 0.08513574433508829,
-      "min": 4.565404164000029,
-      "max": 4.72980078099954
+      "mean": 4.548868662666791,
+      "std": 0.022574251271253475,
+      "min": 4.535280007999972,
+      "max": 4.574927157999809
     },
     "peak_memory": {
-      "gib": 17.037109375,
-      "pct": 9.552000186156143
+      "gib": 18.099609375,
+      "pct": 10.148297152806913
     }
   }
 }

--- a/benchmarks/baselines/benchmark-8xb200-Qwen--Qwen3-4B-Instruct-2507-rl-full-8gpu-Recompute-flash_attention_2-65536-cp1-ep1.json
+++ b/benchmarks/baselines/benchmark-8xb200-Qwen--Qwen3-4B-Instruct-2507-rl-full-8gpu-Recompute-flash_attention_2-65536-cp1-ep1.json
@@ -1,0 +1,48 @@
+{
+  "config": {
+    "type": "rl",
+    "num_gpus": 8,
+    "model_name": "Qwen/Qwen3-4B-Instruct-2507",
+    "lora_rank": null,
+    "seq_len": 65536,
+    "ac": "Recompute",
+    "attention": "flash_attention_2",
+    "output": "benchmarks/fa4_comparison_results/benchmark-8xb200-Qwen--Qwen3-4B-Instruct-2507-rl-full-8gpu-Recompute-flash_attention_2-65536-cp1-ep1/benchmark_result.json",
+    "dry_run": false,
+    "timeout": 1500,
+    "micro_batches": 2,
+    "ep": 1,
+    "cp": 1,
+    "docker_image": null,
+    "device_name": "NVIDIA B200",
+    "commit_sha": "bd087277",
+    "timestamp": "2026-02-06T20:14:19.669600+00:00",
+    "success": true,
+    "error_reason": null,
+    "time_taken": 188.92578771600074
+  },
+  "metrics": {
+    "mfu": {
+      "mean": 13.933376788369557,
+      "std": 0.008869561190692658,
+      "min": 13.924317273856996,
+      "max": 13.942043333427135
+    },
+    "throughput": {
+      "mean": 25959.802683253398,
+      "std": 16.525215810542452,
+      "min": 25942.92355820537,
+      "max": 25975.949652007446
+    },
+    "step_time": {
+      "mean": 38.35014158899988,
+      "std": 0.011004576330276083,
+      "min": 38.34094965700024,
+      "max": 38.36233571199955
+    },
+    "peak_memory": {
+      "gib": 39.029296875,
+      "pct": 21.88339505822171
+    }
+  }
+}

--- a/benchmarks/baselines/benchmark-8xb200-Qwen--Qwen3-4B-Instruct-2507-sft-full-8gpu-Recompute-flash_attention_2-16384-cp1-ep1.json
+++ b/benchmarks/baselines/benchmark-8xb200-Qwen--Qwen3-4B-Instruct-2507-sft-full-8gpu-Recompute-flash_attention_2-16384-cp1-ep1.json
@@ -7,40 +7,42 @@
     "seq_len": 16384,
     "ac": "Recompute",
     "attention": "flash_attention_2",
-    "output": "/tmp/benchmark_result.json",
+    "output": "benchmarks/fa4_comparison_results/benchmark-8xb200-Qwen--Qwen3-4B-Instruct-2507-sft-full-8gpu-Recompute-flash_attention_2-16384-cp1-ep1/benchmark_result.json",
     "dry_run": false,
     "timeout": 1500,
     "micro_batches": 2,
-    "docker_image": "primeintellect/prime-rl-jackmin@sha256:5a146f7dfdcdf6b0e90fd3f1ed0874d22a3a0641378dc8dad46ce213d02fa2e6",
+    "ep": 1,
+    "cp": 1,
+    "docker_image": null,
     "device_name": "NVIDIA B200",
-    "commit_sha": "unknown",
-    "timestamp": "2026-01-15T22:51:22.159961+00:00",
+    "commit_sha": "bd087277",
+    "timestamp": "2026-02-06T20:23:03.531850+00:00",
     "success": true,
     "error_reason": null,
-    "time_taken": 55.56085521700061
+    "time_taken": 43.01598337999985
   },
   "metrics": {
     "mfu": {
-      "mean": 16.045704463732047,
-      "std": 0.3669414038018912,
-      "min": 15.635441903073977,
-      "max": 16.34253889185774
+      "mean": 15.502286808468936,
+      "std": 0.6484375878676393,
+      "min": 14.778724725765658,
+      "max": 16.03084536543696
     },
     "throughput": {
-      "mean": 68355.50317006244,
-      "std": 1563.188724278261,
-      "min": 66607.76415187177,
-      "max": 69620.03267318218
+      "mean": 66040.51679218384,
+      "std": 2762.376540915352,
+      "min": 62958.106147655664,
+      "max": 68292.20266849146
     },
     "step_time": {
-      "mean": 3.743108587333154,
-      "std": 0.11113779012396933,
-      "min": 3.6789139749998867,
-      "max": 3.8714394489998085
+      "mean": 3.6758344136666588,
+      "std": 0.000726874648752453,
+      "min": 3.6750092660004157,
+      "max": 3.6763800110002194
     },
     "peak_memory": {
-      "gib": 54.59375,
-      "pct": 30.60844998319804
+      "gib": 52.521484375,
+      "pct": 29.448349922966514
     }
   }
 }

--- a/benchmarks/baselines/benchmark-8xb200-meta-llama--Llama-3.1-8B-Instruct-rl-16-8gpu-Recompute-flash_attention_4-16384-cp1-ep1.json
+++ b/benchmarks/baselines/benchmark-8xb200-meta-llama--Llama-3.1-8B-Instruct-rl-16-8gpu-Recompute-flash_attention_4-16384-cp1-ep1.json
@@ -1,0 +1,49 @@
+{
+  "config": {
+    "type": "rl",
+    "num_gpus": 8,
+    "model_name": "meta-llama/Llama-3.1-8B-Instruct",
+    "lora_rank": 16,
+    "seq_len": 16384,
+    "ac": "Recompute",
+    "attention": "flash_attention_4",
+    "impl": "custom",
+    "output": "benchmarks/fa4_comparison_results/benchmark-8xb200-meta-llama--Llama-3.1-8B-Instruct-rl-16-8gpu-Recompute-flash_attention_4-16384-cp1-ep1.json",
+    "dry_run": false,
+    "timeout": 1500,
+    "micro_batches": 2,
+    "ep": 1,
+    "cp": 1,
+    "docker_image": null,
+    "device_name": "NVIDIA B200",
+    "commit_sha": "30bf494f",
+    "timestamp": "2026-02-07T02:32:14.679426+00:00",
+    "success": true,
+    "error_reason": null,
+    "time_taken": 143.06908139900042
+  },
+  "metrics": {
+    "mfu": {
+      "mean": 20.549656232361308,
+      "std": 0.4568797927050528,
+      "min": 20.02213699850713,
+      "max": 20.819049535260955
+    },
+    "throughput": {
+      "mean": 66005.20703466261,
+      "std": 1467.4914736510732,
+      "min": 64310.82266873443,
+      "max": 66870.49453780055
+    },
+    "step_time": {
+      "mean": 4.075625299000724,
+      "std": 0.26658554213426405,
+      "min": 3.919594087998121,
+      "max": 4.383442008002021
+    },
+    "peak_memory": {
+      "gib": 16.5625,
+      "pct": 9.286452989727271
+    }
+  }
+}

--- a/benchmarks/baselines/benchmark-8xb200-meta-llama--Llama-3.1-8B-Instruct-rl-16-8gpu-Recompute-flash_attention_4-65536-cp1-ep1.json
+++ b/benchmarks/baselines/benchmark-8xb200-meta-llama--Llama-3.1-8B-Instruct-rl-16-8gpu-Recompute-flash_attention_4-65536-cp1-ep1.json
@@ -1,0 +1,49 @@
+{
+  "config": {
+    "type": "rl",
+    "num_gpus": 8,
+    "model_name": "meta-llama/Llama-3.1-8B-Instruct",
+    "lora_rank": 16,
+    "seq_len": 65536,
+    "ac": "Recompute",
+    "attention": "flash_attention_4",
+    "impl": "custom",
+    "output": "benchmarks/fa4_comparison_results/benchmark-8xb200-meta-llama--Llama-3.1-8B-Instruct-rl-16-8gpu-Recompute-flash_attention_4-65536-cp1-ep1.json",
+    "dry_run": false,
+    "timeout": 1500,
+    "micro_batches": 2,
+    "ep": 1,
+    "cp": 1,
+    "docker_image": null,
+    "device_name": "NVIDIA B200",
+    "commit_sha": "30bf494f",
+    "timestamp": "2026-02-07T02:34:45.930803+00:00",
+    "success": true,
+    "error_reason": null,
+    "time_taken": 150.38491048799915
+  },
+  "metrics": {
+    "mfu": {
+      "mean": 37.651840581209534,
+      "std": 0.45712713911794334,
+      "min": 37.2996745210949,
+      "max": 38.16843722464473
+    },
+    "throughput": {
+      "mean": 50823.81970079875,
+      "std": 617.0467881580015,
+      "min": 50348.453183047706,
+      "max": 51521.14058229348
+    },
+    "step_time": {
+      "mean": 20.72143832033301,
+      "std": 0.5071736950680849,
+      "min": 20.351867591998598,
+      "max": 21.299655081998935
+    },
+    "peak_memory": {
+      "gib": 43.91796875,
+      "pct": 24.624431831015027
+    }
+  }
+}

--- a/benchmarks/baselines/benchmark-8xb200-meta-llama--Llama-3.2-1B-Instruct-rl-16-8gpu-Recompute-flash_attention_4-16384-cp1-ep1.json
+++ b/benchmarks/baselines/benchmark-8xb200-meta-llama--Llama-3.2-1B-Instruct-rl-16-8gpu-Recompute-flash_attention_4-16384-cp1-ep1.json
@@ -1,0 +1,49 @@
+{
+  "config": {
+    "type": "rl",
+    "num_gpus": 8,
+    "model_name": "meta-llama/Llama-3.2-1B-Instruct",
+    "lora_rank": 16,
+    "seq_len": 16384,
+    "ac": "Recompute",
+    "attention": "flash_attention_4",
+    "impl": "custom",
+    "output": "benchmarks/fa4_comparison_results/benchmark-8xb200-meta-llama--Llama-3.2-1B-Instruct-rl-16-8gpu-Recompute-flash_attention_4-16384-cp1-ep1.json",
+    "dry_run": false,
+    "timeout": 1500,
+    "micro_batches": 2,
+    "ep": 1,
+    "cp": 1,
+    "docker_image": null,
+    "device_name": "NVIDIA B200",
+    "commit_sha": "30bf494f",
+    "timestamp": "2026-02-07T02:25:54.383341+00:00",
+    "success": true,
+    "error_reason": null,
+    "time_taken": 63.57433102699724
+  },
+  "metrics": {
+    "mfu": {
+      "mean": 9.894281806556904,
+      "std": 0.012614726385869333,
+      "min": 9.883677413452471,
+      "max": 9.908232208527318
+    },
+    "throughput": {
+      "mean": 155501.58286800745,
+      "std": 198.25692847655142,
+      "min": 155334.9209570842,
+      "max": 155720.831685704
+    },
+    "step_time": {
+      "mean": 1.6827887619995938,
+      "std": 0.0052277736941694596,
+      "min": 1.6769270299992058,
+      "max": 1.686968504000106
+    },
+    "peak_memory": {
+      "gib": 5.5859375,
+      "pct": 3.131987682856132
+    }
+  }
+}

--- a/benchmarks/baselines/benchmark-8xb200-meta-llama--Llama-3.2-1B-Instruct-rl-16-8gpu-Recompute-flash_attention_4-65536-cp1-ep1.json
+++ b/benchmarks/baselines/benchmark-8xb200-meta-llama--Llama-3.2-1B-Instruct-rl-16-8gpu-Recompute-flash_attention_4-65536-cp1-ep1.json
@@ -1,0 +1,49 @@
+{
+  "config": {
+    "type": "rl",
+    "num_gpus": 8,
+    "model_name": "meta-llama/Llama-3.2-1B-Instruct",
+    "lora_rank": 16,
+    "seq_len": 65536,
+    "ac": "Recompute",
+    "attention": "flash_attention_4",
+    "impl": "custom",
+    "output": "benchmarks/fa4_comparison_results/benchmark-8xb200-meta-llama--Llama-3.2-1B-Instruct-rl-16-8gpu-Recompute-flash_attention_4-65536-cp1-ep1.json",
+    "dry_run": false,
+    "timeout": 1500,
+    "micro_batches": 2,
+    "ep": 1,
+    "cp": 1,
+    "docker_image": null,
+    "device_name": "NVIDIA B200",
+    "commit_sha": "30bf494f",
+    "timestamp": "2026-02-07T02:27:05.746852+00:00",
+    "success": true,
+    "error_reason": null,
+    "time_taken": 77.57304684500195
+  },
+  "metrics": {
+    "mfu": {
+      "mean": 22.317547007065226,
+      "std": 0.03717266022673286,
+      "min": 22.285872301044677,
+      "max": 22.35847103815802
+    },
+    "throughput": {
+      "mean": 130510.17218651006,
+      "std": 217.38098211626007,
+      "min": 130324.9425402864,
+      "max": 130749.49070761797
+    },
+    "step_time": {
+      "mean": 8.045055978668339,
+      "std": 0.02292812684280389,
+      "min": 8.018829075001122,
+      "max": 8.061301705001824
+    },
+    "peak_memory": {
+      "gib": 15.501953125,
+      "pct": 8.691813370219972
+    }
+  }
+}

--- a/benchmarks/baselines/benchmark-8xb200-meta-llama--Llama-3.2-3B-Instruct-rl-16-8gpu-Recompute-flash_attention_4-16384-cp1-ep1.json
+++ b/benchmarks/baselines/benchmark-8xb200-meta-llama--Llama-3.2-3B-Instruct-rl-16-8gpu-Recompute-flash_attention_4-16384-cp1-ep1.json
@@ -1,0 +1,49 @@
+{
+  "config": {
+    "type": "rl",
+    "num_gpus": 8,
+    "model_name": "meta-llama/Llama-3.2-3B-Instruct",
+    "lora_rank": 16,
+    "seq_len": 16384,
+    "ac": "Recompute",
+    "attention": "flash_attention_4",
+    "impl": "custom",
+    "output": "benchmarks/fa4_comparison_results/benchmark-8xb200-meta-llama--Llama-3.2-3B-Instruct-rl-16-8gpu-Recompute-flash_attention_4-16384-cp1-ep1.json",
+    "dry_run": false,
+    "timeout": 1500,
+    "micro_batches": 2,
+    "ep": 1,
+    "cp": 1,
+    "docker_image": null,
+    "device_name": "NVIDIA B200",
+    "commit_sha": "30bf494f",
+    "timestamp": "2026-02-07T02:28:31.503876+00:00",
+    "success": true,
+    "error_reason": null,
+    "time_taken": 93.44344491200172
+  },
+  "metrics": {
+    "mfu": {
+      "mean": 16.246141032503175,
+      "std": 0.00479902654028844,
+      "min": 16.241119387416152,
+      "max": 16.250681132307037
+    },
+    "throughput": {
+      "mean": 97777.95097013842,
+      "std": 28.88310404432946,
+      "min": 97747.728028818,
+      "max": 97805.27571483521
+    },
+    "step_time": {
+      "mean": 2.6807592719997047,
+      "std": 0.001993019171030851,
+      "min": 2.6788191359992197,
+      "max": 2.68280126800164
+    },
+    "peak_memory": {
+      "gib": 9.951171875,
+      "pct": 5.579537497955242
+    }
+  }
+}

--- a/benchmarks/baselines/benchmark-8xb200-meta-llama--Llama-3.2-3B-Instruct-rl-16-8gpu-Recompute-flash_attention_4-65536-cp1-ep1.json
+++ b/benchmarks/baselines/benchmark-8xb200-meta-llama--Llama-3.2-3B-Instruct-rl-16-8gpu-Recompute-flash_attention_4-65536-cp1-ep1.json
@@ -1,0 +1,49 @@
+{
+  "config": {
+    "type": "rl",
+    "num_gpus": 8,
+    "model_name": "meta-llama/Llama-3.2-3B-Instruct",
+    "lora_rank": 16,
+    "seq_len": 65536,
+    "ac": "Recompute",
+    "attention": "flash_attention_4",
+    "impl": "custom",
+    "output": "benchmarks/fa4_comparison_results/benchmark-8xb200-meta-llama--Llama-3.2-3B-Instruct-rl-16-8gpu-Recompute-flash_attention_4-65536-cp1-ep1.json",
+    "dry_run": false,
+    "timeout": 1500,
+    "micro_batches": 2,
+    "ep": 1,
+    "cp": 1,
+    "docker_image": null,
+    "device_name": "NVIDIA B200",
+    "commit_sha": "30bf494f",
+    "timestamp": "2026-02-07T02:30:12.710313+00:00",
+    "success": true,
+    "error_reason": null,
+    "time_taken": 113.88598341300167
+  },
+  "metrics": {
+    "mfu": {
+      "mean": 35.2332488671421,
+      "std": 0.017098610693464317,
+      "min": 35.21616684670768,
+      "max": 35.25036401994357
+    },
+    "throughput": {
+      "mean": 78643.77531784035,
+      "std": 38.16563447483204,
+      "min": 78605.64671431345,
+      "max": 78681.97787578567
+    },
+    "step_time": {
+      "mean": 13.332519448002131,
+      "std": 0.017143881156537616,
+      "min": 13.31971798900122,
+      "max": 13.351997052002844
+    },
+    "peak_memory": {
+      "gib": 28.044921875,
+      "pct": 15.724549348996922
+    }
+  }
+}

--- a/benchmarks/results/BENCHMARKS.md
+++ b/benchmarks/results/BENCHMARKS.md
@@ -2,7 +2,7 @@
 
 Automated benchmark results for prime-rl using `--bench` flag.
 
-**Last Updated:** 2026-02-07 02:37 UTC  
+**Last Updated:** 2026-02-07 03:03 UTC  
 **Commit:** `30bf494f`  
 **Docker Image:** `None`
 
@@ -14,9 +14,11 @@ Automated benchmark results for prime-rl using `--bench` flag.
 
 | Type | SeqLen | AC | Attn | EP | CP | Hardware | MFU | TPS | Step Time | Peak Mem |
 |------|--------|----|----|----|----|----------|-----|-----|-----------|----------|
+| RL LoRA(r=16) | 16384 | Recompute | FA4 | 1 | 1 | 8xB200 | 13.3% | 25.56k | 5.13s | 91.9 GiB |
 | RL LoRA(r=16) | 16384 | Recompute | FA3 | 1 | 1 | 8xH200 | 19.8% | 16.69k | 7.85s | 89.7 GiB |
 | RL LoRA(r=16) | 16384 | Offload | FA3 | 1 | 1 | 8xH200 | 19.2% | 16.15k | 8.11s | 84.2 GiB |
 | RL LoRA(r=16) | 16384 | Recompute | FA2 | 1 | 1 | 8xB200 | 2.5% | 4.78k | 27.45s | 90.4 GiB |
+| RL LoRA(r=16) | 65536 | Recompute | FA4 | 1 | 1 | 8xB200 | 19.6% | 17.36k | 30.20s | 161.7 GiB |
 | RL LoRA(r=16) | 65536 | Offload | FA3 | 1 | 1 | 8xH200 | 25.1% | 9.76k | 53.73s | 128.8 GiB |
 | RL LoRA(r=16) | 65536 | Offload | FA2 | 1 | 1 | 8xH200 | 16.2% | 6.30k | 83.23s | 130.3 GiB |
 | RL LoRA(r=16) | 65536 | Recompute | FA2 | 1 | 1 | 8xB200 | 5.8% | 5.16k | 101.60s | 153.6 GiB |

--- a/benchmarks/results/BENCHMARKS.md
+++ b/benchmarks/results/BENCHMARKS.md
@@ -2,7 +2,7 @@
 
 Automated benchmark results for prime-rl using `--bench` flag.
 
-**Last Updated:** 2026-02-01 00:43 UTC  
+**Last Updated:** 2026-02-07 01:44 UTC  
 **Commit:** `unknown`  
 **Docker Image:** `primeintellect/prime-rl-jackmin@sha256:5a146f7dfdcdf6b0e90fd3f1ed0874d22a3a0641378dc8dad46ce213d02fa2e6`
 
@@ -52,38 +52,47 @@ Automated benchmark results for prime-rl using `--bench` flag.
 
 | Type | SeqLen | AC | Attn | EP | CP | Hardware | MFU | TPS | Step Time | Peak Mem |
 |------|--------|----|----|----|----|----------|-----|-----|-----------|----------|
+| RL Full | 16384 | Recompute | FA2 | 1 | 1 | 8xB200 | 2.8% | 13.57k | 9.66s | 85.6 GiB |
+| RL Full | 16384 | Recompute | FA4 | 1 | 1 | 8xB200 | 2.5% | 11.87k | 11.04s | 86.6 GiB |
 | RL Full | 16384 | Recompute | FA3 | 1 | 1 | 8xH100 HBM3 | 2.9% | 6.11k | 21.44s | 74.6 GiB |
 | RL Full | 16384 | Recompute | FA3 | 1 | 1 | 8xH200 | 2.8% | 5.94k | 22.06s | 74.6 GiB |
+| RL Full | 65536 | Recompute | FA4 | 1 | 1 | 8xB200 | 12.7% | 24.01k | 21.84s | 108.8 GiB |
+| RL Full | 65536 | Recompute | FA2 | 1 | 1 | 8xB200 | 8.8% | 16.55k | 31.69s | 101.3 GiB |
 | RL Full | 65536 | Recompute | FA3 | 1 | 1 | 8xH200 | 15.4% | 12.75k | 41.13s | 105.4 GiB |
+| RL LoRA(r=16) | 16384 | Recompute | FA4 | 1 | 1 | 8xB200 | 10.0% | 49.13k | 2.67s | 32.9 GiB |
 | RL LoRA(r=16) | 16384 | Recompute | FA3 | 1 | 1 | 8xH200 | 17.0% | 36.77k | 3.56s | 31.6 GiB |
+| RL LoRA(r=16) | 16384 | Recompute | FA2 | 1 | 1 | 8xB200 | 7.3% | 36.12k | 3.63s | 32.9 GiB |
 | RL LoRA(r=16) | 16384 | Recompute | FA3 | 1 | 1 | 8xH100 HBM3 | 15.3% | 33.10k | 3.96s | 31.6 GiB |
-| RL LoRA(r=16) | 16384 | Recompute | FA2 | 1 | 1 | 8xB200 | 1.9% | 9.27k | 14.14s | 32.0 GiB |
+| RL LoRA(r=16) | 65536 | Recompute | FA4 | 1 | 1 | 8xB200 | 19.7% | 37.43k | 14.01s | 64.3 GiB |
 | RL LoRA(r=16) | 65536 | Recompute | FA3 | 1 | 1 | 8xH200 | 29.2% | 24.41k | 21.48s | 63.7 GiB |
 | RL LoRA(r=16) | 65536 | Recompute | FA3 | 1 | 1 | 8xH100 HBM3 | 27.9% | 23.39k | 22.42s | 63.7 GiB |
-| RL LoRA(r=16) | 65536 | Recompute | FA2 | 1 | 1 | 8xB200 | 6.9% | 13.23k | 39.64s | 64.8 GiB |
+| RL LoRA(r=16) | 65536 | Recompute | FA2 | 1 | 1 | 8xB200 | 10.0% | 19.06k | 27.51s | 64.3 GiB |
+| SFT Full | 16384 | Recompute | FA4 | 1 | 1 | 8xB200 | 11.6% | 55.68k | 2.35s | 111.8 GiB |
+| SFT Full | 16384 | Recompute | FA2 | 1 | 1 | 8xB200 | 11.6% | 55.67k | 2.35s | 111.8 GiB |
 | SFT Full | 16384 | Recompute | FA3 | 1 | 1 | 8xH200 | 16.6% | 35.03k | 3.74s | 106.4 GiB |
 
 ## Qwen3-4B-Instruct-2507
 
 | Type | SeqLen | AC | Attn | EP | CP | Hardware | MFU | TPS | Step Time | Peak Mem |
 |------|--------|----|----|----|----|----------|-----|-----|-----------|----------|
-| RL Full | 16384 | Recompute | FA2 | 1 | 1 | 8xB200 | 6.5% | 27.54k | 4.76s | 17.0 GiB |
+| RL Full | 16384 | Recompute | FA2 | 1 | 1 | 8xB200 | 9.4% | 40.20k | 3.26s | 18.1 GiB |
 | RL Full | 16384 | Recompute | FA3 | 1 | 1 | 8xH200 | 14.7% | 27.44k | 4.78s | 17.1 GiB |
 | RL Full | 16384 | Recompute | FA3 | 1 | 1 | 8xH100 HBM3 | 13.9% | 26.03k | 5.04s | 17.1 GiB |
 | RL Full | 65536 | Recompute | FA3 | 1 | 1 | 8xH200 | 36.1% | 29.54k | 17.75s | 36.1 GiB |
 | RL Full | 65536 | Recompute | FA3 | 1 | 1 | 8xH100 HBM3 | 35.4% | 28.97k | 18.10s | 36.1 GiB |
+| RL Full | 65536 | Recompute | FA2 | 1 | 1 | 8xB200 | 13.9% | 25.96k | 20.20s | 39.0 GiB |
 | RL LoRA(r=16) | 16384 | Recompute | FA3 | 1 | 1 | 8xH200 | 22.8% | 52.38k | 2.50s | 10.3 GiB |
+| RL LoRA(r=16) | 16384 | Recompute | FA2 | 1 | 1 | 8xB200 | 9.8% | 51.21k | 2.56s | 11.1 GiB |
 | RL LoRA(r=16) | 16384 | Recompute | FA3 | 1 | 1 | 8xH100 HBM3 | 21.2% | 48.72k | 2.69s | 10.3 GiB |
-| RL LoRA(r=16) | 16384 | Recompute | FA2 | 1 | 1 | 8xB200 | 8.8% | 46.08k | 2.84s | 10.2 GiB |
 | RL LoRA(r=16) | 16384 | Recompute | FA3 | 1 | 1 | 1xH100 HBM3 | 21.7% | 6.23k | 2.63s | 23.3 GiB |
 | RL LoRA(r=16) | 16384 | Offload | FA3 | 1 | 1 | 1xH100 HBM3 | 20.7% | 5.95k | 2.75s | 20.6 GiB |
 | RL LoRA(r=16) | 16384 | Recompute | FA2 | 1 | 1 | 1xA6000 | 13.6% | 1.23k | 13.29s | 23.3 GiB |
 | RL LoRA(r=16) | 65536 | Recompute | FA3 | 1 | 1 | 8xH200 | 37.5% | 33.43k | 15.68s | 28.8 GiB |
 | RL LoRA(r=16) | 65536 | Recompute | FA3 | 1 | 1 | 8xH100 HBM3 | 36.8% | 32.80k | 15.98s | 28.8 GiB |
-| RL LoRA(r=16) | 65536 | Recompute | FA2 | 1 | 1 | 8xB200 | 12.3% | 25.04k | 20.94s | 28.8 GiB |
+| RL LoRA(r=16) | 65536 | Recompute | FA2 | 1 | 1 | 8xB200 | 12.8% | 25.90k | 20.25s | 31.7 GiB |
 | RL LoRA(r=16) | 65536 | Recompute | FA3 | 1 | 1 | 1xH100 HBM3 | 37.4% | 4.16k | 15.74s | 42.0 GiB |
 | RL LoRA(r=16) | 65536 | Offload | FA3 | 1 | 1 | 1xH100 HBM3 | 36.3% | 4.04k | 16.21s | 31.1 GiB |
-| SFT Full | 16384 | Recompute | FA2 | 1 | 1 | 8xB200 | 16.0% | 68.36k | 1.92s | 54.6 GiB |
+| SFT Full | 16384 | Recompute | FA2 | 1 | 1 | 8xB200 | 15.5% | 66.04k | 1.98s | 52.5 GiB |
 | SFT Full | 16384 | Recompute | FA2 | 1 | 1 | 8xH200 | 28.4% | 53.14k | 2.47s | 54.6 GiB |
 | SFT Full | 16384 | Recompute | FA2 | 1 | 1 | 8xH100 HBM3 | 26.6% | 49.72k | 2.64s | 54.6 GiB |
 | SFT Full | 65536 | Recompute | FA2 | 1 | 1 | 8xB200 | 14.2% | 26.39k | 19.86s | 171.5 GiB |

--- a/benchmarks/results/BENCHMARKS.md
+++ b/benchmarks/results/BENCHMARKS.md
@@ -2,9 +2,9 @@
 
 Automated benchmark results for prime-rl using `--bench` flag.
 
-**Last Updated:** 2026-02-07 01:44 UTC  
-**Commit:** `unknown`  
-**Docker Image:** `primeintellect/prime-rl-jackmin@sha256:5a146f7dfdcdf6b0e90fd3f1ed0874d22a3a0641378dc8dad46ce213d02fa2e6`
+**Last Updated:** 2026-02-07 02:37 UTC  
+**Commit:** `30bf494f`  
+**Docker Image:** `None`
 
 > :warning: indicates regression > 5% from baseline
 > diffs shown when abs(change) >= 1.0% (except regressions, which always show diffs)
@@ -96,3 +96,24 @@ Automated benchmark results for prime-rl using `--bench` flag.
 | SFT Full | 16384 | Recompute | FA2 | 1 | 1 | 8xH200 | 28.4% | 53.14k | 2.47s | 54.6 GiB |
 | SFT Full | 16384 | Recompute | FA2 | 1 | 1 | 8xH100 HBM3 | 26.6% | 49.72k | 2.64s | 54.6 GiB |
 | SFT Full | 65536 | Recompute | FA2 | 1 | 1 | 8xB200 | 14.2% | 26.39k | 19.86s | 171.5 GiB |
+
+## Llama-3.1-8B-Instruct
+
+| Type | SeqLen | AC | Attn | EP | CP | Hardware | MFU | TPS | Step Time | Peak Mem |
+|------|--------|----|----|----|----|----------|-----|-----|-----------|----------|
+| RL LoRA(r=16) | 16384 | Recompute | FA4 | 1 | 1 | 8xB200 | 20.5% | 66.01k | 1.99s | 16.6 GiB |
+| RL LoRA(r=16) | 65536 | Recompute | FA4 | 1 | 1 | 8xB200 | 37.7% | 50.82k | 10.32s | 43.9 GiB |
+
+## Llama-3.2-1B-Instruct
+
+| Type | SeqLen | AC | Attn | EP | CP | Hardware | MFU | TPS | Step Time | Peak Mem |
+|------|--------|----|----|----|----|----------|-----|-----|-----------|----------|
+| RL LoRA(r=16) | 16384 | Recompute | FA4 | 1 | 1 | 8xB200 | 9.9% | 155.50k | 0.84s | 5.6 GiB |
+| RL LoRA(r=16) | 65536 | Recompute | FA4 | 1 | 1 | 8xB200 | 22.3% | 130.51k | 4.02s | 15.5 GiB |
+
+## Llama-3.2-3B-Instruct
+
+| Type | SeqLen | AC | Attn | EP | CP | Hardware | MFU | TPS | Step Time | Peak Mem |
+|------|--------|----|----|----|----|----------|-----|-----|-----------|----------|
+| RL LoRA(r=16) | 16384 | Recompute | FA4 | 1 | 1 | 8xB200 | 16.2% | 97.78k | 1.34s | 10.0 GiB |
+| RL LoRA(r=16) | 65536 | Recompute | FA4 | 1 | 1 | 8xB200 | 35.2% | 78.64k | 6.67s | 28.0 GiB |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Data-only updates to benchmark baselines and the generated markdown report; no runtime logic changes, with the main risk being downstream consumers relying on exact baseline file contents/paths.
> 
> **Overview**
> Updates benchmark artifacts to include **FlashAttention v4 (FA4) baseline results** on `8xB200` for multiple models (new baseline JSONs for `INTELLECT-3` and several `Llama`/`Qwen` configurations, plus refreshed metrics for some existing `flash_attention_2` baselines).
> 
> Refreshes `benchmarks/results/BENCHMARKS.md` with the new run metadata (timestamp/commit and docker image set to `None`) and adds the corresponding new rows/sections for FA4 results (including new `Llama-3.x` sections) while removing superseded older baseline entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bffbdd057c2202fb160d699f373d7654dd742150. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->