### PR TITLE
fix 2.5 -> qwen

### DIFF
--- a/examples/qwen30b_math/README.md
+++ b/examples/qwen30b_math/README.md
@@ -1,6 +1,6 @@
-# Qwen 2.5 32B Math
+# Qwen 3 30B Math
 
-This example guides you through RL training [Qwen2.5-32B](https://huggingface.co/Qwen/Qwen2.5-32B) on math tasks.
+This example guides you through RL training [Qwen3-30B-A3B-Thinking-2507](https://huggingface.co/Qwen/Qwen3-30B-A3B-Thinking-2507) on math tasks.
 
 ## Requirements
 

--- a/examples/qwen30b_swe/README.md
+++ b/examples/qwen30b_swe/README.md
@@ -1,6 +1,6 @@
-# Qwen 2.5 32B SWE
+# Qwen 3 32B SWE
 
-This example guides you through RL training [Qwen2.5-32B](https://huggingface.co/Qwen/Qwen2.5-32B) on agentic SWE tasks.
+This example guides you through RL training [Qwen3-30B-A3B-Thinking-2507](https://huggingface.co/Qwen/Qwen3-30B-A3B-Thinking-2507) on agentic SWE tasks.
 
 ## Requirements
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes updating model names/links; no runtime or training logic is modified.
> 
> **Overview**
> Updates the `qwen30b_math` and `qwen30b_swe` example READMEs to reference **Qwen 3** instead of **Qwen 2.5**, including new titles and swapping the linked base model to `Qwen3-30B-A3B-Thinking-2507`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c36f7c3662684589e989d7e8ca5fe306a1e0638f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->