### PR TITLE
Fix: Initialize logger in env-server before install_env

### DIFF
--- a/src/prime_rl/orchestrator/env_server/env_server.py
+++ b/src/prime_rl/orchestrator/env_server/env_server.py
@@ -2,6 +2,7 @@ from loguru import logger
 from verifiers.workers import ZMQEnvServer
 
 from prime_rl.orchestrator.env_server.config import EnvServerConfig
+from prime_rl.utils.logger import setup_logger
 from prime_rl.utils.pathing import get_log_dir
 from prime_rl.utils.pydantic_config import parse_argv
 from prime_rl.utils.utils import clean_exit, get_env_ids_to_install, install_env, strip_env_version
@@ -10,6 +11,8 @@ from prime_rl.utils.utils import clean_exit, get_env_ids_to_install, install_env
 @clean_exit
 @logger.catch(reraise=True)
 def run_server(config: EnvServerConfig):
+    setup_logger(config.log.level, json_logging=config.log.json_logging)
+
     # install environment if not already installed
     env_ids_to_install = set()
     env_ids_to_install.update(get_env_ids_to_install([config.env]))


### PR DESCRIPTION
install_env() calls get_logger() which requires the logger to be set up first. This was missing in env-server but present in orchestrator.

Fixes the crash:
```
RuntimeError: Logger not set. Please call `set_logger` first.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized startup-order change that only affects logging initialization; minimal behavioral impact beyond preventing a crash.
> 
> **Overview**
> Initializes Prime-RL logging in `env_server.run_server()` by calling `setup_logger(config.log.level, json_logging=config.log.json_logging)` before `install_env()` runs.
> 
> This prevents `install_env()` (and any code it calls) from crashing when it attempts to use `get_logger()` prior to logger setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55a362d2d2857cb744deca2dac5dab9717803274. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->