### PR TITLE
fix(ci): bump nightly test container /dev/shm to 16g

### DIFF
--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -57,7 +57,10 @@ jobs:
         runs-on: research-cluster
         container:
             image: pytorch/pytorch:2.10.0-cuda13.0-cudnn9-devel
-            options: --gpus all
+            # --shm-size: vLLM V1's DP engine/API-server IPC uses POSIX shm-backed
+            # MessageQueue (~160MB per queue); Docker's default 64MB /dev/shm triggers
+            # SIGBUS in DP engine cores on VLM runs (mm data overflows tmpfs).
+            options: --gpus all --shm-size=16g
         timeout-minutes: 1440 # 24 hours
         strategy:
             fail-fast: false


### PR DESCRIPTION
## Summary

- Adds `--shm-size=16g` to the nightly-test container options (`pytorch/pytorch:2.10.0-cuda13.0-cudnn9-devel`, currently runs with Docker's default 64 MB `/dev/shm`).
- Targets the `test_multimodal_color_codeword` nightly failure (DP3 dying with `exit code None` ~4 s into step 0). Non-VLM nightlies on the same container pass because their IPC payloads stay under 64 MB; the VLM test pushes much more through shm and trips the limit.
- `benchmarks.yaml` in this repo already sets the same flag.

## Why

vLLM V1's DP architecture (4 api-server + 4 engine-core workers) passes all inter-process traffic through POSIX-shm-backed `MessageQueue`s. Default buffer: `max_chunk_bytes=24 MiB × max_chunks=10 = 240 MB` per queue (`vllm/distributed/device_communicators/shm_broadcast.py:361`). With ~2 queues per DP rank × 4 ranks, steady-state demand is ~2 GB of `/dev/shm`.

`shm_open + ftruncate` on a 64 MB tmpfs succeeds (metadata only), which is why the CI server starts and serves many `200 OK` requests. Once writers fill the region, the tmpfs hits `ENOSPC` → `SIGBUS` → the process dies without emitting a traceback → `multiprocessing.Process.exitcode` is `None`, which is exactly what the failing job prints:

```
ERROR [utils.py:316] Exception occurred while running API servers: Process EngineCore_DP3 (PID: ...) died with exit code None
```

Confirmed by:
- CI's `docker create` command (from the GH Actions log) has no `--shm-size`.
- A 25-step bare-metal SLURM run of the same test (same HEAD, H200 node, ample shm) completes cleanly, reward 0.57 → 0.99.
- Non-VLM nightlies in the same container (e.g. `test_acereason_math`, also DP=4) pass, consistent with smaller shm demand.

## Test plan

- [ ] Dispatch the nightly workflow on this branch with `test_file=tests/nightly/test_multimodal_color_codeword.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that increases container shared-memory allocation; main impact is potential higher RAM usage on runners but no product/runtime code changes.
> 
> **Overview**
> Nightly GitHub Actions runs now start the `pytorch/pytorch:2.10.0-cuda13.0-cudnn9-devel` container with `--shm-size=16g` (in addition to `--gpus all`). This is intended to prevent `/dev/shm` exhaustion and related crashes during VLM/data-parallel nightly tests by providing sufficient POSIX shared memory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3744a65dbf52828ed1cd3e7b7d96ae3fb04db19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->