### PR TITLE
fix: remove trailing comma from vllm dependency in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "torch>=2.9.0",
     "torchdata>=0.11.0",
     "transformers",
-    "vllm>=0.16.0,",
+    "vllm>=0.16.0",
     "wandb>=0.24.2",
     "ring-flash-attn>=0.1.8",
     "prime>=0.5.37",


### PR DESCRIPTION
The `vllm` dependency in the `pyproject.toml` has a trailing comma.
Before: `"vllm>=0.16.0,",` -> After: `"vllm>=0.16.0",`

This change does not affect the `uv.lock`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit cfd3691b55f67af6518ae3ae66c7db75bbda59a4. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->