### PR TITLE
Add MLflow integration for experiment logging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,8 @@ dependencies = [
     "tenacity>=8.2.0",
     "pyzmq>=27.1.0",
     "aiolimiter>=1.2.1",
+    "mlflow>=2.15.0",
+    "boto3>=1.35.0",
 ]
 
 [project.scripts]

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -8,6 +8,7 @@ from prime_rl.utils.config import (
     ClientConfig,
     HeartbeatConfig,
     LogConfig,
+    MLflowWithExtrasConfig,
     PrimeMonitorConfig,
     WandbWithExtrasConfig,
 )
@@ -640,6 +641,9 @@ class OrchestratorConfig(BaseSettings):
     # The prime monitor configuration
     prime_monitor: PrimeMonitorConfig | None = None
 
+    # The MLflow configuration
+    mlflow: MLflowWithExtrasConfig | None = None
+
     # The checkpoint configuration
     ckpt: CheckpointConfig | None = None
 
@@ -791,6 +795,8 @@ class OrchestratorConfig(BaseSettings):
                 self.wandb.log_extras = None
             if self.prime_monitor:
                 self.prime_monitor.log_extras = None
+            if self.mlflow:
+                self.mlflow.log_extras = None
 
         return self
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -134,10 +134,13 @@ async def orchestrate(config: OrchestratorConfig):
         )
 
     # Setup monitor
-    logger.info(f"Initializing monitor (wandb={config.wandb}, prime_monitor={config.prime_monitor})")
+    logger.info(
+        f"Initializing monitor (wandb={config.wandb}, prime_monitor={config.prime_monitor}, mlflow={config.mlflow})"
+    )
     monitor = setup_monitor(
         wandb_config=config.wandb,
         prime_config=config.prime_monitor,
+        mlflow_config=config.mlflow,
         output_dir=config.output_dir,
         tokenizer=tokenizer,
         run_config=config,

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -26,7 +26,7 @@ from prime_rl.trainer.rl.config import FakeDataLoaderConfig
 from prime_rl.trainer.rl.config import FileSystemWeightBroadcastConfig as TrainerFileSystemWeightBroadcastConfig
 from prime_rl.trainer.rl.config import NCCLWeightBroadcastConfig as TrainerNCCLWeightBroadcastConfig
 from prime_rl.trainer.rl.config import RLTrainerConfig as TrainerConfig
-from prime_rl.utils.config import WandbConfig, WandbWithExtrasConfig
+from prime_rl.utils.config import MLflowConfig, MLflowWithExtrasConfig, WandbConfig, WandbWithExtrasConfig
 from prime_rl.utils.logger import setup_logger
 from prime_rl.utils.pydantic_config import BaseSettings, get_temp_toml_file, parse_argv
 from prime_rl.utils.utils import (
@@ -39,6 +39,7 @@ from prime_rl.utils.validation import (
     validate_shared_ckpt_config,
     validate_shared_max_async_level,
     validate_shared_max_steps,
+    validate_shared_mlflow_config,
     validate_shared_model_name,
     validate_shared_output_dir,
     validate_shared_wandb_config,
@@ -67,6 +68,16 @@ class SharedWandbConfig(BaseSettings):
     name: Annotated[str | None, Field(description="The W&B run name to use.")] = None
 
     offline: Annotated[bool | None, Field(description="Whether to run W&B in offline mode.")] = False
+
+
+class SharedMLflowConfig(BaseSettings):
+    """Configures shared MLflow configs."""
+
+    tracking_uri: Annotated[str | None, Field(description="MLflow tracking URI.")] = "mlruns"
+
+    experiment_name: Annotated[str | None, Field(description="The MLflow experiment name.")] = "prime-rl"
+
+    run_name: Annotated[str | None, Field(description="The MLflow run name.")] = None
 
 
 class SharedCheckpointConfig(BaseSettings):
@@ -176,6 +187,13 @@ class RLConfig(BaseSettings):
         SharedWandbConfig | None,
         Field(
             description="Shared W&B configs. If None, will fallback to the W&B configs specified on submodule configs."
+        ),
+    ] = None
+
+    mlflow: Annotated[
+        SharedMLflowConfig | None,
+        Field(
+            description="Shared MLflow configs. If None, will fallback to the MLflow configs specified on submodule configs."
         ),
     ] = None
 
@@ -317,6 +335,30 @@ class RLConfig(BaseSettings):
                 self.orchestrator.wandb.offline = self.wandb.offline
 
         validate_shared_wandb_config(self.trainer, self.orchestrator)
+
+        return self
+
+    @model_validator(mode="after")
+    def auto_setup_mlflow(self):
+        if self.mlflow is not None:
+            if not self.trainer.mlflow:
+                self.trainer.mlflow = MLflowConfig()
+            if not self.orchestrator.mlflow:
+                self.orchestrator.mlflow = MLflowWithExtrasConfig()
+
+            if self.mlflow.tracking_uri:
+                self.trainer.mlflow.tracking_uri = self.mlflow.tracking_uri
+                self.orchestrator.mlflow.tracking_uri = self.mlflow.tracking_uri
+
+            if self.mlflow.experiment_name:
+                self.trainer.mlflow.experiment_name = self.mlflow.experiment_name
+                self.orchestrator.mlflow.experiment_name = self.mlflow.experiment_name
+
+            if self.mlflow.run_name:
+                self.trainer.mlflow.run_name = f"{self.mlflow.run_name}-trainer"
+                self.orchestrator.mlflow.run_name = f"{self.mlflow.run_name}-orchestrator"
+
+        validate_shared_mlflow_config(self.trainer, self.orchestrator)
 
         return self
 

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -14,7 +14,7 @@ from prime_rl.trainer.config import (
     TokenizerConfig,
 )
 from prime_rl.transport.config import FileSystemTransportConfig, TransportConfigType
-from prime_rl.utils.config import HeartbeatConfig, LogConfig, MetricsServerConfig, WandbConfig
+from prime_rl.utils.config import HeartbeatConfig, LogConfig, MetricsServerConfig, MLflowConfig, WandbConfig
 from prime_rl.utils.pydantic_config import BaseConfig, BaseSettings
 
 
@@ -173,6 +173,9 @@ class RLTrainerConfig(BaseSettings):
 
     # The wandb configuration
     wandb: WandbConfig | None = None
+
+    # The MLflow configuration
+    mlflow: MLflowConfig | None = None
 
     output_dir: Annotated[
         Path,

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -79,8 +79,8 @@ def train(config: RLTrainerConfig):
         logger.warning(f"Running in benchmark mode (max_steps={config.max_steps})")
 
     # Setup the monitor
-    logger.info(f"Initializing monitor ({config.wandb})")
-    monitor = setup_monitor(config.wandb, output_dir=config.output_dir, run_config=config)
+    logger.info(f"Initializing monitor (wandb={config.wandb}, mlflow={config.mlflow})")
+    monitor = setup_monitor(config.wandb, output_dir=config.output_dir, run_config=config, mlflow_config=config.mlflow)
 
     # Setup heartbeat (only on rank 0)
     heart = None

--- a/src/prime_rl/trainer/sft/config.py
+++ b/src/prime_rl/trainer/sft/config.py
@@ -13,7 +13,7 @@ from prime_rl.trainer.config import (
     SchedulerConfigType,
     TokenizerConfig,
 )
-from prime_rl.utils.config import HeartbeatConfig, LogConfig, WandbConfig
+from prime_rl.utils.config import HeartbeatConfig, LogConfig, MLflowConfig, WandbConfig
 from prime_rl.utils.pydantic_config import BaseConfig, BaseSettings
 
 
@@ -130,6 +130,9 @@ class SFTTrainerConfig(BaseSettings):
 
     # The wandb configuration
     wandb: WandbConfig | None = None
+
+    # The MLflow configuration
+    mlflow: MLflowConfig | None = None
 
     output_dir: Annotated[
         Path,

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -67,8 +67,8 @@ def train(config: SFTTrainerConfig):
         logger.warning(f"Running in benchmark mode (max_steps={config.max_steps})")
 
     # Setup the monitor
-    logger.info(f"Initializing monitor ({config.wandb})")
-    monitor = setup_monitor(config.wandb, output_dir=config.output_dir, run_config=config)
+    logger.info(f"Initializing monitor (wandb={config.wandb}, mlflow={config.mlflow})")
+    monitor = setup_monitor(config.wandb, output_dir=config.output_dir, run_config=config, mlflow_config=config.mlflow)
 
     # Setup heartbeat (only on rank 0)
     heart = None

--- a/src/prime_rl/utils/config.py
+++ b/src/prime_rl/utils/config.py
@@ -210,6 +210,52 @@ class WandbWithExtrasConfig(WandbConfig):
     ] = LogExtrasConfig()
 
 
+class MLflowConfig(BaseConfig):
+    """Configures logging to MLflow."""
+
+    tracking_uri: Annotated[
+        str,
+        Field(description="MLflow tracking URI. Can be a local path or a remote server URL."),
+    ] = "mlruns"
+
+    experiment_name: Annotated[
+        str,
+        Field(description="The MLflow experiment name to log to."),
+    ] = "prime-rl"
+
+    run_name: Annotated[
+        str | None,
+        Field(description="The MLflow run name. If None, MLflow will auto-generate one."),
+    ] = None
+
+    artifact_location: Annotated[
+        str | None,
+        Field(
+            description="Artifact location for the experiment. Use 'mlflow-artifacts:/' to proxy "
+            "artifact uploads through the tracking server (no S3 credentials needed on the client).",
+        ),
+    ] = None
+
+    log_artifacts: Annotated[
+        bool,
+        Field(
+            description="Whether to upload artifacts (samples, summaries) to MLflow. "
+            "Set to false for metrics-only logging when no artifact storage is configured.",
+        ),
+    ] = True
+
+
+class MLflowWithExtrasConfig(MLflowConfig):
+    """Configures logging to MLflow with extras."""
+
+    log_extras: Annotated[
+        LogExtrasConfig | None,
+        Field(
+            description="Configuration for logging extras. If None, no extras are logged.",
+        ),
+    ] = LogExtrasConfig()
+
+
 class PrimeMonitorConfig(BaseConfig):
     """Configures logging to Prime Intellect API."""
 

--- a/src/prime_rl/utils/monitor/__init__.py
+++ b/src/prime_rl/utils/monitor/__init__.py
@@ -2,8 +2,9 @@ from pathlib import Path
 
 from transformers.tokenization_utils import PreTrainedTokenizer
 
-from prime_rl.utils.config import PrimeMonitorConfig, WandbWithExtrasConfig
+from prime_rl.utils.config import MLflowConfig, MLflowWithExtrasConfig, PrimeMonitorConfig, WandbWithExtrasConfig
 from prime_rl.utils.monitor.base import Monitor, NoOpMonitor
+from prime_rl.utils.monitor.mlflow import MLflowMonitor
 from prime_rl.utils.monitor.multi import MultiMonitor
 from prime_rl.utils.monitor.prime import PrimeMonitor
 from prime_rl.utils.monitor.wandb import WandbMonitor
@@ -13,6 +14,7 @@ __all__ = [
     "Monitor",
     "WandbMonitor",
     "PrimeMonitor",
+    "MLflowMonitor",
     "MultiMonitor",
     "NoOpMonitor",
     "setup_monitor",
@@ -37,6 +39,7 @@ def setup_monitor(
     run_config: BaseSettings | None = None,
     *,
     prime_config: PrimeMonitorConfig | None = None,
+    mlflow_config: MLflowConfig | MLflowWithExtrasConfig | None = None,
     # Backward compatibility: support old 'config' keyword argument
     config: WandbWithExtrasConfig | None = None,
 ) -> Monitor:
@@ -66,6 +69,16 @@ def setup_monitor(
         monitors.append(
             PrimeMonitor(
                 config=prime_config,
+                output_dir=output_dir,
+                tokenizer=tokenizer,
+                run_config=run_config,
+            )
+        )
+
+    if mlflow_config is not None:
+        monitors.append(
+            MLflowMonitor(
+                config=mlflow_config,
                 output_dir=output_dir,
                 tokenizer=tokenizer,
                 run_config=run_config,

--- a/src/prime_rl/utils/monitor/mlflow.py
+++ b/src/prime_rl/utils/monitor/mlflow.py
@@ -1,0 +1,211 @@
+import json
+import os
+import statistics
+import time
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import verifiers as vf
+from transformers.tokenization_utils import PreTrainedTokenizer
+
+from prime_rl.utils.config import MLflowConfig, MLflowWithExtrasConfig
+from prime_rl.utils.logger import get_logger
+from prime_rl.utils.monitor.base import Monitor
+from prime_rl.utils.pydantic_config import BaseSettings
+
+
+class MLflowMonitor(Monitor):
+    """Logs to MLflow."""
+
+    def __init__(
+        self,
+        config: MLflowConfig | MLflowWithExtrasConfig | None,
+        output_dir: Path | None = None,
+        tokenizer: PreTrainedTokenizer | None = None,
+        run_config: BaseSettings | None = None,
+    ):
+        self.config = config
+        self.logger = get_logger()
+        self.history: list[dict[str, Any]] = []
+        self.output_dir = output_dir
+
+        rank = int(os.environ.get("RANK", os.environ.get("DP_RANK", "0")))
+        self.enabled = self.config is not None
+        self.is_master = rank == 0
+        if not self.enabled or not self.is_master:
+            if not self.is_master:
+                self.logger.warning(f"Skipping {self.__class__.__name__} initialization from non-master rank ({rank})")
+            return
+
+        assert config is not None
+        self.logger.info(f"Initializing {self.__class__.__name__} ({config})")
+
+        import mlflow
+
+        self._mlflow = mlflow
+
+        mlflow.set_tracking_uri(config.tracking_uri)
+
+        client = mlflow.MlflowClient()
+        experiment = client.get_experiment_by_name(config.experiment_name)
+        if experiment is None and config.artifact_location:
+            experiment_id = client.create_experiment(config.experiment_name, artifact_location=config.artifact_location)
+            mlflow.set_experiment(experiment_id=experiment_id)
+        else:
+            mlflow.set_experiment(config.experiment_name)
+
+        self.run = mlflow.start_run(run_name=config.run_name)
+
+        if run_config is not None:
+            params = run_config.model_dump()
+            # MLflow has a 500-param limit per batch; flatten and truncate values
+            flat_params = _flatten_dict(params)
+            # MLflow param values are limited to 500 chars
+            flat_params = {k: str(v)[:500] for k, v in flat_params.items()}
+            mlflow.log_params(flat_params)
+
+        if isinstance(config, MLflowWithExtrasConfig) and config.log_extras:
+            if config.log_extras.samples:
+                self.tokenizer = tokenizer
+                self.samples: list[dict[str, Any]] = []
+
+    def log(self, metrics: dict[str, Any], step: int | None = None) -> None:
+        self.history.append(metrics)
+        if not self.is_master or not self.enabled:
+            return
+
+        if step is None and "step" in metrics:
+            step = int(metrics["step"])
+
+        numeric_metrics = {}
+        for k, v in metrics.items():
+            if k == "step":
+                continue
+            if isinstance(v, (int, float)) and not isinstance(v, bool):
+                numeric_metrics[k] = v
+
+        if numeric_metrics:
+            self._mlflow.log_metrics(numeric_metrics, step=step)
+
+    def log_samples(self, rollouts: list[vf.RolloutOutput], step: int) -> None:
+        if not self.is_master or not self.enabled:
+            return
+        if (
+            not self.config
+            or not isinstance(self.config, MLflowWithExtrasConfig)
+            or not self.config.log_extras
+            or not self.config.log_extras.samples
+            or step % self.config.log_extras.interval != 0
+        ):
+            return
+
+        assert self.tokenizer is not None, "Tokenizer is required for sample logging"
+
+        self.logger.info(f"Logging samples to MLflow at step {step}")
+        start_time = time.perf_counter()
+
+        rows = []
+        for rollout in rollouts:
+            trajectory = rollout["trajectory"]
+            if not trajectory:
+                continue
+            last_step = trajectory[-1]
+            tokens = last_step["tokens"]
+            full_ids = tokens["prompt_ids"] + tokens["completion_ids"]
+            messages_text = self.tokenizer.decode(full_ids)
+            row = {
+                "step": step,
+                "task": rollout.get("task"),
+                "example_id": rollout["example_id"],
+                "messages": messages_text,
+                "reward": rollout["reward"],
+            }
+            rows.append(row)
+            self.samples.append(row)
+
+        if rows and self.config.log_artifacts:
+            df = pd.DataFrame(rows)
+            self._mlflow.log_table(df, artifact_file=f"samples/step_{step}.json")
+
+        self.logger.debug(f"Logged samples at step {step} to MLflow in {time.perf_counter() - start_time:.2f}s")
+
+    def log_final_samples(self) -> None:
+        if not self.is_master or not self.enabled:
+            return
+        if (
+            not self.config
+            or not isinstance(self.config, MLflowWithExtrasConfig)
+            or not self.config.log_extras
+            or not self.config.log_extras.samples
+        ):
+            return
+
+        if not self.config.log_artifacts:
+            return
+
+        self.logger.info("Logging final samples to MLflow")
+        if self.samples:
+            df = pd.DataFrame(self.samples)
+            self._mlflow.log_table(df, artifact_file="final_samples.json")
+
+    def log_distributions(self, distributions: dict[str, list[float]], step: int) -> None:
+        if not self.is_master or not self.enabled:
+            return
+        if (
+            not self.config
+            or not isinstance(self.config, MLflowWithExtrasConfig)
+            or not self.config.log_extras
+            or not self.config.log_extras.distributions
+            or step % self.config.log_extras.interval != 0
+        ):
+            return
+
+        dist_metrics = {}
+        for name, values in distributions.items():
+            if not values:
+                continue
+            dist_metrics[f"distributions/{name}/mean"] = statistics.mean(values)
+            dist_metrics[f"distributions/{name}/std"] = statistics.stdev(values) if len(values) > 1 else 0.0
+            dist_metrics[f"distributions/{name}/min"] = min(values)
+            dist_metrics[f"distributions/{name}/max"] = max(values)
+            dist_metrics[f"distributions/{name}/median"] = statistics.median(values)
+
+        if dist_metrics:
+            self._mlflow.log_metrics(dist_metrics, step=step)
+
+    def save_final_summary(self, filename: str = "final_summary.json") -> None:
+        if not self.is_master or not self.enabled:
+            return
+        if not self.config.log_artifacts:
+            return
+
+        self.logger.info("Saving final summary via MLflow")
+        assert self.output_dir is not None, "Output directory is required for saving final summary"
+
+        run_id = self.run.info.run_id
+        dir_path = self.output_dir / f"mlflow-{run_id}"
+        dir_path.mkdir(parents=True, exist_ok=True)
+
+        summary = self.history[-1] if self.history else {}
+        summary_path = dir_path / filename
+        with open(summary_path, "w") as f:
+            json.dump(summary, f)
+
+        self._mlflow.log_artifact(str(summary_path))
+
+    def close(self) -> None:
+        if not self.is_master or not self.enabled:
+            return
+        self._mlflow.end_run()
+
+
+def _flatten_dict(d: dict, parent_key: str = "", sep: str = ".") -> dict:
+    items: list[tuple[str, Any]] = []
+    for k, v in d.items():
+        new_key = f"{parent_key}{sep}{k}" if parent_key else k
+        if isinstance(v, dict):
+            items.extend(_flatten_dict(v, new_key, sep=sep).items())
+        else:
+            items.append((new_key, v))
+    return dict(items)

--- a/src/prime_rl/utils/validation.py
+++ b/src/prime_rl/utils/validation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from typing import Optional
 
 from prime_rl.inference.config import InferenceConfig
@@ -115,4 +116,20 @@ def validate_shared_weight_broadcast(
     elif trainer.weight_broadcast.type != orchestrator.weight_broadcast.type:
         raise ValueError(
             f"Trainer weight broadcast type ({trainer.weight_broadcast.type}) and orchestrator weight broadcast type ({orchestrator.weight_broadcast.type}) are not the same. Please specify the same weight broadcast type for both."
+        )
+
+
+def validate_shared_mlflow_config(
+    trainer: RLTrainerConfig,
+    orchestrator: OrchestratorConfig,
+) -> None:
+    if trainer.mlflow and not orchestrator.mlflow:
+        warnings.warn(
+            "Trainer MLflow config is specified, but orchestrator MLflow config is not. "
+            "Only trainer metrics will be logged to MLflow. Use [mlflow] to configure both at once."
+        )
+    if orchestrator.mlflow and not trainer.mlflow:
+        warnings.warn(
+            "Orchestrator MLflow config is specified, but trainer MLflow config is not. "
+            "Only orchestrator metrics will be logged to MLflow. Use [mlflow] to configure both at once."
         )

--- a/src/prime_rl/utils/validation.py
+++ b/src/prime_rl/utils/validation.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from typing import Optional
 
 from prime_rl.inference.config import InferenceConfig
@@ -124,12 +123,14 @@ def validate_shared_mlflow_config(
     orchestrator: OrchestratorConfig,
 ) -> None:
     if trainer.mlflow and not orchestrator.mlflow:
-        warnings.warn(
+        raise ValueError(
             "Trainer MLflow config is specified, but orchestrator MLflow config is not. "
-            "Only trainer metrics will be logged to MLflow. Use [mlflow] to configure both at once."
+            "This means only trainer metrics will be logged. Please specify [orchestrator.mlflow] to log orchestrator metrics as well, "
+            "or use [mlflow] to configure both at once."
         )
     if orchestrator.mlflow and not trainer.mlflow:
-        warnings.warn(
+        raise ValueError(
             "Orchestrator MLflow config is specified, but trainer MLflow config is not. "
-            "Only orchestrator metrics will be logged to MLflow. Use [mlflow] to configure both at once."
+            "This means only orchestrator metrics will be logged. Please specify [trainer.mlflow] to log trainer metrics as well, "
+            "or use [mlflow] to configure both at once."
         )

--- a/tests/unit/utils/test_mlflow_monitor.py
+++ b/tests/unit/utils/test_mlflow_monitor.py
@@ -1,0 +1,130 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from prime_rl.utils.config import MLflowConfig, MLflowWithExtrasConfig
+from prime_rl.utils.monitor.mlflow import MLflowMonitor
+
+
+@pytest.fixture(autouse=True)
+def _reset_env(monkeypatch):
+    monkeypatch.setenv("RANK", "0")
+    monkeypatch.setenv("DP_RANK", "0")
+
+
+@patch("mlflow.set_tracking_uri")
+@patch("mlflow.set_experiment")
+@patch("mlflow.start_run")
+@patch("mlflow.log_params")
+@patch("mlflow.log_metrics")
+def test_basic_log(mock_log_metrics, mock_log_params, mock_start_run, mock_set_experiment, mock_set_tracking_uri):
+    mock_start_run.return_value = MagicMock(info=MagicMock(run_id="test-run-id"))
+
+    config = MLflowConfig(tracking_uri="mlruns", experiment_name="test")
+    monitor = MLflowMonitor(config=config)
+
+    monitor.log({"loss": 0.5, "step": 1}, step=1)
+
+    mock_set_tracking_uri.assert_called_once_with("mlruns")
+    mock_set_experiment.assert_called_once_with("test")
+    mock_start_run.assert_called_once()
+    mock_log_metrics.assert_called_once_with({"loss": 0.5}, step=1)
+
+
+@patch("mlflow.set_tracking_uri")
+@patch("mlflow.set_experiment")
+@patch("mlflow.start_run")
+@patch("mlflow.log_params")
+@patch("mlflow.log_metrics")
+def test_log_skips_step_key(
+    mock_log_metrics, mock_log_params, mock_start_run, mock_set_experiment, mock_set_tracking_uri
+):
+    mock_start_run.return_value = MagicMock(info=MagicMock(run_id="test-run-id"))
+
+    config = MLflowConfig()
+    monitor = MLflowMonitor(config=config)
+
+    monitor.log({"loss": 0.5, "accuracy": 0.9, "step": 10}, step=10)
+
+    mock_log_metrics.assert_called_once_with({"loss": 0.5, "accuracy": 0.9}, step=10)
+
+
+@patch("mlflow.set_tracking_uri")
+@patch("mlflow.set_experiment")
+@patch("mlflow.start_run")
+@patch("mlflow.log_params")
+@patch("mlflow.log_metrics")
+def test_log_skips_non_numeric(
+    mock_log_metrics, mock_log_params, mock_start_run, mock_set_experiment, mock_set_tracking_uri
+):
+    mock_start_run.return_value = MagicMock(info=MagicMock(run_id="test-run-id"))
+
+    config = MLflowConfig()
+    monitor = MLflowMonitor(config=config)
+
+    monitor.log({"loss": 0.5, "name": "test", "flag": True, "step": 1}, step=1)
+
+    mock_log_metrics.assert_called_once_with({"loss": 0.5}, step=1)
+
+
+def test_non_master_noop(monkeypatch):
+    monkeypatch.setenv("RANK", "1")
+
+    config = MLflowConfig()
+    monitor = MLflowMonitor(config=config)
+
+    # Should not raise, just no-op
+    monitor.log({"loss": 0.5}, step=1)
+    assert monitor.history == [{"loss": 0.5}]
+    assert not monitor.is_master
+
+
+def test_disabled_config():
+    monitor = MLflowMonitor(config=None)
+
+    monitor.log({"loss": 0.5}, step=1)
+    assert monitor.history == [{"loss": 0.5}]
+    assert not monitor.enabled
+
+
+@patch("mlflow.set_tracking_uri")
+@patch("mlflow.set_experiment")
+@patch("mlflow.start_run")
+@patch("mlflow.log_params")
+@patch("mlflow.log_metrics")
+def test_log_distributions(
+    mock_log_metrics, mock_log_params, mock_start_run, mock_set_experiment, mock_set_tracking_uri
+):
+    mock_start_run.return_value = MagicMock(info=MagicMock(run_id="test-run-id"))
+
+    config = MLflowWithExtrasConfig()
+    monitor = MLflowMonitor(config=config)
+
+    distributions = {"rewards": [1.0, 2.0, 3.0], "advantages": [0.1, 0.2, 0.3]}
+    monitor.log_distributions(distributions, step=10)
+
+    call_args = mock_log_metrics.call_args
+    logged_metrics = call_args[0][0]
+    assert "distributions/rewards/mean" in logged_metrics
+    assert "distributions/rewards/std" in logged_metrics
+    assert "distributions/rewards/min" in logged_metrics
+    assert "distributions/rewards/max" in logged_metrics
+    assert "distributions/rewards/median" in logged_metrics
+    assert logged_metrics["distributions/rewards/mean"] == 2.0
+    assert logged_metrics["distributions/rewards/min"] == 1.0
+    assert logged_metrics["distributions/rewards/max"] == 3.0
+
+
+@patch("mlflow.set_tracking_uri")
+@patch("mlflow.set_experiment")
+@patch("mlflow.start_run")
+@patch("mlflow.log_params")
+@patch("mlflow.end_run")
+def test_close(mock_end_run, mock_log_params, mock_start_run, mock_set_experiment, mock_set_tracking_uri):
+    mock_start_run.return_value = MagicMock(info=MagicMock(run_id="test-run-id"))
+
+    config = MLflowConfig()
+    monitor = MLflowMonitor(config=config)
+    monitor.close()
+
+    mock_end_run.assert_called_once()


### PR DESCRIPTION
# Add MLflow integration for experiment logging

Hello the PrimeIntellect Team, thank you for your super valuable work. I am a `wandb` fan, but we only use MLFlow at work. So I had to come up with a solution, it works well for me and I thought it could benefit the community. 

## Summary

- Adds MLflow as an alternative experiment tracking backend alongside the existing W&B and PrimeMonitor integrations. Follows the same `Monitor` interface pattern — supports metric logging, sample tables, distribution summaries, and final artifacts.
- Integrates into all three entry points: RL trainer, SFT trainer, and orchestrator. A shared `[mlflow]` config section in the top-level RL config propagates `tracking_uri`, `experiment_name`, and `run_name` to both trainer and orchestrator (with `-trainer`/`-orchestrator` suffixes on the run name).
- Includes a `log_artifacts` toggle so users can run metrics-only logging when no artifact storage (S3/GCS) is configured, and an `artifact_location` option to proxy uploads through the tracking server via `mlflow-artifacts:/`.

## Changes

**New files:**
- `src/prime_rl/utils/monitor/mlflow.py` : `MLflowMonitor` implementing the full `Monitor` interface (log, log_samples, log_distributions, log_final_samples, save_final_summary, close)
- `tests/unit/utils/test_mlflow_monitor.py` : Unit tests covering basic logging, step/non-numeric filtering, non-master no-op, disabled config, distribution logging, and cleanup

**Config plumbing:**
- `src/prime_rl/utils/config.py` : `MLflowConfig` and `MLflowWithExtrasConfig` (mirrors the Wandb config pattern)
- `src/prime_rl/trainer/rl/config.py`, `src/prime_rl/trainer/sft/config.py` : Added `mlflow: MLflowConfig | None` field
- `src/prime_rl/orchestrator/config.py` : Added `mlflow: MLflowWithExtrasConfig | None` field
- `src/prime_rl/rl.py` : `SharedMLflowConfig`, `auto_setup_mlflow` model validator, config propagation

**Wiring:**
- `src/prime_rl/trainer/rl/train.py`, `src/prime_rl/trainer/sft/train.py`, `src/prime_rl/orchestrator/orchestrator.py` : Pass `mlflow_config` to `setup_monitor()`
- `src/prime_rl/utils/monitor/__init__.py` : `setup_monitor()` now accepts `mlflow_config` and creates an `MLflowMonitor` when provided

**Validation:**
- `src/prime_rl/utils/validation.py` : `validate_shared_mlflow_config()` warns when only one of trainer/orchestrator has MLflow configured

**Dependencies (unstaged):**
- `pyproject.toml` — `mlflow>=2.15.0`, `boto3>=1.35.0`

## Usage

```toml
# In TOML config, shared section sets both trainer and orchestrator
[mlflow]
tracking_uri = "http://mlflow-server:5000"
experiment_name = "my-experiment"
run_name = "run-1"
```

Or per-component:

```toml
[trainer.mlflow]
tracking_uri = "mlruns"
experiment_name = "trainer-only"

[orchestrator.mlflow]
tracking_uri = "mlruns"
experiment_name = "orchestrator-only"
log_artifacts = false
```

## Test checklist

- [x] Run unit tests: `uv run pytest tests/unit/utils/test_mlflow_monitor.py`
- [x] Verify MLflow monitor works end-to-end with a local `mlruns` directory on a debug RL run
- [x] Verify MLflow monitor works with a remote tracking server
- [x] Confirm no regressions when `mlflow` config is omitted (existing W&B-only workflows)

## Notes for reviewers

- No documentation has been added yet — a config reference for the new `[mlflow]` section may be worth adding to `docs/`, let me know if it is needed, I'll add it. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new third-party logging backend (`mlflow`/`boto3`) and touches shared config/validation paths used by all training entry points, so misconfiguration could break runs or alter logging behavior.
> 
> **Overview**
> Adds **MLflow** as a first-class monitoring option alongside W&B/PrimeMonitor, including a new `MLflowMonitor` that logs numeric metrics, optional sample tables, distribution summaries, and final artifacts/summaries.
> 
> Plumbs new `mlflow` config blocks through orchestrator, RL trainer, and SFT trainer, adds a shared top-level `[mlflow]` section in `rl.py` to propagate `tracking_uri`/`experiment_name`/`run_name` (with `-trainer`/`-orchestrator` suffixing), and validates that trainer/orchestrator MLflow settings are configured consistently.
> 
> Updates dependencies to include `mlflow` and `boto3`, extends `setup_monitor` to construct an `MLflowMonitor`, and adds unit tests covering core MLflow logging behavior and rank/no-op handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7df8893b8d655cf542c92e5e483344479e2fc20. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->