### PR TITLE
pass json_logging to env servers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,6 @@ transformers = { git = "https://github.com/huggingface/transformers.git", rev = 
 vllm = { url = "https://github.com/vllm-project/vllm/releases/download/v0.16.0/vllm-0.16.0-cp38-abi3-manylinux_2_31_x86_64.whl" }
 flash-attn-cute = { git = "https://github.com/Dao-AILab/flash-attention.git", subdirectory = "flash_attn/cute", rev = "main" }
 reverse-text = { index = "primeintellect" }
-math-env = { index = "primeintellect" }
 
 [tool.uv.extra-build-dependencies]
 flash-attn = [{ requirement = "torch", match-runtime = true }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ override-dependencies = [
 
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
+math-env = { index = "primeintellect" }
 verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "013d4da" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eeb" }

--- a/src/prime_rl/orchestrator/env_server/env_server.py
+++ b/src/prime_rl/orchestrator/env_server/env_server.py
@@ -29,6 +29,7 @@ def run_server(config: EnvServerConfig):
         log_level=config.log.level,
         log_file_level=config.log.vf_level,
         log_file=log_file,
+        json_logging=config.log.json_logging,
         **{"address": config.env.address} if config.env.address is not None else {},
     )
     asyncio.run(server.run())

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -174,6 +174,7 @@ async def orchestrate(config: OrchestratorConfig):
                 log_level="CRITICAL",
                 log_file=(get_log_dir(config.output_dir) / "train" / f"{env_name}.log").as_posix(),
                 log_file_level=config.log.vf_level,
+                json_logging=config.log.json_logging,
             )
         else:
             address = env.address
@@ -208,6 +209,7 @@ async def orchestrate(config: OrchestratorConfig):
                     log_level="CRITICAL",
                     log_file=(get_log_dir(config.output_dir) / "eval" / f"{eval_env_name}.log").as_posix(),
                     log_file_level=config.log.vf_level,
+                    json_logging=config.log.json_logging,
                 )
             else:
                 address = env.address

--- a/src/prime_rl/orchestrator/vf_utils.py
+++ b/src/prime_rl/orchestrator/vf_utils.py
@@ -26,6 +26,7 @@ def spawn_env_server(
     log_level: str | None = None,
     log_file: str | None = None,
     log_file_level: str | None = None,
+    json_logging: bool = False,
     daemon: bool = True,
 ) -> str:
     """
@@ -47,7 +48,7 @@ def spawn_env_server(
             log_file,
             log_file_level,
         ),
-        kwargs=dict(address=address),
+        kwargs=dict(address=address, json_logging=json_logging),
         daemon=daemon,
     ).start()
 


### PR DESCRIPTION
depends on https://github.com/PrimeIntellect-ai/verifiers/pull/930

- pass `json_logging` to `ZMQEnvServer` in standalone `env-server` entrypoint
- add `json_logging` param to `spawn_env_server()`
- pass `config.log.json_logging` through in orchestrator spawn calls

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, configuration-only change that affects log formatting/handlers for env server subprocesses, with minimal impact on runtime behavior.
> 
> **Overview**
> Enables JSON-formatted logging for environment server subprocesses by plumbing `config.log.json_logging` through the standalone `env-server` entrypoint, the orchestrator’s env server spawn paths (train + eval), and `spawn_env_server()` into `ZMQEnvServer.run_server`.
> 
> Also fixes `pyproject.toml` so `math-env` is sourced from the `primeintellect` index in the correct location.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 620561ec33e9d9444dd0a1326b4ae1074355d96a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->