### PR TITLE
Fix tool_call_parser not resolved when model name is propagated

### DIFF
--- a/src/prime_rl/inference/config.py
+++ b/src/prime_rl/inference/config.py
@@ -3,11 +3,8 @@ from typing import Annotated, Any, Literal
 
 from pydantic import Field, model_validator
 
-from prime_rl.utils.logger import get_logger
 from prime_rl.utils.pydantic_config import BaseConfig, BaseSettings, get_all_fields
 from prime_rl.utils.utils import rgetattr, rsetattr
-
-logger = get_logger()
 
 MODEL_TOOL_CALL_PARSER: dict[str, str] = {
     # GLM-4.5
@@ -192,7 +189,6 @@ class ModelConfig(BaseConfig):
         if self.tool_call_parser is None:
             parser = MODEL_TOOL_CALL_PARSER.get(self.name)
             if parser is not None:
-                logger.info(f"Auto-detected tool_call_parser='{parser}' for model '{self.name}'")
                 self.tool_call_parser = parser
 
         if self.tool_call_parser is not None:
@@ -221,7 +217,7 @@ class InferenceConfig(BaseSettings):
     server: ServerConfig = ServerConfig()
 
     # The model configuration
-    model: ModelConfig = ModelConfig()
+    model: ModelConfig = Field(default_factory=ModelConfig)
 
     # The parallel configuration
     parallel: ParallelConfig = ParallelConfig()

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -22,6 +22,9 @@ from vllm.logger import init_logger
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 
 from prime_rl.inference.config import InferenceConfig
+from prime_rl.utils.logger import get_logger
+
+logger = get_logger()
 from prime_rl.inference.patches import (
     monkey_patch_hermes_tool_parser_thread_safety,
     monkey_patch_load_lora_adapter,
@@ -229,6 +232,9 @@ vllm.entrypoints.cli.serve.run_api_server_worker_proc = custom_run_api_server_wo
 def server(config: InferenceConfig, vllm_args: list[str]):
     from vllm.entrypoints.cli.serve import run_headless, run_multi_api_server
     from vllm.entrypoints.openai.api_server import run_server
+
+    if config.model.tool_call_parser is not None:
+        logger.info(f"Using tool_call_parser='{config.model.tool_call_parser}' for model '{config.model.name}'")
 
     parser = FlexibleArgumentParser(description="vLLM OpenAI-Compatible RESTful API server.")
     parser = make_arg_parser(parser)

--- a/src/prime_rl/rl_config.py
+++ b/src/prime_rl/rl_config.py
@@ -261,6 +261,9 @@ class BaseRLConfig(BaseSettings):
             self.orchestrator.model.name = self.model.name
             if self.inference is not None:
                 self.inference.model.name = self.model.name
+                self.inference.model.tool_call_parser = None
+                self.inference.model.enable_auto_tool_choice = False
+                self.inference.model.resolve_tool_call_parser()
 
         validate_shared_model_name(self.trainer, self.orchestrator, self.inference)
 


### PR DESCRIPTION
## Summary
- **Fix**: `auto_setup_model()` propagates `model.name` to `inference.model.name` *after* `ModelConfig.resolve_tool_call_parser()` has already run, so the tool_call_parser was resolved for the default model (`Qwen/Qwen3-0.6B` → `hermes`) instead of the actual model (e.g. `zai-org/GLM-4.5-Air` → `glm45`). Now re-resolves after propagating the name.
- **Cleanup**: Moved tool_call_parser auto-detection log from the pydantic validator (which fires on every `ModelConfig` construction, including during import) to `server()` where the config is actually consumed. Also switched `InferenceConfig.model` default to `default_factory` to avoid eager instantiation at class definition time.

## Test plan
- [ ] Verify `uv run python -c "from prime_rl.rl import RLConfig; cfg = RLConfig(model={'name': 'zai-org/GLM-4.5-Air'}, inference={}, ...); assert cfg.inference.model.tool_call_parser == 'glm45'"` 
- [ ] Verify unknown models get `tool_call_parser=None`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized config/initialization changes that mainly affect tool parser selection and logging; low risk aside from potential behavior changes in auto tool-choice defaults for inference.
> 
> **Overview**
> Fixes a config ordering bug where `RLConfig.auto_setup_model()` overwrote `inference.model.name` after `ModelConfig.resolve_tool_call_parser()` had already run, by resetting `tool_call_parser`/`enable_auto_tool_choice` and re-invoking `resolve_tool_call_parser()` after propagating the shared model name.
> 
> Cleans up inference config initialization by switching `InferenceConfig.model` to `Field(default_factory=ModelConfig)` and moving tool parser auto-detection logging out of the Pydantic validator into `vllm.server.server()` (logging the parser actually used at runtime).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9ea9affd99d320586d78554cfdade870193be99. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->