### PR TITLE
feat: make vllm-router policy configurable

### DIFF
--- a/src/prime_rl/configs/inference.py
+++ b/src/prime_rl/configs/inference.py
@@ -140,6 +140,9 @@ class MultiNodeInferenceDeploymentConfig(BaseInferenceDeploymentConfig):
 
     router_port: Annotated[int, Field(description="Port for the vllm-router.")] = 8000
     backend_port: Annotated[int, Field(description="Port for vLLM backend instances.")] = 8100
+    router_policy: Annotated[
+        str, Field(description="Routing policy for the vllm-router (e.g. 'consistent_hash', 'round_robin').")
+    ] = "consistent_hash"
 
 
 class KVCacheOffloadConfig(BaseModel):
@@ -191,6 +194,9 @@ class DisaggregatedInferenceDeploymentConfig(BaseInferenceDeploymentConfig):
     router_port: Annotated[int, Field(description="Port for the vllm-router on each replica.")] = 8000
     prefill_port: Annotated[int, Field(description="Port for prefill vLLM instances.")] = 8100
     decode_port: Annotated[int, Field(description="Port for decode vLLM instances.")] = 8200
+    router_policy: Annotated[
+        str, Field(description="Routing policy for the vllm-router (e.g. 'consistent_hash', 'round_robin').")
+    ] = "consistent_hash"
 
     prefill_env_overrides: Annotated[
         dict[str, str],

--- a/src/prime_rl/entrypoints/inference.py
+++ b/src/prime_rl/entrypoints/inference.py
@@ -56,6 +56,7 @@ def write_slurm_script(config: InferenceConfig, config_path: Path, script_path: 
             prefill_port=config.deployment.prefill_port,
             decode_port=config.deployment.decode_port,
             router_port=config.deployment.router_port,
+            router_policy=config.deployment.router_policy,
             data_parallel_rpc_port=config.data_parallel_rpc_port,
             use_deep_gemm=config.use_deep_gemm,
             prefill_env_overrides=config.deployment.prefill_env_overrides,
@@ -72,6 +73,7 @@ def write_slurm_script(config: InferenceConfig, config_path: Path, script_path: 
         template_vars.update(
             router_port=config.deployment.router_port,
             backend_port=config.deployment.backend_port,
+            router_policy=config.deployment.router_policy,
         )
 
     script = template.render(**template_vars)

--- a/src/prime_rl/templates/inference.sbatch.j2
+++ b/src/prime_rl/templates/inference.sbatch.j2
@@ -212,7 +212,7 @@ srun bash -c '
         REPLICA_ROUTER_ARGS=$(echo "$ALL_ROUTER_ARGS" | cut -d"|" -f$((REPLICA_IDX + 1)))
 
         vllm-router \
-            --policy consistent_hash \
+            --policy {{ router_policy }} \
             --vllm-pd-disaggregation \
             $REPLICA_ROUTER_ARGS \
             --host 0.0.0.0 \
@@ -243,7 +243,7 @@ srun bash -c '
         echo "Starting vllm-router on $LOCAL_IP:$ROUTER_PORT" | tee $ROUTER_LOG
 
         vllm-router \
-            --policy consistent_hash \
+            --policy {{ router_policy }} \
             --worker-urls $ROUTER_ARGS \
             --host 0.0.0.0 \
             --port $ROUTER_PORT \


### PR DESCRIPTION
## Summary
- Add `router_policy` config field to `MultiNodeInferenceDeploymentConfig` and `DisaggregatedInferenceDeploymentConfig`
- Replace hardcoded `--policy consistent_hash` in the inference sbatch template with `--policy {{ router_policy }}`
- Default remains `consistent_hash` (no behavior change for existing deployments)

Useful for standalone inference deployments (e.g. user model servers) where `round_robin` is preferred over `consistent_hash`, since consistent hashing pins all requests to a single node when requests lack a differentiating header (like `X-Session-ID`).

### Usage

```toml
[deployment]
type = "multi_node"
num_nodes = 2
router_policy = "round_robin"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new optional config field and threads it into SLURM script generation; default remains `consistent_hash`, so existing deployments should behave the same unless explicitly configured.
> 
> **Overview**
> Makes the `vllm-router` routing policy configurable for SLURM-based inference deployments by adding `router_policy` to both `multi_node` and `disaggregated` deployment configs.
> 
> Threads `router_policy` through `write_slurm_script` into `inference.sbatch.j2`, replacing the hardcoded `--policy consistent_hash` with `--policy {{ router_policy }}` while keeping the default as `consistent_hash`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96f74a3f92bbaa5d2ddc2a583a68a911e4e24f05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->