### PR TITLE
fix(tests): inject prime lm_head + complete ring-attn restore

### DIFF
--- a/tests/unit/train/models/test_qwen3_5_moe.py
+++ b/tests/unit/train/models/test_qwen3_5_moe.py
@@ -117,18 +117,23 @@ def test_qwen3_5_moe_cp_patching():
     """Verify substitute_ring_attn patches Qwen3_5MoeGatedFlashAttention._compute_attention."""
     from unittest.mock import MagicMock
 
-    from prime_rl.trainer.models.layers.attn import substitute_ring_attn
+    from prime_rl.trainer.models.afmoe.modeling_afmoe import AfmoeFlashAttention
+    from prime_rl.trainer.models.layers.attn import FlashAttention, substitute_ring_attn
     from prime_rl.trainer.models.qwen3_5_moe.modeling_qwen3_5_moe import Qwen3_5MoeGatedFlashAttention
 
-    original_method = Qwen3_5MoeGatedFlashAttention._compute_attention
-
-    mock_group = MagicMock()
-    substitute_ring_attn(process_group=mock_group, heads_k_stride=1)
-
-    assert Qwen3_5MoeGatedFlashAttention._compute_attention is not original_method
-
-    # Restore to avoid polluting other tests
-    Qwen3_5MoeGatedFlashAttention._compute_attention = original_method
+    # substitute_ring_attn rewrites _compute_attention on all three classes;
+    # snapshot every one so the patch can't leak into later tests via the
+    # untouched siblings.
+    originals = {
+        cls: cls._compute_attention for cls in (FlashAttention, AfmoeFlashAttention, Qwen3_5MoeGatedFlashAttention)
+    }
+    try:
+        mock_group = MagicMock()
+        substitute_ring_attn(process_group=mock_group, heads_k_stride=1)
+        assert Qwen3_5MoeGatedFlashAttention._compute_attention is not originals[Qwen3_5MoeGatedFlashAttention]
+    finally:
+        for cls, method in originals.items():
+            cls._compute_attention = method
 
 
 if __name__ == "__main__":

--- a/tests/unit/train/test_model.py
+++ b/tests/unit/train/test_model.py
@@ -30,7 +30,13 @@ def attn(request) -> AttnImplementation:
 @pytest.fixture
 def model(attn):
     config = ModelConfig(name="Qwen/Qwen3-0.6B", attn=attn)
-    return get_model(config)
+    model = get_model(config)
+    # Mirror setup_model: the custom Qwen3 forward calls lm_head with
+    # (hidden_states, labels, temperature=...), which only VanillaOutputLinear
+    # / FusedOutputLinear accept. Plain nn.Linear errors with
+    # `Linear.forward() got an unexpected keyword argument 'temperature'`.
+    inject_prime_lm_head(model, chunk_size=None)
+    return model
 
 
 def test_model_to_gpu(model):


### PR DESCRIPTION
## Summary

Restores green CI on `tests/unit/train/test_model.py`. Two coupled GPU test failures introduced by #2505:

| Test | Error | Root cause |
|---|---|---|
| `test_model_forward[sdpa]` | `TypeError: Linear.forward() got an unexpected keyword argument 'temperature'` | The `model` fixture calls `get_model(config)` but never calls `inject_prime_lm_head(model, ...)`. The custom Qwen3 dense forward added in #2505 calls `self.lm_head(hidden_states, labels, temperature=...)`, which only works on `VanillaOutputLinear` / `FusedOutputLinear`. |
| `test_model_with_position_ids[sdpa]` | same | same |
| `test_model_forward[flash_attention_2]` | `KeyError: 'cu_seqlens_q'` | `test_qwen3_5_moe_cp_patching` (added in #2026) calls `substitute_ring_attn` which rewrites `_compute_attention` on **three** classes; the cleanup only restored one. The ring patch leaks into later tests that touch `FlashAttention`. Dormant until #2505 made a downstream GPU test use `FlashAttention`. |
| `test_model_with_position_ids[flash_attention_2]` | same | same |

The two issues are independent (one in #2505, one dormant since #2026 / 2026-03-13) but #2505 surfaced both at once.

## Fixes

**1. `tests/unit/train/test_model.py`** — call `inject_prime_lm_head(model, chunk_size=None)` in the `model` fixture, mirroring `setup_model`. Existing tests in this file (`test_moe_custom_impl`, `test_model_forward_custom_impl`) already do this manually.

**2. `tests/unit/train/models/test_qwen3_5_moe.py::test_qwen3_5_moe_cp_patching`** — snapshot `_compute_attention` on all three patched classes (`FlashAttention`, `AfmoeFlashAttention`, `Qwen3_5MoeGatedFlashAttention`) before the patch, restore all three in a `finally` block.

## Verified locally on 2× RTX PRO 6000 Blackwell

```
$ uv run pytest tests/unit/train/test_model.py -m gpu -v
================== 7 passed, 5 skipped, 21 warnings in 12.81s ==================

$ uv run pytest tests/unit/train/models/test_qwen3_5_moe.py::test_qwen3_5_moe_cp_patching tests/unit/train/test_model.py -m gpu -v
================== 8 passed, 5 skipped, 21 warnings in 12.96s ==================
```

Without these fixes, the four `test_model_forward[*]` / `test_model_with_position_ids[*]` cases all fail (reproducing the CI red).

## Notes

- The `cp_patching` leak existed for ~2 months and only became fatal when #2505 added a `FlashAttention` user downstream of `test_qwen3_5_moe_cp_patching` in pytest collection order. The same leak would have caught any future test that exercises prime-rl's `FlashAttention` class — fixing it here also protects later additions.
- Alternative I considered: have `substitute_ring_attn` return a teardown closure or accept context-manager semantics so callers can't forget. Bigger API change for the same end result — happy to take that on in a follow-up if you'd prefer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that adjust fixtures and ensure monkeypatch cleanup; main risk is masking a real integration issue if production setup diverges from tests.
> 
> **Overview**
> Fixes GPU unit test failures for Qwen models by updating the `tests/unit/train/test_model.py` `model` fixture to call `inject_prime_lm_head(...)`, matching the model’s expected `lm_head` signature.
> 
> Prevents test pollution in `test_qwen3_5_moe_cp_patching` by snapshotting and restoring `_compute_attention` for all classes patched by `substitute_ring_attn` (`FlashAttention`, `AfmoeFlashAttention`, and `Qwen3_5MoeGatedFlashAttention`) via a `try/finally` cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3be2026c2bcd661188db796d54f388616fa700d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->