### PR TITLE
Add experimental subconfig to user-facing configs

### DIFF
--- a/src/prime_rl/configs/inference.py
+++ b/src/prime_rl/configs/inference.py
@@ -244,6 +244,10 @@ InferenceDeploymentConfig: TypeAlias = Annotated[
 ]
 
 
+class InferenceExperimentalConfig(BaseConfig):
+    """Experimental features for inference."""
+
+
 class InferenceConfig(BaseConfig):
     """Configures inference."""
 
@@ -412,6 +416,11 @@ class InferenceConfig(BaseConfig):
     output_dir: Annotated[Path, Field(description="Directory for SLURM logs and generated scripts.")] = Path("outputs")
 
     dry_run: Annotated[bool, Field(description="Only validate and dump resolved configs and exit early.")] = False
+
+    experimental: Annotated[
+        InferenceExperimentalConfig,
+        Field(description="Experimental features for inference."),
+    ] = InferenceExperimentalConfig()
 
     @model_validator(mode="after")
     def validate_multi_node_requires_slurm(self):

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -809,6 +809,10 @@ WeightBroadcastConfig: TypeAlias = Annotated[
 ]
 
 
+class OrchestratorExperimentalConfig(BaseConfig):
+    """Experimental features for the orchestrator."""
+
+
 class TeacherModelConfig(BaseConfig):
     """Configures the teacher model for computing teacher logprobs (e.g. for distillation)."""
 
@@ -1028,6 +1032,11 @@ class OrchestratorConfig(BaseConfig):
             description="Whether to use the token-in-token-out (TITO) client for training across all environments. WARNING: Only use this if your environment has a linear history and the chat template has the extension property (i.e. no tokens are ever removed or inserted by the chat template)"
         ),
     ] = True
+
+    experimental: Annotated[
+        OrchestratorExperimentalConfig,
+        Field(description="Experimental features for the orchestrator."),
+    ] = OrchestratorExperimentalConfig()
 
     @model_validator(mode="before")
     @classmethod

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -52,6 +52,10 @@ from prime_rl.utils.validation import (
 )
 
 
+class RLExperimentalConfig(BaseConfig):
+    """Experimental features for RL training."""
+
+
 class SharedLogConfig(BaseConfig):
     """Configures shared logging."""
 
@@ -349,6 +353,11 @@ class RLConfig(BaseConfig):
     slurm: Annotated[SlurmConfig | None, Field(description="SLURM configuration. If None, will run locally.")] = None
 
     dry_run: Annotated[bool, Field(description="Only validate and dump resolved configs and exit early.")] = False
+
+    experimental: Annotated[
+        RLExperimentalConfig,
+        Field(description="Experimental features for RL training."),
+    ] = RLExperimentalConfig()
 
     ### Validate configs (e.g. raise for unsupported (combinations of) configs)
 

--- a/src/prime_rl/configs/sft.py
+++ b/src/prime_rl/configs/sft.py
@@ -159,6 +159,10 @@ SFTDeploymentConfig: TypeAlias = Annotated[
 ]
 
 
+class SFTExperimentalConfig(BaseConfig):
+    """Experimental features for SFT training."""
+
+
 class SFTConfig(BaseConfig):
     """Configures the SFT trainer"""
 
@@ -269,6 +273,11 @@ class SFTConfig(BaseConfig):
     ] = None
 
     dry_run: Annotated[bool, Field(description="Only validate and dump resolved configs and exit early.")] = False
+
+    experimental: Annotated[
+        SFTExperimentalConfig,
+        Field(description="Experimental features for SFT training."),
+    ] = SFTExperimentalConfig()
 
     ### Pre-validation normalization
 

--- a/src/prime_rl/configs/trainer.py
+++ b/src/prime_rl/configs/trainer.py
@@ -719,6 +719,10 @@ WeightBroadcastConfig: TypeAlias = Annotated[
 ]
 
 
+class TrainerExperimentalConfig(BaseConfig):
+    """Experimental features for the trainer."""
+
+
 class TrainerConfig(BaseConfig):
     """Configures the RL trainer"""
 
@@ -836,6 +840,11 @@ class TrainerConfig(BaseConfig):
             description="The maximum number of concurrent runs to allow. If 1, then only one run will be allowed at a time.",
         ),
     ] = 1
+
+    experimental: Annotated[
+        TrainerExperimentalConfig,
+        Field(description="Experimental features for the trainer."),
+    ] = TrainerExperimentalConfig()
 
     @model_validator(mode="after")
     def deepep_disables_grad_clipping(self):


### PR DESCRIPTION
## Summary

Introduces empty experimental config classes for each user-facing config to provide a structured place for future experimental features:

- `RLExperimentalConfig` for `RLConfig`
- `InferenceExperimentalConfig` for `InferenceConfig`
- `OrchestratorExperimentalConfig` for `OrchestratorConfig`
- `SFTExperimentalConfig` for `SFTConfig`
- `TrainerExperimentalConfig` for `TrainerConfig`

Each config now has an `experimental` field with a default instance of its corresponding experimental config. These are intentionally left empty for now.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk schema extension: adds new optional `experimental` sections to multiple Pydantic configs, which may affect config serialization/validation but does not change runtime behavior (fields are empty and defaulted).
> 
> **Overview**
> Adds a new `experimental` sub-config to each user-facing config (`RLConfig`, `InferenceConfig`, `OrchestratorConfig`, `SFTConfig`, `TrainerConfig`) by introducing corresponding empty `*ExperimentalConfig` classes and defaulting a new `experimental` field.
> 
> This extends the public config schema to provide a dedicated namespace for future experimental flags without changing existing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9c1f0ea80ada7a84cccdec8f9bbbd60558955d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->