### PR TITLE
Add watchdog to packer to detect silent hangs

### DIFF
--- a/src/prime_rl/trainer/rl/data.py
+++ b/src/prime_rl/trainer/rl/data.py
@@ -170,8 +170,10 @@ class DataLoader:
     def wait_for_batch(self) -> None:
         if self.world.is_master:
             self.packer._arm_watchdog()
-            self.packer.pack()
-            self.packer._disarm_watchdog()
+            try:
+                self.packer.pack()
+            finally:
+                self.packer._disarm_watchdog()
         self.receiver.wait()
         self.multi_run_manager.synchronize_state()
 

--- a/src/prime_rl/trainer/rl/data.py
+++ b/src/prime_rl/trainer/rl/data.py
@@ -169,7 +169,9 @@ class DataLoader:
 
     def wait_for_batch(self) -> None:
         if self.world.is_master:
+            self.packer._arm_watchdog()
             self.packer.pack()
+            self.packer._disarm_watchdog()
         self.receiver.wait()
         self.multi_run_manager.synchronize_state()
 

--- a/src/prime_rl/trainer/rl/packer.py
+++ b/src/prime_rl/trainer/rl/packer.py
@@ -46,15 +46,25 @@ class BasePacker(ABC):
             self.multi_run_manager.output_dir, dp_world_size, start_step, config
         )
         self._last_heartbeat = time.monotonic()
+        self._watchdog_armed = threading.Event()
         self._watchdog = threading.Thread(target=self._watchdog_loop, daemon=True)
         self._watchdog.start()
 
     def _heartbeat(self) -> None:
         self._last_heartbeat = time.monotonic()
 
+    def _arm_watchdog(self) -> None:
+        self._last_heartbeat = time.monotonic()
+        self._watchdog_armed.set()
+
+    def _disarm_watchdog(self) -> None:
+        self._watchdog_armed.clear()
+
     def _watchdog_loop(self) -> None:
         while True:
             time.sleep(60)
+            if not self._watchdog_armed.is_set():
+                continue
             stale = time.monotonic() - self._last_heartbeat
             if stale > WATCHDOG_TIMEOUT_SECONDS:
                 self.logger.error(f"Packer heartbeat stale for {stale:.0f}s, killing process to trigger restart")

--- a/src/prime_rl/trainer/rl/packer.py
+++ b/src/prime_rl/trainer/rl/packer.py
@@ -1,4 +1,6 @@
+import os
 import shutil
+import threading
 import time
 from abc import ABC, abstractmethod
 from collections import deque
@@ -19,6 +21,7 @@ from prime_rl.utils.logger import get_logger
 from prime_rl.utils.pathing import get_rollout_dir
 
 TIMEOUT_SECONDS = 0.1
+WATCHDOG_TIMEOUT_SECONDS = 1800  # 30 minutes
 
 
 class BasePacker(ABC):
@@ -42,6 +45,20 @@ class BasePacker(ABC):
         self.sender: MicroBatchSender = setup_micro_batch_sender(
             self.multi_run_manager.output_dir, dp_world_size, start_step, config
         )
+        self._last_heartbeat = time.monotonic()
+        self._watchdog = threading.Thread(target=self._watchdog_loop, daemon=True)
+        self._watchdog.start()
+
+    def _heartbeat(self) -> None:
+        self._last_heartbeat = time.monotonic()
+
+    def _watchdog_loop(self) -> None:
+        while True:
+            time.sleep(60)
+            stale = time.monotonic() - self._last_heartbeat
+            if stale > WATCHDOG_TIMEOUT_SECONDS:
+                self.logger.error(f"Packer heartbeat stale for {stale:.0f}s, killing process to trigger restart")
+                os._exit(1)
 
     @abstractmethod
     def pack(self) -> None:
@@ -66,6 +83,7 @@ class SinglePacker(BasePacker):
         # Wait for batch to be available
         batches = []
         while len(batches) == 0:
+            self._heartbeat()
             self.multi_run_manager.discover_runs()
             batches = self.receiver.receive()
             time.sleep(0.2)
@@ -157,6 +175,7 @@ class MultiPacker(BasePacker):
 
     def _get_batch(self) -> None:
         """Receive batches from orchestrator and buffer samples per run."""
+        self._heartbeat()
         self.multi_run_manager.discover_runs()
         batches = self.receiver.receive()
 


### PR DESCRIPTION
## Summary
- Packer on rank 0 can silently hang (e.g. NFS I/O stall), leaving ranks 1-7 waiting forever for rank_N.bin files with no recovery
- Adds a heartbeat + watchdog thread to BasePacker — heartbeat is bumped each loop iteration, watchdog kills the process after 30min of staleness
- StatefulSet restart recovers automatically

Discovered on `qwen3-30b-instruct-e2e-spk` where the trainer was stuck for 4+ days with no training progress.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a background watchdog thread that can forcefully terminate the master process via `os._exit(1)` if heartbeats stop, which could cause unintended restarts if the heartbeat isn’t updated during legitimate long operations.
> 
> **Overview**
> Prevents training from hanging indefinitely when the master packer stalls by adding a **heartbeat + watchdog** to `BasePacker` that kills the process after 30 minutes of no progress.
> 
> `DataLoader.wait_for_batch()` now arms/disarms this watchdog around `packer.pack()`, and packer loops (`SinglePacker.pack()` and `MultiPacker._get_batch()`) periodically bump the heartbeat while waiting for orchestrator batches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit adc12cb0b1ebcba64b4e2250ab570b771b23af00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->