### PR TITLE
Fix mamba-ssm Docker build failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,7 @@ flash-linear-attention = { git = "https://github.com/fla-org/flash-linear-attent
 [tool.uv.extra-build-dependencies]
 flash-attn = [{ requirement = "torch", match-runtime = true }]
 flash-attn-3 = [{ requirement = "torch", match-runtime = true }]
+mamba-ssm = [{ requirement = "torch", match-runtime = true }]
 
 [tool.uv.extra-build-variables]
 flash-attn = { FLASH_ATTENTION_SKIP_CUDA_BUILD = "TRUE" }


### PR DESCRIPTION
uv was resolving CPU-only torch for mamba-ssm's build environment, causing the build to fail with NameError: bare_metal_version is not defined.

- Added mamba-ssm to [tool.uv.extra-build-dependencies] with match-runtime = true so the CUDA torch from the pytorch-cu128 index is used during compilation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts uv build configuration in `pyproject.toml` to force `mamba-ssm` to use the runtime `torch` during compilation.
> 
> **Overview**
> Fixes a Docker build failure by updating `pyproject.toml` so `uv` treats `mamba-ssm` like other CUDA-compiled deps and installs `torch` (with `match-runtime = true`) into its build environment.
> 
> This prevents `uv` from resolving a CPU-only Torch during `mamba-ssm` compilation when the runtime Torch is sourced from the CUDA index.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 811669f04392305b7688ae52f611b4f54d40e012. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->