### PR TITLE
chore(orchestrator): consolidate hardcoded teacher sampling args

### DIFF
--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -79,6 +79,28 @@ def print_benchmark(history: dict[str, list[Any]]) -> None:
     console.print(table)
 
 
+def get_teacher_sampling_args() -> dict[str, Any]:
+    """Sampling args for the teacher `/chat/completions/tokens` prefill call.
+
+    These values are load-bearing rather than user-tunable:
+    - `max_tokens=1`: the teacher isn't sampling — the request just carries
+      `prompt_ids + completion_ids` as tokens to be scored. vLLM rejects `0`.
+    - `temperature=1.0` / `top_p=1.0`: no-op for prompt logprobs today (see
+      vllm-project/vllm#37082), kept to satisfy the schema.
+    - `skip_special_tokens=False`: keep special tokens so teacher logprobs
+      line up 1:1 with the student token ids.
+    - `prompt_logprobs=True`: required — without it the teacher logprobs
+      for `prompt + completion` are not returned.
+    """
+    return {
+        "max_tokens": 1,
+        "temperature": 1.0,
+        "top_p": 1.0,
+        "skip_special_tokens": False,
+        "prompt_logprobs": True,
+    }
+
+
 async def compute_teacher_logprobs(
     clients: list[vf.ClientConfig],
     model_name: str,
@@ -95,11 +117,7 @@ async def compute_teacher_logprobs(
                 "model": model_name,
                 "messages": [{"role": "user", "content": ""}],
                 "tokens": sample.prompt_ids + sample.completion_ids,
-                "max_tokens": 1,
-                "temperature": 1.0,
-                "top_p": 1.0,
-                "skip_special_tokens": False,
-                "prompt_logprobs": True,
+                **get_teacher_sampling_args(),
             },
             cast_to=ChatCompletion,
         )


### PR DESCRIPTION
## Summary

`compute_teacher_logprobs` in `src/prime_rl/orchestrator/utils.py` passes five hardcoded kwargs (`max_tokens=1`, `temperature=1.0`, `top_p=1.0`, `skip_special_tokens=False`, `prompt_logprobs=True`) into the `/chat/completions/tokens` call. As flagged in #2211, these are load-bearing but opaque at the call site — `max_tokens=1` looks tunable, `temperature=1.0` looks like a sampling knob. Per @JacobHelwig's explanation in the issue thread and @mikasenghaas's suggestion to "consolidate with other helpers like `get_{train,eval}_sampling_args`", this pulls them into a named helper.

## Fix

Extract the five kwargs into a new module-level `get_teacher_sampling_args()` in the same file, and splat it back via `**get_teacher_sampling_args()` at the call site. The helper's docstring captures the reason each value is hardcoded:

- `max_tokens=1`: teacher isn't sampling; vLLM rejects `0`.
- `temperature=1.0` / `top_p=1.0`: no-op for prompt logprobs today (see vllm-project/vllm#37082), kept to satisfy the schema.
- `skip_special_tokens=False`: keeps teacher logprobs aligned 1:1 with the student token ids.
- `prompt_logprobs=True`: required — without it the teacher logprobs for `prompt + completion` are not returned.

Pure refactor — the dict passed to `client.post(...)` is byte-identical to the previous inline version.

## Testing

`uvx ruff check` and `uvx ruff format --check` both pass on the changed file. No new test was added: per AGENTS.md "Conservative test additions ... only test code with clear, isolated logic", the new helper is a five-line pure function returning a literal dict, and a test would just restate the body. The existing behavior is still exercised wherever `compute_teacher_logprobs` is called.

Closes #2211

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only extracts hardcoded `/chat/completions/tokens` request parameters into a helper; behavior should remain identical unless the dict is later modified incorrectly.
> 
> **Overview**
> Extracts the hardcoded teacher prefill sampling parameters used by `compute_teacher_logprobs` into a new `get_teacher_sampling_args()` helper, with a docstring explaining why each value is fixed.
> 
> Updates the `/chat/completions/tokens` call site to splat `**get_teacher_sampling_args()` instead of inlining the five kwargs, keeping the request payload effectively the same while making the intent clearer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47b95cea77123d6dc29a902c365913d215405233. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->