### PR TITLE
validate VLM dtype in configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Documenting changes which affect configuration usage patterns (added/moved/removed/renamed fields, notable logic changes).
 
+- **`model.optimization_dtype` / `model.reduce_dtype` (VLM models)**: Added validation that VLM models must use `optimization_dtype='bfloat16'` and `reduce_dtype='bfloat16'` to match vLLM inference. Previously valid configs with `float32` (the default) are now rejected for VLM model names. Set both fields to `"bfloat16"` when training VLMs. (2026-03-21)
 - **`orchestrator.advantage.length_weighted_mean`**: Removed. The default advantage now always uses the plain per-problem mean baseline unless `orchestrator.advantage.length_shaping_alpha` is set. Existing configs must delete this field. (2026-03-19)
 - **`orchestrator.advantage.length_shaping_alpha`**: Added Group Relative Reward Rescaling coefficient to the default advantage config. When set, applies length-based GR3 shaping during advantage computation and requires `orchestrator.buffer.online_difficulty_filtering = true` (default: `None`) (2026-03-18)
 - **`prime_monitor.log_extras.sample_ratio`**: Added ratio-based rollout sampling (0.0–1.0, default: None). When set, caps the number of rollouts logged per step to `len(rollouts) * sample_ratio`. `None` preserves current behavior (log all rollouts). Interacts with existing `interval` gate which still runs first. (2026-03-12)

--- a/src/prime_rl/configs/trainer.py
+++ b/src/prime_rl/configs/trainer.py
@@ -13,6 +13,7 @@ from prime_rl.configs.shared import (
     WandbConfig,
 )
 from prime_rl.utils.config import BaseConfig
+from prime_rl.utils.vlm import is_vlm_model
 
 # -- Shared trainer configs (used by both SFT and RL trainers) --
 
@@ -296,6 +297,17 @@ class ModelConfig(BaseModelConfig):
         if self.trust_remote_code:
             if self.impl not in ("hf", "auto"):
                 raise ValueError("Trust remote code is only supported with the HF implementation or auto mode.")
+        return self
+
+    @model_validator(mode="after")
+    def vlms_require_bfloat16(self):
+        if is_vlm_model(self.name) and (
+            self.optimization_dtype != "bfloat16" or self.reduce_dtype != "bfloat16"
+        ):
+            raise ValueError(
+                "VLM models must use optimization_dtype='bfloat16' and reduce_dtype='bfloat16' "
+                "to match vLLM inference."
+            )
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/configs/trainer.py
+++ b/src/prime_rl/configs/trainer.py
@@ -301,12 +301,9 @@ class ModelConfig(BaseModelConfig):
 
     @model_validator(mode="after")
     def vlms_require_bfloat16(self):
-        if is_vlm_model(self.name) and (
-            self.optimization_dtype != "bfloat16" or self.reduce_dtype != "bfloat16"
-        ):
+        if is_vlm_model(self.name) and (self.optimization_dtype != "bfloat16" or self.reduce_dtype != "bfloat16"):
             raise ValueError(
-                "VLM models must use optimization_dtype='bfloat16' and reduce_dtype='bfloat16' "
-                "to match vLLM inference."
+                "VLM models must use optimization_dtype='bfloat16' and reduce_dtype='bfloat16' to match vLLM inference."
             )
         return self
 

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -154,3 +154,14 @@ def test_cli_overrides_toml(tmp_path):
 def test_removed_fused_lm_head_chunk_size_field_is_rejected():
     with pytest.raises(ValidationError, match="fused_lm_head_chunk_size"):
         TrainerModelConfig.model_validate({"fused_lm_head_chunk_size": "auto"})
+
+
+def test_vlm_models_require_bfloat16_dtypes():
+    with pytest.raises(ValidationError, match="optimization_dtype='bfloat16' and reduce_dtype='bfloat16'"):
+        TrainerModelConfig.model_validate(
+            {
+                "name": "Qwen/Qwen3.5-4B",
+                "optimization_dtype": "float32",
+                "reduce_dtype": "float32",
+            }
+        )

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -154,14 +154,3 @@ def test_cli_overrides_toml(tmp_path):
 def test_removed_fused_lm_head_chunk_size_field_is_rejected():
     with pytest.raises(ValidationError, match="fused_lm_head_chunk_size"):
         TrainerModelConfig.model_validate({"fused_lm_head_chunk_size": "auto"})
-
-
-def test_vlm_models_require_bfloat16_dtypes():
-    with pytest.raises(ValidationError, match="optimization_dtype='bfloat16' and reduce_dtype='bfloat16'"):
-        TrainerModelConfig.model_validate(
-            {
-                "name": "Qwen/Qwen3.5-4B",
-                "optimization_dtype": "float32",
-                "reduce_dtype": "float32",
-            }
-        )


### PR DESCRIPTION
to enforce already documented behavior: 

- **Optimization dtype must be bfloat16**: VLM models must load in bfloat16 to match vLLM inference. If the trainer uses a different dtype, the vision encoder produces different `pixel_values`, causing a mismatch between inference and training. A workaround would be to propagate the `pixel_values` computed by vLLM to the trainer, but this is more involved. For now, set `optimization_dtype = "bfloat16"` and `reduce_dtype = "bfloat16"` in your trainer config.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds stricter config validation that will now reject previously valid VLM trainer configs using default `float32` dtypes, potentially breaking existing runs until configs are updated. Logic is limited to config-time checks, so runtime risk is otherwise low.
> 
> **Overview**
> **Enforces VLM dtype constraints at config validation time.** Trainer `ModelConfig` now detects VLM model names (via `is_vlm_model`) and raises a validation error unless both `model.optimization_dtype` and `model.reduce_dtype` are set to `"bfloat16"`.
> 
> Documentation is updated in `CHANGELOG.md` to call out the new rejection of the prior default `float32` settings for VLM configs and the required config change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 326bfd700a8c728d3f35b54164085d687a0b1f75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->