### PR TITLE
ENG-3683: Allow configuring <batch_size inflight rollouts via oversampling factor

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -1026,10 +1026,11 @@ class OrchestratorConfig(BaseConfig):
     oversampling_factor: Annotated[
         float | None,
         Field(
-            ge=1,
+            gt=0,
             description=(
                 "Rollout-mode batching only. Multiplier used to derive max_inflight_rollouts from batch_size "
-                "when max_inflight_rollouts is unset."
+                "when max_inflight_rollouts is unset. Values below 1.0 intentionally cap in-flight rollout "
+                "capacity below batch_size."
             ),
         ),
     ] = None
@@ -1304,13 +1305,17 @@ class OrchestratorConfig(BaseConfig):
             assert self.batch_size is not None
             if self.batch_size % self.rollouts_per_example != 0:
                 raise ValueError("Batch size must be divisible by the number of samples per problem")
+            oversampling_factor = self.oversampling_factor if self.oversampling_factor is not None else 1.0
+            resolved_max_inflight_rollouts = max(
+                self.rollouts_per_example,
+                int(self.batch_size * oversampling_factor),
+            )
             if self.max_inflight_rollouts is not None and self.oversampling_factor is not None:
-                expected_max_inflight_rollouts = int(self.batch_size * self.oversampling_factor)
+                expected_max_inflight_rollouts = resolved_max_inflight_rollouts
                 if self.max_inflight_rollouts != expected_max_inflight_rollouts:
                     raise ValueError("max_inflight_rollouts conflicts with oversampling_factor * batch_size")
             if self.max_inflight_rollouts is None:
-                oversampling_factor = self.oversampling_factor if self.oversampling_factor is not None else 1.0
-                self.max_inflight_rollouts = int(self.batch_size * oversampling_factor)
+                self.max_inflight_rollouts = resolved_max_inflight_rollouts
 
         if self.max_inflight_rollouts is not None and self.max_inflight_rollouts < self.rollouts_per_example:
             raise ValueError("max_inflight_rollouts must be at least the number of rollouts per example")

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -448,6 +448,12 @@ class Scheduler:
                     rollouts: list[vf.RolloutOutput] = result if isinstance(result, list) else [result]
                     self.total_rollouts_by_env[env_name] += len(rollouts)
 
+                    if env.requires_group_scoring and not rollouts:
+                        assert group_id is not None
+                        self.dropped_groups_by_env[env_name] += 1
+                        await self.drop_group(group_id)
+                        continue
+
                     # Check for empty/errored rollouts and reschedule
                     valid_rollouts = []
                     has_failures = False

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -156,42 +156,6 @@ def test_removed_fused_lm_head_chunk_size_field_is_rejected():
         TrainerModelConfig.model_validate({"fused_lm_head_chunk_size": "auto"})
 
 
-@pytest.mark.parametrize(
-    ("batch_size", "rollouts_per_example", "oversampling_factor", "expected_max_inflight"),
-    [
-        (256, 8, 0.377, 96),
-        (128, 16, 0.01, 16),
-    ],
-)
-def test_orchestrator_resolves_fractional_oversampling_factor(
-    batch_size: int,
-    rollouts_per_example: int,
-    oversampling_factor: float,
-    expected_max_inflight: int,
-):
-    config = OrchestratorConfig.model_validate(
-        {
-            "batch_size": batch_size,
-            "rollouts_per_example": rollouts_per_example,
-            "oversampling_factor": oversampling_factor,
-        }
-    )
-
-    assert config.max_inflight_rollouts == expected_max_inflight
-
-
-def test_orchestrator_rejects_conflicting_explicit_max_inflight_rollouts():
-    with pytest.raises(ValidationError, match="max_inflight_rollouts conflicts"):
-        OrchestratorConfig.model_validate(
-            {
-                "batch_size": 256,
-                "rollouts_per_example": 8,
-                "oversampling_factor": 0.375,
-                "max_inflight_rollouts": 95,
-            }
-        )
-
-
 def test_selective_activation_checkpointing_requires_custom_impl():
     with pytest.raises(ValidationError, match="Selective activation checkpointing requires model.impl='custom'"):
         TrainerModelConfig.model_validate({"impl": "hf", "ac": {"mode": "selective"}})

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -156,33 +156,28 @@ def test_removed_fused_lm_head_chunk_size_field_is_rejected():
         TrainerModelConfig.model_validate({"fused_lm_head_chunk_size": "auto"})
 
 
-def test_orchestrator_accepts_fractional_oversampling_factor():
-    config = OrchestratorConfig.model_validate(
-        {"batch_size": 256, "rollouts_per_example": 8, "oversampling_factor": 0.377}
-    )
-
-    assert config.max_inflight_rollouts == 96
-
-
-def test_orchestrator_keeps_enough_capacity_for_one_group_when_undersampling():
-    config = OrchestratorConfig.model_validate(
-        {"batch_size": 128, "rollouts_per_example": 16, "oversampling_factor": 0.01}
-    )
-
-    assert config.max_inflight_rollouts == 16
-
-
-def test_orchestrator_accepts_matching_explicit_max_inflight_rollouts():
+@pytest.mark.parametrize(
+    ("batch_size", "rollouts_per_example", "oversampling_factor", "expected_max_inflight"),
+    [
+        (256, 8, 0.377, 96),
+        (128, 16, 0.01, 16),
+    ],
+)
+def test_orchestrator_resolves_fractional_oversampling_factor(
+    batch_size: int,
+    rollouts_per_example: int,
+    oversampling_factor: float,
+    expected_max_inflight: int,
+):
     config = OrchestratorConfig.model_validate(
         {
-            "batch_size": 256,
-            "rollouts_per_example": 8,
-            "oversampling_factor": 0.377,
-            "max_inflight_rollouts": 96,
+            "batch_size": batch_size,
+            "rollouts_per_example": rollouts_per_example,
+            "oversampling_factor": oversampling_factor,
         }
     )
 
-    assert config.max_inflight_rollouts == 96
+    assert config.max_inflight_rollouts == expected_max_inflight
 
 
 def test_orchestrator_rejects_conflicting_explicit_max_inflight_rollouts():

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -156,6 +156,47 @@ def test_removed_fused_lm_head_chunk_size_field_is_rejected():
         TrainerModelConfig.model_validate({"fused_lm_head_chunk_size": "auto"})
 
 
+def test_orchestrator_accepts_fractional_oversampling_factor():
+    config = OrchestratorConfig.model_validate(
+        {"batch_size": 256, "rollouts_per_example": 8, "oversampling_factor": 0.377}
+    )
+
+    assert config.max_inflight_rollouts == 96
+
+
+def test_orchestrator_keeps_enough_capacity_for_one_group_when_undersampling():
+    config = OrchestratorConfig.model_validate(
+        {"batch_size": 128, "rollouts_per_example": 16, "oversampling_factor": 0.01}
+    )
+
+    assert config.max_inflight_rollouts == 16
+
+
+def test_orchestrator_accepts_matching_explicit_max_inflight_rollouts():
+    config = OrchestratorConfig.model_validate(
+        {
+            "batch_size": 256,
+            "rollouts_per_example": 8,
+            "oversampling_factor": 0.377,
+            "max_inflight_rollouts": 96,
+        }
+    )
+
+    assert config.max_inflight_rollouts == 96
+
+
+def test_orchestrator_rejects_conflicting_explicit_max_inflight_rollouts():
+    with pytest.raises(ValidationError, match="max_inflight_rollouts conflicts"):
+        OrchestratorConfig.model_validate(
+            {
+                "batch_size": 256,
+                "rollouts_per_example": 8,
+                "oversampling_factor": 0.375,
+                "max_inflight_rollouts": 95,
+            }
+        )
+
+
 def test_selective_activation_checkpointing_requires_custom_impl():
     with pytest.raises(ValidationError, match="Selective activation checkpointing requires model.impl='custom'"):
         TrainerModelConfig.model_validate({"impl": "hf", "ac": {"mode": "selective"}})


### PR DESCRIPTION
Superseded by the clean standalone PR against `main`: https://github.com/PrimeIntellect-ai/prime-rl/pull/2533

This PR used the old shared branch and included the group-disregard scheduler change in addition to the max-inflight config change.