### PR TITLE
set default api key var to vllm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,3 +55,4 @@ Documenting changes which affect configuration usage patterns (added/moved/remov
 - **`OrchestratorConfig`**: Removed `workers_per_env`, `max_env_worker_restarts`, and `mask_env_responses` (2026-02-06)
 - **`EvalSaveDiskConfig`**, **`EvalSaveConfig`**, **`RetryConfig`**, **`OnlineEvalConfig`**: Removed (2026-02-06)
 - **`TemperatureScheduleConfig`**: Renamed to `TemperatureSchedulerConfig` (2026-02-06)
+- **`client.api_key_var`**: Changed default from "OPENAI_API_KEY" to "VLLM_API_KEY" (2026-02-12)

--- a/src/prime_rl/utils/config.py
+++ b/src/prime_rl/utils/config.py
@@ -76,9 +76,9 @@ class ClientConfig(BaseConfig):
     api_key_var: Annotated[
         str,
         Field(
-            description="Name of environment variable containing the API key to use for the OpenAI API. Will parse using `os.getenv(client_config.api_key_var)`. Can be set to an arbitrary string if the inference server is not protected by an API key. If multiple URLs are specified, the same API key will be used for all servers.",
+            description="Name of environment variable containing the API key to use for the inference API. Will parse using `os.getenv(client_config.api_key_var)`. Can be set to an arbitrary string if the inference server is not protected by an API key. If multiple URLs are specified, the same API key will be used for all servers.",
         ),
-    ] = "OPENAI_API_KEY"
+    ] = "VLLM_API_KEY"
 
     headers: Annotated[
         dict[str, str],


### PR DESCRIPTION
use `VLLM_API_KEY` because prime-rl is not interfacing with the OAI API ever (we used to with evals, but now deprecated). this makes it so that one does not have to configure the orchestrator clients when the vllm server is protected with an api key via `VLLM_API_KEY` (the default)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small config-default/documentation change; main risk is a breaking behavior change for users implicitly relying on the old `OPENAI_API_KEY` default.
> 
> **Overview**
> Updates `ClientConfig.api_key_var` to default to `VLLM_API_KEY` rather than `OPENAI_API_KEY`, and tweaks the field description to reference the inference API instead of OpenAI.
> 
> Adds a changelog entry noting the new default so deployments relying on `OPENAI_API_KEY` can adjust config/environment accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7be399c5c6d69e1bc95a21096d03c40797aeb3a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->