### PR TITLE
log mismatch_kl-entropy ratio

### DIFF
--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -505,6 +505,12 @@ def train(config: RLTrainerConfig):
         }
         monitor.log(optim_metrics, step=progress.step)
 
+        # Compute derived metrics
+        entropy_mean = tensor_stats.get("entropy/mean", 0.0)
+        mismatch_kl_mean = tensor_stats.get("mismatch_kl/mean")
+        if mismatch_kl_mean is not None and entropy_mean > 0:
+            tensor_stats["kl_ent_ratio/mean"] = mismatch_kl_mean / entropy_mean
+
         # Log tensor stats
         tensor_stats["step"] = progress.step
         monitor.log(tensor_stats, step=progress.step)

--- a/src/prime_rl/utils/metrics_server.py
+++ b/src/prime_rl/utils/metrics_server.py
@@ -114,6 +114,7 @@ class MetricsServer(HealthServer):
         self._mismatch_kl = Gauge(
             "trainer_mismatch_kl", "KL divergence between trainer and inference model", registry=self._registry
         )
+        self._kl_ent_ratio = Gauge("trainer_kl_ent_ratio", "Ratio of mismatch KL to entropy", registry=self._registry)
         # Aggregate run metrics
         self._runs_discovered = Gauge(
             "trainer_runs_discovered", "Number of run folders discovered", registry=self._registry
@@ -206,6 +207,8 @@ class MetricsServer(HealthServer):
         self._mfu.set(mfu)
         self._entropy.set(entropy)
         self._mismatch_kl.set(mismatch_kl)
+        if entropy > 0:
+            self._kl_ent_ratio.set(mismatch_kl / entropy)
         self._last_step_ts.set(time.time())
 
     def update_runs(

--- a/tests/unit/utils/test_metrics_server.py
+++ b/tests/unit/utils/test_metrics_server.py
@@ -92,6 +92,7 @@ def test_server_update_metrics():
     assert "trainer_loss" in content
     assert "trainer_last_step_timestamp_seconds" in content
     assert "trainer_mismatch_kl" in content
+    assert "trainer_kl_ent_ratio" in content
 
     server.stop()
 
@@ -102,6 +103,8 @@ def test_server_metrics_values_are_correct():
     server.start()
     time.sleep(0.1)
 
+    entropy = 1.5
+    mismatch_kl = 0.045
     server.update(
         step=100,
         loss=0.123,
@@ -109,7 +112,8 @@ def test_server_metrics_values_are_correct():
         grad_norm=2.5,
         peak_memory_gib=16.0,
         learning_rate=3e-5,
-        mismatch_kl=0.045,
+        entropy=entropy,
+        mismatch_kl=mismatch_kl,
     )
 
     response = urllib.request.urlopen(f"http://localhost:{port}/metrics", timeout=2)
@@ -118,6 +122,7 @@ def test_server_metrics_values_are_correct():
     assert "trainer_step 100.0" in content
     assert "trainer_loss 0.123" in content
     assert "trainer_mismatch_kl 0.045" in content
+    assert f"trainer_kl_ent_ratio {mismatch_kl / entropy}" in content
 
     server.stop()
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds a read-only derived metric and Prometheus gauge with simple conditional logic; minimal impact beyond observability and low chance of affecting training behavior.
> 
> **Overview**
> Adds a new derived metric, `kl_ent_ratio`, computed as `mismatch_kl / entropy` when entropy is non-zero.
> 
> The ratio is logged both to the training monitor (`kl_ent_ratio/mean` in `train.py`) and exposed via Prometheus (`trainer_kl_ent_ratio` gauge in `MetricsServer`), with unit tests updated to assert presence and correct value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8c9f9d0419bdd8c7ff8619920250b322959cbac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->