### PR TITLE
fix: remove debug log level from vllm-router in SLURM templates

### DIFF
--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -249,7 +249,6 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
             --port $ROUTER_PORT \
             --intra-node-data-parallel-size 1 \
             --worker-startup-timeout-secs 1200 \
-            --log-level debug \
             >> $ROUTER_LOG 2>&1 &
     fi
 
@@ -276,7 +275,6 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
             --host 0.0.0.0 \
             --port $ROUTER_PORT \
             --worker-startup-timeout-secs 1200 \
-            --log-level debug \
             >> $ROUTER_LOG 2>&1 &
     fi
 


### PR DESCRIPTION
## Summary
- Remove `--log-level debug` from vllm-router invocations in the multi-node RL SLURM template

Cherry-picked from `daniel/fix-rlm-command-timeout` (7ee8af698).

## Test plan
- [ ] Verify SLURM template renders correctly without the debug flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Template-only change that adjusts router verbosity; no changes to training/inference logic or data handling.
> 
> **Overview**
> Removes the explicit `--log-level debug` flag from `vllm-router` invocations in the `multi_node_rl.sbatch.j2` SLURM template (both PD-disaggregated and standard router startup paths), reverting router logging to its default level.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f426a4f1d62f3a134173f4bf799d5626c03e688. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->