### PR TITLE
Fix sft config path in reverse_text README

### DIFF
--- a/examples/reverse_text/README.md
+++ b/examples/reverse_text/README.md
@@ -55,7 +55,7 @@ To train on multiple GPUs, run
 uv run torchrun \
   --local-ranks-filter 0 \
   --nproc-per-node ... \
-  src/prime_rl/trainer/sft/train.py @ examples/reverse_text/sft/train.toml \
+  src/prime_rl/trainer/sft/train.py @ examples/reverse_text/sft.toml \
   --wandb.project ... \
   --wandb.name ...
 ```


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that corrects a command-line config reference; no runtime or API behavior is affected.
> 
> **Overview**
> Updates the `examples/reverse_text` README to point the multi-GPU SFT `torchrun` command at the correct config file (`examples/reverse_text/sft.toml` instead of the old `sft/train.toml` path).
> 
> Also fixes the missing trailing newline at the end of the document.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2ba9ca92f57d13ce7aa12832ef93b948ec348a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->