### PR TITLE
use lower-variance estimator for pass@k

### DIFF
--- a/src/prime_rl/orchestrator/eval_utils.py
+++ b/src/prime_rl/orchestrator/eval_utils.py
@@ -45,22 +45,21 @@ def get_eval_sampling_args(sampling_config: EvalSamplingConfig) -> dict[str, Any
     return sampling_args
 
 
-def compute_pass_at_k(rewards: list[int]) -> dict[str, float]:
-    total_attempts = len(rewards)
-    k = total_attempts // 2
+def _pass_at_k(n: int, c: int, k: int) -> float:
+    """Unbiased estimator of pass@k (Chen et al., 2021).
 
-    if k == 0:
-        return {"pass@1": float(any(reward == 1.0 for reward in rewards))}
+    Computes 1 - C(n-c, k) / C(n, k) in a numerically stable way.
+    """
+    if n - c < k:
+        return 1.0
+    return 1.0 - np.prod(1.0 - k / np.arange(n - c + 1, n + 1))
 
-    num_trials = 100
-    pass_rates = []
 
-    for _ in range(num_trials):
-        sampled_rewards = np.random.choice(rewards, size=k, replace=False)
-        pass_rate = float(any(reward == 1.0 for reward in sampled_rewards))
-        pass_rates.append(pass_rate)
-
-    return {f"pass@{k}": float(np.mean(pass_rates))}
+def compute_pass_at_k(rewards: list[float]) -> dict[str, float]:
+    n = len(rewards)
+    c = sum(r == 1.0 for r in rewards)
+    ks = [k for k in (1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024) if k <= n]
+    return {f"pass@{k}": _pass_at_k(n, c, k) for k in ks}
 
 
 async def evaluate_env(

--- a/src/prime_rl/orchestrator/eval_utils.py
+++ b/src/prime_rl/orchestrator/eval_utils.py
@@ -58,7 +58,7 @@ def _pass_at_k(n: int, c: int, k: int) -> float:
 def compute_pass_at_k(rewards: list[float]) -> dict[str, float]:
     n = len(rewards)
     c = sum(r == 1.0 for r in rewards)
-    ks = [k for k in (1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024) if k <= n]
+    ks = [2**i for i in range(n.bit_length()) if 2**i <= n]
     return {f"pass@{k}": _pass_at_k(n, c, k) for k in ks}
 
 

--- a/src/prime_rl/orchestrator/eval_utils.py
+++ b/src/prime_rl/orchestrator/eval_utils.py
@@ -58,7 +58,7 @@ def _pass_at_k(n: int, c: int, k: int) -> float:
 def compute_pass_at_k(rewards: list[float]) -> dict[str, float]:
     n = len(rewards)
     c = sum(r == 1.0 for r in rewards)
-    ks = [2**i for i in range(n.bit_length()) if 2**i <= n]
+    ks = [2**i for i in range(n.bit_length())]
     return {f"pass@{k}": _pass_at_k(n, c, k) for k in ks}
 
 


### PR DESCRIPTION
This PR replaces the higher-variance Monte-Carlo estimator for pass@k in online evals with the unbiased, low-variance, closed-form estimator from [Chen et al. (2021)](https://arxiv.org/abs/2107.03374).

We now also get pass@k for $k = 2^i$, for all $i$, where $k \leq n$, so if we sample 4 rollouts per example in the eval ($n=4$), we automatically calculate pass@1, pass@2 and pass@4!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to evaluation metric calculation; main risk is altered reported pass@k values/keys affecting downstream expectations or dashboards.
> 
> **Overview**
> Online eval `pass@k` computation is switched from a Monte-Carlo subsampling approach to the closed-form, unbiased Chen et al. (2021) estimator via a new helper `_pass_at_k`.
> 
> `compute_pass_at_k` now returns multiple metrics (`pass@1`, `pass@2`, `pass@4`, … up to `n`) based on power-of-two `k`, instead of a single `pass@k` derived from `n//2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a98f50bddd56c520f9567d5c2f97c214d554b015. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->