### PR TITLE
fix: derive inference nccl rank from worker local rank and add unit test

### DIFF
--- a/src/prime_rl/inference/vllm/worker/nccl.py
+++ b/src/prime_rl/inference/vllm/worker/nccl.py
@@ -1,3 +1,4 @@
+import os
 import pickle
 from typing import TYPE_CHECKING, Callable, Generator, cast
 
@@ -24,6 +25,26 @@ else:
     Worker = object
 
 logger = init_logger("vllm.inference.vllm.worker_nccl")
+
+
+def resolve_nccl_worker_ranks(
+    tp_size: int,
+    rank_offset: int,
+    device_index: int,
+    local_rank_env: str | None = None,
+) -> tuple[int, int, int]:
+    """Resolve per-worker NCCL ranks for single-server inference shards.
+
+    vLLM launches local DP shards as separate worker processes. In that layout,
+    the DP process group inside each worker can still report rank 0 even when
+    multiple local shards exist. Derive shard identity from the worker's local
+    GPU rank instead.
+    """
+    local_rank_value = local_rank_env if local_rank_env is not None else os.environ.get("LOCAL_RANK")
+    local_rank = int(local_rank_value) if local_rank_value is not None else device_index
+    local_dp_rank = local_rank // tp_size
+    global_rank_inference = rank_offset + local_rank
+    return local_rank, local_dp_rank, global_rank_inference
 
 
 def receive_integer(communicator: PyNcclCommunicator) -> int:
@@ -113,11 +134,12 @@ class NCCLWeightUpdateWorker(Worker):
         tp_size = get_tp_group().world_size
         tp_rank = get_tp_group().rank_in_group
         dp_rank = get_dp_group().rank_in_group
-        # Use modulo to get the local DP rank within this server (needed when
-        # the DP group spans multiple nodes in distributed EP mode).
-        local_dp_rank = dp_rank % (gpus_per_server // tp_size)
-        local_rank = local_dp_rank * tp_size + tp_rank
-        global_rank_inference = rank_offset + local_rank
+
+        local_rank, local_dp_rank, global_rank_inference = resolve_nccl_worker_ranks(
+            tp_size=tp_size,
+            rank_offset=rank_offset,
+            device_index=self.device.index,
+        )
 
         logger.info(
             f"Worker [tp={tp_rank} dp={dp_rank} local_dp={local_dp_rank} rank_offset={rank_offset}] "

--- a/src/prime_rl/inference/vllm/worker/nccl.py
+++ b/src/prime_rl/inference/vllm/worker/nccl.py
@@ -28,23 +28,42 @@ logger = init_logger("vllm.inference.vllm.worker_nccl")
 
 
 def resolve_nccl_worker_ranks(
+    *,
     tp_size: int,
+    tp_rank: int,
+    dp_rank: int,
+    dp_world_size: int | None,
+    dp_rank_local: int | None,
     rank_offset: int,
+    gpus_per_server: int,
     device_index: int,
     local_rank_env: str | None = None,
-) -> tuple[int, int, int]:
+) -> tuple[int, int, int, str]:
     """Resolve per-worker NCCL ranks for single-server inference shards.
 
-    vLLM launches local DP shards as separate worker processes. In that layout,
-    the DP process group inside each worker can still report rank 0 even when
-    multiple local shards exist. Derive shard identity from the worker's local
-    GPU rank instead.
+    Prefer vLLM's explicit local DP rank when available. Otherwise preserve the
+    old DP-group based behavior when the worker is part of a real multi-rank DP
+    group. Only fall back to the worker's local GPU rank in the singleton-group
+    layout where DP rank cannot distinguish local shards.
     """
+    if dp_rank_local is not None:
+        local_dp_rank = dp_rank_local
+        local_rank = local_dp_rank * tp_size + tp_rank
+        global_rank_inference = rank_offset + local_rank
+        return local_rank, local_dp_rank, global_rank_inference, "data_parallel_rank_local"
+
+    if dp_world_size is not None and dp_world_size > 1:
+        local_dp_rank = dp_rank % (gpus_per_server // tp_size)
+        local_rank = local_dp_rank * tp_size + tp_rank
+        global_rank_inference = rank_offset + local_rank
+        return local_rank, local_dp_rank, global_rank_inference, "dp_group"
+
     local_rank_value = local_rank_env if local_rank_env is not None else os.environ.get("LOCAL_RANK")
+    rank_source = "local_rank_env" if local_rank_value is not None else "device_index"
     local_rank = int(local_rank_value) if local_rank_value is not None else device_index
     local_dp_rank = local_rank // tp_size
     global_rank_inference = rank_offset + local_rank
-    return local_rank, local_dp_rank, global_rank_inference
+    return local_rank, local_dp_rank, global_rank_inference, rank_source
 
 
 def receive_integer(communicator: PyNcclCommunicator) -> int:
@@ -131,18 +150,30 @@ class NCCLWeightUpdateWorker(Worker):
             gpus_per_server: Number of GPUs managed by this server instance.
         """
         self.quantize_in_weight_transfer = quantize_in_weight_transfer
-        tp_size = get_tp_group().world_size
-        tp_rank = get_tp_group().rank_in_group
-        dp_rank = get_dp_group().rank_in_group
+        tp_group = get_tp_group()
+        dp_group = get_dp_group()
+        tp_size = tp_group.world_size
+        tp_rank = tp_group.rank_in_group
+        dp_rank = dp_group.rank_in_group
+        dp_world_size = getattr(dp_group, "world_size", None)
+        parallel_config = getattr(self, "parallel_config", None)
+        dp_rank_local = getattr(parallel_config, "data_parallel_rank_local", None)
 
-        local_rank, local_dp_rank, global_rank_inference = resolve_nccl_worker_ranks(
+        local_rank, local_dp_rank, global_rank_inference, rank_source = resolve_nccl_worker_ranks(
             tp_size=tp_size,
+            tp_rank=tp_rank,
+            dp_rank=dp_rank,
+            dp_world_size=dp_world_size,
+            dp_rank_local=dp_rank_local,
             rank_offset=rank_offset,
+            gpus_per_server=gpus_per_server,
             device_index=self.device.index,
         )
 
         logger.info(
-            f"Worker [tp={tp_rank} dp={dp_rank} local_dp={local_dp_rank} rank_offset={rank_offset}] "
+            f"Worker [tp={tp_rank} dp={dp_rank} dp_world_size={dp_world_size} "
+            f"dp_rank_local={dp_rank_local} local_dp={local_dp_rank} "
+            f"rank_source={rank_source} rank_offset={rank_offset}] "
             f"-> [global_rank={global_rank_inference} inference_world_size={inference_world_size}]"
         )
 

--- a/tests/unit/inference/test_nccl_worker.py
+++ b/tests/unit/inference/test_nccl_worker.py
@@ -1,0 +1,76 @@
+import pytest
+
+from prime_rl.inference.vllm.worker import nccl
+from prime_rl.inference.vllm.worker.nccl import resolve_nccl_worker_ranks
+
+
+@pytest.mark.parametrize(
+    ("tp_size", "rank_offset", "device_index", "local_rank_env", "expected"),
+    [
+        (1, 0, 0, "0", (0, 0, 0)),
+        (1, 0, 1, "1", (1, 1, 1)),
+        (2, 0, 0, "0", (0, 0, 0)),
+        (2, 0, 1, "1", (1, 0, 1)),
+        (2, 0, 2, "2", (2, 1, 2)),
+        (2, 4, 1, "1", (1, 0, 5)),
+    ],
+)
+def test_resolve_nccl_worker_ranks_prefers_local_rank(
+    tp_size: int,
+    rank_offset: int,
+    device_index: int,
+    local_rank_env: str,
+    expected: tuple[int, int, int],
+):
+    assert (
+        resolve_nccl_worker_ranks(
+            tp_size=tp_size,
+            rank_offset=rank_offset,
+            device_index=device_index,
+            local_rank_env=local_rank_env,
+        )
+        == expected
+    )
+
+
+def test_resolve_nccl_worker_ranks_falls_back_to_device_index(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("LOCAL_RANK", raising=False)
+    assert resolve_nccl_worker_ranks(tp_size=2, rank_offset=4, device_index=3, local_rank_env=None) == (3, 1, 7)
+
+
+def test_init_broadcaster_uses_local_rank_even_when_dp_rank_is_zero(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(nccl, "get_tp_group", lambda: type("Group", (), {"world_size": 1, "rank_in_group": 0})())
+    monkeypatch.setattr(nccl, "get_dp_group", lambda: type("Group", (), {"rank_in_group": 0})())
+
+    receiver_init = {}
+
+    class FakeReceiver:
+        def __init__(self, host, port, rank, world_size, device, timeout):
+            receiver_init.update(
+                {
+                    "host": host,
+                    "port": port,
+                    "rank": rank,
+                    "world_size": world_size,
+                    "device": device,
+                    "timeout": timeout,
+                }
+            )
+
+    monkeypatch.setattr(nccl, "NCCLWeightBroadcastReceiver", FakeReceiver)
+    monkeypatch.setenv("LOCAL_RANK", "1")
+
+    worker = nccl.NCCLWeightUpdateWorker()
+    worker.device = type("Device", (), {"index": 1})()
+
+    worker.init_broadcaster(
+        host="localhost",
+        port=29501,
+        rank_offset=0,
+        inference_world_size=2,
+        gpus_per_server=2,
+        timeout=10,
+    )
+
+    assert receiver_init["rank"] == 2
+    assert receiver_init["world_size"] == 3

--- a/tests/unit/inference/test_nccl_worker.py
+++ b/tests/unit/inference/test_nccl_worker.py
@@ -5,27 +5,46 @@ from prime_rl.inference.vllm.worker.nccl import resolve_nccl_worker_ranks
 
 
 @pytest.mark.parametrize(
-    ("tp_size", "rank_offset", "device_index", "local_rank_env", "expected"),
+    (
+        "tp_size",
+        "tp_rank",
+        "dp_rank",
+        "dp_world_size",
+        "dp_rank_local",
+        "rank_offset",
+        "gpus_per_server",
+        "device_index",
+        "local_rank_env",
+        "expected",
+    ),
     [
-        (1, 0, 0, "0", (0, 0, 0)),
-        (1, 0, 1, "1", (1, 1, 1)),
-        (2, 0, 0, "0", (0, 0, 0)),
-        (2, 0, 1, "1", (1, 0, 1)),
-        (2, 0, 2, "2", (2, 1, 2)),
-        (2, 4, 1, "1", (1, 0, 5)),
+        (1, 0, 0, 2, 0, 0, 2, 0, "1", (0, 0, 0, "data_parallel_rank_local")),
+        (2, 1, 3, 4, None, 4, 4, 1, "0", (3, 1, 7, "dp_group")),
+        (1, 0, 0, 1, None, 0, 2, 0, "1", (1, 1, 1, "local_rank_env")),
+        (2, 0, 0, None, None, 0, 4, 2, "2", (2, 1, 2, "local_rank_env")),
     ],
 )
-def test_resolve_nccl_worker_ranks_prefers_local_rank(
+def test_resolve_nccl_worker_ranks(
     tp_size: int,
+    tp_rank: int,
+    dp_rank: int,
+    dp_world_size: int | None,
+    dp_rank_local: int | None,
     rank_offset: int,
+    gpus_per_server: int,
     device_index: int,
     local_rank_env: str,
-    expected: tuple[int, int, int],
+    expected: tuple[int, int, int, str],
 ):
     assert (
         resolve_nccl_worker_ranks(
             tp_size=tp_size,
+            tp_rank=tp_rank,
+            dp_rank=dp_rank,
+            dp_world_size=dp_world_size,
+            dp_rank_local=dp_rank_local,
             rank_offset=rank_offset,
+            gpus_per_server=gpus_per_server,
             device_index=device_index,
             local_rank_env=local_rank_env,
         )
@@ -35,12 +54,103 @@ def test_resolve_nccl_worker_ranks_prefers_local_rank(
 
 def test_resolve_nccl_worker_ranks_falls_back_to_device_index(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv("LOCAL_RANK", raising=False)
-    assert resolve_nccl_worker_ranks(tp_size=2, rank_offset=4, device_index=3, local_rank_env=None) == (3, 1, 7)
+    assert (
+        resolve_nccl_worker_ranks(
+            tp_size=2,
+            tp_rank=1,
+            dp_rank=0,
+            dp_world_size=1,
+            dp_rank_local=None,
+            rank_offset=4,
+            gpus_per_server=4,
+            device_index=3,
+            local_rank_env=None,
+        )
+        == (3, 1, 7, "device_index")
+    )
+
+
+def test_init_broadcaster_preserves_dp_group_path(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(nccl, "get_tp_group", lambda: type("Group", (), {"world_size": 2, "rank_in_group": 1})())
+    monkeypatch.setattr(nccl, "get_dp_group", lambda: type("Group", (), {"rank_in_group": 3, "world_size": 4})())
+
+    receiver_init = {}
+
+    class FakeReceiver:
+        def __init__(self, host, port, rank, world_size, device, timeout):
+            receiver_init.update(
+                {
+                    "host": host,
+                    "port": port,
+                    "rank": rank,
+                    "world_size": world_size,
+                    "device": device,
+                    "timeout": timeout,
+                }
+            )
+
+    monkeypatch.setattr(nccl, "NCCLWeightBroadcastReceiver", FakeReceiver)
+    monkeypatch.setenv("LOCAL_RANK", "0")
+
+    worker = nccl.NCCLWeightUpdateWorker()
+    worker.device = type("Device", (), {"index": 1})()
+    worker.parallel_config = type("ParallelConfig", (), {"data_parallel_rank_local": None})()
+
+    worker.init_broadcaster(
+        host="localhost",
+        port=29501,
+        rank_offset=4,
+        inference_world_size=8,
+        gpus_per_server=4,
+        timeout=10,
+    )
+
+    assert receiver_init["rank"] == 8
+    assert receiver_init["world_size"] == 9
+
+
+def test_init_broadcaster_prefers_data_parallel_rank_local(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(nccl, "get_tp_group", lambda: type("Group", (), {"world_size": 2, "rank_in_group": 1})())
+    monkeypatch.setattr(nccl, "get_dp_group", lambda: type("Group", (), {"rank_in_group": 0, "world_size": 1})())
+
+    receiver_init = {}
+
+    class FakeReceiver:
+        def __init__(self, host, port, rank, world_size, device, timeout):
+            receiver_init.update(
+                {
+                    "host": host,
+                    "port": port,
+                    "rank": rank,
+                    "world_size": world_size,
+                    "device": device,
+                    "timeout": timeout,
+                }
+            )
+
+    monkeypatch.setattr(nccl, "NCCLWeightBroadcastReceiver", FakeReceiver)
+    monkeypatch.setenv("LOCAL_RANK", "0")
+
+    worker = nccl.NCCLWeightUpdateWorker()
+    worker.device = type("Device", (), {"index": 1})()
+    worker.parallel_config = type("ParallelConfig", (), {"data_parallel_rank_local": 1})()
+
+    worker.init_broadcaster(
+        host="localhost",
+        port=29501,
+        rank_offset=4,
+        inference_world_size=8,
+        gpus_per_server=4,
+        timeout=10,
+    )
+
+    assert receiver_init["rank"] == 8
+    assert receiver_init["world_size"] == 9
 
 
 def test_init_broadcaster_uses_local_rank_even_when_dp_rank_is_zero(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(nccl, "get_tp_group", lambda: type("Group", (), {"world_size": 1, "rank_in_group": 0})())
-    monkeypatch.setattr(nccl, "get_dp_group", lambda: type("Group", (), {"rank_in_group": 0})())
+    monkeypatch.setattr(nccl, "get_dp_group", lambda: type("Group", (), {"rank_in_group": 0, "world_size": 1})())
 
     receiver_init = {}
 
@@ -62,6 +172,7 @@ def test_init_broadcaster_uses_local_rank_even_when_dp_rank_is_zero(monkeypatch:
 
     worker = nccl.NCCLWeightUpdateWorker()
     worker.device = type("Device", (), {"index": 1})()
+    worker.parallel_config = type("ParallelConfig", (), {"data_parallel_rank_local": None})()
 
     worker.init_broadcaster(
         host="localhost",

--- a/tests/unit/inference/test_nccl_worker.py
+++ b/tests/unit/inference/test_nccl_worker.py
@@ -54,20 +54,17 @@ def test_resolve_nccl_worker_ranks(
 
 def test_resolve_nccl_worker_ranks_falls_back_to_device_index(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv("LOCAL_RANK", raising=False)
-    assert (
-        resolve_nccl_worker_ranks(
-            tp_size=2,
-            tp_rank=1,
-            dp_rank=0,
-            dp_world_size=1,
-            dp_rank_local=None,
-            rank_offset=4,
-            gpus_per_server=4,
-            device_index=3,
-            local_rank_env=None,
-        )
-        == (3, 1, 7, "device_index")
-    )
+    assert resolve_nccl_worker_ranks(
+        tp_size=2,
+        tp_rank=1,
+        dp_rank=0,
+        dp_world_size=1,
+        dp_rank_local=None,
+        rank_offset=4,
+        gpus_per_server=4,
+        device_index=3,
+        local_rank_env=None,
+    ) == (3, 1, 7, "device_index")
 
 
 def test_init_broadcaster_preserves_dp_group_path(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
Fixes https://github.com/PrimeIntellect-ai/prime-rl/issues/2199

- prefer data_parallel_rank_local when available
- preserve dp_group-based rank resolution for real multi-rank DP groups
- fall back to LOCAL_RANK/device.index for singleton-group local-DP workers
- log which rank source was used
- add unit coverage for all rank resolution paths


Before:

```
Worker pid=4410) INFO 04-08 18:42:56 [nccl.py:122] Worker [tp=0 dp=0 local_dp=0 rank_offset=0] -> [global_rank=0 inference_world_size=2]
(Worker pid=4410) INFO 04-08 18:42:56 [nccl.py:75] Initializing NCCL broadcast receiver (localhost:29501, rank=1, world_size=3)
(Worker pid=4416) INFO 04-08 18:42:56 [nccl.py:122] Worker [tp=0 dp=0 local_dp=0 rank_offset=0] -> [global_rank=0 inference_world_size=2]
(Worker pid=4416) INFO 04-08 18:42:56 [nccl.py:75] Initializing NCCL broadcast receiver (localhost:29501, rank=1, world_size=3)
```


After:

```
(Worker pid=7778) INFO 04-08 19:10:30 [nccl.py:173] Worker [tp=0 dp=0 dp_world_size=1 dp_rank_local=0 local_dp=0 rank_source=data_parallel_rank_local rank_offset=0] -> [global_rank=0 inference_world_size=2]
(Worker pid=7778) INFO 04-08 19:10:30 [nccl.py:115] Initializing NCCL broadcast receiver (localhost:29501, rank=1, world_size=3)
(Worker pid=7781) INFO 04-08 19:10:30 [nccl.py:173] Worker [tp=0 dp=0 dp_world_size=1 dp_rank_local=1 local_dp=1 rank_source=data_parallel_rank_local rank_offset=0] -> [global_rank=1 inference_world_size=2]
(Worker pid=7781) INFO 04-08 19:10:30 [nccl.py:115] Initializing NCCL broadcast receiver (localhost:29501, rank=2, world_size=3)
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rank derivation used to form NCCL process groups for weight transfer, which can break multi-GPU inference if miscomputed. Risk is mitigated by explicit fallback logic and new unit tests covering each resolution path.
> 
> **Overview**
> **Fixes NCCL rank resolution for inference weight broadcasts.** `NCCLWeightUpdateWorker.init_broadcaster` now computes `local_rank`/`global_rank` via a new `resolve_nccl_worker_ranks` helper that *prefers* `parallel_config.data_parallel_rank_local`, *preserves* the previous DP-group modulo behavior only when `dp_world_size > 1`, and otherwise *falls back* to `LOCAL_RANK` (or `device.index`) for singleton DP groups.
> 
> Adds more detailed logging of the chosen rank source, and introduces `tests/unit/inference/test_nccl_worker.py` to validate all rank-resolution branches and the resulting receiver `rank`/`world_size` passed to `NCCLWeightBroadcastReceiver`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adb94b1c38542ab39afc1ede249147c0c19eb5db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->