### PR TITLE
Fix disagg: thread kv_transfer_params into engine for /inference/v1/generate

### DIFF
--- a/src/prime_rl/inference/vllm/serving_tokens.py
+++ b/src/prime_rl/inference/vllm/serving_tokens.py
@@ -222,6 +222,22 @@ class PrimeRlServingTokens(ServingTokens):
 
         sampling_params: SamplingParams = request.sampling_params
 
+        # Upstream ``ServingTokens.serve_tokens`` parses ``request.kv_transfer_params``
+        # but never threads it into the engine, so PD disagg never fires on
+        # ``/inference/v1/generate`` — decode receives an empty NIXL handshake
+        # and ends up re-prefilling the prompt locally (~100× slower under
+        # concurrency). The chat path bridges this via
+        # ``ChatCompletionRequestWithTokens.to_sampling_params``; we mirror that
+        # bridge here so the engine's KV connector picks the params up out of
+        # ``sampling_params.extra_args``.
+        #
+        # Upstream fix: https://github.com/vllm-project/vllm/pull/42644 — drop
+        # this block once we pin a vLLM version that includes it.
+        if request.kv_transfer_params is not None:
+            extra = sampling_params.extra_args or {}
+            extra["kv_transfer_params"] = request.kv_transfer_params
+            sampling_params.extra_args = extra
+
         # Server-side ``max_tokens`` defaulting — see module docstring.
         # Mirrors ``OpenAIServingChat`` (vllm/entrypoints/openai/chat_completion/
         # serving.py:284) so callers that omit ``max_tokens`` don't get capped


### PR DESCRIPTION
## Summary

- `PrimeRlServingTokens.serve_tokens` now injects `request.kv_transfer_params` into `sampling_params.extra_args` before calling `engine_client.generate(...)`. Without this, PD disaggregation silently degrades to a single-stage path for `/inference/v1/generate`: the prefill response carries `kv_transfer_params=null`, decode receives an empty NIXL handshake, and it re-prefills the prompt locally.
- Root cause is in upstream `vllm.entrypoints.serve.disagg.serving.ServingTokens.serve_tokens` (vllm 0.20.2) — it parses `request.kv_transfer_params` from the request body but never threads it to the engine. The chat path bridges this via `ChatCompletionRequestWithTokens.to_sampling_params` (`vllm/entrypoints/openai/chat_completion/protocol.py:533-536`); the generate path didn't. This patch mirrors that bridge inline in our override.

## Numbers (GLM-5.1-FP8, 2P+2D disagg, vllm-router consistent_hash, c=256, max_tokens=1)

| Endpoint | Before | After |
|---|---|---|
| `/v1/chat/completions/tokens` total | 8.86 s | 8.76 s |
| `/inference/v1/generate` total | **40.47 s** | **9.13 s** |
| decode HTTP roundtrip (chat) | ~147 ms | ~143 ms |
| decode HTTP roundtrip (generate) | **~14,900 ms** | **~180 ms** |
| chat:generate ratio | 4.57× | 1.04× |

Direct prefill probe before the fix: `kv_transfer_params: null` in response. After: full NIXL handshake (`remote_engine_id`, `remote_block_ids`, `remote_host`, `remote_port`).

## Test plan

- [x] Direct curl to prefill engine with `kv_transfer_params` inside `sampling_params.extra_args` returns populated handshake (confirms engine-side wiring is correct, only the protocol→engine bridge was missing).
- [x] vllm-router probe at c=256, max_tokens=1: `/inference/v1/generate` drops from ~41s to ~9s, matching `/v1/chat/completions/tokens` within 4%.
- [x] Per-stage router timing (instrumented vllm-router): decode HTTP roundtrip per-request drops ~100× (14.9s → 180ms).
- [ ] Re-run the renderer-vs-TITO vf-eval comparison on general-agent end-to-end (was 2937s renderer vs 1060s TITO; expected to come down to chat parity now).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core `/inference/v1/generate` request→engine wiring; incorrect propagation could break disaggregated prefill/decode behavior or unexpectedly change engine sampling behavior via `extra_args`. Scope is small and gated on `request.kv_transfer_params` being present.
> 
> **Overview**
> Fixes `/inference/v1/generate` disaggregated execution by **threading `request.kv_transfer_params` into the engine call**: when present, it is now injected into `sampling_params.extra_args["kv_transfer_params"]` before invoking `engine_client.generate`.
> 
> This mirrors the existing chat-completions bridging behavior so the engine KV connector receives the NIXL handshake parameters and avoids falling back to local re-prefill in the decode stage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9784fb905a73600d79abd2583e3412acd07177d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->