### PR TITLE
implement self-verification support

### DIFF
--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -899,9 +899,7 @@ class OrchestratorConfig(BaseSettings):
             if self.max_inflight_rollouts is not None and self.oversampling_factor is not None:
                 expected_max_inflight_rollouts = int(self.batch_size * self.oversampling_factor)
                 if self.max_inflight_rollouts != expected_max_inflight_rollouts:
-                    raise ValueError(
-                        "max_inflight_rollouts conflicts with oversampling_factor * batch_size"
-                    )
+                    raise ValueError("max_inflight_rollouts conflicts with oversampling_factor * batch_size")
             if self.max_inflight_rollouts is None:
                 oversampling_factor = self.oversampling_factor if self.oversampling_factor is not None else 1.0
                 self.max_inflight_rollouts = int(self.batch_size * oversampling_factor)

--- a/src/prime_rl/orchestrator/buffer.py
+++ b/src/prime_rl/orchestrator/buffer.py
@@ -113,7 +113,12 @@ class Buffer:
         saved_rollout_buffer = cast(list[vf.RolloutOutput], read_jsonl(path / "rollout_buffer.jsonl"))
         saved_rollout_history = cast(list[vf.RolloutOutput], read_jsonl(path / "rollout_history.jsonl"))
 
-        if any(saved_easy_examples) or any(saved_hard_examples) or any(saved_rollout_buffer) or any(saved_rollout_history):
+        if (
+            any(saved_easy_examples)
+            or any(saved_hard_examples)
+            or any(saved_rollout_buffer)
+            or any(saved_rollout_history)
+        ):
             # Build hash lookup for example buffer (env -> (example_hash -> example_id))
             example_hash_lookup = defaultdict(dict)
             all_hashes = set()


### PR DESCRIPTION
Save previous rollout history
Allow for sampling from rollout history when we have dynamic prompt mode = self-verification
dynamic prompt mode also would allow for envs that can generate prompts on the fly like logic tasks, or pairwise stuff

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes training-time sampling behavior and checkpoint contents; incorrect history sampling/exclusions could bias data or break assumptions about example immutability across rollouts.
> 
> **Overview**
> Adds **self-verification dynamic prompting** by persisting a non-destructive `rollout_history` in the orchestrator `Buffer`, saving/loading it in checkpoints, and exposing `sample_random_history_rollout()` for random historical sampling.
> 
> Updates the rollout `Scheduler` to deepcopy sampled examples and, when `example["info"].dynamic_prompt_mode == "self_verification"`, inject a sampled historical rollout (task/example_id/reward/prompt/completion) into `info.self_verification.source`, with optional task exclusions to avoid recursive self-verification.
> 
> Also includes a tiny formatting-only tweak to an `OrchestratorConfig` validation error message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3f31a6837353dca66cb3a70279836a3d0061c3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->