### PR TITLE
feat(slurm): cleanup stale node-local state before launch

### DIFF
--- a/src/prime_rl/templates/inference.sbatch.j2
+++ b/src/prime_rl/templates/inference.sbatch.j2
@@ -107,6 +107,22 @@ echo "INFER_URLS=${INFER_URLS}"
 {{ pre_run_command }}
 {% endif %}
 
+# Cleanup stale node-local state from prior jobs. Orphan python/torchrun/vllm
+# processes and vLLM/torch IPC files under /dev/shm and /tmp can survive SLURM
+# termination and cause the next launch to hang (e.g. decode engines stuck at
+# "Waiting for READY message from DP Coordinator"). Harmless on clean nodes.
+srun bash -c '
+    pkill -9 -f "python.*prime_rl" 2>/dev/null
+    pkill -9 -f "torchrun" 2>/dev/null
+    pkill -9 -f "vllm" 2>/dev/null
+    pkill -9 -f "prime_rl" 2>/dev/null
+    sleep 2
+    rm -rf /dev/shm/vllm-* /dev/shm/vllm_* /tmp/vllm-* /tmp/vllm_* /tmp/torch-* /tmp/torchelastic_* 2>/dev/null
+    procs=$(ps -ef | grep -E "python|torchrun|vllm" | grep -v grep | wc -l)
+    gpu=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits | awk "{s+=\$1} END {print s}")
+    echo "[node-cleanup] $(hostname) procs=$procs gpu_mem=${gpu}MiB"
+'
+
 # Run inference
 srun bash -c '
     cd $PROJECT_DIR

--- a/src/prime_rl/templates/inference.sbatch.j2
+++ b/src/prime_rl/templates/inference.sbatch.j2
@@ -114,11 +114,12 @@ echo "INFER_URLS=${INFER_URLS}"
 srun bash -c '
     pkill -9 -f "python.*prime_rl" 2>/dev/null
     pkill -9 -f "torchrun" 2>/dev/null
+    pkill -9 -f "vllm-router" 2>/dev/null
     pkill -9 -f "vllm" 2>/dev/null
     pkill -9 -f "prime_rl" 2>/dev/null
     sleep 2
     rm -rf /dev/shm/vllm-* /dev/shm/vllm_* /tmp/vllm-* /tmp/vllm_* /tmp/torch-* /tmp/torchelastic_* 2>/dev/null
-    procs=$(ps -ef | grep -E "python|torchrun|vllm" | grep -v grep | wc -l)
+    procs=$(ps -ef | grep -E "python|torchrun|vllm|vllm-router" | grep -v grep | wc -l)
     gpu=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits | awk "{s+=\$1} END {print s}")
     echo "[node-cleanup] $(hostname) procs=$procs gpu_mem=${gpu}MiB"
 '

--- a/src/prime_rl/templates/inference.sbatch.j2
+++ b/src/prime_rl/templates/inference.sbatch.j2
@@ -117,9 +117,13 @@ srun bash -c '
     pkill -9 -f "vllm-router" 2>/dev/null
     pkill -9 -f "vllm" 2>/dev/null
     pkill -9 -f "prime_rl" 2>/dev/null
+    # Also match prctl-set process names (kernel comm) like "vllm::router"
+    # which pkill -f does not see because -f only matches the cmdline.
+    pkill -9 "vllm" 2>/dev/null
+    pkill -9 "vllm::.*" 2>/dev/null
     sleep 2
     rm -rf /dev/shm/vllm-* /dev/shm/vllm_* /tmp/vllm-* /tmp/vllm_* /tmp/torch-* /tmp/torchelastic_* 2>/dev/null
-    procs=$(ps -ef | grep -E "python|torchrun|vllm|vllm-router" | grep -v grep | wc -l)
+    procs=$(ps -eo comm,args | grep -E "python|torchrun|vllm|vllm::" | grep -v grep | wc -l)
     gpu=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits | awk "{s+=\$1} END {print s}")
     echo "[node-cleanup] $(hostname) procs=$procs gpu_mem=${gpu}MiB"
 '

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -161,9 +161,13 @@ srun bash -c '
     pkill -9 -f "vllm-router" 2>/dev/null
     pkill -9 -f "vllm" 2>/dev/null
     pkill -9 -f "prime_rl" 2>/dev/null
+    # Also match prctl-set process names (kernel comm) like "vllm::router"
+    # which pkill -f does not see because -f only matches the cmdline.
+    pkill -9 "vllm" 2>/dev/null
+    pkill -9 "vllm::.*" 2>/dev/null
     sleep 2
     rm -rf /dev/shm/vllm-* /dev/shm/vllm_* /tmp/vllm-* /tmp/vllm_* /tmp/torch-* /tmp/torchelastic_* 2>/dev/null
-    procs=$(ps -ef | grep -E "python|torchrun|vllm|vllm-router" | grep -v grep | wc -l)
+    procs=$(ps -eo comm,args | grep -E "python|torchrun|vllm|vllm::" | grep -v grep | wc -l)
     gpu=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits | awk "{s+=\$1} END {print s}")
     echo "[node-cleanup] $(hostname) procs=$procs gpu_mem=${gpu}MiB"
 '

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -158,11 +158,12 @@ uv sync --all-extras
 srun bash -c '
     pkill -9 -f "python.*prime_rl" 2>/dev/null
     pkill -9 -f "torchrun" 2>/dev/null
+    pkill -9 -f "vllm-router" 2>/dev/null
     pkill -9 -f "vllm" 2>/dev/null
     pkill -9 -f "prime_rl" 2>/dev/null
     sleep 2
     rm -rf /dev/shm/vllm-* /dev/shm/vllm_* /tmp/vllm-* /tmp/vllm_* /tmp/torch-* /tmp/torchelastic_* 2>/dev/null
-    procs=$(ps -ef | grep -E "python|torchrun|vllm" | grep -v grep | wc -l)
+    procs=$(ps -ef | grep -E "python|torchrun|vllm|vllm-router" | grep -v grep | wc -l)
     gpu=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits | awk "{s+=\$1} END {print s}")
     echo "[node-cleanup] $(hostname) procs=$procs gpu_mem=${gpu}MiB"
 '

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -151,6 +151,22 @@ uv sync --all-extras
 {{ pre_run_command }}
 {% endif %}
 
+# Cleanup stale node-local state from prior jobs. Orphan python/torchrun/vllm
+# processes and vLLM/torch IPC files under /dev/shm and /tmp can survive SLURM
+# termination and cause the next launch to hang (e.g. decode engines stuck at
+# "Waiting for READY message from DP Coordinator"). Harmless on clean nodes.
+srun bash -c '
+    pkill -9 -f "python.*prime_rl" 2>/dev/null
+    pkill -9 -f "torchrun" 2>/dev/null
+    pkill -9 -f "vllm" 2>/dev/null
+    pkill -9 -f "prime_rl" 2>/dev/null
+    sleep 2
+    rm -rf /dev/shm/vllm-* /dev/shm/vllm_* /tmp/vllm-* /tmp/vllm_* /tmp/torch-* /tmp/torchelastic_* 2>/dev/null
+    procs=$(ps -ef | grep -E "python|torchrun|vllm" | grep -v grep | wc -l)
+    gpu=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits | awk "{s+=\$1} END {print s}")
+    echo "[node-cleanup] $(hostname) procs=$procs gpu_mem=${gpu}MiB"
+'
+
 # Run RL
 srun bash -c '
     # Source environment

--- a/src/prime_rl/templates/multi_node_sft.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_sft.sbatch.j2
@@ -65,11 +65,12 @@ cd $PROJECT_DIR && uv sync --all-extras
 srun bash -c '
     pkill -9 -f "python.*prime_rl" 2>/dev/null
     pkill -9 -f "torchrun" 2>/dev/null
+    pkill -9 -f "vllm-router" 2>/dev/null
     pkill -9 -f "vllm" 2>/dev/null
     pkill -9 -f "prime_rl" 2>/dev/null
     sleep 2
     rm -rf /dev/shm/vllm-* /dev/shm/vllm_* /tmp/vllm-* /tmp/vllm_* /tmp/torch-* /tmp/torchelastic_* 2>/dev/null
-    procs=$(ps -ef | grep -E "python|torchrun|vllm" | grep -v grep | wc -l)
+    procs=$(ps -ef | grep -E "python|torchrun|vllm|vllm-router" | grep -v grep | wc -l)
     gpu=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits | awk "{s+=\$1} END {print s}")
     echo "[node-cleanup] $(hostname) procs=$procs gpu_mem=${gpu}MiB"
 '

--- a/src/prime_rl/templates/multi_node_sft.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_sft.sbatch.j2
@@ -68,9 +68,13 @@ srun bash -c '
     pkill -9 -f "vllm-router" 2>/dev/null
     pkill -9 -f "vllm" 2>/dev/null
     pkill -9 -f "prime_rl" 2>/dev/null
+    # Also match prctl-set process names (kernel comm) like "vllm::router"
+    # which pkill -f does not see because -f only matches the cmdline.
+    pkill -9 "vllm" 2>/dev/null
+    pkill -9 "vllm::.*" 2>/dev/null
     sleep 2
     rm -rf /dev/shm/vllm-* /dev/shm/vllm_* /tmp/vllm-* /tmp/vllm_* /tmp/torch-* /tmp/torchelastic_* 2>/dev/null
-    procs=$(ps -ef | grep -E "python|torchrun|vllm|vllm-router" | grep -v grep | wc -l)
+    procs=$(ps -eo comm,args | grep -E "python|torchrun|vllm|vllm::" | grep -v grep | wc -l)
     gpu=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits | awk "{s+=\$1} END {print s}")
     echo "[node-cleanup] $(hostname) procs=$procs gpu_mem=${gpu}MiB"
 '

--- a/src/prime_rl/templates/multi_node_sft.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_sft.sbatch.j2
@@ -59,6 +59,21 @@ cd $PROJECT_DIR && uv sync --all-extras
 {{ pre_run_command }}
 {% endif %}
 
+# Cleanup stale node-local state from prior jobs. Orphan python/torchrun/vllm
+# processes and vLLM/torch IPC files under /dev/shm and /tmp can survive SLURM
+# termination and cause the next launch to hang. Harmless on clean nodes.
+srun bash -c '
+    pkill -9 -f "python.*prime_rl" 2>/dev/null
+    pkill -9 -f "torchrun" 2>/dev/null
+    pkill -9 -f "vllm" 2>/dev/null
+    pkill -9 -f "prime_rl" 2>/dev/null
+    sleep 2
+    rm -rf /dev/shm/vllm-* /dev/shm/vllm_* /tmp/vllm-* /tmp/vllm_* /tmp/torch-* /tmp/torchelastic_* 2>/dev/null
+    procs=$(ps -ef | grep -E "python|torchrun|vllm" | grep -v grep | wc -l)
+    gpu=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits | awk "{s+=\$1} END {print s}")
+    echo "[node-cleanup] $(hostname) procs=$procs gpu_mem=${gpu}MiB"
+'
+
 # Run SFT
 srun bash -c '
     # Setup environment


### PR DESCRIPTION
## Summary
- Add a pre-workload `srun` step to `multi_node_rl.sbatch.j2`, `multi_node_sft.sbatch.j2`, and `inference.sbatch.j2` that runs once per allocated node and wipes stale state left over from prior jobs.
- Specifically kills orphan `python`/`torchrun`/`vllm`/`prime_rl` processes and removes IPC state under `/dev/shm/vllm-*`, `/tmp/vllm-*`, `/tmp/torch-*`, `/tmp/torchelastic_*`.
- Prints one line per node so the sbatch log confirms `procs=N gpu_mem=MMiB` on startup.

## Motivation
When a SLURM job wedges in the `CG` (completing) state for a long time after `scancel` — which happens to us regularly on large multi-node RL runs that die in mid-NCCL/collective — SLURM doesn't always reap every process. The next job scheduled onto the same nodes inherits:

- orphan Python/vLLM/torchrun processes still holding GPU memory and sockets, and
- stale `/dev/shm/vllm-*` segments and `/tmp/torchelastic_*` rendezvous files.

The concrete failure mode we hit in production was decode engines hanging on startup with:

```
Waiting for READY message from DP Coordinator...
```

for 1800s until the orchestrator aborted. A manual `pdsh` cleanup of the allocated nodes (identical to what this PR adds inside the sbatch template) fixed it immediately on the next launch, and has continued to.

The cleanup is a no-op on clean nodes — it just prints `procs=1 gpu_mem=0MiB`.

## Notes
- Relies on `#SBATCH --exclusive`, which all three templates already set, so we're only killing our own user's stale processes and never touching other users' workloads.
- Runs before `srun`'s workload launch, so it can't race with the current job's own processes.
- Intentionally broad `pkill -9 -f "vllm"` etc. — anything matching `prime_rl`/`torchrun`/`vllm` in the process name on an exclusively-allocated node is by definition a leftover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an aggressive per-node preflight cleanup (`pkill -9` and `rm -rf` in `/dev/shm`/`/tmp`) to SLURM templates; while intended for `--exclusive` nodes, incorrect matching or environment assumptions could still terminate unintended processes or remove needed temp state.
> 
> **Overview**
> Adds a pre-workload `srun` cleanup step to the `inference`, `multi_node_rl`, and `multi_node_sft` SLURM sbatch templates to proactively remove stale node-local state left behind by prior jobs.
> 
> The new step force-kills leftover `python`/`torchrun`/`vllm`/`prime_rl` processes (including `comm`-name matches like `vllm::...`), deletes related IPC/temp files under `/dev/shm` and `/tmp`, and logs a per-node `[node-cleanup]` line with remaining process count and GPU memory usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11a4e7a6fa21d4b91c7c2e4e7bec16ca45486058. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->