### PR TITLE
fix: prevent NaN loss from stale inference logprobs in async RL

### DIFF
--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -145,7 +145,8 @@ def default_loss_fn(inputs: LossInputs, loss_config: DefaultLossConfig) -> LossO
     else:
         teacher_kl = None
 
-    pg_loss = keep_mask * advantages * importance_ratio
+    zeros = torch.zeros_like(advantages)
+    pg_loss = torch.where(keep_mask, advantages * importance_ratio, zeros)
     kl_loss = loss_mask * log_importance_ratio**2
     loss = (-pg_loss + loss_config.kl_tau * kl_loss).sum()
 

--- a/tests/unit/train/rl/test_loss.py
+++ b/tests/unit/train/rl/test_loss.py
@@ -41,6 +41,7 @@ def test_grpo_loss():
     assert not torch.isnan(loss), f"Loss is NaN from stale logprobs: {loss}"
     assert not torch.isinf(loss), f"Loss is Inf from stale logprobs: {loss}"
 
+
 def test_gspo_loss():
     trainer_logprobs = [torch.randn(40, dtype=torch.float32).cuda(), torch.randn(60, dtype=torch.float32).cuda()]
     inference_logprobs = [torch.randn(40, dtype=torch.float32).cuda(), torch.randn(60, dtype=torch.float32).cuda()]

--- a/tests/unit/train/rl/test_loss.py
+++ b/tests/unit/train/rl/test_loss.py
@@ -26,6 +26,20 @@ def test_grpo_loss():
     )
     assert loss.shape == ()
 
+    # Stale inference logprobs can cause exp(log_importance_ratio) to overflow to Inf.
+    # The IPO mask catches divergent tokens, but mask * Inf = NaN without torch.where.
+    inference_logprobs[0][25] = -100.0
+    loss, _ = compute_loss(
+        trainer_logprobs,
+        inference_logprobs,
+        teacher_logprobs,
+        advantages,
+        loss_mask=loss_mask,
+        loss_fn=setup_loss_fn(DefaultLossConfig()),
+        loss_scale=1.0,
+    )
+    assert not torch.isnan(loss), f"Loss is NaN from stale logprobs: {loss}"
+    assert not torch.isinf(loss), f"Loss is Inf from stale logprobs: {loss}"
 
 def test_gspo_loss():
     trainer_logprobs = [torch.randn(40, dtype=torch.float32).cuda(), torch.randn(60, dtype=torch.float32).cuda()]


### PR DESCRIPTION
## What happened

A shared trainer went into a permanent NaN state, poisoning all subsequent training steps and runs on that cluster. A run got stuck for 12+ hours because inference was serving corrupted LoRA weights.

## Root cause

In async RL, inference logprobs in a training batch can be stale. When `trainer_logprobs - inference_logprobs` is large enough (~89+), `torch.exp()` overflows to Inf. The IPO mask correctly identifies these divergent tokens, but the mask is applied via multiplication:

```python
pg_loss = keep_mask * advantages * importance_ratio
```

When `keep_mask` is False (0) and `importance_ratio` is Inf, `0 * Inf = NaN` in IEEE 754. This NaN propagates through `.sum()` into the loss, then into gradients, then into model weights via `optimizer.step()`, permanently corrupting the LoRA adapter. The corrupted weights get broadcast to inference, breaking all subsequent runs.

## Fix

Replace boolean multiplication with `torch.where` for the pg_loss masking:

```python
pg_loss = torch.where(keep_mask, advantages * importance_ratio, zeros)
```

`torch.where` selects element-wise — masked positions get zero regardless of what the other branch contains. No NaN propagation.

## Test

Extended `test_grpo_loss` with a stale logprob scenario (inference logprob at -100 vs trainer at -1, causing exp(99) overflow). Asserts loss stays finite.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes token-level masking in the RL loss to handle Inf importance ratios safely; a mistake here could alter training dynamics, but the change is small and covered by a targeted regression test.
> 
> **Overview**
> Prevents RL training from entering a NaN/Inf state when stale `inference_logprobs` make `exp(trainer_logprobs - inference_logprobs)` overflow.
> 
> In `default_loss_fn`, replaces boolean-multiply masking (`keep_mask * ...`) with `torch.where(keep_mask, ..., 0)` so masked tokens cannot produce `0 * Inf = NaN`. Adds a unit test case that forces an overflow scenario and asserts the computed loss remains finite.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7ad015fb2cb79aebe52302815a37b4a509f2609. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->