### PR TITLE
fix: wandb logging order

### DIFF
--- a/src/prime_rl/orchestrator/eval_utils.py
+++ b/src/prime_rl/orchestrator/eval_utils.py
@@ -144,4 +144,4 @@ async def evaluate_env(
     eval_metrics = {**{f"eval/{env_name}/{k}": v for k, v in eval_metrics.items()}}
     eval_metrics.update({"progress/ckpt_step": ckpt_step, "step": step or ckpt_step})
     monitor = get_monitor()
-    monitor.log(eval_metrics, step=None)
+    monitor.log(eval_metrics, step=step or ckpt_step)

--- a/src/prime_rl/orchestrator/eval_utils.py
+++ b/src/prime_rl/orchestrator/eval_utils.py
@@ -142,6 +142,7 @@ async def evaluate_env(
         assert pass_at_k is not None
         eval_metrics.update(pd.Series(pass_at_k.mean()).to_dict())
     eval_metrics = {**{f"eval/{env_name}/{k}": v for k, v in eval_metrics.items()}}
-    eval_metrics.update({"progress/ckpt_step": ckpt_step, "step": step or ckpt_step})
+    effective_step = step if step is not None else ckpt_step
+    eval_metrics.update({"progress/ckpt_step": ckpt_step, "step": effective_step})
     monitor = get_monitor()
-    monitor.log(eval_metrics, step=step or ckpt_step)
+    monitor.log(eval_metrics, step=effective_step)

--- a/src/prime_rl/orchestrator/eval_utils.py
+++ b/src/prime_rl/orchestrator/eval_utils.py
@@ -71,7 +71,7 @@ async def evaluate_env(
     rollouts_per_example: int,
     max_retries: int,
     ckpt_step: int,
-    step: int | None,
+    step: int,
     get_client: Callable[[], Awaitable[vf.ClientConfig]],
 ):
     logger = get_logger()
@@ -142,7 +142,6 @@ async def evaluate_env(
         assert pass_at_k is not None
         eval_metrics.update(pd.Series(pass_at_k.mean()).to_dict())
     eval_metrics = {**{f"eval/{env_name}/{k}": v for k, v in eval_metrics.items()}}
-    effective_step = step if step is not None else ckpt_step
-    eval_metrics.update({"progress/ckpt_step": ckpt_step, "step": effective_step})
+    eval_metrics.update({"progress/ckpt_step": ckpt_step, "step": step})
     monitor = get_monitor()
-    monitor.log(eval_metrics, step=effective_step)
+    monitor.log(eval_metrics, step=step)

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -716,7 +716,7 @@ async def orchestrate(config: OrchestratorConfig):
                 to_log.update({f"val_batch/{env}": ratio for env, ratio in per_env_ratio.items()})
 
         # Log metrics to monitor(s)
-        monitor.log(to_log)
+        monitor.log(to_log, step=progress.step)
 
         # Log samples to monitor(s) if enabled
         subset_train_rollouts = random.sample(train_rollouts, min(8, len(train_rollouts)))

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -743,6 +743,9 @@ async def orchestrate(config: OrchestratorConfig):
             step=progress.step,
         )
 
+        # Flush all accumulated metrics for this step
+        monitor.flush(step=progress.step)
+
         step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Reward: {results_df.reward.mean():.4f} |{f' Val. Reward: {val_results_df.reward.mean():.4f} |' if val_results_df is not None else ''} Throughput: {throughput:.1f} tokens/s | Seq. Length: {results_df.groupby('example_id').seq_len.mean().mean():.1f} tokens/sample | Async Level: {scheduler.async_level} | Max. Off-Policy Level: {scheduler.max_off_policy_level}"
         logger.success(step_message)
 

--- a/src/prime_rl/utils/monitor/base.py
+++ b/src/prime_rl/utils/monitor/base.py
@@ -31,6 +31,10 @@ class Monitor(ABC):
     def log_distributions(self, distributions: dict[str, list[float]], step: int) -> None:
         pass
 
+    def flush(self, step: int) -> None:
+        """Commit all accumulated metrics for the given step."""
+        pass
+
     def close(self) -> None:
         """Close any resources held by the monitor. Override in subclasses that need cleanup."""
         pass

--- a/src/prime_rl/utils/monitor/multi.py
+++ b/src/prime_rl/utils/monitor/multi.py
@@ -54,6 +54,13 @@ class MultiMonitor(Monitor):
             except Exception as e:
                 self.logger.warning(f"Failed to log distributions to {monitor.__class__.__name__}: {e}")
 
+    def flush(self, step: int) -> None:
+        for monitor in self.monitors:
+            try:
+                monitor.flush(step=step)
+            except Exception as e:
+                self.logger.warning(f"Failed to flush {monitor.__class__.__name__}: {e}")
+
     def close(self) -> None:
         for monitor in self.monitors:
             try:

--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -77,7 +77,7 @@ class WandbMonitor(Monitor):
             return
         if not self.enabled:
             return
-        wandb.log(metrics, step=step)
+        wandb.log(metrics, step=step, commit=True)
 
     def log_samples(self, rollouts: list[vf.RolloutOutput], step: int) -> None:
         """Logs rollouts to W&B table."""
@@ -122,7 +122,7 @@ class WandbMonitor(Monitor):
             self.samples_table.add_data(*sample.values())
             self.samples.append(sample)
 
-        wandb.log({"samples": self.samples_table}, step=step)
+        wandb.log({"samples": self.samples_table}, step=step, commit=True)
         self.last_log_samples_step = step
         self.logger.debug(f"Logged samples at step {step} to W&B table in {time.perf_counter() - start_time:.2f}s")
 

--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -77,7 +77,7 @@ class WandbMonitor(Monitor):
             return
         if not self.enabled:
             return
-        wandb.log(metrics, step=step, commit=True)
+        wandb.log(metrics, step=step)
 
     def log_samples(self, rollouts: list[vf.RolloutOutput], step: int) -> None:
         """Logs rollouts to W&B table."""
@@ -122,7 +122,7 @@ class WandbMonitor(Monitor):
             self.samples_table.add_data(*sample.values())
             self.samples.append(sample)
 
-        wandb.log({"samples": self.samples_table}, step=step, commit=True)
+        wandb.log({"samples": self.samples_table}, step=step)
         self.last_log_samples_step = step
         self.logger.debug(f"Logged samples at step {step} to W&B table in {time.perf_counter() - start_time:.2f}s")
 

--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -147,6 +147,11 @@ class WandbMonitor(Monitor):
         """Log distributions (no-op for W&B)."""
         pass
 
+    def flush(self, step: int) -> None:
+        if not self.is_master or not self.enabled:
+            return
+        wandb.log({}, step=step, commit=True)
+
     def save_final_summary(self, filename: str = "final_summary.json") -> None:
         """Save final summary to W&B table."""
         if not self.is_master or not self.enabled:


### PR DESCRIPTION
Without an explicit step, `wandb.log(metrics, step=None)` auto-increments wandb's internal counter, causing subsequent calls (e.g. `log_samples`) with explicit step values to trigger `"Tried to log to step N that is less than the current step N+1"` warnings.  Fix is to pass explicit `step=progress.step` to `monitor.log()` in the orchestrator main loop and `step=step or ckpt_step` in eval utils and flush (log empty dict) at the beginning of each step to immediately log the previous steps' metrics.

```bash
wandb: WARNING Tried to log to step 0 that is less than the current step 1. Steps must be monotonically increasing, so this data will be ignored. See https://wandb.me/define-metric to log data out of order.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only changes that primarily adjust W&B step/commit behavior; low blast radius but could affect how runs are indexed on dashboards.
> 
> **Overview**
> Prevents W&B "step less than current" warnings by ensuring metrics logging always uses an explicit `step` in both the training loop and eval logging.
> 
> Adds a `Monitor.flush(step)` hook (implemented in `MultiMonitor` and `WandbMonitor`) and calls it once per orchestrator step to force a committed W&B step after metrics/samples/distributions are logged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 411e8153054d0ed394c66bfafb67b03abec48b3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->