### PR TITLE
add monkeypatch for qwen3.5 lora

### DIFF
--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -32,9 +32,6 @@ def _patch_qwen35_lora():
 
     qkvz_fix = ["in_proj_q", "in_proj_k", "in_proj_v", "in_proj_z"]
 
-    if Qwen3_5ForCausalLMBase.packed_modules_mapping.get("in_proj_qkvz") == qkvz_fix:
-        return
-
     Qwen3_5ForCausalLMBase.packed_modules_mapping["in_proj_qkvz"] = qkvz_fix
     Qwen3_5ForConditionalGeneration.packed_modules_mapping["in_proj_qkvz"] = qkvz_fix
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> This PR monkeypatches vLLM’s LoRA/model internals for Qwen3.5, which is sensitive to upstream changes and could affect LoRA layer replacement behavior at runtime. Impact should be limited to LoRA initialization/replacement paths but could break on vLLM version drift.
> 
> **Overview**
> Fixes Qwen3.5 LoRA initialization in vLLM by adding a `_patch_qwen35_lora()` hook that runs from `transformers_v5_compat()`.
> 
> The patch aligns Qwen3.5’s `packed_modules_mapping["in_proj_qkvz"]` with the 4-way `output_sizes` (q/k/v/z) and overrides `MergedColumnParallelLinearWithLoRA.can_replace_layer` to accept *any* packed-module count as long as it matches `output_sizes`, avoiding the prior 2-module assumption and the resulting `IndexError`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41c924dfde7ca33c2b870f956a8c532bb06e9ba5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->