### PR TITLE
feat(inference): fp32 lm_head via native bf16xbf16 -> fp32 mm (alt to #2438)

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -390,6 +390,13 @@ class InferenceConfig(BaseConfig):
         ),
     ] = False
 
+    enable_fp32_lm_head: Annotated[
+        bool,
+        Field(
+            description="Run the lm_head projection in fp32 via a native bf16xbf16 -> fp32 GEMM (`torch.mm` with `out_dtype=torch.float32`). Stabilizes logprob precision under FP8/bf16 inference, matching SGLang's `--enable-fp32-lm-head`. Implemented as a monkey-patch over vLLM's LogitsProcessor, activated by setting `additional_config[\"fp32_lm_head\"] = True` on the vLLM config.",
+        ),
+    ] = False
+
     vllm_extra: Annotated[
         dict[str, Any],
         Field(
@@ -534,6 +541,13 @@ class InferenceConfig(BaseConfig):
 
         # Set `logprobs_mode` to `processed_logprobs` by default
         rsetattr(namespace, "logprobs_mode", "processed_logprobs")
+
+        # Pass prime-rl-specific flags through vLLM's additional_config dict;
+        # workers read these via get_current_vllm_config().additional_config.
+        if self.enable_fp32_lm_head:
+            existing = getattr(namespace, "additional_config", None) or {}
+            existing["fp32_lm_head"] = True
+            rsetattr(namespace, "additional_config", existing)
 
         # Remove chat_template if not set (vLLM doesn't accept None)
         if namespace.chat_template is None:

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -1086,3 +1086,65 @@ def monkey_patch_no_moe_lora():
         self.is_lora_enabled = False
 
     FusedMoEConfig.__post_init__ = _patched__post_init__
+
+
+def monkey_patch_fp32_lm_head():
+    """Run the lm_head projection in fp32, via a native bf16xbf16 -> fp32 GEMM.
+
+    Uses ``torch.mm(..., out_dtype=torch.float32)`` (PyTorch >= 2.10) so the
+    matmul accumulates and emits fp32 directly without zero-padding the bf16
+    operands or maintaining a separate fp32 weight copy. This avoids the
+    epilogue truncation to bf16 that `F.linear(bf16, bf16)` does, which is
+    where lm_head precision actually leaks before the sampler's softmax.
+
+    Activated by setting ``additional_config["fp32_lm_head"] = True`` on the
+    vLLM namespace; the launcher does this when ``inference.enable_fp32_lm_head``
+    is set. The flag is captured once on ``LogitsProcessor.__init__`` (where
+    vLLM guarantees a ``set_current_vllm_config()`` context) and stored on the
+    instance — reading it from ``_get_logits`` during serving doesn't work
+    because vLLM doesn't keep the context set during forwards.
+
+    Tracks vllm-project/vllm#24567 (which uses the operand-upcast approach).
+    Per @Jackmin801 on PR #2438, native ``out_dtype=fp32`` mm is more efficient
+    and just as correct.
+    """
+    import torch
+    from vllm.config import get_current_vllm_config
+    from vllm.logger import init_logger
+    from vllm.model_executor.layers.logits_processor import LogitsProcessor
+
+    logger = init_logger(__name__)
+
+    _original_init = LogitsProcessor.__init__
+    _original_get_logits = LogitsProcessor._get_logits
+
+    def _patched_init(self, *args, **kwargs):
+        _original_init(self, *args, **kwargs)
+        vllm_config = get_current_vllm_config()
+        additional_config = vllm_config.additional_config or {}
+        self._fp32_lm_head_enabled = additional_config.get("fp32_lm_head", False)
+        if self._fp32_lm_head_enabled:
+            logger.warning("fp32 lm_head ENABLED for this LogitsProcessor instance.")
+
+    def _patched_get_logits(self, hidden_states, lm_head, embedding_bias):
+        if not getattr(self, "_fp32_lm_head_enabled", False):
+            return _original_get_logits(self, hidden_states, lm_head, embedding_bias)
+
+        # Native bf16xbf16 -> fp32 GEMM. torch.mm requires 2D inputs; vLLM v1's
+        # generative path passes 2D [num_tokens, hidden_size] hidden_states, but
+        # flatten defensively in case some future caller passes 3D.
+        flat = hidden_states.reshape(-1, hidden_states.shape[-1])
+        logits = torch.mm(flat, lm_head.weight.t(), out_dtype=torch.float32)
+        if embedding_bias is not None:
+            logits = logits + embedding_bias.to(torch.float32)
+        if hidden_states.dim() > 2:
+            logits = logits.reshape(*hidden_states.shape[:-1], -1)
+
+        logits = self._gather_logits(logits)
+        if logits is not None:
+            logits = logits[..., : self.org_vocab_size]
+        return logits
+
+    LogitsProcessor.__init__ = _patched_init
+    LogitsProcessor._get_logits = _patched_get_logits
+    logger.info("Installed fp32 lm_head patch (native out_dtype=fp32 mm).")

--- a/src/prime_rl/inference/vllm/worker/__init__.py
+++ b/src/prime_rl/inference/vllm/worker/__init__.py
@@ -2,6 +2,7 @@ import logging
 import os
 
 from prime_rl.inference.patches import (
+    monkey_patch_fp32_lm_head,
     monkey_patch_LRUCacheWorkerLoRAManager,
     monkey_patch_minimax_m2_for_lora,
     monkey_patch_no_moe_lora,
@@ -23,3 +24,6 @@ if os.environ.get("PRIME_NO_MOE_LORA") == "1":
     monkey_patch_no_moe_lora()
 else:
     logger.info("PRIME_NO_MOE_LORA=0: no patch applied")
+
+# Install fp32 lm_head patch; self-gates on additional_config["fp32_lm_head"] at call time
+monkey_patch_fp32_lm_head()


### PR DESCRIPTION
## Summary
Alternative implementation of `inference.enable_fp32_lm_head` (sibling of #2438), following @Jackmin801's suggestion: use `torch.mm(hidden_states, lm_head.weight.T, out_dtype=torch.float32)` (PyTorch >= 2.10) instead of explicitly upcasting both operands.

## Why this version
@Jackmin801 [pointed out on #2438](https://github.com/PrimeIntellect-ai/prime-rl/pull/2438#discussion_r3205738500) that the operand-upcast approach (`hidden_states.float() @ lm_head.weight.float().T`) only differs from the bf16 path in the epilogue — bf16 weights cast to fp32 are zero-padded mantissa, no extra precision in the operands; the actual win is keeping the fp32 GEMM output instead of truncating to bf16. Native `out_dtype=fp32` does that directly with bf16 operands and a fp32 accumulator/epilogue.

Trade-offs vs #2438 (operand upcast + cache):
- ✅ No fp32 weight copy on the layer (~600MB saved for Qwen3-30B-class vocab/hidden)
- ✅ No cache invalidation logic (RL weight broadcasts mutate `lm_head.weight` in place; #2438 needs `Tensor._version` checks to avoid serving stale step-0 weights — see [bugbot comment](https://github.com/PrimeIntellect-ai/prime-rl/pull/2438#discussion_r3205738495))
- ✅ Simpler code: 25-line patch body vs ~50
- ⚠️ Requires PyTorch >= 2.10 for `torch.mm` `out_dtype` kwarg

Same wiring as #2438: `inference.enable_fp32_lm_head` -> `additional_config["fp32_lm_head"]` -> captured once on `LogitsProcessor.__init__` -> per-instance flag read in `_get_logits`.

## Usage
```toml
[inference]
enable_fp32_lm_head = true
```

## Notes
- Tracks [vllm-project/vllm#24567](https://github.com/vllm-project/vllm/pull/24567) — the upstream PR uses operand upcast; if it adopts native `out_dtype`, our patch becomes a single-line removal.
- No tied-embeddings restriction needed here — we don't mutate `lm_head.weight`, so tied configs are safe (just slower because we still use `lm_head.weight` regardless of whether it aliases `embed_tokens`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches vLLM logits computation via monkey-patching, which can affect numerical behavior and performance across all inference paths when enabled. Gated behind a config flag but depends on PyTorch support for `torch.mm(..., out_dtype=...)`.
> 
> **Overview**
> Adds an opt-in `inference.enable_fp32_lm_head` flag that threads through to vLLM via `additional_config["fp32_lm_head"]`.
> 
> When enabled, installs a worker-side monkey patch on vLLM’s `LogitsProcessor` to compute the `lm_head` matmul with `torch.mm(..., out_dtype=torch.float32)` (bf16×bf16 -> fp32) to improve logprob stability under lower-precision inference, while leaving the default path unchanged when the flag is off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c9cfe473e7f0b5a5042cd3bef0416db60f5f2b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->