### PR TITLE
fix arm64 flash-attn: use prebuilt aarch64 wheel

### DIFF
--- a/scripts/docker-arm64-post-install.sh
+++ b/scripts/docker-arm64-post-install.sh
@@ -2,15 +2,12 @@
 # arm64 post-install fixups for Docker builds.
 set -e
 
-echo "=== building flash-attn from source (sm_100 / GB200) ==="
-# Run from /tmp so uv doesn't read pyproject.toml's [tool.uv.extra-build-variables]
-# which sets FLASH_ATTENTION_SKIP_CUDA_BUILD=TRUE and prevents CUDA kernel compilation.
-export TORCH_CUDA_ARCH_LIST="10.0"
-export MAX_JOBS=4
-export FLASH_ATTENTION_FORCE_BUILD=TRUE
-export FLASH_ATTENTION_SKIP_CUDA_BUILD=FALSE
-(cd /tmp && uv pip install --python /app/.venv/bin/python \
-    "flash-attn==2.8.3" --no-build-isolation --no-binary flash-attn --no-cache)
+echo "=== installing flash-attn for arm64 ==="
+# flash-attn setup.py has a CachedWheelsCommand that downloads a prebuilt aarch64
+# wheel from GitHub releases (includes compiled flash_attn_2_cuda.so).
+# Do NOT use --no-binary or --no-cache as those force a source build which is
+# slow and hits FLASH_ATTENTION_SKIP_CUDA_BUILD from pyproject.toml.
+uv pip install "flash-attn==2.8.3" --no-build-isolation
 
 echo "=== reinstalling flash-attn-cute (flash-attn overwrites it with a stub) ==="
 uv pip install --reinstall --no-deps \


### PR DESCRIPTION
## Summary

- The working NVL72 image used uv pip install flash-attn --no-build-isolation which downloads a prebuilt aarch64 wheel from GitHub releases
- PRs 1972/1973 added --no-binary and --no-cache forcing source compilation, hitting FLASH_ATTENTION_SKIP_CUDA_BUILD=TRUE from pyproject.toml
- Fix: revert to simple install that uses the prebuilt flash_attn-2.8.3+cu12torch2.9-cp312-linux_aarch64.whl
- Reverts the /tmp workaround from 1975 which forced a 45+ min source build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change limited to an arm64 Docker post-install script; main risk is relying on availability/compatibility of the upstream prebuilt `flash-attn` wheel.
> 
> **Overview**
> Updates the arm64 Docker post-install script to **stop forcing a `flash-attn` source build** and instead `uv pip install` the prebuilt aarch64 wheel (removing the extra build env vars and `/tmp` workaround).
> 
> Keeps the follow-on steps to reinstall `flash-attn-cute` and copy `ampere_helpers.py`, but clarifies via comments that `--no-binary`/`--no-cache` should not be used for arm64.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f0f25551859f5313a8cf2026fd120be7def7547. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->