### PR TITLE
[codex] add Poolside Laguna custom model

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ With `[model] impl = "auto"` (the default), the trainer selects that custom stac
 | Qwen3 MoE (`qwen3_moe`) | `Qwen/Qwen3-30B-A3B`, … | yes | ✅ | ✅ |
 | Qwen3.5 MoE (`qwen3_5_moe`) | `Qwen/Qwen3.5-35B-A3B`, … | yes | ✅ | ✅ |
 | Qwen3 / Qwen3.5 VLMs | [multimodal.md](docs/multimodal.md) (`qwen3_vl`, `qwen3_5`, `qwen3_5_moe`) | MoE only on MoE VLMs | MoE only | ✅ |
+| Poolside Laguna (`laguna`) | `poolside/Laguna-XS.2` | yes | ✅ | ✅ |
 | MiniMax M2 (`minimax_m2`) | `MiniMax/MiniMax-M2` | yes | ✅ | ✅ |
 | Nemotron H (`nemotron_h`) | `nvidia/Nemotron-3-Nano-30B-A3B`, `nvidia/Nemotron-3-Super-120B-A12B`, … | yes | ✅ | ❌ |
 | Trinity (`afmoe`) | `arcee-ai/Trinity-Mini`, … | yes | ✅ | ✅ |

--- a/scripts/mini_moe.py
+++ b/scripts/mini_moe.py
@@ -23,6 +23,8 @@ from transformers.models.qwen3_5_moe.modeling_qwen3_5_moe import (
 
 from prime_rl.trainer.models.glm4_moe import Glm4MoeConfig
 from prime_rl.trainer.models.glm4_moe import Glm4MoeForCausalLM as PrimeRLGlm4MoeForCausalLM
+from prime_rl.trainer.models.laguna import LagunaConfig
+from prime_rl.trainer.models.laguna import LagunaForCausalLM as PrimeRLLagunaForCausalLM
 from prime_rl.trainer.models.layers.lm_head import inject_prime_lm_head
 from prime_rl.trainer.models.minimax_m2 import MiniMaxM2Config
 from prime_rl.trainer.models.minimax_m2 import MiniMaxM2ForCausalLM as PrimeRLMiniMaxM2ForCausalLM
@@ -129,6 +131,59 @@ ARCH_PRESETS = {
         "hf_model_class": None,  # uses AutoModelForCausalLM with trust_remote_code
         "prime_model_class": PrimeRLMiniMaxM2ForCausalLM,
         "tokenizer_source": "MiniMaxAI/MiniMax-M2.1",
+    },
+    "laguna": {
+        "config_class": LagunaConfig,
+        "config_kwargs": dict(
+            vocab_size=100352,
+            hidden_size=512,
+            intermediate_size=2048,
+            num_hidden_layers=12,
+            num_attention_heads=8,
+            num_attention_heads_per_layer=[8] * 12,
+            num_key_value_heads=4,
+            head_dim=64,
+            hidden_act="silu",
+            max_position_embeddings=4096,
+            rms_norm_eps=1e-6,
+            rope_parameters={
+                "full_attention": {
+                    "rope_type": "yarn",
+                    "rope_theta": 500000.0,
+                    "factor": 4.0,
+                    "original_max_position_embeddings": 1024,
+                    "beta_slow": 1.0,
+                    "beta_fast": 64.0,
+                    "attention_factor": 1.0,
+                    "partial_rotary_factor": 0.5,
+                },
+                "sliding_attention": {
+                    "rope_type": "default",
+                    "rope_theta": 10000.0,
+                    "partial_rotary_factor": 1.0,
+                },
+            },
+            layer_types=["full_attention", "sliding_attention", "sliding_attention", "sliding_attention"] * 3,
+            sliding_window=512,
+            moe_intermediate_size=128,
+            shared_expert_intermediate_size=128,
+            num_experts=8,
+            num_experts_per_tok=4,
+            mlp_layer_types=["dense"] + ["sparse"] * 11,
+            moe_routed_scaling_factor=2.5,
+            use_grouped_mm=False,
+            pad_token_id=9,
+            bos_token_id=2,
+            eos_token_id=[2, 24],
+            auto_map={
+                "AutoConfig": "poolside/Laguna-XS.2--configuration_laguna.LagunaConfig",
+                "AutoModel": "poolside/Laguna-XS.2--modeling_laguna.LagunaModel",
+                "AutoModelForCausalLM": "poolside/Laguna-XS.2--modeling_laguna.LagunaForCausalLM",
+            },
+        ),
+        "hf_model_class": None,  # uses Poolside remote modeling code
+        "prime_model_class": PrimeRLLagunaForCausalLM,
+        "tokenizer_source": "poolside/Laguna-XS.2",
     },
     "qwen3_5_moe_vlm": {
         "config_fn": _qwen3_5_moe_vlm_config,

--- a/src/prime_rl/trainer/models/__init__.py
+++ b/src/prime_rl/trainer/models/__init__.py
@@ -13,6 +13,7 @@ from prime_rl.trainer.models.base import PreTrainedModelPrimeRL
 from prime_rl.trainer.models.glm4_moe import Glm4MoeConfig, Glm4MoeForCausalLM
 from prime_rl.trainer.models.glm_moe_dsa import GlmMoeDsaConfig, GlmMoeDsaForCausalLM
 from prime_rl.trainer.models.gpt_oss import GptOssConfig, GptOssForCausalLM
+from prime_rl.trainer.models.laguna import LagunaConfig, LagunaForCausalLM
 from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput, cast_float_and_contiguous
 from prime_rl.trainer.models.llama import LlamaForCausalLM
 from prime_rl.trainer.models.minimax_m2 import MiniMaxM2Config, MiniMaxM2ForCausalLM
@@ -24,6 +25,7 @@ from prime_rl.trainer.models.qwen3_moe import Qwen3MoeConfig, Qwen3MoeForCausalL
 AutoConfig.register("afmoe", AfmoeConfig, exist_ok=True)
 AutoConfig.register("glm4_moe", Glm4MoeConfig, exist_ok=True)
 AutoConfig.register("glm_moe_dsa", GlmMoeDsaConfig, exist_ok=True)
+AutoConfig.register("laguna", LagunaConfig, exist_ok=True)
 AutoConfig.register("minimax_m2", MiniMaxM2Config, exist_ok=True)
 AutoConfig.register("nemotron_h", NemotronHConfig, exist_ok=True)
 AutoConfig.register("qwen3_moe", Qwen3MoeConfig, exist_ok=True)
@@ -35,6 +37,7 @@ _CUSTOM_CAUSAL_LM_MAPPING.register(LlamaConfig, LlamaForCausalLM, exist_ok=True)
 _CUSTOM_CAUSAL_LM_MAPPING.register(AfmoeConfig, AfmoeForCausalLM, exist_ok=True)
 _CUSTOM_CAUSAL_LM_MAPPING.register(Glm4MoeConfig, Glm4MoeForCausalLM, exist_ok=True)
 _CUSTOM_CAUSAL_LM_MAPPING.register(GlmMoeDsaConfig, GlmMoeDsaForCausalLM, exist_ok=True)
+_CUSTOM_CAUSAL_LM_MAPPING.register(LagunaConfig, LagunaForCausalLM, exist_ok=True)
 _CUSTOM_CAUSAL_LM_MAPPING.register(MiniMaxM2Config, MiniMaxM2ForCausalLM, exist_ok=True)
 _CUSTOM_CAUSAL_LM_MAPPING.register(NemotronHConfig, NemotronHForCausalLM, exist_ok=True)
 _CUSTOM_CAUSAL_LM_MAPPING.register(Qwen3MoeConfig, Qwen3MoeForCausalLM, exist_ok=True)

--- a/src/prime_rl/trainer/models/laguna/__init__.py
+++ b/src/prime_rl/trainer/models/laguna/__init__.py
@@ -1,0 +1,13 @@
+from prime_rl.trainer.models.laguna.configuration_laguna import LagunaConfig
+from prime_rl.trainer.models.laguna.modeling_laguna import (
+    LagunaForCausalLM,
+    LagunaModel,
+    LagunaPreTrainedModel,
+)
+
+__all__ = [
+    "LagunaConfig",
+    "LagunaForCausalLM",
+    "LagunaModel",
+    "LagunaPreTrainedModel",
+]

--- a/src/prime_rl/trainer/models/laguna/configuration_laguna.py
+++ b/src/prime_rl/trainer/models/laguna/configuration_laguna.py
@@ -1,0 +1,190 @@
+from typing import Any, Literal
+
+from transformers.configuration_utils import PretrainedConfig
+
+
+class LagunaConfig(PretrainedConfig):
+    """Configuration for Poolside Laguna MoE models."""
+
+    model_type = "laguna"
+    keys_to_ignore_at_inference = ["past_key_values"]
+    attribute_map = {"num_local_experts": "num_experts"}
+
+    base_model_tp_plan = {
+        "layers.*.self_attn.q_proj": "colwise",
+        "layers.*.self_attn.k_proj": "colwise",
+        "layers.*.self_attn.v_proj": "colwise",
+        "layers.*.self_attn.g_proj": "colwise",
+        "layers.*.self_attn.o_proj": "rowwise",
+        "layers.*.self_attn.q_norm": "replicated_with_grad_allreduce",
+        "layers.*.self_attn.k_norm": "replicated_with_grad_allreduce",
+        "layers.*.mlp.gate_proj": "colwise",
+        "layers.*.mlp.up_proj": "colwise",
+        "layers.*.mlp.down_proj": "rowwise",
+        "layers.*.mlp.experts.gate_up_proj": "packed_colwise",
+        "layers.*.mlp.experts.down_proj": "rowwise",
+        "layers.*.mlp.experts": "moe_tp_experts",
+        "layers.*.shared_expert.w1": "colwise",
+        "layers.*.shared_expert.w2": "rowwise",
+        "layers.*.shared_expert.w3": "colwise",
+    }
+    base_model_pp_plan = {
+        "embed_tokens": (["input_ids"], ["inputs_embeds"]),
+        "layers": (["hidden_states", "attention_mask"], ["hidden_states"]),
+        "norm": (["hidden_states"], ["hidden_states"]),
+    }
+
+    def __init__(
+        self,
+        vocab_size: int = 100352,
+        hidden_size: int = 2048,
+        intermediate_size: int = 8192,
+        num_hidden_layers: int = 40,
+        num_attention_heads: int = 48,
+        num_key_value_heads: int = 8,
+        hidden_act: str = "silu",
+        max_position_embeddings: int = 131072,
+        initializer_range: float = 0.02,
+        rms_norm_eps: float = 1e-6,
+        use_cache: bool = True,
+        tie_word_embeddings: bool = False,
+        rope_parameters: dict[str, Any] | None = None,
+        rope_scaling: dict[str, Any] | None = None,
+        sliding_window: int | None = 512,
+        attention_dropout: float = 0.0,
+        moe_intermediate_size: int = 512,
+        shared_expert_intermediate_size: int = 512,
+        num_experts_per_tok: int = 8,
+        num_experts: int = 256,
+        output_router_logits: bool = False,
+        router_aux_loss_coef: float = 0.001,
+        layer_types: list[str] | None = None,
+        pad_token_id: int | None = None,
+        bos_token_id: int | None = None,
+        eos_token_id: int | list[int] | None = None,
+        head_dim: int = 128,
+        attention_bias: bool = False,
+        partial_rotary_factor: float | None = None,
+        num_attention_heads_per_layer: list[int] | None = None,
+        mlp_layer_types: list[str] | None = None,
+        moe_routed_scaling_factor: float = 1.0,
+        moe_apply_router_weight_on_input: bool = False,
+        moe_router_logit_softcapping: float = 0.0,
+        load_balance_coeff: float | None = 1e-3,
+        use_grouped_mm: bool = True,
+        **kwargs,
+    ):
+        raw_rope_parameters = rope_parameters if rope_parameters is not None else rope_scaling
+
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_key_value_heads = num_key_value_heads
+        self.hidden_act = hidden_act
+        self.max_position_embeddings = max_position_embeddings
+        self.initializer_range = initializer_range
+        self.rms_norm_eps = rms_norm_eps
+        self.use_cache = use_cache
+        self.sliding_window = sliding_window
+        self.attention_dropout = attention_dropout
+        self.moe_intermediate_size = moe_intermediate_size
+        self.shared_expert_intermediate_size = shared_expert_intermediate_size
+        self.num_experts_per_tok = num_experts_per_tok
+        self.num_experts = num_experts
+        self.output_router_logits = output_router_logits
+        self.router_aux_loss_coef = router_aux_loss_coef
+        self.layer_types = layer_types or ["full_attention"] * num_hidden_layers
+        self.head_dim = head_dim
+        self.attention_bias = attention_bias
+        self.partial_rotary_factor = partial_rotary_factor
+        self.num_attention_heads_per_layer = num_attention_heads_per_layer or [num_attention_heads] * num_hidden_layers
+        self.mlp_layer_types = mlp_layer_types or ["dense"] + ["sparse"] * (num_hidden_layers - 1)
+        self.moe_routed_scaling_factor = moe_routed_scaling_factor
+        self.moe_apply_router_weight_on_input = moe_apply_router_weight_on_input
+        self.moe_router_logit_softcapping = moe_router_logit_softcapping
+        self.load_balance_coeff = load_balance_coeff
+        self.use_grouped_mm = use_grouped_mm
+
+        super().__init__(
+            pad_token_id=pad_token_id,
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            tie_word_embeddings=tie_word_embeddings,
+            **kwargs,
+        )
+
+        self.rope_parameters = raw_rope_parameters
+        self._normalize_rope_parameters()
+        self.rope_scaling = self.rope_parameters
+        self.validate_architecture()
+
+    def _normalize_rope_parameters(self) -> None:
+        default_rope_params: dict[Literal["full_attention", "sliding_attention"], dict[str, Any]] = {
+            "full_attention": {"rope_type": "default", "rope_theta": 500000.0},
+            "sliding_attention": {"rope_type": "default", "rope_theta": 10000.0},
+        }
+        layer_types = set(self.layer_types)
+        rope_params = self.rope_parameters or {}
+        is_nested = isinstance(rope_params, dict) and any(key in layer_types for key in rope_params)
+        if is_nested:
+            nested = {}
+            for layer_type in layer_types:
+                params = dict(default_rope_params.get(layer_type, {}))
+                params.update(rope_params.get(layer_type, {}))
+                nested[layer_type] = params
+        else:
+            nested = {}
+            for layer_type in layer_types:
+                params = dict(default_rope_params.get(layer_type, {}))
+                params.update(rope_params)
+                nested[layer_type] = params
+
+        if self.partial_rotary_factor is not None:
+            for params in nested.values():
+                params.setdefault("partial_rotary_factor", self.partial_rotary_factor)
+
+        for params in nested.values():
+            params.setdefault("rope_type", "default")
+
+        self.rope_parameters = nested
+        self.partial_rotary_factor = None
+
+    def convert_rope_params_to_dict(self, **kwargs):
+        return kwargs
+
+    def _validate_yarn_rope_parameters(self, rope_parameters: dict, ignore_keys=None) -> None:
+        flat_rope_parameters = self.rope_parameters
+        self.rope_parameters = rope_parameters
+        try:
+            super()._validate_yarn_rope_parameters(rope_parameters, ignore_keys=ignore_keys)
+        finally:
+            self.rope_parameters = flat_rope_parameters
+
+    def validate_architecture(self) -> None:
+        if self.moe_apply_router_weight_on_input:
+            raise NotImplementedError("moe_apply_router_weight_on_input=True is not supported by PrimeRL Laguna.")
+        if len(self.num_attention_heads_per_layer) != self.num_hidden_layers:
+            raise ValueError(
+                f"num_attention_heads_per_layer length ({len(self.num_attention_heads_per_layer)}) "
+                f"must equal num_hidden_layers ({self.num_hidden_layers})."
+            )
+        for num_heads in self.num_attention_heads_per_layer:
+            if num_heads % self.num_key_value_heads != 0:
+                raise ValueError(
+                    f"Per-layer attention head count ({num_heads}) must be divisible by "
+                    f"num_key_value_heads ({self.num_key_value_heads})."
+                )
+        if len(self.layer_types) != self.num_hidden_layers:
+            raise ValueError(
+                f"layer_types length ({len(self.layer_types)}) must equal num_hidden_layers ({self.num_hidden_layers})."
+            )
+        if len(self.mlp_layer_types) != self.num_hidden_layers:
+            raise ValueError(
+                f"mlp_layer_types length ({len(self.mlp_layer_types)}) "
+                f"must equal num_hidden_layers ({self.num_hidden_layers})."
+            )
+
+
+__all__ = ["LagunaConfig"]

--- a/src/prime_rl/trainer/models/laguna/converting_laguna.py
+++ b/src/prime_rl/trainer/models/laguna/converting_laguna.py
@@ -1,0 +1,120 @@
+import torch
+from torch import Tensor
+
+
+def get_max_layer_num(state_dict: dict[str, Tensor]) -> int:
+    return max(int(key.split(".")[2]) for key in state_dict if key.startswith("model.layers.")) + 1
+
+
+def _pop_first(state_dict: dict[str, Tensor], keys: tuple[str, ...]) -> Tensor | None:
+    for key in keys:
+        if key in state_dict:
+            return state_dict.pop(key)
+    return None
+
+
+def convert_hf_layer_to_prime(state_dict: dict[str, Tensor], layer_idx: int) -> None:
+    prefix = f"model.layers.{layer_idx}"
+    gate_key = f"{prefix}.mlp.gate.weight"
+    if gate_key not in state_dict:
+        return
+
+    state_dict[f"{prefix}.mlp.router.gate.weight"] = state_dict.pop(gate_key)
+
+    expert_bias = _pop_first(
+        state_dict,
+        (
+            f"{prefix}.mlp.experts.e_score_correction_bias",
+            f"{prefix}.mlp.gate.e_score_correction_bias",
+        ),
+    )
+    if expert_bias is not None:
+        state_dict[f"{prefix}.mlp.expert_bias"] = expert_bias
+
+    fused_key = f"{prefix}.mlp.experts.gate_up_proj"
+    if fused_key in state_dict:
+        gate_up_proj = state_dict.pop(fused_key)
+        down_proj = state_dict.pop(f"{prefix}.mlp.experts.down_proj")
+        moe_dim = gate_up_proj.shape[1] // 2
+        w1 = gate_up_proj[:, :moe_dim, :]
+        w3 = gate_up_proj[:, moe_dim:, :]
+        w2 = down_proj
+    else:
+        expert_ids = sorted(
+            int(key[len(f"{prefix}.mlp.experts.") :].split(".")[0])
+            for key in state_dict
+            if key.startswith(f"{prefix}.mlp.experts.") and key.endswith(".gate_proj.weight")
+        )
+        if not expert_ids:
+            return
+
+        first_down = state_dict[f"{prefix}.mlp.experts.{expert_ids[0]}.down_proj.weight"]
+        dim, moe_dim = first_down.shape
+        w1 = torch.empty((len(expert_ids), moe_dim, dim), dtype=first_down.dtype, device=first_down.device)
+        w2 = torch.empty((len(expert_ids), dim, moe_dim), dtype=first_down.dtype, device=first_down.device)
+        w3 = torch.empty((len(expert_ids), moe_dim, dim), dtype=first_down.dtype, device=first_down.device)
+        for out_idx, expert_idx in enumerate(expert_ids):
+            w1[out_idx].copy_(state_dict.pop(f"{prefix}.mlp.experts.{expert_idx}.gate_proj.weight"))
+            w2[out_idx].copy_(state_dict.pop(f"{prefix}.mlp.experts.{expert_idx}.down_proj.weight"))
+            w3[out_idx].copy_(state_dict.pop(f"{prefix}.mlp.experts.{expert_idx}.up_proj.weight"))
+
+    state_dict[f"{prefix}.mlp.experts.w1"] = w1
+    state_dict[f"{prefix}.mlp.experts.w2"] = w2
+    state_dict[f"{prefix}.mlp.experts.w3"] = w3
+
+    shared_prefix = None
+    for candidate in (f"{prefix}.mlp.shared_expert", f"{prefix}.mlp.shared_experts"):
+        if f"{candidate}.gate_proj.weight" in state_dict:
+            shared_prefix = candidate
+            break
+
+    if shared_prefix is not None:
+        state_dict[f"{prefix}.shared_expert.w1.weight"] = state_dict.pop(f"{shared_prefix}.gate_proj.weight")
+        state_dict[f"{prefix}.shared_expert.w2.weight"] = state_dict.pop(f"{shared_prefix}.down_proj.weight")
+        state_dict[f"{prefix}.shared_expert.w3.weight"] = state_dict.pop(f"{shared_prefix}.up_proj.weight")
+
+
+def convert_prime_layer_to_hf(state_dict: dict[str, Tensor], layer_idx: int) -> None:
+    prefix = f"model.layers.{layer_idx}"
+    router_key = f"{prefix}.mlp.router.gate.weight"
+    if router_key not in state_dict:
+        return
+
+    if f"{prefix}.mlp.tokens_per_expert" in state_dict:
+        del state_dict[f"{prefix}.mlp.tokens_per_expert"]
+    if f"{prefix}.mlp.expert_bias" in state_dict:
+        state_dict[f"{prefix}.mlp.experts.e_score_correction_bias"] = state_dict.pop(f"{prefix}.mlp.expert_bias")
+
+    state_dict[f"{prefix}.mlp.gate.weight"] = state_dict.pop(router_key)
+
+    w1 = state_dict.pop(f"{prefix}.mlp.experts.w1")
+    w2 = state_dict.pop(f"{prefix}.mlp.experts.w2")
+    w3 = state_dict.pop(f"{prefix}.mlp.experts.w3")
+    for expert_idx in range(w1.shape[0]):
+        state_dict[f"{prefix}.mlp.experts.{expert_idx}.gate_proj.weight"] = w1[expert_idx]
+        state_dict[f"{prefix}.mlp.experts.{expert_idx}.down_proj.weight"] = w2[expert_idx]
+        state_dict[f"{prefix}.mlp.experts.{expert_idx}.up_proj.weight"] = w3[expert_idx]
+
+    shared_key = f"{prefix}.shared_expert.w1.weight"
+    if shared_key in state_dict:
+        state_dict[f"{prefix}.mlp.shared_expert.gate_proj.weight"] = state_dict.pop(shared_key)
+        state_dict[f"{prefix}.mlp.shared_expert.down_proj.weight"] = state_dict.pop(f"{prefix}.shared_expert.w2.weight")
+        state_dict[f"{prefix}.mlp.shared_expert.up_proj.weight"] = state_dict.pop(f"{prefix}.shared_expert.w3.weight")
+
+
+def convert_hf_to_prime(state_dict: dict[str, Tensor]) -> None:
+    for layer_idx in range(get_max_layer_num(state_dict)):
+        convert_hf_layer_to_prime(state_dict, layer_idx)
+
+
+def convert_prime_to_hf(state_dict: dict[str, Tensor]) -> None:
+    for layer_idx in range(get_max_layer_num(state_dict)):
+        convert_prime_layer_to_hf(state_dict, layer_idx)
+
+
+__all__ = [
+    "convert_hf_layer_to_prime",
+    "convert_hf_to_prime",
+    "convert_prime_layer_to_hf",
+    "convert_prime_to_hf",
+]

--- a/src/prime_rl/trainer/models/laguna/modeling_laguna.py
+++ b/src/prime_rl/trainer/models/laguna/modeling_laguna.py
@@ -1,0 +1,482 @@
+from collections.abc import Callable
+from typing import Optional, Union
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor, nn
+from transformers.cache_utils import Cache
+from transformers.generation import GenerationMixin
+from transformers.masking_utils import create_causal_mask, create_sliding_window_causal_mask
+from transformers.modeling_layers import GradientCheckpointingLayer
+from transformers.modeling_outputs import MoeModelOutputWithPast
+from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
+from transformers.processing_utils import Unpack
+from transformers.utils import TransformersKwargs, can_return_tuple
+from transformers.utils.generic import maybe_autocast
+
+from prime_rl.trainer.models.base import PreTrainedModelPrimeRL
+from prime_rl.trainer.models.laguna.configuration_laguna import LagunaConfig
+from prime_rl.trainer.models.laguna.converting_laguna import (
+    convert_hf_layer_to_prime,
+    convert_hf_to_prime,
+    convert_prime_layer_to_hf,
+    convert_prime_to_hf,
+)
+from prime_rl.trainer.models.layers.attn import AttentionConfig, FlashAttention, SDPAAttention
+from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput
+from prime_rl.trainer.models.layers.mlp import MLP, MLPConfig
+from prime_rl.trainer.models.layers.moe import FeedForward, MoE, MoEArgs
+from prime_rl.trainer.models.layers.norms import RMSNorm, RMSNormConfig
+from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
+
+
+class LagunaRotaryEmbedding(nn.Module):
+    def __init__(self, config: LagunaConfig, device=None):
+        super().__init__()
+        self.max_seq_len_cached = config.max_position_embeddings
+        self.original_max_seq_len = config.max_position_embeddings
+        self.config = config
+        self.layer_types = list(dict.fromkeys(config.layer_types))
+        self.rope_type = {}
+
+        for layer_type in self.layer_types:
+            rope_params = self.config.rope_parameters[layer_type]
+            self.rope_type[layer_type] = rope_params["rope_type"]
+            rope_init_fn: Callable = self.compute_default_rope_parameters
+            if self.rope_type[layer_type] != "default":
+                rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type[layer_type]]
+            inv_freq, attention_scaling = rope_init_fn(self.config, device, layer_type=layer_type)
+            self.register_buffer(f"{layer_type}_inv_freq", inv_freq, persistent=False)
+            self.register_buffer(f"{layer_type}_original_inv_freq", inv_freq.clone(), persistent=False)
+            setattr(self, f"{layer_type}_attention_scaling", attention_scaling)
+
+    @staticmethod
+    def compute_default_rope_parameters(
+        config: LagunaConfig | None = None,
+        device: Optional[torch.device] = None,
+        seq_len: int | None = None,
+        layer_type: str | None = None,
+    ) -> tuple[torch.Tensor, float]:
+        rope_params = config.rope_parameters[layer_type]
+        base = rope_params["rope_theta"]
+        partial_rotary_factor = rope_params.get("partial_rotary_factor", 1.0)
+        head_dim = getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads
+        dim = int(head_dim * partial_rotary_factor)
+        inv_freq = 1.0 / (
+            base ** (torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float) / dim)
+        )
+        return inv_freq, 1.0
+
+    @torch.no_grad()
+    @dynamic_rope_update
+    def forward(
+        self,
+        x: torch.Tensor,
+        position_ids: torch.LongTensor,
+        layer_type: str,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        inv_freq = getattr(self, f"{layer_type}_inv_freq")
+        attention_scaling = getattr(self, f"{layer_type}_attention_scaling")
+        inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+        position_ids_expanded = position_ids[:, None, :].float()
+
+        device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+        with maybe_autocast(device_type=device_type, enabled=False):
+            freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
+            emb = torch.cat((freqs, freqs), dim=-1)
+            cos = emb.cos() * attention_scaling
+            sin = emb.sin() * attention_scaling
+        return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
+
+
+def _laguna_attention_config(config: LagunaConfig, num_heads: int) -> AttentionConfig:
+    return AttentionConfig(
+        hidden_size=config.hidden_size,
+        head_dim=config.head_dim,
+        num_attention_heads=num_heads,
+        num_key_value_heads=config.num_key_value_heads,
+        is_causal=True,
+        attention_bias=config.attention_bias,
+        use_qk_norm=True,
+        rms_norm_eps=config.rms_norm_eps,
+        qk_norm_type="per_head",
+    )
+
+
+class LagunaFlashAttention(FlashAttention):
+    def __init__(self, config: LagunaConfig, layer_idx: int, num_heads: int, flash_attn_version: int = 2):
+        super().__init__(_laguna_attention_config(config, num_heads), flash_attn_version=flash_attn_version)
+        self.num_heads = num_heads
+        self.config = config
+        self.layer_idx = layer_idx
+        self.attention_dropout = config.attention_dropout
+        self.is_local_attention = config.layer_types[layer_idx] == "sliding_attention"
+        self.sliding_window = config.sliding_window if self.is_local_attention else None
+        self.g_proj = nn.Linear(config.hidden_size, num_heads, bias=False)
+        self.o_proj = nn.Linear(num_heads * self.head_dim, config.hidden_size, bias=config.attention_bias)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
+        attention_mask: torch.Tensor | None = None,
+        cu_seqlens: torch.LongTensor | None = None,
+        max_seqlen: int | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        query_states, key_states, value_states = self.attn_projections(hidden_states, position_embeddings)
+        attn_output = self._attention_core(
+            query_states,
+            key_states,
+            value_states,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+        )
+        input_shape = hidden_states.shape[:-1]
+        attn_output = attn_output.view(*input_shape, self.num_heads, self.head_dim)
+        gate = F.softplus(self.g_proj(hidden_states).float()).to(attn_output.dtype)
+        attn_output = (attn_output * gate.unsqueeze(-1)).view(*input_shape, -1)
+        return self.o_proj(attn_output), None
+
+
+class LagunaSDPAAttention(SDPAAttention):
+    def __init__(self, config: LagunaConfig, layer_idx: int, num_heads: int):
+        super().__init__(_laguna_attention_config(config, num_heads))
+        self.num_heads = num_heads
+        self.config = config
+        self.layer_idx = layer_idx
+        self.attention_dropout = config.attention_dropout
+        self.is_local_attention = config.layer_types[layer_idx] == "sliding_attention"
+        self.sliding_window = config.sliding_window if self.is_local_attention else None
+        self.g_proj = nn.Linear(config.hidden_size, num_heads, bias=False)
+        self.o_proj = nn.Linear(num_heads * self.head_dim, config.hidden_size, bias=config.attention_bias)
+
+    def _attention_core(
+        self,
+        query_states: torch.Tensor,
+        key_states: torch.Tensor,
+        value_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        key_states = key_states.repeat_interleave(self.num_key_value_groups, dim=1)
+        value_states = value_states.repeat_interleave(self.num_key_value_groups, dim=1)
+        dropout_p = 0.0 if not self.training else self.attention_dropout
+        out = F.scaled_dot_product_attention(
+            query_states,
+            key_states,
+            value_states,
+            attn_mask=attention_mask,
+            dropout_p=dropout_p,
+            is_causal=attention_mask is None,
+        )
+        out = out.transpose(1, 2).contiguous()
+        return out.view(out.shape[0], out.shape[1], -1)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
+        attention_mask: torch.Tensor | None = None,
+        cu_seqlens: torch.LongTensor | None = None,
+        max_seqlen: int | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        query_states, key_states, value_states = self.attn_projections(hidden_states, position_embeddings)
+        attn_output = self._attention_core(query_states, key_states, value_states, attention_mask=attention_mask)
+        input_shape = hidden_states.shape[:-1]
+        attn_output = attn_output.view(*input_shape, self.num_heads, self.head_dim)
+        gate = F.softplus(self.g_proj(hidden_states).float()).to(attn_output.dtype)
+        attn_output = (attn_output * gate.unsqueeze(-1)).view(*input_shape, -1)
+        return self.o_proj(attn_output), None
+
+
+def _get_laguna_attention(config: LagunaConfig, layer_idx: int):
+    attn_impl = config._attn_implementation
+    if attn_impl == "eager":
+        attn_impl = "sdpa"
+    num_heads = config.num_attention_heads_per_layer[layer_idx]
+    match attn_impl:
+        case "flash_attention_2":
+            return LagunaFlashAttention(config, layer_idx, num_heads, flash_attn_version=2)
+        case "flash_attention_3":
+            return LagunaFlashAttention(config, layer_idx, num_heads, flash_attn_version=3)
+        case "fa4":
+            return LagunaFlashAttention(config, layer_idx, num_heads, flash_attn_version=4)
+        case "sdpa":
+            return LagunaSDPAAttention(config, layer_idx, num_heads)
+        case _:
+            raise ValueError(f"Laguna attention does not support '{config._attn_implementation}'.")
+
+
+class LagunaDecoderLayer(GradientCheckpointingLayer):
+    def __init__(self, config: LagunaConfig, layer_idx: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.layer_type = config.layer_types[layer_idx]
+        self.mlp_layer_type = config.mlp_layer_types[layer_idx]
+        self.self_attn = _get_laguna_attention(config, layer_idx)
+
+        if self.mlp_layer_type == "sparse":
+            moe_args = MoEArgs(
+                num_experts=config.num_experts,
+                num_shared_experts=0,
+                score_func="sigmoid",
+                route_norm=True,
+                route_scale=config.moe_routed_scaling_factor,
+                score_before_experts=False,
+                top_k=config.num_experts_per_tok,
+                use_grouped_mm=config.use_grouped_mm,
+                load_balance_coeff=config.load_balance_coeff,
+                fp8=getattr(config, "fp8", False),
+            )
+            if config.moe_router_logit_softcapping:
+                raise NotImplementedError("Laguna router logit softcapping is not supported by PrimeRL MoE yet.")
+            self.mlp = MoE(moe_args, dim=config.hidden_size, hidden_dim=config.moe_intermediate_size)
+            self.shared_expert = FeedForward(
+                dim=config.hidden_size,
+                hidden_dim=config.shared_expert_intermediate_size,
+            )
+        else:
+            mlp_config = MLPConfig(
+                hidden_size=config.hidden_size,
+                intermediate_size=config.intermediate_size,
+                gate_act=config.hidden_act,
+                bias=False,
+            )
+            self.mlp = MLP(mlp_config)
+            self.shared_expert = None
+
+        self.input_layernorm = RMSNorm(RMSNormConfig(hidden_size=config.hidden_size, eps=config.rms_norm_eps))
+        self.post_attention_layernorm = RMSNorm(RMSNormConfig(hidden_size=config.hidden_size, eps=config.rms_norm_eps))
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
+        cu_seqlens: torch.LongTensor | None = None,
+        max_seqlen: int | None = None,
+        routed_experts: Optional[torch.LongTensor] = None,
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states, _ = self.self_attn(
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            position_embeddings=position_embeddings,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+        )
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        mlp_input = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(mlp_input, routed_experts=routed_experts)
+        if self.shared_expert is not None:
+            bs, slen, dim = hidden_states.shape
+            shared_output = self.shared_expert(mlp_input.view(-1, dim)).view(bs, slen, dim)
+            hidden_states = hidden_states + shared_output
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+
+class LagunaPreTrainedModel(PreTrainedModelPrimeRL):
+    config: LagunaConfig
+    config_class = LagunaConfig
+    base_model_prefix = "model"
+    supports_gradient_checkpointing = True
+    _no_split_modules = ["LagunaDecoderLayer"]
+    _skip_keys_device_placement = ["past_key_values"]
+    _supports_flash_attn = True
+    _supports_sdpa = True
+    _supports_flex_attn = False
+    _can_compile_fullgraph = False
+    _supports_attention_backend = True
+    _can_record_outputs = {
+        "hidden_states": LagunaDecoderLayer,
+    }
+
+    @classmethod
+    def is_hf_state_dict(cls, state_dict: dict[str, Tensor]) -> bool:
+        return any(
+            "mlp.experts.0.gate_proj.weight" in name or "mlp.experts.gate_up_proj" in name or "mlp.gate.weight" in name
+            for name in state_dict
+        )
+
+    @classmethod
+    def is_prime_state_dict(cls, state_dict: dict[str, Tensor]) -> bool:
+        return any("mlp.experts.w1" in name for name in state_dict)
+
+    @classmethod
+    def convert_to_hf(cls, state_dict: dict[str, Tensor]) -> dict[str, Tensor]:
+        convert_prime_to_hf(state_dict)
+        return state_dict
+
+    @classmethod
+    def convert_to_prime(cls, state_dict: dict[str, Tensor]) -> dict[str, Tensor]:
+        convert_hf_to_prime(state_dict)
+        return state_dict
+
+    @classmethod
+    def convert_layer_to_hf(cls, state_dict: dict[str, Tensor], layer_idx: int) -> dict[str, Tensor]:
+        convert_prime_layer_to_hf(state_dict, layer_idx)
+        return state_dict
+
+    @classmethod
+    def convert_layer_to_prime(cls, state_dict: dict[str, Tensor], layer_idx: int) -> dict[str, Tensor]:
+        convert_hf_layer_to_prime(state_dict, layer_idx)
+        return state_dict
+
+
+class LagunaModel(LagunaPreTrainedModel):
+    def __init__(self, config: LagunaConfig):
+        super().__init__(config)
+        self.padding_idx = config.pad_token_id
+        self.vocab_size = config.vocab_size
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)
+        self.layers = nn.ModuleList([LagunaDecoderLayer(config, idx) for idx in range(config.num_hidden_layers)])
+        self.norm = RMSNorm(RMSNormConfig(hidden_size=config.hidden_size, eps=config.rms_norm_eps))
+        self.rotary_emb = LagunaRotaryEmbedding(config=config)
+        self.gradient_checkpointing = False
+        self.post_init()
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        routed_experts: torch.LongTensor | None = None,
+    ) -> MoeModelOutputWithPast:
+        if (input_ids is None) ^ (inputs_embeds is not None):
+            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+        if position_ids is None:
+            position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
+
+        if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4"):
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
+            torch._dynamo.mark_dynamic(cu_seqlens, 0)
+            causal_mask_mapping = dict.fromkeys(set(self.config.layer_types), None)
+        else:
+            cu_seqlens = None
+            max_seqlen = None
+            if isinstance(attention_mask, dict):
+                causal_mask_mapping = attention_mask
+            else:
+                mask_kwargs = {
+                    "config": self.config,
+                    "inputs_embeds": inputs_embeds,
+                    "attention_mask": attention_mask,
+                    "past_key_values": None,
+                    "position_ids": position_ids,
+                }
+                causal_mask_mapping = {
+                    "full_attention": create_causal_mask(**mask_kwargs),
+                    "sliding_attention": create_sliding_window_causal_mask(**mask_kwargs),
+                }
+
+        hidden_states = inputs_embeds
+        position_embeddings = {
+            layer_type: self.rotary_emb(hidden_states, position_ids, layer_type)
+            for layer_type in set(self.config.layer_types)
+        }
+
+        for layer_idx, decoder_layer in enumerate(self.layers[: self.config.num_hidden_layers]):
+            routed_experts_layer = routed_experts[:, :, layer_idx, :] if routed_experts is not None else None
+            hidden_states = decoder_layer(
+                hidden_states,
+                attention_mask=causal_mask_mapping[self.config.layer_types[layer_idx]],
+                position_embeddings=position_embeddings[self.config.layer_types[layer_idx]],
+                cu_seqlens=cu_seqlens,
+                max_seqlen=max_seqlen,
+                routed_experts=routed_experts_layer,
+            )
+
+        hidden_states = self.norm(hidden_states)
+        return MoeModelOutputWithPast(last_hidden_state=hidden_states)
+
+
+class LagunaForCausalLM(LagunaPreTrainedModel, GenerationMixin):
+    _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
+    _tp_plan = {"lm_head": "colwise_gather_output"}
+    _pp_plan = {"lm_head": (["hidden_states"], ["logits"])}
+
+    def __init__(self, config: LagunaConfig):
+        super().__init__(config)
+        self.model = LagunaModel(config)
+        self.vocab_size = config.vocab_size
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        self.router_aux_loss_coef = config.router_aux_loss_coef
+        self.num_experts = config.num_experts
+        self.num_experts_per_tok = config.num_experts_per_tok
+        self.post_init()
+
+    def set_decoder(self, decoder):
+        self.model = decoder
+
+    def get_decoder(self):
+        return self.model
+
+    @can_return_tuple
+    def forward(
+        self,
+        input_ids: torch.LongTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        past_key_values: Cache | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        labels: torch.LongTensor | None = None,
+        use_cache: bool | None = None,
+        output_router_logits: bool | None = None,
+        cache_position: torch.LongTensor | None = None,
+        logits_to_keep: Union[int, torch.Tensor] = 0,
+        temperature: torch.Tensor | None = None,
+        routed_experts: torch.LongTensor | None = None,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> PrimeLmOutput:
+        assert use_cache is None, "use_cache is not supported for custom Laguna"
+        assert past_key_values is None, "past_key_values is not supported for custom Laguna"
+
+        outputs = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            inputs_embeds=inputs_embeds,
+            routed_experts=routed_experts,
+        )
+        hidden_states = outputs.last_hidden_state
+        slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+        return self.lm_head(
+            hidden_states[:, slice_indices, :],
+            labels[:, slice_indices] if labels is not None else None,
+            temperature=temperature,
+        )
+
+    def init_buffers_post_meta(self) -> None:
+        rotary_emb = self.model.rotary_emb
+        for layer_type in rotary_emb.layer_types:
+            rope_init_fn = rotary_emb.compute_default_rope_parameters
+            if rotary_emb.rope_type[layer_type] != "default":
+                rope_init_fn = ROPE_INIT_FUNCTIONS[rotary_emb.rope_type[layer_type]]
+            inv_freq, attention_scaling = rope_init_fn(
+                rotary_emb.config,
+                getattr(rotary_emb, f"{layer_type}_inv_freq").device,
+                layer_type=layer_type,
+            )
+            getattr(rotary_emb, f"{layer_type}_inv_freq").copy_(inv_freq)
+            getattr(rotary_emb, f"{layer_type}_original_inv_freq").copy_(inv_freq)
+            setattr(rotary_emb, f"{layer_type}_attention_scaling", attention_scaling)
+
+        for module in self.modules():
+            if isinstance(module, MoE) and module.tokens_per_expert.device.type != "meta":
+                module.tokens_per_expert.zero_()
+                if module.expert_bias is not None:
+                    module.expert_bias.zero_()
+
+
+__all__ = [
+    "LagunaForCausalLM",
+    "LagunaModel",
+    "LagunaPreTrainedModel",
+]


### PR DESCRIPTION
## Summary
- add a PrimeRL custom model/config/conversion path for Poolside Laguna (`laguna`)
- register Laguna with `AutoConfig` and the custom causal LM mapping
- add a `scripts/mini_moe.py --arch laguna` preset and README support row

## Validation
- `uv run python scripts/mini_moe.py --arch laguna --output-dir /tmp/prime-rl-laguna-tests/mini-laguna` passed (`HF vs PrimeRL max logits diff: 0.000002`; HF -> PrimeRL -> HF weight roundtrip verified)
- `uv run python -m compileall -q src/prime_rl/trainer/models/laguna src/prime_rl/trainer/models/__init__.py scripts/mini_moe.py`
- `uv run ruff check src/prime_rl/trainer/models/laguna src/prime_rl/trainer/models/__init__.py scripts/mini_moe.py`
- `uv run ruff format --check src/prime_rl/trainer/models/laguna src/prime_rl/trainer/models/__init__.py scripts/mini_moe.py`
- reverse-text smoke completed 50 steps with batch size 64; mismatch KL: min `0.0011`, max `0.0314` at step 44, avg `0.0073`, final `0.0040`
- Hendrycks math smoke completed 100 steps with batch size 64, eval disabled, and zero-advantage filtering monitor-only; mismatch KL: min `0.0002`, max `0.0005` at step 40, avg `0.0003`, final `0.0003`

## Notes
- Attempted a Laguna mini reverse-text RL run through vLLM 0.20.2 remote-code/generic Transformers serving. The custom PrimeRL model and conversion passed parity checks, but vLLM loaded the checkpoint without becoming serving-ready, so the Laguna RL smoke did not complete.




# Training sanity check

## hendrycks math

<img width="1293" height="561" alt="image" src="https://github.com/user-attachments/assets/8a730af0-d288-4315-ab95-584f41e3c136" />

<img width="1252" height="501" alt="image" src="https://github.com/user-attachments/assets/4a692b82-3044-436d-8c1f-3ed88fb94121" />
<img width="1263" height="496" alt="image" src="https://github.com/user-attachments/assets/d75ca5c7-84f7-41cc-9a26-961892847a4c" />



## Reverse text

<img width="624" height="481" alt="image" src="https://github.com/user-attachments/assets/04ee6e04-59fb-4bd7-ac65-f60eefa21138" />
<img width="594" height="462" alt="image" src="https://github.com/user-attachments/assets/821e137a-8e8e-4e06-b2d4-5dd90c71e63b" />




