### PR TITLE
add mini moe

### DIFF
--- a/docs/testing-moe-at-small-scale.md
+++ b/docs/testing-moe-at-small-scale.md
@@ -1,0 +1,113 @@
+# Testing MoE at Small Scale
+
+When working on MoE architectures (GLM-4, Kimi, etc.), you can't iterate on a 100B+ parameter model locally. This guide shows how to create a small (~0.5B) MoE model with the same architecture, run SFT to warm it up, and run RL on it — all on 1-2 GPUs.
+
+The goal isn't performance. It's catching bugs in modeling code, state dict conversions, and training pipeline integration before running at scale.
+
+## Overview
+
+1. **Create + verify** a mini model with random weights and check HF <-> PrimeRL roundtrip
+2. **SFT** to give it a non-trivial distribution
+3. **RL** on reverse-text to validate the full pipeline
+
+## Prerequisites
+
+- At least 1 GPU for steps 1-2, 2 GPUs for step 3 (RL)
+- Architecture presets are defined in `scripts/mini_moe.py`
+
+## Step 1: Create and verify the mini model
+
+```bash
+uv run python scripts/mini_moe.py --arch glm4_moe --output-dir ./mini-glm-moe
+```
+
+This creates a ~543M parameter GLM-4 MoE (1024 hidden, 24 layers, 8 experts) with random weights, copies the tokenizer from the original GLM-4 model, then verifies that:
+- Logits match between HF and PrimeRL implementations (`convert_to_prime`)
+- The HF -> PrimeRL -> HF roundtrip is lossless (`convert_to_hf`)
+
+To re-run verification only (e.g. after a modeling code change):
+
+```bash
+uv run python scripts/mini_moe.py --arch glm4_moe --output-dir ./mini-glm-moe --verify-only
+```
+
+## Step 2: SFT warmup
+
+Using the existing debug MoE SFT config with overrides for real data:
+
+```bash
+uv run sft @ configs/debug/moe/sft/train.toml \
+    --model.name ./mini-glm-moe \
+    --data.name PrimeIntellect/Reverse-Text-SFT \
+    --data.type null \
+    --max_steps 200 \
+    --optim.lr 1e-4 \
+    --ckpt.weights
+```
+
+This fine-tunes on [PrimeIntellect/Reverse-Text-SFT](https://huggingface.co/datasets/PrimeIntellect/Reverse-Text-SFT) for 200 steps. Loss should drop from ~12 to ~2.5. The model won't be coherent, but it will have a non-trivial distribution so KL divergence is meaningful during RL.
+
+The latest weight checkpoint is saved under `outputs/weights/step_<N>`. You can verify the roundtrip on it:
+
+```bash
+uv run python scripts/mini_moe.py --arch glm4_moe --output-dir outputs/weights/step_200 --verify-only
+```
+
+A pre-built SFT'd model is available at [samsja/mini-glm-moe](https://huggingface.co/samsja/mini-glm-moe).
+
+## Step 3: RL (reverse-text)
+
+Requires 2 GPUs (one for inference, one for training).
+
+```bash
+uv run rl @ configs/ci/integration/rl/start.toml \
+    --model.name samsja/mini-glm-moe \
+    --trainer.model.impl custom \
+    --inference.gpu-memory-utilization 0.7 \
+    --inference.model.max-model-len 2048
+```
+
+Or to use the checkpoint from step 2:
+
+```bash
+uv run rl @ configs/ci/integration/rl/start.toml \
+    --model.name outputs/weights/step_200 \
+    --trainer.model.impl custom \
+    --inference.gpu-memory-utilization 0.7 \
+    --inference.model.max-model-len 2048
+```
+
+What to look for:
+- **Training runs without crashing** — validates the full pipeline (inference server, orchestrator, trainer)
+- **KL divergence is non-zero and finite** — confirms the reference model distribution is working
+- **Loss is reasonable** — not NaN, not stuck at a constant value
+
+Don't expect the reward to go up meaningfully in 20 steps on a random model.
+
+## Adding a new architecture
+
+To test a new MoE architecture (e.g., Kimi2.5):
+
+1. Add modeling code under `src/prime_rl/trainer/models/<arch>/`
+2. Add a preset to `scripts/mini_moe.py` with the config class, small dimensions, HF model class, PrimeRL model class, and tokenizer source
+3. Run steps 1-3 above with `--arch <your_arch>`
+
+The preset defines the small config:
+
+```python
+ARCH_PRESETS = {
+    "glm4_moe": {
+        "config_class": Glm4MoeConfig,
+        "config_kwargs": dict(
+            hidden_size=1024,
+            num_hidden_layers=24,
+            n_routed_experts=8,
+            # ...
+        ),
+        "hf_model_class": HFGlm4MoeForCausalLM,
+        "prime_model_class": PrimeRLGlm4MoeForCausalLM,
+        "tokenizer_source": "THUDM/GLM-4-9B-0414",
+    },
+    # Add your new arch here
+}
+```

--- a/scripts/mini_moe.py
+++ b/scripts/mini_moe.py
@@ -1,0 +1,147 @@
+"""Create and verify a mini MoE model for testing.
+
+Creates a small MoE model with random weights, saves it with a tokenizer,
+and verifies the HF <-> PrimeRL weight conversion roundtrip.
+
+Usage:
+    # Create and verify
+    uv run python scripts/mini_moe.py --arch glm4_moe --output-dir ./mini-glm-moe
+
+    # Verify only (on an existing checkpoint)
+    uv run python scripts/mini_moe.py --arch glm4_moe --output-dir ./mini-glm-moe --verify-only
+"""
+
+import argparse
+from pathlib import Path
+
+import torch
+from transformers import AutoConfig, AutoTokenizer
+from transformers import Glm4MoeForCausalLM as HFGlm4MoeForCausalLM
+
+from prime_rl.trainer.models.glm4_moe import Glm4MoeConfig
+from prime_rl.trainer.models.glm4_moe import Glm4MoeForCausalLM as PrimeRLGlm4MoeForCausalLM
+from prime_rl.trainer.models.layers.lm_head import inject_prime_lm_head
+from prime_rl.utils.logger import setup_logger
+from prime_rl.utils.utils import default_dtype
+
+setup_logger("info")
+
+ARCH_PRESETS = {
+    "glm4_moe": {
+        "config_class": Glm4MoeConfig,
+        "config_kwargs": dict(
+            vocab_size=151552,
+            hidden_size=1024,
+            intermediate_size=2048,
+            num_hidden_layers=24,
+            num_attention_heads=16,
+            num_key_value_heads=4,
+            hidden_act="silu",
+            max_position_embeddings=131072,
+            rms_norm_eps=1e-5,
+            rope_theta=1000000,
+            attention_bias=True,
+            partial_rotary_factor=0.5,
+            moe_intermediate_size=256,
+            n_routed_experts=8,
+            num_experts_per_tok=4,
+            n_shared_experts=1,
+            first_k_dense_replace=1,
+            norm_topk_prob=True,
+            use_qk_norm=False,
+            use_grouped_mm=False,
+            pad_token_id=151329,
+            eos_token_id=[151329, 151336, 151338],
+        ),
+        "hf_model_class": HFGlm4MoeForCausalLM,
+        "prime_model_class": PrimeRLGlm4MoeForCausalLM,
+        "tokenizer_source": "THUDM/GLM-4-9B-0414",
+    },
+}
+
+
+def create(arch: str, output_dir: Path) -> None:
+    preset = ARCH_PRESETS[arch]
+    config = preset["config_class"](**preset["config_kwargs"])
+
+    print(f"Creating mini {arch} model...")
+    print(
+        f"  hidden_size={config.hidden_size}, layers={config.num_hidden_layers}, "
+        f"experts={config.n_routed_experts}, moe_intermediate_size={config.moe_intermediate_size}"
+    )
+
+    with torch.device("cpu"):
+        model = preset["hf_model_class"](config)
+
+    param_count = sum(p.numel() for p in model.parameters())
+    print(f"  Parameters: {param_count / 1e6:.1f}M")
+
+    print(f"  Copying tokenizer from {preset['tokenizer_source']}...")
+    tokenizer = AutoTokenizer.from_pretrained(preset["tokenizer_source"], trust_remote_code=True)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    model.save_pretrained(output_dir)
+    tokenizer.save_pretrained(output_dir)
+    print(f"  Saved to {output_dir}")
+
+
+def verify(arch: str, model_dir: Path) -> None:
+    preset = ARCH_PRESETS[arch]
+    print(f"Verifying HF <-> PrimeRL roundtrip for {model_dir}...")
+
+    config = AutoConfig.from_pretrained(str(model_dir))
+    config._attn_implementation = "sdpa"
+
+    with torch.device("cuda"), default_dtype(torch.float32):
+        hf_model = preset["hf_model_class"].from_pretrained(str(model_dir), config=config)
+        prime_model = preset["prime_model_class"]._from_config(config)
+
+    with torch.no_grad():
+        state_dict = hf_model.state_dict()
+        prime_model.convert_to_prime(state_dict)
+        prime_model.load_state_dict(state_dict)
+
+    inject_prime_lm_head(prime_model, chunk_size=None)
+
+    with torch.device("cuda"), default_dtype(torch.float32):
+        input_ids = torch.randint(0, config.vocab_size, (1, 64))
+        position_ids = torch.arange(1, 65).unsqueeze(0)
+
+    hf_output = hf_model(input_ids, position_ids)
+    prime_output = prime_model(input_ids, position_ids)
+
+    logits_diff = prime_output["logits"] - hf_output.logits
+    max_diff = logits_diff.abs().max().item()
+    print(f"  HF vs PrimeRL max logits diff: {max_diff:.6f}")
+    assert max_diff < 0.1, f"HF vs PrimeRL logits mismatch: max diff {max_diff}"
+
+    with torch.no_grad():
+        roundtrip_state_dict = prime_model.convert_to_hf(prime_model.state_dict())
+    with torch.device("cuda"), default_dtype(torch.float32):
+        hf_roundtrip = preset["hf_model_class"]._from_config(config)
+        hf_roundtrip.load_state_dict(roundtrip_state_dict)
+
+    hf_roundtrip_output = hf_roundtrip(input_ids, position_ids)
+    roundtrip_diff = hf_roundtrip_output.logits - hf_output.logits
+    max_roundtrip_diff = roundtrip_diff.abs().max().item()
+    print(f"  HF -> PrimeRL -> HF roundtrip max logits diff: {max_roundtrip_diff:.6f}")
+    assert max_roundtrip_diff < 0.1, f"Roundtrip logits mismatch: max diff {max_roundtrip_diff}"
+
+    print("  Verification passed.")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create and verify a mini MoE model")
+    parser.add_argument("--arch", choices=list(ARCH_PRESETS.keys()), required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--verify-only", action="store_true", help="Skip creation, only verify an existing model")
+    args = parser.parse_args()
+
+    if not args.verify_only:
+        create(args.arch, args.output_dir)
+
+    verify(args.arch, args.output_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a script and doc for testing MoE architectures (GLM-4, Kimi, etc.) at small scale on 1-2 GPUs.

- `scripts/mini_moe.py`: creates a ~0.5B MoE model with random weights, verifies HF <-> PrimeRL weight conversion roundtrip
- `docs/testing-moe-at-small-scale.md`: walkthrough for creating the mini model, running SFT warmup, and running RL on it

Useful for catching bugs in modeling code and state dict conversions before running at full scale.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds new docs and an offline utility script; it doesn’t change training/inference code paths, though the script depends on existing conversion routines and requires GPU execution to validate them.
> 
> **Overview**
> Adds `scripts/mini_moe.py` to generate a small (~0.5B) GLM-4 MoE checkpoint with random weights, copy a source tokenizer, and **verify HF ↔ PrimeRL weight conversions** by comparing logits and asserting a lossless HF→PrimeRL→HF roundtrip.
> 
> Adds `docs/testing-moe-at-small-scale.md` with a step-by-step workflow to create the mini model, run a short SFT warmup, then run a small RL job to validate end-to-end pipeline integration and catch conversion/modeling regressions before scaling up.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86dcda72c28056037239cb77f0c7e4e17498bb06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->