### PR TITLE
fix: resolve slurm project_dir to absolute path

### DIFF
--- a/src/prime_rl/configs/shared.py
+++ b/src/prime_rl/configs/shared.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from prime_rl.utils.pydantic_config import BaseConfig
 
@@ -26,6 +26,11 @@ class SlurmConfig(BaseConfig):
     partition: Annotated[
         str, Field(description="The SLURM partition to use. Will be passed as #SBATCH --partition.")
     ] = "cluster"
+
+    @model_validator(mode="after")
+    def resolve_project_dir(self):
+        self.project_dir = self.project_dir.resolve()
+        return self
 
 
 ServerType = Literal["vllm", "openai"]


### PR DESCRIPTION
## Summary
- `SlurmConfig.project_dir` defaults to `Path(".")` which was passed as-is to sbatch templates, producing `export PROJECT_DIR=.` in the generated script
- On compute nodes the cwd can differ from the submission directory, breaking the `cd $PROJECT_DIR` and all subsequent commands
- Added a `model_validator` that calls `.resolve()` on `project_dir` at config construction time, ensuring the sbatch script always gets an absolute path

## Test plan
- [x] Verified default `"."` resolves to absolute cwd
- [x] Verified explicit relative paths get resolved
- [x] Verified explicit absolute paths are unchanged
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config normalization change that only affects how `SlurmConfig.project_dir` is rendered into SLURM sbatch templates; main risk is surprising users who relied on relative paths.
> 
> **Overview**
> Ensures SLURM submission scripts always receive an absolute `project_dir` by adding a Pydantic `@model_validator` that resolves `SlurmConfig.project_dir` at config construction time.
> 
> This prevents jobs from `cd`-ing into the wrong directory on compute nodes when the config default (`Path(".")`) or other relative paths are used.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79f8e4451a75e6ff151627794b2c1b9f32d38e8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->