### PR TITLE
refactor(slurm): move NCCL and runtime configs from template to config

### DIFF
--- a/docs/slurm.md
+++ b/docs/slurm.md
@@ -3,7 +3,7 @@
 For SLURM clusters, use the `rl_slurm` entrypoint. It resolves the full config (trainer, orchestrator, inference), dumps sub-configs as TOML files, renders a SLURM batch script from a Jinja2 template, and submits it with `sbatch`.
 
 ```bash
-uv run python -m prime_rl.slurm.rl @ examples/slurm/hendrycks_math.toml
+uv run rl_slurm @ examples/slurm/hendrycks_math.toml
 ```
 
 This will:
@@ -15,7 +15,7 @@ This will:
 To only generate the script without submitting, use `--dry-run`:
 
 ```bash
-uv run python -m prime_rl.slurm.rl @ examples/slurm/hendrycks_math.toml --dry-run
+uv run rl_slurm @ examples/slurm/hendrycks_math.toml --dry-run
 ```
 
 ## Configuration
@@ -123,7 +123,7 @@ dp = 2
 The default template handles a standard multi-node setup with NCCL weight broadcast, InfiniBand detection, and `srun`-based process dispatch. For more advanced use cases (custom partitions, account settings, module loads, different networking setups, etc.), provide your own Jinja2 template:
 
 ```bash
-uv run python -m prime_rl.slurm.rl \
+uv run rl_slurm \
     @ my_config.toml \
     --slurm-template path/to/my_template.sh.j2
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
 
 [project.scripts]
 rl = "prime_rl.rl:main"
+rl_slurm = "prime_rl.slurm.rl:main"
 trainer = "prime_rl.trainer.rl.train:main"
 orchestrator = "prime_rl.orchestrator.orchestrator:main"
 inference = "prime_rl.inference.server:main"

--- a/src/prime_rl/rl_config.py
+++ b/src/prime_rl/rl_config.py
@@ -92,6 +92,9 @@ class SharedWeightBroadcastConfig(BaseSettings):
         "filesystem"
     )
 
+    port: Annotated[int, Field(description="The port to use for NCCL weight broadcast.")] = 29501
+    timeout: Annotated[int, Field(description="The timeout in seconds for NCCL weight broadcast.")] = 1200
+
 
 class BaseRLConfig(BaseSettings):
     """Configures an RL training run."""
@@ -306,10 +309,15 @@ class BaseRLConfig(BaseSettings):
             if self.weight_broadcast.type == "nccl":
                 inference_world_size = self.inference.parallel.dp * self.inference.parallel.tp if self.inference else 1
                 self.trainer.weight_broadcast = TrainerNCCLWeightBroadcastConfig(
-                    type=self.weight_broadcast.type, inference_world_size=inference_world_size
+                    type=self.weight_broadcast.type,
+                    inference_world_size=inference_world_size,
+                    port=self.weight_broadcast.port,
+                    timeout=self.weight_broadcast.timeout,
                 )
                 self.orchestrator.weight_broadcast = OrchestratorNCCLWeightBroadcastConfig(
-                    type=self.weight_broadcast.type
+                    type=self.weight_broadcast.type,
+                    port=self.weight_broadcast.port,
+                    timeout=self.weight_broadcast.timeout,
                 )
             elif self.weight_broadcast.type == "filesystem":
                 self.trainer.weight_broadcast = TrainerFileSystemWeightBroadcastConfig()

--- a/src/prime_rl/slurm/rl_slurm.sh.j2
+++ b/src/prime_rl/slurm/rl_slurm.sh.j2
@@ -38,9 +38,6 @@ export OMP_NUM_THREADS=1
 export HOSTNAMES=( $( scontrol show hostnames $SLURM_JOB_NODELIST ) )
 export INFER_HOSTS=${HOSTNAMES[@]:0:$NUM_INFER_NODES}
 export TRAIN_HOSTS=${HOSTNAMES[@]:$NUM_INFER_NODES:$SLURM_JOB_NUM_NODES}
-export BROADCAST_PORT=${BROADCAST_PORT:-29501}
-export BROADCAST_TIMEOUT=${BROADCAST_TIMEOUT:-12000}
-export NCCL_COMM_TIMEOUT=${NCCL_BROADCAST_TIMEOUT:-12000}
 
 INFER_URLS=""
 for host in ${INFER_HOSTS[@]}; do
@@ -105,11 +102,7 @@ else
         uv run orchestrator \
             @ $CONFIG_DIR/orchestrator.toml \
             --weight_broadcast.host $MASTER_ADDR \
-            --weight_broadcast.port $BROADCAST_PORT \
-            --weight_broadcast.timeout $BROADCAST_TIMEOUT \
             --client.base-url $INFER_URLS \
-            --client.timeout 3600 \
-            --num-train-workers $((NUM_TRAIN_NODES * GPUS_PER_NODE)) \
             2>&1 | tee $OUTPUT_DIR/slurm/latest_orchestrator.log $OUTPUT_DIR/slurm/job_${SLURM_JOB_ID}_orchestrator.log & disown
     fi
 
@@ -132,11 +125,6 @@ else
         --local-ranks-filter=$(seq -s, 0 $((GPUS_PER_NODE - 1))) \
         -m prime_rl.trainer.rl.train \
         @ $CONFIG_DIR/trainer.toml \
-        --weight_broadcast.host 0.0.0.0 \
-        --weight_broadcast.port $BROADCAST_PORT \
-        --weight_broadcast.inference_world_size $((GPUS_PER_NODE * NUM_INFER_NODES)) \
-        --weight_broadcast.timeout $BROADCAST_TIMEOUT \
-        --dist_timeout_seconds $NCCL_COMM_TIMEOUT \
         2>&1 | tee -a $OUTPUT_DIR/slurm/latest_train_node_rank_${TRAIN_NODE_RANK}.log $OUTPUT_DIR/slurm/job_${SLURM_JOB_ID}_train_node_rank_${TRAIN_NODE_RANK}.log
     fi
 '


### PR DESCRIPTION
## Summary

- Add `port` and `timeout` fields to `SharedWeightBroadcastConfig` for NCCL configuration
- Propagate port/timeout values in `auto_setup_weight_broadcast`
- Add `auto_setup_slurm_nccl` validator that automatically sets:
  - `orchestrator.num_train_workers` from SLURM topology
  - `trainer.weight_broadcast.host` to `0.0.0.0`
  - `trainer.weight_broadcast.inference_world_size` from SLURM topology
- Add `validate_inference_config` to catch missing inference config early when `num_infer_nodes > 0`
- Remove hardcoded env vars (`BROADCAST_PORT`, `BROADCAST_TIMEOUT`, `NCCL_COMM_TIMEOUT`) and CLI args from SLURM template

Only `--weight_broadcast.host $MASTER_ADDR` and `--client.base-url $INFER_URLS` remain as CLI args since they are runtime values from SLURM.

## Test plan

- [ ] Verify SLURM job submission with NCCL weight broadcast works
- [ ] Verify config validation catches missing inference config when `num_infer_nodes > 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SLURM launch/config validation and NCCL weight-broadcast wiring; mis-propagated ports/timeouts or derived topology values could break distributed job startup.
> 
> **Overview**
> SLURM runs now use a first-class `rl_slurm` script entrypoint, with docs updated accordingly.
> 
> NCCL weight broadcast configuration is moved into config: `SharedWeightBroadcastConfig` gains `port`/`timeout` and `BaseRLConfig.auto_setup_weight_broadcast` propagates them into trainer/orchestrator NCCL configs. `RLSLURMConfig` adds validators to derive `orchestrator.num_train_workers` and SLURM-specific NCCL fields (`trainer.weight_broadcast.host=0.0.0.0`, `inference_world_size`) from cluster topology, and to error early if `num_infer_nodes > 0` but no `inference` config is provided.
> 
> The default `rl_slurm.sh.j2` template is simplified by removing hardcoded broadcast env vars and most NCCL/worker CLI overrides, leaving only runtime SLURM-derived values like `--weight_broadcast.host $MASTER_ADDR` and `--client.base-url $INFER_URLS`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42c4a6d83c59ae75e360ba156f8c667bfa23474c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->