### PR TITLE
Add renderer keep_thinking config plumbing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,7 @@ nixl-cu12 = false
 
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "1fcfe41f3f81f796a3b400acdfe05e4d62f7d741" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "d57692637f2064e8f50229c7d63b565504408a35" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eeb" }
 transformers = { git = "https://github.com/huggingface/transformers.git", rev = "c1c3424" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,7 @@ nixl-cu12 = false
 
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "d57692637f2064e8f50229c7d63b565504408a35" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "350c1604e8a944cc9c84d0bae72fecba1fd62f1c" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eeb" }
 transformers = { git = "https://github.com/huggingface/transformers.git", rev = "c1c3424" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,7 @@ nixl-cu12 = false
 
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "3b77145" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "1fcfe41f3f81f796a3b400acdfe05e4d62f7d741" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eeb" }
 transformers = { git = "https://github.com/huggingface/transformers.git", rev = "c1c3424" }

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -1207,7 +1207,7 @@ class OrchestratorConfig(BaseConfig):
             renderer_args_set.append(f"renderer.reasoning_parser={self.renderer.reasoning_parser!r}")
         if self.renderer.pool_size is not None:
             renderer_args_set.append(f"renderer.pool_size={self.renderer.pool_size!r}")
-        if self.renderer.keep_thinking:
+        if self.renderer.keep_thinking is not None:
             renderer_args_set.append(f"renderer.keep_thinking={self.renderer.keep_thinking!r}")
 
         if renderer_args_set:

--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -1075,7 +1075,7 @@ class OrchestratorConfig(BaseConfig):
         Field(
             description="Whether to use the renderer client (client-side tokenization via the ``renderers`` package, "
             "served by ``/v1/generate``). Mutually exclusive with ``use_token_client``. When True, the "
-            "``[orchestrator.renderer]`` block (name / tool_parser / reasoning_parser / pool_size) "
+            "``[orchestrator.renderer]`` block (name / tool_parser / reasoning_parser / pool_size / keep_thinking) "
             "applies; when False those fields must be left at their defaults. Not supported for VLMs — "
             "VLMs must use the token client (TITO) so image preprocessing and chat templating stay server-side."
         ),
@@ -1207,6 +1207,8 @@ class OrchestratorConfig(BaseConfig):
             renderer_args_set.append(f"renderer.reasoning_parser={self.renderer.reasoning_parser!r}")
         if self.renderer.pool_size is not None:
             renderer_args_set.append(f"renderer.pool_size={self.renderer.pool_size!r}")
+        if self.renderer.keep_thinking:
+            renderer_args_set.append(f"renderer.keep_thinking={self.renderer.keep_thinking!r}")
 
         if renderer_args_set:
             raise ValueError(

--- a/src/prime_rl/configs/shared.py
+++ b/src/prime_rl/configs/shared.py
@@ -187,13 +187,15 @@ class RendererConfig(BaseConfig):
     ] = None
 
     keep_thinking: Annotated[
-        bool,
+        bool | None,
         Field(
             description=(
-                "Whether to preserve historical assistant reasoning blocks for renderers that support keep_thinking."
+                "Override historical assistant reasoning block handling for renderers that support "
+                "keep_thinking. True preserves historical thinking, False disables it, and None "
+                "uses the selected renderer's default."
             ),
         ),
-    ] = False
+    ] = None
 
 
 class ElasticConfig(BaseConfig):

--- a/src/prime_rl/configs/shared.py
+++ b/src/prime_rl/configs/shared.py
@@ -186,6 +186,15 @@ class RendererConfig(BaseConfig):
         ),
     ] = None
 
+    keep_thinking: Annotated[
+        bool,
+        Field(
+            description=(
+                "Whether to preserve historical assistant reasoning blocks for renderers that support keep_thinking."
+            ),
+        ),
+    ] = False
+
 
 class ElasticConfig(BaseConfig):
     """Configures elastic inference pool with DNS-based service discovery.

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -925,6 +925,7 @@ async def setup_rollout_inference_pool(
             renderer=config.renderer.name,
             tool_parser=config.renderer.tool_parser,
             reasoning_parser=config.renderer.reasoning_parser,
+            keep_thinking=config.renderer.keep_thinking,
         )
         logger.info(f"Initialized {type(renderer).__name__} for {config.model.name}")
         inference_pool = await setup_inference_pool(
@@ -936,6 +937,7 @@ async def setup_rollout_inference_pool(
             tool_parser=config.renderer.tool_parser,
             reasoning_parser=config.renderer.reasoning_parser,
             renderer_pool_size=config.renderer.pool_size,
+            renderer_keep_thinking=config.renderer.keep_thinking,
         )
         logger.info("Using direct renderer rollout client")
         return renderer, inference_pool

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -68,6 +68,7 @@ class StaticInferencePool:
         tool_parser: str | None = None,
         reasoning_parser: str | None = None,
         renderer_pool_size: int | None = None,
+        renderer_keep_thinking: bool = False,
     ):
         renderer_model_name = model_name if train_client_type == "renderer" else None
         self._train_clients = setup_clients(
@@ -78,6 +79,7 @@ class StaticInferencePool:
             tool_parser=tool_parser,
             reasoning_parser=reasoning_parser,
             renderer_pool_size=renderer_pool_size,
+            renderer_keep_thinking=renderer_keep_thinking,
         )
         self._eval_clients = setup_clients(client_config, client_type=eval_client_type)
         self._admin_clients = setup_admin_clients(client_config)
@@ -129,6 +131,7 @@ async def setup_inference_pool(
     tool_parser: str | None = None,
     reasoning_parser: str | None = None,
     renderer_pool_size: int | None = None,
+    renderer_keep_thinking: bool = False,
 ) -> InferencePool:
     """Create an inference pool from config (static or elastic)."""
     logger = get_logger()
@@ -152,6 +155,7 @@ async def setup_inference_pool(
             tool_parser=tool_parser,
             reasoning_parser=reasoning_parser,
             renderer_pool_size=renderer_pool_size,
+            renderer_keep_thinking=renderer_keep_thinking,
         )
 
     logger.info(
@@ -168,6 +172,7 @@ async def setup_inference_pool(
         tool_parser=tool_parser,
         reasoning_parser=reasoning_parser,
         renderer_pool_size=renderer_pool_size,
+        renderer_keep_thinking=renderer_keep_thinking,
     )
 
 
@@ -179,6 +184,7 @@ def setup_clients(
     tool_parser: str | None = None,
     reasoning_parser: str | None = None,
     renderer_pool_size: int | None = None,
+    renderer_keep_thinking: bool = False,
 ) -> list[vf.ClientConfig]:
     clients = []
     client_idx = 0
@@ -194,6 +200,7 @@ def setup_clients(
                     renderer=renderer_name,
                     renderer_model_name=renderer_model_name,
                     renderer_pool_size=renderer_pool_size,
+                    renderer_keep_thinking=renderer_keep_thinking,
                     tool_parser=tool_parser,
                     reasoning_parser=reasoning_parser,
                     api_base_url=base_url,

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -68,7 +68,7 @@ class StaticInferencePool:
         tool_parser: str | None = None,
         reasoning_parser: str | None = None,
         renderer_pool_size: int | None = None,
-        renderer_keep_thinking: bool = False,
+        renderer_keep_thinking: bool | None = None,
     ):
         renderer_model_name = model_name if train_client_type == "renderer" else None
         self._train_clients = setup_clients(
@@ -131,7 +131,7 @@ async def setup_inference_pool(
     tool_parser: str | None = None,
     reasoning_parser: str | None = None,
     renderer_pool_size: int | None = None,
-    renderer_keep_thinking: bool = False,
+    renderer_keep_thinking: bool | None = None,
 ) -> InferencePool:
     """Create an inference pool from config (static or elastic)."""
     logger = get_logger()
@@ -184,7 +184,7 @@ def setup_clients(
     tool_parser: str | None = None,
     reasoning_parser: str | None = None,
     renderer_pool_size: int | None = None,
-    renderer_keep_thinking: bool = False,
+    renderer_keep_thinking: bool | None = None,
 ) -> list[vf.ClientConfig]:
     clients = []
     client_idx = 0

--- a/src/prime_rl/utils/elastic.py
+++ b/src/prime_rl/utils/elastic.py
@@ -110,7 +110,7 @@ class ElasticInferencePool:
         tool_parser: str | None = None,
         reasoning_parser: str | None = None,
         renderer_pool_size: int | None = None,
-        renderer_keep_thinking: bool = False,
+        renderer_keep_thinking: bool | None = None,
     ):
         self.logger = get_logger()
         self.client_config = client_config
@@ -154,7 +154,7 @@ class ElasticInferencePool:
         tool_parser: str | None = None,
         reasoning_parser: str | None = None,
         renderer_pool_size: int | None = None,
-        renderer_keep_thinking: bool = False,
+        renderer_keep_thinking: bool | None = None,
     ) -> ElasticInferencePool:
         if client_config.elastic is None:
             raise ValueError("Elastic inference pool requires elastic config")

--- a/src/prime_rl/utils/elastic.py
+++ b/src/prime_rl/utils/elastic.py
@@ -110,6 +110,7 @@ class ElasticInferencePool:
         tool_parser: str | None = None,
         reasoning_parser: str | None = None,
         renderer_pool_size: int | None = None,
+        renderer_keep_thinking: bool = False,
     ):
         self.logger = get_logger()
         self.client_config = client_config
@@ -125,6 +126,7 @@ class ElasticInferencePool:
         self.tool_parser = tool_parser
         self.reasoning_parser = reasoning_parser
         self.renderer_pool_size = renderer_pool_size
+        self.renderer_keep_thinking = renderer_keep_thinking
         self.router_url = client_config.router_url
 
         self._servers: dict[str, ServerState] = {}
@@ -152,6 +154,7 @@ class ElasticInferencePool:
         tool_parser: str | None = None,
         reasoning_parser: str | None = None,
         renderer_pool_size: int | None = None,
+        renderer_keep_thinking: bool = False,
     ) -> ElasticInferencePool:
         if client_config.elastic is None:
             raise ValueError("Elastic inference pool requires elastic config")
@@ -164,6 +167,7 @@ class ElasticInferencePool:
             tool_parser=tool_parser,
             reasoning_parser=reasoning_parser,
             renderer_pool_size=renderer_pool_size,
+            renderer_keep_thinking=renderer_keep_thinking,
         )
         await pool.start()
         return pool
@@ -214,6 +218,7 @@ class ElasticInferencePool:
                     tool_parser=self.tool_parser,
                     reasoning_parser=self.reasoning_parser,
                     renderer_pool_size=self.renderer_pool_size,
+                    renderer_keep_thinking=self.renderer_keep_thinking,
                 )
                 if urls
                 else []

--- a/tests/unit/orchestrator/test_orchestrator_setup.py
+++ b/tests/unit/orchestrator/test_orchestrator_setup.py
@@ -50,6 +50,7 @@ def test_setup_rollout_inference_pool_uses_direct_renderer_client_for_local_vllm
                 tool_parser=None,
                 reasoning_parser=None,
                 pool_size=None,
+                keep_thinking=True,
             ),
         )
         rollout_client_config = SimpleNamespace(base_url=["http://localhost:8000/v1"])
@@ -79,6 +80,7 @@ def test_setup_rollout_inference_pool_uses_direct_renderer_client_for_local_vllm
             renderer="qwen3_vl",
             tool_parser=None,
             reasoning_parser=None,
+            keep_thinking=True,
         )
         setup_pool_mock.assert_awaited_once_with(
             rollout_client_config,
@@ -89,6 +91,7 @@ def test_setup_rollout_inference_pool_uses_direct_renderer_client_for_local_vllm
             tool_parser=None,
             reasoning_parser=None,
             renderer_pool_size=None,
+            renderer_keep_thinking=True,
         )
 
     asyncio.run(run())

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -156,6 +156,26 @@ def test_removed_fused_lm_head_chunk_size_field_is_rejected():
         TrainerModelConfig.model_validate({"fused_lm_head_chunk_size": "auto"})
 
 
+def test_renderer_keep_thinking_requires_renderer_client():
+    with pytest.raises(ValidationError, match="renderer.keep_thinking=True"):
+        OrchestratorConfig.model_validate({"renderer": {"keep_thinking": True}})
+
+
+def test_renderer_keep_thinking_is_accepted_with_renderer_client():
+    config = OrchestratorConfig.model_validate(
+        {
+            "use_token_client": False,
+            "use_renderer": True,
+            "renderer": {
+                "name": "nemotron3",
+                "keep_thinking": True,
+            },
+        }
+    )
+
+    assert config.renderer.keep_thinking is True
+
+
 def test_selective_activation_checkpointing_requires_custom_impl():
     with pytest.raises(ValidationError, match="Selective activation checkpointing requires model.impl='custom'"):
         TrainerModelConfig.model_validate({"impl": "hf", "ac": {"mode": "selective"}})

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -156,9 +156,10 @@ def test_removed_fused_lm_head_chunk_size_field_is_rejected():
         TrainerModelConfig.model_validate({"fused_lm_head_chunk_size": "auto"})
 
 
-def test_renderer_keep_thinking_requires_renderer_client():
-    with pytest.raises(ValidationError, match="renderer.keep_thinking=True"):
-        OrchestratorConfig.model_validate({"renderer": {"keep_thinking": True}})
+@pytest.mark.parametrize("keep_thinking", [True, False])
+def test_renderer_keep_thinking_requires_renderer_client(keep_thinking):
+    with pytest.raises(ValidationError, match="renderer.keep_thinking"):
+        OrchestratorConfig.model_validate({"renderer": {"keep_thinking": keep_thinking}})
 
 
 def test_renderer_keep_thinking_is_accepted_with_renderer_client():

--- a/tests/unit/utils/test_client.py
+++ b/tests/unit/utils/test_client.py
@@ -67,7 +67,7 @@ def test_setup_clients_assigns_renderer_and_dp_rank_headers():
     assert [client.client_type for client in clients] == ["renderer", "renderer"]
     assert [client.renderer for client in clients] == ["qwen3_vl", "qwen3_vl"]
     assert [client.renderer_model_name for client in clients] == [None, None]
-    assert [client.renderer_keep_thinking for client in clients] == [False, False]
+    assert [client.renderer_keep_thinking for client in clients] == [None, None]
     assert [client.api_base_url for client in clients] == ["http://worker-a:8000/v1"] * 2
     assert [client.extra_headers["X-data-parallel-rank"] for client in clients] == ["0", "1"]
     assert clients[0].extra_headers["X-Test"] == "test"
@@ -120,7 +120,7 @@ def test_setup_clients_preserves_chat_client_defaults():
             client_type="openai_chat_completions",
             renderer="auto",
             renderer_model_name=None,
-            renderer_keep_thinking=False,
+            renderer_keep_thinking=None,
             api_key_var="PRIME_API_KEY",
             api_base_url="http://worker-a:8000/v1",
             timeout=client_config.timeout,

--- a/tests/unit/utils/test_client.py
+++ b/tests/unit/utils/test_client.py
@@ -67,6 +67,7 @@ def test_setup_clients_assigns_renderer_and_dp_rank_headers():
     assert [client.client_type for client in clients] == ["renderer", "renderer"]
     assert [client.renderer for client in clients] == ["qwen3_vl", "qwen3_vl"]
     assert [client.renderer_model_name for client in clients] == [None, None]
+    assert [client.renderer_keep_thinking for client in clients] == [False, False]
     assert [client.api_base_url for client in clients] == ["http://worker-a:8000/v1"] * 2
     assert [client.extra_headers["X-data-parallel-rank"] for client in clients] == ["0", "1"]
     assert clients[0].extra_headers["X-Test"] == "test"
@@ -89,6 +90,22 @@ def test_setup_clients_assigns_renderer_model_name():
     assert clients[0].renderer_model_name == "Qwen/Qwen3-VL-4B-Instruct"
 
 
+def test_setup_clients_assigns_renderer_keep_thinking():
+    client_config = ClientConfig(
+        base_url=["http://worker-a:8000/v1"],
+        api_key_var="PRIME_API_KEY",
+    )
+
+    clients = setup_clients(
+        client_config,
+        client_type="renderer",
+        renderer_name="nemotron3",
+        renderer_keep_thinking=True,
+    )
+
+    assert clients[0].renderer_keep_thinking is True
+
+
 def test_setup_clients_preserves_chat_client_defaults():
     client_config = ClientConfig(
         base_url=["http://worker-a:8000/v1"],
@@ -103,6 +120,7 @@ def test_setup_clients_preserves_chat_client_defaults():
             client_type="openai_chat_completions",
             renderer="auto",
             renderer_model_name=None,
+            renderer_keep_thinking=False,
             api_key_var="PRIME_API_KEY",
             api_base_url="http://worker-a:8000/v1",
             timeout=client_config.timeout,

--- a/tests/unit/utils/test_elastic.py
+++ b/tests/unit/utils/test_elastic.py
@@ -423,6 +423,7 @@ def test_elastic_clients_preserve_renderer_model_name_when_model_name_updates():
             model_name="Qwen/Qwen3-VL-4B-Instruct",
             train_client_type="renderer",
             renderer_name="qwen3_vl",
+            renderer_keep_thinking=True,
         )
         pool._servers = {
             "10.0.0.1": MagicMock(status="ready"),
@@ -437,6 +438,7 @@ def test_elastic_clients_preserve_renderer_model_name_when_model_name_updates():
                 client_type="renderer",
                 renderer="qwen3_vl",
                 renderer_model_name="Qwen/Qwen3-VL-4B-Instruct",
+                renderer_keep_thinking=True,
                 api_key_var="PRIME_API_KEY",
                 api_base_url="http://10.0.0.1:8000/v1",
                 timeout=1200,

--- a/uv.lock
+++ b/uv.lock
@@ -2831,7 +2831,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", git = "https://github.com/huggingface/transformers.git?rev=c1c3424" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=3b77145" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=1fcfe41f3f81f796a3b400acdfe05e4d62f7d741" },
     { name = "vllm", specifier = ">=0.19.0" },
     { name = "vllm-router", marker = "platform_machine == 'x86_64' and extra == 'disagg'", url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.22/vllm_router-0.1.22-cp38-abi3-manylinux_2_28_x86_64.whl" },
     { name = "wandb", specifier = ">=0.26.1" },
@@ -3282,7 +3282,7 @@ wheels = [
 [[package]]
 name = "renderers"
 version = "0.1.0"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?subdirectory=packages%2Frenderers&rev=3b77145#3b77145e14a9bcdaf180a49e7df97dbf2d7bb150" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?subdirectory=packages%2Frenderers&rev=1fcfe41f3f81f796a3b400acdfe05e4d62f7d741#1fcfe41f3f81f796a3b400acdfe05e4d62f7d741" }
 dependencies = [
     { name = "openai-harmony", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "transformers", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -4078,7 +4078,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.13.dev8"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=3b77145#3b77145e14a9bcdaf180a49e7df97dbf2d7bb150" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=1fcfe41f3f81f796a3b400acdfe05e4d62f7d741#1fcfe41f3f81f796a3b400acdfe05e4d62f7d741" }
 dependencies = [
     { name = "aiolimiter", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "anthropic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },

--- a/uv.lock
+++ b/uv.lock
@@ -2831,7 +2831,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", git = "https://github.com/huggingface/transformers.git?rev=c1c3424" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=1fcfe41f3f81f796a3b400acdfe05e4d62f7d741" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=d57692637f2064e8f50229c7d63b565504408a35" },
     { name = "vllm", specifier = ">=0.19.0" },
     { name = "vllm-router", marker = "platform_machine == 'x86_64' and extra == 'disagg'", url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.22/vllm_router-0.1.22-cp38-abi3-manylinux_2_28_x86_64.whl" },
     { name = "wandb", specifier = ">=0.26.1" },
@@ -3282,7 +3282,7 @@ wheels = [
 [[package]]
 name = "renderers"
 version = "0.1.0"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?subdirectory=packages%2Frenderers&rev=1fcfe41f3f81f796a3b400acdfe05e4d62f7d741#1fcfe41f3f81f796a3b400acdfe05e4d62f7d741" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?subdirectory=packages%2Frenderers&rev=d57692637f2064e8f50229c7d63b565504408a35#d57692637f2064e8f50229c7d63b565504408a35" }
 dependencies = [
     { name = "openai-harmony", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "transformers", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -4078,7 +4078,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.13.dev8"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=1fcfe41f3f81f796a3b400acdfe05e4d62f7d741#1fcfe41f3f81f796a3b400acdfe05e4d62f7d741" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=d57692637f2064e8f50229c7d63b565504408a35#d57692637f2064e8f50229c7d63b565504408a35" }
 dependencies = [
     { name = "aiolimiter", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "anthropic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },

--- a/uv.lock
+++ b/uv.lock
@@ -2831,7 +2831,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", git = "https://github.com/huggingface/transformers.git?rev=c1c3424" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=d57692637f2064e8f50229c7d63b565504408a35" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=350c1604e8a944cc9c84d0bae72fecba1fd62f1c" },
     { name = "vllm", specifier = ">=0.19.0" },
     { name = "vllm-router", marker = "platform_machine == 'x86_64' and extra == 'disagg'", url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.22/vllm_router-0.1.22-cp38-abi3-manylinux_2_28_x86_64.whl" },
     { name = "wandb", specifier = ">=0.26.1" },
@@ -3282,7 +3282,7 @@ wheels = [
 [[package]]
 name = "renderers"
 version = "0.1.0"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?subdirectory=packages%2Frenderers&rev=d57692637f2064e8f50229c7d63b565504408a35#d57692637f2064e8f50229c7d63b565504408a35" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?subdirectory=packages%2Frenderers&rev=350c1604e8a944cc9c84d0bae72fecba1fd62f1c#350c1604e8a944cc9c84d0bae72fecba1fd62f1c" }
 dependencies = [
     { name = "openai-harmony", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "transformers", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -4078,7 +4078,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.13.dev8"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=d57692637f2064e8f50229c7d63b565504408a35#d57692637f2064e8f50229c7d63b565504408a35" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=350c1604e8a944cc9c84d0bae72fecba1fd62f1c#350c1604e8a944cc9c84d0bae72fecba1fd62f1c" }
 dependencies = [
     { name = "aiolimiter", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "anthropic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },


### PR DESCRIPTION
## Summary
- Add `orchestrator.renderer.keep_thinking` as the generic prime-rl config knob.
- Preserve renderer defaults when the TOML key is omitted, pass `true` to force keeping historical reasoning, and pass `false` to force disabling it.
- Pass the tri-state value into local renderer construction and through static/elastic renderer client setup.
- Update the pinned `verifiers`/`renderers` git rev to PrimeIntellect-ai/verifiers#1281 so `vf.ClientConfig.renderer_keep_thinking` and renderer factory support are available.

## Usage
```toml
[orchestrator.renderer]
name = "nemotron3"
keep_thinking = true
```

To explicitly disable a keep-thinking renderer alias:
```toml
[orchestrator.renderer]
name = "qwen3-keep-thinking"
keep_thinking = false
```

Omitting `keep_thinking` uses the selected renderer's default. This avoids model-name aliases like `nemotron3_keep_thinking`; the renderer name stays the actual renderer, and the historical-reasoning behavior is configured independently.

## Dependency
Depends on PrimeIntellect-ai/verifiers#1281. If that PR is merged and GitHub creates a different merge SHA, the `verifiers` pin can be moved to the merged upstream commit before merging this PR.

## Tests
- `uv sync --all-extras`
- `uv run pytest tests/unit/test_configs.py -k 'renderer_keep_thinking' tests/unit/orchestrator/test_orchestrator_setup.py tests/unit/utils/test_client.py tests/unit/utils/test_elastic.py -k 'renderer or elastic_clients_preserve_renderer_model_name or renderer_keep_thinking'`
- `uv run ruff check pyproject.toml src/prime_rl/configs/shared.py src/prime_rl/configs/orchestrator.py src/prime_rl/orchestrator/orchestrator.py src/prime_rl/utils/client.py src/prime_rl/utils/elastic.py tests/unit/test_configs.py tests/unit/orchestrator/test_orchestrator_setup.py tests/unit/utils/test_client.py tests/unit/utils/test_elastic.py`
- `uv run ruff format --check src/prime_rl/configs/shared.py src/prime_rl/configs/orchestrator.py src/prime_rl/orchestrator/orchestrator.py src/prime_rl/utils/client.py src/prime_rl/utils/elastic.py tests/unit/test_configs.py tests/unit/orchestrator/test_orchestrator_setup.py tests/unit/utils/test_client.py tests/unit/utils/test_elastic.py`
- `git diff --check`
- `uv lock --locked`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes renderer client configuration plumbing and modifies inference `/v1/generate` error handling and scheduler I/O (new JSONL dumps), which can affect rollout behavior and server responses under load.
> 
> **Overview**
> Adds a tri-state `orchestrator.renderer.keep_thinking` config knob and threads it through renderer creation and both static/elastic inference client setup (`renderer_keep_thinking`), while validating it is only set when `use_renderer=true`.
> 
> Hardens vLLM’s `/v1/generate` path by detecting non-finite logprob values before JSON serialization and returning a structured `ErrorResponse` (400) that the server now propagates with the correct status code.
> 
> Improves rollout debuggability by appending per-attempt rollout/exception records (with metadata) to `train_rollout_attempts.jsonl`, and updates SLURM templates to set `TRITON_CACHE_DIR` plus default `VLLM_COMPUTE_NANS_IN_LOGITS=1`; also bumps the pinned `verifiers`/`renderers` git rev to pick up required support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d318adf58578b1c8299b1dff0ffb9507eca4cd3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->