### PR TITLE
Add MoE RL integration tests

### DIFF
--- a/configs/ci/integration/rl_moe/start.toml
+++ b/configs/ci/integration/rl_moe/start.toml
@@ -1,0 +1,27 @@
+inference_gpu_ids = [0]
+trainer_gpu_ids = [1]
+
+max_steps = 20
+seq_len = 2048
+
+[ckpt]
+
+[model]
+name = "samsja/mini-glm-moe"
+
+[trainer.optim]
+lr = 3e-6
+
+[orchestrator]
+batch_size = 128
+rollouts_per_example = 16
+
+[orchestrator.sampling]
+max_tokens = 128
+
+[[orchestrator.env]]
+id = "reverse-text"
+
+[inference]
+gpu-memory-utilization = 0.7
+model.max-model-len = 2048

--- a/tests/integration/test_rl_moe.py
+++ b/tests/integration/test_rl_moe.py
@@ -1,0 +1,104 @@
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+from tests.conftest import ProcessResult
+from tests.utils import check_no_error
+
+pytestmark = [pytest.mark.gpu, pytest.mark.slow]
+
+TIMEOUT = 900  # 15 minutes
+
+
+@pytest.fixture(scope="module")
+def wandb_name(branch_name: str) -> str:
+    return f"test-rl-moe-{branch_name}"
+
+
+# --- MoE with HF impl (default) ---
+
+
+@pytest.fixture(scope="module")
+def moe_hf_output_dir(output_dir: Path) -> Path:
+    d = output_dir / "rl_moe_hf"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+@pytest.fixture(scope="module")
+def moe_hf_process(
+    run_process: Callable[..., ProcessResult],
+    moe_hf_output_dir: Path,
+    wandb_project: str,
+    wandb_name: str,
+) -> ProcessResult:
+    cmd = [
+        "uv",
+        "run",
+        "rl",
+        "@",
+        "configs/ci/integration/rl_moe/start.toml",
+        "--trainer.model.impl",
+        "hf",
+        "--wandb.project",
+        wandb_project,
+        "--wandb.name",
+        f"{wandb_name}-hf",
+        "--output-dir",
+        moe_hf_output_dir.as_posix(),
+    ]
+    return run_process(cmd, timeout=TIMEOUT)
+
+
+@pytest.fixture(scope="module")
+def test_no_error_hf(moe_hf_process: ProcessResult, moe_hf_output_dir: Path):
+    check_no_error(moe_hf_process, moe_hf_output_dir)
+
+
+def test_moe_hf_runs(moe_hf_process: ProcessResult, test_no_error_hf):
+    """MoE RL with HF model impl completes without error."""
+
+
+# --- MoE with custom impl ---
+
+
+@pytest.fixture(scope="module")
+def moe_custom_output_dir(output_dir: Path) -> Path:
+    d = output_dir / "rl_moe_custom"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+@pytest.fixture(scope="module")
+def moe_custom_process(
+    run_process: Callable[..., ProcessResult],
+    moe_custom_output_dir: Path,
+    wandb_project: str,
+    wandb_name: str,
+) -> ProcessResult:
+    cmd = [
+        "uv",
+        "run",
+        "rl",
+        "@",
+        "configs/ci/integration/rl_moe/start.toml",
+        "--trainer.model.impl",
+        "custom",
+        "--wandb.project",
+        wandb_project,
+        "--wandb.name",
+        f"{wandb_name}-custom",
+        "--output-dir",
+        moe_custom_output_dir.as_posix(),
+    ]
+    return run_process(cmd, timeout=TIMEOUT)
+
+
+@pytest.fixture(scope="module")
+def test_no_error_custom(moe_custom_process: ProcessResult, moe_custom_output_dir: Path):
+    check_no_error(moe_custom_process, moe_custom_output_dir)
+
+
+def test_moe_custom_runs(moe_custom_process: ProcessResult, test_no_error_custom):
+    """MoE RL with custom model impl completes without error."""


### PR DESCRIPTION
Adds integration tests for MoE RL with both HF and custom model implementations. Uses `samsja/mini-glm-moe` (~0.5B) on reverse-text.

Two test variants:
- `test_moe_hf_runs` — HF impl
- `test_moe_custom_runs` — custom (PrimeRL) impl

Both validate the pipeline completes without crashing.

### Debug locally (2 GPUs)

**HF impl:**
```bash
uv run rl @ configs/ci/integration/rl_moe/start.toml --trainer.model.impl hf
```

**Custom impl:**
```bash
uv run rl @ configs/ci/integration/rl_moe/start.toml --trainer.model.impl custom
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds slow, GPU-dependent integration coverage that downloads/runs an external MoE model and can increase CI flakiness/timeouts, but it doesn’t change production code paths.
> 
> **Overview**
> Adds a new GPU CI integration scenario for MoE RL by introducing `configs/ci/integration/rl_moe/start.toml` (mini MoE model, reverse-text env, short run) and a matching `tests/integration/test_rl_moe.py`.
> 
> The new test runs the RL pipeline twice—once with `--trainer.model.impl hf` and once with `--trainer.model.impl custom`—and asserts both complete successfully via `check_no_error`, with separate output directories and W&B run names.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40aab23a65b745b0dae4c00b897af9b7886300aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->