### PR TITLE
Fix Hermes tool parser thread-safety race with AsyncMicrobatchTokenizer

### DIFF
--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -23,6 +23,7 @@ from vllm.utils.argparse_utils import FlexibleArgumentParser
 
 from prime_rl.inference.config import InferenceConfig
 from prime_rl.inference.patches import (
+    monkey_patch_hermes_tool_parser_thread_safety,
     monkey_patch_load_lora_adapter,
     monkey_patch_prometheus_stat_logger_for_lora_in_dp_mode,
     monkey_patch_tokenize_params_validation,
@@ -38,6 +39,8 @@ monkey_patch_prometheus_stat_logger_for_lora_in_dp_mode()
 monkey_patch_load_lora_adapter()
 # NOTE: Monkeypatch TokenizeParams to fix overly conservative validation
 monkey_patch_tokenize_params_validation()
+# NOTE: Monkeypatch Hermes tool parser to cache tokenizer.encode() results (huggingface/tokenizers#537)
+monkey_patch_hermes_tool_parser_thread_safety()
 
 logger = init_logger("vllm.entrypoints.openai.api_server")
 


### PR DESCRIPTION
## Summary

- Cache tokenized `<tool_call>`/`</tool_call>` markers at the class level so `Hermes2ProToolParser.__init__()` never calls `tokenizer.encode()` after the first instantiation per tokenizer
- Eliminates `RuntimeError: Already borrowed` crash caused by concurrent access to the HuggingFace Rust tokenizer between `AsyncMicrobatchTokenizer`'s background thread and the per-request tool parser constructor ([huggingface/tokenizers#537](https://github.com/huggingface/tokenizers/issues/537))
- Under concurrent tool-calling load, ~18-38% of requests fail without this fix, causing unexecuted tool calls in RL rollouts

## Details

`AsyncMicrobatchTokenizer` dispatches `tokenizer.encode()` to a `ThreadPoolExecutor` while `Hermes2ProToolParser.__init__()` (which runs per-request at `serving.py:1044` and `serving.py:1287`) calls `tokenizer.encode("<tool_call>")` synchronously on the main asyncio thread. Both share the same underlying Rust tokenizer object, which panics with `RuntimeError: Already borrowed`.

The fix uses a class-level cache with double-checked locking: the first instantiation per tokenizer runs `encode()`/`decode()` and caches the results; all subsequent instantiations read from cache without touching the tokenizer.

This follows the existing monkey-patch pattern in `patches.py` (alongside patches for Prometheus stats, LoRA loading, tokenize params validation, and MiniMax M2).

## Test plan

- [x] Reproduced: 37/200 (18.5%) requests failed on a single vLLM v0.16.0 server with 32 concurrent tool-calling requests and long prompts
- [x] After patch: 500/500 requests succeed at 64 concurrency, 0 `Already borrowed` errors in server logs
- [ ] Full RL training run with tool-calling verifier to confirm rollout success rate improves

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches vLLM tool parsing via a runtime monkey patch; while scoped to init-time caching, regressions could break tool-call extraction or introduce subtle cross-tokenizer caching issues under concurrency.
> 
> **Overview**
> Prevents intermittent vLLM tool-calling crashes by monkey-patching `Hermes2ProToolParser.__init__` to cache `<tool_call>`/`</tool_call>` token IDs/decoded arrays per underlying tokenizer, avoiding concurrent `tokenizer.encode()`/`decode()` calls.
> 
> Wires this patch into the vLLM API server startup (`server.py`) so it’s applied alongside existing inference monkey patches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58b63ab9d16eb9969078f60b0f4b44e746d5cae0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->