### PR TITLE
[codex] log masked advantage sign rates

### DIFF
--- a/skills/monitor-run/SKILL.md
+++ b/skills/monitor-run/SKILL.md
@@ -145,6 +145,8 @@ These tell you whether training is healthy or diverging.
 |--------|--------|-------------|
 | `mismatch_kl/mean` | trainer | KL divergence between trainer and (old) inference policy  |
 | `entropy/mean` | trainer | policy entropy |
+| `masked_advantage_positive/mean` | trainer | fraction of DPPO-masked trainable tokens with positive advantage (W&B) |
+| `masked_advantage_negative/mean` | trainer | fraction of DPPO-masked trainable tokens with negative advantage (W&B) |
 | `optim/grad_norm` | trainer | gradient norm — spikes may precede divergence |
 
 #### Performance

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -127,11 +127,14 @@ def default_loss_fn(inputs: LossInputs, loss_config: DefaultLossConfig) -> LossO
     probs_diff = trainer_probs - inference_probs
     dppo_invalid_mask_high = probs_diff > loss_config.dppo_mask_high
     dppo_invalid_mask_low = probs_diff < -loss_config.dppo_mask_low
-    dppo_invalid_mask = torch.where(advantages > 0, dppo_invalid_mask_high, dppo_invalid_mask_low)
+    positive_advantages = advantages > 0
+    negative_advantages = advantages < 0
+    dppo_invalid_mask = torch.where(positive_advantages, dppo_invalid_mask_high, dppo_invalid_mask_low)
 
     is_masked = dppo_invalid_mask
-    is_masked_high = (advantages > 0) & dppo_invalid_mask_high
-    is_masked_low = (advantages < 0) & dppo_invalid_mask_low
+    is_masked_high = positive_advantages & dppo_invalid_mask_high
+    is_masked_low = negative_advantages & dppo_invalid_mask_low
+    drop_mask = loss_mask & is_masked
     keep_mask = loss_mask & ~is_masked
 
     log_importance_ratio = trainer_logprobs - inference_logprobs
@@ -156,6 +159,8 @@ def default_loss_fn(inputs: LossInputs, loss_config: DefaultLossConfig) -> LossO
         "is_masked": _safe_mean(is_masked, loss_mask),
         "is_masked_low": _safe_mean(is_masked_low, loss_mask),
         "is_masked_high": _safe_mean(is_masked_high, loss_mask),
+        "masked_advantage_positive": _safe_mean(positive_advantages, drop_mask),
+        "masked_advantage_negative": _safe_mean(negative_advantages, drop_mask),
     }
     if teacher_kl is not None:
         metrics["teacher_kl"] = _safe_mean(teacher_kl, loss_mask)

--- a/src/prime_rl/trainer/utils.py
+++ b/src/prime_rl/trainer/utils.py
@@ -389,6 +389,8 @@ def filter_rl_trainer_tensor_stats_for_wandb(metrics: dict[str, float | int]) ->
         "is_masked/",
         "is_masked_low/",
         "is_masked_high/",
+        "masked_advantage_positive/",
+        "masked_advantage_negative/",
         "mismatch_kl/",
         "masked_mismatch_kl/",
         "unmasked_mismatch_kl/",


### PR DESCRIPTION
## Summary

Adds trainer metrics for the sign split of DPPO-masked trainable tokens:

- `masked_advantage_positive/mean`
- `masked_advantage_negative/mean`

These are 0-1 ratios computed from masked trainable tokens in the default RL loss, then passed through the existing trainer tensor-stat W&B filter. The monitor-run skill docs now list the new stability metrics.

## Validation

- `uv run ruff check tests/unit/train/rl/test_loss.py src/prime_rl/trainer/rl/loss.py src/prime_rl/trainer/utils.py`
- `uv run pytest tests/unit/train/rl/test_loss.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds two new trainer-only metrics and updates W&B filtering/docs without changing optimization behavior or data flow.
> 
> **Overview**
> Adds two new stability metrics, `masked_advantage_positive/mean` and `masked_advantage_negative/mean`, reporting the fraction of DPPO-masked *trainable* tokens with positive vs. negative advantage.
> 
> Computes these ratios in `default_loss_fn` (based on `loss_mask & dppo_invalid_mask`) and whitelists them through the existing RL trainer tensor-stat W&B filter, with corresponding additions to the monitor-run documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 089237a16f1ee4f96d96922e8a8324d28904fbd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->