### PR TITLE
[Inference]: KV Cache offloading for non-PD deployments

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -110,6 +110,16 @@ class WeightBroadcastConfig(BaseConfig):
     )
 
 
+class KVCacheOffloadConfig(BaseModel):
+    """CPU KV cache offloading for vLLM inference workers."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    cpu_bytes: Annotated[int, Field(gt=0, description="CPU bytes available for KV cache offloading per worker.")] = (
+        1_000_000_000
+    )
+
+
 # Valid vLLM max_lora_rank values (from vllm/config/lora.py)
 # TODO: on newer vLLM, can import via `get_args(vllm.config.lora.MaxLoRARanks)`
 VALID_VLLM_LORA_RANKS = (8, 16, 32, 64, 128, 256, 320, 512)
@@ -150,20 +160,6 @@ class MultiNodeInferenceDeploymentConfig(BaseInferenceDeploymentConfig):
     router_policy: Annotated[
         str, Field(description="Routing policy for the vllm-router (e.g. 'consistent_hash', 'round_robin').")
     ] = "consistent_hash"
-
-
-class KVCacheOffloadConfig(BaseModel):
-    """CPU KV cache offloading for disaggregated serving.
-
-    When configured, both prefill and decode nodes use
-    MultiConnector (NixlConnector + OffloadingConnector).
-    """
-
-    model_config = ConfigDict(extra="forbid")
-
-    cpu_bytes: Annotated[int, Field(ge=0, description="CPU bytes available for KV cache offloading per worker.")] = (
-        1_000_000_000
-    )
 
 
 class DisaggregatedInferenceDeploymentConfig(BaseInferenceDeploymentConfig):
@@ -213,11 +209,6 @@ class DisaggregatedInferenceDeploymentConfig(BaseInferenceDeploymentConfig):
         dict[str, str],
         Field(description="Extra environment variables exported only on decode nodes."),
     ] = {}
-
-    kv_cache_offload: Annotated[
-        KVCacheOffloadConfig | None,
-        Field(description="CPU KV cache offload config for prefill nodes. None = disabled (NixlConnector only)."),
-    ] = None
 
     @property
     def num_nodes(self) -> int:
@@ -383,6 +374,17 @@ class InferenceConfig(BaseConfig):
         WeightBroadcastConfig()
     )
 
+    kv_cache_offload: Annotated[
+        KVCacheOffloadConfig | None,
+        Field(
+            description=(
+                "CPU KV cache offload config for inference workers. Standard inference uses vLLM's "
+                "OffloadingConnector. Disaggregated P/D deployments combine it with NIXL through "
+                "MultiConnector in the SLURM launcher."
+            ),
+        ),
+    ] = None
+
     enable_return_routed_experts: Annotated[
         bool,
         Field(
@@ -433,6 +435,16 @@ class InferenceConfig(BaseConfig):
     def validate_multi_node_requires_slurm(self):
         if self.deployment.type == "multi_node" and self.slurm is None:
             raise ValueError("Must use SLURM for multi-node deployment.")
+        return self
+
+    @model_validator(mode="after")
+    def auto_setup_kv_cache_offload(self):
+        if self.kv_cache_offload is not None:
+            if self.enable_prefix_caching is False:
+                raise ValueError("KV cache offloading requires inference.enable_prefix_caching to be true.")
+            if "enable_prefix_caching" not in self.model_fields_set:
+                self.enable_prefix_caching = True
+
         return self
 
     @model_validator(mode="after")
@@ -541,6 +553,19 @@ class InferenceConfig(BaseConfig):
 
         # Set `logprobs_mode` to `processed_logprobs` by default
         rsetattr(namespace, "logprobs_mode", "processed_logprobs")
+
+        if self.kv_cache_offload is not None:
+            rsetattr(
+                namespace,
+                "kv_transfer_config",
+                {
+                    "kv_connector": "OffloadingConnector",
+                    "kv_role": "kv_both",
+                    "kv_connector_extra_config": {
+                        "cpu_bytes_to_use": int(self.kv_cache_offload.cpu_bytes),
+                    },
+                },
+            )
 
         # Pass prime-rl-specific flags through vLLM's additional_config dict;
         # workers read these via get_current_vllm_config().additional_config.

--- a/src/prime_rl/entrypoints/inference.py
+++ b/src/prime_rl/entrypoints/inference.py
@@ -45,6 +45,7 @@ def write_slurm_script(config: InferenceConfig, config_path: Path, script_path: 
         num_nodes=getattr(config.deployment, "num_nodes", 1),
         port=config.server.port,
         disaggregated=is_disaggregated,
+        kv_offload=config.kv_cache_offload is not None,
     )
 
     is_multi_node = config.deployment.type == "multi_node"
@@ -63,10 +64,7 @@ def write_slurm_script(config: InferenceConfig, config_path: Path, script_path: 
             use_deep_gemm=config.use_deep_gemm,
             prefill_env_overrides=config.deployment.prefill_env_overrides,
             decode_env_overrides=config.deployment.decode_env_overrides,
-            kv_offload=config.deployment.kv_cache_offload is not None,
-            kv_offload_cpu_bytes=int(config.deployment.kv_cache_offload.cpu_bytes)
-            if config.deployment.kv_cache_offload
-            else 0,
+            kv_offload_cpu_bytes=int(config.kv_cache_offload.cpu_bytes) if config.kv_cache_offload else 0,
         )
     elif is_multi_node:
         template_vars.update(

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -445,8 +445,10 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
             prefill_env_overrides=infer_deploy.prefill_env_overrides,
             decode_env_overrides=infer_deploy.decode_env_overrides,
             dp_per_node=config.deployment.gpus_per_node // config.inference.parallel.tp,
-            kv_offload=infer_deploy.kv_cache_offload is not None,
-            kv_offload_cpu_bytes=int(infer_deploy.kv_cache_offload.cpu_bytes) if infer_deploy.kv_cache_offload else 0,
+            kv_offload=config.inference.kv_cache_offload is not None,
+            kv_offload_cpu_bytes=int(config.inference.kv_cache_offload.cpu_bytes)
+            if config.inference.kv_cache_offload
+            else 0,
             use_nccl_broadcast=config.weight_broadcast is not None and config.weight_broadcast.type == "nccl",
             wandb_shared=config.wandb is not None and config.wandb.shared,
             ranks_filter=",".join(map(str, config.trainer.log.ranks_filter)),
@@ -470,6 +472,7 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
             inference_enable_expert_parallel=config.inference.enable_expert_parallel if config.inference else False,
             inference_data_parallel_rpc_port=config.inference.data_parallel_rpc_port if config.inference else 29600,
             dp_per_node=(config.deployment.gpus_per_node // config.inference.parallel.tp) if config.inference else 1,
+            kv_offload=config.inference is not None and config.inference.kv_cache_offload is not None,
             use_nccl_broadcast=config.weight_broadcast is not None and config.weight_broadcast.type == "nccl",
             wandb_shared=config.wandb is not None and config.wandb.shared,
             ranks_filter=",".join(map(str, config.trainer.log.ranks_filter)),

--- a/src/prime_rl/templates/inference.sbatch.j2
+++ b/src/prime_rl/templates/inference.sbatch.j2
@@ -142,6 +142,10 @@ srun bash -c '
     INFER_NODE_RANK=$SLURM_PROCID
     LOCAL_IP=$(hostname -I | awk "{print \$1}")
 
+{%- if kv_offload %}
+    ulimit -l unlimited
+{%- endif %}
+
 {% if disaggregated -%}
     # NVSHMEM libs for DeepEP — ensure the rpath target exists on all nodes
     if [ ! -d /tmp/deepep_build/nvshmem/lib ] && [ -d "$OUTPUT_DIR/nvshmem/lib" ]; then
@@ -167,7 +171,6 @@ srun bash -c '
     export VLLM_NIXL_SIDE_CHANNEL_PORT=5600
 
 {%- if kv_offload %}
-    ulimit -l unlimited
     PREFILL_KV_CFG='"'"'{"kv_connector":"MultiConnector","kv_role":"kv_both","kv_connector_extra_config":{"connectors":[{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"num_threads":1}},{"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"cpu_bytes_to_use":{{ kv_offload_cpu_bytes }}}}]}}'"'"'
 {%- else %}
     PREFILL_KV_CFG='"'"'{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"num_threads":1}}'"'"'

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -197,6 +197,10 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
     export VLLM_WORKER_MULTIPROC_METHOD=spawn
     LOCAL_IP=$(hostname -I | awk "{print \$1}")
 
+{%- if kv_offload %}
+    ulimit -l unlimited
+{%- endif %}
+
     REPLICA_IDX=$((INFER_NODE_RANK / NODES_PER_INFER_REPLICA))
     RANK_IN_REPLICA=$((INFER_NODE_RANK % NODES_PER_INFER_REPLICA))
 
@@ -219,7 +223,6 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
     export VLLM_NIXL_SIDE_CHANNEL_PORT=5600
 
 {%- if kv_offload %}
-    ulimit -l unlimited
     PREFILL_KV_CFG='"'"'{"kv_connector":"MultiConnector","kv_role":"kv_both","kv_connector_extra_config":{"connectors":[{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"num_threads":1}},{"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"cpu_bytes_to_use":{{ kv_offload_cpu_bytes }}}}]}}'"'"'
 {%- else %}
     PREFILL_KV_CFG='"'"'{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"num_threads":1}}'"'"'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches inference configuration translation and SLURM launch scripts, which can affect runtime behavior and job startup; failures would surface as misconfigured vLLM connector settings or resource limits.
> 
> **Overview**
> Adds first-class `inference.kv_cache_offload` support so *non-disaggregated* vLLM deployments can use CPU KV-cache offloading via vLLM’s `OffloadingConnector` (emitting `kv_transfer_config` during `InferenceConfig.to_vllm`).
> 
> Moves KV offload configuration out of the disaggregated deployment config, updates both inference and RL SLURM entrypoints/templates to use the new top-level setting (including `ulimit -l unlimited` when enabled), and enforces/auto-enables `enable_prefix_caching` when KV offload is configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9ed757bd8db4d75589f61c7799e3b794cde6154. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->