### PR TITLE
add `eval/{env}/failed_rollouts` metric

### DIFF
--- a/src/prime_rl/orchestrator/eval_utils.py
+++ b/src/prime_rl/orchestrator/eval_utils.py
@@ -103,6 +103,7 @@ async def evaluate_env(
     logger = get_logger()
     logger.info(f"Evaluating {env_name} ({num_examples=}, {rollouts_per_example=})")
     eval_start_time = time.perf_counter()
+    total_inputs = len(env._get_eval_inputs(num_examples, rollouts_per_example))
     outputs = await evaluate(
         env=env,
         model_name=model_name,
@@ -113,9 +114,15 @@ async def evaluate_env(
         max_retries=max_retries,
     )
     eval_time = time.perf_counter() - eval_start_time
+    failed_rollouts = total_inputs - len(outputs)
 
     if not outputs:
-        logger.warning(f"All rollouts failed for {env_name}, skipping metrics")
+        logger.warning(f"All rollouts failed for {env_name} ({failed_rollouts} failed), skipping metrics")
+        monitor = get_monitor()
+        monitor.log(
+            {f"eval/{env_name}/failed_rollouts": failed_rollouts, "progress/ckpt_step": ckpt_step, "step": step},
+            step=step,
+        )
         return
 
     rows = []
@@ -166,6 +173,7 @@ async def evaluate_env(
         "completion_len/max": results_df.completion_len.max().item(),
         "completion_len/min": results_df.completion_len.min().item(),
         "is_truncated/mean": results_df.is_truncated.mean().item(),
+        "failed_rollouts": failed_rollouts,
         "time": eval_time,
     }
     if could_be_binary:

--- a/src/prime_rl/orchestrator/vf_utils.py
+++ b/src/prime_rl/orchestrator/vf_utils.py
@@ -207,6 +207,10 @@ async def generate(
     finally:
         pbar.close()
 
+    failed_groups = sum(1 for g in group_outputs_list if g is None)
+    if failed_groups:
+        get_logger().warning(f"{failed_groups}/{len(group_outputs_list)} groups failed")
+
     return [output for group_outputs in group_outputs_list if group_outputs is not None for output in group_outputs]
 
 
@@ -229,7 +233,7 @@ async def evaluate(
 
     """
     inputs = env._get_eval_inputs(num_examples, rollouts_per_example)
-    outputs = await generate(
+    return await generate(
         env=env,
         clients=clients,
         get_client=get_client,
@@ -244,7 +248,6 @@ async def evaluate(
         max_retries=max_retries,
         state_columns=state_columns,
     )
-    return outputs
 
 
 # TODO: remove once usage is tracked by verifiers


### PR DESCRIPTION
log silently excluded failed rollouts during online-eval to understand how skewed eval results are.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to evaluation/monitoring instrumentation and warning logs, without altering rollout generation/scoring behavior.
> 
> **Overview**
> Adds a new `eval/{env}/failed_rollouts` metric by comparing requested eval inputs vs returned outputs, and logs it both in normal eval metrics and when *all* rollouts fail (so the failure rate is still visible).
> 
> Improves visibility into generation failures by warning when some rollout groups fail inside `vf_utils.generate()` (previously failures were only logged per-group).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0afdb601339b92e8abf5e4350b19232ff8c9ffb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->