### PR TITLE
[codex] Add synchronous ES LoRA trainer

### DIFF
--- a/configs/debug/es/train.toml
+++ b/configs/debug/es/train.toml
@@ -1,0 +1,37 @@
+max_steps = 1
+output_dir = "outputs/debug/es"
+
+[model]
+name = "PrimeIntellect/Qwen3-0.6B"
+
+[model.lora]
+rank = 8
+
+[algorithm]
+population_size = 4
+candidate_chunk_size = 2
+mirrored = true
+sigma = 0.001
+lr = 0.0001
+
+[train]
+examples_per_env = 2
+rollouts_per_example = 1
+max_concurrent_rollouts_per_rank = 8
+
+[train.sampling]
+max_completion_tokens = 128
+
+[[train.env]]
+id = "math-env"
+name = "gsm8k"
+num_workers = 1
+args = { dataset_name = "openai/gsm8k", dataset_subset = "main", math_verify_max_workers = 4, math_verify_timeout = 60 }
+
+[deployment]
+num_gpus = 1
+gpus_per_node = 1
+
+[ckpt]
+interval = 1
+keep_last = 2

--- a/configs/gsm8k/README.md
+++ b/configs/gsm8k/README.md
@@ -30,7 +30,7 @@ Start the inference server:
 
 ```bash
 # In the `Inference` pane
-uv run inference --model.name PrimeIntellect/Qwen3-0.6B
+uv run inference --model.name Qwen/Qwen3-0.6B-Base
 ```
 
 Evaluate the base model:
@@ -39,7 +39,7 @@ Evaluate the base model:
 # In the `Trainer` pane
 uv run vf-eval math-env \
   -a '{"dataset_name": "openai/gsm8k", "dataset_subset": "main"}' \
-  -m PrimeIntellect/Qwen3-0.6B \
+  -m Qwen/Qwen3-0.6B-Base \
   -b http://localhost:8000/v1 \
   -n 20 \
   -t 2048

--- a/configs/gsm8k/es.toml
+++ b/configs/gsm8k/es.toml
@@ -1,6 +1,6 @@
 max_steps = 100
 output_dir = "outputs/gsm8k/es_qwen3_0_6b"
-clean_output_dir = true
+clean_output_dir = false
 
 [model]
 name = "PrimeIntellect/Qwen3-0.6B"

--- a/configs/gsm8k/es.toml
+++ b/configs/gsm8k/es.toml
@@ -3,7 +3,7 @@ output_dir = "outputs/gsm8k/es_qwen3_0_6b"
 clean_output_dir = false
 
 [model]
-name = "PrimeIntellect/Qwen3-0.6B"
+name = "Qwen/Qwen3-0.6B-Base"
 attn = "flash_attention_2"
 optimization_dtype = "bfloat16"
 
@@ -21,7 +21,7 @@ target_modules = [
 ]
 
 [tokenizer]
-name = "PrimeIntellect/Qwen3-0.6B"
+name = "Qwen/Qwen3-0.6B-Base"
 
 [algorithm]
 population_size = 64

--- a/configs/gsm8k/es.toml
+++ b/configs/gsm8k/es.toml
@@ -1,0 +1,57 @@
+max_steps = 100
+output_dir = "outputs/gsm8k/es_qwen3_0_6b"
+clean_output_dir = true
+
+[model]
+name = "PrimeIntellect/Qwen3-0.6B"
+attn = "flash_attention_2"
+optimization_dtype = "bfloat16"
+
+[model.lora]
+rank = 16
+alpha = 32
+target_modules = [
+    "q_proj",
+    "k_proj",
+    "v_proj",
+    "o_proj",
+    "gate_proj",
+    "up_proj",
+    "down_proj",
+]
+
+[tokenizer]
+name = "PrimeIntellect/Qwen3-0.6B"
+
+[algorithm]
+population_size = 64
+candidate_chunk_size = 32
+adapter_transport = "slots"
+mirrored = false
+sigma = 0.012
+lr = 0.01
+reward_normalization = "zscore"
+
+[train]
+examples_per_env = 16
+rollouts_per_example = 1
+max_concurrent_rollouts_per_rank = 512
+
+[train.sampling]
+temperature = 1.0
+max_completion_tokens = 2048
+logprobs = false
+
+[[train.env]]
+id = "math-env"
+name = "gsm8k"
+num_workers = 1
+args = { dataset_name = "openai/gsm8k", dataset_subset = "main", math_verify_max_workers = 128, math_verify_timeout = 60 }
+
+[deployment]
+num_gpus = 1
+gpus_per_node = 1
+
+[ckpt]
+interval = 10
+keep_last = 2

--- a/configs/gsm8k/es.toml
+++ b/configs/gsm8k/es.toml
@@ -33,7 +33,7 @@ lr = 0.01
 reward_normalization = "zscore"
 
 [train]
-examples_per_env = 16
+examples_per_env = 8
 rollouts_per_example = 1
 max_concurrent_rollouts_per_rank = 512
 
@@ -45,6 +45,23 @@ logprobs = false
 [[train.env]]
 id = "math-env"
 name = "gsm8k"
+num_workers = 1
+args = { dataset_name = "openai/gsm8k", dataset_subset = "main", math_verify_max_workers = 128, math_verify_timeout = 60 }
+
+[eval]
+interval = 5
+num_examples = 128
+rollouts_per_example = 1
+eval_base_model = true
+
+[eval.sampling]
+temperature = 0.0
+max_completion_tokens = 2048
+extra_body = { top_k = -1 }
+
+[[eval.env]]
+id = "math-env"
+name = "gsm8k_eval"
 num_workers = 1
 args = { dataset_name = "openai/gsm8k", dataset_subset = "main", math_verify_max_workers = 128, math_verify_timeout = 60 }
 

--- a/configs/gsm8k/es.toml
+++ b/configs/gsm8k/es.toml
@@ -41,6 +41,7 @@ max_concurrent_rollouts_per_rank = 512
 temperature = 1.0
 max_completion_tokens = 2048
 logprobs = false
+extra_body = { top_k = -1 }
 
 [[train.env]]
 id = "math-env"

--- a/configs/gsm8k/es_init_slots.toml
+++ b/configs/gsm8k/es_init_slots.toml
@@ -1,0 +1,54 @@
+max_steps = 0
+output_dir = "outputs/gsm8k/es_slot_init"
+clean_output_dir = false
+
+[model]
+name = "PrimeIntellect/Qwen3-0.6B"
+attn = "flash_attention_2"
+optimization_dtype = "bfloat16"
+
+[model.lora]
+rank = 16
+alpha = 32
+target_modules = [
+    "q_proj",
+    "k_proj",
+    "v_proj",
+    "o_proj",
+    "gate_proj",
+    "up_proj",
+    "down_proj",
+]
+
+[tokenizer]
+name = "PrimeIntellect/Qwen3-0.6B"
+
+[algorithm]
+population_size = 64
+candidate_chunk_size = 32
+adapter_transport = "slots"
+mirrored = false
+sigma = 0.012
+lr = 0.01
+reward_normalization = "zscore"
+
+[train]
+examples_per_env = 1
+rollouts_per_example = 1
+max_concurrent_rollouts_per_rank = 32
+
+[train.sampling]
+temperature = 1.0
+max_completion_tokens = 2048
+logprobs = false
+extra_body = { top_k = -1 }
+
+[[train.env]]
+id = "math-env"
+name = "gsm8k"
+num_workers = 1
+args = { dataset_name = "openai/gsm8k", dataset_subset = "main", math_verify_max_workers = 128, math_verify_timeout = 60 }
+
+[deployment]
+num_gpus = 1
+gpus_per_node = 1

--- a/configs/gsm8k/es_init_slots.toml
+++ b/configs/gsm8k/es_init_slots.toml
@@ -3,7 +3,7 @@ output_dir = "outputs/gsm8k/es_slot_init"
 clean_output_dir = false
 
 [model]
-name = "PrimeIntellect/Qwen3-0.6B"
+name = "Qwen/Qwen3-0.6B-Base"
 attn = "flash_attention_2"
 optimization_dtype = "bfloat16"
 
@@ -21,7 +21,7 @@ target_modules = [
 ]
 
 [tokenizer]
-name = "PrimeIntellect/Qwen3-0.6B"
+name = "Qwen/Qwen3-0.6B-Base"
 
 [algorithm]
 population_size = 64

--- a/configs/gsm8k/inference_es.toml
+++ b/configs/gsm8k/inference_es.toml
@@ -5,7 +5,7 @@ max_lora_rank = 16
 gpu_memory_utilization = 0.8
 
 [model]
-name = "PrimeIntellect/Qwen3-0.6B"
+name = "Qwen/Qwen3-0.6B-Base"
 max_model_len = 4096
 
 [server]

--- a/configs/gsm8k/inference_es.toml
+++ b/configs/gsm8k/inference_es.toml
@@ -2,7 +2,7 @@ enable_lora = true
 max_loras = 32
 max_cpu_loras = 32
 max_lora_rank = 16
-gpu_memory_utilization = 0.75
+gpu_memory_utilization = 0.8
 
 [model]
 name = "PrimeIntellect/Qwen3-0.6B"
@@ -10,3 +10,7 @@ max_model_len = 4096
 
 [server]
 port = 8000
+
+[vllm_extra]
+max_num_seqs = 384
+max_num_batched_tokens = 32768

--- a/configs/gsm8k/inference_es.toml
+++ b/configs/gsm8k/inference_es.toml
@@ -1,0 +1,12 @@
+enable_lora = true
+max_loras = 32
+max_cpu_loras = 32
+max_lora_rank = 16
+gpu_memory_utilization = 0.75
+
+[model]
+name = "PrimeIntellect/Qwen3-0.6B"
+max_model_len = 4096
+
+[server]
+port = 8000

--- a/configs/gsm8k/inference_sweep_seq384.toml
+++ b/configs/gsm8k/inference_sweep_seq384.toml
@@ -5,7 +5,7 @@ max_lora_rank = 16
 gpu_memory_utilization = 0.8
 
 [model]
-name = "PrimeIntellect/Qwen3-0.6B"
+name = "Qwen/Qwen3-0.6B-Base"
 max_model_len = 4096
 
 [server]

--- a/configs/gsm8k/inference_sweep_seq384.toml
+++ b/configs/gsm8k/inference_sweep_seq384.toml
@@ -1,0 +1,16 @@
+enable_lora = true
+max_loras = 32
+max_cpu_loras = 32
+max_lora_rank = 16
+gpu_memory_utilization = 0.8
+
+[model]
+name = "PrimeIntellect/Qwen3-0.6B"
+max_model_len = 4096
+
+[server]
+port = 8000
+
+[vllm_extra]
+max_num_seqs = 384
+max_num_batched_tokens = 32768

--- a/configs/gsm8k/inference_sweep_seq512.toml
+++ b/configs/gsm8k/inference_sweep_seq512.toml
@@ -5,7 +5,7 @@ max_lora_rank = 16
 gpu_memory_utilization = 0.85
 
 [model]
-name = "PrimeIntellect/Qwen3-0.6B"
+name = "Qwen/Qwen3-0.6B-Base"
 max_model_len = 4096
 
 [server]

--- a/configs/gsm8k/inference_sweep_seq512.toml
+++ b/configs/gsm8k/inference_sweep_seq512.toml
@@ -1,0 +1,16 @@
+enable_lora = true
+max_loras = 32
+max_cpu_loras = 32
+max_lora_rank = 16
+gpu_memory_utilization = 0.85
+
+[model]
+name = "PrimeIntellect/Qwen3-0.6B"
+max_model_len = 4096
+
+[server]
+port = 8000
+
+[vllm_extra]
+max_num_seqs = 512
+max_num_batched_tokens = 65536

--- a/configs/gsm8k/inference_sweep_seq512_prefix_off.toml
+++ b/configs/gsm8k/inference_sweep_seq512_prefix_off.toml
@@ -1,0 +1,17 @@
+enable_lora = true
+max_loras = 32
+max_cpu_loras = 32
+max_lora_rank = 16
+enable_prefix_caching = false
+gpu_memory_utilization = 0.85
+
+[model]
+name = "PrimeIntellect/Qwen3-0.6B"
+max_model_len = 4096
+
+[server]
+port = 8000
+
+[vllm_extra]
+max_num_seqs = 512
+max_num_batched_tokens = 65536

--- a/configs/gsm8k/inference_sweep_seq512_prefix_off.toml
+++ b/configs/gsm8k/inference_sweep_seq512_prefix_off.toml
@@ -6,7 +6,7 @@ enable_prefix_caching = false
 gpu_memory_utilization = 0.85
 
 [model]
-name = "PrimeIntellect/Qwen3-0.6B"
+name = "Qwen/Qwen3-0.6B-Base"
 max_model_len = 4096
 
 [server]

--- a/configs/gsm8k/rl.toml
+++ b/configs/gsm8k/rl.toml
@@ -6,7 +6,7 @@ project = "gsm8k-debug"
 name = "gsm8k"
 
 [model]
-name = "PrimeIntellect/Qwen3-0.6B"
+name = "Qwen/Qwen3-0.6B-Base"
 
 [orchestrator]
 batch_size = 512

--- a/environments/concision_gemma/README.md
+++ b/environments/concision_gemma/README.md
@@ -1,0 +1,14 @@
+# concision-gemma
+
+`concision-gemma` is a single-turn Verifiers environment for the concision objective used in the ES/GRPO comparison setup.
+
+- Train split: 2 short prompt/answer pairs
+- Eval split: 8 held-out prompt/answer pairs
+- Reward: `-abs(len(completion) - len(answer))`
+- Metrics: normalized concision reward and completion length
+
+The environment intentionally scores length matching only. It does not score answer correctness.
+
+```bash
+PYTHONPATH=environments/concision_gemma uv run python -c "import verifiers as vf; print(vf.load_environment('concision-gemma'))"
+```

--- a/environments/concision_gemma/concision_gemma.py
+++ b/environments/concision_gemma/concision_gemma.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import re
+
+import verifiers as vf
+from datasets import Dataset
+
+TRAIN_EXAMPLES = [
+    {"question": "Solve: 3 + 5 =", "answer": "8"},
+    {
+        "question": "If all birds can fly and penguins are birds, can penguins fly",
+        "answer": "No",
+    },
+]
+
+EVAL_EXAMPLES = [
+    {"question": "What is the capital of France?", "answer": "Paris"},
+    {"question": "Calculate: 12 * 7 =", "answer": "84"},
+    {"question": 'Is the statement "All cats are mammals" true or false?', "answer": "True"},
+    {"question": "What comes next in the sequence: 2, 4, 6, 8, ?", "answer": "10"},
+    {"question": 'Translate "Hello" to Spanish:', "answer": "Hola"},
+    {"question": "What is 15% of 200?", "answer": "30"},
+    {"question": "Name one primary color:", "answer": "Red"},
+    {"question": "How many days are in a week?", "answer": "7"},
+]
+
+
+def _completion_text(completion: str | list[object], **_: object) -> str:
+    if isinstance(completion, str):
+        return completion.strip()
+    if isinstance(completion, list):
+        parts: list[str] = []
+        for item in completion:
+            if isinstance(item, dict):
+                role = item.get("role")
+                if role in (None, "assistant"):
+                    parts.append(str(item.get("content", "")))
+                continue
+
+            role = getattr(item, "role", None)
+            content = getattr(item, "content", None)
+            if content is not None and role in (None, "assistant"):
+                parts.append(str(content))
+                continue
+
+            text = str(item)
+            match = re.search(r"content=(['\"])(.*?)\1", text, flags=re.DOTALL)
+            if match:
+                parts.append(match.group(2).encode("utf-8").decode("unicode_escape"))
+            elif text:
+                parts.append(text)
+        return "".join(parts).strip()
+    return str(completion).strip()
+
+
+def raw_concision_reward(completion: str | list[object], answer: str, **_: object) -> float:
+    text = _completion_text(completion)
+    return -float(abs(len(text) - len(answer.strip())))
+
+
+def normalized_concision_reward(
+    completion: str | list[object],
+    answer: str,
+    reward_floor: float = -2000.0,
+    **_: object,
+) -> float:
+    raw = raw_concision_reward(completion=completion, answer=answer)
+    return max(0.0, min(1.0, (raw - reward_floor) / (0.0 - reward_floor)))
+
+
+def completion_length(completion: str | list[object], **_: object) -> float:
+    return float(len(_completion_text(completion)))
+
+
+def _to_prompt_row(row: dict[str, str]) -> dict[str, object]:
+    return {
+        "prompt": [{"role": "user", "content": row["question"]}],
+        "answer": row["answer"],
+    }
+
+
+def _dataset_from_rows(rows: list[dict[str, str]]) -> Dataset:
+    return Dataset.from_list([_to_prompt_row(row) for row in rows])
+
+
+def load_environment(**kwargs) -> vf.Environment:
+    reward_floor = float(kwargs.get("reward_floor", -2000.0))
+
+    def normalized_with_floor(completion, answer, **kw):
+        return normalized_concision_reward(
+            completion=completion,
+            answer=answer,
+            reward_floor=reward_floor,
+            **kw,
+        )
+
+    rubric = vf.Rubric(
+        funcs=[
+            raw_concision_reward,
+            normalized_with_floor,
+            completion_length,
+        ],
+        weights=[1.0, 0.0, 0.0],
+    )
+
+    return vf.SingleTurnEnv(
+        dataset=_dataset_from_rows(TRAIN_EXAMPLES),
+        eval_dataset=_dataset_from_rows(EVAL_EXAMPLES),
+        rubric=rubric,
+        env_id="concision-gemma",
+        env_args=kwargs,
+        sampling_args={"n": 1, "extra_body": {}},
+    )

--- a/environments/concision_gemma/pyproject.toml
+++ b/environments/concision_gemma/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "concision-gemma"
+description = "Verifiers concision reward environment for Gemma 3 270M ES experiments."
+tags = ["concision", "train", "eval", "gemma"]
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "datasets>=3.3.0",
+    "verifiers>=0.1.12",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+include = ["concision_gemma.py", "pyproject.toml"]
+
+[tool.verifiers.eval]
+num_examples = 8
+rollouts_per_example = 20

--- a/examples/alphabet_sort/es.toml
+++ b/examples/alphabet_sort/es.toml
@@ -1,15 +1,15 @@
-max_steps = 50
-output_dir = "outputs/concision_gemma/es"
+max_steps = 100
+output_dir = "outputs/alphabet_sort/es"
 clean_output_dir = true
 
 [model]
-name = "OpenKing/Gemma-270m-it-non-gated"
+name = "Qwen/Qwen3-4B-Instruct-2507"
 attn = "flash_attention_2"
 optimization_dtype = "bfloat16"
 
 [model.lora]
-rank = 8
-alpha = 16
+rank = 32
+alpha = 64
 target_modules = [
     "q_proj",
     "k_proj",
@@ -21,30 +21,33 @@ target_modules = [
 ]
 
 [tokenizer]
-name = "OpenKing/Gemma-270m-it-non-gated"
+name = "Qwen/Qwen3-4B-Instruct-2507"
 
 [algorithm]
-population_size = 32
+population_size = 128
 candidate_chunk_size = 32
+adapter_transport = "slots"
 mirrored = false
 sigma = 0.012
 lr = 0.01
 reward_normalization = "zscore"
 
 [train]
-examples_per_env = 8
+examples_per_env = 16
 rollouts_per_example = 1
 max_concurrent_rollouts_per_rank = 512
 
 [train.sampling]
 temperature = 0.0
-max_completion_tokens = 64
+max_completion_tokens = 768
 logprobs = false
+extra_body = { top_k = -1, chat_template_kwargs = { enable_thinking = false } }
 
 [[train.env]]
-id = "concision-gemma"
-name = "concision-gemma"
+id = "alphabet-sort"
+name = "alphabet-sort"
 num_workers = 1
+args = { min_turns = 3, max_turns = 5, min_names_per_turn = 1, max_names_per_turn = 5, similarity_power = 4, power_per_turn = false }
 
 [deployment]
 num_gpus = 1

--- a/examples/alphabet_sort/inference_es.toml
+++ b/examples/alphabet_sort/inference_es.toml
@@ -1,0 +1,13 @@
+enable_lora = true
+max_loras = 32
+max_cpu_loras = 32
+max_lora_rank = 32
+gpu_memory_utilization = 0.7
+
+[model]
+name = "Qwen/Qwen3-4B-Instruct-2507"
+max_model_len = 4096
+trust_remote_code = true
+
+[server]
+port = 8000

--- a/examples/concision_gemma/README.md
+++ b/examples/concision_gemma/README.md
@@ -1,0 +1,17 @@
+# Concision Gemma ES
+
+This example runs synchronous ES-LoRA on the `concision-gemma` Verifiers environment with
+`OpenKing/Gemma-270m-it-non-gated`, a non-gated HF-format mirror of Gemma 3 270M IT.
+
+The concision reward is length-only:
+
+```text
+reward = -abs(len(completion) - len(answer))
+```
+
+It is useful as a small, fast environment for ES trainer smoke runs and timing breakdowns.
+
+```bash
+PYTHONPATH=environments/concision_gemma uv run inference @ examples/concision_gemma/inference.toml
+PYTHONPATH=environments/concision_gemma uv run es @ examples/concision_gemma/es.toml
+```

--- a/examples/concision_gemma/README.md
+++ b/examples/concision_gemma/README.md
@@ -10,6 +10,8 @@ reward = -abs(len(completion) - len(answer))
 ```
 
 It is useful as a small, fast environment for ES trainer smoke runs and timing breakdowns.
+The ES config deliberately samples the two training rows with replacement so each
+candidate evaluates enough rollouts to keep vLLM batched.
 
 ```bash
 PYTHONPATH=environments/concision_gemma uv run inference @ examples/concision_gemma/inference.toml

--- a/examples/concision_gemma/es.toml
+++ b/examples/concision_gemma/es.toml
@@ -26,10 +26,10 @@ name = "OpenKing/Gemma-270m-it-non-gated"
 [algorithm]
 population_size = 4
 candidate_chunk_size = 4
-mirrored = true
-sigma = 0.05
-lr = 0.0000005
-reward_normalization = "none"
+mirrored = false
+sigma = 0.012
+lr = 0.01
+reward_normalization = "zscore"
 
 [train]
 examples_per_env = 2

--- a/examples/concision_gemma/es.toml
+++ b/examples/concision_gemma/es.toml
@@ -1,0 +1,54 @@
+max_steps = 50
+output_dir = "outputs/concision_gemma/es"
+clean_output_dir = true
+
+[model]
+name = "OpenKing/Gemma-270m-it-non-gated"
+attn = "flash_attention_2"
+optimization_dtype = "bfloat16"
+
+[model.lora]
+rank = 8
+alpha = 16
+target_modules = [
+    "q_proj",
+    "k_proj",
+    "v_proj",
+    "o_proj",
+    "gate_proj",
+    "up_proj",
+    "down_proj",
+]
+
+[tokenizer]
+name = "OpenKing/Gemma-270m-it-non-gated"
+
+[algorithm]
+population_size = 4
+candidate_chunk_size = 4
+mirrored = true
+sigma = 0.05
+lr = 0.0000005
+reward_normalization = "none"
+
+[train]
+examples_per_env = 2
+rollouts_per_example = 1
+max_concurrent_rollouts_per_rank = 8
+
+[train.sampling]
+temperature = 0.0
+max_completion_tokens = 64
+
+[[train.env]]
+id = "concision-gemma"
+name = "concision-gemma"
+num_workers = 1
+
+[deployment]
+num_gpus = 1
+gpus_per_node = 1
+
+[ckpt]
+interval = 10
+keep_last = 2

--- a/examples/concision_gemma/inference.toml
+++ b/examples/concision_gemma/inference.toml
@@ -1,0 +1,13 @@
+enable_lora = true
+max_loras = 4
+max_cpu_loras = 8
+max_lora_rank = 8
+gpu_memory_utilization = 0.6
+
+[model]
+name = "OpenKing/Gemma-270m-it-non-gated"
+enforce_eager = true
+max_model_len = 2048
+
+[server]
+port = 8000

--- a/examples/concision_gemma/inference.toml
+++ b/examples/concision_gemma/inference.toml
@@ -1,12 +1,11 @@
 enable_lora = true
-max_loras = 4
-max_cpu_loras = 8
+max_loras = 32
+max_cpu_loras = 64
 max_lora_rank = 8
-gpu_memory_utilization = 0.6
+gpu_memory_utilization = 0.8
 
 [model]
 name = "OpenKing/Gemma-270m-it-non-gated"
-enforce_eager = true
 max_model_len = 2048
 
 [server]

--- a/packages/prime-rl-configs/src/prime_rl/configs/es.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/es.py
@@ -3,7 +3,7 @@ from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from prime_rl.configs.orchestrator import TrainEnvConfig, TrainSamplingConfig
+from prime_rl.configs.orchestrator import EvalConfig, TrainEnvConfig, TrainSamplingConfig
 from prime_rl.configs.shared import ClientConfig, HeartbeatConfig, SlurmConfig, TrainerLogConfig, WandbConfig
 from prime_rl.configs.trainer import GCConfig, LoRAConfig, ModelConfig, TokenizerConfig
 from prime_rl.utils.config import BaseConfig
@@ -184,6 +184,8 @@ class ESConfig(BaseConfig):
     client: ClientConfig = ClientConfig()
 
     train: ESTrainConfig = ESTrainConfig()
+
+    eval: EvalConfig | None = None
 
     algorithm: ESAlgorithmConfig = ESAlgorithmConfig()
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/es.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/es.py
@@ -51,6 +51,27 @@ class ESAlgorithmConfig(BaseConfig):
         Field(description="Keep per-candidate adapter directories instead of deleting them after each chunk."),
     ] = False
 
+    adapter_transport: Annotated[
+        Literal["disk", "slots"],
+        Field(
+            description=(
+                "How candidate LoRA adapters are presented to inference. 'disk' writes PEFT adapters and uses "
+                "vLLM's load endpoint; 'slots' keeps fixed vLLM LoRA slots resident and overwrites them in-place."
+            ),
+        ),
+    ] = "disk"
+
+    adapter_write_workers: Annotated[
+        int,
+        Field(
+            ge=1,
+            description=(
+                "Number of bounded worker threads used to serialize candidate LoRA adapters. Higher values can "
+                "overlap CPU tensor conversion and safetensors writes, but may increase filesystem pressure."
+            ),
+        ),
+    ] = 4
+
     @model_validator(mode="after")
     def validate_mirrored_population(self):
         if self.mirrored and self.population_size % 2 != 0:

--- a/packages/prime-rl-configs/src/prime_rl/configs/es.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/es.py
@@ -1,0 +1,238 @@
+from pathlib import Path
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from prime_rl.configs.orchestrator import TrainEnvConfig, TrainSamplingConfig
+from prime_rl.configs.shared import ClientConfig, HeartbeatConfig, SlurmConfig, TrainerLogConfig, WandbConfig
+from prime_rl.configs.trainer import GCConfig, LoRAConfig, ModelConfig, TokenizerConfig
+from prime_rl.utils.config import BaseConfig
+
+
+class ESAlgorithmConfig(BaseConfig):
+    """Configures the synchronous evolution-strategy update."""
+
+    population_size: Annotated[int, Field(ge=1, description="Number of candidate perturbations per ES step.")] = 32
+
+    candidate_chunk_size: Annotated[
+        int,
+        Field(
+            ge=1,
+            description=(
+                "Number of candidates to materialize and evaluate at once. Larger chunks improve inference "
+                "batching but increase LoRA cache and filesystem pressure."
+            ),
+        ),
+    ] = 32
+
+    sigma: Annotated[float, Field(gt=0, description="Standard deviation of the parameter-space perturbations.")] = 1e-3
+
+    lr: Annotated[float, Field(ge=0, description="Learning rate applied to the ES gradient estimate.")] = 1e-4
+
+    mirrored: Annotated[
+        bool,
+        Field(
+            description=(
+                "Use mirrored +/- perturbation pairs. When enabled, population_size must be even and the "
+                "candidate score is computed from reward_plus - reward_minus."
+            )
+        ),
+    ] = False
+
+    reward_normalization: Annotated[
+        Literal["zscore", "centered", "none"],
+        Field(description="Normalization applied to one-sided candidate rewards before reconstructing the update."),
+    ] = "zscore"
+
+    seed: Annotated[int, Field(description="Base random seed for perturbation and dataset sampling.")] = 42
+
+    keep_candidate_adapters: Annotated[
+        bool,
+        Field(description="Keep per-candidate adapter directories instead of deleting them after each chunk."),
+    ] = False
+
+    @model_validator(mode="after")
+    def validate_mirrored_population(self):
+        if self.mirrored and self.population_size % 2 != 0:
+            raise ValueError("population_size must be even when mirrored=True")
+        return self
+
+
+class ESTrainConfig(BaseConfig):
+    """Configures training rollout environments for synchronous ES."""
+
+    env: list[TrainEnvConfig] = [TrainEnvConfig()]
+
+    sampling: TrainSamplingConfig = TrainSamplingConfig()
+
+    examples_per_env: Annotated[
+        int,
+        Field(
+            ge=1,
+            description="Number of examples sampled per training environment for each candidate evaluation.",
+        ),
+    ] = 16
+
+    rollouts_per_example: Annotated[
+        int,
+        Field(ge=1, description="Number of rollouts per example for each candidate."),
+    ] = 1
+
+    num_workers: Annotated[
+        int | Literal["auto"],
+        Field(description="Default number of worker processes for spawned env servers."),
+    ] = "auto"
+
+    max_retries: Annotated[
+        int,
+        Field(ge=0, description="Default number of retries for failed rollouts."),
+    ] = 0
+
+    max_concurrent_rollouts_per_rank: Annotated[
+        int,
+        Field(
+            ge=1,
+            description="Maximum number of rollout coroutines a trainer rank runs concurrently.",
+        ),
+    ] = 256
+
+    @model_validator(mode="after")
+    def resolve_env_defaults(self):
+        group_sampling = self.sampling.model_dump()
+        for env in self.env:
+            if "sampling" not in env.model_fields_set:
+                env.sampling = TrainSamplingConfig(**group_sampling)
+            else:
+                merged = group_sampling | env.sampling.model_dump(exclude_unset=True)
+                env.sampling = TrainSamplingConfig(**merged)
+            if "num_workers" not in env.model_fields_set:
+                env.num_workers = self.num_workers
+            if "max_retries" not in env.model_fields_set:
+                env.max_retries = self.max_retries
+        return self
+
+    @model_validator(mode="after")
+    def validate_unique_env_names(self):
+        env_names = [env.resolved_name for env in self.env]
+        duplicates = [n for n in env_names if env_names.count(n) > 1]
+        if duplicates:
+            raise ValueError(
+                f"Duplicate training environment names: {set(duplicates)}. Each env must have a unique name."
+            )
+        return self
+
+
+class ESCheckpointConfig(BaseConfig):
+    """Configures ES state and mean-adapter checkpoints."""
+
+    interval: Annotated[int | None, Field(ge=1, description="Save ES state every N steps.")] = None
+
+    resume_step: Annotated[
+        int | None,
+        Field(ge=-1, description="Step to resume from. If -1, resume from the latest ES checkpoint."),
+    ] = None
+
+    keep_last: Annotated[int | None, Field(ge=1, description="Keep at most this many recent ES checkpoints.")] = None
+
+
+class ESDeploymentConfig(BaseModel):
+    """Configures local synchronous ES launch."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["single_node"] = "single_node"
+
+    num_gpus: Annotated[int, Field(ge=1, description="Number of trainer ranks to launch with torchrun.")] = 1
+
+    gpus_per_node: Annotated[int, Field(ge=1, description="Number of GPUs available on the local node.")] = 8
+
+    @model_validator(mode="after")
+    def validate_gpu_count(self):
+        if self.num_gpus > self.gpus_per_node:
+            raise ValueError(f"num_gpus ({self.num_gpus}) exceeds gpus_per_node ({self.gpus_per_node}).")
+        return self
+
+
+class ESConfig(BaseConfig):
+    """Configures the synchronous ES-LoRA trainer."""
+
+    model: ModelConfig = ModelConfig(lora=LoRAConfig())
+
+    tokenizer: TokenizerConfig = TokenizerConfig()
+
+    client: ClientConfig = ClientConfig()
+
+    train: ESTrainConfig = ESTrainConfig()
+
+    algorithm: ESAlgorithmConfig = ESAlgorithmConfig()
+
+    ckpt: ESCheckpointConfig | None = ESCheckpointConfig(interval=10)
+
+    log: TrainerLogConfig = TrainerLogConfig()
+
+    wandb: WandbConfig | None = None
+
+    output_dir: Annotated[
+        Path,
+        Field(description="Directory to write ES state, adapters, logs, and metrics."),
+    ] = Path("outputs/es")
+
+    clean_output_dir: Annotated[
+        bool,
+        Field(description="Delete output_dir before starting. Refuses to overwrite by default."),
+    ] = False
+
+    matmul_precision: Annotated[
+        Literal["highest", "high", "medium"],
+        Field(
+            description=(
+                "Precision for float32 matrix multiplications. Use 'highest' on ROCm/AMD GPUs if reduced "
+                "precision matmuls corrupt large-vocabulary softmaxes; use 'high' for TF32 on NVIDIA GPUs."
+            ),
+        ),
+    ] = "high"
+
+    max_steps: Annotated[int | None, Field(description="Maximum ES steps to run. If None, run indefinitely.")] = None
+
+    dist_timeout_seconds: Annotated[
+        int,
+        Field(ge=1, description="Timeout in seconds for torch distributed operations."),
+    ] = 600
+
+    gc: Annotated[
+        GCConfig | None,
+        Field(description="Garbage collection config. Set to null to use Python's default GC behavior."),
+    ] = GCConfig()
+
+    heartbeat: Annotated[
+        HeartbeatConfig | None, Field(description="Heartbeat config for monitoring training progress.")
+    ] = None
+
+    deployment: ESDeploymentConfig = ESDeploymentConfig()
+
+    slurm: Annotated[
+        SlurmConfig | None,
+        Field(description="Reserved for future SLURM ES launch support. Local torchrun is implemented first."),
+    ] = None
+
+    dry_run: Annotated[bool, Field(description="Only validate and dump resolved configs and exit early.")] = False
+
+    @model_validator(mode="after")
+    def validate_lora_enabled(self):
+        if self.model.lora is None:
+            raise ValueError("Synchronous ES currently requires model.lora to be configured.")
+        return self
+
+    @model_validator(mode="after")
+    def auto_setup_tokenizer(self):
+        if self.tokenizer.name is None:
+            self.tokenizer.name = self.model.name
+        if self.tokenizer.trust_remote_code is None:
+            self.tokenizer.trust_remote_code = self.model.trust_remote_code
+        return self
+
+    @model_validator(mode="after")
+    def validate_slurm_not_supported_yet(self):
+        if self.slurm is not None:
+            raise ValueError("ES SLURM launch is not implemented yet; run with deployment.type='single_node'.")
+        return self

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -112,6 +112,13 @@ class TrainSamplingConfig(BaseConfig):
         ),
     ] = None
 
+    logprobs: Annotated[
+        bool,
+        Field(
+            description="Whether to request per-token logprobs from the inference server.",
+        ),
+    ] = True
+
     # Strictly speaking, extra_body is not a sampling parameter, but it is the
     # easiest way to pass arbitrary extra parameters to the server via verifiers
     extra_body: Annotated[
@@ -127,7 +134,7 @@ class TrainSamplingConfig(BaseConfig):
         args: dict[str, Any] = {
             "temperature": self.temperature,
             "top_p": 1.0,
-            "logprobs": True,
+            "logprobs": self.logprobs,
         }
         if self.max_completion_tokens is not None:
             args["max_completion_tokens"] = self.max_completion_tokens

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
 [project.scripts]
 rl = "prime_rl.entrypoints.rl:main"
 sft = "prime_rl.entrypoints.sft:main"
+es = "prime_rl.entrypoints.es:main"
 inference = "prime_rl.entrypoints.inference:main"
 trainer = "prime_rl.trainer.rl.train:main"
 orchestrator = "prime_rl.orchestrator.orchestrator:main"

--- a/scripts/benchmark_es_vllm_slots.py
+++ b/scripts/benchmark_es_vllm_slots.py
@@ -1,0 +1,182 @@
+import argparse
+import asyncio
+import json
+import statistics
+import time
+import tomllib
+from pathlib import Path
+
+import httpx
+import torch
+from datasets import load_dataset
+
+from prime_rl.configs.es import ESConfig
+from prime_rl.trainer.es.lora_materialize import build_adapter_template
+
+
+def serialize_specs(template) -> list[dict]:
+    return [
+        {
+            "name": spec.name,
+            "shape": list(spec.shape),
+            "dtype": str(spec.dtype),
+            "numel": spec.numel,
+        }
+        for spec in template.specs
+    ]
+
+
+def slot_definitions(count: int) -> list[dict]:
+    return [{"lora_name": f"es_slot_{idx}", "lora_int_id": 10_000 + idx, "slot": idx} for idx in range(count)]
+
+
+async def wait_ready(client: httpx.AsyncClient, timeout_s: float) -> None:
+    deadline = time.perf_counter() + timeout_s
+    last_error = None
+    while time.perf_counter() < deadline:
+        try:
+            response = await client.get("/liveness", timeout=5)
+            if response.status_code == 200:
+                return
+            last_error = response.text
+        except Exception as exc:
+            last_error = repr(exc)
+        await asyncio.sleep(2)
+    raise TimeoutError(f"server did not become ready within {timeout_s}s: {last_error}")
+
+
+async def init_slots(client: httpx.AsyncClient, config: ESConfig, slots: list[dict], work_dir: Path) -> None:
+    template = build_adapter_template(work_dir, config.model, device=torch.device("cpu"))
+    theta_path = work_dir / "bench_theta_init.pt"
+    torch.save({"theta": template.theta.detach().cpu()}, theta_path)
+    response = await client.post(
+        "/es/init_lora_slots",
+        json={
+            "theta_path": theta_path.resolve().as_posix(),
+            "specs": serialize_specs(template),
+            "adapter_config": template.adapter_config,
+            "slots": slots,
+        },
+        timeout=None,
+    )
+    response.raise_for_status()
+    response = await client.post(
+        "/es/materialize_lora_slots",
+        json={"slots": [{**slot, "candidate_idx": slot["slot"], "seed": slot["slot"], "sign": 1} for slot in slots], "sigma": 0.0},
+        timeout=None,
+    )
+    response.raise_for_status()
+    theta_path.unlink(missing_ok=True)
+
+
+def gsm8k_messages(count: int) -> list[list[dict[str, str]]]:
+    dataset = load_dataset("openai/gsm8k", "main", split=f"train[:{count}]")
+    return [[{"role": "user", "content": row["question"]}] for row in dataset]
+
+
+async def run_batch(
+    client: httpx.AsyncClient,
+    messages: list[list[dict[str, str]]],
+    *,
+    candidates: int,
+    concurrency: int,
+    max_tokens: int,
+    top_k: int | None,
+) -> dict:
+    semaphore = asyncio.Semaphore(concurrency)
+    latencies = []
+    completion_tokens = 0
+    prompt_tokens = 0
+    failures = 0
+
+    async def one_request(idx: int, message: list[dict[str, str]]) -> None:
+        nonlocal completion_tokens, prompt_tokens, failures
+        candidate_idx = idx % candidates
+        payload = {
+            "model": f"es_slot_{candidate_idx}",
+            "messages": message,
+            "temperature": 1.0,
+            "top_p": 1.0,
+            "max_tokens": max_tokens,
+            "logprobs": False,
+        }
+        if top_k is not None:
+            payload["top_k"] = top_k
+        async with semaphore:
+            t0 = time.perf_counter()
+            try:
+                response = await client.post("/v1/chat/completions", json=payload, timeout=None)
+                response.raise_for_status()
+                body = response.json()
+                usage = body.get("usage") or {}
+                completion_tokens += int(usage.get("completion_tokens") or 0)
+                prompt_tokens += int(usage.get("prompt_tokens") or 0)
+            except Exception:
+                failures += 1
+            finally:
+                latencies.append(time.perf_counter() - t0)
+
+    started = time.perf_counter()
+    await asyncio.gather(*(one_request(idx, message) for idx, message in enumerate(messages)))
+    elapsed = time.perf_counter() - started
+    latencies_sorted = sorted(latencies)
+    return {
+        "requests": len(messages),
+        "failures": failures,
+        "elapsed_s": elapsed,
+        "completion_tokens": completion_tokens,
+        "prompt_tokens": prompt_tokens,
+        "completion_tps": completion_tokens / elapsed if elapsed > 0 else 0.0,
+        "total_tps": (completion_tokens + prompt_tokens) / elapsed if elapsed > 0 else 0.0,
+        "latency_mean_s": statistics.mean(latencies) if latencies else 0.0,
+        "latency_p50_s": latencies_sorted[int(0.50 * (len(latencies_sorted) - 1))] if latencies_sorted else 0.0,
+        "latency_p95_s": latencies_sorted[int(0.95 * (len(latencies_sorted) - 1))] if latencies_sorted else 0.0,
+    }
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-url", default="http://localhost:8000")
+    parser.add_argument("--es-config", type=Path, default=Path("configs/gsm8k/es.toml"))
+    parser.add_argument("--work-dir", type=Path, default=Path("outputs/gsm8k/es_qwen3_0_6b/bench"))
+    parser.add_argument("--candidates", type=int, default=32)
+    parser.add_argument("--examples-per-candidate", type=int, default=8)
+    parser.add_argument("--concurrency", type=int, default=256)
+    parser.add_argument("--max-tokens", type=int, default=2048)
+    parser.add_argument("--top-k", type=int, default=None)
+    parser.add_argument("--skip-init-slots", action="store_true")
+    parser.add_argument("--ready-timeout-s", type=float, default=240)
+    args = parser.parse_args()
+
+    with open(args.es_config, "rb") as f:
+        config = ESConfig(**tomllib.load(f))
+    args.work_dir.mkdir(parents=True, exist_ok=True)
+    slots = slot_definitions(args.candidates)
+    messages = gsm8k_messages(args.candidates * args.examples_per_candidate)
+
+    async with httpx.AsyncClient(base_url=args.base_url) as client:
+        await wait_ready(client, args.ready_timeout_s)
+        if not args.skip_init_slots:
+            await init_slots(client, config, slots, args.work_dir)
+        warmup_messages = messages[: min(32, len(messages))]
+        await run_batch(
+            client,
+            warmup_messages,
+            candidates=args.candidates,
+            concurrency=min(args.concurrency, len(warmup_messages)),
+            max_tokens=min(args.max_tokens, 256),
+            top_k=args.top_k,
+        )
+        result = await run_batch(
+            client,
+            messages,
+            candidates=args.candidates,
+            concurrency=args.concurrency,
+            max_tokens=args.max_tokens,
+            top_k=args.top_k,
+        )
+    print(json.dumps(result, sort_keys=True))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/benchmark_es_vllm_slots.py
+++ b/scripts/benchmark_es_vllm_slots.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import httpx
 import torch
+import torch.distributed as dist
 from datasets import load_dataset
 
 from prime_rl.configs.es import ESConfig
@@ -46,6 +47,10 @@ async def wait_ready(client: httpx.AsyncClient, timeout_s: float) -> None:
 
 
 async def init_slots(client: httpx.AsyncClient, config: ESConfig, slots: list[dict], work_dir: Path) -> None:
+    if not dist.is_initialized():
+        init_path = work_dir / "bench_dist_init"
+        init_path.unlink(missing_ok=True)
+        dist.init_process_group("gloo", init_method=f"file://{init_path}", rank=0, world_size=1)
     template = build_adapter_template(work_dir, config.model, device=torch.device("cpu"))
     theta_path = work_dir / "bench_theta_init.pt"
     torch.save({"theta": template.theta.detach().cpu()}, theta_path)

--- a/src/prime_rl/entrypoints/es.py
+++ b/src/prime_rl/entrypoints/es.py
@@ -1,0 +1,121 @@
+import os
+import subprocess
+import uuid
+from pathlib import Path
+from subprocess import Popen
+from threading import Event, Thread
+
+import tomli_w
+
+import prime_rl._compat  # noqa: F401 — patch ring_flash_attn compat before transitive import
+from prime_rl.configs.es import ESConfig
+from prime_rl.utils.config import cli
+from prime_rl.utils.logger import setup_logger
+from prime_rl.utils.pathing import get_config_dir, validate_output_dir
+from prime_rl.utils.process import cleanup_processes, cleanup_threads, monitor_process, set_proc_title
+from prime_rl.utils.utils import get_free_port
+
+ES_TOML = "es.toml"
+
+
+def write_config(config: ESConfig, config_path: Path) -> None:
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(config_path, "wb") as f:
+        tomli_w.dump(config.model_dump(exclude_none=True, mode="json"), f)
+
+
+def es_local(config: ESConfig) -> None:
+    logger = setup_logger(config.log.level or "info", json_logging=config.log.json_logging)
+
+    config_dir = get_config_dir(config.output_dir)
+    config_path = config_dir / ES_TOML
+    write_config(config, config_path)
+    logger.info(f"Wrote config to {config_path}")
+
+    if config.dry_run:
+        logger.success("Dry run complete. To start ES training locally, remove --dry-run from your command.")
+        return
+
+    log_dir = config.output_dir / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    trainer_cmd = [
+        "torchrun",
+        "--role=trainer",
+        f"--rdzv-endpoint=localhost:{get_free_port()}",
+        f"--rdzv-id={uuid.uuid4().hex}",
+        f"--log-dir={log_dir / 'trainer' / 'torchrun'}",
+        f"--local-ranks-filter={','.join(map(str, config.log.ranks_filter))}",
+        "--redirect=3",
+        "--tee=3",
+        f"--nproc-per-node={config.deployment.num_gpus}",
+        "-m",
+        "prime_rl.trainer.es.train",
+        "@",
+        config_path.as_posix(),
+    ]
+
+    logger.info(f"Starting ES trainer with {config.deployment.num_gpus} GPU(s)")
+    logger.debug(f"Trainer command: {' '.join(trainer_cmd)}")
+
+    processes: list[Popen] = []
+    monitor_threads: list[Thread] = []
+    error_queue: list[Exception] = []
+
+    try:
+        with open(log_dir / "trainer.log", "w") as log_file:
+            trainer_process = Popen(
+                trainer_cmd,
+                env={
+                    **os.environ,
+                    "PYTHONUNBUFFERED": "1",
+                    "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
+                },
+                stdout=log_file,
+                stderr=log_file,
+            )
+        processes.append(trainer_process)
+
+        stop_event = Event()
+        monitor_thread = Thread(
+            target=monitor_process,
+            args=(trainer_process, stop_event, error_queue, "es-trainer"),
+            daemon=True,
+        )
+        monitor_thread.start()
+        monitor_threads.append(monitor_thread)
+
+        stop_event.wait()
+
+        if error_queue:
+            raise error_queue[0]
+
+        if trainer_process.returncode != 0:
+            raise subprocess.CalledProcessError(trainer_process.returncode, trainer_cmd)
+
+        logger.success("ES training completed")
+    except KeyboardInterrupt:
+        logger.info("Interrupted, cleaning up")
+        raise
+    finally:
+        cleanup_processes(processes)
+        cleanup_threads(monitor_threads)
+
+
+def es(config: ESConfig) -> None:
+    if config.slurm is not None:
+        raise ValueError("ES SLURM launch is not implemented yet.")
+    resuming = config.ckpt is not None and config.ckpt.resume_step is not None
+    clean = config.clean_output_dir and not os.environ.get("NEVER_CLEAN_OUTPUT_DIR")
+    validate_output_dir(config.output_dir, resuming=resuming, clean=clean)
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+    es_local(config)
+
+
+def main():
+    set_proc_title("ES")
+    es(cli(ESConfig))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -18,6 +18,7 @@ from vllm.entrypoints.openai.utils import validate_json_request
 from vllm.entrypoints.serve.lora.protocol import LoadLoRAAdapterRequest
 from vllm.entrypoints.utils import load_aware_call, with_cancellation
 from vllm.logger import init_logger
+from vllm.lora.request import LoRARequest
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 
 from prime_rl.configs.inference import InferenceConfig
@@ -263,6 +264,53 @@ async def load_lora_adapter(lora_request: LoadLoRAAdapterRequest, raw_request: R
     response = await handler.load_lora_adapter(lora_request)
     if isinstance(response, ErrorResponse):
         return JSONResponse(content=response.model_dump(), status_code=response.error.code)
+    return {"status": "ok"}
+
+
+@router.post("/es/init_lora_slots")
+async def es_init_lora_slots(request: Request):
+    data = await request.json()
+    await engine_client(request).collective_rpc(
+        "es_init_lora_slots",
+        args=(data["theta_path"], data["specs"], data["adapter_config"], data["slots"]),
+    )
+    model_handler = models(request)
+    for slot in data["slots"]:
+        lora_name = str(slot["lora_name"])
+        model_handler.lora_requests[lora_name] = LoRARequest(
+            lora_name=lora_name,
+            lora_int_id=int(slot["lora_int_id"]),
+            lora_path="/prime_rl_es_slot",
+        )
+    await engine_client(request).reset_prefix_cache(reset_running_requests=True)
+    return {"status": "ok"}
+
+
+@router.post("/es/materialize_lora_slots")
+async def es_materialize_lora_slots(request: Request):
+    data = await request.json()
+    await engine_client(request).collective_rpc(
+        "es_materialize_lora_slots",
+        args=(data["slots"], float(data["sigma"])),
+    )
+    await engine_client(request).reset_prefix_cache(reset_running_requests=True)
+    return {"status": "ok"}
+
+
+@router.post("/es/update_lora_theta")
+async def es_update_lora_theta(request: Request):
+    data = await request.json()
+    await engine_client(request).collective_rpc(
+        "es_update_lora_theta",
+        args=(
+            data["candidates"],
+            data["rewards"],
+            float(data["lr"]),
+            data["normalization"],
+            bool(data["mirrored"]),
+            float(data["sigma"]),
+        ),
+    )
     return {"status": "ok"}
 
 

--- a/src/prime_rl/inference/vllm/worker/es_lora_slots.py
+++ b/src/prime_rl/inference/vllm/worker/es_lora_slots.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import torch
+from vllm.lora.lora_model import LoRAModel
+from vllm.lora.peft_helper import PEFTHelper
+from vllm.lora.request import LoRARequest
+
+if TYPE_CHECKING:
+    from vllm.lora.model_manager import LoRAModelManager
+
+
+@dataclass(frozen=True)
+class ESLoRATensorSpec:
+    name: str
+    shape: tuple[int, ...]
+    dtype: str
+    numel: int
+
+
+def _dtype_from_name(name: str) -> torch.dtype:
+    return getattr(torch, name.replace("torch.", ""))
+
+
+def _noise_like(theta: torch.Tensor, seed: int) -> torch.Tensor:
+    generator = torch.Generator(device=theta.device)
+    generator.manual_seed(seed)
+    return torch.randn(theta.shape, generator=generator, device=theta.device, dtype=torch.float32)
+
+
+def _normalize_rewards(rewards: list[float], mode: str) -> torch.Tensor:
+    values = torch.tensor(rewards, dtype=torch.float32)
+    if mode == "none":
+        return values
+    centered = values - values.mean()
+    if mode == "centered":
+        return centered
+    if mode != "zscore":
+        raise ValueError(f"Unsupported reward normalization: {mode}")
+    std = values.std(unbiased=False)
+    if float(std.item()) < 1e-8:
+        return torch.zeros_like(values)
+    return centered / std
+
+
+def _load_specs(payload: list[dict[str, Any]]) -> list[ESLoRATensorSpec]:
+    return [
+        ESLoRATensorSpec(
+            name=str(item["name"]),
+            shape=tuple(int(v) for v in item["shape"]),
+            dtype=str(item["dtype"]),
+            numel=int(item["numel"]),
+        )
+        for item in payload
+    ]
+
+
+def _unflatten_lora_tensors(
+    flat: torch.Tensor,
+    specs: list[ESLoRATensorSpec],
+) -> dict[str, torch.Tensor]:
+    tensors: dict[str, torch.Tensor] = {}
+    offset = 0
+    for spec in specs:
+        dtype = _dtype_from_name(spec.dtype)
+        tensors[spec.name] = flat[offset : offset + spec.numel].reshape(spec.shape).to(dtype=dtype)
+        offset += spec.numel
+    return tensors
+
+
+class ESLoRASlotWorkerMixin:
+    """vLLM worker extension mixin for ES-managed persistent LoRA slots."""
+
+    def es_init_lora_slots(
+        self,
+        theta_path: str,
+        specs_payload: list[dict[str, Any]],
+        adapter_config: dict[str, Any],
+        slots: list[dict[str, Any]],
+    ) -> None:
+        lora_manager = self.model_runner.lora_manager
+        adapter_manager: LoRAModelManager = lora_manager._adapter_manager
+
+        state = torch.load(Path(theta_path), map_location="cpu", weights_only=False)
+        theta = state["theta"] if isinstance(state, dict) else state
+        self.es_lora_theta = theta.to(device=self.device, dtype=torch.float32)
+        self.es_lora_specs = _load_specs(specs_payload)
+        self.es_lora_adapter_config = dict(adapter_config)
+        max_position_embeddings = getattr(self, "max_position_embeddings", None)
+        self.es_lora_peft_helper = PEFTHelper.from_dict(
+            self.es_lora_adapter_config | {"vllm_max_position_embeddings": max_position_embeddings}
+        )
+        self.es_lora_peft_helper.validate_legal(lora_manager.lora_config)
+
+        self.es_lora_slots = {int(slot["lora_int_id"]): str(slot["lora_name"]) for slot in slots}
+        rank = int(self.es_lora_adapter_config["r"])
+        for lora_int_id, lora_name in self.es_lora_slots.items():
+            request = LoRARequest(lora_name=lora_name, lora_int_id=lora_int_id, lora_path="/prime_rl_es_slot")
+            if lora_int_id not in lora_manager.list_adapters():
+                lora_manager.add_dummy_lora(request, rank=rank)
+            adapter_manager.activate_adapter(lora_int_id)
+
+    def _es_lora_model_from_flat(self, lora_int_id: int, flat: torch.Tensor) -> LoRAModel:
+        model = self.model_runner.lora_manager._adapter_manager.model
+        hf_to_vllm_mapper = getattr(model, "hf_to_vllm_mapper", None)
+        lora_skip_prefixes = getattr(model, "lora_skip_prefixes", None)
+        tensors = _unflatten_lora_tensors(flat, self.es_lora_specs)
+        return LoRAModel.from_lora_tensors(
+            lora_model_id=lora_int_id,
+            tensors=tensors,
+            peft_helper=self.es_lora_peft_helper,
+            device=str(self.device),
+            dtype=self.model_runner.lora_manager.lora_config.lora_dtype,
+            model_vocab_size=self.model_runner.lora_manager.vocab_size,
+            weights_mapper=hf_to_vllm_mapper,
+            skip_prefixes=lora_skip_prefixes,
+        )
+
+    @torch.no_grad()
+    def es_materialize_lora_slots(self, slot_payload: list[dict[str, Any]], sigma: float) -> None:
+        adapter_manager: LoRAModelManager = self.model_runner.lora_manager._adapter_manager
+        for item in slot_payload:
+            lora_int_id = int(item["lora_int_id"])
+            seed = int(item["seed"])
+            sign = int(item.get("sign", 1))
+            if lora_int_id not in self.es_lora_slots:
+                raise ValueError(f"Unknown ES LoRA slot id: {lora_int_id}")
+            slot_index = adapter_manager.lora_index_to_id.index(lora_int_id)
+            candidate_theta = self.es_lora_theta + sign * float(sigma) * _noise_like(self.es_lora_theta, seed)
+            lora_model = self._es_lora_model_from_flat(lora_int_id, candidate_theta)
+            adapter_manager._create_merged_loras_inplace(lora_model)
+            for module_name, module in adapter_manager.modules.items():
+                module_lora = adapter_manager._get_lora_layer_weights(lora_model, module_name)
+                if module_lora is None:
+                    module.reset_lora(slot_index)
+                    continue
+                module.set_lora(slot_index, module_lora.lora_a, module_lora.lora_b)
+        torch.cuda.synchronize(self.device)
+
+    @torch.no_grad()
+    def es_update_lora_theta(
+        self,
+        candidates_payload: list[dict[str, Any]],
+        rewards: list[float],
+        lr: float,
+        normalization: str,
+        mirrored: bool,
+        sigma: float,
+    ) -> None:
+        if mirrored:
+            by_seed: dict[int, dict[int, float]] = {}
+            for item, reward in zip(candidates_payload, rewards, strict=True):
+                by_seed.setdefault(int(item["seed"]), {})[int(item.get("sign", 1))] = float(reward)
+            grad = torch.zeros_like(self.es_lora_theta)
+            used_pairs = 0
+            for seed, pair in by_seed.items():
+                if 1 not in pair or -1 not in pair:
+                    continue
+                grad.add_(_noise_like(self.es_lora_theta, seed), alpha=(pair[1] - pair[-1]) / (2.0 * float(sigma)))
+                used_pairs += 1
+            if used_pairs:
+                grad.div_(float(used_pairs))
+        else:
+            scores = _normalize_rewards(rewards, normalization).tolist()
+            grad = torch.zeros_like(self.es_lora_theta)
+            for item, score in zip(candidates_payload, scores, strict=True):
+                grad.add_(_noise_like(self.es_lora_theta, int(item["seed"])), alpha=float(score))
+            if candidates_payload:
+                grad.div_(float(len(candidates_payload)))
+        self.es_lora_theta.add_(grad, alpha=float(lr))
+        torch.cuda.synchronize(self.device)

--- a/src/prime_rl/inference/vllm/worker/filesystem.py
+++ b/src/prime_rl/inference/vllm/worker/filesystem.py
@@ -4,6 +4,8 @@ from torch.nn import Module
 from vllm.model_executor.model_loader import DefaultModelLoader, get_model_loader
 from vllm.model_executor.model_loader.utils import process_weights_after_loading
 
+from prime_rl.inference.vllm.worker.es_lora_slots import ESLoRASlotWorkerMixin
+
 # This is to get type hints for the Worker class but not actually extend it at runtime as this is required by vLLM worker extension
 if TYPE_CHECKING:
     from vllm.v1.worker.gpu_worker import Worker
@@ -13,7 +15,7 @@ else:
     Worker = object
 
 
-class FileSystemWeightUpdateWorker(Worker):
+class FileSystemWeightUpdateWorker(ESLoRASlotWorkerMixin, Worker):
     """vLLM worker extension for updating weights in-place using shared filesystem."""
 
     def init_broadcaster(self) -> None:

--- a/src/prime_rl/inference/vllm/worker/nccl.py
+++ b/src/prime_rl/inference/vllm/worker/nccl.py
@@ -13,6 +13,7 @@ from prime_rl.inference.vllm.worker.weight_transfer import (
     postprocess_weights_checkpoint,
     postprocess_weights_kernel,
 )
+from prime_rl.inference.vllm.worker.es_lora_slots import ESLoRASlotWorkerMixin
 from prime_rl.utils.nccl import disable_nccl_p2p_if_unavailable
 
 # This is to get type hints for the Worker class but not actually extend it at runtime as this is required by vLLM worker extension
@@ -90,7 +91,7 @@ class NCCLWeightBroadcastReceiver:
                 yield key, value
 
 
-class NCCLWeightUpdateWorker(Worker):
+class NCCLWeightUpdateWorker(ESLoRASlotWorkerMixin, Worker):
     """vLLM worker extension for updating weights in-place using NCCL."""
 
     def init_broadcaster(

--- a/src/prime_rl/orchestrator/vf_utils.py
+++ b/src/prime_rl/orchestrator/vf_utils.py
@@ -56,6 +56,11 @@ def get_model_completion_len(output: vf.RolloutOutput) -> int:
     Unlike get_completion_len, this excludes environment responses injected
     between turns in multi-turn rollouts.
     """
+    token_usage = output.get("token_usage") or {}
+    for key in ("final_output_tokens", "output_tokens"):
+        value = token_usage.get(key)
+        if isinstance(value, (int, float)):
+            return int(value)
     return sum(len(step["tokens"]["completion_ids"]) for step in output["trajectory"] if step.get("tokens"))
 
 

--- a/src/prime_rl/trainer/es/__init__.py
+++ b/src/prime_rl/trainer/es/__init__.py
@@ -1,0 +1,1 @@
+"""Synchronous ES-LoRA trainer."""

--- a/src/prime_rl/trainer/es/candidates.py
+++ b/src/prime_rl/trainer/es/candidates.py
@@ -79,7 +79,9 @@ def estimate_gradient(
     ordered_rewards = [rewards[c.idx] for c in candidates]
     scores = normalize_rewards(ordered_rewards, normalization)
     for candidate, score in zip(candidates, scores, strict=True):
-        grad.add_(noise_like(theta, candidate.seed), alpha=float(score) / sigma)
+        # Matches the prior Alphabet Sort ES runner: sigma controls candidate
+        # perturbation scale, while the update averages score-weighted noise.
+        grad.add_(noise_like(theta, candidate.seed), alpha=float(score))
     if candidates:
         grad.div_(float(len(candidates)))
     return grad

--- a/src/prime_rl/trainer/es/candidates.py
+++ b/src/prime_rl/trainer/es/candidates.py
@@ -1,0 +1,85 @@
+from dataclasses import dataclass
+
+import numpy as np
+import torch
+
+
+@dataclass(frozen=True)
+class Candidate:
+    idx: int
+    seed: int
+    sign: int = 1
+
+    @property
+    def name_suffix(self) -> str:
+        if self.sign > 0:
+            return f"cand_{self.idx:04d}"
+        return f"cand_{self.idx:04d}_minus"
+
+
+def make_candidates(base_seed: int, step: int, population_size: int, mirrored: bool) -> list[Candidate]:
+    rng = np.random.default_rng(base_seed + step)
+    if mirrored:
+        seeds = [int(rng.integers(0, np.iinfo(np.uint32).max)) for _ in range(population_size // 2)]
+        candidates: list[Candidate] = []
+        for idx, seed in enumerate(seeds):
+            candidates.append(Candidate(idx=2 * idx, seed=seed, sign=1))
+            candidates.append(Candidate(idx=2 * idx + 1, seed=seed, sign=-1))
+        return candidates
+    return [
+        Candidate(idx=idx, seed=int(rng.integers(0, np.iinfo(np.uint32).max)), sign=1) for idx in range(population_size)
+    ]
+
+
+def noise_like(theta: torch.Tensor, seed: int) -> torch.Tensor:
+    generator = torch.Generator(device=theta.device)
+    generator.manual_seed(seed)
+    return torch.randn(theta.shape, generator=generator, device=theta.device, dtype=torch.float32)
+
+
+def normalize_rewards(rewards: list[float], mode: str) -> np.ndarray:
+    arr = np.asarray(rewards, dtype=np.float32)
+    if mode == "none":
+        return arr
+    mean = float(arr.mean()) if arr.size else 0.0
+    centered = arr - mean
+    if mode == "centered":
+        return centered
+    if mode != "zscore":
+        raise ValueError(f"Unsupported reward normalization: {mode}")
+    std = float(arr.std())
+    if std < 1e-8:
+        return np.zeros_like(arr)
+    return centered / std
+
+
+def estimate_gradient(
+    theta: torch.Tensor,
+    candidates: list[Candidate],
+    rewards: dict[int, float],
+    sigma: float,
+    normalization: str,
+    mirrored: bool,
+) -> torch.Tensor:
+    grad = torch.zeros_like(theta)
+    if mirrored:
+        by_seed: dict[int, dict[int, float]] = {}
+        for candidate in candidates:
+            by_seed.setdefault(candidate.seed, {})[candidate.sign] = rewards[candidate.idx]
+        used_pairs = 0
+        for seed, pair in by_seed.items():
+            if 1 not in pair or -1 not in pair:
+                continue
+            grad.add_(noise_like(theta, seed), alpha=(pair[1] - pair[-1]) / (2.0 * sigma))
+            used_pairs += 1
+        if used_pairs:
+            grad.div_(float(used_pairs))
+        return grad
+
+    ordered_rewards = [rewards[c.idx] for c in candidates]
+    scores = normalize_rewards(ordered_rewards, normalization)
+    for candidate, score in zip(candidates, scores, strict=True):
+        grad.add_(noise_like(theta, candidate.seed), alpha=float(score) / sigma)
+    if candidates:
+        grad.div_(float(len(candidates)))
+    return grad

--- a/src/prime_rl/trainer/es/ckpt.py
+++ b/src/prime_rl/trainer/es/ckpt.py
@@ -1,0 +1,66 @@
+import shutil
+from pathlib import Path
+
+import torch
+
+from prime_rl.trainer.es.lora_materialize import TensorSpec
+from prime_rl.utils.pathing import get_ckpt_dir, get_step_path
+
+
+def save_es_state(
+    output_dir: Path,
+    step: int,
+    theta: torch.Tensor,
+    specs: list[TensorSpec],
+    metrics: dict,
+) -> Path:
+    step_dir = get_step_path(get_ckpt_dir(output_dir), step) / "es"
+    step_dir.mkdir(parents=True, exist_ok=True)
+    torch.save(
+        {
+            "step": step,
+            "theta": theta.detach().cpu(),
+            "specs": specs,
+            "metrics": metrics,
+        },
+        step_dir / "es_state.pt",
+    )
+    (step_dir.parent / "STABLE").touch()
+    return step_dir
+
+
+def load_es_state(output_dir: Path, step: int) -> dict:
+    state_path = get_step_path(get_ckpt_dir(output_dir), step) / "es" / "es_state.pt"
+    return torch.load(state_path, map_location="cpu", weights_only=False)
+
+
+def latest_es_step(output_dir: Path) -> int | None:
+    ckpt_dir = get_ckpt_dir(output_dir)
+    if not ckpt_dir.exists():
+        return None
+    steps: list[int] = []
+    for path in ckpt_dir.glob("step_*"):
+        stable = path / "STABLE"
+        state = path / "es" / "es_state.pt"
+        if stable.exists() and state.exists():
+            try:
+                steps.append(int(path.name.split("_")[-1]))
+            except ValueError:
+                continue
+    return max(steps) if steps else None
+
+
+def maybe_clean_es_checkpoints(output_dir: Path, current_step: int, keep_last: int | None) -> None:
+    if keep_last is None:
+        return
+    ckpt_dir = get_ckpt_dir(output_dir)
+    if not ckpt_dir.exists():
+        return
+    keep_from = max(current_step - keep_last + 1, 0)
+    for path in ckpt_dir.glob("step_*"):
+        try:
+            step = int(path.name.split("_")[-1])
+        except ValueError:
+            continue
+        if step < keep_from:
+            shutil.rmtree(path, ignore_errors=True)

--- a/src/prime_rl/trainer/es/lora_materialize.py
+++ b/src/prime_rl/trainer/es/lora_materialize.py
@@ -1,14 +1,17 @@
+import json
 from dataclasses import dataclass
 from pathlib import Path
 
 import torch
 import torch.nn as nn
+from safetensors.torch import save_file
+from transformers.utils import ADAPTER_SAFE_WEIGHTS_NAME
 
 from prime_rl.configs.trainer import LoRAConfig, ModelConfig
-from prime_rl.trainer.lora import apply_lora_to_model, save_lora_config
+from prime_rl.trainer.lora import apply_lora_to_model
+from prime_rl.trainer.models.layers.lora import MultiLoRAModule
 from prime_rl.trainer.model import DTYPE_MAP, configure_moe_ep_backend, get_model
 from prime_rl.trainer.runs import setup_multi_run_manager
-from prime_rl.trainer.weights import save_state_dict
 from prime_rl.utils.logger import get_logger
 
 
@@ -25,6 +28,7 @@ class AdapterTemplate:
     model: nn.Module
     specs: list[TensorSpec]
     theta: torch.Tensor
+    adapter_config: dict
 
 
 def _init_lora_tensor(name: str, shape: torch.Size) -> torch.Tensor:
@@ -36,7 +40,11 @@ def _init_lora_tensor(name: str, shape: torch.Size) -> torch.Tensor:
     return tensor
 
 
-def flatten_state_specs(state_dict: dict[str, torch.Tensor]) -> tuple[torch.Tensor, list[TensorSpec]]:
+def flatten_state_specs(
+    state_dict: dict[str, torch.Tensor],
+    *,
+    device: torch.device | None = None,
+) -> tuple[torch.Tensor, list[TensorSpec]]:
     pieces: list[torch.Tensor] = []
     specs: list[TensorSpec] = []
     for name, tensor in state_dict.items():
@@ -46,7 +54,10 @@ def flatten_state_specs(state_dict: dict[str, torch.Tensor]) -> tuple[torch.Tens
         specs.append(TensorSpec(name=name, shape=shape, dtype=tensor.dtype, numel=init.numel()))
     if not pieces:
         raise RuntimeError("No LoRA tensors were found while building the ES adapter template.")
-    return torch.cat(pieces).to(torch.float32), specs
+    theta = torch.cat(pieces).to(dtype=torch.float32)
+    if device is not None:
+        theta = theta.to(device=device)
+    return theta, specs
 
 
 def unflatten_state(
@@ -65,7 +76,37 @@ def unflatten_state(
     return state
 
 
-def build_adapter_template(output_dir: Path, model_config: ModelConfig) -> AdapterTemplate:
+def build_adapter_config(model: nn.Module, lora_config: LoRAConfig) -> dict:
+    target_modules = set()
+    modules_to_save = set()
+
+    for name, module in model.named_modules():
+        if isinstance(module, MultiLoRAModule):
+            target_modules.add(name.split(".")[-1])
+
+    for name, param in model.named_parameters():
+        if param.requires_grad and "lora_A" not in name and "lora_B" not in name:
+            modules_to_save.add(name.rsplit(".", 1)[0].split(".")[-1])
+
+    return {
+        "peft_type": "LORA",
+        "task_type": "CAUSAL_LM",
+        "base_model_name_or_path": model.config._name_or_path,
+        "r": lora_config.rank,
+        "lora_alpha": lora_config.alpha,
+        "lora_dropout": lora_config.dropout,
+        "bias": "none",
+        "target_modules": sorted(target_modules),
+        "modules_to_save": sorted(modules_to_save) if modules_to_save else None,
+    }
+
+
+def build_adapter_template(
+    output_dir: Path,
+    model_config: ModelConfig,
+    *,
+    device: torch.device | None = None,
+) -> AdapterTemplate:
     if model_config.lora is None:
         raise ValueError("ES adapter template requires model.lora to be configured.")
 
@@ -75,6 +116,7 @@ def build_adapter_template(output_dir: Path, model_config: ModelConfig) -> Adapt
     model = get_model(model_config, device=torch.device("meta"), dtype=DTYPE_MAP[model_config.optimization_dtype])
     configure_moe_ep_backend(model, model_config)
     apply_lora_to_model(model, model_config.lora)
+    adapter_config = build_adapter_config(model, model_config.lora)
 
     from prime_rl.trainer.runs import get_multi_run_manager
 
@@ -82,22 +124,22 @@ def build_adapter_template(output_dir: Path, model_config: ModelConfig) -> Adapt
     manager.reset_run_parameters(0)
     manager.scaling_factors[0] = model_config.lora.alpha / model_config.lora.rank
     state_dict = manager.get_state_dict_for_run(0)
-    theta, specs = flatten_state_specs(state_dict)
-    logger.info(f"ES LoRA search space has {theta.numel():,} parameters across {len(specs):,} tensors")
-    return AdapterTemplate(model=model, specs=specs, theta=theta)
+    theta, specs = flatten_state_specs(state_dict, device=device)
+    logger.info(
+        f"ES LoRA search space has {theta.numel():,} parameters across {len(specs):,} tensors on {theta.device}"
+    )
+    return AdapterTemplate(model=model, specs=specs, theta=theta, adapter_config=adapter_config)
 
 
 def write_adapter_from_theta(
     adapter_dir: Path,
     template: AdapterTemplate,
-    lora_config: LoRAConfig,
     theta: torch.Tensor,
     *,
     dtype: torch.dtype = torch.bfloat16,
 ) -> None:
     adapter_dir.mkdir(parents=True, exist_ok=True)
     state = unflatten_state(theta, template.specs, dtype=dtype)
-    save_state_dict(state, adapter_dir, save_format="safetensors", save_sharded=False, adapter=True)
-    save_lora_config(
-        template.model, adapter_dir, rank=lora_config.rank, alpha=lora_config.alpha, dropout=lora_config.dropout
-    )
+    save_file(state, adapter_dir / ADAPTER_SAFE_WEIGHTS_NAME, metadata={"format": "pt"})
+    with open(adapter_dir / "adapter_config.json", "w", encoding="utf-8") as f:
+        json.dump(template.adapter_config, f, indent=2)

--- a/src/prime_rl/trainer/es/lora_materialize.py
+++ b/src/prime_rl/trainer/es/lora_materialize.py
@@ -1,0 +1,103 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+
+from prime_rl.configs.trainer import LoRAConfig, ModelConfig
+from prime_rl.trainer.lora import apply_lora_to_model, save_lora_config
+from prime_rl.trainer.model import DTYPE_MAP, configure_moe_ep_backend, get_model
+from prime_rl.trainer.runs import setup_multi_run_manager
+from prime_rl.trainer.weights import save_state_dict
+from prime_rl.utils.logger import get_logger
+
+
+@dataclass(frozen=True)
+class TensorSpec:
+    name: str
+    shape: torch.Size
+    dtype: torch.dtype
+    numel: int
+
+
+@dataclass
+class AdapterTemplate:
+    model: nn.Module
+    specs: list[TensorSpec]
+    theta: torch.Tensor
+
+
+def _init_lora_tensor(name: str, shape: torch.Size) -> torch.Tensor:
+    tensor = torch.empty(shape, dtype=torch.float32)
+    if "lora_B" in name:
+        nn.init.zeros_(tensor)
+    else:
+        nn.init.kaiming_uniform_(tensor, a=5**0.5)
+    return tensor
+
+
+def flatten_state_specs(state_dict: dict[str, torch.Tensor]) -> tuple[torch.Tensor, list[TensorSpec]]:
+    pieces: list[torch.Tensor] = []
+    specs: list[TensorSpec] = []
+    for name, tensor in state_dict.items():
+        shape = torch.Size(tensor.shape)
+        init = _init_lora_tensor(name, shape)
+        pieces.append(init.reshape(-1))
+        specs.append(TensorSpec(name=name, shape=shape, dtype=tensor.dtype, numel=init.numel()))
+    if not pieces:
+        raise RuntimeError("No LoRA tensors were found while building the ES adapter template.")
+    return torch.cat(pieces).to(torch.float32), specs
+
+
+def unflatten_state(
+    flat: torch.Tensor,
+    specs: list[TensorSpec],
+    *,
+    dtype: torch.dtype = torch.bfloat16,
+) -> dict[str, torch.Tensor]:
+    state: dict[str, torch.Tensor] = {}
+    offset = 0
+    cpu_flat = flat.detach().to("cpu")
+    for spec in specs:
+        tensor = cpu_flat[offset : offset + spec.numel].reshape(spec.shape).to(dtype=dtype).contiguous()
+        state[spec.name] = tensor
+        offset += spec.numel
+    return state
+
+
+def build_adapter_template(output_dir: Path, model_config: ModelConfig) -> AdapterTemplate:
+    if model_config.lora is None:
+        raise ValueError("ES adapter template requires model.lora to be configured.")
+
+    logger = get_logger()
+    logger.info("Building ES LoRA adapter template on meta device")
+    setup_multi_run_manager(output_dir, max_runs=1, device=torch.device("cpu"), lora_config=model_config.lora)
+    model = get_model(model_config, device=torch.device("meta"), dtype=DTYPE_MAP[model_config.optimization_dtype])
+    configure_moe_ep_backend(model, model_config)
+    apply_lora_to_model(model, model_config.lora)
+
+    from prime_rl.trainer.runs import get_multi_run_manager
+
+    manager = get_multi_run_manager()
+    manager.reset_run_parameters(0)
+    manager.scaling_factors[0] = model_config.lora.alpha / model_config.lora.rank
+    state_dict = manager.get_state_dict_for_run(0)
+    theta, specs = flatten_state_specs(state_dict)
+    logger.info(f"ES LoRA search space has {theta.numel():,} parameters across {len(specs):,} tensors")
+    return AdapterTemplate(model=model, specs=specs, theta=theta)
+
+
+def write_adapter_from_theta(
+    adapter_dir: Path,
+    template: AdapterTemplate,
+    lora_config: LoRAConfig,
+    theta: torch.Tensor,
+    *,
+    dtype: torch.dtype = torch.bfloat16,
+) -> None:
+    adapter_dir.mkdir(parents=True, exist_ok=True)
+    state = unflatten_state(theta, template.specs, dtype=dtype)
+    save_state_dict(state, adapter_dir, save_format="safetensors", save_sharded=False, adapter=True)
+    save_lora_config(
+        template.model, adapter_dir, rank=lora_config.rank, alpha=lora_config.alpha, dropout=lora_config.dropout
+    )

--- a/src/prime_rl/trainer/es/rollout.py
+++ b/src/prime_rl/trainer/es/rollout.py
@@ -1,4 +1,5 @@
 import asyncio
+import random
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -27,11 +28,16 @@ def sample_examples(env: TrainEnv, count: int, seed: int) -> list[dict]:
     dataset = env.get_dataset(seed=seed)
     if hasattr(dataset, "shuffle"):
         dataset = dataset.shuffle(seed=seed)
-    if hasattr(dataset, "select"):
-        dataset = dataset.select(range(min(count, len(dataset))))
     if hasattr(dataset, "to_list"):
-        return dataset.to_list()
-    return list(dataset)[:count]
+        rows = dataset.to_list()
+    else:
+        rows = list(dataset)
+    if not rows:
+        return []
+    if count <= len(rows):
+        return rows[:count]
+    rng = random.Random(seed)
+    return [rng.choice(rows) for _ in range(count)]
 
 
 async def start_train_envs(config: ESConfig) -> list[TrainEnv]:
@@ -78,6 +84,61 @@ async def unload_candidate_adapters(
     candidate_names: dict[int, str],
 ) -> None:
     await asyncio.gather(*[unload_lora_adapter(admin_clients, name) for name in candidate_names.values()])
+
+
+async def init_lora_slots(
+    admin_clients: list[httpx.AsyncClient],
+    theta_path: Path,
+    specs: list[dict],
+    adapter_config: dict,
+    slots: list[dict],
+) -> None:
+    payload = {
+        "theta_path": theta_path.resolve().as_posix(),
+        "specs": specs,
+        "adapter_config": adapter_config,
+        "slots": slots,
+    }
+    responses = await asyncio.gather(*[client.post("/es/init_lora_slots", json=payload) for client in admin_clients])
+    for response in responses:
+        response.raise_for_status()
+
+
+async def materialize_lora_slots(
+    admin_clients: list[httpx.AsyncClient],
+    slots: list[dict],
+    sigma: float,
+) -> None:
+    payload = {"slots": slots, "sigma": sigma}
+    responses = await asyncio.gather(
+        *[client.post("/es/materialize_lora_slots", json=payload, timeout=None) for client in admin_clients]
+    )
+    for response in responses:
+        response.raise_for_status()
+
+
+async def update_lora_slot_theta(
+    admin_clients: list[httpx.AsyncClient],
+    candidates: list[dict],
+    rewards: list[float],
+    lr: float,
+    normalization: str,
+    mirrored: bool,
+    sigma: float,
+) -> None:
+    payload = {
+        "candidates": candidates,
+        "rewards": rewards,
+        "lr": lr,
+        "normalization": normalization,
+        "mirrored": mirrored,
+        "sigma": sigma,
+    }
+    responses = await asyncio.gather(
+        *[client.post("/es/update_lora_theta", json=payload, timeout=None) for client in admin_clients]
+    )
+    for response in responses:
+        response.raise_for_status()
 
 
 async def evaluate_candidate(

--- a/src/prime_rl/trainer/es/rollout.py
+++ b/src/prime_rl/trainer/es/rollout.py
@@ -1,0 +1,186 @@
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+import verifiers as vf
+
+from prime_rl.configs.es import ESConfig
+from prime_rl.orchestrator.envs import TrainEnv
+from prime_rl.orchestrator.vf_utils import get_model_completion_len, get_num_turns
+from prime_rl.trainer.es.candidates import Candidate
+from prime_rl.utils.client import load_lora_adapter, setup_admin_clients, setup_clients, unload_lora_adapter
+from prime_rl.utils.logger import ProgressTracker, get_logger
+
+
+@dataclass
+class CandidateRolloutResult:
+    candidate_idx: int
+    reward: float
+    num_rollouts: int
+    failed_rollouts: int
+    generated_tokens: int
+    turns: int
+
+
+def sample_examples(env: TrainEnv, count: int, seed: int) -> list[dict]:
+    dataset = env.get_dataset(seed=seed)
+    if hasattr(dataset, "shuffle"):
+        dataset = dataset.shuffle(seed=seed)
+    if hasattr(dataset, "select"):
+        dataset = dataset.select(range(min(count, len(dataset))))
+    if hasattr(dataset, "to_list"):
+        return dataset.to_list()
+    return list(dataset)[:count]
+
+
+async def start_train_envs(config: ESConfig) -> list[TrainEnv]:
+    envs = [TrainEnv(env_config) for env_config in config.train.env]
+    log_dir = config.output_dir / "logs" / "envs"
+    for env in envs:
+        await env.start(log_dir=log_dir, log_level=config.log.level, json_logging=config.log.json_logging)
+    return envs
+
+
+def shutdown_train_envs(envs: list[TrainEnv]) -> None:
+    for env in envs:
+        env.shutdown()
+
+
+def build_clients(config: ESConfig) -> list[vf.ClientConfig]:
+    return setup_clients(config.client)
+
+
+def build_admin_clients(config: ESConfig) -> list[httpx.AsyncClient]:
+    return setup_admin_clients(config.client)
+
+
+async def close_admin_clients(admin_clients: list[httpx.AsyncClient]) -> None:
+    for client in admin_clients:
+        await client.aclose()
+
+
+async def load_candidate_adapters(
+    admin_clients: list[httpx.AsyncClient],
+    candidate_paths: dict[int, Path],
+    candidate_names: dict[int, str],
+) -> None:
+    await asyncio.gather(
+        *[
+            load_lora_adapter(admin_clients, candidate_names[candidate_idx], candidate_path.resolve())
+            for candidate_idx, candidate_path in candidate_paths.items()
+        ]
+    )
+
+
+async def unload_candidate_adapters(
+    admin_clients: list[httpx.AsyncClient],
+    candidate_names: dict[int, str],
+) -> None:
+    await asyncio.gather(*[unload_lora_adapter(admin_clients, name) for name in candidate_names.values()])
+
+
+async def evaluate_candidate(
+    candidate: Candidate,
+    candidate_name: str,
+    envs: list[TrainEnv],
+    examples_by_env: dict[str, list[dict]],
+    clients: list[vf.ClientConfig],
+    config: ESConfig,
+    *,
+    step: int,
+) -> CandidateRolloutResult:
+    semaphore = asyncio.Semaphore(config.train.max_concurrent_rollouts_per_rank)
+    logger = get_logger()
+    outputs = []
+    failed = 0
+    client_cursor = 0
+
+    async def run_one(env: TrainEnv, example: dict, rollout_idx: int):
+        nonlocal failed, client_cursor
+        async with semaphore:
+            client = clients[client_cursor % len(clients)]
+            client_cursor += 1
+            cache_salt = f"es-{step}-{candidate.idx}-{rollout_idx}"
+            try:
+                if env.requires_group_scoring:
+                    group = await env.run_group(
+                        client=client,
+                        example=example,
+                        model_name=candidate_name,
+                        rollouts_per_example=config.train.rollouts_per_example,
+                        cache_salt=cache_salt,
+                    )
+                    return group
+                rollout = await env.run_rollout(
+                    client=client,
+                    example=example,
+                    model_name=candidate_name,
+                    cache_salt=cache_salt,
+                )
+                return [rollout]
+            except Exception as exc:
+                failed += 1
+                logger.warning(f"Candidate {candidate.idx} rollout failed in {env.name}: {exc}")
+                return []
+
+    coros = []
+    for env in envs:
+        examples = examples_by_env[env.name]
+        repeats = 1 if env.requires_group_scoring else config.train.rollouts_per_example
+        for example in examples:
+            for rollout_idx in range(repeats):
+                coros.append(run_one(env, example, rollout_idx))
+
+    for group in await asyncio.gather(*coros):
+        outputs.extend(group)
+
+    valid = [o for o in outputs if o.get("error") is None and o.get("trajectory")]
+    failed += len(outputs) - len(valid)
+    rewards = [float(o.get("reward") or 0.0) for o in valid]
+    reward = sum(rewards) / len(rewards) if rewards else 0.0
+    return CandidateRolloutResult(
+        candidate_idx=candidate.idx,
+        reward=reward,
+        num_rollouts=len(valid),
+        failed_rollouts=failed,
+        generated_tokens=sum(get_model_completion_len(o) for o in valid),
+        turns=sum(get_num_turns(o) for o in valid),
+    )
+
+
+async def evaluate_candidate_chunk(
+    candidates: list[Candidate],
+    candidate_names: dict[int, str],
+    envs: list[TrainEnv],
+    examples_by_env: dict[str, list[dict]],
+    clients: list[vf.ClientConfig],
+    config: ESConfig,
+    *,
+    step: int,
+) -> list[CandidateRolloutResult]:
+    pbar = ProgressTracker(
+        total=len(candidates),
+        desc=f"Evaluating ES candidates (step {step})",
+        json_logging=config.log.json_logging,
+        step=step,
+    )
+
+    async def run(candidate: Candidate):
+        try:
+            return await evaluate_candidate(
+                candidate,
+                candidate_names[candidate.idx],
+                envs,
+                examples_by_env,
+                clients,
+                config,
+                step=step,
+            )
+        finally:
+            pbar.update(1)
+
+    try:
+        return await asyncio.gather(*(run(candidate) for candidate in candidates))
+    finally:
+        pbar.close()

--- a/src/prime_rl/trainer/es/train.py
+++ b/src/prime_rl/trainer/es/train.py
@@ -1,0 +1,291 @@
+import asyncio
+import gc
+import json
+import shutil
+import time
+from datetime import timedelta
+from pathlib import Path
+
+import tomli_w
+import torch
+import torch.distributed as dist
+
+import prime_rl._compat  # noqa: F401 — patch ring_flash_attn compat before transitive import
+from prime_rl.configs.es import ESConfig
+from prime_rl.trainer.es.candidates import estimate_gradient, make_candidates, noise_like
+from prime_rl.trainer.es.ckpt import latest_es_step, load_es_state, maybe_clean_es_checkpoints, save_es_state
+from prime_rl.trainer.es.lora_materialize import build_adapter_template, write_adapter_from_theta
+from prime_rl.trainer.es.rollout import (
+    build_admin_clients,
+    build_clients,
+    close_admin_clients,
+    evaluate_candidate_chunk,
+    load_candidate_adapters,
+    sample_examples,
+    shutdown_train_envs,
+    start_train_envs,
+    unload_candidate_adapters,
+)
+from prime_rl.trainer.runs import Progress
+from prime_rl.trainer.utils import GarbageCollection, setup_torch_distributed
+from prime_rl.trainer.world import get_world
+from prime_rl.utils.config import cli
+from prime_rl.utils.heartbeat import Heartbeat
+from prime_rl.utils.logger import setup_logger
+from prime_rl.utils.monitor import setup_monitor
+from prime_rl.utils.pathing import get_config_dir
+from prime_rl.utils.process import set_proc_title
+
+
+def append_jsonl(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a", encoding="utf-8") as f:
+        json.dump(payload, f)
+        f.write("\n")
+
+
+def rank_assigned_candidates(candidates, rank: int, world_size: int):
+    return [candidate for i, candidate in enumerate(candidates) if i % world_size == rank]
+
+
+def all_reduce_float(value: float, op: dist.ReduceOp) -> float:
+    device = torch.device("cuda", torch.cuda.current_device()) if torch.cuda.is_available() else torch.device("cpu")
+    tensor = torch.tensor(value, dtype=torch.float64, device=device)
+    dist.all_reduce(tensor, op=op)
+    return float(tensor.item())
+
+
+async def train_async(config: ESConfig) -> None:
+    world = get_world()
+    logger = setup_logger(config.log.level, json_logging=config.log.json_logging)
+    logger.info(f"Starting synchronous ES trainer in {world} in {config.output_dir}")
+
+    setup_torch_distributed(
+        timeout=timedelta(seconds=config.dist_timeout_seconds),
+        enable_gloo=config.model.fsdp_cpu_offload,
+    )
+    torch.set_float32_matmul_precision(config.matmul_precision)
+
+    if world.is_master:
+        config.output_dir.mkdir(parents=True, exist_ok=True)
+        config_dir = get_config_dir(config.output_dir)
+        config_dir.mkdir(parents=True, exist_ok=True)
+        with open(config_dir / "es.toml", "wb") as f:
+            tomli_w.dump(config.model_dump(exclude_none=True, mode="json"), f)
+    dist.barrier()
+
+    monitor = setup_monitor(config.wandb, output_dir=config.output_dir, run_config=config)
+    heart = Heartbeat(config.heartbeat.url) if config.heartbeat is not None and world.is_master else None
+    gc_handler = GarbageCollection(config.gc.interval) if config.gc else None
+
+    template = None
+    theta = None
+    if world.is_master:
+        template = build_adapter_template(config.output_dir, config.model)
+        theta = template.theta
+
+        if config.ckpt and config.ckpt.resume_step is not None:
+            resume_step = (
+                latest_es_step(config.output_dir) if config.ckpt.resume_step == -1 else config.ckpt.resume_step
+            )
+            if resume_step is not None:
+                state = load_es_state(config.output_dir, resume_step)
+                theta = state["theta"].to(torch.float32)
+                progress = Progress(step=int(state["step"]))
+                logger.info(f"Resumed ES state from step {progress.step}")
+            else:
+                progress = Progress()
+        else:
+            progress = Progress()
+    else:
+        progress = Progress()
+
+    progress_box = [progress]
+    dist.broadcast_object_list(progress_box, src=0)
+    progress = progress_box[0]
+
+    envs = await start_train_envs(config)
+    clients = build_clients(config)
+    admin_clients = build_admin_clients(config) if world.is_master else []
+
+    metrics_path = config.output_dir / "metrics.jsonl"
+    adapter_root = config.output_dir / "adapters"
+    candidate_root = adapter_root / "candidates_tmp"
+    final_adapter = config.output_dir / "adapter"
+
+    try:
+        while config.max_steps is None or progress.step < config.max_steps:
+            step = progress.step + 1
+            if gc_handler is not None:
+                gc_handler.run(step)
+
+            step_start = time.perf_counter()
+            examples_by_env = {
+                env.name: sample_examples(env, config.train.examples_per_env, config.algorithm.seed + 100_000 + step)
+                for env in envs
+            }
+
+            candidates = make_candidates(
+                config.algorithm.seed,
+                step,
+                config.algorithm.population_size,
+                config.algorithm.mirrored,
+            )
+            chunk_size = min(config.algorithm.candidate_chunk_size, len(candidates))
+            all_results = []
+            adapter_write_s = 0.0
+            adapter_load_s = 0.0
+            adapter_unload_s = 0.0
+            generation_s = 0.0
+
+            for chunk_start in range(0, len(candidates), chunk_size):
+                chunk = candidates[chunk_start : chunk_start + chunk_size]
+                step_chunk_root = candidate_root / f"step_{step:06d}" / f"chunk_{chunk_start:04d}"
+                candidate_paths: dict[int, Path] = {}
+                candidate_names = {candidate.idx: f"es_step_{step}_cand_{candidate.idx}" for candidate in chunk}
+
+                if world.is_master:
+                    assert template is not None and theta is not None and config.model.lora is not None
+                    if step_chunk_root.exists():
+                        shutil.rmtree(step_chunk_root)
+                    t0 = time.perf_counter()
+                    for candidate in chunk:
+                        candidate_theta = theta + candidate.sign * config.algorithm.sigma * noise_like(
+                            theta, candidate.seed
+                        )
+                        adapter_dir = step_chunk_root / candidate.name_suffix
+                        write_adapter_from_theta(adapter_dir, template, config.model.lora, candidate_theta)
+                        candidate_paths[candidate.idx] = adapter_dir
+                    adapter_write_s += time.perf_counter() - t0
+
+                    t0 = time.perf_counter()
+                    await load_candidate_adapters(admin_clients, candidate_paths, candidate_names)
+                    adapter_load_s += time.perf_counter() - t0
+
+                names_box = [candidate_names]
+                dist.broadcast_object_list(names_box, src=0)
+                candidate_names = names_box[0]
+                dist.barrier()
+
+                local_chunk = rank_assigned_candidates(chunk, world.rank, world.world_size)
+                t0 = time.perf_counter()
+                local_results = await evaluate_candidate_chunk(
+                    local_chunk,
+                    candidate_names,
+                    envs,
+                    examples_by_env,
+                    clients,
+                    config,
+                    step=step,
+                )
+                local_generation_s = time.perf_counter() - t0
+                generation_s += all_reduce_float(local_generation_s, dist.ReduceOp.MAX)
+
+                gathered: list[list] = [None for _ in range(world.world_size)]  # type: ignore[list-item]
+                dist.all_gather_object(gathered, local_results)
+                if world.is_master:
+                    for rank_results in gathered:
+                        all_results.extend(rank_results)
+                    t0 = time.perf_counter()
+                    await unload_candidate_adapters(admin_clients, candidate_names)
+                    adapter_unload_s += time.perf_counter() - t0
+                    if not config.algorithm.keep_candidate_adapters:
+                        shutil.rmtree(step_chunk_root, ignore_errors=True)
+                dist.barrier()
+
+            update_s = 0.0
+            payload = None
+            if world.is_master:
+                assert theta is not None and template is not None and config.model.lora is not None
+                rewards = {result.candidate_idx: result.reward for result in all_results}
+                t0 = time.perf_counter()
+                grad = estimate_gradient(
+                    theta,
+                    candidates,
+                    rewards,
+                    config.algorithm.sigma,
+                    config.algorithm.reward_normalization,
+                    config.algorithm.mirrored,
+                )
+                theta = theta + config.algorithm.lr * grad
+                update_s = time.perf_counter() - t0
+
+                progress.step = step
+                progress.total_samples += sum(result.num_rollouts for result in all_results)
+                progress.total_tokens += sum(result.generated_tokens for result in all_results)
+
+                reward_values = [result.reward for result in all_results]
+                generated_tokens = sum(result.generated_tokens for result in all_results)
+                failed_rollouts = sum(result.failed_rollouts for result in all_results)
+                valid_rollouts = sum(result.num_rollouts for result in all_results)
+                step_s = time.perf_counter() - step_start
+                grad_norm = float(torch.linalg.vector_norm(grad).item())
+                step_norm = float(torch.linalg.vector_norm(config.algorithm.lr * grad).item())
+                payload = {
+                    "phase": "train",
+                    "step": step,
+                    "population_size": len(candidates),
+                    "candidate_chunk_size": chunk_size,
+                    "candidate_reward_mean": float(sum(reward_values) / len(reward_values)) if reward_values else 0.0,
+                    "candidate_reward_min": float(min(reward_values)) if reward_values else 0.0,
+                    "candidate_reward_max": float(max(reward_values)) if reward_values else 0.0,
+                    "generated_tokens": int(generated_tokens),
+                    "tokens_per_second": float(generated_tokens / generation_s) if generation_s > 0 else 0.0,
+                    "valid_rollouts": int(valid_rollouts),
+                    "failed_rollouts": int(failed_rollouts),
+                    "generation_s": generation_s,
+                    "adapter_write_s": adapter_write_s,
+                    "adapter_load_s": adapter_load_s,
+                    "adapter_unload_s": adapter_unload_s,
+                    "update_s": update_s,
+                    "iteration_wall_clock_s": step_s,
+                    "grad_norm": grad_norm,
+                    "step_norm": step_norm,
+                }
+                append_jsonl(metrics_path, payload)
+                monitor.log(payload, step=step)
+                logger.success(
+                    f"Step {step} | reward={payload['candidate_reward_mean']:.4f} "
+                    f"| tok/s={payload['tokens_per_second']:.0f} | gen={generation_s:.2f}s "
+                    f"| write={adapter_write_s:.2f}s | load={adapter_load_s:.2f}s "
+                    f"| unload={adapter_unload_s:.2f}s | update={update_s:.2f}s"
+                )
+
+                should_ckpt = config.ckpt is not None and (
+                    config.ckpt.interval is None or step % config.ckpt.interval == 0 or step == config.max_steps
+                )
+                if should_ckpt:
+                    save_es_state(config.output_dir, step, theta, template.specs, payload)
+                    write_adapter_from_theta(final_adapter, template, config.model.lora, theta)
+                    maybe_clean_es_checkpoints(config.output_dir, step, config.ckpt.keep_last)
+
+                if heart is not None:
+                    heart.beat()
+
+            progress_box = [progress]
+            dist.broadcast_object_list(progress_box, src=0)
+            progress = progress_box[0]
+            dist.barrier()
+
+    finally:
+        if admin_clients:
+            await close_admin_clients(admin_clients)
+        shutdown_train_envs(envs)
+        if world.is_master and candidate_root.exists() and not config.algorithm.keep_candidate_adapters:
+            shutil.rmtree(candidate_root, ignore_errors=True)
+        if dist.is_initialized():
+            dist.destroy_process_group()
+        gc.collect()
+
+
+def train(config: ESConfig) -> None:
+    asyncio.run(train_async(config))
+
+
+def main():
+    set_proc_title("ES Trainer")
+    train(cli(ESConfig))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/prime_rl/trainer/es/train.py
+++ b/src/prime_rl/trainer/es/train.py
@@ -3,6 +3,7 @@ import gc
 import json
 import shutil
 import time
+from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import timedelta
 from pathlib import Path
 
@@ -20,11 +21,14 @@ from prime_rl.trainer.es.rollout import (
     build_clients,
     close_admin_clients,
     evaluate_candidate_chunk,
+    init_lora_slots,
     load_candidate_adapters,
+    materialize_lora_slots,
     sample_examples,
     shutdown_train_envs,
     start_train_envs,
     unload_candidate_adapters,
+    update_lora_slot_theta,
 )
 from prime_rl.trainer.runs import Progress
 from prime_rl.trainer.utils import GarbageCollection, setup_torch_distributed
@@ -55,6 +59,73 @@ def all_reduce_float(value: float, op: dist.ReduceOp) -> float:
     return float(tensor.item())
 
 
+def es_compute_device() -> torch.device:
+    if torch.cuda.is_available():
+        return torch.device("cuda", torch.cuda.current_device())
+    return torch.device("cpu")
+
+
+def write_candidate_adapters(
+    chunk,
+    step_chunk_root: Path,
+    template,
+    theta: torch.Tensor,
+    sigma: float,
+    max_workers: int,
+) -> dict[int, Path]:
+    candidate_paths: dict[int, Path] = {}
+    pending: list[Future[None]] = []
+    worker_count = max(1, min(max_workers, len(chunk)))
+
+    with ThreadPoolExecutor(max_workers=worker_count) as executor:
+        for candidate in chunk:
+            candidate_theta = theta + candidate.sign * sigma * noise_like(theta, candidate.seed)
+            adapter_dir = step_chunk_root / candidate.name_suffix
+            candidate_paths[candidate.idx] = adapter_dir
+            pending.append(executor.submit(write_adapter_from_theta, adapter_dir, template, candidate_theta))
+            if len(pending) >= worker_count:
+                pending.pop(0).result()
+        for future in pending:
+            future.result()
+
+    return candidate_paths
+
+
+def serialize_specs(template) -> list[dict]:
+    return [
+        {
+            "name": spec.name,
+            "shape": list(spec.shape),
+            "dtype": str(spec.dtype),
+            "numel": spec.numel,
+        }
+        for spec in template.specs
+    ]
+
+
+def slot_definitions(chunk_size: int) -> list[dict]:
+    return [{"lora_name": f"es_slot_{idx}", "lora_int_id": 10_000 + idx, "slot": idx} for idx in range(chunk_size)]
+
+
+def slot_payload_for_chunk(chunk, slots: list[dict]) -> list[dict]:
+    payload = []
+    for slot, candidate in zip(slots, chunk, strict=True):
+        payload.append(
+            {
+                "lora_name": slot["lora_name"],
+                "lora_int_id": slot["lora_int_id"],
+                "candidate_idx": candidate.idx,
+                "seed": candidate.seed,
+                "sign": candidate.sign,
+            }
+        )
+    return payload
+
+
+def candidate_payload(candidates) -> list[dict]:
+    return [{"idx": candidate.idx, "seed": candidate.seed, "sign": candidate.sign} for candidate in candidates]
+
+
 async def train_async(config: ESConfig) -> None:
     world = get_world()
     logger = setup_logger(config.log.level, json_logging=config.log.json_logging)
@@ -81,7 +152,8 @@ async def train_async(config: ESConfig) -> None:
     template = None
     theta = None
     if world.is_master:
-        template = build_adapter_template(config.output_dir, config.model)
+        device = es_compute_device()
+        template = build_adapter_template(config.output_dir, config.model, device=device)
         theta = template.theta
 
         if config.ckpt and config.ckpt.resume_step is not None:
@@ -90,7 +162,7 @@ async def train_async(config: ESConfig) -> None:
             )
             if resume_step is not None:
                 state = load_es_state(config.output_dir, resume_step)
-                theta = state["theta"].to(torch.float32)
+                theta = state["theta"].to(device=device, dtype=torch.float32)
                 progress = Progress(step=int(state["step"]))
                 logger.info(f"Resumed ES state from step {progress.step}")
             else:
@@ -112,6 +184,17 @@ async def train_async(config: ESConfig) -> None:
     adapter_root = config.output_dir / "adapters"
     candidate_root = adapter_root / "candidates_tmp"
     final_adapter = config.output_dir / "adapter"
+    use_lora_slots = config.algorithm.adapter_transport == "slots"
+    slots: list[dict] = []
+    if world.is_master and use_lora_slots:
+        assert template is not None and theta is not None
+        slots = slot_definitions(config.algorithm.candidate_chunk_size)
+        theta_init_path = config.output_dir / "es_lora_theta_init.pt"
+        torch.save({"theta": theta.detach().cpu()}, theta_init_path)
+        t0 = time.perf_counter()
+        await init_lora_slots(admin_clients, theta_init_path, serialize_specs(template), template.adapter_config, slots)
+        logger.info(f"Initialized {len(slots)} persistent ES LoRA slots in {time.perf_counter() - t0:.2f}s")
+        theta_init_path.unlink(missing_ok=True)
 
     try:
         while config.max_steps is None or progress.step < config.max_steps:
@@ -136,31 +219,49 @@ async def train_async(config: ESConfig) -> None:
             adapter_write_s = 0.0
             adapter_load_s = 0.0
             adapter_unload_s = 0.0
+            adapter_slot_update_s = 0.0
             generation_s = 0.0
 
             for chunk_start in range(0, len(candidates), chunk_size):
                 chunk = candidates[chunk_start : chunk_start + chunk_size]
                 step_chunk_root = candidate_root / f"step_{step:06d}" / f"chunk_{chunk_start:04d}"
                 candidate_paths: dict[int, Path] = {}
-                candidate_names = {candidate.idx: f"es_step_{step}_cand_{candidate.idx}" for candidate in chunk}
+                if use_lora_slots:
+                    chunk_slots = slots[: len(chunk)] if world.is_master else []
+                    candidate_names = {
+                        candidate.idx: chunk_slots[i]["lora_name"] if world.is_master else ""
+                        for i, candidate in enumerate(chunk)
+                    }
+                else:
+                    candidate_names = {candidate.idx: f"es_step_{step}_cand_{candidate.idx}" for candidate in chunk}
 
                 if world.is_master:
                     assert template is not None and theta is not None and config.model.lora is not None
-                    if step_chunk_root.exists():
-                        shutil.rmtree(step_chunk_root)
-                    t0 = time.perf_counter()
-                    for candidate in chunk:
-                        candidate_theta = theta + candidate.sign * config.algorithm.sigma * noise_like(
-                            theta, candidate.seed
+                    if use_lora_slots:
+                        t0 = time.perf_counter()
+                        await materialize_lora_slots(
+                            admin_clients,
+                            slot_payload_for_chunk(chunk, slots[: len(chunk)]),
+                            config.algorithm.sigma,
                         )
-                        adapter_dir = step_chunk_root / candidate.name_suffix
-                        write_adapter_from_theta(adapter_dir, template, config.model.lora, candidate_theta)
-                        candidate_paths[candidate.idx] = adapter_dir
-                    adapter_write_s += time.perf_counter() - t0
+                        adapter_slot_update_s += time.perf_counter() - t0
+                    else:
+                        if step_chunk_root.exists():
+                            shutil.rmtree(step_chunk_root)
+                        t0 = time.perf_counter()
+                        candidate_paths = write_candidate_adapters(
+                            chunk,
+                            step_chunk_root,
+                            template,
+                            theta,
+                            config.algorithm.sigma,
+                            config.algorithm.adapter_write_workers,
+                        )
+                        adapter_write_s += time.perf_counter() - t0
 
-                    t0 = time.perf_counter()
-                    await load_candidate_adapters(admin_clients, candidate_paths, candidate_names)
-                    adapter_load_s += time.perf_counter() - t0
+                        t0 = time.perf_counter()
+                        await load_candidate_adapters(admin_clients, candidate_paths, candidate_names)
+                        adapter_load_s += time.perf_counter() - t0
 
                 names_box = [candidate_names]
                 dist.broadcast_object_list(names_box, src=0)
@@ -186,11 +287,12 @@ async def train_async(config: ESConfig) -> None:
                 if world.is_master:
                     for rank_results in gathered:
                         all_results.extend(rank_results)
-                    t0 = time.perf_counter()
-                    await unload_candidate_adapters(admin_clients, candidate_names)
-                    adapter_unload_s += time.perf_counter() - t0
-                    if not config.algorithm.keep_candidate_adapters:
-                        shutil.rmtree(step_chunk_root, ignore_errors=True)
+                    if not use_lora_slots:
+                        t0 = time.perf_counter()
+                        await unload_candidate_adapters(admin_clients, candidate_names)
+                        adapter_unload_s += time.perf_counter() - t0
+                        if not config.algorithm.keep_candidate_adapters:
+                            shutil.rmtree(step_chunk_root, ignore_errors=True)
                 dist.barrier()
 
             update_s = 0.0
@@ -208,7 +310,22 @@ async def train_async(config: ESConfig) -> None:
                     config.algorithm.mirrored,
                 )
                 theta = theta + config.algorithm.lr * grad
+                if theta.device.type == "cuda":
+                    torch.cuda.synchronize(theta.device)
                 update_s = time.perf_counter() - t0
+                if use_lora_slots:
+                    ordered_rewards = [rewards[candidate.idx] for candidate in candidates]
+                    t0 = time.perf_counter()
+                    await update_lora_slot_theta(
+                        admin_clients,
+                        candidate_payload(candidates),
+                        ordered_rewards,
+                        config.algorithm.lr,
+                        config.algorithm.reward_normalization,
+                        config.algorithm.mirrored,
+                        config.algorithm.sigma,
+                    )
+                    adapter_slot_update_s += time.perf_counter() - t0
 
                 progress.step = step
                 progress.total_samples += sum(result.num_rollouts for result in all_results)
@@ -235,9 +352,12 @@ async def train_async(config: ESConfig) -> None:
                     "failed_rollouts": int(failed_rollouts),
                     "generation_s": generation_s,
                     "adapter_write_s": adapter_write_s,
+                    "adapter_write_workers": config.algorithm.adapter_write_workers,
                     "adapter_load_s": adapter_load_s,
                     "adapter_unload_s": adapter_unload_s,
+                    "adapter_slot_update_s": adapter_slot_update_s,
                     "update_s": update_s,
+                    "adapter_transport": config.algorithm.adapter_transport,
                     "iteration_wall_clock_s": step_s,
                     "grad_norm": grad_norm,
                     "step_norm": step_norm,
@@ -248,7 +368,8 @@ async def train_async(config: ESConfig) -> None:
                     f"Step {step} | reward={payload['candidate_reward_mean']:.4f} "
                     f"| tok/s={payload['tokens_per_second']:.0f} | gen={generation_s:.2f}s "
                     f"| write={adapter_write_s:.2f}s | load={adapter_load_s:.2f}s "
-                    f"| unload={adapter_unload_s:.2f}s | update={update_s:.2f}s"
+                    f"| unload={adapter_unload_s:.2f}s | slot={adapter_slot_update_s:.2f}s "
+                    f"| update={update_s:.2f}s"
                 )
 
                 should_ckpt = config.ckpt is not None and (
@@ -256,7 +377,7 @@ async def train_async(config: ESConfig) -> None:
                 )
                 if should_ckpt:
                     save_es_state(config.output_dir, step, theta, template.specs, payload)
-                    write_adapter_from_theta(final_adapter, template, config.model.lora, theta)
+                    write_adapter_from_theta(final_adapter, template, theta)
                     maybe_clean_es_checkpoints(config.output_dir, step, config.ckpt.keep_last)
 
                 if heart is not None:

--- a/src/prime_rl/trainer/es/train.py
+++ b/src/prime_rl/trainer/es/train.py
@@ -13,6 +13,8 @@ import torch.distributed as dist
 
 import prime_rl._compat  # noqa: F401 — patch ring_flash_attn compat before transitive import
 from prime_rl.configs.es import ESConfig
+from prime_rl.orchestrator.envs import EvalEnv, EvalEnvs
+from prime_rl.orchestrator.vf_utils import get_model_completion_len
 from prime_rl.trainer.es.candidates import estimate_gradient, make_candidates, noise_like
 from prime_rl.trainer.es.ckpt import latest_es_step, load_es_state, maybe_clean_es_checkpoints, save_es_state
 from prime_rl.trainer.es.lora_materialize import build_adapter_template, write_adapter_from_theta
@@ -126,6 +128,114 @@ def candidate_payload(candidates) -> list[dict]:
     return [{"idx": candidate.idx, "seed": candidate.seed, "sign": candidate.sign} for candidate in candidates]
 
 
+def eval_slot_payload(slot: dict) -> list[dict]:
+    return [
+        {
+            "lora_name": slot["lora_name"],
+            "lora_int_id": slot["lora_int_id"],
+            "candidate_idx": -1,
+            "seed": 0,
+            "sign": 1,
+        }
+    ]
+
+
+def make_client_getter(clients):
+    cursor = 0
+
+    async def get_client():
+        nonlocal cursor
+        client = clients[cursor % len(clients)]
+        cursor += 1
+        return client
+
+    return get_client
+
+
+def eval_metric_payload(outputs, env: EvalEnv, step: int, eval_s: float, baseline: bool, model_name: str) -> dict:
+    total_rollouts = len(env.examples) * env.config.rollouts_per_example
+    failed_rollouts = max(0, total_rollouts - len(outputs))
+    rewards = [float(output.get("reward") or 0.0) for output in outputs]
+    completion_lens = [get_model_completion_len(output) for output in outputs]
+    generated_tokens = sum(completion_lens)
+    return {
+        "phase": "eval",
+        "step": step,
+        "env": env.name,
+        "baseline": baseline,
+        "model_name": model_name,
+        "num_examples": len(env.examples),
+        "rollouts_per_example": env.config.rollouts_per_example,
+        "valid_rollouts": len(outputs),
+        "failed_rollouts": failed_rollouts,
+        "reward_mean": float(sum(rewards) / len(rewards)) if rewards else 0.0,
+        "reward_min": float(min(rewards)) if rewards else 0.0,
+        "reward_max": float(max(rewards)) if rewards else 0.0,
+        "generated_tokens": int(generated_tokens),
+        "tokens_per_second": float(generated_tokens / eval_s) if eval_s > 0 else 0.0,
+        "eval_s": eval_s,
+    }
+
+
+async def evaluate_mean_policy(
+    *,
+    eval_envs,
+    clients,
+    admin_clients,
+    metrics_path: Path,
+    monitor,
+    logger,
+    config: ESConfig,
+    template,
+    theta: torch.Tensor,
+    use_lora_slots: bool,
+    slots: list[dict],
+    step: int,
+    baseline: bool,
+) -> None:
+    eval_adapter_name = "es_eval_mean"
+    eval_adapter_dir = config.output_dir / "adapters" / "eval_mean"
+    eval_adapter_s = 0.0
+
+    if use_lora_slots:
+        eval_adapter_name = slots[0]["lora_name"]
+        t0 = time.perf_counter()
+        await materialize_lora_slots(admin_clients, eval_slot_payload(slots[0]), 0.0)
+        eval_adapter_s = time.perf_counter() - t0
+    else:
+        if eval_adapter_dir.exists():
+            shutil.rmtree(eval_adapter_dir)
+        t0 = time.perf_counter()
+        write_adapter_from_theta(eval_adapter_dir, template, theta)
+        await load_candidate_adapters(admin_clients, {-1: eval_adapter_dir}, {-1: eval_adapter_name})
+        eval_adapter_s = time.perf_counter() - t0
+
+    try:
+        for env in eval_envs:
+            t0 = time.perf_counter()
+            outputs = await env.evaluate(
+                model_name=eval_adapter_name,
+                get_client=make_client_getter(clients),
+                ckpt_step=step,
+                step=step,
+                cache_salt=f"es-eval-{step}-{env.name}",
+            )
+            eval_s = time.perf_counter() - t0
+            payload = eval_metric_payload(outputs, env, step, eval_s, baseline, eval_adapter_name)
+            payload["eval_adapter_s"] = eval_adapter_s
+            append_jsonl(metrics_path, payload)
+            monitor.log(payload, step=step)
+            logger.success(
+                f"Eval step {step} | {env.name} | reward={payload['reward_mean']:.4f} "
+                f"| tok/s={payload['tokens_per_second']:.0f} | eval={eval_s:.2f}s "
+                f"| adapter={eval_adapter_s:.2f}s"
+            )
+    finally:
+        if not use_lora_slots:
+            await unload_candidate_adapters(admin_clients, {-1: eval_adapter_name})
+            shutil.rmtree(eval_adapter_dir, ignore_errors=True)
+
+
 async def train_async(config: ESConfig) -> None:
     world = get_world()
     logger = setup_logger(config.log.level, json_logging=config.log.json_logging)
@@ -177,6 +287,13 @@ async def train_async(config: ESConfig) -> None:
     progress = progress_box[0]
 
     envs = await start_train_envs(config)
+    eval_envs = EvalEnvs(config.eval.env) if config.eval is not None else None
+    if eval_envs is not None:
+        await eval_envs.start(
+            log_dir=config.output_dir / "logs" / "eval_envs",
+            log_level=config.log.level,
+            json_logging=config.log.json_logging,
+        )
     clients = build_clients(config)
     admin_clients = build_admin_clients(config) if world.is_master else []
 
@@ -197,6 +314,31 @@ async def train_async(config: ESConfig) -> None:
         theta_init_path.unlink(missing_ok=True)
 
     try:
+        if (
+            world.is_master
+            and eval_envs is not None
+            and config.eval is not None
+            and config.eval.eval_base_model
+            and progress.step == 0
+        ):
+            assert template is not None and theta is not None
+            await evaluate_mean_policy(
+                eval_envs=eval_envs,
+                clients=clients,
+                admin_clients=admin_clients,
+                metrics_path=metrics_path,
+                monitor=monitor,
+                logger=logger,
+                config=config,
+                template=template,
+                theta=theta,
+                use_lora_slots=use_lora_slots,
+                slots=slots,
+                step=0,
+                baseline=True,
+            )
+        dist.barrier()
+
         while config.max_steps is None or progress.step < config.max_steps:
             step = progress.step + 1
             if gc_handler is not None:
@@ -372,6 +514,25 @@ async def train_async(config: ESConfig) -> None:
                     f"| update={update_s:.2f}s"
                 )
 
+                if eval_envs is not None:
+                    eval_due = [env for env in eval_envs if step % env.config.interval == 0]
+                    if eval_due:
+                        await evaluate_mean_policy(
+                            eval_envs=eval_due,
+                            clients=clients,
+                            admin_clients=admin_clients,
+                            metrics_path=metrics_path,
+                            monitor=monitor,
+                            logger=logger,
+                            config=config,
+                            template=template,
+                            theta=theta,
+                            use_lora_slots=use_lora_slots,
+                            slots=slots,
+                            step=step,
+                            baseline=False,
+                        )
+
                 should_ckpt = config.ckpt is not None and (
                     config.ckpt.interval is None or step % config.ckpt.interval == 0 or step == config.max_steps
                 )
@@ -392,6 +553,8 @@ async def train_async(config: ESConfig) -> None:
         if admin_clients:
             await close_admin_clients(admin_clients)
         shutdown_train_envs(envs)
+        if eval_envs is not None:
+            eval_envs.shutdown()
         if world.is_master and candidate_root.exists() and not config.algorithm.keep_candidate_adapters:
             shutil.rmtree(candidate_root, ignore_errors=True)
         if dist.is_initialized():

--- a/tests/unit/orchestrator/test_vf_utils.py
+++ b/tests/unit/orchestrator/test_vf_utils.py
@@ -1,0 +1,24 @@
+from prime_rl.orchestrator.vf_utils import get_model_completion_len
+
+
+def test_get_model_completion_len_uses_final_output_tokens():
+    output = {
+        "trajectory": [{"tokens": None}],
+        "token_usage": {
+            "output_tokens": 11,
+            "final_output_tokens": 7,
+        },
+    }
+
+    assert get_model_completion_len(output) == 7
+
+
+def test_get_model_completion_len_falls_back_to_trajectory_tokens():
+    output = {
+        "trajectory": [
+            {"tokens": {"completion_ids": [1, 2, 3]}},
+            {"tokens": {"completion_ids": [4, 5]}},
+        ],
+    }
+
+    assert get_model_completion_len(output) == 5

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -6,6 +6,7 @@ import tomli_w
 from pydantic import BaseModel, Field, ValidationError
 from pydantic_config import ConfigFileError
 
+from prime_rl.configs.es import ESConfig
 from prime_rl.configs.inference import InferenceConfig
 from prime_rl.configs.orchestrator import OrchestratorConfig
 from prime_rl.configs.rl import RLConfig
@@ -19,6 +20,7 @@ CONFIG_CLASSES = [
     RLConfig,
     TrainerConfig,
     SFTConfig,
+    ESConfig,
     OrchestratorConfig,
     InferenceConfig,
 ]

--- a/tests/unit/train/es/test_candidates.py
+++ b/tests/unit/train/es/test_candidates.py
@@ -12,7 +12,7 @@ def test_one_sided_gradient_without_reward_normalization():
 
     grad = estimate_gradient(theta, candidates, rewards, sigma=0.1, normalization="none", mirrored=False)
 
-    expected = ((2.0 / 0.1) * noise_like(theta, 11) - (1.0 / 0.1) * noise_like(theta, 13)) / 2.0
+    expected = (2.0 * noise_like(theta, 11) - 1.0 * noise_like(theta, 13)) / 2.0
     assert torch.allclose(grad, expected)
 
 

--- a/tests/unit/train/es/test_candidates.py
+++ b/tests/unit/train/es/test_candidates.py
@@ -1,0 +1,51 @@
+import pytest
+import torch
+
+from prime_rl.configs.es import ESAlgorithmConfig
+from prime_rl.trainer.es.candidates import Candidate, estimate_gradient, make_candidates, noise_like, normalize_rewards
+
+
+def test_one_sided_gradient_without_reward_normalization():
+    theta = torch.zeros(8)
+    candidates = [Candidate(idx=0, seed=11), Candidate(idx=1, seed=13)]
+    rewards = {0: 2.0, 1: -1.0}
+
+    grad = estimate_gradient(theta, candidates, rewards, sigma=0.1, normalization="none", mirrored=False)
+
+    expected = ((2.0 / 0.1) * noise_like(theta, 11) - (1.0 / 0.1) * noise_like(theta, 13)) / 2.0
+    assert torch.allclose(grad, expected)
+
+
+def test_equal_rewards_zscore_to_zero_update():
+    theta = torch.zeros(8)
+    candidates = [Candidate(idx=0, seed=11), Candidate(idx=1, seed=13)]
+    rewards = {0: 1.0, 1: 1.0}
+
+    grad = estimate_gradient(theta, candidates, rewards, sigma=0.1, normalization="zscore", mirrored=False)
+
+    assert torch.count_nonzero(grad) == 0
+
+
+def test_mirrored_gradient_uses_pairwise_reward_difference():
+    theta = torch.zeros(8)
+    candidates = make_candidates(base_seed=7, step=3, population_size=4, mirrored=True)
+    rewards = {candidate.idx: 3.0 if candidate.sign > 0 else 1.0 for candidate in candidates}
+
+    grad = estimate_gradient(theta, candidates, rewards, sigma=0.5, normalization="zscore", mirrored=True)
+
+    expected = torch.zeros_like(theta)
+    for candidate in candidates:
+        if candidate.sign > 0:
+            expected += noise_like(theta, candidate.seed) * ((3.0 - 1.0) / (2.0 * 0.5))
+    expected /= 2.0
+    assert torch.allclose(grad, expected)
+
+
+def test_normalize_rewards_rejects_unknown_mode():
+    with pytest.raises(ValueError, match="Unsupported reward normalization"):
+        normalize_rewards([1.0, 2.0], "rank")
+
+
+def test_mirrored_population_requires_even_size():
+    with pytest.raises(ValueError, match="population_size must be even"):
+        ESAlgorithmConfig(population_size=3, mirrored=True)

--- a/tests/unit/train/es/test_rollout.py
+++ b/tests/unit/train/es/test_rollout.py
@@ -1,0 +1,23 @@
+from datasets import Dataset
+
+from prime_rl.configs.orchestrator import TrainSamplingConfig
+from prime_rl.trainer.es.rollout import sample_examples
+
+
+class DummyEnv:
+    def get_dataset(self, seed: int):
+        return Dataset.from_list([{"idx": 0}, {"idx": 1}])
+
+
+def test_sample_examples_uses_replacement_when_count_exceeds_dataset():
+    rows = sample_examples(DummyEnv(), count=8, seed=123)
+
+    assert len(rows) == 8
+    assert {row["idx"] for row in rows}.issubset({0, 1})
+
+
+def test_train_sampling_config_can_disable_logprobs():
+    args = TrainSamplingConfig(logprobs=False, max_completion_tokens=64).to_sampling_args()
+
+    assert args["logprobs"] is False
+    assert args["max_completion_tokens"] == 64


### PR DESCRIPTION
## Summary

Adds a synchronous ES-LoRA trainer as a peer trainer path under `prime_rl.trainer.es`, plus an `es` launcher/config surface.

The trainer:
- materializes LoRA candidate adapters from a flat ES parameter vector
- loads candidate adapters into existing vLLM inference pools via Prime-RL admin endpoints
- evaluates candidates synchronously across configured Verifiers train envs
- updates the mean LoRA vector with one-sided or mirrored ES estimates
- writes ES state checkpoints, the current mean adapter, metrics, and a debug config

This intentionally reuses the pieces ES needs from Prime-RL: config parsing, launch/process handling, torch distributed rank setup, env wrappers, client/admin clients, LoRA adapter serialization, logging, checkpoints, and monitors. It does not pull in SFT CE loss, optimizer, FSDP training, gradient scaling, or RL orchestrator async weight-update machinery.

## Validation

Local macOS:
- `uv tool run ruff check packages/prime-rl-configs/src/prime_rl/configs/es.py src/prime_rl/entrypoints/es.py src/prime_rl/trainer/es tests/unit/train/es/test_candidates.py tests/unit/test_configs.py`
- `uv tool run ruff format --check packages/prime-rl-configs/src/prime_rl/configs/es.py src/prime_rl/entrypoints/es.py src/prime_rl/trainer/es tests/unit/train/es/test_candidates.py tests/unit/test_configs.py`
- `git diff --check`

Prime Intellect A6000 smoke box:
- `uv run ruff check packages/prime-rl-configs/src/prime_rl/configs/es.py src/prime_rl/entrypoints/es.py src/prime_rl/trainer/es tests/unit/train/es/test_candidates.py tests/unit/test_configs.py`
- `uv run ruff format --check packages/prime-rl-configs/src/prime_rl/configs/es.py src/prime_rl/entrypoints/es.py src/prime_rl/trainer/es tests/unit/train/es/test_candidates.py tests/unit/test_configs.py`
- `uv run pytest tests/unit/train/es/test_candidates.py tests/unit/test_configs.py -q` (`79 passed`)
- `uv run es @ configs/debug/es/train.toml --dry-run`
- one-step live smoke with temporary Verifiers env + vLLM `PrimeIntellect/Qwen3-0.6B` + dynamic LoRA loading:
  - wrote `/home/ubuntu/es-smoke-output/adapter/adapter_model.safetensors`
  - wrote `/home/ubuntu/es-smoke-output/checkpoints/step_1/es/es_state.pt`
  - metrics showed `generation_s=39.07`, `adapter_write_s=0.22`, `adapter_load_s=0.19`, `adapter_unload_s=0.01`, `update_s=0.08`
