### PR TITLE
chore: config warnings

### DIFF
--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -704,12 +704,3 @@ class RLConfig(BaseConfig):
         return self
 
     ### Warnings
-
-    @model_validator(mode="after")
-    def warn_wandb_resume_id_missing(self):
-        if self.trainer.ckpt is not None and self.trainer.ckpt.resume_step is not None:
-            if self.trainer.wandb and not self.trainer.wandb.id:
-                warnings.warn(
-                    "W&B run ID is not set for trainer even though resuming training. The current run will be created as a new run."
-                )
-        return self

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -712,9 +712,4 @@ class RLConfig(BaseConfig):
                 warnings.warn(
                     "W&B run ID is not set for trainer even though resuming training. The current run will be created as a new run."
                 )
-        if self.orchestrator.ckpt is not None and self.orchestrator.ckpt.resume_step is not None:
-            if self.orchestrator.wandb and not self.orchestrator.wandb.id:
-                warnings.warn(
-                    "W&B run ID is not set for orchestrator even though resuming training. The current run will be created as a new run."
-                )
         return self

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -1,4 +1,3 @@
-import warnings
 from pathlib import Path
 from typing import Annotated, Literal, TypeAlias
 
@@ -38,6 +37,7 @@ from prime_rl.configs.trainer import (
     NCCLWeightBroadcastConfig as TrainerNCCLWeightBroadcastConfig,
 )
 from prime_rl.utils.config import BaseConfig
+from prime_rl.utils.logger import get_logger
 from prime_rl.utils.validation import (
     validate_shared_ckpt_config,
     validate_shared_max_async_level,
@@ -560,7 +560,7 @@ class RLConfig(BaseConfig):
                 self.inference.enable_lora = True
                 self.inference.max_lora_rank = self.trainer.model.lora.rank
             else:
-                warnings.warn(
+                get_logger().warning(
                     "LoRA is enabled, but inference is not configured. When manually starting the inference server, "
                     "make sure to set --enable_lora and --max-lora-rank."
                 )
@@ -572,12 +572,12 @@ class RLConfig(BaseConfig):
         if self.trainer.enable_router_replay:
             if self.inference is not None:
                 if self.inference.enable_return_routed_experts is False:
-                    warnings.warn(
+                    get_logger().warning(
                         "Router replay is enabled, but inference.enable_return_routed_experts is False. Setting to True."
                     )
                 self.inference.enable_return_routed_experts = True
             else:
-                warnings.warn(
+                get_logger().warning(
                     "Router replay is enabled, but inference is not configured. When manually starting the inference server, make sure to pass `--enable-return-routed-experts` to the vLLM server."
                 )
         return self

--- a/src/prime_rl/configs/trainer.py
+++ b/src/prime_rl/configs/trainer.py
@@ -1,4 +1,3 @@
-import warnings
 from pathlib import Path
 from typing import Annotated, Any, Literal, TypeAlias
 
@@ -14,6 +13,7 @@ from prime_rl.configs.shared import (
     WandbConfig,
 )
 from prime_rl.utils.config import BaseConfig
+from prime_rl.utils.logger import get_logger
 
 # -- Shared trainer configs (used by both SFT and RL trainers) --
 
@@ -333,7 +333,7 @@ class ModelConfig(BaseModelConfig):
                     f"Fused LM head chunk size must be at least {low}, got {self.fused_lm_head_chunk_size}"
                 )
             if self.fused_lm_head_chunk_size < warn_threshold:
-                warnings.warn(
+                get_logger().warning(
                     f"Fused LM head chunk size is set to {self.fused_lm_head_chunk_size}, which is less than the recommended threshold of {warn_threshold}. This may cause some runs to diverge due to numerical instability in floating point arithmetic."
                 )
 


### PR DESCRIPTION
## Summary
- Removes the noisy `UserWarning` about missing W&B run ID for orchestrator when resuming training
- Changes other logs from `warnings` to PRIME-RL logger

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only affects how/when warnings are emitted during configuration validation; no training/inference logic or persisted data paths change.
> 
> **Overview**
> Reduces config-time warning noise by removing the `RLConfig.warn_wandb_resume_id_missing` validator that emitted `UserWarning`s when resuming without a W&B run ID.
> 
> Standardizes remaining config warnings by replacing `warnings.warn` with `get_logger().warning` in `RLConfig` (LoRA/inference and router replay setup) and `TrainerConfig` (fused LM head chunk size advisory), and drops the now-unused `warnings` imports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b09f7ff1bca72a7b009abdead84a8efed32d134. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->