### PR TITLE
[codex] make renderers default for rollouts

### DIFF
--- a/configs/ci/nightly/multimodal_color_codeword.toml
+++ b/configs/ci/nightly/multimodal_color_codeword.toml
@@ -16,6 +16,8 @@ language_model_attr = "model.language_model"
 [orchestrator]
 batch_size = 256
 rollouts_per_example = 16
+use_token_client = false
+use_renderer = false
 
 [orchestrator.train.sampling]
 max_completion_tokens = 64

--- a/configs/multimodal/rl_color_codeword.toml
+++ b/configs/multimodal/rl_color_codeword.toml
@@ -11,6 +11,8 @@ language_model_attr = "model.language_model"
 [orchestrator]
 batch_size = 256
 rollouts_per_example = 16
+use_token_client = false
+use_renderer = false
 
 
 [orchestrator.train.sampling]

--- a/configs/multimodal/rl_color_codeword_test.toml
+++ b/configs/multimodal/rl_color_codeword_test.toml
@@ -12,6 +12,8 @@ language_model_attr = "model.language_model"
 [orchestrator]
 batch_size = 16
 rollouts_per_example = 2
+use_token_client = false
+use_renderer = false
 
 [orchestrator.train.sampling]
 max_completion_tokens = 32

--- a/docs/on_policy_distillation.md
+++ b/docs/on_policy_distillation.md
@@ -72,6 +72,8 @@ type = "sft"
 
 [orchestrator]
 use_token_client = false
+use_renderer = false
+use_sft_loss = true
 
 [orchestrator.teacher_rollout_model.client]
 base_url = ["https://your-openai-compatible-endpoint/v1"]

--- a/examples/alphabet_sort/sft_distill_hard.toml
+++ b/examples/alphabet_sort/sft_distill_hard.toml
@@ -30,6 +30,7 @@ save_adapter_separately = true
 batch_size = 256
 rollouts_per_example = 4
 use_token_client = false
+use_renderer = false
 use_sft_loss = true
 
 [orchestrator.train.sampling]

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -1121,23 +1121,23 @@ class OrchestratorConfig(BaseConfig):
     use_token_client: Annotated[
         bool,
         Field(
-            description="Whether to use the token-in-token-out (TITO) client for training across all environments. "
+            description="Whether to use the server-tokenized token-in-token-out (TITO) client for training across all environments. "
             "WARNING: Only use this if your environment has a linear history and the chat template has the extension "
             "property (i.e. no tokens are ever removed or inserted by the chat template). Mutually exclusive with "
             "``use_renderer``."
         ),
-    ] = True
+    ] = False
 
     use_renderer: Annotated[
         bool,
         Field(
-            description="Whether to use the renderer client (client-side tokenization via the ``renderers`` package, "
+            description="Whether to use the renderer-backed TITO client (client-side tokenization via the ``renderers`` package, "
             "served by ``/v1/generate``). Mutually exclusive with ``use_token_client``. When True, the "
-            "``[orchestrator.renderer]`` block (name / tool_parser / reasoning_parser / pool_size) "
-            "applies; when False those fields must be left at their defaults. Not supported for VLMs — "
-            "VLMs must use the token client (TITO) so image preprocessing and chat templating stay server-side."
+            "``[orchestrator.renderer]`` block (name / tool_parser / reasoning_parser / pool_size) applies. "
+            "This is the default for text-only rollouts. Not supported for VLMs — VLMs must use MITO so "
+            "image preprocessing and chat templating stay server-side."
         ),
-    ] = False
+    ] = True
 
     env_install_prerelease: Annotated[
         bool,
@@ -1223,18 +1223,18 @@ class OrchestratorConfig(BaseConfig):
     def validate_client_mode(self):
         """The two client toggles select among three exclusive modes:
 
-        - ``use_token_client=True``  + ``use_renderer=False`` → TITO  (default)
-        - ``use_token_client=False`` + ``use_renderer=True``  → renderer
+        - ``use_token_client=False`` + ``use_renderer=True``  → renderer-backed TITO (default)
+        - ``use_token_client=True``  + ``use_renderer=False`` → server-tokenized TITO
         - ``use_token_client=False`` + ``use_renderer=False`` → MITO
 
-        Both True is invalid: TITO and renderer are different wire protocols
-        (server-side templating vs client-side tokenization).
+        Both True is invalid: renderer-backed TITO and server-tokenized TITO are
+        different wire protocols (client-side vs server-side tokenization).
         """
         if self.use_token_client and self.use_renderer:
             raise ValueError(
                 "orchestrator.use_token_client and orchestrator.use_renderer are mutually exclusive. "
-                "Pick one: token client (TITO, server-side templating) or renderer client (client-side "
-                "tokenization)."
+                "Pick one TITO path: renderer client (client-side tokenization) or token client "
+                "(server-side tokenization)."
             )
         return self
 
@@ -1242,12 +1242,12 @@ class OrchestratorConfig(BaseConfig):
     def validate_renderer_vs_vlm(self):
         """The renderer client takes plain message dicts and tokenizes
         them client-side. VLMs need server-side image preprocessing and
-        chat templating, so they must use the token client (TITO) — fail
+        chat templating, so they must use MITO — fail
         loudly when both are set."""
         if self.use_renderer and self.model.vlm is not None:
             raise ValueError(
-                "orchestrator.use_renderer is not supported for VLMs. Use the token client "
-                "(``use_token_client=true``, the default) so image preprocessing and chat "
+                "orchestrator.use_renderer is not supported for VLMs. Use MITO "
+                "(``use_token_client=false`` and ``use_renderer=false``) so image preprocessing and chat "
                 "templating stay on the inference server."
             )
         return self

--- a/packages/prime-rl-configs/src/prime_rl/configs/shared.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/shared.py
@@ -135,7 +135,7 @@ class BaseModelConfig(BaseConfig):
 class RendererConfig(BaseConfig):
     """Configures the client-side renderer (chat-template + response parsing).
 
-    Only consumed when ``orchestrator.use_renderer = true``. The renderer
+    Consumed when ``use_renderer = true``. The renderer
     owns both directions: render messages → token ids on the client, and
     parse model output tokens → structured ``content`` / ``reasoning_content``
     / ``tool_calls``.

--- a/skills/config/SKILL.md
+++ b/skills/config/SKILL.md
@@ -157,6 +157,10 @@ If you wish to configure values of the default variant, you don't need to set th
 
 For hosted multi-tenant runs where the trainer image's `trainer.loss.type` is fixed, the orchestrator exposes a per-run override that forces SFT loss on every micro-batch without rebuilding the trainer. Set `orchestrator.use_sft_loss = true` alongside `orchestrator.teacher_rollout_model`; both must be configured together (the orchestrator validator enforces this). The orchestrator stamps each `TrainingSample.sft_loss = True`, which the trainer's `compute_loss` honors by dispatching to `sft_loss_fn` per batch — independent of the trainer's configured default loss.
 
+### RL rollout client defaults
+
+For text-only RL rollouts, the orchestrator defaults to renderer-backed TITO (`use_renderer = true`, `use_token_client = false`). VLM configs must explicitly use MITO (`use_token_client = false`, `use_renderer = false`) so image preprocessing and chat templating stay server-side. External teacher rollouts must also set `use_renderer = false`.
+
 ### Model fields
 
 For `BaseModel | None` fields (like `[ckpt]`, `[wandb]`, `[compile]`), a bare flag enables them with defaults:

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -903,12 +903,13 @@ async def setup_rollout_inference_pool(
       - external teacher rollout → MITO (``openai_chat_completions``),
         forced regardless of the toggles (config-level validator
         rejects ``use_token_client`` / ``use_renderer`` in that case)
-      - ``use_renderer=True``  → renderer client (``/v1/generate``).
+      - ``use_renderer=True``  → renderer-backed TITO client (``/v1/generate``).
+        Default for text-only rollouts.
         Not allowed for VLMs (validated at config time).
-      - ``use_token_client=True`` → TITO
+      - ``use_token_client=True`` → server-tokenized TITO
         (``openai_chat_completions_token``, ``/v1/chat/completions/tokens``).
-        Default. VLMs land here too.
       - both False → MITO (``openai_chat_completions``).
+        VLMs land here too.
     """
     if config.teacher_rollout_model is not None:
         logger.info("Using external rollout model (MITO) without renderer client")
@@ -943,7 +944,7 @@ async def setup_rollout_inference_pool(
 
     train_client_type = "openai_chat_completions_token" if config.use_token_client else "openai_chat_completions"
     if config.use_token_client:
-        logger.info("Using token client (TITO) for rollouts — server-side templating, /v1/chat/completions/tokens")
+        logger.info("Using server-tokenized TITO for rollouts — /v1/chat/completions/tokens")
     else:
         logger.info("Using MITO (openai_chat_completions) for rollouts")
     inference_pool = await setup_inference_pool(

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -157,6 +157,36 @@ def test_removed_fused_lm_head_chunk_size_field_is_rejected():
         TrainerModelConfig.model_validate({"fused_lm_head_chunk_size": "auto"})
 
 
+def test_orchestrator_vlm_configs_must_disable_renderer():
+    with pytest.raises(ValidationError, match="orchestrator.use_renderer is not supported for VLMs"):
+        OrchestratorConfig.model_validate(
+            {
+                "model": {
+                    "vlm": {
+                        "vision_encoder_attr": "model.visual",
+                        "language_model_attr": "model.language_model",
+                    }
+                }
+            }
+        )
+
+    config = OrchestratorConfig.model_validate(
+        {
+            "model": {
+                "vlm": {
+                    "vision_encoder_attr": "model.visual",
+                    "language_model_attr": "model.language_model",
+                }
+            },
+            "use_token_client": False,
+            "use_renderer": False,
+        }
+    )
+
+    assert config.use_token_client is False
+    assert config.use_renderer is False
+
+
 def test_selective_activation_checkpointing_requires_custom_impl():
     with pytest.raises(ValidationError, match="Selective activation checkpointing requires model.impl='custom'"):
         TrainerModelConfig.model_validate({"impl": "hf", "ac": {"mode": "selective"}})


### PR DESCRIPTION
## Summary

- Make the orchestrator default to renderer-backed TITO for text-only RL by setting `use_renderer=true` and `use_token_client=false` by default.
- Keep VLM configs on MITO by setting both `use_renderer=false` and `use_token_client=false`, and keep external teacher-rollout configs explicit about non-renderer mode.
- Update config docs, the config skill, runtime comments, and VLM validation coverage for the new rollout-mode defaults.

## Validation

- `uv run pytest tests/unit/test_configs.py`
- `uv run pytest tests/unit/test_configs.py tests/unit/orchestrator/test_orchestrator_setup.py tests/unit/utils/test_client.py tests/unit/utils/test_elastic.py`