### PR TITLE
fix(orchestrator): trim glibc heap after each step to prevent RSS growth

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -1,4 +1,5 @@
 import asyncio
+import ctypes
 import gc
 import os
 import time
@@ -797,6 +798,13 @@ async def orchestrate(config: OrchestratorConfig):
         del train_rollouts, train_examples, training_batch, vlm_cache
         del results_df, metrics_df
         gc.collect()
+        # Return free glibc heap pages to the OS. numpy/pandas allocate array data
+        # via malloc (outside Python's allocator), so gc.collect() alone doesn't
+        # reclaim the RSS. malloc_trim(0) forces glibc to return freed pages.
+        try:
+            ctypes.CDLL("libc.so.6").malloc_trim(0)
+        except Exception as e:
+            logger.warning(f"malloc_trim(0) failed - RSS may grow unboundedly: {e}")
 
         event_loop_lag_monitor.reset()
 


### PR DESCRIPTION
## Summary

- The orchestrator's `RssAnon` grew monotonically at ~+6 MB/step on large runs
- Root cause: numpy/pandas DataFrames created each step allocate via `malloc()` directly (outside Python's allocator). glibc retains freed pages in its internal pool, so `gc.collect()` alone has no effect on RSS
- Fix: call `ctypes.CDLL("libc.so.6").malloc_trim(0)` after `gc.collect()` at the end of each step to force glibc to return freed heap pages to the OS

## Verification

Reproduced and verified on `alphabet-sort` (512 rollouts/step, 20 steps, wandb disabled):

```
# Reproduce
uv run rl @ examples/alphabet_sort/rl.toml --max-steps 20 --clean-output-dir --orchestrator.wandb None

# Monitor (replace PID)
watch -n3 "grep -m1 RssAnon /proc/<PID>/status"
```

Post-trim `RssAnon` per completed step:

| Step | Without fix | With fix   |
|------|-------------|------------|
| 2    | 968 MB      | 941 MB     |
| 3    | 973 MB (+5) | 941 MB (=) |
| 4    | —           | 941 MB (=) |
| 5    | —           | 942 MB (=) |

Without fix: unbounded +5–6 MB/step. With fix: flat sawtooth (peak during rollouts, drops after trim), no trend.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a Linux/glibc-specific `ctypes` call in the main training loop; if `libc.so.6` isn’t available or behaves unexpectedly it could add overhead or noisy warnings, but failures are caught and training continues.
> 
> **Overview**
> Prevents orchestrator RSS from growing across steps by calling `malloc_trim(0)` after per-step cleanup.
> 
> After deleting large per-step objects and running `gc.collect()`, `orchestrator.py` now attempts `ctypes.CDLL("libc.so.6").malloc_trim(0)` to force glibc to return freed heap pages (e.g., from numpy/pandas) back to the OS, logging a warning if the trim fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit faf31fa330120d1a1a13916e0feb1b96f8efef4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->