### PR TITLE
fix: re-schedule errored rollouts

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -603,7 +603,6 @@ async def orchestrate(config: OrchestratorConfig):
                 "task": [rollout["task"] for rollout in train_rollouts],
                 "reward": [rollout["reward"] for rollout in train_rollouts],
                 "is_truncated": [rollout["is_truncated"] for rollout in train_rollouts],
-                "error": [rollout["error"] for rollout in train_rollouts],
                 "stop_condition": [rollout.get("stop_condition") for rollout in train_rollouts],
                 "seq_len": [get_seq_len(rollout) for rollout in train_rollouts],
                 "prefill_len": rollout_prefill_lens,
@@ -703,8 +702,6 @@ async def orchestrate(config: OrchestratorConfig):
             "solve_all/all": solve_all,
             "effective_batch_size/all": effective_batch_size,
             **{f"batch/{env}": r for env, r in results_df.task.value_counts(normalize=True).items()},
-            # Error metrics
-            "error/all/mean": by_example.error.apply(lambda e: e.notna().mean()).mean(),
             # Time metrics
             "time/step": step_time,
             "time/generate_completions": generate_completions_time,
@@ -744,7 +741,6 @@ async def orchestrate(config: OrchestratorConfig):
             to_log[f"reward/{env}/mean"] = env_by_example.reward.mean().mean()
             to_log[f"reward/{env}/max"] = env_by_example.reward.mean().max()
             to_log[f"reward/{env}/min"] = env_by_example.reward.mean().min()
-            to_log[f"error/{env}/mean"] = env_by_example.error.apply(lambda e: e.notna().mean()).mean()
             solve_none, solve_all, effective_batch_size = compute_solve_rates(env_df)
             to_log[f"solve_none/{env}"] = solve_none
             to_log[f"solve_all/{env}"] = solve_all

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -464,16 +464,16 @@ class Scheduler:
             "scheduler/inflight_rollouts": self.inflight_rollout_count,
             "scheduler/inflight_samples": self.inflight_sample_count,
             "scheduler/cancelled_rollouts": self.cancelled_rollouts_count,
-            "scheduler/empty_rollouts/all": sum(self.empty_rollouts_by_task.values()),
-            "scheduler/errored_rollouts/all": sum(self.errored_rollouts_by_task.values()),
+            "empty_rollouts/all": sum(self.empty_rollouts_by_task.values()),
+            "errored_rollouts/all": sum(self.errored_rollouts_by_task.values()),
             "off_policy_level/all/max": self.max_off_policy_level,
             "off_policy_level/all/mean": self.mean_off_policy_level,
             "off_policy_level/all/min": self.min_off_policy_level,
         }
         for task, count in self.empty_rollouts_by_task.items():
-            metrics[f"scheduler/empty_rollouts/{task}"] = count
+            metrics[f"empty_rollouts/{task}"] = count
         for task, count in self.errored_rollouts_by_task.items():
-            metrics[f"scheduler/errored_rollouts/{task}"] = count
+            metrics[f"errored_rollouts/{task}"] = count
         by_task: dict[str, list[int]] = {}
         for info in self.inflight_requests.values():
             by_task.setdefault(info.task, []).append(info.off_policy_steps)

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from collections import Counter
+from collections import Counter, defaultdict
 from dataclasses import dataclass, field
 from typing import NamedTuple, cast
 
@@ -111,8 +111,8 @@ class Scheduler:
         self.update_weights_time, self.wait_for_ckpt_time = 0, 0
         self.update_policy_task: asyncio.Task | None = None
         self.cancelled_rollouts_count = 0
-        self.empty_rollouts_count = 0
-        self.errored_rollouts_count = 0
+        self.empty_rollouts_by_task: dict[str, int] = defaultdict(int)
+        self.errored_rollouts_by_task: dict[str, int] = defaultdict(int)
         self.last_batch_generation_time = 0.0
 
     @property
@@ -374,19 +374,20 @@ class Scheduler:
                         continue
                     rollout = finished_task.result()
 
+                    task = rollout_info.task
                     should_reschedule = False
                     if len(rollout["trajectory"]) == 0:
-                        self.empty_rollouts_count += 1
+                        self.empty_rollouts_by_task[task] += 1
                         should_reschedule = True
                         self.logger.warning(
-                            f"Empty trajectory in group {group_id}, re-scheduling "
+                            f"Empty trajectory in group {group_id} ({task}), re-scheduling "
                             f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete)"
                         )
                     if rollout["error"] is not None:
-                        self.errored_rollouts_count += 1
+                        self.errored_rollouts_by_task[task] += 1
                         should_reschedule = True
                         self.logger.warning(
-                            f"Rollout error in group {group_id}, re-scheduling "
+                            f"Rollout error in group {group_id} ({task}), re-scheduling "
                             f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete): "
                             f"{rollout['error']}"
                         )
@@ -463,12 +464,16 @@ class Scheduler:
             "scheduler/inflight_rollouts": self.inflight_rollout_count,
             "scheduler/inflight_samples": self.inflight_sample_count,
             "scheduler/cancelled_rollouts": self.cancelled_rollouts_count,
-            "scheduler/empty_rollouts": self.empty_rollouts_count,
-            "scheduler/errored_rollouts": self.errored_rollouts_count,
+            "scheduler/empty_rollouts/all": sum(self.empty_rollouts_by_task.values()),
+            "scheduler/errored_rollouts/all": sum(self.errored_rollouts_by_task.values()),
             "off_policy_level/all/max": self.max_off_policy_level,
             "off_policy_level/all/mean": self.mean_off_policy_level,
             "off_policy_level/all/min": self.min_off_policy_level,
         }
+        for task, count in self.empty_rollouts_by_task.items():
+            metrics[f"scheduler/empty_rollouts/{task}"] = count
+        for task, count in self.errored_rollouts_by_task.items():
+            metrics[f"scheduler/errored_rollouts/{task}"] = count
         by_task: dict[str, list[int]] = {}
         for info in self.inflight_requests.values():
             by_task.setdefault(info.task, []).append(info.off_policy_steps)
@@ -477,8 +482,8 @@ class Scheduler:
             metrics[f"off_policy_level/{task}/mean"] = sum(steps) / len(steps)
             metrics[f"off_policy_level/{task}/min"] = min(steps)
         self.cancelled_rollouts_count = 0
-        self.empty_rollouts_count = 0
-        self.errored_rollouts_count = 0
+        self.empty_rollouts_by_task.clear()
+        self.errored_rollouts_by_task.clear()
 
         # Add inference pool metrics (e.g. elastic pool server counts)
         metrics.update(self.inference_pool.get_metrics())

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -112,6 +112,7 @@ class Scheduler:
         self.update_policy_task: asyncio.Task | None = None
         self.cancelled_rollouts_count = 0
         self.empty_rollouts_count = 0
+        self.errored_rollouts_count = 0
         self.last_batch_generation_time = 0.0
 
     @property
@@ -372,14 +373,27 @@ class Scheduler:
                     if group is None:
                         continue
                     rollout = finished_task.result()
+
+                    should_reschedule = False
                     if len(rollout["trajectory"]) == 0:
                         self.empty_rollouts_count += 1
-                        group.rollouts_to_schedule += 1
+                        should_reschedule = True
                         self.logger.warning(
                             f"Empty trajectory in group {group_id}, re-scheduling "
                             f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete)"
                         )
+                    if rollout["error"] is not None:
+                        self.errored_rollouts_count += 1
+                        should_reschedule = True
+                        self.logger.warning(
+                            f"Rollout error in group {group_id}, re-scheduling "
+                            f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete): "
+                            f"{rollout['error']}"
+                        )
+                    if should_reschedule:
+                        group.rollouts_to_schedule += 1
                         continue
+
                     group.completed_rollouts.append(rollout)
                     if len(group.completed_rollouts) < self.rollouts_per_example:
                         continue
@@ -450,6 +464,7 @@ class Scheduler:
             "scheduler/inflight_samples": self.inflight_sample_count,
             "scheduler/cancelled_rollouts": self.cancelled_rollouts_count,
             "scheduler/empty_rollouts": self.empty_rollouts_count,
+            "scheduler/errored_rollouts": self.errored_rollouts_count,
             "off_policy_level/all/max": self.max_off_policy_level,
             "off_policy_level/all/mean": self.mean_off_policy_level,
             "off_policy_level/all/min": self.min_off_policy_level,
@@ -463,6 +478,7 @@ class Scheduler:
             metrics[f"off_policy_level/{task}/min"] = min(steps)
         self.cancelled_rollouts_count = 0
         self.empty_rollouts_count = 0
+        self.errored_rollouts_count = 0
 
         # Add inference pool metrics (e.g. elastic pool server counts)
         metrics.update(self.inference_pool.get_metrics())


### PR DESCRIPTION
## Summary
- When a rollout errored (`rollouts["error"] is not None`) log a warning and re-schedule it (increment `rollouts_to_schedule`)
- Remove logging of `error/{env}/mean` since a batch consists only of healthy rollouts. Instead, log `empty_rollouts/{env}` and `errored_rollouts/{env}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core rollout scheduling behavior by rescheduling rollouts on per-rollout error/empty trajectory, which can affect training throughput and retry behavior. Metric key changes may impact dashboards/alerts expecting the previous `error/*` fields.
> 
> **Overview**
> Prevents a single bad rollout from dropping/cancelling its entire group by **rescheduling** rollouts when they return an empty trajectory or contain a non-null `rollout["error"]`, with clearer warning logs including the task.
> 
> Reworks rollout health metrics: removes orchestrator-side `error/*` logging, and adds scheduler-side `empty_rollouts/*` and `errored_rollouts/*` counters (both *all* and per-task) that reset each reporting interval.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33b0e3118f83e2b000694910f9c1f7eebaa1e0e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->