### PR TITLE
optionally cancel inflight rollouts before eval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Documenting changes which affect configuration usage patterns (added/moved/remov
 - **`EvalSaveDiskConfig`**, **`EvalSaveConfig`**, **`RetryConfig`**, **`OnlineEvalConfig`**: Removed (2026-02-06)
 - **`TemperatureScheduleConfig`**: Renamed to `TemperatureSchedulerConfig` (2026-02-06)
 - **`optim.mu`**: Added Muon momentum (`mu`) config field (default: 0.95). Previously hardcoded to Muon class default. Also fixed `optim.betas1`/`optim.betas2` not being passed through to the Muon optimizer (2026-02-09)
-- **`dump_config`**: Added `--dump-config <path>` flag to the `rl` command. When set, writes the resolved subconfigs (trainer, orchestrator, inference, teacher_inference) to the given directory and exits without starting any processes (2026-02-12
+- **`dump_config`**: Added `--dump-config <path>` flag to the `rl` command. When set, writes the resolved subconfigs (trainer, orchestrator, inference, teacher_inference) to the given directory and exits without starting any processes (2026-02-12)
 - **`client.api_key_var`**: Changed default from "OPENAI_API_KEY" to "VLLM_API_KEY" (2026-02-12)
+- **`orchestrator.eval.cancel_inflight_rollouts_on_eval`**: Added flag to optionally cancel in-flight training rollouts before starting online evals. When enabled, avoids congestion by preventing training and eval rollouts from running simultaneously, but slows training as the rollout pipeline must refill after each eval (default: False) (2026-02-16)
 

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -376,6 +376,13 @@ class EvalConfig(BaseConfig):
         ),
     ] = True
 
+    cancel_inflight_rollouts_on_eval: Annotated[
+        bool,
+        Field(
+            description="Whether to cancel in-flight training rollouts before starting online evals. This is useful to avoid congestion (e.g. do not have training + eval rollouts happening at the same time) but leads to slower training steps as rollouts get cancelled and the pipeline has to fill up after each eval",
+        ),
+    ] = False
+
 
 class CheckpointConfig(BaseConfig):
     """Configures checkpointing the orchestrator."""

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -95,11 +95,8 @@ class Scheduler:
         """Update sampling args for future rollout requests."""
         self.sampling_args = sampling_args
 
-    def cancel_all_inflight_rollouts(self):
-        """Cancel all in-flight rollout requests.
-
-        Used when weights are updated to discard stale rollouts generated with old weights.
-        """
+    def cancel_inflight_rollouts(self):
+        """Cancel all in-flight rollout requests."""
         count = len(self.inflight_group_rollouts)
         for future in list(self.inflight_group_rollouts.keys()):
             if not future.done():


### PR DESCRIPTION
previously, we would always cancel all in-flight rollouts before starting online evals. this can lose a lot of progress and results in large (first) step times after each online eval step because the pipeline has to refill from scratch. this pr makes this configurable and changes the default to not cancel them for improved efficiency. the flag should be turned on if one expects that the in-flight training + eval rollouts would overload the inference server

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches orchestrator scheduling/eval coordination; misconfiguration could increase inference load during evals or change throughput/step timing, but the change is small and defaults to the safer non-cancelling behavior.
> 
> **Overview**
> Online eval no longer *always* cancels in-flight training rollouts; cancellation is now gated by a new `orchestrator.eval.cancel_inflight_rollouts_on_eval` flag (default `False`). This keeps the rollout pipeline warm across evals unless explicitly enabled for heavy eval workloads to avoid inference congestion.
> 
> Renames scheduler API from `cancel_all_inflight_rollouts()` to `cancel_inflight_rollouts()` and updates orchestrator shutdown/eval call sites accordingly, and documents the new config in the changelog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f553b46b70bfaa284c148f6b8d2ae1b423d490e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->