### PR TITLE
feat: add async filesystem weight broadcast (type=async_filesystem)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,3 +91,4 @@ Documenting changes which affect configuration usage patterns (added/moved/remov
 - **`dry_run`**: Added to `RLConfig` and `SFTConfig` (default: `False`). When set, validates the config, writes resolved subconfigs to `output_dir/configs/`, and exits without starting any processes. Works the same for both local and SLURM runs (2026-02-26)
 - **Config output location**: Resolved subconfigs are now always written to `output_dir/configs/` instead of `.pydantic_config/<uuid>/`. This applies to both local and SLURM entrypoints, and for both single-node and multi-node deployments (2026-02-26)
 - **SFT config filename**: The resolved SFT trainer config is now written as `sft.toml` instead of `trainer.toml` (2026-02-26)
+- **`trainer.weight_broadcast.type` / `weight_broadcast.type`**: Added `async_filesystem` as a supported broadcast type. This enables async trainer-side filesystem broadcast while keeping orchestrator/inference on the filesystem protocol (2026-03-02)

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -24,6 +24,9 @@ from prime_rl.configs.shared import (
     WandbWithExtrasConfig,
 )
 from prime_rl.configs.trainer import (
+    AsyncFileSystemWeightBroadcastConfig as TrainerAsyncFileSystemWeightBroadcastConfig,
+)
+from prime_rl.configs.trainer import (
     BenchConfig,
     FakeDataLoaderConfig,
     TrainerConfig,
@@ -110,9 +113,10 @@ class SharedModelConfig(BaseSettings):
 class SharedWeightBroadcastConfig(BaseSettings):
     """Configures shared weight broadcast settings."""
 
-    type: Annotated[Literal["nccl", "filesystem"], Field(description="The type of weight broadcast to use.")] = (
-        "filesystem"
-    )
+    type: Annotated[
+        Literal["nccl", "filesystem", "async_filesystem"],
+        Field(description="The type of weight broadcast to use."),
+    ] = "filesystem"
 
     port: Annotated[int, Field(description="The port to use for NCCL weight broadcast.")] = 29501
     timeout: Annotated[int, Field(description="The timeout in seconds for NCCL weight broadcast.")] = 1200
@@ -486,11 +490,17 @@ class RLConfig(BaseSettings):
                     port=self.weight_broadcast.port,
                     timeout=self.weight_broadcast.timeout,
                 )
+            elif self.weight_broadcast.type == "async_filesystem":
+                self.trainer.weight_broadcast = TrainerAsyncFileSystemWeightBroadcastConfig()
+                self.orchestrator.weight_broadcast = OrchestratorFileSystemWeightBroadcastConfig()
             elif self.weight_broadcast.type == "filesystem":
                 self.trainer.weight_broadcast = TrainerFileSystemWeightBroadcastConfig()
                 self.orchestrator.weight_broadcast = OrchestratorFileSystemWeightBroadcastConfig()
             if self.inference is not None:
-                self.inference.weight_broadcast = InferenceWeightBroadcastConfig(type=self.weight_broadcast.type)
+                # Async is trainer-side only; inference/orchestrator always use "filesystem"
+                wb_type = self.weight_broadcast.type
+                inference_type = "filesystem" if wb_type == "async_filesystem" else wb_type
+                self.inference.weight_broadcast = InferenceWeightBroadcastConfig(type=inference_type)
 
         validate_shared_weight_broadcast(self.trainer, self.orchestrator, self.inference)
 

--- a/src/prime_rl/configs/trainer.py
+++ b/src/prime_rl/configs/trainer.py
@@ -630,6 +630,21 @@ class FileSystemWeightBroadcastConfig(BaseWeightBroadcastConfig):
     ] = "safetensors"
 
 
+class AsyncFileSystemWeightBroadcastConfig(BaseWeightBroadcastConfig):
+    """Configures the async filesystem weight broadcast.
+
+    Same as FileSystemWeightBroadcastConfig but offloads serialization and
+    disk I/O to a background thread so the trainer can proceed immediately
+    after the synchronous FSDP gather.
+    """
+
+    type: Literal["async_filesystem"] = "async_filesystem"
+    save_sharded: Annotated[bool, Field(description="Whether to save the weight checkpoint in sharded format.")] = True
+    save_format: Annotated[
+        Literal["safetensors", "torch"], Field(description="The format to save the weight checkpoint in.")
+    ] = "safetensors"
+
+
 class NCCLWeightBroadcastConfig(BaseWeightBroadcastConfig):
     """Configures the NCCL broadcast."""
 
@@ -642,7 +657,8 @@ class NCCLWeightBroadcastConfig(BaseWeightBroadcastConfig):
 
 
 WeightBroadcastConfig: TypeAlias = Annotated[
-    FileSystemWeightBroadcastConfig | NCCLWeightBroadcastConfig, Field(discriminator="type")
+    FileSystemWeightBroadcastConfig | AsyncFileSystemWeightBroadcastConfig | NCCLWeightBroadcastConfig,
+    Field(discriminator="type"),
 ]
 
 

--- a/src/prime_rl/trainer/rl/broadcast/__init__.py
+++ b/src/prime_rl/trainer/rl/broadcast/__init__.py
@@ -3,23 +3,20 @@ from pathlib import Path
 import torch
 
 from prime_rl.configs.trainer import LoRAConfig, WeightBroadcastConfig
+from prime_rl.trainer.rl.broadcast.async_filesystem import AsyncFileSystemWeightBroadcast
 from prime_rl.trainer.rl.broadcast.base import WeightBroadcast
+from prime_rl.trainer.rl.broadcast.filesystem import FileSystemWeightBroadcast
+from prime_rl.trainer.rl.broadcast.nccl import NCCLWeightBroadcast
 
 
 def setup_weight_broadcast(
     output_dir: Path, config: WeightBroadcastConfig, lora_config: LoRAConfig | None = None
 ) -> WeightBroadcast:
     if config.type == "nccl":
-        from prime_rl.trainer.rl.broadcast.nccl import NCCLWeightBroadcast
-
         return NCCLWeightBroadcast(output_dir, config, torch.cuda.current_device())
     elif config.type == "async_filesystem":
-        from prime_rl.trainer.rl.broadcast.async_filesystem import AsyncFileSystemWeightBroadcast
-
         return AsyncFileSystemWeightBroadcast(output_dir, config, lora_config)
     elif config.type == "filesystem":
-        from prime_rl.trainer.rl.broadcast.filesystem import FileSystemWeightBroadcast
-
         return FileSystemWeightBroadcast(output_dir, config, lora_config)
     else:
         raise ValueError(f"Invalid weight broadcast type: {config.type}")

--- a/src/prime_rl/trainer/rl/broadcast/__init__.py
+++ b/src/prime_rl/trainer/rl/broadcast/__init__.py
@@ -4,16 +4,22 @@ import torch
 
 from prime_rl.configs.trainer import LoRAConfig, WeightBroadcastConfig
 from prime_rl.trainer.rl.broadcast.base import WeightBroadcast
-from prime_rl.trainer.rl.broadcast.filesystem import FileSystemWeightBroadcast
-from prime_rl.trainer.rl.broadcast.nccl import NCCLWeightBroadcast
 
 
 def setup_weight_broadcast(
     output_dir: Path, config: WeightBroadcastConfig, lora_config: LoRAConfig | None = None
 ) -> WeightBroadcast:
     if config.type == "nccl":
+        from prime_rl.trainer.rl.broadcast.nccl import NCCLWeightBroadcast
+
         return NCCLWeightBroadcast(output_dir, config, torch.cuda.current_device())
+    elif config.type == "async_filesystem":
+        from prime_rl.trainer.rl.broadcast.async_filesystem import AsyncFileSystemWeightBroadcast
+
+        return AsyncFileSystemWeightBroadcast(output_dir, config, lora_config)
     elif config.type == "filesystem":
+        from prime_rl.trainer.rl.broadcast.filesystem import FileSystemWeightBroadcast
+
         return FileSystemWeightBroadcast(output_dir, config, lora_config)
     else:
         raise ValueError(f"Invalid weight broadcast type: {config.type}")

--- a/src/prime_rl/trainer/rl/broadcast/async_filesystem.py
+++ b/src/prime_rl/trainer/rl/broadcast/async_filesystem.py
@@ -63,7 +63,7 @@ class AsyncFileSystemWeightBroadcast(WeightBroadcast):
             pending.result()
             if wait_start is not None:
                 wait_time = time.perf_counter() - wait_start
-                self.logger.info(f"[BENCH] async: waited {wait_time:.3f}s for previous write to finish")
+                self.logger.debug(f"Waited {wait_time:.3f}s for previous write to finish")
             return wait_time
         finally:
             # Always clear pending, even when result() raises, so subsequent
@@ -95,7 +95,7 @@ class AsyncFileSystemWeightBroadcast(WeightBroadcast):
         if cuda_event is not None:
             cuda_event.synchronize()
             event_sync_time = time.perf_counter() - write_start
-            self.logger.info(f"[BENCH] async: CUDA event sync={event_sync_time:.3f}s (DMA drain)")
+            self.logger.debug(f"CUDA event sync={event_sync_time:.3f}s (DMA drain)")
 
         for idx, state_dict in state_dicts.items():
             try:
@@ -103,7 +103,7 @@ class AsyncFileSystemWeightBroadcast(WeightBroadcast):
                 save_dir = get_step_path(get_broadcast_dir(run_dir), progress_step)
                 save_dir.mkdir(parents=True, exist_ok=True)
 
-                self.logger.debug(f"[async] Saving weights for run {idx} to {save_dir}")
+                self.logger.debug(f"Saving weights for run {idx} to {save_dir}")
                 save_state_dict(state_dict, save_dir, self.save_format, self.save_sharded, adapter=adapter_only)
 
                 if adapter_only and lora_configs is not None and model is not None and idx in lora_configs:
@@ -117,12 +117,12 @@ class AsyncFileSystemWeightBroadcast(WeightBroadcast):
                 if self.multi_run_manager.get_orchestrator_config(self.multi_run_manager.idx_2_id[idx]) is None:
                     shutil.rmtree(run_dir)
             except FileNotFoundError:
-                self.logger.warning(f"[async] Run {idx} directory deleted during broadcast, skipping")
+                self.logger.warning(f"Run {idx} directory deleted during broadcast, skipping")
             except Exception as e:
-                self.logger.error(f"[async] Error broadcasting weights for run {idx}: {e}")
+                self.logger.error(f"Error broadcasting weights for run {idx}: {e}")
 
         self._last_broadcast_time = time.perf_counter() - write_start
-        self.logger.info(f"[BENCH] async background write completed in {self._last_broadcast_time:.3f}s")
+        self.logger.debug(f"Background write completed in {self._last_broadcast_time:.3f}s")
 
     def broadcast_weights(self, model: nn.Module, step: int) -> None:
         """Broadcast weights: gather synchronously, write asynchronously."""
@@ -146,6 +146,10 @@ class AsyncFileSystemWeightBroadcast(WeightBroadcast):
             if self.world.is_master and torch.cuda.is_available():
                 cuda_event = torch.cuda.Event()
                 cuda_event.record()
+                # Weight conversion reads tensor data, so we must drain the
+                # non-blocking DMA first. The background thread still handles
+                # the heavier save_state_dict + disk I/O asynchronously.
+                cuda_event.synchronize()
 
             if isinstance(model, PreTrainedModelPrimeRL) and model.is_prime_state_dict(state_dict):
                 model.convert_to_hf(state_dict)
@@ -215,8 +219,8 @@ class AsyncFileSystemWeightBroadcast(WeightBroadcast):
                 model if adapter_only else None,
                 cuda_event,
             )
-            self.logger.info(
-                f"[BENCH] async broadcast: blocking={blocking_time:.3f}s "
+            self.logger.debug(
+                f"Broadcast: blocking={blocking_time:.3f}s "
                 f"(pending_wait={pending_wait:.3f}s gather={gather_time:.3f}s) "
                 f"write=background prev_write={self._last_broadcast_time:.3f}s"
             )

--- a/src/prime_rl/trainer/rl/broadcast/async_filesystem.py
+++ b/src/prime_rl/trainer/rl/broadcast/async_filesystem.py
@@ -1,0 +1,233 @@
+import copy
+import shutil
+import time
+from concurrent.futures import Future, ThreadPoolExecutor
+from pathlib import Path
+from typing import Literal
+
+import torch
+import torch.nn as nn
+from torch.distributed.tensor import DTensor
+
+from prime_rl.configs.trainer import AsyncFileSystemWeightBroadcastConfig, LoRAConfig
+from prime_rl.trainer.lora import save_lora_config
+from prime_rl.trainer.models import PreTrainedModelPrimeRL
+from prime_rl.trainer.rl.broadcast.base import WeightBroadcast
+from prime_rl.trainer.runs import get_multi_run_manager
+from prime_rl.trainer.utils import maybe_clean
+from prime_rl.trainer.weights import (
+    gather_weights_on_master,
+    save_state_dict,
+)
+from prime_rl.trainer.world import get_world
+from prime_rl.utils.utils import get_broadcast_dir, get_step_path
+
+
+class AsyncFileSystemWeightBroadcast(WeightBroadcast):
+    """Non-blocking filesystem weight broadcast.
+
+    The FSDP gather runs synchronously (all ranks must participate), but
+    serialization and disk I/O run in a background thread so the trainer
+    can continue to the next step immediately.
+    """
+
+    def __init__(
+        self, output_dir: Path, config: AsyncFileSystemWeightBroadcastConfig, lora_config: LoRAConfig | None = None
+    ):
+        super().__init__(output_dir, lora_config)
+        self.save_format: Literal["safetensors", "torch"] = config.save_format
+        self.save_sharded = config.save_sharded if lora_config is None else False
+        self.world = get_world()
+        self.multi_run_manager = get_multi_run_manager()
+        self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="weight_broadcast")
+        self._pending: Future | None = None
+        self._last_broadcast_time: float = 0.0
+        self.logger.info(
+            f"Async filesystem broadcast initialized (save_format={config.save_format}, "
+            f"save_sharded={self.save_sharded})"
+        )
+
+    def _wait_for_pending(self) -> float:
+        """Block until the previous background write completes. Returns wait time in seconds."""
+        wait_time = 0.0
+        if self._pending is not None and not self._pending.done():
+            wait_start = time.perf_counter()
+            self._pending.result()
+            wait_time = time.perf_counter() - wait_start
+            self.logger.info(f"[BENCH] async: waited {wait_time:.3f}s for previous write to finish")
+        if self._pending is not None and self._pending.done():
+            # Re-raise any exception from the background thread
+            self._pending.result()
+        self._pending = None
+        return wait_time
+
+    def _write_and_notify(
+        self,
+        state_dicts: dict[int, dict],
+        run_metadata: dict[int, tuple[Path, int]],
+        adapter_only: bool,
+        lora_configs: dict[int, tuple[int, float, float]] | None,
+        model: nn.Module | None,
+        cuda_event: torch.cuda.Event | None = None,
+    ) -> None:
+        """Runs in background thread: serialize weights to disk and write STABLE marker.
+
+        Args:
+            state_dicts: {idx: state_dict} per run, each owned exclusively by this thread.
+            run_metadata: {idx: (run_dir, progress_step)} captured on the main thread.
+            lora_configs: {idx: (rank, alpha, dropout)} for adapter runs, None otherwise.
+            model: Model reference for save_lora_config. Only reads immutable module
+                structure and config metadata — safe while trainer mutates parameter data.
+            cuda_event: If provided, synchronize before reading tensor data to
+                ensure non-blocking GPU->CPU DMA transfers have completed.
+        """
+        write_start = time.perf_counter()
+
+        if cuda_event is not None:
+            cuda_event.synchronize()
+            event_sync_time = time.perf_counter() - write_start
+            self.logger.info(f"[BENCH] async: CUDA event sync={event_sync_time:.3f}s (DMA drain)")
+
+        for idx, state_dict in state_dicts.items():
+            try:
+                run_dir, progress_step = run_metadata[idx]
+                save_dir = get_step_path(get_broadcast_dir(run_dir), progress_step)
+                save_dir.mkdir(parents=True, exist_ok=True)
+
+                self.logger.debug(f"[async] Saving weights for run {idx} to {save_dir}")
+                save_state_dict(state_dict, save_dir, self.save_format, self.save_sharded, adapter=adapter_only)
+
+                if adapter_only and lora_configs is not None and model is not None and idx in lora_configs:
+                    rank, alpha, dropout = lora_configs[idx]
+                    save_lora_config(model, save_dir, rank=rank, alpha=alpha, dropout=dropout)
+
+                self._notify_orchestrator(save_dir)
+
+                # Avoid zombie run directories that get recreated by mkdir
+                # after the orchestrator deletes them during broadcast
+                if self.multi_run_manager.get_orchestrator_config(self.multi_run_manager.idx_2_id[idx]) is None:
+                    shutil.rmtree(run_dir)
+            except FileNotFoundError:
+                self.logger.warning(f"[async] Run {idx} directory deleted during broadcast, skipping")
+            except Exception as e:
+                self.logger.error(f"[async] Error broadcasting weights for run {idx}: {e}")
+
+        self._last_broadcast_time = time.perf_counter() - write_start
+        self.logger.info(f"[BENCH] async background write completed in {self._last_broadcast_time:.3f}s")
+
+    def broadcast_weights(self, model: nn.Module, step: int) -> None:
+        """Broadcast weights: gather synchronously, write asynchronously."""
+        self.logger.debug(f"Starting async weight broadcast at step {step}")
+        start_time = time.perf_counter()
+
+        # Block until any in-flight background write finishes.
+        # This provides backpressure: if the disk write from step N is slower
+        # than one training step, we block here at step N+1 (no worse than sync).
+        pending_wait = self._wait_for_pending()
+
+        adapter_only = self.lora_config is not None
+        cuda_event = None
+
+        # Phase 1: FSDP gather (synchronous — all ranks must participate).
+        # With non_blocking=True the per-tensor GPU->CPU DMAs are queued
+        # into pinned memory without blocking. A CUDA event recorded
+        # afterwards lets the background thread wait for the DMA to finish.
+        if not adapter_only:
+            state_dict = gather_weights_on_master(model, is_master=self.world.is_master, non_blocking=True)
+            if self.world.is_master and torch.cuda.is_available():
+                cuda_event = torch.cuda.Event()
+                cuda_event.record()
+
+            if isinstance(model, PreTrainedModelPrimeRL) and model.is_prime_state_dict(state_dict):
+                model.convert_to_hf(state_dict)
+            else:
+                from transformers.core_model_loading import revert_weight_conversion
+
+                state_dict = revert_weight_conversion(model, state_dict)
+
+        gather_time = time.perf_counter() - start_time
+        self.logger.debug(f"Gather completed in {gather_time:.2f}s")
+
+        # Phase 2: Prepare per-run state dicts (synchronous for DTensor ops).
+        ready_idxs = list(self.multi_run_manager.ready_to_update_idxs)
+        prepared: dict[int, dict] = {}
+        lora_configs: dict[int, tuple[int, float, float]] | None = None if not adapter_only else {}
+
+        for idx in ready_idxs:
+            if adapter_only:
+                run_state_dict = self.multi_run_manager.get_state_dict_for_run(idx)
+                for key, value in run_state_dict.items():
+                    if isinstance(value, DTensor):
+                        value = value.full_tensor()
+                    if self.world.is_master:
+                        pinned = torch.empty(value.shape, dtype=value.dtype, device="cpu", pin_memory=True)
+                        pinned.copy_(value, non_blocking=True)
+                        run_state_dict[key] = pinned
+                if self.world.is_master:
+                    prepared[idx] = run_state_dict
+                    if torch.cuda.is_available():
+                        cuda_event = torch.cuda.Event()
+                        cuda_event.record()
+                    if lora_configs is not None:
+                        orch_lora = self.multi_run_manager.config[idx].model.lora
+                        lora_configs[idx] = (orch_lora.rank, orch_lora.alpha, self.lora_config.dropout)
+            else:
+                if self.world.is_master:
+                    # save_state_dict mutates (del keys) the dict it receives,
+                    # so each run needs its own copy to avoid corruption.
+                    if len(ready_idxs) > 1:
+                        prepared[idx] = copy.copy(state_dict)
+                    else:
+                        prepared[idx] = state_dict
+
+        # Snapshot run metadata on the main thread before the trainer's
+        # progress.step increments during the next training step.
+        run_metadata: dict[int, tuple[Path, int]] = {}
+        for idx in prepared:
+            run_metadata[idx] = (
+                self.multi_run_manager.get_run_dir(idx),
+                self.multi_run_manager.progress[idx].step,
+            )
+
+        # Clear ready flags on the main thread to prevent the next broadcast
+        # from double-processing these runs (thread-safety fix).
+        for idx in ready_idxs:
+            self.multi_run_manager.ready_to_update[idx] = False
+
+        # Phase 3: Submit background serialize + write (master only).
+        blocking_time = time.perf_counter() - start_time
+        if self.world.is_master and prepared:
+            self._pending = self._executor.submit(
+                self._write_and_notify,
+                prepared,
+                run_metadata,
+                adapter_only,
+                lora_configs,
+                model if adapter_only else None,
+                cuda_event,
+            )
+            self.logger.info(
+                f"[BENCH] async broadcast: blocking={blocking_time:.3f}s "
+                f"(pending_wait={pending_wait:.3f}s gather={gather_time:.3f}s) "
+                f"write=background prev_write={self._last_broadcast_time:.3f}s"
+            )
+
+    def _notify_orchestrator(self, save_dir: Path):
+        stable_file = save_dir / "STABLE"
+        stable_file.touch()
+
+    def maybe_clean(self, max_async_level: int, interval_to_keep: int | None):
+        # Cleanup targets step-(async_level+1), which is always a completed
+        # write. The pending write is for the current step and won't be cleaned.
+        for idx in self.multi_run_manager.used_idxs:
+            maybe_clean(
+                get_broadcast_dir(self.multi_run_manager.get_run_dir(idx)),
+                self.multi_run_manager.progress[idx].step,
+                max_async_level,
+                interval_to_keep,
+            )
+
+    def shutdown(self):
+        """Wait for pending work and shut down the thread pool."""
+        self._wait_for_pending()
+        self._executor.shutdown(wait=True)

--- a/src/prime_rl/trainer/rl/broadcast/async_filesystem.py
+++ b/src/prime_rl/trainer/rl/broadcast/async_filesystem.py
@@ -49,17 +49,26 @@ class AsyncFileSystemWeightBroadcast(WeightBroadcast):
 
     def _wait_for_pending(self) -> float:
         """Block until the previous background write completes. Returns wait time in seconds."""
+        pending = self._pending
+        if pending is None:
+            return 0.0
+
         wait_time = 0.0
-        if self._pending is not None and not self._pending.done():
+        wait_start = None
+        if not pending.done():
             wait_start = time.perf_counter()
-            self._pending.result()
-            wait_time = time.perf_counter() - wait_start
-            self.logger.info(f"[BENCH] async: waited {wait_time:.3f}s for previous write to finish")
-        if self._pending is not None and self._pending.done():
-            # Re-raise any exception from the background thread
-            self._pending.result()
-        self._pending = None
-        return wait_time
+
+        try:
+            # Re-raise any exception from the background thread.
+            pending.result()
+            if wait_start is not None:
+                wait_time = time.perf_counter() - wait_start
+                self.logger.info(f"[BENCH] async: waited {wait_time:.3f}s for previous write to finish")
+            return wait_time
+        finally:
+            # Always clear pending, even when result() raises, so subsequent
+            # broadcasts/shutdown calls don't get stuck replaying one failure.
+            self._pending = None
 
     def _write_and_notify(
         self,

--- a/src/prime_rl/trainer/rl/broadcast/base.py
+++ b/src/prime_rl/trainer/rl/broadcast/base.py
@@ -16,3 +16,7 @@ class WeightBroadcast(ABC):
     @abstractmethod
     def broadcast_weights(self, model: nn.Module, step: int):
         pass
+
+    def shutdown(self):
+        """Clean up resources. Override in subclasses that use background threads."""
+        pass

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -218,14 +218,15 @@ def train(config: TrainerConfig):
         # Broadcast weights at every step, (except step 0, because no need to broadcast the base model)
         # Also, with NCCL broadcast, we do not broadcast weights the last async level step as the orchestrator is already finished and will not initialize the receive on the inference; for filesystem broadcast, we do "broadcast" until the final step to allow to resume from the broadcast directory
         last_async_level_steps = config.max_steps and progress.step >= config.max_steps - config.max_async_level
-        if progress.step > 0 and (not last_async_level_steps or config.weight_broadcast.type == "filesystem"):
+        is_filesystem_broadcast = config.weight_broadcast.type in ("filesystem", "async_filesystem")
+        if progress.step > 0 and (not last_async_level_steps or is_filesystem_broadcast):
             broadcast_weights_start_time = time.perf_counter()
             weight_broadcast.broadcast_weights(model, step=progress.step)
             broadcast_weights_time = time.perf_counter() - broadcast_weights_start_time
             # Clean up old broadcast directories (unless at ckpt interval if using filesystem weight broadcast)
             ckpt_interval = config.ckpt and config.ckpt.interval
-            interval_to_keep = ckpt_interval if config.weight_broadcast.type == "filesystem" else None
-            if config.weight_broadcast.type == "filesystem":
+            interval_to_keep = ckpt_interval if is_filesystem_broadcast else None
+            if is_filesystem_broadcast:
                 weight_broadcast.maybe_clean(config.max_async_level, interval_to_keep)
         else:
             broadcast_weights_time = 0

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -601,6 +601,9 @@ def train(config: TrainerConfig):
         prof.export_chrome_trace(trace_file)
         logger.info(f"Saved trace to {trace_file}")
 
+    # Ensure any in-flight async broadcast completes before writing final checkpoint
+    weight_broadcast.shutdown()
+
     # Write final checkpoint (only for single-run mode; multi-run checkpoints are managed by MultiCheckpointManager)
     if config.max_concurrent_runs == 1 and ckpt_manager is not None:
         logger.info("Writing final checkpoint")

--- a/src/prime_rl/trainer/weights.py
+++ b/src/prime_rl/trainer/weights.py
@@ -119,9 +119,15 @@ def save_state_dict(
 
 
 def gather_weights_on_master(
-    model: nn.Module, is_master: bool, dtype: torch.dtype = torch.bfloat16
+    model: nn.Module, is_master: bool, dtype: torch.dtype = torch.bfloat16, non_blocking: bool = False
 ) -> dict[str, Tensor]:
-    """Gather distributed weights on CPU on master rank."""
+    """Gather distributed weights on CPU on master rank.
+
+    Args:
+        non_blocking: When True, GPU->CPU transfers use pinned memory with
+            non_blocking copies. The caller must record a CUDA event after this
+            returns and synchronize it before reading the tensors.
+    """
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=FutureWarning, module="torch.distributed")
         warnings.filterwarnings("ignore", category=UserWarning, module="torch.distributed.*")
@@ -129,15 +135,18 @@ def gather_weights_on_master(
         cpu_state = {}
         for key, value in model.state_dict().items():
             if isinstance(value, DTensor):
-                # only gather after the downcast to dtype as it will be faster
                 value = cast(DTensor, value.to(dtype)).full_tensor()
 
             if is_master:
                 key = get_fqns(model, key)
                 assert len(key) == 1
                 key = next(iter(key))
-                # TODO(Sami) Blocking to avoid race condition, should make non-blocking long-term tho
-                cpu_state[key] = value.to("cpu", non_blocking=False)
+                if non_blocking:
+                    pinned = torch.empty(value.shape, dtype=value.dtype, device="cpu", pin_memory=True)
+                    pinned.copy_(value, non_blocking=True)
+                    cpu_state[key] = pinned
+                else:
+                    cpu_state[key] = value.to("cpu", non_blocking=False)
         torch.distributed.barrier()
 
     # Always clean up the state dict for HF compatibility

--- a/src/prime_rl/utils/validation.py
+++ b/src/prime_rl/utils/validation.py
@@ -100,19 +100,33 @@ def validate_shared_max_async_level(
         )
 
 
+def _broadcast_type_family(type_name: str) -> str:
+    """Map broadcast types to their compatibility family.
+
+    async_filesystem is a trainer-side optimization that uses the same
+    filesystem protocol as the regular filesystem broadcast, so they
+    are compatible from the orchestrator/inference perspective.
+    """
+    if type_name in ("filesystem", "async_filesystem"):
+        return "filesystem"
+    return type_name
+
+
 def validate_shared_weight_broadcast(
     trainer: TrainerConfig,
     orchestrator: OrchestratorConfig,
     inference: Optional[InferenceConfig] = None,
 ) -> None:
-    if (
-        inference
-        and trainer.weight_broadcast.type != orchestrator.weight_broadcast.type != inference.weight_broadcast.type
-    ):
-        raise ValueError(
-            f"Inference weight broadcast type ({inference.weight_broadcast.type}) and orchestrator weight broadcast type ({orchestrator.weight_broadcast.type}) are not the same. Please specify the same weight broadcast type for both."
-        )
-    elif trainer.weight_broadcast.type != orchestrator.weight_broadcast.type:
+    trainer_family = _broadcast_type_family(trainer.weight_broadcast.type)
+    orchestrator_family = _broadcast_type_family(orchestrator.weight_broadcast.type)
+
+    if inference:
+        inference_family = _broadcast_type_family(inference.weight_broadcast.type)
+        if not (trainer_family == orchestrator_family == inference_family):
+            raise ValueError(
+                f"Inference weight broadcast type ({inference.weight_broadcast.type}) and orchestrator weight broadcast type ({orchestrator.weight_broadcast.type}) are not the same. Please specify the same weight broadcast type for both."
+            )
+    elif trainer_family != orchestrator_family:
         raise ValueError(
             f"Trainer weight broadcast type ({trainer.weight_broadcast.type}) and orchestrator weight broadcast type ({orchestrator.weight_broadcast.type}) are not the same. Please specify the same weight broadcast type for both."
         )

--- a/src/prime_rl/utils/validation.py
+++ b/src/prime_rl/utils/validation.py
@@ -100,16 +100,12 @@ def validate_shared_max_async_level(
         )
 
 
-def _broadcast_type_family(type_name: str) -> str:
-    """Map broadcast types to their compatibility family.
+FILESYSTEM_BROADCAST_TYPES = ("filesystem", "async_filesystem")
 
-    async_filesystem is a trainer-side optimization that uses the same
-    filesystem protocol as the regular filesystem broadcast, so they
-    are compatible from the orchestrator/inference perspective.
-    """
-    if type_name in ("filesystem", "async_filesystem"):
-        return "filesystem"
-    return type_name
+
+def _broadcast_family(wb_type: str) -> str:
+    """async_filesystem uses the same filesystem protocol, so treat as compatible."""
+    return "filesystem" if wb_type in FILESYSTEM_BROADCAST_TYPES else wb_type
 
 
 def validate_shared_weight_broadcast(
@@ -117,11 +113,11 @@ def validate_shared_weight_broadcast(
     orchestrator: OrchestratorConfig,
     inference: Optional[InferenceConfig] = None,
 ) -> None:
-    trainer_family = _broadcast_type_family(trainer.weight_broadcast.type)
-    orchestrator_family = _broadcast_type_family(orchestrator.weight_broadcast.type)
+    trainer_family = _broadcast_family(trainer.weight_broadcast.type)
+    orchestrator_family = _broadcast_family(orchestrator.weight_broadcast.type)
 
     if inference:
-        inference_family = _broadcast_type_family(inference.weight_broadcast.type)
+        inference_family = _broadcast_family(inference.weight_broadcast.type)
         if not (trainer_family == orchestrator_family == inference_family):
             raise ValueError(
                 f"Inference weight broadcast type ({inference.weight_broadcast.type}) and orchestrator weight broadcast type ({orchestrator.weight_broadcast.type}) are not the same. Please specify the same weight broadcast type for both."

--- a/tests/unit/train/rl/test_async_filesystem_broadcast.py
+++ b/tests/unit/train/rl/test_async_filesystem_broadcast.py
@@ -157,6 +157,8 @@ def test_wait_for_pending_reraises_exception():
         with pytest.raises(RuntimeError, match="disk full"):
             broadcast._wait_for_pending()
 
+        assert broadcast._pending is None
+
         executor.shutdown(wait=True)
         broadcast.shutdown()
 

--- a/tests/unit/train/rl/test_async_filesystem_broadcast.py
+++ b/tests/unit/train/rl/test_async_filesystem_broadcast.py
@@ -11,7 +11,7 @@ from prime_rl.configs.trainer import (
     FileSystemWeightBroadcastConfig,
     NCCLWeightBroadcastConfig,
 )
-from prime_rl.utils.validation import _broadcast_type_family
+from prime_rl.utils.validation import FILESYSTEM_BROADCAST_TYPES
 
 
 def test_async_filesystem_config_defaults():
@@ -45,10 +45,10 @@ def test_config_discriminator_dispatch():
     assert isinstance(nccl, NCCLWeightBroadcastConfig)
 
 
-def test_broadcast_type_family():
-    assert _broadcast_type_family("filesystem") == "filesystem"
-    assert _broadcast_type_family("async_filesystem") == "filesystem"
-    assert _broadcast_type_family("nccl") == "nccl"
+def test_filesystem_broadcast_types():
+    assert "filesystem" in FILESYSTEM_BROADCAST_TYPES
+    assert "async_filesystem" in FILESYSTEM_BROADCAST_TYPES
+    assert "nccl" not in FILESYSTEM_BROADCAST_TYPES
 
 
 def test_setup_weight_broadcast_dispatches_async():

--- a/tests/unit/train/rl/test_async_filesystem_broadcast.py
+++ b/tests/unit/train/rl/test_async_filesystem_broadcast.py
@@ -1,0 +1,265 @@
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from prime_rl.configs.trainer import (
+    AsyncFileSystemWeightBroadcastConfig,
+    FileSystemWeightBroadcastConfig,
+    NCCLWeightBroadcastConfig,
+)
+from prime_rl.utils.validation import _broadcast_type_family
+
+
+def test_async_filesystem_config_defaults():
+    config = AsyncFileSystemWeightBroadcastConfig()
+    assert config.type == "async_filesystem"
+    assert config.save_format == "safetensors"
+    assert config.save_sharded is True
+
+
+def test_async_filesystem_config_custom():
+    config = AsyncFileSystemWeightBroadcastConfig(save_format="torch", save_sharded=False)
+    assert config.save_format == "torch"
+    assert config.save_sharded is False
+
+
+def test_config_discriminator_dispatch():
+    """The WeightBroadcastConfig union should correctly dispatch on type."""
+    from pydantic import TypeAdapter
+
+    from prime_rl.configs.trainer import WeightBroadcastConfig
+
+    adapter = TypeAdapter(WeightBroadcastConfig)
+
+    fs = adapter.validate_python({"type": "filesystem"})
+    assert isinstance(fs, FileSystemWeightBroadcastConfig)
+
+    async_fs = adapter.validate_python({"type": "async_filesystem"})
+    assert isinstance(async_fs, AsyncFileSystemWeightBroadcastConfig)
+
+    nccl = adapter.validate_python({"type": "nccl"})
+    assert isinstance(nccl, NCCLWeightBroadcastConfig)
+
+
+def test_broadcast_type_family():
+    assert _broadcast_type_family("filesystem") == "filesystem"
+    assert _broadcast_type_family("async_filesystem") == "filesystem"
+    assert _broadcast_type_family("nccl") == "nccl"
+
+
+def test_setup_weight_broadcast_dispatches_async():
+    """setup_weight_broadcast should return AsyncFileSystemWeightBroadcast for async_filesystem config."""
+    config = AsyncFileSystemWeightBroadcastConfig()
+
+    with (
+        patch("prime_rl.trainer.rl.broadcast.async_filesystem.get_world") as mock_world,
+        patch("prime_rl.trainer.rl.broadcast.async_filesystem.get_multi_run_manager") as mock_mrm,
+    ):
+        mock_world.return_value = MagicMock(is_master=True)
+        mock_mrm.return_value = MagicMock()
+
+        from prime_rl.trainer.rl.broadcast import setup_weight_broadcast
+        from prime_rl.trainer.rl.broadcast.async_filesystem import AsyncFileSystemWeightBroadcast
+
+        broadcast = setup_weight_broadcast(Path("/tmp/test"), config)
+        assert isinstance(broadcast, AsyncFileSystemWeightBroadcast)
+        broadcast.shutdown()
+
+
+def test_setup_weight_broadcast_dispatches_sync():
+    """setup_weight_broadcast should return FileSystemWeightBroadcast for filesystem config."""
+    config = FileSystemWeightBroadcastConfig()
+
+    with (
+        patch("prime_rl.trainer.rl.broadcast.filesystem.get_world") as mock_world,
+        patch("prime_rl.trainer.rl.broadcast.filesystem.get_multi_run_manager") as mock_mrm,
+    ):
+        mock_world.return_value = MagicMock(is_master=True)
+        mock_mrm.return_value = MagicMock()
+
+        from prime_rl.trainer.rl.broadcast import setup_weight_broadcast
+        from prime_rl.trainer.rl.broadcast.filesystem import FileSystemWeightBroadcast
+
+        broadcast = setup_weight_broadcast(Path("/tmp/test"), config)
+        assert isinstance(broadcast, FileSystemWeightBroadcast)
+
+
+def test_wait_for_pending_returns_zero_when_no_pending():
+    config = AsyncFileSystemWeightBroadcastConfig()
+    with (
+        patch("prime_rl.trainer.rl.broadcast.async_filesystem.get_world") as mock_world,
+        patch("prime_rl.trainer.rl.broadcast.async_filesystem.get_multi_run_manager") as mock_mrm,
+    ):
+        mock_world.return_value = MagicMock(is_master=True)
+        mock_mrm.return_value = MagicMock()
+
+        from prime_rl.trainer.rl.broadcast.async_filesystem import AsyncFileSystemWeightBroadcast
+
+        broadcast = AsyncFileSystemWeightBroadcast(Path("/tmp/test"), config)
+        assert broadcast._pending is None
+        wait = broadcast._wait_for_pending()
+        assert wait == 0.0
+        broadcast.shutdown()
+
+
+def test_wait_for_pending_blocks_on_inflight():
+    config = AsyncFileSystemWeightBroadcastConfig()
+    with (
+        patch("prime_rl.trainer.rl.broadcast.async_filesystem.get_world") as mock_world,
+        patch("prime_rl.trainer.rl.broadcast.async_filesystem.get_multi_run_manager") as mock_mrm,
+    ):
+        mock_world.return_value = MagicMock(is_master=True)
+        mock_mrm.return_value = MagicMock()
+
+        from prime_rl.trainer.rl.broadcast.async_filesystem import AsyncFileSystemWeightBroadcast
+
+        broadcast = AsyncFileSystemWeightBroadcast(Path("/tmp/test"), config)
+
+        executor = ThreadPoolExecutor(max_workers=1)
+        broadcast._pending = executor.submit(time.sleep, 0.2)
+
+        start = time.perf_counter()
+        wait = broadcast._wait_for_pending()
+        elapsed = time.perf_counter() - start
+
+        assert wait > 0.1
+        assert elapsed >= 0.15
+        assert broadcast._pending is None
+
+        executor.shutdown(wait=True)
+        broadcast.shutdown()
+
+
+def test_wait_for_pending_reraises_exception():
+    config = AsyncFileSystemWeightBroadcastConfig()
+    with (
+        patch("prime_rl.trainer.rl.broadcast.async_filesystem.get_world") as mock_world,
+        patch("prime_rl.trainer.rl.broadcast.async_filesystem.get_multi_run_manager") as mock_mrm,
+    ):
+        mock_world.return_value = MagicMock(is_master=True)
+        mock_mrm.return_value = MagicMock()
+
+        from prime_rl.trainer.rl.broadcast.async_filesystem import AsyncFileSystemWeightBroadcast
+
+        broadcast = AsyncFileSystemWeightBroadcast(Path("/tmp/test"), config)
+
+        def failing_task():
+            raise RuntimeError("disk full")
+
+        executor = ThreadPoolExecutor(max_workers=1)
+        broadcast._pending = executor.submit(failing_task)
+        time.sleep(0.05)
+
+        with pytest.raises(RuntimeError, match="disk full"):
+            broadcast._wait_for_pending()
+
+        executor.shutdown(wait=True)
+        broadcast.shutdown()
+
+
+def test_write_and_notify_saves_and_touches_stable(tmp_path):
+    config = AsyncFileSystemWeightBroadcastConfig()
+    with (
+        patch("prime_rl.trainer.rl.broadcast.async_filesystem.get_world") as mock_world,
+        patch("prime_rl.trainer.rl.broadcast.async_filesystem.get_multi_run_manager") as mock_mrm,
+        patch("prime_rl.trainer.rl.broadcast.async_filesystem.save_state_dict") as mock_save,
+        patch("prime_rl.trainer.rl.broadcast.async_filesystem.get_broadcast_dir") as mock_bdir,
+        patch("prime_rl.trainer.rl.broadcast.async_filesystem.get_step_path") as mock_step_path,
+    ):
+        mock_world.return_value = MagicMock(is_master=True)
+        mock_mrm_inst = MagicMock()
+        mock_mrm_inst.get_orchestrator_config.return_value = MagicMock()
+        mock_mrm.return_value = mock_mrm_inst
+
+        from prime_rl.trainer.rl.broadcast.async_filesystem import AsyncFileSystemWeightBroadcast
+
+        broadcast = AsyncFileSystemWeightBroadcast(tmp_path, config)
+
+        save_dir = tmp_path / "broadcast" / "step-0"
+        save_dir.mkdir(parents=True)
+        mock_step_path.return_value = save_dir
+        mock_bdir.return_value = tmp_path / "broadcast"
+
+        run_dir = tmp_path / "run_default"
+        state_dict = {"weight": torch.randn(4, 4)}
+        run_metadata = {0: (run_dir, 0)}
+
+        broadcast._write_and_notify(
+            state_dicts={0: state_dict},
+            run_metadata=run_metadata,
+            adapter_only=False,
+            lora_configs=None,
+            model=None,
+            cuda_event=None,
+        )
+
+        mock_save.assert_called_once_with(state_dict, save_dir, "safetensors", True, adapter=False)
+        assert (save_dir / "STABLE").exists()
+        assert broadcast._last_broadcast_time > 0.0
+
+        broadcast.shutdown()
+
+
+def test_write_and_notify_syncs_cuda_event(tmp_path):
+    config = AsyncFileSystemWeightBroadcastConfig()
+    with (
+        patch("prime_rl.trainer.rl.broadcast.async_filesystem.get_world") as mock_world,
+        patch("prime_rl.trainer.rl.broadcast.async_filesystem.get_multi_run_manager") as mock_mrm,
+        patch("prime_rl.trainer.rl.broadcast.async_filesystem.save_state_dict"),
+        patch("prime_rl.trainer.rl.broadcast.async_filesystem.get_broadcast_dir") as mock_bdir,
+        patch("prime_rl.trainer.rl.broadcast.async_filesystem.get_step_path") as mock_step_path,
+    ):
+        mock_world.return_value = MagicMock(is_master=True)
+        mock_mrm_inst = MagicMock()
+        mock_mrm_inst.get_orchestrator_config.return_value = MagicMock()
+        mock_mrm.return_value = mock_mrm_inst
+
+        from prime_rl.trainer.rl.broadcast.async_filesystem import AsyncFileSystemWeightBroadcast
+
+        broadcast = AsyncFileSystemWeightBroadcast(tmp_path, config)
+
+        save_dir = tmp_path / "broadcast" / "step-0"
+        save_dir.mkdir(parents=True)
+        mock_step_path.return_value = save_dir
+        mock_bdir.return_value = tmp_path / "broadcast"
+
+        mock_event = MagicMock()
+        broadcast._write_and_notify(
+            state_dicts={0: {"w": torch.randn(2, 2)}},
+            run_metadata={0: (tmp_path / "run", 0)},
+            adapter_only=False,
+            lora_configs=None,
+            model=None,
+            cuda_event=mock_event,
+        )
+
+        mock_event.synchronize.assert_called_once()
+        broadcast.shutdown()
+
+
+def test_shutdown_waits_for_pending():
+    config = AsyncFileSystemWeightBroadcastConfig()
+    with (
+        patch("prime_rl.trainer.rl.broadcast.async_filesystem.get_world") as mock_world,
+        patch("prime_rl.trainer.rl.broadcast.async_filesystem.get_multi_run_manager") as mock_mrm,
+    ):
+        mock_world.return_value = MagicMock(is_master=True)
+        mock_mrm.return_value = MagicMock()
+
+        from prime_rl.trainer.rl.broadcast.async_filesystem import AsyncFileSystemWeightBroadcast
+
+        broadcast = AsyncFileSystemWeightBroadcast(Path("/tmp/test"), config)
+
+        executor = ThreadPoolExecutor(max_workers=1)
+        broadcast._pending = executor.submit(time.sleep, 0.15)
+
+        start = time.perf_counter()
+        broadcast.shutdown()
+        elapsed = time.perf_counter() - start
+
+        assert elapsed >= 0.1
+        executor.shutdown(wait=True)


### PR DESCRIPTION
During each training step, the filesystem weight broadcast gathers the full model state dict from GPU to CPU and then serializes it to disk (safetensors) before the trainer can proceed. In the synchronous path, the trainer is blocked for the full gather + write duration, which scales with model size and filesystem throughput. On shared/network filesystems, this can become a significant source of step latency.

We introduce `AsyncFileSystemWeightBroadcast`, a drop-in option activated through config:

```toml
[weight_broadcast]
type = "async_filesystem"
```

It splits broadcast into three phases:

1. **Synchronous FSDP gather with non-blocking DMA.** In `gather_weights_on_master`, when `non_blocking=True`, each tensor is copied into pinned CPU memory (`torch.empty(..., pin_memory=True)` + `.copy_(..., non_blocking=True)`) instead of blocking `.to("cpu")`. This queues DMA on the default CUDA stream without host blocking. A `torch.cuda.Event` is recorded after gather and used as a fence before background write reads tensor data.

2. **Main-thread state preparation.** Run metadata (paths, step counters, ready flags) is snapshotted on the main thread before background submission to avoid races with trainer-side state changes.

3. **Background serialization and disk I/O.** A single-worker `ThreadPoolExecutor` receives the pinned state dict, CUDA event, and run metadata; it calls `cuda_event.synchronize()` to drain in-flight DMA, then performs `save_state_dict` + STABLE marker notification off the training critical path. Backpressure is preserved: if a previous write is still in flight, `_wait_for_pending()` blocks the next broadcast, so worst-case behavior matches the synchronous path.

A `shutdown()` method on `WeightBroadcast` ensures in-flight async writes are drained before final checkpointing in `train.py`.

Wall-clock time for steps 1–19:
- sync = 67s (3.72s/step)
- async = 58s (3.22s/step) -> **13.4% faster**

Broadcast blocking time per step:
- sync ~= 1.5s (gather + write inline)
- async ~= 0.16s (gather-only blocking; write runs in background at ~1.5s with zero backpressure across all 20 steps)

These measurements are from a 0.6B model (~1.2 GB state dict).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new threaded weight-broadcast path and non-blocking GPU→CPU transfers, which can surface race conditions or incomplete writes if mis-synchronized. Changes touch the trainer’s step loop and broadcast validation/config wiring, but are scoped to the filesystem broadcast family and include unit tests.
> 
> **Overview**
> Adds a new `async_filesystem` weight broadcast type that gathers weights synchronously but performs serialization and disk writes asynchronously on the trainer to reduce step blocking time.
> 
> Wires the new type through config (`SharedWeightBroadcastConfig`, trainer `WeightBroadcastConfig` union) and broadcast setup, including logic to keep inference/orchestrator using the `filesystem` protocol and to treat `filesystem`/`async_filesystem` as compatible during shared-config validation.
> 
> Updates training to treat both filesystem-based broadcasts equivalently for final-step behavior and cleanup, and adds `WeightBroadcast.shutdown()` so training drains any in-flight async writes before final checkpointing; includes unit tests covering config dispatch and async broadcast lifecycle helpers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e12ba55ce88ae78bfadf8dc29cf8c80561e919ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->