### PR TITLE
fix(logging): route fatal errors through JSON logger

### DIFF
--- a/src/prime_rl/orchestrator/env_server/env_server.py
+++ b/src/prime_rl/orchestrator/env_server/env_server.py
@@ -1,4 +1,3 @@
-from loguru import logger
 from verifiers.workers import ZMQEnvServer
 
 from prime_rl.orchestrator.env_server.config import EnvServerConfig
@@ -9,7 +8,6 @@ from prime_rl.utils.utils import clean_exit, get_env_ids_to_install, install_env
 
 
 @clean_exit
-@logger.catch(reraise=True)
 def run_server(config: EnvServerConfig):
     setup_logger(config.log.level, json_logging=config.log.json_logging)
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -24,7 +24,6 @@ monkey_patch_chat_completion_logprobs()
 
 import pandas as pd
 import verifiers as vf
-from loguru import logger
 from transformers import AutoProcessor, AutoTokenizer
 
 from prime_rl.orchestrator.buffer import Buffer
@@ -71,7 +70,6 @@ from prime_rl.utils.vlm import is_vlm_model
 
 
 @clean_exit
-@logger.catch(reraise=True)
 async def orchestrate(config: OrchestratorConfig):
     # Initialize the logger
     logger = setup_logger(

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -12,7 +12,6 @@ import torch
 import torch.distributed as dist
 import torch.distributed.nn as dist_nn
 from torch.profiler import profile, ProfilerActivity, record_function
-from loguru import logger
 from prime_rl.trainer.ckpt import setup_ckpt_managers
 from prime_rl.trainer.multi_ckpt import setup_multi_checkpoint_manager
 from prime_rl.trainer.optim import setup_optimizer, setup_multi_optimizer
@@ -63,7 +62,6 @@ from torchtitan.distributed.utils import clip_grad_norm_
 
 
 @clean_exit
-@logger.catch(reraise=True)
 def train(config: RLTrainerConfig):
     # Setup world and logger
     world = get_world()

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -12,7 +12,6 @@ from prime_rl.trainer.models.layers.attn import substitute_prime_rl_flash_attn
 from prime_rl.utils.act_offloading import maybe_activation_offloading
 import torch
 from torch.profiler import profile, ProfilerActivity, record_function
-from loguru import logger
 from prime_rl.trainer.ckpt import setup_ckpt_managers
 from prime_rl.utils.pathing import resolve_latest_ckpt_step
 from prime_rl.trainer.sft.config import SFTTrainerConfig
@@ -51,7 +50,6 @@ from torchtitan.distributed.utils import clip_grad_norm_
 
 
 @clean_exit
-@logger.catch(reraise=True)
 def train(config: SFTTrainerConfig):
     # Setup world and logger
     world = get_world()

--- a/src/prime_rl/utils/utils.py
+++ b/src/prime_rl/utils/utils.py
@@ -130,6 +130,7 @@ def clean_exit(func: Callable) -> Callable:
                 wandb.finish()
                 return ret
             except Exception as e:
+                get_logger().opt(exception=True).error(f"Fatal error in {func.__name__}")
                 wandb.finish(exit_code=1)
                 raise e
             finally:
@@ -146,6 +147,7 @@ def clean_exit(func: Callable) -> Callable:
                 wandb.finish()
                 return ret
             except Exception as e:
+                get_logger().opt(exception=True).error(f"Fatal error in {func.__name__}")
                 wandb.finish(exit_code=1)
                 raise e
             finally:


### PR DESCRIPTION
## Summary

- `@logger.catch(reraise=True)` on all four entrypoints (`orchestrator`, `rl/train`, `sft/train`, `env_server`) used loguru's **default global logger**, not the custom logger created by `setup_logger()`. This meant fatal exceptions bypassed the JSON formatter and were logged in plain-text format, making them invisible to structured log aggregation (Loki, Grafana, etc.).
- Moved exception logging into the `clean_exit` decorator using `get_logger()`, which returns the custom JSON-aware logger.
- Removed the now-unused `from loguru import logger` imports from all four entrypoints.

## Test plan

- [ ] Trigger a fatal error in the orchestrator with `json_logging=true` and verify the exception appears in JSON format
- [ ] Verify normal (non-error) logs are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized logging-path change that should only affect how fatal exceptions are emitted; main risk is missing logs if `setup_logger()` is not initialized before an exception.
> 
> **Overview**
> Fatal exception handling is shifted from per-entrypoint `@logger.catch(reraise=True)` wrappers to the shared `clean_exit` decorator, which now logs crashes via `get_logger().opt(exception=True)` before finishing W&B and tearing down `torch.distributed`.
> 
> The `loguru` global logger import and `@logger.catch` usage are removed from the main entrypoints (`orchestrator`, `env_server`, `trainer/rl`, `trainer/sft`), ensuring uncaught exceptions go through the JSON-aware logger created by `setup_logger()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d49d2aeafd6c9ed0884c0aecbbdeefa52fa8461a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->