### PR TITLE
[Inference]: Pass --data-parallel-hybrid-lb to non-PD template

### DIFF
--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -335,9 +335,9 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
         INFER_DP_START_RANK=$((RANK_IN_REPLICA * INFERENCE_DP_LOCAL))
 
         if [ "$RANK_IN_REPLICA" -eq 0 ]; then
-            VLLM_EXTRA="{\"data_parallel_address\": \"$LOCAL_IP\"}"
+            VLLM_EXTRA="{\"data_parallel_address\": \"$LOCAL_IP\", \"data_parallel_hybrid_lb\": true}"
         else
-            VLLM_EXTRA="{\"data_parallel_address\": \"$REPLICA_HEAD_HOST\", \"data_parallel_start_rank\": $INFER_DP_START_RANK}"
+            VLLM_EXTRA="{\"data_parallel_address\": \"$REPLICA_HEAD_HOST\", \"data_parallel_start_rank\": $INFER_DP_START_RANK, \"data_parallel_hybrid_lb\": true}"
         fi
 
         uv run inference \


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk template-only change that adds an extra `vllm-extra` flag for distributed expert-parallel inference; main risk is altered inference routing/behavior in that specific launch mode.
> 
> **Overview**
> Ensures distributed expert-parallel (non-disaggregated) inference launches pass `"data_parallel_hybrid_lb": true` in `--vllm-extra` for both replica head and non-head nodes.
> 
> This aligns the distributed-EP path in `multi_node_rl.sbatch.j2` with other DP launch paths that already enable vLLM’s hybrid load balancing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7be5fb7efd8f71cb5d1cbe6d5cd64bfb0493a4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->