### PR TITLE
feat(inference): vllm engine liveness probe

### DIFF
--- a/k8s/prime-rl/templates/deployment.yaml
+++ b/k8s/prime-rl/templates/deployment.yaml
@@ -207,7 +207,7 @@ spec:
           timeoutSeconds: {{ .Values.inference.probes.startup.timeoutSeconds }}
         livenessProbe:
           httpGet:
-            path: /health
+            path: /liveness
             port: {{ .Values.inference.service.port }}
           periodSeconds: {{ .Values.inference.probes.liveness.periodSeconds }}
           failureThreshold: {{ .Values.inference.probes.liveness.failureThreshold }}

--- a/k8s/prime-rl/values.yaml
+++ b/k8s/prime-rl/values.yaml
@@ -75,7 +75,7 @@ inference:
 
   runtimeClassName: nvidia
 
-  # Health probes for inference server (requires /health endpoint)
+  # Health probes for inference server (/health for startup/readiness, /liveness for engine liveness)
   probes:
     enabled: false
     # Startup probe: allows long model loading time (up to 45 min by default)
@@ -86,7 +86,7 @@ inference:
     liveness:
       periodSeconds: 10
       failureThreshold: 3
-      timeoutSeconds: 60
+      timeoutSeconds: 10
     readiness:
       periodSeconds: 5
       failureThreshold: 2

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -1,3 +1,4 @@
+import asyncio
 from argparse import Namespace
 from http import HTTPStatus
 from typing import Any
@@ -158,6 +159,7 @@ logger = init_logger("vllm.entrypoints.openai.api_server")
 
 # Create our own router for custom endpoints
 router = APIRouter()
+LIVENESS_TIMEOUT_SECONDS = 5.0
 
 
 def engine_client(request: Request) -> EngineClient:
@@ -208,6 +210,19 @@ async def load_lora_adapter(lora_request: LoadLoRAAdapterRequest, raw_request: R
     response = await handler.load_lora_adapter(lora_request)
     if isinstance(response, ErrorResponse):
         return JSONResponse(content=response.model_dump(), status_code=response.error.code)
+    return {"status": "ok"}
+
+
+@router.get("/liveness")
+async def liveness(raw_request: Request):
+    """Check that the engine event loop can service a no-op worker RPC."""
+    try:
+        await asyncio.wait_for(
+            engine_client(raw_request).collective_rpc("liveness_probe"),
+            timeout=LIVENESS_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError:
+        return JSONResponse({"status": "engine_unresponsive"}, status_code=503)
     return {"status": "ok"}
 
 

--- a/src/prime_rl/inference/vllm/worker/filesystem.py
+++ b/src/prime_rl/inference/vllm/worker/filesystem.py
@@ -20,6 +20,10 @@ class FileSystemWeightUpdateWorker(Worker):
         """Initialize the broadcaster."""
         ...
 
+    def liveness_probe(self) -> None:
+        """No-op RPC used by the API server liveness endpoint."""
+        return None
+
     def update_weights_from_path(self, weight_path: str) -> None:
         """Update weights from a specified path in shared filesystem containing a HF-compatible checkpoint."""
         # Get vLLM model runner and model

--- a/src/prime_rl/inference/vllm/worker/nccl.py
+++ b/src/prime_rl/inference/vllm/worker/nccl.py
@@ -130,6 +130,10 @@ class NCCLWeightUpdateWorker(Worker):
             timeout=timeout,
         )
 
+    def liveness_probe(self) -> None:
+        """No-op RPC used by the API server liveness endpoint."""
+        return None
+
     def update_weights_from_path(self, weight_dir: str) -> None:
         """Update weights with the nccl communicator."""
         model_runner = self.model_runner

--- a/tests/unit/test_tool_call_parser.py
+++ b/tests/unit/test_tool_call_parser.py
@@ -1,6 +1,28 @@
+import asyncio
+import json
+from types import SimpleNamespace
+
 import pytest
 
-from prime_rl.inference.vllm.server import resolve_tool_call_parser
+from prime_rl.inference.vllm.server import liveness, resolve_tool_call_parser
+
+
+class ResponsiveEngine:
+    async def collective_rpc(self, method):
+        assert method == "liveness_probe"
+        return []
+
+
+class HangingEngine:
+    async def collective_rpc(self, method):
+        assert method == "liveness_probe"
+        await asyncio.sleep(60)
+
+
+def request_with_engine(engine):
+    return SimpleNamespace(
+        app=SimpleNamespace(state=SimpleNamespace(engine_client=engine)),
+    )
 
 
 @pytest.mark.parametrize(
@@ -47,3 +69,18 @@ def test_auto_unknown_model():
 
 def test_none_skips_resolution():
     assert resolve_tool_call_parser("Qwen/Qwen3-0.6B", None) is None
+
+
+def test_liveness_returns_ok_when_engine_responds():
+    response = asyncio.run(liveness(request_with_engine(ResponsiveEngine())))
+
+    assert response == {"status": "ok"}
+
+
+def test_liveness_returns_503_when_engine_times_out(monkeypatch):
+    monkeypatch.setattr("prime_rl.inference.vllm.server.LIVENESS_TIMEOUT_SECONDS", 0.001)
+
+    response = asyncio.run(liveness(request_with_engine(HangingEngine())))
+
+    assert response.status_code == 503
+    assert json.loads(response.body) == {"status": "engine_unresponsive"}

--- a/tests/unit/test_tool_call_parser.py
+++ b/tests/unit/test_tool_call_parser.py
@@ -1,28 +1,6 @@
-import asyncio
-import json
-from types import SimpleNamespace
-
 import pytest
 
-from prime_rl.inference.vllm.server import liveness, resolve_tool_call_parser
-
-
-class ResponsiveEngine:
-    async def collective_rpc(self, method):
-        assert method == "liveness_probe"
-        return []
-
-
-class HangingEngine:
-    async def collective_rpc(self, method):
-        assert method == "liveness_probe"
-        await asyncio.sleep(60)
-
-
-def request_with_engine(engine):
-    return SimpleNamespace(
-        app=SimpleNamespace(state=SimpleNamespace(engine_client=engine)),
-    )
+from prime_rl.inference.vllm.server import resolve_tool_call_parser
 
 
 @pytest.mark.parametrize(
@@ -69,18 +47,3 @@ def test_auto_unknown_model():
 
 def test_none_skips_resolution():
     assert resolve_tool_call_parser("Qwen/Qwen3-0.6B", None) is None
-
-
-def test_liveness_returns_ok_when_engine_responds():
-    response = asyncio.run(liveness(request_with_engine(ResponsiveEngine())))
-
-    assert response == {"status": "ok"}
-
-
-def test_liveness_returns_503_when_engine_times_out(monkeypatch):
-    monkeypatch.setattr("prime_rl.inference.vllm.server.LIVENESS_TIMEOUT_SECONDS", 0.001)
-
-    response = asyncio.run(liveness(request_with_engine(HangingEngine())))
-
-    assert response.status_code == 503
-    assert json.loads(response.body) == {"status": "engine_unresponsive"}


### PR DESCRIPTION
currently we just have probes set up to hit `/health` and `/v1/models`, but it isn't really representative of whether or not the vllm engine is alive and responding (ie `/health` just checks if the fastapi server is responding):

```
(APIServer pid=333) INFO:     10.40.4.194:60062 - "GET /health HTTP/1.1" 200 OK
(APIServer pid=333) INFO:     10.40.4.194:60062 - "GET /v1/models HTTP/1.1" 200 OK
```

so adding a liveness endpoint that we can probe that directly tests the responsiveness of the vllm engine itself, which will be helpful with those sync server issues we've been seeing on hosted training.

# Testing
also tested this locally on k8s by manually pausing the vllm engine process to trigger the liveness probe failure and container restart.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Kubernetes liveness behavior and introduces new engine RPC calls; misconfiguration or slow/blocked RPCs could cause unnecessary pod restarts.
> 
> **Overview**
> Adds a new inference-server `/liveness` endpoint that attempts a timed `collective_rpc("liveness_probe")` to verify the vLLM engine event loop is responsive, returning `503` when the engine is unresponsive.
> 
> Implements the corresponding no-op `liveness_probe` RPC on both vLLM worker extensions (`nccl` and `filesystem`), and updates the Helm chart to point the inference `livenessProbe` at `/liveness` (while keeping `/health` for startup/readiness) and to reduce the default liveness probe timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c51aba87e0d1dd235dd7146ee0295c623c3796de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->