### PR TITLE
Add FA4 support to ring attention in context parallel mode

### DIFF
--- a/src/prime_rl/configs/trainer.py
+++ b/src/prime_rl/configs/trainer.py
@@ -184,7 +184,7 @@ class ModelConfig(BaseModelConfig):
     attn: Annotated[
         AttnImplementation,
         Field(
-            description="The attention implementation to use. When CP is enabled, ring attention uses the matching kernel family (FA2 for flash_attention_2, FA3 for flash_attention_3).",
+            description="The attention implementation to use. When CP is enabled, ring attention uses the matching kernel family (FA2 for flash_attention_2, FA3 for flash_attention_3, FA4 for fa4).",
         ),
     ] = "flash_attention_2"
 
@@ -368,12 +368,12 @@ class ModelConfig(BaseModelConfig):
 
     @model_validator(mode="after")
     def cp_only_with_flash_attn(self):
-        if self.cp > 1 and self.attn not in ["flash_attention_2", "flash_attention_3"]:
-            raise ValueError("CP is only supported with flash attention 2 or flash attention 3")
-        if self.cp > 1 and self.attn == "flash_attention_3" and self.impl != "custom":
+        if self.cp > 1 and self.attn not in ["flash_attention_2", "flash_attention_3", "fa4"]:
+            raise ValueError("CP is only supported with flash attention 2, flash attention 3, or fa4")
+        if self.cp > 1 and self.attn in ("flash_attention_3", "fa4") and self.impl != "custom":
             raise ValueError(
-                "CP with flash_attention_3 requires model.impl='custom' "
-                "(the FA3 ring-attention kernel is only implemented for the custom model path)"
+                f"CP with {self.attn} requires model.impl='custom' "
+                "(the ring-attention kernel is only implemented for the custom model path)"
             )
         return self
 

--- a/src/prime_rl/trainer/models/layers/attn.py
+++ b/src/prime_rl/trainer/models/layers/attn.py
@@ -93,14 +93,18 @@ class FlashAttention(nn.Module):
 
     def _compute_attention(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, cu_seqlens, max_seqlen):
         """Run the flash attention kernel. q/k/v are [total_tokens, heads, dim]."""
-        args = [q, k, v, cu_seqlens, cu_seqlens]
-        if self._flash_attn_version != 4:
-            args.extend([max_seqlen, max_seqlen])
         kwargs: dict = {"causal": True}
         sliding_window = getattr(self, "sliding_window", None)
         if sliding_window is not None:
             kwargs["window_size"] = (sliding_window - 1, 0)
-        out = self._flash_attn_call(*args, **kwargs)
+        if self._flash_attn_version == 4:
+            # FA4's flash_attn_varlen_func has qv as the 4th positional arg,
+            # so cu_seqlens must be passed as keyword args to avoid misalignment.
+            kwargs["cu_seqlens_q"] = cu_seqlens
+            kwargs["cu_seqlens_k"] = cu_seqlens
+            out = self._flash_attn_call(q, k, v, **kwargs)
+        else:
+            out = self._flash_attn_call(q, k, v, cu_seqlens, cu_seqlens, max_seqlen, max_seqlen, **kwargs)
         if isinstance(out, tuple):
             out = out[0]
         return out
@@ -291,10 +295,14 @@ def substitute_ring_attn(
     """Patch _compute_attention on FlashAttention variants to use ring attention."""
     from ring_flash_attn import llama3_flash_attn_varlen_func
 
-    from .ring_attn import ring_fa3_varlen_func
+    from .ring_attn import ring_fa3_varlen_func, ring_fa4_varlen_func
 
-    use_fa3 = attn_impl == "flash_attention_3"
-    ring_func = ring_fa3_varlen_func if use_fa3 else llama3_flash_attn_varlen_func
+    if attn_impl == "fa4":
+        ring_func = ring_fa4_varlen_func
+    elif attn_impl == "flash_attention_3":
+        ring_func = ring_fa3_varlen_func
+    else:
+        ring_func = llama3_flash_attn_varlen_func
 
     def _ring_compute_attention(self, q, k, v, cu_seqlens, max_seqlen):
         from ring_flash_attn.adapters.hf_adapter import DATA_PARAMS

--- a/src/prime_rl/trainer/models/layers/ring_attn.py
+++ b/src/prime_rl/trainer/models/layers/ring_attn.py
@@ -297,3 +297,298 @@ def ring_fa3_varlen_func(
         window_size[0],
         window_size[1],
     )
+
+
+# ---------------------------------------------------------------------------
+# FA4 (flash_attn.cute) ring attention
+# ---------------------------------------------------------------------------
+
+
+def _fa4_varlen_forward(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    softmax_scale: float,
+    causal: bool,
+    window_size: tuple[int, int] = (-1, -1),
+) -> tuple[torch.Tensor, torch.Tensor]:
+    from flash_attn.cute.interface import _flash_attn_fwd
+
+    wl = window_size[0] if window_size[0] != -1 else None
+    wr = window_size[1] if window_size[1] != -1 else None
+    out, lse = _flash_attn_fwd(
+        q,
+        k,
+        v,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        window_size_left=wl,
+        window_size_right=wr,
+        return_lse=True,
+    )
+    return out, lse
+
+
+def _fa4_varlen_backward(
+    dout: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    out: torch.Tensor,
+    softmax_lse: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    dq: torch.Tensor,
+    dk: torch.Tensor,
+    dv: torch.Tensor,
+    softmax_scale: float,
+    causal: bool,
+    window_size: tuple[int, int] = (-1, -1),
+) -> None:
+    from flash_attn.cute.interface import _flash_attn_bwd
+
+    wl = window_size[0] if window_size[0] != -1 else None
+    wr = window_size[1] if window_size[1] != -1 else None
+    _flash_attn_bwd(
+        q,
+        k,
+        v,
+        out,
+        dout,
+        softmax_lse,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        window_size_left=wl,
+        window_size_right=wr,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        dq=dq,
+        dk=dk,
+        dv=dv,
+    )
+
+
+class _RingFA4Varlen(torch.autograd.Function):
+    """Ring attention using FA4 (flash_attn.cute) kernels with all-gather communication.
+
+    Mirrors _RingFA3Varlen but calls the FA4 low-level forward/backward.
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+        cu_seqlens_k: torch.Tensor,
+        max_seqlen_q: int,
+        max_seqlen_k: int,
+        local_k_slice_start: int,
+        local_k_slice_stop: int,
+        heads_k_stride: int,
+        causal: bool,
+        group_name: str,
+        window_size_left: int = -1,
+        window_size_right: int = -1,
+    ) -> torch.Tensor:
+        group = dist.group.WORLD
+        for pg in dist.distributed_c10d._world.pg_map:
+            if pg.group_name == group_name:
+                group = pg
+                break
+
+        local_k_slice = slice(local_k_slice_start, local_k_slice_stop)
+        window_size = (window_size_left, window_size_right)
+        softmax_scale = q.shape[-1] ** (-0.5)
+        out_list = []
+        lse_list = []
+
+        nheads = q.shape[1]
+        total_k, nheads_k, head_dim = k.shape
+        world_size = dist.get_world_size(group)
+
+        kv_buffer = torch.empty((2, total_k * world_size, heads_k_stride, head_dim), dtype=k.dtype, device=k.device)
+        kv_buffer_copy = torch.empty_like(kv_buffer)
+        comm = AllGatherComm(group)
+
+        comm.all_gather(kv_buffer_copy[0], k[:, :heads_k_stride].contiguous())
+        comm.all_gather(kv_buffer_copy[1], v[:, :heads_k_stride].contiguous())
+
+        for i in range(0, nheads_k, heads_k_stride):
+            comm.wait()
+            kv_buffer, kv_buffer_copy = kv_buffer_copy, kv_buffer
+
+            if i < nheads_k - heads_k_stride:
+                left = i + heads_k_stride
+                right = left + heads_k_stride
+                comm.all_gather(kv_buffer_copy[0], k[:, left:right].contiguous())
+                comm.all_gather(kv_buffer_copy[1], v[:, left:right].contiguous())
+
+            q_i = q[:, i * nheads // nheads_k : (i + heads_k_stride) * nheads // nheads_k]
+            k_i = kv_buffer[0][local_k_slice]
+            v_i = kv_buffer[1][local_k_slice]
+            out_i, lse_i = _fa4_varlen_forward(
+                q=q_i,
+                k=k_i,
+                v=v_i,
+                cu_seqlens_q=cu_seqlens_q,
+                cu_seqlens_k=cu_seqlens_k,
+                max_seqlen_q=max_seqlen_q,
+                max_seqlen_k=max_seqlen_k,
+                softmax_scale=softmax_scale,
+                causal=causal,
+                window_size=window_size,
+            )
+            out_list.append(out_i)
+            lse_list.append(lse_i)
+
+        out = torch.cat(out_list, dim=1)
+        lse = torch.cat(lse_list, dim=-2)
+
+        ctx.save_for_backward(q, k, v, out, lse, cu_seqlens_q, cu_seqlens_k)
+        ctx.softmax_scale = softmax_scale
+        ctx.max_seqlen_q = max_seqlen_q
+        ctx.max_seqlen_k = max_seqlen_k
+        ctx.local_k_slice = local_k_slice
+        ctx.heads_k_stride = heads_k_stride
+        ctx.causal = causal
+        ctx.group_name = group_name
+        ctx.window_size = window_size
+        return out
+
+    @staticmethod
+    def backward(ctx, dout: torch.Tensor):
+        q, k, v, out, softmax_lse, cu_seqlens_q, cu_seqlens_k = ctx.saved_tensors
+        heads_k_stride = ctx.heads_k_stride
+        local_k_slice = ctx.local_k_slice
+        causal = ctx.causal
+
+        group = dist.group.WORLD
+        for pg in dist.distributed_c10d._world.pg_map:
+            if pg.group_name == ctx.group_name:
+                group = pg
+                break
+
+        nheads = q.shape[1]
+        total_k, nheads_k, head_dim = k.shape
+        world_size = dist.get_world_size(group)
+
+        kv_buffer = torch.empty((2, total_k * world_size, heads_k_stride, head_dim), dtype=k.dtype, device=k.device)
+        kv_buffer_copy = torch.empty_like(kv_buffer)
+        dkv_buffer = torch.empty((2, total_k * world_size, heads_k_stride, head_dim), dtype=k.dtype, device=k.device)
+
+        kv_contiguous_buffer = None
+        if heads_k_stride != nheads_k:
+            kv_contiguous_buffer = torch.empty((2, total_k, heads_k_stride, head_dim), dtype=k.dtype, device=k.device)
+
+        dq = torch.empty_like(q)
+        dk = torch.empty_like(k)
+        dv = torch.empty_like(v)
+
+        comm = AllGatherComm(group)
+        comm.all_gather(kv_buffer_copy[0], k[:, :heads_k_stride].contiguous())
+        comm.all_gather(kv_buffer_copy[1], v[:, :heads_k_stride].contiguous())
+
+        for i in range(0, nheads_k, heads_k_stride):
+            dkv_buffer.zero_()
+            q_slice = slice(i * nheads // nheads_k, (i + heads_k_stride) * nheads // nheads_k)
+            q_i = q[:, q_slice]
+            dout_i = dout[:, q_slice]
+            out_i = out[:, q_slice]
+            dq_i = dq[:, q_slice]
+            lse_i = softmax_lse[q_slice].contiguous()
+
+            comm.wait()
+            kv_buffer, kv_buffer_copy = kv_buffer_copy, kv_buffer
+            if i < nheads_k - heads_k_stride:
+                left = i + heads_k_stride
+                right = left + heads_k_stride
+                comm.all_gather(kv_buffer_copy[0], k[:, left:right].contiguous())
+                comm.all_gather(kv_buffer_copy[1], v[:, left:right].contiguous())
+
+            k_i = kv_buffer[0][local_k_slice]
+            v_i = kv_buffer[1][local_k_slice]
+            dk_i = dkv_buffer[0][local_k_slice]
+            dv_i = dkv_buffer[1][local_k_slice]
+
+            _fa4_varlen_backward(
+                dout=dout_i,
+                q=q_i,
+                k=k_i,
+                v=v_i,
+                out=out_i,
+                softmax_lse=lse_i,
+                cu_seqlens_q=cu_seqlens_q,
+                cu_seqlens_k=cu_seqlens_k,
+                max_seqlen_q=ctx.max_seqlen_q,
+                max_seqlen_k=ctx.max_seqlen_k,
+                dq=dq_i,
+                dk=dk_i,
+                dv=dv_i,
+                softmax_scale=ctx.softmax_scale,
+                causal=causal,
+                window_size=ctx.window_size,
+            )
+
+            if heads_k_stride != nheads_k:
+                dk_i = kv_contiguous_buffer[0]
+                dv_i = kv_contiguous_buffer[1]
+            else:
+                dk_i = dk
+                dv_i = dv
+
+            dist.reduce_scatter_tensor(dk_i, dkv_buffer[0], group=group)
+            dist.reduce_scatter_tensor(dv_i, dkv_buffer[1], group=group)
+            if heads_k_stride != nheads_k:
+                dk[:, i : i + heads_k_stride] = dk_i
+                dv[:, i : i + heads_k_stride] = dv_i
+
+        # Grads for: q, k, v, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k,
+        #            local_k_slice_start, local_k_slice_stop, heads_k_stride, causal, group_name,
+        #            window_size_left, window_size_right
+        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None
+
+
+def ring_fa4_varlen_func(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    local_k_slice: slice,
+    causal: bool,
+    heads_k_stride: int,
+    group: dist.ProcessGroup,
+    window_size: tuple[int, int] = (-1, -1),
+) -> torch.Tensor:
+    return _RingFA4Varlen.apply(
+        q,
+        k,
+        v,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        max_seqlen_q,
+        max_seqlen_k,
+        local_k_slice.start,
+        local_k_slice.stop,
+        heads_k_stride,
+        causal,
+        group.group_name,
+        window_size[0],
+        window_size[1],
+    )


### PR DESCRIPTION
Mirrors the FA3 ring attention pattern (all-gather K/V, compute per GQA stride, reduce-scatter grads) using FA4 low-level _flash_attn_fwd/_flash_attn_bwd.

Changes:
- ring_attn.py: FA4 forward/backward wrappers, _RingFA4Varlen autograd Function, ring_fa4_varlen_func public API
- attn.py: route FA4 to ring_fa4_varlen_func in substitute_ring_attn
- trainer.py: allow CP with fa4 (requires model.impl='custom')

Notes:
Integration tests failures are due to missing wandb API keys. Need to re-trigger the tests from an internal branch. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches performance-critical distributed attention and custom autograd paths; incorrect FA4 kernel argument/collective behavior could cause silent numerical issues or training hangs in CP mode.
> 
> **Overview**
> Adds **FlashAttention-4 (FA4)** support to context-parallel ring attention.
> 
> Config validation now allows `model.attn="fa4"` with `model.cp>1` (and enforces `model.impl="custom"`), `substitute_ring_attn` routes `fa4` to a new ring kernel, and `FlashAttention._compute_attention` updates its FA4 call signature to pass `cu_seqlens_*` by keyword to match FA4’s positional args.
> 
> Introduces an FA4 ring-attention implementation in `ring_attn.py` (FA4 forward/backward wrappers plus `_RingFA4Varlen` autograd Function) that mirrors the FA3 pattern with all-gather K/V per GQA stride and reduce-scatter gradients.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55ea0b37b7675e8128f5d0d4ceeb380f6149b479. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->