### PR TITLE
feat: set process titles on all entrypoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ override-dependencies = [
 
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "e27b68f" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "73deb26" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eeb" }
 transformers = { git = "https://github.com/huggingface/transformers.git", rev = "5c1c72b" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "tenacity>=8.2.0",
     "openai>=1.106.1",
     "rich>=14.0.0",
+    "setproctitle>=1.3.0",
     "uvloop>=0.21.0",
     "torchtitan",
     "verifiers",
@@ -114,7 +115,7 @@ override-dependencies = [
 
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "5d75d97" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "e27b68f" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eeb" }
 transformers = { git = "https://github.com/huggingface/transformers.git", rev = "5c1c72b" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ override-dependencies = [
 
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "73deb26" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "adf8138" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eeb" }
 transformers = { git = "https://github.com/huggingface/transformers.git", rev = "5c1c72b" }

--- a/skills/monitor-run/SKILL.md
+++ b/skills/monitor-run/SKILL.md
@@ -98,6 +98,7 @@ All prime-rl and verifiers processes set custom process titles using `setproctit
 | RL trainer (via torchrun) | `PRIME-RL::Trainer` |
 | SFT trainer (via torchrun) | `PRIME-RL::SFTTrainer` |
 | Env server (`uv run env-server`) | `PRIME-RL::EnvServer` |
+| vLLM engine core (spawned by inference) | `VLLM::EngineCore` |
 | Env server (spawned by orchestrator) | `Verifiers::EnvServer` |
 | Env worker N | `Verifiers::EnvWorker{N}` |
 
@@ -107,8 +108,14 @@ All prime-rl and verifiers processes set custom process titles using `setproctit
 # Find all prime-rl / verifiers processes
 ps -eo pid,comm,args | grep -E "PRIME-RL|Verifiers"
 
-# Show the full tree from the launcher PID
-pstree -ap <launcher_pid>
+# Show the full tree from the launcher PID (filter threads with grep -v)
+pstree -ap <launcher_pid> | grep -v '{.*}'
+
+# Find vLLM processes specifically (engine core, router)
+ps -eo pid,comm,args | grep -E "VLLM::"
+
+# Find vLLM processes on GPUs
+nvidia-smi --query-compute-apps=pid,name,gpu_uuid --format=csv,noheader
 ```
 
 A typical single-node RL run process tree:

--- a/skills/monitor-run/SKILL.md
+++ b/skills/monitor-run/SKILL.md
@@ -83,6 +83,50 @@ Log paths are consistent across deployment types — `logs/trainer.log` and `log
     └── ...
 ```
 
+### Identify processes via process tree
+
+All prime-rl and verifiers processes set custom process titles using `setproctitle`, making them easy to identify in `ps`, `htop`, and `pstree`.
+
+#### Process titles
+
+| Process | Title |
+|---------|-------|
+| RL launcher (`uv run rl`) | `PRIME-RL::Launcher` |
+| SFT launcher (`uv run sft`) | `PRIME-RL::SFT` |
+| Inference server (`uv run inference`) | `PRIME-RL::Inference` |
+| Orchestrator (`uv run orchestrator`) | `PRIME-RL::Orchestrator` |
+| RL trainer (via torchrun) | `PRIME-RL::Trainer` |
+| SFT trainer (via torchrun) | `PRIME-RL::SFTTrainer` |
+| Env server (`uv run env-server`) | `PRIME-RL::EnvServer` |
+| Env server (spawned by orchestrator) | `Verifiers::EnvServer` |
+| Env worker N | `Verifiers::EnvWorker{N}` |
+
+#### Inspecting the process tree
+
+```bash
+# Find all prime-rl / verifiers processes
+ps -eo pid,comm,args | grep -E "PRIME-RL|Verifiers"
+
+# Show the full tree from the launcher PID
+pstree -ap <launcher_pid>
+```
+
+A typical single-node RL run process tree:
+
+```
+PRIME-RL::Launcher
+├── PRIME-RL::Inference          (vLLM server, GPU 0)
+├── PRIME-RL::Orchestrator       (CPU-only, data/scheduling)
+│   ├── Verifiers::EnvServer     (ZMQ env server per environment)
+│   │   ├── Verifiers::EnvWorker0
+│   │   ├── Verifiers::EnvWorker1
+│   │   └── ...
+│   └── ...
+├── torchrun
+│   └── PRIME-RL::Trainer        (RL trainer, GPU 1+)
+└── tail -F trainer.log
+```
+
 ### Check performance
 
 #### Trainer

--- a/src/prime_rl/entrypoints/inference.py
+++ b/src/prime_rl/entrypoints/inference.py
@@ -8,6 +8,7 @@ from prime_rl.configs.inference import InferenceConfig
 from prime_rl.utils.config import cli
 from prime_rl.utils.logger import setup_logger
 from prime_rl.utils.pathing import format_log_message, get_config_dir, get_log_dir
+from prime_rl.utils.process import set_proc_title
 
 INFERENCE_TOML = "inference.toml"
 INFERENCE_SBATCH = "inference.sbatch"
@@ -137,6 +138,7 @@ def inference(config: InferenceConfig):
 
 
 def main():
+    set_proc_title("Inference")
     inference(cli(InferenceConfig))
 
 

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -15,7 +15,7 @@ from prime_rl.configs.rl import RLConfig
 from prime_rl.utils.config import cli
 from prime_rl.utils.logger import setup_logger
 from prime_rl.utils.pathing import format_log_message, validate_output_dir
-from prime_rl.utils.process import cleanup_processes, cleanup_threads, monitor_process
+from prime_rl.utils.process import cleanup_processes, cleanup_threads, monitor_process, set_proc_title
 from prime_rl.utils.utils import (
     get_free_port,
     get_log_dir,
@@ -535,6 +535,7 @@ def rl(config: RLConfig):
 
 
 def main():
+    set_proc_title("Launcher")
     rl(cli(RLConfig))
 
 

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -171,7 +171,7 @@ def rl_local(config: RLConfig):
     try:
         # Optionally, start inference process
         if config.inference:
-            inference_cmd = ["uv", "run", "inference", "@", (config_dir / INFERENCE_TOML).as_posix()]
+            inference_cmd = ["inference", "@", (config_dir / INFERENCE_TOML).as_posix()]
             logger.info(f"Starting inference on GPU(s) {' '.join(map(str, infer_gpu_ids))}")
             logger.debug(f"Inference start command: {' '.join(inference_cmd)}")
             # If we don't log stdout, the server hangs
@@ -216,7 +216,7 @@ def rl_local(config: RLConfig):
                     "or omit teacher_inference and configure orchestrator.teacher_model to use an existing server."
                 )
 
-            teacher_inference_cmd = ["uv", "run", "inference", "@", (config_dir / TEACHER_INFERENCE_TOML).as_posix()]
+            teacher_inference_cmd = ["inference", "@", (config_dir / TEACHER_INFERENCE_TOML).as_posix()]
             logger.info(f"Starting teacher inference process on GPU(s) {' '.join(map(str, teacher_gpu_ids))}")
             logger.debug(f"Teacher inference start command: {' '.join(teacher_inference_cmd)}")
             with open(log_dir / "teacher_inference.log", "w") as log_file:
@@ -251,8 +251,6 @@ def rl_local(config: RLConfig):
 
         # Start orchestrator process
         orchestrator_cmd = [
-            "uv",
-            "run",
             "orchestrator",
             "@",
             (config_dir / ORCHESTRATOR_TOML).as_posix(),
@@ -288,11 +286,6 @@ def rl_local(config: RLConfig):
 
         # Start training process
         trainer_cmd = [
-            "uv",
-            "run",
-            "env",
-            "PYTHONUNBUFFERED=1",
-            "PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True",
             "torchrun",
             f"--rdzv-endpoint=localhost:{get_free_port()}",
             f"--rdzv-id={uuid.uuid4().hex}",
@@ -317,6 +310,7 @@ def rl_local(config: RLConfig):
                     **wandb_shared_env,
                     "WANDB_SHARED_LABEL": "trainer",
                     "CUDA_VISIBLE_DEVICES": ",".join(map(str, trainer_gpu_ids)),
+                    "PYTHONUNBUFFERED": "1",
                     "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
                     "LOGURU_FORCE_COLORS": "1",
                     "WANDB_PROGRAM": "uv run rl",

--- a/src/prime_rl/entrypoints/sft.py
+++ b/src/prime_rl/entrypoints/sft.py
@@ -114,11 +114,6 @@ def sft_local(config: SFTConfig):
     log_dir.mkdir(parents=True, exist_ok=True)
 
     trainer_cmd = [
-        "uv",
-        "run",
-        "env",
-        "PYTHONUNBUFFERED=1",
-        "PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True",
         "torchrun",
         f"--rdzv-endpoint=localhost:{get_free_port()}",
         f"--rdzv-id={uuid.uuid4().hex}",
@@ -146,6 +141,7 @@ def sft_local(config: SFTConfig):
                 trainer_cmd,
                 env={
                     **os.environ,
+                    "PYTHONUNBUFFERED": "1",
                     "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
                 },
                 stdout=log_file,

--- a/src/prime_rl/entrypoints/sft.py
+++ b/src/prime_rl/entrypoints/sft.py
@@ -12,7 +12,7 @@ from prime_rl.configs.sft import SFTConfig
 from prime_rl.utils.config import cli
 from prime_rl.utils.logger import setup_logger
 from prime_rl.utils.pathing import format_log_message, get_config_dir, get_log_dir, validate_output_dir
-from prime_rl.utils.process import cleanup_processes, cleanup_threads, monitor_process
+from prime_rl.utils.process import cleanup_processes, cleanup_threads, monitor_process, set_proc_title
 from prime_rl.utils.utils import get_free_port
 
 SFT_TOML = "sft.toml"
@@ -203,6 +203,7 @@ def sft(config: SFTConfig):
 
 
 def main():
+    set_proc_title("SFT")
     sft(cli(SFTConfig))
 
 

--- a/src/prime_rl/orchestrator/env_server/env_server.py
+++ b/src/prime_rl/orchestrator/env_server/env_server.py
@@ -6,6 +6,7 @@ from prime_rl.configs.env_server import EnvServerConfig
 from prime_rl.utils.config import cli
 from prime_rl.utils.logger import setup_logger
 from prime_rl.utils.pathing import get_log_dir
+from prime_rl.utils.process import set_proc_title
 from prime_rl.utils.utils import clean_exit, get_env_ids_to_install, install_env, strip_env_version
 
 
@@ -36,6 +37,7 @@ def run_server(config: EnvServerConfig):
 
 def main():
     """Main entry-point for env-server. Run using `uv run env-server`"""
+    set_proc_title("EnvServer")
     run_server(cli(EnvServerConfig))
 
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -66,6 +66,7 @@ from prime_rl.utils.config import cli
 from prime_rl.utils.heartbeat import Heartbeat
 from prime_rl.utils.logger import setup_logger
 from prime_rl.utils.monitor import setup_monitor
+from prime_rl.utils.process import set_proc_title
 from prime_rl.utils.temp_scheduling import compute_temperature
 from prime_rl.utils.utils import (
     clean_exit,
@@ -916,7 +917,7 @@ async def orchestrate(config: OrchestratorConfig):
 
 def main():
     """Main entry-point for orchestrator. Run using `uv run orchestrator`"""
-
+    set_proc_title("Orchestrator")
     asyncio.run(orchestrate(cli(OrchestratorConfig)))
 
 

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -58,6 +58,7 @@ from prime_rl.utils.heartbeat import Heartbeat
 from prime_rl.utils.metrics_server import HealthServer, MetricsServer, RunStats
 from prime_rl.utils.monitor import setup_monitor
 from prime_rl.utils.config import cli
+from prime_rl.utils.process import set_proc_title
 from prime_rl.utils.utils import clean_exit, resolve_latest_ckpt_step, to_col_format
 from ring_flash_attn import substitute_hf_flash_attn
 from torchtitan.distributed.utils import clip_grad_norm_
@@ -647,7 +648,7 @@ def train(config: TrainerConfig):
 
 def main():
     """Main entry-point for RL trainer. Run using `uv run trainer`"""
-
+    set_proc_title("Trainer")
     train(cli(TrainerConfig))
 
 

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -45,6 +45,7 @@ from prime_rl.trainer.world import get_world
 from prime_rl.utils.heartbeat import Heartbeat
 from prime_rl.utils.monitor import setup_monitor
 from prime_rl.utils.config import cli
+from prime_rl.utils.process import set_proc_title
 from prime_rl.utils.utils import clean_exit, to_col_format
 import torch.distributed as dist
 from liger_kernel.transformers.cross_entropy import LigerCrossEntropyLoss
@@ -538,6 +539,7 @@ def train(config: SFTConfig):
 
 
 def main():
+    set_proc_title("SFTTrainer")
     train(cli(SFTConfig))
 
 

--- a/src/prime_rl/utils/process.py
+++ b/src/prime_rl/utils/process.py
@@ -2,6 +2,23 @@ import subprocess
 from subprocess import Popen
 from threading import Event, Thread
 
+import setproctitle
+from loguru import logger
+
+PRIME_RL_PROC_PREFIX = "PRIME-RL"
+
+
+def set_proc_title(name: str) -> None:
+    """Set the process title for visibility in tools like ``ps`` and ``htop``.
+
+    Args:
+        name: A short, descriptive label (e.g. ``Trainer``, ``Orchestrator``).
+              The process title is set to ``{PRIME_RL_PROC_PREFIX}::{name}``.
+    """
+    title = f"{PRIME_RL_PROC_PREFIX}::{name}"
+    setproctitle.setproctitle(title)
+    logger.info(f"Process title set to {title!r}")
+
 
 def cleanup_threads(threads: list[Thread]):
     """Cleanup a list of threads"""

--- a/src/prime_rl/utils/process.py
+++ b/src/prime_rl/utils/process.py
@@ -3,7 +3,6 @@ from subprocess import Popen
 from threading import Event, Thread
 
 import setproctitle
-from loguru import logger
 
 PRIME_RL_PROC_PREFIX = "PRIME-RL"
 
@@ -17,7 +16,6 @@ def set_proc_title(name: str) -> None:
     """
     title = f"{PRIME_RL_PROC_PREFIX}::{name}"
     setproctitle.setproctitle(title)
-    logger.info(f"Process title set to {title!r}")
 
 
 def cleanup_threads(threads: list[Thread]):

--- a/uv.lock
+++ b/uv.lock
@@ -2641,6 +2641,7 @@ dependencies = [
     { name = "pyzmq", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "rich", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "ring-flash-attn", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "setproctitle", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "tenacity", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "tilelang", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "tomli", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -2744,6 +2745,7 @@ requires-dist = [
     { name = "rich", specifier = ">=14.0.0" },
     { name = "ring-flash-attn", specifier = ">=0.1.8" },
     { name = "science-env", marker = "extra == 'envs'", index = "https://hub.primeintellect.ai/primeintellect/simple/" },
+    { name = "setproctitle", specifier = ">=1.3.0" },
     { name = "tenacity", specifier = ">=8.2.0" },
     { name = "tilelang", specifier = ">=0.1.8" },
     { name = "tomli", specifier = ">=2.2.1" },
@@ -2753,7 +2755,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", git = "https://github.com/huggingface/transformers.git?rev=5c1c72b" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=5d75d97" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=e27b68f" },
     { name = "vllm", specifier = ">=0.18.0" },
     { name = "vllm-router", marker = "platform_machine == 'x86_64' and extra == 'disagg'", url = "https://github.com/samsja/flash-attn-builds/releases/download/v0.3/vllm_router-0.1.11-cp38-abi3-linux_x86_64.whl" },
     { name = "wandb", specifier = ">=0.24.2" },
@@ -4003,7 +4005,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.12.dev1"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=5d75d97#5d75d979a6eef05d494acf31348ebcb52cd473ea" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=e27b68f#e27b68f73cc8f6c4430257397df738b3d3b72a73" }
 dependencies = [
     { name = "aiolimiter", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "anthropic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -4023,6 +4025,7 @@ dependencies = [
     { name = "pyzmq", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "requests", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "rich", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "setproctitle", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "tenacity", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "textual", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "wget", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },

--- a/uv.lock
+++ b/uv.lock
@@ -2755,7 +2755,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", git = "https://github.com/huggingface/transformers.git?rev=5c1c72b" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=73deb26" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=adf8138" },
     { name = "vllm", specifier = ">=0.18.0" },
     { name = "vllm-router", marker = "platform_machine == 'x86_64' and extra == 'disagg'", url = "https://github.com/samsja/flash-attn-builds/releases/download/v0.3/vllm_router-0.1.11-cp38-abi3-linux_x86_64.whl" },
     { name = "wandb", specifier = ">=0.24.2" },
@@ -2775,7 +2775,7 @@ mamba-ssm = [{ name = "mamba-ssm", specifier = ">=2.3.0" }]
 
 [[package]]
 name = "prime-sandboxes"
-version = "0.2.16"
+version = "0.2.19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -2785,23 +2785,23 @@ dependencies = [
     { name = "pydantic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "tenacity", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/83/58/fdb9a63f1ea0c793da5e08b283c0eb2a3d986a25953126abd0b9bfa9535a/prime_sandboxes-0.2.16.tar.gz", hash = "sha256:c1a4504d7c094427fee436ad1561e12079c1d607003dd0345d4fead34ae873a8", size = 55606, upload-time = "2026-02-28T00:45:49.118Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/8c/7d8b8013f65d8394094a922bc493eaae09e5e88058f80bd009637ffeff63/prime_sandboxes-0.2.19.tar.gz", hash = "sha256:081cd9ef246d397b4a2fdd77a94679a5f08115ecbbe3f90f320e5f4a7988820e", size = 60558, upload-time = "2026-04-01T00:46:28.212Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/7f/b717338c70a785feef5cb1bdaff46a1f942115a40fcd53df3127dea8c2f7/prime_sandboxes-0.2.16-py3-none-any.whl", hash = "sha256:18ef8b2bd073628bdc979b5a17acb640e5c30d19ab7ec356153b51c8fe3b12a2", size = 26639, upload-time = "2026-02-28T00:45:47.891Z" },
+    { url = "https://files.pythonhosted.org/packages/79/56/9bd4b3733773e6c122ebfe92144476c143666d09d9e8cccb9d1349d4d43c/prime_sandboxes-0.2.19-py3-none-any.whl", hash = "sha256:ce5db7314c007aae796e1ce274181eaa1370000a478bcd55c26149edfee580c1", size = 31617, upload-time = "2026-04-01T00:46:27.216Z" },
 ]
 
 [[package]]
 name = "prime-tunnel"
-version = "0.1.4"
+version = "0.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pydantic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "tenacity", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/50/d4/be7356eab434edd623bc000b5c8d457e98b6feb3eed513b88e7865522178/prime_tunnel-0.1.4.tar.gz", hash = "sha256:caf092ae01be921a17824d14aca3b526f8b5b704f9996dbc6cdcefd40619ca8a", size = 11660, upload-time = "2026-02-27T01:32:15.261Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/d2/17236f43b855a4261252d317ef230beb0571268427418c8d471d3eba195c/prime_tunnel-0.1.5.tar.gz", hash = "sha256:eec296f92abbd761edcb779db7052bf9ce9c3469641f8f17645b7ed5c478257e", size = 12609, upload-time = "2026-03-21T00:52:56.147Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/c3/8def582c17f0f64f31efe11f7a0299139af3120c19fb2937a21c63de48d0/prime_tunnel-0.1.4-py3-none-any.whl", hash = "sha256:8e49715fdcdeed2e761c9b96fc7a94f07e6733ba9bf8e4022f8c46f496998a54", size = 13675, upload-time = "2026-02-27T01:32:13.816Z" },
+    { url = "https://files.pythonhosted.org/packages/66/d2/26c801e0ee8ed867875a704c1fa238581f505bbd96f618c894c8dca991fc/prime_tunnel-0.1.5-py3-none-any.whl", hash = "sha256:fc24bf60d8023f53850be9602dc7d0e1be3e091a019a06c65d32a6b3d61754af", size = 14758, upload-time = "2026-03-21T00:52:55.278Z" },
 ]
 
 [[package]]
@@ -4005,7 +4005,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.12.dev1"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=73deb26#73deb26ba27981e5852bfe54b25718945160a4c7" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=adf8138#adf81382fedcc5a137db6eb8c7a1d73865246f9e" }
 dependencies = [
     { name = "aiolimiter", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "anthropic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },

--- a/uv.lock
+++ b/uv.lock
@@ -2755,7 +2755,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", git = "https://github.com/huggingface/transformers.git?rev=5c1c72b" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=e27b68f" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=73deb26" },
     { name = "vllm", specifier = ">=0.18.0" },
     { name = "vllm-router", marker = "platform_machine == 'x86_64' and extra == 'disagg'", url = "https://github.com/samsja/flash-attn-builds/releases/download/v0.3/vllm_router-0.1.11-cp38-abi3-linux_x86_64.whl" },
     { name = "wandb", specifier = ">=0.24.2" },
@@ -4005,7 +4005,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.12.dev1"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=e27b68f#e27b68f73cc8f6c4430257397df738b3d3b72a73" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=73deb26#73deb26ba27981e5852bfe54b25718945160a4c7" }
 dependencies = [
     { name = "aiolimiter", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "anthropic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },


### PR DESCRIPTION
## Summary
- Adds `setproctitle` dependency and `set_proc_title` utility to label all prime-rl processes (`PRIME-RL::Launcher`, `PRIME-RL::Inference`, `PRIME-RL::Orchestrator`, `PRIME-RL::Trainer`, etc.)
- Removes intermediate `uv run` wrappers from local launchers — child processes now invoke entrypoints directly since the venv is already resolved by the parent
- Bumps verifiers pin to include companion PR PrimeIntellect-ai/verifiers#1082 which labels env server/worker processes (`Verifiers::EnvServer`, `Verifiers::EnvWorker{N}`)
- Updates the `monitor-run` skill with process tree documentation

Process tree of a single-node RL run (`pstree -ap <pid> | grep -v '{.*}'`):

```
uv run rl @ config.toml
└── PRIME-RL::Launcher
    ├── PRIME-RL::Inference
    │   ├── VLLM::EngineCore
    │   └── python3 (resource_tracker)
    ├── PRIME-RL::Orchestrator
    │   ├── Verifiers::EnvServer
    │   │   └── Verifiers::EnvWorker0
    │   ├── python3 (resource_tracker)
    │   └── wandb-core → gpu_stats
    ├── torchrun (pt_elastic)
    │   └── PRIME-RL::Trainer
    │       └── wandb-core → gpu_stats
    └── tail -F trainer.log
```

Companion: PrimeIntellect-ai/verifiers#1082

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate operational risk because changing how subprocesses are invoked (removing `uv run` wrappers) can affect environment/entrypoint resolution and runtime behavior; process-title changes themselves are low impact.
> 
> **Overview**
> Adds process naming across prime-rl by introducing `setproctitle` + a `set_proc_title()` helper and calling it from all major entrypoints (launcher, SFT/inference/orchestrator/env-server, and both trainers) so process trees are easier to inspect.
> 
> Simplifies local launchers by removing `uv run ...` wrappers when spawning child processes (now invoking `inference`/`orchestrator` directly and moving `PYTHONUNBUFFERED`/CUDA alloc settings into the subprocess `env`). Also bumps the pinned `verifiers` revision and updates the `monitor-run` skill docs with the new process-title conventions and example `ps`/`pstree` commands.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e568868898cdf914b9dd6355f23f20f476c3aea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->