### PR TITLE
fix: hybrid CP for Qwen3.5 MoE (DeltaNet + attention)

### DIFF
--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -105,8 +105,6 @@ def train(config: SFTConfig):
         substitute_ring_attn(cp_group, heads_k_stride=1, attn_impl=config.model.attn)
         from prime_rl.utils.cp import setup_hybrid_cp
 
-        setup_hybrid_cp(model, cp_group, cp_rank, parallel_dims.cp)
-
     # Set up checkpoint manager
     logger.info(f"Initializing checkpoint managers ({config.ckpt})")
     ckpt_manager, weight_ckpt_manager = setup_ckpt_managers(config.output_dir, config.ckpt, config.model.lora)
@@ -124,6 +122,9 @@ def train(config: SFTConfig):
     model = setup_model(
         config.model, parallel_dims, loading_from_ckpt_later, fused_cross_entropy=config.loss_impl == "liger_fused"
     )
+
+    if parallel_dims.cp_enabled:
+        setup_hybrid_cp(model, cp_group, cp_rank, parallel_dims.cp)
 
     if config.model.lora is not None:
         multi_run_manager = get_multi_run_manager()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only changes when `setup_hybrid_cp` is invoked during SFT startup, but it can affect context-parallel initialization for Qwen3.5 hybrid/DeltaNet layers.
> 
> **Overview**
> Fixes SFT context-parallel (CP) initialization by moving `setup_hybrid_cp(...)` to run **after** `setup_model(...)` constructs the model, instead of during the earlier CP setup block.
> 
> This ensures hybrid CP configuration is applied to the actual model instance (e.g., Qwen3.5 DeltaNet/linear-attention modules) while keeping flash/ring attention substitution behavior unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4433cbd344192b66a2c6ca44ae5a6c5743a34de3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->