### PR TITLE
chore: rename deprecated orchestrator config keys

### DIFF
--- a/configs/acereason_math/stage1.toml
+++ b/configs/acereason_math/stage1.toml
@@ -19,11 +19,11 @@ name = "stage1"
 batch_size = 1024
 rollouts_per_example = 8
 
-[orchestrator.sampling]
+[orchestrator.train.sampling]
 temperature = 0.6
-max_tokens = 8192
+max_completion_tokens = 8192
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "math-env"
 args = { dataset_name = "nvidia/AceReason-Math", dataset_subset = "default", question_key = "problem", math_verify_max_workers = 128, math_verify_timeout = 60 }
 

--- a/configs/acereason_math/stage2.toml
+++ b/configs/acereason_math/stage2.toml
@@ -20,11 +20,11 @@ name = "stage2"
 batch_size = 2048
 rollouts_per_example = 16
 
-[orchestrator.sampling]
+[orchestrator.train.sampling]
 temperature = 0.6
-max_tokens = 16384
+max_completion_tokens = 16384
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "math-env"
 args = { dataset_name = "nvidia/AceReason-Math", dataset_subset = "default", question_key = "problem", math_verify_max_workers = 128, math_verify_timeout = 60 }
 

--- a/configs/alphabet_sort/rl.toml
+++ b/configs/alphabet_sort/rl.toml
@@ -13,10 +13,10 @@ name = "Qwen/Qwen3-4B-Instruct-2507"
 batch_size = 512
 rollouts_per_example = 16
 
-[orchestrator.sampling]
-max_tokens = 512
+[orchestrator.train.sampling]
+max_completion_tokens = 512
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "alphabet-sort"
 name = "alphabet-sort"
 args = { min_turns = 2, max_turns = 2 }

--- a/configs/ci/integration/alphabet_sort/start.toml
+++ b/configs/ci/integration/alphabet_sort/start.toml
@@ -13,10 +13,10 @@ lr = 1e-5
 batch_size = 128
 rollouts_per_example = 8
 
-[orchestrator.sampling]
-max_tokens = 384
+[orchestrator.train.sampling]
+max_completion_tokens = 384
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "alphabet-sort"
 name = "alphabet-sort"
 args = { min_turns = 2, max_turns = 2, min_names_per_turn = 1, max_names_per_turn = 3, similarity_power = 4, power_per_turn = false }

--- a/configs/ci/integration/alphabet_sort_branch/start.toml
+++ b/configs/ci/integration/alphabet_sort_branch/start.toml
@@ -18,10 +18,10 @@ lr = 1e-5
 batch_size = 128
 rollouts_per_example = 8
 
-[orchestrator.sampling]
-max_tokens = 1024
+[orchestrator.train.sampling]
+max_completion_tokens = 1024
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "primeintellect/alphabet-sort"
 name = "alphabet-sort"
 args = { min_turns = 2, max_turns = 2, min_names_per_turn = 1, max_names_per_turn = 3, similarity_power = 4, power_per_turn = false }

--- a/configs/ci/integration/rl/resume.toml
+++ b/configs/ci/integration/rl/resume.toml
@@ -14,10 +14,10 @@ lr = 3e-6
 batch_size = 128
 rollouts_per_example = 16
 
-[orchestrator.sampling]
-max_tokens = 128
+[orchestrator.train.sampling]
+max_completion_tokens = 128
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "reverse-text"
 
 [inference]

--- a/configs/ci/integration/rl/start.toml
+++ b/configs/ci/integration/rl/start.toml
@@ -13,10 +13,10 @@ lr = 3e-6
 batch_size = 128
 rollouts_per_example = 16
 
-[orchestrator.sampling]
-max_tokens = 128
+[orchestrator.train.sampling]
+max_completion_tokens = 128
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "reverse-text"
 
 [inference]

--- a/configs/ci/integration/rl_lora/resume.toml
+++ b/configs/ci/integration/rl_lora/resume.toml
@@ -23,10 +23,10 @@ rollouts_per_example = 16
 [orchestrator.model.lora]
 name = "r8-1e-4"
 
-[orchestrator.sampling]
-max_tokens = 128
+[orchestrator.train.sampling]
+max_completion_tokens = 128
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "reverse-text"
 
 [inference]

--- a/configs/ci/integration/rl_lora/start.toml
+++ b/configs/ci/integration/rl_lora/start.toml
@@ -22,10 +22,10 @@ rollouts_per_example = 16
 [orchestrator.model.lora]
 name = "r8-1e-4"
 
-[orchestrator.sampling]
-max_tokens = 128
+[orchestrator.train.sampling]
+max_completion_tokens = 128
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "reverse-text"
 
 [inference]

--- a/configs/ci/integration/rl_moe/start.toml
+++ b/configs/ci/integration/rl_moe/start.toml
@@ -13,10 +13,10 @@ lr = 3e-6
 batch_size = 128
 rollouts_per_example = 16
 
-[orchestrator.sampling]
-max_tokens = 128
+[orchestrator.train.sampling]
+max_completion_tokens = 128
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "reverse-text"
 
 [inference]

--- a/configs/ci/integration/rl_multi_run/orchestrator.toml
+++ b/configs/ci/integration/rl_multi_run/orchestrator.toml
@@ -11,10 +11,10 @@ name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
 [optim]
 lr = 3e-5
 
-[sampling]
-max_tokens = 128
+[train.sampling]
+max_completion_tokens = 128
 
-[[env]]
+[[train.env]]
 id = "reverse-text"
 
 [ckpt]

--- a/configs/ci/nightly/acereason_math.toml
+++ b/configs/ci/nightly/acereason_math.toml
@@ -17,11 +17,11 @@ name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"
 batch_size = 1024
 rollouts_per_example = 8
 
-[orchestrator.sampling]
+[orchestrator.train.sampling]
 temperature = 0.6
-max_tokens = 8192
+max_completion_tokens = 8192
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "math-env"
 name = "acereason-math"
 args = { dataset_name = "nvidia/AceReason-Math", dataset_subset = "default", question_key = "problem", math_verify_max_workers = 128, math_verify_timeout = 60 }

--- a/configs/ci/nightly/multimodal_color_codeword.toml
+++ b/configs/ci/nightly/multimodal_color_codeword.toml
@@ -17,10 +17,10 @@ language_model_attr = "model.language_model"
 batch_size = 256
 rollouts_per_example = 16
 
-[orchestrator.sampling]
-max_tokens = 64
+[orchestrator.train.sampling]
+max_completion_tokens = 64
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "color-codeword"
 args = { images_per_turn = 1, max_turns = 3, num_examples = 1000, seed = 42 }
 

--- a/configs/debug/orch.toml
+++ b/configs/debug/orch.toml
@@ -2,6 +2,6 @@ max_steps = 5
 max_async_level = 5
 batch_size = 16
 
-[sampling]
-max_tokens = 16
+[train.sampling]
+max_completion_tokens = 16
 

--- a/configs/deepscaler/stage1.toml
+++ b/configs/deepscaler/stage1.toml
@@ -19,11 +19,11 @@ interval = 100
 batch_size = 1024
 rollouts_per_example = 8
 
-[orchestrator.sampling]
+[orchestrator.train.sampling]
 temperature = 0.6
-max_tokens = 8192
+max_completion_tokens = 8192
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "math-env"
 name = "deepscaler"
 args = { dataset_name= "agentica-org/DeepScaleR-Preview-Dataset", dataset_subset = "default", question_key = "problem", answer_key = "solution", math_verify_max_workers = 128, math_verify_timeout = 60 }

--- a/configs/deepscaler/stage2.toml
+++ b/configs/deepscaler/stage2.toml
@@ -20,11 +20,11 @@ resume_step = 500
 batch_size = 1024
 rollouts_per_example = 8
 
-[orchestrator.sampling]
+[orchestrator.train.sampling]
 temperature = 0.6
-max_tokens = 16384
+max_completion_tokens = 16384
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "math-env"
 name = "deepscaler"
 args = { dataset_name= "agentica-org/DeepScaleR-Preview-Dataset", dataset_subset = "default", question_key = "problem", answer_key = "solution", math_verify_max_workers = 128, math_verify_timeout = 60 }

--- a/configs/deepscaler/stage3.toml
+++ b/configs/deepscaler/stage3.toml
@@ -20,11 +20,11 @@ resume_step = 1000
 batch_size = 1024
 rollouts_per_example = 8
 
-[orchestrator.sampling]
+[orchestrator.train.sampling]
 temperature = 0.6
-max_tokens = 24576
+max_completion_tokens = 24576
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "math-env"
 name = "deepscaler"
 args = { dataset_name= "agentica-org/DeepScaleR-Preview-Dataset", dataset_subset = "default", question_key = "problem", answer_key = "solution", math_verify_max_workers = 128, math_verify_timeout = 60 }

--- a/configs/elastic/rl.toml
+++ b/configs/elastic/rl.toml
@@ -32,15 +32,15 @@ lr = 1e-5
 batch_size = 512
 rollouts_per_example = 8
 
-[orchestrator.sampling]
-max_tokens = 768
+[orchestrator.train.sampling]
+max_completion_tokens = 768
 
 [orchestrator.client.elastic]
 hostname = "localhost"
 port = 8000
 sync_interval = 5.0
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "alphabet-sort"
 name = "alphabet-sort"
 args = { min_turns = 3, max_turns = 5, power_per_turn = false }

--- a/configs/env_mix/env_mix.toml
+++ b/configs/env_mix/env_mix.toml
@@ -16,27 +16,27 @@ name = "Qwen/Qwen3-4B-Instruct-2507"
 batch_size = 512
 rollouts_per_example = 16
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "math-env"
 name = "math"
 args = { min_avg_reward = 0.1, rubric_max_workers = 128 }
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "code-env"
 name = "code"
 args = { min_avg_reward = 0.1 }
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "science-env"
 name = "science"
 args = { min_avg_reward = 0.1, pool_size = 128, rubric_max_workers = 128 }
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "logic-env"
 name = "logic"
 args = { min_avg_reward = 0.1 }
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "math-env"
 name = "math-python"
 args = { min_avg_reward = 0.1, sandbox_client_max_workers = 128, sandbox_timeout_minutes = 10, sandbox_memory_gb = 1, sandbox_disk_size_gb = 1, pip_install_packages = "numpy sympy", python_tool = true, rubric_max_workers = 128 }

--- a/configs/gsm8k/rl.toml
+++ b/configs/gsm8k/rl.toml
@@ -12,10 +12,10 @@ name = "PrimeIntellect/Qwen3-0.6B"
 batch_size = 512
 rollouts_per_example = 16
 
-[orchestrator.sampling]
-max_tokens = 2048
+[orchestrator.train.sampling]
+max_completion_tokens = 2048
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "math-env"
 name = "gsm8k"
 args = { dataset_name = "openai/gsm8k", dataset_subset = "main", math_verify_max_workers = 128, math_verify_timeout = 60 }

--- a/configs/hendrycks_math/rl.toml
+++ b/configs/hendrycks_math/rl.toml
@@ -12,10 +12,10 @@ name = "Qwen/Qwen3-4B-Instruct-2507"
 batch_size = 512
 rollouts_per_example = 16
 
-[orchestrator.sampling]
-max_tokens = 2048
+[orchestrator.train.sampling]
+max_completion_tokens = 2048
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "math-env"
 name = "hendrycks-math"
 args = { dataset_name = "PrimeIntellect/Hendrycks-Math", dataset_subset = "default", math_verify_max_workers = 128, math_verify_timeout = 60 }
@@ -28,7 +28,7 @@ hard_threshold = 0.0
 interval = 10
 
 [orchestrator.eval.sampling]
-max_tokens = 2048
+max_completion_tokens = 2048
 
 [[orchestrator.eval.env]]
 id = "math500"

--- a/configs/hendrycks_math/sanity.toml
+++ b/configs/hendrycks_math/sanity.toml
@@ -12,7 +12,7 @@ name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
 batch_size = 512
 rollouts_per_example = 8
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "math-env"
 args = { dataset_name = "mikasenghaas/Sanity-Test-R1D-1.5B", dataset_subset = "default" }
 name = "hendrycks-math"

--- a/configs/math_group/rl.toml
+++ b/configs/math_group/rl.toml
@@ -11,13 +11,13 @@ name = "Qwen/Qwen3-4B-Instruct-2507"
 batch_size = 256
 rollouts_per_example = 8
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "math-env"
 name = "hendrycks-math"
 args = { dataset_name = "PrimeIntellect/Hendrycks-Math", dataset_subset = "default" }
 ratio = 0.5
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "math-env"
 name = "acereason-math"
 args = { dataset_name = "nvidia/AceReason-Math", dataset_subset = "default", question_key = "problem" }

--- a/configs/math_python/math_python.toml
+++ b/configs/math_python/math_python.toml
@@ -12,10 +12,10 @@ name = "Qwen/Qwen3-4B-Instruct-2507"
 batch_size = 512
 rollouts_per_example = 16
 
-[orchestrator.sampling]
-max_tokens = 512
+[orchestrator.train.sampling]
+max_completion_tokens = 512
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "math-python"
 args = { sandbox_client_max_workers = 128, sandbox_timeout_minutes = 10, sandbox_memory_gb = 1, sandbox_disk_size_gb = 1, pip_install_packages = "numpy sympy" }
 

--- a/configs/multimodal/rl_color_codeword.toml
+++ b/configs/multimodal/rl_color_codeword.toml
@@ -13,10 +13,10 @@ batch_size = 256
 rollouts_per_example = 16
 
 
-[orchestrator.sampling]
-max_tokens = 64
+[orchestrator.train.sampling]
+max_completion_tokens = 64
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "color-codeword"
 args = { images_per_turn = 1, max_turns = 3, num_examples = 1000, seed = 42 }
 

--- a/configs/multimodal/rl_color_codeword_test.toml
+++ b/configs/multimodal/rl_color_codeword_test.toml
@@ -13,10 +13,10 @@ language_model_attr = "model.language_model"
 batch_size = 16
 rollouts_per_example = 2
 
-[orchestrator.sampling]
-max_tokens = 32
+[orchestrator.train.sampling]
+max_completion_tokens = 32
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "color-codeword"
 args = { images_per_turn = 1, max_turns = 2, num_examples = 100, seed = 42 }
 

--- a/configs/nemotron_4node/rl.toml
+++ b/configs/nemotron_4node/rl.toml
@@ -48,10 +48,10 @@ max_inflight_activations = 5
 batch_size = 128
 rollouts_per_example = 8
 
-[orchestrator.sampling]
-max_tokens = 2048
+[orchestrator.train.sampling]
+max_completion_tokens = 2048
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "math-env"
 name = "hendrycks-math"
 args = { dataset_name = "PrimeIntellect/Hendrycks-Math", dataset_subset = "default", math_verify_max_workers = 128, math_verify_timeout = 60 }
@@ -64,7 +64,7 @@ hard_threshold = 0.0
 interval = 10
 
 [orchestrator.eval.sampling]
-max_tokens = 2048
+max_completion_tokens = 2048
 
 [[orchestrator.eval.env]]
 id = "math500"

--- a/configs/nemotron_debug/rl.toml
+++ b/configs/nemotron_debug/rl.toml
@@ -47,10 +47,10 @@ freq = 1
 batch_size = 512
 rollouts_per_example = 16
 
-[orchestrator.sampling]
-max_tokens = 4096
+[orchestrator.train.sampling]
+max_completion_tokens = 4096
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "math-env"
 name = "hendrycks-math"
 args = { dataset_name = "PrimeIntellect/Hendrycks-Math", dataset_subset = "default", math_verify_max_workers = 128, math_verify_timeout = 60 }
@@ -63,7 +63,7 @@ hard_threshold = 0.0
 interval = 10
 
 [orchestrator.eval.sampling]
-max_tokens = 4096
+max_completion_tokens = 4096
 
 [[orchestrator.eval.env]]
 id = "math500"

--- a/configs/wiki_search/rl.toml
+++ b/configs/wiki_search/rl.toml
@@ -30,13 +30,13 @@ batch_size = 512
 rollouts_per_example = 16
 oversampling_factor = 2.0
 
-[orchestrator.sampling]
-max_tokens = 512
+[orchestrator.train.sampling]
+max_completion_tokens = 512
 
 [orchestrator.buffer]
 online_difficulty_filtering = true
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "wiki-search"
 
 [inference.model]

--- a/examples/Intellect-3.1/rl.toml
+++ b/examples/Intellect-3.1/rl.toml
@@ -47,31 +47,31 @@ weight_decay = 0.01
 batch_size = 2048
 oversampling_factor = 2
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "mini-swe-agent-plus"
 name = "swe"
 ratio = 0.3
 args = { max_turns = 200, cpu_cores = 2,  memory_gb = 4, disk_size_gb = 4, labels = ["mini-swe-agent-plus"], total_timeout_minutes = 720, sandbox_client_max_workers = 256, max_command_timeouts = 3, sandbox_command_timeout = 30}
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "deepdive"
 name = "deepdive"
 ratio = 0.2
 args = { finish_with_tool = true, open_max_workers = 128, cache_dir = "/tmp/i3_deepdive_cache_train" }
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "math-env"
 name = "math"
 ratio = 0.3
 args = { min_avg_reward = 0.0, max_avg_reward = 0.874}
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "logic-env"
 name = "logic"
 ratio = 0.2
 args = { min_avg_reward = 0.0, max_avg_reward = 0.874 }
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "code-env"
 name = "code"
 ratio = 0.2

--- a/examples/alphabet_sort/rl.toml
+++ b/examples/alphabet_sort/rl.toml
@@ -28,10 +28,10 @@ lr = 1e-5
 batch_size = 512
 rollouts_per_example = 8
 
-[orchestrator.sampling]
-max_tokens = 768
+[orchestrator.train.sampling]
+max_completion_tokens = 768
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "primeintellect/alphabet-sort"
 name = "alphabet-sort"
 args = { min_turns = 3, max_turns = 5, power_per_turn = false }

--- a/examples/alphabet_sort/sft_distill_hard.toml
+++ b/examples/alphabet_sort/sft_distill_hard.toml
@@ -34,8 +34,8 @@ batch_size = 256
 rollouts_per_example = 4
 use_token_client = false
 
-[orchestrator.sampling]
-max_tokens = 512
+[orchestrator.train.sampling]
+max_completion_tokens = 512
 temperature = 0.7
 
 [orchestrator.teacher_rollout_model.client]
@@ -45,7 +45,7 @@ api_key_var = "PRIME_API_KEY"
 [orchestrator.teacher_rollout_model.model]
 name = "qwen/qwen3-235b-a22b-instruct-2507"
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "primeintellect/alphabet-sort"
 name = "alphabet-sort"
 args = { min_turns = 2, max_turns = 2, min_names_per_turn = 1, max_names_per_turn = 3, similarity_power = 4, power_per_turn = false }

--- a/examples/hendrycks_sanity/rl.toml
+++ b/examples/hendrycks_sanity/rl.toml
@@ -16,7 +16,7 @@ name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
 batch_size = 512
 rollouts_per_example = 8
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "math-env" # included in lock file
 args = { dataset_name = "mikasenghaas/Sanity-Test-R1D-1.5B", dataset_subset = "default" }
 name = "hendrycks-math"

--- a/examples/minimax_m2.5_swe/rl.toml
+++ b/examples/minimax_m2.5_swe/rl.toml
@@ -49,7 +49,7 @@ oversampling_factor = 2
 max_off_policy_steps = 16
 
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "mini-swe-agent-plus"
 name = "swe"
 args = { max_turns = 200, cpu_cores = 2,  memory_gb = 4, disk_size_gb = 4, labels = ["mini-swe-agent-plus"], total_timeout_minutes = 720, sandbox_client_max_workers = 256, max_command_timeouts = 3, sandbox_command_timeout = 30}

--- a/examples/multinode/rl.toml
+++ b/examples/multinode/rl.toml
@@ -38,10 +38,10 @@ freq = 1
 batch_size = 512
 rollouts_per_example = 16
 
-[orchestrator.sampling]
-max_tokens = 2048
+[orchestrator.train.sampling]
+max_completion_tokens = 2048
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "math-env"
 name = "hendrycks-math"
 args = { dataset_name = "PrimeIntellect/Hendrycks-Math", dataset_subset = "default", math_verify_max_workers = 128, math_verify_timeout = 60 }

--- a/examples/qwen30b_math/rl.toml
+++ b/examples/qwen30b_math/rl.toml
@@ -45,10 +45,10 @@ batch_size = 512
 oversampling_factor = 2
 max_off_policy_steps = 8
 
-[orchestrator.sampling]
-max_tokens = 32768
+[orchestrator.train.sampling]
+max_completion_tokens = 32768
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "math-env"
 name = "math"
 

--- a/examples/qwen30b_swe/rl.toml
+++ b/examples/qwen30b_swe/rl.toml
@@ -46,7 +46,7 @@ batch_size = 512
 oversampling_factor = 2
 max_off_policy_steps = 16
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "mini-swe-agent-plus"
 name = "swe"
 args = { max_turns = 200, cpu_cores = 2,  memory_gb = 4, disk_size_gb = 4, labels = ["mini-swe-agent-plus"], total_timeout_minutes = 720, sandbox_client_max_workers = 256, max_command_timeouts = 3, sandbox_command_timeout = 30}

--- a/examples/reverse_text/rl.toml
+++ b/examples/reverse_text/rl.toml
@@ -12,10 +12,10 @@ name = "reverse-text"
 batch_size = 128
 rollouts_per_example = 16
 
-[orchestrator.sampling]
-max_tokens = 128
+[orchestrator.train.sampling]
+max_completion_tokens = 128
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "reverse-text"
 
 [trainer.optim]

--- a/examples/wiki_search/rl.toml
+++ b/examples/wiki_search/rl.toml
@@ -37,13 +37,13 @@ oversampling_factor = 2.0
 [orchestrator.model.lora]
 name = "qwen3-4b-wiki-search"
 
-[orchestrator.sampling]
-max_tokens = 512
+[orchestrator.train.sampling]
+max_completion_tokens = 512
 
 [orchestrator.buffer]
 online_difficulty_filtering = true
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "primeintellect/wiki-search"
 
 [ckpt] # Checkpoint at the end of training

--- a/examples/wordle/rl.toml
+++ b/examples/wordle/rl.toml
@@ -18,12 +18,12 @@ name = "PrimeIntellect/Qwen3-1.7B-Wordle-SFT"
 batch_size = 1024
 rollouts_per_example = 16
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "primeintellect/wordle"
 name = "wordle"
 
-[orchestrator.sampling]
-max_tokens = 1024
+[orchestrator.train.sampling]
+max_completion_tokens = 1024
 
 [trainer] # Default trainer config
 


### PR DESCRIPTION
## Summary
- Rename `[orchestrator.sampling]` → `[orchestrator.train.sampling]` and `[[orchestrator.env]]` → `[[orchestrator.train.env]]` across all configs
- Rename `max_tokens` → `max_completion_tokens` in sampling sections
- Drops reliance on the deprecated auto-translation emitted by the orchestrator config validator

## Validation
- Ran `uv run rl @ <config> --dry-run` on all 38 modified RL configs — no deprecation warnings
- Validated the two orchestrator-only partial configs (`configs/debug/orch.toml`, `configs/ci/integration/rl_multi_run/orchestrator.toml`) via direct `OrchestratorConfig.model_validate` — no deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a mechanical rename of TOML config keys/fields to match the current orchestrator schema, with no functional code changes. Main risk is mis-typed keys causing configs to be ignored or validation to fail at runtime.
> 
> **Overview**
> Updates training configs across `configs/` and `examples/` to stop using deprecated orchestrator keys.
> 
> Specifically renames `[orchestrator.sampling]` to `[orchestrator.train.sampling]`, `[[orchestrator.env]]` to `[[orchestrator.train.env]]` (and similarly for orchestrator-only partial configs), and replaces `max_tokens` with `max_completion_tokens` in sampling sections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ce27075cd60fbdfee79575df91b516f201d645a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->