### PR TITLE
fix(trainer): escape dots in FP8 ignore patterns

### DIFF
--- a/src/prime_rl/trainer/models/layers/fp8_linear.py
+++ b/src/prime_rl/trainer/models/layers/fp8_linear.py
@@ -113,7 +113,12 @@ class Float8BlockwiseLinear(nn.Linear):
 DEFAULT_FP8_IGNORE_PATTERNS: list[str] = [
     "lm_head",
     "router",
-    "mlp.gate.",
+    # Use escaped dots — re.search treats `.` as any-char, so the previous
+    # "mlp.gate." pattern was also matching dense MLP `mlp.gate_proj` (the
+    # trailing `.` was matching `_`). That left the dense MLP gate projection
+    # in BF16 on the trainer while inference quantized it to FP8, causing
+    # hidden-state drift before the MoE router.
+    r"mlp\.gate\.",
     "shared_expert_gate",  # Qwen3.5 MoE: nn.Linear(hidden, 1, bias=False)
     "eh_proj",
     "weights_proj",


### PR DESCRIPTION
`replace_linear_with_fp8_blockwise_linear` uses `re.search(pattern, name)` to decide which linears to keep in BF16. The default ignore list had "mlp.gate." which is a regex where `.` matches any character. As a result, dense MLPs' `mlp.gate_proj` (the trailing `.` matched `_`) were being skipped from FP8 conversion alongside the MoE router gate.

For FP8 inference checkpoints (e.g. `zai-org/GLM-5-FP8`) where the dense MLP gate_proj IS quantized to FP8, this leaves the trainer's copy in BF16 — causing hidden-state divergence in early dense layers that propagates through the MoE router and inflates trainer↔inference KL mismatch.

Escape the dots (`mlp\.gate\.`) so the pattern matches only the actual MoE router gate (`mlp.gate.weight`, `mlp.gate.e_score_correction_bias`) and not `mlp.gate_proj` / `mlp.gate_up_proj`.

Verified on a 12-node GLM-5.1-FP8 RL run: trainer log now reports `Replaced 477` (was 474) with `mlp.gate_proj` no longer in the `first skipped(name)` list.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Small change but it alters which `nn.Linear` layers are converted to FP8 during training, which can affect numerical behavior and parity with FP8 inference checkpoints.
> 
> **Overview**
> Fixes FP8 layer-selection in `replace_linear_with_fp8_blockwise_linear` by escaping dots in the default ignore regex for MoE gates (`"mlp.gate."` -> `r"mlp\.gate\."`).
> 
> This prevents the ignore rule from unintentionally matching dense MLP projections like `mlp.gate_proj`, so those layers are now eligible for FP8 conversion, improving trainer↔inference consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0978bbb2b56094b3b1d22e5374541d0f813b834. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->