### PR TITLE
fix: clean stale rollouts on fresh runs

### DIFF
--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -548,15 +548,23 @@ def rl(config: RLConfig):
     if ckpt_output_dir is not None:
         ckpt_output_dir.mkdir(parents=True, exist_ok=True)
 
-    # Clean stale artifacts from steps after the resume point
+    # Clean stale rollouts and broadcasts. When resuming, anything past the resume
+    # step is stale. When training from scratch, every existing step directory is
+    # stale — without this, a fresh run in a dirty output_dir would pick up rollouts
+    # from a previous run and the orchestrator would see a negative async level.
+    resume_step: int | None = None
     if resuming:
         resume_step = config.ckpt.resume_step
         if resume_step == -1:
             ckpt_base = ckpt_output_dir if ckpt_output_dir is not None else config.output_dir
             resume_step = resolve_latest_ckpt_step(get_ckpt_dir(ckpt_base))
-        if resume_step is not None:
-            get_logger().info(f"Resuming from step {resume_step}, cleaning future rollouts and broadcasts")
-            clean_future_steps(config.output_dir, resume_step)
+
+    if resume_step is not None:
+        get_logger().info(f"Resuming from step {resume_step}, cleaning future rollouts and broadcasts")
+        clean_future_steps(config.output_dir, resume_step)
+    else:
+        get_logger().info("Training from scratch, cleaning any stale rollouts and broadcasts")
+        clean_future_steps(config.output_dir, -1)
 
     if not config.dry_run:
         pre_download_model(config.trainer.model.name)

--- a/src/prime_rl/utils/pathing.py
+++ b/src/prime_rl/utils/pathing.py
@@ -150,7 +150,10 @@ def validate_output_dir(output_dir: Path, *, resuming: bool, clean: bool, ckpt_o
 
 
 def clean_future_steps(output_dir: Path, resume_step: int) -> None:
-    """Remove stale rollouts and broadcasts from a resumed run."""
+    """Remove stale rollouts and broadcasts past ``resume_step``.
+
+    Pass ``resume_step=-1`` to wipe every step directory (fresh runs).
+    """
     run_default = output_dir / "run_default"
     dirs = [
         get_rollout_dir(output_dir),


### PR DESCRIPTION
## Summary
- If a run is started from scratch in an `output_dir` that still contains stale rollouts or broadcasts from a previous run (but no checkpoint), the trainer would consume those stale rollouts and the orchestrator would see a negative async level because the trainer appears ahead of it.
- `clean_future_steps` previously only ran when resuming from a checkpoint. Now it also runs from step 0 (i.e. `resume_step=-1`) when training from scratch, wiping every existing rollout/broadcast step directory before training begins.
- Also updates `clean_future_steps`' docstring to document the new `resume_step=-1` semantics.

## Repro
```
uv run rl @ examples/reverse_text/rl.toml --max-steps 3 && rm -rf outputs/checkpoints && uv run rl @ examples/reverse_text/rl.toml --max-steps 3
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes startup behavior to delete existing rollout/broadcast step directories, which could remove data if an `output_dir` is reused unexpectedly. The logic is localized to pre-run cleanup and should reduce mis-synchronization issues when starting from a dirty directory.
> 
> **Overview**
> Pre-run cleanup now **always** invokes `clean_future_steps`: when resuming it deletes steps after the resolved `resume_step`, and when training from scratch it calls `clean_future_steps(..., -1)` to wipe all existing rollout/broadcast step directories in the `output_dir`.
> 
> Updates `clean_future_steps`’s docstring to document the new `resume_step=-1` semantics for fresh runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fb40111b33e4607ef84abf3ad1a17a0e2449b23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->