### PR TITLE
feat: clean stale artifacts on resume

### DIFF
--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -14,8 +14,14 @@ import tomli_w
 
 from prime_rl.configs.rl import RLConfig
 from prime_rl.utils.config import cli
-from prime_rl.utils.logger import setup_logger
-from prime_rl.utils.pathing import format_log_message, validate_output_dir
+from prime_rl.utils.logger import get_logger, setup_logger
+from prime_rl.utils.pathing import (
+    clean_future_steps,
+    format_log_message,
+    get_ckpt_dir,
+    resolve_latest_ckpt_step,
+    validate_output_dir,
+)
 from prime_rl.utils.process import cleanup_processes, cleanup_threads, monitor_process, set_proc_title
 from prime_rl.utils.utils import (
     get_free_port,
@@ -537,6 +543,16 @@ def rl(config: RLConfig):
     config.output_dir.mkdir(parents=True, exist_ok=True)
     if ckpt_output_dir is not None:
         ckpt_output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Clean stale artifacts from steps after the resume point
+    if resuming:
+        resume_step = config.ckpt.resume_step
+        if resume_step == -1:
+            ckpt_base = ckpt_output_dir if ckpt_output_dir is not None else config.output_dir
+            resume_step = resolve_latest_ckpt_step(get_ckpt_dir(ckpt_base))
+        if resume_step is not None:
+            get_logger().info(f"Resuming from step {resume_step}, cleaning future rollouts and broadcasts")
+            clean_future_steps(config.output_dir, resume_step)
 
     if config.slurm is not None:
         rl_slurm(config)

--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -20,6 +20,7 @@ from prime_rl.utils.utils import (
     get_broadcast_dir,
     get_ckpt_dir,
     get_step_path,
+    get_weights_dir,
 )
 
 SEMAPHORE: AsyncContextManager | None = None
@@ -195,15 +196,20 @@ def get_weight_dir(output_dir: Path, step: int, check_exists: bool = True, wait_
             If None, no waiting is performed.
     """
     ckpt_weight_dir = get_step_path(get_ckpt_dir(output_dir), step) / "weight"
+    weights_dir = get_step_path(get_weights_dir(output_dir), step)
     broadcast_weight_dir = get_step_path(get_broadcast_dir(output_dir), step)
 
     def find_stable_dir() -> Path | None:
-        # For checkpoint weights, check STABLE file in parent directory (checkpoints/step_{step}/STABLE)
+        # Trainer checkpoints: checkpoints/step_{step}/STABLE with weights in checkpoints/step_{step}/weight/
         ckpt_step_dir = get_step_path(get_ckpt_dir(output_dir), step)
         if (ckpt_step_dir / "STABLE").exists() and ckpt_weight_dir.exists():
             return ckpt_weight_dir
 
-        # For broadcast weights, check STABLE file in the broadcast directory itself
+        # Weight-only checkpoints: weights/step_{step}/STABLE
+        if (weights_dir / "STABLE").exists() and weights_dir.exists():
+            return weights_dir
+
+        # Broadcast weights: broadcasts/step_{step}/STABLE
         if (broadcast_weight_dir / "STABLE").exists() and broadcast_weight_dir.exists():
             return broadcast_weight_dir
 

--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -20,7 +20,6 @@ from prime_rl.utils.utils import (
     get_broadcast_dir,
     get_ckpt_dir,
     get_step_path,
-    get_weights_dir,
 )
 
 SEMAPHORE: AsyncContextManager | None = None
@@ -196,20 +195,15 @@ def get_weight_dir(output_dir: Path, step: int, check_exists: bool = True, wait_
             If None, no waiting is performed.
     """
     ckpt_weight_dir = get_step_path(get_ckpt_dir(output_dir), step) / "weight"
-    weights_dir = get_step_path(get_weights_dir(output_dir), step)
     broadcast_weight_dir = get_step_path(get_broadcast_dir(output_dir), step)
 
     def find_stable_dir() -> Path | None:
-        # Trainer checkpoints: checkpoints/step_{step}/STABLE with weights in checkpoints/step_{step}/weight/
+        # For checkpoint weights, check STABLE file in parent directory (checkpoints/step_{step}/STABLE)
         ckpt_step_dir = get_step_path(get_ckpt_dir(output_dir), step)
         if (ckpt_step_dir / "STABLE").exists() and ckpt_weight_dir.exists():
             return ckpt_weight_dir
 
-        # Weight-only checkpoints: weights/step_{step}/STABLE
-        if (weights_dir / "STABLE").exists() and weights_dir.exists():
-            return weights_dir
-
-        # Broadcast weights: broadcasts/step_{step}/STABLE
+        # For broadcast weights, check STABLE file in the broadcast directory itself
         if (broadcast_weight_dir / "STABLE").exists() and broadcast_weight_dir.exists():
             return broadcast_weight_dir
 

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -62,13 +62,6 @@ mkdir -p $OUTPUT_DIR/logs/trainer $OUTPUT_DIR/logs/inference
 ln -sfn trainer/node_0.log $OUTPUT_DIR/logs/trainer.log
 ln -sfn inference/node_0.log $OUTPUT_DIR/logs/inference.log
 
-# Clear previous rollouts and broadcast flags from ALL runs (not just the current one)
-# to prevent the trainer from training on stale data from old run_* directories.
-# WARN: This is potentially dangerous and could lead to data loss
-rm -rf $OUTPUT_DIR/run_*/rollouts
-rm -rf $OUTPUT_DIR/run_*/broadcasts
-rm -rf $OUTPUT_DIR/rollouts
-
 # General
 export CUDA_DEVICE_ORDER=PCI_BUS_ID
 export PYTHONUNBUFFERED=1

--- a/src/prime_rl/utils/pathing.py
+++ b/src/prime_rl/utils/pathing.py
@@ -149,6 +149,26 @@ def validate_output_dir(output_dir: Path, *, resuming: bool, clean: bool, ckpt_o
             )
 
 
+def clean_future_steps(output_dir: Path, resume_step: int) -> None:
+    """Remove stale rollouts and broadcasts from a resumed run."""
+    run_default = output_dir / "run_default"
+    dirs = [
+        get_rollout_dir(output_dir),
+        get_rollout_dir(run_default),
+        get_broadcast_dir(run_default),
+    ]
+
+    for directory in dirs:
+        steps_to_delete = [step for step in get_all_ckpt_steps(directory) if step >= resume_step]
+        if not steps_to_delete:
+            continue
+        get_logger().info(
+            f"Deleting {len(steps_to_delete)} step directories in {directory} ({','.join(map(str, steps_to_delete))})"
+        )
+        for step in steps_to_delete:
+            shutil.rmtree(get_step_path(directory, step))
+
+
 def sync_wait_for_path(path: Path, interval: int = 1, log_interval: int = 10) -> None:
     logger = get_logger()
     wait_time = 0

--- a/src/prime_rl/utils/pathing.py
+++ b/src/prime_rl/utils/pathing.py
@@ -159,7 +159,7 @@ def clean_future_steps(output_dir: Path, resume_step: int) -> None:
     ]
 
     for directory in dirs:
-        steps_to_delete = [step for step in get_all_ckpt_steps(directory) if step >= resume_step]
+        steps_to_delete = [step for step in get_all_ckpt_steps(directory) if step > resume_step]
         if not steps_to_delete:
             continue
         get_logger().info(


### PR DESCRIPTION
## Motivation

This PR was motivated by us not cleaning up the rollout and broadcast directories on a single-node run with filesystem which would lead to wrong training resumption (trainer trains on future rollouts + orch computes async level based on future checkpoint).

## Summary
- Clean stale RL resume artifacts from `output_dir` and `run_default`, while leaving checkpoints and weight snapshots out of resume cleanup.

Tested basic starting a run + resume with both FS and NCCL

```bash
# start
uv run rl @ examples/reverse_text/rl.toml --clean-output-dir --ckpt.interval 5 --max-steps 10 --log.level debug

# resume
uv run rl @ examples/reverse_text/rl.toml --clean-output-dir --ckpt.interval 5 --max-steps 10 --log.level debug --ckpt.resume-step 5
```

<img width="403" height="229" alt="Screenshot 2026-04-07 at 9 10 00 PM" src="https://github.com/user-attachments/assets/269e4128-4a96-4925-93d7-3f49245d36f7" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds automatic filesystem deletion of rollout/broadcast step directories when resuming runs; incorrect step resolution or directory targeting could remove needed artifacts and affect training continuity.
> 
> **Overview**
> **Resuming RL runs now proactively removes stale data beyond the chosen checkpoint step.** The launcher (`entrypoints/rl.py`) determines the effective `resume_step` (including `-1` meaning *latest checkpoint*) and calls new `clean_future_steps()` to delete `rollouts/step_*` and `run_default/{rollouts,broadcasts}/step_*` directories with steps greater than the resume point.
> 
> The SLURM multi-node template stops doing a blanket `rm -rf` of rollout/broadcast directories across all `run_*` folders, shifting cleanup to a targeted, step-aware Python implementation in `utils/pathing.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2b20f3b065fd340904c5528aac1d1dd20626d95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->