### PR TITLE
fix: Patch `get_encode_kwargs` to prevent HF tokenizer left-truncation

### DIFF
--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -201,8 +201,27 @@ def monkey_patch_tokenize_params_validation():
                 )
         return text
 
+    def _patched_get_encode_kwargs(self):
+        """Use max_total_tokens (max_model_len) instead of max_input_tokens for HF tokenizer truncation.
+
+        The original uses max_input_tokens (= max_model_len - max_tokens) + 1, which causes HuggingFace's
+        tokenizer.encode() to left-truncate prompts before _token_len_check even runs.
+        """
+        max_length = self.truncate_prompt_tokens
+        if max_length is not None and max_length < 0:
+            max_length = self.max_total_tokens
+        elif max_length is None and self.max_total_tokens is not None:
+            max_length = self.max_total_tokens + 1
+
+        return dict(
+            truncation=max_length is not None,
+            max_length=max_length,
+            add_special_tokens=self.add_special_tokens,
+        )
+
     TokenizeParams._token_len_check = _patched_token_len_check
     TokenizeParams._text_len_check = _patched_text_len_check
+    TokenizeParams.get_encode_kwargs = _patched_get_encode_kwargs
 
 
 def monkey_patch_hermes_tool_parser_thread_safety():


### PR DESCRIPTION
`monkey_patch_tokenize_params_validation` patches `_token_len_check` to accept prompts up to `max_model_len`, but `get_encode_kwargs` still passes `max_length=max_input_tokens+1` (= `max_model_len - max_tokens + 1`) to the HuggingFace tokenizer. HF silently left-truncates prompts to that limit *before* `_token_len_check` ever runs, so the patched validation never sees the overlong prompt.

With `max_model_len=32768` and `max_tokens=8192`, any prompt exceeding 24577 tokens is left-truncated, stripping the system prompt and early conversation turns. Every subsequent MITO extension check fails because the prefix no longer starts at token 0.

### Call trace

1. `vllm/renderers/params.py:227-241` — `get_encode_kwargs` computes `max_length = self.max_input_tokens + 1` (24577) when `truncate_prompt_tokens` is `None`
2. `vllm/renderers/protocol.py:114` — passes `truncation=True, max_length=24577` to `tokenizer.encode()`
3. HuggingFace `tokenizer.encode()` left-truncates to 24577 tokens
4. `patches.py:_patched_token_len_check` sees 24577 < 32768 → passes
5. `interleave_rollout` detects prefix mismatch at position 0 → extension break

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tokenization/truncation behavior for all vLLM requests via monkeypatching, which can affect prompt handling and downstream generation in edge cases near context limits.
> 
> **Overview**
> Updates the `monkey_patch_tokenize_params_validation` vLLM monkeypatch to also override `TokenizeParams.get_encode_kwargs`, so HuggingFace tokenization truncation uses `max_total_tokens` (context length) rather than `max_input_tokens`.
> 
> This prevents HF’s `tokenizer.encode()` from silently left-truncating long prompts before the patched `_token_len_check` runs, preserving full prompt prefixes/system messages when prompts approach the model’s max context.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 916e39ba1136947d6946c6081afdf7b1b93e3c3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->