### PR TITLE
fix: reclaim GPU memory after checkpoint load with CPU optimizer offloading

### DIFF
--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -1,4 +1,5 @@
 import bisect
+import gc
 import shutil
 import time
 import warnings
@@ -101,16 +102,28 @@ class AppState(Stateful):
         )
 
         # Re-initialize CPU offload wrappers after loading
+        has_cpu_offload = False
         for opt in self.optimizers:
             if isinstance(opt, CPUOffloadOptimizer):
                 opt._move_states("cpu")
                 opt._initialized = True
+                has_cpu_offload = True
 
         if self.scheduler is not None:
             self.scheduler.load_state_dict(state_dict["scheduler"])
         if self.progress is not None:
             for key, value in state_dict["progress"].items():
                 setattr(self.progress, key, value)
+
+        # Reclaim GPU memory freed by moving optimizer states to CPU.
+        # After set_state_dict + _move_states("cpu"), the optimizer states live on CPU,
+        # but the state_dict (owned by dcp_load) still holds references to stale GPU
+        # optimizer tensors. Clearing them and flushing the CUDA cache prevents OOM on
+        # the first training step.
+        if has_cpu_offload:
+            state_dict.clear()  # drop stale GPU tensor references from dcp_load
+            gc.collect()  # break any circular references so tensors are freed
+            torch.cuda.empty_cache()  # return freed GPU memory to CUDA
 
 
 class CheckpointManager:


### PR DESCRIPTION
## Summary

- Fixes OOM when resuming from checkpoint with `optim_cpu_offload` enabled
- After `set_state_dict()` + `_move_states("cpu")`, the `state_dict` (owned by `dcp_load`) still holds references to stale GPU optimizer tensors, and the CUDA caching allocator retains the memory — causing OOM on the first training step
- Fix: clear stale references, `gc.collect()`, and `torch.cuda.empty_cache()` to fully reclaim GPU memory

## Before / After

Measured on Qwen3-0.6B with `optim_cpu_offload=true`, single GPU, `expandable_segments:True`:

| Metric | Before | After |
|---|---|---|
| Reserved after load | 14,362 MB | 2,942 MB |
| Allocated after load | 2,884 MB | 2,884 MB |
| **Wasted (reserved − allocated)** | **11,478 MB** | **58 MB** |
| Spike from baseline | 11,420 MB | 0 MB |


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches checkpoint resume behavior and CUDA memory management; incorrect clearing could mask bugs or impact memory/perf, but the change is localized to the CPU-offload load path.
> 
> **Overview**
> Fixes an OOM when resuming from a distributed checkpoint with `CPUOffloadOptimizer` enabled by explicitly reclaiming GPU memory after `set_state_dict()`.
> 
> After optimizer states are moved back to CPU during `AppState.load_state_dict`, the code now detects CPU-offload usage and clears the loaded `state_dict`, runs `gc.collect()`, and calls `torch.cuda.empty_cache()` to drop lingering references to stale GPU optimizer tensors held by `dcp_load`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b73448ed71e0f51397e3b98515bb5f7b8cfa3b4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->