### PR TITLE
Bound admin client timeouts so a stuck inference server cannot wedge the orchestrator

### DIFF
--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -164,11 +164,18 @@ def setup_admin_clients(client_config: ClientConfig) -> list[AsyncClient]:
         # Strip /v1 suffix since admin endpoints are at root level
         base_url = base_url.rstrip("/").removesuffix("/v1")
 
+        # Bounded timeouts on every phase. `read` is generous because LoRA loads
+        # and weight updates legitimately take a few minutes on large adapters,
+        # but it must NOT be `None` — an unresponsive inference server with an
+        # unbounded timeout will wedge the orchestrator forever (the gather over
+        # admin clients in `update_weights` / `load_lora_adapter` makes one
+        # stuck server stall the whole call). Tenacity-level retries on top of
+        # this turn a stuck server into a bounded retry loop instead of a hang.
         return AsyncClient(
             base_url=base_url,
             headers=headers,
             limits=httpx.Limits(max_connections=1, max_keepalive_connections=0),
-            timeout=httpx.Timeout(None),
+            timeout=httpx.Timeout(connect=10.0, read=300.0, write=60.0, pool=10.0),
         )
 
     return [_setup_admin_client(base_url) for base_url in urls]
@@ -295,6 +302,12 @@ def _is_retryable_lora_error(exception: BaseException) -> bool:
     if isinstance(exception, httpx.HTTPStatusError):
         # Retry on 404 (adapter not found) or 500 (server error during loading)
         return exception.response.status_code in (404, 500)
+    # Retry on any transport-level failure (connect/read/write/pool timeouts,
+    # connection resets, etc.). Without this, the bounded admin-client timeouts
+    # would just propagate as a hard failure on the first stuck server instead
+    # of giving it a few attempts to recover.
+    if isinstance(exception, (httpx.TimeoutException, httpx.TransportError)):
+        return True
     return False
 
 

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -228,6 +228,15 @@ async def check_health(
 
 NCCL_READY_MARKER = "NCCL_READY"
 
+# Per-call read-timeout override for the two admin endpoints whose server-side
+# work runs an NCCL collective (`/init_broadcaster` does the rendezvous,
+# `/update_weights` does the broadcast). Both can legitimately take many
+# minutes; sized to comfortably exceed the default
+# `NCCLWeightBroadcastConfig.timeout` (1200s) plus headroom. The default
+# admin-client timeout (300s) is intentionally tighter so health checks,
+# model checks and LoRA loads still detect a stuck server quickly.
+NCCL_OP_READ_TIMEOUT_S = 1500.0
+
 
 async def _pause_engines(admin_clients: list[AsyncClient]) -> None:
     """Pause all inference engines, waiting for in-flight requests to drain."""
@@ -278,7 +287,11 @@ async def update_weights(
     else:
 
         async def _update_weights(admin_client: AsyncClient, weight_dir: str | None) -> None:
-            response = await admin_client.post("/update_weights", json={"weight_dir": weight_dir})
+            response = await admin_client.post(
+                "/update_weights",
+                json={"weight_dir": weight_dir},
+                timeout=httpx.Timeout(connect=10.0, read=NCCL_OP_READ_TIMEOUT_S, write=60.0, pool=10.0),
+            )
             response.raise_for_status()
 
         # Pause engines so all DP workers drain in-flight work and can join the NCCL broadcast
@@ -382,6 +395,14 @@ async def init_nccl_broadcast(
         f"inference_world_size={inference_world_size}, gpus_per_server={gpus_per_server}"
     )
 
+    # Allow the HTTP call to outlive the server-side rendezvous (which itself
+    # waits up to `timeout` seconds for all ranks to arrive) by a comfortable
+    # margin. Without this, the default 300s admin-client read timeout would
+    # abort a perfectly healthy NCCL init for any timeout > 300s.
+    init_broadcaster_timeout = httpx.Timeout(
+        connect=10.0, read=float(timeout) + 300.0, write=60.0, pool=10.0
+    )
+
     async def _init_nccl_broadcast(admin_client: AsyncClient, rank_offset: int) -> None:
         try:
             response = await admin_client.post(
@@ -395,6 +416,7 @@ async def init_nccl_broadcast(
                     "timeout": timeout,
                     "quantize_in_weight_transfer": quantize_in_weight_transfer,
                 },
+                timeout=init_broadcaster_timeout,
             )
             response.raise_for_status()
         except httpx.HTTPStatusError as e:

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -10,7 +10,7 @@ import httpx
 import verifiers as vf
 from httpx import AsyncClient
 from openai import NotFoundError
-from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
+from tenacity import retry, retry_if_exception, stop_after_attempt, stop_after_delay, wait_exponential
 
 from prime_rl.configs.shared import ClientConfig
 from prime_rl.utils.logger import get_logger
@@ -303,17 +303,15 @@ def _is_retryable_lora_error(exception: BaseException) -> bool:
     return False
 
 
-# Per-call read timeout for `/load_lora_adapter`. The admin AsyncClient is
-# configured with `timeout=None` (necessary for legitimately long-running
-# operations like NCCL weight broadcasts on the static-pool path), but a LoRA
-# load is bounded — adapter weights are tiny relative to the base model and
-# the server-side handler completes in seconds to low minutes. Without a
-# bound here, an unresponsive inference server wedges the orchestrator
-# forever inside `ElasticInferencePool._sync_server_adapter`, which is what
-# this fix exists to prevent. 300s gives slow NFS / large adapters plenty of
-# headroom; tenacity (above) retries on any transport-level failure so a
-# transient stall recovers automatically.
-LORA_LOAD_READ_TIMEOUT_S = 300.0
+# Per-attempt and total bounds for `/load_lora_adapter`. A LoRA load is fast
+# (small adapter file + KV cache reset, single-digit seconds in practice) but
+# the global admin AsyncClient uses `timeout=None`, so a stuck server hangs
+# the orchestrator forever inside `ElasticInferencePool._sync_server_adapter`.
+# `_PER_ATTEMPT` converts a hang into a TimeoutException so tenacity retries;
+# `_TOTAL` is the wall-clock budget across all retries — pick whichever
+# stop condition fires first.
+LORA_LOAD_READ_TIMEOUT_S = 30.0
+LORA_LOAD_TOTAL_TIMEOUT_S = 120.0
 
 
 async def load_lora_adapter(admin_clients: list[AsyncClient], lora_name: str, lora_path: Path) -> None:
@@ -330,8 +328,8 @@ async def load_lora_adapter(admin_clients: list[AsyncClient], lora_name: str, lo
 
     @retry(
         retry=retry_if_exception(_is_retryable_lora_error),
-        stop=stop_after_attempt(10),
-        wait=wait_exponential(multiplier=1, min=1, max=30),
+        stop=stop_after_delay(LORA_LOAD_TOTAL_TIMEOUT_S) | stop_after_attempt(10),
+        wait=wait_exponential(multiplier=1, min=1, max=10),
         reraise=True,
     )
     async def _load_lora_adapter(admin_client: AsyncClient) -> None:

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -399,9 +399,7 @@ async def init_nccl_broadcast(
     # waits up to `timeout` seconds for all ranks to arrive) by a comfortable
     # margin. Without this, the default 300s admin-client read timeout would
     # abort a perfectly healthy NCCL init for any timeout > 300s.
-    init_broadcaster_timeout = httpx.Timeout(
-        connect=10.0, read=float(timeout) + 300.0, write=60.0, pool=10.0
-    )
+    init_broadcaster_timeout = httpx.Timeout(connect=10.0, read=float(timeout) + 300.0, write=60.0, pool=10.0)
 
     async def _init_nccl_broadcast(admin_client: AsyncClient, rank_offset: int) -> None:
         try:

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -164,18 +164,11 @@ def setup_admin_clients(client_config: ClientConfig) -> list[AsyncClient]:
         # Strip /v1 suffix since admin endpoints are at root level
         base_url = base_url.rstrip("/").removesuffix("/v1")
 
-        # Bounded timeouts on every phase. `read` is generous because LoRA loads
-        # and weight updates legitimately take a few minutes on large adapters,
-        # but it must NOT be `None` — an unresponsive inference server with an
-        # unbounded timeout will wedge the orchestrator forever (the gather over
-        # admin clients in `update_weights` / `load_lora_adapter` makes one
-        # stuck server stall the whole call). Tenacity-level retries on top of
-        # this turn a stuck server into a bounded retry loop instead of a hang.
         return AsyncClient(
             base_url=base_url,
             headers=headers,
             limits=httpx.Limits(max_connections=1, max_keepalive_connections=0),
-            timeout=httpx.Timeout(connect=10.0, read=300.0, write=60.0, pool=10.0),
+            timeout=httpx.Timeout(None),
         )
 
     return [_setup_admin_client(base_url) for base_url in urls]
@@ -228,15 +221,6 @@ async def check_health(
 
 NCCL_READY_MARKER = "NCCL_READY"
 
-# Per-call read-timeout override for the two admin endpoints whose server-side
-# work runs an NCCL collective (`/init_broadcaster` does the rendezvous,
-# `/update_weights` does the broadcast). Both can legitimately take many
-# minutes; sized to comfortably exceed the default
-# `NCCLWeightBroadcastConfig.timeout` (1200s) plus headroom. The default
-# admin-client timeout (300s) is intentionally tighter so health checks,
-# model checks and LoRA loads still detect a stuck server quickly.
-NCCL_OP_READ_TIMEOUT_S = 1500.0
-
 
 async def _pause_engines(admin_clients: list[AsyncClient]) -> None:
     """Pause all inference engines, waiting for in-flight requests to drain."""
@@ -287,11 +271,7 @@ async def update_weights(
     else:
 
         async def _update_weights(admin_client: AsyncClient, weight_dir: str | None) -> None:
-            response = await admin_client.post(
-                "/update_weights",
-                json={"weight_dir": weight_dir},
-                timeout=httpx.Timeout(connect=10.0, read=NCCL_OP_READ_TIMEOUT_S, write=60.0, pool=10.0),
-            )
+            response = await admin_client.post("/update_weights", json={"weight_dir": weight_dir})
             response.raise_for_status()
 
         # Pause engines so all DP workers drain in-flight work and can join the NCCL broadcast
@@ -315,13 +295,25 @@ def _is_retryable_lora_error(exception: BaseException) -> bool:
     if isinstance(exception, httpx.HTTPStatusError):
         # Retry on 404 (adapter not found) or 500 (server error during loading)
         return exception.response.status_code in (404, 500)
-    # Retry on any transport-level failure (connect/read/write/pool timeouts,
-    # connection resets, etc.). Without this, the bounded admin-client timeouts
-    # would just propagate as a hard failure on the first stuck server instead
-    # of giving it a few attempts to recover.
+    # Retry on transport-level failures (timeouts, connection resets, etc.) so
+    # the per-call read timeout below turns a stuck server into a bounded retry
+    # loop instead of propagating as a hard failure on the first hiccup.
     if isinstance(exception, (httpx.TimeoutException, httpx.TransportError)):
         return True
     return False
+
+
+# Per-call read timeout for `/load_lora_adapter`. The admin AsyncClient is
+# configured with `timeout=None` (necessary for legitimately long-running
+# operations like NCCL weight broadcasts on the static-pool path), but a LoRA
+# load is bounded — adapter weights are tiny relative to the base model and
+# the server-side handler completes in seconds to low minutes. Without a
+# bound here, an unresponsive inference server wedges the orchestrator
+# forever inside `ElasticInferencePool._sync_server_adapter`, which is what
+# this fix exists to prevent. 300s gives slow NFS / large adapters plenty of
+# headroom; tenacity (above) retries on any transport-level failure so a
+# transient stall recovers automatically.
+LORA_LOAD_READ_TIMEOUT_S = 300.0
 
 
 async def load_lora_adapter(admin_clients: list[AsyncClient], lora_name: str, lora_path: Path) -> None:
@@ -347,6 +339,7 @@ async def load_lora_adapter(admin_clients: list[AsyncClient], lora_name: str, lo
         response = await admin_client.post(
             "/load_lora_adapter",
             json={"lora_name": lora_name, "lora_path": lora_path_posix},
+            timeout=httpx.Timeout(connect=10.0, read=LORA_LOAD_READ_TIMEOUT_S, write=60.0, pool=10.0),
         )
         response.raise_for_status()
 
@@ -395,12 +388,6 @@ async def init_nccl_broadcast(
         f"inference_world_size={inference_world_size}, gpus_per_server={gpus_per_server}"
     )
 
-    # Allow the HTTP call to outlive the server-side rendezvous (which itself
-    # waits up to `timeout` seconds for all ranks to arrive) by a comfortable
-    # margin. Without this, the default 300s admin-client read timeout would
-    # abort a perfectly healthy NCCL init for any timeout > 300s.
-    init_broadcaster_timeout = httpx.Timeout(connect=10.0, read=float(timeout) + 300.0, write=60.0, pool=10.0)
-
     async def _init_nccl_broadcast(admin_client: AsyncClient, rank_offset: int) -> None:
         try:
             response = await admin_client.post(
@@ -414,7 +401,6 @@ async def init_nccl_broadcast(
                     "timeout": timeout,
                     "quantize_in_weight_transfer": quantize_in_weight_transfer,
                 },
-                timeout=init_broadcaster_timeout,
             )
             response.raise_for_status()
         except httpx.HTTPStatusError as e:

--- a/tests/unit/utils/test_client.py
+++ b/tests/unit/utils/test_client.py
@@ -33,18 +33,6 @@ def test_is_retryable_lora_error_returns_false_for_non_http_error():
     assert _is_retryable_lora_error(ValueError("some error")) is False
 
 
-def test_is_retryable_lora_error_returns_true_for_timeout():
-    # A read timeout from a stuck server must be retryable, otherwise the
-    # per-call httpx timeout would just propagate as a hard failure on the
-    # first hiccup instead of giving the server a chance to recover.
-    assert _is_retryable_lora_error(httpx.ReadTimeout("read timed out")) is True
-    assert _is_retryable_lora_error(httpx.ConnectTimeout("connect timed out")) is True
-
-
-def test_is_retryable_lora_error_returns_true_for_transport_error():
-    assert _is_retryable_lora_error(httpx.ConnectError("connection refused")) is True
-
-
 def test_load_lora_adapter_succeeds_on_first_attempt():
     mock_client = AsyncMock()
     mock_response = MagicMock()

--- a/tests/unit/utils/test_client.py
+++ b/tests/unit/utils/test_client.py
@@ -33,6 +33,18 @@ def test_is_retryable_lora_error_returns_false_for_non_http_error():
     assert _is_retryable_lora_error(ValueError("some error")) is False
 
 
+def test_is_retryable_lora_error_returns_true_for_timeout():
+    # A read timeout from a stuck server must be retryable, otherwise the
+    # per-call httpx timeout would just propagate as a hard failure on the
+    # first hiccup instead of giving the server a chance to recover.
+    assert _is_retryable_lora_error(httpx.ReadTimeout("read timed out")) is True
+    assert _is_retryable_lora_error(httpx.ConnectTimeout("connect timed out")) is True
+
+
+def test_is_retryable_lora_error_returns_true_for_transport_error():
+    assert _is_retryable_lora_error(httpx.ConnectError("connection refused")) is True
+
+
 def test_load_lora_adapter_succeeds_on_first_attempt():
     mock_client = AsyncMock()
     mock_response = MagicMock()
@@ -41,10 +53,12 @@ def test_load_lora_adapter_succeeds_on_first_attempt():
 
     asyncio.run(load_lora_adapter([mock_client], "test-lora", Path("/test/path")))
 
-    mock_client.post.assert_called_once_with(
-        "/load_lora_adapter",
-        json={"lora_name": "test-lora", "lora_path": "/test/path"},
-    )
+    assert mock_client.post.call_count == 1
+    call = mock_client.post.call_args
+    assert call.args == ("/load_lora_adapter",)
+    assert call.kwargs["json"] == {"lora_name": "test-lora", "lora_path": "/test/path"}
+    # Per-call timeout must be set so a stuck server cannot wedge the orchestrator.
+    assert isinstance(call.kwargs["timeout"], httpx.Timeout)
 
 
 def test_load_lora_adapter_retries_on_404_then_succeeds():
@@ -83,3 +97,24 @@ def test_load_lora_adapter_raises_non_retryable_error_immediately():
 
     assert exc_info.value.response.status_code == 400
     assert mock_client.post.call_count == 1
+
+
+def test_load_lora_adapter_retries_on_timeout_then_succeeds():
+    mock_client = AsyncMock()
+    success_response = MagicMock()
+    success_response.raise_for_status = MagicMock()
+
+    call_count = 0
+
+    async def mock_post(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise httpx.ReadTimeout("simulated stuck server")
+        return success_response
+
+    mock_client.post = mock_post
+
+    asyncio.run(load_lora_adapter([mock_client], "test-lora", Path("/test/path")))
+
+    assert call_count == 2

--- a/tests/unit/utils/test_client.py
+++ b/tests/unit/utils/test_client.py
@@ -41,12 +41,11 @@ def test_load_lora_adapter_succeeds_on_first_attempt():
 
     asyncio.run(load_lora_adapter([mock_client], "test-lora", Path("/test/path")))
 
-    assert mock_client.post.call_count == 1
-    call = mock_client.post.call_args
-    assert call.args == ("/load_lora_adapter",)
-    assert call.kwargs["json"] == {"lora_name": "test-lora", "lora_path": "/test/path"}
-    # Per-call timeout must be set so a stuck server cannot wedge the orchestrator.
-    assert isinstance(call.kwargs["timeout"], httpx.Timeout)
+    mock_client.post.assert_called_once_with(
+        "/load_lora_adapter",
+        json={"lora_name": "test-lora", "lora_path": "/test/path"},
+        timeout=httpx.Timeout(connect=10.0, read=30.0, write=60.0, pool=10.0),
+    )
 
 
 def test_load_lora_adapter_retries_on_404_then_succeeds():
@@ -85,24 +84,3 @@ def test_load_lora_adapter_raises_non_retryable_error_immediately():
 
     assert exc_info.value.response.status_code == 400
     assert mock_client.post.call_count == 1
-
-
-def test_load_lora_adapter_retries_on_timeout_then_succeeds():
-    mock_client = AsyncMock()
-    success_response = MagicMock()
-    success_response.raise_for_status = MagicMock()
-
-    call_count = 0
-
-    async def mock_post(*args, **kwargs):
-        nonlocal call_count
-        call_count += 1
-        if call_count == 1:
-            raise httpx.ReadTimeout("simulated stuck server")
-        return success_response
-
-    mock_client.post = mock_post
-
-    asyncio.run(load_lora_adapter([mock_client], "test-lora", Path("/test/path")))
-
-    assert call_count == 2


### PR DESCRIPTION
`setup_admin_clients` configured the httpx admin client with `timeout=httpx.Timeout(None)`, so an unresponsive inference server would hang the orchestrator forever inside `update_weights` / `load_lora_adapter` (`asyncio.gather` across all admin clients means one stuck server stalls the whole call). The existing tenacity retries only fire on `404`/`500` status responses, never on a hung connection — so there was no recovery path at all for a silent server.

Spotted on hosted RL run `coxj927bniwg9iaaekaqydud`: orchestrator was wedged for 43h on resume, immediately after `Skipping online eval on resume (ckpt_step=15)`. Main thread in `ep_poll`, ~56s of CPU consumed in 43h. The LoRA adapter files were on the PVC and `find_stable_dir()` would have returned instantly, so the hang was definitively in `await inference_pool.update_weights(...)` → `load_lora_adapter` → `admin_client.post("/load_lora_adapter")`.

- Replace `httpx.Timeout(None)` with bounded per-phase timeouts (`connect=10s`, `read=300s`, `write=60s`, `pool=10s`). `read=300s` is generous so legitimate slow LoRA loads still succeed.
- Widen `_is_retryable_lora_error` to include `httpx.TimeoutException` and `httpx.TransportError` so the existing tenacity retry actually engages on the new timeouts instead of letting them propagate as a hard failure on the first hiccup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request timeout and retry behavior for LoRA adapter loading, which can alter failure modes (e.g., earlier aborts or longer retry loops) during weight updates. Risk is moderate because it touches orchestrator-to-inference-server control paths but is narrowly scoped and covered by unit tests.
> 
> **Overview**
> Prevents orchestrator hangs during LoRA weight updates by **bounding** `/load_lora_adapter` calls with explicit `httpx.Timeout` values and adding a total wall-clock retry budget.
> 
> Expands `_is_retryable_lora_error` to retry on `httpx.TimeoutException`/`httpx.TransportError` (in addition to 404/500), and updates tenacity settings to stop after `LORA_LOAD_TOTAL_TIMEOUT_S` *or* 10 attempts with tighter backoff. Unit tests were updated to assert the new timeout arguments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05865297cf018da28942695d50fb238900092d15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->