### PR TITLE
Reject full-context chat prompts before max_tokens underflows

### DIFF
--- a/src/prime_rl/inference/vllm/serving_chat_with_tokens.py
+++ b/src/prime_rl/inference/vllm/serving_chat_with_tokens.py
@@ -51,6 +51,33 @@ class ChatCompletionRequestWithTokens(ChatCompletionRequest):
 class OpenAIServingChatWithTokens(OpenAIServingChat):
     """OpenAI-compatible generate API that allows token-in and routed experts capture."""
 
+    def _validate_prompt_has_generation_room(self, engine_prompt) -> int:
+        prompt_len = self._extract_prompt_len(engine_prompt)
+        max_model_len = self.model_config.max_model_len
+        if prompt_len >= max_model_len:
+            raise VLLMValidationError(
+                f"This model's maximum context length is "
+                f"{max_model_len} tokens. However, your request has "
+                f"{prompt_len} input tokens. Please reduce the length of "
+                "the input messages.",
+                parameter="input_tokens",
+                value=prompt_len,
+            )
+        return prompt_len
+
+    async def render_chat_request(self, request: ChatCompletionRequest):
+        result = await super().render_chat_request(request)
+        if isinstance(result, ErrorResponse) or isinstance(request, ChatCompletionRequestWithTokens):
+            return result
+
+        _, engine_prompts = result
+        try:
+            for engine_prompt in engine_prompts:
+                self._validate_prompt_has_generation_room(engine_prompt)
+        except ValueError as e:
+            return self.create_error_response(e)
+        return result
+
     async def chat_completion_full_generator(
         self,
         request: ChatCompletionRequest,
@@ -159,21 +186,12 @@ class OpenAIServingChatWithTokens(OpenAIServingChat):
                 # have unique request ids.
                 sub_request_id = request_id if len(engine_prompts) == 1 else f"{request_id}_{i}"
 
-                prompt_len = self._extract_prompt_len(engine_prompt)
-                if prompt_len >= max_model_len:
-                    raise VLLMValidationError(
-                        f"This model's maximum context length is "
-                        f"{max_model_len} tokens. However, your request has "
-                        f"{prompt_len} input tokens. Please reduce the length of "
-                        "the input messages.",
-                        parameter="input_tokens",
-                        value=prompt_len,
-                    )
+                prompt_len = self._validate_prompt_has_generation_room(engine_prompt)
 
                 max_tokens = get_max_tokens(
                     max_model_len,
                     request.max_completion_tokens if request.max_completion_tokens is not None else request.max_tokens,
-                    self._extract_prompt_len(engine_prompt),
+                    prompt_len,
                     self.default_sampling_params,
                     self.override_max_tokens,
                 )

--- a/tests/unit/inference/test_serving_chat_with_tokens.py
+++ b/tests/unit/inference/test_serving_chat_with_tokens.py
@@ -1,1 +1,72 @@
+import asyncio
+from types import MethodType, SimpleNamespace
 
+import pytest
+from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
+from vllm.exceptions import VLLMValidationError
+
+from prime_rl.inference.vllm.serving_chat_with_tokens import (
+    ChatCompletionRequestWithTokens,
+    OpenAIServingChatWithTokens,
+)
+
+
+def _handler(max_model_len: int) -> OpenAIServingChatWithTokens:
+    handler = object.__new__(OpenAIServingChatWithTokens)
+    handler.model_config = SimpleNamespace(max_model_len=max_model_len)
+
+    def _extract_prompt_len(self, prompt):
+        return len(prompt["prompt_token_ids"])
+
+    handler._extract_prompt_len = MethodType(_extract_prompt_len, handler)
+    return handler
+
+
+def test_validate_prompt_has_generation_room_allows_one_token_margin():
+    handler = _handler(max_model_len=4)
+
+    assert handler._validate_prompt_has_generation_room({"prompt_token_ids": [1, 2, 3]}) == 3
+
+
+def test_validate_prompt_has_generation_room_rejects_full_context():
+    handler = _handler(max_model_len=4)
+
+    with pytest.raises(VLLMValidationError) as exc_info:
+        handler._validate_prompt_has_generation_room({"prompt_token_ids": [1, 2, 3, 4]})
+
+    message = str(exc_info.value)
+    assert "maximum context length is 4 tokens" in message
+    assert "4 input tokens" in message
+
+
+def test_render_chat_request_returns_context_error_before_max_tokens_underflows(monkeypatch):
+    async def fake_render_chat_request(self, request):
+        return "conversation", [{"prompt_token_ids": [1, 2, 3, 4]}]
+
+    monkeypatch.setattr(OpenAIServingChat, "render_chat_request", fake_render_chat_request)
+
+    handler = _handler(max_model_len=4)
+
+    def create_error_response(self, error):
+        return {"error": str(error)}
+
+    handler.create_error_response = MethodType(create_error_response, handler)
+
+    result = asyncio.run(handler.render_chat_request(object()))
+
+    assert "maximum context length is 4 tokens" in result["error"]
+    assert "4 input tokens" in result["error"]
+
+
+def test_render_chat_request_defers_token_endpoint_validation_until_tokens_are_installed(monkeypatch):
+    async def fake_render_chat_request(self, request):
+        return "conversation", [{"prompt_token_ids": [1, 2, 3, 4]}]
+
+    monkeypatch.setattr(OpenAIServingChat, "render_chat_request", fake_render_chat_request)
+
+    handler = _handler(max_model_len=4)
+    request = object.__new__(ChatCompletionRequestWithTokens)
+
+    result = asyncio.run(handler.render_chat_request(request))
+
+    assert result == ("conversation", [{"prompt_token_ids": [1, 2, 3, 4]}])


### PR DESCRIPTION
## Summary
- reject rendered standard chat prompts that already fill the model context before vLLM derives `max_tokens=0`
- preserve `/chat/completions/tokens` behavior by validating after stitched `request.tokens` are installed, so TITO checks the actual request tokens
- add focused coverage for the context-limit guard and token-endpoint deferral

## Why This Fixes The Bug
Before this change, the standard `/v1/chat/completions` serving path rendered the prompt and then called vLLM `get_max_tokens(...)`. When `prompt_len == max_model_len`, that helper can return `0`; `request.to_sampling_params(max_tokens=0)` then surfaces as:

`BadRequestError: max_tokens must be at least 1, got 0`

That error is a generic model error to the rollout env, so group-scored rollouts can reschedule an otherwise nearly complete group.

After this change, `OpenAIServingChatWithTokens.render_chat_request()` validates rendered standard chat prompts before vLLM reaches `get_max_tokens`. If the prompt has no generation room, it raises `VLLMValidationError(parameter="input_tokens")`, which vLLM serializes as a 400 `BadRequestError` with a context-length message:

`This model's maximum context length is ... However, your request has ... input tokens ... (parameter=input_tokens, value=...)`

The verifiers OpenAI client already classifies messages containing `maximum context length` / `context length` as `OverlongPromptError`, and the env handles that as `prompt_too_long` instead of a generic model failure.

## Impact
Long multi-turn rollouts that reach `max_model_len` now stop through the existing overlong-prompt path instead of sending `max_tokens=0` to vLLM. In the observed SLURM run this was not the dominant throughput bottleneck, but each occurrence can still be expensive because group scoring discards partial group progress and reschedules.

## Verification
- `uv run pytest tests/unit/inference/test_serving_chat_with_tokens.py tests/unit/inference/test_serving_generate.py`
- `uv run ruff format --check src/prime_rl/inference/vllm/serving_chat_with_tokens.py tests/unit/inference/test_serving_chat_with_tokens.py`
- `uv run ruff check src/prime_rl/inference/vllm/serving_chat_with_tokens.py tests/unit/inference/test_serving_chat_with_tokens.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request validation behavior in the OpenAI chat serving path; could alter which requests are rejected and the error shape returned, but is localized and covered by unit tests.
> 
> **Overview**
> Adds an explicit context-length guard for standard `/v1/chat/completions` requests by validating rendered `engine_prompts` in `render_chat_request` and returning a `VLLMValidationError(parameter="input_tokens")` when the prompt already fills the model context (avoiding `max_tokens=0` underflow errors).
> 
> Refactors the same check into `_validate_prompt_has_generation_room()` and reuses it in the token-in (`/chat/completions/tokens`) path, while *deferring validation* there until after `request.tokens` are stitched in so the check reflects the actual prompt tokens. Includes new unit tests covering both the guard behavior and the token-endpoint deferral.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82d8849a94b64248abdf28b2106cd0b5344f06f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->