### PR TITLE
perf: deduplicate VLM image bytes in orchestrator cache

### DIFF
--- a/src/prime_rl/orchestrator/trajectories.py
+++ b/src/prime_rl/orchestrator/trajectories.py
@@ -1,5 +1,6 @@
 import base64
 import time
+from concurrent.futures import ThreadPoolExecutor
 from io import BytesIO
 
 import torch
@@ -73,13 +74,7 @@ def interleave_rollout(
     # this field should be guaranteed because we set temperature in get_sampling_args
     temperature = output["sampling_args"]["temperature"]
 
-    def get_images(step_idx: int) -> tuple[bytes | None, list[int] | None, list[list[int]] | None]:
-        if vlm_cache is None:
-            return None, None, None
-        key = output["example_id"] if cache_key is None else cache_key
-        return vlm_cache.get_for_step(key, step_idx)
-
-    def make_sample(step: vf.TrajectoryStep, step_idx: int) -> TrainingSample:
+    def make_sample(step: vf.TrajectoryStep) -> TrainingSample:
         """Create a new TrainingSample from a trajectory step."""
         tokens = step["tokens"]
         assert tokens is not None
@@ -88,7 +83,6 @@ def interleave_rollout(
         else:
             completion_mask = [bool(i) for i in tokens["completion_mask"]]
         completion_ids = list(tokens["completion_ids"])
-        pixel_values, pixel_values_shape, image_grid_thw = get_images(step_idx)
 
         routed_experts = _align_routed_experts(
             tokens.get("routed_experts"),
@@ -104,13 +98,10 @@ def interleave_rollout(
             completion_temperatures=[temperature] * len(completion_ids),
             teacher_logprobs=None,
             advantage=None,
-            pixel_values=pixel_values,
-            pixel_values_shape=pixel_values_shape,
-            image_grid_thw=image_grid_thw,
             routed_experts=routed_experts,
         )
 
-    def extend_sample(sample: TrainingSample, step: vf.TrajectoryStep, prefix_len: int, step_idx: int) -> None:
+    def extend_sample(sample: TrainingSample, step: vf.TrajectoryStep, prefix_len: int) -> None:
         """Extend an existing sample with a new trajectory step (extension property holds)."""
         tokens = step["tokens"]
         assert tokens is not None
@@ -132,12 +123,6 @@ def interleave_rollout(
         sample.completion_logprobs.extend(tokens["completion_logprobs"])
         sample.completion_temperatures.extend([temperature] * len(completion_ids))
 
-        # Update cumulative images to include any new images from this step
-        pixel_values, pixel_values_shape, image_grid_thw = get_images(step_idx)
-        sample.pixel_values = pixel_values
-        sample.pixel_values_shape = pixel_values_shape
-        sample.image_grid_thw = image_grid_thw
-
         if tokens.get("routed_experts") is not None and sample.routed_experts is not None:
             step_routed = tokens["routed_experts"]
             # The previous step's last routing entry was zero-padded by _align_routed_experts
@@ -150,13 +135,12 @@ def interleave_rollout(
             expected_len = len(sample.prompt_ids) + len(sample.completion_ids)
             sample.routed_experts = _align_routed_experts(sample.routed_experts, expected_len)
 
-    # Track multiple active (prefix, sample) pairs to handle interleaved agents
-    # Each entry is [prefix_tokens, sample] where prefix_tokens is the accumulated token sequence
+    # Track [prefix_tokens, sample, last_step_idx] per active sample
     active_samples: list[list] = []
 
     first_tokens = trajectory[0]["tokens"]
     first_prefix = first_tokens["prompt_ids"] + first_tokens["completion_ids"]
-    active_samples.append([first_prefix, make_sample(trajectory[0], step_idx=0)])
+    active_samples.append([first_prefix, make_sample(trajectory[0]), 0])
 
     for step_idx, step in enumerate(trajectory[1:], start=1):
         tokens = step["tokens"]
@@ -164,17 +148,17 @@ def interleave_rollout(
 
         # Check if this step extends ANY active prefix
         matched_idx = None
-        for idx, (prefix_tokens, _) in enumerate(active_samples):
+        for idx, (prefix_tokens, _, _) in enumerate(active_samples):
             if step_prompt_ids[: len(prefix_tokens)] == prefix_tokens:
                 matched_idx = idx
                 break
 
         if matched_idx is not None:
             # Extension holds - merge into matched sample
-            prefix_tokens, sample = active_samples[matched_idx]
-            extend_sample(sample, step, len(prefix_tokens), step_idx=step_idx)
-            # Update prefix for this sample
+            prefix_tokens, sample, _ = active_samples[matched_idx]
+            extend_sample(sample, step, len(prefix_tokens))
             active_samples[matched_idx][0] = tokens["prompt_ids"] + tokens["completion_ids"]
+            active_samples[matched_idx][2] = step_idx
         else:
             # No prefix matches - start a new sample
             logger.debug(
@@ -182,9 +166,18 @@ def interleave_rollout(
                 f"Starting new sample (active_prefixes={len(active_samples)}, step_prompt_len={len(step_prompt_ids)})."
             )
             new_prefix = tokens["prompt_ids"] + tokens["completion_ids"]
-            active_samples.append([new_prefix, make_sample(step, step_idx=step_idx)])
+            active_samples.append([new_prefix, make_sample(step), step_idx])
 
-    return [sample for _, sample in active_samples]
+    # Attach images once per sample using only the last merged step
+    if vlm_cache is not None:
+        key = output["example_id"] if cache_key is None else cache_key
+        for _, sample, last_step_idx in active_samples:
+            pv, shape, grids = vlm_cache.get_for_step(key, last_step_idx)
+            sample.pixel_values = pv
+            sample.pixel_values_shape = shape
+            sample.image_grid_thw = grids
+
+    return [sample for _, sample, _ in active_samples]
 
 
 # =============================================================================
@@ -212,15 +205,38 @@ def _extract_images_from_messages(messages: list) -> list[tuple[Image.Image, str
     return images
 
 
+def _collect_b64_keys_from_messages(messages: list) -> list[str]:
+    """Extract base64 keys from OpenAI-style chat messages without decoding."""
+    keys = []
+    if not messages or not isinstance(messages, list):
+        return keys
+    for msg in messages:
+        content = msg.get("content", [])
+        if isinstance(content, list):
+            for item in content:
+                if item.get("type") == "image_url":
+                    url = item.get("image_url", {}).get("url", "")
+                    if url.startswith("data:image"):
+                        keys.append(url.split(",", 1)[1])
+    return keys
+
+
+def _decode_b64_image(b64_data: str) -> Image.Image:
+    """Decode a single base64 string into a PIL Image."""
+    return Image.open(BytesIO(base64.b64decode(b64_data)))
+
+
+_PARALLEL_DECODE_THRESHOLD = 4
+
+
 def _extract_images_from_examples(
     examples: list[tuple[int, vf.RolloutOutput]],
 ) -> tuple[list[Image.Image], dict[int, list[list[int]]]]:
     """
     Extract images from all trajectory steps of each example.
 
-    Parses OpenAI-style message content looking for image_url items with base64 data URLs.
-    Images are deduplicated across the batch by their base64 content. Each step records
-    the indices of its images into the deduplicated all_images list.
+    Two-pass approach: first collects unique base64 keys (fast, string-only),
+    then decodes unique images in parallel via ThreadPoolExecutor.
 
     Args:
         examples: List of (cache_key, output) tuples where output contains a "trajectory"
@@ -232,8 +248,9 @@ def _extract_images_from_examples(
         - step_image_indices_per_example: dict mapping cache_key to per-step lists of
           indices into all_images (e.g., [[0], [0, 1], [1]] for the decreasing-images case)
     """
-    all_images: list[Image.Image] = []
-    image_registry: dict[str, int] = {}  # b64_key -> index in all_images
+    # Pass 1: collect unique b64 keys and build step indices
+    unique_keys: list[str] = []
+    key_to_index: dict[str, int] = {}
     step_image_indices_per_example: dict[int, list[list[int]]] = {}
 
     for eid, output in examples:
@@ -245,42 +262,89 @@ def _extract_images_from_examples(
         step_image_indices = []
         for step in trajectory:
             prompt = step.get("prompt")
-            step_image_pairs = _extract_images_from_messages(prompt)
+            b64_keys = _collect_b64_keys_from_messages(prompt)
             indices = []
-            for img, key in step_image_pairs:
-                if key not in image_registry:
-                    image_registry[key] = len(all_images)
-                    all_images.append(img)
-                indices.append(image_registry[key])
+            for key in b64_keys:
+                if key not in key_to_index:
+                    key_to_index[key] = len(unique_keys)
+                    unique_keys.append(key)
+                indices.append(key_to_index[key])
             step_image_indices.append(indices)
 
         step_image_indices_per_example[eid] = step_image_indices
 
+    # Pass 2: decode unique images (parallel when worthwhile)
+    if len(unique_keys) > _PARALLEL_DECODE_THRESHOLD:
+        with ThreadPoolExecutor(max_workers=min(len(unique_keys), 16)) as pool:
+            all_images = list(pool.map(_decode_b64_image, unique_keys))
+    else:
+        all_images = [_decode_b64_image(k) for k in unique_keys]
+
     return all_images, step_image_indices_per_example
 
 
-_IMAGE_CHUNK_SIZE = 8
+_DEFAULT_IMAGE_CHUNK_SIZE = 32
+
+
+class _ImageStore:
+    """Holds per-unique-image data, assembled lazily on demand.
+
+    Instead of duplicating pixel bytes for every step that references an image,
+    we store each image's bytes once and assemble the concatenation at retrieval time.
+    """
+
+    def __init__(
+        self,
+        image_bytes: list[bytes],
+        image_num_patches: list[int],
+        patch_dim: int,
+        image_grids: list[list[int]],
+    ):
+        self.image_bytes = image_bytes
+        self.image_num_patches = image_num_patches
+        self.patch_dim = patch_dim
+        self.image_grids = image_grids
+        self._cache: dict[tuple[int, ...], tuple[bytes, list[int], list[list[int]]]] = {}
+
+    def assemble(self, indices: list[int]) -> tuple[bytes, list[int], list[list[int]]]:
+        """Assemble pixel bytes, shape, and grids for a set of image indices.
+
+        Results are cached by index tuple — multi-turn rollouts with the same
+        cumulative image set (common across rollouts of the same example) hit
+        the cache and skip the join.
+        """
+        cache_key = tuple(indices)
+        cached = self._cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        total_patches = sum(self.image_num_patches[i] for i in indices)
+        pixel_bytes = b"".join(self.image_bytes[i] for i in indices)
+        shape = [total_patches, self.patch_dim]
+        grids = [self.image_grids[i] for i in indices]
+        result = (pixel_bytes, shape, grids)
+        self._cache[cache_key] = result
+        return result
 
 
 def _preprocess_images_batched(
     images: list[Image.Image],
     step_image_indices_per_example: dict[int, list[list[int]]],
     processor,
-) -> dict[int, list[tuple[bytes | None, list[int] | None, list[list[int]] | None]]]:
+    chunk_size: int = _DEFAULT_IMAGE_CHUNK_SIZE,
+) -> tuple["_ImageStore | None", dict[int, list[list[int]]]]:
     """
-    Preprocess all images in chunked batches, then distribute results per step.
+    Preprocess all images in chunked batches, returning an _ImageStore and step indices.
 
-    Images are processed in chunks to avoid OOM on large batches. Pixel values are
-    stored as raw float32 bytes for efficient serialization via msgspec.
+    Images are processed in chunks to avoid OOM on large batches. Per-image bytes are
+    stored once in the _ImageStore and assembled lazily at retrieval time.
 
     Returns:
-        Dict mapping cache_key to list of (pixel_values_bytes, pixel_values_shape, image_grid_thw) per step.
+        Tuple of (_ImageStore or None, step_image_indices_per_example).
+        The store is None when there are no images or no processor.
     """
     if not images or processor is None:
-        return {
-            eid: [(None, None, None)] * max(len(step_indices), 1)
-            for eid, step_indices in step_image_indices_per_example.items()
-        }
+        return None, step_image_indices_per_example
 
     logger = get_logger()
     image_sizes = [(img.width, img.height) for img in images]
@@ -288,8 +352,8 @@ def _preprocess_images_batched(
     # Process images in chunks to avoid OOM
     all_pixel_values_list = []
     all_grid_thw_list = []
-    for i in range(0, len(images), _IMAGE_CHUNK_SIZE):
-        chunk = images[i : i + _IMAGE_CHUNK_SIZE]
+    for i in range(0, len(images), chunk_size):
+        chunk = images[i : i + chunk_size]
         processed = processor.image_processor(images=chunk, return_tensors="pt")
         all_pixel_values_list.append(processed["pixel_values"])
         all_grid_thw_list.append(processed["image_grid_thw"])
@@ -307,24 +371,26 @@ def _preprocess_images_batched(
     for g in all_grid_thw:
         patch_starts.append(patch_starts[-1] + int(g[0] * g[1] * g[2]))
 
-    result = {}
-    for eid, step_indices_list in step_image_indices_per_example.items():
-        if not step_indices_list:
-            result[eid] = [(None, None, None)]
-            continue
+    patch_dim = all_pixel_values.shape[1]
 
-        per_step = []
-        for indices in step_indices_list:
-            if not indices:
-                per_step.append((None, None, None))
-            else:
-                grids = all_grid_thw[indices]
-                patches = torch.cat([all_pixel_values[patch_starts[i] : patch_starts[i + 1]] for i in indices], dim=0)
-                per_step.append((patches.numpy().tobytes(), list(patches.shape), grids.tolist()))
+    # Store per-image bytes once
+    image_bytes_list: list[bytes] = []
+    image_num_patches_list: list[int] = []
+    image_grids_list: list[list[int]] = []
+    for i in range(len(images)):
+        img_slice = all_pixel_values[patch_starts[i] : patch_starts[i + 1]]
+        image_bytes_list.append(img_slice.numpy().tobytes())
+        image_num_patches_list.append(img_slice.shape[0])
+        image_grids_list.append(all_grid_thw[i].tolist())
 
-        result[eid] = per_step
+    store = _ImageStore(
+        image_bytes=image_bytes_list,
+        image_num_patches=image_num_patches_list,
+        patch_dim=patch_dim,
+        image_grids=image_grids_list,
+    )
 
-    return result
+    return store, step_image_indices_per_example
 
 
 class VLMImageCache:
@@ -337,15 +403,47 @@ class VLMImageCache:
         extract_time: float,
         preprocess_time: float,
     ):
+        self._store: _ImageStore | None = None
+        self._step_indices: dict[int, list[list[int]]] | None = None
         self.cache = cache
         self.num_unique_examples = num_unique_examples
         self.extract_time = extract_time
         self.preprocess_time = preprocess_time
 
+    @classmethod
+    def from_store(
+        cls,
+        store: _ImageStore | None,
+        step_indices: dict[int, list[list[int]]],
+        num_unique_examples: int,
+        extract_time: float,
+        preprocess_time: float,
+    ) -> "VLMImageCache":
+        """Create a store-backed cache that assembles bytes lazily."""
+        obj = cls.__new__(cls)
+        obj._store = store
+        obj._step_indices = step_indices
+        obj.cache = {}
+        obj.num_unique_examples = num_unique_examples
+        obj.extract_time = extract_time
+        obj.preprocess_time = preprocess_time
+        return obj
+
+    def _assemble(self, indices: list[int]) -> tuple[bytes | None, list[int] | None, list[list[int]] | None]:
+        if not indices:
+            return (None, None, None)
+        return self._store.assemble(indices)
+
     def get_for_step(
         self, cache_key: int, step_idx: int
     ) -> tuple[bytes | None, list[int] | None, list[list[int]] | None]:
         """Get cumulative images up to and including the given step."""
+        if self._store is not None:
+            steps = self._step_indices.get(cache_key, [])
+            if not steps or step_idx >= len(steps):
+                return (None, None, None)
+            return self._assemble(steps[step_idx])
+
         steps = self.cache.get(cache_key, [])
         if not steps or step_idx >= len(steps):
             return (None, None, None)
@@ -353,6 +451,12 @@ class VLMImageCache:
 
     def get_all(self, cache_key: int) -> tuple[bytes | None, list[int] | None, list[list[int]] | None]:
         """Get all images for the cache key (last step's cumulative images)."""
+        if self._store is not None:
+            steps = self._step_indices.get(cache_key, [])
+            if not steps:
+                return (None, None, None)
+            return self._assemble(steps[-1])
+
         steps = self.cache.get(cache_key, [])
         if not steps:
             return (None, None, None)
@@ -375,11 +479,12 @@ def build_vlm_image_cache(rollouts: list[vf.RolloutOutput], processor) -> VLMIma
 
     # Preprocess images
     preprocess_start = time.perf_counter()
-    cache = _preprocess_images_batched(all_images, images_per_example, processor)
+    store, step_indices = _preprocess_images_batched(all_images, images_per_example, processor)
     preprocess_time = time.perf_counter() - preprocess_start
 
-    return VLMImageCache(
-        cache=cache,
+    return VLMImageCache.from_store(
+        store=store,
+        step_indices=step_indices,
         num_unique_examples=len(unique_example_ids),
         extract_time=extract_time,
         preprocess_time=preprocess_time,

--- a/tests/unit/orchestrator/test_trajectories.py
+++ b/tests/unit/orchestrator/test_trajectories.py
@@ -12,6 +12,7 @@ from prime_rl.orchestrator.trajectories import (
     _align_routed_experts,
     _extract_images_from_examples,
     _extract_images_from_messages,
+    _ImageStore,
     build_vlm_image_cache,
     interleave_rollout,
 )
@@ -2002,3 +2003,154 @@ def test_interleave_rollout_none_routed_experts_stays_none():
     rollouts = interleave_rollout(output)
     assert rollouts is not None
     assert rollouts[0].routed_experts is None
+
+
+# =============================================================================
+# _ImageStore and store-backed VLMImageCache tests
+# =============================================================================
+
+
+def test_image_store_assemble():
+    """_ImageStore.assemble joins per-image bytes and computes correct shape/grids."""
+    # 2 images: image 0 has 3 patches, image 1 has 2 patches, patch_dim=4
+    patch_dim = 4
+    img0 = np.arange(3 * patch_dim, dtype=np.float32).tobytes()
+    img1 = np.arange(2 * patch_dim, dtype=np.float32).tobytes()
+
+    store = _ImageStore(
+        image_bytes=[img0, img1],
+        image_num_patches=[3, 2],
+        patch_dim=patch_dim,
+        image_grids=[[1, 1, 3], [1, 1, 2]],
+    )
+
+    # Assemble both images
+    pixel_bytes, shape, grids = store.assemble([0, 1])
+    assert shape == [5, 4]
+    assert grids == [[1, 1, 3], [1, 1, 2]]
+    assert pixel_bytes == img0 + img1
+
+    # Assemble single image
+    pixel_bytes, shape, grids = store.assemble([1])
+    assert shape == [2, 4]
+    assert grids == [[1, 1, 2]]
+    assert pixel_bytes == img1
+
+    # Assemble in reverse order
+    pixel_bytes, shape, grids = store.assemble([1, 0])
+    assert shape == [5, 4]
+    assert grids == [[1, 1, 2], [1, 1, 3]]
+    assert pixel_bytes == img1 + img0
+
+
+def test_vlm_image_cache_from_store():
+    """VLMImageCache.from_store provides correct get_for_step/get_all via lazy assembly."""
+    patch_dim = 2
+    img0_data = np.array([[1.0, 2.0]], dtype=np.float32)
+    img1_data = np.array([[3.0, 4.0]], dtype=np.float32)
+
+    store = _ImageStore(
+        image_bytes=[img0_data.tobytes(), img1_data.tobytes()],
+        image_num_patches=[1, 1],
+        patch_dim=patch_dim,
+        image_grids=[[1, 2, 3], [1, 4, 4]],
+    )
+
+    step_indices = {
+        1: [[0], [0, 1]],  # step 0: image 0; step 1: images 0+1
+    }
+
+    cache = VLMImageCache.from_store(
+        store=store,
+        step_indices=step_indices,
+        num_unique_examples=1,
+        extract_time=0.0,
+        preprocess_time=0.0,
+    )
+
+    # Step 0: just image 0
+    pv, shape, grid = cache.get_for_step(1, 0)
+    assert _decode_pixels(pv, shape) == [[1.0, 2.0]]
+    assert grid == [[1, 2, 3]]
+
+    # Step 1: images 0 + 1
+    pv, shape, grid = cache.get_for_step(1, 1)
+    assert _decode_pixels(pv, shape) == [[1.0, 2.0], [3.0, 4.0]]
+    assert grid == [[1, 2, 3], [1, 4, 4]]
+
+    # get_all returns last step
+    pv, shape, grid = cache.get_all(1)
+    assert _decode_pixels(pv, shape) == [[1.0, 2.0], [3.0, 4.0]]
+    assert grid == [[1, 2, 3], [1, 4, 4]]
+
+    # Missing key
+    pv, shape, grid = cache.get_for_step(999, 0)
+    assert pv is None
+
+    # Out of range step
+    pv, shape, grid = cache.get_for_step(1, 5)
+    assert pv is None
+
+
+def test_vlm_image_cache_from_store_no_images():
+    """from_store with store=None returns (None, None, None) for all queries."""
+    step_indices = {0: [[], []]}  # 2 steps with no images
+
+    cache = VLMImageCache.from_store(
+        store=None,
+        step_indices=step_indices,
+        num_unique_examples=1,
+        extract_time=0.0,
+        preprocess_time=0.0,
+    )
+
+    pv, shape, grid = cache.get_for_step(0, 0)
+    assert pv is None
+    assert shape is None
+    assert grid is None
+
+
+def test_build_vlm_image_cache_uses_store():
+    """build_vlm_image_cache returns a store-backed cache."""
+    import torch
+
+    red_url = _create_test_image("red")
+
+    output = vf.RolloutOutput(
+        example_id=1,
+        trajectory=[
+            vf.TrajectoryStep(
+                prompt=[_create_image_message(red_url, "What color?")],
+                completion=[{"role": "assistant", "content": "Red"}],
+                response=MagicMock(),
+                tokens=MagicMock(),
+                reward=None,
+                advantage=None,
+                is_truncated=False,
+                trajectory_id="1",
+                extras={},
+            ),
+        ],
+        sampling_args={"temperature": 1.0},
+        error=None,
+    )
+
+    mock_processor = MagicMock()
+    mock_processor.image_processor = MagicMock(
+        side_effect=lambda images, return_tensors: {
+            "pixel_values": torch.arange(len(images), dtype=torch.float32).view(-1, 1),
+            "image_grid_thw": torch.tensor([[1, 1, 1]] * len(images)),
+        }
+    )
+
+    cache = build_vlm_image_cache([output], mock_processor)
+
+    # Should be store-backed
+    assert cache._store is not None
+    assert cache._step_indices is not None
+
+    # Should still work correctly
+    pv, shape, grid = cache.get_for_step(0, 0)
+    assert pv is not None
+    assert shape == [1, 1]
+    assert grid == [[1, 1, 1]]


### PR DESCRIPTION
Store processed image bytes once per unique image in _ImageStore instead of materializing per-step copies via `torch.cat`  + `.tobytes()`. Adds parallel base64 decoding, assembly caching for repeated index patterns, and deferred image attachment in `interleave_rollout`. Merge after #1923.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit af80854efcafddad7e5e7d0cfb32ff1699b83437. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->