### PR TITLE
ENG-3683: Allow configuring <batch_size inflight rollouts via oversampling factor

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -1026,10 +1026,11 @@ class OrchestratorConfig(BaseConfig):
     oversampling_factor: Annotated[
         float | None,
         Field(
-            ge=1,
+            gt=0,
             description=(
                 "Rollout-mode batching only. Multiplier used to derive max_inflight_rollouts from batch_size "
-                "when max_inflight_rollouts is unset."
+                "when max_inflight_rollouts is unset. Values below 1.0 intentionally cap in-flight rollout "
+                "capacity below batch_size."
             ),
         ),
     ] = None
@@ -1304,13 +1305,17 @@ class OrchestratorConfig(BaseConfig):
             assert self.batch_size is not None
             if self.batch_size % self.rollouts_per_example != 0:
                 raise ValueError("Batch size must be divisible by the number of samples per problem")
+            oversampling_factor = self.oversampling_factor if self.oversampling_factor is not None else 1.0
+            resolved_max_inflight_rollouts = max(
+                self.rollouts_per_example,
+                int(self.batch_size * oversampling_factor),
+            )
             if self.max_inflight_rollouts is not None and self.oversampling_factor is not None:
-                expected_max_inflight_rollouts = int(self.batch_size * self.oversampling_factor)
+                expected_max_inflight_rollouts = resolved_max_inflight_rollouts
                 if self.max_inflight_rollouts != expected_max_inflight_rollouts:
                     raise ValueError("max_inflight_rollouts conflicts with oversampling_factor * batch_size")
             if self.max_inflight_rollouts is None:
-                oversampling_factor = self.oversampling_factor if self.oversampling_factor is not None else 1.0
-                self.max_inflight_rollouts = int(self.batch_size * oversampling_factor)
+                self.max_inflight_rollouts = resolved_max_inflight_rollouts
 
         if self.max_inflight_rollouts is not None and self.max_inflight_rollouts < self.rollouts_per_example:
             raise ValueError("max_inflight_rollouts must be at least the number of rollouts per example")

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -448,6 +448,12 @@ class Scheduler:
                     rollouts: list[vf.RolloutOutput] = result if isinstance(result, list) else [result]
                     self.total_rollouts_by_env[env_name] += len(rollouts)
 
+                    if env.requires_group_scoring and not rollouts:
+                        assert group_id is not None
+                        self.dropped_groups_by_env[env_name] += 1
+                        await self.drop_group(group_id)
+                        continue
+
                     # Check for empty/errored rollouts and reschedule
                     valid_rollouts = []
                     has_failures = False


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes rollout scheduling/batching behavior: `oversampling_factor` can now reduce in-flight capacity below `batch_size`, and group-scoring envs will now drop groups that return an empty rollout list, which could affect throughput and step completion semantics.
> 
> **Overview**
> **Batching config now allows intentionally smaller in-flight rollout capacity than `batch_size`.** `oversampling_factor` validation is relaxed to `> 0` (instead of `>= 1`) and `max_inflight_rollouts` is resolved as `max(rollouts_per_example, int(batch_size * oversampling_factor))`, including when validating conflicts between explicit `max_inflight_rollouts` and `oversampling_factor`.
> 
> **Scheduler now treats empty group-scoring results as a dropped group.** When a group-scoring env returns an empty rollout list, the scheduler increments `dropped_groups` and calls `drop_group()` instead of proceeding through the normal reschedule/validation path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af83b0dac96d0a864884c3a98a22089bef2cf379. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->