### PR TITLE
chore: drop trajectory from saved rollout JSONL files

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -398,7 +398,9 @@ async def orchestrate(config: OrchestratorConfig):
             eval_rollouts = [o for outputs in eval_results for o in outputs]
             if eval_rollouts:
                 step_path = get_step_path(get_rollout_dir(config.output_dir), progress.step)
-                await asyncio.to_thread(save_rollouts, eval_rollouts, step_path / "eval_rollouts.jsonl")
+                await asyncio.to_thread(
+                    save_rollouts, eval_rollouts, step_path / "eval_rollouts.jsonl", exclude_keys={"trajectory"}
+                )
 
             # Resume weight updates
             scheduler.checkpoint_ready.set()
@@ -416,7 +418,9 @@ async def orchestrate(config: OrchestratorConfig):
 
         # Save train rollouts to disk (fire-and-forget background thread)
         step_path = get_step_path(get_rollout_dir(config.output_dir), progress.step)
-        await asyncio.to_thread(save_rollouts, train_rollouts, step_path / "train_rollouts.jsonl")
+        await asyncio.to_thread(
+            save_rollouts, train_rollouts, step_path / "train_rollouts.jsonl", exclude_keys={"trajectory"}
+        )
 
         # VLM: offload base64 images to disk immediately to free memory
         if is_vlm:
@@ -732,7 +736,9 @@ async def orchestrate(config: OrchestratorConfig):
         eval_rollouts = [o for outputs in eval_results for o in outputs]
         if eval_rollouts:
             step_path = get_step_path(get_rollout_dir(config.output_dir), progress.step)
-            await asyncio.to_thread(save_rollouts, eval_rollouts, step_path / "eval_rollouts.jsonl")
+            await asyncio.to_thread(
+                save_rollouts, eval_rollouts, step_path / "eval_rollouts.jsonl", exclude_keys={"trajectory"}
+            )
 
     # Log final (immutable) samples and distributions to monitor(s)
     monitor.log_final_samples()

--- a/src/prime_rl/orchestrator/vf_utils.py
+++ b/src/prime_rl/orchestrator/vf_utils.py
@@ -59,12 +59,13 @@ def get_model_completion_len(output: vf.RolloutOutput) -> int:
     return sum(len(step["tokens"]["completion_ids"]) for step in output["trajectory"] if step.get("tokens"))
 
 
-def save_rollouts(rollouts: list[vf.RolloutOutput], path: Path) -> None:
+def save_rollouts(rollouts: list[vf.RolloutOutput], path: Path, exclude_keys: set[str] | None = None) -> None:
     """Save rollouts to a JSONL file using verifiers serialization."""
     path.parent.mkdir(parents=True, exist_ok=True)
     with open(path, "w") as f:
         for rollout in rollouts:
-            json.dump(rollout, f, default=make_serializable)
+            row = {k: v for k, v in rollout.items() if k not in exclude_keys} if exclude_keys else rollout
+            json.dump(row, f, default=make_serializable)
             f.write("\n")
 
 


### PR DESCRIPTION
## Summary

- Excludes the `trajectory` key when saving train/eval rollout JSONL files
- `trajectory` accounts for >86% (in reverse text, for agentic envs this will be even more) of each file's size
- Tested on `reverse_text` example (5 steps): rollout files went from **7.1 MB → 1.0 MB** total (**-86% per file**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the on-disk rollout JSONL schema by dropping `trajectory`, which could break any downstream analysis tooling that expects it, though it does not affect training/eval execution logic.
> 
> **Overview**
> Rollout persistence now drops the `trajectory` field when writing `train_rollouts.jsonl` and `eval_rollouts.jsonl`, significantly reducing artifact size.
> 
> `save_rollouts` was updated to accept an `exclude_keys` set and the orchestrator now passes `exclude_keys={"trajectory"}` for periodic and final eval, as well as training rollouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e262e93b98a79d55a4dbc08f6c9845ab1ed4c88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->