### PR TITLE
feat: clean stale artifacts on resume

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ dion = { git = "https://github.com/samsja/dion.git", rev = "d891eeb" }
 transformers = { git = "https://github.com/huggingface/transformers.git", rev = "c1c3424" }
 flash-attn-4 = { git = "https://github.com/Dao-AILab/flash-attention.git", subdirectory = "flash_attn/cute", rev = "abd9943b" }
 pydantic-config = { git = "https://github.com/samsja/pydantic_config.git", branch = "main" }
-vllm-router = { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.14/vllm_router-0.1.14-cp38-abi3-linux_x86_64.whl" }
+vllm-router = { url = "https://github.com/samsja/flash-attn-builds/releases/download/v0.3/vllm_router-0.1.11-cp38-abi3-linux_x86_64.whl" }
 reverse-text = { index = "primeintellect" }
 alphabet-sort = { index = "primeintellect" }
 wiki-search = { index = "primeintellect" }

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -15,7 +15,13 @@ import tomli_w
 from prime_rl.configs.rl import RLConfig
 from prime_rl.utils.config import cli
 from prime_rl.utils.logger import setup_logger
-from prime_rl.utils.pathing import format_log_message, validate_output_dir
+from prime_rl.utils.pathing import (
+    clean_future_steps,
+    format_log_message,
+    get_ckpt_dir,
+    resolve_latest_ckpt_step,
+    validate_output_dir,
+)
 from prime_rl.utils.process import cleanup_processes, cleanup_threads, monitor_process, set_proc_title
 from prime_rl.utils.utils import (
     get_free_port,
@@ -534,6 +540,15 @@ def rl(config: RLConfig):
     config.output_dir.mkdir(parents=True, exist_ok=True)
     if ckpt_output_dir is not None:
         ckpt_output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Clean stale artifacts from steps after the resume point
+    if resuming:
+        resume_step = config.ckpt.resume_step
+        if resume_step == -1:
+            ckpt_base = ckpt_output_dir if ckpt_output_dir is not None else config.output_dir
+            resume_step = resolve_latest_ckpt_step(get_ckpt_dir(ckpt_base))
+        if resume_step is not None:
+            clean_future_steps(config.output_dir, resume_step, ckpt_output_dir)
 
     if config.slurm is not None:
         rl_slurm(config)

--- a/src/prime_rl/utils/pathing.py
+++ b/src/prime_rl/utils/pathing.py
@@ -149,6 +149,47 @@ def validate_output_dir(output_dir: Path, *, resuming: bool, clean: bool, ckpt_o
             )
 
 
+def _get_step_dirs_after(directory: Path, step: int) -> list[Path]:
+    """Return step_N directories where N > step, sorted ascending."""
+    if not directory.exists():
+        return []
+    future = []
+    for p in directory.iterdir():
+        if p.is_dir() and p.name.startswith("step_"):
+            try:
+                n = int(p.name.split("_", 1)[1])
+            except ValueError:
+                continue
+            if n > step:
+                future.append(p)
+    return sorted(future, key=lambda p: p.name)
+
+
+def clean_future_steps(output_dir: Path, resume_step: int, ckpt_output_dir: Path | None = None) -> None:
+    """Remove rollouts, checkpoints, weights, and broadcasts from steps after resume_step.
+
+    Cleans both the trainer output_dir and the orchestrator run_default subdir.
+    If ckpt_output_dir is set, checkpoints and weights are cleaned there instead.
+    """
+    logger = get_logger()
+
+    ckpt_base = ckpt_output_dir if ckpt_output_dir is not None else output_dir
+
+    dirs_to_clean = [
+        get_rollout_dir(output_dir),
+        get_rollout_dir(output_dir / "run_default"),
+        get_broadcast_dir(output_dir),
+        get_broadcast_dir(output_dir / "run_default"),
+        get_ckpt_dir(ckpt_base),
+        get_weights_dir(ckpt_base),
+    ]
+
+    for directory in dirs_to_clean:
+        for step_dir in _get_step_dirs_after(directory, resume_step):
+            logger.info(f"Removing stale artifact: {step_dir}")
+            shutil.rmtree(step_dir)
+
+
 def sync_wait_for_path(path: Path, interval: int = 1, log_interval: int = 10) -> None:
     logger = get_logger()
     wait_time = 0

--- a/tests/unit/utils/test_pathing.py
+++ b/tests/unit/utils/test_pathing.py
@@ -1,6 +1,6 @@
 import pytest
 
-from prime_rl.utils.pathing import validate_output_dir
+from prime_rl.utils.pathing import clean_future_steps, validate_output_dir
 
 
 def test_nonexistent_dir_passes(tmp_path):
@@ -55,3 +55,75 @@ def test_clean_on_nonexistent_dir_is_noop(tmp_path):
     output_dir = tmp_path / "does_not_exist"
     validate_output_dir(output_dir, resuming=False, clean=True)
     assert not output_dir.exists()
+
+
+def _make_step_dirs(base: str, output_dir, steps: list[int]) -> None:
+    d = output_dir / base
+    d.mkdir(parents=True, exist_ok=True)
+    for s in steps:
+        (d / f"step_{s}").mkdir()
+        (d / f"step_{s}" / "data.bin").touch()
+
+
+def test_clean_future_steps_removes_only_future(tmp_path):
+    output_dir = tmp_path / "run"
+    output_dir.mkdir()
+    steps = [0, 50, 100, 150, 200]
+
+    _make_step_dirs("rollouts", output_dir, steps)
+    _make_step_dirs("checkpoints", output_dir, steps)
+    _make_step_dirs("weights", output_dir, steps)
+    _make_step_dirs("broadcasts", output_dir, steps)
+
+    clean_future_steps(output_dir, resume_step=100)
+
+    for subdir in ["rollouts", "checkpoints", "weights", "broadcasts"]:
+        remaining = {p.name for p in (output_dir / subdir).iterdir()}
+        assert remaining == {"step_0", "step_50", "step_100"}
+
+
+def test_clean_future_steps_with_ckpt_output_dir(tmp_path):
+    output_dir = tmp_path / "run"
+    ckpt_dir = tmp_path / "ckpts"
+    output_dir.mkdir()
+    ckpt_dir.mkdir()
+    steps = [0, 50, 100, 150]
+
+    _make_step_dirs("rollouts", output_dir, steps)
+    _make_step_dirs("checkpoints", ckpt_dir, steps)
+    _make_step_dirs("weights", ckpt_dir, steps)
+
+    clean_future_steps(output_dir, resume_step=50, ckpt_output_dir=ckpt_dir)
+
+    remaining_rollouts = sorted(p.name for p in (output_dir / "rollouts").iterdir())
+    assert remaining_rollouts == ["step_0", "step_50"]
+
+    remaining_ckpts = sorted(p.name for p in (ckpt_dir / "checkpoints").iterdir())
+    assert remaining_ckpts == ["step_0", "step_50"]
+
+    remaining_weights = sorted(p.name for p in (ckpt_dir / "weights").iterdir())
+    assert remaining_weights == ["step_0", "step_50"]
+
+
+def test_clean_future_steps_cleans_run_default(tmp_path):
+    output_dir = tmp_path / "run"
+    run_default = output_dir / "run_default"
+    output_dir.mkdir()
+    steps = [0, 100, 200]
+
+    _make_step_dirs("rollouts", run_default, steps)
+    _make_step_dirs("broadcasts", run_default, steps)
+
+    clean_future_steps(output_dir, resume_step=100)
+
+    remaining_rollouts = sorted(p.name for p in (run_default / "rollouts").iterdir())
+    assert remaining_rollouts == ["step_0", "step_100"]
+
+    remaining_broadcasts = sorted(p.name for p in (run_default / "broadcasts").iterdir())
+    assert remaining_broadcasts == ["step_0", "step_100"]
+
+
+def test_clean_future_steps_noop_when_no_dirs(tmp_path):
+    output_dir = tmp_path / "run"
+    output_dir.mkdir()
+    clean_future_steps(output_dir, resume_step=100)

--- a/uv.lock
+++ b/uv.lock
@@ -2837,7 +2837,7 @@ requires-dist = [
     { name = "uvloop", specifier = ">=0.21.0" },
     { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=0760204" },
     { name = "vllm", specifier = ">=0.19.0" },
-    { name = "vllm-router", marker = "platform_machine == 'x86_64' and extra == 'disagg'", url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.14/vllm_router-0.1.14-cp38-abi3-linux_x86_64.whl" },
+    { name = "vllm-router", marker = "platform_machine == 'x86_64' and extra == 'disagg'", url = "https://github.com/samsja/flash-attn-builds/releases/download/v0.3/vllm_router-0.1.11-cp38-abi3-linux_x86_64.whl" },
     { name = "wandb", specifier = ">=0.24.2" },
     { name = "wiki-search", marker = "extra == 'envs'", index = "https://hub.primeintellect.ai/primeintellect/simple/" },
 ]
@@ -3832,8 +3832,8 @@ dependencies = [
     { name = "typing-extensions", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6f09cdf2415516be028ae82e6b985bcfc3eac37bc52ab401142689f6224516ca" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:628e89bd5110ced7debee2a57c69959725b7fbc64eab81a39dd70e46c7e28ba5" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6f09cdf2415516be028ae82e6b985bcfc3eac37bc52ab401142689f6224516ca" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:628e89bd5110ced7debee2a57c69959725b7fbc64eab81a39dd70e46c7e28ba5" },
 ]
 
 [[package]]
@@ -4243,8 +4243,8 @@ wheels = [
 
 [[package]]
 name = "vllm-router"
-version = "0.1.14"
-source = { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.14/vllm_router-0.1.14-cp38-abi3-linux_x86_64.whl" }
+version = "0.1.11"
+source = { url = "https://github.com/samsja/flash-attn-builds/releases/download/v0.3/vllm_router-0.1.11-cp38-abi3-linux_x86_64.whl" }
 dependencies = [
     { name = "aiohttp", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "fastapi", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -4254,7 +4254,7 @@ dependencies = [
     { name = "uvicorn", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.14/vllm_router-0.1.14-cp38-abi3-linux_x86_64.whl", hash = "sha256:92935a8be0dd642aa8f328388211f7e45385d0cef6e1a851ef6d15e4153f2cae" },
+    { url = "https://github.com/samsja/flash-attn-builds/releases/download/v0.3/vllm_router-0.1.11-cp38-abi3-linux_x86_64.whl", hash = "sha256:43c96cebde3d59f88c0e84fe735bba5ccb6a308d3305c80ffc3723194a5f7230" },
 ]
 
 [package.metadata]


### PR DESCRIPTION
## Summary
- Clean stale RL resume artifacts from `output_dir` and `run_default`, while leaving checkpoints and weight snapshots out of resume cleanup.
- Make filesystem and NCCL resume behavior match by treating broadcast state as the source of truth and re-broadcasting the resume step.
- Stop trainer broadcasts in the final async window for both backends and simplify broadcast cleanup so it no longer depends on checkpoint intervals.
- Discover the single-run orchestrator state before the first resumed broadcast to avoid deadlock on `run_default` resume bootstrap.
- Simplify the resume-path cleanup code by inlining `"run_default"` and removing the `RUN_DEFAULT` constant.

Based on #2219 by @mikasenghaas.