### PR TITLE
log env name in online evals

### DIFF
--- a/src/prime_rl/orchestrator/eval_utils.py
+++ b/src/prime_rl/orchestrator/eval_utils.py
@@ -106,7 +106,7 @@ async def evaluate_env(
         logger.warning("Skipping computing pass@k rates because the task rewards appear to be non-binary")
 
     # Log statistics to console
-    message = f"Evaluated {env.env_id} in {eval_time:.2f}s (Avg@{rollouts_per_example}={results_df.reward.mean():.4f}"
+    message = f"Evaluated {env_name} in {eval_time:.2f}s (Avg@{rollouts_per_example}={results_df.reward.mean():.4f}"
     if could_be_binary:
         assert pass_at_k is not None
         for pass_rate, pass_rate_score in pd.Series(pass_at_k.mean()).items():


### PR DESCRIPTION
prev we logged env_id which could be the same (e.g. when evaluating multiple tau2-bench variants)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-string logging change with no impact on evaluation behavior, metrics computation, or persistence.
> 
> **Overview**
> Updates online evaluation logging to use the passed `env_name` instead of `env.env_id` when reporting summary stats, avoiding ambiguous output when multiple environments share the same underlying `env_id`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69627de99546bbd79e897b537380719a908cecc6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->