### PR TITLE
ENG-3683: Allow capped inflight rollout capacity

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -1026,10 +1026,11 @@ class OrchestratorConfig(BaseConfig):
     oversampling_factor: Annotated[
         float | None,
         Field(
-            ge=1,
+            gt=0,
             description=(
                 "Rollout-mode batching only. Multiplier used to derive max_inflight_rollouts from batch_size "
-                "when max_inflight_rollouts is unset."
+                "when max_inflight_rollouts is unset. Values below 1.0 intentionally cap in-flight rollout "
+                "capacity below batch_size."
             ),
         ),
     ] = None
@@ -1310,13 +1311,17 @@ class OrchestratorConfig(BaseConfig):
             assert self.batch_size is not None
             if self.batch_size % self.rollouts_per_example != 0:
                 raise ValueError("Batch size must be divisible by the number of samples per problem")
+            oversampling_factor = self.oversampling_factor if self.oversampling_factor is not None else 1.0
+            resolved_max_inflight_rollouts = max(
+                self.rollouts_per_example,
+                int(self.batch_size * oversampling_factor),
+            )
             if self.max_inflight_rollouts is not None and self.oversampling_factor is not None:
-                expected_max_inflight_rollouts = int(self.batch_size * self.oversampling_factor)
+                expected_max_inflight_rollouts = resolved_max_inflight_rollouts
                 if self.max_inflight_rollouts != expected_max_inflight_rollouts:
                     raise ValueError("max_inflight_rollouts conflicts with oversampling_factor * batch_size")
             if self.max_inflight_rollouts is None:
-                oversampling_factor = self.oversampling_factor if self.oversampling_factor is not None else 1.0
-                self.max_inflight_rollouts = int(self.batch_size * oversampling_factor)
+                self.max_inflight_rollouts = resolved_max_inflight_rollouts
 
         if self.max_inflight_rollouts is not None and self.max_inflight_rollouts < self.rollouts_per_example:
             raise ValueError("max_inflight_rollouts must be at least the number of rollouts per example")


### PR DESCRIPTION
## Summary

Adds standalone Prime-RL support for using fractional `oversampling_factor` to cap in-flight rollout capacity below `batch_size`.

## Changes

- Allows `oversampling_factor` values in `(0, 1)`.
- Resolves `max_inflight_rollouts` from `int(batch_size * oversampling_factor)` when the explicit cap is unset.
- Clamps the resolved cap to at least `rollouts_per_example` so one full group can be scheduled.
- Keeps compatibility validation when both `max_inflight_rollouts` and legacy `oversampling_factor` are present.

## Related PRs

- Prime CLI support: https://github.com/PrimeIntellect-ai/prime/pull/666
- Platform support: https://github.com/PrimeIntellect-ai/platform/pull/2310

## Validation

- `uv run --no-sync --with ruff ruff check packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py tests/unit/test_configs.py`
- `uv run --no-sync --with-editable packages/prime-rl-configs --with pytest pytest --confcutdir=tests/unit tests/unit/test_configs.py -q`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes batching validation/derivation for `max_inflight_rollouts`, which can alter rollout concurrency and training throughput; incorrect configs may now pass with fractional factors but are still bounded by `rollouts_per_example`.
> 
> **Overview**
> Allows rollout-mode `oversampling_factor` to be **fractional (>0)** so `max_inflight_rollouts` can be capped below `batch_size`.
> 
> `resolve_batching` now derives a `resolved_max_inflight_rollouts = max(rollouts_per_example, int(batch_size * oversampling_factor))`, uses it as the default when `max_inflight_rollouts` is unset, and reuses the same resolved value for conflict validation when both knobs are provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6c9e8ac033f844e121a024d77a4daaa0a8b2f63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->