### PR TITLE
fix arm64 flash-attn: avoid pyproject.toml SKIP_CUDA_BUILD override

### DIFF
--- a/scripts/docker-arm64-post-install.sh
+++ b/scripts/docker-arm64-post-install.sh
@@ -3,12 +3,14 @@
 set -e
 
 echo "=== building flash-attn from source (sm_100 / GB200) ==="
-# FLASH_ATTENTION_FORCE_BUILD=TRUE skips the prebuilt wheel download attempt
-# and forces a local CUDA kernel compilation.
-# FLASH_ATTENTION_SKIP_CUDA_BUILD=FALSE ensures the CUDA extension is compiled.
-TORCH_CUDA_ARCH_LIST="10.0" MAX_JOBS=4 \
-    FLASH_ATTENTION_FORCE_BUILD=TRUE FLASH_ATTENTION_SKIP_CUDA_BUILD=FALSE \
-    uv pip install "flash-attn==2.8.3" --no-build-isolation --no-binary flash-attn --no-cache
+# Run from /tmp so uv doesn't read pyproject.toml's [tool.uv.extra-build-variables]
+# which sets FLASH_ATTENTION_SKIP_CUDA_BUILD=TRUE and prevents CUDA kernel compilation.
+export TORCH_CUDA_ARCH_LIST="10.0"
+export MAX_JOBS=4
+export FLASH_ATTENTION_FORCE_BUILD=TRUE
+export FLASH_ATTENTION_SKIP_CUDA_BUILD=FALSE
+(cd /tmp && uv pip install --python /app/.venv/bin/python \
+    "flash-attn==2.8.3" --no-build-isolation --no-binary flash-attn --no-cache)
 
 echo "=== reinstalling flash-attn-cute (flash-attn overwrites it with a stub) ==="
 uv pip install --reinstall --no-deps \


### PR DESCRIPTION
## Summary

- dev105 confirmed still broken: `uv pip install` reads `[tool.uv.extra-build-variables]` from pyproject.toml and injects `FLASH_ATTENTION_SKIP_CUDA_BUILD=TRUE` even when the inline env var sets it to FALSE
- Fix: run the flash-attn build from `/tmp` so uv has no pyproject.toml to read, and use `export` for all env vars
- Also sets `FLASH_ATTENTION_FORCE_BUILD=TRUE` to skip the prebuilt wheel download attempt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Docker build/install flow for a CUDA extension; mistakes could break arm64 image builds or produce non-functional GPU kernels, but the change is localized to one post-install script.
> 
> **Overview**
> Fixes the arm64 Docker post-install step for `flash-attn` to reliably compile CUDA kernels for `sm_100` by preventing `uv` from reading `pyproject.toml` extra build variables.
> 
> The script now exports the relevant build env vars, runs the install from `/tmp`, and explicitly targets `/app/.venv/bin/python`, while keeping the subsequent `flash-attn-cute` reinstall and `ampere_helpers.py` copy workaround unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dda364175018108397eef7c8b2eac871c856e33b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->