### PR TITLE
fix off policy tracker bug

### DIFF
--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -191,7 +191,7 @@ class Scheduler:
             for task, off_policy_steps, client_config in tasks_to_update:
                 if task in self.inflight_group_rollouts:
                     self.inflight_group_rollouts[task] = InflightRolloutInfo(
-                        off_policy_steps=off_policy_steps + 1, client_config=client_config
+                        off_policy_steps=off_policy_steps, client_config=client_config
                     )
 
             if len(tasks_to_remove) > 0:


### PR DESCRIPTION
We were incrementing off_policy_steps twice instead of once per policy update

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small logic fix in the scheduler’s off-policy counter; behavior change is limited to rollout cancellation thresholds.
> 
> **Overview**
> Fixes off-policy rollout tracking during policy updates by preventing `off_policy_steps` from being incremented twice when updating `inflight_group_rollouts`, which avoids premature cancellation of in-flight rollout tasks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63b859c3d78b72b460b632742f8644a0daf49cc2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->