### PR TITLE
fix: switch vllm-router policy from round_robin to consistent_hash

### DIFF
--- a/src/prime_rl/templates/inference.sbatch.j2
+++ b/src/prime_rl/templates/inference.sbatch.j2
@@ -193,7 +193,7 @@ srun bash -c '
         REPLICA_ROUTER_ARGS=$(echo "$ALL_ROUTER_ARGS" | cut -d"|" -f$((REPLICA_IDX + 1)))
 
         vllm-router \
-            --policy round_robin \
+            --policy consistent_hash \
             --vllm-pd-disaggregation \
             $REPLICA_ROUTER_ARGS \
             --host 0.0.0.0 \
@@ -226,7 +226,7 @@ srun bash -c '
         echo "Starting vllm-router on $LOCAL_IP:$ROUTER_PORT" | tee $ROUTER_LOG
 
         vllm-router \
-            --policy round_robin \
+            --policy consistent_hash \
             --worker-urls $ROUTER_ARGS \
             --host 0.0.0.0 \
             --port $ROUTER_PORT \

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -242,7 +242,7 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
         REPLICA_ROUTER_ARGS=$(echo "$ALL_ROUTER_ARGS" | cut -d"|" -f$((REPLICA_IDX + 1)))
 
         vllm-router \
-            --policy round_robin \
+            --policy consistent_hash \
             --vllm-pd-disaggregation \
             $REPLICA_ROUTER_ARGS \
             --host 0.0.0.0 \
@@ -271,7 +271,7 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
         REPLICA_ROUTER_ARGS=$(echo "$ALL_ROUTER_ARGS" | cut -d"|" -f$((REPLICA_IDX + 1)))
 
         vllm-router \
-            --policy round_robin \
+            --policy consistent_hash \
             --worker-urls $REPLICA_ROUTER_ARGS \
             --host 0.0.0.0 \
             --port $ROUTER_PORT \


### PR DESCRIPTION
## Summary
- Switch vllm-router routing policy from `round_robin` to `consistent_hash` in both inference and multi-node RL SLURM templates

Cherry-picked from `daniel/fix-rlm-command-timeout` (bc8837cf4).

## Test plan
- [ ] Verify SLURM template renders correctly with the new policy
- [ ] Validate consistent hash routing works with PD disaggregation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Small templating change, but it directly alters request routing behavior for distributed inference/RL runs and could impact load balance or hotspotting if the new policy behaves differently in practice.
> 
> **Overview**
> Switches `vllm-router` routing policy from `round_robin` to `consistent_hash` in the SLURM job templates used for both standalone inference and multi-node RL inference replicas (including PD disaggregated mode).
> 
> This changes how requests are distributed across backend workers/roles without altering the surrounding job orchestration or process startup logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3699f721d231c01795e7f9843195d16a47d8dbc2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->