### PR TITLE
top-k masking

### DIFF
--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -146,7 +146,7 @@ class SamplingConfig(BaseConfig):
         int | None,
         Field(
             ge=-1,
-            description="Top-k sampling: restrict sampling to the k most likely tokens. -1 or None means no restriction (sample from full vocabulary). Should match the trainer's top_k setting to avoid distribution mismatch.",
+            description="Top-k sampling: restrict sampling to the k most likely tokens. -1 or None means no restriction (sample from full vocabulary). Automatically propagated to the trainer for consistent masking.",
         ),
     ] = None
 

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -142,6 +142,14 @@ class SamplingConfig(BaseConfig):
         ),
     ] = 0
 
+    top_k: Annotated[
+        int | None,
+        Field(
+            ge=-1,
+            description="Top-k sampling: restrict sampling to the k most likely tokens. -1 or None means no restriction (sample from full vocabulary). Should match the trainer's top_k setting to avoid distribution mismatch.",
+        ),
+    ] = None
+
     seed: Annotated[
         int | None,
         Field(

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -499,7 +499,10 @@ class RLConfig(BaseConfig):
     @model_validator(mode="after")
     def auto_setup_top_k(self):
         """Propagate orchestrator.sampling.top_k to trainer.top_k so both sides use the same value."""
+        # -1 means "no restriction" in vLLM convention, treat as disabled
         sampling_top_k = self.orchestrator.sampling.top_k
+        if sampling_top_k is not None and sampling_top_k < 1:
+            sampling_top_k = None
         trainer_top_k = self.trainer.top_k
 
         if sampling_top_k is not None and trainer_top_k is not None and sampling_top_k != trainer_top_k:

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -497,6 +497,23 @@ class RLConfig(BaseConfig):
         return self
 
     @model_validator(mode="after")
+    def auto_setup_top_k(self):
+        """Propagate orchestrator.sampling.top_k to trainer.top_k so both sides use the same value."""
+        sampling_top_k = self.orchestrator.sampling.top_k
+        trainer_top_k = self.trainer.top_k
+
+        if sampling_top_k is not None and trainer_top_k is not None and sampling_top_k != trainer_top_k:
+            raise ValueError(
+                f"orchestrator.sampling.top_k ({sampling_top_k}) and trainer.top_k ({trainer_top_k}) are both set "
+                f"but differ. Set orchestrator.sampling.top_k only — it will be propagated to the trainer automatically."
+            )
+
+        if sampling_top_k is not None and trainer_top_k is None:
+            self.trainer.top_k = sampling_top_k
+
+        return self
+
+    @model_validator(mode="after")
     def auto_setup_bench(self):
         if self.bench:
             self.trainer.bench = BenchConfig()

--- a/src/prime_rl/configs/trainer.py
+++ b/src/prime_rl/configs/trainer.py
@@ -657,6 +657,14 @@ class TrainerConfig(BaseConfig):
         ),
     ] = 1
 
+    top_k: Annotated[
+        int | None,
+        Field(
+            ge=1,
+            description="Top-k masking for the trainer: restrict logprob computation to the k most likely tokens (plus the target token). Prevents gradient updates for very low-probability tokens and reduces distribution mismatch when inference also uses top-k sampling. Requires fused_lm_head_chunk_size to be disabled.",
+        ),
+    ] = None
+
     enable_router_replay: Annotated[
         bool,
         Field(
@@ -769,6 +777,15 @@ class TrainerConfig(BaseConfig):
         if self.model.fused_lm_head_chunk_size == "auto":
             self.model.fused_lm_head_chunk_size = 8192
 
+        return self
+
+    @model_validator(mode="after")
+    def top_k_requires_vanilla_lm_head(self):
+        if self.top_k is not None and self.model.fused_lm_head_chunk_size != "disabled":
+            raise ValueError(
+                "top_k masking requires fused_lm_head_chunk_size to be 'disabled' because it needs access to full logits. "
+                "Set model.fused_lm_head_chunk_size = 'disabled' in your config."
+            )
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -42,13 +42,14 @@ def get_sampling_args(sampling_config: SamplingConfig, temperature: float) -> di
     # https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html#extra-parameters_2
     sampling_args = dict(sampling_config)
     sampling_args.pop("temp_scheduler", None)
+    sampling_args.pop("top_k", None)
     sampling_args["temperature"] = temperature
     sampling_args["top_p"] = 1.0
     sampling_args["logprobs"] = True
     sampling_args["extra_body"] = {
         **sampling_config.extra_body,
         "return_token_ids": True,  # Always return token IDs
-        "top_k": -1,
+        "top_k": sampling_config.top_k if sampling_config.top_k is not None else -1,
         "min_p": 0.0,
     }
     sampling_args["extra_body"]["min_tokens"] = sampling_args.pop("min_tokens")

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -39,6 +39,24 @@ Expected signature:
 
 
 @jaxtyped(typechecker=typechecker)
+def apply_top_k_mask(
+    logits: Float[Tensor, "batch seq vocab"],
+    top_k: int,
+    keep_indices: Int[Tensor, "batch seq"],
+) -> Float[Tensor, "batch seq vocab"]:
+    """Mask logits to keep only the top-k values per position, setting the rest to -inf.
+
+    The target token (keep_indices) is always preserved in the mask to avoid -inf logprobs
+    for already-sampled tokens whose rank may have shifted between inference and training.
+    """
+    threshold = logits.topk(top_k, dim=-1, sorted=False).values.amin(dim=-1, keepdim=True)
+    mask = logits >= threshold
+    # Always keep the target token in the mask
+    mask.scatter_(-1, keep_indices.unsqueeze(-1), True)
+    return logits.masked_fill(~mask, -1e20)
+
+
+@jaxtyped(typechecker=typechecker)
 @torch.compile(dynamic=True)
 def selective_log_softmax(
     logits: Float[Tensor, "batch seq vocab"], index: Int[Tensor, "batch seq"]

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -24,6 +24,7 @@ from prime_rl.utils.cp import (
 )
 from prime_rl.utils.logger import setup_logger
 from prime_rl.trainer.rl.loss import (
+    apply_top_k_mask,
     compute_entropy,
     compute_loss,
     selective_log_softmax,
@@ -389,6 +390,8 @@ def train(config: TrainerConfig):
                 logits = out["logits"]
                 # Per-token temperature scaling: temperatures is [batch, seq], logits is [batch, seq, vocab]
                 scaled_logits = logits / temperatures.unsqueeze(-1)
+                if config.top_k is not None:
+                    scaled_logits = apply_top_k_mask(scaled_logits, config.top_k, labels)
                 out["logprobs"] = selective_log_softmax(scaled_logits, labels)
                 out["entropy"] = compute_entropy(scaled_logits)
             # else: FusedOutputLinear was used - logprobs already computed with per-token temperatures

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -148,3 +148,29 @@ def test_cli_overrides_toml(tmp_path):
     assert config.nested.lr == 5e-5
     # TOML value not overridden by CLI should still be applied (not reverted to class default)
     assert config.nested.weight_decay == 0.01
+
+
+def test_rl_config_top_k_propagates_from_sampling():
+    """sampling.top_k propagates to trainer.top_k automatically."""
+    config = cli(
+        RLConfig,
+        args=["@", "configs/ci/integration/rl/start.toml", "--orchestrator.sampling.top-k", "50"],
+    )
+    assert config.orchestrator.sampling.top_k == 50
+    assert config.trainer.top_k == 50
+
+
+def test_rl_config_top_k_mismatch_raises():
+    """Conflicting top_k values between sampling and trainer should raise."""
+    with pytest.raises(ValidationError, match="top_k"):
+        cli(
+            RLConfig,
+            args=[
+                "@",
+                "configs/ci/integration/rl/start.toml",
+                "--orchestrator.sampling.top-k",
+                "50",
+                "--trainer.top-k",
+                "100",
+            ],
+        )

--- a/tests/unit/train/rl/test_loss.py
+++ b/tests/unit/train/rl/test_loss.py
@@ -2,7 +2,15 @@ import pytest
 import torch
 
 from prime_rl.configs.trainer import CustomLossConfig, DefaultLossConfig
-from prime_rl.trainer.rl.loss import LossInputs, LossOutputs, compute_entropy, compute_loss, setup_loss_fn
+from prime_rl.trainer.rl.loss import (
+    LossInputs,
+    LossOutputs,
+    apply_top_k_mask,
+    compute_entropy,
+    compute_loss,
+    selective_log_softmax,
+    setup_loss_fn,
+)
 
 pytestmark = [pytest.mark.gpu]
 
@@ -73,6 +81,56 @@ def test_setup_loss_fn_with_custom_config():
     assert isinstance(result, LossOutputs)
     assert result.loss.shape == ()
     assert "custom_metric" in result.metrics
+
+
+def test_apply_top_k_mask():
+    """Test that apply_top_k_mask keeps only top-k logits and the target token."""
+    batch, seq, vocab = 2, 4, 100
+    logits = torch.randn(batch, seq, vocab, dtype=torch.float32).cuda()
+    labels = torch.randint(0, vocab, (batch, seq)).cuda()
+    top_k = 10
+
+    masked = apply_top_k_mask(logits, top_k, labels)
+
+    # Kept values retain their original value, masked values are -1e20
+    kept_mask = masked > -1e20
+    # At least top_k tokens should be kept per position (plus possibly the target)
+    assert (kept_mask.sum(dim=-1) >= top_k).all()
+    # At most top_k + 1 tokens (top_k + target if target wasn't in top_k)
+    assert (kept_mask.sum(dim=-1) <= top_k + 1).all()
+
+    # The target token is always kept (never masked)
+    for b in range(batch):
+        for s in range(seq):
+            assert masked[b, s, labels[b, s]] > -1e20
+
+
+def test_top_k_mask_logprobs_concentrate_probability():
+    """Test that top-k masking concentrates probability on fewer tokens."""
+    batch, seq, vocab = 1, 1, 1000
+    logits = torch.randn(batch, seq, vocab, dtype=torch.float32).cuda()
+    labels = torch.zeros(batch, seq, dtype=torch.long).cuda()
+
+    full_logprobs = selective_log_softmax(logits, labels)
+    masked_logits = apply_top_k_mask(logits, top_k=50, keep_indices=labels)
+    masked_logprobs = selective_log_softmax(masked_logits, labels)
+
+    # With fewer tokens sharing the probability mass, the selected token's logprob
+    # should be >= what it was under the full distribution
+    assert (masked_logprobs >= full_logprobs - 1e-5).all()
+
+
+def test_top_k_mask_entropy_decreases():
+    """Test that top-k masking reduces entropy (fewer possible tokens)."""
+    batch, seq, vocab = 1, 2, 500
+    logits = torch.randn(batch, seq, vocab, dtype=torch.float32).cuda()
+    labels = torch.zeros(batch, seq, dtype=torch.long).cuda()
+
+    full_entropy = compute_entropy(logits)
+    masked_logits = apply_top_k_mask(logits, top_k=20, keep_indices=labels)
+    masked_entropy = compute_entropy(masked_logits)
+
+    assert (masked_entropy <= full_entropy + 1e-5).all()
 
 
 def _dummy_custom_loss(inputs: LossInputs, multiplier: float = 1.0) -> LossOutputs:


### PR DESCRIPTION
When vLLM uses top-k sampling at inference, it restricts token selection to the k most likely tokens. But the trainer computes logprobs over the full vocabulary. This distribution mismatch means the trainer wastes gradient capacity on extremely low-probability tokens that could never have been sampled.

**Solution:** Top-k masking on both sides — inference samples from a truncated distribution, and the trainer masks its logits to the same top-k set before computing logprobs and entropy.

# Usage
Simply set
```
[orchestrator.sampling]
  top_k = 50
```

Note: requires model.fused_lm_head_chunk_size = "disabled" (the fused LM head computes logprobs in chunks without materializing full logits, so it can't apply the top-k mask).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes RL sampling/training math by introducing top-k truncation and masking, which can affect loss/entropy behavior and training stability. Adds new config validation/propagation rules that could break existing configs if conflicting values are set or if fused LM head is enabled.
> 
> **Overview**
> **Adds end-to-end `top_k` support for RL training to reduce inference/trainer distribution mismatch.** `orchestrator.sampling.top_k` is introduced and is now sent through vLLM via `extra_body.top_k` (defaulting to `-1` when unset).
> 
> **Trainer can now mask logits to the same top-k set before computing logprobs/entropy.** A new `trainer.top_k` config is added, auto-propagated from `orchestrator.sampling.top_k` with mismatch detection, and enforced to require `model.fused_lm_head_chunk_size='disabled'`. Unit tests cover config propagation/mismatch and the new `apply_top_k_mask` behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95c7069feced8aa804113210aa1719dc4c427bbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->