### PR TITLE
Add MiniMax M2.1 MoE model support

### DIFF
--- a/scripts/mini_moe.py
+++ b/scripts/mini_moe.py
@@ -15,12 +15,14 @@ import argparse
 from pathlib import Path
 
 import torch
-from transformers import AutoConfig, AutoTokenizer
+from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 from transformers import Glm4MoeForCausalLM as HFGlm4MoeForCausalLM
 
 from prime_rl.trainer.models.glm4_moe import Glm4MoeConfig
 from prime_rl.trainer.models.glm4_moe import Glm4MoeForCausalLM as PrimeRLGlm4MoeForCausalLM
 from prime_rl.trainer.models.layers.lm_head import inject_prime_lm_head
+from prime_rl.trainer.models.minimax_m2 import MiniMaxM2Config
+from prime_rl.trainer.models.minimax_m2 import MiniMaxM2ForCausalLM as PrimeRLMiniMaxM2ForCausalLM
 from prime_rl.utils.logger import setup_logger
 from prime_rl.utils.utils import default_dtype
 
@@ -57,7 +59,59 @@ ARCH_PRESETS = {
         "prime_model_class": PrimeRLGlm4MoeForCausalLM,
         "tokenizer_source": "THUDM/GLM-4-9B-0414",
     },
+    "minimax_m2": {
+        "config_class": MiniMaxM2Config,
+        "config_kwargs": dict(
+            vocab_size=200064,
+            hidden_size=512,
+            intermediate_size=256,
+            num_hidden_layers=12,
+            num_attention_heads=8,
+            num_key_value_heads=4,
+            head_dim=64,
+            hidden_act="silu",
+            max_position_embeddings=4096,
+            rms_norm_eps=1e-6,
+            rope_theta=5000000,
+            rotary_dim=32,
+            num_local_experts=8,
+            num_experts_per_tok=4,
+            scoring_func="sigmoid",
+            use_routing_bias=True,
+            use_qk_norm=True,
+            qk_norm_type="per_layer",
+            use_grouped_mm=False,
+            auto_map={"AutoModelForCausalLM": "MiniMaxAI/MiniMax-M2.1--modeling_minimax_m2.MiniMaxM2ForCausalLM"},
+        ),
+        "hf_model_class": None,  # uses AutoModelForCausalLM with trust_remote_code
+        "prime_model_class": PrimeRLMiniMaxM2ForCausalLM,
+        "tokenizer_source": "MiniMaxAI/MiniMax-M2.1",
+    },
 }
+
+
+def _create_hf_model(preset, config):
+    """Create an HF model from a preset and config."""
+    hf_cls = preset["hf_model_class"]
+    if hf_cls is not None:
+        return hf_cls(config)
+    return AutoModelForCausalLM.from_config(config, trust_remote_code=True)
+
+
+def _load_hf_model(preset, model_dir, config):
+    """Load an HF model from a preset and directory."""
+    hf_cls = preset["hf_model_class"]
+    if hf_cls is not None:
+        return hf_cls.from_pretrained(str(model_dir), config=config)
+    return AutoModelForCausalLM.from_pretrained(str(model_dir), config=config, trust_remote_code=True)
+
+
+def _create_hf_model_from_config(preset, config):
+    """Create an empty HF model from config (for roundtrip verification)."""
+    hf_cls = preset["hf_model_class"]
+    if hf_cls is not None:
+        return hf_cls._from_config(config)
+    return AutoModelForCausalLM.from_config(config, trust_remote_code=True)
 
 
 def create(arch: str, output_dir: Path) -> None:
@@ -65,13 +119,10 @@ def create(arch: str, output_dir: Path) -> None:
     config = preset["config_class"](**preset["config_kwargs"])
 
     print(f"Creating mini {arch} model...")
-    print(
-        f"  hidden_size={config.hidden_size}, layers={config.num_hidden_layers}, "
-        f"experts={config.n_routed_experts}, moe_intermediate_size={config.moe_intermediate_size}"
-    )
+    print(f"  hidden_size={config.hidden_size}, layers={config.num_hidden_layers}")
 
     with torch.device("cpu"):
-        model = preset["hf_model_class"](config)
+        model = _create_hf_model(preset, config)
 
     param_count = sum(p.numel() for p in model.parameters())
     print(f"  Parameters: {param_count / 1e6:.1f}M")
@@ -89,11 +140,12 @@ def verify(arch: str, model_dir: Path) -> None:
     preset = ARCH_PRESETS[arch]
     print(f"Verifying HF <-> PrimeRL roundtrip for {model_dir}...")
 
-    config = AutoConfig.from_pretrained(str(model_dir))
+    trust_remote_code = preset["hf_model_class"] is None
+    config = AutoConfig.from_pretrained(str(model_dir), trust_remote_code=trust_remote_code)
     config._attn_implementation = "sdpa"
 
     with torch.device("cuda"), default_dtype(torch.float32):
-        hf_model = preset["hf_model_class"].from_pretrained(str(model_dir), config=config)
+        hf_model = _load_hf_model(preset, model_dir, config)
         prime_model = preset["prime_model_class"]._from_config(config)
 
     with torch.no_grad():
@@ -118,7 +170,7 @@ def verify(arch: str, model_dir: Path) -> None:
     with torch.no_grad():
         roundtrip_state_dict = prime_model.convert_to_hf(prime_model.state_dict())
     with torch.device("cuda"), default_dtype(torch.float32):
-        hf_roundtrip = preset["hf_model_class"]._from_config(config)
+        hf_roundtrip = _create_hf_model_from_config(preset, config)
         hf_roundtrip.load_state_dict(roundtrip_state_dict)
 
     hf_roundtrip_output = hf_roundtrip(input_ids, position_ids)

--- a/src/prime_rl/trainer/models/__init__.py
+++ b/src/prime_rl/trainer/models/__init__.py
@@ -13,17 +13,20 @@ from prime_rl.trainer.models.base import PreTrainedModelPrimeRL
 from prime_rl.trainer.models.glm4_moe import Glm4MoeConfig, Glm4MoeForCausalLM
 from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput, cast_float_and_contiguous
 from prime_rl.trainer.models.llama import LlamaForCausalLM
+from prime_rl.trainer.models.minimax_m2 import MiniMaxM2Config, MiniMaxM2ForCausalLM
 from prime_rl.trainer.models.qwen3_moe import Qwen3MoeConfig, Qwen3MoeForCausalLM
 
 # Make custom config discoverable by AutoConfig
 AutoConfig.register("afmoe", AfmoeConfig, exist_ok=True)
 AutoConfig.register("glm4_moe", Glm4MoeConfig, exist_ok=True)
+AutoConfig.register("minimax_m2", MiniMaxM2Config, exist_ok=True)
 AutoConfig.register("qwen3_moe", Qwen3MoeConfig, exist_ok=True)
 
 _CUSTOM_CAUSAL_LM_MAPPING = _LazyAutoMapping(CONFIG_MAPPING_NAMES, OrderedDict())
 _CUSTOM_CAUSAL_LM_MAPPING.register(LlamaConfig, LlamaForCausalLM, exist_ok=True)
 _CUSTOM_CAUSAL_LM_MAPPING.register(AfmoeConfig, AfmoeForCausalLM, exist_ok=True)
 _CUSTOM_CAUSAL_LM_MAPPING.register(Glm4MoeConfig, Glm4MoeForCausalLM, exist_ok=True)
+_CUSTOM_CAUSAL_LM_MAPPING.register(MiniMaxM2Config, MiniMaxM2ForCausalLM, exist_ok=True)
 _CUSTOM_CAUSAL_LM_MAPPING.register(Qwen3MoeConfig, Qwen3MoeForCausalLM, exist_ok=True)
 
 

--- a/src/prime_rl/trainer/models/minimax_m2/__init__.py
+++ b/src/prime_rl/trainer/models/minimax_m2/__init__.py
@@ -1,0 +1,13 @@
+from prime_rl.trainer.models.minimax_m2.configuration_minimax_m2 import MiniMaxM2Config
+from prime_rl.trainer.models.minimax_m2.modeling_minimax_m2 import (
+    MiniMaxM2ForCausalLM,
+    MiniMaxM2Model,
+    MiniMaxM2PreTrainedModel,
+)
+
+__all__ = [
+    "MiniMaxM2Config",
+    "MiniMaxM2ForCausalLM",
+    "MiniMaxM2Model",
+    "MiniMaxM2PreTrainedModel",
+]

--- a/src/prime_rl/trainer/models/minimax_m2/configuration_minimax_m2.py
+++ b/src/prime_rl/trainer/models/minimax_m2/configuration_minimax_m2.py
@@ -1,0 +1,151 @@
+from transformers.configuration_utils import PretrainedConfig
+from transformers.modeling_rope_utils import rope_config_validation
+
+
+class MiniMaxM2Config(PretrainedConfig):
+    r"""
+    Configuration class for MiniMax M2.1 MoE model.
+
+    Args:
+        vocab_size (`int`, *optional*, defaults to 200064):
+            Vocabulary size of the model.
+        hidden_size (`int`, *optional*, defaults to 6144):
+            Dimension of the hidden representations.
+        intermediate_size (`int`, *optional*, defaults to 24576):
+            Dimension of the MoE expert FFN.
+        num_hidden_layers (`int`, *optional*, defaults to 92):
+            Number of hidden layers in the Transformer.
+        num_attention_heads (`int`, *optional*, defaults to 48):
+            Number of attention heads.
+        num_key_value_heads (`int`, *optional*, defaults to 8):
+            Number of key-value heads for GQA.
+        head_dim (`int`, *optional*, defaults to 128):
+            Dimension of each attention head.
+        hidden_act (`str`, *optional*, defaults to `"silu"`):
+            Activation function for the MLP.
+        max_position_embeddings (`int`, *optional*, defaults to 131072):
+            Maximum sequence length.
+        rms_norm_eps (`float`, *optional*, defaults to 1e-6):
+            Epsilon for RMS normalization.
+        rope_theta (`float`, *optional*, defaults to 5000000):
+            Base period for RoPE.
+        rotary_dim (`int`, *optional*, defaults to 64):
+            Dimension of the rotary embeddings. Converted to `partial_rotary_factor` for HF rope init.
+        num_local_experts (`int`, *optional*, defaults to 256):
+            Number of routed experts per layer.
+        num_experts_per_tok (`int`, *optional*, defaults to 8):
+            Number of experts selected per token.
+        scoring_func (`str`, *optional*, defaults to `"sigmoid"`):
+            Scoring function for the router.
+        use_routing_bias (`bool`, *optional*, defaults to `True`):
+            Whether to use e_score_correction_bias for load balancing.
+        use_qk_norm (`bool`, *optional*, defaults to `True`):
+            Whether to use QK normalization.
+        qk_norm_type (`str`, *optional*, defaults to `"per_layer"`):
+            Type of QK normalization. "per_layer" means each head has its own scale.
+        attention_bias (`bool`, *optional*, defaults to `False`):
+            Whether to use bias in attention projections.
+        use_grouped_mm (`bool`, *optional*, defaults to `True`):
+            Whether to use grouped matmul for experts.
+    """
+
+    model_type = "minimax_m2"
+    keys_to_ignore_at_inference = ["past_key_values"]
+
+    base_model_tp_plan = {
+        "layers.*.self_attn.q_proj": "colwise",
+        "layers.*.self_attn.k_proj": "colwise",
+        "layers.*.self_attn.v_proj": "colwise",
+        "layers.*.self_attn.o_proj": "rowwise",
+    }
+    base_model_pp_plan = {
+        "embed_tokens": (["input_ids"], ["inputs_embeds"]),
+        "layers": (["hidden_states", "attention_mask"], ["hidden_states"]),
+        "norm": (["hidden_states"], ["hidden_states"]),
+    }
+
+    def __init__(
+        self,
+        vocab_size=200064,
+        hidden_size=6144,
+        intermediate_size=24576,
+        num_hidden_layers=92,
+        num_attention_heads=48,
+        num_key_value_heads=8,
+        head_dim=128,
+        hidden_act="silu",
+        max_position_embeddings=131072,
+        initializer_range=0.02,
+        rms_norm_eps=1e-6,
+        use_cache=True,
+        tie_word_embeddings=False,
+        rope_theta=5000000,
+        rope_scaling=None,
+        rotary_dim=64,
+        pad_token_id=None,
+        bos_token_id=1,
+        eos_token_id=2,
+        num_local_experts=256,
+        num_experts_per_tok=8,
+        scoring_func="sigmoid",
+        use_routing_bias=True,
+        use_qk_norm=True,
+        qk_norm_type="per_layer",
+        attention_bias=False,
+        sliding_window=None,
+        attention_dropout=0.0,
+        output_router_logits=False,
+        router_aux_loss_coef=0.001,
+        router_jitter_noise=0.0,
+        use_grouped_mm=True,
+        **kwargs,
+    ):
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_key_value_heads = num_key_value_heads
+        self.head_dim = head_dim
+        self.hidden_act = hidden_act
+        self.max_position_embeddings = max_position_embeddings
+        self.initializer_range = initializer_range
+        self.rms_norm_eps = rms_norm_eps
+        self.use_cache = use_cache
+        self.rope_theta = rope_theta
+        self.rope_scaling = rope_scaling
+        self.attention_bias = attention_bias
+        self.sliding_window = sliding_window
+        self.attention_dropout = attention_dropout
+
+        # Compute partial_rotary_factor from rotary_dim for HF rope init compatibility
+        self.rotary_dim = rotary_dim
+        self.partial_rotary_factor = rotary_dim / head_dim
+
+        if self.rope_scaling is not None and "type" in self.rope_scaling:
+            self.rope_scaling["rope_type"] = self.rope_scaling["type"]
+        rope_config_validation(self)
+
+        # MoE arguments
+        self.num_local_experts = num_local_experts
+        self.num_experts_per_tok = num_experts_per_tok
+        self.scoring_func = scoring_func
+        self.use_routing_bias = use_routing_bias
+        self.output_router_logits = output_router_logits
+        self.router_aux_loss_coef = router_aux_loss_coef
+        self.router_jitter_noise = router_jitter_noise
+
+        # Attention
+        self.use_qk_norm = use_qk_norm
+        self.qk_norm_type = qk_norm_type
+
+        # Training
+        self.use_grouped_mm = use_grouped_mm
+
+        super().__init__(
+            pad_token_id=pad_token_id,
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            tie_word_embeddings=tie_word_embeddings,
+            **kwargs,
+        )

--- a/src/prime_rl/trainer/models/minimax_m2/converting_minimax_m2.py
+++ b/src/prime_rl/trainer/models/minimax_m2/converting_minimax_m2.py
@@ -1,0 +1,101 @@
+import torch
+from torch import Tensor
+
+
+def get_max_layer_num(state_dict: dict[str, Tensor]) -> int:
+    """Get the maximum number of layers in the model."""
+    return max(int(i.split(".")[2]) for i in state_dict.keys() if "model.layers." in i) + 1
+
+
+def convert_hf_layer_to_tt(state_dict: dict[str, Tensor], layer_idx: int):
+    """Convert a layer from HF to PrimeRL format in-place.
+
+    HF MiniMax M2.1 uses `block_sparse_moe` as the MoE block name, with
+    expert weights stored as `experts.{j}.w1.weight` (nn.Linear format).
+    """
+    i = layer_idx
+    prefix = f"model.layers.{i}"
+
+    # Check if this layer has MoE experts
+    num_experts = len([k for k in state_dict.keys() if f"{prefix}.block_sparse_moe.experts" in k]) // 3
+    if num_experts == 0:
+        return
+
+    # Router: block_sparse_moe.gate.weight -> mlp.router.gate.weight
+    state_dict[f"{prefix}.mlp.router.gate.weight"] = state_dict[f"{prefix}.block_sparse_moe.gate.weight"]
+    del state_dict[f"{prefix}.block_sparse_moe.gate.weight"]
+
+    # e_score_correction_bias: direct tensor under block_sparse_moe -> mlp.expert_bias
+    bias_key = f"{prefix}.block_sparse_moe.e_score_correction_bias"
+    if bias_key in state_dict:
+        state_dict[f"{prefix}.mlp.expert_bias"] = state_dict[bias_key]
+        del state_dict[bias_key]
+
+    # Expert weights: stack individual experts into grouped tensors
+    # HF uses w1.weight, w2.weight, w3.weight (nn.Linear with .weight suffix)
+    dim, moe_dim = state_dict[f"{prefix}.block_sparse_moe.experts.0.w2.weight"].shape
+    dtype = state_dict[f"{prefix}.block_sparse_moe.experts.0.w2.weight"].dtype
+
+    w1 = torch.empty((num_experts, moe_dim, dim), dtype=dtype)
+    w2 = torch.empty((num_experts, dim, moe_dim), dtype=dtype)
+    w3 = torch.empty((num_experts, moe_dim, dim), dtype=dtype)
+
+    for j in range(num_experts):
+        w1[j].copy_(state_dict[f"{prefix}.block_sparse_moe.experts.{j}.w1.weight"])
+        w2[j].copy_(state_dict[f"{prefix}.block_sparse_moe.experts.{j}.w2.weight"])
+        w3[j].copy_(state_dict[f"{prefix}.block_sparse_moe.experts.{j}.w3.weight"])
+
+        del state_dict[f"{prefix}.block_sparse_moe.experts.{j}.w1.weight"]
+        del state_dict[f"{prefix}.block_sparse_moe.experts.{j}.w2.weight"]
+        del state_dict[f"{prefix}.block_sparse_moe.experts.{j}.w3.weight"]
+
+    state_dict[f"{prefix}.mlp.experts.w1"] = w1
+    state_dict[f"{prefix}.mlp.experts.w2"] = w2
+    state_dict[f"{prefix}.mlp.experts.w3"] = w3
+
+
+def convert_tt_layer_to_hf(state_dict: dict[str, Tensor], layer_idx: int):
+    """Convert a layer from PrimeRL to HF format in-place."""
+    i = layer_idx
+    prefix = f"model.layers.{i}"
+
+    if f"{prefix}.mlp.router.gate.weight" not in state_dict:
+        return
+
+    # Router: mlp.router.gate.weight -> block_sparse_moe.gate.weight
+    state_dict[f"{prefix}.block_sparse_moe.gate.weight"] = state_dict[f"{prefix}.mlp.router.gate.weight"]
+    del state_dict[f"{prefix}.mlp.router.gate.weight"]
+
+    # expert_bias -> block_sparse_moe.e_score_correction_bias
+    if f"{prefix}.mlp.expert_bias" in state_dict:
+        state_dict[f"{prefix}.block_sparse_moe.e_score_correction_bias"] = state_dict[f"{prefix}.mlp.expert_bias"]
+        del state_dict[f"{prefix}.mlp.expert_bias"]
+
+    # tokens_per_expert is a runtime buffer, remove if present
+    if f"{prefix}.mlp.tokens_per_expert" in state_dict:
+        del state_dict[f"{prefix}.mlp.tokens_per_expert"]
+
+    # Expert weights: unstack grouped tensors into individual experts
+    num_experts, moe_dim, dim = state_dict[f"{prefix}.mlp.experts.w1"].shape
+    for j in range(num_experts):
+        state_dict[f"{prefix}.block_sparse_moe.experts.{j}.w1.weight"] = state_dict[f"{prefix}.mlp.experts.w1"][j]
+        state_dict[f"{prefix}.block_sparse_moe.experts.{j}.w2.weight"] = state_dict[f"{prefix}.mlp.experts.w2"][j]
+        state_dict[f"{prefix}.block_sparse_moe.experts.{j}.w3.weight"] = state_dict[f"{prefix}.mlp.experts.w3"][j]
+
+    del state_dict[f"{prefix}.mlp.experts.w1"]
+    del state_dict[f"{prefix}.mlp.experts.w2"]
+    del state_dict[f"{prefix}.mlp.experts.w3"]
+
+
+def convert_hf_to_tt_moe(state_dict: dict[str, Tensor]):
+    """Convert MoE weights from HF to PrimeRL format in-place."""
+    num_layers = get_max_layer_num(state_dict)
+    for i in range(num_layers):
+        convert_hf_layer_to_tt(state_dict, i)
+
+
+def convert_tt_to_hf_moe(state_dict: dict[str, Tensor]):
+    """Convert MoE weights from PrimeRL to HF format in-place."""
+    num_layers = get_max_layer_num(state_dict)
+    for i in range(num_layers):
+        convert_tt_layer_to_hf(state_dict, i)

--- a/src/prime_rl/trainer/models/minimax_m2/modeling_minimax_m2.py
+++ b/src/prime_rl/trainer/models/minimax_m2/modeling_minimax_m2.py
@@ -1,0 +1,276 @@
+from typing import Optional, Union
+
+import torch
+from torch import Tensor, nn
+from transformers.cache_utils import Cache
+from transformers.generation import GenerationMixin
+from transformers.modeling_layers import GradientCheckpointingLayer
+from transformers.modeling_outputs import BaseModelOutputWithPast
+from transformers.processing_utils import Unpack
+from transformers.utils import TransformersKwargs, auto_docstring, can_return_tuple, logging
+
+from prime_rl.trainer.models.base import PreTrainedModelPrimeRL
+from prime_rl.trainer.models.layers.attn import ATTN_IMPL2CLASS, AttentionConfig
+from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput
+from prime_rl.trainer.models.layers.moe import MoE, MoEArgs
+from prime_rl.trainer.models.layers.rms_norm import RMSNorm, RMSNormConfig
+from prime_rl.trainer.models.layers.rotary_emb import RotaryEmbedding, RotaryEmbeddingConfig
+from prime_rl.trainer.models.minimax_m2.configuration_minimax_m2 import MiniMaxM2Config
+from prime_rl.trainer.models.minimax_m2.converting_minimax_m2 import (
+    convert_hf_layer_to_tt,
+    convert_hf_to_tt_moe,
+    convert_tt_layer_to_hf,
+    convert_tt_to_hf_moe,
+)
+
+logger = logging.get_logger(__name__)
+
+
+class MiniMaxM2DecoderLayer(GradientCheckpointingLayer):
+    def __init__(self, config: MiniMaxM2Config, layer_idx: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+
+        attn_config = AttentionConfig(
+            hidden_size=config.hidden_size,
+            head_dim=config.head_dim,
+            num_attention_heads=config.num_attention_heads,
+            num_key_value_heads=config.num_key_value_heads,
+            is_causal=True,
+            attention_bias=config.attention_bias,
+            use_qk_norm=config.use_qk_norm,
+            rms_norm_eps=config.rms_norm_eps,
+            qk_norm_type=config.qk_norm_type,
+        )
+        self.self_attn = ATTN_IMPL2CLASS[config._attn_implementation](attn_config)
+
+        moe_args = MoEArgs(
+            num_experts=config.num_local_experts,
+            num_shared_experts=0,
+            score_func=config.scoring_func,
+            route_norm=True,
+            route_scale=1.0,
+            score_before_experts=False,
+            top_k=config.num_experts_per_tok,
+            use_grouped_mm=config.use_grouped_mm,
+            load_balance_coeff=1e-3 if config.use_routing_bias else None,
+        )
+        self.mlp = MoE(moe_args, dim=config.hidden_size, hidden_dim=config.intermediate_size)
+
+        self.input_layernorm = RMSNorm(RMSNormConfig(hidden_size=config.hidden_size, eps=config.rms_norm_eps))
+        self.post_attention_layernorm = RMSNorm(RMSNormConfig(hidden_size=config.hidden_size, eps=config.rms_norm_eps))
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        cu_seqlens: torch.LongTensor | None = None,
+        max_seqlen: int | None = None,
+    ) -> torch.FloatTensor:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states, _ = self.self_attn(
+            hidden_states=hidden_states,
+            position_embeddings=position_embeddings,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+        )
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+
+@auto_docstring
+class MiniMaxM2PreTrainedModel(PreTrainedModelPrimeRL):
+    config: MiniMaxM2Config
+    base_model_prefix = "model"
+    supports_gradient_checkpointing = True
+    _no_split_modules = ["MiniMaxM2DecoderLayer"]
+    _skip_keys_device_placement = ["past_key_values"]
+    _supports_flash_attn = True
+    _supports_sdpa = True
+    _supports_flex_attn = True
+    _can_compile_fullgraph = False
+    _supports_attention_backend = True
+    _can_record_outputs = {
+        "hidden_states": MiniMaxM2DecoderLayer,
+    }
+
+    @classmethod
+    def is_hf_state_dict(cls, state_dict: dict[str, Tensor]) -> bool:
+        return any("block_sparse_moe.experts.1.w1" in name for name in state_dict.keys())
+
+    @classmethod
+    def is_prime_state_dict(cls, state_dict: dict[str, Tensor]) -> bool:
+        return any("mlp.experts.w1" in name for name in state_dict.keys())
+
+    @classmethod
+    def convert_to_hf(cls, state_dict: dict[str, Tensor]) -> dict[str, Tensor]:
+        convert_tt_to_hf_moe(state_dict)
+        return state_dict
+
+    @classmethod
+    def convert_to_prime(cls, state_dict: dict[str, Tensor]) -> dict[str, Tensor]:
+        convert_hf_to_tt_moe(state_dict)
+        return state_dict
+
+    @classmethod
+    def convert_layer_to_hf(cls, state_dict: dict[str, Tensor], layer_idx: int) -> dict[str, Tensor]:
+        convert_tt_layer_to_hf(state_dict, layer_idx)
+        return state_dict
+
+    @classmethod
+    def convert_layer_to_prime(cls, state_dict: dict[str, Tensor], layer_idx: int) -> dict[str, Tensor]:
+        convert_hf_layer_to_tt(state_dict, layer_idx)
+        return state_dict
+
+
+@auto_docstring
+class MiniMaxM2Model(MiniMaxM2PreTrainedModel):
+    def __init__(self, config: MiniMaxM2Config):
+        super().__init__(config)
+        self.padding_idx = config.pad_token_id
+        self.vocab_size = config.vocab_size
+
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)
+        self.layers = nn.ModuleList(
+            [MiniMaxM2DecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
+        )
+        self.norm = RMSNorm(RMSNormConfig(hidden_size=config.hidden_size, eps=config.rms_norm_eps))
+
+        if hasattr(config, "rope_scaling") and isinstance(config.rope_scaling, dict):
+            rope_type = config.rope_scaling.get("rope_type", config.rope_scaling.get("type"))
+        else:
+            rope_type = "default"
+        rotary_config = RotaryEmbeddingConfig(
+            max_position_embeddings=config.max_position_embeddings,
+            rope_type=rope_type,
+            model_config=config,
+        )
+        self.rotary_emb = RotaryEmbedding(rotary_config)
+        self.gradient_checkpointing = False
+
+        self.post_init()
+
+    @auto_docstring
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+    ) -> BaseModelOutputWithPast:
+        if (input_ids is None) ^ (inputs_embeds is not None):
+            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4"):
+            flat_position_ids = position_ids.view(-1)
+            seqlens = torch.cat(
+                [
+                    flat_position_ids[0:1],
+                    flat_position_ids[:-1][(flat_position_ids == 0)[1:]] + 1,
+                    flat_position_ids[-1:] + 1,
+                ]
+            )
+            max_seqlen = seqlens.max().item()
+            cu_seqlens = seqlens.cumsum(dim=0, dtype=torch.int32)
+            torch._dynamo.mark_dynamic(cu_seqlens, 0)
+        else:
+            max_seqlen = None
+            cu_seqlens = None
+
+        hidden_states = inputs_embeds
+        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+
+        for decoder_layer in self.layers[: self.config.num_hidden_layers]:
+            hidden_states = decoder_layer(
+                hidden_states,
+                position_embeddings=position_embeddings,
+                cu_seqlens=cu_seqlens,
+                max_seqlen=max_seqlen,
+            )
+
+        hidden_states = self.norm(hidden_states)
+        return BaseModelOutputWithPast(last_hidden_state=hidden_states)
+
+
+@auto_docstring
+class MiniMaxM2ForCausalLM(MiniMaxM2PreTrainedModel, GenerationMixin):
+    _tied_weights_keys = ["lm_head.weight"]
+    _tp_plan = {"lm_head": "colwise_rep"}
+    _pp_plan = {"lm_head": (["hidden_states"], ["logits"])}
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.model = MiniMaxM2Model(config)
+        self.vocab_size = config.vocab_size
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+        self.post_init()
+
+    @can_return_tuple
+    @auto_docstring
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        labels: Optional[torch.LongTensor] = None,
+        use_cache: Optional[bool] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        logits_to_keep: Union[int, torch.Tensor] = 0,
+        temperature: Union[torch.Tensor, None] = None,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> PrimeLmOutput:
+        r"""
+        labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
+            Labels for computing the masked language modeling loss.
+        temperature (`torch.Tensor` of shape `(batch_size, sequence_length)`, *optional*):
+            Per-token temperatures for logprobs/entropy computation.
+        """
+        assert use_cache is None, "use_cache is not supported for custom minimax_m2 for now"
+        assert past_key_values is None, "past_key_values is not supported for custom minimax_m2 for now"
+
+        if position_ids is None:
+            if inputs_embeds is not None:
+                position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
+            else:
+                position_ids = torch.arange(input_ids.shape[1], device=input_ids.device).unsqueeze(0)
+
+        outputs: BaseModelOutputWithPast = self.model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            inputs_embeds=inputs_embeds,
+        )
+
+        hidden_states = outputs.last_hidden_state
+        slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+        return self.lm_head(
+            hidden_states[:, slice_indices, :],
+            labels[:, slice_indices] if labels is not None else None,
+            temperature=temperature,
+        )
+
+    def init_buffers_post_meta(self):
+        buffer_names = [name for name, _ in self.named_buffers()]
+        if "model.rotary_emb.inv_freq" in buffer_names:
+            rotary_emb = self.model.rotary_emb
+            inv_freq, rotary_emb.attention_scaling = rotary_emb.rope_init_fn(
+                rotary_emb.config, rotary_emb.inv_freq.device
+            )
+            rotary_emb.inv_freq.copy_(inv_freq)
+
+
+__all__ = [
+    "MiniMaxM2ForCausalLM",
+    "MiniMaxM2Model",
+    "MiniMaxM2PreTrainedModel",
+]


### PR DESCRIPTION
## Summary

- Add full MiniMax M2.1 (230B MoE, 10B activated/token) support to prime-rl: modeling, weight conversion, registration, and mini-model verification
- Add per-layer QK norm support to shared attention layer (`qk_norm_type="per_layer"`)
- Refactor `mini_moe.py` to support remote-code HF models via `AutoModelForCausalLM` with `trust_remote_code=True`

## MiniMax M2.1 Architecture

- 256 experts, top-8 sigmoid routing with `e_score_correction_bias` for load balancing
- MoE on ALL layers (no dense-only layers, no shared experts)
- GQA: 48 heads, 8 KV heads, head_dim=128
- Partial rotary: `rotary_dim=64` of `head_dim=128`
- Per-layer QK normalization (each head has its own RMSNorm scale, applied before head reshape)

## Weight Conversion Details

The HF MiniMax M2.1 model uses different naming conventions from PrimeRL's internal format. The conversion handles:

| HF format | PrimeRL format |
|-----------|---------------|
| `layers.{i}.block_sparse_moe.gate.weight` | `layers.{i}.mlp.router.gate.weight` |
| `layers.{i}.block_sparse_moe.experts.{j}.w1.weight` | `layers.{i}.mlp.experts.w1` (stacked `[num_experts, moe_dim, dim]`) |
| `layers.{i}.block_sparse_moe.experts.{j}.w2.weight` | `layers.{i}.mlp.experts.w2` (stacked `[num_experts, dim, moe_dim]`) |
| `layers.{i}.block_sparse_moe.experts.{j}.w3.weight` | `layers.{i}.mlp.experts.w3` (stacked `[num_experts, moe_dim, dim]`) |
| `layers.{i}.block_sparse_moe.e_score_correction_bias` | `layers.{i}.mlp.expert_bias` |
| All other keys (attn, norms, embeddings) | Pass-through (same naming) |

Key differences from GLM4/Qwen3 conversion:
- HF block is named `block_sparse_moe` (not `mlp`)
- Expert weights use `.w1.weight` suffix (nn.Linear format) vs PrimeRL's `.w1` (nn.Parameter)
- `e_score_correction_bias` is a direct tensor under `block_sparse_moe` (not nested under `.gate`)
- No shared experts to convert

## Verification

**mini_moe.py roundtrip (random weights):**
```
HF vs PrimeRL max logits diff: 0.000002
HF -> PrimeRL -> HF roundtrip max logits diff: 0.000000
```

**Post-SFT checkpoint roundtrip (200 steps on Reverse-Text-SFT):**
```
SFT loss: 12.36 -> 4.38 (200 steps, lr=1e-4)

KL Mismatch Report (post-SFT checkpoint):
Max logits diff: 0.00000477
Mean logits diff: 0.00000057
KL divergence (PrimeRL vs HF roundtrip): -0.00000183
PASS: KL mismatch is negligible
```

## Test plan

- [x] `mini_moe.py --arch minimax_m2` roundtrip verification passes
- [x] SFT warmup on Reverse-Text-SFT (200 steps) trains successfully
- [x] Post-SFT KL mismatch is negligible (~0 KL divergence)
- [x] RL training (requires 2 GPUs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new model family plus non-trivial state-dict conversion and changes attention normalization behavior, which could affect logits equivalence/perf across attention backends if misconfigured.
> 
> **Overview**
> Adds first-class MiniMax M2.1 MoE support to PrimeRL: new `MiniMaxM2Config`, `MiniMaxM2ForCausalLM`, and in-place HF↔PrimeRL weight conversion that renames router keys and packs/unpacks per-expert weights between HF `block_sparse_moe.*` and PrimeRL grouped expert tensors.
> 
> Extends shared attention to support *per-layer* QK RMSNorm (`qk_norm_type`) by applying norm either before or after head reshaping across FlashAttention/SDPA/ring variants. Updates model registration (`AutoConfig`/`AutoModelForCausalLMPrimeRL`) and refactors `scripts/mini_moe.py` to add a `minimax_m2` preset and to load/create remote-code HF models via `AutoModelForCausalLM` with `trust_remote_code` for roundtrip verification.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0a24587c5298b8a9feafd0be2d4fa8b81f73527. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->