### PR TITLE
accept fully-qualified expert names in lora check

### DIFF
--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -302,10 +302,17 @@ def _patch_lora_key_prefix():
                 # is embedded: "...experts.N.down_proj".  Taking everything
                 # after ".experts" gives "experts.N.down_proj" which is
                 # never in the expected set even though "down_proj" is.
-                # Fix: always compare just the last component of the path.
+                # Qwen3-30B-A3B goes the other way: the expected set
+                # contains the fully-qualified per-expert name
+                # ("experts.N.down_proj") but not the bare suffix.
+                # Accept either form.
                 if ".experts" in module_name:
                     expert_suffix = module_name.split(".")[-1]
-                    if expert_suffix not in expected_lora_modules:
+                    experts_qualified = "experts" + module_name.split(".experts", 1)[-1]
+                    if (
+                        expert_suffix not in expected_lora_modules
+                        and experts_qualified not in expected_lora_modules
+                    ):
                         unexpected_modules.append(module_name)
 
                 elif module_name.rsplit(".", 1)[-1] not in expected_lora_modules:

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -309,10 +309,7 @@ def _patch_lora_key_prefix():
                 if ".experts" in module_name:
                     expert_suffix = module_name.split(".")[-1]
                     experts_qualified = "experts" + module_name.split(".experts", 1)[-1]
-                    if (
-                        expert_suffix not in expected_lora_modules
-                        and experts_qualified not in expected_lora_modules
-                    ):
+                    if expert_suffix not in expected_lora_modules and experts_qualified not in expected_lora_modules:
                         unexpected_modules.append(module_name)
 
                 elif module_name.rsplit(".", 1)[-1] not in expected_lora_modules:


### PR DESCRIPTION
Tripped over this while bumping the Qwen3-30B-A3B stacks to v0.5.1.dev81 — `load_lora_adapter` 400s on every step broadcast.

The check added in #2242 strips to the bare suffix (`gate_proj`/`up_proj`/`down_proj`) assuming that's what's in `expected_lora_modules`. Works for Qwen3.5 MoE. Qwen3-30B-A3B-2507 registers the other way though — the expected set has `experts.N.gate_proj` and friends, no bare suffixes. Every expert module gets flagged and the load fails.

Just accept either form.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches LoRA adapter validation in the loading path; while small, it changes what modules are considered acceptable and could hide misconfigured adapters if expectations are too broad.
> 
> **Overview**
> Updates the LoRA adapter `check_unexpected_modules` logic to **treat MoE expert weights as valid when they match either** the bare projection suffix (e.g. `down_proj`) **or** the fully-qualified per-expert name (e.g. `experts.N.down_proj`).
> 
> This prevents `from_local_checkpoint` / `load_lora_adapter` from rejecting adapters for models whose `expected_lora_modules` are registered with fully-qualified expert module names (e.g. Qwen3-30B-A3B).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7075c8dc5e71c2f4e952b371c086056ef50e4bde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->