### PR TITLE
feat(orchestrator): bump verifiers to 3b77145, log per-turn timings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ override-dependencies = [
 
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "980a9ea" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "3b77145" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eeb" }
 transformers = { git = "https://github.com/huggingface/transformers.git", rev = "c1c3424" }

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -587,19 +587,27 @@ async def orchestrate(config: OrchestratorConfig):
                 "decode_len": rollout_decode_lens,
                 "samples_per_rollout": rollout_samples_per_rollout,
                 "num_turns": [len(rollout["trajectory"]) for rollout in train_rollouts],
-                "timing_total": [rollout["timing"]["total"] for rollout in train_rollouts],
-                "timing_setup": [rollout["timing"]["setup"]["duration"] for rollout in train_rollouts],
-                "timing_generation": [rollout["timing"]["generation"]["duration"] for rollout in train_rollouts],
-                "timing_model": [rollout["timing"]["model"]["duration"] for rollout in train_rollouts],
-                "timing_env": [rollout["timing"]["env"]["duration"] for rollout in train_rollouts],
-                "timing_scoring": [rollout["timing"]["scoring"]["duration"] for rollout in train_rollouts],
-                "timing_overhead": [rollout["timing"]["overhead"] for rollout in train_rollouts],
             }
         )
 
-        # Separate DataFrames for env reward function metrics and filter flags to avoid column name collisions
+        # Separate DataFrames for env reward function metrics, filter flags, and per-rollout timings
+        # to avoid column name collisions
         metrics_df = pd.DataFrame([rollout["metrics"] for rollout in train_rollouts])
         filter_df = pd.DataFrame([rollout["filters"] for rollout in train_rollouts])
+        timing_df = pd.DataFrame(
+            [
+                {
+                    "total": rollout["timing"]["total"],
+                    "setup": rollout["timing"]["setup"]["duration"],
+                    "generation": rollout["timing"]["generation"]["duration"],
+                    "model": rollout["timing"]["model"]["duration"],
+                    "env": rollout["timing"]["env"]["duration"],
+                    "scoring": rollout["timing"]["scoring"]["duration"],
+                    "overhead": rollout["timing"]["overhead"],
+                }
+                for rollout in train_rollouts
+            ]
+        )
 
         # Update progress metrics
         num_tokens = int(results_df.seq_len.sum())
@@ -655,8 +663,11 @@ async def orchestrate(config: OrchestratorConfig):
             "num_turns/all/max": by_example.num_turns.mean().max(),
             "num_turns/all/min": by_example.num_turns.mean().min(),
             **{
-                f"timing/all/{key}/{stat}": getattr(by_example[f"timing_{key}"].mean(), stat)()
-                for key in ("total", "setup", "generation", "model", "env", "scoring", "overhead")
+                f"timing/all/{key}/{stat}": getattr(
+                    timing_df[key].groupby([results_df.env_name, results_df.example_id]).mean(),
+                    stat,
+                )()
+                for key in timing_df.columns
                 for stat in ("mean", "max", "min")
             },
             # Train reward
@@ -696,7 +707,6 @@ async def orchestrate(config: OrchestratorConfig):
             "samples_per_rollout",
             "num_turns",
         ]
-        per_env_timing_keys = ("total", "setup", "generation", "model", "env", "scoring", "overhead")
 
         for env, env_df in results_df.groupby("env_name"):
             env_by_example = env_df.groupby("example_id")
@@ -705,9 +715,9 @@ async def orchestrate(config: OrchestratorConfig):
                 to_log[f"{col}/{env}/max"] = env_by_example[col].mean().max()
                 if col != "is_truncated":
                     to_log[f"{col}/{env}/min"] = env_by_example[col].mean().min()
-            for key in per_env_timing_keys:
-                col = f"timing_{key}"
-                per_example = env_by_example[col].mean()
+            env_timing_df = timing_df.loc[env_df.index]
+            for key in timing_df.columns:
+                per_example = env_timing_df.groupby(env_df["example_id"])[key].mean()
                 to_log[f"timing/{env}/{key}/mean"] = per_example.mean()
                 to_log[f"timing/{env}/{key}/max"] = per_example.max()
                 to_log[f"timing/{env}/{key}/min"] = per_example.min()

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -587,8 +587,13 @@ async def orchestrate(config: OrchestratorConfig):
                 "decode_len": rollout_decode_lens,
                 "samples_per_rollout": rollout_samples_per_rollout,
                 "num_turns": [len(rollout["trajectory"]) for rollout in train_rollouts],
-                "generation_ms": [rollout["timing"]["generation_ms"] for rollout in train_rollouts],
-                "scoring_ms": [rollout["timing"]["scoring_ms"] for rollout in train_rollouts],
+                "timing_total": [rollout["timing"]["total"] for rollout in train_rollouts],
+                "timing_setup": [rollout["timing"]["setup"]["duration"] for rollout in train_rollouts],
+                "timing_generation": [rollout["timing"]["generation"]["duration"] for rollout in train_rollouts],
+                "timing_model": [rollout["timing"]["model"]["duration"] for rollout in train_rollouts],
+                "timing_env": [rollout["timing"]["env"]["duration"] for rollout in train_rollouts],
+                "timing_scoring": [rollout["timing"]["scoring"]["duration"] for rollout in train_rollouts],
+                "timing_overhead": [rollout["timing"]["overhead"] for rollout in train_rollouts],
             }
         )
 
@@ -649,12 +654,11 @@ async def orchestrate(config: OrchestratorConfig):
             "num_turns/all/mean": by_example.num_turns.mean().mean(),
             "num_turns/all/max": by_example.num_turns.mean().max(),
             "num_turns/all/min": by_example.num_turns.mean().min(),
-            "generation_ms/all/mean": by_example.generation_ms.mean().mean(),
-            "generation_ms/all/max": by_example.generation_ms.mean().max(),
-            "generation_ms/all/min": by_example.generation_ms.mean().min(),
-            "scoring_ms/all/mean": by_example.scoring_ms.mean().mean(),
-            "scoring_ms/all/max": by_example.scoring_ms.mean().max(),
-            "scoring_ms/all/min": by_example.scoring_ms.mean().min(),
+            **{
+                f"timing/all/{key}/{stat}": getattr(by_example[f"timing_{key}"].mean(), stat)()
+                for key in ("total", "setup", "generation", "model", "env", "scoring", "overhead")
+                for stat in ("mean", "max", "min")
+            },
             # Train reward
             "reward/all/mean": by_example.reward.mean().mean(),
             "reward/all/max": by_example.reward.mean().max(),
@@ -691,9 +695,8 @@ async def orchestrate(config: OrchestratorConfig):
             "is_truncated",
             "samples_per_rollout",
             "num_turns",
-            "generation_ms",
-            "scoring_ms",
         ]
+        per_env_timing_keys = ("total", "setup", "generation", "model", "env", "scoring", "overhead")
 
         for env, env_df in results_df.groupby("env_name"):
             env_by_example = env_df.groupby("example_id")
@@ -702,6 +705,12 @@ async def orchestrate(config: OrchestratorConfig):
                 to_log[f"{col}/{env}/max"] = env_by_example[col].mean().max()
                 if col != "is_truncated":
                     to_log[f"{col}/{env}/min"] = env_by_example[col].mean().min()
+            for key in per_env_timing_keys:
+                col = f"timing_{key}"
+                per_example = env_by_example[col].mean()
+                to_log[f"timing/{env}/{key}/mean"] = per_example.mean()
+                to_log[f"timing/{env}/{key}/max"] = per_example.max()
+                to_log[f"timing/{env}/{key}/min"] = per_example.min()
             to_log[f"reward/{env}/mean"] = env_by_example.reward.mean().mean()
             to_log[f"reward/{env}/max"] = env_by_example.reward.mean().max()
             to_log[f"reward/{env}/min"] = env_by_example.reward.mean().min()

--- a/tests/unit/utils/test_prime_monitor.py
+++ b/tests/unit/utils/test_prime_monitor.py
@@ -37,7 +37,7 @@ def _build_rollout(*, example_id: int, reward: float, task: str) -> dict:
         "reward": reward,
         "advantage": reward / 2,
         "metrics": {"accuracy": reward},
-        "timing": {"generation_ms": 12.5},
+        "timing": {"generation": {"start": 0.0, "end": 12.5, "duration": 12.5}},
     }
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2306,17 +2306,17 @@ wheels = [
 
 [[package]]
 name = "openai-harmony"
-version = "0.0.4"
+version = "0.0.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/94/01509d510bebf6606614e51113e5a415ced15b8f34aa98a8bf2539314650/openai_harmony-0.0.4.tar.gz", hash = "sha256:5c67ac6df349236fb7b64f57c3dbb0273efcdca24314daa108f2a482c427106c", size = 279848, upload-time = "2025-08-09T01:43:24.974Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/92/2d038d096f29179c7c9571b431f9e739f87a487121901725e23fe338dd9d/openai_harmony-0.0.8.tar.gz", hash = "sha256:6e43f98e6c242fa2de6f8ea12eab24af63fa2ed3e89c06341fb9d92632c5cbdf", size = 284777, upload-time = "2025-11-05T19:07:06.727Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/88/ade63bd8f36603610040e7cc086bc134d57a99a742e05f7fcddfdf822ee1/openai_harmony-0.0.4-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3cf2344366f10981bbc0f6d9949a0b2bb87151d209ed295943ed6ad8eda37932", size = 2963206, upload-time = "2025-08-09T01:43:02.433Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/ec/dcdcace0ffcf3a532cca910e0c351b62d3a7decf0b091ea8cf856d2a67a6/openai_harmony-0.0.4-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:31e9bcac0902a309e2fc688e52f247eec7fffcd00d17e958b9a83a8fea6519c2", size = 3049306, upload-time = "2025-08-09T01:43:11.019Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/39/172f1048d935db1523a82b45fee5231ad6c622645e566706e6bcf3731da8/openai_harmony-0.0.4-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:96a63199c0d81095b5d5d1ae8ca82b64c1c13d18d4e30323ae9e8ab31bc80a3d", size = 3121347, upload-time = "2025-08-09T01:43:16.705Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/bd/aa9e6e5cf140716dbcae17402fac2a81a9ebb3f934059ac0eec61cb447fc/openai_harmony-0.0.4-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:15e6d53a66502491a3675a536df30e271f976e6c5efe68250a65191efcb85c4f", size = 3221129, upload-time = "2025-08-09T01:43:23.146Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/d2/ce6953ca87db9cae3e775024184da7d1c5cb88cead19a2d75b42f00a959c/openai_harmony-0.0.8-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e4f709815924ec325b9a890e6ab2bbb0ceec8e319a4e257328eb752cf36b2efc", size = 2948463, upload-time = "2025-11-05T19:06:48.17Z" },
+    { url = "https://files.pythonhosted.org/packages/25/3f/1a192b93bb47c6b44cd98ba8cc1d3d2a9308f1bb700c3017e6352da11bda/openai_harmony-0.0.8-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c007d277218a50db8839e599ed78e0fffe5130f614c3f6d93ae257f282071a29", size = 2953260, upload-time = "2025-11-05T19:06:55.406Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/f8/93b582cad3531797c3db7c2db5400fd841538ccddfd9f5e3df61be99a630/openai_harmony-0.0.8-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:8565d4f5a0638da1bffde29832ed63c9e695c558611053add3b2dc0b56c92dbc", size = 3127044, upload-time = "2025-11-05T19:06:59.553Z" },
+    { url = "https://files.pythonhosted.org/packages/60/c3/3d1e01e2dba517a91760e4a03e4f20ffc75039a6fe584d0e6f9b5c78fd15/openai_harmony-0.0.8-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:007b0476a1f331f8130783f901f1da6f5a7057af1a4891f1b6a31dec364189b5", size = 3205080, upload-time = "2025-11-05T19:07:05.078Z" },
 ]
 
 [[package]]
@@ -2798,7 +2798,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", git = "https://github.com/huggingface/transformers.git?rev=c1c3424" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=980a9ea" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=3b77145" },
     { name = "vllm", specifier = ">=0.19.0" },
     { name = "vllm-router", marker = "platform_machine == 'x86_64' and extra == 'disagg'", url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.22/vllm_router-0.1.22-cp38-abi3-manylinux_2_28_x86_64.whl" },
     { name = "wandb", specifier = ">=0.24.2" },
@@ -3244,6 +3244,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/fe/661043d1c263b0d9d10c6ff4e9c9745f3df9641c62b51f96a3473638e7ce/regex-2026.3.32-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f54840bea73541652f1170dc63402a5b776fc851ad36a842da9e5163c1f504a0", size = 801512, upload-time = "2026-03-28T21:46:38.587Z" },
     { url = "https://files.pythonhosted.org/packages/b6/c8/d833397b70cd1bacfcdc0a611f0e2c1f5b91fee8eedd88affcee770cbbb6/regex-2026.3.32-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:66d3126afe7eac41759cd5f0b3b246598086e88e70527c0d68c9e615b81771c4", size = 785837, upload-time = "2026-03-28T21:46:42.926Z" },
     { url = "https://files.pythonhosted.org/packages/18/f4/04ed04ebf335a44083695c22772be6a42efa31900415555563acf02cb4de/regex-2026.3.32-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b56993a7aeb4140c4770f4f7965c9e5af4f024457d06e23c01b0d47501cb18ed", size = 788332, upload-time = "2026-03-28T21:46:50.454Z" },
+]
+
+[[package]]
+name = "renderers"
+version = "0.1.0"
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?subdirectory=packages%2Frenderers&rev=3b77145#3b77145e14a9bcdaf180a49e7df97dbf2d7bb150" }
+dependencies = [
+    { name = "openai-harmony", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "transformers", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
 [[package]]
@@ -4036,12 +4045,13 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.13.dev8"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=980a9ea#980a9ea855cdac9e06426e0434c77e35ad27b3d5" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=3b77145#3b77145e14a9bcdaf180a49e7df97dbf2d7bb150" }
 dependencies = [
     { name = "aiolimiter", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "anthropic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "datasets", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "gepa", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "httpx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "jinja2", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "math-verify", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "mcp", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -4055,6 +4065,7 @@ dependencies = [
     { name = "pydantic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pyzmq", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "regex", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "renderers", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "requests", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "rich", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "setproctitle", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },


### PR DESCRIPTION
## Summary

- Bumps the `verifiers` git pin from `980a9ea` to [`3b77145`](https://github.com/PrimeIntellect-ai/verifiers/commit/3b77145e14a9bcdaf180a49e7df97dbf2d7bb150).
- The main behaviour change being absorbed is [verifiers#1182](https://github.com/PrimeIntellect-ai/verifiers/pull/1182), which reshapes per-rollout timing into a `TimeSpan`-based schema in seconds (`setup`, `generation`, `scoring`, `model`, `env` spans + computed `total`/`overhead`).
- Replaces the flat `generation_ms` / `scoring_ms` orchestrator metrics with a new `timing/{all,env_name}/{key}/{mean,max,min}` section, where `key` is one of `total`, `setup`, `generation`, `model`, `env`, `scoring`, `overhead`. Values are now in seconds (the verifiers PR migrated from ms to s).

## Notes

- W&B / monitor schema is breaking: `generation_ms/...` and `scoring_ms/...` panels are replaced by the new `timing/...` section.
- `tests/unit/utils/test_prime_monitor.py` fixture updated to the new nested timing shape so the parquet round-trip still exercises real-world data.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it bumps the pinned `verifiers` dependency and changes the timing metrics schema (including units), which can break monitoring dashboards and any downstream consumers expecting `generation_ms`/`scoring_ms`. Core training logic is otherwise unchanged.
> 
> **Overview**
> Bumps the pinned `verifiers` git revision to `3b77145` (and updates `uv.lock`, including `openai-harmony` to `0.0.8` and a new `renderers` dependency pulled from the `verifiers` repo).
> 
> Updates orchestrator metric logging to match `verifiers`’ new nested `timing` schema: removes `generation_ms`/`scoring_ms` fields and replaces them with aggregated `timing/{all,env}/{total,setup,generation,model,env,scoring,overhead}/{mean,max,min}` metrics derived per rollout.
> 
> Adjusts the `PrimeMonitor` parquet test fixture to use the new nested `timing` shape so rollouts still round-trip correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3053a1c9dc2aa80e8adba1531adb17cb25f87fb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->