### PR TITLE
set VLLM_WORKER_MULTIPROC_METHOD=spawn by default

### DIFF
--- a/docs/multimodal.md
+++ b/docs/multimodal.md
@@ -32,11 +32,4 @@ Each multimodal sample becomes its own micro-batch during training (no packing w
 
 ## vLLM Configuration
 
-When using vLLM for inference with VLM models, these environment variables are required:
-
-```bash
-VLLM_ENABLE_V1_MULTIPROCESSING=0
-VLLM_WORKER_MULTIPROC_METHOD=spawn
-```
-
-These are set automatically when a VLM model is detected. You can still override them by setting the variables yourself before launching the server.
+`VLLM_WORKER_MULTIPROC_METHOD=spawn` is required for VLM inference. This is set automatically in `src/prime_rl/inference/config.py`, so if you use `uv run rl @ ...` it works out of the box, but if you start the vLLM server yourself, make sure this environment variable is set.

--- a/docs/multimodal.md
+++ b/docs/multimodal.md
@@ -32,9 +32,11 @@ Each multimodal sample becomes its own micro-batch during training (no packing w
 
 ## vLLM Configuration
 
-When using vLLM for inference with VLM models, you must set these environment variables to avoid issues with multimodal models:
+When using vLLM for inference with VLM models, these environment variables are required:
 
 ```bash
-export VLLM_ENABLE_V1_MULTIPROCESSING=0
-export VLLM_WORKER_MULTIPROC_METHOD=spawn
+VLLM_ENABLE_V1_MULTIPROCESSING=0
+VLLM_WORKER_MULTIPROC_METHOD=spawn
 ```
+
+These are set automatically when a VLM model is detected. You can still override them by setting the variables yourself before launching the server.

--- a/src/prime_rl/inference/config.py
+++ b/src/prime_rl/inference/config.py
@@ -6,7 +6,6 @@ from pydantic import Field, model_validator
 
 from prime_rl.utils.pydantic_config import BaseConfig, BaseSettings, get_all_fields
 from prime_rl.utils.utils import rgetattr, rsetattr
-from prime_rl.utils.vlm import is_vlm_model
 
 # TODO: Set thinking/ solution budget
 
@@ -197,9 +196,8 @@ class InferenceConfig(BaseSettings):
 
     @model_validator(mode="after")
     def auto_setup_vllm_env(self):
+        # spawn is more robust in vLLM nightlies and Qwen3-VL (fork can deadlock with multithreaded processes)
         os.environ.setdefault("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
-        if is_vlm_model(self.model.name):
-            os.environ.setdefault("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/inference/config.py
+++ b/src/prime_rl/inference/config.py
@@ -196,10 +196,10 @@ class InferenceConfig(BaseSettings):
         return self
 
     @model_validator(mode="after")
-    def auto_setup_vlm_env(self):
+    def auto_setup_vllm_env(self):
+        os.environ.setdefault("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
         if is_vlm_model(self.model.name):
             os.environ.setdefault("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
-            os.environ.setdefault("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/inference/config.py
+++ b/src/prime_rl/inference/config.py
@@ -6,6 +6,7 @@ from pydantic import Field, model_validator
 
 from prime_rl.utils.pydantic_config import BaseConfig, BaseSettings, get_all_fields
 from prime_rl.utils.utils import rgetattr, rsetattr
+from prime_rl.utils.vlm import is_vlm_model
 
 # TODO: Set thinking/ solution budget
 
@@ -192,6 +193,13 @@ class InferenceConfig(BaseSettings):
     def auto_setup_dynamic_lora_updating(self):
         if self.enable_lora:
             os.environ["VLLM_ALLOW_RUNTIME_LORA_UPDATING"] = "True"
+        return self
+
+    @model_validator(mode="after")
+    def auto_setup_vlm_env(self):
+        if is_vlm_model(self.model.name):
+            os.environ.setdefault("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+            os.environ.setdefault("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
         return self
 
     @model_validator(mode="after")


### PR DESCRIPTION
Automatically set `VLLM_WORKER_MULTIPROC_METHOD=spawn`, making vLLM more robust & removing footgun-y manual setup for VLMs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only sets a default vLLM environment variable during inference config validation and updates documentation; main impact is changing vLLM worker start method unless explicitly overridden.
> 
> **Overview**
> Automatically configures vLLM to use `VLLM_WORKER_MULTIPROC_METHOD=spawn` during inference config validation (via a new `InferenceConfig` `model_validator`), avoiding deadlocks seen with `fork` in some vLLM/VLM setups.
> 
> Updates the multimodal docs to remove the manual env-var export snippet and instead document that Prime-RL sets the variable automatically when launched via `uv run rl`, while noting it must be set when starting vLLM manually.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c10b73d50c156074449adbca93ae860b3cad3cfd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->