### PR TITLE
feat(k8s): minimal kubectl launcher mirroring slurm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,3 +199,4 @@ debug_I2_zero_band
 .idea
 
 outputs/
+k8s-runs/

--- a/examples/reverse_text/k8s_rl.toml
+++ b/examples/reverse_text/k8s_rl.toml
@@ -1,0 +1,18 @@
+# Usage: uv run rl @ examples/reverse_text/rl.toml @ examples/reverse_text/k8s_rl.toml
+# Renders manifests to ./k8s-runs/reverse-text-rl/rl.k8s.yaml and `kubectl apply`.
+output_dir = "/data/runs/reverse-text-rl"
+
+[deployment]
+type = "multi_node"
+num_train_nodes = 1
+num_infer_nodes = 1
+num_infer_replicas = 1
+gpus_per_node = 1
+
+[k8s]
+job_name = "reverse-text-rl"
+namespace = "default"
+image = "primeintellect/prime-rl:main"
+storage_class = "nfs"
+storage_size = "100Gi"
+# secret_name = "prime-rl-secrets"  # optional: kubectl create secret generic prime-rl-secrets --from-literal=wandb-api-key=... --from-literal=hf-token=...

--- a/src/prime_rl/configs/rl.py
+++ b/src/prime_rl/configs/rl.py
@@ -18,6 +18,7 @@ from prime_rl.configs.orchestrator import (
     OrchestratorConfig,
 )
 from prime_rl.configs.shared import (
+    K8sConfig,
     SlurmConfig,
     VLMConfig,
     WandbConfig,
@@ -358,6 +359,10 @@ class RLConfig(BaseConfig):
 
     slurm: Annotated[SlurmConfig | None, Field(description="SLURM configuration. If None, will run locally.")] = None
 
+    k8s: Annotated[K8sConfig | None, Field(description="Kubernetes configuration. Mutually exclusive with slurm.")] = (
+        None
+    )
+
     dry_run: Annotated[bool, Field(description="Only validate and dump resolved configs and exit early.")] = False
 
     experimental: Annotated[
@@ -370,8 +375,8 @@ class RLConfig(BaseConfig):
     @model_validator(mode="after")
     def validate_deployment(self):
         if self.deployment.type == "multi_node":
-            if self.slurm is None:
-                raise ValueError("Must use SLURM for multi-node deployment.")
+            if self.slurm is None and self.k8s is None:
+                raise ValueError("Must use SLURM or k8s for multi-node deployment.")
             if self.deployment.num_infer_nodes > 0 and not self.inference:
                 raise ValueError("Must configure inference when using multi-node deployment with inference nodes.")
             if self.deployment.num_infer_nodes == 0 and self.inference:
@@ -964,6 +969,20 @@ class RLConfig(BaseConfig):
                 self.slurm.template_path = templates_dir / "single_node_rl.sbatch.j2"
             else:
                 self.slurm.template_path = templates_dir / "multi_node_rl.sbatch.j2"
+        return self
+
+    @model_validator(mode="after")
+    def auto_setup_k8s_template(self):
+        if self.k8s is not None and self.k8s.template_path is None:
+            import prime_rl
+
+            self.k8s.template_path = Path(prime_rl.__file__).parent / "templates" / "rl.k8s.yaml.j2"
+        return self
+
+    @model_validator(mode="after")
+    def slurm_xor_k8s(self):
+        if self.slurm is not None and self.k8s is not None:
+            raise ValueError("Set either [slurm] or [k8s], not both.")
         return self
 
     ### Warnings

--- a/src/prime_rl/configs/shared.py
+++ b/src/prime_rl/configs/shared.py
@@ -78,6 +78,80 @@ class SlurmConfig(BaseConfig):
         return self
 
 
+class K8sConfig(BaseConfig):
+    """Configures Kubernetes deployment. Mirrors SlurmConfig: the launcher
+    writes per-component TOMLs and renders a Jinja manifest with a ConfigMap
+    holding those TOMLs and StatefulSets that mount it at /etc/prime-rl/configs.
+    """
+
+    job_name: Annotated[
+        str, Field(description="Used to name all resources (StatefulSets, Services, ConfigMap, PVC).")
+    ] = "prime-rl"
+
+    namespace: Annotated[str, Field(description="Kubernetes namespace to deploy into.")] = "default"
+
+    image: Annotated[
+        str, Field(description="Container image with prime-rl pre-installed (e.g. primeintellect/prime-rl:main).")
+    ]
+
+    image_pull_policy: Annotated[
+        Literal["Always", "IfNotPresent", "Never"], Field(description="imagePullPolicy for all pods.")
+    ] = "IfNotPresent"
+
+    template_path: Annotated[
+        Path | None,
+        Field(description="Path to the k8s manifest Jinja template. If None, uses the default bundled template."),
+    ] = None
+
+    storage_class: Annotated[
+        str, Field(description="StorageClass for the outputs PVC. Must support ReadWriteMany.")
+    ] = "nfs"
+
+    storage_size: Annotated[str, Field(description="Size of the outputs PVC.")] = "100Gi"
+
+    output_mount: Annotated[
+        Path,
+        Field(description="In-pod mount path for the outputs PVC. The TOML output_dir must live under this path."),
+    ] = Path("/data")
+
+    local_output_dir: Annotated[
+        Path,
+        Field(description="Launcher-local directory where the rendered manifest and intermediate TOMLs are written."),
+    ] = Path("./k8s-runs")
+
+    gpu_runtime_class: Annotated[
+        str | None, Field(description="runtimeClassName for GPU pods (e.g. 'nvidia'). None to omit.")
+    ] = "nvidia"
+
+    secret_name: Annotated[
+        str | None,
+        Field(
+            description="Optional Secret holding wandb-api-key and hf-token; injected as WANDB_API_KEY and HF_TOKEN."
+        ),
+    ] = None
+
+    node_selector: Annotated[dict[str, str], Field(description="nodeSelector applied to all StatefulSets.")] = {}
+
+    submit: Annotated[Literal["kubectl", "dry"], Field(description="'kubectl' to apply, 'dry' to render only.")] = (
+        "kubectl"
+    )
+
+    @property
+    def template_vars(self) -> dict:
+        return {
+            "job_name": self.job_name,
+            "namespace": self.namespace,
+            "image": self.image,
+            "image_pull_policy": self.image_pull_policy,
+            "storage_class": self.storage_class,
+            "storage_size": self.storage_size,
+            "output_mount": str(self.output_mount),
+            "gpu_runtime_class": self.gpu_runtime_class,
+            "secret_name": self.secret_name,
+            "node_selector": self.node_selector,
+        }
+
+
 ServerType = Literal["vllm", "openai"]
 
 

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -31,6 +31,7 @@ from prime_rl.utils.utils import (
 
 RL_TOML = "rl.toml"
 RL_SBATCH = "rl.sbatch"
+RL_K8S_YAML = "rl.k8s.yaml"
 
 TRAINER_TOML = "trainer.toml"
 ORCHESTRATOR_TOML = "orchestrator.toml"
@@ -478,6 +479,93 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
     script_path.write_text(script)
 
 
+def _build_infer_urls(job_name: str, namespace: str, num_replicas: int, port: int) -> str:
+    return ",".join(
+        f"http://{job_name}-inference-{i}.{job_name}-inference-headless.{namespace}.svc.cluster.local:{port}/v1"
+        for i in range(num_replicas)
+    )
+
+
+def write_k8s_manifest(config: RLConfig, config_dir: Path, manifest_path: Path) -> None:
+    """Render the k8s manifest from rendered TOML subconfigs."""
+    from jinja2 import Environment, FileSystemLoader
+
+    assert config.k8s is not None
+    assert config.k8s.template_path is not None
+    assert config.deployment.type == "multi_node", "k8s currently supports multi_node deployments only"
+
+    configs = {
+        TRAINER_TOML: (config_dir / TRAINER_TOML).read_text(),
+        ORCHESTRATOR_TOML: (config_dir / ORCHESTRATOR_TOML).read_text(),
+    }
+    if config.inference is not None:
+        configs[INFERENCE_TOML] = (config_dir / INFERENCE_TOML).read_text()
+
+    total_bytes = sum(len(v.encode()) for v in configs.values())
+    if total_bytes > 900_000:
+        raise ValueError(f"Configs too large for ConfigMap ({total_bytes} bytes); split or use a PVC.")
+
+    inference_port = (
+        getattr(config.inference.deployment, "backend_port", 8000) if config.inference is not None else 8000
+    )
+    infer_urls = (
+        _build_infer_urls(
+            config.k8s.job_name,
+            config.k8s.namespace,
+            config.deployment.num_infer_replicas,
+            inference_port,
+        )
+        if config.inference is not None
+        else ""
+    )
+
+    env = Environment(loader=FileSystemLoader(config.k8s.template_path.parent), keep_trailing_newline=True)
+    template = env.get_template(config.k8s.template_path.name)
+    manifest = template.render(
+        **config.k8s.template_vars,
+        configs=configs,
+        has_inference=config.inference is not None,
+        num_train_nodes=config.deployment.num_train_nodes,
+        num_infer_replicas=config.deployment.num_infer_replicas,
+        gpus_per_node=config.deployment.gpus_per_node,
+        master_port=29500,
+        inference_port=inference_port,
+        infer_urls=infer_urls,
+        ranks_filter=",".join(map(str, config.trainer.log.ranks_filter)),
+    )
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(manifest)
+
+
+def rl_k8s(config: RLConfig):
+    assert config.k8s is not None
+
+    logger = setup_logger(
+        config.log.level or os.environ.get("PRIME_LOG_LEVEL", "info"), json_logging=config.log.json_logging
+    )
+
+    local_dir = config.k8s.local_output_dir / config.k8s.job_name
+    config_dir = local_dir / "configs"
+    write_subconfigs(config, config_dir)
+    logger.info(f"Wrote subconfigs to {config_dir}")
+
+    manifest_path = local_dir / RL_K8S_YAML
+    write_k8s_manifest(config, config_dir, manifest_path)
+    logger.info(f"Wrote k8s manifest to {manifest_path}")
+
+    if config.dry_run or config.k8s.submit == "dry":
+        logger.success(f"Dry run complete. To apply manually:\n\n  kubectl apply -f {manifest_path}\n")
+        return
+
+    cmd = ["kubectl", "apply", "-f", str(manifest_path)]
+    logger.info(f"Submitting: {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        logger.error(f"kubectl apply failed: {result.stderr.strip()}")
+        sys.exit(1)
+    logger.success(result.stdout.strip())
+
+
 def rl_slurm(config: RLConfig):
     assert config.slurm is not None
 
@@ -571,6 +659,8 @@ def rl(config: RLConfig):
 
     if config.slurm is not None:
         rl_slurm(config)
+    elif config.k8s is not None:
+        rl_k8s(config)
     else:
         rl_local(config)
 

--- a/src/prime_rl/templates/rl.k8s.yaml.j2
+++ b/src/prime_rl/templates/rl.k8s.yaml.j2
@@ -1,0 +1,234 @@
+{#-
+  Minimal k8s manifest for an RL run. Mirrors the slurm sbatch template:
+  - ConfigMap embeds the rendered trainer/orchestrator/inference TOMLs
+  - One StatefulSet per role, mounts ConfigMap at /etc/prime-rl/configs/
+  - Headless services give stable DNS for trainer rendezvous and inference URLs
+  - Single PVC for outputs, mounted at {{ output_mount }} in every pod
+
+  Currently assumes single-node-per-inference-replica (no router fanout) and
+  single-node training rendezvous via trainer-0. Disagg PD / multi-node
+  inference replicas are intentionally out of scope for the minimal cut.
+-#}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ job_name }}-configs
+  namespace: {{ namespace }}
+data:
+{%- for filename, content in configs.items() %}
+  {{ filename }}: |
+{{ content | indent(4, first=True) }}
+{%- endfor %}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ job_name }}-outputs
+  namespace: {{ namespace }}
+spec:
+  accessModes: [ReadWriteMany]
+  storageClassName: {{ storage_class }}
+  resources:
+    requests:
+      storage: {{ storage_size }}
+---
+{#Headless services for stable per-pod DNS #}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ job_name }}-trainer-headless
+  namespace: {{ namespace }}
+spec:
+  clusterIP: None
+  selector:
+    app: {{ job_name }}
+    role: trainer
+  ports:
+  - {name: rdzv, port: {{ master_port }}}
+{%- if has_inference %}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ job_name }}-inference-headless
+  namespace: {{ namespace }}
+spec:
+  clusterIP: None
+  selector:
+    app: {{ job_name }}
+    role: inference
+  ports:
+  - {name: api, port: {{ inference_port }}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ job_name }}-orchestrator-headless
+  namespace: {{ namespace }}
+spec:
+  clusterIP: None
+  selector:
+    app: {{ job_name }}
+    role: orchestrator
+  ports:
+  - {name: api, port: 8000}
+{%- endif %}
+---
+{#Trainer StatefulSet #}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ job_name }}-trainer
+  namespace: {{ namespace }}
+spec:
+  serviceName: {{ job_name }}-trainer-headless
+  replicas: {{ num_train_nodes }}
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels: {app: {{ job_name }}, role: trainer}
+  template:
+    metadata:
+      labels: {app: {{ job_name }}, role: trainer}
+    spec:
+      {%- if gpu_runtime_class %}
+      runtimeClassName: {{ gpu_runtime_class }}
+      {%- endif %}
+      {%- if node_selector %}
+      nodeSelector:
+        {%- for k, v in node_selector.items() %}
+        {{ k }}: {{ v | tojson }}
+        {%- endfor %}
+      {%- endif %}
+      containers:
+      - name: trainer
+        image: {{ image }}
+        imagePullPolicy: {{ image_pull_policy }}
+        command: ["bash", "-lc"]
+        args:
+        - |
+          set -euo pipefail
+          export NODE_RANK=${HOSTNAME##*-}
+          export PYTORCH_CUDA_ALLOC_CONF="expandable_segments:True"
+          uv run torchrun \
+            --nnodes={{ num_train_nodes }} \
+            --nproc-per-node={{ gpus_per_node }} \
+            --node-rank=$NODE_RANK \
+            --rdzv-id={{ job_name }} \
+            --rdzv-backend=c10d \
+            --rdzv-endpoint={{ job_name }}-trainer-0.{{ job_name }}-trainer-headless.{{ namespace }}.svc.cluster.local:{{ master_port }} \
+            --local-ranks-filter={{ ranks_filter }} \
+            -m prime_rl.trainer.rl.train \
+            @ /etc/prime-rl/configs/trainer.toml
+        env:
+        - {name: HF_HUB_OFFLINE, value: "0"}
+        {%- if secret_name %}
+        - {name: WANDB_API_KEY, valueFrom: {secretKeyRef: {name: {{ secret_name }}, key: wandb-api-key, optional: true}}}
+        - {name: HF_TOKEN, valueFrom: {secretKeyRef: {name: {{ secret_name }}, key: hf-token, optional: true}}}
+        {%- endif %}
+        resources:
+          limits:
+            nvidia.com/gpu: {{ gpus_per_node }}
+        volumeMounts:
+        - {name: configs, mountPath: /etc/prime-rl/configs, readOnly: true}
+        - {name: outputs, mountPath: {{ output_mount }}}
+        - {name: dshm, mountPath: /dev/shm}
+      volumes:
+      - {name: configs, configMap: {name: {{ job_name }}-configs}}
+      - {name: outputs, persistentVolumeClaim: {claimName: {{ job_name }}-outputs}}
+      - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 16Gi}}
+{%- if has_inference %}
+---
+{#Inference StatefulSet (one pod per replica) #}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ job_name }}-inference
+  namespace: {{ namespace }}
+spec:
+  serviceName: {{ job_name }}-inference-headless
+  replicas: {{ num_infer_replicas }}
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels: {app: {{ job_name }}, role: inference}
+  template:
+    metadata:
+      labels: {app: {{ job_name }}, role: inference}
+    spec:
+      {%- if gpu_runtime_class %}
+      runtimeClassName: {{ gpu_runtime_class }}
+      {%- endif %}
+      {%- if node_selector %}
+      nodeSelector:
+        {%- for k, v in node_selector.items() %}
+        {{ k }}: {{ v | tojson }}
+        {%- endfor %}
+      {%- endif %}
+      containers:
+      - name: inference
+        image: {{ image }}
+        imagePullPolicy: {{ image_pull_policy }}
+        command: ["bash", "-lc"]
+        args:
+        - |
+          set -euo pipefail
+          uv run inference \
+            @ /etc/prime-rl/configs/inference.toml \
+            --server.host 0.0.0.0 \
+            --server.port {{ inference_port }}
+        ports:
+        - {containerPort: {{ inference_port }}, name: api}
+        env:
+        {%- if secret_name %}
+        - {name: HF_TOKEN, valueFrom: {secretKeyRef: {name: {{ secret_name }}, key: hf-token, optional: true}}}
+        {%- endif %}
+        resources:
+          limits:
+            nvidia.com/gpu: {{ gpus_per_node }}
+        volumeMounts:
+        - {name: configs, mountPath: /etc/prime-rl/configs, readOnly: true}
+        - {name: outputs, mountPath: {{ output_mount }}}
+        - {name: dshm, mountPath: /dev/shm}
+      volumes:
+      - {name: configs, configMap: {name: {{ job_name }}-configs}}
+      - {name: outputs, persistentVolumeClaim: {claimName: {{ job_name }}-outputs}}
+      - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 16Gi}}
+---
+{#Orchestrator StatefulSet (single pod, no GPU) #}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ job_name }}-orchestrator
+  namespace: {{ namespace }}
+spec:
+  serviceName: {{ job_name }}-orchestrator-headless
+  replicas: 1
+  selector:
+    matchLabels: {app: {{ job_name }}, role: orchestrator}
+  template:
+    metadata:
+      labels: {app: {{ job_name }}, role: orchestrator}
+    spec:
+      containers:
+      - name: orchestrator
+        image: {{ image }}
+        imagePullPolicy: {{ image_pull_policy }}
+        command: ["bash", "-lc"]
+        args:
+        - |
+          set -euo pipefail
+          uv run orchestrator \
+            @ /etc/prime-rl/configs/orchestrator.toml \
+            --client.base-url $INFER_URLS
+        env:
+        - {name: INFER_URLS, value: "{{ infer_urls }}"}
+        {%- if secret_name %}
+        - {name: WANDB_API_KEY, valueFrom: {secretKeyRef: {name: {{ secret_name }}, key: wandb-api-key, optional: true}}}
+        - {name: HF_TOKEN, valueFrom: {secretKeyRef: {name: {{ secret_name }}, key: hf-token, optional: true}}}
+        {%- endif %}
+        volumeMounts:
+        - {name: configs, mountPath: /etc/prime-rl/configs, readOnly: true}
+        - {name: outputs, mountPath: {{ output_mount }}}
+      volumes:
+      - {name: configs, configMap: {name: {{ job_name }}-configs}}
+      - {name: outputs, persistentVolumeClaim: {claimName: {{ job_name }}-outputs}}
+{%- endif %}


### PR DESCRIPTION
## Summary

Adds a k8s launcher path that mirrors the existing slurm flow: same `RLConfig`, new `[k8s]` block, single Jinja template, one `kubectl apply` to submit.

The point of this PR is to share the design with the team for early feedback — scope is intentionally small.

## How it works

```bash
uv run rl @ examples/reverse_text/rl.toml @ examples/reverse_text/k8s_rl.toml
```

1. `rl_k8s()` writes `trainer.toml` / `orchestrator.toml` / `inference.toml` to `./k8s-runs/<job>/configs/` (analog of `write_subconfigs` in slurm).
2. Renders `templates/rl.k8s.yaml.j2` with those TOMLs inlined as a ConfigMap (`data.trainer.toml: |` block scalar).
3. Manifest contains: ConfigMap, PVC, three headless Services, three StatefulSets (trainer / inference / orchestrator). Pods mount the ConfigMap at `/etc/prime-rl/configs/` and the PVC at `/data`.
4. `kubectl apply -f <manifest>`.

Trainer rendezvous via `<job>-trainer-0.<job>-trainer-headless:29500`. Orchestrator gets `INFER_URLS` env from the headless inference service DNS pattern.

## File map (5 changed + 1 gitignore)

| file | change |
|---|---|
| `src/prime_rl/configs/shared.py` | new `K8sConfig` |
| `src/prime_rl/configs/rl.py` | `k8s` field, mutex with slurm, template auto-load, allow multi-node + k8s |
| `src/prime_rl/entrypoints/rl.py` | `rl_k8s()`, `write_k8s_manifest()`, dispatch in `rl()` |
| `src/prime_rl/templates/rl.k8s.yaml.j2` | new template |
| `examples/reverse_text/k8s_rl.toml` | example user-facing config |
| `.gitignore` | ignore `k8s-runs/` |

## Scope cuts (call out for review)

- **Multi-node only.** Single-node still uses `rl_local`.
- **One pod per inference replica.** No vllm-router fanout, no disaggregated PD. That's where the slurm template grows complexity; deferring until the basic flow lands.
- **No NCCL/IB tuning.** Slurm template auto-detects via `ibv_devinfo`; on k8s we rely on the GPU operator. May need an env block later.
- **Existing `k8s/` Helm chart left untouched** as the legacy hand-driven path. Plan is to delete once this lands and disagg/router are ported.
- **No live cluster test.** Validated locally via `yaml.safe_load_all` (8 docs render, ConfigMap contains rendered TOMLs, trainer args reference `/etc/prime-rl/configs/trainer.toml`, `INFER_URLS` resolves correctly). `kubectl --dry-run=client` would catch schema issues but isn't installed in my env.