### PR TITLE
docs: fix debug eval validation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,15 @@ uv run orchestrator @ configs/debug/orch.toml
 5.2. Check that you can run evals against the inference server
 
 ```bash
-uv run eval @ configs/debug/eval.toml
+uv run vf-eval reverse-text \
+  -m Qwen/Qwen3-0.6B \
+  -b http://localhost:8000/v1 \
+  -n 20 \
+  --max-tokens 1024
 ```
+
+The `-m` value must match the inference server's served model name. If you override
+`--model.name` when starting inference, use that same model name here.
 
 </details>
 


### PR DESCRIPTION
## Summary
- replace the stale `uv run eval @ configs/debug/eval.toml` step in the top-level README
- use the working `vf-eval` reverse-text command instead
- note that the eval model name must match the inference server's served model name

## Context
Historically, `prime-rl` did have a standalone `eval` entrypoint and a `configs/debug/eval.toml` config. The eval CLI was added in [0753be0db](https://github.com/PrimeIntellect-ai/prime-rl/commit/0753be0dbf777b359906fe9e99f657c241c5eb73), and the debug eval configs were later removed in [9c00ef860](https://github.com/PrimeIntellect-ai/prime-rl/commit/9c00ef8602da4ee8c1a00d317030fe3eea94270a). The top-level README still referenced `uv run eval @ configs/debug/eval.toml`, but the current repo scripts no longer expose `eval`, and the working examples already use `vf-eval`.

## Testing
- docs change only
- validated manually against the local debug inference server

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change that updates a README command; no runtime or security-sensitive code paths are modified.
> 
> **Overview**
> Replaces the stale README debug validation step (`uv run eval @ configs/debug/eval.toml`) with a working `vf-eval reverse-text` invocation against the local inference server.
> 
> Adds a short note that the `-m` model name used for evals must match the inference server’s served model name (including when overriding `--model.name`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30916f8d229aac782dd8df0490557c5c44083c30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->