### PR TITLE
make httpx connect timout configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Documenting changes which affect configuration usage patterns (added/moved/removed/renamed fields, notable logic changes).
 
+- **`client.connect_timeout`**: Added configurable TCP connect timeout for inference API requests (default: 30.0s). Previously hardcoded to 5.0s. Helps with vLLM or cluster flakiness (2026-03-11)
 - **`model.fused_lm_head_token_chunk_size`**: Added as the fused LM-head chunking field for the token-chunked implementation. Unlike the removed `model.fused_lm_head_chunk_size`, this chunks over flattened sequence tokens rather than vocabulary rows. `model.fused_lm_head_chunk_size` is no longer accepted; switch configs to `model.fused_lm_head_token_chunk_size` explicitly. (2026-03-09)
 - **`slurm.pre_run_command`**: Added optional shell command to run on the head node before starting the job. Useful for cleanup routines (e.g. killing stale processes, removing lock files). For all-nodes execution, wrap with `srun` in the command string (default: None) (2026-03-08)
 - **`slurm.nodelist`**, **`slurm.exclude`**, **`slurm.account`**, **`slurm.time`**: Added common SLURM scheduling options (all default: None) (2026-03-08)

--- a/src/prime_rl/configs/shared.py
+++ b/src/prime_rl/configs/shared.py
@@ -138,6 +138,13 @@ class ClientConfig(BaseConfig):
         ),
     ] = 1200
 
+    connect_timeout: Annotated[
+        float,
+        Field(
+            description="TCP connect timeout in seconds for inference API requests.",
+        ),
+    ] = 5.0
+
     base_url: Annotated[
         list[str],
         Field(

--- a/src/prime_rl/configs/shared.py
+++ b/src/prime_rl/configs/shared.py
@@ -143,7 +143,7 @@ class ClientConfig(BaseConfig):
         Field(
             description="TCP connect timeout in seconds for inference API requests.",
         ),
-    ] = 5.0
+    ] = 30.0
 
     base_url: Annotated[
         list[str],

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -134,6 +134,7 @@ def setup_clients(client_config: ClientConfig, client_type: str = "openai_chat_c
                     api_base_url=base_url,
                     api_key_var=client_config.api_key_var,
                     timeout=client_config.timeout,
+                    connect_timeout=client_config.connect_timeout,
                     max_connections=8192,
                     max_keepalive_connections=8192,
                     max_retries=10,

--- a/src/prime_rl/utils/elastic.py
+++ b/src/prime_rl/utils/elastic.py
@@ -170,6 +170,7 @@ class ElasticInferencePool:
                 setup_clients(
                     ClientConfig(
                         timeout=self.client_config.timeout,
+                        connect_timeout=self.client_config.connect_timeout,
                         base_url=urls,
                         api_key_var=self.client_config.api_key_var,
                         headers=self.client_config.headers,


### PR DESCRIPTION
related https://github.com/PrimeIntellect-ai/verifiers/pull/1006

changes in verifiers to not hardcode httpx connect timeout for OAI or any other client anymore.
helps with vLLM or cluster flakiness.

```diff
def _build_http_client(
    config: ClientConfig, headers: dict[str, str]
) -> httpx.AsyncClient:
-   timeout = httpx.Timeout(config.timeout, connect=5.0)
+   timeout = httpx.Timeout(config.timeout, connect=config.connect_timeout)
    limits = httpx.Limits(
        max_connections=config.max_connections,
        max_keepalive_connections=config.max_keepalive_connections,
    )
    return httpx.AsyncClient(
        limits=limits,
        timeout=timeout,
        headers=headers,
    )
 ```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes network timeout behavior for inference requests (new default connect timeout 30s vs previously hardcoded 5s), which can affect perceived hangs and retry timing under outages.
> 
> **Overview**
> Introduces `client.connect_timeout` config (default `30.0`) and passes it into constructed `vf.ClientConfig` instances so inference HTTP clients use a configurable TCP connect timeout instead of a hardcoded value.
> 
> Elastic inference pool client regeneration is updated to preserve the new `connect_timeout`, and the change is documented in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92c9eb9394f3bea8c41f642231fc90ff3a5ff8f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->