### PR TITLE
feat: add pre_run_command and common SLURM scheduling options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Documenting changes which affect configuration usage patterns (added/moved/removed/renamed fields, notable logic changes).
 
+- **`slurm.pre_run_command`**: Added optional shell command to run on the head node before starting the job. Useful for cleanup routines (e.g. killing stale processes, removing lock files). For all-nodes execution, wrap with `srun` in the command string (default: None) (2026-03-08)
 - **`orchestrator.verification.enabled`**: Added top-level rollout verification switch. `orchestrator.buffer.skip_verification` has been removed; use `verification.enabled = false` instead. When disabled, rewards are always 0 and reward-dependent buffer features (`online_difficulty_filtering`, `easy_threshold`, `hard_threshold`) must be unset (2026-03-03)
 - **`client.dp_rank_count`**: Added configuration for data-parallel inference routing. When > 1, each `client.base_url` is expanded into `dp_rank_count` logical clients and pinned via `X-data-parallel-rank` to keep multi-turn rollouts on a consistent DP rank (default: 1) (2026-03-03)
 - **`model.lora`**: Moved from `model.experimental.lora` to `model.lora` (no longer experimental) (#1440, 2025-12-16)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Documenting changes which affect configuration usage patterns (added/moved/removed/renamed fields, notable logic changes).
 
 - **`slurm.pre_run_command`**: Added optional shell command to run on the head node before starting the job. Useful for cleanup routines (e.g. killing stale processes, removing lock files). For all-nodes execution, wrap with `srun` in the command string (default: None) (2026-03-08)
+- **`slurm.nodelist`**, **`slurm.exclude`**, **`slurm.account`**, **`slurm.time`**: Added common SLURM scheduling options (all default: None) (2026-03-08)
 - **`orchestrator.verification.enabled`**: Added top-level rollout verification switch. `orchestrator.buffer.skip_verification` has been removed; use `verification.enabled = false` instead. When disabled, rewards are always 0 and reward-dependent buffer features (`online_difficulty_filtering`, `easy_threshold`, `hard_threshold`) must be unset (2026-03-03)
 - **`client.dp_rank_count`**: Added configuration for data-parallel inference routing. When > 1, each `client.base_url` is expanded into `dp_rank_count` logical clients and pinned via `X-data-parallel-rank` to keep multi-turn rollouts on a consistent DP rank (default: 1) (2026-03-03)
 - **`model.lora`**: Moved from `model.experimental.lora` to `model.lora` (no longer experimental) (#1440, 2025-12-16)

--- a/docs/slurm.md
+++ b/docs/slurm.md
@@ -51,7 +51,7 @@ For **multi-node** jobs, sub-configs are written separately and `srun` dispatche
 | `exclude` | Comma-separated list of nodes to exclude (`--exclude`) | `None` |
 | `account` | SLURM account to charge (`--account`) | `None` |
 | `time` | Maximum wall time, e.g. `"24:00:00"` (`--time`) | `None` |
-| `pre_run_command` | Shell command to run on head node before starting the job (e.g. cleanup) | `None` |
+| `pre_run_command` | Shell command to run on head node after env setup, before starting the job (e.g. cleanup) | `None` |
 
 ### `[deployment]` — Node and GPU allocation
 

--- a/docs/slurm.md
+++ b/docs/slurm.md
@@ -47,7 +47,11 @@ For **multi-node** jobs, sub-configs are written separately and `srun` dispatche
 | `project_dir` | Path to the project root on the cluster | `"."` |
 | `template_path` | Path to a custom Jinja2 template | auto-selected |
 | `partition` | SLURM partition | `"cluster"` |
-| `pre_run_command` | Shell command to run on compute nodes before starting the job (e.g. cleanup) | `None` |
+| `nodelist` | Comma-separated list of specific nodes to run on (`--nodelist`) | `None` |
+| `exclude` | Comma-separated list of nodes to exclude (`--exclude`) | `None` |
+| `account` | SLURM account to charge (`--account`) | `None` |
+| `time` | Maximum wall time, e.g. `"24:00:00"` (`--time`) | `None` |
+| `pre_run_command` | Shell command to run on head node before starting the job (e.g. cleanup) | `None` |
 
 ### `[deployment]` — Node and GPU allocation
 

--- a/docs/slurm.md
+++ b/docs/slurm.md
@@ -47,6 +47,7 @@ For **multi-node** jobs, sub-configs are written separately and `srun` dispatche
 | `project_dir` | Path to the project root on the cluster | `"."` |
 | `template_path` | Path to a custom Jinja2 template | auto-selected |
 | `partition` | SLURM partition | `"cluster"` |
+| `pre_run_command` | Shell command to run on compute nodes before starting the job (e.g. cleanup) | `None` |
 
 ### `[deployment]` — Node and GPU allocation
 

--- a/src/prime_rl/configs/shared.py
+++ b/src/prime_rl/configs/shared.py
@@ -51,8 +51,8 @@ class SlurmConfig(BaseConfig):
         str | None,
         Field(
             description="Shell command to run on the head node before starting the job. "
+            "Runs after cd into project dir, .env sourcing, and venv activation. "
             "Useful for cleanup routines like 'sudo pkill -f vllm'. "
-            "For complex logic, point to a script: 'bash scripts/cleanup.sh'. "
             "To run on all nodes, wrap with srun: 'srun bash -c \"pkill -f vllm || true\"'.",
         ),
     ] = None

--- a/src/prime_rl/configs/shared.py
+++ b/src/prime_rl/configs/shared.py
@@ -27,6 +27,15 @@ class SlurmConfig(BaseConfig):
         str, Field(description="The SLURM partition to use. Will be passed as #SBATCH --partition.")
     ] = "cluster"
 
+    pre_run_command: Annotated[
+        str | None,
+        Field(
+            description="Shell command to run on each compute node before starting the job. "
+            "Useful for cleanup routines like 'sudo pkill -f vllm'. "
+            "For complex logic, point to a script: 'bash scripts/cleanup.sh'.",
+        ),
+    ] = None
+
     @model_validator(mode="after")
     def resolve_project_dir(self):
         self.project_dir = self.project_dir.resolve()

--- a/src/prime_rl/configs/shared.py
+++ b/src/prime_rl/configs/shared.py
@@ -30,9 +30,10 @@ class SlurmConfig(BaseConfig):
     pre_run_command: Annotated[
         str | None,
         Field(
-            description="Shell command to run on each compute node before starting the job. "
+            description="Shell command to run on the head node before starting the job. "
             "Useful for cleanup routines like 'sudo pkill -f vllm'. "
-            "For complex logic, point to a script: 'bash scripts/cleanup.sh'.",
+            "For complex logic, point to a script: 'bash scripts/cleanup.sh'. "
+            "To run on all nodes, wrap with srun: 'srun bash -c \"pkill -f vllm || true\"'.",
         ),
     ] = None
 

--- a/src/prime_rl/configs/shared.py
+++ b/src/prime_rl/configs/shared.py
@@ -27,6 +27,26 @@ class SlurmConfig(BaseConfig):
         str, Field(description="The SLURM partition to use. Will be passed as #SBATCH --partition.")
     ] = "cluster"
 
+    nodelist: Annotated[
+        str | None,
+        Field(description="Comma-separated list of specific nodes to run on. Passed as #SBATCH --nodelist."),
+    ] = None
+
+    exclude: Annotated[
+        str | None,
+        Field(description="Comma-separated list of nodes to exclude. Passed as #SBATCH --exclude."),
+    ] = None
+
+    account: Annotated[
+        str | None,
+        Field(description="SLURM account to charge. Passed as #SBATCH --account."),
+    ] = None
+
+    time: Annotated[
+        str | None,
+        Field(description="Maximum wall time (e.g. '24:00:00', '7-00:00:00'). Passed as #SBATCH --time."),
+    ] = None
+
     pre_run_command: Annotated[
         str | None,
         Field(
@@ -36,6 +56,20 @@ class SlurmConfig(BaseConfig):
             "To run on all nodes, wrap with srun: 'srun bash -c \"pkill -f vllm || true\"'.",
         ),
     ] = None
+
+    @property
+    def template_vars(self) -> dict:
+        """Common template variables for all SLURM templates."""
+        return {
+            "job_name": self.job_name,
+            "project_dir": self.project_dir,
+            "partition": self.partition,
+            "nodelist": self.nodelist,
+            "exclude": self.exclude,
+            "account": self.account,
+            "time": self.time,
+            "pre_run_command": self.pre_run_command,
+        }
 
     @model_validator(mode="after")
     def resolve_project_dir(self):

--- a/src/prime_rl/entrypoints/inference.py
+++ b/src/prime_rl/entrypoints/inference.py
@@ -33,15 +33,12 @@ def write_slurm_script(config: InferenceConfig, config_path: Path, script_path: 
     template = env.get_template(config.slurm.template_path.name)
 
     script = template.render(
+        **config.slurm.template_vars,
         config_path=config_path,
         output_dir=config.output_dir,
-        job_name=config.slurm.job_name,
-        project_dir=config.slurm.project_dir,
         gpus_per_node=config.deployment.gpus_per_node,
-        partition=config.slurm.partition,
         num_nodes=config.deployment.num_nodes if config.deployment.type == "multi_node" else 1,
         port=config.server.port,
-        pre_run_command=config.slurm.pre_run_command,
     )
 
     script_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/prime_rl/entrypoints/inference.py
+++ b/src/prime_rl/entrypoints/inference.py
@@ -41,6 +41,7 @@ def write_slurm_script(config: InferenceConfig, config_path: Path, script_path: 
         partition=config.slurm.partition,
         num_nodes=config.deployment.num_nodes if config.deployment.type == "multi_node" else 1,
         port=config.server.port,
+        pre_run_command=config.slurm.pre_run_command,
     )
 
     script_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -382,22 +382,17 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
 
     if config.deployment.type == "single_node":
         script = template.render(
+            **config.slurm.template_vars,
             config_path=config_dir / RL_TOML,
-            job_name=config.slurm.job_name,
-            project_dir=config.slurm.project_dir,
-            partition=config.slurm.partition,
             output_dir=config.output_dir,
             gpus_per_node=config.deployment.gpus_per_node,
-            pre_run_command=config.slurm.pre_run_command,
         )
     else:
         assert config.inference is not None
 
         script = template.render(
+            **config.slurm.template_vars,
             config_dir=config_dir,  # TODO: should prob have each subconfig path separately
-            job_name=config.slurm.job_name,
-            project_dir=config.slurm.project_dir,
-            partition=config.slurm.partition,
             output_dir=config.output_dir,
             orchestrator_output_dir=config.orchestrator.output_dir,
             num_train_nodes=config.deployment.num_train_nodes,
@@ -408,7 +403,6 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
             inference_enable_expert_parallel=config.inference.enable_expert_parallel,
             inference_data_parallel_rpc_port=config.inference.data_parallel_rpc_port,
             use_nccl_broadcast=config.weight_broadcast is not None and config.weight_broadcast.type == "nccl",
-            pre_run_command=config.slurm.pre_run_command,
         )
 
     script_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -388,6 +388,7 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
             partition=config.slurm.partition,
             output_dir=config.output_dir,
             gpus_per_node=config.deployment.gpus_per_node,
+            pre_run_command=config.slurm.pre_run_command,
         )
     else:
         assert config.inference is not None
@@ -407,6 +408,7 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
             inference_enable_expert_parallel=config.inference.enable_expert_parallel,
             inference_data_parallel_rpc_port=config.inference.data_parallel_rpc_port,
             use_nccl_broadcast=config.weight_broadcast is not None and config.weight_broadcast.type == "nccl",
+            pre_run_command=config.slurm.pre_run_command,
         )
 
     script_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/prime_rl/entrypoints/sft.py
+++ b/src/prime_rl/entrypoints/sft.py
@@ -45,6 +45,7 @@ def write_slurm_script(config: SFTConfig, config_path: Path, script_path: Path) 
             project_dir=config.slurm.project_dir,
             gpus_per_node=config.deployment.gpus_per_node,
             partition=config.slurm.partition,
+            pre_run_command=config.slurm.pre_run_command,
         )
     else:
         script = template.render(
@@ -55,6 +56,7 @@ def write_slurm_script(config: SFTConfig, config_path: Path, script_path: Path) 
             num_nodes=config.deployment.num_nodes,
             gpus_per_node=config.deployment.gpus_per_node,
             partition=config.slurm.partition,
+            pre_run_command=config.slurm.pre_run_command,
         )
 
     script_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/prime_rl/entrypoints/sft.py
+++ b/src/prime_rl/entrypoints/sft.py
@@ -39,24 +39,18 @@ def write_slurm_script(config: SFTConfig, config_path: Path, script_path: Path) 
 
     if config.deployment.type == "single_node":
         script = template.render(
+            **config.slurm.template_vars,
             config_path=config_path,
             output_dir=config.output_dir,
-            job_name=config.slurm.job_name,
-            project_dir=config.slurm.project_dir,
             gpus_per_node=config.deployment.gpus_per_node,
-            partition=config.slurm.partition,
-            pre_run_command=config.slurm.pre_run_command,
         )
     else:
         script = template.render(
+            **config.slurm.template_vars,
             config_path=config_path,
             output_dir=config.output_dir,
-            job_name=config.slurm.job_name,
-            project_dir=config.slurm.project_dir,
             num_nodes=config.deployment.num_nodes,
             gpus_per_node=config.deployment.gpus_per_node,
-            partition=config.slurm.partition,
-            pre_run_command=config.slurm.pre_run_command,
         )
 
     script_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/prime_rl/templates/inference.sbatch.j2
+++ b/src/prime_rl/templates/inference.sbatch.j2
@@ -44,8 +44,8 @@ echo "HOSTNAMES=${HOSTNAMES[@]}"
 echo "INFER_URLS=${INFER_URLS}"
 
 {% if pre_run_command %}
-# Pre-run command (runs on all nodes)
-srun bash -c '{{ pre_run_command }}'
+# Pre-run command
+{{ pre_run_command }}
 {% endif %}
 
 # Run inference (each node runs an independent vLLM replica)

--- a/src/prime_rl/templates/inference.sbatch.j2
+++ b/src/prime_rl/templates/inference.sbatch.j2
@@ -43,9 +43,11 @@ done
 echo "HOSTNAMES=${HOSTNAMES[@]}"
 echo "INFER_URLS=${INFER_URLS}"
 
-# Cleanup any leftover vLLM processes
-srun bash -c "pkill -9 -f vllm || true"
+{% if pre_run_command %}
+# Pre-run command (runs on all nodes)
+srun bash -c '{{ pre_run_command }}'
 
+{% endif %}
 # Run inference (each node runs an independent vLLM replica)
 srun bash -c '
     cd $PROJECT_DIR

--- a/src/prime_rl/templates/inference.sbatch.j2
+++ b/src/prime_rl/templates/inference.sbatch.j2
@@ -5,11 +5,19 @@
 #SBATCH --ntasks-per-node=1
 #SBATCH --gres=gpu:{{ gpus_per_node }}
 #SBATCH --partition={{ partition }}
-{% if account %}#SBATCH --account={{ account }}
-{% endif %}{% if time %}#SBATCH --time={{ time }}
-{% endif %}{% if nodelist %}#SBATCH --nodelist={{ nodelist }}
-{% endif %}{% if exclude %}#SBATCH --exclude={{ exclude }}
-{% endif %}#SBATCH --exclusive
+{%- if account %}
+#SBATCH --account={{ account }}
+{%- endif %}
+{%- if time %}
+#SBATCH --time={{ time }}
+{%- endif %}
+{%- if nodelist %}
+#SBATCH --nodelist={{ nodelist }}
+{%- endif %}
+{%- if exclude %}
+#SBATCH --exclude={{ exclude }}
+{%- endif %}
+#SBATCH --exclusive
 #SBATCH --output={{ output_dir }}/job_%j.log
 #SBATCH --error={{ output_dir }}/job_%j.log
 

--- a/src/prime_rl/templates/inference.sbatch.j2
+++ b/src/prime_rl/templates/inference.sbatch.j2
@@ -46,8 +46,8 @@ echo "INFER_URLS=${INFER_URLS}"
 {% if pre_run_command %}
 # Pre-run command (runs on all nodes)
 srun bash -c '{{ pre_run_command }}'
-
 {% endif %}
+
 # Run inference (each node runs an independent vLLM replica)
 srun bash -c '
     cd $PROJECT_DIR

--- a/src/prime_rl/templates/inference.sbatch.j2
+++ b/src/prime_rl/templates/inference.sbatch.j2
@@ -5,7 +5,11 @@
 #SBATCH --ntasks-per-node=1
 #SBATCH --gres=gpu:{{ gpus_per_node }}
 #SBATCH --partition={{ partition }}
-#SBATCH --exclusive
+{% if account %}#SBATCH --account={{ account }}
+{% endif %}{% if time %}#SBATCH --time={{ time }}
+{% endif %}{% if nodelist %}#SBATCH --nodelist={{ nodelist }}
+{% endif %}{% if exclude %}#SBATCH --exclude={{ exclude }}
+{% endif %}#SBATCH --exclusive
 #SBATCH --output={{ output_dir }}/job_%j.log
 #SBATCH --error={{ output_dir }}/job_%j.log
 

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -83,8 +83,8 @@ uv sync --all-extras
 {% if pre_run_command %}
 # Pre-run command (runs on all nodes)
 srun bash -c '{{ pre_run_command }}'
-
 {% endif %}
+
 # Run RL
 srun bash -c '
     # Source environment

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -81,8 +81,8 @@ source .venv/bin/activate
 uv sync --all-extras
 
 {% if pre_run_command %}
-# Pre-run command (runs on all nodes)
-srun bash -c '{{ pre_run_command }}'
+# Pre-run command
+{{ pre_run_command }}
 {% endif %}
 
 # Run RL

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -5,11 +5,19 @@
 #SBATCH --ntasks-per-node=1
 #SBATCH --gres=gpu:{{ gpus_per_node }}
 #SBATCH --partition={{ partition }}
-{% if account %}#SBATCH --account={{ account }}
-{% endif %}{% if time %}#SBATCH --time={{ time }}
-{% endif %}{% if nodelist %}#SBATCH --nodelist={{ nodelist }}
-{% endif %}{% if exclude %}#SBATCH --exclude={{ exclude }}
-{% endif %}#SBATCH --exclusive
+{%- if account %}
+#SBATCH --account={{ account }}
+{%- endif %}
+{%- if time %}
+#SBATCH --time={{ time }}
+{%- endif %}
+{%- if nodelist %}
+#SBATCH --nodelist={{ nodelist }}
+{%- endif %}
+{%- if exclude %}
+#SBATCH --exclude={{ exclude }}
+{%- endif %}
+#SBATCH --exclusive
 #SBATCH --output={{ output_dir }}/job_%j.log
 #SBATCH --error={{ output_dir }}/job_%j.log
 

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -80,6 +80,11 @@ cd $PROJECT_DIR
 source .venv/bin/activate
 uv sync --all-extras
 
+{% if pre_run_command %}
+# Pre-run command (runs on all nodes)
+srun bash -c '{{ pre_run_command }}'
+
+{% endif %}
 # Run RL
 srun bash -c '
     # Source environment

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -5,7 +5,11 @@
 #SBATCH --ntasks-per-node=1
 #SBATCH --gres=gpu:{{ gpus_per_node }}
 #SBATCH --partition={{ partition }}
-#SBATCH --exclusive
+{% if account %}#SBATCH --account={{ account }}
+{% endif %}{% if time %}#SBATCH --time={{ time }}
+{% endif %}{% if nodelist %}#SBATCH --nodelist={{ nodelist }}
+{% endif %}{% if exclude %}#SBATCH --exclude={{ exclude }}
+{% endif %}#SBATCH --exclusive
 #SBATCH --output={{ output_dir }}/job_%j.log
 #SBATCH --error={{ output_dir }}/job_%j.log
 

--- a/src/prime_rl/templates/multi_node_sft.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_sft.sbatch.j2
@@ -41,6 +41,11 @@ source $PROJECT_DIR/.venv/bin/activate
 cd $PROJECT_DIR && uv sync --all-extras
 
 
+{% if pre_run_command %}
+# Pre-run command (runs on all nodes)
+srun bash -c '{{ pre_run_command }}'
+
+{% endif %}
 # Run SFT
 srun bash -c '
     # Setup environment

--- a/src/prime_rl/templates/multi_node_sft.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_sft.sbatch.j2
@@ -42,8 +42,8 @@ cd $PROJECT_DIR && uv sync --all-extras
 
 
 {% if pre_run_command %}
-# Pre-run command (runs on all nodes)
-srun bash -c '{{ pre_run_command }}'
+# Pre-run command
+{{ pre_run_command }}
 {% endif %}
 
 # Run SFT

--- a/src/prime_rl/templates/multi_node_sft.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_sft.sbatch.j2
@@ -44,8 +44,8 @@ cd $PROJECT_DIR && uv sync --all-extras
 {% if pre_run_command %}
 # Pre-run command (runs on all nodes)
 srun bash -c '{{ pre_run_command }}'
-
 {% endif %}
+
 # Run SFT
 srun bash -c '
     # Setup environment

--- a/src/prime_rl/templates/multi_node_sft.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_sft.sbatch.j2
@@ -5,11 +5,19 @@
 #SBATCH --ntasks-per-node=1
 #SBATCH --gres=gpu:{{ gpus_per_node }}
 #SBATCH --partition={{ partition }}
-{% if account %}#SBATCH --account={{ account }}
-{% endif %}{% if time %}#SBATCH --time={{ time }}
-{% endif %}{% if nodelist %}#SBATCH --nodelist={{ nodelist }}
-{% endif %}{% if exclude %}#SBATCH --exclude={{ exclude }}
-{% endif %}#SBATCH --exclusive
+{%- if account %}
+#SBATCH --account={{ account }}
+{%- endif %}
+{%- if time %}
+#SBATCH --time={{ time }}
+{%- endif %}
+{%- if nodelist %}
+#SBATCH --nodelist={{ nodelist }}
+{%- endif %}
+{%- if exclude %}
+#SBATCH --exclude={{ exclude }}
+{%- endif %}
+#SBATCH --exclusive
 #SBATCH --output={{ output_dir }}/job_%j.log
 #SBATCH --error={{ output_dir }}/job_%j.log
 

--- a/src/prime_rl/templates/multi_node_sft.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_sft.sbatch.j2
@@ -5,7 +5,11 @@
 #SBATCH --ntasks-per-node=1
 #SBATCH --gres=gpu:{{ gpus_per_node }}
 #SBATCH --partition={{ partition }}
-#SBATCH --exclusive
+{% if account %}#SBATCH --account={{ account }}
+{% endif %}{% if time %}#SBATCH --time={{ time }}
+{% endif %}{% if nodelist %}#SBATCH --nodelist={{ nodelist }}
+{% endif %}{% if exclude %}#SBATCH --exclude={{ exclude }}
+{% endif %}#SBATCH --exclusive
 #SBATCH --output={{ output_dir }}/job_%j.log
 #SBATCH --error={{ output_dir }}/job_%j.log
 

--- a/src/prime_rl/templates/single_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/single_node_rl.sbatch.j2
@@ -10,6 +10,11 @@
 #SBATCH --error={{ output_dir }}/job_%j.log
 
 export PROJECT_DIR={{ project_dir }}
+{% if pre_run_command %}
+
+# Pre-run command
+{{ pre_run_command }}
+{% endif %}
 
 # Setup environment
 cd $PROJECT_DIR

--- a/src/prime_rl/templates/single_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/single_node_rl.sbatch.j2
@@ -15,7 +15,6 @@ export PROJECT_DIR={{ project_dir }}
 # Pre-run command
 {{ pre_run_command }}
 {% endif %}
-
 # Setup environment
 cd $PROJECT_DIR
 [ -f .env ] && source .env

--- a/src/prime_rl/templates/single_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/single_node_rl.sbatch.j2
@@ -6,7 +6,11 @@
 #SBATCH --gres=gpu:{{ gpus_per_node }}
 #SBATCH --exclusive
 #SBATCH --partition={{ partition }}
-#SBATCH --output={{ output_dir }}/job_%j.log
+{% if account %}#SBATCH --account={{ account }}
+{% endif %}{% if time %}#SBATCH --time={{ time }}
+{% endif %}{% if nodelist %}#SBATCH --nodelist={{ nodelist }}
+{% endif %}{% if exclude %}#SBATCH --exclude={{ exclude }}
+{% endif %}#SBATCH --output={{ output_dir }}/job_%j.log
 #SBATCH --error={{ output_dir }}/job_%j.log
 
 export PROJECT_DIR={{ project_dir }}

--- a/src/prime_rl/templates/single_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/single_node_rl.sbatch.j2
@@ -22,15 +22,15 @@
 #SBATCH --error={{ output_dir }}/job_%j.log
 
 export PROJECT_DIR={{ project_dir }}
-{% if pre_run_command %}
 
-# Pre-run command
-{{ pre_run_command }}
-{% endif %}
 # Setup environment
 cd $PROJECT_DIR
 [ -f .env ] && source .env
 source .venv/bin/activate
 uv sync --all-extras
 
+{% if pre_run_command %}
+# Pre-run command
+{{ pre_run_command }}
+{% endif %}
 uv run rl @ {{ config_path }}

--- a/src/prime_rl/templates/single_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/single_node_rl.sbatch.j2
@@ -6,11 +6,19 @@
 #SBATCH --gres=gpu:{{ gpus_per_node }}
 #SBATCH --exclusive
 #SBATCH --partition={{ partition }}
-{% if account %}#SBATCH --account={{ account }}
-{% endif %}{% if time %}#SBATCH --time={{ time }}
-{% endif %}{% if nodelist %}#SBATCH --nodelist={{ nodelist }}
-{% endif %}{% if exclude %}#SBATCH --exclude={{ exclude }}
-{% endif %}#SBATCH --output={{ output_dir }}/job_%j.log
+{%- if account %}
+#SBATCH --account={{ account }}
+{%- endif %}
+{%- if time %}
+#SBATCH --time={{ time }}
+{%- endif %}
+{%- if nodelist %}
+#SBATCH --nodelist={{ nodelist }}
+{%- endif %}
+{%- if exclude %}
+#SBATCH --exclude={{ exclude }}
+{%- endif %}
+#SBATCH --output={{ output_dir }}/job_%j.log
 #SBATCH --error={{ output_dir }}/job_%j.log
 
 export PROJECT_DIR={{ project_dir }}

--- a/src/prime_rl/templates/single_node_sft.sbatch.j2
+++ b/src/prime_rl/templates/single_node_sft.sbatch.j2
@@ -10,6 +10,11 @@
 #SBATCH --error={{ output_dir }}/job_%j.log
 
 export PROJECT_DIR={{ project_dir }}
+{% if pre_run_command %}
+
+# Pre-run command
+{{ pre_run_command }}
+{% endif %}
 
 # Setup environment
 cd $PROJECT_DIR

--- a/src/prime_rl/templates/single_node_sft.sbatch.j2
+++ b/src/prime_rl/templates/single_node_sft.sbatch.j2
@@ -15,7 +15,6 @@ export PROJECT_DIR={{ project_dir }}
 # Pre-run command
 {{ pre_run_command }}
 {% endif %}
-
 # Setup environment
 cd $PROJECT_DIR
 [ -f .env ] && source .env

--- a/src/prime_rl/templates/single_node_sft.sbatch.j2
+++ b/src/prime_rl/templates/single_node_sft.sbatch.j2
@@ -6,7 +6,11 @@
 #SBATCH --gres=gpu:{{ gpus_per_node }}
 #SBATCH --exclusive
 #SBATCH --partition={{ partition }}
-#SBATCH --output={{ output_dir }}/job_%j.log
+{% if account %}#SBATCH --account={{ account }}
+{% endif %}{% if time %}#SBATCH --time={{ time }}
+{% endif %}{% if nodelist %}#SBATCH --nodelist={{ nodelist }}
+{% endif %}{% if exclude %}#SBATCH --exclude={{ exclude }}
+{% endif %}#SBATCH --output={{ output_dir }}/job_%j.log
 #SBATCH --error={{ output_dir }}/job_%j.log
 
 export PROJECT_DIR={{ project_dir }}

--- a/src/prime_rl/templates/single_node_sft.sbatch.j2
+++ b/src/prime_rl/templates/single_node_sft.sbatch.j2
@@ -6,11 +6,19 @@
 #SBATCH --gres=gpu:{{ gpus_per_node }}
 #SBATCH --exclusive
 #SBATCH --partition={{ partition }}
-{% if account %}#SBATCH --account={{ account }}
-{% endif %}{% if time %}#SBATCH --time={{ time }}
-{% endif %}{% if nodelist %}#SBATCH --nodelist={{ nodelist }}
-{% endif %}{% if exclude %}#SBATCH --exclude={{ exclude }}
-{% endif %}#SBATCH --output={{ output_dir }}/job_%j.log
+{%- if account %}
+#SBATCH --account={{ account }}
+{%- endif %}
+{%- if time %}
+#SBATCH --time={{ time }}
+{%- endif %}
+{%- if nodelist %}
+#SBATCH --nodelist={{ nodelist }}
+{%- endif %}
+{%- if exclude %}
+#SBATCH --exclude={{ exclude }}
+{%- endif %}
+#SBATCH --output={{ output_dir }}/job_%j.log
 #SBATCH --error={{ output_dir }}/job_%j.log
 
 export PROJECT_DIR={{ project_dir }}

--- a/src/prime_rl/templates/single_node_sft.sbatch.j2
+++ b/src/prime_rl/templates/single_node_sft.sbatch.j2
@@ -22,15 +22,15 @@
 #SBATCH --error={{ output_dir }}/job_%j.log
 
 export PROJECT_DIR={{ project_dir }}
-{% if pre_run_command %}
 
-# Pre-run command
-{{ pre_run_command }}
-{% endif %}
 # Setup environment
 cd $PROJECT_DIR
 [ -f .env ] && source .env
 source .venv/bin/activate
 uv sync --all-extras
 
+{% if pre_run_command %}
+# Pre-run command
+{{ pre_run_command }}
+{% endif %}
 uv run sft @ {{ config_path }}


### PR DESCRIPTION
## Summary

- Adds `slurm.pre_run_command` (`str | None`) to run a cleanup command on the head node before starting the job
- Adds common SLURM scheduling options: `nodelist`, `exclude`, `account`, `time`
- Extracts shared slurm template variables into `SlurmConfig.template_vars` to reduce duplication across entrypoints
- Replaces the hardcoded `pkill -9 -f vllm` in the inference template with the configurable `pre_run_command`

### Usage

```toml
[slurm]
job_name = "my-job"
pre_run_command = "sudo pkill -f vllm || true"
exclude = "badnode01,badnode02"
account = "myproject"
time = "24:00:00"
nodelist = "gpu-node-[01-04]"
```

For complex cleanup, point to a script:
```toml
[slurm]
pre_run_command = "bash scripts/cleanup.sh"
```

## Test plan

- [x] Verify single-node SFT/RL templates render correctly with and without optional fields
- [x] Verify multi-node RL template renders correctly with `pre_run_command`
- [x] Confirm optional SBATCH directives only appear when set
- [x] Confirm inference template no longer has hardcoded `pkill` when `pre_run_command` is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SLURM job submission templates/entrypoints and introduces an optional arbitrary shell hook (`pre_run_command`), which can change cluster job behavior if misconfigured.
> 
> **Overview**
> Adds new `[slurm]` config fields (`nodelist`, `exclude`, `account`, `time`) plus `pre_run_command` to optionally run a user-specified shell command before launching RL/SFT/inference jobs.
> 
> Refactors SLURM script rendering to pass a shared `SlurmConfig.template_vars` dict into templates, and updates all default `.sbatch.j2` templates to conditionally emit the new `#SBATCH` directives and run `pre_run_command` (replacing the previously hardcoded vLLM `pkill` in the inference template). Documentation and `CHANGELOG` are updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2d2e3f222d92caea15b561539d8ad9a10d15c23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->