### PR TITLE
fix: support VLM models in NCCL weight broadcast layer parsing

### DIFF
--- a/src/prime_rl/trainer/rl/broadcast/nccl.py
+++ b/src/prime_rl/trainer/rl/broadcast/nccl.py
@@ -76,11 +76,7 @@ def filter_state_dict_by_layers(
         prefix = f"{layers_prefix}{i}"
         yield (
             i,
-            {
-                key: value
-                for key, value in state_dict.items()
-                if key.startswith(f"{prefix}.") or key == prefix
-            },
+            {key: value for key, value in state_dict.items() if key.startswith(f"{prefix}.") or key == prefix},
         )
 
 

--- a/src/prime_rl/trainer/rl/broadcast/nccl.py
+++ b/src/prime_rl/trainer/rl/broadcast/nccl.py
@@ -15,7 +15,7 @@ from prime_rl.trainer.models import PreTrainedModelPrimeRL
 from prime_rl.trainer.rl.broadcast.base import WeightBroadcast
 from prime_rl.trainer.runs import get_multi_run_manager
 from prime_rl.trainer.utils import get_world
-from prime_rl.trainer.weights import get_max_layer_num
+from prime_rl.trainer.weights import get_layers_prefix, get_max_layer_num
 from prime_rl.utils.logger import get_logger
 from prime_rl.utils.pathing import sync_wait_for_path
 from prime_rl.utils.utils import get_broadcast_dir, get_step_path
@@ -67,18 +67,19 @@ def broadcast_state_dict(state_dict: dict[str, Tensor], communicator: PyNcclComm
 
 
 def filter_state_dict_by_layers(
-    state_dict: dict[str, torch.Tensor], num_layers: int
+    state_dict: dict[str, torch.Tensor], num_layers: int, layers_prefix: str
 ) -> Generator[tuple[int, dict[str, torch.Tensor]], None, None]:
     """Yield a generator of state dicts for each layer as well as the remaining weights."""
-    yield 0, {key: value for key, value in state_dict.items() if "model.layers" not in key}
+    yield 0, {key: value for key, value in state_dict.items() if layers_prefix not in key}
 
     for i in range(1, num_layers + 1):  # +1 because layer indices start from 1
+        prefix = f"{layers_prefix}{i}"
         yield (
             i,
             {
                 key: value
                 for key, value in state_dict.items()
-                if key.startswith(f"model.layers.{i}.") or key == f"model.layers.{i}"
+                if key.startswith(f"{prefix}.") or key == prefix
             },
         )
 
@@ -112,6 +113,7 @@ class NCCLWeightBroadcastSender:
     def broadcast_weights(self, model: nn.Module, step: int) -> None:
         """Broadcast the state dict of a model into the inference pool using NCCL."""
         state_dict = model.state_dict()
+        layers_prefix = get_layers_prefix(state_dict)
         num_layers = get_max_layer_num(state_dict)
         num_state_dict_to_send = num_layers + 1  # we send all layer plus the remaining weights
 
@@ -120,7 +122,7 @@ class NCCLWeightBroadcastSender:
 
         self.logger.debug(f"Broadcasting {num_state_dict_to_send} layer state dicts")
 
-        for layer_id, state_dict in filter_state_dict_by_layers(state_dict, num_layers):
+        for layer_id, state_dict in filter_state_dict_by_layers(state_dict, num_layers, layers_prefix):
             for key, value in list(state_dict.items()):
                 if isinstance(value, DTensor):
                     value = cast(DTensor, value.to(self.dtype)).full_tensor()

--- a/src/prime_rl/trainer/weights.py
+++ b/src/prime_rl/trainer/weights.py
@@ -1,4 +1,5 @@
 import json
+import re
 import warnings
 from pathlib import Path
 from typing import Literal, cast
@@ -33,9 +34,26 @@ def _strip_pytorch_wrapper_prefix(key: str) -> str:
     return key
 
 
+_LAYER_RE = re.compile(r"^model\.(?:\w+\.)*layers\.(\d+)\b")
+
+
+def get_layers_prefix(state_dict: dict[str, Tensor]) -> str:
+    """Detect the layers prefix in state_dict keys."""
+    for key in state_dict:
+        m = _LAYER_RE.search(key)
+        if m:
+            return key[: m.start(1)]
+    raise ValueError("No 'model.[*.]layers.N' pattern found in state_dict keys")
+
+
 def get_max_layer_num(state_dict: dict[str, Tensor]) -> int:
     """Get the maximum number of layers in the model."""
-    return max(int(i.split(".")[2]) for i in state_dict.keys() if "model.layers." in i) + 1
+    prefix = get_layers_prefix(state_dict)
+    matches = [_LAYER_RE.search(key) for key in state_dict if key.startswith(prefix)]
+    layer_nums = [int(m.group(1)) for m in matches if m]
+    if not layer_nums:
+        raise ValueError(f"No layer keys found with prefix '{prefix}'")
+    return max(layer_nums) + 1
 
 
 def load_state_dict_keys(save_dir: Path) -> list[str]:


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                                               

  NCCL weight broadcast fails for VLM (e.g. `Qwen/Qwen3.5-35B-A3B`) with:

`  ValueError: invalid literal for int() with base 10: 'layers'`

  **Bug:** `get_max_layer_num` and `filter_state_dict_by_layers` hardcode `"model.layers."` as the layer key prefix. VLM models nests the text decoder under `model.language_model.layers.N` instead of `model.layers.N`. The
   substring check `"model.layers." in key` falsely matches (the substring appears inside `language_model.layers.`), and then `key.split(".")[2]` yields `"layers"` instead of a layer number.

  **Fix:**
  - Add `get_layers_prefix()` to dynamically detect the layers prefix via regex
  - Update `get_max_layer_num()` and `filter_state_dict_by_layers()` to use the detected prefix

  Backwards-compatible: for standard decoder models the detected prefix is `"model.layers."` and behavior is unchanged.

  ## Test

  Verified with `Qwen/Qwen3.5-35B-A3B` using NCCL broadcast, training completes and all layer state dicts are broadcast successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized parsing change to weight key handling; primary risk is mis-detecting the layer prefix and broadcasting an incorrect set of weights for unusual state_dict key formats.
> 
> **Overview**
> Fixes NCCL weight broadcasting for VLM-style models by **dynamically detecting the transformer layer key prefix** instead of hardcoding `model.layers.`.
> 
> Adds `get_layers_prefix()` (regex-based) and updates `get_max_layer_num()` plus `filter_state_dict_by_layers()`/`NCCLWeightBroadcastSender.broadcast_weights()` to use the detected prefix when splitting state dicts into per-layer shards for broadcast.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74624966e62df63b40b20d26e2fe618eeed21a5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->