### PR TITLE
feat: allow num_infer_nodes=0 with fake data in multi-node SLURM RL

### DIFF
--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -152,7 +152,13 @@ class MultiNodeDeploymentConfig(BaseDeploymentConfig):
     type: Literal["multi_node"] = "multi_node"
 
     num_train_nodes: Annotated[int, Field(description="Number of training nodes.")]
-    num_infer_nodes: Annotated[int, Field(description="Number of inference nodes.")]
+    num_infer_nodes: Annotated[
+        int,
+        Field(
+            ge=0,
+            description="Number of inference nodes. Set to 0 to skip inference and orchestrator (requires fake data).",
+        ),
+    ]
     num_teacher_nodes: Annotated[int | None, Field(description="Number of teacher inference nodes.")] = None
 
     nodes_per_fsdp_group: Annotated[
@@ -291,8 +297,18 @@ class RLConfig(BaseConfig):
         if self.deployment.type == "multi_node":
             if self.slurm is None:
                 raise ValueError("Must use SLURM for multi-node deployment.")
-            if not self.inference:
-                raise ValueError("Must configure inference when using multi-node deployment.")
+            if self.deployment.num_infer_nodes > 0 and not self.inference:
+                raise ValueError("Must configure inference when using multi-node deployment with inference nodes.")
+            if self.deployment.num_infer_nodes == 0 and self.inference:
+                raise ValueError(
+                    "Cannot configure inference with num_infer_nodes = 0. "
+                    "Either set num_infer_nodes > 0 or remove the inference config."
+                )
+            if self.deployment.num_infer_nodes == 0 and not self.trainer.data.fake and not self.bench:
+                raise ValueError(
+                    "Must use fake data (trainer.data.fake or bench = true) when num_infer_nodes = 0, "
+                    "since no orchestrator or inference server will be running."
+                )
         return self
 
     # TODO: fix this

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -388,8 +388,6 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
             gpus_per_node=config.deployment.gpus_per_node,
         )
     else:
-        assert config.inference is not None
-
         script = template.render(
             **config.slurm.template_vars,
             config_dir=config_dir,  # TODO: should prob have each subconfig path separately
@@ -399,9 +397,9 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
             num_infer_nodes=config.deployment.num_infer_nodes,
             num_teacher_nodes=config.deployment.num_teacher_nodes,
             gpus_per_node=config.deployment.gpus_per_node,
-            inference_tp=config.inference.parallel.tp,
-            inference_enable_expert_parallel=config.inference.enable_expert_parallel,
-            inference_data_parallel_rpc_port=config.inference.data_parallel_rpc_port,
+            inference_tp=config.inference.parallel.tp if config.inference else 1,
+            inference_enable_expert_parallel=config.inference.enable_expert_parallel if config.inference else False,
+            inference_data_parallel_rpc_port=config.inference.data_parallel_rpc_port if config.inference else 29600,
             use_nccl_broadcast=config.weight_broadcast is not None and config.weight_broadcast.type == "nccl",
         )
 
@@ -431,12 +429,11 @@ def rl_slurm(config: RLConfig):
         logger.info(f"Wrote subconfigs to {config_dir}")
 
         slurm_log_dir = config.output_dir / "slurm"
-        log_message = (
-            f"Logs:\n"
-            f"  Trainer:       tail -F {slurm_log_dir}/latest_train_node_rank_0.log\n"
-            f"  Orchestrator:  tail -F {slurm_log_dir}/latest_orchestrator.log\n"
-            f"  Inference:     tail -F {slurm_log_dir}/latest_infer_node_rank_0.log"
-        )
+        log_lines = [f"  Trainer:       tail -F {slurm_log_dir}/latest_train_node_rank_0.log"]
+        if config.deployment.num_infer_nodes > 0:
+            log_lines.append(f"  Orchestrator:  tail -F {slurm_log_dir}/latest_orchestrator.log")
+            log_lines.append(f"  Inference:     tail -F {slurm_log_dir}/latest_infer_node_rank_0.log")
+        log_message = "Logs:\n" + "\n".join(log_lines)
 
     script_path = config.output_dir / RL_SBATCH
     write_slurm_script(config, config_dir, script_path)

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -25,6 +25,7 @@
 export NUM_TRAIN_NODES={{ num_train_nodes }}
 export NUM_INFER_NODES={{ num_infer_nodes }}
 export GPUS_PER_NODE={{ gpus_per_node }}
+{% if num_infer_nodes > 0 -%}
 export INFERENCE_TP={{ inference_tp }}
 export INFERENCE_ENABLE_EXPERT_PARALLEL={{ "1" if inference_enable_expert_parallel else "0" }}
 export INFERENCE_DATA_PARALLEL_RPC_PORT={{ inference_data_parallel_rpc_port }}
@@ -35,6 +36,7 @@ export USE_DISTRIBUTED_EP=0
 if [ "$INFERENCE_ENABLE_EXPERT_PARALLEL" -eq 1 ] && [ "$NUM_INFER_NODES" -gt 1 ]; then
     USE_DISTRIBUTED_EP=1
 fi
+{%- endif %}
 
 # Paths
 export PROJECT_DIR={{ project_dir }}
@@ -57,10 +59,12 @@ export OMP_NUM_THREADS=1
 
 # Networking
 HOSTNAMES=( $( scontrol show hostnames $SLURM_JOB_NODELIST ) )
-INFER_HOSTS=( ${HOSTNAMES[@]:0:$NUM_INFER_NODES} )
 TRAIN_HOSTS=( ${HOSTNAMES[@]:$NUM_INFER_NODES:$SLURM_JOB_NUM_NODES} )
-export INFER_HEAD_HOST="${INFER_HOSTS[0]}"
 export HOSTNAMES_STR="${HOSTNAMES[*]}"
+
+{% if num_infer_nodes > 0 -%}
+INFER_HOSTS=( ${HOSTNAMES[@]:0:$NUM_INFER_NODES} )
+export INFER_HEAD_HOST="${INFER_HOSTS[0]}"
 
 INFER_URLS=""
 if [ "$USE_DISTRIBUTED_EP" -eq 1 ]; then
@@ -75,11 +79,13 @@ else
     done
 fi
 export INFER_URLS
-echo "HOSTNAMES=${HOSTNAMES[*]}"
-echo "TRAIN_HOSTS=${TRAIN_HOSTS[*]}"
 echo "INFER_HOSTS=${INFER_HOSTS[*]}"
 echo "INFER_URLS=${INFER_URLS}"
 echo "USE_DISTRIBUTED_EP=${USE_DISTRIBUTED_EP}"
+{%- endif %}
+
+echo "HOSTNAMES=${HOSTNAMES[*]}"
+echo "TRAIN_HOSTS=${TRAIN_HOSTS[*]}"
 
 export MASTER_ADDR="${HOSTNAMES[$NUM_INFER_NODES]}"
 export MASTER_PORT=29500
@@ -113,6 +119,7 @@ srun bash -c '
     IB_HCA=$(ibv_devinfo | sed -n -e "/hca_id/p" -e "/link_layer:/p" | grep -B1 InfiniBand | grep hca_id | sed -e "s/^hca_id://g" | tr -d "[[:blank:]]" |paste -sd,)
     export NCCL_IB_HCA=$IB_HCA
 
+{% if num_infer_nodes > 0 -%}
 if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
     export PYTORCH_CUDA_ALLOC_CONF="expandable_segments:False"
     INFER_NODE_RANK=$SLURM_PROCID
@@ -151,6 +158,9 @@ else
         {% endif %}uv run orchestrator $ORCHESTRATOR_ARGS \
             2>&1 | tee $OUTPUT_DIR/slurm/latest_orchestrator.log $OUTPUT_DIR/slurm/job_${SLURM_JOB_ID}_orchestrator.log &
     fi
+{%- else %}
+    TRAIN_NODE_RANK=$SLURM_PROCID
+{%- endif %}
 
     export HF_HUB_OFFLINE=1
 
@@ -172,5 +182,5 @@ else
         -m prime_rl.trainer.rl.train \
         @ $CONFIG_DIR/trainer.toml \
         2>&1 | tee -a $OUTPUT_DIR/slurm/latest_train_node_rank_${TRAIN_NODE_RANK}.log $OUTPUT_DIR/slurm/job_${SLURM_JOB_ID}_train_node_rank_${TRAIN_NODE_RANK}.log
-    fi
+{% if num_infer_nodes > 0 %}    fi{% endif %}
 '

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -166,9 +166,13 @@ def train(config: TrainerConfig):
 
     logger.info(f"Using `{config.scheduler.type}` scheduler ({config.scheduler})")
 
-    # Set up weight broadcast
-    logger.info(f"Initializing weight broadcast ({config.weight_broadcast})")
-    weight_broadcast = setup_weight_broadcast(config.output_dir, config.weight_broadcast, config.model.lora)
+    # Set up weight broadcast (skip when using fake data since there's no inference server)
+    if config.data.fake:
+        weight_broadcast = None
+        logger.info("Skipping weight broadcast setup (fake data mode)")
+    else:
+        logger.info(f"Initializing weight broadcast ({config.weight_broadcast})")
+        weight_broadcast = setup_weight_broadcast(config.output_dir, config.weight_broadcast, config.model.lora)
 
     if parallel_dims.cp_enabled:
         substitute_hf_flash_attn(parallel_dims.world_mesh["cp"].get_group(), heads_k_stride=1)
@@ -217,21 +221,24 @@ def train(config: TrainerConfig):
 
         # Broadcast weights at every step, (except step 0, because no need to broadcast the base model)
         # Also, with NCCL broadcast, we do not broadcast weights the last async level step as the orchestrator is already finished and will not initialize the receive on the inference; for filesystem broadcast, we do "broadcast" until the final step to allow to resume from the broadcast directory
-        last_async_level_steps = config.max_steps and progress.step >= config.max_steps - config.max_async_level
-        if progress.step > 0 and (not last_async_level_steps or config.weight_broadcast.type == "filesystem"):
-            broadcast_weights_start_time = time.perf_counter()
-            weight_broadcast.broadcast_weights(model, step=progress.step)
-            broadcast_weights_time = time.perf_counter() - broadcast_weights_start_time
-            # Clean up old broadcast directories (unless at ckpt interval if using filesystem weight broadcast)
-            ckpt_interval = config.ckpt and config.ckpt.interval
-            interval_to_keep = ckpt_interval if config.weight_broadcast.type == "filesystem" else None
-            if config.weight_broadcast.type == "filesystem":
-                weight_broadcast.maybe_clean(config.max_async_level, interval_to_keep)
-        else:
+        if weight_broadcast is None:
             broadcast_weights_time = 0
-            # Usually the broadcast will set this. If broadcast is skipped, we need to reset this here.
-            for idx in multi_run_manager.used_idxs:
-                multi_run_manager.ready_to_update[idx] = False
+        else:
+            last_async_level_steps = config.max_steps and progress.step >= config.max_steps - config.max_async_level
+            if progress.step > 0 and (not last_async_level_steps or config.weight_broadcast.type == "filesystem"):
+                broadcast_weights_start_time = time.perf_counter()
+                weight_broadcast.broadcast_weights(model, step=progress.step)
+                broadcast_weights_time = time.perf_counter() - broadcast_weights_start_time
+                # Clean up old broadcast directories (unless at ckpt interval if using filesystem weight broadcast)
+                ckpt_interval = config.ckpt and config.ckpt.interval
+                interval_to_keep = ckpt_interval if config.weight_broadcast.type == "filesystem" else None
+                if config.weight_broadcast.type == "filesystem":
+                    weight_broadcast.maybe_clean(config.max_async_level, interval_to_keep)
+            else:
+                broadcast_weights_time = 0
+                # Usually the broadcast will set this. If broadcast is skipped, we need to reset this here.
+                for idx in multi_run_manager.used_idxs:
+                    multi_run_manager.ready_to_update[idx] = False
 
         if (
             ckpt_manager is not None


### PR DESCRIPTION
## Summary
- Allow `num_infer_nodes = 0` in multi-node SLURM deployment to skip inference servers and orchestrator
- Only trainer nodes are launched, using fake data for benchmarking multi-node training without inference resources
- Validates that fake data (`trainer.data.fake` or `bench = true`) is required when `num_infer_nodes = 0`

### Usage
```toml
[deployment]
type = "multi_node"
num_train_nodes = 2
num_infer_nodes = 0

bench = true
max_steps = 10
```

## Test plan
- [x] Config validation: `num_infer_nodes=0` + `bench=true` accepted
- [x] Config validation: `num_infer_nodes=0` without fake data rejected
- [x] Config validation: `num_infer_nodes=0` with inference config rejected
- [x] Config validation: `num_infer_nodes=1` (normal case) still works
- [x] Template renders correctly for both 0 and >0 inference nodes
- [ ] End-to-end SLURM job with `num_infer_nodes=0` + `bench=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes multi-node config validation, SLURM script generation, and trainer weight-broadcast behavior; misconfiguration could lead to jobs that launch the wrong processes or silently skip broadcast/orchestrator steps.
> 
> **Overview**
> Enables **trainer-only multi-node SLURM runs** by allowing `deployment.num_infer_nodes=0`, intended for benchmarking multi-node training without allocating inference/orchestrator nodes.
> 
> Adds validation to enforce that `num_infer_nodes=0` cannot be paired with an `inference` config and requires *fake data* (`trainer.data.fake` or `bench=true`). Updates SLURM script rendering/log hints and the `multi_node_rl.sbatch.j2` template to conditionally omit inference/orchestrator setup when no inference nodes are requested, and updates the trainer to **skip weight broadcast** in fake-data mode.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02485971a9226cc72f59aca68d4042c4a7ecdf45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->