### PR TITLE
Fix Prime monitor public API flow

### DIFF
--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -58,6 +58,14 @@ _SAMPLE_SCHEMA = pa.schema(
 class PrimeMonitor(Monitor):
     """Logs to Prime Intellect API."""
 
+    def _api_headers(self) -> dict[str, str]:
+        """Return auth headers accepted by Prime's monitoring API."""
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "x-api-key": self.api_key,
+            "Content-Type": "application/json",
+        }
+
     def __init__(
         self,
         config: PrimeMonitorConfig | None,
@@ -132,8 +140,7 @@ class PrimeMonitor(Monitor):
 
     def _register_run(self, config: PrimeMonitorConfig, run_config: BaseConfig | None) -> str | None:
         """Register an external run with the platform. Returns run_id on success, None on failure."""
-        registration_api_key = self.api_key
-        if not registration_api_key:
+        if not self.api_key:
             self.logger.warning(
                 f"Prime Intellect API key not found. Set {config.api_key_var} environment variable or run `prime login`. "
                 "PrimeMonitor will not be able to register or upload data."
@@ -173,7 +180,7 @@ class PrimeMonitor(Monitor):
         try:
             response = httpx.post(
                 f"{api_base}/external-runs",
-                headers={"Authorization": f"Bearer {registration_api_key}"},
+                headers=self._api_headers(),
                 json=payload,
                 timeout=30,
             )
@@ -202,7 +209,6 @@ class PrimeMonitor(Monitor):
         if not getattr(self, "_registered", False):
             return
 
-        registration_api_key = self.api_key
         payload: dict = {"status": "completed" if success else "failed"}
         status_label = "completed" if success else "failed"
         self.logger.info(f"Finalizing platform run {self.run_id} as {status_label}")
@@ -213,7 +219,7 @@ class PrimeMonitor(Monitor):
         try:
             response = httpx.put(
                 finalize_url,
-                headers={"Authorization": f"Bearer {registration_api_key}"},
+                headers=self._api_headers(),
                 json=payload,
                 timeout=30,
             )
@@ -396,11 +402,10 @@ class PrimeMonitor(Monitor):
 
     async def _request_presigned_url(self, step: int) -> dict[str, Any] | None:
         """Request a presigned URL from the backend."""
-        headers = {"x-api-key": self.api_key, "Content-Type": "application/json"}
         try:
             response = await self._client.post(
                 f"{self.base_url}/samples/presign",
-                headers=headers,
+                headers=self._api_headers(),
                 json={"run_id": self.run_id, "step": step},
             )
             response.raise_for_status()
@@ -428,12 +433,11 @@ class PrimeMonitor(Monitor):
 
     async def _confirm_samples_upload(self, step: int, s3_key: str, max_retries: int = 3) -> bool:
         """Confirm samples upload with the backend. Returns True on success."""
-        headers = {"x-api-key": self.api_key, "Content-Type": "application/json"}
         for attempt in range(max_retries):
             try:
                 response = await self._client.post(
                     f"{self.base_url}/samples/confirm",
-                    headers=headers,
+                    headers=self._api_headers(),
                     json={"run_id": self.run_id, "step": step, "s3_key": s3_key},
                 )
                 response.raise_for_status()
@@ -578,17 +582,13 @@ class PrimeMonitor(Monitor):
 
     async def _make_request_async(self, endpoint: str, data: dict[str, Any], max_retries: int = 3) -> None:
         """Make an async POST request to the Prime Intellect API with retries."""
-        headers = {
-            "x-api-key": self.api_key,
-            "Content-Type": "application/json",
-        }
         full_endpoint = f"{self.base_url}/{endpoint}"
 
         for attempt in range(max_retries):
             try:
                 response = await self._client.post(
                     full_endpoint,
-                    headers=headers,
+                    headers=self._api_headers(),
                     json=data,
                 )
                 response.raise_for_status()

--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -55,43 +55,10 @@ _SAMPLE_SCHEMA = pa.schema(
 )
 
 
-_DROP_JSON_VALUE = object()
-
-
-def _drop_non_finite_json_values(value: Any, dropped_paths: list[str], path: str = "") -> Any:
-    """Remove non-finite floats so payloads remain valid JSON."""
-    if isinstance(value, float):
-        if math.isfinite(value):
-            return value
-        dropped_paths.append(path)
-        return _DROP_JSON_VALUE
-
-    if isinstance(value, dict):
-        sanitized: dict[str, Any] = {}
-        for key, item in value.items():
-            item_path = f"{path}.{key}" if path else str(key)
-            sanitized_item = _drop_non_finite_json_values(item, dropped_paths, item_path)
-            if sanitized_item is not _DROP_JSON_VALUE:
-                sanitized[key] = sanitized_item
-        return sanitized
-
-    if isinstance(value, list):
-        sanitized_items: list[Any] = []
-        for idx, item in enumerate(value):
-            item_path = f"{path}[{idx}]"
-            sanitized_item = _drop_non_finite_json_values(item, dropped_paths, item_path)
-            if sanitized_item is not _DROP_JSON_VALUE:
-                sanitized_items.append(sanitized_item)
-        return sanitized_items
-
-    return value
-
-
 class PrimeMonitor(Monitor):
     """Logs to Prime Intellect API."""
 
     def _api_headers(self) -> dict[str, str]:
-        """Return auth headers accepted by Prime's monitoring API."""
         return {
             "Authorization": f"Bearer {self.api_key}",
             "x-api-key": self.api_key,
@@ -99,9 +66,33 @@ class PrimeMonitor(Monitor):
         }
 
     def _sanitize_json_payload(self, endpoint: str, payload: dict[str, Any]) -> dict[str, Any]:
-        """Return a JSON-safe payload and warn when non-finite values are dropped."""
+        """Drop non-finite floats before sending JSON payloads to the public API."""
         dropped_paths: list[str] = []
-        sanitized_payload = _drop_non_finite_json_values(payload, dropped_paths)
+        dropped_value = object()
+
+        def sanitize(value: Any, path: str = "") -> Any:
+            if isinstance(value, float) and not math.isfinite(value):
+                dropped_paths.append(path)
+                return dropped_value
+            if isinstance(value, dict):
+                sanitized: dict[str, Any] = {}
+                for key, item in value.items():
+                    item_path = f"{path}.{key}" if path else str(key)
+                    sanitized_item = sanitize(item, item_path)
+                    if sanitized_item is not dropped_value:
+                        sanitized[key] = sanitized_item
+                return sanitized
+            if isinstance(value, list):
+                sanitized_items: list[Any] = []
+                for idx, item in enumerate(value):
+                    item_path = f"{path}[{idx}]"
+                    sanitized_item = sanitize(item, item_path)
+                    if sanitized_item is not dropped_value:
+                        sanitized_items.append(sanitized_item)
+                return sanitized_items
+            return value
+
+        sanitized_payload = sanitize(payload)
 
         if dropped_paths:
             preview = ", ".join(dropped_paths[:5])

--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -91,23 +91,13 @@ def _drop_non_finite_json_values(value: Any, dropped_paths: list[str], path: str
 class PrimeMonitor(Monitor):
     """Logs to Prime Intellect API."""
 
-    def _api_headers(self) -> dict[str, str]:
-        return {
-            "Authorization": f"Bearer {self.api_key}",
-            "x-api-key": self.api_key,
-            "Content-Type": "application/json",
-        }
-
     def _sanitize_json_payload(self, endpoint: str, payload: dict[str, Any]) -> dict[str, Any]:
         """Drop non-finite floats before sending JSON payloads to the public API."""
-        try:
-            json.dumps(payload, allow_nan=False)
-            return payload
-        except ValueError:
-            pass
-
         dropped_paths: list[str] = []
         sanitized_payload = _drop_non_finite_json_values(payload, dropped_paths)
+        if not dropped_paths:
+            return payload
+
         preview = ", ".join(dropped_paths[:5])
         suffix = " ..." if len(dropped_paths) > 5 else ""
         self.logger.warning(
@@ -158,6 +148,11 @@ class PrimeMonitor(Monitor):
 
         self.api_key = api_key
         self.base_url = config.base_url.rstrip("/")
+        self._headers = {
+            "Authorization": f"Bearer {api_key}",
+            "x-api-key": api_key,
+            "Content-Type": "application/json",
+        }
 
         run_id = os.getenv("RUN_ID")
         if not run_id:
@@ -220,7 +215,7 @@ class PrimeMonitor(Monitor):
         try:
             response = httpx.post(
                 f"{self.base_url}/external-runs",
-                headers=self._api_headers(),
+                headers=self._headers,
                 json=payload,
                 timeout=30,
             )
@@ -256,7 +251,7 @@ class PrimeMonitor(Monitor):
         try:
             response = httpx.put(
                 f"{self.base_url}/external-runs/{self.run_id}/status",
-                headers=self._api_headers(),
+                headers=self._headers,
                 json=payload,
                 timeout=30,
             )
@@ -438,7 +433,7 @@ class PrimeMonitor(Monitor):
         try:
             response = await self._client.post(
                 f"{self.base_url}/samples/presign",
-                headers=self._api_headers(),
+                headers=self._headers,
                 json={"run_id": self.run_id, "step": step},
             )
             response.raise_for_status()
@@ -474,7 +469,7 @@ class PrimeMonitor(Monitor):
             try:
                 response = await self._client.post(
                     f"{self.base_url}/samples/confirm",
-                    headers=self._api_headers(),
+                    headers=self._headers,
                     json={"run_id": self.run_id, "step": step, "s3_key": s3_key},
                 )
                 response.raise_for_status()
@@ -542,7 +537,7 @@ class PrimeMonitor(Monitor):
         try:
             response = httpx.post(
                 f"{self.base_url}/finalize",
-                headers=self._api_headers(),
+                headers=self._headers,
                 json=payload,
                 timeout=30,
             )
@@ -655,7 +650,7 @@ class PrimeMonitor(Monitor):
             try:
                 response = await self._client.post(
                     full_endpoint,
-                    headers=self._api_headers(),
+                    headers=self._headers,
                     json=sanitized_data,
                 )
                 response.raise_for_status()

--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -8,7 +8,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from threading import Thread
 from typing import Any
-from urllib.parse import urlparse
 
 import httpx
 import pyarrow as pa
@@ -119,10 +118,6 @@ class PrimeMonitor(Monitor):
             "Content-Type": "application/json",
         }
 
-    def _uses_public_monitoring_api(self) -> bool:
-        """Return whether this monitor is talking to the public v1 monitoring API."""
-        return urlparse(self.base_url).path.rstrip("/").endswith("/api/v1/rft")
-
     def _sanitize_json_payload(self, endpoint: str, payload: dict[str, Any]) -> dict[str, Any]:
         """Return a JSON-safe payload and warn when non-finite values are dropped."""
         sanitized_payload, dropped_paths = _drop_non_finite_json_values(payload)
@@ -201,7 +196,7 @@ class PrimeMonitor(Monitor):
         os.register_at_fork(after_in_child=self._reinit_after_fork)
 
         # Optionally, initialize sample logging attributes
-        if config is not None and config.log_extras:
+        if config.log_extras:
             if config.log_extras.samples:
                 self.last_log_samples_step = -1
                 self._pending_sample_steps: set[int] = set()
@@ -211,13 +206,6 @@ class PrimeMonitor(Monitor):
 
     def _register_run(self, config: PrimeMonitorConfig, run_config: BaseConfig | None) -> str | None:
         """Register an external run with the platform. Returns run_id on success, None on failure."""
-        if not self.api_key:
-            self.logger.warning(
-                f"Prime Intellect API key not found. Set {config.api_key_var} environment variable or run `prime login`. "
-                "PrimeMonitor will not be able to register or upload data."
-            )
-            return None
-
         prime_config = None
         team_id = config.team_id
         frontend_url = config.frontend_url
@@ -245,12 +233,9 @@ class PrimeMonitor(Monitor):
         if wandb and getattr(wandb, "project", None):
             payload["wandb_project"] = wandb.project
 
-        parsed = urlparse(config.base_url)
-        api_base = f"{parsed.scheme}://{parsed.netloc}/api/v1/rft"
-
         try:
             response = httpx.post(
-                f"{api_base}/external-runs",
+                f"{self.base_url}/external-runs",
                 headers=self._api_headers(),
                 json=payload,
                 timeout=30,
@@ -277,19 +262,16 @@ class PrimeMonitor(Monitor):
 
     def _finalize_run(self, success: bool) -> None:
         """Mark the run as completed or failed on the platform."""
-        if not getattr(self, "_registered", False):
+        if not self._registered:
             return
 
         payload: dict = {"status": "completed" if success else "failed"}
         status_label = "completed" if success else "failed"
         self.logger.info(f"Finalizing platform run {self.run_id} as {status_label}")
 
-        parsed = urlparse(self.base_url)
-        finalize_url = f"{parsed.scheme}://{parsed.netloc}/api/v1/rft/external-runs/{self.run_id}/status"
-
         try:
             response = httpx.put(
-                finalize_url,
+                f"{self.base_url}/external-runs/{self.run_id}/status",
                 headers=self._api_headers(),
                 json=payload,
                 timeout=30,
@@ -601,7 +583,7 @@ class PrimeMonitor(Monitor):
         if os.getpid() != self._owner_pid:
             return
 
-        if finalized_via_summary and self._uses_public_monitoring_api():
+        if finalized_via_summary:
             self._finalized = True
             return
 

--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -59,6 +59,55 @@ _SAMPLE_SCHEMA = pa.schema(
 _DROP_JSON_VALUE = object()
 
 
+def _normalize_presign_response(payload: Any) -> dict[str, str]:
+    """Normalize presign responses across legacy and public API shapes."""
+    if not isinstance(payload, dict):
+        raise ValueError("Presign response must be a JSON object")
+
+    response_data = payload.get("data", payload)
+    if not isinstance(response_data, dict):
+        raise ValueError("Presign response data must be a JSON object")
+
+    presigned_url = response_data.get("presigned_url") or response_data.get("presignedUrl")
+    s3_key = response_data.get("s3_key") or response_data.get("s3Key")
+    if not isinstance(presigned_url, str) or not isinstance(s3_key, str):
+        raise ValueError("Presign response is missing presigned URL or S3 key")
+
+    return {"presigned_url": presigned_url, "s3_key": s3_key}
+
+
+def _drop_non_finite_json_values(value: Any, path: str = "") -> tuple[Any, list[str]]:
+    """Remove non-finite floats so payloads remain valid JSON."""
+    if isinstance(value, float):
+        if math.isfinite(value):
+            return value, []
+        return _DROP_JSON_VALUE, [path]
+
+    if isinstance(value, dict):
+        sanitized: dict[str, Any] = {}
+        dropped_paths: list[str] = []
+        for key, item in value.items():
+            item_path = f"{path}.{key}" if path else str(key)
+            sanitized_item, item_dropped_paths = _drop_non_finite_json_values(item, item_path)
+            dropped_paths.extend(item_dropped_paths)
+            if sanitized_item is not _DROP_JSON_VALUE:
+                sanitized[key] = sanitized_item
+        return sanitized, dropped_paths
+
+    if isinstance(value, list):
+        sanitized_items: list[Any] = []
+        dropped_paths: list[str] = []
+        for idx, item in enumerate(value):
+            item_path = f"{path}[{idx}]"
+            sanitized_item, item_dropped_paths = _drop_non_finite_json_values(item, item_path)
+            dropped_paths.extend(item_dropped_paths)
+            if sanitized_item is not _DROP_JSON_VALUE:
+                sanitized_items.append(sanitized_item)
+        return sanitized_items, dropped_paths
+
+    return value, []
+
+
 class PrimeMonitor(Monitor):
     """Logs to Prime Intellect API."""
 
@@ -74,55 +123,9 @@ class PrimeMonitor(Monitor):
         """Return whether this monitor is talking to the public v1 monitoring API."""
         return urlparse(self.base_url).path.rstrip("/").endswith("/api/v1/rft")
 
-    def _normalize_presign_response(self, payload: Any) -> dict[str, str] | None:
-        """Normalize presign responses across legacy and public API shapes."""
-        if not isinstance(payload, dict):
-            return None
-
-        response_data = payload.get("data", payload)
-        if not isinstance(response_data, dict):
-            return None
-
-        presigned_url = response_data.get("presigned_url") or response_data.get("presignedUrl")
-        s3_key = response_data.get("s3_key") or response_data.get("s3Key")
-        if not isinstance(presigned_url, str) or not isinstance(s3_key, str):
-            return None
-
-        return {"presigned_url": presigned_url, "s3_key": s3_key}
-
-    def _sanitize_json_value(self, value: Any, path: str, dropped_paths: list[str]) -> Any:
-        """Drop non-finite floats so payloads remain valid JSON."""
-        if isinstance(value, float):
-            if math.isfinite(value):
-                return value
-            dropped_paths.append(path)
-            return _DROP_JSON_VALUE
-
-        if isinstance(value, dict):
-            sanitized: dict[str, Any] = {}
-            for key, item in value.items():
-                item_path = f"{path}.{key}" if path else str(key)
-                sanitized_item = self._sanitize_json_value(item, item_path, dropped_paths)
-                if sanitized_item is not _DROP_JSON_VALUE:
-                    sanitized[key] = sanitized_item
-            return sanitized
-
-        if isinstance(value, (list, tuple)):
-            sanitized_items = []
-            for idx, item in enumerate(value):
-                item_path = f"{path}[{idx}]"
-                sanitized_item = self._sanitize_json_value(item, item_path, dropped_paths)
-                if sanitized_item is not _DROP_JSON_VALUE:
-                    sanitized_items.append(sanitized_item)
-            return sanitized_items
-
-        return value
-
     def _sanitize_json_payload(self, endpoint: str, payload: dict[str, Any]) -> dict[str, Any]:
         """Return a JSON-safe payload and warn when non-finite values are dropped."""
-        dropped_paths: list[str] = []
-        sanitized_payload = self._sanitize_json_value(payload, path="", dropped_paths=dropped_paths)
-        assert isinstance(sanitized_payload, dict), "Sanitized payload must remain a dictionary"
+        sanitized_payload, dropped_paths = _drop_non_finite_json_values(payload)
 
         if dropped_paths:
             preview = ", ".join(dropped_paths[:5])
@@ -473,10 +476,7 @@ class PrimeMonitor(Monitor):
                 json={"run_id": self.run_id, "step": step},
             )
             response.raise_for_status()
-            presign_data = self._normalize_presign_response(response.json())
-            if presign_data is None:
-                self.logger.warning(f"Invalid presign response at step {step}")
-            return presign_data
+            return _normalize_presign_response(response.json())
         except Exception as e:
             self.logger.warning(f"Failed to request presigned URL: {type(e).__name__}: {e}")
             return None

--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -58,15 +58,6 @@ _SAMPLE_SCHEMA = pa.schema(
 _DROP_JSON_VALUE = object()
 
 
-def _normalize_presign_response(payload: dict[str, Any]) -> dict[str, str]:
-    """Parse the public API presign response into the monitor's internal field names."""
-    response_data = payload["data"]
-    return {
-        "presigned_url": response_data["presignedUrl"],
-        "s3_key": response_data["s3Key"],
-    }
-
-
 def _drop_non_finite_json_values(value: Any, dropped_paths: list[str], path: str = "") -> Any:
     """Remove non-finite floats so payloads remain valid JSON."""
     if isinstance(value, float):
@@ -448,7 +439,11 @@ class PrimeMonitor(Monitor):
                 json={"run_id": self.run_id, "step": step},
             )
             response.raise_for_status()
-            return _normalize_presign_response(response.json())
+            response_data = response.json()["data"]
+            return {
+                "presigned_url": response_data["presignedUrl"],
+                "s3_key": response_data["s3Key"],
+            }
         except Exception as e:
             self.logger.warning(f"Failed to request presigned URL: {type(e).__name__}: {e}")
             return None

--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -55,6 +55,39 @@ _SAMPLE_SCHEMA = pa.schema(
 )
 
 
+_DROPPED_JSON_VALUE = object()
+
+
+def _drop_non_finite_json_values(value: Any, dropped_paths: list[str], path: str = "") -> Any:
+    if isinstance(value, float) and not math.isfinite(value):
+        dropped_paths.append(path)
+        return _DROPPED_JSON_VALUE
+
+    if isinstance(value, dict):
+        return {
+            key: sanitized_item
+            for key, item in value.items()
+            if (
+                sanitized_item := _drop_non_finite_json_values(
+                    item,
+                    dropped_paths,
+                    f"{path}.{key}" if path else str(key),
+                )
+            )
+            is not _DROPPED_JSON_VALUE
+        }
+
+    if isinstance(value, list):
+        return [
+            sanitized_item
+            for idx, item in enumerate(value)
+            if (sanitized_item := _drop_non_finite_json_values(item, dropped_paths, f"{path}[{idx}]"))
+            is not _DROPPED_JSON_VALUE
+        ]
+
+    return value
+
+
 class PrimeMonitor(Monitor):
     """Logs to Prime Intellect API."""
 
@@ -67,41 +100,20 @@ class PrimeMonitor(Monitor):
 
     def _sanitize_json_payload(self, endpoint: str, payload: dict[str, Any]) -> dict[str, Any]:
         """Drop non-finite floats before sending JSON payloads to the public API."""
+        try:
+            json.dumps(payload, allow_nan=False)
+            return payload
+        except ValueError:
+            pass
+
         dropped_paths: list[str] = []
-        dropped_value = object()
-
-        def sanitize(value: Any, path: str = "") -> Any:
-            if isinstance(value, float) and not math.isfinite(value):
-                dropped_paths.append(path)
-                return dropped_value
-            if isinstance(value, dict):
-                sanitized: dict[str, Any] = {}
-                for key, item in value.items():
-                    item_path = f"{path}.{key}" if path else str(key)
-                    sanitized_item = sanitize(item, item_path)
-                    if sanitized_item is not dropped_value:
-                        sanitized[key] = sanitized_item
-                return sanitized
-            if isinstance(value, list):
-                sanitized_items: list[Any] = []
-                for idx, item in enumerate(value):
-                    item_path = f"{path}[{idx}]"
-                    sanitized_item = sanitize(item, item_path)
-                    if sanitized_item is not dropped_value:
-                        sanitized_items.append(sanitized_item)
-                return sanitized_items
-            return value
-
-        sanitized_payload = sanitize(payload)
-
-        if dropped_paths:
-            preview = ", ".join(dropped_paths[:5])
-            suffix = " ..." if len(dropped_paths) > 5 else ""
-            self.logger.warning(
-                f"Dropping {len(dropped_paths)} non-finite value(s) from Prime monitor {endpoint} payload: "
-                f"{preview}{suffix}"
-            )
-
+        sanitized_payload = _drop_non_finite_json_values(payload, dropped_paths)
+        preview = ", ".join(dropped_paths[:5])
+        suffix = " ..." if len(dropped_paths) > 5 else ""
+        self.logger.warning(
+            f"Dropping {len(dropped_paths)} non-finite value(s) from Prime monitor {endpoint} payload: "
+            f"{preview}{suffix}"
+        )
         return sanitized_payload
 
     def __init__(

--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -66,6 +66,26 @@ class PrimeMonitor(Monitor):
             "Content-Type": "application/json",
         }
 
+    def _uses_public_monitoring_api(self) -> bool:
+        """Return whether this monitor is talking to the public v1 monitoring API."""
+        return urlparse(self.base_url).path.rstrip("/").endswith("/api/v1/rft")
+
+    def _normalize_presign_response(self, payload: Any) -> dict[str, str] | None:
+        """Normalize presign responses across legacy and public API shapes."""
+        if not isinstance(payload, dict):
+            return None
+
+        response_data = payload.get("data", payload)
+        if not isinstance(response_data, dict):
+            return None
+
+        presigned_url = response_data.get("presigned_url") or response_data.get("presignedUrl")
+        s3_key = response_data.get("s3_key") or response_data.get("s3Key")
+        if not isinstance(presigned_url, str) or not isinstance(s3_key, str):
+            return None
+
+        return {"presigned_url": presigned_url, "s3_key": s3_key}
+
     def __init__(
         self,
         config: PrimeMonitorConfig | None,
@@ -373,10 +393,6 @@ class PrimeMonitor(Monitor):
                 self.logger.warning(f"Failed to get presigned URL for samples at step {step}")
                 return
 
-            if "presigned_url" not in presign_data or "s3_key" not in presign_data:
-                self.logger.warning(f"Invalid presign response at step {step}")
-                return
-
             presigned_url = presign_data["presigned_url"]
             s3_key = presign_data["s3_key"]
 
@@ -409,7 +425,10 @@ class PrimeMonitor(Monitor):
                 json={"run_id": self.run_id, "step": step},
             )
             response.raise_for_status()
-            return response.json()
+            presign_data = self._normalize_presign_response(response.json())
+            if presign_data is None:
+                self.logger.warning(f"Invalid presign response at step {step}")
+            return presign_data
         except Exception as e:
             self.logger.warning(f"Failed to request presigned URL: {type(e).__name__}: {e}")
             return None
@@ -495,22 +514,46 @@ class PrimeMonitor(Monitor):
             f"Logged distributions at step {step} to Prime Intellect API in {time.perf_counter() - start_time:.2f}s"
         )
 
+    def _submit_final_summary(self, summary: dict[str, Any]) -> bool:
+        """Submit the final summary/finalize request synchronously."""
+        try:
+            response = httpx.post(
+                f"{self.base_url}/finalize",
+                headers=self._api_headers(),
+                json={"run_id": self.run_id, "summary": summary},
+                timeout=30,
+            )
+        except httpx.HTTPError as e:
+            self.logger.warning(f"Failed to submit final summary for platform run {self.run_id}: {e}")
+            return False
+
+        if response.status_code != 200:
+            self.logger.warning(
+                f"Failed to submit final summary for platform run {self.run_id} "
+                f"(HTTP {response.status_code}): {response.text}"
+            )
+            return False
+
+        return True
+
     def save_final_summary(self, filename: str = "final_summary.json") -> None:
         """Save final summary to Prime Intellect API."""
         if not self.is_master or not self.enabled:
             return
 
         self.logger.info("Saving final summary to Prime Intellect API")
-        self._make_request(
-            "finalize",
-            {
-                "run_id": self.run_id,
-                "summary": self.history[-1] if self.history else {},
-            },
-        )
-        if os.getpid() == self._owner_pid:
-            self._finalize_run(success=True)
+        summary = self.history[-1] if self.history else {}
+        finalized_via_summary = self._submit_final_summary(summary)
+
+        if os.getpid() != self._owner_pid:
+            return
+
+        if finalized_via_summary and self._uses_public_monitoring_api():
             self._finalized = True
+            return
+
+        self._finalize_run(success=True)
+        self._finalized = True
 
     def close(self) -> None:
         """Close the HTTP client and stop the background event loop."""

--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -67,36 +67,33 @@ def _normalize_presign_response(payload: dict[str, Any]) -> dict[str, str]:
     }
 
 
-def _drop_non_finite_json_values(value: Any, path: str = "") -> tuple[Any, list[str]]:
+def _drop_non_finite_json_values(value: Any, dropped_paths: list[str], path: str = "") -> Any:
     """Remove non-finite floats so payloads remain valid JSON."""
     if isinstance(value, float):
         if math.isfinite(value):
-            return value, []
-        return _DROP_JSON_VALUE, [path]
+            return value
+        dropped_paths.append(path)
+        return _DROP_JSON_VALUE
 
     if isinstance(value, dict):
         sanitized: dict[str, Any] = {}
-        dropped_paths: list[str] = []
         for key, item in value.items():
             item_path = f"{path}.{key}" if path else str(key)
-            sanitized_item, item_dropped_paths = _drop_non_finite_json_values(item, item_path)
-            dropped_paths.extend(item_dropped_paths)
+            sanitized_item = _drop_non_finite_json_values(item, dropped_paths, item_path)
             if sanitized_item is not _DROP_JSON_VALUE:
                 sanitized[key] = sanitized_item
-        return sanitized, dropped_paths
+        return sanitized
 
     if isinstance(value, list):
         sanitized_items: list[Any] = []
-        dropped_paths: list[str] = []
         for idx, item in enumerate(value):
             item_path = f"{path}[{idx}]"
-            sanitized_item, item_dropped_paths = _drop_non_finite_json_values(item, item_path)
-            dropped_paths.extend(item_dropped_paths)
+            sanitized_item = _drop_non_finite_json_values(item, dropped_paths, item_path)
             if sanitized_item is not _DROP_JSON_VALUE:
                 sanitized_items.append(sanitized_item)
-        return sanitized_items, dropped_paths
+        return sanitized_items
 
-    return value, []
+    return value
 
 
 class PrimeMonitor(Monitor):
@@ -112,7 +109,8 @@ class PrimeMonitor(Monitor):
 
     def _sanitize_json_payload(self, endpoint: str, payload: dict[str, Any]) -> dict[str, Any]:
         """Return a JSON-safe payload and warn when non-finite values are dropped."""
-        sanitized_payload, dropped_paths = _drop_non_finite_json_values(payload)
+        dropped_paths: list[str] = []
+        sanitized_payload = _drop_non_finite_json_values(payload, dropped_paths)
 
         if dropped_paths:
             preview = ", ".join(dropped_paths[:5])

--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -1,6 +1,7 @@
 import asyncio
 import io
 import json
+import math
 import os
 import time
 from datetime import datetime, timezone
@@ -55,6 +56,9 @@ _SAMPLE_SCHEMA = pa.schema(
 )
 
 
+_DROP_JSON_VALUE = object()
+
+
 class PrimeMonitor(Monitor):
     """Logs to Prime Intellect API."""
 
@@ -85,6 +89,50 @@ class PrimeMonitor(Monitor):
             return None
 
         return {"presigned_url": presigned_url, "s3_key": s3_key}
+
+    def _sanitize_json_value(self, value: Any, path: str, dropped_paths: list[str]) -> Any:
+        """Drop non-finite floats so payloads remain valid JSON."""
+        if isinstance(value, float):
+            if math.isfinite(value):
+                return value
+            dropped_paths.append(path)
+            return _DROP_JSON_VALUE
+
+        if isinstance(value, dict):
+            sanitized: dict[str, Any] = {}
+            for key, item in value.items():
+                item_path = f"{path}.{key}" if path else str(key)
+                sanitized_item = self._sanitize_json_value(item, item_path, dropped_paths)
+                if sanitized_item is not _DROP_JSON_VALUE:
+                    sanitized[key] = sanitized_item
+            return sanitized
+
+        if isinstance(value, (list, tuple)):
+            sanitized_items = []
+            for idx, item in enumerate(value):
+                item_path = f"{path}[{idx}]"
+                sanitized_item = self._sanitize_json_value(item, item_path, dropped_paths)
+                if sanitized_item is not _DROP_JSON_VALUE:
+                    sanitized_items.append(sanitized_item)
+            return sanitized_items
+
+        return value
+
+    def _sanitize_json_payload(self, endpoint: str, payload: dict[str, Any]) -> dict[str, Any]:
+        """Return a JSON-safe payload and warn when non-finite values are dropped."""
+        dropped_paths: list[str] = []
+        sanitized_payload = self._sanitize_json_value(payload, path="", dropped_paths=dropped_paths)
+        assert isinstance(sanitized_payload, dict), "Sanitized payload must remain a dictionary"
+
+        if dropped_paths:
+            preview = ", ".join(dropped_paths[:5])
+            suffix = " ..." if len(dropped_paths) > 5 else ""
+            self.logger.warning(
+                f"Dropping {len(dropped_paths)} non-finite value(s) from Prime monitor {endpoint} payload: "
+                f"{preview}{suffix}"
+            )
+
+        return sanitized_payload
 
     def __init__(
         self,
@@ -516,11 +564,16 @@ class PrimeMonitor(Monitor):
 
     def _submit_final_summary(self, summary: dict[str, Any]) -> bool:
         """Submit the final summary/finalize request synchronously."""
+        payload = self._sanitize_json_payload(
+            "finalize",
+            {"run_id": self.run_id, "summary": summary},
+        )
+
         try:
             response = httpx.post(
                 f"{self.base_url}/finalize",
                 headers=self._api_headers(),
-                json={"run_id": self.run_id, "summary": summary},
+                json=payload,
                 timeout=30,
             )
         except httpx.HTTPError as e:
@@ -626,13 +679,14 @@ class PrimeMonitor(Monitor):
     async def _make_request_async(self, endpoint: str, data: dict[str, Any], max_retries: int = 3) -> None:
         """Make an async POST request to the Prime Intellect API with retries."""
         full_endpoint = f"{self.base_url}/{endpoint}"
+        sanitized_data = self._sanitize_json_payload(endpoint, data)
 
         for attempt in range(max_retries):
             try:
                 response = await self._client.post(
                     full_endpoint,
                     headers=self._api_headers(),
-                    json=data,
+                    json=sanitized_data,
                 )
                 response.raise_for_status()
                 return  # Success

--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -58,21 +58,13 @@ _SAMPLE_SCHEMA = pa.schema(
 _DROP_JSON_VALUE = object()
 
 
-def _normalize_presign_response(payload: Any) -> dict[str, str]:
-    """Normalize presign responses across legacy and public API shapes."""
-    if not isinstance(payload, dict):
-        raise ValueError("Presign response must be a JSON object")
-
-    response_data = payload.get("data", payload)
-    if not isinstance(response_data, dict):
-        raise ValueError("Presign response data must be a JSON object")
-
-    presigned_url = response_data.get("presigned_url") or response_data.get("presignedUrl")
-    s3_key = response_data.get("s3_key") or response_data.get("s3Key")
-    if not isinstance(presigned_url, str) or not isinstance(s3_key, str):
-        raise ValueError("Presign response is missing presigned URL or S3 key")
-
-    return {"presigned_url": presigned_url, "s3_key": s3_key}
+def _normalize_presign_response(payload: dict[str, Any]) -> dict[str, str]:
+    """Parse the public API presign response into the monitor's internal field names."""
+    response_data = payload["data"]
+    return {
+        "presigned_url": response_data["presignedUrl"],
+        "s3_key": response_data["s3Key"],
+    }
 
 
 def _drop_non_finite_json_values(value: Any, path: str = "") -> tuple[Any, list[str]]:

--- a/tests/unit/utils/test_prime_monitor.py
+++ b/tests/unit/utils/test_prime_monitor.py
@@ -1,9 +1,19 @@
+import asyncio
 import io
 import json
+from unittest.mock import AsyncMock, MagicMock
 
 import pyarrow.parquet as pq
 
 from prime_rl.utils.monitor.prime import PrimeMonitor
+
+
+def _make_monitor(**attrs) -> PrimeMonitor:
+    monitor = PrimeMonitor.__new__(PrimeMonitor)
+    monitor._closed = True
+    for key, value in attrs.items():
+        setattr(monitor, key, value)
+    return monitor
 
 
 def _build_rollout(*, example_id: int, reward: float, task: str) -> dict:
@@ -35,8 +45,7 @@ def _build_rollout(*, example_id: int, reward: float, task: str) -> dict:
 
 
 def test_rollouts_to_parquet_bytes_preserves_all_rollouts_and_ids():
-    monitor = PrimeMonitor.__new__(PrimeMonitor)
-    monitor.run_id = "run-123"
+    monitor = _make_monitor(run_id="run-123")
 
     parquet_bytes = monitor._rollouts_to_parquet_bytes(
         [
@@ -61,8 +70,7 @@ def test_rollouts_to_parquet_bytes_preserves_all_rollouts_and_ids():
 
 
 def test_rollouts_to_parquet_bytes_skips_rollouts_without_trajectory():
-    monitor = PrimeMonitor.__new__(PrimeMonitor)
-    monitor.run_id = "run-456"
+    monitor = _make_monitor(run_id="run-456")
 
     parquet_bytes = monitor._rollouts_to_parquet_bytes(
         [
@@ -85,3 +93,90 @@ def test_rollouts_to_parquet_bytes_skips_rollouts_without_trajectory():
     assert len(rows) == 1
     assert rows[0]["problem_id"] == 1
     assert rows[0]["sample_id"] == 0
+
+
+def test_api_headers_include_bearer_and_x_api_key():
+    monitor = _make_monitor(api_key="pit-test")
+
+    assert monitor._api_headers() == {
+        "Authorization": "Bearer pit-test",
+        "x-api-key": "pit-test",
+        "Content-Type": "application/json",
+    }
+
+
+def test_make_request_async_uses_bearer_auth_headers():
+    monitor = _make_monitor(
+        api_key="pit-test",
+        base_url="https://api.primeintellect.ai/api/v1/rft",
+        _client=AsyncMock(),
+    )
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    monitor._client.post.return_value = response
+    monitor.logger = MagicMock()
+
+    asyncio.run(monitor._make_request_async("metrics", {"run_id": "run-123"}, max_retries=1))
+
+    monitor._client.post.assert_called_once_with(
+        "https://api.primeintellect.ai/api/v1/rft/metrics",
+        headers={
+            "Authorization": "Bearer pit-test",
+            "x-api-key": "pit-test",
+            "Content-Type": "application/json",
+        },
+        json={"run_id": "run-123"},
+    )
+
+
+def test_request_presigned_url_uses_bearer_auth_headers():
+    monitor = _make_monitor(
+        api_key="pit-test",
+        run_id="run-123",
+        base_url="https://api.primeintellect.ai/api/v1/rft",
+        _client=AsyncMock(),
+    )
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.json.return_value = {"presigned_url": "https://upload", "s3_key": "samples/key"}
+    monitor._client.post.return_value = response
+    monitor.logger = MagicMock()
+
+    presign_data = asyncio.run(monitor._request_presigned_url(step=5))
+
+    assert presign_data == {"presigned_url": "https://upload", "s3_key": "samples/key"}
+    monitor._client.post.assert_called_once_with(
+        "https://api.primeintellect.ai/api/v1/rft/samples/presign",
+        headers={
+            "Authorization": "Bearer pit-test",
+            "x-api-key": "pit-test",
+            "Content-Type": "application/json",
+        },
+        json={"run_id": "run-123", "step": 5},
+    )
+
+
+def test_confirm_samples_upload_uses_bearer_auth_headers():
+    monitor = _make_monitor(
+        api_key="pit-test",
+        run_id="run-123",
+        base_url="https://api.primeintellect.ai/api/v1/rft",
+        _client=AsyncMock(),
+    )
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    monitor._client.post.return_value = response
+    monitor.logger = MagicMock()
+
+    upload_confirmed = asyncio.run(monitor._confirm_samples_upload(step=5, s3_key="samples/key", max_retries=1))
+
+    assert upload_confirmed is True
+    monitor._client.post.assert_called_once_with(
+        "https://api.primeintellect.ai/api/v1/rft/samples/confirm",
+        headers={
+            "Authorization": "Bearer pit-test",
+            "x-api-key": "pit-test",
+            "Content-Type": "application/json",
+        },
+        json={"run_id": "run-123", "step": 5, "s3_key": "samples/key"},
+    )

--- a/tests/unit/utils/test_prime_monitor.py
+++ b/tests/unit/utils/test_prime_monitor.py
@@ -1,9 +1,26 @@
 import io
 import json
+import sys
+from types import ModuleType
+from unittest.mock import Mock
 
 import pyarrow.parquet as pq
 
+prime_cli_module = ModuleType("prime_cli")
+prime_cli_core_module = ModuleType("prime_cli.core")
+prime_cli_config_module = ModuleType("prime_cli.core.config")
+prime_cli_config_module.Config = type("Config", (), {})
+sys.modules.setdefault("prime_cli", prime_cli_module)
+sys.modules.setdefault("prime_cli.core", prime_cli_core_module)
+sys.modules.setdefault("prime_cli.core.config", prime_cli_config_module)
+
 from prime_rl.utils.monitor.prime import PrimeMonitor
+
+
+def _new_monitor() -> PrimeMonitor:
+    monitor = PrimeMonitor.__new__(PrimeMonitor)
+    monitor._closed = True
+    return monitor
 
 
 def _build_rollout(*, example_id: int, reward: float, task: str) -> dict:
@@ -35,7 +52,7 @@ def _build_rollout(*, example_id: int, reward: float, task: str) -> dict:
 
 
 def test_rollouts_to_parquet_bytes_preserves_all_rollouts_and_ids():
-    monitor = PrimeMonitor.__new__(PrimeMonitor)
+    monitor = _new_monitor()
     monitor.run_id = "run-123"
 
     parquet_bytes = monitor._rollouts_to_parquet_bytes(
@@ -61,7 +78,7 @@ def test_rollouts_to_parquet_bytes_preserves_all_rollouts_and_ids():
 
 
 def test_rollouts_to_parquet_bytes_skips_rollouts_without_trajectory():
-    monitor = PrimeMonitor.__new__(PrimeMonitor)
+    monitor = _new_monitor()
     monitor.run_id = "run-456"
 
     parquet_bytes = monitor._rollouts_to_parquet_bytes(
@@ -85,3 +102,20 @@ def test_rollouts_to_parquet_bytes_skips_rollouts_without_trajectory():
     assert len(rows) == 1
     assert rows[0]["problem_id"] == 1
     assert rows[0]["sample_id"] == 0
+
+
+def test_sanitize_json_payload_drops_non_finite_values_and_logs_paths():
+    monitor = _new_monitor()
+    monitor.logger = Mock()
+
+    payload = {
+        "metrics": {"finite": 1.0, "nan": float("nan")},
+        "distributions": [0.5, float("inf")],
+    }
+
+    sanitized = monitor._sanitize_json_payload("metrics", payload)
+
+    assert sanitized == {"metrics": {"finite": 1.0}, "distributions": [0.5]}
+    monitor.logger.warning.assert_called_once_with(
+        "Dropping 2 non-finite value(s) from Prime monitor metrics payload: metrics.nan, distributions[1]"
+    )

--- a/tests/unit/utils/test_prime_monitor.py
+++ b/tests/unit/utils/test_prime_monitor.py
@@ -1,19 +1,9 @@
-import asyncio
 import io
 import json
-from unittest.mock import AsyncMock, MagicMock
 
 import pyarrow.parquet as pq
 
 from prime_rl.utils.monitor.prime import PrimeMonitor
-
-
-def _make_monitor(**attrs) -> PrimeMonitor:
-    monitor = PrimeMonitor.__new__(PrimeMonitor)
-    monitor._closed = True
-    for key, value in attrs.items():
-        setattr(monitor, key, value)
-    return monitor
 
 
 def _build_rollout(*, example_id: int, reward: float, task: str) -> dict:
@@ -45,7 +35,8 @@ def _build_rollout(*, example_id: int, reward: float, task: str) -> dict:
 
 
 def test_rollouts_to_parquet_bytes_preserves_all_rollouts_and_ids():
-    monitor = _make_monitor(run_id="run-123")
+    monitor = PrimeMonitor.__new__(PrimeMonitor)
+    monitor.run_id = "run-123"
 
     parquet_bytes = monitor._rollouts_to_parquet_bytes(
         [
@@ -70,7 +61,8 @@ def test_rollouts_to_parquet_bytes_preserves_all_rollouts_and_ids():
 
 
 def test_rollouts_to_parquet_bytes_skips_rollouts_without_trajectory():
-    monitor = _make_monitor(run_id="run-456")
+    monitor = PrimeMonitor.__new__(PrimeMonitor)
+    monitor.run_id = "run-456"
 
     parquet_bytes = monitor._rollouts_to_parquet_bytes(
         [
@@ -93,90 +85,3 @@ def test_rollouts_to_parquet_bytes_skips_rollouts_without_trajectory():
     assert len(rows) == 1
     assert rows[0]["problem_id"] == 1
     assert rows[0]["sample_id"] == 0
-
-
-def test_api_headers_include_bearer_and_x_api_key():
-    monitor = _make_monitor(api_key="pit-test")
-
-    assert monitor._api_headers() == {
-        "Authorization": "Bearer pit-test",
-        "x-api-key": "pit-test",
-        "Content-Type": "application/json",
-    }
-
-
-def test_make_request_async_uses_bearer_auth_headers():
-    monitor = _make_monitor(
-        api_key="pit-test",
-        base_url="https://api.primeintellect.ai/api/v1/rft",
-        _client=AsyncMock(),
-    )
-    response = MagicMock()
-    response.raise_for_status = MagicMock()
-    monitor._client.post.return_value = response
-    monitor.logger = MagicMock()
-
-    asyncio.run(monitor._make_request_async("metrics", {"run_id": "run-123"}, max_retries=1))
-
-    monitor._client.post.assert_called_once_with(
-        "https://api.primeintellect.ai/api/v1/rft/metrics",
-        headers={
-            "Authorization": "Bearer pit-test",
-            "x-api-key": "pit-test",
-            "Content-Type": "application/json",
-        },
-        json={"run_id": "run-123"},
-    )
-
-
-def test_request_presigned_url_uses_bearer_auth_headers():
-    monitor = _make_monitor(
-        api_key="pit-test",
-        run_id="run-123",
-        base_url="https://api.primeintellect.ai/api/v1/rft",
-        _client=AsyncMock(),
-    )
-    response = MagicMock()
-    response.raise_for_status = MagicMock()
-    response.json.return_value = {"presigned_url": "https://upload", "s3_key": "samples/key"}
-    monitor._client.post.return_value = response
-    monitor.logger = MagicMock()
-
-    presign_data = asyncio.run(monitor._request_presigned_url(step=5))
-
-    assert presign_data == {"presigned_url": "https://upload", "s3_key": "samples/key"}
-    monitor._client.post.assert_called_once_with(
-        "https://api.primeintellect.ai/api/v1/rft/samples/presign",
-        headers={
-            "Authorization": "Bearer pit-test",
-            "x-api-key": "pit-test",
-            "Content-Type": "application/json",
-        },
-        json={"run_id": "run-123", "step": 5},
-    )
-
-
-def test_confirm_samples_upload_uses_bearer_auth_headers():
-    monitor = _make_monitor(
-        api_key="pit-test",
-        run_id="run-123",
-        base_url="https://api.primeintellect.ai/api/v1/rft",
-        _client=AsyncMock(),
-    )
-    response = MagicMock()
-    response.raise_for_status = MagicMock()
-    monitor._client.post.return_value = response
-    monitor.logger = MagicMock()
-
-    upload_confirmed = asyncio.run(monitor._confirm_samples_upload(step=5, s3_key="samples/key", max_retries=1))
-
-    assert upload_confirmed is True
-    monitor._client.post.assert_called_once_with(
-        "https://api.primeintellect.ai/api/v1/rft/samples/confirm",
-        headers={
-            "Authorization": "Bearer pit-test",
-            "x-api-key": "pit-test",
-            "Content-Type": "application/json",
-        },
-        json={"run_id": "run-123", "step": 5, "s3_key": "samples/key"},
-    )

--- a/tests/unit/utils/test_prime_monitor.py
+++ b/tests/unit/utils/test_prime_monitor.py
@@ -1,18 +1,8 @@
 import io
 import json
-import sys
-from types import ModuleType
 from unittest.mock import Mock
 
 import pyarrow.parquet as pq
-
-prime_cli_module = ModuleType("prime_cli")
-prime_cli_core_module = ModuleType("prime_cli.core")
-prime_cli_config_module = ModuleType("prime_cli.core.config")
-prime_cli_config_module.Config = type("Config", (), {})
-sys.modules.setdefault("prime_cli", prime_cli_module)
-sys.modules.setdefault("prime_cli.core", prime_cli_core_module)
-sys.modules.setdefault("prime_cli.core.config", prime_cli_config_module)
 
 from prime_rl.utils.monitor.prime import PrimeMonitor
 


### PR DESCRIPTION
## Summary
Fix the remaining Prime monitor public API mismatches by keeping bearer auth for uploads, normalizing `/samples/presign` responses that come back as nested camelCase data, avoiding the duplicate completion update after a successful `/finalize`, and dropping non-finite metric/distribution values before JSON upload so monitor requests do not fail on `NaN`. The payload normalization helpers were also simplified into small pure helpers to keep the monitor flow easier to reason about.

## Verification
- Local synthetic E2E on macOS against a temporary server that exercised registration, metrics, distributions, samples presign/upload/confirm, and finalize with the public `/api/v1/rft` response shape
- Local synthetic E2E on macOS that verified `NaN` values are dropped from metrics, distributions, and final summary payloads before upload
- Synthetic E2E rerun on the RTX 6000 machine against a temporary local server there; registration, metrics, distributions, samples presign/upload/confirm, and finalize all succeeded on the target machine
- Direct production auth check on the RTX 6000 machine with the provided token: `x-api-key` returned 403 Not authenticated and bearer/both returned 401 Invalid token, so full production validation is currently blocked by credentials rather than code
- `VIRTUAL_ENV=$PWD/.venv PATH=$PWD/.venv/bin:$PATH uv run --active --no-project ruff check src/prime_rl/utils/monitor/prime.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request headers, endpoints, and finalize flow for PrimeMonitor uploads; mistakes could break run registration, sample uploads, or completion status updates. Adds sanitization that drops `NaN`/`inf` values, which changes what data is persisted if metrics are non-finite.
> 
> **Overview**
> Fixes Prime public API mismatches in `PrimeMonitor` by standardizing request headers (Bearer + `x-api-key`) and using consistent base URL paths for run registration/status updates and sample presign/confirm calls.
> 
> Normalizes the `/samples/presign` response shape (nested `data` with camelCase keys) and updates finalize behavior to avoid a redundant status update when `/finalize` succeeds.
> 
> Adds JSON payload sanitization to **drop non-finite floats** (`NaN`/`inf`) before uploads (metrics, distributions, finalize summary), logging the dropped field paths; includes a unit test covering the sanitization behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00acb9d1b4f8667453bcc38c00f25b90be7e9cdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->