### PR TITLE
feat: deterministic GC to avoid distributed stragglers

### DIFF
--- a/src/prime_rl/configs/sft.py
+++ b/src/prime_rl/configs/sft.py
@@ -14,6 +14,7 @@ from prime_rl.configs.trainer import (
     BenchConfig,
     CheckpointConfig,
     ConstantSchedulerConfig,
+    GCConfig,
     ModelConfig,
     OptimizerConfig,
     SchedulerConfig,
@@ -212,6 +213,13 @@ class SFTConfig(BaseConfig):
         BenchConfig | None,
         Field(
             description="Whether to run in benchmark mode. It will automatically set the maximum number of steps to run to 4 and use fake data.",
+        ),
+    ] = None
+
+    gc: Annotated[
+        GCConfig | None,
+        Field(
+            description="Garbage collection config. Disables automatic GC and runs deterministic collections every N steps to avoid stragglers. If None, uses Python's default GC behavior.",
         ),
     ] = None
 

--- a/src/prime_rl/configs/sft.py
+++ b/src/prime_rl/configs/sft.py
@@ -219,9 +219,9 @@ class SFTConfig(BaseConfig):
     gc: Annotated[
         GCConfig | None,
         Field(
-            description="Garbage collection config. Disables automatic GC and runs deterministic collections every N steps to avoid stragglers. If None, uses Python's default GC behavior.",
+            description="Garbage collection config. Disables automatic GC and runs deterministic collections every N steps to avoid stragglers. Set to null to use Python's default GC behavior.",
         ),
-    ] = None
+    ] = GCConfig()
 
     trace_path: Annotated[Path | None, Field(description="Path to write pytorch profiler trace to.")] = None
 

--- a/src/prime_rl/configs/trainer.py
+++ b/src/prime_rl/configs/trainer.py
@@ -25,6 +25,22 @@ AttnImplementation: TypeAlias = Literal["sdpa", "flash_attention_2", "flash_atte
 _ATTN_ALIASES = {"flash_attention_4": "fa4"}
 
 
+class GCConfig(BaseConfig):
+    """Configures deterministic garbage collection to avoid stragglers in distributed training.
+
+    Disables Python's automatic GC and runs manual collections every `freq` steps so all
+    ranks collect simultaneously, preventing one rank from stalling others.
+    """
+
+    freq: Annotated[
+        int,
+        Field(
+            ge=1,
+            description="Run garbage collection every `freq` training steps.",
+        ),
+    ] = 50
+
+
 class ActivationCheckpointConfig(BaseConfig):
     """Configures activation checkpointing."""
 
@@ -715,6 +731,13 @@ class TrainerConfig(BaseConfig):
         BenchConfig | None,
         Field(
             description="Whether to run in benchmark mode. It will automatically set the maximum number of steps to run to 4 and use fake data.",
+        ),
+    ] = None
+
+    gc: Annotated[
+        GCConfig | None,
+        Field(
+            description="Garbage collection config. Disables automatic GC and runs deterministic collections every N steps to avoid stragglers. If None, uses Python's default GC behavior.",
         ),
     ] = None
 

--- a/src/prime_rl/configs/trainer.py
+++ b/src/prime_rl/configs/trainer.py
@@ -32,11 +32,11 @@ class GCConfig(BaseConfig):
     ranks collect simultaneously, preventing one rank from stalling others.
     """
 
-    freq: Annotated[
+    interval: Annotated[
         int,
         Field(
             ge=1,
-            description="Run garbage collection every `freq` training steps.",
+            description="Run garbage collection every `interval` training steps.",
         ),
     ] = 50
 

--- a/src/prime_rl/configs/trainer.py
+++ b/src/prime_rl/configs/trainer.py
@@ -737,9 +737,9 @@ class TrainerConfig(BaseConfig):
     gc: Annotated[
         GCConfig | None,
         Field(
-            description="Garbage collection config. Disables automatic GC and runs deterministic collections every N steps to avoid stragglers. If None, uses Python's default GC behavior.",
+            description="Garbage collection config. Disables automatic GC and runs deterministic collections every N steps to avoid stragglers. Set to null to use Python's default GC behavior.",
         ),
-    ] = None
+    ] = GCConfig()
 
     trace_path: Annotated[Path | None, Field(description="Path to write pytorch profiler trace to.")] = None
 

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -210,7 +210,7 @@ def train(config: TrainerConfig):
             config.rollout_transport,
         )
 
-    gc_handler = GarbageCollection(config.gc.freq) if config.gc else None
+    gc_handler = GarbageCollection(config.gc.interval) if config.gc else None
 
     logger.info(f"Starting training loop (max_steps={config.max_steps or 'infinite'})")
     is_first_step = True

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -41,6 +41,7 @@ from prime_rl.trainer.model import (
 from prime_rl.trainer.parallel_dims import get_parallel_dims
 from prime_rl.trainer.perf import get_perf_counter
 from prime_rl.trainer.utils import (
+    GarbageCollection,
     MemoryProfiler,
     Tensors,
     export_benchmark_json,
@@ -209,6 +210,8 @@ def train(config: TrainerConfig):
             config.rollout_transport,
         )
 
+    gc_handler = GarbageCollection(config.gc.freq) if config.gc else None
+
     logger.info(f"Starting training loop (max_steps={config.max_steps or 'infinite'})")
     is_first_step = True
     maybe_record_function = nullcontext
@@ -219,6 +222,8 @@ def train(config: TrainerConfig):
     while True:
         # Reset peak memory stats
         torch.cuda.reset_peak_memory_stats()
+        if gc_handler is not None:
+            gc_handler.run(progress.step)
         is_last_step = config.max_steps is not None and progress.step == config.max_steps
 
         # Broadcast weights at every step, (except step 0, because no need to broadcast the base model)

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -272,7 +272,7 @@ def train(config: SFTConfig):
             logger.success(f"Validation | Step {step} | Loss: {mean_loss:.4f}")
         monitor.log({"val/loss": mean_loss, "step": step}, step=step)
 
-    gc_handler = GarbageCollection(config.gc.freq) if config.gc else None
+    gc_handler = GarbageCollection(config.gc.interval) if config.gc else None
 
     logger.info(f"Starting training loop (max_steps={config.max_steps or 'infinite'})")
     max_memory = torch.cuda.mem_get_info()[1] / 1024**3  # GiB

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -32,6 +32,7 @@ from prime_rl.trainer.parallel_dims import get_parallel_dims
 from prime_rl.trainer.perf import get_perf_counter
 from prime_rl.trainer.sft.data import load_sft_dataset, setup_dataloader, setup_dataset
 from prime_rl.trainer.utils import (
+    GarbageCollection,
     MemoryProfiler,
     export_benchmark_json,
     get_zero_gradient_ratio,
@@ -271,6 +272,8 @@ def train(config: SFTConfig):
             logger.success(f"Validation | Step {step} | Loss: {mean_loss:.4f}")
         monitor.log({"val/loss": mean_loss, "step": step}, step=step)
 
+    gc_handler = GarbageCollection(config.gc.freq) if config.gc else None
+
     logger.info(f"Starting training loop (max_steps={config.max_steps or 'infinite'})")
     max_memory = torch.cuda.mem_get_info()[1] / 1024**3  # GiB
     is_first_step = True
@@ -281,6 +284,8 @@ def train(config: SFTConfig):
     while True:
         # Reset peak memory stats
         torch.cuda.reset_peak_memory_stats()
+        if gc_handler is not None:
+            gc_handler.run(progress.step)
         is_last_step = config.max_steps is not None and progress.step == config.max_steps
 
         if (

--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -1,3 +1,4 @@
+import gc
 import json
 import pickle
 import shutil
@@ -25,6 +26,34 @@ from prime_rl.utils.pathing import get_ckpt_dir
 from prime_rl.utils.utils import format_num, format_time, get_step_path
 
 DEFAULT_TIMEOUT = timedelta(seconds=600)
+
+
+class GarbageCollection:
+    """Controls Python garbage collection to avoid stragglers in distributed training.
+
+    In multi-GPU training, Python's automatic GC can trigger unpredictably on one rank
+    while others wait at a synchronization point, stalling the entire step. This class
+    disables automatic GC and runs deterministic collections every `freq` steps so all
+    ranks collect simultaneously.
+
+    Based on the approach from torchtitan (https://arxiv.org/abs/2505.05713).
+    """
+
+    def __init__(self, freq: int = 50):
+        assert freq > 0, "gc_freq must be a positive integer"
+        self.freq = freq
+        gc.disable()
+        self.collect("Initial GC collection")
+
+    def run(self, step: int):
+        if step > 0 and step % self.freq == 0:
+            self.collect("Periodic GC collection")
+
+    @staticmethod
+    def collect(reason: str, generation: int = 1):
+        begin = time.monotonic()
+        gc.collect(generation)
+        get_logger().info("[GC] %s took %.2f seconds", reason, time.monotonic() - begin)
 
 
 def _to_local_tensor(tensor: Tensor | DTensor) -> Tensor:

--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -53,7 +53,7 @@ class GarbageCollection:
     def collect(reason: str, generation: int = 1):
         begin = time.monotonic()
         gc.collect(generation)
-        get_logger().info("[GC] %s took %.2f seconds", reason, time.monotonic() - begin)
+        get_logger().info(f"[GC] {reason} took {time.monotonic() - begin:.2f} seconds")
 
 
 def _to_local_tensor(tensor: Tensor | DTensor) -> Tensor:

--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -33,27 +33,26 @@ class GarbageCollection:
 
     In multi-GPU training, Python's automatic GC can trigger unpredictably on one rank
     while others wait at a synchronization point, stalling the entire step. This class
-    disables automatic GC and runs deterministic collections every `freq` steps so all
-    ranks collect simultaneously.
+    disables automatic GC and runs deterministic collections every `interval` steps so
+    all ranks collect simultaneously.
 
     Based on the approach from torchtitan (https://arxiv.org/abs/2505.05713).
     """
 
-    def __init__(self, freq: int = 50):
-        assert freq > 0, "gc_freq must be a positive integer"
-        self.freq = freq
+    def __init__(self, interval: int = 50):
+        assert interval > 0, "gc interval must be a positive integer"
+        self.interval = interval
         gc.disable()
-        self.collect("Initial GC collection")
+        self._collect()
 
     def run(self, step: int):
-        if step > 0 and step % self.freq == 0:
-            self.collect("Periodic GC collection")
+        if step > 0 and step % self.interval == 0:
+            self._collect()
 
-    @staticmethod
-    def collect(reason: str, generation: int = 1):
+    def _collect(self, generation: int = 1):
         begin = time.monotonic()
         gc.collect(generation)
-        get_logger().info(f"[GC] {reason} took {time.monotonic() - begin:.2f} seconds")
+        get_logger().info(f"[GC] collection took {time.monotonic() - begin:.2f}s")
 
 
 def _to_local_tensor(tensor: Tensor | DTensor) -> Tensor:


### PR DESCRIPTION
## Summary
- Adds opt-in deterministic garbage collection for both SFT and RL trainers, inspired by [torchtitan's approach](https://github.com/pytorch/torchtitan) ([arXiv:2505.05713](https://arxiv.org/abs/2505.05713))
- Disables Python's automatic GC at init and runs manual `gc.collect(generation=1)` every N steps so all ranks collect simultaneously, preventing one rank from stalling others at synchronization points
- Fully opt-in: disabled by default, enable via `gc = { freq = 50 }` in TOML config

## Changes
- `src/prime_rl/trainer/utils.py`: `GarbageCollection` class (disable auto GC, periodic deterministic collection with logging)
- `src/prime_rl/configs/trainer.py`: `GCConfig` + `gc` field on `TrainerConfig`
- `src/prime_rl/configs/sft.py`: `gc` field on `SFTConfig`
- `src/prime_rl/trainer/sft/train.py`: Initialize and run GC handler in training loop
- `src/prime_rl/trainer/rl/train.py`: Same integration as SFT

## Usage
```toml
[gc]
freq = 50  # collect every 50 steps
```

## Test plan
- [x] All 298 non-GPU tests pass
- [x] Config parsing verified (both `None` default and explicit `gc = { freq = N }`)
- [x] `GarbageCollection` class unit-tested (disables auto GC, collects at correct intervals)
- [ ] Verify on multi-GPU training run that GC collection logs appear at expected intervals

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core training-loop behavior by disabling Python’s automatic GC and forcing periodic collections, which can impact memory/performance and is hard to validate without multi-GPU runs.
> 
> **Overview**
> Adds *deterministic, step-synchronized Python garbage collection* to both SFT and RL training loops to reduce distributed “straggler” stalls.
> 
> Introduces a new `GCConfig` (default `interval=50`) exposed as `gc` on `TrainerConfig` and `SFTConfig`, plus a `GarbageCollection` helper that disables Python’s automatic GC at startup and triggers `gc.collect()` on a fixed step interval with timing logs; trainers invoke it once per step (configurable or disabled by setting `gc=null`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e22822d95802a0e0b2675fe1538e9a4e70c82d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->