### PR TITLE
fix uv warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ dev = [
 
 
 [tool.uv]
+preview = true
 no-build-isolation-package = ["flash-attn"]
 prerelease = "allow"
 # Override torch's pinned cuDNN to fix Conv3d performance regression (torch 2.9 + cuDNN 9.8-9.14)


### PR DESCRIPTION
remove uv warnin when doing uv run


after
<img width="1209" height="202" alt="image" src="https://github.com/user-attachments/assets/c61202c8-b17a-424f-aad1-79faf0828c3b" />


before
<img width="1353" height="216" alt="screenshot-2026-02-12_14-15-02" src="https://github.com/user-attachments/assets/e5c0c700-ef2b-4d0e-aaec-b2df65c28305" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single configuration flag change in `pyproject.toml`; no runtime code paths or data handling are modified.
> 
> **Overview**
> Enables `uv` *preview mode* by setting `tool.uv.preview = true` in `pyproject.toml`, which removes the warning shown during `uv run` while keeping the existing `uv` configuration (sources/overrides) unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6df351bc63fb45b65e07710682ea16556dd88cc3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->