### PR TITLE
feat(orchestrator): default max_error_reschedule_attempts to 3

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -1088,7 +1088,7 @@ class OrchestratorConfig(BaseConfig):
             ge=1,
             description="The group is dropped from the current step's batch once this many of its dispatch rounds have returned errored or empty rollouts (the trainer proceeds with the rollouts from other groups). Counts rounds, not individual rollouts: a non-group-scoring env that dispatches `rollouts_per_example` rollouts at once still only counts one round per failed batch. `None` means retry indefinitely (legacy behavior). Useful for unblocking single-example hangs in agent envs.",
         ),
-    ] = None
+    ] = 3
 
     max_async_level: Annotated[
         int,


### PR DESCRIPTION
## Summary

Follow-up to #2459. Switches the default of `orchestrator.max_error_reschedule_attempts` from `None` (retry indefinitely) to `3`.

## Why

The cap added in #2459 is opt-in, so single-example hangs in agent envs still block step progress out of the box. Defaulting to `3` makes the safe behavior the default — a group that has failed three dispatch rounds gets dropped and the rest of the batch proceeds. Users who want the legacy infinite-retry behavior can still set `None` explicitly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the orchestrator’s default failure-handling behavior by capping reschedule retries, which could cause some rollout groups to be dropped sooner than before and affect training throughput/results in flaky environments.
> 
> **Overview**
> Updates `OrchestratorConfig.max_error_reschedule_attempts` default from `None` (infinite retries) to `3`, so a group that repeatedly returns errored/empty rollouts is dropped from the current training step after three failed dispatch rounds instead of potentially blocking progress indefinitely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3cefc6f560d233e34bd3483c861868057cfe98f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->