### PR TITLE
feat: Dynamo compatibility + LoRA broadcast correctness

### DIFF
--- a/src/prime_rl/_compat.py
+++ b/src/prime_rl/_compat.py
@@ -36,9 +36,9 @@ if not hasattr(_mfau, "is_flash_attn_greater_or_equal_2_10"):
 try:
     import transformers.integrations.hub_kernels as _hub_kernels
 except ImportError:
-    _hub_kernels = None  # transformers < 5.5, no patch needed
+    _hub_kernels = None  # transformers < 5.5 without hub_kernels module, no patch needed
 
-if _hub_kernels is not None:
+if _hub_kernels is not None and hasattr(_hub_kernels, "lazy_load_kernel"):
     from huggingface_hub.errors import OfflineModeIsEnabled
 
     _original_lazy_load_kernel = _hub_kernels.lazy_load_kernel

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -827,6 +827,19 @@ WeightBroadcastConfig: TypeAlias = Annotated[
 class OrchestratorExperimentalConfig(BaseConfig):
     """Experimental features for the orchestrator."""
 
+    use_prefix_cache_salt: Annotated[
+        bool,
+        Field(
+            description=(
+                "When True (default), a 'cache_salt' key is added to every rollout "
+                "request's extra_body so that rollouts from different training steps "
+                "cannot share KV-cache prefixes. Set to False when the inference "
+                "backend does not support this field (e.g. Dynamo builds older than "
+                "the cache_salt passthrough fix)."
+            ),
+        ),
+    ] = True
+
 
 class TeacherModelConfig(BaseConfig):
     """Configures the teacher model for computing teacher logprobs (e.g. for distillation)."""

--- a/src/prime_rl/configs/trainer.py
+++ b/src/prime_rl/configs/trainer.py
@@ -707,6 +707,21 @@ class FileSystemWeightBroadcastConfig(BaseWeightBroadcastConfig):
     save_format: Annotated[
         Literal["safetensors", "torch"], Field(description="The format to save the weight checkpoint in.")
     ] = "safetensors"
+    keep_recent: Annotated[
+        int | None,
+        Field(
+            ge=0,
+            description=(
+                "Number of recent broadcast step directories to keep on disk. At trainer step N, "
+                "step_{N - keep_recent - 1} is deleted. If None (default), falls back to "
+                "trainer.max_async_level, which couples retention to the staleness window. Set this "
+                "greater than max_async_level when using LoRA + filesystem broadcast so that vLLM's "
+                "lazy adapter-load on in-flight requests doesn't race the trainer's cleanup — a "
+                "`generate` call admitted under an older adapter can page the adapter dir in *after* "
+                "the orchestrator has moved on. A +1 or +2 buffer over max_async_level is typical."
+            ),
+        ),
+    ] = None
 
 
 class NCCLWeightBroadcastConfig(BaseWeightBroadcastConfig):
@@ -927,6 +942,21 @@ class TrainerConfig(BaseConfig):
     def validate_weight_broadcast_type(self):
         if self.weight_broadcast.type == "nccl" and self.max_async_level != 1:
             raise ValueError("NCCL weight broadcast only works with async level 1")
+        return self
+
+    @model_validator(mode="after")
+    def validate_broadcast_keep_recent(self):
+        if (
+            self.weight_broadcast.type == "filesystem"
+            and self.weight_broadcast.keep_recent is not None
+            and self.weight_broadcast.keep_recent < self.max_async_level
+        ):
+            raise ValueError(
+                f"weight_broadcast.keep_recent ({self.weight_broadcast.keep_recent}) must be "
+                f">= max_async_level ({self.max_async_level}). The retention window must cover "
+                f"the staleness window, otherwise vLLM can hit LoRAAdapterNotFoundError when an "
+                f"in-flight generate request lazy-loads an adapter dir the trainer already removed."
+            )
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -106,8 +106,12 @@ class Env:
 
     def _sampling_args_with_salt(self, cache_salt: str) -> dict:
         sampling_args = {**self.sampling_args}
-        extra_body = {**sampling_args.get("extra_body", {}), "cache_salt": cache_salt}
-        sampling_args["extra_body"] = extra_body
+        # Only inject cache_salt when it is non-empty.  An empty string signals
+        # that the inference backend does not support this field
+        # (use_prefix_cache_salt=False in [experimental]).
+        if cache_salt:
+            extra_body = {**sampling_args.get("extra_body", {}), "cache_salt": cache_salt}
+            sampling_args["extra_body"] = extra_body
         return sampling_args
 
     async def run_rollout(

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -393,7 +393,7 @@ async def orchestrate(config: OrchestratorConfig):
                         get_client=inference_pool.get_eval_client,
                         ckpt_step=ckpt_step,
                         step=progress.step,
-                        cache_salt=str(ckpt_step),
+                        cache_salt=str(ckpt_step) if config.experimental.use_prefix_cache_salt else "",
                     )
                     for eval_env in envs_to_eval
                 ]

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -199,7 +199,7 @@ class Scheduler:
         env_name = group.example["env_name"]
         env = self.train_envs.get(env_name)
 
-        cache_salt = str(self.ckpt_step)
+        cache_salt = str(self.ckpt_step) if self.config.experimental.use_prefix_cache_salt else ""
         if env.requires_group_scoring:
             rollout_count = group.rollouts_to_schedule
             group.rollouts_to_schedule = 0

--- a/src/prime_rl/trainer/rl/broadcast/filesystem.py
+++ b/src/prime_rl/trainer/rl/broadcast/filesystem.py
@@ -105,15 +105,58 @@ class FileSystemWeightBroadcast(WeightBroadcast):
             self.logger.debug(f"Weights broadcasted in {time.perf_counter() - start_time:.2f}s")
 
     def _notify_orchestrator(self, save_dir: Path):
-        """Notify the orchestrator that the weights have been broadcast by writing a 'STABLE' file to a shared filesystem."""
+        """Notify the orchestrator that the weights have been broadcast by writing a 'STABLE' file to a shared filesystem.
+
+        On shared filesystems (NFS/CephFS/PVC-backed volumes), a write on one node
+        is not immediately visible on another node. Without explicit flushing, the
+        orchestrator can see the STABLE sentinel before the adapter files
+        (``adapter_model.safetensors``, ``adapter_config.json``) are visible to the
+        inference worker — leading to ``LoRAAdapterNotFoundError`` when
+        ``/v1/rl/load_lora_adapter`` is called.
+
+        We flush the adapter files (and the containing directory's dentries) to
+        durable storage *before* touching STABLE so the sentinel only appears once
+        everything it points to is readable cluster-wide.
+        """
+        import os
+        # Flush each file that was just written to the broadcast dir
+        for f in save_dir.iterdir():
+            if f.is_file():
+                try:
+                    fd = os.open(str(f), os.O_RDONLY)
+                    try:
+                        os.fsync(fd)
+                    finally:
+                        os.close(fd)
+                except OSError:
+                    # Non-fatal: the sync is best-effort
+                    pass
+        # Flush the directory itself so the dentries for the adapter files are durable
+        try:
+            dfd = os.open(str(save_dir), os.O_RDONLY)
+            try:
+                os.fsync(dfd)
+            finally:
+                os.close(dfd)
+        except OSError:
+            pass
         stable_file = save_dir / "STABLE"
         stable_file.touch()
+        # Flush the directory once more so STABLE's dentry is durable too
+        try:
+            dfd = os.open(str(save_dir), os.O_RDONLY)
+            try:
+                os.fsync(dfd)
+            finally:
+                os.close(dfd)
+        except OSError:
+            pass
 
-    def maybe_clean(self, max_async_level: int, interval_to_keep: int | None):
+    def maybe_clean(self, retention: int, interval_to_keep: int | None):
         for idx in self.multi_run_manager.used_idxs:
             maybe_clean(
                 get_broadcast_dir(self.multi_run_manager.get_run_dir(idx)),
                 self.multi_run_manager.progress[idx].step,
-                max_async_level,
+                retention,
                 interval_to_keep,
             )

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -249,7 +249,17 @@ def train(config: TrainerConfig):
                 ckpt_interval = config.ckpt and config.ckpt.interval
                 interval_to_keep = ckpt_interval if config.weight_broadcast.type == "filesystem" else None
                 if config.weight_broadcast.type == "filesystem":
-                    weight_broadcast.maybe_clean(config.max_async_level, interval_to_keep)
+                    # Retention window = explicit keep_recent if set, else fall back to
+                    # max_async_level for backward compat. keep_recent > max_async_level
+                    # is the safe setting for LoRA: vLLM lazy-loads adapters inside
+                    # _prepare_inputs, so a generate request admitted under an older
+                    # adapter can page that dir in after the orchestrator has moved on.
+                    retention = (
+                        config.weight_broadcast.keep_recent
+                        if config.weight_broadcast.keep_recent is not None
+                        else config.max_async_level
+                    )
+                    weight_broadcast.maybe_clean(retention, interval_to_keep)
             else:
                 broadcast_weights_time = 0
                 # Usually the broadcast will set this. If broadcast is skipped, we need to reset this here.

--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -434,9 +434,16 @@ class MemoryProfiler:
         self.step_num += 1
 
 
-def maybe_clean(path: Path, step: int, async_level: int, interval_to_keep: int | None) -> None:
+def maybe_clean(path: Path, step: int, retention: int, interval_to_keep: int | None) -> None:
+    """Delete the broadcast step directory that falls outside the retention window.
+
+    At trainer step N, deletes step_{N - retention - 1}. Caller controls whether
+    `retention` is the orchestrator's staleness bound (max_async_level) or a
+    strictly wider buffer (weight_broadcast.keep_recent) — the two semantics
+    are intentionally decoupled at this layer.
+    """
     logger = get_logger()
-    step = max(step - (async_level + 1), 0)  # Consider deleting async_level + 1 steps ago
+    step = max(step - (retention + 1), 0)  # Consider deleting retention + 1 steps ago
     candidate_path_to_delete = get_step_path(path, step)
     keep = bool(interval_to_keep and step % interval_to_keep == 0)
     logger.debug(f"Considering deleting path {candidate_path_to_delete}")


### PR DESCRIPTION
## Summary

Three small `src/`-only changes from @biswapanda's [bis/dynamo-integration](https://github.com/biswapanda/prime-rl/commits/bis/dynamo-integration/) branch. Operational pieces (k8s manifests, smoke scripts, monitoring tools, vLLM patch, debug logging) intentionally excluded — can land in separate PRs if useful.

## Changes

### `feat: keep_recent broadcast retention + NFS fsync for LoRA correctness`
- **`trainer/rl/broadcast/filesystem.py`** — `fsync` adapter files **and** their containing directory before writing the `STABLE` sentinel. Fixes a race on NFS/CephFS/PVC-backed volumes where the orchestrator could see `STABLE` before `adapter_model.safetensors` / `adapter_config.json` were visible to the inference worker, leading to `LoRAAdapterNotFoundError` on `/v1/rl/load_lora_adapter`.
- **`configs/trainer.py`** — new `weight_broadcast.keep_recent` field on `FileSystemWeightBroadcastConfig`, with a validator enforcing `keep_recent >= max_async_level`. Decouples broadcast retention from staleness so vLLM's lazy LoRA-adapter load on in-flight requests doesn't race the trainer's cleanup.
- **`trainer/rl/train.py`** + **`trainer/utils.py`** — rename `async_level` → `retention` in `maybe_clean`; use `keep_recent` if set, else fall back to `max_async_level` for backward compat.

### `fix: reinstate use_prefix_cache_salt config gate for Dynamo compatibility`
- **`configs/orchestrator.py`** — new `experimental.use_prefix_cache_salt` flag (default `True`). Set to `False` to disable the per-step `cache_salt` injection for inference backends that don't accept the field (e.g. older Dynamo builds without the `cache_salt` passthrough fix).
- **`orchestrator/{envs,orchestrator,scheduler}.py`** — plumb `use_prefix_cache_salt` through eval and train rollouts; skip `cache_salt` injection when salt string is empty.

### `fix: guard lazy_load_kernel patch against transformers versions that have hub_kernels but not lazy_load_kernel`
- **`_compat.py`** — guard `lazy_load_kernel` patch against transformers versions that have `hub_kernels` but not `lazy_load_kernel`.

## Test plan

- [ ] Existing test suite passes
- [ ] LoRA + filesystem broadcast end-to-end on a shared FS (NFS/PVC) — verify no `LoRAAdapterNotFoundError`
- [ ] Verify `keep_recent` validator rejects `keep_recent < max_async_level`
- [ ] Verify `use_prefix_cache_salt=False` skips the `cache_salt` field in rollout requests