### PR TITLE
fix: ruff format error in CI

### DIFF
--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -899,9 +899,7 @@ class OrchestratorConfig(BaseSettings):
             if self.max_inflight_rollouts is not None and self.oversampling_factor is not None:
                 expected_max_inflight_rollouts = int(self.batch_size * self.oversampling_factor)
                 if self.max_inflight_rollouts != expected_max_inflight_rollouts:
-                    raise ValueError(
-                        "max_inflight_rollouts conflicts with oversampling_factor * batch_size"
-                    )
+                    raise ValueError("max_inflight_rollouts conflicts with oversampling_factor * batch_size")
             if self.max_inflight_rollouts is None:
                 oversampling_factor = self.oversampling_factor if self.oversampling_factor is not None else 1.0
                 self.max_inflight_rollouts = int(self.batch_size * oversampling_factor)


### PR DESCRIPTION
not sure how this passed ci previously but seems this is choking the ruff ci now:
```
Found ruffDir in tool-cache for 0.13.0
Added /opt/hostedtoolcache/ruff/0.13.0/x86_64 to the path
Set RUFF_OUTPUT_FORMAT to github
Successfully installed ruff version 0.13.0
/opt/hostedtoolcache/ruff/0.13.0/x86_64/ruff format --check --config=pyproject.toml /home/runner/work/prime-rl/prime-rl
Would reformat: src/prime_rl/configs/orchestrator.py
1 file would be reformatted, 186 files already formatted
Error: The process '/opt/hostedtoolcache/ruff/0.13.0/x86_64/ruff' failed with exit code 1
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formatting change to an error-raising branch; no behavioral impact expected beyond identical exception text.
> 
> **Overview**
> Fixes a `ruff format --check` failure by reformatting a multi-line `raise ValueError(...)` in `OrchestratorConfig.resolve_batching` into a single-line statement, with no functional logic changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09b4de2ecc62affe4f6b4864e62a03a7dbfae232. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->