### PR TITLE
feat: support file paths for chat_template config

### DIFF
--- a/src/prime_rl/configs/trainer.py
+++ b/src/prime_rl/configs/trainer.py
@@ -431,7 +431,7 @@ class TokenizerConfig(BaseConfig):
     chat_template: Annotated[
         str | None,
         Field(
-            description="The chat template to use for the tokenizer. If None, will use the tokenizer's default chat template."
+            description="The chat template to use for the tokenizer. Can be a Jinja2 template string or a path to a template file. If None, will use the tokenizer's default chat template."
         ),
     ] = None
 

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -361,10 +361,17 @@ def get_model(
 
 
 def setup_tokenizer(config: TokenizerConfig) -> PreTrainedTokenizer:
+    logger = get_logger()
     tokenizer = AutoTokenizer.from_pretrained(config.name, trust_remote_code=config.trust_remote_code)
     if config.chat_template is not None:
         path = Path(config.chat_template)
-        tokenizer.chat_template = path.read_text() if path.is_file() else config.chat_template
+        if path.is_file():
+            logger.info(f"Loading custom chat template from file: {path}")
+            tokenizer.chat_template = path.read_text()
+            logger.debug(f"Chat template content:\n{tokenizer.chat_template}")
+        else:
+            logger.info("Using inline custom chat template")
+            tokenizer.chat_template = config.chat_template
     tokenizer.pad_token_id = tokenizer.eos_token_id
 
     return tokenizer

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -363,7 +363,8 @@ def get_model(
 def setup_tokenizer(config: TokenizerConfig) -> PreTrainedTokenizer:
     tokenizer = AutoTokenizer.from_pretrained(config.name, trust_remote_code=config.trust_remote_code)
     if config.chat_template is not None:
-        tokenizer.chat_template = config.chat_template
+        path = Path(config.chat_template)
+        tokenizer.chat_template = path.read_text() if path.is_file() else config.chat_template
     tokenizer.pad_token_id = tokenizer.eos_token_id
 
     return tokenizer


### PR DESCRIPTION
## Summary

- `tokenizer.chat_template` now accepts a file path in addition to an inline Jinja2 string
- If the value points to an existing file, its contents are read and used as the template; otherwise it's treated as a raw template string (preserving existing behavior)

This makes it easier to manage complex chat templates — instead of embedding a multi-line Jinja2 string in your TOML config, you can just point to a `.jinja` file:

```toml
[tokenizer]
chat_template = "my_template.jinja"
```

## Verification

Tested on the SLURM cluster with Qwen3-0.6B:
- **File path**: SFT with a custom `.jinja` template file — confirmed the custom template was applied (EOS warnings from non-standard template)
- **Inline string**: existing behavior preserved
- **Default (None)**: no regression, clean training

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tokenizer initialization now performs filesystem checks and reads template content when `tokenizer.chat_template` matches an existing file, which can change behavior in environments where relative paths overlap with intended inline strings.
> 
> **Overview**
> `tokenizer.chat_template` can now be configured as either an inline Jinja2 template string or a path to a template file.
> 
> `setup_tokenizer` detects when the configured value is an existing file, reads the file contents into `tokenizer.chat_template`, and logs whether a file-based or inline template is used; config docs were updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86748f1c8b14e47596da9b0a7b6c94cbab1faa81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->