### PR TITLE
fix: mito rl training

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -490,9 +490,8 @@ async def orchestrate(config: OrchestratorConfig):
 
         # Schedule generating the training batch
         temperature = compute_temperature(progress.step, config.sampling, config.max_steps)
-        sampling_args = get_sampling_args(
-            config.sampling, temperature=temperature, use_token_client=config.use_token_client
-        )
+        is_vllm = config.teacher_rollout_model is None
+        sampling_args = get_sampling_args(config.sampling, temperature=temperature, is_vllm=is_vllm)
         scheduler.set_sampling_args(sampling_args)
         train_task = asyncio.create_task(scheduler.generate_batch(step=progress.step))
 

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -88,9 +88,8 @@ class Scheduler:
         self.enable_policy_updates = enable_policy_updates
         self.lora_name = lora_name
         initial_temp = compute_temperature(step=0, sampling_config=config.sampling, max_steps=config.max_steps)
-        self.sampling_args = get_sampling_args(
-            config.sampling, temperature=initial_temp, use_token_client=config.use_token_client
-        )
+        is_vllm = config.teacher_rollout_model is None
+        self.sampling_args = get_sampling_args(config.sampling, temperature=initial_temp, is_vllm=is_vllm)
         self.model_name = self.config.model.name
         self.json_logging = config.log.json_logging
 

--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -36,13 +36,14 @@ async def get_semaphore() -> AsyncContextManager:
     return SEMAPHORE
 
 
-def get_sampling_args(sampling_config: SamplingConfig, temperature: float, use_token_client: bool = True) -> dict:
+def get_sampling_args(sampling_config: SamplingConfig, temperature: float, is_vllm: bool = True) -> dict:
     # Convert SamplingConfig to vLLM OAI sampling args
     # https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html#extra-parameters_2
     sampling_args = dict(sampling_config)
     sampling_args.pop("temp_scheduler", None)
     sampling_args["temperature"] = temperature
     sampling_args["top_p"] = 1.0
+    sampling_args["logprobs"] = True
     extra_body = dict(sampling_config.extra_body)
 
     min_tokens = sampling_args.pop("min_tokens")
@@ -53,12 +54,9 @@ def get_sampling_args(sampling_config: SamplingConfig, temperature: float, use_t
     if repetition_penalty != 1.0:
         extra_body["repetition_penalty"] = repetition_penalty
 
-    extra_body["top_k"] = -1
-    extra_body["min_p"] = 0.0
-
-    sampling_args["logprobs"] = True
-
-    if use_token_client:
+    if is_vllm:
+        extra_body["top_k"] = -1
+        extra_body["min_p"] = 0.0
         extra_body["return_token_ids"] = True
 
     if extra_body:


### PR DESCRIPTION
## Summary
- `get_sampling_args` was gating `return_token_ids=True` on `use_token_client`, so the non-TITO client path never received token IDs from vLLM — causing `parse_tokens()` in verifiers to crash with `len(None)`
- Replaced the `use_token_client` flag with `is_vllm` (derived from `config.teacher_rollout_model is None`) so vLLM-specific extra_body params are always sent when hitting vLLM, and only skipped for SFT distillation against external non-vLLM APIs

## Repro
Previously broken, now works:
```
uv run rl @ examples/reverse_text/rl.toml --clean-output-dir --orchestrator.no-use-token-client
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches rollout sampling parameter construction and changes when vLLM-specific `extra_body` fields are sent; could affect inference behavior for non-vLLM backends or distillation runs if the vLLM detection is wrong.
> 
> **Overview**
> Fixes RL rollout generation when using the non-TITO client by ensuring vLLM rollouts always request token IDs.
> 
> `get_sampling_args` now gates vLLM-only `extra_body` fields (including `return_token_ids`) on a new `is_vllm` flag instead of `use_token_client`, and both `orchestrator` and `Scheduler` derive `is_vllm` from `config.teacher_rollout_model is None` when building per-step sampling args.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d94939ba7f8c94b16b72b0fccc7649a7164af1ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->