### PR TITLE
Feat: add weigh transfer fix

### DIFF
--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -10,6 +10,7 @@ def transformers_v5_compat():
         Qwen3VLMoeTextConfig.tie_word_embeddings = False
 
     _patch_qwen35_lora()
+    monkey_patch_dp_engine_core_pause_resume_deadlock()
 
 
 def _patch_qwen35_lora():
@@ -712,3 +713,40 @@ def monkey_patch_fused_moe_lora_dp():
         self.base_layer._replace_quant_method(new_method)
 
     FusedMoEWithLoRA._inject_lora_into_fused_moe = _fixed_inject
+
+
+def monkey_patch_dp_engine_core_pause_resume_deadlock():
+    """Fix deadlock with pause/resume and collective_rpc in DP engine core.
+
+    When a request arrives for an already-completed wave while the scheduler is
+    paused, the unpatched code sends a start_wave notification that triggers
+    collective_rpc on other DP engines. But the paused engine can't participate
+    in the collective, causing a deadlock.
+
+    Fix: only send the start_wave notification when the scheduler is unpaused,
+    and explicitly set engines_running=True before notifying.
+
+    Upstream: https://github.com/vllm-project/vllm/pull/37024
+    """
+    from vllm.v1.core.sched.interface import PauseState
+    from vllm.v1.engine import EngineCoreOutputs
+    from vllm.v1.engine.core import DPEngineCoreProc, EngineCore
+    from vllm.v1.request import Request
+
+    _base_add_request = EngineCore.add_request
+
+    def _patched_add_request(self, request: Request, request_wave: int = 0):
+        _base_add_request(self, request, request_wave)
+        if self.has_coordinator and request_wave != self.current_wave:
+            if request_wave > self.current_wave:
+                self.current_wave = request_wave
+            elif (
+                not self.engines_running
+                and self.scheduler.pause_state == PauseState.UNPAUSED
+            ):
+                self.engines_running = True
+                self.output_queue.put_nowait(
+                    (-1, EngineCoreOutputs(start_wave=self.current_wave))
+                )
+
+    DPEngineCoreProc.add_request = _patched_add_request

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -740,13 +740,8 @@ def monkey_patch_dp_engine_core_pause_resume_deadlock():
         if self.has_coordinator and request_wave != self.current_wave:
             if request_wave > self.current_wave:
                 self.current_wave = request_wave
-            elif (
-                not self.engines_running
-                and self.scheduler.pause_state == PauseState.UNPAUSED
-            ):
+            elif not self.engines_running and self.scheduler.pause_state == PauseState.UNPAUSED:
                 self.engines_running = True
-                self.output_queue.put_nowait(
-                    (-1, EngineCoreOutputs(start_wave=self.current_wave))
-                )
+                self.output_queue.put_nowait((-1, EngineCoreOutputs(start_wave=self.current_wave)))
 
     DPEngineCoreProc.add_request = _patched_add_request


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Patches vLLM DP engine core request handling and wave coordination logic, which is concurrency-sensitive and could impact distributed inference behavior if assumptions differ across vLLM versions.
> 
> **Overview**
> Adds a new vLLM monkeypatch to prevent a **pause/resume deadlock** in DP mode by changing `EngineCore.add_request` behavior: it now only emits `start_wave` notifications when the scheduler is unpaused and forces `engines_running=True` before notifying.
> 
> The new patch is wired into the existing `transformers_v5_compat()` general plugin so it runs automatically in all vLLM processes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c192cc04384e0d1e2271993b564bdcb2b8ab8e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->