### PR TITLE
Fix FA3 ring attention signature compatibility

### DIFF
--- a/tests/unit/train/models/test_ring_attn.py
+++ b/tests/unit/train/models/test_ring_attn.py
@@ -1,0 +1,196 @@
+import sys
+import types
+
+import pytest
+import torch
+
+import prime_rl._compat  # noqa: F401
+from prime_rl.trainer.models.layers import ring_attn
+
+
+def _make_tensors() -> tuple[torch.Tensor, ...]:
+    q = torch.empty((1, 1, 64), dtype=torch.bfloat16)
+    k = torch.empty_like(q)
+    v = torch.empty_like(q)
+    cu_seqlens = torch.tensor([0, 1], dtype=torch.int32)
+    out = torch.empty_like(q)
+    lse = torch.empty((1, 1), dtype=torch.float32)
+    return q, k, v, cu_seqlens, out, lse
+
+
+def test_fa3_varlen_uses_legacy_causal_and_window_size_signature(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = {}
+
+    def fake_forward(
+        q,
+        k,
+        v,
+        k_new=None,
+        v_new=None,
+        qv=None,
+        out=None,
+        cu_seqlens_q=None,
+        cu_seqlens_k=None,
+        cu_seqlens_k_new=None,
+        seqused_q=None,
+        seqused_k=None,
+        max_seqlen_q=None,
+        max_seqlen_k=None,
+        page_table=None,
+        kv_batch_idx=None,
+        leftpad_k=None,
+        rotary_cos=None,
+        rotary_sin=None,
+        seqlens_rotary=None,
+        q_descale=None,
+        k_descale=None,
+        v_descale=None,
+        softmax_scale=None,
+        causal=False,
+        window_size=(-1, -1),
+        attention_chunk=0,
+        softcap=0.0,
+        rotary_interleaved=True,
+        scheduler_metadata=None,
+        num_splits=1,
+        pack_gqa=None,
+        sm_margin=0,
+    ):
+        calls["forward"] = {"causal": causal, "window_size": window_size}
+        return q, torch.empty((1, 1), dtype=torch.float32), None, None
+
+    def fake_backward(
+        dout,
+        q,
+        k,
+        v,
+        out,
+        softmax_lse,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        sequed_q=None,
+        sequed_k=None,
+        max_seqlen_q=None,
+        max_seqlen_k=None,
+        dq=None,
+        dk=None,
+        dv=None,
+        softmax_scale=None,
+        causal=False,
+        window_size=(-1, -1),
+        softcap=0.0,
+        deterministic=False,
+        sm_margin=0,
+    ):
+        calls["backward"] = {"causal": causal, "window_size": window_size}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "flash_attn_interface",
+        types.SimpleNamespace(_flash_attn_forward=fake_forward, _flash_attn_backward=fake_backward),
+    )
+
+    q, k, v, cu_seqlens, out, lse = _make_tensors()
+    ring_attn._fa3_varlen_forward(q, k, v, cu_seqlens, cu_seqlens, 1, 1, 1.0, True, window_size=(3, 0))
+    ring_attn._fa3_varlen_backward(
+        out, q, k, v, out, lse, cu_seqlens, cu_seqlens, 1, 1, q, k, v, 1.0, True, window_size=(3, 0)
+    )
+
+    assert calls == {
+        "forward": {"causal": True, "window_size": (3, 0)},
+        "backward": {"causal": True, "window_size": (3, 0)},
+    }
+
+
+def test_fa3_varlen_uses_split_causal_and_window_signature(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = {}
+
+    def fake_forward(
+        q,
+        k,
+        v,
+        k_new=None,
+        v_new=None,
+        qv=None,
+        out=None,
+        cu_seqlens_q=None,
+        cu_seqlens_k=None,
+        cu_seqlens_k_new=None,
+        seqused_q=None,
+        seqused_k=None,
+        max_seqlen_q=None,
+        max_seqlen_k=None,
+        page_table=None,
+        kv_batch_idx=None,
+        leftpad_k=None,
+        rotary_cos=None,
+        rotary_sin=None,
+        seqlens_rotary=None,
+        q_descale=None,
+        k_descale=None,
+        v_descale=None,
+        softmax_scale=None,
+        is_causal=False,
+        window_size_left=-1,
+        window_size_right=-1,
+        attention_chunk=0,
+        softcap=0.0,
+        rotary_interleaved=True,
+        scheduler_metadata=None,
+        num_splits=1,
+        pack_gqa=None,
+        sm_margin=0,
+    ):
+        calls["forward"] = {
+            "is_causal": is_causal,
+            "window_size_left": window_size_left,
+            "window_size_right": window_size_right,
+        }
+        return q, torch.empty((1, 1), dtype=torch.float32), None, None
+
+    def fake_backward(
+        dout,
+        q,
+        k,
+        v,
+        out,
+        softmax_lse,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        sequed_q=None,
+        sequed_k=None,
+        max_seqlen_q=None,
+        max_seqlen_k=None,
+        dq=None,
+        dk=None,
+        dv=None,
+        softmax_scale=None,
+        is_causal=False,
+        window_size_left=-1,
+        window_size_right=-1,
+        softcap=0.0,
+        deterministic=False,
+        sm_margin=0,
+    ):
+        calls["backward"] = {
+            "is_causal": is_causal,
+            "window_size_left": window_size_left,
+            "window_size_right": window_size_right,
+        }
+
+    monkeypatch.setitem(
+        sys.modules,
+        "flash_attn_interface",
+        types.SimpleNamespace(_flash_attn_forward=fake_forward, _flash_attn_backward=fake_backward),
+    )
+
+    q, k, v, cu_seqlens, out, lse = _make_tensors()
+    ring_attn._fa3_varlen_forward(q, k, v, cu_seqlens, cu_seqlens, 1, 1, 1.0, True, window_size=(3, 0))
+    ring_attn._fa3_varlen_backward(
+        out, q, k, v, out, lse, cu_seqlens, cu_seqlens, 1, 1, q, k, v, 1.0, True, window_size=(3, 0)
+    )
+
+    assert calls == {
+        "forward": {"is_causal": True, "window_size_left": 3, "window_size_right": 0},
+        "backward": {"is_causal": True, "window_size_left": 3, "window_size_right": 0},
+    }


### PR DESCRIPTION
## Summary

Fix FlashAttention 3 ring-attention calls so they match the installed FA3 low-level function signature.

The pinned `flash-attn-3` package exposes `_flash_attn_forward` / `_flash_attn_backward` with `causal` and tuple `window_size` parameters, while the PrimeRL ring-attention wrapper was always passing `is_causal`, `window_size_left`, and `window_size_right`. CP + FA3 model paths therefore failed before reaching the kernel.

This change keeps compatibility with both observed signature shapes:

- `causal` + `window_size`
- `is_causal` + `window_size_left` / `window_size_right`

## Repro

On current `main`, this hits the bug through the PrimeRL FA3 ring-attention wrapper:

```bash
UV_CACHE_DIR=/tmp/prime-repro-uv-cache uv run --no-sync python - <<'PY'
import torch
import prime_rl._compat  # noqa: F401
from prime_rl.trainer.models.layers import ring_attn

q = torch.empty((1, 1, 64), dtype=torch.bfloat16)
k = torch.empty_like(q)
v = torch.empty_like(q)
cu = torch.tensor([0, 1], dtype=torch.int32)

ring_attn._fa3_varlen_forward(
    q,
    k,
    v,
    cu,
    cu,
    1,
    1,
    1.0,
    True,
    window_size=(3, 0),
)
PY
```

Before this patch, the installed pinned FA3 wrapper rejects the unexpected `is_causal` keyword.

After this patch, the same path passes `causal=True` and `window_size=(3, 0)` to the installed FA3 wrapper.

## Tests

```bash
UV_CACHE_DIR=/tmp/prime-repro-uv-cache uv run --no-sync pytest tests/unit/train/models/test_ring_attn.py
UV_CACHE_DIR=/tmp/prime-repro-uv-cache uv run --no-sync ruff check src/prime_rl/trainer/models/layers/ring_attn.py tests/unit/train/models/test_ring_attn.py
git diff --check
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized keyword-arg plumbing change for FlashAttention-3 wrappers plus targeted unit tests; behavior only differs in how `causal`/`window_size` kwargs are passed into the FA3 kernel entrypoints.
> 
> **Overview**
> Fixes FlashAttention-3 ring-attention varlen wrapper calls to handle **both** observed low-level FA3 signatures by setting either `causal` + `window_size` or `is_causal` + `window_size_left/right` based on the target function’s default-arg keys.
> 
> Adds unit tests that monkeypatch `flash_attn_interface` to validate the forward/backward wrappers pass the correct causal/window parameters for each signature variant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 573efcf5eef5d69727626434ecb2d8c1639cd119. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->