### PR TITLE
fix: default env server num_workers to 1

### DIFF
--- a/src/prime_rl/configs/env_server.py
+++ b/src/prime_rl/configs/env_server.py
@@ -24,7 +24,5 @@ class EnvServerConfig(BaseConfig):
     @model_validator(mode="after")
     def validate_num_workers(self):
         if self.env.num_workers == "auto":
-            raise ValueError(
-                "num_workers='auto' is not supported for standalone env servers. Set an explicit integer value."
-            )
+            self.env.num_workers = 1
         return self


### PR DESCRIPTION
## Summary
- When `num_workers` is left as `"auto"` for standalone env servers, default to 1 instead of raising an error.

This works now

```
uv run env-server
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)