### PR TITLE
chore: bump verifiers to 5d75d97

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ Namespaces are one honking great idea -- let's do more of those!
 
 - **Always use uv**: run code with `uv run` or `uv run <command>`, never raw `python`.
 - **Adding dependencies**: add to `pyproject.toml` and run `uv sync --all-extras` to install and lock them.
+- **Git dependency pins**: when pinning git dependencies in `pyproject.toml`, always use a small (7-char) commit hash for the `rev` field.
 
 ## Skills
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ override-dependencies = [
 
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "d4796b9" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "5d75d97" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eeb" }
 transformers = { git = "https://github.com/huggingface/transformers.git", rev = "5c1c72b" }

--- a/uv.lock
+++ b/uv.lock
@@ -2753,7 +2753,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", git = "https://github.com/huggingface/transformers.git?rev=5c1c72b" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=d4796b9" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=5d75d97" },
     { name = "vllm", specifier = ">=0.18.0" },
     { name = "vllm-router", marker = "platform_machine == 'x86_64' and extra == 'disagg'", url = "https://github.com/samsja/flash-attn-builds/releases/download/v0.3/vllm_router-0.1.11-cp38-abi3-linux_x86_64.whl" },
     { name = "wandb", specifier = ">=0.24.2" },
@@ -4003,7 +4003,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.12.dev1"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=d4796b9#d4796b99cd71d7251b91564002f637e6b90f5df3" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=5d75d97#5d75d979a6eef05d494acf31348ebcb52cd473ea" }
 dependencies = [
     { name = "aiolimiter", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "anthropic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },


### PR DESCRIPTION
## Summary
- Bump verifiers dependency from `d4796b9` to `5d75d97` -- mainly includes fixes for TITO

### Commits included (`d4796b9..5d75d97`)

- `5d75d97` fix: remove content rstrip in normalize_response to preserve TITO prefix match with OpenCode envs
- `8ac737c` Merge pull request from `PrimeIntellect-ai/eli/fix-tito`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change, but the `verifiers` commit bump could subtly change evaluation/verification behavior at runtime.
> 
> **Overview**
> Updates the `verifiers` git dependency pin from `d4796b9` to `5d75d97` in `pyproject.toml` and regenerates `uv.lock` accordingly.
> 
> Adds an `AGENTS.md` guideline to always pin git dependencies using a short (7‑char) commit hash in the `rev` field.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d80a6435735de5bd45ef1dc24c91f94ad7b2cfc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->