### PR TITLE
fix: log chat templated messages to `eval/samples` Table

### DIFF
--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -183,9 +183,11 @@ class WandbMonitor(Monitor):
             return
 
         for rollout in rollouts:
-            completion = rollout.get("completion", "")
+            completion = rollout.get("completion")
             if not completion:
                 continue
+            if isinstance(completion, list):
+                completion = self.tokenizer.apply_chat_template(completion, tokenize=False)
             sample = {
                 "step": step,
                 "env": env_name,


### PR DESCRIPTION
apply chat template to online-eval messages to have a similar experience as with training rollouts "samples" Table.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is isolated to W&B eval sample logging and only affects how `completion` is formatted for display.
> 
> **Overview**
> Ensures `log_eval_samples` logs a readable `completion` into the W&B `eval/samples` table by detecting list-based chat messages and converting them to text via `tokenizer.apply_chat_template(..., tokenize=False)` before logging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10e552648ce28cd748ccb5fc2e0ce284d6325f08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->