### PR TITLE
fix(monitor): split httpx timeouts so large sample uploads don't WriteTimeout

### DIFF
--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -626,7 +626,7 @@ class PrimeMonitor(Monitor):
         asyncio.set_event_loop(self._loop)
         self._loop.run_forever()
 
-    def _flush(self, timeout: float = 30.0) -> None:
+    def _flush(self, timeout: float = 360.0) -> None:
         """Wait for all pending async requests to complete."""
         if not self.enabled or not hasattr(self, "_loop"):
             return

--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -612,7 +612,9 @@ class PrimeMonitor(Monitor):
         self._loop: asyncio.AbstractEventLoop = asyncio.new_event_loop()
         self._thread = Thread(target=self._run_event_loop, daemon=True)
         self._thread.start()
-        self._client = httpx.AsyncClient(timeout=30)
+        self._client = httpx.AsyncClient(
+            timeout=httpx.Timeout(connect=10.0, read=60.0, write=300.0, pool=10.0)
+        )
         self._pending_futures: list[asyncio.Future] = []
         if hasattr(self, "_pending_sample_steps") and self._pending_sample_steps:
             self._pending_sample_steps.clear()

--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -612,9 +612,7 @@ class PrimeMonitor(Monitor):
         self._loop: asyncio.AbstractEventLoop = asyncio.new_event_loop()
         self._thread = Thread(target=self._run_event_loop, daemon=True)
         self._thread.start()
-        self._client = httpx.AsyncClient(
-            timeout=httpx.Timeout(connect=10.0, read=60.0, write=300.0, pool=10.0)
-        )
+        self._client = httpx.AsyncClient(timeout=httpx.Timeout(connect=10.0, read=60.0, write=300.0, pool=10.0))
         self._pending_futures: list[asyncio.Future] = []
         if hasattr(self, "_pending_sample_steps") and self._pending_sample_steps:
             self._pending_sample_steps.clear()


### PR DESCRIPTION
## Summary
- `PrimeMonitor` used `httpx.AsyncClient(timeout=30)` which applies 30s to connect/read/write/pool. Sample parquet PUTs to R2 on VL/multimodal runs exceed 30s of write time → all 3 retries hit `WriteTimeout`, sample step is dropped, data tab shows gaps.
- Split timeouts: `connect=10s, read=60s, write=300s, pool=10s`.

## Repro
Run `lv813rbcjv6nvlunqz3bx1c7` (Qwen3-VL-4B + browserbase): `stepsWithSamples=[0,20,30,60,90]` vs `stepsWithDistributions=[0,10,20,30,40,50,60,70,80,90]`. Orchestrator log: `Failed to upload to R2 after 3 attempts: WriteTimeout`. Distributions (tiny) always succeed; samples (large) fail ~50%.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adjusts HTTP client timeout configuration and the wait time for draining pending async uploads, which may slightly increase shutdown latency but should reduce upload failures for large payloads.
> 
> **Overview**
> **Improves reliability of PrimeMonitor sample uploads.** The async `httpx.AsyncClient` timeout is changed from a single 30s limit to split timeouts (`connect=10s`, `read=60s`, `write=300s`, `pool=10s`) to avoid `WriteTimeout` on large Parquet PUTs.
> 
> Also increases the default `_flush()` wait from `30s` to `360s` so `close()` is more likely to drain pending async requests before shutdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf3bf45bd4983d2cc6cca3ecaeba3c1c86197fd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->