### PR TITLE
fix: handle chat template errors in eval sample logging

### DIFF
--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -196,14 +196,9 @@ class WandbMonitor(Monitor):
                 continue
             if isinstance(completion, list):
                 try:
-                    completion = self.tokenizer.apply_chat_template(completion, tokenize=False)
+                    completion = self.tokenizer.apply_chat_template(deserialize_tool_calls(completion), tokenize=False)
                 except Exception:
-                    try:
-                        completion = self.tokenizer.apply_chat_template(
-                            deserialize_tool_calls(completion), tokenize=False
-                        )
-                    except Exception:
-                        completion = str(completion)
+                    completion = str(completion)
             sample = {
                 "step": step,
                 "env": env_name,

--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -194,7 +194,10 @@ class WandbMonitor(Monitor):
             if not completion:
                 continue
             if isinstance(completion, list):
-                completion = self.tokenizer.apply_chat_template(completion, tokenize=False)
+                try:
+                    completion = self.tokenizer.apply_chat_template(completion, tokenize=False)
+                except Exception:
+                    completion = str(completion)
             sample = {
                 "step": step,
                 "env": env_name,

--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -12,6 +12,7 @@ from transformers.tokenization_utils import PreTrainedTokenizer
 from wandb.errors import CommError
 
 from prime_rl.configs.shared import WandbConfig, WandbWithExtrasConfig
+from prime_rl.utils.chat_template import deserialize_tool_calls
 from prime_rl.utils.config import BaseConfig
 from prime_rl.utils.logger import get_logger
 from prime_rl.utils.monitor.base import Monitor, sample_items_for_logging
@@ -197,7 +198,12 @@ class WandbMonitor(Monitor):
                 try:
                     completion = self.tokenizer.apply_chat_template(completion, tokenize=False)
                 except Exception:
-                    completion = str(completion)
+                    try:
+                        completion = self.tokenizer.apply_chat_template(
+                            deserialize_tool_calls(completion), tokenize=False
+                        )
+                    except Exception:
+                        completion = str(completion)
             sample = {
                 "step": step,
                 "env": env_name,


### PR DESCRIPTION
## Summary

`apply_chat_template` in `log_eval_samples` crashes when completions contain tool calls serialized as strings (from verifiers) but the model's Jinja template expects tool call objects with `.name`/`.arguments` attributes. This kills the orchestrator after eval.

Observed with gpt-oss + wiki-search environment — the gpt-oss chat template strictly accesses `tool_call.name`, but verifiers serializes tool calls as JSON strings in `RolloutOutput`.

Introduced in #2143.

## Fix

Wrap `apply_chat_template` in try/except, fall back to raw string representation. Logging code should never crash training.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only affects eval sample logging to W&B, adding defensive formatting/parsing with a safe fallback if chat templating fails.
> 
> **Overview**
> Prevents `WandbMonitor.log_eval_samples` from crashing when formatting list-based `completion` messages that include tool calls.
> 
> The monitor now runs completions through `deserialize_tool_calls()` before `tokenizer.apply_chat_template()`, and wraps templating in `try/except` to fall back to a raw string representation on any error so eval logging can't kill training.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d18503e626530d00a54266c5b8fcb7224978a838. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->