### PR TITLE
Patch vLLM layerwise reload alias-buffer handling

### DIFF
--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -83,9 +83,7 @@ def monkey_patch_vllm_layerwise_reload_alias_buffers():
         for name, param in parameters.items():
             param.data.copy_(getattr(layer, name))
         for name, buffer in buffers.items():
-            materialized_buffer = layer._buffers.get(name)
-            if materialized_buffer is not None:
-                buffer.data.copy_(materialized_buffer)
+            buffer.data.copy_(getattr(layer, name))
 
         reload_layerwise._place_kernel_tensors(layer, info)
 

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -21,36 +21,32 @@ def transformers_v5_compat():
     monkey_patch_vllm_layerwise_reload_alias_buffers()
 
 
-def _is_non_persistent_parameter_alias_buffer(layer: torch.nn.Module, name: str, buffer: torch.Tensor) -> bool:
+def _is_non_persistent_parameter_alias_buffer(
+    layer: torch.nn.Module,
+    name: str,
+    buffer: torch.Tensor,
+    parameter_storage_ptrs: set[int],
+) -> bool:
     if name not in layer._non_persistent_buffers_set:
         return False
 
-    return _is_parameter_alias_tensor(layer, buffer)
+    buffer_storage_ptr = _tensor_storage_ptr(buffer)
+    return buffer_storage_ptr is not None and buffer_storage_ptr in parameter_storage_ptrs
 
 
-def _is_parameter_alias_tensor(
-    layer: torch.nn.Module,
-    tensor: torch.Tensor,
-    extra_parameters=(),
-) -> bool:
+def _tensor_storage_ptr(tensor: torch.Tensor) -> int | None:
     try:
-        tensor_storage_ptr = tensor.untyped_storage().data_ptr()
+        return tensor.untyped_storage().data_ptr()
     except RuntimeError:
-        return False
+        return None
 
-    for param in layer.parameters(recurse=True):
-        try:
-            if param.untyped_storage().data_ptr() == tensor_storage_ptr:
-                return True
-        except RuntimeError:
-            continue
-    for param in extra_parameters:
-        try:
-            if param.untyped_storage().data_ptr() == tensor_storage_ptr:
-                return True
-        except RuntimeError:
-            continue
-    return False
+
+def _parameter_storage_ptrs(layer: torch.nn.Module) -> set[int]:
+    return {
+        storage_ptr
+        for param in layer.parameters(recurse=True)
+        if (storage_ptr := _tensor_storage_ptr(param)) is not None
+    }
 
 
 def monkey_patch_vllm_layerwise_reload_alias_buffers():
@@ -73,6 +69,7 @@ def monkey_patch_vllm_layerwise_reload_alias_buffers():
             return ({}, {})
 
         params, buffers = get_layer_params_buffers(layer)
+        parameter_storage_ptrs = _parameter_storage_ptrs(layer)
         return (
             {
                 name: sanitize_layer_refs(reload_meta.to_meta_tensor(param), layer)
@@ -83,7 +80,9 @@ def monkey_patch_vllm_layerwise_reload_alias_buffers():
                 name: sanitize_layer_refs(reload_meta.to_meta_tensor(buffer), layer)
                 for name, buffer in buffers.items()
                 if name not in reload_meta.SKIP_TENSORS
-                and not _is_non_persistent_parameter_alias_buffer(layer, name, buffer)
+                and not _is_non_persistent_parameter_alias_buffer(
+                    layer, name, buffer, parameter_storage_ptrs
+                )
             },
         )
 

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -21,9 +21,7 @@ def transformers_v5_compat():
     monkey_patch_vllm_layerwise_reload_alias_buffers()
 
 
-def _is_non_persistent_parameter_alias_buffer(
-    layer: torch.nn.Module, name: str, buffer: torch.Tensor
-) -> bool:
+def _is_non_persistent_parameter_alias_buffer(layer: torch.nn.Module, name: str, buffer: torch.Tensor) -> bool:
     if name not in layer._non_persistent_buffers_set:
         return False
 
@@ -89,9 +87,7 @@ def monkey_patch_vllm_layerwise_reload_alias_buffers():
             },
         )
 
-    def _copy_and_restore_kernel_tensors(
-        layer: torch.nn.Module, info: reload_layerwise.LayerReloadingInfo
-    ):
+    def _copy_and_restore_kernel_tensors(layer: torch.nn.Module, info: reload_layerwise.LayerReloadingInfo):
         assert info.kernel_tensors is not None
         parameters, buffers = info.kernel_tensors
         for name, param in parameters.items():

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -18,6 +18,82 @@ def transformers_v5_compat():
     monkey_patch_deep_gemm_ep_scatter()
     monkey_patch_deep_gemm_silu_mul_quant_int64()
     monkey_patch_dp_engine_core_pause_resume_deadlock()
+    monkey_patch_vllm_layerwise_reload_alias_buffers()
+
+
+def _is_non_persistent_parameter_alias_buffer(
+    layer: torch.nn.Module, name: str, buffer: torch.Tensor
+) -> bool:
+    if name not in layer._non_persistent_buffers_set:
+        return False
+
+    try:
+        buffer_storage_ptr = buffer.untyped_storage().data_ptr()
+    except RuntimeError:
+        return False
+
+    for param in layer.parameters(recurse=True):
+        try:
+            if param.untyped_storage().data_ptr() == buffer_storage_ptr:
+                return True
+        except RuntimeError:
+            continue
+    return False
+
+
+def monkey_patch_vllm_layerwise_reload_alias_buffers():
+    # Temporary local carry for vLLM layerwise reload corrupting non-persistent
+    # buffers that alias checkpoint-loaded parameters, e.g. Nemotron Mamba
+    # mixer.conv_weights aliasing mixer.conv1d.weight.
+    from vllm.logger import init_logger
+    from vllm.model_executor.model_loader.reload import layerwise as reload_layerwise
+    from vllm.model_executor.model_loader.reload import meta as reload_meta
+    from vllm.model_executor.model_loader.reload.sanitize import sanitize_layer_refs
+    from vllm.model_executor.model_loader.reload.utils import get_layer_params_buffers
+
+    logger = init_logger(__name__)
+
+    if getattr(reload_meta, "_prime_rl_layerwise_alias_buffer_patch", False):
+        return
+
+    def capture_layer_to_meta(layer: torch.nn.Module):
+        if layer.__class__.__name__ in reload_meta.SKIP_MODULES:
+            return ({}, {})
+
+        params, buffers = get_layer_params_buffers(layer)
+        return (
+            {
+                name: sanitize_layer_refs(reload_meta.to_meta_tensor(param), layer)
+                for name, param in params.items()
+                if name not in reload_meta.SKIP_TENSORS
+            },
+            {
+                name: sanitize_layer_refs(reload_meta.to_meta_tensor(buffer), layer)
+                for name, buffer in buffers.items()
+                if name not in reload_meta.SKIP_TENSORS
+                and not _is_non_persistent_parameter_alias_buffer(layer, name, buffer)
+            },
+        )
+
+    def _copy_and_restore_kernel_tensors(
+        layer: torch.nn.Module, info: reload_layerwise.LayerReloadingInfo
+    ):
+        assert info.kernel_tensors is not None
+        parameters, buffers = info.kernel_tensors
+        for name, param in parameters.items():
+            param.data.copy_(getattr(layer, name))
+        for name, buffer in buffers.items():
+            materialized_buffer = layer._buffers.get(name)
+            if materialized_buffer is not None:
+                buffer.data.copy_(materialized_buffer)
+
+        reload_layerwise._place_kernel_tensors(layer, info)
+
+    reload_meta.capture_layer_to_meta = capture_layer_to_meta
+    reload_layerwise.capture_layer_to_meta = capture_layer_to_meta
+    reload_layerwise._copy_and_restore_kernel_tensors = _copy_and_restore_kernel_tensors
+    reload_meta._prime_rl_layerwise_alias_buffer_patch = True
+    logger.warning("Enabled vLLM layerwise reload alias-buffer patch.")
 
 
 @triton.jit

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -80,9 +80,7 @@ def monkey_patch_vllm_layerwise_reload_alias_buffers():
                 name: sanitize_layer_refs(reload_meta.to_meta_tensor(buffer), layer)
                 for name, buffer in buffers.items()
                 if name not in reload_meta.SKIP_TENSORS
-                and not _is_non_persistent_parameter_alias_buffer(
-                    layer, name, buffer, parameter_storage_ptrs
-                )
+                and not _is_non_persistent_parameter_alias_buffer(layer, name, buffer, parameter_storage_ptrs)
             },
         )
 

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -21,85 +21,33 @@ def transformers_v5_compat():
     monkey_patch_vllm_layerwise_reload_alias_buffers()
 
 
-def _is_non_persistent_parameter_alias_buffer(
-    layer: torch.nn.Module,
-    name: str,
-    buffer: torch.Tensor,
-    parameter_storage_ptrs: set[int],
-) -> bool:
-    if name not in layer._non_persistent_buffers_set:
-        return False
-
-    buffer_storage_ptr = _tensor_storage_ptr(buffer)
-    return buffer_storage_ptr is not None and buffer_storage_ptr in parameter_storage_ptrs
-
-
-def _tensor_storage_ptr(tensor: torch.Tensor) -> int | None:
-    try:
-        return tensor.untyped_storage().data_ptr()
-    except RuntimeError:
-        return None
-
-
-def _parameter_storage_ptrs(layer: torch.nn.Module) -> set[int]:
-    return {
-        storage_ptr
-        for param in layer.parameters(recurse=True)
-        if (storage_ptr := _tensor_storage_ptr(param)) is not None
-    }
-
-
 def monkey_patch_vllm_layerwise_reload_alias_buffers():
-    # Temporary local carry for vLLM layerwise reload corrupting non-persistent
-    # buffers that alias checkpoint-loaded parameters, e.g. Nemotron Mamba
-    # mixer.conv_weights aliasing mixer.conv1d.weight.
+    # vLLM's layerwise reload materializes each buffer as an independent tensor
+    # and then copies it back into the original kernel storage. When a buffer
+    # aliases a parameter (e.g. NemotronH Mamba's mixer.conv_weights, a view of
+    # mixer.conv1d.weight), the buffer copy stamps garbage into the parameter's
+    # storage *after* the parameter has been correctly reloaded. Skip the copy
+    # for any buffer that shares storage with a parameter; _place_kernel_tensors
+    # re-registers the original view, which trivially reflects the parameter.
     from vllm.logger import init_logger
     from vllm.model_executor.model_loader.reload import layerwise as reload_layerwise
-    from vllm.model_executor.model_loader.reload import meta as reload_meta
-    from vllm.model_executor.model_loader.reload.sanitize import sanitize_layer_refs
-    from vllm.model_executor.model_loader.reload.utils import get_layer_params_buffers
 
     logger = init_logger(__name__)
-
-    if getattr(reload_meta, "_prime_rl_layerwise_alias_buffer_patch", False):
-        return
-
-    def capture_layer_to_meta(layer: torch.nn.Module):
-        if layer.__class__.__name__ in reload_meta.SKIP_MODULES:
-            return ({}, {})
-
-        params, buffers = get_layer_params_buffers(layer)
-        parameter_storage_ptrs = _parameter_storage_ptrs(layer)
-        return (
-            {
-                name: sanitize_layer_refs(reload_meta.to_meta_tensor(param), layer)
-                for name, param in params.items()
-                if name not in reload_meta.SKIP_TENSORS
-            },
-            {
-                name: sanitize_layer_refs(reload_meta.to_meta_tensor(buffer), layer)
-                for name, buffer in buffers.items()
-                if name not in reload_meta.SKIP_TENSORS
-                and not _is_non_persistent_parameter_alias_buffer(layer, name, buffer, parameter_storage_ptrs)
-            },
-        )
 
     def _copy_and_restore_kernel_tensors(layer: torch.nn.Module, info: reload_layerwise.LayerReloadingInfo):
         assert info.kernel_tensors is not None
         parameters, buffers = info.kernel_tensors
+        param_storage_ptrs = {p.untyped_storage().data_ptr() for p in layer.parameters(recurse=True)}
         for name, param in parameters.items():
             param.data.copy_(getattr(layer, name))
         for name, buffer in buffers.items():
-            if name not in layer._buffers:
+            if buffer.untyped_storage().data_ptr() in param_storage_ptrs:
                 continue
             buffer.data.copy_(getattr(layer, name))
 
         reload_layerwise._place_kernel_tensors(layer, info)
 
-    reload_meta.capture_layer_to_meta = capture_layer_to_meta
-    reload_layerwise.capture_layer_to_meta = capture_layer_to_meta
     reload_layerwise._copy_and_restore_kernel_tensors = _copy_and_restore_kernel_tensors
-    reload_meta._prime_rl_layerwise_alias_buffer_patch = True
     logger.warning("Enabled vLLM layerwise reload alias-buffer patch.")
 
 

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -27,14 +27,28 @@ def _is_non_persistent_parameter_alias_buffer(
     if name not in layer._non_persistent_buffers_set:
         return False
 
+    return _is_parameter_alias_tensor(layer, buffer)
+
+
+def _is_parameter_alias_tensor(
+    layer: torch.nn.Module,
+    tensor: torch.Tensor,
+    extra_parameters=(),
+) -> bool:
     try:
-        buffer_storage_ptr = buffer.untyped_storage().data_ptr()
+        tensor_storage_ptr = tensor.untyped_storage().data_ptr()
     except RuntimeError:
         return False
 
     for param in layer.parameters(recurse=True):
         try:
-            if param.untyped_storage().data_ptr() == buffer_storage_ptr:
+            if param.untyped_storage().data_ptr() == tensor_storage_ptr:
+                return True
+        except RuntimeError:
+            continue
+    for param in extra_parameters:
+        try:
+            if param.untyped_storage().data_ptr() == tensor_storage_ptr:
                 return True
         except RuntimeError:
             continue
@@ -83,6 +97,8 @@ def monkey_patch_vllm_layerwise_reload_alias_buffers():
         for name, param in parameters.items():
             param.data.copy_(getattr(layer, name))
         for name, buffer in buffers.items():
+            if name not in layer._buffers and _is_parameter_alias_tensor(layer, buffer, parameters.values()):
+                continue
             buffer.data.copy_(getattr(layer, name))
 
         reload_layerwise._place_kernel_tensors(layer, info)

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -93,7 +93,7 @@ def monkey_patch_vllm_layerwise_reload_alias_buffers():
         for name, param in parameters.items():
             param.data.copy_(getattr(layer, name))
         for name, buffer in buffers.items():
-            if name not in layer._buffers and _is_parameter_alias_tensor(layer, buffer, parameters.values()):
+            if name not in layer._buffers:
                 continue
             buffer.data.copy_(getattr(layer, name))
 


### PR DESCRIPTION
## Summary

- Add a PrimeRL vLLM plugin patch for layerwise reload alias-buffer handling.
- Skip non-persistent buffers that alias checkpoint-loaded parameters before vLLM materializes layer tensors on meta.
- Detect aliases through child parameters as well as direct layer parameters, which covers Nemotron `MambaMixer2.conv_weights -> conv1d.weight`.

## Why

Nemotron Super hit inference-side NaNs after checkpoint-format `/update_weights`.

Root cause: vLLM layerwise reload captured `MambaMixer2.conv_weights` as reloadable buffer state. That buffer is a non-persistent derived view of `conv1d.weight`. During reload, vLLM materialized it independently, loaded the checkpoint into `conv1d.weight`, then copied the uninitialized materialized `conv_weights` back into the original buffer. Because the original buffer aliases `conv1d.weight`, that copy-back corrupted valid Mamba conv weights and later surfaced as JSON serialization failures from non-finite logits/logprobs.

This patch carries the narrow fix in PrimeRL until the upstream vLLM fix lands.

## Validation

- `uv run ruff check src/prime_rl/inference/patches.py`
- Synthetic child-parameter alias check:
  - direct non-persistent alias buffer is detected when it aliases `child.weight`
  - unrelated non-persistent buffer is not skipped
- Real Nemotron Super math training workload on SLURM:
  - job: `16165`
  - output: `/beegfs/daniel/nemotron-super-math-training-update-probe-20260513-073652`
  - completed 4 orchestrator steps and 3 checkpoint-format weight updates
  - all update probes clean: `failures=0`, `nonfinite=0`
  - no `Out of range float values`, `Non-finite /v1`, or `BadRequestError ... nan`
  - diagnostic branch confirmed `MambaMixer2.conv_weights` was skipped and not copied back over `conv1d.weight`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Monkeypatches vLLM’s layerwise weight reload internals, which is sensitive logic and could affect correctness of checkpoint reloads across models if alias detection is wrong.
> 
> **Overview**
> Adds a new vLLM general-plugin monkeypatch to fix layerwise reload when a **buffer aliases a parameter** (e.g., view-based buffers). The patch overrides `vllm.model_executor.model_loader.reload.layerwise._copy_and_restore_kernel_tensors` to **skip copying back** any buffer whose underlying storage pointer matches any parameter (including child parameters), preventing reload-time corruption that can lead to NaNs after `/update_weights`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a50b565fa16e8ac8537228c25c5718081df5e416. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->