### PR TITLE
feat: add vllm-metrics-tui optional dependency and tmux integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,9 @@ disagg = [
     "nixl-cu12 ; platform_machine == 'x86_64'",
     "vllm-router ; platform_machine == 'x86_64'",
 ]
+tui = [
+    "vllm-metrics-tui",
+]
 quack = [
     "quack-kernels>=0.3.3",
 ]
@@ -127,6 +130,7 @@ transformers = { git = "https://github.com/huggingface/transformers.git", rev = 
 flash-attn-4 = { git = "https://github.com/Dao-AILab/flash-attention.git", subdirectory = "flash_attn/cute", rev = "abd9943b" }
 pydantic-config = { git = "https://github.com/samsja/pydantic_config.git", branch = "main" }
 vllm-router = { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.14/vllm_router-0.1.14-cp38-abi3-linux_x86_64.whl" }
+vllm-metrics-tui = { git = "https://github.com/samsja/vllm-metrics-tui.git", branch = "master" }
 reverse-text = { index = "primeintellect" }
 alphabet-sort = { index = "primeintellect" }
 wiki-search = { index = "primeintellect" }

--- a/scripts/tmux.sh
+++ b/scripts/tmux.sh
@@ -100,6 +100,41 @@ tmux send-keys -t "$SESSION_NAME:Claude" \
 You are running inside tmux session \"${SESSION_NAME}\". The Launcher window (window 0) is where the user runs launch commands. You can read its contents with: tmux capture-pane -t ${SESSION_NAME}:Launcher -p
 Help the user monitor and debug this run.'" C-m
 
+# Window 3: vLLM Metrics TUI (if installed)
+# Discovers inference server URLs from log filenames in the output directory.
+# Node logs are named node_N.log; port is inferred from the ROLE line in each log.
+if command -v vllm-metrics-tui &>/dev/null; then
+  METRICS_URLS=""
+  INFERENCE_LOG_DIR="${LOG_DIR}/inference"
+  if [[ -d "$INFERENCE_LOG_DIR" ]]; then
+    for node_log in "$INFERENCE_LOG_DIR"/node_*.log; do
+      [[ -f "$node_log" ]] || continue
+      # Extract host:port from the "Starting inference on http://..." line
+      url=$(grep -m1 "Starting inference on" "$node_log" 2>/dev/null | grep -oP 'http://[^ ]+' | sed 's|/v1||')
+      if [[ -n "$url" ]]; then
+        # Replace 0.0.0.0 with the hostname from orchestrator connection logs
+        if [[ "$url" == *"0.0.0.0"* ]]; then
+          port=$(echo "$url" | grep -oP ':\d+$')
+          # Try to find the real hostname from orchestrator logs
+          host=$(grep -oP "ltc-[a-z0-9-]+${port}" "${LOG_DIR}/orchestrator.log" 2>/dev/null | head -1)
+          if [[ -n "$host" ]]; then
+            url="http://${host}"
+          else
+            continue
+          fi
+        fi
+        METRICS_URLS="$METRICS_URLS $url"
+      fi
+    done
+  fi
+
+  if [[ -n "$METRICS_URLS" ]]; then
+    tmux new-window -t "$SESSION_NAME" -n "Metrics"
+    tmux send-keys -t "$SESSION_NAME:Metrics" \
+      "vllm-metrics-tui $METRICS_URLS" C-m
+  fi
+fi
+
 # Pane title styling
 tmux set-option -t "$SESSION_NAME" -g pane-border-status top
 tmux set-option -t "$SESSION_NAME" -g pane-border-format " #{pane_title} "


### PR DESCRIPTION
- Add `tui` optional dependency group for vllm-metrics-tui
- Update tmux.sh to auto-discover inference server URLs from logs and launch the metrics TUI in a dedicated window

https://github.com/samsja/vllm-metrics-tui

<img width="983" height="882" alt="image" src="https://github.com/user-attachments/assets/8ae4fa44-ea13-4675-b74d-a2ae62863cc6" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to packaging metadata and a best-effort tmux helper that only runs when `vllm-metrics-tui` is installed and matching logs are present.
> 
> **Overview**
> Adds a new optional dependency extra, `prime-rl[tui]`, sourcing `vllm-metrics-tui` from Git to enable a metrics terminal UI.
> 
> Updates `scripts/tmux.sh` to optionally create a **Metrics** tmux window that auto-discovers vLLM inference server URLs by parsing `logs/inference/node_*.log` (and resolving `0.0.0.0` hosts via `orchestrator.log`) and then launches `vllm-metrics-tui` with the discovered endpoints.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49d4aa506cdc1b2c50e7d66673056876b8fce461. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->