### PR TITLE
fix: complete Prime monitor v1 finalize and samples flow

### DIFF
--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -67,6 +67,26 @@ class PrimeMonitor(Monitor):
             "Content-Type": "application/json",
         }
 
+    def _uses_public_monitoring_api(self) -> bool:
+        """Return whether this monitor is talking to the public v1 monitoring API."""
+        return urlparse(self.base_url).path.rstrip("/").endswith("/api/v1/rft")
+
+    def _normalize_presign_response(self, payload: Any) -> dict[str, str] | None:
+        """Normalize presign responses across legacy and public API shapes."""
+        if not isinstance(payload, dict):
+            return None
+
+        response_data = payload.get("data", payload)
+        if not isinstance(response_data, dict):
+            return None
+
+        presigned_url = response_data.get("presigned_url") or response_data.get("presignedUrl")
+        s3_key = response_data.get("s3_key") or response_data.get("s3Key")
+        if not isinstance(presigned_url, str) or not isinstance(s3_key, str):
+            return None
+
+        return {"presigned_url": presigned_url, "s3_key": s3_key}
+
     def __init__(
         self,
         config: PrimeMonitorConfig | None,
@@ -375,10 +395,6 @@ class PrimeMonitor(Monitor):
                 self.logger.warning(f"Failed to get presigned URL for samples at step {step}")
                 return
 
-            if "presigned_url" not in presign_data or "s3_key" not in presign_data:
-                self.logger.warning(f"Invalid presign response at step {step}")
-                return
-
             presigned_url = presign_data["presigned_url"]
             s3_key = presign_data["s3_key"]
 
@@ -411,7 +427,10 @@ class PrimeMonitor(Monitor):
                 json={"run_id": self.run_id, "step": step},
             )
             response.raise_for_status()
-            return response.json()
+            presign_data = self._normalize_presign_response(response.json())
+            if presign_data is None:
+                self.logger.warning(f"Invalid presign response at step {step}")
+            return presign_data
         except Exception as e:
             self.logger.warning(f"Failed to request presigned URL: {type(e).__name__}: {e}")
             return None
@@ -497,22 +516,46 @@ class PrimeMonitor(Monitor):
             f"Logged distributions at step {step} to Prime Intellect API in {time.perf_counter() - start_time:.2f}s"
         )
 
+    def _submit_final_summary(self, summary: dict[str, Any]) -> bool:
+        """Submit the final summary/finalize request synchronously."""
+        try:
+            response = httpx.post(
+                f"{self.base_url}/finalize",
+                headers=self._api_headers(),
+                json={"run_id": self.run_id, "summary": summary},
+                timeout=30,
+            )
+        except httpx.HTTPError as e:
+            self.logger.warning(f"Failed to submit final summary for platform run {self.run_id}: {e}")
+            return False
+
+        if response.status_code != 200:
+            self.logger.warning(
+                f"Failed to submit final summary for platform run {self.run_id} "
+                f"(HTTP {response.status_code}): {response.text}"
+            )
+            return False
+
+        return True
+
     def save_final_summary(self, filename: str = "final_summary.json") -> None:
         """Save final summary to Prime Intellect API."""
         if not self.is_master or not self.enabled:
             return
 
         self.logger.info("Saving final summary to Prime Intellect API")
-        self._make_request(
-            "finalize",
-            {
-                "run_id": self.run_id,
-                "summary": self.history[-1] if self.history else {},
-            },
-        )
-        if os.getpid() == self._owner_pid:
-            self._finalize_run(success=True)
+        summary = self.history[-1] if self.history else {}
+        finalized_via_summary = self._submit_final_summary(summary)
+
+        if os.getpid() != self._owner_pid:
+            return
+
+        if finalized_via_summary and self._uses_public_monitoring_api():
             self._finalized = True
+            return
+
+        self._finalize_run(success=True)
+        self._finalized = True
 
     def close(self) -> None:
         """Close the HTTP client and stop the background event loop."""

--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -59,6 +59,14 @@ _SAMPLE_SCHEMA = pa.schema(
 class PrimeMonitor(Monitor):
     """Logs to Prime Intellect API."""
 
+    def _api_headers(self) -> dict[str, str]:
+        """Return auth headers accepted by Prime's monitoring API."""
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "x-api-key": self.api_key,
+            "Content-Type": "application/json",
+        }
+
     def __init__(
         self,
         config: PrimeMonitorConfig | None,
@@ -133,8 +141,7 @@ class PrimeMonitor(Monitor):
 
     def _register_run(self, config: PrimeMonitorConfig, run_config: BaseConfig | None) -> str | None:
         """Register an external run with the platform. Returns run_id on success, None on failure."""
-        registration_api_key = self.api_key
-        if not registration_api_key:
+        if not self.api_key:
             self.logger.warning(
                 f"Prime Intellect API key not found. Set {config.api_key_var} environment variable or run `prime login`. "
                 "PrimeMonitor will not be able to register or upload data."
@@ -174,7 +181,7 @@ class PrimeMonitor(Monitor):
         try:
             response = httpx.post(
                 f"{api_base}/external-runs",
-                headers={"Authorization": f"Bearer {registration_api_key}"},
+                headers=self._api_headers(),
                 json=payload,
                 timeout=30,
             )
@@ -203,7 +210,6 @@ class PrimeMonitor(Monitor):
         if not getattr(self, "_registered", False):
             return
 
-        registration_api_key = self.api_key
         payload: dict = {"status": "completed" if success else "failed"}
         status_label = "completed" if success else "failed"
         self.logger.info(f"Finalizing platform run {self.run_id} as {status_label}")
@@ -214,7 +220,7 @@ class PrimeMonitor(Monitor):
         try:
             response = httpx.put(
                 finalize_url,
-                headers={"Authorization": f"Bearer {registration_api_key}"},
+                headers=self._api_headers(),
                 json=payload,
                 timeout=30,
             )
@@ -398,11 +404,10 @@ class PrimeMonitor(Monitor):
 
     async def _request_presigned_url(self, step: int) -> dict[str, Any] | None:
         """Request a presigned URL from the backend."""
-        headers = {"x-api-key": self.api_key, "Content-Type": "application/json"}
         try:
             response = await self._client.post(
                 f"{self.base_url}/samples/presign",
-                headers=headers,
+                headers=self._api_headers(),
                 json={"run_id": self.run_id, "step": step},
             )
             response.raise_for_status()
@@ -430,12 +435,11 @@ class PrimeMonitor(Monitor):
 
     async def _confirm_samples_upload(self, step: int, s3_key: str, max_retries: int = 3) -> bool:
         """Confirm samples upload with the backend. Returns True on success."""
-        headers = {"x-api-key": self.api_key, "Content-Type": "application/json"}
         for attempt in range(max_retries):
             try:
                 response = await self._client.post(
                     f"{self.base_url}/samples/confirm",
-                    headers=headers,
+                    headers=self._api_headers(),
                     json={"run_id": self.run_id, "step": step, "s3_key": s3_key},
                 )
                 response.raise_for_status()
@@ -580,17 +584,13 @@ class PrimeMonitor(Monitor):
 
     async def _make_request_async(self, endpoint: str, data: dict[str, Any], max_retries: int = 3) -> None:
         """Make an async POST request to the Prime Intellect API with retries."""
-        headers = {
-            "x-api-key": self.api_key,
-            "Content-Type": "application/json",
-        }
         full_endpoint = f"{self.base_url}/{endpoint}"
 
         for attempt in range(max_retries):
             try:
                 response = await self._client.post(
                     full_endpoint,
-                    headers=headers,
+                    headers=self._api_headers(),
                     json=data,
                 )
                 response.raise_for_status()

--- a/tests/unit/utils/test_prime_monitor.py
+++ b/tests/unit/utils/test_prime_monitor.py
@@ -1,9 +1,19 @@
+import asyncio
 import io
 import json
+from unittest.mock import AsyncMock, MagicMock
 
 import pyarrow.parquet as pq
 
 from prime_rl.utils.monitor.prime import PrimeMonitor
+
+
+def _make_monitor(**attrs) -> PrimeMonitor:
+    monitor = PrimeMonitor.__new__(PrimeMonitor)
+    monitor._closed = True
+    for key, value in attrs.items():
+        setattr(monitor, key, value)
+    return monitor
 
 
 def _build_rollout(*, example_id: int, reward: float, task: str) -> dict:
@@ -35,8 +45,7 @@ def _build_rollout(*, example_id: int, reward: float, task: str) -> dict:
 
 
 def test_rollouts_to_parquet_bytes_preserves_all_rollouts_and_ids():
-    monitor = PrimeMonitor.__new__(PrimeMonitor)
-    monitor.run_id = "run-123"
+    monitor = _make_monitor(run_id="run-123")
 
     parquet_bytes = monitor._rollouts_to_parquet_bytes(
         [
@@ -61,8 +70,7 @@ def test_rollouts_to_parquet_bytes_preserves_all_rollouts_and_ids():
 
 
 def test_rollouts_to_parquet_bytes_skips_rollouts_without_trajectory():
-    monitor = PrimeMonitor.__new__(PrimeMonitor)
-    monitor.run_id = "run-456"
+    monitor = _make_monitor(run_id="run-456")
 
     parquet_bytes = monitor._rollouts_to_parquet_bytes(
         [
@@ -85,3 +93,90 @@ def test_rollouts_to_parquet_bytes_skips_rollouts_without_trajectory():
     assert len(rows) == 1
     assert rows[0]["problem_id"] == 1
     assert rows[0]["sample_id"] == 0
+
+
+def test_api_headers_include_bearer_and_x_api_key():
+    monitor = _make_monitor(api_key="pit-test")
+
+    assert monitor._api_headers() == {
+        "Authorization": "Bearer pit-test",
+        "x-api-key": "pit-test",
+        "Content-Type": "application/json",
+    }
+
+
+def test_make_request_async_uses_bearer_auth_headers():
+    monitor = _make_monitor(
+        api_key="pit-test",
+        base_url="https://api.primeintellect.ai/api/v1/rft",
+        _client=AsyncMock(),
+    )
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    monitor._client.post.return_value = response
+    monitor.logger = MagicMock()
+
+    asyncio.run(monitor._make_request_async("metrics", {"run_id": "run-123"}, max_retries=1))
+
+    monitor._client.post.assert_called_once_with(
+        "https://api.primeintellect.ai/api/v1/rft/metrics",
+        headers={
+            "Authorization": "Bearer pit-test",
+            "x-api-key": "pit-test",
+            "Content-Type": "application/json",
+        },
+        json={"run_id": "run-123"},
+    )
+
+
+def test_request_presigned_url_uses_bearer_auth_headers():
+    monitor = _make_monitor(
+        api_key="pit-test",
+        run_id="run-123",
+        base_url="https://api.primeintellect.ai/api/v1/rft",
+        _client=AsyncMock(),
+    )
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.json.return_value = {"presigned_url": "https://upload", "s3_key": "samples/key"}
+    monitor._client.post.return_value = response
+    monitor.logger = MagicMock()
+
+    presign_data = asyncio.run(monitor._request_presigned_url(step=5))
+
+    assert presign_data == {"presigned_url": "https://upload", "s3_key": "samples/key"}
+    monitor._client.post.assert_called_once_with(
+        "https://api.primeintellect.ai/api/v1/rft/samples/presign",
+        headers={
+            "Authorization": "Bearer pit-test",
+            "x-api-key": "pit-test",
+            "Content-Type": "application/json",
+        },
+        json={"run_id": "run-123", "step": 5},
+    )
+
+
+def test_confirm_samples_upload_uses_bearer_auth_headers():
+    monitor = _make_monitor(
+        api_key="pit-test",
+        run_id="run-123",
+        base_url="https://api.primeintellect.ai/api/v1/rft",
+        _client=AsyncMock(),
+    )
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    monitor._client.post.return_value = response
+    monitor.logger = MagicMock()
+
+    upload_confirmed = asyncio.run(monitor._confirm_samples_upload(step=5, s3_key="samples/key", max_retries=1))
+
+    assert upload_confirmed is True
+    monitor._client.post.assert_called_once_with(
+        "https://api.primeintellect.ai/api/v1/rft/samples/confirm",
+        headers={
+            "Authorization": "Bearer pit-test",
+            "x-api-key": "pit-test",
+            "Content-Type": "application/json",
+        },
+        json={"run_id": "run-123", "step": 5, "s3_key": "samples/key"},
+    )

--- a/tests/unit/utils/test_prime_monitor.py
+++ b/tests/unit/utils/test_prime_monitor.py
@@ -1,9 +1,30 @@
 import asyncio
 import io
 import json
+import os
+import sys
+import types
 from unittest.mock import AsyncMock, MagicMock
 
 import pyarrow.parquet as pq
+
+prime_cli_module = types.ModuleType("prime_cli")
+prime_cli_core_module = types.ModuleType("prime_cli.core")
+prime_cli_config_module = types.ModuleType("prime_cli.core.config")
+
+
+class _FakePrimeConfig:
+    api_key = None
+    team_id = None
+    frontend_url = None
+
+
+prime_cli_config_module.Config = _FakePrimeConfig
+prime_cli_module.core = prime_cli_core_module
+prime_cli_core_module.config = prime_cli_config_module
+sys.modules.setdefault("prime_cli", prime_cli_module)
+sys.modules.setdefault("prime_cli.core", prime_cli_core_module)
+sys.modules.setdefault("prime_cli.core.config", prime_cli_config_module)
 
 from prime_rl.utils.monitor.prime import PrimeMonitor
 
@@ -156,6 +177,24 @@ def test_request_presigned_url_uses_bearer_auth_headers():
     )
 
 
+def test_request_presigned_url_normalizes_public_api_response_shape():
+    monitor = _make_monitor(
+        api_key="pit-test",
+        run_id="run-123",
+        base_url="https://api.primeintellect.ai/api/v1/rft",
+        _client=AsyncMock(),
+    )
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.json.return_value = {"data": {"presignedUrl": "https://upload", "s3Key": "samples/key", "expiresIn": 900}}
+    monitor._client.post.return_value = response
+    monitor.logger = MagicMock()
+
+    presign_data = asyncio.run(monitor._request_presigned_url(step=5))
+
+    assert presign_data == {"presigned_url": "https://upload", "s3_key": "samples/key"}
+
+
 def test_confirm_samples_upload_uses_bearer_auth_headers():
     monitor = _make_monitor(
         api_key="pit-test",
@@ -180,3 +219,42 @@ def test_confirm_samples_upload_uses_bearer_auth_headers():
         },
         json={"run_id": "run-123", "step": 5, "s3_key": "samples/key"},
     )
+
+
+def test_save_final_summary_uses_finalize_endpoint_for_public_api():
+    monitor = _make_monitor(
+        base_url="https://api.primeintellect.ai/api/v1/rft",
+        enabled=True,
+        is_master=True,
+        history=[{"reward/mean": 1.0}],
+        _owner_pid=os.getpid(),
+        _finalized=False,
+    )
+    monitor.logger = MagicMock()
+    monitor._submit_final_summary = MagicMock(return_value=True)
+    monitor._finalize_run = MagicMock()
+
+    monitor.save_final_summary()
+
+    monitor._submit_final_summary.assert_called_once_with({"reward/mean": 1.0})
+    monitor._finalize_run.assert_not_called()
+    assert monitor._finalized is True
+
+
+def test_save_final_summary_falls_back_to_status_update_when_finalize_request_fails():
+    monitor = _make_monitor(
+        base_url="https://api.primeintellect.ai/api/v1/rft",
+        enabled=True,
+        is_master=True,
+        history=[{"reward/mean": 1.0}],
+        _owner_pid=os.getpid(),
+        _finalized=False,
+    )
+    monitor.logger = MagicMock()
+    monitor._submit_final_summary = MagicMock(return_value=False)
+    monitor._finalize_run = MagicMock()
+
+    monitor.save_final_summary()
+
+    monitor._finalize_run.assert_called_once_with(success=True)
+    assert monitor._finalized is True


### PR DESCRIPTION
Builds on the bearer-auth fix by normalizing public v1 presign responses and avoiding duplicate completion updates so PrimeMonitor works end to end with the production monitoring API.