### PR TITLE
fix: patch sharded LoRA slice_lora_a for Qwen3.5 MoE

### DIFF
--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -20,11 +20,16 @@ def _patch_qwen35_lora():
     during LoRA initialization.
 
     Also generalizes MergedColumnParallelLinearWithLoRA.can_replace_layer
-    to accept any number of packed modules (not just 2).
+    to accept any number of packed modules (not just 2), and generalizes
+    MergedColumnParallelLinearWithShardedLoRA.slice_lora_a to handle N
+    subloras instead of the hardcoded 2 (needed for fully_sharded_loras=True).
 
     Upstream: https://github.com/vllm-project/vllm/issues/36372
     """
-    from vllm.lora.layers.column_parallel_linear import MergedColumnParallelLinearWithLoRA
+    from vllm.lora.layers.column_parallel_linear import (
+        MergedColumnParallelLinearWithLoRA,
+        MergedColumnParallelLinearWithShardedLoRA,
+    )
     from vllm.model_executor.models.qwen3_5 import (
         Qwen3_5ForCausalLMBase,
         Qwen3_5ForConditionalGeneration,
@@ -47,6 +52,15 @@ def _patch_qwen35_lora():
         )
 
     MergedColumnParallelLinearWithLoRA.can_replace_layer = can_replace_layer
+
+    def slice_lora_a(self, lora_a):
+        output_shard_size = self.lora_a_stacked[0].shape[2]
+        output_start_idx = self.tp_rank * output_shard_size
+        return [
+            a[output_start_idx : output_start_idx + output_shard_size, :] if a is not None else None for a in lora_a
+        ]
+
+    MergedColumnParallelLinearWithShardedLoRA.slice_lora_a = slice_lora_a
 
 
 # Monkeypatch PrometheusStatLogger to avoid NotImplementedError for LoRA in DP mode


### PR DESCRIPTION
## Summary
- Generalizes `MergedColumnParallelLinearWithShardedLoRA.slice_lora_a` to handle N subloras instead of the hardcoded 2
- Fixes `IndexError` when using `fully_sharded_loras=True` with Qwen3.5 MoE models (whose GDN layers fuse 4 projections: q, k, v, z)
- Extends the existing Qwen3.5 LoRA monkeypatch from #2019

## Test plan
- [x] Launched `Qwen/Qwen3.5-35B-A3B` with `fully_sharded_loras=true`, TP=2, loaded a LoRA adapter, and served requests successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches vLLM LoRA monkeypatches that affect adapter initialization and tensor-parallel sharding; mistakes could break LoRA loading or produce incorrect weight slicing at runtime.
> 
> **Overview**
> Fixes Qwen3.5 MoE LoRA initialization when GDN layers fuse 4 projections (`q/k/v/z`) by aligning `packed_modules_mapping` with the layer `output_sizes`.
> 
> Extends the existing vLLM monkeypatches to support *N* packed modules: `MergedColumnParallelLinearWithLoRA.can_replace_layer` now validates against the full `output_sizes` length, and `MergedColumnParallelLinearWithShardedLoRA.slice_lora_a` now slices an arbitrary list of sub-LoRAs for `fully_sharded_loras=True` instead of assuming 2.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef8e4edfe3282fd1ba120807585b2fca9b3a8a90. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->