### PR TITLE
feat: save train and eval rollouts in verifiers format

### DIFF
--- a/skills/monitor-run/SKILL.md
+++ b/skills/monitor-run/SKILL.md
@@ -195,6 +195,31 @@ Key vLLM metrics to watch:
 - `vllm:num_requests_waiting` — requests queued waiting for KV cache space
 - `vllm:gpu_cache_usage_perc` — KV cache pressure (approaching 1.0 = requests will queue)
 
+### Rollouts
+
+Plain-text rollouts (verifiers JSONL format) are saved every step alongside the binary training batch:
+
+```
+{output_dir}/rollouts/
+└── step_{N}/
+    ├── train_rollouts.jsonl   # all training rollouts for this step
+    ├── eval_rollouts.jsonl    # all eval rollouts (only present when eval ran at this step)
+    └── train_rollouts.bin     # binary-encoded training batch (consumed by the trainer)
+```
+
+Each line in the `.jsonl` files is a JSON-serialized `vf.RolloutOutput` dict with fields like `example_id`, `task`, `prompt`, `completion`, `reward`, `trajectory`, `metrics`, etc. To inspect rollouts for a given step:
+
+```bash
+# Count rollouts at a step
+wc -l {output_dir}/rollouts/step_42/train_rollouts.jsonl
+
+# Preview first rollout (pretty-printed)
+head -1 {output_dir}/rollouts/step_42/train_rollouts.jsonl | python -m json.tool
+
+# Extract rewards
+jq '.reward' {output_dir}/rollouts/step_42/train_rollouts.jsonl
+```
+
 ### Errors and warnings
 
 As part of every check-in, grep all logs for `WARNING` and `ERROR` level messages. Pay special attention to env server and env worker logs — these are the most common source of issues since they run user-provided code.

--- a/skills/monitor-run/SKILL.md
+++ b/skills/monitor-run/SKILL.md
@@ -197,13 +197,13 @@ Key vLLM metrics to watch:
 
 ### Rollouts
 
-Plain-text rollouts (verifiers JSONL format) are saved every step alongside the binary training batch:
+Plain-text rollouts (`verifiers` format) are saved every step alongside the binary training batch inside the run directory. For single-run (local) runs this is typically `{output_dir}/run_default`.
 
 ```
-{output_dir}/rollouts/
+{output_dir}/{run_dir}/rollouts/
 └── step_{N}/
-    ├── train_rollouts.jsonl   # all training rollouts for this step
-    ├── eval_rollouts.jsonl    # all eval rollouts (only present when eval ran at this step)
+    ├── train_rollouts.jsonl   # all train rollouts
+    ├── eval_rollouts.jsonl    # all eval rollouts (only present when eval ran)
     └── train_rollouts.bin     # binary-encoded training batch (consumed by the trainer)
 ```
 
@@ -211,13 +211,13 @@ Each line in the `.jsonl` files is a JSON-serialized `vf.RolloutOutput` dict wit
 
 ```bash
 # Count rollouts at a step
-wc -l {output_dir}/rollouts/step_42/train_rollouts.jsonl
+wc -l {output_dir}/{run_dir}/rollouts/step_42/train_rollouts.jsonl
 
 # Preview first rollout (pretty-printed)
-head -1 {output_dir}/rollouts/step_42/train_rollouts.jsonl | python -m json.tool
+head -1 {output_dir}/{run_dir}/rollouts/step_42/train_rollouts.jsonl | python -m json.tool
 
 # Extract rewards
-jq '.reward' {output_dir}/rollouts/step_42/train_rollouts.jsonl
+jq '.reward' {output_dir}/{run_dir}/rollouts/step_42/train_rollouts.jsonl
 ```
 
 ### Errors and warnings

--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -171,7 +171,7 @@ class EvalEnv(Env):
         get_client: Callable[[], Awaitable[vf.ClientConfig]],
         ckpt_step: int,
         step: int,
-    ) -> None:
+    ) -> list[vf.RolloutOutput]:
         num_examples = len(self.examples)
         rollouts_per_example = self.config.rollouts_per_example
         get_logger().info(f"Evaluating {self.name} ({num_examples=}, {rollouts_per_example=})")
@@ -240,7 +240,7 @@ class EvalEnv(Env):
                 },
                 step=step,
             )
-            return
+            return []
 
         # Log metrics
         monitor = get_monitor()
@@ -303,6 +303,8 @@ class EvalEnv(Env):
         eval_metrics.update({"progress/ckpt_step": ckpt_step, "step": step})
         monitor.log(eval_metrics, step=step)
         monitor.log_eval_samples(successful_outputs, env_name=self.name, step=step)
+
+        return successful_outputs
 
 
 EnvT = TypeVar("EnvT", bound=Env)

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -388,11 +388,13 @@ async def orchestrate(config: OrchestratorConfig):
                 ]
             )
 
-            # Save eval rollouts to disk
+            # Save eval rollouts to disk (in background thread to avoid blocking the event loop)
             eval_rollouts = [o for outputs in eval_results for o in outputs]
             if eval_rollouts:
                 step_path = get_step_path(get_rollout_dir(config.output_dir), progress.step)
-                save_rollouts(eval_rollouts, step_path / "eval_rollouts.jsonl")
+                asyncio.get_event_loop().run_in_executor(
+                    rollout_executor, save_rollouts, eval_rollouts, step_path / "eval_rollouts.jsonl"
+                )
 
             # Resume weight updates
             scheduler.checkpoint_ready.set()
@@ -408,9 +410,11 @@ async def orchestrate(config: OrchestratorConfig):
         generate_completions_time = scheduler.last_batch_generation_time
         train_rollouts = train_task.result()
 
-        # Save train rollouts to disk
+        # Save train rollouts to disk (in background thread to avoid blocking the event loop)
         step_path = get_step_path(get_rollout_dir(config.output_dir), progress.step)
-        save_rollouts(train_rollouts, step_path / "train_rollouts.jsonl")
+        asyncio.get_event_loop().run_in_executor(
+            rollout_executor, save_rollouts, train_rollouts, step_path / "train_rollouts.jsonl"
+        )
 
         # VLM: offload base64 images to disk immediately to free memory
         if is_vlm:

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -704,7 +704,7 @@ async def orchestrate(config: OrchestratorConfig):
 
     if config.eval and eval_envs is not None:
         logger.info("Running final evals")
-        await asyncio.gather(
+        eval_results = await asyncio.gather(
             *[
                 eval_env.evaluate(
                     model_name=scheduler.model_name,
@@ -715,6 +715,12 @@ async def orchestrate(config: OrchestratorConfig):
                 for eval_env in eval_envs
             ]
         )
+
+        # Save final eval rollouts to disk
+        eval_rollouts = [o for outputs in eval_results for o in outputs]
+        if eval_rollouts:
+            step_path = get_step_path(get_rollout_dir(config.output_dir), progress.step)
+            asyncio.create_task(asyncio.to_thread(save_rollouts, eval_rollouts, step_path / "eval_rollouts.jsonl"))
 
     # Log final (immutable) samples and distributions to monitor(s)
     monitor.log_final_samples()

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -310,8 +310,8 @@ async def orchestrate(config: OrchestratorConfig):
     logger.info(f"Starting orchestrator loop (max_steps={config.max_steps or 'infinite'})")
     is_first_step = True
 
-    # Persistent ThreadPoolExecutor for parallel rollout processing
-    rollout_executor = ThreadPoolExecutor(max_workers=64)
+    # Scale the default thread pool so asyncio.to_thread can handle parallel rollout processing
+    asyncio.get_event_loop().set_default_executor(ThreadPoolExecutor(max_workers=64))
 
     while True:
         # Check if this run has been evicted by the trainer
@@ -388,13 +388,11 @@ async def orchestrate(config: OrchestratorConfig):
                 ]
             )
 
-            # Save eval rollouts to disk (in background thread to avoid blocking the event loop)
+            # Save eval rollouts to disk (fire-and-forget background thread)
             eval_rollouts = [o for outputs in eval_results for o in outputs]
             if eval_rollouts:
                 step_path = get_step_path(get_rollout_dir(config.output_dir), progress.step)
-                asyncio.get_event_loop().run_in_executor(
-                    rollout_executor, save_rollouts, eval_rollouts, step_path / "eval_rollouts.jsonl"
-                )
+                asyncio.create_task(asyncio.to_thread(save_rollouts, eval_rollouts, step_path / "eval_rollouts.jsonl"))
 
             # Resume weight updates
             scheduler.checkpoint_ready.set()
@@ -410,11 +408,9 @@ async def orchestrate(config: OrchestratorConfig):
         generate_completions_time = scheduler.last_batch_generation_time
         train_rollouts = train_task.result()
 
-        # Save train rollouts to disk (in background thread to avoid blocking the event loop)
+        # Save train rollouts to disk (fire-and-forget background thread)
         step_path = get_step_path(get_rollout_dir(config.output_dir), progress.step)
-        asyncio.get_event_loop().run_in_executor(
-            rollout_executor, save_rollouts, train_rollouts, step_path / "train_rollouts.jsonl"
-        )
+        asyncio.create_task(asyncio.to_thread(save_rollouts, train_rollouts, step_path / "train_rollouts.jsonl"))
 
         # VLM: offload base64 images to disk immediately to free memory
         if is_vlm:
@@ -452,9 +448,7 @@ async def orchestrate(config: OrchestratorConfig):
         # This lets the scheduler continue servicing inflight rollout requests
         # and — with max_async_level >= 2 — overlap with the next batch's inference.
         if is_vlm:
-            vlm_cache = await asyncio.get_event_loop().run_in_executor(
-                rollout_executor, build_vlm_image_cache, train_rollouts, processor
-            )
+            vlm_cache = await asyncio.to_thread(build_vlm_image_cache, train_rollouts, processor)
             logger.info(
                 f"VLM timing: extract={vlm_cache.extract_time:.2f}s, preprocess={vlm_cache.preprocess_time:.2f}s "
                 f"({vlm_cache.num_unique_images} unique images from {vlm_cache.num_unique_examples} examples)"
@@ -466,12 +460,9 @@ async def orchestrate(config: OrchestratorConfig):
         def process_rollout(rollout: vf.RolloutOutput, rollout_idx: int) -> list[TrainingSample] | None:
             return interleave_rollout(rollout, vlm_cache=vlm_cache, cache_key=rollout_idx)
 
-        loop = asyncio.get_event_loop()
-        futures = [
-            loop.run_in_executor(rollout_executor, process_rollout, r, rollout_idx)
-            for rollout_idx, r in enumerate(train_rollouts)
-        ]
-        results = await asyncio.gather(*futures)
+        results = await asyncio.gather(
+            *(asyncio.to_thread(process_rollout, r, rollout_idx) for rollout_idx, r in enumerate(train_rollouts))
+        )
 
         # Collect results and assign advantages
         train_examples: list[TrainingSample] = []
@@ -745,7 +736,6 @@ async def orchestrate(config: OrchestratorConfig):
     # failure mode we're guarding against.
     async def _graceful_shutdown() -> None:
         training_batch_sender.close()
-        rollout_executor.shutdown(wait=False)
         await scheduler.stop()
         await inference_pool.stop()
         if teacher_inference_pool is not None:

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -17,7 +17,7 @@ from prime_rl.orchestrator.trajectories import (
     pretokenize_rollout_trajectory,
 )
 from prime_rl.transport import TrainingBatch, TrainingSample, setup_training_batch_sender
-from prime_rl.utils.pathing import get_log_dir
+from prime_rl.utils.pathing import get_log_dir, get_rollout_dir, get_step_path
 from prime_rl.utils.usage_reporter import UsageReporter
 
 # This monkey patch is necessary to avoid Pydantic validating fields using typing.Iterable (e.g. in multimodal or tool call messages) lazily which leads to tokenization errors, for more info see https://github.com/PrimeIntellect-ai/prime-rl/pull/1249
@@ -49,6 +49,7 @@ from prime_rl.orchestrator.vf_utils import (
     get_completion_len,
     get_seq_len,
     intercept_vf_logging,
+    save_rollouts,
 )
 from prime_rl.utils.client import (
     init_nccl_broadcast,
@@ -375,7 +376,7 @@ async def orchestrate(config: OrchestratorConfig):
                 logger.info("Cancelling in-flight training rollouts before starting evals to avoid congestion.")
                 await scheduler.cancel_inflight_rollouts()
 
-            await asyncio.gather(
+            eval_results = await asyncio.gather(
                 *[
                     eval_env.evaluate(
                         model_name=scheduler.model_name,
@@ -386,6 +387,12 @@ async def orchestrate(config: OrchestratorConfig):
                     for eval_env in envs_to_eval
                 ]
             )
+
+            # Save eval rollouts to disk
+            eval_rollouts = [o for outputs in eval_results for o in outputs]
+            if eval_rollouts:
+                step_path = get_step_path(get_rollout_dir(config.output_dir), progress.step)
+                save_rollouts(eval_rollouts, step_path / "eval_rollouts.jsonl")
 
             # Resume weight updates
             scheduler.checkpoint_ready.set()
@@ -400,6 +407,10 @@ async def orchestrate(config: OrchestratorConfig):
         await train_task
         generate_completions_time = scheduler.last_batch_generation_time
         train_rollouts = train_task.result()
+
+        # Save train rollouts to disk
+        step_path = get_step_path(get_rollout_dir(config.output_dir), progress.step)
+        save_rollouts(train_rollouts, step_path / "train_rollouts.jsonl")
 
         # VLM: offload base64 images to disk immediately to free memory
         if is_vlm:

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -2,7 +2,6 @@ import asyncio
 import gc
 import os
 import time
-from concurrent.futures import ThreadPoolExecutor
 
 import tomli_w
 
@@ -43,6 +42,7 @@ from prime_rl.orchestrator.utils import (
     compute_teacher_logprobs,
     get_weight_dir,
     print_benchmark,
+    set_default_executor,
     setup_external_rollout_model,
 )
 from prime_rl.orchestrator.vf_utils import (
@@ -85,6 +85,7 @@ async def orchestrate(config: OrchestratorConfig):
     )
     intercept_vf_logging(logger="verifiers.serve", level="WARN")  # show logs from env clients
     logger.info("Starting orchestrator")
+    set_default_executor()
 
     event_loop_lag_monitor = EventLoopLagMonitor()
     event_loop_lag_monitor_task = asyncio.create_task(event_loop_lag_monitor.run())
@@ -309,9 +310,6 @@ async def orchestrate(config: OrchestratorConfig):
     # Iterate over dataset in batches
     logger.info(f"Starting orchestrator loop (max_steps={config.max_steps or 'infinite'})")
     is_first_step = True
-
-    # Scale the default thread pool so asyncio.to_thread can handle parallel rollout processing
-    asyncio.get_event_loop().set_default_executor(ThreadPoolExecutor(max_workers=64))
 
     while True:
         # Check if this run has been evicted by the trainer

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -720,7 +720,7 @@ async def orchestrate(config: OrchestratorConfig):
         eval_rollouts = [o for outputs in eval_results for o in outputs]
         if eval_rollouts:
             step_path = get_step_path(get_rollout_dir(config.output_dir), progress.step)
-            asyncio.create_task(asyncio.to_thread(save_rollouts, eval_rollouts, step_path / "eval_rollouts.jsonl"))
+            await asyncio.to_thread(save_rollouts, eval_rollouts, step_path / "eval_rollouts.jsonl")
 
     # Log final (immutable) samples and distributions to monitor(s)
     monitor.log_final_samples()

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -390,7 +390,7 @@ async def orchestrate(config: OrchestratorConfig):
             eval_rollouts = [o for outputs in eval_results for o in outputs]
             if eval_rollouts:
                 step_path = get_step_path(get_rollout_dir(config.output_dir), progress.step)
-                asyncio.create_task(asyncio.to_thread(save_rollouts, eval_rollouts, step_path / "eval_rollouts.jsonl"))
+                await asyncio.to_thread(save_rollouts, eval_rollouts, step_path / "eval_rollouts.jsonl")
 
             # Resume weight updates
             scheduler.checkpoint_ready.set()
@@ -408,7 +408,7 @@ async def orchestrate(config: OrchestratorConfig):
 
         # Save train rollouts to disk (fire-and-forget background thread)
         step_path = get_step_path(get_rollout_dir(config.output_dir), progress.step)
-        asyncio.create_task(asyncio.to_thread(save_rollouts, train_rollouts, step_path / "train_rollouts.jsonl"))
+        await asyncio.to_thread(save_rollouts, train_rollouts, step_path / "train_rollouts.jsonl")
 
         # VLM: offload base64 images to disk immediately to free memory
         if is_vlm:

--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import time
+from concurrent.futures import ThreadPoolExecutor
 from itertools import cycle
 from pathlib import Path
 from typing import Any
@@ -13,12 +14,19 @@ from verifiers.utils.client_utils import setup_openai_client
 
 from prime_rl.configs.orchestrator import OrchestratorConfig
 from prime_rl.transport import TrainingSample
+from prime_rl.utils.logger import get_logger
 from prime_rl.utils.utils import (
     format_time,
     get_broadcast_dir,
     get_ckpt_dir,
     get_step_path,
 )
+
+
+def set_default_executor(max_workers: int = 64) -> None:
+    """Scale the default asyncio thread pool so asyncio.to_thread has enough capacity."""
+    get_logger().info(f"Setting default executor to ThreadPoolExecutor(max_workers={max_workers})")
+    asyncio.get_event_loop().set_default_executor(ThreadPoolExecutor(max_workers=max_workers))
 
 
 def print_benchmark(history: dict[str, list[Any]]) -> None:

--- a/src/prime_rl/orchestrator/vf_utils.py
+++ b/src/prime_rl/orchestrator/vf_utils.py
@@ -1,6 +1,9 @@
+import json
 import logging
+from pathlib import Path
 
 import verifiers as vf
+from verifiers.utils.save_utils import make_serializable
 
 from prime_rl.utils.logger import InterceptHandler
 
@@ -45,6 +48,15 @@ def get_completion_len(output: vf.RolloutOutput) -> int:
     tokens.
     """
     return get_seq_len(output) - get_prompt_len(output)
+
+
+def save_rollouts(rollouts: list[vf.RolloutOutput], path: Path) -> None:
+    """Save rollouts to a JSONL file using verifiers serialization."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        for rollout in rollouts:
+            json.dump(rollout, f, default=make_serializable)
+            f.write("\n")
 
 
 def intercept_vf_logging(logger: str = "verifiers", level: str = "DEBUG", prefix: str | None = None):

--- a/src/prime_rl/transport/filesystem.py
+++ b/src/prime_rl/transport/filesystem.py
@@ -6,8 +6,8 @@ from prime_rl.transport.base import MicroBatchReceiver, MicroBatchSender, Traini
 from prime_rl.transport.types import MicroBatch, TrainingBatch
 from prime_rl.utils.pathing import get_rollout_dir, get_step_path, sync_wait_for_path
 
-BATCH_FILE_TMP_NAME = "rollouts.bin.tmp"
-BATCH_FILE_NAME = "rollouts.bin"
+BATCH_FILE_TMP_NAME = "train_rollouts.bin.tmp"
+BATCH_FILE_NAME = "train_rollouts.bin"
 LOG_FREQ_SECONDS = 10
 
 


### PR DESCRIPTION
## Summary
- Save train/eval rollouts as JSONL files using verifiers serialization (`make_serializable`) at every step to `{output_dir}/rollouts/step_{x}/`
- `train_rollouts.jsonl` saved after generating train rollouts, `eval_rollouts.jsonl` saved after eval completes
- Rename `rollouts.bin` → `train_rollouts.bin` for consistency
- `EvalEnv.evaluate()` now returns the successful outputs so the orchestrator can collect and persist them

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds per-step filesystem writes of potentially large rollout payloads and changes eval return values, which can affect orchestrator performance, disk usage, and downstream tooling expecting the old batch filename.
> 
> **Overview**
> **Adds per-step rollout persistence in verifiers format.** The orchestrator now writes `train_rollouts.jsonl` after batch generation and collects `EvalEnv.evaluate()` results to write `eval_rollouts.jsonl` for eval steps (and final eval), using `make_serializable`-based JSONL encoding.
> 
> **Updates runtime plumbing for this new artifact flow.** `EvalEnv.evaluate()` now returns successful rollouts (empty list on total failure), the filesystem transport renames `rollouts.bin` to `train_rollouts.bin`, and the orchestrator switches rollout-related background work to `asyncio.to_thread` with an enlarged default threadpool via `set_default_executor()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9eb6fa7f616565dc6346c6a3cc081cde50a2d2d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->