### PR TITLE
fix device mesh flattened dim deprecation warning

### DIFF
--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -274,10 +274,7 @@ def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDim
         "reshard_after_forward": config.reshard_after_forward,
     }
 
-    if config.dp_replicate > 1:
-        hsdp_mesh = parallel_dims.world_mesh["dp_replicate", "dp_shard_cp"]
-    else:
-        hsdp_mesh = parallel_dims.world_mesh["dp_shard_cp"]
+    hsdp_mesh = parallel_dims.get_mesh("hsdp")
 
     dp_mod_ep_mesh: DeviceMesh | None = None
     if parallel_dims.ep_enabled:
@@ -580,7 +577,7 @@ def apply_ep(model: nn.Module, parallel_dims: ParallelDims):
         if isinstance(transformer_block.mlp, MoE):
             parallelize_module(
                 transformer_block.mlp.experts,
-                device_mesh=parallel_dims.world_mesh["ep"],
+                device_mesh=parallel_dims.get_mesh("ep"),
                 parallelize_plan=ExpertParallel(),
             )
 

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -233,7 +233,7 @@ def _create_muon_optimizer(
     param_groups.append(dict(params=adamw_params, algorithm="adamw", lr=lr, weight_decay=config.weight_decay))
 
     if parallel_dims.dp_shard_enabled or parallel_dims.cp_enabled:
-        distributed_mesh = parallel_dims.world_mesh["dp_shard_cp"]
+        distributed_mesh = parallel_dims.get_mesh("dp_shard_cp")
     else:
         distributed_mesh = parallel_dims.world_mesh
 

--- a/src/prime_rl/trainer/parallel_dims.py
+++ b/src/prime_rl/trainer/parallel_dims.py
@@ -216,9 +216,10 @@ class ParallelDims:
         return self._world_mesh
 
     def get_mesh(self, name: str) -> DeviceMesh:
+        mesh = self.world_mesh  # ensure lazy init has run
         if name in self._submeshes:
             return self._submeshes[name]
-        return self.world_mesh[name]
+        return mesh[name]
 
     @property
     def dp_enabled(self):

--- a/src/prime_rl/trainer/parallel_dims.py
+++ b/src/prime_rl/trainer/parallel_dims.py
@@ -43,8 +43,10 @@ class ParallelDims:
     world_size: int
 
     _world_mesh: DeviceMesh = None
+    _submeshes: dict = None
 
     def __post_init__(self):
+        self._submeshes = {}
         self._validate()
 
     def _validate(self):
@@ -136,10 +138,19 @@ class ParallelDims:
             dp_cp_mesh_dim_names.append("cp")
             ep_mesh_dim_names.append("cp")
 
-        mesh[tuple(dp_mesh_dim_names)]._flatten(mesh_dim_name="dp")
-        mesh[tuple(dp_shard_cp_mesh_dim_names)]._flatten(mesh_dim_name="dp_shard_cp")
-        mesh[tuple(dp_cp_mesh_dim_names)]._flatten(mesh_dim_name="dp_cp")
-        mesh[tuple(ep_mesh_dim_names)]._flatten(mesh_dim_name="ep")
+        self._submeshes["dp"] = mesh[tuple(dp_mesh_dim_names)]._flatten(mesh_dim_name="dp")
+        self._submeshes["dp_shard_cp"] = mesh[tuple(dp_shard_cp_mesh_dim_names)]._flatten(mesh_dim_name="dp_shard_cp")
+        self._submeshes["dp_cp"] = mesh[tuple(dp_cp_mesh_dim_names)]._flatten(mesh_dim_name="dp_cp")
+        self._submeshes["ep"] = mesh[tuple(ep_mesh_dim_names)]._flatten(mesh_dim_name="ep")
+
+        if self.dp_replicate_enabled:
+            parent = mesh[tuple(["dp_replicate"] + dp_shard_cp_mesh_dim_names)]
+            hsdp_tensor = parent.mesh.reshape(self.dp_replicate, -1)
+            self._submeshes["hsdp"] = DeviceMesh(
+                device_type, hsdp_tensor, mesh_dim_names=("dp_replicate", "dp_shard_cp")
+            )
+        else:
+            self._submeshes["hsdp"] = self._submeshes["dp_shard_cp"]
 
         return mesh
 
@@ -177,11 +188,22 @@ class ParallelDims:
             dp_cp_mesh_dim_names.append("cp")
 
         if dp_mesh_dim_names != []:
-            mesh[tuple(dp_mesh_dim_names)]._flatten(mesh_dim_name="dp")
+            self._submeshes["dp"] = mesh[tuple(dp_mesh_dim_names)]._flatten(mesh_dim_name="dp")
         if dp_shard_cp_mesh_dim_names != []:
-            mesh[tuple(dp_shard_cp_mesh_dim_names)]._flatten(mesh_dim_name="dp_shard_cp")
+            self._submeshes["dp_shard_cp"] = mesh[tuple(dp_shard_cp_mesh_dim_names)]._flatten(
+                mesh_dim_name="dp_shard_cp"
+            )
         if dp_cp_mesh_dim_names != []:
-            mesh[tuple(dp_cp_mesh_dim_names)]._flatten(mesh_dim_name="dp_cp")
+            self._submeshes["dp_cp"] = mesh[tuple(dp_cp_mesh_dim_names)]._flatten(mesh_dim_name="dp_cp")
+
+        if self.dp_replicate_enabled:
+            parent = mesh[tuple(["dp_replicate"] + dp_shard_cp_mesh_dim_names)]
+            hsdp_tensor = parent.mesh.reshape(self.dp_replicate, -1)
+            self._submeshes["hsdp"] = DeviceMesh(
+                device_type, hsdp_tensor, mesh_dim_names=("dp_replicate", "dp_shard_cp")
+            )
+        else:
+            self._submeshes["hsdp"] = self._submeshes["dp_shard_cp"]
 
         return mesh
 
@@ -192,6 +214,11 @@ class ParallelDims:
         if self._world_mesh is None:
             self._world_mesh = self.build_mesh()
         return self._world_mesh
+
+    def get_mesh(self, name: str) -> DeviceMesh:
+        if name in self._submeshes:
+            return self._submeshes[name]
+        return self.world_mesh[name]
 
     @property
     def dp_enabled(self):

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -191,12 +191,12 @@ def train(config: RLTrainerConfig):
     # Set up the data loader (Optionally, use a fake data loader for debugging)
     logger.info(f"Initializing data loader ({config.data})")
     if config.data.fake:
-        dataloader = FakeDataLoader(config.data.fake, config.model.seq_len, parallel_dims.world_mesh["dp"].size())
+        dataloader = FakeDataLoader(config.data.fake, config.model.seq_len, parallel_dims.get_mesh("dp").size())
     else:
         dataloader = DataLoader(
             config.output_dir,
             progress.step,
-            parallel_dims.world_mesh["dp"].size(),
+            parallel_dims.get_mesh("dp").size(),
             config.model.seq_len,
             config.model.cp,
             tokenizer,
@@ -468,7 +468,7 @@ def train(config: RLTrainerConfig):
 
         # Compute step metrics
         num_local_tokens = seq_len * batch_size
-        num_tokens = parallel_dims.world_mesh["dp"].size() * num_local_tokens
+        num_tokens = parallel_dims.get_mesh("dp").size() * num_local_tokens
         progress.total_tokens += num_tokens
         progress.total_samples += batch_size
         perf_counter = get_perf_counter(model, seq_len)


### PR DESCRIPTION
## Summary

- Store `_flatten()` return values in a `_submeshes` dict on `ParallelDims` instead of discarding them
- Add `get_mesh(name)` method that looks up stored submeshes first, falling back to `world_mesh[name]` for non-flattened dims
- Pre-build the HSDP 2D mesh (for `fully_shard` when `dp_replicate > 1`) from the root mesh tensor, avoiding access to flattened dims through `world_mesh.__getitem__`
- Update all call sites in `model.py`, `optim.py`, and `rl/train.py` to use `get_mesh()` for flattened dims (`dp`, `dp_shard_cp`, `dp_cp`, `ep`, `hsdp`)

PyTorch 2.10+ warns: *"Slicing a flattened dim from root mesh will be deprecated in PT 2.11."* This fires whenever code accesses a flattened dimension through `world_mesh["dp"]` etc. In PT 2.11, this path will break entirely.

## Before

<img width="1418" height="402" alt="Screenshot 2026-02-24 at 4 24 43 PM" src="https://github.com/user-attachments/assets/059961c9-429b-45e4-877b-ca4dacc70d12" />

## After

<img width="1433" height="613" alt="Screenshot 2026-02-24 at 4 25 01 PM" src="https://github.com/user-attachments/assets/13d93f78-d0c9-449a-9660-a41b68596f8d" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior should be unchanged, but it touches distributed mesh selection for FSDP/EP/optimizer and token-counting; miscomputed submeshes could break multi-GPU training layouts.
> 
> **Overview**
> Eliminates PyTorch `DeviceMesh` flattened-dimension deprecation warnings by caching the return values of `_flatten()` in `ParallelDims` and routing lookups through a new `ParallelDims.get_mesh()` API.
> 
> Pre-builds an `hsdp` 2D mesh for HSDP/FSDP wrapping (handling `dp_replicate>1`) without slicing flattened dims from the root mesh, and updates FSDP setup, MoE expert parallelization, Muon’s `distributed_mesh`, and RL dataloader/token accounting to use `get_mesh()` for `dp`, `dp_shard_cp`, `ep`, and `hsdp`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 759ef6979458f055e973ec5179da7496f712324d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->