### PR TITLE
feat: separate eval client type from training

### DIFF
--- a/configs/alphabet_sort/rl.toml
+++ b/configs/alphabet_sort/rl.toml
@@ -21,6 +21,13 @@ id = "alphabet-sort"
 name = "alphabet-sort"
 args = { min_turns = 2, max_turns = 2 }
 
+[[orchestrator.eval.env]]
+id = "alphabet-sort"
+name = "alphabet-sort"
+num_examples = 50
+rollouts_per_example = 4
+args = { min_turns = 2, max_turns = 2 }
+
 [trainer]
 
 [inference]

--- a/configs/alphabet_sort/rl.toml
+++ b/configs/alphabet_sort/rl.toml
@@ -21,6 +21,9 @@ id = "alphabet-sort"
 name = "alphabet-sort"
 args = { min_turns = 2, max_turns = 2 }
 
+[orchestrator.eval]
+interval = 50
+
 [[orchestrator.eval.env]]
 id = "alphabet-sort"
 name = "alphabet-sort"

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -117,7 +117,10 @@ async def orchestrate(config: OrchestratorConfig):
             "history and the chat template has the extension property."
         )
     inference_pool = await setup_inference_pool(
-        rollout_client_config, model_name=rollout_model_name, client_type=client_type
+        rollout_client_config,
+        model_name=rollout_model_name,
+        client_type=client_type,
+        eval_client_type="openai_chat_completions",
     )
 
     # Setup teacher inference pool if configured
@@ -379,7 +382,7 @@ async def orchestrate(config: OrchestratorConfig):
                 *[
                     eval_env.evaluate(
                         model_name=scheduler.model_name,
-                        get_client=inference_pool.get_next_client,
+                        get_client=inference_pool.get_eval_client,
                         ckpt_step=ckpt_step,
                         step=progress.step,
                     )
@@ -704,7 +707,7 @@ async def orchestrate(config: OrchestratorConfig):
             *[
                 eval_env.evaluate(
                     model_name=scheduler.model_name,
-                    get_client=inference_pool.get_next_client,
+                    get_client=inference_pool.get_eval_client,
                     ckpt_step=ckpt_step,
                     step=progress.step,
                 )

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -111,11 +111,6 @@ async def orchestrate(config: OrchestratorConfig):
     rollout_client_config, rollout_model_name, enable_policy_updates = setup_external_rollout_model(config, logger)
 
     train_client_type = "openai_chat_completions_token" if config.use_token_client else "openai_chat_completions"
-    if config.use_token_client:
-        logger.warning(
-            "Token-in-token-out (TITO) client is enabled. Only use this if your environment has a linear "
-            "history and the chat template has the extension property."
-        )
     inference_pool = await setup_inference_pool(
         rollout_client_config,
         model_name=rollout_model_name,
@@ -500,7 +495,7 @@ async def orchestrate(config: OrchestratorConfig):
             logger.info(f"Computing teacher logprobs for {len(train_examples)} training examples")
             teacher_logprobs_start_time = time.perf_counter()
             teacher_logprobs_list = await compute_teacher_logprobs(
-                clients=teacher_inference_pool.clients,
+                clients=teacher_inference_pool.train_clients,
                 model_name=config.teacher_model.model.name,
                 samples=train_examples,
             )

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -110,7 +110,7 @@ async def orchestrate(config: OrchestratorConfig):
     # Setup rollout inference pool (handles both static and elastic modes)
     rollout_client_config, rollout_model_name, enable_policy_updates = setup_external_rollout_model(config, logger)
 
-    client_type = "openai_chat_completions_token" if config.use_token_client else "openai_chat_completions"
+    train_client_type = "openai_chat_completions_token" if config.use_token_client else "openai_chat_completions"
     if config.use_token_client:
         logger.warning(
             "Token-in-token-out (TITO) client is enabled. Only use this if your environment has a linear "
@@ -119,7 +119,7 @@ async def orchestrate(config: OrchestratorConfig):
     inference_pool = await setup_inference_pool(
         rollout_client_config,
         model_name=rollout_model_name,
-        client_type=client_type,
+        train_client_type=train_client_type,
         eval_client_type="openai_chat_completions",
     )
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -125,7 +125,9 @@ async def orchestrate(config: OrchestratorConfig):
             f"model={config.teacher_model.model.name})"
         )
         teacher_inference_pool = await setup_inference_pool(
-            config.teacher_model.client, model_name=config.teacher_model.model.name
+            config.teacher_model.client,
+            model_name=config.teacher_model.model.name,
+            train_client_type="openai_chat_completions",
         )
     else:
         teacher_inference_pool = None

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -156,10 +156,10 @@ class Scheduler:
         Uses (api_base_url, dp_rank) as identity rather than client_idx so that
         load tracking survives elastic pool refreshes (which reassign indices).
         """
-        clients = self.inference_pool.clients
+        clients = self.inference_pool.train_clients
         while not clients:
             await asyncio.sleep(1)
-            clients = self.inference_pool.clients
+            clients = self.inference_pool.train_clients
         inflight = Counter(self._client_identity(info.client_config) for info in self.inflight_requests.values())
         return min(clients, key=lambda c: inflight[self._client_identity(c)])
 

--- a/src/prime_rl/transport/filesystem.py
+++ b/src/prime_rl/transport/filesystem.py
@@ -6,8 +6,8 @@ from prime_rl.transport.base import MicroBatchReceiver, MicroBatchSender, Traini
 from prime_rl.transport.types import MicroBatch, TrainingBatch
 from prime_rl.utils.pathing import get_rollout_dir, get_step_path, sync_wait_for_path
 
-BATCH_FILE_TMP_NAME = "rollouts.bin.tmp"
-BATCH_FILE_NAME = "rollouts.bin"
+BATCH_FILE_TMP_NAME = "train_rollouts.bin.tmp"
+BATCH_FILE_NAME = "train_rollouts.bin"
 LOG_FREQ_SECONDS = 10
 
 

--- a/src/prime_rl/transport/filesystem.py
+++ b/src/prime_rl/transport/filesystem.py
@@ -6,8 +6,8 @@ from prime_rl.transport.base import MicroBatchReceiver, MicroBatchSender, Traini
 from prime_rl.transport.types import MicroBatch, TrainingBatch
 from prime_rl.utils.pathing import get_rollout_dir, get_step_path, sync_wait_for_path
 
-BATCH_FILE_TMP_NAME = "train_rollouts.bin.tmp"
-BATCH_FILE_NAME = "train_rollouts.bin"
+BATCH_FILE_TMP_NAME = "rollouts.bin.tmp"
+BATCH_FILE_NAME = "rollouts.bin"
 LOG_FREQ_SECONDS = 10
 
 

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -59,13 +59,19 @@ class StaticInferencePool:
     """Static inference pool with fixed client list."""
 
     def __init__(
-        self, clients: list[vf.ClientConfig], admin_clients: list[AsyncClient], skip_model_check: bool = False
+        self,
+        clients: list[vf.ClientConfig],
+        admin_clients: list[AsyncClient],
+        skip_model_check: bool = False,
+        eval_clients: list[vf.ClientConfig] | None = None,
     ):
         self._clients = clients
+        self._eval_clients = eval_clients or clients
         self._admin_clients = admin_clients
         self._skip_model_check = skip_model_check
         self._idx_to_client = {client.client_idx: client for client in clients}
         self._client_cycle = cycle(clients)
+        self._eval_cycle = cycle(self._eval_clients)
         self.model_name = None  # unused
 
     @property
@@ -79,8 +85,15 @@ class StaticInferencePool:
     def update_model_name(self, model_name: str) -> None:
         self.model_name = model_name
 
+    @property
+    def eval_clients(self) -> list[vf.ClientConfig]:
+        return self._eval_clients
+
     async def get_next_client(self) -> vf.ClientConfig:
         return next(self._client_cycle)
+
+    async def get_eval_client(self) -> vf.ClientConfig:
+        return next(self._eval_cycle)
 
     async def wait_for_ready(self, model_name: str, timeout: int = 1800) -> None:
         await check_health(self._admin_clients, timeout=timeout)
@@ -97,7 +110,10 @@ class StaticInferencePool:
 
 
 async def setup_inference_pool(
-    client_config: ClientConfig, model_name: str, client_type: str = "openai_chat_completions"
+    client_config: ClientConfig,
+    model_name: str,
+    client_type: str = "openai_chat_completions",
+    eval_client_type: str = "openai_chat_completions",
 ) -> InferencePool:
     """Create an inference pool from config (static or elastic)."""
     logger = get_logger()
@@ -105,7 +121,9 @@ async def setup_inference_pool(
     if client_config.is_elastic:
         from prime_rl.utils.elastic import ElasticInferencePool
 
-        return await ElasticInferencePool.from_config(client_config, model_name=model_name, client_type=client_type)
+        return await ElasticInferencePool.from_config(
+            client_config, model_name=model_name, client_type=client_type, eval_client_type=eval_client_type
+        )
 
     logger.info(
         f"Initializing static inference pool (base_url={', '.join(client_config.base_url)}, "
@@ -114,6 +132,7 @@ async def setup_inference_pool(
     )
     return StaticInferencePool(
         clients=setup_clients(client_config, client_type=client_type),
+        eval_clients=setup_clients(client_config, client_type=eval_client_type),
         admin_clients=setup_admin_clients(client_config),
         skip_model_check=client_config.skip_model_check,
     )

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -34,8 +34,8 @@ class InferencePool(Protocol):
         """Update the model name."""
         ...
 
-    async def get_next_client(self) -> vf.ClientConfig:
-        """Get next client in round-robin fashion."""
+    async def get_eval_client(self) -> vf.ClientConfig:
+        """Get next eval client in round-robin fashion."""
         ...
 
     async def wait_for_ready(self, model_name: str, timeout: int = 1800) -> None:
@@ -69,7 +69,6 @@ class StaticInferencePool:
         self._eval_clients = setup_clients(client_config, client_type=eval_client_type)
         self._admin_clients = setup_admin_clients(client_config)
         self._skip_model_check = client_config.skip_model_check
-        self._client_cycle = cycle(self._clients)
         self._eval_cycle = cycle(self._eval_clients)
         self.model_name = model_name
 
@@ -87,9 +86,6 @@ class StaticInferencePool:
     @property
     def eval_clients(self) -> list[vf.ClientConfig]:
         return self._eval_clients
-
-    async def get_next_client(self) -> vf.ClientConfig:
-        return next(self._client_cycle)
 
     async def get_eval_client(self) -> vf.ClientConfig:
         return next(self._eval_cycle)
@@ -119,8 +115,8 @@ async def setup_inference_pool(
 
     if train_client_type == "openai_chat_completions_token":
         logger.warning(
-            "Token-in-token-out (TITO) client is enabled for training. Only use"
-            "this if your environment has a linear history and the chat"
+            "Token-in-token-out (TITO) client is enabled for training. Only use "
+            "this if your environment has a linear history and the chat "
             "template has the extension property."
         )
 

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -119,8 +119,9 @@ async def setup_inference_pool(
 
     if train_client_type == "openai_chat_completions_token":
         logger.warning(
-            "Token-in-token-out (TITO) client is enabled. Only use this if your environment has a linear "
-            "history and the chat template has the extension property."
+            "Token-in-token-out (TITO) client is enabled for training. Only use"
+            "this if your environment has a linear history and the chat"
+            "template has the extension property."
         )
 
     if client_config.is_elastic:

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -21,7 +21,7 @@ class InferencePool(Protocol):
     """Protocol for inference pools (static or elastic)."""
 
     @property
-    def clients(self) -> list[vf.ClientConfig]:
+    def train_clients(self) -> list[vf.ClientConfig]:
         """Get inference clients."""
         ...
 
@@ -60,22 +60,21 @@ class StaticInferencePool:
 
     def __init__(
         self,
-        clients: list[vf.ClientConfig],
-        admin_clients: list[AsyncClient],
-        skip_model_check: bool = False,
-        eval_clients: list[vf.ClientConfig] | None = None,
+        client_config: ClientConfig,
+        model_name: str,
+        train_client_type: str = "openai_chat_completions",
+        eval_client_type: str = "openai_chat_completions",
     ):
-        self._clients = clients
-        self._eval_clients = eval_clients or clients
-        self._admin_clients = admin_clients
-        self._skip_model_check = skip_model_check
-        self._idx_to_client = {client.client_idx: client for client in clients}
-        self._client_cycle = cycle(clients)
+        self._clients = setup_clients(client_config, client_type=train_client_type)
+        self._eval_clients = setup_clients(client_config, client_type=eval_client_type)
+        self._admin_clients = setup_admin_clients(client_config)
+        self._skip_model_check = client_config.skip_model_check
+        self._client_cycle = cycle(self._clients)
         self._eval_cycle = cycle(self._eval_clients)
-        self.model_name = None  # unused
+        self.model_name = model_name
 
     @property
-    def clients(self) -> list[vf.ClientConfig]:
+    def train_clients(self) -> list[vf.ClientConfig]:
         return self._clients
 
     @property
@@ -118,11 +117,17 @@ async def setup_inference_pool(
     """Create an inference pool from config (static or elastic)."""
     logger = get_logger()
 
+    if train_client_type == "openai_chat_completions_token":
+        logger.warning(
+            "Token-in-token-out (TITO) client is enabled. Only use this if your environment has a linear "
+            "history and the chat template has the extension property."
+        )
+
     if client_config.is_elastic:
         from prime_rl.utils.elastic import ElasticInferencePool
 
         return await ElasticInferencePool.from_config(
-            client_config, model_name=model_name, client_type=train_client_type, eval_client_type=eval_client_type
+            client_config, model_name=model_name, train_client_type=train_client_type, eval_client_type=eval_client_type
         )
 
     logger.info(
@@ -131,10 +136,7 @@ async def setup_inference_pool(
         f"api_key_var={client_config.api_key_var}, headers={client_config.headers})"
     )
     return StaticInferencePool(
-        clients=setup_clients(client_config, client_type=train_client_type),
-        eval_clients=setup_clients(client_config, client_type=eval_client_type),
-        admin_clients=setup_admin_clients(client_config),
-        skip_model_check=client_config.skip_model_check,
+        client_config, model_name=model_name, train_client_type=train_client_type, eval_client_type=eval_client_type
     )
 
 
@@ -149,7 +151,7 @@ def setup_clients(client_config: ClientConfig, client_type: str = "openai_chat_c
             clients.append(
                 vf.ClientConfig(
                     client_idx=client_idx,
-                    client_type=train_client_type,
+                    client_type=client_type,
                     api_base_url=base_url,
                     api_key_var=client_config.api_key_var,
                     timeout=client_config.timeout,

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -65,7 +65,7 @@ class StaticInferencePool:
         train_client_type: str = "openai_chat_completions",
         eval_client_type: str = "openai_chat_completions",
     ):
-        self._clients = setup_clients(client_config, client_type=train_client_type)
+        self._train_clients = setup_clients(client_config, client_type=train_client_type)
         self._eval_clients = setup_clients(client_config, client_type=eval_client_type)
         self._admin_clients = setup_admin_clients(client_config)
         self._skip_model_check = client_config.skip_model_check
@@ -74,7 +74,7 @@ class StaticInferencePool:
 
     @property
     def train_clients(self) -> list[vf.ClientConfig]:
-        return self._clients
+        return self._train_clients
 
     @property
     def admin_clients(self) -> list[AsyncClient]:

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -112,7 +112,7 @@ class StaticInferencePool:
 async def setup_inference_pool(
     client_config: ClientConfig,
     model_name: str,
-    client_type: str = "openai_chat_completions",
+    train_client_type: str = "openai_chat_completions",
     eval_client_type: str = "openai_chat_completions",
 ) -> InferencePool:
     """Create an inference pool from config (static or elastic)."""
@@ -122,7 +122,7 @@ async def setup_inference_pool(
         from prime_rl.utils.elastic import ElasticInferencePool
 
         return await ElasticInferencePool.from_config(
-            client_config, model_name=model_name, client_type=client_type, eval_client_type=eval_client_type
+            client_config, model_name=model_name, client_type=train_client_type, eval_client_type=eval_client_type
         )
 
     logger.info(
@@ -131,7 +131,7 @@ async def setup_inference_pool(
         f"api_key_var={client_config.api_key_var}, headers={client_config.headers})"
     )
     return StaticInferencePool(
-        clients=setup_clients(client_config, client_type=client_type),
+        clients=setup_clients(client_config, client_type=train_client_type),
         eval_clients=setup_clients(client_config, client_type=eval_client_type),
         admin_clients=setup_admin_clients(client_config),
         skip_model_check=client_config.skip_model_check,
@@ -149,7 +149,7 @@ def setup_clients(client_config: ClientConfig, client_type: str = "openai_chat_c
             clients.append(
                 vf.ClientConfig(
                     client_idx=client_idx,
-                    client_type=client_type,
+                    client_type=train_client_type,
                     api_base_url=base_url,
                     api_key_var=client_config.api_key_var,
                     timeout=client_config.timeout,

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -62,7 +62,7 @@ class StaticInferencePool:
         self,
         client_config: ClientConfig,
         model_name: str,
-        train_client_type: str = "openai_chat_completions",
+        train_client_type: str = "openai_chat_completions_token",
         eval_client_type: str = "openai_chat_completions",
     ):
         self._train_clients = setup_clients(client_config, client_type=train_client_type)
@@ -107,7 +107,7 @@ class StaticInferencePool:
 async def setup_inference_pool(
     client_config: ClientConfig,
     model_name: str,
-    train_client_type: str = "openai_chat_completions",
+    train_client_type: str = "openai_chat_completions_token",
     eval_client_type: str = "openai_chat_completions",
 ) -> InferencePool:
     """Create an inference pool from config (static or elastic)."""

--- a/src/prime_rl/utils/elastic.py
+++ b/src/prime_rl/utils/elastic.py
@@ -108,6 +108,7 @@ class ElasticInferencePool:
         port: int = 8000,
         sync_interval: float = 5.0,
         client_type: str = "openai_chat_completions",
+        eval_client_type: str = "openai_chat_completions",
         router_url: str | None = None,
     ):
         self.logger = get_logger()
@@ -118,6 +119,7 @@ class ElasticInferencePool:
         self.port = port
         self.sync_interval = sync_interval
         self.client_type = client_type
+        self.eval_client_type = eval_client_type
         self.router_url = router_url
 
         self._servers: dict[str, ServerState] = {}
@@ -126,15 +128,21 @@ class ElasticInferencePool:
         self._desired: AdapterState = AdapterState()
 
         self._clients: list[vf.ClientConfig] = []
+        self._eval_clients: list[vf.ClientConfig] = []
         self._client_urls: list[str] = []
         self._client_index = 0
+        self._eval_index = 0
 
         self._sync_task: asyncio.Task | None = None
         self._started = False
 
     @classmethod
     async def from_config(
-        cls, config: ClientConfig, model_name: str, client_type: str = "openai_chat_completions"
+        cls,
+        config: ClientConfig,
+        model_name: str,
+        client_type: str = "openai_chat_completions",
+        eval_client_type: str = "openai_chat_completions",
     ) -> ElasticInferencePool:
         if config.elastic is None:
             raise ValueError("Elastic inference pool requires elastic config")
@@ -145,6 +153,7 @@ class ElasticInferencePool:
             port=config.elastic.port,
             sync_interval=config.elastic.sync_interval,
             client_type=client_type,
+            eval_client_type=eval_client_type,
             router_url=config.router_url,
         )
         await pool.start()
@@ -163,8 +172,8 @@ class ElasticInferencePool:
     def ready_urls(self) -> list[str]:
         return [self._build_inference_url(ip) for ip, s in self._servers.items() if s.status == "ready"]
 
-    @property
-    def clients(self) -> list[vf.ClientConfig]:
+    def _rebuild_clients(self) -> None:
+        """Rebuild inference clients when the set of ready URLs changes."""
         # When a router URL is configured, route inference requests through it
         # instead of directly to discovered pods. Admin operations still use
         # individual pod IPs via admin_clients.
@@ -177,22 +186,27 @@ class ElasticInferencePool:
         if set(urls) != set(self._client_urls):
             self._client_urls = urls
             self._client_index = 0
-            self._clients = (
-                setup_clients(
-                    ClientConfig(
-                        timeout=self.client_config.timeout,
-                        connect_timeout=self.client_config.connect_timeout,
-                        base_url=urls,
-                        api_key_var=self.client_config.api_key_var,
-                        headers=self.client_config.headers,
-                        dp_rank_count=self.client_config.dp_rank_count,
-                    ),
-                    client_type=self.client_type,
-                )
-                if urls
-                else []
+            self._eval_index = 0
+            url_config = ClientConfig(
+                timeout=self.client_config.timeout,
+                connect_timeout=self.client_config.connect_timeout,
+                base_url=urls,
+                api_key_var=self.client_config.api_key_var,
+                headers=self.client_config.headers,
+                dp_rank_count=self.client_config.dp_rank_count,
             )
+            self._clients = setup_clients(url_config, client_type=self.client_type) if urls else []
+            self._eval_clients = setup_clients(url_config, client_type=self.eval_client_type) if urls else []
+
+    @property
+    def clients(self) -> list[vf.ClientConfig]:
+        self._rebuild_clients()
         return self._clients
+
+    @property
+    def eval_clients(self) -> list[vf.ClientConfig]:
+        self._rebuild_clients()
+        return self._eval_clients
 
     @property
     def has_clients(self) -> bool:
@@ -204,6 +218,14 @@ class ElasticInferencePool:
             await asyncio.sleep(self.sync_interval)
         client = self._clients[self._client_index % len(self._clients)]
         self._client_index += 1
+        return client
+
+    async def get_eval_client(self) -> vf.ClientConfig:
+        """Get next eval client in round-robin fashion."""
+        while not self.has_clients:
+            await asyncio.sleep(self.sync_interval)
+        client = self._eval_clients[self._eval_index % len(self._eval_clients)]
+        self._eval_index += 1
         return client
 
     @property

--- a/src/prime_rl/utils/elastic.py
+++ b/src/prime_rl/utils/elastic.py
@@ -197,10 +197,6 @@ class ElasticInferencePool:
         self._rebuild_clients()
         return self._eval_clients
 
-    @property
-    def has_clients(self) -> bool:
-        return len(self.train_clients) > 0
-
     async def get_eval_client(self) -> vf.ClientConfig:
         """Get next eval client in round-robin fashion."""
         while not self.eval_clients:

--- a/src/prime_rl/utils/elastic.py
+++ b/src/prime_rl/utils/elastic.py
@@ -123,7 +123,7 @@ class ElasticInferencePool:
         self._lock = asyncio.Lock()
         self._desired: AdapterState = AdapterState()
 
-        self._clients: list[vf.ClientConfig] = []
+        self._train_clients: list[vf.ClientConfig] = []
         self._eval_clients: list[vf.ClientConfig] = []
         self._client_urls: list[str] = []
 
@@ -184,13 +184,13 @@ class ElasticInferencePool:
                 headers=self.client_config.headers,
                 dp_rank_count=self.client_config.dp_rank_count,
             )
-            self._clients = setup_clients(url_config, client_type=self.train_client_type) if urls else []
+            self._train_clients = setup_clients(url_config, client_type=self.train_client_type) if urls else []
             self._eval_clients = setup_clients(url_config, client_type=self.eval_client_type) if urls else []
 
     @property
     def train_clients(self) -> list[vf.ClientConfig]:
         self._rebuild_clients()
-        return self._clients
+        return self._train_clients
 
     @property
     def eval_clients(self) -> list[vf.ClientConfig]:
@@ -442,7 +442,7 @@ class ElasticInferencePool:
         for ip in list(self._servers.keys()):
             await self._remove_server(ip)
 
-        self._clients = []
+        self._train_clients = []
         self._client_urls = []
         self._started = False
 

--- a/src/prime_rl/utils/elastic.py
+++ b/src/prime_rl/utils/elastic.py
@@ -443,6 +443,7 @@ class ElasticInferencePool:
             await self._remove_server(ip)
 
         self._train_clients = []
+        self._eval_clients = []
         self._client_urls = []
         self._started = False
 

--- a/src/prime_rl/utils/elastic.py
+++ b/src/prime_rl/utils/elastic.py
@@ -102,25 +102,21 @@ class ElasticInferencePool:
 
     def __init__(
         self,
-        hostname: str,
         client_config: ClientConfig,
         model_name: str,
-        port: int = 8000,
-        sync_interval: float = 5.0,
         train_client_type: str = "openai_chat_completions",
         eval_client_type: str = "openai_chat_completions",
-        router_url: str | None = None,
     ):
         self.logger = get_logger()
-        self.hostname = hostname
         self.client_config = client_config
         self.model_name = model_name
         self.base_model_name = model_name  # Keep original for health checks
-        self.port = port
-        self.sync_interval = sync_interval
+        self.hostname = client_config.elastic.hostname
+        self.port = client_config.elastic.port
+        self.sync_interval = client_config.elastic.sync_interval
         self.train_client_type = train_client_type
         self.eval_client_type = eval_client_type
-        self.router_url = router_url
+        self.router_url = client_config.router_url
 
         self._servers: dict[str, ServerState] = {}
         self._admin_clients: dict[str, AsyncClient] = {}
@@ -139,22 +135,15 @@ class ElasticInferencePool:
     @classmethod
     async def from_config(
         cls,
-        config: ClientConfig,
+        client_config: ClientConfig,
         model_name: str,
         train_client_type: str = "openai_chat_completions",
         eval_client_type: str = "openai_chat_completions",
     ) -> ElasticInferencePool:
-        if config.elastic is None:
+        if client_config.elastic is None:
             raise ValueError("Elastic inference pool requires elastic config")
         pool = cls(
-            hostname=config.elastic.hostname,
-            client_config=config,
-            model_name=model_name,
-            port=config.elastic.port,
-            sync_interval=config.elastic.sync_interval,
-            train_client_type=train_client_type,
-            eval_client_type=eval_client_type,
-            router_url=config.router_url,
+            client_config, model_name=model_name, train_client_type=train_client_type, eval_client_type=eval_client_type
         )
         await pool.start()
         return pool
@@ -199,7 +188,7 @@ class ElasticInferencePool:
             self._eval_clients = setup_clients(url_config, client_type=self.eval_client_type) if urls else []
 
     @property
-    def clients(self) -> list[vf.ClientConfig]:
+    def train_clients(self) -> list[vf.ClientConfig]:
         self._rebuild_clients()
         return self._clients
 
@@ -210,7 +199,7 @@ class ElasticInferencePool:
 
     @property
     def has_clients(self) -> bool:
-        return len(self.clients) > 0
+        return len(self.train_clients) > 0
 
     async def get_next_client(self) -> vf.ClientConfig:
         """Get next client in round-robin fashion."""

--- a/src/prime_rl/utils/elastic.py
+++ b/src/prime_rl/utils/elastic.py
@@ -107,7 +107,7 @@ class ElasticInferencePool:
         model_name: str,
         port: int = 8000,
         sync_interval: float = 5.0,
-        client_type: str = "openai_chat_completions",
+        train_client_type: str = "openai_chat_completions",
         eval_client_type: str = "openai_chat_completions",
         router_url: str | None = None,
     ):
@@ -118,7 +118,7 @@ class ElasticInferencePool:
         self.base_model_name = model_name  # Keep original for health checks
         self.port = port
         self.sync_interval = sync_interval
-        self.client_type = client_type
+        self.train_client_type = train_client_type
         self.eval_client_type = eval_client_type
         self.router_url = router_url
 
@@ -141,7 +141,7 @@ class ElasticInferencePool:
         cls,
         config: ClientConfig,
         model_name: str,
-        client_type: str = "openai_chat_completions",
+        train_client_type: str = "openai_chat_completions",
         eval_client_type: str = "openai_chat_completions",
     ) -> ElasticInferencePool:
         if config.elastic is None:
@@ -152,7 +152,7 @@ class ElasticInferencePool:
             model_name=model_name,
             port=config.elastic.port,
             sync_interval=config.elastic.sync_interval,
-            client_type=client_type,
+            train_client_type=train_client_type,
             eval_client_type=eval_client_type,
             router_url=config.router_url,
         )
@@ -195,7 +195,7 @@ class ElasticInferencePool:
                 headers=self.client_config.headers,
                 dp_rank_count=self.client_config.dp_rank_count,
             )
-            self._clients = setup_clients(url_config, client_type=self.client_type) if urls else []
+            self._clients = setup_clients(url_config, client_type=self.train_client_type) if urls else []
             self._eval_clients = setup_clients(url_config, client_type=self.eval_client_type) if urls else []
 
     @property

--- a/src/prime_rl/utils/elastic.py
+++ b/src/prime_rl/utils/elastic.py
@@ -126,7 +126,7 @@ class ElasticInferencePool:
         self._clients: list[vf.ClientConfig] = []
         self._eval_clients: list[vf.ClientConfig] = []
         self._client_urls: list[str] = []
-        self._client_index = 0
+
         self._eval_index = 0
 
         self._sync_task: asyncio.Task | None = None
@@ -174,7 +174,7 @@ class ElasticInferencePool:
             urls = self.ready_urls
         if set(urls) != set(self._client_urls):
             self._client_urls = urls
-            self._client_index = 0
+
             self._eval_index = 0
             url_config = ClientConfig(
                 timeout=self.client_config.timeout,
@@ -200,14 +200,6 @@ class ElasticInferencePool:
     @property
     def has_clients(self) -> bool:
         return len(self.train_clients) > 0
-
-    async def get_next_client(self) -> vf.ClientConfig:
-        """Get next client in round-robin fashion."""
-        while not self.has_clients:
-            await asyncio.sleep(self.sync_interval)
-        client = self._clients[self._client_index % len(self._clients)]
-        self._client_index += 1
-        return client
 
     async def get_eval_client(self) -> vf.ClientConfig:
         """Get next eval client in round-robin fashion."""

--- a/src/prime_rl/utils/elastic.py
+++ b/src/prime_rl/utils/elastic.py
@@ -104,7 +104,7 @@ class ElasticInferencePool:
         self,
         client_config: ClientConfig,
         model_name: str,
-        train_client_type: str = "openai_chat_completions",
+        train_client_type: str = "openai_chat_completions_token",
         eval_client_type: str = "openai_chat_completions",
     ):
         self.logger = get_logger()
@@ -137,7 +137,7 @@ class ElasticInferencePool:
         cls,
         client_config: ClientConfig,
         model_name: str,
-        train_client_type: str = "openai_chat_completions",
+        train_client_type: str = "openai_chat_completions_token",
         eval_client_type: str = "openai_chat_completions",
     ) -> ElasticInferencePool:
         if client_config.elastic is None:

--- a/src/prime_rl/utils/elastic.py
+++ b/src/prime_rl/utils/elastic.py
@@ -203,7 +203,7 @@ class ElasticInferencePool:
 
     async def get_eval_client(self) -> vf.ClientConfig:
         """Get next eval client in round-robin fashion."""
-        while not self.has_clients:
+        while not self.eval_clients:
             await asyncio.sleep(self.sync_interval)
         client = self._eval_clients[self._eval_index % len(self._eval_clients)]
         self._eval_index += 1

--- a/tests/unit/utils/test_elastic.py
+++ b/tests/unit/utils/test_elastic.py
@@ -185,12 +185,12 @@ def test_adapter_state_creation():
 
 def test_adapter_matches_when_no_adapter_desired():
     with patch("prime_rl.utils.elastic.get_logger"):
-        pool = ElasticInferencePool(
-            hostname="test.hostname",
-            client_config=MagicMock(),
-            model_name="base-model",
-            port=8000,
-        )
+        mock_config = MagicMock()
+        mock_config.elastic.hostname = "test.hostname"
+        mock_config.elastic.port = 8000
+        mock_config.elastic.sync_interval = 5.0
+        mock_config.router_url = None
+        pool = ElasticInferencePool(client_config=mock_config, model_name="base-model")
         # No adapter desired (base model inference)
         assert pool._adapter_matches_desired(None) is True
         assert pool._adapter_matches_desired(AdapterState("x", Path("/x"), 0)) is True
@@ -198,12 +198,12 @@ def test_adapter_matches_when_no_adapter_desired():
 
 def test_adapter_matches_by_path():
     with patch("prime_rl.utils.elastic.get_logger"):
-        pool = ElasticInferencePool(
-            hostname="test.hostname",
-            client_config=MagicMock(),
-            model_name="base-model",
-            port=8000,
-        )
+        mock_config = MagicMock()
+        mock_config.elastic.hostname = "test.hostname"
+        mock_config.elastic.port = 8000
+        mock_config.elastic.sync_interval = 5.0
+        mock_config.router_url = None
+        pool = ElasticInferencePool(client_config=mock_config, model_name="base-model")
         pool._desired.path = Path("/weights/step_100")
         pool._desired.step = 100
 
@@ -216,12 +216,12 @@ def test_adapter_matches_by_path():
 
 def test_adapter_matches_by_step_when_nonzero():
     with patch("prime_rl.utils.elastic.get_logger"):
-        pool = ElasticInferencePool(
-            hostname="test.hostname",
-            client_config=MagicMock(),
-            model_name="base-model",
-            port=8000,
-        )
+        mock_config = MagicMock()
+        mock_config.elastic.hostname = "test.hostname"
+        mock_config.elastic.port = 8000
+        mock_config.elastic.sync_interval = 5.0
+        mock_config.router_url = None
+        pool = ElasticInferencePool(client_config=mock_config, model_name="base-model")
         pool._desired.path = Path("/weights/step_100")
         pool._desired.step = 100
 
@@ -232,12 +232,12 @@ def test_adapter_matches_by_step_when_nonzero():
 
 def test_adapter_does_not_match_by_zero_step():
     with patch("prime_rl.utils.elastic.get_logger"):
-        pool = ElasticInferencePool(
-            hostname="test.hostname",
-            client_config=MagicMock(),
-            model_name="base-model",
-            port=8000,
-        )
+        mock_config = MagicMock()
+        mock_config.elastic.hostname = "test.hostname"
+        mock_config.elastic.port = 8000
+        mock_config.elastic.sync_interval = 5.0
+        mock_config.router_url = None
+        pool = ElasticInferencePool(client_config=mock_config, model_name="base-model")
         pool._desired.path = Path("/weights/step_0")
         pool._desired.step = 0
 
@@ -248,12 +248,12 @@ def test_adapter_does_not_match_by_zero_step():
 
 def test_adapter_returns_false_when_no_adapter_loaded():
     with patch("prime_rl.utils.elastic.get_logger"):
-        pool = ElasticInferencePool(
-            hostname="test.hostname",
-            client_config=MagicMock(),
-            model_name="base-model",
-            port=8000,
-        )
+        mock_config = MagicMock()
+        mock_config.elastic.hostname = "test.hostname"
+        mock_config.elastic.port = 8000
+        mock_config.elastic.sync_interval = 5.0
+        mock_config.router_url = None
+        pool = ElasticInferencePool(client_config=mock_config, model_name="base-model")
         pool._desired.path = Path("/weights/step_100")
         pool._desired.step = 100
 
@@ -266,12 +266,12 @@ def test_adapter_returns_false_when_no_adapter_loaded():
 def test_get_loaded_adapter_finds_correct_adapter_when_multiple_loaded():
     """Test that _get_loaded_adapter returns the adapter matching desired name, not the first one."""
     with patch("prime_rl.utils.elastic.get_logger"):
-        pool = ElasticInferencePool(
-            hostname="test.hostname",
-            client_config=MagicMock(),
-            model_name="base-model",
-            port=8000,
-        )
+        mock_config = MagicMock()
+        mock_config.elastic.hostname = "test.hostname"
+        mock_config.elastic.port = 8000
+        mock_config.elastic.sync_interval = 5.0
+        mock_config.router_url = None
+        pool = ElasticInferencePool(client_config=mock_config, model_name="base-model")
 
         # Set the desired adapter name
         pool._desired.name = "rft-target-run"
@@ -317,12 +317,12 @@ def test_get_loaded_adapter_finds_correct_adapter_when_multiple_loaded():
 def test_get_loaded_adapter_returns_none_when_desired_adapter_not_found():
     """Test that _get_loaded_adapter returns None when desired adapter is not in the list."""
     with patch("prime_rl.utils.elastic.get_logger"):
-        pool = ElasticInferencePool(
-            hostname="test.hostname",
-            client_config=MagicMock(),
-            model_name="base-model",
-            port=8000,
-        )
+        mock_config = MagicMock()
+        mock_config.elastic.hostname = "test.hostname"
+        mock_config.elastic.port = 8000
+        mock_config.elastic.sync_interval = 5.0
+        mock_config.router_url = None
+        pool = ElasticInferencePool(client_config=mock_config, model_name="base-model")
 
         pool._desired.name = "rft-missing-run"
         pool._desired.path = Path("/data/outputs/missing_run/broadcasts/step_5")
@@ -348,12 +348,12 @@ def test_get_loaded_adapter_returns_none_when_desired_adapter_not_found():
 def test_get_loaded_adapter_parses_step_from_path():
     """Test that _get_loaded_adapter correctly parses step number from path."""
     with patch("prime_rl.utils.elastic.get_logger"):
-        pool = ElasticInferencePool(
-            hostname="test.hostname",
-            client_config=MagicMock(),
-            model_name="base-model",
-            port=8000,
-        )
+        mock_config = MagicMock()
+        mock_config.elastic.hostname = "test.hostname"
+        mock_config.elastic.port = 8000
+        mock_config.elastic.sync_interval = 5.0
+        mock_config.router_url = None
+        pool = ElasticInferencePool(client_config=mock_config, model_name="base-model")
 
         pool._desired.name = "my-lora"
 
@@ -377,12 +377,12 @@ def test_get_loaded_adapter_parses_step_from_path():
 def test_get_loaded_adapter_handles_step_dash_format():
     """Test that _get_loaded_adapter parses step-N format (with dash)."""
     with patch("prime_rl.utils.elastic.get_logger"):
-        pool = ElasticInferencePool(
-            hostname="test.hostname",
-            client_config=MagicMock(),
-            model_name="base-model",
-            port=8000,
-        )
+        mock_config = MagicMock()
+        mock_config.elastic.hostname = "test.hostname"
+        mock_config.elastic.port = 8000
+        mock_config.elastic.sync_interval = 5.0
+        mock_config.router_url = None
+        pool = ElasticInferencePool(client_config=mock_config, model_name="base-model")
 
         pool._desired.name = "my-lora"
 


### PR DESCRIPTION
## Summary
- Adds separate eval client type (`openai_chat_completions`) while training defaults to `openai_chat_completions_token` (TITO)
- Adds `eval_clients` property and `get_eval_client()` to both pool classes; removes `get_next_client()`
- Renames `clients` → `train_clients` and `client_type` → `train_client_type` for clarity
- Aligns `StaticInferencePool` and `ElasticInferencePool` constructors to the same signature: `(client_config, model_name, train_client_type, eval_client_type)`
- Moves TITO warning into `setup_inference_pool`
- Adds eval config to `configs/alphabet_sort/rl.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core orchestration/inference routing by separating eval vs training client selection; misconfiguration could send requests to the wrong client type or degrade rollout/eval throughput.
> 
> **Overview**
> **Separates eval inference traffic from training traffic.** `setup_inference_pool` now accepts `train_client_type` (defaults to TITO) and `eval_client_type` (defaults to non-token chat completions), with pools exposing `train_clients` plus `get_eval_client()` for eval round-robin selection.
> 
> `orchestrator` and `scheduler` are updated to route training load-balancing/teacher-logprob computation through `train_clients`, while evals call `get_eval_client()` (and the prior `clients`/`get_next_client()` API is removed/renamed). Adds an `orchestrator.eval` block to `configs/alphabet_sort/rl.toml` to run periodic evals (interval 50) with a smaller rollout budget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2c4aa7e42c456742e31c2858226f60b17e00776. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->