### PR TITLE
Fix B200/Blackwell support: rollback flash-attn to 2.8.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,8 @@ sft = "prime_rl.trainer.sft.train:main"
 
 [project.optional-dependencies]
 flash-attn = [
-    "flash-attn @ https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.7.16/flash_attn-2.6.3%2Bcu128torch2.10-cp312-cp312-linux_x86_64.whl",
+    # NOTE: v0.7.16 wheel (2.6.3) doesn't support B200/sm_100, v0.6.8 (2.8.3) does
+    "flash-attn @ https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.6.8/flash_attn-2.8.3+cu128torch2.9-cp312-cp312-linux_x86_64.whl",
 ]
 flash-attn-3 = [
     "flash_attn_3 @ https://github.com/samsja/flash-attn-builds/releases/download/v0.1/flash_attn_3-3.0.0b1-cp39-abi3-linux_x86_64.whl",


### PR DESCRIPTION
## Summary
- Rollback flash-attn from v0.7.16 (2.6.3) to v0.6.8 (2.8.3)
- v0.7.16 wheel doesn't include sm_100 kernels, breaking B200 GPUs
- v0.6.8 wheel has sm_100 support

## Problem
B200 trainer pods crash with:
```
RuntimeError: FlashAttention only supports Ampere GPUs or newer.
```

## Root cause
The v0.7.16 prebuilt wheel was compiled without sm_100 (Blackwell) kernels.
The v0.6.8 wheel includes them and works on B200.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dependency URL/version change limited to an optional extra; risk is mainly runtime compatibility/performance differences for users enabling `flash-attn`.
> 
> **Overview**
> Updates the `flash-attn` optional dependency to use an older prebuilt wheel (`v0.6.8` / `flash_attn 2.8.3`) instead of `v0.7.16` (`2.6.3`), with an inline note explaining this restores Blackwell B200 (`sm_100`) kernel support.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91c74978d4e1c74f4360dc98d9eaab1e1278dcde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->