### PR TITLE
Devx version tag automation

### DIFF
--- a/.github/workflows/cpu_tests.yaml
+++ b/.github/workflows/cpu_tests.yaml
@@ -6,9 +6,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
-permissions:
-  contents: read
-
 jobs:
   unit-tests:
     name: Unit tests
@@ -41,66 +38,3 @@ jobs:
         run: PYTEST_OUTPUT_DIR=/tmp/outputs uv run pytest tests/unit -m "not gpu"
       - name: Cleanup output_dir
         run: rm -rf /tmp/outputs
-
-  create-dev-tag:
-    name: Create dev tag
-    needs: unit-tests
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    permissions:
-      contents: write
-    runs-on: ubuntu-latest
-    steps:
-      - name: Create next .dev tag from latest release
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { owner, repo } = context.repo;
-            const sha = context.sha;
-            const latestRelease = await github.rest.repos.getLatestRelease({ owner, repo });
-            const baseTag = latestRelease.data.tag_name;
-            const prefix = `${baseTag}.dev`;
-
-            const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-            const pattern = new RegExp(`^refs/tags/${escapeRegex(baseTag)}\\.dev(\\d+)$`);
-
-            for (let attempt = 0; attempt < 5; attempt += 1) {
-              const refs = await github.paginate(github.rest.git.listMatchingRefs, {
-                owner,
-                repo,
-                ref: `tags/${prefix}`,
-              });
-
-              let maxVersion = 0;
-              for (const ref of refs) {
-                const match = pattern.exec(ref.ref);
-                if (match) {
-                  const version = Number.parseInt(match[1], 10);
-                  if (version > maxVersion) {
-                    maxVersion = version;
-                  }
-                }
-              }
-
-              const nextVersion = maxVersion + 1;
-              const tag = `${prefix}${nextVersion}`;
-
-              try {
-                await github.rest.git.createRef({
-                  owner,
-                  repo,
-                  ref: `refs/tags/${tag}`,
-                  sha,
-                });
-                core.notice(`Created tag ${tag} at ${sha}`);
-                core.setOutput("tag", tag);
-                return;
-              } catch (error) {
-                if (error.status === 422) {
-                  core.warning(`Tag ${tag} already exists, retrying with next version...`);
-                  continue;
-                }
-                throw error;
-              }
-            }
-
-            core.setFailed("Could not create a unique .dev tag after retries.");

--- a/.github/workflows/devx_tag.yaml
+++ b/.github/workflows/devx_tag.yaml
@@ -1,0 +1,82 @@
+name: DevX Tag
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  create-dev-tag:
+    name: Create .dev tag
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create next .dev tag from latest release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const sha = context.sha;
+
+            let baseTag;
+            try {
+              const latestRelease = await github.rest.repos.getLatestRelease({ owner, repo });
+              baseTag = latestRelease.data.tag_name;
+            } catch (error) {
+              if (error.status === 404) {
+                core.notice("No releases found. Skipping .dev tag creation.");
+                return;
+              }
+              throw error;
+            }
+
+            const prefix = `${baseTag}.dev`;
+            const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+            const pattern = new RegExp(`^refs/tags/${escapeRegex(baseTag)}\\.dev(\\d+)$`);
+
+            for (let attempt = 0; attempt < 5; attempt += 1) {
+              const refs = await github.paginate(github.rest.git.listMatchingRefs, {
+                owner,
+                repo,
+                ref: `tags/${prefix}`,
+              });
+
+              let maxVersion = 0;
+              for (const ref of refs) {
+                const match = pattern.exec(ref.ref);
+                if (match) {
+                  const version = Number.parseInt(match[1], 10);
+                  if (version > maxVersion) {
+                    maxVersion = version;
+                  }
+                }
+              }
+
+              const tag = `${prefix}${maxVersion + 1}`;
+
+              try {
+                await github.rest.git.createRef({
+                  owner,
+                  repo,
+                  ref: `refs/tags/${tag}`,
+                  sha,
+                });
+                core.notice(`Created tag ${tag} at ${sha}`);
+                return;
+              } catch (error) {
+                if (error.status === 422) {
+                  core.warning(`Tag ${tag} already exists, retrying...`);
+                  continue;
+                }
+                throw error;
+              }
+            }
+
+            core.setFailed("Could not create a unique .dev tag after retries.");


### PR DESCRIPTION
Add a CI job to automatically create `.devX` tags based on the latest release for development versioning.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-ee923c19-f172-46d9-8b21-a49f1c4d478c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ee923c19-f172-46d9-8b21-a49f1c4d478c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Automatically creates git tags with `contents: write` on every `main` push, so mis-tagging or unexpected tag churn could impact downstream release/version consumers.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`devx_tag.yaml`) that runs on `main` (and manually) to create a `.devN` tag on each push.
> 
> The job bases the tag prefix on the latest GitHub release tag, finds the highest existing `${release}.dev*` tag, and creates the next incremental tag pointing at the current commit, with retries on tag-collision and a no-op when no releases exist.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7faf680ac4047f386339ccfaa6f281e5c573bab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->