### PR TITLE
Fix: exclude disagg extras from Docker build

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -53,7 +53,7 @@ COPY examples /app/examples
 COPY benchmarks/scripts /app/benchmarks/scripts
 
 RUN --mount=type=cache,target=/app/.cache/uv \
-    uv sync --all-extras --group mamba-ssm --locked --no-dev
+    uv sync --extra flash-attn --extra flash-attn-3 --extra flash-attn-cute --extra envs --group mamba-ssm --locked --no-dev
 
 # arm64: build flash-attn from source, fix namespace conflicts, apply workarounds
 ARG TARGETARCH


### PR DESCRIPTION
- `--all-extras` installs the `disagg` group which includes nixl-cu12, deep-ep, deep-gemm wheels compiled against CUDA 13
- our amd64 clusters (H100/H200) only have CUDA 12.8, causing `ImportError: libcudart.so.13` on inference startup
- also broke the arm64 build (vllm-router x86_64-only wheel, fixed separately in #2103)
- switch to explicit extras, excluding disagg until CUDA 13 is available

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CUDA Docker image’s dependency set by replacing `uv sync --all-extras` with an explicit list of extras, which could inadvertently omit packages expected at runtime but reduces risk of pulling incompatible CUDA wheels.
> 
> **Overview**
> Updates `Dockerfile.cuda` to stop using `uv sync --all-extras` during the build, and instead installs a curated set of extras (`flash-attn*`, `envs`) plus the `mamba-ssm` group.
> 
> This prevents the Docker build from pulling in additional extras that may ship wheels compiled against incompatible CUDA versions (e.g., CUDA 13), improving runtime compatibility on CUDA 12.x clusters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd0d22f87de376674ed8391a67a7bce1ff1d1e03. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->