### PR TITLE
Fix: In-Group Evals

### DIFF
--- a/src/prime_rl/orchestrator/vf_utils.py
+++ b/src/prime_rl/orchestrator/vf_utils.py
@@ -206,15 +206,13 @@ async def evaluate(
           Instead, we use our generate() wrapper which round-robins clients.
 
     """
-    examples = env.get_eval_inputs(num_examples=num_examples, rollouts_per_example=1)
+    inputs = env._get_eval_inputs(num_examples, 1)
     outputs = await generate(
         env=env,
         clients=clients,
         get_client=get_client,
         model_name=model_name,
-        examples=examples,
-        # Keep one unique input per example here. generate()/run_group() handles
-        # producing grouped rollouts so rubric.score_group() sees the full group.
+        examples=inputs,
         rollouts_per_example=rollouts_per_example,
         sampling_args=sampling_args,
         max_retries=max_retries,

--- a/src/prime_rl/orchestrator/vf_utils.py
+++ b/src/prime_rl/orchestrator/vf_utils.py
@@ -206,18 +206,16 @@ async def evaluate(
           Instead, we use our generate() wrapper which round-robins clients.
 
     """
-    inputs = env._get_eval_inputs(num_examples, rollouts_per_example)
+    examples = env.get_eval_inputs(num_examples=num_examples, rollouts_per_example=1)
     outputs = await generate(
         env=env,
         clients=clients,
         get_client=get_client,
         model_name=model_name,
-        examples=inputs,
-        # _get_eval_inputs() already repeats the examples, this currently means
-        # we do not support eval envs with group scoring well -- this should be
-        # resolved once we can use vf.Environment.generate() and
-        # vf.Environment.evaluate() directly though
-        rollouts_per_example=1,
+        examples=examples,
+        # Keep one unique input per example here. generate()/run_group() handles
+        # producing grouped rollouts so rubric.score_group() sees the full group.
+        rollouts_per_example=rollouts_per_example,
         sampling_args=sampling_args,
         max_retries=max_retries,
         state_columns=state_columns,

--- a/src/prime_rl/orchestrator/vf_utils.py
+++ b/src/prime_rl/orchestrator/vf_utils.py
@@ -206,13 +206,17 @@ async def evaluate(
           Instead, we use our generate() wrapper which round-robins clients.
 
     """
-    inputs = env._get_eval_inputs(num_examples, 1)
+    inputs = env._get_eval_inputs(num_examples, rollouts_per_example=1)
     outputs = await generate(
         env=env,
         clients=clients,
         get_client=get_client,
         model_name=model_name,
         examples=inputs,
+        # _get_eval_inputs() already repeats the examples, this currently means
+        # we do not support eval envs with group scoring well -- this should be
+        # resolved once we can use vf.Environment.generate() and
+        # vf.Environment.evaluate() directly though
         rollouts_per_example=rollouts_per_example,
         sampling_args=sampling_args,
         max_retries=max_retries,

--- a/src/prime_rl/orchestrator/vf_utils.py
+++ b/src/prime_rl/orchestrator/vf_utils.py
@@ -77,6 +77,15 @@ async def wait_for_env_servers(env_clients: list[EnvClient]) -> None:
     await asyncio.gather(*[env_client.wait_for_server_startup() for env_client in env_clients])
 
 
+def _get_rollout_state_columns(
+    env: vf.Environment,
+    rollout_input: vf.RolloutInput,
+    state_columns: list[str],
+) -> list[str]:
+    task_env = env.get_env_for_task(rollout_input["task"]) if hasattr(env, "get_env_for_task") else env
+    return state_columns + REQUIRED_STATE_COLUMNS + getattr(task_env, "state_columns", [])
+
+
 async def run_rollout(
     env: vf.Environment,
     client: vf.ClientConfig,
@@ -92,8 +101,7 @@ async def run_rollout(
     Asynchronously generates and scores one rollout.
     """
     rollout_input = vf.RolloutInput(**example)
-    task_env = env.get_env_for_task(rollout_input["task"]) if hasattr(env, "get_env_for_task") else env
-    state_columns = state_columns + REQUIRED_STATE_COLUMNS + getattr(task_env, "state_columns", [])
+    state_columns = _get_rollout_state_columns(env, rollout_input, state_columns)
     return await env.run_rollout(
         rollout_input,
         client=client,
@@ -119,7 +127,8 @@ async def run_group(
 
     Asynchronously generates and scores a group.
     """
-    state_columns = state_columns + REQUIRED_STATE_COLUMNS
+    rollout_input = vf.RolloutInput(**example)
+    state_columns = _get_rollout_state_columns(env, rollout_input, state_columns)
     group_inputs = [vf.RolloutInput(**example) for _ in range(rollouts_per_example)]
     return await env.run_group(
         group_inputs,

--- a/src/prime_rl/orchestrator/vf_utils.py
+++ b/src/prime_rl/orchestrator/vf_utils.py
@@ -13,7 +13,7 @@ from verifiers.workers import ZMQEnvClient, ZMQEnvServer
 from prime_rl.utils.logger import InterceptHandler, ProgressTracker
 
 DEFAULT_RETRIES = 0
-REQUIRED_STATE_COLUMNS = ["trajectory", "sampling_args"]
+REQUIRED_STATE_COLUMNS = ["trajectory", "sampling_args", "additional"]
 DEFAULT_STATE_COLUMNS = []
 
 

--- a/src/prime_rl/orchestrator/vf_utils.py
+++ b/src/prime_rl/orchestrator/vf_utils.py
@@ -13,7 +13,7 @@ from verifiers.workers import ZMQEnvClient, ZMQEnvServer
 from prime_rl.utils.logger import InterceptHandler, ProgressTracker
 
 DEFAULT_RETRIES = 0
-REQUIRED_STATE_COLUMNS = ["trajectory", "sampling_args", "additional"]
+REQUIRED_STATE_COLUMNS = ["trajectory", "sampling_args"]
 DEFAULT_STATE_COLUMNS = []
 
 
@@ -91,8 +91,9 @@ async def run_rollout(
 
     Asynchronously generates and scores one rollout.
     """
-    state_columns = state_columns + REQUIRED_STATE_COLUMNS
     rollout_input = vf.RolloutInput(**example)
+    task_env = env.get_env_for_task(rollout_input["task"]) if hasattr(env, "get_env_for_task") else env
+    state_columns = state_columns + REQUIRED_STATE_COLUMNS + getattr(task_env, "state_columns", [])
     return await env.run_rollout(
         rollout_input,
         client=client,


### PR DESCRIPTION
Fix eval grouping and preserve environment-declared state columns during deferred scoring.

## Description

Two related fixes in `vf_utils.py`:

### 1. Fix eval group construction

`evaluate()` was passing `rollouts_per_example` to `_get_eval_inputs()` (which repeats examples) and then setting `rollouts_per_example=1` on `generate()`. This meant each "group" had only one rollout, breaking group-based scoring and pass@k semantics.

Fixed by passing `rollouts_per_example=1` to `_get_eval_inputs()` to get unique examples, then passing the real `rollouts_per_example` to `generate()` so groups are constructed correctly.

Fixes: 

<img width="1280" height="312" alt="image" src="https://github.com/user-attachments/assets/30ba17cd-0918-4246-8d57-dbfa8ecff911" />


### 2. Preserve environment-declared state columns

`run_rollout()` now reads `env.state_columns` (if present) and includes those fields in the serialization columns. This allows environments to declare which custom state fields (e.g. `eval_score`, `eval_error`) should survive `state_to_output()` serialization, so deferred group scoring can access them without the orchestrator needing to hardcode environment-specific field names.

Resolves to the task-specific sub-environment via `get_env_for_task()` when running under `EnvGroup`.

Falls back gracefully: if the environment has no `state_columns` attribute, `getattr` returns `[]` and behavior is unchanged.

Companion PR: [PrimeIntellect-ai/verifiers#1054](https://github.com/PrimeIntellect-ai/verifiers/pull/1054)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing

- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

Verified locally that `state_columns` declared by an environment are correctly appended to serialization columns. The eval grouping fix was validated by confirming `_get_eval_inputs(..., 1)` produces unique examples and `generate()` constructs proper groups.

## Checklist

- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/prime-rl/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

The `state_columns` feature depends on [PrimeIntellect-ai/verifiers#1054](https://github.com/PrimeIntellect-ai/verifiers/pull/1054), which adds the `state_columns` attribute to `Environment.__init__`. Without that PR, the `getattr` fallback returns `[]` and the behavior is identical to today.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes evaluation batching semantics and rollout serialization columns, which can affect pass@k/group-scoring correctness and downstream metrics, but is localized to `vf_utils` wrappers.
> 
> **Overview**
> Fixes eval grouping so `evaluate()` builds *true groups* of size `rollouts_per_example` by requesting unique eval inputs (`_get_eval_inputs(..., rollouts_per_example=1)`) and passing the real `rollouts_per_example` through to `generate()`.
> 
> Updates `run_rollout()` to preserve environment-declared custom state fields by appending task-specific `state_columns` (via `get_env_for_task()` when available) to the serialized output columns, ensuring deferred/group scoring can access them.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef25835a38ce309d5edb7eea51b0edfc4b160d5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->