### PR TITLE
feat: shared tokenizer config and chat_template support for RL

### DIFF
--- a/src/prime_rl/configs/inference.py
+++ b/src/prime_rl/configs/inference.py
@@ -489,6 +489,7 @@ class InferenceConfig(BaseConfig):
             "model.max_model_len": "max_model_len",
             "model.enforce_eager": "enforce_eager",
             "model.trust_remote_code": "trust_remote_code",
+            "model.chat_template": "chat_template",
             "model.tool_call_parser": "tool_call_parser",
             "model.reasoning_parser": "reasoning_parser",
             "model.rope_scaling": "rope_scaling",
@@ -518,6 +519,10 @@ class InferenceConfig(BaseConfig):
 
         # Set `logprobs_mode` to `processed_logprobs` by default
         rsetattr(namespace, "logprobs_mode", "processed_logprobs")
+
+        # Remove chat_template if not set (vLLM doesn't accept None)
+        if namespace.chat_template is None:
+            delattr(namespace, "chat_template")
 
         # Remove reasoning_parser if not set (vLLM doesn't accept None)
         if namespace.reasoning_parser is None:

--- a/src/prime_rl/configs/inference.py
+++ b/src/prime_rl/configs/inference.py
@@ -71,6 +71,14 @@ class ModelConfig(BaseModelConfig):
         ),
     ] = False
 
+    chat_template: Annotated[
+        str | None,
+        Field(
+            description="Chat template to use. Can be a Jinja2 template string or a path to a template file. "
+            "Passed to vLLM as `--chat-template`. If None, uses the model's default.",
+        ),
+    ] = None
+
     tool_call_parser: Annotated[
         str | None,
         Field(
@@ -248,14 +256,6 @@ class InferenceConfig(BaseConfig):
 
     # The parallel configuration
     parallel: ParallelConfig = ParallelConfig()
-
-    chat_template: Annotated[
-        str | None,
-        Field(
-            description="Chat template to use. Can be a Jinja2 template string or a path to a template file. "
-            "Passed to vLLM as `--chat-template`. If None, uses the model's default.",
-        ),
-    ] = None
 
     enable_lora: Annotated[
         bool,
@@ -497,12 +497,12 @@ class InferenceConfig(BaseConfig):
             "model.max_model_len": "max_model_len",
             "model.enforce_eager": "enforce_eager",
             "model.trust_remote_code": "trust_remote_code",
+            "model.chat_template": "chat_template",
             "model.tool_call_parser": "tool_call_parser",
             "model.reasoning_parser": "reasoning_parser",
             "model.rope_scaling": "rope_scaling",
             "parallel.tp": "tensor_parallel_size",
             "parallel.dp": "data_parallel_size",
-            "chat_template": "chat_template",
             "data_parallel_size_local": "data_parallel_size_local",
             "data_parallel_rpc_port": "data_parallel_rpc_port",
             "enable_lora": "enable_lora",

--- a/src/prime_rl/configs/inference.py
+++ b/src/prime_rl/configs/inference.py
@@ -249,6 +249,14 @@ class InferenceConfig(BaseConfig):
     # The parallel configuration
     parallel: ParallelConfig = ParallelConfig()
 
+    chat_template: Annotated[
+        str | None,
+        Field(
+            description="Chat template to use. Can be a Jinja2 template string or a path to a template file. "
+            "Passed to vLLM as `--chat-template`. If None, uses the model's default.",
+        ),
+    ] = None
+
     enable_lora: Annotated[
         bool,
         Field(
@@ -489,12 +497,12 @@ class InferenceConfig(BaseConfig):
             "model.max_model_len": "max_model_len",
             "model.enforce_eager": "enforce_eager",
             "model.trust_remote_code": "trust_remote_code",
-            "model.chat_template": "chat_template",
             "model.tool_call_parser": "tool_call_parser",
             "model.reasoning_parser": "reasoning_parser",
             "model.rope_scaling": "rope_scaling",
             "parallel.tp": "tensor_parallel_size",
             "parallel.dp": "data_parallel_size",
+            "chat_template": "chat_template",
             "data_parallel_size_local": "data_parallel_size_local",
             "data_parallel_rpc_port": "data_parallel_rpc_port",
             "enable_lora": "enable_lora",

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -14,6 +14,7 @@ from prime_rl.configs.shared import (
     TransportConfig,
     WandbWithExtrasConfig,
 )
+from prime_rl.configs.trainer import TokenizerConfig
 from prime_rl.utils.config import BaseConfig
 from prime_rl.utils.logger import get_logger
 
@@ -842,6 +843,9 @@ class OrchestratorConfig(BaseConfig):
     # The model configuration
     model: ModelConfig = ModelConfig()
 
+    # The tokenizer configuration
+    tokenizer: TokenizerConfig = TokenizerConfig()
+
     # The optimizer configuration (per-run LR for multi-run training)
     optim: OptimizerConfig = OptimizerConfig()
 
@@ -1041,6 +1045,16 @@ class OrchestratorConfig(BaseConfig):
                     )
                     train.setdefault("sampling", data.pop("sampling"))
         return data
+
+    @model_validator(mode="after")
+    def auto_setup_tokenizer(self):
+        if self.tokenizer.name is None:
+            self.tokenizer.name = self.model.name
+        if self.tokenizer.trust_remote_code is None:
+            self.tokenizer.trust_remote_code = self.model.trust_remote_code
+        if self.tokenizer.chat_template is None and self.model.chat_template is not None:
+            self.tokenizer.chat_template = self.model.chat_template
+        return self
 
     @model_validator(mode="after")
     def validate_unique_filter_types(self):

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -1052,8 +1052,6 @@ class OrchestratorConfig(BaseConfig):
             self.tokenizer.name = self.model.name
         if self.tokenizer.trust_remote_code is None:
             self.tokenizer.trust_remote_code = self.model.trust_remote_code
-        if self.tokenizer.chat_template is None and self.model.chat_template is not None:
-            self.tokenizer.chat_template = self.model.chat_template
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -131,6 +131,14 @@ class SharedModelConfig(BaseConfig):
         Field(description="The name of the model to use."),
     ] = "Qwen/Qwen3-0.6B"
 
+    chat_template: Annotated[
+        str | None,
+        Field(
+            description="Chat template to use. Can be a Jinja2 template string or a path to a template file. "
+            "Propagated to inference, orchestrator, and trainer.",
+        ),
+    ] = None
+
     vlm: Annotated[
         "VLMConfig | None",
         Field(description="VLM configuration. Set to enable vision-language model support."),
@@ -543,11 +551,19 @@ class RLConfig(BaseConfig):
                 if self.inference is not None:
                     self.inference.model.vlm = self.model.vlm
 
-            # Re-propagate model name to tokenizer since TrainerConfig.auto_setup_tokenizer
-            # already ran with the default model name before this validator.
-            self.trainer.tokenizer.name = self.trainer.model.name
-            if self.trainer.tokenizer.trust_remote_code is None:
-                self.trainer.tokenizer.trust_remote_code = self.trainer.model.trust_remote_code
+            if self.model.chat_template is not None:
+                self.trainer.model.chat_template = self.model.chat_template
+                self.orchestrator.model.chat_template = self.model.chat_template
+                if self.inference is not None:
+                    self.inference.model.chat_template = self.model.chat_template
+
+            # Re-propagate to tokenizer configs since auto_setup_tokenizer on
+            # TrainerConfig/OrchestratorConfig already ran with defaults before
+            # this validator could set the correct model name.
+            for component in (self.trainer, self.orchestrator):
+                component.tokenizer.name = component.model.name
+                component.tokenizer.trust_remote_code = component.model.trust_remote_code
+                component.tokenizer.chat_template = component.model.chat_template
 
         validate_shared_model_name(self.trainer, self.orchestrator, self.inference)
 

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -582,13 +582,13 @@ class RLConfig(BaseConfig):
                 component.tokenizer.name = component.model.name
                 component.tokenizer.trust_remote_code = component.model.trust_remote_code
 
-        validate_shared_tokenizer(self.trainer, self.orchestrator)
-
         # Propagate chat_template to inference (vLLM --chat-template)
         if self.inference is not None:
             chat_template = self.trainer.tokenizer.chat_template
-            if chat_template is not None:
+            if chat_template is not None and self.inference.chat_template is None:
                 self.inference.chat_template = chat_template
+
+        validate_shared_tokenizer(self.trainer, self.orchestrator, self.inference)
 
         return self
 

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -559,12 +559,7 @@ class RLConfig(BaseConfig):
 
     @model_validator(mode="after")
     def auto_setup_tokenizer(self):
-        """Auto-setup shared tokenizer config for trainer, orchestrator, and inference.
-
-        Re-runs tokenizer auto-setup on trainer/orchestrator since their validators
-        ran during construction with default model names, before auto_setup_model
-        could set the correct ones.
-        """
+        """Auto-setup shared tokenizer config for trainer, orchestrator, and inference."""
         if self.tokenizer is not None:
             # Shared tokenizer config: propagate to all components, then fill
             # in name/trust_remote_code from model config where still unset.

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -585,8 +585,8 @@ class RLConfig(BaseConfig):
         # Propagate chat_template to inference (vLLM --chat-template)
         if self.inference is not None:
             chat_template = self.trainer.tokenizer.chat_template
-            if chat_template is not None and self.inference.chat_template is None:
-                self.inference.chat_template = chat_template
+            if chat_template is not None and self.inference.model.chat_template is None:
+                self.inference.model.chat_template = chat_template
 
         validate_shared_tokenizer(self.trainer, self.orchestrator, self.inference)
 

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -26,6 +26,7 @@ from prime_rl.configs.shared import (
 from prime_rl.configs.trainer import (
     BenchConfig,
     FakeDataLoaderConfig,
+    TokenizerConfig,
     TrainerConfig,
 )
 from prime_rl.configs.trainer import (
@@ -130,14 +131,6 @@ class SharedModelConfig(BaseConfig):
         str,
         Field(description="The name of the model to use."),
     ] = "Qwen/Qwen3-0.6B"
-
-    chat_template: Annotated[
-        str | None,
-        Field(
-            description="Chat template to use. Can be a Jinja2 template string or a path to a template file. "
-            "Propagated to inference, orchestrator, and trainer.",
-        ),
-    ] = None
 
     vlm: Annotated[
         "VLMConfig | None",
@@ -298,6 +291,14 @@ class RLConfig(BaseConfig):
         SharedModelConfig | None,
         Field(
             description="Shared model configs. If None, will fallback to the model configs specified on submodule configs."
+        ),
+    ] = None
+
+    tokenizer: Annotated[
+        TokenizerConfig | None,
+        Field(
+            description="Shared tokenizer config. Propagated to trainer, orchestrator, and inference. "
+            "If None, each component uses its own tokenizer config (defaulting to model name).",
         ),
     ] = None
 
@@ -551,21 +552,40 @@ class RLConfig(BaseConfig):
                 if self.inference is not None:
                     self.inference.model.vlm = self.model.vlm
 
-            if self.model.chat_template is not None:
-                self.trainer.model.chat_template = self.model.chat_template
-                self.orchestrator.model.chat_template = self.model.chat_template
-                if self.inference is not None:
-                    self.inference.model.chat_template = self.model.chat_template
+        validate_shared_model_name(self.trainer, self.orchestrator, self.inference)
 
-            # Re-propagate to tokenizer configs since auto_setup_tokenizer on
-            # TrainerConfig/OrchestratorConfig already ran with defaults before
-            # this validator could set the correct model name.
+        return self
+
+    @model_validator(mode="after")
+    def auto_setup_tokenizer(self):
+        """Auto-setup shared tokenizer config for trainer, orchestrator, and inference.
+
+        Re-runs tokenizer auto-setup on trainer/orchestrator since their validators
+        ran during construction with default model names, before auto_setup_model
+        could set the correct ones.
+        """
+        if self.tokenizer is not None:
+            # Shared tokenizer config: propagate to all components, then fill
+            # in name/trust_remote_code from model config where still unset.
+            self.trainer.tokenizer = self.tokenizer.model_copy()
+            self.orchestrator.tokenizer = self.tokenizer.model_copy()
+            for component in (self.trainer, self.orchestrator):
+                if component.tokenizer.name is None:
+                    component.tokenizer.name = component.model.name
+                if component.tokenizer.trust_remote_code is None:
+                    component.tokenizer.trust_remote_code = component.model.trust_remote_code
+        else:
+            # No shared tokenizer: re-derive from (now-correct) model names,
+            # since auto_setup_tokenizer on sub-configs already ran with defaults.
             for component in (self.trainer, self.orchestrator):
                 component.tokenizer.name = component.model.name
                 component.tokenizer.trust_remote_code = component.model.trust_remote_code
-                component.tokenizer.chat_template = component.model.chat_template
 
-        validate_shared_model_name(self.trainer, self.orchestrator, self.inference)
+        # Propagate chat_template to inference (vLLM --chat-template)
+        if self.inference is not None:
+            chat_template = self.trainer.tokenizer.chat_template
+            if chat_template is not None:
+                self.inference.chat_template = chat_template
 
         return self
 

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -296,12 +296,12 @@ class RLConfig(BaseConfig):
     ] = None
 
     tokenizer: Annotated[
-        TokenizerConfig,
+        TokenizerConfig | None,
         Field(
             description="Shared tokenizer config. Propagated to trainer, orchestrator, and inference. "
-            "Fields left unset (None) are filled from the model config.",
+            "If None, each component uses its own tokenizer config (defaulting to model name).",
         ),
-    ] = TokenizerConfig()
+    ] = None
 
     max_steps: Annotated[
         int | None,
@@ -559,16 +559,22 @@ class RLConfig(BaseConfig):
 
     @model_validator(mode="after")
     def auto_setup_tokenizer(self):
-        """Auto-setup shared tokenizer config for trainer, orchestrator, and inference.
-
-        Must run after auto_setup_model so model names are already propagated.
-        """
-        self.trainer.tokenizer = self.tokenizer.model_copy()
-        self.orchestrator.tokenizer = self.tokenizer.model_copy()
-        for component in (self.trainer, self.orchestrator):
-            if component.tokenizer.name is None:
+        """Auto-setup shared tokenizer config for trainer, orchestrator, and inference."""
+        if self.tokenizer is not None:
+            # Shared tokenizer config: propagate to all components, then fill
+            # in name/trust_remote_code from model config where still unset.
+            self.trainer.tokenizer = self.tokenizer.model_copy()
+            self.orchestrator.tokenizer = self.tokenizer.model_copy()
+            for component in (self.trainer, self.orchestrator):
+                if component.tokenizer.name is None:
+                    component.tokenizer.name = component.model.name
+                if component.tokenizer.trust_remote_code is None:
+                    component.tokenizer.trust_remote_code = component.model.trust_remote_code
+        else:
+            # No shared tokenizer: re-derive from (now-correct) model names,
+            # since auto_setup_tokenizer on sub-configs already ran with defaults.
+            for component in (self.trainer, self.orchestrator):
                 component.tokenizer.name = component.model.name
-            if component.tokenizer.trust_remote_code is None:
                 component.tokenizer.trust_remote_code = component.model.trust_remote_code
 
         # Propagate chat_template to inference (vLLM --chat-template)

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -46,6 +46,7 @@ from prime_rl.utils.validation import (
     validate_shared_max_steps,
     validate_shared_model_name,
     validate_shared_output_dir,
+    validate_shared_tokenizer,
     validate_shared_wandb_config,
     validate_shared_weight_broadcast,
 )
@@ -580,6 +581,8 @@ class RLConfig(BaseConfig):
             for component in (self.trainer, self.orchestrator):
                 component.tokenizer.name = component.model.name
                 component.tokenizer.trust_remote_code = component.model.trust_remote_code
+
+        validate_shared_tokenizer(self.trainer, self.orchestrator)
 
         # Propagate chat_template to inference (vLLM --chat-template)
         if self.inference is not None:

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -296,12 +296,12 @@ class RLConfig(BaseConfig):
     ] = None
 
     tokenizer: Annotated[
-        TokenizerConfig | None,
+        TokenizerConfig,
         Field(
             description="Shared tokenizer config. Propagated to trainer, orchestrator, and inference. "
-            "If None, each component uses its own tokenizer config (defaulting to model name).",
+            "Fields left unset (None) are filled from the model config.",
         ),
-    ] = None
+    ] = TokenizerConfig()
 
     max_steps: Annotated[
         int | None,
@@ -559,22 +559,16 @@ class RLConfig(BaseConfig):
 
     @model_validator(mode="after")
     def auto_setup_tokenizer(self):
-        """Auto-setup shared tokenizer config for trainer, orchestrator, and inference."""
-        if self.tokenizer is not None:
-            # Shared tokenizer config: propagate to all components, then fill
-            # in name/trust_remote_code from model config where still unset.
-            self.trainer.tokenizer = self.tokenizer.model_copy()
-            self.orchestrator.tokenizer = self.tokenizer.model_copy()
-            for component in (self.trainer, self.orchestrator):
-                if component.tokenizer.name is None:
-                    component.tokenizer.name = component.model.name
-                if component.tokenizer.trust_remote_code is None:
-                    component.tokenizer.trust_remote_code = component.model.trust_remote_code
-        else:
-            # No shared tokenizer: re-derive from (now-correct) model names,
-            # since auto_setup_tokenizer on sub-configs already ran with defaults.
-            for component in (self.trainer, self.orchestrator):
+        """Auto-setup shared tokenizer config for trainer, orchestrator, and inference.
+
+        Must run after auto_setup_model so model names are already propagated.
+        """
+        self.trainer.tokenizer = self.tokenizer.model_copy()
+        self.orchestrator.tokenizer = self.tokenizer.model_copy()
+        for component in (self.trainer, self.orchestrator):
+            if component.tokenizer.name is None:
                 component.tokenizer.name = component.model.name
+            if component.tokenizer.trust_remote_code is None:
                 component.tokenizer.trust_remote_code = component.model.trust_remote_code
 
         # Propagate chat_template to inference (vLLM --chat-template)

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -543,6 +543,12 @@ class RLConfig(BaseConfig):
                 if self.inference is not None:
                     self.inference.model.vlm = self.model.vlm
 
+            # Re-propagate model name to tokenizer since TrainerConfig.auto_setup_tokenizer
+            # already ran with the default model name before this validator.
+            self.trainer.tokenizer.name = self.trainer.model.name
+            if self.trainer.tokenizer.trust_remote_code is None:
+                self.trainer.tokenizer.trust_remote_code = self.trainer.model.trust_remote_code
+
         validate_shared_model_name(self.trainer, self.orchestrator, self.inference)
 
         return self

--- a/src/prime_rl/configs/shared.py
+++ b/src/prime_rl/configs/shared.py
@@ -124,14 +124,6 @@ class BaseModelConfig(BaseConfig):
         ),
     ] = False
 
-    chat_template: Annotated[
-        str | None,
-        Field(
-            description="Chat template to use. Can be a Jinja2 template string or a path to a template file. "
-            "If None, uses the model's default chat template.",
-        ),
-    ] = None
-
     vlm: Annotated[
         "VLMConfig | None",
         Field(

--- a/src/prime_rl/configs/shared.py
+++ b/src/prime_rl/configs/shared.py
@@ -124,6 +124,14 @@ class BaseModelConfig(BaseConfig):
         ),
     ] = False
 
+    chat_template: Annotated[
+        str | None,
+        Field(
+            description="Chat template to use. Can be a Jinja2 template string or a path to a template file. "
+            "If None, uses the model's default chat template.",
+        ),
+    ] = None
+
     vlm: Annotated[
         "VLMConfig | None",
         Field(

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -30,7 +30,7 @@ monkey_patch_chat_completion_logprobs()
 
 import pandas as pd
 import verifiers as vf
-from transformers import AutoProcessor, AutoTokenizer
+from transformers import AutoProcessor
 
 from prime_rl.configs.orchestrator import OrchestratorConfig
 from prime_rl.orchestrator.buffer import Buffer
@@ -50,6 +50,7 @@ from prime_rl.orchestrator.vf_utils import (
     intercept_vf_logging,
     save_rollouts,
 )
+from prime_rl.trainer.model import setup_tokenizer
 from prime_rl.utils.client import (
     init_nccl_broadcast,
     setup_inference_pool,
@@ -137,8 +138,8 @@ async def orchestrate(config: OrchestratorConfig):
     is_vlm = config.model.vlm is not None
 
     # Load tokenizer and processor (processor only for VLM models)
-    logger.info(f"Initializing tokenizer for {config.model.name}")
-    tokenizer = AutoTokenizer.from_pretrained(config.model.name, trust_remote_code=config.model.trust_remote_code)
+    logger.info(f"Initializing tokenizer ({config.tokenizer})")
+    tokenizer = setup_tokenizer(config.tokenizer)
 
     processor = None
     if is_vlm:

--- a/src/prime_rl/utils/validation.py
+++ b/src/prime_rl/utils/validation.py
@@ -117,9 +117,9 @@ def validate_shared_tokenizer(
         )
     if inference is not None:
         chat_template = trainer.tokenizer.chat_template
-        if chat_template != inference.chat_template:
+        if chat_template != inference.model.chat_template:
             raise ValueError(
-                f"Inference chat_template ({inference.chat_template!r}) does not match "
+                f"Inference chat_template ({inference.model.chat_template!r}) does not match "
                 f"the shared tokenizer chat_template ({chat_template!r}). "
                 f"Use the shared [tokenizer] config to set chat_template for all components."
             )

--- a/src/prime_rl/utils/validation.py
+++ b/src/prime_rl/utils/validation.py
@@ -109,18 +109,21 @@ def validate_shared_tokenizer(
     orchestrator: OrchestratorConfig,
     inference: Optional[InferenceConfig] = None,
 ) -> None:
-    if trainer.tokenizer != orchestrator.tokenizer:
+    # Validate chat_template is consistent across all components.
+    # We only check chat_template (not name/trust_remote_code) because those
+    # are auto-derived from model names which may legitimately differ (e.g.
+    # when inference uses an FP8 quantized variant of the same model).
+    if trainer.tokenizer.chat_template != orchestrator.tokenizer.chat_template:
         raise ValueError(
-            f"Trainer and orchestrator tokenizer configs must match. "
-            f"Trainer: {trainer.tokenizer}, Orchestrator: {orchestrator.tokenizer}. "
-            f"Use the shared [tokenizer] config to set tokenizer options for both."
+            f"Trainer chat_template ({trainer.tokenizer.chat_template!r}) and orchestrator "
+            f"chat_template ({orchestrator.tokenizer.chat_template!r}) do not match. "
+            f"Use the shared [tokenizer] config to set chat_template for both."
         )
     if inference is not None:
-        chat_template = trainer.tokenizer.chat_template
-        if chat_template != inference.model.chat_template:
+        if trainer.tokenizer.chat_template != inference.model.chat_template:
             raise ValueError(
                 f"Inference chat_template ({inference.model.chat_template!r}) does not match "
-                f"the shared tokenizer chat_template ({chat_template!r}). "
+                f"the shared tokenizer chat_template ({trainer.tokenizer.chat_template!r}). "
                 f"Use the shared [tokenizer] config to set chat_template for all components."
             )
 

--- a/src/prime_rl/utils/validation.py
+++ b/src/prime_rl/utils/validation.py
@@ -104,6 +104,18 @@ def validate_shared_max_async_level(
         )
 
 
+def validate_shared_tokenizer(
+    trainer: TrainerConfig,
+    orchestrator: OrchestratorConfig,
+) -> None:
+    if trainer.tokenizer != orchestrator.tokenizer:
+        raise ValueError(
+            f"Trainer and orchestrator tokenizer configs must match. "
+            f"Trainer: {trainer.tokenizer}, Orchestrator: {orchestrator.tokenizer}. "
+            f"Use the shared [tokenizer] config to set tokenizer options for both."
+        )
+
+
 def validate_shared_weight_broadcast(
     trainer: TrainerConfig,
     orchestrator: OrchestratorConfig,

--- a/src/prime_rl/utils/validation.py
+++ b/src/prime_rl/utils/validation.py
@@ -107,6 +107,7 @@ def validate_shared_max_async_level(
 def validate_shared_tokenizer(
     trainer: TrainerConfig,
     orchestrator: OrchestratorConfig,
+    inference: Optional[InferenceConfig] = None,
 ) -> None:
     if trainer.tokenizer != orchestrator.tokenizer:
         raise ValueError(
@@ -114,6 +115,14 @@ def validate_shared_tokenizer(
             f"Trainer: {trainer.tokenizer}, Orchestrator: {orchestrator.tokenizer}. "
             f"Use the shared [tokenizer] config to set tokenizer options for both."
         )
+    if inference is not None:
+        chat_template = trainer.tokenizer.chat_template
+        if chat_template != inference.chat_template:
+            raise ValueError(
+                f"Inference chat_template ({inference.chat_template!r}) does not match "
+                f"the shared tokenizer chat_template ({chat_template!r}). "
+                f"Use the shared [tokenizer] config to set chat_template for all components."
+            )
 
 
 def validate_shared_weight_broadcast(


### PR DESCRIPTION
## Summary
- Adds `TokenizerConfig` to `OrchestratorConfig` and reuses `setup_tokenizer` instead of inline `AutoTokenizer` usage
- Adds shared `[tokenizer]` config on `RLConfig` that propagates to trainer, orchestrator, and inference
- Adds `chat_template` to inference `ModelConfig`, wired to vLLM `--chat-template`
- Adds `validate_shared_tokenizer` to enforce trainer/orchestrator tokenizer configs match and inference `chat_template` is consistent
- Fixes tokenizer name not being propagated from shared `[model]` config — component `auto_setup_tokenizer` validators ran during construction with default model names before `RLConfig.auto_setup_model` could set the correct ones

### Usage
```toml
[model]
name = "my-org/my-model"

# Optional: override chat template for all components
[tokenizer]
chat_template = "path/to/template.jinja"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches RL configuration resolution/validation and changes how the orchestrator initializes tokenization, which can affect rollout formatting and compatibility across trainer/orchestrator/inference. Risk is mitigated by new cross-component validation, but misconfigurations could now fail fast at startup.
> 
> **Overview**
> Adds a top-level shared `tokenizer` configuration to RL runs and wires it into `TrainerConfig` and `OrchestratorConfig`, with validators that auto-derive `tokenizer.name`/`trust_remote_code` from the selected model when unset and ensure `chat_template` stays consistent across components.
> 
> Extends inference `ModelConfig` with `chat_template` support and forwards it to vLLM (`--chat-template`), omitting the argument when unset to satisfy vLLM’s CLI constraints. The orchestrator now initializes its tokenizer via the shared `setup_tokenizer` helper (instead of constructing `AutoTokenizer` inline), enabling consistent chat templating behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a4a37bc74909a04cc86af9cffe8841b1eb83052. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->