### PR TITLE
feat: per-batch loss type override for hosted SFT hard distill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Documenting **breaking** configuration changes — renamed, removed, or moved fields that require users to update existing configs.
 
+- **`orchestrator.teacher_rollout_model` now requires `orchestrator.use_sft_loss = true`**: External teacher rollout configs no longer rely on `trainer.loss.type = "sft"` to select SFT loss. Existing hard-distill configs must set `orchestrator.use_sft_loss = true` alongside `orchestrator.teacher_rollout_model`; the orchestrator validates the pair and stamps training samples with the per-batch SFT loss bool. (2026-04-26)
 - **`model.attn = "eager"` (NEW option)**: Added `eager` as a valid value for the `model.attn` field. Required for GPT-OSS models on non-Hopper GPUs, since the only flash attention kernel GPT-OSS supports (`kernels-community/vllm-flash-attn3`) is Hopper-only. A clear error message is raised at model load time if GPT-OSS is used without `eager` on unsupported hardware. Also added `kernels` as a core dependency. (2026-04-05)
 - **`[[orchestrator.env]]` → `[[orchestrator.train.env]]`**: Training environments and sampling are now configured under `[orchestrator.train]`. The old `[[orchestrator.env]]` and `[orchestrator.sampling]` paths are auto-translated with a deprecation warning and will be removed in a future release. (2026-04-09)
 - **Per-env sampling overrides (NEW)**: Both `TrainEnvConfig` and `EvalEnvConfig` now accept a `[sampling]` section for per-env overrides. Unset fields inherit from the group-level sampling config (`[orchestrator.train.sampling]` or `[orchestrator.eval.sampling]`). (2026-04-09)

--- a/examples/alphabet_sort/sft_distill_hard.toml
+++ b/examples/alphabet_sort/sft_distill_hard.toml
@@ -33,6 +33,7 @@ save_adapter_separately = true
 batch_size = 256
 rollouts_per_example = 4
 use_token_client = false
+loss_type = "sft"
 
 [orchestrator.sampling]
 max_tokens = 512

--- a/examples/alphabet_sort/sft_distill_hard.toml
+++ b/examples/alphabet_sort/sft_distill_hard.toml
@@ -19,9 +19,6 @@ name = "qwen3-4b-hard-distill"
 [trainer.optim]
 lr = 1e-5
 
-[trainer.loss]
-type = "sft"
-
 [trainer.model.lora]
 rank = 16
 alpha = 32
@@ -33,7 +30,7 @@ save_adapter_separately = true
 batch_size = 256
 rollouts_per_example = 4
 use_token_client = false
-need_sft_loss = true
+use_sft_loss = true
 
 [orchestrator.sampling]
 max_tokens = 512

--- a/examples/alphabet_sort/sft_distill_hard.toml
+++ b/examples/alphabet_sort/sft_distill_hard.toml
@@ -33,7 +33,7 @@ save_adapter_separately = true
 batch_size = 256
 rollouts_per_example = 4
 use_token_client = false
-loss_type = "sft"
+need_sft_loss = true
 
 [orchestrator.sampling]
 max_tokens = 512

--- a/skills/config/SKILL.md
+++ b/skills/config/SKILL.md
@@ -153,6 +153,10 @@ uv run sft --data.type fake --data.batch-size 4
 
 If you wish to configure values of the default variant, you don't need to set the `type` field.
 
+### SFT hard distill override
+
+For hosted multi-tenant runs where the trainer image's `trainer.loss.type` is fixed, the orchestrator exposes a per-run override that forces SFT loss on every micro-batch without rebuilding the trainer. Set `orchestrator.use_sft_loss = true` alongside `orchestrator.teacher_rollout_model`; both must be configured together (the orchestrator validator enforces this). The orchestrator stamps each `TrainingSample.sft_loss = True`, which the trainer's `compute_loss` honors by dispatching to `sft_loss_fn` per batch — independent of the trainer's configured default loss.
+
 ### Model fields
 
 For `BaseModel | None` fields (like `[ckpt]`, `[wandb]`, `[compile]`), a bare flag enables them with defaults:

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -876,6 +876,17 @@ class OrchestratorConfig(BaseConfig):
         ),
     ] = None
 
+    # Loss type for training (per-run override for hosted multi-tenant training)
+    loss_type: Annotated[
+        Literal["rl", "sft"],
+        Field(
+            description=(
+                "Loss type for this run. 'rl' uses the trainer's configured RL loss (default). "
+                "'sft' uses SFT masked NLL loss and requires a teacher_rollout_model to be configured."
+            ),
+        ),
+    ] = "rl"
+
     # The evaluation configuration
     eval: EvalConfig | None = None
 

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -877,7 +877,7 @@ class OrchestratorConfig(BaseConfig):
     ] = None
 
     # When True, trainer uses SFT loss instead of RL loss (per-run override for hosted multi-tenant training)
-    need_sft_loss: Annotated[
+    use_sft_loss: Annotated[
         bool,
         Field(
             description=(
@@ -1076,6 +1076,27 @@ class OrchestratorConfig(BaseConfig):
         types = [f.type for f in self.filters]
         if len(types) != len(set(types)):
             raise ValueError(f"Duplicate filter types: {types}. Each filter type may only appear once.")
+        return self
+
+    @model_validator(mode="after")
+    def validate_sft_distill_mode(self):
+        """Enforce the SFT hard distill invariants that involve only orchestrator fields.
+
+        Runs at ``OrchestratorConfig`` level so hosted deployments (which load this
+        config standalone via the ``orchestrator`` entrypoint) get the same guarantees
+        as the combined ``rl`` entrypoint.
+        """
+        has_teacher = self.teacher_rollout_model is not None
+        if self.use_sft_loss and not has_teacher:
+            raise ValueError(
+                "orchestrator.use_sft_loss = true requires orchestrator.teacher_rollout_model to be configured."
+            )
+        if has_teacher and not self.use_sft_loss:
+            raise ValueError("orchestrator.teacher_rollout_model requires orchestrator.use_sft_loss = true.")
+        if has_teacher and self.use_token_client:
+            raise ValueError(
+                "orchestrator.use_token_client must be false when orchestrator.teacher_rollout_model is configured."
+            )
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -876,16 +876,16 @@ class OrchestratorConfig(BaseConfig):
         ),
     ] = None
 
-    # Loss type for training (per-run override for hosted multi-tenant training)
-    loss_type: Annotated[
-        Literal["rl", "sft"],
+    # When True, trainer uses SFT loss instead of RL loss (per-run override for hosted multi-tenant training)
+    need_sft_loss: Annotated[
+        bool,
         Field(
             description=(
-                "Loss type for this run. 'rl' uses the trainer's configured RL loss (default). "
-                "'sft' uses SFT masked NLL loss and requires a teacher_rollout_model to be configured."
+                "When True, use SFT masked NLL loss instead of the trainer's configured RL loss. "
+                "Requires a teacher_rollout_model to be configured."
             ),
         ),
-    ] = "rl"
+    ] = False
 
     # The evaluation configuration
     eval: EvalConfig | None = None

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -419,23 +419,23 @@ class RLConfig(BaseConfig):
         return self
 
     @model_validator(mode="after")
-    def validate_external_rollout_mode(self):
-        if self.orchestrator.teacher_rollout_model is None:
-            return self
+    def validate_loss_type(self):
+        if self.orchestrator.loss_type == "sft":
+            if self.orchestrator.teacher_rollout_model is None:
+                raise ValueError(
+                    'orchestrator.loss_type = "sft" requires orchestrator.teacher_rollout_model to be configured.'
+                )
 
-        if self.trainer.loss.type != "sft":
-            raise ValueError('orchestrator.teacher_rollout_model is only supported when trainer.loss.type = "sft".')
-
-        if self.inference is not None:
-            raise ValueError(
-                "inference must be omitted when orchestrator.teacher_rollout_model is configured. "
-                "External rollout mode does not use the local inference server."
-            )
-
-        if self.orchestrator.use_token_client:
-            raise ValueError(
-                "orchestrator.use_token_client must be false when orchestrator.teacher_rollout_model is configured."
-            )
+        if self.orchestrator.teacher_rollout_model is not None:
+            if self.inference is not None:
+                raise ValueError(
+                    "inference must be omitted when orchestrator.teacher_rollout_model is configured. "
+                    "External rollout mode does not use the local inference server."
+                )
+            if self.orchestrator.use_token_client:
+                raise ValueError(
+                    "orchestrator.use_token_client must be false when orchestrator.teacher_rollout_model is configured."
+                )
 
         return self
 

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -419,26 +419,18 @@ class RLConfig(BaseConfig):
         return self
 
     @model_validator(mode="after")
-    def validate_loss_type(self):
-        if self.orchestrator.need_sft_loss:
-            if self.orchestrator.teacher_rollout_model is None:
-                raise ValueError(
-                    "orchestrator.need_sft_loss = true requires orchestrator.teacher_rollout_model to be configured."
-                )
+    def validate_external_rollout_inference(self):
+        """Forbid configuring a local inference server when rollouts come from an external teacher.
 
-        if self.orchestrator.teacher_rollout_model is not None:
-            if not self.orchestrator.need_sft_loss:
-                raise ValueError("orchestrator.teacher_rollout_model requires orchestrator.need_sft_loss = true.")
-            if self.inference is not None:
-                raise ValueError(
-                    "inference must be omitted when orchestrator.teacher_rollout_model is configured. "
-                    "External rollout mode does not use the local inference server."
-                )
-            if self.orchestrator.use_token_client:
-                raise ValueError(
-                    "orchestrator.use_token_client must be false when orchestrator.teacher_rollout_model is configured."
-                )
-
+        Orchestrator-only invariants (``use_sft_loss`` paired with ``teacher_rollout_model``,
+        and ``use_token_client`` coupling) live on ``OrchestratorConfig`` so the hosted
+        orchestrator entrypoint also enforces them.
+        """
+        if self.orchestrator.teacher_rollout_model is not None and self.inference is not None:
+            raise ValueError(
+                "inference must be omitted when orchestrator.teacher_rollout_model is configured. "
+                "External rollout mode does not use the local inference server."
+            )
         return self
 
     ### Auto-setup and validate shared configs

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -423,10 +423,12 @@ class RLConfig(BaseConfig):
         if self.orchestrator.need_sft_loss:
             if self.orchestrator.teacher_rollout_model is None:
                 raise ValueError(
-                    "orchestrator.sft_loss = true requires orchestrator.teacher_rollout_model to be configured."
+                    "orchestrator.need_sft_loss = true requires orchestrator.teacher_rollout_model to be configured."
                 )
 
         if self.orchestrator.teacher_rollout_model is not None:
+            if not self.orchestrator.need_sft_loss:
+                raise ValueError("orchestrator.teacher_rollout_model requires orchestrator.need_sft_loss = true.")
             if self.inference is not None:
                 raise ValueError(
                     "inference must be omitted when orchestrator.teacher_rollout_model is configured. "

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -420,10 +420,10 @@ class RLConfig(BaseConfig):
 
     @model_validator(mode="after")
     def validate_loss_type(self):
-        if self.orchestrator.loss_type == "sft":
+        if self.orchestrator.need_sft_loss:
             if self.orchestrator.teacher_rollout_model is None:
                 raise ValueError(
-                    'orchestrator.loss_type = "sft" requires orchestrator.teacher_rollout_model to be configured.'
+                    "orchestrator.sft_loss = true requires orchestrator.teacher_rollout_model to be configured."
                 )
 
         if self.orchestrator.teacher_rollout_model is not None:

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -477,6 +477,8 @@ async def orchestrate(config: OrchestratorConfig):
                 for sample in samples:
                     sample.advantage = rollout["advantage"]
                     sample.reward = rollout["reward"]
+                    if config.teacher_rollout_model is not None:
+                        sample.loss_type = "sft"
                     sample_decode_tokens = sum(sample.completion_mask)
                     sample_prefill_tokens = len(sample.prompt_ids) + len(sample.completion_mask) - sample_decode_tokens
                     rollout_decode_tokens += sample_decode_tokens

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -477,8 +477,8 @@ async def orchestrate(config: OrchestratorConfig):
                 for sample in samples:
                     sample.advantage = rollout["advantage"]
                     sample.reward = rollout["reward"]
-                    if config.teacher_rollout_model is not None:
-                        sample.loss_type = "sft"
+                    if config.loss_type == "sft":
+                        sample.sft_loss = True
                     sample_decode_tokens = sum(sample.completion_mask)
                     sample_prefill_tokens = len(sample.prompt_ids) + len(sample.completion_mask) - sample_decode_tokens
                     rollout_decode_tokens += sample_decode_tokens

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -477,7 +477,7 @@ async def orchestrate(config: OrchestratorConfig):
                 for sample in samples:
                     sample.advantage = rollout["advantage"]
                     sample.reward = rollout["reward"]
-                    if config.loss_type == "sft":
+                    if config.need_sft_loss:
                         sample.sft_loss = True
                     sample_decode_tokens = sum(sample.completion_mask)
                     sample_prefill_tokens = len(sample.prompt_ids) + len(sample.completion_mask) - sample_decode_tokens

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -477,7 +477,7 @@ async def orchestrate(config: OrchestratorConfig):
                 for sample in samples:
                     sample.advantage = rollout["advantage"]
                     sample.reward = rollout["reward"]
-                    if config.need_sft_loss:
+                    if config.use_sft_loss:
                         sample.sft_loss = True
                     sample_decode_tokens = sum(sample.completion_mask)
                     sample_prefill_tokens = len(sample.prompt_ids) + len(sample.completion_mask) - sample_decode_tokens

--- a/src/prime_rl/trainer/batch.py
+++ b/src/prime_rl/trainer/batch.py
@@ -76,7 +76,7 @@ def prepare_sample(training_example: TrainingSample, seq_len: int) -> MicroBatch
         pixel_values=training_example.pixel_values,
         pixel_values_shape=training_example.pixel_values_shape,
         image_grid_thw=training_example.image_grid_thw,
-        loss_type=training_example.loss_type,
+        sft_loss=training_example.sft_loss,
     )
 
 

--- a/src/prime_rl/trainer/batch.py
+++ b/src/prime_rl/trainer/batch.py
@@ -76,6 +76,7 @@ def prepare_sample(training_example: TrainingSample, seq_len: int) -> MicroBatch
         pixel_values=training_example.pixel_values,
         pixel_values_shape=training_example.pixel_values_shape,
         image_grid_thw=training_example.image_grid_thw,
+        loss_type=training_example.loss_type,
     )
 
 

--- a/src/prime_rl/trainer/batch.py
+++ b/src/prime_rl/trainer/batch.py
@@ -116,7 +116,10 @@ def packed_samples_into_micro_bs(
             if _is_multimodal_sample(bin_content):
                 continue
             # Check if sequence fits in this bin
-            if len(bin_content.input_ids) + len(sample.input_ids) <= max_seq_len:
+            if (
+                len(bin_content.input_ids) + len(sample.input_ids) <= max_seq_len
+                and bin_content.sft_loss == sample.sft_loss
+            ):
                 bin_content.input_ids.extend(sample.input_ids)
                 bin_content.loss_mask.extend(sample.loss_mask)
                 bin_content.advantages.extend(sample.advantages)

--- a/src/prime_rl/trainer/rl/data.py
+++ b/src/prime_rl/trainer/rl/data.py
@@ -39,6 +39,9 @@ class TensorMicroBatch(TypedDict):
     # mm_token_type_ids: token type per token [batch seq], int64 (0=text, 1=image, 2=video)
     mm_token_type_ids: Int[Tensor, "batch seq"] | None
 
+    # Per-batch loss override (e.g. "sft" for hard distill); None = use trainer config default
+    loss_type: str | None
+
 
 class FakeDataLoader:
     def __init__(self, config: FakeDataLoaderConfig, seq_len: int, dp_world_size: int):
@@ -111,6 +114,7 @@ class FakeDataLoader:
             "pixel_values": None,
             "image_grid_thw": None,
             "mm_token_type_ids": None,
+            "loss_type": None,
         }
 
     def _get_micro_batch(self, generator: torch.Generator) -> TensorMicroBatch:
@@ -137,6 +141,7 @@ class FakeDataLoader:
             "pixel_values": None,
             "image_grid_thw": None,
             "mm_token_type_ids": None,
+            "loss_type": None,
         }
 
 
@@ -218,4 +223,5 @@ class DataLoader:
             )  # [1, seq_len, layers, topk]
             if micro_batch.routed_experts is not None
             else None,
+            loss_type=micro_batch.loss_type,
         )

--- a/src/prime_rl/trainer/rl/data.py
+++ b/src/prime_rl/trainer/rl/data.py
@@ -39,8 +39,8 @@ class TensorMicroBatch(TypedDict):
     # mm_token_type_ids: token type per token [batch seq], int64 (0=text, 1=image, 2=video)
     mm_token_type_ids: Int[Tensor, "batch seq"] | None
 
-    # Per-batch loss override (e.g. "sft" for hard distill); None = use trainer config default
-    loss_type: str | None
+    # When True, trainer uses SFT loss instead of RL loss for this batch
+    sft_loss: bool
 
 
 class FakeDataLoader:
@@ -114,7 +114,7 @@ class FakeDataLoader:
             "pixel_values": None,
             "image_grid_thw": None,
             "mm_token_type_ids": None,
-            "loss_type": None,
+            "sft_loss": False,
         }
 
     def _get_micro_batch(self, generator: torch.Generator) -> TensorMicroBatch:
@@ -141,7 +141,7 @@ class FakeDataLoader:
             "pixel_values": None,
             "image_grid_thw": None,
             "mm_token_type_ids": None,
-            "loss_type": None,
+            "sft_loss": False,
         }
 
 
@@ -223,5 +223,5 @@ class DataLoader:
             )  # [1, seq_len, layers, topk]
             if micro_batch.routed_experts is not None
             else None,
-            loss_type=micro_batch.loss_type,
+            sft_loss=micro_batch.sft_loss,
         )

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -203,6 +203,7 @@ def compute_loss(
     loss_mask: list[Bool[Tensor, " seq_i"]],
     loss_fn: LossFn,
     loss_scale: int,
+    loss_type_override: str | None = None,
 ) -> tuple[Float[Tensor, ""], dict[str, Any]]:
     """
     Compute loss for packed sequences (batch size = 1, multiple sequences packed along sequence dimension).
@@ -215,10 +216,16 @@ def compute_loss(
         loss_mask: Loss mask for each sequence
         loss_fn: Per-sequence loss function
         loss_scale: Scale factor to normalize the loss
+        loss_type_override: If set, overrides loss_fn for this batch (e.g. "sft")
 
     Returns:
         Tuple of (scaled_loss, aggregated_metrics)
     """
+    # Per-batch loss override: select a different loss function if the batch requests it
+    effective_loss_fn = loss_fn
+    if loss_type_override == "sft":
+        effective_loss_fn = sft_loss_fn
+
     total_loss = 0.0
     all_metrics: dict[str, list[Tensor]] = {}
 
@@ -236,7 +243,7 @@ def compute_loss(
             loss_mask=mask,
         )
 
-        result = loss_fn(inputs)
+        result = effective_loss_fn(inputs)
 
         total_loss = total_loss + result.loss
 

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -203,7 +203,7 @@ def compute_loss(
     loss_mask: list[Bool[Tensor, " seq_i"]],
     loss_fn: LossFn,
     loss_scale: int,
-    loss_type_override: str | None = None,
+    sft_loss: bool = False,
 ) -> tuple[Float[Tensor, ""], dict[str, Any]]:
     """
     Compute loss for packed sequences (batch size = 1, multiple sequences packed along sequence dimension).
@@ -216,15 +216,12 @@ def compute_loss(
         loss_mask: Loss mask for each sequence
         loss_fn: Per-sequence loss function
         loss_scale: Scale factor to normalize the loss
-        loss_type_override: If set, overrides loss_fn for this batch (e.g. "sft")
+        sft_loss: If True, use SFT loss instead of the configured loss_fn for this batch
 
     Returns:
         Tuple of (scaled_loss, aggregated_metrics)
     """
-    # Per-batch loss override: select a different loss function if the batch requests it
-    effective_loss_fn = loss_fn
-    if loss_type_override == "sft":
-        effective_loss_fn = sft_loss_fn
+    effective_loss_fn = sft_loss_fn if sft_loss else loss_fn
 
     total_loss = 0.0
     all_metrics: dict[str, list[Tensor]] = {}

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -444,6 +444,7 @@ def train(config: TrainerConfig):
                 loss_mask=loss_mask.squeeze().split(response_lengths),
                 loss_fn=loss_fn,
                 loss_scale=loss_scale,
+                loss_type_override=micro_batch.get("loss_type"),
             )
 
             # Backward pass

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -444,7 +444,7 @@ def train(config: TrainerConfig):
                 loss_mask=loss_mask.squeeze().split(response_lengths),
                 loss_fn=loss_fn,
                 loss_scale=loss_scale,
-                loss_type_override=micro_batch.get("loss_type"),
+                sft_loss=micro_batch.get("sft_loss", False),
             )
 
             # Backward pass

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -444,7 +444,7 @@ def train(config: TrainerConfig):
                 loss_mask=loss_mask.squeeze().split(response_lengths),
                 loss_fn=loss_fn,
                 loss_scale=loss_scale,
-                sft_loss=micro_batch.get("sft_loss", False),
+                sft_loss=micro_batch["sft_loss"],
             )
 
             # Backward pass

--- a/src/prime_rl/transport/types.py
+++ b/src/prime_rl/transport/types.py
@@ -26,7 +26,7 @@ class TrainingSample(msgspec.Struct, array_like=True, gc=False, omit_defaults=Tr
     # mm_token_type_ids: token type ids per token [batch seq], int64 (0=text, 1=image, 2=video)
     mm_token_type_ids: list[int] | None = None
 
-    loss_type: str | None = None  # Per-sample loss override (e.g. "sft" for hard distill)
+    sft_loss: bool = False  # When True, trainer uses SFT loss instead of RL loss for this sample
 
 
 class TrainingBatch(msgspec.Struct, array_like=True, gc=False, omit_defaults=True):
@@ -59,4 +59,4 @@ class MicroBatch(msgspec.Struct, array_like=True, gc=False, omit_defaults=True):
     # mm_token_type_ids: token type ids per token [batch seq], int64 (0=text, 1=image, 2=video)
     mm_token_type_ids: list[int] | None = None
 
-    loss_type: str | None = None  # Per-batch loss override (e.g. "sft" for hard distill)
+    sft_loss: bool = False  # When True, trainer uses SFT loss instead of RL loss for this batch

--- a/src/prime_rl/transport/types.py
+++ b/src/prime_rl/transport/types.py
@@ -26,6 +26,8 @@ class TrainingSample(msgspec.Struct, array_like=True, gc=False, omit_defaults=Tr
     # mm_token_type_ids: token type ids per token [batch seq], int64 (0=text, 1=image, 2=video)
     mm_token_type_ids: list[int] | None = None
 
+    loss_type: str | None = None  # Per-sample loss override (e.g. "sft" for hard distill)
+
 
 class TrainingBatch(msgspec.Struct, array_like=True, gc=False, omit_defaults=True):
     """A batch of training examples with metadata for transport."""
@@ -56,3 +58,5 @@ class MicroBatch(msgspec.Struct, array_like=True, gc=False, omit_defaults=True):
     image_grid_thw: list[list[int]] | None = None
     # mm_token_type_ids: token type ids per token [batch seq], int64 (0=text, 1=image, 2=video)
     mm_token_type_ids: list[int] | None = None
+
+    loss_type: str | None = None  # Per-batch loss override (e.g. "sft" for hard distill)

--- a/tests/unit/orchestrator/test_batch.py
+++ b/tests/unit/orchestrator/test_batch.py
@@ -6,7 +6,7 @@ from prime_rl.transport.types import TrainingSample
 
 @pytest.fixture
 def make_training_example():
-    def _make_training_example(temperature: float = 1.0) -> TrainingSample:
+    def _make_training_example(temperature: float = 1.0, sft_loss: bool = False) -> TrainingSample:
         return TrainingSample(
             prompt_ids=[1, 2],
             prompt_mask=[False, False],
@@ -16,6 +16,7 @@ def make_training_example():
             completion_temperatures=[temperature, temperature],  # Per-token temperatures
             teacher_logprobs=[0.0, 0.0, 0.0, 0.0],
             advantage=1.0,
+            sft_loss=sft_loss,
         )
 
     return _make_training_example
@@ -77,6 +78,31 @@ def test_prepare_batch_packs_different_temperatures(make_training_example):
     assert flat_batches[0].temperatures[:4] == [0.7, 0.7, 0.7, 0.7]
     # Second sample (4 tokens): all get temp 1.1
     assert flat_batches[0].temperatures[4:8] == [1.1, 1.1, 1.1, 1.1]
+
+
+def test_prepare_sample_propagates_sft_loss(make_training_example):
+    example = make_training_example(sft_loss=True)
+
+    micro_batch = prepare_sample(example, seq_len=16)
+
+    assert micro_batch.sft_loss is True
+
+
+def test_prepare_batch_does_not_pack_mixed_sft_loss(make_training_example):
+    rl_example = make_training_example(sft_loss=False)
+    sft_example = make_training_example(sft_loss=True)
+
+    batches_per_gpu = prepare_batch(
+        rollouts=[rl_example, sft_example],
+        seq_len=16,
+        num_train_workers=1,
+        idxs=[0, 0],
+        num_loras=1,
+    )
+
+    flat_batches = [batch for worker_batches in batches_per_gpu for batch in worker_batches]
+    assert len(flat_batches) == 2
+    assert {batch.sft_loss for batch in flat_batches} == {False, True}
 
 
 def test_prepare_sample_with_routed_experts():

--- a/tests/unit/train/rl/test_loss.py
+++ b/tests/unit/train/rl/test_loss.py
@@ -97,6 +97,29 @@ def test_sft_loss_matches_masked_nll():
     assert "nll" in metrics
 
 
+def test_sft_loss_override_uses_masked_nll_with_default_loss_config():
+    trainer_logprobs = [torch.tensor([-0.1, -0.5, -0.2], dtype=torch.float32).cuda()]
+    inference_logprobs = [torch.zeros(3, dtype=torch.float32).cuda()]
+    advantages = [torch.ones(3, dtype=torch.float32).cuda()]
+    loss_mask = [torch.tensor([True, False, True], dtype=torch.bool).cuda()]
+
+    loss_fn = setup_loss_fn(DefaultLossConfig())
+    loss, metrics = compute_loss(
+        trainer_logprobs=trainer_logprobs,
+        inference_logprobs=inference_logprobs,
+        teacher_logprobs=None,
+        advantages=advantages,
+        loss_mask=loss_mask,
+        loss_fn=loss_fn,
+        loss_scale=2,
+        sft_loss=True,
+    )
+
+    assert torch.isclose(loss, torch.tensor(0.15, device=loss.device), atol=1e-6)
+    assert "nll" in metrics
+    assert "mismatch_kl" not in metrics
+
+
 def _dummy_custom_loss(inputs: LossInputs, multiplier: float = 1.0) -> LossOutputs:
     """A simple custom loss for testing."""
     loss = (inputs.trainer_logprobs[inputs.loss_mask].sum() * multiplier).abs()


### PR DESCRIPTION
Add loss_type field to TrainingSample and MicroBatch transport types so the orchestrator can stamp samples with a loss override (e.g. "sft") that the trainer dispatches per-batch. This allows a shared multi-tenant trainer to handle both RL and SFT distill runs on the same cluster.

When teacher_rollout_model is configured, the orchestrator sets loss_type="sft" on each sample. The trainer's compute_loss checks the field and swaps to sft_loss_fn for that batch, falling back to the configured default when None (fully backward compatible).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes training sample transport and loss dispatch to allow per-batch switching to `sft_loss_fn`, which can alter optimization behavior and packing semantics if misconfigured. Adds stricter config validation around external teacher rollout mode that may break existing configs until updated.
> 
> **Overview**
> Enables hosted hard-distill runs to **force SFT loss per micro-batch** via a new `orchestrator.use_sft_loss` flag, with the orchestrator stamping `TrainingSample.sft_loss` and the trainer dispatching `compute_loss` to `sft_loss_fn` when set.
> 
> Tightens config validation by requiring `orchestrator.teacher_rollout_model` and `orchestrator.use_sft_loss` to be configured together (and `use_token_client=false` in that mode), and removes the old coupling to `trainer.loss.type="sft"`.
> 
> Propagates the new `sft_loss` field through `TrainingSample`/`MicroBatch`, prevents packing sequences with mixed `sft_loss` values into the same micro-batch, and updates docs, example config, changelog, and unit tests accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a56ae24b7f01f31d2c006fb913ff09f19e100f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->