### PR TITLE
fix: scheduler test fixture drift after `enable_policy_updates`

### DIFF
--- a/tests/unit/orchestrator/test_scheduler.py
+++ b/tests/unit/orchestrator/test_scheduler.py
@@ -28,6 +28,7 @@ def make_scheduler() -> Scheduler:
     scheduler.policy_update_lock = asyncio.Lock()
     scheduler.inflight_policy_update_task = None
     scheduler.update_policy_task = None
+    scheduler.enable_policy_updates = True
     return scheduler
 
 


### PR DESCRIPTION
Fix `tests/unit/orchestrator/test_scheduler.py` to initialize `enable_policy_updates` in the `Scheduler.__new__` test fixture. 

This keeps the fixture aligned with the current `Scheduler` state and fixes a hang where `maybe_update_policy()` crashed before the test’s synchronization event was set.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that aligns the `Scheduler.__new__` fixture with current scheduler state to avoid crashes/hangs in async policy-update tests.
> 
> **Overview**
> Fixes test fixture drift in `tests/unit/orchestrator/test_scheduler.py` by initializing `scheduler.enable_policy_updates = True` in `make_scheduler()`.
> 
> This keeps `maybe_update_policy()`-related tests from crashing before their synchronization events are set (avoiding potential hangs) and matches the scheduler’s current expected attributes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79458e12f91a2ddd30576790ea5a83b92e70250f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->