### PR TITLE
[Weight Transfer]: Support quantize_in_weight_transfer + EPLB

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -682,6 +682,24 @@ class RLConfig(BaseConfig):
         return self
 
     @model_validator(mode="after")
+    def validate_eplb_requires_quantized_weight_transfer(self):
+        if self.inference is None or not self.inference.enable_eplb:
+            return self
+
+        # TODO(matej): check if weight reloading works itself before supporting EPLB without quantized transfer.
+        trainer_weight_broadcast = self.trainer.weight_broadcast
+        if (
+            trainer_weight_broadcast.type != "nccl"
+            or not trainer_weight_broadcast.quantize_in_weight_transfer
+        ):
+            raise ValueError(
+                "inference.enable_eplb requires weight_broadcast.type = 'nccl' and "
+                "weight_broadcast.quantize_in_weight_transfer = true."
+            )
+
+        return self
+
+    @model_validator(mode="after")
     def auto_setup_bench(self):
         if self.bench:
             self.trainer.bench = BenchConfig()

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -688,10 +688,7 @@ class RLConfig(BaseConfig):
 
         # TODO(matej): check if weight reloading works itself before supporting EPLB without quantized transfer.
         trainer_weight_broadcast = self.trainer.weight_broadcast
-        if (
-            trainer_weight_broadcast.type != "nccl"
-            or not trainer_weight_broadcast.quantize_in_weight_transfer
-        ):
+        if trainer_weight_broadcast.type != "nccl" or not trainer_weight_broadcast.quantize_in_weight_transfer:
             raise ValueError(
                 "inference.enable_eplb requires weight_broadcast.type = 'nccl' and "
                 "weight_broadcast.quantize_in_weight_transfer = true."

--- a/src/prime_rl/inference/vllm/worker/weight_transfer.py
+++ b/src/prime_rl/inference/vllm/worker/weight_transfer.py
@@ -16,9 +16,7 @@ def postprocess_weights_checkpoint(model: Module, model_config, device: torch.de
     process_weights_after_loading(model, model_config, device)
 
 
-def _invert_logical_to_physical_map(
-    logical_to_physical_map: torch.Tensor, num_physical_experts: int
-) -> torch.Tensor:
+def _invert_logical_to_physical_map(logical_to_physical_map: torch.Tensor, num_physical_experts: int) -> torch.Tensor:
     """Build a physical expert -> logical expert map from vLLM EPLB state."""
     physical_to_logical = torch.full(
         (num_physical_experts,),
@@ -32,7 +30,12 @@ def _invert_logical_to_physical_map(
         device=logical_to_physical_map.device,
     )[:, None].expand_as(logical_to_physical_map)
     physical_indices = logical_to_physical_map.to(torch.long)
-    valid = (physical_indices >= 0) & (physical_indices < num_physical_experts)
+    invalid = (physical_indices < -1) | (physical_indices >= num_physical_experts)
+    if invalid.any():
+        invalid_indices = physical_indices[invalid].unique().tolist()
+        raise ValueError(f"EPLB maps to invalid physical experts: {invalid_indices}")
+
+    valid = physical_indices >= 0
     physical_to_logical[physical_indices[valid]] = logical_indices[valid]
     return physical_to_logical
 

--- a/src/prime_rl/inference/vllm/worker/weight_transfer.py
+++ b/src/prime_rl/inference/vllm/worker/weight_transfer.py
@@ -16,29 +16,69 @@ def postprocess_weights_checkpoint(model: Module, model_config, device: torch.de
     process_weights_after_loading(model, model_config, device)
 
 
+def _invert_logical_to_physical_map(
+    logical_to_physical_map: torch.Tensor, num_physical_experts: int
+) -> torch.Tensor:
+    """Build a physical expert -> logical expert map from vLLM EPLB state."""
+    physical_to_logical = torch.full(
+        (num_physical_experts,),
+        -1,
+        dtype=torch.long,
+        device=logical_to_physical_map.device,
+    )
+    logical_indices = torch.arange(
+        logical_to_physical_map.shape[0],
+        dtype=torch.long,
+        device=logical_to_physical_map.device,
+    )[:, None].expand_as(logical_to_physical_map)
+    physical_indices = logical_to_physical_map.to(torch.long)
+    valid = (physical_indices >= 0) & (physical_indices < num_physical_experts)
+    physical_to_logical[physical_indices[valid]] = logical_indices[valid]
+    return physical_to_logical
+
+
+def _build_expert_source_indices(module) -> torch.Tensor | None:
+    if module._expert_map is None:
+        return None
+
+    physical_indices = torch.where(module._expert_map >= 0)[0]
+    local_indices = module._expert_map[physical_indices]
+    physical_indices = physical_indices[local_indices.argsort()]
+
+    eplb_layer_state = getattr(module, "eplb_state", None)
+    logical_to_physical_map = getattr(eplb_layer_state, "logical_to_physical_map", None)
+    if logical_to_physical_map is None:
+        return physical_indices
+
+    physical_to_logical = _invert_logical_to_physical_map(logical_to_physical_map, module.global_num_experts)
+    logical_indices = physical_to_logical[physical_indices.to(physical_to_logical.device)]
+    if (logical_indices < 0).any():
+        missing = physical_indices[(logical_indices < 0).to(physical_indices.device)].tolist()
+        raise ValueError(f"EPLB has no logical mapping for local physical experts: {missing}")
+
+    return logical_indices.to(physical_indices.device)
+
+
 def build_expert_map(model: Module) -> dict[str, torch.Tensor]:
-    """Map FusedMoE module names to global expert indices local to this worker."""
+    """Map FusedMoE module names to source expert indices local to this worker."""
     from vllm.model_executor.layers.fused_moe.layer import FusedMoE
 
-    expert_slices: dict[str, torch.Tensor] = {}
+    source_indices_by_module: dict[str, torch.Tensor] = {}
     for module_name, module in model.named_modules():
         if not isinstance(module, FusedMoE):
             continue
-        if module._expert_map is None:
+        source_indices = _build_expert_source_indices(module)
+        if source_indices is None:
             continue
-
-        global_indices = torch.where(module._expert_map >= 0)[0]
-        local_indices = module._expert_map[global_indices]
-        global_indices = global_indices[local_indices.argsort()]
-        expert_slices[module_name] = global_indices
-    return expert_slices
+        source_indices_by_module[module_name] = source_indices
+    return source_indices_by_module
 
 
 @torch.no_grad()
 def load_weights_kernel(model: Module, state_iter: Generator[tuple[str, torch.Tensor], None, None]) -> None:
     """Load vLLM kernel-format tensors using in-place copy_ updates."""
     params = dict(model.named_parameters())
-    expert_slices = build_expert_map(model)
+    expert_source_indices = build_expert_map(model)
 
     loaded = 0
     skipped: list[str] = []
@@ -51,15 +91,13 @@ def load_weights_kernel(model: Module, state_iter: Generator[tuple[str, torch.Te
 
         param = params[name]
         if param.shape != tensor.shape:
-            sliced = False
-            for module_name, global_indices in expert_slices.items():
+            for module_name, source_indices in expert_source_indices.items():
                 if not name.startswith(f"{module_name}."):
                     continue
-                tensor = tensor[global_indices.to(tensor.device)]
-                sliced = True
+                tensor = tensor[source_indices.to(tensor.device)]
                 break
 
-            if not sliced or param.shape != tensor.shape:
+            if param.shape != tensor.shape:
                 shape_mismatches.append(f"{name}: param={list(param.shape)} != received={list(tensor.shape)}")
                 continue
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Modifies inference weight-loading logic for MoE expert tensor slicing and adds a new config invariant that can block runs; issues could cause runtime weight-shape mismatches or failed config validation when EPLB/quantized transfer are enabled.
> 
> **Overview**
> Adds a new `RLConfig` validator that **requires** `inference.enable_eplb` to be paired with NCCL weight broadcast and `quantize_in_weight_transfer=true`, failing fast on unsupported combinations.
> 
> Updates vLLM kernel weight transfer to handle EPLB expert remapping: expert tensor slicing now uses *source expert indices* derived from vLLM’s EPLB `logical_to_physical_map`, with extra validation for invalid/missing expert mappings before doing in-place `copy_` updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 109974faa6c690572da9adfd817c10621f22bd62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->