### PR TITLE
Add sample_ratio to LogExtrasConfig for gradual rollout control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Documenting changes which affect configuration usage patterns (added/moved/removed/renamed fields, notable logic changes).
 
+- **`prime_monitor.log_extras.sample_ratio`**: Added ratio-based rollout sampling (0.0–1.0, default: None). When set, caps the number of rollouts logged per step to `len(rollouts) * sample_ratio`. `None` preserves current behavior (log all rollouts). Interacts with existing `interval` gate which still runs first. (2026-03-12)
 - **`client.connect_timeout`**: Added configurable TCP connect timeout for inference API requests (default: 30.0s). Previously hardcoded to 5.0s. Helps with vLLM or cluster flakiness (2026-03-11)
 - **`model.fused_lm_head_token_chunk_size`**: Added as the fused LM-head chunking field for the token-chunked implementation. Unlike the removed `model.fused_lm_head_chunk_size`, this chunks over flattened sequence tokens rather than vocabulary rows. `model.fused_lm_head_chunk_size` is no longer accepted; switch configs to `model.fused_lm_head_token_chunk_size` explicitly. (2026-03-09)
 - **`slurm.pre_run_command`**: Added optional shell command to run on the head node before starting the job. Useful for cleanup routines (e.g. killing stale processes, removing lock files). For all-nodes execution, wrap with `srun` in the command string (default: None) (2026-03-08)

--- a/src/prime_rl/configs/shared.py
+++ b/src/prime_rl/configs/shared.py
@@ -269,6 +269,18 @@ class LogExtrasConfig(BaseConfig):
         ),
     ] = 10
 
+    sample_ratio: Annotated[
+        float | None,
+        Field(
+            ge=0.0,
+            le=1.0,
+            description="Fraction of rollouts to log per step (0.0–1.0). "
+            "When set, the effective sample cap is len(rollouts) * sample_ratio. "
+            "1.0 = all rollouts, 0.5 = half, 0.0 = none. "
+            "None (default) = log all rollouts (current behavior).",
+        ),
+    ] = None
+
 
 class WandbConfig(BaseConfig):
     """Configures logging to Weights and Biases."""

--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -2,6 +2,7 @@ import asyncio
 import io
 import json
 import os
+import random
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -143,14 +144,22 @@ class PrimeMonitor(Monitor):
             or not self.config.log_extras.samples
             or step % self.config.log_extras.interval != 0
         ):
-            # Do not log samples if not enabled or not log interval step
             return
+
+        ratio = self.config.log_extras.sample_ratio
+        if ratio is not None:
+            if ratio <= 0.0:
+                return
+            if ratio < 1.0:
+                max_samples = max(1, int(len(rollouts) * ratio))
+                if len(rollouts) > max_samples:
+                    rollouts = random.sample(rollouts, max_samples)
 
         assert self.last_log_samples_step <= step, "Step must be greater than last logged step"
         assert step not in self._pending_sample_steps, f"Step {step} upload already in progress"
         assert self.logger is not None, "Logger is required for sample logging"
 
-        self.logger.info(f"Logging samples to Prime Intellect API at step {step}")
+        self.logger.info(f"Logging {len(rollouts)} samples to Prime Intellect API at step {step}")
         start_time = time.perf_counter()
 
         parquet_bytes = self._rollouts_to_parquet_bytes(rollouts, step)


### PR DESCRIPTION
## Summary

- Adds `sample_ratio` field (0.0–1.0, optional float) to `LogExtrasConfig` to control what fraction of rollouts are logged per step
- When set, the effective sample cap is computed from the actual rollout count at runtime: `int(len(rollouts) * sample_ratio)`
- `1.0` = all rollouts, `0.5` = half, `0.0` = disable, `None` (default) = current behavior (log all)

### How it interacts with existing defaults

The existing `interval` gate (`step % interval != 0`, default `interval=10`) is untouched and always runs first. `sample_ratio` only applies **after** the interval gate passes. When `sample_ratio` is `None` (the default), the new code is a complete no-op.

**Current behavior (unchanged):** every 10th step, all rollouts are logged.

| `interval` | `sample_ratio` | batch_size=128 | What happens |
|---|---|---|---|
| 10 | `None` (default) | step 10: 128 rollouts | Current behavior, no change |
| 10 | 1.0 | step 10: 128 rollouts | Equivalent to current — all rollouts |
| 10 | 0.5 | step 10: 64 rollouts | Half the rollouts, randomly sampled |
| 1 | 1.0 | every step: 128 rollouts | Full data every step |
| 1 | 0.1 | every step: 12 rollouts | 10% of rollouts every step |
| 10 | 0.0 | step 10: skip | Disables sample logging entirely |

### Usage

In the orchestrator TOML config:

```toml
[orchestrator.prime_monitor.log_extras]
sample_ratio = 0.5
interval = 1
```

Or via CLI args:

```bash
--prime-monitor.log-extras.sample-ratio 0.5 --prime-monitor.log-extras.interval 1
```

For hosted platform runs, this can be passed through `run_config`:

```toml
[run_config]
prime-monitor.log-extras.sample-ratio = 1.0
prime-monitor.log-extras.interval = 1
```