### PR TITLE
[DRAFT] Add trainable KV cache support

### DIFF
--- a/src/prime_rl/inference/vllm/kv_prefix.py
+++ b/src/prime_rl/inference/vllm/kv_prefix.py
@@ -1,0 +1,160 @@
+from collections.abc import Generator, Iterable
+
+import torch
+import torch.nn as nn
+
+KV_PREFIX_KEY_SUFFIX = ".kv_prefix_key"
+KV_PREFIX_VALUE_SUFFIX = ".kv_prefix_value"
+
+
+def is_kv_prefix_weight_name(name: str) -> bool:
+    return name.endswith(KV_PREFIX_KEY_SUFFIX) or name.endswith(KV_PREFIX_VALUE_SUFFIX)
+
+
+def split_kv_prefix_state_dict(
+    weights_iterator: Iterable[tuple[str, torch.Tensor]],
+) -> tuple[Generator[tuple[str, torch.Tensor], None, None], dict[str, torch.Tensor]]:
+    kv_prefix_state_dict: dict[str, torch.Tensor] = {}
+
+    def _iterator() -> Generator[tuple[str, torch.Tensor], None, None]:
+        for name, tensor in weights_iterator:
+            if is_kv_prefix_weight_name(name):
+                kv_prefix_state_dict[name] = tensor
+                continue
+            yield name, tensor
+
+    return _iterator(), kv_prefix_state_dict
+
+
+def _iter_attention_layers(model: nn.Module) -> Generator[tuple[str, nn.Module], None, None]:
+    for _, module in model.named_modules():
+        layer_name = getattr(module, "layer_name", None)
+        if not isinstance(layer_name, str):
+            continue
+        if not hasattr(module, "num_kv_heads") or not hasattr(module, "head_size"):
+            continue
+        yield layer_name, module
+
+
+def clear_kv_prefix_state(model: nn.Module) -> None:
+    for _, layer in _iter_attention_layers(model):
+        layer._prime_kv_prefix_key = None
+        layer._prime_kv_prefix_value = None
+        layer._prime_kv_prefix_num_tokens = 0
+
+
+def _split_kv_prefix_key(name: str) -> tuple[str, str] | None:
+    if name.endswith(KV_PREFIX_KEY_SUFFIX):
+        return name[: -len(KV_PREFIX_KEY_SUFFIX)], "key"
+    if name.endswith(KV_PREFIX_VALUE_SUFFIX):
+        return name[: -len(KV_PREFIX_VALUE_SUFFIX)], "value"
+    return None
+
+
+def _resolve_layer_name(base_name: str, available_layer_names: set[str]) -> str:
+    if base_name in available_layer_names:
+        return base_name
+
+    with_attn = f"{base_name}.attn"
+    if with_attn in available_layer_names:
+        return with_attn
+
+    if base_name.endswith(".attn"):
+        without_attn = base_name[: -len(".attn")]
+        if without_attn in available_layer_names:
+            return without_attn
+
+    raise ValueError(f"No matching vLLM attention layer for KV-prefix tensor base '{base_name}'")
+
+
+def _reshape_prefix_tensor_for_layer(layer: nn.Module, tensor: torch.Tensor, kind: str) -> torch.Tensor:
+    if tensor.ndim != 3:
+        raise ValueError(f"KV-prefix {kind} tensor must be rank-3, got shape {tuple(tensor.shape)}")
+
+    num_kv_heads = int(layer.num_kv_heads)
+    head_size = int(layer.head_size)
+
+    if tensor.shape[0] == num_kv_heads and tensor.shape[2] == head_size:
+        # Trainer layout: [num_kv_heads, num_prefix_tokens, head_size]
+        return tensor.transpose(0, 1).contiguous()
+
+    if tensor.shape[1] == num_kv_heads and tensor.shape[2] == head_size:
+        # Already in inference layout: [num_prefix_tokens, num_kv_heads, head_size]
+        return tensor.contiguous()
+
+    raise ValueError(
+        f"KV-prefix {kind} tensor shape {tuple(tensor.shape)} is incompatible with "
+        f"layer (num_kv_heads={num_kv_heads}, head_size={head_size})"
+    )
+
+
+def _validate_attention_backend(layer: nn.Module, layer_name: str) -> None:
+    impl = getattr(layer, "impl", None)
+    if impl is None:
+        return
+    if "flash_attn" not in type(impl).__module__:
+        raise ValueError(
+            f"KV-prefix inference currently requires FlashAttention backend, but layer '{layer_name}' uses "
+            f"{type(impl).__module__}.{type(impl).__name__}"
+        )
+
+
+def apply_kv_prefix_state_dict(model: nn.Module, kv_prefix_state_dict: dict[str, torch.Tensor]) -> int:
+    clear_kv_prefix_state(model)
+    if len(kv_prefix_state_dict) == 0:
+        return 0
+
+    grouped: dict[str, dict[str, torch.Tensor]] = {}
+    for name, tensor in kv_prefix_state_dict.items():
+        split = _split_kv_prefix_key(name)
+        if split is None:
+            continue
+        base_name, kind = split
+        grouped.setdefault(base_name, {})[kind] = tensor
+
+    if len(grouped) == 0:
+        return 0
+
+    layers = dict(_iter_attention_layers(model))
+    available_layer_names = set(layers.keys())
+
+    applied_layers = 0
+    for base_name, tensors in grouped.items():
+        if "key" not in tensors or "value" not in tensors:
+            raise ValueError(f"KV-prefix tensors for '{base_name}' must include both key and value")
+
+        layer_name = _resolve_layer_name(base_name, available_layer_names)
+        layer = layers[layer_name]
+        _validate_attention_backend(layer, layer_name)
+
+        key = _reshape_prefix_tensor_for_layer(layer, tensors["key"], "key")
+        value = _reshape_prefix_tensor_for_layer(layer, tensors["value"], "value")
+
+        if key.shape != value.shape:
+            raise ValueError(
+                f"KV-prefix key/value shapes do not match for layer '{layer_name}': "
+                f"{tuple(key.shape)} vs {tuple(value.shape)}"
+            )
+
+        prefix_tokens = int(key.shape[0])
+        if prefix_tokens < 1:
+            raise ValueError(f"KV-prefix length must be >= 1 for layer '{layer_name}'")
+
+        device = layer._k_scale.device
+        layer._prime_kv_prefix_key = key.to(device=device, non_blocking=False)
+        layer._prime_kv_prefix_value = value.to(device=device, non_blocking=False)
+        layer._prime_kv_prefix_num_tokens = prefix_tokens
+        applied_layers += 1
+
+    return applied_layers
+
+
+def get_layer_kv_prefix(layer: nn.Module) -> tuple[torch.Tensor, torch.Tensor, int] | None:
+    key = getattr(layer, "_prime_kv_prefix_key", None)
+    value = getattr(layer, "_prime_kv_prefix_value", None)
+    num_tokens = int(getattr(layer, "_prime_kv_prefix_num_tokens", 0))
+
+    if key is None or value is None or num_tokens == 0:
+        return None
+
+    return key, value, num_tokens

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -359,7 +359,9 @@ class ModelConfig(BaseConfig):
         if self.kv_prefix is None:
             return self
         if self.impl == "hf":
-            raise ValueError("KV-prefix tuning is only supported with the custom implementation (impl='custom' or 'auto').")
+            raise ValueError(
+                "KV-prefix tuning is only supported with the custom implementation (impl='custom' or 'auto')."
+            )
         if self.attn not in ["flash_attention_2", "flash_attention_3", "fa4"]:
             raise ValueError("KV-prefix tuning requires flash attention 2/3/4.")
         if self.cp > 1:

--- a/src/prime_rl/trainer/kv_prefix.py
+++ b/src/prime_rl/trainer/kv_prefix.py
@@ -5,7 +5,6 @@ import torch.nn as nn
 
 from prime_rl.trainer.models.layers.attn import FlashAttention
 
-
 KV_PREFIX_KEY_NAME = "kv_prefix_key"
 KV_PREFIX_VALUE_NAME = "kv_prefix_value"
 

--- a/src/prime_rl/trainer/kv_prefix.py
+++ b/src/prime_rl/trainer/kv_prefix.py
@@ -1,0 +1,48 @@
+from typing import Iterable
+
+import torch
+import torch.nn as nn
+
+from prime_rl.trainer.models.layers.attn import FlashAttention
+
+
+KV_PREFIX_KEY_NAME = "kv_prefix_key"
+KV_PREFIX_VALUE_NAME = "kv_prefix_value"
+
+
+def is_kv_prefix_param_name(name: str) -> bool:
+    return KV_PREFIX_KEY_NAME in name or KV_PREFIX_VALUE_NAME in name
+
+
+def strip_kv_prefix_from_state_dict(state_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+    return {key: value for key, value in state_dict.items() if not is_kv_prefix_param_name(key)}
+
+
+def iter_kv_prefix_named_parameters(model: nn.Module) -> Iterable[tuple[str, nn.Parameter]]:
+    for name, param in model.named_parameters():
+        if is_kv_prefix_param_name(name):
+            yield name, param
+
+
+def freeze_all_except_kv_prefix(model: nn.Module) -> None:
+    for name, param in model.named_parameters():
+        param.requires_grad = is_kv_prefix_param_name(name)
+
+
+def apply_kv_prefix_to_model(
+    model: nn.Module,
+    num_tokens: int,
+    init: str = "normal",
+    init_std: float = 0.02,
+) -> list[str]:
+    module_names: list[str] = []
+    for module_name, module in model.named_modules():
+        if not isinstance(module, FlashAttention):
+            continue
+        module.enable_kv_prefix(num_tokens=num_tokens, init=init, init_std=init_std)
+        module_names.append(module_name)
+
+    if not module_names:
+        raise ValueError("No compatible flash-attention modules found for KV-prefix tuning.")
+
+    return module_names

--- a/src/prime_rl/trainer/models/glm4_moe/modeling_glm4_moe.py
+++ b/src/prime_rl/trainer/models/glm4_moe/modeling_glm4_moe.py
@@ -207,8 +207,9 @@ class Glm4MoeModel(Glm4MoePreTrainedModel):
         if inputs_embeds is None:
             inputs_embeds: torch.Tensor = self.embed_tokens(input_ids)
 
+        base_position_ids = position_ids
         if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4"):
-            flat_position_ids = position_ids.view(-1)
+            flat_position_ids = base_position_ids.view(-1)
             seqlens = torch.cat(
                 [
                     flat_position_ids[0:1],
@@ -222,6 +223,11 @@ class Glm4MoeModel(Glm4MoePreTrainedModel):
         else:
             max_seqlen = None
             cu_seqlens = None
+
+        prefix_tokens = 0
+        if len(self.layers) > 0 and hasattr(self.layers[0].self_attn, "kv_prefix_num_tokens"):
+            prefix_tokens = self.layers[0].self_attn.kv_prefix_num_tokens()
+        position_ids = base_position_ids + prefix_tokens if prefix_tokens > 0 else base_position_ids
 
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)

--- a/src/prime_rl/trainer/models/layers/attn.py
+++ b/src/prime_rl/trainer/models/layers/attn.py
@@ -168,11 +168,14 @@ class FlashAttention(nn.Module):
         prefixed_keys = torch.cat(merged_keys, dim=0).contiguous()
         prefixed_values = torch.cat(merged_values, dim=0).contiguous()
 
-        seq_prefix_offsets = torch.arange(
-            cu_seqlens_q.shape[0],
-            device=cu_seqlens_q.device,
-            dtype=cu_seqlens_q.dtype,
-        ) * self._kv_prefix_num_tokens
+        seq_prefix_offsets = (
+            torch.arange(
+                cu_seqlens_q.shape[0],
+                device=cu_seqlens_q.device,
+                dtype=cu_seqlens_q.dtype,
+            )
+            * self._kv_prefix_num_tokens
+        )
         cu_seqlens_k = cu_seqlens_q + seq_prefix_offsets
         max_seqlen_k = max_seqlen_q + self._kv_prefix_num_tokens
         return prefixed_keys, prefixed_values, cu_seqlens_k, max_seqlen_k

--- a/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
@@ -208,8 +208,9 @@ class Qwen3MoeModel(Qwen3MoePreTrainedModel):
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
 
+        base_position_ids = position_ids
         if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4"):
-            flat_position_ids = position_ids.view(-1)
+            flat_position_ids = base_position_ids.view(-1)
             seqlens = torch.cat(
                 [
                     flat_position_ids[0:1],
@@ -223,6 +224,11 @@ class Qwen3MoeModel(Qwen3MoePreTrainedModel):
         else:
             max_seqlen = None
             cu_seqlens = None
+
+        prefix_tokens = 0
+        if len(self.layers) > 0 and hasattr(self.layers[0].self_attn, "kv_prefix_num_tokens"):
+            prefix_tokens = self.layers[0].self_attn.kv_prefix_num_tokens()
+        position_ids = base_position_ids + prefix_tokens if prefix_tokens > 0 else base_position_ids
 
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)

--- a/src/prime_rl/trainer/multi_ckpt.py
+++ b/src/prime_rl/trainer/multi_ckpt.py
@@ -149,9 +149,7 @@ class MultiCheckpointManager:
                 }
                 shared_model_state_dict = None
                 if optimizer.shared_named_params:
-                    shared_model_state_dict = {
-                        k: v.data.detach().clone() for k, v in optimizer.shared_named_params
-                    }
+                    shared_model_state_dict = {k: v.data.detach().clone() for k, v in optimizer.shared_named_params}
                 run_state = RunState(
                     model_state_dict,
                     shared_model_state_dict,

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -348,8 +348,6 @@ def setup_multi_optimizer(
     shared_named_params: list[tuple[str, nn.Parameter]] = []
     if named_params is not None:
         shared_named_params = [
-            (name, param)
-            for name, param in named_params
-            if param.requires_grad and not _is_lora_param_name(name)
+            (name, param) for name, param in named_params if param.requires_grad and not _is_lora_param_name(name)
         ]
     return MultiLoRAOptimizer(config, parallel_dims, shared_named_params=shared_named_params)

--- a/src/prime_rl/trainer/rl/broadcast/__init__.py
+++ b/src/prime_rl/trainer/rl/broadcast/__init__.py
@@ -13,7 +13,7 @@ def setup_weight_broadcast(
     output_dir: Path, config: WeightBroadcastConfigType, lora_config: LoRAConfig | None = None
 ) -> WeightBroadcast:
     if config.type == "nccl":
-        return NCCLWeightBroadcast(output_dir, config, torch.cuda.current_device())
+        return NCCLWeightBroadcast(output_dir, config, torch.cuda.current_device(), lora_config=lora_config)
     elif config.type == "filesystem":
         return FileSystemWeightBroadcast(output_dir, config, lora_config)
     else:

--- a/src/prime_rl/trainer/rl/broadcast/filesystem.py
+++ b/src/prime_rl/trainer/rl/broadcast/filesystem.py
@@ -94,10 +94,14 @@ class FileSystemWeightBroadcast(WeightBroadcast):
 
                     self.logger.debug(f"Saving weights for run {idx} to {save_dir}")
                     if full_state_dict is not None:
-                        save_state_dict(dict(full_state_dict), save_dir, self.save_format, self.save_sharded, adapter=False)
+                        save_state_dict(
+                            dict(full_state_dict), save_dir, self.save_format, self.save_sharded, adapter=False
+                        )
 
                     if adapter_state_dict is not None:
-                        save_state_dict(adapter_state_dict, save_dir, self.save_format, save_sharded=False, adapter=True)
+                        save_state_dict(
+                            adapter_state_dict, save_dir, self.save_format, save_sharded=False, adapter=True
+                        )
                         save_lora_config(self.lora_config, model, save_dir)
 
                     self._notify_orchestrator(save_dir)

--- a/src/prime_rl/trainer/rl/broadcast/filesystem.py
+++ b/src/prime_rl/trainer/rl/broadcast/filesystem.py
@@ -3,6 +3,7 @@ import time
 from pathlib import Path
 from typing import Literal
 
+import torch
 import torch.nn as nn
 from torch.distributed.tensor import DTensor
 
@@ -32,35 +33,55 @@ class FileSystemWeightBroadcast(WeightBroadcast):
         self.save_sharded = config.save_sharded if lora_config is None else False
         self.world = get_world()
         self.multi_run_manager = get_multi_run_manager()
+        self._logged_full_weights_with_lora = False
         self.logger.debug(
             f"Filesystem broadcast initialized (save_format={config.save_format}, save_sharded={self.save_sharded})"
         )
+
+    def _has_trainable_non_lora_params(self, model: nn.Module) -> bool:
+        return any(
+            param.requires_grad and "lora_A" not in name and "lora_B" not in name
+            for name, param in model.named_parameters()
+        )
+
+    def _get_adapter_state_dict_for_run(self, idx: int) -> dict[str, torch.Tensor]:
+        state_dict = self.multi_run_manager.get_state_dict_for_run(idx)
+        for key, value in list(state_dict.items()):
+            if isinstance(value, DTensor):
+                value = value.full_tensor()
+            if self.world.is_master:
+                state_dict[key] = value.to("cpu", non_blocking=False)
+        return state_dict
 
     def broadcast_weights(self, model: nn.Module, step: int) -> None:
         """Broadcast weights by saving a HF-compatible checkpoint to shared filesystem and notifies the orchestrator."""
         self.logger.debug("Starting broadcasting weights to inference engine via shared filesystem")
         start_time = time.perf_counter()
-        adapter_only = self.lora_config is not None
+        has_trainable_non_lora_params = self._has_trainable_non_lora_params(model)
+        adapter_only = self.lora_config is not None and not has_trainable_non_lora_params
 
         if not adapter_only:
-            state_dict = gather_weights_on_master(model, is_master=self.world.is_master)
-            if isinstance(model, PreTrainedModelPrimeRL) and model.is_prime_state_dict(state_dict):
-                model.convert_to_hf(state_dict)
+            full_state_dict = gather_weights_on_master(model, is_master=self.world.is_master)
+            if isinstance(model, PreTrainedModelPrimeRL) and model.is_prime_state_dict(full_state_dict):
+                model.convert_to_hf(full_state_dict)
+        else:
+            full_state_dict = None
+
+        if self.lora_config is not None and not adapter_only and not self._logged_full_weights_with_lora:
+            self.logger.info(
+                "Broadcasting full base weights plus LoRA adapters because non-LoRA trainable parameters are enabled."
+            )
+            self._logged_full_weights_with_lora = True
 
         for idx in self.multi_run_manager.ready_to_update_idxs:
             self.logger.debug(
                 f"Broadcasting weights for run {idx} (ready_to_update={self.multi_run_manager.ready_to_update[idx]})"
             )
 
-            if adapter_only:
-                # For adapter-only, MultiRunManager creates state dict directly for each run
-                # All ranks must participate in DTensor gathering, but only master saves
-                state_dict = self.multi_run_manager.get_state_dict_for_run(idx)
-                for key, value in state_dict.items():
-                    if isinstance(value, DTensor):
-                        value = value.full_tensor()
-                    if self.world.is_master:
-                        state_dict[key] = value.to("cpu", non_blocking=False)
+            adapter_state_dict = None
+            if self.lora_config is not None:
+                # All ranks must participate in DTensor gathering, but only master saves.
+                adapter_state_dict = self._get_adapter_state_dict_for_run(idx)
 
             # TODO: Broadcast ready to update in sync, then we dont need to gather on not ready
             if self.world.is_master:
@@ -72,8 +93,11 @@ class FileSystemWeightBroadcast(WeightBroadcast):
                     save_dir.mkdir(parents=True, exist_ok=True)
 
                     self.logger.debug(f"Saving weights for run {idx} to {save_dir}")
-                    save_state_dict(state_dict, save_dir, self.save_format, self.save_sharded, adapter=adapter_only)
-                    if adapter_only:
+                    if full_state_dict is not None:
+                        save_state_dict(dict(full_state_dict), save_dir, self.save_format, self.save_sharded, adapter=False)
+
+                    if adapter_state_dict is not None:
+                        save_state_dict(adapter_state_dict, save_dir, self.save_format, save_sharded=False, adapter=True)
                         save_lora_config(self.lora_config, model, save_dir)
 
                     self._notify_orchestrator(save_dir)

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -157,7 +157,7 @@ def train(config: RLTrainerConfig):
         )
         scheduler = setup_scheduler(optimizer, config.scheduler, config.max_steps, config.optim.lr)
     else:
-        optimizer = setup_multi_optimizer(config.optim, parallel_dims)
+        optimizer = setup_multi_optimizer(config.optim, parallel_dims, list(model.named_parameters()))
         scheduler = setup_multi_scheduler(optimizer, config.scheduler, config.max_steps)
 
         # Register checkpoint loading callback at index 1 (after scheduler creation at index 0)

--- a/src/prime_rl/trainer/weights.py
+++ b/src/prime_rl/trainer/weights.py
@@ -22,6 +22,7 @@ from transformers.utils import (
 from prime_rl.trainer.lora import (
     clean_lora_state_dict,
 )
+from prime_rl.trainer.kv_prefix import is_kv_prefix_param_name
 from prime_rl.utils.logger import get_logger
 
 PYTORCH_WRAPPER_PREFIXES = ["_fsdp_wrapped_module.", "_orig_module.", "_checkpoint_wrapped_module."]
@@ -146,6 +147,8 @@ def get_adapter_state_dict(model: nn.Module, is_master: bool) -> dict[str, Tenso
 
     named_params = {_strip_pytorch_wrapper_prefix(key): value for key, value in model.named_parameters()}
     for key, value in model.state_dict().items():
+        if is_kv_prefix_param_name(key):
+            continue
         param = named_params.get(key)
         if param is None or not param.requires_grad:
             continue

--- a/src/prime_rl/trainer/weights.py
+++ b/src/prime_rl/trainer/weights.py
@@ -19,10 +19,10 @@ from transformers.utils import (
     WEIGHTS_NAME,
 )
 
+from prime_rl.trainer.kv_prefix import is_kv_prefix_param_name
 from prime_rl.trainer.lora import (
     clean_lora_state_dict,
 )
-from prime_rl.trainer.kv_prefix import is_kv_prefix_param_name
 from prime_rl.utils.logger import get_logger
 
 PYTORCH_WRAPPER_PREFIXES = ["_fsdp_wrapped_module.", "_orig_module.", "_checkpoint_wrapped_module."]

--- a/tests/unit/inference/test_kv_prefix.py
+++ b/tests/unit/inference/test_kv_prefix.py
@@ -1,0 +1,109 @@
+import pytest
+import torch
+from torch import nn
+
+from prime_rl.inference.vllm.kv_prefix import (
+    apply_kv_prefix_state_dict,
+    get_layer_kv_prefix,
+    split_kv_prefix_state_dict,
+)
+
+
+class FakeAttention(nn.Module):
+    def __init__(self, layer_name: str, num_kv_heads: int, head_size: int):
+        super().__init__()
+        self.layer_name = layer_name
+        self.num_kv_heads = num_kv_heads
+        self.head_size = head_size
+        self.register_buffer("_k_scale", torch.tensor(1.0))
+
+
+class FakeModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layers = nn.ModuleList(
+            [
+                FakeAttention("model.layers.0.self_attn.attn", num_kv_heads=2, head_size=4),
+                FakeAttention("model.layers.1.self_attn.attn", num_kv_heads=2, head_size=4),
+            ]
+        )
+
+
+class FakeNonFlashAttentionImpl:
+    pass
+
+
+FakeNonFlashAttentionImpl.__module__ = "vllm.v1.attention.backends.triton_attn"
+
+
+def test_split_kv_prefix_state_dict_filters_kv_tensors():
+    weights = [
+        ("model.layers.0.self_attn.kv_prefix_key", torch.ones(2, 3, 4)),
+        ("model.layers.0.self_attn.kv_prefix_value", torch.ones(2, 3, 4)),
+        ("model.layers.0.self_attn.q_proj.weight", torch.zeros(4, 4)),
+    ]
+
+    filtered_iter, kv_prefix_state = split_kv_prefix_state_dict(weights)
+    filtered_weights = list(filtered_iter)
+
+    assert len(kv_prefix_state) == 2
+    assert len(filtered_weights) == 1
+    assert filtered_weights[0][0] == "model.layers.0.self_attn.q_proj.weight"
+
+
+def test_apply_kv_prefix_state_dict_applies_prefix_to_matching_layer():
+    model = FakeModel()
+
+    kv_prefix_state = {
+        "model.layers.0.self_attn.kv_prefix_key": torch.arange(24, dtype=torch.float32).view(2, 3, 4),
+        "model.layers.0.self_attn.kv_prefix_value": torch.arange(24, dtype=torch.float32).view(2, 3, 4) + 100,
+    }
+
+    applied = apply_kv_prefix_state_dict(model, kv_prefix_state)
+
+    assert applied == 1
+    layer = model.layers[0]
+    prefix = get_layer_kv_prefix(layer)
+    assert prefix is not None
+
+    key, value, prefix_tokens = prefix
+    assert prefix_tokens == 3
+    assert key.shape == (3, 2, 4)
+    assert value.shape == (3, 2, 4)
+    assert torch.equal(key, kv_prefix_state["model.layers.0.self_attn.kv_prefix_key"].transpose(0, 1))
+    assert torch.equal(value, kv_prefix_state["model.layers.0.self_attn.kv_prefix_value"].transpose(0, 1))
+
+def test_apply_kv_prefix_state_dict_clears_existing_prefix_when_empty_update():
+    model = FakeModel()
+    kv_prefix_state = {
+        "model.layers.0.self_attn.kv_prefix_key": torch.ones(2, 2, 4),
+        "model.layers.0.self_attn.kv_prefix_value": torch.ones(2, 2, 4),
+    }
+
+    apply_kv_prefix_state_dict(model, kv_prefix_state)
+    cleared_layers = apply_kv_prefix_state_dict(model, {})
+
+    assert cleared_layers == 0
+    assert get_layer_kv_prefix(model.layers[0]) is None
+
+def test_apply_kv_prefix_state_dict_raises_for_unknown_layer():
+    model = FakeModel()
+    kv_prefix_state = {
+        "model.layers.99.self_attn.kv_prefix_key": torch.ones(2, 2, 4),
+        "model.layers.99.self_attn.kv_prefix_value": torch.ones(2, 2, 4),
+    }
+
+    with pytest.raises(ValueError, match="No matching vLLM attention layer"):
+        apply_kv_prefix_state_dict(model, kv_prefix_state)
+
+
+def test_apply_kv_prefix_state_dict_raises_for_non_flash_attention_backend():
+    model = FakeModel()
+    model.layers[0].impl = FakeNonFlashAttentionImpl()
+    kv_prefix_state = {
+        "model.layers.0.self_attn.kv_prefix_key": torch.ones(2, 2, 4),
+        "model.layers.0.self_attn.kv_prefix_value": torch.ones(2, 2, 4),
+    }
+
+    with pytest.raises(ValueError, match="requires FlashAttention backend"):
+        apply_kv_prefix_state_dict(model, kv_prefix_state)

--- a/tests/unit/inference/test_kv_prefix.py
+++ b/tests/unit/inference/test_kv_prefix.py
@@ -73,6 +73,7 @@ def test_apply_kv_prefix_state_dict_applies_prefix_to_matching_layer():
     assert torch.equal(key, kv_prefix_state["model.layers.0.self_attn.kv_prefix_key"].transpose(0, 1))
     assert torch.equal(value, kv_prefix_state["model.layers.0.self_attn.kv_prefix_value"].transpose(0, 1))
 
+
 def test_apply_kv_prefix_state_dict_clears_existing_prefix_when_empty_update():
     model = FakeModel()
     kv_prefix_state = {
@@ -85,6 +86,7 @@ def test_apply_kv_prefix_state_dict_clears_existing_prefix_when_empty_update():
 
     assert cleared_layers == 0
     assert get_layer_kv_prefix(model.layers[0]) is None
+
 
 def test_apply_kv_prefix_state_dict_raises_for_unknown_layer():
     model = FakeModel()

--- a/tests/unit/train/rl/test_nccl_broadcast_utils.py
+++ b/tests/unit/train/rl/test_nccl_broadcast_utils.py
@@ -1,0 +1,20 @@
+import torch
+
+from prime_rl.trainer.rl.broadcast.nccl import filter_state_dict_by_layers
+
+
+def test_filter_state_dict_by_layers_includes_layer_zero():
+    state_dict = {
+        "model.embed_tokens.weight": torch.zeros(1),
+        "model.layers.0.self_attn.q_proj.weight": torch.zeros(1),
+        "model.layers.1.self_attn.q_proj.weight": torch.zeros(1),
+    }
+
+    chunks = list(filter_state_dict_by_layers(state_dict, num_layers=2))
+
+    assert chunks[0][0] == 0
+    assert "model.embed_tokens.weight" in chunks[0][1]
+
+    layer_chunks = {layer_id: layer_state for layer_id, layer_state in chunks[1:]}
+    assert "model.layers.0.self_attn.q_proj.weight" in layer_chunks[0]
+    assert "model.layers.1.self_attn.q_proj.weight" in layer_chunks[1]

--- a/tests/unit/train/test_kv_prefix.py
+++ b/tests/unit/train/test_kv_prefix.py
@@ -1,0 +1,36 @@
+import pytest
+import torch
+
+from prime_rl.trainer.config import KVPrefixConfig, LoRAConfig, ModelConfig
+from prime_rl.trainer.kv_prefix import strip_kv_prefix_from_state_dict
+from prime_rl.trainer.rl.config import RLTrainerConfig
+
+
+def test_model_config_rejects_kv_prefix_with_sdpa():
+    with pytest.raises(ValueError, match="requires flash attention"):
+        ModelConfig(attn="sdpa", kv_prefix=KVPrefixConfig())
+
+
+def test_model_config_rejects_kv_prefix_with_cp():
+    with pytest.raises(ValueError, match="does not support context parallelism"):
+        ModelConfig(cp=2, kv_prefix=KVPrefixConfig())
+
+
+def test_rl_trainer_config_allows_kv_prefix_multi_run():
+    cfg = RLTrainerConfig(
+        max_concurrent_runs=4,
+        model=ModelConfig(lora=LoRAConfig(), kv_prefix=KVPrefixConfig()),
+    )
+    assert cfg.max_concurrent_runs == 4
+
+
+def test_strip_kv_prefix_from_state_dict():
+    state_dict = {
+        "model.layers.0.self_attn.kv_prefix_key": torch.ones(1),
+        "model.layers.0.self_attn.kv_prefix_value": torch.ones(1),
+        "model.layers.0.self_attn.q_proj.weight": torch.ones(1),
+    }
+    stripped = strip_kv_prefix_from_state_dict(state_dict)
+    assert "model.layers.0.self_attn.kv_prefix_key" not in stripped
+    assert "model.layers.0.self_attn.kv_prefix_value" not in stripped
+    assert "model.layers.0.self_attn.q_proj.weight" in stripped


### PR DESCRIPTION
Not yet tested.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core attention execution and weight hot-reload paths (vLLM monkeypatch + NCCL/filesystem updates), so failures could break inference correctness or online updates. Also changes multi-run optimizer/scheduler/checkpoint semantics by adding shared parameter state.
> 
> **Overview**
> Adds **trainable KV-prefix tuning** end-to-end: trainer can allocate/init per-layer `kv_prefix_key/value` parameters, adjust rotary `position_ids` for the virtual prefix length, and load/init these params correctly under DCP/FSDP.
> 
> Updates the inference weight-update path (filesystem + NCCL) to **separately extract and apply KV-prefix tensors** via a new `inference/vllm/kv_prefix.py`, and monkey-patches vLLM `FlashAttentionImpl.forward` to run attention against both the prefix KV tensors and the normal KV-cache then merge results.
> 
> Improves multi-run training/broadcast to handle **shared non-LoRA trainables**: multi-run optimizer/scheduler/checkpointing now persists/steps shared state, weight broadcast can send full base weights when needed (marker-based `BASE_UPDATE_REQUIRED`), and the client `update_weights` now updates base weights when present before loading LoRA adapters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1b9b7531541188deecd938692c2dbfe4dc9fe85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->