### PR TITLE
configure default logger instead of raise

### DIFF
--- a/src/prime_rl/utils/logger.py
+++ b/src/prime_rl/utils/logger.py
@@ -189,6 +189,8 @@ def get_logger():
 def reset_logger():
     """Reset the logger. Useful mainly in tests."""
     global _LOGGER, _JSON_LOGGING
+    if _LOGGER is not None:
+        _LOGGER.remove()
     _LOGGER = None
     _JSON_LOGGING = False
 

--- a/src/prime_rl/utils/logger.py
+++ b/src/prime_rl/utils/logger.py
@@ -111,6 +111,10 @@ def setup_logger(
     global _LOGGER, _JSON_LOGGING
     _JSON_LOGGING = json_logging
 
+    # Clean up old logger instance to prevent resource leaks
+    if _LOGGER is not None:
+        _LOGGER.remove()
+
     # Format message with optional tag prefix
     tag_prefix = f"[{tag}] " if tag else ""
     message = "".join(

--- a/src/prime_rl/utils/logger.py
+++ b/src/prime_rl/utils/logger.py
@@ -14,7 +14,7 @@ NO_BOLD = "\033[22m"
 RESET = "\033[0m"
 
 
-def _build_log_entry(record) -> dict:
+def build_log_entry(record) -> dict:
     """Build a flat JSON log entry from a loguru record."""
     extra = record["extra"]
 
@@ -54,14 +54,14 @@ def _build_log_entry(record) -> dict:
     return log_entry
 
 
-def _json_sink(message) -> None:
+def json_sink(message) -> None:
     """Sink that outputs flat JSON to stdout for log aggregation (Loki, Grafana, etc.)."""
-    log_entry = _build_log_entry(message.record)
+    log_entry = build_log_entry(message.record)
     sys.stdout.write(json_module.dumps(log_entry) + "\n")
     sys.stdout.flush()
 
 
-class _JsonFileSink:
+class JsonFileSink:
     """File sink that keeps the handle open and writes flat JSON lines."""
 
     def __init__(self, log_file: Path):
@@ -74,7 +74,7 @@ class _JsonFileSink:
             self._file.close()
 
     def write(self, message) -> None:
-        log_entry = _build_log_entry(message.record)
+        log_entry = build_log_entry(message.record)
         self._file.write(json_module.dumps(log_entry) + "\n")
         self._file.flush()
 
@@ -102,15 +102,13 @@ class InterceptHandler(logging.Handler):
 
 
 def setup_logger(
-    log_level: str,
+    log_level: str = "info",
     log_file: Path | None = None,
     append: bool = False,
     tag: str | None = None,
     json_logging: bool = False,
 ):
     global _LOGGER, _JSON_LOGGING
-    if _LOGGER is not None:
-        raise RuntimeError("Logger already set. Please call `setup_logger` only once.")
     _JSON_LOGGING = json_logging
 
     # Format message with optional tag prefix
@@ -154,7 +152,7 @@ def setup_logger(
 
     # Install console handler (enqueue=True only for JSON mode to avoid blocking in async contexts)
     if json_logging:
-        logger.add(_json_sink, level=log_level.upper(), enqueue=True)
+        logger.add(json_sink, level=log_level.upper(), enqueue=True)
     else:
         logger.add(sys.stdout, format=format, level=log_level.upper(), colorize=True)
 
@@ -163,7 +161,7 @@ def setup_logger(
         if not append and log_file.exists():
             log_file.unlink()
         if json_logging:
-            file_sink = _JsonFileSink(log_file)
+            file_sink = JsonFileSink(log_file)
             logger.add(file_sink.write, level=log_level.upper(), enqueue=True)
         else:
             logger.add(log_file, format=format, level=log_level.upper(), colorize=True)
@@ -178,22 +176,14 @@ def setup_logger(
 
 
 def get_logger():
-    """
-    Get the global logger. This function is shared across submodules such as
-    training and inference to access the global logger instance. Raises if the
-    logger has not been set.
-
-    Returns:
-        The global logger.
-    """
     global _LOGGER
     if _LOGGER is None:
-        raise RuntimeError("Logger not set. Please call `set_logger` first.")
+        _LOGGER = setup_logger()
     return _LOGGER
 
 
 def reset_logger():
-    """Reset the global logger. Useful mainly in test to clear loggers between tests."""
+    """Reset the logger. Useful mainly in tests."""
     global _LOGGER, _JSON_LOGGING
     _LOGGER = None
     _JSON_LOGGING = False


### PR DESCRIPTION
two changes to logging:
1. `setup_logger` does not raise on multiple calls. from now on, may be called multiple times, with each call overwriting the previous global logger instance
2. `get_logger` does not raise if no logger was setup prior but will setup a default logger if none available yet

this e.g. allows to import prime-rl utils and functions without raising because no logger has been setup yet

```bash
❯ uv run python
Python 3.12.12 (main, Dec  2 2025, 19:47:35) [Clang 21.1.4 ] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from prime_rl.utils.utils import install_env
>>> install_env("primeintellect/wordle")
15:51:54    INFO Installing environment primeintellect/wordle
15:52:00    INFO Successfully installed environment primeintellect/wordle
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global logging lifecycle behavior (lazy init + reconfiguration), which can affect log routing/formatting and sink cleanup across long-running processes, but is localized to `utils/logger.py`.
> 
> **Overview**
> Removes the hard failure modes around logging by making `setup_logger()` **idempotent**: repeated calls now remove the previous global Loguru sinks and replace the global `_LOGGER` instead of raising.
> 
> Updates `get_logger()` to **lazily create a default logger** (`setup_logger()` with default `log_level="info"`) when accessed before explicit setup, and adds cleanup in `reset_logger()` to remove sinks to avoid resource leaks. Also renames the internal JSON helpers/sinks (`_build_log_entry`, `_json_sink`, `_JsonFileSink`) to public names and sets a default `log_level` parameter.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd1be86cfa00504ca126cf7decc7ecca7cf8dc02. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->