### PR TITLE
[Fix] nemotron fixes

### DIFF
--- a/src/prime_rl/configs/trainer.py
+++ b/src/prime_rl/configs/trainer.py
@@ -139,7 +139,13 @@ class LoRAConfig(BaseConfig):
     target_modules: Annotated[
         list[str],
         Field(
-            description="Module names or regex patterns for modules to apply LoRA to. Simple names (e.g., 'q_proj') match any component in the module path. Regex patterns match anywhere in the name.",
+            description=(
+                "Module names or regex patterns for modules to apply LoRA to. Simple names (e.g., 'q_proj') "
+                "match any component in the module path. Regex patterns match anywhere in the name. "
+                "Names unknown to the current model are silently ignored, so defaults cover multiple architectures. "
+                "NemotronH note: 'experts' matches NonGatedGroupedExperts inside LatentMoE; 'fc1_latent_proj' and "
+                "'fc2_latent_proj' adapt the latent up/down projections. Add 'in_proj'/'out_proj' to also LoRA Mamba."
+            ),
         ),
     ] = [
         "q_proj",
@@ -150,6 +156,8 @@ class LoRAConfig(BaseConfig):
         "up_proj",
         "down_proj",
         "experts",
+        "fc1_latent_proj",
+        "fc2_latent_proj",
     ]
 
     modules_to_save: Annotated[

--- a/src/prime_rl/trainer/lora.py
+++ b/src/prime_rl/trainer/lora.py
@@ -6,8 +6,8 @@ import torch.nn as nn
 
 from prime_rl.configs.trainer import LoRAConfig
 from prime_rl.trainer.models.layers.lora import MultiLoRALinear, MultiLoRAModule
-from prime_rl.trainer.models.layers.lora.multi_moe import MultiLoRAGroupedExperts
-from prime_rl.trainer.models.layers.moe import GroupedExperts
+from prime_rl.trainer.models.layers.lora.multi_moe import MultiLoRAGroupedExperts, MultiLoRANonGatedGroupedExperts
+from prime_rl.trainer.models.layers.moe import GroupedExperts, NonGatedGroupedExperts
 from prime_rl.trainer.runs import get_multi_run_manager
 from prime_rl.utils.logger import get_logger
 
@@ -74,8 +74,8 @@ def _find_target_modules(model: nn.Module, target_patterns: List[str]) -> List[s
     target_modules = []
 
     for name, module in model.named_modules():
-        # Check if module is Linear or GroupedExperts
-        if not (isinstance(module, nn.Linear) or isinstance(module, GroupedExperts)):
+        # Check if module is Linear or (NonGated)GroupedExperts
+        if not isinstance(module, (nn.Linear, GroupedExperts, NonGatedGroupedExperts)):
             continue
 
         for pattern in target_patterns:
@@ -178,10 +178,19 @@ def apply_lora_to_model(model: nn.Module, config: LoRAConfig) -> None:
                 alpha=config.alpha,
                 dropout=config.dropout,
             )
+        # Handle NonGatedGroupedExperts (relu2 experts used by NemotronH's LatentMoE)
+        elif isinstance(base_module, NonGatedGroupedExperts):
+            lora_module = MultiLoRANonGatedGroupedExperts(
+                base_layer=base_module,
+                rank=config.rank,
+                n_adapters=n_loras,
+                alpha=config.alpha,
+                dropout=config.dropout,
+            )
         else:
             logger.warning(
                 f"Module {module_name} is type {type(base_module).__name__}, "
-                f"expected nn.Linear or GroupedExperts. Skipping."
+                f"expected nn.Linear, GroupedExperts, or NonGatedGroupedExperts. Skipping."
             )
             continue
 

--- a/src/prime_rl/trainer/models/layers/lora/__init__.py
+++ b/src/prime_rl/trainer/models/layers/lora/__init__.py
@@ -6,12 +6,13 @@ from prime_rl.trainer.models.layers.lora.base import (
     set_multilora_scaling,
 )
 from prime_rl.trainer.models.layers.lora.multi_linear import MultiLoRALinear
-from prime_rl.trainer.models.layers.lora.multi_moe import MultiLoRAGroupedExperts
+from prime_rl.trainer.models.layers.lora.multi_moe import MultiLoRAGroupedExperts, MultiLoRANonGatedGroupedExperts
 
 __all__ = [
     "MultiLoRAModule",
     "MultiLoRALinear",
     "MultiLoRAGroupedExperts",
+    "MultiLoRANonGatedGroupedExperts",
     "set_lora_num_tokens",
     "get_lora_num_tokens",
     "set_multilora_scaling",

--- a/src/prime_rl/trainer/models/layers/lora/multi_moe.py
+++ b/src/prime_rl/trainer/models/layers/lora/multi_moe.py
@@ -6,7 +6,7 @@ from torch import nn
 from torch.distributed.tensor import DTensor
 
 from prime_rl.trainer.models.layers.lora.base import MultiLoRAModule, get_lora_num_tokens, get_multilora_scaling
-from prime_rl.trainer.models.layers.moe import GroupedExperts
+from prime_rl.trainer.models.layers.moe import GroupedExperts, NonGatedGroupedExperts, relu2
 
 
 def _run_lora_grouped_mm(
@@ -470,6 +470,281 @@ class MultiLoRAGroupedExperts(MultiLoRAModule):
             w2_lora_tmp = torch.matmul(h_lora, w2_lora_a[expert_idx].transpose(-2, -1))
             w2_lora_out = torch.matmul(w2_lora_tmp, w2_lora_b[expert_idx].transpose(-2, -1))
             out = h2_base + scaling * w2_lora_out
+
+            out_splits.append(out)
+            start = end
+
+        return torch.cat(out_splits, dim=0)
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}(base={self.base_layer}, rank={self.rank}, "
+            f"n_adapters={self.n_adapters}, num_experts={self.num_experts}, "
+            f"alpha={self.alpha}, dropout={self.lora_dropout}, "
+            f"use_grouped_mm={self.use_grouped_mm})"
+        )
+
+
+class MultiLoRANonGatedGroupedExperts(MultiLoRAModule):
+    """
+    NonGatedGroupedExperts + multi-LoRA with grouped GEMM.
+    Adapts the two projections (w1: up, w2: down) of NemotronH-style relu2 experts.
+    """
+
+    def __init__(
+        self,
+        base_layer: NonGatedGroupedExperts,
+        rank: int,
+        n_adapters: int,
+        alpha: float = 32.0,
+        dropout: float = 0.0,
+        use_grouped_mm: bool = True,
+    ):
+        super().__init__(base_layer)
+        if rank <= 0 or n_adapters <= 0:
+            raise ValueError("rank and n_adapters must be > 0")
+
+        self.num_experts = base_layer.num_experts
+        # w1 shape: [num_experts, intermediate_dim, input_dim]
+        self.hidden_dim = base_layer.w1.shape[1]
+        self.dim = base_layer.w1.shape[2]
+
+        if rank % 8 != 0 or self.dim % 8 != 0 or self.hidden_dim % 8 != 0:
+            use_grouped_mm = False
+
+        self.rank = rank
+        self.n_adapters = n_adapters
+        self.alpha = alpha
+        self.lora_dropout = nn.Dropout(dropout) if dropout > 0.0 else nn.Identity()
+        self.use_grouped_mm = use_grouped_mm
+
+        self._lora_num_tokens = get_lora_num_tokens()
+        self._scaling_factors = get_multilora_scaling()
+
+        # w1 (up: dim -> hidden_dim)
+        self.w1_lora_A = nn.ParameterList(
+            [
+                nn.Parameter(
+                    torch.empty(
+                        self.num_experts,
+                        rank,
+                        self.dim,
+                        device=base_layer.w1.device,
+                        dtype=base_layer.w1.dtype,
+                    )
+                )
+                for _ in range(n_adapters)
+            ]
+        )
+        self.w1_lora_B = nn.ParameterList(
+            [
+                nn.Parameter(
+                    torch.empty(
+                        self.num_experts,
+                        self.hidden_dim,
+                        rank,
+                        device=base_layer.w1.device,
+                        dtype=base_layer.w1.dtype,
+                    )
+                )
+                for _ in range(n_adapters)
+            ]
+        )
+
+        # w2 (down: hidden_dim -> dim)
+        self.w2_lora_A = nn.ParameterList(
+            [
+                nn.Parameter(
+                    torch.empty(
+                        self.num_experts,
+                        rank,
+                        self.hidden_dim,
+                        device=base_layer.w2.device,
+                        dtype=base_layer.w2.dtype,
+                    )
+                )
+                for _ in range(n_adapters)
+            ]
+        )
+        self.w2_lora_B = nn.ParameterList(
+            [
+                nn.Parameter(
+                    torch.empty(
+                        self.num_experts,
+                        self.dim,
+                        rank,
+                        device=base_layer.w2.device,
+                        dtype=base_layer.w2.dtype,
+                    )
+                )
+                for _ in range(n_adapters)
+            ]
+        )
+
+        self.reset_parameters()
+
+    def reset_parameters(self, index: int | None = None) -> None:
+        if index is None:
+            for i in range(self.n_adapters):
+                self.reset_parameters(i)
+        else:
+            nn.init.kaiming_uniform_(self.w1_lora_A[index], a=math.sqrt(5))
+            nn.init.zeros_(self.w1_lora_B[index])
+            nn.init.kaiming_uniform_(self.w2_lora_A[index], a=math.sqrt(5))
+            nn.init.zeros_(self.w2_lora_B[index])
+
+    def named_parameters_for_adapter(self, idx: int) -> list[tuple[str, nn.Parameter]]:
+        return [
+            ("w1_lora_A", self.w1_lora_A[idx]),
+            ("w1_lora_B", self.w1_lora_B[idx]),
+            ("w2_lora_A", self.w2_lora_A[idx]),
+            ("w2_lora_B", self.w2_lora_B[idx]),
+        ]
+
+    def get_lora_param_counts(self) -> tuple[int, int]:
+        adapter_params = (
+            self.w1_lora_A[0].numel()
+            + self.w1_lora_B[0].numel()
+            + self.w2_lora_A[0].numel()
+            + self.w2_lora_B[0].numel()
+        )
+        adapted_params = self.base_layer.w1.numel() + self.base_layer.w2.numel()
+        return adapter_params, adapted_params
+
+    def state_dict_for_adapter(self, idx: int) -> dict[str, torch.Tensor]:
+        state_dict = {}
+
+        detached_w1_lora_a = self.w1_lora_A[idx].detach()
+        detached_w1_lora_b = self.w1_lora_B[idx].detach()
+        detached_w2_lora_a = self.w2_lora_A[idx].detach()
+        detached_w2_lora_b = self.w2_lora_B[idx].detach()
+
+        if isinstance(detached_w1_lora_a, DTensor):
+            detached_w1_lora_a = detached_w1_lora_a.full_tensor()
+            detached_w1_lora_b = detached_w1_lora_b.full_tensor()
+            detached_w2_lora_a = detached_w2_lora_a.full_tensor()
+            detached_w2_lora_b = detached_w2_lora_b.full_tensor()
+
+        for expert_id in range(self.num_experts):
+            state_dict[f"{expert_id}.up_proj.lora_A.weight"] = detached_w1_lora_a[expert_id].clone()
+            state_dict[f"{expert_id}.up_proj.lora_B.weight"] = detached_w1_lora_b[expert_id].clone()
+            state_dict[f"{expert_id}.down_proj.lora_A.weight"] = detached_w2_lora_a[expert_id].clone()
+            state_dict[f"{expert_id}.down_proj.lora_B.weight"] = detached_w2_lora_b[expert_id].clone()
+
+        return state_dict
+
+    def forward(self, x: torch.Tensor, num_tokens_per_expert: torch.Tensor) -> torch.Tensor:
+        adapter_idx = self._lora_num_tokens.argmax().item()
+        w1_lora_a = self.w1_lora_A[adapter_idx]
+        w1_lora_b = self.w1_lora_B[adapter_idx]
+        w2_lora_a = self.w2_lora_A[adapter_idx]
+        w2_lora_b = self.w2_lora_B[adapter_idx]
+
+        scaling = self._scaling_factors[adapter_idx].item()
+
+        base_w1 = self.base_layer.w1
+        base_w2 = self.base_layer.w2
+
+        permuted_indices = None
+        if isinstance(base_w1, DTensor):
+            base_w1 = base_w1.to_local()
+            base_w2 = base_w2.to_local()
+            w1_lora_a = w1_lora_a.to_local()
+            w1_lora_b = w1_lora_b.to_local()
+            w2_lora_a = w2_lora_a.to_local()
+            w2_lora_b = w2_lora_b.to_local()
+
+            if getattr(self.base_layer, "ep_comm_backend", "torch") != "deepep":
+                from torchtitan.distributed.expert_parallel import TOKEN_GROUP_ALIGN_SIZE_M
+                from torchtitan.experiments.kernels.moe.indices import generate_permute_indices
+
+                experts_per_ep_rank = base_w1.shape[0]
+                num_ep_ranks = num_tokens_per_expert.shape[0] // experts_per_ep_rank
+
+                with torch.no_grad():
+                    permuted_indices, num_tokens_per_expert, _ = generate_permute_indices(
+                        num_tokens_per_expert,
+                        experts_per_ep_rank,
+                        num_ep_ranks,
+                        x.shape[0] + experts_per_ep_rank * TOKEN_GROUP_ALIGN_SIZE_M,
+                        TOKEN_GROUP_ALIGN_SIZE_M,
+                    )
+
+                x = torch.vstack((x, x.new_zeros((x.shape[-1]))))
+                input_shape = x.shape
+                x = x[permuted_indices, :]
+
+        offsets = torch.cumsum(num_tokens_per_expert, dim=0, dtype=torch.int32)
+        lora_x = self.lora_dropout(x)
+
+        if self.use_grouped_mm:
+            # Up (w1)
+            h_base = torch._grouped_mm(x.bfloat16(), base_w1.bfloat16().transpose(-2, -1), offs=offsets)
+            w1_lora_out = _run_lora_grouped_mm(lora_x, w1_lora_a, w1_lora_b, offsets)
+            h = relu2(h_base + scaling * w1_lora_out.bfloat16())
+
+            # Down (w2)
+            lora_h = self.lora_dropout(h)
+            out_base = torch._grouped_mm(h, base_w2.bfloat16().transpose(-2, -1), offs=offsets)
+            w2_lora_out = _run_lora_grouped_mm(lora_h, w2_lora_a, w2_lora_b, offsets)
+            out = out_base + scaling * w2_lora_out.bfloat16()
+            out = out.type_as(x)
+        else:
+            out = self._forward_for_loop(
+                x,
+                num_tokens_per_expert,
+                w1_lora_a,
+                w1_lora_b,
+                w2_lora_a,
+                w2_lora_b,
+                base_w1,
+                base_w2,
+                scaling,
+            )
+
+        if permuted_indices is not None:
+            if out.shape[0] < len(permuted_indices):
+                num_padding = len(permuted_indices) - out.shape[0]
+                out = torch.vstack((out, out.new_zeros((num_padding, out.shape[-1]))))
+            out_unpermuted = out.new_zeros(input_shape)
+            out_unpermuted[permuted_indices, :] = out
+            out = out_unpermuted[:-1]
+
+        return out
+
+    def _forward_for_loop(
+        self,
+        x: torch.Tensor,
+        num_tokens_per_expert: torch.Tensor,
+        w1_lora_a: torch.Tensor,
+        w1_lora_b: torch.Tensor,
+        w2_lora_a: torch.Tensor,
+        w2_lora_b: torch.Tensor,
+        base_w1: torch.Tensor,
+        base_w2: torch.Tensor,
+        scaling: float,
+    ) -> torch.Tensor:
+        num_tokens_per_expert_list = num_tokens_per_expert.tolist()
+        out_splits = []
+
+        start = 0
+        for expert_idx, num_tokens in enumerate(num_tokens_per_expert_list):
+            if num_tokens == 0:
+                continue
+            end = start + num_tokens
+            x_expert = x[start:end]
+            x_expert_lora = self.lora_dropout(x_expert)
+
+            h_base = torch.matmul(x_expert, base_w1[expert_idx].transpose(-2, -1))
+            w1_lora_tmp = torch.matmul(x_expert_lora, w1_lora_a[expert_idx].transpose(-2, -1))
+            w1_lora_out = torch.matmul(w1_lora_tmp, w1_lora_b[expert_idx].transpose(-2, -1))
+            h = relu2(h_base + scaling * w1_lora_out)
+
+            h_lora = self.lora_dropout(h)
+            out_base = torch.matmul(h, base_w2[expert_idx].transpose(-2, -1))
+            w2_lora_tmp = torch.matmul(h_lora, w2_lora_a[expert_idx].transpose(-2, -1))
+            w2_lora_out = torch.matmul(w2_lora_tmp, w2_lora_b[expert_idx].transpose(-2, -1))
+            out = out_base + scaling * w2_lora_out
 
             out_splits.append(out)
             start = end

--- a/src/prime_rl/trainer/models/nemotron_h/converting_nemotron_h.py
+++ b/src/prime_rl/trainer/models/nemotron_h/converting_nemotron_h.py
@@ -50,7 +50,14 @@ def _convert_hf_moe_layer_to_prime(state_dict: dict[str, Tensor], prefix: str):
     if f"{mixer}gate.weight" in state_dict:
         state_dict[f"{mlp}router.gate"] = state_dict.pop(f"{mixer}gate.weight")
     if f"{mixer}gate.e_score_correction_bias" in state_dict:
-        state_dict[f"{mlp}router.e_score_correction_bias"] = state_dict.pop(f"{mixer}gate.e_score_correction_bias")
+        bias = state_dict.pop(f"{mixer}gate.e_score_correction_bias")
+        # Shift by per-row min so values land in a range bf16 can represent without
+        # collapsing. NemotronH biases sit ~57 with ~0.04 inter-expert spread, well
+        # under bf16's ~0.4 step at that magnitude. topk(scores + bias) is invariant
+        # to a constant shift of bias, and the returned routing weights are gathered
+        # from raw sigmoid scores (not biased), so this does not change routing math.
+        bias = bias - bias.min()
+        state_dict[f"{mlp}router.e_score_correction_bias"] = bias
 
     # Experts: check if stored as individual weights (experts.{i}.up_proj.weight)
     # or fused 3D tensors (experts.up_proj)

--- a/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
+++ b/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
@@ -66,7 +66,78 @@ def _patch_mamba2_use_triton_ssd():
         logger.warning_once("mamba_ssm not available; NemotronH Mamba layers will use torch_forward (bf16 softplus)")
         return
 
-    def _patched_forward(self, hidden_states, cache_params=None, attention_mask=None):
+    def _varlen_mamba_forward(self, hidden_states, cu_seqlens):
+        """Varlen-aware mamba forward. `cu_seqlens` is required: shape [num_seq+1],
+        e.g. [0, s1, s1+s2, ...]. Handles packed batches by:
+          - applying conv1d per-sequence (with kernel-1 leading zeros)
+          - passing seq_idx to mamba_chunk_scan_combined (SSM state resets at boundaries)
+        """
+        batch_size, seq_len, _ = hidden_states.shape
+        assert batch_size == 1, "varlen mamba expects batch_size=1 (packed)"
+        groups_time_state_size = self.n_groups * self.ssm_state_size
+
+        # 1. Input projection (pointwise, no cross-seq mixing)
+        projected_states = self.in_proj(hidden_states)
+        A = -torch.exp(self.A_log.float())
+        dt_limit_kwargs = {} if self.time_step_limit is None else {"dt_limit": self.time_step_limit}
+
+        gate, hidden_states_B_C, time_step = torch.split(
+            projected_states,
+            [self.intermediate_size, self.conv_dim, self.num_heads],
+            dim=-1,
+        )
+
+        # 2. Per-sequence causal conv1d. self.conv1d already has padding=kernel-1 so
+        # applying it to each segment independently gives the correct causal output
+        # without cross-sequence history.
+        hbc_t = hidden_states_B_C.transpose(1, 2)  # (1, C, L)
+        cu = cu_seqlens.tolist()
+        conv_outs = []
+        for i in range(len(cu) - 1):
+            s, e = cu[i], cu[i + 1]
+            if s == e:
+                continue
+            seg = hbc_t[:, :, s:e]
+            conv_out = self.conv1d(seg)[:, :, : e - s]
+            conv_outs.append(conv_out)
+        hidden_states_B_C = self.act(torch.cat(conv_outs, dim=-1).transpose(1, 2))
+
+        hidden_states, B, C = torch.split(
+            hidden_states_B_C,
+            [self.intermediate_size, groups_time_state_size, groups_time_state_size],
+            dim=-1,
+        )
+
+        # 3. SSM with seq_idx so state resets at sequence boundaries
+        seq_idx = torch.zeros(seq_len, dtype=torch.int32, device=hidden_states.device)
+        for i in range(len(cu) - 1):
+            s, e = cu[i], cu[i + 1]
+            if e > s:
+                seq_idx[s:e] = i
+        seq_idx = seq_idx.unsqueeze(0)  # (1, L)
+
+        scan_output = _mamba_chunk_scan_combined(
+            hidden_states.view(batch_size, seq_len, -1, self.head_dim),
+            time_step,
+            A,
+            B.view(batch_size, seq_len, self.n_groups, -1),
+            C.view(batch_size, seq_len, self.n_groups, -1),
+            chunk_size=self.chunk_size,
+            D=self.D,
+            z=None,
+            seq_idx=seq_idx,
+            return_final_states=False,
+            dt_bias=self.dt_bias,
+            dt_softplus=True,
+            **dt_limit_kwargs,
+        )
+        scan_output = scan_output.view(batch_size, seq_len, -1)
+        scan_output = self.norm(scan_output, gate)
+        return self.out_proj(scan_output)
+
+    def _patched_forward(self, hidden_states, cache_params=None, attention_mask=None, cu_seqlens=None):
+        if cu_seqlens is not None and cache_params is None and "cuda" in self.in_proj.weight.device.type:
+            return _varlen_mamba_forward(self, hidden_states, cu_seqlens)
         if "cuda" in self.in_proj.weight.device.type:
             # Disable fused training path (needs causal_conv1d CUDA extension)
             orig = self.use_mem_eff_path
@@ -78,7 +149,7 @@ def _patch_mamba2_use_triton_ssd():
 
     NemotronHMamba2Mixer.forward = _patched_forward
     _patch_applied = True
-    logger.info("Patched NemotronHMamba2Mixer to use mamba_ssm Triton SSD kernels")
+    logger.info("Patched NemotronHMamba2Mixer: Triton SSD kernels + varlen (cu_seqlens) support")
 
 
 def _ensure_zamba2_compat(config: NemotronHConfig):
@@ -132,7 +203,7 @@ class NemotronHMambaLayer(GradientCheckpointingLayer):
     ) -> torch.Tensor:
         residual = hidden_states
         hidden_states = self.norm(hidden_states)
-        hidden_states = self.mamba(hidden_states)
+        hidden_states = self.mamba(hidden_states, cu_seqlens=cu_seqlens)
         return residual + hidden_states
 
 


### PR DESCRIPTION
1. varlen mamba
2. bias leveling - nemotron biases are in the 2^6 range but the range is < 2^-2 range which means they get rounded out in bf16
3. we need a multilora layer for the non-gated expert

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches NemotronH kernel/forward paths and MoE routing parameter conversion, which can affect training numerics and packed-sequence correctness. Also introduces a new LoRA module type for NonGated experts, increasing surface area in adapter application and checkpoint compatibility.
> 
> **Overview**
> Improves NemotronH packed-sequence handling by adding a varlen-aware Mamba forward that uses `cu_seqlens` to prevent cross-sequence convolution/SSM state leakage, and wires `cu_seqlens` through `NemotronHMambaLayer`.
> 
> Fixes NemotronH MoE router bias conversion by re-centering `e_score_correction_bias` to avoid bf16 quantization collapse without changing routing semantics.
> 
> Extends LoRA support to NemotronH’s LatentMoE non-gated experts by adding `MultiLoRANonGatedGroupedExperts`, updating LoRA module discovery/application to include `NonGatedGroupedExperts`, and expanding default `LoRAConfig.target_modules` to cover `fc1_latent_proj`/`fc2_latent_proj` (and documenting NemotronH/Mamba LoRA targeting).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc783e5af9e91f766cb2708acf2b6c9a60977ade. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->