### PR TITLE
feat: add modelexpress optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,9 @@ flash-attn-3 = [
 flash-attn-cute = [
     "flash-attn-cute",
 ]
+modelexpress = [
+    "modelexpress>=0.3.0",
+]
 envs = [
     "reverse-text",
     "alphabet-sort",


### PR DESCRIPTION
## Summary
- Adds `modelexpress>=0.3.0` as an optional dependency group in pyproject.toml
- When installed, the modelexpress vLLM plugin registers automatically via entry points (`vllm.general_plugins`), coexisting with prime-rl's existing `transformers_v5_compat` plugin
- Enables `--load-format mx` and `--worker-cls modelexpress.vllm_worker.ModelExpressWorker` via `vllm_extra` config
- `worker_cls` (ModelExpress loader re-registration) and `worker_extension_cls` (RL weight broadcast) are independent vLLM extension points — no conflict

## Context
Part of ModelExpress integration for fast inference autoscaling. The companion Helm chart PR is in PrimeIntellect-ai/hosted-rl.

## Test plan
- [ ] `uv sync --extra modelexpress` installs successfully
- [ ] `--all-extras` still works (Docker build path)
- [ ] vLLM starts with `vllm_extra: {load_format: "mx", worker_cls: "modelexpress.vllm_worker.ModelExpressWorker"}` when modelexpress is installed
- [ ] vLLM starts normally when modelexpress is NOT installed (no import errors)