### PR TITLE
fix env args type coercion from tyro CLI

### DIFF
--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -319,6 +319,7 @@ class EnvConfig(BaseConfig):
         """Coerce env args types after tyro CLI parsing (which makes all dict values strings)."""
         self.args = _coerce_dict_values(self.args)
         return self
+
     name: Annotated[str | None, Field(description="Name of the environment to use.")] = None
     address: Annotated[
         str | None,

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -270,34 +270,41 @@ class EvalSaveHFConfig(BaseConfig):
 def _coerce_dict_values(d: dict) -> dict:
     """Coerce string values from CLI parsing to their proper types.
 
-    tyro parses untyped dict values as strings. This converts them back:
-    "800" -> 800, "3.14" -> 3.14, "true"/"false" -> bool.
+    tyro parses untyped dict values as strings. This only runs when ALL values
+    are strings (i.e. from CLI parsing). TOML/programmatic configs already have
+    proper types so they pass through unchanged.
+
+    Converts: "800" -> 800, "3.14" -> 3.14, "true"/"false" -> bool.
     """
+    if not d or not all(isinstance(v, str) for v in d.values()):
+        return d
+
     coerced = {}
     for k, v in d.items():
-        if isinstance(v, str):
-            # Try int
-            try:
-                coerced[k] = int(v)
+        # Try bool first (before int, since int("true") would fail anyway)
+        if v.lower() == "true":
+            coerced[k] = True
+            continue
+        if v.lower() == "false":
+            coerced[k] = False
+            continue
+        # Try int (only if the string representation round-trips cleanly)
+        try:
+            int_val = int(v)
+            if str(int_val) == v:
+                coerced[k] = int_val
                 continue
-            except ValueError:
-                pass
-            # Try float
-            try:
-                coerced[k] = float(v)
+        except ValueError:
+            pass
+        # Try float
+        try:
+            float_val = float(v)
+            if str(float_val) == v:
+                coerced[k] = float_val
                 continue
-            except ValueError:
-                pass
-            # Try bool
-            if v.lower() == "true":
-                coerced[k] = True
-                continue
-            if v.lower() == "false":
-                coerced[k] = False
-                continue
-            coerced[k] = v
-        else:
-            coerced[k] = v
+        except ValueError:
+            pass
+        coerced[k] = v
     return coerced
 
 

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -267,11 +267,51 @@ class EvalSaveHFConfig(BaseConfig):
     ] = False
 
 
+def _coerce_dict_values(d: dict) -> dict:
+    """Coerce string values from CLI parsing to their proper types.
+
+    tyro parses untyped dict values as strings. This converts them back:
+    "800" -> 800, "3.14" -> 3.14, "true"/"false" -> bool.
+    """
+    coerced = {}
+    for k, v in d.items():
+        if isinstance(v, str):
+            # Try int
+            try:
+                coerced[k] = int(v)
+                continue
+            except ValueError:
+                pass
+            # Try float
+            try:
+                coerced[k] = float(v)
+                continue
+            except ValueError:
+                pass
+            # Try bool
+            if v.lower() == "true":
+                coerced[k] = True
+                continue
+            if v.lower() == "false":
+                coerced[k] = False
+                continue
+            coerced[k] = v
+        else:
+            coerced[k] = v
+    return coerced
+
+
 class EnvConfig(BaseConfig):
     """Configures an environment for training."""
 
     id: Annotated[str, Field(description="ID of the environment to use.")] = "reverse-text"
     args: Annotated[dict, Field(description="Arguments to pass to the environment.")] = {}
+
+    @model_validator(mode="after")
+    def coerce_args_types(self):
+        """Coerce env args types after tyro CLI parsing (which makes all dict values strings)."""
+        self.args = _coerce_dict_values(self.args)
+        return self
     name: Annotated[str | None, Field(description="Name of the environment to use.")] = None
     address: Annotated[
         str | None,


### PR DESCRIPTION
tyro parses untyped dict values as strings, so env args like viewport_width=800 become '800'. Adds a validator on EnvConfig that coerces string values back to int/float/bool.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to config validation that only affects CLI-provided `EnvConfig.args` values; low likelihood of impact outside type conversion edge cases (e.g., leading zeros or non-round-trippable floats).
> 
> **Overview**
> Fixes `EnvConfig.args` coming from tyro CLI parsing being treated as all-strings by coercing values back to basic types.
> 
> Adds `_coerce_dict_values` plus an `EnvConfig` `@model_validator(mode="after")` that converts `"true"/"false"` to booleans and round-trippable numeric strings to `int`/`float`, while leaving TOML/programmatic (already-typed) dicts unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f92e08e0fc6dca7f40747ed426dea062a24fdbcb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->