### PR TITLE
fix env server deadlock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ override-dependencies = [
 
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "786d300" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "e629347" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eeb" }
 transformers = { git = "https://github.com/huggingface/transformers.git", rev = "609e3d5" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ override-dependencies = [
 
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "e629347" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "ad77074" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eeb" }
 transformers = { git = "https://github.com/huggingface/transformers.git", rev = "609e3d5" }

--- a/uv.lock
+++ b/uv.lock
@@ -2358,7 +2358,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", git = "https://github.com/huggingface/transformers.git?rev=609e3d5" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=e629347" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=ad77074" },
     { name = "vllm", url = "https://github.com/vllm-project/vllm/releases/download/v0.16.0/vllm-0.16.0-cp38-abi3-manylinux_2_31_x86_64.whl" },
     { name = "wandb", specifier = ">=0.24.2" },
 ]
@@ -3687,7 +3687,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.11.dev0"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=e629347#e629347daee0f7b8e75b8c379dbd25295eb44b38" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=ad77074#ad77074e6e8585242425aabd598fc102584a0777" }
 dependencies = [
     { name = "anthropic" },
     { name = "datasets" },

--- a/uv.lock
+++ b/uv.lock
@@ -2358,7 +2358,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", git = "https://github.com/huggingface/transformers.git?rev=609e3d5" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=786d300" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=e629347" },
     { name = "vllm", url = "https://github.com/vllm-project/vllm/releases/download/v0.16.0/vllm-0.16.0-cp38-abi3-manylinux_2_31_x86_64.whl" },
     { name = "wandb", specifier = ">=0.24.2" },
 ]
@@ -3687,7 +3687,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.11.dev0"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=786d300#786d300bf5aab105279fc542dda838beafcb025e" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=e629347#e629347daee0f7b8e75b8c379dbd25295eb44b38" }
 dependencies = [
     { name = "anthropic" },
     { name = "datasets" },


### PR DESCRIPTION
bumps verifiers to include a critical bug fix which would lead to deadlocking the training due to a race in the zmq env server, specifically when running validation tasks interleaved with continuously batched training tasks. for details check the verifiers fix pr ([#921](https://github.com/PrimeIntellect-ai/verifiers/pull/921)). also uses `spawn` method to not shared file descriptors for train and eval env servers. 

minimal repro

```bash
uv run orchestrator --model.name deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B --batch-size 1024 --rollouts-per-example 16 --sampling.max-tokens 2048 --env '[{"id": "primeintellect/math-env", "args": {"dataset_name": "PrimeIntellect/Hendrycks-Math", "dataset_subset": "default"}}]' --val.interval 1 --val.num-examples 128 --max-async-level 5 --log.level debug --log.vf-level debug
```

this command (orchestrator of the hendrycks-math nightly run) would hang before the fix after a couple of steps, but now runs without problems

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiprocessing process creation and bumps the `verifiers` dependency to address ZMQ env-server deadlocks; behavior can differ across platforms and could surface new process/lifecycle issues despite being a targeted fix.
> 
> **Overview**
> Fixes orchestrator hangs when running rollout and validation env servers concurrently by **switching env-server subprocess creation to `spawn`** (via `mp.get_context("spawn").Process`) to avoid inheriting shared file descriptors.
> 
> Also **bumps the `verifiers` git dependency** (`786d300` → `ad77074`) and updates `uv.lock` to pull in an upstream ZMQ env-server race/deadlock fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01e32acf09feaa90a3997ef722556ea9feaa9897. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->