### PR TITLE
Feat: multi replica support

### DIFF
--- a/src/prime_rl/configs/inference.py
+++ b/src/prime_rl/configs/inference.py
@@ -147,20 +147,63 @@ class DisaggregatedInferenceDeploymentConfig(BaseInferenceDeploymentConfig):
 
     Each inference replica is split into separate prefill and decode node groups.
     Requires NIXL for KV transfer and a vllm-router for request routing.
+
+    Multi-replica support: set ``num_prefill_replicas`` / ``num_decode_replicas``
+    to run multiple independent vLLM instances within the prefill / decode node
+    groups.  For example, ``num_prefill_nodes=4, num_prefill_replicas=2`` creates
+    two prefill vLLM instances each spanning 2 nodes (EP16 with 8 GPUs/node).
     """
 
     type: Literal["disaggregated"] = "disaggregated"
 
-    num_prefill_nodes: Annotated[int, Field(ge=1, description="Number of prefill nodes per replica.")] = 1
-    num_decode_nodes: Annotated[int, Field(ge=1, description="Number of decode nodes per replica.")] = 1
+    num_prefill_nodes: Annotated[int, Field(ge=1, description="Total number of prefill nodes.")] = 1
+    num_decode_nodes: Annotated[int, Field(ge=1, description="Total number of decode nodes.")] = 1
+
+    num_prefill_replicas: Annotated[
+        int,
+        Field(
+            ge=1,
+            description="Number of independent prefill vLLM instances. Must evenly divide num_prefill_nodes.",
+        ),
+    ] = 1
+    num_decode_replicas: Annotated[
+        int,
+        Field(
+            ge=1,
+            description="Number of independent decode vLLM instances. Must evenly divide num_decode_nodes.",
+        ),
+    ] = 1
 
     router_port: Annotated[int, Field(description="Port for the vllm-router on each replica.")] = 8000
     prefill_port: Annotated[int, Field(description="Port for prefill vLLM instances.")] = 8100
     decode_port: Annotated[int, Field(description="Port for decode vLLM instances.")] = 8200
 
+    prefill_env_overrides: Annotated[
+        dict[str, str],
+        Field(description="Extra environment variables exported only on prefill nodes."),
+    ] = {}
+    decode_env_overrides: Annotated[
+        dict[str, str],
+        Field(description="Extra environment variables exported only on decode nodes."),
+    ] = {}
+
     @property
     def num_nodes(self) -> int:
         return self.num_prefill_nodes + self.num_decode_nodes
+
+    @model_validator(mode="after")
+    def validate_replicas_divide_nodes(self):
+        if self.num_prefill_nodes % self.num_prefill_replicas != 0:
+            raise ValueError(
+                f"num_prefill_replicas ({self.num_prefill_replicas}) must evenly divide "
+                f"num_prefill_nodes ({self.num_prefill_nodes})"
+            )
+        if self.num_decode_nodes % self.num_decode_replicas != 0:
+            raise ValueError(
+                f"num_decode_replicas ({self.num_decode_replicas}) must evenly divide "
+                f"num_decode_nodes ({self.num_decode_nodes})"
+            )
+        return self
 
 
 InferenceDeploymentConfig: TypeAlias = Annotated[

--- a/src/prime_rl/entrypoints/inference.py
+++ b/src/prime_rl/entrypoints/inference.py
@@ -50,11 +50,15 @@ def write_slurm_script(config: InferenceConfig, config_path: Path, script_path: 
         template_vars.update(
             num_prefill_nodes=config.deployment.num_prefill_nodes,
             num_decode_nodes=config.deployment.num_decode_nodes,
+            num_prefill_replicas=config.deployment.num_prefill_replicas,
+            num_decode_replicas=config.deployment.num_decode_replicas,
             prefill_port=config.deployment.prefill_port,
             decode_port=config.deployment.decode_port,
             router_port=config.deployment.router_port,
             data_parallel_rpc_port=config.data_parallel_rpc_port,
             use_deep_gemm=config.use_deep_gemm,
+            prefill_env_overrides=config.deployment.prefill_env_overrides,
+            decode_env_overrides=config.deployment.decode_env_overrides,
         )
     elif is_multi_node:
         template_vars.update(

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -419,6 +419,8 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
             num_infer_replicas=config.deployment.num_infer_replicas,
             num_prefill_nodes=infer_deploy.num_prefill_nodes,
             num_decode_nodes=infer_deploy.num_decode_nodes,
+            num_prefill_replicas=infer_deploy.num_prefill_replicas,
+            num_decode_replicas=infer_deploy.num_decode_replicas,
             gpus_per_node=config.deployment.gpus_per_node,
             router_port=infer_deploy.router_port,
             prefill_port=infer_deploy.prefill_port,
@@ -426,6 +428,8 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
             inference_tp=config.inference.parallel.tp,
             inference_data_parallel_rpc_port=config.inference.data_parallel_rpc_port,
             use_deep_gemm=config.inference.use_deep_gemm,
+            prefill_env_overrides=infer_deploy.prefill_env_overrides,
+            decode_env_overrides=infer_deploy.decode_env_overrides,
             use_nccl_broadcast=config.weight_broadcast is not None and config.weight_broadcast.type == "nccl",
             wandb_shared=config.wandb is not None and config.wandb.shared,
         )

--- a/src/prime_rl/templates/inference.sbatch.j2
+++ b/src/prime_rl/templates/inference.sbatch.j2
@@ -27,7 +27,11 @@ export GPUS_PER_NODE={{ gpus_per_node }}
 {% if disaggregated -%}
 export NUM_PREFILL_NODES={{ num_prefill_nodes }}
 export NUM_DECODE_NODES={{ num_decode_nodes }}
+export NUM_PREFILL_REPLICAS={{ num_prefill_replicas }}
+export NUM_DECODE_REPLICAS={{ num_decode_replicas }}
 export NODES_PER_REPLICA=$((NUM_PREFILL_NODES + NUM_DECODE_NODES))
+export NODES_PER_PREFILL_REPLICA=$((NUM_PREFILL_NODES / NUM_PREFILL_REPLICAS))
+export NODES_PER_DECODE_REPLICA=$((NUM_DECODE_NODES / NUM_DECODE_REPLICAS))
 export PREFILL_PORT={{ prefill_port }}
 export DECODE_PORT={{ decode_port }}
 export ROUTER_PORT={{ router_port }}
@@ -142,19 +146,24 @@ srun bash -c '
     KV_CFG='"'"'{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"num_threads":1}}'"'"'
     DECODE_COMPILE_CFG='"'"'{"cudagraph_mode":"FULL_DECODE_ONLY"}'"'"'
 
-    # Determine replica and role
+    # Determine outer replica (P/D pair) and role
     REPLICA_IDX=$((INFER_NODE_RANK / NODES_PER_REPLICA))
     RANK_IN_REPLICA=$((INFER_NODE_RANK % NODES_PER_REPLICA))
+    REPLICA_BASE=$((REPLICA_IDX * NODES_PER_REPLICA))
 
     if [ "$RANK_IN_REPLICA" -lt "$NUM_PREFILL_NODES" ]; then
         # ── Prefill node ──
         ROLE="prefill"
-        ROLE_RANK=$RANK_IN_REPLICA
-        EP=$((NUM_PREFILL_NODES * GPUS_PER_NODE))
+        SUB_REPLICA=$((RANK_IN_REPLICA / NODES_PER_PREFILL_REPLICA))
+        ROLE_RANK=$((RANK_IN_REPLICA % NODES_PER_PREFILL_REPLICA))
+        EP=$((NODES_PER_PREFILL_REPLICA * GPUS_PER_NODE))
         PORT=$PREFILL_PORT
         START_RANK=$((ROLE_RANK * GPUS_PER_NODE))
-        HEAD_HOST="${HOSTNAMES[$((REPLICA_IDX * NODES_PER_REPLICA))]}"
+        HEAD_HOST="${HOSTNAMES[$((REPLICA_BASE + SUB_REPLICA * NODES_PER_PREFILL_REPLICA))]}"
 
+{% for key, value in prefill_env_overrides.items() %}
+        export {{ key }}="{{ value }}"
+{% endfor %}
         ROLE_EXTRA="\"all2all_backend\": \"deepep_high_throughput\""
 
         if [ "$ROLE_RANK" -eq 0 ]; then
@@ -166,12 +175,17 @@ srun bash -c '
         # ── Decode node ──
         export UCX_NET_DEVICES=mlx5_0:1
         ROLE="decode"
-        ROLE_RANK=$((RANK_IN_REPLICA - NUM_PREFILL_NODES))
-        EP=$((NUM_DECODE_NODES * GPUS_PER_NODE))
+        RANK_IN_DECODE=$((RANK_IN_REPLICA - NUM_PREFILL_NODES))
+        SUB_REPLICA=$((RANK_IN_DECODE / NODES_PER_DECODE_REPLICA))
+        ROLE_RANK=$((RANK_IN_DECODE % NODES_PER_DECODE_REPLICA))
+        EP=$((NODES_PER_DECODE_REPLICA * GPUS_PER_NODE))
         PORT=$DECODE_PORT
         START_RANK=$((ROLE_RANK * GPUS_PER_NODE))
-        HEAD_HOST="${HOSTNAMES[$((REPLICA_IDX * NODES_PER_REPLICA + NUM_PREFILL_NODES))]}"
+        HEAD_HOST="${HOSTNAMES[$((REPLICA_BASE + NUM_PREFILL_NODES + SUB_REPLICA * NODES_PER_DECODE_REPLICA))]}"
 
+{% for key, value in decode_env_overrides.items() %}
+        export {{ key }}="{{ value }}"
+{% endfor %}
         ROLE_EXTRA="\"all2all_backend\": \"deepep_low_latency\", \"compilation_config\": $DECODE_COMPILE_CFG"
 
         if [ "$ROLE_RANK" -eq 0 ]; then
@@ -181,7 +195,7 @@ srun bash -c '
         fi
     fi
 
-    echo "NODE_RANK=$INFER_NODE_RANK ROLE=$ROLE REPLICA=$REPLICA_IDX ROLE_RANK=$ROLE_RANK EP=$EP PORT=$PORT LOCAL_IP=$LOCAL_IP" \
+    echo "NODE_RANK=$INFER_NODE_RANK ROLE=$ROLE REPLICA=$REPLICA_IDX SUB_REPLICA=$SUB_REPLICA ROLE_RANK=$ROLE_RANK EP=$EP PORT=$PORT LOCAL_IP=$LOCAL_IP" \
         | tee $OUTPUT_DIR/slurm/latest_infer_node_rank_${INFER_NODE_RANK}.log \
               $OUTPUT_DIR/slurm/job_${SLURM_JOB_ID}_infer_node_rank_${INFER_NODE_RANK}.log
 

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -35,6 +35,10 @@ export INFERENCE_DATA_PARALLEL_RPC_PORT={{ inference_data_parallel_rpc_port }}
 {% if is_disaggregated -%}
 export NUM_PREFILL_NODES={{ num_prefill_nodes }}
 export NUM_DECODE_NODES={{ num_decode_nodes }}
+export NUM_PREFILL_REPLICAS={{ num_prefill_replicas }}
+export NUM_DECODE_REPLICAS={{ num_decode_replicas }}
+export NODES_PER_PREFILL_REPLICA=$((NUM_PREFILL_NODES / NUM_PREFILL_REPLICAS))
+export NODES_PER_DECODE_REPLICA=$((NUM_DECODE_NODES / NUM_DECODE_REPLICAS))
 export PREFILL_PORT={{ prefill_port }}
 export DECODE_PORT={{ decode_port }}
 {%- else -%}
@@ -201,26 +205,37 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
     KV_CFG='"'"'{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"num_threads":1}}'"'"'
     DECODE_COMPILE_CFG='"'"'{"cudagraph_mode":"FULL_DECODE_ONLY"}'"'"'
 
+    REPLICA_BASE=$((REPLICA_IDX * NODES_PER_INFER_REPLICA))
+
     if [ "$RANK_IN_REPLICA" -lt "$NUM_PREFILL_NODES" ]; then
         ROLE="prefill"
-        ROLE_RANK=$RANK_IN_REPLICA
-        DP=$((NUM_PREFILL_NODES * INFERENCE_DP_LOCAL))
+        SUB_REPLICA=$((RANK_IN_REPLICA / NODES_PER_PREFILL_REPLICA))
+        ROLE_RANK=$((RANK_IN_REPLICA % NODES_PER_PREFILL_REPLICA))
+        DP=$((NODES_PER_PREFILL_REPLICA * INFERENCE_DP_LOCAL))
         PORT=$PREFILL_PORT
         START_RANK=$((ROLE_RANK * INFERENCE_DP_LOCAL))
-        HEAD_HOST="${HOSTNAMES[$((REPLICA_IDX * NODES_PER_INFER_REPLICA))]}"
+        HEAD_HOST="${HOSTNAMES[$((REPLICA_BASE + SUB_REPLICA * NODES_PER_PREFILL_REPLICA))]}"
+{% for key, value in prefill_env_overrides.items() %}
+        export {{ key }}="{{ value }}"
+{% endfor %}
         ROLE_EXTRA="\"all2all_backend\": \"deepep_high_throughput\""
     else
         export UCX_NET_DEVICES=mlx5_0:1
         ROLE="decode"
-        ROLE_RANK=$((RANK_IN_REPLICA - NUM_PREFILL_NODES))
-        DP=$((NUM_DECODE_NODES * INFERENCE_DP_LOCAL))
+        RANK_IN_DECODE=$((RANK_IN_REPLICA - NUM_PREFILL_NODES))
+        SUB_REPLICA=$((RANK_IN_DECODE / NODES_PER_DECODE_REPLICA))
+        ROLE_RANK=$((RANK_IN_DECODE % NODES_PER_DECODE_REPLICA))
+        DP=$((NODES_PER_DECODE_REPLICA * INFERENCE_DP_LOCAL))
         PORT=$DECODE_PORT
         START_RANK=$((ROLE_RANK * INFERENCE_DP_LOCAL))
-        HEAD_HOST="${HOSTNAMES[$((REPLICA_IDX * NODES_PER_INFER_REPLICA + NUM_PREFILL_NODES))]}"
+        HEAD_HOST="${HOSTNAMES[$((REPLICA_BASE + NUM_PREFILL_NODES + SUB_REPLICA * NODES_PER_DECODE_REPLICA))]}"
+{% for key, value in decode_env_overrides.items() %}
+        export {{ key }}="{{ value }}"
+{% endfor %}
         ROLE_EXTRA="\"all2all_backend\": \"deepep_low_latency\", \"compilation_config\": $DECODE_COMPILE_CFG"
     fi
 
-    echo "ROLE=$ROLE REPLICA=$REPLICA_IDX ROLE_RANK=$ROLE_RANK DP=$DP PORT=$PORT" \
+    echo "ROLE=$ROLE REPLICA=$REPLICA_IDX SUB_REPLICA=$SUB_REPLICA ROLE_RANK=$ROLE_RANK DP=$DP PORT=$PORT" \
         | tee -a $OUTPUT_DIR/slurm/latest_infer_node_rank_${INFER_NODE_RANK}.log \
                  $OUTPUT_DIR/slurm/job_${SLURM_JOB_ID}_infer_node_rank_${INFER_NODE_RANK}.log
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates disaggregated inference/RL SLURM launch logic to support multiple prefill/decode sub-replicas and per-role env overrides, which can affect node/rank mapping and routing in production clusters.
> 
> **Overview**
> **Disaggregated inference now supports multiple independent prefill and decode vLLM instances per node group.** The deployment config adds `num_prefill_replicas`/`num_decode_replicas` (with validation that they evenly divide `num_prefill_nodes`/`num_decode_nodes`) and optional `prefill_env_overrides`/`decode_env_overrides`.
> 
> The inference and RL entrypoints pass these new fields into SLURM templates, and the `inference.sbatch.j2`/`multi_node_rl.sbatch.j2` scripts update rank-to-role mapping to compute *sub-replica* indices, derive per-sub-replica head hosts, adjust EP/DP sizing per sub-replica, and export role-specific environment overrides during launch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14c47de7d784acf7463f0c1762fb4f547d3daaca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->