### PR TITLE
Pin flash-attn-cute reinstall to locked commit

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -64,7 +64,7 @@ RUN if [ "$(uname -m)" = "aarch64" ]; then \
     TORCH_CUDA_ARCH_LIST="10.0" MAX_JOBS=4 \
     uv pip install flash-attn --no-build-isolation && \
     uv pip install --reinstall --no-deps \
-      "flash-attn-cute @ git+https://github.com/Dao-AILab/flash-attention.git@main#subdirectory=flash_attn/cute"; \
+      "flash-attn-cute @ git+https://github.com/Dao-AILab/flash-attention.git@e2743ab5b3803bb672b16437ba98a3b1d4576c50#subdirectory=flash_attn/cute"; \
     fi
 
 # Workaround: nvidia-cutlass-dsl 4.4.1 dropped ampere_helpers.py from


### PR DESCRIPTION
Pin flash-attn-cute reinstall to commit e2743ab5 from the lock file. Upstream renamed the package from flash-attn-cute to flash-attn-4 on main, causing uv to reject the metadata name mismatch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 68ce5fc8a42b41b79e8fae777c082b0300b05f36. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->