### PR TITLE
bump vf (bc9fcd5)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,9 @@ dependencies = [
     "torchdata>=0.11.0",
     "accelerate>=1.10.1",
     "blobfile>=3.0.0",
-    "reverse-text>=0.1.4",
     "torchtitan",
     "dion",
-    "reverse-text",
+    # "reverse-text",
     "verifiers>=0.1.8",
     "prime-evals>=0.1.5",
     "ring-flash-attn>=0.1.8",
@@ -83,7 +82,7 @@ override-dependencies = ["nvidia-cudnn-cu12>=9.15"]
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 reverse-text = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "3409cb5" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "bc9fcd5" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eebbd950a6ff11d9b5f806282e33df83df9d" }
 flash-attn-cute = { git = "https://github.com/Dao-AILab/flash-attention.git", subdirectory = "flash_attn/cute", rev = "main" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "blobfile>=3.0.0",
     "torchtitan",
     "dion",
-    # "reverse-text",
+    "reverse-text",
     "verifiers>=0.1.8",
     "prime-evals>=0.1.5",
     "ring-flash-attn>=0.1.8",

--- a/uv.lock
+++ b/uv.lock
@@ -2505,6 +2505,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pylatexenc" },
     { name = "pyzmq" },
+    { name = "reverse-text" },
     { name = "rich" },
     { name = "ring-flash-attn" },
     { name = "tenacity" },
@@ -2567,6 +2568,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.10.1" },
     { name = "pylatexenc", specifier = ">=2.10" },
     { name = "pyzmq", specifier = ">=27.1.0" },
+    { name = "reverse-text", index = "https://hub.primeintellect.ai/primeintellect/simple/" },
     { name = "rich", specifier = ">=14.0.0" },
     { name = "ring-flash-attn", specifier = ">=0.1.8" },
     { name = "tenacity", specifier = ">=8.2.0" },
@@ -3150,6 +3152,17 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "reverse-text"
+version = "0.1.5"
+source = { registry = "https://hub.primeintellect.ai/primeintellect/simple/" }
+dependencies = [
+    { name = "verifiers" },
+]
+wheels = [
+    { url = "https://hub.primeintellect.ai/primeintellect/reverse-text/@e3cd3fe4/reverse_text-0.1.5-py2.py3-none-any.whl", hash = "sha256:f48c5a203603551219df30f734ff5f74b825ea2a29fec05c7a6b2cd4bb657a34" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2505,7 +2505,6 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pylatexenc" },
     { name = "pyzmq" },
-    { name = "reverse-text" },
     { name = "rich" },
     { name = "ring-flash-attn" },
     { name = "tenacity" },
@@ -2568,8 +2567,6 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.10.1" },
     { name = "pylatexenc", specifier = ">=2.10" },
     { name = "pyzmq", specifier = ">=27.1.0" },
-    { name = "reverse-text", index = "https://hub.primeintellect.ai/primeintellect/simple/" },
-    { name = "reverse-text", specifier = ">=0.1.4", index = "https://hub.primeintellect.ai/primeintellect/simple/" },
     { name = "rich", specifier = ">=14.0.0" },
     { name = "ring-flash-attn", specifier = ">=0.1.8" },
     { name = "tenacity", specifier = ">=8.2.0" },
@@ -2581,7 +2578,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", specifier = ">=4.57.6" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=3409cb5" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=bc9fcd5" },
     { name = "vllm", specifier = "==0.14.0" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
@@ -3153,18 +3150,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
-]
-
-[[package]]
-name = "reverse-text"
-version = "0.1.4"
-source = { registry = "https://hub.primeintellect.ai/primeintellect/simple/" }
-dependencies = [
-    { name = "datasets" },
-    { name = "verifiers" },
-]
-wheels = [
-    { url = "https://hub.primeintellect.ai/primeintellect/reverse-text/@3d7ff9e4/reverse_text-0.1.4-py2.py3-none-any.whl", hash = "sha256:0adc3abcb6ceba3fa82709258c732e95c90400bc899230dce47a2e0f31a74aec" },
 ]
 
 [[package]]
@@ -3955,8 +3940,8 @@ wheels = [
 
 [[package]]
 name = "verifiers"
-version = "0.1.10.dev3"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=3409cb5#3409cb5f1d780def683bfa7eec4010f1e4682d9b" }
+version = "0.1.10.dev4"
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=bc9fcd5#bc9fcd51c0e183bd9a9a6e5c322e041849df8f07" }
 dependencies = [
     { name = "datasets" },
     { name = "gepa" },


### PR DESCRIPTION
bumps verifiers to include [#832](https://github.com/PrimeIntellect-ai/verifiers/pull/832) which gives env server support for multiple env groups (used for training envs)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile/dependency pin updates only; risk is limited to potential install or runtime regressions from the new `verifiers`/`reverse-text` versions.
> 
> **Overview**
> Bumps `verifiers` to a newer git revision (`3409cb5` 9 `bc9fcd5`) in `pyproject.toml` and `uv.lock`.
> 
> Cleans up dependency specification by removing the redundant `reverse-text>=0.1.4` entry and updates the lockfile to `reverse-text` `0.1.5` (including dropping its previous `datasets` dependency).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa62c4b0be34b23a6f67292b46fd530afe256a56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->