### PR TITLE
fix resume from latest step for single-run

### DIFF
--- a/src/prime_rl/orchestrator/ckpt.py
+++ b/src/prime_rl/orchestrator/ckpt.py
@@ -29,6 +29,11 @@ class CheckpointManager:
     def get_ckpt_path(self, step: int) -> Path:
         return get_step_path(self.ckpt_dir, step) / "orchestrator"
 
+    def mark_stable(self, step: int) -> None:
+        """Write STABLE file to indicate checkpoint is complete."""
+        step_path = get_step_path(self.ckpt_dir, step)
+        (step_path / "STABLE").touch()
+
     def _save_to_path(
         self,
         ckpt_path: Path,
@@ -88,6 +93,7 @@ class CheckpointManager:
         ckpt_path = self.get_ckpt_path(step)
         ckpt_path.mkdir(parents=True, exist_ok=True)
         self._save_to_path(ckpt_path, progress, buffer)
+        self.mark_stable(step)
 
 
 def setup_ckpt_manager(output_dir: Path, config: CheckpointConfig | None) -> CheckpointManager | None:

--- a/src/prime_rl/orchestrator/ckpt.py
+++ b/src/prime_rl/orchestrator/ckpt.py
@@ -29,11 +29,6 @@ class CheckpointManager:
     def get_ckpt_path(self, step: int) -> Path:
         return get_step_path(self.ckpt_dir, step) / "orchestrator"
 
-    def mark_stable(self, step: int) -> None:
-        """Write STABLE file to indicate checkpoint is complete."""
-        step_path = get_step_path(self.ckpt_dir, step)
-        (step_path / "STABLE").touch()
-
     def save_to_path(
         self,
         ckpt_path: Path,
@@ -93,7 +88,6 @@ class CheckpointManager:
         ckpt_path = self.get_ckpt_path(step)
         ckpt_path.mkdir(parents=True, exist_ok=True)
         self.save_to_path(ckpt_path, progress, buffer)
-        self.mark_stable(step)
 
 
 def setup_ckpt_manager(output_dir: Path, config: CheckpointConfig | None) -> CheckpointManager | None:

--- a/src/prime_rl/orchestrator/ckpt.py
+++ b/src/prime_rl/orchestrator/ckpt.py
@@ -34,7 +34,7 @@ class CheckpointManager:
         step_path = get_step_path(self.ckpt_dir, step)
         (step_path / "STABLE").touch()
 
-    def _save_to_path(
+    def save_to_path(
         self,
         ckpt_path: Path,
         progress: Progress,
@@ -52,7 +52,7 @@ class CheckpointManager:
 
         self.logger.debug(f"Orchestrator checkpoint saved in {time.perf_counter() - start_time:.2f} seconds")
 
-    def _load_from_path(self, ckpt_path: Path, progress: Progress, buffer: Buffer) -> None:
+    def load_from_path(self, ckpt_path: Path, progress: Progress, buffer: Buffer) -> None:
         """Loads a checkpoint from a given path in-place."""
         self.logger.debug(f"Loading checkpoint from {ckpt_path}")
         start_time = time.perf_counter()
@@ -81,7 +81,7 @@ class CheckpointManager:
         ckpt_path = self.get_ckpt_path(step)
         if not ckpt_path.exists():
             raise FileNotFoundError(f"Checkpoint not found at {ckpt_path}")
-        self._load_from_path(ckpt_path, progress, buffer)
+        self.load_from_path(ckpt_path, progress, buffer)
 
     def save(
         self,
@@ -92,7 +92,7 @@ class CheckpointManager:
         """Saves the full checkpoint state for a specified step."""
         ckpt_path = self.get_ckpt_path(step)
         ckpt_path.mkdir(parents=True, exist_ok=True)
-        self._save_to_path(ckpt_path, progress, buffer)
+        self.save_to_path(ckpt_path, progress, buffer)
         self.mark_stable(step)
 
 

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -299,7 +299,7 @@ class WeightCheckpointManager:
         return get_step_path(self.weights_dir, step)
 
     def mark_stable(self, step: int) -> None:
-        """Write STABLE file to indicate checkpoint is complete (for eval to safely read)."""
+        """Write STABLE file to indicate weight checkpoint is complete."""
         if self.world.is_master:
             step_path = self.get_step_path(step)
             (step_path / "STABLE").touch()
@@ -313,44 +313,45 @@ class WeightCheckpointManager:
         tokenizer: PreTrainedTokenizer,
     ):
         """Save HF-compatible weight checkpoint to a given path."""
-        path.mkdir(parents=True, exist_ok=True)
-        start_time = time.perf_counter()
+        if self.world.is_master:
+            path.mkdir(parents=True, exist_ok=True)
+            start_time = time.perf_counter()
 
-        self.logger.debug(f"Saving weight checkpoint to {path}")
-        # Suppress torch.distributed warnings during checkpoint saving
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=FutureWarning, module="torch.distributed")
-            warnings.filterwarnings("ignore", category=UserWarning, module="torch.distributed.*")
+            self.logger.debug(f"Saving weight checkpoint to {path}")
+            # Suppress torch.distributed warnings during checkpoint saving
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=FutureWarning, module="torch.distributed")
+                warnings.filterwarnings("ignore", category=UserWarning, module="torch.distributed.*")
 
-            # Save weights
-            save_state_dict(state_dict, path, self.config.save_format, self.config.save_sharded)
+                # Save weights
+                save_state_dict(state_dict, path, self.config.save_format, self.config.save_sharded)
 
-            # Save model config, generation arguments and tokenizer
-            model.config.save_pretrained(path)
-            if model.generation_config:
-                # training sets use_cache=False which can conflict with
-                # cache_implementation — save with use_cache=True without
-                # mutating the model's config
-                from copy import deepcopy
+                # Save model config, generation arguments and tokenizer
+                model.config.save_pretrained(path)
+                if model.generation_config:
+                    # training sets use_cache=False which can conflict with
+                    # cache_implementation — save with use_cache=True without
+                    # mutating the model's config
+                    from copy import deepcopy
 
-                gen_config = deepcopy(model.generation_config)
-                gen_config.use_cache = True
-                gen_config.save_pretrained(path)
-            tokenizer.save_pretrained(path)
+                    gen_config = deepcopy(model.generation_config)
+                    gen_config.use_cache = True
+                    gen_config.save_pretrained(path)
+                tokenizer.save_pretrained(path)
 
-        if self.config.save_adapter_separately and lora_state_dict is not None:
-            adapter_path = path / "lora_adapters"
-            adapter_path.mkdir(parents=True, exist_ok=True)
-            torch.save(lora_state_dict, adapter_path / "adapter_model.bin")
-            if self.lora_config:
-                save_lora_config(
-                    model,
-                    adapter_path,
-                    rank=self.lora_config.rank,
-                    alpha=self.lora_config.alpha,
-                    dropout=self.lora_config.dropout,
-                )
-        self.logger.debug(f"Saved weight checkpoint to {path} in {time.perf_counter() - start_time:.2f} seconds")
+            if self.config.save_adapter_separately and lora_state_dict is not None:
+                adapter_path = path / "lora_adapters"
+                adapter_path.mkdir(parents=True, exist_ok=True)
+                torch.save(lora_state_dict, adapter_path / "adapter_model.bin")
+                if self.lora_config:
+                    save_lora_config(
+                        model,
+                        adapter_path,
+                        rank=self.lora_config.rank,
+                        alpha=self.lora_config.alpha,
+                        dropout=self.lora_config.dropout,
+                    )
+            self.logger.debug(f"Saved weight checkpoint to {path} in {time.perf_counter() - start_time:.2f} seconds")
 
     def save(
         self,
@@ -399,9 +400,8 @@ class WeightCheckpointManager:
             self.logger.debug(f"Reverted to HF hub format in {time.perf_counter() - start_time:.2f} seconds")
 
         # Save weight checkpoint on master rank
-        if self.world.is_master:
-            self.save_to_path(step_path, state_dict, lora_state_dict, model, tokenizer)
-            self.mark_stable(step)
+        self.save_to_path(step_path, state_dict, lora_state_dict, model, tokenizer)
+        self.mark_stable(step)
         bisect.insort(self.ckpt_steps, step)
 
     def maybe_clean(self) -> None:

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -401,7 +401,7 @@ class WeightCheckpointManager:
         # Save weight checkpoint on master rank
         if self.world.is_master:
             self.save_to_path(step_path, state_dict, lora_state_dict, model, tokenizer)
-        self.mark_stable(step)
+            self.mark_stable(step)
         bisect.insort(self.ckpt_steps, step)
 
     def maybe_clean(self) -> None:

--- a/src/prime_rl/trainer/runs.py
+++ b/src/prime_rl/trainer/runs.py
@@ -11,7 +11,7 @@ import torch.distributed.distributed_c10d as c10d
 from prime_rl.trainer.config import LoRAConfig
 from prime_rl.trainer.world import get_world
 from prime_rl.utils.logger import get_logger
-from prime_rl.utils.pathing import get_all_ckpt_steps
+from prime_rl.utils.pathing import get_all_ckpt_steps, get_stable_ckpt_steps
 
 if TYPE_CHECKING:
     from prime_rl.orchestrator.config import OrchestratorConfig
@@ -264,10 +264,11 @@ class MultiRunManager:
         if config.ckpt is None or config.ckpt.resume_step is None:
             self.progress[new_id].step = 0
         elif config.ckpt.resume_step == -1:
-            # We don't require the STABLE file here because single-run trainer's dont write
-            # a STABLE file into the run dirs so no ckpts are detected there.
-            stable_steps = get_all_ckpt_steps(self.get_run_dir(new_id) / "checkpoints")
-            self.progress[new_id].step = max(stable_steps) if stable_steps else 0
+            ckpt_dir = self.get_run_dir(new_id) / "checkpoints"
+            # In multi-run, the trainer writes STABLE after saving LoRA weights to the run's checkpoint dir.
+            # In single-run, only the orchestrator writes checkpoints here (trainer has its own dir), so no STABLE exists.
+            steps = get_stable_ckpt_steps(ckpt_dir) if self.max_runs > 1 else get_all_ckpt_steps(ckpt_dir)
+            self.progress[new_id].step = max(steps) if steps else 0
         else:
             self.progress[new_id].step = config.ckpt.resume_step
 

--- a/src/prime_rl/trainer/runs.py
+++ b/src/prime_rl/trainer/runs.py
@@ -11,7 +11,7 @@ import torch.distributed.distributed_c10d as c10d
 from prime_rl.trainer.config import LoRAConfig
 from prime_rl.trainer.world import get_world
 from prime_rl.utils.logger import get_logger
-from prime_rl.utils.pathing import get_stable_ckpt_steps
+from prime_rl.utils.pathing import get_all_ckpt_steps
 
 if TYPE_CHECKING:
     from prime_rl.orchestrator.config import OrchestratorConfig
@@ -264,7 +264,9 @@ class MultiRunManager:
         if config.ckpt is None or config.ckpt.resume_step is None:
             self.progress[new_id].step = 0
         elif config.ckpt.resume_step == -1:
-            stable_steps = get_stable_ckpt_steps(self.get_run_dir(new_id) / "checkpoints")
+            # We don't require the STABLE file here because single-run trainer's dont write
+            # a STABLE file into the run dirs so no ckpts are detected there.
+            stable_steps = get_all_ckpt_steps(self.get_run_dir(new_id) / "checkpoints")
             self.progress[new_id].step = max(stable_steps) if stable_steps else 0
         else:
             self.progress[new_id].step = config.ckpt.resume_step


### PR DESCRIPTION
## Summary

Fixes a resume bug where the trainer's resume logic (`resume_step: -1`) would fail to detect orchestrator checkpoints because STABLE marker files were not being created.

## Problem

When resuming a run with `resume_step: -1` (resume from latest checkpoint), the trainer looks for STABLE marker files to determine which step to resume from:
- In `src/prime_rl/trainer/runs.py:267`: `get_stable_ckpt_steps(run_dir / "checkpoints")`  
- In `src/prime_rl/trainer/multi_ckpt.py:194-198`: Similar logic for per-run checkpoints

Previously, only the trainer checkpoint manager created STABLE files. Orchestrator checkpoints existed but had no STABLE markers, causing the trainer to incorrectly default to step 0 even when orchestrator checkpoints existed at later steps.

## Solution

Do not require the run checkpoints directories to have a `STABLE` file to resume from it with `-1` for single-tenant runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches checkpoint save/resume logic and `STABLE`-marker semantics; mistakes could cause resuming from the wrong step or reading partially-written checkpoints, though the change is small and well-scoped.
> 
> **Overview**
> Fixes resume-from-latest (`resume_step: -1`) for *single-run* setups by selecting the latest checkpoint step from all `step_*` dirs (via `get_all_ckpt_steps`) instead of requiring `STABLE` marker files, which are only present in multi-run trainer-written checkpoints.
> 
> Refactors checkpoint utilities: orchestrator checkpoint helpers are made public (`save_to_path`/`load_from_path`), and `WeightCheckpointManager` centralizes `STABLE` creation in a new `mark_stable()` and ensures weight checkpoint writes only occur on the master rank before marking the step stable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 238276a98c9c22ae766b8b58ef59569e80bc745d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->