### PR TITLE
fix: propagate use_cache=False to sub-configs for VLM models

### DIFF
--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -172,6 +172,10 @@ def get_model(
         ),
     )
     model_config.use_cache = False
+    for subconfig_key in getattr(model_config, "sub_configs", {}):
+        subconfig = getattr(model_config, subconfig_key, None)
+        if subconfig is not None and hasattr(subconfig, "use_cache"):
+            subconfig.use_cache = False
     model_config.use_grouped_mm = config.moe_use_grouped_mm
 
     # Ensure pad_token_id is set (some models like Qwen3MoE don't have it).


### PR DESCRIPTION
## Summary
- VLM models like Qwen3-VL use a sub-config architecture where `text_config` is a separate config object from the top-level config
- Setting `model_config.use_cache = False` only affected the top-level `Qwen3VLConfig`, not the nested `Qwen3VLTextConfig`
- The text model's `use_cache` stayed `True`, causing a `DynamicCache` to be created during training
- During activation checkpointing recomputation, the cache was updated twice, doubling the KV sequence length (8000 → 16000) and causing shape mismatch errors
- Fix: propagate `use_cache=False` to all sub-configs that have the attribute

## Test plan
- [ ] Run VLM training with Qwen3-VL-4B-Instruct and activation checkpointing enabled
- [ ] Verify no shape mismatch errors during backward pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches model configuration at load time; low surface area but can affect forward/backward behavior for models with nested configs (notably VLMs), so regressions would show up as training/inference cache semantics issues.
> 
> **Overview**
> Ensures `use_cache=False` is applied to *all* nested config objects referenced by `model_config.sub_configs`, not just the top-level `model_config`.
> 
> This prevents VLM models with separate `text_config` (and similar sub-configs) from leaving caching enabled during training, avoiding unintended KV cache allocation/updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8292ac5ed84c40f02e636b32af2f4f6cbfae0bee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->