### PR TITLE
fix(multi_ckpt): run maybe_clean on all ranks to keep ckpt_steps in sync

### DIFF
--- a/src/prime_rl/trainer/multi_ckpt.py
+++ b/src/prime_rl/trainer/multi_ckpt.py
@@ -219,8 +219,10 @@ class MultiCheckpointManager:
             return False
 
     def maybe_clean(self) -> None:
-        if not self.world.is_master:
-            return
+        # Run on all ranks: file deletion inside CheckpointManager.maybe_clean is
+        # already master-gated, but the in-memory ckpt_steps update must happen on
+        # every rank, otherwise _should_save() diverges across ranks and the next
+        # save can hit the dist.barrier mismatch in save() -> deadlock.
         for idx in self.multi_run_manager.used_idxs:
             if self.managers[idx] is None:
                 continue

--- a/src/prime_rl/trainer/multi_ckpt.py
+++ b/src/prime_rl/trainer/multi_ckpt.py
@@ -4,6 +4,7 @@ MultiCheckpointManager owns per-run CheckpointManagers and AppStates,
 each saving to its own run directory.
 """
 
+import bisect
 import shutil
 from dataclasses import asdict
 from pathlib import Path
@@ -154,7 +155,12 @@ class MultiCheckpointManager:
                         )
                 dist.barrier()
                 manager.mark_stable(step)
-                manager.ckpt_steps.append(step)
+                # Use insort (like CheckpointManager.save_to_path does) so the
+                # list stays sorted. Plain append would break the
+                # `assert list(ckpt_steps) == sorted(ckpt_steps)` invariant in
+                # maybe_clean when saving a step lower than ones already in the
+                # list (happens on resume with orphan future-step ckpt dirs).
+                bisect.insort(manager.ckpt_steps, step)
             except FileNotFoundError:
                 self.logger.warning(f"Run {idx} deleted during checkpoint, skipping")
             except Exception as e:

--- a/tests/unit/train/test_multi_ckpt.py
+++ b/tests/unit/train/test_multi_ckpt.py
@@ -86,3 +86,33 @@ def test_multi_ckpt_maybe_clean_keeps_ckpt_steps_in_sync_across_ranks(
         f"Got {inner.ckpt_steps}, expected [450]. This divergence is what causes "
         f"the dist.barrier() deadlock inside MultiCheckpointManager.save()."
     )
+
+
+def test_multi_ckpt_save_keeps_ckpt_steps_sorted(tmp_path: Path) -> None:
+    """save() must insert sorted, not append. After maybe_clean trims away the
+    resume step and leaves an orphan future-step (e.g. ckpt_steps=[453] when
+    saving step 450), plain append would yield [453, 450] - violating the
+    `assert list(ckpt_steps) == sorted(ckpt_steps)` invariant in maybe_clean
+    and crashing the trainer on the next iteration.
+    """
+    import bisect
+
+    from prime_rl.configs.trainer import CheckpointConfig
+    from prime_rl.trainer.ckpt import CheckpointManager
+
+    reset_world()
+    runs._MULTI_RUN_MANAGER = None
+    setup_multi_run_manager(output_dir=tmp_path, max_runs=1, device=torch.device("cpu"))
+
+    run_dir = tmp_path / "run_orphan"
+    run_dir.mkdir()
+    (run_dir / "checkpoints").mkdir()
+    (run_dir / "checkpoints" / "step_453").mkdir()
+    manager = CheckpointManager(run_dir, CheckpointConfig(interval=3, keep_last=1))
+    assert manager.ckpt_steps == [453]
+
+    # Mirror multi_ckpt.save's append path post-fix.
+    bisect.insort(manager.ckpt_steps, 450)
+
+    assert manager.ckpt_steps == [450, 453]
+    assert list(manager.ckpt_steps) == sorted(manager.ckpt_steps)

--- a/tests/unit/train/test_multi_ckpt.py
+++ b/tests/unit/train/test_multi_ckpt.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+from typing import Generator
+
+import pytest
+import tomli_w
+import torch
+import torch.distributed as dist
+
+import prime_rl.trainer.runs as runs
+from prime_rl.trainer.multi_ckpt import setup_multi_checkpoint_manager
+from prime_rl.trainer.runs import setup_multi_run_manager
+from prime_rl.trainer.world import World, reset_world
+
+
+@pytest.fixture(autouse=True, scope="module")
+def init_process_group() -> Generator[None, None, None]:
+    dist.init_process_group(backend="gloo", init_method="tcp://localhost:12357", rank=0, world_size=1)
+    yield
+    dist.destroy_process_group()
+
+
+def _create_run_with_ckpt_dirs(output_dir: Path, run_name: str, ckpt_steps: list[int]) -> Path:
+    run_dir = output_dir / run_name
+    run_dir.mkdir()
+    control_dir = run_dir / "control"
+    control_dir.mkdir()
+    ckpt_dir = run_dir / "checkpoints"
+    ckpt_dir.mkdir()
+    for step in ckpt_steps:
+        (ckpt_dir / f"step_{step}").mkdir()
+    config = {
+        "model": {"name": "test-model"},
+        "batch_size": 2,
+        "rollouts_per_example": 1,
+        "env": [{"id": "test-env"}],
+        "sampling": {"temperature": 1.0},
+        "ckpt": {"interval": 3, "keep_last": 1},
+    }
+    with open(control_dir / "orch.toml", "wb") as f:
+        tomli_w.dump(config, f)
+    return run_dir
+
+
+def test_multi_ckpt_maybe_clean_keeps_ckpt_steps_in_sync_across_ranks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression test: MultiCheckpointManager.maybe_clean() must update ckpt_steps
+    on every rank, not just master. Otherwise non-master ranks retain stale entries
+    and a later _should_save() call returns divergent values across ranks, causing
+    the dist.barrier() inside save() to deadlock (master enters the save try block
+    and waits on a barrier that non-master ranks - which took the `continue` path -
+    never participate in).
+
+    Repro pre-fix: master cleans step_440, master's ckpt_steps = [450].
+    Non-master's maybe_clean returned early, ckpt_steps stayed [440, 450].
+    Next attempt to save step 440 would diverge: True on master, False on non-master.
+    """
+    reset_world()
+    runs._MULTI_RUN_MANAGER = None
+    manager = setup_multi_run_manager(output_dir=tmp_path, max_runs=1, device=torch.device("cpu"))
+
+    _create_run_with_ckpt_dirs(tmp_path, "run_test", ckpt_steps=[440, 450])
+    manager.discover_runs()
+    run_idx = manager.id_2_idx["run_test"]
+
+    multi_ckpt, _ = setup_multi_checkpoint_manager(tmp_path)
+    # discover_runs ran before manager was constructed, so manually create the
+    # underlying CheckpointManager for the test (mirrors the run-creation hook flow).
+    multi_ckpt._run_creation_hook(run_idx, "run_test")
+    inner = multi_ckpt.managers[run_idx]
+    assert inner is not None
+    assert inner.ckpt_steps == [440, 450]
+
+    # Simulate a non-master rank. The bug only manifested on non-master ranks
+    # because MultiCheckpointManager.maybe_clean returned early for them,
+    # leaving the in-memory ckpt_steps list stale.
+    monkeypatch.setattr(World, "is_master", property(lambda self: False))
+
+    multi_ckpt.maybe_clean()
+
+    # With keep_last=1, step 440 should be removed from ckpt_steps even on
+    # non-master ranks (file deletion is master-gated inside CheckpointManager,
+    # but the in-memory list update must happen on every rank).
+    assert inner.ckpt_steps == [450], (
+        f"non-master rank's ckpt_steps must be updated to match master. "
+        f"Got {inner.ckpt_steps}, expected [450]. This divergence is what causes "
+        f"the dist.barrier() deadlock inside MultiCheckpointManager.save()."
+    )


### PR DESCRIPTION
## Summary

`MultiCheckpointManager.maybe_clean()` returned early on non-master ranks. Only master's in-memory `ckpt_steps` list was updated when old checkpoint directories were deleted; non-master ranks retained the stale entries. A subsequent `_should_save()` call on the same step could then return divergent values across ranks, causing the trainer to deadlock at the next save.

## Reproducer

A trainer in multi-run mode (`max_concurrent_runs > 1`) starts up with multiple per-run checkpoint directories on disk — say `step_440/` and `step_450/` — both showing up in the filesystem scan that initializes `CheckpointManager.ckpt_steps`. The `step_450` checkpoint is selected as the resume target, so `progress[idx].step = 450`.

```
all ranks: ckpt_steps = [440, 450],  progress.step = 450
```

After the first training iteration, `maybe_clean` runs with `keep_last=1`:

```
master:     CheckpointManager.maybe_clean() runs -> ckpt_steps = [450]
non-master: MultiCheckpointManager.maybe_clean() returns early -> ckpt_steps = [440, 450]   ← drift
```

A few iterations later, the multi-run save loop reaches the resumed step that's still inside the in-memory list. `_should_save(idx, 450)`:

| rank       | `step in ckpt_steps?` | `_should_save` |
| ---------- | --------------------- | -------------- |
| master     | `450 in [450]` → no   | True (saves)   |
| non-master | `450 in [440, 450]` → yes | False (skips)  |

Master enters the save try block in `MultiCheckpointManager.save()` and calls `dist.barrier()` (line 155). Non-master ranks took the `continue` path, never participate in that barrier. Master hangs forever — the whole trainer is dead, no rank files get written, the orchestrator's broadcast wait never resolves.

## Root cause

```python
# Before
def maybe_clean(self) -> None:
    if not self.world.is_master:
        return                               # ← non-master ranks bail before updating ckpt_steps
    for idx in self.multi_run_manager.used_idxs:
        if self.managers[idx] is None:
            continue
        self.managers[idx].maybe_clean()
```

The file deletion inside `CheckpointManager.maybe_clean()` is already master-gated. The early return in the wrapper was redundant for filesystem safety but caused the in-memory `ckpt_steps` list to drift across ranks.

## Fix

Remove the early return so every rank executes the cleanup logic. The actual `_try_rmtree` call inside `CheckpointManager.maybe_clean()` is still master-only, so the on-disk behavior is unchanged. Only the in-memory list update now happens uniformly.

## Why this hasn't bitten more stacks

- Single-run mode (`max_concurrent_runs == 1`) doesn't go through `MultiCheckpointManager` and isn't affected.
- In steady-state multi-run, each run usually has exactly one checkpoint dir on disk at startup, so `maybe_clean` has nothing to delete and `ckpt_steps` never drifts.
- The bug only manifests when the filesystem scan picks up multiple checkpoint dirs (e.g., orphan dirs from a prior crash, or fresh-restart-mid-rotation), AND the resumed step is one that gets cleaned out.

## Regression test

`tests/unit/train/test_multi_ckpt.py::test_multi_ckpt_maybe_clean_keeps_ckpt_steps_in_sync_across_ranks` simulates a non-master rank (via `monkeypatch` on `World.is_master`), sets up two pre-existing checkpoint dirs, and asserts `ckpt_steps` is updated to `[450]` after `maybe_clean`. Pre-fix it stayed `[440, 450]`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches distributed checkpoint coordination logic; if incorrect, it can still cause hangs or inconsistent save/cleanup behavior across ranks, though changes are narrowly scoped and regression-tested.
> 
> **Overview**
> Fixes a multi-rank deadlock/inconsistency in multi-run checkpointing by running `MultiCheckpointManager.maybe_clean()` on **all ranks** so in-memory `ckpt_steps` stays synchronized (file deletions remain master-gated inside `CheckpointManager`).
> 
> Also ensures `MultiCheckpointManager.save()` maintains the `ckpt_steps` sorted invariant by inserting steps with `bisect.insort` instead of appending, avoiding crashes when resuming with orphan future-step checkpoint directories.
> 
> Adds unit regression tests covering both the cross-rank `maybe_clean` synchronization and the sorted `ckpt_steps` behavior on save.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81e0434f1051331a2d30567c2422b228c6b52cd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->