### PR TITLE
fix(qwen3.5-moe): align _compute_attention with FA4 kwarg

### DIFF
--- a/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -480,11 +480,19 @@ class Qwen3_5MoeGatedFlashAttention(Qwen3_5MoeGatedAttentionBase):
             self._flash_attn_call = torch._dynamo.disable(self.func)
 
     def _compute_attention(self, q, k, v, cu_seqlens, max_seqlen):
-        args = [q, k, v, cu_seqlens, cu_seqlens]
-        if self._flash_attn_version != 4:
-            args.extend([max_seqlen, max_seqlen])
+        """Run the flash attention kernel. q/k/v are [total_tokens, heads, dim]."""
         kwargs: dict = {"causal": True}
-        out = self._flash_attn_call(*args, **kwargs)
+        sliding_window = getattr(self, "sliding_window", None)
+        if sliding_window is not None:
+            kwargs["window_size"] = (sliding_window - 1, 0)
+        if self._flash_attn_version == 4:
+            # FA4's flash_attn_varlen_func has qv as the 4th positional arg,
+            # so cu_seqlens must be passed as keyword args to avoid misalignment.
+            kwargs["cu_seqlens_q"] = cu_seqlens
+            kwargs["cu_seqlens_k"] = cu_seqlens
+            out = self._flash_attn_call(q, k, v, **kwargs)
+        else:
+            out = self._flash_attn_call(q, k, v, cu_seqlens, cu_seqlens, max_seqlen, max_seqlen, **kwargs)
         if isinstance(out, tuple):
             out = out[0]
         return out


### PR DESCRIPTION
Port the _compute_attention implementation from layers/attn.py so FA4 receives cu_seqlens via keyword args (its 4th positional is qv) and so sliding_window is honored when set.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the low-level attention kernel invocation path; small but can affect correctness or trigger runtime errors across different FlashAttention versions and configurations.
> 
> **Overview**
> Fixes `Qwen3_5MoeGatedFlashAttention._compute_attention` to call FlashAttention v4 with `cu_seqlens_q`/`cu_seqlens_k` keyword arguments (avoiding positional-argument misalignment in FA4), while keeping the existing positional calling convention for FA2/FA3.
> 
> Also adds optional sliding-window support by passing `window_size` to the flash-attn kernel when `sliding_window` is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2707937b32c51f7964a6c79e0cf949719a8dd08c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->