### PR TITLE
fix: always log per-task error and empty rollout metrics

### DIFF
--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -507,12 +507,10 @@ class Scheduler:
             "off_policy_level/all/max": self.max_off_policy_level,
             "off_policy_level/all/mean": self.mean_off_policy_level,
         }
-        for task, count in self.empty_rollouts_by_task.items():
+        for task in self.total_rollouts_by_task:
             task_total = max(self.total_rollouts_by_task[task], 1)
-            metrics[f"empty_rollouts/{task}"] = count / task_total
-        for task, count in self.errored_rollouts_by_task.items():
-            task_total = max(self.total_rollouts_by_task[task], 1)
-            metrics[f"errored_rollouts/{task}"] = count / task_total
+            metrics[f"empty_rollouts/{task}"] = self.empty_rollouts_by_task.get(task, 0) / task_total
+            metrics[f"errored_rollouts/{task}"] = self.errored_rollouts_by_task.get(task, 0) / task_total
         by_task: dict[str, list[int]] = {}
         for info in self.inflight_requests.values():
             by_task.setdefault(info.task, []).append(info.off_policy_steps)


### PR DESCRIPTION
## Summary
- Per-task `errored_rollouts/{task}` and `empty_rollouts/{task}` metrics were silently missing from logs when a task had zero errors/empties, because the code iterated over the error/empty dicts directly
- Now iterates over `total_rollouts_by_task` so every task always emits a 0 value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only metric aggregation/iteration so per-task counters are logged even when zero, without affecting rollout scheduling or data flow.
> 
> **Overview**
> Ensures per-task `empty_rollouts/{task}` and `errored_rollouts/{task}` metrics are always emitted by iterating over `total_rollouts_by_task` and defaulting missing counts to `0`, instead of only logging tasks that had nonzero empty/error counts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a14c2036277107506bce0bf797c6dabde3706759. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->