### PR TITLE
feat: Vendor VeriHop env and add configs/verihop/rl.toml

### DIFF
--- a/configs/verihop/rl.toml
+++ b/configs/verihop/rl.toml
@@ -1,0 +1,38 @@
+# VeriHop: multi-hop procedural visual QA (see environments/verihop/README.md).
+# The `verihop` package is vendored under environments/verihop and wired in pyproject.toml.
+
+max_steps = 20
+seq_len = 8192
+
+[model]
+name = "Qwen/Qwen3-VL-4B-Instruct"
+
+[wandb]
+project = "verihop"
+name = "verihop-rl"
+
+[orchestrator]
+batch_size = 128
+rollouts_per_example = 8
+
+[orchestrator.sampling]
+max_tokens = 1024
+
+[[orchestrator.env]]
+id = "verihop"
+name = "verihop"
+args = { num_samples = 4096, max_hops = 3, seed = 42, use_tools = false, process_weight = 0.4, outcome_weight = 0.6 }
+
+[trainer]
+
+[trainer.model]
+optimization_dtype = "bfloat16"
+reduce_dtype = "bfloat16"
+
+[trainer.optim]
+lr = 3e-6
+
+[inference]
+
+[inference.model]
+tool_call_parser = "hermes"

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -23,6 +23,8 @@ To install a local environment
 uv pip install -e path/to/env
 ```
 
+The **VeriHop** multimodal multi-hop environment is vendored in this repository at `environments/verihop` and is already a dependency of `prime-rl` (see `configs/verihop/rl.toml`).
+
 To verify your installation
 
 ```bash

--- a/environments/verihop/README.md
+++ b/environments/verihop/README.md
@@ -1,0 +1,44 @@
+# VeriHop
+
+Multi-hop **visual** RLVR tasks with **procedural** scenes, optional **PIL-based tools**
+(`crop_region`, `zoom_center`, `count_color_blobs`), and a **dense** rubric (per-hop +
+boxed outcome).
+
+## Layout
+
+- `verihop.synthesize()` — builds a Hugging Face `Dataset` with `prompt`, `answer`, `info['verihop']`.
+- `VeriHopEnv` — multi-turn chain without tools (image on the first user turn only).
+- `VeriHopToolEnv` — same chain, but the model may call tools between hops; hops advance on a **text-only** assistant turn that includes `<hop_answer>...</hop_answer>`.
+- `VeriHopRubric` — `outcome_weight` on final `\boxed{}` match, `process_weight` on hop answers (+ optional grounding IoU vs metadata).
+
+## Hop format
+
+Each hop should include an answer in `<hop_answer>...</hop_answer>`. The **last** hop must also put the final integer in `\boxed{n}`.
+
+Grounding tags (optional, for process rewards):
+
+`<grounding bbox="x0,y0,x1,y1" desc="..."/>`
+
+Boxes use **pixel coordinates** in the original image space (same as PIL).
+
+## Usage
+
+```python
+from verihop import load_environment
+
+env = load_environment(num_samples=1024, seed=0, use_tools=False)
+```
+
+With tools:
+
+```python
+env = load_environment(num_samples=512, use_tools=True)
+```
+
+## Prime RL
+
+Point your orchestrator env at this package after `uv pip install -e environments/verihop`
+(or publish to the hub). Use `name = "verihop"` / your env id and pass `use_tools` via the
+environment args your runner supports.
+
+See `examples/train_with_prime_rl.py` for a commented template.

--- a/environments/verihop/examples/train_with_prime_rl.py
+++ b/environments/verihop/examples/train_with_prime_rl.py
@@ -1,0 +1,19 @@
+# Template for training VeriHop with Prime RL.
+#
+# 1. Install this env: from repo root, `uv pip install -e environments/verihop`
+# 2. In your Prime RL TOML, register an orchestrator env whose `name` resolves to
+#    `verihop` (or your fork) and pass kwargs such as:
+#    args = { num_samples = 10000, seed = 42, use_tools = false }
+#
+# Example (illustrative only — field names follow your prime-rl version):
+#
+# [[orchestrator.env]]
+# id = "verihop-train"
+# name = "verihop"
+# args = { num_samples = 8192, process_weight = 0.35, outcome_weight = 0.65 }
+
+from verihop import load_environment
+
+if __name__ == "__main__":
+    env = load_environment(num_samples=16, seed=1, use_tools=False)
+    print(env)

--- a/environments/verihop/pyproject.toml
+++ b/environments/verihop/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "verihop"
+description = "VeriHop — modular multi-hop multimodal RLVR with procedural scenes and dense rubrics"
+tags = ["multimodal", "multi-turn", "tools", "train", "eval", "rlvr"]
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "verifiers",
+    "pillow>=11.0.0",
+    "datasets>=3.0.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["verihop"]
+
+[tool.verifiers.eval]
+num_examples = 8
+rollouts_per_example = 1

--- a/environments/verihop/verihop/__init__.py
+++ b/environments/verihop/verihop/__init__.py
@@ -1,0 +1,11 @@
+from .rubrics import VeriHopRubric
+from .synthesizer import synthesize
+from .verihop_env import VeriHopEnv, VeriHopToolEnv, load_environment
+
+__all__ = [
+    "VeriHopEnv",
+    "VeriHopRubric",
+    "VeriHopToolEnv",
+    "load_environment",
+    "synthesize",
+]

--- a/environments/verihop/verihop/rubrics.py
+++ b/environments/verihop/verihop/rubrics.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import verifiers as vf
+from verifiers.utils.data_utils import extract_boxed_answer
+
+from .synthesizer import _iou, parse_grounding_boxes
+
+
+def _assistant_segments(completion: vf.Messages) -> list[str]:
+    parts: list[str] = []
+    for msg in completion:
+        role = getattr(msg, "role", None)
+        if role is None and isinstance(msg, dict):
+            role = msg.get("role")
+        if role != "assistant":
+            continue
+        c = getattr(msg, "content", None) if not isinstance(msg, dict) else msg.get("content")
+        if isinstance(c, str):
+            parts.append(c)
+        elif isinstance(c, list):
+            for block in c:
+                if isinstance(block, dict):
+                    if block.get("type") == "text":
+                        parts.append(str(block.get("text", "")))
+                elif getattr(block, "type", None) == "text":
+                    parts.append(str(getattr(block, "text", "")))
+    return parts
+
+
+def _norm_num(s: str) -> str:
+    m = re.search(r"-?\d+", s)
+    return m.group(0) if m else s.strip().lower()
+
+
+class VeriHopRubric(vf.Rubric):
+    """
+    Combines a strict final outcome (boxed integer) with optional dense per-hop
+    scoring using ``state['verihop_collected']`` and grounding IoU when metadata
+    provides normalized boxes.
+    """
+
+    def __init__(
+        self,
+        process_weight: float = 0.4,
+        outcome_weight: float = 0.6,
+        parser: vf.Parser | None = None,
+        min_grounding_iou: float = 0.15,
+    ):
+        self.process_weight = process_weight
+        self.outcome_weight = outcome_weight
+        self.min_grounding_iou = min_grounding_iou
+        super().__init__(
+            funcs=[self.outcome_reward, self.process_reward],
+            weights=[outcome_weight, process_weight],
+            parser=parser or vf.Parser(),
+        )
+
+    async def outcome_reward(self, completion: vf.Messages, answer: str, **kwargs) -> float:
+        segs = _assistant_segments(completion)
+        if not segs:
+            return 0.0
+        last = segs[-1]
+        got = extract_boxed_answer(last) or ""
+        return 1.0 if _norm_num(got) == _norm_num(str(answer)) else 0.0
+
+    async def process_reward(
+        self,
+        completion: vf.Messages,
+        info: dict[str, Any],
+        state: vf.State,
+        **kwargs,
+    ) -> float:
+        vh = info.get("verihop") or {}
+        hops = vh.get("hops") or []
+        collected = state.get("verihop_collected")
+        if not hops or not collected:
+            return 0.0
+        n = min(len(hops), len(collected))
+        if n == 0:
+            return 0.0
+        segs = _assistant_segments(completion)
+        full_text = "\n".join(segs)
+        scores: list[float] = []
+        align_grounding = len(segs) == len(collected)
+        for i in range(n):
+            gt = _norm_num(hops[i]["ground_truth"])
+            pred_raw = collected[i]
+            pred = _norm_num(pred_raw or "")
+            hop_score = 1.0 if pred == gt else 0.0
+            gmeta = hops[i].get("grounding_norm")
+            if gmeta is not None:
+                text_scope = segs[i] if align_grounding else full_text
+                boxes = parse_grounding_boxes(text_scope)
+                geo = 0.0
+                if boxes:
+                    best = max(_iou(b, gmeta) for b in boxes)
+                    geo = 1.0 if best >= self.min_grounding_iou else best / max(
+                        self.min_grounding_iou, 1e-6
+                    )
+                hop_score = 0.5 * hop_score + 0.5 * geo
+            scores.append(hop_score)
+        return sum(scores) / len(scores)

--- a/environments/verihop/verihop/synthesizer.py
+++ b/environments/verihop/verihop/synthesizer.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import base64
+import random
+import re
+from dataclasses import dataclass
+from io import BytesIO
+from typing import Any, Literal
+
+from datasets import Dataset
+from PIL import Image, ImageDraw
+
+HopType = Literal["perception", "relational", "compose", "tool_hint"]
+
+
+def _append_user_image_png(message: dict[str, Any], pil: Image.Image) -> None:
+    """OpenAI-style image_url part; kept local so VeriHop works with older verifiers pins."""
+    buf = BytesIO()
+    pil.save(buf, format="PNG")
+    b64 = base64.b64encode(buf.getvalue()).decode("ascii")
+    c = message["content"]
+    if isinstance(c, str):
+        message["content"] = [{"type": "text", "text": c}]
+        c = message["content"]
+    assert isinstance(c, list)
+    c.append({"type": "image_url", "image_url": {"url": f"data:image/png;base64,{b64}"}})
+
+
+@dataclass
+class HopSpec:
+    type: HopType
+    question: str
+    ground_truth: str
+    grounding_norm: tuple[float, float, float, float] | None = None
+
+
+def _draw_scene(
+    rng: random.Random,
+    size: tuple[int, int] = (320, 240),
+) -> tuple[Image.Image, dict[str, Any]]:
+    w, h = size
+    img = Image.new("RGB", (w, h), (245, 245, 245))
+    draw = ImageDraw.Draw(img)
+    n_red = rng.randint(1, 5)
+    n_blue = rng.randint(1, 5)
+    circles: list[dict[str, Any]] = []
+    for i in range(n_red + n_blue):
+        cx = rng.randint(30, w - 30)
+        cy = rng.randint(30, h - 30)
+        r = rng.randint(12, 22)
+        color = (220, 60, 60) if i < n_red else (60, 100, 220)
+        draw.ellipse((cx - r, cy - r, cx + r, cy + r), fill=color, outline=(0, 0, 0))
+        circles.append(
+            {
+                "cx": cx,
+                "cy": cy,
+                "r": r,
+                "color": "red" if color == (220, 60, 60) else "blue",
+            }
+        )
+    meta = {"n_red": n_red, "n_blue": n_blue, "circles": circles}
+    return img, meta
+
+
+def _bbox_for_color(circles: list[dict[str, Any]], color: str) -> tuple[float, float, float, float]:
+    subset = [c for c in circles if c["color"] == color]
+    if not subset:
+        return (0.0, 0.0, 0.0, 0.0)
+    xs = [c["cx"] for c in subset]
+    ys = [c["cy"] for c in subset]
+    rs = [c["r"] for c in subset]
+    min_x = min(x - r for x, r in zip(xs, rs))
+    max_x = max(x + r for x, r in zip(xs, rs))
+    min_y = min(y - r for y, r in zip(ys, rs))
+    max_y = max(y + r for y, r in zip(ys, rs))
+    return (float(min_x), float(min_y), float(max_x), float(max_y))
+
+
+def _iou(a: tuple[float, float, float, float], b: tuple[float, float, float, float]) -> float:
+    ax0, ay0, ax1, ay1 = a
+    bx0, by0, bx1, by1 = b
+    ix0, iy0 = max(ax0, bx0), max(ay0, by0)
+    ix1, iy1 = min(ax1, bx1), min(ay1, by1)
+    iw, ih = max(0.0, ix1 - ix0), max(0.0, iy1 - iy0)
+    inter = iw * ih
+    if inter <= 0:
+        return 0.0
+    aa = max(0.0, ax1 - ax0) * max(0.0, ay1 - ay0)
+    ba = max(0.0, bx1 - bx0) * max(0.0, by1 - by0)
+    union = aa + ba - inter
+    return inter / union if union > 0 else 0.0
+
+
+def _build_hops(meta: dict[str, Any]) -> list[HopSpec]:
+    n_red = meta["n_red"]
+    n_blue = meta["n_blue"]
+    bbox_red = _bbox_for_color(meta["circles"], "red")
+    hops: list[HopSpec] = [
+        HopSpec(
+            type="perception",
+            question=(
+                "Hop 1 — perception: How many **red** circles are in the image? "
+                "Reply with your reasoning, a grounding tag for the red region like "
+                '<grounding bbox="x0,y0,x1,y1" desc="red circles"/>, '
+                "and your numeric answer inside <hop_answer></hop_answer>."
+            ),
+            ground_truth=str(n_red),
+            grounding_norm=bbox_red,
+        ),
+        HopSpec(
+            type="perception",
+            question=(
+                "Hop 2 — perception: How many **blue** circles are in the image? "
+                "Include <grounding bbox=\"x0,y0,x1,y1\" desc=\"blue circles\"/> "
+                "and <hop_answer>your count</hop_answer>."
+            ),
+            ground_truth=str(n_blue),
+            grounding_norm=_bbox_for_color(meta["circles"], "blue"),
+        ),
+        HopSpec(
+            type="relational",
+            question=(
+                "Hop 3 — relational: What is the **sum** of the red count and blue count "
+                "from the previous hops? Put only the integer in <hop_answer></hop_answer> "
+                "and the final boxed answer \\boxed{n} on the last line."
+            ),
+            ground_truth=str(n_red + n_blue),
+            grounding_norm=None,
+        ),
+    ]
+    return hops
+
+
+def _image_to_b64_png(img: Image.Image) -> str:
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+def _format_initial_user_text(hops: list[HopSpec], system_hint: str) -> str:
+    return (
+        f"{system_hint}\n\n"
+        "You will answer a chain of visual questions about the **same** image. "
+        "Each hop builds on prior answers; re-ground in the image when needed.\n\n"
+        f"{hops[0].question}"
+    )
+
+
+def synthesize(
+    num_samples: int = 64,
+    image_source: Literal["procedural"] = "procedural",
+    min_hops: int = 3,
+    max_hops: int = 3,
+    seed: int = 0,
+    difficulty: Literal["easy", "medium", "hard"] = "medium",
+) -> Dataset:
+    """
+    Build a VeriHop dataset with procedural scenes and a fixed 3-hop chain (count red,
+    count blue, sum). ``min_hops`` / ``max_hops`` / ``difficulty`` are reserved for
+    future curriculum extensions; currently all samples use three hops.
+    """
+    if image_source != "procedural":
+        raise ValueError("Only image_source='procedural' is implemented in this release.")
+    if min_hops != 3 or max_hops != 3:
+        pass
+
+    rows: list[dict[str, Any]] = []
+    rng = random.Random(seed)
+    hint = {
+        "easy": "Use short reasoning.",
+        "medium": "Think step-by-step briefly.",
+        "hard": "Explain each step carefully before answering.",
+    }[difficulty]
+
+    for i in range(num_samples):
+        img, meta = _draw_scene(rng)
+        hops = _build_hops(meta)
+        user_msg: dict[str, Any] = {"role": "user", "content": []}
+        user_msg["content"] = _format_initial_user_text(hops, hint)
+        _append_user_image_png(user_msg, img)
+        prompt = [user_msg]
+        final = hops[-1].ground_truth
+        info = {
+            "verihop": {
+                "hops": [
+                    {
+                        "type": h.type,
+                        "question": h.question,
+                        "ground_truth": h.ground_truth,
+                        "grounding_norm": h.grounding_norm,
+                    }
+                    for h in hops
+                ],
+                "image_b64": _image_to_b64_png(img),
+                "meta": meta,
+            }
+        }
+        rows.append(
+            {
+                "prompt": prompt,
+                "answer": final,
+                "info": info,
+                "task": "verihop",
+            }
+        )
+
+    return Dataset.from_list(rows)
+
+
+def parse_hop_answer(text: str) -> str | None:
+    m = re.search(r"<hop_answer>\s*(.*?)\s*</hop_answer>", text, re.DOTALL | re.IGNORECASE)
+    if not m:
+        return None
+    return m.group(1).strip()
+
+
+def parse_grounding_boxes(text: str) -> list[tuple[float, float, float, float]]:
+    out: list[tuple[float, float, float, float]] = []
+    for m in re.finditer(
+        r'<grounding[^>]*bbox\s*=\s*["\']([^"\']+)["\']', text, re.IGNORECASE
+    ):
+        raw = m.group(1).strip()
+        parts = re.split(r"[,\s]+", raw)
+        if len(parts) != 4:
+            continue
+        try:
+            nums = tuple(float(x) for x in parts)
+            out.append((nums[0], nums[1], nums[2], nums[3]))
+        except ValueError:
+            continue
+    return out

--- a/environments/verihop/verihop/tools/__init__.py
+++ b/environments/verihop/verihop/tools/__init__.py
@@ -1,0 +1,3 @@
+from .visual_tools import make_visual_tools
+
+__all__ = ["make_visual_tools"]

--- a/environments/verihop/verihop/tools/visual_tools.py
+++ b/environments/verihop/verihop/tools/visual_tools.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import Any
+
+from PIL import Image
+
+
+def crop_region(
+    x0: int,
+    y0: int,
+    x1: int,
+    y1: int,
+    _pil_image: Image.Image | None = None,
+) -> str:
+    """
+    Crop the rollout image to integer pixel bounds (inclusive-exclusive width/height
+    semantics: from (x0,y0) to (x1,y1)). Returns a short text summary; the agent
+    should use this to focus reasoning. ``_pil_image`` is injected by the environment.
+    """
+    if _pil_image is None:
+        return "crop_region: no image available in this rollout."
+    w, h = _pil_image.size
+    x0c = max(0, min(w, min(x0, x1)))
+    x1c = max(0, min(w, max(x0, x1)))
+    y0c = max(0, min(h, min(y0, y1)))
+    y1c = max(0, min(h, max(y0, y1)))
+    if x1c <= x0c or y1c <= y0c:
+        return "crop_region: empty region after clamping."
+    crop = _pil_image.crop((x0c, y0c, x1c, y1c))
+    stat = crop.resize((32, 32)).getcolors(maxcolors=1024)
+    ncolors = len(stat) if stat else 0
+    return (
+        f"crop_region: size=({x1c - x0c}x{y1c - y0c}) "
+        f"approx_distinct_colors={ncolors} (32x32 sample)."
+    )
+
+
+def zoom_center(
+    factor_percent: int = 150,
+    _pil_image: Image.Image | None = None,
+) -> str:
+    """
+    Conceptually zoom the center of the image by ``factor_percent`` (100 = original).
+    Returns a coarse summary of the central patch. ``_pil_image`` is injected.
+    """
+    if _pil_image is None:
+        return "zoom_center: no image available."
+    w, h = _pil_image.size
+    f = max(50, min(300, int(factor_percent))) / 100.0
+    cw, ch = int(w / f), int(h / f)
+    cx, cy = w // 2, h // 2
+    x0 = max(0, cx - cw // 2)
+    y0 = max(0, cy - ch // 2)
+    x1 = min(w, x0 + cw)
+    y1 = min(h, y0 + ch)
+    patch = _pil_image.crop((x0, y0, x1, y1))
+    extrema = patch.getextrema()
+    return f"zoom_center: patch bbox=({x0},{y0},{x1},{y1}) extrema={extrema}"
+
+
+def count_color_blobs(
+    color: str = "red",
+    _pil_image: Image.Image | None = None,
+) -> str:
+    """
+    Very rough blob count hint for red-ish or blue-ish pixels (debug-style heuristic,
+    not ground truth). ``_pil_image`` is injected.
+    """
+    if _pil_image is None:
+        return "count_color_blobs: no image."
+    rgb = _pil_image.convert("RGB")
+    w, h = rgb.size
+    data = list(rgb.getdata())
+    c = color.lower()
+    n = 0
+    for r, g, b in data:
+        if c == "red" and r > g + 40 and r > b + 40:
+            n += 1
+        elif c == "blue" and b > r + 30 and b > g + 20:
+            n += 1
+    ratio = n / max(1, w * h)
+    return f"count_color_blobs: ~{n} {c}-leaning pixels ({ratio:.3%} of image)."
+
+
+def make_visual_tools() -> list[Any]:
+    return [crop_region, zoom_center, count_color_blobs]

--- a/environments/verihop/verihop/verihop_env.py
+++ b/environments/verihop/verihop/verihop_env.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from typing import Any, Callable, cast
+
+import verifiers as vf
+from verifiers.types import AssistantMessage, Messages, State, UserMessage
+from verifiers.utils.message_utils import maybe_normalize_messages
+
+from .rubrics import VeriHopRubric
+from .synthesizer import parse_hop_answer, synthesize
+from .tools.visual_tools import make_visual_tools
+
+
+def _text_from_assistant(msg: Any) -> str:
+    if isinstance(msg, dict):
+        if msg.get("role") != "assistant":
+            return ""
+        c = msg.get("content")
+    else:
+        if getattr(msg, "role", None) != "assistant":
+            return ""
+        c = getattr(msg, "content", None)
+    if isinstance(c, str):
+        return c
+    if isinstance(c, list):
+        chunks: list[str] = []
+        for block in c:
+            if isinstance(block, dict):
+                if block.get("type") == "text":
+                    chunks.append(str(block.get("text", "")))
+            elif getattr(block, "type", None) == "text":
+                chunks.append(str(getattr(block, "text", "")))
+        return "\n".join(chunks)
+    return ""
+
+
+def _last_assistant_text(messages: Messages) -> str:
+    for msg in reversed(messages):
+        role = getattr(msg, "role", None) or (
+            msg.get("role") if isinstance(msg, dict) else None
+        )
+        if role == "assistant":
+            return _text_from_assistant(msg)
+    return ""
+
+
+def _advance_hop(messages: Messages, state: State) -> Messages:
+    text = _last_assistant_text(messages)
+    hop_val = parse_hop_answer(text) or ""
+    cast(list[str], state["verihop_collected"]).append(hop_val)
+    vh = cast(dict[str, Any], state["info"]["verihop"])
+    hops = cast(list[dict[str, Any]], vh["hops"])
+    idx = int(state["verihop_hop_idx"])
+    if idx >= len(hops) - 1:
+        state["final_env_response"] = []
+        if "verihop_all_hops_done" in state:
+            state["verihop_all_hops_done"] = True
+        return []
+    state["verihop_hop_idx"] = idx + 1
+    nxt = hops[idx + 1]["question"]
+    return maybe_normalize_messages(
+        [UserMessage(role="user", content=nxt)], field_name="verihop_followup"
+    )
+
+
+class VeriHopEnv(vf.MultiTurnEnv):
+    """
+    Multi-hop visual QA: the first user turn includes the image; later hops arrive
+    as plain user text. The model must use ``<hop_answer>...</hop_answer>`` each hop
+    and ``\\boxed{}`` on the final hop.
+    """
+
+    def __init__(self, max_turns: int = 16, **kwargs: Any):
+        super().__init__(max_turns=max_turns, **kwargs)
+
+    async def setup_state(self, state: State) -> State:
+        state = await super().setup_state(state)
+        info = state.get("info")
+        if not isinstance(info, dict) or "verihop" not in info:
+            raise ValueError("Dataset row must include info['verihop'] from verihop.synthesize()")
+        state["verihop_collected"] = []
+        state["verihop_hop_idx"] = 0
+        return state
+
+    async def env_response(self, messages: Messages, state: State, **kwargs) -> Messages:
+        return _advance_hop(messages, state)
+
+
+class VeriHopToolEnv(vf.StatefulToolEnv):
+    """
+    Like ``VeriHopEnv`` but allows sandboxed PIL tools between hops. A hop advances
+    when the assistant sends a message **without** tool calls.
+    """
+
+    def __init__(
+        self,
+        tools: list[Callable[..., Any]] | None = None,
+        max_turns: int = 48,
+        **kwargs: Any,
+    ):
+        super().__init__(tools=[], max_turns=max_turns, **kwargs)
+        for t in tools or make_visual_tools():
+            self.add_tool(t, args_to_skip=["_pil_image"])
+
+    async def setup_state(self, state: State) -> State:
+        state = await super().setup_state(state)
+        info = state.get("info")
+        if not isinstance(info, dict) or "verihop" not in info:
+            raise ValueError("Dataset row must include info['verihop']")
+        state["verihop_collected"] = []
+        state["verihop_hop_idx"] = 0
+        state["verihop_all_hops_done"] = False
+        import base64
+        from io import BytesIO
+
+        from PIL import Image
+
+        b64 = cast(dict[str, Any], state["info"]["verihop"]).get("image_b64")
+        if isinstance(b64, str):
+            state["verihop_pil_image"] = Image.open(BytesIO(base64.b64decode(b64)))
+        else:
+            state["verihop_pil_image"] = None
+        return state
+
+    def update_tool_args(
+        self,
+        tool_name: str,
+        tool_args: dict,
+        messages: vf.Messages,
+        state: vf.State,
+        **kwargs,
+    ) -> dict:
+        out = dict(tool_args)
+        img = state.get("verihop_pil_image")
+        if img is not None:
+            out["_pil_image"] = img
+        return out
+
+    async def env_response(self, messages: Messages, state: State, **kwargs) -> Messages:
+        last = messages[-1]
+        if not isinstance(last, AssistantMessage):
+            return []
+        if last.tool_calls:
+            return await super().env_response(messages, state, **kwargs)
+        return _advance_hop(messages, state)
+
+    @vf.stop
+    async def no_tools_called(self, state: State) -> bool:
+        if len(state["trajectory"]) == 0:
+            return False
+        last = state["trajectory"][-1]["completion"][-1]
+        if not isinstance(last, AssistantMessage):
+            return False
+        if last.tool_calls:
+            return False
+        return bool(state.get("verihop_all_hops_done", False))
+
+
+def load_environment(
+    num_samples: int = 5000,
+    max_hops: int = 3,
+    seed: int = 42,
+    use_tools: bool = False,
+    process_weight: float = 0.4,
+    outcome_weight: float = 0.6,
+    **kwargs: Any,
+) -> vf.Environment:
+    dataset = synthesize(
+        num_samples=num_samples,
+        max_hops=max_hops,
+        min_hops=max_hops,
+        seed=seed,
+    )
+    rubric = VeriHopRubric(
+        process_weight=process_weight,
+        outcome_weight=outcome_weight,
+    )
+    cls = VeriHopToolEnv if use_tools else VeriHopEnv
+    return cls(
+        dataset=dataset,
+        rubric=rubric,
+        parser=rubric.parser,
+        max_turns=48 if use_tools else 16,
+        env_id="verihop",
+        **kwargs,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "uvloop>=0.21.0",
     "torchtitan",
     "verifiers",
+    "verihop",
     "dion",
     "tilelang>=0.1.8",
 ]
@@ -103,6 +104,7 @@ override-dependencies = [
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "1960e77" }
+verihop = { path = "environments/verihop", editable = true }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eeb" }
 transformers = { git = "https://github.com/huggingface/transformers.git", rev = "5c1c72b" }

--- a/uv.lock
+++ b/uv.lock
@@ -2451,6 +2451,7 @@ dependencies = [
     { name = "transformers", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "uvloop", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "verifiers", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "verihop", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "vllm", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "wandb", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
@@ -2534,6 +2535,7 @@ requires-dist = [
     { name = "transformers", git = "https://github.com/huggingface/transformers.git?rev=5c1c72b" },
     { name = "uvloop", specifier = ">=0.21.0" },
     { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=1960e77" },
+    { name = "verihop", editable = "environments/verihop" },
     { name = "vllm", specifier = ">=0.17.0" },
     { name = "wandb", specifier = ">=0.24.2" },
     { name = "wiki-search", marker = "extra == 'envs'", index = "https://hub.primeintellect.ai/primeintellect/simple/" },
@@ -3755,6 +3757,23 @@ dependencies = [
     { name = "tenacity", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "textual", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "wget", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+
+[[package]]
+name = "verihop"
+version = "0.1.0"
+source = { editable = "environments/verihop" }
+dependencies = [
+    { name = "datasets", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pillow", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "verifiers", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "datasets", specifier = ">=3.0.0" },
+    { name = "pillow", specifier = ">=11.0.0" },
+    { name = "verifiers" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Vendored `environments/verihop` (editable path dependency) with synthesizer compatible with pinned `verifiers`
- `configs/verihop/rl.toml` for VL training (`Qwen/Qwen3-VL-4B-Instruct`)
- `uv.lock` + short note in `docs/environments.md`

Depends on / pairs with VeriHop landing in `verifiers` or can be used standalone with the vendored package.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new vendored environment package and wires it into `prime-rl` dependencies/lockfile, which can impact installs and runtime environment loading. Core training/orchestrator logic is not modified, but the new env/rubric/tooling introduces new execution paths when used.
> 
> **Overview**
> Adds a new vendored multimodal environment, **VeriHop**, under `environments/verihop`, including a procedural dataset synthesizer, multi-turn env implementations (with optional PIL-based tool calls), and a dense rubric that mixes final boxed-answer correctness with per-hop/grounding-based process rewards.
> 
> Wires `verihop` into the repo as an editable path dependency in `pyproject.toml`/`uv.lock`, adds a ready-to-run Prime RL config at `configs/verihop/rl.toml` (Qwen3-VL), and updates `docs/environments.md` to document the bundled environment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35545ae4c0e488a98cd29ec6439806229c5ee5b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->