### PR TITLE
feat(glm_moe_dsa): experimental bucketed sparse-MLA fwd/bwd kernels

### DIFF
--- a/src/prime_rl/trainer/models/glm_moe_dsa/sparse_mla_attention.py
+++ b/src/prime_rl/trainer/models/glm_moe_dsa/sparse_mla_attention.py
@@ -1,3 +1,4 @@
+import os
 from dataclasses import dataclass
 
 import torch
@@ -10,11 +11,40 @@ from prime_rl.trainer.models.layers.rotary_emb import rotate_half
 from prime_rl.utils.cp import gather_for_cp
 
 try:
-    from prime_rl.trainer.models.kernels.sparse_mla_bwd import sparse_mla_bwd
-    from prime_rl.trainer.models.kernels.sparse_mla_fwd import sparse_mla_fwd_interface
+    from prime_rl.trainer.models.kernels.sparse_mla_bwd import sparse_mla_bwd as sparse_mla_bwd_tilelang
+    from prime_rl.trainer.models.kernels.sparse_mla_fwd import sparse_mla_fwd_interface as sparse_mla_fwd_tilelang
 except ImportError:
-    sparse_mla_fwd_interface = None  # type: ignore
-    sparse_mla_bwd = None  # type: ignore
+    sparse_mla_fwd_tilelang = None  # type: ignore
+    sparse_mla_bwd_tilelang = None  # type: ignore
+
+try:
+    from prime_rl.trainer.models.kernels.sparse_mla_bucketed import sparse_mla_bwd_bucketed, sparse_mla_fwd_bucketed
+except ImportError:
+    sparse_mla_fwd_bucketed = None  # type: ignore
+    sparse_mla_bwd_bucketed = None  # type: ignore
+
+
+def _experimental_bucketed_enabled() -> bool:
+    """Opt-in switch for the experimental bucketed sparse-MLA fwd/bwd kernels.
+
+    Set ``PRIME_RL_EXPERIMENTAL_MLA_BWD=1`` (or ``true``/``yes``) to route
+    forward and backward through the bucketed implementation. The default
+    (unset) keeps the existing TileLang single-kernel path.
+    """
+    val = os.environ.get("PRIME_RL_EXPERIMENTAL_MLA_BWD", "")
+    return val.lower() in {"1", "true", "yes", "on"}
+
+
+def _select_sparse_mla_kernel():
+    if _experimental_bucketed_enabled():
+        if sparse_mla_fwd_bucketed is None or sparse_mla_bwd_bucketed is None:
+            raise ImportError(
+                "PRIME_RL_EXPERIMENTAL_MLA_BWD is set but bucketed TileLang sparse MLA kernels are unavailable"
+            )
+        return sparse_mla_fwd_bucketed, sparse_mla_bwd_bucketed
+    if sparse_mla_fwd_tilelang is None or sparse_mla_bwd_tilelang is None:
+        raise ImportError("TileLang sparse MLA kernels are unavailable")
+    return sparse_mla_fwd_tilelang, sparse_mla_bwd_tilelang
 
 
 @dataclass(frozen=True)
@@ -35,18 +65,21 @@ class SparseMlaAttentionArgs:
 
 
 class _SparseMLA(torch.autograd.Function):
-    """Autograd wrapper for tilelang sparse MLA forward/backward kernels."""
+    """Autograd wrapper for sparse MLA forward/backward kernels."""
 
     @staticmethod
     def forward(ctx, q, kv, indices, sm_scale):
+        sparse_mla_fwd_interface, sparse_mla_bwd = _select_sparse_mla_kernel()
         out, lse = sparse_mla_fwd_interface(q, kv, indices, sm_scale=sm_scale)
         ctx.save_for_backward(q, kv, out, indices, lse)
         ctx.sm_scale = sm_scale
+        ctx.sparse_mla_bwd = sparse_mla_bwd
         return out
 
     @staticmethod
     def backward(ctx, do):
         q, kv, out, indices, lse = ctx.saved_tensors
+        sparse_mla_bwd = ctx.sparse_mla_bwd
         dq, dkv = sparse_mla_bwd(q, kv, out, do.contiguous(), indices, lse, sm_scale=ctx.sm_scale)
         return dq, dkv, None, None
 

--- a/src/prime_rl/trainer/models/kernels/sparse_mla_bucketed.py
+++ b/src/prime_rl/trainer/models/kernels/sparse_mla_bucketed.py
@@ -1,0 +1,117 @@
+import torch
+
+from prime_rl.trainer.models.kernels.sparse_mla_bwd import bwd, postprocess, preprocess
+from prime_rl.trainer.models.kernels.sparse_mla_fwd import sparse_mla_fwd_interface
+
+DEFAULT_BUCKET_SIZES = (256, 512, 1024, 1536, 2048)
+
+
+def _query_buckets(
+    indices: torch.Tensor,
+    kv_seq_len: int,
+    bucket_sizes: tuple[int, ...],
+) -> list[tuple[int, torch.Tensor]]:
+    assert indices.shape[0] == 1, "bucketed sparse MLA currently supports batch_size=1"
+    max_valid_index = kv_seq_len - 2
+    valid_counts = (indices <= max_valid_index).sum(dim=-1).flatten()
+
+    topk = indices.shape[-1]
+    sizes = tuple(size for size in bucket_sizes if size < topk) + (topk,)
+    buckets = []
+    previous = 0
+    for size in sizes:
+        query_indices = torch.nonzero((valid_counts > previous) & (valid_counts <= size), as_tuple=False).flatten()
+        if query_indices.numel() > 0:
+            buckets.append((size, query_indices.contiguous()))
+        previous = size
+    return buckets
+
+
+def sparse_mla_fwd_bucketed(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    sm_scale=None,
+    d_v: int = 512,
+    bucket_sizes: tuple[int, ...] = DEFAULT_BUCKET_SIZES,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    assert q.is_contiguous() and kv.is_contiguous() and indices.is_contiguous()
+    assert q.shape[0] == 1, "bucketed sparse MLA currently supports batch_size=1"
+
+    _, seq_len, heads, dim_plus_tail_dim = q.shape
+    out = torch.empty((1, seq_len, heads, d_v), device=q.device, dtype=q.dtype)
+    lse = torch.empty((1, seq_len, heads), device=q.device, dtype=torch.float32)
+
+    for bucket_topk, query_indices in _query_buckets(indices, kv.shape[1], bucket_sizes):
+        q_bucket = q.index_select(1, query_indices).contiguous()
+        indices_bucket = indices.index_select(1, query_indices)[..., :bucket_topk].contiguous()
+        out_bucket, lse_bucket = sparse_mla_fwd_interface(
+            q_bucket,
+            kv,
+            indices_bucket,
+            sm_scale=sm_scale,
+            d_v=d_v,
+        )
+        out.index_copy_(1, query_indices, out_bucket)
+        lse.index_copy_(1, query_indices, lse_bucket)
+
+    return out, lse
+
+
+def sparse_mla_bwd_bucketed(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    o: torch.Tensor,
+    do: torch.Tensor,
+    indices: torch.Tensor,
+    lse: torch.Tensor,
+    sm_scale=None,
+    bucket_sizes: tuple[int, ...] = DEFAULT_BUCKET_SIZES,
+    sort_bwd_indices: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    assert q.is_contiguous()
+    assert kv.is_contiguous()
+    assert o.is_contiguous()
+    assert do.is_contiguous()
+    assert indices.is_contiguous()
+    assert lse.is_contiguous()
+    assert q.shape[0] == 1, "bucketed sparse MLA currently supports batch_size=1"
+
+    _, _, heads, dim_plus_tail_dim = q.shape
+    _, _, kv_group, _ = kv.shape
+    d_v = 512
+    d_tail = dim_plus_tail_dim - d_v
+    assert kv_group == 1, "bucketed sparse MLA currently supports kv_group=1"
+
+    preprocess_kernel = preprocess(heads, d_v)
+    postprocess_kernel = postprocess(d_v, d_tail, kv_group)
+    dkv_acc = torch.zeros_like(kv, dtype=torch.float32)
+    dq = torch.empty_like(q)
+
+    for bucket_topk, query_indices in _query_buckets(indices, kv.shape[1], bucket_sizes):
+        q_bucket = q.index_select(1, query_indices).contiguous()
+        o_bucket = o.index_select(1, query_indices).contiguous()
+        do_bucket = do.index_select(1, query_indices).contiguous()
+        lse_bucket = lse.index_select(1, query_indices).contiguous()
+        indices_bucket = indices.index_select(1, query_indices)[..., :bucket_topk].contiguous()
+        if sort_bwd_indices:
+            indices_bucket = torch.sort(indices_bucket, dim=-1).values.contiguous()
+
+        delta = preprocess_kernel(o_bucket, do_bucket)
+        bwd_kernel = bwd(
+            heads,
+            d_v,
+            d_tail,
+            bucket_topk,
+            kv_group,
+            sm_scale,
+            True,
+            block_size=32,
+            split_store=4,
+            use_gemm_v1=True,
+        )
+        dq_bucket = bwd_kernel(q_bucket, kv, do_bucket, indices_bucket, lse_bucket, delta, dkv_acc)
+        dq.index_copy_(1, query_indices, dq_bucket)
+
+    dkv = postprocess_kernel(dkv_acc)
+    return dq, dkv

--- a/src/prime_rl/trainer/models/kernels/sparse_mla_bwd.py
+++ b/src/prime_rl/trainer/models/kernels/sparse_mla_bwd.py
@@ -1,5 +1,14 @@
 # Vendored from tile-ai/tilelang (Apache 2.0), modified for dynamic shapes.
 
+# TileLang ships a libcudart stub that proxies to the real CUDA runtime via
+# dlsym(RTLD_DEFAULT, ...).  If the stub's own symbols are the first ones found
+# (because nothing loaded the real libcudart globally yet), the self-check fails
+# and the stub calls abort().  Pre-loading the real library with RTLD_GLOBAL
+# ensures dlsym finds it before the stub's own exports.
+import ctypes as _ctypes
+
+_ctypes.CDLL("libcudart.so", mode=_ctypes.RTLD_GLOBAL)
+
 import tilelang
 import torch
 from tilelang import language as T
@@ -92,15 +101,24 @@ def bwd(
     block_size=32,
     num_stages=0,
     threads=256,
+    split_store=2,
+    gemm_policy=T.GemmWarpPolicy.FullCol,
+    use_gemm_v1=False,
+    mask_invalid_stores=False,
+    skip_invalid_blocks=False,
     indices_dtype=T.int32,
     dtype=T.bfloat16,
     accum_dtype=T.float32,
+    compute_dq=True,
+    compute_dkv=True,
 ):
     assert is_causal is True, "non-casual is not supported now"
     assert topk % block_size == 0, "otherwise will load some index=0 thus causing wrong kv to be loaded"
     assert dtype == T.bfloat16
     assert accum_dtype == T.float32
     assert indices_dtype == T.int32
+    assert compute_dq or compute_dkv
+    assert block_size % split_store == 0
 
     if sm_scale is None:
         sm_scale = (D + D_tail) ** (-0.5)
@@ -125,8 +143,7 @@ def bwd(
     NH = padded_H // block_H
     BS = block_size
     NS = tilelang.cdiv(topk, block_size)
-
-    split_store = 2
+    gemm = T.gemm_v1 if use_gemm_v1 else T.gemm
 
     @T.prim_func
     def sparse_mla_bwd_kernel(
@@ -154,12 +171,14 @@ def bwd(
 
             acc_p = T.alloc_fragment([block_H, BS], accum_dtype)
             acc_dp = T.alloc_fragment([block_H, BS], accum_dtype)
-            acc_dq = T.alloc_fragment([block_H, D], accum_dtype)
-            acc_dq_tail = T.alloc_fragment([block_H, D_tail], accum_dtype)
-            acc_dkv = T.alloc_fragment([BS, D], accum_dtype)
-            acc_dkv_tail = T.alloc_fragment([BS, D_tail], accum_dtype)
-            acc_dkv_shared = T.alloc_shared([BS // split_store, D], accum_dtype)
-            acc_dkv_tail_shared = T.alloc_shared([BS // split_store, D_tail], accum_dtype)
+            if compute_dq:
+                acc_dq = T.alloc_fragment([block_H, D], accum_dtype)
+                acc_dq_tail = T.alloc_fragment([block_H, D_tail], accum_dtype)
+            if compute_dkv:
+                acc_dkv = T.alloc_fragment([BS, D], accum_dtype)
+                acc_dkv_tail = T.alloc_fragment([BS, D_tail], accum_dtype)
+                acc_dkv_shared = T.alloc_shared([BS // split_store, D], accum_dtype)
+                acc_dkv_tail_shared = T.alloc_shared([BS // split_store, D_tail], accum_dtype)
 
             # See sparse_mla_fwd: sentinel is at index S_kv - 1 (zero KV), valid indices
             # live in [0, S_kv - 1). Using this single bound makes the kernel work for
@@ -170,10 +189,223 @@ def bwd(
             T.copy(Q[by, s_i, bz * block_H : (bz + 1) * block_H, D:], Q_tail_shared)
             T.copy(dO[by, s_i, bz * block_H : (bz + 1) * block_H, :D], dO_shared)
 
-            T.clear(acc_dq)
-            T.clear(acc_dq_tail)
+            if compute_dq:
+                T.clear(acc_dq)
+                T.clear(acc_dq_tail)
 
             for i_i in T.Pipelined(NS, num_stages=num_stages):
+                if (not skip_invalid_blocks) or (Indices[by, s_i, bz // NH, i_i * BS] <= max_kv_i):
+                    for bi_i in T.Parallel(BS):
+                        mask[bi_i] = Indices[by, s_i, bz // NH, i_i * BS + bi_i] <= max_kv_i
+
+                    for h_i, bi_i in T.Parallel(block_H, BS):
+                        acc_p[h_i, bi_i] = T.if_then_else(mask[bi_i], 0, -T.infinity(acc_p.dtype))
+
+                    for bi_i, d_i in T.Parallel(BS, D):
+                        KV_shared[bi_i, d_i] = KV[by, Indices[by, s_i, bz // NH, i_i * BS + bi_i], bz // NH, d_i]
+
+                    gemm(Q_shared, KV_shared, acc_p, transpose_B=True, policy=gemm_policy)
+
+                    for bi_i, d_i in T.Parallel(BS, D_tail):
+                        KV_tail_shared[bi_i, d_i] = KV[
+                            by, Indices[by, s_i, bz // NH, i_i * BS + bi_i], bz // NH, D + d_i
+                        ]
+                    gemm(Q_tail_shared, KV_tail_shared, acc_p, transpose_B=True, policy=gemm_policy)
+
+                    for h_i, bi_i in T.Parallel(block_H, BS):
+                        acc_p[h_i, bi_i] = T.exp2(
+                            acc_p[h_i, bi_i] * sm_scale_mul_reciprocal_log2 - Lse[by, s_i, bz * block_H + h_i]
+                        )
+
+                    T.copy(acc_p, P_shared_cast)
+
+                    gemm(dO_shared, KV_shared, acc_dp, transpose_B=True, policy=gemm_policy, clear_accum=True)
+
+                    for h_i, bi_i in T.Parallel(block_H, BS):
+                        acc_dp[h_i, bi_i] = (
+                            acc_p[h_i, bi_i] * (acc_dp[h_i, bi_i] - Delta[by, s_i, bz * block_H + h_i]) * sm_scale
+                        )
+
+                    if compute_dq or compute_dkv:
+                        T.copy(acc_dp, dP_shared_cast)
+
+                    if compute_dq:
+                        gemm(dP_shared_cast, KV_shared, acc_dq, policy=gemm_policy)
+                        gemm(dP_shared_cast, KV_tail_shared, acc_dq_tail, policy=gemm_policy)
+
+                    if compute_dkv:
+                        gemm(
+                            dP_shared_cast,
+                            Q_shared,
+                            acc_dkv,
+                            transpose_A=True,
+                            policy=gemm_policy,
+                            clear_accum=True,
+                        )
+                        gemm(P_shared_cast, dO_shared, acc_dkv, transpose_A=True, policy=gemm_policy)
+
+                        T.clear(acc_dkv_tail)
+                        gemm(dP_shared_cast, Q_tail_shared, acc_dkv_tail, transpose_A=True, policy=gemm_policy)
+
+                        for s in range(split_store):
+                            for bi_i, d_i in T.Parallel(BS, D):
+                                if bi_i < BS // split_store:
+                                    acc_dkv_shared[bi_i, d_i] = acc_dkv[bi_i + s * (BS // split_store), d_i]
+
+                            for bi_i, d_i in T.Parallel(BS, D_tail):
+                                if bi_i < BS // split_store:
+                                    acc_dkv_tail_shared[bi_i, d_i] = acc_dkv_tail[bi_i + s * (BS // split_store), d_i]
+
+                            for bi_i, d_i in T.Parallel(BS // split_store, D // 4):
+                                if mask_invalid_stores:
+                                    if mask[bi_i + s * (BS // split_store)]:
+                                        T.atomic_addx4(
+                                            dKV[
+                                                by,
+                                                Indices[by, s_i, bz // NH, i_i * BS + bi_i + s * (BS // split_store)],
+                                                bz // NH,
+                                                d_i * 4,
+                                            ],
+                                            acc_dkv_shared[bi_i, d_i * 4],
+                                        )
+                                else:
+                                    T.atomic_addx4(
+                                        dKV[
+                                            by,
+                                            Indices[by, s_i, bz // NH, i_i * BS + bi_i + s * (BS // split_store)],
+                                            bz // NH,
+                                            d_i * 4,
+                                        ],
+                                        acc_dkv_shared[bi_i, d_i * 4],
+                                    )
+
+                            for bi_i, d_i in T.Parallel(BS // split_store, D_tail // 4):
+                                if mask_invalid_stores:
+                                    if mask[bi_i + s * (BS // split_store)]:
+                                        T.atomic_addx4(
+                                            dKV[
+                                                by,
+                                                Indices[by, s_i, bz // NH, i_i * BS + bi_i + s * (BS // split_store)],
+                                                bz // NH,
+                                                D + d_i * 4,
+                                            ],
+                                            acc_dkv_tail_shared[bi_i, d_i * 4],
+                                        )
+                                else:
+                                    T.atomic_addx4(
+                                        dKV[
+                                            by,
+                                            Indices[by, s_i, bz // NH, i_i * BS + bi_i + s * (BS // split_store)],
+                                            bz // NH,
+                                            D + d_i * 4,
+                                        ],
+                                        acc_dkv_tail_shared[bi_i, d_i * 4],
+                                    )
+
+            if compute_dq:
+                T.copy(acc_dq, dQ_shared)
+                T.copy(acc_dq_tail, dQ_tail_shared)
+
+                T.copy(dQ_shared, dQ[by, s_i, bz * block_H : (bz + 1) * block_H, :D])
+                T.copy(dQ_tail_shared, dQ[by, s_i, bz * block_H : (bz + 1) * block_H, D:])
+
+    return sparse_mla_bwd_kernel
+
+
+@tilelang.jit(
+    out_idx=[],
+    pass_configs={
+        tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+        tilelang.PassConfigKey.TL_ENABLE_AGGRESSIVE_SHARED_MEMORY_MERGE: True,
+    },
+)
+def bwd_dkv_split_topk(
+    H,
+    D,
+    D_tail,
+    topk,
+    kv_group=1,
+    sm_scale=None,
+    block_size=64,
+    chunk_topk=512,
+    num_stages=0,
+    threads=256,
+    indices_dtype=T.int32,
+    dtype=T.bfloat16,
+    accum_dtype=T.float32,
+):
+    assert topk % block_size == 0
+    assert chunk_topk % block_size == 0
+    assert topk % chunk_topk == 0
+    assert dtype == T.bfloat16
+    assert accum_dtype == T.float32
+    assert indices_dtype == T.int32
+
+    if sm_scale is None:
+        sm_scale = (D + D_tail) ** (-0.5)
+    sm_scale_mul_reciprocal_log2 = sm_scale * 1.44269504
+
+    B = T.dynamic("B")
+    S = T.dynamic("S")
+    S_kv = T.dynamic("S_kv")
+
+    H_kv = H // kv_group
+    q_shape = [B, S, H, D + D_tail]
+    k_shape = [B, S_kv, kv_group, D + D_tail]
+    o_shape = [B, S, H, D]
+    indices_shape = [B, S, kv_group, topk]
+    delta_shape = [B, S, H]
+    lse_shape = [B, S, H]
+
+    H = H_kv
+    padded_H = max(tilelang.math.next_power_of_2(H_kv), 16)
+    block_H = min(64, padded_H)
+    assert padded_H % block_H == 0
+    NH = padded_H // block_H
+    BS = block_size
+    split_store = 2
+    chunk_blocks = chunk_topk // block_size
+    num_chunks = topk // chunk_topk
+
+    @T.prim_func
+    def sparse_mla_bwd_dkv_split_topk_kernel(
+        Q: T.Tensor(q_shape, dtype),
+        KV: T.Tensor(k_shape, dtype),
+        dO: T.Tensor(o_shape, dtype),
+        Indices: T.Tensor(indices_shape, indices_dtype),
+        Lse: T.Tensor(lse_shape, accum_dtype),
+        Delta: T.Tensor(delta_shape, accum_dtype),
+        dKV: T.Tensor(k_shape, accum_dtype),
+    ):
+        with T.Kernel(S * num_chunks, B, kv_group * NH, threads=threads) as (bx, by, bz):
+            s_i = bx // num_chunks
+            chunk_i = bx % num_chunks
+            Q_shared = T.alloc_shared([block_H, D], dtype)
+            Q_tail_shared = T.alloc_shared([block_H, D_tail], dtype)
+            KV_shared = T.alloc_shared([BS, D], dtype)
+            KV_tail_shared = T.alloc_shared([BS, D_tail], dtype)
+            dO_shared = T.alloc_shared([block_H, D], dtype)
+            mask = T.alloc_fragment([BS], "bool")
+
+            P_shared_cast = T.alloc_shared([block_H, BS], dtype)
+            dP_shared_cast = T.alloc_shared([block_H, BS], dtype)
+
+            acc_p = T.alloc_fragment([block_H, BS], accum_dtype)
+            acc_dp = T.alloc_fragment([block_H, BS], accum_dtype)
+            acc_dkv = T.alloc_fragment([BS, D], accum_dtype)
+            acc_dkv_tail = T.alloc_fragment([BS, D_tail], accum_dtype)
+            acc_dkv_shared = T.alloc_shared([BS // split_store, D], accum_dtype)
+            acc_dkv_tail_shared = T.alloc_shared([BS // split_store, D_tail], accum_dtype)
+
+            max_kv_i = S_kv - 2
+
+            T.copy(Q[by, s_i, bz * block_H : (bz + 1) * block_H, :D], Q_shared)
+            T.copy(Q[by, s_i, bz * block_H : (bz + 1) * block_H, D:], Q_tail_shared)
+            T.copy(dO[by, s_i, bz * block_H : (bz + 1) * block_H, :D], dO_shared)
+
+            for local_i in T.Pipelined(chunk_blocks, num_stages=num_stages):
+                i_i = chunk_i * chunk_blocks + local_i
                 for bi_i in T.Parallel(BS):
                     mask[bi_i] = Indices[by, s_i, bz // NH, i_i * BS + bi_i] <= max_kv_i
 
@@ -195,20 +427,15 @@ def bwd(
                     )
 
                 T.copy(acc_p, P_shared_cast)
-
                 T.gemm(
                     dO_shared, KV_shared, acc_dp, transpose_B=True, policy=T.GemmWarpPolicy.FullCol, clear_accum=True
                 )
-
                 for h_i, bi_i in T.Parallel(block_H, BS):
                     acc_dp[h_i, bi_i] = (
                         acc_p[h_i, bi_i] * (acc_dp[h_i, bi_i] - Delta[by, s_i, bz * block_H + h_i]) * sm_scale
                     )
 
                 T.copy(acc_dp, dP_shared_cast)
-                T.gemm(dP_shared_cast, KV_shared, acc_dq, policy=T.GemmWarpPolicy.FullCol)
-                T.gemm(dP_shared_cast, KV_tail_shared, acc_dq_tail, policy=T.GemmWarpPolicy.FullCol)
-
                 T.gemm(
                     dP_shared_cast,
                     Q_shared,
@@ -232,37 +459,46 @@ def bwd(
                             acc_dkv_tail_shared[bi_i, d_i] = acc_dkv_tail[bi_i + s * (BS // split_store), d_i]
 
                     for bi_i, d_i in T.Parallel(BS // split_store, D // 4):
-                        T.atomic_addx4(
-                            dKV[
-                                by,
-                                Indices[by, s_i, bz // NH, i_i * BS + bi_i + s * (BS // split_store)],
-                                bz // NH,
-                                d_i * 4,
-                            ],
-                            acc_dkv_shared[bi_i, d_i * 4],
-                        )
+                        if mask[bi_i + s * (BS // split_store)]:
+                            T.atomic_addx4(
+                                dKV[
+                                    by,
+                                    Indices[by, s_i, bz // NH, i_i * BS + bi_i + s * (BS // split_store)],
+                                    bz // NH,
+                                    d_i * 4,
+                                ],
+                                acc_dkv_shared[bi_i, d_i * 4],
+                            )
 
                     for bi_i, d_i in T.Parallel(BS // split_store, D_tail // 4):
-                        T.atomic_addx4(
-                            dKV[
-                                by,
-                                Indices[by, s_i, bz // NH, i_i * BS + bi_i + s * (BS // split_store)],
-                                bz // NH,
-                                D + d_i * 4,
-                            ],
-                            acc_dkv_tail_shared[bi_i, d_i * 4],
-                        )
+                        if mask[bi_i + s * (BS // split_store)]:
+                            T.atomic_addx4(
+                                dKV[
+                                    by,
+                                    Indices[by, s_i, bz // NH, i_i * BS + bi_i + s * (BS // split_store)],
+                                    bz // NH,
+                                    D + d_i * 4,
+                                ],
+                                acc_dkv_tail_shared[bi_i, d_i * 4],
+                            )
 
-            T.copy(acc_dq, dQ_shared)
-            T.copy(acc_dq_tail, dQ_tail_shared)
-
-            T.copy(dQ_shared, dQ[by, s_i, bz * block_H : (bz + 1) * block_H, :D])
-            T.copy(dQ_tail_shared, dQ[by, s_i, bz * block_H : (bz + 1) * block_H, D:])
-
-    return sparse_mla_bwd_kernel
+    return sparse_mla_bwd_dkv_split_topk_kernel
 
 
-def sparse_mla_bwd(q, kv, o, do, indices, lse, sm_scale=None):
+def sparse_mla_bwd(
+    q,
+    kv,
+    o,
+    do,
+    indices,
+    lse,
+    sm_scale=None,
+    block_size=32,
+    split_store=2,
+    use_gemm_v1=False,
+    mask_invalid_stores=False,
+    skip_invalid_blocks=False,
+):
     assert q.is_contiguous()
     assert kv.is_contiguous()
     assert indices.is_contiguous()
@@ -278,12 +514,138 @@ def sparse_mla_bwd(q, kv, o, do, indices, lse, sm_scale=None):
     assert lse.shape == (B, S, H)
 
     preprocess_kernel = preprocess(H, D)
-    bwd_kernel = bwd(H, D, D_tail, topk, kv_group, sm_scale, True)
+    bwd_kernel = bwd(
+        H,
+        D,
+        D_tail,
+        topk,
+        kv_group,
+        sm_scale,
+        True,
+        block_size=block_size,
+        split_store=split_store,
+        use_gemm_v1=use_gemm_v1,
+        mask_invalid_stores=mask_invalid_stores,
+        skip_invalid_blocks=skip_invalid_blocks,
+    )
     postprocess_kernel = postprocess(D, D_tail, kv_group)
 
     delta = preprocess_kernel(o, do)
     dkv = torch.zeros_like(kv, dtype=torch.float32)
     dq = bwd_kernel(q, kv, do, indices, lse, delta, dkv)
+    dkv = postprocess_kernel(dkv)
+
+    return dq, dkv
+
+
+def sparse_mla_bwd_split(q, kv, o, do, indices, lse, sm_scale=None, block_size=64, overlap=False):
+    assert q.is_contiguous()
+    assert kv.is_contiguous()
+    assert indices.is_contiguous()
+    assert lse.is_contiguous()
+    B, S, H, dim_plus_tail_dim = q.shape
+    _, S_kv, kv_group, _ = kv.shape
+    assert kv.shape[-1] == dim_plus_tail_dim
+    assert kv.shape[0] == B
+    D = 512
+    D_tail = dim_plus_tail_dim - D
+    topk = indices.shape[-1]
+    assert indices.shape == (B, S, kv_group, topk)
+    assert lse.shape == (B, S, H)
+
+    preprocess_kernel = preprocess(H, D)
+    dq_kernel = bwd(
+        H,
+        D,
+        D_tail,
+        topk,
+        kv_group,
+        sm_scale,
+        True,
+        block_size=block_size,
+        compute_dq=True,
+        compute_dkv=False,
+    )
+    dkv_kernel = bwd(
+        H,
+        D,
+        D_tail,
+        topk,
+        kv_group,
+        sm_scale,
+        True,
+        block_size=block_size,
+        compute_dq=False,
+        compute_dkv=True,
+    )
+    postprocess_kernel = postprocess(D, D_tail, kv_group)
+
+    delta = preprocess_kernel(o, do)
+    dkv = torch.zeros_like(kv, dtype=torch.float32)
+    if not overlap:
+        dq = dq_kernel(q, kv, do, indices, lse, delta, dkv)
+        dkv_kernel(q, kv, do, indices, lse, delta, dkv)
+    else:
+        current_stream = torch.cuda.current_stream(q.device)
+        dq_stream = torch.cuda.Stream(device=q.device)
+        dkv_stream = torch.cuda.Stream(device=q.device)
+        dq_stream.wait_stream(current_stream)
+        dkv_stream.wait_stream(current_stream)
+        with torch.cuda.stream(dq_stream):
+            dq = dq_kernel(q, kv, do, indices, lse, delta, dkv)
+        with torch.cuda.stream(dkv_stream):
+            dkv_kernel(q, kv, do, indices, lse, delta, dkv)
+        current_stream.wait_stream(dq_stream)
+        current_stream.wait_stream(dkv_stream)
+    dkv = postprocess_kernel(dkv)
+
+    return dq, dkv
+
+
+def sparse_mla_bwd_split_topk(q, kv, o, do, indices, lse, sm_scale=None, block_size=64, chunk_topk=512):
+    assert q.is_contiguous()
+    assert kv.is_contiguous()
+    assert indices.is_contiguous()
+    assert lse.is_contiguous()
+    B, S, H, dim_plus_tail_dim = q.shape
+    _, S_kv, kv_group, _ = kv.shape
+    assert kv.shape[-1] == dim_plus_tail_dim
+    assert kv.shape[0] == B
+    D = 512
+    D_tail = dim_plus_tail_dim - D
+    topk = indices.shape[-1]
+    assert indices.shape == (B, S, kv_group, topk)
+    assert lse.shape == (B, S, H)
+
+    preprocess_kernel = preprocess(H, D)
+    dq_kernel = bwd(
+        H,
+        D,
+        D_tail,
+        topk,
+        kv_group,
+        sm_scale,
+        True,
+        block_size=block_size,
+        compute_dq=True,
+        compute_dkv=False,
+    )
+    dkv_kernel = bwd_dkv_split_topk(
+        H,
+        D,
+        D_tail,
+        topk,
+        kv_group,
+        sm_scale,
+        block_size=block_size,
+        chunk_topk=chunk_topk,
+    )
+    postprocess_kernel = postprocess(D, D_tail, kv_group)
+
+    delta = preprocess_kernel(o, do)
+    dkv = torch.zeros_like(kv, dtype=torch.float32)
+    dq = dq_kernel(q, kv, do, indices, lse, delta, dkv)
+    dkv_kernel(q, kv, do, indices, lse, delta, dkv)
     dkv = postprocess_kernel(dkv)
 
     return dq, dkv

--- a/src/prime_rl/trainer/models/kernels/sparse_mla_fwd.py
+++ b/src/prime_rl/trainer/models/kernels/sparse_mla_fwd.py
@@ -1,5 +1,14 @@
 # Vendored from tile-ai/tilelang (Apache 2.0), modified for dynamic shapes.
 
+# TileLang ships a libcudart stub that proxies to the real CUDA runtime via
+# dlsym(RTLD_DEFAULT, ...).  If the stub's own symbols are the first ones found
+# (because nothing loaded the real libcudart globally yet), the self-check fails
+# and the stub calls abort().  Pre-loading the real library with RTLD_GLOBAL
+# ensures dlsym finds it before the stub's own exports.
+import ctypes as _ctypes
+
+_ctypes.CDLL("libcudart.so", mode=_ctypes.RTLD_GLOBAL)
+
 import tilelang
 from tilelang import language as T
 
@@ -23,6 +32,7 @@ def sparse_mla_fwd(
     block_I=64,
     num_stages=2,
     threads=256,
+    skip_invalid_blocks=False,
 ):
     assert dim == tilelang.math.next_power_of_2(dim), f"haven't check padding correctness yet, dim={dim}"
     assert tail_dim == tilelang.math.next_power_of_2(tail_dim), f"haven't check padding correctness yet, dim={tail_dim}"
@@ -118,46 +128,47 @@ def sparse_mla_fwd(
             T.copy(Q[b_i, s_i, H0:H1, D:], Q_tail_shared)
 
             for i_i in T.Pipelined(NI, num_stages=num_stages):
-                for bi_i in T.Parallel(BI):
-                    mask[bi_i] = Indices[b_i, s_i, g_i, i_i * BI + bi_i] <= max_kv_i
+                if (not skip_invalid_blocks) or (Indices[b_i, s_i, g_i, i_i * BI] <= max_kv_i):
+                    for bi_i in T.Parallel(BI):
+                        mask[bi_i] = Indices[b_i, s_i, g_i, i_i * BI + bi_i] <= max_kv_i
 
-                for bi_i, d_i in T.Parallel(BI, D):
-                    KV_shared[bi_i, d_i] = KV[b_i, Indices[b_i, s_i, g_i, i_i * BI + bi_i], g_i, d_i]
-                for bi_i, d_i in T.Parallel(BI, D_tail):
-                    K_tail_shared[bi_i, d_i] = KV[b_i, Indices[b_i, s_i, g_i, i_i * BI + bi_i], g_i, D + d_i]
+                    for bi_i, d_i in T.Parallel(BI, D):
+                        KV_shared[bi_i, d_i] = KV[b_i, Indices[b_i, s_i, g_i, i_i * BI + bi_i], g_i, d_i]
+                    for bi_i, d_i in T.Parallel(BI, D_tail):
+                        K_tail_shared[bi_i, d_i] = KV[b_i, Indices[b_i, s_i, g_i, i_i * BI + bi_i], g_i, D + d_i]
 
-                for h_i, bi_i in T.Parallel(H_per_block, BI):
-                    acc_s[h_i, bi_i] = T.if_then_else(mask[bi_i], 0, -T.infinity(acc_s.dtype))
-                T.gemm(
-                    Q_shared,
-                    KV_shared,
-                    acc_s,
-                    transpose_B=True,
-                    policy=T.GemmWarpPolicy.FullRow,
-                )
-                T.gemm(
-                    Q_tail_shared,
-                    K_tail_shared,
-                    acc_s,
-                    transpose_B=True,
-                    policy=T.GemmWarpPolicy.FullRow,
-                )
-                T.copy(m_i, m_i_prev)
-                T.reduce_max(acc_s, m_i, dim=1, clear=False)
-                for h_i in T.Parallel(H_per_block):
-                    m_i[h_i] = T.max(m_i[h_i], m_i_prev[h_i])
-                for h_i in T.Parallel(H_per_block):
-                    alpha[h_i] = T.exp2((m_i_prev[h_i] - m_i[h_i]) * sm_scale)
-                for h_i, bi_i in T.Parallel(H_per_block, BI):
-                    acc_s[h_i, bi_i] = T.exp2(acc_s[h_i, bi_i] * sm_scale - m_i[h_i] * sm_scale)
-                T.reduce_sum(acc_s, sumexp_i, dim=1)
-                for h_i in T.Parallel(H_per_block):
-                    sumexp[h_i] = sumexp[h_i] * alpha[h_i] + sumexp_i[h_i]
-                for h_i, d_i in T.Parallel(H_per_block, D):
-                    acc_o[h_i, d_i] = acc_o[h_i, d_i] * alpha[h_i]
+                    for h_i, bi_i in T.Parallel(H_per_block, BI):
+                        acc_s[h_i, bi_i] = T.if_then_else(mask[bi_i], 0, -T.infinity(acc_s.dtype))
+                    T.gemm(
+                        Q_shared,
+                        KV_shared,
+                        acc_s,
+                        transpose_B=True,
+                        policy=T.GemmWarpPolicy.FullRow,
+                    )
+                    T.gemm(
+                        Q_tail_shared,
+                        K_tail_shared,
+                        acc_s,
+                        transpose_B=True,
+                        policy=T.GemmWarpPolicy.FullRow,
+                    )
+                    T.copy(m_i, m_i_prev)
+                    T.reduce_max(acc_s, m_i, dim=1, clear=False)
+                    for h_i in T.Parallel(H_per_block):
+                        m_i[h_i] = T.max(m_i[h_i], m_i_prev[h_i])
+                    for h_i in T.Parallel(H_per_block):
+                        alpha[h_i] = T.exp2((m_i_prev[h_i] - m_i[h_i]) * sm_scale)
+                    for h_i, bi_i in T.Parallel(H_per_block, BI):
+                        acc_s[h_i, bi_i] = T.exp2(acc_s[h_i, bi_i] * sm_scale - m_i[h_i] * sm_scale)
+                    T.reduce_sum(acc_s, sumexp_i, dim=1)
+                    for h_i in T.Parallel(H_per_block):
+                        sumexp[h_i] = sumexp[h_i] * alpha[h_i] + sumexp_i[h_i]
+                    for h_i, d_i in T.Parallel(H_per_block, D):
+                        acc_o[h_i, d_i] = acc_o[h_i, d_i] * alpha[h_i]
 
-                T.copy(acc_s, S_shared)
-                T.gemm(S_shared, KV_shared, acc_o, policy=T.GemmWarpPolicy.FullRow)
+                    T.copy(acc_s, S_shared)
+                    T.gemm(S_shared, KV_shared, acc_o, policy=T.GemmWarpPolicy.FullRow)
 
             for h_i, d_i in T.Parallel(H_per_block, D):
                 acc_o[h_i, d_i] /= sumexp[h_i]
@@ -170,7 +181,17 @@ def sparse_mla_fwd(
     return main
 
 
-def sparse_mla_fwd_interface(q, kv, indices, sm_scale=None, d_v=512, block_I=64, num_stages=2, threads=256):
+def sparse_mla_fwd_interface(
+    q,
+    kv,
+    indices,
+    sm_scale=None,
+    d_v=512,
+    block_I=64,
+    num_stages=2,
+    threads=256,
+    skip_invalid_blocks=False,
+):
     assert q.is_contiguous() and kv.is_contiguous() and indices.is_contiguous()
     batch, seq_len, heads, dim_plus_tail_dim = q.shape
     _, seq_len_kv, kv_group, _ = kv.shape
@@ -194,6 +215,7 @@ def sparse_mla_fwd_interface(q, kv, indices, sm_scale=None, d_v=512, block_I=64,
         block_I=block_I,
         num_stages=num_stages,
         threads=threads,
+        skip_invalid_blocks=skip_invalid_blocks,
     )
     out, lse = kernel(q, kv, indices)
     return out, lse


### PR DESCRIPTION
## Summary

Adds a bucketed alternative to the single-kernel TileLang sparse-MLA fwd/bwd, gated by `PRIME_RL_EXPERIMENTAL_MLA_BWD=1`. Default behaviour is unchanged.

The bucketed backend partitions queries by their number of valid KV indices into the buckets `(256, 512, 1024, 1536, 2048)` and dispatches a size-specialized fwd/bwd kernel per bucket. Pays a per-bucket compile up front, then earns it back when most queries don't need the full topk.

## What's in this PR

- `src/prime_rl/trainer/models/kernels/sparse_mla_bucketed.py` — new module: `sparse_mla_fwd_bucketed` + `sparse_mla_bwd_bucketed`. Reuses `preprocess`/`postprocess` from `sparse_mla_bwd.py` and `sparse_mla_fwd_interface` from `sparse_mla_fwd.py`.
- `src/prime_rl/trainer/models/kernels/sparse_mla_bwd.py` / `sparse_mla_fwd.py` — extended kernel APIs (`block_size`, `split_store`, `use_gemm_v1`, gemm-v1 path) needed by the bucketed wrapper.
- `src/prime_rl/trainer/models/glm_moe_dsa/sparse_mla_attention.py` — single-env-var dispatch:
  - `PRIME_RL_EXPERIMENTAL_MLA_BWD` unset / `0` / `false` → existing TileLang path (no change).
  - set to `1` / `true` / `yes` / `on` → bucketed path.

## Notes

- Bucketed fwd/bwd currently assume `batch_size=1` (asserted at the entry point).
- Default-disabled, so this PR is functionally a no-op for any existing config that doesn't set the env var.