### PR TITLE
chore: move tool_call_parser resolution to server startup

### DIFF
--- a/configs/env_mix/env_mix.toml
+++ b/configs/env_mix/env_mix.toml
@@ -48,6 +48,5 @@ api_server_count = 8
 gpu_memory_utilization = 0.8
 
 [inference.model]
-enable_auto_tool_choice = true
 tool_call_parser = "hermes"
 max_model_len = 8192

--- a/configs/math_python/math_python.toml
+++ b/configs/math_python/math_python.toml
@@ -25,6 +25,5 @@ args = { sandbox_client_max_workers = 128, sandbox_timeout_minutes = 10, sandbox
 api_server_count = 4
 
 [inference.model]
-enable_auto_tool_choice = true
 tool_call_parser = "hermes"
 max_model_len = 4096

--- a/configs/wiki_search/rl.toml
+++ b/configs/wiki_search/rl.toml
@@ -40,5 +40,4 @@ online_difficulty_filtering = true
 id = "primeintellect/wiki-search"
 
 [inference.model]
-enable_auto_tool_choice = true
 tool_call_parser = "hermes"

--- a/examples/wiki_search/rl.toml
+++ b/examples/wiki_search/rl.toml
@@ -49,5 +49,4 @@ id = "primeintellect/wiki-search"
 [ckpt] # Checkpoint at the end of training
 
 [inference.model]
-enable_auto_tool_choice = true
 tool_call_parser = "hermes"

--- a/src/prime_rl/configs/inference.py
+++ b/src/prime_rl/configs/inference.py
@@ -7,84 +7,6 @@ from prime_rl.configs.shared import BaseModelConfig
 from prime_rl.utils.pydantic_config import BaseConfig, BaseSettings, get_all_fields
 from prime_rl.utils.utils import rgetattr, rsetattr
 
-MODEL_TOOL_CALL_PARSER: dict[str, str] = {
-    # GLM-4.5
-    "zai-org/GLM-4.5": "glm45",
-    "zai-org/GLM-4.5-FP8": "glm45",
-    "zai-org/GLM-4.5-Base": "glm45",
-    "zai-org/GLM-4.5-Air": "glm45",
-    "zai-org/GLM-4.5-Air-FP8": "glm45",
-    "zai-org/GLM-4.5-Air-Base": "glm45",
-    "zai-org/GLM-4.5V": "glm45",
-    "zai-org/GLM-4.5V-FP8": "glm45",
-    # GLM-4.7
-    "zai-org/GLM-4.7": "glm47",
-    "zai-org/GLM-4.7-FP8": "glm47",
-    "zai-org/GLM-4.7-Flash": "glm47",
-    # MiniMax M2
-    "MiniMaxAI/MiniMax-M2": "minimax_m2",
-    "MiniMaxAI/MiniMax-M2.1": "minimax_m2",
-    "MiniMaxAI/MiniMax-M2.5": "minimax_m2",
-    # INTELLECT-3
-    "PrimeIntellect/INTELLECT-3": "hermes",
-    "PrimeIntellect/INTELLECT-3-FP8": "hermes",
-    "PrimeIntellect/INTELLECT-3.1": "hermes",
-    # Qwen3 dense
-    "Qwen/Qwen3-0.6B": "hermes",
-    "Qwen/Qwen3-0.6B-Base": "hermes",
-    "Qwen/Qwen3-0.6B-FP8": "hermes",
-    "Qwen/Qwen3-1.7B": "hermes",
-    "Qwen/Qwen3-1.7B-Base": "hermes",
-    "Qwen/Qwen3-1.7B-FP8": "hermes",
-    "Qwen/Qwen3-4B": "hermes",
-    "Qwen/Qwen3-4B-Base": "hermes",
-    "Qwen/Qwen3-4B-FP8": "hermes",
-    "Qwen/Qwen3-8B": "hermes",
-    "Qwen/Qwen3-8B-Base": "hermes",
-    "Qwen/Qwen3-8B-FP8": "hermes",
-    "Qwen/Qwen3-14B": "hermes",
-    "Qwen/Qwen3-14B-Base": "hermes",
-    "Qwen/Qwen3-14B-FP8": "hermes",
-    "Qwen/Qwen3-32B": "hermes",
-    "Qwen/Qwen3-32B-FP8": "hermes",
-    # Qwen3 MoE
-    "Qwen/Qwen3-30B-A3B": "hermes",
-    "Qwen/Qwen3-30B-A3B-Base": "hermes",
-    "Qwen/Qwen3-30B-A3B-FP8": "hermes",
-    "Qwen/Qwen3-235B-A22B": "hermes",
-    "Qwen/Qwen3-235B-A22B-FP8": "hermes",
-    # Qwen3 2507
-    "Qwen/Qwen3-4B-Instruct-2507": "hermes",
-    "Qwen/Qwen3-4B-Thinking-2507": "hermes",
-    "Qwen/Qwen3-4B-Instruct-2507-FP8": "hermes",
-    "Qwen/Qwen3-4B-Thinking-2507-FP8": "hermes",
-    "Qwen/Qwen3-30B-A3B-Instruct-2507": "hermes",
-    "Qwen/Qwen3-30B-A3B-Thinking-2507": "hermes",
-    "Qwen/Qwen3-30B-A3B-Instruct-2507-FP8": "hermes",
-    "Qwen/Qwen3-30B-A3B-Thinking-2507-FP8": "hermes",
-    "Qwen/Qwen3-235B-A22B-Instruct-2507": "hermes",
-    "Qwen/Qwen3-235B-A22B-Thinking-2507": "hermes",
-    "Qwen/Qwen3-235B-A22B-Instruct-2507-FP8": "hermes",
-    "Qwen/Qwen3-235B-A22B-Thinking-2507-FP8": "hermes",
-    # Qwen3-Next
-    "Qwen/Qwen3-Next-80B-A3B-Instruct": "hermes",
-    "Qwen/Qwen3-Next-80B-A3B-Thinking": "hermes",
-    "Qwen/Qwen3-Next-80B-A3B-Instruct-FP8": "hermes",
-    "Qwen/Qwen3-Next-80B-A3B-Thinking-FP8": "hermes",
-    # Qwen3-Coder
-    "Qwen/Qwen3-Coder-480B-A35B-Instruct": "hermes",
-    "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8": "hermes",
-    "Qwen/Qwen3-Coder-30B-A3B-Instruct": "hermes",
-    "Qwen/Qwen3-Coder-30B-A3B-Instruct-FP8": "hermes",
-    # Qwen3-Coder-Next
-    "Qwen/Qwen3-Coder-Next": "hermes",
-    "Qwen/Qwen3-Coder-Next-Base": "hermes",
-    "Qwen/Qwen3-Coder-Next-FP8": "hermes",
-    # Qwen3.5
-    "Qwen/Qwen3.5-397B-A17B": "hermes",
-    "Qwen/Qwen3.5-397B-A17B-FP8": "hermes",
-}
-
 # TODO: Set thinking/ solution budget
 
 
@@ -148,19 +70,11 @@ class ModelConfig(BaseModelConfig):
         ),
     ] = False
 
-    enable_auto_tool_choice: Annotated[
-        bool,
-        Field(
-            description="Whether to enable auto tool choice. Passed to vLLM as `--enable-auto-tool-choice`. "
-            "Automatically set to True when tool_call_parser is configured.",
-        ),
-    ] = False
-
     tool_call_parser: Annotated[
         str | None,
         Field(
             description="The tool call parser to use. Passed to vLLM as `--tool-call-parser`. "
-            "If not set, automatically inferred from the model name.",
+            'Set to "auto" to infer from the model name.',
         ),
     ] = None
 
@@ -177,18 +91,6 @@ class ModelConfig(BaseModelConfig):
             description='RoPE scaling configuration as a dict. For YaRN, use: {rope_type="yarn", factor=4.0, original_max_position_embeddings=32768} or. Passed to vLLM as `--rope-scaling`.',
         ),
     ] = None
-
-    @model_validator(mode="after")
-    def resolve_tool_call_parser(self):
-        if self.tool_call_parser is None:
-            parser = MODEL_TOOL_CALL_PARSER.get(self.name)
-            if parser is not None:
-                self.tool_call_parser = parser
-
-        if self.tool_call_parser is not None:
-            self.enable_auto_tool_choice = True
-
-        return self
 
 
 class WeightBroadcastConfig(BaseSettings):
@@ -354,7 +256,6 @@ class InferenceConfig(BaseSettings):
             "model.max_model_len": "max_model_len",
             "model.enforce_eager": "enforce_eager",
             "model.trust_remote_code": "trust_remote_code",
-            "model.enable_auto_tool_choice": "enable_auto_tool_choice",
             "model.tool_call_parser": "tool_call_parser",
             "model.reasoning_parser": "reasoning_parser",
             "model.rope_scaling": "rope_scaling",

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -428,9 +428,6 @@ class RLConfig(BaseSettings):
             self.orchestrator.model.name = self.model.name
             if self.inference is not None:
                 self.inference.model.name = self.model.name
-                self.inference.model.tool_call_parser = None
-                self.inference.model.enable_auto_tool_choice = False
-                self.inference.model.resolve_tool_call_parser()
 
         validate_shared_model_name(self.trainer, self.orchestrator, self.inference)
 

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -24,6 +24,92 @@ from vllm.utils.argparse_utils import FlexibleArgumentParser
 from prime_rl.configs.inference import InferenceConfig
 from prime_rl.utils.logger import get_logger
 
+MODEL_TOOL_CALL_PARSER: dict[str, str] = {
+    # GLM-4.5
+    "zai-org/GLM-4.5": "glm45",
+    "zai-org/GLM-4.5-FP8": "glm45",
+    "zai-org/GLM-4.5-Base": "glm45",
+    "zai-org/GLM-4.5-Air": "glm45",
+    "zai-org/GLM-4.5-Air-FP8": "glm45",
+    "zai-org/GLM-4.5-Air-Base": "glm45",
+    "zai-org/GLM-4.5V": "glm45",
+    "zai-org/GLM-4.5V-FP8": "glm45",
+    # GLM-4.7
+    "zai-org/GLM-4.7": "glm47",
+    "zai-org/GLM-4.7-FP8": "glm47",
+    "zai-org/GLM-4.7-Flash": "glm47",
+    # MiniMax M2
+    "MiniMaxAI/MiniMax-M2": "minimax_m2",
+    "MiniMaxAI/MiniMax-M2.1": "minimax_m2",
+    "MiniMaxAI/MiniMax-M2.5": "minimax_m2",
+    # INTELLECT-3
+    "PrimeIntellect/INTELLECT-3": "hermes",
+    "PrimeIntellect/INTELLECT-3-FP8": "hermes",
+    "PrimeIntellect/INTELLECT-3.1": "hermes",
+    # Qwen3 dense
+    "Qwen/Qwen3-0.6B": "hermes",
+    "Qwen/Qwen3-0.6B-Base": "hermes",
+    "Qwen/Qwen3-0.6B-FP8": "hermes",
+    "Qwen/Qwen3-1.7B": "hermes",
+    "Qwen/Qwen3-1.7B-Base": "hermes",
+    "Qwen/Qwen3-1.7B-FP8": "hermes",
+    "Qwen/Qwen3-4B": "hermes",
+    "Qwen/Qwen3-4B-Base": "hermes",
+    "Qwen/Qwen3-4B-FP8": "hermes",
+    "Qwen/Qwen3-8B": "hermes",
+    "Qwen/Qwen3-8B-Base": "hermes",
+    "Qwen/Qwen3-8B-FP8": "hermes",
+    "Qwen/Qwen3-14B": "hermes",
+    "Qwen/Qwen3-14B-Base": "hermes",
+    "Qwen/Qwen3-14B-FP8": "hermes",
+    "Qwen/Qwen3-32B": "hermes",
+    "Qwen/Qwen3-32B-FP8": "hermes",
+    # Qwen3 MoE
+    "Qwen/Qwen3-30B-A3B": "hermes",
+    "Qwen/Qwen3-30B-A3B-Base": "hermes",
+    "Qwen/Qwen3-30B-A3B-FP8": "hermes",
+    "Qwen/Qwen3-235B-A22B": "hermes",
+    "Qwen/Qwen3-235B-A22B-FP8": "hermes",
+    # Qwen3 2507
+    "Qwen/Qwen3-4B-Instruct-2507": "hermes",
+    "Qwen/Qwen3-4B-Thinking-2507": "hermes",
+    "Qwen/Qwen3-4B-Instruct-2507-FP8": "hermes",
+    "Qwen/Qwen3-4B-Thinking-2507-FP8": "hermes",
+    "Qwen/Qwen3-30B-A3B-Instruct-2507": "hermes",
+    "Qwen/Qwen3-30B-A3B-Thinking-2507": "hermes",
+    "Qwen/Qwen3-30B-A3B-Instruct-2507-FP8": "hermes",
+    "Qwen/Qwen3-30B-A3B-Thinking-2507-FP8": "hermes",
+    "Qwen/Qwen3-235B-A22B-Instruct-2507": "hermes",
+    "Qwen/Qwen3-235B-A22B-Thinking-2507": "hermes",
+    "Qwen/Qwen3-235B-A22B-Instruct-2507-FP8": "hermes",
+    "Qwen/Qwen3-235B-A22B-Thinking-2507-FP8": "hermes",
+    # Qwen3-Next
+    "Qwen/Qwen3-Next-80B-A3B-Instruct": "hermes",
+    "Qwen/Qwen3-Next-80B-A3B-Thinking": "hermes",
+    "Qwen/Qwen3-Next-80B-A3B-Instruct-FP8": "hermes",
+    "Qwen/Qwen3-Next-80B-A3B-Thinking-FP8": "hermes",
+    # Qwen3-Coder
+    "Qwen/Qwen3-Coder-480B-A35B-Instruct": "hermes",
+    "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8": "hermes",
+    "Qwen/Qwen3-Coder-30B-A3B-Instruct": "hermes",
+    "Qwen/Qwen3-Coder-30B-A3B-Instruct-FP8": "hermes",
+    # Qwen3-Coder-Next
+    "Qwen/Qwen3-Coder-Next": "hermes",
+    "Qwen/Qwen3-Coder-Next-Base": "hermes",
+    "Qwen/Qwen3-Coder-Next-FP8": "hermes",
+    # Qwen3.5
+    "Qwen/Qwen3.5-397B-A17B": "hermes",
+    "Qwen/Qwen3.5-397B-A17B-FP8": "hermes",
+}
+
+
+def resolve_tool_call_parser(model_name: str, tool_call_parser: str | None) -> str | None:
+    """Resolve tool_call_parser from model name if set to "auto"."""
+    if tool_call_parser == "auto":
+        return MODEL_TOOL_CALL_PARSER.get(model_name)
+    return tool_call_parser
+
+
 logger = get_logger()
 from prime_rl.inference.patches import (
     monkey_patch_hermes_tool_parser_thread_safety,
@@ -233,14 +319,16 @@ def server(config: InferenceConfig, vllm_args: list[str]):
     from vllm.entrypoints.cli.serve import run_headless, run_multi_api_server
     from vllm.entrypoints.openai.api_server import run_server
 
-    if config.model.tool_call_parser is not None:
-        logger.info(f"Using tool_call_parser='{config.model.tool_call_parser}' for model '{config.model.name}'")
-
     parser = FlexibleArgumentParser(description="vLLM OpenAI-Compatible RESTful API server.")
     parser = make_arg_parser(parser)
     args = parser.parse_args(args=vllm_args, namespace=config.to_vllm())
     assert args is not None
     validate_parsed_serve_args(args)
+
+    args.tool_call_parser = resolve_tool_call_parser(args.model, args.tool_call_parser)
+    args.enable_auto_tool_choice = args.tool_call_parser is not None
+    if args.tool_call_parser is not None:
+        logger.info(f"Using tool_call_parser='{args.tool_call_parser}' for model '{args.model}'")
 
     # Set the worker extension class based on the broadcast backend
     args.worker_extension_cls = WORKER_EXTENSION_CLS[config.weight_broadcast.type]

--- a/tests/unit/test_tool_call_parser.py
+++ b/tests/unit/test_tool_call_parser.py
@@ -1,6 +1,6 @@
 import pytest
 
-from prime_rl.configs.inference import ModelConfig
+from prime_rl.inference.vllm.server import resolve_tool_call_parser
 
 
 @pytest.mark.parametrize(
@@ -32,10 +32,16 @@ from prime_rl.configs.inference import ModelConfig
     ],
 )
 def test_auto_detect_tool_call_parser(model_name: str, expected_parser: str):
-    config = ModelConfig(name=model_name)
-    assert config.tool_call_parser == expected_parser
+    assert resolve_tool_call_parser(model_name, "auto") == expected_parser
 
 
-def test_explicit_parser_overrides_auto_detect():
-    config = ModelConfig(name="Qwen/Qwen3-4B-Instruct-2507", tool_call_parser="qwen3_xml")
-    assert config.tool_call_parser == "qwen3_xml"
+def test_explicit_parser_not_overridden():
+    assert resolve_tool_call_parser("Qwen/Qwen3-4B-Instruct-2507", "qwen3_xml") == "qwen3_xml"
+
+
+def test_auto_unknown_model():
+    assert resolve_tool_call_parser("some/unknown-model", "auto") is None
+
+
+def test_none_skips_resolution():
+    assert resolve_tool_call_parser("Qwen/Qwen3-0.6B", None) is None


### PR DESCRIPTION
## Summary
- Move `MODEL_TOOL_CALL_PARSER` dict and auto-detection logic from `configs/inference.py` to `inference/vllm/server.py`
- Resolve tool call parser at server startup instead of config validation time, so it always sees the final model name
- Remove the reset+re-resolve hack in `RLConfig.auto_setup_model()`

## Test plan
- [x] `uv run pytest tests/unit/test_tool_call_parser.py` — 20 passed
- [x] `uv run pytest tests/unit/test_configs.py` — 59 passed
- [x] `uv run ruff check && ruff format --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes inference server startup argument resolution for tool calling; mis-resolution could silently disable/enable tool parsing and affect runtime behavior, but the change is localized and covered by unit tests.
> 
> **Overview**
> Tool-call parser selection is now resolved at vLLM server startup: `MODEL_TOOL_CALL_PARSER` and a new `resolve_tool_call_parser()` helper move from `configs/inference.py` into `inference/vllm/server.py`, enabling `tool_call_parser = "auto"` to be interpreted using the final model name and setting `enable_auto_tool_choice` based on whether a parser is resolved.
> 
> Config-layer auto-resolution is removed (drops `enable_auto_tool_choice` from `ModelConfig`, removes the Pydantic validator that inferred the parser, and deletes the reset/re-resolve workaround in `RLConfig.auto_setup_model()`), and example/config TOMLs stop setting `enable_auto_tool_choice` explicitly. Unit tests are updated to cover the new startup-time resolution behavior, including unknown-model and `None` cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98a0804d03b0f27fe04ee1f79531cccf4c83c847. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->