### PR TITLE
Pin Triton JIT cache to node-local /tmp per job

### DIFF
--- a/src/prime_rl/templates/inference.sbatch.j2
+++ b/src/prime_rl/templates/inference.sbatch.j2
@@ -52,6 +52,7 @@ ln -sfn inference/node_0.log $OUTPUT_DIR/logs/inference.log
 export CUDA_DEVICE_ORDER=PCI_BUS_ID
 export PYTHONUNBUFFERED=1
 export OMP_NUM_THREADS=1
+export TRITON_CACHE_DIR=/tmp/triton-cache-$USER-$SLURM_JOB_ID
 export VLLM_CACHE_ROOT=/tmp/.vllm_cache_$(whoami)
 
 # Setup environment

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -66,6 +66,7 @@ ln -sfn inference/node_0.log $OUTPUT_DIR/logs/inference.log
 export CUDA_DEVICE_ORDER=PCI_BUS_ID
 export PYTHONUNBUFFERED=1
 export OMP_NUM_THREADS=1
+export TRITON_CACHE_DIR=/tmp/triton-cache-$USER-$SLURM_JOB_ID
 
 {% if wandb_shared -%}
 export WANDB_SHARED_MODE=1

--- a/src/prime_rl/templates/multi_node_sft.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_sft.sbatch.j2
@@ -36,6 +36,7 @@ ln -sfn trainer/node_0.log $OUTPUT_DIR/logs/trainer.log
 export CUDA_DEVICE_ORDER=PCI_BUS_ID
 export PYTHONUNBUFFERED=1
 export OMP_NUM_THREADS=1
+export TRITON_CACHE_DIR=/tmp/triton-cache-$USER-$SLURM_JOB_ID
 
 # Networking
 export HOSTNAMES=( $( scontrol show hostnames $SLURM_JOB_NODELIST ) )


### PR DESCRIPTION
## Problem

When prime-rl runs multi-node on a cluster with an NFS-shared `$HOME`, `~/.triton/cache` is the default Triton JIT cache location and lives on NFS. Multiple ranks on different nodes writing/reading this cache concurrently races; some ranks then hit:

```
ImportError: /home/<user>/.triton/cache/<hash>/__triton_launcher...so: cannot stat shared object: Stale file handle
```

One rank dies, NCCL watchdog on all other ranks trips after 480s, and the whole job hangs. Clearing `~/.triton/cache` between runs does not help — the race recurs on the next compile.

## Fix

Pin `TRITON_CACHE_DIR` to a node-local path per job in the sbatch templates:

```
export TRITON_CACHE_DIR=/tmp/triton-cache-$USER-$SLURM_JOB_ID
```

- `/tmp` is node-local on essentially all HPC clusters, so no NFS sharing.
- `$SLURM_JOB_ID` expands at sbatch runtime, so concurrent jobs don't share state.

Added the export alongside the other defensive defaults (`CUDA_DEVICE_ORDER`, `PYTHONUNBUFFERED`, `OMP_NUM_THREADS`) in all three multi-node / inference templates for consistency:

- `src/prime_rl/templates/multi_node_rl.sbatch.j2`
- `src/prime_rl/templates/multi_node_sft.sbatch.j2`
- `src/prime_rl/templates/inference.sbatch.j2`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds an environment variable export in sbatch templates; behavior change is limited to Triton kernel cache location and may affect cache reuse across runs.
> 
> **Overview**
> Pins Triton JIT compilation caching to a **per-job, node-local** path by exporting `TRITON_CACHE_DIR=/tmp/triton-cache-$USER-$SLURM_JOB_ID`.
> 
> Applies this consistently across the `inference`, `multi_node_rl`, and `multi_node_sft` sbatch templates to prevent shared `$HOME`/NFS cache contention during multi-node execution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d41cea3c222dc30ee1be62fbc17cdec3f955b33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->