### PR TITLE
fix(configs): use FutureWarning so config deprecations stay visible

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -152,7 +152,7 @@ class TrainSamplingConfig(BaseConfig):
             warnings.warn(
                 "'max_tokens' is deprecated, use 'max_completion_tokens' instead. "
                 "Auto-translating for now, but this will be removed in a future release.",
-                DeprecationWarning,
+                FutureWarning,
                 stacklevel=2,
             )
         return data
@@ -253,7 +253,7 @@ class EvalSamplingConfig(BaseConfig):
             warnings.warn(
                 "'max_tokens' is deprecated, use 'max_completion_tokens' instead. "
                 "Auto-translating for now, but this will be removed in a future release.",
-                DeprecationWarning,
+                FutureWarning,
                 stacklevel=2,
             )
         return data
@@ -1110,7 +1110,7 @@ class OrchestratorConfig(BaseConfig):
                     warnings.warn(
                         "'[[orchestrator.env]]' is deprecated, use '[[orchestrator.train.env]]' instead. "
                         "Auto-translating for now, but this will be removed in a future release.",
-                        DeprecationWarning,
+                        FutureWarning,
                         stacklevel=2,
                     )
                     train.setdefault("env", data.pop("env"))
@@ -1118,7 +1118,7 @@ class OrchestratorConfig(BaseConfig):
                     warnings.warn(
                         "'[orchestrator.sampling]' is deprecated, use '[orchestrator.train.sampling]' instead. "
                         "Auto-translating for now, but this will be removed in a future release.",
-                        DeprecationWarning,
+                        FutureWarning,
                         stacklevel=2,
                     )
                     train.setdefault("sampling", data.pop("sampling"))


### PR DESCRIPTION
## Summary

Follow-up to #2416. The Cursor bot flagged that the deprecation notices ported from `get_logger().warning(...)` to `warnings.warn(..., DeprecationWarning, ...)` are silenced by Python's default warning filters (everything outside `__main__`), so users would stop seeing the `max_tokens` / `[[orchestrator.env]]` / `[orchestrator.sampling]` deprecation messages entirely.

Switch the four sites in `packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py` from `DeprecationWarning` to `FutureWarning`. `FutureWarning` is always shown under default filters and is the semantically correct category for "this will be removed in a future release" notices aimed at end users.

The `warnings.warn(...)` calls in `rl.py` already use the default `UserWarning` and are unaffected.

## Verification

Under `python -W default`, parsing an orchestrator config with the deprecated `[[orchestrator.env]]` shorthand emits a visible `FutureWarning` (previously: `DeprecationWarning`, silenced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: warning-category-only change that affects visibility of deprecation notices but not config parsing/translation behavior.
> 
> **Overview**
> Switches orchestrator config deprecation warnings from `DeprecationWarning` to `FutureWarning` so end users still see notices under Python’s default warning filters.
> 
> This applies to deprecated `max_tokens` handling in `TrainSamplingConfig`/`EvalSamplingConfig` and deprecated `[orchestrator.env]` / `[orchestrator.sampling]` shorthands in `OrchestratorConfig`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21bc08f7f873456169486952a5423570ba113edc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->