### PR TITLE
Fix torch distributed warning messge by adding device_id handling

### DIFF
--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -45,7 +45,8 @@ def get_ckpt_disk_metrics(output_dir: Path) -> dict[str, float]:
 
 
 def setup_torch_distributed(timeout: timedelta = DEFAULT_TIMEOUT, enable_gloo: bool = False):
-    torch.cuda.set_device(get_world().local_rank)
+    device_id = get_world().local_rank
+    torch.cuda.set_device(device_id)
     # Use Gloo backend for CPU and NCCL for GPU when CPU offloading is enabled
     # Otherwise use NCCL for better GPU performance
     backend = None  # by default nccl
@@ -53,7 +54,7 @@ def setup_torch_distributed(timeout: timedelta = DEFAULT_TIMEOUT, enable_gloo: b
         get_logger().info("Using Gloo backend for CPU and NCCL backend for GPU")
         backend = "cpu:gloo,cuda:nccl"
 
-    dist.init_process_group(backend=backend, timeout=timeout)
+    dist.init_process_group(backend=backend, timeout=timeout, device_id=device_id)
 
 
 def get_response_lengths(position_ids: torch.Tensor) -> list[int]:


### PR DESCRIPTION
This PR removes a noisy `torch.distributed` warning that is printed during training runs.

PyTorch emits a warning on every call to `barrier()` when no `device_id` is specified in `init_process_group`. While harmless, this warning clutters logs and makes it harder to spot meaningful training output.

This change explicitly sets the `device_id` so the warning is silenced, without affecting training behavior.

Before:
```shell
[default0]:15:44:10 SUCCESS Step 0 | Time: 53.67s | Loss: 0.0000 | Entropy: 0.3254 | Mismatch KL: 0.0012 | Grad. Norm: 0.0000 | LR: 1.00e-05 | Throughput: 0 tokens/s | MFU: 0.0% | Peak Mem.: 42.6 GiB
[default0]:/home/tzafon/ido/prime-rl-ido/.venv/lib/python3.12/site-packages/torch/distributed/distributed_c10d.py:4876: UserWarning: barrier(): using the device under current context. You can specify `device_id` in `init_process_group` to mute this warning.
[default0]:  warnings.warn(  # warn only once
[default0]:15:44:29 SUCCESS Step 1 | Time: 6.87s | Loss: -0.0000 | Entropy: 0.3129 | Mismatch KL: 0.0012 | Grad. Norm: 0.0080 | LR: 1.00e-05 | Throughput: 4309 tokens/s | MFU: 6.2% | Peak Mem.: 57.6 GiB
[default0]:/home/tzafon/ido/prime-rl-ido/.venv/lib/python3.12/site-packages/torch/distributed/distributed_c10d.py:4876: UserWarning: barrier(): using the device under current context. You can specify `device_id` in `init_process_group` to mute this warning.
[default0]:  warnings.warn(  # warn only once
```

After:
```shell
[default0]:15:48:04 SUCCESS Step 0 | Time: 57.18s | Loss: 0.0000 | Entropy: 0.3271 | Mismatch KL: 0.0013 | Grad. Norm: 0.0000 | LR: 1.00e-05 | Throughput: 0 tokens/s | MFU: 0.0% | Peak Mem.: 42.6 GiB
[default0]:15:48:23 SUCCESS Step 1 | Time: 7.27s | Loss: 0.0008 | Entropy: 0.3136 | Mismatch KL: 0.0013 | Grad. Norm: 0.1774 | LR: 1.00e-05 | Throughput: 5190 tokens/s | MFU: 7.5% | Peak Mem.: 57.6 GiB
```