### PR TITLE
fix: skip incomplete checkpoints when resolving resume step

### DIFF
--- a/src/prime_rl/utils/pathing.py
+++ b/src/prime_rl/utils/pathing.py
@@ -46,31 +46,29 @@ def get_stable_ckpt_steps(ckpt_dir: Path) -> list[int]:
 
 
 def resolve_latest_ckpt_step(ckpt_dir: Path) -> int | None:
-    """Gets the latest resumable checkpoint step from the checkpoint directory.
+    """Gets the latest stable checkpoint step from the checkpoint directory.
 
-    Only considers checkpoints that have the orchestrator subdirectory,
-    ensuring we don't try to resume from a partially written checkpoint
-    (e.g. trainer created the step directory but orchestrator never saved).
+    Only considers checkpoints with a STABLE marker, ensuring we don't
+    resume from a partially written checkpoint.
 
-    Returns None if no valid checkpoints are found.
+    Returns None if no stable checkpoints are found.
     """
-    steps = get_all_ckpt_steps(ckpt_dir)
-    # Filter to steps that have the orchestrator checkpoint data
-    resumable = [s for s in steps if (ckpt_dir / f"step_{s}" / "orchestrator").exists()]
     logger = get_logger()
-    if len(resumable) == 0:
-        if len(steps) > 0:
+    all_steps = get_all_ckpt_steps(ckpt_dir)
+    stable_steps = get_stable_ckpt_steps(ckpt_dir)
+    if len(stable_steps) == 0:
+        if len(all_steps) > 0:
             logger.warning(
-                f"Found {len(steps)} checkpoint dir(s) in {ckpt_dir} but none have orchestrator data. "
+                f"Found {len(all_steps)} checkpoint dir(s) in {ckpt_dir} but none are stable. "
                 "Starting from scratch."
             )
         else:
             logger.warning(f"No checkpoints found in {ckpt_dir}. Starting from scratch.")
         return None
-    latest_step = resumable[-1]
-    if len(resumable) < len(steps):
-        skipped = sorted(set(steps) - set(resumable))
-        logger.warning(f"Skipping incomplete checkpoint(s) without orchestrator data: {skipped}")
+    latest_step = stable_steps[-1]
+    if len(stable_steps) < len(all_steps):
+        skipped = sorted(set(all_steps) - set(stable_steps))
+        logger.warning(f"Skipping incomplete checkpoint(s) without STABLE marker: {skipped}")
     logger.info(f"Found latest checkpoint in {ckpt_dir}: {latest_step}")
     return latest_step
 


### PR DESCRIPTION
resolve_latest_ckpt_step now checks the orchestrator subdirectory exists before selecting a checkpoint to resume from.

- prevents crash when trainer creates step dir but orchestrator never saved (e.g. orchestrator hung mid-step)
- logs a warning when skipping incomplete checkpoints
- falls back to the last complete checkpoint instead of crashing with FileNotFoundError

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to checkpoint-selection logic and logging; low risk aside from potentially changing which checkpoint step is chosen for resume in edge cases.
> 
> **Overview**
> `resolve_latest_ckpt_step` now only resumes from checkpoint steps that contain an `orchestrator/` subdirectory, avoiding attempts to load partially written checkpoints.
> 
> If no resumable checkpoints exist it logs a clearer warning and returns `None`, and it warns when skipping incomplete checkpoint steps before selecting the latest valid step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68d3fbdfd5c85da64ca94f79325e02a88f6ab123. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->