### PR TITLE
fix: compute GR3 baseline from length-corrected rewards

### DIFF
--- a/src/prime_rl/orchestrator/advantage.py
+++ b/src/prime_rl/orchestrator/advantage.py
@@ -21,12 +21,12 @@ def compute_advantages(
     if not advantage_config:
         return rewards
     rewards = torch.tensor(rewards).view(-1, samples_per_problem)
-    lengths = torch.tensor(completion_lengths).view(-1, samples_per_problem)
+    lengths = torch.tensor(completion_lengths, dtype=torch.float32).view(-1, samples_per_problem)
     if advantage_config.gr3_alpha:
         lengths_normalized = lengths / lengths.mean(dim=1, keepdim=True)
         length_shaping = (1 + advantage_config.gr3_alpha * lengths_normalized)**-1
         rewards_corrected = rewards * length_shaping
-        baseline = rewards.mean(dim=1, keepdim=True)
+        baseline = rewards_corrected.mean(dim=1, keepdim=True)
         return (rewards_corrected - baseline).flatten().tolist()
     elif advantage_config.length_weighted_mean:
         baseline = (rewards * lengths).sum(dim=1, keepdim=True) / lengths.sum(dim=1, keepdim=True)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The GR3 advantage computation used `rewards.mean()` (uncorrected raw rewards) as the baseline instead of `rewards_corrected.mean()` (length-rescaled rewards). This broke the zero-mean advantage property for groups with high success rates.

**Example**: In a group with 3 correct and 1 incorrect completion (`mean(r) = 0.75`), correct-but-longer completions received negative advantages because `length_shaping < mean(r)`. This caused the loss to push the model *away* from those correct completions.

**Before** (buggy baseline from raw rewards):
```
advantages: [0.1003, -0.0104, -0.0955, -0.75]
              ^short   ^medium  ^long    ^wrong
```
Correct completions at 200 and 300 tokens get **negative** advantages.

**After** (baseline from corrected rewards):
```
advantages: [0.2892, 0.1785, 0.0933, -0.5611]
              ^short   ^medium  ^long    ^wrong
```
All correct completions have **positive** advantages while still preferring shorter ones.

Also fixes a dtype bug: `completion_lengths` are integers, but `torch.mean()` requires floating point input. Added explicit `dtype=torch.float32` cast.

---

**GitHub Issue**: N/A
**Linear Issue**: N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dfc3041e-c902-40e0-a9f4-27e25910e072"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dfc3041e-c902-40e0-a9f4-27e25910e072"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

