### PR TITLE
Add arm64 support to Dockerfile and deps

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -54,6 +54,13 @@ COPY benchmarks/scripts /app/benchmarks/scripts
 RUN --mount=type=cache,target=/app/.cache/uv \
     uv sync --all-extras --locked --no-dev
 
+# On arm64, flash-attn wheels don't exist so we build from source.
+# Only target sm_90 (Hopper) and sm_100 (Blackwell) to keep compile time reasonable.
+RUN if [ "$(uname -m)" = "aarch64" ]; then \
+    TORCH_CUDA_ARCH_LIST="9.0;10.0" MAX_JOBS=4 \
+    uv pip install flash-attn --no-build-isolation; \
+    fi
+
 FROM python:3.12-slim
 
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -56,8 +56,9 @@ RUN --mount=type=cache,target=/app/.cache/uv \
     uv sync --all-extras --locked --no-dev
 
 # arm64: build flash-attn from source, fix namespace conflicts, apply workarounds
+ARG TARGETARCH
 COPY scripts/docker-arm64-post-install.sh /app/scripts/docker-arm64-post-install.sh
-RUN /app/scripts/docker-arm64-post-install.sh
+RUN if [ "$TARGETARCH" = "arm64" ]; then /app/scripts/docker-arm64-post-install.sh; fi
 
 FROM python:3.12-slim
 

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -13,7 +13,9 @@ ENV CUDA_HOME=/usr/local/cuda
 ENV PATH=$PATH:/usr/local/cuda/bin
 
 # Install packages (including Python 3.12)
+ARG DEBIAN_FRONTEND=noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Etc/UTC
 RUN apt-get update && apt-get install -y --no-install-recommends --force-yes \
     build-essential \
     curl \

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -13,6 +13,7 @@ ENV CUDA_HOME=/usr/local/cuda
 ENV PATH=$PATH:/usr/local/cuda/bin
 
 # Install packages (including Python 3.12)
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends --force-yes \
     build-essential \
     curl \

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -60,7 +60,7 @@ RUN --mount=type=cache,target=/app/.cache/uv \
 RUN if [ "$(uname -m)" = "aarch64" ]; then \
     TORCH_CUDA_ARCH_LIST="10.0" MAX_JOBS=4 && \
     uv pip install flash-attn --no-build-isolation && \
-    pip install "flash-attn-3 @ git+https://github.com/Dao-AILab/flash-attention.git@main#subdirectory=hopper" --no-build-isolation; \
+    .venv/bin/pip install "flash-attn-3 @ git+https://github.com/Dao-AILab/flash-attention.git@main#subdirectory=hopper" --no-build-isolation; \
     fi
 
 FROM python:3.12-slim

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -1,7 +1,7 @@
 #inspired from https://github.com/astral-sh/uv-docker-example/blob/main/multistage.Dockerfile
 
-# Build stage
-FROM pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel AS builder
+# Build stage - multi-arch base (supports amd64 + arm64)
+FROM nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04 AS builder
 LABEL maintainer="prime intellect"
 LABEL repository="prime-rl"
 
@@ -12,12 +12,18 @@ RUN echo "LC_ALL=en_US.UTF-8" >> /etc/environment
 ENV CUDA_HOME=/usr/local/cuda
 ENV PATH=$PATH:/usr/local/cuda/bin
 
-# Install packages
+# Install packages (including Python 3.12)
 RUN apt-get update && apt-get install -y --no-install-recommends --force-yes \
     build-essential \
     curl \
     sudo \
     git \
+    software-properties-common \
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends python3.12 python3.12-dev python3.12-venv \
+    && ln -sf /usr/bin/python3.12 /usr/bin/python3 \
+    && ln -sf /usr/bin/python3.12 /usr/bin/python \
     && apt-get clean autoclean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Download the latest installer

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -64,7 +64,7 @@ RUN if [ "$(uname -m)" = "aarch64" ]; then \
     TORCH_CUDA_ARCH_LIST="10.0" MAX_JOBS=4 \
     uv pip install flash-attn --no-build-isolation && \
     uv pip install --reinstall --no-deps \
-      "flash-attn-cute @ git+https://github.com/Dao-AILab/flash-attention.git@main#subdirectory=flash_attn/cute"; \
+      "flash-attn-cute @ git+https://github.com/Dao-AILab/flash-attention.git@e2743ab5b3803bb672b16437ba98a3b1d4576c50#subdirectory=flash_attn/cute"; \
     fi
 
 # Workaround: nvidia-cutlass-dsl 4.4.1 dropped ampere_helpers.py from

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -64,7 +64,7 @@ RUN if [ "$(uname -m)" = "aarch64" ]; then \
     TORCH_CUDA_ARCH_LIST="10.0" MAX_JOBS=4 \
     uv pip install flash-attn --no-build-isolation && \
     uv pip install --reinstall --no-deps \
-      "flash-attn-cute @ git+https://github.com/Dao-AILab/flash-attention.git@e2743ab5b3803bb672b16437ba98a3b1d4576c50#subdirectory=flash_attn/cute"; \
+      "flash-attn-cute @ git+https://github.com/Dao-AILab/flash-attention.git@7ed0898caa50a8f3fbb4f7212a437479bd59dfc1#subdirectory=flash_attn/cute"; \
     fi
 
 # Workaround: nvidia-cutlass-dsl 4.4.1 dropped ampere_helpers.py from

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -58,7 +58,8 @@ RUN --mount=type=cache,target=/app/.cache/uv \
 # Only target sm_100 (Blackwell) since arm64 clusters are GB200.
 RUN if [ "$(uname -m)" = "aarch64" ]; then \
     TORCH_CUDA_ARCH_LIST="10.0" MAX_JOBS=4 \
-    uv pip install flash-attn --no-build-isolation; \
+    uv pip install flash-attn --no-build-isolation && \
+    uv pip install "flash-attn-3 @ git+https://github.com/Dao-AILab/flash-attention.git@main#subdirectory=hopper" --no-build-isolation; \
     fi
 
 FROM python:3.12-slim

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -56,10 +56,11 @@ RUN --mount=type=cache,target=/app/.cache/uv \
 
 # On arm64, flash-attn wheels don't exist so we build from source.
 # Only target sm_100 (Blackwell) since arm64 clusters are GB200.
+# flash-attn-3 uses pip because uv can't resolve torch's match-runtime metadata from a git source.
 RUN if [ "$(uname -m)" = "aarch64" ]; then \
     TORCH_CUDA_ARCH_LIST="10.0" MAX_JOBS=4 \
     uv pip install flash-attn --no-build-isolation && \
-    uv pip install "flash-attn-3 @ git+https://github.com/Dao-AILab/flash-attention.git@main#subdirectory=hopper" --no-build-isolation; \
+    pip install "flash-attn-3 @ git+https://github.com/Dao-AILab/flash-attention.git@main#subdirectory=hopper" --no-build-isolation; \
     fi
 
 FROM python:3.12-slim

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -56,7 +56,7 @@ RUN --mount=type=cache,target=/app/.cache/uv \
 
 # On arm64, flash-attn wheels don't exist so we build from source.
 # Only target sm_100 (Blackwell) since arm64 clusters are GB200.
-# flash-attn-3 uses pip because uv rejects match-runtime for packages without static metadata.
+# flash-attn-3 uses pip instead of uv due to https://github.com/astral-sh/uv/issues/15264
 RUN if [ "$(uname -m)" = "aarch64" ]; then \
     TORCH_CUDA_ARCH_LIST="10.0" MAX_JOBS=4 && \
     uv pip install flash-attn --no-build-isolation && \

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -60,7 +60,7 @@ RUN --mount=type=cache,target=/app/.cache/uv \
 RUN if [ "$(uname -m)" = "aarch64" ]; then \
     TORCH_CUDA_ARCH_LIST="10.0" MAX_JOBS=4 && \
     uv pip install flash-attn --no-build-isolation && \
-    .venv/bin/pip install "flash-attn-3 @ git+https://github.com/Dao-AILab/flash-attention.git@main#subdirectory=hopper" --no-build-isolation; \
+    uv run pip install "flash-attn-3 @ git+https://github.com/Dao-AILab/flash-attention.git@main#subdirectory=hopper" --no-build-isolation; \
     fi
 
 FROM python:3.12-slim

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -60,7 +60,8 @@ RUN --mount=type=cache,target=/app/.cache/uv \
 RUN if [ "$(uname -m)" = "aarch64" ]; then \
     TORCH_CUDA_ARCH_LIST="10.0" MAX_JOBS=4 && \
     uv pip install flash-attn --no-build-isolation && \
-    uv run pip install "flash-attn-3 @ git+https://github.com/Dao-AILab/flash-attention.git@main#subdirectory=hopper" --no-build-isolation; \
+    uv pip install pip && \
+    .venv/bin/pip install "flash-attn-3 @ git+https://github.com/Dao-AILab/flash-attention.git@main#subdirectory=hopper" --no-build-isolation; \
     fi
 
 FROM python:3.12-slim

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -64,7 +64,7 @@ RUN if [ "$(uname -m)" = "aarch64" ]; then \
     TORCH_CUDA_ARCH_LIST="10.0" MAX_JOBS=4 \
     uv pip install flash-attn --no-build-isolation && \
     uv pip install --reinstall --no-deps \
-      "flash-attn-cute @ git+https://github.com/Dao-AILab/flash-attention.git@7ed0898caa50a8f3fbb4f7212a437479bd59dfc1#subdirectory=flash_attn/cute"; \
+      "flash-attn-cute @ git+https://github.com/Dao-AILab/flash-attention.git@2b5db43#subdirectory=flash_attn/cute"; \
     fi
 
 # Workaround: nvidia-cutlass-dsl 4.4.1 dropped ampere_helpers.py from

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -55,9 +55,9 @@ RUN --mount=type=cache,target=/app/.cache/uv \
     uv sync --all-extras --locked --no-dev
 
 # On arm64, flash-attn wheels don't exist so we build from source.
-# Only target sm_90 (Hopper) and sm_100 (Blackwell) to keep compile time reasonable.
+# Only target sm_100 (Blackwell) since arm64 clusters are GB200.
 RUN if [ "$(uname -m)" = "aarch64" ]; then \
-    TORCH_CUDA_ARCH_LIST="9.0;10.0" MAX_JOBS=4 \
+    TORCH_CUDA_ARCH_LIST="10.0" MAX_JOBS=4 \
     uv pip install flash-attn --no-build-isolation; \
     fi
 

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -63,6 +63,20 @@ RUN if [ "$(uname -m)" = "aarch64" ]; then \
     uv pip install flash-attn --no-build-isolation; \
     fi
 
+# Workaround: nvidia-cutlass-dsl 4.4.1 dropped ampere_helpers.py from
+# cutlass.utils (only ships hopper_helpers and blackwell_helpers), but
+# flash-attn 2.8.3's flash_attn.cute unconditionally imports it at module
+# level for the Sm80 forward kernel:
+#   flash_attn.cute.flash_fwd -> import cutlass.utils.ampere_helpers
+# This triggers even on GB200 (sm_100) because the import isn't gated by
+# GPU architecture. The file exists in flashinfer's vendored cutlass, so
+# we copy it over. Can be removed once flash-attn gates the import or
+# nvidia-cutlass-dsl re-adds ampere_helpers.
+RUN if [ "$(uname -m)" = "aarch64" ]; then \
+    cp .venv/lib/python3.12/site-packages/flashinfer/data/cutlass/python/CuTeDSL/cutlass/utils/ampere_helpers.py \
+       .venv/lib/python3.12/site-packages/nvidia_cutlass_dsl/python_packages/cutlass/utils/ampere_helpers.py; \
+    fi
+
 FROM python:3.12-slim
 
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -58,9 +58,13 @@ RUN --mount=type=cache,target=/app/.cache/uv \
 # On arm64, flash-attn wheels don't exist so we build from source.
 # Only target sm_100 (Blackwell) since arm64 clusters are GB200.
 # flash-attn-cute (FA4) is already installed via uv sync and supports sm_100 natively.
+# IMPORTANT: installing flash-attn overwrites flash_attn/cute/ with a stub,
+# so we must reinstall flash-attn-cute afterwards to restore the real FA4 kernels.
 RUN if [ "$(uname -m)" = "aarch64" ]; then \
     TORCH_CUDA_ARCH_LIST="10.0" MAX_JOBS=4 \
-    uv pip install flash-attn --no-build-isolation; \
+    uv pip install flash-attn --no-build-isolation && \
+    uv pip install --reinstall --no-deps \
+      "flash-attn-cute @ git+https://github.com/Dao-AILab/flash-attention.git@main#subdirectory=flash_attn/cute"; \
     fi
 
 # Workaround: nvidia-cutlass-dsl 4.4.1 dropped ampere_helpers.py from

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -57,14 +57,10 @@ RUN --mount=type=cache,target=/app/.cache/uv \
 
 # On arm64, flash-attn wheels don't exist so we build from source.
 # Only target sm_100 (Blackwell) since arm64 clusters are GB200.
-# Python ninja package is required for parallel CUDA kernel compilation (without it: 2h+).
-# flash-attn-3 uses pip instead of uv due to https://github.com/astral-sh/uv/issues/15264
+# flash-attn-cute (FA4) is already installed via uv sync and supports sm_100 natively.
 RUN if [ "$(uname -m)" = "aarch64" ]; then \
-    export TORCH_CUDA_ARCH_LIST="10.0" && export MAX_JOBS=4 && export NVCC_THREADS=4 && \
-    uv pip install ninja && \
-    uv pip install flash-attn --no-build-isolation && \
-    uv pip install pip && \
-    .venv/bin/pip install "flash-attn-3 @ git+https://github.com/Dao-AILab/flash-attention.git@main#subdirectory=hopper" --no-build-isolation; \
+    TORCH_CUDA_ARCH_LIST="10.0" MAX_JOBS=4 \
+    uv pip install flash-attn --no-build-isolation; \
     fi
 
 FROM python:3.12-slim

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -57,10 +57,11 @@ RUN --mount=type=cache,target=/app/.cache/uv \
 
 # On arm64, flash-attn wheels don't exist so we build from source.
 # Only target sm_100 (Blackwell) since arm64 clusters are GB200.
-# ninja-build is installed above for parallel compilation (without it: 2h+, with it: ~5min).
+# Python ninja package is required for parallel CUDA kernel compilation (without it: 2h+).
 # flash-attn-3 uses pip instead of uv due to https://github.com/astral-sh/uv/issues/15264
 RUN if [ "$(uname -m)" = "aarch64" ]; then \
-    export TORCH_CUDA_ARCH_LIST="10.0" MAX_JOBS=4 && \
+    export TORCH_CUDA_ARCH_LIST="10.0" && export MAX_JOBS=4 && export NVCC_THREADS=4 && \
+    uv pip install ninja && \
     uv pip install flash-attn --no-build-isolation && \
     uv pip install pip && \
     .venv/bin/pip install "flash-attn-3 @ git+https://github.com/Dao-AILab/flash-attention.git@main#subdirectory=hopper" --no-build-isolation; \

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -56,9 +56,9 @@ RUN --mount=type=cache,target=/app/.cache/uv \
 
 # On arm64, flash-attn wheels don't exist so we build from source.
 # Only target sm_100 (Blackwell) since arm64 clusters are GB200.
-# flash-attn-3 uses pip because uv can't resolve torch's match-runtime metadata from a git source.
+# flash-attn-3 uses pip because uv rejects match-runtime for packages without static metadata.
 RUN if [ "$(uname -m)" = "aarch64" ]; then \
-    TORCH_CUDA_ARCH_LIST="10.0" MAX_JOBS=4 \
+    TORCH_CUDA_ARCH_LIST="10.0" MAX_JOBS=4 && \
     uv pip install flash-attn --no-build-isolation && \
     pip install "flash-attn-3 @ git+https://github.com/Dao-AILab/flash-attention.git@main#subdirectory=hopper" --no-build-isolation; \
     fi

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -12,7 +12,7 @@ RUN echo "LC_ALL=en_US.UTF-8" >> /etc/environment
 ENV CUDA_HOME=/usr/local/cuda
 ENV PATH=$PATH:/usr/local/cuda/bin
 
-# Install packages (including Python 3.12)
+# Install packages (including Python 3.12 and ninja for fast CUDA kernel compilation)
 ARG DEBIAN_FRONTEND=noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends --force-yes \
     curl \
     sudo \
     git \
+    ninja-build \
     software-properties-common \
     && add-apt-repository ppa:deadsnakes/ppa \
     && apt-get update \
@@ -56,9 +57,10 @@ RUN --mount=type=cache,target=/app/.cache/uv \
 
 # On arm64, flash-attn wheels don't exist so we build from source.
 # Only target sm_100 (Blackwell) since arm64 clusters are GB200.
+# ninja-build is installed above for parallel compilation (without it: 2h+, with it: ~5min).
 # flash-attn-3 uses pip instead of uv due to https://github.com/astral-sh/uv/issues/15264
 RUN if [ "$(uname -m)" = "aarch64" ]; then \
-    TORCH_CUDA_ARCH_LIST="10.0" MAX_JOBS=4 && \
+    export TORCH_CUDA_ARCH_LIST="10.0" MAX_JOBS=4 && \
     uv pip install flash-attn --no-build-isolation && \
     uv pip install pip && \
     .venv/bin/pip install "flash-attn-3 @ git+https://github.com/Dao-AILab/flash-attention.git@main#subdirectory=hopper" --no-build-isolation; \

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -55,31 +55,9 @@ COPY benchmarks/scripts /app/benchmarks/scripts
 RUN --mount=type=cache,target=/app/.cache/uv \
     uv sync --all-extras --locked --no-dev
 
-# On arm64, flash-attn wheels don't exist so we build from source.
-# Only target sm_100 (Blackwell) since arm64 clusters are GB200.
-# flash-attn-cute (FA4) is already installed via uv sync and supports sm_100 natively.
-# IMPORTANT: installing flash-attn overwrites flash_attn/cute/ with a stub,
-# so we must reinstall flash-attn-cute afterwards to restore the real FA4 kernels.
-RUN if [ "$(uname -m)" = "aarch64" ]; then \
-    TORCH_CUDA_ARCH_LIST="10.0" MAX_JOBS=4 \
-    uv pip install flash-attn --no-build-isolation && \
-    uv pip install --reinstall --no-deps \
-      "flash-attn-cute @ git+https://github.com/Dao-AILab/flash-attention.git@2b5db43#subdirectory=flash_attn/cute"; \
-    fi
-
-# Workaround: nvidia-cutlass-dsl 4.4.1 dropped ampere_helpers.py from
-# cutlass.utils (only ships hopper_helpers and blackwell_helpers), but
-# flash-attn 2.8.3's flash_attn.cute unconditionally imports it at module
-# level for the Sm80 forward kernel:
-#   flash_attn.cute.flash_fwd -> import cutlass.utils.ampere_helpers
-# This triggers even on GB200 (sm_100) because the import isn't gated by
-# GPU architecture. The file exists in flashinfer's vendored cutlass, so
-# we copy it over. Can be removed once flash-attn gates the import or
-# nvidia-cutlass-dsl re-adds ampere_helpers.
-RUN if [ "$(uname -m)" = "aarch64" ]; then \
-    cp .venv/lib/python3.12/site-packages/flashinfer/data/cutlass/python/CuTeDSL/cutlass/utils/ampere_helpers.py \
-       .venv/lib/python3.12/site-packages/nvidia_cutlass_dsl/python_packages/cutlass/utils/ampere_helpers.py; \
-    fi
+# arm64: build flash-attn from source, fix namespace conflicts, apply workarounds
+COPY scripts/docker-arm64-post-install.sh /app/scripts/docker-arm64-post-install.sh
+RUN /app/scripts/docker-arm64-post-install.sh
 
 FROM python:3.12-slim
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = 
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eeb" }
 transformers = { git = "https://github.com/huggingface/transformers.git", rev = "5c1c72b" }
-flash-attn-cute = { git = "https://github.com/Dao-AILab/flash-attention.git", subdirectory = "flash_attn/cute", rev = "main" }
+flash-attn-cute = { git = "https://github.com/Dao-AILab/flash-attention.git", subdirectory = "flash_attn/cute", rev = "e2743ab5" }
 pydantic-config = { git = "https://github.com/samsja/pydantic_config.git", branch = "main" }
 reverse-text = { index = "primeintellect" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,18 +50,18 @@ prime_rl = "prime_rl.inference.patches:transformers_v5_compat"
 
 [project.optional-dependencies]
 flash-attn = [
-    "flash-attn @ https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.7.16/flash_attn-2.8.3+cu128torch2.10-cp312-cp312-linux_x86_64.whl",
+    "flash-attn @ https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.7.16/flash_attn-2.8.3+cu128torch2.10-cp312-cp312-linux_x86_64.whl ; platform_machine == 'x86_64'",
 ]
 
 flash-attn-3 = [
-    "flash_attn_3 @ https://github.com/samsja/flash-attn-builds/releases/download/v0.1/flash_attn_3-3.0.0b1-cp39-abi3-linux_x86_64.whl",
+    "flash_attn_3 @ https://github.com/samsja/flash-attn-builds/releases/download/v0.1/flash_attn_3-3.0.0b1-cp39-abi3-linux_x86_64.whl ; platform_machine == 'x86_64'",
 ]
 flash-attn-cute = [
     "flash-attn-cute",
 ]
 [dependency-groups]
 fp8-inference = [
-    "deep-gemm @ https://github.com/hallerite/DeepGEMM/releases/download/v2.3.0-torch2.9/deep_gemm-2.3.0+35c4bc8-cp312-cp312-linux_x86_64.whl",
+    "deep-gemm @ https://github.com/hallerite/DeepGEMM/releases/download/v2.3.0-torch2.9/deep_gemm-2.3.0+35c4bc8-cp312-cp312-linux_x86_64.whl ; platform_machine == 'x86_64'",
 ]
 dev = [
     "ipykernel>=6.29.5",

--- a/scripts/docker-arm64-post-install.sh
+++ b/scripts/docker-arm64-post-install.sh
@@ -4,7 +4,7 @@ set -e
 
 echo "=== building flash-attn from source (sm_100 / GB200) ==="
 TORCH_CUDA_ARCH_LIST="10.0" MAX_JOBS=4 \
-    uv pip install flash-attn --no-build-isolation
+    uv pip install "flash-attn==2.8.3" --no-build-isolation
 
 echo "=== reinstalling flash-attn-cute (flash-attn overwrites it with a stub) ==="
 uv pip install --reinstall --no-deps \

--- a/scripts/docker-arm64-post-install.sh
+++ b/scripts/docker-arm64-post-install.sh
@@ -1,38 +1,17 @@
 #!/bin/bash
-# Post-install fixups for arm64 Docker builds.
-# On x86_64 this script is a no-op.
-#
-# Why arm64 needs special handling:
-#   - flash-attn doesn't publish arm64 wheels, so we build from source
-#   - Installing flash-attn overwrites flash_attn/cute/ with a stub,
-#     so flash-attn-cute must be reinstalled afterwards
-#   - nvidia-cutlass-dsl 4.4.1 dropped ampere_helpers.py but flash-attn
-#     still imports it unconditionally (not gated by GPU arch)
+# arm64 post-install fixups for Docker builds.
 set -e
 
-if [ "$(uname -m)" != "aarch64" ]; then
-    echo "Not arm64, skipping post-install fixups."
-    exit 0
-fi
-
-echo "=== arm64 post-install: building flash-attn from source ==="
-# Only target sm_100 (Blackwell) since arm64 clusters are GB200.
+echo "=== building flash-attn from source (sm_100 / GB200) ==="
 TORCH_CUDA_ARCH_LIST="10.0" MAX_JOBS=4 \
     uv pip install flash-attn --no-build-isolation
 
-echo "=== arm64 post-install: reinstalling flash-attn-cute ==="
-# flash-attn ships a stub flash_attn/cute/ that overwrites the real FA4
-# kernels from flash-attn-cute. Reinstall to restore them.
+echo "=== reinstalling flash-attn-cute (flash-attn overwrites it with a stub) ==="
 uv pip install --reinstall --no-deps \
     "flash-attn-cute @ git+https://github.com/Dao-AILab/flash-attention.git@2b5db43#subdirectory=flash_attn/cute"
 
-echo "=== arm64 post-install: ampere_helpers.py workaround ==="
-# nvidia-cutlass-dsl 4.4.1 removed ampere_helpers.py, but flash-attn 2.8.3
-# unconditionally imports it (flash_attn.cute.flash_fwd -> cutlass.utils.ampere_helpers).
-# flashinfer vendors a copy, so we use that.
-# TODO: remove once flash-attn gates the import or cutlass-dsl re-adds the file.
+# TODO: remove once flash-attn gates the ampere_helpers import or cutlass-dsl re-adds it.
+echo "=== copying ampere_helpers.py from flashinfer vendor ==="
 SITE_PACKAGES=".venv/lib/python3.12/site-packages"
 cp "$SITE_PACKAGES/flashinfer/data/cutlass/python/CuTeDSL/cutlass/utils/ampere_helpers.py" \
    "$SITE_PACKAGES/nvidia_cutlass_dsl/python_packages/cutlass/utils/ampere_helpers.py"
-
-echo "=== arm64 post-install: done ==="

--- a/scripts/docker-arm64-post-install.sh
+++ b/scripts/docker-arm64-post-install.sh
@@ -8,7 +8,7 @@ TORCH_CUDA_ARCH_LIST="10.0" MAX_JOBS=4 \
 
 echo "=== reinstalling flash-attn-cute (flash-attn overwrites it with a stub) ==="
 uv pip install --reinstall --no-deps \
-    "flash-attn-cute @ git+https://github.com/Dao-AILab/flash-attention.git@2b5db43#subdirectory=flash_attn/cute"
+    "flash-attn-cute @ git+https://github.com/Dao-AILab/flash-attention.git@e2743ab5#subdirectory=flash_attn/cute"
 
 # TODO: remove once flash-attn gates the ampere_helpers import or cutlass-dsl re-adds it.
 echo "=== copying ampere_helpers.py from flashinfer vendor ==="

--- a/scripts/docker-arm64-post-install.sh
+++ b/scripts/docker-arm64-post-install.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Post-install fixups for arm64 Docker builds.
+# On x86_64 this script is a no-op.
+#
+# Why arm64 needs special handling:
+#   - flash-attn doesn't publish arm64 wheels, so we build from source
+#   - Installing flash-attn overwrites flash_attn/cute/ with a stub,
+#     so flash-attn-cute must be reinstalled afterwards
+#   - nvidia-cutlass-dsl 4.4.1 dropped ampere_helpers.py but flash-attn
+#     still imports it unconditionally (not gated by GPU arch)
+set -e
+
+if [ "$(uname -m)" != "aarch64" ]; then
+    echo "Not arm64, skipping post-install fixups."
+    exit 0
+fi
+
+echo "=== arm64 post-install: building flash-attn from source ==="
+# Only target sm_100 (Blackwell) since arm64 clusters are GB200.
+TORCH_CUDA_ARCH_LIST="10.0" MAX_JOBS=4 \
+    uv pip install flash-attn --no-build-isolation
+
+echo "=== arm64 post-install: reinstalling flash-attn-cute ==="
+# flash-attn ships a stub flash_attn/cute/ that overwrites the real FA4
+# kernels from flash-attn-cute. Reinstall to restore them.
+uv pip install --reinstall --no-deps \
+    "flash-attn-cute @ git+https://github.com/Dao-AILab/flash-attention.git@2b5db43#subdirectory=flash_attn/cute"
+
+echo "=== arm64 post-install: ampere_helpers.py workaround ==="
+# nvidia-cutlass-dsl 4.4.1 removed ampere_helpers.py, but flash-attn 2.8.3
+# unconditionally imports it (flash_attn.cute.flash_fwd -> cutlass.utils.ampere_helpers).
+# flashinfer vendors a copy, so we use that.
+# TODO: remove once flash-attn gates the import or cutlass-dsl re-adds the file.
+SITE_PACKAGES=".venv/lib/python3.12/site-packages"
+cp "$SITE_PACKAGES/flashinfer/data/cutlass/python/CuTeDSL/cutlass/utils/ampere_helpers.py" \
+   "$SITE_PACKAGES/nvidia_cutlass_dsl/python_packages/cutlass/utils/ampere_helpers.py"
+
+echo "=== arm64 post-install: done ==="

--- a/scripts/fix-flash-attn-cute.sh
+++ b/scripts/fix-flash-attn-cute.sh
@@ -11,7 +11,7 @@
 set -e
 
 echo "Reinstalling flash-attn-cute to fix namespace conflict with flash-attn..."
-uv pip install --reinstall --no-deps "flash-attn-cute @ git+https://github.com/Dao-AILab/flash-attention.git@main#subdirectory=flash_attn/cute"
+uv pip install --reinstall --no-deps "flash-attn-cute @ git+https://github.com/Dao-AILab/flash-attention.git@7ed0898caa50a8f3fbb4f7212a437479bd59dfc1#subdirectory=flash_attn/cute"
 
 # Verify installation
 LINES=$(wc -l < "$(python -c 'import flash_attn.cute.interface as m; print(m.__file__)')")

--- a/scripts/fix-flash-attn-cute.sh
+++ b/scripts/fix-flash-attn-cute.sh
@@ -11,7 +11,7 @@
 set -e
 
 echo "Reinstalling flash-attn-cute to fix namespace conflict with flash-attn..."
-uv pip install --reinstall --no-deps "flash-attn-cute @ git+https://github.com/Dao-AILab/flash-attention.git@7ed0898caa50a8f3fbb4f7212a437479bd59dfc1#subdirectory=flash_attn/cute"
+uv pip install --reinstall --no-deps "flash-attn-cute @ git+https://github.com/Dao-AILab/flash-attention.git@2b5db43#subdirectory=flash_attn/cute"
 
 # Verify installation
 LINES=$(wc -l < "$(python -c 'import flash_attn.cute.interface as m; print(m.__file__)')")

--- a/scripts/fix-flash-attn-cute.sh
+++ b/scripts/fix-flash-attn-cute.sh
@@ -11,7 +11,7 @@
 set -e
 
 echo "Reinstalling flash-attn-cute to fix namespace conflict with flash-attn..."
-uv pip install --reinstall --no-deps "flash-attn-cute @ git+https://github.com/Dao-AILab/flash-attention.git@2b5db43#subdirectory=flash_attn/cute"
+uv pip install --reinstall --no-deps "flash-attn-cute @ git+https://github.com/Dao-AILab/flash-attention.git@e2743ab5#subdirectory=flash_attn/cute"
 
 # Verify installation
 LINES=$(wc -l < "$(python -c 'import flash_attn.cute.interface as m; print(m.__file__)')")

--- a/src/prime_rl/configs/inference.py
+++ b/src/prime_rl/configs/inference.py
@@ -226,6 +226,13 @@ class InferenceConfig(BaseConfig):
         ),
     ] = 13345
 
+    max_num_seqs: Annotated[
+        int | None,
+        Field(
+            description="Maximum number of sequences per iteration. Passed to vLLM as `--max-num-seqs`",
+        ),
+    ] = None
+
     seed: Annotated[
         int,
         Field(
@@ -370,6 +377,7 @@ class InferenceConfig(BaseConfig):
             "enable_expert_parallel": "enable_expert_parallel",
             "all2all_backend": "all2all_backend",
             "enable_eplb": "enable_eplb",
+            "max_num_seqs": "max_num_seqs",
             "seed": "seed",
         }
 

--- a/src/prime_rl/configs/inference.py
+++ b/src/prime_rl/configs/inference.py
@@ -226,13 +226,6 @@ class InferenceConfig(BaseConfig):
         ),
     ] = 13345
 
-    max_num_seqs: Annotated[
-        int | None,
-        Field(
-            description="Maximum number of sequences per iteration. Passed to vLLM as `--max-num-seqs`",
-        ),
-    ] = None
-
     seed: Annotated[
         int,
         Field(
@@ -377,7 +370,6 @@ class InferenceConfig(BaseConfig):
             "enable_expert_parallel": "enable_expert_parallel",
             "all2all_backend": "all2all_backend",
             "enable_eplb": "enable_eplb",
-            "max_num_seqs": "max_num_seqs",
             "seed": "seed",
         }
 

--- a/uv.lock
+++ b/uv.lock
@@ -822,7 +822,7 @@ requires-dist = [
 [[package]]
 name = "flash-attn-cute"
 version = "0.1.0"
-source = { git = "https://github.com/Dao-AILab/flash-attention.git?subdirectory=flash_attn%2Fcute&rev=2b5db43#2b5db43ba0e2638aa2cf54d4a0ad851004bef069" }
+source = { git = "https://github.com/Dao-AILab/flash-attention.git?subdirectory=flash_attn%2Fcute&rev=e2743ab5#e2743ab5b3803bb672b16437ba98a3b1d4576c50" }
 dependencies = [
     { name = "apache-tvm-ffi" },
     { name = "einops" },
@@ -2515,7 +2515,7 @@ requires-dist = [
     { name = "dion", git = "https://github.com/samsja/dion.git?rev=d891eeb" },
     { name = "flash-attn", marker = "platform_machine == 'x86_64' and extra == 'flash-attn'", url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.7.16/flash_attn-2.8.3+cu128torch2.10-cp312-cp312-linux_x86_64.whl" },
     { name = "flash-attn-3", marker = "platform_machine == 'x86_64' and extra == 'flash-attn-3'", url = "https://github.com/samsja/flash-attn-builds/releases/download/v0.1/flash_attn_3-3.0.0b1-cp39-abi3-linux_x86_64.whl" },
-    { name = "flash-attn-cute", marker = "extra == 'flash-attn-cute'", git = "https://github.com/Dao-AILab/flash-attention.git?subdirectory=flash_attn%2Fcute&rev=2b5db43" },
+    { name = "flash-attn-cute", marker = "extra == 'flash-attn-cute'", git = "https://github.com/Dao-AILab/flash-attention.git?subdirectory=flash_attn%2Fcute&rev=e2743ab5" },
     { name = "jaxtyping", specifier = ">=0.3.2" },
     { name = "liger-kernel", specifier = ">=0.5.10" },
     { name = "loguru", specifier = ">=0.7.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -822,7 +822,7 @@ requires-dist = [
 [[package]]
 name = "flash-attn-cute"
 version = "0.1.0"
-source = { git = "https://github.com/Dao-AILab/flash-attention.git?subdirectory=flash_attn%2Fcute&rev=main#e2743ab5b3803bb672b16437ba98a3b1d4576c50" }
+source = { git = "https://github.com/Dao-AILab/flash-attention.git?subdirectory=flash_attn%2Fcute&rev=7ed0898#7ed0898caa50a8f3fbb4f7212a437479bd59dfc1" }
 dependencies = [
     { name = "apache-tvm-ffi" },
     { name = "einops" },
@@ -2515,7 +2515,7 @@ requires-dist = [
     { name = "dion", git = "https://github.com/samsja/dion.git?rev=d891eeb" },
     { name = "flash-attn", marker = "platform_machine == 'x86_64' and extra == 'flash-attn'", url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.7.16/flash_attn-2.8.3+cu128torch2.10-cp312-cp312-linux_x86_64.whl" },
     { name = "flash-attn-3", marker = "platform_machine == 'x86_64' and extra == 'flash-attn-3'", url = "https://github.com/samsja/flash-attn-builds/releases/download/v0.1/flash_attn_3-3.0.0b1-cp39-abi3-linux_x86_64.whl" },
-    { name = "flash-attn-cute", marker = "extra == 'flash-attn-cute'", git = "https://github.com/Dao-AILab/flash-attention.git?subdirectory=flash_attn%2Fcute&rev=main" },
+    { name = "flash-attn-cute", marker = "extra == 'flash-attn-cute'", git = "https://github.com/Dao-AILab/flash-attention.git?subdirectory=flash_attn%2Fcute&rev=7ed0898" },
     { name = "jaxtyping", specifier = ">=0.3.2" },
     { name = "liger-kernel", specifier = ">=0.5.10" },
     { name = "loguru", specifier = ">=0.7.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -822,7 +822,7 @@ requires-dist = [
 [[package]]
 name = "flash-attn-cute"
 version = "0.1.0"
-source = { git = "https://github.com/Dao-AILab/flash-attention.git?subdirectory=flash_attn%2Fcute&rev=7ed0898#7ed0898caa50a8f3fbb4f7212a437479bd59dfc1" }
+source = { git = "https://github.com/Dao-AILab/flash-attention.git?subdirectory=flash_attn%2Fcute&rev=2b5db43#2b5db43ba0e2638aa2cf54d4a0ad851004bef069" }
 dependencies = [
     { name = "apache-tvm-ffi" },
     { name = "einops" },
@@ -2515,7 +2515,7 @@ requires-dist = [
     { name = "dion", git = "https://github.com/samsja/dion.git?rev=d891eeb" },
     { name = "flash-attn", marker = "platform_machine == 'x86_64' and extra == 'flash-attn'", url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.7.16/flash_attn-2.8.3+cu128torch2.10-cp312-cp312-linux_x86_64.whl" },
     { name = "flash-attn-3", marker = "platform_machine == 'x86_64' and extra == 'flash-attn-3'", url = "https://github.com/samsja/flash-attn-builds/releases/download/v0.1/flash_attn_3-3.0.0b1-cp39-abi3-linux_x86_64.whl" },
-    { name = "flash-attn-cute", marker = "extra == 'flash-attn-cute'", git = "https://github.com/Dao-AILab/flash-attention.git?subdirectory=flash_attn%2Fcute&rev=7ed0898" },
+    { name = "flash-attn-cute", marker = "extra == 'flash-attn-cute'", git = "https://github.com/Dao-AILab/flash-attention.git?subdirectory=flash_attn%2Fcute&rev=2b5db43" },
     { name = "jaxtyping", specifier = ">=0.3.2" },
     { name = "liger-kernel", specifier = ">=0.5.10" },
     { name = "loguru", specifier = ">=0.7.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -2525,7 +2525,7 @@ requires-dist = [
     { name = "prime", specifier = ">=0.5.37" },
     { name = "pyarrow", specifier = ">=21.0.0" },
     { name = "pydantic", specifier = ">=1.10.13" },
-    { name = "pydantic-config", git = "https://github.com/samsja/pydantic_config.git?rev=6990941" },
+    { name = "pydantic-config", git = "https://github.com/samsja/pydantic_config.git?branch=main" },
     { name = "pyzmq", specifier = ">=27.1.0" },
     { name = "reverse-text", index = "https://hub.primeintellect.ai/primeintellect/simple/" },
     { name = "rich", specifier = ">=14.0.0" },
@@ -2785,7 +2785,7 @@ email = [
 [[package]]
 name = "pydantic-config"
 version = "0.3.0"
-source = { git = "https://github.com/samsja/pydantic_config.git?rev=6990941#699094170fb4ef906bd05b2f3dd811c16278775d" }
+source = { git = "https://github.com/samsja/pydantic_config.git?branch=main#204aef7f81719b1ddf7176f844b29dd15c08abea" }
 dependencies = [
     { name = "pydantic" },
     { name = "tyro" },

--- a/uv.lock
+++ b/uv.lock
@@ -2486,10 +2486,10 @@ dependencies = [
 
 [package.optional-dependencies]
 flash-attn = [
-    { name = "flash-attn" },
+    { name = "flash-attn", marker = "platform_machine == 'x86_64'" },
 ]
 flash-attn-3 = [
-    { name = "flash-attn-3" },
+    { name = "flash-attn-3", marker = "platform_machine == 'x86_64'" },
 ]
 flash-attn-cute = [
     { name = "flash-attn-cute" },
@@ -2504,7 +2504,7 @@ dev = [
     { name = "ruff" },
 ]
 fp8-inference = [
-    { name = "deep-gemm" },
+    { name = "deep-gemm", marker = "platform_machine == 'x86_64'" },
 ]
 
 [package.metadata]
@@ -2513,8 +2513,8 @@ requires-dist = [
     { name = "beartype", specifier = ">=0.21.0" },
     { name = "datasets", specifier = ">=4.0.0" },
     { name = "dion", git = "https://github.com/samsja/dion.git?rev=d891eeb" },
-    { name = "flash-attn", marker = "extra == 'flash-attn'", url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.7.16/flash_attn-2.8.3+cu128torch2.10-cp312-cp312-linux_x86_64.whl" },
-    { name = "flash-attn-3", marker = "extra == 'flash-attn-3'", url = "https://github.com/samsja/flash-attn-builds/releases/download/v0.1/flash_attn_3-3.0.0b1-cp39-abi3-linux_x86_64.whl" },
+    { name = "flash-attn", marker = "platform_machine == 'x86_64' and extra == 'flash-attn'", url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.7.16/flash_attn-2.8.3+cu128torch2.10-cp312-cp312-linux_x86_64.whl" },
+    { name = "flash-attn-3", marker = "platform_machine == 'x86_64' and extra == 'flash-attn-3'", url = "https://github.com/samsja/flash-attn-builds/releases/download/v0.1/flash_attn_3-3.0.0b1-cp39-abi3-linux_x86_64.whl" },
     { name = "flash-attn-cute", marker = "extra == 'flash-attn-cute'", git = "https://github.com/Dao-AILab/flash-attention.git?subdirectory=flash_attn%2Fcute&rev=main" },
     { name = "jaxtyping", specifier = ">=0.3.2" },
     { name = "liger-kernel", specifier = ">=0.5.10" },
@@ -2553,7 +2553,7 @@ dev = [
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "ruff", specifier = ">=0.12.1" },
 ]
-fp8-inference = [{ name = "deep-gemm", url = "https://github.com/hallerite/DeepGEMM/releases/download/v2.3.0-torch2.9/deep_gemm-2.3.0+35c4bc8-cp312-cp312-linux_x86_64.whl" }]
+fp8-inference = [{ name = "deep-gemm", marker = "platform_machine == 'x86_64'", url = "https://github.com/hallerite/DeepGEMM/releases/download/v2.3.0-torch2.9/deep_gemm-2.3.0+35c4bc8-cp312-cp312-linux_x86_64.whl" }]
 
 [[package]]
 name = "prime-sandboxes"

--- a/uv.lock
+++ b/uv.lock
@@ -2525,7 +2525,7 @@ requires-dist = [
     { name = "prime", specifier = ">=0.5.37" },
     { name = "pyarrow", specifier = ">=21.0.0" },
     { name = "pydantic", specifier = ">=1.10.13" },
-    { name = "pydantic-config", git = "https://github.com/samsja/pydantic_config.git?branch=main" },
+    { name = "pydantic-config", git = "https://github.com/samsja/pydantic_config.git?rev=6990941" },
     { name = "pyzmq", specifier = ">=27.1.0" },
     { name = "reverse-text", index = "https://hub.primeintellect.ai/primeintellect/simple/" },
     { name = "rich", specifier = ">=14.0.0" },
@@ -2785,7 +2785,7 @@ email = [
 [[package]]
 name = "pydantic-config"
 version = "0.3.0"
-source = { git = "https://github.com/samsja/pydantic_config.git?branch=main#204aef7f81719b1ddf7176f844b29dd15c08abea" }
+source = { git = "https://github.com/samsja/pydantic_config.git?rev=6990941#699094170fb4ef906bd05b2f3dd811c16278775d" }
 dependencies = [
     { name = "pydantic" },
     { name = "tyro" },


### PR DESCRIPTION
Adds arm64/GH200 support to prime-rl Docker builds.

## What
- Multi-arch Dockerfile base (`nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04`)
- `platform_machine` markers on x86_64-only wheels (flash-attn, flash-attn-3, deep-gemm)
- arm64 post-install script: builds flash-attn from source, reinstalls flash-attn-cute, applies cutlass-dsl workaround
- vllm 0.17 compat fix (`log_error_stack`)

## Example model
Tested with **Qwen/Qwen3.5-9B** on GH200 (arm64).

<!-- screenshot placeholder -->
> **TODO:** Add screenshot here
<!-- /screenshot placeholder -->

No behavior change on x86_64.