### PR TITLE
fix: use qwen3_coder tool parser for Qwen3.5 models

### DIFF
--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -98,9 +98,25 @@ MODEL_TOOL_CALL_PARSER: dict[str, str] = {
     "Qwen/Qwen3-Coder-Next": "hermes",
     "Qwen/Qwen3-Coder-Next-Base": "hermes",
     "Qwen/Qwen3-Coder-Next-FP8": "hermes",
-    # Qwen3.5
-    "Qwen/Qwen3.5-397B-A17B": "hermes",
-    "Qwen/Qwen3.5-397B-A17B-FP8": "hermes",
+    # Qwen3.5 dense (uses qwen3_coder tool format, not hermes)
+    "Qwen/Qwen3.5-0.8B": "qwen3_coder",
+    "Qwen/Qwen3.5-0.8B-Base": "qwen3_coder",
+    "Qwen/Qwen3.5-2B": "qwen3_coder",
+    "Qwen/Qwen3.5-2B-Base": "qwen3_coder",
+    "Qwen/Qwen3.5-4B": "qwen3_coder",
+    "Qwen/Qwen3.5-4B-Base": "qwen3_coder",
+    "Qwen/Qwen3.5-9B": "qwen3_coder",
+    "Qwen/Qwen3.5-9B-Base": "qwen3_coder",
+    "Qwen/Qwen3.5-27B": "qwen3_coder",
+    "Qwen/Qwen3.5-27B-FP8": "qwen3_coder",
+    # Qwen3.5 MoE (uses qwen3_coder tool format, not hermes)
+    "Qwen/Qwen3.5-35B-A3B": "qwen3_coder",
+    "Qwen/Qwen3.5-35B-A3B-Base": "qwen3_coder",
+    "Qwen/Qwen3.5-35B-A3B-FP8": "qwen3_coder",
+    "Qwen/Qwen3.5-122B-A10B": "qwen3_coder",
+    "Qwen/Qwen3.5-122B-A10B-FP8": "qwen3_coder",
+    "Qwen/Qwen3.5-397B-A17B": "qwen3_coder",
+    "Qwen/Qwen3.5-397B-A17B-FP8": "qwen3_coder",
 }
 
 

--- a/tests/unit/test_tool_call_parser.py
+++ b/tests/unit/test_tool_call_parser.py
@@ -28,7 +28,7 @@ from prime_rl.inference.vllm.server import resolve_tool_call_parser
         ("Qwen/Qwen3-4B-Instruct-2507", "hermes"),
         ("Qwen/Qwen3-Coder-480B-A35B-Instruct", "hermes"),
         ("Qwen/Qwen3-Next-80B-A3B-Instruct", "hermes"),
-        ("Qwen/Qwen3.5-397B-A17B", "hermes"),
+        ("Qwen/Qwen3.5-397B-A17B", "qwen3_coder"),
     ],
 )
 def test_auto_detect_tool_call_parser(model_name: str, expected_parser: str):


### PR DESCRIPTION
## Summary
- Qwen3.5 uses a different tool call format (`<function=name><parameter=arg>` XML) than Qwen3 (hermes JSON). The existing map had Qwen3.5-397B entries using `hermes`, which caused tool calls to not be parsed.
- Maps all Qwen3.5 model variants (dense: 0.8B–27B, MoE: 35B-A3B–397B-A17B) to the `qwen3_coder` parser.

## Test plan
- [x] Verified Qwen3.5-4B chat template produces `<function=...><parameter=...>` format
- [x] Verified vLLM has `qwen3_coder` parser registered
- [ ] Run `uv run rl` with Qwen3.5 model and `tool_call_parser = "auto"` to confirm tool calls are parsed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Change is limited to model-name-to-parser mapping and a corresponding test update; it only affects tool-call parsing behavior for Qwen3.5 models.
> 
> **Overview**
> Fixes `tool_call_parser="auto"` resolution for Qwen3.5 models by mapping all Qwen3.5 dense and MoE variants to the `qwen3_coder` parser (instead of `hermes`) in `MODEL_TOOL_CALL_PARSER`.
> 
> Updates the unit test to assert `Qwen/Qwen3.5-397B-A17B` now resolves to `qwen3_coder`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5c36a909d205661abe3425051d94d8e90507c9a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->