### PR TITLE
Support runtime verifiers version override

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -8,7 +8,7 @@ ulimit -n 32000 2>/dev/null || echo "Warning: Could not set ulimit (may need --u
 # VERIFIERS_VERSION can be a git tag, branch, or commit hash.
 if [ -n "$VERIFIERS_VERSION" ]; then
     echo "Installing verifiers version: $VERIFIERS_VERSION"
-    uv pip install --reinstall \
+    uv pip install --reinstall-package verifiers \
         "verifiers @ git+https://github.com/PrimeIntellect-ai/verifiers.git@${VERIFIERS_VERSION}"
 fi
 

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -4,5 +4,13 @@ set -e
 # Set higher ulimit for file descriptors to prevent API timeout issues
 ulimit -n 32000 2>/dev/null || echo "Warning: Could not set ulimit (may need --ulimit flag in docker run)"
 
+# Allow runtime override of the verifiers package version.
+# VERIFIERS_VERSION can be a git tag, branch, or commit hash.
+if [ -n "$VERIFIERS_VERSION" ]; then
+    echo "Installing verifiers version: $VERIFIERS_VERSION"
+    uv pip install --reinstall --no-deps \
+        "verifiers @ git+https://github.com/PrimeIntellect-ai/verifiers.git@${VERIFIERS_VERSION}"
+fi
+
 # Execute the main command
 exec "$@"

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -8,7 +8,7 @@ ulimit -n 32000 2>/dev/null || echo "Warning: Could not set ulimit (may need --u
 # VERIFIERS_VERSION can be a git tag, branch, or commit hash.
 if [ -n "$VERIFIERS_VERSION" ]; then
     echo "Installing verifiers version: $VERIFIERS_VERSION"
-    uv pip install --reinstall --no-deps \
+    uv pip install --reinstall \
         "verifiers @ git+https://github.com/PrimeIntellect-ai/verifiers.git@${VERIFIERS_VERSION}"
 fi
 


### PR DESCRIPTION
- Adds VERIFIERS_VERSION env var support to the docker entrypoint
- When set, reinstalls verifiers from the specified git ref (tag/branch/commit) before starting
- Allows platform to let users override the baked-in verifiers version per run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes container startup behavior to optionally reinstall a dependency from a user-supplied git ref, which can impact reproducibility and introduce supply-chain/availability failures at runtime.
> 
> **Overview**
> Adds support for a `VERIFIERS_VERSION` environment variable in `scripts/docker-entrypoint.sh` to **optionally reinstall** the `verifiers` Python package from the `PrimeIntellect-ai/verifiers` GitHub repo at a specified tag/branch/commit before executing the container command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 086ab3d60d1876cc4f0c547d63616510af75062f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->