### PR TITLE
Fix: checkpoint resume fails on PyTorch 2.9 (weights_only default)

### DIFF
--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -196,7 +196,7 @@ class CheckpointManager:
                     raise RuntimeError(
                         f"Couldn't fallback to using the master rank's dataloader checkpoint, because dataloder checkpoint was not found at path {dataloader_path}. Cannot resume training."
                     )
-            dataloader.load_state_dict(torch.load(dataloader_path))
+            dataloader.load_state_dict(torch.load(dataloader_path, weights_only=False))
 
         self.logger.debug(f"Training checkpoint loaded in {time.perf_counter() - start_time:.2f} seconds")
 

--- a/src/prime_rl/trainer/multi_ckpt.py
+++ b/src/prime_rl/trainer/multi_ckpt.py
@@ -209,7 +209,7 @@ class MultiCheckpointManager:
             if not ckpt_path.exists():
                 raise FileNotFoundError(f"Checkpoint not found at {ckpt_path}")
             self.logger.info(f"Loading checkpoint from {ckpt_path}")
-            state_dict = torch.load(ckpt_path / f"rank_{self.world.rank}.pt")
+            state_dict = torch.load(ckpt_path / f"rank_{self.world.rank}.pt", weights_only=False)
             run_state.load_state_dict(state_dict)
 
             self.logger.info(f"Resumed run {self.multi_run_manager.idx_2_id[idx]} from step {step}")


### PR DESCRIPTION
- PyTorch 2.9 changed torch.load default to weights_only=True
- EP=8 checkpoints contain DTensor _StridedShard which isn't in the safe globals list
- Causes checkpoint resume to fail silently on 397B models, trainer restarts from scratch every time
- Fix: pass weights_only=False to both torch.load calls in multi_ckpt.py and ckpt.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, localized change to checkpoint resume behavior that only affects deserialization flags, with no change to checkpoint formats or save paths.
> 
> **Overview**
> Fixes checkpoint resume on PyTorch 2.9+ by explicitly passing `weights_only=False` to `torch.load` when restoring (1) per-rank dataloader state in `ckpt.py` and (2) per-run adapter/optimizer/scheduler state in `multi_ckpt.py`, avoiding failures from the new default safe/weights-only loading behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 383d8f3903161334bdfc542ea5f5a8531ce340e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->