### PR TITLE
chore: add reasoning_parser to GLM-5 config

### DIFF
--- a/configs/glm5_disagg_inference/inference.toml
+++ b/configs/glm5_disagg_inference/inference.toml
@@ -6,6 +6,7 @@ gpu_memory_utilization = 0.85
 [model]
 name = "zai-org/GLM-5-FP8"
 tool_call_parser = "auto"
+reasoning_parser = "glm45"
 
 [deployment]
 type = "disaggregated"


### PR DESCRIPTION
Adds `reasoning_parser = "glm45"` to the GLM-5 inference config.

Without this, vLLM leaves reasoning embedded in the `content` field (with a `</think>` separator). With it, vLLM splits reasoning into `reasoning_content` natively, and verifiers saves it as a separate field in trajectories — needed for correct SFT tokenization.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that affects how GLM-5 responses are parsed (reasoning vs content) during inference; may change downstream outputs/trajectories but not core code paths.
> 
> **Overview**
> Sets `reasoning_parser = "glm45"` in `configs/glm5_disagg_inference/inference.toml` so GLM-5 inference output is parsed with a dedicated reasoning field rather than leaving reasoning embedded in `content`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43d146ae80b7c24e384140cced079bb72d3266c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->