### PR TITLE
fix: use token-level loss normalization for all loss types

### DIFF
--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -16,7 +16,7 @@ from prime_rl.trainer.ckpt import setup_ckpt_managers
 from prime_rl.trainer.multi_ckpt import setup_multi_checkpoint_manager
 from prime_rl.trainer.optim import setup_optimizer, setup_multi_optimizer
 from prime_rl.trainer.scheduler import setup_scheduler, setup_multi_scheduler
-from prime_rl.configs.trainer import DefaultLossConfig, TrainerConfig
+from prime_rl.configs.trainer import TrainerConfig
 from prime_rl.trainer.rl.data import DataLoader, FakeDataLoader
 from prime_rl.utils.cp import (
     setup_cp_params,
@@ -302,10 +302,7 @@ def train(config: TrainerConfig):
         seq_len = micro_batches[0]["input_ids"].shape[1]
 
         # Normalize by the local number of unmasked tokens in the batch (per-batch length normalization)
-        if isinstance(config.loss, DefaultLossConfig):
-            loss_scale = sum(micro_batch["loss_mask"].sum().item() for micro_batch in micro_batches)
-        else:
-            loss_scale = batch_size
+        loss_scale = sum(micro_batch["loss_mask"].sum().item() for micro_batch in micro_batches)
         loss_scale = max(loss_scale, 1)
 
         logger.debug(f"Starting forward and backward pass ({batch_size=})")


### PR DESCRIPTION
Previously, custom losses were normalized by batch_size (number of sequences) while our default loss was normalized by the number of unmasked tokens. I think all loss functions (including custom) should use the DAPO-normalizer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the loss scaling used for backprop, which will alter optimization dynamics and reported loss across runs; requires validation that training stability and metrics remain consistent for custom losses.
> 
> **Overview**
> Applies *token-level (unmasked token count) loss normalization* for all RL loss types, removing the previous branch where non-default/custom losses were normalized by `batch_size`.
> 
> Also drops the now-unused `DefaultLossConfig` import from `trainer/rl/train.py`, making `loss_scale` consistently derived from `loss_mask` across micro-batches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97e760368cf5abe6367afb643d6240f8500f4e24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->