### PR TITLE
robustify env crash detection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ override-dependencies = [
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 math-env = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "488bfad" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "0317556" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eeb" }
 transformers = { git = "https://github.com/huggingface/transformers.git", rev = "609e3d5" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ override-dependencies = [
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 math-env = { index = "primeintellect" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "013d4da" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "488bfad" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eeb" }
 transformers = { git = "https://github.com/huggingface/transformers.git", rev = "609e3d5" }

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -1,4 +1,5 @@
 import asyncio
+import multiprocessing as mp
 import random
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -164,9 +165,10 @@ async def orchestrate(config: OrchestratorConfig):
     )
 
     train_env_addresses = []
+    env_processes: list[mp.Process] = []
     for env_id, env, env_name in zip(env_ids, config.env, train_env_names):
         if env.address is None:
-            address = spawn_env_server(
+            address, process = spawn_env_server(
                 env_id=env_id,
                 env_args=env.args,
                 extra_env_kwargs=env.extra_env_kwargs,
@@ -175,6 +177,7 @@ async def orchestrate(config: OrchestratorConfig):
                 log_file_level=config.log.vf_level,
                 json_logging=config.log.json_logging,
             )
+            env_processes.append(process)
         else:
             address = env.address
         logger.info(f"Connecting train environment {env_name} to server at {address}")
@@ -201,7 +204,7 @@ async def orchestrate(config: OrchestratorConfig):
 
         for env_id, env, eval_env_name in zip(env_ids, config.eval.env, eval_env_names):
             if env.address is None:
-                address = spawn_env_server(
+                address, process = spawn_env_server(
                     env_id=env_id,
                     env_args=env.args,
                     extra_env_kwargs=env.extra_env_kwargs,
@@ -210,6 +213,7 @@ async def orchestrate(config: OrchestratorConfig):
                     log_file_level=config.log.vf_level,
                     json_logging=config.log.json_logging,
                 )
+                env_processes.append(process)
             else:
                 address = env.address
             logger.info(f"Connecting eval environment {eval_env_name} to server at {address}")
@@ -774,6 +778,14 @@ async def orchestrate(config: OrchestratorConfig):
 
     # Cancel event loop lag monitor task
     event_loop_lag_monitor_task.cancel()
+
+    # Shutdown env processes
+    for process in env_processes:
+        process.terminate()
+        process.join(timeout=5)
+        if process.is_alive():
+            process.kill()
+            process.join(timeout=5)
 
     logger.success("Orchestrator finished.")
 

--- a/src/prime_rl/orchestrator/vf_utils.py
+++ b/src/prime_rl/orchestrator/vf_utils.py
@@ -27,7 +27,7 @@ def spawn_env_server(
     log_file: str | None = None,
     log_file_level: str | None = None,
     json_logging: bool = False,
-) -> str:
+) -> tuple[str, mp.Process]:
     """
     Starts a ZMQEnvServer process in a subprocess.
 
@@ -37,7 +37,7 @@ def spawn_env_server(
     # Use spawn to avoid inheriting file descriptors (e.g. sockets) from
     # the parent process, which has caused hangs when multiple env server
     # subprocesses share the same fds.
-    mp.get_context("spawn").Process(
+    process = mp.get_context("spawn").Process(
         target=ZMQEnvServer.run_server,
         args=(
             env_id,
@@ -49,9 +49,10 @@ def spawn_env_server(
         ),
         kwargs=dict(address=address, json_logging=json_logging),
         daemon=False,  # cannot run daemon because env server uses subprocesses
-    ).start()
+    )
+    process.start()
 
-    return address
+    return address, process
 
 
 def setup_env_client(

--- a/src/prime_rl/orchestrator/vf_utils.py
+++ b/src/prime_rl/orchestrator/vf_utils.py
@@ -27,7 +27,6 @@ def spawn_env_server(
     log_file: str | None = None,
     log_file_level: str | None = None,
     json_logging: bool = False,
-    daemon: bool = True,
 ) -> str:
     """
     Starts a ZMQEnvServer process in a subprocess.
@@ -49,7 +48,7 @@ def spawn_env_server(
             log_file_level,
         ),
         kwargs=dict(address=address, json_logging=json_logging),
-        daemon=daemon,
+        daemon=False,  # cannot run daemon because env server uses subprocesses
     ).start()
 
     return address

--- a/uv.lock
+++ b/uv.lock
@@ -2373,7 +2373,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", git = "https://github.com/huggingface/transformers.git?rev=609e3d5" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=013d4da" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=488bfad" },
     { name = "vllm", url = "https://github.com/vllm-project/vllm/releases/download/v0.16.0/vllm-0.16.0-cp38-abi3-manylinux_2_31_x86_64.whl" },
     { name = "wandb", specifier = ">=0.24.2" },
 ]
@@ -3702,7 +3702,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.11.dev0"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=013d4da#013d4da8a906bef2e1cbb6b4bc4347214c1fd534" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=488bfad#488bfadf57912df1ed3237827313152ac0307f75" }
 dependencies = [
     { name = "anthropic" },
     { name = "datasets" },

--- a/uv.lock
+++ b/uv.lock
@@ -2373,7 +2373,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", git = "https://github.com/huggingface/transformers.git?rev=609e3d5" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=488bfad" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=0317556" },
     { name = "vllm", url = "https://github.com/vllm-project/vllm/releases/download/v0.16.0/vllm-0.16.0-cp38-abi3-manylinux_2_31_x86_64.whl" },
     { name = "wandb", specifier = ">=0.24.2" },
 ]
@@ -3702,7 +3702,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.11.dev0"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=488bfad#488bfadf57912df1ed3237827313152ac0307f75" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=0317556#031755682c1572be2bacad7c808680c95bfcdaef" }
 dependencies = [
     { name = "anthropic" },
     { name = "datasets" },


### PR DESCRIPTION
bumps verifiers to include fix for false env server crash detection ([#942](https://github.com/PrimeIntellect-ai/verifiers/pull/942)). env server does not run as daemon anymore because the env server has spawns a subprocess for responding to health checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes process lifecycle management for env servers and updates a core dependency, which could affect orchestrator shutdown semantics and resource cleanup across platforms.
> 
> **Overview**
> Improves orchestrator robustness by explicitly tracking spawned env server processes and forcefully shutting them down on exit (terminate/join, then kill as fallback), instead of relying on daemon subprocess behavior.
> 
> `spawn_env_server` now returns the `mp.Process` handle and always starts env servers as non-daemon processes (to support env servers that spawn subprocesses), and the `verifiers` dependency is bumped to a newer git rev to pick up related crash-detection fixes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 402254b2df2e16aa425955bbc521c38a0d6b104d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->