### PR TITLE
chore: pr guidelines for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,9 +42,11 @@ You are responsible for maintaining the skills folder. When a workflow fails and
 
 Write tests as plain functions with pytest fixtures. Don't use class-based tests.
 
-## Git & GitHub
+## Git
 
 Branch prefixes: `feat/`, `fix/`, `chore/`
 
-**Pull requests**: do not include a "Test plan" section in PR descriptions unless you actually ran tests to verify the changes or the user explicitly asked for one.
+## GitHub
+
+- **Pull requests**: do not include a "Test plan" section in PR descriptions unless you actually ran tests to verify the changes or the user explicitly asked for one.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,9 @@ You are responsible for maintaining the skills folder. When a workflow fails and
 
 Write tests as plain functions with pytest fixtures. Don't use class-based tests.
 
-## Git
+## Git & GitHub
 
 Branch prefixes: `feat/`, `fix/`, `chore/`
+
+**Pull requests**: do not include a "Test plan" section in PR descriptions unless you actually ran tests to verify the changes or the user explicitly asked for one.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,10 +44,10 @@ Write tests as plain functions with pytest fixtures. Don't use class-based tests
 
 ## Git
 
-Branch prefixes: `feat/`, `fix/`, `chore/`
+- **Branch prefixes**: use the following prefixes for branches: `feat/`, `fix/`, `chore/`
 
 ## GitHub
 
 - **Draft PRs**: always create PRs as drafts (`gh pr create --draft`) to avoid triggering CI unnecessarily.
-- **Pull requests**: do not include a "Test plan" section in PR descriptions unless you actually ran tests to verify the changes or the user explicitly asked for one.
+- **Pull requests**: do not include a "test plan" section in PR descriptions unless you actually ran tests to verify the changes or the user explicitly asked for one.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,5 +48,6 @@ Branch prefixes: `feat/`, `fix/`, `chore/`
 
 ## GitHub
 
+- **Draft PRs**: always create PRs as drafts (`gh pr create --draft`) to avoid triggering CI unnecessarily.
 - **Pull requests**: do not include a "Test plan" section in PR descriptions unless you actually ran tests to verify the changes or the user explicitly asked for one.
 


### PR DESCRIPTION
Consolidate Git section into Git & GitHub. Add rule: no test plan section in PR descriptions unless tests were actually run or explicitly requested.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that doesn’t affect runtime behavior. Risk is limited to minor workflow confusion if guidelines are misapplied.
> 
> **Overview**
> Clarifies the **Git** guidance in `AGENTS.md` by consolidating/standardizing the branch prefix rule.
> 
> Adds a new **GitHub** section requiring agents to open PRs as *drafts* by default and to omit a "test plan" section unless tests were actually run (or explicitly requested).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0e45ddfd675fc3e1122a67d366ffb6f01cfac33. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->