### PR TITLE
[DYNAMO] chore: remove dead unload_lora_adapter

### DIFF
--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -409,19 +409,6 @@ async def load_lora_adapter(admin_clients: list[AsyncClient], lora_name: str, lo
     await asyncio.gather(*[_load_lora_adapter(admin_client) for admin_client in admin_clients])
 
 
-async def unload_lora_adapter(admin_clients: list[AsyncClient], lora_name: str) -> None:
-    """Make a HTTP post request to the vLLM server to unload a LoRA adapter."""
-    logger = get_logger()
-
-    async def _unload_lora_adapter(admin_client: AsyncClient) -> None:
-        logger.debug(f"Sending request to unload LoRA adapter {lora_name}")
-        await admin_client.post("/v1/unload_lora_adapter", json={"lora_name": lora_name})
-        # TODO: The first one can fail, but subsequent ones should succeed.
-        # response.raise_for_status()
-
-    await asyncio.gather(*[_unload_lora_adapter(admin_client) for admin_client in admin_clients])
-
-
 async def init_nccl_broadcast(
     admin_clients: list[AsyncClient],
     host: str,


### PR DESCRIPTION
## Summary

`unload_lora_adapter` in `src/prime_rl/utils/client.py` has been dead code since November 2025. Removing it.

## History

- #1320 (`2aa47ae6b`, 2025-11-21) introduced `unload_lora_adapter` along with a call to it at the end of `orchestrate()` in `orchestrator.py`. The PR also shipped with a `# TODO: first one can fail, subsequent ones should succeed` comment and a commented-out `raise_for_status()` — i.e. the author already knew the call was unreliable.
- `220b50a38` ("dont unload for now"), same day, **same author**, removed the call site and the import. The function has had zero callers ever since.

```bash
$ git log --all --oneline -S'unload_lora_adapter(' -- src/
2aa47ae6b Support broadcasting just lora weights ...   # adds function + caller
220b50a38 dont unload for now                          # removes caller, leaves function
$ rg 'unload_lora' src/ tests/ examples/
src/prime_rl/utils/client.py:412 ...   # only the function itself
```

## Why delete, not fix

The function has two issues that surface only when reactivated:

1. **Silent-failure pattern.** The `raise_for_status()` is commented out. Per `AGENTS.md`: *"Minimal try/except: let errors propagate — silent failures hide bugs."*
2. **Path bug against Dynamo.** Line 418 is `/v1/unload_lora_adapter` (with `/v1/` prefix). Line 403 — its sibling `load_lora_adapter` — is bare `/load_lora_adapter`. Against vLLM, both paths work because vLLM aliases them. Against a Dynamo frontend with `admin_base_url = http://.../v1/rl`, httpx joins the path onto the base, producing `http://.../v1/rl/v1/unload_lora_adapter`, which doesn't exist. The 404 is invisible because `raise_for_status()` is commented out.

Fixing in place would mean making dead code "correct" without any way to validate the fix end-to-end. When end-of-training adapter unload is actually needed, the right move is to re-add it with a real call site and a real integration check, not to maintain a half-working stub in the meantime.

## Scope

13 lines removed in one file. No callers, no imports, no tests reference it. Verified.