### PR TITLE
fix: remove misleading orchestrator throughput metric

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -641,12 +641,11 @@ async def orchestrate(config: OrchestratorConfig):
             else None
         )
 
-        # Update progress metrics and throughput
+        # Update progress metrics
         num_tokens = int(results_df.seq_len.sum())
         progress.total_tokens += num_tokens
         progress.total_samples += num_rollouts
         progress.total_problems += num_unique_examples
-        throughput = num_tokens / generate_completions_time
 
         def compute_solve_rates(df):
             """Compute solve_none, solve_all, effective_batch_size for a set of rollouts."""
@@ -702,8 +701,6 @@ async def orchestrate(config: OrchestratorConfig):
             "scoring_ms/all/mean": by_example.scoring_ms.mean().mean(),
             "scoring_ms/all/max": by_example.scoring_ms.mean().max(),
             "scoring_ms/all/min": by_example.scoring_ms.mean().min(),
-            # Performance metrics
-            "perf/throughput": throughput,
             # Train reward
             "reward/all/mean": by_example.reward.mean().mean(),
             "reward/all/max": by_example.reward.mean().max(),
@@ -794,7 +791,7 @@ async def orchestrate(config: OrchestratorConfig):
             step=progress.step,
         )
 
-        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Reward: {results_df.reward.mean():.4f} |{f' Val. Reward: {val_results_df.reward.mean():.4f} |' if val_results_df is not None else ''} Throughput: {throughput:.1f} tokens/s | Seq. Length: {results_df.groupby('example_id').seq_len.mean().mean():.1f} tokens/sample | Async Level: {scheduler.async_level} | Max. Off-Policy Level: {scheduler.max_off_policy_level}"
+        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Reward: {results_df.reward.mean():.4f} |{f' Val. Reward: {val_results_df.reward.mean():.4f} |' if val_results_df is not None else ''} Seq. Length: {results_df.groupby('example_id').seq_len.mean().mean():.1f} tokens/sample | Async Level: {scheduler.async_level} | Max. Off-Policy Level: {scheduler.max_off_policy_level}"
         logger.success(step_message)
 
         # Increment step

--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -16,7 +16,6 @@ from verifiers.utils.client_utils import setup_openai_client
 from prime_rl.configs.orchestrator import SamplingConfig
 from prime_rl.transport import TrainingSample
 from prime_rl.utils.utils import (
-    format_num,
     format_time,
     get_broadcast_dir,
     get_ckpt_dir,
@@ -92,9 +91,9 @@ def parse_is_truncated_completions(responses: list[list[ChatCompletion]]) -> lis
 
 def print_benchmark(history: dict[str, list[Any]]) -> None:
     """
-    Print benchmark results as rich table. Shows formatted values for the
-    inference throughput and overall step time. First first N rows show the
-    per-step values, and the last row shows the mean, std, min, and max values.
+    Print benchmark results as rich table. Shows formatted step time values.
+    First N rows show the per-step values, and the last row shows the mean,
+    std, min, and max values.
     """
     history.pop("step")
     assert all(len(v) for v in history.values()), "All metrics must have logged the same number of steps"
@@ -102,7 +101,6 @@ def print_benchmark(history: dict[str, list[Any]]) -> None:
     # Turn metric history into pd.DataFrame
     df = pd.DataFrame(dict(history.items()))
     columns = {
-        "perf/throughput": "Throughput",
         "time/step": "Step Time",
     }
     df = df.rename(columns=columns)
@@ -121,7 +119,6 @@ def print_benchmark(history: dict[str, list[Any]]) -> None:
     # Add formatted rows
     formatted_df = pd.DataFrame(columns=df.columns)
     formatted_df["Step Time"] = df["Step Time"].apply(format_time)
-    formatted_df["Throughput"] = df["Throughput"].apply(format_num, precision=2)
     for step, row in formatted_df.iterrows():
         table.add_row(*([str(step)] + [str(x) for x in row]))
 
@@ -133,7 +130,6 @@ def print_benchmark(history: dict[str, list[Any]]) -> None:
     mean_df = df.describe().loc[["mean", "std", "min", "max"], :]
     formatted_mean_df = pd.DataFrame(columns=mean_df.columns)
     formatted_mean_df["Step Time"] = mean_df["Step Time"].apply(format_time)
-    formatted_mean_df["Throughput"] = mean_df["Throughput"].apply(format_num, precision=2)
     mean_row = ["Overall"] + formatted_mean_df.T.apply(
         lambda row: f"{row['mean']} ± {row['std']} [{row['min']}, {row['max']}]", axis=1
     ).tolist()


### PR DESCRIPTION
## Summary
- Remove `perf/throughput` (tokens/s) from the orchestrator metrics
- With in-flight rollouts, some tokens are generated during the previous training step, so `generate_completions_time` undercounts the actual inference time, inflating the reported throughput
- Per-rollout `generation_ms` metrics remain available for accurate inference speed tracking

## Test plan
- [ ] Verify orchestrator runs without errors after removing the metric

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a derived `perf/throughput` metric and its display without changing rollout generation, training, or timing collection logic.
> 
> **Overview**
> Removes the orchestrator’s `perf/throughput` (tokens/sec) calculation and logging, and stops including it in the per-step status line.
> 
> Updates `print_benchmark` to no longer expect or render a throughput column, leaving benchmark output focused on step-time statistics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90f427b2614f825f93e32908f1314b0472fe9bc5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->