### PR TITLE
bump mini-swe RLM timeouts to 6 hours

### DIFF
--- a/prod.toml
+++ b/prod.toml
@@ -5,6 +5,8 @@ output_dir = "/data/outputs/glm5-rlm"
 
 [log]
 level = "debug"
+vf_level = "debug"
+env_worker_logs = true
 
 [wandb]
 project = "RLM-GLM5"
@@ -93,7 +95,7 @@ args = { repl_language="bash", expose_message_history=true, root_max_completion_
 [[orchestrator.env]]
 id = "mini-swe-agent-plus-rlm"
 name = "mini-swe-agent-plus-rlm-bash"
-args = { repl_language="bash", expose_message_history=true, root_max_completion_tokens=4096, sub_max_completion_tokens=10240, code_execution_timeout=600, sandbox_command_timeout=90, max_iterations = 20, sandbox_labels = ["rlm-prod-cluster"], max_sub_llm_parallelism = 5, sub_prompt_verbosity = "light", root_prompt_verbosity = "light" }
+args = { repl_language="bash", expose_message_history=true, root_max_completion_tokens=4096, sub_max_completion_tokens=10240, code_execution_timeout=600, sandbox_command_timeout=90, max_iterations = 20, sandbox_labels = ["rlm-prod-cluster"], max_sub_llm_parallelism = 5, sub_prompt_verbosity = "light", root_prompt_verbosity = "light", total_timeout_minutes = 360, rollout_timeout_seconds = 21600.0 }
 
 [[orchestrator.env]]
 id = "deepdive-rlm"
@@ -108,7 +110,7 @@ args = { repl_language="python", expose_message_history=true, root_max_completio
 [[orchestrator.env]]
 id = "mini-swe-agent-plus-rlm"
 name = "mini-swe-agent-plus-rlm-python"
-args = { repl_language="python", expose_message_history=true, root_max_completion_tokens=4096, sub_max_completion_tokens=10240, code_execution_timeout=600, sandbox_command_timeout=90, max_iterations = 20, sandbox_labels = ["rlm-prod-cluster"], max_sub_llm_parallelism = 5, sub_prompt_verbosity = "light", root_prompt_verbosity = "light" }
+args = { repl_language="python", expose_message_history=true, root_max_completion_tokens=4096, sub_max_completion_tokens=10240, code_execution_timeout=600, sandbox_command_timeout=90, max_iterations = 20, sandbox_labels = ["rlm-prod-cluster"], max_sub_llm_parallelism = 5, sub_prompt_verbosity = "light", root_prompt_verbosity = "light", total_timeout_minutes = 360, rollout_timeout_seconds = 21600.0 }
 
 [orchestrator.buffer]
 env_ratios = [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk, config-only changes; main impact is longer-running `mini-swe-agent-plus-rlm` rollouts and increased logging volume in production.
> 
> **Overview**
> Updates `prod.toml` to **increase runtime limits** for the `mini-swe-agent-plus-rlm` orchestrator envs (bash and python) by adding `total_timeout_minutes = 360` and `rollout_timeout_seconds = 21600` (6 hours).
> 
> Also enables additional logging by setting `log.vf_level = "debug"` and turning on `log.env_worker_logs = true`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 144cc8599217da458d8e4a84623fb95dfe63d79a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->