### PR TITLE
feat: add multimodal SFT support

### DIFF
--- a/configs/multimodal/sft_color_codeword.toml
+++ b/configs/multimodal/sft_color_codeword.toml
@@ -1,0 +1,23 @@
+max_steps = 500
+output_dir = "outputs/sft_color_codeword"
+
+[model]
+name = "Qwen/Qwen3-VL-4B-Instruct"
+optimization_dtype = "bfloat16"
+reduce_dtype = "bfloat16"
+
+[data]
+type = "sft"
+name = "data/color_codeword_sft"
+seq_len = 2048
+batch_size = 1
+micro_batch_size = 1
+pack_function = "single"
+
+[optim]
+type = "adamw"
+lr = 1e-5
+
+[ckpt]
+weights_only = true
+interval = 500

--- a/docs/multimodal.md
+++ b/docs/multimodal.md
@@ -1,35 +1,108 @@
 # Multimodal (VLM) Support
 
-Prime-RL has experimental support for training vision-language models (VLMs) like Qwen3-VL.
+Prime-RL supports training vision-language models (VLMs) like Qwen3-VL via both RL and SFT.
+
+## Quick Start
+
+### RL Training
+```bash
+uv run rl @ configs/multimodal/rl_color_codeword.toml
+```
+
+### SFT Training
+```bash
+# Generate synthetic data (or bring your own)
+uv run python scripts/generate_color_codeword_sft_data.py
+
+# Train
+uv run sft @ configs/multimodal/sft_color_codeword.toml
+```
+
+## Configuration
+
+### VLM Detection
+
+VLMs are auto-detected from the model name (e.g. `Qwen/Qwen3-VL*`). For local checkpoints or custom models, set `vlm = true` explicitly:
+
+```toml
+[model]
+name = "my-local-vlm-checkpoint"
+vlm = true
+```
+
+### Custom VLM Architectures
+
+For models not in the built-in registry, you can specify the vision encoder location and layer prefix:
+
+```toml
+[model]
+name = "my-custom-vlm"
+vlm = true
+vlm_vision_encoder_attr = "model.my_vision_module"    # Dotted path to vision encoder
+vlm_layer_prefix = "model.language_model.layers."      # Weight key prefix for text layers
+```
+
+The built-in registry covers:
+- **Qwen3-VL** (`visual`)
+- **LLaVA** (`vision_tower`)
+- **Idefics3 / SmolVLM** (`vision_model`)
+
+### Vision Encoder Training
+
+By default, the vision encoder is frozen. To make it trainable:
+
+```toml
+[trainer.model]
+freeze_vision_encoder = false
+```
+
+When unfrozen, the vision encoder is FSDP-sharded per-block for proper gradient flow. Note: this has no effect when using LoRA (LoRA freezes all non-adapter parameters).
+
+### SFT Data Format
+
+Your dataset needs `prompt` and `completion` columns with OpenAI-format messages. Images can be included as `image_url` content items:
+
+```json
+{
+  "prompt": [
+    {"role": "system", "content": "You are helpful."},
+    {"role": "user", "content": [
+      {"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}},
+      {"type": "text", "text": "What is this?"}
+    ]}
+  ],
+  "completion": [
+    {"role": "assistant", "content": "A red square."}
+  ]
+}
+```
+
+Use `pack_function = "single"` for multimodal SFT — each sample becomes its own micro-batch since image tensor sizes vary.
 
 ## Current Limitations
 
-- **No SFT support**: Supervised fine-tuning is not yet supported for VLM models. Only RL training is available.
+- **Optimization dtype must be bfloat16**: VLM models must load in bfloat16 to match vLLM inference. Set `optimization_dtype = "bfloat16"` and `reduce_dtype = "bfloat16"`.
 
-- **Vision encoder is frozen**: The vision encoder is automatically frozen during training. Only the language model is trained.
+- **Multimodal samples exceeding `seq_len` are skipped**: Truncation would break the alignment between image tokens and pixel values. Ensure `seq_len` covers your longest VLM samples.
 
-- **No multimodal-safe truncation**: Token sequences are truncated to `seq_len`, but `pixel_values` and `image_grid_thw` are passed through unchanged. If a multimodal sample exceeds `seq_len`, image tokens can be dropped while image tensors still describe the full set of images. Ensure `seq_len` covers your longest VLM samples or avoid overlong rollouts.
+- **Per-role loss masking not supported for multimodal SFT**: The multimodal path uses a simple prompt/completion binary loss mask. `loss_mask_config` is only applied for text-only samples.
 
-- **The images that the VLM sees are not logged**
+- **Higher KL mismatch with multi-image inputs**: VLM training exhibits higher KL mismatch compared to text-only, especially with multiple images.
 
-- **Optimization dtype must be bfloat16**: VLM models must load in bfloat16 to match vLLM inference. If the trainer uses a different dtype, the vision encoder produces different `pixel_values`, causing a mismatch between inference and training. A workaround would be to propagate the `pixel_values` computed by vLLM to the trainer, but this is more involved. For now, set `optimization_dtype = "bfloat16"` and `reduce_dtype = "bfloat16"` in your trainer config.
+- **Images are not logged**: The images the VLM sees during training are not logged to monitors.
 
-- **Higher KL mismatch with multi-image inputs**: VLM training exhibits higher KL mismatch between inference and trainer logprobs compared to text-only models, especially with multiple images per sample. We are investigating the root cause. The existing importance ratio masking thresholds should handle reasonable mismatches.
+## How Multi-Turn VLM RL Training Works
 
-## How Multi-Turn VLM Training Works
-
-VLM training uses the same `interleave_rollout` path as text-only models. Multi-turn trajectory steps are merged into a single training sample wherever the extension property holds (consecutive steps share a token prefix). When extension breaks (e.g., due to context compaction), a new sample is started automatically.
+VLM training uses the same `interleave_rollout` path as text-only models. Multi-turn trajectory steps are merged into a single training sample wherever the extension property holds.
 
 Images are handled via a `VLMImageCache` built once per batch:
 
-1. **Extract**: Base64 images are decoded from trajectory step prompts into PIL images. Since prompts are cumulative, only new images per step are extracted.
-2. **Preprocess**: All images are processed in a single batched call through the HuggingFace image processor, producing `pixel_values` (patches) and `image_grid_thw` (grid dimensions).
-3. **Attach**: Each training sample receives the cumulative `pixel_values` up to its last merged step. When steps are merged, the sample's images are updated to include all images seen so far.
-
-This works correctly for all combinations: images in early turns with text-only follow-ups, images appearing mid-conversation, new images accumulating across turns, and interleaved agents with separate image streams.
+1. **Extract**: Base64 images are decoded from trajectory step prompts into PIL images.
+2. **Preprocess**: Images are processed through the HuggingFace image processor (runs in a background thread to avoid blocking the event loop).
+3. **Attach**: Each training sample receives the cumulative `pixel_values` up to its last merged step.
 
 Each multimodal sample becomes its own micro-batch during training (no packing with other samples) since image tensor sizes vary per sample.
 
 ## vLLM Configuration
 
-`VLLM_WORKER_MULTIPROC_METHOD=spawn` is required for VLM inference. This is set automatically in `src/prime_rl/inference/config.py`, so if you use `uv run rl @ ...` it works out of the box, but if you start the vLLM server yourself, make sure this environment variable is set.
+`VLLM_WORKER_MULTIPROC_METHOD=spawn` is required for VLM inference. This is set automatically when using `uv run rl @ ...`, but if you start the vLLM server yourself, make sure this environment variable is set.

--- a/scripts/eval_color_codeword.py
+++ b/scripts/eval_color_codeword.py
@@ -1,0 +1,116 @@
+"""Evaluate a VLM on the color-codeword task.
+
+Generates random color images and checks if the model outputs the correct codeword.
+Usage:
+    uv run python scripts/eval_color_codeword.py --model Qwen/Qwen3-VL-4B-Instruct [--sft-weights path/to/weights]
+"""
+
+import argparse
+import random
+
+import torch
+from PIL import Image
+from transformers import AutoModelForImageTextToText, AutoProcessor
+
+COLOR_TO_LETTER = {
+    "red": "A",
+    "green": "B",
+    "blue": "C",
+    "yellow": "D",
+    "purple": "E",
+    "cyan": "F",
+    "orange": "G",
+    "white": "H",
+    "black": "I",
+}
+COLOR_RGB = {
+    "red": (255, 0, 0),
+    "green": (0, 255, 0),
+    "blue": (0, 0, 255),
+    "yellow": (255, 255, 0),
+    "purple": (128, 0, 128),
+    "cyan": (0, 255, 255),
+    "orange": (255, 165, 0),
+    "white": (255, 255, 255),
+    "black": (0, 0, 0),
+}
+
+SYSTEM_PROMPT = (
+    "You are looking at colored squares. Each color maps to a letter:\n"
+    "Red=A, Green=B, Blue=C, Yellow=D, Purple=E, Cyan=F, Orange=G, White=H, Black=I\n"
+    "After seeing the squares, output ONLY the corresponding letters with NO spaces."
+)
+
+
+def make_color_image(color_name: str) -> Image.Image:
+    return Image.new("RGB", (100, 100), COLOR_RGB[color_name])
+
+
+def evaluate(model, processor, num_examples=50, seed=123):
+    rng = random.Random(seed)
+    color_names = list(COLOR_TO_LETTER.keys())
+    correct = 0
+
+    for i in range(num_examples):
+        n_colors = rng.randint(1, 3)
+        colors = [rng.choice(color_names) for _ in range(n_colors)]
+        expected = "".join(COLOR_TO_LETTER[c] for c in colors)
+        images = [make_color_image(c) for c in colors]
+
+        image_items = [{"type": "image"} for _ in colors]
+        messages = [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": image_items + [{"type": "text", "text": f"Here are {n_colors} squares."}]},
+        ]
+
+        text = processor.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+        inputs = processor(text=[text], images=images, return_tensors="pt", padding=False)
+        inputs = {k: v.to(model.device) for k, v in inputs.items()}
+
+        with torch.no_grad():
+            output_ids = model.generate(**inputs, max_new_tokens=20, do_sample=False)
+
+        # Decode only the new tokens
+        new_tokens = output_ids[0][inputs["input_ids"].shape[1] :]
+        response = processor.decode(new_tokens, skip_special_tokens=True).strip()
+
+        # Extract letters A-I from response
+        extracted = "".join(c for c in response.upper() if c in "ABCDEFGHI")
+
+        is_correct = extracted == expected
+        if is_correct:
+            correct += 1
+        if i < 5:
+            print(
+                f"  Colors: {colors} | Expected: {expected} | Got: {response!r} | Extracted: {extracted} | {'OK' if is_correct else 'WRONG'}"
+            )
+
+    accuracy = correct / num_examples
+    print(f"\nAccuracy: {correct}/{num_examples} = {accuracy:.1%}")
+    return accuracy
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default="Qwen/Qwen3-VL-4B-Instruct")
+    parser.add_argument("--sft-weights", default=None, help="Path to SFT weight checkpoint")
+    parser.add_argument("--num-examples", type=int, default=50)
+    args = parser.parse_args()
+
+    print(f"Loading processor from {args.model}")
+    processor = AutoProcessor.from_pretrained(args.model, trust_remote_code=True)
+
+    model_path = args.sft_weights if args.sft_weights else args.model
+    print(f"Loading model from {model_path}")
+    model = (
+        AutoModelForImageTextToText.from_pretrained(model_path, torch_dtype=torch.bfloat16, trust_remote_code=True)
+        .to("cuda")
+        .eval()
+    )
+
+    print(f"\nEvaluating {model_path} on {args.num_examples} color-codeword examples:")
+    evaluate(model, processor, num_examples=args.num_examples)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_color_codeword_sft_data.py
+++ b/scripts/generate_color_codeword_sft_data.py
@@ -1,0 +1,146 @@
+"""Generate synthetic SFT data for the color-codeword environment.
+
+Creates a HF dataset with multimodal prompt/completion pairs that teach the
+model the color-to-letter mapping:
+  Red→A, Green→B, Blue→C, Yellow→D, Purple→E, Cyan→F, Orange→G, White→H, Black→I
+"""
+
+import base64
+import io
+import json
+import random
+from pathlib import Path
+
+from PIL import Image
+
+COLOR_TO_LETTER = {
+    "red": "A",
+    "green": "B",
+    "blue": "C",
+    "yellow": "D",
+    "purple": "E",
+    "cyan": "F",
+    "orange": "G",
+    "white": "H",
+    "black": "I",
+}
+
+COLOR_RGB = {
+    "red": (255, 0, 0),
+    "green": (0, 255, 0),
+    "blue": (0, 0, 255),
+    "yellow": (255, 255, 0),
+    "purple": (128, 0, 128),
+    "cyan": (0, 255, 255),
+    "orange": (255, 165, 0),
+    "white": (255, 255, 255),
+    "black": (0, 0, 0),
+}
+
+SYSTEM_PROMPT = (
+    "You are looking at colored squares. Each color maps to a letter:\n"
+    "Red=A, Green=B, Blue=C, Yellow=D, Purple=E, Cyan=F, Orange=G, White=H, Black=I\n"
+    "After seeing the squares, output ONLY the corresponding letters with NO spaces."
+)
+
+
+def make_color_image(color_name: str, size: int = 100) -> str:
+    """Create a solid-color image and return as base64 data URL."""
+    rgb = COLOR_RGB[color_name]
+    img = Image.new("RGB", (size, size), rgb)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    b64 = base64.b64encode(buf.getvalue()).decode()
+    return f"data:image/png;base64,{b64}"
+
+
+def make_single_turn_example(colors: list[str]) -> dict:
+    """Create a single-turn example: show N colors, expect the codeword."""
+    image_items = [{"type": "image_url", "image_url": {"url": make_color_image(c)}} for c in colors]
+    n = len(colors)
+    text = f"Here are {n} square{'s' if n > 1 else ''}."
+    codeword = "".join(COLOR_TO_LETTER[c] for c in colors)
+
+    prompt = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": image_items + [{"type": "text", "text": text}]},
+    ]
+    completion = [{"role": "assistant", "content": codeword}]
+    return {"prompt": prompt, "completion": completion}
+
+
+def make_multi_turn_example(colors_per_turn: list[list[str]]) -> dict:
+    """Create a multi-turn example with accumulated codeword."""
+    prompt = [{"role": "system", "content": SYSTEM_PROMPT}]
+    accumulated = ""
+
+    for turn_idx, colors in enumerate(colors_per_turn):
+        image_items = [{"type": "image_url", "image_url": {"url": make_color_image(c)}} for c in colors]
+        n = len(colors)
+
+        if turn_idx == 0:
+            text = f"Here are {n} square{'s' if n > 1 else ''}."
+        elif turn_idx == len(colors_per_turn) - 1:
+            total = sum(len(t) for t in colors_per_turn)
+            text = f"Here are {n} more square{'s' if n > 1 else ''}. Combine your previous answer with these new letters to output all {total} letters."
+        else:
+            text = f"Here are {n} more square{'s' if n > 1 else ''}."
+
+        prompt.append({"role": "user", "content": image_items + [{"type": "text", "text": text}]})
+        accumulated += "".join(COLOR_TO_LETTER[c] for c in colors)
+
+        if turn_idx < len(colors_per_turn) - 1:
+            prompt.append({"role": "assistant", "content": accumulated})
+
+    completion = [{"role": "assistant", "content": accumulated}]
+    return {"prompt": prompt, "completion": completion}
+
+
+def generate_dataset(num_examples: int = 500, seed: int = 42) -> list[dict]:
+    rng = random.Random(seed)
+    color_names = list(COLOR_TO_LETTER.keys())
+    examples = []
+
+    # Single-turn: 1-3 colors
+    for _ in range(num_examples // 2):
+        n_colors = rng.randint(1, 3)
+        colors = [rng.choice(color_names) for _ in range(n_colors)]
+        examples.append(make_single_turn_example(colors))
+
+    # Multi-turn: 2-3 turns, 1 color per turn
+    for _ in range(num_examples - num_examples // 2):
+        n_turns = rng.randint(2, 3)
+        colors_per_turn = [[rng.choice(color_names)] for _ in range(n_turns)]
+        examples.append(make_multi_turn_example(colors_per_turn))
+
+    rng.shuffle(examples)
+    return examples
+
+
+def main():
+    output_dir = Path("data/color_codeword_sft")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    examples = generate_dataset(num_examples=500, seed=42)
+
+    # Save as JSONL with prompt/completion serialized as JSON strings
+    # (PyArrow can't handle mixed string/list content types in nested dicts)
+    output_path = output_dir / "train.jsonl"
+    with open(output_path, "w") as f:
+        for ex in examples:
+            row = {
+                "prompt": json.dumps(ex["prompt"]),
+                "completion": json.dumps(ex["completion"]),
+            }
+            f.write(json.dumps(row) + "\n")
+
+    print(f"Generated {len(examples)} examples to {output_path}")
+
+    # Verify a sample
+    sample = examples[0]
+    print(f"\nSample prompt roles: {[m['role'] for m in sample['prompt']]}")
+    print(f"Sample completion: {sample['completion'][0]['content']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/prime_rl/configs/sft.py
+++ b/src/prime_rl/configs/sft.py
@@ -27,7 +27,7 @@ class BaseDataConfig(BaseModel):
 
     batch_size: Annotated[int, Field(ge=1)] = 128
     seq_len: Annotated[int, Field(ge=1)] = 128
-    pack_function: Literal["cat", "stack"] = "cat"
+    pack_function: Literal["cat", "stack", "single"] = "cat"
     micro_batch_size: Annotated[int, Field(ge=1)] = 1
 
     @model_validator(mode="after")

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -1,3 +1,5 @@
+import base64
+import io
 import json
 import uuid
 from collections import defaultdict
@@ -5,7 +7,8 @@ from typing import Literal, TypedDict, cast
 
 import torch
 from datasets import Dataset, interleave_datasets, load_dataset
-from jaxtyping import Bool, Int
+from jaxtyping import Bool, Float, Int
+from PIL import Image
 from torch import Tensor
 from torch.distributed.checkpoint.stateful import Stateful
 from torch.utils.data import IterableDataset, get_worker_info
@@ -24,6 +27,9 @@ class Sample(TypedDict):
     position_ids: list[int]
     loss_mask: list[bool]
     target_ids: list[int]
+    pixel_values: bytes | None
+    pixel_values_shape: list[int] | None
+    image_grid_thw: list[list[int]] | None
 
 
 class Batch(TypedDict):
@@ -31,6 +37,8 @@ class Batch(TypedDict):
     position_ids: Int[Tensor, "batch seq"]
     target_ids: Int[Tensor, "batch seq"]
     loss_mask: Bool[Tensor, "batch seq"]
+    pixel_values: Float[Tensor, "num_patches patch_dim"] | None
+    image_grid_thw: Int[Tensor, "num_images 3"] | None
 
 
 class StatefulIterableDataset(Stateful, IterableDataset):
@@ -106,6 +114,35 @@ class FakeDataset(StatefulIterableDataset):
             yield fake_sample
 
 
+def _extract_images_from_messages(messages: list[dict]) -> list[Image.Image]:
+    """Extract PIL images from OpenAI-format messages with image_url content."""
+    images = []
+    for msg in messages:
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        for item in content:
+            if not isinstance(item, dict):
+                continue
+            if item.get("type") == "image_url":
+                url = item["image_url"]["url"]
+                if url.startswith("data:image"):
+                    header, data = url.split(",", 1)
+                    img_bytes = base64.b64decode(data)
+                    images.append(Image.open(io.BytesIO(img_bytes)).convert("RGB"))
+                elif url.startswith("file://"):
+                    images.append(Image.open(url.removeprefix("file://")).convert("RGB"))
+            elif item.get("type") == "image":
+                url = item.get("image", "")
+                if url.startswith("data:image"):
+                    header, data = url.split(",", 1)
+                    img_bytes = base64.b64decode(data)
+                    images.append(Image.open(io.BytesIO(img_bytes)).convert("RGB"))
+                elif url.startswith("file://"):
+                    images.append(Image.open(url.removeprefix("file://")).convert("RGB"))
+    return images
+
+
 class SFTDataset(StatefulIterableDataset):
     """A dataset wrapping a HF SFT dataset with prompt + completion format."""
 
@@ -120,6 +157,7 @@ class SFTDataset(StatefulIterableDataset):
         loss_mask_config: LossMaskConfig = LossMaskConfig(),
         max_examples: int | None = None,
         max_epochs: int | None = None,
+        processor=None,
     ):
         super().__init__()
         self.logger = get_logger()
@@ -132,6 +170,7 @@ class SFTDataset(StatefulIterableDataset):
         self.loss_mask_config = loss_mask_config
         self.max_examples = max_examples
         self.max_epochs = max_epochs
+        self.processor = processor
 
         if self.tokenizer is None:
             self.logger.warning("No tokenizer provided, will not process examples")
@@ -150,6 +189,13 @@ class SFTDataset(StatefulIterableDataset):
         assert get_world().world_size % non_dp_size == 0, "world_size must be divisible by non_dp_size"
         self.data_rank = get_world().rank // non_dp_size * num_workers + worker_id
         self.data_world_size = get_world().world_size // non_dp_size * num_workers
+
+    @staticmethod
+    def _parse_messages(field) -> list[dict]:
+        """Parse a prompt/completion field that may be a JSON string or a list of dicts."""
+        if isinstance(field, str):
+            return json.loads(field)
+        return field
 
     def _process(self, example: dict) -> dict | None:
         # Skip processing if no tokenizer was provided
@@ -197,8 +243,8 @@ class SFTDataset(StatefulIterableDataset):
 
         # Deserialize tool call arguments from message list, if present - assumes OAI format
         # Reference: https://platform.openai.com/docs/guides/function-calling#handling-function-calls
-        prompt = deserialize_tool_calls(example["prompt"])
-        completion = deserialize_tool_calls(example["completion"])
+        prompt = deserialize_tool_calls(self._parse_messages(example["prompt"]))
+        completion = deserialize_tool_calls(self._parse_messages(example["completion"]))
 
         # Strip content from all messages so that incremental tokenization works
         # NOTE: This has the side effect that we do never train on leading or trailing whitespace
@@ -300,6 +346,88 @@ class SFTDataset(StatefulIterableDataset):
             "position_ids": list(range(len(input_ids))),
         }
 
+    def _process_multimodal(self, example: dict) -> dict | None:
+        """Process a multimodal example using the processor for image handling.
+
+        Note: loss_mask_config is not applied here — the loss mask is a simple
+        prompt/completion binary split. Per-role masking would require incremental
+        tokenization with expanded image tokens, which is not yet implemented.
+        """
+        if "prompt" not in example or "completion" not in example:
+            raise ValueError("All examples in the dataset must have a 'prompt' and 'completion' column for SFT")
+
+        prompt = self._parse_messages(example["prompt"])
+        completion = self._parse_messages(example["completion"])
+        all_messages = prompt + completion
+
+        # Extract images from all messages
+        images = _extract_images_from_messages(all_messages)
+        if not images:
+            return self._process(example)
+
+        # Use apply_chat_template with original messages (keeps image markers for token expansion)
+        # Prompt-only: determines loss mask boundary (uses only prompt images)
+        prompt_images = _extract_images_from_messages(prompt)
+        prompt_text = self.processor.apply_chat_template(prompt, tokenize=False, add_generation_prompt=True)
+        prompt_inputs = self.processor(
+            text=[prompt_text], images=prompt_images or None, return_tensors="pt", padding=False
+        )
+        prompt_len = prompt_inputs["input_ids"].shape[1]
+
+        # Full sequence (prompt + completion) with all images
+        full_text = self.processor.apply_chat_template(all_messages, tokenize=False, add_generation_prompt=False)
+        full_inputs = self.processor(text=[full_text], images=images, return_tensors="pt", padding=False)
+        input_ids = full_inputs["input_ids"][0].tolist()
+
+        # Build loss mask: False for prompt, True for completion
+        loss_mask = [False] * min(prompt_len, len(input_ids)) + [True] * max(0, len(input_ids) - prompt_len)
+
+        # Append EOS if missing
+        if self.tokenizer.eos_token_id not in input_ids:
+            self.logger.warning("Appending missing EOS token to multimodal sample")
+            input_ids.append(cast(int, self.tokenizer.eos_token_id))
+            loss_mask.append(True)
+
+        # Prepare inputs (shift for next-token prediction)
+        target_ids = input_ids[1:]
+        loss_mask = loss_mask[1:]
+        input_ids = input_ids[:-1]
+
+        if sum(loss_mask[: self.seq_len]) == 0:
+            self.logger.warning(
+                f"Skipping multimodal example {example.get('__index', '')} because no trainable tokens within seq_len"
+            )
+            return None
+
+        # Extract pixel values and image grid info
+        # pixel_values from the processor has no batch dim: [num_patches, patch_dim]
+        pixel_values = full_inputs["pixel_values"]
+        pv_bytes = pixel_values.to(torch.float32).numpy().tobytes()
+        pv_shape = list(pixel_values.shape)
+        image_grid_thw = full_inputs["image_grid_thw"].tolist()
+
+        return {
+            "input_ids": input_ids,
+            "target_ids": target_ids,
+            "loss_mask": loss_mask,
+            "position_ids": list(range(len(input_ids))),
+            "pixel_values": pv_bytes,
+            "pixel_values_shape": pv_shape,
+            "image_grid_thw": image_grid_thw,
+        }
+
+    def _has_images(self, example: dict) -> bool:
+        """Check if an example contains image content."""
+        for msg in self._parse_messages(example.get("prompt", [])) + self._parse_messages(
+            example.get("completion", [])
+        ):
+            content = msg.get("content")
+            if isinstance(content, list):
+                for item in content:
+                    if isinstance(item, dict) and item.get("type") in ("image_url", "image"):
+                        return True
+        return False
+
     def __iter__(self):
         """
         Apply chat template and tokenize a single example in prompt + completion format (https://github.com/huggingface/trl/blob/de27d612b026526ba39b88eee348994d7636e033/trl/trainer/sft_trainer.py#L661)
@@ -327,8 +455,12 @@ class SFTDataset(StatefulIterableDataset):
             # Get example
             example = dataset[(self.step - 1) % self.num_examples]
 
-            # Process example
-            processed_example = self._process(cast(dict, example))
+            # Process example — route multimodal samples through processor path
+            example_dict = cast(dict, example)
+            if self.processor is not None and self._has_images(example_dict):
+                processed_example = self._process_multimodal(example_dict)
+            else:
+                processed_example = self._process(example_dict)
 
             # If processed example is None, skip it (e.g. if tokenized sample exceeds context window)
             if processed_example is None:
@@ -490,6 +622,45 @@ class StackDataset(StatefulIterableDataset):
                     self.bucket_timers[bucket_idx] = self.step
 
 
+class SingleSampleDataset(StatefulIterableDataset):
+    """Wraps a dataset to pad each sample individually. Used for multimodal SFT where packing is not possible."""
+
+    def __init__(self, dataset: StatefulIterableDataset, seq_len: int):
+        self.dataset = dataset
+        self.seq_len = seq_len
+
+    def state_dict(self) -> dict:
+        return {"dataset": self.dataset.state_dict()}
+
+    def load_state_dict(self, state_dict: dict):
+        self.dataset.load_state_dict(state_dict["dataset"])
+
+    def __iter__(self):
+        for sample in self.dataset:
+            seq_len = self.seq_len
+            is_multimodal = sample.get("pixel_values") is not None
+
+            # Skip multimodal samples that exceed seq_len (truncation would break
+            # the alignment between image_pad tokens and pixel_values)
+            if is_multimodal and len(sample["input_ids"]) > seq_len:
+                get_logger().warning(
+                    f"Skipping multimodal SFT sample that exceeds seq_len ({len(sample['input_ids'])} > {seq_len})"
+                )
+                continue
+
+            # Truncate token fields (text-only samples only at this point)
+            for key in ["input_ids", "target_ids", "position_ids", "loss_mask"]:
+                sample[key] = sample[key][:seq_len]
+            # Pad token fields to seq_len
+            pad_len = seq_len - len(sample["input_ids"])
+            if pad_len > 0:
+                sample["input_ids"] = sample["input_ids"] + [0] * pad_len
+                sample["target_ids"] = sample["target_ids"] + [0] * pad_len
+                sample["position_ids"] = sample["position_ids"] + [0] * pad_len
+                sample["loss_mask"] = sample["loss_mask"] + [False] * pad_len
+            yield sample
+
+
 def stack_collate(samples: list[Sample]) -> Batch:
     return {
         "input_ids": torch.tensor(samples[0]["input_ids"], dtype=torch.long, device="cuda"),
@@ -508,6 +679,27 @@ def cat_collate(samples: list[Sample]) -> Batch:
         "loss_mask": torch.stack([torch.tensor(sample["loss_mask"]) for sample in samples], dim=0).bool().to("cuda"),
         "target_ids": torch.stack([torch.tensor(sample["target_ids"]) for sample in samples], dim=0).long().to("cuda"),
     }
+
+
+def single_collate(samples: list[Sample]) -> Batch:
+    """Collate for single-sample batches (multimodal SFT)."""
+    sample = samples[0]
+    batch: Batch = {
+        "input_ids": torch.tensor(sample["input_ids"], dtype=torch.long, device="cuda").unsqueeze(0),
+        "position_ids": torch.tensor(sample["position_ids"], dtype=torch.long, device="cuda").unsqueeze(0),
+        "loss_mask": torch.tensor(sample["loss_mask"], dtype=torch.bool, device="cuda").unsqueeze(0),
+        "target_ids": torch.tensor(sample["target_ids"], dtype=torch.long, device="cuda").unsqueeze(0),
+        "pixel_values": None,
+        "image_grid_thw": None,
+    }
+    if sample.get("pixel_values") is not None:
+        batch["pixel_values"] = (
+            torch.frombuffer(bytearray(sample["pixel_values"]), dtype=torch.float32)
+            .reshape(sample["pixel_values_shape"])
+            .to("cuda")
+        )
+        batch["image_grid_thw"] = torch.tensor(sample["image_grid_thw"], dtype=torch.long, device="cuda")
+    return batch
 
 
 def setup_and_interleave_datasets(
@@ -585,6 +777,7 @@ def setup_dataset(
     *,
     max_epochs: int | None = None,
     raw_dataset: Dataset | None = None,
+    processor=None,
 ) -> StatefulIterableDataset:
     if config.type == "fake":
         return FakeDataset(
@@ -602,13 +795,17 @@ def setup_dataset(
             loss_mask_config=config.loss_mask,
             non_dp_size=non_dp_size,
             max_epochs=max_epochs,
+            processor=processor,
         )
     else:
         raise ValueError(f"Invalid dataset type: {config.type}")
 
 
 def setup_dataloader(dataset: StatefulIterableDataset, config: DataConfig) -> StatefulDataLoader:
-    if config.pack_function == "stack":
+    if config.pack_function == "single":
+        single_dataset = SingleSampleDataset(dataset, config.seq_len)
+        return StatefulDataLoader(single_dataset, batch_size=1, collate_fn=single_collate)
+    elif config.pack_function == "stack":
         stacking_dataset = StackDataset(dataset, config.seq_len * config.micro_batch_size)
         return StatefulDataLoader(stacking_dataset, batch_size=1, collate_fn=stack_collate)
     elif config.pack_function == "cat":

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -27,6 +27,7 @@ from prime_rl.trainer.model import (
     setup_tokenizer,
     setup_model,
 )
+from prime_rl.utils.vlm import is_vlm_model
 from prime_rl.trainer.parallel_dims import get_parallel_dims
 from prime_rl.trainer.perf import get_perf_counter
 from prime_rl.trainer.sft.data import load_sft_dataset, setup_dataloader, setup_dataset
@@ -123,6 +124,14 @@ def train(config: SFTConfig):
     logger.info(f"Initializing tokenizer ({config.tokenizer})")
     tokenizer = setup_tokenizer(config.tokenizer)
 
+    # Load processor for VLM models (needed for multimodal SFT)
+    processor = None
+    if is_vlm_model(config.model.name):
+        from transformers import AutoProcessor
+
+        logger.info("Loading VLM processor for multimodal SFT")
+        processor = AutoProcessor.from_pretrained(config.model.name, trust_remote_code=config.model.trust_remote_code)
+
     # Set up the optimizer
     logger.info(f"Initializing optimizer ({config.optim})")
     optimizer = setup_optimizer(
@@ -141,7 +150,7 @@ def train(config: SFTConfig):
 
     # Set up the dataset and dataloader
     logger.info(f"Initializing data ({config.data})")
-    dataset = setup_dataset(tokenizer, config.data, config.model.cp * config.model.tp)
+    dataset = setup_dataset(tokenizer, config.data, config.model.cp * config.model.tp, processor=processor)
     dataloader = setup_dataloader(dataset, config.data)
     dataiter = iter(dataloader)
 
@@ -194,6 +203,13 @@ def train(config: SFTConfig):
         target_ids = micro_batch["target_ids"].to("cuda")
         loss_mask = micro_batch["loss_mask"].to("cuda")
 
+        # Multimodal fields (None for text-only samples)
+        pixel_values = micro_batch.get("pixel_values")
+        image_grid_thw = micro_batch.get("image_grid_thw")
+        if pixel_values is not None:
+            pixel_values = pixel_values.to("cuda")
+            image_grid_thw = image_grid_thw.to("cuda")
+
         if cp_enabled:
             input_ids, position_ids = setup_cp_params(input_ids, position_ids, cp_rank, cp_size, cp_group)
             target_ids = shard_for_cp(target_ids, cp_rank=cp_rank, cp_world_size=cp_size)
@@ -205,10 +221,23 @@ def train(config: SFTConfig):
             if config.loss_impl == "liger_fused":
                 masked_target_ids = target_ids.clone()
                 masked_target_ids[~loss_mask] = FusedCrossEntropyOutputLinear.IGNORE_INDEX
-                out = forward(model, input_ids, position_ids, labels=masked_target_ids)
+                out = forward(
+                    model,
+                    input_ids,
+                    position_ids,
+                    labels=masked_target_ids,
+                    pixel_values=pixel_values,
+                    image_grid_thw=image_grid_thw,
+                )
                 loss_sum = out["loss"] * token_count
             else:
-                out = forward(model, input_ids, position_ids)
+                out = forward(
+                    model,
+                    input_ids,
+                    position_ids,
+                    pixel_values=pixel_values,
+                    image_grid_thw=image_grid_thw,
+                )
                 logits = out["logits"]
                 B, L, V = logits.shape
                 token_loss = ce_loss(logits.view(-1, V), target_ids.view(-1)).view(B, L)
@@ -244,7 +273,12 @@ def train(config: SFTConfig):
 
     def run_validation(step: int) -> None:
         val_dataset = setup_dataset(
-            tokenizer, config.val.data, config.model.cp * config.model.tp, max_epochs=1, raw_dataset=val_raw_dataset
+            tokenizer,
+            config.val.data,
+            config.model.cp * config.model.tp,
+            max_epochs=1,
+            raw_dataset=val_raw_dataset,
+            processor=processor,
         )
         val_dataloader = setup_dataloader(val_dataset, config.val.data)
 


### PR DESCRIPTION
## Summary
Enable supervised fine-tuning for vision-language models. The SFT pipeline now handles image extraction, processor-based tokenization, and pixel_values flow through training.

### Key changes
- **`trainer/sft/data.py`**: Extend `Sample`/`Batch` with `pixel_values`, `pixel_values_shape`, `image_grid_thw`. Add `_process_multimodal()` using HF processor for tokenization + image preprocessing. Add `SingleSampleDataset` + `single_collate` for multimodal batching (no packing).
- **`trainer/sft/train.py`**: Auto-load processor for VLM models. Pass `pixel_values`/`image_grid_thw` through `compute_loss` to `forward()`.
- **`configs/sft.py`**: Add `pack_function = "single"` option.
- **Example config**: `configs/multimodal/sft_color_codeword.toml`
- **Scripts**: `generate_color_codeword_sft_data.py` (synthetic data), `eval_color_codeword.py` (evaluation)

### Design decisions
- Multimodal samples use `pack_function = "single"` — each sample is its own micro-batch since image tensor sizes vary
- HF processor handles tokenization + image preprocessing together, ensuring image_pad token count matches pixel_values
- Text-only samples in multimodal datasets fall through to the existing `_process()` path unchanged
- Dataset prompt/completion stored as JSON strings for PyArrow compatibility (mixed string/list content types)

## Validation: color-codeword task (Qwen3-VL-4B-Instruct)

100-step SFT on 500 synthetic color→letter mapping examples:
- Training loss: 4.5 → ~0.0
- **Base model accuracy: 68%** (34/50)
- **SFT model accuracy: 86%** (43/50)
- **+18 percentage point improvement**

## Test plan
- [x] All 47 existing VLM + trajectory tests pass
- [x] Data pipeline smoke test: images extracted, pixel_values correct shape
- [x] End-to-end SFT training: 100 steps, loss converges
- [x] Model evaluation: SFT'd model outperforms base on color-codeword (68% → 86%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new multimodal data path and batching mode to the SFT trainer, including image decoding and processor-driven tokenization; issues here could cause silent data/label misalignment or dropped training samples. Core training loop now conditionally feeds `pixel_values`/`image_grid_thw` into model `forward()`, so regressions could affect VLM SFT runs.
> 
> **Overview**
> Enables **multimodal SFT for VLMs** by extending the SFT dataset pipeline to detect image-containing OpenAI-format messages, decode embedded/base64 or `file://` images, and use a HuggingFace processor to produce aligned `input_ids`, `pixel_values`, and `image_grid_thw`.
> 
> Adds a new `pack_function = "single"` mode that pads *each sample independently* (and skips overlong multimodal samples) plus a corresponding `single_collate` that reconstructs `pixel_values` tensors from stored bytes/shape.
> 
> Updates SFT training to auto-load a VLM `AutoProcessor` when `is_vlm_model()` is true and to pass `pixel_values`/`image_grid_thw` through `compute_loss()` into `forward()`. Includes an example VLM SFT config, updated multimodal docs, and scripts to generate/evaluate the color-codeword multimodal SFT dataset.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 392600b3a6ef459b21e894af496bd136d2f27165. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->