### PR TITLE
fix: sanitize NaN/Inf values in chat completions JSON response

### DIFF
--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -1,3 +1,4 @@
+import math
 from argparse import Namespace
 from http import HTTPStatus
 from typing import Any
@@ -183,6 +184,17 @@ def chat_with_tokens(request: Request) -> OpenAIServingChatWithTokens | None:
     return request.app.state.openai_serving_chat_with_tokens
 
 
+def _sanitize_floats(obj: Any) -> Any:
+    """Replace NaN and Inf float values with None for JSON serialization."""
+    if isinstance(obj, float) and (math.isnan(obj) or math.isinf(obj)):
+        return None
+    if isinstance(obj, dict):
+        return {k: _sanitize_floats(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_sanitize_floats(v) for v in obj]
+    return obj
+
+
 @router.post("/update_weights")
 async def update_weights(request: Request):
     data = await request.json()
@@ -249,7 +261,7 @@ async def _chat_with_tokens(request: ChatCompletionRequestWithTokens, raw_reques
         return JSONResponse(content=generator.model_dump(), status_code=generator.error.code)
 
     elif isinstance(generator, ChatCompletionResponse):
-        return JSONResponse(content=generator.model_dump())
+        return JSONResponse(content=_sanitize_floats(generator.model_dump()))
 
     return StreamingResponse(content=generator, media_type="text/event-stream")
 


### PR DESCRIPTION
## Summary

- Fixes `ValueError: Out of range float values are not JSON compliant: nan` when certain models (e.g. Llama-3.1-8B-Instruct) produce NaN/Inf values in `ChatCompletionResponse`
- Adds a recursive `_sanitize_floats` helper that replaces NaN/Inf float values with `None` (JSON `null`) before passing the response dict to `JSONResponse`
- Applied only at the serialization boundary in the `/v1/chat/completions/tokens` endpoint to keep the fix minimal

Closes #1646

## Test plan

- [ ] Verify the fix by running inference with Llama-3.1-8B-Instruct and confirming the `/v1/chat/completions/tokens` endpoint no longer returns 500 errors
- [ ] Confirm existing unit tests pass (`uv run pytest tests/unit -v -m "not gpu" -q` — 287 passed, 2 pre-existing failures unrelated to this change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is confined to the `/v1/chat/completions/tokens` JSON serialization path and only alters otherwise-non-JSON-compliant `NaN`/`Inf` values to `null` to prevent 500s.
> 
> **Overview**
> Prevents `/v1/chat/completions/tokens` from erroring when models emit non-JSON-compliant float values.
> 
> Adds a recursive `_sanitize_floats` helper and applies it when returning a `ChatCompletionResponse`, converting any `NaN`/`Inf` floats in the response payload to `null` before `JSONResponse` serialization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe91dd9bea1808cd05cdf04705ef7ef99bdcefeb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->