### PR TITLE
cleaner naming for discriminated unions in config

### DIFF
--- a/src/prime_rl/orchestrator/advantage.py
+++ b/src/prime_rl/orchestrator/advantage.py
@@ -5,7 +5,7 @@ import torch
 from jaxtyping import Float, Int
 from torch import Tensor
 
-from prime_rl.orchestrator.config import AdvantageConfigType, CustomAdvantageConfig
+from prime_rl.orchestrator.config import AdvantageConfig, CustomAdvantageConfig
 from prime_rl.utils.utils import import_object
 
 
@@ -45,7 +45,7 @@ def default_advantage_fn(inputs: AdvantageInputs, length_weighted_mean: bool = F
     return AdvantageOutputs(advantages=inputs.rewards - baseline)
 
 
-def setup_advantage_fn(config: AdvantageConfigType) -> AdvantageFn:
+def setup_advantage_fn(config: AdvantageConfig) -> AdvantageFn:
     """Setup advantage function from config."""
     if isinstance(config, CustomAdvantageConfig):
         custom_fn = import_object(config.import_path)
@@ -66,7 +66,7 @@ def compute_advantages(
     rewards: list[float],
     completion_lengths: list[int],
     samples_per_problem: int,
-    advantage_config: AdvantageConfigType | None,
+    advantage_config: AdvantageConfig | None,
 ) -> list[float]:
     """
     Computes advantages from a flattened list of rewards, grouped by problem.
@@ -75,7 +75,7 @@ def compute_advantages(
         rewards: Flattened list of rewards where first `samples_per_problem` rewards are for the first problem
         completion_lengths: List of completion lengths for each reward
         samples_per_problem: Number of samples (and thus, rewards) per problem
-        advantage_config: Configuration for advantage computation (AdvantageConfig or CustomAdvantageConfig)
+        advantage_config: Configuration for advantage computation (DefaultAdvantageConfig or CustomAdvantageConfig)
     """
     if not advantage_config:
         return rewards

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -3,7 +3,7 @@ from typing import Annotated, Any, Literal, TypeAlias
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, model_validator
 
-from prime_rl.transport.config import FileSystemTransportConfig, TransportConfigType
+from prime_rl.transport.config import FileSystemTransportConfig, TransportConfig
 from prime_rl.utils.config import (
     ClientConfig,
     HeartbeatConfig,
@@ -548,7 +548,7 @@ class BufferConfig(BaseConfig):
         return self
 
 
-class AdvantageConfig(BaseModel):
+class DefaultAdvantageConfig(BaseModel):
     """Config for the default advantage."""
 
     model_config = ConfigDict(extra="forbid")
@@ -569,8 +569,8 @@ class CustomAdvantageConfig(BaseModel):
     ]
 
 
-AdvantageConfigType: TypeAlias = Annotated[
-    AdvantageConfig | CustomAdvantageConfig,
+AdvantageConfig: TypeAlias = Annotated[
+    DefaultAdvantageConfig | CustomAdvantageConfig,
     Field(discriminator="type"),
 ]
 
@@ -625,7 +625,7 @@ class RepetitionFilterConfig(BaseModel):
     ] = 0.99
 
 
-FilterConfigType: TypeAlias = Annotated[
+FilterConfig: TypeAlias = Annotated[
     GibberishFilterConfig | RepetitionFilterConfig,
     Field(discriminator="type"),
 ]
@@ -647,7 +647,7 @@ class NCCLWeightBroadcastConfig(BaseModel):
     timeout: Annotated[int, Field(description="The timeout in seconds to use for the NCCL broadcast.")] = 1200
 
 
-WeightBroadcastConfigType: TypeAlias = FileSystemWeightBroadcastConfig | NCCLWeightBroadcastConfig
+WeightBroadcastConfig: TypeAlias = FileSystemWeightBroadcastConfig | NCCLWeightBroadcastConfig
 
 
 class TeacherModelConfig(BaseConfig):
@@ -699,10 +699,10 @@ class OrchestratorConfig(BaseSettings):
     buffer: BufferConfig = BufferConfig()
 
     # The advantage configuration
-    advantage: AdvantageConfigType | None = AdvantageConfig()
+    advantage: AdvantageConfig | None = DefaultAdvantageConfig()
 
     # Rollout filters (monitor by default, enforce optionally)
-    filters: list[FilterConfigType] = [GibberishFilterConfig(), RepetitionFilterConfig()]
+    filters: list[FilterConfig] = [GibberishFilterConfig(), RepetitionFilterConfig()]
 
     # The logging configuration
     log: LogConfig = LogConfig()
@@ -719,11 +719,9 @@ class OrchestratorConfig(BaseSettings):
     # The validation configuration
     val: ValConfig | None = None
 
-    weight_broadcast: Annotated[WeightBroadcastConfigType, Field(discriminator="type")] = (
-        FileSystemWeightBroadcastConfig()
-    )
+    weight_broadcast: Annotated[WeightBroadcastConfig, Field(discriminator="type")] = FileSystemWeightBroadcastConfig()
 
-    rollout_transport: Annotated[TransportConfigType, Field(discriminator="type")] = FileSystemTransportConfig()
+    rollout_transport: Annotated[TransportConfig, Field(discriminator="type")] = FileSystemTransportConfig()
 
     output_dir: Annotated[
         Path,

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -647,7 +647,9 @@ class NCCLWeightBroadcastConfig(BaseModel):
     timeout: Annotated[int, Field(description="The timeout in seconds to use for the NCCL broadcast.")] = 1200
 
 
-WeightBroadcastConfig: TypeAlias = FileSystemWeightBroadcastConfig | NCCLWeightBroadcastConfig
+WeightBroadcastConfig: TypeAlias = Annotated[
+    FileSystemWeightBroadcastConfig | NCCLWeightBroadcastConfig, Field(discriminator="type")
+]
 
 
 class TeacherModelConfig(BaseConfig):
@@ -719,9 +721,9 @@ class OrchestratorConfig(BaseSettings):
     # The validation configuration
     val: ValConfig | None = None
 
-    weight_broadcast: Annotated[WeightBroadcastConfig, Field(discriminator="type")] = FileSystemWeightBroadcastConfig()
+    weight_broadcast: WeightBroadcastConfig = FileSystemWeightBroadcastConfig()
 
-    rollout_transport: Annotated[TransportConfig, Field(discriminator="type")] = FileSystemTransportConfig()
+    rollout_transport: TransportConfig = FileSystemTransportConfig()
 
     output_dir: Annotated[
         Path,

--- a/src/prime_rl/orchestrator/filters.py
+++ b/src/prime_rl/orchestrator/filters.py
@@ -14,7 +14,7 @@ from typing import Protocol
 import verifiers as vf
 from loguru import logger
 
-from prime_rl.orchestrator.config import FilterConfigType
+from prime_rl.orchestrator.config import FilterConfig
 
 
 @dataclass
@@ -95,7 +95,7 @@ class RepetitionFilter:
         return FilterResult(detected=False)
 
 
-def setup_filter(config: FilterConfigType, vocab_size: int) -> RolloutFilter:
+def setup_filter(config: FilterConfig, vocab_size: int) -> RolloutFilter:
     """Create a RolloutFilter from a filter config."""
     if config.type == "gibberish":
         return GibberishFilter(
@@ -114,7 +114,7 @@ def setup_filter(config: FilterConfigType, vocab_size: int) -> RolloutFilter:
     raise ValueError(f"Unknown filter type: {config.type}")
 
 
-def setup_filters(configs: list[FilterConfigType], vocab_size: int) -> list[RolloutFilter]:
+def setup_filters(configs: list[FilterConfig], vocab_size: int) -> list[RolloutFilter]:
     """Create RolloutFilters from a list of filter configs."""
     return [setup_filter(config, vocab_size) for config in configs]
 

--- a/src/prime_rl/rl_config.py
+++ b/src/prime_rl/rl_config.py
@@ -189,7 +189,7 @@ class RLConfig(BaseSettings):
         ),
     ] = False
 
-    deployment: Annotated[DeploymentConfig, Field(discriminator="type")] = SingleNodeDeploymentConfig()
+    deployment: DeploymentConfig = SingleNodeDeploymentConfig()
 
     slurm: Annotated[SlurmConfig | None, Field(description="SLURM configuration. If None, will run locally.")] = None
 

--- a/src/prime_rl/rl_config.py
+++ b/src/prime_rl/rl_config.py
@@ -151,7 +151,7 @@ class MultiNodeDeploymentConfig(BaseDeploymentConfig):
         return self
 
 
-DeploymentConfigType: TypeAlias = Annotated[
+DeploymentConfig: TypeAlias = Annotated[
     SingleNodeDeploymentConfig | MultiNodeDeploymentConfig, Field(discriminator="type")
 ]
 
@@ -189,7 +189,7 @@ class RLConfig(BaseSettings):
         ),
     ] = False
 
-    deployment: Annotated[DeploymentConfigType, Field(discriminator="type")] = SingleNodeDeploymentConfig()
+    deployment: Annotated[DeploymentConfig, Field(discriminator="type")] = SingleNodeDeploymentConfig()
 
     slurm: Annotated[SlurmConfig | None, Field(description="SLURM configuration. If None, will run locally.")] = None
 

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -403,7 +403,9 @@ class CosineSchedulerConfig(BaseModel):
     min_lr: Annotated[float, Field(ge=0, description="Minimum learning rate to converge to.")] = 0.0
 
 
-SchedulerConfig: TypeAlias = ConstantSchedulerConfig | LinearSchedulerConfig | CosineSchedulerConfig
+SchedulerConfig: TypeAlias = Annotated[
+    ConstantSchedulerConfig | LinearSchedulerConfig | CosineSchedulerConfig, Field(discriminator="type")
+]
 
 
 class BaseOptimizerConfig(BaseModel):
@@ -437,7 +439,7 @@ class MuonConfig(BaseOptimizerConfig):
     ] = 0.95
 
 
-OptimizerConfig: TypeAlias = SGDConfig | AdamWConfig | MuonConfig
+OptimizerConfig: TypeAlias = Annotated[SGDConfig | AdamWConfig | MuonConfig, Field(discriminator="type")]
 
 
 class WeightCheckpointConfig(BaseConfig):

--- a/src/prime_rl/trainer/config.py
+++ b/src/prime_rl/trainer/config.py
@@ -403,7 +403,7 @@ class CosineSchedulerConfig(BaseModel):
     min_lr: Annotated[float, Field(ge=0, description="Minimum learning rate to converge to.")] = 0.0
 
 
-SchedulerConfigType: TypeAlias = ConstantSchedulerConfig | LinearSchedulerConfig | CosineSchedulerConfig
+SchedulerConfig: TypeAlias = ConstantSchedulerConfig | LinearSchedulerConfig | CosineSchedulerConfig
 
 
 class BaseOptimizerConfig(BaseModel):
@@ -437,7 +437,7 @@ class MuonConfig(BaseOptimizerConfig):
     ] = 0.95
 
 
-OptimizerConfigType: TypeAlias = SGDConfig | AdamWConfig | MuonConfig
+OptimizerConfig: TypeAlias = SGDConfig | AdamWConfig | MuonConfig
 
 
 class WeightCheckpointConfig(BaseConfig):

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -8,7 +8,7 @@ from torch import nn
 from torch.distributed.tensor import DTensor
 from torch.optim import SGD, AdamW, Optimizer
 
-from prime_rl.trainer.config import OptimizerConfigType
+from prime_rl.trainer.config import OptimizerConfig
 from prime_rl.trainer.parallel_dims import ParallelDims
 from prime_rl.trainer.runs import get_multi_run_manager
 from prime_rl.trainer.world import get_world
@@ -110,7 +110,7 @@ class CPUOffloadOptimizer:
 
 
 def setup_optimizer(
-    config: OptimizerConfigType,
+    config: OptimizerConfig,
     named_params: list[tuple[str, nn.Parameter]],
     parallel_dims: ParallelDims,
     lora: bool = False,
@@ -140,7 +140,7 @@ def setup_optimizer(
 
 
 def _create_optimizer(
-    config: OptimizerConfigType,
+    config: OptimizerConfig,
     named_params: list[tuple[str, nn.Parameter]],
     parallel_dims: ParallelDims,
     lr: float | None = None,
@@ -169,7 +169,7 @@ def _create_optimizer(
 
 
 def _create_muon_optimizer(
-    config: OptimizerConfigType,
+    config: OptimizerConfig,
     named_params: list[tuple[str, nn.Parameter]],
     parallel_dims: ParallelDims,
     lr: float | None = None,
@@ -252,7 +252,7 @@ def _create_muon_optimizer(
 
 
 class MultiLoRAOptimizer:
-    def __init__(self, config: OptimizerConfigType, parallel_dims: ParallelDims):
+    def __init__(self, config: OptimizerConfig, parallel_dims: ParallelDims):
         self.config = config
         self.parallel_dims = parallel_dims
         self.multi_run_manager = get_multi_run_manager()
@@ -309,5 +309,5 @@ class MultiLoRAOptimizer:
             return self.optimizers[idx].param_groups[0]["lr"]
 
 
-def setup_multi_optimizer(config: OptimizerConfigType, parallel_dims: ParallelDims) -> MultiLoRAOptimizer:
+def setup_multi_optimizer(config: OptimizerConfig, parallel_dims: ParallelDims) -> MultiLoRAOptimizer:
     return MultiLoRAOptimizer(config, parallel_dims)

--- a/src/prime_rl/trainer/rl/broadcast/__init__.py
+++ b/src/prime_rl/trainer/rl/broadcast/__init__.py
@@ -6,11 +6,11 @@ from prime_rl.trainer.config import LoRAConfig
 from prime_rl.trainer.rl.broadcast.base import WeightBroadcast
 from prime_rl.trainer.rl.broadcast.filesystem import FileSystemWeightBroadcast
 from prime_rl.trainer.rl.broadcast.nccl import NCCLWeightBroadcast
-from prime_rl.trainer.rl.config import WeightBroadcastConfigType
+from prime_rl.trainer.rl.config import WeightBroadcastConfig
 
 
 def setup_weight_broadcast(
-    output_dir: Path, config: WeightBroadcastConfigType, lora_config: LoRAConfig | None = None
+    output_dir: Path, config: WeightBroadcastConfig, lora_config: LoRAConfig | None = None
 ) -> WeightBroadcast:
     if config.type == "nccl":
         return NCCLWeightBroadcast(output_dir, config, torch.cuda.current_device())

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -9,16 +9,16 @@ from prime_rl.trainer.config import (
     CheckpointConfig,
     ConstantSchedulerConfig,
     ModelConfig,
-    OptimizerConfigType,
-    SchedulerConfigType,
+    OptimizerConfig,
+    SchedulerConfig,
     TokenizerConfig,
 )
-from prime_rl.transport.config import FileSystemTransportConfig, TransportConfigType
+from prime_rl.transport.config import FileSystemTransportConfig, TransportConfig
 from prime_rl.utils.config import HeartbeatConfig, LogConfig, MetricsServerConfig, WandbConfig
 from prime_rl.utils.pydantic_config import BaseConfig, BaseSettings
 
 
-class LossConfig(BaseModel):
+class DefaultLossConfig(BaseModel):
     """Config for the default loss."""
 
     model_config = ConfigDict(extra="forbid")
@@ -83,8 +83,8 @@ class CustomLossConfig(BaseModel):
     kwargs: Annotated[dict[str, Any], Field(default_factory=dict, description="Kwargs to pass to the loss function")]
 
 
-LossConfigType: TypeAlias = Annotated[
-    LossConfig | CustomLossConfig,
+LossConfig: TypeAlias = Annotated[
+    DefaultLossConfig | CustomLossConfig,
     Field(discriminator="type"),
 ]
 
@@ -131,7 +131,7 @@ class NCCLWeightBroadcastConfig(BaseWeightBroadcastConfig):
     inference_world_size: Annotated[int, Field(description="The number of GPUs used for inference.")] = 1
 
 
-WeightBroadcastConfigType: TypeAlias = FileSystemWeightBroadcastConfig | NCCLWeightBroadcastConfig
+WeightBroadcastConfig: TypeAlias = FileSystemWeightBroadcastConfig | NCCLWeightBroadcastConfig
 
 
 class RLTrainerConfig(BaseSettings):
@@ -147,22 +147,20 @@ class RLTrainerConfig(BaseSettings):
     data: DataLoaderConfig = DataLoaderConfig()
 
     # The loss configuration
-    loss: LossConfigType = LossConfig()
+    loss: LossConfig = DefaultLossConfig()
 
     # The optimizer configuration
-    optim: Annotated[OptimizerConfigType, Field(discriminator="type")] = AdamWConfig()
+    optim: Annotated[OptimizerConfig, Field(discriminator="type")] = AdamWConfig()
 
     # The learning rate scheduler configuration
-    scheduler: Annotated[SchedulerConfigType, Field(discriminator="type")] = ConstantSchedulerConfig()
+    scheduler: Annotated[SchedulerConfig, Field(discriminator="type")] = ConstantSchedulerConfig()
 
     # The checkpoint configuration
     ckpt: CheckpointConfig | None = None
 
-    weight_broadcast: Annotated[WeightBroadcastConfigType, Field(discriminator="type")] = (
-        FileSystemWeightBroadcastConfig()
-    )
+    weight_broadcast: Annotated[WeightBroadcastConfig, Field(discriminator="type")] = FileSystemWeightBroadcastConfig()
 
-    rollout_transport: Annotated[TransportConfigType, Field(discriminator="type")] = FileSystemTransportConfig()
+    rollout_transport: Annotated[TransportConfig, Field(discriminator="type")] = FileSystemTransportConfig()
 
     # The logging configuration
     log: LogConfig = LogConfig()

--- a/src/prime_rl/trainer/rl/config.py
+++ b/src/prime_rl/trainer/rl/config.py
@@ -131,7 +131,9 @@ class NCCLWeightBroadcastConfig(BaseWeightBroadcastConfig):
     inference_world_size: Annotated[int, Field(description="The number of GPUs used for inference.")] = 1
 
 
-WeightBroadcastConfig: TypeAlias = FileSystemWeightBroadcastConfig | NCCLWeightBroadcastConfig
+WeightBroadcastConfig: TypeAlias = Annotated[
+    FileSystemWeightBroadcastConfig | NCCLWeightBroadcastConfig, Field(discriminator="type")
+]
 
 
 class RLTrainerConfig(BaseSettings):
@@ -150,17 +152,17 @@ class RLTrainerConfig(BaseSettings):
     loss: LossConfig = DefaultLossConfig()
 
     # The optimizer configuration
-    optim: Annotated[OptimizerConfig, Field(discriminator="type")] = AdamWConfig()
+    optim: OptimizerConfig = AdamWConfig()
 
     # The learning rate scheduler configuration
-    scheduler: Annotated[SchedulerConfig, Field(discriminator="type")] = ConstantSchedulerConfig()
+    scheduler: SchedulerConfig = ConstantSchedulerConfig()
 
     # The checkpoint configuration
     ckpt: CheckpointConfig | None = None
 
-    weight_broadcast: Annotated[WeightBroadcastConfig, Field(discriminator="type")] = FileSystemWeightBroadcastConfig()
+    weight_broadcast: WeightBroadcastConfig = FileSystemWeightBroadcastConfig()
 
-    rollout_transport: Annotated[TransportConfig, Field(discriminator="type")] = FileSystemTransportConfig()
+    rollout_transport: TransportConfig = FileSystemTransportConfig()
 
     # The logging configuration
     log: LogConfig = LogConfig()

--- a/src/prime_rl/trainer/rl/data.py
+++ b/src/prime_rl/trainer/rl/data.py
@@ -10,7 +10,7 @@ from prime_rl.trainer.rl.config import FakeDataLoaderConfig
 from prime_rl.trainer.rl.packer import BasePacker, setup_packer
 from prime_rl.trainer.runs import get_multi_run_manager
 from prime_rl.trainer.world import get_world
-from prime_rl.transport import MicroBatch, MicroBatchReceiver, TransportConfigType, setup_micro_batch_receiver
+from prime_rl.transport import MicroBatch, MicroBatchReceiver, TransportConfig, setup_micro_batch_receiver
 
 
 class TensorMicroBatch(TypedDict):
@@ -142,7 +142,7 @@ class DataLoader:
         seq_len: int,
         pad_to_multiple_of: int,
         tokenizer: PreTrainedTokenizer,
-        config: TransportConfigType,
+        config: TransportConfig,
     ):
         self.world = get_world()
 

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -6,7 +6,7 @@ from beartype import beartype as typechecker
 from jaxtyping import Bool, Float, Int, jaxtyped
 from torch import Tensor
 
-from prime_rl.trainer.rl.config import CustomLossConfig, LossConfig, LossConfigType
+from prime_rl.trainer.rl.config import CustomLossConfig, DefaultLossConfig, LossConfig
 from prime_rl.utils.utils import import_object
 
 
@@ -104,7 +104,7 @@ def _safe_mean(values: Tensor, mask: Tensor) -> Tensor:
     return values[mask].sum() / denom
 
 
-def default_loss_fn(inputs: LossInputs, loss_config: LossConfig) -> LossOutputs:
+def default_loss_fn(inputs: LossInputs, loss_config: DefaultLossConfig) -> LossOutputs:
     """Masked importance sampling with KL against the inference policy, and optional masking strategies."""
     trainer_logprobs = inputs.trainer_logprobs
     inference_logprobs = inputs.inference_logprobs
@@ -173,7 +173,7 @@ def default_loss_fn(inputs: LossInputs, loss_config: LossConfig) -> LossOutputs:
     return LossOutputs(loss=loss, metrics=metrics)
 
 
-def setup_loss_fn(loss_config: LossConfigType) -> LossFn:
+def setup_loss_fn(loss_config: LossConfig) -> LossFn:
     """Setup the loss function based on config."""
     if isinstance(loss_config, CustomLossConfig):
         custom_fn = import_object(loss_config.import_path)

--- a/src/prime_rl/trainer/rl/packer.py
+++ b/src/prime_rl/trainer/rl/packer.py
@@ -11,7 +11,7 @@ from prime_rl.transport import (
     MicroBatch,
     MicroBatchSender,
     TrainingSample,
-    TransportConfigType,
+    TransportConfig,
     setup_micro_batch_sender,
     setup_training_batch_receiver,
 )
@@ -28,7 +28,7 @@ class BasePacker(ABC):
         seq_len: int,
         pad_to_multiple_of: int,
         tokenizer: PreTrainedTokenizer,
-        config: TransportConfigType,
+        config: TransportConfig,
         start_step: int = 0,
     ):
         self.logger = get_logger()
@@ -56,7 +56,7 @@ class SinglePacker(BasePacker):
         seq_len: int,
         pad_to_multiple_of: int,
         tokenizer: PreTrainedTokenizer,
-        config: TransportConfigType,
+        config: TransportConfig,
         start_step: int = 0,
     ):
         super().__init__(dp_world_size, seq_len, pad_to_multiple_of, tokenizer, config, start_step)
@@ -94,7 +94,7 @@ class MultiPacker(BasePacker):
         seq_len: int,
         pad_to_multiple_of: int,
         tokenizer: PreTrainedTokenizer,
-        config: TransportConfigType,
+        config: TransportConfig,
         start_step: int = 0,
     ):
         super().__init__(dp_world_size, seq_len, pad_to_multiple_of, tokenizer, config, start_step)
@@ -311,7 +311,7 @@ def setup_packer(
     seq_len: int,
     pad_to_multiple_of: int,
     tokenizer: PreTrainedTokenizer,
-    transport_config: TransportConfigType,
+    transport_config: TransportConfig,
     start_step: int = 0,
 ) -> BasePacker:
     multi_run_manager = get_multi_run_manager()

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -16,7 +16,7 @@ from prime_rl.trainer.ckpt import setup_ckpt_managers
 from prime_rl.trainer.multi_ckpt import setup_multi_checkpoint_manager
 from prime_rl.trainer.optim import setup_optimizer, setup_multi_optimizer
 from prime_rl.trainer.scheduler import setup_scheduler, setup_multi_scheduler
-from prime_rl.trainer.rl.config import LossConfig, RLTrainerConfig
+from prime_rl.trainer.rl.config import DefaultLossConfig, RLTrainerConfig
 from prime_rl.trainer.rl.data import DataLoader, FakeDataLoader
 from prime_rl.utils.cp import (
     setup_cp_params,
@@ -294,7 +294,7 @@ def train(config: RLTrainerConfig):
         seq_len = micro_batches[0]["input_ids"].shape[1]
 
         # Normalize by the local number of unmasked tokens in the batch (per-batch length normalization)
-        if isinstance(config.loss, LossConfig) and config.loss.ratio_type == "token":
+        if isinstance(config.loss, DefaultLossConfig) and config.loss.ratio_type == "token":
             loss_scale = sum(micro_batch["loss_mask"].sum().item() for micro_batch in micro_batches)
         else:
             loss_scale = batch_size

--- a/src/prime_rl/trainer/scheduler.py
+++ b/src/prime_rl/trainer/scheduler.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from torch.optim import Optimizer
 from torch.optim.lr_scheduler import ConstantLR, CosineAnnealingLR, LinearLR, LRScheduler, SequentialLR
 
-from prime_rl.trainer.config import SchedulerConfigType
+from prime_rl.trainer.config import SchedulerConfig
 from prime_rl.trainer.optim import CPUOffloadOptimizer, MultiLoRAOptimizer
 from prime_rl.trainer.runs import get_multi_run_manager
 from prime_rl.utils.logger import get_logger
@@ -88,7 +88,7 @@ def setup_cosine_scheduler(
 
 def setup_scheduler(
     optimizer: Optimizer | CPUOffloadOptimizer,
-    scheduler_config: SchedulerConfigType,
+    scheduler_config: SchedulerConfig,
     max_steps: int | None,
     lr: float,
 ) -> LRScheduler:
@@ -131,7 +131,7 @@ class MultiLoRAScheduler:
 
     def __init__(
         self,
-        scheduler_config: SchedulerConfigType,
+        scheduler_config: SchedulerConfig,
         max_steps: int | None,
     ):
         self.scheduler_config = scheduler_config
@@ -178,7 +178,7 @@ class MultiLoRAScheduler:
 
 def setup_multi_scheduler(
     optimizer: MultiLoRAOptimizer,
-    scheduler_config: SchedulerConfigType,
+    scheduler_config: SchedulerConfig,
     max_steps: int | None,
 ) -> MultiLoRAScheduler:
     """Create a MultiLoRAScheduler for managing per-run schedulers."""

--- a/src/prime_rl/trainer/sft/config.py
+++ b/src/prime_rl/trainer/sft/config.py
@@ -102,7 +102,7 @@ class SFTDataConfig(BaseDataConfig):
         return self
 
 
-DataConfig: TypeAlias = FakeDataConfig | SFTDataConfig
+DataConfig: TypeAlias = Annotated[FakeDataConfig | SFTDataConfig, Field(discriminator="type")]
 
 
 class BaseDeploymentConfig(BaseModel):
@@ -142,7 +142,9 @@ class MultiNodeDeploymentConfig(BaseDeploymentConfig):
     ] = None
 
 
-SFTDeploymentConfig: TypeAlias = SingleNodeDeploymentConfig | MultiNodeDeploymentConfig
+SFTDeploymentConfig: TypeAlias = Annotated[
+    SingleNodeDeploymentConfig | MultiNodeDeploymentConfig, Field(discriminator="type")
+]
 
 
 class SFTTrainerConfig(BaseSettings):
@@ -156,7 +158,7 @@ class SFTTrainerConfig(BaseSettings):
         ),
     ] = None
 
-    deployment: Annotated[SFTDeploymentConfig, Field(discriminator="type")] = SingleNodeDeploymentConfig()
+    deployment: SFTDeploymentConfig = SingleNodeDeploymentConfig()
 
     # The model configuration
     model: ModelConfig = ModelConfig()
@@ -165,13 +167,13 @@ class SFTTrainerConfig(BaseSettings):
     tokenizer: TokenizerConfig = TokenizerConfig()
 
     # The data configuration
-    data: Annotated[DataConfig, Field(discriminator="type")] = SFTDataConfig()
+    data: DataConfig = SFTDataConfig()
 
     # The optimizer configuration
-    optim: Annotated[OptimizerConfig, Field(discriminator="type")] = AdamWConfig()
+    optim: OptimizerConfig = AdamWConfig()
 
     # The learning rate scheduler configuration
-    scheduler: Annotated[SchedulerConfig, Field(discriminator="type")] = ConstantSchedulerConfig()
+    scheduler: SchedulerConfig = ConstantSchedulerConfig()
 
     # The checkpoint configuration
     ckpt: CheckpointConfig | None = None

--- a/src/prime_rl/trainer/sft/config.py
+++ b/src/prime_rl/trainer/sft/config.py
@@ -9,8 +9,8 @@ from prime_rl.trainer.config import (
     CheckpointConfig,
     ConstantSchedulerConfig,
     ModelConfig,
-    OptimizerConfigType,
-    SchedulerConfigType,
+    OptimizerConfig,
+    SchedulerConfig,
     SlurmConfig,
     TokenizerConfig,
 )
@@ -102,7 +102,7 @@ class SFTDataConfig(BaseDataConfig):
         return self
 
 
-DataConfigType: TypeAlias = FakeDataConfig | SFTDataConfig
+DataConfig: TypeAlias = FakeDataConfig | SFTDataConfig
 
 
 class BaseDeploymentConfig(BaseModel):
@@ -142,7 +142,7 @@ class MultiNodeDeploymentConfig(BaseDeploymentConfig):
     ] = None
 
 
-SFTDeploymentConfigType: TypeAlias = SingleNodeDeploymentConfig | MultiNodeDeploymentConfig
+SFTDeploymentConfig: TypeAlias = SingleNodeDeploymentConfig | MultiNodeDeploymentConfig
 
 
 class SFTTrainerConfig(BaseSettings):
@@ -156,7 +156,7 @@ class SFTTrainerConfig(BaseSettings):
         ),
     ] = None
 
-    deployment: Annotated[SFTDeploymentConfigType, Field(discriminator="type")] = SingleNodeDeploymentConfig()
+    deployment: Annotated[SFTDeploymentConfig, Field(discriminator="type")] = SingleNodeDeploymentConfig()
 
     # The model configuration
     model: ModelConfig = ModelConfig()
@@ -165,13 +165,13 @@ class SFTTrainerConfig(BaseSettings):
     tokenizer: TokenizerConfig = TokenizerConfig()
 
     # The data configuration
-    data: Annotated[DataConfigType, Field(discriminator="type")] = SFTDataConfig()
+    data: Annotated[DataConfig, Field(discriminator="type")] = SFTDataConfig()
 
     # The optimizer configuration
-    optim: Annotated[OptimizerConfigType, Field(discriminator="type")] = AdamWConfig()
+    optim: Annotated[OptimizerConfig, Field(discriminator="type")] = AdamWConfig()
 
     # The learning rate scheduler configuration
-    scheduler: Annotated[SchedulerConfigType, Field(discriminator="type")] = ConstantSchedulerConfig()
+    scheduler: Annotated[SchedulerConfig, Field(discriminator="type")] = ConstantSchedulerConfig()
 
     # The checkpoint configuration
     ckpt: CheckpointConfig | None = None

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -12,7 +12,7 @@ from torch.utils.data import IterableDataset, get_worker_info
 from torchdata.stateful_dataloader import StatefulDataLoader
 from transformers.tokenization_utils import PreTrainedTokenizer
 
-from prime_rl.trainer.sft.config import DataConfigType, LossMaskConfig
+from prime_rl.trainer.sft.config import DataConfig, LossMaskConfig
 from prime_rl.trainer.world import get_world
 from prime_rl.utils.logger import get_logger
 
@@ -541,9 +541,7 @@ def setup_and_interleave_datasets(
     return dataset
 
 
-def setup_dataset(
-    tokenizer: PreTrainedTokenizer, config: DataConfigType, non_dp_size: int = 1
-) -> StatefulIterableDataset:
+def setup_dataset(tokenizer: PreTrainedTokenizer, config: DataConfig, non_dp_size: int = 1) -> StatefulIterableDataset:
     if config.type == "fake":
         # Shouldnt matter to handle non_dp_size if dataset is random
         return FakeDataset(
@@ -596,7 +594,7 @@ def setup_dataset(
         raise ValueError(f"Invalid dataset type: {config.type}")
 
 
-def setup_dataloader(dataset: StatefulIterableDataset, config: DataConfigType) -> StatefulDataLoader:
+def setup_dataloader(dataset: StatefulIterableDataset, config: DataConfig) -> StatefulDataLoader:
     if config.pack_function == "stack":
         stacking_dataset = StackDataset(dataset, config.seq_len * config.micro_batch_size)
         return StatefulDataLoader(stacking_dataset, batch_size=1, collate_fn=stack_collate)

--- a/src/prime_rl/transport/__init__.py
+++ b/src/prime_rl/transport/__init__.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from prime_rl.transport.base import MicroBatchReceiver, MicroBatchSender, TrainingBatchReceiver, TrainingBatchSender
-from prime_rl.transport.config import TransportConfigType
+from prime_rl.transport.config import TransportConfig
 from prime_rl.transport.filesystem import (
     FileSystemMicroBatchReceiver,
     FileSystemMicroBatchSender,
@@ -17,7 +17,7 @@ from prime_rl.transport.zmq import (
 )
 
 
-def setup_training_batch_sender(output_dir: Path, transport: TransportConfigType) -> TrainingBatchSender:
+def setup_training_batch_sender(output_dir: Path, transport: TransportConfig) -> TrainingBatchSender:
     if transport.type == "filesystem":
         return FileSystemTrainingBatchSender(output_dir)
     elif transport.type == "zmq":
@@ -26,7 +26,7 @@ def setup_training_batch_sender(output_dir: Path, transport: TransportConfigType
         raise ValueError(f"Invalid transport type: {transport.type}")
 
 
-def setup_training_batch_receiver(transport: TransportConfigType) -> TrainingBatchReceiver:
+def setup_training_batch_receiver(transport: TransportConfig) -> TrainingBatchReceiver:
     if transport.type == "filesystem":
         return FileSystemTrainingBatchReceiver()
     elif transport.type == "zmq":
@@ -36,7 +36,7 @@ def setup_training_batch_receiver(transport: TransportConfigType) -> TrainingBat
 
 
 def setup_micro_batch_sender(
-    output_dir: Path, data_world_size: int, current_step: int, transport: TransportConfigType
+    output_dir: Path, data_world_size: int, current_step: int, transport: TransportConfig
 ) -> MicroBatchSender:
     if transport.type == "filesystem":
         return FileSystemMicroBatchSender(output_dir, data_world_size, current_step)
@@ -47,7 +47,7 @@ def setup_micro_batch_sender(
 
 
 def setup_micro_batch_receiver(
-    output_dir: Path, data_rank: int, current_step: int, transport: TransportConfigType
+    output_dir: Path, data_rank: int, current_step: int, transport: TransportConfig
 ) -> MicroBatchReceiver:
     if transport.type == "filesystem":
         return FileSystemMicroBatchReceiver(output_dir, data_rank, current_step)

--- a/src/prime_rl/transport/config.py
+++ b/src/prime_rl/transport/config.py
@@ -24,4 +24,4 @@ class ZMQTransportConfig(BaseTransportConfig):
     hwm: Annotated[int, Field(description="High water mark (max messages in queue) for ZMQ sockets.")] = 10
 
 
-TransportConfigType: TypeAlias = FileSystemTransportConfig | ZMQTransportConfig
+TransportConfig: TypeAlias = FileSystemTransportConfig | ZMQTransportConfig

--- a/src/prime_rl/transport/config.py
+++ b/src/prime_rl/transport/config.py
@@ -24,4 +24,4 @@ class ZMQTransportConfig(BaseTransportConfig):
     hwm: Annotated[int, Field(description="High water mark (max messages in queue) for ZMQ sockets.")] = 10
 
 
-TransportConfig: TypeAlias = FileSystemTransportConfig | ZMQTransportConfig
+TransportConfig: TypeAlias = Annotated[FileSystemTransportConfig | ZMQTransportConfig, Field(discriminator="type")]

--- a/tests/unit/orchestrator/test_advantage.py
+++ b/tests/unit/orchestrator/test_advantage.py
@@ -7,7 +7,7 @@ from prime_rl.orchestrator.advantage import (
     default_advantage_fn,
     setup_advantage_fn,
 )
-from prime_rl.orchestrator.config import AdvantageConfig, CustomAdvantageConfig
+from prime_rl.orchestrator.config import CustomAdvantageConfig, DefaultAdvantageConfig
 
 
 def test_default_advantage_fn_simple_mean():
@@ -39,7 +39,7 @@ def test_compute_advantages_with_config():
     rewards = [1.0, 0.5, 0.8, 0.2, 0.9, 0.1]
     lengths = [10, 12, 8, 15, 11, 9]
 
-    result = compute_advantages(rewards, lengths, samples_per_problem=3, advantage_config=AdvantageConfig())
+    result = compute_advantages(rewards, lengths, samples_per_problem=3, advantage_config=DefaultAdvantageConfig())
 
     assert len(result) == 6
     # First 3 should sum to ~0 (mean subtracted)

--- a/tests/unit/train/rl/test_loss.py
+++ b/tests/unit/train/rl/test_loss.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from prime_rl.trainer.rl.config import CustomLossConfig, LossConfig
+from prime_rl.trainer.rl.config import CustomLossConfig, DefaultLossConfig
 from prime_rl.trainer.rl.loss import LossInputs, LossOutputs, compute_entropy, compute_loss, setup_loss_fn
 
 pytestmark = [pytest.mark.gpu]
@@ -14,7 +14,7 @@ def test_grpo_loss():
     advantages = [torch.randn(50).cuda(), torch.randn(30).cuda()]
     loss_mask = [torch.ones(50, dtype=torch.bool).cuda(), torch.ones(30, dtype=torch.bool).cuda()]
 
-    loss_fn = setup_loss_fn(LossConfig(ratio_type="token", token_mask_high=10.0))
+    loss_fn = setup_loss_fn(DefaultLossConfig(ratio_type="token", token_mask_high=10.0))
     loss, _ = compute_loss(
         trainer_logprobs,
         inference_logprobs,
@@ -34,7 +34,7 @@ def test_gspo_loss():
     advantages = [torch.randn(40).cuda(), torch.randn(60).cuda()]
     loss_mask = [torch.ones(40, dtype=torch.bool).cuda(), torch.ones(60, dtype=torch.bool).cuda()]
 
-    loss_fn = setup_loss_fn(LossConfig(ratio_type="sequence", token_mask_high=10.0))
+    loss_fn = setup_loss_fn(DefaultLossConfig(ratio_type="sequence", token_mask_high=10.0))
     loss, _ = compute_loss(
         trainer_logprobs,
         inference_logprobs,


### PR DESCRIPTION
just cleaner naming

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily mechanical renames/type-alias reshaping with no intended behavioral changes; risk is limited to breaking config parsing/serialization if any downstream code still references the old names.
> 
> **Overview**
> Renames multiple config discriminated-union aliases to cleaner names (e.g., `*ConfigType`  `*Config`) and renames default implementations to `Default*Config` (e.g., `AdvantageConfig`  `DefaultAdvantageConfig`, `LossConfig`  `DefaultLossConfig`).
> 
> Updates all call sites (orchestrator advantage/filters, trainer loss/optimizer/scheduler, RL/SFT configs, transport setup) to use the new type aliases and default config classes, including default field initializers and a couple `isinstance` checks. Unit tests are adjusted to construct the renamed default configs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e588c23ee9a4591f55c2e79acdd65a9ff930e3cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->