### PR TITLE
Fix CP-local cu_seqlens from position ids

### DIFF
--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -53,6 +53,7 @@ from prime_rl.trainer.weights import (
 )
 from prime_rl.trainer.world import get_world
 from prime_rl.utils.logger import get_logger
+from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
 from prime_rl.utils.utils import format_time
 from prime_rl.utils.vlm import get_language_model, get_vision_encoder, is_vlm_architecture
 
@@ -275,9 +276,7 @@ def _patch_qwen3_5_linear_attn_varlen():
             pids = position_ids
             if pids.ndim == 3:
                 pids = pids[0]
-            flat = pids.view(-1)
-            seqlens = torch.cat([flat[0:1], flat[:-1][(flat == 0)[1:]] + 1, flat[-1:] + 1])
-            cu_seqlens = seqlens.cumsum(dim=0, dtype=torch.int32)
+            cu_seqlens, _ = get_cu_seqlens_from_position_ids(pids)
         kwargs["cu_seqlens"] = cu_seqlens
         return _text_orig(
             self,

--- a/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
+++ b/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
@@ -28,6 +28,7 @@ from prime_rl.trainer.models.layers.rotary_emb import (
     RotaryEmbeddingConfig,
     apply_rotary_pos_emb,
 )
+from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
 
 try:
     from flash_attn import flash_attn_varlen_func
@@ -489,16 +490,7 @@ class AfmoeModel(AfmoePreTrainedModel):
         use_flash = self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4")
 
         if use_flash:
-            flat_position_ids = position_ids.view(-1)
-            seqlens = torch.cat(
-                [
-                    flat_position_ids[0:1],
-                    flat_position_ids[:-1][(flat_position_ids == 0)[1:]] + 1,
-                    flat_position_ids[-1:] + 1,
-                ]
-            )
-            max_seqlen = seqlens.max().item()
-            cu_seqlens = seqlens.cumsum(dim=0, dtype=torch.int32)
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
             causal_mask_mapping = None
         else:

--- a/src/prime_rl/trainer/models/glm4_moe/modeling_glm4_moe.py
+++ b/src/prime_rl/trainer/models/glm4_moe/modeling_glm4_moe.py
@@ -39,6 +39,7 @@ from prime_rl.trainer.models.layers.mlp import MLP, MLPConfig
 from prime_rl.trainer.models.layers.moe import MoE, MoEArgs
 from prime_rl.trainer.models.layers.norms import RMSNorm, RMSNormConfig
 from prime_rl.trainer.models.layers.rotary_emb import RotaryEmbedding, RotaryEmbeddingConfig
+from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
 
 
 class Glm4MoeDecoderLayer(GradientCheckpointingLayer):
@@ -215,16 +216,7 @@ class Glm4MoeModel(Glm4MoePreTrainedModel):
             inputs_embeds: torch.Tensor = self.embed_tokens(input_ids)
 
         if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4"):
-            flat_position_ids = position_ids.view(-1)
-            seqlens = torch.cat(
-                [
-                    flat_position_ids[0:1],
-                    flat_position_ids[:-1][(flat_position_ids == 0)[1:]] + 1,
-                    flat_position_ids[-1:] + 1,
-                ]
-            )
-            max_seqlen = seqlens.max().item()
-            cu_seqlens = seqlens.cumsum(dim=0, dtype=torch.int32)
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
         else:
             max_seqlen = None

--- a/src/prime_rl/trainer/models/llama/modeling_llama.py
+++ b/src/prime_rl/trainer/models/llama/modeling_llama.py
@@ -40,6 +40,7 @@ from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput
 from prime_rl.trainer.models.layers.mlp import MLP, MLPConfig
 from prime_rl.trainer.models.layers.norms import RMSNorm, RMSNormConfig
 from prime_rl.trainer.models.layers.rotary_emb import RotaryEmbedding, RotaryEmbeddingConfig
+from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
 
 logger = logging.get_logger(__name__)
 
@@ -188,16 +189,7 @@ class LlamaModel(LlamaPreTrainedModel):
             inputs_embeds: torch.Tensor = self.embed_tokens(input_ids)
 
         if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4"):
-            flat_position_ids = position_ids.view(-1)
-            seqlens = torch.cat(
-                [
-                    flat_position_ids[0:1],
-                    flat_position_ids[:-1][(flat_position_ids == 0)[1:]] + 1,
-                    flat_position_ids[-1:] + 1,
-                ]
-            )
-            max_seqlen = seqlens.max().item()
-            cu_seqlens = seqlens.cumsum(dim=0, dtype=torch.int32)
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
         else:
             max_seqlen = None

--- a/src/prime_rl/trainer/models/minimax_m2/modeling_minimax_m2.py
+++ b/src/prime_rl/trainer/models/minimax_m2/modeling_minimax_m2.py
@@ -22,6 +22,7 @@ from prime_rl.trainer.models.minimax_m2.converting_minimax_m2 import (
     convert_tt_layer_to_hf,
     convert_tt_to_hf_moe,
 )
+from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
 
 logger = logging.get_logger(__name__)
 
@@ -176,16 +177,7 @@ class MiniMaxM2Model(MiniMaxM2PreTrainedModel):
             inputs_embeds = self.embed_tokens(input_ids)
 
         if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4"):
-            flat_position_ids = position_ids.view(-1)
-            seqlens = torch.cat(
-                [
-                    flat_position_ids[0:1],
-                    flat_position_ids[:-1][(flat_position_ids == 0)[1:]] + 1,
-                    flat_position_ids[-1:] + 1,
-                ]
-            )
-            max_seqlen = seqlens.max().item()
-            cu_seqlens = seqlens.cumsum(dim=0, dtype=torch.int32)
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
         else:
             max_seqlen = None

--- a/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
+++ b/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
@@ -30,6 +30,7 @@ from prime_rl.trainer.models.nemotron_h.converting_nemotron_h import (
     convert_prime_layer_to_hf,
     convert_prime_to_hf,
 )
+from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
 
 logger = logging.get_logger(__name__)
 
@@ -505,16 +506,7 @@ class NemotronHModel(NemotronHPreTrainedModel):
 
         # Compute cu_seqlens and max_seqlen for flash attention
         if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4"):
-            flat_position_ids = position_ids.view(-1)
-            seqlens = torch.cat(
-                [
-                    flat_position_ids[0:1],
-                    flat_position_ids[:-1][(flat_position_ids == 0)[1:]] + 1,
-                    flat_position_ids[-1:] + 1,
-                ]
-            )
-            max_seqlen = seqlens.max().item()
-            cu_seqlens = seqlens.cumsum(dim=0, dtype=torch.int32)
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
         else:
             max_seqlen = None

--- a/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -18,6 +18,7 @@ from prime_rl.trainer.models.base import PreTrainedModelPrimeRL
 from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput
 from prime_rl.trainer.models.layers.moe import FeedForward, MoE, MoEArgs
 from prime_rl.trainer.models.layers.rotary_emb import RotaryEmbedding, RotaryEmbeddingConfig, apply_rotary_pos_emb
+from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
 
 from .configuration_qwen3_5_moe import Qwen3_5MoeConfig
 from .converting_qwen3_5_moe import (
@@ -763,16 +764,7 @@ class Qwen3_5MoeModel(Qwen3_5MoePreTrainedModel):
             inputs_embeds = self.embed_tokens(input_ids)
 
         if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4"):
-            flat_position_ids = position_ids.view(-1)
-            seqlens = torch.cat(
-                [
-                    flat_position_ids[0:1],
-                    flat_position_ids[:-1][(flat_position_ids == 0)[1:]] + 1,
-                    flat_position_ids[-1:] + 1,
-                ]
-            )
-            max_seqlen = seqlens.max().item()
-            cu_seqlens = seqlens.cumsum(dim=0, dtype=torch.int32)
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
         else:
             max_seqlen = None

--- a/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
@@ -40,6 +40,7 @@ from prime_rl.trainer.models.qwen3_moe.converting_qwen3_moe import (
     convert_tt_layer_to_hf,
     convert_tt_to_hf_moe,
 )
+from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
 
 logger = logging.get_logger(__name__)
 
@@ -216,16 +217,7 @@ class Qwen3MoeModel(Qwen3MoePreTrainedModel):
             inputs_embeds = self.embed_tokens(input_ids)
 
         if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4"):
-            flat_position_ids = position_ids.view(-1)
-            seqlens = torch.cat(
-                [
-                    flat_position_ids[0:1],
-                    flat_position_ids[:-1][(flat_position_ids == 0)[1:]] + 1,
-                    flat_position_ids[-1:] + 1,
-                ]
-            )
-            max_seqlen = seqlens.max().item()
-            cu_seqlens = seqlens.cumsum(dim=0, dtype=torch.int32)
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
             torch._dynamo.mark_dynamic(cu_seqlens, 0)
         else:
             max_seqlen = None

--- a/src/prime_rl/utils/cp.py
+++ b/src/prime_rl/utils/cp.py
@@ -6,6 +6,8 @@ import torch.distributed.nn as dist_nn
 import torch.nn as nn
 from ring_flash_attn import update_ring_flash_attn_params
 
+from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
+
 
 def setup_hybrid_cp(model: nn.Module, cp_group: dist.ProcessGroup, cp_rank: int, cp_world_size: int) -> None:
     """Configure DeltaNet modules in Qwen3.5 hybrid models for native fla CP."""
@@ -139,15 +141,7 @@ def get_padding_logit_from_prev_cp_rank(
 
 
 def _get_cu_seqlens_for_cp(position_ids: torch.Tensor) -> torch.Tensor:
-    flat_position_ids = position_ids.view(-1)
-    seqlens = torch.cat(
-        [
-            flat_position_ids[0:1],
-            flat_position_ids[:-1][(flat_position_ids == 0)[1:]] + 1,
-            flat_position_ids[-1:] + 1,
-        ]
-    )
-    cu_seqlens = seqlens.cumsum(dim=0, dtype=torch.int32)
+    cu_seqlens, _ = get_cu_seqlens_from_position_ids(position_ids)
     return cu_seqlens
 
 

--- a/src/prime_rl/utils/sequence.py
+++ b/src/prime_rl/utils/sequence.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import torch
+
+
+def get_cu_seqlens_from_position_ids(position_ids: torch.Tensor) -> tuple[torch.Tensor, int]:
+    """Build local-relative cumulative sequence lengths from packed position ids.
+
+    ``position_ids`` may be a full packed sequence or a context-parallel local shard.
+    In the shard case, the first local token can be a continuation with a non-zero
+    position id, so cumulative offsets must be anchored to the local tensor rather
+    than to the absolute position id value.
+    """
+    flat_position_ids = position_ids.view(-1)
+    total_tokens = flat_position_ids.numel()
+    assert total_tokens > 0, "Cannot build cu_seqlens for an empty position_ids tensor"
+
+    zero_starts = (flat_position_ids == 0).nonzero(as_tuple=True)[0]
+    starts = torch.cat(
+        [torch.zeros(1, dtype=zero_starts.dtype, device=zero_starts.device), zero_starts]
+    ).unique_consecutive()
+
+    ends = torch.cat(
+        [
+            starts[1:],
+            torch.tensor([total_tokens], dtype=starts.dtype, device=starts.device),
+        ]
+    )
+    seqlens = ends - starts
+
+    cu_seqlens = torch.empty(seqlens.numel() + 1, dtype=torch.int32, device=position_ids.device)
+    cu_seqlens[0] = 0
+    cu_seqlens[1:] = seqlens.cumsum(dim=0, dtype=torch.int32)
+
+    return cu_seqlens, seqlens.max().item()

--- a/tests/unit/utils/test_sequence.py
+++ b/tests/unit/utils/test_sequence.py
@@ -1,0 +1,25 @@
+import pytest
+import torch
+
+from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
+
+
+@pytest.mark.parametrize(
+    ("position_ids", "expected_cu_seqlens", "expected_max_seqlen"),
+    [
+        (torch.arange(8).unsqueeze(0), [0, 8], 8),
+        (torch.arange(8, 16).unsqueeze(0), [0, 8], 8),
+        (torch.tensor([[0, 1, 2, 3, 0, 1, 2]]), [0, 4, 7], 4),
+        (torch.tensor([[5, 6, 7, 0, 1, 2]]), [0, 3, 6], 3),
+    ],
+)
+def test_get_cu_seqlens_from_position_ids_is_local_relative(
+    position_ids: torch.Tensor,
+    expected_cu_seqlens: list[int],
+    expected_max_seqlen: int,
+) -> None:
+    cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
+
+    assert cu_seqlens.dtype == torch.int32
+    assert cu_seqlens.tolist() == expected_cu_seqlens
+    assert max_seqlen == expected_max_seqlen


### PR DESCRIPTION
## Summary

Fix CP-local `cu_seqlens` construction from packed `position_ids`.

The old formula treated the first local `position_id` as a cumulative offset. That is valid before CP sharding, but wrong after CP sharding because rank > 0 can see local positions like `1024..2047`. In that case the model-local formula produced `cu_seqlens=[1024, 3072]` for a local tensor of length 1024, which made Qwen3.5/Qwen3.6 GatedDeltaNet slice an empty Conv1d segment.

This PR adds a shared helper that builds local-relative cumulative sequence lengths, then replaces the duplicated model-local formulas across the custom model implementations and the HF Qwen3.5 text monkeypatch.

## Minimal Repro

Config used for the deterministic repro:

```toml
output_dir = "/tmp/qwen36-cp-trainer-repro"
max_steps = 1

[model]
name = "Qwen/Qwen3.6-35B-A3B"
cp = 2
attn = "flash_attention_3"
impl = "custom"

[model.debug]
random_init = true
num_layers = 1

[data.fake]
```

Slurm command:

```bash
UV_CACHE_DIR=/tmp/prime-repro-uv-cache uv run --no-sync torchrun --standalone --nproc-per-node=2 \
  -m prime_rl.trainer.rl.train \
  @ /home/daniel/git/research-prod/repro/qwen36_cp_trainer_repro.toml
```

Before this fix, the repro failed in `Qwen3_5MoeGatedDeltaNet.forward`:

```text
cu_seqlens = tensor([1024, 3072], device='cuda:1', dtype=torch.int32)
RuntimeError: Only zero batch or zero channel inputs are supported, but got input shape: [1, 8192, 1, 0]
```

After this fix, the same repro completed:

```text
SUCCESS Step 0 | Time: 169.87s | Loss: 0.0775 | ...
SUCCESS RL trainer finished!
```

## Tests

```bash
UV_CACHE_DIR=/tmp/prime-repro-uv-cache uv run --no-sync pytest tests/unit/utils/test_sequence.py
UV_CACHE_DIR=/tmp/prime-repro-uv-cache uv run --no-sync ruff check \
  src/prime_rl/utils/sequence.py \
  src/prime_rl/utils/cp.py \
  src/prime_rl/trainer/model.py \
  src/prime_rl/trainer/models/llama/modeling_llama.py \
  src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py \
  src/prime_rl/trainer/models/glm4_moe/modeling_glm4_moe.py \
  src/prime_rl/trainer/models/minimax_m2/modeling_minimax_m2.py \
  src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py \
  src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py \
  src/prime_rl/trainer/models/afmoe/modeling_afmoe.py \
  tests/unit/utils/test_sequence.py
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sequence-packing metadata (`cu_seqlens`) used by FlashAttention/linear-attention across multiple model implementations; mistakes can cause incorrect attention/conv state resets or runtime shape errors, especially under context parallelism.
> 
> **Overview**
> Fixes how `cu_seqlens` is derived from packed `position_ids` when using context parallel (CP) sharding by introducing `get_cu_seqlens_from_position_ids`, which computes **local-relative** cumulative offsets instead of treating absolute `position_id` values as offsets.
> 
> Replaces several duplicated, inline `cu_seqlens`/`max_seqlen` constructions across custom model forwards (Llama/GLM4-MoE/MiniMaxM2/NemotronH/Qwen3 MoE/Qwen3.5 MoE/AFMoE) and the Qwen3.5 HF monkeypatch, and updates CP utilities to use the shared helper. Adds unit tests covering non-zero-start shards and multi-segment packed sequences.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b76b4f1d1d12b73921dc919e10051877b33f7305. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->