### PR TITLE
[DYNAMO] fix: NFS-safe filesystem broadcast for LoRA adapters

### DIFF
--- a/src/prime_rl/trainer/rl/broadcast/filesystem.py
+++ b/src/prime_rl/trainer/rl/broadcast/filesystem.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import time
 from pathlib import Path
@@ -105,9 +106,23 @@ class FileSystemWeightBroadcast(WeightBroadcast):
             self.logger.debug(f"Weights broadcasted in {time.perf_counter() - start_time:.2f}s")
 
     def _notify_orchestrator(self, save_dir: Path):
-        """Notify the orchestrator that the weights have been broadcast by writing a 'STABLE' file to a shared filesystem."""
-        stable_file = save_dir / "STABLE"
-        stable_file.touch()
+        """Notify the orchestrator that the weights have been broadcast by writing a 'STABLE' file to a shared filesystem.
+
+        On shared filesystems (NFS / CephFS / PVC-backed volumes), a write on one
+        node is not immediately visible on another. Without explicit flushing, the
+        orchestrator can see the STABLE sentinel before the adapter files
+        (``adapter_model.safetensors``, ``adapter_config.json``) are visible to
+        the inference worker — causing ``LoRAAdapterNotFoundError`` when
+        ``/v1/rl/load_lora_adapter`` is called. We fsync the adapter files and
+        the directory's dentries before touching STABLE, then fsync the
+        directory again so STABLE itself is durable.
+        """
+        for f in save_dir.iterdir():
+            if f.is_file():
+                _fsync_path(f)
+        _fsync_path(save_dir)
+        (save_dir / "STABLE").touch()
+        _fsync_path(save_dir)
 
     def maybe_clean(self, max_async_level: int, interval_to_keep: int | None):
         for idx in self.multi_run_manager.used_idxs:
@@ -117,3 +132,17 @@ class FileSystemWeightBroadcast(WeightBroadcast):
                 max_async_level,
                 interval_to_keep,
             )
+
+
+def _fsync_path(path: Path) -> None:
+    """Best-effort fsync of a file or directory. Silent on OSError because the
+    sync is an availability-of-data hint to the kernel, not a correctness gate
+    on its own — STABLE ordering is what matters."""
+    try:
+        fd = os.open(str(path), os.O_RDONLY)
+        try:
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+    except OSError:
+        pass


### PR DESCRIPTION
## Summary

Fixes a visibility-ordering race in the filesystem-based weight broadcast that surfaces on shared filesystems (NFS / CephFS / Kubernetes PVC volumes). On a shared filesystem, a write on the trainer node is not immediately visible on the orchestrator/inference node. The previous code touched `STABLE` immediately after `save_state_dict`, so the orchestrator could observe the sentinel before `adapter_model.safetensors` / `adapter_config.json` were readable cluster-wide — causing `LoRAAdapterNotFoundError` when `/v1/rl/load_lora_adapter` was called.

Fix: fsync each adapter file, fsync the directory's dentries, touch `STABLE`, then fsync the directory once more so the sentinel itself is durable.

`_fsync_path` is a small helper. `OSError` is swallowed deliberately — fsync is a hint to the kernel, not the correctness gate on its own. The actual correctness gate is the *ordering*: write all data → flush → publish sentinel. On filesystems that don't support directory fsync, the `OSError` is harmless; on filesystems that do, the call is load-bearing.

## Scope

One file changed, 32 lines added. No new config knobs, no behavior change for local-filesystem deployments.

A companion PR (#2395) adds the `weight_broadcast.keep_recent` config knob that addresses a *separate* LoRA failure mode on the same code path (the trainer racing ahead and `rmtree`-ing an adapter dir while a vLLM generate request is still lazily loading it). The two are independent and can land in either order. Together they cover both classes of `LoRAAdapterNotFoundError` we've seen on shared-filesystem deployments.