### PR TITLE
add `eval/samples` table

### DIFF
--- a/src/prime_rl/orchestrator/eval_utils.py
+++ b/src/prime_rl/orchestrator/eval_utils.py
@@ -175,3 +175,4 @@ async def evaluate_env(
     eval_metrics.update({"progress/ckpt_step": ckpt_step, "step": step})
     monitor = get_monitor()
     monitor.log(eval_metrics, step=step)
+    monitor.log_eval_samples(outputs, env_name=env_name, step=step)

--- a/src/prime_rl/utils/monitor/base.py
+++ b/src/prime_rl/utils/monitor/base.py
@@ -20,6 +20,10 @@ class Monitor(ABC):
         pass
 
     @abstractmethod
+    def log_eval_samples(self, rollouts: list[vf.RolloutOutput], env_name: str, step: int) -> None:
+        pass
+
+    @abstractmethod
     def log_final_samples(self) -> None:
         pass
 
@@ -46,6 +50,9 @@ class NoOpMonitor(Monitor):
         self.history.append(metrics)
 
     def log_samples(self, rollouts: list[vf.RolloutOutput], step: int) -> None:
+        pass
+
+    def log_eval_samples(self, rollouts: list[vf.RolloutOutput], env_name: str, step: int) -> None:
         pass
 
     def log_final_samples(self) -> None:

--- a/src/prime_rl/utils/monitor/multi.py
+++ b/src/prime_rl/utils/monitor/multi.py
@@ -33,6 +33,13 @@ class MultiMonitor(Monitor):
             except Exception as e:
                 self.logger.warning(f"Failed to log samples to {monitor.__class__.__name__}: {e}")
 
+    def log_eval_samples(self, rollouts: list[vf.RolloutOutput], env_name: str, step: int) -> None:
+        for monitor in self.monitors:
+            try:
+                monitor.log_eval_samples(rollouts=rollouts, env_name=env_name, step=step)
+            except Exception as e:
+                self.logger.warning(f"Failed to log eval samples to {monitor.__class__.__name__}: {e}")
+
     def log_final_samples(self) -> None:
         for monitor in self.monitors:
             try:

--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -446,6 +446,9 @@ class PrimeMonitor(Monitor):
                 await asyncio.sleep(delay)
         return False
 
+    def log_eval_samples(self, rollouts: list[vf.RolloutOutput], env_name: str, step: int) -> None:
+        pass
+
     def log_final_samples(self) -> None:
         """Log final samples (no-op - samples are logged per-step only)."""
         pass

--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -102,6 +102,11 @@ class WandbMonitor(Monitor):
                 )
                 self.tokenizer = tokenizer
                 self.samples = []
+                self.eval_samples_cols = ["step", "env", "task", "example_id", "completion", "reward"]
+                self.eval_samples_table = wandb.Table(
+                    columns=self.eval_samples_cols,
+                    log_mode="INCREMENTAL",
+                )
 
     def _maybe_overwrite_wandb_command(self) -> None:
         """Overwrites sys.argv with the start command if it is set in the environment variables."""
@@ -164,6 +169,34 @@ class WandbMonitor(Monitor):
         wandb.log({"samples": self.samples_table, "step": step})
         self.last_log_samples_step = step
         self.logger.debug(f"Logged samples at step {step} to W&B table in {time.perf_counter() - start_time:.2f}s")
+
+    def log_eval_samples(self, rollouts: list[vf.RolloutOutput], env_name: str, step: int) -> None:
+        """Logs eval rollouts to a separate W&B table."""
+        if not self.is_master:
+            return
+        if (
+            not self.config
+            or not isinstance(self.config, WandbWithExtrasConfig)
+            or not self.config.log_extras
+            or not self.config.log_extras.samples
+        ):
+            return
+
+        for rollout in rollouts:
+            completion = rollout.get("completion", "")
+            if not completion:
+                continue
+            sample = {
+                "step": step,
+                "env": env_name,
+                "task": rollout.get("task"),
+                "example_id": rollout["example_id"],
+                "completion": completion,
+                "reward": rollout["reward"],
+            }
+            self.eval_samples_table.add_data(*sample.values())
+
+        wandb.log({"eval/samples": self.eval_samples_table, "step": step})
 
     def log_final_samples(self) -> None:
         """Log final samples to W&B table."""


### PR DESCRIPTION
not only log training rollouts to "samples" table, but also online-eval rollouts to "eval/samples" table

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional new monitoring hook for eval rollouts and wires it into evaluation; primary behavior change is additional W&B logging, with other monitors defaulting to no-op.
> 
> **Overview**
> Online evaluation now logs rollout examples in addition to aggregate metrics.
> 
> This introduces a new `Monitor.log_eval_samples(...)` hook, calls it from `evaluate_env`, and updates `MultiMonitor`/`NoOpMonitor` accordingly. `WandbMonitor` implements the hook by writing eval completions to a dedicated W&B table logged under `eval/samples` (including `env`), while `PrimeMonitor` currently leaves eval-sample logging as a no-op.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ebf74db8a95e490f5f883707dfa7f733cf6cba4b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->