### PR TITLE
Sami/fp8 inference

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -1,6 +1,7 @@
 import asyncio
 import multiprocessing as mp
 import random
+import shutil
 import time
 from concurrent.futures import ThreadPoolExecutor
 
@@ -62,44 +63,12 @@ from prime_rl.utils.utils import (
     clean_exit,
     get_broadcast_dir,
     get_env_ids_to_install,
-    get_step_path,
     install_env,
     resolve_latest_ckpt_step,
     strip_env_version,
     to_col_format,
-    wait_for_path,
 )
 from prime_rl.utils.vlm import is_vlm_model
-
-
-async def _bootstrap_initial_weight_update(config: OrchestratorConfig, inference_pool, scheduler: Scheduler) -> None:
-    step = scheduler.ckpt_step
-    weight_dir = get_step_path(get_broadcast_dir(config.output_dir), step)
-    stable_path = weight_dir / "STABLE"
-    config_path = config.output_dir / "control" / "orch.toml"
-    min_stable_mtime = config_path.stat().st_mtime if config_path.exists() else None
-
-    wait_timeout = config.ckpt.wait_for_weights_timeout if config.ckpt else None
-    if wait_timeout is None and config.weight_broadcast.type == "nccl":
-        wait_timeout = config.weight_broadcast.timeout
-
-    async def _wait_for_fresh_stable() -> None:
-        while True:
-            await wait_for_path(stable_path)
-            if min_stable_mtime is None or stable_path.stat().st_mtime >= min_stable_mtime:
-                return
-            await asyncio.sleep(1)
-
-    if wait_timeout is None:
-        await _wait_for_fresh_stable()
-    else:
-        await asyncio.wait_for(_wait_for_fresh_stable(), timeout=wait_timeout)
-
-    lora_name = config.model.lora.name if config.model.lora else None
-    await inference_pool.update_weights(weight_dir, lora_name=lora_name, step=step)
-    if lora_name is not None:
-        scheduler.model_name = lora_name
-        inference_pool.update_model_name(lora_name)
 
 
 @clean_exit
@@ -362,12 +331,13 @@ async def orchestrate(config: OrchestratorConfig):
         )
         lora_name = config.model.lora.name if config.model.lora else None
         await inference_pool.update_weights(weights_path, lora_name=lora_name, step=scheduler.ckpt_step)
+        scheduler.checkpoint_ready.set()
     else:
         logger.info("Training from scratch")
-        logger.info("Loading initial step-0 broadcast weights")
-        bootstrap_start_time = time.perf_counter()
-        await _bootstrap_initial_weight_update(config, inference_pool, scheduler)
-        logger.info(f"Loaded initial step-0 broadcast weights in {time.perf_counter() - bootstrap_start_time:.2f}s")
+        broadcast_dir = get_broadcast_dir(config.output_dir)
+        if broadcast_dir.exists():
+            logger.info(f"Cleaning stale broadcast directory: {broadcast_dir}")
+            shutil.rmtree(broadcast_dir)
 
     # Iterate over dataset in batches
     max_steps = config.max_steps or int(1e9)
@@ -377,6 +347,11 @@ async def orchestrate(config: OrchestratorConfig):
 
     # Start update policy loop
     update_policy_task = asyncio.create_task(scheduler.update_policy_loop())
+
+    # Wait for initial weights before entering the main loop.
+    # On fresh start: update_policy_loop loads step-0 weights and sets checkpoint_ready.
+    # On resume: checkpoint_ready was already set above after loading resume weights.
+    await scheduler.checkpoint_ready.wait()
 
     # Track consecutive empty batches for retry logic
     empty_batch_retries = 0

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -1,7 +1,6 @@
 import asyncio
 import multiprocessing as mp
 import random
-import shutil
 import time
 from concurrent.futures import ThreadPoolExecutor
 
@@ -61,7 +60,6 @@ from prime_rl.utils.pydantic_config import parse_argv
 from prime_rl.utils.temp_scheduling import compute_temperature
 from prime_rl.utils.utils import (
     clean_exit,
-    get_broadcast_dir,
     get_env_ids_to_install,
     install_env,
     resolve_latest_ckpt_step,
@@ -334,10 +332,9 @@ async def orchestrate(config: OrchestratorConfig):
         scheduler.checkpoint_ready.set()
     else:
         logger.info("Training from scratch")
-        broadcast_dir = get_broadcast_dir(config.output_dir)
-        if broadcast_dir.exists():
-            logger.info(f"Cleaning stale broadcast directory: {broadcast_dir}")
-            shutil.rmtree(broadcast_dir)
+        config_path = config.output_dir / "control" / "orch.toml"
+        if config_path.exists():
+            scheduler.min_stable_mtime = config_path.stat().st_mtime
 
     # Iterate over dataset in batches
     max_steps = config.max_steps or int(1e9)

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -87,6 +87,7 @@ class Scheduler:
 
         self.step, self.ckpt_step = 0, -1
         self.checkpoint_ready = asyncio.Event()
+        self.min_stable_mtime: float | None = None
         self.update_weights_time, self.wait_for_ckpt_time = 0, 0
         self.update_policy_task = None
         self.cancelled_rollouts_count = 0
@@ -155,6 +156,15 @@ class Scheduler:
         )
         self.inflight_group_rollouts[run_group_task] = InflightRolloutInfo(0, client_config)
 
+    async def _wait_for_fresh_stable(self, stable_path: Path) -> None:
+        """Wait for a STABLE marker, skipping stale files from previous runs."""
+        while True:
+            await wait_for_path(stable_path)
+            if self.min_stable_mtime is None or stable_path.stat().st_mtime >= self.min_stable_mtime:
+                self.min_stable_mtime = None
+                return
+            await asyncio.sleep(1)
+
     async def update_policy_loop(self):
         """Continuously checks for new policy checkpoints."""
         while True:
@@ -180,7 +190,8 @@ class Scheduler:
                     )
                 self.checkpoint_ready.clear()
                 wait_for_ckpt_start_time = time.perf_counter()
-                await wait_for_path(get_step_path(get_broadcast_dir(self.config.output_dir), next_ckpt_step) / "STABLE")
+                stable_path = get_step_path(get_broadcast_dir(self.config.output_dir), next_ckpt_step) / "STABLE"
+                await self._wait_for_fresh_stable(stable_path)
                 self.wait_for_ckpt_time = time.perf_counter() - wait_for_ckpt_start_time
                 self.logger.info(
                     f"Orchestrator resumed: checkpoint {next_ckpt_step} ready (after {self.wait_for_ckpt_time:.2f}s)"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes orchestrator/scheduler startup synchronization around checkpoint readiness, which can affect training start-up and rollout scheduling if the event is mis-set or STABLE detection is wrong.
> 
> **Overview**
> Ensures the orchestrator does not start generating rollouts until the first policy weights are available by gating the main loop on `scheduler.checkpoint_ready`.
> 
> Removes the bespoke step-0 bootstrap logic from `orchestrator.py` and moves/extends STABLE-file waiting into `Scheduler` with a new `_wait_for_fresh_stable` helper that ignores stale markers from previous runs using `min_stable_mtime`. The scheduler now starts with `ckpt_step=-1`, logs a dedicated “waiting for initial weight broadcast” message, and sets `checkpoint_ready` only after weights are updated (with resume explicitly setting the event after loading the checkpoint).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83efcf248fc68dfa4a4961c7dfa7285e55387ab7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->