### PR TITLE
chore: add qwen3_vl_moe to VLM registry docs table

### DIFF
--- a/docs/multimodal.md
+++ b/docs/multimodal.md
@@ -11,6 +11,7 @@ The built-in registry supports these model families out of the box:
 | Model Family | model_type | Vision Encoder | Language Model |
 |-------------|------------|---------------|----------------|
 | Qwen3-VL | `qwen3_vl` | `model.visual` | `model.language_model` |
+| Qwen3-VL-MoE | `qwen3_vl_moe` | `model.visual` | `model.language_model` |
 | Qwen3.5 | `qwen3_5` | `model.visual` | `model.language_model` |
 | Qwen3.5-MoE | `qwen3_5_moe` | `model.visual` | `model.language_model` |
 


### PR DESCRIPTION
## Summary

- Adds the missing `qwen3_vl_moe` entry to the VLM registry table in `docs/multimodal.md`
- The `qwen3_vl_moe` model type is already present in `VLM_REGISTRY` in `src/prime_rl/utils/vlm.py` but was not documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change with no runtime or configuration behavior changes.
> 
> **Overview**
> Adds the missing `qwen3_vl_moe` entry to the supported VLM models table in `docs/multimodal.md`, aligning the docs with the existing `VLM_REGISTRY` model types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5b456dfc9eeb8408125875f2661417e852723e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->