### PR TITLE
fix: check rollout error before empty trajectory in scheduler

### DIFF
--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -434,20 +434,20 @@ class Scheduler:
                     valid_rollouts = []
                     has_failures = False
                     for rollout in rollouts:
-                        if len(rollout["trajectory"]) == 0:
-                            self.empty_rollouts_by_env[env_name] += 1
-                            has_failures = True
-                            self.logger.warning(
-                                f"Empty trajectory in group {group_id} ({env_name}), re-scheduling "
-                                f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete)"
-                            )
-                        elif rollout["error"] is not None:
+                        if rollout["error"] is not None:
                             self.errored_rollouts_by_env[env_name] += 1
                             has_failures = True
                             self.logger.warning(
                                 f"Rollout error in group {group_id} ({env_name}), re-scheduling "
                                 f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete): "
                                 f"{rollout['error']['error_chain_repr']}"
+                            )
+                        elif len(rollout["trajectory"]) == 0:
+                            self.empty_rollouts_by_env[env_name] += 1
+                            has_failures = True
+                            self.logger.warning(
+                                f"Empty trajectory in group {group_id} ({env_name}), re-scheduling "
+                                f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete)"
                             )
                         else:
                             rollout["env_name"] = env_name


### PR DESCRIPTION
## Summary

The orchestrator scheduler misclassifies errored rollouts whose `trajectory` is `[]` as "Empty trajectory", swallowing the diagnostic set by verifiers' `CliAgentEnv` (see PrimeIntellect-ai/verifiers#1127 and PrimeIntellect-ai/verifiers#1130). When `CliAgentEnv` catches an agent crash before the first LLM call, it sets `state["error"]` but produces no messages, so the trajectory stays empty. Under the current branch order in `Scheduler.generate_batch_rollouts` the empty-trajectory check fires first and the `AgentError(exit_code=..., stderr_snippet=...)` payload in `rollout["error"]` is never logged.

## Fix

In `src/prime_rl/orchestrator/scheduler.py`, swap the order of the two failure branches in the rollout post-processing loop: check `rollout["error"] is not None` first, then fall back to the empty-trajectory branch. The counters (`errored_rollouts_by_env` / `empty_rollouts_by_env`), `has_failures` handling, and the `requires_group_scoring` group-clear logic below are unchanged — only the branch order flips.

## Impact

In the current opencode-math ablation training runs this path fires ~9000 times per step. Today those all surface as a blind "Empty trajectory" warning; after this fix they will surface as "Rollout error ...: AgentError(exit_code=..., stderr_snippet=...)" with the actual crash reason, making the verifiers `CliAgentEnv` fix visible to operators.

## Testing

No regression test was added: the affected branches live inline inside `generate_batch_rollouts`'s main `while batch_progress < self.batch_target` loop rather than a standalone helper, and covering them end-to-end would require mocking the full inflight-task / group / env machinery. Extracting the classification into a testable helper is a separate refactor and out of scope for this fix. `uv run ruff check` and `uv run ruff format --check` pass on the changed file.

## Related

- PrimeIntellect-ai/verifiers#1127
- PrimeIntellect-ai/verifiers#1130

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tiny control-flow change limited to warning/counter classification during rollout post-processing; no changes to scheduling mechanics or data handling.
> 
> **Overview**
> Fixes rollout post-processing in `Scheduler.generate_batch` to **prioritize `rollout["error"]` over empty `trajectory`** when classifying failures.
> 
> This ensures errored rollouts with no messages are counted/logged as *errors* (including the error chain) rather than being misreported as “Empty trajectory”, while rescheduling and group-scoring behavior stays the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2789a9df0559f151fd06ea8ee18d107cbf586fca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->