### PR TITLE
make odf enforced as on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Documenting changes which affect configuration usage patterns (added/moved/remov
 - **`EvalSaveDiskConfig`**, **`EvalSaveConfig`**, **`RetryConfig`**, **`OnlineEvalConfig`**: Removed (2026-02-06)
 - **`TemperatureScheduleConfig`**: Renamed to `TemperatureSchedulerConfig` (2026-02-06)
 - **`optim.mu`**: Added Muon momentum (`mu`) config field (default: 0.95). Previously hardcoded to Muon class default. Also fixed `optim.betas1`/`optim.betas2` not being passed through to the Muon optimizer (2026-02-09)
-- **`dump_config`**: Added `--dump-config <path>` flag to the `rl` command. When set, writes the resolved subconfigs (trainer, orchestrator, inference, teacher_inference) to the given directory and exits without starting any processes (2026-02-12
+- **`dump_config`**: Added `--dump-config <path>` flag to the `rl` command. When set, writes the resolved subconfigs (trainer, orchestrator, inference, teacher_inference) to the given directory and exits without starting any processes (2026-02-12)
 - **`client.api_key_var`**: Changed default from "OPENAI_API_KEY" to "VLLM_API_KEY" (2026-02-12)
+- **`orchestrator.buffer.online_difficulty_filtering`**: Removed. Online difficulty filtering is now always enabled when verification is on, and automatically bypassed when `orchestrator.buffer.skip_verification=true` (2026-02-16)
 

--- a/configs/wiki_search/rl.toml
+++ b/configs/wiki_search/rl.toml
@@ -36,9 +36,6 @@ oversampling_factor = 2.0
 [orchestrator.sampling]
 max_tokens = 512
 
-[orchestrator.buffer]
-online_difficulty_filtering = true
-
 [[orchestrator.env]]
 id = "primeintellect/wiki-search"
 

--- a/examples/wiki_search/rl.toml
+++ b/examples/wiki_search/rl.toml
@@ -39,9 +39,6 @@ name = "qwen3-4b-wiki-search"
 [orchestrator.sampling]
 max_tokens = 512
 
-[orchestrator.buffer]
-online_difficulty_filtering = true
-
 [[orchestrator.env]]
 id = "primeintellect/wiki-search"
 

--- a/src/prime_rl/orchestrator/buffer.py
+++ b/src/prime_rl/orchestrator/buffer.py
@@ -231,7 +231,7 @@ class Buffer:
                 target_pool.append(example)
 
             self.num_examples_per_step[env_name][pool] += 1
-            if self.config.online_difficulty_filtering:
+            if not self.config.skip_verification:
                 if avg_reward == 0.0:
                     self.num_rollouts_per_step[env_name]["hard"] += len(example_rollouts)
                     continue

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -481,13 +481,6 @@ class BufferConfig(BaseConfig):
         ),
     ] = 0.0
 
-    online_difficulty_filtering: Annotated[
-        bool,
-        Field(
-            description="Whether to filter rollouts based on difficulty. If True, rollouts with average reward 0.0 or 1.0 are not added to the buffer.",
-        ),
-    ] = False
-
     hash_keys: Annotated[
         list[str],
         Field(
@@ -501,8 +494,7 @@ class BufferConfig(BaseConfig):
         Field(
             description=(
                 "Whether to skip verification of rollouts using the environment's rubric. "
-                "If True, rewards are always set to 0, online_difficulty_filtering is disabled, "
-                "and easy/hard thresholds are not used."
+                "If True, rewards are always set to 0 and easy/hard thresholds are not used."
             ),
         ),
     ] = False
@@ -523,11 +515,6 @@ class BufferConfig(BaseConfig):
     def validate_skip_verification(self):
         """Validate that skip_verification is not used with reward-dependent features."""
         if self.skip_verification:
-            if self.online_difficulty_filtering:
-                raise ValueError(
-                    "skip_verification cannot be True when online_difficulty_filtering is True. "
-                    "These features depend on rewards which are disabled when skip_verification=True."
-                )
             if self.easy_threshold is not None:
                 raise ValueError(
                     "skip_verification cannot be True when easy_threshold is set. "

--- a/tests/unit/orchestrator/test_buffer.py
+++ b/tests/unit/orchestrator/test_buffer.py
@@ -108,24 +108,20 @@ def test_buffer_problem_pool_assignment(dummy_env_group, make_rollouts):
 
 
 def test_buffer_online_difficulty_filtering(dummy_env_group, make_rollouts):
-    """With online_difficulty_filtering=True, only partial reward rollouts are kept."""
+    """Extreme rewards are filtered out by default."""
     dataset = dummy_env_group.get_dataset()
-    buffer = Buffer(
-        dataset,
-        dummy_env_group.env_names,
-        BufferConfig(online_difficulty_filtering=True),
-    )
+    buffer = Buffer(dataset, dummy_env_group.env_names, BufferConfig())
     buffer.update(make_rollouts(dataset.select(range(5)), rewards=[1.0, 0.5, 0.0, 0.5, 0.5]))
 
     # Only 3 problems with reward 0.5 -> 6 rollouts kept
     assert len(buffer.rollout_buffer) == 6
 
 
-def test_buffer_no_filtering_by_default(dummy_env_group, make_rollouts):
-    """With online_difficulty_filtering=False (default), all rollouts are kept."""
+def test_buffer_skip_verification_disables_filtering(dummy_env_group, make_rollouts):
+    """When verification is skipped, reward-based filtering is bypassed."""
     dataset = dummy_env_group.get_dataset()
-    buffer = Buffer(dataset, dummy_env_group.env_names, BufferConfig())
-    buffer.update(make_rollouts(dataset.select(range(5)), rewards=[1.0, 0.5, 0.0, 0.5, 0.5]))
+    buffer = Buffer(dataset, dummy_env_group.env_names, BufferConfig(skip_verification=True))
+    buffer.update(make_rollouts(dataset.select(range(5)), rewards=[0.0, 0.0, 0.0, 0.0, 0.0]))
 
     # All 5 problems -> 10 rollouts kept
     assert len(buffer.rollout_buffer) == 10


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core rollout buffering behavior and removes a config knob; existing training runs may see different sample composition or break if they still set the removed field.
> 
> **Overview**
> Online difficulty filtering is now **always applied** when rollout verification is enabled: the buffer drops examples whose average reward is exactly `0.0` or `1.0`, and this filtering is bypassed only when `orchestrator.buffer.skip_verification=true`.
> 
> This removes the `orchestrator.buffer.online_difficulty_filtering` config flag (and related validation), updates wiki-search example configs accordingly, refreshes unit tests to reflect the new default behavior, and documents the breaking config change in the changelog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1478cd7afab35df08755a06f9962e03a72061139. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->