### PR TITLE
dont reload weights on start by default

### DIFF
--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -720,11 +720,10 @@ class OrchestratorConfig(BaseSettings):
     # The checkpoint configuration
     ckpt: CheckpointConfig | None = None
 
-    # Whether to reset inference weights to base model when starting from scratch
     reload_weights_on_start: Annotated[
         bool,
-        Field(description="Whether to reset inference weights to the base model when starting from scratch."),
-    ] = True
+        Field(description="Whether to reset inference weights to the base model when training from scratch."),
+    ] = False
 
     # The validation configuration
     val: ValConfig | None = None


### PR DESCRIPTION
  Looking at the logic in orchestrator.py:307-331:                                                                                                                                  
                                                                                                                                                                                    
  1. If resuming from checkpoint (line 307): the flag is irrelevant — it loads the checkpoint weights regardless.
  2. If training from scratch (the else on line 323):
    - reload_weights_on_start=True + no LoRA: calls reload_weights() to reset vLLM's weights to the base model
    - reload_weights_on_start=True + LoRA: already skips the reload (line 329: "Skipping base weight reload because LoRA is enabled")
    - reload_weights_on_start=False: skips the reload entirely

  Impact on multi-run / LoRA

  LoRA is not affected. Even with the old default (True), LoRA was already explicitly skipped (line 325-329). So changing to False has zero effect on LoRA runs.

  Multi-run is not affected either. Multi-run uses MultiRunManager which lives on the trainer side. When a new run is discovered, _create_run_hooks calls reset_run_parameters(idx)
  (line 291) which reinitializes the LoRA adapter weights. The orchestrator-side reload_weights_on_start is about resetting the inference server's base model weights, which is a
  separate concern.

  Single-run non-LoRA from scratch is the only case where behavior changes. With the old default, starting fresh would reload the base model on vLLM. With the new default, it skips
   that reload. This only matters if vLLM was somehow already serving modified weights (e.g., from a previous run on the same server). In practice, when starting from scratch, the
  vLLM server is freshly started and already has the base weights, so the reload was a no-op anyway.

  Verdict: safe to merge. The change doesn't break multi-run or LoRA.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Alters the default startup behavior for scratch runs, which can change which weights the inference pool starts with and potentially affect training correctness if callers relied on the previous default.
> 
> **Overview**
> Changes the orchestrator default for `reload_weights_on_start` to **False** (was True) and updates the field description to refer to *training from scratch* instead of *starting from scratch*. This means fresh runs will now skip resetting inference weights to the base model unless explicitly enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8135eda81b0b81da085354e15d040341c8817d30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->