### PR TITLE
clean up some metrics

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -724,7 +724,6 @@ async def orchestrate(config: OrchestratorConfig):
             "decode_len/all/min": by_example.decode_len.mean().min(),
             "is_truncated/all/mean": by_example.is_truncated.mean().mean(),
             "is_truncated/all/max": by_example.is_truncated.mean().max(),
-            "is_truncated/all/min": by_example.is_truncated.mean().min(),
             "stop_condition/all/generation_truncated": (
                 results_df.is_truncated & (results_df.stop_condition != "prompt_too_long")
             ).mean(),
@@ -789,7 +788,8 @@ async def orchestrate(config: OrchestratorConfig):
             for col in per_env_columns:
                 to_log[f"{col}/{env}/mean"] = env_by_example[col].mean().mean()
                 to_log[f"{col}/{env}/max"] = env_by_example[col].mean().max()
-                to_log[f"{col}/{env}/min"] = env_by_example[col].mean().min()
+                if col != "is_truncated":
+                    to_log[f"{col}/{env}/min"] = env_by_example[col].mean().min()
             to_log[f"reward/{env}/mean"] = env_by_example.reward.mean().mean()
             to_log[f"reward/{env}/max"] = env_by_example.reward.mean().max()
             to_log[f"reward/{env}/min"] = env_by_example.reward.mean().min()

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -483,13 +483,6 @@ class Scheduler:
         return max(steps)
 
     @property
-    def min_off_policy_level(self) -> int:
-        steps = [info.off_policy_steps for info in self.inflight_requests.values()]
-        if not steps:
-            return 0
-        return min(steps)
-
-    @property
     def mean_off_policy_level(self) -> float:
         steps = [info.off_policy_steps for info in self.inflight_requests.values()]
         if not steps:
@@ -513,7 +506,6 @@ class Scheduler:
             "errored_rollouts/all": sum(self.errored_rollouts_by_task.values()) / max(total_rollouts, 1),
             "off_policy_level/all/max": self.max_off_policy_level,
             "off_policy_level/all/mean": self.mean_off_policy_level,
-            "off_policy_level/all/min": self.min_off_policy_level,
         }
         for task, count in self.empty_rollouts_by_task.items():
             task_total = max(self.total_rollouts_by_task[task], 1)
@@ -527,7 +519,6 @@ class Scheduler:
         for task, steps in by_task.items():
             metrics[f"off_policy_level/{task}/max"] = max(steps)
             metrics[f"off_policy_level/{task}/mean"] = sum(steps) / len(steps)
-            metrics[f"off_policy_level/{task}/min"] = min(steps)
         self.cancelled_rollouts_count = 0
         self.empty_rollouts_by_task.clear()
         self.errored_rollouts_by_task.clear()

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -45,6 +45,7 @@ from prime_rl.trainer.utils import (
     MemoryProfiler,
     Tensors,
     export_benchmark_json,
+    filter_rl_trainer_tensor_stats_for_wandb,
     get_zero_gradient_ratio,
     get_ckpt_disk_metrics,
     setup_torch_distributed,
@@ -440,8 +441,6 @@ def train(config: TrainerConfig):
                 loss.backward()
 
             # Add relevant tensors to tensor dict for logging purposes
-            tensors["trainer_probs"].append(torch.exp(out["logprobs"])[loss_mask].detach().to("cpu"))
-            tensors["inference_probs"].append(torch.exp(inference_logprobs)[loss_mask].detach().to("cpu"))
             tensors["entropy"].append(out["entropy"][loss_mask].detach().to("cpu"))
             tensors["loss"].append(loss.detach().to("cpu").unsqueeze(0))
 
@@ -539,9 +538,8 @@ def train(config: TrainerConfig):
         if mismatch_kl_mean is not None and entropy_mean > 0:
             tensor_stats["kl_ent_ratio/mean"] = mismatch_kl_mean / entropy_mean
 
-        # Log tensor stats
         tensor_stats["step"] = progress.step
-        monitor.log(tensor_stats, step=progress.step)
+        monitor.log(filter_rl_trainer_tensor_stats_for_wandb(tensor_stats), step=progress.step)
 
         # Log time metrics
         time_metrics = {

--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -382,6 +382,33 @@ class Tensors(defaultdict):
         return metrics
 
 
+def filter_rl_trainer_tensor_stats_for_wandb(metrics: dict[str, float | int]) -> dict[str, float | int]:
+    """Drop noisy per-token distribution keys before sending RL trainer stats to W&B."""
+    skip_prefixes = ("trainer_probs/", "inference_probs/")
+    mean_max_only_prefixes = (
+        "is_masked/",
+        "is_masked_low/",
+        "is_masked_high/",
+        "mismatch_kl/",
+        "masked_mismatch_kl/",
+        "unmasked_mismatch_kl/",
+    )
+    out: dict[str, float | int] = {}
+    for k, v in metrics.items():
+        if k == "step":
+            out[k] = v
+            continue
+        if any(k.startswith(p) for p in skip_prefixes):
+            continue
+        if k.startswith("entropy/") and k != "entropy/mean":
+            continue
+        if any(k.startswith(p) for p in mean_max_only_prefixes):
+            if not (k.endswith("/mean") or k.endswith("/max")):
+                continue
+        out[k] = v
+    return out
+
+
 MEMORY_SNAPSHOT_MAX_ENTRIES = 100000
 
 


### PR DESCRIPTION
Removed these metrics:
trainer_probs (all metrics with it)
inference_probs (all metrics with it)
off_policy_level min
is_truncated min
is_masked (all except for mean and max)
is_masked_low (all except for mean and max)
is_masked_high (all except for mean and max)
entropy (all except for mean)
mismatch_kl (all except for mean and max)
masked_mismatch_kl (all except for mean and max)
unmasked_mismatch_kl (all except for mean and max)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only affect which metrics are emitted to logging/monitoring (W&B), not training/scheduling behavior. Main risk is dashboards/alerts that depended on removed `min`/distribution metrics.
> 
> **Overview**
> **Cleans up monitoring metrics to reduce noise and payload size.**
> 
> In the orchestrator, drops `is_truncated` `min` logging (both overall and per-task), and in the scheduler removes `off_policy_level` `min` metrics (including deleting the `min_off_policy_level` property).
> 
> In the RL trainer, stops collecting/logging `trainer_probs` and `inference_probs`, and adds `filter_rl_trainer_tensor_stats_for_wandb()` to strip noisy tensor-stat keys (e.g. non-mean `entropy`, and non-`mean`/`max` variants for `is_masked*` and `*mismatch_kl*`) before sending stats to W&B.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c240eee49fcbcbbca8b1342b6b922f84b32d04b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->