### PR TITLE
fix(models): document cache_position to silence auto_docstring warnings

### DIFF
--- a/src/prime_rl/trainer/models/glm4_moe/modeling_glm4_moe.py
+++ b/src/prime_rl/trainer/models/glm4_moe/modeling_glm4_moe.py
@@ -278,6 +278,10 @@ class Glm4MoeForCausalLM(Glm4MoePreTrainedModel, GenerationMixin):
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
+        cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
+            Indices of input tokens in the KV cache. Accepted only for HuggingFace API
+            compatibility — prime-rl asserts `use_cache is None` since training does not
+            perform autoregressive decoding, so this argument is unused.
         labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
             Labels used by PrimeRL's wrapped LM head to optionally compute per-token logprobs/entropy.
             If not provided, the wrapped LM head returns logits only.

--- a/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
+++ b/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
@@ -307,6 +307,10 @@ class GlmMoeDsaForCausalLM(GlmMoeDsaPreTrainedModel, GenerationMixin):
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
+        cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
+            Indices of input tokens in the KV cache. Accepted only for HuggingFace API
+            compatibility — prime-rl asserts `use_cache is None` since training does not
+            perform autoregressive decoding, so this argument is unused.
         labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
             Labels used by PrimeRL's wrapped LM head to optionally compute per-token logprobs/entropy.
         temperature (`torch.Tensor` of shape `(batch_size, sequence_length)`, *optional*):

--- a/src/prime_rl/trainer/models/llama/modeling_llama.py
+++ b/src/prime_rl/trainer/models/llama/modeling_llama.py
@@ -252,6 +252,10 @@ class LlamaForCausalLM(LlamaPreTrainedModel, GenerationMixin):
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
+        cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
+            Indices of input tokens in the KV cache. Accepted only for HuggingFace API
+            compatibility — prime-rl asserts `use_cache is None` since training does not
+            perform autoregressive decoding, so this argument is unused.
         labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
             Labels used by PrimeRL's wrapped LM head to optionally compute per-token logprobs/entropy.
             If not provided, the wrapped LM head returns logits only.

--- a/src/prime_rl/trainer/models/minimax_m2/modeling_minimax_m2.py
+++ b/src/prime_rl/trainer/models/minimax_m2/modeling_minimax_m2.py
@@ -240,6 +240,10 @@ class MiniMaxM2ForCausalLM(MiniMaxM2PreTrainedModel, GenerationMixin):
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
+        cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
+            Indices of input tokens in the KV cache. Accepted only for HuggingFace API
+            compatibility — prime-rl asserts `use_cache is None` since training does not
+            perform autoregressive decoding, so this argument is unused.
         labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
             Labels for computing the masked language modeling loss.
         temperature (`torch.Tensor` of shape `(batch_size, sequence_length)`, *optional*):

--- a/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
@@ -374,6 +374,10 @@ class Qwen3MoeForCausalLM(Qwen3MoePreTrainedModel, GenerationMixin):
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         r"""
+        cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
+            Indices of input tokens in the KV cache. Accepted only for HuggingFace API
+            compatibility — prime-rl asserts `use_cache is None` since training does not
+            perform autoregressive decoding, so this argument is unused.
         labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
             Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
             config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored


### PR DESCRIPTION
## Summary

- Five custom `*ForCausalLM` models (`llama`, `glm4_moe`, `glm_moe_dsa`, `minimax_m2`, `qwen3_moe`) print `[ERROR] \`cache_position\` is part of ...'s signature, but not documented` at import time. The message comes from transformers' `@auto_docstring` decorator (`utils/auto_docstring.py:3351`).
- These models accept `cache_position` only for HuggingFace API compatibility — they assert `use_cache is None` and never run autoregressive decoding, so the argument is unused. Documenting that fact in each forward's docstring is the right resolution; it clears the warning *and* makes the behavior explicit for future readers.
- No code changes; docstring-only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only updates across several model `forward` methods; no runtime behavior or data handling changes.
> 
> **Overview**
> Adds missing `cache_position` parameter documentation to the `forward` docstrings of five custom `*ForCausalLM` models (`llama`, `glm4_moe`, `glm_moe_dsa`, `minimax_m2`, `qwen3_moe`) to satisfy Transformers `@auto_docstring` requirements.
> 
> The new text clarifies that `cache_position` is accepted solely for HuggingFace API compatibility and is unused because these training-only implementations assert `use_cache is None` (no autoregressive KV-cache decoding).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 020b53cbcc75c67a14bc20cfa10748ff18de7659. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->