### PR TITLE
Support routed experts replay for vLLM P/D

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,4 +200,5 @@ debug_I2_zero_band
 
 outputs/
 
-third_party/
+deps/
+third_party

--- a/.gitignore
+++ b/.gitignore
@@ -200,5 +200,4 @@ debug_I2_zero_band
 
 outputs/
 
-deps/
-third_party
+third_party/

--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -402,6 +402,14 @@ class InferenceConfig(BaseConfig):
         ),
     ] = False
 
+    routed_experts_replay_max_blocks: Annotated[
+        int,
+        Field(
+            ge=1,
+            description="Maximum number of KV-cache-sized routing blocks to keep in vLLM's routed-experts replay LRU cache. Passed to vLLM as `--routed-experts-replay-max-blocks`.",
+        ),
+    ] = 4096
+
     enable_fp32_lm_head: Annotated[
         bool,
         Field(
@@ -551,6 +559,7 @@ class InferenceConfig(BaseConfig):
             "gpu_memory_utilization": "gpu_memory_utilization",
             "api_server_count": "api_server_count",
             "enable_return_routed_experts": "enable_return_routed_experts",
+            "routed_experts_replay_max_blocks": "routed_experts_replay_max_blocks",
             "enable_expert_parallel": "enable_expert_parallel",
             "all2all_backend": "all2all_backend",
             "enable_eplb": "enable_eplb",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,7 +166,7 @@ prime-rl-configs = { workspace = true }
 torch = { index = "pytorch-cu128" }
 torchvision = { index = "pytorch-cu128" }
 torchaudio = { index = "pytorch-cu128" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "0c6fcff" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "162cffb" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eeb" }
 transformers = { git = "https://github.com/huggingface/transformers.git", rev = "c1c3424" }
@@ -176,7 +176,7 @@ pydantic-config = { git = "https://github.com/samsja/pydantic_config.git", branc
 vllm-router = { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.22/vllm_router-0.1.22-cp38-abi3-manylinux_2_28_x86_64.whl" }
 vllm = [
     { url = "https://github.com/vllm-project/vllm/releases/download/v0.20.2/vllm-0.20.2+cu129-cp38-abi3-manylinux_2_31_aarch64.whl", marker = "platform_machine == 'aarch64'" },
-    { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev213%2Bgcff9b14e3.precompiled-cp312-cp312-linux_x86_64.whl", marker = "platform_machine == 'x86_64'" },
+    { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev214%2Bg24c0208fc.precompiled-cp312-cp312-linux_x86_64.whl", marker = "platform_machine == 'x86_64'" },
 ]
 reverse-text = { index = "primeintellect" }
 alphabet-sort = { index = "primeintellect" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ override-dependencies = [
 [tool.uv.exclude-newer-package]
 # we want latest vllm, remove next patch
 vllm = false
+mistral-common = false
 flash_attn_3 = false
 # Self-vendored packages on our primeintellect index
 reverse-text = false
@@ -166,16 +167,18 @@ prime-rl-configs = { workspace = true }
 torch = { index = "pytorch-cu128" }
 torchvision = { index = "pytorch-cu128" }
 torchaudio = { index = "pytorch-cu128" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "aa428f3" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "8dbd674" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eeb" }
 transformers = { git = "https://github.com/huggingface/transformers.git", rev = "c1c3424" }
 flash-attn-4 = { git = "https://github.com/Dao-AILab/flash-attention.git", subdirectory = "flash_attn/cute", rev = "96bd151" }
 pydantic-config = { git = "https://github.com/samsja/pydantic_config.git", branch = "main" }
+# P/D routed experts rely on PrimeIntellect-ai/router#28; keep the old router
+# wheel until a new vllm-router build with that change is published.
 vllm-router = { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.22/vllm_router-0.1.22-cp38-abi3-manylinux_2_28_x86_64.whl" }
 vllm = [
-    { url = "https://github.com/vllm-project/vllm/releases/download/v0.20.2/vllm-0.20.2+cu129-cp38-abi3-manylinux_2_31_x86_64.whl", marker = "platform_machine == 'x86_64'" },
     { url = "https://github.com/vllm-project/vllm/releases/download/v0.20.2/vllm-0.20.2+cu129-cp38-abi3-manylinux_2_31_aarch64.whl", marker = "platform_machine == 'aarch64'" },
+    { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev209%2Bga1c9051bc.precompiled-cp312-cp312-linux_x86_64.whl", marker = "platform_machine == 'x86_64'" },
 ]
 reverse-text = { index = "primeintellect" }
 alphabet-sort = { index = "primeintellect" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,13 +68,11 @@ envs = [
     "science-env",
     "logic-env",
     "color-codeword",
-    "wordle",
     "math500",
     "aime2024",
     "aime2025",
     "mini_swe_agent_plus",
-    "deepdive",
-    "rlm-swe",
+    "deepdive"
 ]
 disagg = [
     "deep-ep ; platform_machine == 'x86_64'",
@@ -132,7 +130,6 @@ override-dependencies = [
 [tool.uv.exclude-newer-package]
 # we want latest vllm, remove next patch
 vllm = false
-mistral-common = false
 flash_attn_3 = false
 # Self-vendored packages on our primeintellect index
 reverse-text = false
@@ -144,13 +141,11 @@ code-env = false
 science-env = false
 logic-env = false
 color-codeword = false
-wordle = false
 math500 = false
 aime2024 = false
 aime2025 = false
 deepdive = false
 mini_swe_agent_plus = false
-rlm-swe = false
 # PrimeIntellect-published on PyPI (trusted publisher)
 prime = false
 prime-sandboxes = false
@@ -171,17 +166,17 @@ prime-rl-configs = { workspace = true }
 torch = { index = "pytorch-cu128" }
 torchvision = { index = "pytorch-cu128" }
 torchaudio = { index = "pytorch-cu128" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "b76a6bb" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "0c6fcff" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eeb" }
 transformers = { git = "https://github.com/huggingface/transformers.git", rev = "c1c3424" }
 flash-attn-4 = { git = "https://github.com/Dao-AILab/flash-attention.git", subdirectory = "flash_attn/cute", rev = "96bd151" }
 pydantic-config = { git = "https://github.com/samsja/pydantic_config.git", branch = "main" }
-# P/D routed experts require PrimeIntellect-ai/router#28 (ca0de22).
-vllm-router = { path = "/beegfs/outputs/vllm-router-wheels/pr28-ca0de22/vllm_router-0.1.23-cp38-abi3-linux_x86_64.whl" }
+# TODO: update router wheel when ready.
+vllm-router = { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.22/vllm_router-0.1.22-cp38-abi3-manylinux_2_28_x86_64.whl" }
 vllm = [
     { url = "https://github.com/vllm-project/vllm/releases/download/v0.20.2/vllm-0.20.2+cu129-cp38-abi3-manylinux_2_31_aarch64.whl", marker = "platform_machine == 'aarch64'" },
-    { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev212%2Bgcba9775b5.precompiled-cp312-cp312-linux_x86_64.whl", marker = "platform_machine == 'x86_64'" },
+    { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev213%2Bgcff9b14e3.precompiled-cp312-cp312-linux_x86_64.whl", marker = "platform_machine == 'x86_64'" },
 ]
 reverse-text = { index = "primeintellect" }
 alphabet-sort = { index = "primeintellect" }
@@ -192,13 +187,11 @@ code-env = { index = "primeintellect" }
 science-env = { index = "primeintellect" }
 logic-env = { index = "primeintellect" }
 color-codeword = { index = "primeintellect" }
-wordle = { index = "primeintellect" }
 math500 = { index = "primeintellect" }
 aime2024 = { index = "primeintellect" }
 aime2025 = { index = "primeintellect" }
 deepdive = { index = "primeintellect" }
 mini_swe_agent_plus = { index = "primeintellect" }
-rlm-swe = { path = "/shared/research-prod/research-environments/environments/rlm_swe", editable = true }
 deep-ep = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_ep-1.2.1+29d31c0-cp312-cp312-linux_x86_64.whl" }
 deep-gemm = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_gemm-2.5.0+891d57b-cp312-cp312-linux_x86_64.whl" }
 nixl-cu12 = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/nixl_cu12-0.10.1-cp312-cp312-linux_x86_64.whl" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,11 +68,13 @@ envs = [
     "science-env",
     "logic-env",
     "color-codeword",
+    "wordle",
     "math500",
     "aime2024",
     "aime2025",
     "mini_swe_agent_plus",
-    "deepdive"
+    "deepdive",
+    "rlm-swe",
 ]
 disagg = [
     "deep-ep ; platform_machine == 'x86_64'",
@@ -142,11 +144,13 @@ code-env = false
 science-env = false
 logic-env = false
 color-codeword = false
+wordle = false
 math500 = false
 aime2024 = false
 aime2025 = false
 deepdive = false
 mini_swe_agent_plus = false
+rlm-swe = false
 # PrimeIntellect-published on PyPI (trusted publisher)
 prime = false
 prime-sandboxes = false
@@ -167,18 +171,17 @@ prime-rl-configs = { workspace = true }
 torch = { index = "pytorch-cu128" }
 torchvision = { index = "pytorch-cu128" }
 torchaudio = { index = "pytorch-cu128" }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "8dbd674" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", rev = "b76a6bb" }
 torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eeb" }
 transformers = { git = "https://github.com/huggingface/transformers.git", rev = "c1c3424" }
 flash-attn-4 = { git = "https://github.com/Dao-AILab/flash-attention.git", subdirectory = "flash_attn/cute", rev = "96bd151" }
 pydantic-config = { git = "https://github.com/samsja/pydantic_config.git", branch = "main" }
-# P/D routed experts rely on PrimeIntellect-ai/router#28; keep the old router
-# wheel until a new vllm-router build with that change is published.
-vllm-router = { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.22/vllm_router-0.1.22-cp38-abi3-manylinux_2_28_x86_64.whl" }
+# P/D routed experts require PrimeIntellect-ai/router#28 (ca0de22).
+vllm-router = { path = "/beegfs/outputs/vllm-router-wheels/pr28-ca0de22/vllm_router-0.1.23-cp38-abi3-linux_x86_64.whl" }
 vllm = [
     { url = "https://github.com/vllm-project/vllm/releases/download/v0.20.2/vllm-0.20.2+cu129-cp38-abi3-manylinux_2_31_aarch64.whl", marker = "platform_machine == 'aarch64'" },
-    { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev209%2Bga1c9051bc.precompiled-cp312-cp312-linux_x86_64.whl", marker = "platform_machine == 'x86_64'" },
+    { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev212%2Bgcba9775b5.precompiled-cp312-cp312-linux_x86_64.whl", marker = "platform_machine == 'x86_64'" },
 ]
 reverse-text = { index = "primeintellect" }
 alphabet-sort = { index = "primeintellect" }
@@ -189,11 +192,13 @@ code-env = { index = "primeintellect" }
 science-env = { index = "primeintellect" }
 logic-env = { index = "primeintellect" }
 color-codeword = { index = "primeintellect" }
+wordle = { index = "primeintellect" }
 math500 = { index = "primeintellect" }
 aime2024 = { index = "primeintellect" }
 aime2025 = { index = "primeintellect" }
 deepdive = { index = "primeintellect" }
 mini_swe_agent_plus = { index = "primeintellect" }
+rlm-swe = { path = "/shared/research-prod/research-environments/environments/rlm_swe", editable = true }
 deep-ep = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_ep-1.2.1+29d31c0-cp312-cp312-linux_x86_64.whl" }
 deep-gemm = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_gemm-2.5.0+891d57b-cp312-cp312-linux_x86_64.whl" }
 nixl-cu12 = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/nixl_cu12-0.10.1-cp312-cp312-linux_x86_64.whl" }

--- a/skills/config/SKILL.md
+++ b/skills/config/SKILL.md
@@ -71,7 +71,6 @@ CLI uses kebab-case (`--model.max-model-len`), TOML uses snake_case (`max_model_
 
 - **Fail early**: incompatible option combinations (e.g. CP requires flash attention, NCCL broadcast requires async level 1) should raise in `model_validator` at config resolution time, not at runtime. When adding new constraints, add a validator to the config class.
 - **Deprecation**: when renaming or removing config fields, emit a deprecation warning with a clear migration path (e.g. "field X is deprecated, use Y instead"). Do not silently drop fields — help users update their configs.
-- **Router replay**: `trainer.enable_router_replay` auto-enables `inference.enable_return_routed_experts`. Prefix caching may stay enabled when using the patched vLLM fork with routed-expert block replay; without that vLLM support, cached prefix tokens can miss routed experts and corrupt replay logprobs. Tune `inference.routed_experts_replay_max_blocks` when repeated prefixes exceed the default replay LRU size.
 
 ## Important patterns
 

--- a/skills/config/SKILL.md
+++ b/skills/config/SKILL.md
@@ -71,6 +71,7 @@ CLI uses kebab-case (`--model.max-model-len`), TOML uses snake_case (`max_model_
 
 - **Fail early**: incompatible option combinations (e.g. CP requires flash attention, NCCL broadcast requires async level 1) should raise in `model_validator` at config resolution time, not at runtime. When adding new constraints, add a validator to the config class.
 - **Deprecation**: when renaming or removing config fields, emit a deprecation warning with a clear migration path (e.g. "field X is deprecated, use Y instead"). Do not silently drop fields — help users update their configs.
+- **Router replay**: `trainer.enable_router_replay` auto-enables `inference.enable_return_routed_experts`. Prefix caching may stay enabled when using the patched vLLM fork with routed-expert block replay; without that vLLM support, cached prefix tokens can miss routed experts and corrupt replay logprobs. Tune `inference.routed_experts_replay_max_blocks` when repeated prefixes exceed the default replay LRU size.
 
 ## Important patterns
 

--- a/src/prime_rl/inference/vllm/serving_chat_with_tokens.py
+++ b/src/prime_rl/inference/vllm/serving_chat_with_tokens.py
@@ -1,4 +1,4 @@
-from collections.abc import AsyncGenerator, AsyncIterator
+from collections.abc import AsyncGenerator
 from typing import ClassVar, Optional, Union
 
 from fastapi import Request
@@ -14,20 +14,7 @@ from vllm.outputs import RequestOutput
 from vllm.reasoning import ReasoningParser
 from vllm.sampling_params import BeamSearchParams, SamplingParams
 
-from prime_rl.inference.vllm.serving_tokens import _RoutedExpertsCaptureBase
-
 logger = init_logger(__name__)
-
-
-class _RoutedExpertsCapture(_RoutedExpertsCaptureBase):
-    """Chat-endpoint variant: mutates choices in-place because
-    ``ChatCompletionResponseChoice`` is ``extra='allow'``, so an extra
-    ``routed_experts`` attribute survives serialization."""
-
-    def post_process(self, response: ChatCompletionResponse) -> None:
-        for choice in response.choices:
-            if choice.index in self.routed_experts:
-                choice.routed_experts = self.routed_experts[choice.index]
 
 
 class ChatCompletionRequestWithTokens(ChatCompletionRequest):
@@ -36,46 +23,7 @@ class ChatCompletionRequestWithTokens(ChatCompletionRequest):
 
 
 class OpenAIServingChatWithTokens(OpenAIServingChat):
-    """OpenAI-compatible generate API that allows token-in and routed experts capture."""
-
-    async def chat_completion_full_generator(
-        self,
-        request: ChatCompletionRequest,
-        result_generator: AsyncIterator[RequestOutput],
-        request_id: str,
-        model_name: str,
-        conversation,
-        tokenizer,
-        request_metadata: RequestResponseMetadata,
-        reasoning_parser: ReasoningParser | None = None,
-    ) -> ErrorResponse | ChatCompletionResponse:
-        # We need to override the full_generator to be able to capture the routed experts
-        # By default, VLLM does not save the routed experts into ChatCompletionResponse.choices, so we need to capture them manually
-        # How this works:
-        # 1. We create a custom generator that encapsulates the original result_generator in self._generator
-        # 2. We override it's __aiter__ method to also capture the routed experts as an extra field in ChatCompletionResponse.choices
-        # 3. We override the full_generator method to use the custom generator instead of the original one if expert routing is enabled
-        if self.model_config.enable_return_routed_experts:
-            capture = _RoutedExpertsCapture(result_generator)
-            result_generator = capture
-        else:
-            capture = None
-
-        response = await super().chat_completion_full_generator(
-            request,
-            result_generator,
-            request_id,
-            model_name,
-            conversation,
-            tokenizer,
-            request_metadata,
-            reasoning_parser,
-        )
-
-        if capture and isinstance(response, ChatCompletionResponse):
-            capture.post_process(response)
-
-        return response
+    """OpenAI-compatible chat API that allows token-in requests."""
 
     async def create_chat_completion_with_tokens(
         self,

--- a/src/prime_rl/inference/vllm/serving_tokens.py
+++ b/src/prime_rl/inference/vllm/serving_tokens.py
@@ -12,8 +12,8 @@ we subclass it to add them back:
 
 2. ``prompt_routed_experts`` and choice ``routed_experts`` export — when the
    engine emits routing decisions (``enable_return_routed_experts``), surface
-   the prompt and completion routing as JSON arrays. This is what the trainer's
-   router-replay path consumes.
+   the prompt and completion routing. This is what the trainer's router-replay
+   path consumes.
 
 3. Server-side ``max_tokens`` defaulting — ``ServingTokens`` hands the
    client-supplied ``SamplingParams`` to the engine verbatim, and
@@ -36,8 +36,9 @@ from functools import cached_property
 from typing import cast
 
 import numpy as np
+import pybase64 as base64
 from fastapi import Request
-from pydantic import Field
+from pydantic import BaseModel, Field
 from vllm.entrypoints.openai.engine.protocol import ErrorResponse, RequestResponseMetadata
 from vllm.entrypoints.serve.disagg.protocol import (
     GenerateRequest,
@@ -50,8 +51,18 @@ from vllm.outputs import RequestOutput
 from vllm.sampling_params import RequestOutputKind, SamplingParams
 
 
+class RoutedExpertsBytes(BaseModel):
+    encoding: str = "base64"
+    dtype: str = "int16"
+    shape: list[int]
+    data: str
+
+
+RoutedExpertsResponsePayload = list[list[list[int]]] | RoutedExpertsBytes
+
+
 class PrimeRlGenerateResponseChoice(GenerateResponseChoice):
-    routed_experts: list[list[list[int]]] | None = Field(
+    routed_experts: RoutedExpertsResponsePayload | None = Field(
         default=None,
         description=(
             "Per-completion-token expert routing decisions. Populated only "
@@ -63,7 +74,7 @@ class PrimeRlGenerateResponseChoice(GenerateResponseChoice):
 
 class PrimeRlGenerateResponse(GenerateResponse):
     choices: list[PrimeRlGenerateResponseChoice]
-    prompt_routed_experts: list[list[list[int]]] | None = Field(
+    prompt_routed_experts: RoutedExpertsResponsePayload | None = Field(
         default=None,
         description=(
             "Per-prompt-token expert routing decisions. Populated only when "
@@ -73,24 +84,46 @@ class PrimeRlGenerateResponse(GenerateResponse):
     )
 
 
-def _serialize_routed_experts(arr: np.ndarray) -> list[list[list[int]]]:
-    _seq_len, _num_layers, _topk = arr.shape
-    return cast(list[list[list[int]]], arr.tolist())
+def _get_routed_experts_encoding(request: GenerateRequest) -> str:
+    extra_args = request.sampling_params.extra_args or {}
+    encoding = extra_args.get("routed_experts_encoding", "json")
+    assert encoding in ("json", "base64")
+    return str(encoding)
+
+
+def _serialize_routed_experts(
+    arr: np.ndarray,
+    encoding: str,
+) -> RoutedExpertsResponsePayload:
+    if encoding == "json":
+        return cast(list[list[list[int]]], arr.tolist())
+    data = arr.data if arr.flags.c_contiguous else arr.tobytes()
+    return RoutedExpertsBytes(
+        shape=list(arr.shape),
+        data=base64.b64encode(data).decode("ascii"),
+    )
 
 
 class _RoutedExpertsCapture:
-    def __init__(self, generator: AsyncGenerator[RequestOutput, None]):
+    def __init__(self, generator: AsyncGenerator[RequestOutput, None], encoding: str):
         self._generator = generator
-        self.prompt_routed_experts: list[list[list[int]]] | None = None
-        self.routed_experts: dict[int, list[list[list[int]]]] = {}
+        self._encoding = encoding
+        self.prompt_routed_experts: RoutedExpertsResponsePayload | None = None
+        self.routed_experts: dict[int, RoutedExpertsResponsePayload] = {}
 
     async def __aiter__(self) -> AsyncGenerator[RequestOutput, None]:
         async for request_output in self._generator:
             if request_output.prompt_routed_experts is not None:
-                self.prompt_routed_experts = _serialize_routed_experts(request_output.prompt_routed_experts)
+                self.prompt_routed_experts = _serialize_routed_experts(
+                    request_output.prompt_routed_experts,
+                    self._encoding,
+                )
             for output in request_output.outputs:
                 if output.routed_experts is not None:
-                    self.routed_experts[output.index] = _serialize_routed_experts(output.routed_experts)
+                    self.routed_experts[output.index] = _serialize_routed_experts(
+                        output.routed_experts,
+                        self._encoding,
+                    )
             yield request_output
 
     def post_process(self, response: GenerateResponse) -> PrimeRlGenerateResponse:
@@ -285,7 +318,10 @@ class PrimeRlServingTokens(ServingTokens):
     ) -> ErrorResponse | GenerateResponse:
         capture: _RoutedExpertsCapture | None = None
         if self.model_config.enable_return_routed_experts:
-            capture = _RoutedExpertsCapture(result_generator)
+            capture = _RoutedExpertsCapture(
+                result_generator,
+                _get_routed_experts_encoding(request),
+            )
             result_generator = capture  # type: ignore[assignment]
 
         response = await super().serve_tokens_full_generator(

--- a/src/prime_rl/inference/vllm/serving_tokens.py
+++ b/src/prime_rl/inference/vllm/serving_tokens.py
@@ -33,7 +33,6 @@ from __future__ import annotations
 
 from collections.abc import AsyncGenerator
 from functools import cached_property
-from typing import cast
 
 import numpy as np
 import pybase64 as base64
@@ -58,7 +57,7 @@ class RoutedExpertsBytes(BaseModel):
     data: str
 
 
-RoutedExpertsResponsePayload = list[list[list[int]]] | RoutedExpertsBytes
+RoutedExpertsResponsePayload = RoutedExpertsBytes
 
 
 class PrimeRlGenerateResponseChoice(GenerateResponseChoice):
@@ -84,19 +83,7 @@ class PrimeRlGenerateResponse(GenerateResponse):
     )
 
 
-def _get_routed_experts_encoding(request: GenerateRequest) -> str:
-    extra_args = request.sampling_params.extra_args or {}
-    encoding = extra_args.get("routed_experts_encoding", "json")
-    assert encoding in ("json", "base64")
-    return str(encoding)
-
-
-def _serialize_routed_experts(
-    arr: np.ndarray,
-    encoding: str,
-) -> RoutedExpertsResponsePayload:
-    if encoding == "json":
-        return cast(list[list[list[int]]], arr.tolist())
+def _serialize_routed_experts(arr: np.ndarray) -> RoutedExpertsResponsePayload:
     data = arr.data if arr.flags.c_contiguous else arr.tobytes()
     return RoutedExpertsBytes(
         shape=list(arr.shape),
@@ -105,9 +92,8 @@ def _serialize_routed_experts(
 
 
 class _RoutedExpertsCapture:
-    def __init__(self, generator: AsyncGenerator[RequestOutput, None], encoding: str):
+    def __init__(self, generator: AsyncGenerator[RequestOutput, None]):
         self._generator = generator
-        self._encoding = encoding
         self.prompt_routed_experts: RoutedExpertsResponsePayload | None = None
         self.routed_experts: dict[int, RoutedExpertsResponsePayload] = {}
 
@@ -116,13 +102,11 @@ class _RoutedExpertsCapture:
             if request_output.prompt_routed_experts is not None:
                 self.prompt_routed_experts = _serialize_routed_experts(
                     request_output.prompt_routed_experts,
-                    self._encoding,
                 )
             for output in request_output.outputs:
                 if output.routed_experts is not None:
                     self.routed_experts[output.index] = _serialize_routed_experts(
                         output.routed_experts,
-                        self._encoding,
                     )
             yield request_output
 
@@ -318,10 +302,7 @@ class PrimeRlServingTokens(ServingTokens):
     ) -> ErrorResponse | GenerateResponse:
         capture: _RoutedExpertsCapture | None = None
         if self.model_config.enable_return_routed_experts:
-            capture = _RoutedExpertsCapture(
-                result_generator,
-                _get_routed_experts_encoding(request),
-            )
+            capture = _RoutedExpertsCapture(result_generator)
             result_generator = capture  # type: ignore[assignment]
 
         response = await super().serve_tokens_full_generator(

--- a/src/prime_rl/inference/vllm/serving_tokens.py
+++ b/src/prime_rl/inference/vllm/serving_tokens.py
@@ -10,9 +10,10 @@ we subclass it to add them back:
    header and forwarded to ``engine_client.generate``. The DP-replicated
    inference servers prime-RL runs need this to target a specific replica.
 
-2. ``routed_experts`` per-token export — when the engine emits routing
-   decisions (``enable_return_routed_experts``), surface them on each choice.
-   This is what the trainer's router-replay path consumes.
+2. ``prompt_routed_experts`` and choice ``routed_experts`` export — when the
+   engine emits routing decisions (``enable_return_routed_experts``), surface
+   the prompt and completion routing as JSON arrays. This is what the trainer's
+   router-replay path consumes.
 
 3. Server-side ``max_tokens`` defaulting — ``ServingTokens`` hands the
    client-supplied ``SamplingParams`` to the engine verbatim, and
@@ -30,9 +31,9 @@ delegates to upstream so we track future vLLM changes for free.
 
 from __future__ import annotations
 
-import base64
 from collections.abc import AsyncGenerator
 from functools import cached_property
+from typing import cast
 
 import numpy as np
 from fastapi import Request
@@ -50,11 +51,11 @@ from vllm.sampling_params import RequestOutputKind, SamplingParams
 
 
 class PrimeRlGenerateResponseChoice(GenerateResponseChoice):
-    routed_experts: dict | None = Field(
+    routed_experts: list[list[list[int]]] | None = Field(
         default=None,
         description=(
-            "Per-token expert routing decisions (base85-encoded int32 array + shape). "
-            "Populated only when the engine was launched with "
+            "Per-completion-token expert routing decisions. Populated only "
+            "when the engine was launched with "
             "``enable_return_routed_experts=True``; otherwise ``None``."
         ),
     )
@@ -62,51 +63,49 @@ class PrimeRlGenerateResponseChoice(GenerateResponseChoice):
 
 class PrimeRlGenerateResponse(GenerateResponse):
     choices: list[PrimeRlGenerateResponseChoice]
+    prompt_routed_experts: list[list[list[int]]] | None = Field(
+        default=None,
+        description=(
+            "Per-prompt-token expert routing decisions. Populated only when "
+            "the engine was launched with ``enable_return_routed_experts=True``; "
+            "otherwise ``None``."
+        ),
+    )
 
 
-def encode_routed_experts(arr: np.ndarray) -> dict:
-    return {
-        "data": base64.b85encode(arr.tobytes()).decode("ascii"),
-        "shape": list(arr.shape),
-    }
+def _serialize_routed_experts(arr: np.ndarray) -> list[list[list[int]]]:
+    _seq_len, _num_layers, _topk = arr.shape
+    return cast(list[list[list[int]]], arr.tolist())
 
 
-class _RoutedExpertsCaptureBase:
-    """Wraps the engine result generator and accumulates a
-    ``{output_index: encoded_experts}`` map as outputs stream. Subclasses
-    implement ``post_process`` to fold the captured map into the response
-    in whatever shape the endpoint returns (in-place vs rebuilt)."""
-
+class _RoutedExpertsCapture:
     def __init__(self, generator: AsyncGenerator[RequestOutput, None]):
         self._generator = generator
-        self.routed_experts: dict[int, dict] = {}
+        self.prompt_routed_experts: list[list[list[int]]] | None = None
+        self.routed_experts: dict[int, list[list[list[int]]]] = {}
 
-    async def __aiter__(self):
+    async def __aiter__(self) -> AsyncGenerator[RequestOutput, None]:
         async for request_output in self._generator:
+            if request_output.prompt_routed_experts is not None:
+                self.prompt_routed_experts = _serialize_routed_experts(request_output.prompt_routed_experts)
             for output in request_output.outputs:
                 if output.routed_experts is not None:
-                    self.routed_experts[output.index] = encode_routed_experts(output.routed_experts)
+                    self.routed_experts[output.index] = _serialize_routed_experts(output.routed_experts)
             yield request_output
 
-
-class _RoutedExpertsCapture(_RoutedExpertsCaptureBase):
-    """Generate-endpoint variant: rebuilds the response with
-    ``PrimeRlGenerateResponseChoice`` because upstream's
-    ``GenerateResponseChoice`` isn't ``extra='allow'``, so an attribute
-    set after construction wouldn't survive serialization."""
-
     def post_process(self, response: GenerateResponse) -> PrimeRlGenerateResponse:
-        new_choices = [
+        choices = [
             PrimeRlGenerateResponseChoice(
                 **choice.model_dump(),
-                routed_experts=self.routed_experts.get(choice.index),
+                routed_experts=(self.routed_experts[choice.index] if choice.index in self.routed_experts else None),
             )
             for choice in response.choices
         ]
         return PrimeRlGenerateResponse(
             request_id=response.request_id,
-            choices=new_choices,
+            choices=choices,
             prompt_logprobs=response.prompt_logprobs,
+            prompt_routed_experts=self.prompt_routed_experts,
             kv_transfer_params=response.kv_transfer_params,
         )
 
@@ -162,7 +161,7 @@ class PrimeRlServingTokens(ServingTokens):
         self,
         request: GenerateRequest,
         raw_request: Request | None = None,
-    ) -> PrimeRlGenerateResponse | ErrorResponse | AsyncGenerator[str, None]:
+    ) -> PrimeRlGenerateResponse | GenerateResponse | ErrorResponse | AsyncGenerator[str, None]:
         # Mirrors upstream ``ServingTokens.serve_tokens`` (vllm 0.20). Diffs:
         # (a) inject ``data_parallel_rank`` from the inbound header into
         # ``engine_client.generate``; (b) default ``sampling_params.max_tokens``
@@ -284,12 +283,6 @@ class PrimeRlServingTokens(ServingTokens):
         model_name: str,
         request_metadata: RequestResponseMetadata,
     ) -> ErrorResponse | GenerateResponse:
-        # Mirror serving_chat_with_tokens: wrap the result generator to capture
-        # routed_experts as it streams, defer the rest to upstream, then post-
-        # process the response into our PrimeRlGenerateResponse subclass so the
-        # encoded experts surface in the JSON. Skipping the wrapper when the
-        # engine isn't producing routed experts keeps us a no-op subclass on
-        # the common path.
         capture: _RoutedExpertsCapture | None = None
         if self.model_config.enable_return_routed_experts:
             capture = _RoutedExpertsCapture(result_generator)

--- a/src/prime_rl/inference/vllm_state.md
+++ b/src/prime_rl/inference/vllm_state.md
@@ -1,10 +1,10 @@
 # vLLM State
 
-Last updated: 2026-05-12
+Last updated: 2026-05-13
 
 prime-rl's routed-experts replay path requires a patched vLLM fork. This note
-records the vLLM PR state the prime-rl wheel pin expects, what the fork changes,
-and how the wheel was produced.
+records the vLLM PR state expected by the pinned wheel, the required fork
+behavior, and how the wheel was produced.
 
 ## Required vLLM
 
@@ -14,10 +14,11 @@ Use:
 repo: https://github.com/S1ro1/vllm.git
 pr: https://github.com/S1ro1/vllm/pull/3
 branch: feat/routed-experts-prefix-replay
-head: cba9775b5897a60f7b91c2eed6412dd2c32b1886
+head: cff9b14e3f28310128ddbacb708f7bf87768ea86
 ```
 
-The branch is based on upstream vLLM `main` at:
+The native objects in the pinned wheel are taken from the vLLM precompiled
+nightly for:
 
 ```text
 879a8c318032ed32716e5e0b10af355a4ddbced2
@@ -32,25 +33,25 @@ native/CUDA objects are taken from an already-built vLLM wheel:
 ```bash
 export VLLM_PRECOMPILED_WHEEL_COMMIT=nightly
 export VLLM_USE_PRECOMPILED=1
-uv build --wheel --out-dir dist
+uv build --python 3.12 --wheel --out-dir dist
 ```
 
 The resulting wheel was uploaded to the prime-rl `v0.5.0` release and pinned in
 `pyproject.toml` for x86_64 installs:
 
 ```text
-https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev212%2Bgcba9775b5.precompiled-cp312-cp312-linux_x86_64.whl
+https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev213%2Bgcff9b14e3.precompiled-cp312-cp312-linux_x86_64.whl
 ```
 
 SHA256:
 
 ```text
-3e625083ce0ed7ab2a941fdd84e34571ad35425890fba82196052405cc6acdc9
+5b594e78118d7e6d16adf63a6c8ac4cba059d9f8a1a37ec7e57bbbc70a7acbac
 ```
 
 ## Required Changes
 
-The fork must keep upstream routed-experts response support from
+The fork keeps upstream routed-experts response support from
 `vllm-project/vllm#39917`. prime-rl depends on vLLM returning prompt routing at
 the response level and completion routing on each generated choice.
 
@@ -59,23 +60,39 @@ prefill. Without this, cached prompt blocks can be missing their routed experts,
 which makes trainer-side replay either fail or compare against the wrong
 experts. The PR adds the replay cache and prefix-cache plumbing needed to
 reconstruct prompt routing for cached blocks, including the DPEP/GLM MoE-layer
-shape expected by the trainer. It also avoids extra routed replay prefill work
-on P/D decode requests, where decode uses external KV and should only emit
-completion routing.
+shape expected by the trainer.
 
-The fork also reverts upstream `vllm-project/vllm#39366` to keep NCCL weight
-transfer working. That upstream PR introduced a two-phase DP pause protocol that
+For P/D decode requests, the fork avoids extra routed replay prefill work. The
+decode side uses external KV and should only emit completion routing, while the
+paired prefill response supplies prompt routing.
+
+The fork reverts upstream `vllm-project/vllm#39366` to keep NCCL weight transfer
+working. That upstream PR introduced a two-phase DP pause protocol that
 conflicts with prime-rl's pause/resume flow during NCCL transfer. Keeping it
-reverted preserves the older pause behavior that prime-rl's DP pause/deadlock
-patch expects, so weight transfer can pause and resume generation reliably.
+reverted preserves the older pause behavior needed by prime-rl's DP
+pause/deadlock patch.
 
 The fork reduces routed-experts overhead in the capture and response path. It
-serializes engine-core routed experts as `(shape, bytes)` instead of nested
-Python lists, supports opt-in base64 HTTP routed-experts payloads via
-`vllm_xargs.routed_experts_encoding = "base64"`, grows per-request host buffers
-less aggressively during decode, avoids an extra device-to-device staging copy
-before routed-experts D2H, and only publishes replay-cache blocks when a block
-can newly become complete.
+serializes routed experts as compact `(shape, bytes)` payloads instead of nested
+Python lists, grows per-request host buffers less aggressively during decode,
+avoids an extra device-to-device staging copy before routed-experts D2H, and
+only publishes replay-cache blocks when a block can newly become complete.
+
+## HTTP Payload Contract
+
+Routed-experts HTTP responses use the compact payload only:
+
+```json
+{
+  "encoding": "base64",
+  "dtype": "int16",
+  "shape": [1, 1024, 75, 8],
+  "data": "..."
+}
+```
+
+The old nested-list routed-experts response format is not supported by this
+PR stack.
 
 ## prime-rl Contract
 

--- a/src/prime_rl/inference/vllm_state.md
+++ b/src/prime_rl/inference/vllm_state.md
@@ -14,7 +14,7 @@ Use:
 repo: https://github.com/S1ro1/vllm.git
 pr: https://github.com/S1ro1/vllm/pull/3
 branch: feat/routed-experts-prefix-replay
-head: a1c9051bc490be4200137735c4a806d22a184121
+head: cba9775b5897a60f7b91c2eed6412dd2c32b1886
 ```
 
 The branch is based on upstream vLLM `main` at:
@@ -31,7 +31,6 @@ native/CUDA objects are taken from an already-built vLLM wheel:
 
 ```bash
 export VLLM_PRECOMPILED_WHEEL_COMMIT=nightly
-export VLLM_PRECOMPILED_WHEEL_VARIANT=cu129
 export VLLM_USE_PRECOMPILED=1
 uv build --wheel --out-dir dist
 ```
@@ -40,13 +39,13 @@ The resulting wheel was uploaded to the prime-rl `v0.5.0` release and pinned in
 `pyproject.toml` for x86_64 installs:
 
 ```text
-https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev209%2Bga1c9051bc.precompiled-cp312-cp312-linux_x86_64.whl
+https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev212%2Bgcba9775b5.precompiled-cp312-cp312-linux_x86_64.whl
 ```
 
 SHA256:
 
 ```text
-9f9fd0f24f6c93082e2449c37d6fa3e18a8ced838e0831db7563f358776db1d2
+3e625083ce0ed7ab2a941fdd84e34571ad35425890fba82196052405cc6acdc9
 ```
 
 ## Required Changes
@@ -69,6 +68,14 @@ transfer working. That upstream PR introduced a two-phase DP pause protocol that
 conflicts with prime-rl's pause/resume flow during NCCL transfer. Keeping it
 reverted preserves the older pause behavior that prime-rl's DP pause/deadlock
 patch expects, so weight transfer can pause and resume generation reliably.
+
+The fork reduces routed-experts overhead in the capture and response path. It
+serializes engine-core routed experts as `(shape, bytes)` instead of nested
+Python lists, supports opt-in base64 HTTP routed-experts payloads via
+`vllm_xargs.routed_experts_encoding = "base64"`, grows per-request host buffers
+less aggressively during decode, avoids an extra device-to-device staging copy
+before routed-experts D2H, and only publishes replay-cache blocks when a block
+can newly become complete.
 
 ## prime-rl Contract
 

--- a/src/prime_rl/inference/vllm_state.md
+++ b/src/prime_rl/inference/vllm_state.md
@@ -14,7 +14,7 @@ Use:
 repo: https://github.com/S1ro1/vllm.git
 pr: https://github.com/S1ro1/vllm/pull/3
 branch: feat/routed-experts-prefix-replay
-head: cff9b14e3f28310128ddbacb708f7bf87768ea86
+head: 24c0208fc6ed488797c3401b3e7f87f3ea9b61a3
 ```
 
 The native objects in the pinned wheel are taken from the vLLM precompiled
@@ -40,13 +40,13 @@ The resulting wheel was uploaded to the prime-rl `v0.5.0` release and pinned in
 `pyproject.toml` for x86_64 installs:
 
 ```text
-https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev213%2Bgcff9b14e3.precompiled-cp312-cp312-linux_x86_64.whl
+https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev214%2Bg24c0208fc.precompiled-cp312-cp312-linux_x86_64.whl
 ```
 
 SHA256:
 
 ```text
-5b594e78118d7e6d16adf63a6c8ac4cba059d9f8a1a37ec7e57bbbc70a7acbac
+437a618dd32400d2636e17de266061aa6685001653e6b9a78751e3ae53036e51
 ```
 
 ## Required Changes

--- a/src/prime_rl/inference/vllm_state.md
+++ b/src/prime_rl/inference/vllm_state.md
@@ -1,0 +1,83 @@
+# vLLM State
+
+Last updated: 2026-05-12
+
+prime-rl's routed-experts replay path requires a patched vLLM fork. This note
+records the vLLM PR state the prime-rl wheel pin expects, what the fork changes,
+and how the wheel was produced.
+
+## Required vLLM
+
+Use:
+
+```text
+repo: https://github.com/S1ro1/vllm.git
+pr: https://github.com/S1ro1/vllm/pull/3
+branch: feat/routed-experts-prefix-replay
+head: a1c9051bc490be4200137735c4a806d22a184121
+```
+
+The branch is based on upstream vLLM `main` at:
+
+```text
+879a8c318032ed32716e5e0b10af355a4ddbced2
+```
+
+## Wheel Build
+
+The x86_64 wheel pinned by prime-rl was built from the fork PR head with
+vLLM's precompiled build path, so the Python changes come from the fork while
+native/CUDA objects are taken from an already-built vLLM wheel:
+
+```bash
+export VLLM_PRECOMPILED_WHEEL_COMMIT=nightly
+export VLLM_PRECOMPILED_WHEEL_VARIANT=cu129
+export VLLM_USE_PRECOMPILED=1
+uv build --wheel --out-dir dist
+```
+
+The resulting wheel was uploaded to the prime-rl `v0.5.0` release and pinned in
+`pyproject.toml` for x86_64 installs:
+
+```text
+https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev209%2Bga1c9051bc.precompiled-cp312-cp312-linux_x86_64.whl
+```
+
+SHA256:
+
+```text
+9f9fd0f24f6c93082e2449c37d6fa3e18a8ced838e0831db7563f358776db1d2
+```
+
+## Required Changes
+
+The fork must keep upstream routed-experts response support from
+`vllm-project/vllm#39917`. prime-rl depends on vLLM returning prompt routing at
+the response level and completion routing on each generated choice.
+
+The fork adds routed-experts replay support for prefix caching and chunked
+prefill. Without this, cached prompt blocks can be missing their routed experts,
+which makes trainer-side replay either fail or compare against the wrong
+experts. The PR adds the replay cache and prefix-cache plumbing needed to
+reconstruct prompt routing for cached blocks, including the DPEP/GLM MoE-layer
+shape expected by the trainer. It also avoids extra routed replay prefill work
+on P/D decode requests, where decode uses external KV and should only emit
+completion routing.
+
+The fork also reverts upstream `vllm-project/vllm#39366` to keep NCCL weight
+transfer working. That upstream PR introduced a two-phase DP pause protocol that
+conflicts with prime-rl's pause/resume flow during NCCL transfer. Keeping it
+reverted preserves the older pause behavior that prime-rl's DP pause/deadlock
+patch expects, so weight transfer can pause and resume generation reliably.
+
+## prime-rl Contract
+
+prime-rl's trainer consumes routed experts in the shape emitted by vLLM:
+
+```text
+[batch, sequence_length, num_moe_layers, topk]
+```
+
+`num_moe_layers` is the sparse MoE-layer count, not the total decoder-layer
+count. The trainer maps decoder layers to sparse MoE-layer indices when replaying
+experts.

--- a/src/prime_rl/orchestrator/trajectories.py
+++ b/src/prime_rl/orchestrator/trajectories.py
@@ -31,14 +31,19 @@ def _align_routed_experts(
 ) -> list[list[list[int]]] | None:
     """Align routed_experts length with the expected token count.
 
-    VLLM's capturer uses `num_tokens - 1` slot mappings because the final
-    generated token was never fed as input to a forward pass and has no
-    routing decision. Append zero-filled entries for the missing positions.
+    The verifier client should provide full prompt+completion routing. The only
+    accepted short form is one missing final token, because the final generated
+    token was not fed into another forward pass and has no routing decision.
     """
-    if routed_experts is None or not routed_experts:
+    if routed_experts is None:
+        return routed_experts
+    if not routed_experts:
+        assert expected_len == 0
         return routed_experts
     deficit = expected_len - len(routed_experts)
-    if deficit <= 0:
+    assert deficit >= 0
+    assert deficit <= 1
+    if deficit == 0:
         return routed_experts
     num_layers = len(routed_experts[0])
     topk = len(routed_experts[0][0])

--- a/src/prime_rl/orchestrator/trajectories.py
+++ b/src/prime_rl/orchestrator/trajectories.py
@@ -12,6 +12,11 @@ from PIL import Image
 from transformers.tokenization_utils import PreTrainedTokenizer
 
 from prime_rl.transport import TrainingSample
+from prime_rl.transport.routed_experts import (
+    align_routed_experts,
+    extend_routed_experts,
+    routed_experts_from_raw,
+)
 from prime_rl.utils.chat_template import (
     common_prefix_len,
     deserialize_tool_calls,
@@ -23,32 +28,6 @@ from prime_rl.utils.logger import get_logger
 
 # We use list() instead of deepcopy() for flat lists (token IDs, logprobs) - safe because
 # primitives are immutable. pixel_values/image_grid_thw are not mutated after creation.
-
-
-def _align_routed_experts(
-    routed_experts: list[list[list[int]]] | None,
-    expected_len: int,
-) -> list[list[list[int]]] | None:
-    """Align routed_experts length with the expected token count.
-
-    The verifier client should provide full prompt+completion routing. The only
-    accepted short form is one missing final token, because the final generated
-    token was not fed into another forward pass and has no routing decision.
-    """
-    if routed_experts is None:
-        return routed_experts
-    if not routed_experts:
-        assert expected_len == 0
-        return routed_experts
-    deficit = expected_len - len(routed_experts)
-    assert deficit >= 0
-    assert deficit <= 1
-    if deficit == 0:
-        return routed_experts
-    num_layers = len(routed_experts[0])
-    topk = len(routed_experts[0][0])
-    zero_entry = [[0] * topk for _ in range(num_layers)]
-    return routed_experts + [zero_entry for _ in range(deficit)]
 
 
 def _common_prefix_len(a: list[int], b: list[int]) -> int:
@@ -301,13 +280,16 @@ def interleave_rollout(
     def prepare_step_tokens(step: vf.TrajectoryStep, step_idx: int) -> dict[str, Any] | None:
         tokens = step["tokens"]
         if tokens is not None:
+            raw_routed_experts = tokens["routed_experts"]
             return {
                 "prompt_ids": list(tokens["prompt_ids"]),
                 "prompt_mask": [bool(i) for i in tokens["prompt_mask"]],
                 "completion_ids": list(tokens["completion_ids"]),
                 "completion_mask": [bool(i) for i in tokens["completion_mask"]],
                 "completion_logprobs": list(tokens["completion_logprobs"]),
-                "routed_experts": tokens.get("routed_experts"),
+                "routed_experts": routed_experts_from_raw(raw_routed_experts)
+                if raw_routed_experts is not None
+                else None,
             }
 
         logger.warning(f"Missing rollout tokens for example {output['example_id']} step {step_idx}.")
@@ -328,8 +310,8 @@ def interleave_rollout(
             completion_mask = [bool(i) for i in tokens["completion_mask"]]
         completion_ids = list(tokens["completion_ids"])
 
-        routed_experts = _align_routed_experts(
-            tokens.get("routed_experts"),
+        routed_experts = align_routed_experts(
+            tokens["routed_experts"],
             len(tokens["prompt_ids"]) + len(tokens["completion_ids"]),
         )
         prompt_ids = list(tokens["prompt_ids"])
@@ -367,17 +349,11 @@ def interleave_rollout(
         sample.completion_logprobs.extend(tokens["completion_logprobs"])
         sample.completion_temperatures.extend([temperature] * len(completion_ids))
 
-        if tokens.get("routed_experts") is not None and sample.routed_experts is not None:
+        if sample.routed_experts is not None:
             step_routed = tokens["routed_experts"]
-            # The previous step's last routing entry was zero-padded by _align_routed_experts
-            # (vLLM only captures num_tokens-1 routings per request). This step actually
-            # processed that boundary token as part of its prompt, so replace the zero-fill
-            # with the real routing decision before appending new entries.
-            if prefix_len > 0 and prefix_len <= len(step_routed):
-                sample.routed_experts[prefix_len - 1] = step_routed[prefix_len - 1]
-            sample.routed_experts.extend(step_routed[prefix_len:])
+            sample.routed_experts = extend_routed_experts(sample.routed_experts, step_routed, prefix_len)
             expected_len = len(sample.prompt_ids) + len(sample.completion_ids)
-            sample.routed_experts = _align_routed_experts(sample.routed_experts, expected_len)
+            sample.routed_experts = align_routed_experts(sample.routed_experts, expected_len)
 
     # Track [prefix_tokens, sample, last_step_idx] per active sample
     active_samples: list[tuple[list[int], TrainingSample, int]] = []

--- a/src/prime_rl/trainer/batch.py
+++ b/src/prime_rl/trainer/batch.py
@@ -173,6 +173,12 @@ def pad_micro_batch(micro_batch: MicroBatch, pad_to_multiple_of: int) -> MicroBa
     micro_batch.temperatures.extend([1.0] * padding_size)
     if micro_batch.teacher_logprobs is not None:
         micro_batch.teacher_logprobs.extend([0.0] * padding_size)
+    if micro_batch.routed_experts is not None:
+        assert micro_batch.routed_experts
+        num_layers = len(micro_batch.routed_experts[0])
+        topk = len(micro_batch.routed_experts[0][0])
+        zero_entry = [[0] * topk for _ in range(num_layers)]
+        micro_batch.routed_experts.extend([zero_entry] * padding_size)
     micro_batch.lora_num_tokens[-1] += (
         padding_size  # We send padding to the last lora so that tokens have ascending lora idx
     )

--- a/src/prime_rl/trainer/batch.py
+++ b/src/prime_rl/trainer/batch.py
@@ -1,5 +1,11 @@
 import copy
 
+from prime_rl.transport.routed_experts import (
+    append_zero_tokens,
+    concat_routed_experts,
+    routed_experts_len,
+    slice_routed_experts,
+)
 from prime_rl.transport.types import MicroBatch, TrainingSample
 
 
@@ -35,7 +41,7 @@ def prepare_sample(training_example: TrainingSample, seq_len: int) -> MicroBatch
         if teacher_logprobs is not None:
             teacher_logprobs = teacher_logprobs[:seq_len]
         if routed_experts is not None:
-            routed_experts = routed_experts[:seq_len]
+            routed_experts = slice_routed_experts(routed_experts, seq_len)
         if mm_token_type_ids is not None:
             mm_token_type_ids = mm_token_type_ids[:seq_len]
 
@@ -53,8 +59,8 @@ def prepare_sample(training_example: TrainingSample, seq_len: int) -> MicroBatch
         assert len(teacher_logprobs) == len(input_ids), f"teacher_logprobs: {len(teacher_logprobs)}"
 
     if routed_experts is not None:
-        assert len(routed_experts) == len(input_ids), (
-            f"routed_experts: {len(routed_experts)}, input_ids: {len(input_ids)}"
+        assert routed_experts_len(routed_experts) == len(input_ids), (
+            f"routed_experts: {routed_experts_len(routed_experts)}, input_ids: {len(input_ids)}"
         )
 
     if mm_token_type_ids is not None:
@@ -131,8 +137,11 @@ def packed_samples_into_micro_bs(
                     bin_content.teacher_logprobs.extend(sample.teacher_logprobs)
                 if sample.routed_experts is not None:
                     if bin_content.routed_experts is None:
-                        bin_content.routed_experts = []
-                    bin_content.routed_experts.extend(sample.routed_experts)
+                        bin_content.routed_experts = sample.routed_experts
+                    else:
+                        bin_content.routed_experts = concat_routed_experts(
+                            bin_content.routed_experts, sample.routed_experts
+                        )
                 if sample.mm_token_type_ids is not None:
                     if bin_content.mm_token_type_ids is None:
                         bin_content.mm_token_type_ids = []
@@ -174,11 +183,7 @@ def pad_micro_batch(micro_batch: MicroBatch, pad_to_multiple_of: int) -> MicroBa
     if micro_batch.teacher_logprobs is not None:
         micro_batch.teacher_logprobs.extend([0.0] * padding_size)
     if micro_batch.routed_experts is not None:
-        assert micro_batch.routed_experts
-        num_layers = len(micro_batch.routed_experts[0])
-        topk = len(micro_batch.routed_experts[0][0])
-        zero_entry = [[0] * topk for _ in range(num_layers)]
-        micro_batch.routed_experts.extend([zero_entry] * padding_size)
+        micro_batch.routed_experts = append_zero_tokens(micro_batch.routed_experts, padding_size)
     micro_batch.lora_num_tokens[-1] += (
         padding_size  # We send padding to the last lora so that tokens have ascending lora idx
     )

--- a/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
+++ b/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
@@ -21,7 +21,12 @@ from transformers.utils import TransformersKwargs
 from prime_rl.trainer.models.base import PreTrainedModelPrimeRL
 from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput
 from prime_rl.trainer.models.layers.mlp import MLP, MLPConfig
-from prime_rl.trainer.models.layers.moe import MoE, MoEArgs
+from prime_rl.trainer.models.layers.moe import (
+    MoE,
+    MoEArgs,
+    assert_routed_experts_layer_count,
+    get_routed_experts_layer,
+)
 from prime_rl.trainer.models.layers.norms import RMSNorm, RMSNormConfig
 from prime_rl.trainer.models.layers.rotary_emb import (
     RotaryEmbedding,
@@ -476,7 +481,7 @@ class AfmoeModel(AfmoePreTrainedModel):
         routed_experts: Optional[torch.LongTensor] = None,
     ) -> MoeModelOutputWithPast:
         """
-        routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
+        routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_moe_layers, num_experts_per_tok)`, *optional*):
             Routed experts for each token in the sequence. Only used for router replay.
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
@@ -519,9 +524,14 @@ class AfmoeModel(AfmoePreTrainedModel):
 
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
 
-        for layer_idx, decoder_layer in enumerate(self.layers):
+        sparse_layer_idx = 0
+        for decoder_layer in self.layers:
             mask = causal_mask_mapping[decoder_layer.attention_type] if causal_mask_mapping is not None else None
-            routed_experts_layer = routed_experts[:, :, layer_idx, :] if routed_experts is not None else None
+            routed_experts_layer, sparse_layer_idx = get_routed_experts_layer(
+                routed_experts,
+                decoder_layer,
+                sparse_layer_idx,
+            )
 
             hidden_states = decoder_layer(
                 hidden_states,
@@ -531,6 +541,7 @@ class AfmoeModel(AfmoePreTrainedModel):
                 max_seqlen=max_seqlen,
                 routed_experts=routed_experts_layer,
             )
+        assert_routed_experts_layer_count(routed_experts, sparse_layer_idx)
 
         hidden_states = self.norm(hidden_states)
         return MoeModelOutputWithPast(
@@ -591,7 +602,7 @@ class AfmoeForCausalLM(AfmoePreTrainedModel, GenerationMixin):
             If not provided, the wrapped LM head returns logits only.
         temperature (`torch.Tensor` of shape `(batch_size, sequence_length)`, *optional*):
             Per-token temperatures for logprobs/entropy computation when `labels` are provided.
-        routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
+        routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_moe_layers, num_experts_per_tok)`, *optional*):
             Routed experts for each token in the sequence. Only used for router replay.
         """
         assert use_cache is None, "use_cache is not supported for custom afmoe for now"

--- a/src/prime_rl/trainer/models/glm4_moe/modeling_glm4_moe.py
+++ b/src/prime_rl/trainer/models/glm4_moe/modeling_glm4_moe.py
@@ -36,7 +36,12 @@ from prime_rl.trainer.models.glm4_moe.converting_glm4_moe import (
 from prime_rl.trainer.models.layers.attn import ATTN_IMPL2CLASS, AttentionConfig
 from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput
 from prime_rl.trainer.models.layers.mlp import MLP, MLPConfig
-from prime_rl.trainer.models.layers.moe import MoE, MoEArgs
+from prime_rl.trainer.models.layers.moe import (
+    MoE,
+    MoEArgs,
+    assert_routed_experts_layer_count,
+    get_routed_experts_layer,
+)
 from prime_rl.trainer.models.layers.norms import RMSNorm, RMSNormConfig
 from prime_rl.trainer.models.layers.rotary_emb import RotaryEmbedding, RotaryEmbeddingConfig
 from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
@@ -207,7 +212,7 @@ class Glm4MoeModel(Glm4MoePreTrainedModel):
         routed_experts: Optional[torch.LongTensor] = None,
     ) -> BaseModelOutputWithPast:
         """
-        routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
+        routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_moe_layers, num_experts_per_tok)`, *optional*):
             Routed experts for each token in the sequence. Only used for router replay.
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
@@ -226,8 +231,13 @@ class Glm4MoeModel(Glm4MoePreTrainedModel):
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
 
-        for layer_idx, decoder_layer in enumerate(self.layers[: self.config.num_hidden_layers]):
-            routed_experts_layer = routed_experts[:, :, layer_idx, :] if routed_experts is not None else None
+        sparse_layer_idx = 0
+        for decoder_layer in self.layers[: self.config.num_hidden_layers]:
+            routed_experts_layer, sparse_layer_idx = get_routed_experts_layer(
+                routed_experts,
+                decoder_layer,
+                sparse_layer_idx,
+            )
             hidden_states = decoder_layer(
                 hidden_states,
                 position_embeddings=position_embeddings,
@@ -235,6 +245,7 @@ class Glm4MoeModel(Glm4MoePreTrainedModel):
                 max_seqlen=max_seqlen,
                 routed_experts=routed_experts_layer,
             )
+        assert_routed_experts_layer_count(routed_experts, sparse_layer_idx)
 
         hidden_states = self.norm(hidden_states)
         return BaseModelOutputWithPast(last_hidden_state=hidden_states)
@@ -280,7 +291,7 @@ class Glm4MoeForCausalLM(Glm4MoePreTrainedModel, GenerationMixin):
             If not provided, the wrapped LM head returns logits only.
         temperature (`torch.Tensor` of shape `(batch_size, sequence_length)`, *optional*):
             Per-token temperatures for logprobs/entropy computation when `labels` are provided.
-        routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
+        routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_moe_layers, num_experts_per_tok)`, *optional*):
             Routed experts for each token in the sequence. Only used for router replay.
 
         Example:

--- a/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
+++ b/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
@@ -24,7 +24,12 @@ from prime_rl.trainer.models.glm_moe_dsa.converting_glm_moe_dsa import (
 from prime_rl.trainer.models.glm_moe_dsa.sparse_mla_attention import GlmMoeDsaAttention, SparseMlaAttentionArgs
 from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput
 from prime_rl.trainer.models.layers.mlp import MLP, MLPConfig
-from prime_rl.trainer.models.layers.moe import MoE, MoEArgs
+from prime_rl.trainer.models.layers.moe import (
+    MoE,
+    MoEArgs,
+    assert_routed_experts_layer_count,
+    get_routed_experts_layer,
+)
 from prime_rl.trainer.models.layers.norms import RMSNorm, RMSNormConfig
 from prime_rl.trainer.models.layers.rotary_emb import RotaryEmbedding, RotaryEmbeddingConfig
 
@@ -220,7 +225,7 @@ class GlmMoeDsaModel(GlmMoeDsaPreTrainedModel):
         routed_experts: Optional[torch.LongTensor] = None,
     ) -> BaseModelOutputWithPast:
         """
-        routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
+        routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_moe_layers, num_experts_per_tok)`, *optional*):
             Routed experts for each token in the sequence. Only used for router replay.
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
@@ -256,8 +261,13 @@ class GlmMoeDsaModel(GlmMoeDsaPreTrainedModel):
         else:
             ks, ke = ks_full, ke_full
 
-        for layer_idx, decoder_layer in enumerate(self.layers[: self.config.num_hidden_layers]):
-            routed_experts_layer = routed_experts[:, :, layer_idx, :] if routed_experts is not None else None
+        sparse_layer_idx = 0
+        for decoder_layer in self.layers[: self.config.num_hidden_layers]:
+            routed_experts_layer, sparse_layer_idx = get_routed_experts_layer(
+                routed_experts,
+                decoder_layer,
+                sparse_layer_idx,
+            )
             hidden_states = decoder_layer(
                 hidden_states,
                 position_embeddings=position_embeddings,
@@ -265,6 +275,7 @@ class GlmMoeDsaModel(GlmMoeDsaPreTrainedModel):
                 ke=ke,
                 routed_experts=routed_experts_layer,
             )
+        assert_routed_experts_layer_count(routed_experts, sparse_layer_idx)
 
         hidden_states = self.norm(hidden_states)
         return BaseModelOutputWithPast(last_hidden_state=hidden_states)
@@ -311,7 +322,7 @@ class GlmMoeDsaForCausalLM(GlmMoeDsaPreTrainedModel, GenerationMixin):
             Labels used by PrimeRL's wrapped LM head to optionally compute per-token logprobs/entropy.
         temperature (`torch.Tensor` of shape `(batch_size, sequence_length)`, *optional*):
             Per-token temperatures for logprobs/entropy computation when `labels` are provided.
-        routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
+        routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_moe_layers, num_experts_per_tok)`, *optional*):
             Routed experts for each token in the sequence. Only used for router replay.
         """
         assert use_cache is None, "use_cache is not supported for custom glm_moe_dsa for now"

--- a/src/prime_rl/trainer/models/layers/moe.py
+++ b/src/prime_rl/trainer/models/layers/moe.py
@@ -1198,3 +1198,21 @@ class LatentMoE(nn.Module):
             self.tokens_per_expert = torch.zeros(self.experts.num_experts, dtype=torch.float32)
             if self.load_balance_coeff is not None:
                 self.expert_bias = torch.zeros(self.experts.num_experts, dtype=torch.float32)
+
+
+def get_routed_experts_layer(
+    routed_experts: torch.Tensor | None,
+    decoder_layer: nn.Module,
+    sparse_layer_idx: int,
+) -> tuple[torch.Tensor | None, int]:
+    mlp = getattr(decoder_layer, "mlp", None)
+    if routed_experts is None or not isinstance(mlp, (MoE, LatentMoE)):
+        return None, sparse_layer_idx
+    return routed_experts[:, :, sparse_layer_idx, :], sparse_layer_idx + 1
+
+
+def assert_routed_experts_layer_count(routed_experts: torch.Tensor | None, sparse_layer_count: int) -> None:
+    if routed_experts is not None:
+        assert routed_experts.shape[2] == sparse_layer_count, (
+            f"routed_experts has {routed_experts.shape[2]} layers, expected {sparse_layer_count} MoE layers"
+        )

--- a/src/prime_rl/trainer/models/minimax_m2/modeling_minimax_m2.py
+++ b/src/prime_rl/trainer/models/minimax_m2/modeling_minimax_m2.py
@@ -12,7 +12,12 @@ from transformers.utils import TransformersKwargs, auto_docstring, can_return_tu
 from prime_rl.trainer.models.base import PreTrainedModelPrimeRL
 from prime_rl.trainer.models.layers.attn import ATTN_IMPL2CLASS, AttentionConfig
 from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput
-from prime_rl.trainer.models.layers.moe import MoE, MoEArgs
+from prime_rl.trainer.models.layers.moe import (
+    MoE,
+    MoEArgs,
+    assert_routed_experts_layer_count,
+    get_routed_experts_layer,
+)
 from prime_rl.trainer.models.layers.norms import RMSNorm, RMSNormConfig
 from prime_rl.trainer.models.layers.rotary_emb import RotaryEmbedding, RotaryEmbeddingConfig
 from prime_rl.trainer.models.minimax_m2.configuration_minimax_m2 import MiniMaxM2Config
@@ -168,7 +173,7 @@ class MiniMaxM2Model(MiniMaxM2PreTrainedModel):
         routed_experts: Optional[torch.LongTensor] = None,
     ) -> BaseModelOutputWithPast:
         """
-        routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
+        routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_moe_layers, num_experts_per_tok)`, *optional*):
             Routed experts for each token in the sequence. Only used for router replay.
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
@@ -187,8 +192,13 @@ class MiniMaxM2Model(MiniMaxM2PreTrainedModel):
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
 
-        for layer_idx, decoder_layer in enumerate(self.layers[: self.config.num_hidden_layers]):
-            routed_experts_layer = routed_experts[:, :, layer_idx, :] if routed_experts is not None else None
+        sparse_layer_idx = 0
+        for decoder_layer in self.layers[: self.config.num_hidden_layers]:
+            routed_experts_layer, sparse_layer_idx = get_routed_experts_layer(
+                routed_experts,
+                decoder_layer,
+                sparse_layer_idx,
+            )
             hidden_states = decoder_layer(
                 hidden_states,
                 position_embeddings=position_embeddings,
@@ -196,6 +206,7 @@ class MiniMaxM2Model(MiniMaxM2PreTrainedModel):
                 max_seqlen=max_seqlen,
                 routed_experts=routed_experts_layer,
             )
+        assert_routed_experts_layer_count(routed_experts, sparse_layer_idx)
 
         hidden_states = self.norm(hidden_states)
         return BaseModelOutputWithPast(last_hidden_state=hidden_states)
@@ -241,7 +252,7 @@ class MiniMaxM2ForCausalLM(MiniMaxM2PreTrainedModel, GenerationMixin):
             Labels for computing the masked language modeling loss.
         temperature (`torch.Tensor` of shape `(batch_size, sequence_length)`, *optional*):
             Per-token temperatures for logprobs/entropy computation.
-        routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
+        routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_moe_layers, num_experts_per_tok)`, *optional*):
             Routed experts for each token in the sequence. Only used for router replay.
         """
         assert use_cache is None, "use_cache is not supported for custom minimax_m2 for now"

--- a/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -16,7 +16,13 @@ from transformers.utils import TransformersKwargs, logging
 
 from prime_rl.trainer.models.base import PreTrainedModelPrimeRL
 from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput
-from prime_rl.trainer.models.layers.moe import FeedForward, MoE, MoEArgs
+from prime_rl.trainer.models.layers.moe import (
+    FeedForward,
+    MoE,
+    MoEArgs,
+    assert_routed_experts_layer_count,
+    get_routed_experts_layer,
+)
 from prime_rl.trainer.models.layers.rotary_emb import RotaryEmbedding, RotaryEmbeddingConfig, apply_rotary_pos_emb
 from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
 
@@ -774,8 +780,13 @@ class Qwen3_5MoeModel(Qwen3_5MoePreTrainedModel):
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
 
-        for layer_idx, decoder_layer in enumerate(self.layers):
-            routed_experts_layer = routed_experts[:, :, layer_idx, :] if routed_experts is not None else None
+        sparse_layer_idx = 0
+        for decoder_layer in self.layers:
+            routed_experts_layer, sparse_layer_idx = get_routed_experts_layer(
+                routed_experts,
+                decoder_layer,
+                sparse_layer_idx,
+            )
             hidden_states = decoder_layer(
                 hidden_states,
                 position_embeddings=position_embeddings,
@@ -783,6 +794,7 @@ class Qwen3_5MoeModel(Qwen3_5MoePreTrainedModel):
                 max_seqlen=max_seqlen,
                 routed_experts=routed_experts_layer,
             )
+        assert_routed_experts_layer_count(routed_experts, sparse_layer_idx)
 
         hidden_states = self.norm(hidden_states)
         return MoeModelOutputWithPast(last_hidden_state=hidden_states)

--- a/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_moe/modeling_qwen3_moe.py
@@ -30,7 +30,12 @@ from prime_rl.trainer.models.base import PreTrainedModelPrimeRL
 from prime_rl.trainer.models.layers.attn import ATTN_IMPL2CLASS, AttentionConfig
 from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput
 from prime_rl.trainer.models.layers.mlp import MLP, MLPConfig
-from prime_rl.trainer.models.layers.moe import MoE, MoEArgs
+from prime_rl.trainer.models.layers.moe import (
+    MoE,
+    MoEArgs,
+    assert_routed_experts_layer_count,
+    get_routed_experts_layer,
+)
 from prime_rl.trainer.models.layers.norms import RMSNorm, RMSNormConfig
 from prime_rl.trainer.models.layers.rotary_emb import RotaryEmbedding, RotaryEmbeddingConfig
 from prime_rl.trainer.models.qwen3_moe.configuration_qwen3_moe import Qwen3MoeConfig
@@ -208,7 +213,7 @@ class Qwen3MoeModel(Qwen3MoePreTrainedModel):
         routed_experts: Optional[torch.LongTensor] = None,
     ) -> MoeModelOutputWithPast:
         """
-        routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
+        routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_moe_layers, num_experts_per_tok)`, *optional*):
             Routed experts for each token in the sequence. Only used for router replay.
         """
         if (input_ids is None) ^ (inputs_embeds is not None):
@@ -227,8 +232,13 @@ class Qwen3MoeModel(Qwen3MoePreTrainedModel):
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
 
-        for layer_idx, decoder_layer in enumerate(self.layers[: self.config.num_hidden_layers]):
-            routed_experts_layer = routed_experts[:, :, layer_idx, :] if routed_experts is not None else None
+        sparse_layer_idx = 0
+        for decoder_layer in self.layers[: self.config.num_hidden_layers]:
+            routed_experts_layer, sparse_layer_idx = get_routed_experts_layer(
+                routed_experts,
+                decoder_layer,
+                sparse_layer_idx,
+            )
             hidden_states = decoder_layer(
                 hidden_states,
                 position_embeddings=position_embeddings,
@@ -236,6 +246,7 @@ class Qwen3MoeModel(Qwen3MoePreTrainedModel):
                 max_seqlen=max_seqlen,
                 routed_experts=routed_experts_layer,
             )
+        assert_routed_experts_layer_count(routed_experts, sparse_layer_idx)
 
         hidden_states = self.norm(hidden_states)
 
@@ -377,7 +388,7 @@ class Qwen3MoeForCausalLM(Qwen3MoePreTrainedModel, GenerationMixin):
             (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
         temperature (`torch.Tensor` of shape `(batch_size, sequence_length)`, *optional*):
             Per-token temperatures for logprobs/entropy computation.
-        routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
+        routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_moe_layers, num_experts_per_tok)`, *optional*):
             Routed experts for each token in the sequence. Only used for router replay.
 
         Example:

--- a/src/prime_rl/trainer/rl/data.py
+++ b/src/prime_rl/trainer/rl/data.py
@@ -11,6 +11,12 @@ from prime_rl.trainer.rl.packer import BasePacker, setup_packer
 from prime_rl.trainer.runs import get_multi_run_manager
 from prime_rl.trainer.world import get_world
 from prime_rl.transport import MicroBatch, MicroBatchReceiver, TransportConfig, setup_micro_batch_receiver
+from prime_rl.transport.routed_experts import RoutedExperts, validate_routed_experts
+
+
+def _routed_experts_to_tensor(payload: RoutedExperts) -> torch.Tensor:
+    payload = validate_routed_experts(payload)
+    return torch.frombuffer(payload.data, dtype=torch.int16).reshape(payload.shape).to(torch.int32).unsqueeze(0)
 
 
 class TensorMicroBatch(TypedDict):
@@ -218,9 +224,7 @@ class DataLoader:
             mm_token_type_ids=torch.tensor(micro_batch.mm_token_type_ids, dtype=torch.long).unsqueeze(0)
             if micro_batch.mm_token_type_ids is not None
             else None,
-            routed_experts=torch.tensor(micro_batch.routed_experts, dtype=torch.int32).unsqueeze(
-                0
-            )  # [1, seq_len, layers, topk]
+            routed_experts=_routed_experts_to_tensor(micro_batch.routed_experts)
             if micro_batch.routed_experts is not None
             else None,
             sft_loss=micro_batch.sft_loss,

--- a/src/prime_rl/transport/__init__.py
+++ b/src/prime_rl/transport/__init__.py
@@ -8,6 +8,7 @@ from prime_rl.transport.filesystem import (
     FileSystemTrainingBatchReceiver,
     FileSystemTrainingBatchSender,
 )
+from prime_rl.transport.routed_experts import RoutedExperts
 from prime_rl.transport.types import MicroBatch, TrainingBatch, TrainingSample
 from prime_rl.transport.zmq import (
     ZMQMicroBatchReceiver,
@@ -67,6 +68,7 @@ __all__ = [
     "TrainingSample",
     "TrainingBatch",
     "MicroBatch",
+    "RoutedExperts",
     "setup_training_batch_sender",
     "setup_training_batch_receiver",
     "setup_micro_batch_sender",

--- a/src/prime_rl/transport/routed_experts.py
+++ b/src/prime_rl/transport/routed_experts.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, cast
+
+import msgspec
+
+INT16_BYTES = 2
+
+
+class RoutedExperts(msgspec.Struct, gc=False, omit_defaults=True):
+    shape: list[int]
+    data: bytes
+    dtype: str = "int16"
+
+
+def _shape_numel(shape: list[int]) -> int:
+    seq_len, num_layers, topk = shape
+    return seq_len * num_layers * topk
+
+
+def _token_stride(shape: list[int]) -> int:
+    return shape[1] * shape[2] * INT16_BYTES
+
+
+def validate_routed_experts(payload: RoutedExperts) -> RoutedExperts:
+    assert payload.dtype == "int16"
+    assert len(payload.shape) == 3
+    assert len(payload.data) == _shape_numel(payload.shape) * INT16_BYTES
+    return payload
+
+
+def routed_experts_from_raw(raw: Any) -> RoutedExperts:
+    if isinstance(raw, RoutedExperts):
+        return validate_routed_experts(raw)
+    if hasattr(raw, "model_dump"):
+        raw = raw.model_dump(mode="python")
+    raw = cast(Mapping[str, Any], raw)
+    return validate_routed_experts(
+        RoutedExperts(
+            dtype=raw["dtype"],
+            shape=[int(dim) for dim in raw["shape"]],
+            data=raw["data"],
+        )
+    )
+
+
+def routed_experts_len(payload: RoutedExperts) -> int:
+    return validate_routed_experts(payload).shape[0]
+
+
+def align_routed_experts(payload: RoutedExperts | None, expected_len: int) -> RoutedExperts | None:
+    if payload is None:
+        return None
+    payload = validate_routed_experts(payload)
+    deficit = expected_len - payload.shape[0]
+    assert deficit >= 0
+    assert deficit <= 1
+    if deficit == 0:
+        return payload
+    return append_zero_tokens(payload, deficit)
+
+
+def slice_routed_experts(payload: RoutedExperts, end: int) -> RoutedExperts:
+    payload = validate_routed_experts(payload)
+    assert 0 <= end <= payload.shape[0]
+    stride = _token_stride(payload.shape)
+    return RoutedExperts(
+        dtype=payload.dtype,
+        shape=[end, payload.shape[1], payload.shape[2]],
+        data=payload.data[: end * stride],
+    )
+
+
+def append_zero_tokens(payload: RoutedExperts, count: int) -> RoutedExperts:
+    payload = validate_routed_experts(payload)
+    assert count >= 0
+    if count == 0:
+        return payload
+    stride = _token_stride(payload.shape)
+    return RoutedExperts(
+        dtype=payload.dtype,
+        shape=[payload.shape[0] + count, payload.shape[1], payload.shape[2]],
+        data=payload.data + (b"\0" * stride * count),
+    )
+
+
+def concat_routed_experts(left: RoutedExperts, right: RoutedExperts) -> RoutedExperts:
+    left = validate_routed_experts(left)
+    right = validate_routed_experts(right)
+    assert left.dtype == right.dtype
+    assert left.shape[1:] == right.shape[1:]
+    return RoutedExperts(
+        dtype=left.dtype,
+        shape=[left.shape[0] + right.shape[0], left.shape[1], left.shape[2]],
+        data=left.data + right.data,
+    )
+
+
+def extend_routed_experts(base: RoutedExperts, step: RoutedExperts, prefix_len: int) -> RoutedExperts:
+    base = validate_routed_experts(base)
+    step = validate_routed_experts(step)
+    assert base.dtype == step.dtype
+    assert base.shape[1:] == step.shape[1:]
+    assert 0 <= prefix_len <= step.shape[0]
+
+    stride = _token_stride(base.shape)
+    data = bytearray(base.data)
+    if prefix_len > 0:
+        start = (prefix_len - 1) * stride
+        data[start : start + stride] = step.data[start : start + stride]
+    data.extend(step.data[prefix_len * stride :])
+
+    return validate_routed_experts(
+        RoutedExperts(
+            dtype=base.dtype,
+            shape=[base.shape[0] + step.shape[0] - prefix_len, base.shape[1], base.shape[2]],
+            data=bytes(data),
+        )
+    )

--- a/src/prime_rl/transport/types.py
+++ b/src/prime_rl/transport/types.py
@@ -1,5 +1,7 @@
 import msgspec
 
+from prime_rl.transport.routed_experts import RoutedExperts
+
 
 # Orchestrator -> Packer
 class TrainingSample(msgspec.Struct, array_like=True, gc=False, omit_defaults=True):
@@ -21,7 +23,7 @@ class TrainingSample(msgspec.Struct, array_like=True, gc=False, omit_defaults=Tr
     # image_grid_thw: grid dimensions [num_images, 3] where each entry is [temporal, height, width]
     image_grid_thw: list[list[int]] | None = None
 
-    routed_experts: list[list[list[int]]] | None = None  # [seq_len, layers, topk]
+    routed_experts: RoutedExperts | None = None  # [seq_len, layers, topk]
 
     # mm_token_type_ids: token type ids per token [batch seq], int64 (0=text, 1=image, 2=video)
     mm_token_type_ids: list[int] | None = None
@@ -49,7 +51,7 @@ class MicroBatch(msgspec.Struct, array_like=True, gc=False, omit_defaults=True):
     temperatures: list[float]  # Per-token temperatures used during generation
     teacher_logprobs: list[float] | None = None
     lora_num_tokens: list[int] | None = None
-    routed_experts: list[list[list[int]]] | None = None
+    routed_experts: RoutedExperts | None = None
 
     # Multimodal fields (Qwen3-VL) — pixel_values stored as raw float32 bytes for efficient serialization
     pixel_values: bytes | None = None

--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -9,6 +9,7 @@ import verifiers as vf
 import wandb
 from transformers.tokenization_utils import PreTrainedTokenizer
 from wandb.errors import CommError
+from wandb.sdk.mailbox.mailbox_handle import ServerResponseError
 
 from prime_rl.configs.shared import WandbConfig, WandbWithExtrasConfig
 from prime_rl.utils.chat_template import deserialize_tool_calls
@@ -69,6 +70,8 @@ class WandbMonitor(Monitor):
                 mode="offline" if config.offline else "online",
             )
 
+        retryable_init_errors = (CommError, ServerResponseError) if shared_mode and not primary else (CommError,)
+
         def init_wandb(max_retries: int):
             for attempt in range(max_retries):
                 try:
@@ -83,7 +86,7 @@ class WandbMonitor(Monitor):
                         config=run_config.model_dump() if run_config else None,
                         settings=settings,
                     )
-                except CommError as e:
+                except retryable_init_errors as e:
                     if attempt + 1 == max_retries:
                         raise
                     if shared_mode and not primary:

--- a/tests/unit/inference/test_serving_tokens.py
+++ b/tests/unit/inference/test_serving_tokens.py
@@ -3,7 +3,7 @@
 The full happy-path is owned upstream by vLLM 0.20's
 ``vllm/entrypoints/serve/disagg`` test suite. We only cover the prime-RL
 deltas here:
-    * ``_serialize_routed_experts`` emits JSON-compatible arrays.
+    * ``_serialize_routed_experts`` emits compact base64 payloads.
     * ``PrimeRlGenerateResponseChoice`` accepts the optional field.
     * The subclass attaches its overrides without monkey-patching the parent.
     * ``_client_set_max_tokens`` distinguishes raw-body shapes correctly.
@@ -12,6 +12,7 @@ deltas here:
 from __future__ import annotations
 
 import asyncio
+import base64
 
 import numpy as np
 
@@ -35,16 +36,20 @@ class _FakeRawRequest:
         return self._body
 
 
-def test_serialize_routed_experts_json_array():
-    arr = np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]], dtype=np.int32)
-    assert _serialize_routed_experts(arr) == [[[1, 2], [3, 4]], [[5, 6], [7, 8]]]
+def test_serialize_routed_experts_compact_payload():
+    arr = np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]], dtype=np.int16)
+    payload = _serialize_routed_experts(arr)
+    assert payload.encoding == "base64"
+    assert payload.dtype == "int16"
+    assert payload.shape == [2, 2, 2]
+    assert base64.b64decode(payload.data) == arr.tobytes()
 
 
-def test_routed_experts_choice_accepts_none_and_json_array():
+def test_routed_experts_choice_accepts_none_and_compact_payload():
     no_re = PrimeRlGenerateResponseChoice(index=0, finish_reason="stop", token_ids=[1, 2])
     assert no_re.routed_experts is None
 
-    routed_experts = [[[0, 0]]]
+    routed_experts = _serialize_routed_experts(np.array([[[0, 0]]], dtype=np.int16))
     with_re = PrimeRlGenerateResponseChoice(index=0, finish_reason="stop", token_ids=[1], routed_experts=routed_experts)
     assert with_re.routed_experts == routed_experts
 

--- a/tests/unit/inference/test_serving_tokens.py
+++ b/tests/unit/inference/test_serving_tokens.py
@@ -3,7 +3,7 @@
 The full happy-path is owned upstream by vLLM 0.20's
 ``vllm/entrypoints/serve/disagg`` test suite. We only cover the prime-RL
 deltas here:
-    * ``encode_routed_experts`` round-trips a numpy array as expected.
+    * ``_serialize_routed_experts`` emits JSON-compatible arrays.
     * ``PrimeRlGenerateResponseChoice`` accepts the optional field.
     * The subclass attaches its overrides without monkey-patching the parent.
     * ``_client_set_max_tokens`` distinguishes raw-body shapes correctly.
@@ -12,7 +12,6 @@ deltas here:
 from __future__ import annotations
 
 import asyncio
-import base64
 
 import numpy as np
 
@@ -21,7 +20,7 @@ from prime_rl.inference.vllm.serving_tokens import (
     PrimeRlGenerateResponseChoice,
     PrimeRlServingTokens,
     _client_set_max_tokens,
-    encode_routed_experts,
+    _serialize_routed_experts,
 )
 
 
@@ -36,28 +35,24 @@ class _FakeRawRequest:
         return self._body
 
 
-def test_encode_routed_experts_roundtrip():
-    arr = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int32)
-    encoded = encode_routed_experts(arr)
-
-    assert encoded["shape"] == [2, 3]
-    decoded = np.frombuffer(base64.b85decode(encoded["data"]), dtype=np.int32).reshape(encoded["shape"])
-    np.testing.assert_array_equal(decoded, arr)
+def test_serialize_routed_experts_json_array():
+    arr = np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]], dtype=np.int32)
+    assert _serialize_routed_experts(arr) == [[[1, 2], [3, 4]], [[5, 6], [7, 8]]]
 
 
-def test_routed_experts_choice_accepts_none_and_dict():
+def test_routed_experts_choice_accepts_none_and_json_array():
     no_re = PrimeRlGenerateResponseChoice(index=0, finish_reason="stop", token_ids=[1, 2])
     assert no_re.routed_experts is None
 
-    encoded = encode_routed_experts(np.zeros((1, 1), dtype=np.int32))
-    with_re = PrimeRlGenerateResponseChoice(index=0, finish_reason="stop", token_ids=[1], routed_experts=encoded)
-    assert with_re.routed_experts == encoded
+    routed_experts = [[[0, 0]]]
+    with_re = PrimeRlGenerateResponseChoice(index=0, finish_reason="stop", token_ids=[1], routed_experts=routed_experts)
+    assert with_re.routed_experts == routed_experts
 
 
 def test_response_only_serializes_declared_fields():
     # Upstream silently drops id=/created=/model=/usage= because they're not
-    # declared on GenerateResponse. Our subclass adds nothing to that surface
-    # — it only widens the choices type — so the JSON shape stays slim.
+    # declared on GenerateResponse. Our subclass adds routed-experts fields
+    # only, so the JSON shape stays slim.
     resp = PrimeRlGenerateResponse(
         request_id="gen-x",
         choices=[PrimeRlGenerateResponseChoice(index=0, finish_reason="stop", token_ids=[7])],
@@ -67,9 +62,11 @@ def test_response_only_serializes_declared_fields():
         "request_id",
         "choices",
         "prompt_logprobs",
+        "prompt_routed_experts",
         "kv_transfer_params",
     }
     assert dumped["choices"][0]["routed_experts"] is None
+    assert dumped["prompt_routed_experts"] is None
 
 
 def test_subclass_inherits_serve_tokens_full_generator():

--- a/tests/unit/orchestrator/test_batch.py
+++ b/tests/unit/orchestrator/test_batch.py
@@ -1,7 +1,36 @@
 import pytest
 
 from prime_rl.trainer.batch import prepare_batch, prepare_sample
+from prime_rl.transport.routed_experts import RoutedExperts
 from prime_rl.transport.types import TrainingSample
+
+
+def _routed_experts(values: list[list[list[int]]]) -> RoutedExperts:
+    data = bytes()
+    for token in values:
+        for layer in token:
+            for expert in layer:
+                data += int(expert).to_bytes(2, byteorder="little", signed=True)
+    return RoutedExperts(
+        shape=[len(values), len(values[0]) if values else 0, len(values[0][0]) if values and values[0] else 0],
+        data=data,
+    )
+
+
+def _routed_experts_values(payload: RoutedExperts) -> list[list[list[int]]]:
+    seq_len, num_layers, topk = payload.shape
+    values: list[list[list[int]]] = []
+    offset = 0
+    for _ in range(seq_len):
+        token: list[list[int]] = []
+        for _ in range(num_layers):
+            layer: list[int] = []
+            for _ in range(topk):
+                layer.append(int.from_bytes(payload.data[offset : offset + 2], byteorder="little", signed=True))
+                offset += 2
+            token.append(layer)
+        values.append(token)
+    return values
 
 
 @pytest.fixture
@@ -108,7 +137,7 @@ def test_prepare_batch_does_not_pack_mixed_sft_loss(make_training_example):
 def test_prepare_sample_with_routed_experts():
     """Routed experts are passed through prepare_sample and match input_ids length."""
     # 2 prompt + 2 completion = 4 tokens, 2 layers, topk=2
-    routed_experts = [[[0, 1], [2, 3]], [[4, 5], [6, 7]], [[0, 2], [1, 3]], [[1, 0], [3, 2]]]
+    routed_experts_values = [[[0, 1], [2, 3]], [[4, 5], [6, 7]], [[0, 2], [1, 3]], [[1, 0], [3, 2]]]
     sample = TrainingSample(
         prompt_ids=[1, 2],
         prompt_mask=[False, False],
@@ -117,18 +146,18 @@ def test_prepare_sample_with_routed_experts():
         completion_logprobs=[-0.1, -0.2],
         completion_temperatures=[1.0, 1.0],
         advantage=1.0,
-        routed_experts=routed_experts,
+        routed_experts=_routed_experts(routed_experts_values),
     )
 
     micro_batch = prepare_sample(sample, seq_len=8)
     assert micro_batch.routed_experts is not None
-    assert len(micro_batch.routed_experts) == 4
-    assert micro_batch.routed_experts == routed_experts
+    assert micro_batch.routed_experts.shape[0] == 4
+    assert _routed_experts_values(micro_batch.routed_experts) == routed_experts_values
 
 
 def test_prepare_sample_truncates_routed_experts():
     """Routed experts are truncated to seq_len when input exceeds it."""
-    routed_experts = [[[0, 1]], [[2, 3]], [[4, 5]], [[6, 7]]]
+    routed_experts_values = [[[0, 1]], [[2, 3]], [[4, 5]], [[6, 7]]]
     sample = TrainingSample(
         prompt_ids=[1, 2],
         prompt_mask=[False, False],
@@ -137,13 +166,13 @@ def test_prepare_sample_truncates_routed_experts():
         completion_logprobs=[-0.1, -0.2],
         completion_temperatures=[1.0, 1.0],
         advantage=1.0,
-        routed_experts=routed_experts,
+        routed_experts=_routed_experts(routed_experts_values),
     )
 
     micro_batch = prepare_sample(sample, seq_len=3)
     assert micro_batch.routed_experts is not None
-    assert len(micro_batch.routed_experts) == 3
-    assert micro_batch.routed_experts == routed_experts[:3]
+    assert micro_batch.routed_experts.shape[0] == 3
+    assert _routed_experts_values(micro_batch.routed_experts) == routed_experts_values[:3]
 
 
 def test_prepare_sample_none_routed_experts():

--- a/tests/unit/orchestrator/test_trajectories.py
+++ b/tests/unit/orchestrator/test_trajectories.py
@@ -1,5 +1,6 @@
 import base64
 from io import BytesIO
+from typing import Any
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -9,7 +10,6 @@ from PIL import Image
 
 from prime_rl.orchestrator.trajectories import (
     VLMImageCache,
-    _align_routed_experts,
     _deserialize_tool_calls,
     _extract_images_from_examples,
     _extract_images_from_messages,
@@ -17,6 +17,7 @@ from prime_rl.orchestrator.trajectories import (
     build_vlm_image_cache,
     interleave_rollout,
 )
+from prime_rl.transport.routed_experts import RoutedExperts, align_routed_experts
 
 
 def _pixels(data: list[list[float]]) -> tuple[bytes, list[int]]:
@@ -28,6 +29,22 @@ def _pixels(data: list[list[float]]) -> tuple[bytes, list[int]]:
 def _decode_pixels(pixel_bytes: bytes, shape: list[int]) -> list[list[float]]:
     """Decode raw pixel bytes back to nested list for assertions."""
     return np.frombuffer(pixel_bytes, dtype=np.float32).reshape(shape).tolist()
+
+
+def _routed_experts(values: list[list[list[int]]] | np.ndarray) -> RoutedExperts:
+    arr = np.asarray(values, dtype=np.int16)
+    assert arr.ndim == 3
+    return RoutedExperts(shape=list(arr.shape), data=arr.tobytes())
+
+
+def _routed_experts_values(payload: RoutedExperts) -> list[list[list[int]]]:
+    return np.frombuffer(payload.data, dtype=np.int16).reshape(payload.shape).tolist()
+
+
+def _trajectory_step_tokens(**kwargs: Any) -> vf.TrajectoryStepTokens:
+    if "routed_experts" not in kwargs:
+        kwargs["routed_experts"] = None
+    return vf.TrajectoryStepTokens(**kwargs)
 
 
 def test_deserialize_tool_calls_does_not_inject_missing_key():
@@ -66,7 +83,7 @@ def single_step_trajectory_output():
                 prompt=[{"role": "user", "content": "U1"}],
                 completion=[{"role": "assistant", "content": "A1"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2],
                     prompt_mask=[0, 0],
                     completion_ids=[3, 4],
@@ -97,7 +114,7 @@ def multi_step_trajectory_output():
                 prompt=[{"role": "user", "content": "U1"}],
                 completion=[{"role": "assistant", "content": "A1"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2],
                     prompt_mask=[0, 0],
                     completion_ids=[3, 4],
@@ -120,7 +137,7 @@ def multi_step_trajectory_output():
                 ],
                 completion=[{"role": "assistant", "content": "A2"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2, 3, 4, 5, 6],
                     prompt_mask=[0, 0, 0, 0, 0, 0],
                     completion_ids=[7, 8],
@@ -151,7 +168,7 @@ def multi_step_trajectory_with_tool_calls_output():
                 prompt=[{"role": "user", "content": "U1"}],
                 completion=[{"role": "assistant", "content": "A1 + TC1"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2],
                     prompt_mask=[0, 0],
                     completion_ids=[3, 4],
@@ -174,7 +191,7 @@ def multi_step_trajectory_with_tool_calls_output():
                 ],
                 completion=[{"role": "assistant", "content": "A2 + TC2"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2, 3, 4, 5, 6],
                     prompt_mask=[0, 0, 0, 0, 0, 0],
                     completion_ids=[7, 8],
@@ -213,7 +230,7 @@ def multi_step_trajectory_extension_never_holds():
                 prompt=[{"role": "user", "content": "U1"}],
                 completion=[{"role": "assistant", "content": "A1"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2],
                     prompt_mask=[0, 0],
                     completion_ids=[3, 4],
@@ -236,7 +253,7 @@ def multi_step_trajectory_extension_never_holds():
                 ],
                 completion=[{"role": "assistant", "content": "A2"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     # Different tokens - extension breaks (e.g. thinking was stripped)
                     prompt_ids=[10, 20, 30, 40, 50, 60],
                     prompt_mask=[0, 0, 0, 0, 0, 0],
@@ -269,7 +286,7 @@ def multi_step_trajectory_with_tool_calls_extension_never_holds():
                 prompt=[{"role": "user", "content": "U1"}],
                 completion=[{"role": "assistant", "content": "A1 + TC1"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2],
                     prompt_mask=[0, 0],
                     completion_ids=[3, 4],
@@ -292,7 +309,7 @@ def multi_step_trajectory_with_tool_calls_extension_never_holds():
                 ],
                 completion=[{"role": "assistant", "content": "A2 + TC2"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     # Different tokens - extension breaks
                     prompt_ids=[10, 20, 30, 40, 50, 60],
                     prompt_mask=[0, 0, 0, 0, 0, 0],
@@ -434,7 +451,7 @@ def five_step_trajectory_with_extension_break():
                 prompt=[{"role": "user", "content": "U1"}],
                 completion=[{"role": "assistant", "content": "A1"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2],
                     prompt_mask=[0, 0],
                     completion_ids=[3, 4],
@@ -458,7 +475,7 @@ def five_step_trajectory_with_extension_break():
                 ],
                 completion=[{"role": "assistant", "content": "A2"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2, 3, 4, 5, 6],
                     prompt_mask=[0, 0, 0, 0, 0, 0],
                     completion_ids=[7, 8],
@@ -484,7 +501,7 @@ def five_step_trajectory_with_extension_break():
                 ],
                 completion=[{"role": "assistant", "content": "A3"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
                     prompt_mask=[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                     completion_ids=[11, 12],
@@ -512,7 +529,7 @@ def five_step_trajectory_with_extension_break():
                 ],
                 completion=[{"role": "assistant", "content": "A4"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[100, 101, 102, 103],  # completely different tokens (re-rendered)
                     prompt_mask=[0, 0, 0, 0],
                     completion_ids=[104, 105],
@@ -542,7 +559,7 @@ def five_step_trajectory_with_extension_break():
                 ],
                 completion=[{"role": "assistant", "content": "A5"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[100, 101, 102, 103, 104, 105, 106, 107],
                     prompt_mask=[0, 0, 0, 0, 0, 0, 0, 0],
                     completion_ids=[108, 109],
@@ -619,7 +636,7 @@ def interleaved_agents_trajectory():
                 prompt="agent1 turn 1",
                 completion="response 1",
                 response=None,
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2],
                     prompt_mask=[0, 0],
                     completion_ids=[3, 4],
@@ -639,7 +656,7 @@ def interleaved_agents_trajectory():
                 prompt="agent1 turn 2",
                 completion="response 2",
                 response=None,
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2, 3, 4, 5, 6],
                     prompt_mask=[0, 0, 0, 0, 0, 0],
                     completion_ids=[7, 8],
@@ -659,7 +676,7 @@ def interleaved_agents_trajectory():
                 prompt="agent2 turn 1",
                 completion="agent2 response",
                 response=None,
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[100, 101],
                     prompt_mask=[0, 0],
                     completion_ids=[102, 103],
@@ -679,7 +696,7 @@ def interleaved_agents_trajectory():
                 prompt="agent1 turn 3",
                 completion="response 3",
                 response=None,
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
                     prompt_mask=[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                     completion_ids=[11, 12],
@@ -1039,7 +1056,7 @@ def test_interleave_rollout_with_vlm_cache():
                 prompt=[{"role": "user", "content": "Turn 1"}],
                 completion=[{"role": "assistant", "content": "Response 1"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2],
                     prompt_mask=[0, 0],
                     completion_ids=[3, 4],
@@ -1058,7 +1075,7 @@ def test_interleave_rollout_with_vlm_cache():
                 prompt=[{"role": "user", "content": "Turn 2"}],
                 completion=[{"role": "assistant", "content": "Response 2"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2, 3, 4, 5],
                     prompt_mask=[0, 0, 0, 0, 0],
                     completion_ids=[6, 7],
@@ -1113,7 +1130,7 @@ def test_interleave_rollout_uses_cache_key_override():
                 prompt=[{"role": "user", "content": "Turn 1"}],
                 completion=[{"role": "assistant", "content": "Response 1"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2],
                     prompt_mask=[0, 0],
                     completion_ids=[3, 4],
@@ -1164,7 +1181,7 @@ def test_interleave_rollout_vlm_image_then_text_turns():
                 prompt=[{"role": "user", "content": "Describe"}],
                 completion=[{"role": "assistant", "content": "A cat"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2],
                     prompt_mask=[0, 0],
                     completion_ids=[3, 4],
@@ -1184,7 +1201,7 @@ def test_interleave_rollout_vlm_image_then_text_turns():
                 prompt=[{"role": "user", "content": "More detail"}],
                 completion=[{"role": "assistant", "content": "Fluffy"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2, 3, 4, 5, 6],
                     prompt_mask=[0, 0, 0, 0, 0, 0],
                     completion_ids=[7, 8],
@@ -1204,7 +1221,7 @@ def test_interleave_rollout_vlm_image_then_text_turns():
                 prompt=[{"role": "user", "content": "Color?"}],
                 completion=[{"role": "assistant", "content": "Orange"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
                     prompt_mask=[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                     completion_ids=[11, 12],
@@ -1261,7 +1278,7 @@ def test_interleave_rollout_vlm_new_image_mid_conversation():
                 prompt=[{"role": "user", "content": "Image 1"}],
                 completion=[{"role": "assistant", "content": "A"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2],
                     prompt_mask=[0, 0],
                     completion_ids=[3, 4],
@@ -1280,7 +1297,7 @@ def test_interleave_rollout_vlm_new_image_mid_conversation():
                 prompt=[{"role": "user", "content": "Text only"}],
                 completion=[{"role": "assistant", "content": "B"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2, 3, 4, 5, 6],
                     prompt_mask=[0, 0, 0, 0, 0, 0],
                     completion_ids=[7, 8],
@@ -1299,7 +1316,7 @@ def test_interleave_rollout_vlm_new_image_mid_conversation():
                 prompt=[{"role": "user", "content": "Image 2"}],
                 completion=[{"role": "assistant", "content": "C"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
                     prompt_mask=[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                     completion_ids=[11, 12],
@@ -1353,7 +1370,7 @@ def test_interleave_rollout_vlm_extension_break():
                 prompt=[{"role": "user", "content": "Image 1"}],
                 completion=[{"role": "assistant", "content": "A"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2],
                     prompt_mask=[0, 0],
                     completion_ids=[3, 4],
@@ -1373,7 +1390,7 @@ def test_interleave_rollout_vlm_extension_break():
                 prompt=[{"role": "user", "content": "Follow-up"}],
                 completion=[{"role": "assistant", "content": "B"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2, 3, 4, 5, 6],
                     prompt_mask=[0, 0, 0, 0, 0, 0],
                     completion_ids=[7, 8],
@@ -1393,7 +1410,7 @@ def test_interleave_rollout_vlm_extension_break():
                 prompt=[{"role": "user", "content": "Image 2"}],
                 completion=[{"role": "assistant", "content": "C"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[100, 101, 102, 103],
                     prompt_mask=[0, 0, 0, 0],
                     completion_ids=[104, 105],
@@ -1454,7 +1471,7 @@ def test_interleave_rollout_vlm_image_appears_late():
                 prompt=[{"role": "user", "content": "Hello"}],
                 completion=[{"role": "assistant", "content": "Hi"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2],
                     prompt_mask=[0, 0],
                     completion_ids=[3, 4],
@@ -1474,7 +1491,7 @@ def test_interleave_rollout_vlm_image_appears_late():
                 prompt=[{"role": "user", "content": "Question"}],
                 completion=[{"role": "assistant", "content": "Answer"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2, 3, 4, 5, 6],
                     prompt_mask=[0, 0, 0, 0, 0, 0],
                     completion_ids=[7, 8],
@@ -1494,7 +1511,7 @@ def test_interleave_rollout_vlm_image_appears_late():
                 prompt=[{"role": "user", "content": "Describe this"}],
                 completion=[{"role": "assistant", "content": "A photo"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
                     prompt_mask=[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                     completion_ids=[11, 12],
@@ -1549,7 +1566,7 @@ def test_interleave_rollout_error_masks_all_false():
                 prompt=[{"role": "user", "content": "U1"}],
                 completion=[{"role": "assistant", "content": "A1"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2],
                     prompt_mask=[0, 0],
                     completion_ids=[3, 4],
@@ -1568,7 +1585,7 @@ def test_interleave_rollout_error_masks_all_false():
                 prompt=[{"role": "user", "content": "U2"}],
                 completion=[{"role": "assistant", "content": "A2"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2, 3, 4, 5, 6],
                     prompt_mask=[0, 0, 0, 0, 0, 0],
                     completion_ids=[7, 8],
@@ -1634,7 +1651,7 @@ def test_interleave_rollout_vlm_interleaved_agents():
                 prompt=[{"role": "user", "content": "Image A"}],
                 completion=[{"role": "assistant", "content": "A1"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2],
                     prompt_mask=[0, 0],
                     completion_ids=[3, 4],
@@ -1654,7 +1671,7 @@ def test_interleave_rollout_vlm_interleaved_agents():
                 prompt=[{"role": "user", "content": "Follow-up"}],
                 completion=[{"role": "assistant", "content": "A2"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2, 3, 4, 5, 6],
                     prompt_mask=[0, 0, 0, 0, 0, 0],
                     completion_ids=[7, 8],
@@ -1674,7 +1691,7 @@ def test_interleave_rollout_vlm_interleaved_agents():
                 prompt=[{"role": "user", "content": "Image B"}],
                 completion=[{"role": "assistant", "content": "B1"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[100, 101],
                     prompt_mask=[0, 0],
                     completion_ids=[102, 103],
@@ -1694,7 +1711,7 @@ def test_interleave_rollout_vlm_interleaved_agents():
                 prompt=[{"role": "user", "content": "Image C added"}],
                 completion=[{"role": "assistant", "content": "A3"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
                     prompt_mask=[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                     completion_ids=[11, 12],
@@ -1853,40 +1870,45 @@ def test_build_vlm_image_cache_no_images():
 
 
 def test_align_routed_experts_none():
-    assert _align_routed_experts(None, 10) is None
+    assert align_routed_experts(None, 10) is None
 
 
 def test_align_routed_experts_empty():
-    result = _align_routed_experts([], 0)
-    assert result == []
+    result = align_routed_experts(_routed_experts(np.zeros((0, 2, 2), dtype=np.int16)), 0)
+    assert result is not None
+    assert result.shape == [0, 2, 2]
+    assert result.data == b""
 
 
 def test_align_routed_experts_no_deficit():
     # 3 tokens, 2 layers, topk=2
     experts = [[[0, 1], [2, 3]], [[4, 5], [6, 7]], [[0, 2], [1, 3]]]
-    result = _align_routed_experts(experts, expected_len=3)
-    assert result == experts
+    result = align_routed_experts(_routed_experts(experts), expected_len=3)
+    assert result is not None
+    assert _routed_experts_values(result) == experts
 
 
 def test_align_routed_experts_with_deficit():
     experts = [[[1, 2], [3, 4]], [[5, 6], [7, 0]]]
-    result = _align_routed_experts(experts, expected_len=3)
-    assert len(result) == 3
-    assert result[:2] == experts
+    result = align_routed_experts(_routed_experts(experts), expected_len=3)
+    assert result is not None
+    values = _routed_experts_values(result)
+    assert len(values) == 3
+    assert values[:2] == experts
     # Padded entries should be zero-filled with same shape [layers=2, topk=2]
-    assert result[2] == [[0, 0], [0, 0]]
+    assert values[2] == [[0, 0], [0, 0]]
 
 
 def test_align_routed_experts_rejects_large_deficit():
     experts = [[[1, 2], [3, 4]], [[5, 6], [7, 0]]]
     with pytest.raises(AssertionError):
-        _align_routed_experts(experts, expected_len=4)
+        align_routed_experts(_routed_experts(experts), expected_len=4)
 
 
 def test_align_routed_experts_excess_length():
     experts = [[[1, 2]], [[3, 4]], [[5, 6]]]
     with pytest.raises(AssertionError):
-        _align_routed_experts(experts, expected_len=2)
+        align_routed_experts(_routed_experts(experts), expected_len=2)
 
 
 def test_interleave_rollout_single_step_with_routed_experts():
@@ -1901,7 +1923,7 @@ def test_interleave_rollout_single_step_with_routed_experts():
                 prompt=[{"role": "user", "content": "U1"}],
                 completion=[{"role": "assistant", "content": "A1"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2],
                     prompt_mask=[0, 0],
                     completion_ids=[3, 4],
@@ -1909,7 +1931,7 @@ def test_interleave_rollout_single_step_with_routed_experts():
                     completion_logprobs=[-0.1, -0.2],
                     overlong_prompt=False,
                     is_truncated=False,
-                    routed_experts=routed_experts_from_vllm,
+                    routed_experts=_routed_experts(routed_experts_from_vllm),
                 ),
                 reward=None,
                 advantage=None,
@@ -1929,10 +1951,11 @@ def test_interleave_rollout_single_step_with_routed_experts():
 
     # Should be aligned to 4 tokens (2 prompt + 2 completion)
     assert sample.routed_experts is not None
-    assert len(sample.routed_experts) == 4
+    routed_values = _routed_experts_values(sample.routed_experts)
+    assert len(routed_values) == 4
     # First 3 are original, last one is zero-padded
-    assert sample.routed_experts[:3] == routed_experts_from_vllm
-    assert sample.routed_experts[3] == [[0, 0]]
+    assert routed_values[:3] == routed_experts_from_vllm
+    assert routed_values[3] == [[0, 0]]
 
 
 def test_interleave_rollout_multi_step_with_routed_experts():
@@ -1949,7 +1972,7 @@ def test_interleave_rollout_multi_step_with_routed_experts():
                 prompt=[{"role": "user", "content": "U1"}],
                 completion=[{"role": "assistant", "content": "A1"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2],
                     prompt_mask=[0, 0],
                     completion_ids=[3, 4],
@@ -1957,7 +1980,7 @@ def test_interleave_rollout_multi_step_with_routed_experts():
                     completion_logprobs=[-0.1, -0.2],
                     overlong_prompt=False,
                     is_truncated=False,
-                    routed_experts=step1_experts,
+                    routed_experts=_routed_experts(step1_experts),
                 ),
                 reward=None,
                 advantage=None,
@@ -1973,7 +1996,7 @@ def test_interleave_rollout_multi_step_with_routed_experts():
                 ],
                 completion=[{"role": "assistant", "content": "A2"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2, 3, 4, 5, 6],
                     prompt_mask=[0, 0, 0, 0, 0, 0],
                     completion_ids=[7, 8],
@@ -1981,7 +2004,7 @@ def test_interleave_rollout_multi_step_with_routed_experts():
                     completion_logprobs=[-0.3, -0.4],
                     overlong_prompt=False,
                     is_truncated=False,
-                    routed_experts=step2_experts,
+                    routed_experts=_routed_experts(step2_experts),
                 ),
                 reward=None,
                 advantage=None,
@@ -2002,7 +2025,7 @@ def test_interleave_rollout_multi_step_with_routed_experts():
     # Merged sample: prompt=[1,2], completion=[3,4,5,6,7,8] -> 8 tokens total
     assert len(sample.prompt_ids) + len(sample.completion_ids) == 8
     assert sample.routed_experts is not None
-    assert len(sample.routed_experts) == 8
+    assert sample.routed_experts.shape[0] == 8
 
 
 def test_interleave_rollout_none_routed_experts_stays_none():
@@ -2014,7 +2037,7 @@ def test_interleave_rollout_none_routed_experts_stays_none():
                 prompt=[{"role": "user", "content": "U1"}],
                 completion=[{"role": "assistant", "content": "A1"}],
                 response=MagicMock(),
-                tokens=vf.TrajectoryStepTokens(
+                tokens=_trajectory_step_tokens(
                     prompt_ids=[1, 2],
                     prompt_mask=[0, 0],
                     completion_ids=[3, 4],

--- a/tests/unit/orchestrator/test_trajectories.py
+++ b/tests/unit/orchestrator/test_trajectories.py
@@ -1857,7 +1857,7 @@ def test_align_routed_experts_none():
 
 
 def test_align_routed_experts_empty():
-    result = _align_routed_experts([], 10)
+    result = _align_routed_experts([], 0)
     assert result == []
 
 
@@ -1869,21 +1869,24 @@ def test_align_routed_experts_no_deficit():
 
 
 def test_align_routed_experts_with_deficit():
-    # 2 tokens but expected 4 (deficit of 2)
     experts = [[[1, 2], [3, 4]], [[5, 6], [7, 0]]]
-    result = _align_routed_experts(experts, expected_len=4)
-    assert len(result) == 4
+    result = _align_routed_experts(experts, expected_len=3)
+    assert len(result) == 3
     assert result[:2] == experts
     # Padded entries should be zero-filled with same shape [layers=2, topk=2]
     assert result[2] == [[0, 0], [0, 0]]
-    assert result[3] == [[0, 0], [0, 0]]
+
+
+def test_align_routed_experts_rejects_large_deficit():
+    experts = [[[1, 2], [3, 4]], [[5, 6], [7, 0]]]
+    with pytest.raises(AssertionError):
+        _align_routed_experts(experts, expected_len=4)
 
 
 def test_align_routed_experts_excess_length():
     experts = [[[1, 2]], [[3, 4]], [[5, 6]]]
-    result = _align_routed_experts(experts, expected_len=2)
-    # No truncation, just returns as-is
-    assert result == experts
+    with pytest.raises(AssertionError):
+        _align_routed_experts(experts, expected_len=2)
 
 
 def test_interleave_rollout_single_step_with_routed_experts():

--- a/tests/unit/train/models/test_qwen3_moe.py
+++ b/tests/unit/train/models/test_qwen3_moe.py
@@ -134,9 +134,14 @@ def test_qwen3_moe_router_replay():
     # Forward without router replay
     out_normal = prime_model(input_ids, position_ids)
 
-    # Construct routed_experts with fixed expert indices
-    # Shape: [batch=1, seq_len=100, num_hidden_layers=3, num_experts_per_tok=4]
-    num_layers = prime_model.config.num_hidden_layers
+    # Construct routed_experts with fixed expert indices.
+    # Shape: [batch=1, seq_len=100, num_moe_layers=2, num_experts_per_tok=4].
+    num_layers = sum(
+        layer_idx not in prime_model.config.mlp_only_layers
+        and prime_model.config.num_experts > 0
+        and (layer_idx + 1) % prime_model.config.decoder_sparse_step == 0
+        for layer_idx in range(prime_model.config.num_hidden_layers)
+    )
     topk = prime_model.config.num_experts_per_tok
     routed_experts = torch.randint(0, prime_model.config.num_experts, (1, 100, num_layers, topk), device="cuda")
 

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ supported-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-04T22:30:42.685600927Z"
+exclude-newer = "2026-05-05T03:20:50.010629626Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -35,6 +35,7 @@ aime2025 = false
 vllm = false
 vllm-router = false
 color-codeword = false
+rlm-swe = false
 nixl-cu12 = false
 flash-attn-3 = false
 prime-tunnel = false
@@ -43,6 +44,7 @@ aime2024 = false
 math-env = false
 prime-sandboxes = false
 logic-env = false
+wordle = false
 prime = false
 
 [manifest]
@@ -261,6 +263,15 @@ wheels = [
 ]
 
 [[package]]
+name = "bashlex"
+version = "0.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/60/aae0bb54f9af5e0128ba90eb83d8d0d506ee8f0475c4fdda3deeda20b1d2/bashlex-0.18.tar.gz", hash = "sha256:5bb03a01c6d5676338c36fd1028009c8ad07e7d61d8a1ce3f513b7fff52796ee", size = 68742, upload-time = "2023-01-18T15:21:26.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/be/6985abb1011fda8a523cfe21ed9629e397d6e06fb5bae99750402b25c95b/bashlex-0.18-py2.py3-none-any.whl", hash = "sha256:91d73a23a3e51711919c1c899083890cdecffc91d8c088942725ac13e9dcfffa", size = 69539, upload-time = "2023-01-18T15:21:24.167Z" },
+]
+
+[[package]]
 name = "bcrypt"
 version = "5.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -412,6 +423,12 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/35/6525b21aa0db614cf8b5792d232021dca3df7f90a1944db934efa5d20bb1/charset_normalizer-3.4.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:320e8e66157cc4e247d9ddca8e21f427efc7a04bbd0ac8a9faf56583fa543f9f", size = 153173, upload-time = "2025-08-09T07:56:20.289Z" },
     { url = "https://files.pythonhosted.org/packages/8a/1f/f041989e93b001bc4e44bb1669ccdcf54d3f00e628229a85b08d330615c5/charset_normalizer-3.4.3-py3-none-any.whl", hash = "sha256:ce571ab16d890d23b5c278547ba694193a45011ff86a9162a71307ed9f86759a", size = 53175, upload-time = "2025-08-09T07:57:26.864Z" },
 ]
+
+[[package]]
+name = "chess"
+version = "1.11.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/09/7d04d7581ae3bb8b598017941781bceb7959dd1b13e3ebf7b6a2cd843bc9/chess-1.11.2.tar.gz", hash = "sha256:a8b43e5678fdb3000695bdaa573117ad683761e5ca38e591c4826eba6d25bb39", size = 6131385, upload-time = "2025-02-25T19:10:27.328Z" }
 
 [[package]]
 name = "chromadb"
@@ -651,6 +668,19 @@ nvrtc = [
 ]
 nvtx = [
     { name = "nvidia-nvtx-cu12", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+
+[[package]]
+name = "dataclasses-json"
+version = "0.6.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "marshmallow", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "typing-inspect", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/a4/f71d9cf3a5ac257c993b5ca3f93df5f7fb395c725e7f1e6479d2514173c3/dataclasses_json-0.6.7.tar.gz", hash = "sha256:b6b3e528266ea45b9535223bc53ca645f5208833c29229e847b3f26a1cc55fc0", size = 32227, upload-time = "2024-06-09T16:20:19.103Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/be/d0d44e092656fe7a06b55e6103cbce807cdbdee17884a5367c68c9860853/dataclasses_json-0.6.7-py3-none-any.whl", hash = "sha256:0dbf33f26c8d5305befd61b39d2b3414e8a407bedc2834dea9b8d642666fb40a", size = 28686, upload-time = "2024-06-09T16:20:16.715Z" },
 ]
 
 [[package]]
@@ -1510,6 +1540,15 @@ wheels = [
 ]
 
 [[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.25.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1767,6 +1806,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/f0/89e7aadfb3749d0f52234a0c8c7867877876e0a20b60e2188e9850794c17/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e17c96c14e19278594aa4841ec148115f9c7615a47382ecb6b82bd8fea3ab0c8", size = 23118, upload-time = "2024-10-18T15:21:17.133Z" },
     { url = "https://files.pythonhosted.org/packages/da/0e/1f32af846df486dce7c227fe0f2398dc7e2e51d4a370508281f3c1c5cddc/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2181e67807fc2fa785d0592dc2d6206c019b9502410671cc905d132a92866557", size = 24178, upload-time = "2024-10-18T15:21:18.859Z" },
     { url = "https://files.pythonhosted.org/packages/a2/82/8be4c96ffee03c5b4a034e60a31294daf481e12c7c43ab8e34a1453ee48b/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ad10d3ded218f1039f11a75f8091880239651b52e9bb592ca27de44eed242a48", size = 23352, upload-time = "2024-10-18T15:21:20.971Z" },
+]
+
+[[package]]
+name = "marshmallow"
+version = "3.26.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/79/de6c16cc902f4fc372236926b0ce2ab7845268dcc30fb2fbb7f71b418631/marshmallow-3.26.2.tar.gz", hash = "sha256:bbe2adb5a03e6e3571b573f42527c6fe926e17467833660bebd11593ab8dfd57", size = 222095, upload-time = "2025-12-22T06:53:53.309Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/2f/5108cb3ee4ba6501748c4908b908e55f42a5b66245b4cfe0c99326e1ef6e/marshmallow-3.26.2-py3-none-any.whl", hash = "sha256:013fa8a3c4c276c24d26d84ce934dc964e2aa794345a0f8c7e5a7191482c8a73", size = 50964, upload-time = "2025-12-22T06:53:51.801Z" },
 ]
 
 [[package]]
@@ -2070,6 +2121,26 @@ wheels = [
 ]
 
 [[package]]
+name = "multi-swe-bench"
+version = "1.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dataclasses-json", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "docker", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "gitpython", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pygithub", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pyyaml", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "swe-rex", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "toml", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "tqdm", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "unidiff", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/ad/6b7cda600a50392c790b14ee420b9a3bb318a982a298c05f2d1c066a434f/multi_swe_bench-1.1.2.tar.gz", hash = "sha256:44944bc6608d7d9b8d4390f3ce0a3b2c69122ea6be6e35766c6fde2328f50392", size = 1267660, upload-time = "2025-12-18T07:16:09.584Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/a8/060eb46096742944d8d37c34094d4e0fb34b28c6291a877388543ea65660/multi_swe_bench-1.1.2-py3-none-any.whl", hash = "sha256:09a5770096d6a035383c5240762ffa8c87b1e8df7d374110de8fb781b4e5a9f9", size = 4942355, upload-time = "2025-12-18T07:16:07.468Z" },
+]
+
+[[package]]
 name = "multidict"
 version = "6.6.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2096,6 +2167,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/7d/a988f258104dcd2ccf1ed40fdc97e26c4ac351eeaf81d76e266c52d84e2f/multiprocess-0.70.16-py312-none-any.whl", hash = "sha256:fc0544c531920dde3b00c29863377f87e1632601092ea2daca74e4beb40faa2e", size = 146741, upload-time = "2024-01-28T18:52:29.395Z" },
     { url = "https://files.pythonhosted.org/packages/ea/89/38df130f2c799090c978b366cfdf5b96d08de5b29a4a293df7f7429fa50b/multiprocess-0.70.16-py38-none-any.whl", hash = "sha256:a71d82033454891091a226dfc319d0cfa8019a4e888ef9ca910372a446de4435", size = 132628, upload-time = "2024-01-28T18:52:30.853Z" },
     { url = "https://files.pythonhosted.org/packages/da/d9/f7f9379981e39b8c2511c9e0326d212accacb82f12fbfdc1aa2ce2a7b2b6/multiprocess-0.70.16-py39-none-any.whl", hash = "sha256:a0bafd3ae1b732eac64be2e72038231c1ba97724b60b09400d68f229fcc2fbf3", size = 133351, upload-time = "2024-01-28T18:52:31.981Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
 ]
 
 [[package]]
@@ -2174,6 +2254,21 @@ wheels = [
 requires-dist = [
     { name = "numpy" },
     { name = "torch" },
+]
+
+[[package]]
+name = "nltk"
+version = "3.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "joblib", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "regex", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "tqdm", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/a1/b3b4adf15585a5bc4c357adde150c01ebeeb642173ded4d871e89468767c/nltk-3.9.4.tar.gz", hash = "sha256:ed03bc098a40481310320808b2db712d95d13ca65b27372f8a403949c8b523d0", size = 2946864, upload-time = "2026-03-24T06:13:40.641Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/91/04e965f8e717ba0ab4bdca5c112deeab11c9e750d94c4d4602f050295d39/nltk-3.9.4-py3-none-any.whl", hash = "sha256:f2fa301c3a12718ce4a0e9305c5675299da5ad9e26068218b69d692fda84828f", size = 1552087, upload-time = "2026-03-24T06:13:38.47Z" },
 ]
 
 [[package]]
@@ -2835,7 +2930,7 @@ dependencies = [
     { name = "transformers", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "uvloop", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "verifiers", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "vllm", version = "0.20.2rc1.dev209+ga1c9051bc.precompiled", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev209%2Bga1c9051bc.precompiled-cp312-cp312-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "vllm", version = "0.20.2rc1.dev212+gcba9775b5.precompiled", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev212%2Bgcba9775b5.precompiled-cp312-cp312-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "vllm", version = "0.20.2+cu129", source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.20.2/vllm-0.20.2+cu129-cp38-abi3-manylinux_2_31_aarch64.whl" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
     { name = "wandb", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
@@ -2872,8 +2967,10 @@ envs = [
     { name = "math500", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "mini-swe-agent-plus", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "reverse-text", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "rlm-swe", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "science-env", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "wiki-search", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "wordle", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 flash-attn = [
     { name = "flash-attn", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -2949,6 +3046,7 @@ requires-dist = [
     { name = "reverse-text", marker = "extra == 'envs'", index = "https://hub.primeintellect.ai/primeintellect/simple/" },
     { name = "rich", specifier = ">=14.0.0" },
     { name = "ring-flash-attn", specifier = ">=0.1.8" },
+    { name = "rlm-swe", marker = "extra == 'envs'", editable = "/shared/research-prod/research-environments/environments/rlm_swe" },
     { name = "science-env", marker = "extra == 'envs'", index = "https://hub.primeintellect.ai/primeintellect/simple/" },
     { name = "setproctitle", specifier = ">=1.3.0" },
     { name = "tenacity", specifier = ">=8.2.0" },
@@ -2960,13 +3058,14 @@ requires-dist = [
     { name = "torchvision", index = "https://download.pytorch.org/whl/cu128" },
     { name = "transformers", git = "https://github.com/huggingface/transformers.git?rev=c1c3424" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=8dbd674" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=b76a6bb" },
     { name = "vllm", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'", specifier = ">=0.20.2" },
     { name = "vllm", marker = "platform_machine == 'aarch64'", url = "https://github.com/vllm-project/vllm/releases/download/v0.20.2/vllm-0.20.2+cu129-cp38-abi3-manylinux_2_31_aarch64.whl" },
-    { name = "vllm", marker = "platform_machine == 'x86_64'", url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev209%2Bga1c9051bc.precompiled-cp312-cp312-linux_x86_64.whl" },
-    { name = "vllm-router", marker = "platform_machine == 'x86_64' and extra == 'disagg'", url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.22/vllm_router-0.1.22-cp38-abi3-manylinux_2_28_x86_64.whl" },
+    { name = "vllm", marker = "platform_machine == 'x86_64'", url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev212%2Bgcba9775b5.precompiled-cp312-cp312-linux_x86_64.whl" },
+    { name = "vllm-router", marker = "platform_machine == 'x86_64' and extra == 'disagg'", path = "/beegfs/outputs/vllm-router-wheels/pr28-ca0de22/vllm_router-0.1.23-cp38-abi3-linux_x86_64.whl" },
     { name = "wandb", specifier = ">=0.26.1" },
     { name = "wiki-search", marker = "extra == 'envs'", index = "https://hub.primeintellect.ai/primeintellect/simple/" },
+    { name = "wordle", marker = "extra == 'envs'", index = "https://hub.primeintellect.ai/primeintellect/simple/" },
 ]
 provides-extras = ["flash-attn", "flash-attn-3", "flash-attn-cute", "envs", "disagg", "gpt-oss", "quack", "all"]
 
@@ -3246,6 +3345,22 @@ wheels = [
 ]
 
 [[package]]
+name = "pygithub"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyjwt", extra = ["crypto"], marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pynacl", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "requests", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "typing-extensions", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "urllib3", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/c3/8465a311197e16cf5ab68789fe689535e90f6b61ab524cc32a39e67237ae/pygithub-2.9.1.tar.gz", hash = "sha256:59771d7ff63d54d427be2e7d0dad2208dfffc2b0a045fec959263787739b611c", size = 2594989, upload-time = "2026-04-14T07:26:13.622Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/aa/81a5506f089a26338bff17535e4339b3b22049ebd1bcdeff756c4d7a7559/pygithub-2.9.1-py3-none-any.whl", hash = "sha256:2ec78fca30092d51a42d76f4ddb02131b6f0c666a35dfdf364cf302cdda115b9", size = 449710, upload-time = "2026-04-14T07:26:12.382Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3266,6 +3381,25 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+
+[[package]]
+name = "pynacl"
+version = "1.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "(platform_machine == 'aarch64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/9a/4019b524b03a13438637b11538c82781a5eda427394380381af8f04f467a/pynacl-1.6.2.tar.gz", hash = "sha256:018494d6d696ae03c7e656e5e74cdfd8ea1326962cc401bcf018f1ed8436811c", size = 3511692, upload-time = "2026-01-01T17:48:10.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/b4/e927e0653ba63b02a4ca5b4d852a8d1d678afbf69b3dbf9c4d0785ac905c/pynacl-1.6.2-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8845c0631c0be43abdd865511c41eab235e0be69c81dc66a50911594198679b0", size = 800020, upload-time = "2026-01-01T17:32:18.34Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/81/d60984052df5c97b1d24365bc1e30024379b42c4edcd79d2436b1b9806f2/pynacl-1.6.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:22de65bb9010a725b0dac248f353bb072969c94fa8d6b1f34b87d7953cf7bbe4", size = 1399174, upload-time = "2026-01-01T17:32:20.239Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f7/322f2f9915c4ef27d140101dd0ed26b479f7e6f5f183590fd32dfc48c4d3/pynacl-1.6.2-cp38-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46065496ab748469cdd999246d17e301b2c24ae2fdf739132e580a0e94c94a87", size = 835085, upload-time = "2026-01-01T17:32:22.24Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d0/f301f83ac8dbe53442c5a43f6a39016f94f754d7a9815a875b65e218a307/pynacl-1.6.2-cp38-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a66d6fb6ae7661c58995f9c6435bda2b1e68b54b598a6a10247bfcdadac996c", size = 1437614, upload-time = "2026-01-01T17:32:23.766Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/58/fc6e649762b029315325ace1a8c6be66125e42f67416d3dbd47b69563d61/pynacl-1.6.2-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:26bfcd00dcf2cf160f122186af731ae30ab120c18e8375684ec2670dccd28130", size = 818251, upload-time = "2026-01-01T17:32:25.69Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a8/b917096b1accc9acd878819a49d3d84875731a41eb665f6ebc826b1af99e/pynacl-1.6.2-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c8a231e36ec2cab018c4ad4358c386e36eede0319a0c41fed24f840b1dac59f6", size = 1402859, upload-time = "2026-01-01T17:32:27.215Z" },
+    { url = "https://files.pythonhosted.org/packages/85/42/fe60b5f4473e12c72f977548e4028156f4d340b884c635ec6b063fe7e9a5/pynacl-1.6.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:68be3a09455743ff9505491220b64440ced8973fe930f270c8e07ccfa25b1f9e", size = 791926, upload-time = "2026-01-01T17:32:29.314Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f9/e40e318c604259301cc091a2a63f237d9e7b424c4851cafaea4ea7c4834e/pynacl-1.6.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b097553b380236d51ed11356c953bf8ce36a29a3e596e934ecabe76c985a577", size = 1363101, upload-time = "2026-01-01T17:32:31.263Z" },
 ]
 
 [[package]]
@@ -3534,6 +3668,25 @@ wheels = [
 ]
 
 [[package]]
+name = "rlm-swe"
+version = "0.3.3"
+source = { editable = "/shared/research-prod/research-environments/environments/rlm_swe" }
+dependencies = [
+    { name = "multi-swe-bench", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "prime-sandboxes", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "swebench", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "verifiers", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "multi-swe-bench", specifier = ">=1.1.2" },
+    { name = "prime-sandboxes", specifier = ">=0.2.19" },
+    { name = "swebench", specifier = "==4.1.0" },
+    { name = "verifiers", specifier = ">=0.1.13.dev8" },
+]
+
+[[package]]
 name = "rpds-py"
 version = "0.27.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3720,6 +3873,25 @@ wheels = [
 ]
 
 [[package]]
+name = "swe-rex"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bashlex", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "fastapi", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pexpect", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pydantic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "python-multipart", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "requests", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "rich", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "uvicorn", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/86/a069f93ec866151a4d476d546e60220e66b3788878b6e248b2df3ab2c5f1/swe_rex-1.4.0.tar.gz", hash = "sha256:14f8a24c49a63f9e251340b1109ac75a4aacbaece410f8599209de9bfca843c0", size = 41755, upload-time = "2025-08-14T01:19:20.22Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/0d/d06ab2aa78138055c297490762cd7b4d8ac58a544783f874c869cdb7b534/swe_rex-1.4.0-py3-none-any.whl", hash = "sha256:61261ad03eb23b717b5901cd5d229f24f6e1be2e120aad5c2e5ea3384a1d15ad", size = 47756, upload-time = "2025-08-14T01:19:18.93Z" },
+]
+
+[[package]]
 name = "swebench"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3813,6 +3985,24 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/13/e503968fefabd4c6b2650af21e110aa8466fe21432cd7c43a84577a89438/tensorboard_data_server-0.7.2-py3-none-any.whl", hash = "sha256:7e0610d205889588983836ec05dc098e80f97b7e7bbff7e994ebb78f578d0ddb", size = 2356, upload-time = "2023-10-23T21:23:32.16Z" },
     { url = "https://files.pythonhosted.org/packages/73/c6/825dab04195756cf8ff2e12698f22513b3db2f64925bdd41671bfb33aaa5/tensorboard_data_server-0.7.2-py3-none-manylinux_2_31_x86_64.whl", hash = "sha256:ef687163c24185ae9754ed5650eb5bc4d84ff257aabdc33f0cc6f74d8ba54530", size = 6590363, upload-time = "2023-10-23T21:23:35.583Z" },
+]
+
+[[package]]
+name = "textarena"
+version = "0.7.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "chess", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nltk", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "openai", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "python-dotenv", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "requests", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "rich", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "websockets", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/04/4a3ca42093d0be2a9c377ae3335a6c6baac1d278ae932562ec69f339d172/textarena-0.7.4.tar.gz", hash = "sha256:28bb9170d7718f2ae05e4515bea82262422731e563fc7318a9e7983de0cadd4f", size = 954969, upload-time = "2025-10-16T14:41:55.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/b4/9a9ba65154aff853c75b3d7324319d168ad9c69c6097f4aa3c16da7d9ef3/textarena-0.7.4-py3-none-any.whl", hash = "sha256:684784e78278e518066f67557ee93b47c238d16cbbd15d3abdaa3147562d3024", size = 1073570, upload-time = "2025-10-16T14:41:53.965Z" },
 ]
 
 [[package]]
@@ -4124,6 +4314,19 @@ wheels = [
 ]
 
 [[package]]
+name = "typing-inspect"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy-extensions", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "typing-extensions", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78", size = 13825, upload-time = "2023-05-24T20:25:47.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f", size = 8827, upload-time = "2023-05-24T20:25:45.287Z" },
+]
+
+[[package]]
 name = "typing-inspection"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -4223,7 +4426,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.14"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=8dbd674#8dbd6748e4ffed2144b12eb091a60c8d058e6989" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=b76a6bb#b76a6bb7901fff2316a2b4277ba2ea1f9f8f11dd" }
 dependencies = [
     { name = "aiolimiter", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "anthropic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -4266,8 +4469,8 @@ wheels = [
 
 [[package]]
 name = "vllm"
-version = "0.20.2rc1.dev209+ga1c9051bc.precompiled"
-source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev209%2Bga1c9051bc.precompiled-cp312-cp312-linux_x86_64.whl" }
+version = "0.20.2rc1.dev212+gcba9775b5.precompiled"
+source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev212%2Bgcba9775b5.precompiled-cp312-cp312-linux_x86_64.whl" }
 resolution-markers = [
     "platform_machine == 'x86_64' and sys_platform == 'linux'",
 ]
@@ -4342,7 +4545,7 @@ dependencies = [
     { name = "xgrammar", version = "0.2.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev209%2Bga1c9051bc.precompiled-cp312-cp312-linux_x86_64.whl", hash = "sha256:9f9fd0f24f6c93082e2449c37d6fa3e18a8ced838e0831db7563f358776db1d2" },
+    { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev212%2Bgcba9775b5.precompiled-cp312-cp312-linux_x86_64.whl", hash = "sha256:3e625083ce0ed7ab2a941fdd84e34571ad35425890fba82196052405cc6acdc9" },
 ]
 
 [package.metadata]
@@ -4616,8 +4819,8 @@ provides-extras = ["zen", "bench", "tensorizer", "fastsafetensors", "instanttens
 
 [[package]]
 name = "vllm-router"
-version = "0.1.22"
-source = { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.22/vllm_router-0.1.22-cp38-abi3-manylinux_2_28_x86_64.whl" }
+version = "0.1.23"
+source = { path = "/beegfs/outputs/vllm-router-wheels/pr28-ca0de22/vllm_router-0.1.23-cp38-abi3-linux_x86_64.whl" }
 dependencies = [
     { name = "aiohttp", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "fastapi", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -4627,7 +4830,7 @@ dependencies = [
     { name = "uvicorn", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.22/vllm_router-0.1.22-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6361a0387241e56932f3ba2e51af27f58d11a462e3187e58286b2f96056e4d15" },
+    { filename = "vllm_router-0.1.23-cp38-abi3-linux_x86_64.whl", hash = "sha256:9c8c4ecc1cfb0c88283e6afc243c0622348a59ee83a87e32e5b126de6e4463e0" },
 ]
 
 [package.metadata]
@@ -4756,6 +4959,19 @@ dependencies = [
 ]
 wheels = [
     { url = "https://hub.primeintellect.ai/primeintellect/wiki-search/@10d58ffe/wiki_search-0.1.23-py3-none-any.whl", hash = "sha256:ffeff890f2d14d7b2910baf57c27f6939da0f669ae0c4545916762f3f4edd75b" },
+]
+
+[[package]]
+name = "wordle"
+version = "0.1.7"
+source = { registry = "https://hub.primeintellect.ai/primeintellect/simple/" }
+dependencies = [
+    { name = "nltk", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "textarena", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "verifiers", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+wheels = [
+    { url = "https://hub.primeintellect.ai/primeintellect/wordle/@4373cedc/wordle-0.1.7-py2.py3-none-any.whl", hash = "sha256:ca598f461b148e49870baea444e836d8a1eb67752292f716001e9b9269c2203f" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -11,41 +11,38 @@ supported-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-05T03:20:50.010629626Z"
+exclude-newer = "2026-05-05T19:08:02.919471519Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
+vllm = false
 verifiers = false
+vllm-router = false
 dion = false
 alphabet-sort = false
 science-env = false
+color-codeword = false
+nixl-cu12 = false
+flash-attn-3 = false
+prime-tunnel = false
+prime-sandboxes = false
+deep-gemm = false
+aime2024 = false
 prime-evals = false
 deepdive = false
+prime = false
 reverse-text = false
 code-env = false
 mini-swe-agent-plus = false
 deep-ep = false
 pydantic-config = false
 renderers = false
-mistral-common = false
+math-env = false
+logic-env = false
 wiki-search = false
 math-python = false
 math500 = false
 aime2025 = false
-vllm = false
-vllm-router = false
-color-codeword = false
-rlm-swe = false
-nixl-cu12 = false
-flash-attn-3 = false
-prime-tunnel = false
-deep-gemm = false
-aime2024 = false
-math-env = false
-prime-sandboxes = false
-logic-env = false
-wordle = false
-prime = false
 
 [manifest]
 members = [
@@ -263,15 +260,6 @@ wheels = [
 ]
 
 [[package]]
-name = "bashlex"
-version = "0.18"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/76/60/aae0bb54f9af5e0128ba90eb83d8d0d506ee8f0475c4fdda3deeda20b1d2/bashlex-0.18.tar.gz", hash = "sha256:5bb03a01c6d5676338c36fd1028009c8ad07e7d61d8a1ce3f513b7fff52796ee", size = 68742, upload-time = "2023-01-18T15:21:26.402Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/be/6985abb1011fda8a523cfe21ed9629e397d6e06fb5bae99750402b25c95b/bashlex-0.18-py2.py3-none-any.whl", hash = "sha256:91d73a23a3e51711919c1c899083890cdecffc91d8c088942725ac13e9dcfffa", size = 69539, upload-time = "2023-01-18T15:21:24.167Z" },
-]
-
-[[package]]
 name = "bcrypt"
 version = "5.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -423,12 +411,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/35/6525b21aa0db614cf8b5792d232021dca3df7f90a1944db934efa5d20bb1/charset_normalizer-3.4.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:320e8e66157cc4e247d9ddca8e21f427efc7a04bbd0ac8a9faf56583fa543f9f", size = 153173, upload-time = "2025-08-09T07:56:20.289Z" },
     { url = "https://files.pythonhosted.org/packages/8a/1f/f041989e93b001bc4e44bb1669ccdcf54d3f00e628229a85b08d330615c5/charset_normalizer-3.4.3-py3-none-any.whl", hash = "sha256:ce571ab16d890d23b5c278547ba694193a45011ff86a9162a71307ed9f86759a", size = 53175, upload-time = "2025-08-09T07:57:26.864Z" },
 ]
-
-[[package]]
-name = "chess"
-version = "1.11.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/93/09/7d04d7581ae3bb8b598017941781bceb7959dd1b13e3ebf7b6a2cd843bc9/chess-1.11.2.tar.gz", hash = "sha256:a8b43e5678fdb3000695bdaa573117ad683761e5ca38e591c4826eba6d25bb39", size = 6131385, upload-time = "2025-02-25T19:10:27.328Z" }
 
 [[package]]
 name = "chromadb"
@@ -668,19 +650,6 @@ nvrtc = [
 ]
 nvtx = [
     { name = "nvidia-nvtx-cu12", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-]
-
-[[package]]
-name = "dataclasses-json"
-version = "0.6.7"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "marshmallow", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typing-inspect", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/64/a4/f71d9cf3a5ac257c993b5ca3f93df5f7fb395c725e7f1e6479d2514173c3/dataclasses_json-0.6.7.tar.gz", hash = "sha256:b6b3e528266ea45b9535223bc53ca645f5208833c29229e847b3f26a1cc55fc0", size = 32227, upload-time = "2024-06-09T16:20:19.103Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/be/d0d44e092656fe7a06b55e6103cbce807cdbdee17884a5367c68c9860853/dataclasses_json-0.6.7-py3-none-any.whl", hash = "sha256:0dbf33f26c8d5305befd61b39d2b3414e8a407bedc2834dea9b8d642666fb40a", size = 28686, upload-time = "2024-06-09T16:20:16.715Z" },
 ]
 
 [[package]]
@@ -1540,15 +1509,6 @@ wheels = [
 ]
 
 [[package]]
-name = "joblib"
-version = "1.5.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
-]
-
-[[package]]
 name = "jsonschema"
 version = "4.25.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1806,18 +1766,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/f0/89e7aadfb3749d0f52234a0c8c7867877876e0a20b60e2188e9850794c17/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e17c96c14e19278594aa4841ec148115f9c7615a47382ecb6b82bd8fea3ab0c8", size = 23118, upload-time = "2024-10-18T15:21:17.133Z" },
     { url = "https://files.pythonhosted.org/packages/da/0e/1f32af846df486dce7c227fe0f2398dc7e2e51d4a370508281f3c1c5cddc/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2181e67807fc2fa785d0592dc2d6206c019b9502410671cc905d132a92866557", size = 24178, upload-time = "2024-10-18T15:21:18.859Z" },
     { url = "https://files.pythonhosted.org/packages/a2/82/8be4c96ffee03c5b4a034e60a31294daf481e12c7c43ab8e34a1453ee48b/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ad10d3ded218f1039f11a75f8091880239651b52e9bb592ca27de44eed242a48", size = 23352, upload-time = "2024-10-18T15:21:20.971Z" },
-]
-
-[[package]]
-name = "marshmallow"
-version = "3.26.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/55/79/de6c16cc902f4fc372236926b0ce2ab7845268dcc30fb2fbb7f71b418631/marshmallow-3.26.2.tar.gz", hash = "sha256:bbe2adb5a03e6e3571b573f42527c6fe926e17467833660bebd11593ab8dfd57", size = 222095, upload-time = "2025-12-22T06:53:53.309Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/2f/5108cb3ee4ba6501748c4908b908e55f42a5b66245b4cfe0c99326e1ef6e/marshmallow-3.26.2-py3-none-any.whl", hash = "sha256:013fa8a3c4c276c24d26d84ce934dc964e2aa794345a0f8c7e5a7191482c8a73", size = 50964, upload-time = "2025-12-22T06:53:51.801Z" },
 ]
 
 [[package]]
@@ -2121,26 +2069,6 @@ wheels = [
 ]
 
 [[package]]
-name = "multi-swe-bench"
-version = "1.1.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "dataclasses-json", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "docker", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "gitpython", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pygithub", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pyyaml", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "swe-rex", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "toml", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "tqdm", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "unidiff", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/48/ad/6b7cda600a50392c790b14ee420b9a3bb318a982a298c05f2d1c066a434f/multi_swe_bench-1.1.2.tar.gz", hash = "sha256:44944bc6608d7d9b8d4390f3ce0a3b2c69122ea6be6e35766c6fde2328f50392", size = 1267660, upload-time = "2025-12-18T07:16:09.584Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/a8/060eb46096742944d8d37c34094d4e0fb34b28c6291a877388543ea65660/multi_swe_bench-1.1.2-py3-none-any.whl", hash = "sha256:09a5770096d6a035383c5240762ffa8c87b1e8df7d374110de8fb781b4e5a9f9", size = 4942355, upload-time = "2025-12-18T07:16:07.468Z" },
-]
-
-[[package]]
 name = "multidict"
 version = "6.6.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2167,15 +2095,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/7d/a988f258104dcd2ccf1ed40fdc97e26c4ac351eeaf81d76e266c52d84e2f/multiprocess-0.70.16-py312-none-any.whl", hash = "sha256:fc0544c531920dde3b00c29863377f87e1632601092ea2daca74e4beb40faa2e", size = 146741, upload-time = "2024-01-28T18:52:29.395Z" },
     { url = "https://files.pythonhosted.org/packages/ea/89/38df130f2c799090c978b366cfdf5b96d08de5b29a4a293df7f7429fa50b/multiprocess-0.70.16-py38-none-any.whl", hash = "sha256:a71d82033454891091a226dfc319d0cfa8019a4e888ef9ca910372a446de4435", size = 132628, upload-time = "2024-01-28T18:52:30.853Z" },
     { url = "https://files.pythonhosted.org/packages/da/d9/f7f9379981e39b8c2511c9e0326d212accacb82f12fbfdc1aa2ce2a7b2b6/multiprocess-0.70.16-py39-none-any.whl", hash = "sha256:a0bafd3ae1b732eac64be2e72038231c1ba97724b60b09400d68f229fcc2fbf3", size = 133351, upload-time = "2024-01-28T18:52:31.981Z" },
-]
-
-[[package]]
-name = "mypy-extensions"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
 ]
 
 [[package]]
@@ -2254,21 +2173,6 @@ wheels = [
 requires-dist = [
     { name = "numpy" },
     { name = "torch" },
-]
-
-[[package]]
-name = "nltk"
-version = "3.9.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "joblib", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "regex", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "tqdm", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/74/a1/b3b4adf15585a5bc4c357adde150c01ebeeb642173ded4d871e89468767c/nltk-3.9.4.tar.gz", hash = "sha256:ed03bc098a40481310320808b2db712d95d13ca65b27372f8a403949c8b523d0", size = 2946864, upload-time = "2026-03-24T06:13:40.641Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/91/04e965f8e717ba0ab4bdca5c112deeab11c9e750d94c4d4602f050295d39/nltk-3.9.4-py3-none-any.whl", hash = "sha256:f2fa301c3a12718ce4a0e9305c5675299da5ad9e26068218b69d692fda84828f", size = 1552087, upload-time = "2026-03-24T06:13:38.47Z" },
 ]
 
 [[package]]
@@ -2930,7 +2834,7 @@ dependencies = [
     { name = "transformers", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "uvloop", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "verifiers", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "vllm", version = "0.20.2rc1.dev212+gcba9775b5.precompiled", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev212%2Bgcba9775b5.precompiled-cp312-cp312-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "vllm", version = "0.20.2rc1.dev213+gcff9b14e3.precompiled", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev213%2Bgcff9b14e3.precompiled-cp312-cp312-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "vllm", version = "0.20.2+cu129", source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.20.2/vllm-0.20.2+cu129-cp38-abi3-manylinux_2_31_aarch64.whl" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
     { name = "wandb", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
@@ -2967,10 +2871,8 @@ envs = [
     { name = "math500", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "mini-swe-agent-plus", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "reverse-text", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "rlm-swe", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "science-env", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "wiki-search", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "wordle", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 flash-attn = [
     { name = "flash-attn", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -3046,7 +2948,6 @@ requires-dist = [
     { name = "reverse-text", marker = "extra == 'envs'", index = "https://hub.primeintellect.ai/primeintellect/simple/" },
     { name = "rich", specifier = ">=14.0.0" },
     { name = "ring-flash-attn", specifier = ">=0.1.8" },
-    { name = "rlm-swe", marker = "extra == 'envs'", editable = "/shared/research-prod/research-environments/environments/rlm_swe" },
     { name = "science-env", marker = "extra == 'envs'", index = "https://hub.primeintellect.ai/primeintellect/simple/" },
     { name = "setproctitle", specifier = ">=1.3.0" },
     { name = "tenacity", specifier = ">=8.2.0" },
@@ -3058,14 +2959,13 @@ requires-dist = [
     { name = "torchvision", index = "https://download.pytorch.org/whl/cu128" },
     { name = "transformers", git = "https://github.com/huggingface/transformers.git?rev=c1c3424" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=b76a6bb" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=0c6fcff" },
     { name = "vllm", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'", specifier = ">=0.20.2" },
     { name = "vllm", marker = "platform_machine == 'aarch64'", url = "https://github.com/vllm-project/vllm/releases/download/v0.20.2/vllm-0.20.2+cu129-cp38-abi3-manylinux_2_31_aarch64.whl" },
-    { name = "vllm", marker = "platform_machine == 'x86_64'", url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev212%2Bgcba9775b5.precompiled-cp312-cp312-linux_x86_64.whl" },
-    { name = "vllm-router", marker = "platform_machine == 'x86_64' and extra == 'disagg'", path = "/beegfs/outputs/vllm-router-wheels/pr28-ca0de22/vllm_router-0.1.23-cp38-abi3-linux_x86_64.whl" },
+    { name = "vllm", marker = "platform_machine == 'x86_64'", url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev213%2Bgcff9b14e3.precompiled-cp312-cp312-linux_x86_64.whl" },
+    { name = "vllm-router", marker = "platform_machine == 'x86_64' and extra == 'disagg'", url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.22/vllm_router-0.1.22-cp38-abi3-manylinux_2_28_x86_64.whl" },
     { name = "wandb", specifier = ">=0.26.1" },
     { name = "wiki-search", marker = "extra == 'envs'", index = "https://hub.primeintellect.ai/primeintellect/simple/" },
-    { name = "wordle", marker = "extra == 'envs'", index = "https://hub.primeintellect.ai/primeintellect/simple/" },
 ]
 provides-extras = ["flash-attn", "flash-attn-3", "flash-attn-cute", "envs", "disagg", "gpt-oss", "quack", "all"]
 
@@ -3345,22 +3245,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pygithub"
-version = "2.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyjwt", extra = ["crypto"], marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pynacl", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "requests", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typing-extensions", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "urllib3", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ab/c3/8465a311197e16cf5ab68789fe689535e90f6b61ab524cc32a39e67237ae/pygithub-2.9.1.tar.gz", hash = "sha256:59771d7ff63d54d427be2e7d0dad2208dfffc2b0a045fec959263787739b611c", size = 2594989, upload-time = "2026-04-14T07:26:13.622Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/aa/81a5506f089a26338bff17535e4339b3b22049ebd1bcdeff756c4d7a7559/pygithub-2.9.1-py3-none-any.whl", hash = "sha256:2ec78fca30092d51a42d76f4ddb02131b6f0c666a35dfdf364cf302cdda115b9", size = 449710, upload-time = "2026-04-14T07:26:12.382Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3381,25 +3265,6 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-]
-
-[[package]]
-name = "pynacl"
-version = "1.6.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cffi", marker = "(platform_machine == 'aarch64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/9a/4019b524b03a13438637b11538c82781a5eda427394380381af8f04f467a/pynacl-1.6.2.tar.gz", hash = "sha256:018494d6d696ae03c7e656e5e74cdfd8ea1326962cc401bcf018f1ed8436811c", size = 3511692, upload-time = "2026-01-01T17:48:10.851Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/b4/e927e0653ba63b02a4ca5b4d852a8d1d678afbf69b3dbf9c4d0785ac905c/pynacl-1.6.2-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8845c0631c0be43abdd865511c41eab235e0be69c81dc66a50911594198679b0", size = 800020, upload-time = "2026-01-01T17:32:18.34Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/81/d60984052df5c97b1d24365bc1e30024379b42c4edcd79d2436b1b9806f2/pynacl-1.6.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:22de65bb9010a725b0dac248f353bb072969c94fa8d6b1f34b87d7953cf7bbe4", size = 1399174, upload-time = "2026-01-01T17:32:20.239Z" },
-    { url = "https://files.pythonhosted.org/packages/68/f7/322f2f9915c4ef27d140101dd0ed26b479f7e6f5f183590fd32dfc48c4d3/pynacl-1.6.2-cp38-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46065496ab748469cdd999246d17e301b2c24ae2fdf739132e580a0e94c94a87", size = 835085, upload-time = "2026-01-01T17:32:22.24Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/d0/f301f83ac8dbe53442c5a43f6a39016f94f754d7a9815a875b65e218a307/pynacl-1.6.2-cp38-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a66d6fb6ae7661c58995f9c6435bda2b1e68b54b598a6a10247bfcdadac996c", size = 1437614, upload-time = "2026-01-01T17:32:23.766Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/58/fc6e649762b029315325ace1a8c6be66125e42f67416d3dbd47b69563d61/pynacl-1.6.2-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:26bfcd00dcf2cf160f122186af731ae30ab120c18e8375684ec2670dccd28130", size = 818251, upload-time = "2026-01-01T17:32:25.69Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/a8/b917096b1accc9acd878819a49d3d84875731a41eb665f6ebc826b1af99e/pynacl-1.6.2-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c8a231e36ec2cab018c4ad4358c386e36eede0319a0c41fed24f840b1dac59f6", size = 1402859, upload-time = "2026-01-01T17:32:27.215Z" },
-    { url = "https://files.pythonhosted.org/packages/85/42/fe60b5f4473e12c72f977548e4028156f4d340b884c635ec6b063fe7e9a5/pynacl-1.6.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:68be3a09455743ff9505491220b64440ced8973fe930f270c8e07ccfa25b1f9e", size = 791926, upload-time = "2026-01-01T17:32:29.314Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/f9/e40e318c604259301cc091a2a63f237d9e7b424c4851cafaea4ea7c4834e/pynacl-1.6.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b097553b380236d51ed11356c953bf8ce36a29a3e596e934ecabe76c985a577", size = 1363101, upload-time = "2026-01-01T17:32:31.263Z" },
 ]
 
 [[package]]
@@ -3668,25 +3533,6 @@ wheels = [
 ]
 
 [[package]]
-name = "rlm-swe"
-version = "0.3.3"
-source = { editable = "/shared/research-prod/research-environments/environments/rlm_swe" }
-dependencies = [
-    { name = "multi-swe-bench", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "prime-sandboxes", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "swebench", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "verifiers", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "multi-swe-bench", specifier = ">=1.1.2" },
-    { name = "prime-sandboxes", specifier = ">=0.2.19" },
-    { name = "swebench", specifier = "==4.1.0" },
-    { name = "verifiers", specifier = ">=0.1.13.dev8" },
-]
-
-[[package]]
 name = "rpds-py"
 version = "0.27.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3873,25 +3719,6 @@ wheels = [
 ]
 
 [[package]]
-name = "swe-rex"
-version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "bashlex", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "fastapi", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pexpect", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pydantic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "python-multipart", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "requests", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "rich", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "uvicorn", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/94/86/a069f93ec866151a4d476d546e60220e66b3788878b6e248b2df3ab2c5f1/swe_rex-1.4.0.tar.gz", hash = "sha256:14f8a24c49a63f9e251340b1109ac75a4aacbaece410f8599209de9bfca843c0", size = 41755, upload-time = "2025-08-14T01:19:20.22Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/0d/d06ab2aa78138055c297490762cd7b4d8ac58a544783f874c869cdb7b534/swe_rex-1.4.0-py3-none-any.whl", hash = "sha256:61261ad03eb23b717b5901cd5d229f24f6e1be2e120aad5c2e5ea3384a1d15ad", size = 47756, upload-time = "2025-08-14T01:19:18.93Z" },
-]
-
-[[package]]
 name = "swebench"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3985,24 +3812,6 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/13/e503968fefabd4c6b2650af21e110aa8466fe21432cd7c43a84577a89438/tensorboard_data_server-0.7.2-py3-none-any.whl", hash = "sha256:7e0610d205889588983836ec05dc098e80f97b7e7bbff7e994ebb78f578d0ddb", size = 2356, upload-time = "2023-10-23T21:23:32.16Z" },
     { url = "https://files.pythonhosted.org/packages/73/c6/825dab04195756cf8ff2e12698f22513b3db2f64925bdd41671bfb33aaa5/tensorboard_data_server-0.7.2-py3-none-manylinux_2_31_x86_64.whl", hash = "sha256:ef687163c24185ae9754ed5650eb5bc4d84ff257aabdc33f0cc6f74d8ba54530", size = 6590363, upload-time = "2023-10-23T21:23:35.583Z" },
-]
-
-[[package]]
-name = "textarena"
-version = "0.7.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "chess", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nltk", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "openai", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "python-dotenv", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "requests", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "rich", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "websockets", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/04/4a3ca42093d0be2a9c377ae3335a6c6baac1d278ae932562ec69f339d172/textarena-0.7.4.tar.gz", hash = "sha256:28bb9170d7718f2ae05e4515bea82262422731e563fc7318a9e7983de0cadd4f", size = 954969, upload-time = "2025-10-16T14:41:55.981Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/b4/9a9ba65154aff853c75b3d7324319d168ad9c69c6097f4aa3c16da7d9ef3/textarena-0.7.4-py3-none-any.whl", hash = "sha256:684784e78278e518066f67557ee93b47c238d16cbbd15d3abdaa3147562d3024", size = 1073570, upload-time = "2025-10-16T14:41:53.965Z" },
 ]
 
 [[package]]
@@ -4314,19 +4123,6 @@ wheels = [
 ]
 
 [[package]]
-name = "typing-inspect"
-version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mypy-extensions", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typing-extensions", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78", size = 13825, upload-time = "2023-05-24T20:25:47.612Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f", size = 8827, upload-time = "2023-05-24T20:25:45.287Z" },
-]
-
-[[package]]
 name = "typing-inspection"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -4426,7 +4222,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.14"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=b76a6bb#b76a6bb7901fff2316a2b4277ba2ea1f9f8f11dd" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=0c6fcff#0c6fcff41605bd1d5f654e42069b0dda52e9419a" }
 dependencies = [
     { name = "aiolimiter", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "anthropic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -4469,8 +4265,8 @@ wheels = [
 
 [[package]]
 name = "vllm"
-version = "0.20.2rc1.dev212+gcba9775b5.precompiled"
-source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev212%2Bgcba9775b5.precompiled-cp312-cp312-linux_x86_64.whl" }
+version = "0.20.2rc1.dev213+gcff9b14e3.precompiled"
+source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev213%2Bgcff9b14e3.precompiled-cp312-cp312-linux_x86_64.whl" }
 resolution-markers = [
     "platform_machine == 'x86_64' and sys_platform == 'linux'",
 ]
@@ -4545,7 +4341,7 @@ dependencies = [
     { name = "xgrammar", version = "0.2.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev212%2Bgcba9775b5.precompiled-cp312-cp312-linux_x86_64.whl", hash = "sha256:3e625083ce0ed7ab2a941fdd84e34571ad35425890fba82196052405cc6acdc9" },
+    { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev213%2Bgcff9b14e3.precompiled-cp312-cp312-linux_x86_64.whl", hash = "sha256:5b594e78118d7e6d16adf63a6c8ac4cba059d9f8a1a37ec7e57bbbc70a7acbac" },
 ]
 
 [package.metadata]
@@ -4819,8 +4615,8 @@ provides-extras = ["zen", "bench", "tensorizer", "fastsafetensors", "instanttens
 
 [[package]]
 name = "vllm-router"
-version = "0.1.23"
-source = { path = "/beegfs/outputs/vllm-router-wheels/pr28-ca0de22/vllm_router-0.1.23-cp38-abi3-linux_x86_64.whl" }
+version = "0.1.22"
+source = { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.22/vllm_router-0.1.22-cp38-abi3-manylinux_2_28_x86_64.whl" }
 dependencies = [
     { name = "aiohttp", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "fastapi", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -4830,7 +4626,7 @@ dependencies = [
     { name = "uvicorn", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 wheels = [
-    { filename = "vllm_router-0.1.23-cp38-abi3-linux_x86_64.whl", hash = "sha256:9c8c4ecc1cfb0c88283e6afc243c0622348a59ee83a87e32e5b126de6e4463e0" },
+    { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.22/vllm_router-0.1.22-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6361a0387241e56932f3ba2e51af27f58d11a462e3187e58286b2f96056e4d15" },
 ]
 
 [package.metadata]
@@ -4959,19 +4755,6 @@ dependencies = [
 ]
 wheels = [
     { url = "https://hub.primeintellect.ai/primeintellect/wiki-search/@10d58ffe/wiki_search-0.1.23-py3-none-any.whl", hash = "sha256:ffeff890f2d14d7b2910baf57c27f6939da0f669ae0c4545916762f3f4edd75b" },
-]
-
-[[package]]
-name = "wordle"
-version = "0.1.7"
-source = { registry = "https://hub.primeintellect.ai/primeintellect/simple/" }
-dependencies = [
-    { name = "nltk", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "textarena", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "verifiers", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-]
-wheels = [
-    { url = "https://hub.primeintellect.ai/primeintellect/wordle/@4373cedc/wordle-0.1.7-py2.py3-none-any.whl", hash = "sha256:ca598f461b148e49870baea444e836d8a1eb67752292f716001e9b9269c2203f" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ supported-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-05T19:08:02.919471519Z"
+exclude-newer = "2026-05-05T19:27:20.705492862Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -2834,7 +2834,7 @@ dependencies = [
     { name = "transformers", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "uvloop", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "verifiers", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "vllm", version = "0.20.2rc1.dev213+gcff9b14e3.precompiled", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev213%2Bgcff9b14e3.precompiled-cp312-cp312-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "vllm", version = "0.20.2rc1.dev214+g24c0208fc.precompiled", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev214%2Bg24c0208fc.precompiled-cp312-cp312-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "vllm", version = "0.20.2+cu129", source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.20.2/vllm-0.20.2+cu129-cp38-abi3-manylinux_2_31_aarch64.whl" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
     { name = "wandb", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
@@ -2959,10 +2959,10 @@ requires-dist = [
     { name = "torchvision", index = "https://download.pytorch.org/whl/cu128" },
     { name = "transformers", git = "https://github.com/huggingface/transformers.git?rev=c1c3424" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=0c6fcff" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=162cffb" },
     { name = "vllm", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'", specifier = ">=0.20.2" },
     { name = "vllm", marker = "platform_machine == 'aarch64'", url = "https://github.com/vllm-project/vllm/releases/download/v0.20.2/vllm-0.20.2+cu129-cp38-abi3-manylinux_2_31_aarch64.whl" },
-    { name = "vllm", marker = "platform_machine == 'x86_64'", url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev213%2Bgcff9b14e3.precompiled-cp312-cp312-linux_x86_64.whl" },
+    { name = "vllm", marker = "platform_machine == 'x86_64'", url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev214%2Bg24c0208fc.precompiled-cp312-cp312-linux_x86_64.whl" },
     { name = "vllm-router", marker = "platform_machine == 'x86_64' and extra == 'disagg'", url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.22/vllm_router-0.1.22-cp38-abi3-manylinux_2_28_x86_64.whl" },
     { name = "wandb", specifier = ">=0.26.1" },
     { name = "wiki-search", marker = "extra == 'envs'", index = "https://hub.primeintellect.ai/primeintellect/simple/" },
@@ -3000,7 +3000,7 @@ requires-dist = [
 
 [[package]]
 name = "prime-sandboxes"
-version = "0.2.22"
+version = "0.2.25"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -3010,9 +3010,9 @@ dependencies = [
     { name = "pydantic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "tenacity", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/a7/eb9cb01ce7fa812022ec7c2ffaeb379e1103e07f093a4b85e879b2d0143d/prime_sandboxes-0.2.22.tar.gz", hash = "sha256:7901adca4ff7fff1e7f08c06c4b76765cd90791965216655eb3a87d459588f5e", size = 64970, upload-time = "2026-04-22T18:32:12.973Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/6d/a800c22973f99e4b9a57caa25aa1b54e54f022641b0576bfcfb064137153/prime_sandboxes-0.2.25.tar.gz", hash = "sha256:df4bf7965ccff953208b881fb743c8cde5280064a8c5a13eabeedded53dd366b", size = 66132, upload-time = "2026-05-11T23:45:19.993Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/b8/46bf98c06826fc26d982c53e10d9d4f086a4c322993a6c51188e5bd6fd30/prime_sandboxes-0.2.22-py3-none-any.whl", hash = "sha256:0a75bb02049c16b55aae7475cc4082e8559ffa6d65181b238077771a95b57855", size = 33182, upload-time = "2026-04-22T18:32:11.739Z" },
+    { url = "https://files.pythonhosted.org/packages/34/e8/2ddba24d992ef10b69eb311647443b11992fb2e9514e3a625b98b6a5da65/prime_sandboxes-0.2.25-py3-none-any.whl", hash = "sha256:c335eba6c817722365495ab3d3dfbe77f0a726d9a9f2fd3452ad44666811fbfc", size = 33621, upload-time = "2026-05-11T23:45:18.759Z" },
 ]
 
 [[package]]
@@ -4221,8 +4221,8 @@ wheels = [
 
 [[package]]
 name = "verifiers"
-version = "0.1.14"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=0c6fcff#0c6fcff41605bd1d5f654e42069b0dda52e9419a" }
+version = "0.1.15.dev0"
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=162cffb#162cffbdb2f593ef82d19f0df23073f9b8e6cfe5" }
 dependencies = [
     { name = "aiolimiter", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "anthropic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -4265,8 +4265,8 @@ wheels = [
 
 [[package]]
 name = "vllm"
-version = "0.20.2rc1.dev213+gcff9b14e3.precompiled"
-source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev213%2Bgcff9b14e3.precompiled-cp312-cp312-linux_x86_64.whl" }
+version = "0.20.2rc1.dev214+g24c0208fc.precompiled"
+source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev214%2Bg24c0208fc.precompiled-cp312-cp312-linux_x86_64.whl" }
 resolution-markers = [
     "platform_machine == 'x86_64' and sys_platform == 'linux'",
 ]
@@ -4341,7 +4341,7 @@ dependencies = [
     { name = "xgrammar", version = "0.2.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev213%2Bgcff9b14e3.precompiled-cp312-cp312-linux_x86_64.whl", hash = "sha256:5b594e78118d7e6d16adf63a6c8ac4cba059d9f8a1a37ec7e57bbbc70a7acbac" },
+    { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev214%2Bg24c0208fc.precompiled-cp312-cp312-linux_x86_64.whl", hash = "sha256:437a618dd32400d2636e17de266061aa6685001653e6b9a78751e3ae53036e51" },
 ]
 
 [package.metadata]

--- a/uv.lock
+++ b/uv.lock
@@ -11,38 +11,39 @@ supported-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-05-04T22:30:42.685600927Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-vllm = false
 verifiers = false
-vllm-router = false
 dion = false
 alphabet-sort = false
 science-env = false
-color-codeword = false
-nixl-cu12 = false
-flash-attn-3 = false
-prime-tunnel = false
-prime-sandboxes = false
-deep-gemm = false
-aime2024 = false
 prime-evals = false
 deepdive = false
-prime = false
 reverse-text = false
 code-env = false
 mini-swe-agent-plus = false
 deep-ep = false
 pydantic-config = false
 renderers = false
-math-env = false
-logic-env = false
+mistral-common = false
 wiki-search = false
 math-python = false
 math500 = false
 aime2025 = false
+vllm = false
+vllm-router = false
+color-codeword = false
+nixl-cu12 = false
+flash-attn-3 = false
+prime-tunnel = false
+deep-gemm = false
+aime2024 = false
+math-env = false
+prime-sandboxes = false
+logic-env = false
+prime = false
 
 [manifest]
 members = [
@@ -1893,15 +1894,18 @@ wheels = [
 name = "mistral-common"
 version = "1.11.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "platform_machine == 'aarch64' and sys_platform == 'linux'",
+]
 dependencies = [
-    { name = "jsonschema", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "numpy", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pillow", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pydantic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pydantic-extra-types", extra = ["pycountry"], marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "requests", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "tiktoken", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typing-extensions", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "jsonschema", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "numpy", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "pillow", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "pydantic", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "pydantic-extra-types", extra = ["pycountry"], marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "requests", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "tiktoken", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/97/753c85b5c0a19f4331ac99e0300ac8da06d4b29b629c9cb03064b38561bd/mistral_common-1.11.0.tar.gz", hash = "sha256:439b7fa38f9c3f020154af51bdf30eb81def507643017d8ce9f798384ec47ec3", size = 6355512, upload-time = "2026-04-01T13:54:12.36Z" }
 wheels = [
@@ -1910,7 +1914,34 @@ wheels = [
 
 [package.optional-dependencies]
 image = [
-    { name = "opencv-python-headless", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "opencv-python-headless", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+]
+
+[[package]]
+name = "mistral-common"
+version = "1.11.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "platform_machine == 'x86_64' and sys_platform == 'linux'",
+]
+dependencies = [
+    { name = "jsonschema", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "numpy", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "pillow", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "pydantic", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "pydantic-extra-types", extra = ["pycountry"], marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "requests", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "tiktoken", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/eb/12167a1bea9714582e5b4f539f9c019323363e314a499c72855ff0e5ad43/mistral_common-1.11.2.tar.gz", hash = "sha256:79f68fc2d1190f28637f40e053f919c8c2697e00b2aa679ddee562a95183f4ad", size = 6357845, upload-time = "2026-05-04T19:47:40.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/f0/6a5d604b972e442b9d36c117d01788feddad099e4965699e3516ee6fefc3/mistral_common-1.11.2-py3-none-any.whl", hash = "sha256:ebb42062cd705a0aa2bc69b4cde2b83d446ae58150b7e29322c90cb08fcfca6c", size = 6531968, upload-time = "2026-05-04T19:47:37.718Z" },
+]
+
+[package.optional-dependencies]
+image = [
+    { name = "opencv-python-headless", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -1967,18 +1998,42 @@ wheels = [
 name = "model-hosting-container-standards"
 version = "0.1.13"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "platform_machine == 'aarch64' and sys_platform == 'linux'",
+]
 dependencies = [
-    { name = "fastapi", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "httpx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "jmespath", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pydantic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "setuptools", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "starlette", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "supervisor", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "fastapi", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "httpx", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "jmespath", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "pydantic", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "setuptools", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "starlette", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "supervisor", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d7/b7/a6a31b4dfd30d14b1019dc358f09c9d88ca38e555ba7c976e7d3e6b593fe/model_hosting_container_standards-0.1.13.tar.gz", hash = "sha256:27a1333410dde2719286a300a2803e24fdde407baa91894eb845c0f268aa194d", size = 79116, upload-time = "2026-01-09T21:45:20.683Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8c/37/6dc61971ba31450bbed460b5f40543f0915e352680534e3bcaf57116d8d7/model_hosting_container_standards-0.1.13-py3-none-any.whl", hash = "sha256:be307d4a988cc660df4e6bd8bdedb7917844bac940e332f9fd001cb385d7994c", size = 105738, upload-time = "2026-01-09T21:45:18.959Z" },
+]
+
+[[package]]
+name = "model-hosting-container-standards"
+version = "0.1.14"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "platform_machine == 'x86_64' and sys_platform == 'linux'",
+]
+dependencies = [
+    { name = "fastapi", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "httpx", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "jmespath", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "pydantic", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "setuptools", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "starlette", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "supervisor", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/3d/cf5c6029648cb0a116f7b5c2f74aa155ab0c6dd723a1f204a6d7ff354526/model_hosting_container_standards-0.1.14.tar.gz", hash = "sha256:b6cf4c46d88ce6acd6e543a578bb88ffd55d1179a7c09c22e61ae1d8a567c564", size = 90386, upload-time = "2026-03-18T21:25:14.513Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/94/052452842d39c562237a70345c57ec213a9db22bd25bba998fd2b32d70a7/model_hosting_container_standards-0.1.14-py3-none-any.whl", hash = "sha256:d678be6745899b8ba1e8246c96b101e7802a6a4ea3fb5d90ae8d6eb4204e84c6", size = 121406, upload-time = "2026-03-18T21:25:12.932Z" },
 ]
 
 [[package]]
@@ -2780,8 +2835,8 @@ dependencies = [
     { name = "transformers", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "uvloop", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "verifiers", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "vllm", version = "0.20.2rc1.dev209+ga1c9051bc.precompiled", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev209%2Bga1c9051bc.precompiled-cp312-cp312-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "vllm", version = "0.20.2+cu129", source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.20.2/vllm-0.20.2+cu129-cp38-abi3-manylinux_2_31_aarch64.whl" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "vllm", version = "0.20.2+cu129", source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.20.2/vllm-0.20.2+cu129-cp38-abi3-manylinux_2_31_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "wandb", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
@@ -2905,10 +2960,10 @@ requires-dist = [
     { name = "torchvision", index = "https://download.pytorch.org/whl/cu128" },
     { name = "transformers", git = "https://github.com/huggingface/transformers.git?rev=c1c3424" },
     { name = "uvloop", specifier = ">=0.21.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=aa428f3" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=8dbd674" },
     { name = "vllm", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'", specifier = ">=0.20.2" },
     { name = "vllm", marker = "platform_machine == 'aarch64'", url = "https://github.com/vllm-project/vllm/releases/download/v0.20.2/vllm-0.20.2+cu129-cp38-abi3-manylinux_2_31_aarch64.whl" },
-    { name = "vllm", marker = "platform_machine == 'x86_64'", url = "https://github.com/vllm-project/vllm/releases/download/v0.20.2/vllm-0.20.2+cu129-cp38-abi3-manylinux_2_31_x86_64.whl" },
+    { name = "vllm", marker = "platform_machine == 'x86_64'", url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev209%2Bga1c9051bc.precompiled-cp312-cp312-linux_x86_64.whl" },
     { name = "vllm-router", marker = "platform_machine == 'x86_64' and extra == 'disagg'", url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.22/vllm_router-0.1.22-cp38-abi3-manylinux_2_28_x86_64.whl" },
     { name = "wandb", specifier = ">=0.26.1" },
     { name = "wiki-search", marker = "extra == 'envs'", index = "https://hub.primeintellect.ai/primeintellect/simple/" },
@@ -4168,7 +4223,7 @@ wheels = [
 [[package]]
 name = "verifiers"
 version = "0.1.14"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=aa428f3#aa428f3941ae35a7cf7c0dad7e60c7eca525bac6" }
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?rev=8dbd674#8dbd6748e4ffed2144b12eb091a60c8d058e6989" }
 dependencies = [
     { name = "aiolimiter", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "anthropic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -4193,7 +4248,6 @@ dependencies = [
     { name = "setproctitle", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "tenacity", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "textual", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "wget", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
 [[package]]
@@ -4212,83 +4266,83 @@ wheels = [
 
 [[package]]
 name = "vllm"
-version = "0.20.2+cu129"
-source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.20.2/vllm-0.20.2+cu129-cp38-abi3-manylinux_2_31_aarch64.whl" }
+version = "0.20.2rc1.dev209+ga1c9051bc.precompiled"
+source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev209%2Bga1c9051bc.precompiled-cp312-cp312-linux_x86_64.whl" }
 resolution-markers = [
-    "platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "platform_machine == 'x86_64' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "aiohttp", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "anthropic", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "apache-tvm-ffi", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "blake3", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "cachetools", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "cbor2", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "cloudpickle", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "compressed-tensors", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "depyf", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "diskcache", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "einops", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "fastapi", extra = ["standard"], marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "fastsafetensors", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "filelock", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "flashinfer-cubin", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "flashinfer-python", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "gguf", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "ijson", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "lark", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "llguidance", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "lm-format-enforcer", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "mcp", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "mistral-common", extra = ["image"], marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "model-hosting-container-standards", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "msgspec", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "ninja", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "numba", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "numpy", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-frontend", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "nvidia-cutlass-dsl", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "openai", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "openai-harmony", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "opencv-python-headless", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "opentelemetry-api", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "opentelemetry-exporter-otlp", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "opentelemetry-sdk", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "opentelemetry-semantic-conventions-ai", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "outlines-core", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "partial-json-parser", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "pillow", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "prometheus-client", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "prometheus-fastapi-instrumentator", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "protobuf", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "psutil", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "py-cpuinfo", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "pybase64", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "pydantic", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "python-json-logger", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "pyyaml", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "pyzmq", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "quack-kernels", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "regex", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "requests", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "sentencepiece", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "setproctitle", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "setuptools", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "six", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "tiktoken", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "tilelang", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "tokenizers", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "torch", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "torchaudio", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "torchvision", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "tqdm", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "transformers", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "watchfiles", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "xgrammar", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "aiohttp", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "anthropic", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "apache-tvm-ffi", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "blake3", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "cachetools", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "cbor2", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "cloudpickle", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "compressed-tensors", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "depyf", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "diskcache", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "einops", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "fastapi", extra = ["standard"], marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "fastsafetensors", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "filelock", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "flashinfer-cubin", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "flashinfer-python", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "gguf", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "ijson", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "lark", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "llguidance", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "lm-format-enforcer", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "mcp", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "mistral-common", version = "1.11.2", source = { registry = "https://pypi.org/simple" }, extra = ["image"], marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "model-hosting-container-standards", version = "0.1.14", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "msgspec", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "ninja", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "numba", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "numpy", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-frontend", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cutlass-dsl", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "openai", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "openai-harmony", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "opencv-python-headless", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "opentelemetry-api", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "opentelemetry-exporter-otlp", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "opentelemetry-sdk", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "opentelemetry-semantic-conventions-ai", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "outlines-core", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "partial-json-parser", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "pillow", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "prometheus-client", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "prometheus-fastapi-instrumentator", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "protobuf", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "psutil", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "py-cpuinfo", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "pybase64", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "pydantic", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "python-json-logger", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "pyyaml", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "pyzmq", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "quack-kernels", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "regex", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "requests", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "sentencepiece", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "setproctitle", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "setuptools", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "six", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "tiktoken", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "tilelang", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "tokenizers", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "torch", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "torchaudio", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "torchvision", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "tqdm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "transformers", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "watchfiles", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "xgrammar", version = "0.2.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://github.com/vllm-project/vllm/releases/download/v0.20.2/vllm-0.20.2+cu129-cp38-abi3-manylinux_2_31_aarch64.whl", hash = "sha256:8a58a086c5c4ed2883eee36aaaf6b79c83463d02da3015454acf92afcc8e150e" },
+    { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev209%2Bga1c9051bc.precompiled-cp312-cp312-linux_x86_64.whl", hash = "sha256:9f9fd0f24f6c93082e2449c37d6fa3e18a8ced838e0831db7563f358776db1d2" },
 ]
 
 [package.metadata]
@@ -4322,8 +4376,8 @@ requires-dist = [
     { name = "matplotlib", marker = "extra == 'bench'" },
     { name = "mcp" },
     { name = "mistral-common", extras = ["audio"], marker = "extra == 'audio'" },
-    { name = "mistral-common", extras = ["image"], specifier = ">=1.11.0" },
-    { name = "model-hosting-container-standards", specifier = ">=0.1.13,<1.0.0" },
+    { name = "mistral-common", extras = ["image"], specifier = ">=1.11.2" },
+    { name = "model-hosting-container-standards", specifier = ">=0.1.14,<1.0.0" },
     { name = "msgspec" },
     { name = "ninja" },
     { name = "numba", specifier = "==0.65.0" },
@@ -4380,7 +4434,7 @@ requires-dist = [
     { name = "transformers", specifier = ">=4.56.0,!=5.0.*,!=5.1.*,!=5.2.*,!=5.3.*,!=5.4.*,!=5.5.0" },
     { name = "typing-extensions", specifier = ">=4.10" },
     { name = "watchfiles" },
-    { name = "xgrammar", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'ppc64le' or platform_machine == 's390x' or platform_machine == 'x86_64'", specifier = ">=0.1.32,<1.0.0" },
+    { name = "xgrammar", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'ppc64le' or platform_machine == 's390x' or platform_machine == 'x86_64'", specifier = ">=0.2.0,<1.0.0" },
     { name = "zentorch-weekly", marker = "extra == 'zen'", specifier = "==5.2.1.dev20260408" },
 ]
 provides-extras = ["zen", "bench", "tensorizer", "fastsafetensors", "instanttensor", "runai", "audio", "video", "flashinfer", "helion", "grpc", "otel"]
@@ -4388,82 +4442,82 @@ provides-extras = ["zen", "bench", "tensorizer", "fastsafetensors", "instanttens
 [[package]]
 name = "vllm"
 version = "0.20.2+cu129"
-source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.20.2/vllm-0.20.2+cu129-cp38-abi3-manylinux_2_31_x86_64.whl" }
+source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.20.2/vllm-0.20.2+cu129-cp38-abi3-manylinux_2_31_aarch64.whl" }
 resolution-markers = [
-    "platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "platform_machine == 'aarch64' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "aiohttp", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "anthropic", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "apache-tvm-ffi", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "blake3", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "cachetools", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "cbor2", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "cloudpickle", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "compressed-tensors", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "depyf", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "diskcache", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "einops", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "fastapi", extra = ["standard"], marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "fastsafetensors", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "filelock", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "flashinfer-cubin", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "flashinfer-python", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "gguf", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "ijson", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "lark", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "llguidance", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "lm-format-enforcer", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "mcp", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "mistral-common", extra = ["image"], marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "model-hosting-container-standards", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "msgspec", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "ninja", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "numba", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "numpy", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-frontend", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cutlass-dsl", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "openai", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "openai-harmony", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "opencv-python-headless", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "opentelemetry-api", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "opentelemetry-exporter-otlp", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "opentelemetry-sdk", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "opentelemetry-semantic-conventions-ai", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "outlines-core", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "partial-json-parser", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "pillow", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "prometheus-client", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "prometheus-fastapi-instrumentator", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "protobuf", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "psutil", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "py-cpuinfo", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "pybase64", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "pydantic", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "python-json-logger", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "pyyaml", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "pyzmq", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "quack-kernels", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "regex", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "requests", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "sentencepiece", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "setproctitle", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "setuptools", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "six", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "tiktoken", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "tilelang", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "tokenizers", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "torch", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "torchaudio", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "torchvision", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "tqdm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "transformers", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "watchfiles", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "xgrammar", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "aiohttp", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "anthropic", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "apache-tvm-ffi", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "blake3", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "cachetools", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "cbor2", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "cloudpickle", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "compressed-tensors", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "depyf", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "diskcache", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "einops", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "fastapi", extra = ["standard"], marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "fastsafetensors", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "filelock", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "flashinfer-cubin", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "flashinfer-python", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "gguf", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "ijson", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "lark", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "llguidance", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "lm-format-enforcer", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "mcp", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "mistral-common", version = "1.11.0", source = { registry = "https://pypi.org/simple" }, extra = ["image"], marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "model-hosting-container-standards", version = "0.1.13", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "msgspec", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "ninja", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "numba", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "numpy", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-frontend", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "nvidia-cutlass-dsl", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "openai", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "openai-harmony", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "opencv-python-headless", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "opentelemetry-api", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "opentelemetry-exporter-otlp", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "opentelemetry-sdk", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "opentelemetry-semantic-conventions-ai", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "outlines-core", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "partial-json-parser", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "pillow", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "prometheus-client", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "prometheus-fastapi-instrumentator", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "protobuf", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "psutil", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "py-cpuinfo", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "pybase64", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "pydantic", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "python-json-logger", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "pyyaml", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "pyzmq", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "quack-kernels", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "regex", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "requests", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "sentencepiece", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "setproctitle", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "setuptools", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "six", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "tiktoken", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "tilelang", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "tokenizers", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "torch", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "torchaudio", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "torchvision", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "tqdm", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "transformers", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "watchfiles", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "xgrammar", version = "0.1.33", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://github.com/vllm-project/vllm/releases/download/v0.20.2/vllm-0.20.2+cu129-cp38-abi3-manylinux_2_31_x86_64.whl", hash = "sha256:2f8c2bf2ac6d3d16f930535e66822abd71065468521884eb5b910225b2abef4b" },
+    { url = "https://github.com/vllm-project/vllm/releases/download/v0.20.2/vllm-0.20.2+cu129-cp38-abi3-manylinux_2_31_aarch64.whl", hash = "sha256:8a58a086c5c4ed2883eee36aaaf6b79c83463d02da3015454acf92afcc8e150e" },
 ]
 
 [package.metadata]
@@ -4682,12 +4736,6 @@ wheels = [
 ]
 
 [[package]]
-name = "wget"
-version = "3.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/6a/62e288da7bcda82b935ff0c6cfe542970f04e29c756b0e147251b2fb251f/wget-3.2.zip", hash = "sha256:35e630eca2aa50ce998b9b1a127bb26b30dfee573702782aa982f875e3f16061", size = 10857, upload-time = "2015-10-22T15:26:37.51Z" }
-
-[[package]]
 name = "widgetsnbextension"
 version = "4.0.14"
 source = { registry = "https://pypi.org/simple" }
@@ -4714,18 +4762,40 @@ wheels = [
 name = "xgrammar"
 version = "0.1.33"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "platform_machine == 'aarch64' and sys_platform == 'linux'",
+]
 dependencies = [
-    { name = "numpy", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pydantic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "torch", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "transformers", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "numpy", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "pydantic", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "torch", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "transformers", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/db/43/e5dfddb1d2a4fccf3e3a88f103e88698cdefc3182f4e169a359ffe1c1794/xgrammar-0.1.33.tar.gz", hash = "sha256:8dbe5fc3d76651ab1fac7a68fc2a118b885fa0ec7189927fb6e0dce0081aea99", size = 2398956, upload-time = "2026-03-27T10:16:36.582Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4e/04/43d4baca876f5ae1b45897ec30a59801a2da37f16da1fcd85f9555e4c125/xgrammar-0.1.33-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c803e60d791854c5d1f271ece7e1f34d73c82dd4a8b2a06b7af5331482a78ac", size = 42133168, upload-time = "2026-03-27T10:15:16.994Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/a8/672833a3cff027253793aa999401d8364896ebf396967e475c7a878b895f/xgrammar-0.1.33-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:52b8eaa533282a0efb0835db6998ae72e7b3c7875d7a52e360ffebff9b78c30a", size = 42205803, upload-time = "2026-03-27T10:15:21.599Z" },
+]
+
+[[package]]
+name = "xgrammar"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "platform_machine == 'x86_64' and sys_platform == 'linux'",
+]
+dependencies = [
+    { name = "apache-tvm-ffi", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "numpy", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "pydantic", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "torch", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "transformers", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/54/7e593fc41ffcaf5ac7c0379e0aec0cf03e53a742d1a91f64c6c7e79a6ac1/xgrammar-0.2.0.tar.gz", hash = "sha256:c4f0238a89869343171d43d069b8c5da874f3c2c25f408f20cd5987219a6adef", size = 2421093, upload-time = "2026-05-01T18:33:54.474Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/30/99f4e83821db16d58dd41249ba46038ed47bce274c57ad5567030775fc62/xgrammar-0.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a36c744d24d93e178c138486aa02b390a80326b64ff11e222e063a028dd65849", size = 44616361, upload-time = "2026-05-01T18:32:42.536Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds Prime-RL support for the compact split routed-experts path used by the patched vLLM/router/verifiers stack:

- consumes split prompt/completion routed experts as compact `(shape, bytes)` payloads only
- removes support for the old nested-list/base85 routed-experts paths
- aligns and pads routed experts fail-fast, allowing only the expected missing final-token entry
- replays experts through trainer MoE layers using the sparse MoE-layer index emitted by vLLM
- pads/truncates routed experts correctly during sample and micro-batch preparation
- exposes `inference.routed_experts_replay_max_blocks` for vLLM routed-experts replay cache sizing
- retries the W&B shared-mode non-primary init race surfaced by GPU integration CI
- records the required vLLM fork state and wheel build in `src/prime_rl/inference/vllm_state.md`

Cross-repo PRs:

- vLLM fork: https://github.com/S1ro1/vllm/pull/3
- router: https://github.com/PrimeIntellect-ai/router/pull/28
- verifiers: https://github.com/PrimeIntellect-ai/verifiers/pull/1349

Pinned stack:

- `verifiers`: `162cffb`
- `vllm`: `0.20.2rc1.dev214+g24c0208fc.precompiled`
- vLLM wheel: https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.20.2rc1.dev214%2Bg24c0208fc.precompiled-cp312-cp312-linux_x86_64.whl
- vLLM wheel sha256: `437a618dd32400d2636e17de266061aa6685001653e6b9a78751e3ae53036e51`
- `vllm-router`: kept at upstream `0.1.22` with a `TODO: update router wheel when ready` comment; P/D routed experts require router PR #28 once the wheel is published

Local validation:

- `uv sync --all-extras`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `PYTEST_OUTPUT_DIR=/tmp/outputs uv run pytest tests/unit -m "not gpu"` (`342 passed, 65 deselected`)
- `uv run ruff check src/prime_rl/utils/monitor/wandb.py`
- `uv run ruff format --check src/prime_rl/utils/monitor/wandb.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the routed-experts HTTP/transport payload format and replay indexing across multiple trainer models, and pins a custom `vllm` wheel/verifiers revision that can affect inference behavior.
> 
> **Overview**
> Adds end-to-end support for **split prompt vs completion routed-experts** in the vLLM P/D path by emitting `prompt_routed_experts` plus per-choice `routed_experts` from `/inference/v1/generate` using a compact base64 `int16` payload, and removing the chat endpoint’s custom routed-experts capture override.
> 
> Switches trainer/orchestrator transport from nested lists to a new `RoutedExperts` bytes+shape struct (`transport/routed_experts.py`), with strict alignment/concat/slice/padding helpers applied during trajectory interleaving, batch packing, and tensor materialization.
> 
> Updates MoE model router-replay to index routed experts by **sparse MoE-layer order** (not decoder layer index) and asserts layer-count consistency, and exposes `inference.routed_experts_replay_max_blocks` for the vLLM replay cache.
> 
> Pins the patched stack by updating `verifiers` and the x86_64 `vllm` wheel source, and documents the required vLLM fork/build contract in `inference/vllm_state.md`; unit tests are updated to match the new payload/validation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c8adcf93177527b71fe808dbd8c4a166e217214. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

