### PR TITLE
[DYNAMO] fix: guard lazy_load_kernel compat patch

### DIFF
--- a/src/prime_rl/_compat.py
+++ b/src/prime_rl/_compat.py
@@ -36,9 +36,9 @@ if not hasattr(_mfau, "is_flash_attn_greater_or_equal_2_10"):
 try:
     import transformers.integrations.hub_kernels as _hub_kernels
 except ImportError:
-    _hub_kernels = None  # transformers < 5.5, no patch needed
+    _hub_kernels = None  # transformers < 5.5 without hub_kernels module, no patch needed
 
-if _hub_kernels is not None:
+if _hub_kernels is not None and hasattr(_hub_kernels, "lazy_load_kernel"):
     from huggingface_hub.errors import OfflineModeIsEnabled
 
     _original_lazy_load_kernel = _hub_kernels.lazy_load_kernel


### PR DESCRIPTION
## Summary

Ports the small transformer compatibility fix from Biswa's tested `biswapanda/prime-rl@bis/prime-rl-merged` branch.

- keeps the existing `hub_kernels` import guard
- only patches `hub_kernels.lazy_load_kernel` when the attribute actually exists
- avoids import-time `AttributeError` on transformer builds that expose `hub_kernels` without `lazy_load_kernel`

## Context

This is independent of the stacked Dynamo PRs and can target `main` directly.

## Validation

- `python -m py_compile src/prime_rl/_compat.py`

Could not run the targeted pytest command on this macOS checkout because `uv run pytest tests/unit/utils/test_client.py` stopped before pytest with a Linux-only lockfile platform error. `uv run --no-sync pytest tests/unit/utils/test_client.py` exited 139 locally.