### PR TITLE
[feat] use cache salt in request

### DIFF
--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -195,23 +195,20 @@ async def resume(request: Request):
 async def update_weights(request: Request):
     data = await request.json()
     await engine_client(request).collective_rpc("update_weights_from_path", args=(data.get("weight_dir"),))
-    await engine_client(request).reset_prefix_cache()
     return {"status": "ok"}
 
 
 @router.post("/load_lora_adapter")
 async def load_lora_adapter(lora_request: LoadLoRAAdapterRequest, raw_request: Request):
-    """Load a LoRA adapter and reset the prefix cache.
+    """Load a LoRA adapter.
 
-    Wrapper around vLLM's /v1/load_lora_adapter that also resets the prefix cache
-    to invalidate KV states computed with old weights.
+    Wrapper around vLLM's /v1/load_lora_adapter. KV cache invalidation for old
+    weights is handled client-side via per-request cache_salt.
     """
     handler = models(raw_request)
     response = await handler.load_lora_adapter(lora_request)
     if isinstance(response, ErrorResponse):
         return JSONResponse(content=response.model_dump(), status_code=response.error.code)
-    # Reset prefix cache to invalidate KV states computed with old weights
-    await engine_client(raw_request).reset_prefix_cache()
     return {"status": "ok"}
 
 

--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -104,18 +104,27 @@ class Env:
         self._env_server_process = process
         return address
 
+    def _sampling_args_with_salt(self, cache_salt: str | None) -> dict:
+        if cache_salt is None:
+            return self.sampling_args
+        sampling_args = {**self.sampling_args}
+        extra_body = {**sampling_args.get("extra_body", {}), "cache_salt": cache_salt}
+        sampling_args["extra_body"] = extra_body
+        return sampling_args
+
     async def run_rollout(
         self,
         client: vf.ClientConfig,
         example: dict,
         model_name: str,
+        cache_salt: str | None = None,
     ) -> vf.RolloutOutput:
         """Run a single rollout for an example."""
         return await self.env.run_rollout(
             vf.RolloutInput(**example),
             client=client,
             model=model_name,
-            sampling_args=self.sampling_args,
+            sampling_args=self._sampling_args_with_salt(cache_salt),
             max_retries=self.config.max_retries,
             state_columns=REQUIRED_STATE_COLUMNS,
             env_client=self.env_client,
@@ -127,13 +136,14 @@ class Env:
         example: dict,
         model_name: str,
         rollouts_per_example: int,
+        cache_salt: str | None = None,
     ) -> list[vf.RolloutOutput]:
         """Run a group of rollouts for an example. Required for group-scoring envs."""
         return await self.env.run_group(
             [vf.RolloutInput(**example) for _ in range(rollouts_per_example)],
             client=client,
             model=model_name,
-            sampling_args=self.sampling_args,
+            sampling_args=self._sampling_args_with_salt(cache_salt),
             max_retries=self.config.max_retries,
             state_columns=REQUIRED_STATE_COLUMNS,
             env_client=self.env_client,

--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -200,6 +200,7 @@ class EvalEnv(Env):
                         example=example,
                         model_name=model_name,
                         rollouts_per_example=rollouts_per_example,
+                        cache_salt=str(ckpt_step),
                     )
                     pbar.update(rollouts_per_example)
                     return outputs
@@ -216,7 +217,9 @@ class EvalEnv(Env):
                 """Run a single rollout for one example."""
                 try:
                     client = await get_client()
-                    output = await self.run_rollout(client=client, example=example, model_name=model_name)
+                    output = await self.run_rollout(
+                        client=client, example=example, model_name=model_name, cache_salt=str(ckpt_step)
+                    )
                     pbar.update(1)
                     return [output]
                 except Exception as e:

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -196,6 +196,7 @@ class Scheduler:
         env_name = group.example["env_name"]
         env = self.train_envs.get(env_name)
 
+        cache_salt = str(self.ckpt_step)
         if env.requires_group_scoring:
             rollout_count = group.rollouts_to_schedule
             group.rollouts_to_schedule = 0
@@ -205,6 +206,7 @@ class Scheduler:
                     example=group.example,
                     model_name=self.model_name,
                     rollouts_per_example=rollout_count,
+                    cache_salt=cache_salt,
                 )
             )
         else:
@@ -215,6 +217,7 @@ class Scheduler:
                     client=client_config,
                     example=group.example,
                     model_name=self.model_name,
+                    cache_salt=cache_salt,
                 )
             )
         self.inflight_requests[task] = InflightRequest(

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -196,7 +196,7 @@ class Scheduler:
         env_name = group.example["env_name"]
         env = self.train_envs.get(env_name)
 
-        cache_salt = str(self.ckpt_step)
+        cache_salt = str(self.ckpt_step) if self.enable_policy_updates else None
         if env.requires_group_scoring:
             rollout_count = group.rollouts_to_schedule
             group.rollouts_to_schedule = 0


### PR DESCRIPTION
This removes the need to reset kv cache to prevent overly stale cache

we currently reset the kv cache on all inference engines after a policy update. This is because we had a bug that was caught in nightly a few moons ago where the kl mismatch would go crazy after a few hundred steps because the system prompts kv cache would never be reset: https://discord.com/channels/1383922374964936786/1464376927459606681/1464438352303362149

But this causes quite some prefill work everytime we update the policy. So we should instead tag rollouts with the step they started at and make it that requests from different steps dont share kv cache.

That way, it gets refreshed for new rollouts. But running rollouts can keep using the old kv cache they had

This tagging is exposed as cache_salt in vllm. The original intention was to prevent users from being able to use each others prefix cache and be exposed to timing attacks


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how KV/prefix cache is invalidated across policy updates by relying on `cache_salt` propagation rather than server-side cache resets, which could affect rollout correctness and performance if not applied consistently.
> 
> **Overview**
> Switches cache invalidation for policy/adapter updates from server-side prefix-cache resets to **per-request KV cache segregation** using vLLM’s `cache_salt`.
> 
> The orchestrator now threads an optional `cache_salt` (set to the current `ckpt_step` when policy updates are enabled) through `Env.run_rollout`/`run_group` by injecting it into `sampling_args.extra_body`, so rollouts from different checkpoint steps don’t share prefix/KV cache.
> 
> On the inference API side, the `/update_weights` and `/load_lora_adapter` endpoints no longer call `reset_prefix_cache`; the LoRA endpoint docs are updated to note that cache invalidation is handled client-side via `cache_salt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba1ef18c2491be11db3db770a047208142e57ec4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->