### PR TITLE
Fix arm64 flash-attn: bypass uv cache to force source build

### DIFF
--- a/scripts/docker-arm64-post-install.sh
+++ b/scripts/docker-arm64-post-install.sh
@@ -4,7 +4,7 @@ set -e
 
 echo "=== building flash-attn from source (sm_100 / GB200) ==="
 TORCH_CUDA_ARCH_LIST="10.0" MAX_JOBS=4 \
-    uv pip install "flash-attn==2.8.3" --no-build-isolation --no-binary flash-attn
+    uv pip install "flash-attn==2.8.3" --no-build-isolation --no-binary flash-attn --no-cache
 
 echo "=== reinstalling flash-attn-cute (flash-attn overwrites it with a stub) ==="
 uv pip install --reinstall --no-deps \


### PR DESCRIPTION
no-binary alone does not work because uv reuses cached wheels from the uv sync step. Adding --no-cache forces uv to actually build from source. Without this, flash-attn installs a pre-built wheel without CUDA extensions, causing ModuleNotFoundError on the trainer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to the arm64 Docker post-install script, but it can increase build time and changes dependency installation behavior by bypassing cached wheels.
> 
> **Overview**
> Ensures arm64 Docker builds *actually compile* `flash-attn` from source by adding `--no-cache` to the `uv pip install` step, preventing `uv` from reusing a previously cached wheel that lacks CUDA extensions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 573782d7d43183f1aa95a359c1cf9a1be9908ae2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->