### PR TITLE
[feat] attn only lora

### DIFF
--- a/src/prime_rl/configs/inference.py
+++ b/src/prime_rl/configs/inference.py
@@ -274,6 +274,13 @@ class InferenceConfig(BaseConfig):
         ),
     ] = None
 
+    lora_target_modules: Annotated[
+        list[str] | None,
+        Field(
+            description="The target modules for LoRA. Passed to vLLM as `--lora-target-modules`.",
+        ),
+    ] = None
+
     enable_prefix_caching: Annotated[
         bool | None,
         Field(
@@ -488,6 +495,7 @@ class InferenceConfig(BaseConfig):
             "max_loras": "max_loras",
             "max_cpu_loras": "max_cpu_loras",
             "max_lora_rank": "max_lora_rank",
+            "lora_target_modules": "lora_target_modules",
             "gpu_memory_utilization": "gpu_memory_utilization",
             "api_server_count": "api_server_count",
             "enable_return_routed_experts": "enable_return_routed_experts",
@@ -508,6 +516,10 @@ class InferenceConfig(BaseConfig):
         # Remove reasoning_parser if not set (vLLM doesn't accept None)
         if namespace.reasoning_parser is None:
             delattr(namespace, "reasoning_parser")
+
+        # Remove lora_target_modules if not set (vLLM doesn't accept None)
+        if hasattr(namespace, "lora_target_modules") and namespace.lora_target_modules is None:
+            delattr(namespace, "lora_target_modules")
 
         # Remove rope_scaling if not set (vLLM doesn't accept None)
         if hasattr(namespace, "rope_scaling"):

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -809,3 +809,31 @@ def monkey_patch_dp_engine_core_pause_resume_deadlock():
     DPEngineCoreProc._handle_client_request = _patched_handle_client_request
     DPEngineCoreProc.resume_scheduler = _patched_resume_scheduler
     DPEngineCoreProc._has_global_unfinished_reqs = _patched_has_global_unfinished_reqs
+
+
+def monkey_patch_no_moe_lora():
+    """This disables LoRA for MoE layers and makes them pick better kernels.
+
+    Otherwise, the oracle will always try to pick TritonExperts.
+    For blackwells, we want TRTLLMFlashInfer.
+    """
+    from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig, logger
+
+    def _patched__post_init__(self: FusedMoEConfig):
+        if self.dp_size > 1:
+            logger.debug_once("Using FusedMoEConfig::max_num_tokens=%d", self.max_num_tokens)
+
+        assert self.max_num_tokens > 0
+
+        if self.router_logits_dtype is None:
+            self.router_logits_dtype = self.in_dtype
+
+        if self.hidden_dim_unpadded is None:
+            self.hidden_dim_unpadded = self.hidden_dim
+        if self.intermediate_size_per_partition_unpadded is None:
+            self.intermediate_size_per_partition_unpadded = self.intermediate_size_per_partition
+
+        # Disable LoRA for MoE layers
+        self.is_lora_enabled = False
+
+    FusedMoEConfig.__post_init__ = _patched__post_init__

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -318,8 +318,14 @@ vllm.v1.utils.run_api_server_worker_proc = custom_run_api_server_worker_proc
 # Only difference we do some config translation (i.e. pass populated namespace
 # to `parse_args`) and additional arg validation
 def server(config: InferenceConfig, vllm_extra: dict[str, Any] | None = None):
+    import os
+
     from vllm.entrypoints.cli.serve import run_headless, run_multi_api_server
     from vllm.entrypoints.openai.api_server import run_server
+
+    # Signal worker processes to disable LoRA on MoE layers when LoRA targets don't include experts
+    if config.lora_target_modules and not any("expert" in m for m in config.lora_target_modules):
+        os.environ["PRIME_NO_MOE_LORA"] = "1"
 
     namespace = config.to_vllm()
     if vllm_extra:

--- a/src/prime_rl/inference/vllm/worker/__init__.py
+++ b/src/prime_rl/inference/vllm/worker/__init__.py
@@ -1,9 +1,21 @@
+import logging
+import os
+
 from prime_rl.inference.patches import (
     monkey_patch_LRUCacheWorkerLoRAManager,
     monkey_patch_minimax_m2_for_lora,
+    monkey_patch_no_moe_lora,
 )
+
+logger = logging.getLogger(__name__)
 
 # Monkeypatch LRUCacheWorkerLoRAManager to allow loading adapter inplace without doing it every request
 monkey_patch_LRUCacheWorkerLoRAManager()
 # Monkeypatch MiniMaxM2 MoE gate dtype and adapter key mapping for LoRA compatibility
 monkey_patch_minimax_m2_for_lora()
+# Disable LoRA on MoE layers so vLLM picks better kernels (e.g. TRTLLMFlashInfer on Blackwell)
+if os.environ.get("PRIME_NO_MOE_LORA") == "1":
+    logger.info("PRIME_NO_MOE_LORA=1: disabling LoRA on MoE layers")
+    monkey_patch_no_moe_lora()
+else:
+    logger.info("PRIME_NO_MOE_LORA=0: no patch applied")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it conditionally changes LoRA behavior for MoE models via monkeypatching vLLM internals, which could affect kernel selection and adapter application at runtime.
> 
> **Overview**
> Adds `lora_target_modules` to `InferenceConfig` and translates it into vLLM args, ensuring the field is omitted when unset to avoid vLLM rejecting `None`.
> 
> Introduces an opt-in runtime path to **disable LoRA on MoE layers**: the server sets `PRIME_NO_MOE_LORA=1` when configured LoRA targets don’t include experts, and vLLM workers then apply a monkeypatch that forces `FusedMoEConfig.is_lora_enabled = False` to steer kernel selection (e.g., away from `TritonExperts`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 122c0a87e228e41d5bacc16d1e124426904279c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->