### PR TITLE
feat: add sample-level loss normalization for SFT

### DIFF
--- a/src/prime_rl/configs/sft.py
+++ b/src/prime_rl/configs/sft.py
@@ -367,8 +367,6 @@ class SFTConfig(BaseConfig):
                     "because the fused kernel does not support per-token loss output. "
                     "Use loss_impl='liger' or loss_impl='torch' instead."
                 )
-            if self.model.cp > 1:
-                raise ValueError("loss_normalization='sample' is not supported with context parallelism (cp > 1).")
         return self
 
     ### Auto-setup and validate shared configs

--- a/src/prime_rl/configs/sft.py
+++ b/src/prime_rl/configs/sft.py
@@ -360,13 +360,6 @@ class SFTConfig(BaseConfig):
 
     @model_validator(mode="after")
     def validate_loss_normalization(self):
-        if self.loss_normalization == "sample":
-            if self.loss_impl == "liger_fused":
-                raise ValueError(
-                    "loss_normalization='sample' is not supported with loss_impl='liger_fused' "
-                    "because the fused kernel does not support per-token loss output. "
-                    "Use loss_impl='liger' or loss_impl='torch' instead."
-                )
         return self
 
     ### Auto-setup and validate shared configs

--- a/src/prime_rl/configs/sft.py
+++ b/src/prime_rl/configs/sft.py
@@ -232,6 +232,15 @@ class SFTConfig(BaseConfig):
         ),
     ] = "torch"
 
+    loss_normalization: Annotated[
+        Literal["token", "sample"],
+        Field(
+            description="Loss normalization mode. "
+            "'token' averages over all output tokens globally. "
+            "'sample' computes per-sample mean loss then averages across samples.",
+        ),
+    ] = "token"
+
     heartbeat: Annotated[
         HeartbeatConfig | None, Field(description="The heartbeat config for monitoring training progress.")
     ] = None
@@ -347,6 +356,19 @@ class SFTConfig(BaseConfig):
         if self.model.ep > 1 and self.model.impl not in ("custom", "auto"):
             raise ValueError("EP is only supported with the custom implementation or auto mode")
 
+        return self
+
+    @model_validator(mode="after")
+    def validate_loss_normalization(self):
+        if self.loss_normalization == "sample":
+            if self.loss_impl == "liger_fused":
+                raise ValueError(
+                    "loss_normalization='sample' is not supported with loss_impl='liger_fused' "
+                    "because the fused kernel does not support per-token loss output. "
+                    "Use loss_impl='liger' or loss_impl='torch' instead."
+                )
+            if self.model.cp > 1:
+                raise ValueError("loss_normalization='sample' is not supported with context parallelism (cp > 1).")
         return self
 
     ### Auto-setup and validate shared configs

--- a/src/prime_rl/configs/sft.py
+++ b/src/prime_rl/configs/sft.py
@@ -358,10 +358,6 @@ class SFTConfig(BaseConfig):
 
         return self
 
-    @model_validator(mode="after")
-    def validate_loss_normalization(self):
-        return self
-
     ### Auto-setup and validate shared configs
 
     @model_validator(mode="after")

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -807,12 +807,14 @@ def forward(
     # Multimodal fields (Qwen3-VL)
     pixel_values: Float[Tensor, "num_patches patch_dim"] | None = None,
     image_grid_thw: Int[Tensor, "num_images 3"] | None = None,
+    token_weight: Tensor | None = None,
 ) -> PrimeLmOutput:
     # Build kwargs for model forward
     kwargs = {
         "input_ids": input_ids,
         "labels": labels,
         "temperature": temperature,
+        "token_weight": token_weight,
     }
 
     # For multimodal (VLM), don't pass position_ids - let the model compute MRoPE internally

--- a/src/prime_rl/trainer/models/layers/fused_ce_sample_norm.py
+++ b/src/prime_rl/trainer/models/layers/fused_ce_sample_norm.py
@@ -11,10 +11,8 @@ that calls it and accumulates gradients. The key changes:
 import torch
 import triton
 from liger_kernel.ops.cross_entropy import liger_cross_entropy_kernel
-from liger_kernel.ops.fused_linear_cross_entropy import fused_linear_cross_entropy_backward
+from liger_kernel.ops.fused_linear_cross_entropy import MAX_FUSED_SIZE, fused_linear_cross_entropy_backward
 from liger_kernel.ops.utils import amp_custom_bwd, amp_custom_fwd, is_hip
-
-MAX_FUSED_SIZE = 65536 // 2
 
 
 def _fused_linear_cross_entropy_forward_with_token_weight(

--- a/src/prime_rl/trainer/models/layers/fused_ce_sample_norm.py
+++ b/src/prime_rl/trainer/models/layers/fused_ce_sample_norm.py
@@ -1,0 +1,167 @@
+"""
+Vendored and modified version of Liger's fused_linear_cross_entropy_forward that supports
+per-token weighting for sample-level loss normalization.
+
+The Triton kernel (liger_cross_entropy_kernel) is NOT modified — only the Python wrapper
+that calls it and accumulates gradients. The key changes:
+1. Accepts an optional `token_weight` tensor [BT] that scales each token's loss and gradient
+2. Uses reduction="sum" internally, then applies token_weight to get the sample-weighted loss
+"""
+
+import torch
+import triton
+from liger_kernel.ops.cross_entropy import liger_cross_entropy_kernel
+from liger_kernel.ops.fused_linear_cross_entropy import fused_linear_cross_entropy_backward
+from liger_kernel.ops.utils import amp_custom_bwd, amp_custom_fwd, is_hip
+
+MAX_FUSED_SIZE = 65536 // 2
+
+
+def _fused_linear_cross_entropy_forward_with_token_weight(
+    _input: torch.Tensor,
+    weight: torch.Tensor,
+    target: torch.Tensor,
+    token_weight: torch.Tensor,
+    ignore_index: int = -100,
+    softcap: float | None = None,
+):
+    """Fused linear + cross-entropy forward with per-token weighting.
+
+    Like Liger's fused_linear_cross_entropy_forward but:
+    - Always uses reduction="sum" internally
+    - Applies token_weight to both loss and pre-computed gradients
+    - Returns weighted scalar loss
+
+    Args:
+        _input: [BT, H] hidden states
+        weight: [V, H] lm_head weight
+        target: [BT] target token ids (ignore_index for masked positions)
+        token_weight: [BT] per-token weight (e.g. 1/|O_c| for sample normalization)
+        ignore_index: target value to ignore
+        softcap: optional logit soft-capping value
+    """
+    device = _input.device
+    BT, H = _input.shape
+    V = weight.shape[0]
+    BLOCK_SIZE = min(MAX_FUSED_SIZE, triton.next_power_of_2(V))
+
+    inc_factor = triton.cdiv(V, H)
+    chunk_size = triton.next_power_of_2(triton.cdiv(BT, inc_factor))
+    num_chunks = triton.cdiv(BT, chunk_size)
+
+    grad_input = torch.zeros_like(_input, device=device)
+    grad_weight = torch.zeros_like(weight, device=device) if weight.requires_grad else None
+
+    loss_1d = torch.zeros(BT, dtype=torch.float32, device=device)
+
+    target_mask = target != ignore_index
+    total_n_non_ignore = target_mask.sum().item()
+
+    for chunk_id in range(num_chunks):
+        start_idx = chunk_id * chunk_size
+        end_idx = min((chunk_id + 1) * chunk_size, BT)
+        _input_chunk = _input[start_idx:end_idx]
+
+        logits_chunk = _input_chunk @ weight.t()
+        target_chunk = target[start_idx:end_idx]
+        n_rows = logits_chunk.shape[0]
+        loss_1d_slice = loss_1d[start_idx:end_idx]
+
+        logits_chunk = logits_chunk.contiguous()
+        target_chunk = target_chunk.contiguous()
+
+        # Triton kernel computes per-token loss and overwrites logits_chunk with gradients.
+        # Using reduction="sum" so gradients are (softmax - one_hot), not divided by N.
+        liger_cross_entropy_kernel[(n_rows,)](
+            X_ptr=logits_chunk,
+            X_stride=logits_chunk.stride(-2),
+            Y_ptr=target_chunk,
+            Y_stride=target_chunk.stride(-1),
+            weight_ptr=None,
+            loss_ptr=loss_1d_slice,
+            z_loss_ptr=None,
+            loss_stride=loss_1d_slice.stride(-1),
+            n_cols=V,
+            n_non_ignore=total_n_non_ignore,
+            sum_non_ignore_weight=total_n_non_ignore,
+            weight_sum=0.0,
+            ignore_index=ignore_index,
+            lse_square_scale=0.0,
+            label_smoothing=0.0,
+            reduction="sum",
+            softcap=softcap,
+            RETURN_Z_LOSS=False,
+            HAS_WEIGHT=False,
+            HAS_SOFTCAPPING=softcap is not None,
+            BLOCK_SIZE=BLOCK_SIZE,
+            num_warps=32 if not is_hip() else 16,
+        )
+
+        loss_1d[start_idx:end_idx] = loss_1d_slice
+        grad_logits_chunk = logits_chunk  # kernel overwrote logits in-place with grads
+
+        # Apply per-token weight to gradients before projecting back to input space.
+        # This is mathematically equivalent to scaling after projection (linearity).
+        weight_chunk = token_weight[start_idx:end_idx].unsqueeze(-1)
+        grad_logits_chunk = grad_logits_chunk * weight_chunk
+
+        grad_input[start_idx:end_idx] = grad_logits_chunk @ weight
+
+        if grad_weight is not None:
+            grad_weight += torch.mm(grad_logits_chunk.t(), _input_chunk).float()
+
+    loss = torch.sum(loss_1d * token_weight)
+
+    grad_weight = grad_weight.to(weight.dtype) if grad_weight is not None else None
+    return loss, grad_input, grad_weight
+
+
+class SampleWeightedFusedLinearCrossEntropyFunction(torch.autograd.Function):
+    @staticmethod
+    @amp_custom_fwd
+    def forward(ctx, _input, weight, target, token_weight, ignore_index, softcap):
+        loss, grad_input, grad_weight = _fused_linear_cross_entropy_forward_with_token_weight(
+            _input, weight, target, token_weight, ignore_index, softcap
+        )
+        ctx.save_for_backward(
+            grad_input.detach(),
+            grad_weight.detach() if grad_weight is not None else None,
+        )
+        return loss
+
+    @staticmethod
+    @amp_custom_bwd
+    def backward(ctx, grad_output):
+        (grad_input, grad_weight) = ctx.saved_tensors
+        grad_input, grad_weight, _ = fused_linear_cross_entropy_backward(grad_output, grad_input, grad_weight, None)
+        return grad_input, grad_weight, None, None, None, None
+
+
+def sample_weighted_fused_cross_entropy(
+    weight: torch.Tensor,
+    hidden_states: torch.Tensor,
+    labels: torch.Tensor,
+    token_weight: torch.Tensor,
+    ignore_index: int = -100,
+    softcap: float | None = None,
+) -> torch.Tensor:
+    """Compute fused linear + cross-entropy loss with per-token sample weights.
+
+    Args:
+        weight: [V, H] lm_head weight matrix
+        hidden_states: [B, S, H] hidden states from model backbone
+        labels: [B, S] target ids (ignore_index for positions to skip)
+        token_weight: [B, S] per-token weight for sample normalization
+        ignore_index: target value to ignore (default -100)
+        softcap: optional logit soft-capping value
+
+    Returns:
+        Scalar loss: sum of (per-token loss * token_weight)
+    """
+    b, s, h = hidden_states.shape
+    hidden_flat = hidden_states.reshape(b * s, h).contiguous()
+    labels_flat = labels.reshape(b * s).contiguous()
+    token_weight_flat = token_weight.reshape(b * s).contiguous()
+    return SampleWeightedFusedLinearCrossEntropyFunction.apply(
+        hidden_flat, weight, labels_flat, token_weight_flat, ignore_index, softcap
+    )

--- a/src/prime_rl/trainer/models/layers/lm_head.py
+++ b/src/prime_rl/trainer/models/layers/lm_head.py
@@ -43,6 +43,7 @@ class FusedOutputLinear(torch.nn.Linear):
         hidden_states: torch.Tensor,
         labels: torch.Tensor | None = None,
         temperature: Tensor | None = None,
+        token_weight: Tensor | None = None,
     ) -> PrimeLmOutput:
         assert labels is not None, "FusedOutputLinear requires labels for chunked logprob computation"
         assert temperature is not None, "FusedOutputLinear requires per-token temperatures"
@@ -66,7 +67,11 @@ class VanillaOutputLinear(torch.nn.Linear):
         super().__init__(in_features, out_features, bias=False)
 
     def forward(
-        self, hidden_states: torch.Tensor, labels: torch.Tensor | None = None, temperature: Tensor | None = None
+        self,
+        hidden_states: torch.Tensor,
+        labels: torch.Tensor | None = None,
+        temperature: Tensor | None = None,
+        token_weight: Tensor | None = None,
     ) -> PrimeLmOutput:
         # VanillaOutputLinear just returns logits - temperature scaling is done externally in train.py
         return PrimeLmOutput(logits=super().forward(hidden_states))

--- a/src/prime_rl/trainer/models/layers/lm_head.py
+++ b/src/prime_rl/trainer/models/layers/lm_head.py
@@ -94,9 +94,18 @@ class FusedCrossEntropyOutputLinear(torch.nn.Linear):
         hidden_states: torch.Tensor,
         labels: torch.Tensor | None = None,
         temperature: Tensor | None = None,
+        token_weight: Tensor | None = None,
     ) -> PrimeLmOutput:
         if labels is None:
             return PrimeLmOutput(logits=super().forward(hidden_states))
+
+        if token_weight is not None:
+            from prime_rl.trainer.models.layers.fused_ce_sample_norm import sample_weighted_fused_cross_entropy
+
+            loss = sample_weighted_fused_cross_entropy(
+                self.weight, hidden_states, labels, token_weight, self.IGNORE_INDEX, self.fused_ce.softcap
+            )
+            return PrimeLmOutput(loss=loss)
 
         b, s, h = hidden_states.shape
         hidden_flat = hidden_states.reshape(b * s, h).contiguous()
@@ -293,6 +302,7 @@ def _patch_model_forward(model: nn.Module) -> None:
         labels: torch.Tensor | None = None,
         logits_to_keep: int = 0,
         temperature: torch.Tensor | None = None,
+        token_weight: torch.Tensor | None = None,
         **kwargs: object,
     ) -> PrimeLmOutput:
         # For VLM with images, don't create position_ids - let model compute MRoPE internally
@@ -318,6 +328,7 @@ def _patch_model_forward(model: nn.Module) -> None:
             hidden_states[:, slice_indices, :],
             labels[:, slice_indices] if labels is not None else None,
             temperature=temperature[:, slice_indices] if temperature is not None else None,
+            token_weight=token_weight[:, slice_indices] if token_weight is not None else None,
         )
 
     # Bind the new forward to the model

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -242,19 +242,22 @@ def train(config: SFTConfig):
             )
             return per_sample_mean.sum(), valid.sum(dtype=torch.int64)
 
-        # cat packing: group by sample using position_ids-derived boundaries
-        tl = token_loss[0]
-        mask = loss_mask[0]
-        num_samples = sample_ids[-1].item() + 1
-        masked_ids = sample_ids[mask]
-        masked_losses = tl[mask]
-        per_sample_loss = tl.new_zeros(num_samples)
-        per_sample_loss.scatter_add_(0, masked_ids, masked_losses)
-        per_sample_token_count = tl.new_zeros(num_samples)
-        per_sample_token_count.scatter_add_(0, masked_ids, torch.ones_like(masked_losses))
-        valid = per_sample_token_count > 0
-        per_sample_mean = torch.where(valid, per_sample_loss / per_sample_token_count, per_sample_loss.new_zeros(()))
-        return per_sample_mean.sum(), valid.sum(dtype=torch.int64)
+        elif config.data.pack_function == "cat":
+            # Group by sample using position_ids-derived boundaries
+            tl = token_loss[0]
+            mask = loss_mask[0]
+            num_samples = sample_ids[-1].item() + 1
+            masked_ids = sample_ids[mask]
+            masked_losses = tl[mask]
+            per_sample_loss = tl.new_zeros(num_samples)
+            per_sample_loss.scatter_add_(0, masked_ids, masked_losses)
+            per_sample_token_count = tl.new_zeros(num_samples)
+            per_sample_token_count.scatter_add_(0, masked_ids, torch.ones_like(masked_losses))
+            valid = per_sample_token_count > 0
+            per_sample_mean = torch.where(
+                valid, per_sample_loss / per_sample_token_count, per_sample_loss.new_zeros(())
+            )
+            return per_sample_mean.sum(), valid.sum(dtype=torch.int64)
 
     maybe_record_function = nullcontext
 

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -197,19 +197,23 @@ def train(config: SFTConfig):
         target_ids = micro_batch["target_ids"].to("cuda")
         loss_mask = micro_batch["loss_mask"].to("cuda")
 
-        # Detect sample boundaries from position_ids resets (for cat packing + sample normalization)
+        # Detect sample boundaries from position_ids resets before CP sharding
         sample_ids = None
+        num_samples = 0
         if config.loss_normalization == "sample" and config.data.pack_function == "cat":
             pos = position_ids[0]
             is_boundary = torch.zeros_like(pos, dtype=torch.bool)
             is_boundary[0] = True
             is_boundary[1:] = pos[1:] <= pos[:-1]
             sample_ids = is_boundary.cumsum(0) - 1
+            num_samples = sample_ids[-1].item() + 1
 
         if cp_enabled:
             input_ids, position_ids = setup_cp_params(input_ids, position_ids, cp_rank, cp_size, cp_group)
             target_ids = shard_for_cp(target_ids, cp_rank=cp_rank, cp_world_size=cp_size)
             loss_mask = shard_for_cp(loss_mask, cp_rank=cp_rank, cp_world_size=cp_size)
+            if sample_ids is not None:
+                sample_ids = shard_for_cp(sample_ids.unsqueeze(0), cp_rank=cp_rank, cp_world_size=cp_size).squeeze(0)
 
         token_count = loss_mask.sum(dtype=torch.int64)
 
@@ -246,18 +250,30 @@ def train(config: SFTConfig):
             # Group by sample using position_ids-derived boundaries
             tl = token_loss[0]
             mask = loss_mask[0]
-            num_samples = sample_ids[-1].item() + 1
             masked_ids = sample_ids[mask]
             masked_losses = tl[mask]
             per_sample_loss = tl.new_zeros(num_samples)
             per_sample_loss.scatter_add_(0, masked_ids, masked_losses)
             per_sample_token_count = tl.new_zeros(num_samples)
             per_sample_token_count.scatter_add_(0, masked_ids, torch.ones_like(masked_losses))
-            valid = per_sample_token_count > 0
-            per_sample_mean = torch.where(
-                valid, per_sample_loss / per_sample_token_count, per_sample_loss.new_zeros(())
+
+            if cp_enabled:
+                # All-reduce token counts across CP so each rank knows global per-sample counts.
+                # Only the counts are synchronized — per_sample_loss stays local so gradients
+                # are correct per-rank when backward is called.
+                global_token_count = per_sample_token_count.detach().clone()
+                dist.all_reduce(global_token_count, op=dist.ReduceOp.SUM, group=cp_group)
+            else:
+                global_token_count = per_sample_token_count
+
+            valid = global_token_count > 0
+            per_sample_mean = torch.where(valid, per_sample_loss / global_token_count, per_sample_loss.new_zeros(()))
+            # With CP, all ranks in the same CP group process the same sequence, so only
+            # cp_rank 0 reports the sample count to avoid double-counting after dp+cp all-reduce.
+            sample_count = (
+                valid.sum(dtype=torch.int64) if cp_rank == 0 else torch.tensor(0, dtype=torch.int64, device="cuda")
             )
-            return per_sample_mean.sum(), valid.sum(dtype=torch.int64)
+            return per_sample_mean.sum(), sample_count
 
     maybe_record_function = nullcontext
 

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -187,6 +187,38 @@ def train(config: SFTConfig):
         case _:
             raise ValueError(f"Invalid loss implementation: {config.loss_impl}")
 
+    def _compute_token_weight(
+        loss_mask: torch.Tensor,
+        sample_ids: torch.Tensor | None,
+        num_samples: int,
+        use_cp: bool,
+        cp_group_: dist.ProcessGroup | None,
+    ) -> torch.Tensor:
+        """Compute per-token weight = 1/|O_c| for sample-level normalization.
+
+        Returns a [B, S] tensor where each unmasked token gets weight 1/(number of
+        unmasked tokens in its sample). Masked tokens get weight 0.
+        """
+        B, S = loss_mask.shape
+
+        if config.data.pack_function == "stack":
+            per_row_count = loss_mask.sum(dim=1, keepdim=True).float()
+            token_weight = torch.where(loss_mask & (per_row_count > 0), 1.0 / per_row_count, 0.0)
+            return token_weight
+
+        # cat packing: use sample_ids to group tokens
+        mask = loss_mask[0]
+        per_sample_count = torch.zeros(num_samples, device=mask.device, dtype=torch.float)
+        per_sample_count.scatter_add_(0, sample_ids[mask], torch.ones(mask.sum(), device=mask.device))
+
+        if use_cp and cp_group_ is not None:
+            dist.all_reduce(per_sample_count, op=dist.ReduceOp.SUM, group=cp_group_)
+
+        token_weight = torch.zeros(S, device=mask.device)
+        valid_counts = per_sample_count[sample_ids[mask]]
+        token_weight[mask] = torch.where(valid_counts > 0, 1.0 / valid_counts, 0.0)
+        return token_weight.unsqueeze(0)
+
     def compute_loss(micro_batch: dict) -> tuple[torch.Tensor, torch.Tensor]:
         """Forward pass returning (loss_sum, count).
         token normalization: (sum of per-token losses, token count)
@@ -217,12 +249,21 @@ def train(config: SFTConfig):
 
         token_count = loss_mask.sum(dtype=torch.int64)
 
+        # Compute per-token sample weights for fused CE with sample normalization.
+        # The fused kernel applies these weights to both loss and gradients internally.
+        token_weight = None
+        if config.loss_impl == "liger_fused" and config.loss_normalization == "sample":
+            token_weight = _compute_token_weight(loss_mask, sample_ids, num_samples, cp_enabled, cp_group)
+
         with maybe_activation_offloading(config.model.ac_offloading):
             if config.loss_impl == "liger_fused":
                 masked_target_ids = target_ids.clone()
                 masked_target_ids[~loss_mask] = FusedCrossEntropyOutputLinear.IGNORE_INDEX
-                out = forward(model, input_ids, position_ids, labels=masked_target_ids)
-                loss_sum = out["loss"] * token_count
+                out = forward(model, input_ids, position_ids, labels=masked_target_ids, token_weight=token_weight)
+                if config.loss_normalization == "token":
+                    loss_sum = out["loss"] * token_count
+                else:
+                    loss_sum = out["loss"]
             else:
                 out = forward(model, input_ids, position_ids)
                 logits = out["logits"]
@@ -235,6 +276,28 @@ def train(config: SFTConfig):
 
         if config.loss_normalization == "token":
             return loss_sum, token_count
+
+        # For liger_fused + sample, the fused kernel already applied per-sample weighting.
+        # loss_sum = Σ (token_weight * per_token_loss) = Σ_c (1/|O_c|) * Σ_{t∈O_c} ℓ_t
+        # Just need to return the sample count.
+        if config.loss_impl == "liger_fused":
+            if config.data.pack_function == "cat":
+                per_sample_token_count = loss_mask.new_zeros(num_samples, dtype=torch.float)
+                per_sample_token_count.scatter_add_(
+                    0, sample_ids[loss_mask[0]], torch.ones(loss_mask.sum(), device=loss_mask.device)
+                )
+                if cp_enabled:
+                    global_count = per_sample_token_count.detach().clone()
+                    dist.all_reduce(global_count, op=dist.ReduceOp.SUM, group=cp_group)
+                else:
+                    global_count = per_sample_token_count
+                valid = global_count > 0
+            elif config.data.pack_function == "stack":
+                valid = loss_mask.sum(dim=1) > 0
+            sample_count = (
+                valid.sum(dtype=torch.int64) if cp_rank == 0 else torch.tensor(0, dtype=torch.int64, device="cuda")
+            )
+            return loss_sum, sample_count
 
         # Per-sample mean loss, then sum across samples (Nemotron Stage 2)
         if config.data.pack_function == "stack":
@@ -258,9 +321,6 @@ def train(config: SFTConfig):
             per_sample_token_count.scatter_add_(0, masked_ids, torch.ones_like(masked_losses))
 
             if cp_enabled:
-                # All-reduce token counts across CP so each rank knows global per-sample counts.
-                # Only the counts are synchronized — per_sample_loss stays local so gradients
-                # are correct per-rank when backward is called.
                 global_token_count = per_sample_token_count.detach().clone()
                 dist.all_reduce(global_token_count, op=dist.ReduceOp.SUM, group=cp_group)
             else:
@@ -268,8 +328,6 @@ def train(config: SFTConfig):
 
             valid = global_token_count > 0
             per_sample_mean = torch.where(valid, per_sample_loss / global_token_count, per_sample_loss.new_zeros(()))
-            # With CP, all ranks in the same CP group process the same sequence, so only
-            # cp_rank 0 reports the sample count to avoid double-counting after dp+cp all-reduce.
             sample_count = (
                 valid.sum(dtype=torch.int64) if cp_rank == 0 else torch.tensor(0, dtype=torch.int64, device="cuda")
             )

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -284,7 +284,7 @@ def train(config: SFTConfig):
             if config.data.pack_function == "cat":
                 per_sample_token_count = loss_mask.new_zeros(num_samples, dtype=torch.float)
                 per_sample_token_count.scatter_add_(
-                    0, sample_ids[loss_mask[0]], torch.ones(loss_mask.sum(), device=loss_mask.device)
+                    0, sample_ids[loss_mask[0]], torch.ones(loss_mask[0].sum(), device=loss_mask.device)
                 )
                 if cp_enabled:
                     global_count = per_sample_token_count.detach().clone()

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -188,11 +188,23 @@ def train(config: SFTConfig):
             raise ValueError(f"Invalid loss implementation: {config.loss_impl}")
 
     def compute_loss(micro_batch: dict) -> tuple[torch.Tensor, torch.Tensor]:
-        """Forward pass returning (loss_sum, token_count) over unmasked tokens."""
+        """Forward pass returning (loss_sum, count).
+        token normalization: (sum of per-token losses, token count)
+        sample normalization: (sum of per-sample mean losses, sample count)
+        """
         input_ids = micro_batch["input_ids"].to("cuda")
         position_ids = micro_batch["position_ids"].to("cuda")
         target_ids = micro_batch["target_ids"].to("cuda")
         loss_mask = micro_batch["loss_mask"].to("cuda")
+
+        # Detect sample boundaries from position_ids resets (for cat packing + sample normalization)
+        sample_ids = None
+        if config.loss_normalization == "sample" and config.data.pack_function == "cat":
+            pos = position_ids[0]
+            is_boundary = torch.zeros_like(pos, dtype=torch.bool)
+            is_boundary[0] = True
+            is_boundary[1:] = pos[1:] <= pos[:-1]
+            sample_ids = is_boundary.cumsum(0) - 1
 
         if cp_enabled:
             input_ids, position_ids = setup_cp_params(input_ids, position_ids, cp_rank, cp_size, cp_group)
@@ -216,7 +228,33 @@ def train(config: SFTConfig):
                 del logits
 
         del out
-        return loss_sum, token_count
+
+        if config.loss_normalization == "token":
+            return loss_sum, token_count
+
+        # Per-sample mean loss, then sum across samples (Nemotron Stage 2)
+        if config.data.pack_function == "stack":
+            per_sample_token_count = loss_mask.sum(dim=1).float()
+            valid = per_sample_token_count > 0
+            per_sample_loss = (token_loss * loss_mask).sum(dim=1)
+            per_sample_mean = torch.where(
+                valid, per_sample_loss / per_sample_token_count, per_sample_loss.new_zeros(())
+            )
+            return per_sample_mean.sum(), valid.sum(dtype=torch.int64)
+
+        # cat packing: group by sample using position_ids-derived boundaries
+        tl = token_loss[0]
+        mask = loss_mask[0]
+        num_samples = sample_ids[-1].item() + 1
+        masked_ids = sample_ids[mask]
+        masked_losses = tl[mask]
+        per_sample_loss = tl.new_zeros(num_samples)
+        per_sample_loss.scatter_add_(0, masked_ids, masked_losses)
+        per_sample_token_count = tl.new_zeros(num_samples)
+        per_sample_token_count.scatter_add_(0, masked_ids, torch.ones_like(masked_losses))
+        valid = per_sample_token_count > 0
+        per_sample_mean = torch.where(valid, per_sample_loss / per_sample_token_count, per_sample_loss.new_zeros(()))
+        return per_sample_mean.sum(), valid.sum(dtype=torch.int64)
 
     maybe_record_function = nullcontext
 

--- a/tests/unit/train/sft/test_loss_normalization.py
+++ b/tests/unit/train/sft/test_loss_normalization.py
@@ -1,0 +1,197 @@
+import pytest
+import torch
+
+from prime_rl.configs.sft import SFTConfig
+
+
+def test_sample_normalization_rejects_liger_fused():
+    with pytest.raises(ValueError, match="liger_fused"):
+        SFTConfig(loss_impl="liger_fused", loss_normalization="sample")
+
+
+def test_sample_normalization_rejects_cp():
+    with pytest.raises(ValueError, match="context parallelism"):
+        SFTConfig(loss_normalization="sample", model={"cp": 2, "name": "dummy"})
+
+
+def test_token_normalization_is_default():
+    config = SFTConfig()
+    assert config.loss_normalization == "token"
+
+
+def _sample_ids_from_position_ids(position_ids: torch.Tensor) -> torch.Tensor:
+    """Reproduce the boundary detection logic from compute_loss."""
+    pos = position_ids[0]
+    is_boundary = torch.zeros_like(pos, dtype=torch.bool)
+    is_boundary[0] = True
+    is_boundary[1:] = pos[1:] <= pos[:-1]
+    return is_boundary.cumsum(0) - 1
+
+
+def test_sample_boundary_detection_basic():
+    # Two samples: lengths 5 and 3
+    position_ids = torch.tensor([[0, 1, 2, 3, 4, 0, 1, 2]])
+    sample_ids = _sample_ids_from_position_ids(position_ids)
+    assert sample_ids.tolist() == [0, 0, 0, 0, 0, 1, 1, 1]
+
+
+def test_sample_boundary_detection_single_token_samples():
+    # Three 1-token samples followed by a 2-token sample
+    position_ids = torch.tensor([[0, 0, 0, 0, 1]])
+    sample_ids = _sample_ids_from_position_ids(position_ids)
+    assert sample_ids.tolist() == [0, 1, 2, 3, 3]
+
+
+def test_sample_boundary_detection_single_sample():
+    position_ids = torch.tensor([[0, 1, 2, 3, 4]])
+    sample_ids = _sample_ids_from_position_ids(position_ids)
+    assert sample_ids.tolist() == [0, 0, 0, 0, 0]
+
+
+def _compute_sample_level_loss_cat(token_loss, loss_mask, sample_ids):
+    """Reproduce cat-packing sample-level loss from compute_loss."""
+    tl = token_loss[0]
+    mask = loss_mask[0]
+    num_samples = sample_ids[-1].item() + 1
+    masked_ids = sample_ids[mask]
+    masked_losses = tl[mask]
+    per_sample_loss = tl.new_zeros(num_samples)
+    per_sample_loss.scatter_add_(0, masked_ids, masked_losses)
+    per_sample_token_count = tl.new_zeros(num_samples)
+    per_sample_token_count.scatter_add_(0, masked_ids, torch.ones_like(masked_losses))
+    valid = per_sample_token_count > 0
+    per_sample_mean = torch.where(valid, per_sample_loss / per_sample_token_count, per_sample_loss.new_zeros(()))
+    return per_sample_mean.sum(), valid.sum(dtype=torch.int64)
+
+
+def _compute_sample_level_loss_stack(token_loss, loss_mask):
+    """Reproduce stack-packing sample-level loss from compute_loss."""
+    per_sample_token_count = loss_mask.sum(dim=1).float()
+    valid = per_sample_token_count > 0
+    per_sample_loss = (token_loss * loss_mask).sum(dim=1)
+    per_sample_mean = torch.where(valid, per_sample_loss / per_sample_token_count, per_sample_loss.new_zeros(()))
+    return per_sample_mean.sum(), valid.sum(dtype=torch.int64)
+
+
+def test_sample_level_loss_cat_equal_lengths():
+    """Two samples of equal length should give same result as token-level."""
+    # Sample 0: tokens [1, 2, 3], Sample 1: tokens [4, 5, 6]
+    token_loss = torch.tensor([[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]])
+    loss_mask = torch.tensor([[True, True, True, True, True, True]])
+    sample_ids = torch.tensor([0, 0, 0, 1, 1, 1])
+
+    loss_sum, count = _compute_sample_level_loss_cat(token_loss, loss_mask, sample_ids)
+    # Per-sample means: (1+2+3)/3=2.0, (4+5+6)/3=5.0
+    # Sum of means: 7.0
+    assert loss_sum.item() == pytest.approx(7.0)
+    assert count.item() == 2
+
+
+def test_sample_level_loss_cat_unequal_lengths():
+    """Short sample should NOT be dominated by long sample."""
+    # Sample 0: 1 token with loss 10.0
+    # Sample 1: 4 tokens with loss 1.0 each
+    token_loss = torch.tensor([[10.0, 1.0, 1.0, 1.0, 1.0]])
+    loss_mask = torch.tensor([[True, True, True, True, True]])
+    sample_ids = torch.tensor([0, 1, 1, 1, 1])
+
+    loss_sum, count = _compute_sample_level_loss_cat(token_loss, loss_mask, sample_ids)
+    # Per-sample means: 10.0/1=10.0, (1+1+1+1)/4=1.0
+    # Sum of means: 11.0
+    assert loss_sum.item() == pytest.approx(11.0)
+    assert count.item() == 2
+
+    # Compare with token-level: (10+1+1+1+1)/5 = 2.8
+    # Sample-level: (10.0 + 1.0)/2 = 5.5
+    # The short sample contributes much more in sample-level normalization
+    token_mean = token_loss.sum().item() / loss_mask.sum().item()
+    sample_mean = loss_sum.item() / count.item()
+    assert sample_mean > token_mean
+
+
+def test_sample_level_loss_cat_with_masked_tokens():
+    """Masked tokens should not contribute to per-sample means."""
+    # Sample 0: 3 tokens, only last 2 are trainable (loss_mask=True)
+    # Sample 1: 2 tokens, both trainable
+    token_loss = torch.tensor([[99.0, 2.0, 4.0, 3.0, 5.0]])
+    loss_mask = torch.tensor([[False, True, True, True, True]])
+    sample_ids = torch.tensor([0, 0, 0, 1, 1])
+
+    loss_sum, count = _compute_sample_level_loss_cat(token_loss, loss_mask, sample_ids)
+    # Sample 0 trainable: [2.0, 4.0] → mean = 3.0
+    # Sample 1 trainable: [3.0, 5.0] → mean = 4.0
+    # Sum = 7.0
+    assert loss_sum.item() == pytest.approx(7.0)
+    assert count.item() == 2
+
+
+def test_sample_level_loss_cat_fully_masked_sample():
+    """A sample with all tokens masked should be excluded."""
+    token_loss = torch.tensor([[1.0, 2.0, 3.0, 4.0, 5.0]])
+    loss_mask = torch.tensor([[False, False, True, True, True]])
+    sample_ids = torch.tensor([0, 0, 1, 1, 1])
+
+    loss_sum, count = _compute_sample_level_loss_cat(token_loss, loss_mask, sample_ids)
+    # Sample 0: all masked → excluded
+    # Sample 1: [3.0, 4.0, 5.0] → mean = 4.0
+    assert loss_sum.item() == pytest.approx(4.0)
+    assert count.item() == 1
+
+
+def test_sample_level_loss_stack_basic():
+    """Stack mode: each row is a sample."""
+    token_loss = torch.tensor(
+        [
+            [10.0, 0.0, 0.0],  # Sample 0: 1 trainable token
+            [1.0, 1.0, 1.0],  # Sample 1: 3 trainable tokens
+        ]
+    )
+    loss_mask = torch.tensor(
+        [
+            [True, False, False],
+            [True, True, True],
+        ]
+    )
+
+    loss_sum, count = _compute_sample_level_loss_stack(token_loss, loss_mask)
+    # Per-sample means: 10.0/1=10.0, (1+1+1)/3=1.0
+    # Sum = 11.0
+    assert loss_sum.item() == pytest.approx(11.0)
+    assert count.item() == 2
+
+
+def test_sample_level_loss_stack_with_padding():
+    """Padded rows (all masked) should be excluded."""
+    token_loss = torch.tensor(
+        [
+            [2.0, 4.0, 6.0],
+            [0.0, 0.0, 0.0],  # Padding row
+        ]
+    )
+    loss_mask = torch.tensor(
+        [
+            [True, True, True],
+            [False, False, False],
+        ]
+    )
+
+    loss_sum, count = _compute_sample_level_loss_stack(token_loss, loss_mask)
+    assert loss_sum.item() == pytest.approx(4.0)  # mean of [2, 4, 6]
+    assert count.item() == 1
+
+
+def test_sample_level_loss_cat_gradients():
+    """Verify gradients flow correctly through scatter_add."""
+    token_loss = torch.tensor([[1.0, 2.0, 3.0, 6.0]], requires_grad=True)
+    loss_mask = torch.tensor([[True, True, True, True]])
+    sample_ids = torch.tensor([0, 0, 0, 1])
+
+    loss_sum, count = _compute_sample_level_loss_cat(token_loss, loss_mask, sample_ids)
+    # Sample 0: mean = (1+2+3)/3 = 2.0, Sample 1: mean = 6.0/1 = 6.0
+    assert loss_sum.item() == pytest.approx(8.0)
+
+    loss_sum.backward()
+    # d(loss)/d(token_i) for sample 0: 1/3 (each token contributes 1/count to mean)
+    # d(loss)/d(token_i) for sample 1: 1/1
+    expected_grad = torch.tensor([[1 / 3, 1 / 3, 1 / 3, 1.0]])
+    assert torch.allclose(token_loss.grad, expected_grad)

--- a/tests/unit/train/sft/test_loss_normalization.py
+++ b/tests/unit/train/sft/test_loss_normalization.py
@@ -9,9 +9,10 @@ def test_sample_normalization_rejects_liger_fused():
         SFTConfig(loss_impl="liger_fused", loss_normalization="sample")
 
 
-def test_sample_normalization_rejects_cp():
-    with pytest.raises(ValueError, match="context parallelism"):
-        SFTConfig(loss_normalization="sample", model={"cp": 2, "name": "dummy"})
+def test_sample_normalization_allows_cp():
+    config = SFTConfig(loss_normalization="sample", model={"cp": 2, "name": "dummy"})
+    assert config.loss_normalization == "sample"
+    assert config.model.cp == 2
 
 
 def test_token_normalization_is_default():

--- a/tests/unit/train/sft/test_loss_normalization.py
+++ b/tests/unit/train/sft/test_loss_normalization.py
@@ -4,9 +4,10 @@ import torch
 from prime_rl.configs.sft import SFTConfig
 
 
-def test_sample_normalization_rejects_liger_fused():
-    with pytest.raises(ValueError, match="liger_fused"):
-        SFTConfig(loss_impl="liger_fused", loss_normalization="sample")
+def test_sample_normalization_allows_liger_fused():
+    config = SFTConfig(loss_impl="liger_fused", loss_normalization="sample")
+    assert config.loss_impl == "liger_fused"
+    assert config.loss_normalization == "sample"
 
 
 def test_sample_normalization_allows_cp():


### PR DESCRIPTION
## Summary
- Adds `loss_normalization` config option (`"token"` | `"sample"`, default `"token"`) implementing per-conversation normalized loss (Nemotron 3 Super Stage 2, eq. 2)
- `"sample"` mode computes per-sample mean loss then averages across samples, preventing long outputs from dominating the gradient — useful for restoring long-input-short-output performance after token-level SFT
- Works with all packing modes (`cat`, `stack`), all loss implementations (`torch`, `liger`, `liger_fused`), and context parallelism

## How it works
- **`cat` packing**: infers sample boundaries from `position_ids` resets within packed sequences, uses `scatter_add` to group per-token losses by sample
- **`stack` packing**: each batch row is a sample, straightforward per-row normalization
- **`liger_fused`**: vendors Liger fused CE forward (~100 lines of Python, Triton kernel untouched) with a `token_weight` parameter that scales both per-token losses and pre-computed gradients during the chunked forward pass — preserves the memory savings of fused CE (no logit materialization)
- **Context parallelism**: each CP rank computes local per-sample loss sums, all-reduces per-sample token counts across the CP group so every rank divides by the correct global count

## Usage
```toml
loss_normalization = "sample"
```

## Memory comparison (Qwen3-0.6B, seq_len=4096, batch_size=4)
| | `torch` + sample | `liger_fused` + sample |
|--|--|--|
| Peak Memory | 23.3 GiB | 18.1 GiB |

5.2 GiB saved — fused kernel memory advantage fully preserved with sample normalization.

## Numerical verification
- `liger_fused` + `token` on branch is bit-identical at step 0 vs main, with normal float drift at later steps
- `torch` + `sample` vs `liger_fused` + `sample` produce matching loss trajectories (tiny float drift from different accumulation order)

## Test plan
- [x] 13 unit tests: config validation, boundary detection edge cases, both packing modes, masked tokens, gradient correctness
- [x] All 15 existing SFT dataset tests pass
- [x] 2-GPU: `torch` + `sample` + cat packing + variable-length data
- [x] 2-GPU: `torch` + `sample` + stack packing + variable-length data
- [x] 2-GPU: `liger_fused` + `sample` + real SFT data
- [x] 2-GPU: `liger_fused` + `token` regression check (bit-identical to main at step 0)
- [x] 2-GPU: CP=2 + `sample` + real SFT data
- [x] 2-GPU: CP=2 + `sample` + fixed-length fake data
- [x] Memory comparison: `torch` vs `liger_fused` with sample norm (5.2 GiB savings confirmed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SFT loss/gradient scaling semantics and adds a custom wrapper around Liger fused cross-entropy, which can affect training dynamics and correctness (especially with packing + context parallelism). Scope is contained to SFT training and LM-head loss computation paths.
> 
> **Overview**
> Adds `loss_normalization` (`token` default, `sample`) to `SFTConfig` and updates SFT training to optionally normalize loss per sample (mean per conversation) instead of globally per token.
> 
> Implements sample-boundary detection for `cat` packing via `position_ids` resets and computes per-sample means for both `cat` and `stack`, including CP-aware aggregation of per-sample token counts.
> 
> Extends the model/lm-head forward path with an optional `token_weight` and introduces a vendored Python wrapper (`fused_ce_sample_norm.py`) to apply per-token weights to Liger’s fused CE loss/gradients so sample-normalization can be used without materializing logits. Adds unit tests covering boundary detection, packing modes, masking, and gradient behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85bc65fd43871530b9d1ae3171d31c7746c60155. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->