### PR TITLE
fix: exit early for unsupported platforms on `install.sh`

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,15 +1,27 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Colors for output
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-RED='\033[0;31m'
-NC='\033[0m' # No Color
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ] && [ "${TERM:-}" != "dumb" ]; then
+  GREEN=$'\033[0;32m'
+  YELLOW=$'\033[1;33m'
+  STDOUT_NC=$'\033[0m'
+else
+  GREEN=''
+  YELLOW=''
+  STDOUT_NC=''
+fi
 
-log_info() { echo -e "${GREEN}[INFO]${NC} $*"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
-log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+if [ -t 2 ] && [ -z "${NO_COLOR:-}" ] && [ "${TERM:-}" != "dumb" ]; then
+  RED=$'\033[0;31m'
+  STDERR_NC=$'\033[0m'
+else
+  RED=''
+  STDERR_NC=''
+fi
+
+log_info() { printf '%s[INFO]%s %s\n' "$GREEN" "$STDOUT_NC" "$*"; }
+log_warn() { printf '%s[WARN]%s %s\n' "$YELLOW" "$STDOUT_NC" "$*"; }
+log_error() { printf '%s[ERROR]%s %s\n' "$RED" "$STDERR_NC" "$*" >&2; }
 
 REPO_ID="prime-rl"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,86 +4,118 @@ set -euo pipefail
 # Colors for output
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
+RED='\033[0;31m'
 NC='\033[0m' # No Color
 
-log_info()  { echo -e "${GREEN}[INFO]${NC} $*"; }
-log_warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
+log_info() { echo -e "${GREEN}[INFO]${NC} $*"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
 
 REPO_ID="prime-rl"
 
 # Flag defaults (can be overridden via env)
 SKIP_CLONE=${SKIP_CLONE:-0}
 
+assert_supported_platform() {
+  local os arch
+  os="$(uname -s)"
+  arch="$(uname -m)"
+
+  if [ "$os" != "Linux" ]; then
+    log_error "Unsupported platform: ${os}/${arch}."
+    log_error "prime-rl currently supports Linux on x86_64 or aarch64 only."
+    exit 1
+  fi
+
+  case "$arch" in
+  x86_64 | aarch64) ;;
+  *)
+    log_error "Unsupported architecture: ${arch}."
+    log_error "prime-rl currently supports Linux on x86_64 or aarch64 only."
+    exit 1
+    ;;
+  esac
+
+  if ! command -v apt &>/dev/null; then
+    log_error "Unsupported Linux distribution: apt is required by this installer."
+    log_error "Use a Debian/Ubuntu-based Linux machine on x86_64 or aarch64, or install manually."
+    exit 1
+  fi
+}
+
 has_ssh_access() {
-    # Probe SSH auth to GitHub without prompting; treat any nonzero as "no ssh"
-    # We try a quick ls-remote to avoid cloning on failure.
-    # Disable -e for the probe so the script doesn't exit on a failed test.
-    set +e
-    timeout 5s git ls-remote --heads git@github.com:PrimeIntellect-ai/${REPO_ID}.git >/dev/null 2>&1
-    rc=$?
-    set -e
-    return $rc
+  # Probe SSH auth to GitHub without prompting; treat any nonzero as "no ssh"
+  # We try a quick ls-remote to avoid cloning on failure.
+  # Disable -e for the probe so the script doesn't exit on a failed test.
+  set +e
+  timeout 5s git ls-remote --heads git@github.com:PrimeIntellect-ai/${REPO_ID}.git >/dev/null 2>&1
+  rc=$?
+  set -e
+  return $rc
 }
 
 ensure_known_hosts() {
-    # Make sure ~/.ssh exists with the right perms, then add GitHub host key.
-    mkdir -p "${HOME}/.ssh"
-    chmod 700 "${HOME}/.ssh"
-    # Use -H to hash hostnames; merge uniquely to avoid dupes.
-    if command -v ssh-keyscan >/dev/null 2>&1; then
-    ssh-keyscan -H github.com 2>/dev/null | sort -u \
-        | tee -a "${HOME}/.ssh/known_hosts" >/dev/null
+  # Make sure ~/.ssh exists with the right perms, then add GitHub host key.
+  mkdir -p "${HOME}/.ssh"
+  chmod 700 "${HOME}/.ssh"
+  # Use -H to hash hostnames; merge uniquely to avoid dupes.
+  if command -v ssh-keyscan >/dev/null 2>&1; then
+    ssh-keyscan -H github.com 2>/dev/null | sort -u |
+      tee -a "${HOME}/.ssh/known_hosts" >/dev/null
     chmod 600 "${HOME}/.ssh/known_hosts"
-    fi
+  fi
 }
 
 main() {
-    # Ensure sudo exists
-    if ! command -v sudo &>/dev/null; then
-        apt update
-        apt install -y sudo
-    fi
+  assert_supported_platform
 
-    log_info "Installing base packages..."
-    sudo apt update && sudo apt install -y build-essential openssh-client curl git tmux htop nvtop
+  # Ensure sudo exists
+  if ! command -v sudo &>/dev/null; then
+    apt update
+    apt install -y sudo
+  fi
 
-    log_info "Configuring SSH known_hosts for GitHub..."
-    ensure_known_hosts
+  log_info "Installing base packages..."
+  sudo apt update
+  sudo apt install -y build-essential openssh-client curl git tmux htop nvtop
 
-    if [ "$SKIP_CLONE" -eq 1 ]; then
-        log_info "Skipping clone; assuming we are already inside the repo."
+  log_info "Configuring SSH known_hosts for GitHub..."
+  ensure_known_hosts
+
+  if [ "$SKIP_CLONE" -eq 1 ]; then
+    log_info "Skipping clone; assuming we are already inside the repo."
+  else
+    log_info "Determining best way to clone (SSH vs HTTPS)..."
+    if has_ssh_access; then
+      log_info "SSH access to GitHub works. Cloning via SSH."
+      git clone git@github.com:PrimeIntellect-ai/${REPO_ID}.git
     else
-        log_info "Determining best way to clone (SSH vs HTTPS)..."
-        if has_ssh_access; then
-            log_info "SSH access to GitHub works. Cloning via SSH."
-            git clone git@github.com:PrimeIntellect-ai/${REPO_ID}.git
-        else
-            log_warn "SSH auth to GitHub not available. Cloning via HTTPS."
-            git clone https://github.com/PrimeIntellect-ai/${REPO_ID}.git
-        fi
-
-        log_info "Entering project directory..."
-        cd ${REPO_ID}
+      log_warn "SSH auth to GitHub not available. Cloning via HTTPS."
+      git clone https://github.com/PrimeIntellect-ai/${REPO_ID}.git
     fi
 
-    log_info "Installing uv..."
-    curl -LsSf https://astral.sh/uv/install.sh | sh
+    log_info "Entering project directory..."
+    cd ${REPO_ID}
+  fi
 
-    log_info "Sourcing uv environment..."
-    if ! command -v uv &> /dev/null; then
-        source $HOME/.local/bin/env
-    fi
+  log_info "Installing uv..."
+  curl -LsSf https://astral.sh/uv/install.sh | sh
 
-    log_info "Installing prime..."
-    uv tool install prime
+  log_info "Sourcing uv environment..."
+  if ! command -v uv &>/dev/null; then
+    source $HOME/.local/bin/env
+  fi
 
-    log_info "Syncing virtual environment..."
-    uv sync --all-extras
+  log_info "Installing prime..."
+  uv tool install prime
 
-    log_info "Installing pre-commit hooks..."
-    uv run pre-commit install
+  log_info "Syncing virtual environment..."
+  uv sync --all-extras
 
-    log_info "Installation completed!"
+  log_info "Installing pre-commit hooks..."
+  uv run pre-commit install
+
+  log_info "Installation completed!"
 }
 
 main

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,27 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ -t 1 ] && [ -z "${NO_COLOR:-}" ] && [ "${TERM:-}" != "dumb" ]; then
-  GREEN=$'\033[0;32m'
-  YELLOW=$'\033[1;33m'
-  STDOUT_NC=$'\033[0m'
-else
-  GREEN=''
-  YELLOW=''
-  STDOUT_NC=''
-fi
+# Colors for output
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
 
-if [ -t 2 ] && [ -z "${NO_COLOR:-}" ] && [ "${TERM:-}" != "dumb" ]; then
-  RED=$'\033[0;31m'
-  STDERR_NC=$'\033[0m'
-else
-  RED=''
-  STDERR_NC=''
-fi
-
-log_info() { printf '%s[INFO]%s %s\n' "$GREEN" "$STDOUT_NC" "$*"; }
-log_warn() { printf '%s[WARN]%s %s\n' "$YELLOW" "$STDOUT_NC" "$*"; }
-log_error() { printf '%s[ERROR]%s %s\n' "$RED" "$STDERR_NC" "$*" >&2; }
+log_info() { echo -e "${GREEN}[INFO]${NC} $*"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
 
 REPO_ID="prime-rl"
 


### PR DESCRIPTION
install script should exit early on unsupported platforms rather than proceeding with most of the install steps before ultimately failing

tested on my apple silicon machine:
```
❯ curl -sSL https://raw.githubusercontent.com/primeintellect-ai/prime-rl/improvement/install-script-early-exit/scripts/install.sh | bash
[ERROR] Unsupported platform: Darwin/arm64.
[ERROR] prime-rl currently supports Linux on x86_64 or aarch64 only.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to the installer script and add early OS/arch/distro checks plus clearer error logging, without affecting runtime application behavior.
> 
> **Overview**
> Adds a new `assert_supported_platform` guard to `scripts/install.sh` that exits early with clear errors when run on non-Linux systems, unsupported architectures (non-`x86_64`/`aarch64`), or distros without `apt`.
> 
> Improves installer UX by adding `log_error`, tidying shell formatting, and slightly restructuring the apt install steps (separate `apt update` call) while keeping the existing clone/`uv`/env setup flow intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c905aa3115dc47283a5c7da92cf68f74ccf0977d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->