### PR TITLE
some more skills for training

### DIFF
--- a/skills/train-rl/SKILL.md
+++ b/skills/train-rl/SKILL.md
@@ -10,95 +10,31 @@ Launch stable RL jobs that match the user's hardware, environment, and rollout c
 
 ## Default Workflow
 1. Start from the closest `examples/*/rl.toml`.
-2. Prefer a single unified `rl.toml` for local or single-node runs.
-3. Use `bash scripts/tmux.sh` for local multi-process workflows when the user wants separate panes for logs and components.
-4. Validate the resolved config before long jobs:
+2. Launch with:
 
 ```bash
-uv run rl @ path/to/rl.toml --dry-run
+uv run rl @ path/to/rl.toml
 ```
 
 ## Deployment Choice
-- Single node: use `deployment.type = "single_node"` and launch with `uv run rl @ ...`.
 - Larger runs: use `deployment.type = "multi_node"` or start from an example `slurm_rl.toml`.
 - Multi-node RL requires a shared filesystem and exactly one orchestrator per run.
 
-## First Knobs To Change
-1. `output_dir`, `model.name`, `max_steps`, `seq_len`
-2. `[[orchestrator.env]]` IDs, names, and args
-3. `orchestrator.batch_size`, `orchestrator.rollouts_per_example`, `orchestrator.sampling.max_tokens`
-4. `deployment.*` and `inference.parallel.*`
-5. `trainer.optim.lr` and optional `trainer.model.lora`
+## Sampling
+1. Touch `orchestrator.sampling.temperature` only when entropy is not around `0.2-0.5` which is a good range to be in
+2. `orchestrator.oversampling_factor` is the main throughput knob if the trainer is starving.
 
-## Hard Constraints
-1. Set exactly one of `orchestrator.batch_size` or `orchestrator.token_batch_size`.
-2. `orchestrator.batch_size` must be divisible by `orchestrator.rollouts_per_example`.
-3. If `orchestrator.token_batch_size` is used, set `orchestrator.max_inflight_rollouts`.
-4. If `orchestrator.max_concurrent` is set, it must be at least `orchestrator.rollouts_per_example`.
-5. `weight_broadcast.type = "nccl"` requires `max_async_level = 1`.
-6. NCCL weight broadcast does not support LoRA.
-
-## Rollout Geometry
-1. `orchestrator.rollouts_per_example` controls group size for per-example advantages and is one of the most important RL knobs.
-2. `orchestrator.batch_size` is total rollout samples per step, not number of prompt groups.
-3. Good starting points:
-- Simple smoke tests: `rollouts_per_example = 8`, `batch_size = 128`
-- Common single-node or moderate runs: `rollouts_per_example = 8` or `16`, `batch_size = 512`
-- Large cluster runs: `rollouts_per_example = 16`, then scale `batch_size` to `1024-4096` only after throughput is stable
-4. `orchestrator.oversampling_factor = 2.0` is a common starting point for rollout-mode batching.
-5. If rollouts are long or expensive, lower `orchestrator.sampling.max_tokens` before shrinking `rollouts_per_example`.
-
-## Sampling And Exploration
-1. Training sampling defaults to `orchestrator.sampling.temperature = 1.0` if neither `orchestrator.sampling.temperature` nor `orchestrator.sampling.temp_scheduler` is set.
-2. Start with `orchestrator.sampling.temperature` around `0.7-1.0`.
-3. Lower `orchestrator.sampling.temperature` if outputs are noisy, malformed, or mostly low reward.
-4. Raise `orchestrator.sampling.temperature` cautiously only when rollouts collapse to near-identical completions and advantages vanish.
-5. Use `orchestrator.sampling.temp_scheduler` instead of constant temperature when you want exploration to decay over training.
-6. Leave `orchestrator.sampling.repetition_penalty = 1.0` unless the model gets stuck in repetition loops.
-7. Use `orchestrator.sampling.min_tokens` only if the model is ending generations too early.
-
-## Async And Off-Policy
-1. Use `max_async_level = 0` for synchronous debugging.
-2. Use `max_async_level = 1` for the standard async path and whenever NCCL broadcast is enabled.
-3. Increase `max_off_policy_steps` only after measuring throughput pressure. The default is `8`; larger example runs often use `16`.
-4. Leave `strict_async_level = false` unless you need tightly controlled staleness for an experiment.
-5. If eval quality regresses while throughput looks good, reduce async aggressiveness before touching optimizer knobs.
-
-## Optimizer, Loss, And Distillation
-1. `trainer.optim.lr` is usually `1e-6` for large full-model runs and `3e-6` to `1e-5` for smaller or LoRA-heavy jobs.
-2. Start with `trainer.optim.max_norm = 1.0` and treat it as a safety knob, not a first-line tuning lever.
-3. Treat `weight_decay` as secondary regularization. Existing examples span `0.0` to `0.1`.
-4. Leave `trainer.loss.adv_tau = 1.0` and `trainer.loss.kl_tau = 1e-3` unless you are intentionally rebalancing reward learning versus KL regularization.
-5. Use `trainer.loss.teacher_tau > 0` only with a configured teacher model or teacher server. Set `trainer.loss.adv_tau = 0` for pure distillation, where you can also set `verification.enabled = true` to save compute.
-6. Leave `trainer.loss.ipo_mask_low` and `trainer.loss.ipo_mask_high` at defaults unless you are intentionally changing token masking behavior.
-
-## Difficulty Filtering And Advantage Shaping
-1. Turn on `orchestrator.buffer.online_difficulty_filtering = true` only after rewards are trustworthy.
-2. `orchestrator.buffer.easy_threshold = 1.0` and `orchestrator.buffer.hard_threshold = 0.0` are common starting points for binary-ish rewards.
-3. Use `orchestrator.buffer.easy_fraction` and `orchestrator.buffer.hard_fraction` to bleed some filtered examples back into normal sampling instead of fully excluding them.
-4. `advantage.length_shaping_alpha = 0.33` is the recommended GR^3 starting value and requires `online_difficulty_filtering`.
-
-## Throughput And Stability
-- Lower `orchestrator.sampling.max_tokens` first when rollouts are too expensive.
-- Keep `max_async_level` low on first runs. Use `0` for synchronous debugging and `1` for the normal async path.
-- Use `orchestrator.oversampling_factor` or `orchestrator.max_inflight_rollouts` to keep the trainer fed without letting rollout cost explode.
-- Turn on `orchestrator.buffer.easy_threshold`, `hard_threshold`, or `online_difficulty_filtering` only after rewards are already meaningful.
-
-## Memory Tuning
-1. Reduce `seq_len` first.
-2. Reduce `orchestrator.batch_size` or `orchestrator.token_batch_size` next.
-3. Then enable memory savers as needed:
-- `trainer.model.ac.freq = 1`
-- `trainer.model.ac_offloading.max_inflight_activations = 5`
-- `trainer.model.optim_cpu_offload = true`
-- `trainer.model.lora`
+## Optimization
+1. `trainer.optim.lr` is usually the first optimization knob to touch.
+2. Do not change `trainer.loss.*` unless the user explicitly asks for distillation or objective changes.
+3. Use `orchestrator.buffer.*` only when reward quality is already good enough to support difficulty-based sampling.
 
 ## Diagnosis
 - High `time/wait_for_batch`: inference or environment is the bottleneck.
 - High `time/wait_for_ckpt`: trainer is the bottleneck.
 - Flat reward: inspect rollout samples and reward quality before assuming optimizer issues.
-- Unstable reward swings: lower `trainer.optim.lr`, lower `orchestrator.sampling.temperature`, or reduce async aggressiveness before changing advanced loss knobs.
-- Trainer OOM: shrink `seq_len` and trainer batch pressure before adding more advanced features.
+- Unstable reward swings: lower `trainer.optim.lr` or `orchestrator.sampling.temperature` before changing advanced loss knobs.
+- Trainer OOM: follow `docs/memory_usage.md`.
 
 ## Resume Pattern
 
@@ -113,6 +49,8 @@ The inference server is stateless. On resume, the orchestrator will reload the c
 - Read `entrypoints` for launcher behavior.
 - Read `config` for TOML composition and CLI overrides.
 - Read `monitor-run` for log paths and runtime bottleneck analysis.
+- Read `docs/memory_usage.md` for trainer memory tradeoffs.
+- Read `docs/on_policy_distillation.md` for distillation-specific tuning.
 
 ## Deliverable
 Return:

--- a/skills/train-rl/SKILL.md
+++ b/skills/train-rl/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: train-rl
+description: Launch and tune prime-rl reinforcement learning runs. Use when asked to configure or run `uv run rl`, adapt `rl.toml`, choose rollout, trainer, or inference settings, resume RL runs, or diagnose rollout and trainer bottlenecks.
+---
+
+# Train RL
+
+## Goal
+Launch stable RL jobs that match the user's hardware, environment, and rollout cost budget.
+
+## Default Workflow
+1. Start from the closest `examples/*/rl.toml`.
+2. Prefer a single unified `rl.toml` for local or single-node runs.
+3. Use `bash scripts/tmux.sh` for local multi-process workflows when the user wants separate panes for logs and components.
+4. Validate the resolved config before long jobs:
+
+```bash
+uv run rl @ path/to/rl.toml --dry-run
+```
+
+## Deployment Choice
+- Single node: use `deployment.type = "single_node"` and launch with `uv run rl @ ...`.
+- Larger runs: use `deployment.type = "multi_node"` or start from an example `slurm_rl.toml`.
+- Multi-node RL requires a shared filesystem and exactly one orchestrator per run.
+
+## First Knobs To Change
+1. `output_dir`, `model.name`, `max_steps`, `seq_len`
+2. `[[orchestrator.env]]` IDs, names, and args
+3. `orchestrator.batch_size`, `orchestrator.rollouts_per_example`, `orchestrator.sampling.max_tokens`
+4. `deployment.*` and `inference.parallel.*`
+5. `trainer.optim.lr` and optional `trainer.model.lora`
+
+## Hard Constraints
+1. Set exactly one of `orchestrator.batch_size` or `orchestrator.token_batch_size`.
+2. `orchestrator.batch_size` must be divisible by `orchestrator.rollouts_per_example`.
+3. If `orchestrator.token_batch_size` is used, set `orchestrator.max_inflight_rollouts`.
+4. If `orchestrator.max_concurrent` is set, it must be at least `orchestrator.rollouts_per_example`.
+5. `weight_broadcast.type = "nccl"` requires `max_async_level = 1`.
+6. NCCL weight broadcast does not support LoRA.
+
+## Rollout Geometry
+1. `orchestrator.rollouts_per_example` controls group size for per-example advantages and is one of the most important RL knobs.
+2. `orchestrator.batch_size` is total rollout samples per step, not number of prompt groups.
+3. Good starting points:
+- Simple smoke tests: `rollouts_per_example = 8`, `batch_size = 128`
+- Common single-node or moderate runs: `rollouts_per_example = 8` or `16`, `batch_size = 512`
+- Large cluster runs: `rollouts_per_example = 16`, then scale `batch_size` to `1024-4096` only after throughput is stable
+4. `orchestrator.oversampling_factor = 2.0` is a common starting point for rollout-mode batching.
+5. If rollouts are long or expensive, lower `orchestrator.sampling.max_tokens` before shrinking `rollouts_per_example`.
+
+## Sampling And Exploration
+1. Training sampling defaults to `orchestrator.sampling.temperature = 1.0` if neither `orchestrator.sampling.temperature` nor `orchestrator.sampling.temp_scheduler` is set.
+2. Start with `orchestrator.sampling.temperature` around `0.7-1.0`.
+3. Lower `orchestrator.sampling.temperature` if outputs are noisy, malformed, or mostly low reward.
+4. Raise `orchestrator.sampling.temperature` cautiously only when rollouts collapse to near-identical completions and advantages vanish.
+5. Use `orchestrator.sampling.temp_scheduler` instead of constant temperature when you want exploration to decay over training.
+6. Leave `orchestrator.sampling.repetition_penalty = 1.0` unless the model gets stuck in repetition loops.
+7. Use `orchestrator.sampling.min_tokens` only if the model is ending generations too early.
+
+## Async And Off-Policy
+1. Use `max_async_level = 0` for synchronous debugging.
+2. Use `max_async_level = 1` for the standard async path and whenever NCCL broadcast is enabled.
+3. Increase `max_off_policy_steps` only after measuring throughput pressure. The default is `8`; larger example runs often use `16`.
+4. Leave `strict_async_level = false` unless you need tightly controlled staleness for an experiment.
+5. If eval quality regresses while throughput looks good, reduce async aggressiveness before touching optimizer knobs.
+
+## Optimizer, Loss, And Distillation
+1. `trainer.optim.lr` is usually `1e-6` for large full-model runs and `3e-6` to `1e-5` for smaller or LoRA-heavy jobs.
+2. Start with `trainer.optim.max_norm = 1.0` and treat it as a safety knob, not a first-line tuning lever.
+3. Treat `weight_decay` as secondary regularization. Existing examples span `0.0` to `0.1`.
+4. Leave `trainer.loss.adv_tau = 1.0` and `trainer.loss.kl_tau = 1e-3` unless you are intentionally rebalancing reward learning versus KL regularization.
+5. Use `trainer.loss.teacher_tau > 0` only with a configured teacher model or teacher server. Set `trainer.loss.adv_tau = 0` for pure distillation, where you can also set `verification.enabled = true` to save compute.
+6. Leave `trainer.loss.ipo_mask_low` and `trainer.loss.ipo_mask_high` at defaults unless you are intentionally changing token masking behavior.
+
+## Difficulty Filtering And Advantage Shaping
+1. Turn on `orchestrator.buffer.online_difficulty_filtering = true` only after rewards are trustworthy.
+2. `orchestrator.buffer.easy_threshold = 1.0` and `orchestrator.buffer.hard_threshold = 0.0` are common starting points for binary-ish rewards.
+3. Use `orchestrator.buffer.easy_fraction` and `orchestrator.buffer.hard_fraction` to bleed some filtered examples back into normal sampling instead of fully excluding them.
+4. `advantage.length_shaping_alpha = 0.33` is the recommended GR^3 starting value and requires `online_difficulty_filtering`.
+
+## Throughput And Stability
+- Lower `orchestrator.sampling.max_tokens` first when rollouts are too expensive.
+- Keep `max_async_level` low on first runs. Use `0` for synchronous debugging and `1` for the normal async path.
+- Use `orchestrator.oversampling_factor` or `orchestrator.max_inflight_rollouts` to keep the trainer fed without letting rollout cost explode.
+- Turn on `orchestrator.buffer.easy_threshold`, `hard_threshold`, or `online_difficulty_filtering` only after rewards are already meaningful.
+
+## Memory Tuning
+1. Reduce `seq_len` first.
+2. Reduce `orchestrator.batch_size` or `orchestrator.token_batch_size` next.
+3. Then enable memory savers as needed:
+- `trainer.model.ac.freq = 1`
+- `trainer.model.ac_offloading.max_inflight_activations = 5`
+- `trainer.model.optim_cpu_offload = true`
+- `trainer.model.lora`
+
+## Diagnosis
+- High `time/wait_for_batch`: inference or environment is the bottleneck.
+- High `time/wait_for_ckpt`: trainer is the bottleneck.
+- Flat reward: inspect rollout samples and reward quality before assuming optimizer issues.
+- Unstable reward swings: lower `trainer.optim.lr`, lower `orchestrator.sampling.temperature`, or reduce async aggressiveness before changing advanced loss knobs.
+- Trainer OOM: shrink `seq_len` and trainer batch pressure before adding more advanced features.
+
+## Resume Pattern
+
+```bash
+uv run rl @ path/to/rl.toml --max-steps 10 --ckpt
+uv run rl @ path/to/rl.toml --max-steps 20 --ckpt.resume-step 10
+```
+
+The inference server is stateless. On resume, the orchestrator will reload the correct weights into inference.
+
+## Related Skills
+- Read `entrypoints` for launcher behavior.
+- Read `config` for TOML composition and CLI overrides.
+- Read `monitor-run` for log paths and runtime bottleneck analysis.
+
+## Deliverable
+Return:
+1. The example or template the run started from.
+2. Config deltas applied.
+3. Why each major RL knob was changed.
+4. The exact launch command.
+5. Which trainer and orchestrator metrics to watch first.

--- a/skills/train-rl/SKILL.md
+++ b/skills/train-rl/SKILL.md
@@ -21,7 +21,7 @@ uv run rl @ path/to/rl.toml
 - Multi-node RL requires a shared filesystem and exactly one orchestrator per run.
 
 ## Sampling
-1. Touch `orchestrator.sampling.temperature` only when entropy is not around `0.2-0.5` which is a good range to be in
+1. Touch `orchestrator.sampling.temperature` only when entropy is not around `0.2-0.5` which is a good range to be in.
 2. `orchestrator.oversampling_factor` is the main throughput knob if the trainer is starving.
 
 ## Optimization

--- a/skills/train-sft/SKILL.md
+++ b/skills/train-sft/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: train-sft
+description: Launch and tune prime-rl supervised fine-tuning runs. Use when asked to configure or run `uv run sft`, prepare SFT datasets, choose batch or sequence settings, resume training, or debug trainer memory and performance issues.
+---
+
+# Train SFT
+
+## Goal
+Run reproducible SFT jobs that are compatible with later RL fine-tuning.
+
+## Preferred Workflow
+1. Start from the closest `examples/*/sft.toml` or `configs/debug/sft/train.toml`.
+2. Prefer the `sft` entrypoint for single-node training:
+
+```bash
+uv run sft @ path/to/sft.toml
+```
+
+It launches `torchrun` internally based on `deployment.num_gpus`.
+
+3. Use `--dry-run` before long jobs or SLURM submissions:
+
+```bash
+uv run sft @ path/to/sft.toml --dry-run
+```
+
+4. For multi-node non-SLURM setups, use manual `torchrun` as shown in `docs/deployment.md`.
+
+## Dataset Requirements
+- Use datasets in `messages` format or prompt-completion format.
+- If `messages` is present, it takes precedence over `prompt` and `completion`.
+- The tokenizer chat template must satisfy the prefix property for correct loss masking. Do not assume every instruct model already does.
+- Keep role-based loss masking defaults unless the user has a clear reason to train on user, system, or tool tokens.
+
+## Hard Constraints
+1. `data.batch_size` must be divisible by `data.micro_batch_size`.
+2. `data.batch_size` must be at least `data.micro_batch_size`.
+3. If `model.cp > 1`, keep `data.micro_batch_size = 1`.
+
+## First Knobs To Change
+1. `model.name`
+2. `data.name`, `data.subsets`, `data.splits`
+3. `data.batch_size`, `data.micro_batch_size`, `data.seq_len`
+4. `optim.lr`
+5. `max_steps` and `output_dir`
+6. Optional `model.lora`
+
+## Memory And Scale
+1. Reduce `data.micro_batch_size` before reducing global `data.batch_size`.
+2. Reduce `data.seq_len` if the trainer OOMs.
+3. Then enable memory savers as needed:
+- `model.ac.freq = 1`
+- `model.ac_offloading.max_inflight_activations = 5`
+- `model.optim_cpu_offload = true`
+- `model.lora`
+4. For single-node multi-GPU training, set `deployment.type = "single_node"` and increase `deployment.num_gpus`.
+5. For SLURM, keep the config in the repo and validate with `--dry-run` first.
+
+## Diagnosis
+- Noisy or flat loss: verify the dataset format and chat template before retuning the optimizer.
+- Trainer OOM: reduce `data.seq_len` or `data.micro_batch_size` first.
+- Slow steps without OOM: check whether activation offloading or CPU optimizer offload is the trade-off you want, or whether the global batch is simply too large for the hardware.
+
+## Resume Pattern
+
+```bash
+uv run sft @ path/to/sft.toml --max-steps 20 --ckpt
+uv run sft @ path/to/sft.toml --max-steps 40 --ckpt.resume-step 20
+```
+
+## Related Skills
+- Read `entrypoints` for launcher behavior.
+- Read `config` for TOML composition and CLI overrides.
+- Read `monitor-run` when diagnosing live trainer logs.
+
+## Deliverable
+Return:
+1. The example or template the run started from.
+2. Dataset and model choices.
+3. Config deltas applied.
+4. The exact launch command.
+5. The expected checkpoint or output path.

--- a/skills/train-sft/SKILL.md
+++ b/skills/train-sft/SKILL.md
@@ -8,23 +8,16 @@ description: Launch and tune prime-rl supervised fine-tuning runs. Use when aske
 ## Goal
 Run reproducible SFT jobs that are compatible with later RL fine-tuning.
 
-## Preferred Workflow
+## Default Workflow
 1. Start from the closest `examples/*/sft.toml` or `configs/debug/sft/train.toml`.
-2. Prefer the `sft` entrypoint for single-node training:
+2. Launch with:
 
 ```bash
 uv run sft @ path/to/sft.toml
 ```
 
-It launches `torchrun` internally based on `deployment.num_gpus`.
-
-3. Use `--dry-run` before long jobs or SLURM submissions:
-
-```bash
-uv run sft @ path/to/sft.toml --dry-run
-```
-
-4. For multi-node non-SLURM setups, use manual `torchrun` as shown in `docs/deployment.md`.
+## Deployment Choice
+- For multi-node or SLURM-specific setups, follow `docs/deployment.md`.
 
 ## Dataset Requirements
 - Use datasets in `messages` format or prompt-completion format.
@@ -32,34 +25,23 @@ uv run sft @ path/to/sft.toml --dry-run
 - The tokenizer chat template must satisfy the prefix property for correct loss masking. Do not assume every instruct model already does.
 - Keep role-based loss masking defaults unless the user has a clear reason to train on user, system, or tool tokens.
 
-## Hard Constraints
-1. `data.batch_size` must be divisible by `data.micro_batch_size`.
-2. `data.batch_size` must be at least `data.micro_batch_size`.
-3. If `model.cp > 1`, keep `data.micro_batch_size = 1`.
-
 ## First Knobs To Change
 1. `model.name`
 2. `data.name`, `data.subsets`, `data.splits`
 3. `data.batch_size`, `data.micro_batch_size`, `data.seq_len`
 4. `optim.lr`
 5. `max_steps` and `output_dir`
-6. Optional `model.lora`
+6. `model.lora` when hardware makes full-model SFT impractical
 
-## Memory And Scale
-1. Reduce `data.micro_batch_size` before reducing global `data.batch_size`.
-2. Reduce `data.seq_len` if the trainer OOMs.
-3. Then enable memory savers as needed:
-- `model.ac.freq = 1`
-- `model.ac_offloading.max_inflight_activations = 5`
-- `model.optim_cpu_offload = true`
-- `model.lora`
-4. For single-node multi-GPU training, set `deployment.type = "single_node"` and increase `deployment.num_gpus`.
-5. For SLURM, keep the config in the repo and validate with `--dry-run` first.
+## Optimization
+1. `optim.lr` is usually the first optimization knob to touch.
+2. Keep the data format and chat template stable before changing optimization settings.
+3. Do not change loss masking defaults unless the user explicitly wants a different training target.
 
 ## Diagnosis
 - Noisy or flat loss: verify the dataset format and chat template before retuning the optimizer.
-- Trainer OOM: reduce `data.seq_len` or `data.micro_batch_size` first.
-- Slow steps without OOM: check whether activation offloading or CPU optimizer offload is the trade-off you want, or whether the global batch is simply too large for the hardware.
+- Trainer OOM: follow `docs/memory_usage.md`.
+- Slow steps without OOM: check whether the batch size, sequence length, or deployment choice fits the available hardware.
 
 ## Resume Pattern
 
@@ -72,6 +54,8 @@ uv run sft @ path/to/sft.toml --max-steps 40 --ckpt.resume-step 20
 - Read `entrypoints` for launcher behavior.
 - Read `config` for TOML composition and CLI overrides.
 - Read `monitor-run` when diagnosing live trainer logs.
+- Read `docs/memory_usage.md` for trainer memory tradeoffs.
+- Read `docs/deployment.md` for multi-node and SLURM setups.
 
 ## Deliverable
 Return:

--- a/skills/train-with-environments/SKILL.md
+++ b/skills/train-with-environments/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: train-with-environments
+description: Train models with prime-rl on verifiers environments. Use when asked to choose between SFT warmup and direct RL, adapt an example config to a new environment, set up baseline evals, or plan environment-backed training runs end to end.
+---
+
+# Train With Environments
+
+## Goal
+Turn a working environment into a reproducible SFT and/or RL run with the smallest possible delta from an existing example.
+
+## Preferred Starting Point
+1. Do not build configs from scratch unless the user explicitly asks.
+2. Start from the closest example in `examples/`:
+- `reverse_text` for tiny single-turn SFT+RL smoke tests
+- `wordle` for multi-turn SFT+RL
+- `alphabet_sort` for LoRA-first RL without SFT warmup
+- `wiki_search` for tool use and difficulty filtering
+- `hendrycks_sanity` for RL algorithm sanity checks
+3. Prefer the high-level entrypoints:
+
+```bash
+uv run sft @ path/to/sft.toml
+uv run rl @ path/to/rl.toml
+```
+
+4. Run `--dry-run` before long jobs or SLURM submissions:
+
+```bash
+uv run sft @ path/to/sft.toml --dry-run
+uv run rl @ path/to/rl.toml --dry-run
+```
+
+## First-Run Protocol
+1. Install the environment and verify the Python package if needed:
+
+```bash
+prime env install owner/my-env
+uv run python -c "import my_env"
+```
+
+2. Get a baseline against a local inference server before training:
+
+```bash
+uv run inference --model.name Qwen/Qwen3-0.6B
+uv run vf-eval my-env -m Qwen/Qwen3-0.6B -b http://localhost:8000/v1 -n 20
+```
+
+3. If the base model already follows the environment format well, consider going straight to RL.
+4. If the model fails format, tool-calling, or multi-turn conventions, do a short SFT warmup first.
+
+## Choose The Training Path
+- Prefer SFT first when the base model does not understand the response format, tool schema, or conversational structure.
+- Prefer direct RL when the base model already behaves structurally correctly and mainly needs reward-driven improvement.
+- Prefer LoRA when VRAM is tight, when training on one or a few envs, and when the batch size is small
+
+
+## RL Rules Of Thumb
+1. Keep `orchestrator.batch_size` divisible by `orchestrator.rollouts_per_example`.
+2. Keep `orchestrator.max_concurrent` and `orchestrator.max_inflight_rollouts` at least `rollouts_per_example`.
+3. Simple smoke-test starting point: `rollouts_per_example = 8`, `batch_size = 128`, `oversampling_factor = 2.0`.
+4. Common stable starting point: `rollouts_per_example = 16`, `batch_size = 512`, `oversampling_factor = 2.0`.
+5. Reduce `orchestrator.sampling.max_tokens` before touching more exotic knobs when rollouts are too slow or memory-heavy. Mainly prefer this if the truncation rate is low.
+6. A good initial `orchestrator.sampling.temperature` is around `0.7-1.0`. Change this depending on the entropy, a good heuristic is to keep entropy around `0.3-0.5`. Increase `orchestrator.sampling.temperature` to increase entropy and vice versa.
+7. Keep `max_async_level` low on first runs. Use `0` for fully synchronous debugging or `1` for the usual async path. `nccl` weight broadcast requires `max_async_level = 1`.
+8. Turn on difficulty filtering only after rewards are meaningful enough to separate easy and hard cases.
+
+## SFT Rules Of Thumb
+1. Use datasets in `messages` or prompt-completion format.
+2. If `messages` is present, it takes precedence over `prompt` and `completion`.
+3. Start from the closest example `sft.toml` and first change only model, dataset, batch size, sequence length, and output directory.
+
+## Failure Triage
+- Flat reward or no learning: inspect baseline samples first. The problem is often environment format or reward quality, not just trainer hyperparameters.
+- Trainer OOM: reduce sequence length or batch pressure, then enable activation checkpointing, activation offloading, CPU optimizer offload, or LoRA.
+- High `time/wait_for_batch`: inference or environment is the bottleneck.
+- High `time/wait_for_ckpt`: trainer is the bottleneck.
+
+## Related Skills
+- Read `entrypoints` for command coverage.
+- Read `config` for TOML composition and CLI overrides.
+- Read `monitor-run` when diagnosing live runs.
+
+## Deliverable
+Return:
+1. Which example the run was based on.
+2. Config deltas applied.
+3. Why SFT, RL, or both were chosen.
+4. The exact launch command.
+5. The first metrics or logs to watch.

--- a/skills/train-with-environments/SKILL.md
+++ b/skills/train-with-environments/SKILL.md
@@ -23,13 +23,6 @@ uv run sft @ path/to/sft.toml
 uv run rl @ path/to/rl.toml
 ```
 
-4. Run `--dry-run` before long jobs or SLURM submissions:
-
-```bash
-uv run sft @ path/to/sft.toml --dry-run
-uv run rl @ path/to/rl.toml --dry-run
-```
-
 ## First-Run Protocol
 1. Install the environment and verify the Python package if needed:
 
@@ -51,31 +44,24 @@ uv run vf-eval my-env -m Qwen/Qwen3-0.6B -b http://localhost:8000/v1 -n 20
 ## Choose The Training Path
 - Prefer SFT first when the base model does not understand the response format, tool schema, or conversational structure.
 - Prefer direct RL when the base model already behaves structurally correctly and mainly needs reward-driven improvement.
-- Prefer LoRA when VRAM is tight, when training on one or a few envs, and when the batch size is small
+- Prefer LoRA when hardware or turnaround time makes full-model training impractical.
 
-
-## RL Rules Of Thumb
-1. Keep `orchestrator.batch_size` divisible by `orchestrator.rollouts_per_example`.
-2. Keep `orchestrator.max_concurrent` and `orchestrator.max_inflight_rollouts` at least `rollouts_per_example`.
-3. Simple smoke-test starting point: `rollouts_per_example = 8`, `batch_size = 128`, `oversampling_factor = 2.0`.
-4. Common stable starting point: `rollouts_per_example = 16`, `batch_size = 512`, `oversampling_factor = 2.0`.
-5. Reduce `orchestrator.sampling.max_tokens` before touching more exotic knobs when rollouts are too slow or memory-heavy. Mainly prefer this if the truncation rate is low.
-6. A good initial `orchestrator.sampling.temperature` is around `0.7-1.0`. Change this depending on the entropy, a good heuristic is to keep entropy around `0.3-0.5`. Increase `orchestrator.sampling.temperature` to increase entropy and vice versa.
-7. Keep `max_async_level` low on first runs. Use `0` for fully synchronous debugging or `1` for the usual async path. `nccl` weight broadcast requires `max_async_level = 1`.
-8. Turn on difficulty filtering only after rewards are meaningful enough to separate easy and hard cases.
-
-## SFT Rules Of Thumb
-1. Use datasets in `messages` or prompt-completion format.
-2. If `messages` is present, it takes precedence over `prompt` and `completion`.
-3. Start from the closest example `sft.toml` and first change only model, dataset, batch size, sequence length, and output directory.
+## Keep Deltas Small
+1. Change model, environment IDs or args, `output_dir`, and `max_steps` first.
+2. Only change RL-specific knobs when the closest example is clearly not enough for the environment or hardware.
+3. Only change SFT-specific knobs when the base model clearly needs format or tool-use warmup.
+4. Read `train-rl` before changing RL batching, sampling, or optimization settings.
+5. Read `train-sft` before changing SFT dataset, memory, or deployment settings.
 
 ## Failure Triage
 - Flat reward or no learning: inspect baseline samples first. The problem is often environment format or reward quality, not just trainer hyperparameters.
-- Trainer OOM: reduce sequence length or batch pressure, then enable activation checkpointing, activation offloading, CPU optimizer offload, or LoRA.
+- Trainer OOM: reduce sequence length and follow `train-rl`, `train-sft`, or `docs/memory_usage.md` instead of guessing.
 - High `time/wait_for_batch`: inference or environment is the bottleneck.
 - High `time/wait_for_ckpt`: trainer is the bottleneck.
 
 ## Related Skills
+- Read `train-rl` for RL-specific tuning.
+- Read `train-sft` for SFT-specific tuning.
 - Read `entrypoints` for command coverage.
 - Read `config` for TOML composition and CLI overrides.
 - Read `monitor-run` when diagnosing live runs.


### PR DESCRIPTION
Added some good starting point skills on general training recommendations and tuning decisions

<!--** CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: documentation-only additions with no runtime or configuration changes.
> 
> **Overview**
> Adds new `skills/` documentation for **training workflows**: `train-sft`, `train-rl`, and `train-with-environments`.
> 
> These guides standardize how to launch runs (including `--dry-run` and resume patterns), which key config knobs/constraints to adjust first, and quick diagnosis tips for throughput, stability, and memory issues.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b43158ea3872f33c71ec4c3eb632bf5fc54e2e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->