### PR TITLE
fix(docker): FA build on arm64

### DIFF
--- a/scripts/docker-arm64-post-install.sh
+++ b/scripts/docker-arm64-post-install.sh
@@ -14,7 +14,7 @@ export FLASH_ATTENTION_SKIP_CUDA_BUILD=FALSE
 
 echo "=== reinstalling flash-attn-cute (flash-attn overwrites it with a stub) ==="
 uv pip install --reinstall --no-deps \
-    "flash-attn-cute @ git+https://github.com/Dao-AILab/flash-attention.git@96bd151#subdirectory=flash_attn/cute"
+    "flash-attn-4 @ git+https://github.com/Dao-AILab/flash-attention.git@96bd151#subdirectory=flash_attn/cute"
 
 # TODO: remove once flash-attn gates the ampere_helpers import or cutlass-dsl re-adds it.
 echo "=== copying ampere_helpers.py from flashinfer vendor ==="

--- a/scripts/fix-flash-attn-cute.sh
+++ b/scripts/fix-flash-attn-cute.sh
@@ -11,7 +11,7 @@
 set -e
 
 echo "Reinstalling flash-attn-cute to fix namespace conflict with flash-attn..."
-uv pip install --reinstall --no-deps "flash-attn-cute @ git+https://github.com/Dao-AILab/flash-attention.git@96bd151#subdirectory=flash_attn/cute"
+uv pip install --reinstall --no-deps "flash-attn-4 @ git+https://github.com/Dao-AILab/flash-attention.git@96bd151#subdirectory=flash_attn/cute"
 
 # Verify installation
 LINES=$(wc -l < "$(python -c 'import flash_attn.cute.interface as m; print(m.__file__)')")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only adjusts Docker/post-install scripts to change which package is reinstalled to resolve a flash-attn namespace/stub overwrite issue; no runtime application logic changes.
> 
> **Overview**
> Updates the arm64 Docker post-install and local fixup scripts to reinstall the FA4 `flash_attn/cute` module via `flash-attn-4` (from the same `flash-attention` git subdirectory) instead of `flash-attn-cute`, preventing `flash-attn` from overwriting the real kernels with its stub.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6925bb3b94f0afee5946d7c76b9270ef24c86d72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->