### PR TITLE
hrl dev90 cherry-pick #2308

### DIFF
--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -434,20 +434,20 @@ class Scheduler:
                     valid_rollouts = []
                     has_failures = False
                     for rollout in rollouts:
-                        if len(rollout["trajectory"]) == 0:
-                            self.empty_rollouts_by_env[env_name] += 1
-                            has_failures = True
-                            self.logger.warning(
-                                f"Empty trajectory in group {group_id} ({env_name}), re-scheduling "
-                                f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete)"
-                            )
-                        elif rollout["error"] is not None:
+                        if rollout["error"] is not None:
                             self.errored_rollouts_by_env[env_name] += 1
                             has_failures = True
                             self.logger.warning(
                                 f"Rollout error in group {group_id} ({env_name}), re-scheduling "
                                 f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete): "
                                 f"{rollout['error']['error_chain_repr']}"
+                            )
+                        elif len(rollout["trajectory"]) == 0:
+                            self.empty_rollouts_by_env[env_name] += 1
+                            has_failures = True
+                            self.logger.warning(
+                                f"Empty trajectory in group {group_id} ({env_name}), re-scheduling "
+                                f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete)"
                             )
                         else:
                             rollout["env_name"] = env_name


### PR DESCRIPTION
Branch = v0.5.1.dev90 + cherry-pick of #2308 (`fix: check rollout error before empty trajectory in scheduler`).

Built to unblock hosted-RL runs hitting the empty-trajectory pattern (glm47 today).

Note: base is v0.5.1.dev90 tag — diff against main will show all intermediate commits. Adjust base if needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small conditional reordering in the orchestrator scheduler; behavior change is limited to rollout failure classification/logging and rescheduling decisions.
> 
> **Overview**
> Fixes scheduler rollout validation to **check `rollout["error"]` before treating a rollout as an empty trajectory**.
> 
> This ensures errored rollouts are counted/logged as errors (with the error chain) and rescheduled appropriately, instead of being misclassified as empty trajectories when both conditions could apply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92eb836e329fcb560c245a4ed16b1f3b68160440. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->