### PR TITLE
feat: shared concurrency limiter for train/eval rollouts

### DIFF
--- a/configs/hendrycks_math/rl.toml
+++ b/configs/hendrycks_math/rl.toml
@@ -12,13 +12,18 @@ name = "Qwen/Qwen3-4B-Instruct-2507"
 batch_size = 512
 rollouts_per_example = 16
 
-[orchestrator.sampling]
-max_tokens = 2048
+[orchestrator.train.sampling]
+max_completion_tokens = 2048
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "math-env"
 name = "hendrycks-math"
-args = { dataset_name = "PrimeIntellect/Hendrycks-Math", dataset_subset = "default", math_verify_max_workers = 128, math_verify_timeout = 60 }
+
+[orchestrator.train.env.args]
+dataset_name = "PrimeIntellect/Hendrycks-Math"
+dataset_subset = "default"
+math_verify_max_workers = 128
+math_verify_timeout = 60
 
 [orchestrator.buffer]
 easy_threshold = 1.0
@@ -28,7 +33,7 @@ hard_threshold = 0.0
 interval = 10
 
 [orchestrator.eval.sampling]
-max_tokens = 2048
+max_completion_tokens = 2048
 
 [[orchestrator.eval.env]]
 id = "math500"

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -548,7 +548,19 @@ class EvalConfig(BaseConfig):
     cancel_inflight_rollouts_on_eval: Annotated[
         bool,
         Field(
-            description="Whether to cancel in-flight training rollouts before starting online evals. This is useful to avoid congestion (e.g. do not have training + eval rollouts happening at the same time) but leads to slower training steps as rollouts get cancelled and the pipeline has to fill up after each eval",
+            description="Whether to cancel in-flight training rollouts before starting online evals. This is useful to avoid congestion (e.g. do not have training + eval rollouts happening at the same time) but leads to slower training steps as rollouts get cancelled and the pipeline has to fill up after each eval. Incompatible with overlap_train_and_eval_rollouts.",
+        ),
+    ] = False
+
+    overlap_train_and_eval_rollouts: Annotated[
+        bool,
+        Field(
+            description=(
+                "When True, eval rollouts run concurrently with training rollouts (sharing the "
+                "concurrency limiter). Training is not paused during eval, improving throughput "
+                "at the cost of eval results potentially spanning multiple checkpoints. "
+                "When False (default), training is paused during eval for consistent checkpoint evaluation."
+            ),
         ),
     ] = False
 

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -548,11 +548,11 @@ class EvalConfig(BaseConfig):
     cancel_inflight_rollouts_on_eval: Annotated[
         bool,
         Field(
-            description="Whether to cancel in-flight training rollouts before starting online evals. This is useful to avoid congestion (e.g. do not have training + eval rollouts happening at the same time) but leads to slower training steps as rollouts get cancelled and the pipeline has to fill up after each eval. Incompatible with overlap_train_and_eval_rollouts.",
+            description="Whether to cancel in-flight training rollouts before starting online evals. This is useful to avoid congestion (e.g. do not have training + eval rollouts happening at the same time) but leads to slower training steps as rollouts get cancelled and the pipeline has to fill up after each eval. Can be combined with overlap_with_train_rollouts.",
         ),
     ] = False
 
-    overlap_train_and_eval_rollouts: Annotated[
+    overlap_with_train_rollouts: Annotated[
         bool,
         Field(
             description=(

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -1030,7 +1030,6 @@ class OrchestratorConfig(BaseConfig):
         return data
 
     @model_validator(mode="before")
-    @classmethod
     def _env_to_train(cls, data: Any) -> Any:
         """Allow [[env]] and [sampling] as shorthand for [train] with [[train.env]] and [train.sampling]."""
         if not isinstance(data, dict):

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -997,6 +997,14 @@ class OrchestratorConfig(BaseConfig):
         ),
     ] = 8
 
+    max_rollout_retries: Annotated[
+        int,
+        Field(
+            ge=1,
+            description="Maximum number of times a failed rollout request is retried before the entire group is dropped.",
+        ),
+    ] = 3
+
     max_async_level: Annotated[
         int,
         Field(

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -901,11 +901,12 @@ class OrchestratorConfig(BaseConfig):
         ),
     ] = Path("outputs/run_default")
 
-    tasks_per_minute: Annotated[
+    max_rollouts_per_minute: Annotated[
         int | None,
         Field(
             ge=1,
-            description="Rate limit for tasks per environment worker, in tasks per minute. Recommended for sandbox-backed environments to prevent sandbox-not-ready errors during autoscaling. When set to None, no rate limiting is applied. Note: with multiple workers, the effective total rate equals workers × this value.",
+            validation_alias=AliasChoices("max_rollouts_per_minute", "tasks_per_minute"),
+            description="Rate limit for rollouts per minute. Recommended for sandbox-backed environments to prevent sandbox-not-ready errors during autoscaling. When set to None, no rate limiting is applied.",
         ),
     ] = None
 
@@ -1018,6 +1019,16 @@ class OrchestratorConfig(BaseConfig):
             description="Whether to use the token-in-token-out (TITO) client for training across all environments. WARNING: Only use this if your environment has a linear history and the chat template has the extension property (i.e. no tokens are ever removed or inserted by the chat template)"
         ),
     ] = True
+
+    @model_validator(mode="before")
+    @classmethod
+    def _deprecate_tasks_per_minute(cls, data: Any) -> Any:
+        if isinstance(data, dict) and "tasks_per_minute" in data and "max_rollouts_per_minute" not in data:
+            get_logger().warning(
+                "'tasks_per_minute' is deprecated, use 'max_rollouts_per_minute' instead. "
+                "Auto-translating for now, but this will be removed in a future release."
+            )
+        return data
 
     @model_validator(mode="before")
     @classmethod

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -1021,7 +1021,6 @@ class OrchestratorConfig(BaseConfig):
     ] = True
 
     @model_validator(mode="before")
-    @classmethod
     def _deprecate_tasks_per_minute(cls, data: Any) -> Any:
         if isinstance(data, dict) and "tasks_per_minute" in data and "max_rollouts_per_minute" not in data:
             get_logger().warning(

--- a/src/prime_rl/orchestrator/concurrency.py
+++ b/src/prime_rl/orchestrator/concurrency.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+import math
 
 from aiolimiter import AsyncLimiter
+
+from prime_rl.utils.logger import get_logger
 
 
 class RateLimiter:
@@ -10,31 +13,43 @@ class RateLimiter:
 
     Wraps aiolimiter.AsyncLimiter, which rejects acquire(amount) when amount
     exceeds max_rate. We loop instead so group-scoring envs work correctly.
+    If max_rate is None, acquiring is a no-op (unlimited).
     """
 
-    def __init__(self, max_rate: float, time_period: float = 60):
-        self._limiter = AsyncLimiter(max_rate=max_rate, time_period=time_period)
+    def __init__(self, max_rate: float | None = None, time_period: float = 60):
+        self._limiter = AsyncLimiter(max_rate=max_rate, time_period=time_period) if max_rate is not None else None
+
+    @property
+    def unlimited(self) -> bool:
+        return self._limiter is None
 
     async def acquire(self, count: int = 1) -> None:
+        if self._limiter is None:
+            return
         for _ in range(count):
             await self._limiter.acquire()
 
 
 class ConcurrencyLimiter:
-    """Shared concurrency limiter that gates both train and eval rollouts.
+    """Slot-based concurrency limiter for rollouts.
 
     Uses a simple counter with an asyncio.Event for wakeup. All calls must
     happen on the same event loop (single-threaded asyncio), so no lock is needed.
+    If max_concurrency is None, all operations are no-ops (unlimited).
     """
 
-    def __init__(self, max_concurrency: int):
+    def __init__(self, max_concurrency: int | None = None):
         self._max = max_concurrency
         self._used = 0
         self._available = asyncio.Event()
         self._available.set()
 
     @property
-    def max_concurrency(self) -> int:
+    def unlimited(self) -> bool:
+        return self._max is None
+
+    @property
+    def max_concurrency(self) -> int | None:
         return self._max
 
     @property
@@ -43,10 +58,14 @@ class ConcurrencyLimiter:
 
     @property
     def remaining(self) -> int:
+        if self._max is None:
+            return math.inf
         return self._max - self._used
 
     async def acquire(self, count: int = 1) -> None:
         """Wait until *count* slots are available, then reserve them."""
+        if self._max is None:
+            return
         while self.remaining < count:
             self._available.clear()
             await self._available.wait()
@@ -54,6 +73,8 @@ class ConcurrencyLimiter:
 
     def try_acquire(self, count: int = 1) -> bool:
         """Non-blocking acquire. Returns True if slots were reserved."""
+        if self._max is None:
+            return True
         if self.remaining >= count:
             self._used += count
             return True
@@ -61,6 +82,8 @@ class ConcurrencyLimiter:
 
     def release(self, count: int = 1) -> None:
         """Return *count* slots to the pool and wake any blocked acquirers."""
+        if self._max is None:
+            return
         self._used -= count
         assert self._used >= 0, f"ConcurrencyLimiter released too many slots (used={self._used})"
         self._available.set()
@@ -73,9 +96,19 @@ class RolloutLimiter:
     Release only applies to concurrency (rate tokens are not returned).
     """
 
-    def __init__(self, max_concurrency: int, max_rate: float | None = None, time_period: float = 60):
+    def __init__(self, max_concurrency: int | None = None, max_rate: float | None = None, time_period: float = 60):
         self.concurrency = ConcurrencyLimiter(max_concurrency)
-        self.rate = RateLimiter(max_rate, time_period) if max_rate is not None else None
+        self.rate = RateLimiter(max_rate, time_period)
+
+        parts = []
+        if not self.concurrency.unlimited:
+            parts.append(f"max_concurrency={max_concurrency}")
+        if not self.rate.unlimited:
+            parts.append(f"max_rate={max_rate}/{time_period}s")
+        if parts:
+            get_logger().info(f"RolloutLimiter initialized ({', '.join(parts)})")
+        else:
+            get_logger().info("RolloutLimiter initialized (unlimited)")
 
     @property
     def remaining(self) -> int:
@@ -83,8 +116,7 @@ class RolloutLimiter:
 
     async def acquire(self, count: int = 1) -> None:
         """Acquire rate tokens then concurrency slots (blocking)."""
-        if self.rate:
-            await self.rate.acquire(count)
+        await self.rate.acquire(count)
         await self.concurrency.acquire(count)
 
     def try_acquire(self, count: int = 1) -> bool:

--- a/src/prime_rl/orchestrator/concurrency.py
+++ b/src/prime_rl/orchestrator/concurrency.py
@@ -96,15 +96,15 @@ class RolloutLimiter:
     Release only applies to concurrency (rate tokens are not returned).
     """
 
-    def __init__(self, max_concurrency: int | None = None, max_rate: float | None = None, time_period: float = 60):
-        self.concurrency = ConcurrencyLimiter(max_concurrency)
-        self.rate = RateLimiter(max_rate, time_period)
+    def __init__(self, max_concurrent_rollouts: int | None = None, max_rollouts_per_minute: float | None = None):
+        self.concurrency = ConcurrencyLimiter(max_concurrent_rollouts)
+        self.rate = RateLimiter(max_rollouts_per_minute, time_period=60)
 
         parts = []
         if not self.concurrency.unlimited:
-            parts.append(f"max_concurrency={max_concurrency}")
+            parts.append(f"max_concurrent_rollouts={max_concurrent_rollouts}")
         if not self.rate.unlimited:
-            parts.append(f"max_rate={max_rate}/{time_period}s")
+            parts.append(f"max_rollouts_per_minute={max_rollouts_per_minute}")
         if parts:
             get_logger().info(f"RolloutLimiter initialized ({', '.join(parts)})")
         else:

--- a/src/prime_rl/orchestrator/concurrency.py
+++ b/src/prime_rl/orchestrator/concurrency.py
@@ -64,3 +64,33 @@ class ConcurrencyLimiter:
         self._used -= count
         assert self._used >= 0, f"ConcurrencyLimiter released too many slots (used={self._used})"
         self._available.set()
+
+
+class RolloutLimiter:
+    """Combined rate + concurrency limiter for rollout scheduling.
+
+    Acquire gates on both limits (rate first, then concurrency).
+    Release only applies to concurrency (rate tokens are not returned).
+    """
+
+    def __init__(self, max_concurrency: int, max_rate: float | None = None, time_period: float = 60):
+        self.concurrency = ConcurrencyLimiter(max_concurrency)
+        self.rate = RateLimiter(max_rate, time_period) if max_rate is not None else None
+
+    @property
+    def remaining(self) -> int:
+        return self.concurrency.remaining
+
+    async def acquire(self, count: int = 1) -> None:
+        """Acquire rate tokens then concurrency slots (blocking)."""
+        if self.rate:
+            await self.rate.acquire(count)
+        await self.concurrency.acquire(count)
+
+    def try_acquire(self, count: int = 1) -> bool:
+        """Non-blocking concurrency acquire (rate limiting is skipped)."""
+        return self.concurrency.try_acquire(count)
+
+    def release(self, count: int = 1) -> None:
+        """Release concurrency slots."""
+        self.concurrency.release(count)

--- a/src/prime_rl/orchestrator/concurrency.py
+++ b/src/prime_rl/orchestrator/concurrency.py
@@ -2,6 +2,23 @@ from __future__ import annotations
 
 import asyncio
 
+from aiolimiter import AsyncLimiter
+
+
+class RateLimiter:
+    """Rate limiter that supports variable-cost acquire (N rollouts at once).
+
+    Wraps aiolimiter.AsyncLimiter, which rejects acquire(amount) when amount
+    exceeds max_rate. We loop instead so group-scoring envs work correctly.
+    """
+
+    def __init__(self, max_rate: float, time_period: float = 60):
+        self._limiter = AsyncLimiter(max_rate=max_rate, time_period=time_period)
+
+    async def acquire(self, count: int = 1) -> None:
+        for _ in range(count):
+            await self._limiter.acquire()
+
 
 class ConcurrencyLimiter:
     """Shared concurrency limiter that gates both train and eval rollouts.

--- a/src/prime_rl/orchestrator/concurrency.py
+++ b/src/prime_rl/orchestrator/concurrency.py
@@ -57,7 +57,7 @@ class ConcurrencyLimiter:
         return self._used
 
     @property
-    def remaining(self) -> int:
+    def remaining(self) -> float:
         if self._max is None:
             return math.inf
         return self._max - self._used
@@ -111,7 +111,7 @@ class RolloutLimiter:
             get_logger().info("RolloutLimiter initialized (unlimited)")
 
     @property
-    def remaining(self) -> int:
+    def remaining(self) -> float:
         return self.concurrency.remaining
 
     async def acquire(self, count: int = 1) -> None:

--- a/src/prime_rl/orchestrator/concurrency.py
+++ b/src/prime_rl/orchestrator/concurrency.py
@@ -90,14 +90,6 @@ class ConcurrencyLimiter:
         assert self._used >= 0, f"ConcurrencyLimiter released too many slots (used={self._used})"
         self._available.set()
 
-    async def wait_for_capacity(self, count: int = 1) -> None:
-        """Block until *count* slots are available, without acquiring them."""
-        if self._max is None:
-            return
-        while self.remaining < count:
-            self._available.clear()
-            await self._available.wait()
-
 
 class RolloutLimiter:
     """Combined rate + concurrency limiter for rollout scheduling.
@@ -128,10 +120,6 @@ class RolloutLimiter:
         """Acquire rate tokens then concurrency slots (blocking)."""
         await self.rate.acquire(count)
         await self.concurrency.acquire(count)
-
-    def try_acquire(self, count: int = 1) -> bool:
-        """Non-blocking concurrency acquire (rate limiting is skipped)."""
-        return self.concurrency.try_acquire(count)
 
     def release(self, count: int = 1) -> None:
         """Release concurrency slots."""

--- a/src/prime_rl/orchestrator/concurrency.py
+++ b/src/prime_rl/orchestrator/concurrency.py
@@ -66,6 +66,8 @@ class ConcurrencyLimiter:
         """Wait until *count* slots are available, then reserve them."""
         if self._max is None:
             return
+        if count > self._max:
+            raise ValueError(f"Cannot acquire {count} slots (max_concurrency={self._max})")
         while self.remaining < count:
             self._available.clear()
             await self._available.wait()

--- a/src/prime_rl/orchestrator/concurrency.py
+++ b/src/prime_rl/orchestrator/concurrency.py
@@ -41,6 +41,7 @@ class ConcurrencyLimiter:
     def __init__(self, max_concurrency: int | None = None):
         self._max = max_concurrency
         self._used = 0
+        self._priority_pending = 0
         self._available = asyncio.Event()
         self._available.set()
 
@@ -62,16 +63,26 @@ class ConcurrencyLimiter:
             return math.inf
         return self._max - self._used
 
-    async def acquire(self, count: int = 1) -> None:
-        """Wait until *count* slots are available, then reserve them."""
+    async def acquire(self, count: int = 1, priority: bool = False) -> None:
+        """Wait until *count* slots are available, then reserve them.
+
+        When priority=True, this acquire is served before non-priority ones.
+        Non-priority acquires yield while any priority acquires are pending.
+        """
         if self._max is None:
             return
         if count > self._max:
             raise ValueError(f"Cannot acquire {count} slots (max_concurrency={self._max})")
-        while self.remaining < count:
-            self._available.clear()
-            await self._available.wait()
-        self._used += count
+        if priority:
+            self._priority_pending += count
+        try:
+            while self.remaining < count or (not priority and self._priority_pending > 0):
+                self._available.clear()
+                await self._available.wait()
+            self._used += count
+        finally:
+            if priority:
+                self._priority_pending -= count
 
     def try_acquire(self, count: int = 1) -> bool:
         """Non-blocking acquire. Returns True if slots were reserved."""
@@ -116,10 +127,10 @@ class RolloutLimiter:
     def remaining(self) -> float:
         return self.concurrency.remaining
 
-    async def acquire(self, count: int = 1) -> None:
+    async def acquire(self, count: int = 1, priority: bool = False) -> None:
         """Acquire rate tokens then concurrency slots (blocking)."""
         await self.rate.acquire(count)
-        await self.concurrency.acquire(count)
+        await self.concurrency.acquire(count, priority=priority)
 
     def release(self, count: int = 1) -> None:
         """Release concurrency slots."""

--- a/src/prime_rl/orchestrator/concurrency.py
+++ b/src/prime_rl/orchestrator/concurrency.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import asyncio
+
+
+class ConcurrencyLimiter:
+    """Shared concurrency limiter that gates both train and eval rollouts.
+
+    Uses a simple counter with an asyncio.Event for wakeup. All calls must
+    happen on the same event loop (single-threaded asyncio), so no lock is needed.
+    """
+
+    def __init__(self, max_concurrency: int):
+        self._max = max_concurrency
+        self._used = 0
+        self._available = asyncio.Event()
+        self._available.set()
+
+    @property
+    def max_concurrency(self) -> int:
+        return self._max
+
+    @property
+    def used(self) -> int:
+        return self._used
+
+    @property
+    def remaining(self) -> int:
+        return self._max - self._used
+
+    async def acquire(self, count: int = 1) -> None:
+        """Wait until *count* slots are available, then reserve them."""
+        while self.remaining < count:
+            self._available.clear()
+            await self._available.wait()
+        self._used += count
+
+    def try_acquire(self, count: int = 1) -> bool:
+        """Non-blocking acquire. Returns True if slots were reserved."""
+        if self.remaining >= count:
+            self._used += count
+            return True
+        return False
+
+    def release(self, count: int = 1) -> None:
+        """Return *count* slots to the pool and wake any blocked acquirers."""
+        self._used -= count
+        assert self._used >= 0, f"ConcurrencyLimiter released too many slots (used={self._used})"
+        self._available.set()

--- a/src/prime_rl/orchestrator/concurrency.py
+++ b/src/prime_rl/orchestrator/concurrency.py
@@ -90,6 +90,14 @@ class ConcurrencyLimiter:
         assert self._used >= 0, f"ConcurrencyLimiter released too many slots (used={self._used})"
         self._available.set()
 
+    async def wait_for_capacity(self, count: int = 1) -> None:
+        """Block until *count* slots are available, without acquiring them."""
+        if self._max is None:
+            return
+        while self.remaining < count:
+            self._available.clear()
+            await self._available.wait()
+
 
 class RolloutLimiter:
     """Combined rate + concurrency limiter for rollout scheduling.

--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -3,23 +3,17 @@ from __future__ import annotations
 import asyncio
 import atexit
 import multiprocessing as mp
-import time
-from collections.abc import Awaitable, Callable, Iterator, Sequence
+from collections.abc import Iterator, Sequence
 from multiprocessing.process import BaseProcess
 from pathlib import Path
 from typing import Generic, TypeVar
 
-import pandas as pd
 import verifiers as vf
 from verifiers.serve import ZMQEnvClient, ZMQEnvServer
 from verifiers.utils.serve_utils import get_free_port
 
 from prime_rl.configs.orchestrator import EnvConfig, EvalEnvConfig, TrainEnvConfig
-from prime_rl.orchestrator.eval_utils import compute_pass_at_k
-from prime_rl.orchestrator.vf_utils import get_completion_len
-from prime_rl.utils.logger import ProgressTracker, get_logger
-from prime_rl.utils.monitor import get_monitor
-from prime_rl.utils.utils import capitalize
+from prime_rl.utils.logger import get_logger
 
 REQUIRED_STATE_COLUMNS = ["trajectory", "sampling_args"]
 
@@ -164,154 +158,6 @@ class EvalEnv(Env):
         super().__init__(config)
         self.sampling_args = config.sampling.to_sampling_args()
         self.examples = self.env.get_eval_dataset(n=config.num_examples).to_list()
-
-    async def evaluate(
-        self,
-        model_name: str,
-        get_client: Callable[[], Awaitable[vf.ClientConfig]],
-        ckpt_step: int,
-        step: int,
-        on_rollout_done: Callable[[int], None] | None = None,
-    ) -> list[vf.RolloutOutput]:
-        num_examples = len(self.examples)
-        rollouts_per_example = self.config.rollouts_per_example
-        get_logger().info(f"Evaluating {self.name} ({num_examples=}, {rollouts_per_example=})")
-        total_rollouts = num_examples * rollouts_per_example
-        pbar = ProgressTracker(total=total_rollouts, desc=f"Evaluating {self.name}")
-        eval_start = time.perf_counter()
-
-        if self.requires_group_scoring:
-
-            async def run_with_progress(example: dict) -> list[vf.RolloutOutput] | None:
-                """Run rollouts_per_example rollouts as a scored group for one example."""
-                try:
-                    client = await get_client()
-                    outputs = await self.run_group(
-                        client=client,
-                        example=example,
-                        model_name=model_name,
-                        rollouts_per_example=rollouts_per_example,
-                    )
-                    pbar.update(rollouts_per_example)
-                    return outputs
-                except Exception as e:
-                    get_logger().warning(f"Group failed: {e}")
-                    pbar.update(rollouts_per_example)
-                    return None
-                finally:
-                    if on_rollout_done is not None:
-                        on_rollout_done(rollouts_per_example)
-
-            coros = [run_with_progress(example) for example in self.examples]
-
-        else:
-
-            async def run_with_progress(example: dict) -> list[vf.RolloutOutput] | None:
-                """Run a single rollout for one example."""
-                try:
-                    client = await get_client()
-                    output = await self.run_rollout(client=client, example=example, model_name=model_name)
-                    pbar.update(1)
-                    return [output]
-                except Exception as e:
-                    get_logger().warning(f"Rollout failed: {e}")
-                    pbar.update(1)
-                    return None
-                finally:
-                    if on_rollout_done is not None:
-                        on_rollout_done(1)
-
-            coros = [run_with_progress(example) for example in self.examples for _ in range(rollouts_per_example)]
-
-        try:
-            results = await asyncio.gather(*coros)
-        finally:
-            pbar.close()
-
-        successful_outputs = [o for group in results if group is not None for o in group]
-        failed_count = total_rollouts - len(successful_outputs)
-        eval_time = time.perf_counter() - eval_start
-
-        if failed_count:
-            get_logger().warning(
-                f"{failed_count}/{total_rollouts} ({failed_count / total_rollouts * 100:.1f}%) rollouts failed"
-            )
-
-        if not successful_outputs:
-            get_logger().warning(f"All rollouts failed for {self.name}, skipping logging metrics")
-            get_monitor().log(
-                {
-                    f"eval/{self.name}/failed_rollouts": failed_count / total_rollouts,
-                    "progress/ckpt_step": ckpt_step,
-                    "step": step,
-                },
-                step=step,
-            )
-            return []
-
-        # Log metrics
-        monitor = get_monitor()
-
-        rows = [
-            {
-                "example_id": o["example_id"],
-                "reward": o["reward"],
-                "completion_len": get_completion_len(o),
-                "is_truncated": o["is_truncated"],
-                "has_error": o.get("error") is not None,
-                "no_response": not o.get("completion"),
-            }
-            for o in successful_outputs
-        ]
-        results_df = pd.DataFrame(rows)
-
-        unique_rewards = results_df.reward.dropna().unique()
-        could_be_binary = set(unique_rewards).issubset({0.0, 1.0})
-        if could_be_binary:
-            pass_at_k = (
-                results_df.groupby("example_id")
-                .apply(lambda x: compute_pass_at_k(x.reward.dropna()), include_groups=False)
-                .apply(pd.Series)
-            )
-        else:
-            pass_at_k = None
-            get_logger().warning("Skipping computing pass@k rates because the task rewards appear to be non-binary")
-
-        message = (
-            f"Evaluated {self.name} in {eval_time:.2f}s (Avg@{rollouts_per_example}={results_df.reward.mean():.4f}"
-        )
-        if could_be_binary:
-            assert pass_at_k is not None
-            for pass_rate, pass_rate_score in pd.Series(pass_at_k.mean()).items():
-                message += f", {capitalize(str(pass_rate))}: {pass_rate_score:.4f}"
-
-        message += (
-            f", No-response: {results_df.no_response.mean() * 100:.1f}%"
-            f", Completion Length: {results_df.completion_len.mean():.2f} (±{results_df.completion_len.std():.2f}, ∈[{results_df.completion_len.min():.2f}, {results_df.completion_len.max():.2f}])"
-            f", Truncated: {results_df.is_truncated.mean() * 100:.1f}%)"
-        )
-        get_logger().success(message)
-
-        eval_metrics = {
-            f"avg@{rollouts_per_example}": float(results_df.reward.mean()),
-            "no_response/mean": float(results_df.no_response.mean()),
-            "no_response/count": int(results_df.no_response.sum()),
-            "completion_len/mean": results_df.completion_len.mean().item(),
-            "completion_len/max": results_df.completion_len.max().item(),
-            "completion_len/min": results_df.completion_len.min().item(),
-            "is_truncated/mean": results_df.is_truncated.mean().item(),
-            "failed_rollouts": failed_count / total_rollouts,
-            "time": eval_time,
-        }
-        if could_be_binary:
-            assert pass_at_k is not None
-            eval_metrics.update(pd.Series(pass_at_k.mean()).to_dict())
-        eval_metrics = {f"eval/{self.name}/{key}": v for key, v in eval_metrics.items()}
-        eval_metrics.update({"progress/ckpt_step": ckpt_step, "step": step})
-        monitor.log(eval_metrics, step=step)
-        monitor.log_eval_samples(successful_outputs, env_name=self.name, step=step)
-
-        return successful_outputs
 
 
 EnvT = TypeVar("EnvT", bound=Env)

--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -171,6 +171,7 @@ class EvalEnv(Env):
         get_client: Callable[[], Awaitable[vf.ClientConfig]],
         ckpt_step: int,
         step: int,
+        on_rollout_done: Callable[[int], None] | None = None,
     ) -> list[vf.RolloutOutput]:
         num_examples = len(self.examples)
         rollouts_per_example = self.config.rollouts_per_example
@@ -197,6 +198,9 @@ class EvalEnv(Env):
                     get_logger().warning(f"Group failed: {e}")
                     pbar.update(rollouts_per_example)
                     return None
+                finally:
+                    if on_rollout_done is not None:
+                        on_rollout_done(rollouts_per_example)
 
             coros = [run_with_progress(example) for example in self.examples]
 
@@ -213,6 +217,9 @@ class EvalEnv(Env):
                     get_logger().warning(f"Rollout failed: {e}")
                     pbar.update(1)
                     return None
+                finally:
+                    if on_rollout_done is not None:
+                        on_rollout_done(1)
 
             coros = [run_with_progress(example) for example in self.examples for _ in range(rollouts_per_example)]
 

--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -98,40 +98,35 @@ class Env:
         self._env_server_process = process
         return address
 
-    async def run_rollout(
+    async def run(
         self,
         client: vf.ClientConfig,
         example: dict,
         model_name: str,
-    ) -> vf.RolloutOutput:
-        """Run a single rollout for an example."""
-        return await self.env.run_rollout(
-            vf.RolloutInput(**example),
-            client=client,
-            model=model_name,
-            sampling_args=self.sampling_args,
-            max_retries=self.config.max_retries,
-            state_columns=REQUIRED_STATE_COLUMNS,
-            env_client=self.env_client,
-        )
-
-    async def run_group(
-        self,
-        client: vf.ClientConfig,
-        example: dict,
-        model_name: str,
-        rollouts_per_example: int,
+        n: int = 1,
     ) -> list[vf.RolloutOutput]:
-        """Run a group of rollouts for an example. Required for group-scoring envs."""
-        return await self.env.run_group(
-            [vf.RolloutInput(**example) for _ in range(rollouts_per_example)],
-            client=client,
-            model=model_name,
-            sampling_args=self.sampling_args,
-            max_retries=self.config.max_retries,
-            state_columns=REQUIRED_STATE_COLUMNS,
-            env_client=self.env_client,
-        )
+        """Run rollout(s) for an example. Dispatches to group or single based on the env."""
+        if self.requires_group_scoring:
+            return await self.env.run_group(
+                [vf.RolloutInput(**example) for _ in range(n)],
+                client=client,
+                model=model_name,
+                sampling_args=self.sampling_args,
+                max_retries=self.config.max_retries,
+                state_columns=REQUIRED_STATE_COLUMNS,
+                env_client=self.env_client,
+            )
+        return [
+            await self.env.run_rollout(
+                vf.RolloutInput(**example),
+                client=client,
+                model=model_name,
+                sampling_args=self.sampling_args,
+                max_retries=self.config.max_retries,
+                state_columns=REQUIRED_STATE_COLUMNS,
+                env_client=self.env_client,
+            )
+        ]
 
     def shutdown(self) -> None:
         if self._env_server_process is None:

--- a/src/prime_rl/orchestrator/eval_utils.py
+++ b/src/prime_rl/orchestrator/eval_utils.py
@@ -1,4 +1,101 @@
+from __future__ import annotations
+
 import numpy as np
+import pandas as pd
+import verifiers as vf
+
+from prime_rl.orchestrator.vf_utils import get_completion_len
+from prime_rl.utils.logger import get_logger
+from prime_rl.utils.monitor import get_monitor
+from prime_rl.utils.utils import capitalize
+
+
+def log_eval_metrics(
+    env_name: str,
+    rollouts: list[vf.RolloutOutput],
+    total_rollouts: int,
+    rollouts_per_example: int,
+    eval_time: float,
+    ckpt_step: int,
+    step: int,
+) -> None:
+    """Compute and log eval metrics to the monitor."""
+    monitor = get_monitor()
+    failed_count = total_rollouts - len(rollouts)
+
+    if failed_count:
+        get_logger().warning(
+            f"{failed_count}/{total_rollouts} ({failed_count / total_rollouts * 100:.1f}%) rollouts failed"
+        )
+
+    if not rollouts:
+        get_logger().warning(f"All rollouts failed for {env_name}, skipping logging metrics")
+        monitor.log(
+            {
+                f"eval/{env_name}/failed_rollouts": failed_count / total_rollouts,
+                "progress/ckpt_step": ckpt_step,
+                "step": step,
+            },
+            step=step,
+        )
+        return
+
+    rows = [
+        {
+            "example_id": o["example_id"],
+            "reward": o["reward"],
+            "completion_len": get_completion_len(o),
+            "is_truncated": o["is_truncated"],
+            "has_error": o.get("error") is not None,
+            "no_response": not o.get("completion"),
+        }
+        for o in rollouts
+    ]
+    results_df = pd.DataFrame(rows)
+
+    unique_rewards = results_df.reward.dropna().unique()
+    could_be_binary = set(unique_rewards).issubset({0.0, 1.0})
+    if could_be_binary:
+        pass_at_k = (
+            results_df.groupby("example_id")
+            .apply(lambda x: compute_pass_at_k(x.reward.dropna()), include_groups=False)
+            .apply(pd.Series)
+        )
+    else:
+        pass_at_k = None
+        get_logger().warning("Skipping computing pass@k rates because the task rewards appear to be non-binary")
+
+    message = f"Evaluated {env_name} in {eval_time:.2f}s (Avg@{rollouts_per_example}={results_df.reward.mean():.4f}"
+    if could_be_binary:
+        assert pass_at_k is not None
+        for pass_rate, pass_rate_score in pd.Series(pass_at_k.mean()).items():
+            message += f", {capitalize(str(pass_rate))}: {pass_rate_score:.4f}"
+
+    message += (
+        f", No-response: {results_df.no_response.mean() * 100:.1f}%"
+        f", Completion Length: {results_df.completion_len.mean():.2f} (±{results_df.completion_len.std():.2f}, ∈[{results_df.completion_len.min():.2f}, {results_df.completion_len.max():.2f}])"
+        f", Truncated: {results_df.is_truncated.mean() * 100:.1f}%)"
+    )
+    get_logger().success(message)
+
+    eval_metrics = {
+        f"avg@{rollouts_per_example}": float(results_df.reward.mean()),
+        "no_response/mean": float(results_df.no_response.mean()),
+        "no_response/count": int(results_df.no_response.sum()),
+        "completion_len/mean": results_df.completion_len.mean().item(),
+        "completion_len/max": results_df.completion_len.max().item(),
+        "completion_len/min": results_df.completion_len.min().item(),
+        "is_truncated/mean": results_df.is_truncated.mean().item(),
+        "failed_rollouts": failed_count / total_rollouts,
+        "time": eval_time,
+    }
+    if could_be_binary:
+        assert pass_at_k is not None
+        eval_metrics.update(pd.Series(pass_at_k.mean()).to_dict())
+    eval_metrics = {f"eval/{env_name}/{key}": v for key, v in eval_metrics.items()}
+    eval_metrics.update({"progress/ckpt_step": ckpt_step, "step": step})
+    monitor.log(eval_metrics, step=step)
+    monitor.log_eval_samples(rollouts, env_name=env_name, step=step)
 
 
 def compute_eval_ckpt_step(

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -440,10 +440,6 @@ async def orchestrate(config: OrchestratorConfig):
         # Update prev_ckpt_step for next iteration
         prev_ckpt_step = ckpt_step
 
-        # Enforce async barrier before accepting the next batch
-        if policy_scheduler:
-            await policy_scheduler.wait_until_ready()
-
         # Wait for the train batch to complete (background loops are always running)
         train_rollouts = await train_scheduler.wait_for_batch()
         generate_completions_time = train_scheduler.last_batch_generation_time

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -340,8 +340,9 @@ async def orchestrate(config: OrchestratorConfig):
             step_path = get_step_path(get_rollout_dir(config.output_dir), eval_step)
             await asyncio.to_thread(save_rollouts, all_rollouts, step_path / "eval_rollouts.jsonl")
 
-    # Iterate over dataset in batches
+    # Start the train scheduler (background loops)
     logger.info(f"Starting orchestrator loop (max_steps={config.max_steps or 'infinite'})")
+    await train_scheduler.start(step=progress.step)
     is_first_step = True
     eval_task: asyncio.Task | None = None
 
@@ -424,13 +425,9 @@ async def orchestrate(config: OrchestratorConfig):
         # Update prev_ckpt_step for next iteration
         prev_ckpt_step = ckpt_step
 
-        # Schedule generating the training batch
-        train_task = asyncio.create_task(train_scheduler.generate_batch(step=progress.step))
-
-        # Await train rollouts
-        await train_task
+        # Wait for the train batch to complete (background loops are always running)
+        train_rollouts = await train_scheduler.wait_for_batch()
         generate_completions_time = train_scheduler.last_batch_generation_time
-        train_rollouts = train_task.result()
 
         # Save train rollouts to disk (fire-and-forget background thread)
         step_path = get_step_path(get_rollout_dir(config.output_dir), progress.step)
@@ -706,9 +703,10 @@ async def orchestrate(config: OrchestratorConfig):
         step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Reward: {reward_mean:.4f} | Seq. Length: {by_example.seq_len.mean().mean():.1f} tokens/sample | Async Level: {train_scheduler.async_level} | Max. Off-Policy Level: {train_scheduler.max_off_policy_level}"
         logger.success(step_message)
 
-        # Increment step
+        # Increment step and advance train scheduler to next batch
         progress.step += 1
         is_first_step = False
+        train_scheduler.advance_step(progress.step)
 
         # Free large per-step objects to prevent memory accumulation
         del train_rollouts, train_examples, training_batch, vlm_cache

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -356,7 +356,7 @@ async def orchestrate(config: OrchestratorConfig):
     logger.info(f"Starting orchestrator loop (max_steps={config.max_steps or 'infinite'})")
     policy_loop_task: asyncio.Task | None = None
     if policy_scheduler:
-        policy_loop_task = asyncio.create_task(policy_scheduler.run())
+        policy_loop_task = asyncio.create_task(policy_scheduler.start())
     await train_scheduler.start()
     is_first_step = True
     eval_task: asyncio.Task | None = None

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -6,7 +6,7 @@ import time
 import tomli_w
 
 from prime_rl.orchestrator.advantage import compute_advantages
-from prime_rl.orchestrator.eval_utils import compute_eval_ckpt_step
+from prime_rl.orchestrator.eval_utils import compute_eval_ckpt_step, log_eval_metrics
 from prime_rl.orchestrator.event_loop_lag import EventLoopLagMonitor
 from prime_rl.orchestrator.patches import monkey_patch_chat_completion_logprobs, monkey_patch_oai_iterable_types
 from prime_rl.orchestrator.trajectories import (
@@ -37,7 +37,7 @@ from prime_rl.configs.orchestrator import OrchestratorConfig
 from prime_rl.orchestrator.buffer import Buffer
 from prime_rl.orchestrator.ckpt import Progress, setup_ckpt_manager
 from prime_rl.orchestrator.concurrency import ConcurrencyLimiter
-from prime_rl.orchestrator.envs import EvalEnv, EvalEnvs, TrainEnvs
+from prime_rl.orchestrator.envs import EvalEnvs, TrainEnvs
 from prime_rl.orchestrator.filters import apply_filters, setup_filters
 from prime_rl.orchestrator.scheduler import EvalScheduler, Scheduler
 from prime_rl.orchestrator.utils import (
@@ -355,7 +355,7 @@ async def orchestrate(config: OrchestratorConfig):
         # Run evals BEFORE training (blocking). Weight updates are paused via
         # scheduler.checkpoint_ready during eval to ensure consistent weights.
         # Each eval env has its own interval, so we check each independently.
-        envs_to_eval: list[EvalEnv] = []
+        envs_to_eval = []
         if config.eval:
             assert eval_envs is not None
             for eval_env in eval_envs:
@@ -384,20 +384,20 @@ async def orchestrate(config: OrchestratorConfig):
                 await scheduler.cancel_inflight_rollouts()
 
             assert eval_scheduler is not None
-            eval_results = await asyncio.gather(
-                *[
-                    eval_scheduler.evaluate(
-                        eval_env=eval_env,
-                        model_name=scheduler.model_name,
-                        ckpt_step=ckpt_step,
-                        step=progress.step,
-                    )
-                    for eval_env in envs_to_eval
-                ]
-            )
+            eval_rollouts: list[vf.RolloutOutput] = []
+            async for result in eval_scheduler.run(envs_to_eval, model_name=scheduler.model_name):
+                log_eval_metrics(
+                    env_name=result.env_name,
+                    rollouts=result.rollouts,
+                    total_rollouts=result.total_rollouts,
+                    rollouts_per_example=result.rollouts_per_example,
+                    eval_time=result.eval_time,
+                    ckpt_step=ckpt_step,
+                    step=progress.step,
+                )
+                eval_rollouts.extend(result.rollouts)
 
             # Save eval rollouts to disk (fire-and-forget background thread)
-            eval_rollouts = [o for outputs in eval_results for o in outputs]
             if eval_rollouts:
                 step_path = get_step_path(get_rollout_dir(config.output_dir), progress.step)
                 await asyncio.to_thread(save_rollouts, eval_rollouts, step_path / "eval_rollouts.jsonl")
@@ -707,20 +707,20 @@ async def orchestrate(config: OrchestratorConfig):
 
     if config.eval and eval_envs is not None and eval_scheduler is not None:
         logger.info("Running final evals")
-        eval_results = await asyncio.gather(
-            *[
-                eval_scheduler.evaluate(
-                    eval_env=eval_env,
-                    model_name=scheduler.model_name,
-                    ckpt_step=ckpt_step,
-                    step=progress.step,
-                )
-                for eval_env in eval_envs
-            ]
-        )
+        eval_rollouts: list[vf.RolloutOutput] = []
+        async for result in eval_scheduler.run(list(eval_envs), model_name=scheduler.model_name):
+            log_eval_metrics(
+                env_name=result.env_name,
+                rollouts=result.rollouts,
+                total_rollouts=result.total_rollouts,
+                rollouts_per_example=result.rollouts_per_example,
+                eval_time=result.eval_time,
+                ckpt_step=ckpt_step,
+                step=progress.step,
+            )
+            eval_rollouts.extend(result.rollouts)
 
         # Save final eval rollouts to disk
-        eval_rollouts = [o for outputs in eval_results for o in outputs]
         if eval_rollouts:
             step_path = get_step_path(get_rollout_dir(config.output_dir), progress.step)
             await asyncio.to_thread(save_rollouts, eval_rollouts, step_path / "eval_rollouts.jsonl")

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -385,7 +385,7 @@ async def orchestrate(config: OrchestratorConfig):
                 await train_scheduler.cancel_inflight_rollouts()
 
             eval_rollouts: list[vf.RolloutOutput] = []
-            async for result in eval_scheduler.run(envs_to_eval, model_name=train_scheduler.model_name):
+            async for result in eval_scheduler.evaluate_envs(envs_to_eval, model_name=train_scheduler.model_name):
                 log_eval_metrics(
                     env_name=result.env_name,
                     rollouts=result.rollouts,
@@ -708,7 +708,7 @@ async def orchestrate(config: OrchestratorConfig):
     if config.eval and eval_envs is not None and eval_scheduler is not None:
         logger.info("Running final evals")
         eval_rollouts = []
-        async for result in eval_scheduler.run(list(eval_envs), model_name=train_scheduler.model_name):
+        async for result in eval_scheduler.evaluate_envs(list(eval_envs), model_name=train_scheduler.model_name):
             log_eval_metrics(
                 env_name=result.env_name,
                 rollouts=result.rollouts,

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -370,6 +370,8 @@ async def orchestrate(config: OrchestratorConfig):
                     envs_to_eval.append(eval_env)
 
         if envs_to_eval:
+            assert config.eval is not None and eval_scheduler is not None
+
             env_names = ", ".join(e.name for e in envs_to_eval)
             logger.info(f"Running evals at {ckpt_step=} for {env_names}")
 
@@ -382,7 +384,6 @@ async def orchestrate(config: OrchestratorConfig):
                 logger.info("Cancelling in-flight training rollouts before starting evals to avoid congestion.")
                 await train_scheduler.cancel_inflight_rollouts()
 
-            assert eval_scheduler is not None
             eval_rollouts: list[vf.RolloutOutput] = []
             async for result in eval_scheduler.run(envs_to_eval, model_name=train_scheduler.model_name):
                 log_eval_metrics(

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -242,6 +242,7 @@ async def orchestrate(config: OrchestratorConfig):
             progress=progress,
             output_dir=config.output_dir,
             max_async_level=config.max_async_level,
+            strict_async_level=config.strict_async_level,
             lora_name=config.model.lora.name if config.model.lora else None,
         )
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -352,9 +352,9 @@ async def orchestrate(config: OrchestratorConfig):
         logger.info(f"Starting orchestrator step {progress.step}")
         step_start_time = time.perf_counter()
 
-        # Run evals BEFORE training (blocking). Weight updates are paused via
-        # train_scheduler.checkpoint_ready during eval to ensure consistent weights.
-        # Each eval env has its own interval, so we check each independently.
+        # Run evals BEFORE training (blocking). Scheduling is paused during eval
+        # to ensure consistent weights. Each eval env has its own interval.
+        # TODO: for overlapping eval, remove pause/resume and rely on the shared limiter.
         envs_to_eval = []
         if config.eval:
             assert eval_envs is not None
@@ -378,7 +378,7 @@ async def orchestrate(config: OrchestratorConfig):
 
             # Pause weight updates and re-scheduling of training rollouts during eval
             # to avoid evaluating across different checkpoints and avoid congestion
-            train_scheduler.checkpoint_ready.clear()
+            train_scheduler.pause()
 
             # For heavy eval workloads, it might be necessary additionally cancel in-flight training rollouts
             if config.eval.cancel_inflight_rollouts_on_eval:
@@ -404,7 +404,7 @@ async def orchestrate(config: OrchestratorConfig):
                 await asyncio.to_thread(save_rollouts, eval_rollouts, step_path / "eval_rollouts.jsonl")
 
             # Resume weight updates
-            train_scheduler.checkpoint_ready.set()
+            train_scheduler.resume()
 
         # Update prev_ckpt_step for next iteration
         prev_ckpt_step = ckpt_step

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -229,7 +229,6 @@ async def orchestrate(config: OrchestratorConfig):
         token_batch_size=config.token_batch_size,
         rollouts_per_example=config.rollouts_per_example,
         max_off_policy_steps=config.max_off_policy_steps,
-        max_async_level=config.max_async_level,
         model_name=rollout_model_name,
         json_logging=config.log.json_logging,
     )
@@ -239,10 +238,11 @@ async def orchestrate(config: OrchestratorConfig):
         policy_scheduler = PolicyScheduler(
             train_scheduler=train_scheduler,
             inference_pool=inference_pool,
+            progress=progress,
             output_dir=config.output_dir,
+            max_async_level=config.max_async_level,
             lora_name=config.model.lora.name if config.model.lora else None,
         )
-        train_scheduler.policy_scheduler = policy_scheduler
 
     if eval_envs is not None:
         eval_scheduler = EvalScheduler(
@@ -367,7 +367,7 @@ async def orchestrate(config: OrchestratorConfig):
             raise RuntimeError(f"Run evicted by trainer: {reason}")
 
         # Capture ckpt_step once for consistency (read from policy scheduler or use current step)
-        ckpt_step = train_scheduler.ckpt_step
+        ckpt_step = policy_scheduler.ckpt_step if policy_scheduler else progress.step
 
         # Save checkpoint (if we are at an interval step and not at the first or last step)
         is_last_step = config.max_steps is not None and progress.step == config.max_steps - 1
@@ -436,6 +436,11 @@ async def orchestrate(config: OrchestratorConfig):
 
         # Update prev_ckpt_step for next iteration
         prev_ckpt_step = ckpt_step
+
+        # Enforce async barrier: don't schedule new rollouts until policy is fresh
+        if policy_scheduler:
+            await policy_scheduler.wait_for_async_barrier()
+        train_scheduler.resume()
 
         # Wait for the train batch to complete (background loops are always running)
         train_rollouts = await train_scheduler.wait_for_batch()
@@ -715,7 +720,8 @@ async def orchestrate(config: OrchestratorConfig):
         reward_mean = by_example.reward.mean().mean()
         off_policy_levels = train_scheduler._off_policy_levels()
         max_off_policy = max(off_policy_levels) if off_policy_levels else 0
-        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Reward: {reward_mean:.4f} | Seq. Length: {by_example.seq_len.mean().mean():.1f} tokens/sample | Max. Off-Policy Level: {max_off_policy}"
+        async_level = policy_scheduler.async_level if policy_scheduler else 0
+        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Reward: {reward_mean:.4f} | Seq. Length: {by_example.seq_len.mean().mean():.1f} tokens/sample | Async Level: {async_level} | Max. Off-Policy Level: {max_off_policy}"
         logger.success(step_message)
 
         # Increment step and advance train scheduler to next batch

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -225,8 +225,8 @@ async def orchestrate(config: OrchestratorConfig):
             checkpoint_step = config.ckpt.resume_step
 
     rollout_limiter = RolloutLimiter(
-        max_concurrency=config.max_inflight_rollouts,
-        max_rate=config.tasks_per_minute,
+        max_concurrent_rollouts=config.max_inflight_rollouts,
+        max_rollouts_per_minute=config.max_rollouts_per_minute,
     )
     train_scheduler = TrainScheduler(
         train_envs=train_envs,

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -209,9 +209,33 @@ async def orchestrate(config: OrchestratorConfig):
         )
         logger.success("Eval environment(s) ready")
 
-    # Setup buffer
     logger.info(f"Setting up buffer ({config.buffer})")
     buffer = Buffer(train_envs, config.buffer)
+
+    rollout_limiter = RolloutLimiter(
+        max_concurrent_rollouts=config.max_inflight_rollouts,
+        max_rollouts_per_minute=config.max_rollouts_per_minute,
+    )
+
+    train_scheduler = TrainScheduler(
+        train_envs=train_envs,
+        buffer=buffer,
+        inference_pool=inference_pool,
+        rollout_limiter=rollout_limiter,
+        max_async_level=config.max_async_level,
+        max_off_policy_steps=config.max_off_policy_steps,
+        strict_async_level=config.strict_async_level,
+        enable_policy_updates=enable_policy_updates,
+        model_name=rollout_model_name,
+        lora_name=config.model.lora.name if config.model.lora else None,
+        config=config,
+    )
+
+    if eval_envs is not None:
+        eval_scheduler = EvalScheduler(
+            rollout_limiter=rollout_limiter,
+            inference_pool=inference_pool,
+        )
 
     # Get checkpoint manager
     logger.info(f"Initializing checkpoint manager ({config.ckpt})")
@@ -224,30 +248,7 @@ async def orchestrate(config: OrchestratorConfig):
         else:
             checkpoint_step = config.ckpt.resume_step
 
-    rollout_limiter = RolloutLimiter(
-        max_concurrent_rollouts=config.max_inflight_rollouts,
-        max_rollouts_per_minute=config.max_rollouts_per_minute,
-    )
-    train_scheduler = TrainScheduler(
-        train_envs=train_envs,
-        buffer=buffer,
-        inference_pool=inference_pool,
-        rollout_limiter=rollout_limiter,
-        max_async_level=config.max_async_level,
-        max_off_policy_steps=config.max_off_policy_steps,
-        strict_async_level=config.strict_async_level,
-        enable_policy_updates=enable_policy_updates,
-        lora_name=config.model.lora.name if config.model.lora else None,
-        config=config,
-    )
-    train_scheduler.model_name = rollout_model_name
-
-    if eval_envs is not None:
-        eval_scheduler = EvalScheduler(
-            rollout_limiter=rollout_limiter,
-            inference_pool=inference_pool,
-        )
-
+    # When resuming with LoRA, the adapter name is the model name (first weight update already happened)
     if checkpoint_step is not None and config.model.lora is not None and enable_policy_updates:
         assert config.model.lora.name is not None
         train_scheduler.model_name = config.model.lora.name

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -30,13 +30,12 @@ monkey_patch_chat_completion_logprobs()
 
 import pandas as pd
 import verifiers as vf
-from aiolimiter import AsyncLimiter
 from transformers import AutoProcessor, AutoTokenizer
 
 from prime_rl.configs.orchestrator import OrchestratorConfig
 from prime_rl.orchestrator.buffer import Buffer
 from prime_rl.orchestrator.ckpt import Progress, setup_ckpt_manager
-from prime_rl.orchestrator.concurrency import ConcurrencyLimiter
+from prime_rl.orchestrator.concurrency import ConcurrencyLimiter, RateLimiter
 from prime_rl.orchestrator.envs import EvalEnvs, TrainEnvs
 from prime_rl.orchestrator.filters import apply_filters, setup_filters
 from prime_rl.orchestrator.scheduler import EvalScheduler, Scheduler
@@ -226,7 +225,7 @@ async def orchestrate(config: OrchestratorConfig):
             checkpoint_step = config.ckpt.resume_step
 
     concurrency_limiter = ConcurrencyLimiter(config.max_inflight_rollouts)
-    rate_limiter = AsyncLimiter(max_rate=config.tasks_per_minute, time_period=60) if config.tasks_per_minute else None
+    rate_limiter = RateLimiter(max_rate=config.tasks_per_minute, time_period=60) if config.tasks_per_minute else None
     scheduler = Scheduler(
         train_envs=train_envs,
         buffer=buffer,

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -240,7 +240,6 @@ async def orchestrate(config: OrchestratorConfig):
             output_dir=config.output_dir,
             max_async_level=config.max_async_level,
             strict_async_level=config.strict_async_level,
-            model_name=rollout_model_name,
             lora_name=config.model.lora.name if config.model.lora else None,
         )
 
@@ -265,8 +264,6 @@ async def orchestrate(config: OrchestratorConfig):
     if checkpoint_step is not None and config.model.lora is not None and enable_policy_updates:
         assert config.model.lora.name is not None
         train_scheduler.model_name = config.model.lora.name
-        if policy_scheduler:
-            policy_scheduler.model_name = config.model.lora.name
 
     # Check health of the inference pool
     logger.info("Waiting for inference pool to be ready")

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -38,7 +38,7 @@ from prime_rl.orchestrator.ckpt import Progress, setup_ckpt_manager
 from prime_rl.orchestrator.concurrency import RolloutLimiter
 from prime_rl.orchestrator.envs import EvalEnvs, TrainEnvs
 from prime_rl.orchestrator.filters import apply_filters, setup_filters
-from prime_rl.orchestrator.scheduler import EvalScheduler, TrainScheduler
+from prime_rl.orchestrator.scheduler import EvalScheduler, PolicyScheduler, TrainScheduler
 from prime_rl.orchestrator.utils import (
     compute_teacher_logprobs,
     get_weight_dir,
@@ -222,18 +222,25 @@ async def orchestrate(config: OrchestratorConfig):
         inference_pool=inference_pool,
         buffer=buffer,
         rollout_limiter=rollout_limiter,
-        output_dir=config.output_dir,
         batch_size=config.batch_size,
         token_batch_size=config.token_batch_size,
         rollouts_per_example=config.rollouts_per_example,
-        max_async_level=config.max_async_level,
         max_off_policy_steps=config.max_off_policy_steps,
-        strict_async_level=config.strict_async_level,
-        enable_policy_updates=enable_policy_updates,
         model_name=rollout_model_name,
         json_logging=config.log.json_logging,
-        lora_name=config.model.lora.name if config.model.lora else None,
     )
+
+    policy_scheduler: PolicyScheduler | None = None
+    if enable_policy_updates:
+        policy_scheduler = PolicyScheduler(
+            train_scheduler=train_scheduler,
+            inference_pool=inference_pool,
+            output_dir=config.output_dir,
+            max_async_level=config.max_async_level,
+            strict_async_level=config.strict_async_level,
+            model_name=rollout_model_name,
+            lora_name=config.model.lora.name if config.model.lora else None,
+        )
 
     if eval_envs is not None:
         eval_scheduler = EvalScheduler(
@@ -256,8 +263,8 @@ async def orchestrate(config: OrchestratorConfig):
     if checkpoint_step is not None and config.model.lora is not None and enable_policy_updates:
         assert config.model.lora.name is not None
         train_scheduler.model_name = config.model.lora.name
-        if train_scheduler.policy:
-            train_scheduler.policy.model_name = config.model.lora.name
+        if policy_scheduler:
+            policy_scheduler.model_name = config.model.lora.name
 
     # Check health of the inference pool
     logger.info("Waiting for inference pool to be ready")
@@ -301,24 +308,25 @@ async def orchestrate(config: OrchestratorConfig):
     if checkpoint_step is not None and ckpt_manager is not None:
         ckpt_manager.load(progress, buffer, step=checkpoint_step)
         logger.info(f"Resuming training from checkpoint step {checkpoint_step}")
-        train_scheduler.ckpt_step = progress.step  # Always resume from the latest checkpoint
+        resume_ckpt_step = progress.step
+        train_scheduler.ckpt_step = resume_ckpt_step
+        if policy_scheduler:
+            policy_scheduler.ckpt_step = resume_ckpt_step
         if config.eval and config.eval.skip_eval_on_resume:
-            prev_ckpt_step = train_scheduler.ckpt_step
-            last_eval_steps = {name: train_scheduler.ckpt_step for name in last_eval_steps}
-            logger.info(f"Skipping online eval on resume (ckpt_step={train_scheduler.ckpt_step})")
+            prev_ckpt_step = resume_ckpt_step
+            last_eval_steps = {name: resume_ckpt_step for name in last_eval_steps}
+            logger.info(f"Skipping online eval on resume (ckpt_step={resume_ckpt_step})")
         else:
-            # Allow eval at resumed step by setting prev_ckpt_step one behind
-            prev_ckpt_step = train_scheduler.ckpt_step - 1
+            prev_ckpt_step = resume_ckpt_step - 1
 
         if enable_policy_updates:
-            # In NCCL mode, skip existence check - weights are broadcasted, not stored on disk
             check_exists = config.weight_broadcast.type != "nccl"
             wait_timeout = config.ckpt.wait_for_weights_timeout if config.ckpt else None
             weights_path = get_weight_dir(
-                config.output_dir, train_scheduler.ckpt_step, check_exists=check_exists, wait_timeout=wait_timeout
+                config.output_dir, resume_ckpt_step, check_exists=check_exists, wait_timeout=wait_timeout
             )
             lora_name = config.model.lora.name if config.model.lora else None
-            await inference_pool.update_weights(weights_path, lora_name=lora_name, step=train_scheduler.ckpt_step)
+            await inference_pool.update_weights(weights_path, lora_name=lora_name, step=resume_ckpt_step)
     else:
         logger.info("Training from scratch")
 
@@ -346,8 +354,12 @@ async def orchestrate(config: OrchestratorConfig):
             step_path = get_step_path(get_rollout_dir(config.output_dir), eval_step)
             await asyncio.to_thread(save_rollouts, all_rollouts, step_path / "eval_rollouts.jsonl")
 
-    # Start the train scheduler (background loops)
+    # Start background loops
     logger.info(f"Starting orchestrator loop (max_steps={config.max_steps or 'infinite'})")
+    policy_loop_task: asyncio.Task | None = None
+    if policy_scheduler:
+        await policy_scheduler.maybe_update(progress.step)
+        policy_loop_task = asyncio.create_task(policy_scheduler.run())
     await train_scheduler.start(step=progress.step)
     is_first_step = True
     eval_task: asyncio.Task | None = None
@@ -359,8 +371,8 @@ async def orchestrate(config: OrchestratorConfig):
             reason = evicted_path.read_text().strip()
             raise RuntimeError(f"Run evicted by trainer: {reason}")
 
-        # Capture ckpt_step once for consistency (it's updated inside the scheduler)
-        ckpt_step = train_scheduler.ckpt_step if enable_policy_updates else progress.step
+        # Capture ckpt_step once for consistency
+        ckpt_step = policy_scheduler.ckpt_step if policy_scheduler else progress.step
         train_scheduler.ckpt_step = ckpt_step
 
         # Save checkpoint (if we are at an interval step and not at the first or last step)
@@ -638,6 +650,7 @@ async def orchestrate(config: OrchestratorConfig):
             "time/parallel_preprocess": parallel_preprocess_time,
             # Scheduler metrics
             **train_scheduler.get_metrics(),
+            **(policy_scheduler.get_metrics() if policy_scheduler else {}),
             # Buffer metrics
             **buffer.get_metrics(),
             # Event loop lag metrics
@@ -708,7 +721,7 @@ async def orchestrate(config: OrchestratorConfig):
         reward_mean = by_example.reward.mean().mean()
         off_policy_levels = train_scheduler._off_policy_levels()
         max_off_policy = max(off_policy_levels) if off_policy_levels else 0
-        async_level = train_scheduler.policy.async_level if train_scheduler.policy else 0
+        async_level = policy_scheduler.async_level if policy_scheduler else 0
         step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Reward: {reward_mean:.4f} | Seq. Length: {by_example.seq_len.mean().mean():.1f} tokens/sample | Async Level: {async_level} | Max. Off-Policy Level: {max_off_policy}"
         logger.success(step_message)
 
@@ -754,6 +767,8 @@ async def orchestrate(config: OrchestratorConfig):
     # failure mode we're guarding against.
     async def _graceful_shutdown() -> None:
         training_batch_sender.close()
+        if policy_loop_task is not None:
+            policy_loop_task.cancel()
         await train_scheduler.stop()
         await inference_pool.stop()
         if teacher_inference_pool is not None:

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -238,10 +238,7 @@ async def orchestrate(config: OrchestratorConfig):
         policy_scheduler = PolicyScheduler(
             train_scheduler=train_scheduler,
             inference_pool=inference_pool,
-            progress=progress,
             output_dir=config.output_dir,
-            max_async_level=config.max_async_level,
-            strict_async_level=config.strict_async_level,
             lora_name=config.model.lora.name if config.model.lora else None,
         )
 
@@ -475,7 +472,7 @@ async def orchestrate(config: OrchestratorConfig):
 
         # VLM: build image cache in a thread so it doesn't block the event loop.
         # This lets the scheduler continue servicing inflight rollout requests
-        # and — with max_async_level >= 2 — overlap with the next batch's inference.
+        # and overlap with the next batch's inference.
         if is_vlm:
             vlm_cache = await asyncio.to_thread(build_vlm_image_cache, train_rollouts, processor)
             logger.info(
@@ -718,8 +715,7 @@ async def orchestrate(config: OrchestratorConfig):
         reward_mean = by_example.reward.mean().mean()
         off_policy_levels = train_scheduler._off_policy_levels()
         max_off_policy = max(off_policy_levels) if off_policy_levels else 0
-        async_level = policy_scheduler.async_level if policy_scheduler else 0
-        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Reward: {reward_mean:.4f} | Seq. Length: {by_example.seq_len.mean().mean():.1f} tokens/sample | Async Level: {async_level} | Max. Off-Policy Level: {max_off_policy}"
+        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Reward: {reward_mean:.4f} | Seq. Length: {by_example.seq_len.mean().mean():.1f} tokens/sample | Max. Off-Policy Level: {max_off_policy}"
         logger.success(step_message)
 
         # Increment step and advance train scheduler to next batch

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -212,6 +212,8 @@ async def orchestrate(config: OrchestratorConfig):
     logger.info(f"Setting up buffer ({config.buffer})")
     buffer = Buffer(train_envs, config.buffer)
 
+    progress = Progress()
+
     rollout_limiter = RolloutLimiter(
         max_concurrent_rollouts=config.max_inflight_rollouts,
         max_rollouts_per_minute=config.max_rollouts_per_minute,
@@ -300,9 +302,6 @@ async def orchestrate(config: OrchestratorConfig):
     last_eval_steps: dict[str, int] = {env.name: -1 for env in eval_envs} if eval_envs else {}
     # Track previous ckpt_step to detect when ckpt_step jumps over eval interval boundaries
     prev_ckpt_step = -1
-
-    # Reset weights to base model if starting from scratch
-    progress = Progress()
 
     if checkpoint_step is not None and ckpt_manager is not None:
         ckpt_manager.load(progress, buffer, step=checkpoint_step)

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -316,9 +316,34 @@ async def orchestrate(config: OrchestratorConfig):
     else:
         logger.info("Training from scratch")
 
+    async def _run_eval(
+        eval_sched: EvalScheduler,
+        envs: list,
+        model_name: str,
+        eval_ckpt_step: int,
+        eval_step: int,
+    ) -> None:
+        """Run evals, log metrics per-env, and save rollouts to disk."""
+        all_rollouts: list[vf.RolloutOutput] = []
+        async for result in eval_sched.evaluate_envs(envs, model_name=model_name):
+            log_eval_metrics(
+                env_name=result.env_name,
+                rollouts=result.rollouts,
+                total_rollouts=result.total_rollouts,
+                rollouts_per_example=result.rollouts_per_example,
+                eval_time=result.eval_time,
+                ckpt_step=eval_ckpt_step,
+                step=eval_step,
+            )
+            all_rollouts.extend(result.rollouts)
+        if all_rollouts:
+            step_path = get_step_path(get_rollout_dir(config.output_dir), eval_step)
+            await asyncio.to_thread(save_rollouts, all_rollouts, step_path / "eval_rollouts.jsonl")
+
     # Iterate over dataset in batches
     logger.info(f"Starting orchestrator loop (max_steps={config.max_steps or 'infinite'})")
     is_first_step = True
+    eval_task: asyncio.Task | None = None
 
     while True:
         # Check if this run has been evicted by the trainer
@@ -352,9 +377,7 @@ async def orchestrate(config: OrchestratorConfig):
         logger.info(f"Starting orchestrator step {progress.step}")
         step_start_time = time.perf_counter()
 
-        # Run evals BEFORE training (blocking). Scheduling is paused during eval
-        # to ensure consistent weights. Each eval env has its own interval.
-        # TODO: for overlapping eval, remove pause/resume and rely on the shared limiter.
+        # Determine which eval envs need evaluation at this checkpoint
         envs_to_eval = []
         if config.eval:
             assert eval_envs is not None
@@ -376,35 +399,27 @@ async def orchestrate(config: OrchestratorConfig):
             env_names = ", ".join(e.name for e in envs_to_eval)
             logger.info(f"Running evals at {ckpt_step=} for {env_names}")
 
-            # Pause weight updates and re-scheduling of training rollouts during eval
-            # to avoid evaluating across different checkpoints and avoid congestion
-            train_scheduler.pause()
-
-            # For heavy eval workloads, it might be necessary additionally cancel in-flight training rollouts
             if config.eval.cancel_inflight_rollouts_on_eval:
                 logger.info("Cancelling in-flight training rollouts before starting evals to avoid congestion.")
                 await train_scheduler.cancel_inflight_rollouts()
 
-            eval_rollouts: list[vf.RolloutOutput] = []
-            async for result in eval_scheduler.evaluate_envs(envs_to_eval, model_name=train_scheduler.model_name):
-                log_eval_metrics(
-                    env_name=result.env_name,
-                    rollouts=result.rollouts,
-                    total_rollouts=result.total_rollouts,
-                    rollouts_per_example=result.rollouts_per_example,
-                    eval_time=result.eval_time,
-                    ckpt_step=ckpt_step,
-                    step=progress.step,
+            if config.eval.overlap_train_and_eval_rollouts:
+                # Overlapping mode: eval runs concurrently with training via the shared limiter.
+                # At most one eval task runs at a time — warn if the previous one hasn't finished.
+                if eval_task is not None and not eval_task.done():
+                    logger.warning(
+                        "New eval triggered while previous eval is still running. "
+                        "Consider increasing the eval interval or max_inflight_rollouts."
+                    )
+                    await eval_task
+                eval_task = asyncio.create_task(
+                    _run_eval(eval_scheduler, envs_to_eval, train_scheduler.model_name, ckpt_step, progress.step)
                 )
-                eval_rollouts.extend(result.rollouts)
-
-            # Save eval rollouts to disk (fire-and-forget background thread)
-            if eval_rollouts:
-                step_path = get_step_path(get_rollout_dir(config.output_dir), progress.step)
-                await asyncio.to_thread(save_rollouts, eval_rollouts, step_path / "eval_rollouts.jsonl")
-
-            # Resume weight updates
-            train_scheduler.resume()
+            else:
+                # Non-overlapping mode: pause train scheduling during eval
+                train_scheduler.pause()
+                await _run_eval(eval_scheduler, envs_to_eval, train_scheduler.model_name, ckpt_step, progress.step)
+                train_scheduler.resume()
 
         # Update prev_ckpt_step for next iteration
         prev_ckpt_step = ckpt_step
@@ -706,25 +721,13 @@ async def orchestrate(config: OrchestratorConfig):
         if heart is not None:
             heart.beat()
 
+    # Await any pending overlapping eval before final eval
+    if eval_task is not None and not eval_task.done():
+        await eval_task
+
     if config.eval and eval_envs is not None and eval_scheduler is not None:
         logger.info("Running final evals")
-        eval_rollouts = []
-        async for result in eval_scheduler.evaluate_envs(list(eval_envs), model_name=train_scheduler.model_name):
-            log_eval_metrics(
-                env_name=result.env_name,
-                rollouts=result.rollouts,
-                total_rollouts=result.total_rollouts,
-                rollouts_per_example=result.rollouts_per_example,
-                eval_time=result.eval_time,
-                ckpt_step=ckpt_step,
-                step=progress.step,
-            )
-            eval_rollouts.extend(result.rollouts)
-
-        # Save final eval rollouts to disk
-        if eval_rollouts:
-            step_path = get_step_path(get_rollout_dir(config.output_dir), progress.step)
-            await asyncio.to_thread(save_rollouts, eval_rollouts, step_path / "eval_rollouts.jsonl")
+        await _run_eval(eval_scheduler, list(eval_envs), train_scheduler.model_name, ckpt_step, progress.step)
 
     # Log final (immutable) samples and distributions to monitor(s)
     monitor.log_final_samples()

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -221,6 +221,7 @@ async def orchestrate(config: OrchestratorConfig):
         train_envs=train_envs,
         inference_pool=inference_pool,
         buffer=buffer,
+        progress=progress,
         rollout_limiter=rollout_limiter,
         batch_size=config.batch_size,
         token_batch_size=config.token_batch_size,
@@ -235,6 +236,7 @@ async def orchestrate(config: OrchestratorConfig):
         policy_scheduler = PolicyScheduler(
             train_scheduler=train_scheduler,
             inference_pool=inference_pool,
+            progress=progress,
             output_dir=config.output_dir,
             max_async_level=config.max_async_level,
             strict_async_level=config.strict_async_level,
@@ -360,7 +362,7 @@ async def orchestrate(config: OrchestratorConfig):
     if policy_scheduler:
         await policy_scheduler.maybe_update(progress.step)
         policy_loop_task = asyncio.create_task(policy_scheduler.run())
-    await train_scheduler.start(step=progress.step)
+    await train_scheduler.start()
     is_first_step = True
     eval_task: asyncio.Task | None = None
 
@@ -728,7 +730,6 @@ async def orchestrate(config: OrchestratorConfig):
         # Increment step and advance train scheduler to next batch
         progress.step += 1
         is_first_step = False
-        train_scheduler.advance_step(progress.step)
 
         # Free large per-step objects to prevent memory accumulation
         del train_rollouts, train_examples, training_batch, vlm_cache

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -30,14 +30,16 @@ monkey_patch_chat_completion_logprobs()
 
 import pandas as pd
 import verifiers as vf
+from aiolimiter import AsyncLimiter
 from transformers import AutoProcessor, AutoTokenizer
 
 from prime_rl.configs.orchestrator import OrchestratorConfig
 from prime_rl.orchestrator.buffer import Buffer
 from prime_rl.orchestrator.ckpt import Progress, setup_ckpt_manager
+from prime_rl.orchestrator.concurrency import ConcurrencyLimiter
 from prime_rl.orchestrator.envs import EvalEnv, EvalEnvs, TrainEnvs
 from prime_rl.orchestrator.filters import apply_filters, setup_filters
-from prime_rl.orchestrator.scheduler import Scheduler
+from prime_rl.orchestrator.scheduler import EvalScheduler, Scheduler
 from prime_rl.orchestrator.utils import (
     compute_teacher_logprobs,
     get_weight_dir,
@@ -195,6 +197,7 @@ async def orchestrate(config: OrchestratorConfig):
     logger.success("Train environment(s) ready")
 
     eval_envs: EvalEnvs | None = None
+    eval_scheduler: EvalScheduler | None = None
     if config.eval:
         logger.info("Loading eval environment(s)")
         eval_envs = EvalEnvs(config.eval.env)
@@ -222,20 +225,29 @@ async def orchestrate(config: OrchestratorConfig):
         else:
             checkpoint_step = config.ckpt.resume_step
 
+    concurrency_limiter = ConcurrencyLimiter(config.max_inflight_rollouts)
+    rate_limiter = AsyncLimiter(max_rate=config.tasks_per_minute, time_period=60) if config.tasks_per_minute else None
     scheduler = Scheduler(
         train_envs=train_envs,
         buffer=buffer,
         inference_pool=inference_pool,
-        max_inflight_rollouts=config.max_inflight_rollouts,
+        concurrency_limiter=concurrency_limiter,
         max_async_level=config.max_async_level,
         max_off_policy_steps=config.max_off_policy_steps,
         strict_async_level=config.strict_async_level,
-        tasks_per_minute=config.tasks_per_minute,
+        rate_limiter=rate_limiter,
         enable_policy_updates=enable_policy_updates,
         lora_name=config.model.lora.name if config.model.lora else None,
         config=config,
     )
     scheduler.model_name = rollout_model_name
+
+    if eval_envs is not None:
+        eval_scheduler = EvalScheduler(
+            concurrency_limiter=concurrency_limiter,
+            inference_pool=inference_pool,
+            rate_limiter=rate_limiter,
+        )
 
     if checkpoint_step is not None and config.model.lora is not None and enable_policy_updates:
         assert config.model.lora.name is not None
@@ -371,11 +383,12 @@ async def orchestrate(config: OrchestratorConfig):
                 logger.info("Cancelling in-flight training rollouts before starting evals to avoid congestion.")
                 await scheduler.cancel_inflight_rollouts()
 
+            assert eval_scheduler is not None
             eval_results = await asyncio.gather(
                 *[
-                    eval_env.evaluate(
+                    eval_scheduler.evaluate(
+                        eval_env=eval_env,
                         model_name=scheduler.model_name,
-                        get_client=inference_pool.get_eval_client,
                         ckpt_step=ckpt_step,
                         step=progress.step,
                     )
@@ -692,13 +705,13 @@ async def orchestrate(config: OrchestratorConfig):
         if heart is not None:
             heart.beat()
 
-    if config.eval and eval_envs is not None:
+    if config.eval and eval_envs is not None and eval_scheduler is not None:
         logger.info("Running final evals")
         eval_results = await asyncio.gather(
             *[
-                eval_env.evaluate(
+                eval_scheduler.evaluate(
+                    eval_env=eval_env,
                     model_name=scheduler.model_name,
-                    get_client=inference_pool.get_eval_client,
                     ckpt_step=ckpt_step,
                     step=progress.step,
                 )

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -439,12 +439,12 @@ async def orchestrate(config: OrchestratorConfig):
 
         # Enforce async barrier: don't schedule new rollouts until policy is fresh
         if policy_scheduler:
-            await policy_scheduler.wait_for_async_barrier()
-        train_scheduler.resume()
+            await policy_scheduler.wait_for_barrier()
 
         # Wait for the train batch to complete (background loops are always running)
-        train_rollouts = await train_scheduler.wait_for_batch()
-        generate_completions_time = train_scheduler.last_batch_generation_time
+        batch = await train_scheduler.next_batch()
+        train_rollouts = batch.rollouts
+        generate_completions_time = batch.generation_time
 
         # Save train rollouts to disk (fire-and-forget background thread)
         step_path = get_step_path(get_rollout_dir(config.output_dir), progress.step)
@@ -718,7 +718,7 @@ async def orchestrate(config: OrchestratorConfig):
             )
 
         reward_mean = by_example.reward.mean().mean()
-        off_policy_levels = train_scheduler._off_policy_levels()
+        off_policy_levels = train_scheduler.off_policy_levels()
         max_off_policy = max(off_policy_levels) if off_policy_levels else 0
         async_level = policy_scheduler.async_level if policy_scheduler else 0
         step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Reward: {reward_mean:.4f} | Seq. Length: {by_example.seq_len.mean().mean():.1f} tokens/sample | Async Level: {async_level} | Max. Off-Policy Level: {max_off_policy}"

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -38,7 +38,7 @@ from prime_rl.orchestrator.ckpt import Progress, setup_ckpt_manager
 from prime_rl.orchestrator.concurrency import RolloutLimiter
 from prime_rl.orchestrator.envs import EvalEnvs, TrainEnvs
 from prime_rl.orchestrator.filters import apply_filters, setup_filters
-from prime_rl.orchestrator.scheduler import EvalScheduler, PolicyScheduler, TrainScheduler
+from prime_rl.orchestrator.scheduler import EvalScheduler, PolicyScheduler, RolloutDispatcher, TrainScheduler
 from prime_rl.orchestrator.utils import (
     compute_teacher_logprobs,
     get_weight_dir,
@@ -219,12 +219,13 @@ async def orchestrate(config: OrchestratorConfig):
         max_rollouts_per_minute=config.max_rollouts_per_minute,
     )
 
+    dispatcher = RolloutDispatcher(limiter=rollout_limiter, inference_pool=inference_pool)
+
     train_scheduler = TrainScheduler(
         train_envs=train_envs,
-        inference_pool=inference_pool,
+        dispatcher=dispatcher,
         buffer=buffer,
         progress=progress,
-        rollout_limiter=rollout_limiter,
         batch_size=config.batch_size,
         token_batch_size=config.token_batch_size,
         rollouts_per_example=config.rollouts_per_example,
@@ -247,10 +248,7 @@ async def orchestrate(config: OrchestratorConfig):
         )
 
     if eval_envs is not None:
-        eval_scheduler = EvalScheduler(
-            rollout_limiter=rollout_limiter,
-            inference_pool=inference_pool,
-        )
+        eval_scheduler = EvalScheduler(dispatcher=dispatcher)
 
     # Get checkpoint manager
     logger.info(f"Initializing checkpoint manager ({config.ckpt})")

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -229,6 +229,7 @@ async def orchestrate(config: OrchestratorConfig):
         token_batch_size=config.token_batch_size,
         rollouts_per_example=config.rollouts_per_example,
         max_off_policy_steps=config.max_off_policy_steps,
+        max_async_level=config.max_async_level,
         model_name=rollout_model_name,
         json_logging=config.log.json_logging,
     )
@@ -241,6 +242,7 @@ async def orchestrate(config: OrchestratorConfig):
             output_dir=config.output_dir,
             lora_name=config.model.lora.name if config.model.lora else None,
         )
+        train_scheduler.policy_scheduler = policy_scheduler
 
     if eval_envs is not None:
         eval_scheduler = EvalScheduler(
@@ -304,7 +306,6 @@ async def orchestrate(config: OrchestratorConfig):
         ckpt_manager.load(progress, buffer, step=checkpoint_step)
         logger.info(f"Resuming training from checkpoint step {checkpoint_step}")
         resume_ckpt_step = progress.step
-        train_scheduler.ckpt_step = resume_ckpt_step
         if policy_scheduler:
             policy_scheduler.ckpt_step = resume_ckpt_step
         if config.eval and config.eval.skip_eval_on_resume:
@@ -365,9 +366,8 @@ async def orchestrate(config: OrchestratorConfig):
             reason = evicted_path.read_text().strip()
             raise RuntimeError(f"Run evicted by trainer: {reason}")
 
-        # Capture ckpt_step once for consistency
-        ckpt_step = policy_scheduler.ckpt_step if policy_scheduler else progress.step
-        train_scheduler.ckpt_step = ckpt_step
+        # Capture ckpt_step once for consistency (read from policy scheduler or use current step)
+        ckpt_step = train_scheduler.ckpt_step
 
         # Save checkpoint (if we are at an interval step and not at the first or last step)
         is_last_step = config.max_steps is not None and progress.step == config.max_steps - 1

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -35,10 +35,10 @@ from transformers import AutoProcessor, AutoTokenizer
 from prime_rl.configs.orchestrator import OrchestratorConfig
 from prime_rl.orchestrator.buffer import Buffer
 from prime_rl.orchestrator.ckpt import Progress, setup_ckpt_manager
-from prime_rl.orchestrator.concurrency import ConcurrencyLimiter, RateLimiter
+from prime_rl.orchestrator.concurrency import RolloutLimiter
 from prime_rl.orchestrator.envs import EvalEnvs, TrainEnvs
 from prime_rl.orchestrator.filters import apply_filters, setup_filters
-from prime_rl.orchestrator.scheduler import EvalScheduler, Scheduler
+from prime_rl.orchestrator.scheduler import EvalScheduler, TrainScheduler
 from prime_rl.orchestrator.utils import (
     compute_teacher_logprobs,
     get_weight_dir,
@@ -224,33 +224,33 @@ async def orchestrate(config: OrchestratorConfig):
         else:
             checkpoint_step = config.ckpt.resume_step
 
-    concurrency_limiter = ConcurrencyLimiter(config.max_inflight_rollouts)
-    rate_limiter = RateLimiter(max_rate=config.tasks_per_minute, time_period=60) if config.tasks_per_minute else None
-    scheduler = Scheduler(
+    rollout_limiter = RolloutLimiter(
+        max_concurrency=config.max_inflight_rollouts,
+        max_rate=config.tasks_per_minute,
+    )
+    train_scheduler = TrainScheduler(
         train_envs=train_envs,
         buffer=buffer,
         inference_pool=inference_pool,
-        concurrency_limiter=concurrency_limiter,
+        rollout_limiter=rollout_limiter,
         max_async_level=config.max_async_level,
         max_off_policy_steps=config.max_off_policy_steps,
         strict_async_level=config.strict_async_level,
-        rate_limiter=rate_limiter,
         enable_policy_updates=enable_policy_updates,
         lora_name=config.model.lora.name if config.model.lora else None,
         config=config,
     )
-    scheduler.model_name = rollout_model_name
+    train_scheduler.model_name = rollout_model_name
 
     if eval_envs is not None:
         eval_scheduler = EvalScheduler(
-            concurrency_limiter=concurrency_limiter,
+            rollout_limiter=rollout_limiter,
             inference_pool=inference_pool,
-            rate_limiter=rate_limiter,
         )
 
     if checkpoint_step is not None and config.model.lora is not None and enable_policy_updates:
         assert config.model.lora.name is not None
-        scheduler.model_name = config.model.lora.name
+        train_scheduler.model_name = config.model.lora.name
 
     # Check health of the inference pool
     logger.info("Waiting for inference pool to be ready")
@@ -294,24 +294,24 @@ async def orchestrate(config: OrchestratorConfig):
     if checkpoint_step is not None and ckpt_manager is not None:
         ckpt_manager.load(progress, buffer, step=checkpoint_step)
         logger.info(f"Resuming training from checkpoint step {checkpoint_step}")
-        scheduler.ckpt_step = progress.step  # Always resume from the latest checkpoint
+        train_scheduler.ckpt_step = progress.step  # Always resume from the latest checkpoint
         if config.eval and config.eval.skip_eval_on_resume:
-            prev_ckpt_step = scheduler.ckpt_step
-            last_eval_steps = {name: scheduler.ckpt_step for name in last_eval_steps}
-            logger.info(f"Skipping online eval on resume (ckpt_step={scheduler.ckpt_step})")
+            prev_ckpt_step = train_scheduler.ckpt_step
+            last_eval_steps = {name: train_scheduler.ckpt_step for name in last_eval_steps}
+            logger.info(f"Skipping online eval on resume (ckpt_step={train_scheduler.ckpt_step})")
         else:
             # Allow eval at resumed step by setting prev_ckpt_step one behind
-            prev_ckpt_step = scheduler.ckpt_step - 1
+            prev_ckpt_step = train_scheduler.ckpt_step - 1
 
         if enable_policy_updates:
             # In NCCL mode, skip existence check - weights are broadcasted, not stored on disk
             check_exists = config.weight_broadcast.type != "nccl"
             wait_timeout = config.ckpt.wait_for_weights_timeout if config.ckpt else None
             weights_path = get_weight_dir(
-                config.output_dir, scheduler.ckpt_step, check_exists=check_exists, wait_timeout=wait_timeout
+                config.output_dir, train_scheduler.ckpt_step, check_exists=check_exists, wait_timeout=wait_timeout
             )
             lora_name = config.model.lora.name if config.model.lora else None
-            await inference_pool.update_weights(weights_path, lora_name=lora_name, step=scheduler.ckpt_step)
+            await inference_pool.update_weights(weights_path, lora_name=lora_name, step=train_scheduler.ckpt_step)
     else:
         logger.info("Training from scratch")
 
@@ -327,8 +327,8 @@ async def orchestrate(config: OrchestratorConfig):
             raise RuntimeError(f"Run evicted by trainer: {reason}")
 
         # Capture ckpt_step once for consistency (it's updated inside the scheduler)
-        ckpt_step = scheduler.ckpt_step if enable_policy_updates else progress.step
-        scheduler.ckpt_step = ckpt_step
+        ckpt_step = train_scheduler.ckpt_step if enable_policy_updates else progress.step
+        train_scheduler.ckpt_step = ckpt_step
 
         # Save checkpoint (if we are at an interval step and not at the first or last step)
         is_last_step = config.max_steps is not None and progress.step == config.max_steps - 1
@@ -352,7 +352,7 @@ async def orchestrate(config: OrchestratorConfig):
         step_start_time = time.perf_counter()
 
         # Run evals BEFORE training (blocking). Weight updates are paused via
-        # scheduler.checkpoint_ready during eval to ensure consistent weights.
+        # train_scheduler.checkpoint_ready during eval to ensure consistent weights.
         # Each eval env has its own interval, so we check each independently.
         envs_to_eval = []
         if config.eval:
@@ -375,16 +375,16 @@ async def orchestrate(config: OrchestratorConfig):
 
             # Pause weight updates and re-scheduling of training rollouts during eval
             # to avoid evaluating across different checkpoints and avoid congestion
-            scheduler.checkpoint_ready.clear()
+            train_scheduler.checkpoint_ready.clear()
 
             # For heavy eval workloads, it might be necessary additionally cancel in-flight training rollouts
             if config.eval.cancel_inflight_rollouts_on_eval:
                 logger.info("Cancelling in-flight training rollouts before starting evals to avoid congestion.")
-                await scheduler.cancel_inflight_rollouts()
+                await train_scheduler.cancel_inflight_rollouts()
 
             assert eval_scheduler is not None
             eval_rollouts: list[vf.RolloutOutput] = []
-            async for result in eval_scheduler.run(envs_to_eval, model_name=scheduler.model_name):
+            async for result in eval_scheduler.run(envs_to_eval, model_name=train_scheduler.model_name):
                 log_eval_metrics(
                     env_name=result.env_name,
                     rollouts=result.rollouts,
@@ -402,17 +402,17 @@ async def orchestrate(config: OrchestratorConfig):
                 await asyncio.to_thread(save_rollouts, eval_rollouts, step_path / "eval_rollouts.jsonl")
 
             # Resume weight updates
-            scheduler.checkpoint_ready.set()
+            train_scheduler.checkpoint_ready.set()
 
         # Update prev_ckpt_step for next iteration
         prev_ckpt_step = ckpt_step
 
         # Schedule generating the training batch
-        train_task = asyncio.create_task(scheduler.generate_batch(step=progress.step))
+        train_task = asyncio.create_task(train_scheduler.generate_batch(step=progress.step))
 
         # Await train rollouts
         await train_task
-        generate_completions_time = scheduler.last_batch_generation_time
+        generate_completions_time = train_scheduler.last_batch_generation_time
         train_rollouts = train_task.result()
 
         # Save train rollouts to disk (fire-and-forget background thread)
@@ -617,7 +617,7 @@ async def orchestrate(config: OrchestratorConfig):
             "time/save_ckpt": save_ckpt_time,
             "time/parallel_preprocess": parallel_preprocess_time,
             # Scheduler metrics
-            **scheduler.get_metrics(),
+            **train_scheduler.get_metrics(),
             # Buffer metrics
             **buffer.get_metrics(),
             # Event loop lag metrics
@@ -686,7 +686,7 @@ async def orchestrate(config: OrchestratorConfig):
             )
 
         reward_mean = by_example.reward.mean().mean()
-        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Reward: {reward_mean:.4f} | Seq. Length: {by_example.seq_len.mean().mean():.1f} tokens/sample | Async Level: {scheduler.async_level} | Max. Off-Policy Level: {scheduler.max_off_policy_level}"
+        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Reward: {reward_mean:.4f} | Seq. Length: {by_example.seq_len.mean().mean():.1f} tokens/sample | Async Level: {train_scheduler.async_level} | Max. Off-Policy Level: {train_scheduler.max_off_policy_level}"
         logger.success(step_message)
 
         # Increment step
@@ -707,7 +707,7 @@ async def orchestrate(config: OrchestratorConfig):
     if config.eval and eval_envs is not None and eval_scheduler is not None:
         logger.info("Running final evals")
         eval_rollouts: list[vf.RolloutOutput] = []
-        async for result in eval_scheduler.run(list(eval_envs), model_name=scheduler.model_name):
+        async for result in eval_scheduler.run(list(eval_envs), model_name=train_scheduler.model_name):
             log_eval_metrics(
                 env_name=result.env_name,
                 rollouts=result.rollouts,
@@ -742,7 +742,7 @@ async def orchestrate(config: OrchestratorConfig):
     # failure mode we're guarding against.
     async def _graceful_shutdown() -> None:
         training_batch_sender.close()
-        await scheduler.stop()
+        await train_scheduler.stop()
         await inference_pool.stop()
         if teacher_inference_pool is not None:
             await teacher_inference_pool.stop()

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -219,16 +219,20 @@ async def orchestrate(config: OrchestratorConfig):
 
     train_scheduler = TrainScheduler(
         train_envs=train_envs,
-        buffer=buffer,
         inference_pool=inference_pool,
+        buffer=buffer,
         rollout_limiter=rollout_limiter,
+        output_dir=config.output_dir,
+        batch_size=config.batch_size,
+        token_batch_size=config.token_batch_size,
+        rollouts_per_example=config.rollouts_per_example,
         max_async_level=config.max_async_level,
         max_off_policy_steps=config.max_off_policy_steps,
         strict_async_level=config.strict_async_level,
         enable_policy_updates=enable_policy_updates,
         model_name=rollout_model_name,
+        json_logging=config.log.json_logging,
         lora_name=config.model.lora.name if config.model.lora else None,
-        config=config,
     )
 
     if eval_envs is not None:
@@ -704,7 +708,8 @@ async def orchestrate(config: OrchestratorConfig):
         reward_mean = by_example.reward.mean().mean()
         off_policy_levels = train_scheduler._off_policy_levels()
         max_off_policy = max(off_policy_levels) if off_policy_levels else 0
-        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Reward: {reward_mean:.4f} | Seq. Length: {by_example.seq_len.mean().mean():.1f} tokens/sample | Async Level: {train_scheduler.async_level} | Max. Off-Policy Level: {max_off_policy}"
+        async_level = train_scheduler.policy.async_level if train_scheduler.policy else 0
+        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Reward: {reward_mean:.4f} | Seq. Length: {by_example.seq_len.mean().mean():.1f} tokens/sample | Async Level: {async_level} | Max. Off-Policy Level: {max_off_policy}"
         logger.success(step_message)
 
         # Increment step and advance train scheduler to next batch

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -252,6 +252,8 @@ async def orchestrate(config: OrchestratorConfig):
     if checkpoint_step is not None and config.model.lora is not None and enable_policy_updates:
         assert config.model.lora.name is not None
         train_scheduler.model_name = config.model.lora.name
+        if train_scheduler.policy:
+            train_scheduler.policy.model_name = config.model.lora.name
 
     # Check health of the inference pool
     logger.info("Waiting for inference pool to be ready")

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -702,7 +702,9 @@ async def orchestrate(config: OrchestratorConfig):
             )
 
         reward_mean = by_example.reward.mean().mean()
-        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Reward: {reward_mean:.4f} | Seq. Length: {by_example.seq_len.mean().mean():.1f} tokens/sample | Async Level: {train_scheduler.async_level} | Max. Off-Policy Level: {train_scheduler.max_off_policy_level}"
+        off_policy_levels = train_scheduler._off_policy_levels()
+        max_off_policy = max(off_policy_levels) if off_policy_levels else 0
+        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Reward: {reward_mean:.4f} | Seq. Length: {by_example.seq_len.mean().mean():.1f} tokens/sample | Async Level: {train_scheduler.async_level} | Max. Off-Policy Level: {max_off_policy}"
         logger.success(step_message)
 
         # Increment step and advance train scheduler to next batch

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -440,6 +440,10 @@ async def orchestrate(config: OrchestratorConfig):
         # Update prev_ckpt_step for next iteration
         prev_ckpt_step = ckpt_step
 
+        # Enforce async barrier before accepting the next batch
+        if policy_scheduler:
+            await policy_scheduler.wait_until_ready()
+
         # Wait for the train batch to complete (background loops are always running)
         train_rollouts = await train_scheduler.wait_for_batch()
         generate_completions_time = train_scheduler.last_batch_generation_time

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -229,6 +229,7 @@ async def orchestrate(config: OrchestratorConfig):
         token_batch_size=config.token_batch_size,
         rollouts_per_example=config.rollouts_per_example,
         max_off_policy_steps=config.max_off_policy_steps,
+        max_retries=config.max_rollout_retries,
         model_name=rollout_model_name,
         json_logging=config.log.json_logging,
     )
@@ -442,9 +443,7 @@ async def orchestrate(config: OrchestratorConfig):
             await policy_scheduler.wait_for_barrier()
 
         # Wait for the train batch to complete (background loops are always running)
-        batch = await train_scheduler.next_batch()
-        train_rollouts = batch.rollouts
-        generate_completions_time = batch.generation_time
+        train_rollouts, generate_completions_time = await train_scheduler.next_batch()
 
         # Save train rollouts to disk (fire-and-forget background thread)
         step_path = get_step_path(get_rollout_dir(config.output_dir), progress.step)

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -403,7 +403,7 @@ async def orchestrate(config: OrchestratorConfig):
                 logger.info("Cancelling in-flight training rollouts before starting evals to avoid congestion.")
                 await train_scheduler.cancel_inflight_rollouts()
 
-            if config.eval.overlap_train_and_eval_rollouts:
+            if config.eval.overlap_with_train_rollouts:
                 # Overlapping mode: eval runs concurrently with training via the shared limiter.
                 # At most one eval task runs at a time — warn if the previous one hasn't finished.
                 if eval_task is not None and not eval_task.done():

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -360,7 +360,7 @@ async def orchestrate(config: OrchestratorConfig):
     logger.info(f"Starting orchestrator loop (max_steps={config.max_steps or 'infinite'})")
     policy_loop_task: asyncio.Task | None = None
     if policy_scheduler:
-        await policy_scheduler.maybe_update(progress.step)
+        await policy_scheduler.maybe_update()
         policy_loop_task = asyncio.create_task(policy_scheduler.run())
     await train_scheduler.start()
     is_first_step = True

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -360,7 +360,6 @@ async def orchestrate(config: OrchestratorConfig):
     logger.info(f"Starting orchestrator loop (max_steps={config.max_steps or 'infinite'})")
     policy_loop_task: asyncio.Task | None = None
     if policy_scheduler:
-        await policy_scheduler.maybe_update()
         policy_loop_task = asyncio.create_task(policy_scheduler.run())
     await train_scheduler.start()
     is_first_step = True

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -706,7 +706,7 @@ async def orchestrate(config: OrchestratorConfig):
 
     if config.eval and eval_envs is not None and eval_scheduler is not None:
         logger.info("Running final evals")
-        eval_rollouts: list[vf.RolloutOutput] = []
+        eval_rollouts = []
         async for result in eval_scheduler.run(list(eval_envs), model_name=train_scheduler.model_name):
             log_eval_metrics(
                 env_name=result.env_name,

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -104,9 +104,9 @@ class PolicyScheduler:
         lora_name: str | None = None,
     ):
         self.logger = get_logger()
-        self._train = train_scheduler
+        self.train_scheduler = train_scheduler
         self.inference_pool = inference_pool
-        self.config = config
+        self.output_dir = config.output_dir
         self.max_async_level = max_async_level
         self.strict_async_level = strict_async_level
         self.model_name = model_name
@@ -115,62 +115,6 @@ class PolicyScheduler:
         self.ckpt_step = 0
         self.update_weights_time = 0.0
         self.wait_for_ckpt_time = 0.0
-        self._inflight_task: asyncio.Task | None = None
-        self._lock = asyncio.Lock()
-
-    def _compute_next_ckpt_step(self, step: int) -> int:
-        latest_ckpt_step = get_latest_ckpt_step(get_broadcast_dir(self.config.output_dir)) or 0
-        async_away_ckpt_step = max(step - self.max_async_level, 0)
-        if self.strict_async_level:
-            return async_away_ckpt_step
-        return max(async_away_ckpt_step, latest_ckpt_step)
-
-    async def _apply_update(self, next_ckpt_step: int, step: int) -> None:
-        async_away_ckpt_step = max(step - self.max_async_level, 0)
-        if next_ckpt_step == async_away_ckpt_step:
-            self.logger.info(
-                f"Orchestrator paused: waiting for trainer process to complete checkpoint {next_ckpt_step} "
-                f"(>{self.max_async_level} step(s) ahead). Training is progressing normally."
-            )
-            self._train.pause()
-            t0 = time.perf_counter()
-            await wait_for_path(get_step_path(get_broadcast_dir(self.config.output_dir), next_ckpt_step) / "STABLE")
-            self.wait_for_ckpt_time = time.perf_counter() - t0
-            self.logger.info(
-                f"Orchestrator resumed: checkpoint {next_ckpt_step} ready (after {self.wait_for_ckpt_time:.2f}s)"
-            )
-
-        self.logger.debug(f"Got new policy with step {next_ckpt_step}. Updating weights.")
-
-        t0 = time.perf_counter()
-        weights_path = get_step_path(get_broadcast_dir(self.config.output_dir), next_ckpt_step)
-        await self.inference_pool.update_weights(weights_path, lora_name=self.lora_name, step=next_ckpt_step)
-        self.update_weights_time = time.perf_counter() - t0
-        self.logger.debug(f"Updated weights to step {next_ckpt_step} in {self.update_weights_time:.2f}s")
-
-        self.ckpt_step = next_ckpt_step
-        if self.lora_name is not None:
-            self.model_name = self.lora_name
-            self._train.model_name = self.lora_name
-            self.inference_pool.update_model_name(self.model_name)
-
-        self._train.resume()
-        await self._train.drop_stale_groups(next_ckpt_step)
-
-    async def _get_or_start_update_task(self, next_ckpt_step: int, step: int) -> asyncio.Task:
-        async with self._lock:
-            if self._inflight_task is not None and not self._inflight_task.done():
-                return self._inflight_task
-
-            task = asyncio.create_task(self._apply_update(next_ckpt_step, step))
-            self._inflight_task = task
-
-            def _clear(done_task: asyncio.Task) -> None:
-                if self._inflight_task is done_task:
-                    self._inflight_task = None
-
-            task.add_done_callback(_clear)
-            return task
 
     async def maybe_update(self, step: int) -> None:
         """Check for and apply any pending policy updates."""
@@ -178,19 +122,50 @@ class PolicyScheduler:
             next_ckpt_step = self._compute_next_ckpt_step(step)
             if next_ckpt_step <= self.ckpt_step:
                 return
-            task = await self._get_or_start_update_task(next_ckpt_step, step)
-            await asyncio.shield(task)
+            await self._apply_update(next_ckpt_step, step)
 
-    async def run(self, step_fn) -> None:
-        """Background loop. step_fn returns the current training step."""
+    async def run(self) -> None:
+        """Background loop. Reads current step from train_scheduler.step."""
         while True:
-            await self.maybe_update(step_fn())
+            await self.maybe_update(self.train_scheduler.step)
             await asyncio.sleep(1)
 
-    async def stop(self) -> None:
-        if self._inflight_task is not None:
-            await safe_cancel(self._inflight_task)
-            self._inflight_task = None
+    def _compute_next_ckpt_step(self, step: int) -> int:
+        latest_ckpt_step = get_latest_ckpt_step(get_broadcast_dir(self.output_dir)) or 0
+        async_away_ckpt_step = max(step - self.max_async_level, 0)
+        if self.strict_async_level:
+            return async_away_ckpt_step
+        return max(async_away_ckpt_step, latest_ckpt_step)
+
+    async def _apply_update(self, next_ckpt_step: int, step: int) -> None:
+        # Wait for checkpoint if we're at the async barrier
+        async_away_ckpt_step = max(step - self.max_async_level, 0)
+        if next_ckpt_step == async_away_ckpt_step:
+            self.logger.info(
+                f"Orchestrator paused: waiting for checkpoint {next_ckpt_step} (>{self.max_async_level} step(s) ahead)"
+            )
+            self.train_scheduler.pause()
+            t0 = time.perf_counter()
+            await wait_for_path(get_step_path(get_broadcast_dir(self.output_dir), next_ckpt_step) / "STABLE")
+            self.wait_for_ckpt_time = time.perf_counter() - t0
+            self.logger.info(f"Checkpoint {next_ckpt_step} ready (after {self.wait_for_ckpt_time:.2f}s)")
+
+        # Update weights on inference servers
+        t0 = time.perf_counter()
+        weights_path = get_step_path(get_broadcast_dir(self.output_dir), next_ckpt_step)
+        await self.inference_pool.update_weights(weights_path, lora_name=self.lora_name, step=next_ckpt_step)
+        self.update_weights_time = time.perf_counter() - t0
+        self.logger.debug(f"Updated weights to step {next_ckpt_step} in {self.update_weights_time:.2f}s")
+
+        self.ckpt_step = next_ckpt_step
+        if self.lora_name is not None:
+            self.model_name = self.lora_name
+            self.train_scheduler.model_name = self.lora_name
+            self.inference_pool.update_model_name(self.model_name)
+
+        # Resume scheduling and drop stale rollouts
+        self.train_scheduler.resume()
+        await self.train_scheduler.drop_stale_groups(next_ckpt_step)
 
 
 # ---------------------------------------------------------------------------
@@ -308,7 +283,7 @@ class TrainScheduler:
 
         if self.policy:
             await self.policy.maybe_update(step)
-            self._policy_loop_task = asyncio.create_task(self.policy.run(lambda: self.step))
+            self._policy_loop_task = asyncio.create_task(self.policy.run())
         else:
             self.resume()
 
@@ -379,10 +354,6 @@ class TrainScheduler:
         self._scheduling_task = None
         self._completion_task = None
         self._policy_loop_task = None
-
-        if self.policy:
-            await self.policy.stop()
-
         await self.cancel_inflight_rollouts()
 
     # ------------------------------------------------------------------

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -198,8 +198,7 @@ class TrainScheduler:
         else:
             rollout_count = 1
 
-        if self.limiter.rate:
-            await self.limiter.rate.acquire(rollout_count)
+        await self.limiter.rate.acquire(rollout_count)
 
         if not self.limiter.try_acquire(rollout_count):
             return

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -150,20 +150,23 @@ class PolicyScheduler:
 
             if self.at_async_barrier:
                 logger.info(
-                    f"Waiting for checkpoint {next_ckpt_step} "
-                    f"(orchestrator is >{self.max_async_level} step(s) ahead of trainer)"
+                    f"[policy] Pausing training rollout scheduling — waiting for trainer to produce "
+                    f"checkpoint {next_ckpt_step} (>{self.max_async_level} step(s) ahead)"
                 )
                 self.train_scheduler.pause()
                 t0 = time.perf_counter()
                 await wait_for_path(get_step_path(get_broadcast_dir(self.output_dir), next_ckpt_step) / "STABLE")
                 self.wait_for_ckpt_time = time.perf_counter() - t0
-                logger.debug(f"Checkpoint {next_ckpt_step} ready (waited {self.wait_for_ckpt_time:.2f}s)")
+                logger.info(f"[policy] Checkpoint {next_ckpt_step} ready after {self.wait_for_ckpt_time:.2f}s")
 
-            logger.info(f"Updating inference weights to checkpoint {next_ckpt_step}")
+            logger.info(f"[policy] Loading weights for checkpoint {next_ckpt_step} onto inference servers")
             await self.update_weights(next_ckpt_step)
+            logger.debug(f"[policy] Weights loaded in {self.update_weights_time:.2f}s")
+
+            logger.info("[policy] Dropping stale rollouts and resuming training rollout scheduling")
             await self.train_scheduler.drop_stale_groups(next_ckpt_step)
             self.train_scheduler.resume()
-            logger.debug(f"Policy update to step {next_ckpt_step} complete ({self.update_weights_time:.2f}s)")
+            logger.debug(f"[policy] Policy update to checkpoint {next_ckpt_step} complete")
 
     async def update_weights(self, next_ckpt_step: int) -> None:
         t0 = time.perf_counter()

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -206,17 +206,12 @@ class TrainScheduler:
         inference_pool: InferencePool,
         buffer: Buffer,
         rollout_limiter: RolloutLimiter,
-        output_dir: Path,
-        batch_size: int,
-        token_batch_size: int,
+        batch_size: int | None,
+        token_batch_size: int | None,
         rollouts_per_example: int,
-        max_async_level: int,
         max_off_policy_steps: int,
-        strict_async_level: bool,
-        enable_policy_updates: bool,
         model_name: str,
-        json_logging: bool,
-        lora_name: str | None = None,
+        json_logging: bool = False,
     ):
         self.logger = get_logger()
         self.limiter = rollout_limiter
@@ -227,21 +222,8 @@ class TrainScheduler:
         self._batch_target = token_batch_size or batch_size
         self.rollouts_per_example = rollouts_per_example
         self.max_off_policy_steps = max_off_policy_steps
-        self.enable_policy_updates = enable_policy_updates
         self.model_name = model_name
         self.json_logging = json_logging
-
-        self.policy: PolicyScheduler | None = None
-        if enable_policy_updates:
-            self.policy = PolicyScheduler(
-                train_scheduler=self,
-                inference_pool=inference_pool,
-                output_dir=output_dir,
-                max_async_level=max_async_level,
-                strict_async_level=strict_async_level,
-                model_name=model_name,
-                lora_name=lora_name,
-            )
 
         # Group tracking
         self._next_group_id = 0
@@ -261,7 +243,7 @@ class TrainScheduler:
         self._completion_task: asyncio.Task | None = None
 
         self.step = 0
-        self._policy_loop_task: asyncio.Task | None = None
+        self.ckpt_step = 0
 
         # Metrics (reset per step)
         self.cancelled_rollouts_count = 0
@@ -286,30 +268,13 @@ class TrainScheduler:
     # Public API
     # ------------------------------------------------------------------
 
-    @property
-    def ckpt_step(self) -> int:
-        return self.policy.ckpt_step if self.policy else self.step
-
-    @ckpt_step.setter
-    def ckpt_step(self, value: int) -> None:
-        if self.policy:
-            self.policy.ckpt_step = value
-
     async def start(self, step: int) -> None:
         """Start background loops. Call once at the beginning of training."""
         self.step = step
-
-        if self.policy:
-            await self.policy.maybe_update(step)
-            self._policy_loop_task = asyncio.create_task(self.policy.run())
-        else:
-            self.resume()
-
         self._batch_start_time = time.perf_counter()
         self._pbar = ProgressTracker(
             total=self._batch_target, desc="Generating rollouts (train)", json_logging=self.json_logging, step=step
         )
-
         self._scheduling_task = asyncio.create_task(self._scheduling_loop())
         self._completion_task = asyncio.create_task(self._completion_loop())
 
@@ -347,8 +312,6 @@ class TrainScheduler:
     def advance_step(self, step: int) -> None:
         """Advance to the next training step and reset batch accumulation."""
         self.step = step
-
-        # Reset batch state
         self._batch_rollouts.clear()
         self._batch_progress = 0
         self._batch_ready.clear()
@@ -357,21 +320,13 @@ class TrainScheduler:
             total=self._batch_target, desc="Generating rollouts (train)", json_logging=self.json_logging, step=step
         )
 
-        # Trigger policy update check
-        if self.enable_policy_updates and self._policy_loop_task is not None:
-            # The policy loop runs continuously; it will pick up the new step
-            pass
-        elif not self.enable_policy_updates:
-            self.ckpt_step = step
-
     async def stop(self) -> None:
         """Stop all background tasks and cancel in-flight rollouts."""
-        for task in [self._scheduling_task, self._completion_task, self._policy_loop_task]:
+        for task in [self._scheduling_task, self._completion_task]:
             if task is not None:
                 await safe_cancel(task)
         self._scheduling_task = None
         self._completion_task = None
-        self._policy_loop_task = None
         await self.cancel_inflight_rollouts()
 
     # ------------------------------------------------------------------
@@ -645,8 +600,6 @@ class TrainScheduler:
         self.total_rollouts_by_env.clear()
 
         metrics.update(self.inference_pool.get_metrics())
-        if self.policy:
-            metrics.update(self.policy.get_metrics())
         return metrics
 
 

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -207,14 +207,7 @@ class TrainScheduler:
         else:
             rollout_count = 1
 
-        if not self.limiter.try_acquire(rollout_count):
-            return
-
-        try:
-            await self.limiter.rate.acquire(rollout_count)
-        except BaseException:
-            self.limiter.release(rollout_count)
-            raise
+        await self.limiter.acquire(rollout_count)
 
         if env.requires_group_scoring:
             group.rollouts_to_schedule = 0
@@ -252,23 +245,13 @@ class TrainScheduler:
         pending = sum(g.rollouts_to_schedule for g in self.groups.values())
         return self.inflight_rollout_count + pending
 
-    async def _schedule_next_request(self) -> bool:
-        remaining_capacity = self.limiter.remaining
-
-        if remaining_capacity <= 0:
-            return False
-
+    async def _schedule_next_request(self) -> None:
+        """Schedule one rollout request. Blocks until a concurrency slot is available."""
         for group_id, group in self.groups.items():
             if group.rollouts_to_schedule <= 0:
                 continue
-            env = self.train_envs.get(group.example["env_name"])
-            cost = group.rollouts_to_schedule if env.requires_group_scoring else 1
-            if cost <= remaining_capacity:
-                await self.schedule_rollout(group_id=group_id)
-                return True
-
-        if remaining_capacity < self.rollouts_per_example:
-            return False
+            await self.schedule_rollout(group_id=group_id)
+            return
 
         example = self.buffer.sample_examples(n=1)[0]
         group_id = self.next_group_id
@@ -278,8 +261,12 @@ class TrainScheduler:
         return True
 
     async def _fill_inflight_requests(self) -> None:
-        while await self._schedule_next_request():
-            pass
+        """Schedule requests up to available concurrency. Blocks on the first request if needed."""
+        # Always schedule at least one (blocks until capacity is available)
+        await self._schedule_next_request()
+        # Fill remaining capacity without blocking
+        while self.limiter.remaining > 0:
+            await self._schedule_next_request()
 
     async def update_policy_loop(self):
         """Continuously checks for new policy checkpoints."""
@@ -415,22 +402,6 @@ class TrainScheduler:
         while batch_progress < self.batch_target:
             await self._fill_inflight_requests()
             inflight_tasks = list(self.inflight_requests.keys())
-
-            if not inflight_tasks:
-                if self.limiter.concurrency.used > 0:
-                    # Slots are held by eval (or other consumers) — wait for capacity to free up
-                    self.logger.debug(
-                        f"Train scheduler waiting for concurrency slots "
-                        f"(used={self.limiter.concurrency.used}, remaining={self.limiter.remaining})"
-                    )
-                    await self.limiter.concurrency.wait_for_capacity(self.rollouts_per_example)
-                    continue
-                raise RuntimeError(
-                    f"No in-flight rollouts and batch incomplete ({batch_progress}/{self.batch_target}). "
-                    f"Limiter state: used={self.limiter.concurrency.used}, "
-                    f"remaining={self.limiter.remaining}. "
-                    f"This likely indicates a concurrency slot leak."
-                )
 
             finished_tasks, _ = await asyncio.wait(
                 inflight_tasks,

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -141,6 +141,7 @@ class PolicyScheduler:
                 return async_away_ckpt_step
             return max(async_away_ckpt_step, latest_ckpt_step)
 
+        logger = get_logger()
         while True:
             next_ckpt_step = get_next_ckpt_step()
             if next_ckpt_step <= self.ckpt_step:
@@ -148,14 +149,21 @@ class PolicyScheduler:
                 continue
 
             if self.at_async_barrier:
+                logger.info(
+                    f"Waiting for checkpoint {next_ckpt_step} "
+                    f"(orchestrator is >{self.max_async_level} step(s) ahead of trainer)"
+                )
                 self.train_scheduler.pause()
                 t0 = time.perf_counter()
                 await wait_for_path(get_step_path(get_broadcast_dir(self.output_dir), next_ckpt_step) / "STABLE")
                 self.wait_for_ckpt_time = time.perf_counter() - t0
+                logger.debug(f"Checkpoint {next_ckpt_step} ready (waited {self.wait_for_ckpt_time:.2f}s)")
 
+            logger.info(f"Updating inference weights to checkpoint {next_ckpt_step}")
             await self.update_weights(next_ckpt_step)
             await self.train_scheduler.drop_stale_groups(next_ckpt_step)
             self.train_scheduler.resume()
+            logger.debug(f"Policy update to step {next_ckpt_step} complete ({self.update_weights_time:.2f}s)")
 
     async def update_weights(self, next_ckpt_step: int) -> None:
         t0 = time.perf_counter()

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -210,7 +210,11 @@ class TrainScheduler:
         if not self.limiter.try_acquire(rollout_count):
             return
 
-        await self.limiter.rate.acquire(rollout_count)
+        try:
+            await self.limiter.rate.acquire(rollout_count)
+        except BaseException:
+            self.limiter.release(rollout_count)
+            raise
 
         if env.requires_group_scoring:
             group.rollouts_to_schedule = 0
@@ -536,6 +540,8 @@ class TrainScheduler:
             "scheduler/async_level": self.async_level,
             "scheduler/inflight_rollouts": self.inflight_rollout_count,
             "scheduler/inflight_samples": self.inflight_sample_count,
+            "scheduler/limiter_used": self.limiter.concurrency.used,
+            "scheduler/limiter_remaining": self.limiter.remaining,
             "scheduler/cancelled_rollouts": self.cancelled_rollouts_count,
             "empty_rollouts/all": sum(self.empty_rollouts_by_env.values()) / max(total_rollouts, 1),
             "errored_rollouts/all": sum(self.errored_rollouts_by_env.values()) / max(total_rollouts, 1),

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from abc import abstractmethod
 from collections import Counter, defaultdict
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
@@ -23,33 +24,68 @@ from prime_rl.utils.utils import (
     wait_for_path,
 )
 
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
 
 @dataclass
 class InflightRequest:
-    """Metadata for an in-flight request."""
+    """Base class for an in-flight rollout API call."""
 
-    off_policy_steps: int
-    client_config: vf.ClientConfig
-    env_name: str
-    group_id: int | None = None
-    rollout_count: int = 1
+    task: asyncio.Task
+    client: vf.ClientConfig
+    off_policy_steps: int = 0
+
+    @property
+    @abstractmethod
+    def rollout_count(self) -> int: ...
 
 
 @dataclass
-class GroupState:
-    """Tracks the state of a rollout group (one example × N rollouts)."""
+class InflightRolloutRequest(InflightRequest):
+    """A single run_rollout call producing 1 rollout."""
+
+    @property
+    def rollout_count(self) -> int:
+        return 1
+
+
+@dataclass
+class InflightGroupRequest(InflightRequest):
+    """A single run_group call producing N rollouts."""
+
+    rollouts_per_example: int = 1
+
+    @property
+    def rollout_count(self) -> int:
+        return self.rollouts_per_example
+
+
+@dataclass
+class InflightGroup:
+    """Tracks one example being evaluated with N rollouts."""
 
     example: dict
-    rollouts_to_schedule: int
-    completed_rollouts: list[vf.RolloutOutput] = field(default_factory=list)
+    env_name: str
     pinned_client: vf.ClientConfig | None = None
+
+    requests: dict[asyncio.Task, InflightRequest] = field(default_factory=dict)
+    completed_rollouts: list[vf.RolloutOutput] = field(default_factory=list)
+    rollouts_to_schedule: int = 0
+
+    @property
+    def total_inflight_rollouts(self) -> int:
+        return sum(r.rollout_count for r in self.requests.values())
+
+
+# ---------------------------------------------------------------------------
+# Train scheduler
+# ---------------------------------------------------------------------------
 
 
 class TrainScheduler:
-    """
-    Asynchronously manages scheduling of rollout requests and policy updates.
-    Keeps a constant number of rollouts in-flight (continuous batching) and
-    updates the policy as soon as it becomes available.
+    """Always-on scheduler with two background loops: scheduling and completion processing.
 
     References:
     - AReal: https://arxiv.org/abs/2505.24298v1
@@ -85,193 +121,390 @@ class TrainScheduler:
         self.lora_name = lora_name
         self.model_name = model_name
         self.json_logging = config.log.json_logging
-
-        # Inference pool - used for admin operations (adapter sync) and metrics
         self.inference_pool = inference_pool
 
-        group_scoring_envs = [env.name for env in train_envs if env.requires_group_scoring]
-        if group_scoring_envs:
-            self.logger.info(f"Group rollout scoring active for env(s): {', '.join(group_scoring_envs)}")
+        # Group tracking
+        self._next_group_id = 0
+        self._groups: dict[int, InflightGroup] = {}
+        self._task_to_group: dict[asyncio.Task, int] = {}
 
-        # Track in-flight requests: task -> info
-        self.inflight_requests: dict[asyncio.Task, InflightRequest] = {}
+        # Batch accumulation
+        self._batch_rollouts: list[vf.RolloutOutput] = []
+        self._batch_progress = 0
+        self._batch_ready = asyncio.Event()
+        self._pbar: ProgressTracker | None = None
 
-        # Track in-progress groups while rollouts are generated independently.
-        self.next_group_id = 0
-        self.groups: dict[int, GroupState] = {}
-
-        self.step, self.ckpt_step = 0, 0
+        # Scheduling control
         self._scheduling_enabled = asyncio.Event()
         self._scheduling_enabled.set()
+        self._scheduling_task: asyncio.Task | None = None
+        self._completion_task: asyncio.Task | None = None
+
+        # Policy update state
+        self.step, self.ckpt_step = 0, 0
         self.update_weights_time, self.wait_for_ckpt_time = 0, 0
-        self.update_policy_task: asyncio.Task | None = None
-        self.inflight_policy_update_task: asyncio.Task | None = None
-        self.policy_update_lock = asyncio.Lock()
+        self._policy_loop_task: asyncio.Task | None = None
+        self._inflight_policy_update_task: asyncio.Task | None = None
+        self._policy_update_lock = asyncio.Lock()
+
+        # Metrics (reset per step)
         self.cancelled_rollouts_count = 0
         self.empty_rollouts_by_env: dict[str, int] = defaultdict(int)
         self.errored_rollouts_by_env: dict[str, int] = defaultdict(int)
         self.total_rollouts_by_env: dict[str, int] = defaultdict(int)
         self.last_batch_generation_time = 0.0
+        self._batch_start_time = 0.0
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
 
     @property
-    def uses_token_batching(self) -> bool:
+    def _uses_token_batching(self) -> bool:
         return self.token_batch_size is not None
 
     @property
-    def batch_target(self) -> int:
-        if self.uses_token_batching:
+    def _batch_target(self) -> int:
+        if self._uses_token_batching:
             assert self.token_batch_size is not None
             return self.token_batch_size
         assert self.batch_size is not None
         return self.batch_size
 
-    def get_batch_progress_increment(self, rollouts: list[vf.RolloutOutput]) -> int:
-        if self.uses_token_batching:
-            return sum(get_seq_len(rollout) for rollout in rollouts)
-        return len(rollouts)
+    @property
+    def inflight_rollout_count(self) -> int:
+        return sum(g.total_inflight_rollouts for g in self._groups.values())
 
-    def finalize_batch_rollouts(self, rollouts: list[vf.RolloutOutput]) -> list[vf.RolloutOutput]:
-        if self.batch_size is None:
-            return rollouts
-        return rollouts[: self.batch_size]
+    @property
+    def inflight_sample_count(self) -> int:
+        pending = sum(g.rollouts_to_schedule for g in self._groups.values())
+        return self.inflight_rollout_count + pending
+
+    @property
+    def async_level(self) -> int:
+        return self.step - self.ckpt_step
+
+    @property
+    def max_off_policy_level(self) -> int:
+        steps = [r.off_policy_steps for g in self._groups.values() for r in g.requests.values()]
+        return max(steps) if steps else 0
+
+    @property
+    def mean_off_policy_level(self) -> float:
+        steps = [r.off_policy_steps for g in self._groups.values() for r in g.requests.values()]
+        return sum(steps) / len(steps) if steps else 0
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def start(self, step: int) -> None:
+        """Start background loops. Call once at the beginning of training."""
+        self.step = step
+
+        if self.enable_policy_updates:
+            await self._maybe_update_policy()
+            self._policy_loop_task = asyncio.create_task(self._policy_update_loop())
+        else:
+            self.ckpt_step = step
+            self.resume()
+
+        self._batch_start_time = time.perf_counter()
+        self._pbar = ProgressTracker(
+            total=self._batch_target, desc="Generating rollouts (train)", json_logging=self.json_logging, step=step
+        )
+
+        self._scheduling_task = asyncio.create_task(self._scheduling_loop())
+        self._completion_task = asyncio.create_task(self._completion_loop())
 
     def pause(self) -> None:
-        """Pause scheduling of new rollouts. Existing in-flight rollouts continue."""
+        """Pause scheduling. In-flight rollouts continue to completion."""
         self._scheduling_enabled.clear()
 
     def resume(self) -> None:
-        """Resume scheduling of new rollouts."""
+        """Resume scheduling."""
         self._scheduling_enabled.set()
 
-    async def cancel_inflight_rollouts(self):
-        """Cancel all in-flight rollout requests."""
-        count = sum(info.rollout_count for info in self.inflight_requests.values())
-        await safe_cancel_all(list(self.inflight_requests))
-        self.inflight_requests.clear()
-        self.groups.clear()
+    async def cancel_inflight_rollouts(self) -> None:
+        """Cancel all in-flight rollout requests and release their slots."""
+        all_tasks = list(self._task_to_group.keys())
+        count = sum(g.total_inflight_rollouts for g in self._groups.values())
+        await safe_cancel_all(all_tasks)
+        for group in self._groups.values():
+            group.requests.clear()
+        self._task_to_group.clear()
+        self._groups.clear()
         self.cancelled_rollouts_count += count
         self.limiter.release(count)
+
+    async def wait_for_batch(self) -> list[vf.RolloutOutput]:
+        """Block until the current batch is complete, then return it."""
+        await self._batch_ready.wait()
+
+        batch = self._finalize_batch()
+        self.last_batch_generation_time = time.perf_counter() - self._batch_start_time
+        if self._pbar:
+            self._pbar.close()
+            self._pbar = None
+        return batch
+
+    def advance_step(self, step: int) -> None:
+        """Advance to the next training step and reset batch accumulation."""
+        self.step = step
+
+        # Reset batch state
+        self._batch_rollouts.clear()
+        self._batch_progress = 0
+        self._batch_ready.clear()
+        self._batch_start_time = time.perf_counter()
+        self._pbar = ProgressTracker(
+            total=self._batch_target, desc="Generating rollouts (train)", json_logging=self.json_logging, step=step
+        )
+
+        # Trigger policy update check
+        if self.enable_policy_updates and self._policy_loop_task is not None:
+            # The policy loop runs continuously; it will pick up the new step
+            pass
+        elif not self.enable_policy_updates:
+            self.ckpt_step = step
+
+    async def stop(self) -> None:
+        """Stop all background tasks and cancel in-flight rollouts."""
+        for task in [self._scheduling_task, self._completion_task, self._policy_loop_task]:
+            if task is not None:
+                await safe_cancel(task)
+        self._scheduling_task = None
+        self._completion_task = None
+        self._policy_loop_task = None
+
+        if self._inflight_policy_update_task is not None:
+            await safe_cancel(self._inflight_policy_update_task)
+            self._inflight_policy_update_task = None
+
+        await self.cancel_inflight_rollouts()
+
+    # ------------------------------------------------------------------
+    # Scheduling loop
+    # ------------------------------------------------------------------
+
+    async def _scheduling_loop(self) -> None:
+        """Continuously schedule rollouts. Blocks on acquire when capacity is full."""
+        while True:
+            await self._scheduling_enabled.wait()
+
+            # Try to schedule from existing groups first (retries/pending)
+            scheduled = False
+            for group in list(self._groups.values()):
+                if group.rollouts_to_schedule > 0:
+                    await self._schedule_from_group(group)
+                    scheduled = True
+                    break
+
+            if not scheduled:
+                group = self._create_group()
+                await self._schedule_from_group(group)
+
+    def _create_group(self) -> InflightGroup:
+        """Sample an example from the buffer and create a new group."""
+        example = self.buffer.sample_examples(n=1)[0]
+        group_id = self._next_group_id
+        self._next_group_id += 1
+        group = InflightGroup(
+            example=example,
+            env_name=example["env_name"],
+            rollouts_to_schedule=self.rollouts_per_example,
+        )
+        self._groups[group_id] = group
+        return group
+
+    async def _schedule_from_group(self, group: InflightGroup) -> None:
+        """Schedule one request from a group. Blocks until a concurrency slot is available."""
+        env = self.train_envs.get(group.env_name)
+
+        if group.pinned_client is not None:
+            client = group.pinned_client
+        else:
+            client = await self._select_least_loaded_client()
+            group.pinned_client = client
+
+        if env.requires_group_scoring:
+            rollout_count = group.rollouts_to_schedule
+            await self.limiter.acquire(rollout_count)
+            group.rollouts_to_schedule = 0
+            task = asyncio.create_task(
+                env.run_group(
+                    client=client,
+                    example=group.example,
+                    model_name=self.model_name,
+                    rollouts_per_example=rollout_count,
+                )
+            )
+            request = InflightGroupRequest(task=task, client=client, rollouts_per_example=rollout_count)
+        else:
+            await self.limiter.acquire(1)
+            group.rollouts_to_schedule -= 1
+            task = asyncio.create_task(
+                env.run_rollout(
+                    client=client,
+                    example=group.example,
+                    model_name=self.model_name,
+                )
+            )
+            request = InflightRolloutRequest(task=task, client=client)
+
+        group.requests[task] = request
+        group_id = self._group_id_for(group)
+        self._task_to_group[task] = group_id
+
+    # ------------------------------------------------------------------
+    # Completion loop
+    # ------------------------------------------------------------------
+
+    async def _completion_loop(self) -> None:
+        """Continuously process completed rollout tasks."""
+        while True:
+            tasks = list(self._task_to_group.keys())
+            if not tasks:
+                await asyncio.sleep(0)
+                continue
+
+            done, _ = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+            await self._scheduling_enabled.wait()
+
+            for task in done:
+                group_id = self._task_to_group.pop(task, None)
+                if group_id is None:
+                    continue
+
+                group = self._groups.get(group_id)
+                if group is None:
+                    continue
+
+                request = group.requests.pop(task, None)
+                if request is None:
+                    continue
+
+                self.limiter.release(request.rollout_count)
+                await self._process_completion(group_id, group, request)
+
+    async def _process_completion(self, group_id: int, group: InflightGroup, request: InflightRequest) -> None:
+        """Process a completed request: validate, reschedule failures, accumulate batch."""
+        env = self.train_envs.get(group.env_name)
+
+        try:
+            result = request.task.result()
+            rollouts: list[vf.RolloutOutput] = result if isinstance(result, list) else [result]
+        except asyncio.CancelledError:
+            await self._drop_group(group_id)
+            return
+        except Exception as e:
+            self.logger.warning(f"Rollout failed: {e}")
+            await self._drop_group(group_id)
+            return
+
+        self.total_rollouts_by_env[group.env_name] += len(rollouts)
+
+        valid_rollouts = []
+        has_failures = False
+        for rollout in rollouts:
+            if len(rollout["trajectory"]) == 0:
+                self.empty_rollouts_by_env[group.env_name] += 1
+                has_failures = True
+                self.logger.warning(
+                    f"Empty trajectory in group {group_id} ({group.env_name}), re-scheduling "
+                    f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete)"
+                )
+            elif rollout["error"] is not None:
+                self.errored_rollouts_by_env[group.env_name] += 1
+                has_failures = True
+                self.logger.warning(
+                    f"Rollout error in group {group_id} ({group.env_name}), re-scheduling "
+                    f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete): "
+                    f"{rollout['error']['error_chain_repr']}"
+                )
+            else:
+                rollout["env_name"] = group.env_name
+                valid_rollouts.append(rollout)
+
+        if has_failures and env.requires_group_scoring:
+            group.completed_rollouts.clear()
+            group.rollouts_to_schedule = self.rollouts_per_example
+            return
+
+        group.rollouts_to_schedule += len(rollouts) - len(valid_rollouts)
+        group.completed_rollouts.extend(valid_rollouts)
+
+        if len(group.completed_rollouts) < self.rollouts_per_example:
+            return
+
+        # Group complete — add to batch
+        completed = self._groups.pop(group_id).completed_rollouts
+        self.buffer.update(completed)
+        accepted = self.buffer.sample_rollouts(n=self.rollouts_per_example)
+
+        self._batch_rollouts.extend(accepted)
+        if self._uses_token_batching:
+            increment = sum(get_seq_len(r) for r in accepted)
+        else:
+            increment = len(accepted)
+        self._batch_progress += increment
+        if self._pbar:
+            self._pbar.update(increment)
+
+        if self._batch_progress >= self._batch_target:
+            self._batch_ready.set()
+
+    # ------------------------------------------------------------------
+    # Group management
+    # ------------------------------------------------------------------
+
+    def _group_id_for(self, group: InflightGroup) -> int:
+        """Find group_id for a group object."""
+        for gid, g in self._groups.items():
+            if g is group:
+                return gid
+        raise ValueError("Group not found")
+
+    async def _drop_group(self, group_id: int) -> int:
+        """Drop a group: cancel pending requests, release slots."""
+        group = self._groups.pop(group_id, None)
+        if group is None:
+            return 0
+
+        tasks_to_cancel = list(group.requests.keys())
+        rollout_count = sum(r.rollout_count for r in group.requests.values())
+
+        for task in tasks_to_cancel:
+            self._task_to_group.pop(task, None)
+        group.requests.clear()
+
+        await safe_cancel_all(tasks_to_cancel)
+        if rollout_count:
+            self.limiter.release(rollout_count)
+            self.cancelled_rollouts_count += rollout_count
+        return rollout_count
 
     @staticmethod
     def _client_identity(c: vf.ClientConfig) -> tuple[str, str | None]:
         return (c.api_base_url, c.extra_headers.get("X-data-parallel-rank"))
 
     async def _select_least_loaded_client(self) -> vf.ClientConfig:
-        """Select the client with the fewest in-flight tasks.
-
-        Uses (api_base_url, dp_rank) as identity rather than client_idx so that
-        load tracking survives elastic pool refreshes (which reassign indices).
-        """
+        """Select the client with the fewest in-flight tasks."""
         clients = self.inference_pool.train_clients
         while not clients:
             await asyncio.sleep(1)
             clients = self.inference_pool.train_clients
-        inflight = Counter(self._client_identity(info.client_config) for info in self.inflight_requests.values())
+        inflight = Counter(self._client_identity(r.client) for g in self._groups.values() for r in g.requests.values())
         return min(clients, key=lambda c: inflight[self._client_identity(c)])
 
-    async def drop_group(self, group_id: int) -> int:
-        """Drop a group and cancel any remaining in-flight rollouts for it. Returns the number of cancelled rollouts."""
-        tasks_to_cancel = []
-        rollout_count = 0
-        for task, info in list(self.inflight_requests.items()):
-            if info.group_id != group_id:
-                continue
-            self.inflight_requests.pop(task, None)
-            tasks_to_cancel.append(task)
-            rollout_count += info.rollout_count
-        self.groups.pop(group_id, None)
-        await safe_cancel_all(tasks_to_cancel)
-        if rollout_count:
-            self.limiter.release(rollout_count)
-        return rollout_count
+    # ------------------------------------------------------------------
+    # Policy updates
+    # ------------------------------------------------------------------
 
-    async def _schedule_rollout(self, group_id: int):
-        """Acquire a concurrency slot and launch a rollout task. Blocks until a slot is available."""
-        group = self.groups.get(group_id)
-        if group is None or group.rollouts_to_schedule <= 0:
-            return
-
-        if group.pinned_client is not None:
-            client_config = group.pinned_client
-        else:
-            client_config = await self._select_least_loaded_client()
-            if group_id not in self.groups:
-                return
-            group.pinned_client = client_config
-
-        env_name = group.example["env_name"]
-        env = self.train_envs.get(env_name)
-
-        if env.requires_group_scoring:
-            rollout_count = group.rollouts_to_schedule
-        else:
-            rollout_count = 1
-
-        await self.limiter.acquire(rollout_count)
-
-        if env.requires_group_scoring:
-            group.rollouts_to_schedule = 0
-            task = asyncio.create_task(
-                env.run_group(
-                    client=client_config,
-                    example=group.example,
-                    model_name=self.model_name,
-                    rollouts_per_example=rollout_count,
-                )
-            )
-        else:
-            group.rollouts_to_schedule -= 1
-            task = asyncio.create_task(
-                env.run_rollout(
-                    client=client_config,
-                    example=group.example,
-                    model_name=self.model_name,
-                )
-            )
-        self.inflight_requests[task] = InflightRequest(
-            off_policy_steps=0,
-            client_config=client_config,
-            env_name=env_name,
-            group_id=group_id,
-            rollout_count=rollout_count,
-        )
-
-    @property
-    def inflight_rollout_count(self) -> int:
-        return sum(info.rollout_count for info in self.inflight_requests.values())
-
-    @property
-    def inflight_sample_count(self) -> int:
-        pending = sum(g.rollouts_to_schedule for g in self.groups.values())
-        return self.inflight_rollout_count + pending
-
-    async def _scheduling_loop(self) -> None:
-        """Continuously schedule rollouts. Blocks on acquire when capacity is full.
-
-        Runs as a background task alongside generate_batch — when slots are freed
-        by completion processing, this loop wakes up and fills them.
-        """
+    async def _policy_update_loop(self) -> None:
+        """Continuously check for new policy checkpoints."""
         while True:
-            # Check existing groups first
-            scheduled = False
-            for group_id, group in list(self.groups.items()):
-                if group.rollouts_to_schedule <= 0:
-                    continue
-                await self._schedule_rollout(group_id=group_id)
-                scheduled = True
-                break
-
-            if not scheduled:
-                example = self.buffer.sample_examples(n=1)[0]
-                group_id = self.next_group_id
-                self.next_group_id += 1
-                self.groups[group_id] = GroupState(example=example, rollouts_to_schedule=self.rollouts_per_example)
-                await self._schedule_rollout(group_id=group_id)
-
-    async def update_policy_loop(self):
-        """Continuously checks for new policy checkpoints."""
-        while True:
-            await self.maybe_update_policy()
+            await self._maybe_update_policy()
             await asyncio.sleep(1)
 
     def _compute_next_ckpt_step(self) -> int:
@@ -315,23 +548,22 @@ class TrainScheduler:
         await self._update_off_policy()
 
     async def _get_or_start_policy_update_task(self, next_ckpt_step: int) -> asyncio.Task:
-        async with self.policy_update_lock:
-            task = self.inflight_policy_update_task
+        async with self._policy_update_lock:
+            task = self._inflight_policy_update_task
             if task is not None and not task.done():
                 return task
 
             task = asyncio.create_task(self._apply_policy_update(next_ckpt_step))
-            self.inflight_policy_update_task = task
+            self._inflight_policy_update_task = task
 
-            def _clear_inflight_policy_update(done_task: asyncio.Task) -> None:
-                if self.inflight_policy_update_task is done_task:
-                    self.inflight_policy_update_task = None
+            def _clear(done_task: asyncio.Task) -> None:
+                if self._inflight_policy_update_task is done_task:
+                    self._inflight_policy_update_task = None
 
-            task.add_done_callback(_clear_inflight_policy_update)
+            task.add_done_callback(_clear)
             return task
 
-    async def maybe_update_policy(self):
-        """Updates the policy to the latest available checkpoint. Aborts rollout requests that are older than the max retention steps."""
+    async def _maybe_update_policy(self) -> None:
         if not self.enable_policy_updates:
             self.ckpt_step = self.step
             self.resume()
@@ -341,191 +573,46 @@ class TrainScheduler:
             next_ckpt_step = self._compute_next_ckpt_step()
             if next_ckpt_step <= self.ckpt_step:
                 return
-
             task = await self._get_or_start_policy_update_task(next_ckpt_step)
             await asyncio.shield(task)
 
     async def _update_off_policy(self) -> None:
-        stale_group_ids = {
-            info.group_id
-            for info in self.inflight_requests.values()
-            if info.group_id is not None and info.off_policy_steps >= self.max_off_policy_steps
-        }
-        tasks_to_increment = [
-            task
-            for task, info in list(self.inflight_requests.items())
-            if info.group_id is None or info.group_id not in stale_group_ids
-        ]
+        """Increment off-policy counters and drop stale groups."""
+        stale_group_ids = set()
+        for gid, group in self._groups.items():
+            for request in group.requests.values():
+                if request.off_policy_steps >= self.max_off_policy_steps:
+                    stale_group_ids.add(gid)
+                    break
 
-        counts = await asyncio.gather(*(self.drop_group(gid) for gid in stale_group_ids))
+        groups_to_increment = [(gid, group) for gid, group in self._groups.items() if gid not in stale_group_ids]
+
+        counts = await asyncio.gather(*(self._drop_group(gid) for gid in stale_group_ids))
         removed = sum(counts)
-        for task in tasks_to_increment:
-            info = self.inflight_requests.get(task)
-            if info is None:
-                continue
-            info.off_policy_steps += 1
 
-        self.cancelled_rollouts_count += removed
+        for _, group in groups_to_increment:
+            for request in group.requests.values():
+                request.off_policy_steps += 1
+
         if removed:
             self.logger.warning(
                 f"Cancelled {removed} old rollout requests (will refill naturally). "
                 f"Consider increasing max_off_policy_steps to avoid this."
             )
 
-    async def generate_batch(self, step: int) -> list[vf.RolloutOutput]:
-        """Continuously generates a batch of rollouts.
+    # ------------------------------------------------------------------
+    # Batch helpers
+    # ------------------------------------------------------------------
 
-        Runs a background scheduling loop that acquires concurrency slots and
-        launches rollouts. The main loop processes completions as they arrive.
-        This avoids deadlocks: scheduling blocks on acquire (waiting for eval or
-        completions to free slots), while completion processing runs concurrently.
-        """
-        self.step = step
+    def _finalize_batch(self) -> list[vf.RolloutOutput]:
+        batch = list(self._batch_rollouts)
+        if self.batch_size is not None:
+            batch = batch[: self.batch_size]
+        return batch
 
-        if self.enable_policy_updates:
-            if self.update_policy_task is not None:
-                await safe_cancel(self.update_policy_task)
-            await self.maybe_update_policy()
-            self.update_policy_task = asyncio.create_task(self.update_policy_loop())
-        else:
-            self.ckpt_step = step
-            self.resume()
-
-        batch_start_time = time.perf_counter()
-        self.logger.debug("Starting to generate batch rollouts")
-
-        batch_rollouts: list[vf.RolloutOutput] = []
-        batch_progress = 0
-        pbar = ProgressTracker(
-            total=self.batch_target, desc="Generating rollouts (train)", json_logging=self.json_logging, step=step
-        )
-
-        # Background task continuously fills concurrency slots
-        scheduling_task = asyncio.create_task(self._scheduling_loop())
-
-        try:
-            while batch_progress < self.batch_target:
-                # Wait until at least one inflight task exists
-                while not self.inflight_requests:
-                    await asyncio.sleep(0)
-
-                inflight_tasks = list(self.inflight_requests.keys())
-
-                finished_tasks, _ = await asyncio.wait(
-                    inflight_tasks,
-                    return_when=asyncio.FIRST_COMPLETED,
-                )
-                await self._scheduling_enabled.wait()
-
-                for finished_task in finished_tasks:
-                    if batch_progress >= self.batch_target:
-                        break
-
-                    rollout_info = self.inflight_requests.pop(finished_task, None)
-                    if rollout_info is None:
-                        continue
-
-                    self.limiter.release(rollout_info.rollout_count)
-                    group_id = rollout_info.group_id
-                    env_name = rollout_info.env_name
-
-                    try:
-                        group = self.groups.get(group_id)
-                        if group is None:
-                            continue
-
-                        env = self.train_envs.get(env_name)
-                        result = finished_task.result()
-                        rollouts: list[vf.RolloutOutput] = result if isinstance(result, list) else [result]
-                        self.total_rollouts_by_env[env_name] += len(rollouts)
-
-                        # Check for empty/errored rollouts and reschedule
-                        valid_rollouts = []
-                        has_failures = False
-                        for rollout in rollouts:
-                            if len(rollout["trajectory"]) == 0:
-                                self.empty_rollouts_by_env[env_name] += 1
-                                has_failures = True
-                                self.logger.warning(
-                                    f"Empty trajectory in group {group_id} ({env_name}), re-scheduling "
-                                    f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete)"
-                                )
-                            elif rollout["error"] is not None:
-                                self.errored_rollouts_by_env[env_name] += 1
-                                has_failures = True
-                                self.logger.warning(
-                                    f"Rollout error in group {group_id} ({env_name}), re-scheduling "
-                                    f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete): "
-                                    f"{rollout['error']['error_chain_repr']}"
-                                )
-                            else:
-                                rollout["env_name"] = env_name
-                                valid_rollouts.append(rollout)
-
-                        if has_failures and env.requires_group_scoring:
-                            # Group scoring requires all rollouts — discard partial results, reschedule full group
-                            group.completed_rollouts.clear()
-                            group.rollouts_to_schedule = self.rollouts_per_example
-                            continue
-
-                        # For individual scoring, reschedule only the failed ones
-                        group.rollouts_to_schedule += len(rollouts) - len(valid_rollouts)
-                        group.completed_rollouts.extend(valid_rollouts)
-                        if len(group.completed_rollouts) < self.rollouts_per_example:
-                            continue
-                        completed_rollouts = self.groups.pop(group_id).completed_rollouts
-
-                    except asyncio.CancelledError:
-                        if group_id is not None:
-                            await self.drop_group(group_id)
-                        continue
-                    except Exception as e:
-                        self.logger.warning(f"Rollout failed: {e}")
-                        if group_id is not None:
-                            await self.drop_group(group_id)
-                        continue
-
-                    self.buffer.update(completed_rollouts)
-                    accepted_rollouts = self.buffer.sample_rollouts(n=self.rollouts_per_example)
-
-                    batch_rollouts.extend(accepted_rollouts)
-                    progress_increment = self.get_batch_progress_increment(accepted_rollouts)
-                    batch_progress += progress_increment
-                    pbar.update(progress_increment)
-        finally:
-            await safe_cancel(scheduling_task)
-
-        batch_rollouts = self.finalize_batch_rollouts(batch_rollouts)
-        pbar.close()
-        self.last_batch_generation_time = time.perf_counter() - batch_start_time
-        return batch_rollouts
-
-    async def stop(self) -> None:
-        await self.cancel_inflight_rollouts()
-        if self.update_policy_task is not None:
-            await safe_cancel(self.update_policy_task)
-            self.update_policy_task = None
-        if self.inflight_policy_update_task is not None:
-            await safe_cancel(self.inflight_policy_update_task)
-            self.inflight_policy_update_task = None
-
-    @property
-    def max_off_policy_level(self) -> int:
-        steps = [info.off_policy_steps for info in self.inflight_requests.values()]
-        if not steps:
-            return 0
-        return max(steps)
-
-    @property
-    def mean_off_policy_level(self) -> float:
-        steps = [info.off_policy_steps for info in self.inflight_requests.values()]
-        if not steps:
-            return 0
-        return sum(steps) / len(steps)
-
-    @property
-    def async_level(self) -> int:
-        return self.step - self.ckpt_step
+    # ------------------------------------------------------------------
+    # Metrics
+    # ------------------------------------------------------------------
 
     def get_metrics(self) -> dict[str, float]:
         total_rollouts = sum(self.total_rollouts_by_env.values())
@@ -548,8 +635,9 @@ class TrainScheduler:
             metrics[f"empty_rollouts/{env_name}"] = self.empty_rollouts_by_env.get(env_name, 0) / env_total
             metrics[f"errored_rollouts/{env_name}"] = self.errored_rollouts_by_env.get(env_name, 0) / env_total
         by_env: dict[str, list[int]] = {}
-        for info in self.inflight_requests.values():
-            by_env.setdefault(info.env_name, []).append(info.off_policy_steps)
+        for group in self._groups.values():
+            for request in group.requests.values():
+                by_env.setdefault(group.env_name, []).append(request.off_policy_steps)
         for env_name, steps in by_env.items():
             metrics[f"off_policy_level/{env_name}/max"] = max(steps)
             metrics[f"off_policy_level/{env_name}/mean"] = sum(steps) / len(steps)
@@ -558,10 +646,13 @@ class TrainScheduler:
         self.errored_rollouts_by_env.clear()
         self.total_rollouts_by_env.clear()
 
-        # Add inference pool metrics (e.g. elastic pool server counts)
         metrics.update(self.inference_pool.get_metrics())
-
         return metrics
+
+
+# ---------------------------------------------------------------------------
+# Eval scheduler (unchanged)
+# ---------------------------------------------------------------------------
 
 
 @dataclass

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -27,6 +27,61 @@ from prime_rl.utils.utils import (
 )
 
 # ---------------------------------------------------------------------------
+# Rollout dispatcher
+# ---------------------------------------------------------------------------
+
+
+class RolloutDispatcher:
+    """Shared rollout dispatch: limiter, client selection, load tracking.
+
+    Both TrainScheduler and EvalScheduler use this for acquiring limiter
+    slots, selecting the least-loaded client, and tracking per-client load.
+    """
+
+    def __init__(self, limiter: RolloutLimiter, inference_pool: InferencePool):
+        self.limiter = limiter
+        self.inference_pool = inference_pool
+        self._client_load: Counter[tuple[str, str | None]] = Counter()
+
+    async def acquire(
+        self, cost: int, client: vf.ClientConfig | None = None, priority: bool = False
+    ) -> vf.ClientConfig:
+        """Acquire limiter slots and return a client.
+
+        If *client* is provided it is reused (for pinning to a group).
+        Otherwise the least-loaded client is selected.
+        """
+        await self.limiter.acquire(cost, priority=priority)
+        if client is None:
+            clients = self.inference_pool.train_clients
+            while not clients:
+                await asyncio.sleep(1)
+                clients = self.inference_pool.train_clients
+            client = min(clients, key=lambda c: self._client_load[client_identity(c)])
+        self._client_load[client_identity(client)] += cost
+        return client
+
+    def release(self, client: vf.ClientConfig, cost: int) -> None:
+        """Release limiter slots and untrack client load."""
+        self._client_load[client_identity(client)] -= cost
+        self.limiter.release(cost)
+
+    def cancel(self, client: vf.ClientConfig | None, cost: int) -> None:
+        """Release slots + untrack load for a cancelled request (client may be None)."""
+        if client is not None:
+            self._client_load[client_identity(client)] -= cost
+        self.limiter.release(cost)
+
+    def clear(self) -> None:
+        """Reset all tracking state."""
+        self._client_load.clear()
+
+    @property
+    def remaining(self) -> float:
+        return self.limiter.remaining
+
+
+# ---------------------------------------------------------------------------
 # Data structures
 # ---------------------------------------------------------------------------
 
@@ -195,10 +250,9 @@ class TrainScheduler:
     def __init__(
         self,
         train_envs: TrainEnvs,
-        inference_pool: InferencePool,
+        dispatcher: RolloutDispatcher,
         buffer: Buffer,
         progress: Progress,
-        rollout_limiter: RolloutLimiter,
         batch_size: int | None,
         token_batch_size: int | None,
         rollouts_per_example: int,
@@ -208,10 +262,9 @@ class TrainScheduler:
         json_logging: bool = False,
     ):
         self.train_envs = train_envs
-        self.inference_pool = inference_pool
+        self.dispatcher = dispatcher
         self.buffer = buffer
         self.progress = progress
-        self.limiter = rollout_limiter
         self._uses_token_batching = token_batch_size is not None
         self._batch_target = token_batch_size or batch_size
         self.rollouts_per_example = rollouts_per_example
@@ -225,7 +278,6 @@ class TrainScheduler:
         self._requests: dict[asyncio.Task, RolloutRequest] = {}
         self._retry_queue: deque[RolloutRequest] = deque()
         self._schedule_queue: deque[RolloutRequest] = deque()
-        self._client_load: Counter[tuple[str, str | None]] = Counter()
 
         # Batch accumulation
         self._batch_rollouts: list[vf.RolloutOutput] = []
@@ -283,9 +335,9 @@ class TrainScheduler:
         self._groups.clear()
         self._retry_queue.clear()
         self._schedule_queue.clear()
-        self._client_load.clear()
+        self.dispatcher.clear()
         self.cancelled_rollouts_count += count
-        self.limiter.release(count)
+        self.dispatcher.limiter.release(count)
 
     async def next_batch(self) -> tuple[list[vf.RolloutOutput], float]:
         """Block until the current batch is complete, then return (rollouts, generation_time).
@@ -339,16 +391,12 @@ class TrainScheduler:
             request = self._next_request()
             group = self._groups[request.group_id]
 
-            if group.client is None:
-                group.client = await self._select_least_loaded_client()
-
-            await self.limiter.acquire(request.cost)
+            group.client = await self.dispatcher.acquire(request.cost, client=group.client)
             env = self.train_envs.get(group.env_name)
             task = asyncio.create_task(
                 env.run(client=group.client, example=group.example, model_name=self.model_name, n=request.cost)
             )
             self._requests[task] = request
-            self._client_load[client_identity(group.client)] += request.cost
 
     def _next_request(self) -> RolloutRequest:
         """Return the next request to schedule: retries first, then queued, then new."""
@@ -399,14 +447,12 @@ class TrainScheduler:
                 if request is None:
                     continue  # already removed by _drop_group
 
-                self.limiter.release(request.cost)
-
                 group = self._groups.get(request.group_id)
                 if group is None:
+                    self.dispatcher.limiter.release(request.cost)
                     continue
 
-                if group.client is not None:
-                    self._client_load[client_identity(group.client)] -= request.cost
+                self.dispatcher.release(group.client, request.cost)
 
                 try:
                     result = task.result()
@@ -498,23 +544,13 @@ class TrainScheduler:
                 self._requests.pop(task)
 
         if count:
-            if group is not None and group.client is not None:
-                self._client_load[client_identity(group.client)] -= count
-            self.limiter.release(count)
+            self.dispatcher.cancel(group.client if group else None, count)
             self.cancelled_rollouts_count += count
 
         for task in tasks_to_cancel:
             task.cancel()
 
         return count
-
-    async def _select_least_loaded_client(self) -> vf.ClientConfig:
-        """Select the client with the fewest in-flight requests."""
-        clients = self.inference_pool.train_clients
-        while not clients:
-            await asyncio.sleep(1)
-            clients = self.inference_pool.train_clients
-        return min(clients, key=lambda c: self._client_load[client_identity(c)])
 
     def on_weights_updated(self) -> None:
         """Called after a weight update: increment off-policy steps and drop stale groups."""
@@ -545,8 +581,8 @@ class TrainScheduler:
         total_rollouts = sum(self.total_rollouts_by_env.values())
         metrics = {
             "scheduler/inflight_rollouts": self.num_inflight_rollouts,
-            "scheduler/limiter_used": self.limiter.concurrency.used,
-            "scheduler/limiter_remaining": self.limiter.remaining,
+            "scheduler/limiter_used": self.dispatcher.limiter.concurrency.used,
+            "scheduler/limiter_remaining": self.dispatcher.remaining,
             "scheduler/cancelled_rollouts": self.cancelled_rollouts_count,
             "empty_rollouts/all": sum(self.empty_rollouts_by_env.values()) / max(total_rollouts, 1),
             "errored_rollouts/all": sum(self.errored_rollouts_by_env.values()) / max(total_rollouts, 1),
@@ -568,7 +604,7 @@ class TrainScheduler:
         self.errored_rollouts_by_env.clear()
         self.total_rollouts_by_env.clear()
 
-        metrics.update(self.inference_pool.get_metrics())
+        metrics.update(self.dispatcher.inference_pool.get_metrics())
         return metrics
 
 
@@ -589,16 +625,11 @@ class EvalResult:
 
 
 class EvalScheduler:
-    """Schedules eval rollouts with shared concurrency and rate limiting."""
+    """Schedules eval rollouts through the shared RolloutDispatcher."""
 
-    def __init__(
-        self,
-        rollout_limiter: RolloutLimiter,
-        inference_pool: InferencePool,
-    ):
+    def __init__(self, dispatcher: RolloutDispatcher):
         self.logger = get_logger()
-        self.limiter = rollout_limiter
-        self.inference_pool = inference_pool
+        self.dispatcher = dispatcher
 
     async def evaluate_envs(
         self,
@@ -630,9 +661,8 @@ class EvalScheduler:
         eval_start = time.perf_counter()
 
         async def run_one(example: dict, n: int) -> list[vf.RolloutOutput] | None:
-            await self.limiter.acquire(cost, priority=True)
+            client = await self.dispatcher.acquire(cost, priority=True)
             try:
-                client = await self.inference_pool.get_eval_client()
                 outputs = await eval_env.run(client=client, example=example, model_name=model_name, n=n)
                 pbar.update(n)
                 return outputs
@@ -641,7 +671,7 @@ class EvalScheduler:
                 pbar.update(n)
                 return None
             finally:
-                self.limiter.release(cost)
+                self.dispatcher.release(client, cost)
 
         if eval_env.requires_group_scoring:
             coros = [run_one(example, rollouts_per_example) for example in eval_env.examples]

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -584,14 +584,17 @@ class EvalScheduler:
         model_name: str,
     ) -> AsyncIterator[EvalResult]:
         """Run evals for multiple envs, yielding results as each env completes."""
-        tasks: dict[asyncio.Task, EvalEnv] = {
-            asyncio.create_task(self.evaluate_env(env, model_name)): env for env in eval_envs
-        }
-        while tasks:
-            done, _ = await asyncio.wait(tasks.keys(), return_when=asyncio.FIRST_COMPLETED)
-            for task in done:
-                tasks.pop(task)
-                yield task.result()
+        tasks = {asyncio.create_task(self.evaluate_env(env, model_name)) for env in eval_envs}
+        try:
+            while tasks:
+                done, tasks = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+                for task in done:
+                    yield task.result()
+        finally:
+            for task in tasks:
+                task.cancel()
+            if tasks:
+                await asyncio.gather(*tasks, return_exceptions=True)
 
     async def evaluate_env(self, eval_env: EvalEnv, model_name: str) -> EvalResult:
         """Run all rollouts for one eval env with concurrency control."""

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -101,8 +101,8 @@ class TrainScheduler:
         self.groups: dict[int, GroupState] = {}
 
         self.step, self.ckpt_step = 0, 0
-        self.checkpoint_ready = asyncio.Event()
-        self.checkpoint_ready.set()
+        self._scheduling_enabled = asyncio.Event()
+        self._scheduling_enabled.set()
         self.update_weights_time, self.wait_for_ckpt_time = 0, 0
         self.update_policy_task: asyncio.Task | None = None
         self.inflight_policy_update_task: asyncio.Task | None = None
@@ -134,6 +134,14 @@ class TrainScheduler:
         if self.batch_size is None:
             return rollouts
         return rollouts[: self.batch_size]
+
+    def pause(self) -> None:
+        """Pause scheduling of new rollouts. Existing in-flight rollouts continue."""
+        self._scheduling_enabled.clear()
+
+    def resume(self) -> None:
+        """Resume scheduling of new rollouts."""
+        self._scheduling_enabled.set()
 
     async def cancel_inflight_rollouts(self):
         """Cancel all in-flight rollout requests."""
@@ -199,10 +207,10 @@ class TrainScheduler:
         else:
             rollout_count = 1
 
-        await self.limiter.rate.acquire(rollout_count)
-
         if not self.limiter.try_acquire(rollout_count):
             return
+
+        await self.limiter.rate.acquire(rollout_count)
 
         if env.requires_group_scoring:
             group.rollouts_to_schedule = 0
@@ -289,7 +297,7 @@ class TrainScheduler:
                 f"Orchestrator paused: waiting for trainer process to complete checkpoint {next_ckpt_step} "
                 f"(>{self.max_async_level} step(s) ahead). Training is progressing normally."
             )
-            self.checkpoint_ready.clear()
+            self.pause()
             wait_for_ckpt_start_time = time.perf_counter()
             await wait_for_path(get_step_path(get_broadcast_dir(self.config.output_dir), next_ckpt_step) / "STABLE")
             self.wait_for_ckpt_time = time.perf_counter() - wait_for_ckpt_start_time
@@ -312,7 +320,7 @@ class TrainScheduler:
             self.model_name = self.lora_name
             self.inference_pool.update_model_name(self.model_name)
 
-        self.checkpoint_ready.set()
+        self.resume()
         await self._update_off_policy()
 
     async def _get_or_start_policy_update_task(self, next_ckpt_step: int) -> asyncio.Task:
@@ -335,7 +343,7 @@ class TrainScheduler:
         """Updates the policy to the latest available checkpoint. Aborts rollout requests that are older than the max retention steps."""
         if not self.enable_policy_updates:
             self.ckpt_step = self.step
-            self.checkpoint_ready.set()
+            self.resume()
             return
 
         while True:
@@ -388,7 +396,7 @@ class TrainScheduler:
             self.update_policy_task = asyncio.create_task(self.update_policy_loop())
         else:
             self.ckpt_step = step
-            self.checkpoint_ready.set()
+            self.resume()
 
         batch_start_time = time.perf_counter()
 
@@ -408,7 +416,7 @@ class TrainScheduler:
                 inflight_tasks,
                 return_when=asyncio.FIRST_COMPLETED,
             )
-            await self.checkpoint_ready.wait()
+            await self._scheduling_enabled.wait()
 
             for finished_task in finished_tasks:
                 if batch_progress >= self.batch_target:
@@ -610,8 +618,8 @@ class EvalScheduler:
         if eval_env.requires_group_scoring:
 
             async def run_one(example: dict) -> list[vf.RolloutOutput] | None:
+                await self.limiter.acquire(cost_per_coro)
                 try:
-                    await self.limiter.acquire(cost_per_coro)
                     client = await self.inference_pool.get_eval_client()
                     outputs = await eval_env.run_group(
                         client=client,
@@ -633,8 +641,8 @@ class EvalScheduler:
         else:
 
             async def run_one(example: dict) -> list[vf.RolloutOutput] | None:
+                await self.limiter.acquire(1)
                 try:
-                    await self.limiter.acquire(1)
                     client = await self.inference_pool.get_eval_client()
                     output = await eval_env.run_rollout(client=client, example=example, model_name=model_name)
                     pbar.update(1)

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -417,6 +417,15 @@ class TrainScheduler:
             inflight_tasks = list(self.inflight_requests.keys())
 
             if not inflight_tasks:
+                if self.limiter.concurrency.used > 0:
+                    # Slots are held by eval (or other consumers) — wait for capacity to free up
+                    self.logger.debug(
+                        f"Train scheduler waiting for concurrency slots "
+                        f"(used={self.limiter.concurrency.used}, remaining={self.limiter.remaining})"
+                    )
+                    await self.limiter.concurrency.acquire(1)
+                    self.limiter.concurrency.release(1)
+                    continue
                 raise RuntimeError(
                     f"No in-flight rollouts and batch incomplete ({batch_progress}/{self.batch_target}). "
                     f"Limiter state: used={self.limiter.concurrency.used}, "

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -112,8 +112,8 @@ class TrainScheduler:
         self.train_envs = train_envs
         self.buffer = buffer
         self.config = config
+        self._uses_token_batching = config.token_batch_size is not None
         self._batch_target = config.token_batch_size or config.batch_size
-        self._batch_size = config.batch_size
         self.rollouts_per_example = config.rollouts_per_example
         self.max_async_level = max_async_level
         self.max_off_policy_steps = max_off_policy_steps
@@ -230,7 +230,7 @@ class TrainScheduler:
         """Block until the current batch is complete, then return it."""
         await self._batch_ready.wait()
 
-        batch = self._finalize_batch()
+        batch = list(self._batch_rollouts)
         self.last_batch_generation_time = time.perf_counter() - self._batch_start_time
         if self._pbar:
             self._pbar.close()
@@ -432,7 +432,7 @@ class TrainScheduler:
         accepted = self.buffer.sample_rollouts(n=self.rollouts_per_example)
 
         self._batch_rollouts.extend(accepted)
-        if self._batch_size is None:
+        if self._uses_token_batching:
             increment = sum(get_seq_len(r) for r in accepted)
         else:
             increment = len(accepted)
@@ -590,16 +590,6 @@ class TrainScheduler:
                 f"Cancelled {removed} old rollout requests (will refill naturally). "
                 f"Consider increasing max_off_policy_steps to avoid this."
             )
-
-    # ------------------------------------------------------------------
-    # Batch helpers
-    # ------------------------------------------------------------------
-
-    def _finalize_batch(self) -> list[vf.RolloutOutput]:
-        batch = list(self._batch_rollouts)
-        if self._batch_size is not None:
-            batch = batch[: self._batch_size]
-        return batch
 
     # ------------------------------------------------------------------
     # Metrics

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import heapq
 import time
 import uuid
 from collections import Counter, defaultdict
@@ -98,21 +99,11 @@ class RolloutGroup:
     client: vf.ClientConfig | None = None
     off_policy_steps: int = 0
     completed: list[vf.RolloutOutput] = field(default_factory=list)
-    remaining: int = -1  # individual rollouts left to schedule (set in __post_init__)
-    pending_retries: int = 0
     failure_count: int = 0
-
-    def __post_init__(self) -> None:
-        if self.remaining < 0:
-            self.remaining = 0 if self.requires_group_scoring else self.rollouts_per_example
 
     @property
     def is_complete(self) -> bool:
         return len(self.completed) >= self.rollouts_per_example
-
-    @property
-    def needs_scheduling(self) -> bool:
-        return self.pending_retries > 0 or self.remaining > 0
 
 
 @dataclass
@@ -242,6 +233,10 @@ class PolicyScheduler:
 # Train scheduler
 # ---------------------------------------------------------------------------
 
+# Heap priorities (lower = scheduled first)
+_PRIORITY_RETRY = 0
+_PRIORITY_NORMAL = 1
+
 
 class TrainScheduler:
     """Always-on scheduler with two background loops: scheduling and completion processing.
@@ -286,6 +281,8 @@ class TrainScheduler:
         # Group + request tracking
         self._groups: dict[str, RolloutGroup] = {}
         self._requests: dict[asyncio.Task, RolloutRequest] = {}
+        self._work_queue: list[tuple[int, int, str, int]] = []  # heap of (priority, seq, group_id, cost)
+        self._work_seq = 0  # tiebreaker for heap ordering (FIFO within same priority)
 
         # Batch accumulation
         self._batch_rollouts: list[vf.RolloutOutput] = []
@@ -341,6 +338,7 @@ class TrainScheduler:
         await safe_cancel_all(all_tasks)
         self._requests.clear()
         self._groups.clear()
+        self._work_queue.clear()
         self.dispatcher.clear()
         self.cancelled_rollouts_count += count
         self.dispatcher.limiter.release(count)
@@ -404,23 +402,21 @@ class TrainScheduler:
             )
             self._requests[task] = request
 
+    def _enqueue(self, group_id: str, cost: int, priority: int = _PRIORITY_NORMAL) -> None:
+        """Push a work item onto the scheduling heap."""
+        heapq.heappush(self._work_queue, (priority, self._work_seq, group_id, cost))
+        self._work_seq += 1
+
     def _next_request(self) -> RolloutRequest:
-        """Return the next request: retries first, then remaining work, then new group."""
-        for group in self._groups.values():
-            if group.pending_retries > 0:
-                group.pending_retries -= 1
-                cost = group.rollouts_per_example if group.requires_group_scoring else 1
-                return RolloutRequest(group_id=group.group_id, cost=cost)
-
-        for group in self._groups.values():
-            if group.remaining > 0:
-                group.remaining -= 1
-                return RolloutRequest(group_id=group.group_id, cost=1)
-
+        """Pop the next request from the heap. Skips dropped groups. Creates new work if empty."""
+        while self._work_queue:
+            _, _, group_id, cost = heapq.heappop(self._work_queue)
+            if group_id in self._groups:
+                return RolloutRequest(group_id=group_id, cost=cost)
         return self._create_new_request()
 
     def _create_new_request(self) -> RolloutRequest:
-        """Sample an example, create a group, and return its first request."""
+        """Sample an example, create a group, enqueue its work, and return the first request."""
         example = self.buffer.sample_examples(n=1)[0]
         env = self.train_envs.get(example["env_name"])
         group = RolloutGroup(
@@ -434,7 +430,9 @@ class TrainScheduler:
         if group.requires_group_scoring:
             return RolloutRequest(group_id=group.group_id, cost=group.rollouts_per_example)
 
-        group.remaining -= 1
+        # Enqueue N-1 items, return first immediately
+        for _ in range(self.rollouts_per_example - 1):
+            self._enqueue(group.group_id, cost=1)
         return RolloutRequest(group_id=group.group_id, cost=1)
 
     # ------------------------------------------------------------------
@@ -492,10 +490,11 @@ class TrainScheduler:
                 return
             if group.requires_group_scoring:
                 group.completed.clear()
-                group.pending_retries += 1
+                self._enqueue(group.group_id, group.rollouts_per_example, _PRIORITY_RETRY)
             else:
                 group.completed.extend(valid)
-                group.pending_retries += num_failed
+                for _ in range(num_failed):
+                    self._enqueue(group.group_id, 1, _PRIORITY_RETRY)
         else:
             group.completed.extend(valid)
 

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -619,7 +619,7 @@ class EvalScheduler:
         if eval_env.requires_group_scoring:
 
             async def run_one(example: dict) -> list[vf.RolloutOutput] | None:
-                await self.limiter.acquire(cost_per_coro)
+                await self.limiter.acquire(cost_per_coro, priority=True)
                 try:
                     client = await self.inference_pool.get_eval_client()
                     outputs = await eval_env.run_group(
@@ -642,7 +642,7 @@ class EvalScheduler:
         else:
 
             async def run_one(example: dict) -> list[vf.RolloutOutput] | None:
-                await self.limiter.acquire(1)
+                await self.limiter.acquire(1, priority=True)
                 try:
                     client = await self.inference_pool.get_eval_client()
                     output = await eval_env.run_rollout(client=client, example=example, model_name=model_name)

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -68,7 +68,8 @@ class InflightGroup:
 
     example: dict
     env_name: str
-    pinned_client: vf.ClientConfig | None = None
+    # Reuse the same client for all rollouts in a group to maximize prefix cache hits
+    client: vf.ClientConfig | None = None
 
     requests: dict[asyncio.Task, InflightRequest] = field(default_factory=dict)
     completed_rollouts: list[vf.RolloutOutput] = field(default_factory=list)
@@ -321,11 +322,11 @@ class TrainScheduler:
         """Schedule one request from a group. Blocks until a concurrency slot is available."""
         env = self.train_envs.get(group.env_name)
 
-        if group.pinned_client is not None:
-            client = group.pinned_client
+        if group.client is not None:
+            client = group.client
         else:
             client = await self._select_least_loaded_client()
-            group.pinned_client = client
+            group.client = client
 
         if env.requires_group_scoring:
             rollout_count = group.rollouts_to_schedule

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -77,6 +77,7 @@ class PolicyScheduler:
         progress: Progress,
         output_dir: Path,
         max_async_level: int,
+        strict_async_level: bool = False,
         lora_name: str | None = None,
     ):
         self.train_scheduler = train_scheduler
@@ -84,6 +85,7 @@ class PolicyScheduler:
         self.progress = progress
         self.output_dir = output_dir
         self.max_async_level = max_async_level
+        self.strict_async_level = strict_async_level
         self.lora_name = lora_name
 
         self.ckpt_step = 0
@@ -103,13 +105,18 @@ class PolicyScheduler:
     def _next_ckpt_step(self) -> int:
         """Compute the next checkpoint step to update to.
 
-        Returns the maximum of the latest available checkpoint and the
-        minimum required to stay within ``max_async_level``. When the
-        orchestrator is far ahead, this may return a step whose checkpoint
-        hasn't been written yet — the caller must wait for it.
+        In strict mode, always returns exactly ``step - max_async_level``
+        (ignoring newer checkpoints). In non-strict mode, returns the
+        maximum of that and the latest available checkpoint — using the
+        freshest weights possible.
+
+        Either way, the returned step may not exist yet. The caller must
+        wait for it.
         """
-        latest = get_latest_ckpt_step(get_broadcast_dir(self.output_dir)) or 0
         min_required = max(self.progress.step - self.max_async_level, 0)
+        if self.strict_async_level:
+            return min_required
+        latest = get_latest_ckpt_step(get_broadcast_dir(self.output_dir)) or 0
         return max(min_required, latest)
 
     async def start(self) -> None:

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -167,6 +167,7 @@ class TrainScheduler:
         token_batch_size: int | None,
         rollouts_per_example: int,
         max_off_policy_steps: int,
+        max_async_level: int,
         model_name: str,
         json_logging: bool = False,
     ):
@@ -175,6 +176,8 @@ class TrainScheduler:
         self.buffer = buffer
         self.progress = progress
         self.limiter = rollout_limiter
+        self.max_async_level = max_async_level
+        self.policy_scheduler: PolicyScheduler | None = None
         self._uses_token_batching = token_batch_size is not None
         self._batch_target = token_batch_size or batch_size
         self.rollouts_per_example = rollouts_per_example
@@ -199,8 +202,6 @@ class TrainScheduler:
         self._scheduling_task: asyncio.Task | None = None
         self._completion_task: asyncio.Task | None = None
 
-        self.ckpt_step = 0
-
         # Metrics (reset per step)
         self.cancelled_rollouts_count = 0
         self.empty_rollouts_by_env: dict[str, int] = defaultdict(int)
@@ -212,6 +213,10 @@ class TrainScheduler:
     # ------------------------------------------------------------------
     # Properties
     # ------------------------------------------------------------------
+
+    @property
+    def ckpt_step(self) -> int:
+        return self.policy_scheduler.ckpt_step if self.policy_scheduler else self.progress.step
 
     @property
     def num_inflight_rollouts(self) -> int:
@@ -251,8 +256,12 @@ class TrainScheduler:
         self.limiter.release(count)
 
     async def wait_for_batch(self) -> list[vf.RolloutOutput]:
-        """Block until the current batch is complete, then return it."""
+        """Block until the current batch is complete and async level allows it."""
         await self._batch_ready.wait()
+
+        # Enforce async level: don't return batch if orchestrator is too far ahead
+        while self.progress.step - self.ckpt_step > self.max_async_level:
+            await asyncio.sleep(0.1)
 
         batch = list(self._batch_rollouts)
         self.last_batch_generation_time = time.perf_counter() - self._batch_start_time

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -416,6 +416,14 @@ class TrainScheduler:
             await self._fill_inflight_requests()
             inflight_tasks = list(self.inflight_requests.keys())
 
+            if not inflight_tasks:
+                raise RuntimeError(
+                    f"No in-flight rollouts and batch incomplete ({batch_progress}/{self.batch_target}). "
+                    f"Limiter state: used={self.limiter.concurrency.used}, "
+                    f"remaining={self.limiter.remaining}. "
+                    f"This likely indicates a concurrency slot leak."
+                )
+
             finished_tasks, _ = await asyncio.wait(
                 inflight_tasks,
                 return_when=asyncio.FIRST_COMPLETED,

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -71,13 +71,13 @@ class InflightGroup:
     # Reuse the same client for all rollouts in a group to maximize prefix cache hits
     client: vf.ClientConfig | None = None
 
-    requests: dict[asyncio.Task, InflightRequest] = field(default_factory=dict)
+    inflight_requests: dict[asyncio.Task, InflightRequest] = field(default_factory=dict)
     completed_rollouts: list[vf.RolloutOutput] = field(default_factory=list)
     rollouts_to_schedule: int = 0
 
     @property
     def total_inflight_rollouts(self) -> int:
-        return sum(r.rollout_count for r in self.requests.values())
+        return sum(r.rollout_count for r in self.inflight_requests.values())
 
 
 # ---------------------------------------------------------------------------
@@ -187,12 +187,12 @@ class TrainScheduler:
 
     @property
     def max_off_policy_level(self) -> int:
-        steps = [r.off_policy_steps for g in self._groups.values() for r in g.requests.values()]
+        steps = [r.off_policy_steps for g in self._groups.values() for r in g.inflight_requests.values()]
         return max(steps) if steps else 0
 
     @property
     def mean_off_policy_level(self) -> float:
-        steps = [r.off_policy_steps for g in self._groups.values() for r in g.requests.values()]
+        steps = [r.off_policy_steps for g in self._groups.values() for r in g.inflight_requests.values()]
         return sum(steps) / len(steps) if steps else 0
 
     # ------------------------------------------------------------------
@@ -232,7 +232,7 @@ class TrainScheduler:
         count = sum(g.total_inflight_rollouts for g in self._groups.values())
         await safe_cancel_all(all_tasks)
         for group in self._groups.values():
-            group.requests.clear()
+            group.inflight_requests.clear()
         self._task_to_group.clear()
         self._groups.clear()
         self.cancelled_rollouts_count += count
@@ -353,7 +353,7 @@ class TrainScheduler:
             )
             request = InflightRolloutRequest(task=task, client=client)
 
-        group.requests[task] = request
+        group.inflight_requests[task] = request
         group_id = self._group_id_for(group)
         self._task_to_group[task] = group_id
 
@@ -381,7 +381,7 @@ class TrainScheduler:
                 if group is None:
                     continue
 
-                request = group.requests.pop(task, None)
+                request = group.inflight_requests.pop(task, None)
                 if request is None:
                     continue
 
@@ -472,12 +472,12 @@ class TrainScheduler:
         if group is None:
             return 0
 
-        tasks_to_cancel = list(group.requests.keys())
-        rollout_count = sum(r.rollout_count for r in group.requests.values())
+        tasks_to_cancel = list(group.inflight_requests.keys())
+        rollout_count = sum(r.rollout_count for r in group.inflight_requests.values())
 
         for task in tasks_to_cancel:
             self._task_to_group.pop(task, None)
-        group.requests.clear()
+        group.inflight_requests.clear()
 
         await safe_cancel_all(tasks_to_cancel)
         if rollout_count:
@@ -495,7 +495,9 @@ class TrainScheduler:
         while not clients:
             await asyncio.sleep(1)
             clients = self.inference_pool.train_clients
-        inflight = Counter(self._client_identity(r.client) for g in self._groups.values() for r in g.requests.values())
+        inflight = Counter(
+            self._client_identity(r.client) for g in self._groups.values() for r in g.inflight_requests.values()
+        )
         return min(clients, key=lambda c: inflight[self._client_identity(c)])
 
     # ------------------------------------------------------------------
@@ -581,7 +583,7 @@ class TrainScheduler:
         """Increment off-policy counters and drop stale groups."""
         stale_group_ids = set()
         for gid, group in self._groups.items():
-            for request in group.requests.values():
+            for request in group.inflight_requests.values():
                 if request.off_policy_steps >= self.max_off_policy_steps:
                     stale_group_ids.add(gid)
                     break
@@ -592,7 +594,7 @@ class TrainScheduler:
         removed = sum(counts)
 
         for _, group in groups_to_increment:
-            for request in group.requests.values():
+            for request in group.inflight_requests.values():
                 request.off_policy_steps += 1
 
         if removed:
@@ -637,7 +639,7 @@ class TrainScheduler:
             metrics[f"errored_rollouts/{env_name}"] = self.errored_rollouts_by_env.get(env_name, 0) / env_total
         by_env: dict[str, list[int]] = {}
         for group in self._groups.values():
-            for request in group.requests.values():
+            for request in group.inflight_requests.values():
                 by_env.setdefault(group.env_name, []).append(request.off_policy_steps)
         for env_name, steps in by_env.items():
             metrics[f"off_policy_level/{env_name}/max"] = max(steps)

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -126,25 +126,6 @@ class PolicyScheduler:
     def at_async_barrier(self) -> bool:
         return self.async_level > self.max_async_level
 
-    async def wait_until_ready(self) -> None:
-        """Block until the async barrier is clear (ckpt_step is fresh enough).
-
-        Called by the orchestrator before each step to enforce max_async_level,
-        exactly like the old synchronous maybe_update_policy() at the top of
-        generate_batch(). The background run() loop handles opportunistic
-        updates mid-batch.
-        """
-        while True:
-            next_ckpt_step = self._get_next_ckpt_step()
-            if next_ckpt_step <= self.ckpt_step:
-                return
-            # At barrier — wait for checkpoint and update weights
-            self.train_scheduler.pause()
-            await wait_for_path(get_step_path(get_broadcast_dir(self.output_dir), next_ckpt_step) / "STABLE")
-            await self._update_weights(next_ckpt_step)
-            await self.train_scheduler.drop_stale_groups(next_ckpt_step)
-            self.train_scheduler.resume()
-
     async def start(self) -> None:
         """Background loop: poll for new checkpoints and apply weight updates.
 

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -67,6 +67,7 @@ class InflightGroupRequest(InflightRequest):
 class InflightGroup:
     """Tracks one example being evaluated with N rollouts."""
 
+    group_id: int
     example: dict
     env_name: str
     # Reuse the same client for all rollouts in a group to maximize prefix cache hits
@@ -102,7 +103,6 @@ class PolicyScheduler:
         output_dir: Path,
         max_async_level: int,
         strict_async_level: bool,
-        model_name: str,
         lora_name: str | None = None,
     ):
         self.train_scheduler = train_scheduler
@@ -111,7 +111,6 @@ class PolicyScheduler:
         self.output_dir = output_dir
         self.max_async_level = max_async_level
         self.strict_async_level = strict_async_level
-        self.model_name = model_name
         self.lora_name = lora_name
 
         self.ckpt_step = 0
@@ -120,7 +119,11 @@ class PolicyScheduler:
 
     @property
     def async_level(self) -> int:
-        return self.progress.step - self.ckpt_step, 0
+        return self.progress.step - self.ckpt_step
+
+    @property
+    def at_async_barrier(self) -> bool:
+        return self.async_level >= self.max_async_level
 
     async def run(self) -> None:
         """Background loop: poll for new checkpoints and apply weight updates.
@@ -129,24 +132,32 @@ class PolicyScheduler:
         2. If at async barrier — pause train scheduler, wait for checkpoint
         3. Update weights, drop stale groups, resume train scheduler
         """
+
+        def get_next_ckpt_step() -> int:
+            orch_step = self.progress.step
+            latest_ckpt_step = get_latest_ckpt_step(get_broadcast_dir(self.output_dir)) or 0
+            async_away_ckpt_step = max(orch_step - self.max_async_level, 0)
+            if self.strict_async_level:
+                return async_away_ckpt_step
+            return max(async_away_ckpt_step, latest_ckpt_step)
+
         while True:
-            next_ckpt_step = self._get_next_ckpt_step()
+            next_ckpt_step = get_next_ckpt_step()
             if next_ckpt_step <= self.ckpt_step:
                 await asyncio.sleep(1)
                 continue
 
-            at_barrier = next_ckpt_step == self.async_level
-            if at_barrier:
+            if self.at_async_barrier:
                 self.train_scheduler.pause()
                 t0 = time.perf_counter()
                 await wait_for_path(get_step_path(get_broadcast_dir(self.output_dir), next_ckpt_step) / "STABLE")
                 self.wait_for_ckpt_time = time.perf_counter() - t0
 
-            await self._update_weights(next_ckpt_step)
+            await self.update_weights(next_ckpt_step)
             await self.train_scheduler.drop_stale_groups(next_ckpt_step)
             self.train_scheduler.resume()
 
-    async def _update_weights(self, next_ckpt_step: int) -> None:
+    async def update_weights(self, next_ckpt_step: int) -> None:
         t0 = time.perf_counter()
         weights_path = get_step_path(get_broadcast_dir(self.output_dir), next_ckpt_step)
         await self.inference_pool.update_weights(weights_path, lora_name=self.lora_name, step=next_ckpt_step)
@@ -154,17 +165,8 @@ class PolicyScheduler:
 
         self.ckpt_step = next_ckpt_step
         if self.lora_name is not None:
-            self.model_name = self.lora_name
             self.train_scheduler.model_name = self.lora_name
-            self.inference_pool.update_model_name(self.model_name)
-
-    def _get_next_ckpt_step(self) -> int:
-        step = self.progress.step
-        latest_ckpt_step = get_latest_ckpt_step(get_broadcast_dir(self.output_dir)) or 0
-        async_away_ckpt_step = max(step - self.max_async_level, 0)
-        if self.strict_async_level:
-            return async_away_ckpt_step
-        return max(async_away_ckpt_step, latest_ckpt_step)
+            self.inference_pool.update_model_name(self.lora_name)
 
     def get_metrics(self) -> dict[str, float]:
         return {
@@ -342,6 +344,7 @@ class TrainScheduler:
         group_id = self._next_group_id
         self._next_group_id += 1
         group = InflightGroup(
+            group_id=group_id,
             example=example,
             env_name=example["env_name"],
             rollouts_to_schedule=self.rollouts_per_example,
@@ -387,8 +390,7 @@ class TrainScheduler:
             request = InflightRolloutRequest(task=task, client=client, ckpt_step=self.ckpt_step)
 
         group.inflight_requests[task] = request
-        group_id = self._group_id_for(group)
-        self._task_to_group[task] = group_id
+        self._task_to_group[task] = group.group_id
 
     # ------------------------------------------------------------------
     # Completion loop
@@ -399,11 +401,10 @@ class TrainScheduler:
         while True:
             tasks = list(self._task_to_group.keys())
             if not tasks:
-                await asyncio.sleep(0)
+                await asyncio.sleep(0.1)
                 continue
 
             done, _ = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
-            await self._scheduling_enabled.wait()
 
             for task in done:
                 group_id = self._task_to_group.pop(task, None)
@@ -491,13 +492,6 @@ class TrainScheduler:
     # ------------------------------------------------------------------
     # Group management
     # ------------------------------------------------------------------
-
-    def _group_id_for(self, group: InflightGroup) -> int:
-        """Find group_id for a group object."""
-        for gid, g in self._groups.items():
-            if g is group:
-                return gid
-        raise ValueError("Group not found")
 
     async def _drop_group(self, group_id: int) -> int:
         """Drop a group: cancel pending requests, release slots."""

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -81,6 +81,119 @@ class InflightGroup:
 
 
 # ---------------------------------------------------------------------------
+# Policy scheduler
+# ---------------------------------------------------------------------------
+
+
+class PolicyScheduler:
+    """Watches for new policy checkpoints and applies weight updates.
+
+    Runs as a background loop owned by TrainScheduler. On policy update:
+    pauses scheduling, waits for checkpoint, updates weights, drops stale
+    rollouts, then resumes scheduling.
+    """
+
+    def __init__(
+        self,
+        train_scheduler: TrainScheduler,
+        inference_pool: InferencePool,
+        config: OrchestratorConfig,
+        max_async_level: int,
+        strict_async_level: bool,
+        model_name: str,
+        lora_name: str | None = None,
+    ):
+        self.logger = get_logger()
+        self._train = train_scheduler
+        self.inference_pool = inference_pool
+        self.config = config
+        self.max_async_level = max_async_level
+        self.strict_async_level = strict_async_level
+        self.model_name = model_name
+        self.lora_name = lora_name
+
+        self.ckpt_step = 0
+        self.update_weights_time = 0.0
+        self.wait_for_ckpt_time = 0.0
+        self._inflight_task: asyncio.Task | None = None
+        self._lock = asyncio.Lock()
+
+    def _compute_next_ckpt_step(self, step: int) -> int:
+        latest_ckpt_step = get_latest_ckpt_step(get_broadcast_dir(self.config.output_dir)) or 0
+        async_away_ckpt_step = max(step - self.max_async_level, 0)
+        if self.strict_async_level:
+            return async_away_ckpt_step
+        return max(async_away_ckpt_step, latest_ckpt_step)
+
+    async def _apply_update(self, next_ckpt_step: int, step: int) -> None:
+        async_away_ckpt_step = max(step - self.max_async_level, 0)
+        if next_ckpt_step == async_away_ckpt_step:
+            self.logger.info(
+                f"Orchestrator paused: waiting for trainer process to complete checkpoint {next_ckpt_step} "
+                f"(>{self.max_async_level} step(s) ahead). Training is progressing normally."
+            )
+            self._train.pause()
+            t0 = time.perf_counter()
+            await wait_for_path(get_step_path(get_broadcast_dir(self.config.output_dir), next_ckpt_step) / "STABLE")
+            self.wait_for_ckpt_time = time.perf_counter() - t0
+            self.logger.info(
+                f"Orchestrator resumed: checkpoint {next_ckpt_step} ready (after {self.wait_for_ckpt_time:.2f}s)"
+            )
+
+        self.logger.debug(f"Got new policy with step {next_ckpt_step}. Updating weights.")
+
+        t0 = time.perf_counter()
+        weights_path = get_step_path(get_broadcast_dir(self.config.output_dir), next_ckpt_step)
+        await self.inference_pool.update_weights(weights_path, lora_name=self.lora_name, step=next_ckpt_step)
+        self.update_weights_time = time.perf_counter() - t0
+        self.logger.debug(f"Updated weights to step {next_ckpt_step} in {self.update_weights_time:.2f}s")
+
+        self.ckpt_step = next_ckpt_step
+        if self.lora_name is not None:
+            self.model_name = self.lora_name
+            self._train.model_name = self.lora_name
+            self.inference_pool.update_model_name(self.model_name)
+
+        self._train.resume()
+        await self._train._update_off_policy()
+
+    async def _get_or_start_update_task(self, next_ckpt_step: int, step: int) -> asyncio.Task:
+        async with self._lock:
+            if self._inflight_task is not None and not self._inflight_task.done():
+                return self._inflight_task
+
+            task = asyncio.create_task(self._apply_update(next_ckpt_step, step))
+            self._inflight_task = task
+
+            def _clear(done_task: asyncio.Task) -> None:
+                if self._inflight_task is done_task:
+                    self._inflight_task = None
+
+            task.add_done_callback(_clear)
+            return task
+
+    async def maybe_update(self, step: int) -> None:
+        """Check for and apply any pending policy updates."""
+        while True:
+            next_ckpt_step = self._compute_next_ckpt_step(step)
+            if next_ckpt_step <= self.ckpt_step:
+                return
+            task = await self._get_or_start_update_task(next_ckpt_step, step)
+            await asyncio.shield(task)
+
+    async def run(self, step_fn) -> None:
+        """Background loop. step_fn returns the current training step."""
+        while True:
+            await self.maybe_update(step_fn())
+            await asyncio.sleep(1)
+
+    async def stop(self) -> None:
+        if self._inflight_task is not None:
+            await safe_cancel(self._inflight_task)
+            self._inflight_task = None
+
+
+# ---------------------------------------------------------------------------
 # Train scheduler
 # ---------------------------------------------------------------------------
 
@@ -115,14 +228,23 @@ class TrainScheduler:
         self._uses_token_batching = config.token_batch_size is not None
         self._batch_target = config.token_batch_size or config.batch_size
         self.rollouts_per_example = config.rollouts_per_example
-        self.max_async_level = max_async_level
         self.max_off_policy_steps = max_off_policy_steps
-        self.strict_async_level = strict_async_level
         self.enable_policy_updates = enable_policy_updates
-        self.lora_name = lora_name
         self.model_name = model_name
         self.json_logging = config.log.json_logging
         self.inference_pool = inference_pool
+
+        self.policy: PolicyScheduler | None = None
+        if enable_policy_updates:
+            self.policy = PolicyScheduler(
+                train_scheduler=self,
+                inference_pool=inference_pool,
+                config=config,
+                max_async_level=max_async_level,
+                strict_async_level=strict_async_level,
+                model_name=model_name,
+                lora_name=lora_name,
+            )
 
         # Group tracking
         self._next_group_id = 0
@@ -141,12 +263,8 @@ class TrainScheduler:
         self._scheduling_task: asyncio.Task | None = None
         self._completion_task: asyncio.Task | None = None
 
-        # Policy update state
-        self.step, self.ckpt_step = 0, 0
-        self.update_weights_time, self.wait_for_ckpt_time = 0, 0
+        self.step = 0
         self._policy_loop_task: asyncio.Task | None = None
-        self._inflight_policy_update_task: asyncio.Task | None = None
-        self._policy_update_lock = asyncio.Lock()
 
         # Metrics (reset per step)
         self.cancelled_rollouts_count = 0
@@ -161,13 +279,8 @@ class TrainScheduler:
     # ------------------------------------------------------------------
 
     @property
-    def inflight_rollout_count(self) -> int:
+    def num_inflight_rollouts(self) -> int:
         return sum(g.total_inflight_rollouts for g in self._groups.values())
-
-    @property
-    def inflight_sample_count(self) -> int:
-        pending = sum(g.rollouts_to_schedule for g in self._groups.values())
-        return self.inflight_rollout_count + pending
 
     @property
     def async_level(self) -> int:
@@ -187,15 +300,23 @@ class TrainScheduler:
     # Public API
     # ------------------------------------------------------------------
 
+    @property
+    def ckpt_step(self) -> int:
+        return self.policy.ckpt_step if self.policy else self.step
+
+    @ckpt_step.setter
+    def ckpt_step(self, value: int) -> None:
+        if self.policy:
+            self.policy.ckpt_step = value
+
     async def start(self, step: int) -> None:
         """Start background loops. Call once at the beginning of training."""
         self.step = step
 
-        if self.enable_policy_updates:
-            await self._maybe_update_policy()
-            self._policy_loop_task = asyncio.create_task(self._policy_update_loop())
+        if self.policy:
+            await self.policy.maybe_update(step)
+            self._policy_loop_task = asyncio.create_task(self.policy.run(lambda: self.step))
         else:
-            self.ckpt_step = step
             self.resume()
 
         self._batch_start_time = time.perf_counter()
@@ -266,9 +387,8 @@ class TrainScheduler:
         self._completion_task = None
         self._policy_loop_task = None
 
-        if self._inflight_policy_update_task is not None:
-            await safe_cancel(self._inflight_policy_update_task)
-            self._inflight_policy_update_task = None
+        if self.policy:
+            await self.policy.stop()
 
         await self.cancel_inflight_rollouts()
 
@@ -488,85 +608,6 @@ class TrainScheduler:
         )
         return min(clients, key=lambda c: inflight[self._client_identity(c)])
 
-    # ------------------------------------------------------------------
-    # Policy updates
-    # ------------------------------------------------------------------
-
-    async def _policy_update_loop(self) -> None:
-        """Continuously check for new policy checkpoints."""
-        while True:
-            await self._maybe_update_policy()
-            await asyncio.sleep(1)
-
-    def _compute_next_ckpt_step(self) -> int:
-        latest_ckpt_step = get_latest_ckpt_step(get_broadcast_dir(self.config.output_dir)) or 0
-        async_away_ckpt_step = max(self.step - self.max_async_level, 0)
-        if self.strict_async_level:
-            return async_away_ckpt_step
-        return max(async_away_ckpt_step, latest_ckpt_step)
-
-    async def _apply_policy_update(self, next_ckpt_step: int) -> None:
-        async_away_ckpt_step = max(self.step - self.max_async_level, 0)
-        if next_ckpt_step == async_away_ckpt_step:
-            self.logger.info(
-                f"Orchestrator paused: waiting for trainer process to complete checkpoint {next_ckpt_step} "
-                f"(>{self.max_async_level} step(s) ahead). Training is progressing normally."
-            )
-            self.pause()
-            wait_for_ckpt_start_time = time.perf_counter()
-            await wait_for_path(get_step_path(get_broadcast_dir(self.config.output_dir), next_ckpt_step) / "STABLE")
-            self.wait_for_ckpt_time = time.perf_counter() - wait_for_ckpt_start_time
-            self.logger.info(
-                f"Orchestrator resumed: checkpoint {next_ckpt_step} ready (after {self.wait_for_ckpt_time:.2f}s)"
-            )
-
-        self.logger.debug(
-            f"Got new policy with step {next_ckpt_step}. Updating weights and cancelling old rollout requests."
-        )
-
-        update_weights_start_time = time.perf_counter()
-        weights_path = get_step_path(get_broadcast_dir(self.config.output_dir), next_ckpt_step)
-        await self.inference_pool.update_weights(weights_path, lora_name=self.lora_name, step=next_ckpt_step)
-        self.update_weights_time = time.perf_counter() - update_weights_start_time
-        self.logger.debug(f"Updated weights to step {next_ckpt_step} in {self.update_weights_time:.2f}s")
-
-        self.ckpt_step = next_ckpt_step
-        if self.lora_name is not None:
-            self.model_name = self.lora_name
-            self.inference_pool.update_model_name(self.model_name)
-
-        self.resume()
-        await self._update_off_policy()
-
-    async def _get_or_start_policy_update_task(self, next_ckpt_step: int) -> asyncio.Task:
-        async with self._policy_update_lock:
-            task = self._inflight_policy_update_task
-            if task is not None and not task.done():
-                return task
-
-            task = asyncio.create_task(self._apply_policy_update(next_ckpt_step))
-            self._inflight_policy_update_task = task
-
-            def _clear(done_task: asyncio.Task) -> None:
-                if self._inflight_policy_update_task is done_task:
-                    self._inflight_policy_update_task = None
-
-            task.add_done_callback(_clear)
-            return task
-
-    async def _maybe_update_policy(self) -> None:
-        if not self.enable_policy_updates:
-            self.ckpt_step = self.step
-            self.resume()
-            return
-
-        while True:
-            next_ckpt_step = self._compute_next_ckpt_step()
-            if next_ckpt_step <= self.ckpt_step:
-                return
-            task = await self._get_or_start_policy_update_task(next_ckpt_step)
-            await asyncio.shield(task)
-
     async def _update_off_policy(self) -> None:
         """Increment off-policy counters and drop stale groups."""
         stale_group_ids = set()
@@ -598,11 +639,10 @@ class TrainScheduler:
     def get_metrics(self) -> dict[str, float]:
         total_rollouts = sum(self.total_rollouts_by_env.values())
         metrics = {
-            "time/wait_for_ckpt": self.wait_for_ckpt_time,
-            "time/update_weights": self.update_weights_time,
+            "time/wait_for_ckpt": self.policy.wait_for_ckpt_time if self.policy else 0,
+            "time/update_weights": self.policy.update_weights_time if self.policy else 0,
             "scheduler/async_level": self.async_level,
-            "scheduler/inflight_rollouts": self.inflight_rollout_count,
-            "scheduler/inflight_samples": self.inflight_sample_count,
+            "scheduler/inflight_rollouts": self.num_inflight_rollouts,
             "scheduler/limiter_used": self.limiter.concurrency.used,
             "scheduler/limiter_remaining": self.limiter.remaining,
             "scheduler/cancelled_rollouts": self.cancelled_rollouts_count,

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -423,8 +423,7 @@ class TrainScheduler:
                         f"Train scheduler waiting for concurrency slots "
                         f"(used={self.limiter.concurrency.used}, remaining={self.limiter.remaining})"
                     )
-                    await self.limiter.concurrency.acquire(1)
-                    self.limiter.concurrency.release(1)
+                    await self.limiter.concurrency.wait_for_capacity(self.rollouts_per_example)
                     continue
                 raise RuntimeError(
                     f"No in-flight rollouts and batch incomplete ({batch_progress}/{self.batch_target}). "

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -120,36 +120,22 @@ class PolicyScheduler:
 
     @property
     def async_level(self) -> int:
-        return self.progress.step - self.ckpt_step
+        return self.progress.step - self.ckpt_step, 0
 
-    def get_metrics(self) -> dict[str, float]:
-        return {
-            "time/wait_for_ckpt": self.wait_for_ckpt_time,
-            "time/update_weights": self.update_weights_time,
-            "scheduler/async_level": self.async_level,
-        }
+    async def run(self) -> None:
+        """Background loop: poll for new checkpoints and apply weight updates.
 
-    def _get_next_ckpt_step(self) -> int:
-        step = self.progress.step
-        latest_ckpt_step = get_latest_ckpt_step(get_broadcast_dir(self.output_dir)) or 0
-        async_away_ckpt_step = max(step - self.max_async_level, 0)
-        if self.strict_async_level:
-            return async_away_ckpt_step
-        return max(async_away_ckpt_step, latest_ckpt_step)
-
-    async def maybe_update(self) -> None:
-        """Check for and apply pending policy updates.
-
-        1. If at latest checkpoint — return
+        1. If at latest checkpoint — sleep and retry
         2. If at async barrier — pause train scheduler, wait for checkpoint
         3. Update weights, drop stale groups, resume train scheduler
         """
         while True:
             next_ckpt_step = self._get_next_ckpt_step()
             if next_ckpt_step <= self.ckpt_step:
-                return
+                await asyncio.sleep(1)
+                continue
 
-            at_barrier = next_ckpt_step == max(self.progress.step - self.max_async_level, 0)
+            at_barrier = next_ckpt_step == self.async_level
             if at_barrier:
                 self.train_scheduler.pause()
                 t0 = time.perf_counter()
@@ -172,11 +158,20 @@ class PolicyScheduler:
             self.train_scheduler.model_name = self.lora_name
             self.inference_pool.update_model_name(self.model_name)
 
-    async def run(self) -> None:
-        """Background loop."""
-        while True:
-            await self.maybe_update()
-            await asyncio.sleep(1)
+    def _get_next_ckpt_step(self) -> int:
+        step = self.progress.step
+        latest_ckpt_step = get_latest_ckpt_step(get_broadcast_dir(self.output_dir)) or 0
+        async_away_ckpt_step = max(step - self.max_async_level, 0)
+        if self.strict_async_level:
+            return async_away_ckpt_step
+        return max(async_away_ckpt_step, latest_ckpt_step)
+
+    def get_metrics(self) -> dict[str, float]:
+        return {
+            "time/wait_for_ckpt": self.wait_for_ckpt_time,
+            "time/update_weights": self.update_weights_time,
+            "scheduler/async_level": self.async_level,
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -261,10 +261,15 @@ class TrainScheduler:
         return True
 
     async def _fill_inflight_requests(self) -> None:
-        """Schedule requests up to available concurrency. Blocks on the first request if needed."""
-        # Always schedule at least one (blocks until capacity is available)
-        await self._schedule_next_request()
-        # Fill remaining capacity without blocking
+        """Schedule requests up to available concurrency.
+
+        If no requests are in flight, blocks until capacity is available
+        (e.g. waiting for eval to release slots). Otherwise returns
+        immediately so generate_batch can process completed tasks.
+        """
+        if not self.inflight_requests:
+            # Nothing in flight — must block until we can schedule at least one
+            await self._schedule_next_request()
         while self.limiter.remaining > 0:
             await self._schedule_next_request()
 

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from abc import abstractmethod
+import uuid
 from collections import Counter, defaultdict
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
@@ -23,6 +23,7 @@ from prime_rl.utils.utils import (
     get_broadcast_dir,
     get_latest_ckpt_step,
     get_step_path,
+    wait_for_path,
 )
 
 # ---------------------------------------------------------------------------
@@ -32,53 +33,31 @@ from prime_rl.utils.utils import (
 
 @dataclass
 class InflightRequest:
-    """Base class for an in-flight rollout API call."""
+    """An in-flight rollout/ group rollout request."""
 
     task: asyncio.Task
     client: vf.ClientConfig
-    ckpt_step: int = 0
-
-    @property
-    @abstractmethod
-    def rollout_count(self) -> int: ...
-
-
-@dataclass
-class InflightRolloutRequest(InflightRequest):
-    """A single run_rollout call producing 1 rollout."""
-
-    @property
-    def rollout_count(self) -> int:
-        return 1
-
-
-@dataclass
-class InflightGroupRequest(InflightRequest):
-    """A single run_group call producing N rollouts."""
-
-    rollouts_per_example: int = 1
-
-    @property
-    def rollout_count(self) -> int:
-        return self.rollouts_per_example
+    rollout_count: int = 1
+    off_policy_steps: int = 0
 
 
 @dataclass
 class InflightGroup:
-    """Tracks one example being evaluated with N rollouts."""
+    """An inflight group"""
 
-    group_id: int
-    example: dict
     env_name: str
+    example: dict
+    rollouts_to_schedule: int
+
     # Reuse the same client for all rollouts in a group to maximize prefix cache hits
     client: vf.ClientConfig | None = None
+    group_id: str = field(default_factory=lambda: uuid.uuid4().hex[:12])
 
     inflight_requests: dict[asyncio.Task, InflightRequest] = field(default_factory=dict)
     completed_rollouts: list[vf.RolloutOutput] = field(default_factory=list)
-    rollouts_to_schedule: int = 0
 
     @property
-    def total_inflight_rollouts(self) -> int:
+    def num_inflight_rollouts(self) -> int:
         return sum(r.rollout_count for r in self.inflight_requests.values())
 
 
@@ -98,19 +77,43 @@ class PolicyScheduler:
         self,
         train_scheduler: TrainScheduler,
         inference_pool: InferencePool,
+        progress: Progress,
         output_dir: Path,
+        max_async_level: int,
         lora_name: str | None = None,
     ):
         self.train_scheduler = train_scheduler
         self.inference_pool = inference_pool
+        self.progress = progress
         self.output_dir = output_dir
+        self.max_async_level = max_async_level
         self.lora_name = lora_name
 
         self.ckpt_step = 0
         self.update_weights_time = 0.0
+        self.wait_for_ckpt_time = 0.0
+        self.async_barrier_clear = asyncio.Event()
+        self.async_barrier_clear.set()  # initially clear (no barrier)
+
+    @property
+    def async_level(self) -> int:
+        return self.progress.step - self.ckpt_step
+
+    @property
+    def at_async_barrier(self) -> bool:
+        return self.async_level > self.max_async_level
+
+    async def wait_for_async_barrier(self) -> None:
+        """Block until the async barrier is cleared."""
+        await self.async_barrier_clear.wait()
 
     async def start(self) -> None:
-        """Background loop: poll for new checkpoints and apply weight updates."""
+        """Background loop: poll for new checkpoints and apply weight updates.
+
+        1. If at latest checkpoint — sleep and retry
+        2. If at async barrier — pause train scheduler, wait for checkpoint
+        3. Update weights, drop stale groups, signal barrier cleared
+        """
         logger = get_logger()
         while True:
             latest_ckpt_step = get_latest_ckpt_step(get_broadcast_dir(self.output_dir)) or 0
@@ -118,12 +121,22 @@ class PolicyScheduler:
                 await asyncio.sleep(0.1)
                 continue
 
+            if self.at_async_barrier:
+                self.async_barrier_clear.clear()
+                logger.info(f"At async barrier: pausing train scheduling, waiting for checkpoint {latest_ckpt_step}")
+                self.train_scheduler.pause()
+                t0 = time.perf_counter()
+                await wait_for_path(get_step_path(get_broadcast_dir(self.output_dir), latest_ckpt_step) / "STABLE")
+                self.wait_for_ckpt_time = time.perf_counter() - t0
+                logger.debug(f"Waited for checkpoint {latest_ckpt_step} in {print_time(self.wait_for_ckpt_time)}")
+
             logger.info(f"Updating weights to training checkpoint {latest_ckpt_step}")
             await self._update_weights(latest_ckpt_step)
             logger.debug(f"Weights updated in {print_time(self.update_weights_time)}")
 
-            await self.train_scheduler.drop_stale_groups(latest_ckpt_step)
-            logger.debug(f"Dropped stale rollouts for checkpoint {latest_ckpt_step}")
+            self.train_scheduler.off_policy_steps += 1
+            await self.train_scheduler.drop_stale_groups()
+            self.async_barrier_clear.set()
 
     async def _update_weights(self, ckpt_step: int) -> None:
         """Update the weights to the next training checkpoint."""
@@ -140,6 +153,8 @@ class PolicyScheduler:
     def get_metrics(self) -> dict[str, float]:
         return {
             "time/update_weights": self.update_weights_time,
+            "time/wait_for_ckpt": self.wait_for_ckpt_time,
+            "scheduler/async_level": self.async_level,
         }
 
 
@@ -167,7 +182,6 @@ class TrainScheduler:
         token_batch_size: int | None,
         rollouts_per_example: int,
         max_off_policy_steps: int,
-        max_async_level: int,
         model_name: str,
         json_logging: bool = False,
     ):
@@ -176,8 +190,6 @@ class TrainScheduler:
         self.buffer = buffer
         self.progress = progress
         self.limiter = rollout_limiter
-        self.max_async_level = max_async_level
-        self.policy_scheduler: PolicyScheduler | None = None
         self._uses_token_batching = token_batch_size is not None
         self._batch_target = token_batch_size or batch_size
         self.rollouts_per_example = rollouts_per_example
@@ -186,9 +198,9 @@ class TrainScheduler:
         self.json_logging = json_logging
 
         # Group tracking
-        self._next_group_id = 0
-        self._groups: dict[int, InflightGroup] = {}
-        self._task_to_group: dict[asyncio.Task, int] = {}
+        self._groups: dict[str, InflightGroup] = {}
+        self._task_to_group: dict[asyncio.Task, str] = {}
+        self.off_policy_steps = 0
 
         # Batch accumulation
         self._batch_rollouts: list[vf.RolloutOutput] = []
@@ -215,15 +227,15 @@ class TrainScheduler:
     # ------------------------------------------------------------------
 
     @property
-    def ckpt_step(self) -> int:
-        return self.policy_scheduler.ckpt_step if self.policy_scheduler else self.progress.step
-
-    @property
     def num_inflight_rollouts(self) -> int:
-        return sum(g.total_inflight_rollouts for g in self._groups.values())
+        return sum(g.num_inflight_rollouts for g in self._groups.values())
 
     def _off_policy_levels(self) -> list[int]:
-        return [self.ckpt_step - r.ckpt_step for g in self._groups.values() for r in g.inflight_requests.values()]
+        return [
+            self.off_policy_steps - r.off_policy_steps
+            for g in self._groups.values()
+            for r in g.inflight_requests.values()
+        ]
 
     # ------------------------------------------------------------------
     # Public API
@@ -246,7 +258,7 @@ class TrainScheduler:
     async def cancel_inflight_rollouts(self) -> None:
         """Cancel all in-flight rollout requests and release their slots."""
         all_tasks = list(self._task_to_group.keys())
-        count = sum(g.total_inflight_rollouts for g in self._groups.values())
+        count = sum(g.num_inflight_rollouts for g in self._groups.values())
         await safe_cancel_all(all_tasks)
         for group in self._groups.values():
             group.inflight_requests.clear()
@@ -256,12 +268,8 @@ class TrainScheduler:
         self.limiter.release(count)
 
     async def wait_for_batch(self) -> list[vf.RolloutOutput]:
-        """Block until the current batch is complete and async level allows it."""
+        """Block until the current batch is complete, then return it."""
         await self._batch_ready.wait()
-
-        # Enforce async level: don't return batch if orchestrator is too far ahead
-        while self.progress.step - self.ckpt_step > self.max_async_level:
-            await asyncio.sleep(0.1)
 
         batch = list(self._batch_rollouts)
         self.last_batch_generation_time = time.perf_counter() - self._batch_start_time
@@ -282,7 +290,6 @@ class TrainScheduler:
             json_logging=self.json_logging,
             step=self.progress.step,
         )
-        self.resume()  # start filling the next batch
 
     async def stop(self) -> None:
         """Stop all background tasks and cancel in-flight rollouts."""
@@ -317,15 +324,12 @@ class TrainScheduler:
     def _create_group(self) -> InflightGroup:
         """Sample an example from the buffer and create a new group."""
         example = self.buffer.sample_examples(n=1)[0]
-        group_id = self._next_group_id
-        self._next_group_id += 1
         group = InflightGroup(
-            group_id=group_id,
             example=example,
             env_name=example["env_name"],
             rollouts_to_schedule=self.rollouts_per_example,
         )
-        self._groups[group_id] = group
+        self._groups[group.group_id] = group
         return group
 
     async def _schedule_from_group(self, group: InflightGroup) -> None:
@@ -350,8 +354,8 @@ class TrainScheduler:
                     rollouts_per_example=rollout_count,
                 )
             )
-            request = InflightGroupRequest(
-                task=task, client=client, ckpt_step=self.ckpt_step, rollouts_per_example=rollout_count
+            request = InflightRequest(
+                task=task, client=client, rollout_count=rollout_count, off_policy_steps=self.off_policy_steps
             )
         else:
             await self.limiter.acquire(1)
@@ -363,7 +367,7 @@ class TrainScheduler:
                     model_name=self.model_name,
                 )
             )
-            request = InflightRolloutRequest(task=task, client=client, ckpt_step=self.ckpt_step)
+            request = InflightRequest(task=task, client=client, off_policy_steps=self.off_policy_steps)
 
         group.inflight_requests[task] = request
         self._task_to_group[task] = group.group_id
@@ -398,7 +402,7 @@ class TrainScheduler:
                 self.limiter.release(request.rollout_count)
                 await self._process_completion(group_id, group, request)
 
-    async def _process_completion(self, group_id: int, group: InflightGroup, request: InflightRequest) -> None:
+    async def _process_completion(self, group_id: str, group: InflightGroup, request: InflightRequest) -> None:
         """Process a completed request: validate, reschedule failures, accumulate batch."""
         env = self.train_envs.get(group.env_name)
 
@@ -470,7 +474,7 @@ class TrainScheduler:
     # Group management
     # ------------------------------------------------------------------
 
-    async def _drop_group(self, group_id: int) -> int:
+    async def _drop_group(self, group_id: str) -> int:
         """Drop a group: cancel pending requests, release slots."""
         group = self._groups.pop(group_id, None)
         if group is None:
@@ -504,13 +508,14 @@ class TrainScheduler:
         )
         return min(clients, key=lambda c: inflight[self._client_identity(c)])
 
-    async def drop_stale_groups(self, current_ckpt_step: int) -> None:
+    async def drop_stale_groups(self) -> None:
         """Drop groups with requests older than max_off_policy_steps."""
         stale_group_ids = {
             gid
             for gid, group in self._groups.items()
             if any(
-                current_ckpt_step - r.ckpt_step >= self.max_off_policy_steps for r in group.inflight_requests.values()
+                self.off_policy_steps - r.off_policy_steps >= self.max_off_policy_steps
+                for r in group.inflight_requests.values()
             )
         }
         if not stale_group_ids:
@@ -520,8 +525,7 @@ class TrainScheduler:
         removed = sum(counts)
         if removed:
             get_logger().warning(
-                f"Cancelled {removed} stale rollout requests (ckpt_step={current_ckpt_step}). "
-                f"Consider increasing max_off_policy_steps to avoid this."
+                f"Cancelled {removed} stale rollout requests. Consider increasing max_off_policy_steps to avoid this."
             )
 
     # ------------------------------------------------------------------
@@ -547,7 +551,7 @@ class TrainScheduler:
         by_env: dict[str, list[int]] = {}
         for group in self._groups.values():
             for request in group.inflight_requests.values():
-                by_env.setdefault(group.env_name, []).append(self.ckpt_step - request.ckpt_step)
+                by_env.setdefault(group.env_name, []).append(self.off_policy_steps - request.off_policy_steps)
         for env_name, steps in by_env.items():
             metrics[f"off_policy_level/{env_name}/max"] = max(steps)
             metrics[f"off_policy_level/{env_name}/mean"] = sum(steps) / len(steps)

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -112,8 +112,8 @@ class TrainScheduler:
         self.train_envs = train_envs
         self.buffer = buffer
         self.config = config
-        self.batch_size = config.batch_size
-        self.token_batch_size = config.token_batch_size
+        self._batch_target = config.token_batch_size or config.batch_size
+        self._max_batch_rollouts = config.batch_size
         self.rollouts_per_example = config.rollouts_per_example
         self.max_async_level = max_async_level
         self.max_off_policy_steps = max_off_policy_steps
@@ -159,18 +159,6 @@ class TrainScheduler:
     # ------------------------------------------------------------------
     # Properties
     # ------------------------------------------------------------------
-
-    @property
-    def _uses_token_batching(self) -> bool:
-        return self.token_batch_size is not None
-
-    @property
-    def _batch_target(self) -> int:
-        if self._uses_token_batching:
-            assert self.token_batch_size is not None
-            return self.token_batch_size
-        assert self.batch_size is not None
-        return self.batch_size
 
     @property
     def inflight_rollout_count(self) -> int:
@@ -444,7 +432,7 @@ class TrainScheduler:
         accepted = self.buffer.sample_rollouts(n=self.rollouts_per_example)
 
         self._batch_rollouts.extend(accepted)
-        if self._uses_token_batching:
+        if self._max_batch_rollouts is None:
             increment = sum(get_seq_len(r) for r in accepted)
         else:
             increment = len(accepted)
@@ -609,8 +597,8 @@ class TrainScheduler:
 
     def _finalize_batch(self) -> list[vf.RolloutOutput]:
         batch = list(self._batch_rollouts)
-        if self.batch_size is not None:
-            batch = batch[: self.batch_size]
+        if self._max_batch_rollouts is not None:
+            batch = batch[: self._max_batch_rollouts]
         return batch
 
     # ------------------------------------------------------------------

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -408,15 +408,16 @@ class TrainScheduler:
         self._work_seq += 1
 
     def _next_request(self) -> RolloutRequest:
-        """Pop the next request from the heap. Skips dropped groups. Creates new work if empty."""
-        while self._work_queue:
+        """Pop the next request from the heap, creating new groups as needed."""
+        while True:
+            if not self._work_queue:
+                self._enqueue_new_group()
             _, _, group_id, cost = heapq.heappop(self._work_queue)
             if group_id in self._groups:
                 return RolloutRequest(group_id=group_id, cost=cost)
-        return self._create_new_request()
 
-    def _create_new_request(self) -> RolloutRequest:
-        """Sample an example, create a group, enqueue its work, and return the first request."""
+    def _enqueue_new_group(self) -> None:
+        """Sample an example, create a group, and enqueue all its work."""
         example = self.buffer.sample_examples(n=1)[0]
         env = self.train_envs.get(example["env_name"])
         group = RolloutGroup(
@@ -428,12 +429,10 @@ class TrainScheduler:
         self._groups[group.group_id] = group
 
         if group.requires_group_scoring:
-            return RolloutRequest(group_id=group.group_id, cost=group.rollouts_per_example)
-
-        # Enqueue N-1 items, return first immediately
-        for _ in range(self.rollouts_per_example - 1):
-            self._enqueue(group.group_id, cost=1)
-        return RolloutRequest(group_id=group.group_id, cost=1)
+            self._enqueue(group.group_id, cost=group.rollouts_per_example)
+        else:
+            for _ in range(self.rollouts_per_example):
+                self._enqueue(group.group_id, cost=1)
 
     # ------------------------------------------------------------------
     # Completion loop

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -12,6 +12,7 @@ import verifiers as vf
 from verifiers.utils.logging_utils import print_time
 
 from prime_rl.orchestrator.buffer import Buffer
+from prime_rl.orchestrator.ckpt import Progress
 from prime_rl.orchestrator.concurrency import RolloutLimiter
 from prime_rl.orchestrator.envs import EvalEnv, TrainEnvs
 from prime_rl.orchestrator.vf_utils import get_seq_len
@@ -98,6 +99,7 @@ class PolicyScheduler:
         self,
         train_scheduler: TrainScheduler,
         inference_pool: InferencePool,
+        progress: Progress,
         output_dir: Path,
         max_async_level: int,
         strict_async_level: bool,
@@ -106,6 +108,7 @@ class PolicyScheduler:
     ):
         self.train_scheduler = train_scheduler
         self.inference_pool = inference_pool
+        self.progress = progress
         self.output_dir = output_dir
         self.max_async_level = max_async_level
         self.strict_async_level = strict_async_level
@@ -118,15 +121,27 @@ class PolicyScheduler:
 
     async def maybe_update(self, step: int) -> None:
         """Check for and apply any pending policy updates."""
+
+        def get_next_ckpt_step() -> int:
+            latest_ckpt_step = get_latest_ckpt_step(get_broadcast_dir(self.output_dir)) or 0
+            async_away_ckpt_step = max(step - self.max_async_level, 0)
+            if self.strict_async_level:
+                return async_away_ckpt_step
+            return max(async_away_ckpt_step, latest_ckpt_step)
+
         while True:
-            next_ckpt_step = self._compute_next_ckpt_step(step)
+            next_ckpt_step = get_next_ckpt_step()
             if next_ckpt_step <= self.ckpt_step:
                 return
             await self._apply_update(next_ckpt_step, step)
 
     @property
     def async_level(self) -> int:
-        return self.train_scheduler.step - self.ckpt_step
+        return self.progress.step - self.ckpt_step
+
+    @property
+    def at_async_barrier(self) -> bool:
+        return self.progress.step - self.ckpt_step == self.max_async_level
 
     def get_metrics(self) -> dict[str, float]:
         return {
@@ -136,17 +151,10 @@ class PolicyScheduler:
         }
 
     async def run(self) -> None:
-        """Background loop. Reads current step from train_scheduler.step."""
+        """Background loop. Reads current step from progress.step."""
         while True:
-            await self.maybe_update(self.train_scheduler.step)
+            await self.maybe_update(self.progress.step)
             await asyncio.sleep(1)
-
-    def _compute_next_ckpt_step(self, step: int) -> int:
-        latest_ckpt_step = get_latest_ckpt_step(get_broadcast_dir(self.output_dir)) or 0
-        async_away_ckpt_step = max(step - self.max_async_level, 0)
-        if self.strict_async_level:
-            return async_away_ckpt_step
-        return max(async_away_ckpt_step, latest_ckpt_step)
 
     async def _apply_update(self, next_ckpt_step: int, step: int) -> None:
         # Wait for checkpoint if we're at the async barrier
@@ -205,6 +213,7 @@ class TrainScheduler:
         train_envs: TrainEnvs,
         inference_pool: InferencePool,
         buffer: Buffer,
+        progress: Progress,
         rollout_limiter: RolloutLimiter,
         batch_size: int | None,
         token_batch_size: int | None,
@@ -218,6 +227,7 @@ class TrainScheduler:
         self.train_envs = train_envs
         self.inference_pool = inference_pool
         self.buffer = buffer
+        self.progress = progress
         self._uses_token_batching = token_batch_size is not None
         self._batch_target = token_batch_size or batch_size
         self.rollouts_per_example = rollouts_per_example
@@ -242,7 +252,6 @@ class TrainScheduler:
         self._scheduling_task: asyncio.Task | None = None
         self._completion_task: asyncio.Task | None = None
 
-        self.step = 0
         self.ckpt_step = 0
 
         # Metrics (reset per step)
@@ -268,13 +277,9 @@ class TrainScheduler:
     # Public API
     # ------------------------------------------------------------------
 
-    async def start(self, step: int) -> None:
+    async def start(self) -> None:
         """Start background loops. Call once at the beginning of training."""
-        self.step = step
-        self._batch_start_time = time.perf_counter()
-        self._pbar = ProgressTracker(
-            total=self._batch_target, desc="Generating rollouts (train)", json_logging=self.json_logging, step=step
-        )
+        self._reset_batch()
         self._scheduling_task = asyncio.create_task(self._scheduling_loop())
         self._completion_task = asyncio.create_task(self._completion_loop())
 
@@ -307,17 +312,19 @@ class TrainScheduler:
         if self._pbar:
             self._pbar.close()
             self._pbar = None
+        self._reset_batch()
         return batch
 
-    def advance_step(self, step: int) -> None:
-        """Advance to the next training step and reset batch accumulation."""
-        self.step = step
+    def _reset_batch(self) -> None:
         self._batch_rollouts.clear()
         self._batch_progress = 0
         self._batch_ready.clear()
         self._batch_start_time = time.perf_counter()
         self._pbar = ProgressTracker(
-            total=self._batch_target, desc="Generating rollouts (train)", json_logging=self.json_logging, step=step
+            total=self._batch_target,
+            desc="Generating rollouts (train)",
+            json_logging=self.json_logging,
+            step=self.progress.step,
         )
 
     async def stop(self) -> None:

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import time
 import uuid
-from collections import Counter, defaultdict, deque
+from collections import Counter, defaultdict
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -98,19 +98,29 @@ class RolloutGroup:
     client: vf.ClientConfig | None = None
     off_policy_steps: int = 0
     completed: list[vf.RolloutOutput] = field(default_factory=list)
+    remaining: int = -1  # individual rollouts left to schedule (set in __post_init__)
+    pending_retries: int = 0
+    failure_count: int = 0
+
+    def __post_init__(self) -> None:
+        if self.remaining < 0:
+            self.remaining = 0 if self.requires_group_scoring else self.rollouts_per_example
 
     @property
     def is_complete(self) -> bool:
         return len(self.completed) >= self.rollouts_per_example
 
+    @property
+    def needs_scheduling(self) -> bool:
+        return self.pending_retries > 0 or self.remaining > 0
+
 
 @dataclass
 class RolloutRequest:
-    """Tracks a single rollout task — lives in queues, then in the inflight dict."""
+    """Metadata for a single in-flight rollout task."""
 
     group_id: str
     cost: int  # limiter slots: 1 for individual, N for group scoring
-    failure_count: int = 0
 
 
 # ---------------------------------------------------------------------------
@@ -276,8 +286,6 @@ class TrainScheduler:
         # Group + request tracking
         self._groups: dict[str, RolloutGroup] = {}
         self._requests: dict[asyncio.Task, RolloutRequest] = {}
-        self._retry_queue: deque[RolloutRequest] = deque()
-        self._schedule_queue: deque[RolloutRequest] = deque()
 
         # Batch accumulation
         self._batch_rollouts: list[vf.RolloutOutput] = []
@@ -333,8 +341,6 @@ class TrainScheduler:
         await safe_cancel_all(all_tasks)
         self._requests.clear()
         self._groups.clear()
-        self._retry_queue.clear()
-        self._schedule_queue.clear()
         self.dispatcher.clear()
         self.cancelled_rollouts_count += count
         self.dispatcher.limiter.release(count)
@@ -399,16 +405,22 @@ class TrainScheduler:
             self._requests[task] = request
 
     def _next_request(self) -> RolloutRequest:
-        """Return the next request to schedule: retries first, then queued, then new."""
-        for queue in (self._retry_queue, self._schedule_queue):
-            while queue:
-                request = queue.popleft()
-                if request.group_id in self._groups:
-                    return request
+        """Return the next request: retries first, then remaining work, then new group."""
+        for group in self._groups.values():
+            if group.pending_retries > 0:
+                group.pending_retries -= 1
+                cost = group.rollouts_per_example if group.requires_group_scoring else 1
+                return RolloutRequest(group_id=group.group_id, cost=cost)
+
+        for group in self._groups.values():
+            if group.remaining > 0:
+                group.remaining -= 1
+                return RolloutRequest(group_id=group.group_id, cost=1)
+
         return self._create_new_request()
 
     def _create_new_request(self) -> RolloutRequest:
-        """Sample an example, create a group, and enqueue its requests."""
+        """Sample an example, create a group, and return its first request."""
         example = self.buffer.sample_examples(n=1)[0]
         env = self.train_envs.get(example["env_name"])
         group = RolloutGroup(
@@ -422,12 +434,8 @@ class TrainScheduler:
         if group.requires_group_scoring:
             return RolloutRequest(group_id=group.group_id, cost=group.rollouts_per_example)
 
-        for _ in range(self.rollouts_per_example - 1):
-            self._schedule_queue.append(RolloutRequest(group_id=group.group_id, cost=1))
+        group.remaining -= 1
         return RolloutRequest(group_id=group.group_id, cost=1)
-
-    def _fire(self, group: RolloutGroup, cost: int) -> asyncio.Task:
-        """Create an asyncio task for a rollout request."""
 
     # ------------------------------------------------------------------
     # Completion loop
@@ -478,15 +486,16 @@ class TrainScheduler:
         self._record_rollout_metrics(group, rollouts)
 
         if num_failed:
-            request.failure_count += 1
-            if request.failure_count >= self.max_retries:
+            group.failure_count += num_failed
+            if group.failure_count >= self.max_retries:
                 self._drop_group(group.group_id)
                 return
             if group.requires_group_scoring:
                 group.completed.clear()
+                group.pending_retries += 1
             else:
                 group.completed.extend(valid)
-            self._retry_queue.append(request)
+                group.pending_retries += num_failed
         else:
             group.completed.extend(valid)
 

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -113,7 +113,7 @@ class TrainScheduler:
         self.buffer = buffer
         self.config = config
         self._batch_target = config.token_batch_size or config.batch_size
-        self._max_batch_rollouts = config.batch_size
+        self._batch_size = config.batch_size
         self.rollouts_per_example = config.rollouts_per_example
         self.max_async_level = max_async_level
         self.max_off_policy_steps = max_off_policy_steps
@@ -432,7 +432,7 @@ class TrainScheduler:
         accepted = self.buffer.sample_rollouts(n=self.rollouts_per_example)
 
         self._batch_rollouts.extend(accepted)
-        if self._max_batch_rollouts is None:
+        if self._batch_size is None:
             increment = sum(get_seq_len(r) for r in accepted)
         else:
             increment = len(accepted)
@@ -597,8 +597,8 @@ class TrainScheduler:
 
     def _finalize_batch(self) -> list[vf.RolloutOutput]:
         batch = list(self._batch_rollouts)
-        if self._max_batch_rollouts is not None:
-            batch = batch[: self._max_batch_rollouts]
+        if self._batch_size is not None:
+            batch = batch[: self._batch_size]
         return batch
 
     # ------------------------------------------------------------------

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -124,7 +124,7 @@ class PolicyScheduler:
 
     @property
     def at_async_barrier(self) -> bool:
-        return self.async_level >= self.max_async_level
+        return self.async_level > self.max_async_level
 
     async def wait_until_ready(self) -> None:
         """Block until the async barrier is clear (ckpt_step is fresh enough).
@@ -145,7 +145,7 @@ class PolicyScheduler:
             await self.train_scheduler.drop_stale_groups(next_ckpt_step)
             self.train_scheduler.resume()
 
-    async def run(self) -> None:
+    async def start(self) -> None:
         """Background loop: poll for new checkpoints and apply weight updates.
 
         1. If at latest checkpoint — sleep and retry
@@ -157,7 +157,7 @@ class PolicyScheduler:
         while True:
             next_ckpt_step = self._get_next_ckpt_step()
             if next_ckpt_step <= self.ckpt_step:
-                await asyncio.sleep(1)
+                await asyncio.sleep(0.1)
                 continue
 
             if self.at_async_barrier:

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections import Counter, defaultdict
+from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 
 import verifiers as vf
@@ -556,8 +557,19 @@ class Scheduler:
         return metrics
 
 
+@dataclass
+class EvalResult:
+    """Result of evaluating a single eval environment."""
+
+    env_name: str
+    rollouts: list[vf.RolloutOutput]
+    total_rollouts: int
+    rollouts_per_example: int
+    eval_time: float
+
+
 class EvalScheduler:
-    """Manages concurrency-limited eval rollout scheduling via a shared ConcurrencyLimiter."""
+    """Schedules eval rollouts with shared concurrency and rate limiting."""
 
     def __init__(
         self,
@@ -565,34 +577,94 @@ class EvalScheduler:
         inference_pool: InferencePool,
         rate_limiter: AsyncLimiter | None = None,
     ):
+        self.logger = get_logger()
         self.limiter = concurrency_limiter
         self.inference_pool = inference_pool
         self.rate_limiter = rate_limiter
 
-    async def evaluate(
+    async def run(
         self,
-        eval_env: EvalEnv,
+        eval_envs: list[EvalEnv],
         model_name: str,
-        ckpt_step: int,
-        step: int,
-    ) -> list[vf.RolloutOutput]:
-        """Run eval with concurrency limiting via the shared limiter."""
+    ) -> AsyncIterator[EvalResult]:
+        """Run evals for multiple envs, yielding results as each env completes."""
+        tasks: dict[asyncio.Task, EvalEnv] = {
+            asyncio.create_task(self._run_env(env, model_name)): env for env in eval_envs
+        }
+        while tasks:
+            done, _ = await asyncio.wait(tasks.keys(), return_when=asyncio.FIRST_COMPLETED)
+            for task in done:
+                tasks.pop(task)
+                yield task.result()
+
+    async def _run_env(self, eval_env: EvalEnv, model_name: str) -> EvalResult:
+        """Run all rollouts for one eval env with concurrency control."""
+        num_examples = len(eval_env.examples)
         rollouts_per_example = eval_env.config.rollouts_per_example
+        total_rollouts = num_examples * rollouts_per_example
         cost_per_coro = rollouts_per_example if eval_env.requires_group_scoring else 1
 
-        async def get_client() -> vf.ClientConfig:
-            if self.rate_limiter:
-                await self.rate_limiter.acquire()
-            await self.limiter.acquire(cost_per_coro)
-            return await self.inference_pool.get_eval_client()
+        self.logger.info(f"Evaluating {eval_env.name} ({num_examples=}, {rollouts_per_example=})")
+        pbar = ProgressTracker(total=total_rollouts, desc=f"Evaluating {eval_env.name}")
+        eval_start = time.perf_counter()
 
-        def on_rollout_done(count: int) -> None:
-            self.limiter.release(count)
+        if eval_env.requires_group_scoring:
 
-        return await eval_env.evaluate(
-            model_name=model_name,
-            get_client=get_client,
-            ckpt_step=ckpt_step,
-            step=step,
-            on_rollout_done=on_rollout_done,
+            async def run_one(example: dict) -> list[vf.RolloutOutput] | None:
+                try:
+                    if self.rate_limiter:
+                        await self.rate_limiter.acquire()
+                    await self.limiter.acquire(cost_per_coro)
+                    client = await self.inference_pool.get_eval_client()
+                    outputs = await eval_env.run_group(
+                        client=client,
+                        example=example,
+                        model_name=model_name,
+                        rollouts_per_example=rollouts_per_example,
+                    )
+                    pbar.update(rollouts_per_example)
+                    return outputs
+                except Exception as e:
+                    self.logger.warning(f"Group failed: {e}")
+                    pbar.update(rollouts_per_example)
+                    return None
+                finally:
+                    self.limiter.release(cost_per_coro)
+
+            coros = [run_one(example) for example in eval_env.examples]
+
+        else:
+
+            async def run_one(example: dict) -> list[vf.RolloutOutput] | None:
+                try:
+                    if self.rate_limiter:
+                        await self.rate_limiter.acquire()
+                    await self.limiter.acquire(1)
+                    client = await self.inference_pool.get_eval_client()
+                    output = await eval_env.run_rollout(client=client, example=example, model_name=model_name)
+                    pbar.update(1)
+                    return [output]
+                except Exception as e:
+                    self.logger.warning(f"Rollout failed: {e}")
+                    pbar.update(1)
+                    return None
+                finally:
+                    self.limiter.release(1)
+
+            coros = [run_one(example) for example in eval_env.examples for _ in range(rollouts_per_example)]
+
+        try:
+            results = await asyncio.gather(*coros)
+        finally:
+            pbar.close()
+
+        rollouts = [o for group in results if group is not None for o in group]
+        eval_time = time.perf_counter() - eval_start
+
+        return EvalResult(
+            env_name=eval_env.name,
+            rollouts=rollouts,
+            total_rollouts=total_rollouts,
+            rollouts_per_example=rollouts_per_example,
+            eval_time=eval_time,
         )

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import time
 import uuid
-from collections import Counter, defaultdict
+from collections import Counter, defaultdict, deque
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -14,10 +14,10 @@ from verifiers.utils.logging_utils import print_time
 from prime_rl.orchestrator.buffer import Buffer
 from prime_rl.orchestrator.ckpt import Progress
 from prime_rl.orchestrator.concurrency import RolloutLimiter
-from prime_rl.orchestrator.envs import EvalEnv, TrainEnv, TrainEnvs
+from prime_rl.orchestrator.envs import EvalEnv, TrainEnvs
 from prime_rl.orchestrator.vf_utils import get_seq_len
 from prime_rl.utils.async_utils import safe_cancel, safe_cancel_all
-from prime_rl.utils.client import InferencePool
+from prime_rl.utils.client import InferencePool, client_identity
 from prime_rl.utils.logger import ProgressTracker, get_logger
 from prime_rl.utils.utils import (
     get_broadcast_dir,
@@ -33,82 +33,29 @@ from prime_rl.utils.utils import (
 
 @dataclass
 class RolloutGroup:
-    """All rollouts for a single example. Manages its own tasks and completion."""
+    """Pure state for a rollout group (one example x N rollouts)."""
 
     env_name: str
     example: dict
     requires_group_scoring: bool
     rollouts_per_example: int
     group_id: str = field(default_factory=lambda: uuid.uuid4().hex[:12])
-
-    # Reuse the same client for all rollouts in a group to maximize prefix cache hits
     client: vf.ClientConfig | None = None
     off_policy_steps: int = 0
-
-    tasks: dict[asyncio.Task, int] = field(default_factory=dict)  # task → rollout_count
     completed: list[vf.RolloutOutput] = field(default_factory=list)
-    _remaining: int = -1  # set in __post_init__
-
-    def __post_init__(self) -> None:
-        self._remaining = self.rollouts_per_example
 
     @property
     def is_complete(self) -> bool:
         return len(self.completed) >= self.rollouts_per_example
 
-    @property
-    def needs_scheduling(self) -> bool:
-        return self._remaining > 0
 
-    @property
-    def num_inflight(self) -> int:
-        return sum(self.tasks.values())
+@dataclass
+class RolloutRequest:
+    """Tracks a single rollout task — lives in queues, then in the inflight dict."""
 
-    async def schedule(self, env: TrainEnv, model_name: str, limiter: RolloutLimiter) -> asyncio.Task:
-        """Schedule the next chunk of work. Blocks on limiter until a slot is available."""
-        if self.requires_group_scoring:
-            n = self._remaining
-            self._remaining = 0
-        else:
-            n = 1
-            self._remaining -= 1
-
-        await limiter.acquire(n)
-
-        if self.requires_group_scoring:
-            task = asyncio.create_task(
-                env.run_group(client=self.client, example=self.example, model_name=model_name, rollouts_per_example=n)
-            )
-        else:
-            task = asyncio.create_task(env.run_rollout(client=self.client, example=self.example, model_name=model_name))
-
-        self.tasks[task] = n
-        return task
-
-    def complete(self, task: asyncio.Task) -> tuple[int, list[vf.RolloutOutput]]:
-        """Process a finished task. Returns (slots_to_release, raw_rollouts)."""
-        n = self.tasks.pop(task)
-
-        result = task.result()
-        rollouts: list[vf.RolloutOutput] = result if isinstance(result, list) else [result]
-
-        valid = []
-        failed = 0
-        for rollout in rollouts:
-            if len(rollout["trajectory"]) == 0 or rollout["error"] is not None:
-                failed += 1
-            else:
-                rollout["env_name"] = self.env_name
-                valid.append(rollout)
-
-        if failed and self.requires_group_scoring:
-            self.completed.clear()
-            self._remaining = self.rollouts_per_example
-        else:
-            self.completed.extend(valid)
-            self._remaining += failed
-
-        return n, rollouts
+    group_id: str
+    cost: int  # limiter slots: 1 for individual, N for group scoring
+    failure_count: int = 0
 
 
 # ---------------------------------------------------------------------------
@@ -195,7 +142,7 @@ class PolicyScheduler:
             await self._update_weights(next_step)
             get_logger().debug(f"Weights updated in {print_time(self.update_weights_time)}")
 
-            await self.train_scheduler.on_weights_updated()
+            self.train_scheduler.on_weights_updated()
             self.train_scheduler.resume()
             self.async_barrier_clear.set()
 
@@ -220,19 +167,6 @@ class PolicyScheduler:
 
 
 # ---------------------------------------------------------------------------
-# Batch
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class Batch:
-    """A collected batch of rollouts ready for training."""
-
-    rollouts: list[vf.RolloutOutput]
-    generation_time: float
-
-
-# ---------------------------------------------------------------------------
 # Train scheduler
 # ---------------------------------------------------------------------------
 
@@ -241,9 +175,9 @@ class TrainScheduler:
     """Always-on scheduler with two background loops: scheduling and completion processing.
 
     Scheduling is gated on two independent events:
-    - ``_batch_gate``: open while the current batch needs more rollouts.
-      Automatically closed when a batch fills, re-opened by ``next_batch()``.
-    - ``_policy_gate``: open unless an external caller (``PolicyScheduler``
+    - ``_batch_needs_rollouts``: set while the current batch needs more rollouts.
+      Automatically cleared when a batch fills, re-set by ``next_batch()``.
+    - ``_policy_gate``: set unless an external caller (``PolicyScheduler``
       or eval) explicitly pauses scheduling via ``pause()``/``resume()``.
 
     References:
@@ -262,6 +196,7 @@ class TrainScheduler:
         token_batch_size: int | None,
         rollouts_per_example: int,
         max_off_policy_steps: int,
+        max_retries: int,
         model_name: str,
         json_logging: bool = False,
     ):
@@ -274,23 +209,27 @@ class TrainScheduler:
         self._batch_target = token_batch_size or batch_size
         self.rollouts_per_example = rollouts_per_example
         self.max_off_policy_steps = max_off_policy_steps
+        self.max_retries = max_retries
         self.model_name = model_name
         self.json_logging = json_logging
 
-        # Group tracking
-        self.inflight_groups: dict[str, RolloutGroup] = {}
-        self._task_index: dict[asyncio.Task, str] = {}  # task → group_id
+        # Group + request tracking
+        self._groups: dict[str, RolloutGroup] = {}
+        self._requests: dict[asyncio.Task, RolloutRequest] = {}
+        self._retry_queue: deque[RolloutRequest] = deque()
+        self._schedule_queue: deque[RolloutRequest] = deque()
+        self._client_load: Counter[tuple[str, str | None]] = Counter()
 
         # Batch accumulation
         self._batch_rollouts: list[vf.RolloutOutput] = []
         self._batch_progress = 0
-        self._batch_ready = asyncio.Event()
+        self._batch_full = asyncio.Event()  # set when batch reaches target, waited on by next_batch()
+        self._batch_needs_rollouts = asyncio.Event()  # inverse of _batch_full, waited on by scheduling loop
+        self._batch_needs_rollouts.set()
         self._pbar: ProgressTracker | None = None
 
-        # Scheduling gates (both must be set for scheduling to proceed)
-        self._batch_gate = asyncio.Event()  # cleared when batch is full
-        self._batch_gate.set()
-        self._policy_gate = asyncio.Event()  # cleared by pause(), set by resume()
+        # Scheduling gate: cleared by pause(), set by resume()
+        self._policy_gate = asyncio.Event()
         self._policy_gate.set()
         self._scheduling_task: asyncio.Task | None = None
         self._completion_task: asyncio.Task | None = None
@@ -308,7 +247,7 @@ class TrainScheduler:
 
     @property
     def num_inflight_rollouts(self) -> int:
-        return sum(g.num_inflight for g in self.inflight_groups.values())
+        return sum(r.cost for r in self._requests.values())
 
     # ------------------------------------------------------------------
     # Public API
@@ -330,38 +269,39 @@ class TrainScheduler:
 
     async def cancel_inflight_rollouts(self) -> None:
         """Cancel all in-flight rollout requests and release their slots."""
-        all_tasks = list(self._task_index.keys())
-        count = sum(g.num_inflight for g in self.inflight_groups.values())
+        all_tasks = list(self._requests.keys())
+        count = sum(r.cost for r in self._requests.values())
         await safe_cancel_all(all_tasks)
-        self._task_index.clear()
-        self.inflight_groups.clear()
+        self._requests.clear()
+        self._groups.clear()
+        self._retry_queue.clear()
+        self._schedule_queue.clear()
+        self._client_load.clear()
         self.cancelled_rollouts_count += count
         self.limiter.release(count)
 
-    async def next_batch(self) -> Batch:
-        """Block until the current batch is complete, then return it.
+    async def next_batch(self) -> tuple[list[vf.RolloutOutput], float]:
+        """Block until the current batch is complete, then return (rollouts, generation_time).
 
-        Automatically re-opens the batch gate so scheduling resumes for the
-        next batch. Callers never need to call ``resume()`` for batch
-        lifecycle — only for external pauses (eval, async barrier).
+        Automatically resets for the next batch so scheduling resumes.
+        Callers never need to call ``resume()`` for batch lifecycle —
+        only for external pauses (eval, async barrier).
         """
-        await self._batch_ready.wait()
+        await self._batch_full.wait()
 
-        batch = Batch(
-            rollouts=list(self._batch_rollouts),
-            generation_time=time.perf_counter() - self._batch_start_time,
-        )
+        rollouts = list(self._batch_rollouts)
+        generation_time = time.perf_counter() - self._batch_start_time
         if self._pbar:
             self._pbar.close()
             self._pbar = None
         self._reset_batch()
-        return batch
+        return rollouts, generation_time
 
     def _reset_batch(self) -> None:
         self._batch_rollouts.clear()
         self._batch_progress = 0
-        self._batch_ready.clear()
-        self._batch_gate.set()
+        self._batch_full.clear()
+        self._batch_needs_rollouts.set()
         self._batch_start_time = time.perf_counter()
         self._pbar = ProgressTracker(
             total=self._batch_target,
@@ -384,78 +324,118 @@ class TrainScheduler:
     # ------------------------------------------------------------------
 
     async def _scheduling_loop(self) -> None:
-        """Continuously schedule rollouts. Blocks on gates or limiter."""
+        """Continuously schedule rollouts. Blocks when batch is full or paused."""
         while True:
-            await self._batch_gate.wait()
+            await self._batch_needs_rollouts.wait()
             await self._policy_gate.wait()
-            group = self._next_schedulable() or self._create_group()
-            await self._schedule_from_group(group)
 
-    def _next_schedulable(self) -> RolloutGroup | None:
-        """Find a group that has pending rollouts to schedule (retries)."""
-        for group in self.inflight_groups.values():
-            if group.needs_scheduling:
-                return group
-        return None
+            request = self._next_request()
+            group = self._groups[request.group_id]
 
-    def _create_group(self) -> RolloutGroup:
-        """Sample an example from the buffer and create a new group."""
+            if group.client is None:
+                group.client = await self._select_least_loaded_client()
+
+            await self.limiter.acquire(request.cost)
+            env = self.train_envs.get(group.env_name)
+            task = asyncio.create_task(
+                env.run(client=group.client, example=group.example, model_name=self.model_name, n=cost)
+            )
+            self._requests[task] = request
+            self._client_load[client_identity(group.client)] += request.cost
+
+    def _next_request(self) -> RolloutRequest:
+        """Return the next request to schedule: retries first, then queued, then new."""
+        for queue in (self._retry_queue, self._schedule_queue):
+            while queue:
+                request = queue.popleft()
+                if request.group_id in self._groups:
+                    return request
+        return self._create_new_request()
+
+    def _create_new_request(self) -> RolloutRequest:
+        """Sample an example, create a group, and enqueue its requests."""
         example = self.buffer.sample_examples(n=1)[0]
         env = self.train_envs.get(example["env_name"])
         group = RolloutGroup(
-            example=example,
             env_name=example["env_name"],
+            example=example,
             requires_group_scoring=env.requires_group_scoring,
             rollouts_per_example=self.rollouts_per_example,
         )
-        self.inflight_groups[group.group_id] = group
-        return group
+        self._groups[group.group_id] = group
 
-    async def _schedule_from_group(self, group: RolloutGroup) -> None:
-        """Schedule one request from a group. Blocks until a concurrency slot is available."""
-        if group.client is None:
-            group.client = await self._select_least_loaded_client()
-        env = self.train_envs.get(group.env_name)
-        task = await group.schedule(env, self.model_name, self.limiter)
-        self._task_index[task] = group.group_id
+        if group.requires_group_scoring:
+            return RolloutRequest(group_id=group.group_id, cost=group.rollouts_per_example)
+
+        for _ in range(self.rollouts_per_example - 1):
+            self._schedule_queue.append(RolloutRequest(group_id=group.group_id, cost=1))
+        return RolloutRequest(group_id=group.group_id, cost=1)
+
+    def _fire(self, group: RolloutGroup, cost: int) -> asyncio.Task:
+        """Create an asyncio task for a rollout request."""
 
     # ------------------------------------------------------------------
     # Completion loop
     # ------------------------------------------------------------------
 
     async def _completion_loop(self) -> None:
-        """Continuously process completed rollout tasks."""
+        """Await completed tasks, process results, release slots."""
         while True:
-            tasks = list(self._task_index.keys())
-            if not tasks:
+            if not self._requests:
                 await asyncio.sleep(0.1)
                 continue
 
-            done, _ = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+            done, _ = await asyncio.wait(self._requests, return_when=asyncio.FIRST_COMPLETED)
 
             for task in done:
-                group_id = self._task_index.pop(task, None)
-                if group_id is None:
-                    continue
-                group = self.inflight_groups.get(group_id)
+                request = self._requests.pop(task, None)
+                if request is None:
+                    continue  # already removed by _drop_group
+
+                self.limiter.release(request.cost)
+
+                group = self._groups.get(request.group_id)
                 if group is None:
                     continue
-                await self._process_completion(group, task)
 
-    async def _process_completion(self, group: RolloutGroup, task: asyncio.Task) -> None:
-        """Process a completed task: validate, reschedule failures, accumulate batch."""
-        try:
-            n, rollouts = group.complete(task)
-        except asyncio.CancelledError:
-            await self._drop_group(group.group_id)
-            return
-        except Exception as e:
-            get_logger().warning(f"Rollout failed: {e}")
-            await self._drop_group(group.group_id)
-            return
+                if group.client is not None:
+                    self._client_load[client_identity(group.client)] -= request.cost
 
-        self.limiter.release(n)
+                try:
+                    result = task.result()
+                except asyncio.CancelledError:
+                    continue
+                except Exception as e:
+                    get_logger().warning(f"Rollout failed: {e}")
+                    self._drop_group(group.group_id)
+                    continue
+
+                self._process_rollouts(group, request, result)
+
+    def _process_rollouts(self, group: RolloutGroup, request: RolloutRequest, rollouts: list[vf.RolloutOutput]) -> None:
+        """Validate rollouts, handle retries, and finalize complete groups."""
+        valid, num_failed = [], 0
+        for rollout in rollouts:
+            if not rollout["trajectory"] or rollout["error"] is not None:
+                num_failed += 1
+            else:
+                rollout["env_name"] = group.env_name
+                valid.append(rollout)
+
         self._record_rollout_metrics(group, rollouts)
+
+        if num_failed:
+            request.failure_count += 1
+            if request.failure_count >= self.max_retries:
+                self._drop_group(group.group_id)
+                return
+            if group.requires_group_scoring:
+                group.completed.clear()
+            else:
+                group.completed.extend(valid)
+            self._retry_queue.append(request)
+        else:
+            group.completed.extend(valid)
 
         if group.is_complete:
             self._finalize_group(group)
@@ -464,7 +444,7 @@ class TrainScheduler:
         """Log warnings and track metrics for completed rollouts."""
         self.total_rollouts_by_env[group.env_name] += len(rollouts)
         for rollout in rollouts:
-            if len(rollout["trajectory"]) == 0:
+            if not rollout["trajectory"]:
                 self.empty_rollouts_by_env[group.env_name] += 1
                 get_logger().warning(
                     f"Empty trajectory in group {group.group_id} ({group.env_name}), re-scheduling "
@@ -480,7 +460,7 @@ class TrainScheduler:
 
     def _finalize_group(self, group: RolloutGroup) -> None:
         """Group complete — submit to buffer and accumulate batch."""
-        self.inflight_groups.pop(group.group_id)
+        self._groups.pop(group.group_id, None)
         self.buffer.update(group.completed)
         accepted = self.buffer.sample_rollouts(n=self.rollouts_per_example)
 
@@ -491,68 +471,55 @@ class TrainScheduler:
             self._pbar.update(increment)
 
         if self._batch_progress >= self._batch_target:
-            self._batch_ready.set()
-            self._batch_gate.clear()
+            self._batch_full.set()
+            self._batch_needs_rollouts.clear()
 
     # ------------------------------------------------------------------
     # Group management
     # ------------------------------------------------------------------
 
-    async def _drop_group(self, group_id: str) -> int:
-        """Drop a group: cancel pending tasks, release slots."""
-        group = self.inflight_groups.pop(group_id, None)
-        if group is None:
-            return 0
+    def _drop_group(self, group_id: str) -> int:
+        """Drop a group: cancel inflight tasks and release slots. Queued items are skipped lazily."""
+        group = self._groups.pop(group_id, None)
 
-        tasks_to_cancel = list(group.tasks.keys())
-        count = group.num_inflight
+        tasks_to_cancel = []
+        count = 0
+        for task, request in list(self._requests.items()):
+            if request.group_id == group_id:
+                tasks_to_cancel.append(task)
+                count += request.cost
+                self._requests.pop(task)
 
-        for task in tasks_to_cancel:
-            self._task_index.pop(task, None)
-        group.tasks.clear()
-
-        await safe_cancel_all(tasks_to_cancel)
         if count:
+            if group is not None and group.client is not None:
+                self._client_load[client_identity(group.client)] -= count
             self.limiter.release(count)
             self.cancelled_rollouts_count += count
+
+        for task in tasks_to_cancel:
+            task.cancel()
+
         return count
 
-    @staticmethod
-    def _client_identity(c: vf.ClientConfig) -> tuple[str, str | None]:
-        return (c.api_base_url, c.extra_headers.get("X-data-parallel-rank"))
-
     async def _select_least_loaded_client(self) -> vf.ClientConfig:
-        """Select the client with the fewest in-flight tasks."""
+        """Select the client with the fewest in-flight requests."""
         clients = self.inference_pool.train_clients
         while not clients:
             await asyncio.sleep(1)
             clients = self.inference_pool.train_clients
-        inflight: Counter = Counter()
-        for g in self.inflight_groups.values():
-            if g.client is not None:
-                inflight[self._client_identity(g.client)] += len(g.tasks)
-        return min(clients, key=lambda c: inflight[self._client_identity(c)])
+        return min(clients, key=lambda c: self._client_load[client_identity(c)])
 
-    async def on_weights_updated(self) -> None:
+    def on_weights_updated(self) -> None:
         """Called after a weight update: increment off-policy steps and drop stale groups."""
-        for group in self.inflight_groups.values():
+        for group in self._groups.values():
             group.off_policy_steps += 1
-        await self._drop_stale_groups()
 
-    def off_policy_levels(self) -> list[int]:
-        """Return off-policy step counts for all inflight groups."""
-        return [g.off_policy_steps for g in self.inflight_groups.values()]
-
-    async def _drop_stale_groups(self) -> None:
-        """Drop groups that exceed max_off_policy_steps."""
-        stale_group_ids = [
-            gid for gid, g in self.inflight_groups.items() if g.off_policy_steps >= self.max_off_policy_steps
-        ]
+        # drop groups that have exceeded max_off_policy_steps
+        stale_group_ids = [gid for gid, g in self._groups.items() if g.off_policy_steps >= self.max_off_policy_steps]
         if not stale_group_ids:
             return
 
-        counts = await asyncio.gather(*(self._drop_group(gid) for gid in stale_group_ids))
-        removed = sum(counts)
+        removed = sum(self._drop_group(gid) for gid in stale_group_ids)
         if removed:
             get_logger().warning(
                 f"Cancelled {removed} stale rollout requests. Consider increasing max_off_policy_steps to avoid this."
@@ -563,7 +530,7 @@ class TrainScheduler:
     # ------------------------------------------------------------------
 
     def get_metrics(self) -> dict[str, float]:
-        levels = self.off_policy_levels()
+        levels = [g.off_policy_steps for g in self._groups.values()]
         total_rollouts = sum(self.total_rollouts_by_env.values())
         metrics = {
             "scheduler/inflight_rollouts": self.num_inflight_rollouts,
@@ -580,7 +547,7 @@ class TrainScheduler:
             metrics[f"empty_rollouts/{env_name}"] = self.empty_rollouts_by_env.get(env_name, 0) / env_total
             metrics[f"errored_rollouts/{env_name}"] = self.errored_rollouts_by_env.get(env_name, 0) / env_total
         by_env: dict[str, list[int]] = {}
-        for group in self.inflight_groups.values():
+        for group in self._groups.values():
             by_env.setdefault(group.env_name, []).append(group.off_policy_steps)
         for env_name, steps in by_env.items():
             metrics[f"off_policy_level/{env_name}/max"] = max(steps)
@@ -645,52 +612,30 @@ class EvalScheduler:
         num_examples = len(eval_env.examples)
         rollouts_per_example = eval_env.config.rollouts_per_example
         total_rollouts = num_examples * rollouts_per_example
-        cost_per_coro = rollouts_per_example if eval_env.requires_group_scoring else 1
+        cost = rollouts_per_example if eval_env.requires_group_scoring else 1
 
         self.logger.info(f"Evaluating {eval_env.name} ({num_examples=}, {rollouts_per_example=})")
         pbar = ProgressTracker(total=total_rollouts, desc=f"Evaluating {eval_env.name}")
         eval_start = time.perf_counter()
 
+        async def run_one(example: dict, n: int) -> list[vf.RolloutOutput] | None:
+            await self.limiter.acquire(cost, priority=True)
+            try:
+                client = await self.inference_pool.get_eval_client()
+                outputs = await eval_env.run(client=client, example=example, model_name=model_name, n=n)
+                pbar.update(n)
+                return outputs
+            except Exception as e:
+                self.logger.warning(f"Rollout failed: {e}")
+                pbar.update(n)
+                return None
+            finally:
+                self.limiter.release(cost)
+
         if eval_env.requires_group_scoring:
-
-            async def run_one(example: dict) -> list[vf.RolloutOutput] | None:
-                await self.limiter.acquire(cost_per_coro, priority=True)
-                try:
-                    client = await self.inference_pool.get_eval_client()
-                    outputs = await eval_env.run_group(
-                        client=client,
-                        example=example,
-                        model_name=model_name,
-                        rollouts_per_example=rollouts_per_example,
-                    )
-                    pbar.update(rollouts_per_example)
-                    return outputs
-                except Exception as e:
-                    self.logger.warning(f"Group failed: {e}")
-                    pbar.update(rollouts_per_example)
-                    return None
-                finally:
-                    self.limiter.release(cost_per_coro)
-
-            coros = [run_one(example) for example in eval_env.examples]
-
+            coros = [run_one(example, rollouts_per_example) for example in eval_env.examples]
         else:
-
-            async def run_one(example: dict) -> list[vf.RolloutOutput] | None:
-                await self.limiter.acquire(1, priority=True)
-                try:
-                    client = await self.inference_pool.get_eval_client()
-                    output = await eval_env.run_rollout(client=client, example=example, model_name=model_name)
-                    pbar.update(1)
-                    return [output]
-                except Exception as e:
-                    self.logger.warning(f"Rollout failed: {e}")
-                    pbar.update(1)
-                    return None
-                finally:
-                    self.limiter.release(1)
-
-            coros = [run_one(example) for example in eval_env.examples for _ in range(rollouts_per_example)]
+            coros = [run_one(example, 1) for example in eval_env.examples for _ in range(rollouts_per_example)]
 
         try:
             results = await asyncio.gather(*coros)

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -126,6 +126,25 @@ class PolicyScheduler:
     def at_async_barrier(self) -> bool:
         return self.async_level >= self.max_async_level
 
+    async def wait_until_ready(self) -> None:
+        """Block until the async barrier is clear (ckpt_step is fresh enough).
+
+        Called by the orchestrator before each step to enforce max_async_level,
+        exactly like the old synchronous maybe_update_policy() at the top of
+        generate_batch(). The background run() loop handles opportunistic
+        updates mid-batch.
+        """
+        while True:
+            next_ckpt_step = self._get_next_ckpt_step()
+            if next_ckpt_step <= self.ckpt_step:
+                return
+            # At barrier — wait for checkpoint and update weights
+            self.train_scheduler.pause()
+            await wait_for_path(get_step_path(get_broadcast_dir(self.output_dir), next_ckpt_step) / "STABLE")
+            await self._update_weights(next_ckpt_step)
+            await self.train_scheduler.drop_stale_groups(next_ckpt_step)
+            self.train_scheduler.resume()
+
     async def run(self) -> None:
         """Background loop: poll for new checkpoints and apply weight updates.
 
@@ -300,14 +319,8 @@ class TrainScheduler:
         self.limiter.release(count)
 
     async def wait_for_batch(self) -> list[vf.RolloutOutput]:
-        """Block until the current batch is complete and scheduling is active.
-
-        If the policy scheduler has paused us at the async barrier, we hold
-        the batch until the weight update completes and resume() is called.
-        This ensures the orchestrator doesn't advance faster than max_async_level.
-        """
+        """Block until the current batch is complete, then return it."""
         await self._batch_ready.wait()
-        await self._scheduling_enabled.wait()
 
         batch = list(self._batch_rollouts)
         self.last_batch_generation_time = time.perf_counter() - self._batch_start_time

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -185,8 +185,8 @@ class TrainScheduler:
             self.limiter.release(rollout_count)
         return rollout_count
 
-    async def schedule_rollout(self, group_id: int):
-        """Asynchronously schedules a rollout request (or a group request for group-scoring envs)."""
+    async def _schedule_rollout(self, group_id: int):
+        """Acquire a concurrency slot and launch a rollout task. Blocks until a slot is available."""
         group = self.groups.get(group_id)
         if group is None or group.rollouts_to_schedule <= 0:
             return
@@ -245,33 +245,28 @@ class TrainScheduler:
         pending = sum(g.rollouts_to_schedule for g in self.groups.values())
         return self.inflight_rollout_count + pending
 
-    async def _schedule_next_request(self) -> None:
-        """Schedule one rollout request. Blocks until a concurrency slot is available."""
-        for group_id, group in self.groups.items():
-            if group.rollouts_to_schedule <= 0:
-                continue
-            await self.schedule_rollout(group_id=group_id)
-            return
+    async def _scheduling_loop(self) -> None:
+        """Continuously schedule rollouts. Blocks on acquire when capacity is full.
 
-        example = self.buffer.sample_examples(n=1)[0]
-        group_id = self.next_group_id
-        self.next_group_id += 1
-        self.groups[group_id] = GroupState(example=example, rollouts_to_schedule=self.rollouts_per_example)
-        await self.schedule_rollout(group_id=group_id)
-        return True
-
-    async def _fill_inflight_requests(self) -> None:
-        """Schedule requests up to available concurrency.
-
-        If no requests are in flight, blocks until capacity is available
-        (e.g. waiting for eval to release slots). Otherwise returns
-        immediately so generate_batch can process completed tasks.
+        Runs as a background task alongside generate_batch — when slots are freed
+        by completion processing, this loop wakes up and fills them.
         """
-        if not self.inflight_requests:
-            # Nothing in flight — must block until we can schedule at least one
-            await self._schedule_next_request()
-        while self.limiter.remaining > 0:
-            await self._schedule_next_request()
+        while True:
+            # Check existing groups first
+            scheduled = False
+            for group_id, group in list(self.groups.items()):
+                if group.rollouts_to_schedule <= 0:
+                    continue
+                await self._schedule_rollout(group_id=group_id)
+                scheduled = True
+                break
+
+            if not scheduled:
+                example = self.buffer.sample_examples(n=1)[0]
+                group_id = self.next_group_id
+                self.next_group_id += 1
+                self.groups[group_id] = GroupState(example=example, rollouts_to_schedule=self.rollouts_per_example)
+                await self._schedule_rollout(group_id=group_id)
 
     async def update_policy_loop(self):
         """Continuously checks for new policy checkpoints."""
@@ -378,16 +373,18 @@ class TrainScheduler:
             )
 
     async def generate_batch(self, step: int) -> list[vf.RolloutOutput]:
-        """Continuously generates a batch of rollouts."""
+        """Continuously generates a batch of rollouts.
+
+        Runs a background scheduling loop that acquires concurrency slots and
+        launches rollouts. The main loop processes completions as they arrive.
+        This avoids deadlocks: scheduling blocks on acquire (waiting for eval or
+        completions to free slots), while completion processing runs concurrently.
+        """
         self.step = step
 
         if self.enable_policy_updates:
-            # Cancel the previous update policy task to avoid concurrent updates
             if self.update_policy_task is not None:
                 await safe_cancel(self.update_policy_task)
-
-            # Manually check the async barrier before starting the step, then re-create the update policy loop
-            # This ensures that we respect max_async_level, while still listening for policy updates mid-step
             await self.maybe_update_policy()
             self.update_policy_task = asyncio.create_task(self.update_policy_loop())
         else:
@@ -395,7 +392,6 @@ class TrainScheduler:
             self.resume()
 
         batch_start_time = time.perf_counter()
-
         self.logger.debug("Starting to generate batch rollouts")
 
         batch_rollouts: list[vf.RolloutOutput] = []
@@ -404,93 +400,100 @@ class TrainScheduler:
             total=self.batch_target, desc="Generating rollouts (train)", json_logging=self.json_logging, step=step
         )
 
-        while batch_progress < self.batch_target:
-            await self._fill_inflight_requests()
-            inflight_tasks = list(self.inflight_requests.keys())
+        # Background task continuously fills concurrency slots
+        scheduling_task = asyncio.create_task(self._scheduling_loop())
 
-            finished_tasks, _ = await asyncio.wait(
-                inflight_tasks,
-                return_when=asyncio.FIRST_COMPLETED,
-            )
-            await self._scheduling_enabled.wait()
+        try:
+            while batch_progress < self.batch_target:
+                # Wait until at least one inflight task exists
+                while not self.inflight_requests:
+                    await asyncio.sleep(0)
 
-            for finished_task in finished_tasks:
-                if batch_progress >= self.batch_target:
-                    break
+                inflight_tasks = list(self.inflight_requests.keys())
 
-                rollout_info = self.inflight_requests.pop(finished_task, None)
-                if rollout_info is None:
-                    continue
+                finished_tasks, _ = await asyncio.wait(
+                    inflight_tasks,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                await self._scheduling_enabled.wait()
 
-                self.limiter.release(rollout_info.rollout_count)
-                group_id = rollout_info.group_id
-                env_name = rollout_info.env_name
+                for finished_task in finished_tasks:
+                    if batch_progress >= self.batch_target:
+                        break
 
-                try:
-                    group = self.groups.get(group_id)
-                    if group is None:
+                    rollout_info = self.inflight_requests.pop(finished_task, None)
+                    if rollout_info is None:
                         continue
 
-                    env = self.train_envs.get(env_name)
-                    result = finished_task.result()
-                    rollouts: list[vf.RolloutOutput] = result if isinstance(result, list) else [result]
-                    self.total_rollouts_by_env[env_name] += len(rollouts)
+                    self.limiter.release(rollout_info.rollout_count)
+                    group_id = rollout_info.group_id
+                    env_name = rollout_info.env_name
 
-                    # Check for empty/errored rollouts and reschedule
-                    valid_rollouts = []
-                    has_failures = False
-                    for rollout in rollouts:
-                        if len(rollout["trajectory"]) == 0:
-                            self.empty_rollouts_by_env[env_name] += 1
-                            has_failures = True
-                            self.logger.warning(
-                                f"Empty trajectory in group {group_id} ({env_name}), re-scheduling "
-                                f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete)"
-                            )
-                        elif rollout["error"] is not None:
-                            self.errored_rollouts_by_env[env_name] += 1
-                            has_failures = True
-                            self.logger.warning(
-                                f"Rollout error in group {group_id} ({env_name}), re-scheduling "
-                                f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete): "
-                                f"{rollout['error']['error_chain_repr']}"
-                            )
-                        else:
-                            rollout["env_name"] = env_name
-                            valid_rollouts.append(rollout)
+                    try:
+                        group = self.groups.get(group_id)
+                        if group is None:
+                            continue
 
-                    if has_failures and env.requires_group_scoring:
-                        # Group scoring requires all rollouts — discard partial results, reschedule full group
-                        group.completed_rollouts.clear()
-                        group.rollouts_to_schedule = self.rollouts_per_example
+                        env = self.train_envs.get(env_name)
+                        result = finished_task.result()
+                        rollouts: list[vf.RolloutOutput] = result if isinstance(result, list) else [result]
+                        self.total_rollouts_by_env[env_name] += len(rollouts)
+
+                        # Check for empty/errored rollouts and reschedule
+                        valid_rollouts = []
+                        has_failures = False
+                        for rollout in rollouts:
+                            if len(rollout["trajectory"]) == 0:
+                                self.empty_rollouts_by_env[env_name] += 1
+                                has_failures = True
+                                self.logger.warning(
+                                    f"Empty trajectory in group {group_id} ({env_name}), re-scheduling "
+                                    f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete)"
+                                )
+                            elif rollout["error"] is not None:
+                                self.errored_rollouts_by_env[env_name] += 1
+                                has_failures = True
+                                self.logger.warning(
+                                    f"Rollout error in group {group_id} ({env_name}), re-scheduling "
+                                    f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete): "
+                                    f"{rollout['error']['error_chain_repr']}"
+                                )
+                            else:
+                                rollout["env_name"] = env_name
+                                valid_rollouts.append(rollout)
+
+                        if has_failures and env.requires_group_scoring:
+                            # Group scoring requires all rollouts — discard partial results, reschedule full group
+                            group.completed_rollouts.clear()
+                            group.rollouts_to_schedule = self.rollouts_per_example
+                            continue
+
+                        # For individual scoring, reschedule only the failed ones
+                        group.rollouts_to_schedule += len(rollouts) - len(valid_rollouts)
+                        group.completed_rollouts.extend(valid_rollouts)
+                        if len(group.completed_rollouts) < self.rollouts_per_example:
+                            continue
+                        completed_rollouts = self.groups.pop(group_id).completed_rollouts
+
+                    except asyncio.CancelledError:
+                        if group_id is not None:
+                            await self.drop_group(group_id)
+                        continue
+                    except Exception as e:
+                        self.logger.warning(f"Rollout failed: {e}")
+                        if group_id is not None:
+                            await self.drop_group(group_id)
                         continue
 
-                    # For individual scoring, reschedule only the failed ones
-                    group.rollouts_to_schedule += len(rollouts) - len(valid_rollouts)
-                    group.completed_rollouts.extend(valid_rollouts)
-                    if len(group.completed_rollouts) < self.rollouts_per_example:
-                        continue
-                    completed_rollouts = self.groups.pop(group_id).completed_rollouts
+                    self.buffer.update(completed_rollouts)
+                    accepted_rollouts = self.buffer.sample_rollouts(n=self.rollouts_per_example)
 
-                except asyncio.CancelledError:
-                    if group_id is not None:
-                        await self.drop_group(group_id)
-                    continue
-                except Exception as e:
-                    self.logger.warning(f"Rollout failed: {e}")
-                    if group_id is not None:
-                        await self.drop_group(group_id)
-                    continue
-
-                self.buffer.update(completed_rollouts)
-                accepted_rollouts = self.buffer.sample_rollouts(n=self.rollouts_per_example)
-
-                batch_rollouts.extend(accepted_rollouts)
-                progress_increment = self.get_batch_progress_increment(accepted_rollouts)
-                batch_progress += progress_increment
-                pbar.update(progress_increment)
-
-        await self._fill_inflight_requests()
+                    batch_rollouts.extend(accepted_rollouts)
+                    progress_increment = self.get_batch_progress_increment(accepted_rollouts)
+                    batch_progress += progress_increment
+                    pbar.update(progress_increment)
+        finally:
+            await safe_cancel(scheduling_task)
 
         batch_rollouts = self.finalize_batch_rollouts(batch_rollouts)
         pbar.close()

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -345,7 +345,7 @@ class TrainScheduler:
             await self.limiter.acquire(request.cost)
             env = self.train_envs.get(group.env_name)
             task = asyncio.create_task(
-                env.run(client=group.client, example=group.example, model_name=self.model_name, n=cost)
+                env.run(client=group.client, example=group.example, model_name=self.model_name, n=request.cost)
             )
             self._requests[task] = request
             self._client_load[client_identity(group.client)] += request.cost

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -7,11 +7,10 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 
 import verifiers as vf
-from aiolimiter import AsyncLimiter
 
 from prime_rl.configs.orchestrator import OrchestratorConfig
 from prime_rl.orchestrator.buffer import Buffer
-from prime_rl.orchestrator.concurrency import ConcurrencyLimiter
+from prime_rl.orchestrator.concurrency import ConcurrencyLimiter, RateLimiter
 from prime_rl.orchestrator.envs import EvalEnv, TrainEnvs
 from prime_rl.orchestrator.vf_utils import get_seq_len
 from prime_rl.utils.async_utils import safe_cancel, safe_cancel_all
@@ -67,7 +66,7 @@ class Scheduler:
         max_async_level: int,
         max_off_policy_steps: int,
         strict_async_level: bool,
-        rate_limiter: AsyncLimiter | None = None,
+        rate_limiter: RateLimiter | None = None,
         enable_policy_updates: bool = True,
         lora_name: str | None = None,
     ):
@@ -202,8 +201,7 @@ class Scheduler:
             rollout_count = 1
 
         if self.rate_limiter:
-            for _ in range(rollout_count):
-                await self.rate_limiter.acquire()
+            await self.rate_limiter.acquire(rollout_count)
 
         if not self.limiter.try_acquire(rollout_count):
             return
@@ -577,7 +575,7 @@ class EvalScheduler:
         self,
         concurrency_limiter: ConcurrencyLimiter,
         inference_pool: InferencePool,
-        rate_limiter: AsyncLimiter | None = None,
+        rate_limiter: RateLimiter | None = None,
     ):
         self.logger = get_logger()
         self.limiter = concurrency_limiter
@@ -615,8 +613,7 @@ class EvalScheduler:
             async def run_one(example: dict) -> list[vf.RolloutOutput] | None:
                 try:
                     if self.rate_limiter:
-                        for _ in range(cost_per_coro):
-                            await self.rate_limiter.acquire()
+                        await self.rate_limiter.acquire(cost_per_coro)
                     await self.limiter.acquire(cost_per_coro)
                     client = await self.inference_pool.get_eval_client()
                     outputs = await eval_env.run_group(

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -23,7 +23,6 @@ from prime_rl.utils.utils import (
     get_broadcast_dir,
     get_latest_ckpt_step,
     get_step_path,
-    wait_for_path,
 )
 
 # ---------------------------------------------------------------------------
@@ -91,86 +90,40 @@ class InflightGroup:
 class PolicyScheduler:
     """Watches for new policy checkpoints and applies weight updates.
 
-    Runs as a background loop owned by TrainScheduler. On policy update:
-    pauses scheduling, waits for checkpoint, updates weights, drops stale
-    rollouts, then resumes scheduling.
+    Polls the broadcast directory for new checkpoints. When found, updates
+    inference server weights and drops stale rollouts via the train scheduler.
     """
 
     def __init__(
         self,
         train_scheduler: TrainScheduler,
         inference_pool: InferencePool,
-        progress: Progress,
         output_dir: Path,
-        max_async_level: int,
-        strict_async_level: bool,
         lora_name: str | None = None,
     ):
         self.train_scheduler = train_scheduler
         self.inference_pool = inference_pool
-        self.progress = progress
         self.output_dir = output_dir
-        self.max_async_level = max_async_level
-        self.strict_async_level = strict_async_level
         self.lora_name = lora_name
 
         self.ckpt_step = 0
         self.update_weights_time = 0.0
-        self.wait_for_ckpt_time = 0.0
-
-    @property
-    def async_level(self) -> int:
-        return self.progress.step - self.ckpt_step
-
-    @property
-    def at_async_barrier(self) -> bool:
-        return self.async_level > self.max_async_level
 
     async def start(self) -> None:
-        """Background loop: poll for new checkpoints and apply weight updates.
-
-        1. If at latest checkpoint — sleep and retry
-        2. If at async barrier — pause train scheduler, wait for checkpoint
-        3. Update weights, drop stale groups, resume train scheduler
-        """
-
+        """Background loop: poll for new checkpoints and apply weight updates."""
         logger = get_logger()
         while True:
-            next_ckpt_step = self._get_next_ckpt_step()
-            if next_ckpt_step <= self.ckpt_step:
+            latest_ckpt_step = get_latest_ckpt_step(get_broadcast_dir(self.output_dir)) or 0
+            if latest_ckpt_step <= self.ckpt_step:
                 await asyncio.sleep(0.1)
                 continue
 
-            if self.at_async_barrier:
-                logger.info(
-                    f"At async barrier: Pausing training rollout scheduling and waiting for training checkpoint {next_ckpt_step}"
-                )
-                self.train_scheduler.pause()
-                t0 = time.perf_counter()
-                await wait_for_path(get_step_path(get_broadcast_dir(self.output_dir), next_ckpt_step) / "STABLE")
-                self.wait_for_ckpt_time = time.perf_counter() - t0
-                logger.debug(
-                    f"Cleared async barrier: Training checkpoint {next_ckpt_step} ready after {print_time(self.wait_for_ckpt_time)}"
-                )
+            logger.info(f"Updating weights to training checkpoint {latest_ckpt_step}")
+            await self._update_weights(latest_ckpt_step)
+            logger.debug(f"Weights updated in {print_time(self.update_weights_time)}")
 
-            logger.info(f"Updating weights to training checkpoint {next_ckpt_step}")
-            await self._update_weights(next_ckpt_step)
-            logger.debug(
-                f"Weights updated to training checkpoint {next_ckpt_step} in {print_time(self.update_weights_time)}"
-            )
-
-            logger.info("Resuming training rollout scheduling")
-            await self.train_scheduler.drop_stale_groups(next_ckpt_step)
-            self.train_scheduler.resume()
-
-    def _get_next_ckpt_step(self) -> int:
-        """Compute the next training checkpoint to update to."""
-        orch_step = self.progress.step
-        latest_ckpt_step = get_latest_ckpt_step(get_broadcast_dir(self.output_dir)) or 0
-        async_away_ckpt_step = max(orch_step - self.max_async_level, 0)
-        if self.strict_async_level:
-            return async_away_ckpt_step
-        return max(async_away_ckpt_step, latest_ckpt_step)
+            await self.train_scheduler.drop_stale_groups(latest_ckpt_step)
+            logger.debug(f"Dropped stale rollouts for checkpoint {latest_ckpt_step}")
 
     async def _update_weights(self, ckpt_step: int) -> None:
         """Update the weights to the next training checkpoint."""
@@ -186,9 +139,7 @@ class PolicyScheduler:
 
     def get_metrics(self) -> dict[str, float]:
         return {
-            "time/wait_for_ckpt": self.wait_for_ckpt_time,
             "time/update_weights": self.update_weights_time,
-            "scheduler/async_level": self.async_level,
         }
 
 

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -536,8 +536,12 @@ class TrainScheduler:
     # Metrics
     # ------------------------------------------------------------------
 
+    def off_policy_levels(self) -> list[int]:
+        """Return off-policy step counts for all inflight groups."""
+        return [g.off_policy_steps for g in self._groups.values()]
+
     def get_metrics(self) -> dict[str, float]:
-        levels = [g.off_policy_steps for g in self._groups.values()]
+        levels = self.off_policy_levels()
         total_rollouts = sum(self.total_rollouts_by_env.values())
         metrics = {
             "scheduler/inflight_rollouts": self.num_inflight_rollouts,

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -66,6 +66,7 @@ class TrainScheduler:
         max_async_level: int,
         max_off_policy_steps: int,
         strict_async_level: bool,
+        model_name: str,
         enable_policy_updates: bool = True,
         lora_name: str | None = None,
     ):
@@ -82,7 +83,7 @@ class TrainScheduler:
         self.strict_async_level = strict_async_level
         self.enable_policy_updates = enable_policy_updates
         self.lora_name = lora_name
-        self.model_name = self.config.model.name
+        self.model_name = model_name
         self.json_logging = config.log.json_logging
 
         # Inference pool - used for admin operations (adapter sync) and metrics
@@ -577,14 +578,14 @@ class EvalScheduler:
         self.limiter = rollout_limiter
         self.inference_pool = inference_pool
 
-    async def run(
+    async def evaluate_envs(
         self,
         eval_envs: list[EvalEnv],
         model_name: str,
     ) -> AsyncIterator[EvalResult]:
         """Run evals for multiple envs, yielding results as each env completes."""
         tasks: dict[asyncio.Task, EvalEnv] = {
-            asyncio.create_task(self._run_env(env, model_name)): env for env in eval_envs
+            asyncio.create_task(self.evaluate_env(env, model_name)): env for env in eval_envs
         }
         while tasks:
             done, _ = await asyncio.wait(tasks.keys(), return_when=asyncio.FIRST_COMPLETED)
@@ -592,7 +593,7 @@ class EvalScheduler:
                 tasks.pop(task)
                 yield task.result()
 
-    async def _run_env(self, eval_env: EvalEnv, model_name: str) -> EvalResult:
+    async def evaluate_env(self, eval_env: EvalEnv, model_name: str) -> EvalResult:
         """Run all rollouts for one eval env with concurrency control."""
         num_examples = len(eval_env.examples)
         rollouts_per_example = eval_env.config.rollouts_per_example

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -181,8 +181,6 @@ class Scheduler:
 
     async def schedule_rollout(self, group_id: int):
         """Asynchronously schedules a rollout request (or a group request for group-scoring envs)."""
-        if self.rate_limiter:
-            await self.rate_limiter.acquire()
         group = self.groups.get(group_id)
         if group is None or group.rollouts_to_schedule <= 0:
             return
@@ -202,6 +200,10 @@ class Scheduler:
             rollout_count = group.rollouts_to_schedule
         else:
             rollout_count = 1
+
+        if self.rate_limiter:
+            for _ in range(rollout_count):
+                await self.rate_limiter.acquire()
 
         if not self.limiter.try_acquire(rollout_count):
             return
@@ -613,7 +615,8 @@ class EvalScheduler:
             async def run_one(example: dict) -> list[vf.RolloutOutput] | None:
                 try:
                     if self.rate_limiter:
-                        await self.rate_limiter.acquire()
+                        for _ in range(cost_per_coro):
+                            await self.rate_limiter.acquire()
                     await self.limiter.acquire(cost_per_coro)
                     client = await self.inference_pool.get_eval_client()
                     outputs = await eval_env.run_group(

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -35,7 +35,7 @@ class InflightRequest:
 
     task: asyncio.Task
     client: vf.ClientConfig
-    off_policy_steps: int = 0
+    ckpt_step: int = 0
 
     @property
     @abstractmethod
@@ -155,7 +155,7 @@ class PolicyScheduler:
             self.inference_pool.update_model_name(self.model_name)
 
         self._train.resume()
-        await self._train._update_off_policy()
+        await self._train.drop_stale_groups(next_ckpt_step)
 
     async def _get_or_start_update_task(self, next_ckpt_step: int, step: int) -> asyncio.Task:
         async with self._lock:
@@ -286,15 +286,8 @@ class TrainScheduler:
     def async_level(self) -> int:
         return self.step - self.ckpt_step
 
-    @property
-    def max_off_policy_level(self) -> int:
-        steps = [r.off_policy_steps for g in self._groups.values() for r in g.inflight_requests.values()]
-        return max(steps) if steps else 0
-
-    @property
-    def mean_off_policy_level(self) -> float:
-        steps = [r.off_policy_steps for g in self._groups.values() for r in g.inflight_requests.values()]
-        return sum(steps) / len(steps) if steps else 0
+    def _off_policy_levels(self) -> list[int]:
+        return [self.ckpt_step - r.ckpt_step for g in self._groups.values() for r in g.inflight_requests.values()]
 
     # ------------------------------------------------------------------
     # Public API
@@ -448,7 +441,9 @@ class TrainScheduler:
                     rollouts_per_example=rollout_count,
                 )
             )
-            request = InflightGroupRequest(task=task, client=client, rollouts_per_example=rollout_count)
+            request = InflightGroupRequest(
+                task=task, client=client, ckpt_step=self.ckpt_step, rollouts_per_example=rollout_count
+            )
         else:
             await self.limiter.acquire(1)
             group.rollouts_to_schedule -= 1
@@ -459,7 +454,7 @@ class TrainScheduler:
                     model_name=self.model_name,
                 )
             )
-            request = InflightRolloutRequest(task=task, client=client)
+            request = InflightRolloutRequest(task=task, client=client, ckpt_step=self.ckpt_step)
 
         group.inflight_requests[task] = request
         group_id = self._group_id_for(group)
@@ -608,27 +603,23 @@ class TrainScheduler:
         )
         return min(clients, key=lambda c: inflight[self._client_identity(c)])
 
-    async def _update_off_policy(self) -> None:
-        """Increment off-policy counters and drop stale groups."""
-        stale_group_ids = set()
-        for gid, group in self._groups.items():
-            for request in group.inflight_requests.values():
-                if request.off_policy_steps >= self.max_off_policy_steps:
-                    stale_group_ids.add(gid)
-                    break
-
-        groups_to_increment = [(gid, group) for gid, group in self._groups.items() if gid not in stale_group_ids]
+    async def drop_stale_groups(self, current_ckpt_step: int) -> None:
+        """Drop groups with requests older than max_off_policy_steps."""
+        stale_group_ids = {
+            gid
+            for gid, group in self._groups.items()
+            if any(
+                current_ckpt_step - r.ckpt_step >= self.max_off_policy_steps for r in group.inflight_requests.values()
+            )
+        }
+        if not stale_group_ids:
+            return
 
         counts = await asyncio.gather(*(self._drop_group(gid) for gid in stale_group_ids))
         removed = sum(counts)
-
-        for _, group in groups_to_increment:
-            for request in group.inflight_requests.values():
-                request.off_policy_steps += 1
-
         if removed:
             self.logger.warning(
-                f"Cancelled {removed} old rollout requests (will refill naturally). "
+                f"Cancelled {removed} stale rollout requests (ckpt_step={current_ckpt_step}). "
                 f"Consider increasing max_off_policy_steps to avoid this."
             )
 
@@ -648,8 +639,8 @@ class TrainScheduler:
             "scheduler/cancelled_rollouts": self.cancelled_rollouts_count,
             "empty_rollouts/all": sum(self.empty_rollouts_by_env.values()) / max(total_rollouts, 1),
             "errored_rollouts/all": sum(self.errored_rollouts_by_env.values()) / max(total_rollouts, 1),
-            "off_policy_level/all/max": self.max_off_policy_level,
-            "off_policy_level/all/mean": self.mean_off_policy_level,
+            "off_policy_level/all/max": max(levels) if (levels := self._off_policy_levels()) else 0,
+            "off_policy_level/all/mean": sum(levels) / len(levels) if levels else 0,
         }
         for env_name in self.total_rollouts_by_env:
             env_total = max(self.total_rollouts_by_env[env_name], 1)
@@ -658,7 +649,7 @@ class TrainScheduler:
         by_env: dict[str, list[int]] = {}
         for group in self._groups.values():
             for request in group.inflight_requests.values():
-                by_env.setdefault(group.env_name, []).append(request.off_policy_steps)
+                by_env.setdefault(group.env_name, []).append(self.ckpt_step - request.ckpt_step)
         for env_name, steps in by_env.items():
             metrics[f"off_policy_level/{env_name}/max"] = max(steps)
             metrics[f"off_policy_level/{env_name}/mean"] = sum(steps) / len(steps)

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -10,7 +10,7 @@ import verifiers as vf
 
 from prime_rl.configs.orchestrator import OrchestratorConfig
 from prime_rl.orchestrator.buffer import Buffer
-from prime_rl.orchestrator.concurrency import ConcurrencyLimiter, RateLimiter
+from prime_rl.orchestrator.concurrency import RolloutLimiter
 from prime_rl.orchestrator.envs import EvalEnv, TrainEnvs
 from prime_rl.orchestrator.vf_utils import get_seq_len
 from prime_rl.utils.async_utils import safe_cancel, safe_cancel_all
@@ -45,7 +45,7 @@ class GroupState:
     pinned_client: vf.ClientConfig | None = None
 
 
-class Scheduler:
+class TrainScheduler:
     """
     Asynchronously manages scheduling of rollout requests and policy updates.
     Keeps a constant number of rollouts in-flight (continuous batching) and
@@ -62,23 +62,21 @@ class Scheduler:
         inference_pool: InferencePool,
         buffer: Buffer,
         config: OrchestratorConfig,
-        concurrency_limiter: ConcurrencyLimiter,
+        rollout_limiter: RolloutLimiter,
         max_async_level: int,
         max_off_policy_steps: int,
         strict_async_level: bool,
-        rate_limiter: RateLimiter | None = None,
         enable_policy_updates: bool = True,
         lora_name: str | None = None,
     ):
         self.logger = get_logger()
-        self.rate_limiter = rate_limiter
+        self.limiter = rollout_limiter
         self.train_envs = train_envs
         self.buffer = buffer
         self.config = config
         self.batch_size = config.batch_size
         self.token_batch_size = config.token_batch_size
         self.rollouts_per_example = config.rollouts_per_example
-        self.limiter = concurrency_limiter
         self.max_async_level = max_async_level
         self.max_off_policy_steps = max_off_policy_steps
         self.strict_async_level = strict_async_level
@@ -200,8 +198,8 @@ class Scheduler:
         else:
             rollout_count = 1
 
-        if self.rate_limiter:
-            await self.rate_limiter.acquire(rollout_count)
+        if self.limiter.rate:
+            await self.limiter.rate.acquire(rollout_count)
 
         if not self.limiter.try_acquire(rollout_count):
             return
@@ -573,14 +571,12 @@ class EvalScheduler:
 
     def __init__(
         self,
-        concurrency_limiter: ConcurrencyLimiter,
+        rollout_limiter: RolloutLimiter,
         inference_pool: InferencePool,
-        rate_limiter: RateLimiter | None = None,
     ):
         self.logger = get_logger()
-        self.limiter = concurrency_limiter
+        self.limiter = rollout_limiter
         self.inference_pool = inference_pool
-        self.rate_limiter = rate_limiter
 
     async def run(
         self,
@@ -612,8 +608,6 @@ class EvalScheduler:
 
             async def run_one(example: dict) -> list[vf.RolloutOutput] | None:
                 try:
-                    if self.rate_limiter:
-                        await self.rate_limiter.acquire(cost_per_coro)
                     await self.limiter.acquire(cost_per_coro)
                     client = await self.inference_pool.get_eval_client()
                     outputs = await eval_env.run_group(
@@ -637,8 +631,6 @@ class EvalScheduler:
 
             async def run_one(example: dict) -> list[vf.RolloutOutput] | None:
                 try:
-                    if self.rate_limiter:
-                        await self.rate_limiter.acquire()
                     await self.limiter.acquire(1)
                     client = await self.inference_pool.get_eval_client()
                     output = await eval_env.run_rollout(client=client, example=example, model_name=model_name)

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -14,7 +14,7 @@ from verifiers.utils.logging_utils import print_time
 from prime_rl.orchestrator.buffer import Buffer
 from prime_rl.orchestrator.ckpt import Progress
 from prime_rl.orchestrator.concurrency import RolloutLimiter
-from prime_rl.orchestrator.envs import EvalEnv, TrainEnvs
+from prime_rl.orchestrator.envs import EvalEnv, TrainEnv, TrainEnvs
 from prime_rl.orchestrator.vf_utils import get_seq_len
 from prime_rl.utils.async_utils import safe_cancel, safe_cancel_all
 from prime_rl.utils.client import InferencePool
@@ -32,33 +32,83 @@ from prime_rl.utils.utils import (
 
 
 @dataclass
-class InflightRequest:
-    """An in-flight rollout/ group rollout request."""
-
-    task: asyncio.Task
-    client: vf.ClientConfig
-    rollout_count: int = 1
-    off_policy_steps: int = 0
-
-
-@dataclass
-class InflightGroup:
-    """An inflight group"""
+class RolloutGroup:
+    """All rollouts for a single example. Manages its own tasks and completion."""
 
     env_name: str
     example: dict
-    rollouts_to_schedule: int
+    requires_group_scoring: bool
+    rollouts_per_example: int
+    group_id: str = field(default_factory=lambda: uuid.uuid4().hex[:12])
 
     # Reuse the same client for all rollouts in a group to maximize prefix cache hits
     client: vf.ClientConfig | None = None
-    group_id: str = field(default_factory=lambda: uuid.uuid4().hex[:12])
+    off_policy_steps: int = 0
 
-    inflight_requests: dict[asyncio.Task, InflightRequest] = field(default_factory=dict)
-    completed_rollouts: list[vf.RolloutOutput] = field(default_factory=list)
+    tasks: dict[asyncio.Task, int] = field(default_factory=dict)  # task → rollout_count
+    completed: list[vf.RolloutOutput] = field(default_factory=list)
+    _remaining: int = -1  # set in __post_init__
+
+    def __post_init__(self) -> None:
+        self._remaining = self.rollouts_per_example
 
     @property
-    def num_inflight_rollouts(self) -> int:
-        return sum(r.rollout_count for r in self.inflight_requests.values())
+    def is_complete(self) -> bool:
+        return len(self.completed) >= self.rollouts_per_example
+
+    @property
+    def needs_scheduling(self) -> bool:
+        return self._remaining > 0
+
+    @property
+    def num_inflight(self) -> int:
+        return sum(self.tasks.values())
+
+    async def schedule(self, env: TrainEnv, model_name: str, limiter: RolloutLimiter) -> asyncio.Task:
+        """Schedule the next chunk of work. Blocks on limiter until a slot is available."""
+        if self.requires_group_scoring:
+            n = self._remaining
+            self._remaining = 0
+        else:
+            n = 1
+            self._remaining -= 1
+
+        await limiter.acquire(n)
+
+        if self.requires_group_scoring:
+            task = asyncio.create_task(
+                env.run_group(client=self.client, example=self.example, model_name=model_name, rollouts_per_example=n)
+            )
+        else:
+            task = asyncio.create_task(env.run_rollout(client=self.client, example=self.example, model_name=model_name))
+
+        self.tasks[task] = n
+        return task
+
+    def complete(self, task: asyncio.Task) -> tuple[int, list[vf.RolloutOutput]]:
+        """Process a finished task. Returns (slots_to_release, raw_rollouts)."""
+        n = self.tasks.pop(task)
+
+        result = task.result()
+        rollouts: list[vf.RolloutOutput] = result if isinstance(result, list) else [result]
+
+        valid = []
+        failed = 0
+        for rollout in rollouts:
+            if len(rollout["trajectory"]) == 0 or rollout["error"] is not None:
+                failed += 1
+            else:
+                rollout["env_name"] = self.env_name
+                valid.append(rollout)
+
+        if failed and self.requires_group_scoring:
+            self.completed.clear()
+            self._remaining = self.rollouts_per_example
+        else:
+            self.completed.extend(valid)
+            self._remaining += failed
+
+        return n, rollouts
 
 
 # ---------------------------------------------------------------------------
@@ -99,43 +149,54 @@ class PolicyScheduler:
     def async_level(self) -> int:
         return self.progress.step - self.ckpt_step
 
-    @property
-    def at_async_barrier(self) -> bool:
-        return self.async_level > self.max_async_level
-
-    async def wait_for_async_barrier(self) -> None:
+    async def wait_for_barrier(self) -> None:
         """Block until the async barrier is cleared."""
         await self.async_barrier_clear.wait()
+
+    def _next_ckpt_step(self) -> int:
+        """Compute the next checkpoint step to update to.
+
+        Returns the maximum of the latest available checkpoint and the
+        minimum required to stay within ``max_async_level``. When the
+        orchestrator is far ahead, this may return a step whose checkpoint
+        hasn't been written yet — the caller must wait for it.
+        """
+        latest = get_latest_ckpt_step(get_broadcast_dir(self.output_dir)) or 0
+        min_required = max(self.progress.step - self.max_async_level, 0)
+        return max(min_required, latest)
 
     async def start(self) -> None:
         """Background loop: poll for new checkpoints and apply weight updates.
 
-        1. If at latest checkpoint — sleep and retry
-        2. If at async barrier — pause train scheduler, wait for checkpoint
-        3. Update weights, drop stale groups, signal barrier cleared
+        1. Compute next needed checkpoint (may not exist yet if orchestrator is ahead)
+        2. If at async barrier — pause scheduling, wait for checkpoint to be written
+        3. Update weights, drop stale groups, resume scheduling
         """
-        logger = get_logger()
         while True:
-            latest_ckpt_step = get_latest_ckpt_step(get_broadcast_dir(self.output_dir)) or 0
-            if latest_ckpt_step <= self.ckpt_step:
+            next_step = self._next_ckpt_step()
+            if next_step <= self.ckpt_step:
                 await asyncio.sleep(0.1)
                 continue
 
-            if self.at_async_barrier:
+            # When the next step is dictated by the async level (not just a new
+            # checkpoint appearing), the checkpoint may not exist yet. Pause
+            # scheduling and block the orchestrator until it's ready.
+            min_required = max(self.progress.step - self.max_async_level, 0)
+            if next_step == min_required:
                 self.async_barrier_clear.clear()
-                logger.info(f"At async barrier: pausing train scheduling, waiting for checkpoint {latest_ckpt_step}")
                 self.train_scheduler.pause()
+                get_logger().info(f"At async barrier: pausing train scheduling, waiting for checkpoint {next_step}")
                 t0 = time.perf_counter()
-                await wait_for_path(get_step_path(get_broadcast_dir(self.output_dir), latest_ckpt_step) / "STABLE")
+                await wait_for_path(get_step_path(get_broadcast_dir(self.output_dir), next_step) / "STABLE")
                 self.wait_for_ckpt_time = time.perf_counter() - t0
-                logger.debug(f"Waited for checkpoint {latest_ckpt_step} in {print_time(self.wait_for_ckpt_time)}")
+                get_logger().debug(f"Waited for checkpoint {next_step} in {print_time(self.wait_for_ckpt_time)}")
 
-            logger.info(f"Updating weights to training checkpoint {latest_ckpt_step}")
-            await self._update_weights(latest_ckpt_step)
-            logger.debug(f"Weights updated in {print_time(self.update_weights_time)}")
+            get_logger().info(f"Updating weights to training checkpoint {next_step}")
+            await self._update_weights(next_step)
+            get_logger().debug(f"Weights updated in {print_time(self.update_weights_time)}")
 
-            self.train_scheduler.off_policy_steps += 1
-            await self.train_scheduler.drop_stale_groups()
+            await self.train_scheduler.on_weights_updated()
+            self.train_scheduler.resume()
             self.async_barrier_clear.set()
 
     async def _update_weights(self, ckpt_step: int) -> None:
@@ -159,12 +220,31 @@ class PolicyScheduler:
 
 
 # ---------------------------------------------------------------------------
+# Batch
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Batch:
+    """A collected batch of rollouts ready for training."""
+
+    rollouts: list[vf.RolloutOutput]
+    generation_time: float
+
+
+# ---------------------------------------------------------------------------
 # Train scheduler
 # ---------------------------------------------------------------------------
 
 
 class TrainScheduler:
     """Always-on scheduler with two background loops: scheduling and completion processing.
+
+    Scheduling is gated on two independent events:
+    - ``_batch_gate``: open while the current batch needs more rollouts.
+      Automatically closed when a batch fills, re-opened by ``next_batch()``.
+    - ``_policy_gate``: open unless an external caller (``PolicyScheduler``
+      or eval) explicitly pauses scheduling via ``pause()``/``resume()``.
 
     References:
     - AReal: https://arxiv.org/abs/2505.24298v1
@@ -198,9 +278,8 @@ class TrainScheduler:
         self.json_logging = json_logging
 
         # Group tracking
-        self._groups: dict[str, InflightGroup] = {}
-        self._task_to_group: dict[asyncio.Task, str] = {}
-        self.off_policy_steps = 0
+        self.inflight_groups: dict[str, RolloutGroup] = {}
+        self._task_index: dict[asyncio.Task, str] = {}  # task → group_id
 
         # Batch accumulation
         self._batch_rollouts: list[vf.RolloutOutput] = []
@@ -208,9 +287,11 @@ class TrainScheduler:
         self._batch_ready = asyncio.Event()
         self._pbar: ProgressTracker | None = None
 
-        # Scheduling control
-        self._scheduling_enabled = asyncio.Event()
-        self._scheduling_enabled.set()
+        # Scheduling gates (both must be set for scheduling to proceed)
+        self._batch_gate = asyncio.Event()  # cleared when batch is full
+        self._batch_gate.set()
+        self._policy_gate = asyncio.Event()  # cleared by pause(), set by resume()
+        self._policy_gate.set()
         self._scheduling_task: asyncio.Task | None = None
         self._completion_task: asyncio.Task | None = None
 
@@ -219,7 +300,6 @@ class TrainScheduler:
         self.empty_rollouts_by_env: dict[str, int] = defaultdict(int)
         self.errored_rollouts_by_env: dict[str, int] = defaultdict(int)
         self.total_rollouts_by_env: dict[str, int] = defaultdict(int)
-        self.last_batch_generation_time = 0.0
         self._batch_start_time = 0.0
 
     # ------------------------------------------------------------------
@@ -228,14 +308,7 @@ class TrainScheduler:
 
     @property
     def num_inflight_rollouts(self) -> int:
-        return sum(g.num_inflight_rollouts for g in self._groups.values())
-
-    def _off_policy_levels(self) -> list[int]:
-        return [
-            self.off_policy_steps - r.off_policy_steps
-            for g in self._groups.values()
-            for r in g.inflight_requests.values()
-        ]
+        return sum(g.num_inflight for g in self.inflight_groups.values())
 
     # ------------------------------------------------------------------
     # Public API
@@ -248,31 +321,36 @@ class TrainScheduler:
         self._completion_task = asyncio.create_task(self._completion_loop())
 
     def pause(self) -> None:
-        """Pause scheduling. In-flight rollouts continue to completion."""
-        self._scheduling_enabled.clear()
+        """Pause scheduling (policy gate). In-flight rollouts continue to completion."""
+        self._policy_gate.clear()
 
     def resume(self) -> None:
-        """Resume scheduling."""
-        self._scheduling_enabled.set()
+        """Resume scheduling (policy gate)."""
+        self._policy_gate.set()
 
     async def cancel_inflight_rollouts(self) -> None:
         """Cancel all in-flight rollout requests and release their slots."""
-        all_tasks = list(self._task_to_group.keys())
-        count = sum(g.num_inflight_rollouts for g in self._groups.values())
+        all_tasks = list(self._task_index.keys())
+        count = sum(g.num_inflight for g in self.inflight_groups.values())
         await safe_cancel_all(all_tasks)
-        for group in self._groups.values():
-            group.inflight_requests.clear()
-        self._task_to_group.clear()
-        self._groups.clear()
+        self._task_index.clear()
+        self.inflight_groups.clear()
         self.cancelled_rollouts_count += count
         self.limiter.release(count)
 
-    async def wait_for_batch(self) -> list[vf.RolloutOutput]:
-        """Block until the current batch is complete, then return it."""
+    async def next_batch(self) -> Batch:
+        """Block until the current batch is complete, then return it.
+
+        Automatically re-opens the batch gate so scheduling resumes for the
+        next batch. Callers never need to call ``resume()`` for batch
+        lifecycle — only for external pauses (eval, async barrier).
+        """
         await self._batch_ready.wait()
 
-        batch = list(self._batch_rollouts)
-        self.last_batch_generation_time = time.perf_counter() - self._batch_start_time
+        batch = Batch(
+            rollouts=list(self._batch_rollouts),
+            generation_time=time.perf_counter() - self._batch_start_time,
+        )
         if self._pbar:
             self._pbar.close()
             self._pbar = None
@@ -283,6 +361,7 @@ class TrainScheduler:
         self._batch_rollouts.clear()
         self._batch_progress = 0
         self._batch_ready.clear()
+        self._batch_gate.set()
         self._batch_start_time = time.perf_counter()
         self._pbar = ProgressTracker(
             total=self._batch_target,
@@ -305,72 +384,40 @@ class TrainScheduler:
     # ------------------------------------------------------------------
 
     async def _scheduling_loop(self) -> None:
-        """Continuously schedule rollouts. Blocks on acquire when capacity is full."""
+        """Continuously schedule rollouts. Blocks on gates or limiter."""
         while True:
-            await self._scheduling_enabled.wait()
+            await self._batch_gate.wait()
+            await self._policy_gate.wait()
+            group = self._next_schedulable() or self._create_group()
+            await self._schedule_from_group(group)
 
-            # Try to schedule from existing groups first (retries/pending)
-            scheduled = False
-            for group in list(self._groups.values()):
-                if group.rollouts_to_schedule > 0:
-                    await self._schedule_from_group(group)
-                    scheduled = True
-                    break
+    def _next_schedulable(self) -> RolloutGroup | None:
+        """Find a group that has pending rollouts to schedule (retries)."""
+        for group in self.inflight_groups.values():
+            if group.needs_scheduling:
+                return group
+        return None
 
-            if not scheduled:
-                group = self._create_group()
-                await self._schedule_from_group(group)
-
-    def _create_group(self) -> InflightGroup:
+    def _create_group(self) -> RolloutGroup:
         """Sample an example from the buffer and create a new group."""
         example = self.buffer.sample_examples(n=1)[0]
-        group = InflightGroup(
+        env = self.train_envs.get(example["env_name"])
+        group = RolloutGroup(
             example=example,
             env_name=example["env_name"],
-            rollouts_to_schedule=self.rollouts_per_example,
+            requires_group_scoring=env.requires_group_scoring,
+            rollouts_per_example=self.rollouts_per_example,
         )
-        self._groups[group.group_id] = group
+        self.inflight_groups[group.group_id] = group
         return group
 
-    async def _schedule_from_group(self, group: InflightGroup) -> None:
+    async def _schedule_from_group(self, group: RolloutGroup) -> None:
         """Schedule one request from a group. Blocks until a concurrency slot is available."""
+        if group.client is None:
+            group.client = await self._select_least_loaded_client()
         env = self.train_envs.get(group.env_name)
-
-        if group.client is not None:
-            client = group.client
-        else:
-            client = await self._select_least_loaded_client()
-            group.client = client
-
-        if env.requires_group_scoring:
-            rollout_count = group.rollouts_to_schedule
-            await self.limiter.acquire(rollout_count)
-            group.rollouts_to_schedule = 0
-            task = asyncio.create_task(
-                env.run_group(
-                    client=client,
-                    example=group.example,
-                    model_name=self.model_name,
-                    rollouts_per_example=rollout_count,
-                )
-            )
-            request = InflightRequest(
-                task=task, client=client, rollout_count=rollout_count, off_policy_steps=self.off_policy_steps
-            )
-        else:
-            await self.limiter.acquire(1)
-            group.rollouts_to_schedule -= 1
-            task = asyncio.create_task(
-                env.run_rollout(
-                    client=client,
-                    example=group.example,
-                    model_name=self.model_name,
-                )
-            )
-            request = InflightRequest(task=task, client=client, off_policy_steps=self.off_policy_steps)
-
-        group.inflight_requests[task] = request
-        self._task_to_group[task] = group.group_id
+        task = await group.schedule(env, self.model_name, self.limiter)
+        self._task_index[task] = group.group_id
 
     # ------------------------------------------------------------------
     # Completion loop
@@ -379,7 +426,7 @@ class TrainScheduler:
     async def _completion_loop(self) -> None:
         """Continuously process completed rollout tasks."""
         while True:
-            tasks = list(self._task_to_group.keys())
+            tasks = list(self._task_index.keys())
             if not tasks:
                 await asyncio.sleep(0.1)
                 continue
@@ -387,111 +434,88 @@ class TrainScheduler:
             done, _ = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
 
             for task in done:
-                group_id = self._task_to_group.pop(task, None)
+                group_id = self._task_index.pop(task, None)
                 if group_id is None:
                     continue
-
-                group = self._groups.get(group_id)
+                group = self.inflight_groups.get(group_id)
                 if group is None:
                     continue
+                await self._process_completion(group, task)
 
-                request = group.inflight_requests.pop(task, None)
-                if request is None:
-                    continue
-
-                self.limiter.release(request.rollout_count)
-                await self._process_completion(group_id, group, request)
-
-    async def _process_completion(self, group_id: str, group: InflightGroup, request: InflightRequest) -> None:
-        """Process a completed request: validate, reschedule failures, accumulate batch."""
-        env = self.train_envs.get(group.env_name)
-
+    async def _process_completion(self, group: RolloutGroup, task: asyncio.Task) -> None:
+        """Process a completed task: validate, reschedule failures, accumulate batch."""
         try:
-            result = request.task.result()
-            rollouts: list[vf.RolloutOutput] = result if isinstance(result, list) else [result]
+            n, rollouts = group.complete(task)
         except asyncio.CancelledError:
-            await self._drop_group(group_id)
+            await self._drop_group(group.group_id)
             return
         except Exception as e:
             get_logger().warning(f"Rollout failed: {e}")
-            await self._drop_group(group_id)
+            await self._drop_group(group.group_id)
             return
 
-        self.total_rollouts_by_env[group.env_name] += len(rollouts)
+        self.limiter.release(n)
+        self._record_rollout_metrics(group, rollouts)
 
-        valid_rollouts = []
-        has_failures = False
+        if group.is_complete:
+            self._finalize_group(group)
+
+    def _record_rollout_metrics(self, group: RolloutGroup, rollouts: list[vf.RolloutOutput]) -> None:
+        """Log warnings and track metrics for completed rollouts."""
+        self.total_rollouts_by_env[group.env_name] += len(rollouts)
         for rollout in rollouts:
             if len(rollout["trajectory"]) == 0:
                 self.empty_rollouts_by_env[group.env_name] += 1
-                has_failures = True
                 get_logger().warning(
-                    f"Empty trajectory in group {group_id} ({group.env_name}), re-scheduling "
-                    f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete)"
+                    f"Empty trajectory in group {group.group_id} ({group.env_name}), re-scheduling "
+                    f"({len(group.completed)}/{self.rollouts_per_example} complete)"
                 )
             elif rollout["error"] is not None:
                 self.errored_rollouts_by_env[group.env_name] += 1
-                has_failures = True
                 get_logger().warning(
-                    f"Rollout error in group {group_id} ({group.env_name}), re-scheduling "
-                    f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete): "
+                    f"Rollout error in group {group.group_id} ({group.env_name}), re-scheduling "
+                    f"({len(group.completed)}/{self.rollouts_per_example} complete): "
                     f"{rollout['error']['error_chain_repr']}"
                 )
-            else:
-                rollout["env_name"] = group.env_name
-                valid_rollouts.append(rollout)
 
-        if has_failures and env.requires_group_scoring:
-            group.completed_rollouts.clear()
-            group.rollouts_to_schedule = self.rollouts_per_example
-            return
-
-        group.rollouts_to_schedule += len(rollouts) - len(valid_rollouts)
-        group.completed_rollouts.extend(valid_rollouts)
-
-        if len(group.completed_rollouts) < self.rollouts_per_example:
-            return
-
-        # Group complete — add to batch
-        completed = self._groups.pop(group_id).completed_rollouts
-        self.buffer.update(completed)
+    def _finalize_group(self, group: RolloutGroup) -> None:
+        """Group complete — submit to buffer and accumulate batch."""
+        self.inflight_groups.pop(group.group_id)
+        self.buffer.update(group.completed)
         accepted = self.buffer.sample_rollouts(n=self.rollouts_per_example)
 
         self._batch_rollouts.extend(accepted)
-        if self._uses_token_batching:
-            increment = sum(get_seq_len(r) for r in accepted)
-        else:
-            increment = len(accepted)
+        increment = sum(get_seq_len(r) for r in accepted) if self._uses_token_batching else len(accepted)
         self._batch_progress += increment
         if self._pbar:
             self._pbar.update(increment)
 
         if self._batch_progress >= self._batch_target:
             self._batch_ready.set()
-            self.pause()  # stop scheduling until the batch is consumed
+            self._batch_gate.clear()
 
     # ------------------------------------------------------------------
     # Group management
     # ------------------------------------------------------------------
 
     async def _drop_group(self, group_id: str) -> int:
-        """Drop a group: cancel pending requests, release slots."""
-        group = self._groups.pop(group_id, None)
+        """Drop a group: cancel pending tasks, release slots."""
+        group = self.inflight_groups.pop(group_id, None)
         if group is None:
             return 0
 
-        tasks_to_cancel = list(group.inflight_requests.keys())
-        rollout_count = sum(r.rollout_count for r in group.inflight_requests.values())
+        tasks_to_cancel = list(group.tasks.keys())
+        count = group.num_inflight
 
         for task in tasks_to_cancel:
-            self._task_to_group.pop(task, None)
-        group.inflight_requests.clear()
+            self._task_index.pop(task, None)
+        group.tasks.clear()
 
         await safe_cancel_all(tasks_to_cancel)
-        if rollout_count:
-            self.limiter.release(rollout_count)
-            self.cancelled_rollouts_count += rollout_count
-        return rollout_count
+        if count:
+            self.limiter.release(count)
+            self.cancelled_rollouts_count += count
+        return count
 
     @staticmethod
     def _client_identity(c: vf.ClientConfig) -> tuple[str, str | None]:
@@ -503,21 +527,27 @@ class TrainScheduler:
         while not clients:
             await asyncio.sleep(1)
             clients = self.inference_pool.train_clients
-        inflight = Counter(
-            self._client_identity(r.client) for g in self._groups.values() for r in g.inflight_requests.values()
-        )
+        inflight: Counter = Counter()
+        for g in self.inflight_groups.values():
+            if g.client is not None:
+                inflight[self._client_identity(g.client)] += len(g.tasks)
         return min(clients, key=lambda c: inflight[self._client_identity(c)])
 
-    async def drop_stale_groups(self) -> None:
-        """Drop groups with requests older than max_off_policy_steps."""
-        stale_group_ids = {
-            gid
-            for gid, group in self._groups.items()
-            if any(
-                self.off_policy_steps - r.off_policy_steps >= self.max_off_policy_steps
-                for r in group.inflight_requests.values()
-            )
-        }
+    async def on_weights_updated(self) -> None:
+        """Called after a weight update: increment off-policy steps and drop stale groups."""
+        for group in self.inflight_groups.values():
+            group.off_policy_steps += 1
+        await self._drop_stale_groups()
+
+    def off_policy_levels(self) -> list[int]:
+        """Return off-policy step counts for all inflight groups."""
+        return [g.off_policy_steps for g in self.inflight_groups.values()]
+
+    async def _drop_stale_groups(self) -> None:
+        """Drop groups that exceed max_off_policy_steps."""
+        stale_group_ids = [
+            gid for gid, g in self.inflight_groups.items() if g.off_policy_steps >= self.max_off_policy_steps
+        ]
         if not stale_group_ids:
             return
 
@@ -533,6 +563,7 @@ class TrainScheduler:
     # ------------------------------------------------------------------
 
     def get_metrics(self) -> dict[str, float]:
+        levels = self.off_policy_levels()
         total_rollouts = sum(self.total_rollouts_by_env.values())
         metrics = {
             "scheduler/inflight_rollouts": self.num_inflight_rollouts,
@@ -541,7 +572,7 @@ class TrainScheduler:
             "scheduler/cancelled_rollouts": self.cancelled_rollouts_count,
             "empty_rollouts/all": sum(self.empty_rollouts_by_env.values()) / max(total_rollouts, 1),
             "errored_rollouts/all": sum(self.errored_rollouts_by_env.values()) / max(total_rollouts, 1),
-            "off_policy_level/all/max": max(levels) if (levels := self._off_policy_levels()) else 0,
+            "off_policy_level/all/max": max(levels) if levels else 0,
             "off_policy_level/all/mean": sum(levels) / len(levels) if levels else 0,
         }
         for env_name in self.total_rollouts_by_env:
@@ -549,9 +580,8 @@ class TrainScheduler:
             metrics[f"empty_rollouts/{env_name}"] = self.empty_rollouts_by_env.get(env_name, 0) / env_total
             metrics[f"errored_rollouts/{env_name}"] = self.errored_rollouts_by_env.get(env_name, 0) / env_total
         by_env: dict[str, list[int]] = {}
-        for group in self._groups.values():
-            for request in group.inflight_requests.values():
-                by_env.setdefault(group.env_name, []).append(self.off_policy_steps - request.off_policy_steps)
+        for group in self.inflight_groups.values():
+            by_env.setdefault(group.env_name, []).append(group.off_policy_steps)
         for env_name, steps in by_env.items():
             metrics[f"off_policy_level/{env_name}/max"] = max(steps)
             metrics[f"off_policy_level/{env_name}/mean"] = sum(steps) / len(steps)

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -10,7 +10,8 @@ from aiolimiter import AsyncLimiter
 
 from prime_rl.configs.orchestrator import OrchestratorConfig
 from prime_rl.orchestrator.buffer import Buffer
-from prime_rl.orchestrator.envs import TrainEnvs
+from prime_rl.orchestrator.concurrency import ConcurrencyLimiter
+from prime_rl.orchestrator.envs import EvalEnv, TrainEnvs
 from prime_rl.orchestrator.vf_utils import get_seq_len
 from prime_rl.utils.async_utils import safe_cancel, safe_cancel_all
 from prime_rl.utils.client import InferencePool
@@ -61,26 +62,23 @@ class Scheduler:
         inference_pool: InferencePool,
         buffer: Buffer,
         config: OrchestratorConfig,
-        max_inflight_rollouts: int,
+        concurrency_limiter: ConcurrencyLimiter,
         max_async_level: int,
         max_off_policy_steps: int,
         strict_async_level: bool,
-        tasks_per_minute: int | None,
+        rate_limiter: AsyncLimiter | None = None,
         enable_policy_updates: bool = True,
         lora_name: str | None = None,
     ):
         self.logger = get_logger()
-        if tasks_per_minute is not None:
-            self.rate_limiter = AsyncLimiter(max_rate=tasks_per_minute, time_period=60)
-        else:
-            self.rate_limiter = None
+        self.rate_limiter = rate_limiter
         self.train_envs = train_envs
         self.buffer = buffer
         self.config = config
         self.batch_size = config.batch_size
         self.token_batch_size = config.token_batch_size
         self.rollouts_per_example = config.rollouts_per_example
-        self.max_inflight_rollouts = max_inflight_rollouts
+        self.limiter = concurrency_limiter
         self.max_async_level = max_async_level
         self.max_off_policy_steps = max_off_policy_steps
         self.strict_async_level = strict_async_level
@@ -145,6 +143,7 @@ class Scheduler:
         self.inflight_requests.clear()
         self.groups.clear()
         self.cancelled_rollouts_count += count
+        self.limiter.release(count)
 
     @staticmethod
     def _client_identity(c: vf.ClientConfig) -> tuple[str, str | None]:
@@ -175,6 +174,8 @@ class Scheduler:
             rollout_count += info.rollout_count
         self.groups.pop(group_id, None)
         await safe_cancel_all(tasks_to_cancel)
+        if rollout_count:
+            self.limiter.release(rollout_count)
         return rollout_count
 
     async def schedule_rollout(self, group_id: int):
@@ -198,6 +199,13 @@ class Scheduler:
 
         if env.requires_group_scoring:
             rollout_count = group.rollouts_to_schedule
+        else:
+            rollout_count = 1
+
+        if not self.limiter.try_acquire(rollout_count):
+            return
+
+        if env.requires_group_scoring:
             group.rollouts_to_schedule = 0
             task = asyncio.create_task(
                 env.run_group(
@@ -208,7 +216,6 @@ class Scheduler:
                 )
             )
         else:
-            rollout_count = 1
             group.rollouts_to_schedule -= 1
             task = asyncio.create_task(
                 env.run_rollout(
@@ -235,7 +242,7 @@ class Scheduler:
         return self.inflight_rollout_count + pending
 
     async def _schedule_next_request(self) -> bool:
-        remaining_capacity = self.max_inflight_rollouts - self.inflight_rollout_count
+        remaining_capacity = self.limiter.remaining
 
         if remaining_capacity <= 0:
             return False
@@ -412,6 +419,7 @@ class Scheduler:
                 if rollout_info is None:
                     continue
 
+                self.limiter.release(rollout_info.rollout_count)
                 group_id = rollout_info.group_id
                 env_name = rollout_info.env_name
 
@@ -546,3 +554,45 @@ class Scheduler:
         metrics.update(self.inference_pool.get_metrics())
 
         return metrics
+
+
+class EvalScheduler:
+    """Manages concurrency-limited eval rollout scheduling via a shared ConcurrencyLimiter."""
+
+    def __init__(
+        self,
+        concurrency_limiter: ConcurrencyLimiter,
+        inference_pool: InferencePool,
+        rate_limiter: AsyncLimiter | None = None,
+    ):
+        self.limiter = concurrency_limiter
+        self.inference_pool = inference_pool
+        self.rate_limiter = rate_limiter
+
+    async def evaluate(
+        self,
+        eval_env: EvalEnv,
+        model_name: str,
+        ckpt_step: int,
+        step: int,
+    ) -> list[vf.RolloutOutput]:
+        """Run eval with concurrency limiting via the shared limiter."""
+        rollouts_per_example = eval_env.config.rollouts_per_example
+        cost_per_coro = rollouts_per_example if eval_env.requires_group_scoring else 1
+
+        async def get_client() -> vf.ClientConfig:
+            if self.rate_limiter:
+                await self.rate_limiter.acquire()
+            await self.limiter.acquire(cost_per_coro)
+            return await self.inference_pool.get_eval_client()
+
+        def on_rollout_done(count: int) -> None:
+            self.limiter.release(count)
+
+        return await eval_env.evaluate(
+            model_name=model_name,
+            get_client=get_client,
+            ckpt_step=ckpt_step,
+            step=step,
+            on_rollout_done=on_rollout_done,
+        )

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -273,6 +273,7 @@ class TrainScheduler:
             json_logging=self.json_logging,
             step=self.progress.step,
         )
+        self.resume()  # start filling the next batch
 
     async def stop(self) -> None:
         """Stop all background tasks and cancel in-flight rollouts."""
@@ -454,6 +455,7 @@ class TrainScheduler:
 
         if self._batch_progress >= self._batch_target:
             self._batch_ready.set()
+            self.pause()  # stop scheduling until the batch is consumed
 
     # ------------------------------------------------------------------
     # Group management

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 import verifiers as vf
-from verifiers.utils.logging_utils import print_time
 
 from prime_rl.orchestrator.buffer import Buffer
 from prime_rl.orchestrator.ckpt import Progress
@@ -119,29 +118,9 @@ class PolicyScheduler:
         self.update_weights_time = 0.0
         self.wait_for_ckpt_time = 0.0
 
-    async def maybe_update(self, step: int) -> None:
-        """Check for and apply any pending policy updates."""
-
-        def get_next_ckpt_step() -> int:
-            latest_ckpt_step = get_latest_ckpt_step(get_broadcast_dir(self.output_dir)) or 0
-            async_away_ckpt_step = max(step - self.max_async_level, 0)
-            if self.strict_async_level:
-                return async_away_ckpt_step
-            return max(async_away_ckpt_step, latest_ckpt_step)
-
-        while True:
-            next_ckpt_step = get_next_ckpt_step()
-            if next_ckpt_step <= self.ckpt_step:
-                return
-            await self._apply_update(next_ckpt_step, step)
-
     @property
     def async_level(self) -> int:
         return self.progress.step - self.ckpt_step
-
-    @property
-    def at_async_barrier(self) -> bool:
-        return self.progress.step - self.ckpt_step == self.max_async_level
 
     def get_metrics(self) -> dict[str, float]:
         return {
@@ -150,35 +129,41 @@ class PolicyScheduler:
             "scheduler/async_level": self.async_level,
         }
 
-    async def run(self) -> None:
-        """Background loop. Reads current step from progress.step."""
-        while True:
-            await self.maybe_update(self.progress.step)
-            await asyncio.sleep(1)
-
-    async def _apply_update(self, next_ckpt_step: int, step: int) -> None:
-        # Wait for checkpoint if we're at the async barrier
+    def _get_next_ckpt_step(self) -> int:
+        step = self.progress.step
+        latest_ckpt_step = get_latest_ckpt_step(get_broadcast_dir(self.output_dir)) or 0
         async_away_ckpt_step = max(step - self.max_async_level, 0)
-        if next_ckpt_step == async_away_ckpt_step:
-            get_logger().info(
-                f"At async barrier: Pausing new rollout scheduling while waiting for checkpoint {next_ckpt_step}"
-            )
-            self.train_scheduler.pause()
-            t0 = time.perf_counter()
-            await wait_for_path(get_step_path(get_broadcast_dir(self.output_dir), next_ckpt_step) / "STABLE")
-            self.wait_for_ckpt_time = time.perf_counter() - t0
-            get_logger().info(
-                f"Cleared async barrier: Checkpoint {next_ckpt_step} ready after {print_time(self.wait_for_ckpt_time)}"
-            )
+        if self.strict_async_level:
+            return async_away_ckpt_step
+        return max(async_away_ckpt_step, latest_ckpt_step)
 
-        # Update weights on inference servers
-        get_logger().info(f"Updating weights to step {next_ckpt_step}")
+    async def maybe_update(self) -> None:
+        """Check for and apply pending policy updates.
+
+        1. If at latest checkpoint — return
+        2. If at async barrier — pause train scheduler, wait for checkpoint
+        3. Update weights, drop stale groups, resume train scheduler
+        """
+        while True:
+            next_ckpt_step = self._get_next_ckpt_step()
+            if next_ckpt_step <= self.ckpt_step:
+                return
+
+            at_barrier = next_ckpt_step == max(self.progress.step - self.max_async_level, 0)
+            if at_barrier:
+                self.train_scheduler.pause()
+                t0 = time.perf_counter()
+                await wait_for_path(get_step_path(get_broadcast_dir(self.output_dir), next_ckpt_step) / "STABLE")
+                self.wait_for_ckpt_time = time.perf_counter() - t0
+
+            await self._update_weights(next_ckpt_step)
+            await self.train_scheduler.drop_stale_groups(next_ckpt_step)
+            self.train_scheduler.resume()
+
+    async def _update_weights(self, next_ckpt_step: int) -> None:
         t0 = time.perf_counter()
-        await self.inference_pool.update_weights(
-            weight_dir=get_step_path(get_broadcast_dir(self.output_dir), next_ckpt_step),
-            lora_name=self.lora_name,
-            step=next_ckpt_step,
-        )
+        weights_path = get_step_path(get_broadcast_dir(self.output_dir), next_ckpt_step)
+        await self.inference_pool.update_weights(weights_path, lora_name=self.lora_name, step=next_ckpt_step)
         self.update_weights_time = time.perf_counter() - t0
 
         self.ckpt_step = next_ckpt_step
@@ -187,12 +172,11 @@ class PolicyScheduler:
             self.train_scheduler.model_name = self.lora_name
             self.inference_pool.update_model_name(self.model_name)
 
-        # Resume scheduling and drop stale rollouts
-        self.train_scheduler.resume()
-        await self.train_scheduler.drop_stale_groups(next_ckpt_step)
-        get_logger().debug(
-            f"Updated weights to step {next_ckpt_step} in {print_time(self.update_weights_time)}. Resuming scheduling of training rollouts"
-        )
+    async def run(self) -> None:
+        """Background loop."""
+        while True:
+            await self.maybe_update()
+            await asyncio.sleep(1)
 
 
 # ---------------------------------------------------------------------------

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 import verifiers as vf
+from verifiers.utils.logging_utils import print_time
 
 from prime_rl.orchestrator.buffer import Buffer
 from prime_rl.orchestrator.ckpt import Progress
@@ -133,48 +134,52 @@ class PolicyScheduler:
         3. Update weights, drop stale groups, resume train scheduler
         """
 
-        def get_next_ckpt_step() -> int:
-            orch_step = self.progress.step
-            latest_ckpt_step = get_latest_ckpt_step(get_broadcast_dir(self.output_dir)) or 0
-            async_away_ckpt_step = max(orch_step - self.max_async_level, 0)
-            if self.strict_async_level:
-                return async_away_ckpt_step
-            return max(async_away_ckpt_step, latest_ckpt_step)
-
         logger = get_logger()
         while True:
-            next_ckpt_step = get_next_ckpt_step()
+            next_ckpt_step = self._get_next_ckpt_step()
             if next_ckpt_step <= self.ckpt_step:
                 await asyncio.sleep(1)
                 continue
 
             if self.at_async_barrier:
                 logger.info(
-                    f"[policy] Pausing training rollout scheduling — waiting for trainer to produce "
-                    f"checkpoint {next_ckpt_step} (>{self.max_async_level} step(s) ahead)"
+                    f"At async barrier: Pausing training rollout scheduling and waiting for training checkpoint {next_ckpt_step}"
                 )
                 self.train_scheduler.pause()
                 t0 = time.perf_counter()
                 await wait_for_path(get_step_path(get_broadcast_dir(self.output_dir), next_ckpt_step) / "STABLE")
                 self.wait_for_ckpt_time = time.perf_counter() - t0
-                logger.info(f"[policy] Checkpoint {next_ckpt_step} ready after {self.wait_for_ckpt_time:.2f}s")
+                logger.debug(
+                    f"Cleared async barrier: Training checkpoint {next_ckpt_step} ready after {print_time(self.wait_for_ckpt_time)}"
+                )
 
-            logger.info(f"[policy] Loading weights for checkpoint {next_ckpt_step} onto inference servers")
-            await self.update_weights(next_ckpt_step)
-            logger.debug(f"[policy] Weights loaded in {self.update_weights_time:.2f}s")
+            logger.info(f"Updating weights to training checkpoint {next_ckpt_step}")
+            await self._update_weights(next_ckpt_step)
+            logger.debug(
+                f"Weights updated to training checkpoint {next_ckpt_step} in {print_time(self.update_weights_time)}"
+            )
 
-            logger.info("[policy] Dropping stale rollouts and resuming training rollout scheduling")
+            logger.info("Resuming training rollout scheduling")
             await self.train_scheduler.drop_stale_groups(next_ckpt_step)
             self.train_scheduler.resume()
-            logger.debug(f"[policy] Policy update to checkpoint {next_ckpt_step} complete")
 
-    async def update_weights(self, next_ckpt_step: int) -> None:
+    def _get_next_ckpt_step(self) -> int:
+        """Compute the next training checkpoint to update to."""
+        orch_step = self.progress.step
+        latest_ckpt_step = get_latest_ckpt_step(get_broadcast_dir(self.output_dir)) or 0
+        async_away_ckpt_step = max(orch_step - self.max_async_level, 0)
+        if self.strict_async_level:
+            return async_away_ckpt_step
+        return max(async_away_ckpt_step, latest_ckpt_step)
+
+    async def _update_weights(self, ckpt_step: int) -> None:
+        """Update the weights to the next training checkpoint."""
         t0 = time.perf_counter()
-        weights_path = get_step_path(get_broadcast_dir(self.output_dir), next_ckpt_step)
-        await self.inference_pool.update_weights(weights_path, lora_name=self.lora_name, step=next_ckpt_step)
+        weights_path = get_step_path(get_broadcast_dir(self.output_dir), ckpt_step)
+        await self.inference_pool.update_weights(weights_path, lora_name=self.lora_name, step=ckpt_step)
         self.update_weights_time = time.perf_counter() - t0
 
-        self.ckpt_step = next_ckpt_step
+        self.ckpt_step = ckpt_step
         if self.lora_name is not None:
             self.train_scheduler.model_name = self.lora_name
             self.inference_pool.update_model_name(self.lora_name)
@@ -214,12 +219,11 @@ class TrainScheduler:
         model_name: str,
         json_logging: bool = False,
     ):
-        self.logger = get_logger()
-        self.limiter = rollout_limiter
         self.train_envs = train_envs
         self.inference_pool = inference_pool
         self.buffer = buffer
         self.progress = progress
+        self.limiter = rollout_limiter
         self._uses_token_batching = token_batch_size is not None
         self._batch_target = token_batch_size or batch_size
         self.rollouts_per_example = rollouts_per_example
@@ -296,8 +300,14 @@ class TrainScheduler:
         self.limiter.release(count)
 
     async def wait_for_batch(self) -> list[vf.RolloutOutput]:
-        """Block until the current batch is complete, then return it."""
+        """Block until the current batch is complete and scheduling is active.
+
+        If the policy scheduler has paused us at the async barrier, we hold
+        the batch until the weight update completes and resume() is called.
+        This ensures the orchestrator doesn't advance faster than max_async_level.
+        """
         await self._batch_ready.wait()
+        await self._scheduling_enabled.wait()
 
         batch = list(self._batch_rollouts)
         self.last_batch_generation_time = time.perf_counter() - self._batch_start_time
@@ -444,7 +454,7 @@ class TrainScheduler:
             await self._drop_group(group_id)
             return
         except Exception as e:
-            self.logger.warning(f"Rollout failed: {e}")
+            get_logger().warning(f"Rollout failed: {e}")
             await self._drop_group(group_id)
             return
 
@@ -456,14 +466,14 @@ class TrainScheduler:
             if len(rollout["trajectory"]) == 0:
                 self.empty_rollouts_by_env[group.env_name] += 1
                 has_failures = True
-                self.logger.warning(
+                get_logger().warning(
                     f"Empty trajectory in group {group_id} ({group.env_name}), re-scheduling "
                     f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete)"
                 )
             elif rollout["error"] is not None:
                 self.errored_rollouts_by_env[group.env_name] += 1
                 has_failures = True
-                self.logger.warning(
+                get_logger().warning(
                     f"Rollout error in group {group_id} ({group.env_name}), re-scheduling "
                     f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete): "
                     f"{rollout['error']['error_chain_repr']}"
@@ -553,7 +563,7 @@ class TrainScheduler:
         counts = await asyncio.gather(*(self._drop_group(gid) for gid in stale_group_ids))
         removed = sum(counts)
         if removed:
-            self.logger.warning(
+            get_logger().warning(
                 f"Cancelled {removed} stale rollout requests (ckpt_step={current_ckpt_step}). "
                 f"Consider increasing max_off_policy_steps to avoid this."
             )

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -6,10 +6,11 @@ from abc import abstractmethod
 from collections import Counter, defaultdict
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
+from pathlib import Path
 
 import verifiers as vf
+from verifiers.utils.logging_utils import print_time
 
-from prime_rl.configs.orchestrator import OrchestratorConfig
 from prime_rl.orchestrator.buffer import Buffer
 from prime_rl.orchestrator.concurrency import RolloutLimiter
 from prime_rl.orchestrator.envs import EvalEnv, TrainEnvs
@@ -97,16 +98,15 @@ class PolicyScheduler:
         self,
         train_scheduler: TrainScheduler,
         inference_pool: InferencePool,
-        config: OrchestratorConfig,
+        output_dir: Path,
         max_async_level: int,
         strict_async_level: bool,
         model_name: str,
         lora_name: str | None = None,
     ):
-        self.logger = get_logger()
         self.train_scheduler = train_scheduler
         self.inference_pool = inference_pool
-        self.output_dir = config.output_dir
+        self.output_dir = output_dir
         self.max_async_level = max_async_level
         self.strict_async_level = strict_async_level
         self.model_name = model_name
@@ -123,6 +123,17 @@ class PolicyScheduler:
             if next_ckpt_step <= self.ckpt_step:
                 return
             await self._apply_update(next_ckpt_step, step)
+
+    @property
+    def async_level(self) -> int:
+        return self.train_scheduler.step - self.ckpt_step
+
+    def get_metrics(self) -> dict[str, float]:
+        return {
+            "time/wait_for_ckpt": self.wait_for_ckpt_time,
+            "time/update_weights": self.update_weights_time,
+            "scheduler/async_level": self.async_level,
+        }
 
     async def run(self) -> None:
         """Background loop. Reads current step from train_scheduler.step."""
@@ -141,21 +152,26 @@ class PolicyScheduler:
         # Wait for checkpoint if we're at the async barrier
         async_away_ckpt_step = max(step - self.max_async_level, 0)
         if next_ckpt_step == async_away_ckpt_step:
-            self.logger.info(
-                f"Orchestrator paused: waiting for checkpoint {next_ckpt_step} (>{self.max_async_level} step(s) ahead)"
+            get_logger().info(
+                f"At async barrier: Pausing new rollout scheduling while waiting for checkpoint {next_ckpt_step}"
             )
             self.train_scheduler.pause()
             t0 = time.perf_counter()
             await wait_for_path(get_step_path(get_broadcast_dir(self.output_dir), next_ckpt_step) / "STABLE")
             self.wait_for_ckpt_time = time.perf_counter() - t0
-            self.logger.info(f"Checkpoint {next_ckpt_step} ready (after {self.wait_for_ckpt_time:.2f}s)")
+            get_logger().info(
+                f"Cleared async barrier: Checkpoint {next_ckpt_step} ready after {print_time(self.wait_for_ckpt_time)}"
+            )
 
         # Update weights on inference servers
+        get_logger().info(f"Updating weights to step {next_ckpt_step}")
         t0 = time.perf_counter()
-        weights_path = get_step_path(get_broadcast_dir(self.output_dir), next_ckpt_step)
-        await self.inference_pool.update_weights(weights_path, lora_name=self.lora_name, step=next_ckpt_step)
+        await self.inference_pool.update_weights(
+            weight_dir=get_step_path(get_broadcast_dir(self.output_dir), next_ckpt_step),
+            lora_name=self.lora_name,
+            step=next_ckpt_step,
+        )
         self.update_weights_time = time.perf_counter() - t0
-        self.logger.debug(f"Updated weights to step {next_ckpt_step} in {self.update_weights_time:.2f}s")
 
         self.ckpt_step = next_ckpt_step
         if self.lora_name is not None:
@@ -166,6 +182,9 @@ class PolicyScheduler:
         # Resume scheduling and drop stale rollouts
         self.train_scheduler.resume()
         await self.train_scheduler.drop_stale_groups(next_ckpt_step)
+        get_logger().debug(
+            f"Updated weights to step {next_ckpt_step} in {print_time(self.update_weights_time)}. Resuming scheduling of training rollouts"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -186,35 +205,38 @@ class TrainScheduler:
         train_envs: TrainEnvs,
         inference_pool: InferencePool,
         buffer: Buffer,
-        config: OrchestratorConfig,
         rollout_limiter: RolloutLimiter,
+        output_dir: Path,
+        batch_size: int,
+        token_batch_size: int,
+        rollouts_per_example: int,
         max_async_level: int,
         max_off_policy_steps: int,
         strict_async_level: bool,
+        enable_policy_updates: bool,
         model_name: str,
-        enable_policy_updates: bool = True,
+        json_logging: bool,
         lora_name: str | None = None,
     ):
         self.logger = get_logger()
         self.limiter = rollout_limiter
         self.train_envs = train_envs
+        self.inference_pool = inference_pool
         self.buffer = buffer
-        self.config = config
-        self._uses_token_batching = config.token_batch_size is not None
-        self._batch_target = config.token_batch_size or config.batch_size
-        self.rollouts_per_example = config.rollouts_per_example
+        self._uses_token_batching = token_batch_size is not None
+        self._batch_target = token_batch_size or batch_size
+        self.rollouts_per_example = rollouts_per_example
         self.max_off_policy_steps = max_off_policy_steps
         self.enable_policy_updates = enable_policy_updates
         self.model_name = model_name
-        self.json_logging = config.log.json_logging
-        self.inference_pool = inference_pool
+        self.json_logging = json_logging
 
         self.policy: PolicyScheduler | None = None
         if enable_policy_updates:
             self.policy = PolicyScheduler(
                 train_scheduler=self,
                 inference_pool=inference_pool,
-                config=config,
+                output_dir=output_dir,
                 max_async_level=max_async_level,
                 strict_async_level=strict_async_level,
                 model_name=model_name,
@@ -256,10 +278,6 @@ class TrainScheduler:
     @property
     def num_inflight_rollouts(self) -> int:
         return sum(g.total_inflight_rollouts for g in self._groups.values())
-
-    @property
-    def async_level(self) -> int:
-        return self.step - self.ckpt_step
 
     def _off_policy_levels(self) -> list[int]:
         return [self.ckpt_step - r.ckpt_step for g in self._groups.values() for r in g.inflight_requests.values()]
@@ -601,9 +619,6 @@ class TrainScheduler:
     def get_metrics(self) -> dict[str, float]:
         total_rollouts = sum(self.total_rollouts_by_env.values())
         metrics = {
-            "time/wait_for_ckpt": self.policy.wait_for_ckpt_time if self.policy else 0,
-            "time/update_weights": self.policy.update_weights_time if self.policy else 0,
-            "scheduler/async_level": self.async_level,
             "scheduler/inflight_rollouts": self.num_inflight_rollouts,
             "scheduler/limiter_used": self.limiter.concurrency.used,
             "scheduler/limiter_remaining": self.limiter.remaining,
@@ -630,6 +645,8 @@ class TrainScheduler:
         self.total_rollouts_by_env.clear()
 
         metrics.update(self.inference_pool.get_metrics())
+        if self.policy:
+            metrics.update(self.policy.get_metrics())
         return metrics
 
 

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -137,6 +137,11 @@ async def setup_inference_pool(
     )
 
 
+def client_identity(c: vf.ClientConfig) -> tuple[str, str | None]:
+    """Stable identity for a client config that survives elastic pool refreshes."""
+    return (c.api_base_url, c.extra_headers.get("X-data-parallel-rank"))
+
+
 def setup_clients(client_config: ClientConfig, client_type: str = "openai_chat_completions") -> list[vf.ClientConfig]:
     clients = []
     client_idx = 0

--- a/tests/unit/orchestrator/test_scheduler.py
+++ b/tests/unit/orchestrator/test_scheduler.py
@@ -107,7 +107,7 @@ def test_policy_scheduler_applies_latest_checkpoint():
             patch("prime_rl.orchestrator.scheduler.wait_for_path", new=AsyncMock()),
         ):
             # Run the loop briefly — it should apply the update then sleep
-            task = asyncio.create_task(ps.run())
+            task = asyncio.create_task(ps.start())
             await asyncio.sleep(0.1)
             task.cancel()
             try:
@@ -145,7 +145,7 @@ def test_stop_cancels_inflight_policy_update_task():
             patch("prime_rl.orchestrator.scheduler.get_latest_ckpt_step", return_value=8),
             patch("prime_rl.orchestrator.scheduler.wait_for_path", new=AsyncMock()),
         ):
-            policy_task = asyncio.create_task(ps.run())
+            policy_task = asyncio.create_task(ps.start())
             await started.wait()
             policy_task.cancel()
             try:

--- a/tests/unit/orchestrator/test_scheduler.py
+++ b/tests/unit/orchestrator/test_scheduler.py
@@ -105,7 +105,7 @@ def test_maybe_update_applies_latest_checkpoint():
             patch("prime_rl.orchestrator.scheduler.get_latest_ckpt_step", return_value=8),
             patch("prime_rl.orchestrator.scheduler.wait_for_path", new=AsyncMock()),
         ):
-            await ps.maybe_update(step=9)
+            await ps.maybe_update()
 
         assert applied_steps == [8]
         assert ps.ckpt_step == 8
@@ -137,7 +137,7 @@ def test_stop_cancels_inflight_policy_update_task():
             patch("prime_rl.orchestrator.scheduler.get_latest_ckpt_step", return_value=8),
             patch("prime_rl.orchestrator.scheduler.wait_for_path", new=AsyncMock()),
         ):
-            policy_task = asyncio.create_task(ps.maybe_update(step=9))
+            policy_task = asyncio.create_task(ps.maybe_update())
             await started.wait()
             policy_task.cancel()
             try:

--- a/tests/unit/orchestrator/test_scheduler.py
+++ b/tests/unit/orchestrator/test_scheduler.py
@@ -86,8 +86,8 @@ def test_drop_stale_groups_drops_old_requests():
     asyncio.run(run())
 
 
-def test_maybe_update_applies_latest_checkpoint():
-    async def run() -> None:
+def test_policy_scheduler_applies_latest_checkpoint():
+    async def run_test() -> None:
         scheduler = _make_train_scheduler()
         ps = _make_policy_scheduler(scheduler)
         applied_steps: list[int] = []
@@ -105,12 +105,19 @@ def test_maybe_update_applies_latest_checkpoint():
             patch("prime_rl.orchestrator.scheduler.get_latest_ckpt_step", return_value=8),
             patch("prime_rl.orchestrator.scheduler.wait_for_path", new=AsyncMock()),
         ):
-            await ps.maybe_update()
+            # Run the loop briefly — it should apply the update then sleep
+            task = asyncio.create_task(ps.run())
+            await asyncio.sleep(0.1)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
 
         assert applied_steps == [8]
         assert ps.ckpt_step == 8
 
-    asyncio.run(run())
+    asyncio.run(run_test())
 
 
 def test_stop_cancels_inflight_policy_update_task():
@@ -137,7 +144,7 @@ def test_stop_cancels_inflight_policy_update_task():
             patch("prime_rl.orchestrator.scheduler.get_latest_ckpt_step", return_value=8),
             patch("prime_rl.orchestrator.scheduler.wait_for_path", new=AsyncMock()),
         ):
-            policy_task = asyncio.create_task(ps.maybe_update())
+            policy_task = asyncio.create_task(ps.run())
             await started.wait()
             policy_task.cancel()
             try:

--- a/tests/unit/orchestrator/test_scheduler.py
+++ b/tests/unit/orchestrator/test_scheduler.py
@@ -17,8 +17,8 @@ def make_scheduler() -> TrainScheduler:
     scheduler.ckpt_step = 7
     scheduler.config = SimpleNamespace(output_dir=Path("/tmp/prime-rl-test"))
     scheduler.logger = MagicMock()
-    scheduler.checkpoint_ready = asyncio.Event()
-    scheduler.checkpoint_ready.set()
+    scheduler._scheduling_enabled = asyncio.Event()
+    scheduler._scheduling_enabled.set()
     scheduler.lora_name = None
     scheduler.model_name = "test-model"
     scheduler.update_weights_time = 0

--- a/tests/unit/orchestrator/test_scheduler.py
+++ b/tests/unit/orchestrator/test_scheduler.py
@@ -30,18 +30,12 @@ def _make_train_scheduler() -> TrainScheduler:
 def _make_policy_scheduler(train_scheduler: TrainScheduler) -> PolicyScheduler:
     """Create a minimal PolicyScheduler for testing."""
     ps = PolicyScheduler.__new__(PolicyScheduler)
-    ps.logger = MagicMock()
     ps.train_scheduler = train_scheduler
     ps.inference_pool = MagicMock()
-    ps.progress = Progress(step=9)
     ps.output_dir = Path("/tmp/prime-rl-test")
-    ps.max_async_level = 1
-    ps.strict_async_level = False
     ps.lora_name = None
     ps.ckpt_step = 7
     ps.update_weights_time = 0
-    ps.wait_for_ckpt_time = 0
-    train_scheduler.progress = ps.progress
     return ps
 
 

--- a/tests/unit/orchestrator/test_scheduler.py
+++ b/tests/unit/orchestrator/test_scheduler.py
@@ -5,7 +5,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from prime_rl.orchestrator.concurrency import ConcurrencyLimiter, RolloutLimiter
 from prime_rl.orchestrator.scheduler import InflightGroup, InflightRolloutRequest, PolicyScheduler, TrainScheduler
-from prime_rl.utils.async_utils import safe_cancel
 
 
 def _make_train_scheduler() -> TrainScheduler:
@@ -33,9 +32,9 @@ def _make_policy_scheduler(train_scheduler: TrainScheduler) -> PolicyScheduler:
     """Create a minimal PolicyScheduler for testing."""
     ps = PolicyScheduler.__new__(PolicyScheduler)
     ps.logger = MagicMock()
-    ps._train = train_scheduler
+    ps.train_scheduler = train_scheduler
     ps.inference_pool = MagicMock()
-    ps.config = SimpleNamespace(output_dir=Path("/tmp/prime-rl-test"))
+    ps.output_dir = Path("/tmp/prime-rl-test")
     ps.max_async_level = 1
     ps.strict_async_level = False
     ps.model_name = "test-model"
@@ -43,8 +42,6 @@ def _make_policy_scheduler(train_scheduler: TrainScheduler) -> PolicyScheduler:
     ps.ckpt_step = 7
     ps.update_weights_time = 0
     ps.wait_for_ckpt_time = 0
-    ps._inflight_task = None
-    ps._lock = asyncio.Lock()
     train_scheduler.policy = ps
     train_scheduler.step = 9
     return ps
@@ -90,18 +87,14 @@ def test_drop_stale_groups_drops_old_requests():
     asyncio.run(run())
 
 
-def test_maybe_update_reuses_inflight_update_after_cancellation():
+def test_maybe_update_applies_latest_checkpoint():
     async def run() -> None:
         scheduler = _make_train_scheduler()
         ps = _make_policy_scheduler(scheduler)
-        started = asyncio.Event()
-        release = asyncio.Event()
         applied_steps: list[int] = []
 
         async def update_weights(weight_dir, lora_name=None, step=0) -> None:
             applied_steps.append(step)
-            started.set()
-            await release.wait()
 
         ps.inference_pool = SimpleNamespace(
             update_weights=update_weights,
@@ -113,16 +106,7 @@ def test_maybe_update_reuses_inflight_update_after_cancellation():
             patch("prime_rl.orchestrator.scheduler.get_latest_ckpt_step", return_value=8),
             patch("prime_rl.orchestrator.scheduler.wait_for_path", new=AsyncMock()),
         ):
-            first = asyncio.create_task(ps.maybe_update(step=9))
-            await started.wait()
-            await safe_cancel(first)
-
-            second = asyncio.create_task(ps.maybe_update(step=9))
-            await asyncio.sleep(0)
-            assert applied_steps == [8]
-
-            release.set()
-            await second
+            await ps.maybe_update(step=9)
 
         assert applied_steps == [8]
         assert ps.ckpt_step == 8
@@ -160,7 +144,6 @@ def test_stop_cancels_inflight_policy_update_task():
 
         assert cancelled.is_set()
         assert scheduler._policy_loop_task is None
-        assert ps._inflight_task is None
 
     asyncio.run(run())
 

--- a/tests/unit/orchestrator/test_scheduler.py
+++ b/tests/unit/orchestrator/test_scheduler.py
@@ -51,12 +51,12 @@ def test_update_off_policy_does_not_increment_interleaved_on_policy_tasks():
             1: InflightGroup(
                 example={},
                 env_name="test",
-                requests={stale_task: stale_request},
+                inflight_requests={stale_task: stale_request},
             ),
             2: InflightGroup(
                 example={},
                 env_name="test",
-                requests={survivor_task: survivor_request},
+                inflight_requests={survivor_task: survivor_request},
             ),
         }
         scheduler._task_to_group = {stale_task: 1, survivor_task: 2}

--- a/tests/unit/orchestrator/test_scheduler.py
+++ b/tests/unit/orchestrator/test_scheduler.py
@@ -4,20 +4,28 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from prime_rl.orchestrator.ckpt import Progress
 from prime_rl.orchestrator.concurrency import ConcurrencyLimiter, RolloutLimiter
-from prime_rl.orchestrator.scheduler import PolicyScheduler, RolloutGroup, RolloutRequest, TrainScheduler
+from prime_rl.orchestrator.scheduler import (
+    PolicyScheduler,
+    RolloutDispatcher,
+    RolloutGroup,
+    RolloutRequest,
+    TrainScheduler,
+)
+
+
+def _make_dispatcher() -> RolloutDispatcher:
+    return RolloutDispatcher(limiter=RolloutLimiter(128), inference_pool=MagicMock())
 
 
 def _make_train_scheduler() -> TrainScheduler:
     """Create a minimal TrainScheduler for testing (no __init__)."""
     scheduler = TrainScheduler.__new__(TrainScheduler)
-    scheduler.limiter = RolloutLimiter(128)
-    scheduler._batch_gate = asyncio.Event()
-    scheduler._batch_gate.set()
+    scheduler.dispatcher = _make_dispatcher()
     scheduler._policy_gate = asyncio.Event()
     scheduler._policy_gate.set()
     scheduler._groups = {}
     scheduler._requests = {}
-    scheduler._retry_queue = asyncio.deque() if hasattr(asyncio, "deque") else __import__("collections").deque()
+    scheduler._retry_queue = __import__("collections").deque()
     scheduler._schedule_queue = __import__("collections").deque()
     scheduler.max_off_policy_steps = 2
     scheduler.max_retries = 3
@@ -79,7 +87,7 @@ def test_drop_stale_groups():
             stale_task: RolloutRequest(group_id=stale_group.group_id, cost=1),
             survivor_task: RolloutRequest(group_id=survivor_group.group_id, cost=1),
         }
-        scheduler.limiter.concurrency.try_acquire(2)
+        scheduler.dispatcher.limiter.concurrency.try_acquire(2)
 
         scheduler.on_weights_updated()
 

--- a/tests/unit/orchestrator/test_scheduler.py
+++ b/tests/unit/orchestrator/test_scheduler.py
@@ -138,12 +138,15 @@ def test_stop_cancels_inflight_policy_update_task():
             patch("prime_rl.orchestrator.scheduler.get_latest_ckpt_step", return_value=8),
             patch("prime_rl.orchestrator.scheduler.wait_for_path", new=AsyncMock()),
         ):
-            scheduler._policy_loop_task = asyncio.create_task(ps.maybe_update(step=9))
+            policy_task = asyncio.create_task(ps.maybe_update(step=9))
             await started.wait()
-            await asyncio.wait_for(scheduler.stop(), timeout=0.2)
+            policy_task.cancel()
+            try:
+                await asyncio.wait_for(policy_task, timeout=0.2)
+            except (asyncio.CancelledError, asyncio.TimeoutError):
+                pass
 
         assert cancelled.is_set()
-        assert scheduler._policy_loop_task is None
 
     asyncio.run(run())
 

--- a/tests/unit/orchestrator/test_scheduler.py
+++ b/tests/unit/orchestrator/test_scheduler.py
@@ -1,28 +1,30 @@
 import asyncio
 from pathlib import Path
-from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from prime_rl.orchestrator.ckpt import Progress
 from prime_rl.orchestrator.concurrency import ConcurrencyLimiter, RolloutLimiter
-from prime_rl.orchestrator.scheduler import InflightGroup, InflightRequest, PolicyScheduler, TrainScheduler
+from prime_rl.orchestrator.scheduler import PolicyScheduler, RolloutGroup, RolloutRequest, TrainScheduler
 
 
 def _make_train_scheduler() -> TrainScheduler:
     """Create a minimal TrainScheduler for testing (no __init__)."""
     scheduler = TrainScheduler.__new__(TrainScheduler)
     scheduler.limiter = RolloutLimiter(128)
-    scheduler.logger = MagicMock()
-    scheduler._scheduling_enabled = asyncio.Event()
-    scheduler._scheduling_enabled.set()
+    scheduler._batch_gate = asyncio.Event()
+    scheduler._batch_gate.set()
+    scheduler._policy_gate = asyncio.Event()
+    scheduler._policy_gate.set()
     scheduler._groups = {}
-    scheduler._task_to_group = {}
-    scheduler.max_off_policy_steps = 1
+    scheduler._requests = {}
+    scheduler._retry_queue = asyncio.deque() if hasattr(asyncio, "deque") else __import__("collections").deque()
+    scheduler._schedule_queue = __import__("collections").deque()
+    scheduler.max_off_policy_steps = 2
+    scheduler.max_retries = 3
     scheduler.cancelled_rollouts_count = 0
     scheduler._scheduling_task = None
     scheduler._completion_task = None
     scheduler.progress = Progress(step=0)
-    scheduler.off_policy_steps = 0
     scheduler.model_name = "test-model"
     return scheduler
 
@@ -36,43 +38,54 @@ def _make_policy_scheduler(train_scheduler: TrainScheduler) -> PolicyScheduler:
     ps.lora_name = None
     ps.ckpt_step = 7
     ps.update_weights_time = 0
-    ps._barrier_cleared = asyncio.Event()
+    ps.wait_for_ckpt_time = 0
+    ps.async_barrier_clear = asyncio.Event()
+    ps.async_barrier_clear.set()
     ps.max_async_level = 1
     ps.progress = Progress(step=9)
     train_scheduler.progress = Progress(step=9)
     return ps
 
 
-def test_drop_stale_groups_drops_old_requests():
+def test_drop_stale_groups():
     async def run() -> None:
         scheduler = _make_train_scheduler()
 
-        client = SimpleNamespace(api_base_url="http://test")
         stale_task = asyncio.create_task(asyncio.sleep(60))
         survivor_task = asyncio.create_task(asyncio.sleep(60))
 
-        stale_request = InflightRequest(task=stale_task, client=client, off_policy_steps=0)
-        survivor_request = InflightRequest(task=survivor_task, client=client, off_policy_steps=1)
+        stale_group = RolloutGroup(
+            env_name="test",
+            example={},
+            requires_group_scoring=False,
+            rollouts_per_example=1,
+        )
+        stale_group.off_policy_steps = 1  # at max_off_policy_steps
 
-        stale_group = InflightGroup(
-            example={},
+        survivor_group = RolloutGroup(
             env_name="test",
-            inflight_requests={stale_task: stale_request},
-        )
-        survivor_group = InflightGroup(
             example={},
-            env_name="test",
-            inflight_requests={survivor_task: survivor_request},
+            requires_group_scoring=False,
+            rollouts_per_example=1,
         )
-        scheduler._groups = {stale_group.group_id: stale_group, survivor_group.group_id: survivor_group}
-        scheduler._task_to_group = {stale_task: stale_group.group_id, survivor_task: survivor_group.group_id}
+        survivor_group.off_policy_steps = 0  # below threshold
+
+        scheduler._groups = {
+            stale_group.group_id: stale_group,
+            survivor_group.group_id: survivor_group,
+        }
+        scheduler._requests = {
+            stale_task: RolloutRequest(group_id=stale_group.group_id, cost=1),
+            survivor_task: RolloutRequest(group_id=survivor_group.group_id, cost=1),
+        }
         scheduler.limiter.concurrency.try_acquire(2)
 
-        scheduler.off_policy_steps = 1
-        await scheduler.drop_stale_groups()
+        scheduler.on_weights_updated()
 
         assert stale_group.group_id not in scheduler._groups
         assert survivor_group.group_id in scheduler._groups
+        assert stale_task not in scheduler._requests
+        assert survivor_task in scheduler._requests
         assert scheduler.cancelled_rollouts_count == 1
 
         for task in (stale_task, survivor_task):
@@ -92,18 +105,18 @@ def test_policy_scheduler_applies_latest_checkpoint():
         async def update_weights(weight_dir, lora_name=None, step=0) -> None:
             applied_steps.append(step)
 
-        ps.inference_pool = SimpleNamespace(
+        ps.inference_pool = MagicMock(
             update_weights=update_weights,
             update_model_name=MagicMock(),
         )
-        scheduler.drop_stale_groups = AsyncMock()
+        scheduler.on_weights_updated = MagicMock()
 
         with (
             patch("prime_rl.orchestrator.scheduler.get_latest_ckpt_step", return_value=8),
+            patch("prime_rl.orchestrator.scheduler.wait_for_path", new_callable=AsyncMock),
         ):
-            # Run the loop briefly — it should apply the update then sleep
             task = asyncio.create_task(ps.start())
-            await asyncio.sleep(0.1)
+            await asyncio.sleep(0.2)
             task.cancel()
             try:
                 await task
@@ -130,14 +143,15 @@ def test_stop_cancels_inflight_policy_update_task():
             finally:
                 cancelled.set()
 
-        ps.inference_pool = SimpleNamespace(
+        ps.inference_pool = MagicMock(
             update_weights=update_weights,
             update_model_name=MagicMock(),
         )
-        scheduler.drop_stale_groups = AsyncMock()
+        scheduler.on_weights_updated = MagicMock()
 
         with (
             patch("prime_rl.orchestrator.scheduler.get_latest_ckpt_step", return_value=8),
+            patch("prime_rl.orchestrator.scheduler.wait_for_path", new_callable=AsyncMock),
         ):
             policy_task = asyncio.create_task(ps.start())
             await started.wait()

--- a/tests/unit/orchestrator/test_scheduler.py
+++ b/tests/unit/orchestrator/test_scheduler.py
@@ -42,6 +42,7 @@ def _make_policy_scheduler(train_scheduler: TrainScheduler) -> PolicyScheduler:
     ps.async_barrier_clear = asyncio.Event()
     ps.async_barrier_clear.set()
     ps.max_async_level = 1
+    ps.strict_async_level = False
     ps.progress = Progress(step=9)
     train_scheduler.progress = Progress(step=9)
     return ps

--- a/tests/unit/orchestrator/test_scheduler.py
+++ b/tests/unit/orchestrator/test_scheduler.py
@@ -50,7 +50,7 @@ def _make_policy_scheduler(train_scheduler: TrainScheduler) -> PolicyScheduler:
     return ps
 
 
-def test_update_off_policy_does_not_increment_interleaved_on_policy_tasks():
+def test_drop_stale_groups_drops_old_requests():
     async def run() -> None:
         scheduler = _make_train_scheduler()
 
@@ -58,8 +58,8 @@ def test_update_off_policy_does_not_increment_interleaved_on_policy_tasks():
         stale_task = asyncio.create_task(asyncio.sleep(60))
         survivor_task = asyncio.create_task(asyncio.sleep(60))
 
-        stale_request = InflightRolloutRequest(task=stale_task, client=client, off_policy_steps=1)
-        survivor_request = InflightRolloutRequest(task=survivor_task, client=client, off_policy_steps=0)
+        stale_request = InflightRolloutRequest(task=stale_task, client=client, ckpt_step=0)
+        survivor_request = InflightRolloutRequest(task=survivor_task, client=client, ckpt_step=1)
 
         scheduler._groups = {
             1: InflightGroup(
@@ -76,11 +76,10 @@ def test_update_off_policy_does_not_increment_interleaved_on_policy_tasks():
         scheduler._task_to_group = {stale_task: 1, survivor_task: 2}
         scheduler.limiter.concurrency.try_acquire(2)
 
-        await scheduler._update_off_policy()
+        await scheduler.drop_stale_groups(current_ckpt_step=1)
 
         assert 1 not in scheduler._groups
         assert 2 in scheduler._groups
-        assert survivor_request.off_policy_steps == 1
         assert scheduler.cancelled_rollouts_count == 1
 
         for task in (stale_task, survivor_task):
@@ -108,7 +107,7 @@ def test_maybe_update_reuses_inflight_update_after_cancellation():
             update_weights=update_weights,
             update_model_name=MagicMock(),
         )
-        scheduler._update_off_policy = AsyncMock()
+        scheduler.drop_stale_groups = AsyncMock()
 
         with (
             patch("prime_rl.orchestrator.scheduler.get_latest_ckpt_step", return_value=8),
@@ -149,7 +148,7 @@ def test_stop_cancels_inflight_policy_update_task():
             update_weights=update_weights,
             update_model_name=MagicMock(),
         )
-        scheduler._update_off_policy = AsyncMock()
+        scheduler.drop_stale_groups = AsyncMock()
 
         with (
             patch("prime_rl.orchestrator.scheduler.get_latest_ckpt_step", return_value=8),

--- a/tests/unit/orchestrator/test_scheduler.py
+++ b/tests/unit/orchestrator/test_scheduler.py
@@ -3,14 +3,14 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from prime_rl.orchestrator.concurrency import ConcurrencyLimiter
-from prime_rl.orchestrator.scheduler import InflightRequest, Scheduler
+from prime_rl.orchestrator.concurrency import ConcurrencyLimiter, RolloutLimiter
+from prime_rl.orchestrator.scheduler import InflightRequest, TrainScheduler
 from prime_rl.utils.async_utils import safe_cancel
 
 
-def make_scheduler() -> Scheduler:
-    scheduler = Scheduler.__new__(Scheduler)
-    scheduler.limiter = ConcurrencyLimiter(128)
+def make_scheduler() -> TrainScheduler:
+    scheduler = TrainScheduler.__new__(TrainScheduler)
+    scheduler.limiter = RolloutLimiter(128)
     scheduler.max_async_level = 1
     scheduler.strict_async_level = False
     scheduler.step = 9
@@ -36,8 +36,8 @@ def make_scheduler() -> Scheduler:
 
 def test_update_off_policy_does_not_increment_interleaved_on_policy_tasks():
     async def run() -> None:
-        scheduler = Scheduler.__new__(Scheduler)
-        scheduler.limiter = ConcurrencyLimiter(128)
+        scheduler = TrainScheduler.__new__(TrainScheduler)
+        scheduler.limiter = RolloutLimiter(128)
         scheduler.max_off_policy_steps = 1
         scheduler.cancelled_rollouts_count = 0
         scheduler.logger = MagicMock()

--- a/tests/unit/orchestrator/test_scheduler.py
+++ b/tests/unit/orchestrator/test_scheduler.py
@@ -37,7 +37,6 @@ def _make_policy_scheduler(train_scheduler: TrainScheduler) -> PolicyScheduler:
     ps.output_dir = Path("/tmp/prime-rl-test")
     ps.max_async_level = 1
     ps.strict_async_level = False
-    ps.model_name = "test-model"
     ps.lora_name = None
     ps.ckpt_step = 7
     ps.update_weights_time = 0
@@ -59,11 +58,13 @@ def test_drop_stale_groups_drops_old_requests():
 
         scheduler._groups = {
             1: InflightGroup(
+                group_id=1,
                 example={},
                 env_name="test",
                 inflight_requests={stale_task: stale_request},
             ),
             2: InflightGroup(
+                group_id=2,
                 example={},
                 env_name="test",
                 inflight_requests={survivor_task: survivor_request},

--- a/tests/unit/orchestrator/test_scheduler.py
+++ b/tests/unit/orchestrator/test_scheduler.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from prime_rl.orchestrator.ckpt import Progress
 from prime_rl.orchestrator.concurrency import ConcurrencyLimiter, RolloutLimiter
-from prime_rl.orchestrator.scheduler import InflightGroup, InflightRolloutRequest, PolicyScheduler, TrainScheduler
+from prime_rl.orchestrator.scheduler import InflightGroup, InflightRequest, PolicyScheduler, TrainScheduler
 
 
 def _make_train_scheduler() -> TrainScheduler:
@@ -22,8 +22,7 @@ def _make_train_scheduler() -> TrainScheduler:
     scheduler._scheduling_task = None
     scheduler._completion_task = None
     scheduler.progress = Progress(step=0)
-    scheduler.policy_scheduler = None
-    scheduler.max_async_level = 1
+    scheduler.off_policy_steps = 0
     scheduler.model_name = "test-model"
     return scheduler
 
@@ -37,7 +36,9 @@ def _make_policy_scheduler(train_scheduler: TrainScheduler) -> PolicyScheduler:
     ps.lora_name = None
     ps.ckpt_step = 7
     ps.update_weights_time = 0
-    train_scheduler.policy_scheduler = ps
+    ps._barrier_cleared = asyncio.Event()
+    ps.max_async_level = 1
+    ps.progress = Progress(step=9)
     train_scheduler.progress = Progress(step=9)
     return ps
 
@@ -50,30 +51,28 @@ def test_drop_stale_groups_drops_old_requests():
         stale_task = asyncio.create_task(asyncio.sleep(60))
         survivor_task = asyncio.create_task(asyncio.sleep(60))
 
-        stale_request = InflightRolloutRequest(task=stale_task, client=client, ckpt_step=0)
-        survivor_request = InflightRolloutRequest(task=survivor_task, client=client, ckpt_step=1)
+        stale_request = InflightRequest(task=stale_task, client=client, off_policy_steps=0)
+        survivor_request = InflightRequest(task=survivor_task, client=client, off_policy_steps=1)
 
-        scheduler._groups = {
-            1: InflightGroup(
-                group_id=1,
-                example={},
-                env_name="test",
-                inflight_requests={stale_task: stale_request},
-            ),
-            2: InflightGroup(
-                group_id=2,
-                example={},
-                env_name="test",
-                inflight_requests={survivor_task: survivor_request},
-            ),
-        }
-        scheduler._task_to_group = {stale_task: 1, survivor_task: 2}
+        stale_group = InflightGroup(
+            example={},
+            env_name="test",
+            inflight_requests={stale_task: stale_request},
+        )
+        survivor_group = InflightGroup(
+            example={},
+            env_name="test",
+            inflight_requests={survivor_task: survivor_request},
+        )
+        scheduler._groups = {stale_group.group_id: stale_group, survivor_group.group_id: survivor_group}
+        scheduler._task_to_group = {stale_task: stale_group.group_id, survivor_task: survivor_group.group_id}
         scheduler.limiter.concurrency.try_acquire(2)
 
-        await scheduler.drop_stale_groups(current_ckpt_step=1)
+        scheduler.off_policy_steps = 1
+        await scheduler.drop_stale_groups()
 
-        assert 1 not in scheduler._groups
-        assert 2 in scheduler._groups
+        assert stale_group.group_id not in scheduler._groups
+        assert survivor_group.group_id in scheduler._groups
         assert scheduler.cancelled_rollouts_count == 1
 
         for task in (stale_task, survivor_task):

--- a/tests/unit/orchestrator/test_scheduler.py
+++ b/tests/unit/orchestrator/test_scheduler.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from prime_rl.orchestrator.concurrency import ConcurrencyLimiter, RolloutLimiter
-from prime_rl.orchestrator.scheduler import InflightRequest, TrainScheduler
+from prime_rl.orchestrator.scheduler import InflightGroup, InflightRolloutRequest, TrainScheduler
 from prime_rl.utils.async_utils import safe_cancel
 
 
@@ -23,68 +23,55 @@ def make_scheduler() -> TrainScheduler:
     scheduler.model_name = "test-model"
     scheduler.update_weights_time = 0
     scheduler.wait_for_ckpt_time = 0
-    scheduler.inflight_requests = {}
-    scheduler.groups = {}
+    scheduler._groups = {}
+    scheduler._task_to_group = {}
     scheduler.max_off_policy_steps = 1
     scheduler.cancelled_rollouts_count = 0
-    scheduler.policy_update_lock = asyncio.Lock()
-    scheduler.inflight_policy_update_task = None
-    scheduler.update_policy_task = None
+    scheduler._policy_update_lock = asyncio.Lock()
+    scheduler._inflight_policy_update_task = None
+    scheduler._policy_loop_task = None
+    scheduler._scheduling_task = None
+    scheduler._completion_task = None
     scheduler.enable_policy_updates = True
     return scheduler
 
 
 def test_update_off_policy_does_not_increment_interleaved_on_policy_tasks():
     async def run() -> None:
-        scheduler = TrainScheduler.__new__(TrainScheduler)
-        scheduler.limiter = RolloutLimiter(128)
-        scheduler.max_off_policy_steps = 1
-        scheduler.cancelled_rollouts_count = 0
-        scheduler.logger = MagicMock()
+        scheduler = make_scheduler()
 
         client = SimpleNamespace(api_base_url="http://test")
         stale_task = asyncio.create_task(asyncio.sleep(60))
         survivor_task = asyncio.create_task(asyncio.sleep(60))
-        interleaved_task = None
 
-        scheduler.inflight_requests = {
-            stale_task: InflightRequest(off_policy_steps=1, client_config=client, env_name="test", group_id=1),
-            survivor_task: InflightRequest(off_policy_steps=0, client_config=client, env_name="test", group_id=2),
+        stale_request = InflightRolloutRequest(task=stale_task, client=client, off_policy_steps=1)
+        survivor_request = InflightRolloutRequest(task=survivor_task, client=client, off_policy_steps=0)
+
+        scheduler._groups = {
+            1: InflightGroup(
+                example={},
+                env_name="test",
+                requests={stale_task: stale_request},
+            ),
+            2: InflightGroup(
+                example={},
+                env_name="test",
+                requests={survivor_task: survivor_request},
+            ),
         }
-
-        async def drop_group(group_id: int) -> int:
-            tasks_to_remove = [
-                task for task, info in list(scheduler.inflight_requests.items()) if info.group_id == group_id
-            ]
-            for task in tasks_to_remove:
-                scheduler.inflight_requests.pop(task, None)
-                task.cancel()
-
-            await asyncio.sleep(0)
-
-            nonlocal interleaved_task
-            if interleaved_task is None:
-                interleaved_task = asyncio.create_task(asyncio.sleep(60))
-                scheduler.inflight_requests[interleaved_task] = InflightRequest(
-                    off_policy_steps=0,
-                    client_config=client,
-                    env_name="test",
-                    group_id=3,
-                )
-            return len(tasks_to_remove)
-
-        scheduler.drop_group = drop_group
+        scheduler._task_to_group = {stale_task: 1, survivor_task: 2}
+        # Simulate slots acquired for each request
+        scheduler.limiter.concurrency.try_acquire(2)
 
         await scheduler._update_off_policy()
 
-        assert stale_task not in scheduler.inflight_requests
-        assert scheduler.inflight_requests[survivor_task].off_policy_steps == 1
-        assert interleaved_task is not None
-        assert scheduler.inflight_requests[interleaved_task].off_policy_steps == 0
+        assert 1 not in scheduler._groups
+        assert 2 in scheduler._groups
+        assert survivor_request.off_policy_steps == 1
         assert scheduler.cancelled_rollouts_count == 1
 
-        for task in (stale_task, survivor_task, interleaved_task):
-            if task is not None and not task.done():
+        for task in (stale_task, survivor_task):
+            if not task.done():
                 task.cancel()
         await asyncio.sleep(0)
 
@@ -113,11 +100,11 @@ def test_maybe_update_policy_reuses_inflight_update_after_cancellation():
             patch("prime_rl.orchestrator.scheduler.get_latest_ckpt_step", return_value=8),
             patch("prime_rl.orchestrator.scheduler.wait_for_path", new=AsyncMock()),
         ):
-            first = asyncio.create_task(scheduler.maybe_update_policy())
+            first = asyncio.create_task(scheduler._maybe_update_policy())
             await started.wait()
             await safe_cancel(first)
 
-            second = asyncio.create_task(scheduler.maybe_update_policy())
+            second = asyncio.create_task(scheduler._maybe_update_policy())
             await asyncio.sleep(0)
             assert applied_steps == [8]
 
@@ -153,13 +140,13 @@ def test_stop_cancels_inflight_policy_update_task():
             patch("prime_rl.orchestrator.scheduler.get_latest_ckpt_step", return_value=8),
             patch("prime_rl.orchestrator.scheduler.wait_for_path", new=AsyncMock()),
         ):
-            scheduler.update_policy_task = asyncio.create_task(scheduler.maybe_update_policy())
+            scheduler._policy_loop_task = asyncio.create_task(scheduler._maybe_update_policy())
             await started.wait()
             await asyncio.wait_for(scheduler.stop(), timeout=0.2)
 
         assert cancelled.is_set()
-        assert scheduler.update_policy_task is None
-        assert scheduler.inflight_policy_update_task is None
+        assert scheduler._policy_loop_task is None
+        assert scheduler._inflight_policy_update_task is None
 
     asyncio.run(run())
 

--- a/tests/unit/orchestrator/test_scheduler.py
+++ b/tests/unit/orchestrator/test_scheduler.py
@@ -3,12 +3,14 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from prime_rl.orchestrator.concurrency import ConcurrencyLimiter
 from prime_rl.orchestrator.scheduler import InflightRequest, Scheduler
 from prime_rl.utils.async_utils import safe_cancel
 
 
 def make_scheduler() -> Scheduler:
     scheduler = Scheduler.__new__(Scheduler)
+    scheduler.limiter = ConcurrencyLimiter(128)
     scheduler.max_async_level = 1
     scheduler.strict_async_level = False
     scheduler.step = 9
@@ -35,6 +37,7 @@ def make_scheduler() -> Scheduler:
 def test_update_off_policy_does_not_increment_interleaved_on_policy_tasks():
     async def run() -> None:
         scheduler = Scheduler.__new__(Scheduler)
+        scheduler.limiter = ConcurrencyLimiter(128)
         scheduler.max_off_policy_steps = 1
         scheduler.cancelled_rollouts_count = 0
         scheduler.logger = MagicMock()
@@ -157,5 +160,49 @@ def test_stop_cancels_inflight_policy_update_task():
         assert cancelled.is_set()
         assert scheduler.update_policy_task is None
         assert scheduler.inflight_policy_update_task is None
+
+    asyncio.run(run())
+
+
+def test_concurrency_limiter_basic():
+    limiter = ConcurrencyLimiter(10)
+    assert limiter.remaining == 10
+    assert limiter.used == 0
+
+    assert limiter.try_acquire(3)
+    assert limiter.remaining == 7
+    assert limiter.used == 3
+
+    assert not limiter.try_acquire(8)
+    assert limiter.remaining == 7
+
+    limiter.release(3)
+    assert limiter.remaining == 10
+    assert limiter.used == 0
+
+
+def test_concurrency_limiter_acquire_blocks():
+    async def run():
+        limiter = ConcurrencyLimiter(2)
+        limiter.try_acquire(2)
+        assert limiter.remaining == 0
+
+        acquired = False
+
+        async def waiter():
+            nonlocal acquired
+            await limiter.acquire(1)
+            acquired = True
+
+        task = asyncio.create_task(waiter())
+        await asyncio.sleep(0)
+        assert not acquired
+
+        limiter.release(1)
+        await asyncio.sleep(0)
+        assert acquired
+
+        limiter.release(1)
+        task.cancel()
 
     asyncio.run(run())

--- a/tests/unit/orchestrator/test_scheduler.py
+++ b/tests/unit/orchestrator/test_scheduler.py
@@ -22,7 +22,8 @@ def _make_train_scheduler() -> TrainScheduler:
     scheduler._scheduling_task = None
     scheduler._completion_task = None
     scheduler.progress = Progress(step=0)
-    scheduler.ckpt_step = 0
+    scheduler.policy_scheduler = None
+    scheduler.max_async_level = 1
     scheduler.model_name = "test-model"
     return scheduler
 
@@ -36,6 +37,8 @@ def _make_policy_scheduler(train_scheduler: TrainScheduler) -> PolicyScheduler:
     ps.lora_name = None
     ps.ckpt_step = 7
     ps.update_weights_time = 0
+    train_scheduler.policy_scheduler = ps
+    train_scheduler.progress = Progress(step=9)
     return ps
 
 

--- a/tests/unit/orchestrator/test_scheduler.py
+++ b/tests/unit/orchestrator/test_scheduler.py
@@ -25,8 +25,6 @@ def _make_train_scheduler() -> TrainScheduler:
     scheduler._policy_gate.set()
     scheduler._groups = {}
     scheduler._requests = {}
-    scheduler._retry_queue = __import__("collections").deque()
-    scheduler._schedule_queue = __import__("collections").deque()
     scheduler.max_off_policy_steps = 2
     scheduler.max_retries = 3
     scheduler.cancelled_rollouts_count = 0

--- a/tests/unit/orchestrator/test_scheduler.py
+++ b/tests/unit/orchestrator/test_scheduler.py
@@ -4,41 +4,55 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from prime_rl.orchestrator.concurrency import ConcurrencyLimiter, RolloutLimiter
-from prime_rl.orchestrator.scheduler import InflightGroup, InflightRolloutRequest, TrainScheduler
+from prime_rl.orchestrator.scheduler import InflightGroup, InflightRolloutRequest, PolicyScheduler, TrainScheduler
 from prime_rl.utils.async_utils import safe_cancel
 
 
-def make_scheduler() -> TrainScheduler:
+def _make_train_scheduler() -> TrainScheduler:
+    """Create a minimal TrainScheduler for testing (no __init__)."""
     scheduler = TrainScheduler.__new__(TrainScheduler)
     scheduler.limiter = RolloutLimiter(128)
-    scheduler.max_async_level = 1
-    scheduler.strict_async_level = False
-    scheduler.step = 9
-    scheduler.ckpt_step = 7
-    scheduler.config = SimpleNamespace(output_dir=Path("/tmp/prime-rl-test"))
     scheduler.logger = MagicMock()
     scheduler._scheduling_enabled = asyncio.Event()
     scheduler._scheduling_enabled.set()
-    scheduler.lora_name = None
-    scheduler.model_name = "test-model"
-    scheduler.update_weights_time = 0
-    scheduler.wait_for_ckpt_time = 0
     scheduler._groups = {}
     scheduler._task_to_group = {}
     scheduler.max_off_policy_steps = 1
     scheduler.cancelled_rollouts_count = 0
-    scheduler._policy_update_lock = asyncio.Lock()
-    scheduler._inflight_policy_update_task = None
-    scheduler._policy_loop_task = None
     scheduler._scheduling_task = None
     scheduler._completion_task = None
-    scheduler.enable_policy_updates = True
+    scheduler._policy_loop_task = None
+    scheduler.policy = None
+    scheduler.step = 0
+    scheduler.model_name = "test-model"
+    scheduler.enable_policy_updates = False
     return scheduler
+
+
+def _make_policy_scheduler(train_scheduler: TrainScheduler) -> PolicyScheduler:
+    """Create a minimal PolicyScheduler for testing."""
+    ps = PolicyScheduler.__new__(PolicyScheduler)
+    ps.logger = MagicMock()
+    ps._train = train_scheduler
+    ps.inference_pool = MagicMock()
+    ps.config = SimpleNamespace(output_dir=Path("/tmp/prime-rl-test"))
+    ps.max_async_level = 1
+    ps.strict_async_level = False
+    ps.model_name = "test-model"
+    ps.lora_name = None
+    ps.ckpt_step = 7
+    ps.update_weights_time = 0
+    ps.wait_for_ckpt_time = 0
+    ps._inflight_task = None
+    ps._lock = asyncio.Lock()
+    train_scheduler.policy = ps
+    train_scheduler.step = 9
+    return ps
 
 
 def test_update_off_policy_does_not_increment_interleaved_on_policy_tasks():
     async def run() -> None:
-        scheduler = make_scheduler()
+        scheduler = _make_train_scheduler()
 
         client = SimpleNamespace(api_base_url="http://test")
         stale_task = asyncio.create_task(asyncio.sleep(60))
@@ -60,7 +74,6 @@ def test_update_off_policy_does_not_increment_interleaved_on_policy_tasks():
             ),
         }
         scheduler._task_to_group = {stale_task: 1, survivor_task: 2}
-        # Simulate slots acquired for each request
         scheduler.limiter.concurrency.try_acquire(2)
 
         await scheduler._update_off_policy()
@@ -78,9 +91,10 @@ def test_update_off_policy_does_not_increment_interleaved_on_policy_tasks():
     asyncio.run(run())
 
 
-def test_maybe_update_policy_reuses_inflight_update_after_cancellation():
+def test_maybe_update_reuses_inflight_update_after_cancellation():
     async def run() -> None:
-        scheduler = make_scheduler()
+        scheduler = _make_train_scheduler()
+        ps = _make_policy_scheduler(scheduler)
         started = asyncio.Event()
         release = asyncio.Event()
         applied_steps: list[int] = []
@@ -90,7 +104,7 @@ def test_maybe_update_policy_reuses_inflight_update_after_cancellation():
             started.set()
             await release.wait()
 
-        scheduler.inference_pool = SimpleNamespace(
+        ps.inference_pool = SimpleNamespace(
             update_weights=update_weights,
             update_model_name=MagicMock(),
         )
@@ -100,11 +114,11 @@ def test_maybe_update_policy_reuses_inflight_update_after_cancellation():
             patch("prime_rl.orchestrator.scheduler.get_latest_ckpt_step", return_value=8),
             patch("prime_rl.orchestrator.scheduler.wait_for_path", new=AsyncMock()),
         ):
-            first = asyncio.create_task(scheduler._maybe_update_policy())
+            first = asyncio.create_task(ps.maybe_update(step=9))
             await started.wait()
             await safe_cancel(first)
 
-            second = asyncio.create_task(scheduler._maybe_update_policy())
+            second = asyncio.create_task(ps.maybe_update(step=9))
             await asyncio.sleep(0)
             assert applied_steps == [8]
 
@@ -112,14 +126,15 @@ def test_maybe_update_policy_reuses_inflight_update_after_cancellation():
             await second
 
         assert applied_steps == [8]
-        assert scheduler.ckpt_step == 8
+        assert ps.ckpt_step == 8
 
     asyncio.run(run())
 
 
 def test_stop_cancels_inflight_policy_update_task():
     async def run() -> None:
-        scheduler = make_scheduler()
+        scheduler = _make_train_scheduler()
+        ps = _make_policy_scheduler(scheduler)
         started = asyncio.Event()
         cancelled = asyncio.Event()
 
@@ -130,7 +145,7 @@ def test_stop_cancels_inflight_policy_update_task():
             finally:
                 cancelled.set()
 
-        scheduler.inference_pool = SimpleNamespace(
+        ps.inference_pool = SimpleNamespace(
             update_weights=update_weights,
             update_model_name=MagicMock(),
         )
@@ -140,13 +155,13 @@ def test_stop_cancels_inflight_policy_update_task():
             patch("prime_rl.orchestrator.scheduler.get_latest_ckpt_step", return_value=8),
             patch("prime_rl.orchestrator.scheduler.wait_for_path", new=AsyncMock()),
         ):
-            scheduler._policy_loop_task = asyncio.create_task(scheduler._maybe_update_policy())
+            scheduler._policy_loop_task = asyncio.create_task(ps.maybe_update(step=9))
             await started.wait()
             await asyncio.wait_for(scheduler.stop(), timeout=0.2)
 
         assert cancelled.is_set()
         assert scheduler._policy_loop_task is None
-        assert scheduler._inflight_policy_update_task is None
+        assert ps._inflight_task is None
 
     asyncio.run(run())
 

--- a/tests/unit/orchestrator/test_scheduler.py
+++ b/tests/unit/orchestrator/test_scheduler.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from prime_rl.orchestrator.ckpt import Progress
 from prime_rl.orchestrator.concurrency import ConcurrencyLimiter, RolloutLimiter
 from prime_rl.orchestrator.scheduler import InflightGroup, InflightRolloutRequest, PolicyScheduler, TrainScheduler
 
@@ -20,11 +21,9 @@ def _make_train_scheduler() -> TrainScheduler:
     scheduler.cancelled_rollouts_count = 0
     scheduler._scheduling_task = None
     scheduler._completion_task = None
-    scheduler._policy_loop_task = None
-    scheduler.policy = None
-    scheduler.step = 0
+    scheduler.progress = Progress(step=0)
+    scheduler.ckpt_step = 0
     scheduler.model_name = "test-model"
-    scheduler.enable_policy_updates = False
     return scheduler
 
 
@@ -34,6 +33,7 @@ def _make_policy_scheduler(train_scheduler: TrainScheduler) -> PolicyScheduler:
     ps.logger = MagicMock()
     ps.train_scheduler = train_scheduler
     ps.inference_pool = MagicMock()
+    ps.progress = Progress(step=9)
     ps.output_dir = Path("/tmp/prime-rl-test")
     ps.max_async_level = 1
     ps.strict_async_level = False
@@ -42,8 +42,7 @@ def _make_policy_scheduler(train_scheduler: TrainScheduler) -> PolicyScheduler:
     ps.ckpt_step = 7
     ps.update_weights_time = 0
     ps.wait_for_ckpt_time = 0
-    train_scheduler.policy = ps
-    train_scheduler.step = 9
+    train_scheduler.progress = ps.progress
     return ps
 
 

--- a/tests/unit/orchestrator/test_scheduler.py
+++ b/tests/unit/orchestrator/test_scheduler.py
@@ -98,7 +98,6 @@ def test_policy_scheduler_applies_latest_checkpoint():
 
         with (
             patch("prime_rl.orchestrator.scheduler.get_latest_ckpt_step", return_value=8),
-            patch("prime_rl.orchestrator.scheduler.wait_for_path", new=AsyncMock()),
         ):
             # Run the loop briefly — it should apply the update then sleep
             task = asyncio.create_task(ps.start())
@@ -137,7 +136,6 @@ def test_stop_cancels_inflight_policy_update_task():
 
         with (
             patch("prime_rl.orchestrator.scheduler.get_latest_ckpt_step", return_value=8),
-            patch("prime_rl.orchestrator.scheduler.wait_for_path", new=AsyncMock()),
         ):
             policy_task = asyncio.create_task(ps.start())
             await started.wait()


### PR DESCRIPTION
## Summary

> PR mainly used for brainstorming design tradeoffs. Closing and reopening as multiple smaller PRs

- Train and eval rollouts now share a single `ConcurrencyLimiter` enforcing `max_inflight_rollouts` across both. Previously eval fired all rollouts via `asyncio.gather` with no concurrency control, causing congestion on shared inference servers.
- `EvalScheduler` manages eval rollout scheduling with concurrency + rate limiting. Its `run()` method is an async generator yielding results per-env as each completes, enabling incremental metric logging.
- `EvalEnv` is now minimal (config, examples, `run_rollout`/`run_group`) — scheduling and metrics logic moved to `EvalScheduler` and `eval_utils.log_eval_metrics()`.
- Rate limiter (`tasks_per_minute`) is shared between train and eval schedulers.
- Existing `cancel_inflight_rollouts_on_eval` config controls overlapping (faster, mixed ckpts) vs non-overlapping (exact ckpt) eval mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)