### PR TITLE
feat: more per-env configs

### DIFF
--- a/configs/multi_reverse_text/rl.toml
+++ b/configs/multi_reverse_text/rl.toml
@@ -8,11 +8,14 @@ name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
 batch_size = 128
 rollouts_per_example = 16
 
+# -- train envs --
+
 [orchestrator.train.sampling]
 max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 id = "reverse-text"
+name = "reverse-text-1"
 
 [orchestrator.train.env.sampling]
 max_completion_tokens = 127
@@ -20,6 +23,8 @@ max_completion_tokens = 127
 [[orchestrator.train.env]]
 id = "reverse-text"
 name = "reverse-text-2"
+
+# -- eval envs --
 
 [orchestrator.eval]
 interval = 5

--- a/configs/multi_reverse_text/rl.toml
+++ b/configs/multi_reverse_text/rl.toml
@@ -38,6 +38,7 @@ id = "reverse-text"
 name = "eval-custom"
 num_examples = 16
 rollouts_per_example = 2
+interval = 10
 
 [orchestrator.eval.env.sampling]
 max_completion_tokens = 256

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -383,12 +383,12 @@ class EvalEnvConfig(EnvConfig):
     ] = 1
 
     interval: Annotated[
-        int | None,
+        int,
         Field(
             ge=1,
             description="Per-env eval interval. If unset, inherits from the group-level eval interval.",
         ),
-    ] = None
+    ] = 100
 
 
 class TrainConfig(BaseConfig):

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -382,6 +382,14 @@ class EvalEnvConfig(EnvConfig):
         ),
     ] = 1
 
+    interval: Annotated[
+        int | None,
+        Field(
+            ge=1,
+            description="Per-env eval interval. If unset, inherits from the group-level eval interval.",
+        ),
+    ] = None
+
 
 class TrainConfig(BaseConfig):
     """Configures training environments and their shared sampling settings."""
@@ -468,12 +476,14 @@ class EvalConfig(BaseConfig):
 
     @model_validator(mode="after")
     def resolve_env_defaults(self):
-        """Fill per-env num_examples and rollouts_per_example from group defaults, then resolve num_workers."""
+        """Fill per-env num_examples, rollouts_per_example, and interval from group defaults, then resolve num_workers."""
         for env in self.env:
             if "num_examples" not in env.model_fields_set:
                 env.num_examples = self.num_examples
             if "rollouts_per_example" not in env.model_fields_set:
                 env.rollouts_per_example = self.rollouts_per_example
+            if "interval" not in env.model_fields_set:
+                env.interval = self.interval
             # Resolve num_workers now that num_examples and rollouts_per_example are set
             if env.num_workers == "auto":
                 if env.num_examples == -1:

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -412,25 +412,18 @@ class TrainConfig(BaseConfig):
 
     @model_validator(mode="after")
     def resolve_env_defaults(self):
-        """Fill per-env num_workers and max_retries from group defaults."""
+        """Resolve per-env overrides: inherit group-level sampling, num_workers, and max_retries."""
+        group_sampling = self.sampling.model_dump()
         for env in self.env:
+            if "sampling" not in env.model_fields_set:
+                env.sampling = TrainSamplingConfig(**group_sampling)
+            else:
+                merged = group_sampling | env.sampling.model_dump(exclude_unset=True)
+                env.sampling = TrainSamplingConfig(**merged)
             if "num_workers" not in env.model_fields_set:
                 env.num_workers = self.num_workers
             if "max_retries" not in env.model_fields_set:
                 env.max_retries = self.max_retries
-        return self
-
-    @model_validator(mode="after")
-    def resolve_sampling(self):
-        """Resolve each env's sampling by merging group defaults with per-env overrides."""
-        group = self.sampling.model_dump()
-        for env in self.env:
-            if "sampling" not in env.model_fields_set:
-                env.sampling = TrainSamplingConfig(**group)
-            else:
-                merged = group.copy()
-                merged.update(env.sampling.model_dump(exclude_unset=True))
-                env.sampling = TrainSamplingConfig(**merged)
         return self
 
     @model_validator(mode="after")
@@ -496,22 +489,15 @@ class EvalConfig(BaseConfig):
     ] = 100
 
     @model_validator(mode="after")
-    def resolve_sampling(self):
-        """Resolve each env's sampling by merging group defaults with per-env overrides."""
-        group = self.sampling.model_dump()
+    def resolve_env_defaults(self):
+        """Resolve per-env overrides: inherit group-level sampling, num_workers, max_retries, num_examples, rollouts_per_example, and interval. Then resolve auto num_workers."""
+        group_sampling = self.sampling.model_dump()
         for env in self.env:
             if "sampling" not in env.model_fields_set:
-                env.sampling = EvalSamplingConfig(**group)
+                env.sampling = EvalSamplingConfig(**group_sampling)
             else:
-                merged = group.copy()
-                merged.update(env.sampling.model_dump(exclude_unset=True))
+                merged = group_sampling | env.sampling.model_dump(exclude_unset=True)
                 env.sampling = EvalSamplingConfig(**merged)
-        return self
-
-    @model_validator(mode="after")
-    def resolve_env_defaults(self):
-        """Fill per-env defaults from group-level values, then resolve auto num_workers."""
-        for env in self.env:
             if "num_examples" not in env.model_fields_set:
                 env.num_examples = self.num_examples
             if "rollouts_per_example" not in env.model_fields_set:
@@ -522,7 +508,7 @@ class EvalConfig(BaseConfig):
                 env.num_workers = self.num_workers
             if "max_retries" not in env.model_fields_set:
                 env.max_retries = self.max_retries
-            # Resolve num_workers now that num_examples and rollouts_per_example are set
+            # Resolve auto num_workers now that num_examples and rollouts_per_example are set
             if env.num_workers == "auto":
                 if env.num_examples == -1:
                     env.num_workers = 4

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -398,6 +398,28 @@ class TrainConfig(BaseConfig):
 
     sampling: TrainSamplingConfig = TrainSamplingConfig()
 
+    num_workers: Annotated[
+        int | Literal["auto"],
+        Field(
+            description="Default number of worker processes for env servers. Can be overridden per env.",
+        ),
+    ] = "auto"
+
+    max_retries: Annotated[
+        int,
+        Field(ge=0, description="Default number of retries for failed rollouts. Can be overridden per env."),
+    ] = 0
+
+    @model_validator(mode="after")
+    def resolve_env_defaults(self):
+        """Fill per-env num_workers and max_retries from group defaults."""
+        for env in self.env:
+            if "num_workers" not in env.model_fields_set:
+                env.num_workers = self.num_workers
+            if "max_retries" not in env.model_fields_set:
+                env.max_retries = self.max_retries
+        return self
+
     @model_validator(mode="after")
     def resolve_sampling(self):
         """Resolve each env's sampling by merging group defaults with per-env overrides."""
@@ -453,6 +475,18 @@ class EvalConfig(BaseConfig):
         Field(ge=1, description="Default number of rollouts per example. Can be overridden per env."),
     ] = 1
 
+    num_workers: Annotated[
+        int | Literal["auto"],
+        Field(
+            description="Default number of worker processes for env servers. Can be overridden per env.",
+        ),
+    ] = "auto"
+
+    max_retries: Annotated[
+        int,
+        Field(ge=0, description="Default number of retries for failed rollouts. Can be overridden per env."),
+    ] = 0
+
     interval: Annotated[
         int,
         Field(
@@ -476,7 +510,7 @@ class EvalConfig(BaseConfig):
 
     @model_validator(mode="after")
     def resolve_env_defaults(self):
-        """Fill per-env num_examples, rollouts_per_example, and interval from group defaults, then resolve num_workers."""
+        """Fill per-env defaults from group-level values, then resolve auto num_workers."""
         for env in self.env:
             if "num_examples" not in env.model_fields_set:
                 env.num_examples = self.num_examples
@@ -484,6 +518,10 @@ class EvalConfig(BaseConfig):
                 env.rollouts_per_example = self.rollouts_per_example
             if "interval" not in env.model_fields_set:
                 env.interval = self.interval
+            if "num_workers" not in env.model_fields_set:
+                env.num_workers = self.num_workers
+            if "max_retries" not in env.model_fields_set:
+                env.max_retries = self.max_retries
             # Resolve num_workers now that num_examples and rollouts_per_example are set
             if env.num_workers == "auto":
                 if env.num_examples == -1:

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -364,7 +364,7 @@ async def orchestrate(config: OrchestratorConfig):
 
         if envs_to_eval:
             env_names = ", ".join(e.name for e in envs_to_eval)
-            logger.info(f"Running evals at {ckpt_step=} for [{env_names}]")
+            logger.info(f"Running evals at {ckpt_step=} for {env_names}")
 
             # Pause weight updates and re-scheduling of training rollouts during eval
             # to avoid evaluating across different checkpoints and avoid congestion

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -364,7 +364,7 @@ async def orchestrate(config: OrchestratorConfig):
 
         if envs_to_eval:
             env_names = ", ".join(e.name for e in envs_to_eval)
-            logger.info(f"Running evals at ckpt_step={ckpt_step}: [{env_names}]")
+            logger.info(f"Running evals at {ckpt_step=} for {' '.join(env_names)}")
 
             # Pause weight updates and re-scheduling of training rollouts during eval
             # to avoid evaluating across different checkpoints and avoid congestion

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -364,7 +364,7 @@ async def orchestrate(config: OrchestratorConfig):
 
         if envs_to_eval:
             env_names = ", ".join(e.name for e in envs_to_eval)
-            logger.info(f"Running evals at {ckpt_step=} for {' '.join(env_names)}")
+            logger.info(f"Running evals at {ckpt_step=} for [{env_names}]")
 
             # Pause weight updates and re-scheduling of training rollouts during eval
             # to avoid evaluating across different checkpoints and avoid congestion

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -36,7 +36,7 @@ from transformers import AutoProcessor, AutoTokenizer
 from prime_rl.configs.orchestrator import OrchestratorConfig
 from prime_rl.orchestrator.buffer import Buffer
 from prime_rl.orchestrator.ckpt import Progress, setup_ckpt_manager
-from prime_rl.orchestrator.envs import EvalEnvs, TrainEnvs
+from prime_rl.orchestrator.envs import EvalEnv, EvalEnvs, TrainEnvs
 from prime_rl.orchestrator.filters import apply_filters, setup_filters
 from prime_rl.orchestrator.scheduler import Scheduler
 from prime_rl.orchestrator.utils import (
@@ -273,8 +273,8 @@ async def orchestrate(config: OrchestratorConfig):
     logger.info(f"Initializing training batch sender ({config.rollout_transport})")
     training_batch_sender = setup_training_batch_sender(config.output_dir, config.rollout_transport)
 
-    # Track last online eval checkpoint step for this process
-    last_eval_step = -1
+    # Track last online eval checkpoint step per eval env
+    last_eval_steps: dict[str, int] = {env.name: -1 for env in eval_envs} if eval_envs else {}
     # Track previous ckpt_step to detect when ckpt_step jumps over eval interval boundaries
     prev_ckpt_step = -1
 
@@ -287,7 +287,7 @@ async def orchestrate(config: OrchestratorConfig):
         scheduler.ckpt_step = progress.step  # Always resume from the latest checkpoint
         if config.eval and config.eval.skip_eval_on_resume:
             prev_ckpt_step = scheduler.ckpt_step
-            last_eval_step = scheduler.ckpt_step
+            last_eval_steps = {name: scheduler.ckpt_step for name in last_eval_steps}
             logger.info(f"Skipping online eval on resume (ckpt_step={scheduler.ckpt_step})")
         else:
             # Allow eval at resumed step by setting prev_ckpt_step one behind
@@ -346,24 +346,25 @@ async def orchestrate(config: OrchestratorConfig):
 
         # Run evals BEFORE training (blocking). Weight updates are paused via
         # scheduler.checkpoint_ready during eval to ensure consistent weights.
-        # Use range check to handle ckpt_step jumping over interval boundaries.
-        eval_ckpt_step = None
+        # Each eval env has its own interval, so we check each independently.
+        envs_to_eval: list[EvalEnv] = []
         if config.eval:
             assert eval_envs is not None
-            eval_ckpt_step = compute_eval_ckpt_step(
-                ckpt_step=ckpt_step,
-                prev_ckpt_step=prev_ckpt_step,
-                last_eval_step=last_eval_step,
-                interval=config.eval.interval,
-                eval_base_model=config.eval.eval_base_model,
-            )
+            for eval_env in eval_envs:
+                eval_ckpt_step = compute_eval_ckpt_step(
+                    ckpt_step=ckpt_step,
+                    prev_ckpt_step=prev_ckpt_step,
+                    last_eval_step=last_eval_steps[eval_env.name],
+                    interval=eval_env.config.interval,
+                    eval_base_model=config.eval.eval_base_model,
+                )
+                if eval_ckpt_step is not None:
+                    last_eval_steps[eval_env.name] = ckpt_step
+                    envs_to_eval.append(eval_env)
 
-        if eval_ckpt_step is not None:
-            last_eval_step = ckpt_step
-            if eval_ckpt_step != ckpt_step:
-                logger.info(f"Running evals for interval step {eval_ckpt_step} (current ckpt_step={ckpt_step})")
-            else:
-                logger.info(f"Running evals for checkpoint step {ckpt_step}")
+        if envs_to_eval:
+            env_names = ", ".join(e.name for e in envs_to_eval)
+            logger.info(f"Running evals at ckpt_step={ckpt_step}: [{env_names}]")
 
             # Pause weight updates and re-scheduling of training rollouts during eval
             # to avoid evaluating across different checkpoints and avoid congestion
@@ -382,7 +383,7 @@ async def orchestrate(config: OrchestratorConfig):
                         ckpt_step=ckpt_step,
                         step=progress.step,
                     )
-                    for eval_env in eval_envs
+                    for eval_env in envs_to_eval
                 ]
             )
 

--- a/tests/unit/orchestrator/test_eval_scheduling.py
+++ b/tests/unit/orchestrator/test_eval_scheduling.py
@@ -84,3 +84,22 @@ def test_simulate_full_run():
         prev_ckpt_step = ckpt_step
 
     assert eval_triggered_at == [0, 25, 50, 75]
+
+
+def test_per_env_intervals():
+    """Simulate two eval envs with different intervals (5 and 10) over 20 steps."""
+    env_intervals = {"fast": 5, "slow": 10}
+    last_eval_steps = {name: -1 for name in env_intervals}
+    triggered = {name: [] for name in env_intervals}
+
+    prev_ckpt_step = -1
+    for ckpt_step in range(21):
+        for name, interval in env_intervals.items():
+            result = compute_eval_ckpt_step(ckpt_step, prev_ckpt_step, last_eval_steps[name], interval)
+            if result is not None:
+                triggered[name].append(result)
+                last_eval_steps[name] = ckpt_step
+        prev_ckpt_step = ckpt_step
+
+    assert triggered["fast"] == [0, 5, 10, 15, 20]
+    assert triggered["slow"] == [0, 10, 20]

--- a/tests/unit/orchestrator/test_eval_scheduling.py
+++ b/tests/unit/orchestrator/test_eval_scheduling.py
@@ -84,22 +84,3 @@ def test_simulate_full_run():
         prev_ckpt_step = ckpt_step
 
     assert eval_triggered_at == [0, 25, 50, 75]
-
-
-def test_per_env_intervals():
-    """Simulate two eval envs with different intervals (5 and 10) over 20 steps."""
-    env_intervals = {"fast": 5, "slow": 10}
-    last_eval_steps = {name: -1 for name in env_intervals}
-    triggered = {name: [] for name in env_intervals}
-
-    prev_ckpt_step = -1
-    for ckpt_step in range(21):
-        for name, interval in env_intervals.items():
-            result = compute_eval_ckpt_step(ckpt_step, prev_ckpt_step, last_eval_steps[name], interval)
-            if result is not None:
-                triggered[name].append(result)
-                last_eval_steps[name] = ckpt_step
-        prev_ckpt_step = ckpt_step
-
-    assert triggered["fast"] == [0, 5, 10, 15, 20]
-    assert triggered["slow"] == [0, 10, 20]


### PR DESCRIPTION
## Summary
- Add optional `interval` field to `EvalEnvConfig` so each eval env can run at its own cadence (inherits from group-level `eval.interval` if unset)
- Track `last_eval_step` per eval environment in the orchestrator loop
- Add group-level `num_workers` and `max_retries` to both `TrainConfig` and `EvalConfig`, inherited by individual envs unless overridden per-env
- Update multi reverse text config to demonstrate per-env eval intervals (`eval-default` every 5 steps, `eval-custom` every 10)

## Example config
```toml
[orchestrator.train]
num_workers = 4
max_retries = 2

[[orchestrator.train.env]]
id = "math-env"
# inherits num_workers=4, max_retries=2

[[orchestrator.train.env]]
id = "code-env"
num_workers = 8  # override

[orchestrator.eval]
interval = 5
num_workers = 2
max_retries = 1

[[orchestrator.eval.env]]
id = "math-env"
name = "eval-fast"
# inherits interval=5, num_workers=2, max_retries=1

[[orchestrator.eval.env]]
id = "math-env"
name = "eval-slow"
interval = 20  # runs less frequently
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes evaluation scheduling to run each eval environment on its own interval and adds new group-level defaults for env server behavior; misconfiguration could alter eval frequency or worker/retry settings during training.
> 
> **Overview**
> Adds **per-environment evaluation cadence** by introducing `EvalEnvConfig.interval` (inheriting from `eval.interval` when not overridden) and updating the orchestrator loop to track `last_eval_step` per eval env and only run the envs due at a given checkpoint.
> 
> Extends `TrainConfig` and `EvalConfig` with group-level `num_workers` and `max_retries` defaults that are inherited by individual env configs unless explicitly set.
> 
> Updates the `multi_reverse_text` example config to demonstrate per-env eval intervals (e.g., `eval-default` every 5 steps, `eval-custom` every 10).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb1026ccd243bd527785e6c9296774de36a5ba31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->