### PR TITLE
feat(trainer): add single-point TPS/MFU API for RL

### DIFF
--- a/src/prime_rl/trainer/perf.py
+++ b/src/prime_rl/trainer/perf.py
@@ -1,5 +1,3 @@
-import time
-
 import torch
 from torch import nn
 from transformers import PretrainedConfig
@@ -12,16 +10,11 @@ from prime_rl.utils.logger import get_logger
 
 class PerfCounter:
     """
-    A class to count throughput (tokens/s) with a rolling window to obtain
-    precise throughput and MFU estimates.
-
-    Inspired from https://github.com/pytorch/torchtitan/blob/4b3f2e41a084bf79a8540068ed525539d1244edd/torchtitan/utils.py#L119
+    Computes per-step throughput (tokens/s) and MFU from the forward+backward
+    time of the current step.
     """
 
-    def __init__(self, model: nn.Module, seq_len: int, window_size: int):
-        self.window_size = window_size
-        self.tokens = []
-        self.times = []
+    def __init__(self, model: nn.Module, seq_len: int):
         self.model = model
 
         self._world = get_world()
@@ -36,22 +29,11 @@ class PerfCounter:
         self.num_params = self._get_num_params(model, exclude_embedding=not model.config.tie_word_embeddings)
         self.num_flop_per_token = self._get_num_flop_per_token(model.config, seq_len=seq_len)
 
-    def count_tokens(self, tokens: int):
-        self.tokens.append(tokens)
-        self.times.append(time.perf_counter())
-        if len(self.tokens) > self.window_size:
-            self.tokens.pop(0)
-            self.times.pop(0)
+    def get_tokens_per_second(self, tokens: int, fwd_bwd_time: float) -> float:
+        return tokens / fwd_bwd_time
 
-    def get_tokens_per_second(self) -> float | None:
-        if len(self.tokens) < 2:
-            return None
-        return sum(self.tokens[1:]) / (self.times[-1] - self.times[0])
-
-    def get_mfu(self) -> float | None:
-        tokens_per_second = self.get_tokens_per_second()
-        if tokens_per_second is None:
-            return None
+    def get_mfu(self, tokens: int, fwd_bwd_time: float) -> float:
+        tokens_per_second = self.get_tokens_per_second(tokens, fwd_bwd_time)
         return 100 * self.num_flop_per_token * tokens_per_second / self.gpu_peak_flops / self._world.world_size
 
     def _get_peak_flops(self, device_name: str) -> float:
@@ -234,9 +216,9 @@ class PerfCounter:
 _PERF_COUNTER: PerfCounter | None = None
 
 
-def get_perf_counter(model: nn.Module, seq_len: int, window_size: int = 10) -> PerfCounter:
+def get_perf_counter(model: nn.Module, seq_len: int) -> PerfCounter:
     global _PERF_COUNTER
     if _PERF_COUNTER is None:
-        _PERF_COUNTER = PerfCounter(model, seq_len, window_size)
+        _PERF_COUNTER = PerfCounter(model, seq_len)
 
     return _PERF_COUNTER

--- a/src/prime_rl/trainer/perf.py
+++ b/src/prime_rl/trainer/perf.py
@@ -1,3 +1,5 @@
+import time
+
 import torch
 from torch import nn
 from transformers import PretrainedConfig
@@ -10,19 +12,22 @@ from prime_rl.utils.logger import get_logger
 
 class PerfCounter:
     """
-    Computes throughput (tokens/s) and MFU from forward+backward time.
+    Computes throughput (tokens/s) and MFU.
 
     Two modes:
-    - Sliding window: call `count_tokens(tokens, fwd_bwd_time)` each step,
-      then read smoothed values via `get_tokens_per_second()` / `get_mfu()`.
-    - Single point: call `get_step_tokens_per_second(tokens, fwd_bwd_time)`
-      / `get_step_mfu(tokens, fwd_bwd_time)` directly each step.
+    - Sliding window over full-step wall time: `count_tokens(tokens)` each step,
+      read smoothed values via `get_tokens_per_second()` / `get_mfu()`.
+      Time is measured between successive `count_tokens` calls (full step).
+    - Single point on a caller-provided duration: `get_step_tokens_per_second(tokens, fwd_bwd_time)`
+      / `get_step_mfu(tokens, fwd_bwd_time)`. No smoothing.
+
+    Sliding window inspired by https://github.com/pytorch/torchtitan/blob/4b3f2e41a084bf79a8540068ed525539d1244edd/torchtitan/utils.py#L119
     """
 
     def __init__(self, model: nn.Module, seq_len: int, window_size: int = 10):
         self.window_size = window_size
         self.tokens: list[int] = []
-        self.fwd_bwd_times: list[float] = []
+        self.times: list[float] = []
         self.model = model
 
         self._world = get_world()
@@ -37,22 +42,18 @@ class PerfCounter:
         self.num_params = self._get_num_params(model, exclude_embedding=not model.config.tie_word_embeddings)
         self.num_flop_per_token = self._get_num_flop_per_token(model.config, seq_len=seq_len)
 
-    def count_tokens(self, tokens: int, fwd_bwd_time: float) -> None:
-        """Record a step for the sliding window."""
+    def count_tokens(self, tokens: int) -> None:
+        """Push a step into the sliding window. Time is recorded internally."""
         self.tokens.append(tokens)
-        self.fwd_bwd_times.append(fwd_bwd_time)
+        self.times.append(time.perf_counter())
         if len(self.tokens) > self.window_size:
             self.tokens.pop(0)
-            self.fwd_bwd_times.pop(0)
+            self.times.pop(0)
 
     def get_tokens_per_second(self) -> float | None:
-        """Sliding-window throughput. None until `count_tokens` has been called."""
-        if not self.tokens:
+        if len(self.tokens) < 2:
             return None
-        total_time = sum(self.fwd_bwd_times)
-        if total_time <= 0:
-            return None
-        return sum(self.tokens) / total_time
+        return sum(self.tokens[1:]) / (self.times[-1] - self.times[0])
 
     def get_mfu(self) -> float | None:
         tokens_per_second = self.get_tokens_per_second()
@@ -61,7 +62,7 @@ class PerfCounter:
         return self._mfu_from_tps(tokens_per_second)
 
     def get_step_tokens_per_second(self, tokens: int, fwd_bwd_time: float) -> float:
-        """Single-step throughput, no smoothing."""
+        """Single-step throughput from a caller-provided duration."""
         return tokens / fwd_bwd_time
 
     def get_step_mfu(self, tokens: int, fwd_bwd_time: float) -> float:

--- a/src/prime_rl/trainer/perf.py
+++ b/src/prime_rl/trainer/perf.py
@@ -10,11 +10,19 @@ from prime_rl.utils.logger import get_logger
 
 class PerfCounter:
     """
-    Computes per-step throughput (tokens/s) and MFU from the forward+backward
-    time of the current step.
+    Computes throughput (tokens/s) and MFU from forward+backward time.
+
+    Two modes:
+    - Sliding window: call `count_tokens(tokens, fwd_bwd_time)` each step,
+      then read smoothed values via `get_tokens_per_second()` / `get_mfu()`.
+    - Single point: call `get_step_tokens_per_second(tokens, fwd_bwd_time)`
+      / `get_step_mfu(tokens, fwd_bwd_time)` directly each step.
     """
 
-    def __init__(self, model: nn.Module, seq_len: int):
+    def __init__(self, model: nn.Module, seq_len: int, window_size: int = 10):
+        self.window_size = window_size
+        self.tokens: list[int] = []
+        self.fwd_bwd_times: list[float] = []
         self.model = model
 
         self._world = get_world()
@@ -29,11 +37,37 @@ class PerfCounter:
         self.num_params = self._get_num_params(model, exclude_embedding=not model.config.tie_word_embeddings)
         self.num_flop_per_token = self._get_num_flop_per_token(model.config, seq_len=seq_len)
 
-    def get_tokens_per_second(self, tokens: int, fwd_bwd_time: float) -> float:
+    def count_tokens(self, tokens: int, fwd_bwd_time: float) -> None:
+        """Record a step for the sliding window."""
+        self.tokens.append(tokens)
+        self.fwd_bwd_times.append(fwd_bwd_time)
+        if len(self.tokens) > self.window_size:
+            self.tokens.pop(0)
+            self.fwd_bwd_times.pop(0)
+
+    def get_tokens_per_second(self) -> float | None:
+        """Sliding-window throughput. None until `count_tokens` has been called."""
+        if not self.tokens:
+            return None
+        total_time = sum(self.fwd_bwd_times)
+        if total_time <= 0:
+            return None
+        return sum(self.tokens) / total_time
+
+    def get_mfu(self) -> float | None:
+        tokens_per_second = self.get_tokens_per_second()
+        if tokens_per_second is None:
+            return None
+        return self._mfu_from_tps(tokens_per_second)
+
+    def get_step_tokens_per_second(self, tokens: int, fwd_bwd_time: float) -> float:
+        """Single-step throughput, no smoothing."""
         return tokens / fwd_bwd_time
 
-    def get_mfu(self, tokens: int, fwd_bwd_time: float) -> float:
-        tokens_per_second = self.get_tokens_per_second(tokens, fwd_bwd_time)
+    def get_step_mfu(self, tokens: int, fwd_bwd_time: float) -> float:
+        return self._mfu_from_tps(self.get_step_tokens_per_second(tokens, fwd_bwd_time))
+
+    def _mfu_from_tps(self, tokens_per_second: float) -> float:
         return 100 * self.num_flop_per_token * tokens_per_second / self.gpu_peak_flops / self._world.world_size
 
     def _get_peak_flops(self, device_name: str) -> float:
@@ -216,9 +250,9 @@ class PerfCounter:
 _PERF_COUNTER: PerfCounter | None = None
 
 
-def get_perf_counter(model: nn.Module, seq_len: int) -> PerfCounter:
+def get_perf_counter(model: nn.Module, seq_len: int, window_size: int = 10) -> PerfCounter:
     global _PERF_COUNTER
     if _PERF_COUNTER is None:
-        _PERF_COUNTER = PerfCounter(model, seq_len)
+        _PERF_COUNTER = PerfCounter(model, seq_len, window_size)
 
     return _PERF_COUNTER

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -475,8 +475,6 @@ def train(config: TrainerConfig):
                 micro_step_message += f" | Max Vio: {tensors['max_vio'][-1].mean().item():.4f}"
             logger.debug(micro_step_message)
 
-        forward_backward_time = time.perf_counter() - forward_backward_start_time
-
         # Optionally, clip the gradients
         grad_norm: torch.Tensor | None = None
         if config.optim.max_norm is not None:
@@ -499,6 +497,7 @@ def train(config: TrainerConfig):
             current_lr = optimizer.param_groups[0]["lr"]
         else:
             current_lr = optimizer.get_current_lr()
+        forward_backward_time = time.perf_counter() - forward_backward_start_time
 
         # Optionally, dump memory snapshot
         if memory_profiler is not None:

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -512,8 +512,8 @@ def train(config: TrainerConfig):
         progress.total_tokens += num_tokens
         progress.total_samples += batch_size
         perf_counter = get_perf_counter(model, seq_len)
-        throughput = perf_counter.get_tokens_per_second(num_tokens, forward_backward_time)
-        mfu = perf_counter.get_mfu(num_tokens, forward_backward_time)
+        throughput = perf_counter.get_step_tokens_per_second(num_tokens, forward_backward_time)
+        mfu = perf_counter.get_step_mfu(num_tokens, forward_backward_time)
         peak_memory = torch.cuda.max_memory_reserved() / 1024**3  # GiB
 
         # Log step metrics

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -475,6 +475,8 @@ def train(config: TrainerConfig):
                 micro_step_message += f" | Max Vio: {tensors['max_vio'][-1].mean().item():.4f}"
             logger.debug(micro_step_message)
 
+        forward_backward_time = time.perf_counter() - forward_backward_start_time
+
         # Optionally, clip the gradients
         grad_norm: torch.Tensor | None = None
         if config.optim.max_norm is not None:
@@ -497,7 +499,6 @@ def train(config: TrainerConfig):
             current_lr = optimizer.param_groups[0]["lr"]
         else:
             current_lr = optimizer.get_current_lr()
-        forward_backward_time = time.perf_counter() - forward_backward_start_time
 
         # Optionally, dump memory snapshot
         if memory_profiler is not None:
@@ -512,9 +513,8 @@ def train(config: TrainerConfig):
         progress.total_tokens += num_tokens
         progress.total_samples += batch_size
         perf_counter = get_perf_counter(model, seq_len)
-        perf_counter.count_tokens(num_tokens)
-        throughput = perf_counter.get_tokens_per_second() or 0
-        mfu = perf_counter.get_mfu() or 0
+        throughput = perf_counter.get_tokens_per_second(num_tokens, forward_backward_time)
+        mfu = perf_counter.get_mfu(num_tokens, forward_backward_time)
         peak_memory = torch.cuda.max_memory_reserved() / 1024**3  # GiB
 
         # Log step metrics

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -427,8 +427,9 @@ def train(config: SFTConfig):
         progress.total_tokens += num_tokens
         progress.total_samples = dataset.step
         perf_counter = get_perf_counter(model, config.data.seq_len)
-        throughput = perf_counter.get_tokens_per_second(num_tokens, forward_backward_time)
-        mfu = perf_counter.get_mfu(num_tokens, forward_backward_time)
+        perf_counter.count_tokens(num_tokens, forward_backward_time)
+        throughput = perf_counter.get_tokens_per_second() or 0
+        mfu = perf_counter.get_mfu() or 0
         peak_memory = torch.cuda.max_memory_reserved() / 1024**3  # GiB
 
         # Log step metrics

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -368,6 +368,8 @@ def train(config: SFTConfig):
                     dist.all_reduce(max_vio, op=dist.ReduceOp.MAX)
                     batch_max_vio += max_vio / grad_accum_steps
 
+        forward_backward_time = time.perf_counter() - forward_backward_start_time
+
         # All-reduce token counts and rescale gradients to get a global token-weighted mean.
         # FSDP already divided grads by fsdp_gradient_divide_factor, so we undo that and
         # divide by the true global token count instead.
@@ -415,7 +417,6 @@ def train(config: SFTConfig):
         # Update learning rate scheduler
         current_lr = optimizer.param_groups[0]["lr"]
         scheduler.step()
-        forward_backward_time = time.perf_counter() - forward_backward_start_time
 
         # Optionally, dump memory snapshot
         if memory_profiler is not None:
@@ -427,7 +428,7 @@ def train(config: SFTConfig):
         progress.total_tokens += num_tokens
         progress.total_samples = dataset.step
         perf_counter = get_perf_counter(model, config.data.seq_len)
-        perf_counter.count_tokens(num_tokens, forward_backward_time)
+        perf_counter.count_tokens(num_tokens)
         throughput = perf_counter.get_tokens_per_second() or 0
         mfu = perf_counter.get_mfu() or 0
         peak_memory = torch.cuda.max_memory_reserved() / 1024**3  # GiB

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -368,8 +368,6 @@ def train(config: SFTConfig):
                     dist.all_reduce(max_vio, op=dist.ReduceOp.MAX)
                     batch_max_vio += max_vio / grad_accum_steps
 
-        forward_backward_time = time.perf_counter() - forward_backward_start_time
-
         # All-reduce token counts and rescale gradients to get a global token-weighted mean.
         # FSDP already divided grads by fsdp_gradient_divide_factor, so we undo that and
         # divide by the true global token count instead.
@@ -417,6 +415,7 @@ def train(config: SFTConfig):
         # Update learning rate scheduler
         current_lr = optimizer.param_groups[0]["lr"]
         scheduler.step()
+        forward_backward_time = time.perf_counter() - forward_backward_start_time
 
         # Optionally, dump memory snapshot
         if memory_profiler is not None:

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -428,9 +428,8 @@ def train(config: SFTConfig):
         progress.total_tokens += num_tokens
         progress.total_samples = dataset.step
         perf_counter = get_perf_counter(model, config.data.seq_len)
-        perf_counter.count_tokens(num_tokens)
-        throughput = perf_counter.get_tokens_per_second() or 0
-        mfu = perf_counter.get_mfu() or 0
+        throughput = perf_counter.get_tokens_per_second(num_tokens, forward_backward_time)
+        mfu = perf_counter.get_mfu(num_tokens, forward_backward_time)
         peak_memory = torch.cuda.max_memory_reserved() / 1024**3  # GiB
 
         # Log step metrics

--- a/tests/unit/train/test_perf.py
+++ b/tests/unit/train/test_perf.py
@@ -25,7 +25,7 @@ def test_perf_counter(model_name: str, active_params: int, flops_per_token: int)
                 None,
             )
         model = AutoModelForCausalLM.from_config(config)
-    perf_counter = PerfCounter(model, seq_len=1024, window_size=10)
+    perf_counter = PerfCounter(model, seq_len=1024)
 
     assert perf_counter.get_active_mm_params(config) == active_params, (
         f"Expected {active_params:,} active parameters, got {perf_counter.get_active_mm_params(config):,} active parameters"


### PR DESCRIPTION
## Summary

- Add `get_step_tokens_per_second(tokens, fwd_bwd_time)` and `get_step_mfu(tokens, fwd_bwd_time)` to `PerfCounter` — a single-point, no-smoothing API that takes an explicit duration.
- RL trainer switches to this API, using `forward_backward_time` as the duration. Previously the rolling-window getters were measuring wall time between successive `count_tokens` calls, which on RL spans the wait-for-batch / load-data block and inflates the denominator.
- SFT trainer is unchanged: it keeps the original sliding-window-over-full-step behavior.

## Changes

- `perf.py`: keep the sliding-window API, add `get_step_*` methods alongside.
- `rl/train.py`: call `get_step_tokens_per_second` / `get_step_mfu` with `num_tokens` and `forward_backward_time`.
- `sft/train.py`: no change.
- `tests/unit/train/test_perf.py`: drop the now-default `window_size` arg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit a7dcd7cf430c5966cae49b96189789570487d479. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->