### PR TITLE
drop ampere in fa4

### DIFF
--- a/scripts/docker-arm64-post-install.sh
+++ b/scripts/docker-arm64-post-install.sh
@@ -15,9 +15,3 @@ export FLASH_ATTENTION_SKIP_CUDA_BUILD=FALSE
 echo "=== reinstalling flash-attn-cute (flash-attn overwrites it with a stub) ==="
 uv pip install --reinstall --no-deps \
     "flash-attn-4 @ git+https://github.com/Dao-AILab/flash-attention.git@96bd151#subdirectory=flash_attn/cute"
-
-# TODO: remove once flash-attn gates the ampere_helpers import or cutlass-dsl re-adds it.
-echo "=== copying ampere_helpers.py from flashinfer vendor ==="
-SITE_PACKAGES=".venv/lib/python3.12/site-packages"
-cp "$SITE_PACKAGES/flashinfer/data/cutlass/python/CuTeDSL/cutlass/utils/ampere_helpers.py" \
-   "$SITE_PACKAGES/nvidia_cutlass_dsl/python_packages/cutlass/utils/ampere_helpers.py"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches Docker build post-install logic for `flash-attn` on arm64; risk is limited but could break image builds if the removed `ampere_helpers.py` patch is still required in some environments.
> 
> **Overview**
> Removes the temporary post-install step in `scripts/docker-arm64-post-install.sh` that copied `ampere_helpers.py` into `nvidia_cutlass_dsl` from `flashinfer`.
> 
> The script now only builds `flash-attn` from source with the required CUDA build env vars and reinstalls `flash-attn-cute` afterward.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0daa3e818c80ac9f89c89c43f19a0a5b63db7e7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->