### PR TITLE
Fix Qwen3 GPU unit regressions

### DIFF
--- a/src/prime_rl/trainer/models/qwen3/modeling_qwen3.py
+++ b/src/prime_rl/trainer/models/qwen3/modeling_qwen3.py
@@ -12,7 +12,7 @@ from transformers.utils import TransformersKwargs, auto_docstring, can_return_tu
 
 from prime_rl.trainer.models.base import PreTrainedModelPrimeRL
 from prime_rl.trainer.models.layers.attn import ATTN_IMPL2CLASS, AttentionConfig
-from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput
+from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput, VanillaOutputLinear
 from prime_rl.trainer.models.layers.mlp import MLP, MLPConfig
 from prime_rl.trainer.models.layers.norms import RMSNorm, RMSNormConfig
 from prime_rl.trainer.models.layers.rotary_emb import RotaryEmbedding, RotaryEmbeddingConfig
@@ -197,7 +197,7 @@ class Qwen3ForCausalLM(Qwen3PreTrainedModel, GenerationMixin):
         super().__init__(config)
         self.model = Qwen3Model(config)
         self.vocab_size = config.vocab_size
-        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        self.lm_head = VanillaOutputLinear(config.hidden_size, config.vocab_size)
 
         self.post_init()
 

--- a/tests/unit/train/models/test_qwen3.py
+++ b/tests/unit/train/models/test_qwen3.py
@@ -1,0 +1,38 @@
+import torch
+from transformers.models.qwen3.configuration_qwen3 import Qwen3Config
+
+from prime_rl.trainer.models.qwen3 import Qwen3ForCausalLM
+
+
+def _tiny_qwen3_config() -> Qwen3Config:
+    config = Qwen3Config(
+        vocab_size=32,
+        hidden_size=8,
+        intermediate_size=16,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        head_dim=4,
+        hidden_act="silu",
+        max_position_embeddings=32,
+        rms_norm_eps=1e-6,
+        attention_bias=False,
+        pad_token_id=0,
+        bos_token_id=1,
+        eos_token_id=2,
+        use_cache=False,
+        tie_word_embeddings=False,
+        rope_parameters={"rope_type": "default", "rope_theta": 10000},
+    )
+    config._attn_implementation = "sdpa"
+    config.layer_types = ["full_attention"]
+    return config
+
+
+def test_qwen3_forward_with_unwrapped_lm_head():
+    model = Qwen3ForCausalLM(_tiny_qwen3_config())
+    input_ids = torch.randint(0, model.config.vocab_size, (1, 4))
+
+    outputs = model(input_ids=input_ids)
+
+    assert outputs["logits"].shape == (1, 4, model.config.vocab_size)

--- a/tests/unit/train/models/test_qwen3_5_moe.py
+++ b/tests/unit/train/models/test_qwen3_5_moe.py
@@ -117,18 +117,23 @@ def test_qwen3_5_moe_cp_patching():
     """Verify substitute_ring_attn patches Qwen3_5MoeGatedFlashAttention._compute_attention."""
     from unittest.mock import MagicMock
 
-    from prime_rl.trainer.models.layers.attn import substitute_ring_attn
+    from prime_rl.trainer.models.afmoe.modeling_afmoe import AfmoeFlashAttention
+    from prime_rl.trainer.models.layers.attn import FlashAttention, substitute_ring_attn
     from prime_rl.trainer.models.qwen3_5_moe.modeling_qwen3_5_moe import Qwen3_5MoeGatedFlashAttention
 
-    original_method = Qwen3_5MoeGatedFlashAttention._compute_attention
+    original_flash_method = FlashAttention._compute_attention
+    original_afmoe_method = AfmoeFlashAttention._compute_attention
+    original_qwen3_5_moe_method = Qwen3_5MoeGatedFlashAttention._compute_attention
 
     mock_group = MagicMock()
-    substitute_ring_attn(process_group=mock_group, heads_k_stride=1)
+    try:
+        substitute_ring_attn(process_group=mock_group, heads_k_stride=1)
 
-    assert Qwen3_5MoeGatedFlashAttention._compute_attention is not original_method
-
-    # Restore to avoid polluting other tests
-    Qwen3_5MoeGatedFlashAttention._compute_attention = original_method
+        assert Qwen3_5MoeGatedFlashAttention._compute_attention is not original_qwen3_5_moe_method
+    finally:
+        FlashAttention._compute_attention = original_flash_method
+        AfmoeFlashAttention._compute_attention = original_afmoe_method
+        Qwen3_5MoeGatedFlashAttention._compute_attention = original_qwen3_5_moe_method
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- use the PrimeRL vanilla LM head for custom Qwen3 so standalone forwards accept the shared LM-head call signature
- restore all class-level attention methods mutated by the Qwen3.5 MoE CP-patching test to avoid leaking ring attention into later Qwen3 tests
- add a tiny CPU Qwen3 forward regression test

## Validation
- `python -m pytest tests/unit/train/models/test_qwen3.py tests/unit/train/models/test_qwen3_5_moe.py::test_qwen3_5_moe_cp_patching`
- ordered GPU subset covering the four failing Qwen3 cases: `5 passed`
- `python -m pytest -q tests/unit/train/test_model.py`
- `python -m ruff check src/prime_rl/trainer/models/qwen3/modeling_qwen3.py tests/unit/train/models/test_qwen3.py tests/unit/train/models/test_qwen3_5_moe.py`
- `git diff --check HEAD~1..HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to swapping the Qwen3 LM head wrapper and tightening unit tests to avoid global attention-method leakage across tests.
> 
> **Overview**
> Updates custom `Qwen3ForCausalLM` to use PrimeRL’s `VanillaOutputLinear` LM head (instead of a raw `nn.Linear`) so standalone forwards return `PrimeLmOutput` with the expected shared LM-head call signature.
> 
> Adds a tiny CPU Qwen3 forward regression test, and hardens the Qwen3.5 MoE ring-attention CP-patching test to restore all mutated class-level `_compute_attention` methods (`FlashAttention`, `AfmoeFlashAttention`, and `Qwen3_5MoeGatedFlashAttention`) via `try/finally` to prevent cross-test contamination.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a3b3413ca647799377bd89fb9898dbd6124df7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->