### PR TITLE
chore(agents): keep PR descriptions in sync on push

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,4 +54,5 @@ Write tests as plain functions with pytest fixtures. Don't use class-based tests
 
 - **Draft PRs**: always create PRs as drafts (`gh pr create --draft`) to avoid triggering CI unnecessarily.
 - **Pull requests**: do not include a "test plan" section in PR descriptions unless you actually ran tests to verify the changes or the user explicitly asked for one.
+- **Keep PR descriptions in sync**: every time you push commits to a PR, also update the PR description (`gh pr edit <num> --body-file ...`) so it reflects the current state of the branch — not just what was true when the PR was opened. Preserve any auto-generated blocks (e.g. `<!-- CURSOR_SUMMARY -->`).
 


### PR DESCRIPTION
## Summary

Adds a rule to `AGENTS.md` requiring agents to update the PR description whenever they push new commits to a PR, so the description reflects the current state of the branch rather than only what was true when the PR was opened. Auto-generated blocks (e.g. `<!-- CURSOR_SUMMARY -->`) should be preserved.