### PR TITLE
[do not review] stage fp8 linear and grouped GEMM experimental work

### DIFF
--- a/docs/grouped_gemm_experimental.md
+++ b/docs/grouped_gemm_experimental.md
@@ -1,0 +1,38 @@
+# Experimental Grouped GEMM
+
+This page tracks the current DeepGEMM FP8 grouped GEMM prototype that was developed outside the main trainer path and imported here for iterative integration.
+
+## What is included
+
+- `src/prime_rl/trainer/fp8_linear.py` contains the current single-linear FP8 path used for integration work.
+- `src/prime_rl/trainer/experimental/grouped_gemm/fp8_grouped_linear.py` contains the grouped GEMM prototype classes (`FP8GroupedLinearDeepGEMM`, `FP8LinearDeepGEMM`) and supporting quantization kernels.
+- `scripts/experimental/bench_deepgemm_grouped_linear.py` runs grouped correctness and performance checks.
+- `scripts/experimental/bench_deepgemm_linear.py` runs single-linear correctness and performance checks against BF16 baselines.
+
+## Running on a multi-GPU node
+
+Both benchmark scripts now honor `LOCAL_RANK` and call `torch.cuda.set_device(local_rank)`, so they can run directly with `torchrun`.
+
+Single process sanity check:
+
+```bash
+uv run python scripts/experimental/bench_deepgemm_grouped_linear.py --experts 8 --k 7168 --n 4096 --tokens-per-expert 2048
+```
+
+Multi-GPU launch (one benchmark process per GPU):
+
+```bash
+uv run torchrun --standalone --nproc-per-node 8 scripts/experimental/bench_deepgemm_grouped_linear.py --experts 8 --k 7168 --n 4096 --tokens-per-expert 2048 --skip-correctness
+```
+
+Single-linear benchmark:
+
+```bash
+uv run python scripts/experimental/bench_deepgemm_linear.py --mkn 16384,4096,4096
+```
+
+## Integration plan
+
+1. Keep grouped GEMM work isolated in `trainer/experimental/grouped_gemm` while the API is stabilized.
+2. Port grouped kernels and autograd into `trainer/fp8_linear.py` in small PRs, preserving existing trainer behavior.
+3. Add dedicated tests under `tests/unit/trainer` once grouped forward and backward API contracts are finalized.

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@ This directory maintains the documentation for PRIME-RL. It is organized into th
 - [**MultiRunManager**](multi_run_manager.md) - Multi-run training with the MultiRunManager object for concurrent LoRA adapters
 - [**Checkpointing**](checkpointing.md) - Saving and resuming training from checkpoints
 - [**Benchmarking**](benchmarking.md) - Performance benchmarking and throughput measurement
+- [**Experimental Grouped GEMM**](grouped_gemm_experimental.md) - Current FP8 grouped GEMM prototype and multi-GPU benchmark entrypoints
 - [**Deployment**](deployment.md) - Training deployment on single-GPU, multi-GPU, and multi-node clusters
 - [**Kubernetes**](kubernetes.md) - Deploying PRIME-RL on Kubernetes with Helm
 - [**Troubleshooting**](troubleshooting.md) - Common issues and their solutions

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -13,6 +13,7 @@
                 "runs",
                 "checkpointing",
                 "benchmarking",
+                "grouped_gemm_experimental",
                 "deployment",
                 "kubernetes",
                 "troubleshooting"

--- a/scripts/experimental/bench_deepgemm_grouped_linear.py
+++ b/scripts/experimental/bench_deepgemm_grouped_linear.py
@@ -1,0 +1,238 @@
+import argparse
+import os
+
+import torch
+import torch.nn as nn
+
+from triton.testing import do_bench
+
+from prime_rl.trainer.experimental.grouped_gemm.fp8_grouped_linear import FP8GroupedLinearDeepGEMM
+
+
+def _set_cuda_device_from_env() -> None:
+    if not torch.cuda.is_available():
+        return
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    torch.cuda.set_device(local_rank)
+
+
+def _bench_ms(fn) -> float:
+    ms = do_bench(fn)
+    if ms is None:
+        raise RuntimeError("do_bench returned None")
+    if isinstance(ms, (tuple, list)):
+        return float(ms[0])
+    return float(ms)
+
+
+def _diff_report(a: torch.Tensor, b: torch.Tensor) -> tuple[float, float, float]:
+    a_d = a.detach()
+    b_d = b.detach()
+    d = (a_d.float() - b_d.float()).abs()
+    denom = b_d.float().abs().max().clamp_min(1e-6)
+    rel = (d.max() / denom).item()
+    return float(rel), float(d.max().item()), float(d.mean().item())
+
+
+def _layout_from_offsets(group_offsets: torch.Tensor) -> torch.Tensor:
+    counts = torch.empty_like(group_offsets)
+    counts[0] = group_offsets[0]
+    if group_offsets.numel() > 1:
+        counts[1:] = group_offsets[1:] - group_offsets[:-1]
+    experts = torch.arange(
+        group_offsets.numel(),
+        device=group_offsets.device,
+        dtype=torch.int32,
+    )
+    return torch.repeat_interleave(experts, counts.to(torch.long))
+
+
+def _parse_tokens(tokens_csv: str, num_experts: int, tokens_per_expert: int) -> list[int]:
+    if tokens_csv.strip() == "":
+        return [tokens_per_expert for _ in range(num_experts)]
+    vals = [int(x.strip()) for x in tokens_csv.split(",") if x.strip()]
+    if len(vals) == 1:
+        return vals * num_experts
+    if len(vals) != num_experts:
+        raise ValueError("--tokens must have exactly num_experts entries")
+    return vals
+
+
+class TorchGroupedLinearBF16(nn.Module):
+    def __init__(self, num_experts: int, k: int, n: int, bias: bool):
+        super().__init__()
+        self.weight = nn.Parameter(torch.empty(num_experts, n, k, dtype=torch.bfloat16, device="cuda"))
+        nn.init.normal_(self.weight, mean=0.0, std=0.02)
+        if bias:
+            self.bias = nn.Parameter(torch.zeros(num_experts, n, dtype=torch.bfloat16, device="cuda"))
+        else:
+            self.register_parameter("bias", None)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        group_offsets: torch.Tensor,
+        grouped_layout_long: torch.Tensor,
+    ):
+        out = torch._grouped_mm(
+            x,
+            self.weight.transpose(-2, -1),
+            offs=group_offsets,
+            out_dtype=torch.bfloat16,
+        )
+        if self.bias is not None:
+            out = out + self.bias[grouped_layout_long]
+        return out
+
+
+def run(
+    num_experts: int,
+    k: int,
+    n: int,
+    tokens: list[int],
+    bias: bool,
+    run_correctness: bool,
+):
+    assert k % 128 == 0
+    assert n % 128 == 0
+    assert len(tokens) == num_experts
+    assert all(t >= 0 for t in tokens)
+    assert all(t % 128 == 0 for t in tokens)
+
+    m = sum(tokens)
+    group_offsets = torch.tensor(tokens, dtype=torch.int32, device="cuda").cumsum(dim=0).to(torch.int32)
+    grouped_layout = _layout_from_offsets(group_offsets)
+    grouped_layout_long = grouped_layout.to(torch.long)
+
+    fp8_mod = FP8GroupedLinearDeepGEMM(num_experts, k, n, bias=bias)
+    bf16_mod = TorchGroupedLinearBF16(num_experts, k, n, bias=bias)
+    bf16_mod.weight.data.copy_(fp8_mod.weight.data)
+    if bias:
+        bf16_mod.bias.data.copy_(fp8_mod.bias.data)
+
+    print(f"Grouped shape: E={num_experts}, M={m}, K={k}, N={n}, bias={int(bias)}")
+    print(f"Tokens/expert: {tokens}")
+    print("BF16 baseline: torch._grouped_mm (torch.functional.grouped_mm equivalent)")
+    print()
+
+    if run_correctness:
+        x_ref = torch.randn(m, k, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+        x_fp8 = x_ref.detach().clone().requires_grad_(True)
+        grad_out = torch.randn(m, n, dtype=torch.bfloat16, device="cuda") / 1e2
+
+        bf16_mod.zero_grad(set_to_none=True)
+        fp8_mod.zero_grad(set_to_none=True)
+
+        y_ref = bf16_mod(x_ref, group_offsets, grouped_layout_long)
+        y_fp8 = fp8_mod(x_fp8, group_offsets=group_offsets)
+        y_ref.backward(grad_out)
+        y_fp8.backward(grad_out)
+
+        assert x_ref.grad is not None and x_fp8.grad is not None
+        assert bf16_mod.weight.grad is not None and fp8_mod.weight.grad is not None
+
+        f_diff, f_max, f_mean = _diff_report(y_fp8, y_ref)
+        gi_diff, gi_max, gi_mean = _diff_report(x_fp8.grad, x_ref.grad)
+        gw_diff, gw_max, gw_mean = _diff_report(fp8_mod.weight.grad, bf16_mod.weight.grad)
+
+        print("Correctness")
+        print(f"  Forward:     diff={f_diff:.6f}, max={f_max:.6f}, mean={f_mean:.6f}")
+        print(f"  Grad input:  diff={gi_diff:.6f}, max={gi_max:.6f}, mean={gi_mean:.6f}")
+        print(f"  Grad weight: diff={gw_diff:.6f}, max={gw_max:.6f}, mean={gw_mean:.6f}")
+        if bias:
+            assert bf16_mod.bias is not None and bf16_mod.bias.grad is not None
+            assert fp8_mod.bias is not None and fp8_mod.bias.grad is not None
+            gb_diff, gb_max, gb_mean = _diff_report(fp8_mod.bias.grad, bf16_mod.bias.grad)
+            print(f"  Grad bias:   diff={gb_diff:.6f}, max={gb_max:.6f}, mean={gb_mean:.6f}")
+        print()
+
+        del x_ref, x_fp8, grad_out, y_ref, y_fp8
+        torch.cuda.empty_cache()
+
+    x_fwd = torch.randn(m, k, dtype=torch.bfloat16, device="cuda")
+    with torch.no_grad():
+        fp8_mod.prepare_prequantized_weight()
+
+    def bf16_fwd():
+        with torch.no_grad():
+            return bf16_mod(x_fwd, group_offsets, grouped_layout_long)
+
+    def fp8_fwd_prequant():
+        with torch.no_grad():
+            return fp8_mod(x_fwd, group_offsets=group_offsets, quantize_weight_on_the_fly=False)
+
+    def fp8_fwd_onthefly():
+        with torch.no_grad():
+            return fp8_mod(x_fwd, group_offsets=group_offsets, quantize_weight_on_the_fly=True)
+
+    x_ref_train = torch.randn(m, k, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+    x_fp8_train = x_ref_train.detach().clone().requires_grad_(True)
+    grad_out_train = torch.randn(m, n, dtype=torch.bfloat16, device="cuda")
+
+    def bf16_fwd_bwd():
+        bf16_mod.zero_grad(set_to_none=True)
+        if x_ref_train.grad is not None:
+            x_ref_train.grad = None
+        y = bf16_mod(x_ref_train, group_offsets, grouped_layout_long)
+        torch.autograd.backward(y, grad_out_train)
+
+    def _invalidate_fp8_weight_cache():
+        fp8_mod._w_q_version = -1
+        fp8_mod._w_t_q_version = -1
+
+    def fp8_fwd_bwd_requant_each_iter():
+        fp8_mod.zero_grad(set_to_none=True)
+        if x_fp8_train.grad is not None:
+            x_fp8_train.grad = None
+        _invalidate_fp8_weight_cache()
+        y = fp8_mod(x_fp8_train, group_offsets=group_offsets)
+        torch.autograd.backward(y, grad_out_train)
+
+    with torch.no_grad():
+        _ = bf16_fwd()
+        _ = fp8_fwd_prequant()
+        _ = fp8_fwd_onthefly()
+    bf16_fwd_bwd()
+    fp8_fwd_bwd_requant_each_iter()
+    torch.cuda.synchronize()
+
+    bf16_fwd_ms = _bench_ms(bf16_fwd)
+    fp8_pre_ms = _bench_ms(fp8_fwd_prequant)
+    fp8_otf_ms = _bench_ms(fp8_fwd_onthefly)
+    bf16_fwbw_ms = _bench_ms(bf16_fwd_bwd)
+    fp8_fwbw_requant_ms = _bench_ms(fp8_fwd_bwd_requant_each_iter)
+
+    print()
+    print("Performance")
+    print(f"  BF16 grouped forward:          {bf16_fwd_ms:.3f} ms")
+    print(f"  FP8 grouped forward (prequant):{fp8_pre_ms:.3f} ms")
+    print(f"  FP8 grouped forward (on-fly):  {fp8_otf_ms:.3f} ms")
+    print(f"  BF16 grouped forward+backward: {bf16_fwbw_ms:.3f} ms")
+    print(f"  FP8 grouped forward+backward (requant/iter): {fp8_fwbw_requant_ms:.3f} ms")
+    print(f"  FWD speedup (prequant):        {bf16_fwd_ms / fp8_pre_ms:.3f}x")
+    print(f"  FWD speedup (on-fly):          {bf16_fwd_ms / fp8_otf_ms:.3f}x")
+    print(f"  FWD+BWD speedup (requant/iter): {bf16_fwbw_ms / fp8_fwbw_requant_ms:.3f}x")
+
+
+if __name__ == "__main__":
+    _set_cuda_device_from_env()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--experts", type=int, default=8)
+    parser.add_argument("--k", type=int, default=7168)
+    parser.add_argument("--n", type=int, default=4096)
+    parser.add_argument("--tokens-per-expert", type=int, default=2048)
+    parser.add_argument("--tokens", type=str, default="")
+    parser.add_argument("--bias", action="store_true")
+    parser.add_argument("--skip-correctness", action="store_true")
+    args = parser.parse_args()
+
+    tokens = _parse_tokens(args.tokens, args.experts, args.tokens_per_expert)
+    run(
+        args.experts,
+        args.k,
+        args.n,
+        tokens,
+        args.bias,
+        run_correctness=not args.skip_correctness,
+    )

--- a/scripts/experimental/bench_deepgemm_linear.py
+++ b/scripts/experimental/bench_deepgemm_linear.py
@@ -1,0 +1,178 @@
+import argparse
+import os
+
+import torch
+import torch.nn as nn
+
+from triton.testing import do_bench
+
+from deep_gemm.testing import calc_diff
+from prime_rl.trainer.experimental.grouped_gemm.fp8_grouped_linear import FP8LinearDeepGEMM
+
+
+def _set_cuda_device_from_env() -> None:
+    if not torch.cuda.is_available():
+        return
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    torch.cuda.set_device(local_rank)
+
+
+def _diff_report(a: torch.Tensor, b: torch.Tensor) -> tuple[float, float, float]:
+    a_d = a.detach()
+    b_d = b.detach()
+    d = (a_d.float() - b_d.float()).abs()
+    return float(calc_diff(a_d, b_d)), float(d.max().item()), float(d.mean().item())
+
+
+def _bench_ms(fn) -> float:
+    ms = do_bench(fn)
+    if ms is None:
+        raise RuntimeError("do_bench returned None")
+    if isinstance(ms, (tuple, list)):
+        return float(ms[0])
+    return float(ms)
+
+
+def _run_correctness(
+    m: int,
+    k: int,
+    n: int,
+    bias: bool,
+    fp8_mod: FP8LinearDeepGEMM,
+    bf16_mod: nn.Linear,
+):
+    x_ref = torch.randn(m, k, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+    x_fp8 = x_ref.detach().clone().requires_grad_(True)
+    grad_out = torch.randn(m, n, dtype=torch.bfloat16, device="cuda") / 1e2
+
+    bf16_mod.zero_grad(set_to_none=True)
+    fp8_mod.zero_grad(set_to_none=True)
+
+    y_ref = bf16_mod(x_ref)
+    y_fp8 = fp8_mod(x_fp8)
+    y_ref.backward(grad_out)
+    y_fp8.backward(grad_out)
+
+    assert x_ref.grad is not None
+    assert x_fp8.grad is not None
+    assert bf16_mod.weight.grad is not None
+    assert fp8_mod.weight.grad is not None
+
+    f_diff, f_max, f_mean = _diff_report(y_fp8, y_ref)
+    gi_diff, gi_max, gi_mean = _diff_report(x_fp8.grad, x_ref.grad)
+    gw_diff, gw_max, gw_mean = _diff_report(fp8_mod.weight.grad, bf16_mod.weight.grad)
+
+    print("Correctness")
+    print(f"  Forward:     diff={f_diff:.6f}, max={f_max:.6f}, mean={f_mean:.6f}")
+    print(f"  Grad input:  diff={gi_diff:.6f}, max={gi_max:.6f}, mean={gi_mean:.6f}")
+    print(f"  Grad weight: diff={gw_diff:.6f}, max={gw_max:.6f}, mean={gw_mean:.6f}")
+    if bias:
+        assert bf16_mod.bias is not None and bf16_mod.bias.grad is not None
+        assert fp8_mod.bias is not None and fp8_mod.bias.grad is not None
+        gb_diff, gb_max, gb_mean = _diff_report(fp8_mod.bias.grad, bf16_mod.bias.grad)
+        print(f"  Grad bias:   diff={gb_diff:.6f}, max={gb_max:.6f}, mean={gb_mean:.6f}")
+
+
+def _run_bench(
+    m: int,
+    k: int,
+    n: int,
+    bias: bool,
+    fp8_mod: FP8LinearDeepGEMM,
+    bf16_mod: nn.Linear,
+):
+    x_fwd = torch.randn(m, k, dtype=torch.bfloat16, device="cuda")
+
+    with torch.no_grad():
+        fp8_mod.prepare_prequantized_weight()
+
+    def bf16_fwd():
+        return bf16_mod(x_fwd)
+
+    def fp8_fwd_prequant():
+        return fp8_mod(x_fwd, quantize_weight_on_the_fly=False)
+
+    def fp8_fwd_onthefly():
+        return fp8_mod(x_fwd, quantize_weight_on_the_fly=True)
+
+    with torch.no_grad():
+        _ = bf16_fwd()
+        _ = fp8_fwd_prequant()
+        _ = fp8_fwd_onthefly()
+    torch.cuda.synchronize()
+
+    x_ref_train = torch.randn(m, k, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+    x_fp8_train = x_ref_train.detach().clone().requires_grad_(True)
+    grad_out = torch.randn(m, n, dtype=torch.bfloat16, device="cuda")
+
+    def bf16_fwd_bwd():
+        bf16_mod.zero_grad(set_to_none=True)
+        if x_ref_train.grad is not None:
+            x_ref_train.grad = None
+        y = bf16_mod(x_ref_train)
+        torch.autograd.backward(y, grad_out)
+
+    def _invalidate_fp8_weight_cache():
+        # Simulate post-optimizer-step state where weight changed and must be re-quantized.
+        fp8_mod._w_q_version = -1
+        fp8_mod._w_t_q_version = -1
+
+    def fp8_fwd_bwd_requant_each_iter():
+        fp8_mod.zero_grad(set_to_none=True)
+        if x_fp8_train.grad is not None:
+            x_fp8_train.grad = None
+        _invalidate_fp8_weight_cache()
+        y = fp8_mod(x_fp8_train)
+        torch.autograd.backward(y, grad_out)
+
+    bf16_fwd_ms = _bench_ms(bf16_fwd)
+    fp8_fwd_pre_ms = _bench_ms(fp8_fwd_prequant)
+    fp8_fwd_otf_ms = _bench_ms(fp8_fwd_onthefly)
+    bf16_fwbw_ms = _bench_ms(bf16_fwd_bwd)
+    fp8_fwbw_requant_ms = _bench_ms(fp8_fwd_bwd_requant_each_iter)
+
+    print()
+    print("Performance")
+    print(f"  BF16 forward:               {bf16_fwd_ms:.3f} ms")
+    print(f"  FP8 forward (prequant):     {fp8_fwd_pre_ms:.3f} ms")
+    print(f"  FP8 forward (on-the-fly):   {fp8_fwd_otf_ms:.3f} ms")
+    print(f"  BF16 forward+backward:      {bf16_fwbw_ms:.3f} ms")
+    print(f"  FP8 forward+backward (requant/iter): {fp8_fwbw_requant_ms:.3f} ms")
+    print(f"  FWD speedup (prequant):     {bf16_fwd_ms / fp8_fwd_pre_ms:.3f}x")
+    print(f"  FWD speedup (on-the-fly):   {bf16_fwd_ms / fp8_fwd_otf_ms:.3f}x")
+    print(f"  FWD+BWD speedup (requant/iter): {bf16_fwbw_ms / fp8_fwbw_requant_ms:.3f}x")
+
+
+def run(shape: tuple[int, int, int], bias: bool):
+    m, k, n = shape
+    assert m % 4 == 0
+    assert k % 128 == 0
+    assert n % 128 == 0
+
+    fp8_mod = FP8LinearDeepGEMM(k, n, bias=bias)
+    bf16_mod = nn.Linear(k, n, bias=bias, dtype=torch.bfloat16, device="cuda")
+    bf16_mod.weight.data.copy_(fp8_mod.weight.data)
+    if bias:
+        bf16_mod.bias.data.copy_(fp8_mod.bias.data)
+
+    print(f"Shape: M={m}, K={k}, N={n}, bias={int(bias)}")
+    print()
+
+    _run_correctness(m, k, n, bias, fp8_mod, bf16_mod)
+    _run_bench(m, k, n, bias, fp8_mod, bf16_mod)
+
+
+if __name__ == "__main__":
+    _set_cuda_device_from_env()
+
+    def parse_comma_separated_ints(s: str) -> tuple[int, ...]:
+        try:
+            return tuple(int(x.strip()) for x in s.split(","))
+        except ValueError as exc:
+            raise argparse.ArgumentTypeError("Invalid format. Expected comma-separated integers.") from exc
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mkn", type=parse_comma_separated_ints, default=(16384, 4096, 4096))
+    parser.add_argument("--bias", action="store_true")
+    args = parser.parse_args()
+    run(args.mkn, args.bias)

--- a/src/prime_rl/trainer/experimental/__init__.py
+++ b/src/prime_rl/trainer/experimental/__init__.py
@@ -1,0 +1,1 @@
+"""Experimental trainer components."""

--- a/src/prime_rl/trainer/experimental/grouped_gemm/__init__.py
+++ b/src/prime_rl/trainer/experimental/grouped_gemm/__init__.py
@@ -1,0 +1,4 @@
+from .fp8_grouped_linear import FP8GroupedLinearDeepGEMM
+from .fp8_grouped_linear import FP8LinearDeepGEMM
+
+__all__ = ["FP8LinearDeepGEMM", "FP8GroupedLinearDeepGEMM"]

--- a/src/prime_rl/trainer/experimental/grouped_gemm/fp8_grouped_linear.py
+++ b/src/prime_rl/trainer/experimental/grouped_gemm/fp8_grouped_linear.py
@@ -1,0 +1,1564 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.utils as utils
+
+from cutlass.cute.runtime import from_dlpack
+
+import deep_gemm
+
+
+def make_col_major_tensor(shape: tuple[int, int], dtype: torch.dtype) -> torch.Tensor:
+    m, n = shape
+    return torch.empty_strided((m, n), (1, m), dtype=dtype, device="cuda")
+
+
+class ActivationQuantizer1x128:
+    def __init__(self, tile_mk: tuple[int, int] = (4, 128), num_vectorized: int = 4):
+        self._bM, self._bK = tile_mk
+        self._num_vectorized = num_vectorized
+        assert self._bM == 4
+        assert self._bK == 128
+        assert self._num_vectorized == 4
+
+    @cute.jit
+    def __call__(self, x: cute.Tensor, y: cute.Tensor, scales: cute.Tensor):
+        x_major = utils.LayoutEnum.from_tensor(x)
+        y_major = utils.LayoutEnum.from_tensor(y)
+        s_major = utils.LayoutEnum.from_tensor(scales)
+
+        assert x_major == utils.LayoutEnum.ROW_MAJOR
+        assert y_major == utils.LayoutEnum.ROW_MAJOR
+        assert s_major in (utils.LayoutEnum.ROW_MAJOR, utils.LayoutEnum.COL_MAJOR)
+        assert x.shape == y.shape
+
+        copy_atom = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(),
+            x.element_type,
+            num_bits_per_copy=x.element_type.width * self._num_vectorized,
+        )
+
+        major_mode_size = self._bK // self._num_vectorized
+        tA = cute.make_layout((self._bM, major_mode_size), stride=(major_mode_size, 1))
+        vA = cute.make_layout(
+            (1, self._num_vectorized), stride=(self._num_vectorized, self._bK)
+        )
+        tiled_copy = cute.make_tiled_copy_tv(copy_atom, tA, vA)
+
+        sX_layout = cute.make_layout((self._bM, self._bK), stride=(self._bK, 1))
+
+        block = (cute.size(tA), 1, 1)
+        grid = (*cute.ceil_div(x.shape, (self._bM, self._bK)), 1)
+        smem_size = cute.size_in_bytes(x.element_type, sX_layout)
+
+        self.kernel(x, y, scales, tiled_copy, sX_layout).launch(
+            grid=grid,
+            block=block,
+            smem=smem_size,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        x: cute.Tensor,
+        y: cute.Tensor,
+        scales: cute.Tensor,
+        tiled_copy: cute.TiledCopy,
+        sX_layout: cute.Layout,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, bidy, _ = cute.arch.block_idx()
+
+        row_tiles = cute.ceil_div(x.shape[0], self._bM)
+        col_tiles = cute.ceil_div(x.shape[1], self._bK)
+
+        if bidx < row_tiles and bidy < col_tiles:
+            tiler_coord = (bidx, bidy)
+            gX = cute.local_tile(x, tiler=(self._bM, self._bK), coord=tiler_coord)
+            gY = cute.local_tile(y, tiler=(self._bM, self._bK), coord=tiler_coord)
+
+            smem = cutlass.utils.SmemAllocator()
+            sX = smem.allocate_tensor(x.element_type, sX_layout, 16)
+
+            thr_copy = tiled_copy.get_slice(tidx)
+            tXgX = thr_copy.partition_S(gX)
+            tXsX = thr_copy.partition_D(sX)
+            tYgY = thr_copy.partition_D(gY)
+
+            cute.copy(
+                tiled_copy,
+                tXgX[None, None, 0],
+                tXsX[None, None, 0],
+            )
+            cute.arch.cp_async_commit_group()
+            cute.arch.cp_async_wait_group(0)
+            cute.arch.sync_threads()
+
+            thread_vals = tXsX[(None, None), 0, 0].load().to(cutlass.Float32)
+            max_per_thread = cutlass.Float32(0.0)
+            for vid in cutlass.range_constexpr(self._num_vectorized):
+                v = thread_vals[vid]
+                abs_v = v
+                nv = -v
+                if nv > abs_v:
+                    abs_v = nv
+                if abs_v > max_per_thread:
+                    max_per_thread = abs_v
+
+            max_per_warp = cute.arch.warp_reduction_max(
+                max_per_thread, threads_in_group=32
+            )
+            max_per_warp_scalar = max_per_warp
+
+            lane_id = tidx % 32
+            warp_id = tidx // 32
+            row_idx = bidx * self._bM + warp_id
+
+            fp8_max = cutlass.Float32(448.0)
+            eps = cutlass.Float32(1e-4)
+            safe_max = max_per_warp_scalar
+            if safe_max < eps:
+                safe_max = eps
+            scale = safe_max / fp8_max
+            inv_scale = fp8_max / safe_max
+
+            if lane_id == 0 and row_idx < x.shape[0]:
+                scales[row_idx, bidy] = scale
+
+            out_vals = thread_vals * inv_scale
+            tYgY[(None, None), 0, 0].store(out_vals.to(y.element_type))
+
+
+class WeightQuantizer128x128:
+    def __init__(
+        self,
+        block_shape: tuple[int, int] = (128, 128),
+        warps_per_cta: int = 1,
+        num_vectorized: int = 8,
+    ):
+        self._bM, self._bK = block_shape
+        self._warps_per_cta = warps_per_cta
+        self._num_vectorized = num_vectorized
+
+        assert self._bM == 128
+        assert self._bK == 128
+        assert self._warps_per_cta >= 1
+        assert self._num_vectorized == 8
+
+    @cute.jit
+    def __call__(self, x: cute.Tensor, y: cute.Tensor, scales: cute.Tensor):
+        x_major = utils.LayoutEnum.from_tensor(x)
+        y_major = utils.LayoutEnum.from_tensor(y)
+        s_major = utils.LayoutEnum.from_tensor(scales)
+
+        assert x_major == utils.LayoutEnum.COL_MAJOR
+        assert y_major == utils.LayoutEnum.COL_MAJOR
+        assert s_major in (utils.LayoutEnum.ROW_MAJOR, utils.LayoutEnum.COL_MAJOR)
+        assert x.shape == y.shape
+
+        copy_atom = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(),
+            x.element_type,
+            num_bits_per_copy=x.element_type.width * self._num_vectorized,
+        )
+        tA = cute.make_layout((1, 32), stride=(0, 1))
+        vA = cute.make_layout((8,), stride=(1,))
+        tiled_copy = cute.make_tiled_copy_tv(copy_atom, tA, vA)
+
+        sX_layout = cute.make_layout(
+            (self._warps_per_cta, self._bM, self._bK),
+            stride=(self._bM * self._bK, 1, self._bM),
+        )
+
+        row_blocks = cute.ceil_div(x.shape[0], self._bM)
+        col_blocks = cute.ceil_div(x.shape[1], self._bK)
+
+        grid = (cute.ceil_div(row_blocks, self._warps_per_cta), col_blocks, 1)
+        block = (self._warps_per_cta * 32, 1, 1)
+        smem_size = cute.size_in_bytes(x.element_type, sX_layout)
+
+        self.kernel(x, y, scales, tiled_copy, sX_layout).launch(
+            grid=grid,
+            block=block,
+            smem=smem_size,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        x: cute.Tensor,
+        y: cute.Tensor,
+        scales: cute.Tensor,
+        tiled_copy: cute.TiledCopy,
+        sX_layout: cute.Layout,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, bidy, _ = cute.arch.block_idx()
+
+        warp_id = tidx // 32
+        lane_id = tidx % 32
+
+        row_block = bidx * self._warps_per_cta + warp_id
+        col_block = bidy
+
+        row_blocks = cute.ceil_div(x.shape[0], self._bM)
+        col_blocks = cute.ceil_div(x.shape[1], self._bK)
+
+        if row_block < row_blocks and col_block < col_blocks:
+            thread_absmax = cutlass.Float32(0.0)
+
+            smem = cutlass.utils.SmemAllocator()
+            sX = smem.allocate_tensor(x.element_type, sX_layout, 16)
+            sX_warp = sX[warp_id, None, None]
+
+            tiler_coord = (row_block, col_block)
+            gX = cute.local_tile(x, tiler=(self._bM, self._bK), coord=tiler_coord)
+            gY = cute.local_tile(y, tiler=(self._bM, self._bK), coord=tiler_coord)
+
+            lane_map = (lane_id % 16) * 2 + (lane_id // 16)
+            thr_copy = tiled_copy.get_slice(lane_map)
+
+            for col_group in cutlass.range_constexpr(self._bK // 32):
+                for row_vec in cutlass.range_constexpr(
+                    self._bM // self._num_vectorized
+                ):
+                    gX_sub = cute.local_tile(
+                        gX, tiler=(8, 32), coord=(row_vec, col_group)
+                    )
+                    sX_sub = cute.local_tile(
+                        sX_warp, tiler=(8, 32), coord=(row_vec, col_group)
+                    )
+                    tXgX = thr_copy.partition_S(gX_sub)
+                    tXsX = thr_copy.partition_D(sX_sub)
+                    vals = tXgX[(None, None), 0, 0].load().to(cutlass.Float32)
+                    tXsX[(None, None), 0, 0].store(vals.to(x.element_type))
+                    for vid in cutlass.range_constexpr(self._num_vectorized):
+                        v = vals[vid]
+                        abs_v = v
+                        nv = -v
+                        if nv > abs_v:
+                            abs_v = nv
+                        if abs_v > thread_absmax:
+                            thread_absmax = abs_v
+
+            block_absmax = cute.arch.warp_reduction_max(
+                thread_absmax, threads_in_group=32
+            )
+
+            fp8_max = cutlass.Float32(448.0)
+            eps = cutlass.Float32(1e-6)
+            safe_absmax = block_absmax
+            if safe_absmax < eps:
+                safe_absmax = eps
+            scale = safe_absmax / fp8_max
+
+            if lane_id == 0:
+                scales[row_block, col_block] = scale
+
+            inv_scale = fp8_max / safe_absmax
+
+            for col_group in cutlass.range_constexpr(self._bK // 32):
+                for row_vec in cutlass.range_constexpr(
+                    self._bM // self._num_vectorized
+                ):
+                    gY_sub = cute.local_tile(
+                        gY, tiler=(8, 32), coord=(row_vec, col_group)
+                    )
+                    sX_sub = cute.local_tile(
+                        sX_warp, tiler=(8, 32), coord=(row_vec, col_group)
+                    )
+                    tXsX = thr_copy.partition_S(sX_sub)
+                    tYgY = thr_copy.partition_D(gY_sub)
+                    vals = tXsX[(None, None), 0, 0].load().to(cutlass.Float32)
+                    tYgY[(None, None), 0, 0].store(
+                        (vals * inv_scale).to(y.element_type)
+                    )
+
+
+class WeightQuantizer128x128DualOutput:
+    def __init__(
+        self,
+        block_shape: tuple[int, int] = (128, 128),
+        warps_per_cta: int = 1,
+        num_vectorized: int = 8,
+    ):
+        self._bM, self._bK = block_shape
+        self._warps_per_cta = warps_per_cta
+        self._num_vectorized = num_vectorized
+
+        assert self._bM == 128
+        assert self._bK == 128
+        assert self._warps_per_cta >= 1
+        assert self._num_vectorized == 8
+
+    @cute.jit
+    def __call__(
+        self,
+        x: cute.Tensor,
+        y_col: cute.Tensor,
+        scales_col: cute.Tensor,
+        y_row: cute.Tensor,
+        scales_row: cute.Tensor,
+    ):
+        x_major = utils.LayoutEnum.from_tensor(x)
+        y_col_major = utils.LayoutEnum.from_tensor(y_col)
+        y_row_major = utils.LayoutEnum.from_tensor(y_row)
+        s_col_major = utils.LayoutEnum.from_tensor(scales_col)
+        s_row_major = utils.LayoutEnum.from_tensor(scales_row)
+
+        assert x_major == utils.LayoutEnum.COL_MAJOR
+        assert y_col_major == utils.LayoutEnum.COL_MAJOR
+        assert y_row_major == utils.LayoutEnum.ROW_MAJOR
+        assert s_col_major in (utils.LayoutEnum.ROW_MAJOR, utils.LayoutEnum.COL_MAJOR)
+        assert s_row_major in (utils.LayoutEnum.ROW_MAJOR, utils.LayoutEnum.COL_MAJOR)
+        assert x.shape == y_col.shape
+        assert x.shape == y_row.shape
+
+        copy_atom = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(),
+            x.element_type,
+            num_bits_per_copy=x.element_type.width * self._num_vectorized,
+        )
+        tA = cute.make_layout((1, 32), stride=(0, 1))
+        vA = cute.make_layout((8,), stride=(1,))
+        tiled_copy = cute.make_tiled_copy_tv(copy_atom, tA, vA)
+
+        sX_layout = cute.make_layout(
+            (self._warps_per_cta, self._bM, self._bK),
+            stride=(self._bM * self._bK, 1, self._bM),
+        )
+
+        row_blocks = cute.ceil_div(x.shape[0], self._bM)
+        col_blocks = cute.ceil_div(x.shape[1], self._bK)
+
+        grid = (cute.ceil_div(row_blocks, self._warps_per_cta), col_blocks, 1)
+        block = (self._warps_per_cta * 32, 1, 1)
+        smem_size = cute.size_in_bytes(x.element_type, sX_layout)
+
+        self.kernel(
+            x,
+            y_col,
+            scales_col,
+            y_row,
+            scales_row,
+            tiled_copy,
+            sX_layout,
+        ).launch(
+            grid=grid,
+            block=block,
+            smem=smem_size,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        x: cute.Tensor,
+        y_col: cute.Tensor,
+        scales_col: cute.Tensor,
+        y_row: cute.Tensor,
+        scales_row: cute.Tensor,
+        tiled_copy: cute.TiledCopy,
+        sX_layout: cute.Layout,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, bidy, _ = cute.arch.block_idx()
+
+        warp_id = tidx // 32
+        lane_id = tidx % 32
+
+        row_block = bidx * self._warps_per_cta + warp_id
+        col_block = bidy
+
+        row_blocks = cute.ceil_div(x.shape[0], self._bM)
+        col_blocks = cute.ceil_div(x.shape[1], self._bK)
+
+        if row_block < row_blocks and col_block < col_blocks:
+            thread_absmax = cutlass.Float32(0.0)
+
+            smem = cutlass.utils.SmemAllocator()
+            sX = smem.allocate_tensor(x.element_type, sX_layout, 16)
+            sX_warp = sX[warp_id, None, None]
+
+            tiler_coord = (row_block, col_block)
+            gX = cute.local_tile(x, tiler=(self._bM, self._bK), coord=tiler_coord)
+            gY_col = cute.local_tile(
+                y_col, tiler=(self._bM, self._bK), coord=tiler_coord
+            )
+            gY_row = cute.local_tile(
+                y_row, tiler=(self._bM, self._bK), coord=tiler_coord
+            )
+
+            lane_map = (lane_id % 16) * 2 + (lane_id // 16)
+            thr_copy = tiled_copy.get_slice(lane_map)
+
+            for col_group in cutlass.range_constexpr(self._bK // 32):
+                for row_vec in cutlass.range_constexpr(
+                    self._bM // self._num_vectorized
+                ):
+                    gX_sub = cute.local_tile(
+                        gX, tiler=(8, 32), coord=(row_vec, col_group)
+                    )
+                    sX_sub = cute.local_tile(
+                        sX_warp, tiler=(8, 32), coord=(row_vec, col_group)
+                    )
+                    tXgX = thr_copy.partition_S(gX_sub)
+                    tXsX = thr_copy.partition_D(sX_sub)
+                    vals = tXgX[(None, None), 0, 0].load().to(cutlass.Float32)
+                    tXsX[(None, None), 0, 0].store(vals.to(x.element_type))
+                    for vid in cutlass.range_constexpr(self._num_vectorized):
+                        v = vals[vid]
+                        abs_v = v
+                        nv = -v
+                        if nv > abs_v:
+                            abs_v = nv
+                        if abs_v > thread_absmax:
+                            thread_absmax = abs_v
+
+            block_absmax = cute.arch.warp_reduction_max(
+                thread_absmax, threads_in_group=32
+            )
+
+            fp8_max = cutlass.Float32(448.0)
+            eps = cutlass.Float32(1e-6)
+            safe_absmax = block_absmax
+            if safe_absmax < eps:
+                safe_absmax = eps
+            scale = safe_absmax / fp8_max
+
+            if lane_id == 0:
+                scales_col[row_block, col_block] = scale
+                scales_row[row_block, col_block] = scale
+
+            inv_scale = fp8_max / safe_absmax
+
+            for col_group in cutlass.range_constexpr(self._bK // 32):
+                for row_vec in cutlass.range_constexpr(
+                    self._bM // self._num_vectorized
+                ):
+                    gY_col_sub = cute.local_tile(
+                        gY_col, tiler=(8, 32), coord=(row_vec, col_group)
+                    )
+                    gY_row_sub = cute.local_tile(
+                        gY_row, tiler=(8, 32), coord=(row_vec, col_group)
+                    )
+                    sX_sub = cute.local_tile(
+                        sX_warp, tiler=(8, 32), coord=(row_vec, col_group)
+                    )
+                    tXsX = thr_copy.partition_S(sX_sub)
+                    tYgY_col = thr_copy.partition_D(gY_col_sub)
+                    tYgY_row = thr_copy.partition_D(gY_row_sub)
+                    vals = tXsX[(None, None), 0, 0].load().to(cutlass.Float32)
+                    out_vals = (vals * inv_scale).to(y_col.element_type)
+                    tYgY_col[(None, None), 0, 0].store(out_vals)
+                    tYgY_row[(None, None), 0, 0].store(out_vals)
+
+
+class _FP8LinearBase(nn.Module):
+    def __init__(self, in_features: int, out_features: int):
+        super().__init__()
+        assert in_features % 128 == 0
+        assert out_features % 128 == 0
+
+        self.in_features = in_features
+        self.out_features = out_features
+        self.k_blocks = in_features // 128
+        self.n_blocks = out_features // 128
+
+        # Keep identical parameter format to torch.nn.Linear: [out_features, in_features].
+        self.weight = nn.Parameter(
+            torch.empty(out_features, in_features, dtype=torch.bfloat16, device="cuda")
+        )
+        nn.init.normal_(self.weight, mean=0.0, std=0.02)
+
+        self._act_quant_kernel = ActivationQuantizer1x128()
+        self._wgt_quant_kernel = WeightQuantizer128x128(warps_per_cta=1)
+        self._act_quant_fn = None
+        self._wgt_quant_fn = None
+
+        self._has_prequantized_weight = False
+        self._act_q = None
+        self._act_s = None
+
+    def _to_cute(self, t: torch.Tensor):
+        return from_dlpack(t.detach(), assumed_align=16)
+
+    def _run_act_quant(self, x: torch.Tensor, y: torch.Tensor, s: torch.Tensor):
+        x_t = self._to_cute(x)
+        y_t = self._to_cute(y)
+        s_t = self._to_cute(s)
+        if self._act_quant_fn is None:
+            self._act_quant_fn = cute.compile[cute.GenerateLineInfo](
+                self._act_quant_kernel, x_t, y_t, s_t
+            )
+        self._act_quant_fn(x_t, y_t, s_t)
+
+    def _run_wgt_quant(self, x: torch.Tensor, y: torch.Tensor, s: torch.Tensor):
+        x_t = self._to_cute(x)
+        y_t = self._to_cute(y)
+        s_t = self._to_cute(s)
+        if self._wgt_quant_fn is None:
+            self._wgt_quant_fn = cute.compile[cute.GenerateLineInfo](
+                self._wgt_quant_kernel, x_t, y_t, s_t
+            )
+        self._wgt_quant_fn(x_t, y_t, s_t)
+
+    def _check_input(self, x: torch.Tensor):
+        assert x.dim() == 2
+        assert x.shape[1] == self.in_features
+        assert x.dtype == torch.bfloat16
+
+    def _quantize_weight_from_linear(
+        self,
+        w_q_kn: torch.Tensor,
+        w_s_kn: torch.Tensor,
+    ):
+        # `self.weight` is [N, K] (torch.nn.Linear format).
+        # The custom kernel consumes [K, N] col-major blocks, so we pass a view.
+        self._run_wgt_quant(self.weight.detach().t(), w_q_kn, w_s_kn)
+
+
+class FP8LinearScaledMM(_FP8LinearBase):
+    def __init__(self, in_features: int, out_features: int):
+        super().__init__(in_features, out_features)
+        self.k_blocks_scaledmm = max(4, self.k_blocks)
+
+        self.register_buffer(
+            "w_q_kn",
+            make_col_major_tensor((in_features, out_features), torch.float8_e4m3fn),
+            persistent=False,
+        )
+        self.register_buffer(
+            "w_s_kn",
+            make_col_major_tensor(
+                (self.k_blocks_scaledmm, self.n_blocks), torch.float32
+            ),
+            persistent=False,
+        )
+
+        self._w_q_kn_tmp = make_col_major_tensor(
+            (in_features, out_features), torch.float8_e4m3fn
+        )
+        self._w_s_kn_tmp = make_col_major_tensor(
+            (self.k_blocks_scaledmm, self.n_blocks), torch.float32
+        )
+
+    def _pad_scaledmm_scales(self, w_s_kn: torch.Tensor):
+        if self.k_blocks_scaledmm > self.k_blocks:
+            w_s_kn[self.k_blocks :, :].copy_(
+                w_s_kn[self.k_blocks - 1 : self.k_blocks, :]
+            )
+
+    def _quantize_weight_into(self, w_q_kn: torch.Tensor, w_s_kn: torch.Tensor):
+        self._quantize_weight_from_linear(w_q_kn, w_s_kn)
+        self._pad_scaledmm_scales(w_s_kn)
+
+    def prepare_prequantized_weight(self):
+        self._quantize_weight_into(self.w_q_kn, self.w_s_kn)
+        self._has_prequantized_weight = True
+
+    def _ensure_act_buffers(self, m: int):
+        if self._act_q is not None and self._act_q.shape[0] == m:
+            return
+        self._act_q = torch.empty(
+            m, self.in_features, dtype=torch.float8_e4m3fn, device="cuda"
+        )
+        # scaled_mm blockwise requires this stride: (1, M)
+        self._act_s = torch.empty_strided(
+            (m, self.k_blocks), (1, m), dtype=torch.float32, device="cuda"
+        )
+
+    def forward(
+        self, x: torch.Tensor, quantize_weight_on_the_fly: bool = False
+    ) -> torch.Tensor:
+        self._check_input(x)
+        x = x.contiguous()
+
+        m = x.shape[0]
+        self._ensure_act_buffers(m)
+        self._run_act_quant(x, self._act_q, self._act_s)
+
+        if quantize_weight_on_the_fly or not self._has_prequantized_weight:
+            self._quantize_weight_into(self._w_q_kn_tmp, self._w_s_kn_tmp)
+            w_q_kn = self._w_q_kn_tmp
+            w_s_kn = self._w_s_kn_tmp
+        else:
+            w_q_kn = self.w_q_kn
+            w_s_kn = self.w_s_kn
+
+        return F.scaled_mm(
+            self._act_q,
+            w_q_kn,
+            self._act_s,
+            F.ScalingType.BlockWise1x128,
+            w_s_kn,
+            F.ScalingType.BlockWise128x128,
+            output_dtype=torch.bfloat16,
+        )
+
+
+class _DeepGemmCustomQuant:
+    def __init__(self):
+        self._act_quant_kernel = ActivationQuantizer1x128()
+        self._wgt_quant_kernel = WeightQuantizer128x128(warps_per_cta=1)
+        self._wgt_quant_dual_kernel = WeightQuantizer128x128DualOutput(warps_per_cta=1)
+        self._act_quant_fns = {}
+        self._wgt_quant_fns = {}
+        self._wgt_quant_dual_fns = {}
+
+    def _to_cute(self, t: torch.Tensor):
+        return from_dlpack(t.detach(), assumed_align=16)
+
+    @staticmethod
+    def _sig(t: torch.Tensor):
+        return (tuple(t.shape), tuple(t.stride()), t.dtype)
+
+    def _get_act_fn(self, x: torch.Tensor, y: torch.Tensor, s: torch.Tensor):
+        key = (self._sig(x), self._sig(y), self._sig(s))
+        fn = self._act_quant_fns.get(key)
+        if fn is None:
+            fn = cute.compile[cute.GenerateLineInfo](
+                self._act_quant_kernel,
+                self._to_cute(x),
+                self._to_cute(y),
+                self._to_cute(s),
+            )
+            self._act_quant_fns[key] = fn
+        return fn
+
+    def _get_wgt_fn(self, x: torch.Tensor, y: torch.Tensor, s: torch.Tensor):
+        key = (self._sig(x), self._sig(y), self._sig(s))
+        fn = self._wgt_quant_fns.get(key)
+        if fn is None:
+            fn = cute.compile[cute.GenerateLineInfo](
+                self._wgt_quant_kernel,
+                self._to_cute(x),
+                self._to_cute(y),
+                self._to_cute(s),
+            )
+            self._wgt_quant_fns[key] = fn
+        return fn
+
+    def _get_wgt_dual_fn(
+        self,
+        x: torch.Tensor,
+        y_col: torch.Tensor,
+        s_col: torch.Tensor,
+        y_row: torch.Tensor,
+        s_row: torch.Tensor,
+    ):
+        key = (
+            self._sig(x),
+            self._sig(y_col),
+            self._sig(s_col),
+            self._sig(y_row),
+            self._sig(s_row),
+        )
+        fn = self._wgt_quant_dual_fns.get(key)
+        if fn is None:
+            fn = cute.compile[cute.GenerateLineInfo](
+                self._wgt_quant_dual_kernel,
+                self._to_cute(x),
+                self._to_cute(y_col),
+                self._to_cute(s_col),
+                self._to_cute(y_row),
+                self._to_cute(s_row),
+            )
+            self._wgt_quant_dual_fns[key] = fn
+        return fn
+
+    def run_act_quant(self, x: torch.Tensor, y: torch.Tensor, s: torch.Tensor):
+        fn = self._get_act_fn(x, y, s)
+        fn(self._to_cute(x), self._to_cute(y), self._to_cute(s))
+
+    def run_wgt_quant(self, x: torch.Tensor, y: torch.Tensor, s: torch.Tensor):
+        fn = self._get_wgt_fn(x, y, s)
+        fn(self._to_cute(x), self._to_cute(y), self._to_cute(s))
+
+    def run_wgt_quant_dual(
+        self,
+        x: torch.Tensor,
+        y_col: torch.Tensor,
+        s_col: torch.Tensor,
+        y_row: torch.Tensor,
+        s_row: torch.Tensor,
+    ):
+        fn = self._get_wgt_dual_fn(x, y_col, s_col, y_row, s_row)
+        fn(
+            self._to_cute(x),
+            self._to_cute(y_col),
+            self._to_cute(s_col),
+            self._to_cute(y_row),
+            self._to_cute(s_row),
+        )
+
+    def quantize_activation(self, x: torch.Tensor):
+        m, k = x.shape
+        assert m % 4 == 0
+        assert k % 128 == 0
+        y = torch.empty(m, k, dtype=torch.float8_e4m3fn, device=x.device)
+        s = torch.empty(m, k // 128, dtype=torch.float32, device=x.device)
+        self.run_act_quant(x, y, s)
+        return y, s
+
+    def quantize_activation_into(
+        self, x: torch.Tensor, y: torch.Tensor, s: torch.Tensor
+    ):
+        m, k = x.shape
+        assert m % 4 == 0
+        assert k % 128 == 0
+        self.run_act_quant(x, y, s)
+
+    def quantize_weight_linear_into(
+        self,
+        w_nk: torch.Tensor,
+        w_q_nk: torch.Tensor,
+        w_s_nk: torch.Tensor,
+    ):
+        # Kernel quantizes [K, N] col-major into [K, N] col-major with [K/128, N/128] scales.
+        # For linear-format tensors [N, K], use transposed views as adapters.
+        self.run_wgt_quant(
+            w_nk.t(),
+            w_q_nk.t(),
+            w_s_nk.t(),
+        )
+
+    def quantize_weight_linear_dual_into(
+        self,
+        w_nk: torch.Tensor,
+        w_q_nk: torch.Tensor,
+        w_s_nk: torch.Tensor,
+        w_t_q_kn: torch.Tensor,
+        w_t_s_kn: torch.Tensor,
+    ):
+        # Quantize once from [K, N] col-major adapter and write both:
+        # - forward layout: w_q_nk / w_s_nk (via transposed adapter views)
+        # - dgrad layout:   w_t_q_kn / w_t_s_kn (row-major)
+        self.run_wgt_quant_dual(
+            w_nk.t(),
+            w_q_nk.t(),
+            w_s_nk.t(),
+            w_t_q_kn,
+            w_t_s_kn,
+        )
+
+    def transpose_quantized_weight_into(
+        self,
+        w_q_nk: torch.Tensor,
+        w_s_nk: torch.Tensor,
+        w_t_q_kn: torch.Tensor,
+        w_t_s_kn: torch.Tensor,
+    ):
+        # Reuse already-quantized linear weights for dgrad path.
+        w_t_q_kn.copy_(w_q_nk.t())
+        w_t_s_kn.copy_(w_s_nk.t())
+
+    def quantize_col_matrix_to_row(self, x_col: torch.Tensor):
+        # `x_col` is [M, K] col-major. Return [M, K] row-major data + [M/128, K/128] scales.
+        m, k = x_col.shape
+        assert m % 128 == 0
+        assert k % 128 == 0
+        y_col = make_col_major_tensor((m, k), torch.float8_e4m3fn)
+        s_mk = torch.empty(m // 128, k // 128, dtype=torch.float32, device=x_col.device)
+        self.run_wgt_quant(x_col, y_col, s_mk)
+        return y_col.contiguous(), s_mk
+
+
+class _DeepGemmLinearAutograd(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        bias: torch.Tensor | None,
+        quant: _DeepGemmCustomQuant,
+        w_q: torch.Tensor,
+        w_s: torch.Tensor,
+        w_t_q: torch.Tensor | None,
+        w_t_s: torch.Tensor | None,
+    ) -> torch.Tensor:
+        need_grad_input = ctx.needs_input_grad[0]
+        need_grad_weight = ctx.needs_input_grad[1]
+
+        x_q, x_s = quant.quantize_activation(x)
+
+        out = torch.empty(
+            x.shape[0], weight.shape[0], dtype=torch.bfloat16, device=x.device
+        )
+        deep_gemm.fp8_gemm_nt(
+            (x_q, x_s),
+            (w_q, w_s),
+            out,
+            disable_ue8m0_cast=True,
+        )
+        if bias is not None:
+            out = out + bias
+
+        x_saved = (
+            x if need_grad_weight else torch.empty(0, device=x.device, dtype=x.dtype)
+        )
+        ctx.save_for_backward(x_saved)
+        ctx.has_saved_x = need_grad_weight
+        ctx.weight_shape = tuple(weight.shape)
+        ctx.weight_dtype = weight.dtype
+        ctx.weight_device = weight.device
+
+        if need_grad_input:
+            assert w_t_q is not None and w_t_s is not None
+            ctx.w_t_q = w_t_q
+            ctx.w_t_s = w_t_s
+        else:
+            ctx.w_t_q = None
+            ctx.w_t_s = None
+
+        ctx.has_bias = bias is not None
+        ctx.quant = quant
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        quant = ctx.quant
+        (x_saved,) = ctx.saved_tensors
+        x = x_saved if ctx.has_saved_x else None
+        grad_output = grad_output.contiguous()
+
+        grad_input = None
+        grad_weight = None
+        grad_bias = None
+
+        if ctx.needs_input_grad[0]:
+            go_q, go_s = quant.quantize_activation(grad_output)
+            w_t_q = ctx.w_t_q
+            w_t_s = ctx.w_t_s
+            assert w_t_q is not None and w_t_s is not None
+            grad_input = torch.empty_like(x)
+            deep_gemm.fp8_gemm_nt(
+                (go_q, go_s),
+                (w_t_q, w_t_s),
+                grad_input,
+                disable_ue8m0_cast=True,
+            )
+
+        if ctx.needs_input_grad[1]:
+            assert x is not None
+            n, k = ctx.weight_shape
+            grad_weight = torch.empty(
+                n,
+                k,
+                dtype=ctx.weight_dtype,
+                device=ctx.weight_device,
+            )
+            deep_gemm.bf16_gemm_tn(grad_output, x, grad_weight)
+
+        if ctx.has_bias and ctx.needs_input_grad[2]:
+            grad_bias = grad_output.sum(dim=0)
+
+        return grad_input, grad_weight, grad_bias, None, None, None, None, None
+
+
+class FP8LinearDeepGEMM(nn.Module):
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        bias: bool = False,
+    ):
+        super().__init__()
+        assert in_features % 128 == 0
+        assert out_features % 128 == 0
+
+        self.in_features = in_features
+        self.out_features = out_features
+        self.k_blocks = in_features // 128
+        self.n_blocks = out_features // 128
+
+        self.weight = nn.Parameter(
+            torch.empty(out_features, in_features, dtype=torch.bfloat16, device="cuda")
+        )
+        nn.init.normal_(self.weight, mean=0.0, std=0.02)
+
+        if bias:
+            self.bias = nn.Parameter(
+                torch.zeros(out_features, dtype=torch.bfloat16, device="cuda")
+            )
+        else:
+            self.register_parameter("bias", None)
+
+        self.register_buffer(
+            "w_q",
+            torch.empty(
+                out_features,
+                in_features,
+                dtype=torch.float8_e4m3fn,
+                device="cuda",
+            ),
+            persistent=False,
+        )
+        self.register_buffer(
+            "w_s",
+            torch.empty(
+                self.n_blocks, self.k_blocks, dtype=torch.float32, device="cuda"
+            ),
+            persistent=False,
+        )
+        self.register_buffer(
+            "w_t_q",
+            torch.empty(
+                in_features,
+                out_features,
+                dtype=torch.float8_e4m3fn,
+                device="cuda",
+            ),
+            persistent=False,
+        )
+        self.register_buffer(
+            "w_t_s",
+            torch.empty(
+                self.k_blocks,
+                self.n_blocks,
+                dtype=torch.float32,
+                device="cuda",
+            ),
+            persistent=False,
+        )
+
+        self._w_q_tmp = torch.empty(
+            out_features,
+            in_features,
+            dtype=torch.float8_e4m3fn,
+            device="cuda",
+        )
+        self._w_s_tmp = torch.empty(
+            self.n_blocks,
+            self.k_blocks,
+            dtype=torch.float32,
+            device="cuda",
+        )
+
+        self._act_q = None
+        self._act_s = None
+        self._has_prequantized_weight = False
+        self._w_q_version = -1
+        self._w_t_q_version = -1
+        self._quant = _DeepGemmCustomQuant()
+
+    def _ensure_act_buffers(self, m: int):
+        if self._act_q is not None and self._act_q.shape[0] == m:
+            return
+        self._act_q = torch.empty(
+            m, self.in_features, dtype=torch.float8_e4m3fn, device="cuda"
+        )
+        self._act_s = torch.empty(m, self.k_blocks, dtype=torch.float32, device="cuda")
+
+    def _ensure_weight_cache(self, need_transposed: bool):
+        v = self.weight._version
+        if (not self._has_prequantized_weight) or (self._w_q_version != v):
+            if need_transposed:
+                self._quant.quantize_weight_linear_dual_into(
+                    self.weight.detach(),
+                    self.w_q,
+                    self.w_s,
+                    self.w_t_q,
+                    self.w_t_s,
+                )
+                self._w_t_q_version = v
+            else:
+                self._quant.quantize_weight_linear_into(
+                    self.weight.detach(), self.w_q, self.w_s
+                )
+                self._w_t_q_version = -1
+            self._has_prequantized_weight = True
+            self._w_q_version = v
+
+        if need_transposed and self._w_t_q_version != self._w_q_version:
+            self._quant.transpose_quantized_weight_into(
+                self.w_q,
+                self.w_s,
+                self.w_t_q,
+                self.w_t_s,
+            )
+            self._w_t_q_version = self._w_q_version
+
+    def prepare_prequantized_weight(self):
+        self._ensure_weight_cache(need_transposed=False)
+
+    def _forward_inference(
+        self, x: torch.Tensor, quantize_weight_on_the_fly: bool
+    ) -> torch.Tensor:
+        m = x.shape[0]
+        self._ensure_act_buffers(m)
+        self._quant.quantize_activation_into(x, self._act_q, self._act_s)
+
+        if quantize_weight_on_the_fly or not self._has_prequantized_weight:
+            self._quant.quantize_weight_linear_into(
+                self.weight.detach(), self._w_q_tmp, self._w_s_tmp
+            )
+            w_q, w_s = self._w_q_tmp, self._w_s_tmp
+        else:
+            self._ensure_weight_cache(need_transposed=False)
+            w_q, w_s = self.w_q, self.w_s
+
+        out = torch.empty(
+            m,
+            self.out_features,
+            dtype=torch.bfloat16,
+            device=x.device,
+        )
+        deep_gemm.fp8_gemm_nt(
+            (self._act_q, self._act_s),
+            (w_q, w_s),
+            out,
+            disable_ue8m0_cast=True,
+        )
+        if self.bias is not None:
+            out = out + self.bias
+        return out
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        quantize_weight_on_the_fly: bool = False,
+    ) -> torch.Tensor:
+        assert x.dim() == 2
+        assert x.shape[1] == self.in_features
+        assert x.shape[0] % 128 == 0
+        assert x.dtype == torch.bfloat16
+        x = x.contiguous()
+
+        if torch.is_grad_enabled() and (
+            x.requires_grad
+            or self.weight.requires_grad
+            or (self.bias is not None and self.bias.requires_grad)
+        ):
+            need_dgrad = x.requires_grad
+            self._ensure_weight_cache(need_transposed=need_dgrad)
+            return _DeepGemmLinearAutograd.apply(
+                x,
+                self.weight,
+                self.bias,
+                self._quant,
+                self.w_q,
+                self.w_s,
+                self.w_t_q if need_dgrad else None,
+                self.w_t_s if need_dgrad else None,
+            )
+
+        return self._forward_inference(x, quantize_weight_on_the_fly)
+
+
+class _DeepGemmGroupedLinearAutograd(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        bias: torch.Tensor | None,
+        group_offsets: torch.Tensor,
+        grouped_layout: torch.Tensor,
+        quant: _DeepGemmCustomQuant,
+        w_q: torch.Tensor,
+        w_s: torch.Tensor,
+        w_t_q: torch.Tensor | None,
+        w_t_s: torch.Tensor | None,
+    ) -> torch.Tensor:
+        need_grad_input = ctx.needs_input_grad[0]
+        need_grad_weight = ctx.needs_input_grad[1]
+
+        x_q, x_s = quant.quantize_activation(x)
+        out = torch.empty(
+            x.shape[0],
+            weight.shape[1],
+            dtype=torch.bfloat16,
+            device=x.device,
+        )
+        deep_gemm.m_grouped_fp8_gemm_nt_contiguous(
+            (x_q, x_s),
+            (w_q, w_s),
+            out,
+            grouped_layout,
+            disable_ue8m0_cast=True,
+        )
+        if bias is not None:
+            out = out + bias[grouped_layout.to(torch.long)]
+
+        x_saved = (
+            x if need_grad_weight else torch.empty(0, device=x.device, dtype=x.dtype)
+        )
+        ctx.save_for_backward(x_saved, group_offsets, grouped_layout)
+        ctx.has_saved_x = need_grad_weight
+        ctx.has_bias = bias is not None
+
+        ctx.weight_shape = tuple(weight.shape)
+        ctx.weight_dtype = weight.dtype
+        ctx.weight_device = weight.device
+        ctx.quant = quant
+
+        if need_grad_input:
+            assert w_t_q is not None and w_t_s is not None
+            ctx.w_t_q = w_t_q
+            ctx.w_t_s = w_t_s
+        else:
+            ctx.w_t_q = None
+            ctx.w_t_s = None
+
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        quant = ctx.quant
+        x_saved, group_offsets, grouped_layout = ctx.saved_tensors
+        x = x_saved if ctx.has_saved_x else None
+        grad_output = grad_output.contiguous()
+
+        grad_input = None
+        grad_weight = None
+        grad_bias = None
+
+        if ctx.needs_input_grad[0]:
+            w_t_q = ctx.w_t_q
+            w_t_s = ctx.w_t_s
+            assert w_t_q is not None and w_t_s is not None
+            go_q, go_s = quant.quantize_activation(grad_output)
+            grad_input = torch.empty(
+                grad_output.shape[0],
+                ctx.weight_shape[2],
+                dtype=ctx.weight_dtype,
+                device=ctx.weight_device,
+            )
+            deep_gemm.m_grouped_fp8_gemm_nt_contiguous(
+                (go_q, go_s),
+                (w_t_q, w_t_s),
+                grad_input,
+                grouped_layout,
+                disable_ue8m0_cast=True,
+            )
+
+        if ctx.needs_input_grad[1]:
+            assert x is not None
+            grad_weight = torch._grouped_mm(
+                grad_output.t().contiguous(),
+                x,
+                offs=group_offsets,
+                out_dtype=torch.bfloat16,
+            )
+
+        if ctx.has_bias and ctx.needs_input_grad[2]:
+            n_experts, n_out, _ = ctx.weight_shape
+            grad_bias = torch.zeros(
+                n_experts,
+                n_out,
+                dtype=grad_output.dtype,
+                device=grad_output.device,
+            )
+            grad_bias.index_add_(0, grouped_layout.to(torch.long), grad_output)
+
+        return (
+            grad_input,
+            grad_weight,
+            grad_bias,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+
+
+class FP8GroupedLinearDeepGEMM(nn.Module):
+    def __init__(
+        self,
+        num_experts: int,
+        in_features: int,
+        out_features: int,
+        bias: bool = False,
+    ):
+        super().__init__()
+        assert num_experts > 0
+        assert in_features % 128 == 0
+        assert out_features % 128 == 0
+
+        self.num_experts = num_experts
+        self.in_features = in_features
+        self.out_features = out_features
+        self.k_blocks = in_features // 128
+        self.n_blocks = out_features // 128
+
+        self.weight = nn.Parameter(
+            torch.empty(
+                num_experts,
+                out_features,
+                in_features,
+                dtype=torch.bfloat16,
+                device="cuda",
+            )
+        )
+        nn.init.normal_(self.weight, mean=0.0, std=0.02)
+
+        if bias:
+            self.bias = nn.Parameter(
+                torch.zeros(
+                    num_experts,
+                    out_features,
+                    dtype=torch.bfloat16,
+                    device="cuda",
+                )
+            )
+        else:
+            self.register_parameter("bias", None)
+
+        self.register_buffer(
+            "w_q",
+            torch.empty(
+                num_experts,
+                out_features,
+                in_features,
+                dtype=torch.float8_e4m3fn,
+                device="cuda",
+            ),
+            persistent=False,
+        )
+        self.register_buffer(
+            "w_s",
+            torch.empty(
+                num_experts,
+                self.n_blocks,
+                self.k_blocks,
+                dtype=torch.float32,
+                device="cuda",
+            ),
+            persistent=False,
+        )
+        self.register_buffer(
+            "w_t_q",
+            torch.empty(
+                num_experts,
+                in_features,
+                out_features,
+                dtype=torch.float8_e4m3fn,
+                device="cuda",
+            ),
+            persistent=False,
+        )
+        self.register_buffer(
+            "w_t_s",
+            torch.empty(
+                num_experts,
+                self.k_blocks,
+                self.n_blocks,
+                dtype=torch.float32,
+                device="cuda",
+            ),
+            persistent=False,
+        )
+
+        self._w_q_tmp = torch.empty(
+            num_experts,
+            out_features,
+            in_features,
+            dtype=torch.float8_e4m3fn,
+            device="cuda",
+        )
+        self._w_s_tmp = torch.empty(
+            num_experts,
+            self.n_blocks,
+            self.k_blocks,
+            dtype=torch.float32,
+            device="cuda",
+        )
+
+        self._act_q = None
+        self._act_s = None
+        self._has_prequantized_weight = False
+        self._w_q_version = -1
+        self._w_t_q_version = -1
+        self._quant = _DeepGemmCustomQuant()
+
+    @staticmethod
+    def _align128(x: int) -> int:
+        return ((x + 127) // 128) * 128
+
+    def _ensure_act_buffers(self, m: int):
+        if self._act_q is not None and self._act_q.shape[0] == m:
+            return
+        self._act_q = torch.empty(
+            m,
+            self.in_features,
+            dtype=torch.float8_e4m3fn,
+            device="cuda",
+        )
+        self._act_s = torch.empty(
+            m,
+            self.k_blocks,
+            dtype=torch.float32,
+            device="cuda",
+        )
+
+    def _quantize_weight_into(self, w_q: torch.Tensor, w_s: torch.Tensor):
+        for e in range(self.num_experts):
+            self._quant.quantize_weight_linear_into(
+                self.weight[e].detach(), w_q[e], w_s[e]
+            )
+
+    def _quantize_weight_dual_into(
+        self,
+        w_q: torch.Tensor,
+        w_s: torch.Tensor,
+        w_t_q: torch.Tensor,
+        w_t_s: torch.Tensor,
+    ):
+        for e in range(self.num_experts):
+            self._quant.quantize_weight_linear_dual_into(
+                self.weight[e].detach(),
+                w_q[e],
+                w_s[e],
+                w_t_q[e],
+                w_t_s[e],
+            )
+
+    def _ensure_weight_cache(self, need_transposed: bool):
+        v = self.weight._version
+        if (not self._has_prequantized_weight) or (self._w_q_version != v):
+            if need_transposed:
+                self._quantize_weight_dual_into(
+                    self.w_q,
+                    self.w_s,
+                    self.w_t_q,
+                    self.w_t_s,
+                )
+                self._w_t_q_version = v
+            else:
+                self._quantize_weight_into(self.w_q, self.w_s)
+                self._w_t_q_version = -1
+            self._has_prequantized_weight = True
+            self._w_q_version = v
+
+        if need_transposed and self._w_t_q_version != self._w_q_version:
+            for e in range(self.num_experts):
+                self._quant.transpose_quantized_weight_into(
+                    self.w_q[e],
+                    self.w_s[e],
+                    self.w_t_q[e],
+                    self.w_t_s[e],
+                )
+            self._w_t_q_version = self._w_q_version
+
+    def prepare_prequantized_weight(self):
+        self._ensure_weight_cache(need_transposed=False)
+
+    def _add_group_bias_(self, out: torch.Tensor, grouped_layout: torch.Tensor):
+        if self.bias is None:
+            return
+        valid = grouped_layout >= 0
+        if bool(valid.all()):
+            out += self.bias[grouped_layout.to(torch.long)]
+            return
+        idx = grouped_layout[valid].to(torch.long)
+        out_valid = out[valid]
+        out_valid += self.bias[idx]
+        out[valid] = out_valid
+
+    def _forward_fp8_packed(
+        self,
+        x_packed: torch.Tensor,
+        grouped_layout: torch.Tensor,
+        quantize_weight_on_the_fly: bool,
+    ) -> torch.Tensor:
+        m = x_packed.shape[0]
+        self._ensure_act_buffers(m)
+        self._quant.quantize_activation_into(x_packed, self._act_q, self._act_s)
+
+        if quantize_weight_on_the_fly or not self._has_prequantized_weight:
+            self._quantize_weight_into(self._w_q_tmp, self._w_s_tmp)
+            w_q, w_s = self._w_q_tmp, self._w_s_tmp
+        else:
+            self._ensure_weight_cache(need_transposed=False)
+            w_q, w_s = self.w_q, self.w_s
+
+        out = torch.empty(
+            m,
+            self.out_features,
+            dtype=torch.bfloat16,
+            device=x_packed.device,
+        )
+        deep_gemm.m_grouped_fp8_gemm_nt_contiguous(
+            (self._act_q, self._act_s),
+            (w_q, w_s),
+            out,
+            grouped_layout,
+            disable_ue8m0_cast=True,
+        )
+        self._add_group_bias_(out, grouped_layout)
+        return out
+
+    def _forward_bf16_packed(
+        self,
+        x_packed: torch.Tensor,
+        grouped_layout: torch.Tensor,
+    ) -> torch.Tensor:
+        out = torch.empty(
+            x_packed.shape[0],
+            self.out_features,
+            dtype=torch.bfloat16,
+            device=x_packed.device,
+        )
+        deep_gemm.m_grouped_bf16_gemm_nt_contiguous(
+            x_packed,
+            self.weight,
+            out,
+            grouped_layout,
+        )
+        self._add_group_bias_(out, grouped_layout)
+        return out
+
+    def _counts_from_offsets(self, group_offsets: torch.Tensor) -> torch.Tensor:
+        assert group_offsets.dtype == torch.int32
+        assert group_offsets.dim() == 1
+        assert group_offsets.numel() == self.num_experts
+        counts = torch.empty_like(group_offsets)
+        counts[0] = group_offsets[0]
+        if group_offsets.numel() > 1:
+            counts[1:] = group_offsets[1:] - group_offsets[:-1]
+        return counts
+
+    def _grouped_layout_from_offsets_aligned(
+        self,
+        group_offsets: torch.Tensor,
+    ) -> torch.Tensor:
+        counts = self._counts_from_offsets(group_offsets).to(torch.long)
+        experts = torch.arange(
+            self.num_experts,
+            dtype=torch.int32,
+            device=group_offsets.device,
+        )
+        return torch.repeat_interleave(experts, counts)
+
+    def _pack_from_offsets(self, x: torch.Tensor, group_offsets: torch.Tensor):
+        assert group_offsets.dtype == torch.int32
+        assert group_offsets.numel() == self.num_experts
+
+        ends = group_offsets.detach().to(device="cpu", dtype=torch.int64).tolist()
+        assert len(ends) == self.num_experts
+        assert ends[-1] == x.shape[0]
+
+        counts = []
+        last = 0
+        for end in ends:
+            assert end >= last
+            counts.append(end - last)
+            last = end
+
+        aligned_total = 0
+        for c in counts:
+            aligned_total += self._align128(c)
+
+        if aligned_total == x.shape[0]:
+            x_packed = x
+        else:
+            x_packed = torch.zeros(
+                aligned_total,
+                x.shape[1],
+                dtype=x.dtype,
+                device=x.device,
+            )
+
+        grouped_layout = torch.empty(
+            aligned_total,
+            dtype=torch.int32,
+            device=x.device,
+        )
+
+        src_start = 0
+        dst_start = 0
+        for e, c in enumerate(counts):
+            aligned_c = self._align128(c)
+            if c > 0:
+                if aligned_total != x.shape[0]:
+                    x_packed[dst_start : dst_start + c].copy_(
+                        x[src_start : src_start + c]
+                    )
+                grouped_layout[dst_start : dst_start + c] = e
+            if aligned_c > c:
+                grouped_layout[dst_start + c : dst_start + aligned_c] = -1
+            src_start += c
+            dst_start += aligned_c
+
+        return x_packed, grouped_layout
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        group_offsets: torch.Tensor | None = None,
+        grouped_layout: torch.Tensor | None = None,
+        quantize_weight_on_the_fly: bool = False,
+    ) -> torch.Tensor:
+        assert x.dim() == 2
+        assert x.shape[1] == self.in_features
+        assert x.shape[0] % 4 == 0
+        assert x.dtype == torch.bfloat16
+        x = x.contiguous()
+
+        use_offsets = group_offsets is not None
+        use_layout = grouped_layout is not None
+        assert use_offsets != use_layout
+
+        m_real = x.shape[0]
+        if use_offsets:
+            assert group_offsets is not None
+            group_offsets = group_offsets.contiguous().to(torch.int32)
+            assert group_offsets.shape[0] == self.num_experts
+            assert int(group_offsets[-1].item()) == m_real
+            counts = self._counts_from_offsets(group_offsets)
+            is_aligned = bool((counts % 128 == 0).all().item())
+
+            if is_aligned:
+                x_packed = x
+                grouped_layout = self._grouped_layout_from_offsets_aligned(
+                    group_offsets
+                )
+            else:
+                x_packed, grouped_layout = self._pack_from_offsets(x, group_offsets)
+        else:
+            assert grouped_layout is not None
+            assert grouped_layout.dtype == torch.int32
+            assert grouped_layout.dim() == 1
+            assert grouped_layout.shape[0] == x.shape[0]
+            grouped_layout = grouped_layout.contiguous()
+            x_packed = x
+            group_offsets = None
+
+        needs_grad = torch.is_grad_enabled() and (
+            x.requires_grad
+            or self.weight.requires_grad
+            or (self.bias is not None and self.bias.requires_grad)
+        )
+        if needs_grad:
+            assert group_offsets is not None
+            assert x_packed.shape[0] == m_real
+            need_dgrad = x.requires_grad
+            self._ensure_weight_cache(need_transposed=need_dgrad)
+            out = _DeepGemmGroupedLinearAutograd.apply(
+                x_packed,
+                self.weight,
+                self.bias,
+                group_offsets,
+                grouped_layout,
+                self._quant,
+                self.w_q,
+                self.w_s,
+                self.w_t_q if need_dgrad else None,
+                self.w_t_s if need_dgrad else None,
+            )
+        else:
+            out = self._forward_fp8_packed(
+                x_packed,
+                grouped_layout,
+                quantize_weight_on_the_fly=quantize_weight_on_the_fly,
+            )
+
+        if use_offsets and out.shape[0] != m_real:
+            out = out[:m_real]
+        return out

--- a/src/prime_rl/trainer/fp8_linear.py
+++ b/src/prime_rl/trainer/fp8_linear.py
@@ -1,0 +1,737 @@
+from dataclasses import dataclass
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.utils as utils
+import deep_gemm
+import torch
+import torch.nn as nn
+from cutlass.cute.runtime import make_ptr
+
+
+@cute.kernel
+def _activation_quant_1x128_kernel(
+    x: cute.Tensor,
+    y: cute.Tensor,
+    scales: cute.Tensor,
+    tiled_copy: cute.TiledCopy,
+    s_x_layout: cute.Layout,
+):
+    tidx, _, _ = cute.arch.thread_idx()
+    bidx, bidy, _ = cute.arch.block_idx()
+
+    row_tiles = cute.ceil_div(x.shape[0], 4)
+    col_tiles = cute.ceil_div(x.shape[1], 128)
+
+    if bidx < row_tiles and bidy < col_tiles:
+        tiler_coord = (bidx, bidy)
+        g_x = cute.local_tile(x, tiler=(4, 128), coord=tiler_coord)
+        g_y = cute.local_tile(y, tiler=(4, 128), coord=tiler_coord)
+
+        smem = cutlass.utils.SmemAllocator()
+        s_x = smem.allocate_tensor(x.element_type, s_x_layout, 16)
+
+        thr_copy = tiled_copy.get_slice(tidx)
+        t_xg_x = thr_copy.partition_S(g_x)
+        t_xs_x = thr_copy.partition_D(s_x)
+        t_yg_y = thr_copy.partition_D(g_y)
+
+        cute.copy(tiled_copy, t_xg_x[None, None, 0], t_xs_x[None, None, 0])
+        cute.arch.cp_async_commit_group()
+        cute.arch.cp_async_wait_group(0)
+        cute.arch.sync_threads()
+
+        thread_vals = t_xs_x[(None, None), 0, 0].load().to(cutlass.Float32)
+        max_per_thread = cutlass.Float32(0.0)
+        for vid in cutlass.range_constexpr(4):
+            v = thread_vals[vid]
+            abs_v = v
+            nv = -v
+            if nv > abs_v:
+                abs_v = nv
+            if abs_v > max_per_thread:
+                max_per_thread = abs_v
+
+        max_per_warp = cute.arch.warp_reduction_max(max_per_thread, threads_in_group=32)
+        max_per_warp_scalar = max_per_warp
+
+        lane_id = tidx % 32
+        warp_id = tidx // 32
+        row_idx = bidx * 4 + warp_id
+
+        fp8_max = cutlass.Float32(448.0)
+        eps = cutlass.Float32(1e-4)
+        safe_max = max_per_warp_scalar
+        if safe_max < eps:
+            safe_max = eps
+        scale = safe_max / fp8_max
+        inv_scale = fp8_max / safe_max
+
+        if lane_id == 0 and row_idx < x.shape[0]:
+            scales[row_idx, bidy] = scale
+
+        out_vals = thread_vals * inv_scale
+        t_yg_y[(None, None), 0, 0].store(out_vals.to(y.element_type))
+
+
+@cute.jit
+def _activation_quant_1x128_op(x: cute.Tensor, y: cute.Tensor, scales: cute.Tensor):
+    copy_atom = cute.make_copy_atom(
+        cute.nvgpu.CopyUniversalOp(),
+        x.element_type,
+        num_bits_per_copy=x.element_type.width * 4,
+    )
+    major_mode_size = 32
+    t_a = cute.make_layout((4, major_mode_size), stride=(major_mode_size, 1))
+    v_a = cute.make_layout((1, 4), stride=(4, 128))
+    tiled_copy = cute.make_tiled_copy_tv(copy_atom, t_a, v_a)
+
+    s_x_layout = cute.make_layout((4, 128), stride=(128, 1))
+    block = (cute.size(t_a), 1, 1)
+    grid = (*cute.ceil_div(x.shape, (4, 128)), 1)
+    smem_size = cute.size_in_bytes(x.element_type, s_x_layout)
+
+    _activation_quant_1x128_kernel(x, y, scales, tiled_copy, s_x_layout).launch(grid=grid, block=block, smem=smem_size)
+
+
+@cute.kernel
+def _weight_quant_128x128_kernel(
+    x: cute.Tensor,
+    y: cute.Tensor,
+    scales: cute.Tensor,
+    tiled_copy: cute.TiledCopy,
+    s_x_layout: cute.Layout,
+):
+    tidx, _, _ = cute.arch.thread_idx()
+    bidx, bidy, _ = cute.arch.block_idx()
+
+    warp_id = tidx // 32
+    lane_id = tidx % 32
+    row_block = bidx + warp_id
+    col_block = bidy
+
+    row_blocks = cute.ceil_div(x.shape[0], 128)
+    col_blocks = cute.ceil_div(x.shape[1], 128)
+
+    if row_block < row_blocks and col_block < col_blocks:
+        thread_absmax = cutlass.Float32(0.0)
+
+        smem = cutlass.utils.SmemAllocator()
+        s_x = smem.allocate_tensor(x.element_type, s_x_layout, 16)
+        s_x_warp = s_x[warp_id, None, None]
+
+        tiler_coord = (row_block, col_block)
+        g_x = cute.local_tile(x, tiler=(128, 128), coord=tiler_coord)
+        g_y = cute.local_tile(y, tiler=(128, 128), coord=tiler_coord)
+
+        lane_map = (lane_id % 16) * 2 + (lane_id // 16)
+        thr_copy = tiled_copy.get_slice(lane_map)
+
+        for col_group in cutlass.range_constexpr(4):
+            for row_vec in cutlass.range_constexpr(16):
+                g_x_sub = cute.local_tile(g_x, tiler=(8, 32), coord=(row_vec, col_group))
+                s_x_sub = cute.local_tile(s_x_warp, tiler=(8, 32), coord=(row_vec, col_group))
+                t_xg_x = thr_copy.partition_S(g_x_sub)
+                t_xs_x = thr_copy.partition_D(s_x_sub)
+                vals = t_xg_x[(None, None), 0, 0].load().to(cutlass.Float32)
+                t_xs_x[(None, None), 0, 0].store(vals.to(x.element_type))
+                for vid in cutlass.range_constexpr(8):
+                    v = vals[vid]
+                    abs_v = v
+                    nv = -v
+                    if nv > abs_v:
+                        abs_v = nv
+                    if abs_v > thread_absmax:
+                        thread_absmax = abs_v
+
+        block_absmax = cute.arch.warp_reduction_max(thread_absmax, threads_in_group=32)
+        fp8_max = cutlass.Float32(448.0)
+        eps = cutlass.Float32(1e-6)
+        safe_absmax = block_absmax
+        if safe_absmax < eps:
+            safe_absmax = eps
+        scale = safe_absmax / fp8_max
+
+        if lane_id == 0:
+            scales[row_block, col_block] = scale
+
+        inv_scale = fp8_max / safe_absmax
+        for col_group in cutlass.range_constexpr(4):
+            for row_vec in cutlass.range_constexpr(16):
+                g_y_sub = cute.local_tile(g_y, tiler=(8, 32), coord=(row_vec, col_group))
+                s_x_sub = cute.local_tile(s_x_warp, tiler=(8, 32), coord=(row_vec, col_group))
+                t_xs_x = thr_copy.partition_S(s_x_sub)
+                t_yg_y = thr_copy.partition_D(g_y_sub)
+                vals = t_xs_x[(None, None), 0, 0].load().to(cutlass.Float32)
+                t_yg_y[(None, None), 0, 0].store((vals * inv_scale).to(y.element_type))
+
+
+@cute.jit
+def _weight_quant_128x128_op(x: cute.Tensor, y: cute.Tensor, scales: cute.Tensor):
+    copy_atom = cute.make_copy_atom(
+        cute.nvgpu.CopyUniversalOp(),
+        x.element_type,
+        num_bits_per_copy=x.element_type.width * 8,
+    )
+    t_a = cute.make_layout((1, 32), stride=(0, 1))
+    v_a = cute.make_layout((8,), stride=(1,))
+    tiled_copy = cute.make_tiled_copy_tv(copy_atom, t_a, v_a)
+
+    s_x_layout = cute.make_layout((1, 128, 128), stride=(128 * 128, 1, 128))
+    row_blocks = cute.ceil_div(x.shape[0], 128)
+    col_blocks = cute.ceil_div(x.shape[1], 128)
+
+    grid = (row_blocks, col_blocks, 1)
+    block = (32, 1, 1)
+    smem_size = cute.size_in_bytes(x.element_type, s_x_layout)
+    _weight_quant_128x128_kernel(x, y, scales, tiled_copy, s_x_layout).launch(grid=grid, block=block, smem=smem_size)
+
+
+@cute.kernel
+def _weight_quant_dual_128x128_kernel(
+    x: cute.Tensor,
+    y_col: cute.Tensor,
+    scales_col: cute.Tensor,
+    y_row: cute.Tensor,
+    scales_row: cute.Tensor,
+    tiled_copy: cute.TiledCopy,
+    s_x_layout: cute.Layout,
+):
+    tidx, _, _ = cute.arch.thread_idx()
+    bidx, bidy, _ = cute.arch.block_idx()
+
+    warp_id = tidx // 32
+    lane_id = tidx % 32
+    row_block = bidx + warp_id
+    col_block = bidy
+
+    row_blocks = cute.ceil_div(x.shape[0], 128)
+    col_blocks = cute.ceil_div(x.shape[1], 128)
+
+    if row_block < row_blocks and col_block < col_blocks:
+        thread_absmax = cutlass.Float32(0.0)
+
+        smem = cutlass.utils.SmemAllocator()
+        s_x = smem.allocate_tensor(x.element_type, s_x_layout, 16)
+        s_x_warp = s_x[warp_id, None, None]
+
+        tiler_coord = (row_block, col_block)
+        g_x = cute.local_tile(x, tiler=(128, 128), coord=tiler_coord)
+        g_y_col = cute.local_tile(y_col, tiler=(128, 128), coord=tiler_coord)
+        g_y_row = cute.local_tile(y_row, tiler=(128, 128), coord=tiler_coord)
+
+        lane_map = (lane_id % 16) * 2 + (lane_id // 16)
+        thr_copy = tiled_copy.get_slice(lane_map)
+
+        for col_group in cutlass.range_constexpr(4):
+            for row_vec in cutlass.range_constexpr(16):
+                g_x_sub = cute.local_tile(g_x, tiler=(8, 32), coord=(row_vec, col_group))
+                s_x_sub = cute.local_tile(s_x_warp, tiler=(8, 32), coord=(row_vec, col_group))
+                t_xg_x = thr_copy.partition_S(g_x_sub)
+                t_xs_x = thr_copy.partition_D(s_x_sub)
+                vals = t_xg_x[(None, None), 0, 0].load().to(cutlass.Float32)
+                t_xs_x[(None, None), 0, 0].store(vals.to(x.element_type))
+                for vid in cutlass.range_constexpr(8):
+                    v = vals[vid]
+                    abs_v = v
+                    nv = -v
+                    if nv > abs_v:
+                        abs_v = nv
+                    if abs_v > thread_absmax:
+                        thread_absmax = abs_v
+
+        block_absmax = cute.arch.warp_reduction_max(thread_absmax, threads_in_group=32)
+        fp8_max = cutlass.Float32(448.0)
+        eps = cutlass.Float32(1e-6)
+        safe_absmax = block_absmax
+        if safe_absmax < eps:
+            safe_absmax = eps
+        scale = safe_absmax / fp8_max
+
+        if lane_id == 0:
+            scales_col[row_block, col_block] = scale
+            scales_row[row_block, col_block] = scale
+
+        inv_scale = fp8_max / safe_absmax
+        for col_group in cutlass.range_constexpr(4):
+            for row_vec in cutlass.range_constexpr(16):
+                g_y_col_sub = cute.local_tile(g_y_col, tiler=(8, 32), coord=(row_vec, col_group))
+                g_y_row_sub = cute.local_tile(g_y_row, tiler=(8, 32), coord=(row_vec, col_group))
+                s_x_sub = cute.local_tile(s_x_warp, tiler=(8, 32), coord=(row_vec, col_group))
+                t_xs_x = thr_copy.partition_S(s_x_sub)
+                t_yg_y_col = thr_copy.partition_D(g_y_col_sub)
+                t_yg_y_row = thr_copy.partition_D(g_y_row_sub)
+                vals = t_xs_x[(None, None), 0, 0].load().to(cutlass.Float32)
+                out_vals = (vals * inv_scale).to(y_col.element_type)
+                t_yg_y_col[(None, None), 0, 0].store(out_vals)
+                t_yg_y_row[(None, None), 0, 0].store(out_vals)
+
+
+@cute.jit
+def _weight_quant_dual_128x128_op(
+    x: cute.Tensor,
+    y_col: cute.Tensor,
+    scales_col: cute.Tensor,
+    y_row: cute.Tensor,
+    scales_row: cute.Tensor,
+):
+    copy_atom = cute.make_copy_atom(
+        cute.nvgpu.CopyUniversalOp(),
+        x.element_type,
+        num_bits_per_copy=x.element_type.width * 8,
+    )
+    t_a = cute.make_layout((1, 32), stride=(0, 1))
+    v_a = cute.make_layout((8,), stride=(1,))
+    tiled_copy = cute.make_tiled_copy_tv(copy_atom, t_a, v_a)
+
+    s_x_layout = cute.make_layout((1, 128, 128), stride=(128 * 128, 1, 128))
+    row_blocks = cute.ceil_div(x.shape[0], 128)
+    col_blocks = cute.ceil_div(x.shape[1], 128)
+
+    grid = (row_blocks, col_blocks, 1)
+    block = (32, 1, 1)
+    smem_size = cute.size_in_bytes(x.element_type, s_x_layout)
+    _weight_quant_dual_128x128_kernel(
+        x,
+        y_col,
+        scales_col,
+        y_row,
+        scales_row,
+        tiled_copy,
+        s_x_layout,
+    ).launch(grid=grid, block=block, smem=smem_size)
+
+
+_ACTIVATION_QUANT_1X128_COMPILED = None
+_WEIGHT_QUANT_128X128_COMPILED = None
+_WEIGHT_QUANT_DUAL_128X128_COMPILED = None
+
+
+@cute.jit
+def _activation_quant_1x128_entry(
+    x_ptr: cute.Pointer,
+    y_ptr: cute.Pointer,
+    scales_ptr: cute.Pointer,
+    m: cutlass.Int32,
+    k: cutlass.Int32,
+):
+    m = cute.assume(m, divby=128)
+    k = cute.assume(k, divby=128)
+    x = cute.make_tensor(x_ptr, cute.make_layout((m, k), stride=(k, 1)))
+    y = cute.make_tensor(y_ptr, cute.make_layout((m, k), stride=(k, 1)))
+    scales = cute.make_tensor(
+        scales_ptr,
+        cute.make_layout((m, k // 128), stride=(k // 128, 1)),
+    )
+    _activation_quant_1x128_op(x, y, scales)
+
+
+@cute.jit
+def _weight_quant_128x128_entry(
+    x_ptr: cute.Pointer,
+    y_ptr: cute.Pointer,
+    scales_ptr: cute.Pointer,
+    k: cutlass.Int32,
+    n: cutlass.Int32,
+):
+    k = cute.assume(k, divby=128)
+    n = cute.assume(n, divby=128)
+    x = cute.make_tensor(x_ptr, cute.make_layout((k, n), stride=(1, k)))
+    y = cute.make_tensor(y_ptr, cute.make_layout((k, n), stride=(1, k)))
+    scales = cute.make_tensor(
+        scales_ptr,
+        cute.make_layout((k // 128, n // 128), stride=(1, k // 128)),
+    )
+    _weight_quant_128x128_op(x, y, scales)
+
+
+@cute.jit
+def _weight_quant_dual_128x128_entry(
+    x_ptr: cute.Pointer,
+    y_col_ptr: cute.Pointer,
+    scales_col_ptr: cute.Pointer,
+    y_row_ptr: cute.Pointer,
+    scales_row_ptr: cute.Pointer,
+    k: cutlass.Int32,
+    n: cutlass.Int32,
+):
+    k = cute.assume(k, divby=128)
+    n = cute.assume(n, divby=128)
+    x = cute.make_tensor(x_ptr, cute.make_layout((k, n), stride=(1, k)))
+    y_col = cute.make_tensor(y_col_ptr, cute.make_layout((k, n), stride=(1, k)))
+    scales_col = cute.make_tensor(
+        scales_col_ptr,
+        cute.make_layout((k // 128, n // 128), stride=(1, k // 128)),
+    )
+    y_row = cute.make_tensor(y_row_ptr, cute.make_layout((k, n), stride=(n, 1)))
+    scales_row = cute.make_tensor(
+        scales_row_ptr,
+        cute.make_layout((k // 128, n // 128), stride=(n // 128, 1)),
+    )
+    _weight_quant_dual_128x128_op(x, y_col, scales_col, y_row, scales_row)
+
+
+def compile_activation_quant_1x128():
+    global _ACTIVATION_QUANT_1X128_COMPILED
+    if _ACTIVATION_QUANT_1X128_COMPILED is None:
+        x_ptr = make_ptr(cutlass.BFloat16, 0, cute.AddressSpace.gmem, assumed_align=16)
+        y_ptr = make_ptr(cutlass.Float8E4M3FN, 0, cute.AddressSpace.gmem, assumed_align=16)
+        scales_ptr = make_ptr(cutlass.Float32, 0, cute.AddressSpace.gmem, assumed_align=16)
+        _ACTIVATION_QUANT_1X128_COMPILED = cute.compile(
+            _activation_quant_1x128_entry,
+            x_ptr,
+            y_ptr,
+            scales_ptr,
+            0,
+            0,
+        )
+    return _ACTIVATION_QUANT_1X128_COMPILED
+
+
+def compile_weight_quant_128x128():
+    global _WEIGHT_QUANT_128X128_COMPILED
+    if _WEIGHT_QUANT_128X128_COMPILED is None:
+        x_ptr = make_ptr(cutlass.BFloat16, 0, cute.AddressSpace.gmem, assumed_align=16)
+        y_ptr = make_ptr(cutlass.Float8E4M3FN, 0, cute.AddressSpace.gmem, assumed_align=16)
+        scales_ptr = make_ptr(cutlass.Float32, 0, cute.AddressSpace.gmem, assumed_align=16)
+        _WEIGHT_QUANT_128X128_COMPILED = cute.compile(
+            _weight_quant_128x128_entry,
+            x_ptr,
+            y_ptr,
+            scales_ptr,
+            0,
+            0,
+        )
+    return _WEIGHT_QUANT_128X128_COMPILED
+
+
+def compile_weight_quant_dual_128x128():
+    global _WEIGHT_QUANT_DUAL_128X128_COMPILED
+    if _WEIGHT_QUANT_DUAL_128X128_COMPILED is None:
+        x_ptr = make_ptr(cutlass.BFloat16, 0, cute.AddressSpace.gmem, assumed_align=16)
+        y_col_ptr = make_ptr(cutlass.Float8E4M3FN, 0, cute.AddressSpace.gmem, assumed_align=16)
+        scales_col_ptr = make_ptr(cutlass.Float32, 0, cute.AddressSpace.gmem, assumed_align=16)
+        y_row_ptr = make_ptr(cutlass.Float8E4M3FN, 0, cute.AddressSpace.gmem, assumed_align=16)
+        scales_row_ptr = make_ptr(cutlass.Float32, 0, cute.AddressSpace.gmem, assumed_align=16)
+        _WEIGHT_QUANT_DUAL_128X128_COMPILED = cute.compile(
+            _weight_quant_dual_128x128_entry,
+            x_ptr,
+            y_col_ptr,
+            scales_col_ptr,
+            y_row_ptr,
+            scales_row_ptr,
+            0,
+            0,
+        )
+    return _WEIGHT_QUANT_DUAL_128X128_COMPILED
+
+
+def activation_quant_1x128(x: torch.Tensor, y: torch.Tensor, scales: torch.Tensor) -> None:
+    m, k = x.shape
+    assert m % 4 == 0
+    assert k % 128 == 0
+
+    compiled = compile_activation_quant_1x128()
+    compiled(
+        make_ptr(cutlass.BFloat16, x.data_ptr(), cute.AddressSpace.gmem, assumed_align=16),
+        make_ptr(cutlass.Float8E4M3FN, y.data_ptr(), cute.AddressSpace.gmem, assumed_align=16),
+        make_ptr(cutlass.Float32, scales.data_ptr(), cute.AddressSpace.gmem, assumed_align=16),
+        m,
+        k,
+    )
+
+
+def weight_quant_128x128(x: torch.Tensor, y: torch.Tensor, scales: torch.Tensor) -> None:
+    k, n = x.shape
+    compiled = compile_weight_quant_128x128()
+    compiled(
+        make_ptr(cutlass.BFloat16, x.data_ptr(), cute.AddressSpace.gmem, assumed_align=16),
+        make_ptr(cutlass.Float8E4M3FN, y.data_ptr(), cute.AddressSpace.gmem, assumed_align=16),
+        make_ptr(cutlass.Float32, scales.data_ptr(), cute.AddressSpace.gmem, assumed_align=16),
+        k,
+        n,
+    )
+
+
+def weight_quant_dual_128x128(
+    x: torch.Tensor,
+    y_col: torch.Tensor,
+    scales_col: torch.Tensor,
+    y_row: torch.Tensor,
+    scales_row: torch.Tensor,
+) -> None:
+    k, n = x.shape
+    compiled = compile_weight_quant_dual_128x128()
+    compiled(
+        make_ptr(cutlass.BFloat16, x.data_ptr(), cute.AddressSpace.gmem, assumed_align=16),
+        make_ptr(cutlass.Float8E4M3FN, y_col.data_ptr(), cute.AddressSpace.gmem, assumed_align=16),
+        make_ptr(cutlass.Float32, scales_col.data_ptr(), cute.AddressSpace.gmem, assumed_align=16),
+        make_ptr(cutlass.Float8E4M3FN, y_row.data_ptr(), cute.AddressSpace.gmem, assumed_align=16),
+        make_ptr(cutlass.Float32, scales_row.data_ptr(), cute.AddressSpace.gmem, assumed_align=16),
+        k,
+        n,
+    )
+
+
+class _DeepGemmLinearAutograd(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        bias: torch.Tensor | None,
+        output_dtype: str,
+        w_q: torch.Tensor,
+        w_s: torch.Tensor,
+        w_t_q: torch.Tensor,
+        w_t_s: torch.Tensor,
+        act_q: torch.Tensor,
+        act_s: torch.Tensor,
+    ) -> torch.Tensor:
+        x_bf16 = x if x.dtype == torch.bfloat16 else x.to(torch.bfloat16)
+        activation_quant_1x128(x_bf16, act_q, act_s)
+
+        out = torch.empty(x.shape[0], weight.shape[0], dtype=torch.bfloat16, device=x.device)
+        deep_gemm.fp8_gemm_nt((act_q, act_s), (w_q, w_s), out, disable_ue8m0_cast=True)
+        if bias is not None:
+            out = out + bias
+
+        ctx.save_for_backward(x_bf16)
+        ctx.has_bias = bias is not None
+        ctx.x_dtype = x.dtype
+
+        ctx.weight_shape = tuple(weight.shape)
+        ctx.weight_dtype = weight.dtype
+        ctx.weight_device = weight.device
+
+        ctx.w_t_q = w_t_q
+        ctx.w_t_s = w_t_s
+
+        if output_dtype == "input" and out.dtype != x.dtype:
+            out = out.to(x.dtype)
+
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        (x,) = ctx.saved_tensors
+        grad_output = grad_output.contiguous()
+        grad_output_bf16 = grad_output if grad_output.dtype == torch.bfloat16 else grad_output.to(torch.bfloat16)
+
+        go_q = torch.empty(
+            grad_output.shape[0],
+            grad_output.shape[1],
+            dtype=torch.float8_e4m3fn,
+            device=grad_output.device,
+        )
+        go_s = torch.empty(
+            grad_output.shape[0],
+            grad_output.shape[1] // 128,
+            dtype=torch.float32,
+            device=grad_output.device,
+        )
+        activation_quant_1x128(grad_output_bf16, go_q, go_s)
+
+        grad_input_bf16 = torch.empty(
+            grad_output.shape[0],
+            ctx.weight_shape[1],
+            dtype=torch.bfloat16,
+            device=ctx.weight_device,
+        )
+        deep_gemm.fp8_gemm_nt((go_q, go_s), (ctx.w_t_q, ctx.w_t_s), grad_input_bf16, disable_ue8m0_cast=True)
+        grad_input = grad_input_bf16 if ctx.x_dtype == torch.bfloat16 else grad_input_bf16.to(ctx.x_dtype)
+
+        n, k = ctx.weight_shape
+        grad_weight_bf16 = torch.empty(n, k, dtype=torch.bfloat16, device=ctx.weight_device)
+        deep_gemm.bf16_gemm_tn(grad_output_bf16, x, grad_weight_bf16)
+        grad_weight = grad_weight_bf16 if ctx.weight_dtype == torch.bfloat16 else grad_weight_bf16.to(ctx.weight_dtype)
+
+        grad_bias = grad_output.sum(dim=0) if ctx.has_bias else None
+
+        return grad_input, grad_weight, grad_bias, None, None, None, None, None, None, None
+
+
+@dataclass(frozen=True)
+class FP8LinearConfig:
+    output_dtype: str = "input"
+
+    def __post_init__(self):
+        if self.output_dtype not in {"input", "bfloat16"}:
+            raise ValueError("FP8LinearConfig.output_dtype must be 'input' or 'bfloat16'")
+
+
+class FP8LinearDeepGEMM(nn.Linear):
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        bias: bool = True,
+        dtype: torch.dtype = torch.bfloat16,
+        device: torch.device | str | None = None,
+        config: FP8LinearConfig | None = None,
+    ):
+        super().__init__(in_features, out_features, bias=bias, device=device, dtype=dtype)
+        assert in_features % 128 == 0
+        assert out_features % 128 == 0
+
+        self.config = config or FP8LinearConfig()
+        self.k_blocks = in_features // 128
+        self.n_blocks = out_features // 128
+
+        if self.weight.device.type == "meta":
+            self.register_buffer("w_q", torch.empty(0), persistent=False)
+            self.register_buffer("w_s", torch.empty(0), persistent=False)
+            self.register_buffer("w_t_q", torch.empty(0), persistent=False)
+            self.register_buffer("w_t_s", torch.empty(0), persistent=False)
+        else:
+            self.register_buffer(
+                "w_q",
+                torch.empty(out_features, in_features, dtype=torch.float8_e4m3fn, device=self.weight.device),
+                persistent=False,
+            )
+            self.register_buffer(
+                "w_s",
+                torch.empty(self.n_blocks, self.k_blocks, dtype=torch.float32, device=self.weight.device),
+                persistent=False,
+            )
+            self.register_buffer(
+                "w_t_q",
+                torch.empty(in_features, out_features, dtype=torch.float8_e4m3fn, device=self.weight.device),
+                persistent=False,
+            )
+            self.register_buffer(
+                "w_t_s",
+                torch.empty(self.k_blocks, self.n_blocks, dtype=torch.float32, device=self.weight.device),
+                persistent=False,
+            )
+        self.register_buffer("_act_q", torch.empty(0), persistent=False)
+        self.register_buffer("_act_s", torch.empty(0), persistent=False)
+
+    @classmethod
+    def from_float(cls, linear: nn.Linear, config: FP8LinearConfig | None = None) -> "FP8LinearDeepGEMM":
+        module = cls(
+            in_features=linear.in_features,
+            out_features=linear.out_features,
+            bias=linear.bias is not None,
+            dtype=linear.weight.dtype,
+            device=linear.weight.device,
+            config=config,
+        )
+        module.weight = linear.weight
+        if linear.bias is not None:
+            module.bias = linear.bias
+        return module
+
+    @classmethod
+    def from_linear(cls, linear: nn.Linear, config: FP8LinearConfig | None = None) -> "FP8LinearDeepGEMM":
+        return cls.from_float(linear, config=config)
+
+    def extra_repr(self) -> str:
+        return f"{super().extra_repr()}, fp8_output_dtype={self.config.output_dtype}"
+
+    def _ensure_weight_buffers(self, device: torch.device) -> None:
+        if self.w_q.shape != (self.out_features, self.in_features) or self.w_q.device != device:
+            self.w_q = torch.empty(self.out_features, self.in_features, dtype=torch.float8_e4m3fn, device=device)
+            self.w_s = torch.empty(self.n_blocks, self.k_blocks, dtype=torch.float32, device=device)
+            self.w_t_q = torch.empty(self.in_features, self.out_features, dtype=torch.float8_e4m3fn, device=device)
+            self.w_t_s = torch.empty(self.k_blocks, self.n_blocks, dtype=torch.float32, device=device)
+
+    def _ensure_act_buffers(self, m: int, device: torch.device) -> None:
+        if self._act_q.shape != (m, self.in_features) or self._act_q.device != device:
+            self._act_q = torch.empty(m, self.in_features, dtype=torch.float8_e4m3fn, device=device)
+            self._act_s = torch.empty(m, self.k_blocks, dtype=torch.float32, device=device)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        bsz, seq_len, _ = x.shape
+        x_2d = x.reshape(bsz * seq_len, self.in_features).contiguous()
+        self._ensure_weight_buffers(x.device)
+        self._ensure_act_buffers(bsz * seq_len, x.device)
+
+        weight_quant = self.weight.detach()
+        if weight_quant.dtype != torch.bfloat16:
+            weight_quant = weight_quant.to(torch.bfloat16)
+        weight_quant_dual_128x128(weight_quant.t(), self.w_q.t(), self.w_s.t(), self.w_t_q, self.w_t_s)
+
+        out_2d = _DeepGemmLinearAutograd.apply(
+            x_2d,
+            self.weight,
+            self.bias,
+            self.config.output_dtype,
+            self.w_q,
+            self.w_s,
+            self.w_t_q,
+            self.w_t_s,
+            self._act_q,
+            self._act_s,
+        )
+
+        return out_2d.view(bsz, seq_len, self.out_features)
+
+
+@dataclass
+class FP8ConversionResult:
+    converted: int
+    skipped_non_multiple_128: int
+    skipped_excluded: int
+
+
+def _get_module_by_name(model: nn.Module, module_name: str) -> nn.Module:
+    module = model
+    for part in module_name.split("."):
+        module = getattr(module, part)
+    return module
+
+
+def _set_module_by_name(model: nn.Module, module_name: str, new_module: nn.Module) -> None:
+    parts = module_name.split(".")
+    parent = model
+    for part in parts[:-1]:
+        parent = getattr(parent, part)
+    setattr(parent, parts[-1], new_module)
+
+
+def _is_excluded_linear(module_name: str, module: nn.Linear) -> bool:
+    if module.__class__.__name__ in {
+        "FusedOutputLinear",
+        "VanillaOutputLinear",
+        "GemmaFusedOutputLinear",
+        "GemmaVanillaOutputLinear",
+    }:
+        return True
+    if module_name == "lm_head" or module_name.endswith(".lm_head"):
+        return True
+    return False
+
+
+def convert_to_fp8(model: nn.Module, config: FP8LinearConfig | None = None) -> FP8ConversionResult:
+    config = config or FP8LinearConfig()
+    target_names: list[str] = []
+    skipped_non_multiple_128 = 0
+    skipped_excluded = 0
+
+    for module_name, module in model.named_modules():
+        if not module_name:
+            continue
+        if not isinstance(module, nn.Linear):
+            continue
+        if isinstance(module, FP8LinearDeepGEMM):
+            continue
+        if _is_excluded_linear(module_name, module):
+            skipped_excluded += 1
+            continue
+        if module.in_features % 128 != 0 or module.out_features % 128 != 0:
+            skipped_non_multiple_128 += 1
+            continue
+        target_names.append(module_name)
+
+    for module_name in target_names:
+        module = _get_module_by_name(model, module_name)
+        assert isinstance(module, nn.Linear)
+        fp8_module = FP8LinearDeepGEMM.from_float(module, config=config)
+        _set_module_by_name(model, module_name, fp8_module)
+
+    return FP8ConversionResult(
+        converted=len(target_names),
+        skipped_non_multiple_128=skipped_non_multiple_128,
+        skipped_excluded=skipped_excluded,
+    )


### PR DESCRIPTION
## Summary
- add the current FP8 linear implementation into `src/prime_rl/trainer/fp8_linear.py` so this work can continue inside prime-rl on larger multi-GPU nodes
- stage grouped GEMM prototype code under `src/prime_rl/trainer/experimental/grouped_gemm/` and expose it as an experimental package boundary
- add benchmark entrypoints under `scripts/experimental/` and document setup + multi-GPU `torchrun` usage in `docs/grouped_gemm_experimental.md` (with docs navigation updates)

## Validation
- `uv run python -m py_compile src/prime_rl/trainer/fp8_linear.py src/prime_rl/trainer/experimental/__init__.py src/prime_rl/trainer/experimental/grouped_gemm/__init__.py src/prime_rl/trainer/experimental/grouped_gemm/fp8_grouped_linear.py scripts/experimental/bench_deepgemm_grouped_linear.py scripts/experimental/bench_deepgemm_linear.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds large new low-level FP8 quantization and custom autograd/GEMM code paths (CUTLASS/CuTe + DeepGEMM) that could affect correctness/perf if adopted, though most grouped functionality is isolated under `trainer/experimental` and new benchmarks help validate behavior.
> 
> **Overview**
> Stages **experimental FP8 GEMM work** in-tree: adds a production-facing `FP8LinearDeepGEMM` path in `trainer/fp8_linear.py` (CUTLASS/CuTe quantization + DeepGEMM forward/backward) plus a `convert_to_fp8()` utility to swap eligible `nn.Linear` modules.
> 
> Introduces an **isolated grouped GEMM prototype** under `trainer/experimental/grouped_gemm`, including `FP8GroupedLinearDeepGEMM`/`FP8LinearDeepGEMM` with weight/activation quantization, cached (optionally transposed) quantized weights, and grouped-layout packing for non-128-aligned expert token counts.
> 
> Adds two `scripts/experimental` benchmark entrypoints for correctness/perf (single and grouped) with `torchrun` support via `LOCAL_RANK`, and wires new documentation (`docs/grouped_gemm_experimental.md`) into the docs index/navigation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b142b0857582f8d2e3ad763a142b4a0af94867c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->