### PR TITLE
[DYNAMO] feat(helm): tolerations, imagePullSecrets, configMap mount

### DIFF
--- a/k8s/prime-rl/templates/deployment.yaml
+++ b/k8s/prime-rl/templates/deployment.yaml
@@ -26,6 +26,14 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.orchestrator.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.orchestrator.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: prime-rl-orchestrator
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -33,7 +41,7 @@ spec:
         {{- if .Values.orchestrator.autoStart }}
         command: ["/bin/bash", "-c"]
         args:
-          - {{ .Values.orchestrator.command }}
+          - {{ .Values.orchestrator.command | quote }}
         {{- else }}
         command: ["sleep", "infinity"]
         {{- end }}
@@ -91,16 +99,29 @@ spec:
         {{- end }}
         resources:
           {{- toYaml .Values.orchestrator.resources | nindent 10 }}
-        {{- if .Values.storage.enabled }}
+        {{- if or .Values.storage.enabled .Values.orchestrator.configMap }}
         volumeMounts:
+        {{- if .Values.storage.enabled }}
         - name: shared-data
           mountPath: {{ .Values.storage.mountPath }}
         {{- end }}
-      {{- if .Values.storage.enabled }}
+        {{- if .Values.orchestrator.configMap }}
+        - name: rl-configs
+          mountPath: /configs
+        {{- end }}
+        {{- end }}
+      {{- if or .Values.storage.enabled .Values.orchestrator.configMap }}
       volumes:
+      {{- if .Values.storage.enabled }}
       - name: shared-data
         persistentVolumeClaim:
           claimName: {{ .Release.Name }}-shared-data
+      {{- end }}
+      {{- if .Values.orchestrator.configMap }}
+      - name: rl-configs
+        configMap:
+          name: {{ .Values.orchestrator.configMap }}
+      {{- end }}
       {{- end }}
 {{- end }}
 ---
@@ -132,6 +153,14 @@ spec:
       {{- if .Values.inference.runtimeClassName }}
       runtimeClassName: {{ .Values.inference.runtimeClassName }}
       {{- end }}
+      {{- with .Values.inference.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.inference.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: prime-rl-inference
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -139,7 +168,7 @@ spec:
         {{- if .Values.inference.autoStart }}
         command: ["/bin/bash", "-c"]
         args:
-          - {{ .Values.inference.command }}
+          - {{ .Values.inference.command | quote }}
         {{- else }}
         command: ["sleep", "infinity"]
         {{- end }}
@@ -261,6 +290,14 @@ spec:
       {{- if .Values.trainer.runtimeClassName }}
       runtimeClassName: {{ .Values.trainer.runtimeClassName }}
       {{- end }}
+      {{- with .Values.trainer.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.trainer.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: prime-rl-trainer
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -268,7 +305,7 @@ spec:
         {{- if .Values.trainer.autoStart }}
         command: ["/bin/bash", "-c"]
         args:
-          - {{ .Values.trainer.command }}
+          - {{ .Values.trainer.command | quote }}
         {{- else }}
         command: ["sleep", "infinity"]
         {{- end }}

--- a/k8s/prime-rl/values.yaml
+++ b/k8s/prime-rl/values.yaml
@@ -50,6 +50,19 @@ orchestrator:
   nodeSelector: {}
     # nvidia.com/gpu.present: "true"  # Orchestrator doesn't need GPUs
 
+  tolerations: []
+    # - key: "nvidia.com/gpu"
+    #   operator: "Exists"
+    #   effect: "NoSchedule"
+
+  imagePullSecrets: []
+    # - name: regcred
+
+  # Optional: name of an existing ConfigMap to mount at /configs in the
+  # orchestrator container. Useful for shipping TOML configs without rebuilding
+  # the image. Leave empty to skip.
+  configMap: ""
+
 # Inference component
 inference:
   enabled: true
@@ -74,6 +87,9 @@ inference:
     port: 8000
 
   runtimeClassName: nvidia
+
+  tolerations: []
+  imagePullSecrets: []
 
   # Health probes for inference server (/health for startup/readiness, /liveness for engine liveness)
   probes:
@@ -122,6 +138,9 @@ trainer:
   env: []
 
   runtimeClassName: nvidia
+
+  tolerations: []
+  imagePullSecrets: []
 
   # Health probes for trainer (requires metrics_server config)
   probes:


### PR DESCRIPTION
## Summary

Adds three commonly-needed knobs to the prime-rl Helm chart, all opt-in. Verified with `helm template`: rendered output is byte-identical to current main when defaults are used.

- **`<component>.tolerations`** on orchestrator / inference / trainer — schedule onto tainted nodes (dedicated GPU pools, spot/preemptible nodes, etc.) without forking the chart.
- **`<component>.imagePullSecrets`** so private-registry images can be pulled without baking secrets into the namespace's default ServiceAccount.
- **`orchestrator.configMap`** mounts an existing ConfigMap at `/configs` in the orchestrator container, so TOML configs can be shipped without rebuilding the image.

Also quotes the `command` arg in `autoStart` mode so multi-line shell strings don't break YAML parsing — this was a bug waiting to happen.

The orchestrator's `volumeMounts` / `volumes` blocks are now gated on `storage.enabled OR configMap` so we don't emit empty lists when both are off (the naive version would render `volumes:` with no items, which kubectl rejects).

## Verification

```
helm template t k8s/prime-rl > /tmp/defaults.yaml                # 421 lines, identical to main
helm template t k8s/prime-rl --set 'orchestrator.configMap=cm' \
  --set 'orchestrator.tolerations[0].key=nvidia.com/gpu' \
  --set 'orchestrator.imagePullSecrets[0].name=regcred' > /tmp/over.yaml  # 433 lines, fields land correctly
```