### PR TITLE
Add --dump-config flag to rl command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,3 +56,4 @@ Documenting changes which affect configuration usage patterns (added/moved/remov
 - **`EvalSaveDiskConfig`**, **`EvalSaveConfig`**, **`RetryConfig`**, **`OnlineEvalConfig`**: Removed (2026-02-06)
 - **`TemperatureScheduleConfig`**: Renamed to `TemperatureSchedulerConfig` (2026-02-06)
 - **`optim.mu`**: Added Muon momentum (`mu`) config field (default: 0.95). Previously hardcoded to Muon class default. Also fixed `optim.betas1`/`optim.betas2` not being passed through to the Muon optimizer (2026-02-09)
+- **`dump_config`**: Added `--dump-config <path>` flag to the `rl` command. When set, writes the resolved subconfigs (trainer, orchestrator, inference, teacher_inference) to the given directory and exits without starting any processes (2026-02-12)

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -28,7 +28,7 @@ from prime_rl.trainer.rl.config import NCCLWeightBroadcastConfig as TrainerNCCLW
 from prime_rl.trainer.rl.config import RLTrainerConfig as TrainerConfig
 from prime_rl.utils.config import WandbConfig, WandbWithExtrasConfig
 from prime_rl.utils.logger import setup_logger
-from prime_rl.utils.pydantic_config import BaseSettings, get_temp_toml_file, parse_argv
+from prime_rl.utils.pydantic_config import BaseSettings, parse_argv
 from prime_rl.utils.utils import (
     get_broadcast_dir,
     get_free_port,
@@ -223,6 +223,13 @@ class RLConfig(BaseSettings):
 
     weight_broadcast: Annotated[
         SharedWeightBroadcastConfig | None, Field(description="The weight broadcast config.")
+    ] = None
+
+    dump_config: Annotated[
+        Path | None,
+        Field(
+            description="If set, dump resolved subconfigs (trainer, orchestrator, inference) to this directory and exit without starting any processes."
+        ),
     ] = None
 
     @model_validator(mode="after")
@@ -604,6 +611,25 @@ def check_gpus_available(gpu_ids: list[int]) -> None:
         raise RuntimeError(msg)
 
 
+def write_subconfigs(config: RLConfig, output_dir: Path) -> None:
+    """Write resolved subconfigs to disk as TOML files."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    with open(output_dir / "trainer.toml", "wb") as f:
+        tomli_w.dump(config.trainer.model_dump(exclude_none=True, mode="json"), f)
+
+    with open(output_dir / "orchestrator.toml", "wb") as f:
+        tomli_w.dump(config.orchestrator.model_dump(exclude_none=True, mode="json"), f)
+
+    if config.inference is not None:
+        with open(output_dir / "inference.toml", "wb") as f:
+            tomli_w.dump(config.inference.model_dump(exclude_none=True, mode="json"), f)
+
+    if config.teacher_inference is not None:
+        with open(output_dir / "teacher_inference.toml", "wb") as f:
+            tomli_w.dump(config.teacher_inference.model_dump(exclude_none=True, mode="json"), f)
+
+
 def rl(config: RLConfig):
     # Setup logger
     logger = setup_logger(
@@ -611,6 +637,20 @@ def rl(config: RLConfig):
         log_file=config.output_dir / "logs" / "rl.log" if config.log.file else None,
         json_logging=config.log.json_logging,
     )
+
+    # If dump_config is set, write resolved subconfigs and exit early
+    if config.dump_config is not None:
+        write_subconfigs(config, config.dump_config)
+        logger.info(f"Dumping resolved subconfigs to {config.dump_config}")
+        logger.info(f"  Wrote trainer config to {config.dump_config / 'trainer.toml'}")
+        logger.info(f"  Wrote orchestrator config to {config.dump_config / 'orchestrator.toml'}")
+        if config.inference is not None:
+            logger.info(f"  Wrote inference config to {config.dump_config / 'inference.toml'}")
+        if config.teacher_inference is not None:
+            logger.info(f"  Wrote teacher inference config to {config.dump_config / 'teacher_inference.toml'}")
+        logger.success(f"Config dump complete. Files written to {config.dump_config}")
+        return
+
     start_command = sys.argv
     logger.info("Starting RL run")
     logger.debug(f"RL start command: {' '.join(start_command)}")
@@ -667,6 +707,10 @@ def rl(config: RLConfig):
         logger.info(f"Cleaning rollout dir ({rollout_dir})")
         shutil.rmtree(rollout_dir, ignore_errors=True)
 
+    # Write all resolved subconfigs to disk
+    config_dir = Path(".pydantic_config") / uuid.uuid4().hex
+    write_subconfigs(config, config_dir)
+
     # Start processes
     processes: list[Popen] = []
     monitor_threads: list[Thread] = []
@@ -676,11 +720,7 @@ def rl(config: RLConfig):
     try:
         # Optionally, start inference process
         if config.inference:
-            inference_file = get_temp_toml_file()
-            with open(inference_file, "wb") as f:
-                tomli_w.dump(config.inference.model_dump(exclude_none=True, mode="json"), f)
-
-            inference_cmd = ["uv", "run", "inference", "@", inference_file.as_posix()]
+            inference_cmd = ["uv", "run", "inference", "@", (config_dir / "inference.toml").as_posix()]
             logger.info(f"Starting inference process on GPU(s) {' '.join(map(str, config.inference_gpu_ids))}")
             logger.debug(f"Inference start command: {' '.join(inference_cmd)}")
             # If we don't log stdout, the server hangs
@@ -716,11 +756,8 @@ def rl(config: RLConfig):
                     "Either set teacher_gpu_ids to start a teacher inference server, "
                     "or omit teacher_inference and configure orchestrator.teacher_model to use an existing server."
                 )
-            teacher_inference_file = get_temp_toml_file()
-            with open(teacher_inference_file, "wb") as f:
-                tomli_w.dump(config.teacher_inference.model_dump(exclude_none=True, mode="json"), f)
 
-            teacher_inference_cmd = ["uv", "run", "inference", "@", teacher_inference_file.as_posix()]
+            teacher_inference_cmd = ["uv", "run", "inference", "@", (config_dir / "teacher_inference.toml").as_posix()]
             logger.info(f"Starting teacher inference process on GPU(s) {' '.join(map(str, config.teacher_gpu_ids))}")
             logger.debug(f"Teacher inference start command: {' '.join(teacher_inference_cmd)}")
             with open(log_dir / "teacher_inference.stdout", "w") as log_file:
@@ -749,16 +786,12 @@ def rl(config: RLConfig):
             )
 
         # Start orchestrator process
-        orchestrator_file = get_temp_toml_file()
-        with open(orchestrator_file, "wb") as f:
-            tomli_w.dump(config.orchestrator.model_dump(exclude_none=True, mode="json"), f)
-
         orchestrator_cmd = [
             "uv",
             "run",
             "orchestrator",
             "@",
-            orchestrator_file.as_posix(),
+            (config_dir / "orchestrator.toml").as_posix(),
         ]
         logger.info("Starting orchestrator process")
         logger.debug(f"Orchestrator start command: {' '.join(orchestrator_cmd)}")
@@ -788,10 +821,6 @@ def rl(config: RLConfig):
         monitor_threads.append(monitor_thread)
 
         # Start training process
-        trainer_file = get_temp_toml_file()
-        with open(trainer_file, "wb") as f:
-            tomli_w.dump(config.trainer.model_dump(exclude_none=True, mode="json"), f)
-
         trainer_cmd = [
             "uv",
             "run",
@@ -810,7 +839,7 @@ def rl(config: RLConfig):
             "-m",
             "prime_rl.trainer.rl.train",
             "@",
-            trainer_file.as_posix(),
+            (config_dir / "trainer.toml").as_posix(),
         ]
         logger.info(f"Starting trainer process on GPU(s) {' '.join(map(str, config.trainer_gpu_ids))}")
         logger.debug(f"Training start command: {' '.join(trainer_cmd)}")

--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -640,6 +640,9 @@ def rl(config: RLConfig):
 
     # If dump_config is set, write resolved subconfigs and exit early
     if config.dump_config is not None:
+        logger.warning(
+            "--dump-config is set. No RL training will be started. Only writing resolved subconfigs to disk."
+        )
         write_subconfigs(config, config.dump_config)
         logger.info(f"Dumping resolved subconfigs to {config.dump_config}")
         logger.info(f"  Wrote trainer config to {config.dump_config / 'trainer.toml'}")
@@ -649,6 +652,7 @@ def rl(config: RLConfig):
         if config.teacher_inference is not None:
             logger.info(f"  Wrote teacher inference config to {config.dump_config / 'teacher_inference.toml'}")
         logger.success(f"Config dump complete. Files written to {config.dump_config}")
+        logger.warning("To start an RL run, remove --dump-config from your command.")
         return
 
     start_command = sys.argv


### PR DESCRIPTION
## Summary

- Adds `--dump-config <path>` to the `rl` command. When set, writes the resolved subconfigs (trainer, orchestrator, inference, teacher_inference) to the given directory and exits without starting any processes.
- Refactors config serialization into a shared `write_subconfigs` function used by both dump and normal run paths.

## Usage

```bash
uv run rl @ config.toml --dump-config /tmp/my-configs
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds an opt-in CLI flag and refactors how config TOML files are written/passed to subprocesses; main risk is accidental behavior change in process startup if config serialization paths are incorrect.
> 
> **Overview**
> Adds `--dump-config <dir>` to the `rl` CLI to write the resolved `trainer`/`orchestrator`/`inference`/`teacher_inference` configs as TOML files and exit without launching any processes.
> 
> Refactors config serialization into a shared `write_subconfigs` helper and changes the normal run path to persist subconfigs under `.pydantic_config/<uuid>/` and pass those files to the spawned `inference`, `orchestrator`, and `trainer` processes instead of generating per-process temp TOML files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e370155611fb892f218b70b58a3bdc1415411cd6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->