### PR TITLE
GR3 length penalty: Advantage config validator bug

### DIFF
--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -378,8 +378,6 @@ class AdvantageConfig(BaseConfig):
         if self.gr3_alpha:
             if self.length_weighted_mean:
                 raise ValueError("Group Relative Reward scaling cannot be used in conjunction with length weighted mean")
-            if not self.online_difficulty_filtering:
-                raise ValueError("Group Relative Reward scaling requires online difficulty filtering")
         return self
 
 
@@ -577,6 +575,13 @@ class OrchestratorConfig(BaseSettings):
     def validate_batch_size(self):
         if self.batch_size % self.rollouts_per_example != 0:
             raise ValueError("Batch size must be divisible by the number of samples per problem")
+        return self
+
+    @model_validator(mode="after")
+    def validate_gr3_requires_online_difficulty_filtering(self):
+        if self.advantage and self.advantage.gr3_alpha:
+            if not self.buffer.online_difficulty_filtering:
+                raise ValueError("Group Relative Reward scaling requires online difficulty filtering")
         return self
 
     @model_validator(mode="after")


### PR DESCRIPTION
<!-- Provide a brief description of the changes in this PR -->

Moves `gr3_alpha` validation from `AdvantageConfig` to `OrchestratorConfig` to correctly check `online_difficulty_filtering` from `BufferConfig`, resolving an `AttributeError` when using the GR3 feature.

---

<!-- Link the GitHub and Linear issue (if external, delete the Linear issue link) -->

**GitHub Issue**: [Issue ID]
**Linear Issue**: Resolves [Issue ID]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-validation change that only affects startup/config parsing, but could cause previously-accepted GR3 configs to be rejected if `buffer.online_difficulty_filtering` is not enabled.
> 
> **Overview**
> Fixes GR3 configuration validation by moving the *"GR3 requires online difficulty filtering"* check out of `AdvantageConfig` and into `OrchestratorConfig`, where `buffer.online_difficulty_filtering` is actually available.
> 
> This prevents mis-validation/`AttributeError` when `gr3_alpha` is enabled and ensures GR3 cannot run unless online difficulty filtering is turned on.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97ee0928f9bfcb21e1cf1918743902b21ee516e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->