### PR TITLE
fix: serialize env server spawn to avoid port race

### DIFF
--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -352,10 +352,13 @@ class Envs(Generic[EnvT]):
         log_level: str | None = None,
         json_logging: bool = False,
     ) -> None:
-        """Spawn env servers (where needed) and connect all env clients in parallel."""
-        await asyncio.gather(
-            *(env.start(log_dir=log_dir, log_level=log_level, json_logging=json_logging) for env in self)
-        )
+        """Spawn env servers (where needed) and connect env clients one at a time.
+
+        Serialized to avoid a TOCTOU port race: get_free_port() only holds the port
+        until it returns, so parallel spawns can hand the same port to two children.
+        """
+        for env in self:
+            await env.start(log_dir=log_dir, log_level=log_level, json_logging=json_logging)
         atexit.register(self.shutdown)
 
     def shutdown(self) -> None:


### PR DESCRIPTION
## Summary

Env servers were being spawned in parallel via `asyncio.gather` in `Envs.start`. Each spawn asks `verifiers.utils.serve_utils.get_free_port()` for a free port, but that function binds port 0, reads the assigned port, and **closes the socket** before returning — nothing holds the port. The child process then has to cold-boot (import verifiers, load the environment, spawn N env workers, initialize the router) before `ZMQEnvServer.__init__` finally calls `frontend.bind`.

Under `asyncio.gather`, while env A awaits `wait_for_server_startup()`, env B's `_spawn` runs and calls `get_free_port()` on a kernel that just handed port 45861 to env A's still-not-bound child. The kernel happily hands back the same port. Whichever child binds second dies with `EADDRINUSE`, surfacing as:

```
WARNING Rollout failed: OSError(98, "error while attempting to bind on address ('0.0.0.0', 45861): [errno 98] address already in use") [scheduler.py::474]
```

More env workers per server = longer child init = wider race window, which is why the failure correlated with many envs × many workers.

Fix: serialize `env.start()` so the next env's `get_free_port()` only runs after the previous server's `frontend.bind()` has landed (`wait_for_server_startup()` already gates on this).

## Tradeoff

Env-server startup is now O(N) instead of parallel. One-time cost at scheduler init; no effect on rollout throughput.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small orchestration change limited to startup sequencing; main impact is slower one-time env initialization and reduced chance of `EADDRINUSE` port collisions.
> 
> **Overview**
> `Envs.start()` now starts environments **serially** instead of via `asyncio.gather`, to prevent a TOCTOU race where parallel calls to `get_free_port()` can allocate the same port to multiple env server processes.
> 
> Adds an explanatory docstring noting the port-allocation/bind timing issue; shutdown behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbdec8b7540dc10613d47cf1e7ba50f243330d75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->