### PR TITLE
dp rank routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Documenting changes which affect configuration usage patterns (added/moved/removed/renamed fields, notable logic changes).
 
+- **`orchestrator.verification.enabled`**: Added top-level rollout verification switch. `orchestrator.buffer.skip_verification` has been removed; use `verification.enabled = false` instead. When disabled, rewards are always 0 and reward-dependent buffer features (`online_difficulty_filtering`, `easy_threshold`, `hard_threshold`) must be unset (2026-03-03)
 - **`model.lora`**: Moved from `model.experimental.lora` to `model.lora` (no longer experimental) (#1440, 2025-12-16)
 - Auto-set `api_server_count=1` on inference when LoRA is enabled, because vLLM doesn't support hotloading for multiple API servers (#1422, 2025-12-17)
 - **`inference.model.rope_scaling`**: Added RoPE scaling configuration passthrough to vLLM (#1447 2025-12-17)

--- a/docs/on_policy_distillation.md
+++ b/docs/on_policy_distillation.md
@@ -53,8 +53,8 @@ teacher_gpu_ids = [2, 3]
 teacher_tau = 1.0
 adv_tau = 0.0  # Disable reward-based learning
 
-[orchestrator.buffer]
-skip_verification = true  # Skip expensive verification
+[orchestrator.verification]
+enabled = false  # Skip expensive verification
 ```
 
 This runs pure on-policy distillation: the student learns to match the teacher without needing any reward signal.
@@ -66,7 +66,7 @@ This runs pure on-policy distillation: the student learns to match the teacher w
 | `teacher_gpu_ids` | `None` | GPUs for teacher server. Auto-starts server when set. |
 | `trainer.loss.teacher_tau` | `0.0` | Distillation strength. Set `> 0` to enable. |
 | `trainer.loss.adv_tau` | `1.0` | Weight for RL advantage signal. Set `0` for pure distillation. |
-| `orchestrator.buffer.skip_verification` | `false` | Skip verification. Use with `adv_tau = 0`. |
+| `orchestrator.verification.enabled` | `true` | Enable/disable verification. Set to `false` for pure distillation with `adv_tau = 0`. |
 
 ## Monitoring
 

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -502,17 +502,6 @@ class BufferConfig(BaseConfig):
         ),
     ] = ["task", "prompt"]
 
-    skip_verification: Annotated[
-        bool,
-        Field(
-            description=(
-                "Whether to skip verification of rollouts using the environment's rubric. "
-                "If True, rewards are always set to 0, online_difficulty_filtering is disabled, "
-                "and easy/hard thresholds are not used."
-            ),
-        ),
-    ] = False
-
     @model_validator(mode="after")
     def validate_thresholds(self):
         if self.easy_threshold is not None and self.hard_threshold is not None:
@@ -525,26 +514,18 @@ class BufferConfig(BaseConfig):
             assert all(ratio > 0 for ratio in self.env_ratios), "All env_ratios must be positive."
         return self
 
-    @model_validator(mode="after")
-    def validate_skip_verification(self):
-        """Validate that skip_verification is not used with reward-dependent features."""
-        if self.skip_verification:
-            if self.online_difficulty_filtering:
-                raise ValueError(
-                    "skip_verification cannot be True when online_difficulty_filtering is True. "
-                    "These features depend on rewards which are disabled when skip_verification=True."
-                )
-            if self.easy_threshold is not None:
-                raise ValueError(
-                    "skip_verification cannot be True when easy_threshold is set. "
-                    "Easy threshold depends on rewards which are disabled when skip_verification=True."
-                )
-            if self.hard_threshold is not None:
-                raise ValueError(
-                    "skip_verification cannot be True when hard_threshold is set. "
-                    "Hard threshold depends on rewards which are disabled when skip_verification=True."
-                )
-        return self
+class VerificationConfig(BaseConfig):
+    """Configures rollout verification and rubric scoring."""
+
+    enabled: Annotated[
+        bool,
+        Field(
+            description=(
+                "Whether to verify training rollouts using the environment rubric. "
+                "If False, rewards are always set to 0."
+            ),
+        ),
+    ] = True
 
 
 class DefaultAdvantageConfig(BaseModel):
@@ -698,6 +679,9 @@ class OrchestratorConfig(BaseSettings):
 
     # Data buffer configuration
     buffer: BufferConfig = BufferConfig()
+
+    # Rollout verification configuration
+    verification: VerificationConfig = VerificationConfig()
 
     # The advantage configuration
     advantage: AdvantageConfig | None = DefaultAdvantageConfig()
@@ -915,6 +899,28 @@ class OrchestratorConfig(BaseSettings):
         return self
 
     @model_validator(mode="after")
+    def validate_verification_config(self):
+        if self.verification.enabled:
+            return self
+
+        if self.buffer.online_difficulty_filtering:
+            raise ValueError(
+                "verification.enabled cannot be False when buffer.online_difficulty_filtering is True. "
+                "These features depend on rewards which are disabled when verification.enabled=False."
+            )
+        if self.buffer.easy_threshold is not None:
+            raise ValueError(
+                "verification.enabled cannot be False when buffer.easy_threshold is set. "
+                "Easy threshold depends on rewards which are disabled when verification.enabled=False."
+            )
+        if self.buffer.hard_threshold is not None:
+            raise ValueError(
+                "verification.enabled cannot be False when buffer.hard_threshold is set. "
+                "Hard threshold depends on rewards which are disabled when verification.enabled=False."
+            )
+        return self
+
+    @model_validator(mode="after")
     def auto_setup_bench(self):
         if self.bench:
             self.max_steps = 4  # Run for 1 warmup step + 3 evaluation steps
@@ -933,7 +939,7 @@ class OrchestratorConfig(BaseSettings):
     def resolve_extra_env_kwargs(self):
         train_extra_env_kwargs = dict(
             seq_len=self.seq_len,
-            score_rollouts=not self.buffer.skip_verification,
+            score_rollouts=self.verification.enabled,
         )
         for env in self.env:
             # extra_env_kwargs is not meant to be used by the user, we shamelessly override here

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -514,6 +514,7 @@ class BufferConfig(BaseConfig):
             assert all(ratio > 0 for ratio in self.env_ratios), "All env_ratios must be positive."
         return self
 
+
 class VerificationConfig(BaseConfig):
     """Configures rollout verification and rubric scoring."""
 

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -650,6 +650,16 @@ class RLConfig(BaseSettings):
         return self
 
     @model_validator(mode="after")
+    def auto_setup_dp_rank_count(self):
+        """Auto-set orchestrator client dp_rank_count from inference DP size."""
+        if (
+            self.inference is not None
+            and "dp_rank_count" not in self.orchestrator.client.model_fields_set
+        ):
+            self.orchestrator.client.dp_rank_count = self.inference.parallel.dp
+        return self
+
+    @model_validator(mode="after")
     def auto_setup_teacher_inference(self):
         """Auto-configure teacher inference server and orchestrator teacher_model client."""
         if self.deployment.type != "single_node":

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -652,10 +652,7 @@ class RLConfig(BaseSettings):
     @model_validator(mode="after")
     def auto_setup_dp_rank_count(self):
         """Auto-set orchestrator client dp_rank_count from inference DP size."""
-        if (
-            self.inference is not None
-            and "dp_rank_count" not in self.orchestrator.client.model_fields_set
-        ):
+        if self.inference is not None and "dp_rank_count" not in self.orchestrator.client.model_fields_set:
             self.orchestrator.client.dp_rank_count = self.inference.parallel.dp
         return self
 

--- a/src/prime_rl/configs/shared.py
+++ b/src/prime_rl/configs/shared.py
@@ -122,6 +122,21 @@ class ClientConfig(BaseConfig):
         ),
     ] = False
 
+    dp_rank_count: Annotated[
+        int,
+        Field(
+            ge=1,
+            description=(
+                "Number of data-parallel ranks behind each base URL. When > 1, "
+                "each URL is expanded into dp_rank_count logical clients, each "
+                "pinned to a specific DP rank via the X-data-parallel-rank header. "
+                "This ensures all requests within a multi-turn rollout hit the same "
+                "DP engine, maximizing KV cache reuse. Auto-set from "
+                "inference.parallel.dp when using the RL entrypoint."
+            ),
+        ),
+    ] = 1
+
     elastic: Annotated[
         ElasticConfig | None,
         Field(

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -170,7 +170,7 @@ async def orchestrate(config: OrchestratorConfig):
         env_names=train_env_names,
         map_kwargs=dict(writer_batch_size=1),  # set defensively to not error on map operations on large datasets
     )
-    verification_enabled = not config.buffer.skip_verification
+    verification_enabled = config.verification.enabled
 
     train_env_deferred_group_scoring_tasks = (
         {env_name for env_name in train_env_names if task_uses_group_scoring(train_env_group, env_name)}

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -156,9 +156,7 @@ class Scheduler:
         while not clients:
             await asyncio.sleep(1)
             clients = self.inference_pool.clients
-        inflight_by_client = Counter(
-            info.client_config.client_idx for info in self.inflight_requests.values()
-        )
+        inflight_by_client = Counter(info.client_config.client_idx for info in self.inflight_requests.values())
         return min(clients, key=lambda c: inflight_by_client[c.client_idx])
 
     async def drop_group(self, group_id: int) -> int:

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -310,7 +310,7 @@ class Scheduler:
             )
 
     def _should_defer_group_scoring(self, task: str) -> bool:
-        return task in self.deferred_group_scoring_tasks and not self.config.buffer.skip_verification
+        return task in self.deferred_group_scoring_tasks and self.config.verification.enabled
 
     async def _score_group_if_deferred(self, completed_rollouts: list[vf.RolloutOutput]) -> list[vf.RolloutOutput]:
         if not completed_rollouts:
@@ -338,7 +338,6 @@ class Scheduler:
         batch_start_time = time.perf_counter()
 
         self.logger.debug("Starting to generate batch rollouts")
-        await self._fill_inflight_requests()
 
         batch_rollouts: list[vf.RolloutOutput] = []
         batch_progress = 0
@@ -347,13 +346,8 @@ class Scheduler:
         )
 
         while batch_progress < self.batch_target:
+            await self._fill_inflight_requests()
             inflight_tasks = list(self.inflight_requests.keys())
-            if not inflight_tasks:
-                await self._fill_inflight_requests()
-                inflight_tasks = list(self.inflight_requests.keys())
-                if not inflight_tasks:
-                    raise RuntimeError("No in-flight rollout requests and could not schedule new requests.")
-                continue
 
             finished_tasks, _ = await asyncio.wait(
                 inflight_tasks,
@@ -397,7 +391,7 @@ class Scheduler:
                 batch_progress += progress_increment
                 pbar.update(progress_increment)
 
-            await self._fill_inflight_requests()
+        await self._fill_inflight_requests()
 
         batch_rollouts = self.finalize_batch_rollouts(batch_rollouts)
         pbar.close()

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -40,6 +40,7 @@ class GroupState:
     example: dict
     rollouts_to_schedule: int
     completed_rollouts: list[vf.RolloutOutput] = field(default_factory=list)
+    pinned_client: vf.ClientConfig | None = None
 
 
 class Scheduler:
@@ -146,15 +147,19 @@ class Scheduler:
         self.cancelled_rollouts_count += count
 
     async def _select_least_loaded_client(self) -> vf.ClientConfig:
-        """Select the client with the fewest in-flight tasks."""
+        """Select the client with the fewest in-flight tasks.
+
+        When dp_rank_count > 1, each (URL, dp_rank) pair is a separate client,
+        so this naturally balances across both servers and DP ranks.
+        """
         clients = self.inference_pool.clients
         while not clients:
             await asyncio.sleep(1)
             clients = self.inference_pool.clients
-        inflight_by_url = Counter()
-        for info in self.inflight_requests.values():
-            inflight_by_url[info.client_config.api_base_url] += 1
-        return min(clients, key=lambda c: inflight_by_url[c.api_base_url])
+        inflight_by_client = Counter(
+            info.client_config.client_idx for info in self.inflight_requests.values()
+        )
+        return min(clients, key=lambda c: inflight_by_client[c.client_idx])
 
     async def drop_group(self, group_id: int) -> int:
         """Drop a group and cancel any remaining in-flight rollouts for it."""
@@ -176,9 +181,15 @@ class Scheduler:
         if group is None or group.rollouts_to_schedule <= 0:
             return
         group.rollouts_to_schedule -= 1
-        client_config = await self._select_least_loaded_client()
-        if group_id not in self.groups:
-            return
+
+        if group.pinned_client is not None:
+            client_config = group.pinned_client
+        else:
+            client_config = await self._select_least_loaded_client()
+            if group_id not in self.groups:
+                return
+            group.pinned_client = client_config
+
         run_rollout_task = asyncio.create_task(
             run_rollout(
                 env=self.env,

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -109,6 +109,7 @@ async def setup_inference_pool(
 
     logger.info(
         f"Initializing static inference pool (base_url={', '.join(client_config.base_url)}, "
+        f"dp_rank_count={client_config.dp_rank_count}, "
         f"api_key_var={client_config.api_key_var}, headers={client_config.headers})"
     )
     return StaticInferencePool(
@@ -119,20 +120,28 @@ async def setup_inference_pool(
 
 
 def setup_clients(client_config: ClientConfig, client_type: str = "openai_chat_completions") -> list[vf.ClientConfig]:
-    def setup_client(client_idx: int, base_url: str) -> vf.ClientConfig:
-        return vf.ClientConfig(
-            client_idx=client_idx,
-            client_type=client_type,
-            api_base_url=base_url,
-            api_key_var=client_config.api_key_var,
-            timeout=client_config.timeout,
-            max_connections=8192,
-            max_keepalive_connections=8192,
-            max_retries=10,
-            extra_headers=client_config.headers,
-        )
-
-    return [setup_client(client_idx, base_url) for client_idx, base_url in enumerate(client_config.base_url)]
+    clients = []
+    client_idx = 0
+    for base_url in client_config.base_url:
+        for dp_rank in range(client_config.dp_rank_count):
+            headers = client_config.headers.copy()
+            if client_config.dp_rank_count > 1:
+                headers["X-data-parallel-rank"] = str(dp_rank)
+            clients.append(
+                vf.ClientConfig(
+                    client_idx=client_idx,
+                    client_type=client_type,
+                    api_base_url=base_url,
+                    api_key_var=client_config.api_key_var,
+                    timeout=client_config.timeout,
+                    max_connections=8192,
+                    max_keepalive_connections=8192,
+                    max_retries=10,
+                    extra_headers=headers,
+                )
+            )
+            client_idx += 1
+    return clients
 
 
 def setup_admin_clients(client_config: ClientConfig) -> list[AsyncClient]:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk due to behavior changes in rollout scheduling (client pinning + new dp-rank header expansion) and a breaking config rename for verification that could affect reward/scoring behavior if misconfigured.
> 
> **Overview**
> Adds **data-parallel rank–aware inference routing** via new `client.dp_rank_count`: each `base_url` is expanded into per-DP logical clients and tagged with `X-data-parallel-rank`, and the scheduler now **pins a rollout group to a single client** while balancing load by `client_idx`.
> 
> Replaces `orchestrator.buffer.skip_verification` with a top-level `orchestrator.verification.enabled` switch, updates orchestrator/env `score_rollouts` wiring and validation to block reward-dependent buffer features when verification is disabled, and updates docs/changelog accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7fd3f5c3447659887a7de01ea82fc1335f80eae6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->