### PR TITLE
chore: add 7-day supply chain cooldown via exclude-newer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ dev = [
 
 
 [tool.uv]
+exclude-newer = "7 days"
 preview = true
 no-build-isolation-package = ["flash-attn"]
 environments = [
@@ -122,6 +123,26 @@ override-dependencies = [
     "nvidia-cutlass-dsl>=4.4.1",
     "transformers>=5.1.0.dev0",
 ]
+
+[tool.uv.exclude-newer-package]
+# pytorch-cu128 / pytorch-cu128-test indexes don't publish upload dates
+torch = false
+flash_attn_3 = false
+# Self-vendored packages on our primeintellect index
+reverse-text = false
+alphabet-sort = false
+wiki-search = false
+math-python = false
+math-env = false
+code-env = false
+science-env = false
+logic-env = false
+color-codeword = false
+math500 = false
+aime2024 = false
+aime2025 = false
+deepdive = false
+mini_swe_agent_plus = false
 
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,14 @@ aime2024 = false
 aime2025 = false
 deepdive = false
 mini_swe_agent_plus = false
+# Trusted git/URL sources pinned by rev or wheel URL (defensive: belt-and-suspenders)
+verifiers = false
+vllm-router = false
+dion = false
+pydantic-config = false
+deep-ep = false
+deep-gemm = false
+nixl-cu12 = false
 
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,11 @@ aime2024 = false
 aime2025 = false
 deepdive = false
 mini_swe_agent_plus = false
+# PrimeIntellect-published on PyPI (trusted publisher)
+prime = false
+prime-sandboxes = false
+prime-tunnel = false
+prime-evals = false
 # Trusted git/URL sources pinned by rev or wheel URL (defensive: belt-and-suspenders)
 verifiers = false
 vllm-router = false

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,39 @@ supported-markers = [
     "platform_machine == 'aarch64' and sys_platform == 'linux'",
 ]
 
+[options]
+exclude-newer = "2026-04-23T20:00:49.639641409Z"
+exclude-newer-span = "P7D"
+
+[options.exclude-newer-package]
+verifiers = false
+vllm-router = false
+dion = false
+torch = false
+alphabet-sort = false
+science-env = false
+color-codeword = false
+nixl-cu12 = false
+flash-attn-3 = false
+prime-tunnel = false
+prime = false
+deep-gemm = false
+aime2024 = false
+prime-evals = false
+deepdive = false
+reverse-text = false
+code-env = false
+mini-swe-agent-plus = false
+deep-ep = false
+pydantic-config = false
+math-env = false
+logic-env = false
+wiki-search = false
+math-python = false
+math500 = false
+aime2025 = false
+prime-sandboxes = false
+
 [manifest]
 overrides = [
     { name = "nvidia-cudnn-cu12", specifier = ">=9.15" },


### PR DESCRIPTION
## Summary
- Adds `exclude-newer = "7 days"` to `[tool.uv]`, preventing resolution of packages published less than 7 days ago
- Exempts `torch` and `flash_attn_3` (pytorch-cu128 / pytorch-cu128-test indexes lack upload dates) and self-vendored primeintellect index packages
- Lock file is left unchanged; the policy will take effect on the next intentional `uv lock`

## Why
The recent [litellm supply chain attack](https://docs.litellm.ai/blog/security-update-march-2026) had malicious packages on PyPI for ~5 hours before being yanked. A 7-day cooldown would have completely prevented any automated install from picking them up.

This re-opens #2147 against current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dependency resolution behavior by preventing installs of newly published packages, which can unexpectedly block upgrades or fresh environment builds until the cooldown passes. Risk is mitigated by explicit exemptions for packages/indexes without upload timestamps and for trusted/pinned sources.
> 
> **Overview**
> Adds a **7-day `uv` “exclude-newer” cooldown** in `pyproject.toml` so dependency resolution avoids packages published within the last week.
> 
> Introduces a `tool.uv.exclude-newer-package` allowlist to *opt out* specific packages (e.g., `torch`, `flash_attn_3`, internal `primeintellect` env packages, and pinned git/URL deps), and records the corresponding policy metadata in `uv.lock` under `[options]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3eb9689bab7444d25cbd43be0e994ab1a57e72e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->