### PR TITLE
refactor: propagate shared config via before validator

### DIFF
--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -1089,6 +1089,12 @@ class OrchestratorConfig(BaseConfig):
         return self
 
     @model_validator(mode="after")
+    def auto_setup_session_headers(self):
+        """Ensure X-Session-ID header is always set for sticky DP-aware routing at the inference router."""
+        self.client.extra_headers_from_state.setdefault("X-Session-ID", "example_id")
+        return self
+
+    @model_validator(mode="after")
     def validate_unique_filter_types(self):
         types = [f.type for f in self.filters]
         if len(types) != len(set(types)):

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -468,6 +468,33 @@ class RLConfig(BaseConfig):
 
         data = deepcopy(data)
 
+        # tyro may pass already-constructed sub-config instances rather than
+        # raw dicts (when merging CLI overrides on top of a TOML default). Dump
+        # them back to dicts, dropping fields still at their class defaults so
+        # `fill` can still tell "unset" apart from "set to a default". Discriminator
+        # `type` keys are preserved at every level so pydantic can pick the right
+        # union variant when it re-validates (otherwise `type="multi_node"` gets
+        # stripped as "equals default" and the nested config falls back to the
+        # wrong union variant).
+        def _dump_preserving_discriminators(obj: Any) -> Any:
+            if isinstance(obj, BaseModel):
+                dumped = obj.model_dump(exclude_defaults=True)
+                if "type" in type(obj).model_fields and "type" not in dumped:
+                    dumped["type"] = getattr(obj, "type")
+                for field_name in type(obj).model_fields:
+                    if field_name in dumped:
+                        dumped[field_name] = _dump_preserving_discriminators(getattr(obj, field_name))
+                return dumped
+            if isinstance(obj, list):
+                return [_dump_preserving_discriminators(item) for item in obj]
+            if isinstance(obj, dict):
+                return {k: _dump_preserving_discriminators(v) for k, v in obj.items()}
+            return obj
+
+        for key, value in list(data.items()):
+            if isinstance(value, BaseModel):
+                data[key] = _dump_preserving_discriminators(value)
+
         def get(path: str) -> Any | None:
             """Read a dotted path (e.g. `model.name`) from raw config data. Returns
             None if any intermediate key is missing or not a dict."""

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -6,9 +6,6 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from prime_rl.configs.inference import InferenceConfig
 from prime_rl.configs.inference import WeightBroadcastConfig as InferenceWeightBroadcastConfig
 from prime_rl.configs.orchestrator import (
-    CheckpointConfig as OrchestratorCheckpointConfig,
-)
-from prime_rl.configs.orchestrator import (
     FileSystemWeightBroadcastConfig as OrchestratorFileSystemWeightBroadcastConfig,
 )
 from prime_rl.configs.orchestrator import (
@@ -20,17 +17,12 @@ from prime_rl.configs.orchestrator import (
 from prime_rl.configs.shared import (
     SlurmConfig,
     VLMConfig,
-    WandbConfig,
-    WandbWithExtrasConfig,
 )
 from prime_rl.configs.trainer import (
     BenchConfig,
     FakeDataLoaderConfig,
     TokenizerConfig,
     TrainerConfig,
-)
-from prime_rl.configs.trainer import (
-    CheckpointConfig as TrainerCheckpointConfig,
 )
 from prime_rl.configs.trainer import (
     FileSystemWeightBroadcastConfig as TrainerFileSystemWeightBroadcastConfig,
@@ -448,16 +440,37 @@ class RLConfig(BaseConfig):
 
         return self
 
-    ### Propagate shared configs (before sub-config construction)
+    ### Auto-setup shared configs (before sub-config construction)
 
     @model_validator(mode="before")
     @classmethod
-    def _propagate_shared_config(cls, data: Any) -> Any:
+    def auto_setup_shared_configs(cls, data: Any) -> Any:
         """Propagate shared top-level config values into sub-config dicts.
 
-        Runs before sub-configs are constructed so their validators see
-        the final values (e.g. parser auto-resolution needs the model name).
-        Only sets values that the user didn't explicitly provide.
+        Runs before sub-configs are constructed so their own validators see the
+        final values — e.g. a ModelConfig validator that auto-resolves the parser
+        from the model name needs the propagated name at construction time, not
+        after.
+
+        Shared configs handled here (fill-if-absent: sub-configs win):
+          - `model.name`, `model.vlm`        → trainer / orchestrator / inference
+          - `log.level`, `log.json_logging`  → trainer / orchestrator
+          - `max_steps`, `max_async_level`   → trainer / orchestrator
+          - `output_dir`                     → trainer (verbatim) / orchestrator (`/run_default`)
+          - `[ckpt]` fields                  → trainer / orchestrator (presence enables both)
+          - `[wandb]` fields + shared/-suffix → trainer / orchestrator (presence enables both)
+          - `[tokenizer]` fields             → trainer / orchestrator (+ chat_template to inference)
+          - `seq_len`                        → trainer.model / orchestrator
+
+        Sub-config values always take precedence; any mismatch between shared
+        and sub-config, or between sub-configs themselves, is caught by
+        `validate_shared_configs` (after-validator) which runs the full suite
+        of `validate_shared_*` checks post-construction.
+
+        To add a new shared field, typically you only need a `propagate(...)`
+        call here plus a `validate_shared_*` call in `validate_shared_configs`.
+        If the field drives arithmetic or reads computed values from other
+        sub-configs, keep its auto-setup in an after-validator instead.
         """
         if not isinstance(data, dict):
             return data
@@ -465,13 +478,27 @@ class RLConfig(BaseConfig):
 
         data = copy.deepcopy(data)
 
-        def propagate(target_path: str, value: Any) -> None:
-            """Set a dotted path (e.g. 'trainer.model.name') in data if not already present.
+        def read(path: str) -> Any | None:
+            """Read a dotted path from data, returning None if any intermediate is missing or not a dict."""
+            node: Any = data
+            for part in path.split("."):
+                if not isinstance(node, dict) or part not in node:
+                    return None
+                node = node[part]
+            return node
 
+        def propagate(path: str, value: Any) -> None:
+            """Set a value (e.g. 'trainer.model.name') in raw, if not already present.
+
+            No-op if value is None (i.e. source field was unset).
+            Sub-config values take precedence; mismatches are caught by the
+            corresponding validate_shared_* after-validator.
             Only creates intermediate dicts for nested keys (e.g. 'model' in
             'trainer.model.name'), never for the top-level sub-config itself.
             """
-            parts = target_path.split(".")
+            if value is None:
+                return
+            parts = path.split(".")
             # Don't create the top-level sub-config if it doesn't exist
             if parts[0] not in data or not isinstance(data[parts[0]], dict):
                 return
@@ -484,191 +511,95 @@ class RLConfig(BaseConfig):
                 node[parts[-1]] = value
 
         # [model] → sub-config model dicts
-        shared_model = data.get("model")
-        if isinstance(shared_model, dict):
-            model_name = shared_model.get("name")
-            model_vlm = shared_model.get("vlm")
-
-            if model_name:
-                propagate("trainer.model.name", model_name)
-                propagate("inference.model.name", model_name)
-                # Orchestrator follows inference model name (which may differ from shared)
-                inf_model = (
-                    data.get("inference", {}).get("model", {}) if isinstance(data.get("inference"), dict) else {}
-                )
-                propagate("orchestrator.model.name", inf_model.get("name", model_name))
-            if model_vlm is not None:
-                for target in ("trainer.model.vlm", "inference.model.vlm", "orchestrator.model.vlm"):
-                    propagate(target, model_vlm)
+        model_name = read("model.name")
+        propagate("trainer.model.name", model_name)
+        propagate("inference.model.name", model_name)
+        # Orchestrator follows inference model name (which may differ from shared)
+        propagate("orchestrator.model.name", read("inference.model.name") or model_name)
+        for target in ("trainer.model.vlm", "inference.model.vlm", "orchestrator.model.vlm"):
+            propagate(target, read("model.vlm"))
 
         # [log] → trainer/orchestrator log dicts
-        shared_log = data.get("log")
-        if isinstance(shared_log, dict):
-            for key in ("level", "json_logging"):
-                value = shared_log.get(key)
-                if value is not None:
-                    propagate(f"trainer.log.{key}", value)
-                    propagate(f"orchestrator.log.{key}", value)
+        for key in ("level", "json_logging"):
+            propagate(f"trainer.log.{key}", read(f"log.{key}"))
+            propagate(f"orchestrator.log.{key}", read(f"log.{key}"))
 
         # Scalar shared fields → trainer/orchestrator
         for field in ("max_steps", "max_async_level"):
-            value = data.get(field)
-            if value is not None:
-                propagate(f"trainer.{field}", value)
-                propagate(f"orchestrator.{field}", value)
+            propagate(f"trainer.{field}", read(field))
+            propagate(f"orchestrator.{field}", read(field))
+
+        # [output_dir] → trainer/orchestrator (orchestrator derives a "run_default" subdir)
+        output_dir = read("output_dir")
+        propagate("trainer.output_dir", output_dir)
+        propagate("orchestrator.output_dir", f"{output_dir}/run_default" if output_dir is not None else None)
+
+        # [ckpt] → trainer/orchestrator ckpt dicts (output_dir is trainer-only).
+        # Presence of shared [ckpt] (even empty) enables ckpt on both sub-configs.
+        if read("ckpt") is not None:
+            propagate("trainer.ckpt", {})
+            propagate("orchestrator.ckpt", {})
+        propagate("trainer.ckpt.output_dir", read("ckpt.output_dir"))
+        for field in ("interval", "resume_step", "keep_last", "keep_interval"):
+            propagate(f"trainer.ckpt.{field}", read(f"ckpt.{field}"))
+            propagate(f"orchestrator.ckpt.{field}", read(f"ckpt.{field}"))
+
+        # [wandb] → trainer/orchestrator wandb dicts.
+        # Presence of shared [wandb] (even empty) enables wandb on both sub-configs.
+        if read("wandb") is not None:
+            propagate("trainer.wandb", {})
+            propagate("orchestrator.wandb", {})
+        for field in ("project", "offline"):
+            propagate(f"trainer.wandb.{field}", read(f"wandb.{field}"))
+            propagate(f"orchestrator.wandb.{field}", read(f"wandb.{field}"))
+
+        # W&B name: in shared mode (the default), both sub-configs use the same
+        # name. In non-shared mode (wandb.shared = false), suffix with -trainer/
+        # -orchestrator so the runs are distinguishable.
+        wandb_name = read("wandb.name")
+        if wandb_name:
+            non_shared = read("wandb.shared") is False
+            propagate("trainer.wandb.name", f"{wandb_name}-trainer" if non_shared else wandb_name)
+            propagate("orchestrator.wandb.name", f"{wandb_name}-orchestrator" if non_shared else wandb_name)
+
+        # wandb.name → orchestrator.prime_monitor.run_name, but only when
+        # prime_monitor is already enabled (don't fabricate it).
+        if read("orchestrator.prime_monitor") is not None:
+            propagate("orchestrator.prime_monitor.run_name", wandb_name)
+
+        # [tokenizer] → trainer/orchestrator tokenizer dicts (fill-if-absent).
+        # If tokenizer.name is left absent here, each sub-config's own
+        # auto_setup_tokenizer fills it from model.name during construction.
+        for field in ("name", "trust_remote_code", "chat_template"):
+            propagate(f"trainer.tokenizer.{field}", read(f"tokenizer.{field}"))
+            propagate(f"orchestrator.tokenizer.{field}", read(f"tokenizer.{field}"))
+        # chat_template flows trainer.tokenizer → inference.model (vLLM --chat-template).
+        # Read after the propagation above so we pick up shared → trainer flow.
+        propagate("inference.model.chat_template", read("trainer.tokenizer.chat_template"))
+
+        # [seq_len] → trainer.model.seq_len and orchestrator.seq_len (fill-if-absent)
+        propagate("trainer.model.seq_len", read("seq_len"))
+        propagate("orchestrator.seq_len", read("seq_len"))
 
         return data
 
-    ### Auto-setup and validate shared configs
+    ### Validate shared configs (after sub-config construction)
 
     @model_validator(mode="after")
-    def auto_setup_output_dir(self):
-        """Auto-setup shared output directory for trainer and orchestrator."""
-        self.trainer.output_dir = self.output_dir
-        self.orchestrator.output_dir = self.output_dir / "run_default"
-
+    def validate_shared_configs(self):
+        """Validate consistency of shared configs across trainer, orchestrator, and inference."""
         validate_shared_output_dir(self.trainer, self.orchestrator)
-
-        return self
-
-    @model_validator(mode="after")
-    def auto_setup_ckpt(self):
-        """Auto-setup shared checkpoint config for trainer and orchestrator."""
-        if self.ckpt is not None:
-            # Create checkpoint configs if not specified
-            if self.trainer.ckpt is None:
-                self.trainer.ckpt = TrainerCheckpointConfig()
-            if self.orchestrator.ckpt is None:
-                self.orchestrator.ckpt = OrchestratorCheckpointConfig()
-
-            # If specified, override checkpoint output directory
-            if self.ckpt.output_dir is not None:
-                self.trainer.ckpt.output_dir = self.ckpt.output_dir
-
-            # If specified, use the same ckpt interval
-            if self.ckpt.interval is not None:
-                self.trainer.ckpt.interval = self.ckpt.interval
-                self.orchestrator.ckpt.interval = self.ckpt.interval
-
-            # If resuming training, ensure orchestrator resume from the same step
-            if self.ckpt.resume_step is not None:
-                self.trainer.ckpt.resume_step = self.ckpt.resume_step
-                self.orchestrator.ckpt.resume_step = self.ckpt.resume_step
-
-            # If specified, propagate keep policy
-            if self.ckpt.keep_last is not None:
-                self.trainer.ckpt.keep_last = self.ckpt.keep_last
-                self.orchestrator.ckpt.keep_last = self.ckpt.keep_last
-
-            if self.ckpt.keep_interval is not None:
-                self.trainer.ckpt.keep_interval = self.ckpt.keep_interval
-                self.orchestrator.ckpt.keep_interval = self.ckpt.keep_interval
-
         validate_shared_ckpt_config(self.trainer, self.orchestrator)
-
-        return self
-
-    @model_validator(mode="after")
-    def auto_setup_wandb(self):
-        """Auto-setup shared W&B config for trainer and orchestrator."""
-        if self.wandb is not None:
-            if not self.trainer.wandb:
-                self.trainer.wandb = WandbConfig()
-            if not self.orchestrator.wandb:
-                self.orchestrator.wandb = WandbWithExtrasConfig()
-
-            if self.wandb.project:
-                self.trainer.wandb.project = self.wandb.project
-                self.orchestrator.wandb.project = self.wandb.project
-
-            if self.wandb.shared:
-                if self.wandb.name:
-                    self.trainer.wandb.name = self.wandb.name
-                    self.orchestrator.wandb.name = self.wandb.name
-            else:
-                if self.wandb.name:
-                    self.trainer.wandb.name = f"{self.wandb.name}-trainer"
-                    self.orchestrator.wandb.name = f"{self.wandb.name}-orchestrator"
-
-            if self.wandb.offline:
-                self.trainer.wandb.offline = self.wandb.offline
-                self.orchestrator.wandb.offline = self.wandb.offline
-
         validate_shared_wandb_config(self.trainer, self.orchestrator)
-
-        if self.orchestrator.prime_monitor is not None and self.orchestrator.prime_monitor.run_name is None:
-            if self.wandb and self.wandb.name:
-                self.orchestrator.prime_monitor.run_name = self.wandb.name
-
-        return self
-
-    @model_validator(mode="after")
-    def validate_model(self):
-        """Validate shared model config across trainer, orchestrator, and inference."""
         validate_shared_model_name(self.trainer, self.orchestrator, self.inference)
-        return self
-
-    @model_validator(mode="after")
-    def auto_setup_tokenizer(self):
-        """Auto-setup shared tokenizer config for trainer, orchestrator, and inference."""
-        if self.tokenizer is not None:
-            # Shared tokenizer config: propagate to all components, then fill
-            # in name/trust_remote_code from model config where still unset.
-            self.trainer.tokenizer = self.tokenizer.model_copy()
-            self.orchestrator.tokenizer = self.tokenizer.model_copy()
-            for component in (self.trainer, self.orchestrator):
-                if component.tokenizer.name is None:
-                    component.tokenizer.name = component.model.name
-                if component.tokenizer.trust_remote_code is None:
-                    component.tokenizer.trust_remote_code = component.model.trust_remote_code
-        else:
-            # No shared tokenizer: re-derive from (now-correct) model names,
-            # since auto_setup_tokenizer on sub-configs already ran with defaults.
-            for component in (self.trainer, self.orchestrator):
-                component.tokenizer.name = component.model.name
-                component.tokenizer.trust_remote_code = component.model.trust_remote_code
-
-        # Propagate chat_template to inference (vLLM --chat-template)
-        if self.inference is not None:
-            chat_template = self.trainer.tokenizer.chat_template
-            if chat_template is not None and self.inference.model.chat_template is None:
-                self.inference.model.chat_template = chat_template
-
         validate_shared_tokenizer(self.trainer, self.orchestrator, self.inference)
-
-        return self
-
-    @model_validator(mode="after")
-    def validate_max_steps(self):
-        """Validate shared max steps across trainer and orchestrator."""
         validate_shared_max_steps(self.trainer, self.orchestrator)
-        return self
-
-    @model_validator(mode="after")
-    def validate_async_level(self):
-        """Validate shared async level across trainer and orchestrator."""
         validate_shared_max_async_level(self.trainer, self.orchestrator)
-        return self
-
-    @model_validator(mode="after")
-    def auto_setup_seq_len(self):
-        """Auto-setup shared seq_len for trainer and orchestrator.
-
-        Only propagates to components that weren't explicitly set in the config.
-        Uses model_fields_set to detect explicit assignment.
-        """
-        if self.seq_len is not None:
-            if "seq_len" not in self.trainer.model.model_fields_set:
-                self.trainer.model.seq_len = self.seq_len
-            if "seq_len" not in self.orchestrator.model_fields_set:
-                self.orchestrator.seq_len = self.seq_len
-
         if self.trainer.model.seq_len < self.orchestrator.seq_len:
             raise ValueError(
                 f"Trainer model seq_len ({self.trainer.model.seq_len}) must be >= orchestrator seq_len ({self.orchestrator.seq_len}). "
                 f"The trainer needs to be able to handle sequences at least as long as those produced by the orchestrator."
             )
-
         return self
 
     @model_validator(mode="after")
@@ -770,12 +701,6 @@ class RLConfig(BaseConfig):
                     "make sure to set --enable_lora and --max-lora-rank."
                 )
 
-        return self
-
-    @model_validator(mode="after")
-    def auto_setup_session_headers(self):
-        """Ensure X-Session-ID header is always set for sticky DP-aware routing at the inference router."""
-        self.orchestrator.client.extra_headers_from_state.setdefault("X-Session-ID", "example_id")
         return self
 
     @model_validator(mode="after")
@@ -985,5 +910,3 @@ class RLConfig(BaseConfig):
             else:
                 self.slurm.template_path = templates_dir / "multi_node_rl.sbatch.j2"
         return self
-
-    ### Warnings

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -38,6 +38,7 @@ from prime_rl.utils.validation import (
     validate_shared_max_steps,
     validate_shared_model_name,
     validate_shared_output_dir,
+    validate_shared_seq_len,
     validate_shared_tokenizer,
     validate_shared_wandb_config,
     validate_shared_weight_broadcast,
@@ -453,24 +454,20 @@ class RLConfig(BaseConfig):
         after.
 
         Shared configs handled here (fill-if-absent: sub-configs win):
-          - `model.name`, `model.vlm`        → trainer / orchestrator / inference
-          - `log.level`, `log.json_logging`  → trainer / orchestrator
-          - `max_steps`, `max_async_level`   → trainer / orchestrator
-          - `output_dir`                     → trainer (verbatim) / orchestrator (`/run_default`)
-          - `[ckpt]` fields                  → trainer / orchestrator (presence enables both)
-          - `[wandb]` fields + shared/-suffix → trainer / orchestrator (presence enables both)
+          - `[model]` fields                 → trainer / orchestrator / inference
+          - `[log]` fields                   → trainer / orchestrator
+          - `[ckpt]` fields                  → trainer / orchestrator
+          - `[wandb]` fields + shared/-suffix → trainer / orchestrator
           - `[tokenizer]` fields             → trainer / orchestrator (+ chat_template to inference)
+          - `max_steps`                      → trainer / orchestrator
+          - `max_async_level`                → trainer / orchestrator
+          - `output_dir`                     → trainer / orchestrator (orchestrator derives a "run_default" subdir)
           - `seq_len`                        → trainer.model / orchestrator
 
         Sub-config values always take precedence; any mismatch between shared
         and sub-config, or between sub-configs themselves, is caught by
         `validate_shared_configs` (after-validator) which runs the full suite
         of `validate_shared_*` checks post-construction.
-
-        To add a new shared field, typically you only need a `propagate(...)`
-        call here plus a `validate_shared_*` call in `validate_shared_configs`.
-        If the field drives arithmetic or reads computed values from other
-        sub-configs, keep its auto-setup in an after-validator instead.
         """
         if not isinstance(data, dict):
             return data
@@ -490,14 +487,12 @@ class RLConfig(BaseConfig):
         def propagate(path: str, value: Any) -> None:
             """Set a value (e.g. 'trainer.model.name') in raw, if not already present.
 
-            No-op if value is None (i.e. source field was unset).
-            Sub-config values take precedence; mismatches are caught by the
-            corresponding validate_shared_* after-validator.
+            Caller is responsible for only calling with non-None values.
+            Sub-config values take precedence; mismatches are caught by
+            validate_shared_configs after-validator.
             Only creates intermediate dicts for nested keys (e.g. 'model' in
             'trainer.model.name'), never for the top-level sub-config itself.
             """
-            if value is None:
-                return
             parts = path.split(".")
             # Don't create the top-level sub-config if it doesn't exist
             if parts[0] not in data or not isinstance(data[parts[0]], dict):
@@ -512,37 +507,36 @@ class RLConfig(BaseConfig):
 
         # [model] → sub-config model dicts
         model_name = read("model.name")
-        propagate("trainer.model.name", model_name)
-        propagate("inference.model.name", model_name)
-        # Orchestrator follows inference model name (which may differ from shared)
-        propagate("orchestrator.model.name", read("inference.model.name") or model_name)
-        for target in ("trainer.model.vlm", "inference.model.vlm", "orchestrator.model.vlm"):
-            propagate(target, read("model.vlm"))
+        if model_name is not None:
+            propagate("trainer.model.name", model_name)
+            propagate("inference.model.name", model_name)
+            # Orchestrator follows inference model name (which may differ from shared)
+            propagate("orchestrator.model.name", read("inference.model.name") or model_name)
+        model_vlm = read("model.vlm")
+        if model_vlm is not None:
+            for target in ("trainer.model.vlm", "inference.model.vlm", "orchestrator.model.vlm"):
+                propagate(target, model_vlm)
 
         # [log] → trainer/orchestrator log dicts
         for key in ("level", "json_logging"):
-            propagate(f"trainer.log.{key}", read(f"log.{key}"))
-            propagate(f"orchestrator.log.{key}", read(f"log.{key}"))
-
-        # Scalar shared fields → trainer/orchestrator
-        for field in ("max_steps", "max_async_level"):
-            propagate(f"trainer.{field}", read(field))
-            propagate(f"orchestrator.{field}", read(field))
-
-        # [output_dir] → trainer/orchestrator (orchestrator derives a "run_default" subdir)
-        output_dir = read("output_dir")
-        propagate("trainer.output_dir", output_dir)
-        propagate("orchestrator.output_dir", f"{output_dir}/run_default" if output_dir is not None else None)
+            val = read(f"log.{key}")
+            if val is not None:
+                propagate(f"trainer.log.{key}", val)
+                propagate(f"orchestrator.log.{key}", val)
 
         # [ckpt] → trainer/orchestrator ckpt dicts (output_dir is trainer-only).
         # Presence of shared [ckpt] (even empty) enables ckpt on both sub-configs.
         if read("ckpt") is not None:
             propagate("trainer.ckpt", {})
             propagate("orchestrator.ckpt", {})
-        propagate("trainer.ckpt.output_dir", read("ckpt.output_dir"))
+        ckpt_output_dir = read("ckpt.output_dir")
+        if ckpt_output_dir is not None:
+            propagate("trainer.ckpt.output_dir", ckpt_output_dir)
         for field in ("interval", "resume_step", "keep_last", "keep_interval"):
-            propagate(f"trainer.ckpt.{field}", read(f"ckpt.{field}"))
-            propagate(f"orchestrator.ckpt.{field}", read(f"ckpt.{field}"))
+            val = read(f"ckpt.{field}")
+            if val is not None:
+                propagate(f"trainer.ckpt.{field}", val)
+                propagate(f"orchestrator.ckpt.{field}", val)
 
         # [wandb] → trainer/orchestrator wandb dicts.
         # Presence of shared [wandb] (even empty) enables wandb on both sub-configs.
@@ -550,8 +544,10 @@ class RLConfig(BaseConfig):
             propagate("trainer.wandb", {})
             propagate("orchestrator.wandb", {})
         for field in ("project", "offline"):
-            propagate(f"trainer.wandb.{field}", read(f"wandb.{field}"))
-            propagate(f"orchestrator.wandb.{field}", read(f"wandb.{field}"))
+            val = read(f"wandb.{field}")
+            if val is not None:
+                propagate(f"trainer.wandb.{field}", val)
+                propagate(f"orchestrator.wandb.{field}", val)
 
         # W&B name: in shared mode (the default), both sub-configs use the same
         # name. In non-shared mode (wandb.shared = false), suffix with -trainer/
@@ -564,22 +560,46 @@ class RLConfig(BaseConfig):
 
         # wandb.name → orchestrator.prime_monitor.run_name, but only when
         # prime_monitor is already enabled (don't fabricate it).
-        if read("orchestrator.prime_monitor") is not None:
+        if wandb_name and read("orchestrator.prime_monitor") is not None:
             propagate("orchestrator.prime_monitor.run_name", wandb_name)
 
         # [tokenizer] → trainer/orchestrator tokenizer dicts (fill-if-absent).
         # If tokenizer.name is left absent here, each sub-config's own
         # auto_setup_tokenizer fills it from model.name during construction.
         for field in ("name", "trust_remote_code", "chat_template"):
-            propagate(f"trainer.tokenizer.{field}", read(f"tokenizer.{field}"))
-            propagate(f"orchestrator.tokenizer.{field}", read(f"tokenizer.{field}"))
+            val = read(f"tokenizer.{field}")
+            if val is not None:
+                propagate(f"trainer.tokenizer.{field}", val)
+                propagate(f"orchestrator.tokenizer.{field}", val)
         # chat_template flows trainer.tokenizer → inference.model (vLLM --chat-template).
         # Read after the propagation above so we pick up shared → trainer flow.
-        propagate("inference.model.chat_template", read("trainer.tokenizer.chat_template"))
+        chat_template = read("trainer.tokenizer.chat_template")
+        if chat_template is not None:
+            propagate("inference.model.chat_template", chat_template)
 
-        # [seq_len] → trainer.model.seq_len and orchestrator.seq_len (fill-if-absent)
-        propagate("trainer.model.seq_len", read("seq_len"))
-        propagate("orchestrator.seq_len", read("seq_len"))
+        # max_steps → trainer/orchestrator
+        max_steps = read("max_steps")
+        if max_steps is not None:
+            propagate("trainer.max_steps", max_steps)
+            propagate("orchestrator.max_steps", max_steps)
+
+        # max_async_level → trainer/orchestrator
+        max_async_level = read("max_async_level")
+        if max_async_level is not None:
+            propagate("trainer.max_async_level", max_async_level)
+            propagate("orchestrator.max_async_level", max_async_level)
+
+        # output_dir → trainer/orchestrator (orchestrator derives a "run_default" subdir)
+        output_dir = read("output_dir")
+        if output_dir is not None:
+            propagate("trainer.output_dir", output_dir)
+            propagate("orchestrator.output_dir", f"{output_dir}/run_default")
+
+        # seq_len → trainer.model.seq_len and orchestrator.seq_len (fill-if-absent)
+        seq_len = read("seq_len")
+        if seq_len is not None:
+            propagate("trainer.model.seq_len", seq_len)
+            propagate("orchestrator.seq_len", seq_len)
 
         return data
 
@@ -595,11 +615,7 @@ class RLConfig(BaseConfig):
         validate_shared_tokenizer(self.trainer, self.orchestrator, self.inference)
         validate_shared_max_steps(self.trainer, self.orchestrator)
         validate_shared_max_async_level(self.trainer, self.orchestrator)
-        if self.trainer.model.seq_len < self.orchestrator.seq_len:
-            raise ValueError(
-                f"Trainer model seq_len ({self.trainer.model.seq_len}) must be >= orchestrator seq_len ({self.orchestrator.seq_len}). "
-                f"The trainer needs to be able to handle sequences at least as long as those produced by the orchestrator."
-            )
+        validate_shared_seq_len(self.trainer, self.orchestrator)
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Annotated, Literal, TypeAlias
+from typing import Annotated, Any, Literal, TypeAlias
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -448,6 +448,77 @@ class RLConfig(BaseConfig):
 
         return self
 
+    ### Propagate shared configs (before sub-config construction)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _propagate_shared_config(cls, data: Any) -> Any:
+        """Propagate shared top-level config values into sub-config dicts.
+
+        Runs before sub-configs are constructed so their validators see
+        the final values (e.g. parser auto-resolution needs the model name).
+        Only sets values that the user didn't explicitly provide.
+        """
+        if not isinstance(data, dict):
+            return data
+        import copy
+
+        data = copy.deepcopy(data)
+
+        def propagate(target_path: str, value: Any) -> None:
+            """Set a dotted path (e.g. 'trainer.model.name') in data if not already present.
+
+            Only creates intermediate dicts for nested keys (e.g. 'model' in
+            'trainer.model.name'), never for the top-level sub-config itself.
+            """
+            parts = target_path.split(".")
+            # Don't create the top-level sub-config if it doesn't exist
+            if parts[0] not in data or not isinstance(data[parts[0]], dict):
+                return
+            node = data
+            for part in parts[:-1]:
+                if not isinstance(node, dict):
+                    return
+                node = node.setdefault(part, {})
+            if isinstance(node, dict) and parts[-1] not in node:
+                node[parts[-1]] = value
+
+        # [model] → sub-config model dicts
+        shared_model = data.get("model")
+        if isinstance(shared_model, dict):
+            model_name = shared_model.get("name")
+            model_vlm = shared_model.get("vlm")
+
+            if model_name:
+                propagate("trainer.model.name", model_name)
+                propagate("inference.model.name", model_name)
+                # Orchestrator follows inference model name (which may differ from shared)
+                inf_model = (
+                    data.get("inference", {}).get("model", {}) if isinstance(data.get("inference"), dict) else {}
+                )
+                propagate("orchestrator.model.name", inf_model.get("name", model_name))
+            if model_vlm is not None:
+                for target in ("trainer.model.vlm", "inference.model.vlm", "orchestrator.model.vlm"):
+                    propagate(target, model_vlm)
+
+        # [log] → trainer/orchestrator log dicts
+        shared_log = data.get("log")
+        if isinstance(shared_log, dict):
+            for key in ("level", "json_logging"):
+                value = shared_log.get(key)
+                if value is not None:
+                    propagate(f"trainer.log.{key}", value)
+                    propagate(f"orchestrator.log.{key}", value)
+
+        # Scalar shared fields → trainer/orchestrator
+        for field in ("max_steps", "max_async_level"):
+            value = data.get(field)
+            if value is not None:
+                propagate(f"trainer.{field}", value)
+                propagate(f"orchestrator.{field}", value)
+
+        return data
+
     ### Auto-setup and validate shared configs
 
     @model_validator(mode="after")
@@ -457,18 +528,6 @@ class RLConfig(BaseConfig):
         self.orchestrator.output_dir = self.output_dir / "run_default"
 
         validate_shared_output_dir(self.trainer, self.orchestrator)
-
-        return self
-
-    @model_validator(mode="after")
-    def auto_setup_logs(self):
-        """Auto-setup shared log config for trainer and orchestrator."""
-        if self.log is not None:
-            if self.log.level is not None:
-                self.trainer.log.level = self.log.level
-                self.orchestrator.log.level = self.log.level
-            self.trainer.log.json_logging = self.log.json_logging
-            self.orchestrator.log.json_logging = self.log.json_logging
 
         return self
 
@@ -544,26 +603,9 @@ class RLConfig(BaseConfig):
         return self
 
     @model_validator(mode="after")
-    def auto_setup_model(self):
-        """Auto-setup shared model config for trainer, orchestrator, and inference."""
-        if self.model is not None:
-            self.trainer.model.name = self.model.name
-            if self.inference is not None:
-                inference_model_explicitly_set = "name" in self.inference.model.model_fields_set
-                if not inference_model_explicitly_set:
-                    self.inference.model.name = self.model.name
-                self.orchestrator.model.name = self.inference.model.name
-            else:
-                self.orchestrator.model.name = self.model.name
-
-            if self.model.vlm is not None:
-                self.trainer.model.vlm = self.model.vlm
-                self.orchestrator.model.vlm = self.model.vlm
-                if self.inference is not None:
-                    self.inference.model.vlm = self.model.vlm
-
+    def validate_model(self):
+        """Validate shared model config across trainer, orchestrator, and inference."""
         validate_shared_model_name(self.trainer, self.orchestrator, self.inference)
-
         return self
 
     @model_validator(mode="after")
@@ -597,25 +639,15 @@ class RLConfig(BaseConfig):
         return self
 
     @model_validator(mode="after")
-    def auto_setup_max_steps(self):
-        """Auto-setup shared max steps for trainer and orchestrator."""
-        if self.max_steps is not None:
-            self.trainer.max_steps = self.max_steps
-            self.orchestrator.max_steps = self.max_steps
-
+    def validate_max_steps(self):
+        """Validate shared max steps across trainer and orchestrator."""
         validate_shared_max_steps(self.trainer, self.orchestrator)
-
         return self
 
     @model_validator(mode="after")
-    def auto_setup_async_level(self):
-        """Auto-setup shared async level for trainer and orchestrator."""
-        if self.max_async_level is not None:
-            self.trainer.max_async_level = self.max_async_level
-            self.orchestrator.max_async_level = self.max_async_level
-
+    def validate_async_level(self):
+        """Validate shared async level across trainer and orchestrator."""
         validate_shared_max_async_level(self.trainer, self.orchestrator)
-
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from pathlib import Path
 from typing import Annotated, Any, Literal, TypeAlias
 
@@ -307,13 +308,6 @@ class RLConfig(BaseConfig):
         ),
     ] = None
 
-    max_model_len: Annotated[
-        int | None,
-        Field(
-            description="The maximum model length to use. If None, will fallback to the max model length specified on submodule configs."
-        ),
-    ] = None
-
     seq_len: Annotated[
         int | None,
         Field(
@@ -454,29 +448,29 @@ class RLConfig(BaseConfig):
         after.
 
         Shared configs handled here (fill-if-absent: sub-configs win):
-          - `[model]` fields                 → trainer / orchestrator / inference
-          - `[log]` fields                   → trainer / orchestrator
-          - `[ckpt]` fields                  → trainer / orchestrator
+          - `[model]` fields                  → trainer / orchestrator / inference
+          - `[log]` fields                    → trainer / orchestrator
+          - `[ckpt]` fields                   → trainer / orchestrator
           - `[wandb]` fields + shared/-suffix → trainer / orchestrator
-          - `[tokenizer]` fields             → trainer / orchestrator (+ chat_template to inference)
-          - `max_steps`                      → trainer / orchestrator
-          - `max_async_level`                → trainer / orchestrator
-          - `output_dir`                     → trainer / orchestrator (orchestrator derives a "run_default" subdir)
-          - `seq_len`                        → trainer.model / orchestrator
+          - `[tokenizer]` fields              → trainer / orchestrator (+ chat_template to inference)
+          - `max_steps`                       → trainer / orchestrator
+          - `max_async_level`                 → trainer / orchestrator
+          - `output_dir`                      → trainer / orchestrator (orchestrator derives a "run_default" subdir)
+          - `seq_len`                         → trainer.model / orchestrator
 
-        Sub-config values always take precedence; any mismatch between shared
-        and sub-config, or between sub-configs themselves, is caught by
-        `validate_shared_configs` (after-validator) which runs the full suite
-        of `validate_shared_*` checks post-construction.
+        Sub-config values always take precedence; any mismatch between
+        sub-configs themselves, is caught by `validate_shared_configs`
+        (after-validator) which runs the full suite of `validate_shared_*`
+        checks post-construction.
         """
         if not isinstance(data, dict):
             return data
-        import copy
 
-        data = copy.deepcopy(data)
+        data = deepcopy(data)
 
-        def read(path: str) -> Any | None:
-            """Read a dotted path from data, returning None if any intermediate is missing or not a dict."""
+        def get(path: str) -> Any | None:
+            """Read a dotted path (e.g. `model.name`) from raw config data. Returns
+            None if any intermediate key is missing or not a dict."""
             node: Any = data
             for part in path.split("."):
                 if not isinstance(node, dict) or part not in node:
@@ -484,14 +478,11 @@ class RLConfig(BaseConfig):
                 node = node[part]
             return node
 
-        def propagate(path: str, value: Any) -> None:
-            """Set a value (e.g. 'trainer.model.name') in raw, if not already present.
+        def fill(path: str, value: Any) -> None:
+            """Fill a value at dotted path in raw data, only if the slot is empty.
 
-            Caller is responsible for only calling with non-None values.
-            Sub-config values take precedence; mismatches are caught by
-            validate_shared_configs after-validator.
             Only creates intermediate dicts for nested keys (e.g. 'model' in
-            'trainer.model.name'), never for the top-level sub-config itself.
+            'trainer.model.name' but not 'trainer').
             """
             parts = path.split(".")
             # Don't create the top-level sub-config if it doesn't exist
@@ -506,100 +497,100 @@ class RLConfig(BaseConfig):
                 node[parts[-1]] = value
 
         # [model] → sub-config model dicts
-        model_name = read("model.name")
+        model_name = get("model.name")
         if model_name is not None:
-            propagate("trainer.model.name", model_name)
-            propagate("inference.model.name", model_name)
+            fill("trainer.model.name", model_name)
+            fill("inference.model.name", model_name)
             # Orchestrator follows inference model name (which may differ from shared)
-            propagate("orchestrator.model.name", read("inference.model.name") or model_name)
-        model_vlm = read("model.vlm")
+            fill("orchestrator.model.name", get("inference.model.name") or model_name)
+        model_vlm = get("model.vlm")
         if model_vlm is not None:
             for target in ("trainer.model.vlm", "inference.model.vlm", "orchestrator.model.vlm"):
-                propagate(target, model_vlm)
+                fill(target, model_vlm)
 
         # [log] → trainer/orchestrator log dicts
         for key in ("level", "json_logging"):
-            val = read(f"log.{key}")
+            val = get(f"log.{key}")
             if val is not None:
-                propagate(f"trainer.log.{key}", val)
-                propagate(f"orchestrator.log.{key}", val)
+                fill(f"trainer.log.{key}", val)
+                fill(f"orchestrator.log.{key}", val)
 
         # [ckpt] → trainer/orchestrator ckpt dicts (output_dir is trainer-only).
         # Presence of shared [ckpt] (even empty) enables ckpt on both sub-configs.
-        if read("ckpt") is not None:
-            propagate("trainer.ckpt", {})
-            propagate("orchestrator.ckpt", {})
-        ckpt_output_dir = read("ckpt.output_dir")
+        if get("ckpt") is not None:
+            fill("trainer.ckpt", {})
+            fill("orchestrator.ckpt", {})
+        ckpt_output_dir = get("ckpt.output_dir")
         if ckpt_output_dir is not None:
-            propagate("trainer.ckpt.output_dir", ckpt_output_dir)
+            fill("trainer.ckpt.output_dir", ckpt_output_dir)
         for field in ("interval", "resume_step", "keep_last", "keep_interval"):
-            val = read(f"ckpt.{field}")
+            val = get(f"ckpt.{field}")
             if val is not None:
-                propagate(f"trainer.ckpt.{field}", val)
-                propagate(f"orchestrator.ckpt.{field}", val)
+                fill(f"trainer.ckpt.{field}", val)
+                fill(f"orchestrator.ckpt.{field}", val)
 
         # [wandb] → trainer/orchestrator wandb dicts.
         # Presence of shared [wandb] (even empty) enables wandb on both sub-configs.
-        if read("wandb") is not None:
-            propagate("trainer.wandb", {})
-            propagate("orchestrator.wandb", {})
+        if get("wandb") is not None:
+            fill("trainer.wandb", {})
+            fill("orchestrator.wandb", {})
         for field in ("project", "offline"):
-            val = read(f"wandb.{field}")
+            val = get(f"wandb.{field}")
             if val is not None:
-                propagate(f"trainer.wandb.{field}", val)
-                propagate(f"orchestrator.wandb.{field}", val)
+                fill(f"trainer.wandb.{field}", val)
+                fill(f"orchestrator.wandb.{field}", val)
 
         # W&B name: in shared mode (the default), both sub-configs use the same
         # name. In non-shared mode (wandb.shared = false), suffix with -trainer/
         # -orchestrator so the runs are distinguishable.
-        wandb_name = read("wandb.name")
+        wandb_name = get("wandb.name")
         if wandb_name:
-            non_shared = read("wandb.shared") is False
-            propagate("trainer.wandb.name", f"{wandb_name}-trainer" if non_shared else wandb_name)
-            propagate("orchestrator.wandb.name", f"{wandb_name}-orchestrator" if non_shared else wandb_name)
+            non_shared = get("wandb.shared") is False
+            fill("trainer.wandb.name", f"{wandb_name}-trainer" if non_shared else wandb_name)
+            fill("orchestrator.wandb.name", f"{wandb_name}-orchestrator" if non_shared else wandb_name)
 
         # wandb.name → orchestrator.prime_monitor.run_name, but only when
         # prime_monitor is already enabled (don't fabricate it).
-        if wandb_name and read("orchestrator.prime_monitor") is not None:
-            propagate("orchestrator.prime_monitor.run_name", wandb_name)
+        if wandb_name and get("orchestrator.prime_monitor") is not None:
+            fill("orchestrator.prime_monitor.run_name", wandb_name)
 
         # [tokenizer] → trainer/orchestrator tokenizer dicts (fill-if-absent).
         # If tokenizer.name is left absent here, each sub-config's own
         # auto_setup_tokenizer fills it from model.name during construction.
         for field in ("name", "trust_remote_code", "chat_template"):
-            val = read(f"tokenizer.{field}")
+            val = get(f"tokenizer.{field}")
             if val is not None:
-                propagate(f"trainer.tokenizer.{field}", val)
-                propagate(f"orchestrator.tokenizer.{field}", val)
+                fill(f"trainer.tokenizer.{field}", val)
+                fill(f"orchestrator.tokenizer.{field}", val)
         # chat_template flows trainer.tokenizer → inference.model (vLLM --chat-template).
         # Read after the propagation above so we pick up shared → trainer flow.
-        chat_template = read("trainer.tokenizer.chat_template")
+        chat_template = get("trainer.tokenizer.chat_template")
         if chat_template is not None:
-            propagate("inference.model.chat_template", chat_template)
+            fill("inference.model.chat_template", chat_template)
 
         # max_steps → trainer/orchestrator
-        max_steps = read("max_steps")
+        max_steps = get("max_steps")
         if max_steps is not None:
-            propagate("trainer.max_steps", max_steps)
-            propagate("orchestrator.max_steps", max_steps)
+            fill("trainer.max_steps", max_steps)
+            fill("orchestrator.max_steps", max_steps)
 
         # max_async_level → trainer/orchestrator
-        max_async_level = read("max_async_level")
+        max_async_level = get("max_async_level")
         if max_async_level is not None:
-            propagate("trainer.max_async_level", max_async_level)
-            propagate("orchestrator.max_async_level", max_async_level)
+            fill("trainer.max_async_level", max_async_level)
+            fill("orchestrator.max_async_level", max_async_level)
 
         # output_dir → trainer/orchestrator (orchestrator derives a "run_default" subdir)
-        output_dir = read("output_dir")
+        output_dir = get("output_dir")
         if output_dir is not None:
-            propagate("trainer.output_dir", output_dir)
-            propagate("orchestrator.output_dir", f"{output_dir}/run_default")
+            fill("trainer.output_dir", output_dir)
+            fill("orchestrator.output_dir", f"{output_dir}/run_default")
 
         # seq_len → trainer.model.seq_len and orchestrator.seq_len (fill-if-absent)
-        seq_len = read("seq_len")
+        seq_len = get("seq_len")
         if seq_len is not None:
-            propagate("trainer.model.seq_len", seq_len)
-            propagate("orchestrator.seq_len", seq_len)
+            fill("trainer.model.seq_len", seq_len)
+            fill("orchestrator.seq_len", seq_len)
 
         return data
 

--- a/src/prime_rl/utils/validation.py
+++ b/src/prime_rl/utils/validation.py
@@ -104,6 +104,17 @@ def validate_shared_max_async_level(
         )
 
 
+def validate_shared_seq_len(
+    trainer: TrainerConfig,
+    orchestrator: OrchestratorConfig,
+) -> None:
+    if trainer.model.seq_len < orchestrator.seq_len:
+        raise ValueError(
+            f"Trainer model seq_len ({trainer.model.seq_len}) must be >= orchestrator seq_len ({orchestrator.seq_len}). "
+            f"The trainer needs to be able to handle sequences at least as long as those produced by the orchestrator."
+        )
+
+
 def validate_shared_tokenizer(
     trainer: TrainerConfig,
     orchestrator: OrchestratorConfig,

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -159,3 +159,21 @@ def test_removed_fused_lm_head_chunk_size_field_is_rejected():
 def test_selective_activation_checkpointing_requires_custom_impl():
     with pytest.raises(ValidationError, match="Selective activation checkpointing requires model.impl='custom'"):
         TrainerModelConfig.model_validate({"impl": "hf", "ac": {"mode": "selective"}})
+
+
+def test_shared_model_name_propagates_to_subconfigs():
+    """Top-level model.name propagates to trainer, orchestrator, and inference, and resolves the tokenizer."""
+    model_name = "PrimeIntellect/test-model"
+    config = RLConfig.model_validate(
+        {
+            "model": {"name": model_name},
+            "trainer": {},
+            "orchestrator": {},
+            "inference": {},
+        }
+    )
+    assert config.trainer.model.name == model_name
+    assert config.orchestrator.model.name == model_name
+    assert config.inference is not None and config.inference.model.name == model_name
+    assert config.trainer.tokenizer.name == model_name
+    assert config.orchestrator.tokenizer.name == model_name

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -177,3 +177,79 @@ def test_shared_model_name_propagates_to_subconfigs():
     assert config.inference is not None and config.inference.model.name == model_name
     assert config.trainer.tokenizer.name == model_name
     assert config.orchestrator.tokenizer.name == model_name
+
+
+def test_shared_tokenizer_propagates_when_subconfigs_unset():
+    config = RLConfig.model_validate(
+        {
+            "model": {"name": "my-model"},
+            "tokenizer": {"name": "my-tokenizer"},
+            "trainer": {},
+            "orchestrator": {},
+        }
+    )
+    assert config.trainer.tokenizer.name == "my-tokenizer"
+    assert config.orchestrator.tokenizer.name == "my-tokenizer"
+
+
+def test_subconfig_tokenizer_wins_over_shared():
+    config = RLConfig.model_validate(
+        {
+            "model": {"name": "my-model"},
+            "tokenizer": {"name": "shared-tok"},
+            "trainer": {"tokenizer": {"name": "trainer-tok"}},
+            "orchestrator": {},
+        }
+    )
+    assert config.trainer.tokenizer.name == "trainer-tok"
+    assert config.orchestrator.tokenizer.name == "shared-tok"
+
+
+def test_tokenizer_name_falls_back_to_model_name_when_unset():
+    """When shared tokenizer omits name and sub-configs don't set it, sub-config auto-setup fills it from model.name."""
+    config = RLConfig.model_validate(
+        {
+            "model": {"name": "my-model"},
+            "tokenizer": {"trust_remote_code": True},
+            "trainer": {},
+            "orchestrator": {},
+        }
+    )
+    assert config.trainer.tokenizer.name == "my-model"
+    assert config.orchestrator.tokenizer.name == "my-model"
+    assert config.trainer.tokenizer.trust_remote_code is True
+    assert config.orchestrator.tokenizer.trust_remote_code is True
+
+
+def test_tokenizer_chat_template_mismatch_raises():
+    with pytest.raises(ValidationError, match="chat_template"):
+        RLConfig.model_validate(
+            {
+                "trainer": {"tokenizer": {"chat_template": "A"}},
+                "orchestrator": {"tokenizer": {"chat_template": "B"}},
+            }
+        )
+
+
+def test_shared_seq_len_propagates_to_subconfigs():
+    config = RLConfig.model_validate(
+        {
+            "seq_len": 4096,
+            "trainer": {},
+            "orchestrator": {},
+        }
+    )
+    assert config.trainer.model.seq_len == 4096
+    assert config.orchestrator.seq_len == 4096
+
+
+def test_subconfig_seq_len_wins_over_shared():
+    config = RLConfig.model_validate(
+        {
+            "seq_len": 4096,
+            "trainer": {"model": {"seq_len": 8192}},
+            "orchestrator": {},
+        }
+    )
+    assert config.trainer.model.seq_len == 8192
+    assert config.orchestrator.seq_len == 4096

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -253,3 +253,24 @@ def test_subconfig_seq_len_wins_over_shared():
     )
     assert config.trainer.model.seq_len == 8192
     assert config.orchestrator.seq_len == 4096
+
+
+def test_shared_output_dir_propagates_through_cli(tmp_path):
+    """Shared output_dir from CLI reaches sub-configs even though tyro constructs
+    sub-configs before the RLConfig before-validator sees them."""
+    toml_path = tmp_path / "cfg.toml"
+    write_toml(
+        toml_path,
+        {
+            "max_steps": 1,
+            "seq_len": 128,
+            "model": {"name": "Qwen/Qwen3-0.6B"},
+            "trainer": {},
+            "orchestrator": {"batch_size": 16, "rollouts_per_example": 1},
+            "inference": {},
+        },
+    )
+    shared_out = tmp_path / "shared"
+    config = cli(RLConfig, args=["@", str(toml_path), "--output-dir", str(shared_out)])
+    assert config.trainer.output_dir == shared_out
+    assert config.orchestrator.output_dir == shared_out / "run_default"


### PR DESCRIPTION
## Summary

Reorganize all shared-config propagation on `RLConfig` into a single `mode="before"` validator (`auto_setup_shared_configs`), so sub-config validators see final values at construction time.

- Covers `model`, `log`, `ckpt`, `wandb`, `tokenizer`, `seq_len`, `max_steps`, `max_async_level`, `output_dir`
- Collapses eight per-field `validate_shared_*` after-validators into one `validate_shared_configs` after-validator
- Removes the fix-up hack in `auto_setup_tokenizer` that had to correct state written by sub-config validators running before model propagation
- Moves `auto_setup_session_headers` onto `OrchestratorConfig` (it only touches orchestrator state, no cross-sub-config logic)
- Deletes `RLConfig.max_model_len` — declared as a shared field but never read or propagated anywhere

## Why

Pydantic constructs nested models before running parent validators. Under the old design, `auto_setup_model` ran *after* `ModelConfig` had already been constructed with default values, so any sub-config validator depending on the final shared value (e.g. parser auto-resolution) saw the wrong input. Moving propagation into a `mode=\"before\"` validator lets sub-configs see the final shared values on their first validation pass.

This also unblocks parser auto-resolution at config time (PR #2290).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Pydantic validation order for `RLConfig` by moving shared-field propagation to a `mode="before"` validator, which can subtly alter how defaults/CLI/TOML merges resolve and what sub-config validators see. Moderate risk of breaking existing config edge cases despite added unit coverage.
> 
> **Overview**
> **Refactors `RLConfig` shared config propagation** to run in a single `mode="before"` validator (`auto_setup_shared_configs`), so `model`/`log`/`ckpt`/`wandb`/`tokenizer`/`seq_len`/`max_steps`/`max_async_level`/`output_dir` are filled into trainer/orchestrator/inference *before* nested models are constructed (with sub-config values taking precedence).
> 
> Collapses multiple per-field after-validators into one `validate_shared_configs` after-validator, extracts the `seq_len` consistency check into `validate_shared_seq_len`, moves `X-Session-ID` header auto-setup onto `OrchestratorConfig`, removes unused `RLConfig.max_model_len`, and adds focused unit tests covering propagation/precedence and CLI merge behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1077bcc454d8cf94bb9ebace7860740da51bebd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->