### PR TITLE
Add CP glm-5 to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ With `[model] impl = "auto"` (the default), the trainer selects that custom stac
 
 | Family | Example IDs | MoE | EP | CP |
 |--------|-------------|-----|----|-----|
-| GLM-5 (`glm_moe_dsa`) | `zai-org/GLM-5`, `zai-org/GLM-5-FP8` | yes | ✅ | ❌ |
+| GLM-5 (`glm_moe_dsa`) | `zai-org/GLM-5`, `zai-org/GLM-5-FP8` | yes | ✅ | ✅ |
 | Qwen3 MoE (`qwen3_moe`) | `Qwen/Qwen3-30B-A3B`, … | yes | ✅ | ✅ |
 | Qwen3.5 MoE (`qwen3_5_moe`) | `Qwen/Qwen3.5-35B-A3B`, … | yes | ✅ | ✅ |
 | Qwen3 / Qwen3.5 VLMs | [multimodal.md](docs/multimodal.md) (`qwen3_vl`, `qwen3_5`, `qwen3_5_moe`) | MoE only on MoE VLMs | MoE only | ✅ |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change updating the model support matrix; no runtime or training code is modified.
> 
> **Overview**
> **Updates the README model support table** to indicate that GLM-5 (`glm_moe_dsa`) now supports context parallelism (CP) in addition to expert parallelism (EP).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47a52d4116ebb9b9e42b4e7c499f76f77cf56770. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->