### PR TITLE
Add built-in PPO clip and REINFORCE loss, normalized and reinforce ad…

### DIFF
--- a/docs/bring-your-own-algorithms.md
+++ b/docs/bring-your-own-algorithms.md
@@ -36,7 +36,36 @@ class LossOutputs:
     metrics: dict[str, Tensor]      # Metrics to log
 ```
 
-### Example: PPO Clipped Loss
+### Built-in loss types
+
+You can use these without writing custom code by setting `type` in `[trainer.loss]`:
+
+| Type | Description | Key config |
+|------|-------------|------------|
+| `default` | IPO-style loss (DPPO-Binary TV + KL); supports teacher distillation | `ipo_mask_low`, `ipo_mask_high`, `adv_tau`, `teacher_tau`, `kl_tau` |
+| `ppo_clip` | Token-level PPO clipped surrogate; optional KL penalty vs reference policy | `clip_eps` (default: 0.2), `kl_coef`, `entropy_coef` |
+| `reinforce` | REINFORCE policy gradient: -log π(a\|s) * A | `entropy_coef` |
+| `custom` | Your own function via `import_path` and `kwargs` | `import_path`, `kwargs` |
+
+Example: PPO clip with optional KL penalty:
+
+```toml
+[trainer.loss]
+type = "ppo_clip"
+clip_eps = 0.2
+kl_coef = 0.01
+```
+
+Example: REINFORCE:
+
+```toml
+[trainer.loss]
+type = "reinforce"
+```
+
+### Example: Custom PPO-style loss (advanced)
+
+If you need a variant not covered by the built-in `ppo_clip`, you can still plug in a custom loss:
 
 ```python
 import torch
@@ -57,7 +86,7 @@ def ppo_clip_loss(inputs: LossInputs, clip_eps: float = 0.2) -> LossOutputs:
     )
 ```
 
-### Configuration
+### Custom loss configuration
 
 ```toml
 [loss]
@@ -98,7 +127,33 @@ class AdvantageOutputs:
     advantages: Float[Tensor, "num_examples rollouts_per_example"]
 ```
 
-### Example: Normalized Advantage
+### Built-in advantage types
+
+You can use these by setting `type` in the orchestrator’s advantage config (e.g. `[orchestrator.advantage]` or the config key your entrypoint uses):
+
+| Type | Description | Key config |
+|------|-------------|------------|
+| `default` | Reward minus per-problem baseline (GRPO-style); optional length-weighted mean | `length_weighted_mean` |
+| `normalized` | Zero-mean, unit-variance per problem | `eps` |
+| `reinforce` | Raw rewards as advantages (no baseline); use with REINFORCE loss | — |
+| `custom` | Your own function via `import_path` and `kwargs` | `import_path`, `kwargs` |
+
+Example: normalized advantages:
+
+```toml
+[orchestrator.advantage]
+type = "normalized"
+eps = 1e-8
+```
+
+Example: REINFORCE (raw rewards):
+
+```toml
+[orchestrator.advantage]
+type = "reinforce"
+```
+
+### Example: Custom normalized advantage (advanced)
 
 ```python
 import torch
@@ -112,7 +167,7 @@ def normalized_advantage(inputs: AdvantageInputs, eps: float = 1e-8) -> Advantag
     return AdvantageOutputs(advantages=advantages)
 ```
 
-### Configuration
+### Custom advantage configuration
 
 ```toml
 [advantage]
@@ -123,14 +178,14 @@ kwargs = { eps = 1e-8 }
 
 ---
 
-## Default Implementations
+## Default behavior
 
-If no custom function is specified:
+If you do not set a custom or built-in type:
 
-- **Loss**: Uses `default_loss_fn` (masked importance sampling with KL against the inference policy, and optional masking strategies)
-- **Advantage**: Uses `default_advantage_fn` (reward minus per-example baseline, a.k.a. DR-GRPO without std normalization)
+- **Loss**: Uses `default` (IPO-style masked importance sampling with KL and optional teacher).
+- **Advantage**: Uses `default` (reward minus per-example baseline).
 
-See `LossConfig` and `AdvantageConfig` for available parameters.
+See `LossConfig` and `AdvantageConfig` in the codebase for all parameters.
 
 ## Tips
 

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -530,12 +530,32 @@ class VerificationConfig(BaseConfig):
 
 
 class DefaultAdvantageConfig(BaseModel):
-    """Config for the default advantage."""
+    """Config for the default advantage (reward minus per-problem baseline, GRPO-style)."""
 
     model_config = ConfigDict(extra="forbid")
 
     type: Literal["default"] = "default"
     length_weighted_mean: bool = False
+
+
+class NormalizedAdvantageConfig(BaseModel):
+    """Config for zero-mean, unit-variance normalized advantages per problem."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["normalized"] = "normalized"
+    eps: Annotated[
+        float,
+        Field(ge=0, description="Small constant added to std for numerical stability."),
+    ] = 1e-8
+
+
+class ReinforceAdvantageConfig(BaseModel):
+    """Config for raw rewards as advantages (no baseline). Used with REINFORCE loss."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["reinforce"] = "reinforce"
 
 
 class CustomAdvantageConfig(BaseModel):
@@ -551,7 +571,7 @@ class CustomAdvantageConfig(BaseModel):
 
 
 AdvantageConfig: TypeAlias = Annotated[
-    DefaultAdvantageConfig | CustomAdvantageConfig,
+    DefaultAdvantageConfig | NormalizedAdvantageConfig | ReinforceAdvantageConfig | CustomAdvantageConfig,
     Field(discriminator="type"),
 ]
 

--- a/src/prime_rl/configs/trainer.py
+++ b/src/prime_rl/configs/trainer.py
@@ -525,6 +525,36 @@ class DefaultLossConfig(BaseModel):
     kl_tau: Annotated[float, Field(ge=0, description="The tau for KL divergence.")] = 1e-3
 
 
+class PPOClipLossConfig(BaseModel):
+    """Config for PPO-style clipped surrogate loss (token-level)."""
+
+    type: Literal["ppo_clip"] = "ppo_clip"
+
+    clip_eps: Annotated[
+        float,
+        Field(gt=0, le=1, description="PPO clipping range; ratio is clamped to [1 - clip_eps, 1 + clip_eps]."),
+    ] = 0.2
+    kl_coef: Annotated[
+        float,
+        Field(ge=0, description="Coefficient for KL penalty vs reference (inference) policy."),
+    ] = 0.0
+    entropy_coef: Annotated[
+        float,
+        Field(ge=0, description="Coefficient for entropy bonus (not used unless trainer passes entropy)."),
+    ] = 0.0
+
+
+class ReinforceLossConfig(BaseModel):
+    """Config for REINFORCE / policy gradient loss: -log π(a|s) * A."""
+
+    type: Literal["reinforce"] = "reinforce"
+
+    entropy_coef: Annotated[
+        float,
+        Field(ge=0, description="Coefficient for entropy bonus (not used unless trainer passes entropy)."),
+    ] = 0.0
+
+
 class CustomLossConfig(BaseModel):
     """Config for a custom external loss function."""
 
@@ -534,7 +564,10 @@ class CustomLossConfig(BaseModel):
     kwargs: Annotated[dict[str, Any], Field(default_factory=dict, description="Kwargs to pass to the loss function")]
 
 
-LossConfig: TypeAlias = Annotated[DefaultLossConfig | CustomLossConfig, Field(discriminator="type")]
+LossConfig: TypeAlias = Annotated[
+    DefaultLossConfig | PPOClipLossConfig | ReinforceLossConfig | CustomLossConfig,
+    Field(discriminator="type"),
+]
 
 
 class FakeDataLoaderConfig(BaseConfig):

--- a/src/prime_rl/orchestrator/advantage.py
+++ b/src/prime_rl/orchestrator/advantage.py
@@ -5,7 +5,12 @@ import torch
 from jaxtyping import Float, Int
 from torch import Tensor
 
-from prime_rl.configs.orchestrator import AdvantageConfig, CustomAdvantageConfig
+from prime_rl.configs.orchestrator import (
+    AdvantageConfig,
+    CustomAdvantageConfig,
+    NormalizedAdvantageConfig,
+    ReinforceAdvantageConfig,
+)
 from prime_rl.utils.utils import import_object
 
 
@@ -45,6 +50,19 @@ def default_advantage_fn(inputs: AdvantageInputs, length_weighted_mean: bool = F
     return AdvantageOutputs(advantages=inputs.rewards - baseline)
 
 
+def normalized_advantage_fn(inputs: AdvantageInputs, eps: float = 1e-8) -> AdvantageOutputs:
+    """Normalize advantages to zero mean and unit variance per problem."""
+    mean = inputs.rewards.mean(dim=1, keepdim=True)
+    std = inputs.rewards.std(dim=1, keepdim=True)
+    advantages = (inputs.rewards - mean) / (std + eps)
+    return AdvantageOutputs(advantages=advantages)
+
+
+def reinforce_advantage_fn(inputs: AdvantageInputs) -> AdvantageOutputs:
+    """Use raw rewards as advantages (no baseline)."""
+    return AdvantageOutputs(advantages=inputs.rewards.clone())
+
+
 def setup_advantage_fn(config: AdvantageConfig) -> AdvantageFn:
     """Setup advantage function from config."""
     if isinstance(config, CustomAdvantageConfig):
@@ -55,6 +73,14 @@ def setup_advantage_fn(config: AdvantageConfig) -> AdvantageFn:
             return custom_fn(inputs, **kwargs)
 
         return advantage_fn
+
+    if isinstance(config, NormalizedAdvantageConfig):
+        def advantage_fn(inputs: AdvantageInputs) -> AdvantageOutputs:
+            return normalized_advantage_fn(inputs, eps=config.eps)
+        return advantage_fn
+
+    if isinstance(config, ReinforceAdvantageConfig):
+        return reinforce_advantage_fn
 
     def advantage_fn(inputs: AdvantageInputs) -> AdvantageOutputs:
         return default_advantage_fn(inputs, length_weighted_mean=config.length_weighted_mean)

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -6,7 +6,13 @@ from beartype import beartype as typechecker
 from jaxtyping import Bool, Float, Int, jaxtyped
 from torch import Tensor
 
-from prime_rl.configs.trainer import CustomLossConfig, DefaultLossConfig, LossConfig
+from prime_rl.configs.trainer import (
+    CustomLossConfig,
+    DefaultLossConfig,
+    LossConfig,
+    PPOClipLossConfig,
+    ReinforceLossConfig,
+)
 from prime_rl.utils.utils import import_object
 
 
@@ -163,6 +169,46 @@ def default_loss_fn(inputs: LossInputs, loss_config: DefaultLossConfig) -> LossO
     return LossOutputs(loss=loss, metrics=metrics)
 
 
+def ppo_clip_loss_fn(inputs: LossInputs, loss_config: PPOClipLossConfig) -> LossOutputs:
+    """PPO clipped surrogate loss (token-level): min(r * A, clip(r) * A) with optional KL penalty."""
+    trainer_logprobs = inputs.trainer_logprobs
+    inference_logprobs = inputs.inference_logprobs
+    advantages = inputs.advantages
+    loss_mask = inputs.loss_mask
+
+    log_ratio = trainer_logprobs - inference_logprobs
+    ratio = torch.exp(log_ratio)
+    clipped_ratio = torch.clamp(
+        ratio, 1.0 - loss_config.clip_eps, 1.0 + loss_config.clip_eps
+    )
+    surr1 = ratio * advantages
+    surr2 = clipped_ratio * advantages
+    pg_loss = torch.min(surr1, surr2)
+    loss = -pg_loss[loss_mask].sum()
+
+    metrics = {
+        "clip_frac": _safe_mean((ratio != clipped_ratio).float(), loss_mask),
+    }
+    if loss_config.kl_coef > 0:
+        kl = (inference_logprobs - trainer_logprobs)[loss_mask].sum()
+        loss = loss + loss_config.kl_coef * kl
+        metrics["kl_ref"] = _safe_mean(inference_logprobs - trainer_logprobs, loss_mask)
+
+    return LossOutputs(loss=loss, metrics=metrics)
+
+
+def reinforce_loss_fn(inputs: LossInputs, loss_config: ReinforceLossConfig) -> LossOutputs:
+    """REINFORCE policy gradient: -sum(log π(a|s) * A) over masked tokens."""
+    trainer_logprobs = inputs.trainer_logprobs
+    advantages = inputs.advantages
+    loss_mask = inputs.loss_mask
+
+    pg_loss = trainer_logprobs * advantages
+    loss = -pg_loss[loss_mask].sum()
+    metrics: dict[str, Tensor] = {}
+    return LossOutputs(loss=loss, metrics=metrics)
+
+
 def setup_loss_fn(loss_config: LossConfig) -> LossFn:
     """Setup the loss function based on config."""
     if isinstance(loss_config, CustomLossConfig):
@@ -172,6 +218,16 @@ def setup_loss_fn(loss_config: LossConfig) -> LossFn:
         def loss_fn(inputs: LossInputs) -> LossOutputs:
             return custom_fn(inputs, **kwargs)
 
+        return loss_fn
+
+    if isinstance(loss_config, PPOClipLossConfig):
+        def loss_fn(inputs: LossInputs) -> LossOutputs:
+            return ppo_clip_loss_fn(inputs, loss_config)
+        return loss_fn
+
+    if isinstance(loss_config, ReinforceLossConfig):
+        def loss_fn(inputs: LossInputs) -> LossOutputs:
+            return reinforce_loss_fn(inputs, loss_config)
         return loss_fn
 
     def loss_fn(inputs: LossInputs) -> LossOutputs:

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -16,7 +16,12 @@ from prime_rl.trainer.ckpt import setup_ckpt_managers
 from prime_rl.trainer.multi_ckpt import setup_multi_checkpoint_manager
 from prime_rl.trainer.optim import setup_optimizer, setup_multi_optimizer
 from prime_rl.trainer.scheduler import setup_scheduler, setup_multi_scheduler
-from prime_rl.configs.trainer import DefaultLossConfig, TrainerConfig
+from prime_rl.configs.trainer import (
+    DefaultLossConfig,
+    PPOClipLossConfig,
+    ReinforceLossConfig,
+    TrainerConfig,
+)
 from prime_rl.trainer.rl.data import DataLoader, FakeDataLoader
 from prime_rl.utils.cp import (
     setup_cp_params,
@@ -294,7 +299,10 @@ def train(config: TrainerConfig):
         seq_len = micro_batches[0]["input_ids"].shape[1]
 
         # Normalize by the local number of unmasked tokens in the batch (per-batch length normalization)
-        if isinstance(config.loss, DefaultLossConfig):
+        if isinstance(
+            config.loss,
+            (DefaultLossConfig, PPOClipLossConfig, ReinforceLossConfig),
+        ):
             loss_scale = sum(micro_batch["loss_mask"].sum().item() for micro_batch in micro_batches)
         else:
             loss_scale = batch_size

--- a/tests/unit/orchestrator/test_advantage.py
+++ b/tests/unit/orchestrator/test_advantage.py
@@ -1,11 +1,18 @@
 import torch
 
-from prime_rl.configs.orchestrator import CustomAdvantageConfig, DefaultAdvantageConfig
+from prime_rl.configs.orchestrator import (
+    CustomAdvantageConfig,
+    DefaultAdvantageConfig,
+    NormalizedAdvantageConfig,
+    ReinforceAdvantageConfig,
+)
 from prime_rl.orchestrator.advantage import (
     AdvantageInputs,
     AdvantageOutputs,
     compute_advantages,
     default_advantage_fn,
+    normalized_advantage_fn,
+    reinforce_advantage_fn,
     setup_advantage_fn,
 )
 
@@ -55,6 +62,49 @@ def test_compute_advantages_without_config():
     result = compute_advantages(rewards, lengths, samples_per_problem=3, advantage_config=None)
 
     # Without config, returns raw rewards
+    assert result == rewards
+
+
+def test_normalized_advantage_fn():
+    inputs = AdvantageInputs(
+        rewards=torch.tensor([[1.0, 0.5, 0.8], [0.2, 0.9, 0.1]]),
+        completion_lengths=torch.tensor([[10, 12, 8], [15, 11, 9]]),
+    )
+    result = normalized_advantage_fn(inputs, eps=1e-8)
+    assert result.advantages.shape == (2, 3)
+    assert torch.allclose(result.advantages.mean(dim=1), torch.zeros(2), atol=1e-6)
+    assert torch.allclose(result.advantages.std(dim=1), torch.ones(2), atol=1e-5)
+
+
+def test_reinforce_advantage_fn():
+    inputs = AdvantageInputs(
+        rewards=torch.tensor([[1.0, 0.5, 0.8]]),
+        completion_lengths=torch.tensor([[10, 12, 8]]),
+    )
+    result = reinforce_advantage_fn(inputs)
+    assert torch.allclose(result.advantages, inputs.rewards)
+
+
+def test_setup_advantage_fn_normalized_config():
+    result = compute_advantages(
+        [1.0, 0.5, 0.8, 0.2, 0.9, 0.1],
+        [10, 12, 8, 15, 11, 9],
+        samples_per_problem=3,
+        advantage_config=NormalizedAdvantageConfig(),
+    )
+    assert len(result) == 6
+    assert abs(sum(result[:3])) < 1e-5
+    assert abs(sum(result[3:])) < 1e-5
+
+
+def test_setup_advantage_fn_reinforce_config():
+    rewards = [1.0, 0.5, 0.8, 0.2, 0.9, 0.1]
+    result = compute_advantages(
+        rewards,
+        [10, 12, 8, 15, 11, 9],
+        samples_per_problem=3,
+        advantage_config=ReinforceAdvantageConfig(),
+    )
     assert result == rewards
 
 

--- a/tests/unit/train/rl/test_loss.py
+++ b/tests/unit/train/rl/test_loss.py
@@ -1,20 +1,25 @@
 import pytest
 import torch
 
-from prime_rl.configs.trainer import CustomLossConfig, DefaultLossConfig
+from prime_rl.configs.trainer import (
+    CustomLossConfig,
+    DefaultLossConfig,
+    PPOClipLossConfig,
+    ReinforceLossConfig,
+)
 from prime_rl.trainer.rl.loss import LossInputs, LossOutputs, compute_entropy, compute_loss, setup_loss_fn
 
 pytestmark = [pytest.mark.gpu]
 
 
-def test_grpo_loss():
+def test_default_loss():
     trainer_logprobs = [torch.randn(50, dtype=torch.float32).cuda(), torch.randn(30, dtype=torch.float32).cuda()]
     inference_logprobs = [torch.randn(50, dtype=torch.float32).cuda(), torch.randn(30, dtype=torch.float32).cuda()]
     teacher_logprobs = [torch.randn(50, dtype=torch.float32).cuda(), torch.randn(30, dtype=torch.float32).cuda()]
     advantages = [torch.randn(50).cuda(), torch.randn(30).cuda()]
     loss_mask = [torch.ones(50, dtype=torch.bool).cuda(), torch.ones(30, dtype=torch.bool).cuda()]
 
-    loss_fn = setup_loss_fn(DefaultLossConfig(ratio_type="token", token_mask_high=10.0))
+    loss_fn = setup_loss_fn(DefaultLossConfig())
     loss, _ = compute_loss(
         trainer_logprobs,
         inference_logprobs,
@@ -27,18 +32,37 @@ def test_grpo_loss():
     assert loss.shape == ()
 
 
-def test_gspo_loss():
+def test_ppo_clip_loss():
     trainer_logprobs = [torch.randn(40, dtype=torch.float32).cuda(), torch.randn(60, dtype=torch.float32).cuda()]
     inference_logprobs = [torch.randn(40, dtype=torch.float32).cuda(), torch.randn(60, dtype=torch.float32).cuda()]
-    teacher_logprobs = [torch.randn(40, dtype=torch.float32).cuda(), torch.randn(60, dtype=torch.float32).cuda()]
     advantages = [torch.randn(40).cuda(), torch.randn(60).cuda()]
     loss_mask = [torch.ones(40, dtype=torch.bool).cuda(), torch.ones(60, dtype=torch.bool).cuda()]
 
-    loss_fn = setup_loss_fn(DefaultLossConfig(ratio_type="sequence", token_mask_high=10.0))
+    loss_fn = setup_loss_fn(PPOClipLossConfig(clip_eps=0.2))
+    loss, metrics = compute_loss(
+        trainer_logprobs,
+        inference_logprobs,
+        [None, None],
+        advantages,
+        loss_mask=loss_mask,
+        loss_fn=loss_fn,
+        loss_scale=1.0,
+    )
+    assert loss.shape == ()
+    assert "clip_frac" in metrics
+
+
+def test_reinforce_loss():
+    trainer_logprobs = [torch.randn(20, dtype=torch.float32).cuda()]
+    inference_logprobs = [torch.randn(20, dtype=torch.float32).cuda()]
+    advantages = [torch.randn(20).cuda()]
+    loss_mask = [torch.ones(20, dtype=torch.bool).cuda()]
+
+    loss_fn = setup_loss_fn(ReinforceLossConfig())
     loss, _ = compute_loss(
         trainer_logprobs,
         inference_logprobs,
-        teacher_logprobs,
+        [None],
         advantages,
         loss_mask=loss_mask,
         loss_fn=loss_fn,


### PR DESCRIPTION
Adds built-in loss and advantage options configurable via TOML.
**Loss (`trainer.loss`):**
- `ppo_clip`: token-level PPO clipped surrogate; `clip_eps`, `kl_coef`, `entropy_coef`
- `reinforce`: policy gradient -log π * A; `entropy_coef`
**Advantage (`orchestrator.advantage`):**
- `normalized`: zero-mean, unit-variance per problem; `eps`
- `reinforce`: raw rewards (no baseline)
Tests and docs (bring-your-own-algorithms.md) updated.