### PR TITLE
chore: simplify tmux script windows

### DIFF
--- a/scripts/tmux.sh
+++ b/scripts/tmux.sh
@@ -58,8 +58,11 @@ fi
 
 echo "Creating new tmux session: $SESSION_NAME"
 
+# Window 0: Command - empty shell
+tmux new-session -d -s "$SESSION_NAME" -n "Command"
+
 # Window 1: Logs - 4 vertical panes
-tmux new-session -d -s "$SESSION_NAME" -n "Logs"
+tmux new-window -t "$SESSION_NAME" -n "Logs"
 
 tmux split-window -v -t "$SESSION_NAME:Logs.0"
 tmux split-window -v -t "$SESSION_NAME:Logs.1"
@@ -83,22 +86,10 @@ tmux send-keys -t "$SESSION_NAME:Logs.2" \
 tmux send-keys -t "$SESSION_NAME:Logs.3" \
   "tail -F ${LOG_DIR}/inference.log 2>/dev/null" C-m
 
-# Window 2: Monitor
-tmux new-window -t "$SESSION_NAME" -n "Monitor"
-tmux split-window -h -t "$SESSION_NAME:Monitor"
-tmux select-layout -t "$SESSION_NAME:Monitor" even-horizontal
-
-tmux select-pane -t "$SESSION_NAME:Monitor.0" -T "GPU"
-tmux send-keys -t "$SESSION_NAME:Monitor.0" "nvtop" C-m
-
-tmux select-pane -t "$SESSION_NAME:Monitor.1" -T "CPU"
-tmux send-keys -t "$SESSION_NAME:Monitor.1" "htop" C-m
-
 # Pane title styling
 tmux set-option -t "$SESSION_NAME" -g pane-border-status top
 tmux set-option -t "$SESSION_NAME" -g pane-border-format " #{pane_title} "
 
-# Focus logs window and attach
-tmux select-window -t "$SESSION_NAME:Logs"
-tmux select-pane -t "$SESSION_NAME:Logs.0"
+# Focus command window and attach
+tmux select-window -t "$SESSION_NAME:Command"
 exec tmux attach-session -t "$SESSION_NAME"

--- a/scripts/tmux.sh
+++ b/scripts/tmux.sh
@@ -89,7 +89,7 @@ tmux send-keys -t "$SESSION_NAME:Logs.3" \
 # Window 2: Claude Code with log context
 tmux new-window -t "$SESSION_NAME" -n "Claude"
 tmux send-keys -t "$SESSION_NAME:Claude" \
-  "claude --append-system-prompt 'You are monitoring a prime-rl training run. The output directory is ${OUTPUT_DIR}. Log paths:
+  "claude --permission-mode auto --append-system-prompt 'You are monitoring a prime-rl training run. The output directory is ${OUTPUT_DIR}. Log paths:
   Trainer:        ${LOG_DIR}/trainer.log
   All nodes:      ${LOG_DIR}/trainer/node_*.log
   All ranks:      ${LOG_DIR}/trainer/torchrun/*/*/*/*.log

--- a/scripts/tmux.sh
+++ b/scripts/tmux.sh
@@ -58,8 +58,8 @@ fi
 
 echo "Creating new tmux session: $SESSION_NAME"
 
-# Window 0: Command - empty shell
-tmux new-session -d -s "$SESSION_NAME" -n "Command"
+# Window 0: Launcher - empty shell
+tmux new-session -d -s "$SESSION_NAME" -n "Launcher"
 
 # Window 1: Logs - 4 vertical panes
 tmux new-window -t "$SESSION_NAME" -n "Logs"
@@ -90,6 +90,6 @@ tmux send-keys -t "$SESSION_NAME:Logs.3" \
 tmux set-option -t "$SESSION_NAME" -g pane-border-status top
 tmux set-option -t "$SESSION_NAME" -g pane-border-format " #{pane_title} "
 
-# Focus command window and attach
-tmux select-window -t "$SESSION_NAME:Command"
+# Focus launcher window and attach
+tmux select-window -t "$SESSION_NAME:Launcher"
 exec tmux attach-session -t "$SESSION_NAME"

--- a/scripts/tmux.sh
+++ b/scripts/tmux.sh
@@ -86,6 +86,19 @@ tmux send-keys -t "$SESSION_NAME:Logs.2" \
 tmux send-keys -t "$SESSION_NAME:Logs.3" \
   "tail -F ${LOG_DIR}/inference.log 2>/dev/null" C-m
 
+# Window 2: Claude Code with log context
+tmux new-window -t "$SESSION_NAME" -n "Claude"
+tmux send-keys -t "$SESSION_NAME:Claude" \
+  "claude --append-system-prompt 'You are monitoring a prime-rl training run. The output directory is ${OUTPUT_DIR}. Log paths:
+  Trainer:        ${LOG_DIR}/trainer.log
+  All nodes:      ${LOG_DIR}/trainer/node_*.log
+  All ranks:      ${LOG_DIR}/trainer/torchrun/*/*/*/*.log
+  Orchestrator:   ${LOG_DIR}/orchestrator.log
+  Inference:      ${LOG_DIR}/inference.log
+  Envs:           ${LOG_DIR}/envs/*/*/*.log
+  Train envs:     ${LOG_DIR}/envs/train/*/*.log
+Help the user monitor and debug this run.'" C-m
+
 # Pane title styling
 tmux set-option -t "$SESSION_NAME" -g pane-border-status top
 tmux set-option -t "$SESSION_NAME" -g pane-border-format " #{pane_title} "

--- a/scripts/tmux.sh
+++ b/scripts/tmux.sh
@@ -97,6 +97,7 @@ tmux send-keys -t "$SESSION_NAME:Claude" \
   Inference:      ${LOG_DIR}/inference.log
   Envs:           ${LOG_DIR}/envs/*/*/*.log
   Train envs:     ${LOG_DIR}/envs/train/*/*.log
+You are running inside tmux session \"${SESSION_NAME}\". The Launcher window (window 0) is where the user runs launch commands. You can read its contents with: tmux capture-pane -t ${SESSION_NAME}:Launcher -p
 Help the user monitor and debug this run.'" C-m
 
 # Pane title styling


### PR DESCRIPTION
## Summary
- Add a **Launcher** window (window 0) as an empty shell for running commands
- Remove the **Monitor** window (nvtop/htop)
- Add a **Claude** window (window 2) that starts an interactive Claude Code session in auto mode with log paths and tmux session awareness injected via `--append-system-prompt`
- **Logs** window (window 1) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to a developer tmux helper script; main risk is local workflow breakage if `claude` isn’t installed or the long `send-keys` command/prompt quoting behaves unexpectedly.
> 
> **Overview**
> Reworks the tmux session layout in `scripts/tmux.sh` by adding a new **Launcher** window as window 0 (empty shell) and shifting the existing **Logs** window to be created via `new-window`.
> 
> Removes the prior **Monitor** window that auto-ran `nvtop`/`htop`, and adds a new **Claude** window that starts `claude` in auto permission mode with an injected system prompt containing output/log paths and tmux session/Launcher capture instructions; the script now focuses the Launcher window before attaching.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73faa5514c5f2818e631153ceda741ce2e860f66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->