### PR TITLE
fix crash when pad_token_id is a list

### DIFF
--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -254,6 +254,11 @@ def get_model(
         )
         model_config.pad_token_id = pad_token_id
 
+    # Some HF configs (e.g. Llama 3.2) set pad_token_id to a list, which crashes
+    # transformers' GenerationConfig.validate() when it does `pad_token_id < 0`.
+    if isinstance(getattr(model_config, "pad_token_id", None), list):
+        model_config.pad_token_id = model_config.pad_token_id[0]
+
     # NOTE: For VLM models, we do NOT propagate dtype to sub_configs.
     # The model should load in its default dtype (bf16) to match vLLM inference.
     # The FSDP MixedPrecisionPolicy handles compute dtype separately.


### PR DESCRIPTION
Fixes #1990. Llama 3.2 HF configs have pad_token_id as a list which crashes transformers GenerationConfig.validate(). Converts list pad_token_id to first element before from_config call.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, defensive config normalization during model loading; low risk aside from potentially masking misconfigured models by silently picking the first ID.
> 
> **Overview**
> Prevents a model-load crash for Hugging Face configs (notably Llama 3.2) that define `pad_token_id` as a list.
> 
> `get_model` now normalizes a list `pad_token_id` to its first element before `GenerationConfig` validation / model instantiation, keeping padding setup compatible across transformer versions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5ff2a150ae5492a035fc64338fcf76620861f96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->