### PR TITLE
Fix model weight loading: crash fix and memory optimization

### DIFF
--- a/src/prime_rl/trainer/weights.py
+++ b/src/prime_rl/trainer/weights.py
@@ -41,8 +41,6 @@ def get_max_layer_num(state_dict: dict[str, Tensor]) -> int:
 def load_state_dict(save_dir: Path) -> dict[str, Tensor]:
     """Load a state dict from a local directory with safetensor files."""
     safetensors_paths = list(save_dir.glob("*.safetensors"))
-    if len(safetensors_paths) > 1:
-        safetensors_paths.sort(key=lambda x: int(x.stem.split("-")[1].split("of")[0]))
     state_dict = {}
     for safetensor_path in safetensors_paths:
         with safe_open(safetensor_path, framework="pt", device="cpu") as f:

--- a/src/prime_rl/trainer/weights.py
+++ b/src/prime_rl/trainer/weights.py
@@ -38,6 +38,15 @@ def get_max_layer_num(state_dict: dict[str, Tensor]) -> int:
     return max(int(i.split(".")[2]) for i in state_dict.keys() if "model.layers." in i) + 1
 
 
+def load_state_dict_keys(save_dir: Path) -> list[str]:
+    """Load only the key names from safetensor files without reading tensor data."""
+    keys: list[str] = []
+    for safetensor_path in save_dir.glob("*.safetensors"):
+        with safe_open(safetensor_path, framework="pt", device="cpu") as f:
+            keys.extend(f.keys())
+    return keys
+
+
 def load_state_dict(save_dir: Path) -> dict[str, Tensor]:
     """Load a state dict from a local directory with safetensor files."""
     safetensors_paths = list(save_dir.glob("*.safetensors"))


### PR DESCRIPTION
## Summary
- **Fix `IndexError` in `load_state_dict`**: The safetensor file sort assumed `model-NNNNN-of-NNNNN.safetensors` naming, crashing on files like `model.safetensors`. Removed the sort since it's unnecessary — all shards merge into a flat dict where key order doesn't matter.
- **Only load snapshot on master rank**: Previously all ranks loaded the full model weights into CPU memory just to check key names for format detection, then discarded them. Now only master loads the snapshot and broadcasts the resolved path to other ranks.

## Test plan
- [ ] Verify GLM model loads without `IndexError`
- [ ] Verify MoE models with format conversion still work (hf↔prime)
- [ ] Verify multi-rank training starts correctly with the broadcast path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches checkpoint loading/conversion paths used at startup; mistakes could lead to incorrect weight format detection or conversion races in multi-rank runs, though the change is localized and guarded by master-only writes plus barriers.
> 
> **Overview**
> Improves weight loading robustness by removing shard filename sorting in `load_state_dict`, avoiding crashes on unsharded or nonstandard `.safetensors` names.
> 
> Optimizes distributed model initialization by adding `load_state_dict_keys` and switching format-detection in `load_dcp_from_hf` to read only checkpoint key names on all ranks; only the master rank loads full tensors when an HF↔PrimeRL conversion is required, then other ranks wait on a barrier before DCP loading from the resolved path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c679b8c29cacb40ce58e287fbc0c054fa624d86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->