### PR TITLE
[DYNAMO] feat: example k8s manifests + local smoke tests

### DIFF
--- a/k8s/dynamo-deploy/admin-stub.yaml
+++ b/k8s/dynamo-deploy/admin-stub.yaml
@@ -1,0 +1,73 @@
+# Optional admin-stub Deployment + Service.
+# kubectl apply -f admin-stub.yaml -n <your-namespace>
+#
+# Only needed if your Dynamo build does NOT serve /v1/rl/* natively
+# (i.e. older builds without DYN_ENABLE_RL=true). With a recent Dynamo,
+# point `admin_base_url` directly at the Dynamo frontend and skip this
+# manifest entirely.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: admin-stub-script
+  namespace: <your-namespace>
+data:
+  admin_stub.py: |
+    from http.server import HTTPServer, BaseHTTPRequestHandler
+    class H(BaseHTTPRequestHandler):
+        def do_POST(self):
+            n = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(n) if n else b""
+            print(f"[stub] POST {self.path} body={body[:200]}")
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"OK")
+        def do_GET(self):
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"OK")
+    HTTPServer(("0.0.0.0", 8001), H).serve_forever()
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: admin-stub
+  namespace: <your-namespace>
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: admin-stub
+  template:
+    metadata:
+      labels:
+        app: admin-stub
+    spec:
+      containers:
+        - name: stub
+          image: python:3.12-slim
+          command: ["python3", "/scripts/admin_stub.py"]
+          ports:
+            - containerPort: 8001
+          volumeMounts:
+            - name: script
+              mountPath: /scripts
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+      volumes:
+        - name: script
+          configMap:
+            name: admin-stub-script
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: admin-stub
+  namespace: <your-namespace>
+spec:
+  selector:
+    app: admin-stub
+  ports:
+    - port: 8001
+      targetPort: 8001

--- a/k8s/dynamo-deploy/dynamo-dgd.yaml
+++ b/k8s/dynamo-deploy/dynamo-dgd.yaml
@@ -1,0 +1,90 @@
+# Example DynamoGraphDeployment for serving inference to prime-rl.
+#   kubectl apply -f dynamo-dgd.yaml -n <your-namespace>
+#
+# Replace `<your-namespace>`, `<your-registry>/dynamo:<vllm-runtime-tag>`,
+# `<your-image-pull-secret>`, and the model name below for your environment.
+# Requires DYN_ENABLE_RL=true on the Dynamo runtime so /v1/rl/* endpoints are
+# served natively.
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: prime-rl-dynamo
+  namespace: <your-namespace>
+spec:
+  backendFramework: vllm
+  pvcs:
+    - create: false
+      name: model-cache
+  services:
+    Frontend:
+      componentType: frontend
+
+      extraPodSpec:
+        imagePullSecrets:
+          - name: <your-image-pull-secret>
+        mainContainer:
+          image: <your-registry>/dynamo:<vllm-runtime-tag>
+          startupProbe:
+            failureThreshold: 360
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 10
+            timeoutSeconds: 5
+      replicas: 1
+      volumeMounts:
+        - mountPoint: /model-cache
+          name: model-cache
+    VllmWorker:
+      componentType: worker
+
+      envFromSecret: hf-token-secret
+      extraPodSpec:
+        imagePullSecrets:
+          - name: <your-image-pull-secret>
+        mainContainer:
+          command:
+            - python3
+            - -m
+            - dynamo.vllm
+          args:
+            - --model
+            - Qwen/Qwen3-4B-Instruct-2507
+            - --served-model-name
+            - Qwen/Qwen3-4B-Instruct-2507
+            - --tensor-parallel-size
+            - "1"
+            - --max-model-len
+            - "2048"
+            - --max-num-seqs
+            - "64"
+            - --gpu-memory-utilization
+            - "0.90"
+            - --enforce-eager
+          env:
+            - name: HF_HOME
+              value: /model-cache/huggingface
+          image: <your-registry>/dynamo:<vllm-runtime-tag>
+          startupProbe:
+            failureThreshold: 360
+            httpGet:
+              path: /health
+              port: 9090
+            periodSeconds: 10
+            timeoutSeconds: 10
+          workingDir: /workspace/examples/backends/vllm
+        tolerations:
+          - effect: NoSchedule
+            key: nvidia.com/gpu
+            operator: Exists
+      replicas: 1
+      resources:
+        limits:
+          gpu: "1"
+        requests:
+          gpu: "1"
+      sharedMemory:
+        size: 16Gi
+      volumeMounts:
+        - mountPoint: /model-cache
+          name: model-cache

--- a/k8s/dynamo-deploy/prime-rl-configs.yaml
+++ b/k8s/dynamo-deploy/prime-rl-configs.yaml
@@ -1,0 +1,57 @@
+# Example ConfigMap mounted at /configs in the orchestrator and trainer pods.
+# kubectl apply -f prime-rl-configs.yaml -n <your-namespace>
+#
+# Replace `<your-namespace>` below with your namespace, and adjust the
+# Dynamo frontend service hostname if it differs in your cluster.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prime-rl-configs
+  namespace: <your-namespace>
+data:
+  orch.toml: |
+    max_steps = 20
+    seq_len = 2048
+    batch_size = 64
+    rollouts_per_example = 4
+    use_token_client = false
+
+    [wandb]
+    project = "prime-rl-dynamo-k8s"
+    name = "dynamo-smoke-qwen3-4b"
+
+    [model]
+    name = "Qwen/Qwen3-4B-Instruct-2507"
+
+    [sampling]
+    max_tokens = 256
+
+    [[env]]
+    id = "math-env"
+    name = "hendrycks-math"
+    args = { dataset_name = "PrimeIntellect/Hendrycks-Math", dataset_subset = "default", math_verify_max_workers = 32, math_verify_timeout = 60 }
+
+    [buffer]
+    easy_threshold = 1.0
+    hard_threshold = 0.0
+
+    [client]
+    base_url = ["http://prime-rl-dynamo-frontend.<your-namespace>.svc.cluster.local:8000/v1"]
+    # Admin endpoints (/v1/rl/*) are served natively by the Dynamo Rust frontend
+    # (DYN_ENABLE_RL=true). No separate admin-stub service needed.
+    admin_base_url = ["http://prime-rl-dynamo-frontend.<your-namespace>.svc.cluster.local:8000/v1/rl"]
+    skip_model_check = true
+
+  train.toml: |
+    max_steps = 20
+
+    [model]
+    name = "Qwen/Qwen3-4B-Instruct-2507"
+    seq_len = 2048
+
+    [wandb]
+    project = "prime-rl-dynamo-k8s"
+    name = "dynamo-smoke-qwen3-4b-trainer"
+
+    [optim]
+    lr = 3e-6

--- a/k8s/dynamo-deploy/prime-rl-values.yaml
+++ b/k8s/dynamo-deploy/prime-rl-values.yaml
@@ -1,0 +1,114 @@
+# Example Helm values for prime-rl when Dynamo serves inference.
+#
+#   helm install prime-rl k8s/prime-rl -f k8s/dynamo-deploy/prime-rl-values.yaml -n <your-namespace>
+#
+# Dynamo serves inference, so prime-rl's own inference component is disabled.
+# Orchestrator and trainer point at the Dynamo frontend (deploy with dynamo-dgd.yaml).
+#
+# Replace the following placeholders for your environment:
+#   - namespace
+#   - image.repository / image.tag (your prime-rl image)
+#   - storage.storageClassName (your cluster's RWX storage class)
+#   - orchestrator/trainer.imagePullSecrets[*].name
+#   - secrets.name (HF token / W&B key)
+
+namespace: <your-namespace>
+
+image:
+  repository: <your-registry>/prime-rl
+  tag: "latest"
+  pullPolicy: IfNotPresent
+
+storage:
+  enabled: true
+  storageClassName: <your-rwx-storageclass>
+  accessModes:
+    - ReadWriteMany
+  size: 100Gi
+  mountPath: /data
+
+config:
+  example: "prime-rl-dynamo"
+  secrets:
+    enabled: true
+    name: hf-token-secret
+
+# Orchestrator: CPU only, talks to Dynamo for inference
+orchestrator:
+  enabled: true
+  replicas: 1
+  autoStart: true
+  command: >-
+    BENCH_API_KEY=EMPTY
+    uv run orchestrator
+    @ /configs/orch.toml
+    --output-dir /data/outputs/run_default
+    --max-concurrent 16
+    ; echo "orchestrator exited: $?" ; sleep infinity
+  resources:
+    requests:
+      memory: "8Gi"
+      cpu: "4"
+  env:
+    - name: HF_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: hf-token-secret
+          key: HF_TOKEN
+          optional: true
+    - name: WANDB_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: wandb-secret
+          key: WANDB_API_KEY
+  configMap: prime-rl-configs
+  imagePullSecrets:
+    - name: <your-image-pull-secret>
+  nodeSelector: {}
+
+# Inference: DISABLED (Dynamo DGD replaces this)
+inference:
+  enabled: false
+
+# Trainer: 1 GPU is sufficient for small models (e.g. Qwen3-4B GRPO)
+trainer:
+  enabled: true
+  replicas: 1
+  autoStart: true
+  command: >-
+    uv run torchrun
+    --nproc-per-node=1
+    --rdzv-endpoint=localhost:29510
+    --rdzv-id=smoke_$(date +%s)
+    -m prime_rl.trainer.rl.train
+    @ /configs/train.toml
+    --output-dir /data/outputs
+    ; echo "trainer exited: $?" ; sleep infinity
+  pytorchCudaAllocConf: "expandable_segments:True"
+  gpu:
+    enabled: true
+    count: 1
+  resources:
+    requests:
+      memory: "32Gi"
+      cpu: "8"
+  env:
+    - name: HF_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: hf-token-secret
+          key: HF_TOKEN
+          optional: true
+    - name: WANDB_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: wandb-secret
+          key: WANDB_API_KEY
+  configMap: prime-rl-configs
+  runtimeClassName: nvidia
+  tolerations:
+    - key: nvidia.com/gpu
+      operator: Exists
+      effect: NoSchedule
+  imagePullSecrets:
+    - name: <your-image-pull-secret>

--- a/tools/dynamo/admin_stub.py
+++ b/tools/dynamo/admin_stub.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""
+Stub HTTP server for prime-rl admin endpoints.
+
+NOTE: As of dynamo#8630 (bis/parity-tokenize-tcp), Dynamo's Rust frontend
+implements these routes natively at /v1/rl/* when DYN_ENABLE_RL=true:
+  POST /v1/rl/load_lora_adapter
+  POST /v1/rl/unload_lora_adapter
+  GET  /v1/rl/health
+
+For K8s and any deployment with a real Dynamo frontend, point admin_base_url
+at the Dynamo service (e.g. http://<frontend-svc>:8000/v1/rl). This stub is
+kept as a local development fallback for running the orchestrator without a
+live Dynamo instance.
+
+Usage:
+    python tools/dynamo/admin_stub.py
+    python tools/dynamo/admin_stub.py --port 8001
+"""
+import argparse
+
+from aiohttp import web
+
+
+async def pause(request):
+    print("[stub] POST /pause - OK")
+    return web.Response(status=200, text="OK")
+
+
+async def resume(request):
+    print("[stub] POST /resume - OK")
+    return web.Response(status=200, text="OK")
+
+
+async def update_weights(request):
+    body = await request.json()
+    print(f"[stub] POST /update_weights weight_dir={body.get('weight_dir')} - OK (weights not reloaded)")
+    return web.Response(status=200, text="OK")
+
+
+async def health(request):
+    return web.Response(status=200, text="OK")
+
+
+app = web.Application()
+app.router.add_post("/pause", pause)
+app.router.add_post("/resume", resume)
+app.router.add_post("/update_weights", update_weights)
+app.router.add_get("/health", health)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Dynamo admin stub server")
+    parser.add_argument("--port", type=int, default=8001, help="Port to listen on")
+    args = parser.parse_args()
+    print(f"[stub] Dynamo admin stub server starting on port {args.port}...")
+    web.run_app(app, port=args.port)

--- a/tools/dynamo/admin_stub.py
+++ b/tools/dynamo/admin_stub.py
@@ -17,6 +17,7 @@ Usage:
     python tools/dynamo/admin_stub.py
     python tools/dynamo/admin_stub.py --port 8001
 """
+
 import argparse
 
 from aiohttp import web

--- a/tools/dynamo/configs/smoke_rl.toml
+++ b/tools/dynamo/configs/smoke_rl.toml
@@ -1,0 +1,34 @@
+# Prime-RL smoke test: Dynamo as inference backend (short -- 5 steps)
+# Model: PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT
+# GPU layout: GPU 0 = Dynamo, GPU 1 = trainer
+#
+# Usage: uv run orchestrator @ tools/dynamo/configs/smoke_rl.toml --output-dir /tmp/.../run_default
+
+max_steps = 5
+seq_len = 512
+batch_size = 16
+rollouts_per_example = 4
+# Disable TITO: Dynamo injects token_ids via nvext (DYN_ENABLE_RL=true) rather than
+# the TITO /v1/chat/completions/tokens path. Keep false for all Dynamo deployments.
+use_token_client = false
+
+[model]
+name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
+
+[wandb]
+offline = true
+
+[sampling]
+max_tokens = 64
+
+[[env]]
+id = "reverse-text"
+
+[client]
+# Point at Dynamo instead of prime-rl's own vLLM
+base_url = ["http://localhost:8000/v1"]
+# Admin endpoints (/v1/rl/load_lora_adapter, /v1/rl/health, etc.) are served
+# natively by the Dynamo Rust frontend when DYN_ENABLE_RL=true
+admin_base_url = ["http://localhost:8000/v1/rl"]
+# Dynamo may serve model under a different name -- skip the /v1/models check
+skip_model_check = true

--- a/tools/dynamo/configs/smoke_rl_long.toml
+++ b/tools/dynamo/configs/smoke_rl_long.toml
@@ -1,0 +1,27 @@
+# Prime-RL LONG smoke test: Dynamo as inference backend (20 steps)
+# Enough steps to observe training dynamics over more iterations.
+#
+# Usage: uv run orchestrator @ tools/dynamo/configs/smoke_rl_long.toml --output-dir /tmp/.../run_default
+
+max_steps = 20
+seq_len = 512
+batch_size = 16
+rollouts_per_example = 4
+use_token_client = false
+
+[model]
+name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
+
+[wandb]
+offline = true
+
+[sampling]
+max_tokens = 64
+
+[[env]]
+id = "reverse-text"
+
+[client]
+base_url = ["http://localhost:8000/v1"]
+admin_base_url = ["http://localhost:8001"]
+skip_model_check = true

--- a/tools/dynamo/configs/smoke_trainer.toml
+++ b/tools/dynamo/configs/smoke_trainer.toml
@@ -1,0 +1,20 @@
+# Prime-RL trainer config for Dynamo smoke test (short -- 5 steps)
+# Single GPU, no FSDP. Reads rollouts written by the orchestrator process.
+#
+# Usage: uv run torchrun --nproc-per-node=1 --rdzv-endpoint=localhost:29510 \
+#          -m prime_rl.trainer.rl.train @ tools/dynamo/configs/smoke_trainer.toml \
+#          --output-dir /tmp/dynamo_smoke_outputs
+
+max_steps = 5
+
+[model]
+name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
+seq_len = 512
+
+[wandb]
+offline = true
+
+[optim]
+lr = 3e-6
+
+[ckpt]

--- a/tools/dynamo/configs/smoke_trainer_long.toml
+++ b/tools/dynamo/configs/smoke_trainer_long.toml
@@ -1,0 +1,19 @@
+# Prime-RL trainer config for long smoke test (20 steps)
+#
+# Usage: uv run torchrun --nproc-per-node=1 --rdzv-endpoint=localhost:29510 \
+#          -m prime_rl.trainer.rl.train @ tools/dynamo/configs/smoke_trainer_long.toml \
+#          --output-dir /tmp/dynamo_smoke_long
+
+max_steps = 20
+
+[model]
+name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
+seq_len = 512
+
+[wandb]
+offline = true
+
+[optim]
+lr = 3e-6
+
+[ckpt]

--- a/tools/dynamo/run_dynamo.sh
+++ b/tools/dynamo/run_dynamo.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Launch Dynamo frontend + vLLM worker for smoke testing with prime-rl.
+#
+# Prerequisites:
+#   - Dynamo virtualenv at $DYNAMO_VENV (default: ~/dev/dynamo/dynamo)
+#   - etcd + NATS running (dynamo depends on them)
+#
+# Usage:
+#   ./tools/dynamo/run_dynamo.sh
+#   CUDA_VISIBLE_DEVICES=0 ./tools/dynamo/run_dynamo.sh
+#   DYNAMO_MODEL=my-org/my-model ./tools/dynamo/run_dynamo.sh
+
+set -euo pipefail
+
+DYNAMO_VENV="${DYNAMO_VENV:-$HOME/dev/dynamo/dynamo}"
+DYNAMO_MODEL="${DYNAMO_MODEL:-PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT}"
+CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0}"
+LOG_DIR="${LOG_DIR:-/tmp}"
+
+export CUDA_VISIBLE_DEVICES
+
+source "$DYNAMO_VENV/bin/activate"
+
+echo "[dynamo-smoke] Starting frontend..."
+python -m dynamo.frontend > "$LOG_DIR/dynamo_frontend.log" 2>&1 &
+FRONTEND_PID=$!
+echo "[dynamo-smoke] Frontend PID: $FRONTEND_PID (log: $LOG_DIR/dynamo_frontend.log)"
+
+sleep 5
+
+echo "[dynamo-smoke] Starting vLLM worker (model: $DYNAMO_MODEL)..."
+DYN_SYSTEM_PORT=8081 python -m dynamo.vllm \
+  --model "$DYNAMO_MODEL" \
+  --enforce-eager \
+  --max-model-len 2048 \
+  --max-num-seqs 32 \
+  > "$LOG_DIR/dynamo_vllm.log" 2>&1 &
+WORKER_PID=$!
+echo "[dynamo-smoke] Worker PID: $WORKER_PID (log: $LOG_DIR/dynamo_vllm.log)"
+
+echo "[dynamo-smoke] Both processes launched."
+echo "[dynamo-smoke] Frontend log: $LOG_DIR/dynamo_frontend.log"
+echo "[dynamo-smoke] Worker log:   $LOG_DIR/dynamo_vllm.log"
+wait

--- a/tools/dynamo/run_smoke_test.sh
+++ b/tools/dynamo/run_smoke_test.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Full Dynamo + prime-rl smoke test: orchestrator + trainer.
+#
+# GPU 0: Dynamo inference (must already be running -- see run_dynamo.sh)
+# GPU 1: prime-rl trainer (single GPU, uses torchrun)
+#
+# Directory structure created:
+#   $OUTPUT_DIR/             <- trainer output_dir
+#   $OUTPUT_DIR/run_default/ <- orchestrator output_dir (run_* naming required)
+#
+# Usage:
+#   # Short run (5 steps, default):
+#   ./tools/dynamo/run_smoke_test.sh
+#
+#   # Long run (20 steps):
+#   ./tools/dynamo/run_smoke_test.sh --long
+#
+#   # Custom output dir:
+#   OUTPUT_DIR=/tmp/my_run ./tools/dynamo/run_smoke_test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+CONFIG_DIR="$SCRIPT_DIR/configs"
+
+# Defaults
+OUTPUT_DIR="${OUTPUT_DIR:-/tmp/dynamo_smoke_outputs}"
+TRAINER_GPU="${TRAINER_GPU:-1}"
+RDZV_PORT="${RDZV_PORT:-29510}"
+
+# Pick short vs long config
+if [[ "${1:-}" == "--long" ]]; then
+    ORCH_CONFIG="$CONFIG_DIR/smoke_rl_long.toml"
+    TRAINER_CONFIG="$CONFIG_DIR/smoke_trainer_long.toml"
+    ORCH_LOG="${OUTPUT_DIR}/smoke_long_orchestrator.log"
+    TRAINER_LOG="${OUTPUT_DIR}/smoke_long_trainer.log"
+    echo "[smoke] Using LONG configs (20 steps)"
+else
+    ORCH_CONFIG="$CONFIG_DIR/smoke_rl.toml"
+    TRAINER_CONFIG="$CONFIG_DIR/smoke_trainer.toml"
+    ORCH_LOG="${OUTPUT_DIR}/smoke_orchestrator.log"
+    TRAINER_LOG="${OUTPUT_DIR}/smoke_trainer.log"
+    echo "[smoke] Using SHORT configs (5 steps)"
+fi
+
+ORCH_DIR="$OUTPUT_DIR/run_default"
+mkdir -p "$ORCH_DIR"
+
+cd "$REPO_DIR"
+
+# Start orchestrator (no GPU needed -- just API calls to Dynamo)
+echo "[smoke] Starting orchestrator (output: $ORCH_DIR)..."
+BENCH_API_KEY=EMPTY CUDA_VISIBLE_DEVICES="" \
+  uv run orchestrator \
+    @ "$ORCH_CONFIG" \
+    --output-dir "$ORCH_DIR" \
+    --max-concurrent 4 \
+  > "$ORCH_LOG" 2>&1 &
+ORCH_PID=$!
+echo "[smoke] Orchestrator PID: $ORCH_PID (log: $ORCH_LOG)"
+
+# Give orchestrator time to write first batch
+sleep 12
+
+# Start trainer on GPU via uv run torchrun (uses project venv Python, needed for torch.distributed)
+echo "[smoke] Starting trainer (output: $OUTPUT_DIR)..."
+CUDA_VISIBLE_DEVICES="$TRAINER_GPU" uv run torchrun \
+  --nproc-per-node=1 \
+  --rdzv-endpoint="localhost:$RDZV_PORT" \
+  --rdzv-id="smoke_$(date +%s)" \
+  -m prime_rl.trainer.rl.train \
+    @ "$TRAINER_CONFIG" \
+    --output-dir "$OUTPUT_DIR" \
+  > "$TRAINER_LOG" 2>&1 &
+TRAINER_PID=$!
+echo "[smoke] Trainer PID: $TRAINER_PID (log: $TRAINER_LOG)"
+
+echo "[smoke] Waiting for both processes..."
+
+wait $ORCH_PID
+ORCH_EXIT=$?
+wait $TRAINER_PID
+TRAINER_EXIT=$?
+
+echo ""
+echo "[smoke] Orchestrator exit: $ORCH_EXIT"
+echo "[smoke] Trainer exit: $TRAINER_EXIT"
+
+if [[ $ORCH_EXIT -eq 0 && $TRAINER_EXIT -eq 0 ]]; then
+    echo "[smoke] Smoke test PASSED."
+else
+    echo "[smoke] Smoke test FAILED."
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Adds a worked example for running prime-rl with NVIDIA Dynamo as the inference backend instead of prime-rl's bundled vLLM frontend. The PR is self-contained: it only adds files under `k8s/dynamo-deploy/` and `tools/dynamo/`, plus a formatting fix for the new local admin stub.

### `k8s/dynamo-deploy/` cluster deployment example

| File | Purpose |
|---|---|
| `dynamo-dgd.yaml` | Example `DynamoGraphDeployment` with frontend + vLLM worker. Requires `DYN_ENABLE_RL=true` so `/v1/rl/*` admin endpoints are served natively. |
| `prime-rl-values.yaml` | Helm values overlay that disables prime-rl's own inference component and points `base_url` / `admin_base_url` at Dynamo. |
| `prime-rl-configs.yaml` | ConfigMap mounted at `/configs` in orchestrator and trainer pods. |
| `admin-stub.yaml` | Optional admin-stub Deployment + Service for older Dynamo builds without native `/v1/rl/*`. |

### `tools/dynamo/` local smoke flow

| File | Purpose |
|---|---|
| `admin_stub.py` | Local-dev fallback admin stub using aiohttp. |
| `configs/smoke_rl.toml` / `smoke_rl_long.toml` | Orchestrator configs pointed at local Dynamo on `localhost:8000`. |
| `configs/smoke_trainer.toml` / `smoke_trainer_long.toml` | Matching trainer configs. |
| `run_dynamo.sh` | Launches Dynamo on GPU 0. |
| `run_smoke_test.sh` | Launches orchestrator + trainer on GPU 1, supports `--long`. |

## Notes

- Depends on the Helm chart additions in #2393: `<component>.configMap`, `imagePullSecrets`, and `tolerations`.
- The orchestrator/trainer source code remains backend-agnostic here; it talks to whichever endpoint `client.base_url` and `client.admin_base_url` point at.
- All manifests use placeholders such as `<your-namespace>` and `<your-registry>/...`; no secrets, paths, or registry coordinates are baked in.

## What's not in this PR

Extracted from the same upstream branch as #2391 and #2393. Skipped:

- `experimental.use_prefix_cache_salt` opt-out, because upstream went the other direction in #2314.
- `tools/rl_monitor.py` / `tools/rl_plot.py`, which can be a separate PR if reviewers want it.
- `tools/patches/vllm_lora_retry.py`, a temporary monkeypatch.

## Latest Validation

After rebasing onto latest `prime-rl/main`, formatted `tools/dynamo/admin_stub.py` on this base branch so #2394 no longer depends on the follow-up PR for Ruff hygiene.

- `uvx ruff==0.13.0 check tools/dynamo/admin_stub.py`
- `uvx ruff==0.13.0 format --check tools/dynamo/admin_stub.py`
- `python -m py_compile tools/dynamo/admin_stub.py`
- `bash -n tools/dynamo/run_dynamo.sh tools/dynamo/run_smoke_test.sh tools/dynamo/run_full_smoke.sh`
