### PR TITLE
fix: re-schedule empty trajectories to guarantee full groups

### DIFF
--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -370,7 +370,16 @@ class Scheduler:
                     group = self.groups.get(group_id)
                     if group is None:
                         continue
-                    group.completed_rollouts.append(finished_task.result())
+                    rollout = finished_task.result()
+                    if len(rollout["trajectory"]) == 0:
+                        self.empty_rollouts_count += 1
+                        group.rollouts_to_schedule += 1
+                        self.logger.warning(
+                            f"Empty trajectory in group {group_id}, re-scheduling "
+                            f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete)"
+                        )
+                        continue
+                    group.completed_rollouts.append(rollout)
                     if len(group.completed_rollouts) < self.rollouts_per_example:
                         continue
                     completed_rollouts = self.groups.pop(group_id).completed_rollouts
@@ -387,14 +396,6 @@ class Scheduler:
 
                 self.buffer.update(completed_rollouts)
                 accepted_rollouts = self.buffer.sample_rollouts(n=self.rollouts_per_example)
-
-                empty_count = sum(1 for r in accepted_rollouts if len(r["trajectory"]) == 0)
-                if empty_count > 0:
-                    self.logger.warning(
-                        f"Filtered {empty_count}/{len(accepted_rollouts)} rollouts with empty trajectories"
-                    )
-                    accepted_rollouts = [r for r in accepted_rollouts if len(r["trajectory"]) > 0]
-                    self.empty_rollouts_count += empty_count
 
                 batch_rollouts.extend(accepted_rollouts)
                 progress_increment = self.get_batch_progress_increment(accepted_rollouts)


### PR DESCRIPTION
## Summary
- Empty trajectories were filtered **after** group completion and buffer sampling, which could yield groups with fewer than `rollouts_per_example` rollouts
- This broke the advantage computation which reshapes rewards with `.view(-1, rollouts_per_example)` — either crashing on misaligned tensors or silently computing wrong per-problem baselines
- Now empty trajectories are detected per-rollout as they arrive. When one is found, `rollouts_to_schedule` is incremented so the group naturally re-fills, and only complete groups are yielded


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core rollout scheduling/group completion logic; a bug could cause groups to stall or skew batch composition, but the change is small and localized.
> 
> **Overview**
> Prevents incomplete rollout groups by handling empty trajectories *before* group completion.
> 
> In `Scheduler.generate_batch`, each finished rollout is now checked for an empty `trajectory`; empty results increment `batch/empty_rollouts`, log a warning, and increase `group.rollouts_to_schedule` so the group naturally re-fills, while the previous post-sampling filtering of empty rollouts is removed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b43629f81ab96e6682d03f8830de39488a87ef0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->