### PR TITLE
allow setting log level from env var

### DIFF
--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -53,7 +53,12 @@ from prime_rl.utils.validation import (
 class SharedLogConfig(BaseConfig):
     """Configures shared logging."""
 
-    level: Annotated[str | None, Field(description="The log level to use.")] = "info"
+    level: Annotated[
+        str | None,
+        Field(
+            description="The log level to use. When unset, the trainer and orchestrator log levels are used as-is (which themselves default to the PRIME_LOG_LEVEL env var if set, else 'info').",
+        ),
+    ] = None
 
     json_logging: Annotated[
         bool,

--- a/src/prime_rl/configs/shared.py
+++ b/src/prime_rl/configs/shared.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from typing import Annotated, Literal, TypeAlias
 
@@ -271,13 +272,19 @@ class LogConfig(BaseConfig):
 
     level: Annotated[
         str,
-        Field(description="Logging level for the process. Will determine the logging verbosity and format."),
-    ] = "info"
+        Field(
+            default_factory=lambda: os.environ.get("PRIME_LOG_LEVEL", "info"),
+            description="Logging level for the process. Will determine the logging verbosity and format. Defaults to the PRIME_LOG_LEVEL env var if set, else 'info'.",
+        ),
+    ]
 
     vf_level: Annotated[
         str,
-        Field(description="Logging level for the verifiers package. Will determine the logging verbosity and format."),
-    ] = "info"
+        Field(
+            default_factory=lambda: os.environ.get("PRIME_VF_LOG_LEVEL", "info"),
+            description="Logging level for the verifiers package. Will determine the logging verbosity and format. Defaults to the PRIME_VF_LOG_LEVEL env var if set, else 'info'.",
+        ),
+    ]
 
     json_logging: Annotated[
         bool,

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -100,7 +100,7 @@ def rl_local(config: RLConfig):
     assert config.deployment.type == "single_node"
 
     logger = setup_logger(
-        config.log.level or "info",
+        config.log.level or os.environ.get("PRIME_LOG_LEVEL", "info"),
         json_logging=config.log.json_logging,
     )
 
@@ -479,7 +479,9 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
 def rl_slurm(config: RLConfig):
     assert config.slurm is not None
 
-    logger = setup_logger(config.log.level or "info", json_logging=config.log.json_logging)
+    logger = setup_logger(
+        config.log.level or os.environ.get("PRIME_LOG_LEVEL", "info"), json_logging=config.log.json_logging
+    )
 
     config_dir = config.output_dir / "configs"
     log_dir = get_log_dir(config.output_dir)


### PR DESCRIPTION
This used to be possible but then we changed config libraries. It was very useful for debugging hosted training

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to configuration defaults and logger initialization, with no effect unless `PRIME_LOG_LEVEL`/`PRIME_VF_LOG_LEVEL` are set or shared log level is left unset.
> 
> **Overview**
> Restores environment-variable control of logging verbosity by defaulting `LogConfig.level` and `LogConfig.vf_level` to `PRIME_LOG_LEVEL` / `PRIME_VF_LOG_LEVEL` (falling back to `info`).
> 
> Changes top-level `SharedLogConfig.level` to default to `None` so it no longer forces `info`, and updates the RL entrypoints (`rl_local`, `rl_slurm`) to fall back to `PRIME_LOG_LEVEL` when no explicit log level is provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78240c62039637ae38f0e2c68810d20a1069d5bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->