### PR TITLE
chore: default weight_decay to 0 in BaseOptimizerConfig

### DIFF
--- a/src/prime_rl/configs/trainer.py
+++ b/src/prime_rl/configs/trainer.py
@@ -496,7 +496,7 @@ SchedulerConfig: TypeAlias = Annotated[
 
 class BaseOptimizerConfig(BaseModel):
     lr: Annotated[float, Field(ge=0)] = 1e-6
-    weight_decay: Annotated[float, Field(ge=0)] = 0.01
+    weight_decay: Annotated[float, Field(ge=0)] = 0.0
     max_norm: Annotated[
         float | None, Field(ge=0, description="Maximum gradient norm to clip. If None, gradient clipping is disabled.")
     ] = 1.0


### PR DESCRIPTION
## Summary

Flip the `BaseOptimizerConfig.weight_decay` default from `0.01` → `0.0`.

Most RL runs in this repo either don't want weight decay or override it explicitly. Leaving the default at `0.01` silently penalizes any run whose config omits the field. Configs that genuinely want `0.01` already set it explicitly:
- `examples/Intellect-3.1/rl.toml`
- `examples/minimax_m2.5_swe/rl.toml`

So no existing run changes behavior unless its author was relying on the implicit default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line config default change, but it will alter training behavior for any runs that relied on the previous implicit `0.01` weight decay.
> 
> **Overview**
> Updates `BaseOptimizerConfig.weight_decay` default in `configs/trainer.py` from `0.01` to `0.0`, so optimizer creation (e.g., `AdamW`/`SGD`/`SignSGD`/`Muon`) no longer applies weight decay unless explicitly configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12359e953592625f9cba0f929c7737d55ea5e502. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->