### PR TITLE
Fix sparse MLA backward TileLang NaNs

### DIFF
--- a/src/prime_rl/trainer/models/kernels/sparse_mla_bwd.py
+++ b/src/prime_rl/trainer/models/kernels/sparse_mla_bwd.py
@@ -91,7 +91,8 @@ def postprocess(
     pass_configs={
         tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
         tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
-        tilelang.PassConfigKey.TL_ENABLE_AGGRESSIVE_SHARED_MEMORY_MERGE: True,
+        # Avoid TileLang MLA backward NaNs: https://github.com/tile-ai/tilelang/issues/2199
+        tilelang.PassConfigKey.TL_ENABLE_AGGRESSIVE_SHARED_MEMORY_MERGE: False,
     },
 )
 def bwd(


### PR DESCRIPTION
## Summary
- Disable TileLang aggressive shared-memory merge for the sparse MLA backward kernel.
- Add an inline link to the upstream TileLang issue: https://github.com/tile-ai/tilelang/issues/2199

## Verification
- `uv run python -m py_compile src/prime_rl/trainer/models/kernels/sparse_mla_bwd.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single TileLang `pass_configs` toggle plus comment update, but it may impact kernel performance and should be verified on target GPUs for both correctness and throughput.
> 
> **Overview**
> Prevents NaNs in the TileLang sparse MLA backward kernel by **disabling** `TL_ENABLE_AGGRESSIVE_SHARED_MEMORY_MERGE` in `sparse_mla_bwd.py`.
> 
> Adds an inline reference to the upstream TileLang issue (`tile-ai/tilelang#2199`) documenting the workaround.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b09f0f884d2b42b6ba9d6afed8a860cd1edb6d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->