### PR TITLE
fix(orchestrator): trim glibc heap after each step to prevent RSS growth

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -1,4 +1,5 @@
 import asyncio
+import ctypes
 import gc
 import os
 import time
@@ -797,6 +798,10 @@ async def orchestrate(config: OrchestratorConfig):
         del train_rollouts, train_examples, training_batch, vlm_cache
         del results_df, metrics_df
         gc.collect()
+        # Return free glibc heap pages to the OS. numpy/pandas allocate array data
+        # via malloc (outside Python's allocator), so gc.collect() alone doesn't
+        # reclaim the RSS. malloc_trim(0) forces glibc to return freed pages.
+        ctypes.CDLL("libc.so.6").malloc_trim(0)
 
         event_loop_lag_monitor.reset()
 

--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -189,7 +189,6 @@ class WandbMonitor(Monitor):
             self.samples_table.add_data(*sample.values())
 
         wandb.log({"samples": self.samples_table, "step": step})
-        self.samples_table = wandb.Table(columns=self.samples_cols, log_mode="INCREMENTAL")
         self.last_log_samples_step = step
         self.logger.debug(f"Logged samples at step {step} to W&B table in {time.perf_counter() - start_time:.2f}s")
 
@@ -225,7 +224,6 @@ class WandbMonitor(Monitor):
             self.eval_samples_table.add_data(*sample.values())
 
         wandb.log({"eval/samples": self.eval_samples_table, "step": step})
-        self.eval_samples_table = wandb.Table(columns=self.eval_samples_cols, log_mode="INCREMENTAL")
 
     def log_distributions(self, distributions: dict[str, list[float]], step: int) -> None:
         """Log distributions (no-op for W&B)."""

--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -189,6 +189,7 @@ class WandbMonitor(Monitor):
             self.samples_table.add_data(*sample.values())
 
         wandb.log({"samples": self.samples_table, "step": step})
+        self.samples_table = wandb.Table(columns=self.samples_cols, log_mode="INCREMENTAL")
         self.last_log_samples_step = step
         self.logger.debug(f"Logged samples at step {step} to W&B table in {time.perf_counter() - start_time:.2f}s")
 
@@ -224,6 +225,7 @@ class WandbMonitor(Monitor):
             self.eval_samples_table.add_data(*sample.values())
 
         wandb.log({"eval/samples": self.eval_samples_table, "step": step})
+        self.eval_samples_table = wandb.Table(columns=self.eval_samples_cols, log_mode="INCREMENTAL")
 
     def log_distributions(self, distributions: dict[str, list[float]], step: int) -> None:
         """Log distributions (no-op for W&B)."""


### PR DESCRIPTION
## Summary

- The orchestrator's \`RssAnon\` grew monotonically at ~+6 MB/step on large runs
- Root cause: numpy/pandas DataFrames created each step allocate via \`malloc()\` directly (outside Python's allocator). glibc retains freed pages in its internal pool, so \`gc.collect()\` alone has no effect on RSS
- Fix: call \`ctypes.CDLL("libc.so.6").malloc_trim(0)\` after \`gc.collect()\` at the end of each step to force glibc to return freed heap pages to the OS

## Verification

Reproduced and verified on \`alphabet-sort\` (512 rollouts/step, 20 steps, wandb disabled):

```
# Reproduce
uv run rl @ examples/alphabet_sort/rl.toml --max-steps 20 --clean-output-dir --orchestrator.wandb None

# Monitor (replace PID)
watch -n3 "grep -m1 RssAnon /proc/<PID>/status"
```

Post-trim \`RssAnon\` per completed step:

| Step | Without fix | With fix  |
|------|-------------|-----------|
| 2    | 968 MB      | 941 MB    |
| 3    | 973 MB (+5) | 941 MB (=)|
| 4    | —           | 941 MB (=)|
| 5    | —           | 942 MB (=)|

Without fix: unbounded +5–6 MB/step. With fix: flat sawtooth (peak during rollouts, drops after trim), no trend.

**Note on wandb sample logging**: at the default \`interval=10\`, wandb's internal upload buffers add a negligible ~0.3 MB/step. At \`interval=1\` this becomes ~2.5 MB/step, but that accumulation is inside wandb's serialization layer and is not addressed here.