### PR TITLE
fix arm64 flash-attn build: override FLASH_ATTENTION_SKIP_CUDA_BUILD

### DIFF
--- a/scripts/docker-arm64-post-install.sh
+++ b/scripts/docker-arm64-post-install.sh
@@ -3,7 +3,10 @@
 set -e
 
 echo "=== building flash-attn from source (sm_100 / GB200) ==="
-TORCH_CUDA_ARCH_LIST="10.0" MAX_JOBS=4 \
+# FLASH_ATTENTION_SKIP_CUDA_BUILD=FALSE overrides the TRUE default set in
+# pyproject.toml [tool.uv.extra-build-variables] (intended for x86_64 prebuilt
+# wheels) so that the CUDA kernels (flash_attn_2_cuda) are actually compiled.
+TORCH_CUDA_ARCH_LIST="10.0" MAX_JOBS=4 FLASH_ATTENTION_SKIP_CUDA_BUILD=FALSE \
     uv pip install "flash-attn==2.8.3" --no-build-isolation --no-binary flash-attn --no-cache
 
 echo "=== reinstalling flash-attn-cute (flash-attn overwrites it with a stub) ==="

--- a/scripts/docker-arm64-post-install.sh
+++ b/scripts/docker-arm64-post-install.sh
@@ -3,10 +3,11 @@
 set -e
 
 echo "=== building flash-attn from source (sm_100 / GB200) ==="
-# FLASH_ATTENTION_SKIP_CUDA_BUILD=FALSE overrides the TRUE default set in
-# pyproject.toml [tool.uv.extra-build-variables] (intended for x86_64 prebuilt
-# wheels) so that the CUDA kernels (flash_attn_2_cuda) are actually compiled.
-TORCH_CUDA_ARCH_LIST="10.0" MAX_JOBS=4 FLASH_ATTENTION_SKIP_CUDA_BUILD=FALSE \
+# FLASH_ATTENTION_FORCE_BUILD=TRUE skips the prebuilt wheel download attempt
+# and forces a local CUDA kernel compilation.
+# FLASH_ATTENTION_SKIP_CUDA_BUILD=FALSE ensures the CUDA extension is compiled.
+TORCH_CUDA_ARCH_LIST="10.0" MAX_JOBS=4 \
+    FLASH_ATTENTION_FORCE_BUILD=TRUE FLASH_ATTENTION_SKIP_CUDA_BUILD=FALSE \
     uv pip install "flash-attn==2.8.3" --no-build-isolation --no-binary flash-attn --no-cache
 
 echo "=== reinstalling flash-attn-cute (flash-attn overwrites it with a stub) ==="


### PR DESCRIPTION
## Summary

- The arm64 Docker image has been failing to load `flash_attn_2_cuda` on both NVL72 clusters (whitefiber and GAI), causing trainer and inference CrashLoopBackOff
- Root cause: `[tool.uv.extra-build-variables]` in pyproject.toml sets `FLASH_ATTENTION_SKIP_CUDA_BUILD=TRUE` (for x86_64 prebuilt wheels), and `uv pip install` in the arm64 post-install script picks this up, so the CUDA extension never gets compiled
- Fix: explicitly set `FLASH_ATTENTION_SKIP_CUDA_BUILD=FALSE` in the arm64 build command

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to an install script that only affects how `flash-attn` is built in arm64 images; main risk is longer build time or unexpected build failures during image creation.
> 
> **Overview**
> Ensures the arm64 Docker post-install script always builds `flash-attn` from source by explicitly setting `FLASH_ATTENTION_FORCE_BUILD=TRUE` and overriding `FLASH_ATTENTION_SKIP_CUDA_BUILD=FALSE` during `uv pip install`, preventing missing `flash_attn_2_cuda` at runtime.
> 
> Adds brief inline comments documenting why these environment variables are set for the arm64 build.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47d89c4ad6fbf27dd8b21d37282e9392a3cf9587. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->