### PR TITLE
feat: add per-env rollout_timeout for train and eval rollouts

### DIFF
--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -324,6 +324,18 @@ class EnvConfig(BaseConfig):
         ),
     ] = -1
 
+    rollout_timeout: Annotated[
+        float | None,
+        Field(
+            gt=0,
+            description=(
+                "Per-rollout wall-clock timeout in seconds, applied to both train and eval rollouts. "
+                "When the timeout fires, the rollout task is cancelled and surfaced as a failure "
+                "(reschedule for train, counted as failed for eval). None (default) disables the timeout."
+            ),
+        ),
+    ] = None
+
     @property
     def stripped_id(self) -> str:
         """Environment ID without the @version suffix."""

--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -118,7 +118,7 @@ class Env:
         cache_salt: str,
     ) -> vf.RolloutOutput:
         """Run a single rollout for an example."""
-        return await self.env.run_rollout(
+        coro = self.env.run_rollout(
             vf.RolloutInput(**example),
             client=client,
             model=model_name,
@@ -127,6 +127,7 @@ class Env:
             state_columns=REQUIRED_STATE_COLUMNS,
             env_client=self.env_client,
         )
+        return await asyncio.wait_for(coro, timeout=self.config.rollout_timeout)
 
     async def run_group(
         self,
@@ -137,7 +138,7 @@ class Env:
         cache_salt: str,
     ) -> list[vf.RolloutOutput]:
         """Run a group of rollouts for an example. Required for group-scoring envs."""
-        return await self.env.run_group(
+        coro = self.env.run_group(
             [vf.RolloutInput(**example) for _ in range(rollouts_per_example)],
             client=client,
             model=model_name,
@@ -146,6 +147,7 @@ class Env:
             state_columns=REQUIRED_STATE_COLUMNS,
             env_client=self.env_client,
         )
+        return await asyncio.wait_for(coro, timeout=self.config.rollout_timeout)
 
     def shutdown(self) -> None:
         if self._env_server_process is None:


### PR DESCRIPTION
## Summary
- Adds a `rollout_timeout` field to base `EnvConfig` (inherited by `TrainEnvConfig` and `EvalEnvConfig`) that bounds the wall-clock duration of a single rollout (or rollout group) via `asyncio.wait_for`.
- Shared between train and eval — same per-env setting applies to both code paths.
- Default `None` (no timeout); on timeout the rollout task is cancelled and the resulting `TimeoutError` flows through existing failure paths (reschedule for train, counted as failed for eval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)