### PR TITLE
chore: remove prefix-cache-salt and reset-prefix-cache config flags

### DIFF
--- a/src/prime_rl/configs/inference.py
+++ b/src/prime_rl/configs/inference.py
@@ -244,6 +244,10 @@ InferenceDeploymentConfig: TypeAlias = Annotated[
 ]
 
 
+class InferenceExperimentalConfig(BaseConfig):
+    """Experimental features for inference."""
+
+
 class InferenceConfig(BaseConfig):
     """Configures inference."""
 
@@ -412,6 +416,11 @@ class InferenceConfig(BaseConfig):
     output_dir: Annotated[Path, Field(description="Directory for SLURM logs and generated scripts.")] = Path("outputs")
 
     dry_run: Annotated[bool, Field(description="Only validate and dump resolved configs and exit early.")] = False
+
+    experimental: Annotated[
+        InferenceExperimentalConfig,
+        Field(description="Experimental features for inference."),
+    ] = InferenceExperimentalConfig()
 
     @model_validator(mode="after")
     def validate_multi_node_requires_slurm(self):

--- a/src/prime_rl/configs/inference.py
+++ b/src/prime_rl/configs/inference.py
@@ -244,19 +244,6 @@ InferenceDeploymentConfig: TypeAlias = Annotated[
 ]
 
 
-class InferenceExperimentalConfig(BaseConfig):
-    """Experimental features for inference."""
-
-    reset_prefix_cache_after_update: Annotated[
-        bool,
-        Field(
-            description="Whether to reset the prefix cache after weight updates (update_weights, load_lora_adapter). "
-            "Ensures all KV states are recomputed with the new weights at the cost of extra prefill. "
-            "When False, prefer using orchestrator.experimental.use_prefix_cache_salt to invalidate stale caches via salt instead.",
-        ),
-    ] = False
-
-
 class InferenceConfig(BaseConfig):
     """Configures inference."""
 
@@ -425,11 +412,6 @@ class InferenceConfig(BaseConfig):
     output_dir: Annotated[Path, Field(description="Directory for SLURM logs and generated scripts.")] = Path("outputs")
 
     dry_run: Annotated[bool, Field(description="Only validate and dump resolved configs and exit early.")] = False
-
-    experimental: Annotated[
-        InferenceExperimentalConfig,
-        Field(description="Experimental features for inference."),
-    ] = InferenceExperimentalConfig()
 
     @model_validator(mode="after")
     def validate_multi_node_requires_slurm(self):

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -809,19 +809,6 @@ WeightBroadcastConfig: TypeAlias = Annotated[
 ]
 
 
-class OrchestratorExperimentalConfig(BaseConfig):
-    """Experimental features for the orchestrator."""
-
-    use_prefix_cache_salt: Annotated[
-        bool,
-        Field(
-            description="Whether to set a cache_salt on inference requests that changes with each weight update. "
-            "This invalidates prefix-cached KV states from previous policies without resetting the entire cache, "
-            "while preserving cache hits for in-flight off-policy rollouts.",
-        ),
-    ] = True
-
-
 class TeacherModelConfig(BaseConfig):
     """Configures the teacher model for computing teacher logprobs (e.g. for distillation)."""
 
@@ -1051,11 +1038,6 @@ class OrchestratorConfig(BaseConfig):
             description="Allow pre-release versions when installing environments (e.g. verifiers>=0.1.12.dev5). Passes --prerelease to prime env install."
         ),
     ] = False
-
-    experimental: Annotated[
-        OrchestratorExperimentalConfig,
-        Field(description="Experimental features for the orchestrator."),
-    ] = OrchestratorExperimentalConfig()
 
     @model_validator(mode="before")
     @classmethod

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -809,6 +809,10 @@ WeightBroadcastConfig: TypeAlias = Annotated[
 ]
 
 
+class OrchestratorExperimentalConfig(BaseConfig):
+    """Experimental features for the orchestrator."""
+
+
 class TeacherModelConfig(BaseConfig):
     """Configures the teacher model for computing teacher logprobs (e.g. for distillation)."""
 
@@ -1038,6 +1042,11 @@ class OrchestratorConfig(BaseConfig):
             description="Allow pre-release versions when installing environments (e.g. verifiers>=0.1.12.dev5). Passes --prerelease to prime env install."
         ),
     ] = False
+
+    experimental: Annotated[
+        OrchestratorExperimentalConfig,
+        Field(description="Experimental features for the orchestrator."),
+    ] = OrchestratorExperimentalConfig()
 
     @model_validator(mode="before")
     @classmethod

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -198,24 +198,16 @@ async def resume(request: Request):
 async def update_weights(request: Request):
     data = await request.json()
     await engine_client(request).collective_rpc("update_weights_from_path", args=(data.get("weight_dir"),))
-    if request.app.state.reset_prefix_cache_after_update:
-        await engine_client(request).reset_prefix_cache()
     return {"status": "ok"}
 
 
 @router.post("/load_lora_adapter")
 async def load_lora_adapter(lora_request: LoadLoRAAdapterRequest, raw_request: Request):
-    """Load a LoRA adapter, optionally resetting the prefix cache.
-
-    Wrapper around vLLM's /v1/load_lora_adapter that also resets the prefix cache
-    to invalidate KV states computed with old weights (unless disabled via config).
-    """
+    """Wrapper around vLLM's /v1/load_lora_adapter."""
     handler = models(raw_request)
     response = await handler.load_lora_adapter(lora_request)
     if isinstance(response, ErrorResponse):
         return JSONResponse(content=response.model_dump(), status_code=response.error.code)
-    if raw_request.app.state.reset_prefix_cache_after_update:
-        await engine_client(raw_request).reset_prefix_cache()
     return {"status": "ok"}
 
 
@@ -273,8 +265,6 @@ async def custom_init_app_state(
     2. Replace the serving_chat with our OpenAIServingChatWithTokens wrapper.
     """
     await init_app_state(engine_client, state, args, supported_tasks)
-
-    state.reset_prefix_cache_after_update = getattr(args, "reset_prefix_cache_after_update", True)
 
     if "generate" in supported_tasks and state.openai_serving_chat is not None:
         original_chat = state.openai_serving_chat
@@ -342,7 +332,6 @@ def server(config: InferenceConfig, vllm_extra: dict[str, Any] | None = None):
 
     args.tool_call_parser = resolve_tool_call_parser(args.model, args.tool_call_parser)
     args.enable_auto_tool_choice = args.tool_call_parser is not None
-    args.reset_prefix_cache_after_update = config.experimental.reset_prefix_cache_after_update
     if args.tool_call_parser is not None:
         logger.info(f"Using tool_call_parser='{args.tool_call_parser}' for model '{args.model}'")
 

--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -104,9 +104,7 @@ class Env:
         self._env_server_process = process
         return address
 
-    def _sampling_args_with_salt(self, cache_salt: str | None) -> dict:
-        if cache_salt is None:
-            return self.sampling_args
+    def _sampling_args_with_salt(self, cache_salt: str) -> dict:
         sampling_args = {**self.sampling_args}
         extra_body = {**sampling_args.get("extra_body", {}), "cache_salt": cache_salt}
         sampling_args["extra_body"] = extra_body
@@ -117,7 +115,7 @@ class Env:
         client: vf.ClientConfig,
         example: dict,
         model_name: str,
-        cache_salt: str | None = None,
+        cache_salt: str,
     ) -> vf.RolloutOutput:
         """Run a single rollout for an example."""
         return await self.env.run_rollout(
@@ -136,7 +134,7 @@ class Env:
         example: dict,
         model_name: str,
         rollouts_per_example: int,
-        cache_salt: str | None = None,
+        cache_salt: str,
     ) -> list[vf.RolloutOutput]:
         """Run a group of rollouts for an example. Required for group-scoring envs."""
         return await self.env.run_group(
@@ -181,7 +179,7 @@ class EvalEnv(Env):
         get_client: Callable[[], Awaitable[vf.ClientConfig]],
         ckpt_step: int,
         step: int,
-        cache_salt: str | None = None,
+        cache_salt: str,
     ) -> list[vf.RolloutOutput]:
         num_examples = len(self.examples)
         rollouts_per_example = self.config.rollouts_per_example

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -236,7 +236,6 @@ async def orchestrate(config: OrchestratorConfig):
         enable_policy_updates=enable_policy_updates,
         lora_name=config.model.lora.name if config.model.lora else None,
         config=config,
-        use_prefix_cache_salt=config.experimental.use_prefix_cache_salt,
     )
     scheduler.model_name = rollout_model_name
 
@@ -380,7 +379,6 @@ async def orchestrate(config: OrchestratorConfig):
                 logger.info("Cancelling in-flight training rollouts before starting evals to avoid congestion.")
                 await scheduler.cancel_inflight_rollouts()
 
-            eval_cache_salt = str(ckpt_step) if config.experimental.use_prefix_cache_salt else None
             eval_results = await asyncio.gather(
                 *[
                     eval_env.evaluate(
@@ -388,7 +386,7 @@ async def orchestrate(config: OrchestratorConfig):
                         get_client=inference_pool.get_eval_client,
                         ckpt_step=ckpt_step,
                         step=progress.step,
-                        cache_salt=eval_cache_salt,
+                        cache_salt=str(ckpt_step),
                     )
                     for eval_env in envs_to_eval
                 ]
@@ -718,7 +716,6 @@ async def orchestrate(config: OrchestratorConfig):
 
     if config.eval and eval_envs is not None:
         logger.info("Running final evals")
-        final_cache_salt = str(ckpt_step) if config.experimental.use_prefix_cache_salt else None
         eval_results = await asyncio.gather(
             *[
                 eval_env.evaluate(
@@ -726,7 +723,7 @@ async def orchestrate(config: OrchestratorConfig):
                     get_client=inference_pool.get_eval_client,
                     ckpt_step=ckpt_step,
                     step=progress.step,
-                    cache_salt=final_cache_salt,
+                    cache_salt=str(ckpt_step),
                 )
                 for eval_env in eval_envs
             ]

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -68,7 +68,6 @@ class Scheduler:
         tasks_per_minute: int | None,
         enable_policy_updates: bool = True,
         lora_name: str | None = None,
-        use_prefix_cache_salt: bool = False,
     ):
         self.logger = get_logger()
         if tasks_per_minute is not None:
@@ -87,7 +86,6 @@ class Scheduler:
         self.strict_async_level = strict_async_level
         self.enable_policy_updates = enable_policy_updates
         self.lora_name = lora_name
-        self.use_prefix_cache_salt = use_prefix_cache_salt
         self.model_name = self.config.model.name
         self.json_logging = config.log.json_logging
 
@@ -198,7 +196,7 @@ class Scheduler:
         env_name = group.example["env_name"]
         env = self.train_envs.get(env_name)
 
-        cache_salt = str(self.ckpt_step) if self.use_prefix_cache_salt else None
+        cache_salt = str(self.ckpt_step)
         if env.requires_group_scoring:
             rollout_count = group.rollouts_to_schedule
             group.rollouts_to_schedule = 0

--- a/tests/unit/orchestrator/test_scheduler.py
+++ b/tests/unit/orchestrator/test_scheduler.py
@@ -29,7 +29,6 @@ def make_scheduler() -> Scheduler:
     scheduler.inflight_policy_update_task = None
     scheduler.update_policy_task = None
     scheduler.enable_policy_updates = True
-    scheduler.use_prefix_cache_salt = False
     return scheduler
 
 


### PR DESCRIPTION
## Summary

- Drop the `orchestrator.experimental.use_prefix_cache_salt` flag — always salt inference requests with `str(ckpt_step)`, for both training rollouts and evals.
- Drop the `inference.experimental.reset_prefix_cache_after_update` flag — the `/update_weights` and `/load_lora_adapter` endpoints no longer reset the prefix cache. The salt alone is sufficient to invalidate stale KV states across policy updates, making the reset path redundant.
- Remove the now-empty `OrchestratorExperimentalConfig` and `InferenceExperimentalConfig` classes and their parent `experimental` fields.
- Tighten `cache_salt` typing in `envs.py` from `str | None` to `str` (always set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes inference cache invalidation behavior by removing prefix-cache resets on weight/LoRA updates and making `cache_salt` mandatory and always derived from `ckpt_step`, which could affect serving performance/correctness if assumptions about vLLM cache salting are wrong.
> 
> **Overview**
> Removes the configurable prefix-cache invalidation toggles (`orchestrator.experimental.use_prefix_cache_salt` and `inference.experimental.reset_prefix_cache_after_update`) and their associated wiring.
> 
> The orchestrator/scheduler now **always** injects `cache_salt=str(ckpt_step)` for training rollouts and evals (and `cache_salt` is now a required `str` throughout env APIs). Inference `/update_weights` and `/load_lora_adapter` no longer reset the vLLM prefix cache after applying updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26fdbc9aa39fd40fa4328e0e1a2fe25a8226cb90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->