### PR TITLE
remove disown from orchestrator in multi-node sbatch

### DIFF
--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -96,7 +96,7 @@ else
             @ $CONFIG_DIR/orchestrator.toml \
             --weight_broadcast.host $MASTER_ADDR \
             --client.base-url $INFER_URLS \
-            2>&1 | tee $OUTPUT_DIR/slurm/latest_orchestrator.log $OUTPUT_DIR/slurm/job_${SLURM_JOB_ID}_orchestrator.log & disown
+            2>&1 | tee $OUTPUT_DIR/slurm/latest_orchestrator.log $OUTPUT_DIR/slurm/job_${SLURM_JOB_ID}_orchestrator.log &
     fi
 
     export HF_HUB_OFFLINE=1


### PR DESCRIPTION
removes disown from the orchestrator launch in the multi-node RL sbatch template, replacing it with just &.

- disown detaches the orchestrator from the shell job table so it does not receive SIGHUP on shell exit
- this causes the orchestrator and its ZMQ env server subprocesses to survive as orphans after job cancellation
- orphaned env servers hold onto their ports, causing ZMQError: Address already in use on subsequent runs
- with just & the shell still tracks the process and forwards signals properly on cleanup

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk template change, but it affects SLURM job lifecycle: the orchestrator will now receive job-cancellation/exit signals and terminate instead of lingering, which could change shutdown behavior in existing workflows.
> 
> **Overview**
> Removes `disown` from the orchestrator launch in `multi_node_rl.sbatch.j2`, keeping it as a background job (`&`) that remains tied to the SLURM task.
> 
> This ensures the orchestrator (and any child env-server processes) is cleaned up on job cancellation/exit, reducing the chance of orphaned processes holding ports and breaking subsequent runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e21053c39e723521813c667e2c93d1e1761a328a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->