### PR TITLE
Fix: add layerwise as default

### DIFF
--- a/src/prime_rl/inference/vllm/worker/filesystem.py
+++ b/src/prime_rl/inference/vllm/worker/filesystem.py
@@ -2,7 +2,8 @@ from typing import TYPE_CHECKING
 
 from torch.nn import Module
 from vllm.model_executor.model_loader import DefaultModelLoader, get_model_loader
-from vllm.model_executor.model_loader.utils import process_weights_after_loading
+
+from prime_rl.inference.vllm.worker.weight_transfer import load_weights_checkpoint_layerwise
 
 # This is to get type hints for the Worker class but not actually extend it at runtime as this is required by vLLM worker extension
 if TYPE_CHECKING:
@@ -46,8 +47,9 @@ class FileSystemWeightUpdateWorker(Worker):
             allow_patterns_overrides=getattr(model, "allow_patterns_overrides", None),
         )
         weights_iterator = model_loader._get_weights_iterator(local_source)
-        model.load_weights(weights_iterator)  # type: ignore
-
-        # Process weights after loading (important for some models)
-        device = next(model.parameters()).device
-        process_weights_after_loading(model, self.model_runner.model_config, device)
+        load_weights_checkpoint_layerwise(
+            model,
+            weights_iterator,
+            self.model_runner.model_config,
+            self.vllm_config,
+        )

--- a/src/prime_rl/inference/vllm/worker/nccl.py
+++ b/src/prime_rl/inference/vllm/worker/nccl.py
@@ -10,7 +10,7 @@ from vllm.logger import init_logger
 from prime_rl.inference.vllm.worker.weight_transfer import (
     load_weights_checkpoint_layerwise,
     load_weights_kernel,
-    postprocess_weights_kernel,
+    update_mla_absorbed_weights,
 )
 from prime_rl.utils.nccl import disable_nccl_p2p_if_unavailable
 
@@ -144,9 +144,8 @@ class NCCLWeightUpdateWorker(Worker):
 
         state_iter = self.nccl_broadcast_receiver.receive_state_dict()
         if self.quantize_in_weight_transfer:
-            device = next(model.parameters()).device
             load_weights_kernel(model, state_iter)
-            postprocess_weights_kernel(model, self.model_runner.model_config, device)
+            update_mla_absorbed_weights(model)
             return
 
         load_weights_checkpoint_layerwise(

--- a/src/prime_rl/inference/vllm/worker/nccl.py
+++ b/src/prime_rl/inference/vllm/worker/nccl.py
@@ -1,5 +1,5 @@
 import pickle
-from typing import TYPE_CHECKING, Callable, Generator, cast
+from typing import TYPE_CHECKING, Generator, cast
 
 import torch
 from torch.nn import Module
@@ -8,9 +8,8 @@ from vllm.distributed.utils import StatelessProcessGroup
 from vllm.logger import init_logger
 
 from prime_rl.inference.vllm.worker.weight_transfer import (
-    load_weights_checkpoint,
+    load_weights_checkpoint_layerwise,
     load_weights_kernel,
-    postprocess_weights_checkpoint,
     postprocess_weights_kernel,
 )
 from prime_rl.utils.nccl import disable_nccl_p2p_if_unavailable
@@ -144,15 +143,15 @@ class NCCLWeightUpdateWorker(Worker):
         assert isinstance(model, Module)
 
         state_iter = self.nccl_broadcast_receiver.receive_state_dict()
-        device = next(model.parameters()).device
-        loader_fn: Callable[[Module, Generator[tuple[str, torch.Tensor], None, None]], None]
-        postprocess_fn: Callable[[Module, object, torch.device], None]
         if self.quantize_in_weight_transfer:
-            loader_fn = load_weights_kernel
-            postprocess_fn = postprocess_weights_kernel
-        else:
-            loader_fn = load_weights_checkpoint
-            postprocess_fn = postprocess_weights_checkpoint
+            device = next(model.parameters()).device
+            load_weights_kernel(model, state_iter)
+            postprocess_weights_kernel(model, self.model_runner.model_config, device)
+            return
 
-        loader_fn(model, state_iter)
-        postprocess_fn(model, self.model_runner.model_config, device)
+        load_weights_checkpoint_layerwise(
+            model,
+            state_iter,
+            self.model_runner.model_config,
+            self.vllm_config,
+        )

--- a/src/prime_rl/inference/vllm/worker/weight_transfer.py
+++ b/src/prime_rl/inference/vllm/worker/weight_transfer.py
@@ -1,8 +1,10 @@
-from typing import Generator
+from typing import Generator, Iterable
 
 import torch
 from torch.nn import Module
+from vllm.config import set_current_vllm_config
 from vllm.logger import init_logger
+from vllm.model_executor.model_loader.reload import finalize_layerwise_reload, initialize_layerwise_reload
 from vllm.model_executor.model_loader.utils import process_weights_after_loading
 
 logger = init_logger("vllm.inference.vllm.worker_weight_transfer")
@@ -14,6 +16,20 @@ def load_weights_checkpoint(model: Module, state_iter: Generator[tuple[str, torc
 
 def postprocess_weights_checkpoint(model: Module, model_config, device: torch.device) -> None:
     process_weights_after_loading(model, model_config, device)
+
+
+def load_weights_checkpoint_layerwise(
+    model: Module,
+    state_iter: Iterable[tuple[str, torch.Tensor]],
+    model_config,
+    vllm_config,
+) -> None:
+    logger.info("Reloading checkpoint-format weights with vLLM layerwise processing")
+    device = next(model.parameters()).device
+    with torch.device(device), set_current_vllm_config(vllm_config):
+        initialize_layerwise_reload(model)
+        model.load_weights(state_iter)  # type: ignore
+        finalize_layerwise_reload(model, model_config)
 
 
 def _invert_logical_to_physical_map(logical_to_physical_map: torch.Tensor, num_physical_experts: int) -> torch.Tensor:

--- a/src/prime_rl/inference/vllm/worker/weight_transfer.py
+++ b/src/prime_rl/inference/vllm/worker/weight_transfer.py
@@ -5,17 +5,8 @@ from torch.nn import Module
 from vllm.config import set_current_vllm_config
 from vllm.logger import init_logger
 from vllm.model_executor.model_loader.reload import finalize_layerwise_reload, initialize_layerwise_reload
-from vllm.model_executor.model_loader.utils import process_weights_after_loading
 
 logger = init_logger("vllm.inference.vllm.worker_weight_transfer")
-
-
-def load_weights_checkpoint(model: Module, state_iter: Generator[tuple[str, torch.Tensor], None, None]) -> None:
-    model.load_weights(state_iter)  # type: ignore
-
-
-def postprocess_weights_checkpoint(model: Module, model_config, device: torch.device) -> None:
-    process_weights_after_loading(model, model_config, device)
 
 
 def load_weights_checkpoint_layerwise(
@@ -159,7 +150,3 @@ def update_mla_absorbed_weights(model: Module) -> None:
             module.W_UK_T.copy_(w_uk.permute(1, 2, 0))
 
         logger.debug(f"Updated MLA absorbed weights for module {name}")
-
-
-def postprocess_weights_kernel(model: Module, _model_config, _device: torch.device) -> None:
-    update_mla_absorbed_weights(model)


### PR DESCRIPTION
Fixes broken nccl weight transfer on vllm 0.20

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the hot weight-reload path for both filesystem and NCCL updates to use vLLM's layerwise reload APIs, which can affect runtime model correctness and stability during in-place updates. Risk is mitigated by keeping the kernel-format path intact and adding explicit MLA absorbed-weight recomputation for that path.
> 
> **Overview**
> Switches checkpoint-format weight updates (filesystem and NCCL) to a new `load_weights_checkpoint_layerwise` flow that wraps `model.load_weights(...)` with vLLM `initialize_layerwise_reload`/`finalize_layerwise_reload` and `set_current_vllm_config`, replacing the prior `process_weights_after_loading` postprocessing.
> 
> For NCCL *kernel-format* transfers, removes the old generic postprocess step and instead explicitly calls `update_mla_absorbed_weights` after `load_weights_kernel`, then returns early.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25f17df792fe7c5d2ac22f37457e4ad08f0cab68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->