### PR TITLE
Fix shared W&B config display

### DIFF
--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -18,6 +18,22 @@ from prime_rl.utils.logger import get_logger
 from prime_rl.utils.monitor.base import Monitor, sample_items_for_logging
 
 
+def _flatten_run_config(data: dict[str, Any], prefix: str) -> dict[str, Any]:
+    """Flatten a nested config dict into slash-delimited W&B keys under a namespace."""
+    flat: dict[str, Any] = {}
+
+    def _walk(value: Any, path: str) -> None:
+        if isinstance(value, dict):
+            for key, child in value.items():
+                next_path = f"{path}/{key}" if path else str(key)
+                _walk(child, next_path)
+        else:
+            flat[path] = value
+
+    _walk(data, prefix)
+    return flat
+
+
 class WandbMonitor(Monitor):
     """Logs to Weights and Biases."""
 
@@ -63,10 +79,12 @@ class WandbMonitor(Monitor):
             )
         else:
             run_id = None
+            label = None
             primary = False
             settings = wandb.Settings(
                 mode="offline" if config.offline else "online",
             )
+        init_config = None if shared_mode else (run_config.model_dump() if run_config else None)
 
         def init_wandb(max_retries: int):
             for attempt in range(max_retries):
@@ -76,7 +94,7 @@ class WandbMonitor(Monitor):
                         project=config.project,
                         name=config.name,
                         dir=output_dir,
-                        config=run_config.model_dump() if run_config else None,
+                        config=init_config,
                         settings=settings,
                     )
                 except CommError:
@@ -89,6 +107,12 @@ class WandbMonitor(Monitor):
 
         max_retries = 1 if not shared_mode or primary else 30
         self.wandb = init_wandb(max_retries)
+        if shared_mode and run_config is not None:
+            config_label = label or "shared"
+            self.wandb.config.update(
+                _flatten_run_config(run_config.model_dump(), prefix=config_label),
+                allow_val_change=True,
+            )
 
         wandb.define_metric("*", step_metric="step")
 


### PR DESCRIPTION
Closes #2342

In shared W&B mode, the orchestrator currently ends up owning the run config because we pass `run_config.model_dump()` into `wandb.init(...)`. That makes the config panel misleading for fields like `optim.lr`, even though the logged metrics are correct.

This keeps non-shared mode unchanged, and in shared mode writes config under namespaced keys like `orchestrator/...` and `trainer/...` instead of a misleading top-level config.

Validation:
- `ruff format --check --config=pyproject.toml .`
- `ruff check --config=pyproject.toml .`
- verified locally with a focused smoke test that:
  - shared mode no longer sets top-level config through `wandb.init(...)`
  - shared mode writes namespaced config for orchestrator and trainer
  - non-shared mode behaves the same as before

I also tried running the full unit suite locally, but some unrelated tests are blocked in my environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to W&B initialization/config logging behavior and should not affect training logic, but could alter how configs appear or update in shared runs.
> 
> **Overview**
> Fixes shared Weights & Biases runs so `run_config` is no longer passed via `wandb.init(...)`, preventing one process from “owning” the top-level config.
> 
> In shared mode, the monitor now flattens and writes config entries under a label namespace (e.g., `orchestrator/...`, `trainer/...`) via `wandb.config.update(..., allow_val_change=True)`, while keeping non-shared mode config logging unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09fd7e775d1d3b2c988aab4c2d807c4dad65596f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->