### PR TITLE
Feat: fix patch

### DIFF
--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -957,18 +957,15 @@ def monkey_patch_dp_engine_core_pause_resume_deadlock():
 def monkey_patch_offloading_connector_cpu_block_count():
     """Fix CPU block count miscalculation in OffloadingConnector.
 
-    CPUOffloadingSpec erroneously multiplies page_size_bytes by
-    len(kv_cache_config.kv_cache_tensors) when computing kv_bytes_per_block.
-    For UniformTypeKVCacheSpecs the page_size is already the total per-block
-    size across all layers, so the extra multiplier makes num_blocks far too
-    small. When the OffloadingManager later allocates block IDs past the
-    undersized CPU tensor, swap_blocks (cuMemcpyDtoHAsync_v2) segfaults on the
-    invalid pinned address.
+    CPUOffloadingSpec derives kv_bytes_per_block from page_size_bytes multiplied
+    by len(kv_cache_config.kv_cache_tensors), which double-counts: page_size is
+    already aggregated across layers in the group. The undersized CPU pool then
+    produces out-of-bounds block mappings and swap_blocks segfaults.
 
-    Fix: remove the num_tensors multiplier.
+    Fix: derive kv_bytes_per_block from the actual total GPU KV tensor size
+    divided by num_blocks, matching the upstream PR.
 
-    Upstream: https://github.com/vllm-project/vllm/pull/38395
-    Related: https://github.com/vllm-project/vllm/issues/39500
+    Upstream: https://github.com/vllm-project/vllm/pull/39617
     """
     from vllm.v1.kv_offload.cpu.spec import CPUOffloadingSpec
 
@@ -977,18 +974,18 @@ def monkey_patch_offloading_connector_cpu_block_count():
     def _patched_init(self, vllm_config, kv_cache_config):
         _original_init(self, vllm_config, kv_cache_config)
 
-        # Recalculate num_blocks WITHOUT the erroneous num_tensors multiplier.
         cpu_bytes_to_use = self.extra_config.get("cpu_bytes_to_use")
         if not cpu_bytes_to_use:
             return
 
-        page_sizes = {g.kv_cache_spec.page_size_bytes for g in kv_cache_config.kv_cache_groups}
-        assert len(page_sizes) == 1
-        page_size_bytes = page_sizes.pop()
+        if kv_cache_config.num_blocks > 0:
+            total_gpu_kv_bytes = sum(t.size for t in kv_cache_config.kv_cache_tensors)
+            kv_bytes_per_block = (
+                total_gpu_kv_bytes // kv_cache_config.num_blocks
+            ) * vllm_config.parallel_config.world_size
+        else:
+            kv_bytes_per_block = 0
 
-        # page_size_bytes already covers all layers in the group.
-        # Only multiply by world_size (each TP rank stores its own copy).
-        kv_bytes_per_block = page_size_bytes * vllm_config.parallel_config.world_size
         kv_bytes_per_offloaded_block = kv_bytes_per_block * self.block_size_factor
         self.num_blocks = (
             int(cpu_bytes_to_use) // kv_bytes_per_offloaded_block if kv_bytes_per_offloaded_block > 0 else 0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches vLLM KV offloading memory sizing by changing how CPU offload block counts are derived; miscalculation could impact allocation limits or stability, though change is localized to the monkeypatch.
> 
> **Overview**
> Updates the `CPUOffloadingSpec` monkeypatch to compute `kv_bytes_per_block` from the *actual total GPU KV tensor size* divided by `num_blocks` (then scaled by TP `world_size`), instead of relying on `page_size_bytes` assumptions.
> 
> This is intended to prevent undersizing the CPU KV offload pool that can lead to out-of-bounds block mappings and `swap_blocks` segfaults, aligning the patch with the referenced upstream fix (`vllm-project/vllm#39617`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4de55995b871051b862fb85ee951ce54846312cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->