### PR TITLE
fix: cast Path to str when spawning tail subprocess

### DIFF
--- a/src/prime_rl/rl.py
+++ b/src/prime_rl/rl.py
@@ -611,7 +611,7 @@ def rl(config: RLConfig):
         # Monitor all processes for failures
         logger.success("Startup complete. Showing trainer logs...")
 
-        tail_process = Popen(["tail", "-F", log_dir / "trainer.stdout"])
+        tail_process = Popen(["tail", "-F", str(log_dir / "trainer.stdout")])
         processes.append(tail_process)
 
         # Check for errors from monitor threads


### PR DESCRIPTION
Ensure subprocess receives string path when spawning tail to avoid potential cross-platform Path handling issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-argument type fix when launching a non-critical `tail` subprocess; minimal behavioral impact beyond improved compatibility.
> 
> **Overview**
> Fixes RL log streaming startup by converting the `Path` for `trainer.stdout` to a plain string when spawning `tail -F` via `Popen`, avoiding `Path`/subprocess argument handling issues on some platforms.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e9bd7686a06be2869891053a1fbacdbdb0bcbe1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->