### PR TITLE
make the loss equal weight per unmaked token

### DIFF
--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -304,38 +304,13 @@ def train(config: SFTConfig):
         step_start_time = time.perf_counter()
         forward_backward_start_time = time.perf_counter()
 
-        # Pre-fetch micro-batches and compute the global supervised-token count so that each
-        # backward pass can use the correct normalization factor directly, avoiding a post-hoc
-        # param.grad traversal.
-        micro_batches = []
-        step_local_token_count = torch.tensor(0, dtype=torch.int64, device="cuda")
-        for _ in range(grad_accum_steps):
-            micro_batch = next(dataiter)
-            micro_batches.append(micro_batch)
-            loss_mask = micro_batch["loss_mask"].to("cuda")
-            if cp_enabled:
-                loss_mask = shard_for_cp(loss_mask, cp_rank=cp_rank, cp_world_size=cp_size)
-            step_local_token_count += loss_mask.sum(dtype=torch.int64)
-
-        global_step_token_count = step_local_token_count.clone()
-        dist.all_reduce(global_step_token_count, op=dist.ReduceOp.SUM, group=dp_cp_group)
-        global_token_count_val = global_step_token_count.item()
-
-        # Scaling factor applied to each micro-step's raw loss sum before backward.  Undoes the
-        # FSDP gradient average and normalises by the global supervised-token count in one shot.
-        # NOTE: global_token_count_val is computed before forward passes, so it includes tokens
-        # from micro-steps that may later produce NaN loss (which are excluded from backward).
-        # This makes the denominator marginally too large on NaN steps — acceptable since NaN
-        # micro-steps are extremely rare and the alternative is a second all-reduce after the loop.
-        if global_token_count_val > 0:
-            loss_scale = parallel_dims.fsdp_gradient_divide_factor / global_token_count_val
-        else:
-            loss_scale = 0.0
-
         step_loss_sum = torch.tensor(0.0, device="cuda")
+        step_local_token_count = torch.tensor(0, dtype=torch.int64, device="cuda")
         nan_loss_count = torch.tensor(0, device="cuda")
         batch_max_vio = torch.tensor(0.0, device="cuda")
-        for micro_step, micro_batch in enumerate(micro_batches):
+        for micro_step in range(grad_accum_steps):
+            micro_batch = next(dataiter)
+
             if config.log.log_data:
                 print_sample(
                     micro_batch["input_ids"].flatten().tolist(), micro_batch["loss_mask"].flatten().tolist(), tokenizer
@@ -344,13 +319,15 @@ def train(config: SFTConfig):
             with maybe_record_function("forward"):
                 local_loss_sum, local_token_count = compute_loss(micro_batch)
 
+            step_local_token_count += local_token_count
+
             if torch.isnan(local_loss_sum.detach()):
                 nan_loss_count += 1
                 logger.warning("Local loss is nan, excluding this micro step from backward")
-                scaled_loss = torch.nan_to_num(local_loss_sum, nan=0.0)  # zero with grad_fn so FSDP hooks fire
+                scaled_loss = torch.nan_to_num(local_loss_sum, nan=0.0) / grad_accum_steps
             else:
                 step_loss_sum += local_loss_sum.detach()
-                scaled_loss = local_loss_sum * loss_scale
+                scaled_loss = local_loss_sum / grad_accum_steps
 
             with maybe_record_function("backward"):
                 scaled_loss.backward()
@@ -364,6 +341,19 @@ def train(config: SFTConfig):
 
         forward_backward_time = time.perf_counter() - forward_backward_start_time
 
+        # All-reduce token counts and rescale gradients to get a global token-weighted mean.
+        # FSDP already divided grads by fsdp_gradient_divide_factor, so we undo that and
+        # divide by the true global token count instead.
+        global_step_token_count = step_local_token_count.clone()
+        dist.all_reduce(global_step_token_count, op=dist.ReduceOp.SUM, group=dp_cp_group)
+        global_token_count_val = global_step_token_count.item()
+
+        if global_token_count_val > 0:
+            grad_scale = parallel_dims.fsdp_gradient_divide_factor * grad_accum_steps / global_token_count_val
+            for param in model.parameters():
+                if param.grad is not None:
+                    param.grad.mul_(grad_scale)
+
         # Run validation after forward-backward (so torch.compile sees training graph first) but before
         # optimizer step (so eval_on_start evaluates untrained weights)
         if config.val is not None and (
@@ -372,8 +362,7 @@ def train(config: SFTConfig):
         ):
             run_validation(progress.step)
 
-        # Compute the global mean loss for logging.  step_loss_sum is local (excludes NaN
-        # micro-steps); all-reduce it over the dp_cp group for a consistent logged value.
+        # Compute the global mean loss for logging.
         dist.all_reduce(step_loss_sum, op=dist.ReduceOp.SUM, group=dp_cp_group)
         dist.all_reduce(nan_loss_count, op=dist.ReduceOp.SUM)
         if global_token_count_val > 0:


### PR DESCRIPTION
warning: not tested yet, do not merge yet.

There is a likely algorithmic weighting bug in PrimeRL SFT because each rank computes a masked-token loss mean on its local shard (loss[loss_mask].mean()), backpropagates that scalar divided only by grad_accum_steps, and then relies on FSDP/HSDP gradient averaging over the hsdp mesh, which includes context-parallel ranks when model.cp > 1; that means the optimized objective is effectively an equal-weight average of per-rank, per-microstep local means, not a global mean over all unmasked tokens in the step. This is harmless only in the special case where every participating rank and every gradient-accumulation microstep has the same number of supervised tokens, which is roughly true for pretraining-style dense loss but not for SFT, because loss_mask is sparse and variable, and because the default SFT packing mode is pack_function = "cat" in prime_rl/configs/sft.py, with CatDataset in prime_rl/trainer/sft/data.py concatenating variable numbers of examples into fixed-length windows; as a result, windows, DP ranks, and GA microsteps can contain very different counts of trainable tokens, yet still contribute equal optimization weight. Context parallelism makes this more severe, because the same local-mean reduction now happens on half-sequences or smaller sequence shards, so token weighting depends on how supervised tokens happen to be distributed across CP partitions, making CP SFT optimize a different objective from both globally token-normalized SFT and non-CP SFT.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the effective training objective and gradient scaling across distributed meshes, which can materially affect convergence/metrics. Touches core training-loop math (DP/CP/FSDP), so any mismatch in token counting or scaling could destabilize training.
> 
> **Overview**
> Fixes SFT loss/gradient weighting to be **per unmasked token globally** instead of averaging per-rank local means.
> 
> `compute_loss` now returns `(loss_sum, token_count)` over unmasked tokens, validation aggregates these across the `dp_cp` mesh to log a token-weighted mean loss, and the training loop accumulates per-microstep loss sums then **rescales gradients** after backprop using the global token count (undoing FSDP’s `fsdp_gradient_divide_factor`) so the optimized objective matches a true global token mean under DP+CP+GA.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8fdc138c5b1e72f1f3832d851ef81637e12fb18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->