### PR TITLE
fix(docker): remove deadsnakes ppa in build stage

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -12,7 +12,7 @@ RUN echo "LC_ALL=en_US.UTF-8" >> /etc/environment
 ENV CUDA_HOME=/usr/local/cuda
 ENV PATH=$PATH:/usr/local/cuda/bin
 
-# Install packages (including Python 3.12 and ninja for fast CUDA kernel compilation)
+# Install build tooling.
 ARG DEBIAN_FRONTEND=noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
@@ -22,12 +22,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends --force-yes \
     sudo \
     git \
     ninja-build \
-    software-properties-common \
-    && add-apt-repository ppa:deadsnakes/ppa \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends python3.12 python3.12-dev python3.12-venv \
-    && ln -sf /usr/bin/python3.12 /usr/bin/python3 \
-    && ln -sf /usr/bin/python3.12 /usr/bin/python \
     && apt-get clean autoclean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Download the latest installer


### PR DESCRIPTION
prime-rl image builds are [broken](https://github.com/PrimeIntellect-ai/hosted-rl/actions/runs/25355771189) in hosted-rl CI too due to deadsnakes PPA issues, but i don't think we actually need to install python via deadsnakes because its already being installed via [uv](https://github.com/PrimeIntellect-ai/prime-rl/blob/main/Dockerfile.cuda#L39) in the build stage

# Testing
i ran a prime-rl image build workflow manually off this branch on hosted-rl and it [successfully](https://github.com/PrimeIntellect-ai/hosted-rl/actions/runs/25350634365) ran and also deployed the image tag on amd64/arm64 clusters to verify

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes Docker build dependencies by removing an external apt repository and direct Python installs; runtime image and app code are unchanged.
> 
> **Overview**
> Removes the `deadsnakes` PPA setup and `python3.12*` apt installation from the `Dockerfile.cuda` builder stage, keeping only core build tooling (`build-essential`, `ninja-build`, etc.).
> 
> This shifts Python acquisition fully to `uv` during the build, reducing CI/build fragility caused by external repository failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79179b92346b2da311d6038a8f31636e94427903. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->