### PR TITLE
feat: Add `ckpt.output_dir` for separate checkpoint storage

### DIFF
--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -75,6 +75,13 @@ class SharedWandbConfig(BaseConfig):
 class SharedCheckpointConfig(BaseConfig):
     """Configures shared checkpoint configs."""
 
+    output_dir: Annotated[
+        Path | None,
+        Field(
+            description="Override directory for checkpoints and weights. When set, checkpoints and weight snapshots are written here instead of under the trainer output_dir.",
+        ),
+    ] = None
+
     interval: Annotated[int | None, Field(description="The interval at which to save checkpoints.")] = None
 
     resume_step: Annotated[
@@ -378,6 +385,10 @@ class RLConfig(BaseConfig):
                 self.trainer.ckpt = TrainerCheckpointConfig()
             if self.orchestrator.ckpt is None:
                 self.orchestrator.ckpt = OrchestratorCheckpointConfig()
+
+            # If specified, override checkpoint output directory
+            if self.ckpt.output_dir is not None:
+                self.trainer.ckpt.output_dir = self.ckpt.output_dir
 
             # If specified, use the same ckpt interval
             if self.ckpt.interval is not None:

--- a/src/prime_rl/configs/trainer.py
+++ b/src/prime_rl/configs/trainer.py
@@ -457,6 +457,13 @@ class WeightCheckpointConfig(BaseConfig):
 class CheckpointConfig(BaseConfig):
     """Configures checkpointing the full model, optimizer and training state for resuming training."""
 
+    output_dir: Annotated[
+        Path | None,
+        Field(
+            description="Override directory for checkpoints and weights. When set, checkpoints and weight snapshots are written here instead of under the trainer output_dir. Useful for writing large checkpoints to a separate storage volume.",
+        ),
+    ] = None
+
     interval: Annotated[
         int | None,
         Field(

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -455,8 +455,11 @@ def rl_slurm(config: RLConfig):
 def rl(config: RLConfig):
     resuming = config.ckpt is not None and config.ckpt.resume_step is not None
     clean = config.clean_output_dir and not os.environ.get("NEVER_CLEAN_OUTPUT_DIR")
-    validate_output_dir(config.output_dir, resuming=resuming, clean=clean)
+    ckpt_output_dir = config.ckpt.output_dir if config.ckpt else None
+    validate_output_dir(config.output_dir, resuming=resuming, clean=clean, ckpt_output_dir=ckpt_output_dir)
     config.output_dir.mkdir(parents=True, exist_ok=True)
+    if ckpt_output_dir is not None:
+        ckpt_output_dir.mkdir(parents=True, exist_ok=True)
 
     if config.slurm is not None:
         rl_slurm(config)

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -443,10 +443,11 @@ def setup_ckpt_managers(
 ) -> tuple[CheckpointManager | None, WeightCheckpointManager | None]:
     if ckpt_config is None:
         return None, None
-    ckpt_manager = CheckpointManager(output_dir, ckpt_config)
+    ckpt_output_dir = ckpt_config.output_dir or output_dir
+    ckpt_manager = CheckpointManager(ckpt_output_dir, ckpt_config)
     if ckpt_config.weights:
         weight_ckpt_manager = WeightCheckpointManager(
-            output_dir,
+            ckpt_output_dir,
             ckpt_config.weights,
             lora_config=lora_config,
             keep_last=ckpt_config.keep_last,

--- a/src/prime_rl/utils/pathing.py
+++ b/src/prime_rl/utils/pathing.py
@@ -69,29 +69,37 @@ def has_checkpoints(output_dir: Path) -> bool:
     return ckpt_dir.exists() and any(ckpt_dir.iterdir())
 
 
-def validate_output_dir(output_dir: Path, *, resuming: bool, clean: bool) -> None:
+def validate_output_dir(output_dir: Path, *, resuming: bool, clean: bool, ckpt_output_dir: Path | None = None) -> None:
     """Validate the output directory before training starts.
 
     Raises if the directory contains checkpoints from a previous run, unless
     explicitly resuming or opting into cleaning. Other artifacts (logs,
     rollouts, configs) are fine and don't trigger the error.
+
+    When ckpt_output_dir is set, checkpoints live there instead of under
+    output_dir, so the guard and clean logic check both locations.
     """
-    if not output_dir.exists():
-        return
+    dirs_to_check = [output_dir]
+    if ckpt_output_dir is not None and ckpt_output_dir != output_dir:
+        dirs_to_check.append(ckpt_output_dir)
+
     if resuming:
         return
     if clean:
         logger = get_logger()
-        logger.warning(f"Cleaning existing output directory: {output_dir}")
-        shutil.rmtree(output_dir)
+        for d in dirs_to_check:
+            if d.exists():
+                logger.warning(f"Cleaning existing directory: {d}")
+                shutil.rmtree(d)
         return
-    if has_checkpoints(output_dir):
-        raise FileExistsError(
-            f"Output directory '{output_dir}' already contains checkpoints from a previous run. "
-            f"To resume the latest step of the previous run, set ckpt.resume_step=-1 or --ckpt.resume-step -1 via CLI. "
-            f"To delete the existing directory and start fresh, set clean_output_dir=true or --clean-output-dir via CLI. "
-            f"Otherwise use a unique output_dir for this experiment."
-        )
+    for d in dirs_to_check:
+        if has_checkpoints(d):
+            raise FileExistsError(
+                f"Directory '{d}' already contains checkpoints from a previous run. "
+                f"To resume the latest step of the previous run, set ckpt.resume_step=-1 or --ckpt.resume-step -1 via CLI. "
+                f"To delete the existing directory and start fresh, set clean_output_dir=true or --clean-output-dir via CLI. "
+                f"Otherwise use a unique output_dir for this experiment."
+            )
 
 
 def sync_wait_for_path(path: Path, interval: int = 1, log_interval: int = 10) -> None:


### PR DESCRIPTION
Adds optional ckpt.output_dir to write checkpoints and weights to a different path than the main output_dir. Keeps logs, rollouts, and broadcasts on fast-access storage while heavy archival checkpoints go to high-capacity storage.       
   
```toml
output_dir = "/shared/outputs/opencode-swe"

[ckpt]
output_dir = "/data/outputs/opencode-swe"
```
                                                                                                                                                                                                                                               
`--clean-output-dir` and the stale-checkpoint guard check both locations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where checkpoints/weight snapshots are written and how output directories are validated/cleaned at startup, which can affect resume behavior and data retention if misconfigured. Scope is limited to path/config plumbing around checkpoint management.
> 
> **Overview**
> Adds an optional `ckpt.output_dir` to route trainer checkpoints and weight snapshots to a separate directory, while leaving the main `output_dir` for other run artifacts.
> 
> Plumbs the override through shared RL config resolution and trainer checkpoint manager setup, and updates the RL entrypoint and `validate_output_dir` logic so the stale-checkpoint guard and `--clean-output-dir` behavior apply to both the primary output directory and the separate checkpoint directory (creating the checkpoint directory when configured).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d28d344b07949006b013b007de49b8c3d52d391a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->