### PR TITLE
fix: terminate process on fatal orchestrator error

### DIFF
--- a/src/prime_rl/utils/utils.py
+++ b/src/prime_rl/utils/utils.py
@@ -130,7 +130,7 @@ def clean_exit(func: Callable) -> Callable:
                 ret = await func(*args, **kwargs)
                 wandb.finish()
                 return ret
-            except Exception as e:
+            except Exception:
                 get_logger().opt(exception=True).error(f"Fatal error in {func.__name__}")
                 wandb.finish(exit_code=1)
                 # sys.exit raises SystemExit so the finally block still runs.
@@ -150,7 +150,7 @@ def clean_exit(func: Callable) -> Callable:
                 ret = func(*args, **kwargs)
                 wandb.finish()
                 return ret
-            except Exception as e:
+            except Exception:
                 get_logger().opt(exception=True).error(f"Fatal error in {func.__name__}")
                 wandb.finish(exit_code=1)
                 # sys.exit raises SystemExit so the finally block still runs.

--- a/src/prime_rl/utils/utils.py
+++ b/src/prime_rl/utils/utils.py
@@ -3,6 +3,7 @@ import functools
 import importlib
 import os
 import subprocess
+import sys
 from collections import defaultdict
 from contextlib import contextmanager
 from pathlib import Path
@@ -132,7 +133,10 @@ def clean_exit(func: Callable) -> Callable:
             except Exception as e:
                 get_logger().opt(exception=True).error(f"Fatal error in {func.__name__}")
                 wandb.finish(exit_code=1)
-                raise e
+                # sys.exit raises SystemExit so the finally block still runs.
+                # raise alone doesn't terminate the process in an async context —
+                # the event loop swallows it and the process hangs indefinitely.
+                sys.exit(1)
             finally:
                 if dist.is_initialized():
                     dist.destroy_process_group()
@@ -149,7 +153,8 @@ def clean_exit(func: Callable) -> Callable:
             except Exception as e:
                 get_logger().opt(exception=True).error(f"Fatal error in {func.__name__}")
                 wandb.finish(exit_code=1)
-                raise e
+                # sys.exit raises SystemExit so the finally block still runs.
+                sys.exit(1)
             finally:
                 if dist.is_initialized():
                     dist.destroy_process_group()


### PR DESCRIPTION
Saw this on hosted training on the platform - a run was stuck in RUNNING but showing the error: `ValueError: dataset is not set` leading to an orphan run which was never cleaned up.

- Replace raise with sys.exit(1) in the clean_exit decorator
- In async context, re-raising an exception does not kill the process - the event loop swallows it and the process hangs forever
- sys.exit raises SystemExit so the finally block still runs and cleans up the distributed process group


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `clean_exit` error path to call `sys.exit(1)` instead of re-raising, which affects how orchestrator/trainer processes terminate and could cause earlier-than-expected shutdown if exceptions were previously handled upstream.
> 
> **Overview**
> Ensures processes terminate on fatal exceptions wrapped by `clean_exit` by replacing exception re-raises with `sys.exit(1)` and importing `sys`.
> 
> This applies to both async and sync wrappers, while preserving cleanup behavior (`wandb.finish` and `torch.distributed` process group teardown) in the `finally` block to avoid hung runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 911c935efa7f2dabbcaca11122dfd4a3cf1d3b04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->