### PR TITLE
Add Qwen3-VL-4B-Instruct to tool call parser map

### DIFF
--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -97,6 +97,8 @@ MODEL_TOOL_CALL_PARSER: dict[str, str] = {
     "Qwen/Qwen3-Coder-Next": "hermes",
     "Qwen/Qwen3-Coder-Next-Base": "hermes",
     "Qwen/Qwen3-Coder-Next-FP8": "hermes",
+    # Qwen3-VL
+    "Qwen/Qwen3-VL-4B-Instruct": "hermes",
     # Qwen3.5
     "Qwen/Qwen3.5-397B-A17B": "hermes",
     "Qwen/Qwen3.5-397B-A17B-FP8": "hermes",


### PR DESCRIPTION
Adds `Qwen/Qwen3-VL-4B-Instruct` to `MODEL_TOOL_CALL_PARSER` with `hermes` parser.

Without this, `tool_call_parser = "auto"` resolves to `None` for Qwen3-VL models, causing vLLM to reject tool call requests with 400 errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single mapping entry change that only affects tool-calling behavior when `tool_call_parser="auto"` is used for this specific model.
> 
> **Overview**
> Adds `Qwen/Qwen3-VL-4B-Instruct` to `MODEL_TOOL_CALL_PARSER` with the `hermes` tool-call parser so `resolve_tool_call_parser()` can auto-select a parser for this model (avoiding `None` and resulting tool-call request failures when `tool_call_parser` is set to `"auto"`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26ef5e25ed8294a2005bde559f320a1c8165e98b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->