### PR TITLE
feat(sft): accept tool_defs column alongside tools

### DIFF
--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -192,7 +192,7 @@ class SFTDataset(StatefulIterableDataset):
         # Reference: https://platform.openai.com/docs/guides/function-calling#function-tool-example
         # Accepts either `tools` or `tool_defs` (the verifiers rollout format),
         # as either a JSON-encoded string of a list or a list of dicts.
-        raw_tools = example.get("tools") if "tools" in example and example["tools"] else example.get("tool_defs")
+        raw_tools = example.get("tools", example.get("tool_defs"))
         if not raw_tools:
             tools = []
         elif isinstance(raw_tools, str):

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -190,7 +190,14 @@ class SFTDataset(StatefulIterableDataset):
 
         # Parse available tools, if present - assumes OAI format
         # Reference: https://platform.openai.com/docs/guides/function-calling#function-tool-example
-        tools = json.loads(example.get("tools") or "[]")
+        # Accepts either `tools` (single JSON string of a list) or `tool_defs`
+        # (list of dicts or list of JSON strings; the verifiers rollout format).
+        if "tools" in example and example["tools"]:
+            tools = json.loads(example["tools"])
+        elif "tool_defs" in example and example["tool_defs"]:
+            tools = [json.loads(t) if isinstance(t, str) else t for t in example["tool_defs"]]
+        else:
+            tools = []
 
         def should_mask(message: dict) -> bool:
             assert "role" in message, "Message must have a role"

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -191,15 +191,14 @@ class SFTDataset(StatefulIterableDataset):
         # Parse available tools, if present - assumes OAI format
         # Reference: https://platform.openai.com/docs/guides/function-calling#function-tool-example
         # Accepts either `tools` or `tool_defs` (the verifiers rollout format),
-        # in any of: JSON-encoded string of a list, list of dicts, or list of
-        # JSON-encoded strings. Result is always list[dict].
+        # as either a JSON-encoded string of a list or a list of dicts.
         raw_tools = example.get("tools") if "tools" in example and example["tools"] else example.get("tool_defs")
         if not raw_tools:
             tools = []
         elif isinstance(raw_tools, str):
             tools = json.loads(raw_tools)
         else:
-            tools = [json.loads(t) if isinstance(t, str) else t for t in raw_tools]
+            tools = list(raw_tools)
 
         def should_mask(message: dict) -> bool:
             assert "role" in message, "Message must have a role"

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -191,14 +191,29 @@ class SFTDataset(StatefulIterableDataset):
         # Parse available tools, if present - assumes OAI format
         # Reference: https://platform.openai.com/docs/guides/function-calling#function-tool-example
         # Accepts either `tools` or `tool_defs` (the verifiers rollout format),
-        # as either a JSON-encoded string of a list or a list of dicts.
+        # as either a JSON-encoded string of a list or a list of dicts. Tools
+        # arriving in the verifiers shape are converted to OAI form so any
+        # downstream chat template can consume them.
         raw_tools = example.get("tools", example.get("tool_defs"))
         if not raw_tools:
             tools = []
-        elif isinstance(raw_tools, str):
-            tools = json.loads(raw_tools)
         else:
-            tools = list(raw_tools)
+            if isinstance(raw_tools, str):
+                raw_tools = json.loads(raw_tools)
+            tools = [
+                t
+                if isinstance(t, dict) and t.get("type") == "function" and "function" in t
+                else {
+                    "type": "function",
+                    "function": {
+                        "name": t.get("name"),
+                        "description": t.get("description"),
+                        "parameters": t.get("parameters"),
+                        **({} if t.get("strict") is None else {"strict": t["strict"]}),
+                    },
+                }
+                for t in raw_tools
+            ]
 
         def should_mask(message: dict) -> bool:
             assert "role" in message, "Message must have a role"

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -190,14 +190,16 @@ class SFTDataset(StatefulIterableDataset):
 
         # Parse available tools, if present - assumes OAI format
         # Reference: https://platform.openai.com/docs/guides/function-calling#function-tool-example
-        # Accepts either `tools` (single JSON string of a list) or `tool_defs`
-        # (list of dicts or list of JSON strings; the verifiers rollout format).
-        if "tools" in example and example["tools"]:
-            tools = json.loads(example["tools"])
-        elif "tool_defs" in example and example["tool_defs"]:
-            tools = [json.loads(t) if isinstance(t, str) else t for t in example["tool_defs"]]
-        else:
+        # Accepts either `tools` or `tool_defs` (the verifiers rollout format),
+        # in any of: JSON-encoded string of a list, list of dicts, or list of
+        # JSON-encoded strings. Result is always list[dict].
+        raw_tools = example.get("tools") if "tools" in example and example["tools"] else example.get("tool_defs")
+        if not raw_tools:
             tools = []
+        elif isinstance(raw_tools, str):
+            tools = json.loads(raw_tools)
+        else:
+            tools = [json.loads(t) if isinstance(t, str) else t for t in raw_tools]
 
         def should_mask(message: dict) -> bool:
             assert "role" in message, "Message must have a role"


### PR DESCRIPTION
## Summary

- SFT data loader now reads tool definitions from either `tools` (OAI convention) or `tool_defs` (verifiers rollout format), each accepted as a JSON-encoded list string OR a `list[dict]`.
- Tools arriving in the verifiers shape (`{name, description, parameters}` at top level) are converted to OAI form (`{type: "function", function: {...}}`) — mirroring what the orchestrator does in `_convert_tools_to_oai_format` — so any downstream chat template can consume them.
- Closes a silent training/inference mismatch: rollout-derived datasets (anything saved via verifiers / `vf-eval`) store tool defs under `tool_defs`. Before this patch SFT trained with an empty system block while vLLM injects the tool definitions at inference time — model sees a context it never saw during training.

## Background

Hit this while SFTing NemotronH-Nano-30B-A3B-Base on a `general_agent` subset built from local-solver verifier rollouts. Symptoms: model over-prosed at eval (64% prose answers vs 1% for the vendor instruct, ~16% for the vendor base) and collapsed below base on bfcl-v3 multi-turn at later checkpoints. Side-by-side render confirmed the system block was empty in training but ~1200 tokens at inference.

## Change

```python
raw_tools = example.get("tools", example.get("tool_defs"))
if not raw_tools:
    tools = []
else:
    if isinstance(raw_tools, str):
        raw_tools = json.loads(raw_tools)
    tools = [
        t if isinstance(t, dict) and t.get("type") == "function" and "function" in t
        else {
            "type": "function",
            "function": {
                "name": t.get("name"),
                "description": t.get("description"),
                "parameters": t.get("parameters"),
                **({} if t.get("strict") is None else {"strict": t["strict"]}),
            },
        }
        for t in raw_tools
    ]
```

Backwards-compatible: existing OAI-shaped `tools` JSON strings pass through unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SFT example preprocessing to accept and transform tool definitions, which can alter the rendered/tokenized training context for tool-using datasets and affect model behavior if formats are malformed.
> 
> **Overview**
> SFT dataset preprocessing now reads tool definitions from either `tools` or verifier-style `tool_defs`, accepting both JSON strings and in-memory lists.
> 
> Verifier-shaped tool entries are normalized into OpenAI function-calling format (`{"type":"function","function":{...}}`) so downstream chat templates/renderers receive consistent `tools` input instead of silently training without tool context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36cfcde56abd0ac340134da646bc7ef9d32e9891. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->