### PR TITLE
fix: reconcile VLM image tokens with pixel_values after prompt truncation

### DIFF
--- a/src/prime_rl/trainer/batch.py
+++ b/src/prime_rl/trainer/batch.py
@@ -6,47 +6,8 @@ from prime_rl.transport.types import MicroBatch, TrainingSample
 _IMAGE_PAD_TOKEN_ID = 151655
 
 
-def _compute_keep_mask_for_multimodal(
-    input_ids: list[int],
-    image_grid_thw: list[list[int]],
-    merge_size: int = 2,
-) -> tuple[list[bool], int, list[list[int]]]:
-    """Compute a per-position keep mask that drops orphaned image_pad tokens.
-
-    After seq_len truncation, the last image may have only partial placeholder tokens.
-    This computes which image_pad tokens belong to complete images (keep=True) and which
-    are orphaned partials (keep=False). Non-image tokens are always kept.
-
-    Returns (keep_mask, kept_image_count, kept_grids).
-    """
-    num_image_tokens = sum(1 for t in input_ids if t == _IMAGE_PAD_TOKEN_ID)
-    expected_tokens = sum(g[0] * g[1] * g[2] // (merge_size**2) for g in image_grid_thw)
-
-    if num_image_tokens == expected_tokens:
-        return [True] * len(input_ids), len(image_grid_thw), image_grid_thw
-
-    # Figure out how many complete images fit
-    kept_grids = []
-    valid_image_tokens = 0
-    for grid in image_grid_thw:
-        img_tokens = grid[0] * grid[1] * grid[2] // (merge_size**2)
-        if valid_image_tokens + img_tokens <= num_image_tokens:
-            kept_grids.append(grid)
-            valid_image_tokens += img_tokens
-        else:
-            break
-
-    # Build keep mask: keep the first `valid_image_tokens` image_pad tokens, drop the rest
-    keep_mask = []
-    seen_image_tokens = 0
-    for t in input_ids:
-        if t == _IMAGE_PAD_TOKEN_ID:
-            keep_mask.append(seen_image_tokens < valid_image_tokens)
-            seen_image_tokens += 1
-        else:
-            keep_mask.append(True)
-
-    return keep_mask, len(kept_grids), kept_grids
+def _grid_tokens(grid: list[int], merge_size: int = 2) -> int:
+    return grid[0] * grid[1] * grid[2] // (merge_size**2)
 
 
 def _trim_multimodal_to_match(
@@ -54,25 +15,43 @@ def _trim_multimodal_to_match(
     pixel_values: bytes | None,
     pixel_values_shape: list[int] | None,
     image_grid_thw: list[list[int]] | None,
-    merge_size: int = 2,
 ) -> tuple[list[int], list[bool] | None, bytes | None, list[int] | None, list[list[int]] | None]:
-    """Ensure image tokens and pixel_values are consistent after seq_len truncation.
+    """Drop images whose placeholder tokens were removed by prompt truncation.
 
     Returns (input_ids, keep_mask, pixel_values, pixel_values_shape, image_grid_thw).
-    keep_mask is None when no filtering was needed, otherwise a bool list aligned with
-    the original input_ids indicating which positions to keep. Callers must apply
-    keep_mask to all parallel arrays (loss_mask, logprobs, etc.).
+    keep_mask is None when no changes were needed; otherwise a bool mask over the
+    original input_ids positions. Callers apply it to parallel arrays.
     """
     if pixel_values is None or image_grid_thw is None:
         return input_ids, None, pixel_values, pixel_values_shape, image_grid_thw
 
     num_image_tokens = sum(1 for t in input_ids if t == _IMAGE_PAD_TOKEN_ID)
-    expected_tokens = sum(g[0] * g[1] * g[2] // (merge_size**2) for g in image_grid_thw)
+    expected_tokens = sum(_grid_tokens(g) for g in image_grid_thw)
 
     if num_image_tokens == expected_tokens:
         return input_ids, None, pixel_values, pixel_values_shape, image_grid_thw
 
-    keep_mask, _, kept_grids = _compute_keep_mask_for_multimodal(input_ids, image_grid_thw, merge_size)
+    # Keep only complete images that fit within the available image tokens
+    kept_grids = []
+    valid_tokens = 0
+    for grid in image_grid_thw:
+        t = _grid_tokens(grid)
+        if valid_tokens + t <= num_image_tokens:
+            kept_grids.append(grid)
+            valid_tokens += t
+        else:
+            break
+
+    # Build keep mask: True for non-image tokens and complete-image tokens, False for orphans
+    keep_mask = []
+    seen = 0
+    for t in input_ids:
+        if t == _IMAGE_PAD_TOKEN_ID:
+            keep_mask.append(seen < valid_tokens)
+            seen += 1
+        else:
+            keep_mask.append(True)
+
     input_ids = [t for t, k in zip(input_ids, keep_mask) if k]
 
     if not kept_grids:
@@ -80,8 +59,7 @@ def _trim_multimodal_to_match(
 
     patch_dim = pixel_values_shape[1] if pixel_values_shape else 0
     kept_patches = sum(g[0] * g[1] * g[2] for g in kept_grids)
-    bytes_per_patch = 4 * patch_dim  # float32
-    kept_bytes = kept_patches * bytes_per_patch
+    kept_bytes = kept_patches * 4 * patch_dim
     return input_ids, keep_mask, pixel_values[:kept_bytes], [kept_patches, patch_dim], kept_grids
 
 

--- a/src/prime_rl/trainer/batch.py
+++ b/src/prime_rl/trainer/batch.py
@@ -2,6 +2,88 @@ import copy
 
 from prime_rl.transport.types import MicroBatch, TrainingSample
 
+# Qwen3-VL image placeholder token ID
+_IMAGE_PAD_TOKEN_ID = 151655
+
+
+def _compute_keep_mask_for_multimodal(
+    input_ids: list[int],
+    image_grid_thw: list[list[int]],
+    merge_size: int = 2,
+) -> tuple[list[bool], int, list[list[int]]]:
+    """Compute a per-position keep mask that drops orphaned image_pad tokens.
+
+    After seq_len truncation, the last image may have only partial placeholder tokens.
+    This computes which image_pad tokens belong to complete images (keep=True) and which
+    are orphaned partials (keep=False). Non-image tokens are always kept.
+
+    Returns (keep_mask, kept_image_count, kept_grids).
+    """
+    num_image_tokens = sum(1 for t in input_ids if t == _IMAGE_PAD_TOKEN_ID)
+    expected_tokens = sum(g[0] * g[1] * g[2] // (merge_size**2) for g in image_grid_thw)
+
+    if num_image_tokens == expected_tokens:
+        return [True] * len(input_ids), len(image_grid_thw), image_grid_thw
+
+    # Figure out how many complete images fit
+    kept_grids = []
+    valid_image_tokens = 0
+    for grid in image_grid_thw:
+        img_tokens = grid[0] * grid[1] * grid[2] // (merge_size**2)
+        if valid_image_tokens + img_tokens <= num_image_tokens:
+            kept_grids.append(grid)
+            valid_image_tokens += img_tokens
+        else:
+            break
+
+    # Build keep mask: keep the first `valid_image_tokens` image_pad tokens, drop the rest
+    keep_mask = []
+    seen_image_tokens = 0
+    for t in input_ids:
+        if t == _IMAGE_PAD_TOKEN_ID:
+            keep_mask.append(seen_image_tokens < valid_image_tokens)
+            seen_image_tokens += 1
+        else:
+            keep_mask.append(True)
+
+    return keep_mask, len(kept_grids), kept_grids
+
+
+def _trim_multimodal_to_match(
+    input_ids: list[int],
+    pixel_values: bytes | None,
+    pixel_values_shape: list[int] | None,
+    image_grid_thw: list[list[int]] | None,
+    merge_size: int = 2,
+) -> tuple[list[int], list[bool] | None, bytes | None, list[int] | None, list[list[int]] | None]:
+    """Ensure image tokens and pixel_values are consistent after seq_len truncation.
+
+    Returns (input_ids, keep_mask, pixel_values, pixel_values_shape, image_grid_thw).
+    keep_mask is None when no filtering was needed, otherwise a bool list aligned with
+    the original input_ids indicating which positions to keep. Callers must apply
+    keep_mask to all parallel arrays (loss_mask, logprobs, etc.).
+    """
+    if pixel_values is None or image_grid_thw is None:
+        return input_ids, None, pixel_values, pixel_values_shape, image_grid_thw
+
+    num_image_tokens = sum(1 for t in input_ids if t == _IMAGE_PAD_TOKEN_ID)
+    expected_tokens = sum(g[0] * g[1] * g[2] // (merge_size**2) for g in image_grid_thw)
+
+    if num_image_tokens == expected_tokens:
+        return input_ids, None, pixel_values, pixel_values_shape, image_grid_thw
+
+    keep_mask, _, kept_grids = _compute_keep_mask_for_multimodal(input_ids, image_grid_thw, merge_size)
+    input_ids = [t for t, k in zip(input_ids, keep_mask) if k]
+
+    if not kept_grids:
+        return input_ids, keep_mask, None, None, None
+
+    patch_dim = pixel_values_shape[1] if pixel_values_shape else 0
+    kept_patches = sum(g[0] * g[1] * g[2] for g in kept_grids)
+    bytes_per_patch = 4 * patch_dim  # float32
+    kept_bytes = kept_patches * bytes_per_patch
+    return input_ids, keep_mask, pixel_values[:kept_bytes], [kept_patches, patch_dim], kept_grids
+
 
 def prepare_sample(training_example: TrainingSample, seq_len: int) -> MicroBatch:
     """
@@ -24,6 +106,10 @@ def prepare_sample(training_example: TrainingSample, seq_len: int) -> MicroBatch
     teacher_logprobs = training_example.teacher_logprobs
     routed_experts = training_example.routed_experts
 
+    pixel_values = training_example.pixel_values
+    pixel_values_shape = training_example.pixel_values_shape
+    image_grid_thw = training_example.image_grid_thw
+
     if len(input_ids) > seq_len:
         input_ids = input_ids[:seq_len]
         loss_mask = loss_mask[:seq_len]
@@ -35,6 +121,24 @@ def prepare_sample(training_example: TrainingSample, seq_len: int) -> MicroBatch
             teacher_logprobs = teacher_logprobs[:seq_len]
         if routed_experts is not None:
             routed_experts = routed_experts[:seq_len]
+
+    # VLM: pixel_values/image_grid_thw are computed from the full conversation images,
+    # but input_ids may have fewer image_pad tokens due to vLLM's prompt truncation
+    # (left-truncation to max_model_len) or seq_len truncation above. Drop trailing
+    # images whose placeholder tokens were removed so features match tokens.
+    input_ids, keep_mask, pixel_values, pixel_values_shape, image_grid_thw = _trim_multimodal_to_match(
+        input_ids, pixel_values, pixel_values_shape, image_grid_thw
+    )
+    if keep_mask is not None:
+        loss_mask = [v for v, k in zip(loss_mask, keep_mask) if k]
+        inference_logprobs = [v for v, k in zip(inference_logprobs, keep_mask) if k]
+        position_ids = [v for v, k in zip(position_ids, keep_mask) if k]
+        advantages = [v for v, k in zip(advantages, keep_mask) if k]
+        temperatures = [v for v, k in zip(temperatures, keep_mask) if k]
+        if teacher_logprobs is not None:
+            teacher_logprobs = [v for v, k in zip(teacher_logprobs, keep_mask) if k]
+        if routed_experts is not None:
+            routed_experts = [v for v, k in zip(routed_experts, keep_mask) if k]
 
     assert (
         len(input_ids)
@@ -63,10 +167,9 @@ def prepare_sample(training_example: TrainingSample, seq_len: int) -> MicroBatch
         teacher_logprobs=teacher_logprobs,
         temperatures=temperatures,
         routed_experts=routed_experts,
-        # Multimodal fields (Qwen3-VL) - passed through without modification
-        pixel_values=training_example.pixel_values,
-        pixel_values_shape=training_example.pixel_values_shape,
-        image_grid_thw=training_example.image_grid_thw,
+        pixel_values=pixel_values,
+        pixel_values_shape=pixel_values_shape,
+        image_grid_thw=image_grid_thw,
     )
 
 

--- a/tests/unit/orchestrator/test_batch.py
+++ b/tests/unit/orchestrator/test_batch.py
@@ -1,6 +1,6 @@
 import pytest
 
-from prime_rl.trainer.batch import prepare_batch, prepare_sample
+from prime_rl.trainer.batch import _IMAGE_PAD_TOKEN_ID, _trim_multimodal_to_match, prepare_batch, prepare_sample
 from prime_rl.transport.types import TrainingSample
 
 
@@ -134,3 +134,177 @@ def test_prepare_sample_none_routed_experts():
 
     micro_batch = prepare_sample(sample, seq_len=8)
     assert micro_batch.routed_experts is None
+
+
+# --- VLM multimodal trimming tests ---
+
+IMG = _IMAGE_PAD_TOKEN_ID
+# Each image: grid [1, 48, 64] -> 3072 patches -> 768 tokens (3072 / merge_size^2)
+GRID = [1, 48, 64]
+TOKENS_PER_IMAGE = 768
+PATCHES_PER_IMAGE = 3072
+PATCH_DIM = 1176
+
+
+def _make_pixel_values(num_images: int) -> tuple[bytes, list[int], list[list[int]]]:
+    total_patches = num_images * PATCHES_PER_IMAGE
+    pv = b"\x00" * (total_patches * 4 * PATCH_DIM)
+    shape = [total_patches, PATCH_DIM]
+    grids = [GRID] * num_images
+    return pv, shape, grids
+
+
+def _make_vlm_sample(
+    num_images: int,
+    text_tokens_per_image: int = 50,
+    trailing_text: int = 50,
+    extra_completion: int = 0,
+) -> TrainingSample:
+    """Build a VLM TrainingSample with interleaved text and image tokens."""
+    prompt_ids = []
+    for _ in range(num_images):
+        prompt_ids.extend([100] * text_tokens_per_image)
+        prompt_ids.extend([IMG] * TOKENS_PER_IMAGE)
+    prompt_ids.extend([100] * trailing_text)
+
+    completion_ids = [101] * max(extra_completion, 100)
+    pv, shape, grids = _make_pixel_values(num_images)
+
+    return TrainingSample(
+        prompt_ids=prompt_ids,
+        prompt_mask=[False] * len(prompt_ids),
+        completion_ids=completion_ids,
+        completion_mask=[True] * len(completion_ids),
+        completion_logprobs=[-0.5] * len(completion_ids),
+        completion_temperatures=[0.7] * len(completion_ids),
+        advantage=1.0,
+        pixel_values=pv,
+        pixel_values_shape=shape,
+        image_grid_thw=grids,
+    )
+
+
+def test_trim_multimodal_noop_when_tokens_match():
+    """No trimming when image tokens already match image_grid_thw."""
+    input_ids = [100] * 50 + [IMG] * TOKENS_PER_IMAGE + [100] * 50
+    pv, shape, grids = _make_pixel_values(1)
+
+    new_ids, keep_mask, new_pv, new_shape, new_grids = _trim_multimodal_to_match(input_ids, pv, shape, grids)
+
+    assert keep_mask is None
+    assert new_ids is input_ids
+    assert new_pv is pv
+    assert new_grids == grids
+
+
+def test_trim_multimodal_noop_for_text_only():
+    """No trimming for text-only samples (pixel_values=None)."""
+    input_ids = [100] * 100
+
+    new_ids, keep_mask, new_pv, new_shape, new_grids = _trim_multimodal_to_match(input_ids, None, None, None)
+
+    assert keep_mask is None
+    assert new_ids is input_ids
+    assert new_pv is None
+
+
+def test_trim_multimodal_drops_partial_image():
+    """When truncation leaves a partial image, drop it and its orphaned tokens."""
+    # 5 images but only 4 complete + 516 partial tokens remain
+    pv, shape, grids = _make_pixel_values(5)
+    partial = 516
+    input_ids = (
+        [100] * 50
+        + [IMG] * TOKENS_PER_IMAGE  # image 1
+        + [100] * 50
+        + [IMG] * TOKENS_PER_IMAGE  # image 2
+        + [100] * 50
+        + [IMG] * TOKENS_PER_IMAGE  # image 3
+        + [100] * 50
+        + [IMG] * TOKENS_PER_IMAGE  # image 4
+        + [100] * 50
+        + [IMG] * partial  # image 5 (partial)
+    )
+
+    new_ids, keep_mask, new_pv, new_shape, new_grids = _trim_multimodal_to_match(input_ids, pv, shape, grids)
+
+    assert keep_mask is not None
+    new_img_tokens = sum(1 for t in new_ids if t == IMG)
+    assert new_img_tokens == 4 * TOKENS_PER_IMAGE
+    assert len(new_grids) == 4
+    assert len(new_ids) == len(input_ids) - partial
+
+
+def test_trim_multimodal_drops_all_images():
+    """When no complete image fits, drop all pixel data."""
+    pv, shape, grids = _make_pixel_values(1)
+    # Only 100 of the 768 image tokens present
+    input_ids = [100] * 50 + [IMG] * 100
+
+    new_ids, keep_mask, new_pv, new_shape, new_grids = _trim_multimodal_to_match(input_ids, pv, shape, grids)
+
+    assert new_pv is None
+    assert new_grids is None
+    assert sum(1 for t in new_ids if t == IMG) == 0
+    assert len(new_ids) == 50  # only text tokens remain
+
+
+def test_prepare_sample_vlm_seq_len_truncation():
+    """prepare_sample truncates to seq_len and trims multimodal data to match."""
+    sample = _make_vlm_sample(num_images=5, text_tokens_per_image=200, extra_completion=500)
+    total = len(sample.prompt_ids) + len(sample.completion_ids)
+    assert total > 4096
+
+    mb = prepare_sample(sample, seq_len=4096)
+
+    img_tokens = sum(1 for t in mb.input_ids if t == IMG)
+    features = sum(g[0] * g[1] * g[2] // 4 for g in mb.image_grid_thw)
+    assert img_tokens == features
+    assert len(mb.input_ids) == len(mb.loss_mask) == len(mb.advantages)
+
+
+def test_prepare_sample_vlm_vllm_truncation():
+    """Simulate vLLM left-truncation: total == seq_len but fewer image tokens than grids."""
+    # This is the actual bug: vLLM truncates prompt to max_model_len, losing some
+    # image_pad tokens, but pixel_values still has all images.
+    pv, shape, grids = _make_pixel_values(5)
+    # Build prompt_ids that simulate vLLM having already truncated:
+    # 4 complete images + 516 partial + some text, totaling exactly 4096
+    partial = 516
+    text_per_gap = 50
+    prompt_ids = (
+        [100] * text_per_gap
+        + [IMG] * partial  # left-truncated 5th image (only partial remains at start)
+        + [100] * text_per_gap
+        + [IMG] * TOKENS_PER_IMAGE
+        + [100] * text_per_gap
+        + [IMG] * TOKENS_PER_IMAGE
+        + [100] * text_per_gap
+        + [IMG] * TOKENS_PER_IMAGE
+        + [100] * text_per_gap
+    )
+    target = 4096
+    completion_len = target - len(prompt_ids)
+    completion_ids = [101] * completion_len
+
+    sample = TrainingSample(
+        prompt_ids=prompt_ids,
+        prompt_mask=[False] * len(prompt_ids),
+        completion_ids=completion_ids,
+        completion_mask=[True] * len(completion_ids),
+        completion_logprobs=[-0.5] * len(completion_ids),
+        completion_temperatures=[0.7] * len(completion_ids),
+        advantage=1.0,
+        pixel_values=pv,
+        pixel_values_shape=shape,
+        image_grid_thw=grids,
+    )
+
+    assert len(sample.prompt_ids) + len(sample.completion_ids) == 4096
+
+    mb = prepare_sample(sample, seq_len=4096)
+
+    img_tokens = sum(1 for t in mb.input_ids if t == IMG)
+    features = sum(g[0] * g[1] * g[2] // 4 for g in mb.image_grid_thw)
+    assert img_tokens == features
+    assert len(mb.input_ids) == len(mb.loss_mask) == len(mb.advantages)

--- a/tests/unit/orchestrator/test_batch.py
+++ b/tests/unit/orchestrator/test_batch.py
@@ -136,40 +136,25 @@ def test_prepare_sample_none_routed_experts():
     assert micro_batch.routed_experts is None
 
 
-# --- VLM multimodal trimming tests ---
-
 IMG = _IMAGE_PAD_TOKEN_ID
-# Each image: grid [1, 48, 64] -> 3072 patches -> 768 tokens (3072 / merge_size^2)
-GRID = [1, 48, 64]
-TOKENS_PER_IMAGE = 768
-PATCHES_PER_IMAGE = 3072
+GRID = [1, 48, 64]  # 3072 patches -> 768 tokens
+TOKENS_PER_IMG = 768
+PATCHES_PER_IMG = 3072
 PATCH_DIM = 1176
 
 
-def _make_pixel_values(num_images: int) -> tuple[bytes, list[int], list[list[int]]]:
-    total_patches = num_images * PATCHES_PER_IMAGE
-    pv = b"\x00" * (total_patches * 4 * PATCH_DIM)
-    shape = [total_patches, PATCH_DIM]
-    grids = [GRID] * num_images
-    return pv, shape, grids
+def _make_pixel_values(n):
+    patches = n * PATCHES_PER_IMG
+    return b"\x00" * (patches * 4 * PATCH_DIM), [patches, PATCH_DIM], [GRID] * n
 
 
-def _make_vlm_sample(
-    num_images: int,
-    text_tokens_per_image: int = 50,
-    trailing_text: int = 50,
-    extra_completion: int = 0,
-) -> TrainingSample:
-    """Build a VLM TrainingSample with interleaved text and image tokens."""
+def _make_vlm_sample(n_images, text_per_image=50, completion=100):
     prompt_ids = []
-    for _ in range(num_images):
-        prompt_ids.extend([100] * text_tokens_per_image)
-        prompt_ids.extend([IMG] * TOKENS_PER_IMAGE)
-    prompt_ids.extend([100] * trailing_text)
-
-    completion_ids = [101] * max(extra_completion, 100)
-    pv, shape, grids = _make_pixel_values(num_images)
-
+    for _ in range(n_images):
+        prompt_ids += [100] * text_per_image + [IMG] * TOKENS_PER_IMG
+    prompt_ids += [100] * 50
+    completion_ids = [101] * completion
+    pv, shape, grids = _make_pixel_values(n_images)
     return TrainingSample(
         prompt_ids=prompt_ids,
         prompt_mask=[False] * len(prompt_ids),
@@ -184,76 +169,50 @@ def _make_vlm_sample(
     )
 
 
-def test_trim_multimodal_noop_when_tokens_match():
-    """No trimming when image tokens already match image_grid_thw."""
-    input_ids = [100] * 50 + [IMG] * TOKENS_PER_IMAGE + [100] * 50
+def test_trim_noop_when_tokens_match():
+    input_ids = [100] * 50 + [IMG] * TOKENS_PER_IMG + [100] * 50
     pv, shape, grids = _make_pixel_values(1)
-
-    new_ids, keep_mask, new_pv, new_shape, new_grids = _trim_multimodal_to_match(input_ids, pv, shape, grids)
-
+    new_ids, keep_mask, *_ = _trim_multimodal_to_match(input_ids, pv, shape, grids)
     assert keep_mask is None
     assert new_ids is input_ids
-    assert new_pv is pv
-    assert new_grids == grids
 
 
-def test_trim_multimodal_noop_for_text_only():
-    """No trimming for text-only samples (pixel_values=None)."""
+def test_trim_noop_for_text_only():
     input_ids = [100] * 100
-
-    new_ids, keep_mask, new_pv, new_shape, new_grids = _trim_multimodal_to_match(input_ids, None, None, None)
-
+    new_ids, keep_mask, *_ = _trim_multimodal_to_match(input_ids, None, None, None)
     assert keep_mask is None
-    assert new_ids is input_ids
-    assert new_pv is None
 
 
-def test_trim_multimodal_drops_partial_image():
-    """When truncation leaves a partial image, drop it and its orphaned tokens."""
-    # 5 images but only 4 complete + 516 partial tokens remain
+def test_trim_drops_partial_image():
     pv, shape, grids = _make_pixel_values(5)
     partial = 516
-    input_ids = (
-        [100] * 50
-        + [IMG] * TOKENS_PER_IMAGE  # image 1
-        + [100] * 50
-        + [IMG] * TOKENS_PER_IMAGE  # image 2
-        + [100] * 50
-        + [IMG] * TOKENS_PER_IMAGE  # image 3
-        + [100] * 50
-        + [IMG] * TOKENS_PER_IMAGE  # image 4
-        + [100] * 50
-        + [IMG] * partial  # image 5 (partial)
-    )
+    input_ids = []
+    for _ in range(4):
+        input_ids += [100] * 50 + [IMG] * TOKENS_PER_IMG
+    input_ids += [100] * 50 + [IMG] * partial
 
-    new_ids, keep_mask, new_pv, new_shape, new_grids = _trim_multimodal_to_match(input_ids, pv, shape, grids)
+    new_ids, keep_mask, _, _, new_grids = _trim_multimodal_to_match(input_ids, pv, shape, grids)
 
     assert keep_mask is not None
-    new_img_tokens = sum(1 for t in new_ids if t == IMG)
-    assert new_img_tokens == 4 * TOKENS_PER_IMAGE
+    assert sum(1 for t in new_ids if t == IMG) == 4 * TOKENS_PER_IMG
     assert len(new_grids) == 4
     assert len(new_ids) == len(input_ids) - partial
 
 
-def test_trim_multimodal_drops_all_images():
-    """When no complete image fits, drop all pixel data."""
+def test_trim_drops_all_images():
     pv, shape, grids = _make_pixel_values(1)
-    # Only 100 of the 768 image tokens present
-    input_ids = [100] * 50 + [IMG] * 100
+    input_ids = [100] * 50 + [IMG] * 100  # partial, no complete image
 
-    new_ids, keep_mask, new_pv, new_shape, new_grids = _trim_multimodal_to_match(input_ids, pv, shape, grids)
+    new_ids, _, new_pv, _, new_grids = _trim_multimodal_to_match(input_ids, pv, shape, grids)
 
     assert new_pv is None
     assert new_grids is None
     assert sum(1 for t in new_ids if t == IMG) == 0
-    assert len(new_ids) == 50  # only text tokens remain
 
 
 def test_prepare_sample_vlm_seq_len_truncation():
-    """prepare_sample truncates to seq_len and trims multimodal data to match."""
-    sample = _make_vlm_sample(num_images=5, text_tokens_per_image=200, extra_completion=500)
-    total = len(sample.prompt_ids) + len(sample.completion_ids)
-    assert total > 4096
+    sample = _make_vlm_sample(5, text_per_image=200, completion=500)
+    assert len(sample.prompt_ids) + len(sample.completion_ids) > 4096
 
     mb = prepare_sample(sample, seq_len=4096)
 
@@ -263,29 +222,16 @@ def test_prepare_sample_vlm_seq_len_truncation():
     assert len(mb.input_ids) == len(mb.loss_mask) == len(mb.advantages)
 
 
-def test_prepare_sample_vlm_vllm_truncation():
-    """Simulate vLLM left-truncation: total == seq_len but fewer image tokens than grids."""
-    # This is the actual bug: vLLM truncates prompt to max_model_len, losing some
-    # image_pad tokens, but pixel_values still has all images.
+def test_prepare_sample_vlm_already_truncated_by_vllm():
+    """vLLM left-truncates prompt to max_model_len, losing image tokens,
+    but pixel_values still has all images."""
     pv, shape, grids = _make_pixel_values(5)
-    # Build prompt_ids that simulate vLLM having already truncated:
-    # 4 complete images + 516 partial + some text, totaling exactly 4096
     partial = 516
-    text_per_gap = 50
-    prompt_ids = (
-        [100] * text_per_gap
-        + [IMG] * partial  # left-truncated 5th image (only partial remains at start)
-        + [100] * text_per_gap
-        + [IMG] * TOKENS_PER_IMAGE
-        + [100] * text_per_gap
-        + [IMG] * TOKENS_PER_IMAGE
-        + [100] * text_per_gap
-        + [IMG] * TOKENS_PER_IMAGE
-        + [100] * text_per_gap
-    )
-    target = 4096
-    completion_len = target - len(prompt_ids)
-    completion_ids = [101] * completion_len
+    prompt_ids = [100] * 50 + [IMG] * partial  # truncated first image
+    for _ in range(3):
+        prompt_ids += [100] * 50 + [IMG] * TOKENS_PER_IMG
+    prompt_ids += [100] * 50
+    completion_ids = [101] * (4096 - len(prompt_ids))
 
     sample = TrainingSample(
         prompt_ids=prompt_ids,
@@ -299,7 +245,6 @@ def test_prepare_sample_vlm_vllm_truncation():
         pixel_values_shape=shape,
         image_grid_thw=grids,
     )
-
     assert len(sample.prompt_ids) + len(sample.completion_ids) == 4096
 
     mb = prepare_sample(sample, seq_len=4096)


### PR DESCRIPTION
## Summary

In multi-turn VLM conversations that exceed `seq_len`, vLLM left-truncates the prompt to fit in `max_model_len`, removing image_pad tokens from early turns. But `pixel_values`/`image_grid_thw` are computed independently by the orchestrator's image processor from all conversation images. This causes a mismatch — the trainer crashes with `ValueError: Image features and image tokens do not match`.

The fix runs after seq_len truncation in `prepare_sample`: compare image_pad tokens in `input_ids` against `image_grid_thw`, drop images whose placeholder tokens were truncated, and remove any orphaned partial image tokens so both sides agree on the same set of complete images. No-op for text-only samples and VLM samples where tokens already match.

## Test plan

- [x] Unit tests for `_trim_multimodal_to_match`: noop cases (text-only, already matching), partial image drop, all images dropped
- [x] Integration tests for `prepare_sample`: seq_len truncation path, vLLM pre-truncation path
- [x] End-to-end: 5-step VLM tic-tac-toe training run with Qwen3-VL-4B-Instruct completes without errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core sample-prep logic for multimodal training and can alter which images/features are fed to the model when truncation occurs, though the behavior is narrowly scoped and covered by new tests.
> 
> **Overview**
> Fixes Qwen3-VL batch preparation when prompts are truncated by ensuring image placeholder tokens in `input_ids` stay consistent with `pixel_values`/`image_grid_thw`.
> 
> `prepare_sample` now calls a new `_trim_multimodal_to_match` helper that drops orphaned/partial image tokens and trims (or removes) trailing image features/grids accordingly, while leaving text-only or already-matching samples unchanged. Adds unit tests covering noop, partial/all-image drops, and both `seq_len` truncation and vLLM left-truncation scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4db3bbd5e470af896fe89ff7ca07073dbbe6a0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->