### PR TITLE
add attention-backend config for inference

### DIFF
--- a/src/prime_rl/configs/inference.py
+++ b/src/prime_rl/configs/inference.py
@@ -265,6 +265,13 @@ class InferenceConfig(BaseConfig):
         ),
     ] = False
 
+    attention_backend: Annotated[
+        str | None,
+        Field(
+            description="Attention backend to use (e.g. FLASH_ATTN, FLASHINFER, TRITON_ATTN). If None, vLLM selects automatically.",
+        ),
+    ] = None
+
     vllm_extra: Annotated[
         dict[str, Any],
         Field(
@@ -371,6 +378,7 @@ class InferenceConfig(BaseConfig):
             "all2all_backend": "all2all_backend",
             "enable_eplb": "enable_eplb",
             "seed": "seed",
+            "attention_backend": "attention_backend",
         }
 
         for config_key, vllm_key in to_vllm.items():


### PR DESCRIPTION
Adds --attention-backend CLI flag to pass through to vLLM. Needed for NVL72 clusters where flashinfer JIT fails due to missing nvcc on the host.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, opt-in config plumbing change that only affects inference when the new `attention_backend` field is set; main risk is misconfiguration leading to vLLM startup/runtime issues.
> 
> **Overview**
> Adds a new optional `attention_backend` field to `InferenceConfig`, allowing deployments to explicitly choose the vLLM attention backend instead of relying on auto-selection.
> 
> Updates `InferenceConfig.to_vllm()` to pass this value through to the vLLM `Namespace`, enabling the corresponding CLI/engine option to be controlled via Prime RL config.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42bc94ed190a51d079e0344eb73be8fd6433bc64. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->