### PR TITLE
fix(ring_attn): make FA3 causal/window_size kwargs version-agnostic

### DIFF
--- a/src/prime_rl/trainer/models/layers/ring_attn.py
+++ b/src/prime_rl/trainer/models/layers/ring_attn.py
@@ -5,6 +5,19 @@ import torch.distributed as dist
 from ring_flash_attn.utils import AllGatherComm, get_default_args
 
 
+def _set_fa3_signature_params(params: dict, causal: bool, window_size: tuple[int, int]) -> None:
+    if "is_causal" in params:
+        params["is_causal"] = causal
+    else:
+        params["causal"] = causal
+
+    if "window_size" in params:
+        params["window_size"] = window_size
+    else:
+        params["window_size_left"] = window_size[0]
+        params["window_size_right"] = window_size[1]
+
+
 def _fa3_varlen_forward(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -30,11 +43,9 @@ def _fa3_varlen_forward(
             "max_seqlen_q": max_seqlen_q,
             "max_seqlen_k": max_seqlen_k,
             "softmax_scale": softmax_scale,
-            "is_causal": causal,
-            "window_size_left": window_size[0],
-            "window_size_right": window_size[1],
         }
     )
+    _set_fa3_signature_params(params, causal, window_size)
     out, lse, _, _ = _flash_attn_forward(**params)
     return out, lse
 
@@ -76,11 +87,9 @@ def _fa3_varlen_backward(
             "dk": dk,
             "dv": dv,
             "softmax_scale": softmax_scale,
-            "is_causal": causal,
-            "window_size_left": window_size[0],
-            "window_size_right": window_size[1],
         }
     )
+    _set_fa3_signature_params(params, causal, window_size)
     _flash_attn_backward(**params)
 
 


### PR DESCRIPTION
 _flash_attn_forward uses causal, _flash_attn_backward uses is_causal — two different names in the same FA3 package. The old code hardcoded is_causal
   for both, which blew up on forward because get_default_args() already had causal in the defaults, so both keys ended up in the dict (35 args
  instead of 34). Only hits when cp>1 since that's the only path through ring attention.                                                              
   
  Fix: a small helper that checks which key is actually in the defaults dict and sets that one, instead of hardcoding. 

<img width="2352" height="151" alt="image" src="https://github.com/user-attachments/assets/72b5ecb8-6ace-4d8d-ab90-24e728cb9cd6" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the FA3 ring-attention kernel invocation path; although small, incorrect kwarg selection would break or subtly change attention behavior in distributed runs.
> 
> **Overview**
> Makes FA3 ring-attention calls resilient to flash-attn v3 signature differences by centralizing how `causal`/`is_causal` and `window_size` vs `window_size_left`/`window_size_right` kwargs are populated.
> 
> Both `_fa3_varlen_forward` and `_fa3_varlen_backward` now derive the correct parameter names from `get_default_args()` to avoid passing duplicate/invalid kwargs when running ring attention (e.g., `cp>1`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5aa595b2979cf76f2d8ae03ece728cc3d1416a8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->