### PR TITLE
track seqs per rollout

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -497,14 +497,14 @@ async def orchestrate(config: OrchestratorConfig):
         train_examples: list[TrainingSample] = []
         rollout_prefill_lens: list[int] = []
         rollout_decode_lens: list[int] = []
-        rollout_seqs_per_rollout: list[int] = []
+        rollout_samples_per_rollout: list[int] = []
         num_prefill_tokens = 0
         num_decode_tokens = 0
         for rollout, advantage, samples in zip(train_rollouts, advantages, results):
             rollout_prefill_tokens = 0
             rollout_decode_tokens = 0
             if samples is not None:
-                rollout_seqs_per_rollout.append(len(samples))
+                rollout_samples_per_rollout.append(len(samples))
                 for sample in samples:
                     sample.advantage = advantage
                     sample.reward = rollout["reward"]
@@ -514,7 +514,7 @@ async def orchestrate(config: OrchestratorConfig):
                     rollout_prefill_tokens += sample_prefill_tokens
                     train_examples.append(sample)
             else:
-                rollout_seqs_per_rollout.append(0)
+                rollout_samples_per_rollout.append(0)
             rollout_prefill_lens.append(rollout_prefill_tokens)
             rollout_decode_lens.append(rollout_decode_tokens)
             num_prefill_tokens += rollout_prefill_tokens
@@ -582,7 +582,7 @@ async def orchestrate(config: OrchestratorConfig):
                 "seq_len": [get_seq_len(rollout) for rollout in train_rollouts],
                 "prefill_len": rollout_prefill_lens,
                 "decode_len": rollout_decode_lens,
-                "seqs_per_rollout": rollout_seqs_per_rollout,
+                "samples_per_rollout": rollout_samples_per_rollout,
                 "num_turns": [len(rollout["trajectory"]) for rollout in train_rollouts],
                 "generation_ms": [rollout["timing"]["generation_ms"] for rollout in train_rollouts],
                 "scoring_ms": [rollout["timing"]["scoring_ms"] for rollout in train_rollouts],
@@ -646,9 +646,9 @@ async def orchestrate(config: OrchestratorConfig):
             "is_truncated/max": results_df.groupby("example_id").is_truncated.mean().max(),
             "is_truncated/min": results_df.groupby("example_id").is_truncated.mean().min(),
             # Seqs per rollout metrics
-            "seqs_per_rollout/mean": results_df.groupby("example_id").seqs_per_rollout.mean().mean(),
-            "seqs_per_rollout/max": results_df.groupby("example_id").seqs_per_rollout.mean().max(),
-            "seqs_per_rollout/min": results_df.groupby("example_id").seqs_per_rollout.mean().min(),
+            "samples_per_rollout/mean": results_df.groupby("example_id").samples_per_rollout.mean().mean(),
+            "samples_per_rollout/max": results_df.groupby("example_id").samples_per_rollout.mean().max(),
+            "samples_per_rollout/min": results_df.groupby("example_id").samples_per_rollout.mean().min(),
             # Turn metrics
             "num_turns/mean": results_df.groupby("example_id").num_turns.mean().mean(),
             "num_turns/max": results_df.groupby("example_id").num_turns.mean().max(),

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -497,12 +497,14 @@ async def orchestrate(config: OrchestratorConfig):
         train_examples: list[TrainingSample] = []
         rollout_prefill_lens: list[int] = []
         rollout_decode_lens: list[int] = []
+        rollout_seqs_per_rollout: list[int] = []
         num_prefill_tokens = 0
         num_decode_tokens = 0
         for rollout, advantage, samples in zip(train_rollouts, advantages, results):
             rollout_prefill_tokens = 0
             rollout_decode_tokens = 0
             if samples is not None:
+                rollout_seqs_per_rollout.append(len(samples))
                 for sample in samples:
                     sample.advantage = advantage
                     sample.reward = rollout["reward"]
@@ -511,6 +513,8 @@ async def orchestrate(config: OrchestratorConfig):
                     rollout_decode_tokens += sample_decode_tokens
                     rollout_prefill_tokens += sample_prefill_tokens
                     train_examples.append(sample)
+            else:
+                rollout_seqs_per_rollout.append(0)
             rollout_prefill_lens.append(rollout_prefill_tokens)
             rollout_decode_lens.append(rollout_decode_tokens)
             num_prefill_tokens += rollout_prefill_tokens
@@ -578,6 +582,7 @@ async def orchestrate(config: OrchestratorConfig):
                 "seq_len": [get_seq_len(rollout) for rollout in train_rollouts],
                 "prefill_len": rollout_prefill_lens,
                 "decode_len": rollout_decode_lens,
+                "seqs_per_rollout": rollout_seqs_per_rollout,
                 "num_turns": [len(rollout["trajectory"]) for rollout in train_rollouts],
                 "generation_ms": [rollout["timing"]["generation_ms"] for rollout in train_rollouts],
                 "scoring_ms": [rollout["timing"]["scoring_ms"] for rollout in train_rollouts],
@@ -640,6 +645,10 @@ async def orchestrate(config: OrchestratorConfig):
             "is_truncated/mean": results_df.groupby("example_id").is_truncated.mean().mean(),
             "is_truncated/max": results_df.groupby("example_id").is_truncated.mean().max(),
             "is_truncated/min": results_df.groupby("example_id").is_truncated.mean().min(),
+            # Seqs per rollout metrics
+            "seqs_per_rollout/mean": results_df.groupby("example_id").seqs_per_rollout.mean().mean(),
+            "seqs_per_rollout/max": results_df.groupby("example_id").seqs_per_rollout.mean().max(),
+            "seqs_per_rollout/min": results_df.groupby("example_id").seqs_per_rollout.mean().min(),
             # Turn metrics
             "num_turns/mean": results_df.groupby("example_id").num_turns.mean().mean(),
             "num_turns/max": results_df.groupby("example_id").num_turns.mean().max(),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Purely adds new per-rollout accounting and logging; no changes to rollout generation, training data contents, or control flow beyond metric collection.
> 
> **Overview**
> Adds tracking of how many `TrainingSample`s are produced per rollout during parallel rollout processing (recording `0` when a rollout yields no samples).
> 
> Plumbs this value into `results_df` as `samples_per_rollout` and logs new aggregate metrics (`samples_per_rollout/{mean,max,min}`) grouped by `example_id` alongside existing sequence-length and timing stats.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93c9c38929d83b5a10b654166b1a5ce0b27ca33c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->