### PR TITLE
feat: dim non-loguru stdout/stderr in log output

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -56,7 +56,7 @@ from prime_rl.utils.client import (
 )
 from prime_rl.utils.config import cli
 from prime_rl.utils.heartbeat import Heartbeat
-from prime_rl.utils.logger import setup_logger
+from prime_rl.utils.logger import dim_unlogged_output, setup_logger
 from prime_rl.utils.monitor import setup_monitor
 from prime_rl.utils.process import set_proc_title
 from prime_rl.utils.utils import (
@@ -78,6 +78,7 @@ SHUTDOWN_TIMEOUT_S = 300
 @clean_exit
 async def orchestrate(config: OrchestratorConfig):
     # Initialize the logger
+    dim_unlogged_output()
     logger = setup_logger(
         config.log.level,
         json_logging=config.log.json_logging,

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -25,7 +25,7 @@ from prime_rl.utils.cp import (
     setup_cp_params,
     shard_for_cp,
 )
-from prime_rl.utils.logger import setup_logger
+from prime_rl.utils.logger import dim_unlogged_output, setup_logger
 from prime_rl.trainer.rl.loss import (
     compute_entropy,
     compute_loss,
@@ -72,6 +72,7 @@ from torchtitan.distributed.utils import clip_grad_norm_
 def train(config: TrainerConfig):
     # Setup world and logger
     world = get_world()
+    dim_unlogged_output()
     logger = setup_logger(
         config.log.level,
         json_logging=config.log.json_logging,

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -20,7 +20,7 @@ from prime_rl.configs.sft import SFTConfig
 from prime_rl.utils.cp import setup_cp_params, shard_for_cp
 from prime_rl.trainer.runs import Progress, get_multi_run_manager, setup_multi_run_manager
 from prime_rl.trainer.models.layers.lora import set_lora_num_tokens
-from prime_rl.utils.logger import setup_logger
+from prime_rl.utils.logger import dim_unlogged_output, setup_logger
 from prime_rl.trainer.optim import setup_optimizer
 from prime_rl.trainer.scheduler import setup_scheduler
 from prime_rl.trainer.model import (
@@ -60,6 +60,7 @@ from torchtitan.distributed.utils import clip_grad_norm_
 def train(config: SFTConfig):
     # Setup world and logger
     world = get_world()
+    dim_unlogged_output()
     logger = setup_logger(
         config.log.level,
         json_logging=config.log.json_logging,

--- a/src/prime_rl/utils/logger.py
+++ b/src/prime_rl/utils/logger.py
@@ -9,7 +9,28 @@ _LOGGER = None
 _JSON_LOGGING = False
 
 NO_BOLD = "\033[22m"
+DIM = "\033[2m"
 RESET = "\033[0m"
+
+
+class _DimStream:
+    """Wraps a stream so that writes appear dim (ANSI dim). Used to visually
+    de-emphasise raw stdout/stderr output that doesn't go through loguru."""
+
+    def __init__(self, wrapped):
+        self._wrapped = wrapped
+
+    def write(self, s: str):
+        if s and s != "\n":
+            self._wrapped.write(f"{DIM}{s}{RESET}")
+        else:
+            self._wrapped.write(s)
+
+    def flush(self):
+        self._wrapped.flush()
+
+    def __getattr__(self, name):
+        return getattr(self._wrapped, name)
 
 
 def build_log_entry(record) -> dict:
@@ -55,8 +76,9 @@ def build_log_entry(record) -> dict:
 def json_sink(message) -> None:
     """Sink that outputs flat JSON to stdout for log aggregation (Loki, Grafana, etc.)."""
     log_entry = build_log_entry(message.record)
-    sys.stdout.write(json_module.dumps(log_entry) + "\n")
-    sys.stdout.flush()
+    out = sys.stdout._wrapped if isinstance(sys.stdout, _DimStream) else sys.stdout
+    out.write(json_module.dumps(log_entry) + "\n")
+    out.flush()
 
 
 class InterceptHandler(logging.Handler):
@@ -139,7 +161,9 @@ def setup_logger(
     if json_logging:
         logger.add(json_sink, level=log_level.upper(), enqueue=True)
     else:
-        logger.add(sys.stdout, format=format, level=log_level.upper(), colorize=True)
+        # Capture the real stdout before wrapping, so loguru writes without dim
+        real_stdout = sys.stdout._wrapped if isinstance(sys.stdout, _DimStream) else sys.stdout
+        logger.add(real_stdout, format=format, level=log_level.upper(), colorize=True)
 
     # Disable critical logging
     logger.critical = lambda _: None
@@ -148,6 +172,16 @@ def setup_logger(
     _LOGGER = logger
 
     return logger
+
+
+def dim_unlogged_output():
+    """Replace sys.stdout/stderr with dim wrappers so that raw output (not from loguru)
+    appears visually muted. Call this *before* setup_logger() — the logger will
+    automatically write to the unwrapped stream."""
+    if not isinstance(sys.stdout, _DimStream):
+        sys.stdout = _DimStream(sys.stdout)
+    if not isinstance(sys.stderr, _DimStream):
+        sys.stderr = _DimStream(sys.stderr)
 
 
 def get_logger():


### PR DESCRIPTION
## Summary
- Adds a `_DimStream` wrapper and `dim_unlogged_output()` helper that replaces `sys.stdout`/`sys.stderr` with ANSI-dim versions
- Loguru sinks write to the unwrapped real stream, so formatted log lines look normal
- Raw output from third-party libraries (PyTorch, NCCL, tqdm, print statements) appears dimmed when tailing `trainer.log` / `orchestrator.log`
- Enabled in RL trainer, SFT trainer, and orchestrator entry points

🤖 Generated with [Claude Code](https://claude.com/claude-code)