### PR TITLE
fix(trainer): wait for NCCL_READY on all ranks before broadcast

### DIFF
--- a/src/prime_rl/trainer/rl/broadcast/nccl.py
+++ b/src/prime_rl/trainer/rl/broadcast/nccl.py
@@ -198,43 +198,61 @@ class NCCLWeightBroadcast(WeightBroadcast):
         """Broadcast the state dict of a model into the inference pool using NCCL and notifies the orchestrator."""
         self.logger.debug("Starting broadcasting weights to inference engine via NCCL")
         start_time = time.perf_counter()
-        notified_runs: list[tuple[int, Path]] = []
+        # `_compute_notified_runs` is a pure function of SPMD-replicated state on
+        # multi_run_manager, so every trainer rank derives the same list. Only
+        # the master touches the filesystem to notify the orchestrator, but all
+        # ranks must wait on NCCL_READY before entering the broadcast path:
+        # the broadcast preparation (DTensor resolution, quantization) enqueues
+        # collectives on non-master ranks, and if those ranks start prep before
+        # the orchestrator has paused inference, the collectives sit unmatched
+        # until NCCL's watchdog kills the process after 10 min.
+        notified_runs = self._compute_notified_runs()
         if self.world.is_master:
-            notified_runs = self._notify_orchestrator()
-            # Wait for inference workers to signal readiness before starting NCCL broadcast
-            self._wait_for_nccl_ready(notified_runs)
+            self._notify_orchestrator(notified_runs)
+        self._wait_for_nccl_ready(notified_runs)
         self.nccl_broadcast_sender.broadcast_weights(model, step)
         self.logger.debug(f"Weights broadcasted in {time.perf_counter() - start_time:.2f}s")
 
-    def _notify_orchestrator(self) -> list[tuple[int, Path]]:
-        """Notify the orchestrator to initiate weight broadcast.
+    def _compute_notified_runs(self) -> list[tuple[int, Path]]:
+        """Derive the list of (run_idx, save_dir) pairs that need broadcasting.
 
-        Returns:
-            List of (run_idx, save_dir) tuples for runs that were notified.
+        Pure function of `multi_run_manager` state, which is replicated across
+        trainer ranks (SPMD). Returns the same list on every rank so master and
+        non-master ranks agree on which NCCL_READY markers to wait for.
         """
         notified_runs: list[tuple[int, Path]] = []
-        if self.world.is_master:
-            for idx in self.multi_run_manager.used_idxs:
-                if not self.multi_run_manager.ready_to_update[idx]:
-                    continue
-
-                try:
-                    save_dir = get_step_path(
-                        get_broadcast_dir(self.multi_run_manager.get_run_dir(idx)),
-                        self.multi_run_manager.progress[idx].step,
-                    )
-                    save_dir.mkdir(parents=True, exist_ok=True)
-
-                    stable_file = save_dir / "STABLE"
-                    stable_file.touch()
-                    notified_runs.append((idx, save_dir))
-                except FileNotFoundError:
-                    self.logger.warning(f"Run {idx} is deleted, skipping")
-                except Exception as e:
-                    self.logger.error(f"Error broadcasting weights for run {idx}: {e}")
-                finally:
-                    self.multi_run_manager.ready_to_update[idx] = False
+        for idx in self.multi_run_manager.used_idxs:
+            if not self.multi_run_manager.ready_to_update[idx]:
+                continue
+            try:
+                save_dir = get_step_path(
+                    get_broadcast_dir(self.multi_run_manager.get_run_dir(idx)),
+                    self.multi_run_manager.progress[idx].step,
+                )
+                notified_runs.append((idx, save_dir))
+            except FileNotFoundError:
+                self.logger.warning(f"Run {idx} is deleted, skipping")
+            except Exception as e:
+                self.logger.error(f"Error resolving broadcast dir for run {idx}: {e}")
         return notified_runs
+
+    def _notify_orchestrator(self, notified_runs: list[tuple[int, Path]]) -> None:
+        """Create STABLE markers for each notified run and clear their ready flags.
+
+        Master-only side effects (filesystem writes + state mutation). Called
+        after `_compute_notified_runs`; non-master ranks skip this entirely.
+        """
+        for idx, save_dir in notified_runs:
+            try:
+                save_dir.mkdir(parents=True, exist_ok=True)
+                stable_file = save_dir / "STABLE"
+                stable_file.touch()
+            except FileNotFoundError:
+                self.logger.warning(f"Run {idx} is deleted, skipping")
+            except Exception as e:
+                self.logger.error(f"Error broadcasting weights for run {idx}: {e}")
+            finally:
+                self.multi_run_manager.ready_to_update[idx] = False
 
     def _wait_for_nccl_ready(self, notified_runs: list[tuple[int, Path]]):
         """Wait for inference workers to signal they are ready to receive NCCL broadcast."""


### PR DESCRIPTION
## The bug

In `src/prime_rl/trainer/rl/broadcast/nccl.py`, `NCCLWeightBroadcast.broadcast_weights` only waits for the orchestrator's `NCCL_READY` marker on the master rank:

\`\`\`python
if self.world.is_master:
    notified_runs = self._notify_orchestrator()
    self._wait_for_nccl_ready(notified_runs)   # master only
self.nccl_broadcast_sender.broadcast_weights(model, step)  # all ranks
\`\`\`

The non-master ranks skip the wait and enter \`nccl_broadcast_sender.broadcast_weights\` immediately. That function's preparation path (DTensor resolution in \`_resolve_dtensors\`, plus optional quantization) runs on every rank and enqueues NCCL all_gathers on PG 1 (FSDP). Those collectives sit in-flight with no counter-party until the orchestrator has paused inference and the master joins.

If the orchestrator takes more than 10 minutes to create the \`NCCL_READY\` marker (which happens when eval and rollout generation are contending for sandbox/IB capacity), NCCL's watchdog kills the process on a non-master rank — hard SIGABRT, ~18 minutes of wall-clock lost per incident.

## Symptom

We've hit this repeatedly on multi-node RL runs. Always the same signature:

- Master (rank 0) logs \`Waiting for path '.../broadcasts/step_N/NCCL_READY'\`
- ~10 minutes later, a non-master rank's stderr shows \`Watchdog caught collective operation timeout: WorkNCCL(SeqNum=..., OpType=COALESCED, NumelIn=25M, NumelOut=402M, Timeout(ms)=600000)\` on PG 1
- Default-PG rank 0 receives the flight-recorder dump signal from that non-master rank and the trainer dies

## Fix

Split \`_notify_orchestrator\` into:

- \`_compute_notified_runs\` — pure function of SPMD-replicated \`multi_run_manager\` state, runs on every rank and returns the same list everywhere.
- \`_notify_orchestrator(notified_runs)\` — master-only, does the filesystem side-effects (\`mkdir\`, \`touch STABLE\`) and clears \`ready_to_update[idx]\`.

Call \`_compute_notified_runs\` unconditionally, \`_notify_orchestrator\` only on master, and then have every trainer rank wait for the \`NCCL_READY\` marker before entering the broadcast path. The wait is a pure filesystem poll, no NCCL involvement, so a slow orchestrator now just blocks the trainer safely instead of tripping the watchdog.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes distributed synchronization around NCCL weight broadcasts; mistakes could deadlock broadcasts or regress multi-run update coordination, but scope is limited to the broadcast/notification path.
> 
> **Overview**
> Prevents non-master ranks from entering the NCCL broadcast preparation path before inference is ready by making **all ranks** compute the same `notified_runs` list and wait for the `NCCL_READY` marker.
> 
> Splits the previous `_notify_orchestrator` flow into `_compute_notified_runs` (pure, SPMD-consistent) and `_notify_orchestrator(notified_runs)` (master-only filesystem `STABLE` writes + clearing `ready_to_update`), so only rank 0 performs side effects while every rank blocks safely before broadcasting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae6aef48553b9703632fc21e58b7984e68a65d37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->