### PR TITLE
fix: skip samples with unstable incremental tokenization

### DIFF
--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -15,6 +15,7 @@ from transformers.tokenization_utils import PreTrainedTokenizer
 from prime_rl.configs.sft import DataConfig, LossMaskConfig, SFTDataConfig
 from prime_rl.trainer.world import get_world
 from prime_rl.utils.chat_template import (
+    IncrementalTokenizationError,
     build_incremental_token_mask,
     deserialize_tool_calls,
     normalize_messages,
@@ -214,7 +215,7 @@ class SFTDataset(StatefulIterableDataset):
                 chat_template_kwargs=example.get("chat_template_kwargs", {}),
                 collapse_consecutive_tool_messages=True,
             )
-        except ValueError as e:
+        except IncrementalTokenizationError as e:
             self.logger.warning(f"Skipping example {example.get('__index', '')}: {e}")
             return None
 

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -205,14 +205,18 @@ class SFTDataset(StatefulIterableDataset):
                 case _:
                     raise ValueError(f"Invalid message role: {message['role']}")
 
-        input_ids, loss_mask = build_incremental_token_mask(
-            self.tokenizer,
-            messages,
-            role_to_mask=should_mask,
-            tools=tools,
-            chat_template_kwargs=example.get("chat_template_kwargs", {}),
-            collapse_consecutive_tool_messages=True,
-        )
+        try:
+            input_ids, loss_mask = build_incremental_token_mask(
+                self.tokenizer,
+                messages,
+                role_to_mask=should_mask,
+                tools=tools,
+                chat_template_kwargs=example.get("chat_template_kwargs", {}),
+                collapse_consecutive_tool_messages=True,
+            )
+        except ValueError as e:
+            self.logger.warning(f"Skipping example {example.get('__index', '')}: {e}")
+            return None
 
         # If EOS token is not found, manually append it
         if not self.tokenizer.eos_token_id in input_ids:

--- a/src/prime_rl/utils/chat_template.py
+++ b/src/prime_rl/utils/chat_template.py
@@ -130,7 +130,12 @@ def build_incremental_token_mask(
             processor=processor,
         )
 
-        assert prev_ids == cur_ids[:prev_len], "Mismatch in incremental tokenization with chat template."
+        if prev_ids != cur_ids[:prev_len]:
+            raise ValueError(
+                f"Mismatch in incremental tokenization with chat template at message {idx} (role={role}). "
+                "This usually means the chat template is not stable under incremental application. "
+                "The sample will be skipped."
+            )
 
         token_mask.extend([role_to_mask(message)] * (len(cur_ids) - prev_len))
         prev_ids = cur_ids

--- a/src/prime_rl/utils/chat_template.py
+++ b/src/prime_rl/utils/chat_template.py
@@ -4,6 +4,12 @@ from typing import Any, Callable
 from transformers.tokenization_utils import PreTrainedTokenizer
 
 
+class IncrementalTokenizationError(ValueError):
+    """Raised when incremental tokenization produces inconsistent token prefixes."""
+
+    pass
+
+
 def common_prefix_len(a: list[int], b: list[int]) -> int:
     max_len = min(len(a), len(b))
     for idx in range(max_len):
@@ -131,7 +137,7 @@ def build_incremental_token_mask(
         )
 
         if prev_ids != cur_ids[:prev_len]:
-            raise ValueError(
+            raise IncrementalTokenizationError(
                 f"Mismatch in incremental tokenization with chat template at message {idx} (role={role}). "
                 "This usually means the chat template is not stable under incremental application. "
                 "The sample will be skipped."


### PR DESCRIPTION
## Summary
- Replaces hard `assert` in `build_incremental_token_mask` with a `ValueError` that includes diagnostic info (message index, role)
- SFT data pipeline catches the error, logs a warning, and skips the sample instead of crashing the entire training run

## Context
Some chat templates (e.g. Nemotron) produce different token prefixes when applied incrementally vs all-at-once. This happens when `reasoning_content` is empty and the generation prompt (`<think>\n`) diverges from the actual template output (`<think></think>`). Previously this killed multi-node training runs with a SIGABRT.

## Test plan
- [x] Confirmed `r2e_gym` sample 357 from `PrimeIntellect/int5-mini-sft-combined` triggers the mismatch with Nemotron tokenizer
- [x] With this fix, the sample is skipped with a warning instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes SFT data preprocessing behavior by skipping certain samples instead of failing fast, which can silently reduce training data and alter loss/masking for affected datasets/templates.
> 
> **Overview**
> Prevents SFT training runs from crashing when a chat template is not stable under incremental application.
> 
> `build_incremental_token_mask` now raises a dedicated `IncrementalTokenizationError` (instead of an `assert`) with message index/role context when token prefixes diverge. The SFT dataset pipeline catches this error, logs a warning, and skips the problematic example rather than aborting the run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aae784d13a858a4088f3d27a519f341a7acdedc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->