### PR TITLE
ci: add devx tag workflow from latest release

### DIFF
--- a/.github/workflows/devx_tag.yaml
+++ b/.github/workflows/devx_tag.yaml
@@ -25,10 +25,10 @@ jobs:
             const { owner, repo } = context.repo;
             const sha = context.sha;
 
-            let baseTag;
+            let latestTag;
             try {
               const latestRelease = await github.rest.repos.getLatestRelease({ owner, repo });
-              baseTag = latestRelease.data.tag_name;
+              latestTag = latestRelease.data.tag_name;
             } catch (error) {
               if (error.status === 404) {
                 core.notice("No releases found. Skipping .dev tag creation.");
@@ -36,6 +36,18 @@ jobs:
               }
               throw error;
             }
+
+            const semverMatch = /^(v?)(\d+)\.(\d+)(?:\.(\d+))?$/.exec(latestTag);
+            if (!semverMatch) {
+              core.setFailed(`Latest release tag '${latestTag}' is not semver-like.`);
+              return;
+            }
+
+            const [, versionPrefix, majorRaw, minorRaw, patchRaw] = semverMatch;
+            const major = Number.parseInt(majorRaw, 10);
+            const minor = Number.parseInt(minorRaw, 10);
+            const patch = Number.parseInt(patchRaw ?? "0", 10) + 1;
+            const baseTag = `${versionPrefix}${major}.${minor}.${patch}`;
 
             const prefix = `${baseTag}.dev`;
             const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Workflow-only change affecting tag naming; risk is limited to potential CI failures if release tags don’t match the expected semver pattern.
> 
> **Overview**
> Updates the `DevX Tag` GitHub Actions workflow to derive the `.devN` tag prefix from a **semver-parsed latest release tag**, incrementing the patch version (and supporting optional `v` prefix / missing patch) before creating the next `.dev` tag.
> 
> If the latest release tag is not semver-like, the workflow now **fails fast** instead of attempting to tag with an invalid base.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d18c5cf3d20d287d48314a67583dd53abc1531f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->