### PR TITLE
fix: force weight broadcast at step 0 for NCCL mode

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -402,23 +402,19 @@ async def orchestrate(config: OrchestratorConfig):
         else:
             # Allow eval at resumed step by setting prev_ckpt_step one behind
             prev_ckpt_step = scheduler.ckpt_step - 1
-
-        if enable_policy_updates:
-            # In NCCL mode, skip existence check - weights are broadcasted, not stored on disk
-            check_exists = config.weight_broadcast.type != "nccl"
-            wait_timeout = config.ckpt.wait_for_weights_timeout if config.ckpt else None
-            weights_path = get_weight_dir(
-                config.output_dir, scheduler.ckpt_step, check_exists=check_exists, wait_timeout=wait_timeout
-            )
-            lora_name = config.model.lora.name if config.model.lora else None
-            await inference_pool.update_weights(weights_path, lora_name=lora_name, step=scheduler.ckpt_step)
     else:
         logger.info("Training from scratch")
-        # For NCCL broadcast, trigger weight update at step 0 to initialize inference workers
-        if enable_policy_updates and config.weight_broadcast.type == "nccl":
-            weights_path = get_step_path(get_broadcast_dir(config.output_dir), 0)
-            lora_name = config.model.lora.name if config.model.lora else None
-            await inference_pool.update_weights(weights_path, lora_name=lora_name, step=0)
+
+    # Update weights at step 0 (or checkpoint step if resuming)
+    if enable_policy_updates:
+        # In NCCL mode, skip existence check - weights are broadcasted, not stored on disk
+        check_exists = config.weight_broadcast.type != "nccl"
+        wait_timeout = config.ckpt.wait_for_weights_timeout if config.ckpt and checkpoint_step is not None else None
+        weights_path = get_weight_dir(
+            config.output_dir, scheduler.ckpt_step, check_exists=check_exists, wait_timeout=wait_timeout
+        )
+        lora_name = config.model.lora.name if config.model.lora else None
+        await inference_pool.update_weights(weights_path, lora_name=lora_name, step=scheduler.ckpt_step)
 
     # Iterate over dataset in batches
     max_steps = config.max_steps or int(1e9)

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -414,6 +414,10 @@ async def orchestrate(config: OrchestratorConfig):
             await inference_pool.update_weights(weights_path, lora_name=lora_name, step=scheduler.ckpt_step)
     else:
         logger.info("Training from scratch")
+        # For NCCL broadcast, trigger weight update at step 0 to initialize inference workers
+        if enable_policy_updates and config.weight_broadcast.type == "nccl":
+            weights_path = get_step_path(get_broadcast_dir(config.output_dir), 0)
+            await inference_pool.update_weights(weights_path, step=0)
 
     # Iterate over dataset in batches
     max_steps = config.max_steps or int(1e9)

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -417,7 +417,8 @@ async def orchestrate(config: OrchestratorConfig):
         # For NCCL broadcast, trigger weight update at step 0 to initialize inference workers
         if enable_policy_updates and config.weight_broadcast.type == "nccl":
             weights_path = get_step_path(get_broadcast_dir(config.output_dir), 0)
-            await inference_pool.update_weights(weights_path, step=0)
+            lora_name = config.model.lora.name if config.model.lora else None
+            await inference_pool.update_weights(weights_path, lora_name=lora_name, step=0)
 
     # Iterate over dataset in batches
     max_steps = config.max_steps or int(1e9)

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -406,7 +406,8 @@ async def orchestrate(config: OrchestratorConfig):
         logger.info("Training from scratch")
 
     # Update weights at step 0 (or checkpoint step if resuming)
-    if enable_policy_updates:
+    # For NCCL broadcast, we always update weights. For filesystem broadcast, we only update when resuming.
+    if enable_policy_updates and (checkpoint_step is not None or config.weight_broadcast.type == "nccl"):
         # In NCCL mode, skip existence check - weights are broadcasted, not stored on disk
         check_exists = config.weight_broadcast.type != "nccl"
         wait_timeout = config.ckpt.wait_for_weights_timeout if config.ckpt and checkpoint_step is not None else None

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -114,6 +114,10 @@ def train(config: TrainerConfig):
         config.output_dir, config.max_concurrent_runs, torch.device("cuda", world.local_rank), config.model.lora
     )
 
+    # For single-run, set ready_to_update to True at initialization to allow weight broadcast at step 0
+    if config.max_concurrent_runs == 1:
+        multi_run_manager.ready_to_update[0] = True
+
     # Initialize parallel dimensions
     parallel_dims = get_parallel_dims(config.model)
 

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -114,8 +114,11 @@ def train(config: TrainerConfig):
         config.output_dir, config.max_concurrent_runs, torch.device("cuda", world.local_rank), config.model.lora
     )
 
-    # For single-run, set ready_to_update to True at initialization to allow weight broadcast at step 0
+    # For single-run, discover the run and set ready_to_update to allow weight broadcast at step 0
     if config.max_concurrent_runs == 1:
+        if world.is_master:
+            multi_run_manager.discover_runs()
+        multi_run_manager.synchronize_state()
         multi_run_manager.ready_to_update[0] = True
 
     # Initialize parallel dimensions

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -242,7 +242,9 @@ def train(config: TrainerConfig):
             broadcast_weights_time = 0
         else:
             last_async_level_steps = config.max_steps and progress.step >= config.max_steps - config.max_async_level
-            if not last_async_level_steps or config.weight_broadcast.type == "filesystem":
+            # Skip broadcast only if we're in the last async level steps AND not at step 0
+            # At step 0, we always broadcast to avoid deadlock when max_steps <= max_async_level
+            if progress.step == 0 or (not last_async_level_steps or config.weight_broadcast.type == "filesystem"):
                 broadcast_weights_start_time = time.perf_counter()
                 weight_broadcast.broadcast_weights(model, step=progress.step)
                 broadcast_weights_time = time.perf_counter() - broadcast_weights_start_time

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -229,13 +229,13 @@ def train(config: TrainerConfig):
             gc_handler.run(progress.step)
         is_last_step = config.max_steps is not None and progress.step == config.max_steps
 
-        # Broadcast weights at every step, (except step 0, because no need to broadcast the base model)
-        # Also, with NCCL broadcast, we do not broadcast weights the last async level step as the orchestrator is already finished and will not initialize the receive on the inference; for filesystem broadcast, we do "broadcast" until the final step to allow to resume from the broadcast directory
+        # Broadcast weights at every step
+        # With NCCL broadcast, we do not broadcast weights the last async level step as the orchestrator is already finished and will not initialize the receive on the inference; for filesystem broadcast, we do "broadcast" until the final step to allow to resume from the broadcast directory
         if weight_broadcast is None:
             broadcast_weights_time = 0
         else:
             last_async_level_steps = config.max_steps and progress.step >= config.max_steps - config.max_async_level
-            if progress.step > 0 and (not last_async_level_steps or config.weight_broadcast.type == "filesystem"):
+            if not last_async_level_steps or config.weight_broadcast.type == "filesystem":
                 broadcast_weights_start_time = time.perf_counter()
                 weight_broadcast.broadcast_weights(model, step=progress.step)
                 broadcast_weights_time = time.perf_counter() - broadcast_weights_start_time


### PR DESCRIPTION
## Summary
- Forces weight broadcast at step 0 for NCCL mode when starting from scratch
- Matches orchestrator behavior when resuming from checkpoint
- Ensures weight synchronization at the start of every run

## Changes

### Orchestrator (`src/prime_rl/orchestrator/orchestrator.py`)
- Added logic to call `update_weights()` at step 0 for NCCL mode when starting from scratch
- This creates the NCCL_READY marker and triggers inference workers to receive weights

### Trainer (`src/prime_rl/trainer/rl/train.py`)
- Set `ready_to_update[0] = True` at initialization for single-run mode
- Removed the `progress.step > 0` condition from weight broadcast logic
- Weights are now broadcast at all steps including step 0

## Flow

**NCCL Broadcast at Step 0 (starting from scratch):**
1. Orchestrator calls `update_weights(weights_path, step=0)` → creates NCCL_READY marker
2. Trainer sets `ready_to_update[0] = True` at initialization
3. Trainer broadcasts weights at step 0
4. Inference workers receive weights via NCCL

**Filesystem Broadcast at Step 0 (starting from scratch):**
1. Trainer sets `ready_to_update[0] = True` at initialization
2. Trainer broadcasts weights at step 0 → saves to filesystem with STABLE marker
3. Orchestrator detects STABLE marker and loads weights

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes weight broadcast/update sequencing between trainer, orchestrator, and inference pools; mistakes could cause startup deadlocks or inference using stale weights, especially in NCCL mode and short runs.
> 
> **Overview**
> Ensures **initial weight synchronization at step 0** for NCCL weight broadcast, aligning “start from scratch” behavior with resume-from-checkpoint.
> 
> In the orchestrator, `inference_pool.update_weights()` is now invoked at the initial step for NCCL (and still on resume for filesystem mode). In the trainer, single-run mode marks the run `ready_to_update` immediately and the broadcast loop now allows broadcasting at step 0 (while still skipping NCCL broadcasts during the final async-level window).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e6c92b015df96c5f086aef4e81c1e27c8558e79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->