### PR TITLE
Chore: Validate mint.json pages exist before syncing docs

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -12,6 +12,39 @@ jobs:
   trigger-docs-sync:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate mint.json pages exist
+        run: |
+          missing=()
+          pages=$(python3 -c "
+          import json, sys
+          data = json.load(open('docs/mint.json'))
+          pages = []
+          def collect(obj):
+              if isinstance(obj, list):
+                  for item in obj: collect(item)
+              elif isinstance(obj, dict):
+                  if 'pages' in obj: collect(obj['pages'])
+                  if 'groups' in obj: collect(obj['groups'])
+              elif isinstance(obj, str):
+                  pages.append(obj)
+          collect(data.get('navigation', []))
+          print('\n'.join(pages))
+          ")
+          while IFS= read -r page; do
+            [ -z "$page" ] && continue
+            if [ ! -f "docs/${page}.md" ] && [ ! -f "docs/${page}.mdx" ]; then
+              missing+=("${page}")
+            fi
+          done <<< "$pages"
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "ERROR: The following pages listed in mint.json do not exist in docs/:"
+            printf '  - %s\n' "${missing[@]}"
+            exit 1
+          fi
+          echo "All mint.json pages verified."
+
       - name: Trigger public-docs workflow
         uses: peter-evans/repository-dispatch@v3
         with:

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -10,7 +10,7 @@
                 "environments",
                 "async",
                 "logging",
-                "runs",
+                "multi_run_manager",
                 "checkpointing",
                 "benchmarking",
                 "deployment",


### PR DESCRIPTION
Fixes ENG-3041

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to the docs sync GitHub Action and a docs navigation entry, only adding a pre-sync validation step that may fail the workflow if pages are missing.
> 
> **Overview**
> Adds a validation step to the `sync-docs` GitHub Action that parses `docs/mint.json` and fails the workflow if any referenced `docs/<page>.md`/`.mdx` files are missing, preventing broken docs syncs.
> 
> Updates `docs/mint.json` navigation to replace the `runs` entry with `multi_run_manager`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9bd1fbbb451dc166112be1e4a71abfc40d58e587. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->