### PR TITLE
fix Hermes tool parser thread-safety crash under concurrent load

### DIFF
--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -23,6 +23,7 @@ from vllm.utils.argparse_utils import FlexibleArgumentParser
 
 from prime_rl.inference.config import InferenceConfig
 from prime_rl.inference.patches import (
+    monkey_patch_hermes_tool_parser_thread_safety,
     monkey_patch_load_lora_adapter,
     monkey_patch_prometheus_stat_logger_for_lora_in_dp_mode,
     monkey_patch_tokenize_params_validation,
@@ -38,6 +39,8 @@ monkey_patch_prometheus_stat_logger_for_lora_in_dp_mode()
 monkey_patch_load_lora_adapter()
 # NOTE: Monkeypatch TokenizeParams to fix overly conservative validation
 monkey_patch_tokenize_params_validation()
+# NOTE: Monkeypatch Hermes tool parser to fix "Already borrowed" RuntimeError under concurrent load
+monkey_patch_hermes_tool_parser_thread_safety()
 
 logger = init_logger("vllm.entrypoints.openai.api_server")
 


### PR DESCRIPTION
## Summary

- Fixes `RuntimeError: Already borrowed` crashes in vLLM's `Hermes2ProToolParser` when handling concurrent `/v1/chat/completions` requests with tool calling enabled
- Adds a monkey-patch in `prime_rl.inference.patches` that caches tokenizer encode/decode results behind a threading lock, so the shared HuggingFace tokenizer is only accessed once

## Problem

vLLM v0.16's `Hermes2ProToolParser.__init__` calls `tokenizer.encode("<tool_call>")` and `tokenizer.decode()` on **every** instantiation (i.e. every incoming request). Under concurrent load, multiple threads call these methods simultaneously on the same shared tokenizer. The tokenizer's Rust backend uses `RefCell`-style borrow tracking and panics when it detects concurrent mutable borrows:

```
RuntimeError: Already borrowed
  File ".../vllm/tool_parsers/hermes_tool_parser.py", line 63, in __init__
    self.tool_call_start_token_ids = self.model_tokenizer.encode(
  File ".../transformers/tokenization_utils_tokenizers.py", line 722
    self._tokenizer.no_truncation()
RuntimeError: Already borrowed
```

This caused ~1% of chat completion requests to return **500 Internal Server Error** (~189 failures out of ~21,000 requests observed in a single session).

## Fix

Added `monkey_patch_hermes_tool_parser_thread_safety()` to `patches.py`, following the existing monkey-patch pattern:

- **Slow path** (first call per tokenizer): runs the original `__init__` under a `threading.Lock`, then caches the computed token IDs and arrays
- **Fast path** (all subsequent calls): reconstructs the parser instance from the cache without ever calling `tokenizer.encode()`/`decode()`, eliminating both the race condition and redundant work

## Test plan

Tested with `uv run rl @ configs/wiki_search/rl.toml --log.level debug` — no `RuntimeError: Already borrowed` or 500 errors observed.


🤖 Generated with [Claude Code](https://claude.com/claude-code)