### PR TITLE
Fix SLURM cleanup self-kill patterns

### DIFF
--- a/src/prime_rl/templates/inference.sbatch.j2
+++ b/src/prime_rl/templates/inference.sbatch.j2
@@ -113,11 +113,11 @@ echo "INFER_URLS=${INFER_URLS}"
 # termination and cause the next launch to hang (e.g. decode engines stuck at
 # "Waiting for READY message from DP Coordinator"). Harmless on clean nodes.
 srun bash -c '
-    pkill -9 -f "python.*prime_rl" 2>/dev/null
-    pkill -9 -f "torchrun" 2>/dev/null
-    pkill -9 -f "vllm-router" 2>/dev/null
-    pkill -9 -f "vllm" 2>/dev/null
-    pkill -9 -f "prime_rl" 2>/dev/null
+    pkill -9 -f "[p]ython.*prime_rl" 2>/dev/null
+    pkill -9 -f "[t]orchrun" 2>/dev/null
+    pkill -9 -f "[v]llm-router" 2>/dev/null
+    pkill -9 -f "[v]llm" 2>/dev/null
+    pkill -9 -f "[p]rime_rl" 2>/dev/null
     # Also match prctl-set process names (kernel comm) like "vllm::router"
     # which pkill -f does not see because -f only matches the cmdline.
     pkill -9 "vllm" 2>/dev/null

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -157,11 +157,11 @@ uv sync --all-extras
 # termination and cause the next launch to hang (e.g. decode engines stuck at
 # "Waiting for READY message from DP Coordinator"). Harmless on clean nodes.
 srun bash -c '
-    pkill -9 -f "python.*prime_rl" 2>/dev/null
-    pkill -9 -f "torchrun" 2>/dev/null
-    pkill -9 -f "vllm-router" 2>/dev/null
-    pkill -9 -f "vllm" 2>/dev/null
-    pkill -9 -f "prime_rl" 2>/dev/null
+    pkill -9 -f "[p]ython.*prime_rl" 2>/dev/null
+    pkill -9 -f "[t]orchrun" 2>/dev/null
+    pkill -9 -f "[v]llm-router" 2>/dev/null
+    pkill -9 -f "[v]llm" 2>/dev/null
+    pkill -9 -f "[p]rime_rl" 2>/dev/null
     # Also match prctl-set process names (kernel comm) like "vllm::router"
     # which pkill -f does not see because -f only matches the cmdline.
     pkill -9 "vllm" 2>/dev/null

--- a/src/prime_rl/templates/multi_node_sft.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_sft.sbatch.j2
@@ -64,11 +64,11 @@ cd $PROJECT_DIR && uv sync --all-extras
 # processes and vLLM/torch IPC files under /dev/shm and /tmp can survive SLURM
 # termination and cause the next launch to hang. Harmless on clean nodes.
 srun bash -c '
-    pkill -9 -f "python.*prime_rl" 2>/dev/null
-    pkill -9 -f "torchrun" 2>/dev/null
-    pkill -9 -f "vllm-router" 2>/dev/null
-    pkill -9 -f "vllm" 2>/dev/null
-    pkill -9 -f "prime_rl" 2>/dev/null
+    pkill -9 -f "[p]ython.*prime_rl" 2>/dev/null
+    pkill -9 -f "[t]orchrun" 2>/dev/null
+    pkill -9 -f "[v]llm-router" 2>/dev/null
+    pkill -9 -f "[v]llm" 2>/dev/null
+    pkill -9 -f "[p]rime_rl" 2>/dev/null
     # Also match prctl-set process names (kernel comm) like "vllm::router"
     # which pkill -f does not see because -f only matches the cmdline.
     pkill -9 "vllm" 2>/dev/null


### PR DESCRIPTION
## Summary
- update SLURM cleanup `pkill -f` patterns to use bracketed regexes so the cleanup shell does not match its own `bash -c` argv
- apply the same fix to multi-node RL, multi-node SFT, and standalone inference templates
- keep the existing process-name cleanup for `vllm` / `vllm::.*` unchanged

## Why
We reproduced the existing cleanup race with an overlapping SLURM step. A command like `pkill -9 -f "SELFKILL_MARKER"` matched its own `bash -c` command line and killed the cleanup step with rc=137. The bracketed form, e.g. `[S]ELFKILL_MARKER`, did not match its own argv and completed normally.

The current templates have the same shape with literals like `vllm` and `prime_rl` embedded in the `bash -c` cleanup body, so `pkill -f "vllm"` can kill the cleanup wrapper before it reaches the final status logging.

## Verification
- `git diff --check`
- checked that no unbracketed broad `pkill -9 -f "python|torchrun|vllm|vllm-router|prime_rl"` patterns remain in `src/prime_rl/templates`
- minimal SLURM repro: unsafe `pkill -f` killed its own cleanup shell with rc=137; bracketed control survived with rc=0

No tests added, per request.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: limited to SLURM sbatch template cleanup commands, with only regex tweaks that reduce accidental self-kills and shouldn’t affect core training/inference logic.
> 
> **Overview**
> Updates the node-cleanup blocks in the `inference`, `multi_node_rl`, and `multi_node_sft` sbatch templates to use bracketed regex patterns (e.g. `[v]llm`) for `pkill -f`, preventing the cleanup `bash -c` wrapper from matching and killing itself.
> 
> Keeps the existing process-name-based `pkill` for `vllm`/`vllm::.*` and the IPC file cleanup/logging behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e407230f8ed6ad8c78dbb6d1d53ab600d3581f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->