### PR TITLE
fix: handle malformed preprocessing payloads

### DIFF
--- a/src/prime_rl/orchestrator/trajectories.py
+++ b/src/prime_rl/orchestrator/trajectories.py
@@ -13,9 +13,11 @@ from transformers.tokenization_utils import PreTrainedTokenizer
 
 from prime_rl.transport import TrainingSample
 from prime_rl.utils.chat_template import (
+    MessagePayloadError,
     common_prefix_len,
     deserialize_tool_calls,
     normalize_messages,
+    prepare_messages_for_rendering,
     render_messages,
     strip_message_content,
 )
@@ -124,16 +126,15 @@ def _tokenize_step_from_messages(
     tools: list[dict[str, Any]] | None = None,
     processor=None,
 ) -> dict[str, Any]:
-    prompt = _normalize_messages(step.get("prompt"), default_role="user")
-    completion = _normalize_messages(step.get("completion"), default_role="assistant")
+    prompt = prepare_messages_for_rendering(step.get("prompt"), default_role="user")
+    completion = prepare_messages_for_rendering(step.get("completion"), default_role="assistant")
 
-    prompt = _strip_message_content(_deserialize_tool_calls(prompt))
-    completion = _strip_message_content(_deserialize_tool_calls(completion))
-
-    assert all(m.get("role") == "assistant" for m in completion), (
-        "Expected all completion messages to be assistant role for SFT distillation, "
-        f"got roles: {[m.get('role') for m in completion]}"
-    )
+    invalid_roles = [m.get("role") for m in completion if m.get("role") != "assistant"]
+    if invalid_roles:
+        raise MessagePayloadError(
+            "Expected all completion messages to be assistant role for SFT distillation, "
+            f"got roles: {invalid_roles}"
+        )
 
     if processor is not None:
         prompt = _prepare_messages_for_processor(prompt)
@@ -212,7 +213,13 @@ def pretokenize_rollout_trajectory(
         if step["tokens"] is not None:
             continue
 
-        reconstructed = _tokenize_step_from_messages(step, tokenizer, tools=tools, processor=processor)
+        try:
+            reconstructed = _tokenize_step_from_messages(step, tokenizer, tools=tools, processor=processor)
+        except MessagePayloadError as e:
+            logger.warning(
+                f"Failed to pretokenize rollout example {output['example_id']} step {step_idx}: {e}. Skipping rollout."
+            )
+            return False
         if reconstructed["prompt_prefix_len"] < reconstructed["original_prompt_len"]:
             logger.debug(
                 f"Prompt tokenization was non-prefix for example {output['example_id']} step {step_idx}. "

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -15,10 +15,9 @@ from transformers.tokenization_utils import PreTrainedTokenizer
 from prime_rl.configs.sft import DataConfig, LossMaskConfig, SFTDataConfig
 from prime_rl.trainer.world import get_world
 from prime_rl.utils.chat_template import (
+    MessagePayloadError,
     build_incremental_token_mask,
-    deserialize_tool_calls,
-    normalize_messages,
-    strip_message_content,
+    prepare_messages_for_rendering,
 )
 from prime_rl.utils.logger import get_logger
 
@@ -166,26 +165,29 @@ class SFTDataset(StatefulIterableDataset):
             # `messages` takes precedence over explicit split fields and is interpreted
             # as a whole-chat training sample with an empty prompt.
             if "messages" in example:
-                messages = normalize_messages(example["messages"], default_role="assistant")
+                return prepare_messages_for_rendering(example["messages"], default_role="assistant")
             elif "prompt" in example and "completion" in example:
-                messages = normalize_messages(example["prompt"], default_role="user") + normalize_messages(
+                return prepare_messages_for_rendering(
+                    example["prompt"], default_role="user"
+                ) + prepare_messages_for_rendering(
                     example["completion"], default_role="assistant"
                 )
-            else:
-                raise ValueError(
-                    "All examples in the dataset must have either a 'messages' column "
-                    "or both 'prompt' and 'completion' columns for SFT"
-                )
+            raise ValueError(
+                "All examples in the dataset must have either a 'messages' column "
+                "or both 'prompt' and 'completion' columns for SFT"
+            )
 
-            # Deserialize tool call arguments from message list, if present - assumes OAI format
-            # Reference: https://platform.openai.com/docs/guides/function-calling#handling-function-calls
-            messages = deserialize_tool_calls(messages)
-
-            # Strip content from all messages so that incremental tokenization works
-            # NOTE: This has the side effect that we do never train on leading or trailing whitespace
-            return strip_message_content(messages)
-
-        messages = resolve_messages(example)
+        try:
+            messages = resolve_messages(example)
+        except MessagePayloadError as e:
+            self.logger.warning(
+                f"Skipping example {example.get('__index', '')} because message preprocessing failed: {e}"
+            )
+            return None
+        except ValueError as e:
+            if "must have either a 'messages' column" in str(e):
+                raise
+            raise
 
         # Parse available tools, if present - assumes OAI format
         # Reference: https://platform.openai.com/docs/guides/function-calling#function-tool-example
@@ -203,16 +205,22 @@ class SFTDataset(StatefulIterableDataset):
                 case "tool":
                     return True if self.loss_mask_config.tool else False
                 case _:
-                    raise ValueError(f"Invalid message role: {message['role']}")
+                    raise MessagePayloadError(f"Invalid message role: {message['role']}")
 
-        input_ids, loss_mask = build_incremental_token_mask(
-            self.tokenizer,
-            messages,
-            role_to_mask=should_mask,
-            tools=tools,
-            chat_template_kwargs=example.get("chat_template_kwargs", {}),
-            collapse_consecutive_tool_messages=True,
-        )
+        try:
+            input_ids, loss_mask = build_incremental_token_mask(
+                self.tokenizer,
+                messages,
+                role_to_mask=should_mask,
+                tools=tools,
+                chat_template_kwargs=example.get("chat_template_kwargs", {}),
+                collapse_consecutive_tool_messages=True,
+            )
+        except MessagePayloadError as e:
+            self.logger.warning(
+                f"Skipping example {example.get('__index', '')} because tokenization failed: {e}"
+            )
+            return None
 
         # If EOS token is not found, manually append it
         if not self.tokenizer.eos_token_id in input_ids:

--- a/src/prime_rl/utils/chat_template.py
+++ b/src/prime_rl/utils/chat_template.py
@@ -4,6 +4,10 @@ from typing import Any, Callable
 from transformers.tokenization_utils import PreTrainedTokenizer
 
 
+class MessagePayloadError(ValueError):
+    """Raised when external message payloads are structurally invalid."""
+
+
 def common_prefix_len(a: list[int], b: list[int]) -> int:
     max_len = min(len(a), len(b))
     for idx in range(max_len):
@@ -27,37 +31,100 @@ def normalize_messages(messages: Any, default_role: str) -> list[dict[str, Any]]
             elif isinstance(message, dict):
                 normalized.append(dict(message))
             else:
-                raise TypeError(f"Unsupported message type: {type(message)}")
+                raise MessagePayloadError(f"Unsupported message type: {type(message)}")
         return normalized
-    raise TypeError(f"Unsupported messages container type: {type(messages)}")
+    raise MessagePayloadError(f"Unsupported messages container type: {type(messages)}")
+
+
+def validate_messages_for_rendering(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    for message_idx, message in enumerate(messages):
+        role = message.get("role")
+        if not isinstance(role, str):
+            raise MessagePayloadError(f"Message {message_idx} is missing a string role")
+
+        content = message.get("content")
+        if content is not None and not isinstance(content, (str, list)):
+            raise MessagePayloadError(
+                f"Message {message_idx} has unsupported content type for chat template rendering: {type(content)}"
+            )
+
+        if "tool_calls" not in message:
+            continue
+
+        tool_calls = message.get("tool_calls")
+        if tool_calls is None:
+            continue
+        if not isinstance(tool_calls, list):
+            raise MessagePayloadError(f"Message {message_idx} tool_calls must be a list, got {type(tool_calls)}")
+
+        for tool_call_idx, tool_call in enumerate(tool_calls):
+            if not isinstance(tool_call, dict):
+                raise MessagePayloadError(
+                    f"Message {message_idx} has non-dict tool call at index {tool_call_idx}: {type(tool_call)}"
+                )
+
+            function = tool_call.get("function")
+            if function is not None and not isinstance(function, dict):
+                raise MessagePayloadError(
+                    f"Message {message_idx} tool call {tool_call_idx} has non-dict function payload: {type(function)}"
+                )
+
+    return messages
 
 
 def deserialize_tool_calls(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    def _deserialize_tool_call(tool_call: dict[str, Any]) -> dict[str, Any]:
+    def _deserialize_tool_call(tool_call: Any, *, message_idx: int, tool_call_idx: int) -> dict[str, Any]:
+        if not isinstance(tool_call, dict):
+            raise MessagePayloadError(
+                f"Message {message_idx} has non-dict tool call at index {tool_call_idx}: {type(tool_call)}"
+            )
         function = tool_call.get("function", {})
+        if function is None:
+            function = {}
+        if not isinstance(function, dict):
+            raise MessagePayloadError(
+                f"Message {message_idx} tool call {tool_call_idx} has non-dict function payload: {type(function)}"
+            )
         arguments = function.get("arguments")
         if isinstance(arguments, str):
-            arguments = json.loads(arguments)
+            try:
+                arguments = json.loads(arguments)
+            except json.JSONDecodeError as e:
+                raise MessagePayloadError(
+                    f"Message {message_idx} tool call {tool_call_idx} has invalid JSON arguments"
+                ) from e
         return {
             **tool_call,
             "function": {**function, "arguments": arguments},
         }
 
     deserialized_messages: list[dict[str, Any]] = []
-    for message in messages:
+    for message_idx, message in enumerate(messages):
         if "tool_calls" not in message:
             deserialized_messages.append(dict(message))
             continue
 
         tool_calls = message.get("tool_calls") or []
+        if not isinstance(tool_calls, list):
+            raise MessagePayloadError(f"Message {message_idx} tool_calls must be a list, got {type(tool_calls)}")
         deserialized_messages.append(
             {
                 **message,
-                "tool_calls": [_deserialize_tool_call(tc) for tc in tool_calls],
+                "tool_calls": [
+                    _deserialize_tool_call(tc, message_idx=message_idx, tool_call_idx=tool_call_idx)
+                    for tool_call_idx, tc in enumerate(tool_calls)
+                ],
             }
         )
 
     return deserialized_messages
+
+
+def prepare_messages_for_rendering(messages: Any, default_role: str) -> list[dict[str, Any]]:
+    normalized_messages = normalize_messages(messages, default_role)
+    validated_messages = validate_messages_for_rendering(normalized_messages)
+    deserialized_messages = deserialize_tool_calls(validated_messages)
+    return strip_message_content(deserialized_messages)
 
 
 def strip_message_content(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -130,7 +197,8 @@ def build_incremental_token_mask(
             processor=processor,
         )
 
-        assert prev_ids == cur_ids[:prev_len], "Mismatch in incremental tokenization with chat template."
+        if prev_ids != cur_ids[:prev_len]:
+            raise ValueError("Mismatch in incremental tokenization with chat template.")
 
         token_mask.extend([role_to_mask(message)] * (len(cur_ids) - prev_len))
         prev_ids = cur_ids

--- a/tests/unit/orchestrator/test_sft_trajectories.py
+++ b/tests/unit/orchestrator/test_sft_trajectories.py
@@ -138,3 +138,70 @@ def test_pretokenize_rollout_trajectory_for_sft():
         [True] * len(step1_completion_ids) + [False] * len(step2_new_prompt_ids) + [True] * len(step2_completion_ids)
     )
     assert rollout.completion_logprobs == [0.0] * len(rollout.completion_ids)
+
+
+def test_pretokenize_rollout_trajectory_invalid_completion_roles_returns_false():
+    tokenizer = SimpleChatTokenizer()
+    output = vf.RolloutOutput(
+        example_id=7,
+        trajectory=[
+            vf.TrajectoryStep(
+                prompt=[{"role": "user", "content": "U1"}],
+                completion=[
+                    {"role": "assistant", "content": "A1"},
+                    {"role": "tool", "content": "tool-output", "tool_call_id": "call_1"},
+                ],
+                response=MagicMock(),
+                tokens=None,
+                reward=None,
+                advantage=None,
+                is_truncated=False,
+                trajectory_id="1",
+                extras={},
+            )
+        ],
+        sampling_args={"temperature": 1.0},
+        error=None,
+    )
+
+    assert pretokenize_rollout_trajectory(output, tokenizer) is False
+    assert output["trajectory"][0]["tokens"] is None
+    assert interleave_rollout(output) is None
+
+
+def test_pretokenize_rollout_trajectory_invalid_tool_call_json_returns_false():
+    tokenizer = SimpleChatTokenizer()
+    output = vf.RolloutOutput(
+        example_id=8,
+        trajectory=[
+            vf.TrajectoryStep(
+                prompt=[{"role": "user", "content": "Check the weather"}],
+                completion=[
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {"name": "get_weather", "arguments": '{"location": "Paris"'},
+                            }
+                        ],
+                    }
+                ],
+                response=MagicMock(),
+                tokens=None,
+                reward=None,
+                advantage=None,
+                is_truncated=False,
+                trajectory_id="1",
+                extras={},
+            )
+        ],
+        sampling_args={"temperature": 1.0},
+        error=None,
+    )
+
+    assert pretokenize_rollout_trajectory(output, tokenizer) is False
+    assert output["trajectory"][0]["tokens"] is None
+    assert interleave_rollout(output) is None

--- a/tests/unit/orchestrator/test_trajectories.py
+++ b/tests/unit/orchestrator/test_trajectories.py
@@ -17,6 +17,7 @@ from prime_rl.orchestrator.trajectories import (
     build_vlm_image_cache,
     interleave_rollout,
 )
+from prime_rl.utils.chat_template import MessagePayloadError, prepare_messages_for_rendering
 
 
 def _pixels(data: list[list[float]]) -> tuple[bytes, list[int]]:
@@ -55,6 +56,32 @@ def test_deserialize_tool_calls_parses_arguments_when_present():
     deserialized = _deserialize_tool_calls(messages)
 
     assert deserialized[0]["tool_calls"][0]["function"]["arguments"] == {"x": 1}
+
+
+def test_deserialize_tool_calls_raises_on_invalid_json_string():
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "1",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": '{"x": 1'},
+                }
+            ],
+        }
+    ]
+
+    with pytest.raises(MessagePayloadError, match="invalid JSON arguments"):
+        _deserialize_tool_calls(messages)
+
+
+def test_prepare_messages_for_rendering_raises_on_non_list_tool_calls():
+    with pytest.raises(MessagePayloadError, match="tool_calls must be a list"):
+        prepare_messages_for_rendering(
+            [{"role": "assistant", "content": None, "tool_calls": {"id": "call_1"}}],
+            default_role="assistant",
+        )
 
 
 @pytest.fixture

--- a/tests/unit/train/sft/test_sft_dataset.py
+++ b/tests/unit/train/sft/test_sft_dataset.py
@@ -11,8 +11,9 @@ from prime_rl.trainer.utils import print_sample
 class NonIncrementalChatTokenizer:
     eos_token_id = 999
 
-    def apply_chat_template(self, messages, add_generation_prompt=False, return_dict=False):
+    def apply_chat_template(self, messages, add_generation_prompt=False, return_dict=False, tools=None):
         del return_dict
+        del tools
         ids = [len(messages)]
         for message in reversed(messages):
             ids.append(len(str(message.get("content", ""))))
@@ -34,8 +35,9 @@ class StructuredChatTokenizer:
             self._next_id += 1
         return self._token_to_id[token]
 
-    def apply_chat_template(self, messages, add_generation_prompt=False, return_dict=False):
+    def apply_chat_template(self, messages, add_generation_prompt=False, return_dict=False, tools=None):
         del return_dict
+        del tools
         ids = []
         for message in messages:
             ids.append(self._id(f"role:{message.get('role', 'unknown')}"))

--- a/tests/unit/train/sft/test_sft_dataset.py
+++ b/tests/unit/train/sft/test_sft_dataset.py
@@ -8,6 +8,47 @@ from prime_rl.trainer.sft.data import SFTDataset
 from prime_rl.trainer.utils import print_sample
 
 
+class NonIncrementalChatTokenizer:
+    eos_token_id = 999
+
+    def apply_chat_template(self, messages, add_generation_prompt=False, return_dict=False):
+        del return_dict
+        ids = [len(messages)]
+        for message in reversed(messages):
+            ids.append(len(str(message.get("content", ""))))
+        if add_generation_prompt:
+            ids.append(self.eos_token_id)
+        return ids
+
+
+class StructuredChatTokenizer:
+    eos_token_id = 999
+
+    def __init__(self):
+        self._token_to_id: dict[str, int] = {}
+        self._next_id = 1
+
+    def _id(self, token: str) -> int:
+        if token not in self._token_to_id:
+            self._token_to_id[token] = self._next_id
+            self._next_id += 1
+        return self._token_to_id[token]
+
+    def apply_chat_template(self, messages, add_generation_prompt=False, return_dict=False):
+        del return_dict
+        ids = []
+        for message in messages:
+            ids.append(self._id(f"role:{message.get('role', 'unknown')}"))
+            ids.append(self._id(f"content:{message.get('content')!r}"))
+            for tool_call in message.get("tool_calls") or []:
+                function = tool_call.get("function", {}) if isinstance(tool_call, dict) else {}
+                ids.append(self._id(f"tool:{function.get('name', '')}"))
+                ids.append(self._id(f"arguments:{function.get('arguments')!r}"))
+        if add_generation_prompt:
+            ids.append(self._id("role:assistant"))
+        return ids
+
+
 @pytest.fixture(scope="module")
 def build_dummy_dataset():
     return lambda letter, num_examples: Dataset.from_list([{"text": f"{letter}{i}"} for i in range(num_examples)])
@@ -26,6 +67,48 @@ def test_raise_error_if_no_prompt_and_completion(build_dummy_dataset):
     tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B")
     sft_dataset = SFTDataset(dataset, tokenizer=tokenizer)
     with pytest.raises(ValueError):
+        next(iter(sft_dataset))
+
+
+def test_sft_dataset_skips_non_incremental_chat_template():
+    dataset = Dataset.from_list(
+        [
+            {
+                "prompt": [{"role": "user", "content": "Prompt 0"}],
+                "completion": [{"role": "assistant", "content": "Completion 0"}],
+            }
+        ]
+    )
+    sft_dataset = SFTDataset(dataset, tokenizer=NonIncrementalChatTokenizer(), shuffle=False, max_epochs=1)
+
+    with pytest.raises(ValueError, match="Mismatch in incremental tokenization with chat template."):
+        next(iter(sft_dataset))
+
+
+def test_sft_dataset_skips_invalid_tool_call_json_string():
+    dataset = Dataset.from_list(
+        [
+            {
+                "prompt": [{"role": "user", "content": "What's the weather?"}],
+                "completion": [
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {"name": "get_weather", "arguments": '{"location": "Paris"'},
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+    )
+    sft_dataset = SFTDataset(dataset, tokenizer=StructuredChatTokenizer(), shuffle=False, max_epochs=1)
+
+    with pytest.raises(StopIteration):
         next(iter(sft_dataset))
 
 


### PR DESCRIPTION
## Summary
- add a shared malformed-payload validation path before chat-template rendering
- skip malformed prompt and tool-call payloads during SFT preprocessing and rollout pretokenization instead of aborting the whole sample or rollout
- add regressions for invalid tool-call JSON, non-list `tool_calls`, mixed-role completions, and preserving the incremental-tokenization invariant failure path

## Root Cause
The preprocessing path trusted external message payloads too early. Invalid tool-call JSON and mixed-role completion payloads raised deep inside tokenization, which aborted processing instead of being treated as malformed external input.

## Impact
Malformed prompt and tool-call payloads now fail soft at the sample or rollout boundary, while real chat-template invariant mismatches still raise explicitly.

## Validation
- `uv run --no-project python -m py_compile src/prime_rl/utils/chat_template.py src/prime_rl/trainer/sft/data.py src/prime_rl/orchestrator/trajectories.py tests/unit/orchestrator/test_sft_trajectories.py tests/unit/orchestrator/test_trajectories.py tests/unit/train/sft/test_sft_dataset.py`
- `git diff --check`
- Targeted `pytest` files could not run from this macOS `uv --no-project` environment because `transformers` is not installed there.
