### PR TITLE
feat: add config to disable prefix cache reset after weight updates

### DIFF
--- a/src/prime_rl/configs/inference.py
+++ b/src/prime_rl/configs/inference.py
@@ -309,9 +309,10 @@ class InferenceConfig(BaseConfig):
         bool,
         Field(
             description="Whether to reset the prefix cache after weight updates (update_weights, load_lora_adapter). "
-            "Disabling this avoids the latency of cache invalidation when prefix caching correctness is not a concern.",
+            "Ensures all KV states are recomputed with the new weights at the cost of extra prefill. "
+            "When False, prefer using orchestrator.use_prefix_cache_salt to invalidate stale caches via salt instead.",
         ),
-    ] = True
+    ] = False
 
     gpu_memory_utilization: Annotated[
         float,

--- a/src/prime_rl/configs/inference.py
+++ b/src/prime_rl/configs/inference.py
@@ -305,6 +305,14 @@ class InferenceConfig(BaseConfig):
         ),
     ] = None
 
+    reset_prefix_cache_after_update: Annotated[
+        bool,
+        Field(
+            description="Whether to reset the prefix cache after weight updates (update_weights, load_lora_adapter). "
+            "Disabling this avoids the latency of cache invalidation when prefix caching correctness is not a concern.",
+        ),
+    ] = True
+
     gpu_memory_utilization: Annotated[
         float,
         Field(

--- a/src/prime_rl/configs/inference.py
+++ b/src/prime_rl/configs/inference.py
@@ -247,6 +247,15 @@ InferenceDeploymentConfig: TypeAlias = Annotated[
 class InferenceExperimentalConfig(BaseConfig):
     """Experimental features for inference."""
 
+    reset_prefix_cache_after_update: Annotated[
+        bool,
+        Field(
+            description="Whether to reset the prefix cache after weight updates (update_weights, load_lora_adapter). "
+            "Ensures all KV states are recomputed with the new weights at the cost of extra prefill. "
+            "When False, prefer using orchestrator.experimental.use_prefix_cache_salt to invalidate stale caches via salt instead.",
+        ),
+    ] = False
+
 
 class InferenceConfig(BaseConfig):
     """Configures inference."""
@@ -304,15 +313,6 @@ class InferenceConfig(BaseConfig):
             description="Whether to enable prefix caching. Passed to vLLM as `--enable-prefix-caching`",
         ),
     ] = None
-
-    reset_prefix_cache_after_update: Annotated[
-        bool,
-        Field(
-            description="Whether to reset the prefix cache after weight updates (update_weights, load_lora_adapter). "
-            "Ensures all KV states are recomputed with the new weights at the cost of extra prefill. "
-            "When False, prefer using orchestrator.use_prefix_cache_salt to invalidate stale caches via salt instead.",
-        ),
-    ] = False
 
     gpu_memory_utilization: Annotated[
         float,

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -812,6 +812,15 @@ WeightBroadcastConfig: TypeAlias = Annotated[
 class OrchestratorExperimentalConfig(BaseConfig):
     """Experimental features for the orchestrator."""
 
+    use_prefix_cache_salt: Annotated[
+        bool,
+        Field(
+            description="Whether to set a cache_salt on inference requests that changes with each weight update. "
+            "This invalidates prefix-cached KV states from previous policies without resetting the entire cache, "
+            "while preserving cache hits for in-flight off-policy rollouts.",
+        ),
+    ] = True
+
 
 class TeacherModelConfig(BaseConfig):
     """Configures the teacher model for computing teacher logprobs (e.g. for distillation)."""

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -342,7 +342,7 @@ def server(config: InferenceConfig, vllm_extra: dict[str, Any] | None = None):
 
     args.tool_call_parser = resolve_tool_call_parser(args.model, args.tool_call_parser)
     args.enable_auto_tool_choice = args.tool_call_parser is not None
-    args.reset_prefix_cache_after_update = config.reset_prefix_cache_after_update
+    args.reset_prefix_cache_after_update = config.experimental.reset_prefix_cache_after_update
     if args.tool_call_parser is not None:
         logger.info(f"Using tool_call_parser='{args.tool_call_parser}' for model '{args.model}'")
 

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -198,23 +198,24 @@ async def resume(request: Request):
 async def update_weights(request: Request):
     data = await request.json()
     await engine_client(request).collective_rpc("update_weights_from_path", args=(data.get("weight_dir"),))
-    await engine_client(request).reset_prefix_cache()
+    if request.app.state.reset_prefix_cache_after_update:
+        await engine_client(request).reset_prefix_cache()
     return {"status": "ok"}
 
 
 @router.post("/load_lora_adapter")
 async def load_lora_adapter(lora_request: LoadLoRAAdapterRequest, raw_request: Request):
-    """Load a LoRA adapter and reset the prefix cache.
+    """Load a LoRA adapter, optionally resetting the prefix cache.
 
     Wrapper around vLLM's /v1/load_lora_adapter that also resets the prefix cache
-    to invalidate KV states computed with old weights.
+    to invalidate KV states computed with old weights (unless disabled via config).
     """
     handler = models(raw_request)
     response = await handler.load_lora_adapter(lora_request)
     if isinstance(response, ErrorResponse):
         return JSONResponse(content=response.model_dump(), status_code=response.error.code)
-    # Reset prefix cache to invalidate KV states computed with old weights
-    await engine_client(raw_request).reset_prefix_cache()
+    if raw_request.app.state.reset_prefix_cache_after_update:
+        await engine_client(raw_request).reset_prefix_cache()
     return {"status": "ok"}
 
 
@@ -272,6 +273,8 @@ async def custom_init_app_state(
     2. Replace the serving_chat with our OpenAIServingChatWithTokens wrapper.
     """
     await init_app_state(engine_client, state, args, supported_tasks)
+
+    state.reset_prefix_cache_after_update = getattr(args, "reset_prefix_cache_after_update", True)
 
     if "generate" in supported_tasks and state.openai_serving_chat is not None:
         original_chat = state.openai_serving_chat
@@ -339,6 +342,7 @@ def server(config: InferenceConfig, vllm_extra: dict[str, Any] | None = None):
 
     args.tool_call_parser = resolve_tool_call_parser(args.model, args.tool_call_parser)
     args.enable_auto_tool_choice = args.tool_call_parser is not None
+    args.reset_prefix_cache_after_update = config.reset_prefix_cache_after_update
     if args.tool_call_parser is not None:
         logger.info(f"Using tool_call_parser='{args.tool_call_parser}' for model '{args.model}'")
 

--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -139,6 +139,10 @@ class Env:
             env_client=self.env_client,
         )
 
+    def set_cache_salt(self, salt: str) -> None:
+        extra_body = self.sampling_args.setdefault("extra_body", {})
+        extra_body["cache_salt"] = salt
+
     def shutdown(self) -> None:
         if self._env_server_process is None:
             return

--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -104,18 +104,27 @@ class Env:
         self._env_server_process = process
         return address
 
+    def _sampling_args_with_salt(self, cache_salt: str | None) -> dict:
+        if cache_salt is None:
+            return self.sampling_args
+        sampling_args = {**self.sampling_args}
+        extra_body = {**sampling_args.get("extra_body", {}), "cache_salt": cache_salt}
+        sampling_args["extra_body"] = extra_body
+        return sampling_args
+
     async def run_rollout(
         self,
         client: vf.ClientConfig,
         example: dict,
         model_name: str,
+        cache_salt: str | None = None,
     ) -> vf.RolloutOutput:
         """Run a single rollout for an example."""
         return await self.env.run_rollout(
             vf.RolloutInput(**example),
             client=client,
             model=model_name,
-            sampling_args=self.sampling_args,
+            sampling_args=self._sampling_args_with_salt(cache_salt),
             max_retries=self.config.max_retries,
             state_columns=REQUIRED_STATE_COLUMNS,
             env_client=self.env_client,
@@ -127,21 +136,18 @@ class Env:
         example: dict,
         model_name: str,
         rollouts_per_example: int,
+        cache_salt: str | None = None,
     ) -> list[vf.RolloutOutput]:
         """Run a group of rollouts for an example. Required for group-scoring envs."""
         return await self.env.run_group(
             [vf.RolloutInput(**example) for _ in range(rollouts_per_example)],
             client=client,
             model=model_name,
-            sampling_args=self.sampling_args,
+            sampling_args=self._sampling_args_with_salt(cache_salt),
             max_retries=self.config.max_retries,
             state_columns=REQUIRED_STATE_COLUMNS,
             env_client=self.env_client,
         )
-
-    def set_cache_salt(self, salt: str) -> None:
-        extra_body = self.sampling_args.setdefault("extra_body", {})
-        extra_body["cache_salt"] = salt
 
     def shutdown(self) -> None:
         if self._env_server_process is None:
@@ -175,6 +181,7 @@ class EvalEnv(Env):
         get_client: Callable[[], Awaitable[vf.ClientConfig]],
         ckpt_step: int,
         step: int,
+        cache_salt: str | None = None,
     ) -> list[vf.RolloutOutput]:
         num_examples = len(self.examples)
         rollouts_per_example = self.config.rollouts_per_example
@@ -194,6 +201,7 @@ class EvalEnv(Env):
                         example=example,
                         model_name=model_name,
                         rollouts_per_example=rollouts_per_example,
+                        cache_salt=cache_salt,
                     )
                     pbar.update(rollouts_per_example)
                     return outputs
@@ -210,7 +218,9 @@ class EvalEnv(Env):
                 """Run a single rollout for one example."""
                 try:
                     client = await get_client()
-                    output = await self.run_rollout(client=client, example=example, model_name=model_name)
+                    output = await self.run_rollout(
+                        client=client, example=example, model_name=model_name, cache_salt=cache_salt
+                    )
                     pbar.update(1)
                     return [output]
                 except Exception as e:

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -236,6 +236,7 @@ async def orchestrate(config: OrchestratorConfig):
         enable_policy_updates=enable_policy_updates,
         lora_name=config.model.lora.name if config.model.lora else None,
         config=config,
+        use_prefix_cache_salt=config.experimental.use_prefix_cache_salt,
     )
     scheduler.model_name = rollout_model_name
 
@@ -312,6 +313,15 @@ async def orchestrate(config: OrchestratorConfig):
     else:
         logger.info("Training from scratch")
 
+    # Set initial cache salt on all envs
+    if config.experimental.use_prefix_cache_salt:
+        salt = str(scheduler.ckpt_step)
+        for env in train_envs:
+            env.set_cache_salt(salt)
+        if eval_envs is not None:
+            for env in eval_envs:
+                env.set_cache_salt(salt)
+
     # Iterate over dataset in batches
     logger.info(f"Starting orchestrator loop (max_steps={config.max_steps or 'infinite'})")
     is_first_step = True
@@ -369,6 +379,10 @@ async def orchestrate(config: OrchestratorConfig):
         if envs_to_eval:
             env_names = ", ".join(e.name for e in envs_to_eval)
             logger.info(f"Running evals at {ckpt_step=} for {env_names}")
+
+            if config.experimental.use_prefix_cache_salt:
+                for eval_env in envs_to_eval:
+                    eval_env.set_cache_salt(str(ckpt_step))
 
             # Pause weight updates and re-scheduling of training rollouts during eval
             # to avoid evaluating across different checkpoints and avoid congestion
@@ -711,6 +725,9 @@ async def orchestrate(config: OrchestratorConfig):
 
     if config.eval and eval_envs is not None:
         logger.info("Running final evals")
+        if config.experimental.use_prefix_cache_salt:
+            for eval_env in eval_envs:
+                eval_env.set_cache_salt(str(ckpt_step))
         eval_results = await asyncio.gather(
             *[
                 eval_env.evaluate(

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -313,15 +313,6 @@ async def orchestrate(config: OrchestratorConfig):
     else:
         logger.info("Training from scratch")
 
-    # Set initial cache salt on all envs
-    if config.experimental.use_prefix_cache_salt:
-        salt = str(scheduler.ckpt_step)
-        for env in train_envs:
-            env.set_cache_salt(salt)
-        if eval_envs is not None:
-            for env in eval_envs:
-                env.set_cache_salt(salt)
-
     # Iterate over dataset in batches
     logger.info(f"Starting orchestrator loop (max_steps={config.max_steps or 'infinite'})")
     is_first_step = True
@@ -380,10 +371,6 @@ async def orchestrate(config: OrchestratorConfig):
             env_names = ", ".join(e.name for e in envs_to_eval)
             logger.info(f"Running evals at {ckpt_step=} for {env_names}")
 
-            if config.experimental.use_prefix_cache_salt:
-                for eval_env in envs_to_eval:
-                    eval_env.set_cache_salt(str(ckpt_step))
-
             # Pause weight updates and re-scheduling of training rollouts during eval
             # to avoid evaluating across different checkpoints and avoid congestion
             scheduler.checkpoint_ready.clear()
@@ -393,6 +380,7 @@ async def orchestrate(config: OrchestratorConfig):
                 logger.info("Cancelling in-flight training rollouts before starting evals to avoid congestion.")
                 await scheduler.cancel_inflight_rollouts()
 
+            eval_cache_salt = str(ckpt_step) if config.experimental.use_prefix_cache_salt else None
             eval_results = await asyncio.gather(
                 *[
                     eval_env.evaluate(
@@ -400,6 +388,7 @@ async def orchestrate(config: OrchestratorConfig):
                         get_client=inference_pool.get_eval_client,
                         ckpt_step=ckpt_step,
                         step=progress.step,
+                        cache_salt=eval_cache_salt,
                     )
                     for eval_env in envs_to_eval
                 ]
@@ -725,9 +714,7 @@ async def orchestrate(config: OrchestratorConfig):
 
     if config.eval and eval_envs is not None:
         logger.info("Running final evals")
-        if config.experimental.use_prefix_cache_salt:
-            for eval_env in eval_envs:
-                eval_env.set_cache_salt(str(ckpt_step))
+        final_cache_salt = str(ckpt_step) if config.experimental.use_prefix_cache_salt else None
         eval_results = await asyncio.gather(
             *[
                 eval_env.evaluate(
@@ -735,6 +722,7 @@ async def orchestrate(config: OrchestratorConfig):
                     get_client=inference_pool.get_eval_client,
                     ckpt_step=ckpt_step,
                     step=progress.step,
+                    cache_salt=final_cache_salt,
                 )
                 for eval_env in eval_envs
             ]

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -68,6 +68,7 @@ class Scheduler:
         tasks_per_minute: int | None,
         enable_policy_updates: bool = True,
         lora_name: str | None = None,
+        use_prefix_cache_salt: bool = False,
     ):
         self.logger = get_logger()
         if tasks_per_minute is not None:
@@ -86,6 +87,7 @@ class Scheduler:
         self.strict_async_level = strict_async_level
         self.enable_policy_updates = enable_policy_updates
         self.lora_name = lora_name
+        self.use_prefix_cache_salt = use_prefix_cache_salt
         self.model_name = self.config.model.name
         self.json_logging = config.log.json_logging
 
@@ -306,6 +308,9 @@ class Scheduler:
             self.model_name = self.lora_name
             self.inference_pool.update_model_name(self.model_name)
 
+        if self.use_prefix_cache_salt:
+            self._update_cache_salt(str(next_ckpt_step))
+
         self.checkpoint_ready.set()
         await self._update_off_policy()
 
@@ -366,6 +371,10 @@ class Scheduler:
                 f"Cancelled {removed} old rollout requests (will refill naturally). "
                 f"Consider increasing max_off_policy_steps to avoid this."
             )
+
+    def _update_cache_salt(self, salt: str) -> None:
+        for env in self.train_envs:
+            env.set_cache_salt(salt)
 
     async def generate_batch(self, step: int) -> list[vf.RolloutOutput]:
         """Continuously generates a batch of rollouts."""

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -198,6 +198,7 @@ class Scheduler:
         env_name = group.example["env_name"]
         env = self.train_envs.get(env_name)
 
+        cache_salt = str(self.ckpt_step) if self.use_prefix_cache_salt else None
         if env.requires_group_scoring:
             rollout_count = group.rollouts_to_schedule
             group.rollouts_to_schedule = 0
@@ -207,6 +208,7 @@ class Scheduler:
                     example=group.example,
                     model_name=self.model_name,
                     rollouts_per_example=rollout_count,
+                    cache_salt=cache_salt,
                 )
             )
         else:
@@ -217,6 +219,7 @@ class Scheduler:
                     client=client_config,
                     example=group.example,
                     model_name=self.model_name,
+                    cache_salt=cache_salt,
                 )
             )
         self.inflight_requests[task] = InflightRequest(
@@ -308,9 +311,6 @@ class Scheduler:
             self.model_name = self.lora_name
             self.inference_pool.update_model_name(self.model_name)
 
-        if self.use_prefix_cache_salt:
-            self._update_cache_salt(str(next_ckpt_step))
-
         self.checkpoint_ready.set()
         await self._update_off_policy()
 
@@ -371,10 +371,6 @@ class Scheduler:
                 f"Cancelled {removed} old rollout requests (will refill naturally). "
                 f"Consider increasing max_off_policy_steps to avoid this."
             )
-
-    def _update_cache_salt(self, salt: str) -> None:
-        for env in self.train_envs:
-            env.set_cache_salt(salt)
 
     async def generate_batch(self, step: int) -> list[vf.RolloutOutput]:
         """Continuously generates a batch of rollouts."""

--- a/tests/unit/orchestrator/test_scheduler.py
+++ b/tests/unit/orchestrator/test_scheduler.py
@@ -29,6 +29,7 @@ def make_scheduler() -> Scheduler:
     scheduler.inflight_policy_update_task = None
     scheduler.update_policy_task = None
     scheduler.enable_policy_updates = True
+    scheduler.use_prefix_cache_salt = False
     return scheduler
 
 


### PR DESCRIPTION
## Summary
- Adds `inference.experimental.reset_prefix_cache_after_update` (default: `false`) — optionally reset the entire prefix cache after weight updates for strict KV correctness at the cost of extra prefill
- Adds `orchestrator.experimental.use_prefix_cache_salt` (default: `true`) — sets a `cache_salt` on inference requests that changes with each weight update, partitioning the prefix cache by policy version without resetting it
- Removes the unconditional `reset_prefix_cache()` calls from `/update_weights` and `/load_lora_adapter` server endpoints

## Usage
```toml
# Salt is on by default — partitions prefix cache by policy version
# Off-policy rollouts keep their cached KV, new rollouts get fresh computation
[orchestrator.experimental]
use_prefix_cache_salt = true  # default

# Full cache reset is off by default — enable for strict correctness
[inference.experimental]
reset_prefix_cache_after_update = false  # default
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how prefix-cache KV state is invalidated across weight/LoRA updates by defaulting away from full cache resets and introducing per-checkpoint cache salting; misconfiguration could lead to stale KV reuse or throughput regressions.
> 
> **Overview**
> Adds new experimental knobs to control prefix-cache invalidation after policy updates: `inference.experimental.reset_prefix_cache_after_update` (default `false`) and `orchestrator.experimental.use_prefix_cache_salt` (default `true`).
> 
> Inference server `/update_weights` and `/load_lora_adapter` now **only** call `reset_prefix_cache()` when configured, while the orchestrator/scheduler can attach a per-checkpoint `cache_salt` to rollout/eval sampling args so new policies avoid reusing prefix-cached KV from older weights without flushing the entire cache.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1e4cca98ede2e1e7b0e427a7e6266e11a9bf0b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->