### PR TITLE
make eval retries configurable and default to no retries

### DIFF
--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -313,6 +313,17 @@ class EvalEnvConfig(EnvConfig):
         ),
     ] = 0
 
+    # TODO: should live on the EnvConfig and also apply to training envs but
+    # this is hard right now because we use the vf.EnvGroup which treats all
+    # envs as one. for now training envs hardcode no retries, but we should
+    # probably treat them like environment groups long-term
+    max_retries: Annotated[
+        int,
+        Field(
+            description="Maximum number of times the environment will try to retry running a rollout.",
+        ),
+    ] = 0
+
 
 class ValConfig(BaseConfig):
     """Configures the validation of the model."""

--- a/src/prime_rl/orchestrator/eval_utils.py
+++ b/src/prime_rl/orchestrator/eval_utils.py
@@ -70,13 +70,14 @@ async def evaluate_env(
     sampling_args: dict,
     num_examples: int,
     rollouts_per_example: int,
+    max_retries: int,
     ckpt_step: int,
     step: int | None,
 ):
     logger = get_logger()
     logger.info(f"Evaluating {env_name} ({num_examples=}, {rollouts_per_example=})")
     eval_start_time = time.perf_counter()
-    outputs = await evaluate(env, clients, model_name, sampling_args, num_examples, rollouts_per_example)
+    outputs = await evaluate(env, clients, model_name, sampling_args, num_examples, rollouts_per_example, max_retries)
     eval_time = time.perf_counter() - eval_start_time
 
     rows = []

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -399,6 +399,7 @@ async def orchestrate(config: OrchestratorConfig):
                         sampling_args=eval_sampling_args,
                         num_examples=eval_env_config.num_examples or config.eval.num_examples,
                         rollouts_per_example=eval_env_config.rollouts_per_example or config.eval.rollouts_per_example,
+                        max_retries=eval_env_config.max_retries,
                         ckpt_step=ckpt_step,
                         step=progress.step,
                     )

--- a/src/prime_rl/orchestrator/vf_utils.py
+++ b/src/prime_rl/orchestrator/vf_utils.py
@@ -11,7 +11,7 @@ from verifiers.workers import ZMQEnvClient, ZMQEnvServer
 
 from prime_rl.utils.logger import InterceptHandler, ProgressTracker, get_logger
 
-DEFAULT_RETRIES = 3
+DEFAULT_RETRIES = 0
 REQUIRED_STATE_COLUMNS = ["trajectory", "sampling_args"]
 DEFAULT_STATE_COLUMNS = []
 
@@ -79,32 +79,6 @@ async def wait_for_env_servers(
         raise TimeoutError(msg)
 
     await asyncio.gather(*[wait_for_env_server(env_client) for env_client in env_clients])
-
-
-async def run_rollout(
-    env: vf.Environment,
-    client: vf.ClientConfig,
-    model_name: str,
-    example: dict,
-    sampling_args: dict,
-    max_retries: int = DEFAULT_RETRIES,
-    state_columns: list[str] = DEFAULT_STATE_COLUMNS,
-) -> vf.RolloutOutput:
-    """
-    Wrapper for vf.Environment.run_rollout().
-
-    Asynchronously generates and scores a rollout.
-    """
-    state_columns = state_columns + REQUIRED_STATE_COLUMNS
-    rollout_input = vf.RolloutInput(**example)
-    return await env.run_rollout(
-        rollout_input,
-        client=client,
-        model=model_name,
-        sampling_args=sampling_args,
-        max_retries=max_retries,
-        state_columns=state_columns,
-    )
 
 
 async def run_group(


### PR DESCRIPTION
not the end of the story but configuring max_retries on training envs would be super ugly rn bc of the vf.EnvGroup. have some thoughts on how to do this nicely but will do in later pr

also noticed that we are never using `run_rollout` (only `run_group`) so removing to avoid confusion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches rollout execution/retry behavior, which can affect eval stability and throughput; also changes `evaluate_env`’s signature, so any missed call sites would cause runtime/type errors.
> 
> **Overview**
> Evaluation rollouts can now be configured with a per-environment `max_retries` setting via `EvalEnvConfig.max_retries`, and this value is threaded through `orchestrator.py` → `evaluate_env` → `vf_utils.evaluate`.
> 
> The default retry behavior is changed to **no retries** (`DEFAULT_RETRIES` from 3 → 0), and the unused `run_rollout` helper in `vf_utils.py` is removed to reduce confusion.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0356902019be4cbaddaf23963ae30f5f3e26d63. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->