### PR TITLE
chore: update pydantic-config for JSON dict CLI support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eeb" }
 transformers = { git = "https://github.com/huggingface/transformers.git", rev = "609e3d5" }
 flash-attn-cute = { git = "https://github.com/Dao-AILab/flash-attention.git", subdirectory = "flash_attn/cute", rev = "main" }
-pydantic-config = { git = "https://github.com/samsja/pydantic_config.git", rev = "6990941" }
+pydantic-config = { git = "https://github.com/samsja/pydantic_config.git", branch = "main" }
 reverse-text = { index = "primeintellect" }
 
 [tool.uv.extra-build-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -2661,7 +2661,7 @@ email = [
 [[package]]
 name = "pydantic-config"
 version = "0.3.0"
-source = { git = "https://github.com/samsja/pydantic_config.git?branch=main#9d0819b0c8559eb3e2b95f687a5637a0957e4aa8" }
+source = { git = "https://github.com/samsja/pydantic_config.git?branch=main#204aef7f81719b1ddf7176f844b29dd15c08abea" }
 dependencies = [
     { name = "pydantic" },
     { name = "tyro" },

--- a/uv.lock
+++ b/uv.lock
@@ -2401,7 +2401,7 @@ requires-dist = [
     { name = "prime", specifier = ">=0.5.37" },
     { name = "pyarrow", specifier = ">=21.0.0" },
     { name = "pydantic", specifier = ">=1.10.13" },
-    { name = "pydantic-config", git = "https://github.com/samsja/pydantic_config.git?rev=6990941" },
+    { name = "pydantic-config", git = "https://github.com/samsja/pydantic_config.git?branch=main" },
     { name = "pyzmq", specifier = ">=27.1.0" },
     { name = "reverse-text", index = "https://hub.primeintellect.ai/primeintellect/simple/" },
     { name = "rich", specifier = ">=14.0.0" },
@@ -2661,7 +2661,7 @@ email = [
 [[package]]
 name = "pydantic-config"
 version = "0.3.0"
-source = { git = "https://github.com/samsja/pydantic_config.git?rev=6990941#699094170fb4ef906bd05b2f3dd811c16278775d" }
+source = { git = "https://github.com/samsja/pydantic_config.git?branch=main#9d0819b0c8559eb3e2b95f687a5637a0957e4aa8" }
 dependencies = [
     { name = "pydantic" },
     { name = "tyro" },


### PR DESCRIPTION
## Summary
- Update pydantic-config to latest main with JSON dict CLI support
- Enables passing `dict[str, Any]` fields as JSON via CLI, e.g.:
  ```bash
  uv run rl @ config.toml --inference.vllm-extra '{"custom_arg": "value"}'
  ```
- Switch pydantic-config source from pinned rev to `branch = "main"`

## Context
Depends on pydantic_config PRs:
- samsja/pydantic_config#21 (JSON dict field support)
- samsja/pydantic_config#22 (fix JSON parsing inside Optional[BaseModel] fields)

## Test plan
- [x] `uv run rl @ examples/reverse_text/rl.toml --dry-run --inference.vllm-extra '{"custom_arg": "value"}'` — works, config written correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-source change limited to `pydantic-config`, but tracking a moving `main` branch can introduce unpinned upstream changes over time.
> 
> **Overview**
> Updates the `pydantic-config` dependency to pull from the upstream `main` branch instead of a pinned git revision.
> 
> Regenerates `uv.lock` to reflect the new git source (and resulting commit hash), enabling newer `pydantic-config` behavior such as improved CLI parsing for JSON `dict` fields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e835aee402bbc18fdc0927cd753104ef1b6cf64. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->