### PR TITLE
[DYNAMO] wire TITO client to Dynamo renderer transport

### DIFF
--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -24,10 +24,15 @@ class AdminAPI(Protocol):
     """
 
     async def health(self, client: AsyncClient) -> None: ...
+
     async def list_models(self, client: AsyncClient) -> list[dict]: ...
+
     async def pause(self, client: AsyncClient) -> None: ...
+
     async def resume(self, client: AsyncClient) -> None: ...
+
     async def update_weights(self, client: AsyncClient, weight_dir: str | None) -> None: ...
+
     async def load_lora_adapter(
         self,
         client: AsyncClient,
@@ -36,6 +41,7 @@ class AdminAPI(Protocol):
         *,
         timeout: httpx.Timeout,
     ) -> None: ...
+
     async def init_broadcaster(
         self,
         client: AsyncClient,
@@ -310,7 +316,16 @@ def setup_clients(
 ) -> list[vf.ClientConfig]:
     clients = []
     client_idx = 0
-    renderer_transport = "dynamo" if client_type == "renderer" and client_config.backend == "dynamo" else "vllm"
+    # `renderer_transport` selects the engine wire shape. Dynamo accepts the
+    # `dynamo` shape (placeholder messages + nvext.token_data on
+    # `/v1/chat/completions`) for both renderer-mode and TITO; vanilla vLLM
+    # accepts only the legacy shapes (`/generate` for renderer, `/chat/
+    # completions/tokens` for TITO).
+    is_token_aware_client = client_type in {"renderer", "openai_chat_completions_token"}
+    if is_token_aware_client and client_config.backend == "dynamo":
+        renderer_transport = "dynamo"
+    else:
+        renderer_transport = "vllm"
     for base_url in client_config.base_url:
         for dp_rank in range(client_config.dp_rank_count):
             headers = client_config.headers.copy()

--- a/tests/unit/utils/test_client.py
+++ b/tests/unit/utils/test_client.py
@@ -101,6 +101,18 @@ def test_setup_clients_uses_dynamo_transport_for_dynamo_renderer():
     assert clients[0].renderer_transport == "dynamo"
 
 
+def test_setup_clients_uses_dynamo_transport_for_dynamo_token_client():
+    client_config = ClientConfig(
+        base_url=["http://worker-a:8000/v1"],
+        api_key_var="PRIME_API_KEY",
+        backend="dynamo",
+    )
+
+    clients = setup_clients(client_config, client_type="openai_chat_completions_token")
+
+    assert clients[0].renderer_transport == "dynamo"
+
+
 def test_setup_clients_preserves_chat_client_defaults():
     client_config = ClientConfig(
         base_url=["http://worker-a:8000/v1"],


### PR DESCRIPTION
## Summary

Ports the missing prime-rl client-side TITO wiring from Biswa's tested branches on top of #2420 (`feat/dynamo-renderer-transport-config`). The shared renderer/verifiers pins and `return_token_ids` cleanup now live in #2420, so this PR only carries the TITO-specific follow-up.

- treats `openai_chat_completions_token` as token-aware for `client.backend = "dynamo"`
- with #2420, uses `renderer_transport="dynamo"` for both renderer-mode and TITO clients when using Dynamo
- adds unit coverage for Dynamo TITO transport selection

## Biswa Compatibility Notes

Included from Biswa's `rl-sdk-2` where it matches the current Dynamo contract:

- backend-based Dynamo transport selection in this PR
- dropping the global `return_token_ids` default in #2420

Not included yet:

- Biswa's `compute_teacher_logprobs` dispatch that asks Dynamo chat completions for `nvext.extra_fields=["prompt_logprobs"]`. Dynamo #9509 currently exposes `engine_data` / completion token data, not `nvext.prompt_logprobs`, so copying that prime-rl path would require a matching Dynamo change first.

## Validation

Local:
- `uv lock --check`
- `uvx ruff==0.13.0 check --config=pyproject.toml src/prime_rl/utils/client.py tests/unit/utils/test_client.py`
- `uvx ruff==0.13.0 format --check --config=pyproject.toml src/prime_rl/utils/client.py tests/unit/utils/test_client.py`

GitHub Actions:
- Ruff: pass
- Slim install (prime-rl-configs only): pass
- Unit tests: pass

Local test note:
- `uv run pytest tests/unit/utils/test_client.py` is blocked on macOS by the repo's Linux-only lockfile; `uv run --no-sync pytest tests/unit/utils/test_client.py` exited 139 locally.
