### PR TITLE
fix(gpt-oss): document `temperature` in GptOssForCausalLM.forward

### DIFF
--- a/src/prime_rl/trainer/models/gpt_oss/modeling_gpt_oss.py
+++ b/src/prime_rl/trainer/models/gpt_oss/modeling_gpt_oss.py
@@ -307,6 +307,10 @@ class GptOssForCausalLM(GptOssPreTrainedModel, GenerationMixin):
         temperature: torch.Tensor | None = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
+        r"""
+        temperature (`torch.Tensor` of shape `(batch_size, sequence_length)`, *optional*):
+            Per-token temperatures for logprobs/entropy computation when `labels` are provided.
+        """
         assert use_cache is None or not use_cache, "use_cache is not supported for custom GPT-OSS"
         assert past_key_values is None, "past_key_values is not supported for custom GPT-OSS"
 


### PR DESCRIPTION
## Summary
- `temperature` is in `GptOssForCausalLM.forward`'s signature but was missing from its docstring, tripping the `auto_docstring` check.
- Add a docstring entry matching the convention used in the other `modeling_*.py` files (e.g. `minimax_m2`, `glm4_moe`).

## Error

```
[ERROR] `temperature` is part of GptOssForCausalLM.forward's signature, but not documented. Make sure to add it to the docstring of the function in /shared/research-prod/prime-rl/src/prime_rl/trainer/models/gpt_oss/modeling_gpt_oss.py.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that updates the `forward` docstring to include the existing `temperature` argument and should not affect runtime behavior.
> 
> **Overview**
> Adds missing docstring documentation for the existing `temperature` argument in `GptOssForCausalLM.forward` (`modeling_gpt_oss.py`) to satisfy the `auto_docstring` signature check and align with other model implementations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f218595d99f1c12e253329252e4bf6e95012df9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->