### PR TITLE
[codex] add per-env trainer metrics

### DIFF
--- a/skills/monitor-run/SKILL.md
+++ b/skills/monitor-run/SKILL.md
@@ -147,8 +147,8 @@ These tell you whether training is healthy or diverging.
 | `entropy/mean` | trainer | policy entropy |
 | `masked_advantage_positive/mean` | trainer | fraction of DPPO-masked trainable tokens with positive advantage (W&B) |
 | `masked_advantage_negative/mean` | trainer | fraction of DPPO-masked trainable tokens with negative advantage (W&B) |
-| `mismatch_kl/{env}/{mean,std,max}` | trainer | per-environment KL mismatch over trainable tokens (W&B) |
-| `entropy/{env}/{mean,std,max}` | trainer | per-environment policy entropy over trainable tokens (W&B) |
+| `mismatch_kl/{all,env}/{mean,std,max}` | trainer | all-token and per-environment KL mismatch over trainable tokens (W&B) |
+| `entropy/{all,env}/{mean,std,max}` | trainer | all-token and per-environment policy entropy over trainable tokens (W&B) |
 | `optim/grad_norm` | trainer | gradient norm — spikes may precede divergence |
 
 #### Performance

--- a/skills/monitor-run/SKILL.md
+++ b/skills/monitor-run/SKILL.md
@@ -143,12 +143,10 @@ These tell you whether training is healthy or diverging.
 
 | Metric | Source | Description |
 |--------|--------|-------------|
-| `mismatch_kl/mean` | trainer | KL divergence between trainer and (old) inference policy  |
-| `entropy/mean` | trainer | policy entropy |
+| `mismatch_kl/{all,env}/{mean,std,max}` | trainer | KL divergence between trainer and (old) inference policy over trainable tokens (W&B) |
+| `entropy/{all,env}/{mean,std,max}` | trainer | policy entropy over trainable tokens (W&B) |
 | `masked_advantage_positive/mean` | trainer | fraction of DPPO-masked trainable tokens with positive advantage (W&B) |
 | `masked_advantage_negative/mean` | trainer | fraction of DPPO-masked trainable tokens with negative advantage (W&B) |
-| `mismatch_kl/{env}/{mean,std,max}` | trainer | per-environment KL mismatch over trainable tokens (W&B) |
-| `entropy/{env}/{mean,std,max}` | trainer | per-environment policy entropy over trainable tokens (W&B) |
 | `optim/grad_norm` | trainer | gradient norm — spikes may precede divergence |
 
 #### Performance

--- a/skills/monitor-run/SKILL.md
+++ b/skills/monitor-run/SKILL.md
@@ -147,6 +147,8 @@ These tell you whether training is healthy or diverging.
 | `entropy/mean` | trainer | policy entropy |
 | `masked_advantage_positive/mean` | trainer | fraction of DPPO-masked trainable tokens with positive advantage (W&B) |
 | `masked_advantage_negative/mean` | trainer | fraction of DPPO-masked trainable tokens with negative advantage (W&B) |
+| `mismatch_kl/{env}/{mean,std,max}` | trainer | per-environment KL mismatch over trainable tokens (W&B) |
+| `entropy/{env}/{mean,std,max}` | trainer | per-environment policy entropy over trainable tokens (W&B) |
 | `optim/grad_norm` | trainer | gradient norm — spikes may precede divergence |
 
 #### Performance
@@ -253,4 +255,3 @@ PRIME-RL::Launcher
 ```
 
 For multi-node runs, trainer and inference processes are distributed across separate nodes. Use `srun` or `ssh` to inspect processes on other nodes directly.
-

--- a/skills/monitor-run/SKILL.md
+++ b/skills/monitor-run/SKILL.md
@@ -147,8 +147,8 @@ These tell you whether training is healthy or diverging.
 | `entropy/mean` | trainer | policy entropy |
 | `masked_advantage_positive/mean` | trainer | fraction of DPPO-masked trainable tokens with positive advantage (W&B) |
 | `masked_advantage_negative/mean` | trainer | fraction of DPPO-masked trainable tokens with negative advantage (W&B) |
-| `mismatch_kl/{all,env}/{mean,std,max}` | trainer | all-token and per-environment KL mismatch over trainable tokens (W&B) |
-| `entropy/{all,env}/{mean,std,max}` | trainer | all-token and per-environment policy entropy over trainable tokens (W&B) |
+| `mismatch_kl/{env}/{mean,std,max}` | trainer | per-environment KL mismatch over trainable tokens (W&B) |
+| `entropy/{env}/{mean,std,max}` | trainer | per-environment policy entropy over trainable tokens (W&B) |
 | `optim/grad_norm` | trainer | gradient norm — spikes may precede divergence |
 
 #### Performance

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -553,6 +553,7 @@ async def orchestrate(config: OrchestratorConfig):
             for sample in samples:
                 sample.advantage = rollout["advantage"]
                 sample.reward = rollout["reward"]
+                sample.env_name = rollout["env_name"]
                 if config.use_sft_loss:
                     sample.sft_loss = True
                 sample_decode_tokens = sum(sample.completion_mask)

--- a/src/prime_rl/orchestrator/trajectories.py
+++ b/src/prime_rl/orchestrator/trajectories.py
@@ -337,7 +337,7 @@ def interleave_rollout(
             completion_temperatures=[temperature] * len(completion_ids),
             teacher_logprobs=None,
             advantage=None,
-            env_name=output.get("env_name") or "",
+            env_name=output["env_name"],
             routed_experts=routed_experts,
             mm_token_type_ids=None,
         )

--- a/src/prime_rl/orchestrator/trajectories.py
+++ b/src/prime_rl/orchestrator/trajectories.py
@@ -337,6 +337,7 @@ def interleave_rollout(
             completion_temperatures=[temperature] * len(completion_ids),
             teacher_logprobs=None,
             advantage=None,
+            env_name=output.get("env_name"),
             routed_experts=routed_experts,
             mm_token_type_ids=None,
         )

--- a/src/prime_rl/orchestrator/trajectories.py
+++ b/src/prime_rl/orchestrator/trajectories.py
@@ -337,7 +337,7 @@ def interleave_rollout(
             completion_temperatures=[temperature] * len(completion_ids),
             teacher_logprobs=None,
             advantage=None,
-            env_name=output.get("env_name"),
+            env_name=output.get("env_name") or "",
             routed_experts=routed_experts,
             mm_token_type_ids=None,
         )

--- a/src/prime_rl/trainer/batch.py
+++ b/src/prime_rl/trainer/batch.py
@@ -14,8 +14,6 @@ def prepare_sample(training_example: TrainingSample, seq_len: int) -> MicroBatch
     advantages = [training_example.advantage] * len(input_ids)
     position_ids = list(range(len(input_ids)))
     mm_token_type_ids = training_example.mm_token_type_ids
-    if not training_example.env_name:
-        raise ValueError("TrainingSample.env_name must be set before packing")
     env_names = [training_example.env_name] * len(input_ids)
 
     # Per-token temperatures: prompt tokens use first completion temp (masked out anyway)

--- a/src/prime_rl/trainer/batch.py
+++ b/src/prime_rl/trainer/batch.py
@@ -14,7 +14,9 @@ def prepare_sample(training_example: TrainingSample, seq_len: int) -> MicroBatch
     advantages = [training_example.advantage] * len(input_ids)
     position_ids = list(range(len(input_ids)))
     mm_token_type_ids = training_example.mm_token_type_ids
-    env_names = [training_example.env_name] * len(input_ids) if training_example.env_name is not None else None
+    if not training_example.env_name:
+        raise ValueError("TrainingSample.env_name must be set before packing")
+    env_names = [training_example.env_name] * len(input_ids)
 
     # Per-token temperatures: prompt tokens use first completion temp (masked out anyway)
     # Default to 1.0 if completion is empty (e.g., model generated only tool calls with no text)
@@ -39,8 +41,7 @@ def prepare_sample(training_example: TrainingSample, seq_len: int) -> MicroBatch
             routed_experts = routed_experts[:seq_len]
         if mm_token_type_ids is not None:
             mm_token_type_ids = mm_token_type_ids[:seq_len]
-        if env_names is not None:
-            env_names = env_names[:seq_len]
+        env_names = env_names[:seq_len]
 
     assert (
         len(input_ids)
@@ -64,8 +65,7 @@ def prepare_sample(training_example: TrainingSample, seq_len: int) -> MicroBatch
         assert len(mm_token_type_ids) == len(input_ids), (
             f"mm_token_type_ids: {len(mm_token_type_ids)}, input_ids: {len(input_ids)}"
         )
-    if env_names is not None:
-        assert len(env_names) == len(input_ids), f"env_names: {len(env_names)}, input_ids: {len(input_ids)}"
+    assert len(env_names) == len(input_ids), f"env_names: {len(env_names)}, input_ids: {len(input_ids)}"
 
     return MicroBatch(
         input_ids=input_ids,
@@ -143,12 +143,7 @@ def packed_samples_into_micro_bs(
                     if bin_content.mm_token_type_ids is None:
                         bin_content.mm_token_type_ids = []
                     bin_content.mm_token_type_ids.extend(sample.mm_token_type_ids)
-                if sample.env_names is not None:
-                    if bin_content.env_names is None:
-                        bin_content.env_names = [""] * (len(bin_content.input_ids) - len(sample.input_ids))
-                    bin_content.env_names.extend(sample.env_names)
-                elif bin_content.env_names is not None:
-                    bin_content.env_names.extend([""] * len(sample.input_ids))
+                bin_content.env_names.extend(sample.env_names)
                 bin_content.position_ids.extend(sample.position_ids)
                 bin_content.lora_num_tokens[idx] += len(sample.input_ids)
                 break
@@ -173,6 +168,12 @@ def pad_micro_batch(micro_batch: MicroBatch, pad_to_multiple_of: int) -> MicroBa
 
     padding_size = (pad_to_multiple_of - (len(micro_batch.input_ids) % pad_to_multiple_of)) % pad_to_multiple_of
 
+    if len(micro_batch.env_names) != len(micro_batch.input_ids):
+        raise ValueError(
+            f"MicroBatch.env_names must match input_ids length before padding: "
+            f"env_names={len(micro_batch.env_names)}, input_ids={len(micro_batch.input_ids)}"
+        )
+
     if not (pad_to_multiple_of > 1 and padding_size > 0):
         return micro_batch
 
@@ -190,8 +191,7 @@ def pad_micro_batch(micro_batch: MicroBatch, pad_to_multiple_of: int) -> MicroBa
     )
     if micro_batch.mm_token_type_ids is not None:
         micro_batch.mm_token_type_ids.extend([0] * padding_size)
-    if micro_batch.env_names is not None:
-        micro_batch.env_names.extend([""] * padding_size)
+    micro_batch.env_names.extend([""] * padding_size)
 
     return micro_batch
 

--- a/src/prime_rl/trainer/batch.py
+++ b/src/prime_rl/trainer/batch.py
@@ -14,6 +14,7 @@ def prepare_sample(training_example: TrainingSample, seq_len: int) -> MicroBatch
     advantages = [training_example.advantage] * len(input_ids)
     position_ids = list(range(len(input_ids)))
     mm_token_type_ids = training_example.mm_token_type_ids
+    env_names = [training_example.env_name] * len(input_ids) if training_example.env_name is not None else None
 
     # Per-token temperatures: prompt tokens use first completion temp (masked out anyway)
     # Default to 1.0 if completion is empty (e.g., model generated only tool calls with no text)
@@ -38,6 +39,8 @@ def prepare_sample(training_example: TrainingSample, seq_len: int) -> MicroBatch
             routed_experts = routed_experts[:seq_len]
         if mm_token_type_ids is not None:
             mm_token_type_ids = mm_token_type_ids[:seq_len]
+        if env_names is not None:
+            env_names = env_names[:seq_len]
 
     assert (
         len(input_ids)
@@ -61,6 +64,8 @@ def prepare_sample(training_example: TrainingSample, seq_len: int) -> MicroBatch
         assert len(mm_token_type_ids) == len(input_ids), (
             f"mm_token_type_ids: {len(mm_token_type_ids)}, input_ids: {len(input_ids)}"
         )
+    if env_names is not None:
+        assert len(env_names) == len(input_ids), f"env_names: {len(env_names)}, input_ids: {len(input_ids)}"
 
     return MicroBatch(
         input_ids=input_ids,
@@ -72,6 +77,7 @@ def prepare_sample(training_example: TrainingSample, seq_len: int) -> MicroBatch
         temperatures=temperatures,
         routed_experts=routed_experts,
         mm_token_type_ids=mm_token_type_ids,
+        env_names=env_names,
         # Multimodal fields (Qwen3-VL) - passed through without modification
         pixel_values=training_example.pixel_values,
         pixel_values_shape=training_example.pixel_values_shape,
@@ -137,6 +143,12 @@ def packed_samples_into_micro_bs(
                     if bin_content.mm_token_type_ids is None:
                         bin_content.mm_token_type_ids = []
                     bin_content.mm_token_type_ids.extend(sample.mm_token_type_ids)
+                if sample.env_names is not None:
+                    if bin_content.env_names is None:
+                        bin_content.env_names = [""] * (len(bin_content.input_ids) - len(sample.input_ids))
+                    bin_content.env_names.extend(sample.env_names)
+                elif bin_content.env_names is not None:
+                    bin_content.env_names.extend([""] * len(sample.input_ids))
                 bin_content.position_ids.extend(sample.position_ids)
                 bin_content.lora_num_tokens[idx] += len(sample.input_ids)
                 break
@@ -178,6 +190,8 @@ def pad_micro_batch(micro_batch: MicroBatch, pad_to_multiple_of: int) -> MicroBa
     )
     if micro_batch.mm_token_type_ids is not None:
         micro_batch.mm_token_type_ids.extend([0] * padding_size)
+    if micro_batch.env_names is not None:
+        micro_batch.env_names.extend([""] * padding_size)
 
     return micro_batch
 

--- a/src/prime_rl/trainer/batch.py
+++ b/src/prime_rl/trainer/batch.py
@@ -14,6 +14,7 @@ def prepare_sample(training_example: TrainingSample, seq_len: int) -> MicroBatch
     advantages = [training_example.advantage] * len(input_ids)
     position_ids = list(range(len(input_ids)))
     mm_token_type_ids = training_example.mm_token_type_ids
+    assert training_example.env_name != "all", "env_name='all' is reserved for aggregate metric keys"
     env_names = [training_example.env_name] * len(input_ids)
 
     # Per-token temperatures: prompt tokens use first completion temp (masked out anyway)

--- a/src/prime_rl/trainer/rl/data.py
+++ b/src/prime_rl/trainer/rl/data.py
@@ -24,6 +24,7 @@ class TensorMicroBatch(TypedDict):
     teacher_logprobs: Float[Tensor, "batch seq"] | None
     loss_mask: Bool[Tensor, "batch seq"]
     temperatures: Float[Tensor, "batch seq"]  # Per-token temperatures
+    env_names: list[str] | None
 
     # Batch level
     lora_num_tokens: Int[Tensor, "n_loras"]
@@ -108,6 +109,7 @@ class FakeDataLoader:
             "inference_logprobs": inference_logprobs.unsqueeze(0),
             "teacher_logprobs": None,
             "temperatures": torch.ones(input_ids.shape[0]).unsqueeze(0),
+            "env_names": ["fake"] * input_ids.shape[0],
             "loss_mask": loss_mask.unsqueeze(0),
             "lora_num_tokens": lora_num_tokens,
             "routed_experts": None,
@@ -135,6 +137,7 @@ class FakeDataLoader:
             "inference_logprobs": torch.randn(self.seq_len, generator=generator).unsqueeze(0),
             "teacher_logprobs": None,
             "temperatures": torch.ones(self.seq_len).unsqueeze(0),
+            "env_names": ["fake"] * self.seq_len,
             "loss_mask": torch.ones(self.seq_len, dtype=torch.bool).unsqueeze(0),
             "lora_num_tokens": lora_num_tokens,
             "routed_experts": None,
@@ -205,6 +208,7 @@ class DataLoader:
             else None,
             loss_mask=torch.tensor(micro_batch.loss_mask, dtype=torch.bool).unsqueeze(0),
             temperatures=torch.tensor(micro_batch.temperatures, dtype=torch.float).unsqueeze(0),
+            env_names=micro_batch.env_names,
             lora_num_tokens=torch.tensor(micro_batch.lora_num_tokens, dtype=torch.int32),
             # Multimodal fields - no batch dimension for these as they are variable-sized
             pixel_values=torch.frombuffer(bytearray(micro_batch.pixel_values), dtype=torch.float32).reshape(

--- a/src/prime_rl/trainer/rl/data.py
+++ b/src/prime_rl/trainer/rl/data.py
@@ -24,7 +24,7 @@ class TensorMicroBatch(TypedDict):
     teacher_logprobs: Float[Tensor, "batch seq"] | None
     loss_mask: Bool[Tensor, "batch seq"]
     temperatures: Float[Tensor, "batch seq"]  # Per-token temperatures
-    env_names: list[str] | None
+    env_names: list[str]
 
     # Batch level
     lora_num_tokens: Int[Tensor, "n_loras"]
@@ -195,6 +195,13 @@ class DataLoader:
 
     def _micro_batch_to_tensor(self, micro_batch: MicroBatch) -> TensorMicroBatch:
         """Convert a MicroBatch (msgspec struct with lists) to a TensorMicroBatch (dict with tensors)."""
+        if len(micro_batch.env_names) != len(micro_batch.input_ids):
+            raise ValueError(
+                f"MicroBatch.env_names must match input_ids length: "
+                f"env_names={len(micro_batch.env_names)}, input_ids={len(micro_batch.input_ids)}"
+            )
+        if any(not env_name for env_name, keep in zip(micro_batch.env_names, micro_batch.loss_mask) if keep):
+            raise ValueError("MicroBatch.env_names must be set for every trainable token")
         if micro_batch.lora_num_tokens is None:
             micro_batch.lora_num_tokens = [0] * self.multi_run_manager.max_runs
             micro_batch.lora_num_tokens[0] = len(micro_batch.input_ids)

--- a/src/prime_rl/trainer/rl/data.py
+++ b/src/prime_rl/trainer/rl/data.py
@@ -200,8 +200,6 @@ class DataLoader:
                 f"MicroBatch.env_names must match input_ids length: "
                 f"env_names={len(micro_batch.env_names)}, input_ids={len(micro_batch.input_ids)}"
             )
-        if any(not env_name for env_name, keep in zip(micro_batch.env_names, micro_batch.loss_mask) if keep):
-            raise ValueError("MicroBatch.env_names must be set for every trainable token")
         if micro_batch.lora_num_tokens is None:
             micro_batch.lora_num_tokens = [0] * self.multi_run_manager.max_runs
             micro_batch.lora_num_tokens[0] = len(micro_batch.input_ids)

--- a/src/prime_rl/trainer/rl/data.py
+++ b/src/prime_rl/trainer/rl/data.py
@@ -195,11 +195,6 @@ class DataLoader:
 
     def _micro_batch_to_tensor(self, micro_batch: MicroBatch) -> TensorMicroBatch:
         """Convert a MicroBatch (msgspec struct with lists) to a TensorMicroBatch (dict with tensors)."""
-        if len(micro_batch.env_names) != len(micro_batch.input_ids):
-            raise ValueError(
-                f"MicroBatch.env_names must match input_ids length: "
-                f"env_names={len(micro_batch.env_names)}, input_ids={len(micro_batch.input_ids)}"
-            )
         if micro_batch.lora_num_tokens is None:
             micro_batch.lora_num_tokens = [0] * self.multi_run_manager.max_runs
             micro_batch.lora_num_tokens[0] = len(micro_batch.input_ids)

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -19,9 +19,6 @@ class LossInputs:
     teacher_logprobs: Float[Tensor, " seq"] | None
     advantages: Float[Tensor, " seq"]
     loss_mask: Bool[Tensor, " seq"]
-    log_importance_ratio: Float[Tensor, " seq"] | None = None
-    importance_ratio: Float[Tensor, " seq"] | None = None
-    mismatch_kl: Float[Tensor, " seq"] | None = None
 
 
 @dataclass
@@ -134,16 +131,9 @@ def default_loss_fn(inputs: LossInputs, loss_config: DefaultLossConfig) -> LossO
     advantages = inputs.advantages
     loss_mask = inputs.loss_mask
 
-    if inputs.log_importance_ratio is None and inputs.importance_ratio is None and inputs.mismatch_kl is None:
-        log_importance_ratio, importance_ratio, mismatch_kl = compute_importance_ratio_and_mismatch_kl(
-            trainer_logprobs, inference_logprobs
-        )
-    elif inputs.log_importance_ratio is None or inputs.importance_ratio is None or inputs.mismatch_kl is None:
-        raise ValueError("precomputed importance-ratio tensors must be provided together")
-    else:
-        log_importance_ratio = inputs.log_importance_ratio
-        importance_ratio = inputs.importance_ratio
-        mismatch_kl = inputs.mismatch_kl
+    log_importance_ratio, importance_ratio, mismatch_kl = compute_importance_ratio_and_mismatch_kl(
+        trainer_logprobs, inference_logprobs
+    )
 
     inference_probs = torch.exp(inference_logprobs)
     probs_diff = inference_probs * (importance_ratio - 1)
@@ -227,9 +217,6 @@ def compute_loss(
     loss_fn: LossFn,
     loss_scale: int,
     sft_loss: bool = False,
-    log_importance_ratio: list[Float[Tensor, " seq_i"]] | None = None,
-    importance_ratio: list[Float[Tensor, " seq_i"]] | None = None,
-    mismatch_kl: list[Float[Tensor, " seq_i"]] | None = None,
 ) -> tuple[Float[Tensor, ""], dict[str, Any]]:
     """
     Compute loss for packed sequences (batch size = 1, multiple sequences packed along sequence dimension).
@@ -243,9 +230,6 @@ def compute_loss(
         loss_fn: Per-sequence loss function
         loss_scale: Scale factor to normalize the loss
         sft_loss: If True, use SFT loss instead of the configured loss_fn for this batch
-        log_importance_ratio: Optional precomputed trainer-reference log ratio for each sequence
-        importance_ratio: Optional precomputed exp(log_importance_ratio) for each sequence
-        mismatch_kl: Optional precomputed mismatch KL for each sequence
 
     Returns:
         Tuple of (scaled_loss, aggregated_metrics)
@@ -257,22 +241,13 @@ def compute_loss(
 
     if teacher_logprobs is None:
         teacher_logprobs = [None] * len(trainer_logprobs)
-    if log_importance_ratio is None:
-        log_importance_ratio = [None] * len(trainer_logprobs)
-    if importance_ratio is None:
-        importance_ratio = [None] * len(trainer_logprobs)
-    if mismatch_kl is None:
-        mismatch_kl = [None] * len(trainer_logprobs)
 
-    for t_logp, i_logp, teach_logp, adv, mask, log_ratio, ratio, kl in zip(
+    for t_logp, i_logp, teach_logp, adv, mask in zip(
         trainer_logprobs,
         inference_logprobs,
         teacher_logprobs,
         advantages,
         loss_mask,
-        log_importance_ratio,
-        importance_ratio,
-        mismatch_kl,
     ):
         inputs = LossInputs(
             trainer_logprobs=t_logp,
@@ -280,9 +255,6 @@ def compute_loss(
             teacher_logprobs=teach_logp,
             advantages=adv,
             loss_mask=mask,
-            log_importance_ratio=log_ratio,
-            importance_ratio=ratio,
-            mismatch_kl=kl,
         )
 
         result = effective_loss_fn(inputs)

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -135,8 +135,7 @@ def default_loss_fn(inputs: LossInputs, loss_config: DefaultLossConfig) -> LossO
         trainer_logprobs, inference_logprobs
     )
 
-    inference_probs = torch.exp(inference_logprobs)
-    probs_diff = inference_probs * (importance_ratio - 1)
+    probs_diff = torch.exp(trainer_logprobs) - torch.exp(inference_logprobs)
     dppo_invalid_mask_high = probs_diff > loss_config.dppo_mask_high
     dppo_invalid_mask_low = probs_diff < -loss_config.dppo_mask_low
     positive_advantages = advantages > 0
@@ -161,7 +160,6 @@ def default_loss_fn(inputs: LossInputs, loss_config: DefaultLossConfig) -> LossO
     loss = (-pg_loss + loss_config.kl_tau * kl_loss).sum()
 
     metrics = {
-        "mismatch_kl": _safe_mean(mismatch_kl, loss_mask),  # all trainable tokens
         "masked_mismatch_kl": _safe_mean(mismatch_kl, loss_mask & is_masked),  # all trainable, masked tokens
         "unmasked_mismatch_kl": _safe_mean(mismatch_kl, keep_mask),  # all trainable, unmasked tokens
         "is_masked": _safe_mean(is_masked, loss_mask),

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -104,10 +104,13 @@ def _safe_mean(values: Tensor, mask: Tensor) -> Tensor:
     return values[mask].sum() / denom
 
 
-def compute_mismatch_kl(trainer_logprobs: Tensor, inference_logprobs: Tensor) -> Tensor:
+def compute_importance_ratio_and_mismatch_kl(
+    trainer_logprobs: Tensor, inference_logprobs: Tensor
+) -> tuple[Tensor, Tensor, Tensor]:
     log_importance_ratio = trainer_logprobs - inference_logprobs
     importance_ratio = torch.exp(log_importance_ratio)
-    return importance_ratio - log_importance_ratio - 1
+    mismatch_kl = importance_ratio - log_importance_ratio - 1
+    return log_importance_ratio, importance_ratio, mismatch_kl
 
 
 def default_loss_fn(inputs: LossInputs, loss_config: DefaultLossConfig) -> LossOutputs:
@@ -143,9 +146,9 @@ def default_loss_fn(inputs: LossInputs, loss_config: DefaultLossConfig) -> LossO
     drop_mask = loss_mask & is_masked
     keep_mask = loss_mask & ~is_masked
 
-    log_importance_ratio = trainer_logprobs - inference_logprobs
-    importance_ratio = torch.exp(log_importance_ratio)
-    mismatch_kl = compute_mismatch_kl(trainer_logprobs, inference_logprobs)
+    log_importance_ratio, importance_ratio, mismatch_kl = compute_importance_ratio_and_mismatch_kl(
+        trainer_logprobs, inference_logprobs
+    )
 
     advantages = loss_config.adv_tau * advantages
     if teacher_logprobs is not None:

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -134,9 +134,19 @@ def default_loss_fn(inputs: LossInputs, loss_config: DefaultLossConfig) -> LossO
     advantages = inputs.advantages
     loss_mask = inputs.loss_mask
 
-    trainer_probs = torch.exp(trainer_logprobs)
+    if inputs.log_importance_ratio is None and inputs.importance_ratio is None and inputs.mismatch_kl is None:
+        log_importance_ratio, importance_ratio, mismatch_kl = compute_importance_ratio_and_mismatch_kl(
+            trainer_logprobs, inference_logprobs
+        )
+    elif inputs.log_importance_ratio is None or inputs.importance_ratio is None or inputs.mismatch_kl is None:
+        raise ValueError("precomputed importance-ratio tensors must be provided together")
+    else:
+        log_importance_ratio = inputs.log_importance_ratio
+        importance_ratio = inputs.importance_ratio
+        mismatch_kl = inputs.mismatch_kl
+
     inference_probs = torch.exp(inference_logprobs)
-    probs_diff = trainer_probs - inference_probs
+    probs_diff = inference_probs * (importance_ratio - 1)
     dppo_invalid_mask_high = probs_diff > loss_config.dppo_mask_high
     dppo_invalid_mask_low = probs_diff < -loss_config.dppo_mask_low
     positive_advantages = advantages > 0
@@ -148,17 +158,6 @@ def default_loss_fn(inputs: LossInputs, loss_config: DefaultLossConfig) -> LossO
     is_masked_low = negative_advantages & dppo_invalid_mask_low
     drop_mask = loss_mask & is_masked
     keep_mask = loss_mask & ~is_masked
-
-    if inputs.log_importance_ratio is None and inputs.importance_ratio is None and inputs.mismatch_kl is None:
-        log_importance_ratio, importance_ratio, mismatch_kl = compute_importance_ratio_and_mismatch_kl(
-            trainer_logprobs, inference_logprobs
-        )
-    elif inputs.log_importance_ratio is None or inputs.importance_ratio is None or inputs.mismatch_kl is None:
-        raise ValueError("precomputed importance-ratio tensors must be provided together")
-    else:
-        log_importance_ratio = inputs.log_importance_ratio
-        importance_ratio = inputs.importance_ratio
-        mismatch_kl = inputs.mismatch_kl
 
     advantages = loss_config.adv_tau * advantages
     if teacher_logprobs is not None:

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -104,6 +104,12 @@ def _safe_mean(values: Tensor, mask: Tensor) -> Tensor:
     return values[mask].sum() / denom
 
 
+def compute_mismatch_kl(trainer_logprobs: Tensor, inference_logprobs: Tensor) -> Tensor:
+    log_importance_ratio = trainer_logprobs - inference_logprobs
+    importance_ratio = torch.exp(log_importance_ratio)
+    return importance_ratio - log_importance_ratio - 1
+
+
 def default_loss_fn(inputs: LossInputs, loss_config: DefaultLossConfig) -> LossOutputs:
     """
     DPPO+KL loss, combining:
@@ -139,7 +145,7 @@ def default_loss_fn(inputs: LossInputs, loss_config: DefaultLossConfig) -> LossO
 
     log_importance_ratio = trainer_logprobs - inference_logprobs
     importance_ratio = torch.exp(log_importance_ratio)
-    mismatch_kl = importance_ratio - log_importance_ratio - 1
+    mismatch_kl = compute_mismatch_kl(trainer_logprobs, inference_logprobs)
 
     advantages = loss_config.adv_tau * advantages
     if teacher_logprobs is not None:

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -19,6 +19,9 @@ class LossInputs:
     teacher_logprobs: Float[Tensor, " seq"] | None
     advantages: Float[Tensor, " seq"]
     loss_mask: Bool[Tensor, " seq"]
+    log_importance_ratio: Float[Tensor, " seq"] | None = None
+    importance_ratio: Float[Tensor, " seq"] | None = None
+    mismatch_kl: Float[Tensor, " seq"] | None = None
 
 
 @dataclass
@@ -146,9 +149,16 @@ def default_loss_fn(inputs: LossInputs, loss_config: DefaultLossConfig) -> LossO
     drop_mask = loss_mask & is_masked
     keep_mask = loss_mask & ~is_masked
 
-    log_importance_ratio, importance_ratio, mismatch_kl = compute_importance_ratio_and_mismatch_kl(
-        trainer_logprobs, inference_logprobs
-    )
+    if inputs.log_importance_ratio is None and inputs.importance_ratio is None and inputs.mismatch_kl is None:
+        log_importance_ratio, importance_ratio, mismatch_kl = compute_importance_ratio_and_mismatch_kl(
+            trainer_logprobs, inference_logprobs
+        )
+    elif inputs.log_importance_ratio is None or inputs.importance_ratio is None or inputs.mismatch_kl is None:
+        raise ValueError("precomputed importance-ratio tensors must be provided together")
+    else:
+        log_importance_ratio = inputs.log_importance_ratio
+        importance_ratio = inputs.importance_ratio
+        mismatch_kl = inputs.mismatch_kl
 
     advantages = loss_config.adv_tau * advantages
     if teacher_logprobs is not None:
@@ -218,6 +228,9 @@ def compute_loss(
     loss_fn: LossFn,
     loss_scale: int,
     sft_loss: bool = False,
+    log_importance_ratio: list[Float[Tensor, " seq_i"]] | None = None,
+    importance_ratio: list[Float[Tensor, " seq_i"]] | None = None,
+    mismatch_kl: list[Float[Tensor, " seq_i"]] | None = None,
 ) -> tuple[Float[Tensor, ""], dict[str, Any]]:
     """
     Compute loss for packed sequences (batch size = 1, multiple sequences packed along sequence dimension).
@@ -231,6 +244,9 @@ def compute_loss(
         loss_fn: Per-sequence loss function
         loss_scale: Scale factor to normalize the loss
         sft_loss: If True, use SFT loss instead of the configured loss_fn for this batch
+        log_importance_ratio: Optional precomputed trainer-reference log ratio for each sequence
+        importance_ratio: Optional precomputed exp(log_importance_ratio) for each sequence
+        mismatch_kl: Optional precomputed mismatch KL for each sequence
 
     Returns:
         Tuple of (scaled_loss, aggregated_metrics)
@@ -242,9 +258,22 @@ def compute_loss(
 
     if teacher_logprobs is None:
         teacher_logprobs = [None] * len(trainer_logprobs)
+    if log_importance_ratio is None:
+        log_importance_ratio = [None] * len(trainer_logprobs)
+    if importance_ratio is None:
+        importance_ratio = [None] * len(trainer_logprobs)
+    if mismatch_kl is None:
+        mismatch_kl = [None] * len(trainer_logprobs)
 
-    for t_logp, i_logp, teach_logp, adv, mask in zip(
-        trainer_logprobs, inference_logprobs, teacher_logprobs, advantages, loss_mask
+    for t_logp, i_logp, teach_logp, adv, mask, log_ratio, ratio, kl in zip(
+        trainer_logprobs,
+        inference_logprobs,
+        teacher_logprobs,
+        advantages,
+        loss_mask,
+        log_importance_ratio,
+        importance_ratio,
+        mismatch_kl,
     ):
         inputs = LossInputs(
             trainer_logprobs=t_logp,
@@ -252,6 +281,9 @@ def compute_loss(
             teacher_logprobs=teach_logp,
             advantages=adv,
             loss_mask=mask,
+            log_importance_ratio=log_ratio,
+            importance_ratio=ratio,
+            mismatch_kl=kl,
         )
 
         result = effective_loss_fn(inputs)

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -479,10 +479,6 @@ def train(config: TrainerConfig):
             tensors["entropy/all"].append(entropy)
             tensors["loss"].append(loss.detach().to("cpu").unsqueeze(0))
 
-            with torch.no_grad():
-                _, _, mismatch_kl = compute_importance_ratio_and_mismatch_kl(out["logprobs"], inference_logprobs)
-            mismatch_kl = mismatch_kl[loss_mask].detach().to("cpu")
-
             env_names = micro_batch["env_names"]
             masked_env_names = [env_name for env_name, keep in zip(env_names, loss_mask.flatten().tolist()) if keep]
             env_to_indices: dict[str, list[int]] = {}
@@ -491,7 +487,13 @@ def train(config: TrainerConfig):
 
             for env_name, indices in env_to_indices.items():
                 tensors[f"entropy/{env_name}"].append(entropy[indices])
-                tensors[f"mismatch_kl/{env_name}"].append(mismatch_kl[indices])
+
+            if not micro_batch["sft_loss"]:
+                with torch.no_grad():
+                    _, _, mismatch_kl = compute_importance_ratio_and_mismatch_kl(out["logprobs"], inference_logprobs)
+                mismatch_kl = mismatch_kl[loss_mask].detach().to("cpu")
+                for env_name, indices in env_to_indices.items():
+                    tensors[f"mismatch_kl/{env_name}"].append(mismatch_kl[indices])
 
             if is_tt_moe_model(model):
                 load_balance_stats = get_load_balance_stats(model)
@@ -507,7 +509,9 @@ def train(config: TrainerConfig):
                 tensors[key].append(loss_tensor)
 
             # Debug log with *local, micro step* stats
-            micro_step_message = f"Micro Step {micro_step}/{len(micro_batches)} | Loss: {tensors['loss'][-1].mean().item():.4f} | Entropy: {tensors['entropy/all'][-1].mean().item():.4f} | Mismatch KL: {tensors['mismatch_kl/all'][-1].mean().item():.4f}"
+            micro_step_message = f"Micro Step {micro_step}/{len(micro_batches)} | Loss: {tensors['loss'][-1].mean().item():.4f} | Entropy: {tensors['entropy/all'][-1].mean().item():.4f}"
+            if not micro_batch["sft_loss"]:
+                micro_step_message += f" | Mismatch KL: {tensors['mismatch_kl/all'][-1].mean().item():.4f}"
             if "max_vio" in tensors:
                 micro_step_message += f" | Max Vio: {tensors['max_vio'][-1].mean().item():.4f}"
             logger.debug(micro_step_message)
@@ -555,7 +559,9 @@ def train(config: TrainerConfig):
 
         # Log step metrics
         step_time = time.perf_counter() - step_start_time
-        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {tensor_stats['loss/mean']:.4f} | Entropy: {tensor_stats['entropy/all/mean']:.4f} | Mismatch KL: {tensor_stats['mismatch_kl/all/mean']:.4f}"
+        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {tensor_stats['loss/mean']:.4f} | Entropy: {tensor_stats['entropy/all/mean']:.4f}"
+        if "mismatch_kl/all/mean" in tensor_stats:
+            step_message += f" | Mismatch KL: {tensor_stats['mismatch_kl/all/mean']:.4f}"
         if grad_norm is not None:
             step_message += f" | Grad. Norm: {grad_norm:.4f}"
         step_message += f" | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}% | Peak Mem.: {peak_memory:.1f} GiB"

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -479,16 +479,23 @@ def train(config: TrainerConfig):
             tensors["entropy"].append(out["entropy"][loss_mask].detach().to("cpu"))
             tensors["loss"].append(loss.detach().to("cpu").unsqueeze(0))
 
-            env_names = micro_batch.get("env_names")
-            if env_names is not None:
-                masked_env_names = [env_name for env_name, keep in zip(env_names, loss_mask.flatten().tolist()) if keep]
-                env_tensors.append("entropy", out["entropy"][loss_mask].detach().to("cpu"), masked_env_names)
-                if "mismatch_kl" in loss_tensors:
-                    with torch.no_grad():
-                        log_importance_ratio = out["logprobs"] - inference_logprobs
-                        importance_ratio = torch.exp(log_importance_ratio)
-                        mismatch_kl = importance_ratio - log_importance_ratio - 1
-                    env_tensors.append("mismatch_kl", mismatch_kl[loss_mask].detach().to("cpu"), masked_env_names)
+            env_names = micro_batch["env_names"]
+            loss_mask_values = loss_mask.flatten().tolist()
+            if len(env_names) != len(loss_mask_values):
+                raise ValueError(
+                    f"micro_batch env_names length must match loss_mask length: "
+                    f"env_names={len(env_names)}, loss_mask={len(loss_mask_values)}"
+                )
+            masked_env_names = [env_name for env_name, keep in zip(env_names, loss_mask_values) if keep]
+            if any(not env_name for env_name in masked_env_names):
+                raise ValueError("micro_batch env_names must be set for every trainable token")
+            env_tensors.append("entropy", out["entropy"][loss_mask].detach().to("cpu"), masked_env_names)
+            if "mismatch_kl" in loss_tensors:
+                with torch.no_grad():
+                    log_importance_ratio = out["logprobs"] - inference_logprobs
+                    importance_ratio = torch.exp(log_importance_ratio)
+                    mismatch_kl = importance_ratio - log_importance_ratio - 1
+                env_tensors.append("mismatch_kl", mismatch_kl[loss_mask].detach().to("cpu"), masked_env_names)
 
             if is_tt_moe_model(model):
                 load_balance_stats = get_load_balance_stats(model)

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -29,7 +29,7 @@ from prime_rl.utils.logger import setup_logger
 from prime_rl.trainer.rl.loss import (
     compute_entropy,
     compute_loss,
-    compute_mismatch_kl,
+    compute_importance_ratio_and_mismatch_kl,
     selective_log_softmax,
     setup_loss_fn,
     shift_tensor_left,
@@ -485,14 +485,12 @@ def train(config: TrainerConfig):
                 env_to_indices.setdefault(env_name, []).append(idx)
 
             entropy = out["entropy"][loss_mask].detach().to("cpu")
-            tensors["entropy/all"].append(entropy)
             for env_name, indices in env_to_indices.items():
                 tensors[f"entropy/{env_name}"].append(entropy[indices])
 
             with torch.no_grad():
-                mismatch_kl = compute_mismatch_kl(out["logprobs"], inference_logprobs)
+                _, _, mismatch_kl = compute_importance_ratio_and_mismatch_kl(out["logprobs"], inference_logprobs)
             mismatch_kl = mismatch_kl[loss_mask].detach().to("cpu")
-            tensors["mismatch_kl/all"].append(mismatch_kl)
             for env_name, indices in env_to_indices.items():
                 tensors[f"mismatch_kl/{env_name}"].append(mismatch_kl[indices])
 

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -45,6 +45,7 @@ from prime_rl.trainer.parallel_dims import get_parallel_dims
 from prime_rl.trainer.perf import get_perf_counter
 from prime_rl.trainer.utils import (
     GarbageCollection,
+    GroupedTensors,
     MemoryProfiler,
     Tensors,
     export_benchmark_json,
@@ -343,6 +344,7 @@ def train(config: TrainerConfig):
 
         logger.debug(f"Starting forward and backward pass ({batch_size=})")
         tensors = Tensors()  # Used to accumulate tensor statistics across micro-batches and ranks for logging
+        env_tensors = GroupedTensors()
         cp_enabled = parallel_dims.cp_enabled
         cp_rank = parallel_dims.world_mesh["cp"].get_local_rank() if cp_enabled else 0
         cp_group = parallel_dims.world_mesh["cp"].get_group() if cp_enabled else None
@@ -477,6 +479,17 @@ def train(config: TrainerConfig):
             tensors["entropy"].append(out["entropy"][loss_mask].detach().to("cpu"))
             tensors["loss"].append(loss.detach().to("cpu").unsqueeze(0))
 
+            env_names = micro_batch.get("env_names")
+            if env_names is not None:
+                masked_env_names = [env_name for env_name, keep in zip(env_names, loss_mask.flatten().tolist()) if keep]
+                env_tensors.append("entropy", out["entropy"][loss_mask].detach().to("cpu"), masked_env_names)
+                if "mismatch_kl" in loss_tensors:
+                    with torch.no_grad():
+                        log_importance_ratio = out["logprobs"] - inference_logprobs
+                        importance_ratio = torch.exp(log_importance_ratio)
+                        mismatch_kl = importance_ratio - log_importance_ratio - 1
+                    env_tensors.append("mismatch_kl", mismatch_kl[loss_mask].detach().to("cpu"), masked_env_names)
+
             if is_tt_moe_model(model):
                 load_balance_stats = get_load_balance_stats(model)
                 for k, v in load_balance_stats.items():
@@ -526,6 +539,7 @@ def train(config: TrainerConfig):
 
         # Synchronize the tensor metrics across all steps and ranks
         tensor_stats = tensors.compute_stats()
+        tensor_stats.update(env_tensors.compute_stats())
 
         # Compute step metrics
         num_local_tokens = seq_len * batch_size

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -46,7 +46,6 @@ from prime_rl.trainer.parallel_dims import get_parallel_dims
 from prime_rl.trainer.perf import get_perf_counter
 from prime_rl.trainer.utils import (
     GarbageCollection,
-    GroupedTensors,
     MemoryProfiler,
     Tensors,
     export_benchmark_json,
@@ -345,7 +344,6 @@ def train(config: TrainerConfig):
 
         logger.debug(f"Starting forward and backward pass ({batch_size=})")
         tensors = Tensors()  # Used to accumulate tensor statistics across micro-batches and ranks for logging
-        env_tensors = GroupedTensors()
         cp_enabled = parallel_dims.cp_enabled
         cp_rank = parallel_dims.world_mesh["cp"].get_local_rank() if cp_enabled else 0
         cp_group = parallel_dims.world_mesh["cp"].get_group() if cp_enabled else None
@@ -482,10 +480,21 @@ def train(config: TrainerConfig):
 
             env_names = micro_batch["env_names"]
             masked_env_names = [env_name for env_name, keep in zip(env_names, loss_mask.flatten().tolist()) if keep]
-            env_tensors.append("entropy", out["entropy"][loss_mask].detach().to("cpu"), masked_env_names)
+            env_to_indices: dict[str, list[int]] = {}
+            for idx, env_name in enumerate(masked_env_names):
+                env_to_indices.setdefault(env_name, []).append(idx)
+
+            entropy = out["entropy"][loss_mask].detach().to("cpu")
+            tensors["entropy/all"].append(entropy)
+            for env_name, indices in env_to_indices.items():
+                tensors[f"entropy/{env_name}"].append(entropy[indices])
+
             with torch.no_grad():
                 mismatch_kl = compute_mismatch_kl(out["logprobs"], inference_logprobs)
-            env_tensors.append("mismatch_kl", mismatch_kl[loss_mask].detach().to("cpu"), masked_env_names)
+            mismatch_kl = mismatch_kl[loss_mask].detach().to("cpu")
+            tensors["mismatch_kl/all"].append(mismatch_kl)
+            for env_name, indices in env_to_indices.items():
+                tensors[f"mismatch_kl/{env_name}"].append(mismatch_kl[indices])
 
             if is_tt_moe_model(model):
                 load_balance_stats = get_load_balance_stats(model)
@@ -536,7 +545,6 @@ def train(config: TrainerConfig):
 
         # Synchronize the tensor metrics across all steps and ranks
         tensor_stats = tensors.compute_stats()
-        tensor_stats.update(env_tensors.compute_stats())
 
         # Compute step metrics
         num_local_tokens = seq_len * batch_size

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -457,9 +457,6 @@ def train(config: TrainerConfig):
 
             # Compute loss
             response_lengths = get_response_lengths(position_ids)
-            log_importance_ratio, importance_ratio, mismatch_kl = compute_importance_ratio_and_mismatch_kl(
-                out["logprobs"], inference_logprobs
-            )
             loss, loss_tensors = compute_loss(
                 trainer_logprobs=out["logprobs"].squeeze().split(response_lengths),
                 inference_logprobs=inference_logprobs.squeeze().split(response_lengths),
@@ -471,9 +468,6 @@ def train(config: TrainerConfig):
                 loss_fn=loss_fn,
                 loss_scale=loss_scale,
                 sft_loss=micro_batch["sft_loss"],
-                log_importance_ratio=log_importance_ratio.squeeze().split(response_lengths),
-                importance_ratio=importance_ratio.squeeze().split(response_lengths),
-                mismatch_kl=mismatch_kl.squeeze().split(response_lengths),
             )
 
             # Backward pass
@@ -481,8 +475,13 @@ def train(config: TrainerConfig):
                 loss.backward()
 
             # Add relevant tensors to tensor dict for logging purposes
-            tensors["entropy"].append(out["entropy"][loss_mask].detach().to("cpu"))
+            entropy = out["entropy"][loss_mask].detach().to("cpu")
+            tensors["entropy/all"].append(entropy)
             tensors["loss"].append(loss.detach().to("cpu").unsqueeze(0))
+
+            with torch.no_grad():
+                _, _, mismatch_kl = compute_importance_ratio_and_mismatch_kl(out["logprobs"], inference_logprobs)
+            mismatch_kl = mismatch_kl[loss_mask].detach().to("cpu")
 
             env_names = micro_batch["env_names"]
             masked_env_names = [env_name for env_name, keep in zip(env_names, loss_mask.flatten().tolist()) if keep]
@@ -490,12 +489,8 @@ def train(config: TrainerConfig):
             for idx, env_name in enumerate(masked_env_names):
                 env_to_indices.setdefault(env_name, []).append(idx)
 
-            entropy = tensors["entropy"][-1]
             for env_name, indices in env_to_indices.items():
                 tensors[f"entropy/{env_name}"].append(entropy[indices])
-
-            mismatch_kl = mismatch_kl[loss_mask].detach().to("cpu")
-            for env_name, indices in env_to_indices.items():
                 tensors[f"mismatch_kl/{env_name}"].append(mismatch_kl[indices])
 
             if is_tt_moe_model(model):
@@ -507,12 +502,12 @@ def train(config: TrainerConfig):
             # Add loss tensors to tensor dict for logging purposes
             for key, loss_tensor in loss_tensors.items():
                 loss_tensor = loss_tensor.detach().to("cpu")
+                if key == "mismatch_kl":
+                    key = "mismatch_kl/all"
                 tensors[key].append(loss_tensor)
 
             # Debug log with *local, micro step* stats
-            micro_step_message = f"Micro Step {micro_step}/{len(micro_batches)} | Loss: {tensors['loss'][-1].mean().item():.4f} | Entropy: {tensors['entropy'][-1].mean().item():.4f}"
-            if "mismatch_kl" in tensors:
-                micro_step_message += f" | Mismatch KL: {tensors['mismatch_kl'][-1].mean().item():.4f}"
+            micro_step_message = f"Micro Step {micro_step}/{len(micro_batches)} | Loss: {tensors['loss'][-1].mean().item():.4f} | Entropy: {tensors['entropy/all'][-1].mean().item():.4f} | Mismatch KL: {tensors['mismatch_kl/all'][-1].mean().item():.4f}"
             if "max_vio" in tensors:
                 micro_step_message += f" | Max Vio: {tensors['max_vio'][-1].mean().item():.4f}"
             logger.debug(micro_step_message)
@@ -560,9 +555,7 @@ def train(config: TrainerConfig):
 
         # Log step metrics
         step_time = time.perf_counter() - step_start_time
-        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {tensor_stats['loss/mean']:.4f} | Entropy: {tensor_stats['entropy/mean']:.4f}"
-        if "mismatch_kl/mean" in tensor_stats:
-            step_message += f" | Mismatch KL: {tensor_stats['mismatch_kl/mean']:.4f}"
+        step_message = f"Step {progress.step} | Time: {step_time:.2f}s | Loss: {tensor_stats['loss/mean']:.4f} | Entropy: {tensor_stats['entropy/all/mean']:.4f} | Mismatch KL: {tensor_stats['mismatch_kl/all/mean']:.4f}"
         if grad_norm is not None:
             step_message += f" | Grad. Norm: {grad_norm:.4f}"
         step_message += f" | LR: {current_lr:.2e} | Throughput: {throughput:.0f} tokens/s | MFU: {mfu:.1f}% | Peak Mem.: {peak_memory:.1f} GiB"
@@ -591,8 +584,8 @@ def train(config: TrainerConfig):
         monitor.log(optim_metrics, step=progress.step)
 
         # Compute derived metrics
-        entropy_mean = tensor_stats.get("entropy/mean", 0.0)
-        mismatch_kl_mean = tensor_stats.get("mismatch_kl/mean")
+        entropy_mean = tensor_stats.get("entropy/all/mean", 0.0)
+        mismatch_kl_mean = tensor_stats.get("mismatch_kl/all/mean")
         if mismatch_kl_mean is not None and entropy_mean > 0:
             tensor_stats["kl_ent_ratio/mean"] = mismatch_kl_mean / entropy_mean
 
@@ -626,8 +619,8 @@ def train(config: TrainerConfig):
                 peak_memory_gib=peak_memory,
                 learning_rate=current_lr,
                 mfu=mfu,
-                entropy=tensor_stats.get("entropy/mean", 0.0),
-                mismatch_kl=tensor_stats.get("mismatch_kl/mean", 0.0),
+                entropy=tensor_stats.get("entropy/all/mean", 0.0),
+                mismatch_kl=tensor_stats.get("mismatch_kl/all/mean", 0.0),
                 zero_grad_ratio=zero_grad_ratio,
             )
             # Update run/LoRA metrics

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -29,6 +29,7 @@ from prime_rl.utils.logger import setup_logger
 from prime_rl.trainer.rl.loss import (
     compute_entropy,
     compute_loss,
+    compute_mismatch_kl,
     selective_log_softmax,
     setup_loss_fn,
     shift_tensor_left,
@@ -480,22 +481,11 @@ def train(config: TrainerConfig):
             tensors["loss"].append(loss.detach().to("cpu").unsqueeze(0))
 
             env_names = micro_batch["env_names"]
-            loss_mask_values = loss_mask.flatten().tolist()
-            if len(env_names) != len(loss_mask_values):
-                raise ValueError(
-                    f"micro_batch env_names length must match loss_mask length: "
-                    f"env_names={len(env_names)}, loss_mask={len(loss_mask_values)}"
-                )
-            masked_env_names = [env_name for env_name, keep in zip(env_names, loss_mask_values) if keep]
-            if any(not env_name for env_name in masked_env_names):
-                raise ValueError("micro_batch env_names must be set for every trainable token")
+            masked_env_names = [env_name for env_name, keep in zip(env_names, loss_mask.flatten().tolist()) if keep]
             env_tensors.append("entropy", out["entropy"][loss_mask].detach().to("cpu"), masked_env_names)
-            if "mismatch_kl" in loss_tensors:
-                with torch.no_grad():
-                    log_importance_ratio = out["logprobs"] - inference_logprobs
-                    importance_ratio = torch.exp(log_importance_ratio)
-                    mismatch_kl = importance_ratio - log_importance_ratio - 1
-                env_tensors.append("mismatch_kl", mismatch_kl[loss_mask].detach().to("cpu"), masked_env_names)
+            with torch.no_grad():
+                mismatch_kl = compute_mismatch_kl(out["logprobs"], inference_logprobs)
+            env_tensors.append("mismatch_kl", mismatch_kl[loss_mask].detach().to("cpu"), masked_env_names)
 
             if is_tt_moe_model(model):
                 load_balance_stats = get_load_balance_stats(model)

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -492,6 +492,7 @@ def train(config: TrainerConfig):
                 with torch.no_grad():
                     _, _, mismatch_kl = compute_importance_ratio_and_mismatch_kl(out["logprobs"], inference_logprobs)
                 mismatch_kl = mismatch_kl[loss_mask].detach().to("cpu")
+                tensors["mismatch_kl/all"].append(mismatch_kl)
                 for env_name, indices in env_to_indices.items():
                     tensors[f"mismatch_kl/{env_name}"].append(mismatch_kl[indices])
 
@@ -503,10 +504,7 @@ def train(config: TrainerConfig):
 
             # Add loss tensors to tensor dict for logging purposes
             for key, loss_tensor in loss_tensors.items():
-                loss_tensor = loss_tensor.detach().to("cpu")
-                if key == "mismatch_kl":
-                    key = "mismatch_kl/all"
-                tensors[key].append(loss_tensor)
+                tensors[key].append(loss_tensor.detach().to("cpu"))
 
             # Debug log with *local, micro step* stats
             micro_step_message = f"Micro Step {micro_step}/{len(micro_batches)} | Loss: {tensors['loss'][-1].mean().item():.4f} | Entropy: {tensors['entropy/all'][-1].mean().item():.4f}"

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -457,6 +457,9 @@ def train(config: TrainerConfig):
 
             # Compute loss
             response_lengths = get_response_lengths(position_ids)
+            log_importance_ratio, importance_ratio, mismatch_kl = compute_importance_ratio_and_mismatch_kl(
+                out["logprobs"], inference_logprobs
+            )
             loss, loss_tensors = compute_loss(
                 trainer_logprobs=out["logprobs"].squeeze().split(response_lengths),
                 inference_logprobs=inference_logprobs.squeeze().split(response_lengths),
@@ -468,6 +471,9 @@ def train(config: TrainerConfig):
                 loss_fn=loss_fn,
                 loss_scale=loss_scale,
                 sft_loss=micro_batch["sft_loss"],
+                log_importance_ratio=log_importance_ratio.squeeze().split(response_lengths),
+                importance_ratio=importance_ratio.squeeze().split(response_lengths),
+                mismatch_kl=mismatch_kl.squeeze().split(response_lengths),
             )
 
             # Backward pass
@@ -484,12 +490,10 @@ def train(config: TrainerConfig):
             for idx, env_name in enumerate(masked_env_names):
                 env_to_indices.setdefault(env_name, []).append(idx)
 
-            entropy = out["entropy"][loss_mask].detach().to("cpu")
+            entropy = tensors["entropy"][-1]
             for env_name, indices in env_to_indices.items():
                 tensors[f"entropy/{env_name}"].append(entropy[indices])
 
-            with torch.no_grad():
-                _, _, mismatch_kl = compute_importance_ratio_and_mismatch_kl(out["logprobs"], inference_logprobs)
             mismatch_kl = mismatch_kl[loss_mask].detach().to("cpu")
             for env_name, indices in env_to_indices.items():
                 tensors[f"mismatch_kl/{env_name}"].append(mismatch_kl[indices])

--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -398,6 +398,7 @@ class GroupedTensors:
             return
 
         cpu_tensors = tensors.detach().to("cpu")
+        self.data[key]["all"].append(cpu_tensors)
         group_to_indices: dict[str, list[int]] = defaultdict(list)
         for idx, group in enumerate(groups):
             if group:

--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -382,6 +382,64 @@ class Tensors(defaultdict):
         return metrics
 
 
+class GroupedTensors:
+    """Accumulate 1D tensors and compute distributed statistics grouped by string labels."""
+
+    def __init__(self):
+        assert dist.is_initialized(), "GroupedTensors requires a distributed environment"
+        self.data: dict[str, dict[str, list[Tensor]]] = defaultdict(lambda: defaultdict(list))
+
+    def append(self, key: str, tensors: Tensor, groups: list[str]) -> None:
+        tensors = tensors.flatten()
+        assert tensors.ndim == 1, "Can only aggregate 1D tensors"
+        assert tensors.numel() == len(groups), f"{key} has {tensors.numel()} values but {len(groups)} groups"
+
+        if tensors.numel() == 0:
+            return
+
+        cpu_tensors = tensors.detach().to("cpu")
+        group_to_indices: dict[str, list[int]] = defaultdict(list)
+        for idx, group in enumerate(groups):
+            if group:
+                group_to_indices[group].append(idx)
+
+        for group, indices in group_to_indices.items():
+            self.data[key][group].append(cpu_tensors[indices])
+
+    def compute_stats(self) -> dict[str, float | int]:
+        local_pairs = [(key, group) for key, by_group in self.data.items() for group in by_group]
+        gathered_pairs: list[list[tuple[str, str]] | None] = [None] * dist.get_world_size()
+        dist.all_gather_object(gathered_pairs, local_pairs)
+
+        pairs = sorted({pair for rank_pairs in gathered_pairs if rank_pairs is not None for pair in rank_pairs})
+        metrics: dict[str, float | int] = {}
+
+        for key, group in pairs:
+            group_tensors = self.data.get(key, {}).get(group, [])
+            if group_tensors:
+                tensors = torch.cat(group_tensors, dim=0).to("cuda")
+            else:
+                tensors = torch.empty(0, device="cuda")
+
+            tensors = flexible_all_gather(tensors)
+            if tensors.numel() == 0:
+                metrics[f"{key}/{group}/mean"] = float("nan")
+                metrics[f"{key}/{group}/std"] = float("nan")
+                metrics[f"{key}/{group}/max"] = float("nan")
+                continue
+
+            metrics[f"{key}/{group}/mean"] = tensors.mean().item()
+            metrics[f"{key}/{group}/std"] = tensors.std().item()
+            metrics[f"{key}/{group}/max"] = tensors.max().item()
+
+        return metrics
+
+
+def _is_env_tensor_stat(key: str, allowed_stats: set[str]) -> bool:
+    parts = key.split("/")
+    return len(parts) >= 3 and parts[-1] in allowed_stats
+
+
 def filter_rl_trainer_tensor_stats_for_wandb(metrics: dict[str, float | int]) -> dict[str, float | int]:
     """Drop noisy per-token distribution keys before sending RL trainer stats to W&B."""
     skip_prefixes = ("trainer_probs/", "inference_probs/")
@@ -402,9 +460,12 @@ def filter_rl_trainer_tensor_stats_for_wandb(metrics: dict[str, float | int]) ->
             continue
         if any(k.startswith(p) for p in skip_prefixes):
             continue
-        if k.startswith("entropy/") and k != "entropy/mean":
+        if k.startswith("entropy/") and k != "entropy/mean" and not _is_env_tensor_stat(k, {"mean", "std", "max"}):
             continue
         if any(k.startswith(p) for p in mean_max_only_prefixes):
+            if _is_env_tensor_stat(k, {"mean", "std", "max"}):
+                out[k] = v
+                continue
             if not (k.endswith("/mean") or k.endswith("/max")):
                 continue
         out[k] = v

--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -413,7 +413,7 @@ def filter_rl_trainer_tensor_stats_for_wandb(metrics: dict[str, float | int]) ->
             continue
         if any(k.startswith(p) for p in skip_prefixes):
             continue
-        if k.startswith("entropy/") and k != "entropy/mean" and not _is_env_tensor_stat(k, {"mean", "std", "max"}):
+        if k.startswith("entropy/") and not _is_env_tensor_stat(k, {"mean", "std", "max"}):
             continue
         if any(k.startswith(p) for p in mean_max_only_prefixes):
             if _is_env_tensor_stat(k, {"mean", "std", "max"}):

--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -352,10 +352,16 @@ class Tensors(defaultdict):
     def compute_stats(self) -> dict[str, float | int]:
         """Synchronize the tensor statistic across all ranks for each key and compute relevant statistics."""
 
+        local_keys = list(self.keys())
+        gathered_keys: list[list[str] | None] = [None] * dist.get_world_size()
+        dist.all_gather_object(gathered_keys, local_keys)
+        keys = sorted({key for rank_keys in gathered_keys if rank_keys is not None for key in rank_keys})
+
         metrics = {}
-        for key in list(self.keys()):
+        for key in keys:
             # All-gather tensors across steps and ranks (get global distribution)
-            tensors = torch.cat(self.pop(key), dim=0).to("cuda")
+            values = self.pop(key, [])
+            tensors = torch.cat(values, dim=0).to("cuda") if values else torch.empty(0, device="cuda")
             assert tensors.ndim == 1, "Can only aggregate 1D tensors"
             tensors = flexible_all_gather(tensors)
             assert tensors.ndim == 1, "Can only aggregate 1D tensors"
@@ -378,60 +384,6 @@ class Tensors(defaultdict):
 
             # Add back all-gathered tensors to self
             self[key].append(tensors.tolist())
-
-        return metrics
-
-
-class GroupedTensors:
-    """Accumulate 1D tensors and compute distributed statistics grouped by string labels."""
-
-    def __init__(self):
-        assert dist.is_initialized(), "GroupedTensors requires a distributed environment"
-        self.data: dict[str, dict[str, list[Tensor]]] = defaultdict(lambda: defaultdict(list))
-
-    def append(self, key: str, tensors: Tensor, groups: list[str]) -> None:
-        tensors = tensors.flatten()
-        assert tensors.ndim == 1, "Can only aggregate 1D tensors"
-        assert tensors.numel() == len(groups), f"{key} has {tensors.numel()} values but {len(groups)} groups"
-
-        if tensors.numel() == 0:
-            return
-
-        cpu_tensors = tensors.detach().to("cpu")
-        self.data[key]["all"].append(cpu_tensors)
-        group_to_indices: dict[str, list[int]] = defaultdict(list)
-        for idx, group in enumerate(groups):
-            if group:
-                group_to_indices[group].append(idx)
-
-        for group, indices in group_to_indices.items():
-            self.data[key][group].append(cpu_tensors[indices])
-
-    def compute_stats(self) -> dict[str, float | int]:
-        local_pairs = [(key, group) for key, by_group in self.data.items() for group in by_group]
-        gathered_pairs: list[list[tuple[str, str]] | None] = [None] * dist.get_world_size()
-        dist.all_gather_object(gathered_pairs, local_pairs)
-
-        pairs = sorted({pair for rank_pairs in gathered_pairs if rank_pairs is not None for pair in rank_pairs})
-        metrics: dict[str, float | int] = {}
-
-        for key, group in pairs:
-            group_tensors = self.data.get(key, {}).get(group, [])
-            if group_tensors:
-                tensors = torch.cat(group_tensors, dim=0).to("cuda")
-            else:
-                tensors = torch.empty(0, device="cuda")
-
-            tensors = flexible_all_gather(tensors)
-            if tensors.numel() == 0:
-                metrics[f"{key}/{group}/mean"] = float("nan")
-                metrics[f"{key}/{group}/std"] = float("nan")
-                metrics[f"{key}/{group}/max"] = float("nan")
-                continue
-
-            metrics[f"{key}/{group}/mean"] = tensors.mean().item()
-            metrics[f"{key}/{group}/std"] = tensors.std().item()
-            metrics[f"{key}/{group}/max"] = tensors.max().item()
 
         return metrics
 

--- a/src/prime_rl/transport/types.py
+++ b/src/prime_rl/transport/types.py
@@ -27,7 +27,7 @@ class TrainingSample(msgspec.Struct, array_like=True, gc=False, omit_defaults=Tr
     mm_token_type_ids: list[int] | None = None
 
     sft_loss: bool = False  # When True, trainer uses SFT loss instead of RL loss for this sample
-    env_name: str | None = None
+    env_name: str = ""
 
 
 class TrainingBatch(msgspec.Struct, array_like=True, gc=False, omit_defaults=True):
@@ -61,4 +61,4 @@ class MicroBatch(msgspec.Struct, array_like=True, gc=False, omit_defaults=True):
     mm_token_type_ids: list[int] | None = None
 
     sft_loss: bool = False  # When True, trainer uses SFT loss instead of RL loss for this batch
-    env_names: list[str] | None = None
+    env_names: list[str] = msgspec.field(default_factory=list)

--- a/src/prime_rl/transport/types.py
+++ b/src/prime_rl/transport/types.py
@@ -11,6 +11,7 @@ class TrainingSample(msgspec.Struct, array_like=True, gc=False, omit_defaults=Tr
     completion_mask: list[bool]
     completion_logprobs: list[float]
     completion_temperatures: list[float]  # Per-token temperatures used during generation
+    env_name: str
     teacher_logprobs: list[float] | None = None
     advantage: float | None = None
     reward: float | None = None
@@ -27,7 +28,6 @@ class TrainingSample(msgspec.Struct, array_like=True, gc=False, omit_defaults=Tr
     mm_token_type_ids: list[int] | None = None
 
     sft_loss: bool = False  # When True, trainer uses SFT loss instead of RL loss for this sample
-    env_name: str = ""
 
 
 class TrainingBatch(msgspec.Struct, array_like=True, gc=False, omit_defaults=True):
@@ -48,6 +48,7 @@ class MicroBatch(msgspec.Struct, array_like=True, gc=False, omit_defaults=True):
     inference_logprobs: list[float]
     position_ids: list[int]
     temperatures: list[float]  # Per-token temperatures used during generation
+    env_names: list[str]
     teacher_logprobs: list[float] | None = None
     lora_num_tokens: list[int] | None = None
     routed_experts: list[list[list[int]]] | None = None
@@ -61,4 +62,3 @@ class MicroBatch(msgspec.Struct, array_like=True, gc=False, omit_defaults=True):
     mm_token_type_ids: list[int] | None = None
 
     sft_loss: bool = False  # When True, trainer uses SFT loss instead of RL loss for this batch
-    env_names: list[str] = msgspec.field(default_factory=list)

--- a/src/prime_rl/transport/types.py
+++ b/src/prime_rl/transport/types.py
@@ -27,6 +27,7 @@ class TrainingSample(msgspec.Struct, array_like=True, gc=False, omit_defaults=Tr
     mm_token_type_ids: list[int] | None = None
 
     sft_loss: bool = False  # When True, trainer uses SFT loss instead of RL loss for this sample
+    env_name: str | None = None
 
 
 class TrainingBatch(msgspec.Struct, array_like=True, gc=False, omit_defaults=True):
@@ -60,3 +61,4 @@ class MicroBatch(msgspec.Struct, array_like=True, gc=False, omit_defaults=True):
     mm_token_type_ids: list[int] | None = None
 
     sft_loss: bool = False  # When True, trainer uses SFT loss instead of RL loss for this batch
+    env_names: list[str] | None = None

--- a/tests/unit/orchestrator/test_batch.py
+++ b/tests/unit/orchestrator/test_batch.py
@@ -27,11 +27,17 @@ def make_training_example():
     return _make_training_example
 
 
-def test_prepare_sample_requires_env_name(make_training_example):
-    example = make_training_example(env_name="")
-
-    with pytest.raises(ValueError, match="env_name"):
-        prepare_sample(example, seq_len=16)
+def test_training_sample_requires_env_name():
+    with pytest.raises(TypeError, match="env_name"):
+        TrainingSample(
+            prompt_ids=[1, 2],
+            prompt_mask=[False, False],
+            completion_ids=[3, 4],
+            completion_mask=[True, True],
+            completion_logprobs=[-0.1, -0.2],
+            completion_temperatures=[1.0, 1.0],
+            advantage=1.0,
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/orchestrator/test_batch.py
+++ b/tests/unit/orchestrator/test_batch.py
@@ -9,7 +9,7 @@ def make_training_example():
     def _make_training_example(
         temperature: float = 1.0,
         sft_loss: bool = False,
-        env_name: str | None = None,
+        env_name: str = "test-env",
     ) -> TrainingSample:
         return TrainingSample(
             prompt_ids=[1, 2],
@@ -25,6 +25,13 @@ def make_training_example():
         )
 
     return _make_training_example
+
+
+def test_prepare_sample_requires_env_name(make_training_example):
+    example = make_training_example(env_name="")
+
+    with pytest.raises(ValueError, match="env_name"):
+        prepare_sample(example, seq_len=16)
 
 
 @pytest.mark.parametrize(
@@ -123,6 +130,7 @@ def test_prepare_sample_with_routed_experts():
         completion_logprobs=[-0.1, -0.2],
         completion_temperatures=[1.0, 1.0],
         advantage=1.0,
+        env_name="test-env",
         routed_experts=routed_experts,
     )
 
@@ -164,6 +172,7 @@ def test_prepare_sample_none_routed_experts():
         completion_logprobs=[-0.1, -0.2],
         completion_temperatures=[1.0, 1.0],
         advantage=1.0,
+        env_name="test-env",
     )
 
     micro_batch = prepare_sample(sample, seq_len=8)

--- a/tests/unit/orchestrator/test_batch.py
+++ b/tests/unit/orchestrator/test_batch.py
@@ -6,7 +6,11 @@ from prime_rl.transport.types import TrainingSample
 
 @pytest.fixture
 def make_training_example():
-    def _make_training_example(temperature: float = 1.0, sft_loss: bool = False) -> TrainingSample:
+    def _make_training_example(
+        temperature: float = 1.0,
+        sft_loss: bool = False,
+        env_name: str | None = None,
+    ) -> TrainingSample:
         return TrainingSample(
             prompt_ids=[1, 2],
             prompt_mask=[False, False],
@@ -16,6 +20,7 @@ def make_training_example():
             completion_temperatures=[temperature, temperature],  # Per-token temperatures
             teacher_logprobs=[0.0, 0.0, 0.0, 0.0],
             advantage=1.0,
+            env_name=env_name,
             sft_loss=sft_loss,
         )
 
@@ -58,8 +63,8 @@ def test_prepare_batch_balances_micro_batches_across_workers(
 
 def test_prepare_batch_packs_different_temperatures(make_training_example):
     """With per-token temperatures, samples can be packed together regardless of their temperature values."""
-    example1 = make_training_example(temperature=0.7)
-    example2 = make_training_example(temperature=1.1)
+    example1 = make_training_example(temperature=0.7, env_name="env-a")
+    example2 = make_training_example(temperature=1.1, env_name="env-b")
 
     batches_per_gpu = prepare_batch(
         rollouts=[example1, example2],
@@ -78,6 +83,7 @@ def test_prepare_batch_packs_different_temperatures(make_training_example):
     assert flat_batches[0].temperatures[:4] == [0.7, 0.7, 0.7, 0.7]
     # Second sample (4 tokens): all get temp 1.1
     assert flat_batches[0].temperatures[4:8] == [1.1, 1.1, 1.1, 1.1]
+    assert flat_batches[0].env_names == ["env-a"] * 4 + ["env-b"] * 4
 
 
 def test_prepare_sample_propagates_sft_loss(make_training_example):
@@ -137,6 +143,7 @@ def test_prepare_sample_truncates_routed_experts():
         completion_logprobs=[-0.1, -0.2],
         completion_temperatures=[1.0, 1.0],
         advantage=1.0,
+        env_name="test-env",
         routed_experts=routed_experts,
     )
 
@@ -144,6 +151,7 @@ def test_prepare_sample_truncates_routed_experts():
     assert micro_batch.routed_experts is not None
     assert len(micro_batch.routed_experts) == 3
     assert micro_batch.routed_experts == routed_experts[:3]
+    assert micro_batch.env_names == ["test-env"] * 3
 
 
 def test_prepare_sample_none_routed_experts():

--- a/tests/unit/orchestrator/test_sft_trajectories.py
+++ b/tests/unit/orchestrator/test_sft_trajectories.py
@@ -60,6 +60,7 @@ def test_pretokenize_rollout_trajectory_for_sft():
     tokenizer = SimpleChatTokenizer()
     output = vf.RolloutOutput(
         example_id=42,
+        env_name="test-env",
         trajectory=[
             vf.TrajectoryStep(
                 prompt=[{"role": "user", "content": "U1"}],

--- a/tests/unit/orchestrator/test_teacher_logprobs.py
+++ b/tests/unit/orchestrator/test_teacher_logprobs.py
@@ -50,6 +50,7 @@ def test_compute_teacher_logprobs_uses_inference_generate(monkeypatch):
             completion_mask=[True, True],
             completion_logprobs=[-0.1, -0.2],
             completion_temperatures=[1.0, 1.0],
+            env_name="test-env",
         )
 
         result = await orchestrator_utils.compute_teacher_logprobs(

--- a/tests/unit/orchestrator/test_trajectories.py
+++ b/tests/unit/orchestrator/test_trajectories.py
@@ -18,6 +18,13 @@ from prime_rl.orchestrator.trajectories import (
     interleave_rollout,
 )
 
+_interleave_rollout = interleave_rollout
+
+
+def interleave_rollout(output, *args, **kwargs):
+    output.setdefault("env_name", "test-env")
+    return _interleave_rollout(output, *args, **kwargs)
+
 
 def _pixels(data: list[list[float]]) -> tuple[bytes, list[int]]:
     """Convert pixel values list to (bytes, shape) for test cache data."""

--- a/tests/unit/orchestrator/test_trajectories.py
+++ b/tests/unit/orchestrator/test_trajectories.py
@@ -372,6 +372,7 @@ def test_branching_equivalent_multi_step_trajectory_with_tool_calls(
 
 
 def test_interleave_rollout_single_step_trajectory(single_step_trajectory_output):
+    single_step_trajectory_output["env_name"] = "test-env"
     rollouts = interleave_rollout(single_step_trajectory_output)
     assert rollouts is not None
     assert len(rollouts) == 1
@@ -383,6 +384,7 @@ def test_interleave_rollout_single_step_trajectory(single_step_trajectory_output
     assert rollout.completion_mask == [True, True]
     assert rollout.completion_logprobs == [-0.1, -0.2]
     assert rollout.completion_temperatures == [1.0, 1.0]
+    assert rollout.env_name == "test-env"
 
 
 def test_interleave_rollout_multi_step_trajectory(multi_step_trajectory_output):

--- a/tests/unit/train/models/test_nemotron_h_kl.py
+++ b/tests/unit/train/models/test_nemotron_h_kl.py
@@ -105,8 +105,8 @@ def test_kl_zero_when_identical():
         )
         result = default_loss_fn(inputs, DefaultLossConfig())
 
-        assert result.metrics["mismatch_kl"].item() == pytest.approx(0.0, abs=1e-6), (
-            f"Expected zero KL for identical models, got {result.metrics['mismatch_kl'].item()}"
+        assert result.metrics["unmasked_mismatch_kl"].item() == pytest.approx(0.0, abs=1e-6), (
+            f"Expected zero KL for identical models, got {result.metrics['unmasked_mismatch_kl'].item()}"
         )
 
 
@@ -138,7 +138,7 @@ def test_kl_positive_after_perturbation():
             loss_mask=loss_mask,
         )
         result = default_loss_fn(inputs, DefaultLossConfig())
-        kl = result.metrics["mismatch_kl"].item()
+        kl = result.metrics["unmasked_mismatch_kl"].item()
 
         assert kl > 0, f"Expected positive KL after perturbation, got {kl}"
         assert kl < 100, f"KL unexpectedly large: {kl}"

--- a/tests/unit/train/rl/test_packer.py
+++ b/tests/unit/train/rl/test_packer.py
@@ -46,6 +46,7 @@ def make_training_sample() -> TrainingSample:
         completion_mask=[True],
         completion_logprobs=[-0.1],
         completion_temperatures=[1.0],
+        env_name="test-env",
     )
 
 


### PR DESCRIPTION
## Summary

Adds environment metadata to the orchestrator-to-trainer batch path so trainer-side token metrics can be broken down by environment in W&B.

- Carries required `env_name` on `TrainingSample` and expands it into required per-token `env_names` on `MicroBatch`.
- Validates per-token env-name length when loading micro-batches into trainer tensors, then keeps the training loop non-defensive.
- Reuses the existing `Tensors` accumulator for grouped trainer token stats, logging per-env `entropy` and `mismatch_kl` as `{metric}/{env}/{mean,std,max}` while preserving existing aggregate metrics like `entropy/mean`.
- Makes `Tensors.compute_stats()` robust to sparse dynamic keys across ranks, so per-env keys cannot desynchronize distributed collectives.
- Computes importance-ratio/mismatch-KL once per microbatch, passes those tensors through the loss path and per-env logging, derives the DPPO probability delta from the shared ratio, and reuses the already-copied entropy tensor for env splits.
- Updates focused tests plus the monitoring skill docs.

## Validation

- `uv run pytest tests/unit/orchestrator/test_batch.py tests/unit/orchestrator/test_teacher_logprobs.py tests/unit/orchestrator/test_sft_trajectories.py tests/unit/orchestrator/test_trajectories.py tests/unit/train/rl/test_packer.py`
- `PYTEST_OUTPUT_DIR=/tmp/outputs uv run pytest $(git ls-files 'tests/unit/**/test_*.py' 'tests/unit/test_*.py') -m "not gpu"` (`344 passed, 65 deselected`)
- `uv run pytest tests/unit/train/rl/test_loss.py -m gpu` (`6 passed`)
- `uv run ruff check src/prime_rl/trainer/rl/loss.py src/prime_rl/trainer/rl/train.py`
- `uv run ruff format --check src/prime_rl/trainer/rl/loss.py src/prime_rl/trainer/rl/train.py`
- Reverse-text W&B smoke run: trainer https://wandb.ai/primeintellect/reverse-text/runs/07xfclyq, orchestrator https://wandb.ai/primeintellect/reverse-text/runs/ytp92whl

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the orchestrator→trainer transport schema and distributed metric aggregation to carry per-token environment names and log per-env trainer stats; mistakes here could break batch serialization or desynchronize multi-rank metric collectives.
> 
> **Overview**
> Adds environment metadata to the training data path so trainer-side token metrics can be reported *per environment*.
> 
> `TrainingSample` now requires `env_name`, which is propagated through the orchestrator and expanded into per-token `env_names` on `MicroBatch` (including packing/truncation/padding validation). The trainer loop then splits token-level `entropy` and `mismatch_kl` by env and logs keys as `entropy/{all,env}/...` and `mismatch_kl/{all,env}/...`.
> 
> Makes `Tensors.compute_stats()` robust to dynamic/sparse metric keys across distributed ranks (gather keys first, handle empty tensors), updates W&B metric filtering to allow env-scoped stats, factors mismatch-KL computation into `compute_importance_ratio_and_mismatch_kl`, and updates tests plus monitoring docs to reflect the new metric keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09c793065514890bd846a5cdc7f99e8aa801d1cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->