### PR TITLE
fix(docker): use Ubuntu 24.04 base to drop deadsnakes PPA

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -1,7 +1,9 @@
 #inspired from https://github.com/astral-sh/uv-docker-example/blob/main/multistage.Dockerfile
 
 # Build stage - multi-arch base (supports amd64 + arm64)
-FROM nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04 AS builder
+# Ubuntu 24.04 (noble) ships python3.12 in its default repos, so we avoid the
+# deadsnakes PPA — Launchpad has been a recurring flake for our image-builder runner.
+FROM nvidia/cuda:12.8.1-cudnn-devel-ubuntu24.04 AS builder
 LABEL maintainer="prime intellect"
 LABEL repository="prime-rl"
 
@@ -22,10 +24,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends --force-yes \
     sudo \
     git \
     ninja-build \
-    software-properties-common \
-    && add-apt-repository ppa:deadsnakes/ppa \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends python3.12 python3.12-dev python3.12-venv \
+    python3.12 \
+    python3.12-dev \
+    python3.12-venv \
     && ln -sf /usr/bin/python3.12 /usr/bin/python3 \
     && ln -sf /usr/bin/python3.12 /usr/bin/python \
     && apt-get clean autoclean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
## Summary
- Switch CUDA builder base from `ubuntu22.04` to `ubuntu24.04` (noble) — noble ships `python3.12` in the default repos.
- Drop `software-properties-common` + `add-apt-repository ppa:deadsnakes/ppa` from the apt step.

## Why
The Release workflow has been failing on `main` since #2382 merged. Both failed runs are TCP timeouts to Launchpad from the `image-builder` self-hosted runner, in different sub-steps of the same `RUN`:

- 2026-05-01 (#2382 merge commit): `apt-get install python3.12 …` → `Could not connect to ppa.launchpadcontent.net:443 (185.125.190.80), connection timed out`
- 2026-05-02 (next commit): `add-apt-repository ppa:deadsnakes/ppa` (Python `launchpadlib` fetching the PPA's GPG key from `api.launchpad.net`) → `TimeoutError: [Errno 110] Connection timed out`

Neither is mechanically caused by #2382's contents (which only touch `[tool.uv]` in `pyproject.toml` and `[options]` in `uv.lock` — both read well after the failing apt layer). But Launchpad reachability from the runner has clearly become unreliable, and the Dockerfile rebuilds from scratch on every release.

Removing the PPA dependency removes the failure mode.

## Notes
- The runtime stage still uses `python:3.12-slim`, unchanged.
- `scripts/docker-arm64-post-install.sh` does not reference jammy/22.04 specifics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrading the CUDA builder base from Ubuntu 22.04 to 24.04 can subtly affect build toolchains and compiled dependencies (e.g., CUDA extensions), even though functionality is intended to remain the same. Change reduces external dependency on Launchpad/`deadsnakes`, lowering CI flakiness risk.
> 
> **Overview**
> Updates `Dockerfile.cuda` to use `nvidia/cuda:12.8.1-cudnn-devel-ubuntu24.04` for the builder stage and adds a short rationale comment.
> 
> Removes installation of `software-properties-common` and the `add-apt-repository ppa:deadsnakes/ppa` step, installing `python3.12`, `python3.12-dev`, and `python3.12-venv` directly from Ubuntu’s default repositories instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 570a084ad89bd1a525e9fc9704ed3e9ba8bcc04c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->