### PR TITLE
[Fix] gpt oss

### DIFF
--- a/src/prime_rl/trainer/lora.py
+++ b/src/prime_rl/trainer/lora.py
@@ -207,7 +207,7 @@ def apply_lora_to_model(model: nn.Module, config: LoRAConfig) -> None:
         else:
             logger.warning(
                 f"Module {module_name} is type {type(base_module).__name__}, "
-                f"expected nn.Linear, GroupedExperts, or NonGatedGroupedExperts. Skipping."
+                f"expected nn.Linear, GroupedExperts, NonGatedGroupedExperts, or GptOssGroupedExperts. Skipping."
             )
             continue
 

--- a/src/prime_rl/trainer/lora.py
+++ b/src/prime_rl/trainer/lora.py
@@ -6,8 +6,12 @@ import torch.nn as nn
 
 from prime_rl.configs.trainer import LoRAConfig
 from prime_rl.trainer.models.layers.lora import MultiLoRALinear, MultiLoRAModule
-from prime_rl.trainer.models.layers.lora.multi_moe import MultiLoRAGroupedExperts, MultiLoRANonGatedGroupedExperts
-from prime_rl.trainer.models.layers.moe import GroupedExperts, NonGatedGroupedExperts
+from prime_rl.trainer.models.layers.lora.multi_moe import (
+    MultiLoRAGptOssGroupedExperts,
+    MultiLoRAGroupedExperts,
+    MultiLoRANonGatedGroupedExperts,
+)
+from prime_rl.trainer.models.layers.moe import GptOssGroupedExperts, GroupedExperts, NonGatedGroupedExperts
 from prime_rl.trainer.runs import get_multi_run_manager
 from prime_rl.utils.logger import get_logger
 
@@ -74,8 +78,8 @@ def _find_target_modules(model: nn.Module, target_patterns: List[str]) -> List[s
     target_modules = []
 
     for name, module in model.named_modules():
-        # Check if module is Linear or (NonGated)GroupedExperts
-        if not isinstance(module, (nn.Linear, GroupedExperts, NonGatedGroupedExperts)):
+        # Check if module is Linear or one of the supported expert classes
+        if not isinstance(module, (nn.Linear, GroupedExperts, NonGatedGroupedExperts, GptOssGroupedExperts)):
             continue
 
         for pattern in target_patterns:
@@ -185,6 +189,15 @@ def apply_lora_to_model(model: nn.Module, config: LoRAConfig) -> None:
         # Handle NonGatedGroupedExperts (relu2 experts used by NemotronH's LatentMoE)
         elif isinstance(base_module, NonGatedGroupedExperts):
             lora_module = MultiLoRANonGatedGroupedExperts(
+                base_layer=base_module,
+                rank=config.rank,
+                n_adapters=n_loras,
+                alpha=config.alpha,
+                dropout=config.dropout,
+            )
+        # Handle GptOssGroupedExperts (gpt-oss fused gate_up + biases)
+        elif isinstance(base_module, GptOssGroupedExperts):
+            lora_module = MultiLoRAGptOssGroupedExperts(
                 base_layer=base_module,
                 rank=config.rank,
                 n_adapters=n_loras,

--- a/src/prime_rl/trainer/models/__init__.py
+++ b/src/prime_rl/trainer/models/__init__.py
@@ -12,6 +12,7 @@ from prime_rl.trainer.models.afmoe import AfmoeConfig, AfmoeForCausalLM
 from prime_rl.trainer.models.base import PreTrainedModelPrimeRL
 from prime_rl.trainer.models.glm4_moe import Glm4MoeConfig, Glm4MoeForCausalLM
 from prime_rl.trainer.models.glm_moe_dsa import GlmMoeDsaConfig, GlmMoeDsaForCausalLM
+from prime_rl.trainer.models.gpt_oss import GptOssConfig, GptOssForCausalLM
 from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput, cast_float_and_contiguous
 from prime_rl.trainer.models.llama import LlamaForCausalLM
 from prime_rl.trainer.models.minimax_m2 import MiniMaxM2Config, MiniMaxM2ForCausalLM
@@ -27,6 +28,7 @@ AutoConfig.register("minimax_m2", MiniMaxM2Config, exist_ok=True)
 AutoConfig.register("nemotron_h", NemotronHConfig, exist_ok=True)
 AutoConfig.register("qwen3_moe", Qwen3MoeConfig, exist_ok=True)
 AutoConfig.register("qwen3_5_moe_text", Qwen3_5MoeConfig, exist_ok=True)
+# GptOssConfig is just HF's class - already registered by transformers, no override needed.
 
 _CUSTOM_CAUSAL_LM_MAPPING = _LazyAutoMapping(CONFIG_MAPPING_NAMES, OrderedDict())
 _CUSTOM_CAUSAL_LM_MAPPING.register(LlamaConfig, LlamaForCausalLM, exist_ok=True)
@@ -37,6 +39,7 @@ _CUSTOM_CAUSAL_LM_MAPPING.register(MiniMaxM2Config, MiniMaxM2ForCausalLM, exist_
 _CUSTOM_CAUSAL_LM_MAPPING.register(NemotronHConfig, NemotronHForCausalLM, exist_ok=True)
 _CUSTOM_CAUSAL_LM_MAPPING.register(Qwen3MoeConfig, Qwen3MoeForCausalLM, exist_ok=True)
 _CUSTOM_CAUSAL_LM_MAPPING.register(Qwen3_5MoeConfig, Qwen3_5MoeForCausalLM, exist_ok=True)
+_CUSTOM_CAUSAL_LM_MAPPING.register(GptOssConfig, GptOssForCausalLM, exist_ok=True)
 
 
 class AutoModelForCausalLMPrimeRL(_BaseAutoModelClass):

--- a/src/prime_rl/trainer/models/gpt_oss/__init__.py
+++ b/src/prime_rl/trainer/models/gpt_oss/__init__.py
@@ -1,0 +1,13 @@
+from prime_rl.trainer.models.gpt_oss.configuration_gpt_oss import GptOssConfig
+from prime_rl.trainer.models.gpt_oss.modeling_gpt_oss import (
+    GptOssForCausalLM,
+    GptOssModel,
+    GptOssPreTrainedModel,
+)
+
+__all__ = [
+    "GptOssConfig",
+    "GptOssForCausalLM",
+    "GptOssModel",
+    "GptOssPreTrainedModel",
+]

--- a/src/prime_rl/trainer/models/gpt_oss/configuration_gpt_oss.py
+++ b/src/prime_rl/trainer/models/gpt_oss/configuration_gpt_oss.py
@@ -1,0 +1,6 @@
+# Re-export HF's GptOssConfig so the parameter naming and rope/sliding-window defaults
+# stay in sync with upstream. We don't need to subclass it: the only PrimeRL-specific
+# behavior lives in modeling_gpt_oss.py (custom MoE for LoRA detection).
+from transformers.models.gpt_oss.configuration_gpt_oss import GptOssConfig
+
+__all__ = ["GptOssConfig"]

--- a/src/prime_rl/trainer/models/gpt_oss/converting_gpt_oss.py
+++ b/src/prime_rl/trainer/models/gpt_oss/converting_gpt_oss.py
@@ -1,0 +1,28 @@
+"""State-dict conversion for GPT-OSS.
+
+The custom prime-rl GPT-OSS implementation mirrors HuggingFace's parameter naming
+exactly (gate_up_proj/gate_up_proj_bias/down_proj/down_proj_bias plus router.weight
+and router.bias as nn.Parameters). So loading the unsloth BF16 checkpoint requires
+no key conversion - HF and prime formats are identical for this model.
+"""
+
+from torch import Tensor
+
+
+def is_hf_state_dict(state_dict: dict[str, Tensor]) -> bool:
+    return any("mlp.experts.gate_up_proj" in name for name in state_dict.keys())
+
+
+def is_prime_state_dict(state_dict: dict[str, Tensor]) -> bool:
+    # Prime format equals HF format for GPT-OSS, so we never claim to be a separate
+    # prime format - this disables the auto-conversion path in load_dcp_from_hf and
+    # lets DCP load HF safetensors directly.
+    return False
+
+
+def convert_to_hf(state_dict: dict[str, Tensor]) -> dict[str, Tensor]:
+    return state_dict
+
+
+def convert_to_prime(state_dict: dict[str, Tensor]) -> dict[str, Tensor]:
+    return state_dict

--- a/src/prime_rl/trainer/models/gpt_oss/modeling_gpt_oss.py
+++ b/src/prime_rl/trainer/models/gpt_oss/modeling_gpt_oss.py
@@ -1,0 +1,349 @@
+# GPT-OSS model with PrimeRL custom MoE.
+#
+# This file mirrors HuggingFace's modeling_gpt_oss.py but swaps the experts module for
+# `GptOssGroupedExperts` so the LoRA detection logic in `prime_rl/trainer/lora.py` can
+# find and adapt the expert weights. Attention, rotary embedding, and RMSNorm are reused
+# from HF as-is - they correctly handle attention sinks and gpt-oss's split-rotate RoPE.
+
+from typing import Union
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor, nn
+from transformers.cache_utils import Cache
+from transformers.generation import GenerationMixin
+from transformers.masking_utils import create_causal_mask, create_sliding_window_causal_mask
+from transformers.modeling_layers import GradientCheckpointingLayer
+from transformers.modeling_outputs import MoeModelOutputWithPast
+from transformers.models.gpt_oss.modeling_gpt_oss import (
+    GptOssAttention,
+    GptOssRMSNorm,
+    GptOssRotaryEmbedding,
+)
+from transformers.processing_utils import Unpack
+from transformers.utils import TransformersKwargs, auto_docstring, can_return_tuple
+
+from prime_rl.trainer.models.base import PreTrainedModelPrimeRL
+from prime_rl.trainer.models.gpt_oss.configuration_gpt_oss import GptOssConfig
+from prime_rl.trainer.models.gpt_oss.converting_gpt_oss import (
+    convert_to_hf,
+    convert_to_prime,
+    is_hf_state_dict,
+    is_prime_state_dict,
+)
+from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput
+from prime_rl.trainer.models.layers.moe import GptOssGroupedExperts
+
+
+class GptOssTopKRouter(nn.Module):
+    """Token-choice top-k router matching HF's GptOssTopKRouter parameter naming.
+
+    Stores `weight` (num_experts, hidden_size) and `bias` (num_experts) as raw nn.Parameters
+    so the unsloth BF16 checkpoint loads with no key conversion. Returns the same outputs as
+    `TokenChoiceTopKRouter` so the surrounding MoE plumbing matches the rest of the repo.
+    """
+
+    def __init__(self, config: GptOssConfig):
+        super().__init__()
+        self.num_experts = config.num_local_experts
+        self.top_k = config.num_experts_per_tok
+        self.hidden_size = config.hidden_size
+        self.weight = nn.Parameter(torch.empty(self.num_experts, self.hidden_size))
+        self.bias = nn.Parameter(torch.empty(self.num_experts))
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """x: (T, hidden). Returns (top_scores, top_indices, num_tokens_per_expert).
+
+        Matches HF's softmax-after-topk semantics: we softmax the top-k logits only,
+        not the full distribution.
+        """
+        logits = F.linear(x, self.weight, self.bias)  # (T, num_experts)
+        top_logits, top_indices = torch.topk(logits, self.top_k, dim=-1)
+        top_scores = F.softmax(top_logits, dim=-1, dtype=top_logits.dtype)
+        num_tokens_per_expert = torch.histc(
+            top_indices.reshape(-1).float(),
+            bins=self.num_experts,
+            min=0,
+            max=self.num_experts,
+        )
+        return top_scores, top_indices, num_tokens_per_expert
+
+    def init_weights(self, init_std: float):
+        nn.init.trunc_normal_(self.weight, mean=0.0, std=init_std)
+        nn.init.zeros_(self.bias)
+
+
+class GptOssMoE(nn.Module):
+    """GPT-OSS sparse MLP: top-k router + grouped experts with biases.
+
+    Wraps `GptOssGroupedExperts` (which expects pre-permuted tokens + num_tokens_per_expert)
+    with the standard MoE permute/unpermute pipeline. Routing weights are applied AFTER
+    the expert computation, matching HF's `routing_weights[token_idx, top_k_pos]` index_add.
+    """
+
+    def __init__(self, config: GptOssConfig):
+        super().__init__()
+        self.num_experts = config.num_local_experts
+        self.top_k = config.num_experts_per_tok
+        self.router = GptOssTopKRouter(config)
+        self.experts = GptOssGroupedExperts(
+            hidden_size=config.hidden_size,
+            intermediate_size=config.intermediate_size,
+            num_experts=self.num_experts,
+            use_grouped_mm=getattr(config, "use_grouped_mm", True),
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        bs, slen, dim = hidden_states.shape
+        x = hidden_states.reshape(-1, dim)  # (T, dim)
+
+        top_scores, top_indices, num_tokens_per_expert = self.router(x)
+        # top_scores, top_indices: (T, top_k)
+
+        # Sort tokens by expert. Each token contributes top_k entries (one per chosen expert).
+        flat_expert_indices = top_indices.reshape(-1)  # (T*top_k,)
+        sorted_perm = torch.argsort(flat_expert_indices, stable=True)  # (T*top_k,)
+        # token id of each (token, k) entry, in expert-sorted order
+        token_indices_experts_sorted = sorted_perm // self.top_k
+        # routing weight for each (token, k) entry, in expert-sorted order
+        top_scores_experts_sorted = top_scores.reshape(-1)[sorted_perm]
+
+        # Gather inputs for each expert in expert-sorted order
+        gather_indices = token_indices_experts_sorted.reshape(-1, 1).expand(-1, dim)
+        routed_input = torch.gather(x, dim=0, index=gather_indices)  # (T*top_k, dim)
+
+        routed_output = self.experts(routed_input, num_tokens_per_expert)  # (T*top_k, dim)
+
+        # Apply routing weights post-experts (HF: weighted_output = out * routing_weights)
+        routed_output = (routed_output.float() * top_scores_experts_sorted.reshape(-1, 1)).to(routed_output.dtype)
+
+        # Scatter-add back to original token positions
+        out = torch.zeros_like(x)
+        scatter_indices = token_indices_experts_sorted.reshape(-1, 1).expand(-1, dim)
+        out = out.scatter_add(dim=0, index=scatter_indices, src=routed_output)
+
+        out = out.reshape(bs, slen, dim)
+        return out, top_scores  # router_scores returned only for compatibility; trainer ignores
+
+
+class GptOssDecoderLayer(GradientCheckpointingLayer):
+    def __init__(self, config: GptOssConfig, layer_idx: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.self_attn = GptOssAttention(config=config, layer_idx=layer_idx)
+        self.mlp = GptOssMoE(config)
+        self.input_layernorm = GptOssRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = GptOssRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        past_key_values: Cache | None = None,
+        use_cache: bool | None = False,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states, _ = self.self_attn(
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            position_embeddings=position_embeddings,
+            **kwargs,
+        )
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states, _ = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+
+@auto_docstring
+class GptOssPreTrainedModel(PreTrainedModelPrimeRL):
+    config: GptOssConfig
+    base_model_prefix = "model"
+    supports_gradient_checkpointing = True
+    _no_split_modules = ["GptOssDecoderLayer"]
+    _skip_keys_device_placement = ["past_key_values"]
+    _supports_flash_attn = True
+    _supports_sdpa = False
+    _supports_flex_attn = True
+    _can_compile_fullgraph = False
+    _supports_attention_backend = True
+    _keep_in_fp32_modules = ["post_attention_layernorm", "input_layernorm", "norm"]
+    _compatible_flash_implementations = ["kernels-community/vllm-flash-attn3", "flash_attention_4"]
+    _can_record_outputs = {"hidden_states": GptOssDecoderLayer}
+
+    @classmethod
+    def is_hf_state_dict(cls, state_dict: dict[str, Tensor]) -> bool:
+        return is_hf_state_dict(state_dict)
+
+    @classmethod
+    def is_prime_state_dict(cls, state_dict: dict[str, Tensor]) -> bool:
+        return is_prime_state_dict(state_dict)
+
+    @classmethod
+    def convert_to_hf(cls, state_dict: dict[str, Tensor]) -> dict[str, Tensor]:
+        return convert_to_hf(state_dict)
+
+    @classmethod
+    def convert_to_prime(cls, state_dict: dict[str, Tensor]) -> dict[str, Tensor]:
+        return convert_to_prime(state_dict)
+
+
+@auto_docstring
+class GptOssModel(GptOssPreTrainedModel):
+    _no_split_modules = ["GptOssDecoderLayer"]
+
+    def __init__(self, config: GptOssConfig):
+        super().__init__(config)
+        self.padding_idx = config.pad_token_id
+        self.vocab_size = config.vocab_size
+
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)
+        self.layers = nn.ModuleList(
+            [GptOssDecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
+        )
+        self.norm = GptOssRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.rotary_emb = GptOssRotaryEmbedding(config=config)
+        self.gradient_checkpointing = False
+
+        self.post_init()
+
+    @auto_docstring
+    def forward(
+        self,
+        input_ids: torch.LongTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        past_key_values: Cache | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        use_cache: bool | None = None,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> MoeModelOutputWithPast:
+        if (input_ids is None) ^ (inputs_embeds is not None):
+            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        if position_ids is None:
+            position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
+
+        if not isinstance(causal_mask_mapping := attention_mask, dict):
+            mask_kwargs = {
+                "config": self.config,
+                "inputs_embeds": inputs_embeds,
+                "attention_mask": attention_mask,
+                "past_key_values": past_key_values,
+                "position_ids": position_ids,
+            }
+            causal_mask_mapping = {
+                "full_attention": create_causal_mask(**mask_kwargs),
+                "sliding_attention": create_sliding_window_causal_mask(**mask_kwargs),
+            }
+
+        hidden_states = inputs_embeds
+        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+
+        for i, decoder_layer in enumerate(self.layers):
+            hidden_states = decoder_layer(
+                hidden_states,
+                attention_mask=causal_mask_mapping[self.config.layer_types[i]],
+                position_embeddings=position_embeddings,
+                position_ids=position_ids,
+                past_key_values=past_key_values,
+                use_cache=use_cache,
+                **kwargs,
+            )
+        hidden_states = self.norm(hidden_states)
+        return MoeModelOutputWithPast(last_hidden_state=hidden_states, past_key_values=past_key_values)
+
+
+@auto_docstring
+class GptOssForCausalLM(GptOssPreTrainedModel, GenerationMixin):
+    _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
+    _tp_plan = {"lm_head": "colwise_gather_output"}
+    _pp_plan = {"lm_head": (["hidden_states"], ["logits"])}
+
+    def __init__(self, config: GptOssConfig):
+        super().__init__(config)
+        self.model = GptOssModel(config)
+        self.vocab_size = config.vocab_size
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        self.num_experts = config.num_local_experts
+        self.num_experts_per_tok = config.num_experts_per_tok
+
+        self.post_init()
+
+    def set_decoder(self, decoder):
+        self.model = decoder
+
+    def get_decoder(self):
+        return self.model
+
+    @can_return_tuple
+    @auto_docstring
+    def forward(
+        self,
+        input_ids: torch.LongTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        past_key_values: Cache | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        labels: torch.LongTensor | None = None,
+        use_cache: bool | None = None,
+        logits_to_keep: Union[int, torch.Tensor] = 0,
+        temperature: torch.Tensor | None = None,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> PrimeLmOutput:
+        assert use_cache is None or not use_cache, "use_cache is not supported for custom GPT-OSS"
+        assert past_key_values is None, "past_key_values is not supported for custom GPT-OSS"
+
+        outputs: MoeModelOutputWithPast = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            use_cache=use_cache,
+            **kwargs,
+        )
+
+        hidden_states = outputs.last_hidden_state
+        slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+        return self.lm_head(
+            hidden_states[:, slice_indices, :],
+            labels[:, slice_indices] if labels is not None else None,
+            temperature=temperature,
+        )
+
+    def init_buffers_post_meta(self):
+        buffer_names = [name for name, _ in self.named_buffers()]
+        if "model.rotary_emb.inv_freq" in buffer_names:
+            rotary_emb = self.model.rotary_emb
+            from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
+
+            rope_init_fn = (
+                ROPE_INIT_FUNCTIONS[rotary_emb.rope_type]
+                if rotary_emb.rope_type != "default"
+                else rotary_emb.compute_default_rope_parameters
+            )
+            inv_freq, rotary_emb.attention_scaling = rope_init_fn(rotary_emb.config, rotary_emb.inv_freq.device)
+            rotary_emb.inv_freq.copy_(inv_freq)
+            if "model.rotary_emb.original_inv_freq" in buffer_names:
+                rotary_emb.original_inv_freq.copy_(inv_freq)
+
+
+__all__ = [
+    "GptOssForCausalLM",
+    "GptOssModel",
+    "GptOssPreTrainedModel",
+]

--- a/src/prime_rl/trainer/models/layers/lora/multi_moe.py
+++ b/src/prime_rl/trainer/models/layers/lora/multi_moe.py
@@ -6,7 +6,14 @@ from torch import nn
 from torch.distributed.tensor import DTensor
 
 from prime_rl.trainer.models.layers.lora.base import MultiLoRAModule, get_lora_num_tokens, get_multilora_scaling
-from prime_rl.trainer.models.layers.moe import GroupedExperts, NonGatedGroupedExperts, relu2
+from prime_rl.trainer.models.layers.moe import (
+    GptOssGroupedExperts,
+    GroupedExperts,
+    NonGatedGroupedExperts,
+    _broadcast_expert_bias,
+    _gpt_oss_apply_gate,
+    relu2,
+)
 
 
 def _run_lora_grouped_mm(
@@ -745,6 +752,313 @@ class MultiLoRANonGatedGroupedExperts(MultiLoRAModule):
             w2_lora_tmp = torch.matmul(h_lora, w2_lora_a[expert_idx].transpose(-2, -1))
             w2_lora_out = torch.matmul(w2_lora_tmp, w2_lora_b[expert_idx].transpose(-2, -1))
             out = out_base + scaling * w2_lora_out
+
+            out_splits.append(out)
+            start = end
+
+        return torch.cat(out_splits, dim=0)
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}(base={self.base_layer}, rank={self.rank}, "
+            f"n_adapters={self.n_adapters}, num_experts={self.num_experts}, "
+            f"alpha={self.alpha}, dropout={self.lora_dropout}, "
+            f"use_grouped_mm={self.use_grouped_mm})"
+        )
+
+
+class MultiLoRAGptOssGroupedExperts(MultiLoRAModule):
+    """
+    GptOssGroupedExperts + multi-LoRA.
+
+    Adapts the two projections of GPT-OSS experts: the fused gate_up projection
+    (hidden_size -> 2*intermediate_size) and the down projection (intermediate_size -> hidden_size).
+    """
+
+    def __init__(
+        self,
+        base_layer: GptOssGroupedExperts,
+        rank: int,
+        n_adapters: int,
+        alpha: float = 32.0,
+        dropout: float = 0.0,
+        use_grouped_mm: bool = True,
+    ):
+        super().__init__(base_layer)
+        if rank <= 0 or n_adapters <= 0:
+            raise ValueError("rank and n_adapters must be > 0")
+
+        self.num_experts = base_layer.num_experts
+        self.hidden_size = base_layer.hidden_size
+        self.intermediate_size = base_layer.intermediate_size
+        self.gate_up_out = 2 * self.intermediate_size
+
+        if rank % 8 != 0 or self.hidden_size % 8 != 0 or self.intermediate_size % 8 != 0:
+            use_grouped_mm = False
+
+        self.rank = rank
+        self.n_adapters = n_adapters
+        self.alpha = alpha
+        self.lora_dropout = nn.Dropout(dropout) if dropout > 0.0 else nn.Identity()
+        self.use_grouped_mm = use_grouped_mm
+
+        self._lora_num_tokens = get_lora_num_tokens()
+        self._scaling_factors = get_multilora_scaling()
+
+        self.gate_up_lora_A = nn.ParameterList(
+            [
+                nn.Parameter(
+                    torch.empty(
+                        self.num_experts,
+                        rank,
+                        self.hidden_size,
+                        device=base_layer.gate_up_proj.device,
+                        dtype=base_layer.gate_up_proj.dtype,
+                    )
+                )
+                for _ in range(n_adapters)
+            ]
+        )
+        self.gate_up_lora_B = nn.ParameterList(
+            [
+                nn.Parameter(
+                    torch.empty(
+                        self.num_experts,
+                        self.gate_up_out,
+                        rank,
+                        device=base_layer.gate_up_proj.device,
+                        dtype=base_layer.gate_up_proj.dtype,
+                    )
+                )
+                for _ in range(n_adapters)
+            ]
+        )
+
+        self.down_lora_A = nn.ParameterList(
+            [
+                nn.Parameter(
+                    torch.empty(
+                        self.num_experts,
+                        rank,
+                        self.intermediate_size,
+                        device=base_layer.down_proj.device,
+                        dtype=base_layer.down_proj.dtype,
+                    )
+                )
+                for _ in range(n_adapters)
+            ]
+        )
+        self.down_lora_B = nn.ParameterList(
+            [
+                nn.Parameter(
+                    torch.empty(
+                        self.num_experts,
+                        self.hidden_size,
+                        rank,
+                        device=base_layer.down_proj.device,
+                        dtype=base_layer.down_proj.dtype,
+                    )
+                )
+                for _ in range(n_adapters)
+            ]
+        )
+
+        self.reset_parameters()
+
+    def reset_parameters(self, index: int | None = None) -> None:
+        if index is None:
+            for i in range(self.n_adapters):
+                self.reset_parameters(i)
+        else:
+            nn.init.kaiming_uniform_(self.gate_up_lora_A[index], a=math.sqrt(5))
+            nn.init.zeros_(self.gate_up_lora_B[index])
+            nn.init.kaiming_uniform_(self.down_lora_A[index], a=math.sqrt(5))
+            nn.init.zeros_(self.down_lora_B[index])
+
+    def named_parameters_for_adapter(self, idx: int) -> list[tuple[str, nn.Parameter]]:
+        return [
+            ("gate_up_lora_A", self.gate_up_lora_A[idx]),
+            ("gate_up_lora_B", self.gate_up_lora_B[idx]),
+            ("down_lora_A", self.down_lora_A[idx]),
+            ("down_lora_B", self.down_lora_B[idx]),
+        ]
+
+    def get_lora_param_counts(self) -> tuple[int, int]:
+        adapter_params = (
+            self.gate_up_lora_A[0].numel()
+            + self.gate_up_lora_B[0].numel()
+            + self.down_lora_A[0].numel()
+            + self.down_lora_B[0].numel()
+        )
+        adapted_params = self.base_layer.gate_up_proj.numel() + self.base_layer.down_proj.numel()
+        return adapter_params, adapted_params
+
+    def state_dict_for_adapter(self, idx: int) -> dict[str, torch.Tensor]:
+        """vLLM-compatible 3D MoE adapter format.
+
+        For 3D MoE models (gpt-oss in vLLM has `is_3d_moe_weight = True`), vLLM expects:
+        - `experts.base_layer.lora_{A,B}.weight` for the gate_up projection
+        - `experts.lora_{A,B}.weight` for the down projection
+        with experts stacked into the rank dim. See
+        vllm/lora/model_manager.py::_stack_moe_lora_weights, which reshapes
+            lora_A: (num_experts*rank, in)  -> (num_experts, rank, in)
+            lora_B: (out, rank*num_experts) -> (out, rank, num_experts) -> (num_experts, out, rank)
+        """
+        detached_gu_a = self.gate_up_lora_A[idx].detach()
+        detached_gu_b = self.gate_up_lora_B[idx].detach()
+        detached_d_a = self.down_lora_A[idx].detach()
+        detached_d_b = self.down_lora_B[idx].detach()
+
+        if isinstance(detached_gu_a, DTensor):
+            detached_gu_a = detached_gu_a.full_tensor()
+            detached_gu_b = detached_gu_b.full_tensor()
+            detached_d_a = detached_d_a.full_tensor()
+            detached_d_b = detached_d_b.full_tensor()
+
+        # lora_A: (num_experts, rank, in) -> (num_experts*rank, in)
+        gu_a_flat = detached_gu_a.reshape(self.num_experts * self.rank, self.hidden_size).clone()
+        d_a_flat = detached_d_a.reshape(self.num_experts * self.rank, self.intermediate_size).clone()
+        # lora_B: (num_experts, out, rank) -> (out, rank, num_experts) -> (out, rank*num_experts)
+        # vLLM's reshape treats the last dim of lora_B as (rank, num_experts) with experts fast-varying.
+        gu_b_flat = detached_gu_b.permute(1, 2, 0).contiguous().reshape(self.gate_up_out, self.rank * self.num_experts)
+        d_b_flat = detached_d_b.permute(1, 2, 0).contiguous().reshape(self.hidden_size, self.rank * self.num_experts)
+
+        return {
+            "base_layer.lora_A.weight": gu_a_flat,
+            "base_layer.lora_B.weight": gu_b_flat,
+            "lora_A.weight": d_a_flat,
+            "lora_B.weight": d_b_flat,
+        }
+
+    def forward(self, x: torch.Tensor, num_tokens_per_expert: torch.Tensor) -> torch.Tensor:
+        adapter_idx = self._lora_num_tokens.argmax().item()
+        gu_a = self.gate_up_lora_A[adapter_idx]
+        gu_b = self.gate_up_lora_B[adapter_idx]
+        d_a = self.down_lora_A[adapter_idx]
+        d_b = self.down_lora_B[adapter_idx]
+
+        scaling = self._scaling_factors[adapter_idx].item()
+
+        base_gu = self.base_layer.gate_up_proj
+        base_gu_bias = self.base_layer.gate_up_proj_bias
+        base_d = self.base_layer.down_proj
+        base_d_bias = self.base_layer.down_proj_bias
+
+        permuted_indices = None
+        if isinstance(base_gu, DTensor):
+            base_gu = base_gu.to_local()
+            base_gu_bias = base_gu_bias.to_local()
+            base_d = base_d.to_local()
+            base_d_bias = base_d_bias.to_local()
+            gu_a = gu_a.to_local()
+            gu_b = gu_b.to_local()
+            d_a = d_a.to_local()
+            d_b = d_b.to_local()
+
+            if getattr(self.base_layer, "ep_comm_backend", "torch") != "deepep":
+                from torchtitan.distributed.expert_parallel import TOKEN_GROUP_ALIGN_SIZE_M
+                from torchtitan.experiments.kernels.moe.indices import generate_permute_indices
+
+                experts_per_ep_rank = base_gu.shape[0]
+                num_ep_ranks = num_tokens_per_expert.shape[0] // experts_per_ep_rank
+
+                with torch.no_grad():
+                    permuted_indices, num_tokens_per_expert, _ = generate_permute_indices(
+                        num_tokens_per_expert,
+                        experts_per_ep_rank,
+                        num_ep_ranks,
+                        x.shape[0] + experts_per_ep_rank * TOKEN_GROUP_ALIGN_SIZE_M,
+                        TOKEN_GROUP_ALIGN_SIZE_M,
+                    )
+
+                x = torch.vstack((x, x.new_zeros((x.shape[-1]))))
+                input_shape = x.shape
+                x = x[permuted_indices, :]
+
+        offsets = torch.cumsum(num_tokens_per_expert, dim=0, dtype=torch.int32)
+        lora_x = self.lora_dropout(x)
+
+        if self.use_grouped_mm:
+            gate_up_base = torch._grouped_mm(x.bfloat16(), base_gu.bfloat16(), offs=offsets)
+            gate_up_base = (
+                gate_up_base
+                + _broadcast_expert_bias(base_gu_bias, num_tokens_per_expert, gate_up_base.shape[0]).bfloat16()
+            )
+            gate_up_lora = _run_lora_grouped_mm(lora_x, gu_a, gu_b, offsets)
+            gate_up = gate_up_base + scaling * gate_up_lora.bfloat16()
+
+            h = _gpt_oss_apply_gate(gate_up)
+            lora_h = self.lora_dropout(h)
+
+            out_base = torch._grouped_mm(h, base_d.bfloat16(), offs=offsets)
+            out_base = (
+                out_base + _broadcast_expert_bias(base_d_bias, num_tokens_per_expert, out_base.shape[0]).bfloat16()
+            )
+            out_lora = _run_lora_grouped_mm(lora_h, d_a, d_b, offsets)
+            out = out_base + scaling * out_lora.bfloat16()
+            out = out.type_as(x)
+        else:
+            out = self._forward_for_loop(
+                x,
+                num_tokens_per_expert,
+                gu_a,
+                gu_b,
+                d_a,
+                d_b,
+                base_gu,
+                base_gu_bias,
+                base_d,
+                base_d_bias,
+                scaling,
+            )
+
+        if permuted_indices is not None:
+            if out.shape[0] < len(permuted_indices):
+                num_padding = len(permuted_indices) - out.shape[0]
+                out = torch.vstack((out, out.new_zeros((num_padding, out.shape[-1]))))
+            out_unpermuted = out.new_zeros(input_shape)
+            out_unpermuted[permuted_indices, :] = out
+            out = out_unpermuted[:-1]
+
+        return out
+
+    def _forward_for_loop(
+        self,
+        x: torch.Tensor,
+        num_tokens_per_expert: torch.Tensor,
+        gu_a: torch.Tensor,
+        gu_b: torch.Tensor,
+        d_a: torch.Tensor,
+        d_b: torch.Tensor,
+        base_gu: torch.Tensor,
+        base_gu_bias: torch.Tensor,
+        base_d: torch.Tensor,
+        base_d_bias: torch.Tensor,
+        scaling: float,
+    ) -> torch.Tensor:
+        n = num_tokens_per_expert.tolist()
+        out_splits = []
+
+        start = 0
+        for e, num_tokens in enumerate(n):
+            if num_tokens == 0:
+                continue
+            end = start + num_tokens
+            x_e = x[start:end]
+            x_e_lora = self.lora_dropout(x_e)
+
+            gate_up_base = x_e @ base_gu[e] + base_gu_bias[e]
+            gate_up_lora_tmp = x_e_lora @ gu_a[e].transpose(-2, -1)
+            gate_up_lora = gate_up_lora_tmp @ gu_b[e].transpose(-2, -1)
+            gate_up = gate_up_base + scaling * gate_up_lora
+
+            h = _gpt_oss_apply_gate(gate_up)
+            h_lora = self.lora_dropout(h)
+
+            out_base = h @ base_d[e] + base_d_bias[e]
+            out_lora_tmp = h_lora @ d_a[e].transpose(-2, -1)
+            out_lora = out_lora_tmp @ d_b[e].transpose(-2, -1)
+            out = out_base + scaling * out_lora
 
             out_splits.append(out)
             start = end

--- a/src/prime_rl/trainer/models/layers/moe.py
+++ b/src/prime_rl/trainer/models/layers/moe.py
@@ -208,6 +208,161 @@ class GroupedExperts(nn.Module):
         nn.init.trunc_normal_(self.w3, mean=0.0, std=init_std)
 
 
+# GPT-OSS activation constants. Both clamping limit and the sigmoid alpha live here
+# rather than as instance attrs so the function is JIT/compile-friendly.
+GPT_OSS_LIMIT = 7.0
+GPT_OSS_ALPHA = 1.702
+
+
+def _gpt_oss_apply_gate(gate_up: torch.Tensor) -> torch.Tensor:
+    """GPT-OSS expert activation: clamped sigmoid-glu over interleaved gate/up channels."""
+    gate, up = gate_up[..., ::2], gate_up[..., 1::2]
+    gate = gate.clamp(min=None, max=GPT_OSS_LIMIT)
+    up = up.clamp(min=-GPT_OSS_LIMIT, max=GPT_OSS_LIMIT)
+    glu = gate * torch.sigmoid(gate * GPT_OSS_ALPHA)
+    return (up + 1) * glu
+
+
+def _broadcast_expert_bias(bias: torch.Tensor, num_tokens_per_expert: torch.Tensor, target_rows: int) -> torch.Tensor:
+    """Repeat per-expert bias to per-token, padding to target_rows if EP added padding rows."""
+    # repeat_interleave on CUDA requires int counts; histc/router output is float.
+    bias_per_token = torch.repeat_interleave(bias, num_tokens_per_expert.to(torch.int64), dim=0)
+    if bias_per_token.shape[0] < target_rows:
+        pad_rows = target_rows - bias_per_token.shape[0]
+        bias_per_token = F.pad(bias_per_token, (0, 0, 0, pad_rows))
+    return bias_per_token
+
+
+def _run_gpt_oss_experts_for_loop_impl(
+    gate_up_proj: torch.Tensor,
+    gate_up_proj_bias: torch.Tensor,
+    down_proj: torch.Tensor,
+    down_proj_bias: torch.Tensor,
+    x: torch.Tensor,
+    num_tokens_per_expert: torch.Tensor,
+) -> torch.Tensor:
+    n = num_tokens_per_expert.tolist()
+    num_padding = x.shape[0] - sum(n)
+    x_split = torch.split(x[: sum(n)], split_size_or_sections=n, dim=0)
+    out_splits = []
+    for e, x_e in enumerate(x_split):
+        gate_up = x_e @ gate_up_proj[e] + gate_up_proj_bias[e]
+        h = _gpt_oss_apply_gate(gate_up)
+        out = h @ down_proj[e] + down_proj_bias[e]
+        out_splits.append(out)
+    out = torch.cat(out_splits, dim=0)
+    return torch.vstack((out, out.new_zeros((num_padding, out.shape[-1]))))
+
+
+@expert_parallel
+def _run_gpt_oss_experts_for_loop(
+    gate_up_proj: torch.Tensor,
+    gate_up_proj_bias: torch.Tensor,
+    down_proj: torch.Tensor,
+    down_proj_bias: torch.Tensor,
+    x: torch.Tensor,
+    num_tokens_per_expert: torch.Tensor,
+) -> torch.Tensor:
+    return _run_gpt_oss_experts_for_loop_impl(
+        gate_up_proj, gate_up_proj_bias, down_proj, down_proj_bias, x, num_tokens_per_expert
+    )
+
+
+def _run_gpt_oss_experts_grouped_mm_impl(
+    gate_up_proj: torch.Tensor,
+    gate_up_proj_bias: torch.Tensor,
+    down_proj: torch.Tensor,
+    down_proj_bias: torch.Tensor,
+    x: torch.Tensor,
+    num_tokens_per_expert: torch.Tensor,
+) -> torch.Tensor:
+    offsets = torch.cumsum(num_tokens_per_expert, dim=0, dtype=torch.int32)
+    assert x.dim() == 2
+
+    gate_up = torch._grouped_mm(x.bfloat16(), gate_up_proj.bfloat16(), offs=offsets)
+    gate_up = gate_up + _broadcast_expert_bias(gate_up_proj_bias, num_tokens_per_expert, gate_up.shape[0]).bfloat16()
+    h = _gpt_oss_apply_gate(gate_up)
+    out = torch._grouped_mm(h, down_proj.bfloat16(), offs=offsets)
+    out = out + _broadcast_expert_bias(down_proj_bias, num_tokens_per_expert, out.shape[0]).bfloat16()
+    return out.type_as(x)
+
+
+@expert_parallel
+def _run_gpt_oss_experts_grouped_mm(
+    gate_up_proj: torch.Tensor,
+    gate_up_proj_bias: torch.Tensor,
+    down_proj: torch.Tensor,
+    down_proj_bias: torch.Tensor,
+    x: torch.Tensor,
+    num_tokens_per_expert: torch.Tensor,
+) -> torch.Tensor:
+    return _run_gpt_oss_experts_grouped_mm_impl(
+        gate_up_proj, gate_up_proj_bias, down_proj, down_proj_bias, x, num_tokens_per_expert
+    )
+
+
+class GptOssGroupedExperts(nn.Module):
+    """GPT-OSS-style grouped experts.
+
+    Mirrors HF's `GptOssExperts` parameter naming (gate_up_proj/down_proj plus per-expert
+    biases, fused interleaved gate/up channels) so the unsloth BF16 checkpoint loads with
+    no key conversion. Forward signature matches `GroupedExperts` (`x`, `num_tokens_per_expert`)
+    so the surrounding MoE plumbing and LoRA wrapper follow the same convention.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        num_experts: int,
+        use_grouped_mm: bool,
+    ):
+        super().__init__()
+        self.num_experts = num_experts
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.gate_up_proj = nn.Parameter(torch.empty(num_experts, hidden_size, 2 * intermediate_size))
+        self.gate_up_proj_bias = nn.Parameter(torch.empty(num_experts, 2 * intermediate_size))
+        self.down_proj = nn.Parameter(torch.empty(num_experts, intermediate_size, hidden_size))
+        self.down_proj_bias = nn.Parameter(torch.empty(num_experts, hidden_size))
+        self.use_grouped_mm = use_grouped_mm
+        self.ep_comm_backend: EPCommBackend = "torch"
+
+    def set_ep_comm_backend(self, backend: EPCommBackend) -> None:
+        self.ep_comm_backend = backend
+
+    def _forward_deepep(self, x: torch.Tensor, num_tokens_per_expert: torch.Tensor) -> torch.Tensor:
+        gate_up_proj = self.gate_up_proj.to_local()
+        gate_up_proj_bias = self.gate_up_proj_bias.to_local()
+        down_proj = self.down_proj.to_local()
+        down_proj_bias = self.down_proj_bias.to_local()
+        if self.use_grouped_mm:
+            return _run_gpt_oss_experts_grouped_mm_impl(
+                gate_up_proj, gate_up_proj_bias, down_proj, down_proj_bias, x, num_tokens_per_expert
+            )
+        return _run_gpt_oss_experts_for_loop_impl(
+            gate_up_proj, gate_up_proj_bias, down_proj, down_proj_bias, x, num_tokens_per_expert
+        )
+
+    def forward(self, x: torch.Tensor, num_tokens_per_expert: torch.Tensor) -> torch.Tensor:
+        if self.ep_comm_backend == "deepep":
+            return self._forward_deepep(x, num_tokens_per_expert)
+
+        if self.use_grouped_mm:
+            return _run_gpt_oss_experts_grouped_mm(
+                self.gate_up_proj, self.gate_up_proj_bias, self.down_proj, self.down_proj_bias, x, num_tokens_per_expert
+            )
+        return _run_gpt_oss_experts_for_loop(
+            self.gate_up_proj, self.gate_up_proj_bias, self.down_proj, self.down_proj_bias, x, num_tokens_per_expert
+        )
+
+    def init_weights(self, init_std: float):
+        nn.init.trunc_normal_(self.gate_up_proj, mean=0.0, std=0.02)
+        nn.init.zeros_(self.gate_up_proj_bias)
+        nn.init.trunc_normal_(self.down_proj, mean=0.0, std=init_std)
+        nn.init.zeros_(self.down_proj_bias)
+
+
 class TokenChoiceTopKRouter(nn.Module):
     """This class implements token-choice routing. In token-choice top-K routing, each token is
         routed to top K experts based on the router scores.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new custom GPT-OSS model path and introduces new MoE expert math (gating, bias handling, routing) plus a dedicated LoRA wrapper, which could affect training correctness/performance for this model family.
> 
> **Overview**
> Adds first-class GPT-OSS support to PrimeRL by registering `GptOssForCausalLM` in `AutoModelForCausalLMPrimeRL` and introducing a custom `trainer/models/gpt_oss` implementation that mirrors HF naming while swapping in a PrimeRL MoE experts module.
> 
> Extends MoE and LoRA plumbing to recognize and adapt GPT-OSS experts: introduces `GptOssGroupedExperts` (with fused `gate_up` + per-expert biases and GPT-OSS gating), adds `MultiLoRAGptOssGroupedExperts` with vLLM 3D-MoE adapter export, and updates `apply_lora_to_model` module detection/wrapping accordingly. Also adds GPT-OSS state-dict conversion helpers that are effectively no-ops to allow direct HF checkpoint loading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 241a3d99a32695dfef75e762895a9d30fb2edcac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->