### PR TITLE
feat: add garbage collection to avoid stragglers during training

### DIFF
--- a/src/prime_rl/configs/sft.py
+++ b/src/prime_rl/configs/sft.py
@@ -14,6 +14,7 @@ from prime_rl.configs.trainer import (
     BenchConfig,
     CheckpointConfig,
     ConstantSchedulerConfig,
+    GCConfig,
     ModelConfig,
     OptimizerConfig,
     SchedulerConfig,
@@ -180,6 +181,9 @@ class SFTConfig(BaseConfig):
 
     # The checkpoint configuration
     ckpt: CheckpointConfig | None = None
+
+    # The garbage collection configuration
+    gc: GCConfig = GCConfig()
 
     # The logging configuration
     log: LogConfig = LogConfig()

--- a/src/prime_rl/configs/trainer.py
+++ b/src/prime_rl/configs/trainer.py
@@ -473,6 +473,25 @@ class WeightCheckpointConfig(BaseConfig):
     ] = False
 
 
+class GCConfig(BaseConfig):
+    """Configures Python garbage collection to avoid stragglers during training."""
+
+    freq: Annotated[
+        int,
+        Field(
+            ge=1,
+            description="Frequency (in steps) at which to perform garbage collection. Default is 50 steps.",
+        ),
+    ] = 50
+
+    debug: Annotated[
+        bool,
+        Field(
+            description="When enabled, performs GC every step and warns about tensor reference cycles on rank 0. Useful for debugging memory leaks.",
+        ),
+    ] = False
+
+
 class CheckpointConfig(BaseConfig):
     """Configures checkpointing the full model, optimizer and training state for resuming training."""
 
@@ -669,6 +688,9 @@ class TrainerConfig(BaseConfig):
 
     # The checkpoint configuration
     ckpt: CheckpointConfig | None = None
+
+    # The garbage collection configuration
+    gc: GCConfig = GCConfig()
 
     weight_broadcast: WeightBroadcastConfig = FileSystemWeightBroadcastConfig()
 

--- a/src/prime_rl/configs/trainer.py
+++ b/src/prime_rl/configs/trainer.py
@@ -484,13 +484,6 @@ class GCConfig(BaseConfig):
         ),
     ] = 50
 
-    debug: Annotated[
-        bool,
-        Field(
-            description="When enabled, performs GC every step and warns about tensor reference cycles on rank 0. Useful for debugging memory leaks.",
-        ),
-    ] = False
-
 
 class CheckpointConfig(BaseConfig):
     """Configures checkpointing the full model, optimizer and training state for resuming training."""

--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -1,4 +1,5 @@
 import bisect
+import gc
 import shutil
 import time
 import warnings
@@ -164,6 +165,9 @@ class CheckpointManager:
         # Save sharded state
         dcp_save(state_dict, checkpoint_id=path)
 
+        # Perform GC after checkpoint save to free memory
+        gc.collect(1)
+
         self.logger.debug(f"Training checkpoint saved in {time.perf_counter() - start_time:.2f} seconds")
 
     def load_from_path(
@@ -183,6 +187,9 @@ class CheckpointManager:
         app_state = AppState(model, optimizers if not self.skip_optimizer else [], scheduler, progress)
         state_dict = {"app": app_state}
         dcp_load(state_dict=state_dict, checkpoint_id=path)
+
+        # Perform GC after checkpoint load to free memory
+        gc.collect(1)
 
         # Load the dataloader
         if dataloader is not None:

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -133,8 +133,8 @@ def train(config: TrainerConfig):
         logger.info("Initialized multi-run checkpoint manager")
 
     # Set up garbage collection
-    logger.info(f"Initializing garbage collection (freq={config.gc.freq}, debug={config.gc.debug})")
-    gc_handler = GarbageCollection(gc_freq=config.gc.freq, debug=config.gc.debug)
+    logger.info(f"Initializing garbage collection (freq={config.gc.freq})")
+    gc_handler = GarbageCollection(gc_freq=config.gc.freq)
 
     # Initialize the model and tokenizer
     logger.info(f"Initializing model ({config.model})")

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -49,6 +49,7 @@ from prime_rl.trainer.utils import (
     setup_torch_distributed,
     print_benchmark,
     get_response_lengths,
+    GarbageCollection,
 )
 from prime_rl.trainer.world import get_world
 from prime_rl.trainer.runs import setup_multi_run_manager, Progress, get_multi_run_manager
@@ -130,6 +131,10 @@ def train(config: TrainerConfig):
         # Multi-run uses per-run checkpointing via MultiCheckpointManager
         ckpt_manager, weight_ckpt_manager = setup_multi_checkpoint_manager(config.output_dir)
         logger.info("Initialized multi-run checkpoint manager")
+
+    # Set up garbage collection
+    logger.info(f"Initializing garbage collection (freq={config.gc.freq}, debug={config.gc.debug})")
+    gc_handler = GarbageCollection(gc_freq=config.gc.freq, debug=config.gc.debug)
 
     # Initialize the model and tokenizer
     logger.info(f"Initializing model ({config.model})")
@@ -472,6 +477,9 @@ def train(config: TrainerConfig):
         # Update the model parameters
         optimizer.step()
         optimizer.zero_grad()
+
+        # Run garbage collection
+        gc_handler.run(progress.step)
 
         # Update learning rate scheduler
         scheduler.step()

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -111,8 +111,8 @@ def train(config: SFTConfig):
     ckpt_manager, weight_ckpt_manager = setup_ckpt_managers(config.output_dir, config.ckpt, config.model.lora)
 
     # Set up garbage collection
-    logger.info(f"Initializing garbage collection (freq={config.gc.freq}, debug={config.gc.debug})")
-    gc_handler = GarbageCollection(gc_freq=config.gc.freq, debug=config.gc.debug)
+    logger.info(f"Initializing garbage collection (freq={config.gc.freq})")
+    gc_handler = GarbageCollection(gc_freq=config.gc.freq)
 
     checkpoint_step = None
     if config.ckpt and config.ckpt.resume_step is not None and ckpt_manager is not None:

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -39,6 +39,7 @@ from prime_rl.trainer.utils import (
     print_sample,
     setup_torch_distributed,
     print_benchmark,
+    GarbageCollection,
 )
 from prime_rl.trainer.world import get_world
 from prime_rl.utils.heartbeat import Heartbeat
@@ -108,6 +109,10 @@ def train(config: SFTConfig):
     # Set up checkpoint manager
     logger.info(f"Initializing checkpoint managers ({config.ckpt})")
     ckpt_manager, weight_ckpt_manager = setup_ckpt_managers(config.output_dir, config.ckpt, config.model.lora)
+
+    # Set up garbage collection
+    logger.info(f"Initializing garbage collection (freq={config.gc.freq}, debug={config.gc.debug})")
+    gc_handler = GarbageCollection(gc_freq=config.gc.freq, debug=config.gc.debug)
 
     checkpoint_step = None
     if config.ckpt and config.ckpt.resume_step is not None and ckpt_manager is not None:
@@ -399,6 +404,9 @@ def train(config: SFTConfig):
         logger.debug("Optimizer step")
         optimizer.step()
         optimizer.zero_grad()
+
+        # Run garbage collection
+        gc_handler.run(progress.step)
 
         # Update learning rate scheduler
         current_lr = optimizer.param_groups[0]["lr"]

--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -404,23 +404,15 @@ class GarbageCollection:
     https://github.com/pytorch/torchtitan
     """
 
-    def __init__(self, gc_freq: int = 50, debug: bool = False):
+    def __init__(self, gc_freq: int = 50):
         assert gc_freq > 0, "gc_freq must be a positive integer"
         self.gc_freq = gc_freq
-        self.debug = debug
         self.logger = get_logger()
         gc.disable()
         self.collect("Initial GC collection")
-        if debug:
-            from torch.utils.viz._cycles import warn_tensor_cycles
-
-            if get_world().rank == 0:
-                warn_tensor_cycles()
 
     def run(self, step_count: int):
-        if self.debug:
-            self.collect("Force GC to perform collection to obtain debug information", generation=2)
-        elif step_count > 1 and step_count % self.gc_freq == 0:
+        if step_count > 1 and step_count % self.gc_freq == 0:
             self.collect("Performing periodic GC collection")
 
     def collect(self, reason: str, generation: int = 1):

--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -388,3 +388,42 @@ def maybe_clean(path: Path, step: int, async_level: int, interval_to_keep: int |
     if not keep:
         logger.debug(f"Removing path {candidate_path_to_delete}")
         shutil.rmtree(candidate_path_to_delete, ignore_errors=True)
+
+
+import gc
+
+
+class GarbageCollection:
+    """Manages Python garbage collection to avoid stragglers during training.
+
+    Disables automatic GC and performs manual collection at specified intervals.
+    This prevents GC from running unpredictably during training steps, which
+    can cause stragglers in distributed training.
+
+    Based on torchtitan's GarbageCollection implementation:
+    https://github.com/pytorch/torchtitan
+    """
+
+    def __init__(self, gc_freq: int = 50, debug: bool = False):
+        assert gc_freq > 0, "gc_freq must be a positive integer"
+        self.gc_freq = gc_freq
+        self.debug = debug
+        self.logger = get_logger()
+        gc.disable()
+        self.collect("Initial GC collection")
+        if debug:
+            from torch.utils.viz._cycles import warn_tensor_cycles
+
+            if get_world().rank == 0:
+                warn_tensor_cycles()
+
+    def run(self, step_count: int):
+        if self.debug:
+            self.collect("Force GC to perform collection to obtain debug information", generation=2)
+        elif step_count > 1 and step_count % self.gc_freq == 0:
+            self.collect("Performing periodic GC collection")
+
+    def collect(self, reason: str, generation: int = 1):
+        begin = time.monotonic()
+        gc.collect(generation)
+        self.logger.info("[GC] %s took %.2f seconds", reason, time.monotonic() - begin)


### PR DESCRIPTION
## Summary

Implements GC logic similar to [torchtitan](https://github.com/pytorch/torchtitan) to prevent stragglers in distributed training by disabling automatic Python GC and performing manual collection at specified intervals.

## Changes

- **GarbageCollection class** (`trainer/utils.py`): Disables automatic GC and performs manual collection at specified intervals to prevent unpredictable GC pauses during training
- **GCConfig** (`configs/trainer.py`): New config with `freq` (default: 50 steps) and `debug` (default: false) options
- **SFT integration** (`trainer/sft/train.py`): Initializes GC handler and calls it after optimizer step
- **RL integration** (`trainer/rl/train.py`): Same integration pattern as SFT
- **Checkpoint GC** (`trainer/ckpt.py`): Calls `gc.collect(1)` after `dcp_save` and `dcp_load` to prevent memory buildup

## Usage

```toml
# In your config.toml
[gc]
freq = 50  # Collect every 50 steps
debug = false  # Set to true to debug memory leaks
```

Or via CLI:
```bash
uv run sft @ config.toml --gc.freq 100 --gc.debug true
```

## Background

In distributed training, Python's automatic garbage collection can run unpredictably during training steps, causing some ranks to take longer than others (stragglers). This leads to synchronization delays as other ranks wait for the straggler.

The solution (from torchtitan) is to:
1. Disable automatic GC at startup
2. Perform manual GC at fixed intervals (every N steps)
3. Use `gc.collect(1)` (first generation only) for periodic collection - faster than full collection
4. Also perform GC after checkpoint operations which can create temporary objects

## Related

- [torchtitan GarbageCollection implementation](https://github.com/pytorch/torchtitan/blob/main/torchtitan/tools/utils.py)
- [torchtitan GC PR #839](https://github.com/pytorch/torchtitan/pull/839)
- [torchtitan GC debug PR #1230](https://github.com/pytorch/torchtitan/pull/1230)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime behavior of training loops by disabling automatic GC and introducing periodic/manual collections, which could affect memory/latency characteristics or surface GC-related edge cases during long runs.
> 
> **Overview**
> Adds an opt-in, configurable Python GC handler that disables automatic garbage collection and runs `gc.collect(1)` on a fixed step interval to reduce distributed-training stragglers.
> 
> Wires the new `gc` config (`GCConfig.freq`, default 50) into both SFT and RL training loops (run after `optimizer.step()`), and triggers a generation-1 GC after distributed checkpoint `dcp_save`/`dcp_load` to free temporary memory spikes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5963d20e1d2cf6f24cb8e08464ba365decd6eac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->