### PR TITLE
[Feat] packer logging

### DIFF
--- a/src/prime_rl/trainer/rl/packer.py
+++ b/src/prime_rl/trainer/rl/packer.py
@@ -232,13 +232,6 @@ class MultiPacker(BasePacker):
         selected: list[tuple[int, TrainingSample, int]] = []
         tokens_collected = 0
 
-        buffer_lens = {
-            self.multi_run_manager.idx_2_id[
-                idx
-            ]: f"{len(self.buffers[idx])} {self.multi_run_manager.progress[idx].step}"
-            for idx in self.multi_run_manager.used_idxs
-        }
-        self.logger.debug(f"Buffer lengths: {buffer_lens}, round_robin_position: {self._round_robin_position}")
         while tokens_collected < token_budget:
             # Round-robin until we find a run with work for the current step
             for _ in range(len(self.buffers)):

--- a/src/prime_rl/trainer/rl/packer.py
+++ b/src/prime_rl/trainer/rl/packer.py
@@ -232,6 +232,13 @@ class MultiPacker(BasePacker):
         selected: list[tuple[int, TrainingSample, int]] = []
         tokens_collected = 0
 
+        buffer_lens = {
+            self.multi_run_manager.idx_2_id[
+                idx
+            ]: f"{len(self.buffers[idx])} {self.multi_run_manager.progress[idx].step}"
+            for idx in self.multi_run_manager.used_idxs
+        }
+        self.logger.debug(f"Buffer lengths: {buffer_lens}, round_robin_position: {self._round_robin_position}")
         while tokens_collected < token_budget:
             # Round-robin until we find a run with work for the current step
             for _ in range(len(self.buffers)):

--- a/src/prime_rl/trainer/rl/packer.py
+++ b/src/prime_rl/trainer/rl/packer.py
@@ -288,6 +288,13 @@ class MultiPacker(BasePacker):
         self.multi_run_manager.progress[run_idx].total_tokens += num_tokens
         self.multi_run_manager.progress[run_idx].total_samples += num_samples
 
+    def get_buffer_stats(self) -> tuple[dict[str, int], int]:
+        """Return per-run buffer lengths and round-robin position for metrics."""
+        buffer_lens = {
+            self.multi_run_manager.idx_2_id[idx]: len(self.buffers[idx]) for idx in self.multi_run_manager.used_idxs
+        }
+        return buffer_lens, self._round_robin_position
+
     def pack(self):
         """Pack samples from buffers using round-robin fair scheduling."""
         self._get_batch()

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -17,6 +17,7 @@ from prime_rl.trainer.optim import setup_optimizer, setup_multi_optimizer
 from prime_rl.trainer.scheduler import setup_scheduler, setup_multi_scheduler
 from prime_rl.configs.trainer import TrainerConfig
 from prime_rl.trainer.rl.data import DataLoader, FakeDataLoader
+from prime_rl.trainer.rl.packer import MultiPacker
 from prime_rl.utils.cp import (
     gather_for_cp,
     gather_for_cp_wo_grad,
@@ -596,6 +597,9 @@ def train(config: TrainerConfig):
                 runs_max=multi_run_manager.max_runs,
                 run_stats=run_stats,
             )
+            if isinstance(dataloader, DataLoader) and isinstance(dataloader.packer, MultiPacker):
+                buffer_lengths, rr_pos = dataloader.packer.get_buffer_stats()
+                metrics_server.update_packer(buffer_lengths, rr_pos)
 
         progress.step += 1
         is_first_step = False

--- a/src/prime_rl/utils/metrics_server.py
+++ b/src/prime_rl/utils/metrics_server.py
@@ -143,8 +143,16 @@ class MetricsServer(HealthServer):
             ["run"],
             registry=self._registry,
         )
+        # Packer metrics
+        self._packer_buffer_length = Gauge(
+            "trainer_packer_buffer_length", "Number of samples in packer buffer", ["run"], registry=self._registry
+        )
+        self._packer_round_robin_position = Gauge(
+            "trainer_packer_round_robin_position", "Current round-robin index in packer", registry=self._registry
+        )
         # Track known run labels for cleanup
         self._known_runs: set[str] = set()
+        self._known_packer_runs: set[str] = set()
 
     def _make_handler(self) -> type[BaseHTTPRequestHandler]:
         """Create handler with /metrics and /health endpoints."""
@@ -256,3 +264,21 @@ class MetricsServer(HealthServer):
             self._run_ready.labels(run=run.run_id).set(1 if run.ready else 0)
 
         self._known_runs = current_runs
+
+    def update_packer(self, buffer_lengths: dict[str, int], round_robin_position: int) -> None:
+        """Update packer buffer metrics.
+
+        Args:
+            buffer_lengths: Mapping of run_id to number of buffered samples
+            round_robin_position: Current round-robin index
+        """
+        self._packer_round_robin_position.set(round_robin_position)
+
+        current_runs = set(buffer_lengths.keys())
+        for run_id in self._known_packer_runs - current_runs:
+            self._packer_buffer_length.remove(run_id)
+
+        for run_id, length in buffer_lengths.items():
+            self._packer_buffer_length.labels(run=run_id).set(length)
+
+        self._known_packer_runs = current_runs


### PR DESCRIPTION
This should make what the packer is doing more observable and we can see if there's heavy backlog

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk observability change: adds new Prometheus gauges and a small trainer-side hook to report packer buffer sizes/round-robin state, with no impact to training logic beyond metrics emission.
> 
> **Overview**
> Improves multi-run packer observability by exporting **per-run buffer backlog** and the packer’s **round-robin position** as Prometheus metrics.
> 
> `MultiPacker` now exposes `get_buffer_stats()`, the training loop conditionally reports these stats to `MetricsServer`, and `metrics_server.py` adds/cleans up the new `trainer_packer_buffer_length{run=...}` and `trainer_packer_round_robin_position` gauges.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9701bfec1fb75438791be0f526da7e5e1bf1dc35. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->