### PR TITLE
fix: ipo loss can produce nan when inference samples very rare token

### DIFF
--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -135,7 +135,10 @@ def default_loss_fn(inputs: LossInputs, loss_config: DefaultLossConfig) -> LossO
     keep_mask = loss_mask & ~is_masked
 
     log_importance_ratio = trainer_logprobs - inference_logprobs
-    importance_ratio = torch.exp(log_importance_ratio)
+    masked_log_importance_ratio = torch.where(
+        keep_mask, log_importance_ratio, torch.finfo(log_importance_ratio.dtype).min
+    )
+    importance_ratio = torch.exp(masked_log_importance_ratio)
     mismatch_kl = importance_ratio - log_importance_ratio - 1
 
     advantages = loss_config.adv_tau * advantages
@@ -145,8 +148,8 @@ def default_loss_fn(inputs: LossInputs, loss_config: DefaultLossConfig) -> LossO
     else:
         teacher_kl = None
 
-    pg_loss = keep_mask * advantages * importance_ratio
-    kl_loss = loss_mask * log_importance_ratio**2
+    pg_loss = advantages * importance_ratio
+    kl_loss = loss_mask * masked_log_importance_ratio**2
     loss = (-pg_loss + loss_config.kl_tau * kl_loss).sum()
 
     metrics = {

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -149,7 +149,7 @@ def default_loss_fn(inputs: LossInputs, loss_config: DefaultLossConfig) -> LossO
         teacher_kl = None
 
     pg_loss = advantages * importance_ratio
-    kl_loss = loss_mask * masked_log_importance_ratio**2
+    kl_loss = loss_mask * log_importance_ratio**2
     loss = (-pg_loss + loss_config.kl_tau * kl_loss).sum()
 
     metrics = {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how masked tokens are handled in the IPO loss by zeroing their `importance_ratio` via a min-log clamp, which can subtly affect gradients and loss magnitude in RL training but is localized to one loss path.
> 
> **Overview**
> Prevents IPO loss NaNs when the reference/inference policy assigns extremely low probability to a sampled token.
> 
> Masked tokens now have their `log_importance_ratio` replaced with the dtype minimum before `exp`, forcing `importance_ratio` to effectively zero and avoiding overflow/NaN. The policy-gradient term is correspondingly simplified to rely on this masked `importance_ratio` rather than multiplying by `keep_mask`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0787f96467c8403340b55bdbdf05232b0f26ab58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->