### PR TITLE
make tito default

### DIFF
--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -830,7 +830,7 @@ class OrchestratorConfig(BaseSettings):
         Field(
             description="Whether to use the token-in-token-out (TITO) client for training across all environments. WARNING: Only use this if your environment has a linear history and the chat template has the extension property (i.e. no tokens are ever removed or inserted by the chat template)"
         ),
-    ] = False
+    ] = True
 
     @model_validator(mode="after")
     def validate_unique_filter_types(self):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the default inference client selection for all orchestrator runs; if environments/chat templates are not compatible with TITO’s linear-history assumptions, rollouts or training behavior may break or differ.
> 
> **Overview**
> The orchestrator configuration now defaults `use_token_client` to `True`, so new runs use the token-in-token-out (TITO) inference client unless explicitly disabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00e4934e697e3ba799d8f7374d2ed8c0c77d0ac7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->