### PR TITLE
chore: tell agents not to edit optimization_dtype / reduce_dtype

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 ## Writing code
 
 - **Minimal try/except**: let errors propagate — silent failures hide bugs. Only catch exceptions for intentional fault tolerance (retries, robustness).
+- **Don't touch `optimization_dtype` / `reduce_dtype`**: never change these model config fields (or their defaults in `trainer.py`) unless the user explicitly asks. They're load-bearing numerical knobs — flipping bfloat16/float32 silently changes training dynamics.
 - **Targeted comments**: don't explain your work process or reference old code. Use targeted comments sparingly to clarify ambiguous logic.
 - **Zen of Python**: remember the Zen of Python when writing code.
 ```


### PR DESCRIPTION
## Summary
- Add an AGENTS.md rule under "Writing code" telling agents not to change `optimization_dtype` / `reduce_dtype` (or their defaults in `trainer.py`) unless the user explicitly asks.
- These are load-bearing numerical knobs in `packages/prime-rl-configs/src/prime_rl/configs/trainer.py:327` — agents flipping bfloat16/float32 on their own can silently change training dynamics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime or configuration code is modified.
> 
> **Overview**
> Adds a new **Writing code** guideline in `AGENTS.md` instructing agents not to change `optimization_dtype`/`reduce_dtype` (or their defaults) unless explicitly requested, to avoid silently altering training numerics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5839a3eb600972c72b594c20c75874a6b674795. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->