### PR TITLE
fix: handle non-serializable objects in JSON log sink

### DIFF
--- a/src/prime_rl/utils/logger.py
+++ b/src/prime_rl/utils/logger.py
@@ -55,7 +55,7 @@ def build_log_entry(record) -> dict:
 def json_sink(message) -> None:
     """Sink that outputs flat JSON to stdout for log aggregation (Loki, Grafana, etc.)."""
     log_entry = build_log_entry(message.record)
-    sys.stdout.write(json_module.dumps(log_entry) + "\n")
+    sys.stdout.write(json_module.dumps(log_entry, default=str) + "\n")
     sys.stdout.flush()
 
 


### PR DESCRIPTION
json_sink crashes when verifier logs contain objects that aren't JSON-serializable (e.g. reward details, rollout metadata from verifiers). Adds default=str fallback to json.dumps, matching the pattern used in monitors and other parts of the codebase.

- Fixes JSON logging mode so you don't have to switch to raw mode to see verifier output
- One-line change in json_sink()

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line change to JSON log serialization that only affects logging output and error handling.
> 
> **Overview**
> Makes JSON logging more robust by updating `json_sink()` to call `json.dumps(..., default=str)`, so log entries containing non-JSON-serializable objects no longer crash the sink and are stringified instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b1e53060857f28b273f91882aaa47161444f85c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->