### PR TITLE
missed patch for nemotron state dict

### DIFF
--- a/src/prime_rl/trainer/lora.py
+++ b/src/prime_rl/trainer/lora.py
@@ -137,6 +137,10 @@ def apply_lora_to_model(model: nn.Module, config: LoRAConfig) -> None:
         config: LoRA configuration
     """
     logger = get_logger()
+    from prime_rl.trainer.models import PreTrainedModelPrimeRL
+
+    if isinstance(model, PreTrainedModelPrimeRL):
+        get_multi_run_manager().register_adapter_state_dict_converter(type(model).convert_adapter_to_hf)
     n_loras = get_multi_run_manager().max_runs
 
     from torch.distributed.fsdp import FSDPModule

--- a/src/prime_rl/trainer/models/base.py
+++ b/src/prime_rl/trainer/models/base.py
@@ -106,14 +106,15 @@ class PreTrainedModelPrimeRL(PreTrainedModel):
     @classmethod
     def convert_adapter_to_hf(cls, state_dict: dict[str, Tensor]) -> dict[str, Tensor]:
         """
-        Convert a LoRA adapter state dict from PrimeRL training format to HuggingFace format in-place.
+        Convert a LoRA adapter state dict from PrimeRL training format to HuggingFace format.
 
         Unlike convert_to_hf, this operates on a partial state dict containing only LoRA
         adapter parameters (e.g. `model.layers.N.<submodule>.<proj>.lora_A.weight`). Models
         whose HF naming differs from PrimeRL naming at the submodule level (e.g. NemotronH's
         unified `mixer` attribute) should override this to perform the rename.
 
-        Default implementation is a no-op.
+        Implementations may mutate state_dict in-place or return a new dict; callers must
+        use the returned value. Default implementation is a no-op.
         """
         return state_dict
 

--- a/src/prime_rl/trainer/models/base.py
+++ b/src/prime_rl/trainer/models/base.py
@@ -104,6 +104,20 @@ class PreTrainedModelPrimeRL(PreTrainedModel):
         raise NotImplementedError(f"convert_layer_to_prime is not implemented for {cls.__name__}")
 
     @classmethod
+    def convert_adapter_to_hf(cls, state_dict: dict[str, Tensor]) -> dict[str, Tensor]:
+        """
+        Convert a LoRA adapter state dict from PrimeRL training format to HuggingFace format in-place.
+
+        Unlike convert_to_hf, this operates on a partial state dict containing only LoRA
+        adapter parameters (e.g. `model.layers.N.<submodule>.<proj>.lora_A.weight`). Models
+        whose HF naming differs from PrimeRL naming at the submodule level (e.g. NemotronH's
+        unified `mixer` attribute) should override this to perform the rename.
+
+        Default implementation is a no-op.
+        """
+        return state_dict
+
+    @classmethod
     def convert_layer_to_vllm_kernel(
         cls,
         state_dict: dict[str, Tensor],

--- a/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
+++ b/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
@@ -375,6 +375,23 @@ class NemotronHPreTrainedModel(PreTrainedModelPrimeRL):
         return state_dict
 
     @classmethod
+    def convert_adapter_to_hf(cls, state_dict: dict[str, Tensor]) -> dict[str, Tensor]:
+        # HF NemotronH unifies attention/mlp under a single `mixer` attribute per layer.
+        import re
+
+        rename = [
+            (re.compile(r"(\.layers\.\d+)\.mlp\."), r"\1.mixer."),
+            (re.compile(r"(\.layers\.\d+)\.self_attn\."), r"\1.mixer."),
+        ]
+        for old_key in list(state_dict.keys()):
+            new_key = old_key
+            for pattern, repl in rename:
+                new_key = pattern.sub(repl, new_key)
+            if new_key != old_key:
+                state_dict[new_key] = state_dict.pop(old_key)
+        return state_dict
+
+    @classmethod
     def convert_layer_to_hf(cls, state_dict: dict[str, Tensor], layer_idx: int) -> dict[str, Tensor]:
         from prime_rl.trainer.models.nemotron_h.converting_nemotron_h import _rename_keys
 

--- a/src/prime_rl/trainer/runs.py
+++ b/src/prime_rl/trainer/runs.py
@@ -188,6 +188,22 @@ class MultiRunManager:
                 # Default: use named_parameters_for_adapter
                 for name, param in module.named_parameters_for_adapter(idx):
                     state_dict[f"{prefix}.{name}.weight"] = param.detach()
+        # Patch for nemotron
+        import re
+
+        def rename_key(k: str) -> str:
+            # mlp -> mixer, self_attn -> mixer
+            k = re.sub(r"(\.layers\.\d+)\.mlp\.", r"\1.mixer.", k)
+            k = re.sub(r"(\.layers\.\d+)\.self_attn\.", r"\1.mixer.", k)
+            return k
+
+        new_sd = {}
+        for k, v in state_dict.items():
+            new_k = rename_key(k)
+            new_sd[new_k] = v
+        state_dict = new_sd
+        # End patch for nemotron
+
         return state_dict
 
     def reset_run_parameters(self, idx: int) -> None:

--- a/src/prime_rl/trainer/runs.py
+++ b/src/prime_rl/trainer/runs.py
@@ -60,6 +60,9 @@ class MultiRunManager:
         # Store modules with their FQN prefixes for parameter management
         self._modules: list[tuple[str, "MultiLoRALinear"]] = []
 
+        # Optional conversion applied to adapter state dicts (e.g. PrimeRL -> HF key rename)
+        self._adapter_state_dict_converter: Callable[[dict[str, torch.Tensor]], dict[str, torch.Tensor]] | None = None
+
         # Initialize lora globals on device so runs.* ARE the global tensors
         from prime_rl.trainer.models.layers.lora import (
             get_lora_num_tokens,
@@ -140,6 +143,12 @@ class MultiRunManager:
     # Module Registration and Parameter Management
     # =========================================================================
 
+    def register_adapter_state_dict_converter(
+        self, converter: Callable[[dict[str, torch.Tensor]], dict[str, torch.Tensor]]
+    ) -> None:
+        """Register a converter applied in-place to adapter state dicts (e.g. model.convert_adapter_to_hf)."""
+        self._adapter_state_dict_converter = converter
+
     def register_module(self, prefix: str, module: "MultiLoRALinear") -> None:
         """Register a MultiLoRALinear module with its FQN prefix.
 
@@ -188,22 +197,9 @@ class MultiRunManager:
                 # Default: use named_parameters_for_adapter
                 for name, param in module.named_parameters_for_adapter(idx):
                     state_dict[f"{prefix}.{name}.weight"] = param.detach()
-        # Patch for nemotron
-        import re
 
-        def rename_key(k: str) -> str:
-            # mlp -> mixer, self_attn -> mixer
-            k = re.sub(r"(\.layers\.\d+)\.mlp\.", r"\1.mixer.", k)
-            k = re.sub(r"(\.layers\.\d+)\.self_attn\.", r"\1.mixer.", k)
-            return k
-
-        new_sd = {}
-        for k, v in state_dict.items():
-            new_k = rename_key(k)
-            new_sd[new_k] = v
-        state_dict = new_sd
-        # End patch for nemotron
-
+        if self._adapter_state_dict_converter is not None:
+            self._adapter_state_dict_converter(state_dict)
         return state_dict
 
     def reset_run_parameters(self, idx: int) -> None:

--- a/src/prime_rl/trainer/runs.py
+++ b/src/prime_rl/trainer/runs.py
@@ -199,7 +199,7 @@ class MultiRunManager:
                     state_dict[f"{prefix}.{name}.weight"] = param.detach()
 
         if self._adapter_state_dict_converter is not None:
-            self._adapter_state_dict_converter(state_dict)
+            state_dict = self._adapter_state_dict_converter(state_dict)
         return state_dict
 
     def reset_run_parameters(self, idx: int) -> None:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how LoRA adapter state dict keys are produced for saving/broadcasting, which could break compatibility if downstream code expects the previous PrimeRL key naming.
> 
> **Overview**
> Ensures LoRA *adapter-only* checkpoints/broadcasts can be emitted in HuggingFace-compatible key naming by adding an optional adapter state-dict conversion step to `MultiRunManager.get_state_dict_for_run()`.
> 
> `apply_lora_to_model()` now registers a model-provided converter when the model is a `PreTrainedModelPrimeRL`, with a new `PreTrainedModelPrimeRL.convert_adapter_to_hf()` hook (default no-op). NemotronH overrides this hook to rename per-layer adapter keys from `mlp.*`/`self_attn.*` to the HF `mixer.*` convention.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 352f0b530a416676822597825ba79dedff0b8f8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->