### PR TITLE
feat: shared rollout limiter for train and eval concurrency

### DIFF
--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -901,12 +901,24 @@ class OrchestratorConfig(BaseConfig):
         ),
     ] = Path("outputs/run_default")
 
+    max_inflight_rollouts: Annotated[
+        int | None,
+        Field(
+            ge=1,
+            description=(
+                "Maximum number of concurrent train and eval rollouts. Required for token-based batching. "
+                "If batch_size is set and this is unset, defaults to batch_size * oversampling_factor "
+                "(or batch_size when oversampling_factor is unset)."
+            ),
+        ),
+    ] = None
+
     max_rollouts_per_minute: Annotated[
         int | None,
         Field(
             ge=1,
             validation_alias=AliasChoices("max_rollouts_per_minute", "tasks_per_minute"),
-            description="Rate limit for rollouts per minute. Recommended for sandbox-backed environments to prevent sandbox-not-ready errors during autoscaling. When set to None, no rate limiting is applied.",
+            description="Rate limit for train and eval rollouts per minute. Recommended if rollouts are attached to sensitive infrastructure (e.g. sandbox-backed environments to prevent load peaks). When set to None, no rate limiting is applied.",
         ),
     ] = None
 
@@ -933,18 +945,6 @@ class OrchestratorConfig(BaseConfig):
             description=(
                 "Rollout-mode batching only. Multiplier used to derive max_inflight_rollouts from batch_size "
                 "when max_inflight_rollouts is unset."
-            ),
-        ),
-    ] = None
-
-    max_inflight_rollouts: Annotated[
-        int | None,
-        Field(
-            ge=1,
-            description=(
-                "Maximum number of rollouts to keep in-flight. Required for token-based batching. "
-                "If batch_size is set and this is unset, defaults to batch_size * oversampling_factor "
-                "(or batch_size when oversampling_factor is unset)."
             ),
         ),
     ] = None

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -1091,8 +1091,17 @@ class OrchestratorConfig(BaseConfig):
                 oversampling_factor = self.oversampling_factor if self.oversampling_factor is not None else 1.0
                 self.max_inflight_rollouts = int(self.batch_size * oversampling_factor)
 
-        if self.max_inflight_rollouts is not None and self.max_inflight_rollouts < self.rollouts_per_example:
-            raise ValueError("max_inflight_rollouts must be at least the number of rollouts per example")
+        if self.max_inflight_rollouts is not None:
+            if self.max_inflight_rollouts < self.rollouts_per_example:
+                raise ValueError("max_inflight_rollouts must be at least rollouts_per_example (train)")
+            if self.eval is not None:
+                for env_cfg in self.eval.env:
+                    if env_cfg.rollouts_per_example > self.max_inflight_rollouts:
+                        raise ValueError(
+                            f"max_inflight_rollouts ({self.max_inflight_rollouts}) must be at least "
+                            f"rollouts_per_example ({env_cfg.rollouts_per_example}) of eval env '{env_cfg.name}', "
+                            f"otherwise group-scoring evals will deadlock"
+                        )
 
         # Resolve train env num_workers from max_inflight_rollouts
         for env_cfg in self.train.env:

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -901,11 +901,12 @@ class OrchestratorConfig(BaseConfig):
         ),
     ] = Path("outputs/run_default")
 
-    tasks_per_minute: Annotated[
+    max_rollouts_per_minute: Annotated[
         int | None,
         Field(
             ge=1,
-            description="Rate limit for tasks per environment worker, in tasks per minute. Recommended for sandbox-backed environments to prevent sandbox-not-ready errors during autoscaling. When set to None, no rate limiting is applied. Note: with multiple workers, the effective total rate equals workers × this value.",
+            validation_alias=AliasChoices("max_rollouts_per_minute", "tasks_per_minute"),
+            description="Rate limit for rollouts per minute. Recommended for sandbox-backed environments to prevent sandbox-not-ready errors during autoscaling. When set to None, no rate limiting is applied.",
         ),
     ] = None
 
@@ -1018,6 +1019,15 @@ class OrchestratorConfig(BaseConfig):
             description="Whether to use the token-in-token-out (TITO) client for training across all environments. WARNING: Only use this if your environment has a linear history and the chat template has the extension property (i.e. no tokens are ever removed or inserted by the chat template)"
         ),
     ] = True
+
+    @model_validator(mode="before")
+    def _deprecate_tasks_per_minute(cls, data: Any) -> Any:
+        if isinstance(data, dict) and "tasks_per_minute" in data and "max_rollouts_per_minute" not in data:
+            get_logger().warning(
+                "'tasks_per_minute' is deprecated, use 'max_rollouts_per_minute' instead. "
+                "Auto-translating for now, but this will be removed in a future release."
+            )
+        return data
 
     @model_validator(mode="before")
     @classmethod

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -144,7 +144,6 @@ class TrainSamplingConfig(BaseConfig):
         return args
 
     @model_validator(mode="before")
-    @classmethod
     def _deprecate_max_tokens(cls, data: Any) -> Any:
         if isinstance(data, dict) and "max_tokens" in data and "max_completion_tokens" not in data:
             get_logger().warning(
@@ -243,7 +242,6 @@ class EvalSamplingConfig(BaseConfig):
         return args
 
     @model_validator(mode="before")
-    @classmethod
     def _deprecate_max_tokens(cls, data: Any) -> Any:
         if isinstance(data, dict) and "max_tokens" in data and "max_completion_tokens" not in data:
             get_logger().warning(
@@ -1030,7 +1028,6 @@ class OrchestratorConfig(BaseConfig):
         return data
 
     @model_validator(mode="before")
-    @classmethod
     def _env_to_train(cls, data: Any) -> Any:
         """Allow [[env]] and [sampling] as shorthand for [train] with [[train.env]] and [train.sampling]."""
         if not isinstance(data, dict):

--- a/src/prime_rl/orchestrator/concurrency.py
+++ b/src/prime_rl/orchestrator/concurrency.py
@@ -101,10 +101,6 @@ class RolloutLimiter:
         else:
             get_logger().info("RolloutLimiter initialized (unlimited)")
 
-    @property
-    def remaining(self) -> float:
-        return self.concurrency.remaining
-
     async def acquire(self, count: int = 1) -> None:
         """Acquire rate tokens then concurrency slots (blocks until both are available)."""
         await self.rate.acquire(count)

--- a/src/prime_rl/orchestrator/concurrency.py
+++ b/src/prime_rl/orchestrator/concurrency.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import asyncio
+import math
+
+from aiolimiter import AsyncLimiter
+
+from prime_rl.utils.logger import get_logger
+
+
+class RateLimiter:
+    """Rate limiter that supports variable-cost acquire (N rollouts at once).
+
+    Wraps aiolimiter.AsyncLimiter, which rejects acquire(amount) when amount
+    exceeds max_rate. We loop instead so group-scoring envs work correctly.
+    If max_rate is None, acquiring is a no-op (unlimited).
+    """
+
+    def __init__(self, max_rate: float | None = None, time_period: float = 60):
+        self._limiter = AsyncLimiter(max_rate=max_rate, time_period=time_period) if max_rate is not None else None
+
+    @property
+    def unlimited(self) -> bool:
+        return self._limiter is None
+
+    async def acquire(self, count: int = 1) -> None:
+        if self._limiter is None:
+            return
+        for _ in range(count):
+            await self._limiter.acquire()
+
+
+class ConcurrencyLimiter:
+    """Slot-based concurrency limiter for rollouts.
+
+    Uses a simple counter with an asyncio.Event for wakeup. All calls must
+    happen on the same event loop (single-threaded asyncio), so no lock is needed.
+    If max_concurrency is None, all operations are no-ops (unlimited).
+    """
+
+    def __init__(self, max_concurrency: int | None = None):
+        self._max = max_concurrency
+        self._used = 0
+        self._available = asyncio.Event()
+        self._available.set()
+
+    @property
+    def unlimited(self) -> bool:
+        return self._max is None
+
+    @property
+    def max_concurrency(self) -> int | None:
+        return self._max
+
+    @property
+    def used(self) -> int:
+        return self._used
+
+    @property
+    def remaining(self) -> float:
+        if self._max is None:
+            return math.inf
+        return self._max - self._used
+
+    def try_acquire(self, count: int = 1) -> bool:
+        """Non-blocking acquire. Returns True if slots were reserved."""
+        if self._max is None:
+            return True
+        if self.remaining >= count:
+            self._used += count
+            return True
+        return False
+
+    def release(self, count: int = 1) -> None:
+        """Return *count* slots to the pool and wake any blocked acquirers."""
+        if self._max is None:
+            return
+        self._used -= count
+        assert self._used >= 0, f"ConcurrencyLimiter released too many slots (used={self._used})"
+        self._available.set()
+
+
+class RolloutLimiter:
+    """Combined rate + concurrency limiter for rollout scheduling.
+
+    Acquire gates on both limits (rate first, then concurrency).
+    Release only applies to concurrency (rate tokens are not returned).
+    """
+
+    def __init__(self, max_concurrent_rollouts: int | None = None, max_rollouts_per_minute: float | None = None):
+        self.concurrency = ConcurrencyLimiter(max_concurrent_rollouts)
+        self.rate = RateLimiter(max_rollouts_per_minute, time_period=60)
+
+        parts = []
+        if not self.concurrency.unlimited:
+            parts.append(f"max_concurrent_rollouts={max_concurrent_rollouts}")
+        if not self.rate.unlimited:
+            parts.append(f"max_rollouts_per_minute={max_rollouts_per_minute}")
+        if parts:
+            get_logger().info(f"RolloutLimiter initialized ({', '.join(parts)})")
+        else:
+            get_logger().info("RolloutLimiter initialized (unlimited)")
+
+    @property
+    def remaining(self) -> float:
+        return self.concurrency.remaining
+
+    async def acquire(self, count: int = 1) -> None:
+        """Acquire rate tokens then concurrency slots (non-blocking for concurrency via try_acquire is separate)."""
+        await self.rate.acquire(count)
+
+    def try_acquire(self, count: int = 1) -> bool:
+        """Non-blocking concurrency acquire. Returns True if slots were reserved."""
+        return self.concurrency.try_acquire(count)
+
+    def release(self, count: int = 1) -> None:
+        """Release concurrency slots."""
+        self.concurrency.release(count)

--- a/src/prime_rl/orchestrator/concurrency.py
+++ b/src/prime_rl/orchestrator/concurrency.py
@@ -62,6 +62,15 @@ class ConcurrencyLimiter:
             return math.inf
         return self._max - self._used
 
+    async def acquire(self, count: int = 1) -> None:
+        """Block until *count* concurrency slots are available, then reserve them."""
+        if self._max is None:
+            return
+        while self.remaining < count:
+            self._available.clear()
+            await self._available.wait()
+        self._used += count
+
     def try_acquire(self, count: int = 1) -> bool:
         """Non-blocking acquire. Returns True if slots were reserved."""
         if self._max is None:
@@ -106,8 +115,9 @@ class RolloutLimiter:
         return self.concurrency.remaining
 
     async def acquire(self, count: int = 1) -> None:
-        """Acquire rate tokens then concurrency slots (non-blocking for concurrency via try_acquire is separate)."""
+        """Acquire rate tokens then concurrency slots (blocks until both are available)."""
         await self.rate.acquire(count)
+        await self.concurrency.acquire(count)
 
     def try_acquire(self, count: int = 1) -> bool:
         """Non-blocking concurrency acquire. Returns True if slots were reserved."""

--- a/src/prime_rl/orchestrator/concurrency.py
+++ b/src/prime_rl/orchestrator/concurrency.py
@@ -71,15 +71,6 @@ class ConcurrencyLimiter:
             await self._available.wait()
         self._used += count
 
-    def try_acquire(self, count: int = 1) -> bool:
-        """Non-blocking acquire. Returns True if slots were reserved."""
-        if self._max is None:
-            return True
-        if self.remaining >= count:
-            self._used += count
-            return True
-        return False
-
     def release(self, count: int = 1) -> None:
         """Return *count* slots to the pool and wake any blocked acquirers."""
         if self._max is None:
@@ -118,10 +109,6 @@ class RolloutLimiter:
         """Acquire rate tokens then concurrency slots (blocks until both are available)."""
         await self.rate.acquire(count)
         await self.concurrency.acquire(count)
-
-    def try_acquire(self, count: int = 1) -> bool:
-        """Non-blocking concurrency acquire. Returns True if slots were reserved."""
-        return self.concurrency.try_acquire(count)
 
     def release(self, count: int = 1) -> None:
         """Release concurrency slots."""

--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -174,7 +174,7 @@ class EvalEnv(Env):
         get_client: Callable[[], Awaitable[vf.ClientConfig]],
         ckpt_step: int,
         step: int,
-        limiter: RolloutLimiter | None = None,
+        limiter: RolloutLimiter,
     ) -> list[vf.RolloutOutput]:
         num_examples = len(self.examples)
         rollouts_per_example = self.config.rollouts_per_example
@@ -188,8 +188,7 @@ class EvalEnv(Env):
 
             async def run_with_progress(example: dict) -> list[vf.RolloutOutput] | None:
                 """Run rollouts_per_example rollouts as a scored group for one example."""
-                if limiter is not None:
-                    await limiter.acquire(cost)
+                await limiter.acquire(cost)
                 try:
                     client = await get_client()
                     outputs = await self.run_group(
@@ -205,8 +204,7 @@ class EvalEnv(Env):
                     pbar.update(rollouts_per_example)
                     return None
                 finally:
-                    if limiter is not None:
-                        limiter.release(cost)
+                    limiter.release(cost)
 
             coros = [run_with_progress(example) for example in self.examples]
 
@@ -214,8 +212,7 @@ class EvalEnv(Env):
 
             async def run_with_progress(example: dict) -> list[vf.RolloutOutput] | None:
                 """Run a single rollout for one example."""
-                if limiter is not None:
-                    await limiter.acquire(1)
+                await limiter.acquire(1)
                 try:
                     client = await get_client()
                     output = await self.run_rollout(client=client, example=example, model_name=model_name)
@@ -226,8 +223,7 @@ class EvalEnv(Env):
                     pbar.update(1)
                     return None
                 finally:
-                    if limiter is not None:
-                        limiter.release(1)
+                    limiter.release(1)
 
             coros = [run_with_progress(example) for example in self.examples for _ in range(rollouts_per_example)]
 

--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -7,12 +7,15 @@ import time
 from collections.abc import Awaitable, Callable, Iterator, Sequence
 from multiprocessing.process import BaseProcess
 from pathlib import Path
-from typing import Generic, TypeVar
+from typing import TYPE_CHECKING, Generic, TypeVar
 
 import pandas as pd
 import verifiers as vf
 from verifiers.serve import ZMQEnvClient, ZMQEnvServer
 from verifiers.utils.serve_utils import get_free_port
+
+if TYPE_CHECKING:
+    from prime_rl.orchestrator.concurrency import RolloutLimiter
 
 from prime_rl.configs.orchestrator import EnvConfig, EvalEnvConfig, TrainEnvConfig
 from prime_rl.orchestrator.eval_utils import compute_pass_at_k
@@ -171,6 +174,7 @@ class EvalEnv(Env):
         get_client: Callable[[], Awaitable[vf.ClientConfig]],
         ckpt_step: int,
         step: int,
+        limiter: RolloutLimiter | None = None,
     ) -> list[vf.RolloutOutput]:
         num_examples = len(self.examples)
         rollouts_per_example = self.config.rollouts_per_example
@@ -180,9 +184,13 @@ class EvalEnv(Env):
         eval_start = time.perf_counter()
 
         if self.requires_group_scoring:
+            cost = rollouts_per_example
 
             async def run_with_progress(example: dict) -> list[vf.RolloutOutput] | None:
                 """Run rollouts_per_example rollouts as a scored group for one example."""
+                if limiter is not None:
+                    await limiter.acquire(cost)
+                    limiter.try_acquire(cost)
                 try:
                     client = await get_client()
                     outputs = await self.run_group(
@@ -197,6 +205,9 @@ class EvalEnv(Env):
                     get_logger().warning(f"Group failed: {e}")
                     pbar.update(rollouts_per_example)
                     return None
+                finally:
+                    if limiter is not None:
+                        limiter.release(cost)
 
             coros = [run_with_progress(example) for example in self.examples]
 
@@ -204,6 +215,9 @@ class EvalEnv(Env):
 
             async def run_with_progress(example: dict) -> list[vf.RolloutOutput] | None:
                 """Run a single rollout for one example."""
+                if limiter is not None:
+                    await limiter.acquire(1)
+                    limiter.try_acquire(1)
                 try:
                     client = await get_client()
                     output = await self.run_rollout(client=client, example=example, model_name=model_name)
@@ -213,6 +227,9 @@ class EvalEnv(Env):
                     get_logger().warning(f"Rollout failed: {e}")
                     pbar.update(1)
                     return None
+                finally:
+                    if limiter is not None:
+                        limiter.release(1)
 
             coros = [run_with_progress(example) for example in self.examples for _ in range(rollouts_per_example)]
 

--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -190,7 +190,6 @@ class EvalEnv(Env):
                 """Run rollouts_per_example rollouts as a scored group for one example."""
                 if limiter is not None:
                     await limiter.acquire(cost)
-                    limiter.try_acquire(cost)
                 try:
                     client = await get_client()
                     outputs = await self.run_group(
@@ -217,7 +216,6 @@ class EvalEnv(Env):
                 """Run a single rollout for one example."""
                 if limiter is not None:
                     await limiter.acquire(1)
-                    limiter.try_acquire(1)
                 try:
                     client = await get_client()
                     output = await self.run_rollout(client=client, example=example, model_name=model_name)

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -716,6 +716,7 @@ async def orchestrate(config: OrchestratorConfig):
                     get_client=inference_pool.get_eval_client,
                     ckpt_step=ckpt_step,
                     step=progress.step,
+                    limiter=rollout_limiter,
                 )
                 for eval_env in eval_envs
             ]

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -708,6 +708,7 @@ async def orchestrate(config: OrchestratorConfig):
             heart.beat()
 
     if config.eval and eval_envs is not None:
+        await scheduler.cancel_inflight_rollouts()
         logger.info("Running final evals")
         eval_results = await asyncio.gather(
             *[

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -35,6 +35,7 @@ from transformers import AutoProcessor, AutoTokenizer
 from prime_rl.configs.orchestrator import OrchestratorConfig
 from prime_rl.orchestrator.buffer import Buffer
 from prime_rl.orchestrator.ckpt import Progress, setup_ckpt_manager
+from prime_rl.orchestrator.concurrency import RolloutLimiter
 from prime_rl.orchestrator.envs import EvalEnv, EvalEnvs, TrainEnvs
 from prime_rl.orchestrator.filters import apply_filters, setup_filters
 from prime_rl.orchestrator.scheduler import Scheduler
@@ -222,15 +223,19 @@ async def orchestrate(config: OrchestratorConfig):
         else:
             checkpoint_step = config.ckpt.resume_step
 
+    rollout_limiter = RolloutLimiter(
+        max_concurrent_rollouts=config.max_inflight_rollouts,
+        max_rollouts_per_minute=config.max_rollouts_per_minute,
+    )
+
     scheduler = Scheduler(
         train_envs=train_envs,
         buffer=buffer,
         inference_pool=inference_pool,
-        max_inflight_rollouts=config.max_inflight_rollouts,
+        limiter=rollout_limiter,
         max_async_level=config.max_async_level,
         max_off_policy_steps=config.max_off_policy_steps,
         strict_async_level=config.strict_async_level,
-        tasks_per_minute=config.tasks_per_minute,
         enable_policy_updates=enable_policy_updates,
         lora_name=config.model.lora.name if config.model.lora else None,
         config=config,
@@ -378,6 +383,7 @@ async def orchestrate(config: OrchestratorConfig):
                         get_client=inference_pool.get_eval_client,
                         ckpt_step=ckpt_step,
                         step=progress.step,
+                        limiter=rollout_limiter,
                     )
                     for eval_env in envs_to_eval
                 ]

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -135,13 +135,11 @@ class Scheduler:
 
     async def cancel_inflight_rollouts(self):
         """Cancel all in-flight rollout requests."""
-        await safe_cancel_all(list(self.inflight_requests))
-        # Compute count after cancellation — other coroutines (e.g. drop_group) may have
-        # popped and released some tasks during the yield in safe_cancel_all.
         count = sum(info.rollout_count for info in self.inflight_requests.values())
+        await safe_cancel_all(list(self.inflight_requests))
         self.inflight_requests.clear()
         self.groups.clear()
-        self.limiter.release(count)
+        # Limiter slots are released by done callbacks on the cancelled tasks.
         self.cancelled_rollouts_count += count
 
     @staticmethod
@@ -173,7 +171,7 @@ class Scheduler:
             rollout_count += info.rollout_count
         self.groups.pop(group_id, None)
         await safe_cancel_all(tasks_to_cancel)
-        self.limiter.release(rollout_count)
+        # Limiter slots are released by done callbacks on the cancelled tasks.
         return rollout_count
 
     async def schedule_rollout(self, group_id: int):
@@ -231,6 +229,9 @@ class Scheduler:
             group_id=group_id,
             rollout_count=rollout_count,
         )
+        # Release limiter slots when the task finishes (success, error, or cancellation)
+        # so that eval coroutines can acquire slots even when generate_batch is not running.
+        task.add_done_callback(lambda _, count=rollout_count: self.limiter.release(count))
 
     @property
     def inflight_rollout_count(self) -> int:
@@ -424,7 +425,6 @@ class Scheduler:
                 if rollout_info is None:
                     continue
 
-                self.limiter.release(rollout_info.rollout_count)
                 group_id = rollout_info.group_id
                 env_name = rollout_info.env_name
 

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -6,10 +6,10 @@ from collections import Counter, defaultdict
 from dataclasses import dataclass, field
 
 import verifiers as vf
-from aiolimiter import AsyncLimiter
 
 from prime_rl.configs.orchestrator import OrchestratorConfig
 from prime_rl.orchestrator.buffer import Buffer
+from prime_rl.orchestrator.concurrency import RolloutLimiter
 from prime_rl.orchestrator.envs import TrainEnvs
 from prime_rl.orchestrator.vf_utils import get_seq_len
 from prime_rl.utils.async_utils import safe_cancel, safe_cancel_all
@@ -61,26 +61,21 @@ class Scheduler:
         inference_pool: InferencePool,
         buffer: Buffer,
         config: OrchestratorConfig,
-        max_inflight_rollouts: int,
+        limiter: RolloutLimiter,
         max_async_level: int,
         max_off_policy_steps: int,
         strict_async_level: bool,
-        tasks_per_minute: int | None,
         enable_policy_updates: bool = True,
         lora_name: str | None = None,
     ):
         self.logger = get_logger()
-        if tasks_per_minute is not None:
-            self.rate_limiter = AsyncLimiter(max_rate=tasks_per_minute, time_period=60)
-        else:
-            self.rate_limiter = None
+        self.limiter = limiter
         self.train_envs = train_envs
         self.buffer = buffer
         self.config = config
         self.batch_size = config.batch_size
         self.token_batch_size = config.token_batch_size
         self.rollouts_per_example = config.rollouts_per_example
-        self.max_inflight_rollouts = max_inflight_rollouts
         self.max_async_level = max_async_level
         self.max_off_policy_steps = max_off_policy_steps
         self.strict_async_level = strict_async_level
@@ -144,6 +139,7 @@ class Scheduler:
         await safe_cancel_all(list(self.inflight_requests))
         self.inflight_requests.clear()
         self.groups.clear()
+        self.limiter.release(count)
         self.cancelled_rollouts_count += count
 
     @staticmethod
@@ -175,14 +171,28 @@ class Scheduler:
             rollout_count += info.rollout_count
         self.groups.pop(group_id, None)
         await safe_cancel_all(tasks_to_cancel)
+        self.limiter.release(rollout_count)
         return rollout_count
 
     async def schedule_rollout(self, group_id: int):
         """Asynchronously schedules a rollout request (or a group request for group-scoring envs)."""
-        if self.rate_limiter:
-            await self.rate_limiter.acquire()
         group = self.groups.get(group_id)
         if group is None or group.rollouts_to_schedule <= 0:
+            return
+
+        env_name = group.example["env_name"]
+        env = self.train_envs.get(env_name)
+        cost = group.rollouts_to_schedule if env.requires_group_scoring else 1
+
+        # Rate limit then reserve concurrency slots
+        await self.limiter.acquire(cost)
+        if not self.limiter.try_acquire(cost):
+            return
+
+        # Re-check group validity after potentially yielding during rate limit
+        group = self.groups.get(group_id)
+        if group is None or group.rollouts_to_schedule <= 0:
+            self.limiter.release(cost)
             return
 
         if group.pinned_client is not None:
@@ -190,11 +200,9 @@ class Scheduler:
         else:
             client_config = await self._select_least_loaded_client()
             if group_id not in self.groups:
+                self.limiter.release(cost)
                 return
             group.pinned_client = client_config
-
-        env_name = group.example["env_name"]
-        env = self.train_envs.get(env_name)
 
         if env.requires_group_scoring:
             rollout_count = group.rollouts_to_schedule
@@ -235,9 +243,9 @@ class Scheduler:
         return self.inflight_rollout_count + pending
 
     async def _schedule_next_request(self) -> bool:
-        remaining_capacity = self.max_inflight_rollouts - self.inflight_rollout_count
+        remaining = self.limiter.remaining
 
-        if remaining_capacity <= 0:
+        if remaining <= 0:
             return False
 
         for group_id, group in self.groups.items():
@@ -245,11 +253,11 @@ class Scheduler:
                 continue
             env = self.train_envs.get(group.example["env_name"])
             cost = group.rollouts_to_schedule if env.requires_group_scoring else 1
-            if cost <= remaining_capacity:
+            if cost <= remaining:
                 await self.schedule_rollout(group_id=group_id)
                 return True
 
-        if remaining_capacity < self.rollouts_per_example:
+        if remaining < self.rollouts_per_example:
             return False
 
         example = self.buffer.sample_examples(n=1)[0]
@@ -412,6 +420,7 @@ class Scheduler:
                 if rollout_info is None:
                     continue
 
+                self.limiter.release(rollout_info.rollout_count)
                 group_id = rollout_info.group_id
                 env_name = rollout_info.env_name
 
@@ -521,6 +530,8 @@ class Scheduler:
             "scheduler/async_level": self.async_level,
             "scheduler/inflight_rollouts": self.inflight_rollout_count,
             "scheduler/inflight_samples": self.inflight_sample_count,
+            "scheduler/limiter_used": self.limiter.concurrency.used,
+            "scheduler/limiter_remaining": self.limiter.remaining,
             "scheduler/cancelled_rollouts": self.cancelled_rollouts_count,
             "empty_rollouts/all": sum(self.empty_rollouts_by_env.values()) / max(total_rollouts, 1),
             "errored_rollouts/all": sum(self.errored_rollouts_by_env.values()) / max(total_rollouts, 1),

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -184,12 +184,7 @@ class Scheduler:
         env = self.train_envs.get(env_name)
         cost = group.rollouts_to_schedule if env.requires_group_scoring else 1
 
-        # Rate limit (blocking), then reserve concurrency slots (non-blocking).
-        # Concurrency is non-blocking here because _fill_inflight_requests must not stall;
-        # the caller already checked remaining slots before invoking this method.
-        await self.limiter.rate.acquire(cost)
-        if not self.limiter.try_acquire(cost):
-            return
+        await self.limiter.acquire(cost)
 
         # Re-check group validity after potentially yielding during rate limit
         group = self.groups.get(group_id)
@@ -537,8 +532,6 @@ class Scheduler:
             "scheduler/async_level": self.async_level,
             "scheduler/inflight_rollouts": self.inflight_rollout_count,
             "scheduler/inflight_samples": self.inflight_sample_count,
-            "scheduler/limiter_used": self.limiter.concurrency.used,
-            "scheduler/limiter_remaining": self.limiter.remaining,
             "scheduler/cancelled_rollouts": self.cancelled_rollouts_count,
             "empty_rollouts/all": sum(self.empty_rollouts_by_env.values()) / max(total_rollouts, 1),
             "errored_rollouts/all": sum(self.errored_rollouts_by_env.values()) / max(total_rollouts, 1),

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -135,8 +135,10 @@ class Scheduler:
 
     async def cancel_inflight_rollouts(self):
         """Cancel all in-flight rollout requests."""
-        count = sum(info.rollout_count for info in self.inflight_requests.values())
         await safe_cancel_all(list(self.inflight_requests))
+        # Compute count after cancellation — other coroutines (e.g. drop_group) may have
+        # popped and released some tasks during the yield in safe_cancel_all.
+        count = sum(info.rollout_count for info in self.inflight_requests.values())
         self.inflight_requests.clear()
         self.groups.clear()
         self.limiter.release(count)

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -240,7 +240,7 @@ class Scheduler:
         return self.inflight_rollout_count + pending
 
     async def _schedule_next_request(self) -> bool:
-        remaining = self.limiter.remaining
+        remaining = self.limiter.concurrency.remaining
 
         if remaining <= 0:
             return False

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -184,8 +184,10 @@ class Scheduler:
         env = self.train_envs.get(env_name)
         cost = group.rollouts_to_schedule if env.requires_group_scoring else 1
 
-        # Rate limit then reserve concurrency slots
-        await self.limiter.acquire(cost)
+        # Rate limit (blocking), then reserve concurrency slots (non-blocking).
+        # Concurrency is non-blocking here because _fill_inflight_requests must not stall;
+        # the caller already checked remaining slots before invoking this method.
+        await self.limiter.rate.acquire(cost)
         if not self.limiter.try_acquire(cost):
             return
 
@@ -405,6 +407,11 @@ class Scheduler:
         while batch_progress < self.batch_target:
             await self._fill_inflight_requests()
             inflight_tasks = list(self.inflight_requests.keys())
+
+            if not inflight_tasks:
+                # All slots are consumed but no tasks are tracked — wait briefly for slots to free up
+                await asyncio.sleep(0.1)
+                continue
 
             finished_tasks, _ = await asyncio.wait(
                 inflight_tasks,

--- a/tests/unit/orchestrator/test_scheduler.py
+++ b/tests/unit/orchestrator/test_scheduler.py
@@ -3,12 +3,14 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from prime_rl.orchestrator.concurrency import RolloutLimiter
 from prime_rl.orchestrator.scheduler import InflightRequest, Scheduler
 from prime_rl.utils.async_utils import safe_cancel
 
 
 def make_scheduler() -> Scheduler:
     scheduler = Scheduler.__new__(Scheduler)
+    scheduler.limiter = RolloutLimiter()
     scheduler.max_async_level = 1
     scheduler.strict_async_level = False
     scheduler.step = 9


### PR DESCRIPTION
## Summary

- Both train and eval rollouts now share a single `RolloutLimiter` that enforces `max_inflight_rollouts` and `max_rollouts_per_minute` across both workloads. Previously eval fired all rollouts concurrently with no limit, which could overwhelm the inference server.
- Renames `tasks_per_minute` → `max_rollouts_per_minute` (backward-compat alias kept via `validation_alias` + deprecation warning).
- New `concurrency.py` module with `RateLimiter`, `ConcurrencyLimiter`, and `RolloutLimiter` classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches rollout scheduling/concurrency and introduces new limiting behavior across train+eval, which could impact throughput or cause stalls/deadlocks if misconfigured (especially with group-scoring envs). Backward-compat config aliasing reduces migration risk but needs coverage in real workloads.
> 
> **Overview**
> Introduces a shared `RolloutLimiter` (rate + concurrency) used by both training and evaluation rollouts so eval no longer fires unbounded concurrent requests and can be throttled alongside training.
> 
> Renames the config knob `tasks_per_minute` to `max_rollouts_per_minute` (with alias + deprecation warning), adds stricter validation to ensure `max_inflight_rollouts` can satisfy both train and eval `rollouts_per_example` for group-scoring envs, and updates the scheduler to acquire/release limiter slots per rollout/group with a small wait path when no tracked tasks remain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6239098e174679da4df0dcc5acca2bb88b1a2d9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->