### PR TITLE
fix: respect existing WANDB_SHARED_RUN_ID env var for run resumption

### DIFF
--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -138,7 +138,7 @@ def rl_local(config: RLConfig):
     wandb_shared_env: dict[str, str] = {}
     if config.wandb and config.wandb.shared:
         wandb_shared_env["WANDB_SHARED_MODE"] = "1"
-        wandb_shared_env["WANDB_SHARED_RUN_ID"] = uuid.uuid4().hex
+        wandb_shared_env["WANDB_SHARED_RUN_ID"] = os.environ.get("WANDB_SHARED_RUN_ID", uuid.uuid4().hex)
 
     # Check for existing processes on GPUs
     all_gpu_ids = list(set(infer_gpu_ids + trainer_gpu_ids + teacher_gpu_ids))


### PR DESCRIPTION
When resuming a run, users need to attach to the existing W&B run by setting `WANDB_SHARED_RUN_ID`. Previously this was always overwritten with a new UUID, making it impossible to resume logging to the same run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change to environment-variable initialization for W&B shared mode; primary impact is run logging/resumption behavior.
> 
> **Overview**
> Stops the RL launcher from always generating a new `WANDB_SHARED_RUN_ID` when `wandb.shared` is enabled. If `WANDB_SHARED_RUN_ID` is already set in the environment (e.g., when resuming), that value is now propagated to the trainer/orchestrator subprocesses; otherwise a new UUID is generated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed4a04bb86ef04c2c7f1a850a6858eb928270388. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->