### PR TITLE
fix(elastic): circuit breaker for adapter sync failures

### DIFF
--- a/src/prime_rl/configs/shared.py
+++ b/src/prime_rl/configs/shared.py
@@ -214,6 +214,14 @@ class ElasticConfig(BaseConfig):
         ),
     ] = 5.0
 
+    max_sync_failures: Annotated[
+        int,
+        Field(
+            ge=1,
+            description="Number of consecutive adapter sync failures before evicting a discovered inference server.",
+        ),
+    ] = 5
+
 
 class ClientConfig(BaseConfig):
     """Configures the OAI client.

--- a/src/prime_rl/utils/elastic.py
+++ b/src/prime_rl/utils/elastic.py
@@ -119,6 +119,7 @@ class ElasticInferencePool:
         self.hostname = client_config.elastic.hostname
         self.port = client_config.elastic.port
         self.sync_interval = client_config.elastic.sync_interval
+        self.max_sync_failures = client_config.elastic.max_sync_failures
         self.train_client_type = train_client_type
         self.eval_client_type = eval_client_type
         self.renderer_name = renderer_name
@@ -323,6 +324,7 @@ class ElasticInferencePool:
 
         if self._adapter_matches_desired(loaded):
             server.status = "ready"
+            server.sync_failures = 0
             return True
 
         # Debug: log why pre-check failed (before attempting load)
@@ -428,11 +430,19 @@ class ElasticInferencePool:
             for ip in list(self._servers.keys()):
                 if ip not in self._admin_clients:
                     continue
+                server = self._servers[ip]
+                if server.sync_failures >= self.max_sync_failures:
+                    self.logger.warning(
+                        f"Evicting inference server {ip} after {server.sync_failures} adapter sync failures"
+                    )
+                    await self._remove_server(ip)
+                    removed += 1
+                    continue
                 if not await self._check_server_health(self._admin_clients[ip], ip):
                     self.logger.debug(f"Server {ip} failed health check, removing")
                     await self._remove_server(ip)
                     removed += 1
-                elif self._servers[ip].status != "ready":
+                elif server.status != "ready":
                     await self._sync_server_adapter(ip)
 
             return added, removed

--- a/src/prime_rl/utils/elastic.py
+++ b/src/prime_rl/utils/elastic.py
@@ -49,7 +49,7 @@ async def check_server_model(url: str, model_name: str, timeout: float = 5.0) ->
             models = [m.get("id") for m in data.get("data", [])]
             return model_name in models, len(models) > 0
     except Exception as e:
-        logger.debug(f"Failed to check server {url}: {e}")
+        logger.debug(f"Failed to check server {url}: {type(e).__name__}: {e!r}")
         return False, False
 
 
@@ -303,7 +303,7 @@ class ElasticInferencePool:
             self.logger.debug(f"No matching adapter found on {ip} for desired={self._desired.name}")
             return None
         except Exception as e:
-            self.logger.warning(f"Failed to query /v1/models on {ip}: {e}")
+            self.logger.warning(f"Failed to query /v1/models on {ip}: {type(e).__name__}: {e!r}")
             return None
 
     def _adapter_matches_desired(self, loaded: AdapterState | None) -> bool:
@@ -344,7 +344,9 @@ class ElasticInferencePool:
             except Exception as e:
                 server.status = "unhealthy"
                 server.sync_failures += 1
-                self.logger.error(f"Failed to sync server {ip}: {e}")
+                self.logger.error(
+                    f"Failed to sync server {ip} (failures={server.sync_failures}): {type(e).__name__}: {e!r}"
+                )
                 return False
 
         loaded = await self._get_loaded_adapter(ip)
@@ -371,7 +373,7 @@ class ElasticInferencePool:
             response = await admin_client.get("/health")
             response.raise_for_status()
         except Exception as e:
-            self.logger.debug(f"Server {ip} health check failed: {e}")
+            self.logger.debug(f"Server {ip} health check failed: {type(e).__name__}: {e!r}")
             return False
 
         try:
@@ -384,7 +386,7 @@ class ElasticInferencePool:
                 self.logger.debug(f"Server {ip} does not have base model {self.base_model_name}")
                 return False
         except Exception as e:
-            self.logger.debug(f"Server {ip} model check failed: {e}")
+            self.logger.debug(f"Server {ip} model check failed: {type(e).__name__}: {e!r}")
             return False
 
         try:
@@ -412,7 +414,7 @@ class ElasticInferencePool:
         try:
             admin_client = await self._create_admin_client(ip)
         except Exception as e:
-            self.logger.debug(f"Failed to create admin client for {ip}: {e}")
+            self.logger.debug(f"Failed to create admin client for {ip}: {type(e).__name__}: {e!r}")
             return False
 
         if not await self._check_server_health(admin_client, ip):
@@ -479,7 +481,7 @@ class ElasticInferencePool:
                         f"(total: {self.num_servers}, ready: {self.num_ready_servers})"
                     )
             except Exception as e:
-                self.logger.error(f"Error in elastic sync loop: {e}")
+                self.logger.error(f"Error in elastic sync loop: {type(e).__name__}: {e!r}")
             await asyncio.sleep(self.sync_interval)
 
     async def start(self) -> None:

--- a/src/prime_rl/utils/elastic.py
+++ b/src/prime_rl/utils/elastic.py
@@ -25,6 +25,9 @@ from prime_rl.utils.logger import get_logger
 
 # --- Shared discovery functions ---
 
+LORA_ADMIN_HEALTHCHECK_ADAPTER = "__prime_rl_healthcheck_probe_does_not_exist__"
+LORA_ADMIN_HEALTHCHECK_TIMEOUT = httpx.Timeout(connect=5.0, read=10.0, write=5.0, pool=5.0)
+
 
 def discover_server_ips(hostname: str) -> list[str]:
     """Discover server IPs via DNS lookup."""
@@ -382,6 +385,25 @@ class ElasticInferencePool:
                 return False
         except Exception as e:
             self.logger.debug(f"Server {ip} model check failed: {e}")
+            return False
+
+        try:
+            response = await admin_client.post(
+                "/v1/unload_lora_adapter",
+                json={"lora_name": LORA_ADMIN_HEALTHCHECK_ADAPTER},
+                timeout=LORA_ADMIN_HEALTHCHECK_TIMEOUT,
+            )
+            if response.status_code >= 500:
+                self.logger.debug(f"Server {ip} LoRA admin probe failed with status {response.status_code}")
+                return False
+        except httpx.TimeoutException as e:
+            self.logger.debug(f"Server {ip} LoRA admin probe timed out: {type(e).__name__}: {e!r}")
+            return False
+        except httpx.TransportError as e:
+            self.logger.debug(f"Server {ip} LoRA admin probe transport error: {type(e).__name__}: {e!r}")
+            return False
+        except Exception as e:
+            self.logger.debug(f"Server {ip} LoRA admin probe failed: {type(e).__name__}: {e!r}")
             return False
 
         return True

--- a/tests/unit/utils/test_elastic.py
+++ b/tests/unit/utils/test_elastic.py
@@ -9,6 +9,8 @@ import verifiers as vf
 from prime_rl.utils.elastic import (
     AdapterState,
     ElasticInferencePool,
+    LORA_ADMIN_HEALTHCHECK_ADAPTER,
+    LORA_ADMIN_HEALTHCHECK_TIMEOUT,
     ServerState,
     check_server_model,
     discover_ready_servers,
@@ -459,6 +461,64 @@ def _make_elastic_pool(max_sync_failures: int = 5) -> ElasticInferencePool:
     mock_config.elastic.max_sync_failures = max_sync_failures
     mock_config.router_url = None
     return ElasticInferencePool(client_config=mock_config, model_name="base-model")
+
+
+def _mock_response(status_code: int = 200, json_data: dict | None = None) -> MagicMock:
+    response = MagicMock()
+    response.status_code = status_code
+    response.raise_for_status = MagicMock()
+    response.json.return_value = json_data or {}
+    return response
+
+
+def test_check_server_health_probes_lora_admin_path():
+    with patch("prime_rl.utils.elastic.get_logger"):
+        pool = _make_elastic_pool()
+        admin_client = AsyncMock()
+        admin_client.get.side_effect = [
+            _mock_response(),
+            _mock_response(json_data={"data": [{"id": "base-model"}]}),
+        ]
+        admin_client.post.return_value = _mock_response(status_code=404)
+
+        result = asyncio.run(pool._check_server_health(admin_client, "10.0.0.1"))
+
+        assert result is True
+        admin_client.post.assert_awaited_once_with(
+            "/v1/unload_lora_adapter",
+            json={"lora_name": LORA_ADMIN_HEALTHCHECK_ADAPTER},
+            timeout=LORA_ADMIN_HEALTHCHECK_TIMEOUT,
+        )
+
+
+def test_check_server_health_fails_when_lora_admin_probe_times_out():
+    with patch("prime_rl.utils.elastic.get_logger"):
+        pool = _make_elastic_pool()
+        admin_client = AsyncMock()
+        admin_client.get.side_effect = [
+            _mock_response(),
+            _mock_response(json_data={"data": [{"id": "base-model"}]}),
+        ]
+        admin_client.post.side_effect = httpx.ReadTimeout("timed out")
+
+        result = asyncio.run(pool._check_server_health(admin_client, "10.0.0.1"))
+
+        assert result is False
+
+
+def test_check_server_health_fails_on_lora_admin_probe_server_error():
+    with patch("prime_rl.utils.elastic.get_logger"):
+        pool = _make_elastic_pool()
+        admin_client = AsyncMock()
+        admin_client.get.side_effect = [
+            _mock_response(),
+            _mock_response(json_data={"data": [{"id": "base-model"}]}),
+        ]
+        admin_client.post.return_value = _mock_response(status_code=500)
+
+        result = asyncio.run(pool._check_server_health(admin_client, "10.0.0.1"))
+
+        assert result is False
 
 
 def test_sync_evicts_server_after_max_sync_failures():

--- a/tests/unit/utils/test_elastic.py
+++ b/tests/unit/utils/test_elastic.py
@@ -7,10 +7,10 @@ import httpx
 import verifiers as vf
 
 from prime_rl.utils.elastic import (
-    AdapterState,
-    ElasticInferencePool,
     LORA_ADMIN_HEALTHCHECK_ADAPTER,
     LORA_ADMIN_HEALTHCHECK_TIMEOUT,
+    AdapterState,
+    ElasticInferencePool,
     ServerState,
     check_server_model,
     discover_ready_servers,

--- a/tests/unit/utils/test_elastic.py
+++ b/tests/unit/utils/test_elastic.py
@@ -9,6 +9,7 @@ import verifiers as vf
 from prime_rl.utils.elastic import (
     AdapterState,
     ElasticInferencePool,
+    ServerState,
     check_server_model,
     discover_ready_servers,
     discover_server_ips,
@@ -448,3 +449,61 @@ def test_elastic_clients_preserve_renderer_model_name_when_model_name_updates():
                 extra_headers_from_state={},
             )
         ]
+
+
+def _make_elastic_pool(max_sync_failures: int = 5) -> ElasticInferencePool:
+    mock_config = MagicMock()
+    mock_config.elastic.hostname = "test.hostname"
+    mock_config.elastic.port = 8000
+    mock_config.elastic.sync_interval = 5.0
+    mock_config.elastic.max_sync_failures = max_sync_failures
+    mock_config.router_url = None
+    return ElasticInferencePool(client_config=mock_config, model_name="base-model")
+
+
+def test_sync_evicts_server_after_max_sync_failures():
+    with (
+        patch("prime_rl.utils.elastic.get_logger"),
+        patch("prime_rl.utils.elastic.discover_server_ips", return_value=["10.0.0.1"]),
+    ):
+        pool = _make_elastic_pool(max_sync_failures=2)
+        admin_client = AsyncMock()
+        pool._admin_clients["10.0.0.1"] = admin_client
+        pool._servers["10.0.0.1"] = ServerState(
+            ip="10.0.0.1",
+            url="http://10.0.0.1:8000",
+            status="unhealthy",
+            sync_failures=2,
+        )
+
+        with patch.object(pool, "_check_server_health", new_callable=AsyncMock) as mock_health:
+            added, removed = asyncio.run(pool.sync())
+
+        assert added == 0
+        assert removed == 1
+        assert "10.0.0.1" not in pool._servers
+        assert "10.0.0.1" not in pool._admin_clients
+        admin_client.aclose.assert_awaited_once()
+        mock_health.assert_not_called()
+
+
+def test_sync_server_adapter_resets_failures_when_adapter_matches_desired():
+    with patch("prime_rl.utils.elastic.get_logger"):
+        pool = _make_elastic_pool()
+        pool._desired.name = "my-lora"
+        pool._desired.path = Path("/weights/step_10")
+        pool._desired.step = 10
+        pool._servers["10.0.0.1"] = ServerState(
+            ip="10.0.0.1",
+            url="http://10.0.0.1:8000",
+            status="unhealthy",
+            sync_failures=3,
+        )
+
+        loaded = AdapterState(name="my-lora", path=Path("/weights/step_10"), step=10)
+        with patch.object(pool, "_get_loaded_adapter", new_callable=AsyncMock, return_value=loaded):
+            result = asyncio.run(pool._sync_server_adapter("10.0.0.1"))
+
+        assert result is True
+        assert pool._servers["10.0.0.1"].status == "ready"
+        assert pool._servers["10.0.0.1"].sync_failures == 0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes elastic pool liveness/eviction behavior and adds an extra admin endpoint probe, which could remove servers from rotation or mark them unhealthy if thresholds/timeouts are mis-tuned.
> 
> **Overview**
> Adds a configurable circuit breaker to elastic inference discovery: `ElasticConfig.max_sync_failures` tracks consecutive LoRA adapter sync errors per server and **evicts** a server once the threshold is reached.
> 
> Tightens readiness checks by adding a LoRA admin-path probe (`POST /v1/unload_lora_adapter` with a non-existent adapter + explicit timeout) to ensure admin operations are responsive before keeping a server in the pool, and improves error logging to include exception types/reprs. Tests cover the new eviction and health-probe behavior and verify sync failure counters reset on successful sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6653f675701e32f0ec7e46ecfa15644af66f873e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->