### PR TITLE
Add SFT SLURM entrypoint

### DIFF
--- a/docs/slurm.md
+++ b/docs/slurm.md
@@ -159,81 +159,10 @@ The trainer and inference panes use glob patterns (`latest_train_node_rank_*.log
 
 ## SFT
 
-For SFT on SLURM clusters, use the `sft_slurm` entrypoint. It extends the standard SFT trainer config with SLURM-specific fields, writes the resolved trainer config, renders a SLURM batch script, and submits it with `sbatch`. No inference or orchestrator nodes are needed.
+For SFT on SLURM, use the `sft_slurm` entrypoint. It works the same way as `rl_slurm` but only needs a trainer config — no inference or orchestrator nodes.
 
 ```bash
-uv run sft_slurm @ examples/slurm/my_sft_config.toml
+uv run sft_slurm @ examples/slurm/sft_moe.toml
 ```
 
-This will:
-
-1. Write the resolved trainer config to `{output_dir}/configs/trainer.toml`
-2. Render the SLURM script to `{output_dir}/sft.sh`
-3. Submit the job via `sbatch`
-
-To only generate the script without submitting, use `--dry-run`:
-
-```bash
-uv run sft_slurm @ examples/slurm/my_sft_config.toml --dry-run
-```
-
-### Configuration
-
-The SLURM config extends the standard SFT trainer config with the following fields:
-
-| Field | Description |
-|---|---|
-| `job_name` | SLURM job name |
-| `output_dir` | Directory for outputs, configs, and logs |
-| `project_dir` | Path to the project root on the cluster (defaults to cwd) |
-| `num_nodes` | Number of training nodes (default: 1) |
-| `gpus_per_node` | Number of GPUs per node (default: 8) |
-| `nodes_per_fsdp_group` | Number of nodes per FSDP island (optional, auto-sets `model.dp_replicate`) |
-| `slurm_template` | Path to a custom Jinja2 template (optional) |
-| `dry_run` | Only generate the script without submitting (default: false) |
-
-All standard SFT trainer config fields (`model`, `data`, `optim`, `scheduler`, `wandb`, `ckpt`, etc.) are available at the top level — no `[trainer]` nesting needed.
-
-### Example
-
-```toml
-job_name = "sft-qwen"
-output_dir = "/shared/outputs/sft-qwen"
-num_nodes = 2
-gpus_per_node = 8
-
-max_steps = 1000
-
-[model]
-name = "Qwen/Qwen3-4B-Instruct-2507"
-
-[data]
-type = "sft"
-name = "PrimeIntellect/Reverse-Text-SFT"
-batch_size = 128
-seq_len = 2048
-
-[wandb]
-project = "sft-qwen"
-name = "sft-qwen"
-```
-
-### Custom SLURM Templates
-
-Provide your own Jinja2 template for custom cluster setups:
-
-```bash
-uv run sft_slurm \
-    @ my_config.toml \
-    --slurm-template path/to/my_template.sh.j2
-```
-
-The template receives the following variables: `job_name`, `project_dir`, `output_dir`, `config_dir`, `num_nodes`, `gpus_per_node`, `hf_hub_offline`. See `src/prime_rl/slurm/sft_slurm.sh.j2` for the default template.
-
-### Monitoring
-
-After submission, the logs are available at:
-
-```bash
-tail -f {output_dir}/slurm/latest_train_node_rank_0.log
-```
+See [`examples/slurm/sft_moe.toml`](../examples/slurm/sft_moe.toml) for a MoE example with activation checkpointing, CPU offload, and compilation. Use `--dry-run` to generate the script without submitting.

--- a/examples/slurm/sft_moe.toml
+++ b/examples/slurm/sft_moe.toml
@@ -1,0 +1,26 @@
+max_steps = 500
+
+[wandb]
+project = "sft-moe-intellect"
+name = "sft-moe-math"
+
+[model]
+name = "Qwen/Qwen3-30B-A3B-Thinking-2507"
+impl = "custom"
+attn = "flash_attention_3"
+
+[model.compile]
+
+[model.ac_offloading]
+max_inflight_activations = 5
+
+[model.ac]
+freq = 1
+
+[data]
+type = "sft"
+name = "PrimeIntellect/INTELLECT-3-SFT-10K"
+subsets = ["default"]
+splits = ["math"]
+batch_size = 128
+seq_len = 8192

--- a/examples/slurm/sft_moe.toml
+++ b/examples/slurm/sft_moe.toml
@@ -1,3 +1,8 @@
+job_name = "sft-moe-math"
+output_dir = "/shared/outputs/sft-moe-math"
+num_nodes = 1
+gpus_per_node = 8
+
 max_steps = 500
 
 [wandb]
@@ -8,6 +13,7 @@ name = "sft-moe-math"
 name = "Qwen/Qwen3-30B-A3B-Thinking-2507"
 impl = "custom"
 attn = "flash_attention_3"
+optim_cpu_offload = true
 
 [model.compile]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ orchestrator = "prime_rl.orchestrator.orchestrator:main"
 inference = "prime_rl.inference.server:main"
 env-server = "prime_rl.orchestrator.env_server.env_server:main"
 sft = "prime_rl.trainer.sft.train:main"
+sft_slurm = "prime_rl.slurm.sft:main"
 
 [project.entry-points."vllm.general_plugins"]
 prime_rl = "prime_rl.inference.patches:transformers_v5_compat"

--- a/src/prime_rl/slurm/sft.py
+++ b/src/prime_rl/slurm/sft.py
@@ -1,0 +1,113 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import tomli_w
+from jinja2 import Environment, FileSystemLoader
+from pydantic import Field, model_validator
+
+from prime_rl.trainer.sft.config import SFTTrainerConfig
+from prime_rl.utils.logger import setup_logger
+from prime_rl.utils.pydantic_config import parse_argv
+
+TEMPLATE_DIR = Path(__file__).parent
+TEMPLATE_NAME = "sft_slurm.sh.j2"
+
+
+class SFTSLURMConfig(SFTTrainerConfig):
+    job_name: str
+    num_nodes: int = Field(default=1, description="Number of training nodes.")
+    gpus_per_node: int = Field(default=8, description="Number of GPUs per node.")
+    nodes_per_fsdp_group: int | None = Field(
+        default=None,
+        description="Number of nodes per FSDP island. Auto-sets model.dp_replicate = num_nodes / nodes_per_fsdp_group.",
+    )
+
+    project_dir: Path = Field(
+        default_factory=lambda: Path.cwd(),
+        description="Path to the project root. Used to source .env, activate .venv, and run uv sync.",
+    )
+    hf_hub_offline: bool = Field(
+        default=False, description="Set HF_HUB_OFFLINE=1 on training nodes to prevent downloading models at runtime."
+    )
+
+    slurm_template: Path | None = Field(
+        default=None, description="The path to the SLURM template file. If none, will use the default template."
+    )
+    dry_run: bool = Field(default=False, description="Only generate the SLURM script and configs without submitting.")
+
+    @model_validator(mode="after")
+    def auto_setup_dp_replicate(self):
+        if self.nodes_per_fsdp_group is not None:
+            if self.num_nodes % self.nodes_per_fsdp_group != 0:
+                raise ValueError(
+                    f"num_nodes ({self.num_nodes}) must be divisible by nodes_per_fsdp_group ({self.nodes_per_fsdp_group})"
+                )
+            self.model.dp_replicate = self.num_nodes // self.nodes_per_fsdp_group
+        return self
+
+
+def write_trainer_config(config: SFTSLURMConfig, output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    slurm_only_fields = set(SFTSLURMConfig.model_fields) - set(SFTTrainerConfig.model_fields)
+    trainer_data = config.model_dump(exclude_none=True, mode="json", exclude=slurm_only_fields)
+    with open(output_dir / "trainer.toml", "wb") as f:
+        tomli_w.dump(trainer_data, f)
+
+
+def render_slurm_script(config: SFTSLURMConfig, config_dir: Path) -> str:
+    if config.slurm_template is not None:
+        template_dir = config.slurm_template.parent
+        template_name = config.slurm_template.name
+    else:
+        template_dir = TEMPLATE_DIR
+        template_name = TEMPLATE_NAME
+    env = Environment(loader=FileSystemLoader(template_dir), keep_trailing_newline=True)
+    template = env.get_template(template_name)
+    return template.render(
+        job_name=config.job_name,
+        output_dir=config.output_dir,
+        config_dir=config_dir,
+        num_nodes=config.num_nodes,
+        project_dir=config.project_dir,
+        gpus_per_node=config.gpus_per_node,
+        hf_hub_offline=config.hf_hub_offline,
+    )
+
+
+def sft_slurm(config: SFTSLURMConfig):
+    logger = setup_logger(config.log.level or "info", json_logging=config.log.json_logging)
+
+    config_dir = config.output_dir / "configs"
+    write_trainer_config(config, config_dir)
+
+    logger.info(f"Wrote trainer config to {config_dir}")
+
+    script = render_slurm_script(config, config_dir)
+    script_path = config.output_dir / "sft.sh"
+    script_path.parent.mkdir(parents=True, exist_ok=True)
+    script_path.write_text(script)
+    logger.info(f"Wrote SLURM script to {script_path}")
+
+    log_message = f"Logs:\n  Trainer:  tail -f {config.output_dir}/slurm/latest_train_node_rank_0.log"
+
+    if config.dry_run:
+        logger.success(f"Dry run complete. To submit manually:\n\n  sbatch {script_path}\n\n{log_message}")
+        return
+
+    logger.info(f"Submitting: sbatch {script_path}")
+    result = subprocess.run(["sbatch", str(script_path)], capture_output=True, text=True)
+    if result.returncode != 0:
+        logger.error(f"sbatch failed: {result.stderr.strip()}")
+        sys.exit(1)
+
+    logger.success(f"{result.stdout.strip()}\n\n{log_message}")
+
+
+def main():
+    sft_slurm(parse_argv(SFTSLURMConfig))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/prime_rl/slurm/sft_slurm.sh.j2
+++ b/src/prime_rl/slurm/sft_slurm.sh.j2
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+#SBATCH --job-name={{ job_name }}
+#SBATCH --nodes={{ num_nodes }}
+#SBATCH --ntasks-per-node=1
+#SBATCH --gres=gpu:{{ gpus_per_node }}
+#SBATCH --partition=cluster
+#SBATCH --exclusive                 # Get the ENTIRE node exclusively
+#SBATCH --output=/shared/logs/job_%j.log
+#SBATCH --error=/shared/logs/job_%j.log
+
+# Configs
+export NUM_NODES={{ num_nodes }}
+export GPUS_PER_NODE={{ gpus_per_node }}
+
+# Paths
+export PROJECT_DIR={{ project_dir }}
+export CONFIG_DIR={{ config_dir }}
+export OUTPUT_DIR={{ output_dir }}
+mkdir -p $OUTPUT_DIR/slurm
+
+# General
+export CUDA_DEVICE_ORDER=PCI_BUS_ID
+export PYTHONUNBUFFERED=1
+export OMP_NUM_THREADS=1
+
+# Networking
+export HOSTNAMES=( $( scontrol show hostnames $SLURM_JOB_NODELIST ) )
+echo "HOSTNAMES=${HOSTNAMES[@]}"
+
+export MASTER_ADDR="${HOSTNAMES[0]}"
+export MASTER_PORT=29500
+echo "MASTER_ADDR=${MASTER_ADDR}"
+echo "MASTER_PORT=${MASTER_PORT}"
+
+# Install environment
+[ -f $PROJECT_DIR/.env ] && source $PROJECT_DIR/.env
+source $PROJECT_DIR/.venv/bin/activate
+
+# Install environment as local package
+cd $PROJECT_DIR && uv sync --all-extras
+
+
+# Run SFT
+srun bash -c '
+    # Setup environment
+    [ -f $PROJECT_DIR/.env ] && source $PROJECT_DIR/.env
+    source $PROJECT_DIR/.venv/bin/activate
+
+    # Higher ulimit
+    ulimit -n 65536
+    export GIT_LFS_SKIP_SMUDGE=1
+
+    # Infiniband setup
+    IB_HCA=$(ibv_devinfo | sed -n -e "/hca_id/p" -e "/link_layer:/p" | grep -B1 InfiniBand | grep hca_id | sed -e "s/^hca_id://g" | tr -d "[[:blank:]]" |paste -sd,)
+    export NCCL_IB_HCA=$IB_HCA
+
+    TRAIN_NODE_RANK=$SLURM_PROCID
+
+    export HF_HUB_OFFLINE={{ 1 if hf_hub_offline else 0 }}
+
+    # This is required for compilation to work correctly
+    export PYTORCH_CUDA_ALLOC_CONF="expandable_segments:True"
+
+    echo $HOSTNAMES | tee $OUTPUT_DIR/slurm/latest_train_node_rank_${TRAIN_NODE_RANK}.log
+    uv run torchrun \
+        --nnodes=$NUM_NODES \
+        --nproc-per-node=$GPUS_PER_NODE \
+        --node-rank=$TRAIN_NODE_RANK \
+        --rdzv-endpoint=$MASTER_ADDR:$MASTER_PORT \
+        --rdzv-id=job_$SLURM_JOB_ID \
+        --log-dir=$OUTPUT_DIR/torchrun \
+        --tee=3 \
+        --redirects=3 \
+        --local-ranks-filter=$(seq -s, 0 $((GPUS_PER_NODE - 1))) \
+        -m prime_rl.trainer.sft.train \
+        @ $CONFIG_DIR/trainer.toml \
+        2>&1 | tee -a $OUTPUT_DIR/slurm/latest_train_node_rank_${TRAIN_NODE_RANK}.log $OUTPUT_DIR/slurm/job_${SLURM_JOB_ID}_train_node_rank_${TRAIN_NODE_RANK}.log
+'

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -8,6 +8,7 @@ from prime_rl.inference.config import InferenceConfig
 from prime_rl.orchestrator.config import OrchestratorConfig
 from prime_rl.rl import RLConfig
 from prime_rl.slurm.rl import RLSLURMConfig
+from prime_rl.slurm.sft import SFTSLURMConfig
 from prime_rl.trainer.rl.config import RLTrainerConfig
 from prime_rl.trainer.sft.config import SFTTrainerConfig
 from prime_rl.utils.pydantic_config import parse_argv
@@ -20,6 +21,7 @@ CONFIG_CLASSES = [
     OrchestratorConfig,
     InferenceConfig,
     RLSLURMConfig,
+    SFTSLURMConfig,
 ]
 
 


### PR DESCRIPTION
## Summary
- Adds `sft_slurm` CLI entrypoint that mirrors `rl_slurm` but for SFT training
- Config extends `SFTTrainerConfig` directly — no `[trainer]` nesting needed, all trainer fields live at the top level
- Simplified Jinja2 SLURM template (`sft_slurm.sh.j2`) with no inference/orchestrator nodes — just `torchrun` across training nodes
- Slurm-only fields (`job_name`, `num_nodes`, etc.) are automatically excluded from the dumped trainer config using pydantic `model_fields` diffing
- Updated `docs/slurm.md` with SFT section

## Test plan
- [x] `uv run sft_slurm @ config.toml --dry-run` generates correct script and trainer config
- [ ] Verify dumped `trainer.toml` contains no slurm-only fields
- [ ] Multi-node submission on a SLURM cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new job-submission pathway that writes scripts/configs and invokes `sbatch`, so misconfiguration could cause failed jobs or unexpected cluster usage, but it is largely additive and parallels existing `rl_slurm` behavior.
> 
> **Overview**
> Adds an `sft_slurm` CLI entrypoint to submit SFT training on SLURM, mirroring `rl_slurm` but generating only a single `trainer.toml` plus an `sft.sh` batch script and optionally submitting via `sbatch` (or `--dry-run`).
> 
> Introduces `SFTSLURMConfig` (extending `SFTTrainerConfig`) with SLURM-specific fields (job/nodes/GPUs/template/offline) and logic to auto-set `model.dp_replicate` from `nodes_per_fsdp_group`, while excluding SLURM-only fields from the dumped trainer config. Updates docs to add an SFT section, adds an MoE SFT SLURM example config, and extends config-parsing unit coverage to include `SFTSLURMConfig`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba724a4985999fc34de51bbd1355de69548f78f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->