### PR TITLE
increase health check interval

### DIFF
--- a/src/prime_rl/orchestrator/vf_utils.py
+++ b/src/prime_rl/orchestrator/vf_utils.py
@@ -59,7 +59,7 @@ def setup_env_client(
     address: str,
     name: str | None = None,
     # health check configs
-    health_check_interval: float = 1.0,  # 1s
+    health_check_interval: float = 5.0,  # 5s (we detect an env server as unhealth after 3 * 5s = 15s of unsuccessful health checks)
     startup_timeout: float = 600.0,  # 10m
     recovery_timeout: float = 600.0,  # 10m
 ) -> EnvClient:


### PR DESCRIPTION
to decrease the chance of falsly detecting an env server as crashed in heavy load environments with high concurrency

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small configuration change affecting only default health-check timing; main risk is slower detection of genuinely crashed env servers.
> 
> **Overview**
> Increases the default `health_check_interval` used by `setup_env_client` from 1s to 5s, effectively requiring a longer window of missed checks before an env server is treated as unhealthy.
> 
> This changes the default behavior for all train/eval env clients created via `setup_env_client`, trading faster failure detection for fewer false positives under high concurrency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 456f7448aa3dcbdce8a48bb58a0cd15f5c916f09. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->