### PR TITLE
[DYNAMO] smoke runner follow-up from tested branch

### DIFF
--- a/tools/dynamo/run_dynamo.sh
+++ b/tools/dynamo/run_dynamo.sh
@@ -29,11 +29,17 @@ echo "[dynamo-smoke] Frontend PID: $FRONTEND_PID (log: $LOG_DIR/dynamo_frontend.
 sleep 5
 
 echo "[dynamo-smoke] Starting vLLM worker (model: $DYNAMO_MODEL)..."
+# --gpu-memory-utilization=0.45 caps vLLM at ~45% of GPU memory so the
+# colocated trainer (run via tools/dynamo/run_full_smoke.sh) has room.
+# On a single 96 GB GPU: ~43 GB to inference, ~50 GB to trainer.
+# Override with GPU_MEM_UTIL=<float> if you have headroom or constraints.
+GPU_MEM_UTIL="${GPU_MEM_UTIL:-0.45}"
 DYN_SYSTEM_PORT=8081 python -m dynamo.vllm \
   --model "$DYNAMO_MODEL" \
   --enforce-eager \
   --max-model-len 2048 \
   --max-num-seqs 32 \
+  --gpu-memory-utilization "$GPU_MEM_UTIL" \
   > "$LOG_DIR/dynamo_vllm.log" 2>&1 &
 WORKER_PID=$!
 echo "[dynamo-smoke] Worker PID: $WORKER_PID (log: $LOG_DIR/dynamo_vllm.log)"

--- a/tools/dynamo/run_full_smoke.sh
+++ b/tools/dynamo/run_full_smoke.sh
@@ -1,11 +1,28 @@
 #!/bin/bash
-# Full Dynamo + prime-rl smoke test: orchestrator + trainer
-# GPU 0: Dynamo inference (already running)
-# GPU 1: prime-rl trainer (single GPU, uses torchrun)
+# Full Dynamo + prime-rl smoke test: orchestrator + trainer (single-GPU colocated).
+#
+# Layout (this machine has 1× NVIDIA RTX PRO 6000 Blackwell, 96 GB):
+#   GPU 0: Dynamo inference (already running, started separately) AND trainer
+#   no GPU: orchestrator (HTTP-only)
+#
+# Prerequisite — Dynamo must already be running on GPU 0 with bounded vLLM
+# memory so the trainer has room to load FSDP-sharded weights + optimizer.
+# Recommended:
+#
+#   CUDA_VISIBLE_DEVICES=0 ./tools/dynamo/run_dynamo.sh
+#
+# AND edit run_dynamo.sh's vllm command to add:
+#
+#   --gpu-memory-utilization 0.45
+#
+# That leaves ~50 GB free for the trainer. For a Qwen3-0.6B smoke test the
+# trainer needs ~10 GB; 50 GB is comfortable.
 #
 # Directory structure:
 #   /tmp/dynamo_smoke_outputs/             <- trainer output_dir
 #   /tmp/dynamo_smoke_outputs/run_default/ <- orchestrator output_dir (run_* naming required)
+
+set -euo pipefail
 
 BASE_DIR=/tmp/dynamo_smoke_outputs
 ORCH_DIR=$BASE_DIR/run_default
@@ -13,7 +30,20 @@ mkdir -p "$ORCH_DIR"
 
 cd /home/biswaranjanp/dev/rl/prime-rl
 
-# Start orchestrator writing to run_default (no GPU needed - just API calls to Dynamo)
+# Sanity check: warn if GPU 0 isn't visible.
+if ! nvidia-smi -i 0 --query-gpu=name --format=csv,noheader >/dev/null 2>&1; then
+  echo "[smoke] ERROR: GPU 0 not visible to nvidia-smi" >&2
+  exit 1
+fi
+
+# Sanity check: warn if Dynamo isn't already up on the default frontend port.
+if ! curl --silent --max-time 2 http://localhost:8000/health >/dev/null 2>&1; then
+  echo "[smoke] ERROR: Dynamo frontend not reachable at http://localhost:8000/health" >&2
+  echo "[smoke]        Start it first via:  ./tools/dynamo/run_dynamo.sh"  >&2
+  exit 1
+fi
+
+# Start orchestrator writing to run_default (no GPU needed — just API calls to Dynamo).
 echo "[smoke] Starting orchestrator (output: $ORCH_DIR)..."
 BENCH_API_KEY=EMPTY CUDA_VISIBLE_DEVICES="" \
   uv run orchestrator \
@@ -24,12 +54,13 @@ BENCH_API_KEY=EMPTY CUDA_VISIBLE_DEVICES="" \
 ORCH_PID=$!
 echo "[smoke] Orchestrator PID: $ORCH_PID"
 
-# Give orchestrator time to write first batch
+# Give orchestrator time to write first batch.
 sleep 12
 
-# Start trainer on GPU 1 via uv run torchrun (uses project venv Python, needed for torch.distributed)
-echo "[smoke] Starting trainer (output: $BASE_DIR)..."
-CUDA_VISIBLE_DEVICES=1 uv run torchrun \
+# Start trainer on GPU 0 (colocated with Dynamo) via uv run torchrun.
+# uv run handles the project venv Python, needed for torch.distributed bootstrap.
+echo "[smoke] Starting trainer (output: $BASE_DIR, colocated on GPU 0)..."
+CUDA_VISIBLE_DEVICES=0 uv run torchrun \
   --nproc-per-node=1 \
   --rdzv-endpoint=localhost:29510 \
   --rdzv-id=smoke_$(date +%s) \

--- a/tools/dynamo/run_full_smoke.sh
+++ b/tools/dynamo/run_full_smoke.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Full Dynamo + prime-rl smoke test: orchestrator + trainer
+# GPU 0: Dynamo inference (already running)
+# GPU 1: prime-rl trainer (single GPU, uses torchrun)
+#
+# Directory structure:
+#   /tmp/dynamo_smoke_outputs/             <- trainer output_dir
+#   /tmp/dynamo_smoke_outputs/run_default/ <- orchestrator output_dir (run_* naming required)
+
+BASE_DIR=/tmp/dynamo_smoke_outputs
+ORCH_DIR=$BASE_DIR/run_default
+mkdir -p "$ORCH_DIR"
+
+cd /home/biswaranjanp/dev/rl/prime-rl
+
+# Start orchestrator writing to run_default (no GPU needed - just API calls to Dynamo)
+echo "[smoke] Starting orchestrator (output: $ORCH_DIR)..."
+BENCH_API_KEY=EMPTY CUDA_VISIBLE_DEVICES="" \
+  uv run orchestrator \
+    @ /tmp/dynamo_smoke_rl.toml \
+    --output-dir "$ORCH_DIR" \
+    --max-concurrent 4 \
+  > /tmp/smoke_orchestrator.log 2>&1 &
+ORCH_PID=$!
+echo "[smoke] Orchestrator PID: $ORCH_PID"
+
+# Give orchestrator time to write first batch
+sleep 12
+
+# Start trainer on GPU 1 via uv run torchrun (uses project venv Python, needed for torch.distributed)
+echo "[smoke] Starting trainer (output: $BASE_DIR)..."
+CUDA_VISIBLE_DEVICES=1 uv run torchrun \
+  --nproc-per-node=1 \
+  --rdzv-endpoint=localhost:29510 \
+  --rdzv-id=smoke_$(date +%s) \
+  -m prime_rl.trainer.rl.train \
+    @ /tmp/dynamo_smoke_trainer.toml \
+    --output-dir "$BASE_DIR" \
+  > /tmp/smoke_trainer.log 2>&1 &
+TRAINER_PID=$!
+echo "[smoke] Trainer PID: $TRAINER_PID"
+
+echo "[smoke] Waiting for both processes..."
+wait $ORCH_PID
+ORCH_EXIT=$?
+wait $TRAINER_PID
+TRAINER_EXIT=$?
+
+echo "[smoke] Orchestrator exit: $ORCH_EXIT"
+echo "[smoke] Trainer exit: $TRAINER_EXIT"


### PR DESCRIPTION
## Summary

Ports the missing smoke-test runner fixes from Biswa's tested `biswapanda/prime-rl@bis/prime-rl-merged` branch on top of #2394 (`feat/dynamo-deployment-example`).

- adds `tools/dynamo/run_full_smoke.sh` for the orchestrator + trainer smoke flow
- updates the smoke runner for a single-GPU colocated setup
- caps `run_dynamo.sh` vLLM worker memory via `GPU_MEM_UTIL` defaulting to `0.45`

## Context

This keeps the tested local Dynamo smoke fixes reviewable separately from the original deployment example PR. The branch has been rebased onto latest `prime-rl/main` via its parent #2394; the admin-stub formatting fix now lives in #2394 itself.

## Validation

- `uvx ruff==0.13.0 check tools/dynamo/admin_stub.py`
- `uvx ruff==0.13.0 format --check tools/dynamo/admin_stub.py`
- `python -m py_compile tools/dynamo/admin_stub.py`
- `bash -n tools/dynamo/run_dynamo.sh tools/dynamo/run_smoke_test.sh tools/dynamo/run_full_smoke.sh`

Full pytest is left to Linux CI for this stack because the local checkout is macOS while the lockfile targets Linux environments.
