### PR TITLE
fix: use mean().mean() for console metrics to match wandb

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -791,7 +791,12 @@ async def orchestrate(config: OrchestratorConfig):
             step=progress.step,
         )
 
-        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Reward: {results_df.reward.mean():.4f} |{f' Val. Reward: {val_results_df.reward.mean():.4f} |' if val_results_df is not None else ''} Seq. Length: {results_df.groupby('example_id').seq_len.mean().mean():.1f} tokens/sample | Async Level: {scheduler.async_level} | Max. Off-Policy Level: {scheduler.max_off_policy_level}"
+        reward_mean = by_example.reward.mean().mean()
+        val_reward_str = ""
+        if val_results_df is not None:
+            val_reward_mean = val_results_df.groupby("example_id").reward.mean().mean()
+            val_reward_str = f" Val. Reward: {val_reward_mean:.4f} |"
+        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Reward: {reward_mean:.4f} |{val_reward_str} Seq. Length: {by_example.seq_len.mean().mean():.1f} tokens/sample | Async Level: {scheduler.async_level} | Max. Off-Policy Level: {scheduler.max_off_policy_level}"
         logger.success(step_message)
 
         # Increment step


### PR DESCRIPTION
## Summary
- Console reward and val reward were using `results_df.reward.mean()` (flat mean across all rollouts), while wandb logged `by_example.reward.mean().mean()` (mean per example, then across examples)
- These diverge when `rollouts_per_example` varies across problems (e.g. due to filtering or errors)
- Now both console and wandb use the same `mean().mean()` aggregation
- Also reuses the existing `by_example` groupby instead of re-computing it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes how step-level console metrics are aggregated and formatted, without affecting training, logging payloads, or model behavior.
> 
> **Overview**
> Console step logging in `orchestrator.py` now computes train and validation reward as *mean per example, then mean across examples* (`groupby("example_id").mean().mean()`), matching the aggregation used for W&B/monitor logging when rollout counts vary.
> 
> It also reuses the existing `by_example` groupby for train reward/sequence length and builds the validation string separately to simplify the step message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 387afacbc38bb28757c30202ff4166cb61d40dd6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->