### PR TITLE
[wip] disagg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "torch>=2.9.0",
     "torchdata>=0.11.0",
     "transformers",
-    "vllm>=0.16.1.dev",
+    "vllm>=0.16.0",
     "vllm-router",
     "wandb>=0.24.2",
     "ring-flash-attn>=0.1.8",
@@ -52,7 +52,7 @@ prime_rl = "prime_rl.inference.patches:transformers_v5_compat"
 
 [project.optional-dependencies]
 flash-attn = [
-    "flash-attn @ https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.7.16/flash_attn-2.8.3+cu128torch2.10-cp312-cp312-linux_x86_64.whl",
+    "flash-attn @ https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.6.8/flash_attn-2.8.3+cu128torch2.9-cp312-cp312-linux_x86_64.whl",
 ]
 
 flash-attn-3 = [
@@ -88,7 +88,6 @@ override-dependencies = [
 
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
-vllm = { url = "https://wheels.vllm.ai/7eca85911072b9732293c3d4181e20a4c9394b21/vllm-0.16.1rc1.dev246%2Bg7eca85911-cp38-abi3-manylinux_2_31_x86_64.whl" }
 math-env = { index = "primeintellect" }
 verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "45fae8d" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
@@ -111,12 +110,7 @@ url = "https://hub.primeintellect.ai/primeintellect/simple/"
 
 [[tool.uv.index]]
 name = "pytorch-cu128"
-url = "https://download.pytorch.org/whl/cu128"
-explicit = true
-
-[[tool.uv.index]]
-name = "vllm-nightly"
-url = "https://wheels.vllm.ai/nightly"
+url = "https://download.pytorch.org/whl/test/cu128"
 explicit = true
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "torchdata>=0.11.0",
     "transformers",
     "vllm>=0.16.1.dev",
+    "vllm-router",
     "wandb>=0.24.2",
     "ring-flash-attn>=0.1.8",
     "prime>=0.5.37",
@@ -35,6 +36,7 @@ dependencies = [
     "dion",
     "reverse-text",
     "tilelang>=0.1.8",
+    "nixl>=0.10.1",
 ]
 
 [project.scripts]
@@ -86,7 +88,7 @@ override-dependencies = [
 
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
-vllm = { index = "vllm-nightly" }
+vllm = { url = "https://wheels.vllm.ai/7eca85911072b9732293c3d4181e20a4c9394b21/vllm-0.16.1rc1.dev246%2Bg7eca85911-cp38-abi3-manylinux_2_31_x86_64.whl" }
 math-env = { index = "primeintellect" }
 verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "45fae8d" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }

--- a/scripts/install_ep_kernels.sh
+++ b/scripts/install_ep_kernels.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Install DeepEP kernels for expert-parallel disaggregated inference.
+#
+# Builds NVSHMEM + DeepEP from source and installs into the project venv.
+# Required for disaggregated prefill/decode deployments with expert parallelism.
+#
+# Auto-detects the CUDA toolkit version that matches the installed PyTorch
+# and looks for it at /usr/local/cuda-X.Y. Fails if not found.
+#
+# Prerequisites:
+#   - Matching CUDA toolkit installed (e.g. `sudo apt install cuda-toolkit-12-8`)
+#   - For multi-node: IBGDA driver configured (see --configure-drivers)
+#
+# Usage:
+#   bash scripts/install_ep_kernels.sh
+#
+# Options:
+#   --workspace DIR       Build directory (default: ./ep_kernels_workspace)
+#   --deepep-ref REF      DeepEP commit hash (default: 73b6ea4)
+#   --nvshmem-ver VER     NVSHMEM version (default: 3.3.24)
+#   --configure-drivers   Also configure IBGDA drivers (requires sudo, needs reboot)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+DEEPEP_COMMIT_HASH="73b6ea4"
+NVSHMEM_VER="3.3.24"
+WORKSPACE="$REPO_ROOT/ep_kernels_workspace"
+CONFIGURE_DRIVERS=0
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --workspace)         WORKSPACE="$2";          shift 2 ;;
+        --deepep-ref)        DEEPEP_COMMIT_HASH="$2"; shift 2 ;;
+        --nvshmem-ver)       NVSHMEM_VER="$2";        shift 2 ;;
+        --configure-drivers) CONFIGURE_DRIVERS=1;     shift   ;;
+        *) echo "Unknown argument: $1" >&2; exit 1 ;;
+    esac
+done
+
+# Skip if DeepEP is already installed
+if python -c "import deep_ep" 2>/dev/null; then
+    echo "DeepEP already installed, skipping."
+    exit 0
+fi
+
+# ── Auto-detect CUDA toolkit matching torch ───────────────────────────────────
+TORCH_CUDA_VER=$(python -c "import torch; print(torch.version.cuda)")
+CUDA_MAJOR_MINOR=$(echo "$TORCH_CUDA_VER" | grep -oP '^\d+\.\d+')
+CUDA_MAJOR=$(echo "$CUDA_MAJOR_MINOR" | cut -d. -f1)
+
+CUDA_HOME="/usr/local/cuda-${CUDA_MAJOR_MINOR}"
+if [ ! -x "$CUDA_HOME/bin/nvcc" ]; then
+    echo "ERROR: Could not find CUDA toolkit matching torch (cuda ${TORCH_CUDA_VER}) at ${CUDA_HOME}" >&2
+    echo "Install it with: sudo apt install cuda-toolkit-${CUDA_MAJOR_MINOR//./-}" >&2
+    exit 1
+fi
+export CUDA_HOME
+
+# Verify versions actually match
+NVCC_VER=$("$CUDA_HOME/bin/nvcc" --version | grep -oP 'release \K[\d.]+')
+echo "Torch CUDA: ${TORCH_CUDA_VER}, nvcc: ${NVCC_VER} (${CUDA_HOME})"
+
+# ── Auto-detect GPU architecture ──────────────────────────────────────────────
+GPU_NAME=$(nvidia-smi --query-gpu=gpu_name --format=csv,noheader,nounits -i 0 2>/dev/null)
+case "$GPU_NAME" in
+    *H100*|*H200*|*H800*)  TORCH_CUDA_ARCH_LIST="9.0" ;;
+    *B100*|*B200*|*GB200*)  TORCH_CUDA_ARCH_LIST="10.0" ;;
+    *)
+        echo "Could not auto-detect GPU arch from '$GPU_NAME'. Set TORCH_CUDA_ARCH_LIST manually." >&2
+        echo "  Hopper (H100/H200): TORCH_CUDA_ARCH_LIST=9.0" >&2
+        echo "  Blackwell (B200):   TORCH_CUDA_ARCH_LIST=10.0" >&2
+        exit 1
+        ;;
+esac
+export TORCH_CUDA_ARCH_LIST
+
+echo "================================================================"
+echo " Installing DeepEP kernels"
+echo " CUDA:       ${CUDA_HOME} (${NVCC_VER})"
+echo " GPU:        ${GPU_NAME} (arch ${TORCH_CUDA_ARCH_LIST})"
+echo " DeepEP:     ${DEEPEP_COMMIT_HASH}"
+echo " NVSHMEM:    ${NVSHMEM_VER}"
+echo " Workspace:  ${WORKSPACE}"
+echo "================================================================"
+
+mkdir -p "$WORKSPACE"
+
+# ── Step 1: Install build deps ────────────────────────────────────────────────
+echo ""
+echo "--- Installing build dependencies ---"
+cd "$REPO_ROOT"
+uv pip install cmake ninja
+
+# ── Step 2: Download and extract NVSHMEM ──────────────────────────────────────
+echo ""
+echo "--- Setting up NVSHMEM ${NVSHMEM_VER} ---"
+
+ARCH=$(uname -m)
+case "${ARCH,,}" in
+    x86_64|amd64)   NVSHMEM_SUBDIR="linux-x86_64" ;;
+    aarch64|arm64)   NVSHMEM_SUBDIR="linux-sbsa" ;;
+    *) echo "Unsupported architecture: ${ARCH}" >&2; exit 1 ;;
+esac
+
+NVSHMEM_DIR="$WORKSPACE/nvshmem"
+if [ ! -d "$NVSHMEM_DIR/lib" ]; then
+    NVSHMEM_FILE="libnvshmem-${NVSHMEM_SUBDIR}-${NVSHMEM_VER}_cuda${CUDA_MAJOR}-archive.tar.xz"
+    NVSHMEM_URL="https://developer.download.nvidia.com/compute/nvshmem/redist/libnvshmem/${NVSHMEM_SUBDIR}/${NVSHMEM_FILE}"
+
+    echo "Downloading ${NVSHMEM_URL}"
+    curl -fSL "${NVSHMEM_URL}" -o "$WORKSPACE/${NVSHMEM_FILE}"
+    tar -xf "$WORKSPACE/${NVSHMEM_FILE}" -C "$WORKSPACE"
+    mv "$WORKSPACE/${NVSHMEM_FILE%.tar.xz}" "$NVSHMEM_DIR"
+    rm -f "$WORKSPACE/${NVSHMEM_FILE}"
+    rm -rf "$NVSHMEM_DIR/lib/bin" "$NVSHMEM_DIR/lib/share"
+    echo "NVSHMEM extracted to ${NVSHMEM_DIR}"
+else
+    echo "NVSHMEM already present at ${NVSHMEM_DIR}, skipping download"
+fi
+
+export CMAKE_PREFIX_PATH="${NVSHMEM_DIR}/lib/cmake:${CMAKE_PREFIX_PATH:-}"
+export NVSHMEM_DIR
+
+# ── Step 3: Build and install DeepEP ──────────────────────────────────────────
+echo ""
+echo "--- Building DeepEP (${DEEPEP_COMMIT_HASH}) ---"
+
+DEEPEP_DIR="$WORKSPACE/DeepEP"
+if [ ! -d "$DEEPEP_DIR/.git" ]; then
+    git clone https://github.com/deepseek-ai/DeepEP "$DEEPEP_DIR"
+fi
+
+cd "$DEEPEP_DIR"
+git fetch origin
+git checkout "$DEEPEP_COMMIT_HASH"
+
+uv pip install --no-build-isolation -v "$DEEPEP_DIR"
+
+echo ""
+echo "--- DeepEP installed successfully ---"
+
+# ── Step 4 (optional): Configure IBGDA drivers ───────────────────────────────
+if [ "$CONFIGURE_DRIVERS" -eq 1 ]; then
+    echo ""
+    echo "--- Configuring IBGDA drivers (requires sudo) ---"
+    echo 'options nvidia NVreg_EnableStreamMemOPs=1 NVreg_RegistryDwords="PeerMappingOverride=1;"' | sudo tee -a /etc/modprobe.d/nvidia.conf
+    if command -v update-initramfs &> /dev/null; then
+        sudo update-initramfs -u
+    elif command -v dracut &> /dev/null; then
+        sudo dracut --force
+    else
+        echo "No supported initramfs update tool found." >&2
+        exit 1
+    fi
+    echo ""
+    echo "IBGDA configured. Please REBOOT the system to apply changes."
+fi
+
+echo ""
+echo "================================================================"
+echo " DeepEP installation complete"
+echo " NVSHMEM: ${NVSHMEM_DIR}"
+echo " To verify: uv run python -c 'import deep_ep; print(deep_ep.__file__)'"
+echo "================================================================"

--- a/scripts/install_nixl_from_source.sh
+++ b/scripts/install_nixl_from_source.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+set -euo pipefail
+
+# Build UCX 1.19.x with CUDA + IB support, then build NIXL against it.
+# Installs the unrepaired wheel (no auditwheel) so NIXL uses the UCX libs
+# directly from third_party/ucx/ at runtime via LD_LIBRARY_PATH.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+VENV_BIN="$PROJECT_DIR/.venv/bin"
+PYTHON="$VENV_BIN/python"
+
+UCX_SRC=/tmp/ucx_source
+UCX_INSTALL="$PROJECT_DIR/third_party/ucx"
+NIXL_SRC=/tmp/nixl_source
+NIXL_VERSION="${NIXL_VERSION:-0.10.1}"
+CUDA_PATH="${CUDA_HOME:-/usr/local/cuda}"
+NPROC=$(nproc)
+
+export PATH="$VENV_BIN:$PATH"
+
+echo "=== Building UCX 1.19.x with CUDA + IB ==="
+if [ ! -d "$UCX_SRC" ]; then
+    git clone https://github.com/openucx/ucx.git "$UCX_SRC"
+fi
+cd "$UCX_SRC"
+git checkout v1.19.x
+
+if [ ! -f "$UCX_INSTALL/lib/libucs.so" ]; then
+    ./autogen.sh
+    ./configure \
+        --prefix="$UCX_INSTALL" \
+        --enable-shared \
+        --disable-static \
+        --disable-doxygen-doc \
+        --enable-optimizations \
+        --enable-cma \
+        --enable-devel-headers \
+        --enable-mt \
+        --with-verbs \
+        --with-cuda="$CUDA_PATH" \
+        --with-ze=no
+    make -j"$NPROC"
+    make install
+    echo "=== UCX installed to $UCX_INSTALL ==="
+else
+    echo "=== UCX already built, skipping ==="
+fi
+
+echo "=== Building NIXL $NIXL_VERSION ==="
+if [ ! -d "$NIXL_SRC" ]; then
+    git clone https://github.com/ai-dynamo/nixl.git "$NIXL_SRC"
+else
+    cd "$NIXL_SRC" && git fetch --tags
+fi
+cd "$NIXL_SRC"
+git checkout "$NIXL_VERSION"
+
+export PKG_CONFIG_PATH="$UCX_INSTALL/lib/pkgconfig"
+export LD_LIBRARY_PATH="$UCX_INSTALL/lib:$UCX_INSTALL/lib/ucx:${LD_LIBRARY_PATH:-}"
+
+# Build and install directly (no auditwheel) so NIXL links to our UCX at runtime
+WHEEL_DIR=/tmp/nixl_wheels
+rm -rf "$WHEEL_DIR"
+"$PYTHON" -m pip wheel . --no-deps --wheel-dir="$WHEEL_DIR"
+
+WHEEL=$(ls "$WHEEL_DIR"/nixl*.whl | head -1)
+echo "=== Installing wheel directly (no auditwheel) ==="
+uv pip install --no-deps --reinstall "$WHEEL"
+
+echo "=== Testing NIXL UCX backend ==="
+LD_LIBRARY_PATH="$UCX_INSTALL/lib:$UCX_INSTALL/lib/ucx:${LD_LIBRARY_PATH:-}" \
+  "$PYTHON" -c "
+from nixl._api import nixl_agent
+agent = nixl_agent('test')
+print('SUCCESS: NIXL UCX backend working')
+"

--- a/scripts/install_vllm_router.sh
+++ b/scripts/install_vllm_router.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Builds the patched vllm-router (Rust) from our fork and installs it into .venv/bin.
+# Requires: cargo (Rust toolchain)
+set -euo pipefail
+
+REPO_URL="https://github.com/S1ro1/router.git"
+BRANCH="fix/preserve-extra-fields-disagg"
+BUILD_DIR="/tmp/vllm-router-build"
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+INSTALL_DIR="$SCRIPT_DIR/.venv/bin"
+
+echo "Cloning $REPO_URL (branch: $BRANCH)..."
+rm -rf "$BUILD_DIR"
+git clone --depth 1 --branch "$BRANCH" "$REPO_URL" "$BUILD_DIR"
+
+echo "Building vllm-router (release)..."
+cd "$BUILD_DIR"
+cargo build --release
+
+echo "Installing to $INSTALL_DIR/vllm-router-rs..."
+cp "$BUILD_DIR/target/release/vllm-router" "$INSTALL_DIR/vllm-router-rs"
+chmod +x "$INSTALL_DIR/vllm-router-rs"
+
+echo "Cleaning up..."
+rm -rf "$BUILD_DIR"
+
+echo "Done. Binary installed at: $INSTALL_DIR/vllm-router-rs"

--- a/skills/installation/SKILL.md
+++ b/skills/installation/SKILL.md
@@ -41,7 +41,30 @@ uv sync --group dev
 
 Installs pytest, ruff, pre-commit, and other development tools.
 
+## Expert parallel kernels (DeepEP) for disaggregated inference
+
+Disaggregated prefill/decode deployments with expert parallelism require DeepEP + NVSHMEM, which must be built from source:
+
+```bash
+bash scripts/install_ep_kernels.sh
+```
+
+This downloads NVSHMEM, clones and builds DeepEP, and installs it into the project venv. Auto-detects GPU architecture (Hopper/Blackwell).
+
+For multi-node deployments, IBGDA drivers must also be configured (requires sudo + reboot):
+
+```bash
+bash scripts/install_ep_kernels.sh --configure-drivers
+```
+
+Verify installation:
+
+```bash
+uv run python -c "import deep_ep; print(deep_ep.__file__)"
+```
+
 ## Key files
 
 - `pyproject.toml` — all dependencies, extras, and dependency groups
 - `uv.lock` — pinned lockfile (update with `uv sync --all-extras`)
+- `scripts/install_ep_kernels.sh` — DeepEP + NVSHMEM installer for expert parallel

--- a/src/prime_rl/configs/inference.py
+++ b/src/prime_rl/configs/inference.py
@@ -317,8 +317,11 @@ class InferenceConfig(BaseConfig):
 
     @model_validator(mode="after")
     def validate_multi_node_requires_slurm(self):
-        if self.deployment.type in ["multi_node", "disaggregated"] and self.slurm is None:
-            raise ValueError("Must use SLURM for multi-node or disaggregated deployment.")
+        # Only validate multi_node here. Disaggregated is excluded because this
+        # config can be nested in RLConfig where SLURM lives on the parent.
+        # For standalone disaggregated inference, the entrypoint validates SLURM.
+        if self.deployment.type == "multi_node" and self.slurm is None:
+            raise ValueError("Must use SLURM for multi-node deployment.")
         return self
 
     @model_validator(mode="after")
@@ -327,10 +330,10 @@ class InferenceConfig(BaseConfig):
             import prime_rl
 
             templates_dir = Path(prime_rl.__file__).parent / "templates"
-            if self.deployment.type == "multi_node":
-                self.slurm.template_path = templates_dir / "inference.sbatch.j2"
-            elif self.deployment.type == "disaggregated":
+            if self.deployment.type == "disaggregated":
                 self.slurm.template_path = templates_dir / "inference_disaggregated.sbatch.j2"
+            else:
+                self.slurm.template_path = templates_dir / "inference.sbatch.j2"
         return self
 
     @model_validator(mode="after")
@@ -352,6 +355,24 @@ class InferenceConfig(BaseConfig):
         return self
 
     @model_validator(mode="after")
+    def auto_setup_disaggregated_deployment(self):
+        """Auto-configure inference settings for disaggregated deployment.
+
+        Forces EP mode (TP=1), enables expert parallel + EPLB, and sets
+        DP sizing based on the number of prefill+decode nodes and GPUs.
+        Must run before auto_setup_api_server_count.
+        """
+        if self.deployment.type != "disaggregated":
+            return self
+
+        self.parallel.tp = 1
+        self.enable_expert_parallel = True
+        self.enable_eplb = True
+        self.data_parallel_size_local = self.deployment.gpus_per_node
+
+        return self
+
+    @model_validator(mode="after")
     def auto_setup_api_server_count(self):
         """
         Ensures that we have at least as many API servers as data parallel
@@ -365,23 +386,6 @@ class InferenceConfig(BaseConfig):
 
         if self.enable_lora:
             self.api_server_count = 1  # LoRA requires only one API server
-        return self
-    
-    @model_validator(mode="after")
-    def auto_setup_disaggregated_deployment(self):
-        """Auto-configure inference settings for disaggregated deployment.
-
-        Forces EP mode (TP=1), enables expert parallel + EPLB, and sets
-        DP sizing based on the number of prefill+decode nodes and GPUs.
-        """
-        if self.deployment.type != "disaggregated":
-            return self
-
-        self.parallel.tp = 1
-        self.enable_expert_parallel = True
-        self.enable_eplb = True
-        self.data_parallel_size_local = self.deployment.gpus_per_node
-
         return self
 
     def to_vllm(self) -> Namespace:

--- a/src/prime_rl/configs/inference.py
+++ b/src/prime_rl/configs/inference.py
@@ -367,7 +367,8 @@ class InferenceConfig(BaseConfig):
 
         self.parallel.tp = 1
         self.enable_expert_parallel = True
-        self.enable_eplb = True
+        if "enable_eplb" not in self.model_fields_set:
+            self.enable_eplb = True
         self.data_parallel_size_local = self.deployment.gpus_per_node
 
         return self

--- a/src/prime_rl/configs/inference.py
+++ b/src/prime_rl/configs/inference.py
@@ -139,8 +139,31 @@ class MultiNodeInferenceDeploymentConfig(BaseInferenceDeploymentConfig):
     num_nodes: Annotated[int, Field(ge=1, description="Number of inference nodes.")] = 2
 
 
+class DisaggregatedInferenceDeploymentConfig(BaseInferenceDeploymentConfig):
+    """Configures a disaggregated prefill/decode inference deployment.
+
+    All nodes run with --data-parallel-hybrid-lb (no headless workers).
+    Expert parallelism, KV transfer, and compilation settings are hard-coded
+    in the SLURM template.
+    """
+
+    type: Literal["disaggregated"] = "disaggregated"
+
+    num_prefill_nodes: Annotated[int, Field(ge=1, description="Number of prefill nodes.")] = 1
+    num_decode_nodes: Annotated[int, Field(ge=1, description="Number of decode nodes.")] = 1
+
+    prefill_port: Annotated[int, Field(description="Port for prefill vLLM instances.")] = 8100
+    decode_port: Annotated[int, Field(description="Port for decode vLLM instances.")] = 8200
+    router_port: Annotated[int, Field(description="Port for the vllm-router.")] = 8000
+
+    @property
+    def num_nodes(self) -> int:
+        return self.num_prefill_nodes + self.num_decode_nodes
+
+
+
 InferenceDeploymentConfig: TypeAlias = Annotated[
-    SingleNodeInferenceDeploymentConfig | MultiNodeInferenceDeploymentConfig, Field(discriminator="type")
+    SingleNodeInferenceDeploymentConfig | MultiNodeInferenceDeploymentConfig | DisaggregatedInferenceDeploymentConfig, Field(discriminator="type")
 ]
 
 
@@ -294,8 +317,8 @@ class InferenceConfig(BaseConfig):
 
     @model_validator(mode="after")
     def validate_multi_node_requires_slurm(self):
-        if self.deployment.type == "multi_node" and self.slurm is None:
-            raise ValueError("Must use SLURM for multi-node deployment.")
+        if self.deployment.type in ["multi_node", "disaggregated"] and self.slurm is None:
+            raise ValueError("Must use SLURM for multi-node or disaggregated deployment.")
         return self
 
     @model_validator(mode="after")
@@ -304,7 +327,10 @@ class InferenceConfig(BaseConfig):
             import prime_rl
 
             templates_dir = Path(prime_rl.__file__).parent / "templates"
-            self.slurm.template_path = templates_dir / "inference.sbatch.j2"
+            if self.deployment.type == "multi_node":
+                self.slurm.template_path = templates_dir / "inference.sbatch.j2"
+            elif self.deployment.type == "disaggregated":
+                self.slurm.template_path = templates_dir / "inference_disaggregated.sbatch.j2"
         return self
 
     @model_validator(mode="after")
@@ -339,6 +365,23 @@ class InferenceConfig(BaseConfig):
 
         if self.enable_lora:
             self.api_server_count = 1  # LoRA requires only one API server
+        return self
+    
+    @model_validator(mode="after")
+    def auto_setup_disaggregated_deployment(self):
+        """Auto-configure inference settings for disaggregated deployment.
+
+        Forces EP mode (TP=1), enables expert parallel + EPLB, and sets
+        DP sizing based on the number of prefill+decode nodes and GPUs.
+        """
+        if self.deployment.type != "disaggregated":
+            return self
+
+        self.parallel.tp = 1
+        self.enable_expert_parallel = True
+        self.enable_eplb = True
+        self.data_parallel_size_local = self.deployment.gpus_per_node
+
         return self
 
     def to_vllm(self) -> Namespace:

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -626,6 +626,9 @@ class NCCLWeightBroadcastConfig(BaseModel):
     host: Annotated[str, Field(description="The host to use for the NCCL broadcast.")] = "localhost"
     port: Annotated[int, Field(description="The port to use for the NCCL broadcast.")] = 29501
     timeout: Annotated[int, Field(description="The timeout in seconds to use for the NCCL broadcast.")] = 1200
+    inference_world_size: Annotated[
+        int, Field(description="Total number of inference GPUs across all servers.")
+    ] = 1
 
 
 WeightBroadcastConfig: TypeAlias = Annotated[

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -495,6 +495,7 @@ class RLConfig(BaseConfig):
                     port=self.weight_broadcast.port,
                     timeout=self.weight_broadcast.timeout,
                 )
+                self.orchestrator.weight_broadcast.inference_world_size = inference_world_size
             elif self.weight_broadcast.type == "filesystem":
                 self.trainer.weight_broadcast = TrainerFileSystemWeightBroadcastConfig()
                 self.orchestrator.weight_broadcast = OrchestratorFileSystemWeightBroadcastConfig()
@@ -656,10 +657,10 @@ class RLConfig(BaseConfig):
 
             if self.weight_broadcast is not None and self.weight_broadcast.type == "nccl":
                 assert self.trainer.weight_broadcast.type == "nccl"
+                inference_world_size = self.deployment.gpus_per_node * self.deployment.num_infer_nodes
                 self.trainer.weight_broadcast.host = "0.0.0.0"
-                self.trainer.weight_broadcast.inference_world_size = (
-                    self.deployment.gpus_per_node * self.deployment.num_infer_nodes
-                )
+                self.trainer.weight_broadcast.inference_world_size = inference_world_size
+                self.orchestrator.weight_broadcast.inference_world_size = inference_world_size
 
         return self
 

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -293,6 +293,15 @@ class RLConfig(BaseConfig):
                 raise ValueError("Must use SLURM for multi-node deployment.")
             if not self.inference:
                 raise ValueError("Must configure inference when using multi-node deployment.")
+            if self.inference.deployment.type == "disaggregated":
+                expected = self.inference.deployment.num_prefill_nodes + self.inference.deployment.num_decode_nodes
+                if self.deployment.num_infer_nodes != expected:
+                    raise ValueError(
+                        f"deployment.num_infer_nodes ({self.deployment.num_infer_nodes}) must equal "
+                        f"inference.deployment.num_prefill_nodes ({self.inference.deployment.num_prefill_nodes}) "
+                        f"+ inference.deployment.num_decode_nodes ({self.inference.deployment.num_decode_nodes}) "
+                        f"= {expected} for disaggregated inference."
+                    )
         return self
 
     # TODO: fix this
@@ -612,7 +621,12 @@ class RLConfig(BaseConfig):
                     self.deployment.num_train_nodes // self.deployment.nodes_per_fsdp_group
                 )
 
-            if self.inference is not None and self.inference.enable_expert_parallel:
+            if self.inference is not None and self.inference.deployment.type == "disaggregated":
+                # Disaggregated inference handles DP sizing per role (prefill/decode)
+                # in the SLURM template via vllm_extra overrides. Skip the single-DP
+                # validation that applies to regular EP deployments.
+                pass
+            elif self.inference is not None and self.inference.enable_expert_parallel:
                 inference_tp = self.inference.parallel.tp
                 if self.deployment.gpus_per_node % inference_tp != 0:
                     raise ValueError(
@@ -699,6 +713,8 @@ class RLConfig(BaseConfig):
             templates_dir = Path(prime_rl.__file__).parent / "templates"
             if self.deployment.type == "single_node":
                 self.slurm.template_path = templates_dir / "single_node_rl.sbatch.j2"
+            elif self.inference and self.inference.deployment.type == "disaggregated":
+                self.slurm.template_path = templates_dir / "disaggregated_rl.sbatch.j2"
             else:
                 self.slurm.template_path = templates_dir / "multi_node_rl.sbatch.j2"
         return self

--- a/src/prime_rl/configs/shared.py
+++ b/src/prime_rl/configs/shared.py
@@ -115,6 +115,16 @@ class ClientConfig(BaseConfig):
         ),
     ] = {}
 
+    admin_base_url: Annotated[
+        list[str] | None,
+        Field(
+            description="Base URLs for admin operations (weight updates, health checks). "
+            "When set, admin requests use these URLs instead of base_url. "
+            "Useful for disaggregated inference where inference requests go through a router "
+            "but weight updates must reach each node directly.",
+        ),
+    ] = None
+
     skip_model_check: Annotated[
         bool,
         Field(

--- a/src/prime_rl/entrypoints/inference.py
+++ b/src/prime_rl/entrypoints/inference.py
@@ -32,16 +32,32 @@ def write_slurm_script(config: InferenceConfig, config_path: Path, script_path: 
     env = Environment(loader=FileSystemLoader(config.slurm.template_path.parent), keep_trailing_newline=True)
     template = env.get_template(config.slurm.template_path.name)
 
-    script = template.render(
-        config_path=config_path,
-        output_dir=config.output_dir,
-        job_name=config.slurm.job_name,
-        project_dir=config.slurm.project_dir,
-        gpus_per_node=config.deployment.gpus_per_node,
-        partition=config.slurm.partition,
-        num_nodes=config.deployment.num_nodes if config.deployment.type == "multi_node" else 1,
-        port=config.server.port,
-    )
+    if config.deployment.type == "disaggregated":
+        script = template.render(
+            config_path=config_path,
+            output_dir=config.output_dir,
+            job_name=config.slurm.job_name,
+            project_dir=config.slurm.project_dir,
+            partition=config.slurm.partition,
+            gpus_per_node=config.deployment.gpus_per_node,
+            num_prefill_nodes=config.deployment.num_prefill_nodes,
+            num_decode_nodes=config.deployment.num_decode_nodes,
+            prefill_port=config.deployment.prefill_port,
+            decode_port=config.deployment.decode_port,
+            router_port=config.deployment.router_port,
+            data_parallel_rpc_port=config.data_parallel_rpc_port,
+        )
+    else:
+        script = template.render(
+            config_path=config_path,
+            output_dir=config.output_dir,
+            job_name=config.slurm.job_name,
+            project_dir=config.slurm.project_dir,
+            gpus_per_node=config.deployment.gpus_per_node,
+            partition=config.slurm.partition,
+            num_nodes=config.deployment.num_nodes if config.deployment.type == "multi_node" else 1,
+            port=config.server.port,
+        )
 
     script_path.parent.mkdir(parents=True, exist_ok=True)
     script_path.write_text(script)
@@ -54,7 +70,7 @@ def inference_slurm(config: InferenceConfig):
     logger = setup_logger("info")
 
     config_dir = get_config_dir(config.output_dir)
-    exclude = {"deployment", "slurm", "dry_run"} if config.deployment.type == "multi_node" else {"slurm", "dry_run"}
+    exclude = {"deployment", "slurm", "dry_run"} if config.deployment.type in ("multi_node", "disaggregated") else {"slurm", "dry_run"}
     config_path = write_config(config, config_dir, exclude=exclude)
     logger.info(f"Wrote config to {config_path}")
 
@@ -103,6 +119,9 @@ def inference_local(config: InferenceConfig):
 
 
 def inference(config: InferenceConfig):
+    if config.deployment.type == "disaggregated" and config.slurm is None:
+        raise ValueError("Must use SLURM for disaggregated deployment.")
+
     if config.slurm is not None:
         inference_slurm(config)
     else:

--- a/src/prime_rl/entrypoints/inference.py
+++ b/src/prime_rl/entrypoints/inference.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -119,7 +120,7 @@ def inference_local(config: InferenceConfig):
 
 
 def inference(config: InferenceConfig):
-    if config.deployment.type == "disaggregated" and config.slurm is None:
+    if config.deployment.type == "disaggregated" and config.slurm is None and not os.environ.get("SLURM_JOB_ID"):
         raise ValueError("Must use SLURM for disaggregated deployment.")
 
     if config.slurm is not None:

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -405,6 +405,7 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
             decode_port=config.inference.deployment.decode_port,
             router_port=config.inference.deployment.router_port,
             data_parallel_rpc_port=config.inference.data_parallel_rpc_port,
+            weight_broadcast_type=config.orchestrator.weight_broadcast.type,
         )
     else:
         assert config.inference is not None
@@ -423,6 +424,7 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
             inference_tp=config.inference.parallel.tp,
             inference_enable_expert_parallel=config.inference.enable_expert_parallel,
             inference_data_parallel_rpc_port=config.inference.data_parallel_rpc_port,
+            weight_broadcast_type=config.orchestrator.weight_broadcast.type,
         )
 
     script_path.parent.mkdir(parents=True, exist_ok=True)
@@ -457,6 +459,8 @@ def rl_slurm(config: RLConfig):
             f"  Orchestrator:  tail -F {slurm_log_dir}/latest_orchestrator.log\n"
             f"  Inference:     tail -F {slurm_log_dir}/latest_infer_node_rank_0.log"
         )
+        if config.inference and config.inference.deployment.type == "disaggregated":
+            log_message += f"\n  Router:        tail -F {slurm_log_dir}/latest_router.log"
 
     script_path = config.output_dir / RL_SBATCH
     write_slurm_script(config, config_dir, script_path)

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -389,11 +389,28 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
             output_dir=config.output_dir,
             gpus_per_node=config.deployment.gpus_per_node,
         )
+    elif config.inference is not None and config.inference.deployment.type == "disaggregated":
+        script = template.render(
+            config_dir=config_dir,
+            job_name=config.slurm.job_name,
+            project_dir=config.slurm.project_dir,
+            partition=config.slurm.partition,
+            output_dir=config.output_dir,
+            orchestrator_output_dir=config.orchestrator.output_dir,
+            num_train_nodes=config.deployment.num_train_nodes,
+            num_prefill_nodes=config.inference.deployment.num_prefill_nodes,
+            num_decode_nodes=config.inference.deployment.num_decode_nodes,
+            gpus_per_node=config.deployment.gpus_per_node,
+            prefill_port=config.inference.deployment.prefill_port,
+            decode_port=config.inference.deployment.decode_port,
+            router_port=config.inference.deployment.router_port,
+            data_parallel_rpc_port=config.inference.data_parallel_rpc_port,
+        )
     else:
         assert config.inference is not None
 
         script = template.render(
-            config_dir=config_dir,  # TODO: should prob have each subconfig path separately
+            config_dir=config_dir,
             job_name=config.slurm.job_name,
             project_dir=config.slurm.project_dir,
             partition=config.slurm.partition,

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -207,12 +207,12 @@ async def init_broadcaster(request: Request):
     host = data.get("host")
     port = data.get("port")
     timeout = data.get("timeout")
-    # Support both legacy and new field names
-    server_rank = data.get("server_rank")
-    num_inference_server = data.get("num_inference_server")
+    rank_offset = data.get("rank_offset")
+    inference_world_size = data.get("inference_world_size")
+    gpus_per_server = data.get("gpus_per_server")
     await engine_client(request).collective_rpc(
         "init_broadcaster",
-        args=(host, port, server_rank, num_inference_server, timeout),
+        args=(host, port, rank_offset, inference_world_size, gpus_per_server, timeout),
     )
     return {"status": "ok"}
 

--- a/src/prime_rl/inference/vllm/worker/nccl.py
+++ b/src/prime_rl/inference/vllm/worker/nccl.py
@@ -118,7 +118,10 @@ class NCCLWeightUpdateWorker(Worker):
     def update_weights_from_path(self, weight_dir: str) -> None:
         """Update weights with the nccl communicator."""
         model_runner = self.model_runner
-        model = model_runner.model.runnable
+        if hasattr(model_runner.model, "runnable"):
+            model = model_runner.model.runnable
+        else:
+            model = model_runner.model
         assert isinstance(model, Module)
 
         state_iter = self.nccl_broadcast_receiver.receive_state_dict()

--- a/src/prime_rl/inference/vllm/worker/nccl.py
+++ b/src/prime_rl/inference/vllm/worker/nccl.py
@@ -86,24 +86,31 @@ class NCCLWeightBroadcastReceiver:
 class NCCLWeightUpdateWorker(Worker):
     """vLLM worker extension for updating weights in-place using NCCL."""
 
-    def init_broadcaster(self, host: str, port: int, server_rank: int, num_inference_server: int, timeout: int) -> None:
+    def init_broadcaster(
+        self, host: str, port: int, rank_offset: int, inference_world_size: int, gpus_per_server: int, timeout: int
+    ) -> None:
         """Initialize the NCCL broadcast receiver."""
         tp_size = get_tp_group().world_size
         tp_rank = get_tp_group().rank_in_group
-        dp_size = get_dp_group().world_size
         dp_rank = get_dp_group().rank_in_group
-        global_rank_inference = (server_rank * tp_size * dp_size) + (dp_rank * tp_size) + tp_rank
-        global_inference_world_size = num_inference_server * tp_size * dp_size
+
+        # dp_rank may be global within a role's DP group (e.g. decode dp_rank 8-15 on node 2).
+        # Use modulo to get the local index within this server.
+        local_dp_size = gpus_per_server // tp_size
+        local_dp_rank = dp_rank % local_dp_size
+        local_rank = local_dp_rank * tp_size + tp_rank
+        global_rank_inference = rank_offset + local_rank
 
         logger.info(
-            f"Worker [tp={tp_rank} dp={dp_rank} server_rank={server_rank}] -> [global_rank={global_rank_inference} global_world_size={global_inference_world_size}]"
+            f"Worker [tp={tp_rank} dp={dp_rank} rank_offset={rank_offset}] -> "
+            f"[global_rank={global_rank_inference} inference_world_size={inference_world_size}]"
         )
 
         self.nccl_broadcast_receiver = NCCLWeightBroadcastReceiver(
             host=host,
             port=port,
             rank=global_rank_inference + 1,  # +1 as the trainer broadcaster is on rank 0
-            world_size=global_inference_world_size + 1,  # +1 as the trainer broadcaster is on rank 0
+            world_size=inference_world_size + 1,  # +1 as the trainer broadcaster is on rank 0
             device=self.device,
             timeout=timeout,
         )

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -489,6 +489,22 @@ async def orchestrate(config: OrchestratorConfig):
         generate_completions_time = scheduler.last_batch_generation_time
         train_rollouts = train_task.result()
 
+        # Debug: log a summary of the first few rollouts
+        for i, r in enumerate(train_rollouts[:3]):
+            traj = r.get("trajectory", [])
+            completion = r.get("completion", "")
+            error = r.get("error")
+            reward = r.get("reward")
+            example_id = r.get("example_id")
+            traj_steps = len(traj)
+            traj_tokens = [len(step.get("tokens", {}).get("completion_ids", [])) if step.get("tokens") else 0 for step in traj] if traj else []
+            completion_preview = completion[:200] if completion else "<empty>"
+            logger.debug(
+                f"Rollout {i}: example_id={example_id} reward={reward} error={error} "
+                f"trajectory_steps={traj_steps} traj_token_lens={traj_tokens} "
+                f"completion_preview={completion_preview!r}"
+            )
+
         # Apply rollout filters (zeros reward/mask for degenerate generations)
         filter_metrics = apply_filters(rollout_filters, train_rollouts)
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -326,6 +326,7 @@ async def orchestrate(config: OrchestratorConfig):
             config.weight_broadcast.host,
             config.weight_broadcast.port,
             config.weight_broadcast.timeout,
+            config.weight_broadcast.inference_world_size,
         )
 
     # Setup training batch sender for sending training examples to trainer

--- a/src/prime_rl/templates/disaggregated_rl.sbatch.j2
+++ b/src/prime_rl/templates/disaggregated_rl.sbatch.j2
@@ -111,10 +111,11 @@ if [ "$NODE_RANK" -lt "$NUM_INFER_NODES" ]; then
     # ── Inference node (prefill or decode) ──
     export VLLM_WORKER_MULTIPROC_METHOD=spawn
     export PYTORCH_CUDA_ALLOC_CONF="expandable_segments:False"
-    export NCCL_NET_PLUGIN=none
-    export NCCL_SOCKET_IFNAME=bond0
     export GLOO_SOCKET_IFNAME=bond0
     export VLLM_ENGINE_READY_TIMEOUT_S=4200
+    export UCX_TLS=all
+    export UCX_NET_DEVICES=all
+    export LD_LIBRARY_PATH="$PROJECT_DIR/third_party/ucx/lib:$PROJECT_DIR/third_party/ucx/lib/ucx:${LD_LIBRARY_PATH:-}"
 
     LOCAL_IP=$(hostname -I | awk "{print \$1}")
     export VLLM_NIXL_SIDE_CHANNEL_HOST=$LOCAL_IP

--- a/src/prime_rl/templates/disaggregated_rl.sbatch.j2
+++ b/src/prime_rl/templates/disaggregated_rl.sbatch.j2
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 #SBATCH --job-name={{ job_name }}
 #SBATCH --nodes={{ num_train_nodes + num_prefill_nodes + num_decode_nodes }}
 #SBATCH --ntasks-per-node=1
@@ -8,6 +7,7 @@
 #SBATCH --exclusive
 #SBATCH --output={{ output_dir }}/job_%j.log
 #SBATCH --error={{ output_dir }}/job_%j.log
+set -euo pipefail
 
 # Configs
 export NUM_PREFILL_NODES={{ num_prefill_nodes }}
@@ -90,7 +90,8 @@ echo "MASTER_PORT=${MASTER_PORT}"
 cd $PROJECT_DIR
 [ -f .env ] && source .env
 source .venv/bin/activate
-uv sync --all-extras
+uv sync --all-extras --inexact
+bash scripts/install_ep_kernels.sh
 
 srun bash -c '
     cd $PROJECT_DIR
@@ -111,6 +112,7 @@ if [ "$NODE_RANK" -lt "$NUM_INFER_NODES" ]; then
     export VLLM_WORKER_MULTIPROC_METHOD=spawn
     export PYTORCH_CUDA_ALLOC_CONF="expandable_segments:False"
     export NCCL_NET_PLUGIN=none
+    export NCCL_SOCKET_IFNAME=bond0
     export GLOO_SOCKET_IFNAME=bond0
     export VLLM_ENGINE_READY_TIMEOUT_S=4200
 
@@ -193,7 +195,9 @@ else
     if [ "$TRAIN_NODE_RANK" -eq 0 ]; then
         uv run orchestrator \
             @ $CONFIG_DIR/orchestrator.toml \
+{%- if weight_broadcast_type == "nccl" %}
             --weight_broadcast.host $MASTER_ADDR \
+{%- endif %}
             --client.base-url $INFER_URLS \
             --client.admin-base-url $ADMIN_INFER_URLS \
             2>&1 | tee $OUTPUT_DIR/slurm/latest_orchestrator.log $OUTPUT_DIR/slurm/job_${SLURM_JOB_ID}_orchestrator.log &

--- a/src/prime_rl/templates/disaggregated_rl.sbatch.j2
+++ b/src/prime_rl/templates/disaggregated_rl.sbatch.j2
@@ -1,0 +1,221 @@
+#!/bin/bash
+
+#SBATCH --job-name={{ job_name }}
+#SBATCH --nodes={{ num_train_nodes + num_prefill_nodes + num_decode_nodes }}
+#SBATCH --ntasks-per-node=1
+#SBATCH --gres=gpu:{{ gpus_per_node }}
+#SBATCH --partition={{ partition }}
+#SBATCH --exclusive
+#SBATCH --output={{ output_dir }}/job_%j.log
+#SBATCH --error={{ output_dir }}/job_%j.log
+
+# Configs
+export NUM_PREFILL_NODES={{ num_prefill_nodes }}
+export NUM_DECODE_NODES={{ num_decode_nodes }}
+export NUM_INFER_NODES=$((NUM_PREFILL_NODES + NUM_DECODE_NODES))
+export NUM_TRAIN_NODES={{ num_train_nodes }}
+export GPUS_PER_NODE={{ gpus_per_node }}
+export PREFILL_PORT={{ prefill_port }}
+export DECODE_PORT={{ decode_port }}
+export ROUTER_PORT={{ router_port }}
+export RPC_PORT={{ data_parallel_rpc_port }}
+export PREFILL_EP=$((NUM_PREFILL_NODES * GPUS_PER_NODE))
+export DECODE_EP=$((NUM_DECODE_NODES * GPUS_PER_NODE))
+
+# Paths
+export PROJECT_DIR={{ project_dir }}
+export CONFIG_DIR={{ config_dir }}
+export OUTPUT_DIR={{ output_dir }}
+export ORCHESTRATOR_OUTPUT_DIR={{ orchestrator_output_dir }}
+mkdir -p $OUTPUT_DIR/slurm
+
+# Clear previous rollouts and broadcast flags
+rm -rf $OUTPUT_DIR/run_*/rollouts
+rm -rf $OUTPUT_DIR/run_*/broadcasts
+rm -rf $OUTPUT_DIR/rollouts
+
+# General
+export CUDA_DEVICE_ORDER=PCI_BUS_ID
+export PYTHONUNBUFFERED=1
+export OMP_NUM_THREADS=1
+
+# Node assignment:
+#   [0, NUM_PREFILL_NODES)                              -> prefill
+#   [NUM_PREFILL_NODES, NUM_PREFILL_NODES+NUM_DECODE)   -> decode
+#   [NUM_INFER_NODES, ...)                              -> training
+HOSTNAMES=( $( scontrol show hostnames $SLURM_JOB_NODELIST ) )
+PREFILL_HOSTS=( ${HOSTNAMES[@]:0:$NUM_PREFILL_NODES} )
+DECODE_HOSTS=( ${HOSTNAMES[@]:$NUM_PREFILL_NODES:$NUM_DECODE_NODES} )
+TRAIN_HOSTS=( ${HOSTNAMES[@]:$NUM_INFER_NODES:$NUM_TRAIN_NODES} )
+export PREFILL_HEAD="${PREFILL_HOSTS[0]}"
+export DECODE_HEAD="${DECODE_HOSTS[0]}"
+export HOSTNAMES_STR="${HOSTNAMES[*]}"
+
+# Router URL for inference requests
+export INFER_URLS="http://${PREFILL_HEAD}:${ROUTER_PORT}/v1"
+
+# Admin URLs for weight updates (every individual inference node)
+ADMIN_URLS=""
+for host in "${PREFILL_HOSTS[@]}"; do
+    ADMIN_URLS="${ADMIN_URLS:+$ADMIN_URLS }http://$host:$PREFILL_PORT/v1"
+done
+for host in "${DECODE_HOSTS[@]}"; do
+    ADMIN_URLS="${ADMIN_URLS:+$ADMIN_URLS }http://$host:$DECODE_PORT/v1"
+done
+export ADMIN_INFER_URLS="$ADMIN_URLS"
+
+# Build vllm-router args: --prefill URL per prefill node, --decode URL per decode node
+ROUTER_BACKEND_ARGS=""
+for host in "${PREFILL_HOSTS[@]}"; do
+    ROUTER_BACKEND_ARGS="$ROUTER_BACKEND_ARGS --prefill http://$host:$PREFILL_PORT"
+done
+for host in "${DECODE_HOSTS[@]}"; do
+    ROUTER_BACKEND_ARGS="$ROUTER_BACKEND_ARGS --decode http://$host:$DECODE_PORT"
+done
+export ROUTER_BACKEND_ARGS
+
+export MASTER_ADDR="${HOSTNAMES[$NUM_INFER_NODES]}"
+export MASTER_PORT=29500
+
+echo "HOSTNAMES=${HOSTNAMES[*]}"
+echo "PREFILL_HOSTS=${PREFILL_HOSTS[*]}"
+echo "DECODE_HOSTS=${DECODE_HOSTS[*]}"
+echo "TRAIN_HOSTS=${TRAIN_HOSTS[*]}"
+echo "INFER_URLS=${INFER_URLS}"
+echo "ADMIN_INFER_URLS=${ADMIN_INFER_URLS}"
+echo "MASTER_ADDR=${MASTER_ADDR}"
+echo "MASTER_PORT=${MASTER_PORT}"
+
+# Setup environment
+cd $PROJECT_DIR
+[ -f .env ] && source .env
+source .venv/bin/activate
+uv sync --all-extras
+
+srun bash -c '
+    cd $PROJECT_DIR
+    [ -f .env ] && source .env
+    source .venv/bin/activate
+
+    ulimit -n 65536
+    export GIT_LFS_SKIP_SMUDGE=1
+
+    # Infiniband setup
+    IB_HCA=$(ibv_devinfo 2>/dev/null | sed -n -e "/hca_id/p" -e "/link_layer:/p" | grep -B1 InfiniBand | grep hca_id | sed -e "s/^hca_id://g" | tr -d "[[:blank:]]" | paste -sd,)
+    [ -n "$IB_HCA" ] && export NCCL_IB_HCA=$IB_HCA
+
+    NODE_RANK=$SLURM_PROCID
+
+if [ "$NODE_RANK" -lt "$NUM_INFER_NODES" ]; then
+    # ── Inference node (prefill or decode) ──
+    export VLLM_WORKER_MULTIPROC_METHOD=spawn
+    export PYTORCH_CUDA_ALLOC_CONF="expandable_segments:False"
+    export NCCL_NET_PLUGIN=none
+    export GLOO_SOCKET_IFNAME=bond0
+    export VLLM_ENGINE_READY_TIMEOUT_S=4200
+
+    LOCAL_IP=$(hostname -I | awk "{print \$1}")
+    export VLLM_NIXL_SIDE_CHANNEL_HOST=$LOCAL_IP
+    export VLLM_NIXL_SIDE_CHANNEL_PORT=5600
+
+    KV_CFG='"'"'{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"num_threads":1}}'"'"'
+    DECODE_COMPILE_CFG='"'"'{"cudagraph_mode":"FULL_DECODE_ONLY"}'"'"'
+
+    if [ "$NODE_RANK" -lt "$NUM_PREFILL_NODES" ]; then
+        # ── Prefill node ──
+        ROLE="prefill"
+        ROLE_RANK=$NODE_RANK
+        EP=$PREFILL_EP
+        PORT=$PREFILL_PORT
+        START_RANK=$((ROLE_RANK * GPUS_PER_NODE))
+        HEAD_HOST=$PREFILL_HEAD
+
+        ROLE_EXTRA="\"all2all_backend\": \"deepep_high_throughput\""
+
+        if [ "$ROLE_RANK" -eq 0 ]; then
+            VLLM_EXTRA="{\"data_parallel_address\": \"$LOCAL_IP\", \"data_parallel_hybrid_lb\": true, \"kv_transfer_config\": $KV_CFG, $ROLE_EXTRA}"
+        else
+            VLLM_EXTRA="{\"data_parallel_address\": \"$HEAD_HOST\", \"data_parallel_start_rank\": $START_RANK, \"data_parallel_hybrid_lb\": true, \"kv_transfer_config\": $KV_CFG, $ROLE_EXTRA}"
+        fi
+    else
+        # ── Decode node ──
+        export UCX_NET_DEVICES=mlx5_0:1
+        ROLE="decode"
+        ROLE_RANK=$((NODE_RANK - NUM_PREFILL_NODES))
+        EP=$DECODE_EP
+        PORT=$DECODE_PORT
+        START_RANK=$((ROLE_RANK * GPUS_PER_NODE))
+        HEAD_HOST=$DECODE_HEAD
+
+        ROLE_EXTRA="\"all2all_backend\": \"deepep_low_latency\", \"compilation_config\": $DECODE_COMPILE_CFG"
+
+        if [ "$ROLE_RANK" -eq 0 ]; then
+            VLLM_EXTRA="{\"data_parallel_address\": \"$LOCAL_IP\", \"data_parallel_hybrid_lb\": true, \"kv_transfer_config\": $KV_CFG, $ROLE_EXTRA}"
+        else
+            VLLM_EXTRA="{\"data_parallel_address\": \"$HEAD_HOST\", \"data_parallel_start_rank\": $START_RANK, \"data_parallel_hybrid_lb\": true, \"kv_transfer_config\": $KV_CFG, $ROLE_EXTRA}"
+        fi
+    fi
+
+    echo "NODE_RANK=$NODE_RANK ROLE=$ROLE ROLE_RANK=$ROLE_RANK EP=$EP PORT=$PORT LOCAL_IP=$LOCAL_IP" \
+        | tee $OUTPUT_DIR/slurm/latest_infer_node_rank_${NODE_RANK}.log \
+              $OUTPUT_DIR/slurm/job_${SLURM_JOB_ID}_infer_node_rank_${NODE_RANK}.log
+
+    # Start vllm-router on prefill head (background)
+    if [ "$NODE_RANK" -eq 0 ]; then
+        ROUTER_LOG="$OUTPUT_DIR/slurm/latest_router.log"
+        echo "Starting vllm-router on $LOCAL_IP:$ROUTER_PORT" | tee $ROUTER_LOG
+
+        vllm-router \
+            --policy round_robin \
+            --vllm-pd-disaggregation \
+            $ROUTER_BACKEND_ARGS \
+            --host 0.0.0.0 \
+            --port $ROUTER_PORT \
+            --intra-node-data-parallel-size 1 \
+            --log-level debug \
+            >> $ROUTER_LOG 2>&1 &
+    fi
+
+    uv run inference \
+        @ $CONFIG_DIR/inference.toml \
+        --server.host 0.0.0.0 \
+        --server.port $PORT \
+        --parallel.dp $EP \
+        --data-parallel-rpc-port $RPC_PORT \
+        --vllm-extra "$VLLM_EXTRA" \
+        2>&1 | tee -a $OUTPUT_DIR/slurm/latest_infer_node_rank_${NODE_RANK}.log \
+                      $OUTPUT_DIR/slurm/job_${SLURM_JOB_ID}_infer_node_rank_${NODE_RANK}.log
+
+else
+    # ── Training node ──
+    TRAIN_NODE_RANK=$((NODE_RANK - NUM_INFER_NODES))
+
+    if [ "$TRAIN_NODE_RANK" -eq 0 ]; then
+        uv run orchestrator \
+            @ $CONFIG_DIR/orchestrator.toml \
+            --weight_broadcast.host $MASTER_ADDR \
+            --client.base-url $INFER_URLS \
+            --client.admin-base-url $ADMIN_INFER_URLS \
+            2>&1 | tee $OUTPUT_DIR/slurm/latest_orchestrator.log $OUTPUT_DIR/slurm/job_${SLURM_JOB_ID}_orchestrator.log &
+    fi
+
+    export HF_HUB_OFFLINE=1
+    export PYTORCH_CUDA_ALLOC_CONF="expandable_segments:True"
+
+    echo $HOSTNAMES_STR | tee $OUTPUT_DIR/slurm/latest_train_node_rank_${TRAIN_NODE_RANK}.log
+
+    uv run torchrun \
+        --nnodes=$NUM_TRAIN_NODES \
+        --nproc-per-node=$GPUS_PER_NODE \
+        --node-rank=$TRAIN_NODE_RANK \
+        --rdzv-endpoint=$MASTER_ADDR:$MASTER_PORT \
+        --rdzv-id=job_$SLURM_JOB_ID \
+        --log-dir=$OUTPUT_DIR/torchrun \
+        --tee=3 \
+        --redirects=3 \
+        --local-ranks-filter=$(seq -s, 0 $((GPUS_PER_NODE - 1))) \
+        -m prime_rl.trainer.rl.train \
+        @ $CONFIG_DIR/trainer.toml \
+        2>&1 | tee -a $OUTPUT_DIR/slurm/latest_train_node_rank_${TRAIN_NODE_RANK}.log $OUTPUT_DIR/slurm/job_${SLURM_JOB_ID}_train_node_rank_${TRAIN_NODE_RANK}.log
+    fi
+'

--- a/src/prime_rl/templates/disaggregated_rl.sbatch.j2
+++ b/src/prime_rl/templates/disaggregated_rl.sbatch.j2
@@ -167,7 +167,7 @@ if [ "$NODE_RANK" -lt "$NUM_INFER_NODES" ]; then
         ROUTER_LOG="$OUTPUT_DIR/slurm/latest_router.log"
         echo "Starting vllm-router on $LOCAL_IP:$ROUTER_PORT" | tee $ROUTER_LOG
 
-        vllm-router \
+        {{ project_dir }}/.venv/bin/vllm-router-rs \
             --policy round_robin \
             --vllm-pd-disaggregation \
             $ROUTER_BACKEND_ARGS \
@@ -193,6 +193,7 @@ else
     TRAIN_NODE_RANK=$((NODE_RANK - NUM_INFER_NODES))
 
     if [ "$TRAIN_NODE_RANK" -eq 0 ]; then
+        export VF_LOG_LEVEL=DEBUG
         uv run orchestrator \
             @ $CONFIG_DIR/orchestrator.toml \
 {%- if weight_broadcast_type == "nccl" %}

--- a/src/prime_rl/templates/inference_disaggregated.sbatch.j2
+++ b/src/prime_rl/templates/inference_disaggregated.sbatch.j2
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 #SBATCH --job-name={{ job_name }}
 #SBATCH --nodes={{ num_prefill_nodes + num_decode_nodes }}
 #SBATCH --ntasks-per-node=1
@@ -8,6 +7,7 @@
 #SBATCH --exclusive
 #SBATCH --output={{ output_dir }}/job_%j.log
 #SBATCH --error={{ output_dir }}/job_%j.log
+set -euo pipefail
 
 # Configs
 export NUM_PREFILL_NODES={{ num_prefill_nodes }}
@@ -35,7 +35,8 @@ export OMP_NUM_THREADS=1
 cd $PROJECT_DIR
 [ -f .env ] && source .env
 source .venv/bin/activate
-uv sync --all-extras
+uv sync --all-extras --inexact
+bash scripts/install_ep_kernels.sh
 
 # Node assignment
 HOSTNAMES=( $( scontrol show hostnames $SLURM_JOB_NODELIST ) )
@@ -76,6 +77,7 @@ srun bash -c '
 
     # Disaggregated env vars
     export NCCL_NET_PLUGIN=none
+    export NCCL_SOCKET_IFNAME=bond0
     export GLOO_SOCKET_IFNAME=bond0
     export VLLM_ENGINE_READY_TIMEOUT_S=4200
 

--- a/src/prime_rl/templates/inference_disaggregated.sbatch.j2
+++ b/src/prime_rl/templates/inference_disaggregated.sbatch.j2
@@ -1,0 +1,156 @@
+#!/bin/bash
+
+#SBATCH --job-name={{ job_name }}
+#SBATCH --nodes={{ num_prefill_nodes + num_decode_nodes }}
+#SBATCH --ntasks-per-node=1
+#SBATCH --gres=gpu:{{ gpus_per_node }}
+#SBATCH --partition={{ partition }}
+#SBATCH --exclusive
+#SBATCH --output={{ output_dir }}/job_%j.log
+#SBATCH --error={{ output_dir }}/job_%j.log
+
+# Configs
+export NUM_PREFILL_NODES={{ num_prefill_nodes }}
+export NUM_DECODE_NODES={{ num_decode_nodes }}
+export GPUS_PER_NODE={{ gpus_per_node }}
+export PREFILL_PORT={{ prefill_port }}
+export DECODE_PORT={{ decode_port }}
+export ROUTER_PORT={{ router_port }}
+export RPC_PORT={{ data_parallel_rpc_port }}
+export PREFILL_EP=$((NUM_PREFILL_NODES * GPUS_PER_NODE))
+export DECODE_EP=$((NUM_DECODE_NODES * GPUS_PER_NODE))
+
+# Paths
+export PROJECT_DIR={{ project_dir }}
+export CONFIG_PATH={{ config_path }}
+export OUTPUT_DIR={{ output_dir }}
+mkdir -p $OUTPUT_DIR/slurm
+
+# General
+export CUDA_DEVICE_ORDER=PCI_BUS_ID
+export PYTHONUNBUFFERED=1
+export OMP_NUM_THREADS=1
+
+# Setup environment
+cd $PROJECT_DIR
+[ -f .env ] && source .env
+source .venv/bin/activate
+uv sync --all-extras
+
+# Node assignment
+HOSTNAMES=( $( scontrol show hostnames $SLURM_JOB_NODELIST ) )
+PREFILL_HOSTS=( ${HOSTNAMES[@]:0:$NUM_PREFILL_NODES} )
+DECODE_HOSTS=( ${HOSTNAMES[@]:$NUM_PREFILL_NODES:$NUM_DECODE_NODES} )
+export PREFILL_HEAD="${PREFILL_HOSTS[0]}"
+export DECODE_HEAD="${DECODE_HOSTS[0]}"
+
+# Build vllm-router args: --prefill URL per prefill node, --decode URL per decode node
+ROUTER_BACKEND_ARGS=""
+for host in "${PREFILL_HOSTS[@]}"; do
+    ROUTER_BACKEND_ARGS="$ROUTER_BACKEND_ARGS --prefill http://$host:$PREFILL_PORT"
+done
+for host in "${DECODE_HOSTS[@]}"; do
+    ROUTER_BACKEND_ARGS="$ROUTER_BACKEND_ARGS --decode http://$host:$DECODE_PORT"
+done
+export ROUTER_BACKEND_ARGS
+
+echo "HOSTNAMES=${HOSTNAMES[*]}"
+echo "PREFILL_HOSTS=${PREFILL_HOSTS[*]}"
+echo "DECODE_HOSTS=${DECODE_HOSTS[*]}"
+
+# Cleanup any leftover vLLM / router processes
+srun bash -c "pkill -9 -f vllm || true; pkill -9 -f vllm-router || true"
+
+srun bash -c '
+    cd $PROJECT_DIR
+    [ -f .env ] && source .env
+    source .venv/bin/activate
+
+    ulimit -n 65536
+    export VLLM_WORKER_MULTIPROC_METHOD=spawn
+    export PYTORCH_CUDA_ALLOC_CONF="expandable_segments:False"
+
+    # Infiniband setup
+    IB_HCA=$(ibv_devinfo 2>/dev/null | sed -n -e "/hca_id/p" -e "/link_layer:/p" | grep -B1 InfiniBand | grep hca_id | sed -e "s/^hca_id://g" | tr -d "[[:blank:]]" | paste -sd,)
+    [ -n "$IB_HCA" ] && export NCCL_IB_HCA=$IB_HCA
+
+    # Disaggregated env vars
+    export NCCL_NET_PLUGIN=none
+    export GLOO_SOCKET_IFNAME=bond0
+    export VLLM_ENGINE_READY_TIMEOUT_S=4200
+
+    LOCAL_IP=$(hostname -I | awk "{print \$1}")
+    export VLLM_NIXL_SIDE_CHANNEL_HOST=$LOCAL_IP
+    export VLLM_NIXL_SIDE_CHANNEL_PORT=5600
+
+    NODE_RANK=$SLURM_PROCID
+    CONFIG_DIR=$(dirname $CONFIG_PATH)
+
+    KV_CFG='"'"'{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"num_threads":1}}'"'"'
+    DECODE_COMPILE_CFG='"'"'{"cudagraph_mode":"FULL_DECODE_ONLY"}'"'"'
+
+    if [ "$NODE_RANK" -lt "$NUM_PREFILL_NODES" ]; then
+        # ── Prefill node ──
+        ROLE="prefill"
+        ROLE_RANK=$NODE_RANK
+        EP=$PREFILL_EP
+        PORT=$PREFILL_PORT
+        START_RANK=$((ROLE_RANK * GPUS_PER_NODE))
+        HEAD_HOST=$PREFILL_HEAD
+
+        ROLE_EXTRA="\"all2all_backend\": \"deepep_high_throughput\""
+
+        if [ "$ROLE_RANK" -eq 0 ]; then
+            VLLM_EXTRA="{\"data_parallel_address\": \"$LOCAL_IP\", \"data_parallel_hybrid_lb\": true, \"kv_transfer_config\": $KV_CFG, $ROLE_EXTRA}"
+        else
+            VLLM_EXTRA="{\"data_parallel_address\": \"$HEAD_HOST\", \"data_parallel_start_rank\": $START_RANK, \"data_parallel_hybrid_lb\": true, \"kv_transfer_config\": $KV_CFG, $ROLE_EXTRA}"
+        fi
+    else
+        # ── Decode node ──
+        export UCX_NET_DEVICES=mlx5_0:1
+        ROLE="decode"
+        ROLE_RANK=$((NODE_RANK - NUM_PREFILL_NODES))
+        EP=$DECODE_EP
+        PORT=$DECODE_PORT
+        START_RANK=$((ROLE_RANK * GPUS_PER_NODE))
+        HEAD_HOST=$DECODE_HEAD
+
+        ROLE_EXTRA="\"all2all_backend\": \"deepep_low_latency\", \"compilation_config\": $DECODE_COMPILE_CFG"
+
+        if [ "$ROLE_RANK" -eq 0 ]; then
+            VLLM_EXTRA="{\"data_parallel_address\": \"$LOCAL_IP\", \"data_parallel_hybrid_lb\": true, \"kv_transfer_config\": $KV_CFG, $ROLE_EXTRA}"
+        else
+            VLLM_EXTRA="{\"data_parallel_address\": \"$HEAD_HOST\", \"data_parallel_start_rank\": $START_RANK, \"data_parallel_hybrid_lb\": true, \"kv_transfer_config\": $KV_CFG, $ROLE_EXTRA}"
+        fi
+    fi
+
+    echo "NODE_RANK=$NODE_RANK ROLE=$ROLE ROLE_RANK=$ROLE_RANK EP=$EP PORT=$PORT LOCAL_IP=$LOCAL_IP" \
+        | tee $OUTPUT_DIR/slurm/latest_infer_node_rank_${NODE_RANK}.log \
+              $OUTPUT_DIR/slurm/job_${SLURM_JOB_ID}_infer_node_rank_${NODE_RANK}.log
+
+    # Start vllm-router on prefill head (background)
+    if [ "$NODE_RANK" -eq 0 ]; then
+        ROUTER_LOG="$OUTPUT_DIR/slurm/latest_router.log"
+        echo "Starting vllm-router on $LOCAL_IP:$ROUTER_PORT" | tee $ROUTER_LOG
+
+        vllm-router \
+            --policy round_robin \
+            --vllm-pd-disaggregation \
+            $ROUTER_BACKEND_ARGS \
+            --host 0.0.0.0 \
+            --port $ROUTER_PORT \
+            --intra-node-data-parallel-size 1 \
+            --log-level debug \
+            >> $ROUTER_LOG 2>&1 &
+    fi
+
+    uv run inference \
+        @ $CONFIG_PATH \
+        --server.host 0.0.0.0 \
+        --server.port $PORT \
+        --parallel.dp $EP \
+        --data-parallel-rpc-port $RPC_PORT \
+        --vllm-extra "$VLLM_EXTRA" \
+        2>&1 | tee -a $OUTPUT_DIR/slurm/latest_infer_node_rank_${NODE_RANK}.log \
+                      $OUTPUT_DIR/slurm/job_${SLURM_JOB_ID}_infer_node_rank_${NODE_RANK}.log
+'

--- a/src/prime_rl/templates/inference_disaggregated.sbatch.j2
+++ b/src/prime_rl/templates/inference_disaggregated.sbatch.j2
@@ -135,7 +135,7 @@ srun bash -c '
         ROUTER_LOG="$OUTPUT_DIR/slurm/latest_router.log"
         echo "Starting vllm-router on $LOCAL_IP:$ROUTER_PORT" | tee $ROUTER_LOG
 
-        vllm-router \
+        {{ project_dir }}/.venv/bin/vllm-router-rs \
             --policy round_robin \
             --vllm-pd-disaggregation \
             $ROUTER_BACKEND_ARGS \

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -130,7 +130,9 @@ else
     if [ "$TRAIN_NODE_RANK" -eq 0 ]; then
         uv run orchestrator \
             @ $CONFIG_DIR/orchestrator.toml \
+{%- if weight_broadcast_type == "nccl" %}
             --weight_broadcast.host $MASTER_ADDR \
+{%- endif %}
             --client.base-url $INFER_URLS \
             2>&1 | tee $OUTPUT_DIR/slurm/latest_orchestrator.log $OUTPUT_DIR/slurm/job_${SLURM_JOB_ID}_orchestrator.log &
     fi

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -136,18 +136,20 @@ def setup_clients(client_config: ClientConfig, client_type: str = "openai_chat_c
 
 
 def setup_admin_clients(client_config: ClientConfig) -> list[AsyncClient]:
-    """Create a dedicated admin client for weight update operations.
+    """Create dedicated admin clients for weight update operations.
 
     Uses a separate connection pool to avoid queueing behind streaming requests.
+    When admin_base_url is set, uses those URLs instead of base_url (useful for
+    disaggregated inference where weight updates bypass the router).
     """
+    urls = client_config.admin_base_url or client_config.base_url
 
     def _setup_admin_client(base_url: str) -> httpx.AsyncClient:
-        headers = client_config.headers.copy()  # avoid mutating config
+        headers = client_config.headers.copy()
         api_key = os.getenv(client_config.api_key_var, "EMPTY")
         if api_key and api_key != "EMPTY":
             headers["Authorization"] = f"Bearer {api_key}"
 
-        # Strip /v1 suffix since admin endpoints are at root level
         base_url = base_url.rstrip("/").removesuffix("/v1")
 
         return AsyncClient(
@@ -157,7 +159,7 @@ def setup_admin_clients(client_config: ClientConfig) -> list[AsyncClient]:
             timeout=httpx.Timeout(None),
         )
 
-    return [_setup_admin_client(base_url) for base_url in client_config.base_url]
+    return [_setup_admin_client(base_url) for base_url in urls]
 
 
 async def maybe_check_has_model(

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -303,12 +303,15 @@ async def unload_lora_adapter(admin_clients: list[AsyncClient], lora_name: str) 
     await asyncio.gather(*[_unload_lora_adapter(admin_client) for admin_client in admin_clients])
 
 
-async def init_nccl_broadcast(admin_clients: list[AsyncClient], host: str, port: int, timeout: int) -> None:
+async def init_nccl_broadcast(
+    admin_clients: list[AsyncClient], host: str, port: int, timeout: int, inference_world_size: int
+) -> None:
     """Make a HTTP post request to the vLLM server to initialize the NCCL broadcast."""
     logger = get_logger()
+    gpus_per_server = inference_world_size // len(admin_clients)
 
     async def _init_nccl_broadcast(
-        admin_client: AsyncClient, host: str, port: int, client_num: int, timeout: int
+        admin_client: AsyncClient, host: str, port: int, rank_offset: int, timeout: int
     ) -> None:
         try:
             response = await admin_client.post(
@@ -316,8 +319,9 @@ async def init_nccl_broadcast(admin_clients: list[AsyncClient], host: str, port:
                 json={
                     "host": host,
                     "port": port,
-                    "server_rank": client_num,
-                    "num_inference_server": len(admin_clients),
+                    "rank_offset": rank_offset,
+                    "inference_world_size": inference_world_size,
+                    "gpus_per_server": gpus_per_server,
                     "timeout": timeout,
                 },
             )
@@ -329,7 +333,7 @@ async def init_nccl_broadcast(admin_clients: list[AsyncClient], host: str, port:
 
     await asyncio.gather(
         *[
-            _init_nccl_broadcast(admin_client, host, port, client_num, timeout)
+            _init_nccl_broadcast(admin_client, host, port, client_num * gpus_per_server, timeout)
             for client_num, admin_client in enumerate(admin_clients)
         ]
     )

--- a/uv.lock
+++ b/uv.lock
@@ -615,7 +615,7 @@ dependencies = [
     { name = "numpy" },
     { name = "torch" },
     { name = "triton", version = "3.3.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
-    { name = "triton", version = "3.6.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "triton", version = "3.5.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -781,14 +781,14 @@ wheels = [
 
 [[package]]
 name = "flash-attn"
-version = "2.8.3+cu128torch2.10"
-source = { url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.7.16/flash_attn-2.8.3+cu128torch2.10-cp312-cp312-linux_x86_64.whl" }
+version = "2.8.3+cu128torch2.9"
+source = { url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.6.8/flash_attn-2.8.3+cu128torch2.9-cp312-cp312-linux_x86_64.whl" }
 dependencies = [
     { name = "einops" },
     { name = "torch" },
 ]
 wheels = [
-    { url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.7.16/flash_attn-2.8.3+cu128torch2.10-cp312-cp312-linux_x86_64.whl", hash = "sha256:5ef676dfd01d198eed36795d924eb6af4c87674896de6bd102390afa7f522bc0" },
+    { url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.6.8/flash_attn-2.8.3+cu128torch2.9-cp312-cp312-linux_x86_64.whl", hash = "sha256:95c7c64416c1be3f3f6d17468e49c343a716d1df681f30fb10148a1441339401" },
 ]
 
 [package.metadata]
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "flashinfer-python"
-version = "0.6.4"
+version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apache-tvm-ffi" },
@@ -852,9 +852,9 @@ dependencies = [
     { name = "torch" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/45/15645d2a4ee81d08206f3e132a77323e48312f510462415d7cd1122eba43/flashinfer_python-0.6.4.tar.gz", hash = "sha256:e6ab798bd1030e5ff7a3bc6952f36386c406928f60b79cf964a6db7aa7ccde75", size = 5337134, upload-time = "2026-02-19T07:33:36.647Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/aa/c564313b42dee7573da4ed0e441844f0c2bd827aecc9f29ea02c3838ffae/flashinfer_python-0.6.3.tar.gz", hash = "sha256:84a762538247a86bc52ff31d9505d161ce1ec059174c1821c87c3ed1e44670fc", size = 5181963, upload-time = "2026-02-06T00:28:23.294Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/9a/d2bab76d2bb15062c6a2329614653e4f8bec9c78eec9069856ef0c7c0a79/flashinfer_python-0.6.4-py3-none-any.whl", hash = "sha256:105596b505892ae330af84e250ee0eb6fc2c3a22e8dc42bd46de1b90d36004c8", size = 7819999, upload-time = "2026-02-19T07:33:34.82Z" },
+    { url = "https://files.pythonhosted.org/packages/33/13/2d95248101d8cb978db9000a4dceafb5b122484a694b53e84df1ac2a7b3d/flashinfer_python-0.6.3-py3-none-any.whl", hash = "sha256:0fe2de934a4b3690c543dafb03f38d7bb4a762431abe8ae4f7292d6fef10c65d", size = 7636254, upload-time = "2026-02-06T00:28:21.234Z" },
 ]
 
 [[package]]
@@ -942,18 +942,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9a/c8/dd58967d119baab745caec2f9d853297cec1989ec1d63f677d3880632b88/gitpython-3.1.45.tar.gz", hash = "sha256:85b0ee964ceddf211c41b9f27a49086010a190fd8132a24e21f362a4b36a791c", size = 215076, upload-time = "2025-07-24T03:45:54.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/01/61/d4b89fec821f72385526e1b9d9a3a0385dda4a72b206d28049e2c7cd39b8/gitpython-3.1.45-py3-none-any.whl", hash = "sha256:8908cb2e02fb3b93b7eb0f2827125cb699869470432cc885f019b8fd0fccff77", size = 208168, upload-time = "2025-07-24T03:45:52.517Z" },
-]
-
-[[package]]
-name = "googleapis-common-protos"
-version = "1.72.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "protobuf" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/7b/adfd75544c415c487b33061fe7ae526165241c1ea133f9a9125a56b39fd8/googleapis_common_protos-1.72.0.tar.gz", hash = "sha256:e55a601c1b32b52d7a3e65f43563e2aa61bcd737998ee672ac9b951cd49319f5", size = 147433, upload-time = "2025-11-06T18:29:24.087Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/ab/09169d5a4612a5f92490806649ac8d41e3ec9129c636754575b3553f4ea4/googleapis_common_protos-1.72.0-py3-none-any.whl", hash = "sha256:4299c5a82d5ae1a9702ada957347726b167f9f8d1fc352477702a1e851ff4038", size = 297515, upload-time = "2025-11-06T18:29:13.14Z" },
 ]
 
 [[package]]
@@ -1399,7 +1387,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "torch" },
     { name = "triton", version = "3.3.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
-    { name = "triton", version = "3.6.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "triton", version = "3.5.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/31/23/be0b4dcac42d77f99406c906567cde22a7a3d71b3f3ffdfda2ac6153ec36/liger_kernel-0.6.2.tar.gz", hash = "sha256:5c5bcffffa769bc26ae838f5a4954170dd5cacde036abb1b383039f39fa5fd69", size = 3679495, upload-time = "2025-08-22T00:15:28.456Z" }
 wheels = [
@@ -2076,11 +2064,11 @@ wheels = [
 
 [[package]]
 name = "nvidia-nvshmem-cu12"
-version = "3.4.5"
+version = "3.3.20"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/6a/03aa43cc9bd3ad91553a88b5f6fb25ed6a3752ae86ce2180221962bc2aa5/nvidia_nvshmem_cu12-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0b48363fc6964dede448029434c6abed6c5e37f823cb43c3bcde7ecfc0457e15", size = 138936938, upload-time = "2025-09-06T00:32:05.589Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/09/6ea3ea725f82e1e76684f0708bbedd871fc96da89945adeba65c3835a64c/nvidia_nvshmem_cu12-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:042f2500f24c021db8a06c5eec2539027d57460e1c1a762055a6554f72c369bd", size = 139103095, upload-time = "2025-09-06T00:32:31.266Z" },
+    { url = "https://files.pythonhosted.org/packages/92/9d/3dd98852568fb845ec1f7902c90a22b240fe1cbabda411ccedf2fd737b7b/nvidia_nvshmem_cu12-3.3.20-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0b0b960da3842212758e4fa4696b94f129090b30e5122fea3c5345916545cff0", size = 124484616, upload-time = "2025-08-04T20:24:59.172Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/6c/99acb2f9eb85c29fc6f3a7ac4dccfd992e22666dd08a642b303311326a97/nvidia_nvshmem_cu12-3.3.20-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d00f26d3f9b2e3c3065be895e3059d6479ea5c638a3f38c9fec49b1b9dd7c1e5", size = 124657145, upload-time = "2025-08-04T20:25:19.995Z" },
 ]
 
 [[package]]
@@ -2185,79 +2173,6 @@ wheels = [
 ]
 
 [[package]]
-name = "opentelemetry-exporter-otlp"
-version = "1.36.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-exporter-otlp-proto-grpc" },
-    { name = "opentelemetry-exporter-otlp-proto-http" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/95/7f/d31294ac28d567a14aefd855756bab79fed69c5a75df712f228f10c47e04/opentelemetry_exporter_otlp-1.36.0.tar.gz", hash = "sha256:72f166ea5a8923ac42889337f903e93af57db8893de200369b07401e98e4e06b", size = 6144, upload-time = "2025-07-29T15:12:07.153Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/a2/8966111a285124f3d6156a663ddf2aeddd52843c1a3d6b56cbd9b6c3fd0e/opentelemetry_exporter_otlp-1.36.0-py3-none-any.whl", hash = "sha256:de93b7c45bcc78296998775d52add7c63729e83ef2cd6560730a6b336d7f6494", size = 7018, upload-time = "2025-07-29T15:11:50.498Z" },
-]
-
-[[package]]
-name = "opentelemetry-exporter-otlp-proto-common"
-version = "1.36.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-proto" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/34/da/7747e57eb341c59886052d733072bc878424bf20f1d8cf203d508bbece5b/opentelemetry_exporter_otlp_proto_common-1.36.0.tar.gz", hash = "sha256:6c496ccbcbe26b04653cecadd92f73659b814c6e3579af157d8716e5f9f25cbf", size = 20302, upload-time = "2025-07-29T15:12:07.71Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/ed/22290dca7db78eb32e0101738366b5bbda00d0407f00feffb9bf8c3fdf87/opentelemetry_exporter_otlp_proto_common-1.36.0-py3-none-any.whl", hash = "sha256:0fc002a6ed63eac235ada9aa7056e5492e9a71728214a61745f6ad04b923f840", size = 18349, upload-time = "2025-07-29T15:11:51.327Z" },
-]
-
-[[package]]
-name = "opentelemetry-exporter-otlp-proto-grpc"
-version = "1.36.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "googleapis-common-protos" },
-    { name = "grpcio" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp-proto-common" },
-    { name = "opentelemetry-proto" },
-    { name = "opentelemetry-sdk" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/72/6f/6c1b0bdd0446e5532294d1d41bf11fbaea39c8a2423a4cdfe4fe6b708127/opentelemetry_exporter_otlp_proto_grpc-1.36.0.tar.gz", hash = "sha256:b281afbf7036b325b3588b5b6c8bb175069e3978d1bd24071f4a59d04c1e5bbf", size = 23822, upload-time = "2025-07-29T15:12:08.292Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/67/5f6bd188d66d0fd8e81e681bbf5822e53eb150034e2611dd2b935d3ab61a/opentelemetry_exporter_otlp_proto_grpc-1.36.0-py3-none-any.whl", hash = "sha256:734e841fc6a5d6f30e7be4d8053adb703c70ca80c562ae24e8083a28fadef211", size = 18828, upload-time = "2025-07-29T15:11:52.235Z" },
-]
-
-[[package]]
-name = "opentelemetry-exporter-otlp-proto-http"
-version = "1.36.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "googleapis-common-protos" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp-proto-common" },
-    { name = "opentelemetry-proto" },
-    { name = "opentelemetry-sdk" },
-    { name = "requests" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/25/85/6632e7e5700ba1ce5b8a065315f92c1e6d787ccc4fb2bdab15139eaefc82/opentelemetry_exporter_otlp_proto_http-1.36.0.tar.gz", hash = "sha256:dd3637f72f774b9fc9608ab1ac479f8b44d09b6fb5b2f3df68a24ad1da7d356e", size = 16213, upload-time = "2025-07-29T15:12:08.932Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/41/a680d38b34f8f5ddbd78ed9f0042e1cc712d58ec7531924d71cb1e6c629d/opentelemetry_exporter_otlp_proto_http-1.36.0-py3-none-any.whl", hash = "sha256:3d769f68e2267e7abe4527f70deb6f598f40be3ea34c6adc35789bea94a32902", size = 18752, upload-time = "2025-07-29T15:11:53.164Z" },
-]
-
-[[package]]
-name = "opentelemetry-proto"
-version = "1.36.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "protobuf" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/02/f6556142301d136e3b7e95ab8ea6a5d9dc28d879a99f3dd673b5f97dca06/opentelemetry_proto-1.36.0.tar.gz", hash = "sha256:0f10b3c72f74c91e0764a5ec88fd8f1c368ea5d9c64639fb455e2854ef87dd2f", size = 46152, upload-time = "2025-07-29T15:12:15.717Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/57/3361e06136225be8180e879199caea520f38026f8071366241ac458beb8d/opentelemetry_proto-1.36.0-py3-none-any.whl", hash = "sha256:151b3bf73a09f94afc658497cf77d45a565606f62ce0c17acb08cd9937ca206e", size = 72537, upload-time = "2025-07-29T15:12:02.243Z" },
-]
-
-[[package]]
 name = "opentelemetry-sdk"
 version = "1.36.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2282,15 +2197,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7e/31/67dfa252ee88476a29200b0255bda8dfc2cf07b56ad66dc9a6221f7dc787/opentelemetry_semantic_conventions-0.57b0.tar.gz", hash = "sha256:609a4a79c7891b4620d64c7aac6898f872d790d75f22019913a660756f27ff32", size = 124225, upload-time = "2025-07-29T15:12:17.873Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/05/75/7d591371c6c39c73de5ce5da5a2cc7b72d1d1cd3f8f4638f553c01c37b11/opentelemetry_semantic_conventions-0.57b0-py3-none-any.whl", hash = "sha256:757f7e76293294f124c827e514c2a3144f191ef175b069ce8d1211e1e38e9e78", size = 201627, upload-time = "2025-07-29T15:12:04.174Z" },
-]
-
-[[package]]
-name = "opentelemetry-semantic-conventions-ai"
-version = "0.4.13"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ba/e6/40b59eda51ac47009fb47afcdf37c6938594a0bd7f3b9fadcbc6058248e3/opentelemetry_semantic_conventions_ai-0.4.13.tar.gz", hash = "sha256:94efa9fb4ffac18c45f54a3a338ffeb7eedb7e1bb4d147786e77202e159f0036", size = 5368, upload-time = "2025-08-22T10:14:17.387Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/b5/cf25da2218910f0d6cdf7f876a06bed118c4969eacaf60a887cbaef44f44/opentelemetry_semantic_conventions_ai-0.4.13-py3-none-any.whl", hash = "sha256:883a30a6bb5deaec0d646912b5f9f6dcbb9f6f72557b73d0f2560bf25d13e2d5", size = 6080, upload-time = "2025-08-22T10:14:16.477Z" },
 ]
 
 [[package]]
@@ -2548,7 +2454,7 @@ requires-dist = [
     { name = "beartype", specifier = ">=0.21.0" },
     { name = "datasets", specifier = ">=4.0.0" },
     { name = "dion", git = "https://github.com/samsja/dion.git?rev=d891eeb" },
-    { name = "flash-attn", marker = "extra == 'flash-attn'", url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.7.16/flash_attn-2.8.3+cu128torch2.10-cp312-cp312-linux_x86_64.whl" },
+    { name = "flash-attn", marker = "extra == 'flash-attn'", url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.6.8/flash_attn-2.8.3+cu128torch2.9-cp312-cp312-linux_x86_64.whl" },
     { name = "flash-attn-3", marker = "extra == 'flash-attn-3'", url = "https://github.com/samsja/flash-attn-builds/releases/download/v0.1/flash_attn_3-3.0.0b1-cp39-abi3-linux_x86_64.whl" },
     { name = "flash-attn-cute", marker = "extra == 'flash-attn-cute'", git = "https://github.com/Dao-AILab/flash-attention.git?subdirectory=flash_attn%2Fcute&rev=main" },
     { name = "jaxtyping", specifier = ">=0.3.2" },
@@ -2570,13 +2476,13 @@ requires-dist = [
     { name = "tilelang", specifier = ">=0.1.8" },
     { name = "tomli", specifier = ">=2.2.1" },
     { name = "tomli-w", specifier = ">=1.2.0" },
-    { name = "torch", specifier = ">=2.9.0", index = "https://download.pytorch.org/whl/cu128" },
+    { name = "torch", specifier = ">=2.9.0", index = "https://download.pytorch.org/whl/test/cu128" },
     { name = "torchdata", specifier = ">=0.11.0" },
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", git = "https://github.com/huggingface/transformers.git?rev=5c1c72b" },
     { name = "uvloop", specifier = ">=0.21.0" },
     { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=45fae8d" },
-    { name = "vllm", url = "https://wheels.vllm.ai/7eca85911072b9732293c3d4181e20a4c9394b21/vllm-0.16.1rc1.dev246%2Bg7eca85911-cp38-abi3-manylinux_2_31_x86_64.whl" },
+    { name = "vllm", specifier = ">=0.16.0" },
     { name = "vllm-router" },
     { name = "wandb", specifier = ">=0.24.2" },
 ]
@@ -3604,10 +3510,9 @@ wheels = [
 
 [[package]]
 name = "torch"
-version = "2.10.0+cu128"
-source = { registry = "https://download.pytorch.org/whl/cu128" }
+version = "2.9.1+cu128"
+source = { registry = "https://download.pytorch.org/whl/test/cu128" }
 dependencies = [
-    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
     { name = "filelock" },
     { name = "fsspec" },
     { name = "jinja2" },
@@ -3629,13 +3534,13 @@ dependencies = [
     { name = "nvidia-nvtx-cu12", marker = "sys_platform == 'linux'" },
     { name = "setuptools" },
     { name = "sympy" },
-    { name = "triton", version = "3.6.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "triton", version = "3.5.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6f09cdf2415516be028ae82e6b985bcfc3eac37bc52ab401142689f6224516ca" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:628e89bd5110ced7debee2a57c69959725b7fbc64eab81a39dd70e46c7e28ba5" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-win_amd64.whl", hash = "sha256:fbde8f6a9ec8c76979a0d14df21c10b9e5cab6f0d106a73ca73e2179bc597cae" },
+    { url = "https://download.pytorch.org/whl/test/cu128/torch-2.9.1%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1176f250311fa95cc3bca8077af323e0d73ea385ba266e096af82e7e2b91f256" },
+    { url = "https://download.pytorch.org/whl/test/cu128/torch-2.9.1%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:7cb4018f4ce68b61fd3ef87dc1c4ca520731c7b5b200e360ad47b612d7844063" },
+    { url = "https://download.pytorch.org/whl/test/cu128/torch-2.9.1%2Bcu128-cp312-cp312-win_amd64.whl", hash = "sha256:3a01f0b64c10a82d444d9fd06b3e8c567b1158b76b2764b8f51bfd8f535064b0" },
 ]
 
 [[package]]
@@ -3655,16 +3560,16 @@ wheels = [
 
 [[package]]
 name = "torchaudio"
-version = "2.10.0"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "torch" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/36/28a6f3e857616cf7576bdbf8170e483b8c5d0a1f8d349ecb2b75921236aa/torchaudio-2.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9d0fbdbfd2f621c51d28571050d6d0c7287791034e5c7303b31480af1258f33f", size = 737144, upload-time = "2026-01-21T16:28:44.189Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/3f/df620439a76ece170472d41438d11a1545d5db5dc9f1eaeab8c6e055a328/torchaudio-2.10.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:42b148a0921a3721abd1f6ae098b1ec9f89703e555c4f7a0d44da87b8decbcb9", size = 391973, upload-time = "2026-01-21T16:28:39.732Z" },
-    { url = "https://files.pythonhosted.org/packages/98/25/e55a30d7138f8fe56ed006df25b0a3c27681f0ec7bc9989e1778e6d559c3/torchaudio-2.10.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:0e77b2956448d63790a99beed0b74ac8b8cd3a94dcdd9ad01974411078f46278", size = 1895234, upload-time = "2026-01-21T16:28:37.034Z" },
-    { url = "https://files.pythonhosted.org/packages/be/a0/da53c7d20fac15f66f8838653b91162de1bf21fb40fee88cf839e4ef5174/torchaudio-2.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f76a01ecebf1869e1f2c50a261f1cf07e5fccb24402b4e9bbb82d6725b9c7dd", size = 475470, upload-time = "2026-01-21T16:28:40.615Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/83/71cbadd7b66753818b5775f2088bad4f721d581de276996df4968000a626/torchaudio-2.9.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7581ef170794c599aed55918e00d0acd9e5c9a0f19400c9a9a840955180365c5", size = 808098, upload-time = "2025-11-12T15:26:01.408Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/2d/32e8bec360459107f9b451cc1a5b6fdd5f1d3e653e65a111502084f21e3a/torchaudio-2.9.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:742f9d24db5f1f46d8c7e29c599fe55b866d92c4a8181fcb95eab12da225ceb0", size = 474604, upload-time = "2025-11-12T15:25:49.122Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/0d/b5af1d55ede1ca07769a2cf71256073d8958e2a5521fc734fc19f5343283/torchaudio-2.9.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4533fdafba73d7bcfcb5f1225b2cc8974a290ed0fe54c44638d6f440e91b8999", size = 2059899, upload-time = "2025-11-12T15:26:19.363Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/7c/df90eb0b337cbad59296ed91778e32be069330f5186256d4ce9ea603d324/torchaudio-2.9.1-cp312-cp312-win_amd64.whl", hash = "sha256:923dccc67be4a6cbb45c3dcc2d69ee182bda75b09b69bc88cd3bcdfc739883a2", size = 665337, upload-time = "2025-11-12T15:26:07.407Z" },
 ]
 
 [[package]]
@@ -3696,7 +3601,7 @@ dependencies = [
 
 [[package]]
 name = "torchvision"
-version = "0.25.0"
+version = "0.24.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
@@ -3704,10 +3609,10 @@ dependencies = [
     { name = "torch" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/3a/6ea0d73f49a9bef38a1b3a92e8dd455cea58470985d25635beab93841748/torchvision-0.25.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c2abe430c90b1d5e552680037d68da4eb80a5852ebb1c811b2b89d299b10573b", size = 1874920, upload-time = "2026-01-21T16:27:45.348Z" },
-    { url = "https://files.pythonhosted.org/packages/51/f8/c0e1ef27c66e15406fece94930e7d6feee4cb6374bbc02d945a630d6426e/torchvision-0.25.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:b75deafa2dfea3e2c2a525559b04783515e3463f6e830cb71de0fb7ea36fe233", size = 2344556, upload-time = "2026-01-21T16:27:40.125Z" },
-    { url = "https://files.pythonhosted.org/packages/68/2f/f24b039169db474e8688f649377de082a965fbf85daf4e46c44412f1d15a/torchvision-0.25.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:f25aa9e380865b11ea6e9d99d84df86b9cc959f1a007cd966fc6f1ab2ed0e248", size = 8072351, upload-time = "2026-01-21T16:27:21.074Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/16/8f650c2e288977cf0f8f85184b90ee56ed170a4919347fc74ee99286ed6f/torchvision-0.25.0-cp312-cp312-win_amd64.whl", hash = "sha256:f9c55ae8d673ab493325d1267cbd285bb94d56f99626c00ac4644de32a59ede3", size = 4303059, upload-time = "2026-01-21T16:27:11.08Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/af/18e2c6b9538a045f60718a0c5a058908ccb24f88fde8e6f0fc12d5ff7bd3/torchvision-0.24.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e48bf6a8ec95872eb45763f06499f87bd2fb246b9b96cb00aae260fda2f96193", size = 1891433, upload-time = "2025-11-12T15:25:03.232Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/43/600e5cfb0643d10d633124f5982d7abc2170dfd7ce985584ff16edab3e76/torchvision-0.24.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:7fb7590c737ebe3e1c077ad60c0e5e2e56bb26e7bccc3b9d04dbfc34fd09f050", size = 2386737, upload-time = "2025-11-12T15:25:08.288Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b1/db2941526ecddd84884132e2742a55c9311296a6a38627f9e2627f5ac889/torchvision-0.24.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:66a98471fc18cad9064123106d810a75f57f0838eee20edc56233fd8484b0cc7", size = 8049868, upload-time = "2025-11-12T15:25:13.058Z" },
+    { url = "https://files.pythonhosted.org/packages/69/98/16e583f59f86cd59949f59d52bfa8fc286f86341a229a9d15cbe7a694f0c/torchvision-0.24.1-cp312-cp312-win_amd64.whl", hash = "sha256:4aa6cb806eb8541e92c9b313e96192c6b826e9eb0042720e2fa250d021079952", size = 4302006, upload-time = "2025-11-12T15:25:16.184Z" },
 ]
 
 [[package]]
@@ -3780,15 +3685,15 @@ dependencies = [
 
 [[package]]
 name = "triton"
-version = "3.6.0"
+version = "3.5.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "(platform_machine != 'x86_64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux')",
     "platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/5d/08201db32823bdf77a0e2b9039540080b2e5c23a20706ddba942924ebcd6/triton-3.6.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:374f52c11a711fd062b4bfbb201fd9ac0a5febd28a96fb41b4a0f51dde3157f4", size = 176128243, upload-time = "2026-01-20T16:16:07.857Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/a8/cdf8b3e4c98132f965f88c2313a4b493266832ad47fb52f23d14d4f86bb5/triton-3.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74caf5e34b66d9f3a429af689c1c7128daba1d8208df60e81106b115c00d6fca", size = 188266850, upload-time = "2026-01-20T16:00:43.041Z" },
+    { url = "https://files.pythonhosted.org/packages/db/53/2bcc46879910991f09c063eea07627baef2bc62fe725302ba8f46a2c1ae5/triton-3.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:275a045b6ed670dd1bd005c3e6c2d61846c74c66f4512d6f33cc027b11de8fd4", size = 159940689, upload-time = "2025-11-11T17:51:55.938Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/50/9a8358d3ef58162c0a415d173cfb45b67de60176e1024f71fbc4d24c0b6d/triton-3.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d2c6b915a03888ab931a9fd3e55ba36785e1fe70cbea0b40c6ef93b20fc85232", size = 170470207, upload-time = "2025-11-11T17:41:00.253Z" },
 ]
 
 [[package]]
@@ -3985,8 +3890,8 @@ wheels = [
 
 [[package]]
 name = "vllm"
-version = "0.16.1rc1.dev246+g7eca85911"
-source = { url = "https://wheels.vllm.ai/7eca85911072b9732293c3d4181e20a4c9394b21/vllm-0.16.1rc1.dev246%2Bg7eca85911-cp38-abi3-manylinux_2_31_x86_64.whl" }
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "anthropic" },
@@ -4015,14 +3920,9 @@ dependencies = [
     { name = "ninja" },
     { name = "numba" },
     { name = "numpy" },
-    { name = "nvidia-cutlass-dsl" },
     { name = "openai" },
     { name = "openai-harmony" },
     { name = "opencv-python-headless" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp" },
-    { name = "opentelemetry-sdk" },
-    { name = "opentelemetry-semantic-conventions-ai" },
     { name = "outlines-core" },
     { name = "partial-json-parser" },
     { name = "pillow" },
@@ -4036,7 +3936,6 @@ dependencies = [
     { name = "python-json-logger" },
     { name = "pyyaml" },
     { name = "pyzmq" },
-    { name = "quack-kernels" },
     { name = "ray", extra = ["cgraph"] },
     { name = "regex" },
     { name = "requests" },
@@ -4055,100 +3954,11 @@ dependencies = [
     { name = "watchfiles" },
     { name = "xgrammar", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'ppc64le' or platform_machine == 's390x' or platform_machine == 'x86_64'" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/fa/ab31c88afd21b69a46c3cc80d4017a2d5045a30cc4862dba6eae6eca7865/vllm-0.16.0.tar.gz", hash = "sha256:1f684bb31fbef59d862e2fe666e23a41f1d39d93f86215ce1ce1db89a8f5665b", size = 29197396, upload-time = "2026-02-26T03:09:45.533Z" }
 wheels = [
-    { url = "https://wheels.vllm.ai/7eca85911072b9732293c3d4181e20a4c9394b21/vllm-0.16.1rc1.dev246%2Bg7eca85911-cp38-abi3-manylinux_2_31_x86_64.whl", hash = "sha256:d6750448f74755b3383769efe3889fce90b01285ea311e4482d301a6771069d7" },
+    { url = "https://files.pythonhosted.org/packages/d6/ed/9fafb939bf8326e4a45e62041bf5d1eb73b4f76aff8ef75ae1169df7f3cb/vllm-0.16.0-cp38-abi3-manylinux_2_31_aarch64.whl", hash = "sha256:dfaa14846608fd229dda9d372e2ad3f13854fd09147c2ba36b40579cf3c03804", size = 460494130, upload-time = "2026-02-26T03:02:38.495Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ce/44a5a999eb7116516a8d4a08ab9fe14df773f0da4b243ceffe76b0afe54a/vllm-0.16.0-cp38-abi3-manylinux_2_31_x86_64.whl", hash = "sha256:f066b2a2f8597a4a3ada8fbbfd122b59086864b2260ca42dc81bf9fb57af0c42", size = 508337437, upload-time = "2026-02-26T03:02:55.258Z" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "aiohttp", specifier = ">=3.13.3" },
-    { name = "anthropic", specifier = ">=0.71.0" },
-    { name = "av", marker = "extra == 'audio'" },
-    { name = "blake3" },
-    { name = "cachetools" },
-    { name = "cbor2" },
-    { name = "cloudpickle" },
-    { name = "compressed-tensors", specifier = "==0.13.0" },
-    { name = "datasets", marker = "extra == 'bench'" },
-    { name = "depyf", specifier = "==0.20.0" },
-    { name = "diskcache", specifier = "==5.6.3" },
-    { name = "einops" },
-    { name = "fastapi", extras = ["standard"], specifier = ">=0.115.0" },
-    { name = "fastsafetensors", marker = "extra == 'fastsafetensors'", specifier = ">=0.2.2" },
-    { name = "filelock", specifier = ">=3.16.1" },
-    { name = "flashinfer-python", specifier = "==0.6.4" },
-    { name = "gguf", specifier = ">=0.17.0" },
-    { name = "grpcio" },
-    { name = "grpcio-reflection" },
-    { name = "helion", marker = "extra == 'helion'" },
-    { name = "ijson" },
-    { name = "lark", specifier = "==1.2.2" },
-    { name = "librosa", marker = "extra == 'audio'" },
-    { name = "llguidance", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'ppc64le' or platform_machine == 's390x' or platform_machine == 'x86_64'", specifier = ">=1.3.0,<1.4.0" },
-    { name = "lm-format-enforcer", specifier = "==0.11.3" },
-    { name = "matplotlib", marker = "extra == 'bench'" },
-    { name = "mcp" },
-    { name = "mistral-common", extras = ["audio"], marker = "extra == 'audio'" },
-    { name = "mistral-common", extras = ["image"], specifier = ">=1.9.1" },
-    { name = "model-hosting-container-standards", specifier = ">=0.1.13,<1.0.0" },
-    { name = "msgspec" },
-    { name = "ninja" },
-    { name = "numba", specifier = "==0.61.2" },
-    { name = "numpy" },
-    { name = "nvidia-cutlass-dsl", specifier = ">=4.4.0.dev1" },
-    { name = "openai", specifier = ">=1.99.1" },
-    { name = "openai-harmony", specifier = ">=0.0.3" },
-    { name = "opencv-python-headless", specifier = ">=4.13.0" },
-    { name = "opentelemetry-api", specifier = ">=1.27.0" },
-    { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.26.0" },
-    { name = "opentelemetry-exporter-otlp", specifier = ">=1.27.0" },
-    { name = "opentelemetry-exporter-otlp", marker = "extra == 'otel'", specifier = ">=1.26.0" },
-    { name = "opentelemetry-sdk", specifier = ">=1.27.0" },
-    { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.26.0" },
-    { name = "opentelemetry-semantic-conventions-ai", specifier = ">=0.4.1" },
-    { name = "opentelemetry-semantic-conventions-ai", marker = "extra == 'otel'", specifier = ">=0.4.1" },
-    { name = "outlines-core", specifier = "==0.2.11" },
-    { name = "pandas", marker = "extra == 'bench'" },
-    { name = "partial-json-parser" },
-    { name = "petit-kernel", marker = "extra == 'petit-kernel'" },
-    { name = "pillow" },
-    { name = "plotly", marker = "extra == 'bench'" },
-    { name = "prometheus-client", specifier = ">=0.18.0" },
-    { name = "prometheus-fastapi-instrumentator", specifier = ">=7.0.0" },
-    { name = "protobuf", specifier = ">=5.29.6,!=6.30.*,!=6.31.*,!=6.32.*,!=6.33.0.*,!=6.33.1.*,!=6.33.2.*,!=6.33.3.*,!=6.33.4.*" },
-    { name = "psutil" },
-    { name = "py-cpuinfo" },
-    { name = "pybase64" },
-    { name = "pydantic", specifier = ">=2.12.0" },
-    { name = "python-json-logger" },
-    { name = "pyyaml" },
-    { name = "pyzmq", specifier = ">=25.0.0" },
-    { name = "quack-kernels", specifier = ">=0.2.7" },
-    { name = "ray", extras = ["cgraph"], specifier = ">=2.48.0" },
-    { name = "regex" },
-    { name = "requests", specifier = ">=2.26.0" },
-    { name = "runai-model-streamer", extras = ["gcs", "s3"], marker = "extra == 'runai'", specifier = ">=0.15.3" },
-    { name = "scipy", marker = "extra == 'audio'" },
-    { name = "scipy", marker = "extra == 'bench'" },
-    { name = "seaborn", marker = "extra == 'bench'" },
-    { name = "sentencepiece" },
-    { name = "setproctitle" },
-    { name = "setuptools", marker = "python_full_version >= '3.12'", specifier = ">=77.0.3,<81.0.0" },
-    { name = "six", marker = "python_full_version >= '3.12'", specifier = ">=1.16.0" },
-    { name = "soundfile", marker = "extra == 'audio'" },
-    { name = "tensorizer", marker = "extra == 'tensorizer'", specifier = "==2.10.1" },
-    { name = "tiktoken", specifier = ">=0.6.0" },
-    { name = "tokenizers", specifier = ">=0.21.1" },
-    { name = "torch", specifier = "==2.10.0" },
-    { name = "torchaudio", specifier = "==2.10.0" },
-    { name = "torchvision", specifier = "==0.25.0" },
-    { name = "tqdm" },
-    { name = "transformers", specifier = ">=4.56.0,<5" },
-    { name = "typing-extensions", specifier = ">=4.10" },
-    { name = "watchfiles" },
-    { name = "xgrammar", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'ppc64le' or platform_machine == 's390x' or platform_machine == 'x86_64'", specifier = "==0.1.29" },
-]
-provides-extras = ["bench", "tensorizer", "fastsafetensors", "runai", "audio", "video", "flashinfer", "petit-kernel", "helion", "otel"]
 
 [[package]]
 name = "vllm-router"
@@ -4305,7 +4115,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "torch" },
     { name = "transformers" },
-    { name = "triton", version = "3.6.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "triton", version = "3.5.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/a3/70dbe3ffd331a1e7e1ad5a95690a4086e6c7cdb8089f5c7eda712219ccec/xgrammar-0.1.29.tar.gz", hash = "sha256:cf195afa81b489eebf35d4c6f37f27136d05420739ab4a6f7f065c938d7e4baa", size = 2321317, upload-time = "2025-12-19T08:23:54.53Z" }

--- a/uv.lock
+++ b/uv.lock
@@ -1829,6 +1829,30 @@ wheels = [
 ]
 
 [[package]]
+name = "nixl"
+version = "0.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nixl-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/a4/10e80e623790d3fb070e966b36bced009419d483c92ae0df6645230f606f/nixl-0.10.1-py3-none-any.whl", hash = "sha256:616465673dae5180d296525a03237af4cd5f2c00c3228d185bc06dbe621509b7", size = 6680, upload-time = "2026-03-03T19:55:44.848Z" },
+]
+
+[[package]]
+name = "nixl-cu12"
+version = "0.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "torch" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/21/c1f34212a3e612b5c0da389c1aa3557588d9cfc2adf864914b32e270847b/nixl_cu12-0.10.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:b4712c6e0f18f57fee34cd970faac01480f0caf12da33d4a40ef4e9096a4caf7", size = 50227261, upload-time = "2026-03-03T19:55:17.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/32/3fe6bb57de847ab59fb9e36c5a64249fb5674959773faca0aeefb791fd8e/nixl_cu12-0.10.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:26e59f9841985cf5b547202865036f84ae6dc23184789446fe5833e7499e21a9", size = 51534091, upload-time = "2026-03-03T19:55:02.199Z" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2270,6 +2294,29 @@ wheels = [
 ]
 
 [[package]]
+name = "orjson"
+version = "3.11.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/45/b268004f745ede84e5798b48ee12b05129d19235d0e15267aa57dcdb400b/orjson-3.11.7.tar.gz", hash = "sha256:9b1a67243945819ce55d24a30b59d6a168e86220452d2c96f4d1f093e71c0c49", size = 6144992, upload-time = "2026-02-02T15:38:49.29Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/bf/76f4f1665f6983385938f0e2a5d7efa12a58171b8456c252f3bae8a4cf75/orjson-3.11.7-cp312-cp312-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:bd03ea7606833655048dab1a00734a2875e3e86c276e1d772b2a02556f0d895f", size = 228545, upload-time = "2026-02-02T15:37:46.376Z" },
+    { url = "https://files.pythonhosted.org/packages/79/53/6c72c002cb13b5a978a068add59b25a8bdf2800ac1c9c8ecdb26d6d97064/orjson-3.11.7-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:89e440ebc74ce8ab5c7bc4ce6757b4a6b1041becb127df818f6997b5c71aa60b", size = 125224, upload-time = "2026-02-02T15:37:47.697Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/83/10e48852865e5dd151bdfe652c06f7da484578ed02c5fca938e3632cb0b8/orjson-3.11.7-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5ede977b5fe5ac91b1dffc0a517ca4542d2ec8a6a4ff7b2652d94f640796342a", size = 128154, upload-time = "2026-02-02T15:37:48.954Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/52/a66e22a2b9abaa374b4a081d410edab6d1e30024707b87eab7c734afe28d/orjson-3.11.7-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b7b1dae39230a393df353827c855a5f176271c23434cfd2db74e0e424e693e10", size = 123548, upload-time = "2026-02-02T15:37:50.187Z" },
+    { url = "https://files.pythonhosted.org/packages/de/38/605d371417021359f4910c496f764c48ceb8997605f8c25bf1dfe58c0ebe/orjson-3.11.7-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ed46f17096e28fb28d2975834836a639af7278aa87c84f68ab08fbe5b8bd75fa", size = 129000, upload-time = "2026-02-02T15:37:51.426Z" },
+    { url = "https://files.pythonhosted.org/packages/44/98/af32e842b0ffd2335c89714d48ca4e3917b42f5d6ee5537832e069a4b3ac/orjson-3.11.7-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3726be79e36e526e3d9c1aceaadbfb4a04ee80a72ab47b3f3c17fefb9812e7b8", size = 141686, upload-time = "2026-02-02T15:37:52.607Z" },
+    { url = "https://files.pythonhosted.org/packages/96/0b/fc793858dfa54be6feee940c1463370ece34b3c39c1ca0aa3845f5ba9892/orjson-3.11.7-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0724e265bc548af1dedebd9cb3d24b4e1c1e685a343be43e87ba922a5c5fff2f", size = 130812, upload-time = "2026-02-02T15:37:53.944Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/91/98a52415059db3f374757d0b7f0f16e3b5cd5976c90d1c2b56acaea039e6/orjson-3.11.7-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e7745312efa9e11c17fbd3cb3097262d079da26930ae9ae7ba28fb738367cbad", size = 133440, upload-time = "2026-02-02T15:37:55.615Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b6/cb540117bda61791f46381f8c26c8f93e802892830a6055748d3bb1925ab/orjson-3.11.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f904c24bdeabd4298f7a977ef14ca2a022ca921ed670b92ecd16ab6f3d01f867", size = 138386, upload-time = "2026-02-02T15:37:56.814Z" },
+    { url = "https://files.pythonhosted.org/packages/63/1a/50a3201c334a7f17c231eee5f841342190723794e3b06293f26e7cf87d31/orjson-3.11.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b9fc4d0f81f394689e0814617aadc4f2ea0e8025f38c226cbf22d3b5ddbf025d", size = 408853, upload-time = "2026-02-02T15:37:58.291Z" },
+    { url = "https://files.pythonhosted.org/packages/87/cd/8de1c67d0be44fdc22701e5989c0d015a2adf391498ad42c4dc589cd3013/orjson-3.11.7-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:849e38203e5be40b776ed2718e587faf204d184fc9a008ae441f9442320c0cab", size = 144130, upload-time = "2026-02-02T15:38:00.163Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/fe/d605d700c35dd55f51710d159fc54516a280923cd1b7e47508982fbb387d/orjson-3.11.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4682d1db3bcebd2b64757e0ddf9e87ae5f00d29d16c5cdf3a62f561d08cc3dd2", size = 134818, upload-time = "2026-02-02T15:38:01.507Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/e4/15ecc67edb3ddb3e2f46ae04475f2d294e8b60c1825fbe28a428b93b3fbd/orjson-3.11.7-cp312-cp312-win32.whl", hash = "sha256:f4f7c956b5215d949a1f65334cf9d7612dde38f20a95f2315deef167def91a6f", size = 127923, upload-time = "2026-02-02T15:38:02.75Z" },
+    { url = "https://files.pythonhosted.org/packages/34/70/2e0855361f76198a3965273048c8e50a9695d88cd75811a5b46444895845/orjson-3.11.7-cp312-cp312-win_amd64.whl", hash = "sha256:bf742e149121dc5648ba0a08ea0871e87b660467ef168a3a5e53bc1fbd64bb74", size = 125007, upload-time = "2026-02-02T15:38:04.032Z" },
+    { url = "https://files.pythonhosted.org/packages/68/40/c2051bd19fc467610fed469dc29e43ac65891571138f476834ca192bc290/orjson-3.11.7-cp312-cp312-win_arm64.whl", hash = "sha256:26c3b9132f783b7d7903bf1efb095fed8d4a3a85ec0d334ee8beff3d7a4749d5", size = 126089, upload-time = "2026-02-02T15:38:05.297Z" },
+]
+
+[[package]]
 name = "outlines-core"
 version = "0.2.11"
 source = { registry = "https://pypi.org/simple" }
@@ -2446,6 +2493,7 @@ dependencies = [
     { name = "liger-kernel" },
     { name = "loguru" },
     { name = "math-env" },
+    { name = "nixl" },
     { name = "numpy" },
     { name = "openai" },
     { name = "prime" },
@@ -2467,6 +2515,7 @@ dependencies = [
     { name = "uvloop" },
     { name = "verifiers" },
     { name = "vllm" },
+    { name = "vllm-router" },
     { name = "wandb" },
 ]
 
@@ -2506,6 +2555,7 @@ requires-dist = [
     { name = "liger-kernel", specifier = ">=0.5.10" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "math-env", index = "https://hub.primeintellect.ai/primeintellect/simple/" },
+    { name = "nixl", specifier = ">=0.10.1" },
     { name = "numpy", specifier = ">=2.2.6" },
     { name = "openai", specifier = ">=1.106.1" },
     { name = "prime", specifier = ">=0.5.37" },
@@ -2526,7 +2576,8 @@ requires-dist = [
     { name = "transformers", git = "https://github.com/huggingface/transformers.git?rev=5c1c72b" },
     { name = "uvloop", specifier = ">=0.21.0" },
     { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=45fae8d" },
-    { name = "vllm", specifier = ">=0.16.1.dev0", index = "https://wheels.vllm.ai/nightly" },
+    { name = "vllm", url = "https://wheels.vllm.ai/7eca85911072b9732293c3d4181e20a4c9394b21/vllm-0.16.1rc1.dev246%2Bg7eca85911-cp38-abi3-manylinux_2_31_x86_64.whl" },
+    { name = "vllm-router" },
     { name = "wandb", specifier = ">=0.24.2" },
 ]
 provides-extras = ["flash-attn", "flash-attn-3", "flash-attn-cute"]
@@ -3935,7 +3986,7 @@ wheels = [
 [[package]]
 name = "vllm"
 version = "0.16.1rc1.dev246+g7eca85911"
-source = { registry = "https://wheels.vllm.ai/nightly" }
+source = { url = "https://wheels.vllm.ai/7eca85911072b9732293c3d4181e20a4c9394b21/vllm-0.16.1rc1.dev246%2Bg7eca85911-cp38-abi3-manylinux_2_31_x86_64.whl" }
 dependencies = [
     { name = "aiohttp" },
     { name = "anthropic" },
@@ -4005,8 +4056,116 @@ dependencies = [
     { name = "xgrammar", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'ppc64le' or platform_machine == 's390x' or platform_machine == 'x86_64'" },
 ]
 wheels = [
-    { url = "https://wheels.vllm.ai/7eca85911072b9732293c3d4181e20a4c9394b21/vllm-0.16.1rc1.dev246%2Bg7eca85911-cp38-abi3-manylinux_2_31_aarch64.whl" },
-    { url = "https://wheels.vllm.ai/7eca85911072b9732293c3d4181e20a4c9394b21/vllm-0.16.1rc1.dev246%2Bg7eca85911-cp38-abi3-manylinux_2_31_x86_64.whl" },
+    { url = "https://wheels.vllm.ai/7eca85911072b9732293c3d4181e20a4c9394b21/vllm-0.16.1rc1.dev246%2Bg7eca85911-cp38-abi3-manylinux_2_31_x86_64.whl", hash = "sha256:d6750448f74755b3383769efe3889fce90b01285ea311e4482d301a6771069d7" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiohttp", specifier = ">=3.13.3" },
+    { name = "anthropic", specifier = ">=0.71.0" },
+    { name = "av", marker = "extra == 'audio'" },
+    { name = "blake3" },
+    { name = "cachetools" },
+    { name = "cbor2" },
+    { name = "cloudpickle" },
+    { name = "compressed-tensors", specifier = "==0.13.0" },
+    { name = "datasets", marker = "extra == 'bench'" },
+    { name = "depyf", specifier = "==0.20.0" },
+    { name = "diskcache", specifier = "==5.6.3" },
+    { name = "einops" },
+    { name = "fastapi", extras = ["standard"], specifier = ">=0.115.0" },
+    { name = "fastsafetensors", marker = "extra == 'fastsafetensors'", specifier = ">=0.2.2" },
+    { name = "filelock", specifier = ">=3.16.1" },
+    { name = "flashinfer-python", specifier = "==0.6.4" },
+    { name = "gguf", specifier = ">=0.17.0" },
+    { name = "grpcio" },
+    { name = "grpcio-reflection" },
+    { name = "helion", marker = "extra == 'helion'" },
+    { name = "ijson" },
+    { name = "lark", specifier = "==1.2.2" },
+    { name = "librosa", marker = "extra == 'audio'" },
+    { name = "llguidance", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'ppc64le' or platform_machine == 's390x' or platform_machine == 'x86_64'", specifier = ">=1.3.0,<1.4.0" },
+    { name = "lm-format-enforcer", specifier = "==0.11.3" },
+    { name = "matplotlib", marker = "extra == 'bench'" },
+    { name = "mcp" },
+    { name = "mistral-common", extras = ["audio"], marker = "extra == 'audio'" },
+    { name = "mistral-common", extras = ["image"], specifier = ">=1.9.1" },
+    { name = "model-hosting-container-standards", specifier = ">=0.1.13,<1.0.0" },
+    { name = "msgspec" },
+    { name = "ninja" },
+    { name = "numba", specifier = "==0.61.2" },
+    { name = "numpy" },
+    { name = "nvidia-cutlass-dsl", specifier = ">=4.4.0.dev1" },
+    { name = "openai", specifier = ">=1.99.1" },
+    { name = "openai-harmony", specifier = ">=0.0.3" },
+    { name = "opencv-python-headless", specifier = ">=4.13.0" },
+    { name = "opentelemetry-api", specifier = ">=1.27.0" },
+    { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.26.0" },
+    { name = "opentelemetry-exporter-otlp", specifier = ">=1.27.0" },
+    { name = "opentelemetry-exporter-otlp", marker = "extra == 'otel'", specifier = ">=1.26.0" },
+    { name = "opentelemetry-sdk", specifier = ">=1.27.0" },
+    { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.26.0" },
+    { name = "opentelemetry-semantic-conventions-ai", specifier = ">=0.4.1" },
+    { name = "opentelemetry-semantic-conventions-ai", marker = "extra == 'otel'", specifier = ">=0.4.1" },
+    { name = "outlines-core", specifier = "==0.2.11" },
+    { name = "pandas", marker = "extra == 'bench'" },
+    { name = "partial-json-parser" },
+    { name = "petit-kernel", marker = "extra == 'petit-kernel'" },
+    { name = "pillow" },
+    { name = "plotly", marker = "extra == 'bench'" },
+    { name = "prometheus-client", specifier = ">=0.18.0" },
+    { name = "prometheus-fastapi-instrumentator", specifier = ">=7.0.0" },
+    { name = "protobuf", specifier = ">=5.29.6,!=6.30.*,!=6.31.*,!=6.32.*,!=6.33.0.*,!=6.33.1.*,!=6.33.2.*,!=6.33.3.*,!=6.33.4.*" },
+    { name = "psutil" },
+    { name = "py-cpuinfo" },
+    { name = "pybase64" },
+    { name = "pydantic", specifier = ">=2.12.0" },
+    { name = "python-json-logger" },
+    { name = "pyyaml" },
+    { name = "pyzmq", specifier = ">=25.0.0" },
+    { name = "quack-kernels", specifier = ">=0.2.7" },
+    { name = "ray", extras = ["cgraph"], specifier = ">=2.48.0" },
+    { name = "regex" },
+    { name = "requests", specifier = ">=2.26.0" },
+    { name = "runai-model-streamer", extras = ["gcs", "s3"], marker = "extra == 'runai'", specifier = ">=0.15.3" },
+    { name = "scipy", marker = "extra == 'audio'" },
+    { name = "scipy", marker = "extra == 'bench'" },
+    { name = "seaborn", marker = "extra == 'bench'" },
+    { name = "sentencepiece" },
+    { name = "setproctitle" },
+    { name = "setuptools", marker = "python_full_version >= '3.12'", specifier = ">=77.0.3,<81.0.0" },
+    { name = "six", marker = "python_full_version >= '3.12'", specifier = ">=1.16.0" },
+    { name = "soundfile", marker = "extra == 'audio'" },
+    { name = "tensorizer", marker = "extra == 'tensorizer'", specifier = "==2.10.1" },
+    { name = "tiktoken", specifier = ">=0.6.0" },
+    { name = "tokenizers", specifier = ">=0.21.1" },
+    { name = "torch", specifier = "==2.10.0" },
+    { name = "torchaudio", specifier = "==2.10.0" },
+    { name = "torchvision", specifier = "==0.25.0" },
+    { name = "tqdm" },
+    { name = "transformers", specifier = ">=4.56.0,<5" },
+    { name = "typing-extensions", specifier = ">=4.10" },
+    { name = "watchfiles" },
+    { name = "xgrammar", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'ppc64le' or platform_machine == 's390x' or platform_machine == 'x86_64'", specifier = "==0.1.29" },
+]
+provides-extras = ["bench", "tensorizer", "fastsafetensors", "runai", "audio", "video", "flashinfer", "petit-kernel", "helion", "otel"]
+
+[[package]]
+name = "vllm-router"
+version = "0.1.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "fastapi" },
+    { name = "orjson" },
+    { name = "requests" },
+    { name = "setproctitle" },
+    { name = "uvicorn" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6b/f3/5d0043120d5b39bd80c3f193ea99ced3134382491409e50e3d5bcf42df0e/vllm_router-0.1.11.tar.gz", hash = "sha256:a9c9d14a478f3d14281f4cbf3fee1e771c3ecf3d8471ac89336affb549d09e59", size = 247092, upload-time = "2026-03-04T05:02:24.645Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/41/e7d6fd9c98e2e58f13ac30a08750253f89aea2e1e9e2ca5c09b6bc48990e/vllm_router-0.1.11-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:c6b5c670356a5f96a0619b9cb34a134406bee9b328bf7eca6aaea5fdfeac371e", size = 11318072, upload-time = "2026-03-04T05:02:20.811Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/fd/b2ec2b4ba958a7b7ee6e6efd9f97be623a1e58f5464762ca4a3547b31886/vllm_router-0.1.11-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2845423faa2bbccaa60d1f0a9206c3f7d2ac7b6edb30d703e7cf415f818b252b", size = 11595125, upload-time = "2026-03-04T05:02:23.046Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> High risk because it introduces a new multi-node disaggregated inference mode with new SLURM templates and kernel/toolchain install scripts, and it changes NCCL weight broadcast initialization/rank calculations used for live weight updates.
> 
> **Overview**
> Adds a new **disaggregated prefill/decode inference deployment** option, including SLURM templates (`inference_disaggregated.sbatch.j2`, `disaggregated_rl.sbatch.j2`) that launch separate prefill/decode vLLM roles plus a `vllm-router`, and wires this mode into the `inference` and `rl` entrypoints/config validators.
> 
> Updates weight-broadcasting to work in this topology by introducing `inference_world_size` and per-server `rank_offset`/`gpus_per_server` parameters (propagated through orchestrator → HTTP admin clients → vLLM worker), and adds `client.admin_base_url` so weight updates/health checks can bypass the router and hit each node directly.
> 
> Adds install tooling/docs for disaggregated expert-parallel requirements (`scripts/install_ep_kernels.sh` for NVSHMEM+DeepEP, `install_nixl_from_source.sh`, `install_vllm_router.sh`) and shifts core deps toward this stack (pin `vllm` to `0.16.0`, add `vllm-router` and `nixl`, adjust torch/flash-attn/triton versions and indices in `pyproject.toml`/`uv.lock`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96bc38b164508e0d3ca15f81b44db7acf52b5938. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->