### PR TITLE
disinguish `is_truncated` and log `stop_condition`s

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -602,6 +602,7 @@ async def orchestrate(config: OrchestratorConfig):
                 "reward": [rollout["reward"] for rollout in train_rollouts],
                 "is_truncated": [rollout["is_truncated"] for rollout in train_rollouts],
                 "error": [rollout["error"] for rollout in train_rollouts],
+                "stop_condition": [rollout.get("stop_condition") for rollout in train_rollouts],
                 "seq_len": [get_seq_len(rollout) for rollout in train_rollouts],
                 "prefill_len": rollout_prefill_lens,
                 "decode_len": rollout_decode_lens,
@@ -666,6 +667,14 @@ async def orchestrate(config: OrchestratorConfig):
             "is_truncated/mean": results_df.groupby("example_id").is_truncated.mean().mean(),
             "is_truncated/max": results_df.groupby("example_id").is_truncated.mean().max(),
             "is_truncated/min": results_df.groupby("example_id").is_truncated.mean().min(),
+            "stop_condition/generation_truncated": (
+                results_df.is_truncated & (results_df.stop_condition != "prompt_too_long")
+            ).mean(),
+            # Log rate of each stop condition (e.g. max_turns, prompt_too_long, has_error)
+            **{
+                f"stop_condition/{sc}": rate
+                for sc, rate in results_df.stop_condition.dropna().value_counts(normalize=True).items()
+            },
             # Seqs per rollout metrics
             "samples_per_rollout/mean": results_df.groupby("example_id").samples_per_rollout.mean().mean(),
             "samples_per_rollout/max": results_df.groupby("example_id").samples_per_rollout.mean().max(),


### PR DESCRIPTION
- breaks down `is_truncated` into `overlong_prompt` and `generation_truncation` where it was lumped together previously
- adds verifiers `stop_condition`s to wandb logging

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only changes that add new metrics/columns without altering rollout generation or training behavior.
> 
> **Overview**
> Adds `stop_condition` to the per-rollout `results_df` and emits new W&B metrics that break down truncation into *generation truncation* vs `prompt_too_long`.
> 
> Also logs the normalized rate of each observed `stop_condition` value (e.g. `max_turns`, `has_error`) to make rollout termination causes visible in monitoring.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48ff2934a88e9c2b33c2034fb261237fe97c4b30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->