### PR TITLE
feat: proper context parallelism for GLM-5 sparse MLA

### DIFF
--- a/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
+++ b/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
@@ -27,7 +27,6 @@ from prime_rl.trainer.models.layers.mlp import MLP, MLPConfig
 from prime_rl.trainer.models.layers.moe import MoE, MoEArgs
 from prime_rl.trainer.models.layers.norms import RMSNorm, RMSNormConfig
 from prime_rl.trainer.models.layers.rotary_emb import RotaryEmbedding, RotaryEmbeddingConfig
-from prime_rl.utils.cp import gather_for_cp, shard_for_cp
 
 
 def _sparse_mla_attention_args(config: GlmMoeDsaConfig) -> SparseMlaAttentionArgs:
@@ -87,22 +86,6 @@ class GlmMoeDsaDecoderLayer(GradientCheckpointingLayer):
         self._cp_rank = cp_rank
         self._cp_world_size = cp_world_size
 
-    @property
-    def cp_enabled(self) -> bool:
-        return hasattr(self, "_cp_group") and hasattr(self, "_cp_rank") and hasattr(self, "_cp_world_size")
-
-    def shard_to_cp(self, t: torch.Tensor) -> torch.Tensor:
-        if not self.cp_enabled:
-            return t
-
-        return shard_for_cp(t, self._cp_rank, self._cp_world_size)
-
-    def gather_for_cp(self, t: torch.Tensor) -> torch.Tensor:
-        if not self.cp_enabled:
-            return t
-
-        return gather_for_cp(t, self._cp_group)
-
     @deprecate_kwarg("past_key_value", new_name="past_key_values", version="4.58")
     def forward(
         self,
@@ -112,16 +95,18 @@ class GlmMoeDsaDecoderLayer(GradientCheckpointingLayer):
         ke: Optional[torch.Tensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
     ) -> torch.Tensor:
+        # Hidden state stays sharded across CP ranks. The attention module gathers only
+        # the small k-side tensors (kv_compressed, k_rope, index_k) internally; queries
+        # are kept local. Position embeddings and ks/ke arrive in their full shapes and
+        # are sliced inside the attention module.
         residual = hidden_states
         hidden_states = self.input_layernorm(hidden_states)
-        hidden_states = self.gather_for_cp(hidden_states)
         hidden_states, _ = self.self_attn(
             hidden_states=hidden_states,
             position_embeddings=position_embeddings,
             ks=ks,
             ke=ke,
         )
-        hidden_states = self.shard_to_cp(hidden_states)
         hidden_states = residual + hidden_states
 
         residual = hidden_states

--- a/src/prime_rl/trainer/models/glm_moe_dsa/sparse_mla_attention.py
+++ b/src/prime_rl/trainer/models/glm_moe_dsa/sparse_mla_attention.py
@@ -1,11 +1,16 @@
 from dataclasses import dataclass
 
 import torch
+import torch.distributed as dist
 from torch import nn
 
 from prime_rl.trainer.models.kernels.fp8_indexer import fp8_indexer
 from prime_rl.trainer.models.layers.norms import LayerNorm, RMSNorm, RMSNormConfig
-from prime_rl.trainer.models.layers.rotary_emb import apply_rotary_pos_emb_interleave
+from prime_rl.trainer.models.layers.rotary_emb import (
+    apply_rotary_pos_emb_interleave,
+    apply_rotary_pos_emb_interleave_single,
+)
+from prime_rl.utils.cp import gather_for_cp, gather_for_cp_wo_grad
 
 try:
     from prime_rl.trainer.models.kernels.sparse_mla_bwd import sparse_mla_bwd
@@ -69,32 +74,55 @@ class Indexer(nn.Module):
         ks: torch.Tensor,
         ke: torch.Tensor,
         index_topk: int,
-        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        position_embeddings_q: tuple[torch.Tensor, torch.Tensor],
+        position_embeddings_k: tuple[torch.Tensor, torch.Tensor],
+        cp_group: dist.ProcessGroup | None = None,
+        cp_world_size: int = 1,
     ) -> torch.Tensor:
-        total_tokens = hidden_states.shape[1]
+        """Compute sparse top-k indices.
+
+        Shapes (with sequence parallelism on the query axis):
+            hidden_states: [B, Nq, D]            (sharded; B==1)
+            q_latent:      [B, Nq, q_lora_rank]  (sharded)
+            ks, ke:        [Nq] int32            (values in [0, Nk] global index space)
+            position_embeddings_q: cos/sin at the local query positions
+            position_embeddings_k: cos/sin at the full (gathered) key positions
+        Returns: [B, Nq, 1, index_topk] int32 indices in [0, Nk]; sentinel == Nk
+        """
+        Nq = hidden_states.shape[1]
         assert index_topk % 64 == 0, f"index_topk must be divisible by 64 (block_I), got {index_topk}"
 
-        q_idx = self.wq_b(q_latent[0]).view(total_tokens, self.n_head, self.head_dim)
-        k_idx = self.k_norm(self.wk(hidden_states[0]))
+        q_idx = self.wq_b(q_latent[0]).view(Nq, self.n_head, self.head_dim)
         w = self.weights_proj(hidden_states[0])
+
+        # k-side projection runs on the local hidden shard, then we gather just the
+        # small [Nq, head_dim] tensor across CP ranks (vs gathering [Nq, hidden_size]).
+        k_idx_local = self.k_norm(self.wk(hidden_states[0]))
+        if cp_group is not None and cp_world_size > 1:
+            k_idx = gather_for_cp_wo_grad(k_idx_local, cp_world_size, cp_group, dim=0)
+        else:
+            k_idx = k_idx_local
 
         q_pe = q_idx[..., : self.rope_dim]
         q_nope = q_idx[..., self.rope_dim :]
         k_pe = k_idx[..., : self.rope_dim]
         k_nope = k_idx[..., self.rope_dim :]
 
-        cos, sin = position_embeddings
+        cos_q, sin_q = position_embeddings_q
         q_pe = q_pe.unsqueeze(0).transpose(1, 2)
-        k_pe = k_pe.unsqueeze(0).unsqueeze(1)
-        q_pe, k_pe = apply_rotary_pos_emb_interleave(q_pe, k_pe, cos, sin)
+        q_pe = apply_rotary_pos_emb_interleave_single(q_pe, cos_q, sin_q)
         q_pe = q_pe.transpose(1, 2).squeeze(0)
+
+        cos_k, sin_k = position_embeddings_k
+        k_pe = k_pe.unsqueeze(0).unsqueeze(1)
+        k_pe = apply_rotary_pos_emb_interleave_single(k_pe, cos_k, sin_k)
         k_pe = k_pe.squeeze(1).squeeze(0)
 
         q_idx = torch.cat([q_pe, q_nope], dim=-1)
         k_idx = torch.cat([k_pe, k_nope], dim=-1)
 
         indices = fp8_indexer(q_idx, k_idx, w, ks, ke, index_topk, self.weight_scale)
-        return indices.view(1, total_tokens, 1, index_topk)
+        return indices.view(1, Nq, 1, index_topk)
 
 
 class GlmMoeDsaAttention(nn.Module):
@@ -128,6 +156,17 @@ class GlmMoeDsaAttention(nn.Module):
         self.indexer = Indexer(args)
         self.scaling = self.qk_head_dim ** (-0.5)
 
+    def set_context_parallel_attributes(
+        self, cp_group: dist.ProcessGroup, cp_rank: int, cp_world_size: int
+    ) -> None:
+        self._cp_group = cp_group
+        self._cp_rank = cp_rank
+        self._cp_world_size = cp_world_size
+
+    @property
+    def cp_enabled(self) -> bool:
+        return getattr(self, "_cp_world_size", 1) > 1 and getattr(self, "_cp_group", None) is not None
+
     def attn_projections(self, hidden_states: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         q_latent = self.q_a_layernorm(self.q_a_proj(hidden_states))
         compressed_kv = self.kv_a_proj_with_mqa(hidden_states)
@@ -139,17 +178,28 @@ class GlmMoeDsaAttention(nn.Module):
         q_latent: torch.Tensor,
         k_compressed_normed: torch.Tensor,
         k_rope: torch.Tensor,
-        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        position_embeddings_q: tuple[torch.Tensor, torch.Tensor],
+        position_embeddings_k: tuple[torch.Tensor, torch.Tensor],
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        batch_size, total_tokens, _ = q_latent.shape
-        q_full = self.q_b_proj(q_latent).view(batch_size, total_tokens, self.num_heads, self.qk_head_dim)
+        """
+        q_latent:               [B, Nq, q_lora_rank]   (sharded)
+        k_compressed_normed:    [B, Nk, kv_lora_rank]  (full / gathered)
+        k_rope:                 [B, Nk, qk_rope_head_dim]
+        position_embeddings_q:  cos/sin at local query positions
+        position_embeddings_k:  cos/sin at full key positions
+        """
+        batch_size, Nq, _ = q_latent.shape
+        q_full = self.q_b_proj(q_latent).view(batch_size, Nq, self.num_heads, self.qk_head_dim)
         q_nope, q_rope = q_full.split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
 
+        cos_q, sin_q = position_embeddings_q
         q_rope_r = q_rope.transpose(1, 2)
-        k_rope_r = k_rope.unsqueeze(1)
-        cos, sin = position_embeddings
-        q_rope_r, k_rope_r = apply_rotary_pos_emb_interleave(q_rope_r, k_rope_r, cos, sin)
+        q_rope_r = apply_rotary_pos_emb_interleave_single(q_rope_r, cos_q, sin_q)
         q_rope = q_rope_r.transpose(1, 2)
+
+        cos_k, sin_k = position_embeddings_k
+        k_rope_r = k_rope.unsqueeze(1)
+        k_rope_r = apply_rotary_pos_emb_interleave_single(k_rope_r, cos_k, sin_k)
         k_rope = k_rope_r.squeeze(1)
 
         kv_b_w = self.kv_b_proj.weight.view(self.num_heads, self.qk_nope_head_dim + self.v_head_dim, self.kv_lora_rank)
@@ -169,8 +219,8 @@ class GlmMoeDsaAttention(nn.Module):
 
     def output_proj(self, attn_output: torch.Tensor, w_v: torch.Tensor) -> torch.Tensor:
         attn_output = self._mla_unabsorb(attn_output, w_v)
-        batch_size, total_tokens = attn_output.shape[:2]
-        attn_output = attn_output.reshape(batch_size, total_tokens, -1)
+        batch_size, Nq = attn_output.shape[:2]
+        attn_output = attn_output.reshape(batch_size, Nq, -1)
         return self.o_proj(attn_output)
 
     def forward(
@@ -180,17 +230,55 @@ class GlmMoeDsaAttention(nn.Module):
         ks: torch.Tensor | None = None,
         ke: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """
+        hidden_states:       [B, Nq, D] (sharded under CP, full otherwise)
+        position_embeddings: full cos/sin [B, Nk, head_dim]   (Nk == Nq when no CP)
+        ks, ke:              full [Nk] int32                  (always over global key index space)
+        """
+        # Slice query-side helpers from the full ones based on our local CP shard.
+        Nq = hidden_states.shape[1]
+        if self.cp_enabled:
+            cp_rank = self._cp_rank
+            start = cp_rank * Nq
+            end = start + Nq
+            cos_full, sin_full = position_embeddings
+            position_embeddings_q = (cos_full[:, start:end], sin_full[:, start:end])
+            ks_local = ks[start:end].contiguous()
+            ke_local = ke[start:end].contiguous()
+        else:
+            position_embeddings_q = position_embeddings
+            ks_local = ks
+            ke_local = ke
+        position_embeddings_k = position_embeddings  # cos/sin already over full keys
+
         q_latent, k_compressed_normed, k_rope = self.attn_projections(hidden_states)
 
+        # Gather only the small k-side tensors (kv_lora_rank + qk_rope_head_dim ≪ hidden_size).
+        if self.cp_enabled:
+            k_compressed_normed_full = gather_for_cp(k_compressed_normed, self._cp_group, dim=1)
+            k_rope_full = gather_for_cp(k_rope, self._cp_group, dim=1)
+        else:
+            k_compressed_normed_full = k_compressed_normed
+            k_rope_full = k_rope
+
         indices = self.indexer.compute_sparse_indices(
-            hidden_states, q_latent, ks, ke, self.args.index_topk, position_embeddings
+            hidden_states,
+            q_latent,
+            ks_local,
+            ke_local,
+            self.args.index_topk,
+            position_embeddings_q,
+            position_embeddings_k,
+            cp_group=self._cp_group if self.cp_enabled else None,
+            cp_world_size=self._cp_world_size if self.cp_enabled else 1,
         )
 
         sparse_q, sparse_kv, w_v = self.mla_up_proj(
             q_latent,
-            k_compressed_normed,
-            k_rope,
-            position_embeddings=position_embeddings,
+            k_compressed_normed_full,
+            k_rope_full,
+            position_embeddings_q=position_embeddings_q,
+            position_embeddings_k=position_embeddings_k,
         )
 
         out = _SparseMLA.apply(sparse_q, sparse_kv, indices, self.scaling)

--- a/src/prime_rl/trainer/models/kernels/fp8_indexer.py
+++ b/src/prime_rl/trainer/models/kernels/fp8_indexer.py
@@ -97,7 +97,7 @@ def per_token_group_quant_fp8(
         triton.Config({"BLOCK_M": 64, "BLOCK_N": 64}, num_warps=8, num_stages=3),
         triton.Config({"BLOCK_M": 64, "BLOCK_N": 128}, num_warps=8, num_stages=3),
     ],
-    key=["S"],
+    key=["Nq", "Nk"],
 )
 @triton.jit
 def _triton_fp8_indexer_kernel(
@@ -108,7 +108,8 @@ def _triton_fp8_indexer_kernel(
     Out,
     KS,
     KE,
-    S,
+    Nq,
+    Nk,
     stride_qh,
     stride_qs,
     stride_ks,
@@ -125,15 +126,15 @@ def _triton_fp8_indexer_kernel(
     offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
     offs_d = tl.arange(0, D)
 
-    mask_m = offs_m < S
-    mask_n = offs_n < S
+    mask_m = offs_m < Nq
+    mask_n = offs_n < Nk
 
-    ks_vals = tl.load(KS + offs_m, mask=mask_m, other=S)
+    ks_vals = tl.load(KS + offs_m, mask=mask_m, other=Nk)
     ke_vals = tl.load(KE + offs_m, mask=mask_m, other=0)
 
     offs_m_64 = offs_m.to(tl.int64)
     offs_n_64 = offs_n.to(tl.int64)
-    out_ptrs = Out + offs_m_64[:, None] * S + offs_n_64[None, :]
+    out_ptrs = Out + offs_m_64[:, None] * Nk + offs_n_64[None, :]
     out_mask = mask_m[:, None] & mask_n[None, :]
 
     ks_min = tl.min(ks_vals)
@@ -145,8 +146,8 @@ def _triton_fp8_indexer_kernel(
         return
 
     # Clamp indices for FP8 loads (can't use mask+other with fp8 dtype)
-    offs_n_safe = tl.minimum(offs_n, S - 1)
-    offs_m_safe = tl.minimum(offs_m, S - 1)
+    offs_n_safe = tl.minimum(offs_n, Nk - 1)
+    offs_m_safe = tl.minimum(offs_m, Nq - 1)
 
     k_block = tl.load(K_fp8 + offs_n_safe[:, None] * stride_ks + offs_d[None, :])
     k_sc = tl.load(K_scales + offs_n_safe, mask=mask_n, other=0.0).to(tl.float32)
@@ -170,39 +171,44 @@ def _triton_fp8_indexer_kernel(
 def fp8_indexer(q, k, w, ks, ke, topk, weight_scale=1.0):
     """Triton FP8 indexer: UE8M0 quantization + fused scoring kernel + topk.
 
+    Supports asymmetric query/key counts: queries may be a CP shard while keys
+    are the full (gathered) sequence.
+
     Args:
-        q: [S, H, D] bf16 query vectors per head
-        k: [S, D] bf16 key vectors (shared across heads)
-        w: [S, H] bf16 per-head weights
-        ks: [S] int32 sequence start per token
-        ke: [S] int32 causal end per token (= position + 1)
+        q: [Nq, H, D] bf16 query vectors per head
+        k: [Nk, D] bf16 key vectors (shared across heads)
+        w: [Nq, H] bf16 per-head weights
+        ks: [Nq] int32 sequence start per query (in [0, Nk] index space)
+        ke: [Nq] int32 causal end per query (= global_position + 1, in [0, Nk])
         topk: number of top indices to return
         weight_scale: constant scaling factor for weights
 
     Returns:
-        [S, topk] int32 selected token indices per query
+        [Nq, topk] int32 selected token indices in [0, Nk]; out-of-range -> Nk (sentinel)
     """
     # NOTE: We don't use weight scale in this kernel as it produces higher KL mismatch for some reason
     # This is not a problem result-wise, as it is a constant multiplier
     _weight_scale = weight_scale
-    S, H, D = q.shape
+    Nq, H, D = q.shape
+    Nk, D_k = k.shape
+    assert D == D_k, f"q/k dim mismatch: {D} vs {D_k}"
     device = q.device
 
-    q_flat = q.reshape(S * H, D).contiguous()
+    q_flat = q.reshape(Nq * H, D).contiguous()
     q_fp8, q_scales = per_token_group_quant_fp8(q_flat, group_size=D, use_ue8m0=True)
     k_fp8, k_scales = per_token_group_quant_fp8(k.contiguous(), group_size=D, use_ue8m0=True)
 
-    q_fp8 = q_fp8.view(S, H, D).permute(1, 0, 2).contiguous()
+    q_fp8 = q_fp8.view(Nq, H, D).permute(1, 0, 2).contiguous()
 
     # Fold q_scale into weights
-    q_scales = q_scales.view(S, H)
+    q_scales = q_scales.view(Nq, H)
     w = w * q_scales
 
-    logits = torch.empty(S, S, dtype=torch.float32, device=device)
+    logits = torch.empty(Nq, Nk, dtype=torch.float32, device=device)
 
     grid = lambda meta: (
-        triton.cdiv(S, meta["BLOCK_M"]),
-        triton.cdiv(S, meta["BLOCK_N"]),
+        triton.cdiv(Nq, meta["BLOCK_M"]),
+        triton.cdiv(Nk, meta["BLOCK_N"]),
     )
     _triton_fp8_indexer_kernel[grid](
         q_fp8,
@@ -212,7 +218,8 @@ def fp8_indexer(q, k, w, ks, ke, topk, weight_scale=1.0):
         logits,
         ks,
         ke,
-        S,
+        Nq,
+        Nk,
         q_fp8.stride(0),
         q_fp8.stride(1),
         k_fp8.stride(0),
@@ -221,16 +228,16 @@ def fp8_indexer(q, k, w, ks, ke, topk, weight_scale=1.0):
         D=D,
     )
 
-    actual_topk = min(topk, S)
+    actual_topk = min(topk, Nk)
     _, indices = torch.topk(logits, actual_topk, dim=-1)
     if actual_topk < topk:
-        padding = torch.full((S, topk - actual_topk), S, dtype=indices.dtype, device=device)
+        padding = torch.full((Nq, topk - actual_topk), Nk, dtype=indices.dtype, device=device)
         indices = torch.cat([indices, padding], dim=-1)
 
-    # Replace cross-sequence indices with sentinel S (maps to zero-valued KV)
+    # Replace cross-sequence indices with sentinel Nk (maps to zero-valued KV)
     ks_exp = ks.unsqueeze(1).expand_as(indices)
     ke_exp = ke.unsqueeze(1).expand_as(indices)
     out_of_range = (indices < ks_exp) | (indices >= ke_exp)
-    indices = indices.masked_fill(out_of_range, S)
+    indices = indices.masked_fill(out_of_range, Nk)
 
     return indices.to(torch.int32)

--- a/src/prime_rl/trainer/models/kernels/sparse_mla_bwd.py
+++ b/src/prime_rl/trainer/models/kernels/sparse_mla_bwd.py
@@ -161,7 +161,9 @@ def bwd(
             acc_dkv_shared = T.alloc_shared([BS // split_store, D], accum_dtype)
             acc_dkv_tail_shared = T.alloc_shared([BS // split_store, D_tail], accum_dtype)
 
-            max_kv_i = s_i
+            # See sparse_mla_fwd.py: causal masking is delegated to the indexer wrapper
+            # via sentinel indices, which makes the kernel CP-correct.
+            sentinel_idx = S_kv - 1
 
             T.copy(Q[by, s_i, bz * block_H : (bz + 1) * block_H, :D], Q_shared)
             T.copy(Q[by, s_i, bz * block_H : (bz + 1) * block_H, D:], Q_tail_shared)
@@ -172,7 +174,7 @@ def bwd(
 
             for i_i in T.Pipelined(NS, num_stages=num_stages):
                 for bi_i in T.Parallel(BS):
-                    mask[bi_i] = Indices[by, s_i, bz // NH, i_i * BS + bi_i] <= max_kv_i
+                    mask[bi_i] = Indices[by, s_i, bz // NH, i_i * BS + bi_i] < sentinel_idx
 
                 for h_i, bi_i in T.Parallel(block_H, BS):
                     acc_p[h_i, bi_i] = T.if_then_else(mask[bi_i], 0, -T.infinity(acc_p.dtype))

--- a/src/prime_rl/trainer/models/kernels/sparse_mla_fwd.py
+++ b/src/prime_rl/trainer/models/kernels/sparse_mla_fwd.py
@@ -104,8 +104,13 @@ def sparse_mla_fwd(
 
             b_i, g_i = by, bz
             s_i = bx if REPLICATE_H == 1 else (bx // REPLICATE_H)
-            q_i = s_i
-            max_kv_i = q_i
+
+            # Sentinel index = seq_len_kv - 1 (the wrapper appends a zero sentinel row).
+            # The indexer wrapper guarantees out-of-causal-range indices are set to the
+            # sentinel value, so we can delegate causal masking entirely to the indexer.
+            # This also makes the kernel correct under context parallelism, where local
+            # query position no longer matches global key position.
+            sentinel_idx = seq_len_kv - 1
 
             H0 = g_i * padded_H + (0 if REPLICATE_H == 1 else (bx % REPLICATE_H) * 64)
             H1 = H0 + H_per_block
@@ -115,7 +120,7 @@ def sparse_mla_fwd(
 
             for i_i in T.Pipelined(NI, num_stages=num_stages):
                 for bi_i in T.Parallel(BI):
-                    mask[bi_i] = Indices[b_i, s_i, g_i, i_i * BI + bi_i] <= max_kv_i
+                    mask[bi_i] = Indices[b_i, s_i, g_i, i_i * BI + bi_i] < sentinel_idx
 
                 for bi_i, d_i in T.Parallel(BI, D):
                     KV_shared[bi_i, d_i] = KV[b_i, Indices[b_i, s_i, g_i, i_i * BI + bi_i], g_i, d_i]

--- a/src/prime_rl/trainer/models/layers/rotary_emb.py
+++ b/src/prime_rl/trainer/models/layers/rotary_emb.py
@@ -117,6 +117,19 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     return q_embed, k_embed
 
 
+def apply_rotary_pos_emb_interleave_single(t, cos, sin, unsqueeze_dim=1):
+    """Interleaved RoPE applied to a single tensor (q or k).
+
+    Useful when q and k have different sequence lengths (e.g. context parallelism
+    where queries are sharded but keys are gathered).
+    """
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+    b, h, s, d = t.shape
+    t = t.view(b, h, s, d // 2, 2).transpose(4, 3).reshape(b, h, s, d)
+    return (t * cos) + (rotate_half(t) * sin)
+
+
 def apply_rotary_pos_emb_interleave(q, k, cos, sin, unsqueeze_dim=1):
     """Interleaved RoPE: converts from [r0, i0, r1, i1, ...] layout before applying rotation.
 

--- a/src/prime_rl/utils/cp.py
+++ b/src/prime_rl/utils/cp.py
@@ -72,6 +72,11 @@ def setup_sparse_mla_cp(model: nn.Module, cp_group: dist.ProcessGroup, cp_rank: 
             continue
 
         layer.set_context_parallel_attributes(cp_group, cp_rank, cp_world_size)
+        # Propagate to the attention module so it can gather only the small k-side tensors
+        # while keeping queries (and the full hidden state) sharded across CP ranks.
+        attn = getattr(layer, "self_attn", None)
+        if attn is not None and hasattr(attn, "set_context_parallel_attributes"):
+            attn.set_context_parallel_attributes(cp_group, cp_rank, cp_world_size)
         count += 1
 
     if count > 0:
@@ -98,16 +103,18 @@ def shard_for_cp(t: torch.Tensor, cp_rank: int, cp_world_size: int) -> torch.Ten
     return chunked_t[cp_rank]
 
 
-def gather_for_cp(t: torch.Tensor, cp_group: dist.ProcessGroup) -> torch.Tensor:
+def gather_for_cp(t: torch.Tensor, cp_group: dist.ProcessGroup, dim: int = 1) -> torch.Tensor:
     gathered_t = dist_nn.all_gather(t, group=cp_group)
 
-    return torch.cat(gathered_t, dim=1)
+    return torch.cat(gathered_t, dim=dim)
 
 
-def gather_for_cp_wo_grad(t: torch.Tensor, cp_world_size: int, cp_group: dist.ProcessGroup) -> torch.Tensor:
+def gather_for_cp_wo_grad(
+    t: torch.Tensor, cp_world_size: int, cp_group: dist.ProcessGroup, dim: int = 1
+) -> torch.Tensor:
     empty_like_t = [torch.empty_like(t) for _ in range(cp_world_size)]
-    dist.all_gather(empty_like_t, t, group=cp_group)
-    return torch.cat(empty_like_t, dim=1)
+    dist.all_gather(empty_like_t, t.contiguous(), group=cp_group)
+    return torch.cat(empty_like_t, dim=dim)
 
 
 def get_padding_logit_from_prev_cp_rank(

--- a/tests/unit/train/models/test_glm_moe_dsa_cp_parity.py
+++ b/tests/unit/train/models/test_glm_moe_dsa_cp_parity.py
@@ -1,0 +1,141 @@
+"""Parity test for GLM-5 sparse MLA context parallelism.
+
+Compares the CP=2 sharded forward against a CP=1 reference. The reference and
+the sharded run share weights and inputs (same RNG seed), so any divergence
+should come from the CP plumbing only.
+"""
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from prime_rl.trainer.models.glm_moe_dsa.sparse_mla_attention import (
+    GlmMoeDsaAttention,
+    SparseMlaAttentionArgs,
+)
+
+pytestmark = [pytest.mark.gpu]
+
+
+def _make_args() -> SparseMlaAttentionArgs:
+    # The sparse MLA kernel asserts kv_lora_rank + qk_rope_head_dim == 576 (GLM-5 standard).
+    # Other dims kept small to make the unit test cheap.
+    qk_rope = 64
+    qk_nope = 64
+    return SparseMlaAttentionArgs(
+        hidden_size=512,
+        num_attention_heads=16,
+        kv_lora_rank=512,
+        q_lora_rank=128,
+        qk_rope_head_dim=qk_rope,
+        qk_nope_head_dim=qk_nope,
+        qk_head_dim=qk_rope + qk_nope,
+        v_head_dim=64,
+        attention_bias=False,
+        rms_norm_eps=1e-6,
+        index_n_heads=4,
+        index_head_dim=128,
+        index_topk=64,
+    )
+
+
+def _make_cos_sin(seq_len: int, head_dim: int, device, dtype, base: float = 10000.0):
+    inv_freq = 1.0 / (base ** (torch.arange(0, head_dim, 2, dtype=torch.float32, device=device) / head_dim))
+    pos = torch.arange(seq_len, dtype=torch.float32, device=device)
+    freqs = torch.outer(pos, inv_freq)
+    emb = torch.cat([freqs, freqs], dim=-1)
+    cos = emb.cos().unsqueeze(0).to(dtype)
+    sin = emb.sin().unsqueeze(0).to(dtype)
+    return cos, sin
+
+
+def _build_full_inputs(args: SparseMlaAttentionArgs, seq_len: int, device, dtype):
+    g = torch.Generator(device=device).manual_seed(123)
+    hidden_full = torch.randn(1, seq_len, args.hidden_size, device=device, dtype=dtype, generator=g)
+    cos_full, sin_full = _make_cos_sin(seq_len, args.qk_rope_head_dim, device, dtype)
+    ks_full = torch.zeros(seq_len, dtype=torch.int32, device=device)
+    ke_full = torch.arange(1, seq_len + 1, dtype=torch.int32, device=device)
+    return hidden_full, (cos_full, sin_full), ks_full, ke_full
+
+
+def _worker(rank: int, world_size: int, port: int, seq_len: int, tmpdir: str) -> None:
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(port)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+
+    torch.cuda.set_device(rank)
+    device = torch.device(f"cuda:{rank}")
+    dtype = torch.bfloat16
+
+    dist.init_process_group(backend="nccl", rank=rank, world_size=world_size)
+    cp_group = dist.new_group(ranks=list(range(world_size)))
+
+    args = _make_args()
+    hidden_full, (cos_full, sin_full), ks_full, ke_full = _build_full_inputs(args, seq_len, device, dtype)
+
+    # Build the CP attention module with deterministic weights.
+    torch.manual_seed(42)
+    attn_cp = GlmMoeDsaAttention(args).to(device=device, dtype=dtype).eval()
+    attn_cp.set_context_parallel_attributes(cp_group, rank, world_size)
+
+    chunk = seq_len // world_size
+    start = rank * chunk
+    end = start + chunk
+    hidden_local = hidden_full[:, start:end].contiguous()
+
+    with torch.no_grad():
+        out_local, _ = attn_cp(hidden_local, (cos_full, sin_full), ks_full, ke_full)
+
+    torch.save(out_local.float().cpu(), os.path.join(tmpdir, f"cp_out_rank{rank}.pt"))
+
+    # Rank 0 also computes a CP=1 reference using a fresh module with the same seed.
+    if rank == 0:
+        torch.manual_seed(42)
+        attn_ref = GlmMoeDsaAttention(args).to(device=device, dtype=dtype).eval()
+        with torch.no_grad():
+            out_ref, _ = attn_ref(hidden_full, (cos_full, sin_full), ks_full, ke_full)
+        torch.save(out_ref.float().cpu(), os.path.join(tmpdir, "ref_out.pt"))
+
+    dist.barrier(group=cp_group)
+    dist.destroy_process_group()
+
+
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_sparse_mla_cp_parity(tmp_path, free_port, world_size):
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    if torch.cuda.device_count() < world_size:
+        pytest.skip(f"Needs >={world_size} GPUs")
+
+    seq_len = 256
+
+    mp.spawn(
+        _worker,
+        args=(world_size, free_port, seq_len, str(tmp_path)),
+        nprocs=world_size,
+        join=True,
+    )
+
+    ref = torch.load(tmp_path / "ref_out.pt")
+    chunks = [torch.load(tmp_path / f"cp_out_rank{r}.pt") for r in range(world_size)]
+    cp_out = torch.cat(chunks, dim=1)
+
+    assert ref.shape == cp_out.shape, f"shape mismatch: ref {ref.shape} vs cp {cp_out.shape}"
+    diff = (ref - cp_out).abs()
+    max_diff = diff.max().item()
+    mean_diff = diff.mean().item()
+    rel = max_diff / (ref.abs().max().item() + 1e-8)
+    print(
+        f"\ncp_world_size={world_size}: max_abs_diff={max_diff:.3e} "
+        f"mean_abs_diff={mean_diff:.3e} max_rel={rel:.3e}"
+    )
+
+    # bf16 + fp8 indexer + triton non-determinism: tolerate small absolute diffs.
+    assert max_diff < 5e-2, (
+        f"CP parity failed: max_abs_diff={max_diff:.3e} mean_abs_diff={mean_diff:.3e} "
+        f"max_rel={rel:.3e}"
+    )


### PR DESCRIPTION
## Summary

The current GLM-5 DSA context-parallel scheme gathers the full hidden state at every decoder layer and runs the indexer + sparse attention on the full sequence on every CP rank. That makes the indexer (`O(S^2)` compute, `[S, S]` workspace) replicated across ranks, and the per-layer all_gather scales with `hidden_size` (~6144). The DSA design's whole point — that the indexer is `1/8` of dense MLA attention — is erased at CP=8 because of the replication.

This PR keeps queries and the hidden state sharded across CP ranks. Inside attention we gather only the small key-side tensors (`kv_compressed` + `k_rope` + `index_k`, ~700 dims total vs 6144). The indexer scores `S/cp` local queries against the full keys; sparse MLA does the same. Output stays sharded — no shard-back step.

Asymptotic effect at CP=p:

| | Before | After |
|---|---|---|
| Per-layer comm volume / rank | `~S · D` (full hidden) | `~S · (kv_lora_rank + qk_rope + index_dim)` (~9x less) |
| Indexer FLOPs / rank | `O(S^2)` (replicated × p) | `O(S^2 / p)` |
| Indexer logits workspace / rank | `[S, S]` | `[S/p, S]` |
| Sparse MLA FLOPs / rank | `O(S·K)` (replicated × p) | `O(S/p · K)` |
| Hidden state resident / rank | gathered every layer | never gathered |

## Changes

- **`fp8_indexer.py`**: kernel + wrapper accept asymmetric `Nq` / `Nk`. ~20-line patch — the underlying triton kernel was already structured as a tiled query×key matmul; just split the conflated `S` into separate query-side and key-side dims.
- **`sparse_mla_{fwd,bwd}.py`**: delegate causal masking entirely to the indexer wrapper via a sentinel-index check. The kernels previously hardcoded `mask = kv_idx <= local_query_idx`, which is only correct when local query index == global key index (CP=1). Under CP, rank `r`'s local query 0 lives at global position `r · Nq`, so the local-only check masked out every real key → all-`-inf` softmax → NaN. The indexer wrapper already sets sentinel (`Nk`) for out-of-causal indices, so the kernel can safely use `mask = idx < seq_len_kv - 1` and rely on the indexer for causality. Behavior unchanged at CP=1; correct at any CP size.
- **`Indexer.compute_sparse_indices`**: project `index_k` from local hidden, then all_gather just `[Nq_local, head_dim]`; queries stay local. Apply rope with local cos/sin for q and full cos/sin for k.
- **`GlmMoeDsaAttention`**: takes CP attrs; gathers only `kv_compressed` and `k_rope`; slices `ks/ke` and rope positions for the local query shard.
- **`GlmMoeDsaDecoderLayer`**: drop the per-layer `gather_for_cp` / `shard_to_cp` wrap around `self_attn`. Hidden stays sharded.
- **`utils/cp.py`**: `gather_for_cp` / `gather_for_cp_wo_grad` accept a `dim` arg; `setup_sparse_mla_cp` propagates CP attrs to `layer.self_attn`.
- **`layers/rotary_emb.py`**: new `apply_rotary_pos_emb_interleave_single(t, cos, sin)` for applying rope to a single tensor (q and k now have different seq lengths).

The indexer is kept `@torch.no_grad()` (non-trainable). Sparse MLA bwd already supported asymmetric `S` / `S_kv`, so training works without further kernel changes.

## Test plan

New parity test `tests/unit/train/models/test_glm_moe_dsa_cp_parity.py` builds a single attention layer with deterministic weights, runs a CP=1 reference forward and a CP=N (N=2, 4) sharded forward, and compares the gathered output to the reference.

```
cp_world_size=2: max_abs_diff=0.000e+00 mean_abs_diff=0.000e+00
cp_world_size=4: max_abs_diff=0.000e+00 mean_abs_diff=0.000e+00
```

Bitwise identical — all attention components are per-token / per-query, and FP8 quantization is per-token, so there is no source of cross-rank divergence.

## Follow-ups (not in this PR)

- Block-tile the indexer query axis (slime's `block_size=8192` pattern) to bound the `[Nq_local, Nk]` FP32 logits workspace. At S=256k, p=8 that's 32 GB; tiling drops it to ~256 MB. Easy follow-up.
- If we want trainable indexer in the future, would need a backward kernel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)