### PR TITLE
fix(inference): make liveness timeout configurable with a 30s default

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -16,6 +16,16 @@ class ServerConfig(BaseConfig):
 
     host: Annotated[str | None, Field(description="The host to bind to.")] = None
     port: Annotated[int, Field(description="The port to bind to.")] = 8000
+    liveness_timeout_seconds: Annotated[
+        float,
+        Field(
+            gt=0,
+            description=(
+                "Timeout in seconds for the /liveness endpoint's internal vLLM worker RPC. "
+                "If Kubernetes liveness probes are enabled, keep the probe timeoutSeconds at least this high."
+            ),
+        ),
+    ] = 30.0
 
 
 class ParallelConfig(BaseConfig):
@@ -499,6 +509,7 @@ class InferenceConfig(BaseConfig):
         to_vllm = {
             "server.host": "host",
             "server.port": "port",
+            "server.liveness_timeout_seconds": "liveness_timeout_seconds",
             "model.name": "model",
             "model.dtype": "dtype",
             "model.max_model_len": "max_model_len",

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -160,7 +160,6 @@ logger = init_logger("vllm.entrypoints.openai.api_server")
 
 # Create our own router for custom endpoints
 router = APIRouter()
-DEFAULT_LIVENESS_TIMEOUT_SECONDS = 30.0
 
 
 def engine_client(request: Request) -> EngineClient:
@@ -269,11 +268,10 @@ async def load_lora_adapter(lora_request: LoadLoRAAdapterRequest, raw_request: R
 @router.get("/liveness")
 async def liveness(raw_request: Request):
     """Check that the engine event loop can service a no-op worker RPC."""
-    timeout = getattr(raw_request.app.state, "liveness_timeout_seconds", DEFAULT_LIVENESS_TIMEOUT_SECONDS)
     try:
         await asyncio.wait_for(
             engine_client(raw_request).collective_rpc("liveness_probe"),
-            timeout=timeout,
+            timeout=raw_request.app.state.liveness_timeout_seconds,
         )
     except asyncio.TimeoutError:
         return JSONResponse({"status": "engine_unresponsive"}, status_code=503)
@@ -313,7 +311,7 @@ async def custom_init_app_state(
     await init_app_state(engine_client, state, args, supported_tasks)
 
     state.reset_prefix_cache_after_update = getattr(args, "reset_prefix_cache_after_update", True)
-    state.liveness_timeout_seconds = getattr(args, "liveness_timeout_seconds", DEFAULT_LIVENESS_TIMEOUT_SECONDS)
+    state.liveness_timeout_seconds = args.liveness_timeout_seconds
 
     # TITO: server-side chat templating + token IDs.
     if "generate" in supported_tasks and state.openai_serving_chat is not None:

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -160,7 +160,7 @@ logger = init_logger("vllm.entrypoints.openai.api_server")
 
 # Create our own router for custom endpoints
 router = APIRouter()
-LIVENESS_TIMEOUT_SECONDS = 5.0
+DEFAULT_LIVENESS_TIMEOUT_SECONDS = 30.0
 
 
 def engine_client(request: Request) -> EngineClient:
@@ -269,10 +269,11 @@ async def load_lora_adapter(lora_request: LoadLoRAAdapterRequest, raw_request: R
 @router.get("/liveness")
 async def liveness(raw_request: Request):
     """Check that the engine event loop can service a no-op worker RPC."""
+    timeout = getattr(raw_request.app.state, "liveness_timeout_seconds", DEFAULT_LIVENESS_TIMEOUT_SECONDS)
     try:
         await asyncio.wait_for(
             engine_client(raw_request).collective_rpc("liveness_probe"),
-            timeout=LIVENESS_TIMEOUT_SECONDS,
+            timeout=timeout,
         )
     except asyncio.TimeoutError:
         return JSONResponse({"status": "engine_unresponsive"}, status_code=503)
@@ -312,6 +313,7 @@ async def custom_init_app_state(
     await init_app_state(engine_client, state, args, supported_tasks)
 
     state.reset_prefix_cache_after_update = getattr(args, "reset_prefix_cache_after_update", True)
+    state.liveness_timeout_seconds = getattr(args, "liveness_timeout_seconds", DEFAULT_LIVENESS_TIMEOUT_SECONDS)
 
     # TITO: server-side chat templating + token IDs.
     if "generate" in supported_tasks and state.openai_serving_chat is not None:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small, localized change affecting only the `/liveness` health-check timeout behavior and its config-to-vLLM wiring.
> 
> **Overview**
> **Makes `/liveness` timeout configurable.** Adds `server.liveness_timeout_seconds` (default `30.0`, `gt=0`) to `InferenceConfig` and passes it through `to_vllm`.
> 
> Updates the vLLM server wrapper to store `args.liveness_timeout_seconds` in app state and uses it in the `/liveness` endpoint instead of a hardcoded `5s` timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66cbe47b476eb4424656cc22e5dcbc19f48f8d3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->