### PR TITLE
chore: scope changelog + bugbot to breaking changes only

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -2,10 +2,16 @@
 
 ## Changelog Enforcement
 
-Any PR that modifies configuration structures or usage patterns must update `CHANGELOG.md`. This includes changes to config fields (added, removed, renamed, moved, or default value changes) in:
+Any PR that introduces **breaking** configuration changes must update `CHANGELOG.md`. Breaking changes are those that require users to update existing configs:
 
-- `src/prime_rl/*/config.py`
-- `src/prime_rl/rl.py`
-- `src/prime_rl/utils/config.py`
+- **Renamed** config fields (old name no longer accepted)
+- **Removed** config fields (field deleted or moved to a different path)
+- **Moved** config fields (field relocated in the config hierarchy)
 
-If such changes are detected without a corresponding `CHANGELOG.md` update, request that the author add an entry.
+Additive changes (new fields with defaults, new optional features) and default value changes do **not** require a changelog entry.
+
+Config files live in:
+
+- `src/prime_rl/configs/`
+
+If breaking changes are detected without a corresponding `CHANGELOG.md` update, request that the author add an entry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-Documenting changes which affect configuration usage patterns (added/moved/removed/renamed fields, notable logic changes).
+Documenting **breaking** configuration changes — renamed, removed, or moved fields that require users to update existing configs.
 
 - **`log.file` and `log.env_worker_logs` removed**: Removed `log.file` (from `LogConfig` and `SharedLogConfig`) and `log.env_worker_logs` (from `LogConfig`). Python file logging is replaced by deployment-level capture. Existing configs using these fields must delete them. Log paths unified: `.stdout` files renamed to `.log`, SLURM logs moved from `slurm/` to `logs/`. (2026-03-31)
 - **`trainer.log.ranks_filter` (NEW)**: Added `ranks_filter: list[int]` to `TrainerLogConfig` (default: `[0]`). Controls which ranks appear in trainer console output via torchrun's `--local-ranks-filter`. (2026-03-31)


### PR DESCRIPTION
## Summary

- Narrows `CHANGELOG.md` scope to **breaking** config changes only (renames, removals, moves) — not additive features or default tweaks
- Updates `.cursor/BUGBOT.md` rule to match, with clearer criteria and updated config paths (`src/prime_rl/configs/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adjusts contribution/enforcement guidance but does not modify runtime behavior.
> 
> **Overview**
> Updates `.cursor/BUGBOT.md` to require `CHANGELOG.md` entries only for **breaking** config changes (renamed/removed/moved fields), explicitly excluding additive fields and default tweaks, and points to the current config location `src/prime_rl/configs/`.
> 
> Tweaks the `CHANGELOG.md` header/description to match this narrower **breaking-changes-only** scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8367349cf69e7d11b2499edd1f877e957c026fae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->