### PR TITLE
clean quack norm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ gpt-oss = [
     "kernels",
 ]
 quack = [
-    "quack-kernels>=0.3.3",
+    "quack-kernels>=0.4.1",
 ]
 all = [
     "prime-rl[flash-attn]",

--- a/src/prime_rl/trainer/models/layers/norms.py
+++ b/src/prime_rl/trainer/models/layers/norms.py
@@ -20,25 +20,6 @@ def _get_quack_rmsnorm():
         return None
 
 
-class _ContiguousGrad(torch.autograd.Function):
-    @staticmethod
-    def forward(ctx, x):
-        return x
-
-    @staticmethod
-    def backward(ctx, grad):
-        return grad.contiguous()
-
-
-def _contiguous_grad(x: torch.Tensor) -> torch.Tensor:
-    """Identity in forward, makes gradient contiguous in backward.
-
-    Quack's RMSNorm backward kernel requires contiguous gradients (stride[-1]==1)
-    but upstream ops like attention permute can produce non-contiguous ones.
-    """
-    return _ContiguousGrad.apply(x) if x.requires_grad else x
-
-
 @dataclass
 class RMSNormConfig:
     hidden_size: int
@@ -55,8 +36,7 @@ class RMSNorm(nn.Module):
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         quack_fn = _get_quack_rmsnorm() if hidden_states.is_cuda else None
         if quack_fn is not None:
-            out = quack_fn(hidden_states, self.weight, eps=self.variance_epsilon)
-            return _contiguous_grad(out)
+            return quack_fn(hidden_states, self.weight, eps=self.variance_epsilon)
         input_dtype = hidden_states.dtype
         hidden_states = hidden_states.to(torch.float32)
         variance = hidden_states.pow(2).mean(-1, keepdim=True)

--- a/uv.lock
+++ b/uv.lock
@@ -4004,7 +4004,7 @@ requires-dist = [
     { name = "prime-rl-configs", editable = "packages/prime-rl-configs" },
     { name = "pyarrow", specifier = ">=21.0.0" },
     { name = "pyzmq", specifier = ">=27.1.0" },
-    { name = "quack-kernels", marker = "extra == 'quack'", specifier = ">=0.3.3" },
+    { name = "quack-kernels", marker = "extra == 'quack'", specifier = ">=0.4.1" },
     { name = "renderers", editable = "deps/renderers" },
     { name = "reverse-text", marker = "extra == 'envs'", editable = "deps/verifiers/environments/reverse_text" },
     { name = "rich", specifier = ">=14.0.0" },


### PR DESCRIPTION
Previously needed this extra code but fixed in https://github.com/Dao-AILab/quack/commit/cbdb042f25e2a37e58eea43d0ab2ae1d75e3493b

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CUDA RMSNorm fast-path by removing a backward/gradient contiguity workaround and relying on an updated `quack-kernels` implementation; this could affect training stability/perf on Hopper GPUs. Scope is small and isolated to the Quack RMSNorm path and dependency pin.
> 
> **Overview**
> Bumps the optional `quack` extra (`quack-kernels` `>=0.3.3` → `>=0.4.1`) and updates `uv.lock` accordingly.
> 
> Simplifies the Quack CUDA fast-path in `RMSNorm` by removing the `_ContiguousGrad`/`_contiguous_grad` autograd wrapper that forced contiguous gradients during backward, returning Quack’s `rmsnorm` output directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 072ee95eb32e2fc1f716c461e4c6125dafa79848. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->