### PR TITLE
feat: add GLM-5.1 to tool call parser auto-detection

### DIFF
--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -39,6 +39,9 @@ MODEL_TOOL_CALL_PARSER: dict[str, str] = {
     # GLM-5
     "zai-org/GLM-5": "glm47",
     "zai-org/GLM-5-FP8": "glm47",
+    # GLM-5.1
+    "zai-org/GLM-5.1": "glm47",
+    "zai-org/GLM-5.1-FP8": "glm47",
     # MiniMax M2
     "MiniMaxAI/MiniMax-M2": "minimax_m2",
     "MiniMaxAI/MiniMax-M2.1": "minimax_m2",

--- a/tests/unit/test_tool_call_parser.py
+++ b/tests/unit/test_tool_call_parser.py
@@ -13,6 +13,8 @@ from prime_rl.inference.vllm.server import resolve_tool_call_parser
         # GLM-4.7
         ("zai-org/GLM-4.7", "glm47"),
         ("zai-org/GLM-4.7-Flash", "glm47"),
+        # GLM-5.1
+        ("zai-org/GLM-5.1", "glm47"),
         # MiniMax
         ("MiniMaxAI/MiniMax-M2", "minimax_m2"),
         ("MiniMaxAI/MiniMax-M2.1", "minimax_m2"),


### PR DESCRIPTION
## Summary
- Add `zai-org/GLM-5.1` and `zai-org/GLM-5.1-FP8` to the tool call parser map using the `glm47` parser (same as GLM-5)
- Add test coverage for GLM-5.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds two model-name mappings and a small unit test; no changes to request handling or inference logic.
> 
> **Overview**
> Adds `zai-org/GLM-5.1` and `zai-org/GLM-5.1-FP8` to `MODEL_TOOL_CALL_PARSER`, mapping them to the existing `glm47` tool call parser.
> 
> Updates the unit parametrized test to assert `resolve_tool_call_parser(..., "auto")` returns `glm47` for `zai-org/GLM-5.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb52cfe2633953eb6b97b636adee321871c5dd46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->