### PR TITLE
chore: add Claude Code review GitHub Action

### DIFF
--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -1,0 +1,35 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  claude:
+    if: |
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Review this pull request for code quality, correctness, and security.
+            Analyze the diff, then post your findings as review comments.


### PR DESCRIPTION
## Summary
- Adds `anthropics/claude-code-action@v1` workflow for automated PR code review
- Reviews run automatically on PR open/sync/reopen, checking for code quality, correctness, and security
- Supports `@claude` mentions in PR and issue comments for interactive assistance

## Setup
Add `ANTHROPIC_API_KEY` to repository secrets (Settings → Secrets → Actions).

Optionally install the [Claude GitHub App](https://github.com/apps/claude) for richer interactions.

## Test plan
- [ ] Add `ANTHROPIC_API_KEY` secret to the repo
- [ ] Open a test PR and verify the Claude Code Review check appears
- [ ] Test `@claude` mention in a PR comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an external GitHub Action with broad write permissions and secret usage, which can impact repo/PR content if misconfigured or compromised.
> 
> **Overview**
> Introduces a new `.github/workflows/claude.yaml` workflow that triggers on PR open/sync/reopen and on new issue/review comments containing `@claude`.
> 
> The job checks out the repo (including submodules) and runs `anthropics/claude-code-action@v1` using the `ANTHROPIC_API_KEY` secret, with write permissions to post/update PR and issue content and review comments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14103c262b8c44b8f4b7873d2e3a74601aca390c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->