### PR TITLE
feat(qwen3_moe): support in-weight-transfer FP8 quantization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ envs = [
     "math500",
     "aime2024",
     "aime2025",
-    "mini_swe_agent_plus",
+    "mini_swe_agent_plus == 0.2.21",
     "deepdive"
 ]
 disagg = [

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -810,12 +810,24 @@ class RLConfig(BaseConfig):
                     )
 
                 inferred_dp_local = self.deployment.gpus_per_node // inference_tp
-                total_infer_gpus = self.deployment.num_infer_nodes * self.deployment.gpus_per_node
-                expected_global_world_size = self.inference.parallel.dp * inference_tp
-                if expected_global_world_size != total_infer_gpus:
+                if self.inference.parallel.dp == 1 and inferred_dp_local > 1:
+                    self.inference.parallel.dp = inferred_dp_local
+
+                server_world_size = self.inference.parallel.dp * inference_tp
+                if server_world_size % self.deployment.gpus_per_node != 0:
                     raise ValueError(
                         "For multi-node expert parallel inference, inference.parallel.dp * inference.parallel.tp "
-                        f"must match total inference GPUs ({total_infer_gpus}), got {expected_global_world_size}."
+                        "must use a whole number of inference nodes, got "
+                        f"{server_world_size} GPUs with {self.deployment.gpus_per_node} GPUs per node."
+                    )
+
+                nodes_per_vllm_server = server_world_size // self.deployment.gpus_per_node
+                if self.deployment.num_infer_nodes % nodes_per_vllm_server != 0:
+                    raise ValueError(
+                        "deployment.num_infer_nodes must be divisible by the number of nodes used by each "
+                        "vLLM server. Got "
+                        f"{self.deployment.num_infer_nodes} inference nodes and "
+                        f"{nodes_per_vllm_server} nodes per vLLM server."
                     )
 
                 if self.inference.data_parallel_size_local is None:
@@ -826,7 +838,10 @@ class RLConfig(BaseConfig):
                         f"({inferred_dp_local}) when inference.enable_expert_parallel is enabled in multi-node deployment."
                     )
 
-                if not self.inference.enable_lora and self.inference.api_server_count == self.inference.parallel.dp:
+                if not self.inference.enable_lora and self.inference.api_server_count in {
+                    1,
+                    self.inference.parallel.dp,
+                }:
                     self.inference.api_server_count = inferred_dp_local
 
             # Auto-infer DP and api_server_count for standard multi-node inference.
@@ -883,6 +898,23 @@ class RLConfig(BaseConfig):
             self.trainer.weight_broadcast.inference_world_size = total_infer_gpus
             assert self.orchestrator.weight_broadcast.type == "nccl"
             self.orchestrator.weight_broadcast.inference_world_size = total_infer_gpus
+
+        return self
+
+    @model_validator(mode="after")
+    def validate_multi_node_inference_deployment(self):
+        """Keep RL and inference multi-node allocation counts in sync."""
+        if self.inference is None or self.inference.deployment.type != "multi_node":
+            return self
+        if self.deployment.type != "multi_node":
+            return self
+
+        infer_deploy = self.inference.deployment
+        if self.deployment.num_infer_nodes != infer_deploy.num_nodes:
+            raise ValueError(
+                f"deployment.num_infer_nodes ({self.deployment.num_infer_nodes}) must equal "
+                f"inference.deployment.num_nodes ({infer_deploy.num_nodes}) for multi-node inference."
+            )
 
         return self
 

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -414,6 +414,12 @@ class RLConfig(BaseConfig):
         if self.trainer.model.impl != "custom":
             raise ValueError("weight_broadcast.quantize_in_weight_transfer requires trainer.model.impl = 'custom'.")
 
+        if not self.inference.enable_expert_parallel:
+            raise ValueError("weight_broadcast.quantize_in_weight_transfer requires inference.enable_expert_parallel.")
+
+        if self.inference.enable_eplb:
+            raise ValueError("weight_broadcast.quantize_in_weight_transfer does not support inference.enable_eplb.")
+
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -469,6 +469,7 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
             inference_enable_expert_parallel=config.inference.enable_expert_parallel if config.inference else False,
             inference_data_parallel_rpc_port=config.inference.data_parallel_rpc_port if config.inference else 29600,
             dp_per_node=(config.deployment.gpus_per_node // config.inference.parallel.tp) if config.inference else 1,
+            use_deep_gemm=config.inference.use_deep_gemm if config.inference else False,
             use_nccl_broadcast=config.weight_broadcast is not None and config.weight_broadcast.type == "nccl",
             wandb_shared=config.wandb is not None and config.wandb.shared,
             ranks_filter=",".join(map(str, config.trainer.log.ranks_filter)),

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -436,9 +436,11 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
             num_decode_replicas=infer_deploy.num_decode_replicas,
             gpus_per_node=config.deployment.gpus_per_node,
             router_port=infer_deploy.router_port,
+            router_policy=infer_deploy.router_policy,
             prefill_port=infer_deploy.prefill_port,
             decode_port=infer_deploy.decode_port,
             inference_tp=config.inference.parallel.tp,
+            inference_dp=config.inference.parallel.dp,
             inference_data_parallel_rpc_port=config.inference.data_parallel_rpc_port,
             use_deep_gemm=config.inference.use_deep_gemm,
             prefill_env_overrides=infer_deploy.prefill_env_overrides,
@@ -451,6 +453,13 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
             ranks_filter=",".join(map(str, config.trainer.log.ranks_filter)),
         )
     else:
+        infer_deploy = config.inference.deployment if config.inference is not None else None
+        nodes_per_infer_replica = (
+            infer_deploy.num_nodes
+            if infer_deploy is not None and infer_deploy.type == "multi_node"
+            else config.deployment.num_infer_nodes
+        )
+
         script = template.render(
             **config.slurm.template_vars,
             is_disaggregated=False,
@@ -458,14 +467,18 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
             output_dir=config.output_dir,
             orchestrator_output_dir=config.orchestrator.output_dir,
             num_train_nodes=config.deployment.num_train_nodes,
-            num_infer_nodes=config.deployment.total_infer_nodes,
-            nodes_per_infer_replica=config.deployment.num_infer_nodes,
+            num_infer_nodes=nodes_per_infer_replica * config.deployment.num_infer_replicas,
+            nodes_per_infer_replica=nodes_per_infer_replica,
             num_infer_replicas=config.deployment.num_infer_replicas,
             num_teacher_nodes=config.deployment.num_teacher_nodes,
             gpus_per_node=config.deployment.gpus_per_node,
             router_port=getattr(config.inference.deployment, "router_port", 8000) if config.inference else 8000,
+            router_policy=getattr(config.inference.deployment, "router_policy", "consistent_hash")
+            if config.inference
+            else "consistent_hash",
             backend_port=getattr(config.inference.deployment, "backend_port", 8100) if config.inference else 8100,
             inference_tp=config.inference.parallel.tp if config.inference else 1,
+            inference_dp=config.inference.parallel.dp if config.inference else 1,
             inference_enable_expert_parallel=config.inference.enable_expert_parallel if config.inference else False,
             inference_data_parallel_rpc_port=config.inference.data_parallel_rpc_port if config.inference else 29600,
             dp_per_node=(config.deployment.gpus_per_node // config.inference.parallel.tp) if config.inference else 1,

--- a/src/prime_rl/inference/vllm/worker/weight_transfer.py
+++ b/src/prime_rl/inference/vllm/worker/weight_transfer.py
@@ -1,6 +1,7 @@
 from typing import Generator
 
 import torch
+from torch import Tensor
 from torch.nn import Module
 from vllm.logger import init_logger
 from vllm.model_executor.model_loader.utils import process_weights_after_loading
@@ -34,10 +35,140 @@ def build_expert_map(model: Module) -> dict[str, torch.Tensor]:
     return expert_slices
 
 
+def _ceil_div(value: int, divisor: int) -> int:
+    return (value + divisor - 1) // divisor
+
+
+def _weight_block_size(module: Module) -> tuple[int, int]:
+    block_size = getattr(module, "weight_block_size", None)
+    if block_size is None:
+        return (128, 128)
+    return (int(block_size[0]), int(block_size[1]))
+
+
+def _slice_scale_dim(tensor: Tensor, dim: int, start: int, size: int, block: int) -> Tensor:
+    return tensor.narrow(dim, start // block, _ceil_div(size, block))
+
+
+def _module_name_for_weight(name: str) -> str | None:
+    for suffix in (
+        ".w13_weight_scale_inv",
+        ".w2_weight_scale_inv",
+        ".w13_weight",
+        ".w2_weight",
+        ".weight_scale_inv",
+        ".weight_scale",
+        ".weight",
+    ):
+        if name.endswith(suffix):
+            return name.removesuffix(suffix)
+    return None
+
+
+def _slice_qkv_tensor(name: str, module: Module, tensor: Tensor) -> Tensor:
+    head_size = module.head_size
+    v_head_size = getattr(module, "v_head_size", head_size)
+
+    q_total = module.total_num_heads * head_size
+    k_total = module.total_num_kv_heads * head_size
+
+    q_size = module.num_heads * head_size
+    k_size = module.num_kv_heads * head_size
+    v_size = module.num_kv_heads * v_head_size
+
+    q_start = module.tp_rank * q_size
+    kv_rank = module.tp_rank // module.num_kv_head_replicas
+    k_start = q_total + kv_rank * k_size
+    v_start = q_total + k_total + kv_rank * v_size
+
+    if name.endswith(".weight_scale_inv"):
+        block_n, _ = _weight_block_size(module)
+        return torch.cat(
+            [
+                _slice_scale_dim(tensor, 0, q_start, q_size, block_n),
+                _slice_scale_dim(tensor, 0, k_start, k_size, block_n),
+                _slice_scale_dim(tensor, 0, v_start, v_size, block_n),
+            ],
+            dim=0,
+        ).contiguous()
+
+    return torch.cat(
+        [
+            tensor.narrow(0, q_start, q_size),
+            tensor.narrow(0, k_start, k_size),
+            tensor.narrow(0, v_start, v_size),
+        ],
+        dim=0,
+    ).contiguous()
+
+
+def _slice_row_parallel_tensor(name: str, module: Module, tensor: Tensor) -> Tensor:
+    start = module.tp_rank * module.input_size_per_partition
+    size = module.input_size_per_partition
+
+    if name.endswith(".weight_scale_inv"):
+        _, block_k = _weight_block_size(module)
+        return _slice_scale_dim(tensor, 1, start, size, block_k).contiguous()
+
+    return tensor.narrow(1, start, size).contiguous()
+
+
+def _slice_merged_column_tensor(name: str, module: Module, tensor: Tensor) -> Tensor:
+    pieces: list[Tensor] = []
+    offset = 0
+    block_n, _ = _weight_block_size(module)
+
+    for output_size in module.output_sizes:
+        shard_size = output_size // module.tp_size
+        start = offset + module.tp_rank * shard_size
+        if name.endswith(".weight_scale_inv"):
+            pieces.append(_slice_scale_dim(tensor, 0, start, shard_size, block_n))
+        else:
+            pieces.append(tensor.narrow(0, start, shard_size))
+        offset += output_size
+
+    return torch.cat(pieces, dim=0).contiguous()
+
+
+def _slice_ep_expert_tensor(name: str, expert_slices: dict[str, Tensor], tensor: Tensor) -> Tensor | None:
+    for module_name, global_indices in expert_slices.items():
+        if name.startswith(f"{module_name}."):
+            return tensor[global_indices.to(tensor.device)].contiguous()
+    return None
+
+
+def _try_load_vocab_parallel_weight(name: str, param: Tensor, tensor: Tensor, modules: dict[str, Module]) -> bool:
+    from vllm.model_executor.layers.vocab_parallel_embedding import VocabParallelEmbedding
+
+    module_name = _module_name_for_weight(name)
+    module = modules.get(module_name or "")
+    if not isinstance(module, VocabParallelEmbedding):
+        return False
+
+    weight_loader = getattr(param, "weight_loader")
+    weight_loader(param, tensor)
+    return True
+
+
+def _slice_tp_tensor(name: str, modules: dict[str, Module], tensor: Tensor) -> Tensor | None:
+    from vllm.model_executor.layers.linear import MergedColumnParallelLinear, QKVParallelLinear, RowParallelLinear
+
+    module_name = _module_name_for_weight(name)
+    module = modules.get(module_name or "")
+    if isinstance(module, QKVParallelLinear):
+        return _slice_qkv_tensor(name, module, tensor)
+    if isinstance(module, RowParallelLinear):
+        return _slice_row_parallel_tensor(name, module, tensor)
+    if isinstance(module, MergedColumnParallelLinear):
+        return _slice_merged_column_tensor(name, module, tensor)
+    return None
+
+
 @torch.no_grad()
 def load_weights_kernel(model: Module, state_iter: Generator[tuple[str, torch.Tensor], None, None]) -> None:
-    """Load vLLM kernel-format tensors using in-place copy_ updates."""
+    """Load vLLM kernel-format tensors for TP inference with EP routed experts."""
     params = dict(model.named_parameters())
+    modules = dict(model.named_modules())
     expert_slices = build_expert_map(model)
 
     loaded = 0
@@ -51,15 +182,20 @@ def load_weights_kernel(model: Module, state_iter: Generator[tuple[str, torch.Te
 
         param = params[name]
         if param.shape != tensor.shape:
-            sliced = False
-            for module_name, global_indices in expert_slices.items():
-                if not name.startswith(f"{module_name}."):
-                    continue
-                tensor = tensor[global_indices.to(tensor.device)]
-                sliced = True
-                break
+            if _try_load_vocab_parallel_weight(name, param, tensor, modules):
+                loaded += 1
+                continue
 
-            if not sliced or param.shape != tensor.shape:
+            sliced = _slice_ep_expert_tensor(name, expert_slices, tensor)
+            if sliced is None:
+                sliced = _slice_tp_tensor(name, modules, tensor)
+
+            if sliced is None:
+                shape_mismatches.append(f"{name}: param={list(param.shape)} != received={list(tensor.shape)}")
+                continue
+
+            tensor = sliced
+            if param.shape != tensor.shape:
                 shape_mismatches.append(f"{name}: param={list(param.shape)} != received={list(tensor.shape)}")
                 continue
 

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -30,7 +30,10 @@ export GPUS_PER_NODE={{ gpus_per_node }}
 {% if num_infer_nodes > 0 -%}
 export ROUTER_PORT={{ router_port }}
 export INFERENCE_TP={{ inference_tp }}
+export INFERENCE_DP={{ inference_dp }}
 export INFERENCE_DP_LOCAL=$((GPUS_PER_NODE / INFERENCE_TP))
+export INFERENCE_WORLD_SIZE=$((INFERENCE_TP * INFERENCE_DP))
+export INFERENCE_NODES_PER_SERVER=$((INFERENCE_WORLD_SIZE / GPUS_PER_NODE))
 export INFERENCE_DATA_PARALLEL_RPC_PORT={{ inference_data_parallel_rpc_port }}
 {% if is_disaggregated -%}
 export NUM_PREFILL_NODES={{ num_prefill_nodes }}
@@ -47,7 +50,7 @@ export INFERENCE_ENABLE_EXPERT_PARALLEL={{ "1" if inference_enable_expert_parall
 
 # Enable distributed EP mode only when expert parallelism spans multiple inference nodes per replica.
 export USE_DISTRIBUTED_EP=0
-if [ "$INFERENCE_ENABLE_EXPERT_PARALLEL" -eq 1 ] && [ "$NODES_PER_INFER_REPLICA" -gt 1 ]; then
+if [ "$INFERENCE_ENABLE_EXPERT_PARALLEL" -eq 1 ] && [ "$INFERENCE_NODES_PER_SERVER" -gt 1 ]; then
     USE_DISTRIBUTED_EP=1
 fi
 {%- endif %}
@@ -174,6 +177,8 @@ srun bash -c '
 
 # Run RL
 srun bash -c '
+    ulimit -l unlimited
+    ulimit -u unlimited
     # Source environment
     cd $PROJECT_DIR
     [ -f .env ] && source .env
@@ -247,7 +252,6 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
 {% endfor %}
         ROLE_EXTRA="\"all2all_backend\": \"deepep_high_throughput\""
     else
-        export UCX_NET_DEVICES=mlx5_0:1
         ROLE="decode"
         RANK_IN_DECODE=$((RANK_IN_REPLICA - NUM_PREFILL_NODES))
         SUB_REPLICA=$((RANK_IN_DECODE / NODES_PER_DECODE_REPLICA))
@@ -293,7 +297,7 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
         REPLICA_ROUTER_ARGS=$(echo "$ALL_ROUTER_ARGS" | cut -d"|" -f$((REPLICA_IDX + 1)))
 
         vllm-router \
-            --policy consistent_hash \
+            --policy {{ router_policy }} \
             --vllm-pd-disaggregation \
             $REPLICA_ROUTER_ARGS \
             --host 0.0.0.0 \
@@ -320,7 +324,7 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
         REPLICA_ROUTER_ARGS=$(echo "$ALL_ROUTER_ARGS" | cut -d"|" -f$((REPLICA_IDX + 1)))
 
         vllm-router \
-            --policy consistent_hash \
+            --policy {{ router_policy }} \
             --worker-urls $REPLICA_ROUTER_ARGS \
             --host 0.0.0.0 \
             --port $ROUTER_PORT \

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -202,12 +202,13 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
     echo "INFER_NODE_RANK=$INFER_NODE_RANK REPLICA=$REPLICA_IDX RANK_IN_REPLICA=$RANK_IN_REPLICA LOCAL_IP=$LOCAL_IP" \
         | tee $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log
 
-{% if is_disaggregated -%}
-    # PD disaggregated: NIXL KV transfer + role-based inference
-    read -ra HOSTNAMES <<< "$HOSTNAMES_STR"
 {%- if use_deep_gemm %}
     export VLLM_USE_DEEP_GEMM=1
 {%- endif %}
+
+{% if is_disaggregated -%}
+    # PD disaggregated: NIXL KV transfer + role-based inference
+    read -ra HOSTNAMES <<< "$HOSTNAMES_STR"
 
     export GLOO_SOCKET_IFNAME=bond0
     export VLLM_ENGINE_READY_TIMEOUT_S=4200
@@ -334,9 +335,9 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
         INFER_DP_START_RANK=$((RANK_IN_REPLICA * INFERENCE_DP_LOCAL))
 
         if [ "$RANK_IN_REPLICA" -eq 0 ]; then
-            VLLM_EXTRA="{\"data_parallel_address\": \"$LOCAL_IP\"}"
+            VLLM_EXTRA="{\"data_parallel_address\": \"$LOCAL_IP\", \"data_parallel_hybrid_lb\": true}"
         else
-            VLLM_EXTRA="{\"data_parallel_address\": \"$REPLICA_HEAD_HOST\", \"data_parallel_start_rank\": $INFER_DP_START_RANK}"
+            VLLM_EXTRA="{\"data_parallel_address\": \"$REPLICA_HEAD_HOST\", \"data_parallel_start_rank\": $INFER_DP_START_RANK, \"data_parallel_hybrid_lb\": true}"
         fi
 
         uv run inference \

--- a/src/prime_rl/trainer/models/qwen3_moe/converting_qwen3_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_moe/converting_qwen3_moe.py
@@ -1,6 +1,8 @@
 import torch
 from torch import Tensor
 
+from prime_rl.trainer.models.fp8 import quantize_to_fp8_blockwise
+
 
 def get_max_layer_num(state_dict: dict[str, Tensor]) -> int:
     """Get the maximum number of layers in the model."""
@@ -98,3 +100,104 @@ def convert_tt_to_hf_moe(state_dict: dict[str, Tensor]):
     num_layers = get_max_layer_num(state_dict)
     for i in range(num_layers):
         convert_tt_layer_to_hf(state_dict, i)
+
+
+def _emit_weight(out: dict[str, Tensor], name: str, tensor: Tensor, quantize_fp8: bool) -> None:
+    """Emit a 2D projection weight, optionally FP8-quantized with block scales."""
+    if quantize_fp8:
+        fp8_weight, scale = quantize_to_fp8_blockwise(tensor)
+        out[name] = fp8_weight
+        out[name.removesuffix(".weight") + ".weight_scale_inv"] = scale
+    else:
+        out[name] = tensor
+
+
+def _emit_moe_experts(
+    out: dict[str, Tensor],
+    prefix: str,
+    w1: Tensor,
+    w2: Tensor,
+    w3: Tensor,
+    quantize_fp8: bool,
+) -> None:
+    """Emit fused MoE expert weights in vLLM FusedMoE W13 layout.
+
+    vLLM's DEEPGEMM FP8 MoE path keeps weights in `[gate; up]` (W13) order;
+    FLASHINFER paths flip to W31 during `process_weights_after_loading`, so
+    inference must select the DEEPGEMM backend (`VLLM_USE_DEEP_GEMM=1`) for
+    RL weight reloads to stay valid across broadcasts.
+    """
+    w13 = torch.cat([w1, w3], dim=1)
+    if not quantize_fp8:
+        out[f"{prefix}.mlp.experts.w13_weight"] = w13
+        out[f"{prefix}.mlp.experts.w2_weight"] = w2
+        return
+
+    num_experts = w1.shape[0]
+    w13_fp8: list[Tensor] = []
+    w13_scales: list[Tensor] = []
+    w2_fp8: list[Tensor] = []
+    w2_scales: list[Tensor] = []
+    for expert_idx in range(num_experts):
+        q13, s13 = quantize_to_fp8_blockwise(w13[expert_idx])
+        q2, s2 = quantize_to_fp8_blockwise(w2[expert_idx])
+        w13_fp8.append(q13)
+        w13_scales.append(s13)
+        w2_fp8.append(q2)
+        w2_scales.append(s2)
+
+    out[f"{prefix}.mlp.experts.w13_weight"] = torch.stack(w13_fp8)
+    out[f"{prefix}.mlp.experts.w13_weight_scale_inv"] = torch.stack(w13_scales)
+    out[f"{prefix}.mlp.experts.w2_weight"] = torch.stack(w2_fp8)
+    out[f"{prefix}.mlp.experts.w2_weight_scale_inv"] = torch.stack(w2_scales)
+
+
+def _is_dense_layer(state_dict: dict[str, Tensor], layer_idx: int) -> bool:
+    """Dense MLP layers have a fused gate_proj; MoE layers route through mlp.router."""
+    return f"model.layers.{layer_idx}.mlp.gate_proj.weight" in state_dict
+
+
+def convert_tt_layer_to_vllm_kernel(
+    state_dict: dict[str, Tensor],
+    layer_idx: int,
+    quantize_fp8: bool = False,
+) -> dict[str, Tensor]:
+    """Convert a single Qwen3MoE layer from PrimeRL format to vLLM kernel format."""
+    prefix = f"model.layers.{layer_idx}"
+    out: dict[str, Tensor] = {
+        f"{prefix}.input_layernorm.weight": state_dict[f"{prefix}.input_layernorm.weight"],
+        f"{prefix}.post_attention_layernorm.weight": state_dict[f"{prefix}.post_attention_layernorm.weight"],
+        f"{prefix}.self_attn.q_norm.weight": state_dict[f"{prefix}.self_attn.q_norm.weight"],
+        f"{prefix}.self_attn.k_norm.weight": state_dict[f"{prefix}.self_attn.k_norm.weight"],
+    }
+
+    qkv = torch.cat(
+        [
+            state_dict[f"{prefix}.self_attn.q_proj.weight"],
+            state_dict[f"{prefix}.self_attn.k_proj.weight"],
+            state_dict[f"{prefix}.self_attn.v_proj.weight"],
+        ],
+        dim=0,
+    )
+    _emit_weight(out, f"{prefix}.self_attn.qkv_proj.weight", qkv, quantize_fp8)
+    _emit_weight(out, f"{prefix}.self_attn.o_proj.weight", state_dict[f"{prefix}.self_attn.o_proj.weight"], quantize_fp8)
+
+    if _is_dense_layer(state_dict, layer_idx):
+        gate_up = torch.cat(
+            [state_dict[f"{prefix}.mlp.gate_proj.weight"], state_dict[f"{prefix}.mlp.up_proj.weight"]],
+            dim=0,
+        )
+        _emit_weight(out, f"{prefix}.mlp.gate_up_proj.weight", gate_up, quantize_fp8)
+        _emit_weight(out, f"{prefix}.mlp.down_proj.weight", state_dict[f"{prefix}.mlp.down_proj.weight"], quantize_fp8)
+    else:
+        out[f"{prefix}.mlp.gate.weight"] = state_dict[f"{prefix}.mlp.router.gate.weight"]
+        _emit_moe_experts(
+            out,
+            prefix,
+            state_dict[f"{prefix}.mlp.experts.w1"],
+            state_dict[f"{prefix}.mlp.experts.w2"],
+            state_dict[f"{prefix}.mlp.experts.w3"],
+            quantize_fp8,
+        )
+
+    return out

--- a/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
@@ -38,6 +38,7 @@ from prime_rl.trainer.models.qwen3_moe.converting_qwen3_moe import (
     convert_hf_layer_to_tt,
     convert_hf_to_tt_moe,
     convert_tt_layer_to_hf,
+    convert_tt_layer_to_vllm_kernel,
     convert_tt_to_hf_moe,
 )
 
@@ -167,6 +168,13 @@ class Qwen3MoePreTrainedModel(PreTrainedModelPrimeRL):
         """Convert a single layer's MoE weights from HuggingFace format to PrimeRL format in-place."""
         convert_hf_layer_to_tt(state_dict, layer_idx)
         return state_dict
+
+    @classmethod
+    def convert_layer_to_vllm_kernel(
+        cls, state_dict: dict[str, Tensor], layer_idx: int, quantize_fp8: bool = False
+    ) -> dict[str, Tensor]:
+        """Convert a single layer's weights from PrimeRL format to vLLM FusedMoE/linear kernel format."""
+        return convert_tt_layer_to_vllm_kernel(state_dict, layer_idx, quantize_fp8=quantize_fp8)
 
 
 @auto_docstring

--- a/uv.lock
+++ b/uv.lock
@@ -873,8 +873,8 @@ dependencies = [
     { name = "torch", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/test/cu128/flash_attn_3-3.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:10a730d5e1a1c23afd930ce419ee425cd1925a16b7eac789dfe98c3ca39bc009" },
-    { url = "https://download.pytorch.org/whl/test/cu128/flash_attn_3-3.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:bbb51d13d7aa1bfe04ef8875ed1bf630ebb116775084a5df612495e10609cd76" },
+    { url = "https://download.pytorch.org/whl/test/cu128/flash_attn_3-3.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:10a730d5e1a1c23afd930ce419ee425cd1925a16b7eac789dfe98c3ca39bc009", upload-time = "2026-02-14T04:28:12Z" },
+    { url = "https://download.pytorch.org/whl/test/cu128/flash_attn_3-3.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:bbb51d13d7aa1bfe04ef8875ed1bf630ebb116775084a5df612495e10609cd76", upload-time = "2026-02-14T04:28:05Z" },
 ]
 
 [[package]]
@@ -1771,7 +1771,7 @@ wheels = [
 
 [[package]]
 name = "mini-swe-agent-plus"
-version = "0.2.17"
+version = "0.2.22"
 source = { registry = "https://hub.primeintellect.ai/primeintellect/simple/" }
 dependencies = [
     { name = "prime-sandboxes", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -1780,7 +1780,7 @@ dependencies = [
     { name = "verifiers", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 wheels = [
-    { url = "https://hub.primeintellect.ai/primeintellect/mini-swe-agent-plus/@aa6f9500/mini_swe_agent_plus-0.2.17-py3-none-any.whl", hash = "sha256:af4f6e10412b86dd4be0623393fc35275fe95080c95ac032bf39e109a2dd390b" },
+    { url = "https://hub.primeintellect.ai/primeintellect/mini-swe-agent-plus/@9f0cc82a/mini_swe_agent_plus-0.2.22-py3-none-any.whl", hash = "sha256:31a4410ab3a929def687a53162f6eb5cd4a1908f91f716cf3b5966ba6ade9fb8" },
 ]
 
 [[package]]
@@ -2767,7 +2767,7 @@ requires-dist = [
     { name = "math-env", marker = "extra == 'envs'", index = "https://hub.primeintellect.ai/primeintellect/simple/" },
     { name = "math-python", marker = "extra == 'envs'", index = "https://hub.primeintellect.ai/primeintellect/simple/" },
     { name = "math500", marker = "extra == 'envs'", index = "https://hub.primeintellect.ai/primeintellect/simple/" },
-    { name = "mini-swe-agent-plus", marker = "extra == 'envs'", index = "https://hub.primeintellect.ai/primeintellect/simple/" },
+    { name = "mini-swe-agent-plus", marker = "extra == 'envs'", specifier = ">=0.2.22", index = "https://hub.primeintellect.ai/primeintellect/simple/" },
     { name = "nixl", marker = "extra == 'disagg'" },
     { name = "nixl-cu12", marker = "platform_machine == 'x86_64' and extra == 'disagg'", url = "https://github.com/samsja/research-pre-built-wheels/releases/download/v0.2/nixl_cu12-0.10.1-cp312-cp312-linux_x86_64.whl" },
     { name = "numpy", specifier = ">=2.2.6" },
@@ -3745,8 +3745,8 @@ dependencies = [
     { name = "typing-extensions", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6f09cdf2415516be028ae82e6b985bcfc3eac37bc52ab401142689f6224516ca" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:628e89bd5110ced7debee2a57c69959725b7fbc64eab81a39dd70e46c7e28ba5" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6f09cdf2415516be028ae82e6b985bcfc3eac37bc52ab401142689f6224516ca", upload-time = "2026-01-21T15:22:03Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:628e89bd5110ced7debee2a57c69959725b7fbc64eab81a39dd70e46c7e28ba5", upload-time = "2026-01-21T15:22:11Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add a vLLM kernel-format converter for Qwen3MoE so the NCCL broadcaster can hand the inference engine block-FP8 weights directly, instead of shipping bf16 and re-quantizing on load. Single dense/MoE branch per layer, strict dict[] access, no silent fallbacks.

Also wire the multi-node RL sbatch non-PD path so it receives `use_deep_gemm` and exports `VLLM_USE_DEEP_GEMM=1`, plus `data_parallel_hybrid_lb=true`. Selecting the DEEPGEMM FP8 MoE backend keeps `w13_weight` in `[gate; up]` order across RL reloads (FLASHINFER_CUTLASS swaps to W31 during `process_weights_after_loading` and would corrupt subsequent `param.copy_` broadcasts).

Verified on Qwen3-235B-A22B-Thinking-2507-FP8 with the prod.toml config: trainer<->inference mismatch KL stays below 0.005 across 5+ steps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches weight broadcast/weight loading and multi-node inference sizing logic; misconfiguration or slicing bugs could cause shape mismatches or deadlocks during distributed inference.
> 
> **Overview**
> Enables **in-weight-transfer FP8 quantization** for Qwen3MoE by adding a per-layer converter to vLLM kernel tensor formats (including `w13`/`w2` expert layouts and optional `.weight_scale_inv` emission) and exposing it via `Qwen3MoePreTrainedModel.convert_layer_to_vllm_kernel`.
> 
> Hardens vLLM NCCL reloads by expanding `load_weights_kernel` to correctly slice incoming tensors for **EP expert subsets** and **TP-sharded** modules (QKV/row-parallel/merged-column + vocab-parallel embeddings), failing fast on skipped weights or shape mismatches.
> 
> Updates multi-node RL deployment validation and SLURM templating to better infer/validate inference `dp/tp` world sizes, enforce consistent node counts, pass `router_policy`/`use_deep_gemm`, and export additional runtime env (e.g. `INFERENCE_WORLD_SIZE`, `data_parallel_hybrid_lb`). Also bumps `mini_swe_agent_plus` pin and refreshes lockfile metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be1c88314a32ea1bb56c9fae0a9df351668bb277. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->