### PR TITLE
feat: add Dynamo vLLM inference backend

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -10,7 +10,7 @@ from prime_rl.utils.config import find_package_resource, rgetattr, rsetattr
 
 # TODO: Set thinking/ solution budget
 
-InferenceBackend: TypeAlias = Literal["vllm", "sglang"]
+InferenceBackend: TypeAlias = Literal["vllm", "sglang", "dynamo"]
 
 
 class ServerConfig(BaseConfig):
@@ -120,6 +120,60 @@ class WeightBroadcastConfig(BaseConfig):
     type: Annotated[Literal["nccl", "filesystem"], Field(description="The type of weight broadcast to use.")] = (
         "filesystem"
     )
+
+
+class DynamoConfig(BaseConfig):
+    """Configures Dynamo when ``inference.backend = "dynamo"``.
+
+    prime-rl launches a local Dynamo frontend and one Dynamo vLLM worker in the
+    same inference process. Requests go to ``server.port``; admin calls for
+    weight updates go to the worker system server on ``system_port``.
+    """
+
+    namespace: Annotated[
+        str,
+        Field(description="Dynamo namespace used by the frontend and worker for service discovery."),
+    ] = "dynamo"
+
+    discovery_backend: Annotated[
+        Literal["file", "etcd", "kubernetes", "mem"],
+        Field(description="Dynamo discovery backend. Use 'file' for local single-node runs without etcd/NATS."),
+    ] = "file"
+
+    request_plane: Annotated[
+        Literal["tcp", "nats", "http"],
+        Field(description="Dynamo request plane used between the frontend and worker."),
+    ] = "tcp"
+
+    event_plane: Annotated[
+        Literal["nats", "zmq"] | None,
+        Field(description="Dynamo event plane. If None, Dynamo derives it from discovery_backend."),
+    ] = None
+
+    system_port: Annotated[
+        int,
+        Field(ge=1, le=65535, description="Dynamo worker system-server port for /health and /engine routes."),
+    ] = 8081
+
+    use_vllm_tokenizer: Annotated[
+        bool,
+        Field(
+            description=(
+                "Use Dynamo's text-in/text-out vLLM worker path. prime-rl defaults this off so the "
+                "frontend sends tokenized requests and the worker can return per-token logprobs."
+            ),
+        ),
+    ] = False
+
+    frontend_extra: Annotated[
+        dict[str, Any],
+        Field(description="Extra CLI arguments for python -m dynamo.frontend."),
+    ] = {}
+
+    worker_extra: Annotated[
+        dict[str, Any],
+        Field(description="Extra CLI arguments for the Dynamo vLLM worker."),
+    ] = {}
 
 
 class KVCacheOffloadConfig(BaseModel):
@@ -257,7 +311,10 @@ class InferenceConfig(BaseConfig):
     backend: Annotated[
         InferenceBackend,
         Field(
-            description="Inference server backend to launch. vLLM is the default; SGLang supports filesystem weight updates."
+            description=(
+                "Inference server backend to launch. vLLM is the default; SGLang and Dynamo are available "
+                "for OpenAI-compatible rollouts with prime-rl weight updates."
+            )
         ),
     ] = "vllm"
 
@@ -393,6 +450,11 @@ class InferenceConfig(BaseConfig):
         WeightBroadcastConfig()
     )
 
+    dynamo: Annotated[
+        DynamoConfig,
+        Field(description="Dynamo-specific settings used when backend='dynamo'."),
+    ] = DynamoConfig()
+
     kv_cache_offload: Annotated[
         KVCacheOffloadConfig | None,
         Field(
@@ -465,14 +527,16 @@ class InferenceConfig(BaseConfig):
 
     @model_validator(mode="after")
     def validate_backend_support(self):
-        if self.backend != "sglang":
+        if self.backend not in ("sglang", "dynamo"):
             return self
 
         if self.deployment.type != "single_node":
-            raise ValueError("inference.backend='sglang' currently supports only single_node deployment.")
-        if self.kv_cache_offload is not None:
+            raise ValueError(f"inference.backend={self.backend!r} currently supports only single_node deployment.")
+        if self.backend == "sglang" and self.kv_cache_offload is not None:
             raise ValueError("inference.backend='sglang' does not support prime-rl kv_cache_offload plumbing yet.")
-        if self.enable_return_routed_experts:
+        if self.backend == "dynamo" and self.kv_cache_offload is not None:
+            raise ValueError("inference.backend='dynamo' does not support prime-rl kv_cache_offload plumbing yet.")
+        if self.backend == "sglang" and self.enable_return_routed_experts:
             raise ValueError("inference.backend='sglang' does not support return routed experts yet.")
         return self
 
@@ -690,6 +754,111 @@ class InferenceConfig(BaseConfig):
 
             value = getattr(namespace, optional_key)
             if value is None or (optional_key in {"reasoning_parser", "tool_call_parser"} and value == "auto"):
+                delattr(namespace, optional_key)
+
+        return namespace
+
+    def to_dynamo_frontend(self) -> Namespace:
+        """Convert InferenceConfig to Dynamo frontend CLI namespace."""
+        namespace = Namespace()
+        to_frontend = {
+            "server.host": "http_host",
+            "server.port": "http_port",
+            "dynamo.namespace": "namespace",
+            "dynamo.discovery_backend": "discovery_backend",
+            "dynamo.request_plane": "request_plane",
+            "dynamo.event_plane": "event_plane",
+            "model.name": "model_name",
+        }
+
+        for config_key, frontend_key in to_frontend.items():
+            value = rgetattr(self, config_key.replace("-", "_"))
+            rsetattr(namespace, frontend_key, value)
+
+        namespace.dyn_chat_processor = "vllm"
+
+        for key, value in self.dynamo.frontend_extra.items():
+            setattr(namespace, key, value)
+
+        for optional_key in ("http_host", "event_plane", "model_name"):
+            value = getattr(namespace, optional_key, None)
+            if value is None:
+                delattr(namespace, optional_key)
+
+        return namespace
+
+    def to_dynamo_vllm(self) -> Namespace:
+        """Convert InferenceConfig to Dynamo vLLM worker CLI namespace."""
+        namespace = Namespace()
+        to_dynamo_vllm = {
+            "dynamo.namespace": "namespace",
+            "dynamo.discovery_backend": "discovery_backend",
+            "dynamo.request_plane": "request_plane",
+            "dynamo.event_plane": "event_plane",
+            "dynamo.use_vllm_tokenizer": "use_vllm_tokenizer",
+            "model.name": "model",
+            "model.dtype": "dtype",
+            "model.max_model_len": "max_model_len",
+            "model.enforce_eager": "enforce_eager",
+            "model.trust_remote_code": "trust_remote_code",
+            "model.rope_scaling": "rope_scaling",
+            "parallel.tp": "tensor_parallel_size",
+            "parallel.dp": "data_parallel_size",
+            "data_parallel_size_local": "data_parallel_size_local",
+            "data_parallel_rpc_port": "data_parallel_rpc_port",
+            "enable_lora": "enable_lora",
+            "enable_prefix_caching": "enable_prefix_caching",
+            "max_loras": "max_loras",
+            "max_cpu_loras": "max_cpu_loras",
+            "max_lora_rank": "max_lora_rank",
+            "lora_target_modules": "lora_target_modules",
+            "gpu_memory_utilization": "gpu_memory_utilization",
+            "enable_return_routed_experts": "enable_return_routed_experts",
+            "enable_expert_parallel": "enable_expert_parallel",
+            "all2all_backend": "all2all_backend",
+            "enable_eplb": "enable_eplb",
+            "enable_dbo": "enable_dbo",
+            "seed": "seed",
+        }
+
+        for config_key, dynamo_key in to_dynamo_vllm.items():
+            value = rgetattr(self, config_key.replace("-", "_"))
+            rsetattr(namespace, dynamo_key, value)
+
+        namespace.served_model_name = self.model.name
+
+        if self.model.tool_call_parser not in (None, "auto"):
+            namespace.dyn_tool_call_parser = self.model.tool_call_parser
+        if self.model.reasoning_parser is not None:
+            namespace.dyn_reasoning_parser = self.model.reasoning_parser
+
+        namespace.logprobs_mode = "processed_logprobs"
+
+        if self.enable_fp32_lm_head:
+            existing = getattr(namespace, "additional_config", None) or {}
+            existing["fp32_lm_head"] = True
+            rsetattr(namespace, "additional_config", existing)
+
+        for key, value in self.vllm_extra.items():
+            setattr(namespace, key, value)
+        for key, value in self.dynamo.worker_extra.items():
+            setattr(namespace, key, value)
+
+        for optional_key in (
+            "event_plane",
+            "rope_scaling",
+            "data_parallel_size_local",
+            "data_parallel_rpc_port",
+            "enable_prefix_caching",
+            "max_lora_rank",
+            "lora_target_modules",
+            "additional_config",
+        ):
+            if not hasattr(namespace, optional_key):
+                continue
+
+            value = getattr(namespace, optional_key)
+            if value is None:
                 delattr(namespace, optional_key)
 
         return namespace

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -712,6 +712,40 @@ class RLConfig(BaseConfig):
         return self
 
     @model_validator(mode="after")
+    def auto_setup_dynamo_backend(self):
+        """Configure orchestrator compatibility when the local inference backend is Dynamo."""
+        if self.inference is None or self.inference.backend != "dynamo":
+            return self
+
+        self.orchestrator.client.admin_backend = "dynamo"
+        if self.orchestrator.client.admin_base_url is None:
+            self.orchestrator.client.admin_base_url = [f"http://localhost:{self.inference.dynamo.system_port}"]
+        if "skip_model_check" not in self.orchestrator.client.model_fields_set:
+            # The admin client points at Dynamo's worker system server, while
+            # /v1/models lives on the frontend. The first rollout still exercises
+            # the frontend before training consumes samples.
+            self.orchestrator.client.skip_model_check = True
+
+        if self.orchestrator.use_renderer:
+            raise ValueError(
+                "inference.backend='dynamo' does not support orchestrator.use_renderer because prime-rl's "
+                "renderer client targets the vLLM-only /v1/generate endpoint."
+            )
+
+        if self.orchestrator.use_token_client:
+            if "use_token_client" in self.orchestrator.model_fields_set:
+                raise ValueError(
+                    "inference.backend='dynamo' does not support orchestrator.use_token_client because Dynamo "
+                    "does not expose prime-rl's vLLM-only /v1/chat/completions/tokens endpoint."
+                )
+            self.orchestrator.use_token_client = False
+
+        for env in self.orchestrator.train.env:
+            env.sampling.extra_body.pop("return_token_ids", None)
+
+        return self
+
+    @model_validator(mode="after")
     def validate_eplb_requires_quantized_weight_transfer(self):
         if self.inference is None or not self.inference.enable_eplb:
             return self

--- a/packages/prime-rl-configs/src/prime_rl/configs/shared.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/shared.py
@@ -79,7 +79,7 @@ class SlurmConfig(BaseConfig):
 
 
 ServerType = Literal["vllm", "sglang", "openai"]
-AdminBackend = Literal["vllm", "sglang"]
+AdminBackend = Literal["vllm", "sglang", "dynamo"]
 
 
 class VLMConfig(BaseConfig):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ dependencies = [
     "torchtitan",
     "verifiers",
     "dion",
+    "ai-dynamo==1.1.1",
+    "blake3>=1.0.0,<2.0.0",
     "tilelang>=0.1.8",
     "flash-linear-attention",
     "nvidia-ml-py>=12.575.51",
@@ -130,6 +132,8 @@ override-dependencies = [
 [tool.uv.exclude-newer-package]
 # we want latest vllm, remove next patch
 vllm = false
+ai-dynamo = false
+ai-dynamo-runtime = false
 sglang = false
 flash_attn_3 = false
 # Self-vendored packages on our primeintellect index

--- a/skills/config/SKILL.md
+++ b/skills/config/SKILL.md
@@ -132,7 +132,7 @@ On the CLI, pass as a JSON string:
 uv run inference --vllm-extra '{"key1": "value1", "key2": 123}'
 ```
 
-SGLang uses a parallel `sglang_extra` dict:
+Dynamo and SGLang use backend-specific extra dicts:
 
 ```toml
 [inference]
@@ -143,6 +143,20 @@ attention_backend = "triton"
 ```
 
 SGLang support currently covers single-node inference with filesystem or NCCL weight broadcast. The RL config auto-switches rollouts from the vLLM-only token client to the standard OpenAI chat-completions client when `inference.backend = "sglang"`.
+
+Dynamo support currently covers single-node aggregated Dynamo + vLLM inference with filesystem or NCCL weight broadcast. The launcher starts an internal Dynamo frontend, a Dynamo vLLM worker in token-in/token-out mode, and a prime-rl OpenAI proxy on `inference.server.port`. The proxy strips Dynamo-unsupported vLLM-only request fields like `return_token_ids`, tokenizes chat prompts, and calls the worker system route that returns `prompt_token_ids`, completion `token_ids`, and completion logprobs for verifiers. The RL config auto-switches rollouts from the vLLM-only token client to the standard OpenAI chat-completions client and uses the Dynamo worker system server for admin calls:
+
+```toml
+[inference]
+backend = "dynamo"
+
+[inference.dynamo]
+system_port = 8081
+discovery_backend = "file"
+
+[inference.dynamo.worker_extra]
+block_size = 64
+```
 
 For SGLang NCCL broadcast:
 

--- a/skills/entrypoints/SKILL.md
+++ b/skills/entrypoints/SKILL.md
@@ -39,7 +39,7 @@ The entrypoint launches torchrun internally — no need to call torchrun directl
 
 ## `inference` — Standalone inference server
 
-Launches an OpenAI-compatible inference server. vLLM is the default backend; SGLang is available with `--backend sglang` or `inference.backend = "sglang"`.
+Launches an OpenAI-compatible inference server. vLLM is the default backend; SGLang is available with `--backend sglang` or `inference.backend = "sglang"`, and Dynamo+vLLM is available with `--backend dynamo` or `inference.backend = "dynamo"`.
 
 ```bash
 uv run inference @ configs/debug/infer.toml
@@ -58,6 +58,12 @@ SGLang custom endpoints used by prime-rl:
 - `/update_weights_from_disk` — filesystem weight reload
 - `/init_broadcaster` — initialize SGLang NCCL receiver
 - `/update_weights` — receive an NCCL weight broadcast
+
+Dynamo launches a public prime-rl OpenAI proxy on `server.port`; the native Dynamo frontend runs on an internal port. Dynamo custom endpoints used by prime-rl run on the worker system server (`inference.dynamo.system_port`, default `8081`):
+- `/engine/update_weights` — hot-reload model weights from the trainer
+- `/engine/init_broadcaster` — initialize weight broadcast for distributed training
+- `/engine/pause` and `/engine/resume` — pause/resume vLLM generation
+- `/engine/chat_completions` — proxy target for OpenAI chat completions with prompt/completion token IDs and logprobs
 
 Check health with:
 ```bash

--- a/src/prime_rl/entrypoints/inference.py
+++ b/src/prime_rl/entrypoints/inference.py
@@ -139,6 +139,10 @@ def inference_local(config: InferenceConfig):
         from prime_rl.inference.sglang.server import server
 
         server(config)
+    elif config.backend == "dynamo":
+        from prime_rl.inference.dynamo.server import server
+
+        server(config)
     else:
         raise ValueError(f"Unsupported inference backend: {config.backend}")
 

--- a/src/prime_rl/inference/dynamo/__init__.py
+++ b/src/prime_rl/inference/dynamo/__init__.py
@@ -1,0 +1,1 @@
+"""Dynamo inference backend integration."""

--- a/src/prime_rl/inference/dynamo/proxy.py
+++ b/src/prime_rl/inference/dynamo/proxy.py
@@ -1,0 +1,159 @@
+"""OpenAI-compatible proxy for prime-rl's Dynamo worker."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping
+from contextlib import asynccontextmanager
+from typing import Any
+
+import httpx
+import uvicorn
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, Response
+from transformers import AutoTokenizer
+
+
+def _content_headers(headers: httpx.Headers) -> dict[str, str]:
+    content_type = headers.get("content-type")
+    if content_type is None:
+        return {}
+    return {"content-type": content_type}
+
+
+class DynamoProxy:
+    def __init__(self, upstream_url: str, worker_url: str, model: str, trust_remote_code: bool) -> None:
+        self.upstream_url = upstream_url.rstrip("/")
+        self.worker_url = worker_url.rstrip("/")
+        self.model = model
+        self.tokenizer = AutoTokenizer.from_pretrained(model, trust_remote_code=trust_remote_code)
+        self.client = httpx.AsyncClient(timeout=None)
+
+    async def close(self) -> None:
+        await self.client.aclose()
+
+    def prompt_token_ids(self, body: dict[str, Any]) -> list[int]:
+        messages = body["messages"]
+        chat_template_kwargs = dict(body.get("chat_template_kwargs") or {})
+        tokenized = self.tokenizer.apply_chat_template(
+            messages,
+            tools=body.get("tools"),
+            documents=body.get("documents"),
+            chat_template=body.get("chat_template"),
+            add_generation_prompt=body.get("add_generation_prompt", True),
+            continue_final_message=body.get("continue_final_message", False),
+            tokenize=True,
+            **chat_template_kwargs,
+        )
+        if isinstance(tokenized, Mapping):
+            tokenized = tokenized["input_ids"]
+        if tokenized and isinstance(tokenized[0], list):
+            tokenized = tokenized[0]
+        return list(tokenized)
+
+    async def chat_completions(self, request: Request) -> Response:
+        body = await request.json()
+        if body.get("stream"):
+            return JSONResponse(
+                {"message": "Dynamo backend streaming chat completions are not supported by prime-rl."},
+                status_code=400,
+            )
+
+        extra_body = body.pop("extra_body", None)
+        if isinstance(extra_body, dict):
+            body.update(extra_body)
+        body.pop("return_token_ids", None)
+        body["prompt_token_ids"] = self.prompt_token_ids(body)
+
+        dp_rank = request.headers.get("x-data-parallel-rank")
+        if dp_rank is not None:
+            body.setdefault("routing", {})["dp_rank"] = int(dp_rank)
+
+        response = await self.client.post(f"{self.worker_url}/engine/chat_completions", json=body)
+        return Response(
+            content=response.content,
+            status_code=response.status_code,
+            headers=_content_headers(response.headers),
+        )
+
+    async def models(self) -> JSONResponse:
+        return JSONResponse(
+            {
+                "object": "list",
+                "data": [
+                    {
+                        "id": self.model,
+                        "object": "model",
+                        "created": 0,
+                        "owned_by": "prime-rl",
+                    }
+                ],
+            }
+        )
+
+    async def forward(self, request: Request, path: str) -> Response:
+        body = await request.body()
+        response = await self.client.request(
+            request.method,
+            f"{self.upstream_url}/{path}",
+            content=body,
+            headers={key: value for key, value in request.headers.items() if key.lower() != "host"},
+            params=request.query_params,
+        )
+        return Response(
+            content=response.content,
+            status_code=response.status_code,
+            headers=_content_headers(response.headers),
+        )
+
+
+def build_app(proxy: DynamoProxy) -> FastAPI:
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI):
+        yield
+        await proxy.close()
+
+    app = FastAPI(lifespan=lifespan)
+
+    @app.get("/health")
+    async def _health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/v1/models")
+    async def _models() -> JSONResponse:
+        return await proxy.models()
+
+    @app.post("/v1/chat/completions")
+    async def _chat_completions(request: Request) -> Response:
+        return await proxy.chat_completions(request)
+
+    @app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
+    async def _forward(request: Request, path: str) -> Response:
+        return await proxy.forward(request, path)
+
+    return app
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="prime-rl Dynamo OpenAI proxy")
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--upstream-url", required=True)
+    parser.add_argument("--worker-url", required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--trust-remote-code", action="store_true")
+    args = parser.parse_args()
+
+    app = build_app(
+        DynamoProxy(
+            upstream_url=args.upstream_url,
+            worker_url=args.worker_url,
+            model=args.model,
+            trust_remote_code=args.trust_remote_code,
+        )
+    )
+    uvicorn.run(app, host=args.host, port=args.port, log_level="info")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/prime_rl/inference/dynamo/server.py
+++ b/src/prime_rl/inference/dynamo/server.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import json
+import os
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from argparse import Namespace
+from pathlib import Path
+from typing import Any
+
+from prime_rl.configs.inference import InferenceConfig
+from prime_rl.inference.vllm.server import WORKER_EXTENSION_CLS
+from prime_rl.utils.logger import get_logger
+from prime_rl.utils.nccl import disable_nccl_p2p_if_unavailable
+
+
+def _format_cli_value(value: Any) -> str:
+    if isinstance(value, Path):
+        return value.as_posix()
+    if isinstance(value, (dict, list, tuple)):
+        return json.dumps(value)
+    return str(value)
+
+
+def _namespace_to_cli_args(namespace: Namespace) -> list[str]:
+    args: list[str] = []
+    for key, value in vars(namespace).items():
+        if value is None:
+            continue
+
+        flag = f"--{key.replace('_', '-')}"
+        if value is True:
+            args.append(flag)
+        elif value is False:
+            continue
+        else:
+            args.extend([flag, _format_cli_value(value)])
+    return args
+
+
+def _terminate(processes: list[subprocess.Popen]) -> None:
+    for process in processes:
+        if process.poll() is None:
+            process.terminate()
+    for process in processes:
+        try:
+            process.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            process.kill()
+
+
+def _build_worker_namespace(config: InferenceConfig) -> Namespace:
+    namespace = config.to_dynamo_vllm()
+    namespace.worker_extension_cls = WORKER_EXTENSION_CLS[config.weight_broadcast.type]
+    return namespace
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def server(config: InferenceConfig) -> None:
+    """Launch a local Dynamo frontend with a Dynamo vLLM worker."""
+    logger = get_logger()
+    disable_nccl_p2p_if_unavailable()
+
+    frontend_namespace = config.to_dynamo_frontend()
+    external_port = frontend_namespace.http_port
+    frontend_namespace.http_port = _free_port()
+
+    frontend_command = [
+        sys.executable,
+        "-m",
+        "dynamo.frontend",
+        *_namespace_to_cli_args(frontend_namespace),
+    ]
+    worker_command = [
+        sys.executable,
+        "-m",
+        "prime_rl.inference.dynamo.worker",
+        *_namespace_to_cli_args(_build_worker_namespace(config)),
+    ]
+    proxy_command = [
+        sys.executable,
+        "-m",
+        "prime_rl.inference.dynamo.proxy",
+        "--host",
+        config.server.host or "0.0.0.0",
+        "--port",
+        str(external_port),
+        "--upstream-url",
+        f"http://127.0.0.1:{frontend_namespace.http_port}",
+        "--worker-url",
+        f"http://127.0.0.1:{config.dynamo.system_port}",
+        "--model",
+        config.model.name,
+    ]
+    if config.model.trust_remote_code:
+        proxy_command.append("--trust-remote-code")
+
+    base_env = os.environ.copy()
+    base_env.setdefault("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
+    if config.enable_lora:
+        base_env["VLLM_ALLOW_RUNTIME_LORA_UPDATING"] = "True"
+
+    discovery_dir = None
+    if config.dynamo.discovery_backend == "file" and "DYN_FILE_KV" not in base_env:
+        discovery_dir = tempfile.TemporaryDirectory(prefix="prime_rl_dynamo_")
+        base_env["DYN_FILE_KV"] = discovery_dir.name
+    if "DYN_EVENT_PLANE" not in base_env:
+        if config.dynamo.event_plane is not None:
+            base_env["DYN_EVENT_PLANE"] = config.dynamo.event_plane
+        elif config.dynamo.discovery_backend in ("file", "mem"):
+            base_env["DYN_EVENT_PLANE"] = "zmq"
+
+    frontend_env = base_env.copy()
+    frontend_env.pop("DYN_SYSTEM_PORT", None)
+
+    worker_env = base_env.copy()
+    worker_env["DYN_SYSTEM_PORT"] = str(config.dynamo.system_port)
+
+    logger.info(f"Starting Dynamo frontend: {' '.join(frontend_command)}")
+    logger.info(f"Starting Dynamo vLLM worker: {' '.join(worker_command)}")
+    logger.info(f"Starting prime-rl Dynamo proxy: {' '.join(proxy_command)}")
+
+    processes: list[subprocess.Popen] = []
+
+    def handle_signal(signum, _frame):
+        logger.warning(f"Received signal {signum}, terminating Dynamo processes")
+        _terminate(processes)
+        raise SystemExit(128 + signum)
+
+    previous_sigterm = signal.signal(signal.SIGTERM, handle_signal)
+    previous_sigint = signal.signal(signal.SIGINT, handle_signal)
+
+    try:
+        processes.append(subprocess.Popen(frontend_command, env=frontend_env))
+        processes.append(subprocess.Popen(worker_command, env=worker_env))
+        processes.append(subprocess.Popen(proxy_command, env=base_env))
+
+        while True:
+            for process in processes:
+                return_code = process.poll()
+                if return_code is not None:
+                    _terminate(processes)
+                    raise SystemExit(return_code)
+            time.sleep(1)
+    finally:
+        signal.signal(signal.SIGTERM, previous_sigterm)
+        signal.signal(signal.SIGINT, previous_sigint)
+        _terminate(processes)
+        if discovery_dir is not None:
+            discovery_dir.cleanup()

--- a/src/prime_rl/inference/dynamo/worker.py
+++ b/src/prime_rl/inference/dynamo/worker.py
@@ -1,0 +1,257 @@
+"""Dynamo vLLM worker entrypoint with prime-rl admin routes."""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Callable
+from uuid import uuid4
+
+from prime_rl.utils.logger import get_logger
+
+logger = get_logger()
+
+
+async def _pause_generation(handler, body: dict[str, Any]) -> dict[str, str]:
+    mode = body.get("mode", "keep")
+    clear_cache = bool(body.get("clear_cache", False))
+    await handler.engine_client.pause_generation(mode=mode, clear_cache=clear_cache)
+    return {"status": "ok"}
+
+
+async def _resume_generation(handler, _body: dict[str, Any]) -> dict[str, str]:
+    await handler.engine_client.resume_generation()
+    return {"status": "ok"}
+
+
+async def _update_weights(handler, body: dict[str, Any]) -> dict[str, str]:
+    weight_dir = body.get("weight_dir")
+    await handler.engine_client.pause_generation(mode="keep", clear_cache=False)
+    try:
+        await handler.engine_client.collective_rpc("update_weights_from_path", args=(weight_dir,))
+        reset_prefix_cache = bool(body.get("reset_prefix_cache", True))
+        if reset_prefix_cache and hasattr(handler.engine_client, "reset_prefix_cache"):
+            await handler.engine_client.reset_prefix_cache()
+    finally:
+        await handler.engine_client.resume_generation()
+    return {"status": "ok"}
+
+
+async def _init_broadcaster(handler, body: dict[str, Any]) -> dict[str, str]:
+    await handler.engine_client.collective_rpc(
+        "init_broadcaster",
+        args=(
+            body.get("host"),
+            body.get("port"),
+            body.get("rank_offset"),
+            body.get("inference_world_size"),
+            body.get("timeout"),
+            body.get("quantize_in_weight_transfer", False),
+        ),
+    )
+    return {"status": "ok"}
+
+
+async def _liveness_probe(handler, _body: dict[str, Any]) -> dict[str, str]:
+    await handler.engine_client.collective_rpc("liveness_probe")
+    return {"status": "ok"}
+
+
+def _sampling_params(handler, body: dict[str, Any]):
+    from vllm.sampling_params import SamplingParams
+
+    params = SamplingParams(**handler.default_sampling_params)
+    for key in (
+        "temperature",
+        "top_p",
+        "top_k",
+        "min_p",
+        "presence_penalty",
+        "frequency_penalty",
+        "repetition_penalty",
+        "seed",
+        "stop",
+        "stop_token_ids",
+        "ignore_eos",
+        "min_tokens",
+    ):
+        if key in body and body[key] is not None and hasattr(params, key):
+            setattr(params, key, body[key])
+
+    max_tokens = body.get("max_completion_tokens", body.get("max_tokens"))
+    if max_tokens is not None:
+        params.max_tokens = max_tokens
+
+    logprobs = body.get("logprobs")
+    top_logprobs = body.get("top_logprobs")
+    if logprobs is True:
+        params.logprobs = top_logprobs or 1
+    elif isinstance(logprobs, int) and not isinstance(logprobs, bool):
+        params.logprobs = logprobs
+    elif top_logprobs not in (None, 0):
+        params.logprobs = top_logprobs
+
+    return params
+
+
+def _decode_token(tokenizer, token_id: int, fallback: str | None = None) -> str:
+    if fallback is not None:
+        return fallback
+    return tokenizer.decode([token_id])
+
+
+def _token_logprobs(tokenizer, output) -> dict[str, Any] | None:
+    if output.logprobs is None:
+        return None
+
+    content: list[dict[str, Any]] = []
+    for index, token_id in enumerate(output.token_ids):
+        if index >= len(output.logprobs):
+            break
+        logprobs = output.logprobs[index]
+        if logprobs is None or token_id not in logprobs:
+            continue
+
+        selected = logprobs[token_id]
+        token = _decode_token(tokenizer, token_id, getattr(selected, "decoded_token", None))
+        top_entries = []
+        for top_token_id, top in logprobs.items():
+            top_token = _decode_token(tokenizer, top_token_id, getattr(top, "decoded_token", None))
+            top_entries.append(
+                {
+                    "token": top_token,
+                    "bytes": list(top_token.encode("utf-8")),
+                    "logprob": float(top.logprob),
+                }
+            )
+
+        content.append(
+            {
+                "token": token,
+                "bytes": list(token.encode("utf-8")),
+                "logprob": float(selected.logprob),
+                "top_logprobs": top_entries,
+            }
+        )
+
+    if not content:
+        return None
+    return {"content": content, "refusal": None}
+
+
+async def _chat_completions(handler, body: dict[str, Any]) -> dict[str, Any]:
+    from vllm.inputs import TokensPrompt
+
+    prompt_token_ids = body["prompt_token_ids"]
+    request_id = body.get("request_id") or f"chatcmpl-{uuid4().hex}"
+    model = body.get("model") or getattr(handler.config, "served_model_name", None) or handler.config.model
+    sampling_params = _sampling_params(handler, body)
+
+    routing = body.get("routing") or {}
+    dp_rank = handler._to_local_dp_rank(routing.get("dp_rank"))
+    priority = -int(routing.get("priority", 0))
+    lora_request = handler._resolve_lora_request(model)
+
+    final_output = None
+    try:
+        async for output in handler.engine_client.generate(
+            TokensPrompt(prompt_token_ids=prompt_token_ids),
+            sampling_params,
+            request_id,
+            lora_request=lora_request,
+            data_parallel_rank=dp_rank,
+            priority=priority,
+        ):
+            final_output = output
+    except Exception:
+        logger.exception("Dynamo chat completion generation failed")
+        raise
+
+    if final_output is None or not final_output.outputs:
+        return {
+            "id": request_id,
+            "object": "chat.completion",
+            "created": int(time.time()),
+            "model": model,
+            "choices": [],
+            "usage": {
+                "prompt_tokens": len(prompt_token_ids),
+                "completion_tokens": 0,
+                "total_tokens": len(prompt_token_ids),
+            },
+            "prompt_token_ids": prompt_token_ids,
+        }
+
+    choice_output = final_output.outputs[0]
+    completion_ids = list(choice_output.token_ids)
+    logprobs = _token_logprobs(handler.engine_client.tokenizer, choice_output)
+
+    return {
+        "id": request_id,
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": choice_output.text},
+                "finish_reason": choice_output.finish_reason,
+                "logprobs": logprobs,
+                "token_ids": completion_ids,
+            }
+        ],
+        "usage": {
+            "prompt_tokens": len(prompt_token_ids),
+            "completion_tokens": len(completion_ids),
+            "total_tokens": len(prompt_token_ids) + len(completion_ids),
+        },
+        "prompt_token_ids": prompt_token_ids,
+    }
+
+
+def _bind(handler, callback: Callable[[Any, dict[str, Any]], Any]):
+    async def route(body: dict[str, Any] | None = None):
+        return await callback(handler, body or {})
+
+    return route
+
+
+def patch_dynamo_vllm_worker() -> None:
+    """Register prime-rl admin routes on Dynamo's worker system server."""
+    from dynamo.vllm.handlers import BaseWorkerHandler
+
+    if getattr(BaseWorkerHandler, "_prime_rl_admin_routes_patched", False):
+        return
+
+    original_init = BaseWorkerHandler.__init__
+
+    def patched_init(self, runtime, *args, **kwargs) -> None:
+        original_init(self, runtime, *args, **kwargs)
+        if getattr(self, "_prime_rl_admin_routes_registered", False):
+            return
+        runtime.register_engine_route("pause", _bind(self, _pause_generation))
+        runtime.register_engine_route("resume", _bind(self, _resume_generation))
+        runtime.register_engine_route("update_weights", _bind(self, _update_weights))
+        runtime.register_engine_route("init_broadcaster", _bind(self, _init_broadcaster))
+        runtime.register_engine_route("liveness", _bind(self, _liveness_probe))
+        runtime.register_engine_route("chat_completions", _bind(self, _chat_completions))
+        self._prime_rl_admin_routes_registered = True
+        logger.info(
+            "Registered prime-rl Dynamo admin routes: "
+            "/engine/pause, /engine/resume, /engine/update_weights, /engine/init_broadcaster, "
+            "/engine/liveness, /engine/chat_completions"
+        )
+
+    BaseWorkerHandler.__init__ = patched_init
+    BaseWorkerHandler._prime_rl_admin_routes_patched = True
+
+
+def main() -> None:
+    patch_dynamo_vllm_worker()
+
+    from dynamo.vllm.main import main as dynamo_vllm_main
+
+    dynamo_vllm_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/prime_rl/inference/server.py
+++ b/src/prime_rl/inference/server.py
@@ -15,7 +15,7 @@ def setup_vllm_env(config: InferenceConfig):
 
 
 def setup_inference_env(config: InferenceConfig):
-    if config.backend == "vllm":
+    if config.backend in ("vllm", "dynamo"):
         setup_vllm_env(config)
 
 
@@ -30,6 +30,10 @@ def main():
         server(config, vllm_extra=config.vllm_extra)
     elif config.backend == "sglang":
         from prime_rl.inference.sglang.server import server
+
+        server(config)
+    elif config.backend == "dynamo":
+        from prime_rl.inference.dynamo.server import server
 
         server(config)
     else:

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -9,7 +9,6 @@ from typing import Protocol, runtime_checkable
 import httpx
 import verifiers as vf
 from httpx import AsyncClient
-from openai import NotFoundError
 from tenacity import retry, retry_if_exception, stop_after_attempt, stop_after_delay, wait_exponential
 
 from prime_rl.configs.shared import ClientConfig
@@ -270,14 +269,19 @@ async def check_health(
 
     async def _check_health(admin_client: AsyncClient) -> None:
         wait_time = 0
-        logger.debug("Starting pinging /health to check health")
+        admin_backend = get_admin_backend(admin_client)
+        logger.debug("Starting pinging health endpoint to check health")
         while wait_time < timeout:
             try:
-                await admin_client.get("/health")
+                if admin_backend == "dynamo":
+                    response = await admin_client.post("/engine/liveness", json={})
+                else:
+                    response = await admin_client.get("/health")
+                    if response.status_code == 404:
+                        logger.warning("The route /health does not exist. Skipping health check.")
+                        return
+                response.raise_for_status()
                 logger.debug(f"Inference pool is ready after {wait_time} seconds")
-                return
-            except NotFoundError:
-                logger.warning("The route /health does not exist. Skipping health check.")
                 return
             except Exception as e:
                 if wait_time % log_interval == 0 and wait_time > 0:
@@ -341,12 +345,19 @@ async def update_weights(
         sglang_clients = [client for client in admin_clients if get_admin_backend(client) == "sglang"]
         if sglang_clients:
             raise ValueError("SGLang backend does not support prime-rl LoRA adapter weight updates yet.")
+        dynamo_clients = [client for client in admin_clients if get_admin_backend(client) == "dynamo"]
+        if dynamo_clients:
+            raise ValueError("Dynamo backend does not support prime-rl LoRA adapter weight updates yet.")
         await load_lora_adapter(admin_clients, lora_name, weight_dir)
     else:
         sglang_clients = [client for client in admin_clients if get_admin_backend(client) == "sglang"]
         vllm_clients = [client for client in admin_clients if get_admin_backend(client) == "vllm"]
+        dynamo_clients = [client for client in admin_clients if get_admin_backend(client) == "dynamo"]
 
         sglang_uses_nccl = weight_dir is not None and (weight_dir / NCCL_BROADCAST_MARKER).exists()
+        dynamo_uses_nccl = bool(
+            weight_dir is not None and dynamo_clients and (weight_dir / NCCL_BROADCAST_MARKER).exists()
+        )
 
         async def _update_weights(admin_client: AsyncClient, weight_dir: str | None) -> None:
             backend = get_admin_backend(admin_client)
@@ -365,6 +376,13 @@ async def update_weights(
                 if result.get("success") is False:
                     raise RuntimeError(result.get("message", "SGLang weight update failed"))
                 return
+            if backend == "dynamo":
+                response = await admin_client.post("/engine/update_weights", json={"weight_dir": weight_dir})
+                response.raise_for_status()
+                result = response.json()
+                if result.get("status") == "error":
+                    raise RuntimeError(result.get("message", "Dynamo weight update failed"))
+                return
 
             response = await admin_client.post("/update_weights", json={"weight_dir": weight_dir})
             response.raise_for_status()
@@ -381,6 +399,11 @@ async def update_weights(
                 nccl_ready_file.touch()
                 logger.debug(f"Created NCCL_READY marker at {nccl_ready_file}")
             if weight_dir is not None and sglang_uses_nccl:
+                nccl_ready_file = weight_dir / NCCL_READY_MARKER
+                nccl_ready_file.parent.mkdir(parents=True, exist_ok=True)
+                nccl_ready_file.touch()
+                logger.debug(f"Created NCCL_READY marker at {nccl_ready_file}")
+            if weight_dir is not None and dynamo_uses_nccl:
                 nccl_ready_file = weight_dir / NCCL_READY_MARKER
                 nccl_ready_file.parent.mkdir(parents=True, exist_ok=True)
                 nccl_ready_file.touch()
@@ -489,7 +512,8 @@ async def init_nccl_broadcast(
     )
 
     async def _init_nccl_broadcast(admin_client: AsyncClient, rank_offset: int) -> None:
-        if get_admin_backend(admin_client) == "sglang":
+        backend = get_admin_backend(admin_client)
+        if backend == "sglang":
             response = await admin_client.post(
                 "/init_broadcaster",
                 json={
@@ -504,6 +528,23 @@ async def init_nccl_broadcast(
             result = response.json()
             if result.get("success") is False:
                 raise RuntimeError(result.get("message", "SGLang NCCL initialization failed"))
+            return
+        if backend == "dynamo":
+            response = await admin_client.post(
+                "/engine/init_broadcaster",
+                json={
+                    "host": host,
+                    "port": port,
+                    "rank_offset": rank_offset,
+                    "inference_world_size": inference_world_size,
+                    "timeout": timeout,
+                    "quantize_in_weight_transfer": quantize_in_weight_transfer,
+                },
+            )
+            response.raise_for_status()
+            result = response.json()
+            if result.get("status") == "error":
+                raise RuntimeError(result.get("message", "Dynamo NCCL initialization failed"))
             return
 
         try:

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -199,6 +199,47 @@ def test_rl_config_auto_selects_openai_client_for_sglang():
     assert config.orchestrator.client.admin_backend == "sglang"
 
 
+def test_inference_config_translates_dynamo_args():
+    config = InferenceConfig.model_validate(
+        {
+            "backend": "dynamo",
+            "server": {"host": "0.0.0.0", "port": 9000},
+            "model": {"name": "Qwen/Qwen3-0.6B", "max_model_len": 4096, "enforce_eager": True},
+            "parallel": {"tp": 2, "dp": 1},
+            "gpu_memory_utilization": 0.8,
+            "dynamo": {"system_port": 9001, "discovery_backend": "file", "worker_extra": {"block_size": 64}},
+        }
+    )
+
+    frontend = config.to_dynamo_frontend()
+    worker = config.to_dynamo_vllm()
+
+    assert frontend.http_host == "0.0.0.0"
+    assert frontend.http_port == 9000
+    assert frontend.namespace == "dynamo"
+    assert frontend.discovery_backend == "file"
+    assert frontend.model_name == "Qwen/Qwen3-0.6B"
+    assert frontend.dyn_chat_processor == "vllm"
+    assert worker.model == "Qwen/Qwen3-0.6B"
+    assert worker.served_model_name == "Qwen/Qwen3-0.6B"
+    assert worker.max_model_len == 4096
+    assert worker.tensor_parallel_size == 2
+    assert worker.enforce_eager is True
+    assert worker.gpu_memory_utilization == 0.8
+    assert worker.use_vllm_tokenizer is False
+    assert worker.block_size == 64
+
+
+def test_rl_config_auto_selects_openai_client_for_dynamo():
+    config = RLConfig.model_validate({"trainer": {}, "orchestrator": {}, "inference": {"backend": "dynamo"}})
+
+    assert config.orchestrator.use_token_client is False
+    assert config.orchestrator.client.admin_backend == "dynamo"
+    assert config.orchestrator.client.admin_base_url == ["http://localhost:8081"]
+    assert config.orchestrator.client.skip_model_check is True
+    assert all("return_token_ids" not in env.sampling.extra_body for env in config.orchestrator.train.env)
+
+
 def test_rl_config_selects_sglang_nccl_trainer_backend():
     config = RLConfig.model_validate(
         {

--- a/uv.lock
+++ b/uv.lock
@@ -11,38 +11,40 @@ supported-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-02T18:28:04.946859534Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-vllm = false
 verifiers = false
-vllm-router = false
 dion = false
 alphabet-sort = false
 science-env = false
-color-codeword = false
-nixl-cu12 = false
-flash-attn-3 = false
-prime-tunnel = false
-prime = false
-deep-gemm = false
-aime2024 = false
 prime-evals = false
 deepdive = false
 reverse-text = false
+ai-dynamo-runtime = false
 sglang = false
 code-env = false
 mini-swe-agent-plus = false
 deep-ep = false
 pydantic-config = false
-math-env = false
-logic-env = false
+ai-dynamo = false
 wiki-search = false
 math-python = false
 math500 = false
 aime2025 = false
+vllm = false
+vllm-router = false
+color-codeword = false
+nixl-cu12 = false
+flash-attn-3 = false
+prime-tunnel = false
+deep-gemm = false
+aime2024 = false
+math-env = false
 prime-sandboxes = false
+logic-env = false
+prime = false
 
 [manifest]
 members = [
@@ -62,6 +64,36 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/10/2a/c93173ffa1b39c1d0395b7e842bbdc62e556ca9d8d3b5572926f3e4ca752/absl_py-2.3.1.tar.gz", hash = "sha256:a97820526f7fbfd2ec1bce83f3f25e3a14840dac0d8e02a0b71cd75db3f77fc9", size = 116588, upload-time = "2025-07-03T09:31:44.05Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8f/aa/ba0014cc4659328dc818a28827be78e6d97312ab0cb98105a770924dc11e/absl_py-2.3.1-py3-none-any.whl", hash = "sha256:eeecf07f0c2a93ace0772c92e596ace6d3d3996c042b2128459aaae2a76de11d", size = 135811, upload-time = "2025-07-03T09:31:42.253Z" },
+]
+
+[[package]]
+name = "ai-dynamo"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ai-dynamo-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "kubernetes", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "msgpack", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "msgspec", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "prometheus-client", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pyzmq", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "transformers", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/7d/b99564ff88262e8ba377bb592c17ba84db9ae1b4993cbdeb532484dc034e/ai_dynamo-1.1.1-py3-none-any.whl", hash = "sha256:fd6a811a6d5ef36537a5f32af88dda722c0cf6b7c4f3e31a7671e1e59dc36777", size = 1762603, upload-time = "2026-05-09T02:43:51.382Z" },
+]
+
+[[package]]
+name = "ai-dynamo-runtime"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "uvloop", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/e2/47cc654088fc4b17f53fbf147020ca497afb9fdd3955997d667c285ba1bb/ai_dynamo_runtime-1.1.1-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2c96c93195c87be5377f42e99151536cde9629bf7e8d5af8574d30e9fbcb8bb3", size = 34753711, upload-time = "2026-05-09T02:41:45.993Z" },
+    { url = "https://files.pythonhosted.org/packages/00/68/acfdb9d6b0b9a4d25f991bae781992893b845fcd0981907189fbb27aa81b/ai_dynamo_runtime-1.1.1-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a7378079c81f2d81ca3363345111f04d9292aa158271b23e0236670f501e2b1d", size = 35042939, upload-time = "2026-05-09T02:40:41.554Z" },
 ]
 
 [[package]]
@@ -1139,6 +1171,19 @@ wheels = [
 ]
 
 [[package]]
+name = "google-auth"
+version = "2.50.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pyasn1-modules", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/18/238d7021d151bdab868f23433817b027dd759135202f4dfce0670d1230ca/google_auth-2.50.0.tar.gz", hash = "sha256:f35eafb191195328e8ce10a7883970877e7aeb49c2bfaa54aa0e394316d353d0", size = 336523, upload-time = "2026-04-30T21:19:29.659Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/cf/4880c2137c14280b2f59975cdf12cc442bc0ae1f9ea473a26eaa0c146786/google_auth-2.50.0-py3-none-any.whl", hash = "sha256:04382175e28b94f49694977f0a792688b59a668def1499e9d8de996dc9ce5b15", size = 246495, upload-time = "2026-04-30T21:19:27.664Z" },
+]
+
+[[package]]
 name = "googleapis-common-protos"
 version = "1.72.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1589,11 +1634,13 @@ wheels = [
 
 [[package]]
 name = "kubernetes"
-version = "35.0.0"
+version = "32.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "durationpy", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "google-auth", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "oauthlib", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "python-dateutil", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pyyaml", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "requests", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -1602,9 +1649,9 @@ dependencies = [
     { name = "urllib3", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "websocket-client", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/8f/85bf51ad4150f64e8c665daf0d9dfe9787ae92005efb9a4d1cba592bd79d/kubernetes-35.0.0.tar.gz", hash = "sha256:3d00d344944239821458b9efd484d6df9f011da367ecb155dadf9513f05f09ee", size = 1094642, upload-time = "2026-01-16T01:05:27.76Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/e8/0598f0e8b4af37cd9b10d8b87386cf3173cb8045d834ab5f6ec347a758b3/kubernetes-32.0.1.tar.gz", hash = "sha256:42f43d49abd437ada79a79a16bd48a604d3471a117a8347e87db693f2ba0ba28", size = 946691, upload-time = "2025-02-18T21:06:34.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/70/05b685ea2dffcb2adbf3cdcea5d8865b7bc66f67249084cf845012a0ff13/kubernetes-35.0.0-py2.py3-none-any.whl", hash = "sha256:39e2b33b46e5834ef6c3985ebfe2047ab39135d41de51ce7641a7ca5b372a13d", size = 2017602, upload-time = "2026-01-16T01:05:25.991Z" },
+    { url = "https://files.pythonhosted.org/packages/08/10/9f8af3e6f569685ce3af7faab51c8dd9d93b9c38eba339ca31c746119447/kubernetes-32.0.1-py2.py3-none-any.whl", hash = "sha256:35282ab8493b938b08ab5526c7ce66588232df00ef5e1dbe88a419107dc10998", size = 1988070, upload-time = "2025-02-18T21:06:31.391Z" },
 ]
 
 [[package]]
@@ -2751,8 +2798,10 @@ name = "prime-rl"
 version = "0.4.0"
 source = { editable = "." }
 dependencies = [
+    { name = "ai-dynamo", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "aiolimiter", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "beartype", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "blake3", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "datasets", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "dion", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "flash-linear-attention", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -2849,11 +2898,13 @@ mamba-ssm = [
 
 [package.metadata]
 requires-dist = [
+    { name = "ai-dynamo", specifier = "==1.1.1" },
     { name = "aime2024", marker = "extra == 'envs'", index = "https://hub.primeintellect.ai/primeintellect/simple/" },
     { name = "aime2025", marker = "extra == 'envs'", index = "https://hub.primeintellect.ai/primeintellect/simple/" },
     { name = "aiolimiter", specifier = ">=1.2.1" },
     { name = "alphabet-sort", marker = "extra == 'envs'", index = "https://hub.primeintellect.ai/primeintellect/simple/" },
     { name = "beartype", specifier = ">=0.21.0" },
+    { name = "blake3", specifier = ">=1.0.0,<2.0.0" },
     { name = "code-env", marker = "extra == 'envs'", index = "https://hub.primeintellect.ai/primeintellect/simple/" },
     { name = "color-codeword", marker = "extra == 'envs'", index = "https://hub.primeintellect.ai/primeintellect/simple/" },
     { name = "datasets", specifier = ">=4.0.0" },
@@ -2975,11 +3026,11 @@ wheels = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.22.1"
+version = "0.25.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/cf/40dde0a2be27cc1eb41e333d1a674a74ce8b8b0457269cc640fd42b07cf7/prometheus_client-0.22.1.tar.gz", hash = "sha256:190f1331e783cf21eb60bca559354e0a4d4378facecf78f5428c39b675d20d28", size = 69746, upload-time = "2025-06-02T14:29:01.152Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/ae/ec06af4fe3ee72d16973474f122541746196aaa16cea6f66d18b963c6177/prometheus_client-0.22.1-py3-none-any.whl", hash = "sha256:cca895342e308174341b2cbf99a56bef291fbc0ef7b9e5412a0f26d653ba7094", size = 58694, upload-time = "2025-06-02T14:29:00.068Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
 ]
 
 [[package]]
@@ -3078,6 +3129,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ad/90/2660332eeb31303c13b653ea566a9918484b6e4d6b9d2d46879a33ab0622/pyarrow-21.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:b7ae0bbdc8c6674259b25bef5d2a1d6af5d39d7200c819cf99e07f7dfef1c51e", size = 42829529, upload-time = "2025-07-18T00:55:47.069Z" },
     { url = "https://files.pythonhosted.org/packages/33/27/1a93a25c92717f6aa0fca06eb4700860577d016cd3ae51aad0e0488ac899/pyarrow-21.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:58c30a1729f82d201627c173d91bd431db88ea74dcaa3885855bc6203e433b82", size = 43367883, upload-time = "2025-07-18T00:55:53.069Z" },
     { url = "https://files.pythonhosted.org/packages/05/d9/4d09d919f35d599bc05c6950095e358c3e15148ead26292dfca1fb659b0c/pyarrow-21.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:072116f65604b822a7f22945a7a6e581cfa28e3454fdcc6939d4ff6090126623", size = 45133802, upload-time = "2025-07-18T00:55:57.714Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds a `dynamo` inference backend alongside vLLM and SGLang, backed by Dynamo's vLLM worker.
- Launches a Dynamo frontend, Dynamo vLLM worker, and prime-rl HTTP proxy that preserves the OpenAI-compatible chat completions surface expected by rollout clients.
- Wires Dynamo admin routes for liveness, NCCL broadcaster init, full-weight updates, pause/resume, and route readiness.
- Adds config translation, RL auto-setup defaults, dependency pins, focused config coverage, and updates the relevant skills docs.

## Validation

- `uv run ruff check packages/prime-rl-configs/src/prime_rl/configs/inference.py packages/prime-rl-configs/src/prime_rl/configs/rl.py packages/prime-rl-configs/src/prime_rl/configs/shared.py src/prime_rl/inference/dynamo src/prime_rl/inference/server.py src/prime_rl/entrypoints/inference.py src/prime_rl/utils/client.py tests/unit/test_configs.py`
- `uv run pytest tests/unit/test_configs.py -q` (`81 passed, 46 warnings`)
- Dry-run config resolution for both backends with the Qwen4B/Hendrycks/AIME25 comparison config:
  - `uv run rl @ /tmp/prime-rl-hendrycks-aime25-bs64.toml --dry-run --inference.backend vllm --wandb.name dryrun-vllm-qwen4b-aime25-500-bs64 --output-dir /tmp/prime-rl-vllm-qwen4b-aime25-500-bs64-dryrun`
  - `uv run rl @ /tmp/prime-rl-hendrycks-aime25-bs64.toml --dry-run --inference.backend dynamo --wandb.name dryrun-dynamo-qwen4b-aime25-500-bs64 --output-dir /tmp/prime-rl-dynamo-qwen4b-aime25-500-bs64-dryrun`
- Online W&B 500-step comparison using the referenced Qwen4B Hendrycks Math config shape, adapted to `max_steps=500`, `batch_size=64`, `max_inflight_rollouts=64`, `rollouts_per_example=4`, and AIME2025 eval with 30 examples x 4 rollouts:
  - vLLM: https://wandb.ai/primeintellect/hendrycks-math-qwen4b/runs/3438d550c9324d1b92229b601e9c87b0
  - Dynamo: https://wandb.ai/primeintellect/hendrycks-math-qwen4b/runs/775b7b96d2c245b8b931ca980c6c37c0
- AIME2025 evals (`Avg@4 / Pass@4`):
  - step 100: vLLM `0.0333 / 0.0667`, Dynamo `0.0667 / 0.1000`
  - step 200: vLLM `0.0667 / 0.1000`, Dynamo `0.0583 / 0.1000`
  - step 300: vLLM `0.0833 / 0.1333`, Dynamo `0.0833 / 0.1333`
  - step 400: vLLM `0.0667 / 0.1333`, Dynamo `0.0917 / 0.1000`
  - final after step 499 (`max_steps=500`): vLLM `0.1333 / 0.2333`, Dynamo `0.1167 / 0.1667`
- Final eval details:
  - vLLM: `Evaluated aime2025 in 12.19s (Avg@4=0.1333, Pass@1=0.1333, Pass@2=0.1889, Pass@4=0.2333, No-response: 0.0%, Completion Length: 982.02, Truncated: 85.0%)`
  - Dynamo: `Evaluated aime2025 in 13.31s (Avg@4=0.1167, Pass@1=0.1167, Pass@2=0.1444, Pass@4=0.1667, No-response: 0.0%, Completion Length: 968.05, Truncated: 81.7%)`
- Both runs ended with `RL training finished!` and `Orchestrator finished.`; no matching vLLM/Dynamo run processes remained afterward.

Note: Dynamo/vLLM logs an `EngineDeadError` during process termination after the RL job sends SIGTERM at shutdown; the final eval, orchestrator shutdown, trainer exit, and W&B sync had already completed successfully.