### PR TITLE
add dp-rank-routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Documenting changes which affect configuration usage patterns (added/moved/removed/renamed fields, notable logic changes).
 
 - **`orchestrator.verification.enabled`**: Added top-level rollout verification switch. `orchestrator.buffer.skip_verification` has been removed; use `verification.enabled = false` instead. When disabled, rewards are always 0 and reward-dependent buffer features (`online_difficulty_filtering`, `easy_threshold`, `hard_threshold`) must be unset (2026-03-03)
+- **`client.dp_rank_count`**: Added configuration for data-parallel inference routing. When > 1, each `client.base_url` is expanded into `dp_rank_count` logical clients and pinned via `X-data-parallel-rank` to keep multi-turn rollouts on a consistent DP rank (default: 1) (2026-03-03)
 - **`model.lora`**: Moved from `model.experimental.lora` to `model.lora` (no longer experimental) (#1440, 2025-12-16)
 - Auto-set `api_server_count=1` on inference when LoRA is enabled, because vLLM doesn't support hotloading for multiple API servers (#1422, 2025-12-17)
 - **`inference.model.rope_scaling`**: Added RoPE scaling configuration passthrough to vLLM (#1447 2025-12-17)

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -650,6 +650,20 @@ class RLConfig(BaseConfig):
         return self
 
     @model_validator(mode="after")
+    def auto_setup_dp_rank_count(self):
+        """Auto-set orchestrator client dp_rank_count from inference DP size.
+
+        Uses data_parallel_size_local (per-node DP) when set, since each base URL
+        points to a single node whose API server only knows about its local ranks.
+        Falls back to the global parallel.dp for single-node setups.
+        """
+        if self.inference is not None and "dp_rank_count" not in self.orchestrator.client.model_fields_set:
+            self.orchestrator.client.dp_rank_count = (
+                self.inference.data_parallel_size_local or self.inference.parallel.dp
+            )
+        return self
+
+    @model_validator(mode="after")
     def auto_setup_teacher_inference(self):
         """Auto-configure teacher inference server and orchestrator teacher_model client."""
         if self.deployment.type != "single_node":

--- a/src/prime_rl/configs/shared.py
+++ b/src/prime_rl/configs/shared.py
@@ -122,6 +122,21 @@ class ClientConfig(BaseConfig):
         ),
     ] = False
 
+    dp_rank_count: Annotated[
+        int,
+        Field(
+            ge=1,
+            description=(
+                "Number of data-parallel ranks behind each base URL. When > 1, "
+                "each URL is expanded into dp_rank_count logical clients, each "
+                "pinned to a specific DP rank via the X-data-parallel-rank header. "
+                "This ensures all requests within a multi-turn rollout hit the same "
+                "DP engine, maximizing KV cache reuse. Auto-set from "
+                "inference.parallel.dp when using the RL entrypoint."
+            ),
+        ),
+    ] = 1
+
     elastic: Annotated[
         ElasticConfig | None,
         Field(

--- a/src/prime_rl/configs/shared.py
+++ b/src/prime_rl/configs/shared.py
@@ -132,7 +132,8 @@ class ClientConfig(BaseConfig):
                 "pinned to a specific DP rank via the X-data-parallel-rank header. "
                 "This ensures all requests within a multi-turn rollout hit the same "
                 "DP engine, maximizing KV cache reuse. Auto-set from "
-                "inference.parallel.dp when using the RL entrypoint."
+                "inference.data_parallel_size_local (or inference.parallel.dp) "
+                "when using the RL entrypoint."
             ),
         ),
     ] = 1

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -146,18 +146,22 @@ class Scheduler:
         self.groups.clear()
         self.cancelled_rollouts_count += count
 
+    @staticmethod
+    def _client_identity(c: vf.ClientConfig) -> tuple[str, str | None]:
+        return (c.api_base_url, c.extra_headers.get("X-data-parallel-rank"))
+
     async def _select_least_loaded_client(self) -> vf.ClientConfig:
         """Select the client with the fewest in-flight tasks.
 
-        When dp_rank_count > 1, each (URL, dp_rank) pair is a separate client,
-        so this naturally balances across both servers and DP ranks.
+        Uses (api_base_url, dp_rank) as identity rather than client_idx so that
+        load tracking survives elastic pool refreshes (which reassign indices).
         """
         clients = self.inference_pool.clients
         while not clients:
             await asyncio.sleep(1)
             clients = self.inference_pool.clients
-        inflight_by_client = Counter(info.client_config.client_idx for info in self.inflight_requests.values())
-        return min(clients, key=lambda c: inflight_by_client[c.client_idx])
+        inflight = Counter(self._client_identity(info.client_config) for info in self.inflight_requests.values())
+        return min(clients, key=lambda c: inflight[self._client_identity(c)])
 
     async def drop_group(self, group_id: int) -> int:
         """Drop a group and cancel any remaining in-flight rollouts for it."""

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -40,6 +40,7 @@ class GroupState:
     example: dict
     rollouts_to_schedule: int
     completed_rollouts: list[vf.RolloutOutput] = field(default_factory=list)
+    pinned_client: vf.ClientConfig | None = None
 
 
 class Scheduler:
@@ -146,15 +147,17 @@ class Scheduler:
         self.cancelled_rollouts_count += count
 
     async def _select_least_loaded_client(self) -> vf.ClientConfig:
-        """Select the client with the fewest in-flight tasks."""
+        """Select the client with the fewest in-flight tasks.
+
+        When dp_rank_count > 1, each (URL, dp_rank) pair is a separate client,
+        so this naturally balances across both servers and DP ranks.
+        """
         clients = self.inference_pool.clients
         while not clients:
             await asyncio.sleep(1)
             clients = self.inference_pool.clients
-        inflight_by_url = Counter()
-        for info in self.inflight_requests.values():
-            inflight_by_url[info.client_config.api_base_url] += 1
-        return min(clients, key=lambda c: inflight_by_url[c.api_base_url])
+        inflight_by_client = Counter(info.client_config.client_idx for info in self.inflight_requests.values())
+        return min(clients, key=lambda c: inflight_by_client[c.client_idx])
 
     async def drop_group(self, group_id: int) -> int:
         """Drop a group and cancel any remaining in-flight rollouts for it."""
@@ -176,9 +179,13 @@ class Scheduler:
         if group is None or group.rollouts_to_schedule <= 0:
             return
         group.rollouts_to_schedule -= 1
-        client_config = await self._select_least_loaded_client()
-        if group_id not in self.groups:
-            return
+        if group.pinned_client is not None:
+            client_config = group.pinned_client
+        else:
+            client_config = await self._select_least_loaded_client()
+            if group_id not in self.groups:
+                return
+            group.pinned_client = client_config
         run_rollout_task = asyncio.create_task(
             run_rollout(
                 env=self.env,

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -109,6 +109,7 @@ async def setup_inference_pool(
 
     logger.info(
         f"Initializing static inference pool (base_url={', '.join(client_config.base_url)}, "
+        f"dp_rank_count={client_config.dp_rank_count}, "
         f"api_key_var={client_config.api_key_var}, headers={client_config.headers})"
     )
     return StaticInferencePool(
@@ -119,20 +120,28 @@ async def setup_inference_pool(
 
 
 def setup_clients(client_config: ClientConfig, client_type: str = "openai_chat_completions") -> list[vf.ClientConfig]:
-    def setup_client(client_idx: int, base_url: str) -> vf.ClientConfig:
-        return vf.ClientConfig(
-            client_idx=client_idx,
-            client_type=client_type,
-            api_base_url=base_url,
-            api_key_var=client_config.api_key_var,
-            timeout=client_config.timeout,
-            max_connections=8192,
-            max_keepalive_connections=8192,
-            max_retries=10,
-            extra_headers=client_config.headers,
-        )
-
-    return [setup_client(client_idx, base_url) for client_idx, base_url in enumerate(client_config.base_url)]
+    clients = []
+    client_idx = 0
+    for base_url in client_config.base_url:
+        for dp_rank in range(client_config.dp_rank_count):
+            headers = client_config.headers.copy()
+            if client_config.dp_rank_count > 1:
+                headers["X-data-parallel-rank"] = str(dp_rank)
+            clients.append(
+                vf.ClientConfig(
+                    client_idx=client_idx,
+                    client_type=client_type,
+                    api_base_url=base_url,
+                    api_key_var=client_config.api_key_var,
+                    timeout=client_config.timeout,
+                    max_connections=8192,
+                    max_keepalive_connections=8192,
+                    max_retries=10,
+                    extra_headers=headers,
+                )
+            )
+            client_idx += 1
+    return clients
 
 
 def setup_admin_clients(client_config: ClientConfig) -> list[AsyncClient]:

--- a/src/prime_rl/utils/elastic.py
+++ b/src/prime_rl/utils/elastic.py
@@ -173,6 +173,7 @@ class ElasticInferencePool:
                         base_url=urls,
                         api_key_var=self.client_config.api_key_var,
                         headers=self.client_config.headers,
+                        dp_rank_count=self.client_config.dp_rank_count,
                     ),
                     client_type=self.client_type,
                 )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes rollout scheduling and inference client selection, which can affect throughput and rollout consistency, especially in elastic pools. Risk is mitigated by a default `dp_rank_count=1` behavior preserving existing routing.
> 
> **Overview**
> Adds data-parallel rank–aware inference routing via new `client.dp_rank_count`: each `client.base_url` can be expanded into multiple logical clients with an `X-data-parallel-rank` header to keep multi-turn rollouts pinned to a consistent DP engine (improving KV cache reuse).
> 
> The RL config now auto-derives `orchestrator.client.dp_rank_count` from inference DP settings when not explicitly set, the scheduler pins a rollout group to a single selected client and tracks load by `(api_base_url, dp_rank)` to remain stable across elastic pool refreshes, and both static + elastic inference pool client construction is updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41c28e2024f3ffaa7e9dd7a9e5656dbf251a8784. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->