### PR TITLE
fix(orchestrator): scope example_id by env_name to prevent cross-env collisions

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -424,7 +424,7 @@ async def orchestrate(config: OrchestratorConfig):
 
             # Compute advantages (in-place)
             num_rollouts = len(train_rollouts)
-            num_unique_examples = len({r["example_id"] for r in train_rollouts})
+            num_unique_examples = len({(r["env_name"], r["example_id"]) for r in train_rollouts})
             compute_advantages(train_rollouts, config.rollouts_per_example, config.advantage)
 
             # Apply rollout filters — sets rollout["filters"] and rollout["is_filtered"]
@@ -601,13 +601,13 @@ async def orchestrate(config: OrchestratorConfig):
 
         def compute_solve_rates(df):
             """Compute solve_none, solve_all, effective_batch_size for a set of rollouts."""
-            reward_per_problem = df.groupby("example_id").reward.sum()
+            reward_per_problem = df.groupby(["env_name", "example_id"]).reward.sum()
             solve_none = (reward_per_problem == 0).mean()
             solve_all = (reward_per_problem == config.rollouts_per_example).mean()
             return solve_none, solve_all, 1 - solve_none - solve_all
 
-        # Group by example_id to average across rollouts within each problem
-        by_example = results_df.groupby("example_id")
+        # Group by (env_name, example_id) to average across rollouts within each problem
+        by_example = results_df.groupby(["env_name", "example_id"])
 
         solve_none, solve_all, effective_batch_size = compute_solve_rates(results_df)
         to_log = {

--- a/src/prime_rl/orchestrator/trajectories.py
+++ b/src/prime_rl/orchestrator/trajectories.py
@@ -797,7 +797,7 @@ def build_vlm_image_cache(rollouts: list[vf.RolloutOutput], processor) -> VLMIma
     Caches per rollout to keep images aligned with divergent multi-turn trajectories.
     """
     examples = [(idx, rollout) for idx, rollout in enumerate(rollouts)]
-    unique_example_ids = {rollout["example_id"] for rollout in rollouts}
+    unique_example_ids = {(rollout.get("env_name"), rollout["example_id"]) for rollout in rollouts}
 
     # Extract images (also strips base64 data from rollout prompts to free memory)
     extract_start = time.perf_counter()


### PR DESCRIPTION
## Summary

- Auto-generated `example_id`s start at 0 for every dataset, so multi-env runs silently merge rollouts from different envs in global metrics (solve rates, reward averages, problem counts)
- Scope all global `groupby`/set operations by `(env_name, example_id)` instead of bare `example_id`
- Fixes 4 locations in `orchestrator.py` and `trajectories.py`; buffer and per-env metrics were already correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only how global rollouts are deduplicated/grouped for metrics and VLM cache counting, without altering rollout generation or training sample construction.
> 
> **Overview**
> Prevents cross-environment `example_id` collisions in multi-env runs by scoping global uniqueness/grouping to `(env_name, example_id)`.
> 
> This updates orchestrator progress/solve-rate calculations (set dedupe and `groupby`) and VLM image-cache unique-example counting so global metrics and problem counts no longer merge different envs that share the same `example_id`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2a661bae21215262e520d887f85fd7e258c488b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->