### PR TITLE
Fix/loss scale skew

### DIFF
--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -214,9 +214,7 @@ def compute_loss(
         advantages: Advantages for each sequence
         loss_mask: Loss mask for each sequence
         loss_fn: Per-sequence loss function
-        loss_scale: Total number of loss-contributing tokens across all DP ranks for this step.
-            Normalizes the loss so gradients average uniformly across tokens regardless of
-            per-rank token-count skew.
+        loss_scale: Scale factor representing the total number of loss tokens in the batch
 
     Returns:
         Tuple of (scaled_loss, aggregated_metrics)

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -202,7 +202,7 @@ def compute_loss(
     advantages: list[Float[Tensor, " seq_i"]],
     loss_mask: list[Bool[Tensor, " seq_i"]],
     loss_fn: LossFn,
-    loss_scale: int,
+    global_token_count: int,
 ) -> tuple[Float[Tensor, ""], dict[str, Any]]:
     """
     Compute loss for packed sequences (batch size = 1, multiple sequences packed along sequence dimension).
@@ -214,7 +214,7 @@ def compute_loss(
         advantages: Advantages for each sequence
         loss_mask: Loss mask for each sequence
         loss_fn: Per-sequence loss function
-        loss_scale: Scale factor to normalize the loss
+        global_token_count: Total number of loss-contributing tokens across all DP ranks for this step, used to normalize the loss so that gradients average uniformly across tokens regardless of per-rank token-count skew
 
     Returns:
         Tuple of (scaled_loss, aggregated_metrics)
@@ -245,7 +245,7 @@ def compute_loss(
                 all_metrics[k] = []
             all_metrics[k].append(v)
 
-    scaled_loss = total_loss / loss_scale
+    scaled_loss = total_loss / global_token_count
 
     aggregated: dict[str, Any] = {}
     for k, v in all_metrics.items():

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -202,7 +202,7 @@ def compute_loss(
     advantages: list[Float[Tensor, " seq_i"]],
     loss_mask: list[Bool[Tensor, " seq_i"]],
     loss_fn: LossFn,
-    global_token_count: int,
+    loss_scale: int,
 ) -> tuple[Float[Tensor, ""], dict[str, Any]]:
     """
     Compute loss for packed sequences (batch size = 1, multiple sequences packed along sequence dimension).
@@ -214,7 +214,9 @@ def compute_loss(
         advantages: Advantages for each sequence
         loss_mask: Loss mask for each sequence
         loss_fn: Per-sequence loss function
-        global_token_count: Total number of loss-contributing tokens across all DP ranks for this step, used to normalize the loss so that gradients average uniformly across tokens regardless of per-rank token-count skew
+        loss_scale: Total number of loss-contributing tokens across all DP ranks for this step.
+            Normalizes the loss so gradients average uniformly across tokens regardless of
+            per-rank token-count skew.
 
     Returns:
         Tuple of (scaled_loss, aggregated_metrics)
@@ -245,7 +247,7 @@ def compute_loss(
                 all_metrics[k] = []
             all_metrics[k].append(v)
 
-    scaled_loss = total_loss / global_token_count
+    scaled_loss = total_loss / loss_scale
 
     aggregated: dict[str, Any] = {}
     for k, v in all_metrics.items():

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -318,9 +318,26 @@ def train(config: TrainerConfig):
         forward_backward_start_time = time.perf_counter()
         seq_len = micro_batches[0]["input_ids"].shape[1]
 
-        # Normalize by the local number of unmasked tokens in the batch (per-batch length normalization)
+        # Local number of unmasked (loss-contributing) tokens on this DP rank for this step.
         loss_scale = sum(micro_batch["loss_mask"].sum().item() for micro_batch in micro_batches)
         loss_scale = max(loss_scale, 1)
+
+        # --- loss_scale diagnostic: gather across dp_cp ranks ---
+        local = torch.tensor([loss_scale], dtype=torch.float64, device="cuda")
+        dp_cp_group = parallel_dims.world_mesh["dp_cp"].get_group()
+        dp_cp_world_size = dist.get_world_size(dp_cp_group)
+        gathered = [torch.zeros_like(local) for _ in range(dp_cp_world_size)]
+        dist.all_gather(gathered, local, group=dp_cp_group)
+        scales = torch.stack(gathered).squeeze()  # shape: [dp_cp_world_size]
+        # --- end diagnostic gather ---
+
+        # Sum local loss_scales into the true global token count, used to normalize the loss so
+        # that gradients average uniformly across tokens regardless of per-rank token-count skew.
+        global_token_count = scales.sum().item()
+        global_token_count = max(global_token_count, 1)
+
+        # Running sum of per-rank loss across microbatches; all-reduced below for logging.
+        step_local_loss_sum = torch.tensor(0.0, device="cuda")
 
         logger.debug(f"Starting forward and backward pass ({batch_size=})")
         tensors = Tensors()  # Used to accumulate tensor statistics across micro-batches and ranks for logging
@@ -444,12 +461,16 @@ def train(config: TrainerConfig):
                 advantages=advantages.squeeze().split(response_lengths),
                 loss_mask=loss_mask.squeeze().split(response_lengths),
                 loss_fn=loss_fn,
-                loss_scale=loss_scale,
+                global_token_count=global_token_count,
             )
 
             # Backward pass
             with maybe_record_function("backward"):
                 loss.backward()
+
+            # loss is already divided by global_token_count, so summing across microbatches and
+            # all-reducing across ranks yields the global token-weighted mean loss directly.
+            step_local_loss_sum += loss.detach()
 
             # Add relevant tensors to tensor dict for logging purposes
             tensors["entropy"].append(out["entropy"][loss_mask].detach().to("cpu"))
@@ -473,6 +494,18 @@ def train(config: TrainerConfig):
             if "max_vio" in tensors:
                 micro_step_message += f" | Max Vio: {tensors['max_vio'][-1].mean().item():.4f}"
             logger.debug(micro_step_message)
+
+        # compute_loss divided by global_token_count, so each rank's grad contribution is already
+        # scaled by 1/global_token_count. FSDP then divided the all-reduced grad by
+        # fsdp_gradient_divide_factor. Multiply by fsdp_gradient_divide_factor to recover the true
+        # global token-weighted mean gradient.
+        for param in model.parameters():
+            if param.grad is not None:
+                param.grad.mul_(parallel_dims.fsdp_gradient_divide_factor)
+
+        # All-reduce the per-rank loss sums to get the global token-weighted mean loss for logging.
+        dist.all_reduce(step_local_loss_sum, op=dist.ReduceOp.SUM, group=dp_cp_group)
+        global_mean_loss = step_local_loss_sum.item()
 
         # Optionally, clip the gradients
         grad_norm: torch.Tensor | None = None
@@ -573,6 +606,30 @@ def train(config: TrainerConfig):
         disk_metrics = get_ckpt_disk_metrics(config.output_dir)
         disk_metrics["step"] = progress.step
         monitor.log(disk_metrics, step=progress.step)
+
+        # --- loss_scale diagnostic metrics ---
+        loss_scale_metrics = {
+            "loss_scale/local": loss_scale,
+            "loss_scale/mean": scales.mean().item(),
+            "loss_scale/std": scales.std().item(),
+            "loss_scale/min": scales.min().item(),
+            "loss_scale/max": scales.max().item(),
+            "loss_scale/cov": (scales.std() / scales.mean()).item(),
+            "loss_scale/max_ratio": (scales.max() / scales.min()).item(),
+            "step": progress.step,
+        }
+        monitor.log(loss_scale_metrics, step=progress.step)
+        # --- end diagnostic metrics ---
+
+        # Global token-weighted mean loss (unbiased across DP ranks with uneven loss_scale).
+        monitor.log(
+            {
+                "loss/global_mean": global_mean_loss,
+                "loss/global_token_count": global_token_count,
+                "step": progress.step,
+            },
+            step=progress.step,
+        )
 
         # Update Prometheus metrics if configured
         if metrics_server is not None:

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -322,14 +322,15 @@ def train(config: TrainerConfig):
         loss_scale = sum(micro_batch["loss_mask"].sum().item() for micro_batch in micro_batches)
         loss_scale = max(loss_scale, 1)
 
-        # --- loss_scale diagnostic: gather across dp_cp ranks ---
+        # Gather loss_scale across DP ranks only (not dp_cp). CP ranks within a DP cell process
+        # the same microbatches, so their loss_scale values are duplicates; gathering across dp_cp
+        # would inflate the global token count by a factor of cp.
         local = torch.tensor([loss_scale], dtype=torch.float64, device="cuda")
-        dp_cp_group = parallel_dims.world_mesh["dp_cp"].get_group()
-        dp_cp_world_size = dist.get_world_size(dp_cp_group)
-        gathered = [torch.zeros_like(local) for _ in range(dp_cp_world_size)]
-        dist.all_gather(gathered, local, group=dp_cp_group)
-        scales = torch.stack(gathered).squeeze()  # shape: [dp_cp_world_size]
-        # --- end diagnostic gather ---
+        dp_group = parallel_dims.world_mesh["dp"].get_group()
+        dp_world_size = dist.get_world_size(dp_group)
+        gathered = [torch.zeros_like(local) for _ in range(dp_world_size)]
+        dist.all_gather(gathered, local, group=dp_group)
+        scales = torch.stack(gathered).squeeze()  # shape: [dp_world_size]
 
         # Sum local loss_scales into the true global token count, used to normalize the loss so
         # that gradients average uniformly across tokens regardless of per-rank token-count skew.
@@ -504,7 +505,9 @@ def train(config: TrainerConfig):
                 param.grad.mul_(parallel_dims.fsdp_gradient_divide_factor)
 
         # All-reduce the per-rank loss sums to get the global token-weighted mean loss for logging.
-        dist.all_reduce(step_local_loss_sum, op=dist.ReduceOp.SUM, group=dp_cp_group)
+        # Reduce over DP only (not dp_cp): CP ranks within a DP cell hold identical loss values,
+        # so summing over dp_cp would inflate the result by a factor of cp.
+        dist.all_reduce(step_local_loss_sum, op=dist.ReduceOp.SUM, group=dp_group)
         global_mean_loss = step_local_loss_sum.item()
 
         # Optionally, clip the gradients

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -318,7 +318,7 @@ def train(config: TrainerConfig):
         forward_backward_start_time = time.perf_counter()
         seq_len = micro_batches[0]["input_ids"].shape[1]
 
-        # Local number of unmasked (loss-contributing) tokens on this DP rank for this step.
+        # Normalize by the local number of unmasked tokens in the batch (per-batch length normalization)
         loss_scale = sum(micro_batch["loss_mask"].sum().item() for micro_batch in micro_batches)
         loss_scale = max(loss_scale, 1)
 

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -492,11 +492,11 @@ def train(config: TrainerConfig):
                 micro_step_message += f" | Max Vio: {tensors['max_vio'][-1].mean().item():.4f}"
             logger.debug(micro_step_message)
 
-        # compute_loss divided by global_token_count so multiplying by fsdp_gradient_divide_factor to recover the true
-        # mean per-token gradient.
+        # compute_loss already divides by the global token count. FSDP averages across DP and CP,
+        # but differentiable CP gathers already contribute the CP factor, so only undo DP averaging.
         for param in model.parameters():
             if param.grad is not None:
-                param.grad.mul_(parallel_dims.fsdp_gradient_divide_factor)
+                param.grad.mul_(dp_world_size)
 
         # All-reduce over the per-rank loss sums over DP ranks to get the mean per-token loss for logging.
         dist.all_reduce(step_local_loss_sum, op=dist.ReduceOp.SUM, group=dp_group)

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -322,9 +322,7 @@ def train(config: TrainerConfig):
         loss_scale = sum(micro_batch["loss_mask"].sum().item() for micro_batch in micro_batches)
         loss_scale = max(loss_scale, 1)
 
-        # Gather loss_scale across DP ranks only (not dp_cp). CP ranks within a DP cell process
-        # the same microbatches, so their loss_scale values are duplicates; gathering across dp_cp
-        # would inflate the global token count by a factor of cp.
+        # Gather loss_scale across DP ranks
         local = torch.tensor([loss_scale], dtype=torch.float64, device="cuda")
         dp_group = parallel_dims.world_mesh["dp"].get_group()
         dp_world_size = dist.get_world_size(dp_group)
@@ -332,8 +330,7 @@ def train(config: TrainerConfig):
         dist.all_gather(gathered, local, group=dp_group)
         scales = torch.stack(gathered).squeeze()  # shape: [dp_world_size]
 
-        # Sum local loss_scales into the true global token count, used to normalize the loss so
-        # that gradients average uniformly across tokens regardless of per-rank token-count skew.
+        # Sum local loss_scales into the global count of loss tokens
         global_token_count = scales.sum().item()
         global_token_count = max(global_token_count, 1)
 
@@ -469,8 +466,7 @@ def train(config: TrainerConfig):
             with maybe_record_function("backward"):
                 loss.backward()
 
-            # loss is already divided by global_token_count, so summing across microbatches and
-            # all-reducing across ranks yields the global token-weighted mean loss directly.
+            # compute sum of per-token loss (scaled by 1/global_token_count) across microbatches for each rank
             step_local_loss_sum += loss.detach()
 
             # Add relevant tensors to tensor dict for logging purposes
@@ -496,17 +492,13 @@ def train(config: TrainerConfig):
                 micro_step_message += f" | Max Vio: {tensors['max_vio'][-1].mean().item():.4f}"
             logger.debug(micro_step_message)
 
-        # compute_loss divided by global_token_count, so each rank's grad contribution is already
-        # scaled by 1/global_token_count. FSDP then divided the all-reduced grad by
-        # fsdp_gradient_divide_factor. Multiply by fsdp_gradient_divide_factor to recover the true
-        # global token-weighted mean gradient.
+        # compute_loss divided by global_token_count so multiplying by fsdp_gradient_divide_factor to recover the true
+        # mean per-token gradient.
         for param in model.parameters():
             if param.grad is not None:
                 param.grad.mul_(parallel_dims.fsdp_gradient_divide_factor)
 
-        # All-reduce the per-rank loss sums to get the global token-weighted mean loss for logging.
-        # Reduce over DP only (not dp_cp): CP ranks within a DP cell hold identical loss values,
-        # so summing over dp_cp would inflate the result by a factor of cp.
+        # All-reduce over the per-rank loss sums over DP ranks to get the mean per-token loss for logging.
         dist.all_reduce(step_local_loss_sum, op=dist.ReduceOp.SUM, group=dp_group)
         global_mean_loss = step_local_loss_sum.item()
 
@@ -624,7 +616,7 @@ def train(config: TrainerConfig):
         monitor.log(loss_scale_metrics, step=progress.step)
         # --- end diagnostic metrics ---
 
-        # Global token-weighted mean loss (unbiased across DP ranks with uneven loss_scale).
+        # mean per-token loss
         monitor.log(
             {
                 "loss/global_mean": global_mean_loss,

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -461,7 +461,7 @@ def train(config: TrainerConfig):
                 advantages=advantages.squeeze().split(response_lengths),
                 loss_mask=loss_mask.squeeze().split(response_lengths),
                 loss_fn=loss_fn,
-                global_token_count=global_token_count,
+                loss_scale=global_token_count,
             )
 
             # Backward pass

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -324,8 +324,9 @@ def train(config: TrainerConfig):
 
         # Gather loss_scale across DP ranks
         local = torch.tensor([loss_scale], dtype=torch.float64, device="cuda")
-        dp_group = parallel_dims.world_mesh["dp"].get_group()
-        dp_world_size = dist.get_world_size(dp_group)
+        dp_mesh = parallel_dims.get_mesh("dp")
+        dp_group = dp_mesh.get_group()
+        dp_world_size = dp_mesh.size()
         gathered = [torch.zeros_like(local) for _ in range(dp_world_size)]
         dist.all_gather(gathered, local, group=dp_group)
         scales = torch.stack(gathered).squeeze()  # shape: [dp_world_size]


### PR DESCRIPTION
## Summary

Fixes gradient bias introduced when DP ranks process different numbers of loss-contributing tokens per step (closes #2358 ).

**Root cause.** Each DP rank computes a local `loss_scale` — the number of unmasked tokens contributing to the loss on that rank — and divides each microbatch's summed token loss by it before `.backward()`. As microbatches accumulate, the local gradient on each rank ends up scaled by its own `loss_scale`. When FSDP scatter-reduces these local gradients, it takes an average  — but because each rank normalized by a different denominator, the result is not a true per-token mean. Ranks with fewer loss tokens get upweighted relative to ranks with more, biasing the gradient in proportion to how unequal the token counts are. We verified this skew is real: see the linked issue for W&B plots showing `loss_scale/max_ratio` deviating from 1.0 during training.

**Fix.** All changes are confined to `src/prime_rl/trainer/rl/train.py` and a minor comment tweak in src/prime_rl/trainer/rl/loss.py. Before the microbatch loop, we all-gather `loss_scale` across the `dp` mesh and sum them into a single global token count. We deliberately gather over `dp` rather than `dp_cp`: CP ranks within a DP cell receive identical microbatches and therefore identical `loss_scale` values, so gathering over `dp_cp` would inflate the global count by a factor of `cp`. The global count is passed to `compute_loss` as the normalization denominator instead of the local `loss_scale`, so every rank divides by the same value and their gradient contributions are commensurate. After the microbatch loop, we multiply each parameter's gradient by `dp_world_size` to undo FSDP's built-in division and recover the true global per-token mean. 

**Diagnostics.** The same `all_gather` (over `dp`) is used to log `loss_scale/local`, `/mean`, `/std`, `/cov`, `/min`, `/max`, and `/max_ratio` to W&B each step, providing ongoing visibility into per-rank loss-token count skew.

**Testing.** Passed/Verified against `tests/integration/test_rl.py`