### PR TITLE
Add router_url support for elastic inference pool

### DIFF
--- a/src/prime_rl/configs/shared.py
+++ b/src/prime_rl/configs/shared.py
@@ -196,6 +196,13 @@ class ClientConfig(BaseConfig):
         ),
     ] = None
 
+    router_url: Annotated[
+        str | None,
+        Field(
+            description="URL of a vllm-router for load-aware inference routing. When set with elastic mode, inference requests go through the router while admin operations (weight updates, LoRA loading) still go directly to discovered pods.",
+        ),
+    ] = None
+
     @property
     def is_elastic(self) -> bool:
         """Check if elastic mode is enabled."""

--- a/src/prime_rl/utils/elastic.py
+++ b/src/prime_rl/utils/elastic.py
@@ -168,7 +168,9 @@ class ElasticInferencePool:
         # When a router URL is configured, route inference requests through it
         # instead of directly to discovered pods. Admin operations still use
         # individual pod IPs via admin_clients.
-        if self.router_url:
+        # Only expose the router when backends are actually ready — otherwise
+        # the orchestrator would send requests into a router with no healthy backends.
+        if self.router_url and self.ready_urls:
             urls = [self.router_url]
         else:
             urls = self.ready_urls

--- a/src/prime_rl/utils/elastic.py
+++ b/src/prime_rl/utils/elastic.py
@@ -108,6 +108,7 @@ class ElasticInferencePool:
         port: int = 8000,
         sync_interval: float = 5.0,
         client_type: str = "openai_chat_completions",
+        router_url: str | None = None,
     ):
         self.logger = get_logger()
         self.hostname = hostname
@@ -117,6 +118,7 @@ class ElasticInferencePool:
         self.port = port
         self.sync_interval = sync_interval
         self.client_type = client_type
+        self.router_url = router_url
 
         self._servers: dict[str, ServerState] = {}
         self._admin_clients: dict[str, AsyncClient] = {}
@@ -143,6 +145,7 @@ class ElasticInferencePool:
             port=config.elastic.port,
             sync_interval=config.elastic.sync_interval,
             client_type=client_type,
+            router_url=config.router_url,
         )
         await pool.start()
         return pool
@@ -162,7 +165,13 @@ class ElasticInferencePool:
 
     @property
     def clients(self) -> list[vf.ClientConfig]:
-        urls = self.ready_urls
+        # When a router URL is configured, route inference requests through it
+        # instead of directly to discovered pods. Admin operations still use
+        # individual pod IPs via admin_clients.
+        if self.router_url:
+            urls = [self.router_url]
+        else:
+            urls = self.ready_urls
         if set(urls) != set(self._client_urls):
             self._client_urls = urls
             self._client_index = 0


### PR DESCRIPTION
## Summary
- Adds `router_url` field to `ClientConfig` for routing inference requests through a vllm-router
- When set alongside elastic mode, inference requests go through the router for load-aware balancing while admin ops (weight updates, LoRA loading) still go directly to discovered pods
- Needed for multi-tenant hosted RL where multiple orchestrators share inference pods

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how elastic inference clients are constructed by optionally routing all inference traffic through a single `router_url`, which can affect availability/traffic flow if misconfigured. Admin operations still target individual pods, but the new branching logic could change behavior in multi-server readiness edge cases.
> 
> **Overview**
> Adds an optional `router_url` to `ClientConfig` to support sending *inference* requests through a vLLM router while keeping elastic DNS discovery for *admin* operations.
> 
> Updates `ElasticInferencePool` to accept/propagate `router_url` from config and, when configured and at least one backend is `ready`, exposes the router as the sole client URL instead of directly using discovered pod `/v1` endpoints.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47833682a06e17edb1c554aafb60a51c1d629710. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->