### PR TITLE
Add orchestrator-side replay buffer support for RL training

### DIFF
--- a/skills/config/SKILL.md
+++ b/skills/config/SKILL.md
@@ -168,6 +168,24 @@ In TOML, an empty section header does the same:
 [ckpt]  # enables checkpointing with defaults
 ```
 
+### Replay config
+
+Replay is configured on the orchestrator. In a standalone orchestrator TOML, use `[replay]`. In an `rl` config, nest it under `[orchestrator.replay]`. It stays disabled unless both `capacity` and `replay_fraction` are set:
+
+```toml
+[orchestrator.replay]
+capacity = 1024
+replay_fraction = 0.25
+max_replay_off_policy_steps = 8
+```
+
+Replay entries are stored as full rollout groups, so `capacity` counts groups rather than individual rollouts. When resuming from a checkpoint, you can skip replay restoration independently of the main buffer:
+
+```toml
+[ckpt]
+skip_replay = true
+```
+
 ## Key files
 
 - `src/prime_rl/utils/config.py` — re-exports `BaseConfig` and `cli` from pydantic_config

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -605,6 +605,13 @@ class CheckpointConfig(BaseConfig):
         ),
     ] = False
 
+    skip_replay: Annotated[
+        bool,
+        Field(
+            description="Whether to skip loading the replay buffer from checkpoint.",
+        ),
+    ] = False
+
 
 class BufferConfig(BaseConfig):
     """Configures the buffer for the orchestrator."""
@@ -667,6 +674,62 @@ class BufferConfig(BaseConfig):
     def validate_thresholds(self):
         if self.easy_threshold is not None and self.hard_threshold is not None:
             assert self.easy_threshold > self.hard_threshold, "easy_threshold must be greater than hard_threshold."
+        return self
+
+
+class ReplaySamplingConfig(BaseModel):
+    """Configures how replay groups are sampled."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["uniform"] = "uniform"
+
+
+class ReplayConfig(BaseConfig):
+    """Configures replay-buffer sampling for the orchestrator."""
+
+    capacity: Annotated[
+        int,
+        Field(
+            ge=0,
+            description="Maximum number of rollout groups to retain in replay. Set to 0 to disable replay.",
+        ),
+    ] = 0
+
+    replay_fraction: Annotated[
+        float,
+        Field(
+            ge=0.0,
+            lt=1.0,
+            description="Target fraction of each training batch to source from replay. Set to 0 to disable replay.",
+        ),
+    ] = 0.0
+
+    seed: Annotated[
+        int | None,
+        Field(description="Random seed used for replay sampling."),
+    ] = None
+
+    max_replay_off_policy_steps: Annotated[
+        int | None,
+        Field(
+            ge=0,
+            description="Maximum age in policy steps for completed replay entries. If None, defaults to max_off_policy_steps.",
+        ),
+    ] = None
+
+    sampling: ReplaySamplingConfig = ReplaySamplingConfig()
+
+    @property
+    def enabled(self) -> bool:
+        return self.capacity > 0 and self.replay_fraction > 0.0
+
+    @model_validator(mode="after")
+    def validate_enabled_fields(self):
+        if self.capacity == 0 and self.replay_fraction > 0.0:
+            raise ValueError("replay.capacity must be > 0 when replay_fraction is set")
+        if self.capacity > 0 and self.replay_fraction == 0.0:
+            raise ValueError("replay.replay_fraction must be > 0 when capacity is set")
         return self
 
 
@@ -885,6 +948,9 @@ class OrchestratorConfig(BaseConfig):
 
     # Data buffer configuration
     buffer: BufferConfig = BufferConfig()
+
+    # Replay buffer configuration
+    replay: ReplayConfig = ReplayConfig()
 
     # The advantage configuration
     advantage: AdvantageConfig | None = DefaultAdvantageConfig()

--- a/src/prime_rl/orchestrator/ckpt.py
+++ b/src/prime_rl/orchestrator/ckpt.py
@@ -6,6 +6,7 @@ import torch
 
 from prime_rl.configs.orchestrator import CheckpointConfig
 from prime_rl.orchestrator.buffer import Buffer
+from prime_rl.orchestrator.replay import ReplayBuffer
 from prime_rl.utils.logger import get_logger
 from prime_rl.utils.utils import get_ckpt_dir, get_step_path
 
@@ -34,6 +35,7 @@ class CheckpointManager:
         ckpt_path: Path,
         progress: Progress,
         buffer: Buffer,
+        replay: ReplayBuffer | None = None,
     ):
         self.logger.debug(f"Saving orchestrator checkpoint to {ckpt_path}")
         start_time = time.perf_counter()
@@ -45,9 +47,18 @@ class CheckpointManager:
         # Save buffer
         buffer.save(ckpt_path / "buffer")
 
+        if replay is not None:
+            replay.save(ckpt_path / "replay")
+
         self.logger.debug(f"Orchestrator checkpoint saved in {time.perf_counter() - start_time:.2f} seconds")
 
-    def load_from_path(self, ckpt_path: Path, progress: Progress, buffer: Buffer) -> None:
+    def load_from_path(
+        self,
+        ckpt_path: Path,
+        progress: Progress,
+        buffer: Buffer,
+        replay: ReplayBuffer | None = None,
+    ) -> None:
         """Loads a checkpoint from a given path in-place."""
         self.logger.debug(f"Loading checkpoint from {ckpt_path}")
         start_time = time.perf_counter()
@@ -69,25 +80,38 @@ class CheckpointManager:
         else:
             buffer.load(ckpt_path / "buffer")
 
+        if replay is not None:
+            if self.config.skip_replay:
+                self.logger.info("Skipping replay loading from checkpoint")
+            else:
+                replay.load(ckpt_path / "replay")
+
         self.logger.debug(f"Orchestrator checkpoint loaded in {time.perf_counter() - start_time:.2f} seconds")
 
-    def load(self, progress: Progress, buffer: Buffer, step: int) -> None:
+    def load(
+        self,
+        progress: Progress,
+        buffer: Buffer,
+        step: int,
+        replay: ReplayBuffer | None = None,
+    ) -> None:
         """Loads a checkpoint from a given path."""
         ckpt_path = self.get_ckpt_path(step)
         if not ckpt_path.exists():
             raise FileNotFoundError(f"Checkpoint not found at {ckpt_path}")
-        self.load_from_path(ckpt_path, progress, buffer)
+        self.load_from_path(ckpt_path, progress, buffer, replay=replay)
 
     def save(
         self,
         progress: Progress,
         buffer: Buffer,
         step: int,
+        replay: ReplayBuffer | None = None,
     ) -> None:
         """Saves the full checkpoint state for a specified step."""
         ckpt_path = self.get_ckpt_path(step)
         ckpt_path.mkdir(parents=True, exist_ok=True)
-        self.save_to_path(ckpt_path, progress, buffer)
+        self.save_to_path(ckpt_path, progress, buffer, replay=replay)
 
 
 def setup_ckpt_manager(output_dir: Path, config: CheckpointConfig | None) -> CheckpointManager | None:

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -38,6 +38,13 @@ from prime_rl.orchestrator.buffer import Buffer
 from prime_rl.orchestrator.ckpt import Progress, setup_ckpt_manager
 from prime_rl.orchestrator.envs import EvalEnv, EvalEnvs, TrainEnvs
 from prime_rl.orchestrator.filters import apply_filters, setup_filters
+from prime_rl.orchestrator.replay import (
+    ReplayBuffer,
+    ReplayGroup,
+    chunk_rollouts,
+    compute_desired_replay_progress,
+    flatten_rollout_groups,
+)
 from prime_rl.orchestrator.scheduler import Scheduler
 from prime_rl.orchestrator.utils import (
     compute_teacher_logprobs,
@@ -218,6 +225,18 @@ async def orchestrate(config: OrchestratorConfig):
     logger.info(f"Setting up buffer ({config.buffer})")
     buffer = Buffer(train_envs, config.buffer)
 
+    replay: ReplayBuffer | None = None
+    if config.replay.enabled:
+        replay_max_off_policy_steps = config.replay.max_replay_off_policy_steps
+        if replay_max_off_policy_steps is None:
+            replay_max_off_policy_steps = config.max_off_policy_steps
+        logger.info(f"Setting up replay ({config.replay})")
+        replay = ReplayBuffer(
+            capacity=config.replay.capacity,
+            max_off_policy_steps=replay_max_off_policy_steps,
+            seed=config.replay.seed,
+        )
+
     # Get checkpoint manager
     logger.info(f"Initializing checkpoint manager ({config.ckpt})")
     ckpt_manager = setup_ckpt_manager(config.output_dir, config.ckpt)
@@ -293,8 +312,31 @@ async def orchestrate(config: OrchestratorConfig):
     # Reset weights to base model if starting from scratch
     progress = Progress()
 
+    def build_replay_groups(rollouts: list[vf.RolloutOutput], insert_step: int) -> list[ReplayGroup]:
+        replay_groups: list[ReplayGroup] = []
+        for group in chunk_rollouts(rollouts, config.rollouts_per_example):
+            if any(not rollout["is_filtered"] for rollout in group):
+                replay_groups.append(ReplayGroup.from_rollouts(group, insert_step=insert_step))
+        return replay_groups
+
+    def annotate_fresh_groups(groups: list[list[vf.RolloutOutput]]) -> None:
+        for problem_idx, group in enumerate(groups):
+            for rollout in group:
+                rollout["data_source"] = "fresh"
+                rollout["problem_idx"] = problem_idx
+
+    def annotate_replay_groups(replay_groups: list[ReplayGroup], problem_idx_offset: int, current_step: int) -> None:
+        for replay_idx, replay_group in enumerate(replay_groups):
+            problem_idx = problem_idx_offset + replay_idx
+            replay_age_steps = current_step - replay_group.policy_step
+            for rollout in replay_group.rollouts:
+                rollout["data_source"] = "replay"
+                rollout["problem_idx"] = problem_idx
+                rollout["replay_insert_step"] = replay_group.insert_step
+                rollout["replay_age_steps"] = replay_age_steps
+
     if checkpoint_step is not None and ckpt_manager is not None:
-        ckpt_manager.load(progress, buffer, step=checkpoint_step)
+        ckpt_manager.load(progress, buffer, step=checkpoint_step, replay=replay)
         logger.info(f"Resuming training from checkpoint step {checkpoint_step}")
         scheduler.ckpt_step = progress.step  # Always resume from the latest checkpoint
         if config.eval and config.eval.skip_eval_on_resume:
@@ -343,7 +385,7 @@ async def orchestrate(config: OrchestratorConfig):
         ):
             logger.info(f"Saving checkpoint at step {progress.step}")
             save_ckpt_start_time = time.perf_counter()
-            ckpt_manager.save(progress, buffer, step=progress.step)
+            ckpt_manager.save(progress, buffer, step=progress.step, replay=replay)
             save_ckpt_time = time.perf_counter() - save_ckpt_start_time
 
         # Break if we have reached the maximum number of steps
@@ -416,19 +458,69 @@ async def orchestrate(config: OrchestratorConfig):
         generate_completions_time = 0.0
         train_rollouts: list[vf.RolloutOutput] = []
         num_rollouts = 0
-        num_unique_examples = 0
+        num_problems = 0
         n_trainable = 0
+        replay_requested_progress = 0
+        replay_progress = 0
+        fresh_rollout_count = 0
+        replay_rollout_count = 0
         for attempt in range(MAX_EMPTY_BATCH_ATTEMPTS):
-            train_rollouts = await scheduler.generate_batch(step=progress.step)
-            generate_completions_time += scheduler.last_batch_generation_time
+            fresh_target = scheduler.batch_target
+            replay_requested_progress = 0
+            replayed_groups: list[ReplayGroup] = []
+            if replay is not None:
+                replay.evict_stale(current_step=progress.step)
+                replay_requested_progress = compute_desired_replay_progress(
+                    batch_target=scheduler.batch_target,
+                    replay_fraction=config.replay.replay_fraction,
+                    rollouts_per_example=config.rollouts_per_example,
+                    use_token_batching=scheduler.uses_token_batching,
+                )
+                replayed_groups = replay.sample(
+                    target_progress=replay_requested_progress,
+                    use_token_batching=scheduler.uses_token_batching,
+                    current_step=progress.step,
+                )
+                replay_progress = sum(
+                    group.num_tokens if scheduler.uses_token_batching else group.num_rollouts
+                    for group in replayed_groups
+                )
+                fresh_target = max(scheduler.batch_target - replay_progress, 0)
+
+            fresh_rollouts = []
+            if fresh_target > 0:
+                fresh_rollouts = await scheduler.generate_batch(step=progress.step, target=fresh_target)
+                generate_completions_time += scheduler.last_batch_generation_time
+            fresh_rollout_count = len(fresh_rollouts)
 
             # Compute advantages (in-place)
-            num_rollouts = len(train_rollouts)
-            num_unique_examples = len({r["example_id"] for r in train_rollouts})
-            compute_advantages(train_rollouts, config.rollouts_per_example, config.advantage)
+            compute_advantages(fresh_rollouts, config.rollouts_per_example, config.advantage)
 
             # Apply rollout filters — sets rollout["filters"] and rollout["is_filtered"]
-            apply_filters(rollout_filters, train_rollouts)
+            apply_filters(rollout_filters, fresh_rollouts)
+
+            if is_vlm:
+                offload_start = time.perf_counter()
+                num_offloaded = offload_images_to_disk(fresh_rollouts, config.output_dir)
+                if num_offloaded:
+                    logger.info(
+                        f"VLM offloaded {num_offloaded} unique images to disk in {time.perf_counter() - offload_start:.2f}s"
+                    )
+
+            for rollout in fresh_rollouts:
+                pretokenize_rollout_trajectory(rollout, tokenizer, processor=processor)
+
+            fresh_groups = chunk_rollouts(fresh_rollouts, config.rollouts_per_example)
+
+            if replay is not None:
+                replay.add(build_replay_groups(fresh_rollouts, insert_step=progress.step))
+                annotate_replay_groups(replayed_groups, problem_idx_offset=len(fresh_groups), current_step=progress.step)
+
+            annotate_fresh_groups(fresh_groups)
+            train_rollouts = flatten_rollout_groups(fresh_groups + [group.rollouts for group in replayed_groups])
+            num_rollouts = len(train_rollouts)
+            num_problems = len(fresh_groups) + len(replayed_groups)
+            replay_rollout_count = sum(group.num_rollouts for group in replayed_groups)
 
             n_trainable = sum(1 for r in train_rollouts if not r["is_filtered"])
             if n_trainable > 0:
@@ -467,21 +559,8 @@ async def orchestrate(config: OrchestratorConfig):
             save_rollouts, train_rollouts, step_path / "train_rollouts.jsonl", exclude_keys={"trajectory"}
         )
 
-        # VLM: offload base64 images to disk immediately to free memory
-        if is_vlm:
-            offload_start = time.perf_counter()
-            num_offloaded = offload_images_to_disk(train_rollouts, config.output_dir)
-            if num_offloaded:
-                logger.info(
-                    f"VLM offloaded {num_offloaded} unique images to disk in {time.perf_counter() - offload_start:.2f}s"
-                )
-
         # Convert rollouts to training samples
         parallel_preprocess_start = time.perf_counter()
-
-        # Pretokenize before VLM image cache build (which strips image data from messages)
-        for rollout in train_rollouts:
-            pretokenize_rollout_trajectory(rollout, tokenizer, processor=processor)
 
         # VLM: build image cache in a thread so it doesn't block the event loop.
         # This lets the scheduler continue servicing inflight rollout requests
@@ -542,7 +621,7 @@ async def orchestrate(config: OrchestratorConfig):
 
         parallel_preprocess_time = time.perf_counter() - parallel_preprocess_start
         logger.debug(
-            f"Converted {len(train_rollouts)} rollouts ({num_unique_examples} unique examples) "
+            f"Converted {len(train_rollouts)} rollouts ({num_problems} problems) "
             f"to {len(train_examples)} training examples"
         )
 
@@ -573,8 +652,12 @@ async def orchestrate(config: OrchestratorConfig):
         # Gather metrics in dataframes
         results_df = pd.DataFrame(
             {
+                "problem_idx": [rollout["problem_idx"] for rollout in train_rollouts],
                 "example_id": [rollout["example_id"] for rollout in train_rollouts],
                 "env_name": [rollout["env_name"] for rollout in train_rollouts],
+                "data_source": [rollout["data_source"] for rollout in train_rollouts],
+                "policy_step": [rollout.get("policy_step") for rollout in train_rollouts],
+                "replay_age_steps": [rollout.get("replay_age_steps") for rollout in train_rollouts],
                 "reward": [rollout["reward"] for rollout in train_rollouts],
                 "is_truncated": [rollout["is_truncated"] for rollout in train_rollouts],
                 "is_filtered": [rollout["is_filtered"] for rollout in train_rollouts],
@@ -595,19 +678,23 @@ async def orchestrate(config: OrchestratorConfig):
 
         # Update progress metrics
         num_tokens = int(results_df.seq_len.sum())
+        fresh_token_count = int(results_df.loc[results_df.data_source == "fresh", "seq_len"].sum())
+        replay_token_count = int(results_df.loc[results_df.data_source == "replay", "seq_len"].sum())
+        batch_progress = num_tokens if scheduler.uses_token_batching else num_rollouts
+        replay_fraction_actual = replay_progress / batch_progress if batch_progress else 0.0
+        replay_fraction_requested = replay_requested_progress / scheduler.batch_target if scheduler.batch_target else 0.0
         progress.total_tokens += num_tokens
         progress.total_samples += num_rollouts
-        progress.total_problems += num_unique_examples
+        progress.total_problems += num_problems
 
         def compute_solve_rates(df):
             """Compute solve_none, solve_all, effective_batch_size for a set of rollouts."""
-            reward_per_problem = df.groupby("example_id").reward.sum()
+            reward_per_problem = df.groupby("problem_idx").reward.sum()
             solve_none = (reward_per_problem == 0).mean()
             solve_all = (reward_per_problem == config.rollouts_per_example).mean()
             return solve_none, solve_all, 1 - solve_none - solve_all
 
-        # Group by example_id to average across rollouts within each problem
-        by_example = results_df.groupby("example_id")
+        by_problem = results_df.groupby("problem_idx")
 
         solve_none, solve_all, effective_batch_size = compute_solve_rates(results_df)
         to_log = {
@@ -616,23 +703,27 @@ async def orchestrate(config: OrchestratorConfig):
             "progress/prefill_tokens": num_prefill_tokens,
             "progress/decode_tokens": num_decode_tokens,
             "progress/samples": num_rollouts,
-            "progress/problems": num_unique_examples,
+            "progress/problems": num_problems,
+            "progress/fresh_samples": fresh_rollout_count,
+            "progress/replay_samples": replay_rollout_count,
+            "progress/fresh_tokens": fresh_token_count,
+            "progress/replay_tokens": replay_token_count,
             "progress/total_tokens": progress.total_tokens,
             "progress/total_samples": progress.total_samples,
             "progress/total_problems": progress.total_problems,
             "progress/ckpt_step": ckpt_step,  # Shared W&B axis
             # Sequence length metrics
-            "seq_len/all/mean": by_example.seq_len.mean().mean(),
-            "seq_len/all/max": by_example.seq_len.mean().max(),
-            "seq_len/all/min": by_example.seq_len.mean().min(),
-            "prefill_len/all/mean": by_example.prefill_len.mean().mean(),
-            "prefill_len/all/max": by_example.prefill_len.mean().max(),
-            "prefill_len/all/min": by_example.prefill_len.mean().min(),
-            "decode_len/all/mean": by_example.decode_len.mean().mean(),
-            "decode_len/all/max": by_example.decode_len.mean().max(),
-            "decode_len/all/min": by_example.decode_len.mean().min(),
-            "is_truncated/all/mean": by_example.is_truncated.mean().mean(),
-            "is_truncated/all/max": by_example.is_truncated.mean().max(),
+            "seq_len/all/mean": by_problem.seq_len.mean().mean(),
+            "seq_len/all/max": by_problem.seq_len.mean().max(),
+            "seq_len/all/min": by_problem.seq_len.mean().min(),
+            "prefill_len/all/mean": by_problem.prefill_len.mean().mean(),
+            "prefill_len/all/max": by_problem.prefill_len.mean().max(),
+            "prefill_len/all/min": by_problem.prefill_len.mean().min(),
+            "decode_len/all/mean": by_problem.decode_len.mean().mean(),
+            "decode_len/all/max": by_problem.decode_len.mean().max(),
+            "decode_len/all/min": by_problem.decode_len.mean().min(),
+            "is_truncated/all/mean": by_problem.is_truncated.mean().mean(),
+            "is_truncated/all/max": by_problem.is_truncated.mean().max(),
             "stop_condition/all/generation_truncated": (
                 results_df.is_truncated & (results_df.stop_condition != "prompt_too_long")
             ).mean(),
@@ -640,26 +731,28 @@ async def orchestrate(config: OrchestratorConfig):
                 f"stop_condition/all/{sc}": rate
                 for sc, rate in results_df.stop_condition.dropna().value_counts(normalize=True).items()
             },
-            "samples_per_rollout/all/mean": by_example.samples_per_rollout.mean().mean(),
-            "samples_per_rollout/all/max": by_example.samples_per_rollout.mean().max(),
-            "samples_per_rollout/all/min": by_example.samples_per_rollout.mean().min(),
-            "num_turns/all/mean": by_example.num_turns.mean().mean(),
-            "num_turns/all/max": by_example.num_turns.mean().max(),
-            "num_turns/all/min": by_example.num_turns.mean().min(),
-            "generation_ms/all/mean": by_example.generation_ms.mean().mean(),
-            "generation_ms/all/max": by_example.generation_ms.mean().max(),
-            "generation_ms/all/min": by_example.generation_ms.mean().min(),
-            "scoring_ms/all/mean": by_example.scoring_ms.mean().mean(),
-            "scoring_ms/all/max": by_example.scoring_ms.mean().max(),
-            "scoring_ms/all/min": by_example.scoring_ms.mean().min(),
+            "samples_per_rollout/all/mean": by_problem.samples_per_rollout.mean().mean(),
+            "samples_per_rollout/all/max": by_problem.samples_per_rollout.mean().max(),
+            "samples_per_rollout/all/min": by_problem.samples_per_rollout.mean().min(),
+            "num_turns/all/mean": by_problem.num_turns.mean().mean(),
+            "num_turns/all/max": by_problem.num_turns.mean().max(),
+            "num_turns/all/min": by_problem.num_turns.mean().min(),
+            "generation_ms/all/mean": by_problem.generation_ms.mean().mean(),
+            "generation_ms/all/max": by_problem.generation_ms.mean().max(),
+            "generation_ms/all/min": by_problem.generation_ms.mean().min(),
+            "scoring_ms/all/mean": by_problem.scoring_ms.mean().mean(),
+            "scoring_ms/all/max": by_problem.scoring_ms.mean().max(),
+            "scoring_ms/all/min": by_problem.scoring_ms.mean().min(),
             # Train reward
-            "reward/all/mean": by_example.reward.mean().mean(),
-            "reward/all/max": by_example.reward.mean().max(),
-            "reward/all/min": by_example.reward.mean().min(),
+            "reward/all/mean": by_problem.reward.mean().mean(),
+            "reward/all/max": by_problem.reward.mean().max(),
+            "reward/all/min": by_problem.reward.mean().min(),
             # Solve / batch metrics
             "solve_none/all": solve_none,
             "solve_all/all": solve_all,
             "effective_batch_size/all": effective_batch_size,
+            "replay/requested_fraction": replay_fraction_requested,
+            "replay/actual_fraction": replay_fraction_actual,
             **{f"batch/{env}": r for env, r in results_df.env_name.value_counts(normalize=True).items()},
             # Time metrics
             "time/step": step_time,
@@ -671,6 +764,7 @@ async def orchestrate(config: OrchestratorConfig):
             **scheduler.get_metrics(),
             # Buffer metrics
             **buffer.get_metrics(),
+            **(replay.get_metrics(progress.step) if replay is not None else {}),
             # Event loop lag metrics
             **event_loop_lag_monitor.get_metrics(),
             # Rollout filter metrics (detection rate per filter + overall drop rate)
@@ -693,15 +787,15 @@ async def orchestrate(config: OrchestratorConfig):
         ]
 
         for env, env_df in results_df.groupby("env_name"):
-            env_by_example = env_df.groupby("example_id")
+            env_by_problem = env_df.groupby("problem_idx")
             for col in per_env_columns:
-                to_log[f"{col}/{env}/mean"] = env_by_example[col].mean().mean()
-                to_log[f"{col}/{env}/max"] = env_by_example[col].mean().max()
+                to_log[f"{col}/{env}/mean"] = env_by_problem[col].mean().mean()
+                to_log[f"{col}/{env}/max"] = env_by_problem[col].mean().max()
                 if col != "is_truncated":
-                    to_log[f"{col}/{env}/min"] = env_by_example[col].mean().min()
-            to_log[f"reward/{env}/mean"] = env_by_example.reward.mean().mean()
-            to_log[f"reward/{env}/max"] = env_by_example.reward.mean().max()
-            to_log[f"reward/{env}/min"] = env_by_example.reward.mean().min()
+                    to_log[f"{col}/{env}/min"] = env_by_problem[col].mean().min()
+            to_log[f"reward/{env}/mean"] = env_by_problem.reward.mean().mean()
+            to_log[f"reward/{env}/max"] = env_by_problem.reward.mean().max()
+            to_log[f"reward/{env}/min"] = env_by_problem.reward.mean().min()
             solve_none, solve_all, effective_batch_size = compute_solve_rates(env_df)
             to_log[f"solve_none/{env}"] = solve_none
             to_log[f"solve_all/{env}"] = solve_all
@@ -713,7 +807,7 @@ async def orchestrate(config: OrchestratorConfig):
                 to_log[f"stop_condition/{env}/{sc}"] = rate
             env_metrics_df = metrics_df.loc[env_df.index]
             for metric in metrics_df.columns:
-                to_log[f"metrics/{env}/{metric}"] = env_metrics_df.groupby(env_df["example_id"])[metric].mean().mean()
+                to_log[f"metrics/{env}/{metric}"] = env_metrics_df.groupby(env_df["problem_idx"])[metric].mean().mean()
             to_log[f"filters/{env}/is_filtered"] = env_df.is_filtered.astype(float).mean()
             env_filter_df = filter_df.loc[env_df.index]
             for name in filter_df.columns:
@@ -741,8 +835,8 @@ async def orchestrate(config: OrchestratorConfig):
                 tokens=num_prefill_tokens + num_decode_tokens,
             )
 
-        reward_mean = by_example.reward.mean().mean()
-        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Reward: {reward_mean:.4f} | Seq. Length: {by_example.seq_len.mean().mean():.1f} tokens/sample | Async Level: {scheduler.async_level} | Max. Off-Policy Level: {scheduler.max_off_policy_level}"
+        reward_mean = by_problem.reward.mean().mean()
+        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Reward: {reward_mean:.4f} | Seq. Length: {by_problem.seq_len.mean().mean():.1f} tokens/sample | Async Level: {scheduler.async_level} | Max. Off-Policy Level: {scheduler.max_off_policy_level}"
         logger.success(step_message)
 
         # Increment step
@@ -790,7 +884,7 @@ async def orchestrate(config: OrchestratorConfig):
     # Write final checkpoint
     if ckpt_manager is not None:
         logger.info("Writing final checkpoint")
-        ckpt_manager.save(progress, buffer, step=progress.step)
+        ckpt_manager.save(progress, buffer, step=progress.step, replay=replay)
 
     # Bounded best-effort cleanup. Each await below may block on a remote peer
     # (env-server ZMQ recv, inference admin httpx aclose, etc.). The outer

--- a/src/prime_rl/orchestrator/replay.py
+++ b/src/prime_rl/orchestrator/replay.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import copy
+import json
+import random
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import verifiers as vf
+from verifiers.utils.save_utils import make_serializable
+
+from prime_rl.orchestrator.vf_utils import get_seq_len
+from prime_rl.utils.utils import mean
+
+
+@dataclass
+class ReplayGroup:
+    rollouts: list[vf.RolloutOutput]
+    env_name: str
+    policy_step: int
+    insert_step: int
+    num_rollouts: int
+    num_tokens: int
+    num_trainable_rollouts: int
+    abs_advantage_mean: float
+    abs_advantage_max: float
+
+    @classmethod
+    def from_rollouts(cls, rollouts: list[vf.RolloutOutput], insert_step: int) -> "ReplayGroup":
+        if not rollouts:
+            raise ValueError("ReplayGroup requires at least one rollout")
+
+        env_name = rollouts[0]["env_name"]
+        policy_step = rollouts[0]["policy_step"]
+        if any(rollout["env_name"] != env_name for rollout in rollouts):
+            raise ValueError("ReplayGroup rollouts must all belong to the same environment")
+        if any(rollout["policy_step"] != policy_step for rollout in rollouts):
+            raise ValueError("ReplayGroup rollouts must all share the same policy step")
+
+        abs_advantages = [abs(float(rollout.get("advantage") or 0.0)) for rollout in rollouts]
+        return cls(
+            rollouts=list(rollouts),
+            env_name=env_name,
+            policy_step=policy_step,
+            insert_step=insert_step,
+            num_rollouts=len(rollouts),
+            num_tokens=sum(get_seq_len(rollout) for rollout in rollouts),
+            num_trainable_rollouts=sum(not rollout.get("is_filtered", False) for rollout in rollouts),
+            abs_advantage_mean=mean(abs_advantages) if abs_advantages else 0.0,
+            abs_advantage_max=max(abs_advantages) if abs_advantages else 0.0,
+        )
+
+    def clone(self) -> "ReplayGroup":
+        return ReplayGroup(
+            rollouts=copy.deepcopy(self.rollouts),
+            env_name=self.env_name,
+            policy_step=self.policy_step,
+            insert_step=self.insert_step,
+            num_rollouts=self.num_rollouts,
+            num_tokens=self.num_tokens,
+            num_trainable_rollouts=self.num_trainable_rollouts,
+            abs_advantage_mean=self.abs_advantage_mean,
+            abs_advantage_max=self.abs_advantage_max,
+        )
+
+
+def chunk_rollouts(
+    rollouts: list[vf.RolloutOutput],
+    rollouts_per_example: int,
+) -> list[list[vf.RolloutOutput]]:
+    if rollouts_per_example <= 0:
+        raise ValueError("rollouts_per_example must be positive")
+    if len(rollouts) % rollouts_per_example != 0:
+        raise ValueError("Rollouts must be divisible by rollouts_per_example")
+    return [rollouts[idx : idx + rollouts_per_example] for idx in range(0, len(rollouts), rollouts_per_example)]
+
+
+def flatten_rollout_groups(groups: list[list[vf.RolloutOutput]]) -> list[vf.RolloutOutput]:
+    flattened: list[vf.RolloutOutput] = []
+    for group in groups:
+        flattened.extend(group)
+    return flattened
+
+
+def compute_desired_replay_progress(
+    batch_target: int,
+    replay_fraction: float,
+    rollouts_per_example: int,
+    use_token_batching: bool,
+) -> int:
+    if batch_target < 0:
+        raise ValueError("batch_target must be non-negative")
+
+    if use_token_batching:
+        return int(batch_target * replay_fraction)
+
+    if batch_target % rollouts_per_example != 0:
+        raise ValueError("Rollout-mode batch target must be divisible by rollouts_per_example")
+    desired_replay_groups = int((batch_target // rollouts_per_example) * replay_fraction)
+    return desired_replay_groups * rollouts_per_example
+
+
+def compute_replay_targets(
+    batch_target: int,
+    replay_fraction: float,
+    available_replay_progress: int,
+    rollouts_per_example: int,
+    use_token_batching: bool,
+) -> tuple[int, int, int]:
+    if batch_target < 0:
+        raise ValueError("batch_target must be non-negative")
+    if available_replay_progress < 0:
+        raise ValueError("available_replay_progress must be non-negative")
+
+    desired_replay_progress = compute_desired_replay_progress(
+        batch_target=batch_target,
+        replay_fraction=replay_fraction,
+        rollouts_per_example=rollouts_per_example,
+        use_token_batching=use_token_batching,
+    )
+    actual_replay_progress = min(desired_replay_progress, available_replay_progress)
+    fresh_target = batch_target - actual_replay_progress
+    return desired_replay_progress, actual_replay_progress, fresh_target
+
+
+class ReplayBuffer:
+    def __init__(
+        self,
+        capacity: int,
+        max_off_policy_steps: int,
+        seed: int | None = None,
+    ):
+        self.capacity = capacity
+        self.max_off_policy_steps = max_off_policy_steps
+        self.rng = random.Random(seed)
+        self.groups: list[ReplayGroup] = []
+
+    def _is_stale(self, group: ReplayGroup, current_step: int) -> bool:
+        return current_step - group.policy_step > self.max_off_policy_steps
+
+    def _eligible_groups(
+        self,
+        current_step: int,
+        exclude_insert_step: int | None = None,
+    ) -> list[ReplayGroup]:
+        eligible = [group for group in self.groups if not self._is_stale(group, current_step)]
+        if exclude_insert_step is not None:
+            eligible = [group for group in eligible if group.insert_step != exclude_insert_step]
+        return eligible
+
+    @staticmethod
+    def _group_progress(group: ReplayGroup, use_token_batching: bool) -> int:
+        return group.num_tokens if use_token_batching else group.num_rollouts
+
+    def add(self, groups: list[ReplayGroup]) -> None:
+        if self.capacity <= 0 or not groups:
+            return
+
+        self.groups.extend(group.clone() for group in groups)
+        overflow = len(self.groups) - self.capacity
+        if overflow > 0:
+            self.groups = self.groups[overflow:]
+
+    def evict_stale(self, current_step: int) -> None:
+        self.groups = [group for group in self.groups if not self._is_stale(group, current_step)]
+
+    def available_progress(
+        self,
+        use_token_batching: bool,
+        current_step: int,
+        exclude_insert_step: int | None = None,
+    ) -> int:
+        return sum(
+            self._group_progress(group, use_token_batching)
+            for group in self._eligible_groups(current_step, exclude_insert_step=exclude_insert_step)
+        )
+
+    def sample(
+        self,
+        target_progress: int,
+        use_token_batching: bool,
+        current_step: int,
+        exclude_insert_step: int | None = None,
+    ) -> list[ReplayGroup]:
+        if target_progress <= 0:
+            return []
+
+        eligible = self._eligible_groups(current_step, exclude_insert_step=exclude_insert_step)
+        if not eligible:
+            return []
+
+        indices = list(range(len(eligible)))
+        self.rng.shuffle(indices)
+
+        sampled: list[ReplayGroup] = []
+        progress = 0
+        for idx in indices:
+            group = eligible[idx]
+            sampled.append(group.clone())
+            progress += self._group_progress(group, use_token_batching)
+            if progress >= target_progress:
+                break
+
+        return sampled
+
+    def get_metrics(self, current_step: int) -> dict[str, float]:
+        if not self.groups:
+            return {
+                "replay/size": 0,
+                "replay/capacity_utilization": 0.0,
+                "replay/age_steps/mean": 0.0,
+                "replay/age_steps/max": 0.0,
+            }
+
+        ages = [current_step - group.policy_step for group in self.groups]
+        capacity_utilization = len(self.groups) / self.capacity if self.capacity > 0 else 0.0
+        return {
+            "replay/size": len(self.groups),
+            "replay/capacity_utilization": capacity_utilization,
+            "replay/age_steps/mean": mean(ages),
+            "replay/age_steps/max": max(ages),
+        }
+
+    def save(self, path: Path) -> None:
+        path.mkdir(parents=True, exist_ok=True)
+        with open(path / "groups.jsonl", "w") as f:
+            for group in self.groups:
+                f.write(json.dumps(asdict(group), default=make_serializable) + "\n")
+
+    def load(self, path: Path) -> None:
+        groups_path = path / "groups.jsonl"
+        if not groups_path.exists():
+            self.groups = []
+            return
+
+        with open(groups_path, "r") as f:
+            self.groups = [ReplayGroup(**json.loads(line)) for line in f]
+
+        overflow = len(self.groups) - self.capacity
+        if overflow > 0:
+            self.groups = self.groups[overflow:]

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -30,6 +30,7 @@ class InflightRequest:
     off_policy_steps: int
     client_config: vf.ClientConfig
     env_name: str
+    policy_step: int = 0
     group_id: int | None = None
     rollout_count: int = 1
 
@@ -133,10 +134,10 @@ class Scheduler:
             return sum(get_seq_len(rollout) for rollout in rollouts)
         return len(rollouts)
 
-    def finalize_batch_rollouts(self, rollouts: list[vf.RolloutOutput]) -> list[vf.RolloutOutput]:
+    def finalize_batch_rollouts(self, rollouts: list[vf.RolloutOutput], batch_target: int) -> list[vf.RolloutOutput]:
         if self.batch_size is None:
             return rollouts
-        return rollouts[: self.batch_size]
+        return rollouts[:batch_target]
 
     async def cancel_inflight_rollouts(self):
         """Cancel all in-flight rollout requests."""
@@ -222,6 +223,7 @@ class Scheduler:
             )
         self.inflight_requests[task] = InflightRequest(
             off_policy_steps=0,
+            policy_step=self.ckpt_step,
             client_config=client_config,
             env_name=env_name,
             group_id=group_id,
@@ -370,7 +372,7 @@ class Scheduler:
                 f"Consider increasing max_off_policy_steps to avoid this."
             )
 
-    async def generate_batch(self, step: int) -> list[vf.RolloutOutput]:
+    async def generate_batch(self, step: int, target: int | None = None) -> list[vf.RolloutOutput]:
         """Continuously generates a batch of rollouts."""
         self.step = step
 
@@ -388,16 +390,17 @@ class Scheduler:
             self.checkpoint_ready.set()
 
         batch_start_time = time.perf_counter()
+        batch_target = self.batch_target if target is None else target
 
         self.logger.debug("Starting to generate batch rollouts")
 
         batch_rollouts: list[vf.RolloutOutput] = []
         batch_progress = 0
         pbar = ProgressTracker(
-            total=self.batch_target, desc="Generating rollouts (train)", json_logging=self.json_logging, step=step
+            total=batch_target, desc="Generating rollouts (train)", json_logging=self.json_logging, step=step
         )
 
-        while batch_progress < self.batch_target:
+        while batch_progress < batch_target:
             await self._fill_inflight_requests()
             inflight_tasks = list(self.inflight_requests.keys())
 
@@ -408,7 +411,7 @@ class Scheduler:
             await self.checkpoint_ready.wait()
 
             for finished_task in finished_tasks:
-                if batch_progress >= self.batch_target:
+                if batch_progress >= batch_target:
                     break
 
                 rollout_info = self.inflight_requests.pop(finished_task, None)
@@ -449,6 +452,7 @@ class Scheduler:
                             )
                         else:
                             rollout["env_name"] = env_name
+                            rollout["policy_step"] = rollout_info.policy_step
                             valid_rollouts.append(rollout)
 
                     if has_failures and env.requires_group_scoring:
@@ -484,7 +488,7 @@ class Scheduler:
 
         await self._fill_inflight_requests()
 
-        batch_rollouts = self.finalize_batch_rollouts(batch_rollouts)
+        batch_rollouts = self.finalize_batch_rollouts(batch_rollouts, batch_target=batch_target)
         pbar.close()
         self.last_batch_generation_time = time.perf_counter() - batch_start_time
         return batch_rollouts

--- a/tests/unit/orchestrator/test_replay.py
+++ b/tests/unit/orchestrator/test_replay.py
@@ -1,0 +1,220 @@
+from pathlib import Path
+
+from prime_rl.configs.orchestrator import CheckpointConfig
+from prime_rl.orchestrator.ckpt import CheckpointManager, Progress
+from prime_rl.orchestrator.replay import ReplayBuffer, ReplayGroup, compute_replay_targets
+
+
+def make_rollout(
+    example_id: int,
+    *,
+    env_name: str = "env",
+    policy_step: int = 0,
+    advantage: float = 1.0,
+    is_filtered: bool = False,
+    image_url: str = "file:///tmp/test-image.png",
+) -> dict:
+    return {
+        "example_id": example_id,
+        "env_name": env_name,
+        "policy_step": policy_step,
+        "advantage": advantage,
+        "is_filtered": is_filtered,
+        "reward": 1.0,
+        "trajectory": [
+            {
+                "prompt": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": image_url},
+                            }
+                        ],
+                    }
+                ],
+                "tokens": {
+                    "prompt_ids": [1, 2],
+                    "prompt_mask": [False, False],
+                    "completion_ids": [3, 4],
+                    "completion_mask": [True, True],
+                    "completion_logprobs": [-0.1, -0.2],
+                },
+            }
+        ],
+        "timing": {"generation_ms": 1.0, "scoring_ms": 1.0},
+        "metrics": {},
+        "filters": {"zero_advantage": False},
+        "is_truncated": False,
+    }
+
+
+def make_group(example_id: int, *, policy_step: int, insert_step: int, env_name: str = "env") -> ReplayGroup:
+    return ReplayGroup.from_rollouts(
+        [
+            make_rollout(example_id * 10, env_name=env_name, policy_step=policy_step),
+            make_rollout(example_id * 10 + 1, env_name=env_name, policy_step=policy_step, advantage=2.0),
+        ],
+        insert_step=insert_step,
+    )
+
+
+def test_compute_replay_targets_for_rollout_batching():
+    requested, actual, fresh = compute_replay_targets(
+        batch_target=8,
+        replay_fraction=0.5,
+        available_replay_progress=2,
+        rollouts_per_example=2,
+        use_token_batching=False,
+    )
+
+    assert requested == 4
+    assert actual == 2
+    assert fresh == 6
+
+
+def test_compute_replay_targets_for_token_batching():
+    requested, actual, fresh = compute_replay_targets(
+        batch_target=100,
+        replay_fraction=0.25,
+        available_replay_progress=18,
+        rollouts_per_example=2,
+        use_token_batching=True,
+    )
+
+    assert requested == 25
+    assert actual == 18
+    assert fresh == 82
+
+
+def test_replay_buffer_sampling_is_non_destructive_and_excludes_current_insert_step():
+    replay = ReplayBuffer(capacity=4, max_off_policy_steps=8, seed=0)
+    replay.add(
+        [
+            make_group(0, policy_step=1, insert_step=0),
+            make_group(1, policy_step=1, insert_step=1),
+            make_group(2, policy_step=2, insert_step=2),
+        ]
+    )
+
+    sampled = replay.sample(
+        target_progress=4,
+        use_token_batching=False,
+        current_step=3,
+        exclude_insert_step=2,
+    )
+
+    assert len(sampled) == 2
+    assert all(group.insert_step != 2 for group in sampled)
+    assert len(replay.groups) == 3
+
+
+def test_replay_buffer_copies_rollouts_on_insert():
+    rollout = make_rollout(0, policy_step=1)
+    replay = ReplayBuffer(capacity=2, max_off_policy_steps=8, seed=0)
+    replay.add([ReplayGroup.from_rollouts([rollout], insert_step=0)])
+
+    rollout["trajectory"][0]["prompt"][0]["content"][0]["image_url"]["url"] = "placeholder"
+
+    sampled = replay.sample(
+        target_progress=1,
+        use_token_batching=False,
+        current_step=1,
+    )[0]
+
+    stored_url = sampled.rollouts[0]["trajectory"][0]["prompt"][0]["content"][0]["image_url"]["url"]
+    assert stored_url == "file:///tmp/test-image.png"
+
+
+def test_replay_buffer_returns_deep_copies_for_nested_rollout_data():
+    replay = ReplayBuffer(capacity=2, max_off_policy_steps=8, seed=0)
+    replay.add([make_group(0, policy_step=1, insert_step=0)])
+
+    sampled = replay.sample(
+        target_progress=2,
+        use_token_batching=False,
+        current_step=2,
+    )[0]
+    sampled.rollouts[0]["trajectory"][0]["prompt"][0]["content"][0]["image_url"]["url"] = "placeholder"
+
+    sampled_again = replay.sample(
+        target_progress=2,
+        use_token_batching=False,
+        current_step=2,
+    )[0]
+    stored_url = sampled_again.rollouts[0]["trajectory"][0]["prompt"][0]["content"][0]["image_url"]["url"]
+    assert stored_url == "file:///tmp/test-image.png"
+
+
+def test_replay_buffer_evicts_stale_groups():
+    replay = ReplayBuffer(capacity=4, max_off_policy_steps=2, seed=0)
+    replay.add(
+        [
+            make_group(0, policy_step=1, insert_step=0),
+            make_group(1, policy_step=4, insert_step=1),
+        ]
+    )
+
+    replay.evict_stale(current_step=6)
+
+    assert len(replay.groups) == 1
+    assert replay.groups[0].policy_step == 4
+
+
+def test_checkpoint_manager_round_trips_replay(tmp_path: Path):
+    class FakeBuffer:
+        def __init__(self):
+            self.loaded = False
+
+        def save(self, path: Path) -> None:
+            path.mkdir(parents=True, exist_ok=True)
+            (path / "buffer.txt").write_text("buffer")
+
+        def load(self, path: Path) -> None:
+            self.loaded = (path / "buffer.txt").read_text() == "buffer"
+
+    progress = Progress(step=3, total_tokens=9, total_samples=4, total_problems=2)
+    replay = ReplayBuffer(capacity=4, max_off_policy_steps=8, seed=0)
+    replay.add([make_group(0, policy_step=2, insert_step=1)])
+
+    manager = CheckpointManager(tmp_path, CheckpointConfig())
+    manager.save(progress, FakeBuffer(), step=3, replay=replay)
+
+    loaded_progress = Progress()
+    loaded_replay = ReplayBuffer(capacity=4, max_off_policy_steps=8, seed=0)
+    loaded_buffer = FakeBuffer()
+    manager.load(loaded_progress, loaded_buffer, step=3, replay=loaded_replay)
+
+    assert loaded_progress.step == 3
+    assert loaded_progress.total_tokens == 9
+    assert loaded_buffer.loaded
+    assert len(loaded_replay.groups) == 1
+    assert loaded_replay.groups[0].policy_step == 2
+    assert loaded_replay.groups[0].insert_step == 1
+
+
+def test_checkpoint_manager_skip_replay_leaves_existing_replay_untouched(tmp_path: Path):
+    class FakeBuffer:
+        def save(self, path: Path) -> None:
+            path.mkdir(parents=True, exist_ok=True)
+            (path / "buffer.txt").write_text("buffer")
+
+        def load(self, path: Path) -> None:
+            assert (path / "buffer.txt").read_text() == "buffer"
+
+    progress = Progress(step=3)
+    saved_replay = ReplayBuffer(capacity=4, max_off_policy_steps=8, seed=0)
+    saved_replay.add([make_group(0, policy_step=2, insert_step=1)])
+
+    manager = CheckpointManager(tmp_path, CheckpointConfig())
+    manager.save(progress, FakeBuffer(), step=3, replay=saved_replay)
+
+    preserved_replay = ReplayBuffer(capacity=4, max_off_policy_steps=8, seed=0)
+    preserved_replay.add([make_group(9, policy_step=9, insert_step=9)])
+    skip_manager = CheckpointManager(tmp_path, CheckpointConfig(skip_replay=True))
+    skip_manager.load(Progress(), FakeBuffer(), step=3, replay=preserved_replay)
+
+    assert len(preserved_replay.groups) == 1
+    assert preserved_replay.groups[0].policy_step == 9
+    assert preserved_replay.groups[0].insert_step == 9

--- a/tests/unit/orchestrator/test_scheduler.py
+++ b/tests/unit/orchestrator/test_scheduler.py
@@ -1,9 +1,10 @@
 import asyncio
+from collections import defaultdict
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from prime_rl.orchestrator.scheduler import InflightRequest, Scheduler
+from prime_rl.orchestrator.scheduler import GroupState, InflightRequest, Scheduler
 from prime_rl.utils.async_utils import safe_cancel
 
 
@@ -157,5 +158,96 @@ def test_stop_cancels_inflight_policy_update_task():
         assert cancelled.is_set()
         assert scheduler.update_policy_task is None
         assert scheduler.inflight_policy_update_task is None
+
+    asyncio.run(run())
+
+
+def test_generate_batch_uses_schedule_time_policy_step():
+    class DummyProgressTracker:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def update(self, _value):
+            pass
+
+        def close(self):
+            pass
+
+    class FakeBuffer:
+        def __init__(self):
+            self.rollouts = []
+
+        def update(self, rollouts):
+            self.rollouts.extend(rollouts)
+
+        def sample_rollouts(self, n: int):
+            return self.rollouts[-n:]
+
+    async def run() -> None:
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.enable_policy_updates = False
+        scheduler.checkpoint_ready = asyncio.Event()
+        scheduler.checkpoint_ready.set()
+        scheduler.logger = MagicMock()
+        scheduler.json_logging = False
+        scheduler.batch_size = 1
+        scheduler.token_batch_size = None
+        scheduler.rollouts_per_example = 1
+        scheduler.max_async_level = 0
+        scheduler.step = 0
+        scheduler.ckpt_step = 11
+        scheduler.last_batch_generation_time = 0.0
+        scheduler.max_inflight_rollouts = 1
+        scheduler.buffer = FakeBuffer()
+        scheduler.inflight_requests = {}
+        scheduler.groups = {}
+        scheduler.total_rollouts_by_env = defaultdict(int)
+        scheduler.empty_rollouts_by_env = defaultdict(int)
+        scheduler.errored_rollouts_by_env = defaultdict(int)
+        scheduler.cancelled_rollouts_count = 0
+        scheduler.inference_pool = SimpleNamespace(get_metrics=lambda: {})
+        scheduler.train_envs = SimpleNamespace(get=lambda _env_name: SimpleNamespace(requires_group_scoring=False))
+        scheduler._fill_inflight_requests = AsyncMock()
+
+        finished = asyncio.Future()
+        finished.set_result(
+            {
+                "example_id": 1,
+                "reward": 1.0,
+                "error": None,
+                "trajectory": [
+                    {
+                        "tokens": {
+                            "prompt_ids": [1],
+                            "prompt_mask": [False],
+                            "completion_ids": [2],
+                            "completion_mask": [True],
+                            "completion_logprobs": [-0.1],
+                        }
+                    }
+                ],
+                "timing": {"generation_ms": 1.0, "scoring_ms": 1.0},
+                "metrics": {},
+                "is_truncated": False,
+            }
+        )
+
+        group_id = 7
+        scheduler.inflight_requests = {
+            finished: InflightRequest(
+                off_policy_steps=0,
+                client_config=SimpleNamespace(api_base_url="http://test", extra_headers={}),
+                env_name="math",
+                policy_step=5,
+                group_id=group_id,
+            )
+        }
+        scheduler.groups = {group_id: GroupState(example={"env_name": "math"}, rollouts_to_schedule=0)}
+
+        with patch("prime_rl.orchestrator.scheduler.ProgressTracker", DummyProgressTracker):
+            batch = await scheduler.generate_batch(step=12, target=1)
+
+        assert batch[0]["env_name"] == "math"
+        assert batch[0]["policy_step"] == 5
 
     asyncio.run(run())

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -159,3 +159,21 @@ def test_removed_fused_lm_head_chunk_size_field_is_rejected():
 def test_selective_activation_checkpointing_requires_custom_impl():
     with pytest.raises(ValidationError, match="Selective activation checkpointing requires model.impl='custom'"):
         TrainerModelConfig.model_validate({"impl": "hf", "ac": {"mode": "selective"}})
+
+
+def test_orchestrator_replay_partial_override(tmp_path):
+    write_toml(tmp_path / "cfg.toml", {"replay": {"capacity": 8, "replay_fraction": 0.25}})
+    config = cli(OrchestratorConfig, args=["@", str(tmp_path / "cfg.toml")])
+
+    assert config.replay.capacity == 8
+    assert config.replay.replay_fraction == 0.25
+    assert config.replay.enabled
+    assert config.replay.sampling.type == "uniform"
+
+
+def test_orchestrator_replay_requires_both_capacity_and_fraction():
+    with pytest.raises(ValidationError, match="replay.capacity must be > 0"):
+        OrchestratorConfig.model_validate({"replay": {"replay_fraction": 0.2}})
+
+    with pytest.raises(ValidationError, match="replay.replay_fraction must be > 0"):
+        OrchestratorConfig.model_validate({"replay": {"capacity": 8}})


### PR DESCRIPTION
## Summary

Implements replay buffer support for RL training in the orchestrator, with replay-aware batching, checkpoint persistence, metrics, and focused unit coverage.

Closes #2273.

## What Changed

- added a new orchestrator-side replay subsystem that stores immutable rollout groups and samples them back into future training batches
- added replay configuration for capacity, replay fraction, replay sampling seed, and replay-specific off-policy age limits
- persisted replay state in orchestrator checkpoints and added `skip_replay` so replay restore can be disabled independently of the main buffer
- captured `policy_step` at rollout schedule time so replay age and off-policy accounting use the policy that actually generated the rollout
- mixed replayed groups into the train batch without changing trainer transport, while keeping the current fresh-buffer path intact
- updated per-step metrics to use `problem_idx` instead of assuming `example_id` is unique within a step, and added replay-specific progress/age/utilization metrics
- added focused tests for replay target calculation, replay immutability, replay checkpoint round-tripping, `skip_replay`, scheduler `policy_step` capture, and replay config validation
- updated the config skill to document the new `[orchestrator.replay]` surface and checkpoint skip behavior

## Design Notes

This keeps replay as an orchestrator-side feature rather than turning the current transient rollout queue into a random bounded buffer or widening trainer transport.

Key design choices:

- replay stores whole rollout groups so problem-level grouping and advantage semantics stay aligned with the existing `rollouts_per_example` contract
- replay entries are deep-copied on insert and on sample so later in-place rollout mutation, especially on the VLM path, does not corrupt stored replay state
- replay is sampled before fresh generation so the fresh target is based on the actual replay payload selected for the step rather than only an estimate
- replay age is tracked from the rollout's schedule-time `policy_step`, not the completion step, which matches the actual generating policy

## Validation

Validated in the isolated worktree with:

- `python3 -m py_compile` on all changed Python files
- `git diff --check`
- dependency-free runtime harnesses covering replay logic, replay checkpoint round-trip behavior, and scheduler schedule-time `policy_step` capture

I also attempted to run the targeted pytest slice:

- `uv run pytest tests/unit/orchestrator/test_replay.py tests/unit/orchestrator/test_scheduler.py tests/unit/test_configs.py -q`
- `./.venv/bin/python -m pytest tests/unit/orchestrator/test_replay.py tests/unit/orchestrator/test_scheduler.py tests/unit/test_configs.py -q`

Those remain blocked on this macOS host because the repo lockfile only supports Linux environments and the local `.venv` does not have `pytest` installed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core orchestrator batching/metrics and checkpoint save/load paths; bugs could change training data mix or resume behavior, though the feature is gated behind explicit `replay` config and has unit coverage.
> 
> **Overview**
> Adds an orchestrator-side replay buffer that stores immutable rollout *groups* and can mix sampled replayed groups into each training batch based on a new `replay` config (`capacity`, `replay_fraction`, seed, and replay-specific off-policy age).
> 
> Extends checkpointing to persist/restore replay state and introduces `ckpt.skip_replay` to independently bypass replay restoration on resume.
> 
> Updates scheduling/batching to record `policy_step` at rollout schedule time, annotates rollouts with `data_source`/`problem_idx`, and adjusts step metrics/aggregations to use `problem_idx` (plus new replay utilization/age and requested-vs-actual replay fraction metrics). Includes focused unit tests and config-skill documentation for the new replay surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01180b616fc080d67feef3d50f995b31dbde75f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->