### PR TITLE
feat: make gradient clipping optional, error with DeepEP

### DIFF
--- a/src/prime_rl/configs/sft.py
+++ b/src/prime_rl/configs/sft.py
@@ -272,6 +272,15 @@ class SFTConfig(BaseConfig):
     ### Validate configs (e.g. raise for unsupported (combinations of) configs)
 
     @model_validator(mode="after")
+    def deepep_incompatible_with_grad_clipping(self):
+        if self.model.ep_comm_backend == "deepep" and self.optim.max_norm is not None:
+            raise ValueError(
+                "Gradient clipping (optim.max_norm) is not compatible with DeepEP (model.ep_comm_backend='deepep'). "
+                "Set optim.max_norm to null to disable gradient clipping."
+            )
+        return self
+
+    @model_validator(mode="after")
     def validate_deployment(self):
         if self.deployment.type == "multi_node" and self.slurm is None:
             raise ValueError("Must use SLURM for multi-node deployment.")

--- a/src/prime_rl/configs/sft.py
+++ b/src/prime_rl/configs/sft.py
@@ -1,3 +1,4 @@
+import warnings
 from pathlib import Path
 from typing import Annotated, Literal, TypeAlias
 
@@ -272,12 +273,14 @@ class SFTConfig(BaseConfig):
     ### Validate configs (e.g. raise for unsupported (combinations of) configs)
 
     @model_validator(mode="after")
-    def deepep_incompatible_with_grad_clipping(self):
+    def deepep_disables_grad_clipping(self):
         if self.model.ep_comm_backend == "deepep" and self.optim.max_norm is not None:
-            raise ValueError(
-                "Gradient clipping (optim.max_norm) is not compatible with DeepEP (model.ep_comm_backend='deepep'). "
-                "Set optim.max_norm to null to disable gradient clipping."
+            warnings.warn(
+                "Gradient clipping is not compatible with DeepEP. "
+                "Automatically setting optim.max_norm to None (disabled).",
+                stacklevel=1,
             )
+            self.optim.max_norm = None
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/configs/trainer.py
+++ b/src/prime_rl/configs/trainer.py
@@ -1,3 +1,4 @@
+import warnings
 from pathlib import Path
 from typing import Annotated, Any, Literal, TypeAlias
 
@@ -824,12 +825,14 @@ class TrainerConfig(BaseConfig):
     ] = 1
 
     @model_validator(mode="after")
-    def deepep_incompatible_with_grad_clipping(self):
+    def deepep_disables_grad_clipping(self):
         if self.model.ep_comm_backend == "deepep" and self.optim.max_norm is not None:
-            raise ValueError(
-                "Gradient clipping (optim.max_norm) is not compatible with DeepEP (model.ep_comm_backend='deepep'). "
-                "Set optim.max_norm to null to disable gradient clipping."
+            warnings.warn(
+                "Gradient clipping is not compatible with DeepEP. "
+                "Automatically setting optim.max_norm to None (disabled).",
+                stacklevel=1,
             )
+            self.optim.max_norm = None
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/configs/trainer.py
+++ b/src/prime_rl/configs/trainer.py
@@ -481,7 +481,9 @@ SchedulerConfig: TypeAlias = Annotated[
 class BaseOptimizerConfig(BaseModel):
     lr: Annotated[float, Field(ge=0)] = 1e-6
     weight_decay: Annotated[float, Field(ge=0)] = 0.01
-    max_norm: Annotated[float, Field(ge=0, description="Maximum gradient norm to clip.")] = 1.0
+    max_norm: Annotated[
+        float | None, Field(ge=0, description="Maximum gradient norm to clip. If None, gradient clipping is disabled.")
+    ] = 1.0
 
 
 class SGDConfig(BaseOptimizerConfig):
@@ -820,6 +822,15 @@ class TrainerConfig(BaseConfig):
             description="The maximum number of concurrent runs to allow. If 1, then only one run will be allowed at a time.",
         ),
     ] = 1
+
+    @model_validator(mode="after")
+    def deepep_incompatible_with_grad_clipping(self):
+        if self.model.ep_comm_backend == "deepep" and self.optim.max_norm is not None:
+            raise ValueError(
+                "Gradient clipping (optim.max_norm) is not compatible with DeepEP (model.ep_comm_backend='deepep'). "
+                "Set optim.max_norm to null to disable gradient clipping."
+            )
+        return self
 
     @model_validator(mode="after")
     def vlms_require_bfloat16(self):

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -570,7 +570,7 @@ def train(config: TrainerConfig):
                 step=progress.step,
                 loss=tensor_stats["loss/mean"],
                 throughput=throughput,
-                grad_norm=grad_norm.item() if grad_norm is not None else 0.0,
+                grad_norm=grad_norm.item() if grad_norm is not None else None,
                 peak_memory_gib=peak_memory,
                 learning_rate=current_lr,
                 mfu=mfu,

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -465,12 +465,14 @@ def train(config: TrainerConfig):
             logger.debug(micro_step_message)
 
         # Optionally, clip the gradients
+        grad_norm: torch.Tensor | None = None
+        if config.optim.max_norm is not None:
+            grad_norm = clip_grad_norm_(
+                model.parameters(), max_norm=config.optim.max_norm, ep_enabled=parallel_dims.ep_enabled
+            )
+            if grad_norm.device.type == "cpu":
+                grad_norm = grad_norm.to(torch.device("cuda"))
 
-        grad_norm = clip_grad_norm_(
-            model.parameters(), max_norm=config.optim.max_norm, ep_enabled=parallel_dims.ep_enabled
-        )
-        if grad_norm.device.type == "cpu":
-            grad_norm = grad_norm.to(torch.device("cuda"))
         zero_grad_ratio = get_zero_gradient_ratio(model.parameters(), parallel_dims.dp_replicate)
 
         # Update the model parameters
@@ -509,7 +511,9 @@ def train(config: TrainerConfig):
         step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {tensor_stats['loss/mean']:.4f} | Entropy: {tensor_stats['entropy/mean']:.4f}"
         if "mismatch_kl/mean" in tensor_stats:
             step_message += f" | Mismatch KL: {tensor_stats['mismatch_kl/mean']:.4f}"
-        step_message += f" | Grad. Norm: {grad_norm:.4f} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}% | Peak Mem.: {peak_memory:.1f} GiB"
+        if grad_norm is not None:
+            step_message += f" | Grad. Norm: {grad_norm:.4f}"
+        step_message += f" | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}% | Peak Mem.: {peak_memory:.1f} GiB"
         if "max_vio/mean" in tensor_stats:
             step_message += f" | Max Vio: {tensor_stats['max_vio/mean']:.4f}"
         logger.success(step_message)
@@ -525,12 +529,13 @@ def train(config: TrainerConfig):
         monitor.log(perf_metrics, step=progress.step)
 
         # Log optimizer metrics
-        optim_metrics = {
+        optim_metrics: dict = {
             "optim/lr": current_lr,
-            "optim/grad_norm": grad_norm.item(),
             "optim/zero_grad_ratio": zero_grad_ratio,
             "step": progress.step,
         }
+        if grad_norm is not None:
+            optim_metrics["optim/grad_norm"] = grad_norm.item()
         monitor.log(optim_metrics, step=progress.step)
 
         # Compute derived metrics
@@ -565,7 +570,7 @@ def train(config: TrainerConfig):
                 step=progress.step,
                 loss=tensor_stats["loss/mean"],
                 throughput=throughput,
-                grad_norm=grad_norm.item(),
+                grad_norm=grad_norm.item() if grad_norm is not None else 0.0,
                 peak_memory_gib=peak_memory,
                 learning_rate=current_lr,
                 mfu=mfu,

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -529,7 +529,7 @@ def train(config: TrainerConfig):
         monitor.log(perf_metrics, step=progress.step)
 
         # Log optimizer metrics
-        optim_metrics: dict = {
+        optim_metrics = {
             "optim/lr": current_lr,
             "optim/zero_grad_ratio": zero_grad_ratio,
             "step": progress.step,

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -473,7 +473,7 @@ def train(config: SFTConfig):
         monitor.log(perf_metrics, step=progress.step)
 
         # Log optimizer metrics
-        optim_metrics: dict = {
+        optim_metrics = {
             "optim/lr": current_lr,
             "optim/zero_grad_ratio": zero_grad_ratio,
             "step": progress.step,

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -396,12 +396,14 @@ def train(config: SFTConfig):
             batch_loss = 0.0
         nan_loss_count = nan_loss_count.item()
 
-        logger.debug(f"Clipping gradients with max norm {config.optim.max_norm}")
-        grad_norm = clip_grad_norm_(
-            model.parameters(), max_norm=config.optim.max_norm, ep_enabled=parallel_dims.ep_enabled
-        )
-        if grad_norm.device.type == "cpu":
-            grad_norm = grad_norm.to(torch.device("cuda"))
+        grad_norm: torch.Tensor | None = None
+        if config.optim.max_norm is not None:
+            logger.debug(f"Clipping gradients with max norm {config.optim.max_norm}")
+            grad_norm = clip_grad_norm_(
+                model.parameters(), max_norm=config.optim.max_norm, ep_enabled=parallel_dims.ep_enabled
+            )
+            if grad_norm.device.type == "cpu":
+                grad_norm = grad_norm.to(torch.device("cuda"))
         zero_grad_ratio = get_zero_gradient_ratio(model.parameters(), parallel_dims.dp_replicate)
 
         logger.debug("Optimizer step")
@@ -429,7 +431,10 @@ def train(config: SFTConfig):
 
         # Log step metrics
         step_time = time.perf_counter() - step_start_time
-        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {batch_loss:.4f} | Grad. Norm: {grad_norm:.4f} | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}% | Peak Mem.: {peak_memory:.1f}/{max_memory:.1f} GiB ({peak_memory / max_memory * 100:.1f}%)"
+        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {batch_loss:.4f}"
+        if grad_norm is not None:
+            step_message += f" | Grad. Norm: {grad_norm:.4f}"
+        step_message += f" | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}% | Peak Mem.: {peak_memory:.1f}/{max_memory:.1f} GiB ({peak_memory / max_memory * 100:.1f}%)"
         if is_tt_moe_model(model) and batch_max_vio.item() > 0:
             step_message += f" | Max Vio: {batch_max_vio.item():.4f}"
         logger.success(step_message)
@@ -468,12 +473,13 @@ def train(config: SFTConfig):
         monitor.log(perf_metrics, step=progress.step)
 
         # Log optimizer metrics
-        optim_metrics = {
+        optim_metrics: dict = {
             "optim/lr": current_lr,
-            "optim/grad_norm": grad_norm.item(),
             "optim/zero_grad_ratio": zero_grad_ratio,
             "step": progress.step,
         }
+        if grad_norm is not None:
+            optim_metrics["optim/grad_norm"] = grad_norm.item()
         monitor.log(optim_metrics, step=progress.step)
 
         loss_log_metrics = {

--- a/src/prime_rl/utils/metrics_server.py
+++ b/src/prime_rl/utils/metrics_server.py
@@ -195,7 +195,7 @@ class MetricsServer(HealthServer):
         step: int,
         loss: float,
         throughput: float,
-        grad_norm: float,
+        grad_norm: float | None,
         peak_memory_gib: float,
         learning_rate: float,
         mfu: float = 0.0,
@@ -207,7 +207,8 @@ class MetricsServer(HealthServer):
         self._step.set(step)
         self._loss.set(loss)
         self._throughput.set(throughput)
-        self._grad_norm.set(grad_norm)
+        if grad_norm is not None:
+            self._grad_norm.set(grad_norm)
         self._peak_mem.set(peak_memory_gib)
         self._lr.set(learning_rate)
         self._mfu.set(mfu)


### PR DESCRIPTION
## Summary
- `optim.max_norm` can now be set to `null` to disable gradient clipping (default remains `1.0`)
- Config validation errors when DeepEP (`model.ep_comm_backend='deepep'`) is used with grad clipping enabled, since they are incompatible
- Applied to both RL and SFT trainers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core RL/SFT training loops and optimizer configuration; disabling gradient clipping (and conditionally skipping grad_norm metrics) can change training stability/observability if configs rely on prior behavior.
> 
> **Overview**
> **Gradient clipping can now be disabled** by setting `optim.max_norm: null` (config type widened to `float | None`).
> 
> Both RL and SFT trainers now *conditionally* call `clip_grad_norm_` and only log/export `grad_norm` when clipping is enabled.
> 
> Adds config-level validation in `TrainerConfig` and `SFTConfig` to warn and automatically turn off gradient clipping when `model.ep_comm_backend='deepep'`, and updates the Prometheus `MetricsServer.update()` API to accept an optional `grad_norm`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8aef65b8735fc246f90e40f2c0a61497acf70aaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->