### PR TITLE
feat: experimental mask_off_policy_rollouts flag

### DIFF
--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -812,6 +812,18 @@ WeightBroadcastConfig: TypeAlias = Annotated[
 class OrchestratorExperimentalConfig(BaseConfig):
     """Experimental features for the orchestrator."""
 
+    mask_off_policy_rollouts: Annotated[
+        bool,
+        Field(
+            description=(
+                "Experimental: when a rollout's off-policy age exceeds max_off_policy_steps, keep the rollout "
+                "and zero out its loss mask instead of cancelling it. The rollout still fills a batch slot but "
+                "contributes no gradient, which keeps the batching pipeline moving under heavy off-policyness "
+                "at the cost of wasted compute on the masked rollouts."
+            ),
+        ),
+    ] = False
+
 
 class TeacherModelConfig(BaseConfig):
     """Configures the teacher model for computing teacher logprobs (e.g. for distillation)."""

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -238,6 +238,7 @@ async def orchestrate(config: OrchestratorConfig):
         max_off_policy_steps=config.max_off_policy_steps,
         strict_async_level=config.strict_async_level,
         tasks_per_minute=config.tasks_per_minute,
+        mask_off_policy_rollouts=config.experimental.mask_off_policy_rollouts,
         enable_policy_updates=enable_policy_updates,
         lora_name=config.model.lora.name if config.model.lora else None,
         config=config,
@@ -526,9 +527,15 @@ async def orchestrate(config: OrchestratorConfig):
             if samples is None:
                 samples = []
             rollout_samples_per_rollout.append(len(samples))
+            off_policy_masked = rollout.get("off_policy_masked", False)
             for sample in samples:
                 sample.advantage = rollout["advantage"]
                 sample.reward = rollout["reward"]
+                if off_policy_masked:
+                    # Rollout exceeded max_off_policy_steps under mask_off_policy_rollouts mode:
+                    # keep the sample for batch-filling, but zero its loss mask so it contributes
+                    # no gradient.
+                    sample.completion_mask = [False] * len(sample.completion_mask)
                 sample_decode_tokens = sum(sample.completion_mask)
                 sample_prefill_tokens = len(sample.prompt_ids) + len(sample.completion_mask) - sample_decode_tokens
                 rollout_decode_tokens += sample_decode_tokens

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -32,6 +32,9 @@ class InflightRequest:
     env_name: str
     group_id: int | None = None
     rollout_count: int = 1
+    # Set when the rollout exceeded max_off_policy_steps under mask_off_policy_rollouts mode.
+    # The request is kept running to completion and its tokens are later masked from the loss.
+    is_stale: bool = False
 
 
 @dataclass
@@ -66,6 +69,7 @@ class Scheduler:
         max_off_policy_steps: int,
         strict_async_level: bool,
         tasks_per_minute: int | None,
+        mask_off_policy_rollouts: bool = False,
         enable_policy_updates: bool = True,
         lora_name: str | None = None,
     ):
@@ -84,6 +88,7 @@ class Scheduler:
         self.max_async_level = max_async_level
         self.max_off_policy_steps = max_off_policy_steps
         self.strict_async_level = strict_async_level
+        self.mask_off_policy_rollouts = mask_off_policy_rollouts
         self.enable_policy_updates = enable_policy_updates
         self.lora_name = lora_name
         self.model_name = self.config.model.name
@@ -111,6 +116,7 @@ class Scheduler:
         self.inflight_policy_update_task: asyncio.Task | None = None
         self.policy_update_lock = asyncio.Lock()
         self.cancelled_rollouts_count = 0
+        self.masked_stale_rollouts_count = 0
         self.empty_rollouts_by_env: dict[str, int] = defaultdict(int)
         self.errored_rollouts_by_env: dict[str, int] = defaultdict(int)
         self.total_rollouts_by_env: dict[str, int] = defaultdict(int)
@@ -347,8 +353,29 @@ class Scheduler:
         stale_group_ids = {
             info.group_id
             for info in self.inflight_requests.values()
-            if info.group_id is not None and info.off_policy_steps >= self.max_off_policy_steps
+            if info.group_id is not None and not info.is_stale and info.off_policy_steps >= self.max_off_policy_steps
         }
+
+        if self.mask_off_policy_rollouts:
+            # Experimental: mark requests in stale groups for loss-masking and let them finish
+            # instead of cancelling. Keeps the batching pipeline flowing under heavy off-policyness.
+            newly_masked = 0
+            for info in self.inflight_requests.values():
+                if info.group_id in stale_group_ids and not info.is_stale:
+                    info.is_stale = True
+                    newly_masked += info.rollout_count
+            for task, info in list(self.inflight_requests.items()):
+                if info.is_stale:
+                    continue
+                info.off_policy_steps += 1
+            self.masked_stale_rollouts_count += newly_masked
+            if newly_masked:
+                self.logger.warning(
+                    f"Marked {newly_masked} rollout requests as stale (loss-masked, kept running). "
+                    f"Consider increasing max_off_policy_steps to avoid this."
+                )
+            return
+
         tasks_to_increment = [
             task
             for task, info in list(self.inflight_requests.items())
@@ -449,6 +476,7 @@ class Scheduler:
                             )
                         else:
                             rollout["env_name"] = env_name
+                            rollout["off_policy_masked"] = rollout_info.is_stale
                             valid_rollouts.append(rollout)
 
                     if has_failures and env.requires_group_scoring:
@@ -525,6 +553,7 @@ class Scheduler:
             "scheduler/inflight_rollouts": self.inflight_rollout_count,
             "scheduler/inflight_samples": self.inflight_sample_count,
             "scheduler/cancelled_rollouts": self.cancelled_rollouts_count,
+            "scheduler/masked_stale_rollouts": self.masked_stale_rollouts_count,
             "empty_rollouts/all": sum(self.empty_rollouts_by_env.values()) / max(total_rollouts, 1),
             "errored_rollouts/all": sum(self.errored_rollouts_by_env.values()) / max(total_rollouts, 1),
             "off_policy_level/all/max": self.max_off_policy_level,
@@ -541,6 +570,7 @@ class Scheduler:
             metrics[f"off_policy_level/{env_name}/max"] = max(steps)
             metrics[f"off_policy_level/{env_name}/mean"] = sum(steps) / len(steps)
         self.cancelled_rollouts_count = 0
+        self.masked_stale_rollouts_count = 0
         self.empty_rollouts_by_env.clear()
         self.errored_rollouts_by_env.clear()
         self.total_rollouts_by_env.clear()

--- a/tests/unit/orchestrator/test_scheduler.py
+++ b/tests/unit/orchestrator/test_scheduler.py
@@ -25,7 +25,6 @@ def make_scheduler() -> Scheduler:
     scheduler.groups = {}
     scheduler.max_off_policy_steps = 1
     scheduler.cancelled_rollouts_count = 0
-    scheduler.masked_stale_rollouts_count = 0
     scheduler.mask_off_policy_rollouts = False
     scheduler.policy_update_lock = asyncio.Lock()
     scheduler.inflight_policy_update_task = None
@@ -39,7 +38,6 @@ def test_update_off_policy_does_not_increment_interleaved_on_policy_tasks():
         scheduler = Scheduler.__new__(Scheduler)
         scheduler.max_off_policy_steps = 1
         scheduler.cancelled_rollouts_count = 0
-        scheduler.masked_stale_rollouts_count = 0
         scheduler.mask_off_policy_rollouts = False
         scheduler.logger = MagicMock()
 
@@ -86,53 +84,6 @@ def test_update_off_policy_does_not_increment_interleaved_on_policy_tasks():
 
         for task in (stale_task, survivor_task, interleaved_task):
             if task is not None and not task.done():
-                task.cancel()
-        await asyncio.sleep(0)
-
-    asyncio.run(run())
-
-
-def test_update_off_policy_masks_stale_instead_of_dropping_when_enabled():
-    async def run() -> None:
-        scheduler = Scheduler.__new__(Scheduler)
-        scheduler.max_off_policy_steps = 2
-        scheduler.cancelled_rollouts_count = 0
-        scheduler.masked_stale_rollouts_count = 0
-        scheduler.mask_off_policy_rollouts = True
-        scheduler.logger = MagicMock()
-        scheduler.drop_group = AsyncMock()
-
-        client = SimpleNamespace(api_base_url="http://test")
-        stale_task = asyncio.create_task(asyncio.sleep(60))
-        fresh_task = asyncio.create_task(asyncio.sleep(60))
-
-        scheduler.inflight_requests = {
-            stale_task: InflightRequest(off_policy_steps=2, client_config=client, env_name="test", group_id=1),
-            fresh_task: InflightRequest(off_policy_steps=0, client_config=client, env_name="test", group_id=2),
-        }
-
-        await scheduler._update_off_policy()
-
-        # Stale request is kept, tagged as is_stale, and no further off-policy increment.
-        assert stale_task in scheduler.inflight_requests
-        assert scheduler.inflight_requests[stale_task].is_stale is True
-        assert scheduler.inflight_requests[stale_task].off_policy_steps == 2
-        # Fresh request is untouched and its counter is incremented once.
-        assert scheduler.inflight_requests[fresh_task].is_stale is False
-        assert scheduler.inflight_requests[fresh_task].off_policy_steps == 1
-        # No cancellation happened; mask counter increments.
-        scheduler.drop_group.assert_not_awaited()
-        assert scheduler.cancelled_rollouts_count == 0
-        assert scheduler.masked_stale_rollouts_count == 1
-
-        # A second pass with the fresh request still below threshold doesn't double-count
-        # the already-stale one.
-        await scheduler._update_off_policy()
-        assert scheduler.masked_stale_rollouts_count == 1
-        assert scheduler.inflight_requests[fresh_task].off_policy_steps == 2
-
-        for task in (stale_task, fresh_task):
-            if not task.done():
                 task.cancel()
         await asyncio.sleep(0)
 

--- a/tests/unit/orchestrator/test_scheduler.py
+++ b/tests/unit/orchestrator/test_scheduler.py
@@ -25,6 +25,8 @@ def make_scheduler() -> Scheduler:
     scheduler.groups = {}
     scheduler.max_off_policy_steps = 1
     scheduler.cancelled_rollouts_count = 0
+    scheduler.masked_stale_rollouts_count = 0
+    scheduler.mask_off_policy_rollouts = False
     scheduler.policy_update_lock = asyncio.Lock()
     scheduler.inflight_policy_update_task = None
     scheduler.update_policy_task = None
@@ -37,6 +39,8 @@ def test_update_off_policy_does_not_increment_interleaved_on_policy_tasks():
         scheduler = Scheduler.__new__(Scheduler)
         scheduler.max_off_policy_steps = 1
         scheduler.cancelled_rollouts_count = 0
+        scheduler.masked_stale_rollouts_count = 0
+        scheduler.mask_off_policy_rollouts = False
         scheduler.logger = MagicMock()
 
         client = SimpleNamespace(api_base_url="http://test")
@@ -82,6 +86,53 @@ def test_update_off_policy_does_not_increment_interleaved_on_policy_tasks():
 
         for task in (stale_task, survivor_task, interleaved_task):
             if task is not None and not task.done():
+                task.cancel()
+        await asyncio.sleep(0)
+
+    asyncio.run(run())
+
+
+def test_update_off_policy_masks_stale_instead_of_dropping_when_enabled():
+    async def run() -> None:
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.max_off_policy_steps = 2
+        scheduler.cancelled_rollouts_count = 0
+        scheduler.masked_stale_rollouts_count = 0
+        scheduler.mask_off_policy_rollouts = True
+        scheduler.logger = MagicMock()
+        scheduler.drop_group = AsyncMock()
+
+        client = SimpleNamespace(api_base_url="http://test")
+        stale_task = asyncio.create_task(asyncio.sleep(60))
+        fresh_task = asyncio.create_task(asyncio.sleep(60))
+
+        scheduler.inflight_requests = {
+            stale_task: InflightRequest(off_policy_steps=2, client_config=client, env_name="test", group_id=1),
+            fresh_task: InflightRequest(off_policy_steps=0, client_config=client, env_name="test", group_id=2),
+        }
+
+        await scheduler._update_off_policy()
+
+        # Stale request is kept, tagged as is_stale, and no further off-policy increment.
+        assert stale_task in scheduler.inflight_requests
+        assert scheduler.inflight_requests[stale_task].is_stale is True
+        assert scheduler.inflight_requests[stale_task].off_policy_steps == 2
+        # Fresh request is untouched and its counter is incremented once.
+        assert scheduler.inflight_requests[fresh_task].is_stale is False
+        assert scheduler.inflight_requests[fresh_task].off_policy_steps == 1
+        # No cancellation happened; mask counter increments.
+        scheduler.drop_group.assert_not_awaited()
+        assert scheduler.cancelled_rollouts_count == 0
+        assert scheduler.masked_stale_rollouts_count == 1
+
+        # A second pass with the fresh request still below threshold doesn't double-count
+        # the already-stale one.
+        await scheduler._update_off_policy()
+        assert scheduler.masked_stale_rollouts_count == 1
+        assert scheduler.inflight_requests[fresh_task].off_policy_steps == 2
+
+        for task in (stale_task, fresh_task):
+            if not task.done():
                 task.cancel()
         await asyncio.sleep(0)
 


### PR DESCRIPTION
## Summary

Adds an experimental orchestrator flag `experimental.mask_off_policy_rollouts` (default `false`). When enabled:

- Rollouts whose off-policy age exceeds `max_off_policy_steps` are **no longer cancelled** — they're tagged `is_stale=True`, kept running, and allowed to finish.
- When the stale rollout lands in the batch, its training samples have `completion_mask` zeroed, so its tokens contribute no gradient but still fill batch slots (sample count + token count).
- A new `scheduler/masked_stale_rollouts` metric tracks the count per step.

Motivation: under heavy off-policyness the default drop-and-refill behavior can empty the batching pipeline and stall training. Masking instead keeps the pipeline moving; we just don't train on the overly-stale tokens.

Cost: compute is wasted on rollouts we end up masking. This is why it's gated and defaulted off — expected usage is debugging or experiments on high-latency rollout setups.

### Files

- `src/prime_rl/configs/orchestrator.py`: new experimental field.
- `src/prime_rl/orchestrator/scheduler.py`: `InflightRequest.is_stale`, mask-mode branch in `_update_off_policy`, tag `rollout["off_policy_masked"]` on completion, new metric.
- `src/prime_rl/orchestrator/orchestrator.py`: zeroes `completion_mask` for masked rollouts when building `TrainingSample`s.
- `tests/unit/orchestrator/test_scheduler.py`: new test covers the mask-mode path; existing tests updated for new fields.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core rollout scheduling/off-policy handling; while gated behind a new experimental flag (default off), incorrect staleness tagging or masking could degrade training throughput/quality when enabled.
> 
> **Overview**
> Adds an experimental `experimental.mask_off_policy_rollouts` config that, when enabled, **keeps** rollouts that exceed `max_off_policy_steps` instead of cancelling them.
> 
> The scheduler now marks such in-flight requests as `is_stale`, propagates this as `rollout["off_policy_masked"]`, increments a new `scheduler/masked_stale_rollouts` metric, and the orchestrator zeroes `TrainingSample.completion_mask` for masked rollouts so they fill batches but contribute no gradient.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7d98728f61d71f0da42e7e4dbf269d36a589e27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->