### PR TITLE
docs: add note about bool | None CLI syntax

### DIFF
--- a/skills/config/SKILL.md
+++ b/skills/config/SKILL.md
@@ -81,6 +81,13 @@ uv run inference --model.enforce-eager          # sets to true
 uv run inference --model.no-enforce-eager       # sets to false
 ```
 
+For `bool | None` fields (e.g. `wandb.offline`), the `--no-flag` toggle syntax does **not** work. Pass the value explicitly instead:
+
+```bash
+uv run rl @ config.toml --wandb.offline true    # sets to true
+uv run rl @ config.toml --wandb.offline false   # sets to false
+```
+
 In TOML, booleans must be explicit:
 
 ```toml


### PR DESCRIPTION
## Summary

- Documents that `bool | None` config fields don't support the `--no-flag` toggle syntax
- Users must pass the value explicitly: `--wandb.offline true` / `--wandb.offline false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)