### PR TITLE
Enable vllm-router for single-node inference deployments (#2323)

### DIFF
--- a/src/prime_rl/configs/inference.py
+++ b/src/prime_rl/configs/inference.py
@@ -137,6 +137,25 @@ class SingleNodeInferenceDeploymentConfig(BaseInferenceDeploymentConfig):
 
     type: Literal["single_node"] = "single_node"
 
+    use_router: Annotated[
+        bool,
+        Field(
+            description="Whether to run a local vllm-router in front of the single-node backend.",
+        ),
+    ] = True
+    router_port: Annotated[
+        int,
+        Field(description="Port for the vllm-router when use_router is enabled."),
+    ] = 8000
+    backend_port: Annotated[
+        int,
+        Field(description="Port for the single-node vLLM backend when use_router is enabled."),
+    ] = 8100
+    router_policy: Annotated[
+        str,
+        Field(description="Routing policy for the vllm-router (e.g. 'consistent_hash', 'round_robin')."),
+    ] = "consistent_hash"
+
 
 class MultiNodeInferenceDeploymentConfig(BaseInferenceDeploymentConfig):
     """Configures a multi-node inference deployment. Each node runs an independent vLLM replica."""
@@ -426,6 +445,26 @@ class InferenceConfig(BaseConfig):
     def validate_multi_node_requires_slurm(self):
         if self.deployment.type == "multi_node" and self.slurm is None:
             raise ValueError("Must use SLURM for multi-node deployment.")
+        return self
+
+    @model_validator(mode="after")
+    def auto_setup_single_node_router(self):
+        if self.deployment.type != "single_node" or not self.deployment.use_router:
+            return self
+
+        if "router_port" in self.deployment.model_fields_set and self.deployment.router_port != self.server.port:
+            raise ValueError(
+                "For single-node router deployments, deployment.router_port must match server.port. "
+                "Set server.port to the public router port and deployment.backend_port to the backend port."
+            )
+
+        self.deployment.router_port = self.server.port
+
+        if self.deployment.backend_port == self.deployment.router_port:
+            raise ValueError(
+                "deployment.backend_port must differ from server.port when deployment.use_router is enabled."
+            )
+
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -747,6 +747,34 @@ class RLConfig(BaseConfig):
         return self
 
     @model_validator(mode="after")
+    def auto_setup_single_node_inference_urls(self):
+        """Auto-configure single-node router/backend URLs for the orchestrator client."""
+        if self.inference is None:
+            return self
+
+        if self.deployment.type != "single_node":
+            return self
+
+        if self.orchestrator.client.is_elastic:
+            return self
+
+        host = self.inference.server.host or "localhost"
+
+        if self.inference.deployment.type == "single_node" and self.inference.deployment.use_router:
+            if "base_url" not in self.orchestrator.client.model_fields_set:
+                self.orchestrator.client.base_url = [f"http://{host}:{self.inference.deployment.router_port}/v1"]
+
+            if "admin_base_url" not in self.orchestrator.client.model_fields_set:
+                self.orchestrator.client.admin_base_url = [f"http://{host}:{self.inference.deployment.backend_port}/v1"]
+
+            return self
+
+        if "base_url" not in self.orchestrator.client.model_fields_set:
+            self.orchestrator.client.base_url = [f"http://{host}:{self.inference.server.port}/v1"]
+
+        return self
+
+    @model_validator(mode="after")
     def auto_setup_router_replay(self):
         if self.trainer.enable_router_replay:
             if self.inference is not None:

--- a/src/prime_rl/entrypoints/inference.py
+++ b/src/prime_rl/entrypoints/inference.py
@@ -1,5 +1,6 @@
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 import tomli_w
@@ -34,7 +35,13 @@ def write_slurm_script(config: InferenceConfig, config_path: Path, script_path: 
     template = env.get_template(config.slurm.template_path.name)
 
     is_disaggregated = config.deployment.type == "disaggregated"
-    dp_per_node = config.deployment.gpus_per_node // config.parallel.tp
+    is_multi_node = config.deployment.type == "multi_node"
+    is_single_node_router = config.deployment.type == "single_node" and config.deployment.use_router
+    dp_per_node = (
+        config.data_parallel_size_local or config.parallel.dp
+        if is_single_node_router
+        else config.deployment.gpus_per_node // config.parallel.tp
+    )
 
     template_vars = dict(
         **config.slurm.template_vars,
@@ -45,9 +52,8 @@ def write_slurm_script(config: InferenceConfig, config_path: Path, script_path: 
         num_nodes=getattr(config.deployment, "num_nodes", 1),
         port=config.server.port,
         disaggregated=is_disaggregated,
+        single_node_router=is_single_node_router,
     )
-
-    is_multi_node = config.deployment.type == "multi_node"
 
     if is_disaggregated:
         template_vars.update(
@@ -68,13 +74,12 @@ def write_slurm_script(config: InferenceConfig, config_path: Path, script_path: 
             if config.deployment.kv_cache_offload
             else 0,
         )
-    elif is_multi_node:
+    elif is_multi_node or is_single_node_router:
         template_vars.update(
             router_port=config.deployment.router_port,
             backend_port=config.deployment.backend_port,
             router_policy=config.deployment.router_policy,
         )
-
     script = template.render(**template_vars)
 
     script_path.parent.mkdir(parents=True, exist_ok=True)
@@ -117,6 +122,72 @@ def inference_slurm(config: InferenceConfig):
     logger.success(f"{result.stdout.strip()}\n\n{log_message}")
 
 
+def run_single_node_with_router(config: InferenceConfig):
+    """Run a single-node backend behind a local vllm-router."""
+    from prime_rl.inference.server import setup_vllm_env
+
+    logger = setup_logger("info")
+
+    host = config.server.host or "0.0.0.0"
+    router_port = config.deployment.router_port
+    backend_port = config.deployment.backend_port
+    router_dp_size = config.data_parallel_size_local or config.parallel.dp
+
+    logger.info(f"Starting single-node backend on http://{host}:{backend_port}/v1")
+    logger.info(f"Starting single-node router on http://{host}:{router_port}/v1\n")
+
+    setup_vllm_env(config)
+
+    with tempfile.TemporaryDirectory(prefix="prime-rl-inference-") as tmpdir:
+        config_path = write_config(config, Path(tmpdir))
+
+        backend_cmd = [
+            sys.executable,
+            "-m",
+            "prime_rl.entrypoints.inference",
+            "@",
+            str(config_path),
+            "--server.host",
+            host,
+            "--server.port",
+            str(backend_port),
+            "--deployment.use_router",
+            "false",
+        ]
+        router_cmd = [
+            "vllm-router",
+            "--policy",
+            config.deployment.router_policy,
+            "--worker-urls",
+            f"http://127.0.0.1:{backend_port}",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            str(router_port),
+            "--intra-node-data-parallel-size",
+            str(router_dp_size),
+            "--worker-startup-timeout-secs",
+            "4200",
+            "--log-level",
+            "debug",
+        ]
+
+        backend_proc = subprocess.Popen(backend_cmd)
+        try:
+            result = subprocess.run(router_cmd)
+        finally:
+            if backend_proc.poll() is None:
+                backend_proc.terminate()
+                try:
+                    backend_proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    backend_proc.kill()
+                    backend_proc.wait()
+
+        if result.returncode != 0:
+            sys.exit(result.returncode)
+
+
 def inference_local(config: InferenceConfig):
     """Run inference locally."""
     from prime_rl.inference.server import setup_vllm_env
@@ -125,6 +196,10 @@ def inference_local(config: InferenceConfig):
 
     if config.dry_run:
         logger.success("Dry run complete. To start inference locally, remove --dry-run from your command.")
+        return
+
+    if config.deployment.type == "single_node" and config.deployment.use_router:
+        run_single_node_with_router(config)
         return
 
     host = config.server.host or "0.0.0.0"

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -66,8 +66,10 @@ def write_subconfigs(config: RLConfig, output_dir: Path) -> None:
         tomli_w.dump(config.orchestrator.model_dump(exclude_none=True, mode="json"), f)
 
     if config.inference is not None:
-        # Exclude launcher-only fields that are not needed by the vLLM server
-        exclude_inference = {"deployment", "slurm", "output_dir", "dry_run"}
+        # Exclude launcher-only fields that are not needed by the inference entrypoint.
+        exclude_inference = {"slurm", "output_dir", "dry_run"}
+        if config.inference.deployment.type in ("multi_node", "disaggregated"):
+            exclude_inference.add("deployment")
         with open(output_dir / INFERENCE_TOML, "wb") as f:
             tomli_w.dump(config.inference.model_dump(exclude=exclude_inference, exclude_none=True, mode="json"), f)
 
@@ -151,20 +153,45 @@ def rl_local(config: RLConfig):
     all_gpu_ids = list(set(infer_gpu_ids + trainer_gpu_ids + teacher_gpu_ids))
     check_gpus_available(all_gpu_ids)
 
-    # Validate client port matches inference server port
+    # Validate client ports match the inference routing shape.
     if config.inference is not None and not config.orchestrator.client.is_elastic:
         from urllib.parse import urlparse
 
         base_url = config.orchestrator.client.base_url[0]
-        parsed = urlparse(base_url)
-        client_port = parsed.port
-        expected_port = config.inference.server.port
-        if client_port != expected_port:
-            raise ValueError(
-                f"orchestrator.client.base_url port ({client_port}) does not match "
-                f"inference.server.port ({expected_port}). "
-                f"Update the base_url to use port {expected_port} to match the inference server."
-            )
+        base_port = urlparse(base_url).port
+
+        if config.inference.deployment.type == "single_node" and config.inference.deployment.use_router:
+            expected_base_port = config.inference.deployment.router_port
+            if base_port != expected_base_port:
+                raise ValueError(
+                    f"orchestrator.client.base_url port ({base_port}) does not match "
+                    f"inference.deployment.router_port ({expected_base_port}). "
+                    f"Update the base_url to use port {expected_base_port} to match the single-node router."
+                )
+
+            admin_base_url = config.orchestrator.client.admin_base_url
+            if not admin_base_url:
+                raise ValueError(
+                    "orchestrator.client.admin_base_url must be set for single-node router deployments "
+                    "to route admin operations directly to the backend."
+                )
+
+            admin_port = urlparse(admin_base_url[0]).port
+            expected_admin_port = config.inference.deployment.backend_port
+            if admin_port != expected_admin_port:
+                raise ValueError(
+                    f"orchestrator.client.admin_base_url port ({admin_port}) does not match "
+                    f"inference.deployment.backend_port ({expected_admin_port}). "
+                    f"Update the admin_base_url to use port {expected_admin_port} to match the single-node backend."
+                )
+        else:
+            expected_port = config.inference.server.port
+            if base_port != expected_port:
+                raise ValueError(
+                    f"orchestrator.client.base_url port ({base_port}) does not match "
+                    f"inference.server.port ({expected_port}). "
+                    f"Update the base_url to use port {expected_port} to match the inference server."
+                )
 
     # Prepare paths to communicate with the trainer
     log_dir = get_log_dir(config.output_dir)

--- a/src/prime_rl/templates/inference.sbatch.j2
+++ b/src/prime_rl/templates/inference.sbatch.j2
@@ -36,7 +36,7 @@ export PREFILL_PORT={{ prefill_port }}
 export DECODE_PORT={{ decode_port }}
 export ROUTER_PORT={{ router_port }}
 export RPC_PORT={{ data_parallel_rpc_port }}
-{%- elif num_nodes > 1 %}
+{%- elif num_nodes > 1 or single_node_router %}
 export ROUTER_PORT={{ router_port }}
 export BACKEND_PORT={{ backend_port }}
 {%- endif %}
@@ -94,6 +94,11 @@ ROUTER_ARGS=""
 for host in ${HOSTNAMES[@]}; do
     ROUTER_ARGS="$ROUTER_ARGS http://${host}:${BACKEND_PORT}"
 done
+export INFER_URLS
+export ROUTER_ARGS
+{%- elif single_node_router %}
+INFER_URLS="http://${HOSTNAMES[0]}:${ROUTER_PORT}/v1"
+ROUTER_ARGS="http://${HOSTNAMES[0]}:${BACKEND_PORT}"
 export INFER_URLS
 export ROUTER_ARGS
 {%- else %}
@@ -270,8 +275,30 @@ srun bash -c '
     # Required for graph compilation to work
     export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False
 
+{%- if single_node_router %}
+    ROUTER_LOG="$OUTPUT_DIR/logs/inference/router.log"
+    echo "Starting vllm-router on $LOCAL_IP:$ROUTER_PORT" | tee $ROUTER_LOG
+
+    vllm-router \
+        --policy {{ router_policy }} \
+        --worker-urls $ROUTER_ARGS \
+        --host 0.0.0.0 \
+        --port $ROUTER_PORT \
+        --intra-node-data-parallel-size {{ dp_per_node }} \
+        --worker-startup-timeout-secs 4200 \
+        --log-level debug \
+        >> $ROUTER_LOG 2>&1 &
+
+    uv run inference \
+        @ $CONFIG_PATH \
+        --server.host 0.0.0.0 \
+        --server.port $BACKEND_PORT \
+        --deployment.use_router false \
+        2>&1 | tee -a $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log
+{%- else %}
     uv run inference \
         @ $CONFIG_PATH \
         2>&1 | tee -a $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log
+{%- endif %}
 {%- endif %}
 '

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -159,3 +159,60 @@ def test_removed_fused_lm_head_chunk_size_field_is_rejected():
 def test_selective_activation_checkpointing_requires_custom_impl():
     with pytest.raises(ValidationError, match="Selective activation checkpointing requires model.impl='custom'"):
         TrainerModelConfig.model_validate({"impl": "hf", "ac": {"mode": "selective"}})
+
+
+def test_inference_single_node_router_defaults_follow_server_port():
+    config = InferenceConfig(server={"port": 9000})
+    assert config.deployment.type == "single_node"
+    assert config.deployment.use_router is True
+    assert config.deployment.router_port == 9000
+    assert config.deployment.backend_port == 8100
+
+
+def test_inference_single_node_router_rejects_backend_port_conflict():
+    with pytest.raises(ValidationError, match="deployment.backend_port must differ from server.port"):
+        InferenceConfig(
+            server={"port": 9000},
+            deployment={"type": "single_node", "use_router": True, "backend_port": 9000},
+        )
+
+
+def test_inference_single_node_router_rejects_router_port_mismatch():
+    with pytest.raises(ValidationError, match="deployment.router_port must match server.port"):
+        InferenceConfig(
+            server={"port": 9000},
+            deployment={"type": "single_node", "use_router": True, "router_port": 9001},
+        )
+
+
+def test_rl_single_node_router_sets_client_and_admin_urls():
+    config = cli(
+        RLConfig,
+        args=[
+            "@",
+            "configs/ci/integration/rl/start.toml",
+            "--inference.server.port",
+            "9000",
+            "--inference.deployment.use_router",
+            "true",
+            "--inference.deployment.backend_port",
+            "9100",
+        ],
+    )
+    assert config.orchestrator.client.base_url == ["http://localhost:9000/v1"]
+    assert config.orchestrator.client.admin_base_url == ["http://localhost:9100/v1"]
+
+
+def test_rl_single_node_without_router_keeps_base_url_on_server_port():
+    config = cli(
+        RLConfig,
+        args=[
+            "@",
+            "configs/ci/integration/rl/start.toml",
+            "--inference.server.port",
+            "9001",
+            "--inference.deployment.use_router",
+            "false",
+        ],
+    )
+    assert config.orchestrator.client.base_url == ["http://localhost:9001/v1"]


### PR DESCRIPTION
Closes #2323

## Summary

This updates single-node inference to run behind `vllm-router`, matching the existing router-fronted shape used in other deployment modes.

For single-node deployments:
- inference traffic now goes through the router on `server.port`
- backend traffic runs on `deployment.backend_port`
- orchestrator admin traffic is routed directly to the backend via `admin_base_url`
- local and SLURM single-node paths both support router-fronted startup

## Changes

- added single-node router config fields in `src/prime_rl/configs/inference.py`
- auto-configured single-node client/admin URLs in `src/prime_rl/configs/rl.py`
- preserved single-node deployment config when RL writes `inference.toml`
- added local single-node router startup in `src/prime_rl/entrypoints/inference.py`
- added single-node router support to the SLURM inference template
- added targeted config tests for single-node router behavior

## Validation

Local validation:
- confirmed backend health on `http://localhost:8100/health`
- confirmed router health on `http://localhost:8000/health`
- confirmed model listing through the router on `http://localhost:8000/v1/models`

Checks run:
- `ruff check --config=pyproject.toml .`
- `ruff format --check --config=pyproject.toml .`
- `PYTHONPATH=src python -m pytest tests/unit/test_configs.py -k "single_node_router or admin_urls"`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes default single-node inference networking (router vs direct backend) and RL launcher URL/port validation, which can break existing local/SLURM run configurations if ports or client URLs are overridden incorrectly.
> 
> **Overview**
> **Single-node inference now defaults to running behind a local `vllm-router`.** `SingleNodeInferenceDeploymentConfig` adds `use_router` (default `true`) plus router/backend port + policy settings, and `InferenceConfig` auto-validates/aligns `deployment.router_port` with `server.port` while enforcing a distinct `backend_port`.
> 
> **Launchers and templates were updated to start and target the router/back-end split.** The inference entrypoint can spawn a backend subprocess and run `vllm-router` locally; the SLURM template and script vars now support the same single-node router mode; and the RL config/entrypoint auto-sets and validates `orchestrator.client.base_url` (router) vs `admin_base_url` (backend), while preserving the `deployment` config when writing `inference.toml` for single-node runs.
> 
> **Tests** add coverage for the new single-node router defaults, validation errors, and RL client/admin URL auto-configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0257da2090027351e1043a56ba40a4175114a3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->