### PR TITLE
Fix checkpoint step ordering bug

### DIFF
--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -1,3 +1,4 @@
+import bisect
 import shutil
 import time
 import warnings
@@ -226,7 +227,7 @@ class CheckpointManager:
         )
 
         self.save_to_path(ckpt_path, model, optimizers, scheduler, progress, dataloader)
-        self.ckpt_steps.append(step)
+        bisect.insort(self.ckpt_steps, step)
 
     def maybe_clean(self) -> None:
         """Deletes past checkpoints based on keep_last and keep_interval policies. No-op if both are None."""
@@ -375,7 +376,7 @@ class WeightCheckpointManager:
             self.save_to_path(step_path, state_dict, lora_state_dict, model, tokenizer)
             # Write STABLE file to indicate checkpoint is complete (for eval to safely read)
             (step_path / "STABLE").touch()
-        self.ckpt_steps.append(step)
+        bisect.insort(self.ckpt_steps, step)
 
     def maybe_clean(self) -> None:
         """Deletes past checkpoints based on keep_last and keep_interval policies. No-op if both are None."""


### PR DESCRIPTION
## Summary
- Use `bisect.insort` to maintain sorted order when adding checkpoint steps
- Fixes crash when saving a checkpoint with step < existing steps

## Problem
When saving a new checkpoint, the step was appended to `ckpt_steps` list without maintaining sort order. This caused `AssertionError` in `maybe_clean()` when `ckpt_steps = [125, 5]` instead of `[5, 125]`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to checkpoint bookkeeping that only affects in-memory step ordering; minimal impact on checkpoint data format or I/O behavior.
> 
> **Overview**
> Fixes checkpoint cleanup crashes by keeping `ckpt_steps` sorted whenever a new checkpoint is saved.
> 
> Both `CheckpointManager.save()` and `WeightCheckpointManager.save()` now insert the new step via `bisect.insort` (and import `bisect`) instead of appending, ensuring `maybe_clean()`'s sorted-order assumption holds even if a lower step is saved after a higher one.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 538bbbf4b71cd6a1961800dabdabde35da42019b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->