### PR TITLE
Add failing test: sync_wait_for_path blocks forever on stopped runs

### DIFF
--- a/tests/unit/utils/test_pathing.py
+++ b/tests/unit/utils/test_pathing.py
@@ -1,6 +1,10 @@
+import asyncio
+import threading
+import time
+
 import pytest
 
-from prime_rl.utils.pathing import validate_output_dir
+from prime_rl.utils.pathing import sync_wait_for_path, validate_output_dir, wait_for_path
 
 
 def test_nonexistent_dir_passes(tmp_path):
@@ -56,3 +60,89 @@ def test_clean_on_nonexistent_dir_is_noop(tmp_path):
     output_dir = tmp_path / "does_not_exist"
     validate_output_dir(output_dir, resuming=False, clean=True)
     assert not output_dir.exists()
+
+
+class TestSyncWaitForPathTimeout:
+    """Tests that sync_wait_for_path blocks forever when a path never appears.
+
+    Reproduces a production issue where the shared trainer gets permanently
+    stuck in pathing.py:106 polling for rollout files from a run that has
+    been stopped. With no timeout parameter, the trainer can never break out
+    of the wait loop to discover new runs.
+
+    See: 4b trainer stuck waiting for step_127 for 4.8 days,
+         35b trainer stuck waiting for step_329 for 3.5 days.
+    """
+
+    def test_sync_wait_blocks_indefinitely_on_missing_path(self, tmp_path):
+        """sync_wait_for_path has no timeout and blocks forever when a path
+        never appears. This reproduces a production issue where the shared
+        trainer gets permanently stuck polling for rollout files from a
+        stopped run (4b stuck 4.8 days on step_127, 35b stuck 3.5 days on
+        step_329)."""
+        missing = tmp_path / "will_never_exist" / "rank_0.bin"
+        returned = threading.Event()
+
+        def target():
+            sync_wait_for_path(missing, interval=1)
+            returned.set()
+
+        t = threading.Thread(target=target, daemon=True)
+        t.start()
+        t.join(timeout=3)
+
+        assert not t.is_alive(), (
+            "sync_wait_for_path should support a timeout parameter so the "
+            "trainer can break out of the poll loop when a run is stopped. "
+            "Currently it blocks indefinitely with no escape."
+        )
+
+    def test_sync_wait_returns_when_path_appears(self, tmp_path):
+        """sync_wait_for_path should return promptly when the path exists."""
+        target_file = tmp_path / "rollouts" / "step_0" / "rank_0.bin"
+
+        def create_after_delay():
+            time.sleep(0.5)
+            target_file.parent.mkdir(parents=True, exist_ok=True)
+            target_file.touch()
+
+        creator = threading.Thread(target=create_after_delay)
+        creator.start()
+
+        sync_wait_for_path(target_file, interval=1)
+        creator.join()
+        assert target_file.exists()
+
+
+class TestAsyncWaitForPathTimeout:
+    """Same issue for the async variant."""
+
+    def test_async_wait_blocks_indefinitely_on_missing_path(self, tmp_path):
+        """wait_for_path has no timeout and blocks forever when a path
+        never appears. Same bug as the sync variant."""
+        missing = tmp_path / "will_never_exist" / "rank_0.bin"
+
+        async def run():
+            await asyncio.wait_for(
+                wait_for_path(missing, interval=1),
+                timeout=3,
+            )
+
+        with pytest.raises(asyncio.TimeoutError):
+            asyncio.run(run())
+
+    def test_async_wait_returns_when_path_appears(self, tmp_path):
+        """wait_for_path should return promptly when the path exists."""
+        target_file = tmp_path / "rollouts" / "step_0" / "rank_0.bin"
+
+        async def run():
+            async def create_after_delay():
+                await asyncio.sleep(0.5)
+                target_file.parent.mkdir(parents=True, exist_ok=True)
+                target_file.touch()
+
+            asyncio.create_task(create_after_delay())
+            await wait_for_path(target_file, interval=1)
+
+        asyncio.run(run())
+        assert target_file.exists()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low code risk since only tests change, but it may intentionally fail CI to highlight a production deadlock until timeout support is implemented.
> 
> **Overview**
> Adds new unit coverage in `tests/unit/utils/test_pathing.py` to **reproduce a production hang** where `sync_wait_for_path` can block forever when rollout files never appear (e.g., stopped runs), by spawning a thread and asserting it returns within a few seconds.
> 
> Also adds async-side tests that demonstrate `wait_for_path` is similarly unbounded (made cancellable via `asyncio.wait_for`) plus happy-path checks that both sync and async helpers return promptly once the file is created.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1b0d3eb40848d3624858f9de5c1ff5e19077841. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->