### PR TITLE
fix: update CI Docker image to CUDA 13.0

### DIFF
--- a/.github/workflows/gpu_tests.yaml
+++ b/.github/workflows/gpu_tests.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Unit tests
     runs-on: vm
     container:
-      image: pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel
+      image: pytorch/pytorch:2.10.0-cuda13.0-cudnn9-devel
       options: --gpus all
     timeout-minutes: 45
     if: github.event_name == 'push' || github.event.pull_request.draft == false
@@ -55,7 +55,7 @@ jobs:
     name: Integration tests (${{ matrix.test }})
     runs-on: ${{ matrix.runner }}
     container:
-      image: pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel
+      image: pytorch/pytorch:2.10.0-cuda13.0-cudnn9-devel
       options: --gpus all
     timeout-minutes: 60
     if: github.event_name == 'push' || github.event.pull_request.draft == false

--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -56,7 +56,7 @@ jobs:
         needs: discover-experiments
         runs-on: research-cluster
         container:
-            image: pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel
+            image: pytorch/pytorch:2.10.0-cuda13.0-cudnn9-devel
             options: --gpus all
         timeout-minutes: 1440 # 24 hours
         strategy:


### PR DESCRIPTION
## Summary
- Updates CI container image from `pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel` to `pytorch/pytorch:2.10.0-cuda13.0-cudnn9-devel` across all GPU workflows (gpu_tests, nightly_tests)
- The `deep-gemm` wheel (added via the `disagg` extra) requires `libcudart.so.13`, which doesn't exist in the CUDA 12.4 image, causing the inference server to crash on startup with `ImportError: libcudart.so.13: cannot open shared object file`
- The lockfile pins `torch 2.10.0+cu128`, so the new image also aligns the base PyTorch version

Manually tested running reverse text from a fresh clone inside this container

<img width="1485" height="796" alt="Screenshot 2026-04-01 at 1 43 07 PM" src="https://github.com/user-attachments/assets/727bbc87-832d-4a19-9d07-3089bc3cfb6a" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the base runtime (CUDA/PyTorch) for all GPU CI jobs, which can surface new dependency or driver compatibility issues despite no application code changes.
> 
> **Overview**
> **Upgrades GPU CI runtime to CUDA 13.0.** The `gpu_tests` (unit + integration) and `nightly_tests` workflows switch their container image from `pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel` to `pytorch/pytorch:2.10.0-cuda13.0-cudnn9-devel`, aligning GPU CI with newer CUDA/PyTorch libraries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fce70ae0139646cc9af5c4d29ba10bbb886babe9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->