### PR TITLE
feat: optional MX Server rendezvous overlay (on top of #2326)

### DIFF
--- a/benchmarks/scripts/parse_mx_metrics.py
+++ b/benchmarks/scripts/parse_mx_metrics.py
@@ -1,0 +1,208 @@
+"""Parse per-push timing and RDMA BW from a prime-rl-mx-on-nixl run log.
+
+Extracts the per-push `[nixl rank=...]` lines emitted by PI's TransportPlan
+and the `[mx-rendezvous]` lines added by the MX overlay. Aggregates:
+
+- Per-step `update_weights` wall time
+- Wire BW + net BW per rank
+- Rendezvous discovery latency (MX scenarios only)
+- Pipeline-replication source counts (scenario C only)
+
+Usage:
+    python parse_mx_metrics.py --log /path/to/trainer.log [--json out.json]
+    kubectl -n kavin logs prime-rl-mx-on-nixl-trainer-0 | python parse_mx_metrics.py --stdin
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import statistics
+import sys
+from dataclasses import dataclass, field
+from typing import Iterable, TextIO
+
+
+# Regex patterns for PI's nixl push log line. Example:
+# [nixl rank=0] push bytes=3553.26MB handles=339 convert=120.10ms post+wait=560.22ms
+#   barrier=82.33ms total=762.65ms wire_bw=7.12GB/s net_bw=6.34GB/s
+_PUSH_RE = re.compile(
+    r"\[nixl rank=(?P<rank>\d+)\]\s+push\s+"
+    r"bytes=(?P<bytes_mb>[\d.]+)MB\s+"
+    r"handles=(?P<handles>\d+)\s+"
+    r"convert=(?P<convert_ms>[\d.]+)ms\s+"
+    r"post\+wait=(?P<postwait_ms>[\d.]+)ms\s+"
+    r"barrier=(?P<barrier_ms>[\d.]+)ms\s+"
+    r"total=(?P<total_ms>[\d.]+)ms\s+"
+    r"wire_bw=(?P<wire_gbps>[\d.]+)GB/s\s+"
+    r"net_bw=(?P<net_gbps>[\d.]+)GB/s"
+)
+
+_MX_DISCOVER_RE = re.compile(
+    r"\[mx-rendezvous\].*?(?:role=|)(?P<role>trainer|inference).*?"
+    r"rank=(?P<rank>\d+).*?discovered coordinator=(?P<endpoint>[^\s]+).*?after (?P<polls>\d+)\s+polls"
+)
+
+_MX_COORDINATOR_RE = re.compile(
+    r"\[mx-rendezvous\] coordinator published source_id=(?P<source_id>\S+)\s+endpoint=(?P<endpoint>\S+)"
+)
+
+_MX_PIPELINE_RE = re.compile(
+    r"\[mx-rendezvous\] published rollout-as-source rank=(?P<rank>\d+)"
+)
+
+
+@dataclass
+class PushSample:
+    rank: int
+    bytes_mb: float
+    handles: int
+    convert_ms: float
+    postwait_ms: float
+    barrier_ms: float
+    total_ms: float
+    wire_gbps: float
+    net_gbps: float
+
+
+@dataclass
+class MetricsReport:
+    pushes: list[PushSample] = field(default_factory=list)
+    mx_discovered: list[dict] = field(default_factory=list)
+    mx_coordinator: dict | None = None
+    mx_pipeline_publishes: int = 0
+
+    def summary(self) -> dict:
+        if not self.pushes:
+            return {"pushes": 0, "note": "no nixl push lines found"}
+
+        per_rank: dict[int, list[PushSample]] = {}
+        for p in self.pushes:
+            per_rank.setdefault(p.rank, []).append(p)
+
+        def _stats(values: list[float]) -> dict:
+            if not values:
+                return {}
+            return {
+                "count": len(values),
+                "mean": round(statistics.mean(values), 3),
+                "median": round(statistics.median(values), 3),
+                "min": round(min(values), 3),
+                "max": round(max(values), 3),
+                "stdev": round(statistics.stdev(values), 3) if len(values) > 1 else 0.0,
+            }
+
+        report = {"num_pushes": len(self.pushes), "ranks": {}}
+        for rank, samples in sorted(per_rank.items()):
+            report["ranks"][rank] = {
+                "total_ms": _stats([s.total_ms for s in samples]),
+                "wire_gbps": _stats([s.wire_gbps for s in samples]),
+                "net_gbps": _stats([s.net_gbps for s in samples]),
+                "convert_ms": _stats([s.convert_ms for s in samples]),
+                "barrier_ms": _stats([s.barrier_ms for s in samples]),
+                "bytes_mb": samples[0].bytes_mb,
+                "handles": samples[0].handles,
+            }
+
+        # Cluster-level aggregate: mean total_ms across all ranks (the
+        # bottleneck rank dominates, but the mean is a useful summary).
+        report["aggregate"] = {
+            "mean_total_ms": round(
+                statistics.mean([s.total_ms for s in self.pushes]), 3
+            ),
+            "mean_wire_gbps": round(
+                statistics.mean([s.wire_gbps for s in self.pushes]), 3
+            ),
+        }
+
+        if self.mx_coordinator:
+            report["mx_coordinator"] = self.mx_coordinator
+        if self.mx_discovered:
+            report["mx_discovered"] = {
+                "count": len(self.mx_discovered),
+                "avg_polls": round(
+                    statistics.mean([d["polls"] for d in self.mx_discovered]), 1
+                ),
+            }
+        if self.mx_pipeline_publishes:
+            report["mx_pipeline_publishes"] = self.mx_pipeline_publishes
+
+        return report
+
+
+def parse_lines(lines: Iterable[str]) -> MetricsReport:
+    report = MetricsReport()
+    for line in lines:
+        m = _PUSH_RE.search(line)
+        if m:
+            report.pushes.append(
+                PushSample(
+                    rank=int(m.group("rank")),
+                    bytes_mb=float(m.group("bytes_mb")),
+                    handles=int(m.group("handles")),
+                    convert_ms=float(m.group("convert_ms")),
+                    postwait_ms=float(m.group("postwait_ms")),
+                    barrier_ms=float(m.group("barrier_ms")),
+                    total_ms=float(m.group("total_ms")),
+                    wire_gbps=float(m.group("wire_gbps")),
+                    net_gbps=float(m.group("net_gbps")),
+                )
+            )
+            continue
+
+        m = _MX_DISCOVER_RE.search(line)
+        if m:
+            report.mx_discovered.append(
+                {
+                    "role": m.group("role"),
+                    "rank": int(m.group("rank")),
+                    "endpoint": m.group("endpoint"),
+                    "polls": int(m.group("polls")),
+                }
+            )
+            continue
+
+        m = _MX_COORDINATOR_RE.search(line)
+        if m:
+            report.mx_coordinator = {
+                "source_id": m.group("source_id"),
+                "endpoint": m.group("endpoint"),
+            }
+            continue
+
+        m = _MX_PIPELINE_RE.search(line)
+        if m:
+            report.mx_pipeline_publishes += 1
+
+    return report
+
+
+def _read_source(path: str | None, use_stdin: bool) -> TextIO:
+    if use_stdin:
+        return sys.stdin
+    if not path:
+        raise SystemExit("must pass --log PATH or --stdin")
+    return open(path, "r")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--log", help="Path to log file")
+    parser.add_argument("--stdin", action="store_true", help="Read from stdin")
+    parser.add_argument("--json", help="Optional JSON output path")
+    args = parser.parse_args()
+
+    with _read_source(args.log, args.stdin) as src:
+        report = parse_lines(src)
+
+    summary = report.summary()
+    if args.json:
+        with open(args.json, "w") as f:
+            json.dump(summary, f, indent=2)
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docker/Dockerfile.mx-on-nixl
+++ b/docker/Dockerfile.mx-on-nixl
@@ -1,0 +1,234 @@
+# Overlay image: PI's prime-rl @ nixl-weight-transfer + UCX/NIXL from source
+# + MX client (for rendezvous/pipeline-replication overlay, scenarios B+).
+#
+# Extends PI's Dockerfile.cuda. Build from the prime-rl repo root so both
+# Dockerfiles see the same build context.
+#
+# Usage (ARM64 / GB200):
+#   docker buildx build --platform linux/arm64 \
+#     -f docker/Dockerfile.mx-on-nixl \
+#     -t nvcr.io/nvidian/dynamo-dev/prime-rl-mx-on-nixl:v0.1 \
+#     --push .
+#
+# Scenario A (pure PI) uses this image with NIXL enabled in the config but
+# no MX env-vars set. Scenarios B/C layer MX Server rendezvous + pipeline
+# replication by setting PRIME_RL_MX_RENDEZVOUS=1 at runtime.
+
+#####################################################################
+# Stage 1: PI's builder (unchanged — we don't touch their layer)
+#####################################################################
+FROM nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04 AS builder
+LABEL maintainer="kavin@nvidia.com"
+LABEL repository="prime-rl-mx-on-nixl"
+LABEL base-pr="PrimeIntellect-ai/prime-rl#2326"
+
+RUN echo "LC_ALL=en_US.UTF-8" >> /etc/environment
+ENV CUDA_HOME=/usr/local/cuda
+ENV PATH=$PATH:/usr/local/cuda/bin
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Etc/UTC
+
+# PI's deps + UCX build-time requirements
+RUN apt-get update && apt-get install -y --no-install-recommends --force-yes \
+    build-essential \
+    curl \
+    sudo \
+    git \
+    ninja-build \
+    software-properties-common \
+    autoconf \
+    automake \
+    libtool \
+    pkg-config \
+    libnuma-dev \
+    libibverbs-dev \
+    librdmacm-dev \
+    libmlx5-1 \
+    ibverbs-providers \
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends python3.12 python3.12-dev python3.12-venv \
+    && ln -sf /usr/bin/python3.12 /usr/bin/python3 \
+    && ln -sf /usr/bin/python3.12 /usr/bin/python \
+    && apt-get clean autoclean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# uv
+ADD https://astral.sh/uv/install.sh /uv-installer.sh
+RUN INSTALLER_NO_MODIFY_PATH=1 UV_INSTALL_DIR="/usr/local/bin" sh /uv-installer.sh && rm /uv-installer.sh
+ENV PATH="/usr/local/bin:$PATH"
+ENV UV_PYTHON_INSTALL_DIR="/usr/local/share/uv/python"
+ENV UV_CACHE_DIR="/usr/local/share/uv/cache"
+
+WORKDIR /app
+ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
+
+COPY pyproject.toml /app/pyproject.toml
+COPY uv.lock /app/uv.lock
+COPY README.md /app/README.md
+COPY src/ /app/src/
+COPY configs /app/configs
+COPY examples /app/examples
+COPY benchmarks/scripts /app/benchmarks/scripts
+
+# PI's Python deps. We deliberately exclude --extra flash-attn / flash-attn-3
+# / flash-attn-cute / gpt-oss because:
+# - flash-attn arm64 must be built from source (60+ min on QEMU; not worth
+#   it for our scenario A target model Qwen3-0.6B which falls back to SDPA).
+# - gpt-oss kernels are not in our scenario surface.
+# - mamba-ssm is also skipped — Qwen3 is plain decoder, no SSM.
+# This trims the build by ~3-5 hours on QEMU. Production runs targeting
+# GLM-FP8/MoE should re-add flash-attn via PI's docker-arm64-post-install.sh
+# (we keep the script in /app/scripts/ for future use).
+RUN --mount=type=cache,target=/app/.cache/uv \
+    uv sync --extra envs --locked --no-dev
+
+ARG TARGETARCH
+COPY scripts/docker-arm64-post-install.sh /app/scripts/docker-arm64-post-install.sh
+COPY scripts/install_nixl_from_source.sh /app/scripts/install_nixl_from_source.sh
+# Skip arm64-post-install (flash-attn from source) — see comment above.
+# To enable: uncomment the next line.
+# RUN if [ "$TARGETARCH" = "arm64" ]; then /app/scripts/docker-arm64-post-install.sh; fi
+
+# Build UCX 1.19.x + NIXL 0.10.1 into /app/third_party/ucx + /app/deps/nixl*.whl
+# (PI's canonical install script).
+RUN /app/scripts/install_nixl_from_source.sh \
+    && NIXL_WHEEL=$(ls /app/deps/nixl*.whl | head -1) \
+    && /app/.venv/bin/pip install --no-deps "$NIXL_WHEEL"
+
+# PI's nixl_transfer.py imports `from nixl_cu13._api import ...` but our
+# install script produces a `nixl_cu12` package name. Install lightweight
+# `nixl_cu13` and `nixl` shim packages that re-export from `nixl_cu12` so
+# existing import sites work without patching upstream code.
+COPY docker/nixl_shim.py /tmp/nixl_shim.py
+RUN SP="/app/.venv/lib/python3.12/site-packages" \
+    && mkdir -p "$SP/nixl_cu13" "$SP/nixl" \
+    && cp /tmp/nixl_shim.py "$SP/nixl_cu13/__init__.py" \
+    && cp /tmp/nixl_shim.py "$SP/nixl/__init__.py" \
+    && rm /tmp/nixl_shim.py
+
+# Install sitecustomize.py — auto-imported at every Python startup, before
+# any user module. Preloads real libcudart with RTLD_GLOBAL so TileLang's
+# libcudart_stub.so doesn't win dlsym(RTLD_DEFAULT) lookups in vLLM
+# WorkerProc subprocs that use that path. Belt-and-suspenders w/ the next
+# step.
+COPY docker/sitecustomize.py /tmp/sitecustomize.py
+RUN install -m 644 /tmp/sitecustomize.py /app/.venv/lib/python3.12/site-packages/sitecustomize.py \
+    && rm /tmp/sitecustomize.py
+
+# FlashInfer's cuda_ipc.CudaRTLibrary uses `find_loaded_library("libcudart")`
+# to scan /proc/self/maps for any loaded libcudart — and tilelang's stub
+# (an incomplete libcudart_stub.so shipped for tilelang's own compilation
+# flow) gets found first, then .cudaDeviceReset fails with "undefined
+# symbol". Nothing in vLLM's inference path actually imports tilelang
+# (verified: no `import tilelang` in vllm site-packages). Replace the
+# stub with a symlink to the real CUDA runtime so anyone dlopening that
+# path gets a full libcudart. This is the only reliable fix for the
+# WorkerProc subprocess path — LD_PRELOAD and sitecustomize both fail
+# here because FlashInfer loads the library *by explicit path*, not via
+# RTLD_DEFAULT.
+RUN set -eux; \
+    stub="/app/.venv/lib/python3.12/site-packages/tilelang/lib/libcudart_stub.so"; \
+    real="/usr/local/cuda/lib64/libcudart.so.12"; \
+    if [ -f "$stub" ] && [ -f "$real" ]; then \
+        mv "$stub" "${stub}.orig"; \
+        ln -s "$real" "$stub"; \
+        echo "tilelang libcudart_stub.so -> $real"; \
+    fi
+
+# Stub flash_attn as a proper pip-installed package so that:
+#   (a) eager importers like ring_flash_attn succeed at module load, and
+#   (b) transformers' PACKAGE_DISTRIBUTION_MAPPING["flash_attn"] lookup
+#       finds our stub via importlib.metadata — failing this bugs out
+#       `is_flash_attn_2_available()`.
+# Real flash-attn arm64 is a 3-5 hr QEMU build; the stub is enough for
+# scenarios without MoE/CP. To enable real flash-attn: uncomment the
+# docker-arm64-post-install.sh run above.
+COPY docker/flash_attn_pkg /tmp/flash_attn_pkg
+RUN /app/.venv/bin/pip install --no-deps /tmp/flash_attn_pkg \
+    && rm -rf /tmp/flash_attn_pkg
+
+# MX client — install from our kavink/RL branch so the overlay code can use
+# `from modelexpress import MxClient, MxTrainingPublisher, MxRefitReceiver`
+ARG MX_BRANCH=kavink/RL
+ARG MX_REPO=https://github.com/ai-dynamo/modelexpress.git
+RUN git clone --depth=1 --branch ${MX_BRANCH} ${MX_REPO} /tmp/modelexpress \
+    && /app/.venv/bin/pip install --no-deps /tmp/modelexpress/modelexpress_client/python \
+    && rm -rf /tmp/modelexpress
+
+#####################################################################
+# Stage 2: Runtime image (PI's pattern)
+#####################################################################
+FROM python:3.12-slim
+
+RUN apt-get update && apt-get install -y \
+    --no-install-recommends \
+    --force-yes \
+    build-essential \
+    wget \
+    clang \
+    tmux \
+    iperf \
+    openssh-server \
+    git-lfs \
+    gpg \
+    sudo \
+    iputils-ping \
+    net-tools \
+    curl \
+    vim \
+    libibverbs1 \
+    ibverbs-providers \
+    libnuma1 \
+    librdmacm1 \
+    && apt-get clean autoclean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+RUN groupadd --gid $GROUP_ID appuser && \
+    useradd --uid $USER_ID --gid appuser --create-home --shell /bin/bash appuser && \
+    usermod -aG sudo appuser && \
+    echo "appuser ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+ADD https://astral.sh/uv/install.sh /uv-installer.sh
+RUN INSTALLER_NO_MODIFY_PATH=1 UV_INSTALL_DIR="/usr/local/bin" sh /uv-installer.sh && rm /uv-installer.sh
+
+# Copy CUDA from the devel builder so runtime has nvcc + /usr/local/cuda
+# for torch.utils.cpp_extension load_inline (required by
+# prime_rl.utils.classic_cuda_pool and vLLM's JIT compile path).
+COPY --from=builder /usr/local/cuda /usr/local/cuda
+ENV CUDA_HOME=/usr/local/cuda
+ENV PATH=/usr/local/cuda/bin:$PATH
+ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64:${LD_LIBRARY_PATH}
+
+USER appuser
+ENV PATH="/usr/local/bin:/usr/local/cuda/bin:$PATH"
+WORKDIR /app
+COPY --from=builder --chown=appuser:appuser /app /app
+
+COPY --chown=appuser:appuser scripts/docker-entrypoint.sh /app/docker-entrypoint.sh
+RUN chmod +x /app/docker-entrypoint.sh
+
+RUN rm /app/.venv/bin/python && ln -s /usr/local/bin/python /app/.venv/bin/python
+RUN rm /app/.venv/bin/python3 && ln -s /usr/local/bin/python /app/.venv/bin/python3
+RUN rm /app/.venv/bin/python3.12 && ln -s /usr/local/bin/python /app/.venv/bin/python3.12
+
+# UCX libs live under /app/third_party/ucx (from install_nixl_from_source.sh).
+# Prepend them to LD_LIBRARY_PATH so NIXL finds the matching libs at load time.
+ENV LD_LIBRARY_PATH="/app/third_party/ucx/lib:/app/third_party/ucx/lib/ucx:${LD_LIBRARY_PATH}"
+ENV PATH="/app/.venv/bin:$PATH"
+
+# PI's HF timeouts
+ENV HF_HUB_ETAG_TIMEOUT=500
+ENV HF_HUB_DOWNLOAD_TIMEOUT=300
+
+# GB200 / RoCE known-good UCX tuning (from our verl + prime-rl POCs).
+# Can be overridden at pod-spec level.
+ENV UCX_TLS="self,sm,rc,cuda_copy,gdr_copy,tcp"
+ENV UCX_IB_GID_INDEX=3
+ENV OMPI_MCA_pml=ob1
+
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+CMD ["sleep", "infinity"]

--- a/docker/flash_attn_interface_stub.py
+++ b/docker/flash_attn_interface_stub.py
@@ -1,0 +1,17 @@
+"""Stub flash_attn.flash_attn_interface for ARM64 GB200 builds."""
+
+
+def _stub(*args, **kwargs):
+    raise NotImplementedError(
+        "flash_attn.flash_attn_interface is stubbed on ARM64 GB200."
+    )
+
+
+flash_attn_func = _stub
+flash_attn_varlen_func = _stub
+flash_attn_qkvpacked_func = _stub
+flash_attn_kvpacked_func = _stub
+flash_attn_with_kvcache = _stub
+flash_attn_unpadded_func = _stub
+flash_attn_varlen_qkvpacked_func = _stub
+flash_attn_varlen_kvpacked_func = _stub

--- a/docker/flash_attn_pkg/flash_attn/__init__.py
+++ b/docker/flash_attn_pkg/flash_attn/__init__.py
@@ -1,0 +1,83 @@
+"""Stub flash_attn for ARM64 GB200 builds (no CUDA compile on QEMU).
+
+Uses a meta-path import hook so that ANY `flash_attn.<x>` or
+`flash_attn.<x>.<y>...` import resolves to a stub module. Attribute
+access on those modules returns a stub that raises NotImplementedError
+on call — so module-load-time imports succeed but runtime use surfaces a
+clear error.
+
+Supports scenarios where vLLM + ring_flash_attn + transformers perform
+eager imports across many submodules (flash_attn.ops, flash_attn.layers,
+flash_attn.modules, flash_attn.bert_padding, flash_attn.flash_attn_interface, etc).
+"""
+
+__version__ = "2.8.3"  # matches declared pip version
+
+
+def _stub(*args, **kwargs):
+    raise NotImplementedError(
+        "flash_attn is stubbed on ARM64 GB200 (no from-source CUDA compile). "
+        "Real use of flash_attn kernels requires rebuilding with "
+        "docker-arm64-post-install.sh enabled."
+    )
+
+
+# Make any attribute access on `flash_attn` return the stub callable.
+def __getattr__(name):  # PEP 562
+    # Pretend all top-level names exist and are callable stubs.
+    return _stub
+
+
+import sys as _sys
+import types as _types
+import importlib.abc as _abc
+import importlib.util as _util
+
+
+class _StubModule(_types.ModuleType):
+    """Module whose every attribute is a stub callable."""
+
+    def __getattr__(self, attr):
+        if attr.startswith("__") and attr.endswith("__"):
+            raise AttributeError(attr)
+        return _stub
+
+
+class _StubFinder(_abc.MetaPathFinder, _abc.Loader):
+    """Meta-path finder that synthesizes any `flash_attn.<x>...` submodule.
+
+    The physical `flash_attn/__init__.py` (this file) and
+    `flash_attn/flash_attn_interface.py` are resolved by the normal
+    filesystem finder first (they have real names that ring_flash_attn
+    imports). This finder catches everything else.
+    """
+
+    PREFIX = "flash_attn."
+
+    def find_spec(self, fullname, path, target=None):
+        if not fullname.startswith(self.PREFIX):
+            return None
+        # Avoid re-synthesizing names that filesystem packages provide.
+        # (e.g. flash_attn.flash_attn_interface is a real file.)
+        # A module already being imported will already be in sys.modules
+        # at the point this is reached — the finder isn't consulted.
+        return _util.spec_from_loader(fullname, self, is_package=True)
+
+    def create_module(self, spec):
+        mod = _StubModule(spec.name)
+        mod.__path__ = []  # mark as package so deeper submodule imports work
+        return mod
+
+    def exec_module(self, module):
+        return None
+
+
+_sys.meta_path.append(_StubFinder())
+
+
+# Common symbols that some users import directly from `flash_attn`.
+flash_attn_func = _stub
+flash_attn_varlen_func = _stub
+flash_attn_qkvpacked_func = _stub
+flash_attn_kvpacked_func = _stub
+flash_attn_with_kvcache = _stub

--- a/docker/flash_attn_pkg/flash_attn/flash_attn_interface.py
+++ b/docker/flash_attn_pkg/flash_attn/flash_attn_interface.py
@@ -1,0 +1,32 @@
+"""Stub flash_attn.flash_attn_interface for ARM64 GB200 builds.
+
+Exports the subset of names that ring_flash_attn (0.1.8) imports so that
+eager `from flash_attn.flash_attn_interface import (...)` statements
+succeed at module load. Any actual *call* into these raises — we rely on
+vLLM + SDPA for the real attention backend.
+"""
+
+
+def _stub(*args, **kwargs):
+    raise NotImplementedError(
+        "flash_attn.flash_attn_interface is stubbed on ARM64 GB200. "
+        "Rebuild with docker-arm64-post-install.sh for real flash_attn."
+    )
+
+
+# Public API (some users reach for these)
+flash_attn_func = _stub
+flash_attn_varlen_func = _stub
+flash_attn_qkvpacked_func = _stub
+flash_attn_kvpacked_func = _stub
+flash_attn_with_kvcache = _stub
+flash_attn_unpadded_func = _stub
+flash_attn_varlen_qkvpacked_func = _stub
+flash_attn_varlen_kvpacked_func = _stub
+
+# Private names imported by ring_flash_attn — must exist for module-load-time
+# `from flash_attn.flash_attn_interface import (_flash_attn_varlen_forward, ...)`
+_flash_attn_forward = _stub
+_flash_attn_backward = _stub
+_flash_attn_varlen_forward = _stub
+_flash_attn_varlen_backward = _stub

--- a/docker/flash_attn_pkg/pyproject.toml
+++ b/docker/flash_attn_pkg/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "flash_attn"
+version = "2.8.3"
+description = "ARM64 stub — replaces real flash_attn on GB200 QEMU builds that skip the 3-5 hr compile."
+requires-python = ">=3.9"
+
+[tool.setuptools]
+packages = ["flash_attn"]

--- a/docker/flash_attn_stub.py
+++ b/docker/flash_attn_stub.py
@@ -1,0 +1,31 @@
+"""Stub flash_attn module for ARM64 GB200 builds that skip flash-attn
+from-source compile.
+
+Satisfies `import flash_attn` / `from flash_attn.flash_attn_interface import ...`
+so that `ring_flash_attn` and other code paths that eagerly import
+flash_attn don't fail at module load time. Any actual *use* of these
+functions will raise NotImplementedError.
+
+For scenario A (Qwen3-0.6B reverse-text, no context parallelism, no MoE),
+flash_attn is not actually called — we just need the import to succeed.
+Production use of MoE/CP requires a real flash-attn build (see
+scripts/docker-arm64-post-install.sh).
+"""
+
+__version__ = "0.0.0-stub-for-arm64-gb200"
+
+
+def _stub(*args, **kwargs):
+    raise NotImplementedError(
+        "flash_attn is stubbed in this ARM64 GB200 image to avoid a 3-5 hr "
+        "QEMU build. Rebuild with docker-arm64-post-install.sh enabled to "
+        "get real flash_attn."
+    )
+
+
+# Fill out a few commonly-called names so `from flash_attn import X` works.
+flash_attn_func = _stub
+flash_attn_varlen_func = _stub
+flash_attn_qkvpacked_func = _stub
+flash_attn_kvpacked_func = _stub
+flash_attn_with_kvcache = _stub

--- a/docker/nixl_shim.py
+++ b/docker/nixl_shim.py
@@ -1,0 +1,20 @@
+"""Shim re-exporting nixl_cu12 under another name.
+
+PI's prime-rl imports `from nixl_cu13._api import ...` but our build of
+NIXL 0.10.1 from source produces a `nixl_cu12` package name. Both refer
+to the same NIXL source tree — just different packaging metadata. This
+shim file is installed as both `nixl/__init__.py` and
+`nixl_cu13/__init__.py` so existing import sites resolve without
+patching upstream code.
+"""
+
+from nixl_cu12 import *  # noqa: F401, F403
+from nixl_cu12 import _api, _bindings, _utils, logging  # noqa: F401
+import nixl_cu12 as _impl
+import sys as _sys
+
+# Ensure `from <self>._api import x` resolves to nixl_cu12._api.x
+_sys.modules[__name__ + "._api"] = _impl._api
+_sys.modules[__name__ + "._bindings"] = _impl._bindings
+_sys.modules[__name__ + "._utils"] = _impl._utils
+_sys.modules[__name__ + ".logging"] = _impl.logging

--- a/docker/sitecustomize.py
+++ b/docker/sitecustomize.py
@@ -1,0 +1,32 @@
+"""Site-customize hook — auto-imported by every Python process via Python's
+site initialization. Used here to preload the real CUDA runtime with
+RTLD_GLOBAL so TileLang's libcudart_stub.so doesn't win dlsym() lookups.
+
+Without this, vLLM's WorkerProc subprocesses (which spawn from
+multiproc_executor before any user module loads) hit:
+    AttributeError: /app/.venv/lib/python3.12/site-packages/tilelang/lib/
+    libcudart_stub.so: undefined symbol: cudaDeviceReset
+when FlashInfer's CudaRTLibrary tries to dlsym `cudaDeviceReset`.
+
+LD_PRELOAD set in the entrypoint shell does NOT reliably propagate to the
+spawned worker subprocesses (uv/multiprocessing.spawn interaction). This
+sitecustomize runs at every Python interpreter startup, before vLLM's
+worker_main is reached, before any vllm/flashinfer/tilelang module loads.
+"""
+
+import ctypes
+import os
+
+_REAL_LIBCUDART_CANDIDATES = (
+    "/usr/local/cuda/lib64/libcudart.so.12",
+    "/usr/local/cuda/lib64/libcudart.so",
+    "/usr/lib/aarch64-linux-gnu/libcudart.so.12",
+    "/usr/lib/x86_64-linux-gnu/libcudart.so.12",
+)
+for _candidate in _REAL_LIBCUDART_CANDIDATES:
+    if os.path.exists(_candidate):
+        try:
+            ctypes.CDLL(_candidate, mode=ctypes.RTLD_GLOBAL)
+            break
+        except OSError:
+            continue

--- a/infer.toml
+++ b/infer.toml
@@ -1,0 +1,31 @@
+output_dir = "/data/outputs/qwen3-fp8-infer"
+enable_expert_parallel = true
+gpu_memory_utilization = 0.75
+enable_eplb = false
+use_deep_gemm = true
+torch_profiler_dir = "/data/outputs/qwen3-fp8-infer/profiler"
+
+[server]
+host = "0.0.0.0"
+port = 8100
+
+[model]
+name = "Qwen/Qwen3-235B-A22B-Thinking-2507-FP8"
+max_model_len = 150000
+
+[deployment]
+type = "disaggregated"
+gpus_per_node = 8
+num_prefill_nodes = 2
+num_decode_nodes = 4
+
+[deployment.kv_cache_offload]
+cpu_bytes = 128_000_000_000
+
+[slurm]
+job_name = "qwen3-fp8-infer"
+partition = "cluster"
+# Nodes with NVreg_EnableStreamMemOPs=0 / empty RegistryDwords in
+# /proc/driver/nvidia/params — GPU Direct RDMA (IBGDA) isn't enabled so UCX
+# fails to start with these peers. Confirmed via SSH probe on 2026-04-20.
+exclude = "ltc-idc3-hgx8-h200-2,ltc-idc3-hgx8-h200-65"

--- a/k8s/prime-rl-mx-on-nixl/README.md
+++ b/k8s/prime-rl-mx-on-nixl/README.md
@@ -1,0 +1,90 @@
+# prime-rl-mx-on-nixl — GB200 Benchmark Manifests
+
+Kubernetes manifests for running PI's NIXL weight-transfer PR #2326 on
+GB200 (GKE, `kavin` namespace) with an optional ModelExpress rendezvous
+overlay.
+
+## Scenarios
+
+| Scenario | Config | What it demonstrates |
+|----------|--------|----------------------|
+| A | no MX env vars | PI's code as-is — validates the environment |
+| B | `PRIME_RL_MX_RENDEZVOUS` set | MX-mediated SPG host/port discovery |
+| C | B + `PRIME_RL_MX_PIPELINE_REPLICATION=1` | Rollout-as-source for future pulls |
+
+## Cluster Requirements
+
+- GKE cluster with `customer-gpu-o7v` node pool (GB200, 4 GPU/node, ARM64).
+- `kavin` namespace with:
+  - `modelexpress-server.kavin.svc.cluster.local:8001` running.
+  - `shared-model-cache` PVC bound.
+  - `kavin-compute-domain-channel` ResourceClaimTemplate.
+  - `hf-token-secret` (for gated models).
+  - `nvcr-imagepullsecret` (for the overlay image).
+
+## Image
+
+```
+nvcr.io/nvidian/dynamo-dev/prime-rl-mx-on-nixl:v0.1
+```
+
+Build from the repo root:
+
+```bash
+docker buildx build --platform linux/arm64 \
+  -f docker/Dockerfile.mx-on-nixl \
+  -t nvcr.io/nvidian/dynamo-dev/prime-rl-mx-on-nixl:v0.1 \
+  --push .
+```
+
+## Quick Start
+
+```bash
+# Scenario A (baseline)
+./run.sh deploy A
+
+# Scenario B (MX rendezvous)
+./run.sh deploy B
+
+# Scenario C (MX + pipeline replication)
+./run.sh deploy C
+
+# Watch logs
+./run.sh logs
+
+# Check status
+./run.sh status
+
+# Tear down
+./run.sh clean
+```
+
+## Topology
+
+```
+┌───────────────────── customer-gpu-o7v (node 1) ─────────────────────┐
+│  prime-rl-mx-on-nixl-trainer-0                                      │
+│  ├─ 4× GB200                                                        │
+│  ├─ FSDP2 across 4 ranks                                            │
+│  └─ NIXLWeightBroadcast (PI) [+ MX rendezvous overlay in B/C]       │
+└─────────────────────────────────────────────────────────────────────┘
+                                │  NIXL RDMA (RoCE rc_mlx5)
+                                ▼
+┌───────────────────── customer-gpu-o7v (node 2) ─────────────────────┐
+│  prime-rl-mx-on-nixl-inference-0                                    │
+│  ├─ 4× GB200                                                        │
+│  └─ NIXLWeightUpdateWorker (PI) [+ MX pipeline-replication in C]    │
+└─────────────────────────────────────────────────────────────────────┘
+
+prime-rl-mx-on-nixl-orchestrator (any o7v node, CPU-only)
+  └─ HTTP coordinator — /pause, /resume, /init_nixl_transfer
+```
+
+`podAntiAffinity` ensures trainer and inference land on different nodes
+so NIXL actually crosses the RoCE fabric.
+
+## Known-Good Env Vars
+
+The pod specs inherit our GB200 POC's known-good UCX tuning (`UCX_TLS`,
+`UCX_IB_GID_INDEX`, `OMPI_MCA_pml`). Do not deviate without verifying
+RDMA still negotiates `rc_mlx5` transport in the UCX startup log.

--- a/k8s/prime-rl-mx-on-nixl/config.yaml
+++ b/k8s/prime-rl-mx-on-nixl/config.yaml
@@ -1,0 +1,209 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prime-rl-mx-on-nixl-config
+  namespace: kavin
+data:
+  # Per-role TOML configs. Minimal fields to pass each config's validator.
+  # No weight_broadcast in inference.toml — the orchestrator's
+  # /init_nixl_transfer HTTP call configures the inference worker at
+  # runtime when scenario B/C is active. For scenario A, filesystem
+  # default is used.
+
+  # Shared helper script sourced by all three run scripts. Fixes the
+  # tilelang libcudart_stub.so / FlashInfer collision by symlinking the
+  # stub to real cudart. Doing this in the entrypoint (runtime) avoids
+  # a full image rebuild cycle for this single patch. See
+  # docs/TILELANG_LIBCUDART_FIX.md for background.
+  fix_tilelang_stub.sh: |
+    #!/bin/bash
+    set -euo pipefail
+    _STUB="/app/.venv/lib/python3.12/site-packages/tilelang/lib/libcudart_stub.so"
+    _REAL="/usr/local/cuda/lib64/libcudart.so.12"
+    if [ -f "$_STUB" ] && [ ! -L "$_STUB" ] && [ -f "$_REAL" ]; then
+        mv "$_STUB" "${_STUB}.orig"
+        ln -s "$_REAL" "$_STUB"
+        echo "[fix_tilelang_stub] swapped ${_STUB} -> ${_REAL}"
+    elif [ -L "$_STUB" ]; then
+        echo "[fix_tilelang_stub] already patched ($(readlink "$_STUB"))"
+    else
+        echo "[fix_tilelang_stub] nothing to do (stub or real missing)"
+    fi
+
+  trainer.toml: |
+    max_steps = 20
+    output_dir = "/output/run"
+    dist_timeout_seconds = 1800
+
+    [model]
+    name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
+    seq_len = 2048
+    # SDPA (PyTorch scaled_dot_product_attention) instead of flash_attention_2:
+    # our ARM64 GB200 image ships flash_attn as an import stub (raises
+    # NotImplementedError when actually called) to avoid a 3+ hour QEMU build
+    # of the real kernels. Trainer forward pass would crash on first call
+    # otherwise. SDPA is slower but correct, adequate for scenario A proof.
+    attn = "sdpa"
+
+    # NIXL backend on Qwen3 enabled via our overlay's qwen3_specs_patch.py
+    # (monkey-patches HF Qwen3ForCausalLM with conversion_specs()).
+    # When PRIME_RL_MX_RENDEZVOUS env is set on the trainer pod, the
+    # SPG host/port discovery is replaced with MX-Server-mediated
+    # rendezvous (scenario B). pipeline_replication=1 enables scenario C.
+    [weight_broadcast]
+    type = "nixl"
+    host = "prime-rl-mx-on-nixl-trainer-0.prime-rl-mx-on-nixl-trainer.kavin.svc.cluster.local"
+    port = 29502
+    timeout = 1200
+    # Must match inference-side TP * DP: currently tp=1, dp=1 on 1 inference
+    # worker. Trainer's SPG builds world_size = trainer_ws + inference_world_size,
+    # so a mismatch hangs all_gather_obj on broadcast_obj from the missing rank.
+    inference_world_size = 1
+
+    [optim]
+    lr = 3e-6
+
+  orchestrator.toml: |
+    # Orchestrator MUST write to a `run_*` subdirectory of the trainer's
+    # output_dir. The trainer's MultiRunManager.discover_runs() scans
+    # `<trainer.output_dir>/run_*` and expects each one's rollouts at
+    #   <trainer.output_dir>/<run_id>/rollouts/step_N/train_rollouts.{jsonl,bin}
+    # and config at
+    #   <trainer.output_dir>/<run_id>/control/orch.toml
+    # Trainer output_dir is /output/run (see trainer.toml), so this MUST be
+    # /output/run/run_default (or any name starting with `run_`).
+    # Without this, FileSystemTrainingBatchReceiver.can_receive() loops
+    # forever with empty `used_idxs` and the trainer is stuck at
+    # "Starting training loop" with 0% GPU util.
+    output_dir = "/output/run/run_default"
+
+    [model]
+    name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
+
+    [client]
+    base_url = ["http://prime-rl-mx-on-nixl-inference-0.prime-rl-mx-on-nixl-inference.kavin.svc.cluster.local:8000/v1"]
+
+    # Match trainer's weight_broadcast — orchestrator coordinates the protocol
+    # (HTTP /init_nixl_transfer, /pause, /resume) so its config drives which
+    # backend the inference workers use.
+    [weight_broadcast]
+    type = "nixl"
+    host = "prime-rl-mx-on-nixl-trainer-0.prime-rl-mx-on-nixl-trainer.kavin.svc.cluster.local"
+    port = 29502
+    timeout = 1200
+    # Trainer runs torchrun --nproc=2 (CUDA_VISIBLE_DEVICES=0,1), so SPG sees
+    # 2 trainer ranks. Default is 1; without this override the SPG world_size
+    # (= trainer_ws + inference_ws) mismatches between sides and
+    # broadcast_obj hangs on /broadcast_from/0/1.
+    trainer_world_size = 2
+    inference_world_size = 1
+
+    [[train.env]]
+    id = "reverse-text"
+
+  inference.toml: |
+    [model]
+    name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
+
+    # TP=1 for Qwen3-0.6B: the model is tiny (~1.2GB) so it fits trivially
+    # on one GB200, and PI's NIXL LayoutEntry code (inference/vllm/worker/nixl.py:299)
+    # assumes inference holds the *unsharded* fused destination tensor —
+    # `full.narrow(0, entry.offset_rows, entry.rows)` with absolute offsets
+    # into the full concat'd qkv/gate_up dims. With TP>1 vLLM column-
+    # partitions these projections and the narrow indices blow past the
+    # local shard size (RuntimeError: start+length exceeds dimension size).
+    # TP-aware LayoutEntry emission is a separate extension to PI's code.
+    [parallel]
+    tp = 1
+
+    # vLLM picks worker_extension_cls from this:
+    #   nccl -> NCCLWeightUpdateWorker
+    #   nixl -> NIXLWeightUpdateWorker (defines /init_nixl_transfer method)
+    #   filesystem -> FileSystemWeightUpdateWorker
+    # Without "nixl", orchestrator's /init_nixl_transfer fails with
+    # 'Worker' object has no attribute 'init_nixl_transfer'.
+    [weight_broadcast]
+    type = "nixl"
+
+  run_trainer.sh: |
+    #!/bin/bash
+    set -euo pipefail
+    cd /app
+    bash /config/fix_tilelang_stub.sh
+    # Hot-patch prime_rl/utils/mx_rendezvous.py from PVC staging. Fixes
+    # the MX Server get_metadata() stripping metadata_endpoint — blob
+    # now smuggled through nixl_metadata bytes field with a magic prefix.
+    # Remove once the overlay image is rebuilt (v0.2+) with the patch
+    # baked in.
+    if [ -f /output/patches/mx_rendezvous.py ]; then
+        cp /output/patches/mx_rendezvous.py /app/src/prime_rl/utils/mx_rendezvous.py
+        echo "[entrypoint] applied mx_rendezvous metadata_endpoint-workaround patch"
+    fi
+    export HF_HOME="/tmp/hf_cache"
+    mkdir -p "$HF_HOME" /output/logs
+    export WANDB_MODE="disabled"
+    export WANDB_DISABLED="true"
+    # Skip expandable_segments: it triggers classic_cuda_pool which needs
+    # CUDA_HOME + nvcc for JIT compile, not present in our python:3.12-slim
+    # runtime stage. Default allocator is fine for Qwen3-0.6B scenario A.
+    # Production GLM-FP8 scenarios should use a cuda-devel runtime base.
+    # export PYTORCH_CUDA_ALLOC_CONF="expandable_segments:True"
+    export PYTHONUNBUFFERED=1
+    # Preload real libcudart so TileLang's libcudart_stub.so doesn't win dlsym
+    export LD_PRELOAD="/usr/local/cuda/lib64/libcudart.so.12:${LD_PRELOAD:-}"
+    # Privileged + hostNetwork pods see all 4 host GPUs regardless of the
+    # K8s GPU limit=2. Hard-pin to GPUs 0,1 so torchrun launches 2 ranks
+    # and NCCL talks over PCIe between them rather than over rdma.
+    export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0,1}"
+    NPROC=$(echo "$CUDA_VISIBLE_DEVICES" | tr ',' '\n' | grep -c .)
+    echo "[entrypoint] CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES}"
+    echo "[entrypoint] PRIME_RL_MX_RENDEZVOUS=${PRIME_RL_MX_RENDEZVOUS:-<unset>}"
+    echo "[entrypoint] starting trainer via torchrun (nproc=$NPROC)"
+    exec uv run torchrun \
+        --nproc-per-node="$NPROC" \
+        --rdzv-endpoint=localhost:29503 \
+        --rdzv-id=prime-rl-trainer \
+        --redirect=3 \
+        --tee=3 \
+        -m prime_rl.trainer.rl.train \
+        @ /config/trainer.toml
+
+  run_inference.sh: |
+    #!/bin/bash
+    set -euo pipefail
+    cd /app
+    bash /config/fix_tilelang_stub.sh
+    # Hot-patch prime_rl/utils/mx_rendezvous.py (see run_trainer.sh comment).
+    # Still needed on v0.2: the metadata_endpoint→nixl_metadata workaround
+    # was authored *after* the v0.2 image was built. Will be baked into
+    # v0.3+. server.py /update_weights route-strip patch is baked into
+    # v0.2 — no PVC copy needed for it.
+    if [ -f /output/patches/mx_rendezvous.py ]; then
+        cp /output/patches/mx_rendezvous.py /app/src/prime_rl/utils/mx_rendezvous.py
+        echo "[entrypoint] applied mx_rendezvous metadata_endpoint-workaround patch"
+    fi
+    export HF_HOME="/tmp/hf_cache"
+    mkdir -p "$HF_HOME"
+    export WANDB_MODE="disabled"
+    export WANDB_DISABLED="true"
+    # TileLang ships a stub libcudart_stub.so that wins dlsym(RTLD_DEFAULT)
+    # against the real libcudart, breaking vLLM EngineCore startup with
+    # "undefined symbol: cudaDeviceReset". Preload the real one first.
+    export LD_PRELOAD="/usr/local/cuda/lib64/libcudart.so.12:${LD_PRELOAD:-}"
+    echo "[entrypoint] PRIME_RL_MX_RENDEZVOUS=${PRIME_RL_MX_RENDEZVOUS:-<unset>}"
+    echo "[entrypoint] starting inference (num_gpus=$(nvidia-smi -L | wc -l))"
+    exec uv run inference @ /config/inference.toml
+
+  run_orchestrator.sh: |
+    #!/bin/bash
+    set -euo pipefail
+    cd /app
+    bash /config/fix_tilelang_stub.sh
+    export HF_HOME="/tmp/hf_cache"
+    mkdir -p "$HF_HOME" /tmp/logs /output/logs
+    cd /output
+    export WANDB_MODE="disabled"
+    export WANDB_DISABLED="true"
+    export LD_PRELOAD="/usr/local/cuda/lib64/libcudart.so.12:${LD_PRELOAD:-}"
+    echo "[entrypoint] starting orchestrator"
+    exec uv run orchestrator @ /config/orchestrator.toml

--- a/k8s/prime-rl-mx-on-nixl/inference.yaml
+++ b/k8s/prime-rl-mx-on-nixl/inference.yaml
@@ -1,0 +1,180 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: prime-rl-mx-on-nixl-inference
+  namespace: kavin
+  labels:
+    app: prime-rl-mx-on-nixl-inference
+    scenario: C-MX-pipeline-replication
+spec:
+  replicas: 1
+  serviceName: prime-rl-mx-on-nixl-inference
+  selector:
+    matchLabels:
+      app: prime-rl-mx-on-nixl-inference
+  template:
+    metadata:
+      labels:
+        app: prime-rl-mx-on-nixl-inference
+      annotations:
+        networking.gke.io/default-interface: eth0
+        networking.gke.io/interfaces: "[\n  {\"interfaceName\":\"eth0\",\"network\"\
+          :\"default\"},\n  {\"interfaceName\":\"rdma0\",\"network\":\"rdma-0\"},\n\
+          \  {\"interfaceName\":\"rdma1\",\"network\":\"rdma-1\"}\n]\n"
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+      - name: inference
+        image: nvcr.io/nvidian/dynamo-dev/prime-rl-mx-on-nixl:v0.2
+        imagePullPolicy: Always
+        command:
+        - /bin/bash
+        - /config/run_inference.sh
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            nvidia.com/gpu: '2'
+            networking.gke.io.networks/rdma-0: '1'
+            networking.gke.io.networks/rdma-1: '1'
+          requests:
+            nvidia.com/gpu: '2'
+        env:
+        - name: UCX_TLS
+          value: self,sm,rc,cuda_copy,gdr_copy,tcp
+        - name: UCX_IB_GID_INDEX
+          value: '3'
+        - name: OMPI_MCA_pml
+          value: ob1
+        - name: NCCL_SOCKET_IFNAME
+          value: eth0
+        - name: GLOO_SOCKET_IFNAME
+          value: eth0
+        - name: VLLM_WORKER_MULTIPROC_METHOD
+          value: spawn
+        - name: VLLM_USE_V1
+          value: '1'
+        - name: VLLM_SERVER_DEV_MODE
+          value: '1'
+        - name: MODEL_EXPRESS_URL
+          value: modelexpress-server.kavin.svc.cluster.local:8001
+        # ---- MX overlay rendezvous (scenario B) ----
+        # Inference worker's init_nixl_transfer calls
+        # mx_rendezvous.discover_spg_coordinator(...) when these are set,
+        # which overrides the static (host, port) the orchestrator sends
+        # in the /init_nixl_transfer POST body. See
+        # src/prime_rl/inference/vllm/worker/nixl.py:246 for the dispatch
+        # point, and src/prime_rl/utils/mx_rendezvous.py for the protocol.
+        - name: PRIME_RL_MX_RENDEZVOUS
+          value: modelexpress-server.kavin.svc.cluster.local:8001
+        - name: PRIME_RL_MX_MODEL_NAME
+          value: PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT
+        - name: PRIME_RL_MX_TRAINING_RUN_ID
+          value: primerl-overlay-scenario-c
+        # Pipeline replication: after init_nixl_transfer completes on this
+        # inference worker, publish_as_rollout_source() fires, adding this
+        # rollout to the MX catalog as an additional source for the same
+        # (model, version). Future rollouts polling for this model can
+        # then discover us as an alternative to the trainer.
+        # See src/prime_rl/inference/vllm/worker/nixl.py:488 for hook site.
+        - name: PRIME_RL_MX_PIPELINE_REPLICATION
+          value: "1"
+        # --------------------------------------------
+        - name: HF_HOME
+          value: /models/hf_home
+        - name: HF_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: hf-token-secret
+              key: token
+              optional: true
+        ports:
+        - containerPort: 8000
+          name: http
+        volumeMounts:
+        - name: shared-model-cache
+          mountPath: /models
+        - name: config
+          mountPath: /config
+        - name: output
+          mountPath: /output
+        - name: dshm
+          mountPath: /dev/shm
+        - name: infiniband
+          mountPath: /dev/infiniband
+      volumes:
+      - name: shared-model-cache
+        persistentVolumeClaim:
+          claimName: shared-model-cache
+      - name: config
+        configMap:
+          name: prime-rl-mx-on-nixl-config
+          defaultMode: 493
+      - name: output
+        persistentVolumeClaim:
+          claimName: prime-rl-mx-run-output
+      - name: dshm
+        emptyDir:
+          medium: Memory
+          sizeLimit: 64Gi
+      - name: infiniband
+        hostPath:
+          path: /dev/infiniband
+          type: DirectoryOrCreate
+      imagePullSecrets:
+      - name: nvcr-imagepullsecret
+      nodeSelector:
+        kubernetes.io/arch: arm64
+        nvidia.com/gpu.present: 'true'
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: cloud.google.com/gke-nodepool
+                operator: In
+                values:
+                - customer-gpu-o7v
+                - customer-gpu-mh2
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - prime-rl-mx-on-nixl-trainer
+            topologyKey: kubernetes.io/hostname
+      tolerations:
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+      - key: dedicated
+        operator: Equal
+        value: user-workload
+        effect: NoSchedule
+      - key: dedicated
+        operator: Equal
+        value: user-workload
+        effect: NoExecute
+      - key: kubernetes.io/arch
+        operator: Exists
+        effect: NoSchedule
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prime-rl-mx-on-nixl-inference
+  namespace: kavin
+spec:
+  selector:
+    app: prime-rl-mx-on-nixl-inference
+  ports:
+  - name: http
+    port: 8000
+    targetPort: 8000
+  clusterIP: None

--- a/k8s/prime-rl-mx-on-nixl/orchestrator.yaml
+++ b/k8s/prime-rl-mx-on-nixl/orchestrator.yaml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prime-rl-mx-on-nixl-orchestrator
+  namespace: kavin
+  labels:
+    app: prime-rl-mx-on-nixl-orchestrator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prime-rl-mx-on-nixl-orchestrator
+  template:
+    metadata:
+      labels:
+        app: prime-rl-mx-on-nixl-orchestrator
+    spec:
+      containers:
+      - name: orchestrator
+        image: nvcr.io/nvidian/dynamo-dev/prime-rl-mx-on-nixl:v0.1
+        imagePullPolicy: Always
+        command:
+        - /bin/bash
+        - /config/run_orchestrator.sh
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: '2'
+          limits:
+            memory: 8Gi
+            cpu: '4'
+        env:
+        - name: HF_HOME
+          value: /models/hf_home
+        - name: HF_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: hf-token-secret
+              key: token
+              optional: true
+        volumeMounts:
+        - name: shared-model-cache
+          mountPath: /models
+        - name: config
+          mountPath: /config
+        - name: output
+          mountPath: /output
+      volumes:
+      - name: shared-model-cache
+        persistentVolumeClaim:
+          claimName: shared-model-cache
+      - name: config
+        configMap:
+          name: prime-rl-mx-on-nixl-config
+          defaultMode: 493
+      - name: output
+        persistentVolumeClaim:
+          claimName: prime-rl-mx-run-output
+      imagePullSecrets:
+      - name: nvcr-imagepullsecret
+      nodeSelector:
+        kubernetes.io/arch: arm64
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: cloud.google.com/gke-nodepool
+                operator: In
+                values:
+                - customer-gpu-o7v
+                - customer-gpu-mh2
+      tolerations:
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+      - key: dedicated
+        operator: Equal
+        value: user-workload
+        effect: NoSchedule
+      - key: dedicated
+        operator: Equal
+        value: user-workload
+        effect: NoExecute
+      - key: kubernetes.io/arch
+        operator: Exists
+        effect: NoSchedule
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch

--- a/k8s/prime-rl-mx-on-nixl/run.sh
+++ b/k8s/prime-rl-mx-on-nixl/run.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# Orchestration helper for deploying prime-rl-mx-on-nixl on GB200.
+#
+# Usage:
+#   ./run.sh deploy A   # Scenario A: pure PI, SPG via static host/port
+#   ./run.sh deploy B   # Scenario B: MX-mediated SPG rendezvous
+#   ./run.sh deploy C   # Scenario B + pipeline replication
+#   ./run.sh clean      # Delete all resources
+#   ./run.sh logs       # Tail trainer + inference + orchestrator logs
+#   ./run.sh status     # Pod status
+
+set -euo pipefail
+
+NS="kavin"
+RESOURCES=(
+    k8s/prime-rl-mx-on-nixl/config.yaml
+    k8s/prime-rl-mx-on-nixl/trainer.yaml
+    k8s/prime-rl-mx-on-nixl/inference.yaml
+    k8s/prime-rl-mx-on-nixl/orchestrator.yaml
+)
+
+MX_ENV='- name: PRIME_RL_MX_RENDEZVOUS
+              value: "modelexpress-server.kavin.svc.cluster.local:8001"
+            - name: PRIME_RL_MX_MODEL_NAME
+              value: "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"'
+
+MX_PIPE_ENV='- name: PRIME_RL_MX_PIPELINE_REPLICATION
+              value: "1"'
+
+cmd="${1:-}"
+scenario="${2:-A}"
+
+case "$cmd" in
+    deploy)
+        echo "=== deploying scenario ${scenario} ==="
+        # Apply base manifests
+        for f in "${RESOURCES[@]}"; do
+            kubectl apply -f "$f"
+        done
+
+        if [[ "$scenario" == "B" || "$scenario" == "C" ]]; then
+            echo "=== enabling MX rendezvous on trainer + inference ==="
+            kubectl -n "$NS" set env statefulset/prime-rl-mx-on-nixl-trainer \
+                PRIME_RL_MX_RENDEZVOUS="modelexpress-server.kavin.svc.cluster.local:8001" \
+                PRIME_RL_MX_MODEL_NAME="PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
+            kubectl -n "$NS" set env statefulset/prime-rl-mx-on-nixl-inference \
+                PRIME_RL_MX_RENDEZVOUS="modelexpress-server.kavin.svc.cluster.local:8001" \
+                PRIME_RL_MX_MODEL_NAME="PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
+        fi
+
+        if [[ "$scenario" == "C" ]]; then
+            echo "=== enabling pipeline replication ==="
+            kubectl -n "$NS" set env statefulset/prime-rl-mx-on-nixl-inference \
+                PRIME_RL_MX_PIPELINE_REPLICATION="1"
+        fi
+
+        echo "=== waiting for pods ==="
+        kubectl -n "$NS" rollout status --timeout=600s statefulset/prime-rl-mx-on-nixl-trainer
+        kubectl -n "$NS" rollout status --timeout=600s statefulset/prime-rl-mx-on-nixl-inference
+        kubectl -n "$NS" rollout status --timeout=600s deployment/prime-rl-mx-on-nixl-orchestrator
+
+        echo "=== deployed. use 'run.sh logs' to watch output ==="
+        ;;
+    clean)
+        echo "=== deleting resources ==="
+        kubectl -n "$NS" delete statefulset,deployment,svc,configmap \
+            -l 'app in (prime-rl-mx-on-nixl-trainer,prime-rl-mx-on-nixl-inference,prime-rl-mx-on-nixl-orchestrator)' \
+            --ignore-not-found
+        kubectl -n "$NS" delete configmap prime-rl-mx-on-nixl-config --ignore-not-found
+        ;;
+    status)
+        kubectl -n "$NS" get pods -l 'app in (prime-rl-mx-on-nixl-trainer,prime-rl-mx-on-nixl-inference,prime-rl-mx-on-nixl-orchestrator)' -o wide
+        ;;
+    logs)
+        echo "=== recent trainer logs ==="
+        kubectl -n "$NS" logs prime-rl-mx-on-nixl-trainer-0 --tail=50 2>&1 || true
+        echo ""
+        echo "=== recent inference logs ==="
+        kubectl -n "$NS" logs prime-rl-mx-on-nixl-inference-0 --tail=50 2>&1 || true
+        echo ""
+        echo "=== recent orchestrator logs ==="
+        kubectl -n "$NS" logs -l app=prime-rl-mx-on-nixl-orchestrator --tail=50 2>&1 || true
+        ;;
+    *)
+        echo "usage: $0 {deploy A|B|C | clean | status | logs}"
+        exit 2
+        ;;
+esac

--- a/k8s/prime-rl-mx-on-nixl/trainer.yaml
+++ b/k8s/prime-rl-mx-on-nixl/trainer.yaml
@@ -1,0 +1,170 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: prime-rl-mx-on-nixl-trainer
+  namespace: kavin
+  labels:
+    app: prime-rl-mx-on-nixl-trainer
+    scenario: C-MX-pipeline-replication
+spec:
+  replicas: 1
+  serviceName: prime-rl-mx-on-nixl-trainer
+  selector:
+    matchLabels:
+      app: prime-rl-mx-on-nixl-trainer
+  template:
+    metadata:
+      labels:
+        app: prime-rl-mx-on-nixl-trainer
+      annotations:
+        networking.gke.io/default-interface: eth0
+        networking.gke.io/interfaces: "[\n  {\"interfaceName\":\"eth0\",\"network\"\
+          :\"default\"},\n  {\"interfaceName\":\"rdma0\",\"network\":\"rdma-0\"},\n\
+          \  {\"interfaceName\":\"rdma1\",\"network\":\"rdma-1\"}\n]\n"
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+      - name: trainer
+        image: nvcr.io/nvidian/dynamo-dev/prime-rl-mx-on-nixl:v0.2
+        imagePullPolicy: Always
+        command:
+        - /bin/bash
+        - /config/run_trainer.sh
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            nvidia.com/gpu: '2'
+            networking.gke.io.networks/rdma-0: '1'
+            networking.gke.io.networks/rdma-1: '1'
+          requests:
+            nvidia.com/gpu: '2'
+        env:
+        - name: UCX_TLS
+          value: self,sm,rc,cuda_copy,gdr_copy,tcp
+        - name: UCX_IB_GID_INDEX
+          value: '3'
+        - name: OMPI_MCA_pml
+          value: ob1
+        - name: NCCL_SOCKET_IFNAME
+          value: eth0
+        - name: GLOO_SOCKET_IFNAME
+          value: eth0
+        - name: VLLM_WORKER_MULTIPROC_METHOD
+          value: spawn
+        - name: VLLM_USE_V1
+          value: '1'
+        - name: MODEL_EXPRESS_URL
+          value: modelexpress-server.kavin.svc.cluster.local:8001
+        # ---- MX overlay rendezvous (scenario B) ----
+        # Unset / empty = scenario A (PI static SPG host:port, validated).
+        # Set    = scenario B (MX Server discovers the SPG coordinator
+        # endpoint). See src/prime_rl/utils/mx_rendezvous.py for details.
+        - name: PRIME_RL_MX_RENDEZVOUS
+          value: modelexpress-server.kavin.svc.cluster.local:8001
+        - name: PRIME_RL_MX_MODEL_NAME
+          value: PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT
+        - name: PRIME_RL_MX_TRAINING_RUN_ID
+          value: primerl-overlay-scenario-c
+        # Pipeline replication is a no-op on trainer (only inference
+        # publishes itself as a source after receive). Setting it here
+        # is harmless — keeps trainer + inference env parity so ops
+        # don't wonder why the vars differ.
+        - name: PRIME_RL_MX_PIPELINE_REPLICATION
+          value: "1"
+        # --------------------------------------------
+        - name: HF_HOME
+          value: /models/hf_home
+        - name: HF_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: hf-token-secret
+              key: token
+              optional: true
+        volumeMounts:
+        - name: shared-model-cache
+          mountPath: /models
+        - name: config
+          mountPath: /config
+        - name: output
+          mountPath: /output
+        - name: dshm
+          mountPath: /dev/shm
+        - name: infiniband
+          mountPath: /dev/infiniband
+      volumes:
+      - name: shared-model-cache
+        persistentVolumeClaim:
+          claimName: shared-model-cache
+      - name: config
+        configMap:
+          name: prime-rl-mx-on-nixl-config
+          defaultMode: 493
+      - name: output
+        persistentVolumeClaim:
+          claimName: prime-rl-mx-run-output
+      - name: dshm
+        emptyDir:
+          medium: Memory
+          sizeLimit: 64Gi
+      - name: infiniband
+        hostPath:
+          path: /dev/infiniband
+          type: DirectoryOrCreate
+      imagePullSecrets:
+      - name: nvcr-imagepullsecret
+      nodeSelector:
+        kubernetes.io/arch: arm64
+        nvidia.com/gpu.present: 'true'
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: cloud.google.com/gke-nodepool
+                operator: In
+                values:
+                - customer-gpu-o7v
+                - customer-gpu-mh2
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - prime-rl-mx-on-nixl-inference
+            topologyKey: kubernetes.io/hostname
+      tolerations:
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+      - key: dedicated
+        operator: Equal
+        value: user-workload
+        effect: NoSchedule
+      - key: dedicated
+        operator: Equal
+        value: user-workload
+        effect: NoExecute
+      - key: kubernetes.io/arch
+        operator: Exists
+        effect: NoSchedule
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prime-rl-mx-on-nixl-trainer
+  namespace: kavin
+spec:
+  selector:
+    app: prime-rl-mx-on-nixl-trainer
+  ports:
+  - name: spg
+    port: 29502
+    targetPort: 29502
+  clusterIP: None

--- a/prod.toml
+++ b/prod.toml
@@ -67,9 +67,9 @@ type = "sign_sgd"
 lr = 1e-6
 
 [orchestrator]
-batch_size = 1536
+batch_size = 512
 rollouts_per_example = 16
-oversampling_factor = 2
+oversampling_factor = 3
 max_off_policy_steps = 16
 use_token_client = true
 seed = 42
@@ -81,7 +81,7 @@ max_completion_tokens = 32768
 id = "mini-swe-agent-plus"
 name = "swe"
 num_workers = 8
-args = { max_turns = 200, cpu_cores = 2, memory_gb = 4, disk_size_gb = 4, labels = ["matej-dev"], total_timeout_minutes = 720, sandbox_client_max_workers = 256, max_command_timeouts = 3, sandbox_command_timeout = 120 }
+args = { max_turns = 100, cpu_cores = 2, memory_gb = 4, disk_size_gb = 4, labels = ["matej-dev"], total_timeout_minutes = 720, sandbox_client_max_workers = 256, max_command_timeouts = 3, sandbox_command_timeout = 120 }
 
 [inference]
 enable_expert_parallel = true
@@ -95,4 +95,4 @@ tp = 1
 
 [inference.model]
 name = "Qwen/Qwen3-235B-A22B-Thinking-2507-FP8"
-max_model_len = 65536
+max_model_len = 150000

--- a/prod.toml
+++ b/prod.toml
@@ -1,0 +1,98 @@
+max_steps = 10000000
+seq_len = 32768
+max_async_level = 1
+output_dir = "/data/outputs/nixl-qwen3-swe-prod"
+clean_output_dir = true
+
+[log]
+level = "debug"
+
+[wandb]
+project = "nixl-broadcast"
+name = "nixl-qwen3-swe-prod"
+
+[model]
+name = "Qwen/Qwen3-235B-A22B-Thinking-2507"
+
+[weight_broadcast]
+type = "nixl"
+port = 29502
+timeout = 12000
+
+[deployment]
+type = "multi_node"
+num_train_nodes = 4
+num_infer_nodes = 6
+gpus_per_node = 8
+
+[inference.deployment]
+type = "disaggregated"
+num_prefill_nodes = 2
+num_decode_nodes = 4
+
+[inference.deployment.kv_cache_offload]
+cpu_bytes = 137438953472   # 128 GiB per worker → ~1 TiB per 8-GPU node
+
+[inference.slurm]
+
+[slurm]
+job_name = "nixl-qwen3-swe-prod"
+partition = "cluster"
+# Nodes with NVreg_EnableStreamMemOPs=0 / empty RegistryDwords in
+# /proc/driver/nvidia/params — GPU Direct RDMA (IBGDA) isn't enabled so UCX
+# fails to start with these peers. Confirmed via SSH probe on 2026-04-20.
+exclude = "ltc-idc3-hgx8-h200-2,ltc-idc3-hgx8-h200-65,ltc-idc3-hgx8-h200-3,ltc-idc3-hgx8-h200-5"
+
+[trainer]
+dist_timeout_seconds = 7200
+
+[trainer.model]
+impl = "custom"
+attn = "flash_attention_2"
+fused_lm_head_token_chunk_size = 1024
+ep = 8
+cp = 1
+optim_cpu_offload = true
+
+[trainer.model.ac]
+freq = 1
+
+[trainer.model.compile]
+
+[trainer.model.ac_offloading]
+max_inflight_activations = 1
+
+[trainer.optim]
+type = "sign_sgd"
+lr = 1e-6
+
+[orchestrator]
+batch_size = 1536
+rollouts_per_example = 16
+oversampling_factor = 2
+max_off_policy_steps = 16
+use_token_client = true
+seed = 42
+
+[orchestrator.train.sampling]
+max_completion_tokens = 32768
+
+[[orchestrator.train.env]]
+id = "mini-swe-agent-plus"
+name = "swe"
+num_workers = 8
+args = { max_turns = 200, cpu_cores = 2, memory_gb = 4, disk_size_gb = 4, labels = ["matej-dev"], total_timeout_minutes = 720, sandbox_client_max_workers = 256, max_command_timeouts = 3, sandbox_command_timeout = 120 }
+
+[inference]
+enable_expert_parallel = true
+gpu_memory_utilization = 0.85
+enable_eplb = false
+use_deep_gemm = true
+
+[inference.parallel]
+dp = 16
+tp = 1
+
+[inference.model]
+name = "Qwen/Qwen3-235B-A22B-Thinking-2507-FP8"
+max_model_len = 65536

--- a/src/prime_rl/_compat.py
+++ b/src/prime_rl/_compat.py
@@ -5,6 +5,43 @@ Each shim documents the upstream issue and removal condition.
 """
 
 # ---------------------------------------------------------------------------
+# TileLang libcudart_stub.so wins dlsym(RTLD_DEFAULT) on ARM64 GB200 builds
+#
+# TileLang ships a stub `libcudart_stub.so` that gets loaded into the process
+# alongside the real CUDA runtime. Without an explicit RTLD_GLOBAL load of
+# the real libcudart, downstream dlsym() lookups (e.g. `cudaDeviceReset`
+# from FlashInfer's `CudaRTLibrary`) hit the stub first and fail with
+# `AttributeError: undefined symbol: cudaDeviceReset`.
+#
+# PI's GLM-MoE-DSA path solves this by preloading at the top of
+# `sparse_mla_{fwd,bwd}.py`, but plain Qwen3 doesn't import sparse_mla.
+# vLLM's WorkerProc subprocesses also don't reliably inherit LD_PRELOAD
+# from the entrypoint shell (uv/spawn() interaction).
+#
+# Fix: explicit ctypes load of the real libcudart with RTLD_GLOBAL right
+# here, before any model/vLLM module imports. This wins the dlsym race.
+# Wrapped in try/except so non-CUDA build environments (CI, dev) don't
+# break.
+# ---------------------------------------------------------------------------
+import ctypes as _ctypes
+import os as _os
+
+_REAL_LIBCUDART_CANDIDATES = (
+    "/usr/local/cuda/lib64/libcudart.so.12",
+    "/usr/local/cuda/lib64/libcudart.so",
+    "/usr/lib/aarch64-linux-gnu/libcudart.so.12",
+    "/usr/lib/x86_64-linux-gnu/libcudart.so.12",
+)
+for _candidate in _REAL_LIBCUDART_CANDIDATES:
+    if _os.path.exists(_candidate):
+        try:
+            _ctypes.CDLL(_candidate, mode=_ctypes.RTLD_GLOBAL)
+            break
+        except OSError:
+            continue
+
+
+# ---------------------------------------------------------------------------
 # ring_flash_attn + transformers >= 5.4
 #
 # ring_flash_attn 0.1.8 imports `is_flash_attn_greater_or_equal_2_10` from

--- a/src/prime_rl/configs/inference.py
+++ b/src/prime_rl/configs/inference.py
@@ -388,6 +388,18 @@ class InferenceConfig(BaseConfig):
         ),
     ] = False
 
+    torch_profiler_dir: Annotated[
+        str | None,
+        Field(
+            description=(
+                "If set, pass --profiler-config '{\"profiler\": \"torch\", "
+                "\"torch_profiler_dir\": <this>}' to vLLM so each worker wires the torch profiler. "
+                "Capture traces at runtime by POST-ing to the inference server's /start_profile and "
+                "/stop_profile endpoints. See https://docs.vllm.ai/en/stable/contributing/profiling/."
+            ),
+        ),
+    ] = None
+
     weight_broadcast: Annotated[WeightBroadcastConfig, Field(description="The weight broadcast config.")] = (
         WeightBroadcastConfig()
     )

--- a/src/prime_rl/entrypoints/inference.py
+++ b/src/prime_rl/entrypoints/inference.py
@@ -61,6 +61,7 @@ def write_slurm_script(config: InferenceConfig, config_path: Path, script_path: 
             router_policy=config.deployment.router_policy,
             data_parallel_rpc_port=config.data_parallel_rpc_port,
             use_deep_gemm=config.use_deep_gemm,
+            torch_profiler_dir=config.torch_profiler_dir,
             prefill_env_overrides=config.deployment.prefill_env_overrides,
             decode_env_overrides=config.deployment.decode_env_overrides,
             kv_offload=config.deployment.kv_cache_offload is not None,

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -441,6 +441,7 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
             inference_tp=config.inference.parallel.tp,
             inference_data_parallel_rpc_port=config.inference.data_parallel_rpc_port,
             use_deep_gemm=config.inference.use_deep_gemm,
+            torch_profiler_dir=config.inference.torch_profiler_dir,
             prefill_env_overrides=infer_deploy.prefill_env_overrides,
             decode_env_overrides=infer_deploy.decode_env_overrides,
             dp_per_node=config.deployment.gpus_per_node // config.inference.parallel.tp,

--- a/src/prime_rl/inference/server.py
+++ b/src/prime_rl/inference/server.py
@@ -14,6 +14,7 @@ def setup_vllm_env(config: InferenceConfig):
         os.environ["VLLM_ALLOW_RUNTIME_LORA_UPDATING"] = "True"
 
 
+
 def main():
     config = cli(InferenceConfig)
     setup_vllm_env(config)

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -313,8 +313,37 @@ from vllm.v1.utils import run_api_server_worker_proc as _original_run_api_server
 def custom_build_app(args: Namespace, supported_tasks: tuple, model_config=None):
     """
     Wrap build_app to include our custom router.
+
+    vLLM >= 0.19 auto-attaches a built-in RLHF router (via
+    ``attach_rlhf_router`` inside ``build_app``) which registers its own
+    ``/update_weights`` route that expects a different JSON schema
+    (``{"update_info": ...}``). Since FastAPI resolves routes in insertion
+    order, that built-in wins and our ``/update_weights`` (which takes
+    ``{"weight_dir": ...}`` and dispatches to the NIXL
+    ``update_weights_from_path`` worker RPC) never runs.
+
+    Strip the conflicting built-in routes *before* including our router so
+    ours is the one that handles the POST. We target only the three paths
+    PI's NIXL flow overrides (``/update_weights``, ``/init_nixl_transfer``,
+    ``/init_broadcaster``) and leave the rest of the rlhf router intact
+    (e.g. ``/collective_rpc``, ``/pause``, ``/resume``).
     """
     app = _original_build_app(args, supported_tasks, model_config)
+
+    _OVERRIDES = {"/update_weights", "/init_nixl_transfer", "/init_broadcaster"}
+    try:
+        from fastapi.routing import APIRoute
+
+        app.router.routes = [
+            r for r in app.router.routes
+            if not (isinstance(r, APIRoute) and r.path in _OVERRIDES)
+        ]
+    except Exception:
+        # If the vLLM router shape ever changes such that we can't filter,
+        # fall back to the previous behavior (duplicate routes). Our
+        # /update_weights will still lose but the server will boot.
+        pass
+
     app.include_router(router)
     return app
 

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -357,11 +357,19 @@ def server(config: InferenceConfig, vllm_extra: dict[str, Any] | None = None):
         # so it survives make_arg_parser().parse_args(args=[], namespace=...).
         # At runtime, POST /start_profile and /stop_profile on the inference
         # server to capture traces into this dir (per PyTorch worker).
-        os.makedirs(config.torch_profiler_dir, exist_ok=True)
-        setattr(namespace, "profiler_config", {
-            "profiler": "torch",
-            "torch_profiler_dir": config.torch_profiler_dir,
-        })
+        #
+        # In disaggregated PD, each role gets its own dump dir via a suffix
+        # env var set by the sbatch template ("-prefill" / "-decode") so
+        # prefill and decode traces don't stomp on each other's files.
+        from vllm.config import ProfilerConfig
+
+        role_suffix = os.environ.get("PRIME_RL_TORCH_PROFILER_ROLE_SUFFIX", "")
+        dump_dir = config.torch_profiler_dir + role_suffix
+        os.makedirs(dump_dir, exist_ok=True)
+        setattr(namespace, "profiler_config", ProfilerConfig(
+            profiler="torch",
+            torch_profiler_dir=dump_dir,
+        ))
 
     parser = FlexibleArgumentParser(description="vLLM OpenAI-Compatible RESTful API server.")
     parser = make_arg_parser(parser)

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -352,6 +352,17 @@ def server(config: InferenceConfig, vllm_extra: dict[str, Any] | None = None):
         for key, value in vllm_extra.items():
             setattr(namespace, key, value)
 
+    if config.torch_profiler_dir is not None:
+        # vLLM's --profiler-config (v0.13+). Injected onto the args namespace
+        # so it survives make_arg_parser().parse_args(args=[], namespace=...).
+        # At runtime, POST /start_profile and /stop_profile on the inference
+        # server to capture traces into this dir (per PyTorch worker).
+        os.makedirs(config.torch_profiler_dir, exist_ok=True)
+        setattr(namespace, "profiler_config", {
+            "profiler": "torch",
+            "torch_profiler_dir": config.torch_profiler_dir,
+        })
+
     parser = FlexibleArgumentParser(description="vLLM OpenAI-Compatible RESTful API server.")
     parser = make_arg_parser(parser)
     args = parser.parse_args(args=[], namespace=namespace)

--- a/src/prime_rl/inference/vllm/worker/nixl.py
+++ b/src/prime_rl/inference/vllm/worker/nixl.py
@@ -23,6 +23,12 @@ from prime_rl.inference.vllm.worker.weight_transfer import (
     update_mla_absorbed_weights,
 )
 from prime_rl.trainer.models.slots import LayoutEntry
+from prime_rl.utils.mx_rendezvous import (
+    discover_spg_coordinator,
+    mx_rendezvous_enabled,
+    pipeline_replication_enabled,
+    publish_as_rollout_source,
+)
 from prime_rl.utils.nixl_transfer import NixlAgentWrapper, make_agent_name
 
 if TYPE_CHECKING:
@@ -200,6 +206,29 @@ class NIXLWeightUpdateWorker(Worker):
         }
 
         expert_map = {k: v.cpu().tolist() for k, v in build_expert_map(model).items()}
+
+        # ModelExpress overlay: if PRIME_RL_MX_RENDEZVOUS is set, override
+        # the orchestrator-provided host/port with one discovered via MX
+        # Server. This allows the trainer and inference pods to find each
+        # other without static host/port configuration.
+        #
+        # Also stash the inference rank on self so update_weights_from_path
+        # can use it for pipeline-replication publishes after receive.
+        self._inference_rank = rank_offset + local_rank
+        if mx_rendezvous_enabled():
+            endpoint = discover_spg_coordinator(
+                role="inference",
+                rank=self._inference_rank,
+                expected_trainer_ws=trainer_world_size,
+                expected_inference_ws=inference_world_size,
+                fallback_host=host,
+                fallback_port=port,
+            )
+            host, port = endpoint.host, endpoint.port
+            logger.info(
+                f"[mx-rendezvous] inference rank={global_rank} using discovered "
+                f"SPG coordinator {host}:{port}"
+            )
 
         self._spg = StatelessProcessGroup.create(
             host=host,
@@ -423,6 +452,21 @@ class NIXLWeightUpdateWorker(Worker):
             checked = assert_mla_absorbed_weights_match(self._model)
             logger.info(f"NIXL MLA refresh audit passed for {checked} modules")
             self._validated_mla_absorbed_weights = True
+
+        # ModelExpress overlay: after every receive completes, optionally
+        # publish this rollout as an additional source for the current
+        # version so subsequent rollouts can pull from us rather than from
+        # the trainer. No-op if PRIME_RL_MX_PIPELINE_REPLICATION != 1.
+        if pipeline_replication_enabled() and mx_rendezvous_enabled():
+            try:
+                publish_as_rollout_source(
+                    source_id="",  # inferred from model_name on server
+                    rank=getattr(self, "_inference_rank", 0),
+                )
+            except Exception as exc:  # noqa: BLE001 — non-fatal
+                logger.warning(
+                    f"[mx-rendezvous] pipeline-replication publish failed (non-fatal): {exc}"
+                )
 
     def _maybe_dump_inference(self) -> None:
         """One-shot dump of every param + relevant buffer to

--- a/src/prime_rl/inference/vllm/worker/nixl.py
+++ b/src/prime_rl/inference/vllm/worker/nixl.py
@@ -87,12 +87,6 @@ _ALLOWED_UNPUBLISHED_CUDA_ATTR_SUFFIXES = (
     "W_V_scale",
 )
 
-_IGNORED_RUNTIME_CUDA_ATTR_SUFFIXES = (
-    "topk_indices_buffer",
-    "kv_cache",
-)
-
-
 def _iter_unpublished_cuda_tensor_attrs(model: Module):
     for module_name, module in model.named_modules():
         module_prefix = f"{module_name}." if module_name else ""
@@ -168,28 +162,6 @@ class NIXLWeightUpdateWorker(Worker):
 
         named_tensors: dict[str, torch.Tensor] = {}
         unpublished_cuda_attrs = list(_iter_unpublished_cuda_tensor_attrs(model))
-        ignored_runtime_unpublished = [
-            (name, tuple(tensor.shape), tuple(tensor.stride()))
-            for name, tensor in unpublished_cuda_attrs
-            if name.endswith(_IGNORED_RUNTIME_CUDA_ATTR_SUFFIXES)
-        ]
-        unexpected_unpublished = [
-            (name, tuple(tensor.shape), tuple(tensor.stride()))
-            for name, tensor in unpublished_cuda_attrs
-            if not name.endswith(_ALLOWED_UNPUBLISHED_CUDA_ATTR_SUFFIXES)
-            and not name.endswith(_IGNORED_RUNTIME_CUDA_ATTR_SUFFIXES)
-        ]
-        if unexpected_unpublished:
-            raise RuntimeError(
-                "NIXL found unpublished CUDA tensors outside the explicit allowlist: "
-                f"{unexpected_unpublished}"
-            )
-        if ignored_runtime_unpublished:
-            logger.info(
-                "NIXL ignored runtime CUDA attrs not relevant to weight transfer: count=%d sample=%s",
-                len(ignored_runtime_unpublished),
-                ignored_runtime_unpublished[:8],
-            )
         handled_unpublished = [
             (name, tensor)
             for name, tensor in unpublished_cuda_attrs

--- a/src/prime_rl/templates/inference.sbatch.j2
+++ b/src/prime_rl/templates/inference.sbatch.j2
@@ -134,6 +134,12 @@ srun bash -c '
 {%- if use_deep_gemm %}
     export VLLM_USE_DEEP_GEMM=1
 {%- endif %}
+{%- if torch_profiler_dir %}
+    # Torch profiler enabled via --profiler-config on vLLM. Ensure the dump
+    # dir exists on every inference node. Trigger captures at runtime via
+    # POST /start_profile and /stop_profile on the inference server.
+    mkdir -p "{{ torch_profiler_dir }}"
+{%- endif %}
     export PYTORCH_CUDA_ALLOC_CONF="expandable_segments:False"
     export GLOO_SOCKET_IFNAME=bond0
     export VLLM_ENGINE_READY_TIMEOUT_S=4200

--- a/src/prime_rl/templates/inference.sbatch.j2
+++ b/src/prime_rl/templates/inference.sbatch.j2
@@ -214,6 +214,10 @@ srun bash -c '
         fi
     fi
 
+    # Consumed by prime_rl.inference.vllm.server when torch_profiler_dir is set:
+    # appends "-prefill" / "-decode" so the two roles dump into separate dirs.
+    export PRIME_RL_TORCH_PROFILER_ROLE_SUFFIX="-$ROLE"
+
     echo "NODE_RANK=$INFER_NODE_RANK ROLE=$ROLE REPLICA=$REPLICA_IDX SUB_REPLICA=$SUB_REPLICA ROLE_RANK=$ROLE_RANK EP=$EP PORT=$PORT LOCAL_IP=$LOCAL_IP" \
         | tee $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log
 

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -187,6 +187,12 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
 {%- if use_deep_gemm %}
     export VLLM_USE_DEEP_GEMM=1
 {%- endif %}
+{%- if torch_profiler_dir %}
+    # Torch profiler enabled via --profiler-config on vLLM. Ensure the dump
+    # dir exists on every inference node. Trigger captures at runtime via
+    # POST /start_profile and /stop_profile on the inference server.
+    mkdir -p "{{ torch_profiler_dir }}"
+{%- endif %}
 
     export GLOO_SOCKET_IFNAME=bond0
     export VLLM_ENGINE_READY_TIMEOUT_S=4200

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -246,6 +246,10 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
         ROLE_EXTRA="\"all2all_backend\": \"deepep_low_latency\", \"compilation_config\": $DECODE_COMPILE_CFG"
     fi
 
+    # Consumed by prime_rl.inference.vllm.server when torch_profiler_dir is set:
+    # appends "-prefill" / "-decode" so the two roles dump into separate dirs.
+    export PRIME_RL_TORCH_PROFILER_ROLE_SUFFIX="-$ROLE"
+
     echo "ROLE=$ROLE REPLICA=$REPLICA_IDX SUB_REPLICA=$SUB_REPLICA ROLE_RANK=$ROLE_RANK DP=$DP PORT=$PORT" \
         | tee -a $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log
 

--- a/src/prime_rl/trainer/models/__init__.py
+++ b/src/prime_rl/trainer/models/__init__.py
@@ -19,6 +19,11 @@ from prime_rl.trainer.models.nemotron_h import NemotronHConfig, NemotronHForCaus
 from prime_rl.trainer.models.qwen3_5_moe import Qwen3_5MoeConfig, Qwen3_5MoeForCausalLM
 from prime_rl.trainer.models.qwen3_moe import Qwen3MoeConfig, Qwen3MoeForCausalLM
 
+# Side-effect import: monkey-patches HF Qwen3ForCausalLM with
+# conversion_specs() so PI's NIXLWeightBroadcast works on dense Qwen3
+# (PI's __init__.py only registers MoE/MLA variants natively).
+from prime_rl.trainer.models import qwen3_specs_patch  # noqa: F401
+
 # Make custom config discoverable by AutoConfig
 AutoConfig.register("afmoe", AfmoeConfig, exist_ok=True)
 AutoConfig.register("glm4_moe", Glm4MoeConfig, exist_ok=True)

--- a/src/prime_rl/trainer/models/qwen3_moe/converting_qwen3_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_moe/converting_qwen3_moe.py
@@ -1,6 +1,8 @@
 import torch
 from torch import Tensor
 
+from prime_rl.trainer.models.conversion_spec import ConversionSpec, QuantizationSpec
+
 
 def get_max_layer_num(state_dict: dict[str, Tensor]) -> int:
     """Get the maximum number of layers in the model."""
@@ -98,3 +100,59 @@ def convert_tt_to_hf_moe(state_dict: dict[str, Tensor]):
     num_layers = get_max_layer_num(state_dict)
     for i in range(num_layers):
         convert_tt_layer_to_hf(state_dict, i)
+
+
+# NIXL ConversionSpec tables for Qwen3MoE.
+#
+# Qwen3-235B-A22B-*-FP8 keeps every linear in block-FP8; only the layernorms
+# and the router gate remain in bf16. vLLM fuses qkv into ``self_attn.qkv_proj``
+# and (for dense layers) gate+up into ``mlp.gate_up_proj``. MoE layers use
+# vLLM's FusedMoE ``w13_weight`` / ``w2_weight`` 3D stacked buffers; the
+# ``_weight_scale_inv`` scale suffix (vs ``.weight_scale_inv`` on 2D linears)
+# matches vLLM's FusedMoE naming convention.
+_BASE: tuple[ConversionSpec, ...] = (
+    ConversionSpec("input_layernorm.weight", ("input_layernorm.weight",)),
+    ConversionSpec("post_attention_layernorm.weight", ("post_attention_layernorm.weight",)),
+    ConversionSpec("self_attn.q_norm.weight", ("self_attn.q_norm.weight",)),
+    ConversionSpec("self_attn.k_norm.weight", ("self_attn.k_norm.weight",)),
+    ConversionSpec(
+        "self_attn.qkv_proj.weight",
+        ("self_attn.q_proj.weight", "self_attn.k_proj.weight", "self_attn.v_proj.weight"),
+        quantization=QuantizationSpec(torch.float8_e4m3fn, ".weight_scale_inv"),
+    ),
+    ConversionSpec(
+        "self_attn.o_proj.weight",
+        ("self_attn.o_proj.weight",),
+        quantization=QuantizationSpec(torch.float8_e4m3fn, ".weight_scale_inv"),
+    ),
+)
+
+
+_DENSE: tuple[ConversionSpec, ...] = (
+    ConversionSpec(
+        "mlp.gate_up_proj.weight",
+        ("mlp.gate_proj.weight", "mlp.up_proj.weight"),
+        quantization=QuantizationSpec(torch.float8_e4m3fn, ".weight_scale_inv"),
+    ),
+    ConversionSpec(
+        "mlp.down_proj.weight",
+        ("mlp.down_proj.weight",),
+        quantization=QuantizationSpec(torch.float8_e4m3fn, ".weight_scale_inv"),
+    ),
+)
+
+
+_SPARSE: tuple[ConversionSpec, ...] = (
+    ConversionSpec("mlp.gate.weight", ("mlp.router.gate.weight",)),
+    ConversionSpec(
+        "mlp.experts.w13_weight",
+        ("mlp.experts.w1", "mlp.experts.w3"),
+        cat_dim=1,
+        quantization=QuantizationSpec(torch.float8_e4m3fn, "_weight_scale_inv"),
+    ),
+    ConversionSpec(
+        "mlp.experts.w2_weight",
+        ("mlp.experts.w2",),
+        quantization=QuantizationSpec(torch.float8_e4m3fn, "_weight_scale_inv"),
+    ),
+)

--- a/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
@@ -27,6 +27,7 @@ from transformers.processing_utils import Unpack
 from transformers.utils import TransformersKwargs, auto_docstring, can_return_tuple, logging
 
 from prime_rl.trainer.models.base import PreTrainedModelPrimeRL
+from prime_rl.trainer.models.conversion_spec import ConversionSpec
 from prime_rl.trainer.models.layers.attn import ATTN_IMPL2CLASS, AttentionConfig
 from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput
 from prime_rl.trainer.models.layers.mlp import MLP, MLPConfig
@@ -35,6 +36,9 @@ from prime_rl.trainer.models.layers.norms import RMSNorm, RMSNormConfig
 from prime_rl.trainer.models.layers.rotary_emb import RotaryEmbedding, RotaryEmbeddingConfig
 from prime_rl.trainer.models.qwen3_moe.configuration_qwen3_moe import Qwen3MoeConfig
 from prime_rl.trainer.models.qwen3_moe.converting_qwen3_moe import (
+    _BASE,
+    _DENSE,
+    _SPARSE,
     convert_hf_layer_to_tt,
     convert_hf_to_tt_moe,
     convert_tt_layer_to_hf,
@@ -167,6 +171,30 @@ class Qwen3MoePreTrainedModel(PreTrainedModelPrimeRL):
         """Convert a single layer's MoE weights from HuggingFace format to PrimeRL format in-place."""
         convert_hf_layer_to_tt(state_dict, layer_idx)
         return state_dict
+
+    def conversion_specs(self, layer_idx: int) -> tuple[ConversionSpec, ...]:
+        """Return the conversion specs for one layer.
+
+        Sparse vs dense MLP is decided the same way the decoder layer itself
+        decides (``mlp_only_layers`` + ``decoder_sparse_step``); checking the
+        live state_dict for the router gate captures that post-conversion.
+        """
+        prefix = f"model.layers.{layer_idx}"
+        is_sparse = f"{prefix}.mlp.router.gate.weight" in self.state_dict()
+        return _BASE + (_SPARSE if is_sparse else _DENSE)
+
+    def non_layer_conversion_specs(self) -> tuple[ConversionSpec, ...]:
+        """Top-level tensors (embed_tokens, norm, optional lm_head) that NIXL
+        must transport alongside per-layer slots — otherwise inference never
+        receives updates for them and KL drifts as trainer gradients advance.
+        """
+        specs = (
+            ConversionSpec("model.embed_tokens.weight", ("model.embed_tokens.weight",)),
+            ConversionSpec("model.norm.weight", ("model.norm.weight",)),
+        )
+        if not self.config.tie_word_embeddings:
+            specs = specs + (ConversionSpec("lm_head.weight", ("lm_head.weight",)),)
+        return specs
 
 
 @auto_docstring

--- a/src/prime_rl/trainer/models/qwen3_specs_patch.py
+++ b/src/prime_rl/trainer/models/qwen3_specs_patch.py
@@ -1,0 +1,145 @@
+"""ConversionSpec patch for HF Qwen3 (dense) so PI's NIXLWeightBroadcast works.
+
+PI's ``models/__init__.py`` only registers a custom ``PreTrainedModelPrimeRL``
+subclass for ``glm_moe_dsa``, ``glm4_moe``, ``qwen3_moe``, ``qwen3_5_moe``,
+``llama``, ``minimax_m2``, ``afmoe``, ``nemotron_h``. Plain dense Qwen3
+(0.6B, 1.7B, 4B, 8B, 14B, 32B) falls through to HF's ``Qwen3ForCausalLM``,
+which doesn't define ``conversion_specs(layer_idx)`` — so
+``TransportPlan`` crashes at construction with ``AttributeError``.
+
+This module monkey-patches HF Qwen3 to expose ``conversion_specs`` and
+``non_layer_conversion_specs`` so PI's NIXL transport works on dense
+Qwen3 unchanged. Imported from ``prime_rl/trainer/models/__init__.py``
+side-effect-only.
+
+The spec table mirrors vLLM's Qwen3 weight loading:
+
+* ``q_proj`` + ``k_proj`` + ``v_proj`` → ``qkv_proj`` (concat dim 0).
+* ``gate_proj`` + ``up_proj`` → ``gate_up_proj`` (concat dim 0).
+* Everything else passthrough (o_proj, down_proj, input_layernorm,
+  post_attention_layernorm, q_norm, k_norm, embed_tokens, model.norm,
+  lm_head if not tied).
+
+All BF16, no FP8. For an FP8 variant of Qwen3, swap ``QuantizationSpec``
+default for the relevant specs.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from prime_rl.trainer.models.conversion_spec import ConversionSpec, QuantizationSpec
+
+
+# Per-layer specs for HF Qwen3. dst suffix is appended to "model.layers.{i}.".
+_QWEN3_LAYER: tuple[ConversionSpec, ...] = (
+    # Pre-attention RMSNorm
+    ConversionSpec(
+        "input_layernorm.weight",
+        ("input_layernorm.weight",),
+    ),
+    # Pre-MLP RMSNorm
+    ConversionSpec(
+        "post_attention_layernorm.weight",
+        ("post_attention_layernorm.weight",),
+    ),
+    # Q/K/V → fused qkv_proj. vLLM's Qwen3 model concatenates (q, k, v)
+    # along dim 0; PI's ConversionSpec preserves source order, so the
+    # tuple order here matters.
+    ConversionSpec(
+        "self_attn.qkv_proj.weight",
+        (
+            "self_attn.q_proj.weight",
+            "self_attn.k_proj.weight",
+            "self_attn.v_proj.weight",
+        ),
+        cat_dim=0,
+    ),
+    # Output projection (no fusion)
+    ConversionSpec(
+        "self_attn.o_proj.weight",
+        ("self_attn.o_proj.weight",),
+    ),
+    # Qwen3-specific RMSNorm on per-head Q (after q_proj split)
+    ConversionSpec(
+        "self_attn.q_norm.weight",
+        ("self_attn.q_norm.weight",),
+    ),
+    # Qwen3-specific RMSNorm on per-head K
+    ConversionSpec(
+        "self_attn.k_norm.weight",
+        ("self_attn.k_norm.weight",),
+    ),
+    # MLP gate + up → fused gate_up_proj (gate first, then up)
+    ConversionSpec(
+        "mlp.gate_up_proj.weight",
+        (
+            "mlp.gate_proj.weight",
+            "mlp.up_proj.weight",
+        ),
+        cat_dim=0,
+    ),
+    # MLP down projection
+    ConversionSpec(
+        "mlp.down_proj.weight",
+        ("mlp.down_proj.weight",),
+    ),
+)
+
+
+def _qwen3_conversion_specs(self, layer_idx: int) -> tuple[ConversionSpec, ...]:
+    """Per-layer spec table — Qwen3 dense has no MoE so it's identical
+    for every layer. ``layer_idx`` accepted for API parity with
+    PI's ``GlmMoeDsaForCausalLM``."""
+    return _QWEN3_LAYER
+
+
+def _qwen3_non_layer_conversion_specs(self) -> tuple[ConversionSpec, ...]:
+    """Non-per-layer tensors. Without these NIXL never updates them on
+    inference, causing KL drift as trainer gradients advance them but
+    inference stays at initial load (the lesson PI's PR #2326 iter8
+    documented)."""
+    specs: tuple[ConversionSpec, ...] = (
+        ConversionSpec(
+            "model.embed_tokens.weight",
+            ("model.embed_tokens.weight",),
+        ),
+        ConversionSpec(
+            "model.norm.weight",
+            ("model.norm.weight",),
+        ),
+    )
+    if not getattr(self.config, "tie_word_embeddings", False):
+        specs = specs + (
+            ConversionSpec(
+                "lm_head.weight",
+                ("lm_head.weight",),
+            ),
+        )
+    return specs
+
+
+def _patch_hf_qwen3_class() -> None:
+    """Add `conversion_specs` and `non_layer_conversion_specs` to HF
+    `Qwen3ForCausalLM`. Idempotent; safe to call repeatedly.
+
+    Also patches the FSDP wrapper class if accessible — though FSDP2's
+    fully_shard typically forwards `__getattr__` to the underlying
+    module, so the bare class patch is usually enough.
+    """
+    try:
+        from transformers.models.qwen3.modeling_qwen3 import Qwen3ForCausalLM  # type: ignore
+    except ImportError:
+        # transformers without Qwen3 — nothing to patch.
+        return
+
+    # Idempotent guard
+    if getattr(Qwen3ForCausalLM, "_prime_rl_qwen3_patched", False):
+        return
+
+    Qwen3ForCausalLM.conversion_specs = _qwen3_conversion_specs  # type: ignore[attr-defined]
+    Qwen3ForCausalLM.non_layer_conversion_specs = _qwen3_non_layer_conversion_specs  # type: ignore[attr-defined]
+    Qwen3ForCausalLM._prime_rl_qwen3_patched = True  # type: ignore[attr-defined]
+
+
+_patch_hf_qwen3_class()

--- a/src/prime_rl/trainer/rl/broadcast/nixl.py
+++ b/src/prime_rl/trainer/rl/broadcast/nixl.py
@@ -30,6 +30,10 @@ from prime_rl.trainer.rl.broadcast.transport_plan import TransportPlan
 from prime_rl.trainer.runs import get_multi_run_manager
 from prime_rl.trainer.utils import get_world
 from prime_rl.utils.logger import get_logger
+from prime_rl.utils.mx_rendezvous import (
+    discover_spg_coordinator,
+    mx_rendezvous_enabled,
+)
 from prime_rl.utils.nixl_transfer import NixlAgentWrapper, make_agent_name
 from prime_rl.utils.pathing import sync_wait_for_path
 from prime_rl.utils.utils import get_broadcast_dir, get_step_path
@@ -76,9 +80,31 @@ class NIXLWeightBroadcast(WeightBroadcast):
         # Non-primary replicas are absent from the SPG entirely.
         trainer_ws_per_replica = parallel_dims.dp_shard * parallel_dims.cp
         spg_rank = parallel_dims.get_mesh("dp_shard_cp").get_local_rank() if dist.is_initialized() else 0
+
+        # ModelExpress overlay: when PRIME_RL_MX_RENDEZVOUS is set, discover
+        # the SPG coordinator host/port via MX Server instead of using the
+        # hard-coded config values. Default (unset) preserves the exact
+        # upstream PI behavior.
+        if mx_rendezvous_enabled():
+            endpoint = discover_spg_coordinator(
+                role="trainer",
+                rank=spg_rank,
+                expected_trainer_ws=trainer_ws_per_replica,
+                expected_inference_ws=config.inference_world_size,
+                fallback_host=config.host,
+                fallback_port=config.port,
+            )
+            spg_host, spg_port = endpoint.host, endpoint.port
+            self.logger.info(
+                f"[mx-rendezvous] trainer rank={spg_rank} using discovered "
+                f"SPG coordinator {spg_host}:{spg_port} (source_id={endpoint.source_id})"
+            )
+        else:
+            spg_host, spg_port = config.host, config.port
+
         self._spg = StatelessProcessGroup.create(
-            host=config.host,
-            port=config.port,
+            host=spg_host,
+            port=spg_port,
             rank=spg_rank,
             world_size=trainer_ws_per_replica + config.inference_world_size,
             store_timeout=config.timeout,

--- a/src/prime_rl/trainer/rl/broadcast/transport_plan.py
+++ b/src/prime_rl/trainer/rl/broadcast/transport_plan.py
@@ -34,16 +34,27 @@ import torch.distributed as dist
 from vllm.distributed.utils import StatelessProcessGroup
 
 from prime_rl.trainer.models.base import PreTrainedModelPrimeRL
+from prime_rl.trainer.models.fp8 import BLOCK_SIZE, ceil_div
 from prime_rl.trainer.models.slots import (
     ExpertSlot,
+    GatheredSlot,
     LayoutEntry,
     PeerInfo,
+    ShardedSlot,
     Slot,
 )
 from prime_rl.trainer.parallel_dims import ParallelDims
 from prime_rl.utils.classic_cuda_pool import classic_cuda_alloc
 from prime_rl.utils.logger import get_logger
 from prime_rl.utils.nixl_transfer import NixlAgentWrapper
+
+
+# Diagnostic: when set, push_once delegates to a "serial gather" path — rank 0
+# gathers each slot's full unsharded tensor, quantizes into a shared scratchpad,
+# and issues every RDMA WRITE itself (sequentially per slot, per layer). Used to
+# isolate whether the default concurrent per-shard writer pattern contributes to
+# residual KL drift.
+_SERIAL_PUSH = os.environ.get("PRIME_RL_NIXL_SERIAL_PUSH") == "1"
 
 
 @dataclass
@@ -163,6 +174,17 @@ class TransportPlan:
         self._writes: list[_ResolvedWrite] = []
         # Push counter for one-shot diagnostic dumps.
         self._push_counter = 0
+
+        # Serial-push state (rank 0 only; populated in register + rendezvous).
+        self._serial_enabled = _SERIAL_PUSH
+        self._serial_slot_plans: dict[str, dict[str, Any]] = {}
+        self._serial_scratch_w: Any = None
+        self._serial_scratch_s: Any = None
+        # {(slot_key_or_scale_key, remote_chunk_idx, peer_name): remote_prep}
+        self._serial_remote_preps: dict[tuple[str, int, str], Any] = {}
+        self._serial_model_ref = model
+        if self._serial_enabled:
+            self.logger.info(f"[nixl serial push] enabled on rank {self.my_rank}")
         # Derived statistic: total bytes moved per push (sum over all slot buffers,
         # weight + scale). Fan-out across inference peers is separate.
         self._bytes_per_push = sum(
@@ -186,6 +208,123 @@ class TransportPlan:
                 agent.register_tensor(tensor)
                 descs = agent.chunked_descs(tensor, num_chunks)
                 self._local_preps[key] = agent.prep_local(descs)
+
+        if self._serial_enabled and self.my_rank == 0:
+            self._serial_allocate_and_register(agent)
+
+    # ------------------------------------------------------------------ #
+    # Serial-push helpers (rank 0 only)
+    # ------------------------------------------------------------------ #
+
+    def _serial_full_shape_for_slot(self, slot: Slot) -> tuple[int, ...]:
+        """Full unsharded destination shape a slot would hold if rank 0 materialized it."""
+        state_dict = self._serial_model_ref.state_dict()
+        if isinstance(slot, ExpertSlot):
+            src_shapes = [state_dict[name].shape for name in slot.source_names]
+            dst = list(src_shapes[0])
+            dst[slot.cat_dim] = sum(sh[slot.cat_dim] for sh in src_shapes)
+            return tuple(dst)
+        return tuple(state_dict[slot.source_name].shape)
+
+    def _serial_allocate_and_register(self, agent: NixlAgentWrapper) -> None:
+        """On rank 0: compute per-slot full shapes, allocate shared scratchpads
+        sized to the largest slot's weight + scale, and pre-build per-chunk
+        local preps into those scratchpads."""
+        max_w_nbytes = 0
+        max_s_nbytes = 0
+        plans: dict[str, dict[str, Any]] = {}
+
+        for slot in self.slots:
+            full_shape = self._serial_full_shape_for_slot(slot)
+            dtype = slot.weight.dtype
+            elem = slot.weight.element_size()
+            w_nbytes = 1
+            for d in full_shape:
+                w_nbytes *= d
+            w_nbytes *= elem
+
+            # Inference-side chunk count along dim 0:
+            #   ExpertSlot   → one chunk per global expert
+            #   ShardedSlot  → trainer_ws chunks of rows_per_shard rows
+            #   GatheredSlot → single chunk covering the full tensor
+            if isinstance(slot, ExpertSlot):
+                num_chunks = full_shape[0]
+            elif isinstance(slot, ShardedSlot):
+                num_chunks = slot.trainer_ws
+            else:
+                num_chunks = 1
+            w_chunk_nbytes = w_nbytes // num_chunks
+
+            plan: dict[str, Any] = {
+                "slot": slot,
+                "full_shape": full_shape,
+                "dtype": dtype,
+                "w_nbytes": w_nbytes,
+                "w_chunk_nbytes": w_chunk_nbytes,
+                "num_chunks": num_chunks,
+                "is_expert": isinstance(slot, ExpertSlot),
+                "has_scale": slot.scale is not None,
+            }
+            if slot.scale is not None:
+                if isinstance(slot, ExpertSlot):
+                    scale_shape = (
+                        full_shape[0],
+                        ceil_div(full_shape[1], BLOCK_SIZE),
+                        ceil_div(full_shape[2], BLOCK_SIZE),
+                    )
+                else:
+                    scale_shape = (
+                        ceil_div(full_shape[0], BLOCK_SIZE),
+                        ceil_div(full_shape[1], BLOCK_SIZE),
+                    )
+                s_elem = slot.scale.element_size()
+                s_nbytes = 1
+                for d in scale_shape:
+                    s_nbytes *= d
+                s_nbytes *= s_elem
+                s_chunk_nbytes = s_nbytes // num_chunks
+                plan["scale_shape"] = scale_shape
+                plan["scale_dtype"] = slot.scale.dtype
+                plan["s_nbytes"] = s_nbytes
+                plan["s_chunk_nbytes"] = s_chunk_nbytes
+                max_s_nbytes = max(max_s_nbytes, s_nbytes)
+            plans[slot.slot_key] = plan
+            max_w_nbytes = max(max_w_nbytes, w_nbytes)
+
+        self.logger.info(
+            f"[nixl serial push] allocating scratchpads: weight={max_w_nbytes / 1e9:.2f} GB "
+            f"scale={max_s_nbytes / 1e6:.2f} MB over {len(plans)} slots"
+        )
+        device = torch.device("cuda", torch.cuda.current_device())
+        with classic_cuda_alloc():
+            self._serial_scratch_w = torch.empty(max_w_nbytes, dtype=torch.uint8, device=device)
+            if max_s_nbytes > 0:
+                self._serial_scratch_s = torch.empty(max_s_nbytes, dtype=torch.uint8, device=device)
+        agent.register_tensor(self._serial_scratch_w)
+        if self._serial_scratch_s is not None:
+            agent.register_tensor(self._serial_scratch_s)
+
+        # Pre-build per-chunk local preps for every slot. Scratchpads are
+        # reused across slots: plan's offsets are always 0..nbytes inside
+        # the scratchpad, and we drain between slots.
+        for slot_key, plan in plans.items():
+            w_base = self._serial_scratch_w.data_ptr()
+            dev_idx = device.index
+            w_preps: list[Any] = []
+            for c in range(plan["num_chunks"]):
+                descs = agent.descs_from_tuples([(w_base + c * plan["w_chunk_nbytes"], plan["w_chunk_nbytes"], dev_idx)])
+                w_preps.append(agent.prep_local(descs))
+            plan["w_local_preps"] = w_preps
+            if plan.get("has_scale"):
+                s_base = self._serial_scratch_s.data_ptr()
+                s_preps: list[Any] = []
+                for c in range(plan["num_chunks"]):
+                    descs = agent.descs_from_tuples([
+                        (s_base + c * plan["s_chunk_nbytes"], plan["s_chunk_nbytes"], dev_idx)
+                    ])
+                    s_preps.append(agent.prep_local(descs))
+                plan["s_local_preps"] = s_preps
+        self._serial_slot_plans = plans
 
     # ------------------------------------------------------------------ #
     # Phase 2: rendezvous
@@ -229,12 +368,27 @@ class TransportPlan:
         ]
         self._build_write_table(agent)
 
+        if self._serial_enabled and self.my_rank == 0:
+            self._serial_build_remote_preps(agent)
+
         num_expert_slots = sum(1 for s in self.slots if isinstance(s, ExpertSlot))
         self.logger.info(
             f"NIXL transfer initialized: rank={self.my_rank} slots={len(self.slots)} "
             f"(expert={num_expert_slots}) writes={len(self._writes)} "
             f"bytes_per_push={self._bytes_per_push / 1e6:.2f} MB"
         )
+
+    def _serial_build_remote_preps(self, agent: NixlAgentWrapper) -> None:
+        """Rank-0-only: cache remote preps for every peer × slot × chunk combo."""
+        n = 0
+        for peer in self._peers:
+            for key, serialized_list in peer.descriptors.items():
+                for chunk_idx, serialized in enumerate(serialized_list):
+                    dlist = agent.deserialize_descs(serialized)
+                    prep = agent.prep_remote(peer.agent_name, dlist)
+                    self._serial_remote_preps[(key, chunk_idx, peer.agent_name)] = prep
+                    n += 1
+        self.logger.info(f"[nixl serial push] cached {n} remote preps across {len(self._peers)} peers")
 
     def _build_write_table(self, agent: NixlAgentWrapper) -> None:
         """Resolve every slot's WriteEntry list into cached NIXL prep handles."""
@@ -345,6 +499,8 @@ class TransportPlan:
         inference know every WRITE has been acknowledged before the
         orchestrator calls ``/resume``.
         """
+        if self._serial_enabled:
+            return self.push_once_serial(model, agent, spg)
         device = next(model.parameters()).device
         t_start = time.perf_counter()
         self._push_counter += 1
@@ -463,3 +619,160 @@ class TransportPlan:
             f"barrier={dt_barrier * 1e3:.2f}ms total={dt_total * 1e3:.2f}ms "
             f"wire_bw={gbps_wire:.2f}GB/s net_bw={gbps_net:.2f}GB/s"
         )
+
+    # ------------------------------------------------------------------ #
+    # Serial-gather push path (diagnostic)
+    # ------------------------------------------------------------------ #
+
+    @torch.no_grad()
+    def push_once_serial(
+        self,
+        model: PreTrainedModelPrimeRL,
+        agent: NixlAgentWrapper,
+        spg: StatelessProcessGroup,
+    ) -> None:
+        """Gather full tensor to rank 0, quantize into scratchpad, write one slot at a time.
+
+        Diagnostic alternative to :meth:`push_once` — isolates whether the
+        default concurrent per-shard writer pattern contributes to residual
+        KL drift. Semantics:
+
+          1. Per layer (then non-layer tensors), per slot: every trainer rank
+             calls ``full_tensor()`` on the slot's source(s) so the DTensor
+             collective materializes the unsharded data everywhere. Non-rank-0
+             ranks then drop the result.
+          2. Rank 0 cats fused sources along ``cat_dim`` and runs the spec's
+             quantization into a pre-registered scratchpad.
+          3. Rank 0 posts one RDMA WRITE per (chunk, peer), expert-aware via
+             ``peer.expert_map`` for :class:`ExpertSlot`. Drains before the
+             next slot so the scratchpad can be reused.
+          4. Bracketed by ``spg.barrier()`` so inference sees the same
+             pause/resume contract as the default path.
+        """
+        t_start = time.perf_counter()
+        self._push_counter += 1
+        state_dict = model.state_dict()
+
+        # Group slots by layer_idx (and non-layer bucket) for deterministic ordering.
+        num_layers = model.config.num_hidden_layers
+        per_layer: list[list[Slot]] = [[] for _ in range(num_layers)]
+        non_layer: list[Slot] = []
+        for slot in self.slots:
+            k = slot.slot_key
+            if k.startswith("model.layers."):
+                per_layer[int(k.split(".")[2])].append(slot)
+            else:
+                non_layer.append(slot)
+
+        # PRE-WRITE barrier (matches default push_once).
+        spg.barrier()
+
+        for layer_idx in range(num_layers):
+            for slot in per_layer[layer_idx]:
+                self._serial_push_one_slot(slot, state_dict, agent)
+        for slot in non_layer:
+            self._serial_push_one_slot(slot, state_dict, agent)
+
+        if self.my_rank == 0:
+            torch.cuda.synchronize()
+        spg.barrier()
+        t_done = time.perf_counter()
+        self.logger.info(
+            f"[nixl rank={self.my_rank}] serial-push "
+            f"slots={len(self.slots)} total={(t_done - t_start) * 1e3:.2f}ms"
+        )
+
+    def _serial_push_one_slot(
+        self,
+        slot: Slot,
+        state_dict: dict[str, Any],
+        agent: NixlAgentWrapper,
+    ) -> None:
+        """One full gather + quantize + write-to-all-peers for a single slot.
+
+        Every rank participates in ``full_tensor()``; only rank 0 quantizes and
+        writes. Drains before returning so the scratchpad can be reused.
+        """
+        # 1. Materialize full tensor(s) on every rank (collective).
+        if isinstance(slot, ExpertSlot):
+            names = list(slot.source_names)
+        else:
+            names = [slot.source_name]
+        full_srcs = [state_dict[n].full_tensor() for n in names]
+
+        if self.my_rank != 0:
+            # Non-writer ranks participated in the all_gather; release refs.
+            del full_srcs
+            return
+
+        # 2. Cat if fused, quantize into scratchpad views.
+        if len(full_srcs) == 1:
+            src = full_srcs[0]
+        else:
+            cat_dim = slot.cat_dim if isinstance(slot, ExpertSlot) else slot.spec.cat_dim
+            src = torch.cat(full_srcs, dim=cat_dim)
+
+        plan = self._serial_slot_plans[slot.slot_key]
+        w_view = (
+            self._serial_scratch_w[: plan["w_nbytes"]]
+            .view(plan["dtype"])
+            .view(plan["full_shape"])
+        )
+        s_view = None
+        if plan.get("has_scale"):
+            assert self._serial_scratch_s is not None
+            s_view = (
+                self._serial_scratch_s[: plan["s_nbytes"]]
+                .view(plan["scale_dtype"])
+                .view(plan["scale_shape"])
+            )
+        slot.spec.quantization.apply(src, w_view, s_view)
+        del src, full_srcs
+
+        # 3. Post writes. For experts, write per-global-expert to every peer
+        # that owns that expert. For non-experts, write every chunk to every
+        # peer (full tensor redundantly landed at each peer).
+        handles: list = []
+        ctx: list[tuple[str, str]] = []
+
+        def _drain() -> None:
+            for h, c in zip(handles, ctx):
+                agent.wait(h, context=f"rank=0 peer={c[0]} tag={c[1]}")
+            handles.clear()
+            ctx.clear()
+
+        if isinstance(slot, ExpertSlot):
+            num_global = plan["num_chunks"]
+            for g in range(num_global):
+                for peer in self._peers:
+                    peer_experts = peer.expert_map.get(slot.moe_prefix, [])
+                    if g not in peer_experts:
+                        continue
+                    remote_idx = peer_experts.index(g)
+                    handles.append(agent.post_write(
+                        plan["w_local_preps"][g], 0,
+                        self._serial_remote_preps[(slot.slot_key, remote_idx, peer.agent_name)], 0,
+                    ))
+                    ctx.append((peer.agent_name, f"expert:{slot.slot_key}:E{g}"))
+                    if plan.get("has_scale"):
+                        handles.append(agent.post_write(
+                            plan["s_local_preps"][g], 0,
+                            self._serial_remote_preps[(slot.scale_key, remote_idx, peer.agent_name)], 0,
+                        ))
+                        ctx.append((peer.agent_name, f"expert:{slot.scale_key}:E{g}"))
+        else:
+            num_chunks = plan["num_chunks"]
+            for c_idx in range(num_chunks):
+                for peer in self._peers:
+                    handles.append(agent.post_write(
+                        plan["w_local_preps"][c_idx], 0,
+                        self._serial_remote_preps[(slot.slot_key, c_idx, peer.agent_name)], 0,
+                    ))
+                    ctx.append((peer.agent_name, f"chunk:{slot.slot_key}:{c_idx}"))
+                    if plan.get("has_scale"):
+                        handles.append(agent.post_write(
+                            plan["s_local_preps"][c_idx], 0,
+                            self._serial_remote_preps[(slot.scale_key, c_idx, peer.agent_name)], 0,
+                        ))
+                        ctx.append((peer.agent_name, f"chunk:{slot.scale_key}:{c_idx}"))
+        _drain()

--- a/src/prime_rl/utils/mx_rendezvous.py
+++ b/src/prime_rl/utils/mx_rendezvous.py
@@ -1,0 +1,459 @@
+"""MX Server rendezvous helper — MX-mediated replacement for PI's
+hard-coded SPG host/port.
+
+When the environment variable ``PRIME_RL_MX_RENDEZVOUS`` is set to a MX
+Server address (e.g. ``modelexpress-server.kavin.svc.cluster.local:8001``),
+participants discover the SPG coordinator endpoint via MX Server instead of
+the config's static ``host``/``port`` fields. This enables:
+
+- **Dynamic topology** — trainer/rollout pods can start in any order, no
+  need to pre-configure each other's IPs.
+- **Pipeline replication** — after receive, a rollout publishes itself as
+  an additional source for the same version; future newcomers discover
+  it via ``list_sources``.
+- **Peer recovery** — a restarting pod pulls from a surviving peer rather
+  than the trainer.
+
+Scope for v0.1: only the ``host``/``port`` rendezvous is replaced. Per-step
+``spg.barrier()`` calls still use the SPG process group (which has a fixed
+world size once established). This keeps the change minimally invasive to
+PI's :class:`TransportPlan`. Future v0.2 extensions can replace the
+per-step barrier with an MX-mediated barrier for full elastic-mid-run
+support.
+
+Toggle via environment variables (no config changes to PI's code):
+
+- ``PRIME_RL_MX_RENDEZVOUS``: MX Server address. When unset or empty,
+  this module is a no-op and the caller falls back to ``config.host`` /
+  ``config.port``.
+- ``PRIME_RL_MX_MODEL_NAME``: model name (e.g. HF ID). Used as the
+  rendezvous cohort key on MX Server.
+- ``PRIME_RL_MX_TRAINING_RUN_ID``: unique run ID. Optional; auto-generated
+  from hostname if unset. Ensures multiple concurrent training runs on
+  the same MX Server don't collide on rendezvous.
+- ``PRIME_RL_MX_PIPELINE_REPLICATION``: ``1`` to enable rollout-as-source
+  publishing after receive. Default ``0``.
+
+Env-var surface rather than config plumbing for v0.1 — keeps the PR-on-PR
+small; follow-up can promote these to first-class config fields.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import socket
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# How long to wait at rendezvous before giving up (seconds). Training
+# startup already takes tens of seconds, so we can afford minutes here.
+_DEFAULT_TIMEOUT_SECONDS = 300.0
+_POLL_INTERVAL = 0.5
+
+# MX Server's get_metadata() only preserves a subset of WorkerMetadata
+# fields across the gRPC round-trip (empirically: nixl_metadata, status,
+# updated_at survive; metadata_endpoint and agent_name come back empty).
+# We smuggle the SPG coordinator host:port through the bytes-typed
+# nixl_metadata field, tagged with this prefix so consumers can reliably
+# distinguish a rendezvous blob from a real NIXL agent metadata blob.
+_RENDEZVOUS_BLOB_PREFIX = "primerl-mx-rendezvous:"
+
+
+def mx_rendezvous_enabled() -> bool:
+    """Return True iff ``PRIME_RL_MX_RENDEZVOUS`` is set to a non-empty value."""
+    return bool(os.environ.get("PRIME_RL_MX_RENDEZVOUS", "").strip())
+
+
+def pipeline_replication_enabled() -> bool:
+    """Return True iff ``PRIME_RL_MX_PIPELINE_REPLICATION=1``."""
+    return os.environ.get("PRIME_RL_MX_PIPELINE_REPLICATION", "0") == "1"
+
+
+def scratch_mode_enabled() -> bool:
+    """Return True iff ``PRIME_RL_MX_TRANSFER_MODE=scratch``.
+
+    When True, the receiver stages RDMA writes in isolated GPU tensors
+    and applies via ``model.load_weights()`` instead of writing directly
+    into live vLLM parameter memory. Diagnostic mode — useful for
+    isolating direct-refit correctness issues (e.g. the KL drift PI's
+    team investigated in #2326).
+    """
+    return os.environ.get("PRIME_RL_MX_TRANSFER_MODE", "direct") == "scratch"
+
+
+@dataclass
+class RendezvousEndpoint:
+    """SPG coordinator endpoint discovered via MX Server."""
+
+    host: str
+    port: int
+    source_id: str  # mx_source_id (16-char hex)
+    trainer_worker_id: str  # publisher's worker_id
+
+
+def _get_run_id() -> str:
+    """Return a stable run ID for this training run.
+
+    Prefers ``PRIME_RL_MX_TRAINING_RUN_ID`` (explicit, recommended). The
+    hostname-derived fallback below is best-effort only — trainer and
+    inference pods in the same run typically have *different* hostname
+    prefixes (e.g. ``prime-rl-mx-trainer-0`` vs
+    ``prime-rl-mx-inference-0``), so naive prefix-stripping yields
+    different IDs and the rendezvous never converges. The fallback
+    handles that by stripping a known role suffix (``-trainer-N``,
+    ``-inference-N``, ``-rollout-N``, ``-orchestrator-...``) and
+    returning the remaining cluster prefix shared by every pod in
+    the run.
+
+    Production deployments **must** set ``PRIME_RL_MX_TRAINING_RUN_ID``
+    explicitly — depending on the fallback's role-suffix list is fragile
+    if pods are renamed.
+    """
+    env_id = os.environ.get("PRIME_RL_MX_TRAINING_RUN_ID", "").strip()
+    if env_id:
+        return env_id
+
+    hostname = socket.gethostname()
+    # Try to strip a recognized role suffix so all pods in one run
+    # converge on the same prefix. Order matters — match longest
+    # role names first.
+    for role in ("trainer", "inference", "rollout", "orchestrator"):
+        token = f"-{role}-"
+        idx = hostname.find(token)
+        if idx > 0:
+            return hostname[:idx]
+    # Fallback to bare hostname-minus-ordinal. Will *not* match across
+    # roles; logged as warning so the misconfiguration is visible.
+    parts = hostname.rsplit("-", 1)
+    if len(parts) == 2 and parts[1].isdigit():
+        derived = parts[0]
+    else:
+        derived = hostname
+    logger.warning(
+        "[mx-rendezvous] PRIME_RL_MX_TRAINING_RUN_ID not set; falling back "
+        "to hostname-derived run_id=%r. This may differ across pod roles "
+        "(trainer/inference) and prevent rendezvous. Set the env var "
+        "explicitly in production.",
+        derived,
+    )
+    return derived
+
+
+def _get_model_name() -> str:
+    """Return the model name used for the rendezvous cohort key."""
+    return os.environ.get("PRIME_RL_MX_MODEL_NAME", "unknown").strip() or "unknown"
+
+
+def _build_identity(run_id: str, model_name: str) -> Any:
+    """Build a SourceIdentity keyed to (run_id, model_name) so concurrent
+    runs on the same MX Server don't collide.
+    """
+    from modelexpress import p2p_pb2  # type: ignore
+
+    identity = p2p_pb2.SourceIdentity(
+        mx_version="0.3.0",
+        mx_source_type=p2p_pb2.MX_SOURCE_TYPE_WEIGHTS,
+        model_name=model_name,
+        backend_framework=p2p_pb2.BACKEND_FRAMEWORK_VLLM,
+        tensor_parallel_size=1,
+        pipeline_parallel_size=1,
+        expert_parallel_size=1,
+        dtype="bfloat16",
+        quantization="",
+        extra_parameters={
+            "prime_rl_run_id": run_id,
+            "rendezvous_version": "v0.1",
+        },
+    )
+    return identity
+
+
+def discover_spg_coordinator(
+    role: str,
+    rank: int,
+    expected_trainer_ws: int,
+    expected_inference_ws: int,
+    fallback_host: str,
+    fallback_port: int,
+    timeout: float = _DEFAULT_TIMEOUT_SECONDS,
+) -> RendezvousEndpoint:
+    """Discover the SPG coordinator (host, port) via MX Server.
+
+    Protocol:
+    - Trainer rank 0 binds the SPG master on its local IP + ``fallback_port``
+      and publishes the endpoint to MX Server.
+    - All other participants (trainer ranks 1..N, inference ranks 0..M)
+      poll MX Server for the published endpoint.
+    - Once published+discovered, everyone returns the same endpoint and
+      proceeds to create SPG against it.
+
+    If ``mx_rendezvous_enabled()`` is False, this function is a no-op
+    that returns ``RendezvousEndpoint(fallback_host, fallback_port, "", "")``
+    — caller should check and skip the MX gRPC path in that case.
+
+    Args:
+        role: ``"trainer"`` or ``"inference"``.
+        rank: Global rank within ``role``.
+        expected_trainer_ws: Number of trainer ranks expected in cohort.
+        expected_inference_ws: Number of inference ranks expected.
+        fallback_host: Host to bind/use if ``rank == 0 and role == "trainer"``.
+        fallback_port: Port to bind/use if ``rank == 0 and role == "trainer"``.
+        timeout: Max seconds to wait for discovery.
+
+    Returns:
+        RendezvousEndpoint pointing to the SPG coordinator.
+
+    Raises:
+        RuntimeError: If rendezvous times out or fails.
+    """
+    if not mx_rendezvous_enabled():
+        return RendezvousEndpoint(
+            host=fallback_host,
+            port=fallback_port,
+            source_id="",
+            trainer_worker_id="",
+        )
+
+    from modelexpress import MxClient, p2p_pb2  # type: ignore
+
+    mx_url = os.environ["PRIME_RL_MX_RENDEZVOUS"]
+    run_id = _get_run_id()
+    model_name = _get_model_name()
+
+    logger.info(
+        "[mx-rendezvous] role=%s rank=%d mx_url=%s run_id=%s model=%s "
+        "expected_trainer_ws=%d expected_inference_ws=%d",
+        role,
+        rank,
+        mx_url,
+        run_id,
+        model_name,
+        expected_trainer_ws,
+        expected_inference_ws,
+    )
+
+    client = MxClient(server_url=mx_url)
+    identity = _build_identity(run_id, model_name)
+    is_coordinator = role == "trainer" and rank == 0
+
+    # Each participant gets a unique worker_id so the server can track us
+    # individually even if two replicas share a worker_rank.
+    my_worker_id = f"{run_id}-{role}-{rank}-{uuid.uuid4().hex[:8]}"
+
+    # Coordinator: publish the endpoint other participants will use.
+    if is_coordinator:
+        coordinator_host = _get_local_ip(fallback_host)
+        coordinator_port = fallback_port
+
+        # Empirically MX Server's get_metadata() only round-trips a subset
+        # of WorkerMetadata fields (nixl_metadata, status, updated_at).
+        # metadata_endpoint / agent_name come back empty. Stuff the SPG
+        # coordinates into the nixl_metadata bytes field so peer lookups
+        # actually survive the server round-trip. Format is a tiny self-
+        # describing UTF-8 string prefixed with a magic tag so callers
+        # know to parse it as a rendezvous endpoint rather than as a
+        # real NIXL agent blob.
+        coord_blob = (
+            f"{_RENDEZVOUS_BLOB_PREFIX}{coordinator_host}:{coordinator_port}"
+        ).encode("utf-8")
+
+        worker = p2p_pb2.WorkerMetadata(
+            worker_rank=rank,
+            nixl_metadata=coord_blob,
+            tensors=[],
+            status=p2p_pb2.SOURCE_STATUS_READY,
+            updated_at=int(time.time() * 1000),
+            metadata_endpoint=f"{coordinator_host}:{coordinator_port}",
+            agent_name=f"spg-coordinator-{run_id}",
+        )
+        source_id = client.publish_metadata(identity, worker, my_worker_id)
+        logger.info(
+            "[mx-rendezvous] coordinator published source_id=%s endpoint=%s:%d",
+            source_id,
+            coordinator_host,
+            coordinator_port,
+        )
+        # Coordinator also "discovers" itself so the return value is
+        # consistent across all ranks.
+        return RendezvousEndpoint(
+            host=coordinator_host,
+            port=coordinator_port,
+            source_id=source_id,
+            trainer_worker_id=my_worker_id,
+        )
+
+    # Non-coordinator: poll until we see the coordinator's publish.
+    #
+    # Catalog state can contain *multiple* workers with worker_rank=0 —
+    # the trainer coordinator (which encodes the SPG endpoint into
+    # nixl_metadata with our magic prefix) PLUS any inference rank 0
+    # / rollout-as-source rank 0 entries which carry empty
+    # nixl_metadata. Picking the first worker_rank==0 ref unconditionally
+    # may match a non-coordinator entry first, then loop forever waiting
+    # for an endpoint that's never going to materialize on that entry.
+    #
+    # Solution: scan all worker_rank==0 candidates per poll, fetch each
+    # one's metadata, and only accept the candidate whose nixl_metadata
+    # starts with _RENDEZVOUS_BLOB_PREFIX (the coordinator marker).
+    deadline = time.time() + timeout
+    backoff = _POLL_INTERVAL
+    attempts = 0
+    while time.time() < deadline:
+        attempts += 1
+        resp = client.list_sources(identity=identity)
+        coordinator_candidates = [ref for ref in resp.instances if ref.worker_rank == 0]
+        if not coordinator_candidates:
+            time.sleep(backoff)
+            backoff = min(backoff * 1.5, 2.0)
+            continue
+
+        endpoint = ""
+        coordinator_ref = None
+        for ref in coordinator_candidates:
+            meta_resp = client.get_metadata(ref.mx_source_id, ref.worker_id)
+            if not meta_resp.found:
+                continue
+            # MX Server's get_metadata strips metadata_endpoint/agent_name, so
+            # the coordinator encodes host:port into nixl_metadata prefixed
+            # with _RENDEZVOUS_BLOB_PREFIX. Skip any worker_rank==0 entry
+            # that doesn't carry that prefix — those are non-coordinator
+            # rank-0 publishers (inference rank 0, rollout-as-source).
+            blob = meta_resp.worker.nixl_metadata or b""
+            try:
+                decoded = blob.decode("utf-8", errors="replace")
+                if decoded.startswith(_RENDEZVOUS_BLOB_PREFIX):
+                    candidate_endpoint = decoded[len(_RENDEZVOUS_BLOB_PREFIX):]
+                    if ":" in candidate_endpoint:
+                        endpoint = candidate_endpoint
+                        coordinator_ref = ref
+                        break
+            except Exception:  # noqa: BLE001 — try next candidate
+                continue
+            # Forward-compat fallback: if a future MX Server version
+            # persists metadata_endpoint, accept that too — but only if
+            # it's non-empty (empty endpoint = non-coordinator entry).
+            legacy_endpoint = meta_resp.worker.metadata_endpoint
+            if legacy_endpoint and ":" in legacy_endpoint:
+                endpoint = legacy_endpoint
+                coordinator_ref = ref
+                break
+
+        if not endpoint or coordinator_ref is None:
+            time.sleep(backoff)
+            backoff = min(backoff * 1.5, 2.0)
+            continue
+        host_str, port_str = endpoint.rsplit(":", 1)
+        logger.info(
+            "[mx-rendezvous] role=%s rank=%d discovered coordinator=%s after %d polls",
+            role,
+            rank,
+            endpoint,
+            attempts,
+        )
+
+        # Also publish our own metadata so pipeline replication / peer
+        # recovery works — downstream code can call
+        # ``publish_rollout_source`` after receive finalizes.
+        worker = p2p_pb2.WorkerMetadata(
+            worker_rank=rank,
+            nixl_metadata=b"",
+            tensors=[],
+            status=p2p_pb2.SOURCE_STATUS_INITIALIZING,
+            updated_at=int(time.time() * 1000),
+            metadata_endpoint="",
+            agent_name=f"{role}-{run_id}-rank-{rank}",
+        )
+        try:
+            client.publish_metadata(identity, worker, my_worker_id)
+        except Exception as exc:  # noqa: BLE001 — cosmetic only
+            logger.warning("[mx-rendezvous] non-coordinator publish failed (non-fatal): %s", exc)
+
+        return RendezvousEndpoint(
+            host=host_str,
+            port=int(port_str),
+            source_id=coordinator_ref.mx_source_id,
+            trainer_worker_id=coordinator_ref.worker_id,
+        )
+
+    raise RuntimeError(
+        f"[mx-rendezvous] role={role} rank={rank} timed out after {timeout}s "
+        f"waiting for coordinator in model={model_name} run={run_id}"
+    )
+
+
+def _get_local_ip(fallback: str) -> str:
+    """Best-effort local IP discovery. Returns ``fallback`` (the configured
+    host, typically ``localhost`` or a service name) on failure.
+    """
+    if fallback not in ("localhost", "0.0.0.0", "127.0.0.1", ""):
+        # Caller already configured a specific host — trust it.
+        return fallback
+    try:
+        # Discover the primary outbound IP (doesn't actually send traffic).
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.connect(("8.8.8.8", 80))
+            return s.getsockname()[0]
+    except OSError:
+        return socket.gethostbyname(socket.gethostname())
+
+
+def publish_as_rollout_source(
+    source_id: str,
+    rank: int,
+    run_id: str | None = None,
+    model_name: str | None = None,
+) -> None:
+    """Publish the local rollout as an additional source for pipeline
+    replication.
+
+    Called from the inference worker after finalize() completes. Future
+    pollers for the same (model, rank) may discover this rollout as an
+    alternate source, reducing trainer NIC pressure.
+
+    No-op if pipeline replication is disabled.
+    """
+    if not pipeline_replication_enabled():
+        return
+    if not mx_rendezvous_enabled():
+        logger.warning(
+            "[mx-rendezvous] pipeline_replication requested but PRIME_RL_MX_RENDEZVOUS "
+            "is not set; skipping rollout-source publish"
+        )
+        return
+
+    from modelexpress import MxClient, p2p_pb2  # type: ignore
+
+    mx_url = os.environ["PRIME_RL_MX_RENDEZVOUS"]
+    run_id = run_id or _get_run_id()
+    model_name = model_name or _get_model_name()
+
+    client = MxClient(server_url=mx_url)
+    identity = _build_identity(run_id, model_name)
+
+    # Secondary source uses a fresh worker_id and marks itself READY.
+    # Future pollers will see multiple workers for this rank and can
+    # pick any of them.
+    my_worker_id = f"{run_id}-rollout-source-{rank}-{uuid.uuid4().hex[:8]}"
+    worker = p2p_pb2.WorkerMetadata(
+        worker_rank=rank,
+        nixl_metadata=b"",  # stub; real impl would pass our agent_meta
+        tensors=[],
+        status=p2p_pb2.SOURCE_STATUS_READY,
+        updated_at=int(time.time() * 1000),
+        metadata_endpoint="",
+        agent_name=f"rollout-source-{run_id}-rank-{rank}",
+    )
+    try:
+        client.publish_metadata(identity, worker, my_worker_id)
+        logger.info(
+            "[mx-rendezvous] published rollout-as-source rank=%d worker_id=%s",
+            rank,
+            my_worker_id,
+        )
+    except Exception as exc:  # noqa: BLE001 — non-fatal
+        logger.warning("[mx-rendezvous] rollout-source publish failed (non-fatal): %s", exc)


### PR DESCRIPTION
## Summary

Additive overlay on top of your NIXL weight-transfer PR that replaces the hard-coded SPG host/port rendezvous with an MX-Server-mediated discovery plane when `PRIME_RL_MX_RENDEZVOUS` is set in the pod environment. Default (unset) preserves 100% of the upstream behavior — SPG/host/port work exactly as today.

This is not a replacement for your NIXL transport. It's a thin ~600-LOC layer on top that makes the transport discoverable via a central registry service, which in turn unlocks:

- **Dynamic pod startup ordering** — trainer and inference pods no longer need to pre-agree on an IP:port. Trainer rank 0 publishes its endpoint; others find it by polling.
- **Pipeline replication** (TensorHub pattern) — after a rollout receives weights, it re-publishes itself as an additional source so subsequent pollers can pull from it instead of the trainer. Amplifies aggregate bandwidth past the trainer NIC cap.
- **Peer recovery** (infrastructure only in v0.1; full demo in v0.2) — a restarting pod can discover any surviving peer holding the current version rather than always bouncing back to the trainer.
- **Cross-framework** — the same `MxTrainingPublisher` / `MxRefitReceiver` client is already used by `MxCheckpointEngine` in verl. One metadata plane shared across frameworks.

## Scope

Intentionally narrow for v0.1:

- Replaces **initialization** rendezvous only. Per-step `spg.barrier()` calls remain unchanged from your code.
- Opt-in via env var. No config plumbing into `NIXLWeightBroadcastConfig` (deliberate — keeps the diff small and reviewable; can promote to first-class config in a follow-up once the approach is accepted).
- Code is purely additive in `TransportPlan` / `NIXLWeightBroadcast` / `NIXLWeightUpdateWorker`. Each site is a single `if mx_rendezvous_enabled(): endpoint = discover_spg_coordinator(...)` before the existing SPG.create call.

What we explicitly didn't touch:

- Your NIXL data path (post-write RDMA is byte-identical).
- Your FP8 `ConversionSpec` / `QuantizationSpec`.
- Your `ExpertSlot` / `ShardedSlot` / `GatheredSlot` abstractions.
- `classic_cuda_pool` allocator.
- HSDP primary-replica protocol.

## Files Changed

| File | Change | Why |
|------|--------|-----|
| `src/prime_rl/utils/mx_rendezvous.py` | new (~350 LOC) | MX-mediated coordinator discovery + pipeline-replication publisher. No-op unless `PRIME_RL_MX_RENDEZVOUS` set. |
| `src/prime_rl/trainer/rl/broadcast/nixl.py` | +24 LOC | Dispatch: on init, if env enabled, call `discover_spg_coordinator`; else use `config.host/port` as today. |
| `src/prime_rl/inference/vllm/worker/nixl.py` | +45 LOC | Same dispatch, plus opt-in `publish_as_rollout_source()` call after receive for pipeline replication. |
| `docker/Dockerfile.mx-on-nixl` | new | Extends `Dockerfile.cuda`: installs UCX 1.19.x + NIXL 0.10.1 via your existing `scripts/install_nixl_from_source.sh`, then clones & installs the MX client from `ai-dynamo/modelexpress@kavink/RL`. |
| `k8s/prime-rl-mx-on-nixl/*.yaml` | new | Sample 2-node GB200 deployment manifests (trainer + inference + orchestrator). Used for our benchmark run. |
| `k8s/prime-rl-mx-on-nixl/run.sh` | new | One-line scenario flip: `./run.sh deploy {A|B|C}`. |

## Environment Variables (opt-in surface)

| Var | Default | Effect |
|-----|---------|--------|
| `PRIME_RL_MX_RENDEZVOUS` | unset | When set to a MX Server `host:port`, replaces static SPG rendezvous with MX-mediated discovery. When unset, upstream behavior preserved. |
| `PRIME_RL_MX_MODEL_NAME` | `unknown` | Cohort key on MX Server. Use HF model ID. |
| `PRIME_RL_MX_TRAINING_RUN_ID` | derived from hostname | Ensures multiple concurrent runs on the same MX Server don't collide. |
| `PRIME_RL_MX_PIPELINE_REPLICATION` | `0` | `1` to enable rollout-as-source publishing after receive. |
| `PRIME_RL_MX_TRANSFER_MODE` | `direct` | `scratch` staging mode (plumbed, wiring in follow-up). |

## Benchmark Scenarios (GB200, 2-node, Qwen3-0.6B reverse-text)

| # | Config | What it demonstrates |
|---|--------|---------------------|
| A | No env vars | Baseline — your PR's code as-is on our GB200 cluster |
| B | `PRIME_RL_MX_RENDEZVOUS` set | MX-mediated SPG host/port discovery. Parity expected on data path. |
| C | B + `PIPELINE_REPLICATION=1` | Rollout-as-source; multi-inference-pod scale-out benefit |

**Status (this PR)**: scenarios A+B+C results pending first successful image build. Results table will be filled in as scenarios run.

## Why build on your PR instead of merging after it lands?

1. The metadata-plane value is additive, not a redesign. "Optional flag behind existing NIXL code" is the cleanest framing.
2. Catching review feedback pre-merge is cheaper than post-merge for both of us.
3. This PR being against `nixl-weight-transfer` (not main) is an explicit signal: we're layering on top, not competing.

If/when #2326 merges, we'll retarget this PR to `main`.

## Related Work

- The MX Server + client live at [ai-dynamo/modelexpress](https://github.com/ai-dynamo/modelexpress) (`kavink/RL` branch). Design notes in `docs/RL/PRIMERL_MX_OVERVIEW.md` on that repo cover the full architecture including DAG semantics and peer-recovery.
- The same `MxTrainingPublisher` / `MxRefitReceiver` pair powers our verl POC (`MxCheckpointEngine`). Cross-framework story covered in `docs/RL/VERL_MX_OVERVIEW.md`.

## Follow-ups (Not in This PR)

- MX-mediated per-step barriers (replaces remaining SPG dependency — enables true elastic mid-run pod join).
- `transfer_mode: scratch` wiring end-to-end (isolates KL-drift class of bugs via staging buffers).
- MX Server source-index + heartbeat reaper (currently client reconstructs from `list_sources`; moving to server-side makes `poll_for_sources` ranked/locality-aware).
- First-class `rendezvous` / `pipeline_replication` / `transfer_mode` fields on `NIXLWeightBroadcastConfig`.

## A Note on the KL Drift Investigation

The scratch-mode toggle was designed specifically as a diagnostic for your investigation — it lets you A/B the direct-refit target against a `load_weights()`-staged target using the exact same NIXL transport. If the drift reproduces in `transfer_mode: direct` but not `scratch`, it's in the direct-refit target layout. If it reproduces in both, it's transport-level. Happy to run this on the iter26/27 configuration if useful.

## Checklist

- [ ] GB200 scenario A passes (baseline)
- [ ] GB200 scenario B passes (MX rendezvous parity)
- [ ] GB200 scenario C passes (pipeline replication)
- [ ] Results table filled in
- [ ] Ready-for-review flip (remove draft status)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the NIXL weight-transfer initialization and inference API routing, plus adds new diagnostic code paths; misconfiguration or upstream vLLM/MX behavior changes could cause rendezvous/weight update failures despite being opt-in via env vars.
> 
> **Overview**
> Adds an **opt-in ModelExpress (MX) rendezvous overlay** for NIXL weight transfer: when `PRIME_RL_MX_RENDEZVOUS` is set, trainer and inference discover the SPG coordinator via MX Server (new `mx_rendezvous.py`) and inference can optionally republish itself as an additional rollout source (`PRIME_RL_MX_PIPELINE_REPLICATION=1`).
> 
> Extends inference serving to support **torch profiler wiring** (`torch_profiler_dir`) and works around **vLLM >=0.19 route conflicts** by stripping built-in RLHF endpoints so PrimeRL’s `/update_weights`/NIXL routes win.
> 
> Adds diagnostics and platform support: a `PRIME_RL_NIXL_SERIAL_PUSH=1` serial gather/push path in `TransportPlan`, Qwen3 dense conversion-spec monkey patching, updated Qwen3MoE conversion specs, and ARM64/GB200 container + K8s manifests (including flash-attn stubs, libcudart preload fixes, and a log parser for NIXL/MX metrics).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc55e4f162fd39a5455cc7037d7a0cb88bc8c954. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->