### PR TITLE
fix(trainer): suppress duplicated trainer logs on non-zero ranks

### DIFF
--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -73,9 +73,13 @@ from torchtitan.distributed.utils import clip_grad_norm_
 def train(config: TrainerConfig):
     # Setup world and logger
     world = get_world()
+    # rank_zero_only suppresses logs on non-zero ranks. Every rank's stdout
+    # is merged in k8s/Loki, so without this each line appears N times in the
+    # dashboard's trainer log tab (one per GPU).
     logger = setup_logger(
         config.log.level,
         json_logging=config.log.json_logging,
+        rank_zero_only=True,
     )
     logger.info(f"Starting RL trainer in {world} in {config.output_dir}")
 

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -62,9 +62,13 @@ from torchtitan.distributed.utils import clip_grad_norm_
 def train(config: SFTConfig):
     # Setup world and logger
     world = get_world()
+    # rank_zero_only suppresses logs on non-zero ranks. Every rank's stdout
+    # is merged in k8s/Loki, so without this each line appears N times in the
+    # dashboard's trainer log tab (one per GPU).
     logger = setup_logger(
         config.log.level,
         json_logging=config.log.json_logging,
+        rank_zero_only=True,
     )
     logger.info(f"Starting SFT trainer in {world}")
 

--- a/src/prime_rl/utils/logger.py
+++ b/src/prime_rl/utils/logger.py
@@ -1,5 +1,6 @@
 import json as json_module
 import logging
+import os
 import sys
 import traceback
 from typing import Any
@@ -88,6 +89,7 @@ def setup_logger(
     log_level: str = "info",
     tag: str | None = None,
     json_logging: bool = False,
+    rank_zero_only: bool = False,
 ):
     global _LOGGER, _JSON_LOGGING
     _JSON_LOGGING = json_logging
@@ -95,6 +97,13 @@ def setup_logger(
     # Clean up old logger instance to prevent resource leaks
     if _LOGGER is not None:
         _LOGGER.remove()
+
+    # When running under torchrun, every rank writes to its own stdout but all
+    # stdout streams are merged in k8s/Loki, so each log line shows up N times.
+    # rank_zero_only=True suppresses output on non-zero ranks. We read the
+    # global RANK env var (set by torchrun before the process starts) so this
+    # works even before torch.distributed.init_process_group is called.
+    is_silent_rank = rank_zero_only and int(os.environ.get("RANK", "0")) != 0
 
     # Format message with optional tag prefix
     tag_prefix = f"[{tag}] " if tag else ""
@@ -135,11 +144,13 @@ def setup_logger(
     if json_logging and tag:
         logger = logger.bind(tag=tag)
 
-    # Install console handler (enqueue=True only for JSON mode to avoid blocking in async contexts)
-    if json_logging:
-        logger.add(json_sink, level=log_level.upper(), enqueue=True)
-    else:
-        logger.add(sys.stdout, format=format, level=log_level.upper(), colorize=True)
+    # Install console handler (enqueue=True only for JSON mode to avoid blocking in async contexts).
+    # Silent ranks get a logger with no sinks so all log calls become no-ops.
+    if not is_silent_rank:
+        if json_logging:
+            logger.add(json_sink, level=log_level.upper(), enqueue=True)
+        else:
+            logger.add(sys.stdout, format=format, level=log_level.upper(), colorize=True)
 
     # Disable critical logging
     logger.critical = lambda _: None


### PR DESCRIPTION
## Why

On an 8-GPU trainer pod, the dashboard's Trainer log tab on `/dashboard/training/<id>` shows every log line 8 times - e.g. 8 identical "Starting training loop" lines and 8 near-identical "Step 0 | Time ..." lines (each with slightly different per-rank throughput/memory).

`torchrun --nproc-per-node=N` spawns N processes, each writes to stdout, k8s ships each stdout to Loki as separate streams, and the platform groups by `role=trainer`. The existing `--local-ranks-filter` plumbing in `entrypoints/rl.py` only applies to the launcher-managed single-node path; on k8s the trainer module is invoked directly via torchrun, bypassing that filter.

## What

- `setup_logger` gains a `rank_zero_only` flag. When `True` and `RANK > 0` (read from torchrun's env var, set before dist init), the loguru instance is built with no sinks so every `logger.info` / `.success` / `.debug` / `.warning` call becomes a no-op on non-zero ranks.
- `trainer/rl/train.py` and `trainer/sft/train.py` opt in.
- All other `setup_logger` callers (orchestrator, inference, RL launcher) are unchanged - they're single-process and never had the fan-out.

## Notes

- Uses global `RANK` (not `LOCAL_RANK`) so it works correctly on multi-node setups where only one trainer pod has global rank 0.
- Reads `os.environ["RANK"]` directly rather than going through `torch.distributed.get_rank()`, so it works for any log line emitted before `dist.init_process_group`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only logging behavior by silencing non-zero distributed ranks, which could reduce per-rank visibility but does not affect training computation.
> 
> **Overview**
> **Reduces duplicated logs in distributed training runs.** `setup_logger` now supports `rank_zero_only`, which detects non-zero `RANK` (from `torchrun`) and creates a loguru logger with no sinks so log calls become no-ops on those ranks.
> 
> Both RL and SFT trainers opt into this (`rank_zero_only=True`) to prevent N-way repeated stdout lines when Kubernetes/Loki merges per-rank streams.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3fe296b87903f294ad3e9bf7bd342a62cd225bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->