### PR TITLE
fp32 chunk

### DIFF
--- a/src/prime_rl/trainer/models/layers/lm_head.py
+++ b/src/prime_rl/trainer/models/layers/lm_head.py
@@ -108,8 +108,8 @@ class _ChunkedLogProbEntropyFn(torch.autograd.Function):
         for start in range(0, vocab, chunk_size):
             end = min(start + chunk_size, vocab)
             w_chunk = weight[start:end]  # [C, H]
-            logits = hidden @ w_chunk.t()  # [N, C] (model dtype)
-            logits_f = logits.to(torch.float32) * inv_t_broadcast  # [N, C] fp32
+            logits = hidden.to(torch.float32) @ w_chunk.to(torch.float32).t()  # [N, C] fp32
+            logits_f = logits * inv_t_broadcast  # [N, C] fp32
 
             # Shared intermediates for logZ and entropy stats.
             m, s, t = _online_logsumexp_and_weighted_update(m, s, t, logits_f)
@@ -156,8 +156,8 @@ class _ChunkedLogProbEntropyFn(torch.autograd.Function):
             end = min(start + chunk_size, vocab)
             w_chunk = weight[start:end]  # [C, H]
 
-            logits = hidden @ w_chunk.t()  # [N, C] (model dtype)
-            logits_f = logits.to(torch.float32) * inv_t_broadcast  # [N, C] fp32
+            logits = hidden.to(torch.float32) @ w_chunk.to(torch.float32).t()  # [N, C] fp32
+            logits_f = logits * inv_t_broadcast  # [N, C] fp32
 
             # p = softmax(logits_f) chunk = exp(logits_f - logz)
             p = torch.exp(logits_f - logz.unsqueeze(-1))  # [N, C] fp32


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the custom chunked softmax/autograd path used during training, which can change numerical results and performance. Risk is mainly around throughput/regression in loss/gradient behavior rather than correctness of external interfaces.
> 
> **Overview**
> Updates the chunked LM-head implementation in `lm_head.py` to compute per-chunk logits via an fp32 matmul (`hidden` and `weight` cast to fp32 before `@`) in both forward and backward, rather than matmul in model dtype followed by fp32 conversion.
> 
> This keeps the rest of the chunked logprob/entropy and gradient computation in fp32, potentially improving numerical stability at the cost of extra casting/compute.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aaa35cc4525a9c3cbe2a3b7a2e551434f79b7fa2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->