### PR TITLE
Make get_module_signature calls lazy

### DIFF
--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -214,8 +214,12 @@ class CheckpointManager:
         if not ckpt_path.exists():
             raise FileNotFoundError(f"Checkpoint not found at {ckpt_path}")
         self.load_from_path(ckpt_path, model, optimizers, scheduler, progress, dataloader)
-        self.logger.debug(
-            f"Signatures after loading training checkpoint: model={get_module_signature(model, compress=True)}, optimizers={', '.join(get_optimizer_signature(optimizer, compress=True) for optimizer in optimizers)}"
+        self.logger.opt(lazy=True).debug(
+            "Signatures after loading training checkpoint: model={model_signature}, optimizers={optimizer_signature}",
+            model_signature=lambda: get_module_signature(model, compress=True),
+            optimizer_signature=lambda: ", ".join(
+                get_optimizer_signature(optimizer, compress=True) for optimizer in optimizers
+            ),
         )
 
     def save(
@@ -230,8 +234,12 @@ class CheckpointManager:
         """Save the full checkpoint state for a specified step."""
         ckpt_path = self.get_ckpt_path(step)
         ckpt_path.parent.mkdir(parents=True, exist_ok=True)
-        self.logger.debug(
-            f"Signatures before saving training checkpoint: model={get_module_signature(model, compress=True)}, optimizers={', '.join(get_optimizer_signature(optimizer, compress=True) for optimizer in optimizers)}"
+        self.logger.opt(lazy=True).debug(
+            "Signatures before saving training checkpoint: model={model_signature}, optimizers={optimizer_signature}",
+            model_signature=lambda: get_module_signature(model, compress=True),
+            optimizer_signature=lambda: ", ".join(
+                get_optimizer_signature(optimizer, compress=True) for optimizer in optimizers
+            ),
         )
 
         self.save_to_path(ckpt_path, model, optimizers, scheduler, progress, dataloader)

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -669,7 +669,10 @@ def setup_model(
         else:
             load_dcp_from_hf(model, config, parallel_dims)
 
-    logger.debug(f"Model signature: {get_module_signature(model, compress=True)}")
+    logger.opt(lazy=True).debug(
+        "Model signature: {model_signature}",
+        model_signature=lambda: get_module_signature(model, compress=True),
+    )
     return model
 
 


### PR DESCRIPTION
The get_module_signature are only used for debug logging, and can be very slow for large models(since they hash all the model's parameters).
Specifically for qwen 30b moe was very slow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change; behavior is unchanged except that signature computation is deferred and may be skipped when debug logging is disabled.
> 
> **Overview**
> Switches expensive debug logging of `get_module_signature`/`get_optimizer_signature` to *lazy evaluation* so signatures are only computed if the debug log line is actually emitted.
> 
> This updates checkpoint save/load logging in `trainer/ckpt.py` and model setup logging in `trainer/model.py` to use `logger.opt(lazy=True).debug(...)` with lambda-bound fields, avoiding large-model parameter hashing overhead during normal runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3710de37269c5fa5da145d1a21fc1561c6fdec24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->