### PR TITLE
fix(sft): prevent validation deadlock with FSDP

### DIFF
--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -265,8 +265,15 @@ def train(config: SFTConfig):
         total_token_count = torch.tensor(0, dtype=torch.int64, device="cuda")
         nan_count = torch.tensor(0, device="cuda")
 
+        has_data = torch.ones(1, dtype=torch.int32, device="cuda")
+        data_iter = iter(data_iter)
         with torch.no_grad():
-            for micro_batch in data_iter:
+            while True:
+                micro_batch = next(data_iter, None)
+                has_data.fill_(micro_batch is not None)
+                dist.all_reduce(has_data, op=dist.ReduceOp.MIN)
+                if has_data.item() == 0:
+                    break
                 loss_sum, token_count = compute_loss(micro_batch)
                 if not torch.isnan(loss_sum.detach()):
                     total_loss_sum += loss_sum.detach()


### PR DESCRIPTION
Fix https://github.com/PrimeIntellect-ai/prime-rl/issues/2515: unsynchronized iteration in `run_eval_loop` that deadlocks when ranks have different validation batch counts.

With FSDP, each forward pass is a collective. Ranks get different batch counts from variable-length data. When one rank exits the loop first, others deadlock on the all-gather.

Fix: one scalar all-reduce per batch so all ranks exit together.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes distributed validation control flow to add a per-batch `all_reduce` synchronization, which could affect validation performance or mask dataloader issues but is localized to eval.
> 
> **Overview**
> Fixes a distributed validation deadlock where ranks could iterate different numbers of validation batches under FSDP and hang in collectives.
> 
> `run_eval_loop` now iterates with `next(..., None)` and uses a per-batch `dist.all_reduce` on a `has_data` flag so **all ranks exit the eval loop together** before aggregating loss/token/NAN counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c890d17d3185c85ab383fa00d2d98707ab53ed38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->