### PR TITLE
Fix: typo in comment for sample_ratio

### DIFF
--- a/src/prime_rl/configs/shared.py
+++ b/src/prime_rl/configs/shared.py
@@ -284,7 +284,7 @@ class LogExtrasConfig(BaseConfig):
             description="Fraction of rollouts to log per step (0.0–1.0). "
             "When set, the effective sample cap is len(rollouts) * sample_ratio. "
             "1.0 = all rollouts, 0.5 = half, 0.0 = none. "
-            "None (default) = log all rollouts (current behavior).",
+            "None (default)",
         ),
     ] = None
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only updates the `sample_ratio` Pydantic field description string with no behavioral or data-handling changes.
> 
> **Overview**
> Fixes the `LogExtrasConfig.sample_ratio` configuration field description in `configs/shared.py` by removing outdated wording about the default behavior, leaving it as "None (default)".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4948b3496314a9a71e3033001cdc30339f0cebdd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->