### PR TITLE
replace round robin

### DIFF
--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import time
 from pathlib import Path
+from collections import Counter
 from typing import NamedTuple
 
 import verifiers as vf

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import time
-from pathlib import Path
 from collections import Counter
+from pathlib import Path
 from typing import NamedTuple
 
 import verifiers as vf

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -106,12 +106,21 @@ class Scheduler:
         self.inflight_group_rollouts.clear()
         self.cancelled_rollouts_count += count
 
+    async def _select_least_loaded_client(self) -> vf.ClientConfig:
+        """Select the client with the fewest in-flight tasks."""
+        clients = self.inference_pool.clients
+        while not clients:
+            await asyncio.sleep(1)
+            clients = self.inference_pool.clients
+        inflight_by_url = Counter(info.client_config.api_base_url for info in self.inflight_group_rollouts.values())
+        return min(clients, key=lambda c: inflight_by_url[c.api_base_url])
+
     async def schedule_group_rollout(self):
         """Asynchronously schedules a group rollout request."""
         if self.rate_limiter:
             await self.rate_limiter.acquire()
         example = self.buffer.sample_examples(n=1)[0]
-        client_config = await self.inference_pool.get_next_client()
+        client_config = await self._select_least_loaded_client()
         run_group_task = asyncio.create_task(
             run_group(
                 env=self.env,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes rollout-to-client routing behavior, which can affect throughput and fairness under load and could introduce scheduling bias or hot-spotting if in-flight tracking is inaccurate.
> 
> **Overview**
> Replaces round-robin client selection for group rollouts with a **least-loaded** strategy: `Scheduler` now counts in-flight rollouts per `api_base_url` and chooses the client with the fewest active tasks.
> 
> Adds a small wait loop to delay scheduling until the inference pool has at least one client available, reducing errors when the pool is initially empty.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa8665b1f70461bca444f812cab69917411964d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->