### PR TITLE
Fix eval metrics type not json serializable.

### DIFF
--- a/src/prime_rl/orchestrator/eval_utils.py
+++ b/src/prime_rl/orchestrator/eval_utils.py
@@ -120,9 +120,9 @@ async def evaluate_env(
 
     # Log statistics to monitor
     eval_metrics = {
-        f"avg@{rollouts_per_example}": results_df.reward.mean(),
-        "no_response/mean": results_df.no_response.mean(),
-        "no_response/count": results_df.no_response.sum(),
+        f"avg@{rollouts_per_example}": float(results_df.reward.mean()),
+        "no_response/mean": float(results_df.no_response.mean()),
+        "no_response/count": int(results_df.no_response.sum()),
         "completion_len/mean": results_df.completion_len.mean().item(),
         "completion_len/max": results_df.completion_len.max().item(),
         "completion_len/min": results_df.completion_len.min().item(),


### PR DESCRIPTION
Closes ENG-2895

Fix numpy type JSON serialization error in eval metrics

Converts numpy.int64 and numpy.float64 values to native Python types (int/float) in eval_utils.py before logging metrics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change that only affects metric type conversion for monitoring output; no behavioral changes to evaluation logic beyond logging.
> 
> **Overview**
> Fixes evaluation metric logging by ensuring scalar values sent to the monitor are JSON-serializable.
> 
> In `evaluate_env` (`eval_utils.py`), casts `avg@k` and `no_response/*` metrics from numpy/pandas scalars to native Python `float`/`int` before calling `monitor.log`, preventing serialization errors during eval logging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3161a360cb16d4d9a2d1fa5816148b593c718263. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->