### PR TITLE
chore: bump verifiers to e305f64

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ override-dependencies = [
 
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "e305f64" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "d4796b9" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eeb" }
 transformers = { git = "https://github.com/huggingface/transformers.git", rev = "5c1c72b" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ override-dependencies = [
 
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "0db45e6" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "e305f64" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eeb" }
 transformers = { git = "https://github.com/huggingface/transformers.git", rev = "5c1c72b" }

--- a/uv.lock
+++ b/uv.lock
@@ -2862,7 +2862,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", git = "https://github.com/huggingface/transformers.git?rev=5c1c72b" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=0db45e6" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=e305f64" },
     { name = "vllm", specifier = ">=0.17.0" },
     { name = "vllm-router", marker = "platform_machine == 'x86_64' and extra == 'disagg'", url = "https://github.com/samsja/flash-attn-builds/releases/download/v0.3/vllm_router-0.1.11-cp38-abi3-linux_x86_64.whl" },
     { name = "wandb", specifier = ">=0.24.2" },
@@ -4184,7 +4184,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.12.dev1"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=0db45e6#0db45e6f4d8b20fb6ecfbb0e06138735ec4f3d99" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=e305f64#e305f6469551e9fdfb528ffdbb2243f201e0514e" }
 dependencies = [
     { name = "aiolimiter", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "anthropic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },

--- a/uv.lock
+++ b/uv.lock
@@ -2862,7 +2862,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", git = "https://github.com/huggingface/transformers.git?rev=5c1c72b" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=e305f64" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=d4796b9" },
     { name = "vllm", specifier = ">=0.17.0" },
     { name = "vllm-router", marker = "platform_machine == 'x86_64' and extra == 'disagg'", url = "https://github.com/samsja/flash-attn-builds/releases/download/v0.3/vllm_router-0.1.11-cp38-abi3-linux_x86_64.whl" },
     { name = "wandb", specifier = ">=0.24.2" },
@@ -4184,7 +4184,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.12.dev1"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=e305f64#e305f6469551e9fdfb528ffdbb2243f201e0514e" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=d4796b9#d4796b99cd71d7251b91564002f637e6b90f5df3" }
 dependencies = [
     { name = "aiolimiter", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "anthropic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },


### PR DESCRIPTION
## Summary
- Bump verifiers from `0db45e6` to `e305f64` to pick up sandbox error handling fix in `RLMEnv`

Cherry-picked from `daniel/fix-rlm-command-timeout`.

## Test plan
- [ ] Verify env server handles sandbox errors correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency-only change but updates `verifiers` to a new git revision, which can change sandbox/env-server runtime behavior without code changes in this repo.
> 
> **Overview**
> Bumps the `verifiers` dependency to a newer git revision by updating `pyproject.toml` and regenerating the corresponding `uv.lock` entries to point at the new commit.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec1f7215a31ae33eb126a32e8b9d0ad53a8056cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->