### PR TITLE
chore: strip [default0] prefix from trainer logs

### DIFF
--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -296,6 +296,7 @@ def rl_local(config: RLConfig):
         # Start training process
         trainer_cmd = [
             "torchrun",
+            "--role=trainer",
             f"--rdzv-endpoint=localhost:{get_free_port()}",
             f"--rdzv-id={uuid.uuid4().hex}",
             # Pipe all logs to file, and only master rank logs to stdout
@@ -342,7 +343,10 @@ def rl_local(config: RLConfig):
         # Monitor all processes for failures
         logger.success("Startup complete. Showing trainer logs...")
 
-        tail_process = Popen(["tail", "-F", log_dir / "trainer.log"])
+        tail_process = Popen(
+            f"tail -F '{log_dir / 'trainer.log'}' | sed -u 's/^\\[[a-zA-Z]*[0-9]*\\]://'",
+            shell=True,
+        )
         processes.append(tail_process)
 
         # Check for errors from monitor threads

--- a/src/prime_rl/entrypoints/sft.py
+++ b/src/prime_rl/entrypoints/sft.py
@@ -115,6 +115,7 @@ def sft_local(config: SFTConfig):
 
     trainer_cmd = [
         "torchrun",
+        "--role=trainer",
         f"--rdzv-endpoint=localhost:{get_free_port()}",
         f"--rdzv-id={uuid.uuid4().hex}",
         f"--log-dir={config.output_dir / 'logs' / 'trainer' / 'torchrun'}",
@@ -159,7 +160,10 @@ def sft_local(config: SFTConfig):
         monitor_threads.append(monitor_thread)
 
         logger.success("Startup complete. Showing trainer logs...")
-        tail_process = Popen(["tail", "-F", str(log_dir / "trainer.log")])
+        tail_process = Popen(
+            f"tail -F '{log_dir / 'trainer.log'}' | sed -u 's/^\\[[a-zA-Z]*[0-9]*\\]://'",
+            shell=True,
+        )
         processes.append(tail_process)
 
         stop_event.wait()

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -342,6 +342,7 @@ else
     echo $HOSTNAMES_STR | tee $OUTPUT_DIR/logs/trainer/node_${TRAIN_NODE_RANK}.log
 
     {% if wandb_shared %}WANDB_SHARED_LABEL=trainer {% endif %}uv run torchrun \
+        --role=trainer \
         --nnodes=$NUM_TRAIN_NODES \
         --nproc-per-node=$GPUS_PER_NODE \
         --node-rank=$TRAIN_NODE_RANK \
@@ -353,6 +354,6 @@ else
         --local-ranks-filter={{ ranks_filter }} \
         -m prime_rl.trainer.rl.train \
         @ $CONFIG_DIR/trainer.toml \
-        2>&1 | tee -a $OUTPUT_DIR/logs/trainer/node_${TRAIN_NODE_RANK}.log
+        2>&1 | sed -u 's/^\[[a-zA-Z]*[0-9]*\]://' | tee -a $OUTPUT_DIR/logs/trainer/node_${TRAIN_NODE_RANK}.log
 {% if num_infer_nodes > 0 %}    fi{% endif %}
 '

--- a/src/prime_rl/templates/multi_node_sft.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_sft.sbatch.j2
@@ -82,6 +82,7 @@ srun bash -c '
 
     echo $HOSTNAMES | tee $OUTPUT_DIR/logs/trainer/node_${TRAIN_NODE_RANK}.log
     uv run torchrun \
+        --role=trainer \
         --nnodes=$NUM_NODES \
         --nproc-per-node=$GPUS_PER_NODE \
         --node-rank=$TRAIN_NODE_RANK \
@@ -93,5 +94,5 @@ srun bash -c '
         --local-ranks-filter={{ ranks_filter }} \
         -m prime_rl.trainer.sft.train \
         @ $CONFIG_PATH \
-        2>&1 | tee -a $OUTPUT_DIR/logs/trainer/node_${TRAIN_NODE_RANK}.log
+        2>&1 | sed -u 's/^\[[a-zA-Z]*[0-9]*\]://' | tee -a $OUTPUT_DIR/logs/trainer/node_${TRAIN_NODE_RANK}.log
 '


### PR DESCRIPTION
## Summary
- Strip the `[default0]:` prefix that torchrun's `--tee` flag prepends to every log line (note, that these can still be seen for in the per-rank logs)
- Uses `sed -u` in the tail/tee pipelines to remove the prefix in real-time
- Also sets `--role=trainer` for clearer per-rank log files in the torchrun log directory
- Applied to both local launchers (rl.py, sft.py) and SLURM templates

**Before:**
```
[default0]:00:19:20    INFO Starting training loop (max_steps=100)
[default0]:00:20:21 SUCCESS Step 0 | Time: 60.98s | Loss: 0.0000 | ...
```

**After:**
```
00:19:20    INFO Starting training loop (max_steps=100)
00:20:21 SUCCESS Step 0 | Time: 60.98s | Loss: 0.0000 | ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only changes that adjust `torchrun` args and shell pipelines; main risk is portability/quoting issues when spawning `shell=True` or running on systems without compatible `sed`.
> 
> **Overview**
> Trainer launch commands now pass `torchrun --role=trainer` so per-rank log files are labeled more clearly.
> 
> For both local (`rl.py`, `sft.py`) and multi-node SLURM templates, the displayed/tee’d trainer log stream is piped through `sed -u` to strip the leading `[...]` rank prefix (e.g., `[default0]:`) while keeping the underlying per-rank torchrun logs intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0332018eac7615dca88e27f84050a9bcef803fa6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->