### PR TITLE
replace callable discriminator with field values

### DIFF
--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Annotated, Any, Literal, TypeAlias
 
-from pydantic import AliasChoices, BaseModel, ConfigDict, Discriminator, Field, Tag, model_validator
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, model_validator
 
 from prime_rl.transport.config import FileSystemTransportConfig, TransportConfigType
 from prime_rl.utils.config import (
@@ -548,8 +548,10 @@ class BufferConfig(BaseConfig):
         return self
 
 
-class AdvantageConfig(BaseConfig):
+class AdvantageConfig(BaseModel):
     """Config for the default advantage."""
+
+    model_config = ConfigDict(extra="forbid")
 
     type: Literal["default"] = "default"
     length_weighted_mean: bool = False
@@ -567,15 +569,9 @@ class CustomAdvantageConfig(BaseModel):
     ]
 
 
-def _advantage_config_discriminator(v: Any) -> str:
-    if isinstance(v, dict):
-        return v.get("type", "default")
-    return getattr(v, "type", "default")
-
-
 AdvantageConfigType: TypeAlias = Annotated[
-    Annotated[AdvantageConfig, Tag("default")] | Annotated[CustomAdvantageConfig, Tag("custom")],
-    Discriminator(_advantage_config_discriminator),
+    AdvantageConfig | CustomAdvantageConfig,
+    Field(discriminator="type"),
 ]
 
 


### PR DESCRIPTION
As per [Pydantic docs](https://docs.pydantic.dev/latest/concepts/unions/#discriminated-unions) we only need callable discriminators if the config variants don't have shared args. In our case, they always have the shared `type` arg which we use to "quick-switch" between variants defaults, so we can remove this complexity.

## Summary
- Replace callable `Discriminator` + `Tag` pattern with simple `Field(discriminator="type")` for `LossConfigType` and `AdvantageConfigType`
- Both union members already have a shared `type: Literal[...]` field, making the callable discriminator unnecessary
- The `_default_discriminator_types` before validator on `BaseSettings` already handles injecting `type` from defaults when missing
- Change `LossConfig` and `AdvantageConfig` from `BaseConfig` to `BaseModel` (with `extra="forbid"`) because `BaseConfig`'s `field_validator("*", mode="before")` conflicts with pydantic's string-based discriminator. Neither model has `Optional` fields that need the `empty_str_to_none` validator.

## Test plan
- [x] All 59 config tests pass (`pytest tests/unit/test_configs.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a config/type refactor with broad but mechanical renames; risk is limited to config parsing/serialization edge cases around discriminated unions and default injection.
> 
> **Overview**
> Simplifies multiple Pydantic union configs by removing callable `Discriminator`/`Tag` usage and standardizing on `Field(discriminator="type")` unions (notably RL `LossConfig` and orchestrator `AdvantageConfig`).
> 
> Renames several `*ConfigType` type aliases to `*Config` (e.g., `TransportConfig`, `FilterConfig`, `OptimizerConfig`, `SchedulerConfig`, `DeploymentConfig`, `WeightBroadcastConfig`) and updates all call sites, defaults, and a few `isinstance` checks (e.g., `DefaultLossConfig`) plus unit tests to match the new names and default model classes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b381818e71429ec7e242782f055413e00dca675f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->