### PR TITLE
Fix arm64 flash-attn: force source build

### DIFF
--- a/scripts/docker-arm64-post-install.sh
+++ b/scripts/docker-arm64-post-install.sh
@@ -4,7 +4,7 @@ set -e
 
 echo "=== building flash-attn from source (sm_100 / GB200) ==="
 TORCH_CUDA_ARCH_LIST="10.0" MAX_JOBS=4 \
-    uv pip install "flash-attn==2.8.3" --no-build-isolation
+    uv pip install "flash-attn==2.8.3" --no-build-isolation --no-binary flash-attn
 
 echo "=== reinstalling flash-attn-cute (flash-attn overwrites it with a stub) ==="
 uv pip install --reinstall --no-deps \


### PR DESCRIPTION
The arm64 post-install script was downloading a pre-built flash-attn wheel from PyPI instead of compiling from source. This wheel lacks the CUDA extension (flash_attn_2_cuda.so), causing the trainer to crash on GB200 with `ModuleNotFoundError: No module named 'flash_attn_2_cuda'`.

- Add `--no-binary flash-attn` to force compilation from source with SM100 CUDA arch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the arm64 Docker post-install to compile `flash-attn` from source, which can affect build time and may fail if toolchain/CUDA headers differ from expectations. Runtime risk is low but the build pipeline is more sensitive to environment changes.
> 
> **Overview**
> Ensures arm64 Docker images build `flash-attn==2.8.3` from source by adding `--no-binary flash-attn` to the install command, so the CUDA extension is compiled for `sm_100`/GB200 instead of pulling a wheel.
> 
> No other behavior changes beyond how `flash-attn` is obtained during the post-install step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit deae4908c948357f50fda9325803f579f37f1e1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->