### PR TITLE
increase default torch.compile recompile limit and cache size

### DIFF
--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import cast
 
 import torch
+import torch._dynamo
 import torch.nn as nn
 from beartype import beartype as typechecker
 from huggingface_hub import snapshot_download
@@ -53,6 +54,11 @@ DTYPE_MAP = {
     "bfloat16": torch.bfloat16,
     "float32": torch.float32,
 }
+
+# We increase the torch.compile recompile limit and cache size as we found this
+# necessary for training INTELLECT-3 with Muon.
+torch._dynamo.config.recompile_limit = 16  # default: 8
+torch._dynamo.config.cache_size_limit = 64  # default: 8
 
 
 def freeze_vision_encoder(model: nn.Module) -> None:


### PR DESCRIPTION
needed for intellect-3 + muon + compile to work well together

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global `torch._dynamo` runtime configuration for the process, which can affect compilation behavior and memory/perf characteristics across all training runs.
> 
> **Overview**
> Increases global TorchDynamo (`torch.compile`) limits by setting `torch._dynamo.config.recompile_limit` to 16 and `cache_size_limit` to 64 during `prime_rl.trainer.model` import, based on INTELLECT-3 + Muon training needs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0344f51bec1573b3c53a3b104c7bcbd97b42e92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->