### PR TITLE
fix: correct multi-env example_id collision in /all/ metrics

### DIFF
--- a/src/prime_rl/orchestrator/metrics.py
+++ b/src/prime_rl/orchestrator/metrics.py
@@ -1,0 +1,44 @@
+"""Pure-pandas metric helpers for the RL orchestrator.
+
+Kept in a separate module with no heavy imports so they can be unit-tested
+without pulling in torch / transformers / verifiers.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def compute_solve_rates(
+    df: pd.DataFrame,
+    rollouts_per_example: int,
+) -> tuple[float, float, float]:
+    """Compute solve_none, solve_all, and effective_batch_size for a set of rollouts.
+
+    Groups by **(env_name, example_id)** so that problems from different
+    environments with the same integer example_id are never merged.  Grouping
+    by example_id alone causes cross-environment collisions when every
+    environment auto-assigns IDs from ``range(len(dataset))``, which is the
+    default behaviour for all built-in environments.
+
+    Args:
+        df: DataFrame with at minimum columns ``env_name``, ``example_id``,
+            and ``reward``.  Must contain at least one row.
+        rollouts_per_example: Number of rollouts generated per problem.
+            A problem is "fully solved" when the sum of its binary rewards
+            equals this value (i.e. every rollout scored 1).
+
+    Returns:
+        (solve_none, solve_all, effective_batch_size) where each value is a
+        float in [0, 1] and the three values sum to 1.0.
+
+        - ``solve_none``: fraction of problems where *no* rollout was correct.
+        - ``solve_all``: fraction of problems where *every* rollout was correct.
+        - ``effective_batch_size``: fraction of problems that are neither fully
+          solved nor fully failed (the "interesting" portion of the batch for
+          GRPO learning).
+    """
+    reward_per_problem = df.groupby(["env_name", "example_id"]).reward.sum()
+    solve_none = float((reward_per_problem == 0).mean())
+    solve_all = float((reward_per_problem == rollouts_per_example).mean())
+    return solve_none, solve_all, 1.0 - solve_none - solve_all

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -6,6 +6,7 @@ import time
 import tomli_w
 
 from prime_rl.orchestrator.advantage import compute_advantages
+from prime_rl.orchestrator.metrics import compute_solve_rates
 from prime_rl.orchestrator.eval_utils import compute_eval_ckpt_step
 from prime_rl.orchestrator.event_loop_lag import EventLoopLagMonitor
 from prime_rl.orchestrator.inference_metrics import InferenceMetricsCollector
@@ -599,17 +600,14 @@ async def orchestrate(config: OrchestratorConfig):
         progress.total_samples += num_rollouts
         progress.total_problems += num_unique_examples
 
-        def compute_solve_rates(df):
-            """Compute solve_none, solve_all, effective_batch_size for a set of rollouts."""
-            reward_per_problem = df.groupby("example_id").reward.sum()
-            solve_none = (reward_per_problem == 0).mean()
-            solve_all = (reward_per_problem == config.rollouts_per_example).mean()
-            return solve_none, solve_all, 1 - solve_none - solve_all
+        # Group by (env_name, example_id) to average across rollouts within each
+        # (environment, problem) pair.  Grouping by example_id alone would merge
+        # rollouts from different environments that share the same integer ID,
+        # corrupting all /all/ metrics (environments auto-assign IDs from
+        # range(len(dataset)), so collisions are guaranteed in multi-env runs).
+        by_example = results_df.groupby(["env_name", "example_id"])
 
-        # Group by example_id to average across rollouts within each problem
-        by_example = results_df.groupby("example_id")
-
-        solve_none, solve_all, effective_batch_size = compute_solve_rates(results_df)
+        solve_none, solve_all, effective_batch_size = compute_solve_rates(results_df, config.rollouts_per_example)
         to_log = {
             # Progress metrics
             "progress/tokens": num_tokens,
@@ -702,7 +700,7 @@ async def orchestrate(config: OrchestratorConfig):
             to_log[f"reward/{env}/mean"] = env_by_example.reward.mean().mean()
             to_log[f"reward/{env}/max"] = env_by_example.reward.mean().max()
             to_log[f"reward/{env}/min"] = env_by_example.reward.mean().min()
-            solve_none, solve_all, effective_batch_size = compute_solve_rates(env_df)
+            solve_none, solve_all, effective_batch_size = compute_solve_rates(env_df, config.rollouts_per_example)
             to_log[f"solve_none/{env}"] = solve_none
             to_log[f"solve_all/{env}"] = solve_all
             to_log[f"effective_batch_size/{env}"] = effective_batch_size

--- a/tests/unit/orchestrator/test_metrics.py
+++ b/tests/unit/orchestrator/test_metrics.py
@@ -1,0 +1,145 @@
+"""Tests for multi-environment metric aggregation in the orchestrator.
+
+Regression tests for the example_id collision bug:
+When multiple environments each auto-assign integer example_ids starting from 0,
+grouping by example_id alone silently merges rollouts from different problems
+across environments, corrupting all /all/ metrics.
+"""
+
+import pandas as pd
+import pytest
+
+from prime_rl.orchestrator.metrics import compute_solve_rates
+
+
+def _make_df(env_rewards: dict[str, list[list[float]]]) -> pd.DataFrame:
+    """Build a results_df from {env_name: [[rollout_rewards per problem], ...]}.
+
+    Example:
+        _make_df({"math": [[1., 1.], [0., 0.]], "code": [[0., 0.], [1., 1.]]})
+    produces a DataFrame with 8 rows (2 envs × 2 problems × 2 rollouts each),
+    with example_ids 0 and 1 for both environments (simulating auto-assignment).
+    """
+    rows = []
+    for env_name, problems in env_rewards.items():
+        for example_id, rollout_rewards in enumerate(problems):
+            for reward in rollout_rewards:
+                rows.append({"env_name": env_name, "example_id": example_id, "reward": reward})
+    return pd.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# Single-environment baseline
+# ---------------------------------------------------------------------------
+
+
+def test_single_env_all_solved():
+    """Single env: all rollouts correct → solve_all = 1.0, solve_none = 0.0."""
+    df = _make_df({"math": [[1., 1., 1., 1.], [1., 1., 1., 1.]]})
+    solve_none, solve_all, effective = compute_solve_rates(df, rollouts_per_example=4)
+    assert solve_all == pytest.approx(1.0)
+    assert solve_none == pytest.approx(0.0)
+    assert effective == pytest.approx(0.0)
+
+
+def test_single_env_none_solved():
+    """Single env: no rollouts correct → solve_none = 1.0, solve_all = 0.0."""
+    df = _make_df({"math": [[0., 0., 0., 0.], [0., 0., 0., 0.]]})
+    solve_none, solve_all, effective = compute_solve_rates(df, rollouts_per_example=4)
+    assert solve_none == pytest.approx(1.0)
+    assert solve_all == pytest.approx(0.0)
+    assert effective == pytest.approx(0.0)
+
+
+def test_single_env_half_solved():
+    """Single env: one problem fully solved, one fully failed → each metric = 0.5."""
+    df = _make_df({"math": [[1., 1., 1., 1.], [0., 0., 0., 0.]]})
+    solve_none, solve_all, effective = compute_solve_rates(df, rollouts_per_example=4)
+    assert solve_all == pytest.approx(0.5)
+    assert solve_none == pytest.approx(0.5)
+    assert effective == pytest.approx(0.0)
+
+
+def test_single_env_partial_credit():
+    """Single env: one problem partially solved → shows up in effective_batch_size."""
+    # problem 0: fully solved, problem 1: partial (2/4 correct)
+    df = _make_df({"math": [[1., 1., 1., 1.], [1., 0., 1., 0.]]})
+    solve_none, solve_all, effective = compute_solve_rates(df, rollouts_per_example=4)
+    assert solve_all == pytest.approx(0.5)
+    assert solve_none == pytest.approx(0.0)
+    assert effective == pytest.approx(0.5)
+
+
+def test_solve_rates_sum_to_one():
+    """solve_none + solve_all + effective_batch_size must always equal 1.0."""
+    df = _make_df({"math": [[1., 0., 1., 0.], [0., 0., 0., 0.], [1., 1., 1., 1.]]})
+    solve_none, solve_all, effective = compute_solve_rates(df, rollouts_per_example=4)
+    assert solve_none + solve_all + effective == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# Multi-environment metrics should not collide
+# ---------------------------------------------------------------------------
+
+
+def test_multi_env_solve_all_not_corrupted():
+    """solve_all must not be corrupted when two envs share example_id integers.
+
+    Setup: math fully solves all problems, code fails all problems.
+    Both envs auto-assign example_ids 0 and 1.
+
+    With the buggy groupby("example_id"), merged groups have reward_sum = 4+0 = 4,
+    which accidentally equals rollouts_per_example=4, making solve_all look correct
+    when it isn't — it's hiding that code failed everything.
+
+    The correct answer: 2/4 groups fully solved (math/0, math/1); solve_all = 0.5.
+    """
+    df = _make_df({
+        "math": [[1., 1., 1., 1.], [1., 1., 1., 1.]],  # fully solved
+        "code": [[0., 0., 0., 0.], [0., 0., 0., 0.]],  # fully failed
+    })
+    solve_none, solve_all, effective = compute_solve_rates(df, rollouts_per_example=4)
+    assert solve_all == pytest.approx(0.5), (
+        "solve_all should be 0.5 (math solved, code failed), "
+        f"got {solve_all} — likely groupby('example_id') collision"
+    )
+    assert solve_none == pytest.approx(0.5)
+    assert effective == pytest.approx(0.0)
+
+
+def test_multi_env_solve_none_not_corrupted():
+    """solve_none must not be corrupted by cross-env example_id collision.
+
+    Setup: math fails all, code fails all → solve_none should be 1.0.
+    But if rewards from both envs are summed into merged groups,
+    solve_none only triggers when the sum is exactly 0, which it is here,
+    so this test catches a different failure mode (false negatives).
+    """
+    df = _make_df({
+        "math": [[0., 0., 0., 0.], [0., 0., 0., 0.]],
+        "code": [[0., 0., 0., 0.], [0., 0., 0., 0.]],
+    })
+    solve_none, solve_all, effective = compute_solve_rates(df, rollouts_per_example=4)
+    assert solve_none == pytest.approx(1.0)
+    assert solve_all == pytest.approx(0.0)
+
+
+def test_multi_env_collision_mixed():
+    """Three envs, three problems each; verifies solve rates are computed per (env, problem).
+
+    math: problem 0 fully solved, problem 1 partial, problem 2 failed  → 1 solved, 1 failed
+    code: all problems failed                                           → 0 solved, 3 failed
+    logic: all problems fully solved                                    → 3 solved, 0 failed
+
+    Total: 4/9 fully solved, 4/9 fully failed, 1/9 partial.
+    """
+    df = _make_df({
+        "math":  [[1., 1., 1., 1.], [0., 1., 0., 1.], [0., 0., 0., 0.]],
+        "code":  [[0., 0., 0., 0.], [0., 0., 0., 0.], [0., 0., 0., 0.]],
+        "logic": [[1., 1., 1., 1.], [1., 1., 1., 1.], [1., 1., 1., 1.]],
+    })
+    solve_none, solve_all, effective = compute_solve_rates(df, rollouts_per_example=4)
+    assert solve_all == pytest.approx(4 / 9)
+    assert solve_none == pytest.approx(4 / 9)
+    assert effective == pytest.approx(1 / 9)
+    assert solve_none + solve_all + effective == pytest.approx(1.0)


### PR DESCRIPTION
# Context

When multiple environments each auto-assign integer `example_ids` from `range(len(dataset))` — the default for every built-in environment — `groupby("example_id")` silently merges rollouts from different problems across environments into invalid groups. 

# Issue

This corrupts `solve_all/all`, `solve_none/all`, `effective_batch_size/all`, and `all seq_len/reward/all/*` metrics logged to W&B in any multi-environment training run. 

# Impact

If anyone is manually using `solve_all/all` or `reward/all/mean` as a stopping signal or to make decisions about hyperparameters mid-run, those decisions could be wrong. But **the automated training loop itself is clean**.

# Fix

- Extract compute_solve_rates into a new, minimal metrics.py module (no heavy deps, directly unit-testable without torch/transformers)
- Group by ["env_name", "example_id"] instead of "example_id" alone in both compute_solve_rates and the by_example groupby
- Add regression tests covering single-env baseline, the collision scenario, and three-env mixed cases

The per-env metrics path (env_df.groupby("example_id")) was already correct because env_df is pre-filtered to a single environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how global training metrics are grouped and computed, which can alter W&B dashboards and any human-in-the-loop stopping heuristics, but does not affect the training data sent to the trainer.
> 
> **Overview**
> Fixes corrupted `/all/` metrics in multi-environment training runs by grouping rollouts by `("env_name", "example_id")` instead of `"example_id"` alone, preventing cross-environment ID collisions from skewing logged `reward/*`, `seq_len/*`, and solve-rate metrics.
> 
> Extracts `compute_solve_rates` into a new lightweight `orchestrator/metrics.py` and adds unit tests covering single-env baselines and multi-env collision regression scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf3d67f9c3075788ec885648beaf812c2c087232. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->