### PR TITLE
fix: let validation errors propagate as 400 on token route

### DIFF
--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -3,7 +3,7 @@ from http import HTTPStatus
 from typing import Any
 
 import uvloop
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 from starlette.datastructures import State
 from vllm.engine.protocol import EngineClient
@@ -247,10 +247,7 @@ async def _chat_with_tokens(request: ChatCompletionRequestWithTokens, raw_reques
     handler = chat_with_tokens(raw_request)
     if handler is None:
         return base(raw_request).create_error_response(message="The model does not support Chat Completions API")
-    try:
-        generator = await handler.create_chat_completion_with_tokens(request, raw_request)
-    except Exception as e:
-        raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value, detail=str(e)) from e
+    generator = await handler.create_chat_completion_with_tokens(request, raw_request)
     if isinstance(generator, ErrorResponse):
         return JSONResponse(content=generator.model_dump(), status_code=generator.error.code)
 


### PR DESCRIPTION
## Summary
- The `/v1/chat/completions/tokens` route had a blanket `except Exception` that wrapped all errors as `HTTPException(500)`, including `VLLMValidationError` from prompt length validation (e.g. overlong prompts)
- This escapes the verifiers guard for `BadRequestError` to gracefully stop a rollout with a overlong prompt
- Fixed by removing try/except and use default vLLM exception handlers for propagating the error to the client

**Before**

<img width="1108" height="242" alt="Screenshot 2026-04-09 at 9 56 17 PM" src="https://github.com/user-attachments/assets/fe63cd03-82bf-4345-b7bf-d65c01c6ed14" />

**After**

<img width="951" height="394" alt="Screenshot 2026-04-09 at 9 59 51 PM" src="https://github.com/user-attachments/assets/5e1acdb7-381d-4d5d-a2cd-6c687c132f10" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error-handling behavior for `/v1/chat/completions/tokens`, which can alter returned HTTP status codes/bodies for some failures and affect clients relying on previous 500s.
> 
> **Overview**
> Removes the catch-all exception wrapper in `/v1/chat/completions/tokens` so errors from `create_chat_completion_with_tokens` (e.g., request/prompt validation failures) propagate through vLLM/FastAPI’s default handlers instead of being converted into a generic 500.
> 
> Also drops the unused `HTTPException` import since the route no longer manually raises it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 082820b995a5f1ea26488888538ecc8e7fb90fb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->