### PR TITLE
Feat: skip master weights gather

### DIFF
--- a/src/prime_rl/configs/trainer.py
+++ b/src/prime_rl/configs/trainer.py
@@ -474,6 +474,13 @@ class CheckpointConfig(BaseConfig):
 
     weights: WeightCheckpointConfig | None = WeightCheckpointConfig()
 
+    skip_gather_master_weights: Annotated[
+        bool,
+        Field(
+            description="When true, skip gathering and saving HF-compatible weight checkpoints. Useful for large models where the gather is expensive and only DCP checkpoints are needed.",
+        ),
+    ] = False
+
     weights_only: Annotated[
         bool,
         Field(

--- a/src/prime_rl/entrypoints/inference.py
+++ b/src/prime_rl/entrypoints/inference.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import tomli_w
 
 from prime_rl.configs.inference import InferenceConfig
-from prime_rl.utils.config import cli, none_to_none_str
+from prime_rl.utils.config import cli
 from prime_rl.utils.logger import setup_logger
 from prime_rl.utils.pathing import get_config_dir
 
@@ -18,7 +18,7 @@ def write_config(config: InferenceConfig, output_dir: Path, exclude: set[str] | 
     output_dir.mkdir(parents=True, exist_ok=True)
     config_path = output_dir / INFERENCE_TOML
     with open(config_path, "wb") as f:
-        tomli_w.dump(none_to_none_str(config.model_dump(exclude=exclude, mode="json")), f)
+        tomli_w.dump(config.model_dump(exclude=exclude, exclude_none=True, mode="json"), f)
     return config_path
 
 

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -12,7 +12,7 @@ import pynvml
 import tomli_w
 
 from prime_rl.configs.rl import RLConfig
-from prime_rl.utils.config import cli, none_to_none_str
+from prime_rl.utils.config import cli
 from prime_rl.utils.logger import setup_logger
 from prime_rl.utils.pathing import validate_output_dir
 from prime_rl.utils.process import cleanup_processes, cleanup_threads, monitor_process
@@ -42,7 +42,7 @@ def get_physical_gpu_ids() -> list[int]:
 def write_config(config: RLConfig, output_dir: Path, exclude: set[str] | None = None) -> None:
     """Write resolved config to disk, excluding launcher-only fields."""
     output_dir.mkdir(parents=True, exist_ok=True)
-    config_dict = none_to_none_str(config.model_dump(exclude=exclude, mode="json"))
+    config_dict = config.model_dump(exclude=exclude, exclude_none=True, mode="json")
     with open(output_dir / RL_TOML, "wb") as f:
         tomli_w.dump(config_dict, f)
 
@@ -52,19 +52,21 @@ def write_subconfigs(config: RLConfig, output_dir: Path) -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
 
     with open(output_dir / TRAINER_TOML, "wb") as f:
-        tomli_w.dump(none_to_none_str(config.trainer.model_dump(mode="json")), f)
+        tomli_w.dump(config.trainer.model_dump(exclude_none=True, mode="json"), f)
 
     with open(output_dir / ORCHESTRATOR_TOML, "wb") as f:
-        tomli_w.dump(none_to_none_str(config.orchestrator.model_dump(mode="json")), f)
+        tomli_w.dump(config.orchestrator.model_dump(exclude_none=True, mode="json"), f)
 
     if config.inference is not None:
+        # Exclude launcher-only fields that are not needed by the vLLM server
+        exclude_inference = {"deployment", "slurm", "output_dir", "dry_run"}
         with open(output_dir / INFERENCE_TOML, "wb") as f:
-            tomli_w.dump(none_to_none_str(config.inference.model_dump(mode="json")), f)
+            tomli_w.dump(config.inference.model_dump(exclude=exclude_inference, exclude_none=True, mode="json"), f)
 
     teacher_inference = getattr(config, "teacher_inference", None)
     if teacher_inference is not None:
         with open(output_dir / TEACHER_INFERENCE_TOML, "wb") as f:
-            tomli_w.dump(none_to_none_str(teacher_inference.model_dump(mode="json")), f)
+            tomli_w.dump(teacher_inference.model_dump(exclude_none=True, mode="json"), f)
 
 
 def check_gpus_available(gpu_ids: list[int]) -> None:

--- a/src/prime_rl/entrypoints/sft.py
+++ b/src/prime_rl/entrypoints/sft.py
@@ -9,7 +9,7 @@ from threading import Event, Thread
 import tomli_w
 
 from prime_rl.configs.sft import SFTConfig
-from prime_rl.utils.config import cli, none_to_none_str
+from prime_rl.utils.config import cli
 from prime_rl.utils.logger import setup_logger
 from prime_rl.utils.pathing import get_config_dir, get_log_dir, validate_output_dir
 from prime_rl.utils.process import cleanup_processes, cleanup_threads, monitor_process
@@ -22,7 +22,7 @@ SFT_SBATCH = "sft.sbatch"
 def write_config(config: SFTConfig, config_path: Path, exclude: set[str] | None = None) -> None:
     """Write resolved config to disk, excluding launcher-only fields."""
     config_path.parent.mkdir(parents=True, exist_ok=True)
-    config_dict = none_to_none_str(config.model_dump(exclude=exclude, mode="json"))
+    config_dict = config.model_dump(exclude=exclude, exclude_none=True, mode="json")
     with open(config_path, "wb") as f:
         tomli_w.dump(config_dict, f)
 

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -461,7 +461,7 @@ def setup_ckpt_managers(
         return None, None
     ckpt_output_dir = ckpt_config.output_dir or output_dir
     ckpt_manager = CheckpointManager(ckpt_output_dir, ckpt_config)
-    if ckpt_config.weights:
+    if ckpt_config.weights and not ckpt_config.skip_gather_master_weights:
         weight_ckpt_manager = WeightCheckpointManager(
             ckpt_output_dir,
             ckpt_config.weights,

--- a/src/prime_rl/utils/config.py
+++ b/src/prime_rl/utils/config.py
@@ -3,25 +3,6 @@ from pydantic_config import BaseConfig as BaseConfig  # noqa: F401
 from pydantic_config import cli  # noqa: F401
 
 
-def _convert_none(value):
-    """Recursively convert None to ``"None"`` strings for TOML serialization."""
-    if value is None:
-        return "None"
-    if isinstance(value, dict):
-        return {k: _convert_none(v) for k, v in value.items()}
-    if isinstance(value, list):
-        return [_convert_none(item) for item in value]
-    return value
-
-
-def none_to_none_str(data: dict) -> dict:
-    """Convert None values to ``"None"`` strings so they survive TOML serialization.
-
-    TOML has no null type, so we use the ``"None"`` string convention which
-    ``BaseConfig._none_str_to_none`` converts back to ``None`` on load.
-    """
-    return _convert_none(data)
-
 
 def get_all_fields(model: BaseModel | type) -> list[str]:
     if isinstance(model, BaseModel):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes checkpoint setup to optionally skip HF-compatible weight snapshotting and alters config TOML serialization to omit unset fields, which could affect downstream consumers expecting explicit `None` values or weight checkpoints.
> 
> **Overview**
> Adds `CheckpointConfig.skip_gather_master_weights` to disable creation of `WeightCheckpointManager`, avoiding the expensive gather/save of HF-compatible weight checkpoints when only DCP trainer checkpoints are desired.
> 
> Simplifies TOML config writing for `rl`, `sft`, and `inference` entrypoints by removing the `"None"` string workaround: configs now use `model_dump(..., exclude_none=True)` (and RL now excludes launcher-only inference fields when writing subconfigs), so unset values are omitted from written TOML.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c30b8f74259c0db228ef46e0ded421246b3414f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->