### PR TITLE
Scrub padded vLLM model inputs

### DIFF
--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -1,5 +1,7 @@
 import torch
 
+from prime_rl.inference.vllm.padded_input_scrub import monkey_patch_vllm_padded_input_scrub
+
 
 def transformers_v5_compat():
     """vLLM general plugin: patch transformers v5 config attrs that vLLM still expects.
@@ -16,6 +18,7 @@ def transformers_v5_compat():
     _patch_lora_key_prefix()
     monkey_patch_dp_engine_core_pause_resume_deadlock()
     monkey_patch_vllm_layerwise_reload_alias_buffers()
+    monkey_patch_vllm_padded_input_scrub()
 
 
 def monkey_patch_vllm_layerwise_reload_alias_buffers():

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -29,6 +29,8 @@ def monkey_patch_vllm_layerwise_reload_alias_buffers():
     # storage *after* the parameter has been correctly reloaded. Skip the copy
     # for any buffer that shares storage with a parameter; _place_kernel_tensors
     # re-registers the original view, which trivially reflects the parameter.
+    # Remove this patch once https://github.com/vllm-project/vllm/pull/42481 is
+    # included in the vLLM release we pin/use.
     from vllm.logger import init_logger
     from vllm.model_executor.model_loader.reload import layerwise as reload_layerwise
 

--- a/src/prime_rl/inference/vllm/padded_input_scrub.py
+++ b/src/prime_rl/inference/vllm/padded_input_scrub.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import logging
+import threading
+from collections.abc import Sequence
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_INSTALL_LOCK = threading.Lock()
+_INSTALLED = False
+
+
+def monkey_patch_vllm_padded_input_scrub() -> None:
+    """Zero vLLM's padded model inputs before graph replay.
+
+    vLLM pads decode batches up to CUDA graph capture sizes. Some kernels read
+    model-input tensors past the scheduled-token prefix, so stale values in the
+    padded tail can affect replayed decode graphs. Keep this shim until the
+    vLLM-side fix is available in the pinned runtime.
+    """
+    global _INSTALLED
+    with _INSTALL_LOCK:
+        if _INSTALLED:
+            return
+
+        from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+
+        if getattr(GPUModelRunner, "_prime_rl_padded_input_scrub", False):
+            _INSTALLED = True
+            return
+
+        original_preprocess = GPUModelRunner._preprocess
+
+        def _patched_preprocess(
+            self: Any,
+            scheduler_output: Any,
+            intermediate_tensors: Any | None,
+        ) -> tuple[Any, ...]:
+            result = original_preprocess(self, scheduler_output, intermediate_tensors)
+
+            num_scheduled_tokens = int(scheduler_output.total_num_scheduled_tokens)
+            num_input_tokens = int(result[0])
+            _zero_padded_model_inputs(result, num_scheduled_tokens, num_input_tokens)
+            return result
+
+        GPUModelRunner._preprocess = _patched_preprocess
+        GPUModelRunner._prime_rl_padded_input_scrub = True
+        _INSTALLED = True
+
+    logger.warning("Enabled vLLM padded model-input scrub.")
+
+
+def _zero_padded_model_inputs(
+    preprocess_result: Sequence[Any],
+    num_scheduled_tokens: int,
+    num_input_tokens: int,
+) -> None:
+    """Zero the model-input tail beyond scheduled tokens in-place."""
+    if num_input_tokens <= num_scheduled_tokens:
+        return
+
+    input_ids = preprocess_result[1]
+    inputs_embeds = preprocess_result[2]
+    positions = preprocess_result[3]
+    pad_slice = slice(num_scheduled_tokens, num_input_tokens)
+
+    if input_ids is not None:
+        input_ids[pad_slice].zero_()
+    if inputs_embeds is not None:
+        inputs_embeds[pad_slice].zero_()
+    if positions is not None:
+        if positions.ndim == 1:
+            positions[pad_slice].zero_()
+        else:
+            positions[..., pad_slice].zero_()

--- a/src/prime_rl/inference/vllm/padded_input_scrub.py
+++ b/src/prime_rl/inference/vllm/padded_input_scrub.py
@@ -18,6 +18,9 @@ def monkey_patch_vllm_padded_input_scrub() -> None:
     model-input tensors past the scheduled-token prefix, so stale values in the
     padded tail can affect replayed decode graphs. Keep this shim until the
     vLLM-side fix is available in the pinned runtime.
+
+    Remove this patch once https://github.com/vllm-project/vllm/pull/42779 is
+    included in the vLLM release we pin/use.
     """
     global _INSTALLED
     with _INSTALL_LOCK:

--- a/src/prime_rl/inference/vllm/padded_input_scrub.py
+++ b/src/prime_rl/inference/vllm/padded_input_scrub.py
@@ -35,13 +35,22 @@ def monkey_patch_vllm_padded_input_scrub() -> None:
         def _patched_preprocess(
             self: Any,
             scheduler_output: Any,
-            intermediate_tensors: Any | None,
+            num_input_tokens: int,
+            intermediate_tensors: Any | None = None,
         ) -> tuple[Any, ...]:
-            result = original_preprocess(self, scheduler_output, intermediate_tensors)
+            result = original_preprocess(
+                self,
+                scheduler_output,
+                num_input_tokens,
+                intermediate_tensors,
+            )
 
             num_scheduled_tokens = int(scheduler_output.total_num_scheduled_tokens)
-            num_input_tokens = int(result[0])
-            _zero_padded_model_inputs(result, num_scheduled_tokens, num_input_tokens)
+            _zero_padded_model_inputs(
+                result,
+                num_scheduled_tokens,
+                int(num_input_tokens),
+            )
             return result
 
         GPUModelRunner._preprocess = _patched_preprocess
@@ -60,9 +69,9 @@ def _zero_padded_model_inputs(
     if num_input_tokens <= num_scheduled_tokens:
         return
 
-    input_ids = preprocess_result[1]
-    inputs_embeds = preprocess_result[2]
-    positions = preprocess_result[3]
+    input_ids = preprocess_result[0]
+    inputs_embeds = preprocess_result[1]
+    positions = preprocess_result[2]
     pad_slice = slice(num_scheduled_tokens, num_input_tokens)
 
     if input_ids is not None:

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -134,6 +134,7 @@ from prime_rl.inference.patches import (
     monkey_patch_harmony_stop_token_propagation,
     monkey_patch_load_lora_adapter,
     monkey_patch_tokenize_params_validation,
+    monkey_patch_vllm_padded_input_scrub,
 )
 
 # NOTE: Fix harmony stop token propagation for GPT-OSS models
@@ -145,6 +146,9 @@ monkey_patch_load_lora_adapter()
 # NOTE: Monkeypatch TokenizeParams to fix overly conservative validation
 # Still needed in vLLM 0.20 — upstream rejects prompt_len > max_model_len - max_tokens
 monkey_patch_tokenize_params_validation()
+# NOTE: Optional mitigation for vLLM padded decode inputs until the native fix
+# is available in our pinned runtime.
+monkey_patch_vllm_padded_input_scrub()
 
 logger = init_logger("vllm.entrypoints.openai.api_server")
 

--- a/tests/unit/inference/test_padded_input_scrub.py
+++ b/tests/unit/inference/test_padded_input_scrub.py
@@ -1,14 +1,76 @@
+from types import SimpleNamespace
+
 import torch
 
-from prime_rl.inference.vllm.padded_input_scrub import _zero_padded_model_inputs
+import prime_rl.inference.vllm.padded_input_scrub as padded_input_scrub
+from prime_rl.inference.vllm.padded_input_scrub import (
+    _zero_padded_model_inputs,
+    monkey_patch_vllm_padded_input_scrub,
+)
+
+
+def test_monkey_patch_preprocess_matches_vllm_preprocess_signature(monkeypatch):
+    from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+
+    calls = {}
+
+    def fake_preprocess(
+        self,
+        scheduler_output,
+        num_input_tokens,
+        intermediate_tensors=None,
+    ):
+        calls["args"] = (
+            self,
+            scheduler_output,
+            num_input_tokens,
+            intermediate_tensors,
+        )
+        return (
+            torch.tensor([10, 11, 12, 991, 992]),
+            None,
+            torch.tensor([0, 1, 2, 991, 992]),
+            intermediate_tensors,
+            {},
+            None,
+        )
+
+    monkeypatch.setattr(padded_input_scrub, "_INSTALLED", False)
+    monkeypatch.setattr(GPUModelRunner, "_preprocess", fake_preprocess)
+    monkeypatch.setattr(
+        GPUModelRunner,
+        "_prime_rl_padded_input_scrub",
+        False,
+        raising=False,
+    )
+
+    monkey_patch_vllm_padded_input_scrub()
+
+    self = object()
+    scheduler_output = SimpleNamespace(total_num_scheduled_tokens=3)
+    intermediate_tensors = object()
+    result = GPUModelRunner._preprocess(self, scheduler_output, 5, intermediate_tensors)
+
+    assert calls["args"] == (
+        self,
+        scheduler_output,
+        5,
+        intermediate_tensors,
+    )
+    assert result[0].tolist() == [10, 11, 12, 0, 0]
+    assert result[2].tolist() == [0, 1, 2, 0, 0]
 
 
 def test_zero_padded_model_inputs_leaves_scheduled_prefix_intact():
     input_ids = torch.tensor([10, 11, 12, 991, 992])
     positions = torch.tensor([0, 1, 2, 991, 992])
-    preprocess_result = (5, input_ids, None, positions)
+    preprocess_result = (input_ids, None, positions, None, {}, None)
 
-    _zero_padded_model_inputs(preprocess_result, num_scheduled_tokens=3, num_input_tokens=5)
+    _zero_padded_model_inputs(
+        preprocess_result,
+        num_scheduled_tokens=3,
+        num_input_tokens=5,
+    )
 
     assert input_ids.tolist() == [10, 11, 12, 0, 0]
     assert positions.tolist() == [0, 1, 2, 0, 0]
@@ -24,9 +86,13 @@ def test_zero_padded_model_inputs_zeroes_embeddings_and_mrope_positions():
             [0, 1, 2, 995, 996],
         ]
     )
-    preprocess_result = (5, None, inputs_embeds, positions)
+    preprocess_result = (None, inputs_embeds, positions, None, {}, None)
 
-    _zero_padded_model_inputs(preprocess_result, num_scheduled_tokens=3, num_input_tokens=5)
+    _zero_padded_model_inputs(
+        preprocess_result,
+        num_scheduled_tokens=3,
+        num_input_tokens=5,
+    )
 
     torch.testing.assert_close(inputs_embeds[:3], torch.ones((3, 4)))
     torch.testing.assert_close(inputs_embeds[3:], torch.zeros((2, 4)))
@@ -40,9 +106,13 @@ def test_zero_padded_model_inputs_zeroes_embeddings_and_mrope_positions():
 def test_zero_padded_model_inputs_noops_without_padding():
     input_ids = torch.tensor([10, 11, 12])
     positions = torch.tensor([0, 1, 2])
-    preprocess_result = (3, input_ids, None, positions)
+    preprocess_result = (input_ids, None, positions, None, {}, None)
 
-    _zero_padded_model_inputs(preprocess_result, num_scheduled_tokens=3, num_input_tokens=3)
+    _zero_padded_model_inputs(
+        preprocess_result,
+        num_scheduled_tokens=3,
+        num_input_tokens=3,
+    )
 
     assert input_ids.tolist() == [10, 11, 12]
     assert positions.tolist() == [0, 1, 2]

--- a/tests/unit/inference/test_padded_input_scrub.py
+++ b/tests/unit/inference/test_padded_input_scrub.py
@@ -1,0 +1,48 @@
+import torch
+
+from prime_rl.inference.vllm.padded_input_scrub import _zero_padded_model_inputs
+
+
+def test_zero_padded_model_inputs_leaves_scheduled_prefix_intact():
+    input_ids = torch.tensor([10, 11, 12, 991, 992])
+    positions = torch.tensor([0, 1, 2, 991, 992])
+    preprocess_result = (5, input_ids, None, positions)
+
+    _zero_padded_model_inputs(preprocess_result, num_scheduled_tokens=3, num_input_tokens=5)
+
+    assert input_ids.tolist() == [10, 11, 12, 0, 0]
+    assert positions.tolist() == [0, 1, 2, 0, 0]
+
+
+def test_zero_padded_model_inputs_zeroes_embeddings_and_mrope_positions():
+    inputs_embeds = torch.ones((5, 4))
+    inputs_embeds[3:] = 7
+    positions = torch.tensor(
+        [
+            [0, 1, 2, 991, 992],
+            [0, 1, 2, 993, 994],
+            [0, 1, 2, 995, 996],
+        ]
+    )
+    preprocess_result = (5, None, inputs_embeds, positions)
+
+    _zero_padded_model_inputs(preprocess_result, num_scheduled_tokens=3, num_input_tokens=5)
+
+    torch.testing.assert_close(inputs_embeds[:3], torch.ones((3, 4)))
+    torch.testing.assert_close(inputs_embeds[3:], torch.zeros((2, 4)))
+    assert positions.tolist() == [
+        [0, 1, 2, 0, 0],
+        [0, 1, 2, 0, 0],
+        [0, 1, 2, 0, 0],
+    ]
+
+
+def test_zero_padded_model_inputs_noops_without_padding():
+    input_ids = torch.tensor([10, 11, 12])
+    positions = torch.tensor([0, 1, 2])
+    preprocess_result = (3, input_ids, None, positions)
+
+    _zero_padded_model_inputs(preprocess_result, num_scheduled_tokens=3, num_input_tokens=3)
+
+    assert input_ids.tolist() == [10, 11, 12]
+    assert positions.tolist() == [0, 1, 2]


### PR DESCRIPTION
## Summary

Adds a prime-rl shim for the vLLM padded decode-input NaN issue:

- Installs a small `GPUModelRunner._preprocess` wrapper through prime-rl's existing vLLM patch path.
- The wrapper zeros `input_ids`, `inputs_embeds`, and `positions` beyond `scheduler_output.total_num_scheduled_tokens`.
- The patch is registered through the existing `vllm.general_plugins` path, so it runs in spawned vLLM workers, and is also called from the prime-rl vLLM server process as a backstop.
- CPU unit coverage verifies the scheduled-token prefix is preserved while the padded tail is cleared for both normal and mrope-style positions.

This is intended as a temporary prime-rl mitigation until the pinned vLLM runtime includes the native upstream fix.

## Why this fixes the NaN

vLLM pads decode batches up to CUDA graph capture sizes. For a batch with `N` scheduled tokens and a larger captured input width, model-input tensors can contain stale values in the padded tail. In our Nemotron Nano SWE repro, those stale padded inputs were sufficient to poison replayed decode graphs and surface as:

```text
BadRequestError: Out of range float values are not JSON compliant: nan
```

The native vLLM-side fix we tested zeros padded model inputs before model execution. This PR carries the same behavioral invariant in prime-rl for the currently pinned vLLM runtime: tokens beyond the scheduled prefix must be inert before graph replay.

## Repro Evidence

The realistic reproducer was the hosted-style Nemotron Nano SWE workload, not a single-prompt synthetic loop:

- model: `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16`
- workload: `daniel/swe` R2E-Gym style rollout workload
- vLLM graph mode: default `FULL_AND_PIECEWISE`
- failure signature: vLLM response JSON serialization fails because output contains `nan`

With this scrub enabled in the prime-rl patch path, the same workload stayed healthy in the validation run:

- SLURM job: `18741`
- run dir: `/beegfs/daniel/nemotron-nano-swe-step7-padded-input-scrub-20260515-220538`
- scrub records observed: ~58k padded-input scrubs
- bad capture buckets were exercised, including widths around `193->200`, `201->208`, `209->216`, `218->224`, `227->232`, and `242->248`
- orchestrator NaN errors: `0`
- non-finite trace files: `0`

This is the same workload family where the default path had reproduced the NaN.

## Validation

Ran in a clean worktree off current `origin/main`:

```bash
uv run pre-commit run --all-files
uv run pytest tests/unit/inference/test_padded_input_scrub.py
```

Both passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Monkey-patches vLLM’s `GPUModelRunner._preprocess` in the serving path, which can affect decode correctness/performance if vLLM’s return structure or padding semantics differ across versions; scope is limited to zeroing padded tails and is covered by unit tests.
> 
> **Overview**
> Adds a temporary vLLM shim that **zeros padded decode model inputs** (`input_ids`, `inputs_embeds`, `positions`) beyond `scheduler_output.total_num_scheduled_tokens` to prevent stale padded values from influencing CUDA-graph replay.
> 
> The patch is installed via the existing `vllm.general_plugins` path (`transformers_v5_compat`) and also applied in the vLLM API server startup as a backstop, with unit tests validating prefix preservation and correct zeroing for both 1D and mRoPE-style position tensors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c831589dd2184fa1f174eeb7691480ca1b8379c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->