### PR TITLE
patch vllm validation for multi-turn prompts

### DIFF
--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -140,3 +140,54 @@ def monkey_patch_LRUCacheWorkerLoRAManager():
 
     LRUCacheWorkerLoRAManager._apply_adapters = _patched__apply_adapters
     LRUCacheWorkerLoRAManager.add_adapter = _patched_add_adapter
+
+
+# Monkeypatch TokenizeParams to fix overly conservative validation
+def monkey_patch_tokenize_params_validation():
+    """
+    Patch TokenizeParams validation to only reject requests where the prompt
+    itself exceeds max_model_len, not where prompt + max_tokens > max_model_len.
+
+    Original behavior:
+        - Rejects if prompt_len > (max_model_len - max_tokens)
+
+    Patched behavior:
+        - Only rejects if prompt_len > max_model_len
+        - Lets the engine naturally cap generation at max_model_len
+    """
+    from vllm.exceptions import VLLMValidationError
+    from vllm.renderers.params import TokenizeParams
+
+    def _patched_token_len_check(self, tokenizer, tokens):
+        """Only validate that prompt fits in max_model_len, not prompt+max_tokens"""
+        if self.max_total_tokens is not None and len(tokens) > self.max_total_tokens:
+            raise VLLMValidationError(
+                f"The prompt is {len(tokens)} tokens, which exceeds the "
+                f"model's maximum context length of {self.max_total_tokens} tokens. "
+                f"Please reduce the length of the input prompt.",
+                parameter="input_tokens",
+                value=len(tokens),
+            )
+        return tokens
+
+    def _patched_text_len_check(self, tokenizer, text):
+        """Only validate text length against max_model_len, not max_input_tokens"""
+        if self.max_total_tokens is None or tokenizer is None:
+            return text
+
+        if self.truncate_prompt_tokens is None:
+            max_chars = self.max_total_tokens * tokenizer.max_chars_per_token
+            if len(text) > max_chars:
+                raise VLLMValidationError(
+                    f"You passed {len(text)} input characters. "
+                    f"However, the model's context length is only "
+                    f"{self.max_total_tokens} tokens "
+                    f"(at most {max_chars} characters). "
+                    f"Please reduce the length of the input prompt.",
+                    parameter="input_text",
+                    value=len(text),
+                )
+        return text
+
+    TokenizeParams._token_len_check = _patched_token_len_check
+    TokenizeParams._text_len_check = _patched_text_len_check

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -25,6 +25,7 @@ from prime_rl.inference.config import InferenceConfig
 from prime_rl.inference.patches import (
     monkey_patch_load_lora_adapter,
     monkey_patch_prometheus_stat_logger_for_lora_in_dp_mode,
+    monkey_patch_tokenize_params_validation,
 )
 from prime_rl.inference.vllm.serving_chat_with_tokens import (
     ChatCompletionRequestWithTokens,
@@ -35,6 +36,8 @@ from prime_rl.inference.vllm.serving_chat_with_tokens import (
 monkey_patch_prometheus_stat_logger_for_lora_in_dp_mode()
 # NOTE: Monkeypatch LoadLoRAAdapter to allow loading the same adapter multiple times
 monkey_patch_load_lora_adapter()
+# NOTE: Monkeypatch TokenizeParams to fix overly conservative validation
+monkey_patch_tokenize_params_validation()
 
 logger = init_logger("vllm.entrypoints.openai.api_server")
 


### PR DESCRIPTION
vllm errors if `prompt_len + max_tokens > max_model_len` which frequently happens in multi-turn RL. if `max_tokens` is large, the its likely that the completion will complete before hitting `max_model_len` and so we abort a rollout early for no good reason. this pr patches vllm to only error if `prompt_len > max_model_len` but not in the above case. tested working with minimal example via vf-eval

```bash
# run inference at low ctx
uv run inference --model.name Qwen/Qwen3-4B-Instruct-2507 --tensor-parallel-size 2      --tool-call-parser hermes            --enable-auto-tool-choice --max-model-len 512

# run vf-eval and limit per-turn max_tokens
uv run vf-eval alphabet-sort -n1 -r1 -d -v -m Qwen/Qwen3-4B-Instruct-2507 -b http://localhost:8000/v1 -t 400
```

previously the second turn would fail, now it works.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core input validation behavior in the inference server via monkeypatching, which could allow requests that run up to context limits and change error/termination behavior under load.
> 
> **Overview**
> Relaxes vLLM request validation so tokenization only rejects inputs when the *prompt itself* exceeds `max_model_len`, instead of failing when `prompt_len + max_tokens` would exceed the context window.
> 
> Implements this as a monkeypatch of `TokenizeParams._token_len_check` and `TokenizeParams._text_len_check` in `patches.py`, and wires it into the vLLM OpenAI server startup so multi-turn RL rollouts aren’t aborted early due to conservative checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58c831036495751265efb17f0b03f4bb86835b0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->