### PR TITLE
feat: add additional wandb init fields

### DIFF
--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -77,7 +77,13 @@ class SharedWandbConfig(BaseConfig):
 
     project: Annotated[str | None, Field(description="The W&B project to use.")] = "prime-rl"
 
+    entity: Annotated[str | None, Field(description="The W&B entity to use.")] = None
+
     name: Annotated[str | None, Field(description="The W&B run name to use.")] = None
+
+    group: Annotated[str | None, Field(description="The W&B group to use.")] = None
+
+    tags: Annotated[list[str] | None, Field(description="The W&B tags to attach to the run.")] = None
 
     offline: Annotated[bool | None, Field(description="Whether to run W&B in offline mode.")] = False
 
@@ -522,6 +528,10 @@ class RLConfig(BaseConfig):
                 self.trainer.wandb.project = self.wandb.project
                 self.orchestrator.wandb.project = self.wandb.project
 
+            if self.wandb.entity:
+                self.trainer.wandb.entity = self.wandb.entity
+                self.orchestrator.wandb.entity = self.wandb.entity
+
             if self.wandb.shared:
                 if self.wandb.name:
                     self.trainer.wandb.name = self.wandb.name
@@ -530,6 +540,14 @@ class RLConfig(BaseConfig):
                 if self.wandb.name:
                     self.trainer.wandb.name = f"{self.wandb.name}-trainer"
                     self.orchestrator.wandb.name = f"{self.wandb.name}-orchestrator"
+
+            if self.wandb.group:
+                self.trainer.wandb.group = self.wandb.group
+                self.orchestrator.wandb.group = self.wandb.group
+
+            if self.wandb.tags:
+                self.trainer.wandb.tags = self.wandb.tags.copy()
+                self.orchestrator.wandb.tags = self.wandb.tags.copy()
 
             if self.wandb.offline:
                 self.trainer.wandb.offline = self.wandb.offline

--- a/src/prime_rl/configs/shared.py
+++ b/src/prime_rl/configs/shared.py
@@ -354,10 +354,31 @@ class WandbConfig(BaseConfig):
     # Shared configs (May be overwritten by WandbConfig from `rl.py`)
     project: Annotated[str, Field(description="The W&B project to log to.")] = "prime-rl"
 
+    entity: Annotated[
+        str | None,
+        Field(
+            description="The W&B entity to log to.",
+        ),
+    ] = None
+
     name: Annotated[
         str | None,
         Field(
             description="The W&B name to to use for logging.",
+        ),
+    ] = None
+
+    group: Annotated[
+        str | None,
+        Field(
+            description="The W&B group to use for logging.",
+        ),
+    ] = None
+
+    tags: Annotated[
+        list[str] | None,
+        Field(
+            description="The W&B tags to attach to the run.",
         ),
     ] = None
 

--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -74,7 +74,10 @@ class WandbMonitor(Monitor):
                     return wandb.init(
                         id=run_id,
                         project=config.project,
+                        entity=config.entity,
                         name=config.name,
+                        group=config.group,
+                        tags=config.tags,
                         dir=output_dir,
                         config=run_config.model_dump() if run_config else None,
                         settings=settings,


### PR DESCRIPTION
This PR adds `entity`, `group`, and `tags` to `WandbConfig` and `SharedWandbConfig`, and wires them through the SFT and RL W&B config paths. These `wandb.init(...)` fields are useful for team W&B projects.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds optional W&B metadata fields and threads them through existing config propagation and `wandb.init` calls without changing core training logic.
> 
> **Overview**
> Adds support for additional Weights & Biases run metadata by introducing optional `entity`, `group`, and `tags` fields on both `WandbConfig` and the RL `SharedWandbConfig`.
> 
> Updates the RL config auto-wiring so shared W&B settings propagate to both trainer and orchestrator configs, and passes these new fields through to `wandb.init()` in `WandbMonitor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 827224c84bd77a9ca6165a0e56540a1032ca994d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->