### PR TITLE
Fix: third_party to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,3 +199,5 @@ debug_I2_zero_band
 .idea
 
 outputs/
+
+third_party/


### PR DESCRIPTION
we have ucx on the cluster in third_party

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates `.gitignore` to prevent committing external/vendor files; no runtime code changes.
> 
> **Overview**
> Adds `third_party/` to `.gitignore` so cluster/vendor dependencies in that directory (e.g., UCX) are not tracked in git.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 874d2a782bdd69e23de49c93eadc82a2e692b1d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->