### PR TITLE
Fix gemma

### DIFF
--- a/oink.sh
+++ b/oink.sh
@@ -1,0 +1,9 @@
+uv run orchestrator @ orchestrator.toml \
+  --train.sampling.max-completion-tokens 256 \
+  --output_dir outputs/run_woof \
+  --wandb.project gemma4-debug \
+  --wandb.name original-impl \
+  --num-train-workers 1 \
+  --model.lora.name r8-1e-4-meow \
+  --model.lora.rank 16 \
+  --log.level debug

--- a/orchestrator.toml
+++ b/orchestrator.toml
@@ -1,0 +1,28 @@
+# Orchestrator config for multi-run RL integration test
+# model.lora.name and output_dir are set via CLI
+batch_size = 1024
+rollouts_per_example = 16
+seq_len = 2048
+max_steps = 200
+
+[model]
+name = "google/gemma-4-26B-A4B-it"
+
+[optim]
+lr = 2e-4
+
+[sampling]
+max_tokens = 256
+
+[sampling.extra_body]
+chat_template_kwarg = { enable_thinking = false }
+
+[[env]]
+id = "ivanleomk/reverse-chinese"
+
+[ckpt]
+interval = 10
+resume_step = -1
+
+[prime_monitor]
+run_name = "gemma4-debug"

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -18,6 +18,7 @@ def transformers_v5_compat():
     monkey_patch_deep_gemm_ep_scatter()
     monkey_patch_dp_engine_core_pause_resume_deadlock()
     monkey_patch_offloading_connector_cpu_block_count()
+    monkey_patch_gemma4()
 
 
 @triton.jit
@@ -996,6 +997,55 @@ def monkey_patch_offloading_connector_cpu_block_count():
         )
 
     CPUOffloadingSpec.__init__ = _patched_init
+
+
+def monkey_patch_gemma4():
+    """Patch Gemma4 model classes for MoE weight loading and LoRA.
+
+    1. Add Gemma4ForCausalLM.get_expert_mapping() — the MoE weight-loading
+       path uses it to map checkpoint expert weights onto FusedMoE's fused
+       w13/w2 params.
+    2. Set Gemma4ForCausalLM.hf_to_vllm_mapper so the conditional-generation
+       checkpoint prefix (`model.language_model.`) and its MoE adapter key
+       layout are translated onto the text-only Gemma4ForCausalLM tree.
+    3. Mark Gemma4ForConditionalGeneration as LoRA-capable. vLLM's
+       supports_lora() is a runtime_checkable Protocol keyed on the
+       attributes below — so attribute assignment is enough.
+    """
+    from vllm.model_executor.layers.fused_moe import FusedMoE
+    from vllm.model_executor.models.gemma4 import Gemma4ForCausalLM
+    from vllm.model_executor.models.gemma4_mm import Gemma4ForConditionalGeneration
+    from vllm.model_executor.models.utils import WeightsMapper
+
+    def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
+        return FusedMoE.make_expert_params_mapping(
+            self,
+            ckpt_gate_proj_name="gate_proj",
+            ckpt_down_proj_name="down_proj",
+            ckpt_up_proj_name="up_proj",
+            num_experts=self.config.num_experts,
+            num_redundant_experts=self.num_redundant_experts,
+        )
+
+    Gemma4ForCausalLM.get_expert_mapping = get_expert_mapping
+    Gemma4ForCausalLM.hf_to_vllm_mapper = WeightsMapper(
+        orig_to_new_prefix={
+            "model.language_model.": "model.",
+        },
+        orig_to_new_substr={
+            ".moe.experts.gate_up_proj": ".moe.gate_up_proj",
+            ".moe.experts.down_proj": ".moe.down_proj",
+        },
+    )
+
+    # The instance-level `isinstance(model, SupportsLoRA)` check enforces the
+    # full Protocol body, so we must set every ClassVar declared on it — not
+    # just the three the class-level `_SupportsLoRAType` check looks at.
+    Gemma4ForConditionalGeneration.supports_lora = True
+    Gemma4ForConditionalGeneration.embedding_modules = {}
+    Gemma4ForConditionalGeneration.is_3d_moe_weight = False
+    Gemma4ForConditionalGeneration.is_non_gated_moe = False
+    Gemma4ForConditionalGeneration.lora_skip_prefixes = []
 
 
 def monkey_patch_no_moe_lora():

--- a/src/prime_rl/trainer/lora.py
+++ b/src/prime_rl/trainer/lora.py
@@ -6,8 +6,30 @@ import torch.nn as nn
 
 from prime_rl.configs.trainer import LoRAConfig
 from prime_rl.trainer.models.layers.lora import MultiLoRALinear, MultiLoRAModule
-from prime_rl.trainer.models.layers.lora.multi_moe import MultiLoRAGroupedExperts, MultiLoRANonGatedGroupedExperts
+from prime_rl.trainer.models.layers.lora.multi_moe import (
+    MultiLoRAGemma4Experts,
+    MultiLoRAGroupedExperts,
+    MultiLoRANonGatedGroupedExperts,
+)
 from prime_rl.trainer.models.layers.moe import GroupedExperts, NonGatedGroupedExperts
+
+
+def _expert_module_types() -> tuple[type, ...]:
+    """Return the tuple of expert container types LoRA can target.
+
+    Gemma4TextExperts comes from transformers; import it lazily so the
+    trainer stays importable on environments without that model.
+    """
+    types: list[type] = [GroupedExperts, NonGatedGroupedExperts]
+    try:
+        from transformers.models.gemma4.modeling_gemma4 import Gemma4TextExperts
+
+        types.append(Gemma4TextExperts)
+    except Exception:
+        pass
+    return tuple(types)
+
+
 from prime_rl.trainer.runs import get_multi_run_manager
 from prime_rl.utils.logger import get_logger
 
@@ -73,9 +95,10 @@ def _find_target_modules(model: nn.Module, target_patterns: List[str]) -> List[s
     """
     target_modules = []
 
+    expert_types = _expert_module_types()
     for name, module in model.named_modules():
-        # Check if module is Linear or (NonGated)GroupedExperts
-        if not isinstance(module, (nn.Linear, GroupedExperts, NonGatedGroupedExperts)):
+        # Check if module is Linear or a known expert container
+        if not isinstance(module, (nn.Linear, *expert_types)):
             continue
 
         for pattern in target_patterns:
@@ -187,10 +210,19 @@ def apply_lora_to_model(model: nn.Module, config: LoRAConfig) -> None:
                 alpha=config.alpha,
                 dropout=config.dropout,
             )
+        # Handle HF Gemma4TextExperts (packed gate_up_proj + down_proj)
+        elif type(base_module).__name__ == "Gemma4TextExperts":
+            lora_module = MultiLoRAGemma4Experts(
+                base_layer=base_module,
+                rank=config.rank,
+                n_adapters=n_loras,
+                alpha=config.alpha,
+                dropout=config.dropout,
+            )
         else:
             logger.warning(
                 f"Module {module_name} is type {type(base_module).__name__}, "
-                f"expected nn.Linear, GroupedExperts, or NonGatedGroupedExperts. Skipping."
+                f"expected nn.Linear, GroupedExperts, NonGatedGroupedExperts, or Gemma4TextExperts. Skipping."
             )
             continue
 

--- a/src/prime_rl/trainer/lora.py
+++ b/src/prime_rl/trainer/lora.py
@@ -92,11 +92,24 @@ def _find_target_modules(model: nn.Module, target_patterns: List[str]) -> List[s
     (e.g., r".*\\.q_proj$"). Simple names match any component in the module path.
 
     Supports both nn.Linear layers and GroupedExperts (MoE) modules.
+
+    For VLMs registered in VLM_REGISTRY, search is restricted to the language
+    model subtree. Otherwise a bare pattern like "q_proj" would also match
+    vision/audio tower projections, and those LoRAs have no destination in
+    inference-side causal-LM trees (vLLM rejects the adapter on load).
     """
+    from prime_rl.utils.vlm import VLM_REGISTRY
+
+    model_type = getattr(getattr(model, "config", None), "model_type", None)
+    vlm_info = VLM_REGISTRY.get(model_type) if model_type else None
+    lm_prefix = (vlm_info.language_model_attr + ".") if vlm_info is not None else None
+
     target_modules = []
 
     expert_types = _expert_module_types()
     for name, module in model.named_modules():
+        if lm_prefix is not None and not name.startswith(lm_prefix):
+            continue
         # Check if module is Linear or a known expert container
         if not isinstance(module, (nn.Linear, *expert_types)):
             continue

--- a/src/prime_rl/trainer/models/__init__.py
+++ b/src/prime_rl/trainer/models/__init__.py
@@ -10,6 +10,7 @@ from transformers.models.llama.configuration_llama import LlamaConfig
 
 from prime_rl.trainer.models.afmoe import AfmoeConfig, AfmoeForCausalLM
 from prime_rl.trainer.models.base import PreTrainedModelPrimeRL
+from prime_rl.trainer.models.gemma4 import Gemma4Config, Gemma4ForCausalLM
 from prime_rl.trainer.models.glm4_moe import Glm4MoeConfig, Glm4MoeForCausalLM
 from prime_rl.trainer.models.glm_moe_dsa import GlmMoeDsaConfig, GlmMoeDsaForCausalLM
 from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput, cast_float_and_contiguous
@@ -21,6 +22,7 @@ from prime_rl.trainer.models.qwen3_moe import Qwen3MoeConfig, Qwen3MoeForCausalL
 
 # Make custom config discoverable by AutoConfig
 AutoConfig.register("afmoe", AfmoeConfig, exist_ok=True)
+AutoConfig.register("gemma4_text", Gemma4Config, exist_ok=True)
 AutoConfig.register("glm4_moe", Glm4MoeConfig, exist_ok=True)
 AutoConfig.register("glm_moe_dsa", GlmMoeDsaConfig, exist_ok=True)
 AutoConfig.register("minimax_m2", MiniMaxM2Config, exist_ok=True)
@@ -31,6 +33,7 @@ AutoConfig.register("qwen3_5_moe_text", Qwen3_5MoeConfig, exist_ok=True)
 _CUSTOM_CAUSAL_LM_MAPPING = _LazyAutoMapping(CONFIG_MAPPING_NAMES, OrderedDict())
 _CUSTOM_CAUSAL_LM_MAPPING.register(LlamaConfig, LlamaForCausalLM, exist_ok=True)
 _CUSTOM_CAUSAL_LM_MAPPING.register(AfmoeConfig, AfmoeForCausalLM, exist_ok=True)
+_CUSTOM_CAUSAL_LM_MAPPING.register(Gemma4Config, Gemma4ForCausalLM, exist_ok=True)
 _CUSTOM_CAUSAL_LM_MAPPING.register(Glm4MoeConfig, Glm4MoeForCausalLM, exist_ok=True)
 _CUSTOM_CAUSAL_LM_MAPPING.register(GlmMoeDsaConfig, GlmMoeDsaForCausalLM, exist_ok=True)
 _CUSTOM_CAUSAL_LM_MAPPING.register(MiniMaxM2Config, MiniMaxM2ForCausalLM, exist_ok=True)

--- a/src/prime_rl/trainer/models/gemma4/__init__.py
+++ b/src/prime_rl/trainer/models/gemma4/__init__.py
@@ -1,0 +1,13 @@
+from prime_rl.trainer.models.gemma4.configuration_gemma4 import Gemma4Config
+from prime_rl.trainer.models.gemma4.modeling_gemma4 import (
+    Gemma4ForCausalLM,
+    Gemma4Model,
+    Gemma4PreTrainedModel,
+)
+
+__all__ = [
+    "Gemma4Config",
+    "Gemma4ForCausalLM",
+    "Gemma4Model",
+    "Gemma4PreTrainedModel",
+]

--- a/src/prime_rl/trainer/models/gemma4/configuration_gemma4.py
+++ b/src/prime_rl/trainer/models/gemma4/configuration_gemma4.py
@@ -1,0 +1,28 @@
+"""Prime-RL Gemma4 text config.
+
+Subclasses HF's Gemma4TextConfig to inherit all field definitions, then adds
+prime-rl-specific knobs (e.g. grouped_mm toggle for MoE).
+
+Keeping the HF field set intact means:
+  - config JSONs from the HF hub load unchanged
+  - layer_types / rope_parameters / hidden_size_per_layer_input / etc. all
+    flow through without having to re-derive them here.
+"""
+
+from transformers.models.gemma4.configuration_gemma4 import Gemma4TextConfig as HFGemma4TextConfig
+
+
+class Gemma4Config(HFGemma4TextConfig):
+    """Gemma4 text config, extended with prime-rl knobs.
+
+    The HF model_type is ``gemma4_text`` for the text-only stack; we keep that
+    so ``AutoConfig`` round-trips and existing checkpoints load unchanged.
+    """
+
+    model_type = "gemma4_text"
+
+    def __init__(self, *args, use_grouped_mm: bool = False, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Used by prime-rl's GroupedExperts path; Gemma4TextExperts uses a
+        # packed (gate+up) layout so we default off.
+        self.use_grouped_mm = use_grouped_mm

--- a/src/prime_rl/trainer/models/gemma4/converting_gemma4.py
+++ b/src/prime_rl/trainer/models/gemma4/converting_gemma4.py
@@ -1,0 +1,30 @@
+"""Weight key conversions between HF and prime-rl for Gemma4.
+
+Our prime-rl Gemma4 mirrors HF's weight layout (same param names under
+``model.layers.{i}.*``, packed ``experts.gate_up_proj`` / ``experts.down_proj``,
+per-head q/k/v norms, etc.). So conversion is a no-op — both sides agree.
+
+These stubs exist for symmetry with other model ports; future customizations
+(e.g. switching experts to a GroupedExperts-style layout with w1/w2/w3) would
+land here.
+"""
+
+from __future__ import annotations
+
+from torch import Tensor
+
+
+def convert_hf_to_prime(state_dict: dict[str, Tensor]) -> dict[str, Tensor]:
+    return state_dict
+
+
+def convert_prime_to_hf(state_dict: dict[str, Tensor]) -> dict[str, Tensor]:
+    return state_dict
+
+
+def convert_hf_layer_to_prime(state_dict: dict[str, Tensor], layer_idx: int) -> dict[str, Tensor]:
+    return state_dict
+
+
+def convert_prime_layer_to_hf(state_dict: dict[str, Tensor], layer_idx: int) -> dict[str, Tensor]:
+    return state_dict

--- a/src/prime_rl/trainer/models/gemma4/modeling_gemma4.py
+++ b/src/prime_rl/trainer/models/gemma4/modeling_gemma4.py
@@ -1,0 +1,838 @@
+# coding=utf-8
+# Copyright 2024 Google Inc. HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Prime-RL Gemma4 text-only modeling.
+
+Started as a verbatim copy of ``transformers.models.gemma4.modeling_gemma4`` (text
+portion only), then edited in-place for prime-rl conventions. The attention
+module is ours — it dispatches to prime-rl's ``FlashAttention``/``SDPAAttention``
+primitives instead of HF's ``ALL_ATTENTION_FUNCTIONS`` registry, so we own the
+(sliding-window + packed-varlen) code path.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional, Union
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor, nn
+from transformers.activations import ACT2FN
+from transformers.generation import GenerationMixin
+from transformers.modeling_layers import GradientCheckpointingLayer
+from transformers.modeling_outputs import BaseModelOutputWithPast
+from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
+from transformers.processing_utils import Unpack
+from transformers.utils import TransformersKwargs, auto_docstring, can_return_tuple, logging
+
+# Flash-attn imports (same dispatch prime-rl uses elsewhere).
+try:
+    from flash_attn import flash_attn_varlen_func as flash_attn_2_varlen_func
+except ImportError:
+    flash_attn_2_varlen_func = None  # type: ignore
+
+try:
+    from flash_attn_interface import flash_attn_varlen_func as flash_attn_3_varlen_func
+except ImportError:
+    flash_attn_3_varlen_func = None  # type: ignore
+
+from prime_rl.trainer.models.base import PreTrainedModelPrimeRL
+from prime_rl.trainer.models.gemma4.configuration_gemma4 import Gemma4Config
+from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput
+
+logger = logging.get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Norm, rotary, MLP, experts, router — vendored verbatim from HF.
+# ---------------------------------------------------------------------------
+
+
+class Gemma4RMSNorm(nn.Module):
+    def __init__(self, dim: int, eps: float = 1e-6, with_scale: bool = True):
+        super().__init__()
+        self.eps = eps
+        self.with_scale = with_scale
+        if self.with_scale:
+            self.weight = nn.Parameter(torch.ones(dim))
+
+    def _norm(self, hidden_states: torch.Tensor):
+        mean_squared = hidden_states.pow(2).mean(-1, keepdim=True) + self.eps
+        return hidden_states * torch.pow(mean_squared, -0.5)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        normed_output = self._norm(hidden_states.float())
+        if self.with_scale:
+            normed_output = normed_output * self.weight.float()
+        return normed_output.type_as(hidden_states)
+
+
+def rotate_half(x: torch.Tensor) -> torch.Tensor:
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def apply_rotary_pos_emb(
+    x: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    unsqueeze_dim: int = 1,
+) -> torch.Tensor:
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+    return (x * cos) + (rotate_half(x) * sin)
+
+
+class Gemma4TextRotaryEmbedding(nn.Module):
+    """Per-layer-type RoPE.
+
+    Gemma4 uses different RoPE parameters (and possibly different head_dim via
+    ``global_head_dim``) for sliding vs full attention, so this module keeps a
+    separate inv_freq per layer_type.
+    """
+
+    def __init__(self, config: Gemma4Config, device: Optional[torch.device] = None):
+        super().__init__()
+        self.max_seq_len_cached = config.max_position_embeddings
+        self.original_max_seq_len = config.max_position_embeddings
+        self.config = config
+        self.layer_types = set(config.layer_types)
+        self.rope_init_fns: dict[str, Callable] = {}
+        self.rope_type: dict[str, str] = {}
+
+        for layer_type in self.layer_types:
+            rope_params = config.rope_parameters[layer_type]
+            if rope_params is None:
+                continue
+            rope_type = rope_params["rope_type"]
+            if rope_type != "default":
+                rope_init_fn = ROPE_INIT_FUNCTIONS[rope_type]
+            else:
+                rope_init_fn = self._default_rope_parameters
+            self.rope_init_fns[layer_type] = rope_init_fn
+            self.rope_type[layer_type] = rope_type
+
+            kwargs = {"device": device, "layer_type": layer_type}
+            if layer_type == "full_attention" and rope_type == "proportional":
+                kwargs["head_dim_key"] = "global_head_dim"
+            curr_inv_freq, curr_attention_scaling = rope_init_fn(config, **kwargs)
+            self.register_buffer(f"{layer_type}_inv_freq", curr_inv_freq, persistent=False)
+            self.register_buffer(f"{layer_type}_original_inv_freq", curr_inv_freq.clone(), persistent=False)
+            setattr(self, f"{layer_type}_attention_scaling", curr_attention_scaling)
+
+    @staticmethod
+    def _default_rope_parameters(
+        config: Gemma4Config | None = None,
+        device: Optional[torch.device] = None,
+        seq_len: Optional[int] = None,
+        layer_type: Optional[str] = None,
+    ) -> tuple[torch.Tensor, float]:
+        base = config.rope_parameters[layer_type]["rope_theta"]
+        dim = getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads
+        inv_freq = 1.0 / (
+            base ** (torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float) / dim)
+        )
+        return inv_freq, 1.0
+
+    @torch.no_grad()
+    @dynamic_rope_update
+    def forward(self, x: torch.Tensor, position_ids: torch.Tensor, layer_type: str):
+        inv_freq = getattr(self, f"{layer_type}_inv_freq")
+        attention_scaling = getattr(self, f"{layer_type}_attention_scaling")
+        inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+        position_ids_expanded = position_ids[:, None, :].float()
+        device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+        with torch.autocast(device_type=device_type, enabled=False):
+            freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
+            emb = torch.cat((freqs, freqs), dim=-1)
+            cos = emb.cos() * attention_scaling
+            sin = emb.sin() * attention_scaling
+        return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
+
+
+class Gemma4TextMLP(nn.Module):
+    """Dense MLP that runs in parallel to the MoE block at each decoder layer."""
+
+    def __init__(self, config: Gemma4Config, layer_idx: int):
+        super().__init__()
+        first_kv_shared_layer_idx = config.num_hidden_layers - config.num_kv_shared_layers
+        is_kv_shared_layer = layer_idx >= first_kv_shared_layer_idx > 0
+        use_double_wide_mlp = getattr(config, "use_double_wide_mlp", False) and is_kv_shared_layer
+        self.hidden_size = config.hidden_size
+        self.intermediate_size = config.intermediate_size * (2 if use_double_wide_mlp else 1)
+        self.gate_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+        self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+        self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
+        self.act_fn = ACT2FN[config.hidden_activation]
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
+
+
+class Gemma4TextExperts(nn.Module):
+    """MoE experts with packed (gate+up) projection. Mirrors HF's layout."""
+
+    def __init__(self, config: Gemma4Config):
+        super().__init__()
+        self.num_experts = config.num_experts
+        self.hidden_dim = config.hidden_size
+        self.intermediate_dim = config.moe_intermediate_size
+        self.gate_up_proj = nn.Parameter(torch.empty(self.num_experts, 2 * self.intermediate_dim, self.hidden_dim))
+        self.down_proj = nn.Parameter(torch.empty(self.num_experts, self.hidden_dim, self.intermediate_dim))
+        self.act_fn = ACT2FN[config.hidden_activation]
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        top_k_index: torch.Tensor,
+        top_k_weights: torch.Tensor,
+    ) -> torch.Tensor:
+        # Accumulate per-(token, top_k_slot) contributions in a 3D buffer, then
+        # reduce over the top_k dim with torch.sum's fp32 accumulator. Matches
+        # HF's grouped_mm / batched_mm forwards and avoids index_add_'s in-place
+        # bf16 accumulation (which loses ~1e-3 relative precision over 8 terms).
+        num_tokens, hidden_dim = hidden_states.shape
+        num_top_k = top_k_index.shape[-1]
+        weighted_out = torch.zeros(
+            (num_tokens, num_top_k, hidden_dim),
+            device=hidden_states.device,
+            dtype=hidden_states.dtype,
+        )
+        with torch.no_grad():
+            expert_mask = F.one_hot(top_k_index, num_classes=self.num_experts).permute(2, 1, 0)
+            expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
+
+        for expert_idx in expert_hit:
+            expert_idx = expert_idx[0]
+            if expert_idx == self.num_experts:
+                continue
+            top_k_pos, token_idx = torch.where(expert_mask[expert_idx])
+            current_state = hidden_states[token_idx]
+            gate, up = F.linear(current_state, self.gate_up_proj[expert_idx]).chunk(2, dim=-1)
+            current_hidden_states = self.act_fn(gate) * up
+            current_hidden_states = F.linear(current_hidden_states, self.down_proj[expert_idx])
+            current_hidden_states = current_hidden_states * top_k_weights[token_idx, top_k_pos, None]
+            # (token_idx, top_k_pos) pairs are disjoint across experts by construction.
+            weighted_out[token_idx, top_k_pos, :] = current_hidden_states.to(weighted_out.dtype)
+        return weighted_out.sum(dim=1).to(hidden_states.dtype)
+
+
+class Gemma4TextRouter(nn.Module):
+    def __init__(self, config: Gemma4Config):
+        super().__init__()
+        self.config = config
+        self.hidden_size = config.hidden_size
+        self.scalar_root_size = self.hidden_size**-0.5
+        self.eps = config.rms_norm_eps
+        self.norm = Gemma4RMSNorm(self.hidden_size, eps=self.eps, with_scale=False)
+        self.proj = nn.Linear(config.hidden_size, config.num_experts, bias=False)
+        self.scale = nn.Parameter(torch.ones(self.hidden_size))
+        self.per_expert_scale = nn.Parameter(torch.ones(config.num_experts))
+
+    def forward(self, hidden_states: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        hidden_states = self.norm(hidden_states)
+        hidden_states = hidden_states * self.scale * self.scalar_root_size
+        expert_scores = self.proj(hidden_states)
+        router_probabilities = F.softmax(expert_scores, dim=-1)
+        top_k_weights, top_k_index = torch.topk(router_probabilities, k=self.config.top_k_experts, dim=-1)
+        top_k_weights = top_k_weights / top_k_weights.sum(dim=-1, keepdim=True)
+        top_k_weights = top_k_weights * self.per_expert_scale[top_k_index]
+        return router_probabilities, top_k_weights, top_k_index
+
+
+# ---------------------------------------------------------------------------
+# Custom attention — the only block that deviates from HF.
+# ---------------------------------------------------------------------------
+
+
+def _repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
+    """Expand KV heads for GQA. Input shape: [B, Hkv, S, D]."""
+    if n_rep == 1:
+        return hidden_states
+    batch, num_kv, slen, head_dim = hidden_states.shape
+    return (
+        hidden_states[:, :, None, :, :]
+        .expand(batch, num_kv, n_rep, slen, head_dim)
+        .reshape(batch, num_kv * n_rep, slen, head_dim)
+    )
+
+
+class Gemma4Attention(nn.Module):
+    """Gemma4 attention with prime-rl-owned kernel dispatch.
+
+    Differences from HF's ``Gemma4TextAttention``:
+      - Dispatches to ``flash_attn_varlen_func`` (FA2/FA3) or ``F.scaled_dot_product_attention``
+        directly, rather than HF's ``ALL_ATTENTION_FUNCTIONS`` registry.
+      - Accepts ``cu_seqlens``/``max_seqlen`` for packed-sequence training (FA path).
+      - Does not implement KV cache sharing / past_key_values (training only).
+
+    Weight layout matches HF exactly so checkpoints load unchanged.
+    """
+
+    def __init__(self, config: Gemma4Config, layer_idx: int):
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+        self.layer_type = config.layer_types[layer_idx]
+        self.is_sliding = self.layer_type == "sliding_attention"
+        self.sliding_window = config.sliding_window if self.is_sliding else None
+
+        # Gemma4 has per-layer-type head_dim: sliding uses ``head_dim``, full uses
+        # ``global_head_dim`` (when set).
+        self.head_dim = (
+            config.global_head_dim
+            if (not self.is_sliding and getattr(config, "global_head_dim", None))
+            else config.head_dim
+        )
+
+        # "Alternative attention" layers (full_attention with attention_k_eq_v)
+        # have no v_proj; V reuses K.
+        self.use_alternative_attention = getattr(config, "attention_k_eq_v", False) and not self.is_sliding
+        num_kv_heads = (
+            config.num_global_key_value_heads if self.use_alternative_attention else config.num_key_value_heads
+        )
+        self.num_heads = config.num_attention_heads
+        self.num_kv_heads = num_kv_heads
+        self.num_kv_groups = self.num_heads // num_kv_heads
+        # Gemma4's effective scaling is absorbed into q_norm / k_norm, so the
+        # attention kernel itself runs with scale=1.0.
+        self.scaling = 1.0
+
+        # Projections
+        bias = config.attention_bias
+        self.q_proj = nn.Linear(config.hidden_size, self.num_heads * self.head_dim, bias=bias)
+        self.k_proj = nn.Linear(config.hidden_size, num_kv_heads * self.head_dim, bias=bias)
+        self.v_proj = (
+            None
+            if self.use_alternative_attention
+            else nn.Linear(config.hidden_size, num_kv_heads * self.head_dim, bias=bias)
+        )
+        self.o_proj = nn.Linear(self.num_heads * self.head_dim, config.hidden_size, bias=bias)
+
+        # Per-head Q/K/V norms. V is norm-without-scale.
+        self.q_norm = Gemma4RMSNorm(dim=self.head_dim, eps=config.rms_norm_eps)
+        self.k_norm = Gemma4RMSNorm(dim=self.head_dim, eps=config.rms_norm_eps)
+        self.v_norm = Gemma4RMSNorm(dim=self.head_dim, eps=config.rms_norm_eps, with_scale=False)
+
+        self.attention_dropout = config.attention_dropout
+        self._attn_impl = config._attn_implementation
+
+    def _project_qkv(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        B, S, _ = hidden_states.shape
+        hidden_shape = (B, S, -1, self.head_dim)
+
+        q = self.q_proj(hidden_states).view(hidden_shape)
+        k = self.k_proj(hidden_states).view(hidden_shape)
+        if self.v_proj is not None:
+            v = self.v_proj(hidden_states).view(hidden_shape)
+        else:
+            v = self.k_proj(hidden_states).view(hidden_shape)
+
+        # Per-head norms happen in full-res [B, S, H, D] layout.
+        q = self.q_norm(q)
+        k = self.k_norm(k)
+        v = self.v_norm(v)
+
+        # Rotary — HF applies with unsqueeze_dim=2 on [B, S, H, D] layouts.
+        cos, sin = position_embeddings
+        q = apply_rotary_pos_emb(q, cos, sin, unsqueeze_dim=2)
+        k = apply_rotary_pos_emb(k, cos, sin, unsqueeze_dim=2)
+
+        return q, k, v  # each [B, S, H, D]
+
+    def _flash_attn_forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        cu_seqlens: torch.LongTensor,
+        max_seqlen: int,
+    ) -> torch.Tensor:
+        """Varlen flash-attn call. q/k/v shape: [1, S, H, D]."""
+        assert q.shape[0] == 1, "packed-varlen attention expects batch dim 1"
+        fn = flash_attn_3_varlen_func if self._attn_impl == "flash_attention_3" else flash_attn_2_varlen_func
+        if fn is None:
+            raise RuntimeError(f"attn impl {self._attn_impl} requested but not installed")
+
+        kwargs: dict = {"causal": True}
+        if self.sliding_window is not None:
+            kwargs["window_size"] = (self.sliding_window - 1, 0)
+        kwargs["softmax_scale"] = self.scaling
+
+        # Shape: [total, H, D]
+        q_flat = q[0]
+        k_flat = k[0]
+        v_flat = v[0]
+        out = fn(
+            q_flat,
+            k_flat,
+            v_flat,
+            cu_seqlens,
+            cu_seqlens,
+            max_seqlen,
+            max_seqlen,
+            **kwargs,
+        )
+        if isinstance(out, tuple):
+            out = out[0]
+        return out.view(1, out.shape[0], -1)
+
+    def _sdpa_forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        cu_seqlens: Optional[torch.LongTensor] = None,
+    ) -> torch.Tensor:
+        """SDPA path. q/k/v shape: [B, S, H, D].
+
+        Builds the correct attention mask for the current layer type:
+          - causal (lower-triangular)
+          - + sliding window (self.sliding_window) if this is a sliding layer
+          - + block-diagonal segmentation if ``cu_seqlens`` is given (packed
+            training), so tokens in segment B don't attend to segment A.
+        """
+        # SDPA wants [B, H, S, D].
+        q = q.transpose(1, 2)
+        k = k.transpose(1, 2)
+        v = v.transpose(1, 2)
+        k = _repeat_kv(k, self.num_kv_groups)
+        v = _repeat_kv(v, self.num_kv_groups)
+
+        dropout_p = self.attention_dropout if self.training else 0.0
+        S = q.size(-2)
+
+        # Always build an explicit mask so SDPA always takes the same kernel
+        # path HF does (is_causal=False + attn_mask=…). Using the is_causal=True
+        # shortcut for the unpacked full-attention case would dispatch to a
+        # different SDPA kernel and produce slightly different bf16 numerics.
+        row = torch.arange(S, device=q.device)[:, None]
+        col = torch.arange(S, device=q.device)[None, :]
+        allow = row >= col  # causal
+        if self.is_sliding:
+            allow = allow & (row - col < self.sliding_window)
+        if cu_seqlens is not None:
+            # Assign a segment id per position, then allow only within-segment pairs.
+            segment_id = torch.zeros(S, dtype=torch.long, device=q.device)
+            bounds = cu_seqlens[1:-1].to(torch.long) if cu_seqlens.numel() > 2 else cu_seqlens.new_empty(0)
+            for b in bounds.tolist():
+                segment_id[b:] += 1
+            allow = allow & (segment_id[:, None] == segment_id[None, :])
+
+        attn_mask = torch.zeros((S, S), dtype=q.dtype, device=q.device).masked_fill(~allow, float("-inf"))
+        out = F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=attn_mask[None, None, :, :],
+            dropout_p=dropout_p,
+            scale=self.scaling,
+        )
+        out = out.transpose(1, 2).contiguous()
+        return out.view(out.shape[0], out.shape[1], -1)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        cu_seqlens: Optional[torch.LongTensor] = None,
+        max_seqlen: Optional[int] = None,
+    ) -> tuple[torch.Tensor, None]:
+        q, k, v = self._project_qkv(hidden_states, position_embeddings)
+
+        if self._attn_impl in ("flash_attention_2", "flash_attention_3") and cu_seqlens is not None:
+            out = self._flash_attn_forward(q, k, v, cu_seqlens, max_seqlen)
+        else:
+            out = self._sdpa_forward(q, k, v, cu_seqlens=cu_seqlens)
+
+        out = self.o_proj(out)
+        return out, None
+
+
+# ---------------------------------------------------------------------------
+# Decoder layer, embedding, model, ForCausalLM.
+# ---------------------------------------------------------------------------
+
+
+class Gemma4TextDecoderLayer(GradientCheckpointingLayer):
+    """Gemma4 decoder layer: MLP runs in parallel to MoE, optional per-layer input gate."""
+
+    def __init__(self, config: Gemma4Config, layer_idx: int):
+        super().__init__()
+        self.config = config
+        self.hidden_size = config.hidden_size
+        self.layer_idx = layer_idx
+
+        self.self_attn = Gemma4Attention(config=config, layer_idx=layer_idx)
+        self.mlp = Gemma4TextMLP(config, layer_idx)
+        self.input_layernorm = Gemma4RMSNorm(self.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = Gemma4RMSNorm(self.hidden_size, eps=config.rms_norm_eps)
+        self.pre_feedforward_layernorm = Gemma4RMSNorm(self.hidden_size, eps=config.rms_norm_eps)
+        self.post_feedforward_layernorm = Gemma4RMSNorm(self.hidden_size, eps=config.rms_norm_eps)
+        self.register_buffer("layer_scalar", torch.ones(1))
+
+        self.hidden_size_per_layer_input = config.hidden_size_per_layer_input
+        if self.hidden_size_per_layer_input:
+            self.act_fn = ACT2FN[config.hidden_activation]
+            self.per_layer_input_gate = nn.Linear(self.hidden_size, self.hidden_size_per_layer_input, bias=False)
+            self.per_layer_projection = nn.Linear(self.hidden_size_per_layer_input, self.hidden_size, bias=False)
+            self.post_per_layer_input_norm = Gemma4RMSNorm(self.hidden_size, eps=config.rms_norm_eps)
+
+        self.enable_moe_block = config.enable_moe_block
+        if self.enable_moe_block:
+            self.router = Gemma4TextRouter(config)
+            self.experts = Gemma4TextExperts(config)
+            self.post_feedforward_layernorm_1 = Gemma4RMSNorm(self.hidden_size, eps=config.rms_norm_eps)
+            self.post_feedforward_layernorm_2 = Gemma4RMSNorm(self.hidden_size, eps=config.rms_norm_eps)
+            self.pre_feedforward_layernorm_2 = Gemma4RMSNorm(self.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        per_layer_input: Optional[torch.Tensor] = None,
+        position_embeddings: Optional[tuple[torch.Tensor, torch.Tensor]] = None,
+        cu_seqlens: Optional[torch.LongTensor] = None,
+        max_seqlen: Optional[int] = None,
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states, _ = self.self_attn(
+            hidden_states=hidden_states,
+            position_embeddings=position_embeddings,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+        )
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.pre_feedforward_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+
+        if self.enable_moe_block:
+            hidden_states_1 = self.post_feedforward_layernorm_1(hidden_states)
+            hidden_states_flat = residual.reshape(-1, residual.shape[-1])
+            _, top_k_weights, top_k_index = self.router(hidden_states_flat)
+            hidden_states_2 = self.pre_feedforward_layernorm_2(hidden_states_flat)
+            hidden_states_2 = self.experts(hidden_states_2, top_k_index, top_k_weights)
+            hidden_states_2 = hidden_states_2.reshape(residual.shape)
+            hidden_states_2 = self.post_feedforward_layernorm_2(hidden_states_2)
+            hidden_states = hidden_states_1 + hidden_states_2
+
+        hidden_states = self.post_feedforward_layernorm(hidden_states)
+        hidden_states = residual + hidden_states
+
+        if self.hidden_size_per_layer_input:
+            residual = hidden_states
+            hidden_states = self.per_layer_input_gate(hidden_states)
+            hidden_states = self.act_fn(hidden_states)
+            hidden_states = hidden_states * per_layer_input
+            hidden_states = self.per_layer_projection(hidden_states)
+            hidden_states = self.post_per_layer_input_norm(hidden_states)
+            hidden_states = residual + hidden_states
+
+        hidden_states = hidden_states * self.layer_scalar
+        return hidden_states
+
+
+class Gemma4TextScaledWordEmbedding(nn.Embedding):
+    """Input embedding scaled by ``embed_scale`` on lookup (Gemma4 convention)."""
+
+    def __init__(
+        self,
+        num_embeddings: int,
+        embedding_dim: int,
+        padding_idx: Optional[int] = None,
+        embed_scale: float = 1.0,
+    ):
+        super().__init__(num_embeddings, embedding_dim, padding_idx)
+        self.register_buffer("embed_scale", torch.tensor(embed_scale), persistent=False)
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)
+
+
+@auto_docstring
+class Gemma4PreTrainedModel(PreTrainedModelPrimeRL):
+    config: Gemma4Config
+    base_model_prefix = "model"
+    supports_gradient_checkpointing = True
+    _no_split_modules = ["Gemma4TextDecoderLayer"]
+    _skip_keys_device_placement = ["past_key_values"]
+    _supports_flash_attn = True
+    _supports_sdpa = True
+    _supports_flex_attn = True
+    _can_compile_fullgraph = False
+    _supports_attention_backend = True
+
+    @classmethod
+    def is_hf_state_dict(cls, state_dict: dict[str, Tensor]) -> bool:
+        return any("experts.gate_up_proj" in name for name in state_dict.keys())
+
+    @classmethod
+    def is_prime_state_dict(cls, state_dict: dict[str, Tensor]) -> bool:
+        return cls.is_hf_state_dict(state_dict)
+
+    @classmethod
+    def convert_to_hf(cls, state_dict: dict[str, Tensor]) -> dict[str, Tensor]:
+        return state_dict
+
+    @classmethod
+    def convert_to_prime(cls, state_dict: dict[str, Tensor]) -> dict[str, Tensor]:
+        return state_dict
+
+    @classmethod
+    def convert_layer_to_hf(cls, state_dict: dict[str, Tensor], layer_idx: int) -> dict[str, Tensor]:
+        return state_dict
+
+    @classmethod
+    def convert_layer_to_prime(cls, state_dict: dict[str, Tensor], layer_idx: int) -> dict[str, Tensor]:
+        return state_dict
+
+
+@auto_docstring
+class Gemma4Model(Gemma4PreTrainedModel):
+    """Gemma4 text model. Training-only: no KV cache, no past_key_values."""
+
+    def __init__(self, config: Gemma4Config):
+        super().__init__(config)
+        self.padding_idx = config.pad_token_id
+        self.vocab_size = config.vocab_size
+
+        self.embed_tokens = Gemma4TextScaledWordEmbedding(
+            config.vocab_size,
+            config.hidden_size,
+            self.padding_idx,
+            embed_scale=config.hidden_size**0.5,
+        )
+        self.layers = nn.ModuleList(
+            [Gemma4TextDecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
+        )
+        self.norm = Gemma4RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.rotary_emb = Gemma4TextRotaryEmbedding(config)
+        self.unique_layer_types = set(config.layer_types)
+
+        self.hidden_size_per_layer_input = config.hidden_size_per_layer_input
+        if self.hidden_size_per_layer_input:
+            self.embed_tokens_per_layer = Gemma4TextScaledWordEmbedding(
+                config.vocab_size_per_layer_input,
+                config.num_hidden_layers * self.hidden_size_per_layer_input,
+                padding_idx=None,
+                embed_scale=self.hidden_size_per_layer_input**0.5,
+            )
+            self.per_layer_model_projection = nn.Linear(
+                config.hidden_size,
+                config.num_hidden_layers * self.hidden_size_per_layer_input,
+                bias=False,
+            )
+            self.register_buffer(
+                "per_layer_model_projection_scale",
+                torch.tensor(config.hidden_size**-0.5),
+                persistent=False,
+            )
+            self.register_buffer(
+                "per_layer_input_scale",
+                torch.rsqrt(torch.tensor(2.0)),
+                persistent=False,
+            )
+            self.per_layer_projection_norm = Gemma4RMSNorm(self.hidden_size_per_layer_input, eps=config.rms_norm_eps)
+
+        self.post_init()
+
+    def get_per_layer_inputs(
+        self,
+        input_ids: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        assert self.hidden_size_per_layer_input, "per-layer inputs only defined when configured"
+        return self.embed_tokens_per_layer(input_ids).reshape(
+            *input_ids.shape,
+            self.config.num_hidden_layers,
+            self.hidden_size_per_layer_input,
+        )
+
+    def project_per_layer_inputs(
+        self,
+        inputs_embeds: torch.Tensor,
+        per_layer_inputs: torch.Tensor,
+    ) -> torch.Tensor:
+        per_layer_projection = self.per_layer_model_projection(inputs_embeds) * self.per_layer_model_projection_scale
+        per_layer_projection = per_layer_projection.reshape(
+            *inputs_embeds.shape[:-1],
+            self.config.num_hidden_layers,
+            self.hidden_size_per_layer_input,
+        )
+        per_layer_projection = self.per_layer_projection_norm(per_layer_projection)
+        return (per_layer_projection + per_layer_inputs) * self.per_layer_input_scale
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+    ) -> BaseModelOutputWithPast:
+        if (input_ids is None) ^ (inputs_embeds is not None):
+            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        per_layer_inputs = None
+        if self.hidden_size_per_layer_input:
+            per_layer_inputs = self.get_per_layer_inputs(input_ids)
+            per_layer_inputs = self.project_per_layer_inputs(inputs_embeds, per_layer_inputs)
+
+        if position_ids is None:
+            position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
+
+        # Varlen cu_seqlens for packed training when FA is the kernel.
+        if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3"):
+            flat_position_ids = position_ids.view(-1)
+            seqlens = torch.cat(
+                [
+                    flat_position_ids[0:1],
+                    flat_position_ids[:-1][(flat_position_ids == 0)[1:]] + 1,
+                    flat_position_ids[-1:] + 1,
+                ]
+            )
+            max_seqlen = seqlens.max().item()
+            cu_seqlens = seqlens.cumsum(dim=0, dtype=torch.int32)
+            torch._dynamo.mark_dynamic(cu_seqlens, 0)
+        else:
+            max_seqlen = None
+            cu_seqlens = None
+
+        # Pre-compute RoPE tables per unique layer_type.
+        position_embeddings: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
+        for layer_type in self.unique_layer_types:
+            position_embeddings[layer_type] = self.rotary_emb(inputs_embeds, position_ids, layer_type)
+
+        hidden_states = inputs_embeds
+        for i, decoder_layer in enumerate(self.layers[: self.config.num_hidden_layers]):
+            per_layer_input = per_layer_inputs[:, :, i, :] if per_layer_inputs is not None else None
+            hidden_states = decoder_layer(
+                hidden_states,
+                per_layer_input=per_layer_input,
+                position_embeddings=position_embeddings[self.config.layer_types[i]],
+                cu_seqlens=cu_seqlens,
+                max_seqlen=max_seqlen,
+            )
+
+        hidden_states = self.norm(hidden_states)
+        return BaseModelOutputWithPast(last_hidden_state=hidden_states)
+
+
+@auto_docstring
+class Gemma4ForCausalLM(Gemma4PreTrainedModel, GenerationMixin):
+    _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
+    _tp_plan = {"lm_head": "colwise_gather_output"}
+    _pp_plan = {"lm_head": (["hidden_states"], ["logits"])}
+
+    def __init__(self, config: Gemma4Config):
+        super().__init__(config)
+        self.model = Gemma4Model(config)
+        self.vocab_size = config.vocab_size
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        self.post_init()
+
+    def set_decoder(self, decoder):
+        self.model = decoder
+
+    def get_decoder(self):
+        return self.model
+
+    @can_return_tuple
+    @auto_docstring
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        labels: Optional[torch.LongTensor] = None,
+        logits_to_keep: Union[int, torch.Tensor] = 0,
+        temperature: Union[torch.Tensor, None] = None,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> PrimeLmOutput:
+        if position_ids is None:
+            ref = inputs_embeds if inputs_embeds is not None else input_ids
+            position_ids = torch.arange(ref.shape[1], device=ref.device).unsqueeze(0)
+
+        outputs: BaseModelOutputWithPast = self.model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            inputs_embeds=inputs_embeds,
+        )
+        hidden_states = outputs.last_hidden_state
+        slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+        return self.lm_head(
+            hidden_states[:, slice_indices, :],
+            labels[:, slice_indices] if labels is not None else None,
+            temperature=temperature,
+        )
+
+    def init_buffers_post_meta(self):
+        """Re-initialize non-persistent buffers that ``.to_empty()`` leaves as garbage.
+
+        ``torch.nn.Module.to_empty()`` allocates empty storage for every buffer,
+        including ones registered with ``persistent=False`` (which aren't in the
+        state_dict and so don't get filled by ``load_state_dict``). We have to
+        restore them by hand.
+        """
+        cfg = self.config
+
+        # 1. Scaled-word-embedding ``embed_scale`` buffers (persistent=False).
+        self.model.embed_tokens.embed_scale.copy_(torch.tensor(cfg.hidden_size**0.5))
+        if getattr(self.model, "embed_tokens_per_layer", None) is not None:
+            self.model.embed_tokens_per_layer.embed_scale.copy_(torch.tensor(cfg.hidden_size_per_layer_input**0.5))
+
+        # 2. Per-layer projection scales used when hidden_size_per_layer_input is set.
+        if self.model.hidden_size_per_layer_input:
+            self.model.per_layer_model_projection_scale.copy_(torch.tensor(cfg.hidden_size**-0.5))
+            self.model.per_layer_input_scale.copy_(torch.rsqrt(torch.tensor(2.0)))
+
+        # 3. Per-decoder ``layer_scalar`` buffers (HF ships as ones).
+        for layer in self.model.layers:
+            layer.layer_scalar.copy_(torch.ones_like(layer.layer_scalar))
+
+        # 4. RoPE inv_freq buffers. Re-register as fp32 regardless of current
+        # buffer dtype: HF keeps inv_freq in fp32 even when params are bf16, so
+        # any ``.to(bfloat16)`` on the whole model that downcast the buffer must
+        # be reverted here. Storing in bf16 perturbs cos/sin enough to drift Q/K
+        # after RoPE, which compounds layer-over-layer (layer 0 ~3e-3 rel).
+        rope = self.model.rotary_emb
+        for layer_type in rope.layer_types:
+            if not hasattr(rope, f"{layer_type}_inv_freq"):
+                continue
+            init_fn = rope.rope_init_fns.get(layer_type)
+            if init_fn is None:
+                continue
+            device = getattr(rope, f"{layer_type}_inv_freq").device
+            kwargs = {"device": device, "layer_type": layer_type}
+            if layer_type == "full_attention" and rope.rope_type[layer_type] == "proportional":
+                kwargs["head_dim_key"] = "global_head_dim"
+            inv_freq, attention_scaling = init_fn(rope.config, **kwargs)
+            rope.register_buffer(f"{layer_type}_inv_freq", inv_freq, persistent=False)
+            rope.register_buffer(f"{layer_type}_original_inv_freq", inv_freq.clone(), persistent=False)
+            setattr(rope, f"{layer_type}_attention_scaling", attention_scaling)
+
+
+__all__ = [
+    "Gemma4ForCausalLM",
+    "Gemma4Model",
+    "Gemma4PreTrainedModel",
+]

--- a/src/prime_rl/trainer/models/layers/lora/__init__.py
+++ b/src/prime_rl/trainer/models/layers/lora/__init__.py
@@ -6,13 +6,18 @@ from prime_rl.trainer.models.layers.lora.base import (
     set_multilora_scaling,
 )
 from prime_rl.trainer.models.layers.lora.multi_linear import MultiLoRALinear
-from prime_rl.trainer.models.layers.lora.multi_moe import MultiLoRAGroupedExperts, MultiLoRANonGatedGroupedExperts
+from prime_rl.trainer.models.layers.lora.multi_moe import (
+    MultiLoRAGemma4Experts,
+    MultiLoRAGroupedExperts,
+    MultiLoRANonGatedGroupedExperts,
+)
 
 __all__ = [
     "MultiLoRAModule",
     "MultiLoRALinear",
     "MultiLoRAGroupedExperts",
     "MultiLoRANonGatedGroupedExperts",
+    "MultiLoRAGemma4Experts",
     "set_lora_num_tokens",
     "get_lora_num_tokens",
     "set_multilora_scaling",

--- a/src/prime_rl/trainer/models/layers/lora/base.py
+++ b/src/prime_rl/trainer/models/layers/lora/base.py
@@ -112,6 +112,15 @@ class MultiLoRAModule(nn.Module):
         """
         ...
 
+    def state_dict_key_prefix(self, prefix: str) -> str:
+        """Transform the model-tree prefix into the save-time key prefix.
+
+        Default: identity. Override when the save format diverges from the
+        in-memory module path (e.g. Gemma4 experts, whose adapter must be
+        saved under vLLM's `.moe.experts.` tree).
+        """
+        return prefix
+
     @abstractmethod
     def get_lora_param_counts(self) -> tuple[int, int]:
         """Get the number of LoRA adapter parameters and adapted base parameters.

--- a/src/prime_rl/trainer/models/layers/lora/multi_moe.py
+++ b/src/prime_rl/trainer/models/layers/lora/multi_moe.py
@@ -758,3 +758,201 @@ class MultiLoRANonGatedGroupedExperts(MultiLoRAModule):
             f"alpha={self.alpha}, dropout={self.lora_dropout}, "
             f"use_grouped_mm={self.use_grouped_mm})"
         )
+
+
+class MultiLoRAGemma4Experts(MultiLoRAModule):
+    """Gemma4TextExperts + multi-LoRA via per-expert for-loop.
+
+    Adapts HF's packed gate_up_proj (first half gate, second half up) and
+    down_proj. Matches the base layer's
+    ``forward(hidden_states, top_k_index, top_k_weights)`` signature so it
+    drops in without touching Gemma4TextMoE.
+    """
+
+    def __init__(
+        self,
+        base_layer,  # transformers Gemma4TextExperts
+        rank: int,
+        n_adapters: int,
+        alpha: float = 32.0,
+        dropout: float = 0.0,
+    ):
+        super().__init__(base_layer)
+        if rank <= 0 or n_adapters <= 0:
+            raise ValueError("rank and n_adapters must be > 0")
+
+        self.num_experts = base_layer.num_experts
+        # gate_up_proj: [E, 2 * intermediate_dim, hidden_dim]
+        self.two_inter = base_layer.gate_up_proj.shape[1]
+        self.dim = base_layer.gate_up_proj.shape[2]
+        self.inter = self.two_inter // 2
+
+        self.rank = rank
+        self.n_adapters = n_adapters
+        self.alpha = alpha
+        self.lora_dropout = nn.Dropout(dropout) if dropout > 0.0 else nn.Identity()
+
+        self._lora_num_tokens = get_lora_num_tokens()
+        self._scaling_factors = get_multilora_scaling()
+
+        gu_dev, gu_dt = base_layer.gate_up_proj.device, base_layer.gate_up_proj.dtype
+        dn_dev, dn_dt = base_layer.down_proj.device, base_layer.down_proj.dtype
+
+        self.gate_up_lora_A = nn.ParameterList(
+            [
+                nn.Parameter(torch.empty(self.num_experts, rank, self.dim, device=gu_dev, dtype=gu_dt))
+                for _ in range(n_adapters)
+            ]
+        )
+        self.gate_up_lora_B = nn.ParameterList(
+            [
+                nn.Parameter(torch.empty(self.num_experts, self.two_inter, rank, device=gu_dev, dtype=gu_dt))
+                for _ in range(n_adapters)
+            ]
+        )
+        self.down_lora_A = nn.ParameterList(
+            [
+                nn.Parameter(torch.empty(self.num_experts, rank, self.inter, device=dn_dev, dtype=dn_dt))
+                for _ in range(n_adapters)
+            ]
+        )
+        self.down_lora_B = nn.ParameterList(
+            [
+                nn.Parameter(torch.empty(self.num_experts, self.dim, rank, device=dn_dev, dtype=dn_dt))
+                for _ in range(n_adapters)
+            ]
+        )
+
+        self.reset_parameters()
+
+    def reset_parameters(self, index: int | None = None) -> None:
+        if index is None:
+            for i in range(self.n_adapters):
+                self.reset_parameters(i)
+        else:
+            nn.init.kaiming_uniform_(self.gate_up_lora_A[index], a=math.sqrt(5))
+            nn.init.zeros_(self.gate_up_lora_B[index])
+            nn.init.kaiming_uniform_(self.down_lora_A[index], a=math.sqrt(5))
+            nn.init.zeros_(self.down_lora_B[index])
+
+    def named_parameters_for_adapter(self, idx: int) -> list[tuple[str, nn.Parameter]]:
+        return [
+            ("gate_up_lora_A", self.gate_up_lora_A[idx]),
+            ("gate_up_lora_B", self.gate_up_lora_B[idx]),
+            ("down_lora_A", self.down_lora_A[idx]),
+            ("down_lora_B", self.down_lora_B[idx]),
+        ]
+
+    def get_lora_param_counts(self) -> tuple[int, int]:
+        adapter_params = (
+            self.gate_up_lora_A[0].numel()
+            + self.gate_up_lora_B[0].numel()
+            + self.down_lora_A[0].numel()
+            + self.down_lora_B[0].numel()
+        )
+        adapted_params = self.base_layer.gate_up_proj.numel() + self.base_layer.down_proj.numel()
+        return adapter_params, adapted_params
+
+    def state_dict_key_prefix(self, prefix: str) -> str:
+        """Rewrite the HF module path into vLLM's Gemma4 expert tree.
+
+        The HF training tree has ``model.language_model.layers.{L}.experts``,
+        but vLLM's Gemma4ForCausalLM exposes experts under
+        ``model.layers.{L}.moe.experts``. Only rewrites the tail so wrapper
+        prefixes (e.g. ``base_model.model.``) added later are preserved.
+        """
+        out = prefix.replace("model.language_model.", "model.")
+        # Append .moe. before the final .experts segment.
+        if out.endswith(".experts"):
+            out = out[: -len(".experts")] + ".moe.experts"
+        return out
+
+    def state_dict_for_adapter(self, idx: int) -> dict[str, torch.Tensor]:
+        state_dict: dict[str, torch.Tensor] = {}
+
+        gu_a = self.gate_up_lora_A[idx].detach()
+        gu_b = self.gate_up_lora_B[idx].detach()
+        dn_a = self.down_lora_A[idx].detach()
+        dn_b = self.down_lora_B[idx].detach()
+
+        if isinstance(gu_a, DTensor):
+            gu_a = gu_a.full_tensor()
+            gu_b = gu_b.full_tensor()
+            dn_a = dn_a.full_tensor()
+            dn_b = dn_b.full_tensor()
+
+        # vLLM consumes gate_proj and up_proj as separate modules. Split the
+        # packed gate_up layout: lora_A is shared (duplicate), lora_B slices
+        # along dim 0 into [gate | up].
+        i = self.inter
+        for expert_id in range(self.num_experts):
+            gu_a_e = gu_a[expert_id].clone()
+            gu_b_e = gu_b[expert_id]
+            state_dict[f"{expert_id}.gate_proj.lora_A.weight"] = gu_a_e
+            state_dict[f"{expert_id}.up_proj.lora_A.weight"] = gu_a_e.clone()
+            state_dict[f"{expert_id}.gate_proj.lora_B.weight"] = gu_b_e[:i, :].clone()
+            state_dict[f"{expert_id}.up_proj.lora_B.weight"] = gu_b_e[i:, :].clone()
+            state_dict[f"{expert_id}.down_proj.lora_A.weight"] = dn_a[expert_id].clone()
+            state_dict[f"{expert_id}.down_proj.lora_B.weight"] = dn_b[expert_id].clone()
+
+        return state_dict
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        top_k_index: torch.Tensor,
+        top_k_weights: torch.Tensor,
+    ) -> torch.Tensor:
+        adapter_idx = self._lora_num_tokens.argmax().item()
+        gu_a = self.gate_up_lora_A[adapter_idx]
+        gu_b = self.gate_up_lora_B[adapter_idx]
+        dn_a = self.down_lora_A[adapter_idx]
+        dn_b = self.down_lora_B[adapter_idx]
+        scaling = self._scaling_factors[adapter_idx].item()
+
+        base_gu = self.base_layer.gate_up_proj
+        base_dn = self.base_layer.down_proj
+
+        if isinstance(base_gu, DTensor):
+            base_gu = base_gu.to_local()
+            base_dn = base_dn.to_local()
+            gu_a = gu_a.to_local()
+            gu_b = gu_b.to_local()
+            dn_a = dn_a.to_local()
+            dn_b = dn_b.to_local()
+
+        act_fn = self.base_layer.act_fn
+        final_hidden_states = torch.zeros_like(hidden_states)
+        with torch.no_grad():
+            expert_mask = F.one_hot(top_k_index, num_classes=self.num_experts)
+            expert_mask = expert_mask.permute(2, 1, 0)
+            expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
+
+        for expert_idx in expert_hit:
+            expert_idx = expert_idx[0]
+            if expert_idx == self.num_experts:
+                continue
+            top_k_pos, token_idx = torch.where(expert_mask[expert_idx])
+            current_state = hidden_states[token_idx]
+            current_lora = self.lora_dropout(current_state)
+
+            gu_base = F.linear(current_state, base_gu[expert_idx])
+            gu_lora = F.linear(F.linear(current_lora, gu_a[expert_idx]), gu_b[expert_idx])
+            gate, up = (gu_base + scaling * gu_lora).chunk(2, dim=-1)
+            h = act_fn(gate) * up
+
+            h_lora_in = self.lora_dropout(h)
+            dn_base = F.linear(h, base_dn[expert_idx])
+            dn_lora = F.linear(F.linear(h_lora_in, dn_a[expert_idx]), dn_b[expert_idx])
+            out = dn_base + scaling * dn_lora
+            out = out * top_k_weights[token_idx, top_k_pos, None]
+            final_hidden_states.index_add_(0, token_idx, out.to(final_hidden_states.dtype))
+
+        return final_hidden_states
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}(base={self.base_layer}, rank={self.rank}, "
+            f"n_adapters={self.n_adapters}, num_experts={self.num_experts}, "
+            f"alpha={self.alpha}, dropout={self.lora_dropout})"
+        )

--- a/src/prime_rl/trainer/runs.py
+++ b/src/prime_rl/trainer/runs.py
@@ -179,15 +179,16 @@ class MultiRunManager:
         """
         state_dict = {}
         for prefix, module in self._modules:
+            save_prefix = module.state_dict_key_prefix(prefix) if hasattr(module, "state_dict_key_prefix") else prefix
             # Check if module has a custom state_dict_for_adapter method (e.g., MoE modules)
             # which returns vLLM-compatible per-expert format
             if hasattr(module, "state_dict_for_adapter"):
                 for name, tensor in module.state_dict_for_adapter(idx).items():
-                    state_dict[f"{prefix}.{name}"] = tensor.detach()
+                    state_dict[f"{save_prefix}.{name}"] = tensor.detach()
             else:
                 # Default: use named_parameters_for_adapter
                 for name, param in module.named_parameters_for_adapter(idx):
-                    state_dict[f"{prefix}.{name}.weight"] = param.detach()
+                    state_dict[f"{save_prefix}.{name}.weight"] = param.detach()
         return state_dict
 
     def reset_run_parameters(self, idx: int) -> None:

--- a/src/prime_rl/utils/vlm.py
+++ b/src/prime_rl/utils/vlm.py
@@ -29,6 +29,7 @@ VLM_REGISTRY: dict[str, VLMModelInfo] = {
     "qwen3_5": VLMModelInfo(vision_encoder_attr="model.visual", language_model_attr="model.language_model"),
     "qwen3_5_moe": VLMModelInfo(vision_encoder_attr="model.visual", language_model_attr="model.language_model"),
     "qwen3_vl_moe": VLMModelInfo(vision_encoder_attr="model.visual", language_model_attr="model.language_model"),
+    "gemma4": VLMModelInfo(vision_encoder_attr="model.vision_tower", language_model_attr="model.language_model"),
 }
 
 # Text-only default

--- a/start_server.sh
+++ b/start_server.sh
@@ -1,0 +1,6 @@
+export CUDA_VISIBLE_DEVICES=6,7
+export VLLM_LOGGING_LEVEL=DEBUG
+uv run inference --model.name google/gemma-4-26B-A4B-it \
+  --enable-lora --max-lora-rank 16 --max-loras 4 \
+  --parallel.tp 2 --gpu-memory-utilization 0.8 --vllm-extra '{"lora_dtype": "bfloat16"}' | tee infer.log
+  #--model.max-model-len 65536 \

--- a/train.sh
+++ b/train.sh
@@ -1,0 +1,10 @@
+export PYTORCH_ALLOC_CONF=expandable_segments:True
+
+uv run torchrun --nproc-per-node 4 \
+    src/prime_rl/trainer/rl/train.py \
+    --model.name google/gemma-4-26B-A4B-it --tokenizer.name google/gemma-4-26B-A4B-it --max-steps 2 \
+    --wandb.project gemma4-debug --wandb.name trainer --max-steps 2 \
+    --model.ac --model.compile \
+    --model.fused-lm-head-token-chunk-size 1024 --model.attn sdpa \
+    --max-concurrent-runs 2 --model.lora.rank 16 --model.seq-len 16384 --model.lora.target-modules '["o_proj","q_proj","k_proj","v_proj","gate_proj","up_proj","down_proj","experts"]' \
+    --output_dir outputs --max-async-level 3 --dist_timeout_seconds 3600 --log.level debug | tee train.log


### PR DESCRIPTION
It works but it has to use sdpa attn and an only fit seqlen up to 16k rn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because this introduces a new Gemma4 model implementation plus inference-side monkeypatching and adapter key remapping, which can affect weight loading and LoRA behavior across training/inference. Changes are scoped to Gemma4 + LoRA state-dict generation but touch core model/adapter plumbing.
> 
> **Overview**
> Adds first-class **Gemma4 text** support to PrimeRL training by introducing a new `Gemma4Config` (`gemma4_text`) and a full `Gemma4ForCausalLM` implementation (including custom attention dispatch and buffer re-init logic) and wiring it into `AutoConfig`/`AutoModelForCausalLMPrimeRL`.
> 
> Extends multi-run LoRA to work with Gemma4’s packed MoE experts by adding `MultiLoRAGemma4Experts`, teaching LoRA target discovery to include `Gemma4TextExperts` and to **restrict VLM LoRA injection to the language-model subtree** (now including `gemma4` in `VLM_REGISTRY`).
> 
> Improves LoRA checkpoint export to match vLLM expectations by allowing modules to rewrite their save-time key prefix (`state_dict_key_prefix`), and adds a vLLM runtime patch (`monkey_patch_gemma4`) for Gemma4 MoE expert mapping and adapter key remapping when loading conditional-generation checkpoints.
> 
> Includes new helper scripts/config (`train.sh`, `start_server.sh`, `oink.sh`, `orchestrator.toml`) for running Gemma4 training/inference and an orchestrator integration test setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4f8dad8a421520307f6e0f3b9371625dd3604ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->