### PR TITLE
Fix checkpoint cleanup crashing trainer on OSError

### DIFF
--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -33,6 +33,14 @@ from prime_rl.utils.tensor_hashing import get_module_signature, get_optimizer_si
 from prime_rl.utils.utils import get_all_ckpt_steps, get_ckpt_dir, get_step_path, get_weights_dir
 
 
+def _try_rmtree(path: Path, logger) -> None:
+    """Remove a directory tree, logging and skipping on failure."""
+    try:
+        shutil.rmtree(path)
+    except OSError as e:
+        logger.warning(f"Failed to remove {path}: {e}, skipping cleanup")
+
+
 class AppState(Stateful):
     """
     A wrapper for checkpointing the trainer with sharded weights and optimizer
@@ -257,7 +265,7 @@ class CheckpointManager:
                 ckpt_path = trainer_ckpt_path.parent
                 if ckpt_path.exists():
                     self.logger.debug(f"Removing past checkpoint for step {ckpt_step} ({ckpt_path})")
-                    shutil.rmtree(ckpt_path)
+                    _try_rmtree(ckpt_path, self.logger)
 
         # Update checkpoint steps
         self.ckpt_steps = [step for step in self.ckpt_steps if step in steps_to_keep]
@@ -405,7 +413,7 @@ class WeightCheckpointManager:
                 ckpt_path = self.get_step_path(ckpt_step)
                 if ckpt_path.exists():
                     self.logger.debug(f"Removing past checkpoint for step {ckpt_step} ({ckpt_path})")
-                    shutil.rmtree(ckpt_path)
+                    _try_rmtree(ckpt_path, self.logger)
 
         # Update checkpoint steps
         self.ckpt_steps = [step for step in self.ckpt_steps if step in steps_to_keep]

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -266,6 +266,7 @@ class CheckpointManager:
             for ckpt_step in ckpt_steps_to_delete:
                 trainer_ckpt_path = self.get_ckpt_path(ckpt_step)
                 ckpt_path = trainer_ckpt_path.parent
+                self.logger.debug(f"Removing past checkpoint for step {ckpt_step} ({ckpt_path})")
                 if not ckpt_path.exists() or _try_rmtree(ckpt_path, self.logger):
                     steps_deleted.add(ckpt_step)
 
@@ -414,6 +415,7 @@ class WeightCheckpointManager:
         if self.world.is_master:
             for ckpt_step in ckpt_steps_to_delete:
                 ckpt_path = self.get_step_path(ckpt_step)
+                self.logger.debug(f"Removing past checkpoint for step {ckpt_step} ({ckpt_path})")
                 if not ckpt_path.exists() or _try_rmtree(ckpt_path, self.logger):
                     steps_deleted.add(ckpt_step)
 

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -33,14 +33,12 @@ from prime_rl.utils.tensor_hashing import get_module_signature, get_optimizer_si
 from prime_rl.utils.utils import get_all_ckpt_steps, get_ckpt_dir, get_step_path, get_weights_dir
 
 
-def _try_rmtree(path: Path, logger) -> bool:
-    """Remove a directory tree, logging and skipping on failure. Returns True if removed."""
+def _try_rmtree(path: Path, logger) -> None:
+    """Remove a directory tree, logging and skipping on failure."""
     try:
         shutil.rmtree(path)
-        return True
     except OSError as e:
         logger.warning(f"Failed to remove {path}: {e}, skipping cleanup")
-        return False
 
 
 class AppState(Stateful):
@@ -261,17 +259,16 @@ class CheckpointManager:
 
         # Delete steps not in steps_to_keep (only master rank deletes to avoid race condition)
         ckpt_steps_to_delete = [step for step in self.ckpt_steps if step not in steps_to_keep]
-        steps_deleted = set()
         if self.world.is_master:
             for ckpt_step in ckpt_steps_to_delete:
                 trainer_ckpt_path = self.get_ckpt_path(ckpt_step)
                 ckpt_path = trainer_ckpt_path.parent
-                self.logger.debug(f"Removing past checkpoint for step {ckpt_step} ({ckpt_path})")
-                if not ckpt_path.exists() or _try_rmtree(ckpt_path, self.logger):
-                    steps_deleted.add(ckpt_step)
+                if ckpt_path.exists():
+                    self.logger.debug(f"Removing past checkpoint for step {ckpt_step} ({ckpt_path})")
+                    _try_rmtree(ckpt_path, self.logger)
 
-        # Update checkpoint steps, keeping steps that failed to delete for retry
-        self.ckpt_steps = [step for step in self.ckpt_steps if step in steps_to_keep or step not in steps_deleted]
+        # Update checkpoint steps
+        self.ckpt_steps = [step for step in self.ckpt_steps if step in steps_to_keep]
 
 
 class WeightCheckpointManager:
@@ -411,16 +408,15 @@ class WeightCheckpointManager:
 
         # Delete steps not in steps_to_keep (only master rank deletes to avoid race condition)
         ckpt_steps_to_delete = [step for step in self.ckpt_steps if step not in steps_to_keep]
-        steps_deleted = set()
         if self.world.is_master:
             for ckpt_step in ckpt_steps_to_delete:
                 ckpt_path = self.get_step_path(ckpt_step)
-                self.logger.debug(f"Removing past checkpoint for step {ckpt_step} ({ckpt_path})")
-                if not ckpt_path.exists() or _try_rmtree(ckpt_path, self.logger):
-                    steps_deleted.add(ckpt_step)
+                if ckpt_path.exists():
+                    self.logger.debug(f"Removing past checkpoint for step {ckpt_step} ({ckpt_path})")
+                    _try_rmtree(ckpt_path, self.logger)
 
-        # Update checkpoint steps, keeping steps that failed to delete for retry
-        self.ckpt_steps = [step for step in self.ckpt_steps if step in steps_to_keep or step not in steps_deleted]
+        # Update checkpoint steps
+        self.ckpt_steps = [step for step in self.ckpt_steps if step in steps_to_keep]
 
 
 def setup_ckpt_managers(


### PR DESCRIPTION
## Summary
- `shutil.rmtree` in `maybe_clean()` can fail with `OSError: Directory not empty` when external processes (e.g. checkpoint uploader pod) hold open file handles on checkpoint directories via NFS
- Instead of crashing the trainer, log a warning and skip 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to checkpoint cleanup behavior that only alters error handling (logs-and-skips instead of raising), with minimal impact on training correctness.
> 
> **Overview**
> Prevents checkpoint cleanup from crashing the trainer by wrapping `shutil.rmtree` in a new helper (`_try_rmtree`) that catches `OSError`, logs a warning, and skips deletion.
> 
> Both trainer and weight checkpoint `maybe_clean()` paths now use this guarded deletion, making cleanup resilient to transient filesystem/NFS issues (e.g., directories temporarily not empty).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 270177931c23ff08a1720a716e35cc4ff2ac93c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->