### PR TITLE
fix: cleanup env subprocesses on orchestrator crash

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -1,4 +1,5 @@
 import asyncio
+import atexit
 import gc
 import multiprocessing as mp
 import random
@@ -193,6 +194,17 @@ async def orchestrate(config: OrchestratorConfig):
 
     train_env_addresses = []
     env_processes: list[mp.Process] = []
+
+    def _cleanup_env_processes():
+        for proc in env_processes:
+            proc.terminate()
+            proc.join(timeout=5)
+            if proc.is_alive():
+                proc.kill()
+                proc.join(timeout=5)
+
+    atexit.register(_cleanup_env_processes)
+
     for env_id, env, env_name in zip(env_ids, config.env, train_env_names):
         if env.address is None:
             address, process = spawn_env_server(
@@ -850,13 +862,9 @@ async def orchestrate(config: OrchestratorConfig):
     # Cancel event loop lag monitor task
     event_loop_lag_monitor_task.cancel()
 
-    # Shutdown env processes
-    for process in env_processes:
-        process.terminate()
-        process.join(timeout=5)
-        if process.is_alive():
-            process.kill()
-            process.join(timeout=5)
+    # Shutdown env processes (also registered as atexit handler for crash safety)
+    atexit.unregister(_cleanup_env_processes)
+    _cleanup_env_processes()
 
     logger.success("Orchestrator finished.")
 


### PR DESCRIPTION
When the orchestrator crashes (e.g. eval env timeout), spawned env server subprocesses are never terminated because the cleanup code at the end of `orchestrate()` is only reached on normal exit. These orphaned processes (spawned with `daemon=False`) keep the container alive, so K8s never detects the job failure and the run stays stuck in RUNNING.

- Register an `atexit` handler after `env_processes` init to terminate all spawned processes on crash
- On normal exit, unregister and call cleanup explicitly (same behavior as before)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts subprocess lifecycle management to prevent orphaned env servers, with existing termination behavior preserved on normal shutdown.
> 
> **Overview**
> Adds an `atexit`-registered `_cleanup_env_processes()` in `orchestrator.py` to ensure spawned env server subprocesses are terminated/killed if the orchestrator exits unexpectedly.
> 
> On normal completion, the orchestrator now explicitly `unregister`s the handler and calls the same cleanup routine, replacing the inline shutdown loop while keeping the termination semantics the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc51741b9321d0a75eb381618fb52e9df36054b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->