### PR TITLE
chore: consolidate VLM detection in trainer

### DIFF
--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -119,21 +119,10 @@ torch._dynamo.config.cache_size_limit = 64  # default: 8
 
 
 def freeze_vision_encoder(model: nn.Module) -> None:
-    """Freeze the vision encoder parameters for VLM training.
-
-    For Qwen3-VL, the vision encoder is at model.model.visual.
-    This freezes all parameters in the vision encoder so only the
-    language model (with LoRA) is trained.
-    """
+    """Freeze the vision encoder parameters for VLM training."""
     logger = get_logger()
-
-    # Qwen3-VL structure: model.model.visual
-    if hasattr(model, "model") and hasattr(model.model, "visual"):
-        vision_encoder = model.model.visual
-    # Qwen2-VL structure: model.visual
-    elif hasattr(model, "visual"):
-        vision_encoder = model.visual
-    else:
+    vision_encoder = get_vision_encoder(model)
+    if vision_encoder is None:
         raise ValueError("Could not find vision encoder to freeze. Expected model.model.visual or model.visual")
 
     num_frozen = 0
@@ -184,6 +173,19 @@ def get_language_model(model: nn.Module) -> nn.Module:
     if hasattr(model.model, "language_model"):
         return model.model.language_model
     return model.model
+
+
+def get_vision_encoder(model: nn.Module) -> nn.Module | None:
+    """Get the vision encoder component, or None for text-only models.
+
+    For Qwen3-VL: model.model.visual
+    For Qwen2-VL: model.visual
+    """
+    if hasattr(model, "model") and hasattr(model.model, "visual"):
+        return model.model.visual
+    if hasattr(model, "visual"):
+        return model.visual
+    return None
 
 
 def get_load_balance_stats(
@@ -329,6 +331,9 @@ def get_model(
     if is_vlm:
         freeze_vision_encoder(model)
 
+    # Store VLM flag on the model so downstream code (setup_fsdp) doesn't need to re-detect
+    model._is_vlm = is_vlm
+
     assert model.lm_head.weight.dtype == dtype, (
         f"LM head dtype wasnt loaded correctly {model.lm_head.weight.dtype} != {dtype}"
     )
@@ -367,13 +372,10 @@ def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDim
 
     # For VLM models, shard the frozen vision encoder as a single unit
     # This allows FSDP to manage the memory while keeping it frozen
-    is_vlm = is_vlm_model(config.name) or (hasattr(model, "model") and hasattr(model.model, "visual"))
+    is_vlm = getattr(model, "_is_vlm", False)
     if is_vlm:
-        if hasattr(model, "model") and hasattr(model.model, "visual"):
-            vision_encoder = model.model.visual
-        elif hasattr(model, "visual"):
-            vision_encoder = model.visual
-        else:
+        vision_encoder = get_vision_encoder(model)
+        if vision_encoder is None:
             raise ValueError(f"VLM model {config.name} does not have a recognized vision encoder attribute")
 
         fully_shard(
@@ -383,15 +385,9 @@ def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDim
         )
         get_logger().info("Applied FSDP to frozen vision encoder")
 
-    # Get the language model layers (handle VLM structure)
-    # For Qwen3-VL: model.model.language_model contains the transformer layers
-    # For text-only models: model.model contains the layers directly
-    if is_vlm:
-        language_model = model.model.language_model
-        transformer_layers = language_model.layers
-    else:
-        language_model = model.model
-        transformer_layers = language_model.layers
+    # Get the language model layers (handles VLM vs text-only structure)
+    language_model = get_language_model(model)
+    transformer_layers = language_model.layers
 
     for transformer_block in transformer_layers:
         if parallel_dims.ep_enabled and isinstance(transformer_block.mlp, MoE):


### PR DESCRIPTION
## Summary
- Store `model._is_vlm` flag in `get_model()` after detection, read it in `setup_fsdp()` instead of re-deriving
- Add `get_vision_encoder(model)` helper — replaces 3 separate `hasattr` patterns across `freeze_vision_encoder()` and `setup_fsdp()`
- Use existing `get_language_model()` in `setup_fsdp()` instead of duplicating the VLM/text-only branch

**Before:** 3 separate VLM detection points in `model.py` — `get_model()` (name pattern + config fallback), `setup_fsdp()` (name pattern + hasattr chain), and structural checks in `freeze_vision_encoder()`.

**After:** Single detection in `get_model()`, propagated via `model._is_vlm`. Net -4 lines.

## Test plan
- [x] All 47 existing VLM + trajectory tests pass
- [x] RL color-codeword integration test with Qwen3-VL-4B (3 steps, stacked with other VLM PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes VLM detection and model submodule access; main risk is mis-detecting a VLM variant and skipping vision freezing/FSDP sharding.
> 
> **Overview**
> Consolidates vision-language model (VLM) handling in `trainer/model.py` by introducing `get_vision_encoder()` and using it in both `freeze_vision_encoder()` and `setup_fsdp()`.
> 
> Moves VLM detection to `get_model()` and persists it via `model._is_vlm`, so `setup_fsdp()` no longer re-derives VLM status, and switches `setup_fsdp()` to use `get_language_model()` instead of duplicating VLM vs text-only layer selection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 407f387a32cf32e48b0aafd102ece5b02517e88d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->