### PR TITLE
feat: pass training context to environment rubrics

### DIFF
--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -116,6 +116,7 @@ class Env:
         example: dict,
         model_name: str,
         cache_salt: str,
+        training_context: dict | None = None,
     ) -> vf.RolloutOutput:
         """Run a single rollout for an example."""
         return await self.env.run_rollout(
@@ -126,6 +127,7 @@ class Env:
             max_retries=self.config.max_retries,
             state_columns=REQUIRED_STATE_COLUMNS,
             env_client=self.env_client,
+            training_context=training_context,
         )
 
     async def run_group(
@@ -135,6 +137,7 @@ class Env:
         model_name: str,
         rollouts_per_example: int,
         cache_salt: str,
+        training_context: dict | None = None,
     ) -> list[vf.RolloutOutput]:
         """Run a group of rollouts for an example. Required for group-scoring envs."""
         return await self.env.run_group(
@@ -145,6 +148,7 @@ class Env:
             max_retries=self.config.max_retries,
             state_columns=REQUIRED_STATE_COLUMNS,
             env_client=self.env_client,
+            training_context=training_context,
         )
 
     def shutdown(self) -> None:

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -197,6 +197,7 @@ class Scheduler:
         env = self.train_envs.get(env_name)
 
         cache_salt = str(self.ckpt_step)
+        training_context = {"step": self.step, "ckpt_step": self.ckpt_step}
         if env.requires_group_scoring:
             rollout_count = group.rollouts_to_schedule
             group.rollouts_to_schedule = 0
@@ -207,6 +208,7 @@ class Scheduler:
                     model_name=self.model_name,
                     rollouts_per_example=rollout_count,
                     cache_salt=cache_salt,
+                    training_context=training_context,
                 )
             )
         else:
@@ -218,6 +220,7 @@ class Scheduler:
                     example=group.example,
                     model_name=self.model_name,
                     cache_salt=cache_salt,
+                    training_context=training_context,
                 )
             )
         self.inflight_requests[task] = InflightRequest(


### PR DESCRIPTION
## Summary

Passes the orchestrator's training step to environment rubrics via the new `training_context` parameter added in PrimeIntellect-ai/verifiers#1270. This enables rubrics to implement step-aware reward functions (warmup schedules, curriculum learning, dynamic weights) using the true orchestrator step rather than fragile internal counters that break on checkpoint resume.

### Changes

**`src/prime_rl/orchestrator/scheduler.py`** — builds `training_context = {"step": self.step, "ckpt_step": self.ckpt_step}` and passes it to `env.run_group()` / `env.run_rollout()` in `schedule_rollout()`.

**`src/prime_rl/orchestrator/envs.py`** — `Env.run_rollout()` and `Env.run_group()` accept an optional `training_context` kwarg and forward it to `self.env.run_rollout()` / `self.env.run_group()`.

### Motivation

Environment authors currently have no way to access the training step from within a rubric. The only workaround is a self-incrementing counter on the rubric class, which:
- Resets to 0 on checkpoint resume
- Requires manual calibration for batch size (e.g. `warmup_calls = warmup_steps * 64`)
- Doesn't reflect the true orchestrator step under async/off-policy

This change gives rubrics direct access to `self.training_context["step"]` (set by verifiers before `score_group` is called), enabling:
- Reward penalty warmup without manual step counting
- Dynamic reward component weights over training
- Step-aware scoring thresholds

### Dependency

Requires PrimeIntellect-ai/verifiers#1270 which adds `training_context` to the rubric base class and request protocol. That PR is standalone and independently useful — if it hasn't merged yet, this change is harmless since `Environment.run_group` already accepts `**kwargs`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only threads an optional `training_context` dict through existing rollout/group calls, with minimal surface area and no control-flow changes beyond adding extra kwargs.
> 
> **Overview**
> Passes orchestrator training metadata into environment rollouts so rubrics can be step-aware.
> 
> `Scheduler.schedule_rollout()` now builds `training_context` (including `step` and `ckpt_step`) and forwards it into `env.run_rollout()` / `env.run_group()`. `Env.run_rollout()` and `Env.run_group()` accept an optional `training_context` argument and pass it through to the underlying verifiers environment calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3e15a1e1f9b8746f3a049530d6055f40e856b42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->