### PR TITLE
replace round robin

### DIFF
--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import os
-from itertools import cycle
 from pathlib import Path
 from typing import Protocol, runtime_checkable
 
@@ -34,10 +33,6 @@ class InferencePool(Protocol):
         """Update the model name."""
         ...
 
-    async def get_next_client(self) -> vf.ClientConfig:
-        """Get next client in round-robin fashion."""
-        ...
-
     async def wait_for_ready(self, model_name: str, timeout: int = 1800) -> None:
         """Wait for inference pool to be ready."""
         ...
@@ -64,8 +59,6 @@ class StaticInferencePool:
         self._clients = clients
         self._admin_clients = admin_clients
         self._skip_model_check = skip_model_check
-        self._idx_to_client = {client.client_idx: client for client in clients}
-        self._client_cycle = cycle(clients)
         self.model_name = None  # unused
 
     @property
@@ -78,9 +71,6 @@ class StaticInferencePool:
 
     def update_model_name(self, model_name: str) -> None:
         self.model_name = model_name
-
-    async def get_next_client(self) -> vf.ClientConfig:
-        return next(self._client_cycle)
 
     async def wait_for_ready(self, model_name: str, timeout: int = 1800) -> None:
         await check_health(self._admin_clients, timeout=timeout)

--- a/src/prime_rl/utils/elastic.py
+++ b/src/prime_rl/utils/elastic.py
@@ -123,7 +123,6 @@ class ElasticInferencePool:
 
         self._clients: list[vf.ClientConfig] = []
         self._client_urls: list[str] = []
-        self._client_index = 0
 
         self._sync_task: asyncio.Task | None = None
         self._started = False
@@ -160,7 +159,6 @@ class ElasticInferencePool:
         urls = self.ready_urls
         if set(urls) != set(self._client_urls):
             self._client_urls = urls
-            self._client_index = 0
             self._clients = (
                 setup_clients(
                     ClientConfig(
@@ -174,18 +172,6 @@ class ElasticInferencePool:
                 else []
             )
         return self._clients
-
-    @property
-    def has_clients(self) -> bool:
-        return len(self.clients) > 0
-
-    async def get_next_client(self) -> vf.ClientConfig:
-        """Get next client in round-robin fashion."""
-        while not self.has_clients:
-            await asyncio.sleep(self.sync_interval)
-        client = self._clients[self._client_index % len(self._clients)]
-        self._client_index += 1
-        return client
 
     @property
     def admin_clients(self) -> list[AsyncClient]:

--- a/tests/unit/orchestrator/test_scheduler_client_selection.py
+++ b/tests/unit/orchestrator/test_scheduler_client_selection.py
@@ -1,0 +1,127 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from prime_rl.orchestrator.scheduler import InflightRolloutInfo, Scheduler
+
+
+def make_client(url: str) -> SimpleNamespace:
+    return SimpleNamespace(api_base_url=url)
+
+
+def make_scheduler(clients: list) -> Scheduler:
+    pool = MagicMock()
+    pool.clients = clients
+
+    config = MagicMock()
+    config.tasks_per_minute = None
+    config.model.lora = None
+    config.model.name = "test-model"
+    config.max_inflight_groups = 8
+    config.rollouts_per_example = 1
+
+    return Scheduler(env=MagicMock(), inference_pool=pool, buffer=MagicMock(), config=config)
+
+
+def make_task() -> MagicMock:
+    task = MagicMock()
+    task.done.return_value = False
+    return task
+
+
+def test_selects_least_loaded_client():
+    client_a = make_client("http://a:8000/v1")
+    client_b = make_client("http://b:8000/v1")
+    scheduler = make_scheduler([client_a, client_b])
+
+    # A has 3 inflight, B has 1
+    for _ in range(3):
+        scheduler.inflight_group_rollouts[make_task()] = InflightRolloutInfo(0, client_a)
+    scheduler.inflight_group_rollouts[make_task()] = InflightRolloutInfo(0, client_b)
+
+    selected = asyncio.run(scheduler._select_least_loaded_client())
+    assert selected.api_base_url == client_b.api_base_url
+
+
+def test_equal_counts_picks_first_client():
+    client_a = make_client("http://a:8000/v1")
+    client_b = make_client("http://b:8000/v1")
+    scheduler = make_scheduler([client_a, client_b])
+
+    scheduler.inflight_group_rollouts[make_task()] = InflightRolloutInfo(0, client_a)
+    scheduler.inflight_group_rollouts[make_task()] = InflightRolloutInfo(0, client_b)
+
+    selected = asyncio.run(scheduler._select_least_loaded_client())
+    assert selected.api_base_url == client_a.api_base_url
+
+
+def test_empty_inflight_picks_first_client():
+    client_a = make_client("http://a:8000/v1")
+    client_b = make_client("http://b:8000/v1")
+    scheduler = make_scheduler([client_a, client_b])
+
+    selected = asyncio.run(scheduler._select_least_loaded_client())
+    assert selected.api_base_url == client_a.api_base_url
+
+
+def test_counts_update_after_completion():
+    client_a = make_client("http://a:8000/v1")
+    client_b = make_client("http://b:8000/v1")
+    scheduler = make_scheduler([client_a, client_b])
+
+    task_a = make_task()
+    scheduler.inflight_group_rollouts[task_a] = InflightRolloutInfo(0, client_a)
+    for _ in range(2):
+        scheduler.inflight_group_rollouts[make_task()] = InflightRolloutInfo(0, client_b)
+
+    # A=1, B=2 → selects A
+    selected = asyncio.run(scheduler._select_least_loaded_client())
+    assert selected.api_base_url == client_a.api_base_url
+
+    # Simulate completion of A's task
+    scheduler.inflight_group_rollouts.pop(task_a)
+
+    # A=0, B=2 → still selects A
+    selected = asyncio.run(scheduler._select_least_loaded_client())
+    assert selected.api_base_url == client_a.api_base_url
+
+
+def test_counts_reset_after_bulk_cancel():
+    client_a = make_client("http://a:8000/v1")
+    client_b = make_client("http://b:8000/v1")
+    scheduler = make_scheduler([client_a, client_b])
+
+    scheduler.inflight_group_rollouts[make_task()] = InflightRolloutInfo(0, client_a)
+    for _ in range(5):
+        scheduler.inflight_group_rollouts[make_task()] = InflightRolloutInfo(0, client_b)
+
+    # B heavily loaded → selects A
+    selected = asyncio.run(scheduler._select_least_loaded_client())
+    assert selected.api_base_url == client_a.api_base_url
+
+    scheduler.cancel_all_inflight_rollouts()
+
+    # All cleared → both at 0, deterministic tie-break picks first (A)
+    selected = asyncio.run(scheduler._select_least_loaded_client())
+    assert selected.api_base_url == client_a.api_base_url
+
+
+def test_new_client_gets_priority():
+    client_a = make_client("http://a:8000/v1")
+    client_b = make_client("http://b:8000/v1")
+    scheduler = make_scheduler([client_a, client_b])
+
+    for _ in range(3):
+        scheduler.inflight_group_rollouts[make_task()] = InflightRolloutInfo(0, client_a)
+    scheduler.inflight_group_rollouts[make_task()] = InflightRolloutInfo(0, client_b)
+
+    # A=3, B=1 → selects B
+    selected = asyncio.run(scheduler._select_least_loaded_client())
+    assert selected.api_base_url == client_b.api_base_url
+
+    # A third server appears with 0 inflight
+    client_c = make_client("http://c:8000/v1")
+    scheduler.inference_pool.clients = [client_a, client_b, client_c]
+
+    selected = asyncio.run(scheduler._select_least_loaded_client())
+    assert selected.api_base_url == client_c.api_base_url


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes core scheduling and inference-pool interfaces (removing `get_next_client` and replacing `generate_batch`), which is likely to break orchestrator call sites and alter rollout throughput/behavior if not updated consistently.
> 
> **Overview**
> Reworks rollout scheduling to **replace round-robin inference client selection** with a *least-loaded* strategy based on per-client in-flight group counts, improving load distribution and handling dynamic client pools.
> 
> The scheduler API is shifted from batch construction (`generate_batch`) to a continuous model (`next_completed_group`) that keeps `max_inflight_groups` topped up, returns rollouts from the first completed group, and simplifies policy-update logic/metrics (removing async-level and checkpoint-wait tracking). Inference pool interfaces are tightened by removing `get_next_client` from `InferencePool`, `StaticInferencePool`, and `ElasticInferencePool`, and unit tests are added to lock in least-loaded client selection behavior and tie-breaking.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c63439e2af141bed1f116537c6a9c23aaddbe22f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->