### PR TITLE
feat(renderer): expose preserve_*_thinking flags in RendererConfig

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -1269,6 +1269,12 @@ class OrchestratorConfig(BaseConfig):
             renderer_args_set.append(f"renderer.reasoning_parser={self.renderer.reasoning_parser!r}")
         if self.renderer.pool_size is not None:
             renderer_args_set.append(f"renderer.pool_size={self.renderer.pool_size!r}")
+        if self.renderer.preserve_all_thinking:
+            renderer_args_set.append(f"renderer.preserve_all_thinking={self.renderer.preserve_all_thinking!r}")
+        if self.renderer.preserve_thinking_between_tool_calls:
+            renderer_args_set.append(
+                f"renderer.preserve_thinking_between_tool_calls={self.renderer.preserve_thinking_between_tool_calls!r}"
+            )
 
         if renderer_args_set:
             raise ValueError(

--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -414,6 +414,12 @@ class SFTConfig(BaseConfig):
             renderer_args_set.append(f"renderer.tool_parser={self.renderer.tool_parser!r}")
         if self.renderer.reasoning_parser is not None:
             renderer_args_set.append(f"renderer.reasoning_parser={self.renderer.reasoning_parser!r}")
+        if self.renderer.preserve_all_thinking:
+            renderer_args_set.append(f"renderer.preserve_all_thinking={self.renderer.preserve_all_thinking!r}")
+        if self.renderer.preserve_thinking_between_tool_calls:
+            renderer_args_set.append(
+                f"renderer.preserve_thinking_between_tool_calls={self.renderer.preserve_thinking_between_tool_calls!r}"
+            )
 
         if renderer_args_set:
             raise ValueError(

--- a/packages/prime-rl-configs/src/prime_rl/configs/shared.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/shared.py
@@ -186,6 +186,37 @@ class RendererConfig(BaseConfig):
         ),
     ] = None
 
+    preserve_all_thinking: Annotated[
+        bool,
+        Field(
+            description=(
+                "Override flag forwarded to the renderer at construction. When "
+                "True, every past-assistant turn's ``reasoning_content`` is "
+                "re-emitted between ``<think>``/``</think>`` (or the model's "
+                "equivalent), even if the underlying chat template would drop "
+                "it. Off by default — preserves byte-identical output to the "
+                "stock template. Strict superset of "
+                "``preserve_thinking_between_tool_calls``."
+            ),
+        ),
+    ] = False
+
+    preserve_thinking_between_tool_calls: Annotated[
+        bool,
+        Field(
+            description=(
+                "Override flag forwarded to the renderer at construction. When "
+                "True, preserves past-assistant ``reasoning_content`` only "
+                "inside the *current* tool cycle — the contiguous "
+                "assistant→tool→…→assistant block after the most recent user "
+                "message, when that block contains at least one tool response. "
+                "A new user turn closes the block; older blocks fall back to "
+                "the template default (typically dropped). Use "
+                "``preserve_all_thinking`` to keep older blocks too."
+            ),
+        ),
+    ] = False
+
 
 class ElasticConfig(BaseConfig):
     """Configures elastic inference pool with DNS-based service discovery.

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -926,6 +926,8 @@ async def setup_rollout_inference_pool(
             renderer=config.renderer.name,
             tool_parser=config.renderer.tool_parser,
             reasoning_parser=config.renderer.reasoning_parser,
+            preserve_all_thinking=config.renderer.preserve_all_thinking,
+            preserve_thinking_between_tool_calls=config.renderer.preserve_thinking_between_tool_calls,
         )
         logger.info(f"Initialized {type(renderer).__name__} for {config.model.name}")
         inference_pool = await setup_inference_pool(
@@ -937,6 +939,8 @@ async def setup_rollout_inference_pool(
             tool_parser=config.renderer.tool_parser,
             reasoning_parser=config.renderer.reasoning_parser,
             renderer_pool_size=config.renderer.pool_size,
+            preserve_all_thinking=config.renderer.preserve_all_thinking,
+            preserve_thinking_between_tool_calls=config.renderer.preserve_thinking_between_tool_calls,
         )
         logger.info("Using direct renderer rollout client")
         return renderer, inference_pool

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -166,6 +166,8 @@ def train(config: SFTConfig):
             renderer=config.renderer.name,
             tool_parser=config.renderer.tool_parser,
             reasoning_parser=config.renderer.reasoning_parser,
+            preserve_all_thinking=config.renderer.preserve_all_thinking,
+            preserve_thinking_between_tool_calls=config.renderer.preserve_thinking_between_tool_calls,
         )
         if isinstance(renderer, DefaultRenderer):
             raise ValueError(

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -68,6 +68,8 @@ class StaticInferencePool:
         tool_parser: str | None = None,
         reasoning_parser: str | None = None,
         renderer_pool_size: int | None = None,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ):
         renderer_model_name = model_name if train_client_type == "renderer" else None
         self._train_clients = setup_clients(
@@ -78,6 +80,8 @@ class StaticInferencePool:
             tool_parser=tool_parser,
             reasoning_parser=reasoning_parser,
             renderer_pool_size=renderer_pool_size,
+            preserve_all_thinking=preserve_all_thinking,
+            preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
         )
         self._eval_clients = setup_clients(client_config, client_type=eval_client_type)
         self._admin_clients = setup_admin_clients(client_config)
@@ -129,6 +133,8 @@ async def setup_inference_pool(
     tool_parser: str | None = None,
     reasoning_parser: str | None = None,
     renderer_pool_size: int | None = None,
+    preserve_all_thinking: bool = False,
+    preserve_thinking_between_tool_calls: bool = False,
 ) -> InferencePool:
     """Create an inference pool from config (static or elastic)."""
     logger = get_logger()
@@ -152,6 +158,8 @@ async def setup_inference_pool(
             tool_parser=tool_parser,
             reasoning_parser=reasoning_parser,
             renderer_pool_size=renderer_pool_size,
+            preserve_all_thinking=preserve_all_thinking,
+            preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
         )
 
     logger.info(
@@ -168,6 +176,8 @@ async def setup_inference_pool(
         tool_parser=tool_parser,
         reasoning_parser=reasoning_parser,
         renderer_pool_size=renderer_pool_size,
+        preserve_all_thinking=preserve_all_thinking,
+        preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
     )
 
 
@@ -179,9 +189,20 @@ def setup_clients(
     tool_parser: str | None = None,
     reasoning_parser: str | None = None,
     renderer_pool_size: int | None = None,
+    preserve_all_thinking: bool = False,
+    preserve_thinking_between_tool_calls: bool = False,
 ) -> list[vf.ClientConfig]:
     clients = []
     client_idx = 0
+    # Only forward preserve flags when the client actually uses a renderer —
+    # MITO/TITO clients ignore them and the verifiers ClientConfig may reject
+    # unknown extras on older versions.
+    renderer_extra: dict = {}
+    if client_type == "renderer":
+        renderer_extra = {
+            "preserve_all_thinking": preserve_all_thinking,
+            "preserve_thinking_between_tool_calls": preserve_thinking_between_tool_calls,
+        }
     for base_url in client_config.base_url:
         for dp_rank in range(client_config.dp_rank_count):
             headers = client_config.headers.copy()
@@ -205,6 +226,7 @@ def setup_clients(
                     max_retries=10,
                     extra_headers=headers,
                     extra_headers_from_state=client_config.extra_headers_from_state,
+                    **renderer_extra,
                 )
             )
             client_idx += 1

--- a/src/prime_rl/utils/elastic.py
+++ b/src/prime_rl/utils/elastic.py
@@ -110,6 +110,8 @@ class ElasticInferencePool:
         tool_parser: str | None = None,
         reasoning_parser: str | None = None,
         renderer_pool_size: int | None = None,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ):
         self.logger = get_logger()
         self.client_config = client_config
@@ -125,6 +127,8 @@ class ElasticInferencePool:
         self.tool_parser = tool_parser
         self.reasoning_parser = reasoning_parser
         self.renderer_pool_size = renderer_pool_size
+        self.preserve_all_thinking = preserve_all_thinking
+        self.preserve_thinking_between_tool_calls = preserve_thinking_between_tool_calls
         self.router_url = client_config.router_url
 
         self._servers: dict[str, ServerState] = {}
@@ -152,6 +156,8 @@ class ElasticInferencePool:
         tool_parser: str | None = None,
         reasoning_parser: str | None = None,
         renderer_pool_size: int | None = None,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ) -> ElasticInferencePool:
         if client_config.elastic is None:
             raise ValueError("Elastic inference pool requires elastic config")
@@ -164,6 +170,8 @@ class ElasticInferencePool:
             tool_parser=tool_parser,
             reasoning_parser=reasoning_parser,
             renderer_pool_size=renderer_pool_size,
+            preserve_all_thinking=preserve_all_thinking,
+            preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
         )
         await pool.start()
         return pool
@@ -214,6 +222,8 @@ class ElasticInferencePool:
                     tool_parser=self.tool_parser,
                     reasoning_parser=self.reasoning_parser,
                     renderer_pool_size=self.renderer_pool_size,
+                    preserve_all_thinking=self.preserve_all_thinking,
+                    preserve_thinking_between_tool_calls=self.preserve_thinking_between_tool_calls,
                 )
                 if urls
                 else []

--- a/tests/unit/orchestrator/test_orchestrator_setup.py
+++ b/tests/unit/orchestrator/test_orchestrator_setup.py
@@ -50,6 +50,8 @@ def test_setup_rollout_inference_pool_uses_direct_renderer_client_for_local_vllm
                 tool_parser=None,
                 reasoning_parser=None,
                 pool_size=None,
+                preserve_all_thinking=False,
+                preserve_thinking_between_tool_calls=False,
             ),
         )
         rollout_client_config = SimpleNamespace(base_url=["http://localhost:8000/v1"])
@@ -79,6 +81,8 @@ def test_setup_rollout_inference_pool_uses_direct_renderer_client_for_local_vllm
             renderer="qwen3_vl",
             tool_parser=None,
             reasoning_parser=None,
+            preserve_all_thinking=False,
+            preserve_thinking_between_tool_calls=False,
         )
         setup_pool_mock.assert_awaited_once_with(
             rollout_client_config,
@@ -89,6 +93,8 @@ def test_setup_rollout_inference_pool_uses_direct_renderer_client_for_local_vllm
             tool_parser=None,
             reasoning_parser=None,
             renderer_pool_size=None,
+            preserve_all_thinking=False,
+            preserve_thinking_between_tool_calls=False,
         )
 
     asyncio.run(run())


### PR DESCRIPTION
## Summary

Re-applies #2433 onto `main`. The original PR landed against `feat/unify-inference-generate` and was merged there by mistake.

Adds two new fields to `RendererConfig`:

- `preserve_all_thinking: bool = False`
- `preserve_thinking_between_tool_calls: bool = False`

Both RL and SFT forward the flags to keep tokenization byte-consistent:

1. **Orchestrator `create_renderer()`** — bound at construction on the training-side renderer used by `build_trajectory_step` / `render_ids` for trajectory tokenization.
2. **Orchestrator `setup_inference_pool()` → `setup_clients()` → `vf.ClientConfig`** — the verifiers `RendererClient` picks them up and forwards to its `create_renderer_pool`, so every inference render carries the same thinking-preservation behaviour.
3. **SFT `create_renderer()`** — same construction-time binding on the training renderer, so SFT tokenization matches the configured preservation policy.

Both flags are off by default → zero behaviour change for existing configs. Both the orchestrator and SFT `validate_renderer_args` validators reject either flag when `use_renderer=False`, matching the existing renderer knobs.

## Per-flag semantics

- `preserve_all_thinking` — emit `reasoning_content` for every past-assistant turn, even those before another user message.
- `preserve_thinking_between_tool_calls` — emit `reasoning_content` only for the *current* tool cycle (post-last-user assistant→tool→…→assistant block). Older blocks fall back to template default. Strict subset of `preserve_all_thinking`.

## Example config

```toml
[orchestrator.renderer]
name = "glm5"
preserve_all_thinking = true
```

## Dependencies

No `pyproject.toml` / `uv.lock` changes. After the monorepo split in #2507, `verifiers` and `renderers` are uv workspace members vendored under `deps/`. Main's current submodule pins already include the upstream changes this PR depends on:

- `deps/verifiers` @ `711a7c7` — 76 commits ahead of the verifiers PR (#1298) that added `preserve_*_thinking` to `ClientConfig`.
- `deps/renderers` @ `87084dc` — 36 commits ahead of the renderers PR (#4) that added construction-time `preserve_*_thinking` to `create_renderer`.

## File-path delta vs #2433

The original PR targeted `feat/unify-inference-generate` where configs live under `src/prime_rl/configs/`. On `main` they live under `packages/prime-rl-configs/src/prime_rl/configs/` (workspace-package split landed in #2416). The diff is otherwise identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new renderer configuration knobs and threads them through orchestrator/inference client construction; while default-off, it touches rollout/inference plumbing and bumps `verifiers` plus adds a new `renderers` dependency, which could affect runtime compatibility.
> 
> **Overview**
> Exposes two new `RendererConfig` booleans (`preserve_all_thinking` and `preserve_thinking_between_tool_calls`) and extends orchestrator validation to reject them unless `orchestrator.use_renderer=true`.
> 
> When the renderer client is enabled, these flags are forwarded both to `create_renderer()` and through `setup_inference_pool()`/`setup_clients()` into `vf.ClientConfig` (guarded so non-renderer clients don’t receive unknown extras), keeping training-side tokenization and inference rendering consistent.
> 
> Updates dependencies by adding a direct `renderers` git dependency and bumping the pinned `verifiers` revision; unit tests are adjusted to assert the new parameters are passed through.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc381eb50b2800ebbd41c5473a53ba522b060d38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
