### PR TITLE
orchestrator: set up early stopping status for zero advantages filtering

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -77,8 +77,8 @@ from prime_rl.utils.utils import (
 SHUTDOWN_TIMEOUT_S = 300
 
 # Maximum number of times to attempt generating a training batch when all
-# rollouts are filtered out. After this many attempts, the orchestrator
-# crashes (or early stops for zero advantages) rather than silently skipping training steps.
+# rollouts are filtered out. After this many attempts, the orchestrator crashes
+# (or early stops for zero advantages) rather than silently skipping training steps.
 MAX_EMPTY_BATCH_ATTEMPTS = 3
 
 
@@ -104,6 +104,10 @@ async def orchestrate(config: OrchestratorConfig):
     # Save configs to output directory
     config_dir = config.output_dir / "control"
     config_dir.mkdir(parents=True, exist_ok=True)
+    evicted_path = config_dir / "evicted.txt"
+    early_stopped_path = config_dir / "early_stopped.txt"
+    if early_stopped_path.exists():
+        early_stopped_path.unlink()
     with open(config_dir / "orch.toml", "wb") as f:
         tomli_w.dump(config.model_dump(exclude_none=True, mode="json"), f)
 
@@ -326,13 +330,10 @@ async def orchestrate(config: OrchestratorConfig):
     early_stopped = False
 
     while True:
-        # Check if this run has been evicted by the trainer (skip early-stop
-        # markers so the run can be resumed with different data/config)
-        evicted_path = config.output_dir / "control" / "evicted.txt"
+        # Check if this run has been evicted by the trainer.
         if evicted_path.exists():
             reason = evicted_path.read_text().strip()
-            if not reason.startswith("early_stopped:"):
-                raise RuntimeError(f"Run evicted by trainer: {reason}")
+            raise RuntimeError(f"Run evicted by trainer: {reason}")
 
         # Capture ckpt_step once for consistency (it's updated inside the scheduler)
         ckpt_step = scheduler.ckpt_step
@@ -447,14 +448,11 @@ async def orchestrate(config: OrchestratorConfig):
                 )
 
                 # Check for zero advantages for early stopping
-                all_zero_advantage = train_rollouts and all(r.get("advantage") == 0.0 for r in train_rollouts)
-
-                evicted_path = config.output_dir / "control" / "evicted.txt"
-                evicted_path.parent.mkdir(parents=True, exist_ok=True)
+                all_zero_advantage = len(train_rollouts) > 0 and all(r.get("advantage") == 0.0 for r in train_rollouts)
 
                 if all_zero_advantage:
                     logger.warning(f"Early stopping: {reason}")
-                    evicted_path.write_text(f"early_stopped: {reason}")
+                    early_stopped_path.write_text(reason)
                     early_stopped = True
                     break
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -444,11 +444,9 @@ async def orchestrate(config: OrchestratorConfig):
                     f"{MAX_EMPTY_BATCH_ATTEMPTS} consecutive attempts at step {progress.step}"
                 )
 
-                # Early stop only when all filtering is due to zero advantages
-                only_zero_advantage = all(
-                    r["filters"].get("zero_advantage", False) for r in train_rollouts if r["is_filtered"]
-                )
-                if only_zero_advantage:
+                # Early stop when every rollout has zero advantage
+                all_zero_advantage = train_rollouts and all(r.get("advantage") == 0.0 for r in train_rollouts)
+                if all_zero_advantage:
                     logger.warning(f"Early stopping: {reason}")
                     early_stopped = True
                     break

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -326,11 +326,13 @@ async def orchestrate(config: OrchestratorConfig):
     early_stopped = False
 
     while True:
-        # Check if this run has been evicted by the trainer
+        # Check if this run has been evicted by the trainer (skip early-stop
+        # markers so the run can be resumed with different data/config)
         evicted_path = config.output_dir / "control" / "evicted.txt"
         if evicted_path.exists():
             reason = evicted_path.read_text().strip()
-            raise RuntimeError(f"Run evicted by trainer: {reason}")
+            if not reason.startswith("early_stopped:"):
+                raise RuntimeError(f"Run evicted by trainer: {reason}")
 
         # Capture ckpt_step once for consistency (it's updated inside the scheduler)
         ckpt_step = scheduler.ckpt_step
@@ -444,15 +446,18 @@ async def orchestrate(config: OrchestratorConfig):
                     f"{MAX_EMPTY_BATCH_ATTEMPTS} consecutive attempts at step {progress.step}"
                 )
 
-                # Early stop when every rollout has zero advantage
+                # Check for zero advantages for early stopping
                 all_zero_advantage = train_rollouts and all(r.get("advantage") == 0.0 for r in train_rollouts)
-                if all_zero_advantage:
-                    logger.warning(f"Early stopping: {reason}")
-                    early_stopped = True
-                    break
 
                 evicted_path = config.output_dir / "control" / "evicted.txt"
                 evicted_path.parent.mkdir(parents=True, exist_ok=True)
+
+                if all_zero_advantage:
+                    logger.warning(f"Early stopping: {reason}")
+                    evicted_path.write_text(f"early_stopped: {reason}")
+                    early_stopped = True
+                    break
+
                 evicted_path.write_text(reason)
                 logger.error(f"{reason} - crashing orchestrator")
                 raise RuntimeError(reason)

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -77,8 +77,8 @@ from prime_rl.utils.utils import (
 SHUTDOWN_TIMEOUT_S = 300
 
 # Maximum number of times to attempt generating a training batch when all
-# rollouts are filtered out. After this many attempts, the orchestrator crashes
-# rather than silently skipping training steps.
+# rollouts are filtered out. After this many attempts, the orchestrator
+# crashes (or early stops for zero advantages) rather than silently skipping training steps.
 MAX_EMPTY_BATCH_ATTEMPTS = 3
 
 
@@ -323,6 +323,7 @@ async def orchestrate(config: OrchestratorConfig):
     # Iterate over dataset in batches
     logger.info(f"Starting orchestrator loop (max_steps={config.max_steps or 'infinite'})")
     is_first_step = True
+    early_stopped = False
 
     while True:
         # Check if this run has been evicted by the trainer
@@ -438,10 +439,6 @@ async def orchestrate(config: OrchestratorConfig):
                 break
 
             if attempt == MAX_EMPTY_BATCH_ATTEMPTS - 1:
-                logger.error(
-                    f"Attempt {attempt + 1}/{MAX_EMPTY_BATCH_ATTEMPTS} at step {progress.step} "
-                    f"filtered out all {num_rollouts} rollouts - crashing orchestrator"
-                )
                 reason = (
                     f"All {num_rollouts} rollouts were filtered out on "
                     f"{MAX_EMPTY_BATCH_ATTEMPTS} consecutive attempts at step {progress.step}"
@@ -449,12 +446,26 @@ async def orchestrate(config: OrchestratorConfig):
                 evicted_path = config.output_dir / "control" / "evicted.txt"
                 evicted_path.parent.mkdir(parents=True, exist_ok=True)
                 evicted_path.write_text(reason)
+
+                # Early stop only when all filtering is due to zero advantages
+                only_zero_advantage = all(
+                    r["filters"].get("zero_advantage", False) for r in train_rollouts if r["is_filtered"]
+                )
+                if only_zero_advantage:
+                    logger.warning(f"Early stopping: {reason}")
+                    early_stopped = True
+                    break
+
+                logger.error(f"{reason} - crashing orchestrator")
                 raise RuntimeError(reason)
 
             logger.warning(
                 f"Attempt {attempt + 1}/{MAX_EMPTY_BATCH_ATTEMPTS} at step {progress.step} "
                 f"filtered out all {num_rollouts} rollouts - retrying batch generation"
             )
+
+        if early_stopped:
+            break
 
         trainable_ratio = n_trainable / num_rollouts
         if trainable_ratio <= 0.1:
@@ -807,7 +818,7 @@ async def orchestrate(config: OrchestratorConfig):
                 save_rollouts, eval_rollouts, step_path / "eval_rollouts.jsonl", exclude_keys={"trajectory"}
             )
 
-    monitor.save_final_summary()
+    monitor.save_final_summary(early_stopped=early_stopped)
 
     # Write final checkpoint
     if ckpt_manager is not None:

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -443,9 +443,6 @@ async def orchestrate(config: OrchestratorConfig):
                     f"All {num_rollouts} rollouts were filtered out on "
                     f"{MAX_EMPTY_BATCH_ATTEMPTS} consecutive attempts at step {progress.step}"
                 )
-                evicted_path = config.output_dir / "control" / "evicted.txt"
-                evicted_path.parent.mkdir(parents=True, exist_ok=True)
-                evicted_path.write_text(reason)
 
                 # Early stop only when all filtering is due to zero advantages
                 only_zero_advantage = all(
@@ -456,6 +453,9 @@ async def orchestrate(config: OrchestratorConfig):
                     early_stopped = True
                     break
 
+                evicted_path = config.output_dir / "control" / "evicted.txt"
+                evicted_path.parent.mkdir(parents=True, exist_ok=True)
+                evicted_path.write_text(reason)
                 logger.error(f"{reason} - crashing orchestrator")
                 raise RuntimeError(reason)
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -77,8 +77,8 @@ from prime_rl.utils.utils import (
 SHUTDOWN_TIMEOUT_S = 300
 
 # Maximum number of times to attempt generating a training batch when all
-# rollouts are filtered out. After this many attempts, the orchestrator crashes
-# rather than silently skipping training steps.
+# rollouts are filtered out. After this many attempts, the orchestrator
+# crashes (or early stops for zero advantages) rather than silently skipping training steps.
 MAX_EMPTY_BATCH_ATTEMPTS = 3
 
 
@@ -320,6 +320,7 @@ async def orchestrate(config: OrchestratorConfig):
     # Iterate over dataset in batches
     logger.info(f"Starting orchestrator loop (max_steps={config.max_steps or 'infinite'})")
     is_first_step = True
+    early_stopped = False
 
     while True:
         # Check if this run has been evicted by the trainer
@@ -435,10 +436,6 @@ async def orchestrate(config: OrchestratorConfig):
                 break
 
             if attempt == MAX_EMPTY_BATCH_ATTEMPTS - 1:
-                logger.error(
-                    f"Attempt {attempt + 1}/{MAX_EMPTY_BATCH_ATTEMPTS} at step {progress.step} "
-                    f"filtered out all {num_rollouts} rollouts - crashing orchestrator"
-                )
                 reason = (
                     f"All {num_rollouts} rollouts were filtered out on "
                     f"{MAX_EMPTY_BATCH_ATTEMPTS} consecutive attempts at step {progress.step}"
@@ -446,12 +443,26 @@ async def orchestrate(config: OrchestratorConfig):
                 evicted_path = config.output_dir / "control" / "evicted.txt"
                 evicted_path.parent.mkdir(parents=True, exist_ok=True)
                 evicted_path.write_text(reason)
+
+                # Early stop only when all filtering is due to zero advantages
+                only_zero_advantage = all(
+                    r["filters"].get("zero_advantage", False) for r in train_rollouts if r["is_filtered"]
+                )
+                if only_zero_advantage:
+                    logger.warning(f"Early stopping: {reason}")
+                    early_stopped = True
+                    break
+
+                logger.error(f"{reason} - crashing orchestrator")
                 raise RuntimeError(reason)
 
             logger.warning(
                 f"Attempt {attempt + 1}/{MAX_EMPTY_BATCH_ATTEMPTS} at step {progress.step} "
                 f"filtered out all {num_rollouts} rollouts - retrying batch generation"
             )
+
+        if early_stopped:
+            break
 
         trainable_ratio = n_trainable / num_rollouts
         if trainable_ratio <= 0.1:
@@ -785,7 +796,7 @@ async def orchestrate(config: OrchestratorConfig):
 
     # Log final (immutable) samples and distributions to monitor(s)
     monitor.log_final_samples()
-    monitor.save_final_summary()
+    monitor.save_final_summary(early_stopped=early_stopped)
 
     # Write final checkpoint
     if ckpt_manager is not None:

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -441,11 +441,9 @@ async def orchestrate(config: OrchestratorConfig):
                     f"{MAX_EMPTY_BATCH_ATTEMPTS} consecutive attempts at step {progress.step}"
                 )
 
-                # Early stop only when all filtering is due to zero advantages
-                only_zero_advantage = all(
-                    r["filters"].get("zero_advantage", False) for r in train_rollouts if r["is_filtered"]
-                )
-                if only_zero_advantage:
+                # Early stop when every rollout has zero advantage
+                all_zero_advantage = train_rollouts and all(r.get("advantage") == 0.0 for r in train_rollouts)
+                if all_zero_advantage:
                     logger.warning(f"Early stopping: {reason}")
                     early_stopped = True
                     break

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -323,11 +323,13 @@ async def orchestrate(config: OrchestratorConfig):
     early_stopped = False
 
     while True:
-        # Check if this run has been evicted by the trainer
+        # Check if this run has been evicted by the trainer (skip early-stop
+        # markers so the run can be resumed with different data/config)
         evicted_path = config.output_dir / "control" / "evicted.txt"
         if evicted_path.exists():
             reason = evicted_path.read_text().strip()
-            raise RuntimeError(f"Run evicted by trainer: {reason}")
+            if not reason.startswith("early_stopped:"):
+                raise RuntimeError(f"Run evicted by trainer: {reason}")
 
         # Capture ckpt_step once for consistency (it's updated inside the scheduler)
         ckpt_step = scheduler.ckpt_step if enable_policy_updates else progress.step
@@ -441,15 +443,18 @@ async def orchestrate(config: OrchestratorConfig):
                     f"{MAX_EMPTY_BATCH_ATTEMPTS} consecutive attempts at step {progress.step}"
                 )
 
-                # Early stop when every rollout has zero advantage
+                # Check for zero advantages for early stopping
                 all_zero_advantage = train_rollouts and all(r.get("advantage") == 0.0 for r in train_rollouts)
-                if all_zero_advantage:
-                    logger.warning(f"Early stopping: {reason}")
-                    early_stopped = True
-                    break
 
                 evicted_path = config.output_dir / "control" / "evicted.txt"
                 evicted_path.parent.mkdir(parents=True, exist_ok=True)
+
+                if all_zero_advantage:
+                    logger.warning(f"Early stopping: {reason}")
+                    evicted_path.write_text(f"early_stopped: {reason}")
+                    early_stopped = True
+                    break
+
                 evicted_path.write_text(reason)
                 logger.error(f"{reason} - crashing orchestrator")
                 raise RuntimeError(reason)

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -440,9 +440,6 @@ async def orchestrate(config: OrchestratorConfig):
                     f"All {num_rollouts} rollouts were filtered out on "
                     f"{MAX_EMPTY_BATCH_ATTEMPTS} consecutive attempts at step {progress.step}"
                 )
-                evicted_path = config.output_dir / "control" / "evicted.txt"
-                evicted_path.parent.mkdir(parents=True, exist_ok=True)
-                evicted_path.write_text(reason)
 
                 # Early stop only when all filtering is due to zero advantages
                 only_zero_advantage = all(
@@ -453,6 +450,9 @@ async def orchestrate(config: OrchestratorConfig):
                     early_stopped = True
                     break
 
+                evicted_path = config.output_dir / "control" / "evicted.txt"
+                evicted_path.parent.mkdir(parents=True, exist_ok=True)
+                evicted_path.write_text(reason)
                 logger.error(f"{reason} - crashing orchestrator")
                 raise RuntimeError(reason)
 

--- a/src/prime_rl/trainer/runs.py
+++ b/src/prime_rl/trainer/runs.py
@@ -357,9 +357,13 @@ class MultiRunManager:
             raise RuntimeError("discover_runs() must only be called on the master rank")
         run_ids = {run_path.stem for run_path in self.output_dir.glob("run_*")}
 
-        # Filter out evicted runs
-        evicted_runs = {run_id for run_id in run_ids if (self.output_dir / run_id / "control" / "evicted.txt").exists()}
-        run_ids = run_ids - evicted_runs
+        inactive_runs = {
+            run_id
+            for run_id in run_ids
+            if (self.output_dir / run_id / "control" / "evicted.txt").exists()
+            or (self.output_dir / run_id / "control" / "early_stopped.txt").exists()
+        }
+        run_ids = run_ids - inactive_runs
 
         deleted_runs = self.id_2_idx.keys() - run_ids
         new_runs = run_ids - self.id_2_idx.keys()

--- a/src/prime_rl/utils/monitor/base.py
+++ b/src/prime_rl/utils/monitor/base.py
@@ -47,7 +47,7 @@ class Monitor(ABC):
         pass
 
     @abstractmethod
-    def save_final_summary(self, filename: str = "final_summary.json") -> None:
+    def save_final_summary(self, filename: str = "final_summary.json", early_stopped: bool = False) -> None:
         pass
 
     @abstractmethod
@@ -78,7 +78,7 @@ class NoOpMonitor(Monitor):
     def log_eval_samples(self, rollouts: list[vf.RolloutOutput], env_name: str, step: int) -> None:
         pass
 
-    def save_final_summary(self, filename: str = "final_summary.json") -> None:
+    def save_final_summary(self, filename: str = "final_summary.json", early_stopped: bool = False) -> None:
         pass
 
     def log_distributions(self, distributions: dict[str, list[float]], step: int) -> None:

--- a/src/prime_rl/utils/monitor/base.py
+++ b/src/prime_rl/utils/monitor/base.py
@@ -51,7 +51,7 @@ class Monitor(ABC):
         pass
 
     @abstractmethod
-    def save_final_summary(self, filename: str = "final_summary.json") -> None:
+    def save_final_summary(self, filename: str = "final_summary.json", early_stopped: bool = False) -> None:
         pass
 
     @abstractmethod
@@ -81,7 +81,7 @@ class NoOpMonitor(Monitor):
     def log_final_samples(self) -> None:
         pass
 
-    def save_final_summary(self, filename: str = "final_summary.json") -> None:
+    def save_final_summary(self, filename: str = "final_summary.json", early_stopped: bool = False) -> None:
         pass
 
     def log_distributions(self, distributions: dict[str, list[float]], step: int) -> None:

--- a/src/prime_rl/utils/monitor/multi.py
+++ b/src/prime_rl/utils/monitor/multi.py
@@ -40,10 +40,10 @@ class MultiMonitor(Monitor):
             except Exception as e:
                 self.logger.warning(f"Failed to log eval samples to {monitor.__class__.__name__}: {e}")
 
-    def save_final_summary(self, filename: str = "final_summary.json") -> None:
+    def save_final_summary(self, filename: str = "final_summary.json", early_stopped: bool = False) -> None:
         for monitor in self.monitors:
             try:
-                monitor.save_final_summary(filename=filename)
+                monitor.save_final_summary(filename=filename, early_stopped=early_stopped)
             except Exception as e:
                 self.logger.warning(f"Failed to save final summary to {monitor.__class__.__name__}: {e}")
 

--- a/src/prime_rl/utils/monitor/multi.py
+++ b/src/prime_rl/utils/monitor/multi.py
@@ -47,10 +47,10 @@ class MultiMonitor(Monitor):
             except Exception as e:
                 self.logger.warning(f"Failed to log final samples to {monitor.__class__.__name__}: {e}")
 
-    def save_final_summary(self, filename: str = "final_summary.json") -> None:
+    def save_final_summary(self, filename: str = "final_summary.json", early_stopped: bool = False) -> None:
         for monitor in self.monitors:
             try:
-                monitor.save_final_summary(filename=filename)
+                monitor.save_final_summary(filename=filename, early_stopped=early_stopped)
             except Exception as e:
                 self.logger.warning(f"Failed to save final summary to {monitor.__class__.__name__}: {e}")
 

--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -241,13 +241,18 @@ class PrimeMonitor(Monitor):
         self._registered = True
         return run_id
 
-    def _finalize_run(self, success: bool) -> None:
-        """Mark the run as completed or failed on the platform."""
+    def _finalize_run(self, success: bool, early_stopped: bool = False) -> None:
+        """Mark the run as completed, early_stopped, or failed on the platform."""
         if not self._registered:
             return
 
-        payload: dict = {"status": "completed" if success else "failed"}
-        status_label = "completed" if success else "failed"
+        if early_stopped:
+            status_label = "early_stopped"
+        elif success:
+            status_label = "completed"
+        else:
+            status_label = "failed"
+        payload: dict = {"status": status_label}
         self.logger.info(f"Finalizing platform run {self.run_id} as {status_label}")
 
         try:
@@ -529,12 +534,12 @@ class PrimeMonitor(Monitor):
             f"Logged distributions at step {step} to Prime Intellect API in {time.perf_counter() - start_time:.2f}s"
         )
 
-    def _submit_final_summary(self, summary: dict[str, Any]) -> bool:
+    def _submit_final_summary(self, summary: dict[str, Any], early_stopped: bool = False) -> bool:
         """Submit the final summary/finalize request synchronously."""
-        payload = self._sanitize_json_payload(
-            "finalize",
-            {"run_id": self.run_id, "summary": summary},
-        )
+        finalize_data: dict[str, Any] = {"run_id": self.run_id, "summary": summary}
+        if early_stopped:
+            finalize_data["status"] = "early_stopped"
+        payload = self._sanitize_json_payload("finalize", finalize_data)
 
         try:
             response = httpx.post(
@@ -556,14 +561,14 @@ class PrimeMonitor(Monitor):
 
         return True
 
-    def save_final_summary(self, filename: str = "final_summary.json") -> None:
+    def save_final_summary(self, filename: str = "final_summary.json", early_stopped: bool = False) -> None:
         """Save final summary to Prime Intellect API."""
         if not self.is_master or not self.enabled:
             return
 
         self.logger.info("Saving final summary to Prime Intellect API")
         summary = self.history[-1] if self.history else {}
-        finalized_via_summary = self._submit_final_summary(summary)
+        finalized_via_summary = self._submit_final_summary(summary, early_stopped=early_stopped)
 
         if os.getpid() != self._owner_pid:
             return
@@ -572,7 +577,7 @@ class PrimeMonitor(Monitor):
             self._finalized = True
             return
 
-        self._finalize_run(success=True)
+        self._finalize_run(success=True, early_stopped=early_stopped)
         self._finalized = True
 
     def close(self) -> None:

--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -240,13 +240,18 @@ class PrimeMonitor(Monitor):
         self._registered = True
         return run_id
 
-    def _finalize_run(self, success: bool) -> None:
-        """Mark the run as completed or failed on the platform."""
+    def _finalize_run(self, success: bool, early_stopped: bool = False) -> None:
+        """Mark the run as completed, early_stopped, or failed on the platform."""
         if not self._registered:
             return
 
-        payload: dict = {"status": "completed" if success else "failed"}
-        status_label = "completed" if success else "failed"
+        if early_stopped:
+            status_label = "early_stopped"
+        elif success:
+            status_label = "completed"
+        else:
+            status_label = "failed"
+        payload: dict = {"status": status_label}
         self.logger.info(f"Finalizing platform run {self.run_id} as {status_label}")
 
         try:
@@ -529,12 +534,12 @@ class PrimeMonitor(Monitor):
             f"Logged distributions at step {step} to Prime Intellect API in {time.perf_counter() - start_time:.2f}s"
         )
 
-    def _submit_final_summary(self, summary: dict[str, Any]) -> bool:
+    def _submit_final_summary(self, summary: dict[str, Any], early_stopped: bool = False) -> bool:
         """Submit the final summary/finalize request synchronously."""
-        payload = self._sanitize_json_payload(
-            "finalize",
-            {"run_id": self.run_id, "summary": summary},
-        )
+        finalize_data: dict[str, Any] = {"run_id": self.run_id, "summary": summary}
+        if early_stopped:
+            finalize_data["status"] = "early_stopped"
+        payload = self._sanitize_json_payload("finalize", finalize_data)
 
         try:
             response = httpx.post(
@@ -556,14 +561,14 @@ class PrimeMonitor(Monitor):
 
         return True
 
-    def save_final_summary(self, filename: str = "final_summary.json") -> None:
+    def save_final_summary(self, filename: str = "final_summary.json", early_stopped: bool = False) -> None:
         """Save final summary to Prime Intellect API."""
         if not self.is_master or not self.enabled:
             return
 
         self.logger.info("Saving final summary to Prime Intellect API")
         summary = self.history[-1] if self.history else {}
-        finalized_via_summary = self._submit_final_summary(summary)
+        finalized_via_summary = self._submit_final_summary(summary, early_stopped=early_stopped)
 
         if os.getpid() != self._owner_pid:
             return
@@ -572,7 +577,7 @@ class PrimeMonitor(Monitor):
             self._finalized = True
             return
 
-        self._finalize_run(success=True)
+        self._finalize_run(success=True, early_stopped=early_stopped)
         self._finalized = True
 
     def close(self) -> None:

--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -237,7 +237,7 @@ class WandbMonitor(Monitor):
         """Log distributions (no-op for W&B)."""
         pass
 
-    def save_final_summary(self, filename: str = "final_summary.json") -> None:
+    def save_final_summary(self, filename: str = "final_summary.json", early_stopped: bool = False) -> None:
         """Save final summary to W&B table."""
         if not self.is_master or not self.enabled:
             return

--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -233,7 +233,7 @@ class WandbMonitor(Monitor):
         """Log distributions (no-op for W&B)."""
         pass
 
-    def save_final_summary(self, filename: str = "final_summary.json") -> None:
+    def save_final_summary(self, filename: str = "final_summary.json", early_stopped: bool = False) -> None:
         """Save final summary to W&B table."""
         if not self.is_master or not self.enabled:
             return


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes orchestrator termination semantics and run lifecycle reporting by introducing an early-stop path, which could prematurely end training or alter platform status if the zero-advantage condition is misdetected.
> 
> **Overview**
> Adds an *early stopping* path in the orchestrator when batch generation repeatedly yields fully-filtered rollouts **and** all computed advantages are `0.0`: the run writes `control/early_stopped.txt`, exits the main loop cleanly, and propagates `early_stopped` into `monitor.save_final_summary()`.
> 
> Extends monitor APIs (`Monitor`, `MultiMonitor`, `PrimeMonitor`, `WandbMonitor`) to accept an `early_stopped` flag; `PrimeMonitor` now finalizes platform runs with `status=early_stopped` (including in the `/finalize` payload) when applicable.
> 
> Updates trainer run discovery to treat both `control/evicted.txt` and `control/early_stopped.txt` as *inactive* runs so they are ignored in future `discover_runs()` scans.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a48b85345a74c722f2c82e84bdb78d7bb6aadc9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->