### PR TITLE
helm: specify deployment component in container name

### DIFF
--- a/k8s/prime-rl/templates/deployment.yaml
+++ b/k8s/prime-rl/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-      - name: prime-rl
+      - name: prime-rl-orchestrator
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- if .Values.orchestrator.autoStart }}
@@ -133,7 +133,7 @@ spec:
       runtimeClassName: {{ .Values.inference.runtimeClassName }}
       {{- end }}
       containers:
-      - name: prime-rl
+      - name: prime-rl-inference
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- if .Values.inference.autoStart }}
@@ -262,7 +262,7 @@ spec:
       runtimeClassName: {{ .Values.trainer.runtimeClassName }}
       {{- end }}
       containers:
-      - name: prime-rl
+      - name: prime-rl-trainer
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- if .Values.trainer.autoStart }}


### PR DESCRIPTION
just a small qol improvement

the k8s container name is commonly used in a lot of the community grafana dashboards, for example i use victorialogs on my k8s cluster and use their dashboard for logs so currently all the `prime-rl` logs get clumped together since they all have the same `prime-rl` container name:
<img width="1432" height="876" alt="Screenshot 2026-02-15 at 12 21 29 PM" src="https://github.com/user-attachments/assets/0be5936a-9921-4ee5-8ac9-9282eaf4ba8d" />

i could also just use the [role](https://github.com/PrimeIntellect-ai/prime-rl/blob/main/k8s/prime-rl/templates/deployment.yaml#L17) label to filter the logs, but i think it would be nicer if this would just work out of the box using the container name since it's a commonly used thing for dashboards

## Testing
after change:
<img width="1414" height="746" alt="Screenshot 2026-02-15 at 12 36 23 PM" src="https://github.com/user-attachments/assets/afe9f4b8-7585-4047-b23e-bea1b46ebd1a" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> YAML-only change that renames container identifiers; runtime behavior is unchanged, but any external tooling that selects containers by the old name will need updating.
> 
> **Overview**
> Updates the Helm `deployment.yaml` StatefulSet templates to use distinct container names per component (`prime-rl-orchestrator`, `prime-rl-inference`, `prime-rl-trainer`) instead of a shared `prime-rl` name, improving log/metrics/dashboard filtering by container.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 810244796c55bc089d7d68396e75930163f25d22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->