### PR TITLE
fix: respect skip_scheduler and skip_progress flags in RL trainer checkpoint loading

### DIFF
--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -195,7 +195,8 @@ def train(config: TrainerConfig):
         )
         logger.info(f"Resuming training from checkpoint step {checkpoint_step}")
         if config.ckpt.skip_scheduler:
-            scheduler = setup_scheduler(optimizer, config.scheduler, config.max_steps, config.optim.lr)
+            remaining_steps = config.max_steps - checkpoint_step if config.max_steps is not None else config.max_steps
+            scheduler = setup_scheduler(optimizer, config.scheduler, remaining_steps, config.optim.lr)
 
     logger.info(
         f"Starting from step {progress.step} (total_tokens={progress.total_tokens}, total_samples={progress.total_samples})"

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -195,8 +195,9 @@ def train(config: TrainerConfig):
         )
         logger.info(f"Resuming training from checkpoint step {checkpoint_step}")
         if config.ckpt.skip_scheduler:
-            remaining_steps = config.max_steps - checkpoint_step if config.max_steps is not None else config.max_steps
-            scheduler = setup_scheduler(optimizer, config.scheduler, remaining_steps, config.optim.lr)
+            scheduler = setup_scheduler(
+                optimizer, config.scheduler, config.max_steps - checkpoint_step, config.optim.lr
+            )
 
     logger.info(
         f"Starting from step {progress.step} (total_tokens={progress.total_tokens}, total_samples={progress.total_samples})"

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -186,8 +186,16 @@ def train(config: TrainerConfig):
     # Optionally, resume training from a checkpoint
     progress = Progress()
     if checkpoint_step is not None:
-        ckpt_manager.load(checkpoint_step, model, [optimizer], scheduler, progress)
+        ckpt_manager.load(
+            checkpoint_step,
+            model,
+            [optimizer],
+            scheduler if not config.ckpt.skip_scheduler else None,
+            progress if not config.ckpt.skip_progress else None,
+        )
         logger.info(f"Resuming training from checkpoint step {checkpoint_step}")
+        if config.ckpt.skip_scheduler:
+            scheduler = setup_scheduler(optimizer, config.scheduler, config.max_steps, config.optim.lr)
 
     logger.info(
         f"Starting from step {progress.step} (total_tokens={progress.total_tokens}, total_samples={progress.total_samples})"


### PR DESCRIPTION
## Summary

The RL trainer ignores `config.ckpt.skip_scheduler` and `config.ckpt.skip_progress` flags when loading from a checkpoint, while the SFT trainer correctly respects them.

**RL trainer (before this fix):**
```python
ckpt_manager.load(checkpoint_step, model, [optimizer], scheduler, progress)
```

**SFT trainer (correct behavior):**
```python
ckpt_manager.load(
    checkpoint_step,
    model,
    [optimizer],
    scheduler if not config.ckpt.skip_scheduler else None,
    progress if not config.ckpt.skip_progress else None,
    dataloader=dataloader if not config.ckpt.skip_dataloader else None,
)
```

## Impact

When resuming RL training from a checkpoint with `skip_scheduler = true`, the scheduler state is still loaded from the checkpoint, making it impossible to reset the learning rate schedule. Similarly, `skip_progress = true` has no effect — step counters and token counts are always restored.

This fix aligns the RL trainer's checkpoint loading with the SFT trainer. When `skip_scheduler` is set, the scheduler is also re-initialized from scratch (matching the SFT trainer's behavior).

Note: `skip_dataloader` is not applicable to the RL trainer since its dataloader is created after checkpoint loading.

## Test plan

- [x] `ruff check` and `ruff format` pass
- [x] `pytest tests/unit -m "not gpu"` — 287 passed (2 pre-existing failures in unrelated `test_fused_lm_head` tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes RL checkpoint resume behavior by conditionally skipping scheduler/progress state restoration and potentially reinitializing the LR schedule, which can affect training dynamics when resuming runs.
> 
> **Overview**
> The RL trainer now respects `config.ckpt.skip_scheduler` and `config.ckpt.skip_progress` when resuming from a checkpoint by passing `None` for those components during `ckpt_manager.load`.
> 
> When `skip_scheduler` is set, the scheduler is re-created after loading so resumed runs start with a fresh LR schedule rather than restoring the checkpointed scheduler state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a190b60bd4cbf7b3fed577c32b84cd3cb523dbf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->