### PR TITLE
remove hash from logs

### DIFF
--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -30,7 +30,6 @@ from prime_rl.trainer.weights import (
 )
 from prime_rl.trainer.world import get_world
 from prime_rl.utils.logger import get_logger
-from prime_rl.utils.tensor_hashing import get_module_signature, get_optimizer_signature
 from prime_rl.utils.utils import get_all_ckpt_steps, get_ckpt_dir, get_step_path, get_weights_dir
 
 
@@ -214,9 +213,6 @@ class CheckpointManager:
         if not ckpt_path.exists():
             raise FileNotFoundError(f"Checkpoint not found at {ckpt_path}")
         self.load_from_path(ckpt_path, model, optimizers, scheduler, progress, dataloader)
-        self.logger.debug(
-            f"Signatures after loading training checkpoint: model={get_module_signature(model, compress=True)}, optimizers={', '.join(get_optimizer_signature(optimizer, compress=True) for optimizer in optimizers)}"
-        )
 
     def save(
         self,
@@ -230,9 +226,6 @@ class CheckpointManager:
         """Save the full checkpoint state for a specified step."""
         ckpt_path = self.get_ckpt_path(step)
         ckpt_path.parent.mkdir(parents=True, exist_ok=True)
-        self.logger.debug(
-            f"Signatures before saving training checkpoint: model={get_module_signature(model, compress=True)}, optimizers={', '.join(get_optimizer_signature(optimizer, compress=True) for optimizer in optimizers)}"
-        )
 
         self.save_to_path(ckpt_path, model, optimizers, scheduler, progress, dataloader)
         bisect.insort(self.ckpt_steps, step)

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -40,7 +40,6 @@ from prime_rl.trainer.weights import (
 )
 from prime_rl.trainer.world import get_world
 from prime_rl.utils.logger import get_logger
-from prime_rl.utils.tensor_hashing import get_module_signature
 from prime_rl.utils.vlm import is_vlm_model
 
 # Add filter to the standard logging module for transformers.modeling_utils to supress the
@@ -679,7 +678,6 @@ def setup_model(
         else:
             load_dcp_from_hf(model, config, parallel_dims)
 
-    logger.debug(f"Model signature: {get_module_signature(model, compress=True)}")
     return model
 
 


### PR DESCRIPTION
we currently logs the hash of each model on ckpt load and saving and after each fsdp loading. This is slow and unnecessary so removing it 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only removes debug log statements and related imports; no changes to checkpoint contents or load/save logic.
> 
> **Overview**
> Removes `tensor_hashing`-based debug logging of model/optimizer “signatures” during trainer checkpoint `save`/`load` and after model weight loading in `setup_model`.
> 
> This eliminates repeated state-dict hashing in hot paths to reduce overhead while leaving checkpointing and loading behavior unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 384f91e3b7f5e83f5886cd3fe4a3ee2e195d7a00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->