### PR TITLE
Fix _tied_weights_keys for transformers v5

### DIFF
--- a/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
+++ b/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
@@ -512,7 +512,7 @@ class AfmoeModel(AfmoePreTrainedModel):
 
 
 class AfmoeForCausalLM(AfmoePreTrainedModel, GenerationMixin):
-    _tied_weights_keys = ["lm_head.weight"]
+    _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
     _tp_plan = {"lm_head": "colwise_rep"}
     _pp_plan = {"lm_head": (["hidden_states"], ["logits"])}
 

--- a/src/prime_rl/trainer/models/glm4_moe/modeling_glm4_moe.py
+++ b/src/prime_rl/trainer/models/glm4_moe/modeling_glm4_moe.py
@@ -249,7 +249,7 @@ class Glm4MoeModel(Glm4MoePreTrainedModel):
 
 @auto_docstring
 class Glm4MoeForCausalLM(Glm4MoePreTrainedModel, GenerationMixin):
-    _tied_weights_keys = ["lm_head.weight"]
+    _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
     _tp_plan = {"lm_head": "colwise_rep"}
     _pp_plan = {"lm_head": (["hidden_states"], ["logits"])}
 

--- a/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
+++ b/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
@@ -376,7 +376,7 @@ class GlmMoeDsaModel(GlmMoeDsaPreTrainedModel):
 
 @auto_docstring
 class GlmMoeDsaForCausalLM(GlmMoeDsaPreTrainedModel, GenerationMixin):
-    _tied_weights_keys = ["lm_head.weight"]
+    _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
     _tp_plan = {"lm_head": "colwise_rep"}
     _pp_plan = {"lm_head": (["hidden_states"], ["logits"])}
 

--- a/src/prime_rl/trainer/models/llama/modeling_llama.py
+++ b/src/prime_rl/trainer/models/llama/modeling_llama.py
@@ -222,7 +222,7 @@ class LlamaModel(LlamaPreTrainedModel):
 
 @auto_docstring
 class LlamaForCausalLM(LlamaPreTrainedModel, GenerationMixin):
-    _tied_weights_keys = ["lm_head.weight"]
+    _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
     _tp_plan = {"lm_head": "colwise_rep"}
     _pp_plan = {"lm_head": (["hidden_states"], ["logits"])}
 

--- a/src/prime_rl/trainer/models/minimax_m2/modeling_minimax_m2.py
+++ b/src/prime_rl/trainer/models/minimax_m2/modeling_minimax_m2.py
@@ -210,7 +210,7 @@ class MiniMaxM2Model(MiniMaxM2PreTrainedModel):
 
 @auto_docstring
 class MiniMaxM2ForCausalLM(MiniMaxM2PreTrainedModel, GenerationMixin):
-    _tied_weights_keys = ["lm_head.weight"]
+    _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
     _tp_plan = {"lm_head": "colwise_rep"}
     _pp_plan = {"lm_head": (["hidden_states"], ["logits"])}
 

--- a/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
@@ -333,7 +333,7 @@ def load_balancing_loss_func(
 
 @auto_docstring
 class Qwen3MoeForCausalLM(Qwen3MoePreTrainedModel, GenerationMixin):
-    _tied_weights_keys = ["lm_head.weight"]
+    _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
     _tp_plan = {"lm_head": "colwise_rep"}
     _pp_plan = {"lm_head": (["hidden_states"], ["logits"])}
 

--- a/tests/unit/train/models/afmoe_hf_modeling/modeling_afmoe.py
+++ b/tests/unit/train/models/afmoe_hf_modeling/modeling_afmoe.py
@@ -563,7 +563,7 @@ class AfmoeModel(AfmoePreTrainedModel):
 
 
 class AfmoeForCausalLM(AfmoePreTrainedModel, GenerationMixin):
-    _tied_weights_keys = ["lm_head.weight"]
+    _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
     _tp_plan = {"lm_head": "colwise_rep"}
     _pp_plan = {"lm_head": (["hidden_states"], ["logits"])}
 


### PR DESCRIPTION
Transformers v5 changed _tied_weights_keys from a list to a dict format. This was missed when transformers was bumped in #1731 (Feb 13), causing all custom model impls to crash on post_init().

Error on trainer startup:

    AttributeError: 'list' object has no attribute 'keys'
    File "transformers/modeling_utils.py", line 2489, in get_expanded_tied_weights_keys

Wasn't caught because prod Llama stacks stayed pinned on v0.4.0-54 (transformers 4.x) and dev stacks only deployed non-MoE Qwen3 models which use upstream HF classes.

Fix: `["lm_head.weight"]` -> `{"lm_head.weight": "model.embed_tokens.weight"}` across all custom models.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches model initialization/weight-tying metadata across several architectures; while mechanically simple, an incorrect mapping could affect checkpoint loading or tied-weights behavior at runtime.
> 
> **Overview**
> Fixes compatibility with Transformers v5 by updating custom `*ForCausalLM` implementations to use the new dict-form `_tied_weights_keys` mapping `lm_head.weight` to `model.embed_tokens.weight`.
> 
> This change is applied across the in-tree custom models (`Afmoe`, `Glm4Moe`, `GlmMoeDsa`, `Llama`, `MiniMaxM2`, `Qwen3Moe`) and the mirrored unit-test `Afmoe` HF modeling to prevent `post_init()` crashes and restore weight tying behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1204cc3541ca20edcf35b5ef9faabef864c1c4bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->