### PR TITLE
fix: pass max_retries to final eval call

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -747,6 +747,7 @@ async def orchestrate(config: OrchestratorConfig):
                     sampling_args=eval_sampling_args,
                     num_examples=eval_env_config.num_examples or config.eval.num_examples,
                     rollouts_per_example=eval_env_config.rollouts_per_example or config.eval.rollouts_per_example,
+                    max_retries=eval_env_config.max_retries,
                     ckpt_step=ckpt_step,
                     step=progress.step,
                 )


### PR DESCRIPTION
The final eval call (after the training loop) was missing `max_retries`, which is required by `evaluate_env()`. The periodic eval call during training already passed it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-parameter plumbing change in the final eval invocation; low likelihood of regressions outside evaluation retry behavior.
> 
> **Overview**
> Ensures the *final evaluation run after training* passes `max_retries` into `evaluate_env()` for each eval environment, aligning it with the in-loop periodic eval call and preventing missing-argument / retry-configuration issues at shutdown.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 550727075d031cc9ed9b3be9bc7ebbdf74bd1b93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->