### PR TITLE
Revert exclude none

### DIFF
--- a/src/prime_rl/entrypoints/inference.py
+++ b/src/prime_rl/entrypoints/inference.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import tomli_w
 
 from prime_rl.configs.inference import InferenceConfig
-from prime_rl.utils.config import cli, none_to_none_str
+from prime_rl.utils.config import cli
 from prime_rl.utils.logger import setup_logger
 from prime_rl.utils.pathing import get_config_dir
 
@@ -18,7 +18,7 @@ def write_config(config: InferenceConfig, output_dir: Path, exclude: set[str] | 
     output_dir.mkdir(parents=True, exist_ok=True)
     config_path = output_dir / INFERENCE_TOML
     with open(config_path, "wb") as f:
-        tomli_w.dump(none_to_none_str(config.model_dump(exclude=exclude, mode="json")), f)
+        tomli_w.dump(config.model_dump(exclude=exclude, exclude_none=True, mode="json"), f)
     return config_path
 
 

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -12,7 +12,7 @@ import pynvml
 import tomli_w
 
 from prime_rl.configs.rl import RLConfig
-from prime_rl.utils.config import cli, none_to_none_str
+from prime_rl.utils.config import cli
 from prime_rl.utils.logger import setup_logger
 from prime_rl.utils.pathing import validate_output_dir
 from prime_rl.utils.process import cleanup_processes, cleanup_threads, monitor_process
@@ -42,7 +42,7 @@ def get_physical_gpu_ids() -> list[int]:
 def write_config(config: RLConfig, output_dir: Path, exclude: set[str] | None = None) -> None:
     """Write resolved config to disk, excluding launcher-only fields."""
     output_dir.mkdir(parents=True, exist_ok=True)
-    config_dict = none_to_none_str(config.model_dump(exclude=exclude, mode="json"))
+    config_dict = config.model_dump(exclude=exclude, exclude_none=True, mode="json")
     with open(output_dir / RL_TOML, "wb") as f:
         tomli_w.dump(config_dict, f)
 
@@ -52,19 +52,19 @@ def write_subconfigs(config: RLConfig, output_dir: Path) -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
 
     with open(output_dir / TRAINER_TOML, "wb") as f:
-        tomli_w.dump(none_to_none_str(config.trainer.model_dump(mode="json")), f)
+        tomli_w.dump(config.trainer.model_dump(exclude_none=True, mode="json"), f)
 
     with open(output_dir / ORCHESTRATOR_TOML, "wb") as f:
-        tomli_w.dump(none_to_none_str(config.orchestrator.model_dump(mode="json")), f)
+        tomli_w.dump(config.orchestrator.model_dump(exclude_none=True, mode="json"), f)
 
     if config.inference is not None:
         with open(output_dir / INFERENCE_TOML, "wb") as f:
-            tomli_w.dump(none_to_none_str(config.inference.model_dump(mode="json")), f)
+            tomli_w.dump(config.inference.model_dump(exclude_none=True, mode="json"), f)
 
     teacher_inference = getattr(config, "teacher_inference", None)
     if teacher_inference is not None:
         with open(output_dir / TEACHER_INFERENCE_TOML, "wb") as f:
-            tomli_w.dump(none_to_none_str(teacher_inference.model_dump(mode="json")), f)
+            tomli_w.dump(teacher_inference.model_dump(exclude_none=True, mode="json"), f)
 
 
 def check_gpus_available(gpu_ids: list[int]) -> None:

--- a/src/prime_rl/entrypoints/sft.py
+++ b/src/prime_rl/entrypoints/sft.py
@@ -9,7 +9,7 @@ from threading import Event, Thread
 import tomli_w
 
 from prime_rl.configs.sft import SFTConfig
-from prime_rl.utils.config import cli, none_to_none_str
+from prime_rl.utils.config import cli
 from prime_rl.utils.logger import setup_logger
 from prime_rl.utils.pathing import get_config_dir, get_log_dir, validate_output_dir
 from prime_rl.utils.process import cleanup_processes, cleanup_threads, monitor_process
@@ -22,7 +22,7 @@ SFT_SBATCH = "sft.sbatch"
 def write_config(config: SFTConfig, config_path: Path, exclude: set[str] | None = None) -> None:
     """Write resolved config to disk, excluding launcher-only fields."""
     config_path.parent.mkdir(parents=True, exist_ok=True)
-    config_dict = none_to_none_str(config.model_dump(exclude=exclude, mode="json"))
+    config_dict = config.model_dump(exclude=exclude, exclude_none=True, mode="json")
     with open(config_path, "wb") as f:
         tomli_w.dump(config_dict, f)
 

--- a/src/prime_rl/utils/config.py
+++ b/src/prime_rl/utils/config.py
@@ -4,6 +4,7 @@ from pydantic_config import cli  # noqa: F401
 
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 def _convert_none(value):
     """Recursively convert None to ``"None"`` strings for TOML serialization."""
     if value is None:
@@ -15,13 +16,23 @@ def _convert_none(value):
     return value
 
 
+=======
+>>>>>>> parent of 4f612601f (Fix/none in list (#2094))
 def none_to_none_str(data: dict) -> dict:
     """Convert None values to ``"None"`` strings so they survive TOML serialization.
 
     TOML has no null type, so we use the ``"None"`` string convention which
     ``BaseConfig._none_str_to_none`` converts back to ``None`` on load.
     """
-    return _convert_none(data)
+    out = {}
+    for key, value in data.items():
+        if value is None:
+            out[key] = "None"
+        elif isinstance(value, dict):
+            out[key] = none_to_none_str(value)
+        else:
+            out[key] = value
+    return out
 
 
 =======

--- a/src/prime_rl/utils/config.py
+++ b/src/prime_rl/utils/config.py
@@ -3,40 +3,6 @@ from pydantic_config import BaseConfig as BaseConfig  # noqa: F401
 from pydantic_config import cli  # noqa: F401
 
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-def _convert_none(value):
-    """Recursively convert None to ``"None"`` strings for TOML serialization."""
-    if value is None:
-        return "None"
-    if isinstance(value, dict):
-        return {k: _convert_none(v) for k, v in value.items()}
-    if isinstance(value, list):
-        return [_convert_none(item) for item in value]
-    return value
-
-
-=======
->>>>>>> parent of 4f612601f (Fix/none in list (#2094))
-def none_to_none_str(data: dict) -> dict:
-    """Convert None values to ``"None"`` strings so they survive TOML serialization.
-
-    TOML has no null type, so we use the ``"None"`` string convention which
-    ``BaseConfig._none_str_to_none`` converts back to ``None`` on load.
-    """
-    out = {}
-    for key, value in data.items():
-        if value is None:
-            out[key] = "None"
-        elif isinstance(value, dict):
-            out[key] = none_to_none_str(value)
-        else:
-            out[key] = value
-    return out
-
-
-=======
->>>>>>> parent of a25b3e7a1 (Enable none in config (#2093))
 def get_all_fields(model: BaseModel | type) -> list[str]:
     if isinstance(model, BaseModel):
         model_cls = model.__class__

--- a/src/prime_rl/utils/config.py
+++ b/src/prime_rl/utils/config.py
@@ -3,6 +3,7 @@ from pydantic_config import BaseConfig as BaseConfig  # noqa: F401
 from pydantic_config import cli  # noqa: F401
 
 
+<<<<<<< HEAD
 def _convert_none(value):
     """Recursively convert None to ``"None"`` strings for TOML serialization."""
     if value is None:
@@ -23,6 +24,8 @@ def none_to_none_str(data: dict) -> dict:
     return _convert_none(data)
 
 
+=======
+>>>>>>> parent of a25b3e7a1 (Enable none in config (#2093))
 def get_all_fields(model: BaseModel | type) -> list[str]:
     if isinstance(model, BaseModel):
         model_cls = model.__class__


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how RL/SFT/Inference launcher configs are serialized to TOML by dropping the prior "None" string convention and excluding `None` values entirely, which may affect downstream config loading or expectations in existing runs.
> 
> **Overview**
> Updates the RL, SFT, and Inference entrypoints to write TOML configs using `model_dump(..., exclude_none=True)` instead of converting `None` to the string `"None"`.
> 
> Removes the `none_to_none_str` helper from `utils/config.py`, meaning `None` fields are no longer preserved through TOML serialization and will be omitted from written config files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab60ed130e054be453ae82ebe0c91638b30ef2ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->