### PR TITLE
feat(orchestrator): make inference pool startup timeout configurable

### DIFF
--- a/src/prime_rl/configs/shared.py
+++ b/src/prime_rl/configs/shared.py
@@ -184,6 +184,14 @@ class ClientConfig(BaseConfig):
         ),
     ] = 30.0
 
+    wait_for_ready_timeout: Annotated[
+        int,
+        Field(
+            description="Timeout in seconds for waiting for the inference pool to become ready at startup. "
+            "Applies to both the static health check and elastic DNS-based discovery. Defaults to 1800 seconds.",
+        ),
+    ] = 1800
+
     base_url: Annotated[
         list[str],
         Field(

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -92,7 +92,9 @@ class StaticInferencePool:
         return next(self._eval_cycle)
 
     async def wait_for_ready(self, model_name: str, timeout: int | None = None) -> None:
-        await check_health(self._admin_clients, timeout=timeout if timeout is not None else self._wait_for_ready_timeout)
+        await check_health(
+            self._admin_clients, timeout=timeout if timeout is not None else self._wait_for_ready_timeout
+        )
         await maybe_check_has_model(self._admin_clients, model_name, skip_model_check=self._skip_model_check)
 
     async def update_weights(self, weight_dir: Path | None, lora_name: str | None = None, step: int = 0) -> None:

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -38,7 +38,7 @@ class InferencePool(Protocol):
         """Get next eval client in round-robin fashion."""
         ...
 
-    async def wait_for_ready(self, model_name: str, timeout: int = 1800) -> None:
+    async def wait_for_ready(self, model_name: str, timeout: int | None = None) -> None:
         """Wait for inference pool to be ready."""
         ...
 
@@ -69,6 +69,7 @@ class StaticInferencePool:
         self._eval_clients = setup_clients(client_config, client_type=eval_client_type)
         self._admin_clients = setup_admin_clients(client_config)
         self._skip_model_check = client_config.skip_model_check
+        self._wait_for_ready_timeout = client_config.wait_for_ready_timeout
         self._eval_cycle = cycle(self._eval_clients)
         self.model_name = model_name
 
@@ -90,8 +91,8 @@ class StaticInferencePool:
     async def get_eval_client(self) -> vf.ClientConfig:
         return next(self._eval_cycle)
 
-    async def wait_for_ready(self, model_name: str, timeout: int = 1800) -> None:
-        await check_health(self._admin_clients, timeout=timeout)
+    async def wait_for_ready(self, model_name: str, timeout: int | None = None) -> None:
+        await check_health(self._admin_clients, timeout=timeout if timeout is not None else self._wait_for_ready_timeout)
         await maybe_check_has_model(self._admin_clients, model_name, skip_model_check=self._skip_model_check)
 
     async def update_weights(self, weight_dir: Path | None, lora_name: str | None = None, step: int = 0) -> None:

--- a/src/prime_rl/utils/elastic.py
+++ b/src/prime_rl/utils/elastic.py
@@ -454,9 +454,7 @@ class ElasticInferencePool:
             # Sync all servers in parallel for faster weight updates
             await asyncio.gather(*[self._sync_server_adapter(ip) for ip in self._servers.keys()])
 
-    async def wait_for_ready(
-        self, model_name: str = "", timeout: int | None = None, min_servers: int = 1
-    ) -> None:
+    async def wait_for_ready(self, model_name: str = "", timeout: int | None = None, min_servers: int = 1) -> None:
         if timeout is None:
             timeout = self.client_config.wait_for_ready_timeout
         start = time.time()

--- a/src/prime_rl/utils/elastic.py
+++ b/src/prime_rl/utils/elastic.py
@@ -454,7 +454,11 @@ class ElasticInferencePool:
             # Sync all servers in parallel for faster weight updates
             await asyncio.gather(*[self._sync_server_adapter(ip) for ip in self._servers.keys()])
 
-    async def wait_for_ready(self, model_name: str = "", timeout: int = 1800, min_servers: int = 1) -> None:
+    async def wait_for_ready(
+        self, model_name: str = "", timeout: int | None = None, min_servers: int = 1
+    ) -> None:
+        if timeout is None:
+            timeout = self.client_config.wait_for_ready_timeout
         start = time.time()
         while time.time() - start < timeout:
             await self.sync()


### PR DESCRIPTION
Adds wait_for_ready_timeout to ClientConfig (default 1800s, matching prior hardcoded value), threaded through StaticInferencePool and ElasticInferencePool so it can be overridden via TOML per-client (e.g. student vs teacher pools).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only parameterizes the inference-pool readiness wait timeout (default unchanged) and threads it through existing static/elastic startup checks.
> 
> **Overview**
> Makes inference pool startup readiness waiting configurable via a new `ClientConfig.wait_for_ready_timeout` (default `1800s`, matching the prior hardcoded value).
> 
> Updates `StaticInferencePool.wait_for_ready` and `ElasticInferencePool.wait_for_ready` to use the config default when no explicit timeout is provided, while still allowing call sites to override the timeout per invocation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f09ade0336527c713d440f95f8661e99836f871a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->