### PR TITLE
set default async to 2

### DIFF
--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -990,7 +990,7 @@ class OrchestratorConfig(BaseConfig):
             ge=0,
             description="Maximum number of steps the inference can be ahead of training. If 0, will degenerate to synchronous on-policy RL. If >=1, training and inference will be overlapped.",
         ),
-    ] = 1
+    ] = 2
 
     strict_async_level: Annotated[
         bool,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the orchestrator’s default async training/inference overlap, which can alter rollout off-policyness and throughput for runs relying on defaults.
> 
> **Overview**
> Updates `OrchestratorConfig` to default `max_async_level` from `1` to `2`, increasing the allowed inference lead over training for configurations that don’t explicitly set this value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26dce1c7bf627171efcf9ef9ee499a7a81681d85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->