### PR TITLE
fix vllm 0.17 compat

### DIFF
--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -271,10 +271,7 @@ async def custom_init_app_state(
 
     resolved_chat_template = load_chat_template(args.chat_template)
 
-    serving_chat = OpenAIServingChatWithTokens(
-        engine_client,
-        state.openai_serving_models,
-        args.response_role,
+    chat_kwargs = dict(
         request_logger=request_logger,
         chat_template=resolved_chat_template,
         chat_template_content_format=args.chat_template_content_format,
@@ -287,7 +284,15 @@ async def custom_init_app_state(
         enable_prompt_tokens_details=args.enable_prompt_tokens_details,
         enable_force_include_usage=args.enable_force_include_usage,
         enable_log_outputs=args.enable_log_outputs,
-        log_error_stack=args.log_error_stack,
+    )
+    if hasattr(args, "log_error_stack"):
+        chat_kwargs["log_error_stack"] = args.log_error_stack
+
+    serving_chat = OpenAIServingChatWithTokens(
+        engine_client,
+        state.openai_serving_models,
+        args.response_role,
+        **chat_kwargs,
     )
     state.openai_serving_chat = serving_chat if "generate" in supported_tasks else None
     state.openai_serving_chat_with_tokens = serving_chat if "generate" in supported_tasks else None


### PR DESCRIPTION
vllm nightly index rotated out 0.16 — any `uv lock` regeneration now pulls 0.17 which removed `log_error_stack` from `OpenAIServingChat.__init__()`, crashing the inference server.

- conditionally pass `log_error_stack` only when the arg exists
- works with both vllm 0.16 and 0.17

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change in API server initialization; risk is limited to startup/config behavior if argument detection is wrong.
> 
> **Overview**
> Prevents the inference server from crashing on vLLM 0.17 by building `OpenAIServingChatWithTokens` kwargs dynamically and *conditionally* including `log_error_stack` only when present in parsed args.
> 
> This keeps the same behavior on older vLLM versions while allowing `uv lock` upgrades to newer vLLM releases that removed the parameter.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e3390e7f2a7d12b4951cacb87864e953b6ce062. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->