### PR TITLE
feat: add NemotronH models to tool call parser map

### DIFF
--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -117,6 +117,9 @@ MODEL_TOOL_CALL_PARSER: dict[str, str] = {
     "Qwen/Qwen3.5-122B-A10B-FP8": "qwen3_coder",
     "Qwen/Qwen3.5-397B-A17B": "qwen3_coder",
     "Qwen/Qwen3.5-397B-A17B-FP8": "qwen3_coder",
+    # NemotronH
+    "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16": "qwen3_coder",
+    "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16": "qwen3_coder",
 }
 
 


### PR DESCRIPTION
## Summary
- Add `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16` and `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16` to `MODEL_TOOL_CALL_PARSER` with `qwen3_coder` parser

## Test plan
- [ ] Verify inference server starts with NemotronH model and resolves tool call parser correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to adding two model-name mappings, affecting only tool parser auto-resolution for those specific models.
> 
> **Overview**
> Adds two NVIDIA NemotronH model identifiers to `MODEL_TOOL_CALL_PARSER` so `tool_call_parser="auto"` resolves to `qwen3_coder` for `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16` and `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea58a8dcfacada9910c5e4562623deee9faa713e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->