### PR TITLE
disable fused lm head chunking by default

### DIFF
--- a/benchmarks/scripts/run_single_benchmark.py
+++ b/benchmarks/scripts/run_single_benchmark.py
@@ -83,6 +83,11 @@ class BenchmarkConfig(BaseSettings):
 
     cp: Annotated[int, Field(ge=1, description="Context parallelism size (1 = no CP)")] = 1
 
+    fused_lm_head_chunk_size: Annotated[
+        int | None,
+        Field(description="Fused LM head chunk size (None uses trainer default)"),
+    ] = None
+
     docker_image: Annotated[str | None, Field(description="Docker image used for the benchmark")] = None
 
     # Metadata set by the script
@@ -151,6 +156,10 @@ def build_command(config: BenchmarkConfig) -> list[str]:
     # Add context parallelism if enabled
     if config.cp > 1:
         cmd.extend(["--model.cp", str(config.cp)])
+
+    # Fused LM head chunk size
+    if config.fused_lm_head_chunk_size is not None:
+        cmd.extend(["--model.fused-lm-head-chunk-size", str(config.fused_lm_head_chunk_size)])
 
     # Data configuration differs between RL and SFT
     if config.type.startswith("rl"):

--- a/configs/ci/integration/rl_multi_run/trainer.toml
+++ b/configs/ci/integration/rl_multi_run/trainer.toml
@@ -5,6 +5,7 @@ max_async_level = 5
 [model]
 name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
 seq_len = 65536
+fused_lm_head_chunk_size = 8192
 
 [model.lora]
 rank = 8

--- a/src/prime_rl/configs/trainer.py
+++ b/src/prime_rl/configs/trainer.py
@@ -281,7 +281,7 @@ class ModelConfig(BaseModelConfig):
                 "Explicitly setting an integer value for this feature isn't supported for SFT training."
             ),
         ),
-    ] = "auto"
+    ] = "disabled"
 
     @model_validator(mode="before")
     @classmethod

--- a/tests/integration/test_benchmark_regression.py
+++ b/tests/integration/test_benchmark_regression.py
@@ -25,10 +25,10 @@ MEMORY_TOLERANCE = 0.01  # 1% tolerance for peak memory
 
 # Baseline files for the Qwen3-0.6B RL benchmark
 BASELINE_FILE_1GPU = Path(
-    "benchmarks/baselines/benchmark-1xa6000-Qwen--Qwen3-0.6B-rl-full-1gpu-Recompute-flash_attention_2-16384-cp1-ep1.json"
+    "benchmarks/baselines/benchmark-1xa6000-Qwen--Qwen3-0.6B-rl-full-1gpu-Recompute-flash_attention_2-65536-cp1-ep1.json"
 )
 BASELINE_FILE_4GPU = Path(
-    "benchmarks/baselines/benchmark-4xa6000-Qwen--Qwen3-0.6B-rl-full-4gpu-Recompute-flash_attention_2-16384-cp1-ep1.json"
+    "benchmarks/baselines/benchmark-4xa6000-Qwen--Qwen3-0.6B-rl-full-4gpu-Recompute-flash_attention_2-65536-cp1-ep1.json"
 )
 
 
@@ -80,7 +80,7 @@ def benchmark_process_1gpu(
         "--model-name",
         "Qwen/Qwen3-0.6B",
         "--seq-len",
-        "16384",
+        "65536",
         "--ac",
         "Recompute",
         "--attention",
@@ -89,6 +89,8 @@ def benchmark_process_1gpu(
         str(benchmark_output_file_1gpu),
         "--timeout",
         str(TIMEOUT - 5 * 60),  # Leave 5 min buffer
+        "--fused-lm-head-chunk-size",
+        "8192",
     ]
     return run_process(cmd, timeout=TIMEOUT, env={"PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True"})
 
@@ -111,7 +113,7 @@ def benchmark_process_4gpu(
         "--model-name",
         "Qwen/Qwen3-0.6B",
         "--seq-len",
-        "16384",
+        "65536",
         "--ac",
         "Recompute",
         "--attention",
@@ -120,6 +122,8 @@ def benchmark_process_4gpu(
         str(benchmark_output_file_4gpu),
         "--timeout",
         str(TIMEOUT - 5 * 60),  # Leave 5 min buffer
+        "--fused-lm-head-chunk-size",
+        "8192",
     ]
     return run_process(cmd, timeout=TIMEOUT, env={"PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True"})
 

--- a/tests/integration/test_benchmark_regression.py
+++ b/tests/integration/test_benchmark_regression.py
@@ -25,10 +25,10 @@ MEMORY_TOLERANCE = 0.01  # 1% tolerance for peak memory
 
 # Baseline files for the Qwen3-0.6B RL benchmark
 BASELINE_FILE_1GPU = Path(
-    "benchmarks/baselines/benchmark-1xa6000-Qwen--Qwen3-0.6B-rl-full-1gpu-Recompute-flash_attention_2-65536-cp1-ep1.json"
+    "benchmarks/baselines/benchmark-1xa6000-Qwen--Qwen3-0.6B-rl-full-1gpu-Recompute-flash_attention_2-16384-cp1-ep1.json"
 )
 BASELINE_FILE_4GPU = Path(
-    "benchmarks/baselines/benchmark-4xa6000-Qwen--Qwen3-0.6B-rl-full-4gpu-Recompute-flash_attention_2-65536-cp1-ep1.json"
+    "benchmarks/baselines/benchmark-4xa6000-Qwen--Qwen3-0.6B-rl-full-4gpu-Recompute-flash_attention_2-16384-cp1-ep1.json"
 )
 
 
@@ -80,7 +80,7 @@ def benchmark_process_1gpu(
         "--model-name",
         "Qwen/Qwen3-0.6B",
         "--seq-len",
-        "65536",
+        "16384",
         "--ac",
         "Recompute",
         "--attention",
@@ -111,7 +111,7 @@ def benchmark_process_4gpu(
         "--model-name",
         "Qwen/Qwen3-0.6B",
         "--seq-len",
-        "65536",
+        "16384",
         "--ac",
         "Recompute",
         "--attention",


### PR DESCRIPTION
## Summary
- Change `fused_lm_head_chunk_size` default from `"auto"` to `"disabled"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes a model-level default (`fused_lm_head_chunk_size`) that affects training execution and performance/memory characteristics across runs. CI/integration tests now pin an explicit chunk size, but other consumers may see behavior changes if relying on the previous default.
> 
> **Overview**
> **Disables fused LM head chunking by default** by changing `ModelConfig.fused_lm_head_chunk_size` from `"auto"` to `"disabled"`.
> 
> Bench/CI flows are updated to **explicitly opt in** when needed: `run_single_benchmark.py` accepts/forwards `--model.fused-lm-head-chunk-size`, the RL multi-run integration `trainer.toml` pins `fused_lm_head_chunk_size = 8192`, and benchmark regression tests pass `--fused-lm-head-chunk-size 8192` to keep results stable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc7621ddcf8a692bff88b15e1302510c324f6b8c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->