### PR TITLE
feat(trainer): enable torch.compile by default

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -208,7 +208,7 @@ class ModelConfig(BaseModelConfig):
         Field(
             description="Whether to compile the model using `torch.compile`.",
         ),
-    ] = None
+    ] = CompileConfig()
 
     ac: Annotated[
         ActivationCheckpointConfig | None,


### PR DESCRIPTION
## Summary
- Default `ModelConfig.compile` to `CompileConfig()` instead of `None`, so `apply_compile` runs by default and each transformer block is wrapped with `torch.compile`.
- `fullgraph` still defaults to `False`. Configs that explicitly set `[model.compile]` (e.g. `configs/nemotron_4node/rl.toml`, `configs/hendrycks_math/sanity.toml`) continue to override as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default training behavior by enabling `torch.compile` unless explicitly disabled, which can impact performance, debugging, and runtime compatibility for some models/environments.
> 
> **Overview**
> **Enables model compilation by default** by changing `ModelConfig.compile`’s default from `None` to `CompileConfig()`, so configurations that don’t specify `model.compile` will now run the model through `torch.compile` automatically.
> 
> Existing configs that explicitly set `model.compile` continue to override this default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f2fc1f26efc6154529d3ce774cc2b4c5af7cafa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->