### PR TITLE
pin images to cudnn cu128. this shold break ci because of the vllm de…

### DIFF
--- a/.github/workflows/gpu_tests.yaml
+++ b/.github/workflows/gpu_tests.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Unit tests
     runs-on: vm
     container:
-      image: pytorch/pytorch:2.10.0-cuda13.0-cudnn9-devel
+      image: nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04
       options: --gpus all
     timeout-minutes: 45
     if: github.event_name == 'push' || github.event.pull_request.draft == false
@@ -55,7 +55,7 @@ jobs:
     name: Integration tests (${{ matrix.test }})
     runs-on: ${{ matrix.runner }}
     container:
-      image: pytorch/pytorch:2.10.0-cuda13.0-cudnn9-devel
+      image: nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04
       options: --gpus all
     timeout-minutes: 60
     if: github.event_name == 'push' || github.event.pull_request.draft == false

--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -56,7 +56,7 @@ jobs:
         needs: discover-experiments
         runs-on: research-cluster
         container:
-            image: pytorch/pytorch:2.10.0-cuda13.0-cudnn9-devel
+            image: nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04
             # --shm-size: vLLM V1's DP engine/API-server IPC uses POSIX shm-backed
             # MessageQueue (~160MB per queue); Docker's default 64MB /dev/shm triggers
             # SIGBUS in DP engine cores on VLM runs (mm data overflows tmpfs).


### PR DESCRIPTION
…fault being cu13

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the container runtime for GPU unit/integration and nightly workflows, which can break CI due to different preinstalled libraries (e.g., PyTorch) and CUDA/cuDNN compatibility.
> 
> **Overview**
> Updates the GPU CI environment by replacing the `pytorch/pytorch:2.10.0-cuda13.0-cudnn9-devel` container with `nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04` for GPU unit tests, GPU integration tests, and nightly experiments.
> 
> This effectively pins workflows to *CUDA 12.8 + cuDNN* and removes reliance on the PyTorch-provided image, changing what system/ML dependencies are present at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 987f9f064874809707c756143a0a467d242c418c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->