### PR TITLE
Fix elastic client dropping in-flight requests during LoRA sync

### DIFF
--- a/src/prime_rl/utils/elastic.py
+++ b/src/prime_rl/utils/elastic.py
@@ -298,7 +298,9 @@ class ElasticInferencePool:
             f"Pre-check failed on {ip}: loaded={loaded.path if loaded else None} "
             f"(step={loaded.step if loaded else None}), desired={self._desired.path} (step={self._desired.step})"
         )
-        server.status = "syncing"
+        # Keep server in current status during sync — setting "syncing" here drops it
+        # from ready_urls, which triggers client recreation and breaks in-flight requests
+        # across all runs sharing this inference pod.
 
         if self._desired.name and self._desired.path:
             try:


### PR DESCRIPTION
- Remove premature `server.status = "syncing"` in `_sync_server_adapter`
- This was dropping the server from `ready_urls` during adapter load, triggering client recreation and killing in-flight requests
- Server now stays ready while loading new adapter, only goes unhealthy on actual failure
- Fixes ConnectError storms on stacks with multiple concurrent runs sharing inference pods

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes server readiness state transitions during adapter loads; incorrect behavior could keep serving a pod that is mid-sync or mask transient issues, affecting request routing under load.
> 
> **Overview**
> Prevents `ElasticInferencePool._sync_server_adapter` from setting `server.status = "syncing"` when the pre-check detects an adapter mismatch.
> 
> Servers now stay in their current status during LoRA adapter load so they aren’t removed from `ready_urls`, avoiding client recreation that could drop in-flight requests; servers are only marked `unhealthy` on actual sync/load failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68d9ec93f7c3aeafa9f793144eb3bcc9946426e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->