### PR TITLE
Add eval sample logging to monitor backends #1995

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 Documenting changes which affect configuration usage patterns (added/moved/removed/renamed fields, notable logic changes).
 
+- **`orchestrator.eval.log_samples`**: Added flag to log individual eval samples to monitors that support it (default: True) (2026-04-06)
+
 - **`log.file` and `log.env_worker_logs` removed**: Removed `log.file` (from `LogConfig` and `SharedLogConfig`) and `log.env_worker_logs` (from `LogConfig`). Python file logging is replaced by deployment-level capture. Existing configs using these fields must delete them. Log paths unified: `.stdout` files renamed to `.log`, SLURM logs moved from `slurm/` to `logs/`. (2026-03-31)
 - **`trainer.log.ranks_filter` (NEW)**: Added `ranks_filter: list[int]` to `TrainerLogConfig` (default: `[0]`). Controls which ranks appear in trainer console output via torchrun's `--local-ranks-filter`. (2026-03-31)
 - **`wandb.log_extras.sample_ratio` / monitor sample logging defaults**: `wandb.log_extras.sample_ratio` is now actually applied to W&B sample-table logging via the shared monitor sampler (it was previously a no-op for WandB). Separately, the orchestrator no longer hard-caps sample logging to 8 rollouts before monitor-level sampling runs, so when monitor `sample_ratio` is `None`, monitors now receive and may log the full rollout batch for a step instead of at most 8 rollouts. This affects both W&B and Prime monitor sample logging behavior. (2026-03-27)

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -401,6 +401,13 @@ class EvalConfig(BaseConfig):
         ),
     ] = False
 
+    log_samples: Annotated[
+        bool,
+        Field(
+            description="Whether to log individual eval samples to monitors that support it.",
+        ),
+    ] = True
+
     @model_validator(mode="after")
     def validate_unique_env_names(self):
         env_names = [env.resolved_name for env in self.env]

--- a/src/prime_rl/orchestrator/eval_utils.py
+++ b/src/prime_rl/orchestrator/eval_utils.py
@@ -99,6 +99,7 @@ async def evaluate_env(
     ckpt_step: int,
     step: int,
     get_client: Callable[[], Awaitable[vf.ClientConfig]],
+    log_samples: bool = True,
 ):
     logger = get_logger()
     logger.info(f"Evaluating {env_name} ({num_examples=}, {rollouts_per_example=})")
@@ -183,4 +184,5 @@ async def evaluate_env(
     eval_metrics.update({"progress/ckpt_step": ckpt_step, "step": step})
     monitor = get_monitor()
     monitor.log(eval_metrics, step=step)
-    monitor.log_eval_samples(outputs, env_name=env_name, step=step)
+    if log_samples:
+        monitor.log_eval_samples(outputs, env_name=env_name, step=step)

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -498,6 +498,7 @@ async def orchestrate(config: OrchestratorConfig):
                         max_retries=eval_env_config.max_retries,
                         ckpt_step=ckpt_step,
                         step=progress.step,
+                        log_samples=config.eval.log_samples,
                     )
                     for eval_env, eval_env_name, eval_env_config in zip(eval_envs, eval_env_names, config.eval.env)
                 ]
@@ -877,6 +878,7 @@ async def orchestrate(config: OrchestratorConfig):
                     max_retries=eval_env_config.max_retries,
                     ckpt_step=ckpt_step,
                     step=progress.step,
+                    log_samples=config.eval.log_samples,
                 )
                 for eval_env, eval_env_name, eval_env_config in zip(eval_envs, eval_env_names, config.eval.env)
             ]

--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -285,8 +285,10 @@ class PrimeMonitor(Monitor):
             f"Initiated samples upload at step {step} to Prime Intellect API in {time.perf_counter() - start_time:.2f}s"
         )
 
-    def _rollouts_to_parquet_bytes(self, rollouts: list[vf.RolloutOutput], step: int) -> bytes | None:
-        """Convert rollouts directly to Parquet bytes for upload."""
+    def _rollouts_to_parquet_bytes_eval(
+        self, rollouts: list[vf.RolloutOutput], env_name: str, step: int
+    ) -> bytes | None:
+        """Convert eval rollouts directly to Parquet bytes for upload."""
         now = datetime.now(timezone.utc)
         rows = []
 
@@ -320,14 +322,14 @@ class PrimeMonitor(Monitor):
                 {
                     "run_id": self.run_id,
                     "step": step,
-                    "tag": "",
+                    "tag": f"eval/{env_name}",
                     "problem_id": problem_id,
                     "sample_id": sample_id,
                     "prompt": json.dumps(prompt),
                     "completion": json.dumps(completion),
                     "trajectory": json.dumps(trajectory_data),
                     "answer": rollout.get("answer") or "",
-                    "task": rollout.get("task") or "",
+                    "task": rollout.get("task") or env_name,
                     "info": _json(rollout.get("info")),
                     "reward": rollout.get("reward"),
                     "advantage": rollout.get("advantage"),
@@ -450,7 +452,39 @@ class PrimeMonitor(Monitor):
         return False
 
     def log_eval_samples(self, rollouts: list[vf.RolloutOutput], env_name: str, step: int) -> None:
-        pass
+        """Logs eval rollouts to Prime Intellect API using presigned URLs for direct R2 upload."""
+        if not self.is_master:
+            return
+        if not self.enabled:
+            return
+        if not self.config or not self.config.log_extras or not self.config.log_extras.samples:
+            return
+
+        # For eval, log all samples since eval sets are small
+        rollouts = sample_items_for_logging(rollouts, None)  # None means log all
+        if not rollouts:
+            return
+
+        assert step not in self._pending_sample_steps, f"Step {step} upload already in progress"
+        assert self.logger is not None, "Logger is required for sample logging"
+
+        self.logger.info(f"Logging {len(rollouts)} eval samples for {env_name} to Prime Intellect API at step {step}")
+        start_time = time.perf_counter()
+
+        parquet_bytes = self._rollouts_to_parquet_bytes_eval(rollouts, env_name, step)
+
+        if not parquet_bytes:
+            self.logger.warning(f"No eval samples to log at step {step}")
+            return
+
+        self._pending_sample_steps.add(step)
+
+        # Use presigned URL flow for uploading samples
+        self._upload_samples_via_presigned_url(parquet_bytes, step)
+
+        self.logger.debug(
+            f"Initiated eval samples upload at step {step} to Prime Intellect API in {time.perf_counter() - start_time:.2f}s"
+        )
 
     def log_final_samples(self) -> None:
         """Log final samples (no-op - samples are logged per-step only)."""

--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -270,7 +270,7 @@ class PrimeMonitor(Monitor):
         self.logger.info(f"Logging {len(rollouts)} samples to Prime Intellect API at step {step}")
         start_time = time.perf_counter()
 
-        parquet_bytes = self._rollouts_to_parquet_bytes(rollouts, step)
+        parquet_bytes = self._rollouts_to_parquet_bytes_eval(rollouts, None, step)
 
         if not parquet_bytes:
             self.logger.warning(f"No samples to log at step {step}")
@@ -282,15 +282,16 @@ class PrimeMonitor(Monitor):
         self._upload_samples_via_presigned_url(parquet_bytes, step)
 
         self.logger.debug(
-            f"Initiated samples upload at step {step} to Prime Intellect API in {time.perf_counter() - start_time:.2f}s"
+            f"Initiated eval samples upload at step {step} to Prime Intellect API in {time.perf_counter() - start_time:.2f}s"
         )
 
     def _rollouts_to_parquet_bytes_eval(
-        self, rollouts: list[vf.RolloutOutput], env_name: str, step: int
+        self, rollouts: list[vf.RolloutOutput], env_name: str | None, step: int
     ) -> bytes | None:
-        """Convert eval rollouts directly to Parquet bytes for upload."""
+        """Convert rollouts to Parquet bytes for upload. If env_name is provided, it's eval samples; otherwise training samples."""
         now = datetime.now(timezone.utc)
         rows = []
+        tag = f"eval/{env_name}" if env_name else "train"
 
         for sample_id, rollout in enumerate(rollouts):
             prompt = rollout.get("prompt")
@@ -322,14 +323,14 @@ class PrimeMonitor(Monitor):
                 {
                     "run_id": self.run_id,
                     "step": step,
-                    "tag": f"eval/{env_name}",
+                    "tag": tag,
                     "problem_id": problem_id,
                     "sample_id": sample_id,
                     "prompt": json.dumps(prompt),
                     "completion": json.dumps(completion),
                     "trajectory": json.dumps(trajectory_data),
                     "answer": rollout.get("answer") or "",
-                    "task": rollout.get("task") or env_name,
+                    "task": rollout.get("task") or (env_name or ""),
                     "info": _json(rollout.get("info")),
                     "reward": rollout.get("reward"),
                     "advantage": rollout.get("advantage"),
@@ -465,7 +466,6 @@ class PrimeMonitor(Monitor):
         if not rollouts:
             return
 
-        assert step not in self._pending_sample_steps, f"Step {step} upload already in progress"
         assert self.logger is not None, "Logger is required for sample logging"
 
         self.logger.info(f"Logging {len(rollouts)} eval samples for {env_name} to Prime Intellect API at step {step}")

--- a/tests/unit/utils/test_prime_monitor.py
+++ b/tests/unit/utils/test_prime_monitor.py
@@ -38,11 +38,12 @@ def test_rollouts_to_parquet_bytes_preserves_all_rollouts_and_ids():
     monitor = PrimeMonitor.__new__(PrimeMonitor)
     monitor.run_id = "run-123"
 
-    parquet_bytes = monitor._rollouts_to_parquet_bytes(
+    parquet_bytes = monitor._rollouts_to_parquet_bytes_eval(
         [
             _build_rollout(example_id=101, reward=1.0, task="task-a"),
             _build_rollout(example_id=202, reward=0.0, task="task-b"),
         ],
+        None,
         step=7,
     )
 
@@ -64,7 +65,7 @@ def test_rollouts_to_parquet_bytes_skips_rollouts_without_trajectory():
     monitor = PrimeMonitor.__new__(PrimeMonitor)
     monitor.run_id = "run-456"
 
-    parquet_bytes = monitor._rollouts_to_parquet_bytes(
+    parquet_bytes = monitor._rollouts_to_parquet_bytes_eval(
         [
             _build_rollout(example_id=1, reward=1.0, task="task-a"),
             {
@@ -74,6 +75,7 @@ def test_rollouts_to_parquet_bytes_skips_rollouts_without_trajectory():
                 "trajectory": [],
             },
         ],
+        None,
         step=3,
     )
 


### PR DESCRIPTION
This PR implements the feature requested in issue #1995 to add eval sample logging to monitor backends.

## Changes
1. **EvalConfig**: Added `log_samples` boolean field to enable/disable eval sample logging (defaults to `true`)
2. **evaluate_env**: Added `log_samples` parameter and conditionally calls `monitor.log_eval_samples()` 
3. **PrimeMonitor**: Implemented `log_eval_samples()` method to upload eval rollouts to Prime Intellect API with eval-specific tagging
4. **Orchestrator**: Updated calls to `evaluate_env()` to pass the `log_samples` config value

## Why this matters
- **Debugging**: Enables inspection of individual eval traces instead of just aggregate metrics
- **Post-hoc analysis**: Eval samples are now available via prime-rl rollouts and W&B for debugging degrading runs
- **Storage**: Eval sets are small by design (30-100 examples), so storage cost is minimal
- **Consistency**: Brings eval logging in line with training sample logging

## Config
Users can disable eval sample logging if storage is a concern by setting `log_samples = false` under `[eval]` in their config.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds per-eval sample upload/logging paths (including Prime Intellect API uploads) and a new config flag controlling when this occurs, which could impact logging volume and external API interactions if misconfigured.
> 
> **Overview**
> Adds optional *per-evaluation* sample logging. A new `orchestrator.eval.log_samples` flag (default `True`) is plumbed through `evaluate_env()` and the orchestrator so monitors only receive eval rollouts when enabled.
> 
> Implements Prime backend support for eval samples by generating parquet uploads with eval-specific `tag`/`task` fields and adding a real `PrimeMonitor.log_eval_samples()` path; training sample parquet generation is refactored to share the same helper. Updates unit tests and documents the new config in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 037ccf46aa0f47b63baa8ef29eef5c9e60994a6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->