### PR TITLE
update env var prefix

### DIFF
--- a/src/prime_rl/utils/pydantic_config.py
+++ b/src/prime_rl/utils/pydantic_config.py
@@ -106,7 +106,7 @@ class BaseSettings(PydanticBaseSettings):
 
     # Pydantic settings configuration
     model_config = SettingsConfigDict(
-        env_prefix="PRIME_",
+        env_prefix="PRIME_RL_",
         env_nested_delimiter="__",
         cli_parse_args=False,
         cli_kebab_case=True,


### PR DESCRIPTION
to not clash with `prime` package

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line configuration change, but it can break deployments/scripts that still set `PRIME_*` environment variables for settings.
> 
> **Overview**
> Updates `BaseSettings` pydantic configuration to read environment variables with the `PRIME_RL_` prefix instead of `PRIME_`, avoiding collisions with the `prime` package and changing how settings are sourced from the environment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8517a698a5eb8a5248f72516eb0902452a8a55da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->