### PR TITLE
Revert "feat: opt-in renderer-based tokenization for SFT"

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -6,7 +6,6 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from prime_rl.configs.shared import (
     HeartbeatConfig,
-    RendererConfig,
     SlurmConfig,
     TrainerLogConfig,
     WandbConfig,
@@ -172,21 +171,6 @@ class SFTConfig(BaseConfig):
 
     # The tokenizer configuration
     tokenizer: TokenizerConfig = TokenizerConfig()
-
-    # The renderer configuration (only used when use_renderer=True)
-    renderer: RendererConfig = RendererConfig()
-
-    use_renderer: Annotated[
-        bool,
-        Field(
-            description=(
-                "If True, tokenize SFT samples through the `renderers` library "
-                "(single render() + message_indices mask) instead of the default "
-                "`build_incremental_token_mask` path. Required for chat templates "
-                "that render position-dependently (e.g. Qwen3, Qwen3.5)."
-            ),
-        ),
-    ] = False
 
     # The data configuration
     data: DataConfig = SFTDataConfig()
@@ -371,55 +355,6 @@ class SFTConfig(BaseConfig):
                 raise ValueError(
                     "Tracing more than 10 steps is not recommended as your trace will be massive. Remove this line if you really want to trace more steps."
                 )
-        return self
-
-    @model_validator(mode="after")
-    def validate_renderer_vs_vlm(self):
-        if self.use_renderer and self.model.vlm is not None:
-            raise ValueError(
-                "use_renderer is not supported for VLMs. The renderer tokenizes "
-                "text-only message dicts client-side and cannot handle image inputs."
-            )
-        return self
-
-    @model_validator(mode="after")
-    def validate_renderer_args(self):
-        # pool_size is orchestrator-only. An in-process renderer pool exists
-        # to amortize tokenization across concurrent rollouts in the
-        # orchestrator (many async requests render at once, HF fast
-        # tokenizers release the GIL during Rust encoding, so a pool of N
-        # tokenizer copies parallelizes well). SFT has no such concurrency:
-        # the StatefulDataLoader is constructed with num_workers=0, so the
-        # main process tokenizes one example at a time, between training
-        # steps. Across DP, each rank already owns its own renderer — an
-        # implicit pool of size world_size. Pooling within a rank gives
-        # nothing on top of that. Reject so callers don't silently set a
-        # knob that does nothing; if SFT tokenization ever becomes a
-        # bottleneck the fix is num_workers on the dataloader, not a pool.
-        if self.renderer.pool_size is not None:
-            raise ValueError(
-                f"renderer.pool_size={self.renderer.pool_size!r} is only used by the orchestrator. "
-                "SFT tokenizes synchronously (num_workers=0) and already gets one renderer per DP "
-                "rank — an in-process pool adds nothing. If tokenization is a bottleneck, raise "
-                "num_workers on the dataloader instead."
-            )
-
-        if self.use_renderer:
-            return self
-
-        renderer_args_set = []
-        if self.renderer.name != "auto":
-            renderer_args_set.append(f"renderer.name={self.renderer.name!r}")
-        if self.renderer.tool_parser is not None:
-            renderer_args_set.append(f"renderer.tool_parser={self.renderer.tool_parser!r}")
-        if self.renderer.reasoning_parser is not None:
-            renderer_args_set.append(f"renderer.reasoning_parser={self.renderer.reasoning_parser!r}")
-
-        if renderer_args_set:
-            raise ValueError(
-                "Renderer-specific args set without use_renderer=True: "
-                f"{', '.join(renderer_args_set)}. Either enable the renderer or remove these knobs."
-            )
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/trainer/sft/data.py
+++ b/src/prime_rl/trainer/sft/data.py
@@ -6,7 +6,6 @@ from typing import Literal, TypedDict, cast
 import torch
 from datasets import Dataset, interleave_datasets, load_dataset
 from jaxtyping import Bool, Int
-from renderers.base import Renderer, build_training_sample
 from torch import Tensor
 from torch.distributed.checkpoint.stateful import Stateful
 from torch.utils.data import IterableDataset, get_worker_info
@@ -128,7 +127,6 @@ class SFTDataset(StatefulIterableDataset):
         loss_mask_config: LossMaskConfig = LossMaskConfig(),
         max_examples: int | None = None,
         max_epochs: int | None = None,
-        renderer: Renderer | None = None,
     ):
         super().__init__()
         self.logger = get_logger()
@@ -141,8 +139,6 @@ class SFTDataset(StatefulIterableDataset):
         self.loss_mask_config = loss_mask_config
         self.max_examples = max_examples
         self.max_epochs = max_epochs
-        self.renderer = renderer
-        self._warned_chat_template_kwargs = False
 
         if self.tokenizer is None:
             self.logger.warning("No tokenizer provided, will not process examples")
@@ -210,35 +206,18 @@ class SFTDataset(StatefulIterableDataset):
                 case _:
                     raise ValueError(f"Invalid message role: {message['role']}")
 
-        if self.renderer is not None:
-            if example.get("chat_template_kwargs") and not self._warned_chat_template_kwargs:
-                self.logger.warning(
-                    "Example carries chat_template_kwargs but use_renderer=True; "
-                    "renderers don't forward chat_template_kwargs (model-specific "
-                    "renderers bake their template behavior in). These kwargs will "
-                    "be ignored. Further warnings suppressed for this dataset."
-                )
-                self._warned_chat_template_kwargs = True
-
-            input_ids, loss_mask = build_training_sample(
-                self.renderer,
+        try:
+            input_ids, loss_mask = build_incremental_token_mask(
+                self.tokenizer,
                 messages,
                 role_to_mask=should_mask,
                 tools=tools,
+                chat_template_kwargs=example.get("chat_template_kwargs", {}),
+                collapse_consecutive_tool_messages=True,
             )
-        else:
-            try:
-                input_ids, loss_mask = build_incremental_token_mask(
-                    self.tokenizer,
-                    messages,
-                    role_to_mask=should_mask,
-                    tools=tools,
-                    chat_template_kwargs=example.get("chat_template_kwargs", {}),
-                    collapse_consecutive_tool_messages=True,
-                )
-            except IncrementalTokenizationError as e:
-                self.logger.warning(f"Skipping example {example.get('__index', '')}: {e}")
-                return None
+        except IncrementalTokenizationError as e:
+            self.logger.warning(f"Skipping example {example.get('__index', '')}: {e}")
+            return None
 
         # If EOS token is not found, manually append it
         if not self.tokenizer.eos_token_id in input_ids:
@@ -558,7 +537,6 @@ def setup_dataset(
     *,
     max_epochs: int | None = None,
     raw_dataset: Dataset | None = None,
-    renderer: Renderer | None = None,
 ) -> StatefulIterableDataset:
     if config.type == "fake":
         return FakeDataset(
@@ -576,7 +554,6 @@ def setup_dataset(
             loss_mask_config=config.loss_mask,
             non_dp_size=non_dp_size,
             max_epochs=max_epochs,
-            renderer=renderer,
         )
     else:
         raise ValueError(f"Invalid dataset type: {config.type}")

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -4,8 +4,6 @@ import time
 from contextlib import nullcontext
 from datetime import timedelta
 
-from renderers.base import create_renderer
-from renderers.default import DefaultRenderer
 from ring_flash_attn import substitute_hf_flash_attn
 from torch.nn import CrossEntropyLoss
 
@@ -159,24 +157,6 @@ def train(config: SFTConfig):
     logger.info(f"Initializing tokenizer ({config.tokenizer})")
     tokenizer = setup_tokenizer(config.tokenizer)
 
-    renderer = None
-    if config.use_renderer:
-        renderer = create_renderer(
-            tokenizer,
-            renderer=config.renderer.name,
-            tool_parser=config.renderer.tool_parser,
-            reasoning_parser=config.renderer.reasoning_parser,
-        )
-        if isinstance(renderer, DefaultRenderer):
-            raise ValueError(
-                f"use_renderer=True for {config.tokenizer.name!r} resolved to DefaultRenderer. "
-                "DefaultRenderer falls back to incremental apply_chat_template and does NOT "
-                "fix position-dependent chat templates — the bug use_renderer is meant to solve. "
-                "Either use a model with a hand-coded renderer (see renderers.base.MODEL_RENDERER_MAP), "
-                "set [renderer] name=<hand-coded renderer> explicitly, or set use_renderer=false."
-            )
-        logger.info(f"Initialized {type(renderer).__name__} for {config.tokenizer.name}")
-
     # Set up the optimizer
     logger.info(f"Initializing optimizer ({config.optim})")
     optimizer = setup_optimizer(
@@ -195,7 +175,7 @@ def train(config: SFTConfig):
 
     # Set up the dataset and dataloader
     logger.info(f"Initializing data ({config.data})")
-    dataset = setup_dataset(tokenizer, config.data, config.model.cp, renderer=renderer)
+    dataset = setup_dataset(tokenizer, config.data, config.model.cp)
     dataloader = setup_dataloader(dataset, config.data)
     dataiter = iter(dataloader)
 
@@ -303,12 +283,7 @@ def train(config: SFTConfig):
 
     def run_validation(step: int) -> None:
         val_dataset = setup_dataset(
-            tokenizer,
-            config.val.data,
-            config.model.cp,
-            max_epochs=1,
-            raw_dataset=val_raw_dataset,
-            renderer=renderer,
+            tokenizer, config.val.data, config.model.cp, max_epochs=1, raw_dataset=val_raw_dataset
         )
         val_dataloader = setup_dataloader(val_dataset, config.val.data)
 


### PR DESCRIPTION
Reverts PrimeIntellect-ai/prime-rl#2493

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SFT tokenization back to the incremental `apply_chat_template`-based path for all runs, which can affect training correctness for models with position-dependent chat templates. Scope is limited to SFT config/data/training wiring but touches core sample construction.
> 
> **Overview**
> Reverts the opt-in renderer-based tokenization flow for SFT training.
> 
> This removes `renderer`/`use_renderer` knobs and related validation from `SFTConfig`, deletes renderer initialization in `sft/train.py`, and drops renderer plumbing in `sft/data.py` so samples are always tokenized via `build_incremental_token_mask` (including passing through per-example `chat_template_kwargs`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac1bd8f8f7b920174c125cda83ff5352fa6ec98f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->