### PR TITLE
feat: rollout timeout config + verifiers 0.1.13.dev8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ override-dependencies = [
 
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "77a9f28" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "v0.1.13.dev8" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eeb" }
 transformers = { git = "https://github.com/huggingface/transformers.git", rev = "c1c3424" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ override-dependencies = [
 
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "v0.1.13.dev8" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "980a9ea" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eeb" }
 transformers = { git = "https://github.com/huggingface/transformers.git", rev = "c1c3424" }

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -324,6 +324,16 @@ class EnvConfig(BaseConfig):
         ),
     ] = -1
 
+    timeout_seconds: Annotated[
+        float | None,
+        Field(
+            description=(
+                "Per-rollout wall-clock timeout in seconds. Set to None (default) to disable. "
+                "Auto-populated into extra_env_kwargs and read by MultiTurnEnv as the rollout cap."
+            ),
+        ),
+    ] = None
+
     @property
     def stripped_id(self) -> str:
         """Environment ID without the @version suffix."""
@@ -344,6 +354,12 @@ class EnvConfig(BaseConfig):
     @model_validator(mode="after")
     def resolve_max_total_completion_tokens(self):
         self.extra_env_kwargs["max_total_completion_tokens"] = self.max_total_completion_tokens
+        return self
+
+    @model_validator(mode="after")
+    def resolve_timeout_seconds(self):
+        if self.timeout_seconds is not None:
+            self.extra_env_kwargs["timeout_seconds"] = self.timeout_seconds
         return self
 
 

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -324,13 +324,11 @@ class EnvConfig(BaseConfig):
         ),
     ] = -1
 
-    timeout_seconds: Annotated[
+    timeout: Annotated[
         float | None,
         Field(
-            description=(
-                "Per-rollout wall-clock timeout in seconds. Set to None (default) to disable. "
-                "Auto-populated into extra_env_kwargs and read by MultiTurnEnv as the rollout cap."
-            ),
+            validation_alias=AliasChoices("timeout", "timeout_seconds"),
+            description="Per-rollout wall-clock timeout in seconds. Set to None (default) to disable.",
         ),
     ] = None
 
@@ -357,9 +355,9 @@ class EnvConfig(BaseConfig):
         return self
 
     @model_validator(mode="after")
-    def resolve_timeout_seconds(self):
-        if self.timeout_seconds is not None:
-            self.extra_env_kwargs["timeout_seconds"] = self.timeout_seconds
+    def resolve_timeout(self):
+        if self.timeout is not None:
+            self.extra_env_kwargs["timeout_seconds"] = self.timeout
         return self
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2798,7 +2798,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", git = "https://github.com/huggingface/transformers.git?rev=c1c3424" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=v0.1.13.dev8" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=980a9ea" },
     { name = "vllm", specifier = ">=0.19.0" },
     { name = "vllm-router", marker = "platform_machine == 'x86_64' and extra == 'disagg'", url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.22/vllm_router-0.1.22-cp38-abi3-manylinux_2_28_x86_64.whl" },
     { name = "wandb", specifier = ">=0.24.2" },
@@ -4036,7 +4036,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.13.dev8"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=v0.1.13.dev8#980a9ea855cdac9e06426e0434c77e35ad27b3d5" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=980a9ea#980a9ea855cdac9e06426e0434c77e35ad27b3d5" }
 dependencies = [
     { name = "aiolimiter", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "anthropic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },

--- a/uv.lock
+++ b/uv.lock
@@ -2798,7 +2798,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", git = "https://github.com/huggingface/transformers.git?rev=c1c3424" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=77a9f28" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=v0.1.13.dev8" },
     { name = "vllm", specifier = ">=0.19.0" },
     { name = "vllm-router", marker = "platform_machine == 'x86_64' and extra == 'disagg'", url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.22/vllm_router-0.1.22-cp38-abi3-manylinux_2_28_x86_64.whl" },
     { name = "wandb", specifier = ">=0.24.2" },
@@ -2818,7 +2818,7 @@ mamba-ssm = [{ name = "mamba-ssm", specifier = ">=2.3.0" }]
 
 [[package]]
 name = "prime-sandboxes"
-version = "0.2.19"
+version = "0.2.22"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -2828,9 +2828,9 @@ dependencies = [
     { name = "pydantic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "tenacity", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/8c/7d8b8013f65d8394094a922bc493eaae09e5e88058f80bd009637ffeff63/prime_sandboxes-0.2.19.tar.gz", hash = "sha256:081cd9ef246d397b4a2fdd77a94679a5f08115ecbbe3f90f320e5f4a7988820e", size = 60558, upload-time = "2026-04-01T00:46:28.212Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/a7/eb9cb01ce7fa812022ec7c2ffaeb379e1103e07f093a4b85e879b2d0143d/prime_sandboxes-0.2.22.tar.gz", hash = "sha256:7901adca4ff7fff1e7f08c06c4b76765cd90791965216655eb3a87d459588f5e", size = 64970, upload-time = "2026-04-22T18:32:12.973Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/56/9bd4b3733773e6c122ebfe92144476c143666d09d9e8cccb9d1349d4d43c/prime_sandboxes-0.2.19-py3-none-any.whl", hash = "sha256:ce5db7314c007aae796e1ce274181eaa1370000a478bcd55c26149edfee580c1", size = 31617, upload-time = "2026-04-01T00:46:27.216Z" },
+    { url = "https://files.pythonhosted.org/packages/90/b8/46bf98c06826fc26d982c53e10d9d4f086a4c322993a6c51188e5bd6fd30/prime_sandboxes-0.2.22-py3-none-any.whl", hash = "sha256:0a75bb02049c16b55aae7475cc4082e8559ffa6d65181b238077771a95b57855", size = 33182, upload-time = "2026-04-22T18:32:11.739Z" },
 ]
 
 [[package]]
@@ -4035,8 +4035,8 @@ wheels = [
 
 [[package]]
 name = "verifiers"
-version = "0.1.12.dev6"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=77a9f28#77a9f282bdea2c09b34e726a1e6c7b5e55bab8be" }
+version = "0.1.13.dev8"
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=v0.1.13.dev8#980a9ea855cdac9e06426e0434c77e35ad27b3d5" }
 dependencies = [
     { name = "aiolimiter", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "anthropic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },


### PR DESCRIPTION
## Summary
- Bump verifiers pin to `v0.1.13.dev8` — brings in the rollout timeout work (PrimeIntellect-ai/verifiers#1258), `CliAgentEnv` sandbox-lifetime auto-derive, and per-turn timing display.
- New \`EnvConfig.timeout_seconds: float | None\` orchestrator-config field. When set, a \`model_validator\` auto-populates \`extra_env_kwargs[\"timeout_seconds\"]\`, which the env server forwards to the env constructor. \`MultiTurnEnv\` reads it as the per-rollout \`asyncio.wait_for\` cap.

Mirrors the existing \`max_total_completion_tokens\` auto-populate pattern — same path, same validator shap

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new timeout parameter that can change rollout execution behavior and failure modes, and updates a core env-related dependency (`verifiers`) to a new dev version.
> 
> **Overview**
> Adds an optional per-environment rollout timeout to orchestrator config via `EnvConfig.timeout` (alias `timeout_seconds`), and auto-forwards it into `extra_env_kwargs["timeout_seconds"]` during model validation.
> 
> Updates dependency pins to pick up the corresponding runtime support by bumping `verifiers` to a newer git rev/version (and refreshing `uv.lock`, including a `prime-sandboxes` patch bump).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80a2206655fc1bd24323201fe9bd835e64e75ba2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->