### PR TITLE
add executor autoscaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Documenting changes which affect configuration usage patterns (added/moved/removed/renamed fields, notable logic changes).
 
+- **`orchestrator.env[].max_workers`**: Added per-environment thread-pool worker count for env servers. When `None` (default), auto-scales using verifiers' `recommended_max_workers()` based on expected concurrency. Set explicitly to override (e.g. `max_workers = 256`). Applies to both train and eval envs. (2026-03-19)
 - **`orchestrator.advantage.length_weighted_mean`**: Removed. The default advantage now always uses the plain per-problem mean baseline unless `orchestrator.advantage.length_shaping_alpha` is set. Existing configs must delete this field. (2026-03-19)
 - **`orchestrator.advantage.length_shaping_alpha`**: Added Group Relative Reward Rescaling coefficient to the default advantage config. When set, applies length-based GR3 shaping during advantage computation and requires `orchestrator.buffer.online_difficulty_filtering = true` (default: `None`) (2026-03-18)
 - **`prime_monitor.log_extras.sample_ratio`**: Added ratio-based rollout sampling (0.0–1.0, default: None). When set, caps the number of rollouts logged per step to `len(rollouts) * sample_ratio`. `None` preserves current behavior (log all rollouts). Interacts with existing `interval` gate which still runs first. (2026-03-12)

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -287,6 +287,13 @@ class EnvConfig(BaseConfig):
             ),
         ),
     ] = {}
+    max_workers: Annotated[
+        int | None,
+        Field(
+            ge=1,
+            description="Maximum number of thread-pool workers for all default and registered executors on the environment server. If None, scales automatically with expected concurrency.",
+        ),
+    ] = None
     max_retries: Annotated[
         int,
         Field(

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -47,6 +47,7 @@ from prime_rl.orchestrator.vf_utils import (
     get_completion_len,
     get_seq_len,
     intercept_vf_logging,
+    resolve_max_workers,
     setup_env_client,
     spawn_env_server,
     task_uses_group_scoring,
@@ -205,7 +206,11 @@ async def orchestrate(config: OrchestratorConfig):
 
     atexit.register(_cleanup_env_processes)
 
+    # TODO: max_inflight_rollouts and batch_size are global while this arg is per-env
+    # in the future, we should make this more consistent but for now we choose a conservative value
+    train_concurrency = config.max_concurrent or config.max_inflight_rollouts or config.batch_size
     for env_id, env, env_name in zip(env_ids, config.env, train_env_names):
+        env.extra_env_kwargs["max_workers"] = resolve_max_workers(env.max_workers, train_concurrency)
         if env.address is None:
             address, process = spawn_env_server(
                 env_id=env_id,
@@ -224,8 +229,11 @@ async def orchestrate(config: OrchestratorConfig):
                     "Ensure that server was started with score_rollouts=False."
                 )
             address = env.address
-        logger.info(f"Connecting train environment {env_name} to server at {address}")
         train_env_addresses.append(address)
+        logger.info(
+            f"Started {env_name} train env server ({address=}, args={env.args}, extra_env_kwargs={env.extra_env_kwargs})"
+        )
+
     train_env_clients = [
         setup_env_client(address=address, name=name) for name, address in zip(train_env_names, train_env_addresses)
     ]
@@ -247,6 +255,10 @@ async def orchestrate(config: OrchestratorConfig):
         eval_env_addresses = []
 
         for env_id, env, eval_env_name in zip(env_ids, config.eval.env, eval_env_names):
+            eval_num_examples = env.num_examples or config.eval.num_examples
+            eval_rollouts_per_example = env.rollouts_per_example or config.eval.rollouts_per_example
+            eval_concurrency = eval_num_examples * eval_rollouts_per_example if eval_num_examples > 0 else None
+            env.extra_env_kwargs["max_workers"] = resolve_max_workers(env.max_workers, eval_concurrency)
             if env.address is None:
                 address, process = spawn_env_server(
                     env_id=env_id,
@@ -260,7 +272,9 @@ async def orchestrate(config: OrchestratorConfig):
                 env_processes.append(process)
             else:
                 address = env.address
-            logger.info(f"Connecting eval environment {eval_env_name} to server at {address}")
+            logger.info(
+                f"Started {eval_env_name} eval env server ({address=}, args={env.args}, extra_env_kwargs={env.extra_env_kwargs})"
+            )
             eval_env_addresses.append(address)
 
         eval_env_clients = [

--- a/src/prime_rl/orchestrator/vf_utils.py
+++ b/src/prime_rl/orchestrator/vf_utils.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import verifiers as vf
 from verifiers.envs.environment import EnvClient
+from verifiers.utils.thread_utils import recommended_max_workers
 from verifiers.utils.worker_utils import get_free_port_pair
 from verifiers.workers import ZMQEnvClient, ZMQEnvServer
 
@@ -15,6 +16,20 @@ from prime_rl.utils.logger import InterceptHandler, ProgressTracker
 DEFAULT_RETRIES = 0
 REQUIRED_STATE_COLUMNS = ["trajectory", "sampling_args"]
 DEFAULT_STATE_COLUMNS = []
+
+
+def resolve_max_workers(configured_max_workers: int | None, concurrency: int | None) -> int:
+    """Resolve max_workers for an environment server.
+
+    If explicitly configured, use that value. Otherwise, use the verifiers
+    recommended_max_workers helper based on the expected concurrency.
+    """
+    if configured_max_workers is not None:
+        return configured_max_workers
+
+    concurrency = concurrency or 64
+    max_workers = recommended_max_workers(concurrency)
+    return max_workers
 
 
 def spawn_env_server(


### PR DESCRIPTION
## Summary
- Adds `max_workers` field to `EnvConfig` (applies to both train and eval envs), configurable per-environment
- When `None` (default), auto-computes using verifiers' `recommended_max_workers(concurrency)` based on expected concurrency
- For train envs, concurrency is derived from `max_concurrent` / `max_inflight_rollouts` / `batch_size`
- For eval envs, concurrency is `num_examples * rollouts_per_example`
- Passes `max_workers` via `extra_env_kwargs` so the env server can scale its thread-pool executors

## Config example
```toml
# Auto (default)
[[env]]
id = "my-env"

# Explicit override
[[env]]
id = "my-env"
max_workers = 256
```

## Test plan
- [ ] Run orchestrator with default `max_workers` (None) and verify auto-scaling logs
- [ ] Run with explicit `max_workers` per env and verify it's passed through

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches orchestrator environment server startup and concurrency sizing; incorrect defaults or concurrency estimation could cause performance regressions or oversubscription under load.
> 
> **Overview**
> Adds per-environment `orchestrator.env[].max_workers` config to control the env server thread-pool size, defaulting to an auto-resolved value via verifiers’ `recommended_max_workers()`.
> 
> Orchestrator now computes an expected concurrency for train (from `max_concurrent`/`max_inflight_rollouts`/`batch_size`) and eval (from `num_examples * rollouts_per_example`) and passes the resolved worker count through `extra_env_kwargs["max_workers"]` when spawning/connecting env servers, with updated startup logging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49bcc69a6c4b720e4e220c2786c0f8d99f10043b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->