### PR TITLE
[DYNAMO] pass renderer transport to verifiers

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -1339,5 +1339,4 @@ class OrchestratorConfig(BaseConfig):
             if is_vllm:
                 env.sampling.extra_body.setdefault("top_k", -1)
                 env.sampling.extra_body.setdefault("min_p", 0.0)
-                env.sampling.extra_body.setdefault("return_token_ids", True)
         return self

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "uvloop>=0.21.0",
     "torchtitan",
     "verifiers",
+    "renderers",
     "dion",
     "tilelang>=0.1.8",
     "flash-linear-attention",
@@ -150,6 +151,7 @@ prime-tunnel = false
 prime-evals = false
 # Trusted git/URL sources pinned by rev or wheel URL (defensive: belt-and-suspenders)
 verifiers = false
+renderers = false
 vllm-router = false
 dion = false
 pydantic-config = false
@@ -160,7 +162,8 @@ nixl-cu12 = false
 [tool.uv.sources]
 prime-rl-configs = { workspace = true }
 torch = { index = "pytorch-cu128" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "3b77145" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "f6f82245" }
+renderers = { git = "https://github.com/PrimeIntellect-ai/renderers.git", rev = "1f3de65" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eeb" }
 transformers = { git = "https://github.com/huggingface/transformers.git", rev = "c1c3424" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,8 +162,8 @@ nixl-cu12 = false
 [tool.uv.sources]
 prime-rl-configs = { workspace = true }
 torch = { index = "pytorch-cu128" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "f6f82245" }
-renderers = { git = "https://github.com/PrimeIntellect-ai/renderers.git", rev = "1f3de65" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "1c7c35f0" }
+renderers = { git = "https://github.com/PrimeIntellect-ai/renderers.git", rev = "7ca1ab3" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eeb" }
 transformers = { git = "https://github.com/huggingface/transformers.git", rev = "c1c3424" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,7 +162,7 @@ nixl-cu12 = false
 [tool.uv.sources]
 prime-rl-configs = { workspace = true }
 torch = { index = "pytorch-cu128" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "0bece1fa" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "9485194f" }
 renderers = { git = "https://github.com/PrimeIntellect-ai/renderers.git", rev = "17005dd" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eeb" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,8 +162,8 @@ nixl-cu12 = false
 [tool.uv.sources]
 prime-rl-configs = { workspace = true }
 torch = { index = "pytorch-cu128" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "1c7c35f0" }
-renderers = { git = "https://github.com/PrimeIntellect-ai/renderers.git", rev = "7ca1ab3" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "0bece1fa" }
+renderers = { git = "https://github.com/PrimeIntellect-ai/renderers.git", rev = "17005dd" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eeb" }
 transformers = { git = "https://github.com/huggingface/transformers.git", rev = "c1c3424" }

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -310,6 +310,11 @@ def setup_clients(
 ) -> list[vf.ClientConfig]:
     clients = []
     client_idx = 0
+    renderer_transport = (
+        "dynamo_chat_nvext"
+        if client_type == "renderer" and client_config.backend == "dynamo"
+        else "prime_vllm_generate"
+    )
     for base_url in client_config.base_url:
         for dp_rank in range(client_config.dp_rank_count):
             headers = client_config.headers.copy()
@@ -321,6 +326,7 @@ def setup_clients(
                     client_type=client_type,
                     renderer=renderer_name,
                     renderer_model_name=renderer_model_name,
+                    renderer_transport=renderer_transport,
                     renderer_pool_size=renderer_pool_size,
                     tool_parser=tool_parser,
                     reasoning_parser=reasoning_parser,

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -310,11 +310,7 @@ def setup_clients(
 ) -> list[vf.ClientConfig]:
     clients = []
     client_idx = 0
-    renderer_transport = (
-        "dynamo_chat_nvext"
-        if client_type == "renderer" and client_config.backend == "dynamo"
-        else "prime_vllm_generate"
-    )
+    renderer_transport = "dynamo" if client_type == "renderer" and client_config.backend == "dynamo" else "vllm"
     for base_url in client_config.base_url:
         for dp_rank in range(client_config.dp_rank_count):
             headers = client_config.headers.copy()

--- a/src/prime_rl/utils/elastic.py
+++ b/src/prime_rl/utils/elastic.py
@@ -203,6 +203,7 @@ class ElasticInferencePool:
                 base_url=urls,
                 api_key_var=self.client_config.api_key_var,
                 headers=self.client_config.headers,
+                backend=self.client_config.backend,
                 dp_rank_count=self.client_config.dp_rank_count,
                 extra_headers_from_state=self.client_config.extra_headers_from_state,
             )

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -156,6 +156,15 @@ def test_removed_fused_lm_head_chunk_size_field_is_rejected():
         TrainerModelConfig.model_validate({"fused_lm_head_chunk_size": "auto"})
 
 
+def test_orchestrator_env_defaults_do_not_force_return_token_ids():
+    config = OrchestratorConfig()
+
+    extra_body = config.train.env[0].sampling.extra_body
+    assert extra_body["top_k"] == -1
+    assert extra_body["min_p"] == 0.0
+    assert "return_token_ids" not in extra_body
+
+
 def test_selective_activation_checkpointing_requires_custom_impl():
     with pytest.raises(ValidationError, match="Selective activation checkpointing requires model.impl='custom'"):
         TrainerModelConfig.model_validate({"impl": "hf", "ac": {"mode": "selective"}})

--- a/tests/unit/utils/test_client.py
+++ b/tests/unit/utils/test_client.py
@@ -89,6 +89,18 @@ def test_setup_clients_assigns_renderer_model_name():
     assert clients[0].renderer_model_name == "Qwen/Qwen3-VL-4B-Instruct"
 
 
+def test_setup_clients_uses_dynamo_transport_for_dynamo_renderer():
+    client_config = ClientConfig(
+        base_url=["http://worker-a:8000/v1"],
+        api_key_var="PRIME_API_KEY",
+        backend="dynamo",
+    )
+
+    clients = setup_clients(client_config, client_type="renderer")
+
+    assert clients[0].renderer_transport == "dynamo_chat_nvext"
+
+
 def test_setup_clients_preserves_chat_client_defaults():
     client_config = ClientConfig(
         base_url=["http://worker-a:8000/v1"],

--- a/tests/unit/utils/test_client.py
+++ b/tests/unit/utils/test_client.py
@@ -98,7 +98,7 @@ def test_setup_clients_uses_dynamo_transport_for_dynamo_renderer():
 
     clients = setup_clients(client_config, client_type="renderer")
 
-    assert clients[0].renderer_transport == "dynamo_chat_nvext"
+    assert clients[0].renderer_transport == "dynamo"
 
 
 def test_setup_clients_preserves_chat_client_defaults():

--- a/tests/unit/utils/test_elastic.py
+++ b/tests/unit/utils/test_elastic.py
@@ -417,6 +417,7 @@ def test_elastic_clients_preserve_renderer_model_name_when_model_name_updates():
         client_config.headers = {}
         client_config.extra_headers_from_state = {}
         client_config.dp_rank_count = 1
+        client_config.backend = "vllm"
 
         pool = ElasticInferencePool(
             client_config=client_config,

--- a/uv.lock
+++ b/uv.lock
@@ -2832,7 +2832,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", git = "https://github.com/huggingface/transformers.git?rev=c1c3424" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=0bece1fa" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=9485194f" },
     { name = "vllm", specifier = ">=0.19.0" },
     { name = "vllm-router", marker = "platform_machine == 'x86_64' and extra == 'disagg'", url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.22/vllm_router-0.1.22-cp38-abi3-manylinux_2_28_x86_64.whl" },
     { name = "wandb", specifier = ">=0.26.1" },
@@ -4102,7 +4102,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.15.dev7"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=0bece1fa#0bece1fa67beb3cef8c180abfcfdfc7605dc2593" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=9485194f#9485194fdd03792f658d5a0c689a5eb1e05473a3" }
 dependencies = [
     { name = "aiolimiter", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "anthropic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },

--- a/uv.lock
+++ b/uv.lock
@@ -2819,7 +2819,7 @@ requires-dist = [
     { name = "pyarrow", specifier = ">=21.0.0" },
     { name = "pyzmq", specifier = ">=27.1.0" },
     { name = "quack-kernels", marker = "extra == 'quack'", specifier = ">=0.3.3" },
-    { name = "renderers", git = "https://github.com/PrimeIntellect-ai/renderers.git?rev=1f3de65" },
+    { name = "renderers", git = "https://github.com/PrimeIntellect-ai/renderers.git?rev=7ca1ab3" },
     { name = "reverse-text", marker = "extra == 'envs'", index = "https://hub.primeintellect.ai/primeintellect/simple/" },
     { name = "rich", specifier = ">=14.0.0" },
     { name = "ring-flash-attn", specifier = ">=0.1.8" },
@@ -2832,7 +2832,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", git = "https://github.com/huggingface/transformers.git?rev=c1c3424" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=f6f82245" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=1c7c35f0" },
     { name = "vllm", specifier = ">=0.19.0" },
     { name = "vllm-router", marker = "platform_machine == 'x86_64' and extra == 'disagg'", url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.22/vllm_router-0.1.22-cp38-abi3-manylinux_2_28_x86_64.whl" },
     { name = "wandb", specifier = ">=0.26.1" },
@@ -3302,7 +3302,7 @@ wheels = [
 [[package]]
 name = "renderers"
 version = "0.1.7"
-source = { git = "https://github.com/PrimeIntellect-ai/renderers.git?rev=1f3de65#1f3de6506208233217f61671ebe81a00b0f5082a" }
+source = { git = "https://github.com/PrimeIntellect-ai/renderers.git?rev=7ca1ab3#7ca1ab357f3ae2262ad10ffe757670739a8ec2c5" }
 dependencies = [
     { name = "jinja2", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "numpy", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -4102,7 +4102,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.14"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=f6f82245#f6f82245113149e7e9244b2b1f52ac9a6f4d38d0" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=1c7c35f0#1c7c35f059b814b01072158ecf683448fe7fffd1" }
 dependencies = [
     { name = "aiolimiter", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "anthropic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ supported-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-29T22:09:49.355713533Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -2819,7 +2819,7 @@ requires-dist = [
     { name = "pyarrow", specifier = ">=21.0.0" },
     { name = "pyzmq", specifier = ">=27.1.0" },
     { name = "quack-kernels", marker = "extra == 'quack'", specifier = ">=0.3.3" },
-    { name = "renderers", git = "https://github.com/PrimeIntellect-ai/renderers.git?rev=7ca1ab3" },
+    { name = "renderers", git = "https://github.com/PrimeIntellect-ai/renderers.git?rev=17005dd" },
     { name = "reverse-text", marker = "extra == 'envs'", index = "https://hub.primeintellect.ai/primeintellect/simple/" },
     { name = "rich", specifier = ">=14.0.0" },
     { name = "ring-flash-attn", specifier = ">=0.1.8" },
@@ -2832,7 +2832,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", git = "https://github.com/huggingface/transformers.git?rev=c1c3424" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=1c7c35f0" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=0bece1fa" },
     { name = "vllm", specifier = ">=0.19.0" },
     { name = "vllm-router", marker = "platform_machine == 'x86_64' and extra == 'disagg'", url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.22/vllm_router-0.1.22-cp38-abi3-manylinux_2_28_x86_64.whl" },
     { name = "wandb", specifier = ">=0.26.1" },
@@ -2871,7 +2871,7 @@ requires-dist = [
 
 [[package]]
 name = "prime-sandboxes"
-version = "0.2.22"
+version = "0.2.26"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -2881,9 +2881,9 @@ dependencies = [
     { name = "pydantic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "tenacity", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/a7/eb9cb01ce7fa812022ec7c2ffaeb379e1103e07f093a4b85e879b2d0143d/prime_sandboxes-0.2.22.tar.gz", hash = "sha256:7901adca4ff7fff1e7f08c06c4b76765cd90791965216655eb3a87d459588f5e", size = 64970, upload-time = "2026-04-22T18:32:12.973Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/7ecfdd389664c5112eda8d83e287b266f627fdbcefe5510b1b7346effa4b/prime_sandboxes-0.2.26.tar.gz", hash = "sha256:87b0aa2d5ee44f201cb4d0fc1bdf52efa617a7f3cbf9e5a5ee7bc2de0f45ac98", size = 68496, upload-time = "2026-05-12T22:17:47.801Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/b8/46bf98c06826fc26d982c53e10d9d4f086a4c322993a6c51188e5bd6fd30/prime_sandboxes-0.2.22-py3-none-any.whl", hash = "sha256:0a75bb02049c16b55aae7475cc4082e8559ffa6d65181b238077771a95b57855", size = 33182, upload-time = "2026-04-22T18:32:11.739Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/51/b5c282dffd4eba73953cdf86c34df36dd31264464489fd14a1a565776e03/prime_sandboxes-0.2.26-py3-none-any.whl", hash = "sha256:03226e4fa81a8008bbdb3046f295a56a43e74bb89b8e894b001547643deca918", size = 34234, upload-time = "2026-05-12T22:17:46.494Z" },
 ]
 
 [[package]]
@@ -3301,8 +3301,8 @@ wheels = [
 
 [[package]]
 name = "renderers"
-version = "0.1.7"
-source = { git = "https://github.com/PrimeIntellect-ai/renderers.git?rev=7ca1ab3#7ca1ab357f3ae2262ad10ffe757670739a8ec2c5" }
+version = "0.1.8.dev12+g17005dd"
+source = { git = "https://github.com/PrimeIntellect-ai/renderers.git?rev=17005dd#17005dd79f031f7993fb8e0b26b52aff346ad07e" }
 dependencies = [
     { name = "jinja2", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "numpy", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -4101,8 +4101,8 @@ wheels = [
 
 [[package]]
 name = "verifiers"
-version = "0.1.14"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=1c7c35f0#1c7c35f059b814b01072158ecf683448fe7fffd1" }
+version = "0.1.15.dev7"
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=0bece1fa#0bece1fa67beb3cef8c180abfcfdfc7605dc2593" }
 dependencies = [
     { name = "aiolimiter", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "anthropic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -4127,7 +4127,6 @@ dependencies = [
     { name = "setproctitle", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "tenacity", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "textual", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "wget", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
 [[package]]
@@ -4341,12 +4340,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/9f/69/83029f1f6300c5fb2
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/24/ab44c871b0f07f491e5d2ad12c9bd7358e527510618cb1b803a88e986db1/werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e", size = 224498, upload-time = "2024-11-08T15:52:16.132Z" },
 ]
-
-[[package]]
-name = "wget"
-version = "3.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/6a/62e288da7bcda82b935ff0c6cfe542970f04e29c756b0e147251b2fb251f/wget-3.2.zip", hash = "sha256:35e630eca2aa50ce998b9b1a127bb26b30dfee573702782aa982f875e3f16061", size = 10857, upload-time = "2015-10-22T15:26:37.51Z" }
 
 [[package]]
 name = "widgetsnbextension"

--- a/uv.lock
+++ b/uv.lock
@@ -30,18 +30,19 @@ deep-gemm = false
 aime2024 = false
 prime-evals = false
 deepdive = false
+prime-sandboxes = false
 reverse-text = false
 code-env = false
 mini-swe-agent-plus = false
 deep-ep = false
 pydantic-config = false
+renderers = false
 math-env = false
 logic-env = false
 wiki-search = false
 math-python = false
 math500 = false
 aime2025 = false
-prime-sandboxes = false
 
 [manifest]
 members = [
@@ -2697,6 +2698,7 @@ dependencies = [
     { name = "prime-rl-configs", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pyarrow", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pyzmq", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "renderers", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "rich", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "ring-flash-attn", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "setproctitle", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -2817,6 +2819,7 @@ requires-dist = [
     { name = "pyarrow", specifier = ">=21.0.0" },
     { name = "pyzmq", specifier = ">=27.1.0" },
     { name = "quack-kernels", marker = "extra == 'quack'", specifier = ">=0.3.3" },
+    { name = "renderers", git = "https://github.com/PrimeIntellect-ai/renderers.git?rev=1f3de65" },
     { name = "reverse-text", marker = "extra == 'envs'", index = "https://hub.primeintellect.ai/primeintellect/simple/" },
     { name = "rich", specifier = ">=14.0.0" },
     { name = "ring-flash-attn", specifier = ">=0.1.8" },
@@ -2829,7 +2832,7 @@ requires-dist = [
     { name = "torchtitan", git = "https://github.com/pytorch/torchtitan?rev=a1fdd7e" },
     { name = "transformers", git = "https://github.com/huggingface/transformers.git?rev=c1c3424" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=3b77145" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=f6f82245" },
     { name = "vllm", specifier = ">=0.19.0" },
     { name = "vllm-router", marker = "platform_machine == 'x86_64' and extra == 'disagg'", url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.22/vllm_router-0.1.22-cp38-abi3-manylinux_2_28_x86_64.whl" },
     { name = "wandb", specifier = ">=0.26.1" },
@@ -3298,10 +3301,14 @@ wheels = [
 
 [[package]]
 name = "renderers"
-version = "0.1.0"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?subdirectory=packages%2Frenderers&rev=3b77145#3b77145e14a9bcdaf180a49e7df97dbf2d7bb150" }
+version = "0.1.7"
+source = { git = "https://github.com/PrimeIntellect-ai/renderers.git?rev=1f3de65#1f3de6506208233217f61671ebe81a00b0f5082a" }
 dependencies = [
+    { name = "jinja2", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "numpy", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "openai", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "openai-harmony", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "tiktoken", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "transformers", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
@@ -4094,8 +4101,8 @@ wheels = [
 
 [[package]]
 name = "verifiers"
-version = "0.1.13.dev8"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=3b77145#3b77145e14a9bcdaf180a49e7df97dbf2d7bb150" }
+version = "0.1.14"
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=f6f82245#f6f82245113149e7e9244b2b1f52ac9a6f4d38d0" }
 dependencies = [
     { name = "aiolimiter", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "anthropic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -4115,7 +4122,6 @@ dependencies = [
     { name = "pydantic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pyzmq", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "regex", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "renderers", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "requests", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "rich", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "setproctitle", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },


### PR DESCRIPTION
## Summary

Passes `renderer_transport="dynamo"` to verifiers renderer clients when `client.backend = "dynamo"`, while preserving `vllm` for the default vLLM path.

Preserves `backend` when `ElasticInferencePool` rebuilds URL-scoped client configs, so elastic Dynamo renderer clients keep the same transport selection.

Updates the shared Dynamo renderer stack contract:

- pins `verifiers` to `9485194f` (PrimeIntellect-ai/verifiers#1287)
- pins `renderers` to `17005dd` (PrimeIntellect-ai/renderers#11)
- stops forcing `return_token_ids` in orchestrator env sampling defaults; token IDs are requested by the renderer/verifiers transport (`nvext.engine_data` for Dynamo)
- adds config coverage that `return_token_ids` is not injected globally

Stacked on #2398.

Companion PRs:
- verifiers: https://github.com/PrimeIntellect-ai/verifiers/pull/1287
- renderers: https://github.com/PrimeIntellect-ai/renderers/pull/11

## Validation

Local:
- `uv lock --check`
- `uvx ruff==0.13.0 check --config=pyproject.toml src/prime_rl/utils/client.py tests/unit/utils/test_client.py`
- `uvx ruff==0.13.0 format --check --config=pyproject.toml src/prime_rl/utils/client.py tests/unit/utils/test_client.py`

GitHub Actions:
- Ruff: pass
- Slim install (prime-rl-configs only): pass
- Unit tests: pass

Local test note:
- `uv run pytest tests/unit/utils/test_client.py` is blocked on macOS by the repo's Linux-only lockfile; `uv run --no-sync pytest tests/unit/utils/test_client.py` exited 139 locally.
