### PR TITLE
Make matmul_precision configurable in trainer config

### DIFF
--- a/src/prime_rl/configs/sft.py
+++ b/src/prime_rl/configs/sft.py
@@ -203,6 +203,19 @@ class SFTConfig(BaseConfig):
         ),
     ] = False
 
+    matmul_precision: Annotated[
+        Literal["highest", "high", "medium"],
+        Field(
+            description=(
+                "Precision for float32 matrix multiplications. "
+                "Use 'highest' for full FP32 (required on ROCm/AMD GPUs to avoid "
+                "catastrophic precision loss in softmax over large vocabularies). "
+                "Use 'high' to enable TF32 on NVIDIA GPUs for a speedup with minor "
+                "precision tradeoff. See torch.set_float32_matmul_precision docs."
+            ),
+        ),
+    ] = "high"
+
     max_steps: Annotated[
         int | None,
         Field(description="Maximum number of steps to run training for. If None, will run indefinitely."),

--- a/src/prime_rl/configs/trainer.py
+++ b/src/prime_rl/configs/trainer.py
@@ -760,6 +760,19 @@ class TrainerConfig(BaseConfig):
         ),
     ] = Path("outputs")
 
+    matmul_precision: Annotated[
+        Literal["highest", "high", "medium"],
+        Field(
+            description=(
+                "Precision for float32 matrix multiplications. "
+                "Use 'highest' for full FP32 (required on ROCm/AMD GPUs to avoid "
+                "catastrophic precision loss in softmax over large vocabularies). "
+                "Use 'high' to enable TF32 on NVIDIA GPUs for a speedup with minor "
+                "precision tradeoff. See torch.set_float32_matmul_precision docs."
+            ),
+        ),
+    ] = "high"
+
     max_steps: Annotated[
         int | None,
         Field(

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -109,7 +109,10 @@ def train(config: TrainerConfig):
     setup_torch_distributed(
         timeout=timedelta(seconds=config.dist_timeout_seconds), enable_gloo=config.model.fsdp_cpu_offload
     )
-    torch.set_float32_matmul_precision("high")
+    # Configurable to support ROCm/AMD GPUs where reduced precision
+    # matmul corrupts softmax over large vocabularies. Override via config
+    # (e.g. matmul_precision = "highest") on ROCm.
+    torch.set_float32_matmul_precision(config.matmul_precision)
 
     # Setup multi run manager and offsets (including LoRA validation/scaling hooks if applicable)
     multi_run_manager = setup_multi_run_manager(

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -84,7 +84,10 @@ def train(config: SFTConfig):
     setup_torch_distributed(
         timeout=timedelta(seconds=config.dist_timeout_seconds), enable_gloo=config.model.fsdp_cpu_offload
     )
-    torch.set_float32_matmul_precision("high")
+    # Configurable to support ROCm/AMD GPUs where reduced precision
+    # matmul corrupts softmax over large vocabularies. Override via config
+    # (e.g. matmul_precision = "highest") on ROCm.
+    torch.set_float32_matmul_precision(config.matmul_precision)
 
     if config.model.lora is not None:
         setup_multi_run_manager(config.output_dir, 1, torch.device("cuda", world.local_rank), config.model.lora)


### PR DESCRIPTION
The RL and SFT trainers both hardcode `torch.set_float32_matmul_precision("high")`. That's a reasonable default on NVIDIA hardware, but it isn't always the right setting on ROCm/AMD GPUs, where the reduced-precision FP32 matmul path can affect softmax accuracy for models with large vocabularies.

This adds a `matmul_precision` field to `TrainerConfig` and `SFTConfig` so users can override the setting from their config file instead of patching the source. Allowed values are the ones `torch.set_float32_matmul_precision` accepts: `"highest"`, `"high"`, `"medium"`.

The default stays at `"high"`, so this is a pure opt-in change and should be a no-op for anyone already running on NVIDIA. Users who need full FP32 (for example on ROCm, or when sanity-checking numerics) can now set:

```toml
matmul_precision = "highest"
```

in their trainer config without touching the source.

Tested by running RL training on AMD MI325X with `matmul_precision = "highest"` set in the trainer config.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: defaults remain unchanged (`high`), but misconfiguration could affect training speed/accuracy on different GPU backends.
> 
> **Overview**
> Adds a new `matmul_precision` config option to both `TrainerConfig` (RL) and `SFTConfig`, allowing users to choose `torch.set_float32_matmul_precision` levels (`highest`/`high`/`medium`) via config.
> 
> Updates the RL and SFT training entrypoints to use `config.matmul_precision` instead of hardcoding `"high"`, enabling full-FP32 matmul as an opt-in workaround for ROCm/AMD numerical issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d206d745910f57242e82ff955f7f023d9710bc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->