### PR TITLE
fix: handle eval rollout failures without crashing orchestrator

### DIFF
--- a/src/prime_rl/orchestrator/eval_utils.py
+++ b/src/prime_rl/orchestrator/eval_utils.py
@@ -114,6 +114,10 @@ async def evaluate_env(
     )
     eval_time = time.perf_counter() - eval_start_time
 
+    if not outputs:
+        logger.warning(f"All rollouts failed for {env_name}, skipping metrics")
+        return
+
     rows = []
     for output in outputs:
         rows.append(

--- a/src/prime_rl/orchestrator/vf_utils.py
+++ b/src/prime_rl/orchestrator/vf_utils.py
@@ -10,7 +10,7 @@ from verifiers.envs.environment import EnvClient
 from verifiers.utils.worker_utils import get_free_port_pair
 from verifiers.workers import ZMQEnvClient, ZMQEnvServer
 
-from prime_rl.utils.logger import InterceptHandler, ProgressTracker
+from prime_rl.utils.logger import InterceptHandler, ProgressTracker, get_logger
 
 DEFAULT_RETRIES = 0
 REQUIRED_STATE_COLUMNS = ["trajectory", "sampling_args"]
@@ -163,29 +163,32 @@ async def generate(
     total_rollouts = len(examples) * rollouts_per_example
     pbar = ProgressTracker(total=total_rollouts, desc=pbar_description)
 
-    async def run_group_with_progress(example):
-        client = await get_client()
-        result = await run_group(
-            env=env,
-            client=client,
-            model_name=model_name,
-            example=example,
-            rollouts_per_example=rollouts_per_example,
-            max_retries=max_retries,
-            state_columns=state_columns,
-            sampling_args=sampling_args,
-        )
-        pbar.update(rollouts_per_example)
-        return result
+    async def run_group_with_progress(example) -> list[vf.RolloutOutput] | None:
+        try:
+            client = await get_client()
+            result = await run_group(
+                env=env,
+                client=client,
+                model_name=model_name,
+                example=example,
+                rollouts_per_example=rollouts_per_example,
+                max_retries=max_retries,
+                state_columns=state_columns,
+                sampling_args=sampling_args,
+            )
+            pbar.update(rollouts_per_example)
+            return result
+        except Exception as e:
+            get_logger().warning(f"Group failed: {e}")
+            pbar.update(rollouts_per_example)
+            return None
 
     try:
-        group_outputs_list: list[list[vf.RolloutOutput]] = await asyncio.gather(
-            *[run_group_with_progress(example) for example in examples]
-        )
+        group_outputs_list = await asyncio.gather(*[run_group_with_progress(example) for example in examples])
     finally:
         pbar.close()
 
-    return [output for group_outputs in group_outputs_list for output in group_outputs]
+    return [output for group_outputs in group_outputs_list if group_outputs is not None for output in group_outputs]
 
 
 async def evaluate(


### PR DESCRIPTION
## Summary
- Catch per-group rollout failures in `generate()` so individual crashes don't take down the entire eval — metrics are computed on whatever succeeded
- Early return in `evaluate_env` when all rollouts fail, avoiding empty DataFrame errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes async eval error-handling to drop failed rollout groups and skip metrics when no outputs, which could alter reported eval metrics and potentially mask systemic failures if logging is missed.
> 
> **Overview**
> Improves eval robustness so partial rollout/group failures no longer crash the orchestrator.
> 
> `vf_utils.generate()` now catches exceptions per group, logs a warning, and continues by filtering out failed groups before flattening outputs. `evaluate_env()` now early-returns (with a warning) when *all* rollouts fail, avoiding downstream metric/DataFrame errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75eec118520ce7c60aa9815d5fc31071938f28bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->