### PR TITLE
docs: fix 404 for "Testing MoE at Small Scale" page

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -15,6 +15,7 @@
                 "benchmarking",
                 "deployment",
                 "kubernetes",
+                "testing-moe-at-small-scale",
                 "troubleshooting"
             ]
         }


### PR DESCRIPTION
The page "Testing MoE at Small Scale" exists in `docs/testing-moe-at-small-scale.md` 
but was missing from the navigation config in `docs/mint.json`, causing a 404 
on the docs site when accessed via:
https://docs.primeintellect.ai/prime-rl/testing-moe-at-small-scale

Added the page to `docs/mint.json` in the correct position (before `troubleshooting`).

Closes #2539

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that just updates the Mintlify navigation config; main risk is limited to potential nav ordering/slug mismatches.
> 
> **Overview**
> Fixes a docs-site 404 by adding the existing `testing-moe-at-small-scale` page to `docs/mint.json` navigation (placed before `troubleshooting`) and normalizing the file’s trailing newline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cd73b8b811378827ca325a1cab6c13d7ec339af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->