### PR TITLE
add flash attn for afmoe

### DIFF
--- a/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
+++ b/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
@@ -279,8 +279,7 @@ def _get_afmoe_attention(config: AfmoeConfig, layer_idx: int) -> nn.Module:
     if attn_impl not in AFMOE_ATTN_IMPL2CLASS:
         supported = list(AFMOE_ATTN_IMPL2CLASS.keys())
         raise ValueError(
-            f"AFMoE attention does not support '{config._attn_implementation}'. "
-            f"Supported implementations: {supported}."
+            f"AFMoE attention does not support '{config._attn_implementation}'. Supported implementations: {supported}."
         )
 
     return AFMOE_ATTN_IMPL2CLASS[attn_impl](attn_config)


### PR DESCRIPTION
notes:
- adds separate afmoe flash attn class due to gated attn and SWA
- still will not work with context parallelism yet, but i do see that [ring flash attn varlen func](https://github.com/zhuzilin/ring-flash-attention/blob/main/ring_flash_attn/ring_flash_attn_varlen.py) has a window size argument, so this can be added in the future

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core attention execution and masking path, and introduces optional dependencies on multiple FlashAttention APIs; incorrect `cu_seqlens`/shape assumptions could cause runtime errors or silent accuracy regressions.
> 
> **Overview**
> AFMoE now supports FlashAttention backends by introducing `AfmoeFlashAttention` (varlen) and wiring new `_attn_implementation` options (`flash_attention_2`, `flash_attention_3`, `fa4`) into the attention factory.
> 
> The model forward path is updated to compute `cu_seqlens`/`max_seqlen` and bypass causal/sliding-window mask construction when FlashAttention is selected, while propagating these new arguments through `AfmoeDecoderLayer` and attention `forward` signatures. `_supports_flash_attn` is enabled for the model.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e76ad75105fd539e3e160e3ff477910141f1ffc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->