### PR TITLE
fix arm64 flash-attn-cute: revert to 2b5db43 for sm100 pipeline fix

### DIFF
--- a/scripts/docker-arm64-post-install.sh
+++ b/scripts/docker-arm64-post-install.sh
@@ -14,7 +14,7 @@ export FLASH_ATTENTION_SKIP_CUDA_BUILD=FALSE
 
 echo "=== reinstalling flash-attn-cute (flash-attn overwrites it with a stub) ==="
 uv pip install --reinstall --no-deps \
-    "flash-attn-cute @ git+https://github.com/Dao-AILab/flash-attention.git@e2743ab5#subdirectory=flash_attn/cute"
+    "flash-attn-cute @ git+https://github.com/Dao-AILab/flash-attention.git@2b5db43#subdirectory=flash_attn/cute"
 
 # TODO: remove once flash-attn gates the ampere_helpers import or cutlass-dsl re-adds it.
 echo "=== copying ampere_helpers.py from flashinfer vendor ==="

--- a/scripts/fix-flash-attn-cute.sh
+++ b/scripts/fix-flash-attn-cute.sh
@@ -11,7 +11,7 @@
 set -e
 
 echo "Reinstalling flash-attn-cute to fix namespace conflict with flash-attn..."
-uv pip install --reinstall --no-deps "flash-attn-cute @ git+https://github.com/Dao-AILab/flash-attention.git@e2743ab5#subdirectory=flash_attn/cute"
+uv pip install --reinstall --no-deps "flash-attn-cute @ git+https://github.com/Dao-AILab/flash-attention.git@2b5db43#subdirectory=flash_attn/cute"
 
 # Verify installation
 LINES=$(wc -l < "$(python -c 'import flash_attn.cute.interface as m; print(m.__file__)')")


### PR DESCRIPTION
Reverts flash-attn-cute rev in arm64 post-install from e2743ab5 back to 2b5db43 which has the sm100 backward pipeline fix. e2743ab5 causes 'Invalid PipelineOp' on GB200.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small build-script-only change that just adjusts a dependency git SHA; risk is limited to arm64/CUDA build behavior and potential upstream incompatibilities with the pinned revision.
> 
> **Overview**
> Pins the `flash-attn-cute` reinstall in `docker-arm64-post-install.sh` and `fix-flash-attn-cute.sh` from Dao-AILab/flash-attention@`e2743ab5` back to `2b5db43` to restore the sm_100/GB200 backward pipeline fix and prevent the `flash-attn` stub from winning after installs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 651380993bd4df8e6e28a3e9689cbb724e777b70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->