### PR TITLE
Add GLM5 index cache support

### DIFF
--- a/configs/glm5_8node_fake/rl.toml
+++ b/configs/glm5_8node_fake/rl.toml
@@ -1,0 +1,54 @@
+max_steps = 100
+seq_len = 32768
+bench = true
+max_async_level = 1
+
+[log]
+level = "debug"
+
+[wandb]
+project = "GLM5-fake"
+name = "glm5-8node-fake"
+
+[model]
+name = "zai-org/GLM-5"
+
+[deployment]
+type = "multi_node"
+num_train_nodes = 8
+num_infer_nodes = 0
+gpus_per_node = 8
+
+[slurm]
+job_name = "glm5-8node-fake"
+partition = "cluster"
+exclude = "ltc-idc3-hgx8-h200-65,ltc-idc3-hgx8-h200-62"
+
+[trainer]
+dist_timeout_seconds = 7200
+
+[trainer.model]
+impl = "custom"
+attn = "flash_attention_2"
+fused_lm_head_token_chunk_size = 2048
+ep = 16
+optim_cpu_offload = true
+
+[trainer.model.ac]
+freq = 1
+
+[trainer.model.compile]
+
+[trainer.model.ac_offloading]
+max_inflight_activations = 1
+
+[trainer.model.debug]
+random_init = true
+
+[trainer.optim]
+type = "adamw"
+lr = 1e-6
+weight_decay = 0.1
+
+
+[orchestrator]

--- a/configs/hendrycks_math/glm5_rl_16train_2infer.toml
+++ b/configs/hendrycks_math/glm5_rl_16train_2infer.toml
@@ -1,0 +1,91 @@
+max_steps = 6
+seq_len = 32768
+max_async_level = 1
+output_dir = "/shared/outputs/matej/glm5-hendrycks-base"
+
+[log]
+level = "debug"
+
+[wandb]
+project = "glm5-index-cache"
+name = "glm5-hendrycks-base"
+offline = true
+shared = false
+
+[model]
+name = "zai-org/GLM-5"
+
+[weight_broadcast]
+type = "nccl"
+port = 29502
+timeout = 12000
+quantize_in_weight_transfer = true
+
+[deployment]
+type = "multi_node"
+num_train_nodes = 16
+num_infer_nodes = 2
+gpus_per_node = 8
+
+[slurm]
+job_name = "glm5-hm-base"
+partition = "cluster"
+time = "04:00:00"
+
+[trainer]
+dist_timeout_seconds = 7200
+
+[trainer.model]
+impl = "custom"
+attn = "flash_attention_2"
+fused_lm_head_token_chunk_size = 2048
+ep = 16
+optim_cpu_offload = true
+
+[trainer.model.ac]
+freq = 1
+
+[trainer.model.compile]
+
+[trainer.model.ac_offloading]
+max_inflight_activations = 1
+
+[trainer.optim]
+type = "adamw"
+lr = 1e-6
+weight_decay = 0.1
+
+[orchestrator]
+batch_size = 256
+rollouts_per_example = 8
+oversampling_factor = 2
+max_off_policy_steps = 8
+use_token_client = true
+
+[orchestrator.sampling]
+temperature = 1.0
+max_tokens = 2048
+
+[[orchestrator.env]]
+id = "math-env"
+name = "hendrycks-math"
+args = { dataset_name = "PrimeIntellect/Hendrycks-Math", dataset_subset = "default", math_verify_max_workers = 128, math_verify_timeout = 60 }
+
+[orchestrator.buffer]
+easy_threshold = 1.0
+hard_threshold = 0.0
+
+[inference]
+enable_expert_parallel = true
+enable_eplb = false
+use_deep_gemm = true
+gpu_memory_utilization = 0.80
+
+[inference.model]
+name = "zai-org/GLM-5-FP8"
+max_model_len = 65536
+tool_call_parser = "glm47"
+
+[inference.parallel]
+tp = 1
+dp = 16

--- a/configs/hendrycks_math/glm5_rl_16train_2infer_index_cache.toml
+++ b/configs/hendrycks_math/glm5_rl_16train_2infer_index_cache.toml
@@ -1,0 +1,94 @@
+max_steps = 6
+seq_len = 32768
+max_async_level = 1
+output_dir = "/shared/outputs/matej/glm5-hendrycks-index-cache-f4"
+
+[log]
+level = "debug"
+
+[wandb]
+project = "glm5-index-cache"
+name = "glm5-hendrycks-index-cache-f4"
+offline = true
+shared = false
+
+[model]
+name = "zai-org/GLM-5"
+
+[model.index_cache]
+freq = 4
+
+[weight_broadcast]
+type = "nccl"
+port = 29502
+timeout = 12000
+quantize_in_weight_transfer = true
+
+[deployment]
+type = "multi_node"
+num_train_nodes = 16
+num_infer_nodes = 2
+gpus_per_node = 8
+
+[slurm]
+job_name = "glm5-hm-ic4"
+partition = "cluster"
+time = "04:00:00"
+
+[trainer]
+dist_timeout_seconds = 7200
+
+[trainer.model]
+impl = "custom"
+attn = "flash_attention_2"
+fused_lm_head_token_chunk_size = 2048
+ep = 16
+optim_cpu_offload = true
+
+[trainer.model.ac]
+freq = 1
+
+[trainer.model.compile]
+
+[trainer.model.ac_offloading]
+max_inflight_activations = 1
+
+[trainer.optim]
+type = "adamw"
+lr = 1e-6
+weight_decay = 0.1
+
+[orchestrator]
+batch_size = 256
+rollouts_per_example = 8
+oversampling_factor = 2
+max_off_policy_steps = 8
+use_token_client = true
+
+[orchestrator.sampling]
+temperature = 1.0
+max_tokens = 2048
+
+[[orchestrator.env]]
+id = "math-env"
+name = "hendrycks-math"
+args = { dataset_name = "PrimeIntellect/Hendrycks-Math", dataset_subset = "default", math_verify_max_workers = 128, math_verify_timeout = 60 }
+
+[orchestrator.buffer]
+easy_threshold = 1.0
+hard_threshold = 0.0
+
+[inference]
+enable_expert_parallel = true
+enable_eplb = false
+use_deep_gemm = true
+gpu_memory_utilization = 0.80
+
+[inference.model]
+name = "zai-org/GLM-5-FP8"
+max_model_len = 65536
+tool_call_parser = "glm47"
+
+[inference.parallel]
+tp = 1
+dp = 16

--- a/scripts/index_cache_bench.py
+++ b/scripts/index_cache_bench.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+TRAINER_STEP_RE = re.compile(
+    r"Step (?P<step>\d+) \| Time: (?P<time>[0-9.]+)s .*? \| Throughput: (?P<throughput>[0-9.]+) tokens/s"
+)
+ORCHESTRATOR_STEP_RE = re.compile(
+    r"Step (?P<step>\d+) \| Time: (?P<time>[0-9.]+)s .*? Seq\. Length: (?P<seq_len>[0-9.]+) tokens/sample"
+)
+
+
+@dataclass
+class StepMetric:
+    step: int
+    time_seconds: float
+    throughput: float
+
+
+@dataclass
+class RunSummary:
+    label: str
+    trainer_steps: list[StepMetric]
+    inference_steps: list[StepMetric]
+    trainer_mean_tokens_per_second: float
+    inference_mean_tokens_per_second: float
+
+
+def strip_ansi(text: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+def parse_trainer_steps(log_path: Path, skip_steps: int) -> list[StepMetric]:
+    metrics: list[StepMetric] = []
+    with log_path.open() as f:
+        for raw_line in f:
+            line = strip_ansi(raw_line)
+            match = TRAINER_STEP_RE.search(line)
+            if match is None:
+                continue
+            step = int(match.group("step"))
+            if step < skip_steps:
+                continue
+            metrics.append(
+                StepMetric(
+                    step=step,
+                    time_seconds=float(match.group("time")),
+                    throughput=float(match.group("throughput")),
+                )
+            )
+    return metrics
+
+
+def parse_orchestrator_steps(log_path: Path, batch_size: int, skip_steps: int) -> list[StepMetric]:
+    metrics: list[StepMetric] = []
+    with log_path.open() as f:
+        for raw_line in f:
+            line = strip_ansi(raw_line)
+            match = ORCHESTRATOR_STEP_RE.search(line)
+            if match is None:
+                continue
+            step = int(match.group("step"))
+            if step < skip_steps:
+                continue
+            time_seconds = float(match.group("time"))
+            seq_len = float(match.group("seq_len"))
+            throughput = batch_size * seq_len / time_seconds
+            metrics.append(
+                StepMetric(
+                    step=step,
+                    time_seconds=time_seconds,
+                    throughput=throughput,
+                )
+            )
+    return metrics
+
+
+def mean(values: list[float]) -> float:
+    if not values:
+        return 0.0
+    return sum(values) / len(values)
+
+
+def summarize_run(label: str, run_dir: Path, batch_size: int, skip_trainer_steps: int, skip_inference_steps: int) -> RunSummary:
+    trainer_log = run_dir / "slurm" / "latest_train_node_rank_0.log"
+    orchestrator_log = run_dir / "slurm" / "latest_orchestrator.log"
+
+    trainer_steps = parse_trainer_steps(trainer_log, skip_trainer_steps)
+    inference_steps = parse_orchestrator_steps(orchestrator_log, batch_size, skip_inference_steps)
+
+    return RunSummary(
+        label=label,
+        trainer_steps=trainer_steps,
+        inference_steps=inference_steps,
+        trainer_mean_tokens_per_second=mean([metric.throughput for metric in trainer_steps]),
+        inference_mean_tokens_per_second=mean([metric.throughput for metric in inference_steps]),
+    )
+
+
+def write_csv(summaries: list[RunSummary], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", newline="") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=[
+                "label",
+                "trainer_mean_tokens_per_second",
+                "inference_mean_tokens_per_second",
+            ],
+        )
+        writer.writeheader()
+        for summary in summaries:
+            writer.writerow(
+                {
+                    "label": summary.label,
+                    "trainer_mean_tokens_per_second": f"{summary.trainer_mean_tokens_per_second:.2f}",
+                    "inference_mean_tokens_per_second": f"{summary.inference_mean_tokens_per_second:.2f}",
+                }
+            )
+
+
+def write_json(summaries: list[RunSummary], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = []
+    for summary in summaries:
+        payload.append(
+            {
+                "label": summary.label,
+                "trainer_steps": [asdict(step) for step in summary.trainer_steps],
+                "inference_steps": [asdict(step) for step in summary.inference_steps],
+                "trainer_mean_tokens_per_second": summary.trainer_mean_tokens_per_second,
+                "inference_mean_tokens_per_second": summary.inference_mean_tokens_per_second,
+            }
+        )
+    output_path.write_text(json.dumps(payload, indent=2))
+
+
+def _bar_svg(x: float, y: float, width: float, height: float, fill: str) -> str:
+    return f'<rect x="{x:.1f}" y="{y:.1f}" width="{width:.1f}" height="{height:.1f}" rx="6" fill="{fill}" />'
+
+
+def _text_svg(x: float, y: float, text: str, size: int = 14, anchor: str = "start", weight: int = 400) -> str:
+    return (
+        f'<text x="{x:.1f}" y="{y:.1f}" font-family="Helvetica, Arial, sans-serif" '
+        f'font-size="{size}" font-weight="{weight}" text-anchor="{anchor}" fill="#1f2937">{text}</text>'
+    )
+
+
+def write_svg(summaries: list[RunSummary], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    width = 920
+    height = 520
+    margin_left = 90
+    margin_right = 40
+    margin_top = 80
+    margin_bottom = 80
+    plot_width = width - margin_left - margin_right
+    plot_height = height - margin_top - margin_bottom
+
+    categories = [
+        ("Trainer", "trainer_mean_tokens_per_second"),
+        ("Inference", "inference_mean_tokens_per_second"),
+    ]
+    max_value = max(
+        max(getattr(summary, metric_name) for summary in summaries)
+        for _, metric_name in categories
+    )
+    max_value = max(max_value, 1.0)
+    y_max = math.ceil(max_value / 1000) * 1000 if max_value > 1000 else math.ceil(max_value / 100) * 100
+    y_max = max(y_max, max_value)
+
+    colors = ["#2563eb", "#dc2626", "#059669", "#d97706"]
+    group_count = len(categories)
+    run_count = len(summaries)
+    group_width = plot_width / group_count
+    bar_slot = min(60.0, group_width / max(run_count + 1, 2))
+    bar_width = bar_slot * 0.8
+
+    svg_parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}">',
+        '<rect width="100%" height="100%" fill="#f8fafc" />',
+        _text_svg(margin_left, 36, "GLM5 Index Cache Throughput", size=24, weight=700),
+        _text_svg(
+            margin_left,
+            58,
+            "Steady-state averages from trainer step logs and orchestrator rollout step logs",
+            size=13,
+            weight=400,
+        ),
+    ]
+
+    for tick_ratio in [0.0, 0.25, 0.5, 0.75, 1.0]:
+        tick_value = y_max * tick_ratio
+        y = margin_top + plot_height * (1 - tick_ratio)
+        svg_parts.append(
+            f'<line x1="{margin_left}" y1="{y:.1f}" x2="{width - margin_right}" y2="{y:.1f}" stroke="#cbd5e1" stroke-width="1" />'
+        )
+        svg_parts.append(_text_svg(margin_left - 12, y + 5, f"{tick_value:.0f}", size=12, anchor="end"))
+
+    for group_idx, (group_label, metric_name) in enumerate(categories):
+        group_x = margin_left + group_idx * group_width
+        center_x = group_x + group_width / 2
+        svg_parts.append(_text_svg(center_x, height - 30, group_label, size=14, anchor="middle", weight=600))
+
+        start_x = center_x - (run_count * bar_slot) / 2
+        for run_idx, summary in enumerate(summaries):
+            value = getattr(summary, metric_name)
+            bar_height = 0 if y_max == 0 else plot_height * (value / y_max)
+            x = start_x + run_idx * bar_slot
+            y = margin_top + plot_height - bar_height
+            color = colors[run_idx % len(colors)]
+            svg_parts.append(_bar_svg(x, y, bar_width, bar_height, color))
+            svg_parts.append(_text_svg(x + bar_width / 2, y - 8, f"{value:.0f}", size=12, anchor="middle", weight=600))
+
+    legend_x = width - margin_right - 240
+    legend_y = 36
+    for idx, summary in enumerate(summaries):
+        color = colors[idx % len(colors)]
+        y = legend_y + idx * 24
+        svg_parts.append(_bar_svg(legend_x, y - 12, 16, 16, color))
+        svg_parts.append(_text_svg(legend_x + 24, y + 1, summary.label, size=13))
+
+    svg_parts.append("</svg>")
+    output_path.write_text("\n".join(svg_parts))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Parse Prime RL baseline/index-cache logs into a throughput report.")
+    parser.add_argument("--baseline-dir", type=Path, required=True)
+    parser.add_argument("--cached-dir", type=Path, required=True)
+    parser.add_argument("--baseline-label", default="No Index Cache")
+    parser.add_argument("--cached-label", default="Index Cache")
+    parser.add_argument("--batch-size", type=int, default=256)
+    parser.add_argument("--skip-trainer-steps", type=int, default=1)
+    parser.add_argument("--skip-inference-steps", type=int, default=1)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    summaries = [
+        summarize_run(
+            label=args.baseline_label,
+            run_dir=args.baseline_dir,
+            batch_size=args.batch_size,
+            skip_trainer_steps=args.skip_trainer_steps,
+            skip_inference_steps=args.skip_inference_steps,
+        ),
+        summarize_run(
+            label=args.cached_label,
+            run_dir=args.cached_dir,
+            batch_size=args.batch_size,
+            skip_trainer_steps=args.skip_trainer_steps,
+            skip_inference_steps=args.skip_inference_steps,
+        ),
+    ]
+
+    write_csv(summaries, args.output_dir / "index_cache_throughput.csv")
+    write_json(summaries, args.output_dir / "index_cache_throughput.json")
+    write_svg(summaries, args.output_dir / "index_cache_throughput.svg")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/inference-server/SKILL.md
+++ b/skills/inference-server/SKILL.md
@@ -9,6 +9,8 @@ description: Start and test the prime-rl inference server. Use when asked to run
 
 Always use the `inference` entry point — never `vllm serve` or `python -m vllm.entrypoints.openai.api_server` directly. The entry point runs `setup_vllm_env()` which configures environment variables (LoRA, multiprocessing) before vLLM is imported.
 
+On shared clusters, prefer node-local vLLM caches. Prime RL now defaults `VLLM_CACHE_ROOT`, `DG_JIT_CACHE_DIR`, and `TRITON_CACHE_DIR` under `/tmp` and sets `VLLM_DEEP_GEMM_WARMUP=skip` to avoid long warmups and shared-home cache failures during SLURM launches.
+
 ```bash
 # With a TOML config
 uv run inference @ path/to/config.toml
@@ -77,6 +79,12 @@ Add `dry_run = true` to generate the sbatch script without submitting:
 ```bash
 uv run inference @ config.toml --dry-run true
 ```
+
+### Cluster startup notes
+
+- If an inference job spends a long time before `/health` comes up, check for DeepGEMM warmup and Triton cache writes in the SLURM logs.
+- If you must override the defaults, keep `VLLM_CACHE_ROOT`, `DG_JIT_CACHE_DIR`, and `TRITON_CACHE_DIR` on node-local storage, not on a flaky shared home directory.
+- For current vLLM builds in this repo, `VLLM_DEEP_GEMM_WARMUP=skip` is the safe default for RL inference startup.
 
 ## Custom endpoints
 

--- a/src/prime_rl/configs/inference.py
+++ b/src/prime_rl/configs/inference.py
@@ -396,6 +396,13 @@ class InferenceConfig(BaseConfig):
             self.api_server_count = 1  # LoRA requires only one API server
         return self
 
+    @model_validator(mode="after")
+    def validate_index_cache_support(self):
+        if self.model.index_cache is not None and self.model.index_cache.enabled:
+            if self.model.name != "zai-org/GLM-5-FP8":
+                raise ValueError("model.index_cache is only supported with model.name='zai-org/GLM-5-FP8'.")
+        return self
+
     def to_vllm(self) -> Namespace:
         """Convert InferenceConfig to vLLM-compatible Namespace."""
         namespace = Namespace()
@@ -443,5 +450,8 @@ class InferenceConfig(BaseConfig):
         if hasattr(namespace, "rope_scaling"):
             if namespace.rope_scaling is None:
                 delattr(namespace, "rope_scaling")
+
+        if self.model.index_cache is not None and self.model.index_cache.enabled:
+            namespace.hf_overrides = {"index_topk_freq": self.model.index_cache.freq}
 
         return namespace

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -18,6 +18,7 @@ from prime_rl.configs.orchestrator import (
     OrchestratorConfig,
 )
 from prime_rl.configs.shared import (
+    IndexCacheConfig,
     SlurmConfig,
     VLMConfig,
     WandbConfig,
@@ -131,6 +132,11 @@ class SharedModelConfig(BaseConfig):
     vlm: Annotated[
         "VLMConfig | None",
         Field(description="VLM configuration. Set to enable vision-language model support."),
+    ] = None
+
+    index_cache: Annotated[
+        IndexCacheConfig | None,
+        Field(description="Shared uniform sparse index cache configuration."),
     ] = None
 
 
@@ -543,8 +549,21 @@ class RLConfig(BaseConfig):
                 if self.inference is not None:
                     self.inference.model.vlm = self.model.vlm
 
+            if self.model.index_cache is not None:
+                if "index_cache" not in self.trainer.model.model_fields_set:
+                    self.trainer.model.index_cache = self.model.index_cache
+                if self.inference is not None and "index_cache" not in self.inference.model.model_fields_set:
+                    self.inference.model.index_cache = self.model.index_cache
+
         validate_shared_model_name(self.trainer, self.orchestrator, self.inference)
 
+        return self
+
+    @model_validator(mode="after")
+    def validate_index_cache_support(self):
+        if self.inference is not None and self.inference.model.index_cache is not None:
+            if self.inference.model.index_cache.enabled and self.inference.model.name != "zai-org/GLM-5-FP8":
+                raise ValueError("inference.model.index_cache is only supported with inference.model.name='zai-org/GLM-5-FP8'.")
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/configs/shared.py
+++ b/src/prime_rl/configs/shared.py
@@ -77,6 +77,25 @@ class SlurmConfig(BaseConfig):
         return self
 
 
+class IndexCacheConfig(BaseConfig):
+    """Configures uniform cross-layer sparse index reuse."""
+
+    freq: Annotated[
+        int,
+        Field(
+            ge=1,
+            description=(
+                "Keep the sparse indexer on every `freq`-th layer and reuse its selected indices on intervening "
+                "layers. `1` disables index cache, `2` keeps every other layer, `4` keeps one quarter."
+            ),
+        ),
+    ] = 1
+
+    @property
+    def enabled(self) -> bool:
+        return self.freq > 1
+
+
 ServerType = Literal["vllm", "openai"]
 
 
@@ -119,6 +138,15 @@ class BaseModelConfig(BaseConfig):
         "VLMConfig | None",
         Field(
             description="VLM configuration. Set this to enable vision-language model support.",
+        ),
+    ] = None
+
+    index_cache: Annotated[
+        IndexCacheConfig | None,
+        Field(
+            description=(
+                "Uniform sparse index cache configuration. Currently intended for GLM-5 / GLM-5-FP8 DSA models."
+            ),
         ),
     ] = None
 

--- a/src/prime_rl/configs/trainer.py
+++ b/src/prime_rl/configs/trainer.py
@@ -347,6 +347,12 @@ class ModelConfig(BaseModelConfig):
             raise ValueError("Flash attention 4 is only supported with the custom implementation")
         return self
 
+    @model_validator(mode="after")
+    def index_cache_requires_custom_impl(self):
+        if self.index_cache is not None and self.index_cache.enabled and self.impl == "hf":
+            raise ValueError("trainer.model.index_cache requires model.impl='custom' or 'auto'")
+        return self
+
 
 class TokenizerConfig(BaseConfig):
     """Configuration for the tokenizer."""

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -10,7 +10,258 @@ def transformers_v5_compat():
         Qwen3VLMoeTextConfig.tie_word_embeddings = False
 
     _patch_qwen35_lora()
+    monkey_patch_glm5_index_cache()
     monkey_patch_dp_engine_core_pause_resume_deadlock()
+
+
+def monkey_patch_glm5_index_cache():
+    from itertools import islice
+
+    import torch
+    from vllm.distributed import get_pp_group
+    from vllm.model_executor.layers.mla import MultiHeadLatentAttentionWrapper
+    from vllm.model_executor.models.deepseek_v2 import (
+        DeepseekAttention,
+        DeepseekV2DecoderLayer,
+        DeepseekV2MLAAttention,
+        DeepseekV2MLP,
+        DeepseekV2Model,
+        _get_llama_4_scaling,
+    )
+    from vllm.sequence import IntermediateTensors
+
+    if getattr(MultiHeadLatentAttentionWrapper.forward, "__prime_index_cache_patch__", False):
+        return
+
+    def _layer_idx_from_prefix(prefix: str) -> int:
+        for segment in reversed(prefix.split(".")):
+            if segment.isdigit():
+                return int(segment)
+        return 0
+
+    _original_mla_init = DeepseekV2MLAAttention.__init__
+
+    def _patched_mla_init(
+        self,
+        vllm_config,
+        config,
+        hidden_size,
+        num_heads,
+        qk_nope_head_dim,
+        qk_rope_head_dim,
+        v_head_dim,
+        q_lora_rank,
+        kv_lora_rank,
+        max_position_embeddings=8192,
+        cache_config=None,
+        quant_config=None,
+        prefix="",
+        topk_indices_buffer=None,
+    ) -> None:
+        _original_mla_init(
+            self,
+            vllm_config,
+            config,
+            hidden_size,
+            num_heads,
+            qk_nope_head_dim,
+            qk_rope_head_dim,
+            v_head_dim,
+            q_lora_rank,
+            kv_lora_rank,
+            max_position_embeddings=max_position_embeddings,
+            cache_config=cache_config,
+            quant_config=quant_config,
+            prefix=prefix,
+            topk_indices_buffer=topk_indices_buffer,
+        )
+
+        self.mla_attn.skip_topk = False
+        self.mla_attn.next_skip_topk = False
+
+        freq = getattr(config, "index_topk_freq", 1)
+        if not getattr(self, "is_v32", False) or getattr(config, "model_type", None) != "glm_moe_dsa" or freq <= 1:
+            return
+
+        layer_idx = _layer_idx_from_prefix(prefix)
+        num_hidden_layers = getattr(config, "num_hidden_layers", layer_idx + 1)
+        self.mla_attn.skip_topk = layer_idx > 0 and layer_idx % freq != 0
+        self.mla_attn.next_skip_topk = layer_idx + 1 < num_hidden_layers and (layer_idx + 1) % freq != 0
+
+    def _patched_mla_wrapper_forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        llama_4_scaling: torch.Tensor | None = None,
+        prev_topk_indices: torch.Tensor | None = None,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        q_c = None
+        kv_lora = None
+
+        if self.q_lora_rank is not None:
+            assert self.fused_qkv_a_proj is not None, (
+                "fused_qkv_a_proj is required when q_lora_rank is not None"
+            )
+            assert self.q_a_layernorm is not None, (
+                "q_a_layernorm is required when q_lora_rank is not None"
+            )
+            assert self.q_b_proj is not None, "q_b_proj is required when q_lora_rank is not None"
+
+            qkv_lora = self.fused_qkv_a_proj(hidden_states)[0]
+            q_c, kv_lora = qkv_lora.split(
+                [self.q_lora_rank, self.kv_lora_rank + self.qk_rope_head_dim],
+                dim=-1,
+            )
+            q_c = self.q_a_layernorm(q_c)
+            q = self.q_b_proj(q_c)[0]
+        else:
+            assert self.kv_a_proj_with_mqa is not None, (
+                "kv_a_proj_with_mqa is required when q_lora_rank is None"
+            )
+            assert self.q_proj is not None, "q_proj is required when q_lora_rank is None"
+            kv_lora = self.kv_a_proj_with_mqa(hidden_states)[0]
+            q = self.q_proj(hidden_states)[0]
+
+        kv_c, k_pe = kv_lora.split([self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
+        kv_c_normed = self.kv_a_layernorm(kv_c)
+
+        q = q.view(-1, self.num_heads, self.qk_head_dim)
+        k_pe = k_pe.unsqueeze(1)
+
+        if self.rotary_emb is not None:
+            q[..., self.qk_nope_head_dim :], k_pe = self.rotary_emb(
+                positions, q[..., self.qk_nope_head_dim :], k_pe
+            )
+
+        topk_indices = None
+        if self.indexer and self.is_sparse:
+            if getattr(self, "skip_topk", False):
+                if prev_topk_indices is None:
+                    raise ValueError("Index cache expected cached sparse indices from a previous full layer.")
+                topk_indices = prev_topk_indices
+            else:
+                topk_indices = self.indexer(hidden_states, q_c, positions, self.indexer_rope_emb)
+
+        if llama_4_scaling is not None:
+            q *= llama_4_scaling
+
+        attn_out = self.mla_attn(
+            q,
+            kv_c_normed,
+            k_pe,
+            output_shape=(hidden_states.shape[0], self.num_heads * self.v_head_dim),
+        )
+
+        output = self.o_proj(attn_out)[0]
+        if self.indexer and self.is_sparse and getattr(self, "next_skip_topk", False):
+            assert topk_indices is not None
+            return output, topk_indices
+        return output
+
+    def _patched_mla_forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        llama_4_scaling: torch.Tensor | None,
+        prev_topk_indices: torch.Tensor | None = None,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        return self.mla_attn(
+            positions,
+            hidden_states,
+            llama_4_scaling,
+            prev_topk_indices=prev_topk_indices,
+        )
+
+    def _patched_decoder_forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+        llama_4_scaling: torch.Tensor | None = None,
+        prev_topk_indices: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        if residual is None:
+            residual = hidden_states.clone()
+            hidden_states = self.input_layernorm(hidden_states)
+        else:
+            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+
+        attn_kwargs = {
+            "positions": positions,
+            "hidden_states": hidden_states,
+        }
+        if not self.use_mha:
+            attn_kwargs["llama_4_scaling"] = llama_4_scaling
+            attn_kwargs["prev_topk_indices"] = prev_topk_indices
+        hidden_states = self.self_attn(**attn_kwargs)
+        if isinstance(hidden_states, tuple):
+            hidden_states, topk_indices = hidden_states
+        else:
+            topk_indices = None
+
+        if not isinstance(self.self_attn, DeepseekAttention) and hidden_states.dtype == torch.float16:
+            hidden_states *= 1.0 / self.routed_scaling_factor
+            if self.layer_idx == 0:
+                residual *= 1.0 / self.routed_scaling_factor
+
+        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+        hidden_states = self.mlp(hidden_states)
+
+        if isinstance(self.mlp, DeepseekV2MLP) and hidden_states.dtype == torch.float16:
+            hidden_states *= 1.0 / self.routed_scaling_factor
+
+        return hidden_states, residual, topk_indices
+
+    def _patched_model_forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None,
+        inputs_embeds: torch.Tensor | None = None,
+    ) -> torch.Tensor | IntermediateTensors:
+        if get_pp_group().is_first_rank:
+            if inputs_embeds is not None:
+                hidden_states = inputs_embeds
+            else:
+                hidden_states = self.embed_input_ids(input_ids)
+            residual = None
+        else:
+            assert intermediate_tensors is not None
+            hidden_states = intermediate_tensors["hidden_states"]
+            residual = intermediate_tensors["residual"]
+
+        llama_4_scaling_config = getattr(self.config, "llama_4_scaling", None)
+        if llama_4_scaling_config is not None:
+            llama_4_scaling = _get_llama_4_scaling(
+                original_max_position_embeddings=llama_4_scaling_config["original_max_position_embeddings"],
+                scaling_beta=llama_4_scaling_config["beta"],
+                positions=positions,
+            )
+        else:
+            llama_4_scaling = None
+
+        topk_indices = None
+        for layer in islice(self.layers, self.start_layer, self.end_layer):
+            hidden_states, residual, topk_indices = layer(
+                positions,
+                hidden_states,
+                residual,
+                llama_4_scaling,
+                prev_topk_indices=topk_indices,
+            )
+
+        if not get_pp_group().is_last_rank:
+            return IntermediateTensors({"hidden_states": hidden_states, "residual": residual})
+
+        hidden_states, _ = self.norm(hidden_states, residual)
+        return hidden_states
+
+    _patched_mla_wrapper_forward.__prime_index_cache_patch__ = True
+    MultiHeadLatentAttentionWrapper.forward = _patched_mla_wrapper_forward
+    DeepseekV2MLAAttention.__init__ = _patched_mla_init
+    DeepseekV2MLAAttention.forward = _patched_mla_forward
+    DeepseekV2DecoderLayer.forward = _patched_decoder_forward
+    DeepseekV2Model.forward = _patched_model_forward
 
 
 def _patch_qwen35_lora():

--- a/src/prime_rl/inference/server.py
+++ b/src/prime_rl/inference/server.py
@@ -1,4 +1,6 @@
+import getpass
 import os
+import tempfile
 
 from prime_rl.configs.inference import InferenceConfig
 from prime_rl.utils.config import cli
@@ -9,6 +11,18 @@ def setup_vllm_env(config: InferenceConfig):
 
     # spawn is more robust in vLLM nightlies and Qwen3-VL (fork can deadlock with multithreaded processes)
     os.environ.setdefault("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
+
+    cache_root = os.environ.get("VLLM_CACHE_ROOT")
+    if not cache_root:
+        cache_dir = f".vllm_cache_{getpass.getuser()}"
+        if job_id := os.environ.get("SLURM_JOB_ID"):
+            cache_dir = f"{cache_dir}_{job_id}"
+        cache_root = os.path.join(tempfile.gettempdir(), cache_dir)
+        os.environ["VLLM_CACHE_ROOT"] = cache_root
+
+    os.environ.setdefault("DG_JIT_CACHE_DIR", os.path.join(cache_root, "deep_gemm"))
+    os.environ.setdefault("TRITON_CACHE_DIR", os.path.join(cache_root, "triton"))
+    os.environ.setdefault("VLLM_DEEP_GEMM_WARMUP", "skip")
 
     if config.enable_lora:
         os.environ["VLLM_ALLOW_RUNTIME_LORA_UPDATING"] = "True"

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -1,3 +1,4 @@
+import json
 from argparse import Namespace
 from http import HTTPStatus
 from typing import Any
@@ -349,6 +350,24 @@ def custom_build_app(args: Namespace, supported_tasks: tuple):
     return app
 
 
+def _merge_hf_overrides(existing: Any, new_values: dict[str, Any]) -> dict[str, Any]:
+    if existing in (None, "", {}):
+        return new_values.copy()
+
+    if isinstance(existing, str):
+        existing = json.loads(existing)
+
+    if not isinstance(existing, dict):
+        raise ValueError(f"Expected hf_overrides to be a dict or JSON object string, got {type(existing).__name__}.")
+
+    merged = existing.copy()
+    for key, value in new_values.items():
+        if key in merged and merged[key] != value:
+            raise ValueError(f"Conflicting hf_overrides value for {key!r}: {merged[key]!r} != {value!r}")
+        merged[key] = value
+    return merged
+
+
 # Also monkey patch run_api_server_worker_proc for multi-api-server mode
 # This is needed because worker processes spawned by run_multi_api_server
 # re-import modules and would otherwise use the original run_server_worker
@@ -367,6 +386,8 @@ def server(config: InferenceConfig, vllm_extra: dict[str, Any] | None = None):
     namespace = config.to_vllm()
     if vllm_extra:
         for key, value in vllm_extra.items():
+            if key == "hf_overrides":
+                value = _merge_hf_overrides(getattr(namespace, "hf_overrides", None), value)
             setattr(namespace, key, value)
 
     parser = FlexibleArgumentParser(description="vLLM OpenAI-Compatible RESTful API server.")

--- a/src/prime_rl/templates/inference.sbatch.j2
+++ b/src/prime_rl/templates/inference.sbatch.j2
@@ -47,7 +47,9 @@ mkdir -p $OUTPUT_DIR/slurm
 export CUDA_DEVICE_ORDER=PCI_BUS_ID
 export PYTHONUNBUFFERED=1
 export OMP_NUM_THREADS=1
-export VLLM_CACHE_ROOT=/tmp/.vllm_cache_$(whoami)
+export VLLM_CACHE_ROOT=/tmp/.vllm_cache_$(whoami)_${SLURM_JOB_ID}
+export DG_JIT_CACHE_DIR=$VLLM_CACHE_ROOT/deep_gemm
+export TRITON_CACHE_DIR=$VLLM_CACHE_ROOT/triton
 
 # Setup environment
 cd $PROJECT_DIR
@@ -126,6 +128,7 @@ srun bash -c '
     read -ra HOSTNAMES <<< "$HOSTNAMES_STR"
 
     export VLLM_WORKER_MULTIPROC_METHOD=spawn
+    export VLLM_DEEP_GEMM_WARMUP=${VLLM_DEEP_GEMM_WARMUP:-skip}
 {%- if use_deep_gemm %}
     export VLLM_USE_DEEP_GEMM=1
 {%- endif %}

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -67,6 +67,9 @@ rm -rf $OUTPUT_DIR/rollouts
 export CUDA_DEVICE_ORDER=PCI_BUS_ID
 export PYTHONUNBUFFERED=1
 export OMP_NUM_THREADS=1
+export VLLM_CACHE_ROOT=/tmp/.vllm_cache_$(whoami)_${SLURM_JOB_ID}
+export DG_JIT_CACHE_DIR=$VLLM_CACHE_ROOT/deep_gemm
+export TRITON_CACHE_DIR=$VLLM_CACHE_ROOT/triton
 
 {% if wandb_shared -%}
 export WANDB_SHARED_MODE=1
@@ -174,6 +177,10 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
     export PYTORCH_CUDA_ALLOC_CONF="expandable_segments:False"
     INFER_NODE_RANK=$SLURM_PROCID
     export VLLM_WORKER_MULTIPROC_METHOD=spawn
+    export VLLM_DEEP_GEMM_WARMUP=${VLLM_DEEP_GEMM_WARMUP:-skip}
+{%- if use_deep_gemm %}
+    export VLLM_USE_DEEP_GEMM=1
+{%- endif %}
     LOCAL_IP=$(hostname -I | awk "{print \$1}")
 
     REPLICA_IDX=$((INFER_NODE_RANK / NODES_PER_INFER_REPLICA))
@@ -186,9 +193,6 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
 {% if is_disaggregated -%}
     # PD disaggregated: NIXL KV transfer + role-based inference
     read -ra HOSTNAMES <<< "$HOSTNAMES_STR"
-{%- if use_deep_gemm %}
-    export VLLM_USE_DEEP_GEMM=1
-{%- endif %}
 
     export GLOO_SOCKET_IFNAME=bond0
     export VLLM_ENGINE_READY_TIMEOUT_S=4200
@@ -286,9 +290,9 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
         INFER_DP_START_RANK=$((RANK_IN_REPLICA * INFERENCE_DP_LOCAL))
 
         if [ "$RANK_IN_REPLICA" -eq 0 ]; then
-            VLLM_EXTRA="{\"data_parallel_address\": \"$LOCAL_IP\"}"
+            VLLM_EXTRA="{\"data_parallel_address\": \"$LOCAL_IP\", \"data_parallel_hybrid_lb\": true}"
         else
-            VLLM_EXTRA="{\"data_parallel_address\": \"$REPLICA_HEAD_HOST\", \"data_parallel_start_rank\": $INFER_DP_START_RANK}"
+            VLLM_EXTRA="{\"data_parallel_address\": \"$REPLICA_HEAD_HOST\", \"data_parallel_start_rank\": $INFER_DP_START_RANK, \"data_parallel_hybrid_lb\": true}"
         fi
 
         uv run inference \

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -224,6 +224,12 @@ def get_model(
     if getattr(model_config, "model_type", "").startswith("qwen3_5_moe"):
         _patch_qwen3_5_text_position_ids()
         _patch_qwen3_5_moe_conversion_mapping()
+
+    if config.index_cache is not None and config.index_cache.enabled:
+        if getattr(model_config, "model_type", None) != "glm_moe_dsa":
+            raise ValueError("trainer.model.index_cache requires a GLM-5 / glm_moe_dsa model.")
+        model_config.index_topk_freq = config.index_cache.freq
+
     for subconfig_key in getattr(model_config, "sub_configs", {}):
         subconfig = getattr(model_config, subconfig_key, None)
         if subconfig is not None and hasattr(subconfig, "use_cache"):

--- a/src/prime_rl/trainer/models/glm_moe_dsa/configuration_glm_moe_dsa.py
+++ b/src/prime_rl/trainer/models/glm_moe_dsa/configuration_glm_moe_dsa.py
@@ -73,6 +73,9 @@ class GlmMoeDsaConfig(PretrainedConfig):
             Whether to use interleaved RoPE style in the sparse indexer.
         index_topk (`int`, defaults to 2048):
             Number of top tokens selected by the sparse indexer.
+        index_topk_freq (`int`, defaults to 1):
+            Keep the sparse indexer on every `index_topk_freq`-th layer and reuse
+            cached top-k indices on intervening layers. `1` disables reuse.
         scoring_func (`str`, defaults to `"sigmoid"`):
             Scoring function for MoE router. Must match the vLLM inference
             server's expectation (vLLM defaults to ``"softmax"`` when this
@@ -141,6 +144,7 @@ class GlmMoeDsaConfig(PretrainedConfig):
         indexer_rope_interleave=True,
         pad_token_id=154820,
         index_topk=2048,
+        index_topk_freq=1,
         scoring_func="sigmoid",
         topk_method="noaux_tc",
         use_grouped_mm=True,
@@ -194,6 +198,7 @@ class GlmMoeDsaConfig(PretrainedConfig):
         self.index_head_dim = index_head_dim
         self.indexer_rope_interleave = indexer_rope_interleave
         self.index_topk = index_topk
+        self.index_topk_freq = index_topk_freq
         self.scoring_func = scoring_func
         self.topk_method = topk_method
         self.use_grouped_mm = use_grouped_mm

--- a/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
+++ b/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
@@ -28,9 +28,20 @@ from prime_rl.trainer.models.layers.norms import RMSNorm, RMSNormConfig
 from prime_rl.trainer.models.layers.rotary_emb import RotaryEmbedding, RotaryEmbeddingConfig
 
 
-def _sparse_mla_attention_args(config: GlmMoeDsaConfig) -> SparseMlaAttentionArgs:
+def _index_cache_flags(config: GlmMoeDsaConfig, layer_idx: int) -> tuple[bool, bool]:
+    freq = getattr(config, "index_topk_freq", 1)
+    if freq <= 1:
+        return False, False
+
+    skip_topk = layer_idx > 0 and layer_idx % freq != 0
+    next_skip_topk = layer_idx + 1 < config.num_hidden_layers and (layer_idx + 1) % freq != 0
+    return skip_topk, next_skip_topk
+
+
+def _sparse_mla_attention_args(config: GlmMoeDsaConfig, layer_idx: int) -> SparseMlaAttentionArgs:
     if config.q_lora_rank is None:
         raise ValueError("Sparse MLA attention requires q_lora_rank to be set")
+    skip_topk, next_skip_topk = _index_cache_flags(config, layer_idx)
     return SparseMlaAttentionArgs(
         hidden_size=config.hidden_size,
         num_attention_heads=config.num_attention_heads,
@@ -45,6 +56,8 @@ def _sparse_mla_attention_args(config: GlmMoeDsaConfig) -> SparseMlaAttentionArg
         index_n_heads=config.index_n_heads,
         index_head_dim=config.index_head_dim,
         index_topk=config.index_topk,
+        skip_topk=skip_topk,
+        next_skip_topk=next_skip_topk,
     )
 
 
@@ -52,7 +65,7 @@ class GlmMoeDsaDecoderLayer(GradientCheckpointingLayer):
     def __init__(self, config: GlmMoeDsaConfig, layer_idx: int):
         super().__init__()
         self.hidden_size = config.hidden_size
-        self.self_attn = GlmMoeDsaAttention(_sparse_mla_attention_args(config))
+        self.self_attn = GlmMoeDsaAttention(_sparse_mla_attention_args(config, layer_idx))
 
         moe_args = MoEArgs(
             num_experts=config.n_routed_experts,
@@ -88,14 +101,16 @@ class GlmMoeDsaDecoderLayer(GradientCheckpointingLayer):
         ks: Optional[torch.Tensor] = None,
         ke: Optional[torch.Tensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
-    ) -> torch.Tensor:
+        prev_topk_indices: Optional[torch.Tensor] = None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
         residual = hidden_states
         hidden_states = self.input_layernorm(hidden_states)
-        hidden_states, _ = self.self_attn(
+        hidden_states, next_topk_indices = self.self_attn(
             hidden_states=hidden_states,
             position_embeddings=position_embeddings,
             ks=ks,
             ke=ke,
+            prev_topk_indices=prev_topk_indices,
         )
         hidden_states = residual + hidden_states
 
@@ -103,7 +118,7 @@ class GlmMoeDsaDecoderLayer(GradientCheckpointingLayer):
         hidden_states = self.post_attention_layernorm(hidden_states)
         hidden_states = self.mlp(hidden_states, routed_experts=routed_experts)
         hidden_states = residual + hidden_states
-        return hidden_states
+        return hidden_states, next_topk_indices
 
 
 @auto_docstring
@@ -211,15 +226,17 @@ class GlmMoeDsaModel(GlmMoeDsaPreTrainedModel):
 
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
+        topk_indices = None
 
         for layer_idx, decoder_layer in enumerate(self.layers[: self.config.num_hidden_layers]):
             routed_experts_layer = routed_experts[:, :, layer_idx, :] if routed_experts is not None else None
-            hidden_states = decoder_layer(
+            hidden_states, topk_indices = decoder_layer(
                 hidden_states,
                 position_embeddings=position_embeddings,
                 ks=ks,
                 ke=ke,
                 routed_experts=routed_experts_layer,
+                prev_topk_indices=topk_indices,
             )
 
         hidden_states = self.norm(hidden_states)

--- a/src/prime_rl/trainer/models/glm_moe_dsa/sparse_mla_attention.py
+++ b/src/prime_rl/trainer/models/glm_moe_dsa/sparse_mla_attention.py
@@ -30,6 +30,8 @@ class SparseMlaAttentionArgs:
     index_n_heads: int
     index_head_dim: int
     index_topk: int
+    skip_topk: bool
+    next_skip_topk: bool
 
 
 class _SparseMLA(torch.autograd.Function):
@@ -127,6 +129,8 @@ class GlmMoeDsaAttention(nn.Module):
         self.o_proj = nn.Linear(self.num_heads * self.v_head_dim, args.hidden_size, bias=args.attention_bias)
         self.indexer = Indexer(args)
         self.scaling = self.qk_head_dim ** (-0.5)
+        self.skip_topk = args.skip_topk
+        self.next_skip_topk = args.next_skip_topk
 
     def _mla_latents(self, hidden_states: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         q_latent = self.q_a_layernorm(self.q_a_proj(hidden_states))
@@ -173,14 +177,20 @@ class GlmMoeDsaAttention(nn.Module):
         position_embeddings: tuple[torch.Tensor, torch.Tensor],
         ks: torch.Tensor | None = None,
         ke: torch.Tensor | None = None,
+        prev_topk_indices: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         batch_size, total_tokens, _ = hidden_states.shape
 
         q_latent, k_compressed_normed, k_rope = self._mla_latents(hidden_states)
 
-        indices = self.indexer.compute_sparse_indices(
-            hidden_states, q_latent, ks, ke, self.args.index_topk, position_embeddings
-        )
+        if self.skip_topk:
+            if prev_topk_indices is None:
+                raise ValueError("Index cache expected cached sparse indices from a previous full layer.")
+            indices = prev_topk_indices
+        else:
+            indices = self.indexer.compute_sparse_indices(
+                hidden_states, q_latent, ks, ke, self.args.index_topk, position_embeddings
+            )
 
         sparse_q, sparse_kv, w_v = self._mla_up_proj(
             q_latent,
@@ -193,4 +203,5 @@ class GlmMoeDsaAttention(nn.Module):
         out = self._mla_unabsorb(out, w_v)
 
         out = out.reshape(batch_size, total_tokens, -1)
-        return self.o_proj(out), None
+        next_topk_indices = indices if self.next_skip_topk else None
+        return self.o_proj(out), next_topk_indices

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -159,3 +159,20 @@ def test_removed_fused_lm_head_chunk_size_field_is_rejected():
 def test_selective_activation_checkpointing_requires_custom_impl():
     with pytest.raises(ValidationError, match="Selective activation checkpointing requires model.impl='custom'"):
         TrainerModelConfig.model_validate({"impl": "hf", "ac": {"mode": "selective"}})
+
+
+def test_trainer_index_cache_requires_custom_impl():
+    with pytest.raises(ValidationError, match="trainer.model.index_cache requires model.impl='custom' or 'auto'"):
+        TrainerModelConfig.model_validate({"impl": "hf", "index_cache": {"freq": 2}})
+
+
+def test_inference_index_cache_requires_glm5_fp8():
+    with pytest.raises(ValidationError, match="model.index_cache is only supported with model.name='zai-org/GLM-5-FP8'"):
+        InferenceConfig.model_validate({"model": {"name": "zai-org/GLM-5", "index_cache": {"freq": 2}}})
+
+
+def test_inference_index_cache_sets_hf_overrides():
+    config = InferenceConfig.model_validate({"model": {"name": "zai-org/GLM-5-FP8", "index_cache": {"freq": 4}}})
+    namespace = config.to_vllm()
+
+    assert namespace.hf_overrides == {"index_topk_freq": 4}

--- a/tests/unit/train/models/test_glm_moe_dsa_index_cache.py
+++ b/tests/unit/train/models/test_glm_moe_dsa_index_cache.py
@@ -1,0 +1,70 @@
+import types
+
+import torch
+
+from prime_rl.trainer.models.glm_moe_dsa.configuration_glm_moe_dsa import GlmMoeDsaConfig
+from prime_rl.trainer.models.glm_moe_dsa.modeling_glm_moe_dsa import GlmMoeDsaModel
+
+
+def test_glm_moe_dsa_uniform_index_cache_threads_topk_indices():
+    config = GlmMoeDsaConfig(
+        vocab_size=32,
+        hidden_size=16,
+        intermediate_size=32,
+        moe_intermediate_size=8,
+        num_hidden_layers=4,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        n_shared_experts=1,
+        n_routed_experts=4,
+        routed_scaling_factor=1.0,
+        kv_lora_rank=8,
+        q_lora_rank=8,
+        qk_rope_head_dim=4,
+        v_head_dim=4,
+        qk_nope_head_dim=4,
+        num_experts_per_tok=2,
+        first_k_dense_replace=4,
+        max_position_embeddings=64,
+        index_n_heads=2,
+        index_head_dim=8,
+        index_topk=64,
+        index_topk_freq=2,
+        pad_token_id=0,
+        use_grouped_mm=False,
+    )
+    model = GlmMoeDsaModel(config)
+
+    received_prev_topk = [None] * config.num_hidden_layers
+    emitted_topk = [torch.tensor([layer_idx + 1], dtype=torch.int32) for layer_idx in range(config.num_hidden_layers)]
+
+    for layer_idx, layer in enumerate(model.layers):
+        def _make_fake_forward(idx):
+            def _fake_forward(self, hidden_states, position_embeddings=None, ks=None, ke=None, prev_topk_indices=None):
+                received_prev_topk[idx] = prev_topk_indices
+                next_topk_indices = emitted_topk[idx] if self.next_skip_topk else None
+                return hidden_states, next_topk_indices
+
+            return _fake_forward
+
+        layer.self_attn.forward = types.MethodType(_make_fake_forward(layer_idx), layer.self_attn)
+
+    input_ids = torch.randint(0, config.vocab_size, (1, 8))
+    position_ids = torch.arange(8).unsqueeze(0)
+    outputs = model(input_ids=input_ids, position_ids=position_ids)
+
+    assert outputs.last_hidden_state.shape == (1, 8, config.hidden_size)
+
+    assert received_prev_topk[0] is None
+    assert torch.equal(received_prev_topk[1], emitted_topk[0])
+    assert received_prev_topk[2] is None
+    assert torch.equal(received_prev_topk[3], emitted_topk[2])
+
+    assert model.layers[0].self_attn.skip_topk is False
+    assert model.layers[0].self_attn.next_skip_topk is True
+    assert model.layers[1].self_attn.skip_topk is True
+    assert model.layers[1].self_attn.next_skip_topk is False
+    assert model.layers[2].self_attn.skip_topk is False
+    assert model.layers[2].self_attn.next_skip_topk is True
+    assert model.layers[3].self_attn.skip_topk is True
+    assert model.layers[3].self_attn.next_skip_topk is False


### PR DESCRIPTION
## Summary
- add uniform GLM5 index-cache config support for trainer and GLM-5-FP8 inference
- implement cached sparse top-k reuse for custom GLM5 trainer layers and vLLM GLM5 inference path
- add Hendrycks Math RL configs, startup fixes for cluster inference caches, and a throughput benchmark script

## Validation
- `uv run pytest tests/unit/test_configs.py tests/unit/train/models/test_glm_moe_dsa_index_cache.py -q`
- `uv run ruff check scripts/index_cache_bench.py src/prime_rl/inference/server.py src/prime_rl/inference/patches.py src/prime_rl/trainer/model.py src/prime_rl/configs/shared.py src/prime_rl/configs/rl.py src/prime_rl/configs/inference.py src/prime_rl/configs/trainer.py`
- `uv run python -m py_compile scripts/index_cache_bench.py src/prime_rl/inference/server.py src/prime_rl/inference/patches.py src/prime_rl/trainer/model.py src/prime_rl/trainer/models/glm_moe_dsa/configuration_glm_moe_dsa.py src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py src/prime_rl/trainer/models/glm_moe_dsa/sparse_mla_attention.py`
- Baseline SLURM job `3843`: trainer step 1 passed, orchestrator steps 0/1/2 passed
- Index-cache SLURM job `3848`: trainer step 1 passed, orchestrator steps 0/1/2 passed

## Throughput
Benchmark artifacts were generated at `/shared/outputs/matej/index-cache-bench/`.

- Trainer mean tokens/s: `17152.88` without cache, `16805.12` with index cache f=4
- Inference mean tokens/s: `1878.46` without cache, `1977.80` with index cache f=4
- SVG chart: `/shared/outputs/matej/index-cache-bench/index_cache_throughput.svg`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core GLM-5 attention/model forward paths and adds invasive vLLM monkey-patches, which could affect correctness/performance and be brittle across vLLM updates. Also changes SLURM/inference environment defaults that may impact cluster startup behavior.
> 
> **Overview**
> Adds a new `index_cache` configuration (shared + trainer + inference) to enable uniform cross-layer sparse top-k index reuse for GLM-5 DSA models, with validation that it only runs on the supported implementations/models (custom trainer, `zai-org/GLM-5-FP8` for inference).
> 
> Implements the cache by threading `topk_indices` through GLM-5 DSA trainer layers and by monkey-patching vLLM’s GLM-5 (DeepSeekV2/MLA) execution path to optionally reuse indices every `freq` layers; inference config translates this into `hf_overrides` (`index_topk_freq`) and merges safely with any user-provided overrides.
> 
> Improves cluster reliability by defaulting vLLM/Triton/DeepGEMM caches to node-local `/tmp` (job-scoped) and skipping DeepGEMM warmup in both runtime env setup and SLURM templates; also enables DP hybrid load balancing in multi-node inference launches. Adds new Hendrycks Math RL configs plus an `index_cache_bench.py` script to parse logs and emit CSV/JSON/SVG throughput reports, and extends unit tests to cover the new config and index-cache behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bab9a734e1b104ea9fc4ef05109dc8a183581ff3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->