### PR TITLE
bump verifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ override-dependencies = [
 
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "45fae8d" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "de2ed50" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eeb" }
 transformers = { git = "https://github.com/huggingface/transformers.git", rev = "5c1c72b" }

--- a/uv.lock
+++ b/uv.lock
@@ -2593,7 +2593,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", git = "https://github.com/huggingface/transformers.git?rev=5c1c72b" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=45fae8d" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=de2ed50" },
     { name = "vllm", specifier = ">=0.17.0" },
     { name = "wandb", specifier = ">=0.24.2" },
     { name = "wiki-search", marker = "extra == 'envs'", index = "https://hub.primeintellect.ai/primeintellect/simple/" },
@@ -3840,8 +3840,8 @@ wheels = [
 
 [[package]]
 name = "verifiers"
-version = "0.1.11.dev1"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=45fae8d#45fae8dd7b44043672cc27ee75c0a2741f2d1b97" }
+version = "0.1.11"
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=de2ed50#de2ed50f015ed1af0990b218de1df0853d9b3973" }
 dependencies = [
     { name = "anthropic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "datasets", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },


### PR DESCRIPTION
bumps to verifiers `de2ed50`

https://github.com/PrimeIntellect-ai/verifiers/commit/de2ed50f015ed1af0990b218de1df0853d9b3973

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk local change (dependency pin/lockfile only), but behavior may change at runtime depending on what the upstream `verifiers` update includes.
> 
> **Overview**
> Bumps the `verifiers` dependency to git rev `de2ed50` and updates `uv.lock` accordingly (including moving from `0.1.11.dev1` to `0.1.11`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6abe92b009fedb2f6dd98e56ae146568c727d4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->