### PR TITLE
discard rollouts after retry exhaustion

### DIFF
--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -825,6 +825,17 @@ class OrchestratorConfig(BaseConfig):
         ),
     ] = 8
 
+    max_error_reschedule_attempts: Annotated[
+        int,
+        Field(
+            ge=0,
+            description=(
+                "Maximum number of times an errored rollout slot is rescheduled before the scheduler falls back "
+                "to shrinking non-deferred rollout groups."
+            ),
+        ),
+    ] = 3
+
     max_async_level: Annotated[
         int,
         Field(

--- a/src/prime_rl/orchestrator/advantage.py
+++ b/src/prime_rl/orchestrator/advantage.py
@@ -13,15 +13,15 @@ from prime_rl.utils.utils import import_object
 class AdvantageInputs:
     """Inputs for advantage computation."""
 
-    rewards: Float[Tensor, "num_problems rollouts_per_example"]
-    completion_lengths: Int[Tensor, "num_problems rollouts_per_example"]
+    rewards: Float[Tensor, "num_groups group_size"]
+    completion_lengths: Int[Tensor, "num_groups group_size"]
 
 
 @dataclass
 class AdvantageOutputs:
     """Outputs from advantage computation."""
 
-    advantages: Float[Tensor, "num_problems rollouts_per_example"]
+    advantages: Float[Tensor, "num_groups group_size"]
 
 
 AdvantageFn = Callable[..., AdvantageOutputs]
@@ -73,27 +73,37 @@ def setup_advantage_fn(config: AdvantageConfig) -> AdvantageFn:
 def compute_advantages(
     rewards: list[float],
     completion_lengths: list[int],
-    samples_per_problem: int,
+    group_sizes: list[int],
     advantage_config: AdvantageConfig | None,
 ) -> list[float]:
     """
-    Computes advantages from a flattened list of rewards, grouped by problem.
+    Computes advantages from a flattened list of rewards, grouped by completed rollout group.
 
     Args:
-        rewards: Flattened list of rewards where first `samples_per_problem` rewards are for the first problem
+        rewards: Flattened rewards in scheduler-emitted group order.
         completion_lengths: List of completion lengths for each reward
-        samples_per_problem: Number of samples (and thus, rewards) per problem
+        group_sizes: Number of accepted rollouts in each completed group
         advantage_config: Configuration for advantage computation (DefaultAdvantageConfig or CustomAdvantageConfig)
     """
     if not advantage_config:
         return rewards
+    if not rewards:
+        return []
+    if sum(group_sizes) != len(rewards) or len(completion_lengths) != len(rewards):
+        raise ValueError("Rewards, completion_lengths, and group_sizes must describe the same flattened groups")
 
     advantage_fn = setup_advantage_fn(advantage_config)
-
-    inputs = AdvantageInputs(
-        rewards=torch.tensor(rewards).view(-1, samples_per_problem),
-        completion_lengths=torch.tensor(completion_lengths).view(-1, samples_per_problem),
-    )
-
-    result = advantage_fn(inputs)
-    return result.advantages.flatten().tolist()
+    advantages: list[float] = []
+    offset = 0
+    for group_size in group_sizes:
+        if group_size <= 0:
+            continue
+        next_offset = offset + group_size
+        inputs = AdvantageInputs(
+            rewards=torch.tensor(rewards[offset:next_offset]).view(1, group_size),
+            completion_lengths=torch.tensor(completion_lengths[offset:next_offset]).view(1, group_size),
+        )
+        result = advantage_fn(inputs)
+        advantages.extend(result.advantages.flatten().tolist())
+        offset = next_offset
+    return advantages

--- a/src/prime_rl/orchestrator/buffer.py
+++ b/src/prime_rl/orchestrator/buffer.py
@@ -207,7 +207,7 @@ class Buffer:
 
         return sampled_examples
 
-    def update(self, rollouts: list[vf.RolloutOutput]):
+    def update(self, rollouts: list[vf.RolloutOutput], *, allow_curriculum_updates: bool = True):
         """Updates the buffer state with completed rollouts."""
 
         rollouts_by_example = defaultdict(list)
@@ -217,6 +217,12 @@ class Buffer:
         for example_id, example_rollouts in rollouts_by_example.items():
             avg_reward = mean([r["reward"] for r in example_rollouts])
             env_name = example_rollouts[0]["task"]
+
+            if not allow_curriculum_updates:
+                self.num_examples_per_step[env_name]["normal"] += 1
+                self.num_rollouts_per_step[env_name]["normal"] += len(example_rollouts)
+                self.rollout_buffer.extend(example_rollouts)
+                continue
 
             if self.config.easy_threshold is not None and avg_reward >= self.config.easy_threshold:
                 pool = "easy"

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -496,7 +496,9 @@ async def orchestrate(config: OrchestratorConfig):
         # Await train rollouts, process results and write batch to disk to consume by trainer
         await train_task
         generate_completions_time = scheduler.last_batch_generation_time
-        train_rollouts = train_task.result()
+        generated_batch = train_task.result()
+        train_rollouts = generated_batch.rollouts
+        group_sizes = generated_batch.group_sizes
 
         # VLM: offload base64 images to disk immediately to free memory
         if is_vlm:
@@ -519,7 +521,7 @@ async def orchestrate(config: OrchestratorConfig):
         advantages = compute_advantages(
             rewards,
             completion_lens,
-            config.rollouts_per_example,
+            group_sizes,
             config.advantage,
         )
 

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -40,8 +40,38 @@ class GroupState:
 
     example: dict
     rollouts_to_schedule: int
+    target_rollouts: int = 0
     completed_rollouts: list[vf.RolloutOutput] = field(default_factory=list)
     pinned_client: vf.ClientConfig | None = None
+    error_reschedule_attempts: int = 0
+    was_shrunk: bool = False
+
+
+class GeneratedBatch(NamedTuple):
+    rollouts: list[vf.RolloutOutput]
+    group_sizes: list[int]
+
+
+ERROR_FAMILY_CLASSES = (
+    vf.Error,
+    vf.ModelError,
+    vf.ToolError,
+    vf.InfraError,
+    vf.SandboxError,
+)
+ERROR_FAMILY_NAMES = tuple(f"vf.{cls.__name__}" for cls in ERROR_FAMILY_CLASSES)
+
+
+def get_error_family_names(error_name: str | None) -> tuple[str, ...]:
+    if error_name is None:
+        return ()
+    families = ["vf.Error"]
+    error_cls = getattr(vf, error_name, None)
+    if isinstance(error_cls, type):
+        for family_cls in ERROR_FAMILY_CLASSES[1:]:
+            if issubclass(error_cls, family_cls):
+                families.append(f"vf.{family_cls.__name__}")
+    return tuple(families)
 
 
 class Scheduler:
@@ -80,6 +110,7 @@ class Scheduler:
         self.batch_size = config.batch_size
         self.token_batch_size = config.token_batch_size
         self.rollouts_per_example = config.rollouts_per_example
+        self.max_error_reschedule_attempts = config.max_error_reschedule_attempts
         self.max_inflight_rollouts = max_inflight_rollouts
         self.max_async_level = max_async_level
         self.max_off_policy_steps = max_off_policy_steps
@@ -117,6 +148,9 @@ class Scheduler:
         self.empty_rollouts_by_task: dict[str, int] = defaultdict(int)
         self.errored_rollouts_by_task: dict[str, int] = defaultdict(int)
         self.total_rollouts_by_task: dict[str, int] = defaultdict(int)
+        self.completed_groups_by_task: dict[str, int] = defaultdict(int)
+        self.partial_groups_by_task: dict[str, int] = defaultdict(int)
+        self.error_family_counts: Counter[str] = Counter()
         self.last_batch_generation_time = 0.0
 
     @property
@@ -136,10 +170,15 @@ class Scheduler:
             return sum(get_seq_len(rollout) for rollout in rollouts)
         return len(rollouts)
 
-    def finalize_batch_rollouts(self, rollouts: list[vf.RolloutOutput]) -> list[vf.RolloutOutput]:
-        if self.batch_size is None:
-            return rollouts
-        return rollouts[: self.batch_size]
+    def finalize_batch_rollouts(self, rollout_groups: list[list[vf.RolloutOutput]]) -> GeneratedBatch:
+        flat_rollouts: list[vf.RolloutOutput] = []
+        group_sizes: list[int] = []
+        for group_rollouts in rollout_groups:
+            if not group_rollouts:
+                continue
+            flat_rollouts.extend(group_rollouts)
+            group_sizes.append(len(group_rollouts))
+        return GeneratedBatch(rollouts=flat_rollouts, group_sizes=group_sizes)
 
     def set_sampling_args(self, sampling_args: dict) -> None:
         """Update sampling args for future rollout requests."""
@@ -170,17 +209,20 @@ class Scheduler:
         inflight = Counter(self._client_identity(info.client_config) for info in self.inflight_requests.values())
         return min(clients, key=lambda c: inflight[self._client_identity(c)])
 
-    async def drop_group(self, group_id: int) -> int:
-        """Drop a group and cancel any remaining in-flight rollouts for it."""
+    async def _cancel_group_inflight_tasks(self, group_id: int) -> int:
         tasks_to_cancel = []
         for task, info in list(self.inflight_requests.items()):
             if info.group_id != group_id:
                 continue
             self.inflight_requests.pop(task, None)
             tasks_to_cancel.append(task)
-        self.groups.pop(group_id, None)
         await safe_cancel_all(tasks_to_cancel)
         return len(tasks_to_cancel)
+
+    async def drop_group(self, group_id: int) -> int:
+        """Drop a group and cancel any remaining in-flight rollouts for it."""
+        self.groups.pop(group_id, None)
+        return await self._cancel_group_inflight_tasks(group_id)
 
     async def schedule_rollout(self, group_id: int):
         """Asynchronously schedules a rollout request."""
@@ -233,7 +275,11 @@ class Scheduler:
         example = self.buffer.sample_examples(n=1)[0]
         group_id = self.next_group_id
         self.next_group_id += 1
-        self.groups[group_id] = GroupState(example=example, rollouts_to_schedule=self.rollouts_per_example)
+        self.groups[group_id] = GroupState(
+            example=example,
+            rollouts_to_schedule=self.rollouts_per_example,
+            target_rollouts=self.rollouts_per_example,
+        )
         await self.schedule_rollout(group_id=group_id)
         return True
 
@@ -353,7 +399,75 @@ class Scheduler:
         await env_for_task.rubric.score_group(cast(list[vf.State], completed_rollouts))
         return completed_rollouts
 
-    async def generate_batch(self, step: int) -> list[vf.RolloutOutput]:
+    def _record_error_families(self, error_info: dict | None) -> None:
+        if error_info is None:
+            return
+        for family_name in get_error_family_names(cast(str | None, error_info.get("error"))):
+            self.error_family_counts[family_name] += 1
+
+    async def _finalize_group(self, group_id: int) -> GroupState | None:
+        group = self.groups.pop(group_id, None)
+        if group is None:
+            return None
+        removed = await self._cancel_group_inflight_tasks(group_id)
+        self.cancelled_rollouts_count += removed
+        task = cast(str, group.example["task"])
+        self.completed_groups_by_task[task] += 1
+        if group.was_shrunk:
+            self.partial_groups_by_task[task] += 1
+        return group
+
+    async def _handle_errored_rollout(
+        self,
+        group_id: int,
+        group: GroupState,
+        task: str,
+        error_info: dict,
+    ) -> GroupState | None:
+        self.errored_rollouts_by_task[task] += 1
+        self._record_error_families(error_info)
+        error_repr = error_info.get("error_chain_repr", error_info.get("error", "unknown error"))
+        completed = len(group.completed_rollouts)
+        if group.error_reschedule_attempts < self.max_error_reschedule_attempts:
+            group.error_reschedule_attempts += 1
+            group.rollouts_to_schedule += 1
+            self.logger.warning(
+                f"Rollout error in group {group_id} ({task}), re-scheduling "
+                f"({completed}/{group.target_rollouts} complete, error retry "
+                f"{group.error_reschedule_attempts}/{self.max_error_reschedule_attempts}): {error_repr}"
+            )
+            return None
+
+        if self._should_defer_group_scoring(task):
+            self.logger.warning(
+                f"Rollout error in group {group_id} ({task}), retry budget exhausted. "
+                f"Dropping deferred-scoring group ({completed}/{group.target_rollouts} complete): {error_repr}"
+            )
+            removed = await self.drop_group(group_id)
+            self.cancelled_rollouts_count += removed
+            return None
+
+        group.target_rollouts -= 1
+        group.was_shrunk = True
+        if group.target_rollouts <= 0:
+            self.logger.warning(
+                f"Rollout error in group {group_id} ({task}), retry budget exhausted. "
+                f"Dropping group after all rollout slots were lost: {error_repr}"
+            )
+            removed = await self.drop_group(group_id)
+            self.cancelled_rollouts_count += removed
+            return None
+
+        self.logger.warning(
+            f"Rollout error in group {group_id} ({task}), retry budget exhausted. "
+            f"Shrinking group target to {group.target_rollouts} "
+            f"({completed}/{group.target_rollouts} complete): {error_repr}"
+        )
+        if len(group.completed_rollouts) < group.target_rollouts:
+            return None
+        return await self._finalize_group(group_id)
+
+    async def generate_batch(self, step: int) -> GeneratedBatch:
         """Continuously generates a batch of rollouts."""
         self.step = step
 
@@ -370,7 +484,7 @@ class Scheduler:
 
         self.logger.debug("Starting to generate batch rollouts")
 
-        batch_rollouts: list[vf.RolloutOutput] = []
+        batch_rollout_groups: list[list[vf.RolloutOutput]] = []
         batch_progress = 0
         pbar = ProgressTracker(
             total=self.batch_target, desc="Generating rollouts (train)", json_logging=self.json_logging, step=step
@@ -404,31 +518,37 @@ class Scheduler:
 
                     task = rollout_info.task
                     self.total_rollouts_by_task[task] += 1
-                    should_reschedule = False
                     if len(rollout["trajectory"]) == 0:
                         self.empty_rollouts_by_task[task] += 1
-                        should_reschedule = True
+                        group.rollouts_to_schedule += 1
                         self.logger.warning(
                             f"Empty trajectory in group {group_id} ({task}), re-scheduling "
-                            f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete)"
+                            f"({len(group.completed_rollouts)}/{group.target_rollouts} complete)"
                         )
-                    if rollout["error"] is not None:
-                        self.errored_rollouts_by_task[task] += 1
-                        should_reschedule = True
-                        self.logger.warning(
-                            f"Rollout error in group {group_id} ({task}), re-scheduling "
-                            f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete): "
-                            f"{rollout['error']['error_chain_repr']}"
-                        )
-                    if should_reschedule:
-                        group.rollouts_to_schedule += 1
                         continue
 
-                    group.completed_rollouts.append(rollout)
-                    if len(group.completed_rollouts) < self.rollouts_per_example:
-                        continue
-                    completed_rollouts = self.groups.pop(group_id).completed_rollouts
-                    completed_rollouts = await self._score_group_if_deferred(completed_rollouts)
+                    if rollout["error"] is not None:
+                        completed_group = await self._handle_errored_rollout(
+                            group_id=group_id,
+                            group=group,
+                            task=task,
+                            error_info=cast(dict, rollout["error"]),
+                        )
+                        if completed_group is not None:
+                            completed_rollouts = completed_group.completed_rollouts
+                            completed_rollouts = await self._score_group_if_deferred(completed_rollouts)
+                        else:
+                            continue
+
+                    else:
+                        group.completed_rollouts.append(rollout)
+                        if len(group.completed_rollouts) < group.target_rollouts:
+                            continue
+                        completed_group = await self._finalize_group(group_id)
+                        if completed_group is None:
+                            continue
+                        completed_rollouts = completed_group.completed_rollouts
+                        completed_rollouts = await self._score_group_if_deferred(completed_rollouts)
                 except asyncio.CancelledError:
                     if group_id is not None:
                         await self.drop_group(group_id)
@@ -439,20 +559,23 @@ class Scheduler:
                         await self.drop_group(group_id)
                     continue
 
-                self.buffer.update(completed_rollouts)
-                accepted_rollouts = self.buffer.sample_rollouts(n=self.rollouts_per_example)
-
-                batch_rollouts.extend(accepted_rollouts)
+                self.buffer.update(
+                    completed_rollouts,
+                    allow_curriculum_updates=not completed_group.was_shrunk,
+                )
+                accepted_rollouts = self.buffer.sample_rollouts(n=len(completed_rollouts))
+                if accepted_rollouts:
+                    batch_rollout_groups.append(accepted_rollouts)
                 progress_increment = self.get_batch_progress_increment(accepted_rollouts)
                 batch_progress += progress_increment
                 pbar.update(progress_increment)
 
         await self._fill_inflight_requests()
 
-        batch_rollouts = self.finalize_batch_rollouts(batch_rollouts)
+        generated_batch = self.finalize_batch_rollouts(batch_rollout_groups)
         pbar.close()
         self.last_batch_generation_time = time.perf_counter() - batch_start_time
-        return batch_rollouts
+        return generated_batch
 
     async def stop(self) -> None:
         await self.cancel_inflight_rollouts()
@@ -503,12 +626,19 @@ class Scheduler:
             "off_policy_level/all/mean": self.mean_off_policy_level,
             "off_policy_level/all/min": self.min_off_policy_level,
         }
+        total_completed_groups = sum(self.completed_groups_by_task.values())
+        metrics["partial_groups/all"] = sum(self.partial_groups_by_task.values()) / max(total_completed_groups, 1)
+        for family_name in ERROR_FAMILY_NAMES:
+            metrics[f"error/{family_name}"] = self.error_family_counts[family_name] / max(total_rollouts, 1)
         for task, count in self.empty_rollouts_by_task.items():
             task_total = max(self.total_rollouts_by_task[task], 1)
             metrics[f"empty_rollouts/{task}"] = count / task_total
         for task, count in self.errored_rollouts_by_task.items():
             task_total = max(self.total_rollouts_by_task[task], 1)
             metrics[f"errored_rollouts/{task}"] = count / task_total
+        for task, count in self.partial_groups_by_task.items():
+            task_total = max(self.completed_groups_by_task[task], 1)
+            metrics[f"partial_groups/{task}"] = count / task_total
         by_task: dict[str, list[int]] = {}
         for info in self.inflight_requests.values():
             by_task.setdefault(info.task, []).append(info.off_policy_steps)
@@ -520,6 +650,9 @@ class Scheduler:
         self.empty_rollouts_by_task.clear()
         self.errored_rollouts_by_task.clear()
         self.total_rollouts_by_task.clear()
+        self.completed_groups_by_task.clear()
+        self.partial_groups_by_task.clear()
+        self.error_family_counts.clear()
 
         # Add inference pool metrics (e.g. elastic pool server counts)
         metrics.update(self.inference_pool.get_metrics())

--- a/src/prime_rl/orchestrator/trajectories.py
+++ b/src/prime_rl/orchestrator/trajectories.py
@@ -76,7 +76,6 @@ def interleave_rollout(
         )
         return None
 
-    has_error = output["error"] is not None
     # this field should be guaranteed because we set temperature in get_sampling_args
     temperature = output["sampling_args"]["temperature"]
 
@@ -84,10 +83,6 @@ def interleave_rollout(
         """Create a new TrainingSample from a trajectory step."""
         tokens = step["tokens"]
         assert tokens is not None
-        if has_error:
-            completion_mask = [False] * len(tokens["completion_mask"])
-        else:
-            completion_mask = [bool(i) for i in tokens["completion_mask"]]
         completion_ids = list(tokens["completion_ids"])
 
         routed_experts = _align_routed_experts(
@@ -99,7 +94,7 @@ def interleave_rollout(
             prompt_ids=list(tokens["prompt_ids"]),
             prompt_mask=[bool(i) for i in tokens["prompt_mask"]],
             completion_ids=completion_ids,
-            completion_mask=completion_mask,
+            completion_mask=[bool(i) for i in tokens["completion_mask"]],
             completion_logprobs=list(tokens["completion_logprobs"]),
             completion_temperatures=[temperature] * len(completion_ids),
             teacher_logprobs=None,
@@ -122,10 +117,7 @@ def interleave_rollout(
         # Extend with new completion tokens
         completion_ids = tokens["completion_ids"]
         sample.completion_ids.extend(completion_ids)
-        if has_error:
-            sample.completion_mask.extend([False] * len(tokens["completion_mask"]))
-        else:
-            sample.completion_mask.extend(bool(i) for i in tokens["completion_mask"])
+        sample.completion_mask.extend(bool(i) for i in tokens["completion_mask"])
         sample.completion_logprobs.extend(tokens["completion_logprobs"])
         sample.completion_temperatures.extend([temperature] * len(completion_ids))
 

--- a/tests/unit/orchestrator/test_advantage.py
+++ b/tests/unit/orchestrator/test_advantage.py
@@ -1,5 +1,7 @@
+import pytest
 import torch
 
+import prime_rl.orchestrator.advantage as advantage_module
 from prime_rl.configs.orchestrator import CustomAdvantageConfig, DefaultAdvantageConfig
 from prime_rl.orchestrator.advantage import (
     AdvantageInputs,
@@ -39,7 +41,7 @@ def test_compute_advantages_with_config():
     rewards = [1.0, 0.5, 0.8, 0.2, 0.9, 0.1]
     lengths = [10, 12, 8, 15, 11, 9]
 
-    result = compute_advantages(rewards, lengths, samples_per_problem=3, advantage_config=DefaultAdvantageConfig())
+    result = compute_advantages(rewards, lengths, group_sizes=[3, 3], advantage_config=DefaultAdvantageConfig())
 
     assert len(result) == 6
     # First 3 should sum to ~0 (mean subtracted)
@@ -52,10 +54,21 @@ def test_compute_advantages_without_config():
     rewards = [1.0, 0.5, 0.8]
     lengths = [10, 12, 8]
 
-    result = compute_advantages(rewards, lengths, samples_per_problem=3, advantage_config=None)
+    result = compute_advantages(rewards, lengths, group_sizes=[3], advantage_config=None)
 
     # Without config, returns raw rewards
     assert result == rewards
+
+
+def test_compute_advantages_with_variable_group_sizes():
+    rewards = [1.0, 0.5, 0.8, 0.2, 0.9]
+    lengths = [10, 12, 8, 15, 11]
+
+    result = compute_advantages(rewards, lengths, group_sizes=[3, 2], advantage_config=DefaultAdvantageConfig())
+
+    assert len(result) == 5
+    assert abs(sum(result[:3])) < 1e-5
+    assert abs(sum(result[3:])) < 1e-5
 
 
 def test_setup_advantage_fn_with_custom_config():
@@ -79,3 +92,25 @@ def test_setup_advantage_fn_with_custom_config():
 def _dummy_custom_advantage(inputs: AdvantageInputs, scale: float = 1.0) -> AdvantageOutputs:
     """A simple custom advantage for testing."""
     return AdvantageOutputs(advantages=inputs.rewards * scale)
+
+
+def test_compute_advantages_calls_custom_advantage_per_group(monkeypatch):
+    recorded_group_shapes: list[tuple[int, int]] = []
+
+    def recording_advantage(inputs: AdvantageInputs) -> AdvantageOutputs:
+        recorded_group_shapes.append(tuple(inputs.rewards.shape))
+        return AdvantageOutputs(advantages=inputs.rewards)
+
+    monkeypatch.setattr(advantage_module, "import_object", lambda _: recording_advantage)
+
+    result = compute_advantages(
+        rewards=[1.0, 0.5, 0.8, 0.2, 0.9],
+        completion_lengths=[10, 12, 8, 15, 11],
+        group_sizes=[2, 1, 2],
+        advantage_config=CustomAdvantageConfig(
+            import_path="unused.module.path",
+        ),
+    )
+
+    assert result == pytest.approx([1.0, 0.5, 0.8, 0.2, 0.9])
+    assert recorded_group_shapes == [(1, 2), (1, 1), (1, 2)]

--- a/tests/unit/orchestrator/test_buffer.py
+++ b/tests/unit/orchestrator/test_buffer.py
@@ -131,6 +131,25 @@ def test_buffer_no_filtering_by_default(dummy_env_group, make_rollouts):
     assert len(buffer.rollout_buffer) == 10
 
 
+def test_buffer_shrunk_group_skips_curriculum_updates(dummy_env_group, make_rollouts):
+    """Fallback-shrunk groups still train but do not drive pool moves or difficulty filtering."""
+    dataset = dummy_env_group.get_dataset()
+    buffer = Buffer(
+        dataset,
+        dummy_env_group.env_names,
+        BufferConfig(easy_threshold=1.0, hard_threshold=0.0, online_difficulty_filtering=True),
+    )
+    rollouts = make_rollouts(dataset.select(range(1)), rewards=[1.0])
+    example_id = dataset[0]["example_id"]
+
+    buffer.update(rollouts, allow_curriculum_updates=False)
+
+    assert len(buffer.easy_examples) == 0
+    assert len(buffer.hard_examples) == 0
+    assert example_id in buffer.example_buffer["env_a"]
+    assert len(buffer.rollout_buffer) == len(rollouts)
+
+
 def test_buffer_save_load_with_conversion(dummy_env_group, make_rollouts, tmp_path):
     """Easy/hard problems are partially converted to normal on load."""
     dataset = dummy_env_group.get_dataset()

--- a/tests/unit/orchestrator/test_scheduler.py
+++ b/tests/unit/orchestrator/test_scheduler.py
@@ -1,9 +1,10 @@
 import asyncio
+from collections import Counter, defaultdict
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from prime_rl.orchestrator.scheduler import InflightRolloutInfo, Scheduler
+from prime_rl.orchestrator.scheduler import GroupState, InflightRolloutInfo, Scheduler
 from prime_rl.utils.async_utils import safe_cancel
 
 
@@ -13,7 +14,10 @@ def make_scheduler() -> Scheduler:
     scheduler.strict_async_level = False
     scheduler.step = 9
     scheduler.ckpt_step = 7
-    scheduler.config = SimpleNamespace(output_dir=Path("/tmp/prime-rl-test"))
+    scheduler.config = SimpleNamespace(
+        output_dir=Path("/tmp/prime-rl-test"),
+        verification=SimpleNamespace(enabled=True),
+    )
     scheduler.logger = MagicMock()
     scheduler.checkpoint_ready = asyncio.Event()
     scheduler.checkpoint_ready.set()
@@ -24,10 +28,20 @@ def make_scheduler() -> Scheduler:
     scheduler.inflight_requests = {}
     scheduler.groups = {}
     scheduler.max_off_policy_steps = 1
+    scheduler.max_error_reschedule_attempts = 3
+    scheduler.rollouts_per_example = 2
+    scheduler.empty_rollouts_by_task = defaultdict(int)
+    scheduler.errored_rollouts_by_task = defaultdict(int)
+    scheduler.total_rollouts_by_task = defaultdict(int)
+    scheduler.completed_groups_by_task = defaultdict(int)
+    scheduler.partial_groups_by_task = defaultdict(int)
+    scheduler.error_family_counts = Counter()
+    scheduler.deferred_group_scoring_tasks = set()
     scheduler.cancelled_rollouts_count = 0
     scheduler.policy_update_lock = asyncio.Lock()
     scheduler.inflight_policy_update_task = None
     scheduler.update_policy_task = None
+    scheduler.inference_pool = SimpleNamespace(get_metrics=lambda: {})
     return scheduler
 
 
@@ -158,3 +172,137 @@ def test_stop_cancels_inflight_policy_update_task():
         assert scheduler.inflight_policy_update_task is None
 
     asyncio.run(run())
+
+
+def _make_success_rollout(task: str = "env_a", example_id: int = 1) -> dict:
+    return {
+        "task": task,
+        "example_id": example_id,
+        "trajectory": [{"tokens": {}}],
+        "reward": 1.0,
+        "metrics": {},
+        "timing": {"generation_ms": 0.0, "scoring_ms": 0.0},
+        "error": None,
+    }
+
+
+def test_errored_rollout_reschedules_before_retry_budget():
+    async def run() -> None:
+        scheduler = make_scheduler()
+        scheduler.max_error_reschedule_attempts = 2
+        group = GroupState(
+            example={"task": "env_a", "example_id": 1},
+            rollouts_to_schedule=0,
+            target_rollouts=2,
+        )
+
+        await scheduler._handle_errored_rollout(
+            group_id=1,
+            group=group,
+            task="env_a",
+            error_info={"error": "SandboxError", "error_chain_repr": "vf.SandboxError('boom')"},
+        )
+
+        assert group.rollouts_to_schedule == 1
+        assert group.error_reschedule_attempts == 1
+        assert group.target_rollouts == 2
+        assert scheduler.error_family_counts["vf.Error"] == 1
+        assert scheduler.error_family_counts["vf.InfraError"] == 1
+        assert scheduler.error_family_counts["vf.SandboxError"] == 1
+
+    asyncio.run(run())
+
+
+def test_errored_rollout_shrinks_group_after_retry_budget():
+    async def run() -> None:
+        scheduler = make_scheduler()
+        scheduler.max_error_reschedule_attempts = 1
+        group = GroupState(
+            example={"task": "env_a", "example_id": 1},
+            rollouts_to_schedule=0,
+            target_rollouts=2,
+            completed_rollouts=[_make_success_rollout()],
+            error_reschedule_attempts=1,
+        )
+        scheduler.groups = {1: group}
+        client = SimpleNamespace(api_base_url="http://test", extra_headers={})
+        leftover_task = asyncio.create_task(asyncio.sleep(60))
+        scheduler.inflight_requests = {
+            leftover_task: InflightRolloutInfo(off_policy_steps=0, client_config=client, task="env_a", group_id=1)
+        }
+
+        completed_group = await scheduler._handle_errored_rollout(
+            group_id=1,
+            group=group,
+            task="env_a",
+            error_info={"error": "SandboxError", "error_chain_repr": "vf.SandboxError('boom')"},
+        )
+
+        assert completed_group is not None
+        assert completed_group.was_shrunk is True
+        assert completed_group.target_rollouts == 1
+        assert 1 not in scheduler.groups
+        assert scheduler.partial_groups_by_task["env_a"] == 1
+        assert scheduler.completed_groups_by_task["env_a"] == 1
+        assert leftover_task.cancelled()
+
+    asyncio.run(run())
+
+
+def test_errored_rollout_drops_deferred_scoring_group_after_retry_budget():
+    async def run() -> None:
+        scheduler = make_scheduler()
+        scheduler.max_error_reschedule_attempts = 0
+        scheduler.deferred_group_scoring_tasks = {"env_a"}
+        group = GroupState(
+            example={"task": "env_a", "example_id": 1},
+            rollouts_to_schedule=0,
+            target_rollouts=2,
+        )
+        scheduler.groups = {1: group}
+        client = SimpleNamespace(api_base_url="http://test", extra_headers={})
+        leftover_task = asyncio.create_task(asyncio.sleep(60))
+        scheduler.inflight_requests = {
+            leftover_task: InflightRolloutInfo(off_policy_steps=0, client_config=client, task="env_a", group_id=1)
+        }
+
+        completed_group = await scheduler._handle_errored_rollout(
+            group_id=1,
+            group=group,
+            task="env_a",
+            error_info={"error": "SandboxError", "error_chain_repr": "vf.SandboxError('boom')"},
+        )
+
+        assert completed_group is None
+        assert 1 not in scheduler.groups
+        assert scheduler.partial_groups_by_task["env_a"] == 0
+        assert scheduler.completed_groups_by_task["env_a"] == 0
+        assert leftover_task.cancelled()
+
+    asyncio.run(run())
+
+
+def test_get_metrics_reports_partial_groups_and_error_families():
+    scheduler = make_scheduler()
+    scheduler.total_rollouts_by_task["env_a"] = 4
+    scheduler.errored_rollouts_by_task["env_a"] = 2
+    scheduler.completed_groups_by_task["env_a"] = 2
+    scheduler.partial_groups_by_task["env_a"] = 1
+    scheduler.error_family_counts.update(
+        {
+            "vf.Error": 2,
+            "vf.InfraError": 2,
+            "vf.SandboxError": 1,
+        }
+    )
+
+    metrics = scheduler.get_metrics()
+
+    assert metrics["partial_groups/all"] == 0.5
+    assert metrics["partial_groups/env_a"] == 0.5
+    assert metrics["error/vf.Error"] == 0.5
+    assert metrics["error/vf.InfraError"] == 0.5
+    assert metrics["error/vf.SandboxError"] == 0.25
+    assert scheduler.completed_groups_by_task == {}
+    assert scheduler.partial_groups_by_task == {}
+    assert scheduler.error_family_counts == Counter()

--- a/tests/unit/orchestrator/test_trajectories.py
+++ b/tests/unit/orchestrator/test_trajectories.py
@@ -1505,10 +1505,10 @@ def test_interleave_rollout_empty_trajectory():
     assert interleave_rollout(output) is None
 
 
-def test_interleave_rollout_error_masks_all_false():
+def test_interleave_rollout_error_preserves_completion_masks():
     """
-    When rollout output has an error, all completion_mask values should be False
-    across both make_sample (step 0) and extend_sample (step 1).
+    Errored rollouts are filtered in the scheduler, so interleaving should preserve
+    the rollout's native completion_mask values.
     """
     output = vf.RolloutOutput(
         example_id=1,
@@ -1561,9 +1561,8 @@ def test_interleave_rollout_error_masks_all_false():
     assert rollouts is not None
     assert len(rollouts) == 1
     rollout = rollouts[0]
-    # Extension holds so tokens merge, but ALL completion_mask should be False
     assert rollout.completion_ids == [3, 4, 5, 6, 7, 8]
-    assert rollout.completion_mask == [False, False, False, False, False, False]
+    assert rollout.completion_mask == [True, True, False, False, True, True]
     # Logprobs and temperatures still present
     assert rollout.completion_logprobs == [-0.1, -0.2, 0.0, 0.0, -0.3, -0.4]
     assert rollout.completion_temperatures == [0.8] * 6


### PR DESCRIPTION
deprecates dead code of previous mask completion on `vf.Error` logic.

introduces dropping of failing rollouts after configurable amount of rescheduling attempts. proceeds to train on a reduced group.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core rollout scheduling/error-handling and how batches/advantages are constructed, which can affect training throughput and data quality if group accounting is wrong. Adds new fallback paths (group shrinking/dropping and curriculum-skip updates) that need careful validation under error-heavy workloads.
> 
> **Overview**
> **Adds bounded error retry handling for rollouts and makes batching group-aware.** The scheduler now tracks per-example rollout groups with `target_rollouts`, retries errored slots up to `max_error_reschedule_attempts`, then either *shrinks* non-deferred groups (training on the remaining rollouts) or *drops* deferred-scoring groups once the retry budget is exhausted.
> 
> Batch generation now returns a `GeneratedBatch` containing flattened rollouts plus `group_sizes`, and advantage computation is updated to normalize/compute advantages per completed group (supporting variable group sizes). Buffer updates can optionally skip curriculum/difficulty filtering for shrunk groups, and new metrics report partial-group rates and error-family breakdowns.
> 
> Separately, `interleave_rollout` no longer forces `completion_mask=False` on errored rollouts (consistent with scheduler filtering them out), and unit tests are updated/added to cover the new behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 724032e20f78aeebf54199d79899ff4e1941a463. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->