### PR TITLE
feat(inference): fp32 lm_head for stable logprobs under FP8/bf16

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -390,6 +390,13 @@ class InferenceConfig(BaseConfig):
         ),
     ] = False
 
+    enable_fp32_lm_head: Annotated[
+        bool,
+        Field(
+            description="Run the lm_head matmul in fp32 (cast both hidden_states and lm_head.weight to float32 before the projection). Stabilizes logprob precision under FP8/bf16 inference, matching SGLang's `--enable-fp32-lm-head`. Implemented as a monkey-patch over vLLM's LogitsProcessor, activated by setting `additional_config[\"fp32_lm_head\"] = True` on the vLLM config. Only supports models with `tie_word_embeddings=False`.",
+        ),
+    ] = False
+
     vllm_extra: Annotated[
         dict[str, Any],
         Field(
@@ -534,6 +541,13 @@ class InferenceConfig(BaseConfig):
 
         # Set `logprobs_mode` to `processed_logprobs` by default
         rsetattr(namespace, "logprobs_mode", "processed_logprobs")
+
+        # Pass prime-rl-specific flags through vLLM's additional_config dict;
+        # workers read these via get_current_vllm_config().additional_config.
+        if self.enable_fp32_lm_head:
+            existing = getattr(namespace, "additional_config", None) or {}
+            existing["fp32_lm_head"] = True
+            rsetattr(namespace, "additional_config", existing)
 
         # Remove chat_template if not set (vLLM doesn't accept None)
         if namespace.chat_template is None:

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -1086,3 +1086,90 @@ def monkey_patch_no_moe_lora():
         self.is_lora_enabled = False
 
     FusedMoEConfig.__post_init__ = _patched__post_init__
+
+
+def monkey_patch_fp32_lm_head():
+    """Run the lm_head projection in fp32.
+
+    Casts both hidden_states and lm_head.weight to float32 before the matmul,
+    so logits are computed in fp32 instead of the model dtype (bf16). The
+    sampler already promotes to fp32 for softmax/sampling, so the head matmul
+    itself is the only step where precision is lost — promoting it closes the
+    gap that bites RL importance-sampling under FP8/bf16 inference (cf.
+    MiniMax-M1 §7.6, ScaleRL, Meta arxiv:2510.13786). SGLang exposes the same
+    knob as `--enable-fp32-lm-head`.
+
+    Activated by setting ``additional_config["fp32_lm_head"] = True`` on the
+    vLLM namespace; the launcher does this when ``inference.enable_fp32_lm_head``
+    is set. Reading from ``get_current_vllm_config().additional_config`` keeps
+    the wiring config-driven (no env vars) and survives multiprocess spawns
+    because vLLM serializes its config across worker processes.
+
+    The fp32 weight is materialized lazily on the first call and cached on the
+    layer (``_fp32_lm_head_weight``) so it isn't recomputed each forward.
+
+    Limitation: tied embeddings would require duplicating the embedding table
+    in fp32; we don't try to handle that here. Equivalent of
+    vllm-project/vllm#24567 restricted to the untied case; intended to be
+    removed once that PR (or follow-up) lands upstream.
+    """
+    import torch
+    import torch.nn.functional as F
+    from vllm.config import get_current_vllm_config
+    from vllm.logger import init_logger
+    from vllm.model_executor.layers.logits_processor import LogitsProcessor
+
+    logger = init_logger(__name__)
+
+    _original_init = LogitsProcessor.__init__
+    _original_get_logits = LogitsProcessor._get_logits
+
+    # Capture the flag once, when the LogitsProcessor is constructed during model
+    # init — that's the one place vLLM guarantees a set_current_vllm_config()
+    # context. Reading additional_config inside _get_logits doesn't work because
+    # vLLM doesn't keep the context set during serving forwards.
+    def _patched_init(self, *args, **kwargs):
+        _original_init(self, *args, **kwargs)
+        vllm_config = get_current_vllm_config()
+        # `or {}` defends against downstream code overriding additional_config to None
+        # (default is an empty dict, but defensive copying is cheap).
+        additional_config = vllm_config.additional_config or {}
+        self._fp32_lm_head_enabled = additional_config.get("fp32_lm_head", False)
+        if self._fp32_lm_head_enabled:
+            if getattr(vllm_config.model_config.hf_config, "tie_word_embeddings", False):
+                raise NotImplementedError(
+                    "fp32_lm_head is not supported for models with tie_word_embeddings=True; "
+                    "casting lm_head.weight in place would also cast embed_tokens. Use a model "
+                    "with untied embeddings, or extend this patch to keep a separate fp32 copy."
+                )
+            logger.warning("fp32 lm_head ENABLED for this LogitsProcessor instance.")
+
+    def _patched_get_logits(self, hidden_states, lm_head, embedding_bias):
+        if not getattr(self, "_fp32_lm_head_enabled", False):
+            return _original_get_logits(self, hidden_states, lm_head, embedding_bias)
+
+        # Cache the fp32 weight, but invalidate it whenever lm_head.weight has
+        # been mutated. RL weight broadcasts (NCCL / filesystem) update params
+        # in place via param.copy_(...), which bumps Tensor._version. Detect
+        # that and rebuild — otherwise we'd serve stale step-0 weights forever.
+        weight = lm_head.weight
+        cur_version = weight._version
+        cached = getattr(lm_head, "_fp32_lm_head_weight", None)
+        cached_version = getattr(lm_head, "_fp32_lm_head_weight_version", None)
+        if cached is None or cached_version != cur_version:
+            with torch.no_grad():
+                cached = weight.detach().to(torch.float32)
+            lm_head._fp32_lm_head_weight = cached
+            lm_head._fp32_lm_head_weight_version = cur_version
+
+        bias_fp32 = embedding_bias.to(torch.float32) if embedding_bias is not None else None
+        logits = F.linear(hidden_states.to(torch.float32), cached, bias_fp32)
+
+        logits = self._gather_logits(logits)
+        if logits is not None:
+            logits = logits[..., : self.org_vocab_size]
+        return logits
+
+    LogitsProcessor.__init__ = _patched_init
+    LogitsProcessor._get_logits = _patched_get_logits
+    logger.info("Installed fp32 lm_head patch; activates per-instance based on additional_config.fp32_lm_head.")

--- a/src/prime_rl/inference/vllm/worker/__init__.py
+++ b/src/prime_rl/inference/vllm/worker/__init__.py
@@ -2,6 +2,7 @@ import logging
 import os
 
 from prime_rl.inference.patches import (
+    monkey_patch_fp32_lm_head,
     monkey_patch_LRUCacheWorkerLoRAManager,
     monkey_patch_minimax_m2_for_lora,
     monkey_patch_no_moe_lora,
@@ -23,3 +24,6 @@ if os.environ.get("PRIME_NO_MOE_LORA") == "1":
     monkey_patch_no_moe_lora()
 else:
     logger.info("PRIME_NO_MOE_LORA=0: no patch applied")
+
+# Install fp32 lm_head patch; self-gates on additional_config["fp32_lm_head"] at call time
+monkey_patch_fp32_lm_head()


### PR DESCRIPTION
## Summary
- New `inference.enable_fp32_lm_head` flag that runs the lm_head projection in fp32 instead of the model dtype (bf16). Both `hidden_states` and `lm_head.weight` are cast to float32 before the matmul.
- Wired through vLLM's `additional_config` dict (no env vars). The launcher's `to_vllm()` injects `{"fp32_lm_head": True}` when the flag is set.
- The flag is captured **once**, on `LogitsProcessor.__init__`, onto the instance. The per-forward check then just reads `self._fp32_lm_head_enabled`. This matters because `get_current_vllm_config()` only resolves during model init — calling it from `_get_logits` during serving raises `AssertionError` (we verified empirically that the per-call approach silently no-ops).
- The fp32 weight is cached on the layer, but **invalidated against `Tensor._version`** so RL weight broadcasts (NCCL / filesystem `param.copy_(...)`) don't leave a stale step-0 fp32 copy serving forever.
- Asserts on `tie_word_embeddings=True` since casting `lm_head.weight` in place would also cast `embed_tokens`.

## Why
Under FP8/bf16 inference the only step between hidden states and the sampler that's *not* fp32 is the lm_head matmul itself — vLLM's sampler already promotes to fp32 before softmax/sampling. Casting the operands to fp32 doesn't add precision to the bf16 weight values themselves (zero-padded mantissa), but it does keep the matmul **output** in fp32 instead of truncating to bf16 — which is what the sampler actually needs. SGLang implements the same flag the same way (`logits_processor.py:894-897` in their tree).

Closes the rollout-vs-trainer logprob gap that destabilizes RL importance sampling. Background: [MiniMax-M1 §7.6](https://arxiv.org/pdf/2506.13585), ScaleRL, Meta arxiv:2510.13786. Tracks [vllm-project/vllm#24567](https://github.com/vllm-project/vllm/pull/24567), restricted here to the untied-embeddings case.

## Validation
Two single-node SLURM jobs on Qwen3-8B-Base + hendrycks-math, identical apart from `enable_fp32_lm_head`. The fp32 run shows a measurably lower train/inference logprob mismatch on wandb. Confirmed the patched path actually executes (vs silently falling through) by temporarily injecting `1/0` inside the fp32 branch — the worker crashed with `ZeroDivisionError` on the first forward, proving the init-time capture is correct.

## Usage
```toml
[inference]
enable_fp32_lm_head = true
```

## Notes
- Cost: one extra fp32 copy of `lm_head.weight` (~600MB for Qwen3-30B vocab/hidden), rebuilt only when the underlying weight is mutated. The fp32 GEMM at the end is negligible vs the rest of the model.
- Limitation: no support for `tie_word_embeddings=True` — explicit `NotImplementedError`.
- Removable once `vllm-project/vllm#24567` (or a successor) lands upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)