### PR TITLE
fix: prepend base_model.model. prefix to broadcast LoRA keys

### DIFF
--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -227,66 +227,35 @@ def _patch_qwen35_lora():
 def _patch_lora_key_prefix():
     """Patch vLLM's LoRA loading to handle keys without base_model.model. prefix.
 
-    The trainer's filesystem broadcast saves LoRA weights with raw model keys
-    (e.g. language_model.model.layers.0.mlp.experts.0.down_proj.lora_A.weight)
-    without the base_model.model. prefix that vLLM's parse_fine_tuned_lora_name()
-    expects. vLLM 0.19 added check_unexpected_modules() which rejects these keys.
-
-    This patch wraps from_local_checkpoint to normalize keys by prepending
-    base_model.model. when missing, so both old checkpoints and new broadcasts
-    work correctly.
+    The trainer's broadcast saves LoRA weights without the base_model.model.
+    prefix that vLLM 0.19's check_unexpected_modules() expects. This patch
+    rewrites the safetensors file in-place to add the prefix before vLLM loads it.
     """
-    import safetensors
+    from pathlib import Path
+
+    from safetensors.torch import load_file, save_file
     from vllm.lora.lora_model import LoRAModel
 
     _original_from_local_checkpoint = LoRAModel.from_local_checkpoint
 
     @classmethod
-    def _patched_from_local_checkpoint(cls, *args, **kwargs):
-        # Intercept safetensors loading to fix key prefixes
-        _original_safe_open = safetensors.safe_open
+    def _patched_from_local_checkpoint(cls, lora_dir, *args, **kwargs):
+        # Check if the safetensors file needs key prefix normalization
+        st_path = Path(lora_dir) / "adapter_model.safetensors"
+        if st_path.exists():
+            tensors = load_file(str(st_path))
+            needs_fix = any(
+                ("lora_A" in k or "lora_B" in k) and not k.startswith("base_model.model.")
+                for k in tensors
+            )
+            if needs_fix:
+                fixed = {
+                    (f"base_model.model.{k}" if ("lora_A" in k or "lora_B" in k) and not k.startswith("base_model.model.") else k): v
+                    for k, v in tensors.items()
+                }
+                save_file(fixed, str(st_path))
 
-        class _PrefixFixWrapper:
-            """Wraps a safetensors file handle to prepend base_model.model. to keys."""
-
-            def __init__(self, handle):
-                self._handle = handle
-                self._needs_prefix = False
-                self._keys = list(handle.keys())
-                # Check if any LoRA key is missing the expected prefix
-                for k in self._keys:
-                    if ("lora_A" in k or "lora_B" in k) and not k.startswith("base_model.model."):
-                        self._needs_prefix = True
-                        break
-
-            def keys(self):
-                if self._needs_prefix:
-                    return [f"base_model.model.{k}" if ("lora_A" in k or "lora_B" in k) and not k.startswith("base_model.model.") else k for k in self._keys]
-                return self._keys
-
-            def get_tensor(self, name):
-                if self._needs_prefix and name.startswith("base_model.model."):
-                    original_name = name[len("base_model.model."):]
-                    if original_name in self._keys:
-                        return self._handle.get_tensor(original_name)
-                return self._handle.get_tensor(name)
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *args):
-                return self._handle.__exit__(*args)
-
-        def _patched_safe_open(path, framework="pt", device="cpu"):
-            handle = _original_safe_open(path, framework=framework, device=device)
-            return _PrefixFixWrapper(handle)
-
-        # Temporarily replace safe_open during from_local_checkpoint
-        safetensors.safe_open = _patched_safe_open
-        try:
-            return _original_from_local_checkpoint.__func__(cls, *args, **kwargs)
-        finally:
-            safetensors.safe_open = _original_safe_open
+        return _original_from_local_checkpoint.__func__(cls, lora_dir, *args, **kwargs)
 
     LoRAModel.from_local_checkpoint = _patched_from_local_checkpoint
 

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -230,7 +230,9 @@ def _patch_lora_key_prefix():
     The trainer's broadcast saves LoRA weights without the base_model.model.
     prefix that vLLM 0.19's check_unexpected_modules() expects. This patch
     rewrites the safetensors file in-place to add the prefix before vLLM loads it.
+    Uses a file lock to prevent race conditions between concurrent workers.
     """
+    import fcntl
     from pathlib import Path
 
     from safetensors.torch import load_file, save_file
@@ -240,21 +242,28 @@ def _patch_lora_key_prefix():
 
     @classmethod
     def _patched_from_local_checkpoint(cls, lora_dir, *args, **kwargs):
-        # Check if the safetensors file needs key prefix normalization
         st_path = Path(lora_dir) / "adapter_model.safetensors"
+        lock_path = Path(lora_dir) / ".lora_key_fix.lock"
         if st_path.exists():
-            tensors = load_file(str(st_path))
-            needs_fix = any(("lora_A" in k or "lora_B" in k) and not k.startswith("base_model.model.") for k in tensors)
-            if needs_fix:
-                fixed = {
-                    (
-                        f"base_model.model.{k}"
-                        if ("lora_A" in k or "lora_B" in k) and not k.startswith("base_model.model.")
-                        else k
-                    ): v
-                    for k, v in tensors.items()
-                }
-                save_file(fixed, str(st_path))
+            with open(lock_path, "w") as lock_fd:
+                fcntl.flock(lock_fd, fcntl.LOCK_EX)
+                try:
+                    tensors = load_file(str(st_path))
+                    needs_fix = any(
+                        ("lora_A" in k or "lora_B" in k) and not k.startswith("base_model.model.") for k in tensors
+                    )
+                    if needs_fix:
+                        fixed = {
+                            (
+                                f"base_model.model.{k}"
+                                if ("lora_A" in k or "lora_B" in k) and not k.startswith("base_model.model.")
+                                else k
+                            ): v
+                            for k, v in tensors.items()
+                        }
+                        save_file(fixed, str(st_path))
+                finally:
+                    fcntl.flock(lock_fd, fcntl.LOCK_UN)
 
         return _original_from_local_checkpoint.__func__(cls, lora_dir, *args, **kwargs)
 

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -243,27 +243,33 @@ def _patch_lora_key_prefix():
     @classmethod
     def _patched_from_local_checkpoint(cls, lora_dir, *args, **kwargs):
         st_path = Path(lora_dir) / "adapter_model.safetensors"
-        lock_path = Path(lora_dir) / ".lora_key_fix.lock"
         if st_path.exists():
-            with open(lock_path, "w") as lock_fd:
-                fcntl.flock(lock_fd, fcntl.LOCK_EX)
-                try:
-                    tensors = load_file(str(st_path))
-                    needs_fix = any(
-                        ("lora_A" in k or "lora_B" in k) and not k.startswith("base_model.model.") for k in tensors
-                    )
-                    if needs_fix:
-                        fixed = {
-                            (
-                                f"base_model.model.{k}"
-                                if ("lora_A" in k or "lora_B" in k) and not k.startswith("base_model.model.")
-                                else k
-                            ): v
-                            for k, v in tensors.items()
-                        }
-                        save_file(fixed, str(st_path))
-                finally:
-                    fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            # Read-only check first — no lock or write needed if keys are fine
+            tensors = load_file(str(st_path))
+            needs_fix = any(("lora_A" in k or "lora_B" in k) and not k.startswith("base_model.model.") for k in tensors)
+            if needs_fix:
+                # Only acquire lock and write when rewrite is actually needed
+                lock_path = Path(lora_dir) / ".lora_key_fix.lock"
+                with open(lock_path, "w") as lock_fd:
+                    fcntl.flock(lock_fd, fcntl.LOCK_EX)
+                    try:
+                        # Re-read under lock in case another worker already fixed it
+                        tensors = load_file(str(st_path))
+                        needs_fix = any(
+                            ("lora_A" in k or "lora_B" in k) and not k.startswith("base_model.model.") for k in tensors
+                        )
+                        if needs_fix:
+                            fixed = {
+                                (
+                                    f"base_model.model.{k}"
+                                    if ("lora_A" in k or "lora_B" in k) and not k.startswith("base_model.model.")
+                                    else k
+                                ): v
+                                for k, v in tensors.items()
+                            }
+                            save_file(fixed, str(st_path))
+                    finally:
+                        fcntl.flock(lock_fd, fcntl.LOCK_UN)
 
         return _original_from_local_checkpoint.__func__(cls, lora_dir, *args, **kwargs)
 

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -244,13 +244,14 @@ def _patch_lora_key_prefix():
         st_path = Path(lora_dir) / "adapter_model.safetensors"
         if st_path.exists():
             tensors = load_file(str(st_path))
-            needs_fix = any(
-                ("lora_A" in k or "lora_B" in k) and not k.startswith("base_model.model.")
-                for k in tensors
-            )
+            needs_fix = any(("lora_A" in k or "lora_B" in k) and not k.startswith("base_model.model.") for k in tensors)
             if needs_fix:
                 fixed = {
-                    (f"base_model.model.{k}" if ("lora_A" in k or "lora_B" in k) and not k.startswith("base_model.model.") else k): v
+                    (
+                        f"base_model.model.{k}"
+                        if ("lora_A" in k or "lora_B" in k) and not k.startswith("base_model.model.")
+                        else k
+                    ): v
                     for k, v in tensors.items()
                 }
                 save_file(fixed, str(st_path))

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -14,6 +14,7 @@ def transformers_v5_compat():
         Qwen3VLMoeTextConfig.tie_word_embeddings = False
 
     _patch_qwen35_lora()
+    _patch_lora_key_prefix()
     monkey_patch_deep_gemm_ep_scatter()
     monkey_patch_dp_engine_core_pause_resume_deadlock()
 
@@ -221,6 +222,73 @@ def _patch_qwen35_lora():
         ]
 
     MergedColumnParallelLinearWithShardedLoRA.slice_lora_a = slice_lora_a
+
+
+def _patch_lora_key_prefix():
+    """Patch vLLM's LoRA loading to handle keys without base_model.model. prefix.
+
+    The trainer's filesystem broadcast saves LoRA weights with raw model keys
+    (e.g. language_model.model.layers.0.mlp.experts.0.down_proj.lora_A.weight)
+    without the base_model.model. prefix that vLLM's parse_fine_tuned_lora_name()
+    expects. vLLM 0.19 added check_unexpected_modules() which rejects these keys.
+
+    This patch wraps from_local_checkpoint to normalize keys by prepending
+    base_model.model. when missing, so both old checkpoints and new broadcasts
+    work correctly.
+    """
+    import safetensors
+    from vllm.lora.lora_model import LoRAModel
+
+    _original_from_local_checkpoint = LoRAModel.from_local_checkpoint
+
+    @classmethod
+    def _patched_from_local_checkpoint(cls, *args, **kwargs):
+        # Intercept safetensors loading to fix key prefixes
+        _original_safe_open = safetensors.safe_open
+
+        class _PrefixFixWrapper:
+            """Wraps a safetensors file handle to prepend base_model.model. to keys."""
+
+            def __init__(self, handle):
+                self._handle = handle
+                self._needs_prefix = False
+                self._keys = list(handle.keys())
+                # Check if any LoRA key is missing the expected prefix
+                for k in self._keys:
+                    if ("lora_A" in k or "lora_B" in k) and not k.startswith("base_model.model."):
+                        self._needs_prefix = True
+                        break
+
+            def keys(self):
+                if self._needs_prefix:
+                    return [f"base_model.model.{k}" if ("lora_A" in k or "lora_B" in k) and not k.startswith("base_model.model.") else k for k in self._keys]
+                return self._keys
+
+            def get_tensor(self, name):
+                if self._needs_prefix and name.startswith("base_model.model."):
+                    original_name = name[len("base_model.model."):]
+                    if original_name in self._keys:
+                        return self._handle.get_tensor(original_name)
+                return self._handle.get_tensor(name)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return self._handle.__exit__(*args)
+
+        def _patched_safe_open(path, framework="pt", device="cpu"):
+            handle = _original_safe_open(path, framework=framework, device=device)
+            return _PrefixFixWrapper(handle)
+
+        # Temporarily replace safe_open during from_local_checkpoint
+        safetensors.safe_open = _patched_safe_open
+        try:
+            return _original_from_local_checkpoint.__func__(cls, *args, **kwargs)
+        finally:
+            safetensors.safe_open = _original_safe_open
+
+    LoRAModel.from_local_checkpoint = _patched_from_local_checkpoint
 
 
 # Monkeypatch LoadLoRAAdapter to allow loading the same adapter multiple times

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -227,53 +227,142 @@ def _patch_qwen35_lora():
 def _patch_lora_key_prefix():
     """Patch vLLM's LoRA loading to handle keys without base_model.model. prefix.
 
-    The trainer's broadcast saves LoRA weights without the base_model.model.
-    prefix that vLLM 0.19's check_unexpected_modules() expects. This patch
-    rewrites the safetensors file in-place to add the prefix before vLLM loads it.
-    Uses a file lock to prevent race conditions between concurrent workers.
+    This is a copy of the upstream patch: https://github.com/vllm-project/vllm/pull/38522
+    We can remove this patch once that PR makes it into a release.
     """
-    import fcntl
-    from pathlib import Path
+    from vllm.lora.lora_model import (
+        LoRAModel,
+        PEFTHelper,
+        TensorizerConfig,
+        WeightsMapper,
+        get_lora_id,
+        is_base_embedding_weights,
+        os,
+        parse_fine_tuned_lora_name,
+        safetensors,
+    )
 
-    from safetensors.torch import load_file, save_file
-    from vllm.lora.lora_model import LoRAModel
+    def _patched_from_local_checkpoint(
+        cls,
+        lora_dir: str,
+        expected_lora_modules: set[str],
+        peft_helper: PEFTHelper,
+        *,
+        lora_model_id: int | None = None,
+        device: str = "cuda",
+        dtype: torch.dtype | None = None,
+        model_vocab_size: int | None = None,
+        weights_mapper: WeightsMapper | None = None,
+        tensorizer_config_dict: dict | None = None,
+        skip_prefixes: list[str] | None = None,
+    ) -> "LoRAModel":
+        """Create a LoRAModel from a local checkpoint.
 
-    _original_from_local_checkpoint = LoRAModel.from_local_checkpoint
+        Args:
+            lora_dir: The local path that has lora data.
+            expected_lora_modules: Name of modules that are expected to be
+                replaced by lora.
+            peft_helper: Loaded lora configuration information.
+            lora_model_id: LoRA model id. If not given, automatically set by
+                a global counter.
+            device: Device where the lora model is loaded.
+            dtype: dtype of the lora model weights.
+            skip_prefixes: List of module name prefixes to skip during loading.
+                Models can define this to skip modules not used in inference
+                (e.g., MTP layers). Format: ["mtp."]
 
-    @classmethod
-    def _patched_from_local_checkpoint(cls, lora_dir, *args, **kwargs):
-        st_path = Path(lora_dir) / "adapter_model.safetensors"
-        if st_path.exists():
-            # Read-only check first — no lock or write needed if keys are fine
-            tensors = load_file(str(st_path))
-            needs_fix = any(("lora_A" in k or "lora_B" in k) and not k.startswith("base_model.model.") for k in tensors)
-            if needs_fix:
-                # Only acquire lock and write when rewrite is actually needed
-                lock_path = Path(lora_dir) / ".lora_key_fix.lock"
-                with open(lock_path, "w") as lock_fd:
-                    fcntl.flock(lock_fd, fcntl.LOCK_EX)
-                    try:
-                        # Re-read under lock in case another worker already fixed it
-                        tensors = load_file(str(st_path))
-                        needs_fix = any(
-                            ("lora_A" in k or "lora_B" in k) and not k.startswith("base_model.model.") for k in tensors
-                        )
-                        if needs_fix:
-                            fixed = {
-                                (
-                                    f"base_model.model.{k}"
-                                    if ("lora_A" in k or "lora_B" in k) and not k.startswith("base_model.model.")
-                                    else k
-                                ): v
-                                for k, v in tensors.items()
-                            }
-                            save_file(fixed, str(st_path))
-                    finally:
-                        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        Returns:
+            Loaded LoRA Model.
+        """
+        lora_tensor_path = os.path.join(lora_dir, "adapter_model.safetensors")
+        lora_bin_file_path = os.path.join(lora_dir, "adapter_model.bin")
+        lora_pt_file_path = os.path.join(lora_dir, "adapter_model.pt")
 
-        return _original_from_local_checkpoint.__func__(cls, lora_dir, *args, **kwargs)
+        tensors: dict[str, torch.Tensor] = {}
+        unexpected_modules: list[list[str] | str] = []
 
-    LoRAModel.from_local_checkpoint = _patched_from_local_checkpoint
+        def check_unexpected_modules(modules: dict):
+            for lora_module in modules.keys():  # noqa
+                if is_base_embedding_weights(lora_module):
+                    continue
+                # Handle PEFT file format where experts.base_layer is the
+                # gate_up_proj and experts is the down_proj
+                if "base_layer" in lora_module:
+                    continue
+                # Skip modules based on model-defined prefixes
+                if skip_prefixes and cls._should_skip_module(lora_module, skip_prefixes):
+                    continue
+                module_name, _ = parse_fine_tuned_lora_name(lora_module, weights_mapper)
+                # Case for expert lora weights.
+                # For standard MoE models the name ends in "...experts",
+                # so expert_idx+1 yields "experts" which is in
+                # expected_lora_modules.
+                # For Qwen 3.5 MoE (and similar models) the expert index
+                # is embedded: "...experts.N.down_proj".  Taking everything
+                # after ".experts" gives "experts.N.down_proj" which is
+                # never in the expected set even though "down_proj" is.
+                # Fix: always compare just the last component of the path.
+                if ".experts" in module_name:
+                    expert_suffix = module_name.split(".")[-1]
+                    if expert_suffix not in expected_lora_modules:
+                        unexpected_modules.append(module_name)
+
+                elif module_name.rsplit(".", 1)[-1] not in expected_lora_modules:
+                    unexpected_modules.append(module_name)
+
+            if unexpected_modules:
+                raise ValueError(
+                    f"While loading {lora_dir}, expected"
+                    f" target modules in {expected_lora_modules}"
+                    f" but received {unexpected_modules}."
+                    f" Please verify that the loaded LoRA module is correct"
+                )
+
+        if tensorizer_config_dict:
+            from tensorizer import TensorDeserializer
+
+            tensorizer_config = TensorizerConfig(**tensorizer_config_dict)
+            lora_tensor_path = os.path.join(tensorizer_config.tensorizer_dir, "adapter_model.tensors")
+            tensorizer_args = tensorizer_config._construct_tensorizer_args()
+            tensors = TensorDeserializer(
+                lora_tensor_path,
+                dtype=tensorizer_config.dtype,
+                **tensorizer_args.deserialization_kwargs,
+            )
+            check_unexpected_modules(tensors)
+
+        elif os.path.isfile(lora_tensor_path):
+            # Find unexpected modules.
+            # Use safetensor key as a source of truth to find expected modules.
+            # in peft if you have target_modules A, B, C and C does not exist
+            # in the model it won’t error and model will be trained with A, B
+            # loraified. C won’t exist in the safetensor but it will exist in
+            # the target_modules of the adapter_config.json.
+            unexpected_modules = []
+            with safetensors.safe_open(lora_tensor_path, framework="pt") as f:  # type: ignore
+                # Load tensors if there are only expected modules.
+                check_unexpected_modules(f)
+                for module in f.keys():  # noqa
+                    tensors[module] = f.get_tensor(module)
+        elif os.path.isfile(lora_bin_file_path) or os.path.isfile(lora_pt_file_path):
+            lora_file_path = lora_bin_file_path if os.path.isfile(lora_bin_file_path) else lora_pt_file_path
+            tensors = torch.load(lora_file_path, map_location=device, weights_only=True)
+            check_unexpected_modules(tensors)
+        else:
+            raise ValueError(f"{lora_dir} doesn't contain tensors")
+
+        return cls.from_lora_tensors(
+            lora_model_id=get_lora_id() if lora_model_id is None else lora_model_id,
+            tensors=tensors,
+            peft_helper=peft_helper,
+            device=device,
+            dtype=dtype,
+            model_vocab_size=model_vocab_size,
+            weights_mapper=weights_mapper,
+            skip_prefixes=skip_prefixes,
+        )
+
+    LoRAModel.from_local_checkpoint = classmethod(_patched_from_local_checkpoint)
 
 
 # Monkeypatch LoadLoRAAdapter to allow loading the same adapter multiple times

--- a/src/prime_rl/trainer/rl/broadcast/filesystem.py
+++ b/src/prime_rl/trainer/rl/broadcast/filesystem.py
@@ -59,12 +59,16 @@ class FileSystemWeightBroadcast(WeightBroadcast):
             if adapter_only:
                 # For adapter-only, MultiRunManager creates state dict directly for each run
                 # All ranks must participate in DTensor gathering, but only master saves
-                state_dict = self.multi_run_manager.get_state_dict_for_run(idx)
-                for key, value in state_dict.items():
+                raw_state_dict = self.multi_run_manager.get_state_dict_for_run(idx)
+                state_dict = {}
+                for key, value in raw_state_dict.items():
                     if isinstance(value, DTensor):
                         value = value.full_tensor()
                     if self.world.is_master:
-                        state_dict[key] = value.to("cpu", non_blocking=False)
+                        # Prepend base_model.model. prefix for PEFT/vLLM compatibility.
+                        # vLLM's parse_fine_tuned_lora_name() expects this prefix to
+                        # correctly strip it and match module names against target_modules.
+                        state_dict[f"base_model.model.{key}"] = value.to("cpu", non_blocking=False)
 
             # TODO: Broadcast ready to update in sync, then we dont need to gather on not ready
             if self.world.is_master:

--- a/src/prime_rl/trainer/rl/broadcast/filesystem.py
+++ b/src/prime_rl/trainer/rl/broadcast/filesystem.py
@@ -59,16 +59,12 @@ class FileSystemWeightBroadcast(WeightBroadcast):
             if adapter_only:
                 # For adapter-only, MultiRunManager creates state dict directly for each run
                 # All ranks must participate in DTensor gathering, but only master saves
-                raw_state_dict = self.multi_run_manager.get_state_dict_for_run(idx)
-                state_dict = {}
-                for key, value in raw_state_dict.items():
+                state_dict = self.multi_run_manager.get_state_dict_for_run(idx)
+                for key, value in state_dict.items():
                     if isinstance(value, DTensor):
                         value = value.full_tensor()
                     if self.world.is_master:
-                        # Prepend base_model.model. prefix for PEFT/vLLM compatibility.
-                        # vLLM's parse_fine_tuned_lora_name() expects this prefix to
-                        # correctly strip it and match module names against target_modules.
-                        state_dict[f"base_model.model.{key}"] = value.to("cpu", non_blocking=False)
+                        state_dict[key] = value.to("cpu", non_blocking=False)
 
             # TODO: Broadcast ready to update in sync, then we dont need to gather on not ready
             if self.world.is_master:


### PR DESCRIPTION
## Problem

LoRA training on MoE models (Qwen3.5-35B, etc.) crashes with vLLM 0.19 (v0.5.1.dev48+) when the orchestrator tries to load the LoRA adapter into inference:

```
ValueError: While loading .../broadcasts/step_1, expected target modules in
{'down_proj', 'gate_proj', 'up_proj', ...} but received
['language_model.model.layers.0.mlp.experts.0.down_proj', ...]
```

## Root cause

Two code paths save LoRA weights:

1. **Checkpoint path** (ckpt.py:322) - prepends `base_model.model.` to keys
2. **Broadcast path** (filesystem.py:62-67) - saves raw keys without prefix

vLLM's `parse_fine_tuned_lora_name()` expects keys starting with `base_model.model.` so it can strip the prefix and match the short module name (e.g. `down_proj`) against `expected_lora_modules`. Without the prefix, the full path doesn't match and vLLM rejects it.

This worked on vLLM 0.17 (dev2) because it didn't have `check_unexpected_modules()` validation. vLLM 0.19 added this check.

## Fix

Prepend `base_model.model.` in the broadcast path, matching what the checkpoint path already does. Backward compatible with dev2/vLLM 0.17.

## Impact

- all MoE model LoRA training broken on dev48 (Qwen3.5-35B confirmed)
- dense models unaffected
- backward compatible

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Overrides vLLM’s `LoRAModel.from_local_checkpoint` validation/parsing via monkeypatching, which can affect whether adapters load or are rejected across models. Risk is moderate because it changes inference-time weight loading logic but is scoped to LoRA adapter ingestion.
> 
> **Overview**
> Fixes LoRA adapter loading failures in vLLM by installing a new `_patch_lora_key_prefix()` that monkeypatches `LoRAModel.from_local_checkpoint` to tolerate adapter tensor keys that *don’t* include the `base_model.model.` prefix.
> 
> The patch also relaxes/adjusts unexpected-module validation for MoE expert weights by matching against the last path component (e.g. `down_proj`) rather than full expert-qualified names, and it is now invoked from `transformers_v5_compat()` so it runs in all vLLM processes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f99fd82f777af2615469d6c9b417ec0429a87408. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->