### PR TITLE
feat(ci): add wiki-search integration test

### DIFF
--- a/.github/workflows/gpu_tests.yaml
+++ b/.github/workflows/gpu_tests.yaml
@@ -72,6 +72,9 @@ jobs:
           - test: alphabet_sort
             runner: vm
             pytest_args: "tests/integration/test_alphabet_sort.py"
+          - test: wiki_search
+            runner: vm
+            pytest_args: "tests/integration/test_wiki_search.py"
           - test: reverse_text_lora
             runner: vm
             pytest_args: "tests/integration/test_reverse_text_lora.py"

--- a/configs/ci/integration/wiki_search.toml
+++ b/configs/ci/integration/wiki_search.toml
@@ -1,0 +1,23 @@
+max_steps = 5
+seq_len = 4096
+
+[ckpt]
+
+[model]
+name = "PrimeIntellect/Qwen3-0.6B"
+
+[trainer.optim]
+lr = 1e-5
+
+[orchestrator]
+batch_size = 32
+rollouts_per_example = 4
+
+[orchestrator.train.sampling]
+max_completion_tokens = 512
+
+[[orchestrator.train.env]]
+id = "wiki-search"
+
+[inference.model]
+tool_call_parser = "hermes"

--- a/configs/ci/integration/wiki_search.toml
+++ b/configs/ci/integration/wiki_search.toml
@@ -20,7 +20,7 @@ max_completion_tokens = 512
 id = "wiki-search"
 
 [orchestrator.renderer]
-tool_parser = "hermes"
+tool_parser = "qwen3"
 
 [inference.model]
 tool_call_parser = "hermes"

--- a/configs/ci/integration/wiki_search.toml
+++ b/configs/ci/integration/wiki_search.toml
@@ -19,5 +19,8 @@ max_completion_tokens = 512
 [[orchestrator.train.env]]
 id = "wiki-search"
 
+[orchestrator.renderer]
+tool_parser = "hermes"
+
 [inference.model]
 tool_call_parser = "hermes"

--- a/configs/ci/integration/wiki_search.toml
+++ b/configs/ci/integration/wiki_search.toml
@@ -11,7 +11,16 @@ lr = 1e-5
 batch_size = 32
 rollouts_per_example = 4
 
+[[orchestrator.filters]]
+type = "zero_advantage"
+enforce = false
+
+[orchestrator.train.sampling]
+max_completion_tokens = 512
+
 [[orchestrator.train.env]]
 id = "wiki-search"
+args = { max_turns = 2 }
 
-[inference]
+[inference.model]
+tool_call_parser = "hermes"

--- a/configs/ci/integration/wiki_search.toml
+++ b/configs/ci/integration/wiki_search.toml
@@ -1,10 +1,8 @@
 max_steps = 5
 seq_len = 4096
 
-[ckpt]
-
 [model]
-name = "PrimeIntellect/Qwen3-0.6B"
+name = "Qwen/Qwen3-4B-Instruct-2507"
 
 [trainer.optim]
 lr = 1e-5
@@ -13,14 +11,7 @@ lr = 1e-5
 batch_size = 32
 rollouts_per_example = 4
 
-[orchestrator.train.sampling]
-max_completion_tokens = 512
-
 [[orchestrator.train.env]]
 id = "wiki-search"
 
-[orchestrator.renderer]
-tool_parser = "qwen3"
-
-[inference.model]
-tool_call_parser = "hermes"
+[inference]

--- a/tests/integration/test_wiki_search.py
+++ b/tests/integration/test_wiki_search.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+from tests.conftest import ProcessResult
+from tests.utils import (
+    check_avg_mismatch_kl_in_range,
+    check_no_error,
+    strip_escape_codes,
+)
+
+pytestmark = [pytest.mark.gpu, pytest.mark.slow]
+
+
+TIMEOUT = 900  # 15 minutes
+
+
+@pytest.fixture(scope="module")
+def wandb_name(branch_name: str) -> str:
+    """Fixture for W&B name for wiki search RL CI integration tests."""
+    return f"test-wiki-search:{branch_name}"
+
+
+@pytest.fixture(scope="module")
+def rl_process(
+    run_process: Callable[..., ProcessResult],
+    output_dir: Path,
+    wandb_project: str,
+    wandb_name: str,
+) -> ProcessResult:
+    cmd = [
+        "uv",
+        "run",
+        "rl",
+        "@",
+        "configs/ci/integration/wiki_search.toml",
+        "--wandb.project",
+        wandb_project,
+        "--wandb.name",
+        wandb_name,
+        "--output-dir",
+        output_dir.as_posix(),
+    ]
+    return run_process(cmd, timeout=TIMEOUT)
+
+
+@pytest.fixture(scope="module")
+def test_no_error(rl_process: ProcessResult, output_dir: Path):
+    """Tests that the RL process does not fail."""
+    check_no_error(rl_process, output_dir)
+
+
+def test_mismatch_kl_in_range(rl_process: ProcessResult, test_no_error, output_dir: Path):
+    """Tests that the average mismatch KL is below 0.15 across the last 5 steps."""
+    with open(output_dir / "logs" / "trainer.log", "r") as f:
+        trainer_stdout = strip_escape_codes(f.read()).splitlines()
+    check_avg_mismatch_kl_in_range(trainer_stdout, last_n_steps=5, max_threshold=0.15)


### PR DESCRIPTION
## Summary

- Adds a minimal `wiki-search` integration test to the CI matrix to cover tool call environments, which are currently untested
- New CI config at `configs/ci/integration/wiki_search.toml`: 5 steps, batch size 32, `PrimeIntellect/Qwen3-0.6B`, with `tool_call_parser = "hermes"`
- Test checks that the process completes without error and mismatch KL stays below 0.15
- Added as a `vm` runner job in `.github/workflows/gpu_tests.yaml` alongside `alphabet_sort`

## Notes

`PrimeIntellect/Qwen3-0.6B` is not in `MODEL_RENDERER_MAP` in the renderers submodule, so it falls back to `DefaultRenderer` which has `supports_tools=False` unless `tool_parser` is explicitly set. The CI config therefore sets both `[orchestrator.renderer] tool_parser = "hermes"` (renderer-side) and `[inference.model] tool_call_parser = "hermes"` (vLLM server-side).