### PR TITLE
[DYNAMO] feat: weight_broadcast.keep_recent retention knob for LoRA

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -740,6 +740,21 @@ class FileSystemWeightBroadcastConfig(BaseWeightBroadcastConfig):
     save_format: Annotated[
         Literal["safetensors", "torch"], Field(description="The format to save the weight checkpoint in.")
     ] = "safetensors"
+    keep_recent: Annotated[
+        int | None,
+        Field(
+            ge=0,
+            description=(
+                "Number of recent broadcast step directories to keep on disk. At trainer step N, "
+                "step_{N - keep_recent - 1} is deleted. If None (default), falls back to "
+                "trainer.max_async_level so retention matches the staleness window. Set this above "
+                "max_async_level for LoRA + filesystem broadcast: vLLM lazy-loads the adapter inside "
+                "_prepare_inputs, so a generate request admitted under an older adapter can page that "
+                "dir in *after* the orchestrator has moved on. A +1 or +2 buffer over max_async_level "
+                "is typical."
+            ),
+        ),
+    ] = None
 
 
 class NCCLWeightBroadcastConfig(BaseWeightBroadcastConfig):
@@ -960,6 +975,21 @@ class TrainerConfig(BaseConfig):
     def validate_weight_broadcast_type(self):
         if self.weight_broadcast.type == "nccl" and self.max_async_level != 1:
             raise ValueError("NCCL weight broadcast only works with async level 1")
+        return self
+
+    @model_validator(mode="after")
+    def validate_broadcast_keep_recent(self):
+        if (
+            self.weight_broadcast.type == "filesystem"
+            and self.weight_broadcast.keep_recent is not None
+            and self.weight_broadcast.keep_recent < self.max_async_level
+        ):
+            raise ValueError(
+                f"weight_broadcast.keep_recent ({self.weight_broadcast.keep_recent}) must be "
+                f">= max_async_level ({self.max_async_level}). The retention window must cover "
+                f"the staleness window, otherwise vLLM can hit LoRAAdapterNotFoundError when an "
+                f"in-flight generate request lazy-loads an adapter dir the trainer already removed."
+            )
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/trainer/rl/broadcast/filesystem.py
+++ b/src/prime_rl/trainer/rl/broadcast/filesystem.py
@@ -109,11 +109,11 @@ class FileSystemWeightBroadcast(WeightBroadcast):
         stable_file = save_dir / "STABLE"
         stable_file.touch()
 
-    def maybe_clean(self, max_async_level: int, interval_to_keep: int | None):
+    def maybe_clean(self, retention: int, interval_to_keep: int | None):
         for idx in self.multi_run_manager.used_idxs:
             maybe_clean(
                 get_broadcast_dir(self.multi_run_manager.get_run_dir(idx)),
                 self.multi_run_manager.progress[idx].step,
-                max_async_level,
+                retention,
                 interval_to_keep,
             )

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -268,7 +268,12 @@ def train(config: TrainerConfig):
                 ckpt_interval = config.ckpt and config.ckpt.interval
                 interval_to_keep = ckpt_interval if config.weight_broadcast.type == "filesystem" else None
                 if config.weight_broadcast.type == "filesystem":
-                    weight_broadcast.maybe_clean(config.max_async_level, interval_to_keep)
+                    retention = (
+                        config.weight_broadcast.keep_recent
+                        if config.weight_broadcast.keep_recent is not None
+                        else config.max_async_level
+                    )
+                    weight_broadcast.maybe_clean(retention, interval_to_keep)
             else:
                 broadcast_weights_time = 0
                 # Usually the broadcast will set this. If broadcast is skipped, we need to reset this here.

--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -434,9 +434,15 @@ class MemoryProfiler:
         self.step_num += 1
 
 
-def maybe_clean(path: Path, step: int, async_level: int, interval_to_keep: int | None) -> None:
+def maybe_clean(path: Path, step: int, retention: int, interval_to_keep: int | None) -> None:
+    """Delete the broadcast step directory that falls outside the retention window.
+
+    At trainer step N, deletes step_{N - retention - 1}. Caller picks whether
+    `retention` is the orchestrator's staleness bound (max_async_level) or a
+    wider buffer (weight_broadcast.keep_recent).
+    """
     logger = get_logger()
-    step = max(step - (async_level + 1), 0)  # Consider deleting async_level + 1 steps ago
+    step = max(step - (retention + 1), 0)
     candidate_path_to_delete = get_step_path(path, step)
     keep = bool(interval_to_keep and step % interval_to_keep == 0)
     logger.debug(f"Considering deleting path {candidate_path_to_delete}")


### PR DESCRIPTION
## Summary

Adds an optional `weight_broadcast.keep_recent` knob that decouples broadcast-dir retention from `max_async_level`. Default behavior is unchanged (when unset, retention falls back to `max_async_level` exactly as before).

## Problem

`maybe_clean` previously deleted `step_{N - max_async_level - 1}`. That's the right bound for full-weight broadcasts, but **not** for LoRA. vLLM lazy-loads the adapter inside `_prepare_inputs`, so a generate request admitted under an older adapter can page that adapter dir in *after* the orchestrator has moved on. The trainer can race ahead and `rmtree` the adapter directory just before the inference worker tries to read it.

## Fix

New optional `weight_broadcast.keep_recent: int | None` (default `None`):
- `None` → fall back to `max_async_level` (no behavior change for existing users).
- Set to `max_async_level + 1` or `+2` for LoRA + filesystem broadcast.

A `model_validator` rejects `keep_recent < max_async_level` with a message that names the failure mode (`LoRAAdapterNotFoundError`), since a smaller-than-staleness retention window is always a misconfiguration.

`maybe_clean`'s int parameter is renamed `async_level` -> `retention` to reflect that it can now come from either knob.

## Relationship to other PRs

A companion PR (#2391) addresses a *different* LoRA failure mode on the same code path — an NFS visibility race where the `STABLE` sentinel becomes visible before the adapter files it points to. The two are independent and can land in either order. Together they cover both classes of `LoRAAdapterNotFoundError` we've seen on shared-filesystem deployments.