### PR TITLE
feat: add mini Qwen3-VL model for local e2e RL testing

### DIFF
--- a/scripts/mini_vlm.py
+++ b/scripts/mini_vlm.py
@@ -1,0 +1,134 @@
+"""Create and verify a mini Qwen3-VL model for local e2e testing.
+
+Creates a small vision-language model with random weights, saves it with
+a tokenizer/processor, and verifies the forward pass works for both
+text-only and multimodal inputs.
+
+Usage:
+    # Create and verify
+    uv run python scripts/mini_vlm.py --output-dir ./mini-qwen3-vl
+
+    # Verify only (on an existing checkpoint)
+    uv run python scripts/mini_vlm.py --output-dir ./mini-qwen3-vl --verify-only
+"""
+
+import argparse
+from pathlib import Path
+
+import torch
+from transformers import AutoModelForImageTextToText, AutoProcessor, AutoTokenizer, Qwen3VLConfig
+
+from prime_rl.utils.logger import setup_logger
+
+setup_logger("info")
+
+TOKENIZER_SOURCE = "Qwen/Qwen3-VL-4B-Instruct"
+
+VLM_CONFIG = Qwen3VLConfig(
+    text_config=dict(
+        vocab_size=151936,
+        hidden_size=256,
+        intermediate_size=512,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=64,
+        max_position_embeddings=4096,
+        rms_norm_eps=1e-6,
+        rope_parameters={
+            "mrope_interleaved": True,
+            "mrope_section": [12, 10, 10],
+            "rope_type": "default",
+            "rope_theta": 5000000,
+        },
+        tie_word_embeddings=True,
+    ),
+    vision_config=dict(
+        depth=4,
+        hidden_size=128,
+        intermediate_size=256,
+        num_heads=4,
+        out_hidden_size=256,  # must match text hidden_size
+        deepstack_visual_indexes=[1, 2, 3],
+        patch_size=16,
+        spatial_merge_size=2,
+        temporal_patch_size=2,
+    ),
+    tie_word_embeddings=True,
+)
+
+
+def create(output_dir: Path) -> None:
+    print("Creating mini Qwen3-VL model...")
+    print(
+        f"  text: hidden_size={VLM_CONFIG.text_config.hidden_size}, layers={VLM_CONFIG.text_config.num_hidden_layers}"
+    )
+    print(f"  vision: hidden_size={VLM_CONFIG.vision_config.hidden_size}, depth={VLM_CONFIG.vision_config.depth}")
+
+    with torch.device("cpu"):
+        model = AutoModelForImageTextToText.from_config(VLM_CONFIG)
+
+    param_count = sum(p.numel() for p in model.parameters())
+    print(f"  Parameters: {param_count / 1e6:.1f}M")
+
+    print(f"  Copying tokenizer & processor from {TOKENIZER_SOURCE}...")
+    tokenizer = AutoTokenizer.from_pretrained(TOKENIZER_SOURCE, trust_remote_code=True)
+    processor = AutoProcessor.from_pretrained(TOKENIZER_SOURCE, trust_remote_code=True, use_fast=True)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    model.save_pretrained(output_dir)
+    tokenizer.save_pretrained(output_dir)
+    processor.save_pretrained(output_dir)
+    print(f"  Saved to {output_dir}")
+
+
+def verify(model_dir: Path) -> None:
+    print(f"Verifying forward pass for {model_dir}...")
+
+    config = Qwen3VLConfig.from_pretrained(str(model_dir))
+    config._attn_implementation = "sdpa"
+
+    with torch.device("cpu"):
+        model = AutoModelForImageTextToText.from_pretrained(str(model_dir), config=config)
+    model.eval()
+
+    # Text-only forward
+    input_ids = torch.randint(0, config.text_config.vocab_size, (1, 32))
+    position_ids = torch.arange(32).unsqueeze(0)
+
+    with torch.no_grad():
+        out = model(input_ids=input_ids, position_ids=position_ids)
+    print(f"  Text-only logits shape: {out.logits.shape}")
+
+    # Multimodal forward
+    image_token_id = config.image_token_id
+    spatial_merge = config.vision_config.spatial_merge_size
+    grid_thw = torch.tensor([[1, 2 * spatial_merge, 2 * spatial_merge]])
+    num_merged_tokens = int(grid_thw[0, 0] * (grid_thw[0, 1] // spatial_merge) * (grid_thw[0, 2] // spatial_merge))
+    num_patches = int(grid_thw[0, 0] * grid_thw[0, 1] * grid_thw[0, 2])
+    patch_dim = 3 * config.vision_config.temporal_patch_size * config.vision_config.patch_size**2
+
+    mm_input_ids = torch.tensor([[1, 2] + [image_token_id] * num_merged_tokens + [3, 4]])
+    pixel_values = torch.randn(num_patches, patch_dim)
+
+    with torch.no_grad():
+        out = model(input_ids=mm_input_ids, pixel_values=pixel_values, image_grid_thw=grid_thw)
+    print(f"  Multimodal logits shape: {out.logits.shape}")
+
+    print("  Verification passed.")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create and verify a mini Qwen3-VL model")
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--verify-only", action="store_true", help="Skip creation, only verify an existing model")
+    args = parser.parse_args()
+
+    if not args.verify_only:
+        create(args.output_dir)
+
+    verify(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/prime_rl/utils/vlm.py
+++ b/src/prime_rl/utils/vlm.py
@@ -4,6 +4,7 @@ This module provides a single source of truth for supported VLM models.
 """
 
 import fnmatch
+from pathlib import Path
 
 # Whitelist of supported VLM model patterns (supports wildcards)
 # Add new patterns here as they are tested and supported
@@ -11,15 +12,34 @@ SUPPORTED_VLM_PATTERNS = [
     "Qwen/Qwen3-VL*",
 ]
 
+# model_type values from HuggingFace configs that indicate a VLM
+SUPPORTED_VLM_MODEL_TYPES = {"qwen3_vl"}
+
 
 def is_vlm_model(model_name: str) -> bool:
     """Check if a model is a supported vision-language model.
+
+    Checks the model name against known patterns first. For local paths,
+    also reads the config to check the model_type (needed for mini/custom
+    checkpoints that don't match the HF naming convention).
 
     Args:
         model_name: The model name or path (e.g., "Qwen/Qwen3-VL-4B-Instruct")
 
     Returns:
-        True if the model matches a supported VLM pattern
+        True if the model matches a supported VLM pattern or model_type
     """
     model_name_lower = model_name.lower()
-    return any(fnmatch.fnmatch(model_name_lower, pattern.lower()) for pattern in SUPPORTED_VLM_PATTERNS)
+    if any(fnmatch.fnmatch(model_name_lower, pattern.lower()) for pattern in SUPPORTED_VLM_PATTERNS):
+        return True
+
+    # For local paths or custom HF repos, check the config's model_type
+    config_path = Path(model_name) / "config.json"
+    if config_path.exists():
+        import json
+
+        with open(config_path) as f:
+            config_data = json.load(f)
+        return config_data.get("model_type", "") in SUPPORTED_VLM_MODEL_TYPES
+
+    return False


### PR DESCRIPTION
## Summary
- Adds `scripts/mini_vlm.py` — creates a tiny ~44M param Qwen3-VL model with random weights for local e2e RL testing, following the same pattern as `scripts/mini_moe.py`
- Updates `is_vlm_model()` to also detect VLM models from local paths by reading `config.json` model_type, so mini/custom checkpoints work without matching the `Qwen/Qwen3-VL*` naming convention

### Mini model specs
| Component | Config |
|-----------|--------|
| **Text** | hidden=256, intermediate=512, layers=4, heads=4, kv_heads=2, head_dim=64 |
| **Vision** | hidden=128, intermediate=256, depth=4, heads=4, out_hidden=256 |
| **Total** | ~44M parameters |

### Usage
```bash
# Create and verify
uv run python scripts/mini_vlm.py --output-dir ./mini-qwen3-vl

# Verify only
uv run python scripts/mini_vlm.py --output-dir ./mini-qwen3-vl --verify-only
```

## Test plan
- [x] Script creates model, saves with tokenizer+processor
- [x] Verification passes: text-only and multimodal forward passes produce correct logit shapes
- [x] `is_vlm_model()` detects local path models via config.json model_type
- [x] Existing tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches VLM detection used in model loading/orchestration; misclassification or unexpected `config.json` contents could route runs down VLM-specific loading/freezing paths. The rest is an additive local testing script.
> 
> **Overview**
> Adds `scripts/mini_vlm.py` to create a small random-weight Qwen3-VL checkpoint, copy a compatible tokenizer/processor, and sanity-check both text-only and multimodal forward passes on CPU.
> 
> Updates `is_vlm_model()` to recognize local/custom checkpoints by reading `config.json` and checking `model_type` (in addition to the existing `Qwen/Qwen3-VL*` name pattern), enabling VLM-specific codepaths to work with mini models stored on disk.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 951b4428d8d877ef67355e37d57204309de83c4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->