### PR TITLE
fix: correct SFT loss token-level weighting across ranks

### DIFF
--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -165,6 +165,8 @@ def train(config: SFTConfig):
     cp_rank = parallel_dims.world_mesh["cp"].get_local_rank() if cp_enabled else 0
     cp_group = parallel_dims.world_mesh["cp"].get_group() if cp_enabled else None
     cp_size = parallel_dims.cp
+    dp_cp_group = parallel_dims.get_mesh("dp_cp").get_group()
+    fsdp_world_size = parallel_dims.fsdp_gradient_divide_factor
 
     match config.loss_impl:
         case "liger":
@@ -223,6 +225,7 @@ def train(config: SFTConfig):
         forward_backward_start_time = time.perf_counter()
 
         batch_loss = torch.tensor(0.0).to("cuda")
+        batch_token_count = 0.0
         nan_loss_count = torch.tensor(0).to("cuda")
         batch_max_vio, max_vio = torch.tensor(0.0).to("cuda"), None
         for micro_step in range(grad_accum_steps):
@@ -256,16 +259,16 @@ def train(config: SFTConfig):
             # Compute loss
             loss = ce_loss(logits.view(-1, V), target_ids.view(-1)).view(B, L)
 
-            # Compute average loss over unmasked tokens
-            loss = loss[loss_mask].mean()
+            # Sum loss over unmasked tokens, allreduce count across dp_cp ranks
+            local_loss_sum = loss[loss_mask].sum()
+            global_count = loss_mask.sum().clone().float()
+            dist.all_reduce(global_count, op=dist.ReduceOp.SUM, group=dp_cp_group)
+            global_count = torch.clamp_min(global_count, 1)
+            loss = local_loss_sum * fsdp_world_size / global_count
 
-            # Accumulate average loss over gradient accumulation steps
-
-            current_loss = loss.detach() / grad_accum_steps
-
-            # only add if the loss is not nan
-            if not torch.isnan(current_loss):
-                batch_loss += current_loss
+            if not torch.isnan(local_loss_sum.detach()):
+                batch_loss += local_loss_sum.detach()
+                batch_token_count += global_count.item()
             else:
                 nan_loss_count += 1
                 logger.warning("Loss is nan, not taking into account in the batch loss calculation")
@@ -286,7 +289,8 @@ def train(config: SFTConfig):
                     batch_max_vio += max_vio / grad_accum_steps
 
             # Debug log with *local, micro step* stats
-            micro_step_message = f"Micro Step {micro_step}/{grad_accum_steps} | Loss: {loss.item():.4f} | Dataloader Step: {dataloader.state_dict()['dataset_state']['dataset']['step']}"
+            local_count = max(loss_mask.sum().item(), 1)
+            micro_step_message = f"Micro Step {micro_step}/{grad_accum_steps} | Loss: {local_loss_sum.item() / local_count:.4f} | Dataloader Step: {dataloader.state_dict()['dataset_state']['dataset']['step']}"
             if is_tt_moe_model(model) and max_vio is not None:
                 micro_step_message += f" | Max Vio: {max_vio.item():.4f}"
             logger.debug(micro_step_message)
@@ -314,8 +318,9 @@ def train(config: SFTConfig):
 
         # Synchronize the tensor metrics across all steps and ranks
         logger.debug("Synchronizing tensor metrics across all steps and ranks")
-        dist.all_reduce(batch_loss, op=dist.ReduceOp.AVG)
-        dist.all_reduce(nan_loss_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(batch_loss, op=dist.ReduceOp.SUM, group=dp_cp_group)
+        batch_loss = batch_loss / max(batch_token_count, 1)
+        dist.all_reduce(nan_loss_count, op=dist.ReduceOp.SUM, group=dp_cp_group)
 
         # Compute step metrics
         # Divide by CP and TP since those ranks process the same data


### PR DESCRIPTION
## Summary

- **Bug**: SFT loss used `loss[loss_mask].mean()` per rank, then FSDP averaged gradients across ranks. When ranks have different numbers of unmasked tokens, tokens on low-count ranks get disproportionately higher gradient weight (e.g. if rank 0 has 5 unmasked tokens and rank 1 has 1, that single token gets 5x the per-token influence).
- **Fix**: `local_sum * fsdp_world_size / global_count` where `global_count` is allreduced across dp_cp ranks per micro-step. One scalar allreduce per micro-step — negligible overhead.

This matters most with:
1. **Context parallelism**: prompt tokens (masked) land on early CP ranks, completion tokens (unmasked) on later CP ranks — systematic bias
2. **Sample packing**: different ranks pack different numbers of unmasked tokens
3. **Across DP ranks**: different samples have different masking ratios

### Math

Per micro-step: `loss = local_sum * N / global_count`, backward with `/ grad_accum_steps`.

After FSDP averages (divides by N):
```
effective_grad = (1/N) · N/G · ∂(local_sum)/∂(params) = (1/G) · ∂(local_sum)/∂(params)
```
Summing across ranks: `(1/G) · ∂(global_sum)/∂(params)` — correct global token-level mean.

## Test plan

- [ ] Run SFT integration tests: `uv run pytest tests/integration/test_sft.py`
- [ ] Validate loss values on a multi-GPU run with masking
- [ ] Test with CP > 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches distributed training loss scaling and introduces additional per-micro-step collective ops; mistakes here would silently skew gradients or break multi-mesh runs, but the change is localized.
> 
> **Overview**
> Fixes a distributed-loss weighting bug in `src/prime_rl/trainer/sft/train.py` by switching from per-rank `mean()` over unmasked tokens to a *global token-count normalized* loss (`local_loss_sum * fsdp_world_size / global_count`) where `global_count` is allreduced over the `dp_cp` process group each micro-step.
> 
> Updates step-level logging/metrics to aggregate `batch_loss` as a sum over tokens (allreduced over `dp_cp`) and divide by the accumulated global token count, and adjusts micro-step debug loss reporting to reflect local per-token loss.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b20cf8ea412ec41d07ac8c053e460f80d8441f27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->