### PR TITLE
feat(orchestrator): drop groups after max_error_reschedule_attempts

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -1082,6 +1082,14 @@ class OrchestratorConfig(BaseConfig):
         ),
     ] = 8
 
+    max_error_reschedule_attempts: Annotated[
+        int | None,
+        Field(
+            ge=1,
+            description="Maximum number of times the scheduler will reschedule a group whose rollouts errored or returned empty trajectories. After this many consecutive failed attempts, the group is dropped from the current step's batch (the trainer proceeds with the rollouts from other groups). `None` means retry indefinitely (legacy behavior). Useful for unblocking single-example hangs in agent envs.",
+        ),
+    ] = None
+
     max_async_level: Annotated[
         int,
         Field(

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -1086,7 +1086,7 @@ class OrchestratorConfig(BaseConfig):
         int | None,
         Field(
             ge=1,
-            description="Maximum number of times the scheduler will reschedule a group whose rollouts errored or returned empty trajectories. After this many consecutive failed attempts, the group is dropped from the current step's batch (the trainer proceeds with the rollouts from other groups). `None` means retry indefinitely (legacy behavior). Useful for unblocking single-example hangs in agent envs.",
+            description="The group is dropped from the current step's batch once this many of its dispatch rounds have returned errored or empty rollouts (the trainer proceeds with the rollouts from other groups). Counts rounds, not individual rollouts: a non-group-scoring env that dispatches `rollouts_per_example` rollouts at once still only counts one round per failed batch. `None` means retry indefinitely (legacy behavior). Useful for unblocking single-example hangs in agent envs.",
         ),
     ] = None
 

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -439,18 +439,21 @@ class Scheduler:
                     # Check for empty/errored rollouts and reschedule
                     valid_rollouts = []
                     has_failures = False
+                    last_failure_reason: str | None = None
                     for rollout in rollouts:
                         if rollout["error"] is not None:
                             self.errored_rollouts_by_env[env_name] += 1
                             has_failures = True
+                            last_failure_reason = rollout["error"]["error_chain_repr"]
                             self.logger.warning(
                                 f"Rollout error in group {group_id} ({env_name}), re-scheduling "
                                 f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete): "
-                                f"{rollout['error']['error_chain_repr']}"
+                                f"{last_failure_reason}"
                             )
                         elif len(rollout["trajectory"]) == 0:
                             self.empty_rollouts_by_env[env_name] += 1
                             has_failures = True
+                            last_failure_reason = "empty trajectory"
                             self.logger.warning(
                                 f"Empty trajectory in group {group_id} ({env_name}), re-scheduling "
                                 f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete)"
@@ -471,7 +474,8 @@ class Scheduler:
                             self.logger.warning(
                                 f"Dropping group {group_id} ({env_name}) after {group.failed_attempts} "
                                 f"failed attempts ({len(group.completed_rollouts)}/{self.rollouts_per_example} "
-                                f"complete). Set orchestrator.max_error_reschedule_attempts higher (or to None) "
+                                f"complete). Last failure: {last_failure_reason}. Set "
+                                f"orchestrator.max_error_reschedule_attempts higher (or to None) "
                                 f"to retry more aggressively."
                             )
                             await self.drop_group(group_id)

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -553,6 +553,7 @@ class Scheduler:
             "scheduler/cancelled_rollouts": self.cancelled_rollouts_count,
             "empty_rollouts/all": sum(self.empty_rollouts_by_env.values()) / max(total_rollouts, 1),
             "errored_rollouts/all": sum(self.errored_rollouts_by_env.values()) / max(total_rollouts, 1),
+            "dropped_groups/all": sum(self.dropped_groups_by_env.values()),
             "off_policy_level/all/max": self.max_off_policy_level,
             "off_policy_level/all/mean": self.mean_off_policy_level,
         }
@@ -560,6 +561,8 @@ class Scheduler:
             env_total = max(self.total_rollouts_by_env[env_name], 1)
             metrics[f"empty_rollouts/{env_name}"] = self.empty_rollouts_by_env.get(env_name, 0) / env_total
             metrics[f"errored_rollouts/{env_name}"] = self.errored_rollouts_by_env.get(env_name, 0) / env_total
+        for env_name, count in self.dropped_groups_by_env.items():
+            metrics[f"dropped_groups/{env_name}"] = count
         by_env: dict[str, list[int]] = {}
         for info in self.inflight_requests.values():
             by_env.setdefault(info.env_name, []).append(info.off_policy_steps)
@@ -570,6 +573,7 @@ class Scheduler:
         self.empty_rollouts_by_env.clear()
         self.errored_rollouts_by_env.clear()
         self.total_rollouts_by_env.clear()
+        self.dropped_groups_by_env.clear()
 
         # Add inference pool metrics (e.g. elastic pool server counts)
         metrics.update(self.inference_pool.get_metrics())

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -42,6 +42,10 @@ class GroupState:
     rollouts_to_schedule: int
     completed_rollouts: list[vf.RolloutOutput] = field(default_factory=list)
     pinned_client: vf.ClientConfig | None = None
+    # Number of rollout attempts in this group that returned errored or empty
+    # trajectories. Compared against config.max_error_reschedule_attempts to
+    # decide when to drop a permanently-stuck group.
+    failed_attempts: int = 0
 
 
 class Scheduler:
@@ -114,6 +118,7 @@ class Scheduler:
         self.empty_rollouts_by_env: dict[str, int] = defaultdict(int)
         self.errored_rollouts_by_env: dict[str, int] = defaultdict(int)
         self.total_rollouts_by_env: dict[str, int] = defaultdict(int)
+        self.dropped_groups_by_env: dict[str, int] = defaultdict(int)
         self.last_batch_generation_time = 0.0
 
     @property
@@ -453,6 +458,24 @@ class Scheduler:
                         else:
                             rollout["env_name"] = env_name
                             valid_rollouts.append(rollout)
+
+                    if has_failures:
+                        group.failed_attempts += 1
+                        max_attempts = self.config.max_error_reschedule_attempts
+                        if max_attempts is not None and group.failed_attempts >= max_attempts:
+                            # Permanently-stuck group: drop it from this step and let the
+                            # rest of the batch proceed. Avoids a single bad example (e.g.
+                            # an agent rollout whose sandbox poll keeps timing out)
+                            # blocking step progress forever.
+                            self.dropped_groups_by_env[env_name] += 1
+                            self.logger.warning(
+                                f"Dropping group {group_id} ({env_name}) after {group.failed_attempts} "
+                                f"failed attempts ({len(group.completed_rollouts)}/{self.rollouts_per_example} "
+                                f"complete). Set orchestrator.max_error_reschedule_attempts higher (or to None) "
+                                f"to retry more aggressively."
+                            )
+                            await self.drop_group(group_id)
+                            continue
 
                     if has_failures and env.requires_group_scoring:
                         # Group scoring requires all rollouts — discard partial results, reschedule full group

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -462,7 +462,7 @@ class Scheduler:
                     if has_failures:
                         group.failed_attempts += 1
                         max_attempts = self.config.max_error_reschedule_attempts
-                        if max_attempts is not None and group.failed_attempts >= max_attempts:
+                        if max_attempts is not None and group.failed_attempts > max_attempts:
                             # Permanently-stuck group: drop it from this step and let the
                             # rest of the batch proceed. Avoids a single bad example (e.g.
                             # an agent rollout whose sandbox poll keeps timing out)

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -32,6 +32,8 @@ class InflightRequest:
     env_name: str
     group_id: int | None = None
     rollout_count: int = 1
+    # Dispatch round the request belongs to (see GroupState.current_round).
+    round_id: int = 0
 
 
 @dataclass
@@ -42,10 +44,19 @@ class GroupState:
     rollouts_to_schedule: int
     completed_rollouts: list[vf.RolloutOutput] = field(default_factory=list)
     pinned_client: vf.ClientConfig | None = None
-    # Number of rollout attempts in this group that returned errored or empty
-    # trajectories. Compared against config.max_error_reschedule_attempts to
-    # decide when to drop a permanently-stuck group.
+    # Number of dispatch rounds in which at least one rollout returned errored
+    # or empty trajectories. Compared against
+    # config.max_error_reschedule_attempts to decide when to drop a
+    # permanently-stuck group. Counts rounds, not rollouts: a failed round in
+    # an individual-scoring env that happens to dispatch N rollouts at once
+    # still only counts as 1.
     failed_attempts: int = 0
+    # Round id assigned to newly-dispatched rollouts. Advances after a failure
+    # is counted so the resulting reschedule starts a new round.
+    current_round: int = 0
+    # Highest round already counted as failed; used to dedupe failures from
+    # multiple rollouts in the same round.
+    last_failed_round: int = -1
 
 
 class Scheduler:
@@ -234,6 +245,7 @@ class Scheduler:
             env_name=env_name,
             group_id=group_id,
             rollout_count=rollout_count,
+            round_id=group.current_round,
         )
 
     @property
@@ -463,9 +475,16 @@ class Scheduler:
                             valid_rollouts.append(rollout)
 
                     if has_failures:
-                        group.failed_attempts += 1
+                        # Dedupe failures within the same dispatch round: an
+                        # individual-scoring env dispatches N rollouts at once,
+                        # so a single failed round can produce up to N failed
+                        # tasks. We only count the round once.
+                        if rollout_info.round_id > group.last_failed_round:
+                            group.failed_attempts += 1
+                            group.last_failed_round = rollout_info.round_id
+                            group.current_round = rollout_info.round_id + 1
                         max_attempts = self.config.max_error_reschedule_attempts
-                        if max_attempts is not None and group.failed_attempts > max_attempts:
+                        if max_attempts is not None and group.failed_attempts >= max_attempts:
                             # Permanently-stuck group: drop it from this step and let the
                             # rest of the batch proceed. Avoids a single bad example (e.g.
                             # an agent rollout whose sandbox poll keeps timing out)
@@ -473,7 +492,7 @@ class Scheduler:
                             self.dropped_groups_by_env[env_name] += 1
                             self.logger.warning(
                                 f"Dropping group {group_id} ({env_name}) after {group.failed_attempts} "
-                                f"failed attempts ({len(group.completed_rollouts)}/{self.rollouts_per_example} "
+                                f"failed dispatch rounds ({len(group.completed_rollouts)}/{self.rollouts_per_example} "
                                 f"complete). Last failure: {last_failure_reason}. Set "
                                 f"orchestrator.max_error_reschedule_attempts higher (or to None) "
                                 f"to retry more aggressively."


### PR DESCRIPTION
## Summary

- Add `orchestrator.max_error_reschedule_attempts: int | None = None` (default: retry indefinitely, current behavior).
- `GroupState.failed_attempts` tracks the number of dispatch rounds where at least one rollout came back errored or empty. Failures in the same round are deduped via a per-request `round_id`, so a non-group-scoring env that dispatches `rollouts_per_example` rollouts at once still only increments the counter by one per failed round.
- The group is dropped from the current step's batch once `failed_attempts >= max_error_reschedule_attempts` (in-flight rollouts cancelled via existing `drop_group`); the rest of the batch proceeds.
- New `dropped_groups_by_env` counter on the scheduler, reported in `get_metrics()` as `dropped_groups/all` and per-env, and cleared each reporting interval like the sibling counters. Warning log on each drop includes the last failure reason.

## Why

Agent envs can hit single-example hangs (e.g. a sandbox poll that times out at 60s on every retry). The error surfaces as `rollout["error"]`, which the scheduler currently treats as a normal "reschedule the group" signal — there is no give-up condition, so a single bad example blocks step progress forever. This adds an opt-in cap so step progress can continue without the bad group.

## Notes

Minimal local re-implementation of the abandoned #2076 — keeps the retry-cap behavior without the larger `GeneratedBatch` / variable group-size / deferred-scoring refactor in that PR.

## Files

- `packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py` — new config field.
- `src/prime_rl/orchestrator/scheduler.py` — `failed_attempts` + per-round dedupe (`round_id`, `current_round`, `last_failed_round`) on `GroupState`/`InflightRequest`, drop logic in the rollout completion path, `dropped_groups_by_env` counter wired through `get_metrics()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core rollout scheduling behavior by allowing examples to be skipped after repeated failures, which can affect batch composition and training signal if misconfigured. Default remains legacy (retry indefinitely), reducing risk unless the knob is enabled.
> 
> **Overview**
> Introduces `orchestrator.max_error_reschedule_attempts` (default `None`) to **stop infinite rescheduling** when a rollout group repeatedly returns errored or empty trajectories.
> 
> The scheduler now tracks per-group dispatch rounds (`failed_attempts`/`round_id`) to dedupe failures within a round, **drops the group** once the cap is reached (cancelling in-flight work via existing `drop_group`), and reports new `dropped_groups/*` metrics alongside existing empty/errored rollout counters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd5dfaa7f7deab05187f28264b68227ebd3b5006. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

