### PR TITLE
fix: use prime-rl logger

### DIFF
--- a/src/prime_rl/orchestrator/filters.py
+++ b/src/prime_rl/orchestrator/filters.py
@@ -12,9 +12,9 @@ from dataclasses import dataclass
 from typing import Protocol
 
 import verifiers as vf
-from loguru import logger
 
 from prime_rl.configs.orchestrator import FilterConfig
+from prime_rl.utils.logger import get_logger
 
 
 @dataclass
@@ -173,7 +173,7 @@ def apply_filters(
 
     if total_detected > 0:
         enforced_msg = f", enforced {total_enforced}" if total_enforced > 0 else ""
-        logger.info(
+        get_logger().info(
             f"Detected {total_detected}/{n} rollouts "
             f"({', '.join(f'{name}={c}' for name, c in counts.items() if c > 0)})" + enforced_msg
         )


### PR DESCRIPTION
been bugging me to look at the default logger haha

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> A small logging-only change that doesn’t affect filter detection/enforcement behavior or data handling; risk is limited to potential differences in logger configuration/output.
> 
> **Overview**
> Rollout filter logging in `orchestrator/filters.py` now uses `prime_rl.utils.logger.get_logger()` instead of importing `loguru`’s global `logger`, standardizing log output/configuration for filter detection summaries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88570a0e52045f66b997407c5d1612ae8da28f9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->