### PR TITLE
feat: debug.force_balanced_routing for MoE smoke tests

### DIFF
--- a/src/prime_rl/configs/trainer.py
+++ b/src/prime_rl/configs/trainer.py
@@ -183,6 +183,13 @@ class DebugModelConfig(BaseConfig):
         ),
     ] = False
 
+    force_balanced_routing: Annotated[
+        bool,
+        Field(
+            description="If True, override MoE token-choice routing with a round-robin assignment so every expert receives an equal share of tokens. Intended for fake-data smoke tests where untrained routing would otherwise produce severe expert imbalance and OOM. Gating scores are still gathered from the override indices so the forward pass stays consistent.",
+        ),
+    ] = False
+
 
 class ModelConfig(BaseModelConfig):
     """Configures the model for training."""

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -351,6 +351,27 @@ def freeze_moe_router(model: nn.Module) -> None:
     logger.info(f"Froze {num_frozen} MoE router parameters")
 
 
+def apply_force_balanced_routing(model: nn.Module) -> None:
+    """Force MoE token-choice routers into round-robin assignment for fake-data smoke tests."""
+    logger = get_logger()
+    language_model = get_language_model(model)
+    num_routers = 0
+
+    for layer in language_model.layers:
+        mlp = layer.mlp if hasattr(layer, "mlp") else layer.feed_forward if hasattr(layer, "feed_forward") else None
+        if isinstance(mlp, (MoE, LatentMoE)):
+            mlp.router.force_balanced = True
+            num_routers += 1
+
+    if num_routers == 0:
+        raise ValueError("No MoE routers found to force-balance. Is this a custom-impl MoE model?")
+
+    logger.warning(
+        f"Forced balanced routing on {num_routers} MoE layers (debug.force_balanced_routing=True). "
+        "Expert assignment is round-robin; gradient flow through the router is broken."
+    )
+
+
 def is_tt_moe_model(model: nn.Module) -> bool:
     return hasattr(model.config, "num_experts") or hasattr(model.config, "n_routed_experts")
 
@@ -1026,6 +1047,9 @@ def setup_model(
 
     if config.freeze_moe_router:
         freeze_moe_router(model)
+
+    if config.debug.force_balanced_routing:
+        apply_force_balanced_routing(model)
 
     if parallel_dims.ep_enabled:
         apply_ep(model, config, parallel_dims)

--- a/src/prime_rl/trainer/models/layers/moe.py
+++ b/src/prime_rl/trainer/models/layers/moe.py
@@ -392,6 +392,7 @@ class TokenChoiceTopKRouter(nn.Module):
         self.score_func = score_func
         self.route_norm = route_norm
         self.route_scale = route_scale
+        self.force_balanced = False
 
     def forward(
         self, x: torch.Tensor, expert_bias: torch.Tensor | None = None, routed_experts: torch.Tensor | None = None
@@ -433,6 +434,11 @@ class TokenChoiceTopKRouter(nn.Module):
         if routed_experts is not None:
             top_scores = scores.gather(dim=1, index=routed_experts)
             selected_experts_indices = routed_experts
+        elif self.force_balanced:
+            num_tokens = scores.shape[0]
+            arange = torch.arange(num_tokens * self.top_k, device=scores.device)
+            selected_experts_indices = (arange % self.num_experts).view(num_tokens, self.top_k)
+            top_scores = scores.gather(dim=1, index=selected_experts_indices)
         elif expert_bias is not None:
             _, selected_experts_indices = torch.topk(scores + expert_bias, k=self.top_k, dim=1)
             top_scores = scores.gather(dim=1, index=selected_experts_indices)


### PR DESCRIPTION
## Summary
- Adds `debug.force_balanced_routing` to `DebugModelConfig`. When true, `TokenChoiceTopKRouter` overrides its top-k expert assignment with a round-robin pattern so every expert receives `num_tokens * top_k / num_experts` tokens.
- Motivation: fake-data smoke tests produce severely skewed routing, which under EP causes per-rank memory blowup and OOM (hit this on a 16-node GLM-5.1 run). Forced balance lets us stress-test memory and throughput without that variance.
- Gating scores are gathered from the override indices, so the forward pass stays self-consistent. Gradients through `gate.weight` are broken — this is **only** valid for benchmarking, not for any optimization signal. The applied path logs a warning calling that out.

## Implementation
- `configs/trainer.py`: `force_balanced_routing: bool = False` on `DebugModelConfig`.
- `models/layers/moe.py`: `TokenChoiceTopKRouter.force_balanced` flag (default False) + a new branch in `forward` that emits `idx = (arange(N*top_k) % num_experts).view(N, top_k)`.
- `trainer/model.py`: `apply_force_balanced_routing(model)` walks `language_model.layers`, flips the flag on each `MoE`/`LatentMoE` router, raises if the model has no custom-impl MoE. Called from `setup_model` immediately after `freeze_moe_router`.

## Caveats
- Custom-impl MoE only (`isinstance(mlp, (MoE, LatentMoE))`); HF-impl path is not affected.
- Per-rank balanced. With EP the resulting traffic is uniform across all experts, which is the intended profile for memory benchmarking.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low-impact by default (flag off), but when enabled it changes MoE expert assignment and intentionally breaks router gradient flow, which could invalidate training runs if misused.
> 
> **Overview**
> Adds a new `debug.force_balanced_routing` config that, when enabled, **overrides MoE token-choice routing** to assign tokens to experts in a round-robin pattern for fake-data/throughput smoke tests.
> 
> Implements the override by adding a `force_balanced` flag to `TokenChoiceTopKRouter` and wiring `setup_model` to enable it across custom `MoE`/`LatentMoE` layers, with a warning and an error if no eligible routers are found.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26a7c5c2a1924f836eac156d296f73d8b73fc131. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->