### PR TITLE
refactor: use `AutoModelForImageTextToText` to configure VLMs

### DIFF
--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -41,7 +41,7 @@ from prime_rl.trainer.weights import (
 )
 from prime_rl.trainer.world import get_world
 from prime_rl.utils.logger import get_logger
-from prime_rl.utils.vlm import get_language_model, get_vision_encoder
+from prime_rl.utils.vlm import get_language_model, get_vision_encoder, unwrap_text_config
 
 
 def _patch_qwen3_5_moe_conversion_mapping():
@@ -207,6 +207,9 @@ def get_model(
         ),
     )
     model_config.use_cache = False
+
+    if not is_vlm:
+        model_config = unwrap_text_config(model_config)
 
     if is_vlm:
         logger.info(f"Detected vision-language model: {config.name}")

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -41,7 +41,7 @@ from prime_rl.trainer.weights import (
 )
 from prime_rl.trainer.world import get_world
 from prime_rl.utils.logger import get_logger
-from prime_rl.utils.vlm import get_language_model, get_vision_encoder, unwrap_text_config
+from prime_rl.utils.vlm import get_language_model, get_vision_encoder, is_vlm_architecture
 
 
 def _patch_qwen3_5_moe_conversion_mapping():
@@ -193,8 +193,7 @@ def get_model(
         f"Loading model config (name={config.name}, attn={config.attn}, trust_remote_code={config.trust_remote_code})"
     )
 
-    # VLM mode is enabled by setting [model.vlm] in config
-    is_vlm = config.vlm is not None
+    is_vlm_training = config.vlm is not None
 
     if "Qwen3.5" in config.name or "qwen3_5" in config.name.lower():
         _patch_qwen3_5_text_position_ids()
@@ -207,11 +206,9 @@ def get_model(
         ),
     )
     model_config.use_cache = False
+    is_vlm_arch = is_vlm_architecture(model_config)
 
-    if not is_vlm:
-        model_config = unwrap_text_config(model_config)
-
-    if is_vlm:
+    if is_vlm_training:
         logger.info(f"Detected vision-language model: {config.name}")
         if config.optimization_dtype != "bfloat16" or config.reduce_dtype != "bfloat16":
             raise ValueError(
@@ -264,9 +261,9 @@ def get_model(
         target_config.num_hidden_layers = num_hidden_layers
 
     # Determine the implementation to use
-    custom_vlm_cls = get_custom_vlm_cls(model_config) if is_vlm else None
+    custom_vlm_cls = get_custom_vlm_cls(model_config) if is_vlm_arch else None
     if config.impl == "auto":
-        if is_vlm:
+        if is_vlm_arch:
             impl_to_use = "custom" if custom_vlm_cls is not None else "hf"
         else:
             impl_to_use = "custom" if supports_custom_impl(model_config) else "hf"
@@ -275,13 +272,12 @@ def get_model(
         impl_to_use = config.impl
 
     with device:
-        if is_vlm:
-            if impl_to_use == "custom" and custom_vlm_cls is not None:
-                model_cls = custom_vlm_cls
-            else:
-                from transformers import AutoModelForImageTextToText
+        if impl_to_use == "custom" and custom_vlm_cls is not None:
+            model_cls = custom_vlm_cls
+        elif is_vlm_arch:
+            from transformers import AutoModelForImageTextToText
 
-                model_cls = AutoModelForImageTextToText
+            model_cls = AutoModelForImageTextToText
         else:
             match impl_to_use:
                 case "hf":
@@ -291,7 +287,7 @@ def get_model(
 
         load_model_start_time = time.perf_counter()
         # HF VLM models require torch_dtype; custom PrimeRL models and text Auto models use dtype
-        use_torch_dtype = is_vlm and model_cls is not custom_vlm_cls
+        use_torch_dtype = is_vlm_arch and model_cls is not custom_vlm_cls
         dtype_kwarg = {"torch_dtype": dtype} if use_torch_dtype else {"dtype": dtype}
         if device == torch.device("meta"):
             logger.info(f"Loading model {config.name} using {model_cls.__name__} to meta device")
@@ -306,8 +302,8 @@ def get_model(
             )
         logger.debug(f"Loaded model {config.name} in {time.perf_counter() - load_model_start_time:.2f} seconds")
 
-    # For VLM models, freeze the vision encoder
-    if is_vlm:
+    # For VLM training, freeze the vision encoder
+    if is_vlm_training:
         freeze_vision_encoder(model, override_attr=config.vlm.vision_encoder_attr)
 
     assert model.lm_head.weight.dtype == dtype, (
@@ -346,15 +342,15 @@ def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDim
 
         dp_mod_ep_mesh = parallel_dims.world_mesh[tuple(dp_mod_ep_mesh_dim_names)]
 
-    is_vlm = config.vlm is not None
-    if is_vlm:
+    is_vlm_training = config.vlm is not None
+    if is_vlm_training:
         vision_encoder = get_vision_encoder(model, override=config.vlm.vision_encoder_attr)
         if vision_encoder is None:
             raise ValueError(f"VLM model {config.name} has no recognized vision encoder")
         fully_shard(vision_encoder, mesh=hsdp_mesh, **fsdp_config)
         get_logger().info("Applied FSDP to frozen vision encoder")
 
-    language_model = get_language_model(model, override=config.vlm.language_model_attr if is_vlm else None)
+    language_model = get_language_model(model, override=config.vlm.language_model_attr if is_vlm_training else None)
     transformer_layers = language_model.layers
 
     for transformer_block in transformer_layers:

--- a/src/prime_rl/trainer/models/__init__.py
+++ b/src/prime_rl/trainer/models/__init__.py
@@ -7,7 +7,6 @@ from transformers.configuration_utils import PretrainedConfig
 from transformers.models.auto.auto_factory import _BaseAutoModelClass, _LazyAutoMapping, auto_class_update
 from transformers.models.auto.configuration_auto import CONFIG_MAPPING_NAMES
 from transformers.models.llama.configuration_llama import LlamaConfig
-from transformers.models.qwen3_5_moe.configuration_qwen3_5_moe import Qwen3_5MoeConfig as HFQwen3_5MoeConfig
 
 from prime_rl.trainer.models.afmoe import AfmoeConfig, AfmoeForCausalLM
 from prime_rl.trainer.models.base import PreTrainedModelPrimeRL
@@ -38,7 +37,6 @@ _CUSTOM_CAUSAL_LM_MAPPING.register(MiniMaxM2Config, MiniMaxM2ForCausalLM, exist_
 _CUSTOM_CAUSAL_LM_MAPPING.register(NemotronHConfig, NemotronHForCausalLM, exist_ok=True)
 _CUSTOM_CAUSAL_LM_MAPPING.register(Qwen3MoeConfig, Qwen3MoeForCausalLM, exist_ok=True)
 _CUSTOM_CAUSAL_LM_MAPPING.register(Qwen3_5MoeConfig, Qwen3_5MoeForCausalLM, exist_ok=True)
-_CUSTOM_CAUSAL_LM_MAPPING.register(HFQwen3_5MoeConfig, Qwen3_5MoeForCausalLM, exist_ok=True)
 
 
 class AutoModelForCausalLMPrimeRL(_BaseAutoModelClass):

--- a/src/prime_rl/trainer/models/__init__.py
+++ b/src/prime_rl/trainer/models/__init__.py
@@ -7,6 +7,7 @@ from transformers.configuration_utils import PretrainedConfig
 from transformers.models.auto.auto_factory import _BaseAutoModelClass, _LazyAutoMapping, auto_class_update
 from transformers.models.auto.configuration_auto import CONFIG_MAPPING_NAMES
 from transformers.models.llama.configuration_llama import LlamaConfig
+from transformers.models.qwen3_5_moe.configuration_qwen3_5_moe import Qwen3_5MoeConfig as HFQwen3_5MoeConfig
 
 from prime_rl.trainer.models.afmoe import AfmoeConfig, AfmoeForCausalLM
 from prime_rl.trainer.models.base import PreTrainedModelPrimeRL
@@ -37,6 +38,7 @@ _CUSTOM_CAUSAL_LM_MAPPING.register(MiniMaxM2Config, MiniMaxM2ForCausalLM, exist_
 _CUSTOM_CAUSAL_LM_MAPPING.register(NemotronHConfig, NemotronHForCausalLM, exist_ok=True)
 _CUSTOM_CAUSAL_LM_MAPPING.register(Qwen3MoeConfig, Qwen3MoeForCausalLM, exist_ok=True)
 _CUSTOM_CAUSAL_LM_MAPPING.register(Qwen3_5MoeConfig, Qwen3_5MoeForCausalLM, exist_ok=True)
+_CUSTOM_CAUSAL_LM_MAPPING.register(HFQwen3_5MoeConfig, Qwen3_5MoeForCausalLM, exist_ok=True)
 
 
 class AutoModelForCausalLMPrimeRL(_BaseAutoModelClass):

--- a/src/prime_rl/utils/vlm.py
+++ b/src/prime_rl/utils/vlm.py
@@ -21,6 +21,7 @@ class VLMModelInfo:
 
     vision_encoder_attr: str
     language_model_attr: str
+    text_config_attr: str = "text_config"
 
 
 # Central registry: model_type -> architecture info.
@@ -78,6 +79,19 @@ def get_language_model(model: nn.Module, override: str | None = None) -> nn.Modu
 
     # Text-only models: language model is directly at model.model
     return model.model
+
+
+def unwrap_text_config(model_config: PretrainedConfig) -> PretrainedConfig:
+    """Unwrap a composite VLM config to its text sub-config for text-only training.
+
+    Returns the text sub-config if the model is a known VLM, otherwise returns the config unchanged.
+    """
+    info = _get_model_info_from_config(model_config)
+    if info is not None:
+        text_config = getattr(model_config, info.text_config_attr, None)
+        if text_config is not None:
+            return text_config
+    return model_config
 
 
 def get_layer_prefix(model_config: PretrainedConfig, override: str | None = None) -> str:

--- a/src/prime_rl/utils/vlm.py
+++ b/src/prime_rl/utils/vlm.py
@@ -21,7 +21,6 @@ class VLMModelInfo:
 
     vision_encoder_attr: str
     language_model_attr: str
-    text_config_attr: str = "text_config"
 
 
 # Central registry: model_type -> architecture info.
@@ -81,17 +80,9 @@ def get_language_model(model: nn.Module, override: str | None = None) -> nn.Modu
     return model.model
 
 
-def unwrap_text_config(model_config: PretrainedConfig) -> PretrainedConfig:
-    """Unwrap a composite VLM config to its text sub-config for text-only training.
-
-    Returns the text sub-config if the model is a known VLM, otherwise returns the config unchanged.
-    """
-    info = _get_model_info_from_config(model_config)
-    if info is not None:
-        text_config = getattr(model_config, info.text_config_attr, None)
-        if text_config is not None:
-            return text_config
-    return model_config
+def is_vlm_architecture(model_config: PretrainedConfig) -> bool:
+    """Check if the model config belongs to a known VLM architecture."""
+    return _get_model_info_from_config(model_config) is not None
 
 
 def get_layer_prefix(model_config: PretrainedConfig, override: str | None = None) -> str:


### PR DESCRIPTION
  AutoConfig.from_pretrained("Qwen/Qwen3.5-35B-A3B") returns the composite VLM Qwen3_5MoeConfig (model_type "qwen3_5_moe"), which wraps text_config + vision_config. On the text-only training path ([model.vlm] not set), AutoModelForCausalLMPrimeRL doesn't recognize this composite config
  class → ValueError.

  The VLM path doesn't have this problem because get_custom_vlm_cls dispatches by model_type string. But the VLM path also triggers vision encoder freezing/FSDP sharding, which is wrong for text-only SFT.

  Fix

  Use VLM_REGISTRY to auto-detect VLM architectures early in get_model, and split the old is_vlm flag into two:

  - is_vlm_arch (from registry lookup): controls model class selection — routes VLM architectures to AutoModelForImageTextToText (which handles composite configs natively) or the custom VLM class
  - is_vlm_training (from TOML [model.vlm]): controls downstream training behavior — vision encoder freezing, FSDP sharding

  This eliminates config class registration issues entirely. AutoModelForImageTextToText handles the composite config, and AutoModelForCausalLMPrimeRL / AutoModelForCausalLM handle text-only configs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes model-class dispatch for Qwen3.5 by adding an additional config-class mapping, which could affect which implementation gets loaded for some checkpoints. Scope is small but touches core model loading/selection logic.
> 
> **Overview**
> Fixes custom text-model loading for Qwen3.5 MoE checkpoints by registering the upstream Transformers `Qwen3_5MoeConfig` class (`model_type` `qwen3_5_moe`) in `AutoModelForCausalLMPrimeRL`’s `_CUSTOM_CAUSAL_LM_MAPPING`.
> 
> This allows `AutoConfig.from_pretrained()` configs from HF to resolve to the PrimeRL `Qwen3_5MoeForCausalLM` implementation in the non-VLM path, matching the existing VLM dispatch behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49392e65fed110dd5509cc13b62ecd270776323f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->