### PR TITLE
add zero grad tracking

### DIFF
--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -43,6 +43,7 @@ from prime_rl.trainer.perf import get_perf_counter
 from prime_rl.trainer.utils import (
     MemoryProfiler,
     Tensors,
+    count_zero_gradient_elements,
     export_benchmark_json,
     get_ckpt_disk_metrics,
     setup_torch_distributed,
@@ -460,6 +461,7 @@ def train(config: TrainerConfig):
         )
         if grad_norm.device.type == "cpu":
             grad_norm = grad_norm.to(torch.device("cuda"))
+        num_zero_grad, num_grad_elements = count_zero_gradient_elements(model.parameters())
 
         # Update the model parameters
         optimizer.step()
@@ -480,6 +482,13 @@ def train(config: TrainerConfig):
 
         # Synchronize the tensor metrics across all steps and ranks
         tensor_stats = tensors.compute_stats()
+        dist.all_reduce(num_zero_grad, op=dist.ReduceOp.SUM)
+        dist.all_reduce(num_grad_elements, op=dist.ReduceOp.SUM)
+        if parallel_dims.dp_replicate > 1:
+            # HSDP replicas share the same post-reduction gradients, so remove the duplicate copies here.
+            num_zero_grad = torch.div(num_zero_grad, parallel_dims.dp_replicate, rounding_mode="floor")
+            num_grad_elements = torch.div(num_grad_elements, parallel_dims.dp_replicate, rounding_mode="floor")
+        zero_grad_ratio = (num_zero_grad.float() / num_grad_elements.clamp_min(1).float()).item()
 
         # Compute step metrics
         num_local_tokens = seq_len * batch_size
@@ -497,7 +506,7 @@ def train(config: TrainerConfig):
         step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {tensor_stats['loss/mean']:.4f} | Entropy: {tensor_stats['entropy/mean']:.4f}"
         if "mismatch_kl/mean" in tensor_stats:
             step_message += f" | Mismatch KL: {tensor_stats['mismatch_kl/mean']:.4f}"
-        step_message += f" | Grad. Norm: {grad_norm:.4f} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}% | Peak Mem.: {peak_memory:.1f} GiB"
+        step_message += f" | Grad. Norm: {grad_norm:.4f} | Num Zero Grad: {num_zero_grad.item():,} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}% | Peak Mem.: {peak_memory:.1f} GiB"
         if "max_vio/mean" in tensor_stats:
             step_message += f" | Max Vio: {tensor_stats['max_vio/mean']:.4f}"
         logger.success(step_message)
@@ -516,6 +525,8 @@ def train(config: TrainerConfig):
         optim_metrics = {
             "optim/lr": current_lr,
             "optim/grad_norm": grad_norm.item(),
+            "optim/num_zero_grad": num_zero_grad.item(),
+            "optim/zero_grad_ratio": zero_grad_ratio,
             "step": progress.step,
         }
         monitor.log(optim_metrics, step=progress.step)
@@ -559,6 +570,8 @@ def train(config: TrainerConfig):
                 mfu=mfu,
                 entropy=tensor_stats.get("entropy/mean", 0.0),
                 mismatch_kl=tensor_stats.get("mismatch_kl/mean", 0.0),
+                num_zero_grad=float(num_zero_grad.item()),
+                zero_grad_ratio=zero_grad_ratio,
             )
             # Update run/LoRA metrics
             multi_run_manager = get_multi_run_manager()

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -43,8 +43,8 @@ from prime_rl.trainer.perf import get_perf_counter
 from prime_rl.trainer.utils import (
     MemoryProfiler,
     Tensors,
-    count_zero_gradient_elements,
     export_benchmark_json,
+    get_zero_gradient_ratio,
     get_ckpt_disk_metrics,
     setup_torch_distributed,
     print_benchmark,
@@ -461,7 +461,7 @@ def train(config: TrainerConfig):
         )
         if grad_norm.device.type == "cpu":
             grad_norm = grad_norm.to(torch.device("cuda"))
-        num_zero_grad, num_grad_elements = count_zero_gradient_elements(model.parameters())
+        zero_grad_ratio = get_zero_gradient_ratio(model.parameters(), parallel_dims.dp_replicate)
 
         # Update the model parameters
         optimizer.step()
@@ -482,13 +482,6 @@ def train(config: TrainerConfig):
 
         # Synchronize the tensor metrics across all steps and ranks
         tensor_stats = tensors.compute_stats()
-        dist.all_reduce(num_zero_grad, op=dist.ReduceOp.SUM)
-        dist.all_reduce(num_grad_elements, op=dist.ReduceOp.SUM)
-        if parallel_dims.dp_replicate > 1:
-            # HSDP replicas share the same post-reduction gradients, so remove the duplicate copies here.
-            num_zero_grad = torch.div(num_zero_grad, parallel_dims.dp_replicate, rounding_mode="floor")
-            num_grad_elements = torch.div(num_grad_elements, parallel_dims.dp_replicate, rounding_mode="floor")
-        zero_grad_ratio = (num_zero_grad.float() / num_grad_elements.clamp_min(1).float()).item()
 
         # Compute step metrics
         num_local_tokens = seq_len * batch_size
@@ -506,7 +499,7 @@ def train(config: TrainerConfig):
         step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {tensor_stats['loss/mean']:.4f} | Entropy: {tensor_stats['entropy/mean']:.4f}"
         if "mismatch_kl/mean" in tensor_stats:
             step_message += f" | Mismatch KL: {tensor_stats['mismatch_kl/mean']:.4f}"
-        step_message += f" | Grad. Norm: {grad_norm:.4f} | Num Zero Grad: {num_zero_grad.item():,} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}% | Peak Mem.: {peak_memory:.1f} GiB"
+        step_message += f" | Grad. Norm: {grad_norm:.4f} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}% | Peak Mem.: {peak_memory:.1f} GiB"
         if "max_vio/mean" in tensor_stats:
             step_message += f" | Max Vio: {tensor_stats['max_vio/mean']:.4f}"
         logger.success(step_message)
@@ -525,7 +518,6 @@ def train(config: TrainerConfig):
         optim_metrics = {
             "optim/lr": current_lr,
             "optim/grad_norm": grad_norm.item(),
-            "optim/num_zero_grad": num_zero_grad.item(),
             "optim/zero_grad_ratio": zero_grad_ratio,
             "step": progress.step,
         }
@@ -570,7 +562,6 @@ def train(config: TrainerConfig):
                 mfu=mfu,
                 entropy=tensor_stats.get("entropy/mean", 0.0),
                 mismatch_kl=tensor_stats.get("mismatch_kl/mean", 0.0),
-                num_zero_grad=float(num_zero_grad.item()),
                 zero_grad_ratio=zero_grad_ratio,
             )
             # Update run/LoRA metrics

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -32,6 +32,7 @@ from prime_rl.trainer.perf import get_perf_counter
 from prime_rl.trainer.sft.data import setup_dataloader, setup_dataset
 from prime_rl.trainer.utils import (
     MemoryProfiler,
+    count_zero_gradient_elements,
     export_benchmark_json,
     get_ckpt_disk_metrics,
     print_sample,
@@ -297,6 +298,7 @@ def train(config: SFTConfig):
         )
         if grad_norm.device.type == "cpu":
             grad_norm = grad_norm.to(torch.device("cuda"))
+        num_zero_grad, num_grad_elements = count_zero_gradient_elements(model.parameters())
 
         logger.debug("Optimizer step")
         optimizer.step()
@@ -316,6 +318,13 @@ def train(config: SFTConfig):
         logger.debug("Synchronizing tensor metrics across all steps and ranks")
         dist.all_reduce(batch_loss, op=dist.ReduceOp.AVG)
         dist.all_reduce(nan_loss_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(num_zero_grad, op=dist.ReduceOp.SUM)
+        dist.all_reduce(num_grad_elements, op=dist.ReduceOp.SUM)
+        if parallel_dims.dp_replicate > 1:
+            # HSDP replicas share the same post-reduction gradients, so remove the duplicate copies here.
+            num_zero_grad = torch.div(num_zero_grad, parallel_dims.dp_replicate, rounding_mode="floor")
+            num_grad_elements = torch.div(num_grad_elements, parallel_dims.dp_replicate, rounding_mode="floor")
+        zero_grad_ratio = (num_zero_grad.float() / num_grad_elements.clamp_min(1).float()).item()
 
         # Compute step metrics
         # Divide by CP and TP since those ranks process the same data
@@ -330,7 +339,7 @@ def train(config: SFTConfig):
 
         # Log step metrics
         step_time = time.perf_counter() - step_start_time
-        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {batch_loss.item():.4f} | Grad. Norm: {grad_norm:.4f} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}% | Peak Mem.: {peak_memory:.1f}/{max_memory:.1f} GiB ({peak_memory / max_memory * 100:.1f}%)"
+        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {batch_loss.item():.4f} | Grad. Norm: {grad_norm:.4f} | Num Zero Grad: {num_zero_grad.item():,} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}% | Peak Mem.: {peak_memory:.1f}/{max_memory:.1f} GiB ({peak_memory / max_memory * 100:.1f}%)"
         if is_tt_moe_model(model) and max_vio is not None:
             step_message += f" | Max Vio: {batch_max_vio.item():.4f}"
         logger.success(step_message)
@@ -372,6 +381,8 @@ def train(config: SFTConfig):
         optim_metrics = {
             "optim/lr": current_lr,
             "optim/grad_norm": grad_norm.item(),
+            "optim/num_zero_grad": num_zero_grad.item(),
+            "optim/zero_grad_ratio": zero_grad_ratio,
             "step": progress.step,
         }
         monitor.log(optim_metrics, step=progress.step)

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -32,8 +32,8 @@ from prime_rl.trainer.perf import get_perf_counter
 from prime_rl.trainer.sft.data import setup_dataloader, setup_dataset
 from prime_rl.trainer.utils import (
     MemoryProfiler,
-    count_zero_gradient_elements,
     export_benchmark_json,
+    get_zero_gradient_ratio,
     get_ckpt_disk_metrics,
     print_sample,
     setup_torch_distributed,
@@ -298,7 +298,7 @@ def train(config: SFTConfig):
         )
         if grad_norm.device.type == "cpu":
             grad_norm = grad_norm.to(torch.device("cuda"))
-        num_zero_grad, num_grad_elements = count_zero_gradient_elements(model.parameters())
+        zero_grad_ratio = get_zero_gradient_ratio(model.parameters(), parallel_dims.dp_replicate)
 
         logger.debug("Optimizer step")
         optimizer.step()
@@ -318,13 +318,6 @@ def train(config: SFTConfig):
         logger.debug("Synchronizing tensor metrics across all steps and ranks")
         dist.all_reduce(batch_loss, op=dist.ReduceOp.AVG)
         dist.all_reduce(nan_loss_count, op=dist.ReduceOp.SUM)
-        dist.all_reduce(num_zero_grad, op=dist.ReduceOp.SUM)
-        dist.all_reduce(num_grad_elements, op=dist.ReduceOp.SUM)
-        if parallel_dims.dp_replicate > 1:
-            # HSDP replicas share the same post-reduction gradients, so remove the duplicate copies here.
-            num_zero_grad = torch.div(num_zero_grad, parallel_dims.dp_replicate, rounding_mode="floor")
-            num_grad_elements = torch.div(num_grad_elements, parallel_dims.dp_replicate, rounding_mode="floor")
-        zero_grad_ratio = (num_zero_grad.float() / num_grad_elements.clamp_min(1).float()).item()
 
         # Compute step metrics
         # Divide by CP and TP since those ranks process the same data
@@ -339,7 +332,7 @@ def train(config: SFTConfig):
 
         # Log step metrics
         step_time = time.perf_counter() - step_start_time
-        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {batch_loss.item():.4f} | Grad. Norm: {grad_norm:.4f} | Num Zero Grad: {num_zero_grad.item():,} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}% | Peak Mem.: {peak_memory:.1f}/{max_memory:.1f} GiB ({peak_memory / max_memory * 100:.1f}%)"
+        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {batch_loss.item():.4f} | Grad. Norm: {grad_norm:.4f} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}% | Peak Mem.: {peak_memory:.1f}/{max_memory:.1f} GiB ({peak_memory / max_memory * 100:.1f}%)"
         if is_tt_moe_model(model) and max_vio is not None:
             step_message += f" | Max Vio: {batch_max_vio.item():.4f}"
         logger.success(step_message)
@@ -381,7 +374,6 @@ def train(config: SFTConfig):
         optim_metrics = {
             "optim/lr": current_lr,
             "optim/grad_norm": grad_norm.item(),
-            "optim/num_zero_grad": num_zero_grad.item(),
             "optim/zero_grad_ratio": zero_grad_ratio,
             "step": progress.step,
         }

--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -3,6 +3,7 @@ import pickle
 import shutil
 import time
 from collections import defaultdict
+from collections.abc import Iterable
 from datetime import timedelta
 from pathlib import Path
 from typing import Any
@@ -14,7 +15,8 @@ from rich import print as rich_print
 from rich.console import Console
 from rich.table import Table
 from rich.text import Text
-from torch import Tensor
+from torch import Tensor, nn
+from torch.distributed.tensor import DTensor
 from transformers.tokenization_utils import PreTrainedTokenizer
 
 from prime_rl.trainer.world import get_world
@@ -23,6 +25,52 @@ from prime_rl.utils.pathing import get_ckpt_dir
 from prime_rl.utils.utils import format_num, format_time, get_step_path
 
 DEFAULT_TIMEOUT = timedelta(seconds=600)
+
+
+def _to_local_tensor(tensor: Tensor | DTensor) -> Tensor:
+    if isinstance(tensor, DTensor):
+        return tensor.to_local()
+    return tensor
+
+
+def count_zero_gradient_elements(parameters: Iterable[nn.Parameter]) -> tuple[Tensor, Tensor]:
+    """Count zero-gradient parameter elements on the local distributed shards.
+
+    Parameters that require gradients but did not receive one in the current step
+    are counted as fully zero. This makes inactive MoE experts visible in the
+    metric instead of silently dropping them from the count.
+    """
+
+    device = torch.device("cuda", torch.cuda.current_device()) if torch.cuda.is_available() else torch.device("cpu")
+    num_zeros = torch.zeros((), dtype=torch.long, device=device)
+    num_tracked = torch.zeros((), dtype=torch.long, device=device)
+
+    for param in parameters:
+        if not param.requires_grad:
+            continue
+
+        local_param = _to_local_tensor(param.detach())
+        if local_param.numel() == 0:
+            continue
+
+        if local_param.device != num_zeros.device:
+            num_zeros = num_zeros.to(local_param.device)
+            num_tracked = num_tracked.to(local_param.device)
+
+        local_numel = torch.tensor(local_param.numel(), dtype=torch.long, device=local_param.device)
+        num_tracked += local_numel
+
+        if param.grad is None:
+            num_zeros += local_numel
+            continue
+
+        local_grad = _to_local_tensor(param.grad.detach())
+        if local_grad.numel() != local_param.numel():
+            raise ValueError("Local gradient shape does not match the local parameter shape")
+
+        num_zeros += local_numel - torch.count_nonzero(local_grad)
+
+    return num_zeros, num_tracked
 
 
 def get_ckpt_disk_metrics(output_dir: Path) -> dict[str, float]:

--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -73,6 +73,16 @@ def count_zero_gradient_elements(parameters: Iterable[nn.Parameter]) -> tuple[Te
     return num_zeros, num_tracked
 
 
+def get_zero_gradient_ratio(parameters: Iterable[nn.Parameter], dp_replicate: int = 1) -> float:
+    num_zero_grad, num_grad_elements = count_zero_gradient_elements(parameters)
+    dist.all_reduce(num_zero_grad, op=dist.ReduceOp.SUM)
+    dist.all_reduce(num_grad_elements, op=dist.ReduceOp.SUM)
+    if dp_replicate > 1:
+        num_zero_grad = torch.div(num_zero_grad, dp_replicate, rounding_mode="floor")
+        num_grad_elements = torch.div(num_grad_elements, dp_replicate, rounding_mode="floor")
+    return (num_zero_grad.float() / num_grad_elements.clamp_min(1).float()).item()
+
+
 def get_ckpt_disk_metrics(output_dir: Path) -> dict[str, float]:
     """
     Disk usage metrics for the checkpoint directory (<output_dir>/checkpoints).

--- a/src/prime_rl/utils/metrics_server.py
+++ b/src/prime_rl/utils/metrics_server.py
@@ -115,9 +115,6 @@ class MetricsServer(HealthServer):
             "trainer_mismatch_kl", "KL divergence between trainer and inference model", registry=self._registry
         )
         self._kl_ent_ratio = Gauge("trainer_kl_ent_ratio", "Ratio of mismatch KL to entropy", registry=self._registry)
-        self._num_zero_grad = Gauge(
-            "trainer_num_zero_grad", "Number of zero-gradient parameter elements", registry=self._registry
-        )
         self._zero_grad_ratio = Gauge(
             "trainer_zero_grad_ratio",
             "Fraction of tracked parameter elements with zero gradient",
@@ -204,7 +201,6 @@ class MetricsServer(HealthServer):
         mfu: float = 0.0,
         entropy: float = 0.0,
         mismatch_kl: float = 0.0,
-        num_zero_grad: float = 0.0,
         zero_grad_ratio: float = 0.0,
     ) -> None:
         """Update metrics after a training step."""
@@ -217,7 +213,6 @@ class MetricsServer(HealthServer):
         self._mfu.set(mfu)
         self._entropy.set(entropy)
         self._mismatch_kl.set(mismatch_kl)
-        self._num_zero_grad.set(num_zero_grad)
         self._zero_grad_ratio.set(zero_grad_ratio)
         if entropy > 0:
             self._kl_ent_ratio.set(mismatch_kl / entropy)

--- a/src/prime_rl/utils/metrics_server.py
+++ b/src/prime_rl/utils/metrics_server.py
@@ -115,6 +115,14 @@ class MetricsServer(HealthServer):
             "trainer_mismatch_kl", "KL divergence between trainer and inference model", registry=self._registry
         )
         self._kl_ent_ratio = Gauge("trainer_kl_ent_ratio", "Ratio of mismatch KL to entropy", registry=self._registry)
+        self._num_zero_grad = Gauge(
+            "trainer_num_zero_grad", "Number of zero-gradient parameter elements", registry=self._registry
+        )
+        self._zero_grad_ratio = Gauge(
+            "trainer_zero_grad_ratio",
+            "Fraction of tracked parameter elements with zero gradient",
+            registry=self._registry,
+        )
         # Aggregate run metrics
         self._runs_discovered = Gauge(
             "trainer_runs_discovered", "Number of run folders discovered", registry=self._registry
@@ -196,6 +204,8 @@ class MetricsServer(HealthServer):
         mfu: float = 0.0,
         entropy: float = 0.0,
         mismatch_kl: float = 0.0,
+        num_zero_grad: float = 0.0,
+        zero_grad_ratio: float = 0.0,
     ) -> None:
         """Update metrics after a training step."""
         self._step.set(step)
@@ -207,6 +217,8 @@ class MetricsServer(HealthServer):
         self._mfu.set(mfu)
         self._entropy.set(entropy)
         self._mismatch_kl.set(mismatch_kl)
+        self._num_zero_grad.set(num_zero_grad)
+        self._zero_grad_ratio.set(zero_grad_ratio)
         if entropy > 0:
             self._kl_ent_ratio.set(mismatch_kl / entropy)
         self._last_step_ts.set(time.time())


### PR DESCRIPTION
<img width="1149" height="253" alt="Screenshot 2026-03-06 at 05 42 24" src="https://github.com/user-attachments/assets/cfb5e0b5-e152-4aff-bae7-443f87084ac0" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a read-only training metric and logging; main risk is minor overhead or incorrect aggregation under distributed sharding/DP replication.
> 
> **Overview**
> Adds a new *zero-gradient ratio* observability metric that counts (and all-reduces) the fraction of parameter elements with zero/absent gradients, including handling for `DTensor` sharded parameters and parameters with `grad is None`.
> 
> Both RL (`trainer/rl/train.py`) and SFT (`trainer/sft/train.py`) training loops now compute `optim/zero_grad_ratio` each step and log it to the monitor, and the Prometheus `MetricsServer` exposes it via a new `trainer_zero_grad_ratio` gauge included in `MetricsServer.update()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b69544322e6b79ea03cf8682f9e14899d8a80cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->