### PR TITLE
WIP fix: call evaluate with explicit keyword arguments

### DIFF
--- a/src/prime_rl/orchestrator/eval_utils.py
+++ b/src/prime_rl/orchestrator/eval_utils.py
@@ -66,7 +66,6 @@ def compute_pass_at_k(rewards: list[int]) -> dict[str, float]:
 async def evaluate_env(
     env: vf.Environment,
     env_name: str,
-    clients: list[vf.ClientConfig],
     model_name: str,
     sampling_args: dict,
     num_examples: int,
@@ -74,14 +73,13 @@ async def evaluate_env(
     max_retries: int,
     ckpt_step: int,
     step: int | None,
-    get_client: Callable[[], Awaitable[vf.ClientConfig]] | None = None,
+    get_client: Callable[[], Awaitable[vf.ClientConfig]],
 ):
     logger = get_logger()
     logger.info(f"Evaluating {env_name} ({num_examples=}, {rollouts_per_example=})")
     eval_start_time = time.perf_counter()
     outputs = await evaluate(
         env=env,
-        clients=clients,
         model_name=model_name,
         sampling_args=sampling_args,
         num_examples=num_examples,

--- a/src/prime_rl/orchestrator/eval_utils.py
+++ b/src/prime_rl/orchestrator/eval_utils.py
@@ -1,4 +1,5 @@
 import time
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 import numpy as np
@@ -73,11 +74,21 @@ async def evaluate_env(
     max_retries: int,
     ckpt_step: int,
     step: int | None,
+    get_client: Callable[[], Awaitable[vf.ClientConfig]] | None = None,
 ):
     logger = get_logger()
     logger.info(f"Evaluating {env_name} ({num_examples=}, {rollouts_per_example=})")
     eval_start_time = time.perf_counter()
-    outputs = await evaluate(env, clients, model_name, sampling_args, num_examples, rollouts_per_example, max_retries)
+    outputs = await evaluate(
+        env=env,
+        clients=clients,
+        model_name=model_name,
+        sampling_args=sampling_args,
+        num_examples=num_examples,
+        rollouts_per_example=rollouts_per_example,
+        get_client=get_client,
+        max_retries=max_retries,
+    )
     eval_time = time.perf_counter() - eval_start_time
 
     rows = []

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -391,7 +391,6 @@ async def orchestrate(config: OrchestratorConfig):
                     evaluate_env(
                         env=eval_env,
                         env_name=eval_env_name,
-                        clients=inference_pool.clients,
                         get_client=inference_pool.get_next_client,
                         model_name=scheduler.model_name,
                         sampling_args=eval_sampling_args,
@@ -421,11 +420,11 @@ async def orchestrate(config: OrchestratorConfig):
             val_task = asyncio.create_task(
                 generate(
                     env=train_env_group,
-                    clients=inference_pool.clients,
                     model_name=scheduler.model_name,
                     examples=val_examples,
                     rollouts_per_example=config.val.rollouts_per_example,
                     sampling_args=sampling_args,
+                    clients=inference_pool.clients,
                     pbar_description="Generating rollouts (val)",
                 )
             )
@@ -728,7 +727,6 @@ async def orchestrate(config: OrchestratorConfig):
                 evaluate_env(
                     env=eval_env,
                     env_name=eval_env_name,
-                    clients=inference_pool.clients,
                     get_client=inference_pool.get_next_client,
                     model_name=scheduler.model_name,
                     sampling_args=eval_sampling_args,

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -386,13 +386,13 @@ async def orchestrate(config: OrchestratorConfig):
             # this avoid doing eval across different checkpoints and avoid congestion
             scheduler.checkpoint_ready.clear()
             scheduler.cancel_all_inflight_rollouts()
-
             results = await asyncio.gather(
                 *[
                     evaluate_env(
                         env=eval_env,
                         env_name=eval_env_name,
                         clients=inference_pool.clients,
+                        get_client=inference_pool.get_next_client,
                         model_name=scheduler.model_name,
                         sampling_args=eval_sampling_args,
                         num_examples=eval_env_config.num_examples or config.eval.num_examples,
@@ -729,6 +729,7 @@ async def orchestrate(config: OrchestratorConfig):
                     env=eval_env,
                     env_name=eval_env_name,
                     clients=inference_pool.clients,
+                    get_client=inference_pool.get_next_client,
                     model_name=scheduler.model_name,
                     sampling_args=eval_sampling_args,
                     num_examples=eval_env_config.num_examples or config.eval.num_examples,

--- a/src/prime_rl/orchestrator/vf_utils.py
+++ b/src/prime_rl/orchestrator/vf_utils.py
@@ -142,7 +142,8 @@ async def generate(
     total_rollouts = len(examples) * rollouts_per_example
     pbar = ProgressTracker(total=total_rollouts, desc=pbar_description)
 
-    async def run_group_with_progress(client, example):
+    async def run_group_with_progress(example):
+        client = await get_client()
         result = await run_group(
             env=env,
             client=client,
@@ -157,9 +158,8 @@ async def generate(
         return result
 
     try:
-        clients_for_examples = await asyncio.gather(*[get_client() for _ in examples])
         group_outputs_list: list[list[vf.RolloutOutput]] = await asyncio.gather(
-            *[run_group_with_progress(client, example) for client, example in zip(clients_for_examples, examples)]
+            *[run_group_with_progress(example) for example in examples]
         )
     finally:
         pbar.close()

--- a/src/prime_rl/orchestrator/vf_utils.py
+++ b/src/prime_rl/orchestrator/vf_utils.py
@@ -159,10 +159,7 @@ async def generate(
     try:
         clients_for_examples = await asyncio.gather(*[get_client() for _ in examples])
         group_outputs_list: list[list[vf.RolloutOutput]] = await asyncio.gather(
-            *[
-                run_group_with_progress(client, example)
-                for client, example in zip(clients_for_examples, examples)
-            ]
+            *[run_group_with_progress(client, example) for client, example in zip(clients_for_examples, examples)]
         )
     finally:
         pbar.close()

--- a/src/prime_rl/orchestrator/vf_utils.py
+++ b/src/prime_rl/orchestrator/vf_utils.py
@@ -112,11 +112,11 @@ async def run_group(
 # TODO: migrate this to vf.Environment.generate() once it supports multiple clients
 async def generate(
     env: vf.Environment,
-    clients: list[vf.ClientConfig],
     model_name: str,
     examples: list,
     rollouts_per_example: int,
     sampling_args: dict,
+    clients: list[vf.ClientConfig] | None = None,
     get_client: Callable[[], Awaitable[vf.ClientConfig]] | None = None,
     max_retries: int = DEFAULT_RETRIES,
     state_columns: list[str] = DEFAULT_STATE_COLUMNS,
@@ -169,11 +169,11 @@ async def generate(
 
 async def evaluate(
     env: vf.Environment,
-    clients: list[vf.ClientConfig],
     model_name: str,
     sampling_args: dict,
     num_examples: int,
     rollouts_per_example: int,
+    clients: list[vf.ClientConfig] | None = None,
     get_client: Callable[[], Awaitable[vf.ClientConfig]] | None = None,
     max_retries: int = DEFAULT_RETRIES,
     state_columns: list[str] = DEFAULT_STATE_COLUMNS,


### PR DESCRIPTION
### Motivation
- Prevent a runtime argument mismatch in `evaluate_env()` caused by positional-argument drift after a signature change to `evaluate()` so the optional `get_client` hook is not accidentally passed into the wrong parameter slot. 
- Preserve the elastic-eval behavior where evals can discover per-example clients while keeping the invocation sites robust to future refactors. 
- Make `generate()`/`evaluate()` client selection explicit and type-annotated for clarity and safety.

### Description
- Fix `evaluate_env()` to call `evaluate()` using explicit keyword arguments (`env=`, `clients=`, `model_name=`, `sampling_args=`, `num_examples=`, `rollouts_per_example=`, `get_client=`, `max_retries=`) to avoid positional-argument drift. 
- Add `Awaitable`/`Callable` imports and an optional `get_client: Callable[[], Awaitable[vf.ClientConfig]] | None` parameter to `generate()` and `evaluate()` in `src/prime_rl/orchestrator/vf_utils.py` and to `evaluate_env()` in `src/prime_rl/orchestrator/eval_utils.py`. 
- Implement per-example dynamic client selection in `generate()` by: raising an error if no `clients` and no `get_client`; providing a local `client_cycle` fallback when `get_client` is not supplied; awaiting `get_client()` for each example and dispatching group rollouts against the returned clients. 
- Update orchestrator eval call sites to pass the `get_client` hook (e.g. `get_client=inference_pool.get_next_client`) so online evals can use newly available elastic endpoints while retaining prior validation paths.

### Testing
- Ran byte-compilation with `python -m compileall src/prime_rl/orchestrator/eval_utils.py src/prime_rl/orchestrator/vf_utils.py src/prime_rl/orchestrator/orchestrator.py src/prime_rl/orchestrator/scheduler.py`, which completed successfully. 
- Linting via the project `uv` wrapper could not be fully validated in this environment due to external dependency resolution/network restrictions, so formal lint checks were not run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6991a21a9fec8330ac4ea15242fa97b5)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches rollout generation/evaluation concurrency and client selection, which can impact eval correctness and load distribution if the callback behavior differs or is misused; scope is otherwise contained to orchestrator utilities.
> 
> **Overview**
> Prevents a potential runtime mismatch in eval by switching `evaluate_env()` to call `evaluate()` with explicit keyword arguments and by changing eval paths to pass a `get_client` callback instead of a static `clients` list.
> 
> Extends `vf_utils.generate()` and `vf_utils.evaluate()` with an optional async `get_client` hook (with validation + round-robin fallback when only `clients` is provided) and updates orchestrator online/final evals to use `inference_pool.get_next_client`, enabling per-example dynamic client selection during evaluation while keeping validation generation on the existing static client list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c36d8c3c375620e61efea59bcd1dd7b6f74625ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->