### PR TITLE
Add qwen3_vl_moe to VLM registry

### DIFF
--- a/src/prime_rl/utils/vlm.py
+++ b/src/prime_rl/utils/vlm.py
@@ -28,6 +28,7 @@ VLM_REGISTRY: dict[str, VLMModelInfo] = {
     "qwen3_vl": VLMModelInfo(vision_encoder_attr="model.visual", language_model_attr="model.language_model"),
     "qwen3_5": VLMModelInfo(vision_encoder_attr="model.visual", language_model_attr="model.language_model"),
     "qwen3_5_moe": VLMModelInfo(vision_encoder_attr="model.visual", language_model_attr="model.language_model"),
+    "qwen3_vl_moe": VLMModelInfo(vision_encoder_attr="model.visual", language_model_attr="model.language_model"),
 }
 
 # Text-only default


### PR DESCRIPTION
- Trainer crashes with `Unrecognized configuration class Qwen3VLMoeConfig for AutoModelForCausalLM` when loading Qwen3-VL-30B-A3B-Thinking
- Missing `qwen3_vl_moe` entry in VLM_REGISTRY, so VLM detection fails and it falls through to AutoModelForCausalLM instead of AutoModelForImageTextToText
- One-line fix: add the model_type to the registry with the same vision/language attrs as the other Qwen VLMs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, single-entry registry update that only affects model-type detection and component attribute resolution for `qwen3_vl_moe`. Potential impact is limited to runs loading that specific model family.
> 
> **Overview**
> Adds `qwen3_vl_moe` to `VLM_REGISTRY` in `vlm.py`, mapping it to the same `vision_encoder_attr`/`language_model_attr` as other Qwen VLM variants.
> 
> This ensures configs with `model_type="qwen3_vl_moe"` are detected as VLMs and use the VLM-specific component resolution paths instead of falling back to text-only handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d45fe96757b3c601a95f4e8468c51fed9b45394. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->