### PR TITLE
fix: validate prompt length in TITO endpoint before computing max_tokens

### DIFF
--- a/src/prime_rl/inference/vllm/serving_chat_with_tokens.py
+++ b/src/prime_rl/inference/vllm/serving_chat_with_tokens.py
@@ -10,6 +10,7 @@ from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
 from vllm.entrypoints.openai.engine.protocol import ErrorResponse, RequestResponseMetadata
 from vllm.entrypoints.openai.engine.serving import GenerationError
 from vllm.entrypoints.utils import get_max_tokens
+from vllm.exceptions import VLLMValidationError
 from vllm.logger import init_logger
 from vllm.outputs import RequestOutput
 from vllm.reasoning import ReasoningParser
@@ -154,10 +155,21 @@ class OpenAIServingChatWithTokens(OpenAIServingChat):
                 # have unique request ids.
                 sub_request_id = request_id if len(engine_prompts) == 1 else f"{request_id}_{i}"
 
+                prompt_len = self._extract_prompt_len(engine_prompt)
+                if prompt_len >= self.max_model_len:
+                    raise VLLMValidationError(
+                        f"This model's maximum context length is "
+                        f"{self.max_model_len} tokens. However, your request has "
+                        f"{prompt_len} input tokens. Please reduce the length of "
+                        "the input messages.",
+                        parameter="input_tokens",
+                        value=prompt_len,
+                    )
+
                 max_tokens = get_max_tokens(
                     self.max_model_len,
                     request.max_completion_tokens if request.max_completion_tokens is not None else request.max_tokens,
-                    self._extract_prompt_len(engine_prompt),
+                    prompt_len,
                     self.default_sampling_params,
                 )
 


### PR DESCRIPTION
## Summary

- In multi-turn TITO rollouts (turns > 1), `prompt_token_ids` are injected *after* `render_chat_request`, bypassing vLLM's built-in context length validation
- When the prompt exceeds `max_model_len`, `get_max_tokens` returns a negative value (e.g. `-17`), causing a `BadRequestError` (`"max_tokens must be at least 1"`)
- This error message isn't recognized by the verifiers `handle_openai_overlong_prompt` decorator, so the rollout is **aborted** instead of gracefully **truncated**
- Adds an explicit prompt length check before `get_max_tokens` that raises a `VLLMValidationError` with the same "context length" message format as vLLM's MITO path, so verifiers catches it as an `OverlongPromptError`

## Example

```bash
# start inference with --max-model-len 256

uv run vf-eval alphabet-sort -d -v -n1 -r1 -m Qwen/Qwen3-4B-Instruct-2507 -p local -a '{"min_turns": 5, "max_turns": 5}' --api-client-type openai_chat_completions_token -t 128
```

The rollout fails on an error (and would be masked out)

<img width="1419" height="509" alt="Screenshot 2026-03-03 at 2 13 48 PM" src="https://github.com/user-attachments/assets/bcb05fc1-de21-4b85-8255-0e8c76ee704c" />

Now, we correctly catch the overlong prompt and treat the rollout as truncated but valid

<img width="1134" height="467" alt="Screenshot 2026-03-03 at 2 45 08 PM" src="https://github.com/user-attachments/assets/891f2583-1652-4427-a5fa-a8d208c49a92" />

```txt
is_truncated: avg - 1.000, std - 0.000
stop_conditions: prompt_too_long: 1.000
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit b1605daf704e3e95a1f597ad9dcc108ae9b955c7. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->