### PR TITLE
support MTP training

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "torch>=2.9.0",
     "torchdata>=0.11.0",
     "transformers",
-    "vllm>=0.17.0",
+    "vllm>=0.18.0",
     "wandb>=0.24.2",
     "ring-flash-attn>=0.1.8",
     "prime>=0.5.37",

--- a/skills/inference-server/SKILL.md
+++ b/skills/inference-server/SKILL.md
@@ -20,6 +20,31 @@ uv run inference --model.name Qwen/Qwen3-0.6B --model.max_model_len 2048 --model
 uv run inference @ path/to/config.toml --server.port 8001 --gpu-memory-utilization 0.5
 ```
 
+## MTP speculative decoding
+
+PrimeRL now has typed inference config for serving a model's built-in MTP head through vLLM speculative decoding.
+
+```toml
+# infer_mtp.toml
+[model]
+name = "Qwen/Qwen3.5-35B-A3B"
+
+[mtp]
+num_speculative_tokens = 1
+```
+
+```bash
+uv run inference @ infer_mtp.toml
+```
+
+This maps to vLLM's `speculative_config` with `method="mtp"`.
+
+Notes:
+
+- This is inference-only. Training-side MTP still uses the trainer's `[model.mtp]` config.
+- Do not set both `[mtp]` and `vllm_extra.speculative_config`; use one source of truth.
+- For RL runs, put the same `[mtp]` block under `[inference]` in the RL config so the spawned inference server uses MTP speculation.
+
 ## SLURM scheduling
 
 The inference entrypoint supports optional SLURM scheduling, following the same patterns as SFT and RL.

--- a/src/prime_rl/configs/inference.py
+++ b/src/prime_rl/configs/inference.py
@@ -94,6 +94,21 @@ class ModelConfig(BaseModelConfig):
     ] = None
 
 
+class MTPInferenceConfig(BaseConfig):
+    """Serve a model's built-in MTP head with vLLM speculative decoding."""
+
+    num_speculative_tokens: Annotated[
+        int,
+        Field(
+            gt=0,
+            description=(
+                "Number of speculative tokens to propose per decode step using the model's built-in MTP draft head. "
+                "Passed to vLLM via `speculative_config.num_speculative_tokens` with `method='mtp'`."
+            ),
+        ),
+    ]
+
+
 class WeightBroadcastConfig(BaseConfig):
     """Configures weight broadcast settings."""
 
@@ -177,6 +192,16 @@ class InferenceConfig(BaseConfig):
 
     # The model configuration
     model: ModelConfig = Field(default_factory=ModelConfig)
+
+    mtp: Annotated[
+        MTPInferenceConfig | None,
+        Field(
+            description=(
+                "Built-in multi-token prediction (MTP) speculative decoding settings. "
+                "When set, prime-rl configures vLLM to use the served model's existing MTP head as its drafter."
+            ),
+        ),
+    ] = None
 
     # The parallel configuration
     parallel: ParallelConfig = ParallelConfig()
@@ -396,6 +421,12 @@ class InferenceConfig(BaseConfig):
             self.api_server_count = 1  # LoRA requires only one API server
         return self
 
+    @model_validator(mode="after")
+    def validate_mtp_config_source(self):
+        if self.mtp is not None and "speculative_config" in self.vllm_extra:
+            raise ValueError("Use `mtp` or `vllm_extra.speculative_config`, not both.")
+        return self
+
     def to_vllm(self) -> Namespace:
         """Convert InferenceConfig to vLLM-compatible Namespace."""
         namespace = Namespace()
@@ -443,5 +474,11 @@ class InferenceConfig(BaseConfig):
         if hasattr(namespace, "rope_scaling"):
             if namespace.rope_scaling is None:
                 delattr(namespace, "rope_scaling")
+
+        if self.mtp is not None:
+            namespace.speculative_config = {
+                "method": "mtp",
+                **self.mtp.model_dump(exclude_none=True),
+            }
 
         return namespace

--- a/src/prime_rl/configs/trainer.py
+++ b/src/prime_rl/configs/trainer.py
@@ -157,6 +157,30 @@ class DebugModelConfig(BaseConfig):
     ] = False
 
 
+class MTPConfig(BaseConfig):
+    """Configures auxiliary multi-token prediction (MTP) training."""
+
+    num_layers: Annotated[
+        int,
+        Field(
+            ge=1,
+            description=(
+                "Number of logical draft/MTP prediction steps to train. For models with distinct MTP blocks, "
+                "this must not exceed the number of MTP layers in the checkpoint. Some architectures reuse a "
+                "shared MTP predictor across multiple steps, in which case larger values are valid."
+            ),
+        ),
+    ] = 1
+
+    loss_scaling_factor: Annotated[
+        float,
+        Field(
+            ge=0,
+            description="Total scaling factor applied to the auxiliary MTP loss, divided evenly across configured MTP layers.",
+        ),
+    ] = 0.2
+
+
 class ModelConfig(BaseModelConfig):
     """Configures the model for training."""
 
@@ -280,6 +304,17 @@ class ModelConfig(BaseModelConfig):
             description="Debugging feature around model and distributed training.",
         ),
     ] = DebugModelConfig()
+
+    mtp: Annotated[
+        MTPConfig | None,
+        Field(
+            description=(
+                "Auxiliary multi-token prediction (MTP) training. When set, PrimeRL trains the model's existing draft/MTP layers "
+                "with an additional cross-entropy loss during RL or SFT. This only adds training support; speculative draft "
+                "inference remains unchanged."
+            ),
+        ),
+    ] = None
 
     fused_lm_head_token_chunk_size: Annotated[
         int | Literal["auto", "disabled"],

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -7,9 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 from starlette.datastructures import State
 from vllm.engine.protocol import EngineClient
-from vllm.entrypoints.chat_utils import load_chat_template
 from vllm.entrypoints.cli.serve import run_api_server_worker_proc
-from vllm.entrypoints.logger import RequestLogger
 from vllm.entrypoints.openai.api_server import init_app_state
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionResponse
 from vllm.entrypoints.openai.cli_args import make_arg_parser, validate_parsed_serve_args
@@ -285,22 +283,21 @@ async def custom_init_app_state(
     # Setup the regular app state first (in-place)
     await init_app_state(engine_client, state, args, supported_tasks)
 
-    # NOTE: Initialize the custom OpenAIServingChatWithTokens state here
-    # TODO: Here, we repeat some calls done in init_app_state to be able to
-    # correctly set up the OpenAIServingChatWithTokens state, which is a bit
-    # brittle, and could probably be made nicer
-    if args.enable_log_requests:
-        request_logger = RequestLogger(max_log_len=args.max_log_len)
-    else:
-        request_logger = None
+    if "generate" not in supported_tasks:
+        state.openai_serving_chat_with_tokens = None
+        return
 
-    resolved_chat_template = load_chat_template(args.chat_template)
-
-    chat_kwargs = dict(
-        request_logger=request_logger,
-        chat_template=resolved_chat_template,
-        chat_template_content_format=args.chat_template_content_format,
-        trust_request_chat_template=args.trust_request_chat_template,
+    serving_render = state.openai_serving_render
+    serving_chat = OpenAIServingChatWithTokens(
+        engine_client,
+        state.openai_serving_models,
+        args.response_role,
+        openai_serving_render=serving_render,
+        request_logger=serving_render.request_logger,
+        chat_template=serving_render.chat_template,
+        chat_template_content_format=serving_render.chat_template_content_format,
+        default_chat_template_kwargs=serving_render.default_chat_template_kwargs,
+        trust_request_chat_template=serving_render.trust_request_chat_template,
         return_tokens_as_token_ids=args.return_tokens_as_token_ids,
         enable_auto_tools=args.enable_auto_tool_choice,
         exclude_tools_when_tool_choice_none=args.exclude_tools_when_tool_choice_none,
@@ -309,18 +306,11 @@ async def custom_init_app_state(
         enable_prompt_tokens_details=args.enable_prompt_tokens_details,
         enable_force_include_usage=args.enable_force_include_usage,
         enable_log_outputs=args.enable_log_outputs,
+        enable_log_deltas=args.enable_log_deltas,
     )
-    if hasattr(args, "log_error_stack"):
-        chat_kwargs["log_error_stack"] = args.log_error_stack
-
-    serving_chat = OpenAIServingChatWithTokens(
-        engine_client,
-        state.openai_serving_models,
-        args.response_role,
-        **chat_kwargs,
-    )
-    state.openai_serving_chat = serving_chat if "generate" in supported_tasks else None
-    state.openai_serving_chat_with_tokens = serving_chat if "generate" in supported_tasks else None
+    serving_chat.warmup()
+    state.openai_serving_chat = serving_chat
+    state.openai_serving_chat_with_tokens = serving_chat
 
 
 def custom_run_api_server_worker_proc(listen_address, sock, args, client_config=None, **uvicorn_kwargs) -> None:

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -837,11 +837,21 @@ async def orchestrate(config: OrchestratorConfig):
         )
 
         reward_mean = by_example.reward.mean().mean()
+        mean_generation_ms = by_example.generation_ms.mean().mean()
+        mean_decode_len = by_example.decode_len.mean().mean()
+        decode_tokens_per_second = 1000 * mean_decode_len / mean_generation_ms if mean_generation_ms > 0 else 0.0
         val_reward_str = ""
         if val_results_df is not None:
             val_reward_mean = val_results_df.groupby("example_id").reward.mean().mean()
             val_reward_str = f" Val. Reward: {val_reward_mean:.4f} |"
-        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Reward: {reward_mean:.4f} |{val_reward_str} Seq. Length: {by_example.seq_len.mean().mean():.1f} tokens/sample | Async Level: {scheduler.async_level} | Max. Off-Policy Level: {scheduler.max_off_policy_level}"
+        step_message = (
+            f"Step {progress.step} | Time: {step_time:.2f}s | Reward: {reward_mean:.4f} |{val_reward_str}"
+            f" Seq. Length: {by_example.seq_len.mean().mean():.1f} tokens/sample"
+            f" | Generation: {mean_generation_ms:.1f} ms/sample"
+            f" | Decode Speed: {decode_tokens_per_second:.1f} tokens/s"
+            f" | Async Level: {scheduler.async_level}"
+            f" | Max. Off-Policy Level: {scheduler.max_off_policy_level}"
+        )
         logger.success(step_message)
 
         # Increment step

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -1,4 +1,5 @@
 import logging
+import shutil
 import time
 from pathlib import Path
 from typing import cast
@@ -48,6 +49,20 @@ from prime_rl.trainer.weights import (
 from prime_rl.trainer.world import get_world
 from prime_rl.utils.logger import get_logger
 from prime_rl.utils.vlm import get_language_model, get_vision_encoder, is_vlm_architecture
+
+
+def _get_expected_load_state_dict_keys(model: nn.Module) -> set[str]:
+    state_dict = strip_lora_from_state_dict(model.state_dict())
+    if getattr(getattr(model, "config", None), "tie_word_embeddings", False):
+        state_dict.pop("lm_head.weight", None)
+    return set(state_dict)
+
+
+def _get_missing_checkpoint_keys(save_dir: Path, required_keys: set[str]) -> list[str]:
+    if not save_dir.exists():
+        return sorted(required_keys)
+    checkpoint_keys = set(load_state_dict_keys(save_dir))
+    return sorted(required_keys - checkpoint_keys)
 
 
 def _patch_qwen3_5_moe_conversion_mapping():
@@ -142,6 +157,13 @@ def _get_mtp_layers(model: nn.Module) -> list[nn.Module]:
         mtp = getattr(model.model, "mtp", None)
     layers = getattr(mtp, "layers", None)
     return list(layers) if isinstance(layers, nn.ModuleList) else []
+
+
+def _get_mtp_fsdp_modules(model: nn.Module) -> list[nn.Module]:
+    # Nemotron MTP now applies its shared start/end projections inside the
+    # child layer forwards, so all supported layouts can shard per logical MTP
+    # layer.
+    return _get_mtp_layers(model)
 
 
 def freeze_moe_router(model: nn.Module) -> None:
@@ -367,6 +389,7 @@ def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDim
     language_model = get_language_model(model, override=config.vlm.language_model_attr if is_vlm_training else None)
     transformer_layers = list(language_model.layers)
     mtp_layers = _get_mtp_layers(model)
+    mtp_fsdp_modules = _get_mtp_fsdp_modules(model)
 
     for transformer_block in [*transformer_layers, *mtp_layers]:
         block_mlp = getattr(transformer_block, "mlp", None)
@@ -375,6 +398,7 @@ def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDim
 
             block_mlp.experts.set_gradient_divide_factor(parallel_dims.fsdp_gradient_divide_factor)
 
+    for transformer_block in [*transformer_layers, *mtp_fsdp_modules]:
         fully_shard(
             transformer_block,
             mesh=hsdp_mesh,
@@ -489,16 +513,24 @@ def load_dcp_from_hf(model: nn.Module, config: ModelConfig, parallel_dims: Paral
     if isinstance(model, PreTrainedModelPrimeRL):
         snapshot_keys = dict.fromkeys(load_state_dict_keys(snapshot_path))
         model_keys = dict.fromkeys(model.state_dict().keys())
+        expected_load_keys = _get_expected_load_state_dict_keys(model)
 
         if model.is_hf_state_dict(snapshot_keys) and model.is_prime_state_dict(model_keys):
             logger.warning(
                 "Found HF weight format in snapshot state dict and PrimeRL weight format in model state dict. Trying to auto-convert..."
             )
             snapshot_path = snapshot_path / "prime"
-            if not snapshot_path.exists() and get_world().is_master:
+            missing_keys = _get_missing_checkpoint_keys(snapshot_path, expected_load_keys)
+            if missing_keys:
+                logger.warning(
+                    f"Converted PrimeRL snapshot at {snapshot_path} is missing {len(missing_keys)} key(s); "
+                    f"rebuilding it. Example missing key: {missing_keys[0]}"
+                )
+            if missing_keys and get_world().is_master:
                 logger.debug(
                     f"Converting snapshot state dict to PrimeRL format and saving to {snapshot_path} on master rank. This is a one-time operation."
                 )
+                shutil.rmtree(snapshot_path, ignore_errors=True)
                 snapshot_state_dict = load_state_dict(snapshot_path.parent)
                 model.convert_to_prime(snapshot_state_dict)
                 save_state_dict(snapshot_state_dict, snapshot_path)
@@ -509,10 +541,17 @@ def load_dcp_from_hf(model: nn.Module, config: ModelConfig, parallel_dims: Paral
                 "Found PrimeRL weight format in snapshot state dict and HF weight format in model state dict. Trying to auto-convert..."
             )
             snapshot_path = snapshot_path / "hf"
-            if not snapshot_path.exists() and get_world().is_master:
+            missing_keys = _get_missing_checkpoint_keys(snapshot_path, expected_load_keys)
+            if missing_keys:
+                logger.warning(
+                    f"Converted HF snapshot at {snapshot_path} is missing {len(missing_keys)} key(s); "
+                    f"rebuilding it. Example missing key: {missing_keys[0]}"
+                )
+            if missing_keys and get_world().is_master:
                 logger.debug(
                     f"Converting snapshot state dict to HF format and saving to {snapshot_path} on master rank. This is a one-time operation."
                 )
+                shutil.rmtree(snapshot_path, ignore_errors=True)
                 snapshot_state_dict = load_state_dict(snapshot_path.parent)
                 model.convert_to_hf(snapshot_state_dict)
                 save_state_dict(snapshot_state_dict, snapshot_path)

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -37,6 +37,7 @@ from prime_rl.trainer.models.layers.checkpointing import (
     supports_selective_activation_checkpointing,
 )
 from prime_rl.trainer.models.layers.lm_head import inject_prime_lm_head
+from prime_rl.trainer.models.layers.mtp import MTPTrainingBatch, configure_mtp_training
 from prime_rl.trainer.models.layers.moe import LatentMoE, MoE
 from prime_rl.trainer.parallel_dims import ParallelDims
 from prime_rl.trainer.weights import (
@@ -135,13 +136,21 @@ def freeze_vision_encoder(model: nn.Module, override_attr: str | None = None) ->
     logger.info(f"Froze {num_frozen} parameters in vision encoder")
 
 
+def _get_mtp_layers(model: nn.Module) -> list[nn.Module]:
+    mtp = getattr(model, "mtp", None)
+    if mtp is None and hasattr(model, "model"):
+        mtp = getattr(model.model, "mtp", None)
+    layers = getattr(mtp, "layers", None)
+    return list(layers) if isinstance(layers, nn.ModuleList) else []
+
+
 def freeze_moe_router(model: nn.Module) -> None:
     """Freeze MoE router parameters to maintain stable routing during training."""
     logger = get_logger()
     language_model = get_language_model(model)
     num_frozen = 0
 
-    for layer in language_model.layers:
+    for layer in [*language_model.layers, *_get_mtp_layers(model)]:
         mlp = layer.mlp if hasattr(layer, "mlp") else layer.feed_forward if hasattr(layer, "feed_forward") else None
         if mlp is None:
             continue
@@ -356,9 +365,10 @@ def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDim
         get_logger().info("Applied FSDP to frozen vision encoder")
 
     language_model = get_language_model(model, override=config.vlm.language_model_attr if is_vlm_training else None)
-    transformer_layers = language_model.layers
+    transformer_layers = list(language_model.layers)
+    mtp_layers = _get_mtp_layers(model)
 
-    for transformer_block in transformer_layers:
+    for transformer_block in [*transformer_layers, *mtp_layers]:
         block_mlp = getattr(transformer_block, "mlp", None)
         if parallel_dims.ep_enabled and block_mlp is not None and isinstance(block_mlp, (MoE, LatentMoE)):
             fully_shard(block_mlp.experts, mesh=dp_mod_ep_mesh, **fsdp_config)
@@ -406,7 +416,7 @@ def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDim
     # if EP is enabled, d2h syncs in the dispatch/combine can interfere with FSDP prefetch, that's why we set it below manually
     # the rest of the function handles only that
 
-    transformer_blocks = list(language_model.layers)
+    transformer_blocks = transformer_layers
     next_transformer_blocks = transformer_blocks[1:] + [None]
 
     embed_module = getattr(language_model, "embed_tokens", None) or getattr(language_model, "embeddings", None)
@@ -426,7 +436,7 @@ def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDim
                 transformer_block.set_modules_to_forward_prefetch([language_model.norm, model.lm_head])
 
     # backward
-    reversed_transformer_blocks = list(reversed(language_model.layers))
+    reversed_transformer_blocks = list(reversed(transformer_layers))
     prev_transformer_blocks = reversed_transformer_blocks[1:] + [None]
 
     if language_model.norm is not None and model.lm_head is not None and len(language_model.layers) > 0:
@@ -568,6 +578,8 @@ def can_reinit_empty_buffers(model: nn.Module):
     # HF standard transformer model
     if len(buffer_names) == 1 and buffer_names[0] == "model.rotary_emb.inv_freq":
         return True
+    if set(buffer_names) == {"model.rotary_emb.inv_freq", "model.rotary_emb.original_inv_freq"}:
+        return True
 
     # Gemma3 model (has embed_scale and local rotary emb)
     gemma3_buffers = {"model.embed_tokens.embed_scale", "model.rotary_emb.inv_freq", "model.rotary_emb_local.inv_freq"}
@@ -583,8 +595,18 @@ def fix_model_post_empty(model: nn.Module):
     # HF standard transformer model
     if "model.rotary_emb.inv_freq" in buffer_names:
         rotary_emb = model.model.rotary_emb
-        inv_freq, rotary_emb.attention_scaling = rotary_emb.rope_init_fn(rotary_emb.config, rotary_emb.inv_freq.device)
+        if hasattr(rotary_emb, "rope_init_fn"):
+            rope_init_fn = rotary_emb.rope_init_fn
+        else:
+            from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
+
+            rope_init_fn = rotary_emb.compute_default_rope_parameters
+            if getattr(rotary_emb, "rope_type", "default") != "default":
+                rope_init_fn = ROPE_INIT_FUNCTIONS[rotary_emb.rope_type]
+        inv_freq, rotary_emb.attention_scaling = rope_init_fn(rotary_emb.config, rotary_emb.inv_freq.device)
         rotary_emb.inv_freq.copy_(inv_freq)
+        if "model.rotary_emb.original_inv_freq" in buffer_names:
+            rotary_emb.original_inv_freq.copy_(inv_freq)
     # Gemma3 local rotary emb
     if "model.rotary_emb_local.inv_freq" in buffer_names:
         rotary_emb_local = model.model.rotary_emb_local
@@ -661,7 +683,7 @@ def apply_compile(model: nn.Module, compile_config: CompileConfig):
 
 def apply_ep(model: nn.Module, parallel_dims: ParallelDims):
     language_model = get_language_model(model)
-    for transformer_block in language_model.layers:
+    for transformer_block in [*language_model.layers, *_get_mtp_layers(model)]:
         block_mlp = getattr(transformer_block, "mlp", None)
         if block_mlp is not None and isinstance(block_mlp, (MoE, LatentMoE)):
             parallelize_module(
@@ -759,6 +781,9 @@ def setup_model(
         lm_head_chunk_size = config.fused_lm_head_token_chunk_size
 
     inject_prime_lm_head(model, chunk_size=lm_head_chunk_size, fused_cross_entropy=fused_cross_entropy)
+    if config.vlm is not None and config.mtp is not None:
+        raise ValueError("MTP training is not supported for vision-language models yet.")
+    configure_mtp_training(model, config.mtp)
 
     # Apply LoRA before FSDP setup
     if config.lora is not None:
@@ -819,6 +844,7 @@ def forward(
     position_ids: Int[Tensor, "batch seq"],
     labels: Int[Tensor, "batch seq"] | None = None,
     temperature: Tensor | None = None,
+    mtp_batch: MTPTrainingBatch | None = None,
     routed_experts: Int[Tensor, "batch seq layers topk"] | None = None,
     # Multimodal fields (Qwen3-VL)
     pixel_values: Float[Tensor, "num_patches patch_dim"] | None = None,
@@ -830,6 +856,8 @@ def forward(
         "labels": labels,
         "temperature": temperature,
     }
+    if mtp_batch is not None:
+        kwargs["mtp_batch"] = mtp_batch
 
     # For multimodal (VLM), don't pass position_ids - let the model compute MRoPE internally
     # using image_grid_thw. Qwen3-VL only computes proper MRoPE when position_ids is None.

--- a/src/prime_rl/trainer/models/layers/lm_head.py
+++ b/src/prime_rl/trainer/models/layers/lm_head.py
@@ -7,6 +7,7 @@ import torch
 import torch.nn as nn
 from torch import Tensor
 
+from prime_rl.trainer.models.layers.mtp import MTPTrainingBatch, compute_mtp_loss
 from prime_rl.utils.logger import get_logger
 
 FUSED_CE_IGNORE_INDEX = -100
@@ -19,6 +20,8 @@ class PrimeLmOutput(TypedDict, total=False):
     logprobs: Tensor | None
     entropy: Tensor | None
     loss: Tensor | None
+    mtp_loss: Tensor | None
+    mtp_loss_sum: Tensor | None
 
 
 def cast_float_and_contiguous(output: PrimeLmOutput) -> PrimeLmOutput:
@@ -32,6 +35,8 @@ def cast_float_and_contiguous(output: PrimeLmOutput) -> PrimeLmOutput:
         logprobs=_float_and_contiguous(output.get("logprobs")),
         entropy=_float_and_contiguous(output.get("entropy")),
         loss=output.get("loss"),
+        mtp_loss=_float_and_contiguous(output.get("mtp_loss")),
+        mtp_loss_sum=_float_and_contiguous(output.get("mtp_loss_sum")),
     )
 
 
@@ -352,6 +357,7 @@ def _patch_model_forward(model: nn.Module) -> None:
         labels: torch.Tensor | None = None,
         logits_to_keep: int = 0,
         temperature: torch.Tensor | None = None,
+        mtp_batch: MTPTrainingBatch | None = None,
         **kwargs: object,
     ) -> PrimeLmOutput:
         # For VLM with images, don't create position_ids - let model compute MRoPE internally
@@ -373,11 +379,17 @@ def _patch_model_forward(model: nn.Module) -> None:
         )
 
         # Pass through the wrapped lm_head
-        return self.lm_head(
+        out = self.lm_head(
             hidden_states[:, slice_indices, :],
             labels[:, slice_indices] if labels is not None else None,
             temperature=temperature[:, slice_indices] if temperature is not None else None,
         )
+        mtp_loss_sum, mtp_loss = compute_mtp_loss(self, hidden_states, mtp_batch)
+        if mtp_loss is not None:
+            out["mtp_loss"] = mtp_loss
+        if mtp_loss_sum is not None:
+            out["mtp_loss_sum"] = mtp_loss_sum
+        return out
 
     # Bind the new forward to the model
     model.forward = types.MethodType(new_forward, model)

--- a/src/prime_rl/trainer/models/layers/lm_head.py
+++ b/src/prime_rl/trainer/models/layers/lm_head.py
@@ -378,13 +378,16 @@ def _patch_model_forward(model: nn.Module) -> None:
             slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) and logits_to_keep > 0 else slice(None)
         )
 
-        # Pass through the wrapped lm_head
+        # Compute MTP loss before the lm_head forward so that the FSDP backward
+        # processes lm_head first and MTP second — matching the reverse of the
+        # forward call order and keeping collective sequences deterministic.
+        mtp_loss_sum, mtp_loss = compute_mtp_loss(self, hidden_states, mtp_batch)
+
         out = self.lm_head(
             hidden_states[:, slice_indices, :],
             labels[:, slice_indices] if labels is not None else None,
             temperature=temperature[:, slice_indices] if temperature is not None else None,
         )
-        mtp_loss_sum, mtp_loss = compute_mtp_loss(self, hidden_states, mtp_batch)
         if mtp_loss is not None:
             out["mtp_loss"] = mtp_loss
         if mtp_loss_sum is not None:

--- a/src/prime_rl/trainer/models/layers/mtp.py
+++ b/src/prime_rl/trainer/models/layers/mtp.py
@@ -1,0 +1,496 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from ring_flash_attn import update_ring_flash_attn_params
+from torch import Tensor, nn
+from transformers.masking_utils import create_causal_mask
+
+from prime_rl.configs.trainer import MTPConfig
+from prime_rl.utils.cp import _get_cu_seqlens_for_cp, shard_for_cp
+
+
+@dataclass
+class MTPLayerBatch:
+    input_ids: Tensor
+    position_ids: Tensor
+    labels: Tensor
+    loss_mask: Tensor
+
+
+@dataclass
+class MTPTrainingBatch:
+    steps: list[MTPLayerBatch]
+    cp_group: dist.ProcessGroup | None = None
+    cp_cu_seqlens: Tensor | None = None
+    attention_cu_seqlens: Tensor | None = None
+    attention_max_seqlen: int | None = None
+
+
+@dataclass
+class MTPRuntime:
+    backbone: nn.Module
+    embed_tokens: nn.Module
+    rotary_emb: nn.Module | None
+    layers: list[nn.Module]
+    run_layer: Callable[
+        [nn.Module, "MTPRuntime", Tensor, Tensor, Tensor, dist.ProcessGroup | None, Tensor | None], Tensor
+    ]
+    container: nn.Module | None = None
+    attention_cu_seqlens: Tensor | None = None
+    attention_max_seqlen: int | None = None
+
+
+def _get_packed_lengths(position_ids: Tensor) -> list[list[int]]:
+    lengths_by_batch: list[list[int]] = []
+    for row in position_ids.tolist():
+        boundaries = [0, *[idx for idx in range(1, len(row)) if row[idx] == 0], len(row)]
+        lengths: list[int] = []
+        for idx, start in enumerate(boundaries[:-1]):
+            end = boundaries[idx + 1]
+            lengths.append(end - start)
+        lengths_by_batch.append(lengths)
+    return lengths_by_batch
+
+
+def _packed_shift_left(tensor: Tensor, lengths_by_batch: list[list[int]], pad_value: int | float | bool) -> Tensor:
+    shifted = torch.full_like(tensor, pad_value)
+    for batch_idx, lengths in enumerate(lengths_by_batch):
+        start = 0
+        for length in lengths:
+            end = start + length
+            if length > 1:
+                shifted[batch_idx, start : end - 1] = tensor[batch_idx, start + 1 : end]
+            start = end
+    return shifted
+
+
+def _get_attention_metadata(
+    position_ids: Tensor, lengths_by_batch: list[list[int]]
+) -> tuple[Tensor | None, int | None]:
+    max_seqlen = max((length for lengths in lengths_by_batch for length in lengths), default=0)
+    if max_seqlen == 0:
+        return None, None
+    return _get_cu_seqlens_for_cp(position_ids), max_seqlen
+
+
+def prepare_mtp_training_batch(
+    input_ids: Tensor,
+    position_ids: Tensor,
+    labels: Tensor,
+    loss_mask: Tensor,
+    num_layers: int,
+) -> MTPTrainingBatch:
+    lengths_by_batch = _get_packed_lengths(position_ids)
+    return _prepare_mtp_training_batch(input_ids, position_ids, labels, loss_mask, num_layers, lengths_by_batch)
+
+
+def prepare_mtp_training_batch_from_current_tokens(
+    input_ids: Tensor,
+    position_ids: Tensor,
+    loss_mask: Tensor,
+    num_layers: int,
+) -> MTPTrainingBatch:
+    lengths_by_batch = _get_packed_lengths(position_ids)
+    labels = _packed_shift_left(input_ids, lengths_by_batch, pad_value=0)
+    aligned_loss_mask = _packed_shift_left(loss_mask.bool(), lengths_by_batch, pad_value=False)
+    return _prepare_mtp_training_batch(
+        input_ids=input_ids,
+        position_ids=position_ids,
+        labels=labels,
+        loss_mask=aligned_loss_mask,
+        num_layers=num_layers,
+        lengths_by_batch=lengths_by_batch,
+    )
+
+
+def _prepare_mtp_training_batch(
+    input_ids: Tensor,
+    position_ids: Tensor,
+    labels: Tensor,
+    loss_mask: Tensor,
+    num_layers: int,
+    lengths_by_batch: list[list[int]],
+) -> MTPTrainingBatch:
+    attention_cu_seqlens, attention_max_seqlen = _get_attention_metadata(position_ids, lengths_by_batch)
+    current_input_ids = input_ids
+    current_position_ids = position_ids
+    current_labels = labels
+    current_loss_mask = loss_mask.bool()
+
+    steps: list[MTPLayerBatch] = []
+
+    for _ in range(num_layers):
+        current_input_ids = _packed_shift_left(current_input_ids, lengths_by_batch, pad_value=0)
+        current_position_ids = _packed_shift_left(current_position_ids, lengths_by_batch, pad_value=0)
+        current_labels = _packed_shift_left(current_labels, lengths_by_batch, pad_value=0)
+        shifted_loss_mask = _packed_shift_left(current_loss_mask, lengths_by_batch, pad_value=False)
+        current_loss_mask = current_loss_mask & shifted_loss_mask
+
+        steps.append(
+            MTPLayerBatch(
+                input_ids=current_input_ids,
+                position_ids=current_position_ids,
+                labels=current_labels,
+                loss_mask=current_loss_mask,
+            )
+        )
+
+    return MTPTrainingBatch(
+        steps=steps,
+        attention_cu_seqlens=attention_cu_seqlens,
+        attention_max_seqlen=attention_max_seqlen,
+    )
+
+
+def shard_mtp_training_batch_for_cp(
+    batch: MTPTrainingBatch,
+    original_position_ids: Tensor,
+    cp_rank: int,
+    cp_world_size: int,
+    cp_group: dist.ProcessGroup,
+) -> MTPTrainingBatch:
+    return MTPTrainingBatch(
+        steps=[
+            MTPLayerBatch(
+                input_ids=shard_for_cp(step.input_ids, cp_rank=cp_rank, cp_world_size=cp_world_size),
+                position_ids=shard_for_cp(step.position_ids, cp_rank=cp_rank, cp_world_size=cp_world_size),
+                labels=shard_for_cp(step.labels, cp_rank=cp_rank, cp_world_size=cp_world_size),
+                loss_mask=shard_for_cp(step.loss_mask, cp_rank=cp_rank, cp_world_size=cp_world_size),
+            )
+            for step in batch.steps
+        ],
+        cp_group=cp_group,
+        cp_cu_seqlens=_get_cu_seqlens_for_cp(original_position_ids),
+        attention_cu_seqlens=batch.attention_cu_seqlens,
+        attention_max_seqlen=batch.attention_max_seqlen,
+    )
+
+
+def _looks_like_mimo_layer(layer: nn.Module) -> bool:
+    required = (
+        "token_layernorm",
+        "hidden_layernorm",
+        "input_proj",
+        "input_layernorm",
+        "self_attn",
+        "post_attention_layernorm",
+        "mlp",
+        "final_layernorm",
+    )
+    return all(hasattr(layer, name) for name in required)
+
+
+def _looks_like_qwen_next_container(container: nn.Module) -> bool:
+    required = ("pre_fc_norm_embedding", "pre_fc_norm_hidden", "fc", "norm", "layers")
+    return all(hasattr(container, name) for name in required)
+
+
+def _looks_like_nemotron_container(container: nn.Module) -> bool:
+    return getattr(container, "prime_mtp_kind", None) == "nemotron_h" and hasattr(container, "layers")
+
+
+def _looks_like_megatron_mtp_layer(layer: nn.Module) -> bool:
+    required = ("enorm", "hnorm", "eh_proj", "transformer_layer", "final_layernorm")
+    return all(hasattr(layer, name) for name in required)
+
+
+def _resolve_mtp_runtime(model: nn.Module, num_layers: int) -> MTPRuntime:
+    backbone = getattr(model, "model", None)
+    if not isinstance(backbone, nn.Module):
+        raise ValueError("MTP training requires a model backbone at `model.model`.")
+
+    embed_tokens = getattr(backbone, "embed_tokens", None)
+    if not isinstance(embed_tokens, nn.Module):
+        raise ValueError("MTP training requires a token embedding module at `model.model.embed_tokens`.")
+
+    rotary_emb = getattr(backbone, "rotary_emb", None)
+
+    mtp_layers = getattr(backbone, "mtp_layers", None)
+    if isinstance(mtp_layers, nn.ModuleList) and len(mtp_layers) >= num_layers:
+        if not _looks_like_mimo_layer(mtp_layers[0]) and not _looks_like_megatron_mtp_layer(mtp_layers[0]):
+            raise ValueError("Found `model.model.mtp_layers`, but the layer structure is not supported yet.")
+        run_layer = _run_mimo_layer if _looks_like_mimo_layer(mtp_layers[0]) else _run_megatron_style_layer
+        return MTPRuntime(
+            backbone=backbone,
+            embed_tokens=embed_tokens,
+            rotary_emb=rotary_emb,
+            layers=list(mtp_layers[:num_layers]),
+            run_layer=run_layer,
+        )
+
+    mtp_container = getattr(model, "mtp", None)
+    if mtp_container is None:
+        mtp_container = getattr(backbone, "mtp", None)
+    if isinstance(mtp_container, nn.Module) and _looks_like_nemotron_container(mtp_container):
+        return MTPRuntime(
+            backbone=backbone,
+            embed_tokens=embed_tokens,
+            rotary_emb=rotary_emb,
+            layers=[mtp_container for _ in range(num_layers)],
+            run_layer=_run_nemotron_container,
+            container=mtp_container,
+        )
+    if isinstance(mtp_container, nn.Module) and _looks_like_qwen_next_container(mtp_container):
+        layers = getattr(mtp_container, "layers")
+        if isinstance(layers, nn.ModuleList) and len(layers) >= num_layers:
+            return MTPRuntime(
+                backbone=backbone,
+                embed_tokens=embed_tokens,
+                rotary_emb=rotary_emb,
+                layers=list(layers[:num_layers]),
+                run_layer=_run_qwen_next_container_layer,
+                container=mtp_container,
+            )
+
+    raise ValueError(
+        "MTP training is enabled, but the loaded model does not expose a supported MTP module layout. "
+        "Currently supported layouts are MiMo-style `model.model.mtp_layers`, Qwen-style `mtp.layers`, "
+        "and Nemotron-style shared `mtp` containers."
+    )
+
+
+def configure_mtp_training(model: nn.Module, mtp_config: MTPConfig | None) -> None:
+    setattr(model, "_prime_mtp_config", mtp_config)
+    if mtp_config is None:
+        setattr(model, "_prime_mtp_runtime", None)
+        return
+    setattr(model, "_prime_mtp_runtime", _resolve_mtp_runtime(model, mtp_config.num_layers))
+
+
+def _get_configured_mtp_runtime(model: nn.Module) -> tuple[MTPConfig | None, MTPRuntime | None]:
+    return getattr(model, "_prime_mtp_config", None), getattr(model, "_prime_mtp_runtime", None)
+
+
+def _update_mtp_cp_state(cp_group: dist.ProcessGroup | None, cp_cu_seqlens: Tensor | None) -> None:
+    if cp_group is None or cp_cu_seqlens is None:
+        return
+    update_ring_flash_attn_params(cp_cu_seqlens, cp_group)
+
+
+def _apply_output_head(hidden_states: Tensor, model: nn.Module) -> Tensor:
+    lm_head = getattr(model, "lm_head", None)
+    if not isinstance(lm_head, nn.Module) or not hasattr(lm_head, "weight"):
+        raise ValueError("MTP training requires an lm_head with a shared `weight` parameter.")
+
+    logits = F.linear(hidden_states, lm_head.weight.detach())
+    softcap = getattr(getattr(model, "config", None), "final_logit_softcapping", None)
+    if softcap is not None:
+        logits = softcap * torch.tanh(logits / softcap)
+    return logits
+
+
+def _build_causal_mask(runtime: MTPRuntime, inputs_embeds: Tensor, position_ids: Tensor) -> Tensor:
+    cache_position = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device)
+    return create_causal_mask(
+        config=runtime.backbone.config,
+        inputs_embeds=inputs_embeds,
+        attention_mask=None,
+        cache_position=cache_position,
+        past_key_values=None,
+        position_ids=position_ids,
+    )
+
+
+def _build_linear_attn_mask(runtime: MTPRuntime) -> Tensor | None:
+    update_mask = getattr(runtime.backbone, "_update_linear_attn_mask", None)
+    if update_mask is None:
+        return None
+    return update_mask(attention_mask=None, past_key_values=None)
+
+
+def _get_position_embeddings(
+    runtime: MTPRuntime, hidden_states: Tensor, position_ids: Tensor
+) -> Tensor | tuple[Tensor, Tensor] | None:
+    if runtime.rotary_emb is None:
+        return None
+    return runtime.rotary_emb(hidden_states, position_ids)
+
+
+def _run_mimo_layer(
+    layer: nn.Module,
+    runtime: MTPRuntime,
+    input_embeds: Tensor,
+    hidden_states: Tensor,
+    position_ids: Tensor,
+    cp_group: dist.ProcessGroup | None,
+    cp_cu_seqlens: Tensor | None,
+) -> Tensor:
+    _update_mtp_cp_state(cp_group, cp_cu_seqlens)
+    attention_mask = _build_causal_mask(runtime, input_embeds, position_ids)
+    position_embeddings = _get_position_embeddings(runtime, hidden_states, position_ids)
+
+    input_embeds = layer.token_layernorm(input_embeds)
+    hidden_states = layer.hidden_layernorm(hidden_states)
+    hidden_states = layer.input_proj(torch.cat([hidden_states, input_embeds], dim=-1))
+
+    residual = hidden_states
+    hidden_states = layer.input_layernorm(hidden_states)
+    hidden_states, _ = layer.self_attn(
+        hidden_states=hidden_states,
+        attention_mask=attention_mask,
+        position_ids=position_ids,
+        past_key_values=None,
+        use_cache=False,
+        position_embeddings=position_embeddings,
+    )
+    hidden_states = residual + hidden_states
+
+    residual = hidden_states
+    hidden_states = layer.post_attention_layernorm(hidden_states)
+    hidden_states = layer.mlp(hidden_states)
+    if isinstance(hidden_states, tuple):
+        hidden_states = hidden_states[0]
+    hidden_states = residual + hidden_states
+    hidden_states = layer.final_layernorm(hidden_states)
+    return hidden_states
+
+
+def _run_qwen_next_container_layer(
+    layer: nn.Module,
+    runtime: MTPRuntime,
+    input_embeds: Tensor,
+    hidden_states: Tensor,
+    position_ids: Tensor,
+    cp_group: dist.ProcessGroup | None,
+    cp_cu_seqlens: Tensor | None,
+) -> Tensor:
+    assert runtime.container is not None
+
+    _update_mtp_cp_state(cp_group, cp_cu_seqlens)
+    causal_mask = _build_causal_mask(runtime, input_embeds, position_ids)
+    linear_attn_mask = _build_linear_attn_mask(runtime)
+    position_embeddings = _get_position_embeddings(runtime, hidden_states, position_ids)
+    cache_position = torch.arange(input_embeds.shape[1], device=input_embeds.device)
+
+    input_embeds = runtime.container.pre_fc_norm_embedding(input_embeds)
+    hidden_states = runtime.container.pre_fc_norm_hidden(hidden_states)
+    hidden_states = runtime.container.fc(torch.cat([input_embeds, hidden_states], dim=-1))
+    hidden_states = layer(
+        hidden_states=hidden_states,
+        attention_mask=linear_attn_mask if getattr(layer, "layer_type", None) == "linear_attention" else causal_mask,
+        position_ids=position_ids,
+        past_key_values=None,
+        use_cache=False,
+        cache_position=cache_position,
+        position_embeddings=position_embeddings,
+    )
+    return runtime.container.norm(hidden_states)
+
+
+def _run_nemotron_container(
+    layer: nn.Module,
+    runtime: MTPRuntime,
+    input_embeds: Tensor,
+    hidden_states: Tensor,
+    position_ids: Tensor,
+    cp_group: dist.ProcessGroup | None,
+    cp_cu_seqlens: Tensor | None,
+) -> Tensor:
+    _update_mtp_cp_state(cp_group, cp_cu_seqlens)
+    output = layer(
+        input_embeds=input_embeds,
+        hidden_states=hidden_states,
+        position_ids=position_ids,
+        cu_seqlens=runtime.attention_cu_seqlens,
+        max_seqlen=runtime.attention_max_seqlen,
+    )
+    if isinstance(output, tuple):
+        output = output[0]
+    return output
+
+
+def _run_megatron_style_layer(
+    layer: nn.Module,
+    runtime: MTPRuntime,
+    input_embeds: Tensor,
+    hidden_states: Tensor,
+    position_ids: Tensor,
+    cp_group: dist.ProcessGroup | None,
+    cp_cu_seqlens: Tensor | None,
+) -> Tensor:
+    _update_mtp_cp_state(cp_group, cp_cu_seqlens)
+    attention_mask = _build_causal_mask(runtime, input_embeds, position_ids)
+    position_embeddings = _get_position_embeddings(runtime, hidden_states, position_ids)
+
+    input_embeds = layer.enorm(input_embeds)
+    hidden_states = layer.hnorm(hidden_states)
+    hidden_states = layer.eh_proj(torch.cat([input_embeds, hidden_states], dim=-1))
+    if isinstance(hidden_states, tuple):
+        hidden_states = hidden_states[0]
+    hidden_states = layer.transformer_layer(
+        hidden_states=hidden_states,
+        attention_mask=attention_mask,
+        position_ids=position_ids,
+        past_key_values=None,
+        use_cache=False,
+        position_embeddings=position_embeddings,
+    )
+    if isinstance(hidden_states, tuple):
+        hidden_states = hidden_states[0]
+    return layer.final_layernorm(hidden_states)
+
+
+def compute_mtp_loss(
+    model: nn.Module,
+    hidden_states: Tensor,
+    mtp_batch: MTPTrainingBatch | None,
+) -> tuple[Tensor | None, Tensor | None]:
+    mtp_config, runtime = _get_configured_mtp_runtime(model)
+    if mtp_config is None or runtime is None or mtp_batch is None:
+        return None, None
+
+    mtp_hidden_states = hidden_states.detach()
+    runtime.attention_cu_seqlens = mtp_batch.attention_cu_seqlens
+    runtime.attention_max_seqlen = mtp_batch.attention_max_seqlen
+    raw_loss_sum = hidden_states.new_zeros(())
+    raw_token_count = hidden_states.new_zeros((), dtype=torch.long)
+    scaled_loss_sum = hidden_states.new_zeros(())
+    layer_scale = mtp_config.loss_scaling_factor / mtp_config.num_layers
+
+    for layer, batch_step in zip(runtime.layers, mtp_batch.steps, strict=True):
+        input_ids = batch_step.input_ids
+        position_ids = batch_step.position_ids
+        labels = batch_step.labels
+        loss_mask = batch_step.loss_mask
+
+        input_embeds = runtime.embed_tokens(input_ids).detach()
+        mtp_hidden_states = runtime.run_layer(
+            layer,
+            runtime,
+            input_embeds,
+            mtp_hidden_states,
+            position_ids,
+            mtp_batch.cp_group,
+            mtp_batch.cp_cu_seqlens,
+        )
+
+        logits = _apply_output_head(mtp_hidden_states, model)
+        token_loss = F.cross_entropy(
+            logits.reshape(-1, logits.shape[-1]),
+            labels.reshape(-1),
+            reduction="none",
+        ).view_as(labels)
+        masked_loss_sum = token_loss[loss_mask].sum()
+        raw_loss_sum = raw_loss_sum + masked_loss_sum
+        raw_token_count = raw_token_count + loss_mask.sum(dtype=torch.long)
+        scaled_loss_sum = scaled_loss_sum + masked_loss_sum * layer_scale
+    if raw_token_count.item() == 0:
+        zero = hidden_states.new_zeros(())
+        return zero, zero
+
+    return scaled_loss_sum, raw_loss_sum / raw_token_count
+
+
+__all__ = [
+    "MTPTrainingBatch",
+    "compute_mtp_loss",
+    "configure_mtp_training",
+    "prepare_mtp_training_batch",
+    "prepare_mtp_training_batch_from_current_tokens",
+    "shard_mtp_training_batch_for_cp",
+]

--- a/src/prime_rl/trainer/models/layers/mtp.py
+++ b/src/prime_rl/trainer/models/layers/mtp.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import inspect
 from typing import Callable
 
 import torch
@@ -12,6 +13,7 @@ from transformers.masking_utils import create_causal_mask
 
 from prime_rl.configs.trainer import MTPConfig
 from prime_rl.utils.cp import _get_cu_seqlens_for_cp, shard_for_cp
+from prime_rl.utils.vlm import get_language_model
 
 
 @dataclass
@@ -199,21 +201,36 @@ def _looks_like_megatron_mtp_layer(layer: nn.Module) -> bool:
     return all(hasattr(layer, name) for name in required)
 
 
-def _resolve_mtp_runtime(model: nn.Module, num_layers: int) -> MTPRuntime:
-    backbone = getattr(model, "model", None)
-    if not isinstance(backbone, nn.Module):
-        raise ValueError("MTP training requires a model backbone at `model.model`.")
+def _looks_like_qwen3_5_moe_decoder_layer(layer: nn.Module) -> bool:
+    params = inspect.signature(layer.forward).parameters
+    return "cu_seqlens" in params and "max_seqlen" in params and "attention_mask" not in params
+
+
+def _resolve_mtp_embed_tokens(backbone: nn.Module, mtp_container: nn.Module | None = None) -> nn.Module:
+    if isinstance(mtp_container, nn.Module):
+        container_embed_tokens = getattr(mtp_container, "embed_tokens", None)
+        if isinstance(container_embed_tokens, nn.Module):
+            return container_embed_tokens
 
     embed_tokens = getattr(backbone, "embed_tokens", None)
-    if not isinstance(embed_tokens, nn.Module):
-        raise ValueError("MTP training requires a token embedding module at `model.model.embed_tokens`.")
+    if isinstance(embed_tokens, nn.Module):
+        return embed_tokens
+
+    raise ValueError("MTP training requires a token embedding module on the language backbone or MTP container.")
+
+
+def _resolve_mtp_runtime(model: nn.Module, num_layers: int) -> MTPRuntime:
+    backbone = get_language_model(model)
+    if not isinstance(backbone, nn.Module):
+        raise ValueError("MTP training requires a language model backbone.")
 
     rotary_emb = getattr(backbone, "rotary_emb", None)
 
     mtp_layers = getattr(backbone, "mtp_layers", None)
     if isinstance(mtp_layers, nn.ModuleList) and len(mtp_layers) >= num_layers:
         if not _looks_like_mimo_layer(mtp_layers[0]) and not _looks_like_megatron_mtp_layer(mtp_layers[0]):
-            raise ValueError("Found `model.model.mtp_layers`, but the layer structure is not supported yet.")
+            raise ValueError("Found `mtp_layers` on the language backbone, but the layer structure is not supported yet.")
+        embed_tokens = _resolve_mtp_embed_tokens(backbone)
         run_layer = _run_mimo_layer if _looks_like_mimo_layer(mtp_layers[0]) else _run_megatron_style_layer
         return MTPRuntime(
             backbone=backbone,
@@ -226,6 +243,10 @@ def _resolve_mtp_runtime(model: nn.Module, num_layers: int) -> MTPRuntime:
     mtp_container = getattr(model, "mtp", None)
     if mtp_container is None:
         mtp_container = getattr(backbone, "mtp", None)
+    embed_tokens = _resolve_mtp_embed_tokens(
+        backbone,
+        mtp_container if isinstance(mtp_container, nn.Module) else None,
+    )
     if isinstance(mtp_container, nn.Module) and _looks_like_nemotron_container(mtp_container):
         return MTPRuntime(
             backbone=backbone,
@@ -238,12 +259,17 @@ def _resolve_mtp_runtime(model: nn.Module, num_layers: int) -> MTPRuntime:
     if isinstance(mtp_container, nn.Module) and _looks_like_qwen_next_container(mtp_container):
         layers = getattr(mtp_container, "layers")
         if isinstance(layers, nn.ModuleList) and len(layers) >= num_layers:
+            run_layer = (
+                _run_qwen3_5_moe_container_layer
+                if _looks_like_qwen3_5_moe_decoder_layer(layers[0])
+                else _run_qwen_next_container_layer
+            )
             return MTPRuntime(
                 backbone=backbone,
                 embed_tokens=embed_tokens,
                 rotary_emb=rotary_emb,
                 layers=list(layers[:num_layers]),
-                run_layer=_run_qwen_next_container_layer,
+                run_layer=run_layer,
                 container=mtp_container,
             )
 
@@ -282,6 +308,59 @@ def _apply_output_head(hidden_states: Tensor, model: nn.Module) -> Tensor:
     if softcap is not None:
         logits = softcap * torch.tanh(logits / softcap)
     return logits
+
+
+def _compute_masked_mtp_loss_sum(
+    hidden_states: Tensor,
+    labels: Tensor,
+    loss_mask: Tensor,
+    model: nn.Module,
+) -> tuple[Tensor, Tensor]:
+    masked_token_count = loss_mask.sum(dtype=torch.long)
+    if masked_token_count.item() == 0:
+        # Maintain a gradient path through hidden_states so that FSDP backward
+        # hooks for the MTP layer fire on every rank, keeping the collective
+        # sequence consistent across ranks and preventing NCCL deadlocks.
+        return hidden_states.flatten()[0] * 0, masked_token_count
+
+    masked_hidden_states = hidden_states[loss_mask]
+    masked_labels = labels[loss_mask]
+
+    lm_head = getattr(model, "lm_head", None)
+    softcap = getattr(getattr(model, "config", None), "final_logit_softcapping", None)
+    if (
+        isinstance(lm_head, nn.Module)
+        and hasattr(lm_head, "weight")
+        and softcap is None
+        and masked_hidden_states.is_cuda
+        and masked_labels.is_cuda
+    ):
+        try:
+            from quack.linear_cross_entropy import chunked_linear_cross_entropy
+        except ImportError:
+            pass
+        else:
+            if masked_hidden_states.shape[0] % 8 != 0:
+                pad_tokens = (-masked_hidden_states.shape[0]) % 8
+                masked_hidden_states = torch.cat(
+                    [masked_hidden_states, masked_hidden_states.new_zeros((pad_tokens, masked_hidden_states.shape[-1]))],
+                    dim=0,
+                )
+                masked_labels = torch.cat([masked_labels, masked_labels.new_full((pad_tokens,), -100)], dim=0)
+            return (
+                chunked_linear_cross_entropy(
+                    masked_hidden_states.contiguous(),
+                    lm_head.weight.detach(),
+                    masked_labels.contiguous(),
+                    chunk_size=4096,
+                    ignore_index=-100,
+                    reduction="sum",
+                ),
+                masked_token_count,
+            )
+
+    logits = _apply_output_head(masked_hidden_states, model)
+    return F.cross_entropy(logits, masked_labels, reduction="sum"), masked_token_count
 
 
 def _build_causal_mask(runtime: MTPRuntime, inputs_embeds: Tensor, position_ids: Tensor) -> Tensor:
@@ -382,6 +461,32 @@ def _run_qwen_next_container_layer(
     return runtime.container.norm(hidden_states)
 
 
+def _run_qwen3_5_moe_container_layer(
+    layer: nn.Module,
+    runtime: MTPRuntime,
+    input_embeds: Tensor,
+    hidden_states: Tensor,
+    position_ids: Tensor,
+    cp_group: dist.ProcessGroup | None,
+    cp_cu_seqlens: Tensor | None,
+) -> Tensor:
+    assert runtime.container is not None
+
+    _update_mtp_cp_state(cp_group, cp_cu_seqlens)
+    position_embeddings = _get_position_embeddings(runtime, hidden_states, position_ids)
+
+    input_embeds = runtime.container.pre_fc_norm_embedding(input_embeds)
+    hidden_states = runtime.container.pre_fc_norm_hidden(hidden_states)
+    hidden_states = runtime.container.fc(torch.cat([input_embeds, hidden_states], dim=-1))
+    hidden_states = layer(
+        hidden_states=hidden_states,
+        position_embeddings=position_embeddings,
+        cu_seqlens=runtime.attention_cu_seqlens,
+        max_seqlen=runtime.attention_max_seqlen,
+    )
+    return runtime.container.norm(hidden_states)
+
+
 def _run_nemotron_container(
     layer: nn.Module,
     runtime: MTPRuntime,
@@ -469,15 +574,11 @@ def compute_mtp_loss(
             mtp_batch.cp_cu_seqlens,
         )
 
-        logits = _apply_output_head(mtp_hidden_states, model)
-        token_loss = F.cross_entropy(
-            logits.reshape(-1, logits.shape[-1]),
-            labels.reshape(-1),
-            reduction="none",
-        ).view_as(labels)
-        masked_loss_sum = token_loss[loss_mask].sum()
+        masked_loss_sum, masked_token_count = _compute_masked_mtp_loss_sum(
+            mtp_hidden_states, labels, loss_mask, model
+        )
         raw_loss_sum = raw_loss_sum + masked_loss_sum
-        raw_token_count = raw_token_count + loss_mask.sum(dtype=torch.long)
+        raw_token_count = raw_token_count + masked_token_count
         scaled_loss_sum = scaled_loss_sum + masked_loss_sum * layer_scale
     if raw_token_count.item() == 0:
         zero = hidden_states.new_zeros(())

--- a/src/prime_rl/trainer/models/nemotron_h/configuration_nemotron_h.py
+++ b/src/prime_rl/trainer/models/nemotron_h/configuration_nemotron_h.py
@@ -64,6 +64,21 @@ class NemotronHConfig(PretrainedConfig):
     PATTERN_MAP = {"M": "mamba", "E": "moe", "*": "attention"}
     REVERSE_PATTERN_MAP = {"mamba": "M", "moe": "E", "attention": "*"}
 
+    @staticmethod
+    def _validate_layers_block_type(
+        layers_block_type, expected_length: int | None = None, param_name: str = "layers_block_type"
+    ) -> None:
+        if not isinstance(layers_block_type, list):
+            raise ValueError(f"{param_name} must be a list of strings. Got type: {type(layers_block_type)}")
+
+        if expected_length is not None and len(layers_block_type) != expected_length:
+            raise ValueError(f"{param_name} must have length {expected_length}. Got length {len(layers_block_type)}.")
+
+        valid_types = {"mamba", "attention", "moe"}
+        if not all(block_type in valid_types for block_type in layers_block_type):
+            invalid = set(layers_block_type) - valid_types
+            raise ValueError(f"{param_name} contains invalid types: {invalid}. Must be one of: {valid_types}")
+
     def __init__(
         self,
         # General
@@ -121,6 +136,9 @@ class NemotronHConfig(PretrainedConfig):
         # PrimeRL training features
         load_balance_coeff=None,
         use_grouped_mm=True,
+        # MTP
+        num_nextn_predict_layers=0,
+        mtp_layers_block_type=None,
         # RoPE
         rope_theta=10000.0,
         rope_scaling=None,
@@ -132,8 +150,15 @@ class NemotronHConfig(PretrainedConfig):
             if layers_block_type is None:
                 layers_block_type = [self.PATTERN_MAP[c] for c in pattern]
 
+        if "mtp_hybrid_override_pattern" in kwargs:
+            pattern = kwargs.pop("mtp_hybrid_override_pattern")
+            if mtp_layers_block_type is None:
+                mtp_layers_block_type = [self.PATTERN_MAP[c] for c in pattern]
+
         if layers_block_type is None:
             layers_block_type = ["mamba", "moe", "attention", "moe"]
+        if mtp_layers_block_type is None:
+            mtp_layers_block_type = ["attention", "moe"]
 
         self.vocab_size = vocab_size
         self.hidden_size = hidden_size
@@ -205,6 +230,15 @@ class NemotronHConfig(PretrainedConfig):
         # PrimeRL training features
         self.load_balance_coeff = load_balance_coeff
         self.use_grouped_mm = use_grouped_mm
+        self.num_nextn_predict_layers = num_nextn_predict_layers
+
+        if self.num_nextn_predict_layers > 0:
+            self._validate_layers_block_type(
+                mtp_layers_block_type,
+                expected_length=None,
+                param_name="mtp_layers_block_type",
+            )
+        self.mtp_layers_block_type = mtp_layers_block_type
 
         super().__init__(
             pad_token_id=pad_token_id,
@@ -222,6 +256,10 @@ class NemotronHConfig(PretrainedConfig):
     def num_hidden_layers(self, value):
         if value is not None and value < len(self.layers_block_type):
             self.layers_block_type = self.layers_block_type[:value]
+
+    @property
+    def mtp_hybrid_override_pattern(self) -> str:
+        return "".join(self.REVERSE_PATTERN_MAP[layer_type] for layer_type in self.mtp_layers_block_type)
 
 
 __all__ = ["NemotronHConfig"]

--- a/src/prime_rl/trainer/models/nemotron_h/converting_nemotron_h.py
+++ b/src/prime_rl/trainer/models/nemotron_h/converting_nemotron_h.py
@@ -4,17 +4,18 @@ HF NemotronH uses a unified `mixer` attribute for all layer types:
   - Mamba layers: backbone.layers.{i}.mixer.{in_proj, conv1d, ...}
   - Attention layers: backbone.layers.{i}.mixer.{q_proj, k_proj, v_proj, o_proj}
   - MoE layers: backbone.layers.{i}.mixer.{gate, experts, shared_experts, fc1_latent_proj, fc2_latent_proj}
+  - MTP layers: mtp.layers.{i}.* with the same mixer naming plus extra fusion/norm weights
 
 PrimeRL separates these into distinct namespaces:
   - Mamba layers: model.layers.{i}.mamba.*
   - Attention layers: model.layers.{i}.self_attn.*
   - MoE layers: model.layers.{i}.mlp.{router, experts, shared_expert, fc1_latent_proj, fc2_latent_proj}
+  - MTP layers: mtp.layers.{i}.*
 
 Global renames:
   - HF: backbone.embeddings.weight <-> PrimeRL: model.embed_tokens.weight
   - HF: backbone.norm_f.weight <-> PrimeRL: model.norm.weight
   - HF uses "backbone." prefix, PrimeRL uses "model." prefix
-  - HF mtp.* keys (multi-token prediction) are dropped during conversion
 """
 
 import torch
@@ -29,16 +30,53 @@ def _rename_keys(state_dict: dict[str, Tensor], old_prefix: str, new_prefix: str
         state_dict[new_key] = state_dict.pop(key)
 
 
-def convert_hf_layer_to_prime(state_dict: dict[str, Tensor], layer_idx: int, layer_type: str):
-    """Convert a single layer from HF to PrimeRL format in-place."""
-    prefix = f"model.layers.{layer_idx}."
+def _get_max_layer_num(state_dict: dict[str, Tensor], layers_prefix: str) -> int | None:
+    layer_keys = [k for k in state_dict if k.startswith(layers_prefix)]
+    if not layer_keys:
+        return None
+    return max(int(k[len(layers_prefix) :].split(".")[0]) for k in layer_keys) + 1
 
-    if layer_type == "moe":
-        _convert_hf_moe_layer_to_prime(state_dict, prefix)
-    elif layer_type == "attention":
-        _convert_hf_attention_layer_to_prime(state_dict, prefix)
-    elif layer_type == "mamba":
-        _rename_keys(state_dict, f"{prefix}mixer.", f"{prefix}mamba.")
+
+def _infer_layer_type_hf_at_prefix(state_dict: dict[str, Tensor], prefix: str) -> str:
+    layer_keys = [k for k in state_dict if k.startswith(prefix)]
+    if not layer_keys:
+        return "mamba"
+
+    for key in layer_keys:
+        suffix = key[len(prefix) :]
+        if suffix.startswith("mixer.gate.") or suffix.startswith("mixer.experts."):
+            return "moe"
+        if suffix.startswith("mixer.q_proj") or suffix.startswith("mixer.k_proj"):
+            return "attention"
+    return "mamba"
+
+
+def _infer_layer_type_prime_at_prefix(state_dict: dict[str, Tensor], prefix: str) -> str:
+    for key in state_dict:
+        if not key.startswith(prefix):
+            continue
+        suffix = key[len(prefix) :]
+        if suffix.startswith("mlp."):
+            return "moe"
+        if suffix.startswith("self_attn."):
+            return "attention"
+        if suffix.startswith("mamba."):
+            return "mamba"
+    return "mamba"
+
+
+def _infer_layer_types_from_hf(state_dict: dict[str, Tensor], layers_prefix: str) -> list[str]:
+    max_layer = _get_max_layer_num(state_dict, layers_prefix)
+    if max_layer is None:
+        return []
+    return [_infer_layer_type_hf_at_prefix(state_dict, f"{layers_prefix}{i}.") for i in range(max_layer)]
+
+
+def _infer_layer_types_from_prime(state_dict: dict[str, Tensor], layers_prefix: str) -> list[str]:
+    max_layer = _get_max_layer_num(state_dict, layers_prefix)
+    if max_layer is None:
+        return []
+    return [_infer_layer_type_prime_at_prefix(state_dict, f"{layers_prefix}{i}.") for i in range(max_layer)]
 
 
 def _convert_hf_moe_layer_to_prime(state_dict: dict[str, Tensor], prefix: str):
@@ -46,14 +84,11 @@ def _convert_hf_moe_layer_to_prime(state_dict: dict[str, Tensor], prefix: str):
     mixer = f"{prefix}mixer."
     mlp = f"{prefix}mlp."
 
-    # Router: gate.weight -> router.gate (nn.Parameter), gate.e_score_correction_bias -> router.e_score_correction_bias
     if f"{mixer}gate.weight" in state_dict:
         state_dict[f"{mlp}router.gate"] = state_dict.pop(f"{mixer}gate.weight")
     if f"{mixer}gate.e_score_correction_bias" in state_dict:
         state_dict[f"{mlp}router.e_score_correction_bias"] = state_dict.pop(f"{mixer}gate.e_score_correction_bias")
 
-    # Experts: check if stored as individual weights (experts.{i}.up_proj.weight)
-    # or fused 3D tensors (experts.up_proj)
     individual_keys = [
         k
         for k in state_dict
@@ -69,39 +104,35 @@ def _convert_hf_moe_layer_to_prime(state_dict: dict[str, Tensor], prefix: str):
         down_projs = [state_dict.pop(f"{mixer}experts.{i}.down_proj.weight") for i in expert_indices]
         state_dict[f"{mlp}experts.w2"] = torch.stack(down_projs)
     else:
-        # Fused 3D tensors
         if f"{mixer}experts.up_proj" in state_dict:
             state_dict[f"{mlp}experts.w1"] = state_dict.pop(f"{mixer}experts.up_proj")
         if f"{mixer}experts.down_proj" in state_dict:
             state_dict[f"{mlp}experts.w2"] = state_dict.pop(f"{mixer}experts.down_proj")
 
-    # Dummy w3 required by @expert_parallel decorator compatibility
     device = state_dict[f"{mlp}experts.w1"].device if f"{mlp}experts.w1" in state_dict else "cpu"
     state_dict[f"{mlp}experts.w3"] = torch.empty(0, device=device)
 
-    # Shared expert
     _rename_keys(state_dict, f"{mixer}shared_experts.", f"{mlp}shared_expert.")
-
-    # Latent projections
     _rename_keys(state_dict, f"{mixer}fc1_latent_proj.", f"{mlp}fc1_latent_proj.")
     _rename_keys(state_dict, f"{mixer}fc2_latent_proj.", f"{mlp}fc2_latent_proj.")
 
 
 def _convert_hf_attention_layer_to_prime(state_dict: dict[str, Tensor], prefix: str):
-    """Convert attention layer: mixer.{q,k,v,o}_proj -> self_attn.{q,k,v,o}_proj."""
     _rename_keys(state_dict, f"{prefix}mixer.", f"{prefix}self_attn.")
 
 
-def convert_prime_layer_to_hf(state_dict: dict[str, Tensor], layer_idx: int, layer_type: str):
-    """Convert a single layer from PrimeRL to HF format in-place."""
-    prefix = f"model.layers.{layer_idx}."
-
+def _convert_hf_layer_to_prime_at_prefix(state_dict: dict[str, Tensor], prefix: str, layer_type: str):
     if layer_type == "moe":
-        _convert_prime_moe_layer_to_hf(state_dict, prefix)
+        _convert_hf_moe_layer_to_prime(state_dict, prefix)
     elif layer_type == "attention":
-        _rename_keys(state_dict, f"{prefix}self_attn.", f"{prefix}mixer.")
+        _convert_hf_attention_layer_to_prime(state_dict, prefix)
     elif layer_type == "mamba":
-        _rename_keys(state_dict, f"{prefix}mamba.", f"{prefix}mixer.")
+        _rename_keys(state_dict, f"{prefix}mixer.", f"{prefix}mamba.")
+
+
+def convert_hf_layer_to_prime(state_dict: dict[str, Tensor], layer_idx: int, layer_type: str):
+    """Convert a single backbone layer from HF to PrimeRL format in-place."""
+    _convert_hf_layer_to_prime_at_prefix(state_dict, f"model.layers.{layer_idx}.", layer_type)
 
 
 def _convert_prime_moe_layer_to_hf(state_dict: dict[str, Tensor], prefix: str):
@@ -109,13 +140,11 @@ def _convert_prime_moe_layer_to_hf(state_dict: dict[str, Tensor], prefix: str):
     mlp = f"{prefix}mlp."
     mixer = f"{prefix}mixer."
 
-    # Router
     if f"{mlp}router.gate" in state_dict:
         state_dict[f"{mixer}gate.weight"] = state_dict.pop(f"{mlp}router.gate")
     if f"{mlp}router.e_score_correction_bias" in state_dict:
         state_dict[f"{mixer}gate.e_score_correction_bias"] = state_dict.pop(f"{mlp}router.e_score_correction_bias")
 
-    # Experts: unstack fused 3D tensors into individual expert weights
     if f"{mlp}experts.w1" in state_dict:
         w1 = state_dict.pop(f"{mlp}experts.w1")
         for i in range(w1.shape[0]):
@@ -124,27 +153,43 @@ def _convert_prime_moe_layer_to_hf(state_dict: dict[str, Tensor], prefix: str):
         w2 = state_dict.pop(f"{mlp}experts.w2")
         for i in range(w2.shape[0]):
             state_dict[f"{mixer}experts.{i}.down_proj.weight"] = w2[i]
-    # Remove dummy w3 (not present in HF format)
     state_dict.pop(f"{mlp}experts.w3", None)
 
-    # Shared expert
     _rename_keys(state_dict, f"{mlp}shared_expert.", f"{mixer}shared_experts.")
-
-    # Latent projections
     _rename_keys(state_dict, f"{mlp}fc1_latent_proj.", f"{mixer}fc1_latent_proj.")
     _rename_keys(state_dict, f"{mlp}fc2_latent_proj.", f"{mixer}fc2_latent_proj.")
 
 
+def _convert_prime_layer_to_hf_at_prefix(state_dict: dict[str, Tensor], prefix: str, layer_type: str):
+    if layer_type == "moe":
+        _convert_prime_moe_layer_to_hf(state_dict, prefix)
+    elif layer_type == "attention":
+        _rename_keys(state_dict, f"{prefix}self_attn.", f"{prefix}mixer.")
+    elif layer_type == "mamba":
+        _rename_keys(state_dict, f"{prefix}mamba.", f"{prefix}mixer.")
+
+
+def convert_prime_layer_to_hf(state_dict: dict[str, Tensor], layer_idx: int, layer_type: str):
+    """Convert a single backbone layer from PrimeRL to HF format in-place."""
+    _convert_prime_layer_to_hf_at_prefix(state_dict, f"model.layers.{layer_idx}.", layer_type)
+
+
+def _convert_hf_mtp_to_prime(state_dict: dict[str, Tensor], mtp_layers_block_type: list[str]):
+    for i, layer_type in enumerate(mtp_layers_block_type):
+        _convert_hf_layer_to_prime_at_prefix(state_dict, f"mtp.layers.{i}.", layer_type)
+
+
+def _convert_prime_mtp_to_hf(state_dict: dict[str, Tensor], mtp_layers_block_type: list[str]):
+    for i, layer_type in enumerate(mtp_layers_block_type):
+        _convert_prime_layer_to_hf_at_prefix(state_dict, f"mtp.layers.{i}.", layer_type)
+
+
 def convert_hf_to_prime(state_dict: dict[str, Tensor], layers_block_type: list[str]):
     """Convert full model from HF to PrimeRL format in-place."""
-    # Handle backbone.* -> model.* prefix (HF NemotronH uses "backbone" instead of "model")
+    mtp_layers_block_type = _infer_layer_types_from_hf(state_dict, "mtp.layers.")
+
     _rename_keys(state_dict, "backbone.", "model.")
 
-    # Drop multi-token prediction keys (not used in training)
-    for key in [k for k in state_dict if k.startswith("mtp.")]:
-        del state_dict[key]
-
-    # Global renames
     if "model.embeddings.weight" in state_dict:
         state_dict["model.embed_tokens.weight"] = state_dict.pop("model.embeddings.weight")
     if "model.norm_f.weight" in state_dict:
@@ -153,10 +198,17 @@ def convert_hf_to_prime(state_dict: dict[str, Tensor], layers_block_type: list[s
     for i, layer_type in enumerate(layers_block_type):
         convert_hf_layer_to_prime(state_dict, i, layer_type)
 
+    if mtp_layers_block_type:
+        _convert_hf_mtp_to_prime(state_dict, mtp_layers_block_type)
+
 
 def convert_prime_to_hf(state_dict: dict[str, Tensor], layers_block_type: list[str]):
     """Convert full model from PrimeRL to HF format in-place."""
-    # Global renames
+    mtp_layers_block_type = _infer_layer_types_from_prime(state_dict, "mtp.layers.")
+
+    if mtp_layers_block_type:
+        _convert_prime_mtp_to_hf(state_dict, mtp_layers_block_type)
+
     if "model.embed_tokens.weight" in state_dict:
         state_dict["model.embeddings.weight"] = state_dict.pop("model.embed_tokens.weight")
     if "model.norm.weight" in state_dict:
@@ -165,5 +217,4 @@ def convert_prime_to_hf(state_dict: dict[str, Tensor], layers_block_type: list[s
     for i, layer_type in enumerate(layers_block_type):
         convert_prime_layer_to_hf(state_dict, i, layer_type)
 
-    # Rename model.* -> backbone.* (HF checkpoint uses "backbone" prefix)
     _rename_keys(state_dict, "model.", "backbone.")

--- a/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
+++ b/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
@@ -112,6 +112,26 @@ def _ensure_zamba2_compat(config: NemotronHConfig):
     config.mamba_expand = correct_expand
 
 
+def _get_attention_sequence_metadata(
+    config: NemotronHConfig, position_ids: torch.LongTensor
+) -> tuple[torch.LongTensor | None, int | None]:
+    if config._attn_implementation not in ("flash_attention_2", "flash_attention_3", "fa4"):
+        return None, None
+
+    flat_position_ids = position_ids.view(-1)
+    seqlens = torch.cat(
+        [
+            flat_position_ids[0:1],
+            flat_position_ids[:-1][(flat_position_ids == 0)[1:]] + 1,
+            flat_position_ids[-1:] + 1,
+        ]
+    )
+    max_seqlen = seqlens.max().item()
+    cu_seqlens = seqlens.cumsum(dim=0, dtype=torch.int32)
+    torch._dynamo.mark_dynamic(cu_seqlens, 0)
+    return cu_seqlens, max_seqlen
+
+
 class NemotronHMambaLayer(GradientCheckpointingLayer):
     """Mamba-2 SSM layer: norm -> NemotronHMamba2Mixer -> residual."""
 
@@ -207,6 +227,112 @@ class NemotronHAttentionLayer(GradientCheckpointingLayer):
         return residual + hidden_states
 
 
+def _init_nemotron_mtp_layer(
+    layer: nn.Module,
+    config: NemotronHConfig,
+    has_start_projections: bool,
+    has_end_norm: bool,
+) -> None:
+    layer.has_start_projections = has_start_projections
+    layer.has_end_norm = has_end_norm
+
+    if has_start_projections:
+        layer.enorm = RMSNorm(RMSNormConfig(hidden_size=config.hidden_size, eps=config.layer_norm_epsilon))
+        layer.hnorm = RMSNorm(RMSNormConfig(hidden_size=config.hidden_size, eps=config.layer_norm_epsilon))
+        layer.eh_proj = nn.Linear(config.hidden_size * 2, config.hidden_size, bias=False)
+
+    if has_end_norm:
+        layer.final_layernorm = RMSNorm(RMSNormConfig(hidden_size=config.hidden_size, eps=config.layer_norm_epsilon))
+
+
+class NemotronHMTPAttentionLayer(NemotronHAttentionLayer):
+    """NemotronH MTP attention layer with optional input fusion and output norm."""
+
+    def __init__(
+        self,
+        config: NemotronHConfig,
+        has_start_projections: bool = False,
+        has_end_norm: bool = False,
+    ):
+        super().__init__(config)
+        _init_nemotron_mtp_layer(self, config, has_start_projections, has_end_norm)
+
+
+class NemotronHMTPMoELayer(NemotronHMoELayer):
+    """NemotronH MTP MoE layer with optional input fusion and output norm."""
+
+    def __init__(
+        self,
+        config: NemotronHConfig,
+        has_start_projections: bool = False,
+        has_end_norm: bool = False,
+    ):
+        super().__init__(config)
+        _init_nemotron_mtp_layer(self, config, has_start_projections, has_end_norm)
+
+
+class NemotronHMultiTokenPredictor(nn.Module):
+    """Shared NemotronH MTP predictor applied for each logical prediction step."""
+
+    prime_mtp_kind = "nemotron_h"
+
+    def __init__(self, config: NemotronHConfig):
+        super().__init__()
+        self.config = config
+        self.layers = nn.ModuleList()
+
+        for idx, layer_type in enumerate(config.mtp_layers_block_type):
+            is_start_of_step = idx == 0
+            is_end_of_step = idx == len(config.mtp_layers_block_type) - 1
+
+            if layer_type == "attention":
+                layer = NemotronHMTPAttentionLayer(
+                    config,
+                    has_start_projections=is_start_of_step,
+                    has_end_norm=is_end_of_step,
+                )
+            elif layer_type == "moe":
+                layer = NemotronHMTPMoELayer(
+                    config,
+                    has_start_projections=is_start_of_step,
+                    has_end_norm=is_end_of_step,
+                )
+            else:
+                raise NotImplementedError(f"NemotronH MTP only supports attention/moe blocks, got {layer_type!r}.")
+
+            self.layers.append(layer)
+
+    def forward(
+        self,
+        input_embeds: torch.Tensor,
+        hidden_states: torch.Tensor,
+        position_ids: torch.LongTensor,
+        cu_seqlens: torch.LongTensor | None = None,
+        max_seqlen: int | None = None,
+    ) -> torch.Tensor:
+        first_layer = self.layers[0]
+        if getattr(first_layer, "has_start_projections", False):
+            input_embeds = first_layer.enorm(input_embeds)
+            hidden_states = first_layer.hnorm(hidden_states)
+            hidden_states = first_layer.eh_proj(torch.cat([input_embeds, hidden_states], dim=-1))
+
+        if cu_seqlens is None or max_seqlen is None:
+            cu_seqlens, max_seqlen = _get_attention_sequence_metadata(self.config, position_ids)
+        for layer in self.layers:
+            hidden_states = layer(
+                hidden_states,
+                position_embeddings=None,
+                cu_seqlens=cu_seqlens,
+                max_seqlen=max_seqlen,
+            )
+
+        last_layer = self.layers[-1]
+        if getattr(last_layer, "has_end_norm", False):
+            hidden_states = last_layer.final_layernorm(hidden_states)
+
+        return hidden_states
+
+
 BLOCK_TYPE_MAP = {
     "mamba": NemotronHMambaLayer,
     "moe": NemotronHMoELayer,
@@ -227,7 +353,13 @@ class NemotronHPreTrainedModel(PreTrainedModelPrimeRL):
     config: NemotronHConfig
     base_model_prefix = "model"
     supports_gradient_checkpointing = True
-    _no_split_modules = ["NemotronHMambaLayer", "NemotronHMoELayer", "NemotronHAttentionLayer"]
+    _no_split_modules = [
+        "NemotronHMambaLayer",
+        "NemotronHMoELayer",
+        "NemotronHAttentionLayer",
+        "NemotronHMTPMoELayer",
+        "NemotronHMTPAttentionLayer",
+    ]
     _supports_flash_attn = True
     _supports_sdpa = True
     _can_compile_fullgraph = False
@@ -247,7 +379,11 @@ class NemotronHPreTrainedModel(PreTrainedModelPrimeRL):
 
     @classmethod
     def is_hf_state_dict(cls, state_dict: dict[str, Tensor]) -> bool:
-        return any("mixer." in name for name in state_dict) or any("backbone." in name for name in state_dict)
+        return (
+            any("mixer." in name for name in state_dict)
+            or any("backbone." in name for name in state_dict)
+            or any(name.startswith("mtp.layers.") and ".mixer." in name for name in state_dict)
+        )
 
     @classmethod
     def is_prime_state_dict(cls, state_dict: dict[str, Tensor]) -> bool:
@@ -257,6 +393,7 @@ class NemotronHPreTrainedModel(PreTrainedModelPrimeRL):
             or "self_attn." in name
             or "model.embed_tokens." in name
             or "model.norm." in name
+            or (name.startswith("mtp.layers.") and (".self_attn." in name or ".mlp." in name))
             for name in state_dict
         )
 
@@ -275,15 +412,10 @@ class NemotronHPreTrainedModel(PreTrainedModelPrimeRL):
 
     @classmethod
     def convert_layer_to_hf(cls, state_dict: dict[str, Tensor], layer_idx: int) -> dict[str, Tensor]:
-        from prime_rl.trainer.models.nemotron_h.converting_nemotron_h import _rename_keys
+        from prime_rl.trainer.models.nemotron_h.converting_nemotron_h import _rename_keys, convert_prime_to_hf
 
         if layer_idx == -1:
-            # Non-layer weights: rename global keys and model.* -> backbone.*
-            if "model.embed_tokens.weight" in state_dict:
-                state_dict["model.embeddings.weight"] = state_dict.pop("model.embed_tokens.weight")
-            if "model.norm.weight" in state_dict:
-                state_dict["model.norm_f.weight"] = state_dict.pop("model.norm.weight")
-            _rename_keys(state_dict, "model.", "backbone.")
+            convert_prime_to_hf(state_dict, [])
         else:
             layer_type = _infer_layer_type_prime(state_dict, layer_idx)
             convert_prime_layer_to_hf(state_dict, layer_idx, layer_type)
@@ -292,18 +424,13 @@ class NemotronHPreTrainedModel(PreTrainedModelPrimeRL):
 
     @classmethod
     def convert_layer_to_prime(cls, state_dict: dict[str, Tensor], layer_idx: int) -> dict[str, Tensor]:
-        from prime_rl.trainer.models.nemotron_h.converting_nemotron_h import _rename_keys
+        from prime_rl.trainer.models.nemotron_h.converting_nemotron_h import _rename_keys, convert_hf_to_prime
 
         # Handle backbone.* -> model.* prefix before layer conversion
-        _rename_keys(state_dict, "backbone.", "model.")
-
         if layer_idx == -1:
-            # Non-layer weights: rename global keys
-            if "model.embeddings.weight" in state_dict:
-                state_dict["model.embed_tokens.weight"] = state_dict.pop("model.embeddings.weight")
-            if "model.norm_f.weight" in state_dict:
-                state_dict["model.norm.weight"] = state_dict.pop("model.norm_f.weight")
+            convert_hf_to_prime(state_dict, [])
         else:
+            _rename_keys(state_dict, "backbone.", "model.")
             layer_type = _infer_layer_type_hf(state_dict, layer_idx)
             convert_hf_layer_to_prime(state_dict, layer_idx, layer_type)
         return state_dict
@@ -385,22 +512,7 @@ class NemotronHModel(NemotronHPreTrainedModel):
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
 
-        # Compute cu_seqlens and max_seqlen for flash attention
-        if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4"):
-            flat_position_ids = position_ids.view(-1)
-            seqlens = torch.cat(
-                [
-                    flat_position_ids[0:1],
-                    flat_position_ids[:-1][(flat_position_ids == 0)[1:]] + 1,
-                    flat_position_ids[-1:] + 1,
-                ]
-            )
-            max_seqlen = seqlens.max().item()
-            cu_seqlens = seqlens.cumsum(dim=0, dtype=torch.int32)
-            torch._dynamo.mark_dynamic(cu_seqlens, 0)
-        else:
-            max_seqlen = None
-            cu_seqlens = None
+        cu_seqlens, max_seqlen = _get_attention_sequence_metadata(self.config, position_ids)
 
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids) if self.rotary_emb is not None else None
@@ -424,6 +536,7 @@ class NemotronHForCausalLM(NemotronHPreTrainedModel, GenerationMixin):
     def __init__(self, config: NemotronHConfig):
         super().__init__(config)
         self.model = NemotronHModel(config)
+        self.mtp = NemotronHMultiTokenPredictor(config) if config.num_nextn_predict_layers > 0 else None
         self.vocab_size = config.vocab_size
         self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
         self.post_init()

--- a/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
+++ b/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
@@ -245,6 +245,27 @@ def _init_nemotron_mtp_layer(
         layer.final_layernorm = RMSNorm(RMSNormConfig(hidden_size=config.hidden_size, eps=config.layer_norm_epsilon))
 
 
+def _apply_nemotron_mtp_start_projections(
+    layer: nn.Module,
+    hidden_states: torch.Tensor,
+    input_embeds: torch.Tensor | None,
+) -> torch.Tensor:
+    if not getattr(layer, "has_start_projections", False):
+        return hidden_states
+    if input_embeds is None:
+        raise ValueError("NemotronH MTP start projections require `input_embeds` on the first MTP layer.")
+
+    input_embeds = layer.enorm(input_embeds)
+    hidden_states = layer.hnorm(hidden_states)
+    return layer.eh_proj(torch.cat([input_embeds, hidden_states], dim=-1))
+
+
+def _apply_nemotron_mtp_final_norm(layer: nn.Module, hidden_states: torch.Tensor) -> torch.Tensor:
+    if getattr(layer, "has_end_norm", False):
+        return layer.final_layernorm(hidden_states)
+    return hidden_states
+
+
 class NemotronHMTPAttentionLayer(NemotronHAttentionLayer):
     """NemotronH MTP attention layer with optional input fusion and output norm."""
 
@@ -256,6 +277,23 @@ class NemotronHMTPAttentionLayer(NemotronHAttentionLayer):
     ):
         super().__init__(config)
         _init_nemotron_mtp_layer(self, config, has_start_projections, has_end_norm)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
+        cu_seqlens: torch.LongTensor | None = None,
+        max_seqlen: int | None = None,
+        input_embeds: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        hidden_states = _apply_nemotron_mtp_start_projections(self, hidden_states, input_embeds)
+        hidden_states = super().forward(
+            hidden_states,
+            position_embeddings=position_embeddings,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+        )
+        return _apply_nemotron_mtp_final_norm(self, hidden_states)
 
 
 class NemotronHMTPMoELayer(NemotronHMoELayer):
@@ -269,6 +307,23 @@ class NemotronHMTPMoELayer(NemotronHMoELayer):
     ):
         super().__init__(config)
         _init_nemotron_mtp_layer(self, config, has_start_projections, has_end_norm)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
+        cu_seqlens: torch.LongTensor | None = None,
+        max_seqlen: int | None = None,
+        input_embeds: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        hidden_states = _apply_nemotron_mtp_start_projections(self, hidden_states, input_embeds)
+        hidden_states = super().forward(
+            hidden_states,
+            position_embeddings=position_embeddings,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+        )
+        return _apply_nemotron_mtp_final_norm(self, hidden_states)
 
 
 class NemotronHMultiTokenPredictor(nn.Module):
@@ -310,12 +365,6 @@ class NemotronHMultiTokenPredictor(nn.Module):
         cu_seqlens: torch.LongTensor | None = None,
         max_seqlen: int | None = None,
     ) -> torch.Tensor:
-        first_layer = self.layers[0]
-        if getattr(first_layer, "has_start_projections", False):
-            input_embeds = first_layer.enorm(input_embeds)
-            hidden_states = first_layer.hnorm(hidden_states)
-            hidden_states = first_layer.eh_proj(torch.cat([input_embeds, hidden_states], dim=-1))
-
         if cu_seqlens is None or max_seqlen is None:
             cu_seqlens, max_seqlen = _get_attention_sequence_metadata(self.config, position_ids)
         for layer in self.layers:
@@ -324,11 +373,8 @@ class NemotronHMultiTokenPredictor(nn.Module):
                 position_embeddings=None,
                 cu_seqlens=cu_seqlens,
                 max_seqlen=max_seqlen,
+                input_embeds=input_embeds,
             )
-
-        last_layer = self.layers[-1]
-        if getattr(last_layer, "has_end_norm", False):
-            hidden_states = last_layer.final_layernorm(hidden_states)
 
         return hidden_states
 

--- a/src/prime_rl/trainer/models/qwen3_5_moe/configuration_qwen3_5_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_5_moe/configuration_qwen3_5_moe.py
@@ -46,6 +46,8 @@ class Qwen3_5MoeConfig(PretrainedConfig):
         num_experts=256,
         output_router_logits=False,
         router_aux_loss_coef=0.001,
+        mtp_num_hidden_layers=0,
+        mtp_use_dedicated_embeddings=False,
         # Layer type configuration
         layer_types=None,
         # PrimeRL additions
@@ -97,6 +99,8 @@ class Qwen3_5MoeConfig(PretrainedConfig):
         self.num_experts = num_experts
         self.output_router_logits = output_router_logits
         self.router_aux_loss_coef = router_aux_loss_coef
+        self.mtp_num_hidden_layers = mtp_num_hidden_layers
+        self.mtp_use_dedicated_embeddings = mtp_use_dedicated_embeddings
 
         # PrimeRL additions
         self.load_balance_coeff = load_balance_coeff

--- a/src/prime_rl/trainer/models/qwen3_5_moe/converting_qwen3_5_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_5_moe/converting_qwen3_5_moe.py
@@ -1,125 +1,147 @@
 import torch
 from torch import Tensor
 
-
-def get_max_layer_num(state_dict: dict[str, Tensor]) -> int:
-    """Get the maximum number of layers in the model."""
-    return max(int(i.split(".")[2]) for i in state_dict.keys() if "model.layers." in i) + 1
+LANGUAGE_LAYER_PREFIX = "model.layers."
+MTP_LAYER_PREFIX = "mtp.layers."
 
 
-def convert_hf_layer_to_tt(state_dict: dict[str, Tensor], layer_idx: int):
-    """Convert a single layer from HF to PrimeRL format in-place.
+def get_max_layer_num(state_dict: dict[str, Tensor], layer_prefix: str = LANGUAGE_LAYER_PREFIX) -> int:
+    """Get the number of layers present under a given prefix."""
+    layer_indices = [
+        int(key[len(layer_prefix) :].split(".", 1)[0])
+        for key in state_dict
+        if key.startswith(layer_prefix)
+    ]
+    return max(layer_indices, default=-1) + 1
 
-    Handles:
-    - Router: mlp.gate.weight -> mlp.router.gate.weight
-    - Routed experts: fused gate_up_proj/down_proj or per-expert -> w1/w2/w3
-    - Shared expert: mlp.shared_expert.{gate,up,down}_proj.weight -> shared_expert.{w1,w3,w2}.weight
-    - Shared expert gate: mlp.shared_expert_gate.weight -> shared_expert_gate.weight
-    """
-    i = layer_idx
 
-    # Router: mlp.gate.weight -> mlp.router.gate.weight
-    gate_key = f"model.layers.{i}.mlp.gate.weight"
+def _layer_key(layer_prefix: str, layer_idx: int, suffix: str) -> str:
+    return f"{layer_prefix}{layer_idx}.{suffix}"
+
+
+def _convert_hf_layer_to_tt(state_dict: dict[str, Tensor], layer_idx: int, layer_prefix: str) -> None:
+    gate_key = _layer_key(layer_prefix, layer_idx, "mlp.gate.weight")
     if gate_key not in state_dict:
         return
 
-    state_dict[f"model.layers.{i}.mlp.router.gate.weight"] = state_dict.pop(gate_key)
+    state_dict[_layer_key(layer_prefix, layer_idx, "mlp.router.gate.weight")] = state_dict.pop(gate_key)
 
-    # Routed experts: convert to fused w1/w2/w3 format
-    if f"model.layers.{i}.mlp.experts.gate_up_proj" in state_dict:
-        # New fused format (transformers 5.0+): gate_up_proj shape (num_experts, 2*moe_dim, dim)
-        gate_up_proj = state_dict.pop(f"model.layers.{i}.mlp.experts.gate_up_proj")
-        down_proj = state_dict.pop(f"model.layers.{i}.mlp.experts.down_proj")
+    gate_up_proj_key = _layer_key(layer_prefix, layer_idx, "mlp.experts.gate_up_proj")
+    down_proj_key = _layer_key(layer_prefix, layer_idx, "mlp.experts.down_proj")
+    if gate_up_proj_key in state_dict:
+        gate_up_proj = state_dict.pop(gate_up_proj_key)
+        down_proj = state_dict.pop(down_proj_key)
 
         moe_dim = gate_up_proj.shape[1] // 2
-        w1 = gate_up_proj[:, :moe_dim, :]  # gate
-        w3 = gate_up_proj[:, moe_dim:, :]  # up
-        w2 = down_proj  # down
+        w1 = gate_up_proj[:, :moe_dim, :]
+        w3 = gate_up_proj[:, moe_dim:, :]
+        w2 = down_proj
     else:
-        # Old per-expert format
-        num_experts = len([k for k in state_dict.keys() if f"model.layers.{i}.mlp.experts" in k and "gate_proj" in k])
-        if num_experts == 0:
+        expert_prefix = _layer_key(layer_prefix, layer_idx, "mlp.experts.")
+        expert_ids = sorted(
+            {
+                int(key[len(expert_prefix) :].split(".", 1)[0])
+                for key in state_dict
+                if key.startswith(expert_prefix) and key.endswith(".gate_proj.weight")
+            }
+        )
+        if not expert_ids:
             return
 
-        dim, moe_dim = state_dict[f"model.layers.{i}.mlp.experts.0.down_proj.weight"].shape
-        dtype = state_dict[f"model.layers.{i}.mlp.experts.0.down_proj.weight"].dtype
-        w1 = torch.empty((num_experts, moe_dim, dim), dtype=dtype)
-        w2 = torch.empty((num_experts, dim, moe_dim), dtype=dtype)
-        w3 = torch.empty((num_experts, moe_dim, dim), dtype=dtype)
-        for j in range(num_experts):
-            w1[j].copy_(state_dict.pop(f"model.layers.{i}.mlp.experts.{j}.gate_proj.weight"))
-            w2[j].copy_(state_dict.pop(f"model.layers.{i}.mlp.experts.{j}.down_proj.weight"))
-            w3[j].copy_(state_dict.pop(f"model.layers.{i}.mlp.experts.{j}.up_proj.weight"))
+        first_down_proj_key = _layer_key(layer_prefix, layer_idx, f"mlp.experts.{expert_ids[0]}.down_proj.weight")
+        dim, moe_dim = state_dict[first_down_proj_key].shape
+        dtype = state_dict[first_down_proj_key].dtype
+        device = state_dict[first_down_proj_key].device
+        num_experts = len(expert_ids)
+        w1 = torch.empty((num_experts, moe_dim, dim), dtype=dtype, device=device)
+        w2 = torch.empty((num_experts, dim, moe_dim), dtype=dtype, device=device)
+        w3 = torch.empty((num_experts, moe_dim, dim), dtype=dtype, device=device)
+        for tensor_idx, expert_id in enumerate(expert_ids):
+            w1[tensor_idx].copy_(state_dict.pop(_layer_key(layer_prefix, layer_idx, f"mlp.experts.{expert_id}.gate_proj.weight")))
+            w2[tensor_idx].copy_(state_dict.pop(_layer_key(layer_prefix, layer_idx, f"mlp.experts.{expert_id}.down_proj.weight")))
+            w3[tensor_idx].copy_(state_dict.pop(_layer_key(layer_prefix, layer_idx, f"mlp.experts.{expert_id}.up_proj.weight")))
 
-    state_dict[f"model.layers.{i}.mlp.experts.w1"] = w1
-    state_dict[f"model.layers.{i}.mlp.experts.w2"] = w2
-    state_dict[f"model.layers.{i}.mlp.experts.w3"] = w3
+    state_dict[_layer_key(layer_prefix, layer_idx, "mlp.experts.w1")] = w1
+    state_dict[_layer_key(layer_prefix, layer_idx, "mlp.experts.w2")] = w2
+    state_dict[_layer_key(layer_prefix, layer_idx, "mlp.experts.w3")] = w3
 
-    # Shared expert: mlp.shared_expert.{gate,up,down}_proj -> shared_expert.{w1,w3,w2}
-    se_gate_key = f"model.layers.{i}.mlp.shared_expert.gate_proj.weight"
-    if se_gate_key in state_dict:
-        state_dict[f"model.layers.{i}.shared_expert.w1.weight"] = state_dict.pop(se_gate_key)
-        state_dict[f"model.layers.{i}.shared_expert.w2.weight"] = state_dict.pop(
-            f"model.layers.{i}.mlp.shared_expert.down_proj.weight"
+    shared_gate_key = _layer_key(layer_prefix, layer_idx, "mlp.shared_expert.gate_proj.weight")
+    if shared_gate_key in state_dict:
+        state_dict[_layer_key(layer_prefix, layer_idx, "shared_expert.w1.weight")] = state_dict.pop(shared_gate_key)
+        state_dict[_layer_key(layer_prefix, layer_idx, "shared_expert.w2.weight")] = state_dict.pop(
+            _layer_key(layer_prefix, layer_idx, "mlp.shared_expert.down_proj.weight")
         )
-        state_dict[f"model.layers.{i}.shared_expert.w3.weight"] = state_dict.pop(
-            f"model.layers.{i}.mlp.shared_expert.up_proj.weight"
+        state_dict[_layer_key(layer_prefix, layer_idx, "shared_expert.w3.weight")] = state_dict.pop(
+            _layer_key(layer_prefix, layer_idx, "mlp.shared_expert.up_proj.weight")
         )
 
-    # Shared expert gate: mlp.shared_expert_gate.weight -> shared_expert_gate.weight
-    seg_key = f"model.layers.{i}.mlp.shared_expert_gate.weight"
-    if seg_key in state_dict:
-        state_dict[f"model.layers.{i}.shared_expert_gate.weight"] = state_dict.pop(seg_key)
+    shared_expert_gate_key = _layer_key(layer_prefix, layer_idx, "mlp.shared_expert_gate.weight")
+    if shared_expert_gate_key in state_dict:
+        state_dict[_layer_key(layer_prefix, layer_idx, "shared_expert_gate.weight")] = state_dict.pop(
+            shared_expert_gate_key
+        )
 
 
-def convert_tt_layer_to_hf(state_dict: dict[str, Tensor], layer_idx: int):
-    """Convert a single layer from PrimeRL to HF format in-place."""
-    i = layer_idx
+def convert_hf_layer_to_tt(
+    state_dict: dict[str, Tensor],
+    layer_idx: int,
+    layer_prefix: str = LANGUAGE_LAYER_PREFIX,
+) -> None:
+    """Convert a single HF layer from HuggingFace format to PrimeRL format in-place."""
+    _convert_hf_layer_to_tt(state_dict, layer_idx, layer_prefix)
 
-    # Router
-    router_key = f"model.layers.{i}.mlp.router.gate.weight"
+
+def _convert_tt_layer_to_hf(state_dict: dict[str, Tensor], layer_idx: int, layer_prefix: str) -> None:
+    router_key = _layer_key(layer_prefix, layer_idx, "mlp.router.gate.weight")
     if router_key not in state_dict:
         return
 
-    state_dict[f"model.layers.{i}.mlp.gate.weight"] = state_dict.pop(router_key)
+    state_dict[_layer_key(layer_prefix, layer_idx, "mlp.gate.weight")] = state_dict.pop(router_key)
 
-    # Routed experts: w1/w2/w3 -> per-expert format
-    w1 = state_dict.pop(f"model.layers.{i}.mlp.experts.w1")
-    w2 = state_dict.pop(f"model.layers.{i}.mlp.experts.w2")
-    w3 = state_dict.pop(f"model.layers.{i}.mlp.experts.w3")
+    w1 = state_dict.pop(_layer_key(layer_prefix, layer_idx, "mlp.experts.w1"))
+    w2 = state_dict.pop(_layer_key(layer_prefix, layer_idx, "mlp.experts.w2"))
+    w3 = state_dict.pop(_layer_key(layer_prefix, layer_idx, "mlp.experts.w3"))
 
-    num_experts = w1.shape[0]
-    for j in range(num_experts):
-        state_dict[f"model.layers.{i}.mlp.experts.{j}.gate_proj.weight"] = w1[j]
-        state_dict[f"model.layers.{i}.mlp.experts.{j}.down_proj.weight"] = w2[j]
-        state_dict[f"model.layers.{i}.mlp.experts.{j}.up_proj.weight"] = w3[j]
+    for expert_id in range(w1.shape[0]):
+        state_dict[_layer_key(layer_prefix, layer_idx, f"mlp.experts.{expert_id}.gate_proj.weight")] = w1[expert_id]
+        state_dict[_layer_key(layer_prefix, layer_idx, f"mlp.experts.{expert_id}.down_proj.weight")] = w2[expert_id]
+        state_dict[_layer_key(layer_prefix, layer_idx, f"mlp.experts.{expert_id}.up_proj.weight")] = w3[expert_id]
 
-    # Shared expert: shared_expert.{w1,w2,w3} -> mlp.shared_expert.{gate,down,up}_proj
-    se_w1_key = f"model.layers.{i}.shared_expert.w1.weight"
-    if se_w1_key in state_dict:
-        state_dict[f"model.layers.{i}.mlp.shared_expert.gate_proj.weight"] = state_dict.pop(se_w1_key)
-        state_dict[f"model.layers.{i}.mlp.shared_expert.down_proj.weight"] = state_dict.pop(
-            f"model.layers.{i}.shared_expert.w2.weight"
+    shared_w1_key = _layer_key(layer_prefix, layer_idx, "shared_expert.w1.weight")
+    if shared_w1_key in state_dict:
+        state_dict[_layer_key(layer_prefix, layer_idx, "mlp.shared_expert.gate_proj.weight")] = state_dict.pop(shared_w1_key)
+        state_dict[_layer_key(layer_prefix, layer_idx, "mlp.shared_expert.down_proj.weight")] = state_dict.pop(
+            _layer_key(layer_prefix, layer_idx, "shared_expert.w2.weight")
         )
-        state_dict[f"model.layers.{i}.mlp.shared_expert.up_proj.weight"] = state_dict.pop(
-            f"model.layers.{i}.shared_expert.w3.weight"
+        state_dict[_layer_key(layer_prefix, layer_idx, "mlp.shared_expert.up_proj.weight")] = state_dict.pop(
+            _layer_key(layer_prefix, layer_idx, "shared_expert.w3.weight")
         )
 
-    # Shared expert gate
-    seg_key = f"model.layers.{i}.shared_expert_gate.weight"
-    if seg_key in state_dict:
-        state_dict[f"model.layers.{i}.mlp.shared_expert_gate.weight"] = state_dict.pop(seg_key)
+    shared_expert_gate_key = _layer_key(layer_prefix, layer_idx, "shared_expert_gate.weight")
+    if shared_expert_gate_key in state_dict:
+        state_dict[_layer_key(layer_prefix, layer_idx, "mlp.shared_expert_gate.weight")] = state_dict.pop(
+            shared_expert_gate_key
+        )
 
 
-def convert_hf_to_tt_moe(state_dict: dict[str, Tensor]):
-    """Convert all MoE weights from HF to PrimeRL format in-place."""
-    num_layers = get_max_layer_num(state_dict)
-    for i in range(num_layers):
-        convert_hf_layer_to_tt(state_dict, i)
+def convert_tt_layer_to_hf(
+    state_dict: dict[str, Tensor],
+    layer_idx: int,
+    layer_prefix: str = LANGUAGE_LAYER_PREFIX,
+) -> None:
+    """Convert a single PrimeRL layer from PrimeRL format to HuggingFace format in-place."""
+    _convert_tt_layer_to_hf(state_dict, layer_idx, layer_prefix)
 
 
-def convert_tt_to_hf_moe(state_dict: dict[str, Tensor]):
-    """Convert all MoE weights from PrimeRL to HF format in-place."""
-    num_layers = get_max_layer_num(state_dict)
-    for i in range(num_layers):
-        convert_tt_layer_to_hf(state_dict, i)
+def convert_hf_to_tt_moe(state_dict: dict[str, Tensor]) -> None:
+    """Convert all Qwen3.5 MoE weights from HuggingFace format to PrimeRL format in-place."""
+    for layer_prefix in (LANGUAGE_LAYER_PREFIX, MTP_LAYER_PREFIX):
+        for layer_idx in range(get_max_layer_num(state_dict, layer_prefix)):
+            convert_hf_layer_to_tt(state_dict, layer_idx, layer_prefix)
+
+
+def convert_tt_to_hf_moe(state_dict: dict[str, Tensor]) -> None:
+    """Convert all Qwen3.5 MoE weights from PrimeRL format to HuggingFace format in-place."""
+    for layer_prefix in (LANGUAGE_LAYER_PREFIX, MTP_LAYER_PREFIX):
+        for layer_idx in range(get_max_layer_num(state_dict, layer_prefix)):
+            convert_tt_layer_to_hf(state_dict, layer_idx, layer_prefix)

--- a/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -542,10 +542,10 @@ def _get_gated_attention(config: Qwen3_5MoeConfig) -> nn.Module:
 
 
 class Qwen3_5MoeDecoderLayer(GradientCheckpointingLayer):
-    def __init__(self, config: Qwen3_5MoeConfig, layer_idx: int):
+    def __init__(self, config: Qwen3_5MoeConfig, layer_idx: int, layer_type: str | None = None):
         super().__init__()
         self.hidden_size = config.hidden_size
-        self.layer_type = config.layer_types[layer_idx]
+        self.layer_type = config.layer_types[layer_idx] if layer_type is None else layer_type
 
         # Token mixer: either GatedDeltaNet or gated softmax attention
         if self.layer_type == "linear_attention":
@@ -676,12 +676,18 @@ class Qwen3_5MoePreTrainedModel(PreTrainedModelPrimeRL):
 
     @classmethod
     def convert_layer_to_hf(cls, state_dict: dict[str, Tensor], layer_idx: int) -> dict[str, Tensor]:
-        convert_tt_layer_to_hf(state_dict, layer_idx)
+        if layer_idx < 0:
+            convert_tt_to_hf_moe(state_dict)
+        else:
+            convert_tt_layer_to_hf(state_dict, layer_idx)
         return state_dict
 
     @classmethod
     def convert_layer_to_prime(cls, state_dict: dict[str, Tensor], layer_idx: int) -> dict[str, Tensor]:
-        convert_hf_layer_to_tt(state_dict, layer_idx)
+        if layer_idx < 0:
+            convert_hf_to_tt_moe(state_dict)
+        else:
+            convert_hf_layer_to_tt(state_dict, layer_idx)
         return state_dict
 
 
@@ -745,6 +751,25 @@ class Qwen3_5MoeModel(Qwen3_5MoePreTrainedModel):
 
         hidden_states = self.norm(hidden_states)
         return MoeModelOutputWithPast(last_hidden_state=hidden_states)
+
+
+class Qwen3_5MoeMultiTokenPredictor(nn.Module):
+    def __init__(self, config: Qwen3_5MoeConfig):
+        super().__init__()
+        self.num_mtp_layers = getattr(config, "mtp_num_hidden_layers", 0)
+        self.embed_tokens = None
+        if getattr(config, "mtp_use_dedicated_embeddings", False):
+            self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, config.pad_token_id)
+        self.fc = nn.Linear(config.hidden_size * 2, config.hidden_size, bias=False)
+        self.layers = nn.ModuleList(
+            [
+                Qwen3_5MoeDecoderLayer(config, layer_idx, layer_type="full_attention")
+                for layer_idx in range(self.num_mtp_layers)
+            ]
+        )
+        self.norm = Qwen3_5MoeRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.pre_fc_norm_hidden = Qwen3_5MoeRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.pre_fc_norm_embedding = Qwen3_5MoeRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
 
 
 # ---------------------------------------------------------------------------
@@ -854,13 +879,18 @@ class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
 
         if self._is_vlm:
             self.model = Qwen3_5MoeVLMModel(config)
-            text_config = config.text_config
+            text_config = self.model.language_model.config
             self._tied_weights_keys = {"lm_head.weight": "model.language_model.embed_tokens.weight"}
         else:
             self.model = Qwen3_5MoeModel(config)
-            text_config = config
+            text_config = self.model.config
 
         self.vocab_size = text_config.vocab_size
+        self.mtp = (
+            Qwen3_5MoeMultiTokenPredictor(text_config)
+            if getattr(text_config, "mtp_num_hidden_layers", 0) > 0
+            else None
+        )
         self.lm_head = nn.Linear(text_config.hidden_size, text_config.vocab_size, bias=False)
         self.post_init()
 
@@ -923,7 +953,10 @@ class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
         vlm = _has_vlm_keys(state_dict)
         if vlm:
             _remap_lm_keys(state_dict, to_flat=True)
-        convert_tt_layer_to_hf(state_dict, layer_idx)
+        if layer_idx < 0:
+            convert_tt_to_hf_moe(state_dict)
+        else:
+            convert_tt_layer_to_hf(state_dict, layer_idx)
         if vlm:
             _remap_lm_keys(state_dict, to_flat=False)
         return state_dict
@@ -933,7 +966,10 @@ class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
         vlm = _has_vlm_keys(state_dict)
         if vlm:
             _remap_lm_keys(state_dict, to_flat=True)
-        convert_hf_layer_to_tt(state_dict, layer_idx)
+        if layer_idx < 0:
+            convert_hf_to_tt_moe(state_dict)
+        else:
+            convert_hf_layer_to_tt(state_dict, layer_idx)
         if vlm:
             _remap_lm_keys(state_dict, to_flat=False)
         return state_dict
@@ -1020,5 +1056,6 @@ class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
 __all__ = [
     "Qwen3_5MoeForCausalLM",
     "Qwen3_5MoeModel",
+    "Qwen3_5MoeMultiTokenPredictor",
     "Qwen3_5MoePreTrainedModel",
 ]

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -130,7 +130,7 @@ def setup_optimizer(
             time.sleep(1)
         named_params = multi_run_manager.get_named_parameters_for_run(0)
 
-    optimizer = _create_optimizer(config, named_params, parallel_dims)
+    optimizer = _create_optimizer(config, named_params, parallel_dims, cpu_offload=cpu_offload)
 
     if cpu_offload:
         get_logger().info("Wrapping optimizer with CPUOffloadOptimizer for optimizer state CPU offloading")
@@ -144,6 +144,7 @@ def _create_optimizer(
     named_params: list[tuple[str, nn.Parameter]],
     parallel_dims: ParallelDims,
     lr: float | None = None,
+    cpu_offload: bool = False,
 ) -> Optimizer:
     """Create optimizer. If lr is None, uses config.lr."""
     if lr is None:
@@ -158,11 +159,16 @@ def _create_optimizer(
                 nesterov=config.nesterov,
             )
         case "adamw":
+            adamw_kwargs = {}
+            if cpu_offload:
+                # Avoid large `_foreach_*` temporaries during optimizer.step().
+                adamw_kwargs["foreach"] = False
             return AdamW(
                 params=[p for _, p in named_params],
                 lr=lr,
                 weight_decay=config.weight_decay,
                 betas=(config.betas1, config.betas2),
+                **adamw_kwargs,
             )
         case "muon":
             return _create_muon_optimizer(config, named_params, parallel_dims, lr)

--- a/src/prime_rl/trainer/rl/broadcast/nccl.py
+++ b/src/prime_rl/trainer/rl/broadcast/nccl.py
@@ -89,9 +89,12 @@ def preprocess_layer_checkpoint(
     layer_state_dict: dict[str, Tensor],
     layer_idx: int,
 ) -> dict[str, Tensor]:
-    if isinstance(model, PreTrainedModelPrimeRL) and model.is_prime_state_dict(layer_state_dict):
-        model.convert_layer_to_hf(layer_state_dict, layer_idx)
-        return layer_state_dict
+    if isinstance(model, PreTrainedModelPrimeRL):
+        # The non-layer chunk can still contain PrimeRL-only MTP weights even if
+        # it lacks the MoE/router markers used by `is_prime_state_dict`.
+        if layer_idx < 0 or model.is_prime_state_dict(layer_state_dict):
+            model.convert_layer_to_hf(layer_state_dict, layer_idx)
+            return layer_state_dict
 
     from transformers.core_model_loading import revert_weight_conversion
 
@@ -199,8 +202,13 @@ class NCCLWeightBroadcast(WeightBroadcast):
         notified_runs: list[tuple[int, Path]] = []
         if self.world.is_master:
             notified_runs = self._notify_orchestrator()
-            # Wait for inference workers to signal readiness before starting NCCL broadcast
             self._wait_for_nccl_ready(notified_runs)
+        # All ranks must synchronize here: _resolve_dtensors inside the sender
+        # calls DTensor.full_tensor() which is a collective all-gather across all
+        # ranks.  Without this barrier the master can still be blocked on
+        # _wait_for_nccl_ready while non-master ranks already enter full_tensor(),
+        # causing an NCCL deadlock.
+        torch.distributed.barrier()
         self.nccl_broadcast_sender.broadcast_weights(model, step)
         self.logger.debug(f"Weights broadcasted in {time.perf_counter() - start_time:.2f}s")
 

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -482,7 +482,6 @@ def train(config: TrainerConfig):
             logger.debug(micro_step_message)
 
         # Optionally, clip the gradients
-
         grad_norm = clip_grad_norm_(
             model.parameters(), max_norm=config.optim.max_norm, ep_enabled=parallel_dims.ep_enabled
         )

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -53,6 +53,10 @@ from prime_rl.trainer.utils import (
 from prime_rl.trainer.world import get_world
 from prime_rl.trainer.runs import setup_multi_run_manager, Progress, get_multi_run_manager
 from prime_rl.trainer.models.layers.lora import set_lora_num_tokens
+from prime_rl.trainer.models.layers.mtp import (
+    prepare_mtp_training_batch_from_current_tokens,
+    shard_mtp_training_batch_for_cp,
+)
 from prime_rl.utils.heartbeat import Heartbeat
 from prime_rl.utils.metrics_server import HealthServer, MetricsServer, RunStats
 from prime_rl.utils.monitor import setup_monitor
@@ -346,6 +350,14 @@ def train(config: TrainerConfig):
             )
 
             labels = shift_tensor_left(input_ids)
+            mtp_batch = None
+            if config.model.mtp is not None:
+                mtp_batch = prepare_mtp_training_batch_from_current_tokens(
+                    input_ids=input_ids,
+                    position_ids=position_ids,
+                    loss_mask=loss_mask,
+                    num_layers=config.model.mtp.num_layers,
+                )
 
             # VLM + CP is not supported: MRoPE requires global positions but CP shards the sequence
             if cp_enabled and pixel_values is not None:
@@ -354,6 +366,8 @@ def train(config: TrainerConfig):
             if cp_enabled:
                 input_ids, forward_position_ids = setup_cp_params(input_ids, position_ids, cp_rank, cp_size, cp_group)
                 labels = shard_for_cp(labels, cp_rank=cp_rank, cp_world_size=cp_size)
+                if mtp_batch is not None:
+                    mtp_batch = shard_mtp_training_batch_for_cp(mtp_batch, position_ids, cp_rank, cp_size, cp_group)
                 if routed_experts is not None:
                     routed_experts = shard_for_cp(routed_experts, cp_rank=cp_rank, cp_world_size=cp_size)
             else:
@@ -385,6 +399,7 @@ def train(config: TrainerConfig):
                     forward_position_ids,
                     labels=labels,
                     temperature=temperatures,
+                    mtp_batch=mtp_batch,
                     pixel_values=pixel_values,
                     image_grid_thw=image_grid_thw,
                     routed_experts=routed_experts,
@@ -430,6 +445,8 @@ def train(config: TrainerConfig):
                 loss_fn=loss_fn,
                 loss_scale=loss_scale,
             )
+            if out.get("mtp_loss_sum") is not None:
+                loss = loss + out["mtp_loss_sum"] / loss_scale
 
             # Backward pass
             with maybe_record_function("backward"):
@@ -440,6 +457,8 @@ def train(config: TrainerConfig):
             tensors["inference_probs"].append(torch.exp(inference_logprobs)[loss_mask].detach().to("cpu"))
             tensors["entropy"].append(out["entropy"][loss_mask].detach().to("cpu"))
             tensors["loss"].append(loss.detach().to("cpu").unsqueeze(0))
+            if out.get("mtp_loss") is not None:
+                tensors["mtp_loss"].append(out["mtp_loss"].detach().to("cpu").unsqueeze(0))
 
             if is_tt_moe_model(model):
                 load_balance_stats = get_load_balance_stats(model)
@@ -456,6 +475,8 @@ def train(config: TrainerConfig):
             micro_step_message = f"Micro Step {micro_step}/{len(micro_batches)} | Loss: {tensors['loss'][-1].mean().item():.4f} | Entropy: {tensors['entropy'][-1].mean().item():.4f}"
             if "mismatch_kl" in tensors:
                 micro_step_message += f" | Mismatch KL: {tensors['mismatch_kl'][-1].mean().item():.4f}"
+            if "mtp_loss" in tensors:
+                micro_step_message += f" | MTP Loss: {tensors['mtp_loss'][-1].mean().item():.4f}"
             if "max_vio" in tensors:
                 micro_step_message += f" | Max Vio: {tensors['max_vio'][-1].mean().item():.4f}"
             logger.debug(micro_step_message)
@@ -505,6 +526,8 @@ def train(config: TrainerConfig):
         step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {tensor_stats['loss/mean']:.4f} | Entropy: {tensor_stats['entropy/mean']:.4f}"
         if "mismatch_kl/mean" in tensor_stats:
             step_message += f" | Mismatch KL: {tensor_stats['mismatch_kl/mean']:.4f}"
+        if "mtp_loss/mean" in tensor_stats:
+            step_message += f" | MTP Loss: {tensor_stats['mtp_loss/mean']:.4f}"
         step_message += f" | Grad. Norm: {grad_norm:.4f} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}% | Peak Mem.: {peak_memory:.1f} GiB"
         if "max_vio/mean" in tensor_stats:
             step_message += f" | Max Vio: {tensor_stats['max_vio/mean']:.4f}"

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -18,6 +18,7 @@ from prime_rl.configs.sft import SFTConfig
 from prime_rl.utils.cp import setup_cp_params, shard_for_cp
 from prime_rl.trainer.runs import Progress, get_multi_run_manager, setup_multi_run_manager
 from prime_rl.trainer.models.layers.lora import set_lora_num_tokens
+from prime_rl.trainer.models.layers.mtp import prepare_mtp_training_batch, shard_mtp_training_batch_for_cp
 from prime_rl.utils.logger import setup_logger
 from prime_rl.trainer.optim import setup_optimizer
 from prime_rl.trainer.scheduler import setup_scheduler
@@ -197,17 +198,29 @@ def train(config: SFTConfig):
         case _:
             raise ValueError(f"Invalid loss implementation: {config.loss_impl}")
 
-    def compute_loss(micro_batch: dict) -> tuple[torch.Tensor, torch.Tensor]:
-        """Forward pass returning (loss_sum, token_count) over unmasked tokens."""
+    def compute_loss(micro_batch: dict) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        """Forward pass returning (loss_sum, token_count, mtp_loss) over unmasked tokens."""
         input_ids = micro_batch["input_ids"].to("cuda")
         position_ids = micro_batch["position_ids"].to("cuda")
         target_ids = micro_batch["target_ids"].to("cuda")
         loss_mask = micro_batch["loss_mask"].to("cuda")
+        mtp_batch = None
+        if config.model.mtp is not None:
+            mtp_batch = prepare_mtp_training_batch(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                labels=target_ids,
+                loss_mask=loss_mask,
+                num_layers=config.model.mtp.num_layers,
+            )
 
         if cp_enabled:
+            full_position_ids = position_ids
             input_ids, position_ids = setup_cp_params(input_ids, position_ids, cp_rank, cp_size, cp_group)
             target_ids = shard_for_cp(target_ids, cp_rank=cp_rank, cp_world_size=cp_size)
             loss_mask = shard_for_cp(loss_mask, cp_rank=cp_rank, cp_world_size=cp_size)
+            if mtp_batch is not None:
+                mtp_batch = shard_mtp_training_batch_for_cp(mtp_batch, full_position_ids, cp_rank, cp_size, cp_group)
 
         if config.model.lora is not None:
             set_lora_num_tokens(torch.full((1,), input_ids.numel(), dtype=torch.int32, device="cuda"))
@@ -218,18 +231,21 @@ def train(config: SFTConfig):
             if config.loss_impl in ("liger_fused", "quack_fused"):
                 masked_target_ids = target_ids.clone()
                 masked_target_ids[~loss_mask] = FUSED_CE_IGNORE_INDEX
-                out = forward(model, input_ids, position_ids, labels=masked_target_ids)
+                out = forward(model, input_ids, position_ids, labels=masked_target_ids, mtp_batch=mtp_batch)
                 loss_sum = out["loss"] * token_count
             else:
-                out = forward(model, input_ids, position_ids)
+                out = forward(model, input_ids, position_ids, mtp_batch=mtp_batch)
                 logits = out["logits"]
                 B, L, V = logits.shape
                 token_loss = ce_loss(logits.view(-1, V), target_ids.view(-1)).view(B, L)
                 loss_sum = token_loss[loss_mask].sum()
                 del logits
+            if out.get("mtp_loss_sum") is not None:
+                loss_sum = loss_sum + out["mtp_loss_sum"]
 
+        mtp_loss = out.get("mtp_loss")
         del out
-        return loss_sum, token_count
+        return loss_sum, token_count, mtp_loss
 
     maybe_record_function = nullcontext
 
@@ -241,7 +257,7 @@ def train(config: SFTConfig):
 
         with torch.no_grad():
             for micro_batch in data_iter:
-                loss_sum, token_count = compute_loss(micro_batch)
+                loss_sum, token_count, _ = compute_loss(micro_batch)
                 if not torch.isnan(loss_sum.detach()):
                     total_loss_sum += loss_sum.detach()
                     total_token_count += token_count
@@ -323,6 +339,8 @@ def train(config: SFTConfig):
 
         step_loss_sum = torch.tensor(0.0, device="cuda")
         step_local_token_count = torch.tensor(0, dtype=torch.int64, device="cuda")
+        step_mtp_loss_sum = torch.tensor(0.0, device="cuda")
+        step_mtp_loss_count = torch.tensor(0, dtype=torch.int64, device="cuda")
         nan_loss_count = torch.tensor(0, device="cuda")
         batch_max_vio = torch.tensor(0.0, device="cuda")
         for micro_step in range(grad_accum_steps):
@@ -334,9 +352,12 @@ def train(config: SFTConfig):
                 )
 
             with maybe_record_function("forward"):
-                local_loss_sum, local_token_count = compute_loss(micro_batch)
+                local_loss_sum, local_token_count, local_mtp_loss = compute_loss(micro_batch)
 
             step_local_token_count += local_token_count
+            if local_mtp_loss is not None:
+                step_mtp_loss_sum += local_mtp_loss.detach()
+                step_mtp_loss_count += 1
 
             if torch.isnan(local_loss_sum.detach()):
                 nan_loss_count += 1
@@ -381,11 +402,14 @@ def train(config: SFTConfig):
 
         # Compute the global mean loss for logging.
         dist.all_reduce(step_loss_sum, op=dist.ReduceOp.SUM, group=dp_cp_group)
+        dist.all_reduce(step_mtp_loss_sum, op=dist.ReduceOp.SUM, group=dp_cp_group)
+        dist.all_reduce(step_mtp_loss_count, op=dist.ReduceOp.SUM, group=dp_cp_group)
         dist.all_reduce(nan_loss_count, op=dist.ReduceOp.SUM)
         if global_token_count_val > 0:
             batch_loss = (step_loss_sum / global_token_count_val).item()
         else:
             batch_loss = 0.0
+        batch_mtp_loss = (step_mtp_loss_sum / step_mtp_loss_count).item() if step_mtp_loss_count.item() > 0 else None
         nan_loss_count = nan_loss_count.item()
 
         logger.debug(f"Clipping gradients with max norm {config.optim.max_norm}")
@@ -421,7 +445,10 @@ def train(config: SFTConfig):
 
         # Log step metrics
         step_time = time.perf_counter() - step_start_time
-        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {batch_loss:.4f} | Grad. Norm: {grad_norm:.4f} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}% | Peak Mem.: {peak_memory:.1f}/{max_memory:.1f} GiB ({peak_memory / max_memory * 100:.1f}%)"
+        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {batch_loss:.4f}"
+        if batch_mtp_loss is not None:
+            step_message += f" | MTP Loss: {batch_mtp_loss:.4f}"
+        step_message += f" | Grad. Norm: {grad_norm:.4f} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}% | Peak Mem.: {peak_memory:.1f}/{max_memory:.1f} GiB ({peak_memory / max_memory * 100:.1f}%)"
         if is_tt_moe_model(model) and batch_max_vio.item() > 0:
             step_message += f" | Max Vio: {batch_max_vio.item():.4f}"
         logger.success(step_message)
@@ -473,6 +500,8 @@ def train(config: SFTConfig):
             "loss/nan_count": nan_loss_count,
             "step": progress.step,
         }
+        if batch_mtp_loss is not None:
+            loss_log_metrics["mtp_loss/mean"] = batch_mtp_loss
         # Log tensor stats
         monitor.log(loss_log_metrics, step=progress.step)
 

--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -1,3 +1,4 @@
+import os
 import json
 import pickle
 import shutil
@@ -25,6 +26,17 @@ from prime_rl.utils.pathing import get_ckpt_dir
 from prime_rl.utils.utils import format_num, format_time, get_step_path
 
 DEFAULT_TIMEOUT = timedelta(seconds=600)
+
+
+def _configure_nccl_heartbeat_timeout(timeout: timedelta) -> None:
+    if "TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC" in os.environ:
+        return
+
+    # PyTorch's NCCL watchdog heartbeat defaults to 480s, which can abort
+    # legitimately long first steps (e.g. large-model compile/warmup) before the
+    # trainer's configured distributed timeout does.
+    timeout_seconds = max(480, int(timeout.total_seconds()))
+    os.environ["TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC"] = str(timeout_seconds)
 
 
 def _to_local_tensor(tensor: Tensor | DTensor) -> Tensor:
@@ -105,6 +117,7 @@ def get_ckpt_disk_metrics(output_dir: Path) -> dict[str, float]:
 def setup_torch_distributed(timeout: timedelta = DEFAULT_TIMEOUT, enable_gloo: bool = False):
     device_id = get_world().local_rank
     torch.cuda.set_device(device_id)
+    _configure_nccl_heartbeat_timeout(timeout)
     # Use Gloo backend for CPU and NCCL for GPU when CPU offloading is enabled
     # Otherwise use NCCL for better GPU performance
     backend = None  # by default nccl

--- a/src/prime_rl/utils/cp.py
+++ b/src/prime_rl/utils/cp.py
@@ -8,26 +8,35 @@ from ring_flash_attn import update_ring_flash_attn_params
 
 def setup_hybrid_cp(model: nn.Module, cp_group: dist.ProcessGroup, cp_rank: int, cp_world_size: int) -> None:
     """Configure DeltaNet modules in Qwen3.5 hybrid models for native fla CP."""
-    layers = None
+    layer_collections: list = []
     if hasattr(model, "model"):
         inner = model.model
         if hasattr(inner, "language_model"):
             inner = inner.language_model
         if hasattr(inner, "layers"):
-            layers = inner.layers
+            layer_collections.append(inner.layers)
+        mtp_layers = getattr(inner, "mtp_layers", None)
+        if mtp_layers is not None:
+            layer_collections.append(mtp_layers)
+        mtp = getattr(model, "mtp", None)
+        if mtp is None:
+            mtp = getattr(inner, "mtp", None)
+        if mtp is not None and hasattr(mtp, "layers"):
+            layer_collections.append(mtp.layers)
 
-    if layers is None:
+    if not layer_collections:
         return
 
     count = 0
-    for layer in layers:
-        if getattr(layer, "layer_type", None) == "linear_attention":
-            attn = getattr(layer, "linear_attn", None)
-            if attn is not None:
-                attn.cp_group = cp_group
-                attn.cp_rank = cp_rank
-                attn.cp_world_size = cp_world_size
-                count += 1
+    for layers in layer_collections:
+        for layer in layers:
+            if getattr(layer, "layer_type", None) == "linear_attention":
+                attn = getattr(layer, "linear_attn", None)
+                if attn is not None:
+                    attn.cp_group = cp_group
+                    attn.cp_rank = cp_rank
+                    attn.cp_world_size = cp_world_size
+                    count += 1
 
     if count > 0:
         from prime_rl.utils.logger import get_logger

--- a/uv.lock
+++ b/uv.lock
@@ -537,19 +537,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cupy-cuda12x"
-version = "13.6.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "fastrlock", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "numpy", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/c5/7e7fc4816d0de0154e5d9053242c3a08a0ca8b43ee656a6f7b3b95055a7b/cupy_cuda12x-13.6.0-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:a6970ceefe40f9acbede41d7fe17416bd277b1bd2093adcde457b23b578c5a59", size = 127334633, upload-time = "2025-08-18T08:24:43.065Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/95/d7e1295141e7d530674a3cc567e13ed0eb6b81524cb122d797ed996b5bea/cupy_cuda12x-13.6.0-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:79b0cacb5e8b190ef409f9e03f06ac8de1b021b0c0dda47674d446f5557e0eb1", size = 112886268, upload-time = "2025-08-18T08:24:49.294Z" },
-]
-
-[[package]]
 name = "datasets"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -789,18 +776,6 @@ wheels = [
 ]
 
 [[package]]
-name = "fastrlock"
-version = "0.8.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/73/b1/1c3d635d955f2b4bf34d45abf8f35492e04dbd7804e94ce65d9f928ef3ec/fastrlock-0.8.3.tar.gz", hash = "sha256:4af6734d92eaa3ab4373e6c9a1dd0d5ad1304e172b1521733c6c3b3d73c8fa5d", size = 79327, upload-time = "2024-12-17T11:03:39.638Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/21/ea1511b0ef0d5457efca3bf1823effb9c5cad4fc9dca86ce08e4d65330ce/fastrlock-0.8.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:85a49a1f1e020097d087e1963e42cea6f307897d5ebe2cb6daf4af47ffdd3eed", size = 52201, upload-time = "2024-12-17T11:02:19.512Z" },
-    { url = "https://files.pythonhosted.org/packages/80/07/cdecb7aa976f34328372f1c4efd6c9dc1b039b3cc8d3f38787d640009a25/fastrlock-0.8.3-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5f13ec08f1adb1aa916c384b05ecb7dbebb8df9ea81abd045f60941c6283a670", size = 53924, upload-time = "2024-12-17T11:02:20.85Z" },
-    { url = "https://files.pythonhosted.org/packages/88/6d/59c497f8db9a125066dd3a7442fab6aecbe90d6fec344c54645eaf311666/fastrlock-0.8.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0ea4e53a04980d646def0f5e4b5e8bd8c7884288464acab0b37ca0c65c482bfe", size = 52140, upload-time = "2024-12-17T11:02:22.263Z" },
-    { url = "https://files.pythonhosted.org/packages/62/04/9138943c2ee803d62a48a3c17b69de2f6fa27677a6896c300369e839a550/fastrlock-0.8.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:38340f6635bd4ee2a4fb02a3a725759fe921f2ca846cb9ca44531ba739cc17b4", size = 53261, upload-time = "2024-12-17T11:02:24.418Z" },
-]
-
-[[package]]
 name = "filelock"
 version = "3.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -874,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "flashinfer-python"
-version = "0.6.4"
+version = "0.6.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apache-tvm-ffi", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -891,9 +866,9 @@ dependencies = [
     { name = "torch", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "tqdm", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/45/15645d2a4ee81d08206f3e132a77323e48312f510462415d7cd1122eba43/flashinfer_python-0.6.4.tar.gz", hash = "sha256:e6ab798bd1030e5ff7a3bc6952f36386c406928f60b79cf964a6db7aa7ccde75", size = 5337134, upload-time = "2026-02-19T07:33:36.647Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/70/c5a235297351021f5d3d3233523a85f5a6468495587489ad2f257e8eafe2/flashinfer_python-0.6.6.tar.gz", hash = "sha256:0730ba7c7aad332961933bcebc5119762797161ede57d955f6fd199818ed1d92", size = 5344156, upload-time = "2026-03-11T01:36:21.434Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/9a/d2bab76d2bb15062c6a2329614653e4f8bec9c78eec9069856ef0c7c0a79/flashinfer_python-0.6.4-py3-none-any.whl", hash = "sha256:105596b505892ae330af84e250ee0eb6fc2c3a22e8dc42bd46de1b90d36004c8", size = 7819999, upload-time = "2026-02-19T07:33:34.82Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/61/385d06755f3ab66333018285657adf0daf8a90a129448231fd09e315bd2e/flashinfer_python-0.6.6-py3-none-any.whl", hash = "sha256:078f158636969eec1a0d3dea19c3ca90b426b66df89bbf7b7b8276ce2ec08148", size = 7817047, upload-time = "2026-03-11T01:36:19.198Z" },
 ]
 
 [[package]]
@@ -1015,19 +990,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c4/d7/60e821443c044365222a7fcd6630344016ea3e31bf4903f3a22f93e5b3a1/grpcio-1.78.0rc2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7bde54ad7bee2d4dbc6d4a351d5b62cc2bfa87c58e9db911ed8a0489192ca9a", size = 6690812, upload-time = "2026-01-16T07:28:43.887Z" },
     { url = "https://files.pythonhosted.org/packages/80/47/b19c67ca6e0622fccb88558452e6f7458551ef365456585968dcd84a1db3/grpcio-1.78.0rc2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4e99bbce4f509eb6af4b523109152258043b92bbb945950456a9318eca71ef2e", size = 7266122, upload-time = "2026-01-16T07:28:46.109Z" },
     { url = "https://files.pythonhosted.org/packages/df/81/dcf11b5915a39024d4a98ef14b16cb0c636a4f2f26ef657982d3144c6544/grpcio-1.78.0rc2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ea66e360e5ea032a1f6dde926915ba683edca811ed6f0e0620c52e264ba364e4", size = 7698266, upload-time = "2026-01-16T07:28:51.342Z" },
-]
-
-[[package]]
-name = "grpcio-reflection"
-version = "1.78.0rc2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "grpcio", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "protobuf", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/4f/7c5032a6365cf964ef3e1fea7df76294d2804e6414802e36000d57f0eeb3/grpcio_reflection-1.78.0rc2.tar.gz", hash = "sha256:d925a43ef37f93a2129575111bf4add284d344eecc7e610b65f3b61a59c671b7", size = 19111, upload-time = "2026-01-16T08:01:53.077Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/c3/a1082fb098bb23c19c5df32b78c83bd000289592e079fa2daf7dddba7a43/grpcio_reflection-1.78.0rc2-py3-none-any.whl", hash = "sha256:c4a5f8e9681a83c0ddc80b8648d74144bf6c7bad1e7e2598c77754a8e7998d61", size = 22838, upload-time = "2026-01-16T08:01:41.466Z" },
 ]
 
 [[package]]
@@ -1384,16 +1346,6 @@ wheels = [
 ]
 
 [[package]]
-name = "kaldi-native-fbank"
-version = "1.22.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3a/2c/84076b352107ce12d56f28c313f1aca1be332d953dd96aec7b84976e6d53/kaldi-native-fbank-1.22.3.tar.gz", hash = "sha256:387bf87225c6b83c93ae652eeaef1b4d531994b6e398e7a77189de340674f9af", size = 71013, upload-time = "2025-10-09T02:31:21.487Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/28/6f4fd8953c0b3f30de4526fd024095032abcdc25b6736c77a891687c604e/kaldi_native_fbank-1.22.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5a44b4a83cf9bf13d3f77858928068b06d3ec2238c27ff2e39393fbf7749c9f", size = 298887, upload-time = "2025-10-09T02:30:53.739Z" },
-    { url = "https://files.pythonhosted.org/packages/84/90/01ef7331c52b1eaf9916f3f7a535155aac2e9e2ddad12a141613d92758c7/kaldi_native_fbank-1.22.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f16e74372fe9e20abb4183f98a8e2288d5ee4c48d04d94b6160311170e007661", size = 322002, upload-time = "2025-10-09T02:30:13.04Z" },
-]
-
-[[package]]
 name = "kubernetes"
 version = "35.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1683,7 +1635,7 @@ wheels = [
 
 [[package]]
 name = "mistral-common"
-version = "1.9.1"
+version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonschema", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -1695,9 +1647,9 @@ dependencies = [
     { name = "tiktoken", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "typing-extensions", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/db/ce/685b8127a326478e05501cb4c9ca23d1cd9f37e16c465a1e832c75aea709/mistral_common-1.9.1.tar.gz", hash = "sha256:550583d70a395c3586cfb748ffab53bd1d7c3409507f0efc0118bff30ffb26e9", size = 6338922, upload-time = "2026-02-12T10:53:41.639Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/22/f798c1acc3f8cf32b6201b063d96867d79aa39d31dff12478739e1a78979/mistral_common-1.10.0.tar.gz", hash = "sha256:e456ff101edbdfc094039ec6c26f7d0f73356729798d628a6e6e96c3917147bc", size = 6351515, upload-time = "2026-03-13T10:13:46.683Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/72/a38bb1fd9fd4d4ef990341c9dd1a7c8061f1951e10efa6d50c0a3f04eced/mistral_common-1.9.1-py3-none-any.whl", hash = "sha256:9e2b2520b6f67bac2e2bb06fcf985b7a1277b01938da2b7cda8cf0fdbfa92e91", size = 6518623, upload-time = "2026-02-12T10:53:39.457Z" },
+    { url = "https://files.pythonhosted.org/packages/87/c6/1429a0a3ab40f8530492b62b52eb792266c261b22ed62aa7f25d61d531ae/mistral_common-1.10.0-py3-none-any.whl", hash = "sha256:c594d1a05202b61e8f0d867ec6064df4c5e5d492c2c2bdb6fd8fb4872c6afd8b", size = 6525284, upload-time = "2026-03-13T10:13:44.329Z" },
 ]
 
 [package.optional-dependencies]
@@ -2630,7 +2582,7 @@ requires-dist = [
     { name = "transformers", git = "https://github.com/huggingface/transformers.git?rev=5c1c72b" },
     { name = "uvloop", specifier = ">=0.21.0" },
     { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=0db45e6" },
-    { name = "vllm", specifier = ">=0.17.0" },
+    { name = "vllm", specifier = ">=0.18.0" },
     { name = "vllm-router", marker = "platform_machine == 'x86_64' and extra == 'disagg'", url = "https://github.com/samsja/flash-attn-builds/releases/download/v0.3/vllm_router-0.1.11-cp38-abi3-linux_x86_64.whl" },
     { name = "wandb", specifier = ">=0.24.2" },
     { name = "wiki-search", marker = "extra == 'envs'", index = "https://hub.primeintellect.ai/primeintellect/simple/" },
@@ -3049,30 +3001,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/75/af/5b77f565d4268905eb7e7fe3367f877ae98d0cae920c6d9f2d019a39f214/quack_kernels-0.3.6.tar.gz", hash = "sha256:43af5a1f31099682cb1c53aa835fcdfebeb88d917c08aa342b959af88c6e8749", size = 192593, upload-time = "2026-03-24T13:30:00.923Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/28/e688da97806474963b2983a8231572733de11ed48f8899410c0afc8bdf15/quack_kernels-0.3.6-py3-none-any.whl", hash = "sha256:973d974ccca816014006af8f136294ba0f15b1c324197f8b54ffc6500666e0e5", size = 198865, upload-time = "2026-03-24T13:29:59.107Z" },
-]
-
-[[package]]
-name = "ray"
-version = "2.49.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "filelock", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jsonschema", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "msgpack", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "packaging", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "protobuf", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pyyaml", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "requests", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/ba/77eae921fc2595087516df6efc0ca03caacc14d16592341985916f1aed13/ray-2.49.1-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:cf63b916e399c2a4d484249611a96cee283cef32e544126115a4ad3e872c34eb", size = 69287149, upload-time = "2025-09-03T00:25:47.605Z" },
-    { url = "https://files.pythonhosted.org/packages/00/02/c81260c0f94bd34a1442ea488bdd433dfc9e6ed6211c9a59bc4157b8e00e/ray-2.49.1-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:484064fca02732e0b6f4a09dad0d1fb6abd4ca4b6d9bf7c26ab7a17a2887cd09", size = 70114899, upload-time = "2025-09-03T00:25:53.144Z" },
-]
-
-[package.optional-dependencies]
-cgraph = [
-    { name = "cupy-cuda12x", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
 [[package]]
@@ -3871,7 +3799,7 @@ wheels = [
 
 [[package]]
 name = "vllm"
-version = "0.17.0"
+version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -3888,10 +3816,7 @@ dependencies = [
     { name = "filelock", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "flashinfer-python", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "gguf", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "grpcio", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "grpcio-reflection", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "ijson", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "kaldi-native-fbank", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "lark", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "llguidance", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "lm-format-enforcer", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -3902,6 +3827,7 @@ dependencies = [
     { name = "ninja", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "numba", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "numpy", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cudnn-frontend", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nvidia-cutlass-dsl", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "openai", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "openai-harmony", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -3924,7 +3850,6 @@ dependencies = [
     { name = "pyyaml", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pyzmq", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "quack-kernels", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "ray", extra = ["cgraph"], marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "regex", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "requests", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "sentencepiece", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -3942,10 +3867,10 @@ dependencies = [
     { name = "watchfiles", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "xgrammar", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/13/d5/af83a4262ca4d5692a93b3c322ae954e3e6c4e23f8f9db3ab87bd79c919e/vllm-0.17.0.tar.gz", hash = "sha256:b0b62e58ef4eb633ef371f2726976372cf6dfcb7ff2ea9ddf7194c1930d5629a", size = 30541311, upload-time = "2026-03-07T03:54:54.333Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/a9/ed48c497572a41552cc71b5ede15291d882c546a01df27ed42944eb3b3ad/vllm-0.18.0.tar.gz", hash = "sha256:9a1bee091db8dbb4664a2a09cd9c61912e9912a44af1ce12b8593a231d05971c", size = 30812817, upload-time = "2026-03-20T22:16:59.039Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/72/78a48668f2631def18bbaaa331d7878bcfc5c3137455422aafb0748e1261/vllm-0.17.0-cp38-abi3-manylinux_2_31_aarch64.whl", hash = "sha256:310fb82fe061ed75dceeb4aeb803cd8ee0d590337ec720f7abfb03a69314d710", size = 385329399, upload-time = "2026-03-07T03:54:34.261Z" },
-    { url = "https://files.pythonhosted.org/packages/25/4f/972726f9a501f01203b5c4796e1932abbe435fae6d7715a4c3f1aad14a58/vllm-0.17.0-cp38-abi3-manylinux_2_31_x86_64.whl", hash = "sha256:0296670a09d392ee43455d9bebf590d05a9bc2ebce5e25e2919222fc815158da", size = 432927988, upload-time = "2026-03-07T03:54:02.312Z" },
+    { url = "https://files.pythonhosted.org/packages/37/f8/d677aef63536b54d8d0268241dc50a4fe01efcf162ef26190b9ed4bed109/vllm-0.18.0-cp38-abi3-manylinux_2_31_aarch64.whl", hash = "sha256:66a2c5bcf1bdf8de3e63b9fee067754068108cd510c65ffba70ff4368c33cba8", size = 385589729, upload-time = "2026-03-20T22:16:38.734Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/e9/59cf9b8939b51e859d2166ac3336b353f52ec4f9ceda34228aae7b386840/vllm-0.18.0-cp38-abi3-manylinux_2_31_x86_64.whl", hash = "sha256:0bc51491598f4bcd161b693b27cbe2864082d6c49fa9065965d94b371f6ae8ef", size = 433215727, upload-time = "2026-03-20T22:16:00.336Z" },
 ]
 
 [[package]]
@@ -4100,7 +4025,7 @@ wheels = [
 
 [[package]]
 name = "xgrammar"
-version = "0.1.29"
+version = "0.1.33"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -4110,10 +4035,10 @@ dependencies = [
     { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "typing-extensions", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/a3/70dbe3ffd331a1e7e1ad5a95690a4086e6c7cdb8089f5c7eda712219ccec/xgrammar-0.1.29.tar.gz", hash = "sha256:cf195afa81b489eebf35d4c6f37f27136d05420739ab4a6f7f065c938d7e4baa", size = 2321317, upload-time = "2025-12-19T08:23:54.53Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/43/e5dfddb1d2a4fccf3e3a88f103e88698cdefc3182f4e169a359ffe1c1794/xgrammar-0.1.33.tar.gz", hash = "sha256:8dbe5fc3d76651ab1fac7a68fc2a118b885fa0ec7189927fb6e0dce0081aea99", size = 2398956, upload-time = "2026-03-27T10:16:36.582Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/94/18793c64bf0368075a34c06e196bf002f1e6ab0aee332268f44e8d356d5a/xgrammar-0.1.29-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6eb370a16b27a683e5f2b9e429ab41440c69977d4a504849ed61831b94cc704c", size = 34705239, upload-time = "2025-12-19T08:23:28.369Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/da/4c14e3e00be698009b52700f15326a23272b4b00475939b6acc86b151188/xgrammar-0.1.29-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79e6e4f5cd33be77418cf91efc482f2b3d773d309891224383bc8a4948ad7b07", size = 34906135, upload-time = "2025-12-19T08:23:30.838Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/04/43d4baca876f5ae1b45897ec30a59801a2da37f16da1fcd85f9555e4c125/xgrammar-0.1.33-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c803e60d791854c5d1f271ece7e1f34d73c82dd4a8b2a06b7af5331482a78ac", size = 42133168, upload-time = "2026-03-27T10:15:16.994Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/a8/672833a3cff027253793aa999401d8364896ebf396967e475c7a878b895f/xgrammar-0.1.33-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:52b8eaa533282a0efb0835db6998ae72e7b3c7875d7a52e360ffebff9b78c30a", size = 42205803, upload-time = "2026-03-27T10:15:21.599Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> High risk because it adds new loss paths and model/weight-conversion logic in the training stack (forward pass, checkpoint conversion, FSDP/EP sharding) and bumps vLLM, which can impact correctness and distributed stability.
> 
> **Overview**
> Adds first-class **multi-token prediction (MTP)** support end-to-end: a new `[model.mtp]` training config, a new `trainer/models/layers/mtp.py` module that builds per-step MTP batches and computes an auxiliary CE loss, and wiring in RL + SFT loops to pass `mtp_batch`, add `mtp_loss_sum` to the total loss, and log `mtp_loss`.
> 
> Extends model implementations and checkpoint tooling to carry MTP weights: NemotronH and Qwen3.5-MoE configs/models now optionally instantiate MTP modules, and HF↔PrimeRL conversion/broadcast paths are updated to convert `mtp.layers.*` rather than dropping them (including handling non-layer checkpoint chunks).
> 
> Updates inference to support serving a model’s built-in MTP head via vLLM speculative decoding (`[mtp]` → `speculative_config.method="mtp"`), guards against conflicting config sources, and adjusts vLLM server patching for vLLM `0.18.0`.
> 
> Includes distributed-stability/perf tweaks: barrier to prevent NCCL deadlock during weight broadcast, automatic `TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC` based on trainer timeout, CPU-offload AdamW disables foreach, added decode-speed logging, and minor meta-buffer/RoPE init compatibility fixes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78f02c689428cfc7894f4c2a9075352bc6e3325d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->