### PR TITLE
History replay

### DIFF
--- a/src/prime_rl/orchestrator/buffer.py
+++ b/src/prime_rl/orchestrator/buffer.py
@@ -113,7 +113,12 @@ class Buffer:
         saved_rollout_buffer = cast(list[vf.RolloutOutput], read_jsonl(path / "rollout_buffer.jsonl"))
         saved_rollout_history = cast(list[vf.RolloutOutput], read_jsonl(path / "rollout_history.jsonl"))
 
-        if any(saved_easy_examples) or any(saved_hard_examples) or any(saved_rollout_buffer) or any(saved_rollout_history):
+        if (
+            any(saved_easy_examples)
+            or any(saved_hard_examples)
+            or any(saved_rollout_buffer)
+            or any(saved_rollout_history)
+        ):
             # Build hash lookup for example buffer (env -> (example_hash -> example_id))
             example_hash_lookup = defaultdict(dict)
             all_hashes = set()

--- a/src/prime_rl/orchestrator/buffer.py
+++ b/src/prime_rl/orchestrator/buffer.py
@@ -276,16 +276,13 @@ class Buffer:
             return None
         return random.choice(eligible)
 
-    def sample_random_incorrect_history_rollout(
-        self, exclude_tasks: set[str] | None = None
-    ) -> vf.RolloutOutput | None:
+    def sample_random_incorrect_history_rollout(self, exclude_tasks: set[str] | None = None) -> vf.RolloutOutput | None:
         """Sample one random incorrect historical rollout."""
         exclude_tasks = exclude_tasks or set()
         eligible = [
             rollout
             for rollout in self.rollout_history
-            if rollout["task"] not in exclude_tasks
-            and rollout.get("reward") == 0.0
+            if rollout["task"] not in exclude_tasks and rollout.get("reward") == 0.0
         ]
         if not eligible:
             return None

--- a/src/prime_rl/orchestrator/buffer.py
+++ b/src/prime_rl/orchestrator/buffer.py
@@ -2,6 +2,7 @@ import hashlib
 import json
 import random
 from collections import defaultdict
+from copy import deepcopy
 from functools import partial
 from pathlib import Path
 from typing import cast
@@ -78,6 +79,10 @@ class Buffer:
         self.rollout_history: list[vf.RolloutOutput] = []
 
         self.reset_step_metrics()
+
+    @staticmethod
+    def _copy_rollout(rollout: vf.RolloutOutput) -> vf.RolloutOutput:
+        return cast(vf.RolloutOutput, deepcopy(rollout))
 
     def get_example_hash(self, example: dict) -> str:
         """Returns a hash of the example based on hash keys."""
@@ -227,7 +232,7 @@ class Buffer:
 
     def update(self, rollouts: list[vf.RolloutOutput]):
         """Updates the buffer state with completed rollouts."""
-        self.rollout_history.extend(rollouts)
+        self.rollout_history.extend(self._copy_rollout(rollout) for rollout in rollouts)
 
         rollouts_by_example = defaultdict(list)
         for rollout in rollouts:
@@ -274,7 +279,7 @@ class Buffer:
         eligible = [rollout for rollout in self.rollout_history if rollout["task"] not in exclude_tasks]
         if not eligible:
             return None
-        return random.choice(eligible)
+        return self._copy_rollout(random.choice(eligible))
 
     def sample_random_incorrect_history_rollout(self, exclude_tasks: set[str] | None = None) -> vf.RolloutOutput | None:
         """Sample one random incorrect historical rollout."""
@@ -286,7 +291,7 @@ class Buffer:
         ]
         if not eligible:
             return None
-        return random.choice(eligible)
+        return self._copy_rollout(random.choice(eligible))
 
     def reset_step_metrics(self) -> None:
         """Reset per-step metrics (called after get_metrics)."""

--- a/src/prime_rl/orchestrator/buffer.py
+++ b/src/prime_rl/orchestrator/buffer.py
@@ -276,6 +276,21 @@ class Buffer:
             return None
         return random.choice(eligible)
 
+    def sample_random_incorrect_history_rollout(
+        self, exclude_tasks: set[str] | None = None
+    ) -> vf.RolloutOutput | None:
+        """Sample one random incorrect historical rollout."""
+        exclude_tasks = exclude_tasks or set()
+        eligible = [
+            rollout
+            for rollout in self.rollout_history
+            if rollout["task"] not in exclude_tasks
+            and rollout.get("reward") == 0.0
+        ]
+        if not eligible:
+            return None
+        return random.choice(eligible)
+
     def reset_step_metrics(self) -> None:
         """Reset per-step metrics (called after get_metrics)."""
         zero_per_pool = lambda: {p: 0 for p in self.POOLS}

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -143,7 +143,7 @@ class Scheduler:
         if self.rate_limiter:
             await self.rate_limiter.acquire()
         example = deepcopy(self.buffer.sample_examples(n=1)[0])
-        example = self._maybe_prepare_dynamic_prompt_example(example)
+        example = self._maybe_prepare_history_replay_example(example)
         client_config = await self._select_least_loaded_client()
         run_group_task = asyncio.create_task(
             run_group(
@@ -158,35 +158,42 @@ class Scheduler:
         )
         self.inflight_group_rollouts[run_group_task] = InflightRolloutInfo(0, client_config)
 
-    def _maybe_prepare_dynamic_prompt_example(self, example: dict) -> dict:
+    def _maybe_prepare_history_replay_example(self, example: dict) -> dict:
         existing_info = example.get("info")
         if not isinstance(existing_info, dict):
             return example
-        if existing_info.get("dynamic_prompt_mode") != "self_verification":
+        history_replay = existing_info.get("history_replay")
+        if not isinstance(history_replay, dict) or not history_replay.get("enabled", False):
             return example
 
-        exclude_tasks_raw = existing_info.get("dynamic_prompt_exclude_tasks")
-        exclude_tasks = {str(task) for task in exclude_tasks_raw} if isinstance(exclude_tasks_raw, list) else set()
-        # Default to excluding the current task to avoid recursive self-verification-on-self-verification.
+        exclude_tasks = set(history_replay.get("exclude_tasks") or [])
+        # Default is non-recursive replay; envs can opt in with history_replay.allow_recursive.
         current_task = example.get("task")
-        if current_task is not None:
-            exclude_tasks.add(str(current_task))
+        if current_task and not history_replay.get("allow_recursive", False):
+            exclude_tasks.add(current_task)
 
-        source_rollout = self.buffer.sample_random_history_rollout(exclude_tasks=exclude_tasks)
+        sample_source_rollout = (
+            self.buffer.sample_random_incorrect_history_rollout
+            if history_replay.get("incorrect_only", False)
+            else self.buffer.sample_random_history_rollout
+        )
+        source_rollout = sample_source_rollout(exclude_tasks=exclude_tasks)
         if source_rollout is None:
             return example
 
+        build_replay_info = getattr(self.env, "build_history_replay_info", None)
+        assert callable(build_replay_info), (
+            "history_replay.enabled requires env.build_history_replay_info(history_replay, source_rollout, example)."
+        )
+        replay_info = build_replay_info(
+            history_replay=history_replay,
+            source_rollout=source_rollout,
+            example=example,
+        )
+
         example["info"] = {
             **existing_info,
-            "self_verification": {
-                "source": {
-                    "task": source_rollout["task"],
-                    "example_id": source_rollout["example_id"],
-                    "reward": source_rollout["reward"],
-                    "prompt": source_rollout.get("prompt"),
-                    "completion": source_rollout.get("completion"),
-                }
-            },
+            "history_replay": replay_info,
         }
         return example
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes orchestration behavior by persisting and randomly sampling historical rollouts, which can affect training dynamics and increase memory/disk usage. Also introduces a new runtime contract on environments (`build_history_replay_info`) that will assert if enabled but not implemented.
> 
> **Overview**
> Adds a persistent `rollout_history` alongside the existing `rollout_buffer`, recording deep-copied rollouts on `Buffer.update`, saving/loading it from checkpoints, and exposing random (optionally incorrect-only) history sampling APIs.
> 
> Updates the scheduler to deep-copy sampled examples and optionally inject *history replay* metadata into `example["info"]["history_replay"]` by sampling a source rollout from history (with task exclusion/recursive controls) and delegating construction to `env.build_history_replay_info(...)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3078515fb38a4a54a69c837f4e785e264399eb85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->