### PR TITLE
fix: wire verifiers `max_seq_len` correctly

### DIFF
--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -939,7 +939,7 @@ class OrchestratorConfig(BaseConfig):
     @model_validator(mode="after")
     def resolve_extra_env_kwargs(self):
         train_extra_env_kwargs = dict(
-            seq_len=self.seq_len,
+            max_seq_len=self.seq_len,
             score_rollouts=self.verification.enabled,
         )
         for env in self.env:


### PR DESCRIPTION
`resolve_extra_env_kwargs` sends `seq_len` to verifiers, but the `Environment` base class expects `max_seq_len`. Since there is no `set_seq_len` setter, `set_kwargs` falls through to a dangling `setattr`. `self.max_seq_len` stays `None`, so `parse_response_tokens` never detects overlong prompts and rollouts keep going past the context limit.

vLLM silently left-truncates prompts at `max_model_len - max_tokens`, producing training samples missing the system prompt. Each overflow turn cascades into another broken sample.

### Call trace

1. `configs/orchestrator.py:942` — `resolve_extra_env_kwargs` populates `{"seq_len": self.seq_len}` into `env.extra_env_kwargs`
2. `orchestrator/orchestrator.py:200` — passes `extra_env_kwargs` to `spawn_env_server()`
3. `orchestrator/vf_utils.py:42-45` — forwards as args to `ZMQEnvServer.run_server()`
4. **verifiers** `workers/server/env_server.py:94` — calls `self.env.set_kwargs(**extra_env_kwargs)`
5. **verifiers** `envs/environment.py:1241-1246` — `set_kwargs` looks for `set_seq_len` → not found → `setattr(self, 'seq_len', 32768)`. The setter `set_max_seq_len` at line 1256 is never called.
6. **verifiers** `envs/multiturn_env.py:135` — `parse_response_tokens(response, self.max_seq_len)` passes `None`
7. **verifiers** `utils/response_utils.py:39` — `max_seq_len is None` → skips prompt-side truncation detection. `is_truncated` can still be set via `response.message.is_truncated` (vLLM completion hitting `max_tokens`), but overlong prompts are never caught.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Small, localized change, but it affects how rollout servers enforce context limits during training/verification, which can change generated samples and training dynamics.
> 
> **Overview**
> Fixes a config wiring bug in `OrchestratorConfig.resolve_extra_env_kwargs` by renaming the propagated env kwarg from `seq_len` to `max_seq_len`, ensuring environment servers/verifiers correctly enforce the training context length while scoring rollouts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc66b5f08d45a7f937a93d395a15190c9bc01e9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->