### PR TITLE
Fix elastic autoscaling: use base model for health checks

### DIFF
--- a/src/prime_rl/utils/elastic.py
+++ b/src/prime_rl/utils/elastic.py
@@ -112,6 +112,7 @@ class ElasticInferencePool:
         self.hostname = hostname
         self.client_config = client_config
         self.model_name = model_name
+        self.base_model_name = model_name  # Keep original for health checks
         self.port = port
         self.sync_interval = sync_interval
 
@@ -323,8 +324,8 @@ class ElasticInferencePool:
             data = response.json()
             models = [m.get("id") for m in data.get("data", [])]
 
-            if self.model_name not in models:
-                self.logger.debug(f"Server {ip} does not have model {self.model_name}")
+            if self.base_model_name not in models:
+                self.logger.debug(f"Server {ip} does not have base model {self.base_model_name}")
                 return False
         except Exception as e:
             self.logger.debug(f"Server {ip} model check failed: {e}")


### PR DESCRIPTION
## Summary
- Fix elastic autoscaling not working for newly scaled-up inference servers
- Health check was using `model_name` which gets updated to LoRA name after training starts
- New servers only have base model, so they'd fail health checks forever

## The bug
After training starts, `update_model_name()` changes `model_name` to the LoRA adapter name (e.g., `rft-xxx`). New inference servers only have the base model loaded. The health check would reject them, so they'd never get added to the pool and never receive the LoRA adapter.

## The fix
Store original model name as `base_model_name` at init time and use it for health checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to elastic pool health checks; main risk is unintentionally accepting servers that lack the current LoRA model, which is mitigated by the separate adapter sync logic.
> 
> **Overview**
> Fixes elastic inference autoscaling by decoupling server health checks from the mutable `model_name`.
> 
> `ElasticInferencePool` now stores the initial `model_name` as `base_model_name` and uses it when validating `/v1/models` in `_check_server_health`, so newly scaled servers that only have the base model are considered healthy and can be added to the pool for subsequent LoRA adapter syncing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d566a96018ea4636dbc14097833c4c72888d024. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->