### PR TITLE
fix: filesystem broadcast in multi-node rl

### DIFF
--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -406,6 +406,7 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
             inference_tp=config.inference.parallel.tp,
             inference_enable_expert_parallel=config.inference.enable_expert_parallel,
             inference_data_parallel_rpc_port=config.inference.data_parallel_rpc_port,
+            use_nccl_broadcast=config.weight_broadcast is not None and config.weight_broadcast.type == "nccl",
         )
 
     script_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -128,10 +128,10 @@ else
     TRAIN_NODE_RANK=$((SLURM_PROCID - NUM_INFER_NODES))
 
     if [ "$TRAIN_NODE_RANK" -eq 0 ]; then
-        uv run orchestrator \
-            @ $CONFIG_DIR/orchestrator.toml \
-            --weight_broadcast.host $MASTER_ADDR \
-            --client.base-url $INFER_URLS \
+        ORCHESTRATOR_ARGS="@ $CONFIG_DIR/orchestrator.toml"
+        ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --client.base-url $INFER_URLS"
+        {% if use_nccl_broadcast %}ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --weight_broadcast.host $MASTER_ADDR"
+        {% endif %}uv run orchestrator $ORCHESTRATOR_ARGS \
             2>&1 | tee $OUTPUT_DIR/slurm/latest_orchestrator.log $OUTPUT_DIR/slurm/job_${SLURM_JOB_ID}_orchestrator.log &
     fi
 


### PR DESCRIPTION
allow using filesystem broadcast in multi-node rl. previously, this would fail because we unconditionally pass the nccl broadcast host.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to SLURM script generation; main risk is mis-rendered orchestrator CLI args affecting multi-node job startup.
> 
> **Overview**
> Fixes multi-node RL SLURM runs when using non-NCCL (e.g., filesystem) weight broadcast by **conditionally** adding the orchestrator `--weight_broadcast.host $MASTER_ADDR` argument only when `config.weight_broadcast.type == "nccl"`.
> 
> This threads a new `use_nccl_broadcast` flag from `rl.py` into the `multi_node_rl.sbatch.j2` template and refactors orchestrator argument construction to support the conditional flag cleanly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b970d089a93fdcea61582501e8b71e1ec51d489. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->