### PR TITLE
chore: silence third-party import noise on CLI startup

### DIFF
--- a/src/prime_rl/_compat.py
+++ b/src/prime_rl/_compat.py
@@ -4,6 +4,42 @@ Imported early (before any model code) by trainer and orchestrator entrypoints.
 Each shim documents the upstream issue and removal condition.
 """
 
+import logging
+import warnings
+
+# ---------------------------------------------------------------------------
+# Third-party warning noise on import
+#
+# - requests 2.33 asserts chardet < 6 but mini-swe-agent-plus → swebench pulls
+#   in chardet 7.x, triggering RequestsDependencyWarning on every import.
+# - tyro mis-handles Annotated[X | Y, Field(discriminator=...)] nested inside
+#   another Union, producing a spurious TyroWarning for our AdvantageConfig.
+#   See tyro/_resolver.py:unwrap_origin_strip_extras.
+#
+# Match by message pattern so we can install the filter before the offending
+# package is imported (importing the warning class would trigger the warning).
+# ---------------------------------------------------------------------------
+warnings.filterwarnings(
+    "ignore",
+    message=r"urllib3 \(.*\) or chardet \(.*\)/charset_normalizer \(.*\) doesn't match a supported version",
+)
+warnings.filterwarnings(
+    "ignore",
+    message=r".*does not match any type in Union.*",
+)
+
+# ---------------------------------------------------------------------------
+# flash_attn.cute leaks DEBUG logs on import
+#
+# flash_attn/cute/cache_utils.py attaches its own StreamHandler and hardcodes
+# logger.setLevel(DEBUG), so "Persistent cache disabled, using in-memory JIT
+# cache" prints five times when flash_attn.cute.interface loads (once per
+# get_jit_cache call in its module body). Those calls fire during the package
+# import itself, so we can't downgrade the logger after-the-fact — install a
+# drop-everything filter on the named logger before the package loads.
+# ---------------------------------------------------------------------------
+logging.getLogger("flash_attn.cute.cache_utils").addFilter(lambda r: False)
+
 # ---------------------------------------------------------------------------
 # ring_flash_attn + transformers >= 5.4
 #

--- a/src/prime_rl/trainer/models/glm4_moe/modeling_glm4_moe.py
+++ b/src/prime_rl/trainer/models/glm4_moe/modeling_glm4_moe.py
@@ -271,7 +271,6 @@ class Glm4MoeForCausalLM(Glm4MoePreTrainedModel, GenerationMixin):
         inputs_embeds: Optional[torch.FloatTensor] = None,
         labels: Optional[torch.LongTensor] = None,
         use_cache: Optional[bool] = None,
-        cache_position: Optional[torch.LongTensor] = None,
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: Optional[torch.Tensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,

--- a/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
+++ b/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
@@ -300,7 +300,6 @@ class GlmMoeDsaForCausalLM(GlmMoeDsaPreTrainedModel, GenerationMixin):
         inputs_embeds: Optional[torch.FloatTensor] = None,
         labels: Optional[torch.LongTensor] = None,
         use_cache: Optional[bool] = None,
-        cache_position: Optional[torch.LongTensor] = None,
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: Optional[torch.Tensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,

--- a/src/prime_rl/trainer/models/llama/modeling_llama.py
+++ b/src/prime_rl/trainer/models/llama/modeling_llama.py
@@ -246,7 +246,6 @@ class LlamaForCausalLM(LlamaPreTrainedModel, GenerationMixin):
         inputs_embeds: Optional[torch.FloatTensor] = None,
         labels: Optional[torch.LongTensor] = None,
         use_cache: Optional[bool] = None,
-        cache_position: Optional[torch.LongTensor] = None,
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: Optional[torch.Tensor] = None,
         **kwargs: Unpack[TransformersKwargs],

--- a/src/prime_rl/trainer/models/minimax_m2/modeling_minimax_m2.py
+++ b/src/prime_rl/trainer/models/minimax_m2/modeling_minimax_m2.py
@@ -233,7 +233,6 @@ class MiniMaxM2ForCausalLM(MiniMaxM2PreTrainedModel, GenerationMixin):
         inputs_embeds: Optional[torch.FloatTensor] = None,
         labels: Optional[torch.LongTensor] = None,
         use_cache: Optional[bool] = None,
-        cache_position: Optional[torch.LongTensor] = None,
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: Union[torch.Tensor, None] = None,
         routed_experts: Optional[torch.LongTensor] = None,

--- a/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
@@ -367,7 +367,6 @@ class Qwen3MoeForCausalLM(Qwen3MoePreTrainedModel, GenerationMixin):
         labels: Optional[torch.LongTensor] = None,
         use_cache: Optional[bool] = None,
         output_router_logits: Optional[bool] = None,
-        cache_position: Optional[torch.LongTensor] = None,
         logits_to_keep: Union[int, torch.Tensor] = 0,
         temperature: Union[torch.Tensor, None] = None,
         routed_experts: Optional[torch.LongTensor] = None,


### PR DESCRIPTION
## Summary

Running `rl -h` (and every other entrypoint) dumps ~15 lines of third-party import noise before the actual help text. This PR tracks down each source and silences them.

Before:

```
/home/.../requests/__init__.py:113: RequestsDependencyWarning: urllib3 (2.5.0) or chardet (7.4.0.post1)/charset_normalizer (3.4.3) doesn't match a supported version!
2026-04-19 04:36:59.314 DEBUG Persistent cache disabled, using in-memory JIT cache   (x5)
[ERROR] `cache_position` is part of Glm4MoeForCausalLM.forward's signature, but not documented...   (x5 models)
/home/.../tyro/_resolver.py:600: TyroWarning: <class '...DefaultAdvantageConfig'> does not match any type in Union: [<class 'types.UnionType'>, <class 'NoneType'>]
```

## What changed

- **`RequestsDependencyWarning`**: `requests 2.33` asserts `chardet < 6`, but `mini-swe-agent-plus` → `swebench` pulls in `chardet 7.4`. Filtered by message pattern.
- **`TyroWarning` on `DefaultAdvantageConfig`**: tyro's `unwrap_origin_strip_extras` returns the bare `types.UnionType` class when it strips `Annotated[X | Y, Field(discriminator=...)]` inside another Union, so the default-type check falsely fails. False positive, filtered by message pattern.
- **`flash_attn.cute.cache_utils` DEBUG ×5**: `flash_attn/cute/cache_utils.py` attaches its own `StreamHandler` and hardcodes `logger.setLevel(DEBUG)`. The five messages fire during `flash_attn.cute.interface`'s module body (one per `get_jit_cache` call), so the logger level can't be lowered after the fact. Installed a drop-everything filter on the named logger before the package loads.
- **`[ERROR] cache_position is part of … signature, but not documented` ×5**: transformers' `@auto_docstring` scans the `forward` signature and `print()`s for every undocumented param. Our custom `ForCausalLM` classes listed `cache_position` in the signature but never used it. Removed it from all five model forwards — upstream `LlamaForCausalLM` doesn't list it either, so callers that pass it will continue to receive it via `**kwargs`.

Filters are installed in `_compat.py` via message pattern (not by class) so they take effect before the offending package is imported (importing the warning class would itself trigger the warning).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only suppress noisy third-party warnings/logs during import and remove an unused `forward` argument from local model wrappers without affecting runtime behavior.
> 
> **Overview**
> Reduces CLI startup noise by adding early `_compat.py` shims that **filter known `requests` and `tyro` warning messages** and **drop all `flash_attn.cute.cache_utils` import-time DEBUG logs**.
> 
> Removes the unused `cache_position` parameter from several custom `ForCausalLM.forward` signatures (GLM4 MoE, GLM MoE DSA, Llama, MiniMax M2, Qwen3 MoE) to stop transformers’ `@auto_docstring` from emitting repeated “[ERROR] … not documented” messages, while still accepting extra kwargs via `**kwargs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0a02d9af0496e0146cca5873957671fc3055b44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->