### PR TITLE
fix: harden CI git bootstrap against CUDA mirror sync

### DIFF
--- a/.github/workflows/gpu_tests.yaml
+++ b/.github/workflows/gpu_tests.yaml
@@ -22,8 +22,14 @@ jobs:
     steps:
       - name: Install Git
         run: |
-          apt-get update
-          apt-get install -y git
+          if ! command -v git >/dev/null 2>&1; then
+            cuda_repo_files="$(grep -rl --fixed-strings 'developer.download.nvidia.com/compute/cuda/repos' /etc/apt/sources.list.d 2>/dev/null || true)"
+            for repo_file in $cuda_repo_files; do
+              mv "$repo_file" "$repo_file.disabled"
+            done
+            apt-get update
+            apt-get install -y git
+          fi
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -81,8 +87,14 @@ jobs:
     steps:
       - name: Install Git
         run: |
-          apt-get update
-          apt-get install -y git
+          if ! command -v git >/dev/null 2>&1; then
+            cuda_repo_files="$(grep -rl --fixed-strings 'developer.download.nvidia.com/compute/cuda/repos' /etc/apt/sources.list.d 2>/dev/null || true)"
+            for repo_file in $cuda_repo_files; do
+              mv "$repo_file" "$repo_file.disabled"
+            done
+            apt-get update
+            apt-get install -y git
+          fi
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -66,8 +66,14 @@ jobs:
         steps:
             - name: Install Git
               run: |
-                  apt-get update
-                  apt-get install -y git
+                  if ! command -v git >/dev/null 2>&1; then
+                      cuda_repo_files="$(grep -rl --fixed-strings 'developer.download.nvidia.com/compute/cuda/repos' /etc/apt/sources.list.d 2>/dev/null || true)"
+                      for repo_file in $cuda_repo_files; do
+                          mv "$repo_file" "$repo_file.disabled"
+                      done
+                      apt-get update
+                      apt-get install -y git
+                  fi
                   git config --global --add safe.directory "$GITHUB_WORKSPACE"
             - name: Checkout repository
               uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
fixing 
<img width="3206" height="1362" alt="image" src="https://github.com/user-attachments/assets/78e6e663-e8b8-429e-9855-e8aad8cda0a4" />


- skip apt entirely when the GPU test container already has git
- disable the NVIDIA CUDA apt source before installing git when the package is actually missing
- apply the same bootstrap hardening to nightly GPU jobs

## Root cause
The GPU workflow was failing before checkout because apt-get update hit the NVIDIA CUDA Ubuntu 22.04 repo during a mirror sync window and exited with a mirror-sync error.

Example failing job: https://github.com/PrimeIntellect-ai/prime-rl/actions/runs/22871551681/job/66352377730?pr=1998

## Validation
- git diff --check
- parsed the updated workflow YAML successfully with uv run python

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that affects CI bootstrapping; main risk is inadvertently disabling needed apt sources if the grep matches unexpected files, but impact is limited to CI containers.
> 
> **Overview**
> Hardens GPU CI workflows by making the `Install Git` step resilient to NVIDIA CUDA apt repo mirror-sync failures.
> 
> For `gpu_tests.yaml` and `nightly_tests.yaml`, the job now **skips `apt-get` entirely when `git` is already present**, and otherwise **disables CUDA apt source list entries** under `/etc/apt/sources.list.d` before running `apt-get update && apt-get install -y git` to avoid update-time failures that block checkout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ccb27b31774cb2a62239b65fa4b8e2da2c8912b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->