### PR TITLE
GlmMoeDsa - better CP implementation

### DIFF
--- a/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
+++ b/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
@@ -27,7 +27,6 @@ from prime_rl.trainer.models.layers.mlp import MLP, MLPConfig
 from prime_rl.trainer.models.layers.moe import MoE, MoEArgs
 from prime_rl.trainer.models.layers.norms import RMSNorm, RMSNormConfig
 from prime_rl.trainer.models.layers.rotary_emb import RotaryEmbedding, RotaryEmbeddingConfig
-from prime_rl.utils.cp import gather_for_cp, shard_for_cp
 
 
 def _sparse_mla_attention_args(config: GlmMoeDsaConfig) -> SparseMlaAttentionArgs:
@@ -86,22 +85,7 @@ class GlmMoeDsaDecoderLayer(GradientCheckpointingLayer):
         self._cp_group = cp_group
         self._cp_rank = cp_rank
         self._cp_world_size = cp_world_size
-
-    @property
-    def cp_enabled(self) -> bool:
-        return hasattr(self, "_cp_group") and hasattr(self, "_cp_rank") and hasattr(self, "_cp_world_size")
-
-    def shard_to_cp(self, t: torch.Tensor) -> torch.Tensor:
-        if not self.cp_enabled:
-            return t
-
-        return shard_for_cp(t, self._cp_rank, self._cp_world_size)
-
-    def gather_for_cp(self, t: torch.Tensor) -> torch.Tensor:
-        if not self.cp_enabled:
-            return t
-
-        return gather_for_cp(t, self._cp_group)
+        self.self_attn.set_context_parallel_attributes(cp_group, cp_rank, cp_world_size)
 
     @deprecate_kwarg("past_key_value", new_name="past_key_values", version="4.58")
     def forward(
@@ -114,14 +98,14 @@ class GlmMoeDsaDecoderLayer(GradientCheckpointingLayer):
     ) -> torch.Tensor:
         residual = hidden_states
         hidden_states = self.input_layernorm(hidden_states)
-        hidden_states = self.gather_for_cp(hidden_states)
+        # Attention runs with CP-sharded Q (length S_local) and gathers KV internally
+        # to length S_full. No gather/scatter wrapper needed at the layer boundary.
         hidden_states, _ = self.self_attn(
             hidden_states=hidden_states,
             position_embeddings=position_embeddings,
             ks=ks,
             ke=ke,
         )
-        hidden_states = self.shard_to_cp(hidden_states)
         hidden_states = residual + hidden_states
 
         residual = hidden_states
@@ -246,19 +230,35 @@ class GlmMoeDsaModel(GlmMoeDsaPreTrainedModel):
         if inputs_embeds is None:
             inputs_embeds: torch.Tensor = self.embed_tokens(input_ids)
 
-        cp_group, _, cp_world_size = self._context_parallel_state()
+        cp_group, cp_rank, cp_world_size = self._context_parallel_state()
         if cp_group is not None and cp_world_size > 1:
-            position_ids_for_attn = self._gather_position_ids_for_cp(position_ids, cp_group, cp_world_size)
+            position_ids_full = self._gather_position_ids_for_cp(position_ids, cp_group, cp_world_size)
         else:
-            position_ids_for_attn = position_ids
+            position_ids_full = position_ids
 
-        flat_position_ids = position_ids_for_attn.view(-1)
-        S = flat_position_ids.shape[0]
-        ks = torch.arange(S, dtype=torch.int32, device=flat_position_ids.device) - flat_position_ids.to(torch.int32)
-        ke = torch.arange(1, S + 1, dtype=torch.int32, device=flat_position_ids.device)
+        flat_position_ids = position_ids_full.view(-1)
+        S_full = flat_position_ids.shape[0]
+        ks_full = torch.arange(S_full, dtype=torch.int32, device=flat_position_ids.device) - flat_position_ids.to(
+            torch.int32
+        )
+        ke_full = torch.arange(1, S_full + 1, dtype=torch.int32, device=flat_position_ids.device)
 
+        # Position embeddings are computed over the full sequence: K uses cos/sin[0:S_full]
+        # while Q uses the local CP slice. ks/ke are computed in K's global coordinate
+        # system and then sharded to the local Q range so the indexer's per-token
+        # causal/varlen mask aligns with the gathered K.
         hidden_states = inputs_embeds
-        position_embeddings = self.rotary_emb(hidden_states, position_ids_for_attn)
+        position_embeddings = self.rotary_emb(hidden_states, position_ids_full)
+
+        if cp_world_size > 1:
+            assert S_full % cp_world_size == 0, (
+                f"Full sequence length {S_full} must be divisible by cp_world_size {cp_world_size}"
+            )
+            s_local = S_full // cp_world_size
+            ks = ks_full[cp_rank * s_local : (cp_rank + 1) * s_local].contiguous()
+            ke = ke_full[cp_rank * s_local : (cp_rank + 1) * s_local].contiguous()
+        else:
+            ks, ke = ks_full, ke_full
 
         for layer_idx, decoder_layer in enumerate(self.layers[: self.config.num_hidden_layers]):
             routed_experts_layer = routed_experts[:, :, layer_idx, :] if routed_experts is not None else None

--- a/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
+++ b/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
@@ -98,8 +98,6 @@ class GlmMoeDsaDecoderLayer(GradientCheckpointingLayer):
     ) -> torch.Tensor:
         residual = hidden_states
         hidden_states = self.input_layernorm(hidden_states)
-        # Attention runs with CP-sharded Q (length S_local) and gathers KV internally
-        # to length S_full. No gather/scatter wrapper needed at the layer boundary.
         hidden_states, _ = self.self_attn(
             hidden_states=hidden_states,
             position_embeddings=position_embeddings,
@@ -251,9 +249,6 @@ class GlmMoeDsaModel(GlmMoeDsaPreTrainedModel):
         position_embeddings = self.rotary_emb(hidden_states, position_ids_full)
 
         if cp_world_size > 1:
-            assert S_full % cp_world_size == 0, (
-                f"Full sequence length {S_full} must be divisible by cp_world_size {cp_world_size}"
-            )
             s_local = S_full // cp_world_size
             ks = ks_full[cp_rank * s_local : (cp_rank + 1) * s_local].contiguous()
             ke = ke_full[cp_rank * s_local : (cp_rank + 1) * s_local].contiguous()

--- a/src/prime_rl/trainer/models/glm_moe_dsa/sparse_mla_attention.py
+++ b/src/prime_rl/trainer/models/glm_moe_dsa/sparse_mla_attention.py
@@ -1,11 +1,13 @@
 from dataclasses import dataclass
 
 import torch
+import torch.distributed as dist
 from torch import nn
 
 from prime_rl.trainer.models.kernels.fp8_indexer import fp8_indexer
 from prime_rl.trainer.models.layers.norms import LayerNorm, RMSNorm, RMSNormConfig
-from prime_rl.trainer.models.layers.rotary_emb import apply_rotary_pos_emb_interleave
+from prime_rl.trainer.models.layers.rotary_emb import rotate_half
+from prime_rl.utils.cp import gather_for_cp
 
 try:
     from prime_rl.trainer.models.kernels.sparse_mla_bwd import sparse_mla_bwd
@@ -49,6 +51,15 @@ class _SparseMLA(torch.autograd.Function):
         return dq, dkv, None, None
 
 
+def _apply_rope_interleave_single(t: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor, unsqueeze_dim: int = 1) -> torch.Tensor:
+    """Interleaved RoPE on a single tensor (Q or K), matching apply_rotary_pos_emb_interleave."""
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+    b, h, s, d = t.shape
+    t = t.view(b, h, s, d // 2, 2).transpose(4, 3).reshape(b, h, s, d)
+    return (t * cos) + (rotate_half(t) * sin)
+
+
 class Indexer(nn.Module):
     def __init__(self, args: SparseMlaAttentionArgs):
         super().__init__()
@@ -64,37 +75,58 @@ class Indexer(nn.Module):
     @torch.no_grad()
     def compute_sparse_indices(
         self,
-        hidden_states: torch.Tensor,
-        q_latent: torch.Tensor,
+        hidden_states_local: torch.Tensor,
+        q_latent_local: torch.Tensor,
         ks: torch.Tensor,
         ke: torch.Tensor,
         index_topk: int,
-        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        position_embeddings_full: tuple[torch.Tensor, torch.Tensor],
+        cp_group: dist.ProcessGroup | None,
+        cp_world_size: int,
+        cp_rank: int,
     ) -> torch.Tensor:
-        total_tokens = hidden_states.shape[1]
         assert index_topk % 64 == 0, f"index_topk must be divisible by 64 (block_I), got {index_topk}"
 
-        q_idx = self.wq_b(q_latent[0]).view(total_tokens, self.n_head, self.head_dim)
-        k_idx = self.k_norm(self.wk(hidden_states[0]))
-        w = self.weights_proj(hidden_states[0])
+        s_local = hidden_states_local.shape[1]
+
+        q_idx = self.wq_b(q_latent_local[0]).view(s_local, self.n_head, self.head_dim)
+        k_idx_local = self.k_norm(self.wk(hidden_states_local[0]))
+        w = self.weights_proj(hidden_states_local[0])
+
+        if cp_world_size > 1:
+            # Gather K-side projections across CP. Smaller than gathering raw hidden_states.
+            k_idx = gather_for_cp(k_idx_local.unsqueeze(0), cp_group).squeeze(0)
+        else:
+            k_idx = k_idx_local
+        s_full = k_idx.shape[0]
+
+        cos_full, sin_full = position_embeddings_full
+        if cp_world_size > 1:
+            cos_local = cos_full[:, cp_rank * s_local : (cp_rank + 1) * s_local, :]
+            sin_local = sin_full[:, cp_rank * s_local : (cp_rank + 1) * s_local, :]
+        else:
+            cos_local, sin_local = cos_full, sin_full
 
         q_pe = q_idx[..., : self.rope_dim]
         q_nope = q_idx[..., self.rope_dim :]
         k_pe = k_idx[..., : self.rope_dim]
         k_nope = k_idx[..., self.rope_dim :]
 
-        cos, sin = position_embeddings
-        q_pe = q_pe.unsqueeze(0).transpose(1, 2)
-        k_pe = k_pe.unsqueeze(0).unsqueeze(1)
-        q_pe, k_pe = apply_rotary_pos_emb_interleave(q_pe, k_pe, cos, sin)
+        q_pe = q_pe.unsqueeze(0).transpose(1, 2)  # [1, H, S_local, rope_dim]
+        q_pe = _apply_rope_interleave_single(q_pe, cos_local, sin_local)
         q_pe = q_pe.transpose(1, 2).squeeze(0)
+
+        k_pe = k_pe.unsqueeze(0).unsqueeze(1)  # [1, 1, S_full, rope_dim]
+        k_pe = _apply_rope_interleave_single(k_pe, cos_full, sin_full)
         k_pe = k_pe.squeeze(1).squeeze(0)
 
         q_idx = torch.cat([q_pe, q_nope], dim=-1)
         k_idx = torch.cat([k_pe, k_nope], dim=-1)
 
         indices = fp8_indexer(q_idx, k_idx, w, ks, ke, index_topk, self.weight_scale)
-        return indices.view(1, total_tokens, 1, index_topk)
+        # indices shape: [S_local, topk] in K's coordinate space (sentinel = s_full)
+        # KV passed to sparse MLA has length s_full + 1 (sentinel zeros at index s_full).
+        return indices.view(1, s_local, 1, index_topk)
 
 
 class GlmMoeDsaAttention(nn.Module):
@@ -128,6 +160,21 @@ class GlmMoeDsaAttention(nn.Module):
         self.indexer = Indexer(args)
         self.scaling = self.qk_head_dim ** (-0.5)
 
+        self._cp_group: dist.ProcessGroup | None = None
+        self._cp_rank: int = 0
+        self._cp_world_size: int = 1
+
+    def set_context_parallel_attributes(
+        self, cp_group: dist.ProcessGroup, cp_rank: int, cp_world_size: int
+    ) -> None:
+        self._cp_group = cp_group
+        self._cp_rank = cp_rank
+        self._cp_world_size = cp_world_size
+
+    @property
+    def cp_enabled(self) -> bool:
+        return self._cp_world_size > 1
+
     def attn_projections(self, hidden_states: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         q_latent = self.q_a_layernorm(self.q_a_proj(hidden_states))
         compressed_kv = self.kv_a_proj_with_mqa(hidden_states)
@@ -136,21 +183,31 @@ class GlmMoeDsaAttention(nn.Module):
 
     def mla_up_proj(
         self,
-        q_latent: torch.Tensor,
-        k_compressed_normed: torch.Tensor,
-        k_rope: torch.Tensor,
-        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        q_latent_local: torch.Tensor,
+        k_compressed_normed_full: torch.Tensor,
+        k_rope_full: torch.Tensor,
+        position_embeddings_full: tuple[torch.Tensor, torch.Tensor],
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        batch_size, total_tokens, _ = q_latent.shape
-        q_full = self.q_b_proj(q_latent).view(batch_size, total_tokens, self.num_heads, self.qk_head_dim)
+        batch_size, s_local, _ = q_latent_local.shape
+        s_full = k_compressed_normed_full.shape[1]
+
+        q_full = self.q_b_proj(q_latent_local).view(batch_size, s_local, self.num_heads, self.qk_head_dim)
         q_nope, q_rope = q_full.split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
 
-        q_rope_r = q_rope.transpose(1, 2)
-        k_rope_r = k_rope.unsqueeze(1)
-        cos, sin = position_embeddings
-        q_rope_r, k_rope_r = apply_rotary_pos_emb_interleave(q_rope_r, k_rope_r, cos, sin)
+        cos_full, sin_full = position_embeddings_full
+        if self.cp_enabled:
+            cos_local = cos_full[:, self._cp_rank * s_local : (self._cp_rank + 1) * s_local, :]
+            sin_local = sin_full[:, self._cp_rank * s_local : (self._cp_rank + 1) * s_local, :]
+        else:
+            cos_local, sin_local = cos_full, sin_full
+
+        q_rope_r = q_rope.transpose(1, 2)  # [B, H, S_local, rope_dim]
+        q_rope_r = _apply_rope_interleave_single(q_rope_r, cos_local, sin_local)
         q_rope = q_rope_r.transpose(1, 2)
-        k_rope = k_rope_r.squeeze(1)
+
+        k_rope_r = k_rope_full.unsqueeze(1)  # [B, 1, S_full, rope_dim]
+        k_rope_r = _apply_rope_interleave_single(k_rope_r, cos_full, sin_full)
+        k_rope_full = k_rope_r.squeeze(1)
 
         kv_b_w = self.kv_b_proj.weight.view(self.num_heads, self.qk_nope_head_dim + self.v_head_dim, self.kv_lora_rank)
         w_k_nope = kv_b_w[:, : self.qk_nope_head_dim, :]
@@ -158,10 +215,11 @@ class GlmMoeDsaAttention(nn.Module):
         q_absorbed = torch.einsum("bshd,hdk->bshk", q_nope, w_k_nope)
 
         sparse_q = torch.cat([q_absorbed, q_rope], dim=-1)
-        sparse_kv = torch.cat([k_compressed_normed, k_rope], dim=-1).unsqueeze(2)
+        sparse_kv = torch.cat([k_compressed_normed_full, k_rope_full], dim=-1).unsqueeze(2)
 
         sentinel = torch.zeros(batch_size, 1, 1, sparse_kv.shape[-1], dtype=sparse_kv.dtype, device=sparse_kv.device)
         sparse_kv = torch.cat([sparse_kv, sentinel], dim=1)
+        assert sparse_kv.shape[1] == s_full + 1
         return sparse_q, sparse_kv, w_v
 
     def _mla_unabsorb(self, out: torch.Tensor, w_v: torch.Tensor) -> torch.Tensor:
@@ -180,17 +238,41 @@ class GlmMoeDsaAttention(nn.Module):
         ks: torch.Tensor | None = None,
         ke: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Sharded-Q sparse MLA.
+
+        Inputs are CP-sharded along the sequence dimension; KV is gathered to full length
+        inside this module so the tilelang fwd/bwd kernels execute on Q of length S_local
+        and KV of length S_full + 1, keeping per-rank attention compute proportional to
+        S_local * S_full instead of S_full ** 2.
+
+        Args:
+            hidden_states: [B, S_local, hidden_size] CP-sharded along seq.
+            position_embeddings: (cos, sin) over the full sequence length S_full.
+            ks, ke: [S_local] int32, sequence-start and causal-end in K's global coordinates.
+        """
         q_latent, k_compressed_normed, k_rope = self.attn_projections(hidden_states)
 
+        if self.cp_enabled:
+            k_compressed_normed = gather_for_cp(k_compressed_normed, self._cp_group)
+            k_rope = gather_for_cp(k_rope, self._cp_group)
+
         indices = self.indexer.compute_sparse_indices(
-            hidden_states, q_latent, ks, ke, self.args.index_topk, position_embeddings
+            hidden_states_local=hidden_states,
+            q_latent_local=q_latent,
+            ks=ks,
+            ke=ke,
+            index_topk=self.args.index_topk,
+            position_embeddings_full=position_embeddings,
+            cp_group=self._cp_group,
+            cp_world_size=self._cp_world_size,
+            cp_rank=self._cp_rank,
         )
 
         sparse_q, sparse_kv, w_v = self.mla_up_proj(
-            q_latent,
-            k_compressed_normed,
-            k_rope,
-            position_embeddings=position_embeddings,
+            q_latent_local=q_latent,
+            k_compressed_normed_full=k_compressed_normed,
+            k_rope_full=k_rope,
+            position_embeddings_full=position_embeddings,
         )
 
         out = _SparseMLA.apply(sparse_q, sparse_kv, indices, self.scaling)

--- a/src/prime_rl/trainer/models/glm_moe_dsa/sparse_mla_attention.py
+++ b/src/prime_rl/trainer/models/glm_moe_dsa/sparse_mla_attention.py
@@ -51,7 +51,9 @@ class _SparseMLA(torch.autograd.Function):
         return dq, dkv, None, None
 
 
-def _apply_rope_interleave_single(t: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor, unsqueeze_dim: int = 1) -> torch.Tensor:
+def _apply_rope_interleave_single(
+    t: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor, unsqueeze_dim: int = 1
+) -> torch.Tensor:
     """Interleaved RoPE on a single tensor (Q or K), matching apply_rotary_pos_emb_interleave."""
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
@@ -164,9 +166,7 @@ class GlmMoeDsaAttention(nn.Module):
         self._cp_rank: int = 0
         self._cp_world_size: int = 1
 
-    def set_context_parallel_attributes(
-        self, cp_group: dist.ProcessGroup, cp_rank: int, cp_world_size: int
-    ) -> None:
+    def set_context_parallel_attributes(self, cp_group: dist.ProcessGroup, cp_rank: int, cp_world_size: int) -> None:
         self._cp_group = cp_group
         self._cp_rank = cp_rank
         self._cp_world_size = cp_world_size

--- a/src/prime_rl/trainer/models/glm_moe_dsa/sparse_mla_attention.py
+++ b/src/prime_rl/trainer/models/glm_moe_dsa/sparse_mla_attention.py
@@ -51,10 +51,9 @@ class _SparseMLA(torch.autograd.Function):
         return dq, dkv, None, None
 
 
-def _apply_rope_interleave_single(
+def apply_rope_interleave_single(
     t: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor, unsqueeze_dim: int = 1
 ) -> torch.Tensor:
-    """Interleaved RoPE on a single tensor (Q or K), matching apply_rotary_pos_emb_interleave."""
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
     b, h, s, d = t.shape
@@ -96,11 +95,9 @@ class Indexer(nn.Module):
         w = self.weights_proj(hidden_states_local[0])
 
         if cp_world_size > 1:
-            # Gather K-side projections across CP. Smaller than gathering raw hidden_states.
             k_idx = gather_for_cp(k_idx_local.unsqueeze(0), cp_group).squeeze(0)
         else:
             k_idx = k_idx_local
-        s_full = k_idx.shape[0]
 
         cos_full, sin_full = position_embeddings_full
         if cp_world_size > 1:
@@ -115,11 +112,11 @@ class Indexer(nn.Module):
         k_nope = k_idx[..., self.rope_dim :]
 
         q_pe = q_pe.unsqueeze(0).transpose(1, 2)  # [1, H, S_local, rope_dim]
-        q_pe = _apply_rope_interleave_single(q_pe, cos_local, sin_local)
+        q_pe = apply_rope_interleave_single(q_pe, cos_local, sin_local)
         q_pe = q_pe.transpose(1, 2).squeeze(0)
 
         k_pe = k_pe.unsqueeze(0).unsqueeze(1)  # [1, 1, S_full, rope_dim]
-        k_pe = _apply_rope_interleave_single(k_pe, cos_full, sin_full)
+        k_pe = apply_rope_interleave_single(k_pe, cos_full, sin_full)
         k_pe = k_pe.squeeze(1).squeeze(0)
 
         q_idx = torch.cat([q_pe, q_nope], dim=-1)
@@ -202,11 +199,11 @@ class GlmMoeDsaAttention(nn.Module):
             cos_local, sin_local = cos_full, sin_full
 
         q_rope_r = q_rope.transpose(1, 2)  # [B, H, S_local, rope_dim]
-        q_rope_r = _apply_rope_interleave_single(q_rope_r, cos_local, sin_local)
+        q_rope_r = apply_rope_interleave_single(q_rope_r, cos_local, sin_local)
         q_rope = q_rope_r.transpose(1, 2)
 
         k_rope_r = k_rope_full.unsqueeze(1)  # [B, 1, S_full, rope_dim]
-        k_rope_r = _apply_rope_interleave_single(k_rope_r, cos_full, sin_full)
+        k_rope_r = apply_rope_interleave_single(k_rope_r, cos_full, sin_full)
         k_rope_full = k_rope_r.squeeze(1)
 
         kv_b_w = self.kv_b_proj.weight.view(self.num_heads, self.qk_nope_head_dim + self.v_head_dim, self.kv_lora_rank)
@@ -238,18 +235,6 @@ class GlmMoeDsaAttention(nn.Module):
         ks: torch.Tensor | None = None,
         ke: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        """Sharded-Q sparse MLA.
-
-        Inputs are CP-sharded along the sequence dimension; KV is gathered to full length
-        inside this module so the tilelang fwd/bwd kernels execute on Q of length S_local
-        and KV of length S_full + 1, keeping per-rank attention compute proportional to
-        S_local * S_full instead of S_full ** 2.
-
-        Args:
-            hidden_states: [B, S_local, hidden_size] CP-sharded along seq.
-            position_embeddings: (cos, sin) over the full sequence length S_full.
-            ks, ke: [S_local] int32, sequence-start and causal-end in K's global coordinates.
-        """
         q_latent, k_compressed_normed, k_rope = self.attn_projections(hidden_states)
 
         if self.cp_enabled:

--- a/src/prime_rl/trainer/models/kernels/fp8_indexer.py
+++ b/src/prime_rl/trainer/models/kernels/fp8_indexer.py
@@ -97,7 +97,7 @@ def per_token_group_quant_fp8(
         triton.Config({"BLOCK_M": 64, "BLOCK_N": 64}, num_warps=8, num_stages=3),
         triton.Config({"BLOCK_M": 64, "BLOCK_N": 128}, num_warps=8, num_stages=3),
     ],
-    key=["S"],
+    key=["S_Q", "S_K"],
 )
 @triton.jit
 def _triton_fp8_indexer_kernel(
@@ -108,7 +108,8 @@ def _triton_fp8_indexer_kernel(
     Out,
     KS,
     KE,
-    S,
+    S_Q,
+    S_K,
     stride_qh,
     stride_qs,
     stride_ks,
@@ -125,15 +126,15 @@ def _triton_fp8_indexer_kernel(
     offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
     offs_d = tl.arange(0, D)
 
-    mask_m = offs_m < S
-    mask_n = offs_n < S
+    mask_m = offs_m < S_Q
+    mask_n = offs_n < S_K
 
-    ks_vals = tl.load(KS + offs_m, mask=mask_m, other=S)
+    ks_vals = tl.load(KS + offs_m, mask=mask_m, other=S_K)
     ke_vals = tl.load(KE + offs_m, mask=mask_m, other=0)
 
     offs_m_64 = offs_m.to(tl.int64)
     offs_n_64 = offs_n.to(tl.int64)
-    out_ptrs = Out + offs_m_64[:, None] * S + offs_n_64[None, :]
+    out_ptrs = Out + offs_m_64[:, None] * S_K + offs_n_64[None, :]
     out_mask = mask_m[:, None] & mask_n[None, :]
 
     ks_min = tl.min(ks_vals)
@@ -145,8 +146,8 @@ def _triton_fp8_indexer_kernel(
         return
 
     # Clamp indices for FP8 loads (can't use mask+other with fp8 dtype)
-    offs_n_safe = tl.minimum(offs_n, S - 1)
-    offs_m_safe = tl.minimum(offs_m, S - 1)
+    offs_n_safe = tl.minimum(offs_n, S_K - 1)
+    offs_m_safe = tl.minimum(offs_m, S_Q - 1)
 
     k_block = tl.load(K_fp8 + offs_n_safe[:, None] * stride_ks + offs_d[None, :])
     k_sc = tl.load(K_scales + offs_n_safe, mask=mask_n, other=0.0).to(tl.float32)
@@ -171,38 +172,39 @@ def fp8_indexer(q, k, w, ks, ke, topk, weight_scale=1.0):
     """Triton FP8 indexer: UE8M0 quantization + fused scoring kernel + topk.
 
     Args:
-        q: [S, H, D] bf16 query vectors per head
-        k: [S, D] bf16 key vectors (shared across heads)
-        w: [S, H] bf16 per-head weights
-        ks: [S] int32 sequence start per token
-        ke: [S] int32 causal end per token (= position + 1)
+        q: [S_q, H, D] bf16 query vectors per head
+        k: [S_k, D] bf16 key vectors (shared across heads)
+        w: [S_q, H] bf16 per-head weights
+        ks: [S_q] int32 sequence start per token (in K's coordinate system)
+        ke: [S_q] int32 causal end per token (in K's coordinate system, = global position + 1)
         topk: number of top indices to return
         weight_scale: constant scaling factor for weights
 
     Returns:
-        [S, topk] int32 selected token indices per query
+        [S_q, topk] int32 selected token indices per query (sentinel = S_k)
     """
     # NOTE: We don't use weight scale in this kernel as it produces higher KL mismatch for some reason
     # This is not a problem result-wise, as it is a constant multiplier
     _weight_scale = weight_scale
-    S, H, D = q.shape
+    S_q, H, D = q.shape
+    S_k = k.shape[0]
     device = q.device
 
-    q_flat = q.reshape(S * H, D).contiguous()
+    q_flat = q.reshape(S_q * H, D).contiguous()
     q_fp8, q_scales = per_token_group_quant_fp8(q_flat, group_size=D, use_ue8m0=True)
     k_fp8, k_scales = per_token_group_quant_fp8(k.contiguous(), group_size=D, use_ue8m0=True)
 
-    q_fp8 = q_fp8.view(S, H, D).permute(1, 0, 2).contiguous()
+    q_fp8 = q_fp8.view(S_q, H, D).permute(1, 0, 2).contiguous()
 
     # Fold q_scale into weights
-    q_scales = q_scales.view(S, H)
+    q_scales = q_scales.view(S_q, H)
     w = w * q_scales
 
-    logits = torch.empty(S, S, dtype=torch.float32, device=device)
+    logits = torch.empty(S_q, S_k, dtype=torch.float32, device=device)
 
     grid = lambda meta: (
-        triton.cdiv(S, meta["BLOCK_M"]),
-        triton.cdiv(S, meta["BLOCK_N"]),
+        triton.cdiv(S_q, meta["BLOCK_M"]),
+        triton.cdiv(S_k, meta["BLOCK_N"]),
     )
     _triton_fp8_indexer_kernel[grid](
         q_fp8,
@@ -212,7 +214,8 @@ def fp8_indexer(q, k, w, ks, ke, topk, weight_scale=1.0):
         logits,
         ks,
         ke,
-        S,
+        S_q,
+        S_k,
         q_fp8.stride(0),
         q_fp8.stride(1),
         k_fp8.stride(0),
@@ -221,16 +224,16 @@ def fp8_indexer(q, k, w, ks, ke, topk, weight_scale=1.0):
         D=D,
     )
 
-    actual_topk = min(topk, S)
+    actual_topk = min(topk, S_k)
     _, indices = torch.topk(logits, actual_topk, dim=-1)
     if actual_topk < topk:
-        padding = torch.full((S, topk - actual_topk), S, dtype=indices.dtype, device=device)
+        padding = torch.full((S_q, topk - actual_topk), S_k, dtype=indices.dtype, device=device)
         indices = torch.cat([indices, padding], dim=-1)
 
-    # Replace cross-sequence indices with sentinel S (maps to zero-valued KV)
+    # Replace cross-sequence indices with sentinel S_k (maps to zero-valued KV)
     ks_exp = ks.unsqueeze(1).expand_as(indices)
     ke_exp = ke.unsqueeze(1).expand_as(indices)
     out_of_range = (indices < ks_exp) | (indices >= ke_exp)
-    indices = indices.masked_fill(out_of_range, S)
+    indices = indices.masked_fill(out_of_range, S_k)
 
     return indices.to(torch.int32)

--- a/src/prime_rl/trainer/models/kernels/sparse_mla_bwd.py
+++ b/src/prime_rl/trainer/models/kernels/sparse_mla_bwd.py
@@ -161,7 +161,10 @@ def bwd(
             acc_dkv_shared = T.alloc_shared([BS // split_store, D], accum_dtype)
             acc_dkv_tail_shared = T.alloc_shared([BS // split_store, D_tail], accum_dtype)
 
-            max_kv_i = s_i
+            # See sparse_mla_fwd: sentinel is at index S_kv - 1 (zero KV), valid indices
+            # live in [0, S_kv - 1). Using this single bound makes the kernel work for
+            # both full and CP-sharded Q without needing a global Q offset.
+            max_kv_i = S_kv - 2
 
             T.copy(Q[by, s_i, bz * block_H : (bz + 1) * block_H, :D], Q_shared)
             T.copy(Q[by, s_i, bz * block_H : (bz + 1) * block_H, D:], Q_tail_shared)

--- a/src/prime_rl/trainer/models/kernels/sparse_mla_fwd.py
+++ b/src/prime_rl/trainer/models/kernels/sparse_mla_fwd.py
@@ -104,7 +104,6 @@ def sparse_mla_fwd(
 
             b_i, g_i = by, bz
             s_i = bx if REPLICATE_H == 1 else (bx // REPLICATE_H)
-            q_i = s_i
             # The indexer pre-filters indices using per-token `ke` and replaces out-of-range
             # entries with the sentinel value `seq_len_kv - 1` (the last KV slot is a
             # zero sentinel; valid K indices live in [0, seq_len_kv - 1)). This single

--- a/src/prime_rl/trainer/models/kernels/sparse_mla_fwd.py
+++ b/src/prime_rl/trainer/models/kernels/sparse_mla_fwd.py
@@ -105,7 +105,12 @@ def sparse_mla_fwd(
             b_i, g_i = by, bz
             s_i = bx if REPLICATE_H == 1 else (bx // REPLICATE_H)
             q_i = s_i
-            max_kv_i = q_i
+            # The indexer pre-filters indices using per-token `ke` and replaces out-of-range
+            # entries with the sentinel value `seq_len_kv - 1` (the last KV slot is a
+            # zero sentinel; valid K indices live in [0, seq_len_kv - 1)). This single
+            # bound preserves causality + varlen masking for both full and CP-sharded Q
+            # (where local q_i no longer matches the global K position).
+            max_kv_i = seq_len_kv - 2
 
             H0 = g_i * padded_H + (0 if REPLICATE_H == 1 else (bx % REPLICATE_H) * 64)
             H1 = H0 + H_per_block


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the sparse-attention indexing, rotary embedding application, and kernel masking to support context-parallel (CP) execution, which can impact attention correctness and stability across ranks. Risk is moderate because it touches custom Triton/TileLang kernels and sequence-coordinate assumptions.
> 
> **Overview**
> Adds **context-parallel (CP) aware sparse MLA attention** for `glm_moe_dsa` by gathering full-sequence K/V while keeping Q and `ks/ke` local, and by computing rotary embeddings over the full sequence with per-rank slicing for Q.
> 
> Updates the FP8 Triton `fp8_indexer` and sparse MLA TileLang kernels to handle **different query vs key sequence lengths** and to use a **sentinel-based KV bound** (`S_k-1`) for masking/causality, making the same kernels work for both full-seq and CP-sharded Q.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2ad03f09f797bd84df6d20b61ebc2b4398efee4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<img width="1434" height="300" alt="image" src="https://github.com/user-attachments/assets/889f9b3b-f045-47d4-94bb-b42be2d1483e" />

<img width="1368" height="381" alt="image" src="https://github.com/user-attachments/assets/f7e17378-81bb-4518-bb85-8f434253cac9" />

