### PR TITLE
Added default output_dir handling

### DIFF
--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -196,14 +196,14 @@ class RLConfig(BaseSettings):
     output_dir: Annotated[
         Path,
         Field(
-            description="The directory to store the outputs. Should be set to a unique directory identifying the experiment."
+            description="The directory to store the outputs. Must be unique per experiment. Will raise if the directory already exists unless resuming or clean_output_dir is set."
         ),
     ] = Path("outputs")
 
     clean_output_dir: Annotated[
         bool,
         Field(
-            description="If true, delete the output directory before starting training. Required to overwrite an output directory that contains checkpoints from a previous run when not resuming.",
+            description="If true, delete the output directory before starting training. Required to overwrite an existing output directory when not resuming.",
         ),
     ] = False
 

--- a/src/prime_rl/configs/sft.py
+++ b/src/prime_rl/configs/sft.py
@@ -181,14 +181,14 @@ class SFTConfig(BaseSettings):
     output_dir: Annotated[
         Path,
         Field(
-            description="Directory to write outputs to. Will be populated with checkpoints and logs as subdirectories. Should be set to a persistent directory with enough disk space. This value should be distinct across experiments running on a single node. See the README for more details."
+            description="Directory to write outputs to. Must be unique per experiment. Will raise if the directory already exists unless resuming or clean_output_dir is set."
         ),
     ] = Path("outputs")
 
     clean_output_dir: Annotated[
         bool,
         Field(
-            description="If true, delete the output directory before starting training. Required to overwrite an output directory that contains checkpoints from a previous run when not resuming.",
+            description="If true, delete the output directory before starting training. Required to overwrite an existing output directory when not resuming.",
         ),
     ] = False
 

--- a/src/prime_rl/utils/pathing.py
+++ b/src/prime_rl/utils/pathing.py
@@ -63,18 +63,11 @@ def resolve_latest_ckpt_step(ckpt_dir: Path) -> int | None:
     return latest_step
 
 
-def has_checkpoints(output_dir: Path) -> bool:
-    """Check if the output directory contains any checkpoints."""
-    ckpt_dir = get_ckpt_dir(output_dir)
-    return ckpt_dir.exists() and any(ckpt_dir.iterdir())
-
-
 def validate_output_dir(output_dir: Path, *, resuming: bool, clean: bool) -> None:
     """Validate the output directory before training starts.
 
-    Raises if the directory contains checkpoints from a previous run, unless
-    explicitly resuming or opting into cleaning. Other artifacts (logs,
-    rollouts, configs) are fine and don't trigger the error.
+    Raises if the output directory already exists, unless explicitly resuming
+    or opting into cleaning via clean_output_dir flag.
     """
     if not output_dir.exists():
         return
@@ -85,13 +78,12 @@ def validate_output_dir(output_dir: Path, *, resuming: bool, clean: bool) -> Non
         logger.warning(f"Cleaning existing output directory: {output_dir}")
         shutil.rmtree(output_dir)
         return
-    if has_checkpoints(output_dir):
-        raise FileExistsError(
-            f"Output directory '{output_dir}' already contains checkpoints from a previous run. "
-            f"To resume the latest step of the previous run, set ckpt.resume_step=-1 or --ckpt.resume-step -1 via CLI. "
-            f"To delete the existing directory and start fresh, set clean_output_dir=true or --clean-output-dir via CLI. "
-            f"Otherwise use a unique output_dir for this experiment."
-        )
+    raise FileExistsError(
+        f"Output directory '{output_dir}' already exists. "
+        f"To resume a previous run, set ckpt.resume_step=-1 or --ckpt.resume-step -1 via CLI. "
+        f"To delete the existing directory and start fresh, set clean_output_dir=true or --clean-output-dir via CLI. "
+        f"Otherwise use a unique output_dir for this experiment."
+    )
 
 
 def sync_wait_for_path(path: Path, interval: int = 1, log_interval: int = 10) -> None:

--- a/tests/unit/utils/test_pathing.py
+++ b/tests/unit/utils/test_pathing.py
@@ -8,40 +8,40 @@ def test_nonexistent_dir_passes(tmp_path):
     validate_output_dir(output_dir, resuming=False, clean=False)
 
 
-def test_empty_dir_passes(tmp_path):
+def test_empty_dir_raises(tmp_path):
     output_dir = tmp_path / "empty"
     output_dir.mkdir()
-    validate_output_dir(output_dir, resuming=False, clean=False)
+    with pytest.raises(FileExistsError, match="already exists"):
+        validate_output_dir(output_dir, resuming=False, clean=False)
 
 
-def test_dir_with_only_logs_passes(tmp_path):
+def test_dir_with_only_logs_raises(tmp_path):
     output_dir = tmp_path / "has_logs"
     output_dir.mkdir()
     (output_dir / "logs").mkdir()
     (output_dir / "logs" / "trainer").mkdir(parents=True)
     (output_dir / "logs" / "trainer" / "rank_0.log").touch()
-    validate_output_dir(output_dir, resuming=False, clean=False)
-
-
-def test_dir_with_checkpoints_raises(tmp_path):
-    output_dir = tmp_path / "has_ckpt"
-    output_dir.mkdir()
-    (output_dir / "checkpoints").mkdir()
-    (output_dir / "checkpoints" / "step_0").mkdir()
-    with pytest.raises(FileExistsError, match="already contains checkpoints"):
+    with pytest.raises(FileExistsError, match="already exists"):
         validate_output_dir(output_dir, resuming=False, clean=False)
 
 
-def test_dir_with_checkpoints_passes_when_resuming(tmp_path):
-    output_dir = tmp_path / "has_ckpt"
+def test_existing_dir_raises(tmp_path):
+    output_dir = tmp_path / "exists"
+    output_dir.mkdir()
+    with pytest.raises(FileExistsError, match="already exists"):
+        validate_output_dir(output_dir, resuming=False, clean=False)
+
+
+def test_existing_dir_passes_when_resuming(tmp_path):
+    output_dir = tmp_path / "exists"
     output_dir.mkdir()
     (output_dir / "checkpoints").mkdir()
     (output_dir / "checkpoints" / "step_0").mkdir()
     validate_output_dir(output_dir, resuming=True, clean=False)
 
 
-def test_dir_with_checkpoints_cleaned_when_flag_set(tmp_path):
-    output_dir = tmp_path / "has_ckpt"
+def test_existing_dir_cleaned_when_flag_set(tmp_path):
+    output_dir = tmp_path / "exists"
     output_dir.mkdir()
     (output_dir / "checkpoints").mkdir()
     (output_dir / "checkpoints" / "step_0").mkdir()


### PR DESCRIPTION
`src/prime_rl/utils/pathing.py`:
- Modified validate_output_dir() to raise if the directory exists at all (not just if it has checkpoints)
- Removed unused has_checkpoints() function
`src/prime_rl/configs/rl.py and src/prime_rl/configs/sft.py`:
- Updated output_dir description to indicate it must be unique per experiment
- Updated clean_output_dir description to reflect new behavior
`tests/unit/utils/test_pathing.py`:
- Updated tests to reflect new behavior - any existing directory now raises
The behavior now matches the issue request:
- output_dir = Path("outputs") is the default
- If directory exists and NOT resuming → raises error
- To overwrite: set clean_output_dir=true or --clean-output-dir 
- Resuming is unaffected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes training startup behavior to fail fast whenever `output_dir` already exists, which can break workflows that previously reused directories containing only logs/configs. Cleanup behavior is unchanged but now more likely to be used to overwrite runs.
> 
> **Overview**
> **Enforces unique `output_dir` per run** by updating `validate_output_dir()` to raise on *any* pre-existing directory unless the run is resuming or `clean_output_dir` is set (and then it deletes the directory).
> 
> Removes the checkpoint-only existence check (`has_checkpoints`) and updates RL/SFT config field descriptions and unit tests to match the new “directory must not exist” behavior and error messaging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d87fe5f216cdd62a42fa1e95fb7b4f8342dff5c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->