### PR TITLE
Handle disregarded verifier groups in scheduler

### DIFF
--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -448,6 +448,12 @@ class Scheduler:
                     rollouts: list[vf.RolloutOutput] = result if isinstance(result, list) else [result]
                     self.total_rollouts_by_env[env_name] += len(rollouts)
 
+                    if env.requires_group_scoring and not rollouts:
+                        assert group_id is not None
+                        self.dropped_groups_by_env[env_name] += 1
+                        await self.drop_group(group_id)
+                        continue
+
                     # Check for empty/errored rollouts and reschedule
                     valid_rollouts = []
                     has_failures = False


### PR DESCRIPTION
## Summary
- Treat a group-scoring verifier `run_group(...)` result of `[]` as a dropped/disregarded group.
- Remove that group from scheduler state so training samples a replacement example instead of leaving the group stuck with no pending or completed rollouts.
- Reuse the existing `dropped_groups` metrics for visibility without duplicating Verifiers-side disregard logs.

## Why
In async training, an example can be scheduled at time T1 but judged at time T2. Between scheduling and judgment, the example may stop being valid training signal: a website changes, a target page disappears, a job posting closes, a reference answer becomes unverifiable, judge/rubric expectations change, an external API returns different state, or a synthetic task is discovered to be logically inconsistent.

When Verifiers decides the example itself is invalid, Prime-RL should not train on a zero reward or retry it as infra failure. It should drop the group and sample a replacement example.

## Validation
- `git diff --check`
- Addressed CI `ruff format --check` failure by applying the formatter-expected scheduler.py change locally.
- `uv run pytest tests/unit/orchestrator/test_scheduler.py` could not start on this macOS host because the Prime-RL lockfile only supports Linux platforms.
- Local `ruff format --check --config=pyproject.toml src/prime_rl/orchestrator/scheduler.py` could not run because `ruff` is not installed outside the Linux-only uv environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes scheduler control flow for group-scoring envs by treating an empty `run_group` result as an intentional drop, which can affect training sample selection and throughput if misclassified.
> 
> **Overview**
> Prevents group-scoring examples from getting stuck when a verifier returns an empty `run_group(...)` result by treating `[]` as a *dropped/disregarded group*.
> 
> When this occurs, the scheduler now increments existing `dropped_groups` metrics and calls `drop_group(...)` to remove the group and cancel any remaining in-flight work, allowing training to naturally resample a replacement example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44c3b02d7426bf997cfc41bcbda1943bf033a050. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->