### PR TITLE
Fp8 layerwise

### DIFF
--- a/src/prime_rl/configs/orchestrator.py
+++ b/src/prime_rl/configs/orchestrator.py
@@ -811,6 +811,10 @@ class NCCLWeightBroadcastConfig(BaseModel):
         bool,
         Field(description="Use kernel-format FP8 quantized NCCL transfer for weight updates."),
     ] = False
+    quant_scheme: Annotated[
+        Literal["fp8_blockwise", "fp8_channelwise"] | None,
+        Field(description="Quantization scheme for layerwise reload. Auto-detected from inference model."),
+    ] = None
 
     inference_world_size: Annotated[
         int,

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -651,18 +651,38 @@ class RLConfig(BaseConfig):
 
         return self
 
+    def _resolve_quant_scheme(self) -> Literal["fp8_blockwise", "fp8_channelwise"] | None:
+        """Auto-detect quantization scheme when inference model differs from trainer."""
+        if self.weight_broadcast.quantize_in_weight_transfer:
+            return None
+
+        inference_model = self.inference.model.name if self.inference else self.model.name
+        if inference_model == self.model.name:
+            return None
+
+        from prime_rl.trainer.models.fp8_dispatch import detect_quant_scheme
+
+        result = detect_quant_scheme(inference_model)
+        if result is None:
+            return None
+        return result[0]
+
     @model_validator(mode="after")
     def auto_setup_weight_broadcast(self):
         """Auto-setup shared weight broadcast config for trainer, orchestrator, and inference."""
         if self.weight_broadcast is not None:
             if self.weight_broadcast.type == "nccl":
                 inference_world_size = self.inference.parallel.dp * self.inference.parallel.tp if self.inference else 1
+                quant_scheme = self._resolve_quant_scheme()
+                inference_model_name = self.inference.model.name if self.inference else ""
                 self.trainer.weight_broadcast = TrainerNCCLWeightBroadcastConfig(
                     type=self.weight_broadcast.type,
                     inference_world_size=inference_world_size,
                     port=self.weight_broadcast.port,
                     timeout=self.weight_broadcast.timeout,
                     quantize_in_weight_transfer=self.weight_broadcast.quantize_in_weight_transfer,
+                    quant_scheme=quant_scheme,
+                    inference_model_name=inference_model_name if quant_scheme else "",
                 )
                 self.orchestrator.weight_broadcast = OrchestratorNCCLWeightBroadcastConfig(
                     type=self.weight_broadcast.type,
@@ -670,6 +690,7 @@ class RLConfig(BaseConfig):
                     timeout=self.weight_broadcast.timeout,
                     inference_world_size=inference_world_size,
                     quantize_in_weight_transfer=self.weight_broadcast.quantize_in_weight_transfer,
+                    quant_scheme=quant_scheme,
                 )
             elif self.weight_broadcast.type == "filesystem":
                 self.trainer.weight_broadcast = TrainerFileSystemWeightBroadcastConfig()

--- a/src/prime_rl/configs/trainer.py
+++ b/src/prime_rl/configs/trainer.py
@@ -727,6 +727,13 @@ class NCCLWeightBroadcastConfig(BaseWeightBroadcastConfig):
             ),
         ),
     ] = False
+    quant_scheme: Annotated[
+        Literal["fp8_blockwise", "fp8_channelwise"] | None,
+        Field(description="Quantization scheme for layerwise reload. Auto-detected from inference model."),
+    ] = None
+    inference_model_name: Annotated[
+        str, Field(description="Inference model name for quantization details. Auto-set.")
+    ] = ""
 
 
 WeightBroadcastConfig: TypeAlias = Annotated[

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -1114,3 +1114,36 @@ def monkey_patch_layerwise_reload_spurious_warnings():
 
     layerwise.finalize_layerwise_processing = _patched_finalize
     layerwise.finalize_layerwise_reload = _patched_finalize
+
+    _patch_layerwise_skip_tensors()
+
+
+def _patch_layerwise_skip_tensors():
+    """Skip expert-map and bias tensors during layerwise reload weight-loader wrapping.
+
+    Without this, initialize_online_processing wraps weight_loaders on tensors
+    like _expert_map and e_score_correction_bias, causing OOM when they are
+    materialized from meta device during reload.
+
+    Upstream: https://github.com/vllm-project/vllm/pull/38746
+    Remove this patch once we upgrade to vLLM >= 0.20.
+    """
+    from vllm.model_executor.model_loader.reload import layerwise, meta
+    from vllm.model_executor.model_loader.reload.utils import get_layer_tensors
+
+    meta.SKIP_TENSORS.add("e_score_correction_bias")
+
+    def _patched_init_online(layer):
+        info = layerwise.get_layerwise_info(layer)
+        from vllm.model_executor.model_loader.reload.utils import get_layer_size
+
+        info.load_numel = 0
+        info.load_numel_total = get_layer_size(layer)
+
+        for name, tensor in get_layer_tensors(layer).items():
+            if name in meta.SKIP_TENSORS:
+                continue
+            if layerwise._get_weight_loader(tensor).__name__ != "online_process_loader":
+                tensor.weight_loader = layerwise.make_online_process_loader(layer, name)
+
+    layerwise.initialize_online_processing = _patched_init_online

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -18,6 +18,7 @@ def transformers_v5_compat():
     monkey_patch_deep_gemm_ep_scatter()
     monkey_patch_dp_engine_core_pause_resume_deadlock()
     monkey_patch_offloading_connector_cpu_block_count()
+    monkey_patch_layerwise_reload_spurious_warnings()
 
 
 @triton.jit
@@ -1086,3 +1087,30 @@ def monkey_patch_no_moe_lora():
         self.is_lora_enabled = False
 
     FusedMoEConfig.__post_init__ = _patched__post_init__
+
+
+def monkey_patch_layerwise_reload_spurious_warnings():
+    """Suppress spurious "Failed to load weights" warnings for container modules.
+
+    Container modules (ModuleList, Qwen3Attention, Qwen2MLP, etc.) have no
+    direct parameters, so load_numel stays at 0 during layerwise reload.
+    vLLM 0.19 warns unconditionally when kernel_tensors is not None, even
+    though the empty-dict ({}, {}) case is harmless.
+
+    Fixed upstream in vllm-project/vllm#38032 (commit 648edcf) by tightening
+    the condition to `load_numel_total > 0`. Remove this patch once we
+    upgrade to vLLM >= 0.20.
+    """
+    from vllm.model_executor.model_loader.reload import layerwise
+
+    _original_finalize = layerwise.finalize_layerwise_processing
+
+    def _patched_finalize(model, model_config):
+        for layer in model.modules():
+            info = layerwise.get_layerwise_info(layer)
+            if info.kernel_tensors is not None and info.load_numel_total == 0:
+                info.kernel_tensors = None
+        _original_finalize(model, model_config)
+
+    layerwise.finalize_layerwise_processing = _patched_finalize
+    layerwise.finalize_layerwise_reload = _patched_finalize

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -288,9 +288,10 @@ async def init_broadcaster(request: Request):
     rank_offset = data.get("rank_offset")
     inference_world_size = data.get("inference_world_size")
     quantize_in_weight_transfer = data.get("quantize_in_weight_transfer", False)
+    quant_scheme = data.get("quant_scheme")
     await engine_client(request).collective_rpc(
         "init_broadcaster",
-        args=(host, port, rank_offset, inference_world_size, timeout, quantize_in_weight_transfer),
+        args=(host, port, rank_offset, inference_world_size, timeout, quantize_in_weight_transfer, quant_scheme),
     )
     return {"status": "ok"}
 

--- a/src/prime_rl/inference/vllm/worker/nccl.py
+++ b/src/prime_rl/inference/vllm/worker/nccl.py
@@ -101,6 +101,7 @@ class NCCLWeightUpdateWorker(Worker):
         inference_world_size: int,
         timeout: int,
         quantize_in_weight_transfer: bool = False,
+        quant_scheme: str | None = None,
     ) -> None:
         """Initialize the NCCL broadcast receiver.
 
@@ -109,6 +110,7 @@ class NCCLWeightUpdateWorker(Worker):
             inference_world_size: Total number of inference GPUs across all servers.
         """
         self.quantize_in_weight_transfer = quantize_in_weight_transfer
+        self.use_layerwise_reload = quant_scheme is not None
         # Use the worker's device index directly as the local rank.
         # The previous dp_group-based computation broke in vLLM v1 multiprocess
         # DP mode where each worker is a separate process with a singleton
@@ -145,14 +147,20 @@ class NCCLWeightUpdateWorker(Worker):
 
         state_iter = self.nccl_broadcast_receiver.receive_state_dict()
         device = next(model.parameters()).device
-        loader_fn: Callable[[Module, Generator[tuple[str, torch.Tensor], None, None]], None]
-        postprocess_fn: Callable[[Module, object, torch.device], None]
-        if self.quantize_in_weight_transfer:
-            loader_fn = load_weights_kernel
-            postprocess_fn = postprocess_weights_kernel
-        else:
-            loader_fn = load_weights_checkpoint
-            postprocess_fn = postprocess_weights_checkpoint
 
-        loader_fn(model, state_iter)
-        postprocess_fn(model, self.model_runner.model_config, device)
+        if self.use_layerwise_reload:
+            from vllm.model_executor.model_loader.reload import (
+                finalize_layerwise_reload,
+                initialize_layerwise_reload,
+            )
+
+            with torch.device(device):
+                initialize_layerwise_reload(model)
+                load_weights_checkpoint(model, state_iter)
+                finalize_layerwise_reload(model, self.model_runner.model_config)
+        elif self.quantize_in_weight_transfer:
+            load_weights_kernel(model, state_iter)
+            postprocess_weights_kernel(model, self.model_runner.model_config, device)
+        else:
+            load_weights_checkpoint(model, state_iter)
+            postprocess_weights_checkpoint(model, self.model_runner.model_config, device)

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -279,6 +279,7 @@ async def orchestrate(config: OrchestratorConfig):
                 config.weight_broadcast.timeout,
                 inference_world_size=config.weight_broadcast.inference_world_size,
                 quantize_in_weight_transfer=config.weight_broadcast.quantize_in_weight_transfer,
+                quant_scheme=config.weight_broadcast.quant_scheme,
             )
     else:
         logger.info("Skipping weight broadcast initialization (SFT distillation mode)")

--- a/src/prime_rl/trainer/models/fp8.py
+++ b/src/prime_rl/trainer/models/fp8.py
@@ -37,3 +37,15 @@ def quantize_to_fp8_blockwise(weight: Tensor, block_size: int = 128) -> tuple[Te
 
     quantized = blocks_fp8.permute(0, 2, 1, 3).reshape(padded_rows, padded_cols)[:rows, :cols].contiguous()
     return quantized, scales.float().contiguous()
+
+
+def quantize_to_fp8_channelwise(weight: Tensor) -> tuple[Tensor, Tensor]:
+    """Quantize a 2D tensor to FP8 e4m3 with per-row (channel-wise) scales."""
+    if weight.ndim != 2:
+        raise ValueError(f"FP8 quantization expects a 2D tensor, got shape={tuple(weight.shape)}")
+
+    fp8_max = torch.finfo(torch.float8_e4m3fn).max
+    row_max = weight.float().abs().amax(dim=1, keepdim=True)
+    scales = (row_max / fp8_max).clamp(min=1e-12)
+    quantized = (weight.float() / scales).clamp(-fp8_max, fp8_max).to(torch.float8_e4m3fn)
+    return quantized.contiguous(), scales.float().contiguous()

--- a/src/prime_rl/trainer/models/fp8_dispatch.py
+++ b/src/prime_rl/trainer/models/fp8_dispatch.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from typing import Literal, Protocol
+
+import torch
+from torch import Tensor
+
+from prime_rl.trainer.models.fp8 import quantize_to_fp8_blockwise, quantize_to_fp8_channelwise
+
+QuantSchemeName = Literal["fp8_blockwise", "fp8_channelwise"]
+
+
+class QuantScheme(Protocol):
+    scale_name_suffix: str
+    scale_dtype: torch.dtype
+    modules_to_not_convert: list[str]
+
+    def quantize(self, weight: Tensor) -> tuple[Tensor, Tensor]: ...
+
+
+class FP8BlockwiseQuantScheme:
+    scale_name_suffix = "weight_scale_inv"
+    scale_dtype = torch.float32
+
+    def __init__(self, block_size: int = 128, modules_to_not_convert: list[str] | None = None):
+        self.block_size = block_size
+        self.modules_to_not_convert = modules_to_not_convert or []
+
+    def quantize(self, weight: Tensor) -> tuple[Tensor, Tensor]:
+        return quantize_to_fp8_blockwise(weight, self.block_size)
+
+
+class FP8ChannelwiseQuantScheme:
+    scale_name_suffix = "weight_scale"
+    scale_dtype = torch.float32
+
+    def __init__(self, modules_to_not_convert: list[str] | None = None):
+        self.modules_to_not_convert = modules_to_not_convert or []
+
+    def quantize(self, weight: Tensor) -> tuple[Tensor, Tensor]:
+        return quantize_to_fp8_channelwise(weight)
+
+
+def detect_quant_scheme(target_model: str) -> tuple[QuantSchemeName, QuantScheme] | None:
+    """Parse quantization_config from a HF model; return (name, scheme) or None."""
+    from transformers import AutoConfig
+
+    config = AutoConfig.from_pretrained(target_model, trust_remote_code=True)
+    qconfig = getattr(config, "quantization_config", None)
+    if qconfig is None:
+        return None
+
+    qconfig = qconfig if isinstance(qconfig, dict) else qconfig.to_dict()
+    quant_method = qconfig.get("quant_method", "")
+
+    if quant_method == "fp8":
+        block_size = qconfig.get("weight_block_size")
+        skip = qconfig.get("modules_to_not_convert") or qconfig.get("ignored_layers") or []
+        if block_size:
+            return "fp8_blockwise", FP8BlockwiseQuantScheme(block_size[0], skip)
+        return "fp8_channelwise", FP8ChannelwiseQuantScheme(skip)
+
+    if quant_method == "compressed-tensors":
+        ignore = qconfig.get("ignore") or []
+        for group in qconfig.get("config_groups", {}).values():
+            weights = group.get("weights", {})
+            strategy = weights.get("strategy", "tensor")
+            block_structure = weights.get("block_structure")
+            if strategy == "block" or block_structure:
+                bs = block_structure[0] if block_structure else 128
+                return "fp8_blockwise", FP8BlockwiseQuantScheme(bs, ignore)
+            return "fp8_channelwise", FP8ChannelwiseQuantScheme(ignore)
+
+    return None
+
+
+def get_quant_scheme(name: QuantSchemeName) -> QuantScheme:
+    """Translate a scheme name string to a QuantScheme instance."""
+    if name == "fp8_blockwise":
+        return FP8BlockwiseQuantScheme()
+    if name == "fp8_channelwise":
+        return FP8ChannelwiseQuantScheme()
+    raise ValueError(f"Unknown quant scheme: {name}")
+
+
+def _expand_fused_moe_experts(layer_state_dict: dict[str, Tensor]) -> dict[str, Tensor]:
+    """Expand fused 3D MoE expert tensors to per-expert 2D (HF checkpoint format).
+
+    Transformers 5.x stores experts as fused 3D:
+      experts.gate_up_proj: (num_experts, 2*intermediate, hidden)
+      experts.down_proj:    (num_experts, hidden, intermediate)
+
+    HF checkpoints and VLLM load_weights expect per-expert 2D:
+      experts.{j}.gate_proj.weight: (intermediate, hidden)
+      experts.{j}.up_proj.weight:   (intermediate, hidden)
+      experts.{j}.down_proj.weight: (hidden, intermediate)
+    """
+    expanded: dict[str, Tensor] = {}
+    for name, tensor in layer_state_dict.items():
+        if tensor.ndim == 3 and ".mlp.experts." in name:
+            base = name.rsplit(".", 1)[0]
+            suffix = name.rsplit(".", 1)[1]
+
+            if suffix == "gate_up_proj":
+                gates, ups = tensor.chunk(2, dim=1)
+                for j, (gate, up) in enumerate(zip(gates, ups)):
+                    expanded[f"{base}.{j}.gate_proj.weight"] = gate
+                    expanded[f"{base}.{j}.up_proj.weight"] = up
+            elif suffix == "down_proj":
+                for j, down in enumerate(tensor):
+                    expanded[f"{base}.{j}.down_proj.weight"] = down
+            else:
+                expanded[name] = tensor
+        else:
+            expanded[name] = tensor
+    return expanded
+
+
+def quantize_layer_for_scheme(layer_state_dict: dict[str, Tensor], scheme: QuantScheme) -> dict[str, Tensor]:
+    """Quantize 2D tensors in a layer state dict according to the scheme."""
+    layer_state_dict = _expand_fused_moe_experts(layer_state_dict)
+    quantized: dict[str, Tensor] = {}
+    for name, tensor in layer_state_dict.items():
+        should_skip = any(skip in name for skip in scheme.modules_to_not_convert)
+        if tensor.ndim == 2 and not should_skip:
+            fp8_weight, scale = scheme.quantize(tensor)
+            quantized[name] = fp8_weight
+            quantized[name.removesuffix(".weight") + f".{scheme.scale_name_suffix}"] = scale.to(scheme.scale_dtype)
+        else:
+            quantized[name] = tensor
+    return quantized

--- a/src/prime_rl/trainer/rl/broadcast/nccl.py
+++ b/src/prime_rl/trainer/rl/broadcast/nccl.py
@@ -1,7 +1,7 @@
 import pickle
 import time
 from pathlib import Path
-from typing import Callable, Generator, cast
+from typing import Generator, cast
 
 import torch
 import torch.nn as nn
@@ -12,6 +12,7 @@ from vllm.distributed.utils import StatelessProcessGroup
 
 from prime_rl.configs.trainer import NCCLWeightBroadcastConfig
 from prime_rl.trainer.models import PreTrainedModelPrimeRL
+from prime_rl.trainer.models.fp8_dispatch import quantize_layer_for_scheme
 from prime_rl.trainer.rl.broadcast.base import WeightBroadcast
 from prime_rl.trainer.runs import get_multi_run_manager
 from prime_rl.trainer.utils import get_world
@@ -109,6 +110,19 @@ def preprocess_layer_quantized(
     return model.convert_layer_to_vllm_kernel(layer_state_dict, layer_idx, quantize_fp8=True)
 
 
+def preprocess_layer_layerwise_quantize(
+    model: nn.Module,
+    layer_state_dict: dict[str, Tensor],
+    layer_idx: int,
+    scheme=None,
+) -> dict[str, Tensor]:
+    """Convert to HF checkpoint format with FP8 quantization matching the inference model."""
+    layer_state_dict = preprocess_layer_checkpoint(model, layer_state_dict, layer_idx)
+    if layer_idx < 0 or scheme is None:
+        return layer_state_dict
+    return quantize_layer_for_scheme(layer_state_dict, scheme)
+
+
 class NCCLWeightBroadcastSender:
     def __init__(
         self,
@@ -120,11 +134,23 @@ class NCCLWeightBroadcastSender:
         timeout: int,
         dtype: torch.dtype = torch.bfloat16,
         quantize_in_weight_transfer: bool = False,
+        inference_model_name: str = "",
     ):
         self.logger = get_logger()
         self.world = get_world()
         self.dtype = dtype
         self.quantize_in_weight_transfer = quantize_in_weight_transfer
+        self.quant_scheme = None
+        if inference_model_name and not quantize_in_weight_transfer:
+            from prime_rl.trainer.models.fp8_dispatch import detect_quant_scheme
+
+            result = detect_quant_scheme(inference_model_name)
+            if result is not None:
+                self.quant_scheme = result[1]
+                self.logger.info(
+                    f"Layerwise quantize: {result[0]}, "
+                    f"skip {len(self.quant_scheme.modules_to_not_convert)} modules"
+                )
 
         if self.world.is_master:
             disable_nccl_p2p_if_unavailable()
@@ -149,9 +175,13 @@ class NCCLWeightBroadcastSender:
             broadcast_integer(num_state_dict_to_send, self.communicator)
 
         self.logger.debug(f"Broadcasting {num_state_dict_to_send} layer state dicts")
-        preprocess_fn: Callable[[nn.Module, dict[str, Tensor], int], dict[str, Tensor]]
         if self.quantize_in_weight_transfer:
             preprocess_fn = preprocess_layer_quantized
+        elif self.quant_scheme is not None:
+            scheme = self.quant_scheme
+
+            def preprocess_fn(m: nn.Module, sd: dict[str, Tensor], idx: int) -> dict[str, Tensor]:
+                return preprocess_layer_layerwise_quantize(m, sd, idx, scheme=scheme)
         else:
             preprocess_fn = preprocess_layer_checkpoint
 
@@ -191,6 +221,7 @@ class NCCLWeightBroadcast(WeightBroadcast):
             config.timeout,
             dtype,
             quantize_in_weight_transfer=config.quantize_in_weight_transfer,
+            inference_model_name=config.inference_model_name,
         )
 
     @torch.no_grad()

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -429,6 +429,7 @@ async def init_nccl_broadcast(
     timeout: int,
     inference_world_size: int | None = None,
     quantize_in_weight_transfer: bool = False,
+    quant_scheme: str | None = None,
 ) -> None:
     """Initialize NCCL broadcast on all inference servers.
 
@@ -462,6 +463,7 @@ async def init_nccl_broadcast(
                     "inference_world_size": inference_world_size,
                     "timeout": timeout,
                     "quantize_in_weight_transfer": quantize_in_weight_transfer,
+                    "quant_scheme": quant_scheme,
                 },
             )
             response.raise_for_status()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the NCCL weight-broadcast/update path across trainer, orchestrator, and vLLM workers, including new FP8 quantization logic and monkeypatching vLLM reload internals; mistakes could cause incorrect weights, OOMs, or failed updates during training.
> 
> **Overview**
> Enables **FP8 “layerwise” weight updates** when the inference model differs from the trainer, by auto-detecting a `quant_scheme` (`fp8_blockwise`/`fp8_channelwise`) from the inference model config and propagating it through shared `weight_broadcast` configs and the `/init_broadcaster` RPC.
> 
> On the trainer side, adds a new FP8 dispatch module (`fp8_dispatch.py`) and channelwise quantization, then uses these to optionally quantize each layer into HF-checkpoint format before NCCL broadcast. On the inference side, the NCCL worker can now switch between kernel-quantized loads, checkpoint loads, or **vLLM layerwise reload** flow, and adds vLLM monkeypatches to suppress layerwise-reload warning spam and skip problematic tensors to avoid meta-materialization OOMs (pending vLLM >= 0.20).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e9df4e2a6cefb1e7c4a95736b70c859c41bf3ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->