### PR TITLE
fix double logging in local execution

### DIFF
--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -332,10 +332,7 @@ def rl_local(config: RLConfig):
         monitor_threads.append(monitor_thread)
 
         # Monitor all processes for failures
-        logger.success("Startup complete. Showing trainer logs...")
-
-        tail_process = Popen(["tail", "-F", log_dir / "trainer.stdout"])
-        processes.append(tail_process)
+        logger.success("Startup complete. Following trainer logs...")
 
         # Check for errors from monitor threads
         while not (stop_events["orchestrator"].is_set() and stop_events["trainer"].is_set()):

--- a/src/prime_rl/entrypoints/sft.py
+++ b/src/prime_rl/entrypoints/sft.py
@@ -159,9 +159,7 @@ def sft_local(config: SFTTrainerConfig):
         monitor_thread.start()
         monitor_threads.append(monitor_thread)
 
-        logger.success("Startup complete. Showing trainer logs...")
-        tail_process = Popen(["tail", "-F", str(log_dir / "trainer.stdout")])
-        processes.append(tail_process)
+        logger.success("Startup complete. Following logs...")
 
         stop_event.wait()
 


### PR DESCRIPTION
prev, the rl and sft trainer would log each line twice (even on a single GPU), e.g.

```bash
uv run sft @ examples/reverse_text/sft.toml
```

## Before

<img width="1482" height="224" alt="Screenshot 2026-02-24 at 12 28 29 PM" src="https://github.com/user-attachments/assets/c3e41561-bc5d-4337-a4ef-2cf02701bf5f" />

## After

<img width="1479" height="181" alt="Screenshot 2026-02-24 at 12 27 45 PM" src="https://github.com/user-attachments/assets/8544a4d8-2dee-4115-bc07-19df93c1cb71" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change limited to local entrypoint log streaming; it removes an auxiliary `tail` process and should not affect training logic or data handling.
> 
> **Overview**
> Fixes duplicate console output during local `rl` and `sft` runs by removing the extra `tail -F` subprocess that followed `trainer.stdout`.
> 
> Startup messaging is updated to reflect that logs are being followed without spawning a separate tail process, while process monitoring/cleanup behavior remains unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ecb04ccb66384f088a0226f994c6547a1d028b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->