### PR TITLE
Bound orchestrator post-training cleanup with hard timeout

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -2,6 +2,7 @@ import asyncio
 import atexit
 import gc
 import multiprocessing as mp
+import os
 import time
 from concurrent.futures import ThreadPoolExecutor
 
@@ -76,6 +77,13 @@ from prime_rl.utils.utils import (
     strip_env_version,
     to_col_format,
 )
+
+# Hard wall-clock budget for the orchestrator's post-training cleanup. If the
+# graceful shutdown sequence (scheduler / inference pool / env teardown) is
+# still running after this many seconds, we force-exit the process so the run
+# pod terminates instead of sitting wedged forever. The training checkpoint
+# and artifacts are persisted *before* this point, so a forced exit is safe.
+SHUTDOWN_TIMEOUT_S = 60
 
 
 @clean_exit
@@ -891,27 +899,33 @@ async def orchestrate(config: OrchestratorConfig):
         logger.info("Writing final checkpoint")
         ckpt_manager.save(progress, buffer, step=progress.step)
 
-    # Close training batch sender
-    training_batch_sender.close()
+    # Bounded best-effort cleanup. Each await below may block on a remote peer
+    # (env-server ZMQ recv, inference admin httpx aclose, etc.). The outer
+    # asyncio.wait gives the whole sequence a single deadline; if anything
+    # wedges past SHUTDOWN_TIMEOUT_S we force-exit the process. Individual
+    # awaits intentionally do NOT have their own timeouts — asyncio.wait_for
+    # would itself hang on an uncancellable await, which is exactly the
+    # failure mode we're guarding against.
+    async def _graceful_shutdown() -> None:
+        training_batch_sender.close()
+        rollout_executor.shutdown(wait=False)
+        await scheduler.stop()
+        await inference_pool.stop()
+        if teacher_inference_pool is not None:
+            await teacher_inference_pool.stop()
+        event_loop_lag_monitor_task.cancel()
+        atexit.unregister(_cleanup_env_processes)
+        _cleanup_env_processes()
 
-    # Shutdown rollout executor
-    rollout_executor.shutdown(wait=False)
+    shutdown_task = asyncio.create_task(_graceful_shutdown())
+    _, pending = await asyncio.wait({shutdown_task}, timeout=SHUTDOWN_TIMEOUT_S)
 
-    # Stop scheduler
-    await scheduler.stop()
-
-    # Stop inference pool
-    await inference_pool.stop()
-
-    if teacher_inference_pool is not None:
-        await teacher_inference_pool.stop()
-
-    # Cancel event loop lag monitor task
-    event_loop_lag_monitor_task.cancel()
-
-    # Shutdown env processes (also registered as atexit handler for crash safety)
-    atexit.unregister(_cleanup_env_processes)
-    _cleanup_env_processes()
+    if pending:
+        logger.warning(
+            f"Orchestrator shutdown did not complete within {SHUTDOWN_TIMEOUT_S}s; "
+            "forcing process exit. Training artifacts are already persisted."
+        )
+        os._exit(0)
 
     logger.success("Orchestrator finished.")
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -83,7 +83,7 @@ from prime_rl.utils.utils import (
 # still running after this many seconds, we force-exit the process so the run
 # pod terminates instead of sitting wedged forever. The training checkpoint
 # and artifacts are persisted *before* this point, so a forced exit is safe.
-SHUTDOWN_TIMEOUT_S = 60
+SHUTDOWN_TIMEOUT_S = 300
 
 
 @clean_exit

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -927,6 +927,11 @@ async def orchestrate(config: OrchestratorConfig):
         )
         os._exit(0)
 
+    # asyncio.wait swallows task exceptions; re-raise so a fast cleanup
+    # failure surfaces the same way as it did when each step was awaited
+    # directly.
+    await shutdown_task
+
     logger.success("Orchestrator finished.")
 
     # Optionally, print benchmark table


### PR DESCRIPTION
The orchestrator post-training cleanup awaits scheduler.stop() / inference_pool.stop() / env teardown without any deadline. If any of those awaits wedges on a remote peer (e.g. env-server ZMQ recv, inference admin httpx aclose on a streaming connection), the run pod sits in RUNNING forever even though training is done and the final checkpoint has been uploaded.

Spotted on a hosted training run: all 100 steps completed, STABLE marker + 8 trainer rank files written, uploader confirmed `Successfully uploaded checkpoint step_100 (509.8 MB)`, then orchestrator hung for 12+ hours after `Writing final checkpoint`. Main thread in ep_poll, total CPU ~2 minutes — fully blocked.

- Wrap the cleanup steps in an asyncio.wait with a 60s budget.
- On timeout, warn and os._exit(0) so the pod terminates.
- asyncio.wait_for is deliberately not used because it would itself hang on an uncancellable inner await.
- Healthy path is byte-equivalent to before.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestrator shutdown behavior to force-exit after a fixed deadline, which could skip some graceful teardown work but is limited to post-checkpoint cleanup.
> 
> **Overview**
> Adds a bounded, best-effort shutdown path for the orchestrator after the final checkpoint is written.
> 
> Cleanup steps (closing the batch sender, stopping scheduler/inference pools, cancelling the lag monitor, and tearing down env processes) are now run in a single task guarded by `asyncio.wait` with a hard `SHUTDOWN_TIMEOUT_S` deadline; if exceeded, the process logs a warning and exits via `os._exit(0)` to prevent runs from hanging indefinitely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0b61d7b87aeca64a104e128f6d8d14f7873c486. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->