### PR TITLE
fix: clean stale rollouts and broadcasts in SLURM template

### DIFF
--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -58,6 +58,7 @@ export PROJECT_DIR={{ project_dir }}
 export CONFIG_DIR={{ config_dir }}
 export OUTPUT_DIR={{ output_dir }}
 export ORCHESTRATOR_OUTPUT_DIR={{ orchestrator_output_dir }}
+rm -rf $ORCHESTRATOR_OUTPUT_DIR/rollouts $ORCHESTRATOR_OUTPUT_DIR/broadcasts
 mkdir -p $OUTPUT_DIR/logs/trainer $OUTPUT_DIR/logs/inference
 ln -sfn trainer/node_0.log $OUTPUT_DIR/logs/trainer.log
 ln -sfn inference/node_0.log $OUTPUT_DIR/logs/inference.log


### PR DESCRIPTION
## Summary
- Remove `$ORCHESTRATOR_OUTPUT_DIR/rollouts` and `$ORCHESTRATOR_OUTPUT_DIR/broadcasts` at the start of multi-node SLURM jobs to prevent stale data from previous runs causing issues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds a pre-run cleanup step in the SLURM batch template; main concern is accidental deletion if `ORCHESTRATOR_OUTPUT_DIR` is misconfigured.
> 
> **Overview**
> Prevents stale orchestrator artifacts from previous runs by adding a startup cleanup in `multi_node_rl.sbatch.j2` that `rm -rf`s `$ORCHESTRATOR_OUTPUT_DIR/rollouts` and `$ORCHESTRATOR_OUTPUT_DIR/broadcasts` before creating log directories and launching the job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 571a262bcf69f49a3c06849b06846e648df04b37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->