### PR TITLE
fix: wire default_chat_template_kwargs to chat handler and /tokenize

### DIFF
--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -264,6 +264,24 @@ async def custom_init_app_state(
     # Setup the regular app state first (in-place)
     await init_app_state(engine_client, state, args, supported_tasks)
 
+    # Patch the tokenization handler to use default_chat_template_kwargs.
+    # vLLM's OpenAIServingTokenization hardcodes default_template_kwargs=None
+    # in create_tokenize, so the /tokenize endpoint ignores server-level kwargs
+    # like enable_thinking=false. This causes token mismatches in the TITO flow.
+    if hasattr(args, "default_chat_template_kwargs") and args.default_chat_template_kwargs:
+        tokenization = state.openai_serving_tokenization
+        if tokenization is not None:
+            tokenization._default_chat_template_kwargs = args.default_chat_template_kwargs
+            _orig_create_tokenize = tokenization.create_tokenize
+
+            async def _patched_create_tokenize(request, raw_request):
+                from vllm.entrypoints.serve.tokenize.protocol import TokenizeChatRequest
+                if isinstance(request, TokenizeChatRequest) and not request.chat_template_kwargs:
+                    request.chat_template_kwargs = tokenization._default_chat_template_kwargs
+                return await _orig_create_tokenize(request, raw_request)
+
+            tokenization.create_tokenize = _patched_create_tokenize
+
     # NOTE: Initialize the custom OpenAIServingChatWithTokens state here
     # TODO: Here, we repeat some calls done in init_app_state to be able to
     # correctly set up the OpenAIServingChatWithTokens state, which is a bit
@@ -291,6 +309,8 @@ async def custom_init_app_state(
     )
     if hasattr(args, "log_error_stack"):
         chat_kwargs["log_error_stack"] = args.log_error_stack
+    if hasattr(args, "default_chat_template_kwargs") and args.default_chat_template_kwargs:
+        chat_kwargs["default_chat_template_kwargs"] = args.default_chat_template_kwargs
 
     serving_chat = OpenAIServingChatWithTokens(
         engine_client,


### PR DESCRIPTION
## Summary

- Forward `default_chat_template_kwargs` (e.g. `enable_thinking=false`) into the `OpenAIServingChatWithTokens` constructor so the chat completion handler respects server-level template kwargs
- Monkey-patch `OpenAIServingTokenization.create_tokenize` to inject `default_chat_template_kwargs` into `/tokenize` requests that lack them — vLLM hardcodes `default_template_kwargs=None` in `create_tokenize`, so without this the tokenization endpoint ignores server-level kwargs

Without these two changes, `default_chat_template_kwargs` set in the RL config (e.g. `[inference.vllm_extra] default_chat_template_kwargs = { enable_thinking = false }`) never reaches either endpoint. This causes:
1. ~30% empty responses with thinking models (Qwen3.5, DeepSeek-R1) when thinking mode should be disabled
2. Token mismatch between `/v1/chat/completions` and `/tokenize` — the chat handler renders with one template behavior while `/tokenize` renders with another, breaking the TITO flow

## Test plan

- [x] Verified 0 empty responses across 288 rollouts (was ~30%)
- [x] Verified 0/6732 `<|im_end|>` → `<|im_start|>` boundary violations
- [x] Ran 12-step RL training with Qwen3.5-35B-A3B, reward stable at 0.4–0.6
- [x] Decoded rollouts show correct multi-turn structure (up to 28 turns) with thinking mode active

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it monkey-patches vLLM’s tokenization handler at runtime and changes request mutation behavior, which could affect API compatibility and tokenization correctness across models.
> 
> **Overview**
> Ensures server-level `default_chat_template_kwargs` (e.g. `enable_thinking=false`) are consistently applied to both chat completions and the `/tokenize` endpoint.
> 
> `custom_init_app_state` now injects `default_chat_template_kwargs` into `OpenAIServingChatWithTokens` construction and monkey-patches `OpenAIServingTokenization.create_tokenize` to fill missing `chat_template_kwargs` on `TokenizeChatRequest`, preventing chat/tokenization template mismatches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e73c75048c0d3de2b758ac23da36bb71653a631. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->