### PR TITLE
Max Tokens Optimizer

### DIFF
--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -268,6 +268,33 @@ class EvalSaveHFConfig(BaseConfig):
     ] = False
 
 
+class MaxTokensControllerConfig(BaseConfig):
+    """Adaptively adjusts max_tokens per environment based on observed reward."""
+
+    target_reward: Annotated[float, Field(ge=0, le=1, description="Target reward to drive each environment toward.")]
+    step_size: Annotated[int, Field(ge=1, description="Amount to increase or decrease max_tokens per step.")] = 32
+    momentum: Annotated[float, Field(ge=0, le=1, description="EMA momentum for smoothing reward signal.")] = 0.9
+    min_max_tokens: Annotated[int, Field(ge=1, description="Lower bound for max_tokens.")] = 64
+    max_max_tokens: Annotated[int, Field(ge=1, description="Upper bound for max_tokens.")] = 32768
+    initial_max_tokens: Annotated[
+        int | None,
+        Field(ge=1, description="Initial max_tokens. Falls back to SamplingConfig.max_tokens if None."),
+    ] = None
+    truncation_threshold: Annotated[
+        float,
+        Field(ge=0, le=1, description="Don't decrease max_tokens when truncation rate exceeds this threshold."),
+    ] = 0.1
+
+    @model_validator(mode="after")
+    def validate_bounds(self):
+        if self.min_max_tokens > self.max_max_tokens:
+            raise ValueError("min_max_tokens must be <= max_max_tokens")
+        if self.initial_max_tokens is not None:
+            if not (self.min_max_tokens <= self.initial_max_tokens <= self.max_max_tokens):
+                raise ValueError("initial_max_tokens must be within [min_max_tokens, max_max_tokens]")
+        return self
+
+
 class EnvConfig(BaseConfig):
     """Configures an environment for training."""
 
@@ -288,6 +315,10 @@ class EnvConfig(BaseConfig):
             ),
         ),
     ] = {}
+    max_tokens_controller: Annotated[
+        MaxTokensControllerConfig | None,
+        Field(description="Adaptive max_tokens controller config. If None, uses the global sampling max_tokens."),
+    ] = None
 
 
 class EvalEnvConfig(EnvConfig):
@@ -805,6 +836,18 @@ class OrchestratorConfig(BaseSettings):
             # extra_env_kwargs is not meant to be used by the user, we shamelessly override here
             env.extra_env_kwargs.update(train_extra_env_kwargs)
 
+        return self
+
+    @model_validator(mode="after")
+    def validate_max_tokens_controller(self):
+        for env in self.env:
+            if env.max_tokens_controller is not None:
+                ctrl = env.max_tokens_controller
+                if ctrl.initial_max_tokens is None and self.sampling.max_tokens is None:
+                    raise ValueError(
+                        f"Environment '{env.name or env.id}' has a max_tokens_controller but neither "
+                        "controller.initial_max_tokens nor sampling.max_tokens is set."
+                    )
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -226,7 +226,17 @@ async def orchestrate(config: OrchestratorConfig):
     # Setup buffer
     logger.info(f"Setting up buffer ({config.buffer})")
     train_dataset = train_env_group.get_dataset(seed=config.buffer.seed)
-    buffer = Buffer(train_dataset, train_env_group.env_names, config.buffer)
+    max_tokens_controllers = {}
+    for env_config, env_name in zip(config.env, train_env_group.env_names):
+        if env_config.max_tokens_controller is not None:
+            max_tokens_controllers[env_name] = env_config.max_tokens_controller
+    buffer = Buffer(
+        train_dataset,
+        train_env_group.env_names,
+        config.buffer,
+        max_tokens_controllers=max_tokens_controllers or None,
+        initial_max_tokens=config.sampling.max_tokens,
+    )
     if config.val is not None:
         val_buffer_config = BufferConfig(env_ratios=config.buffer.env_ratios)
         val_dataset = train_env_group.get_eval_dataset(seed=val_buffer_config.seed)


### PR DESCRIPTION
Adds a per-environment `max_tokens` controller that automatically adjusts `max_tokens` based on observed reward. Each env is driven toward a configurable target reward using an EMA-smoothed signal: if reward is too low and rollouts are being truncated, `max_tokens` increases; if reward is too high and truncation is minimal, it decreases. This forces the model to use more tokens on hard problems and fewer on easy ones, without manual tuning.

How it works

- New `MaxTokensControllerConfig` on `EnvConfig` (optional, per-env)
- Buffer accumulates per-env reward and truncation stats each batch, then applies a step adjustment with clamping
- Scheduler reads the per-env `max_tokens` from the buffer when scheduling each rollout
- Controller state (EMA, current max_tokens) is checkpointed with the buffer