### PR TITLE
fix(sft): don't divide reported throughput/MFU by cp

### DIFF
--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -422,9 +422,14 @@ def train(config: SFTConfig):
         if memory_profiler is not None:
             memory_profiler.step()
 
-        # Compute step metrics
-        # Divide by CP since those ranks process the same data
-        num_tokens = config.data.batch_size * config.data.seq_len // config.model.cp
+        # Compute step metrics. CP shards the same sequences across cp ranks
+        # (sequence-sharded data parallelism on the seq dim), so the unique
+        # training tokens per step is dp_size * (batch_per_dp_rank * seq).
+        # The `dp` mesh excludes cp by construction (parallel_dims.py), mirroring
+        # the RL trainer's accounting (rl/train.py).
+        dp_size = parallel_dims.get_mesh("dp").size()
+        num_local_tokens = config.data.seq_len * (config.data.batch_size // dp_size)
+        num_tokens = dp_size * num_local_tokens
         progress.total_tokens += num_tokens
         progress.total_samples = dataset.step
         perf_counter = get_perf_counter(model, config.data.seq_len)


### PR DESCRIPTION
## Summary

The SFT bench reports `num_tokens = batch * seq // cp` when computing throughput and MFU. The `÷ cp` is wrong for cross-cp comparisons: it under-reports tps and MFU by ~`cp×` when CP > 1.

CP is sequence-sharded data parallelism — `cp` ranks split the seq dim of the *same* `batch × seq` tokens, so the unique training tokens trained on per step is `batch × seq` regardless of `cp`. The current code is the formula you'd want for tensor-parallel-style data replication, not for CP.

## Concrete numbers (from a 4-node Nemotron-Super 16k run, batch=32)

| | step time | reported tps | reported MFU | **true tps** = batch·seq/step | **true MFU** ≈ × cp |
|---|---:|---:|---:|---:|---:|
| cp=1     | 8.57s  | 60 849 | 91.8% | 61 177 | 91.8% |
| cp=2 ulysses | 10.28s | 25 388 | 38.3% | 51 000 | **76.6%** |

After the fix, cp=2 ulysses reports `~50 000 tok/s` and `~76% MFU` — the actual training throughput. Without the fix, cp=2 looks 2× slower than it really is.

## Fix

```diff
- # Divide by CP since those ranks process the same data
- num_tokens = config.data.batch_size * config.data.seq_len // config.model.cp
+ # CP shards the same `batch * seq` tokens across cp ranks (sequence-sharded
+ # data parallelism on the seq dim), so the unique training tokens per step
+ # is `batch * seq` regardless of cp.
+ num_tokens = config.data.batch_size * config.data.seq_len
```

This matches the convention RL already uses — `rl/train.py:521-522` counts tokens via the `dp` mesh, which by definition excludes `cp` (`parallel_dims.py:138`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the token-counting formula used for logging throughput/MFU, but it will shift reported performance metrics in dashboards/benchmarks for CP>1 runs.
> 
> **Overview**
> Adjusts SFT step metric token accounting to **exclude CP sharding effects**, matching RL trainer conventions.
> 
> Instead of dividing tokens by `config.model.cp`, it derives tokens from the `dp` mesh size so reported `perf/throughput` and `perf/mfu` reflect unique training tokens per step for cross-CP comparisons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05424ee00449c98e7a2310370def82448f81b668. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->