### PR TITLE
Add token export visualizer

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -494,8 +494,6 @@ class TokenExportConfig(BaseConfig):
 
 
 class TrainerExperimentalConfig(BaseConfig):
-    pass
-
     token_export: Annotated[
         TokenExportConfig | None,
         Field(

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -492,14 +492,6 @@ class TokenExportConfig(BaseConfig):
         ),
     ] = None
 
-    interval: Annotated[
-        int,
-        Field(
-            ge=1,
-            description="Export every N training steps.",
-        ),
-    ] = 1
-
 
 class TrainerExperimentalConfig(BaseConfig):
     pass

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -479,8 +479,40 @@ WeightBroadcastConfig: TypeAlias = Annotated[
 ]
 
 
+class TokenExportConfig(BaseConfig):
+    """Configures per-token rollout exports from the RL trainer."""
+
+    path: Annotated[
+        Path | None,
+        Field(
+            description=(
+                "JSONL output file. If unset, writes to "
+                "`<output_dir>/token_exports/rank_<rank>.jsonl`. Relative paths are resolved under output_dir."
+            ),
+        ),
+    ] = None
+
+    interval: Annotated[
+        int,
+        Field(
+            ge=1,
+            description="Export every N training steps.",
+        ),
+    ] = 1
+
+
 class TrainerExperimentalConfig(BaseConfig):
     pass
+
+    token_export: Annotated[
+        TokenExportConfig | None,
+        Field(
+            description=(
+                "Opt-in per-token JSONL export for rollout visualization. "
+                "When enabled, writes token ids and aligned trainer metrics after each forward pass."
+            ),
+        ),
+    ] = None
 
 
 class TrainerConfig(BaseConfig):

--- a/scripts/token_export_visualizer.py
+++ b/scripts/token_export_visualizer.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python3
+import argparse
+import html
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Render a prime-rl token export JSONL record as HTML.")
+    parser.add_argument("jsonl", type=Path, help="Path to a token export JSONL file.")
+    parser.add_argument("--output", "-o", type=Path, help="Path to write the HTML file.")
+    parser.add_argument("--record-index", type=int, default=0, help="Record index to render after filters are applied.")
+    parser.add_argument("--step", type=int, help="Only consider records from this trainer step.")
+    parser.add_argument("--rank", type=int, help="Only consider records from this trainer rank.")
+    parser.add_argument("--env-name", help="Only consider records for this env name.")
+    parser.add_argument(
+        "--tokenizer",
+        help="Tokenizer model name or local path used to decode token ids into text fragments.",
+    )
+    parser.add_argument(
+        "--trust-remote-code",
+        action="store_true",
+        help="Pass trust_remote_code=True when loading --tokenizer.",
+    )
+    parser.add_argument(
+        "--max-mismatch",
+        type=float,
+        help="Mismatch KL value mapped to the deepest red. Defaults to the max finite mismatch in the record.",
+    )
+    args = parser.parse_args()
+
+    records = _load_records(args.jsonl)
+    record = _select_record(records, args.record_index, step=args.step, rank=args.rank, env_name=args.env_name)
+    if args.tokenizer:
+        _decode_token_texts(record, args.tokenizer, trust_remote_code=args.trust_remote_code)
+    _add_derived_token_fields(record)
+    output = args.output or args.jsonl.with_suffix(".html")
+    output.write_text(_render_html(record, max_mismatch=args.max_mismatch), encoding="utf-8")
+    print(output)
+
+
+def _load_records(path: Path) -> list[dict[str, Any]]:
+    with path.open("r", encoding="utf-8") as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def _select_record(
+    records: list[dict[str, Any]],
+    record_index: int,
+    *,
+    step: int | None,
+    rank: int | None,
+    env_name: str | None,
+) -> dict[str, Any]:
+    matches = [
+        record
+        for record in records
+        if (step is None or record.get("step") == step)
+        and (rank is None or record.get("rank") == rank)
+        and (env_name is None or record.get("env_name") == env_name)
+    ]
+    if not matches:
+        raise ValueError("No token export records matched the requested filters.")
+    if record_index < 0 or record_index >= len(matches):
+        raise IndexError(f"record-index {record_index} is out of range for {len(matches)} matched records.")
+    return matches[record_index]
+
+
+def _decode_token_texts(record: dict[str, Any], tokenizer_name: str, trust_remote_code: bool) -> None:
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_name, trust_remote_code=trust_remote_code)
+    tokens = record.get("tokens", [])
+    token_ids = [int(token["id"]) for token in tokens]
+    token_texts = tokenizer.batch_decode(
+        [[token_id] for token_id in token_ids],
+        skip_special_tokens=False,
+        clean_up_tokenization_spaces=False,
+    )
+    for token, text in zip(tokens, token_texts):
+        token["text"] = text
+
+
+def _add_derived_token_fields(record: dict[str, Any]) -> None:
+    for token in record.get("tokens", []):
+        log_ratio = _finite_float(token.get("log_importance_ratio"))
+        if log_ratio is None:
+            continue
+        token.setdefault("sample_kl_trainer_to_inference", log_ratio)
+        token.setdefault("sample_kl_inference_to_trainer", -log_ratio)
+
+
+def _render_html(record: dict[str, Any], max_mismatch: float | None) -> str:
+    tokens = record.get("tokens", [])
+    scale = _mismatch_scale(tokens, max_mismatch)
+    content = _render_segments(_chat_segments(tokens), scale)
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>prime-rl token export</title>
+  <style>
+    :root {{
+      color-scheme: light;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+      line-height: 1.5;
+    }}
+    body {{
+      margin: 0;
+      background: #f8fafc;
+      color: #111827;
+    }}
+    main {{
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 420px;
+      min-height: 100vh;
+    }}
+    .conversation {{
+      padding: 20px;
+    }}
+    .message {{
+      display: grid;
+      grid-template-columns: 92px minmax(0, 1fr);
+      gap: 12px;
+      padding: 14px 0;
+      border-bottom: 1px solid #e5e7eb;
+    }}
+    .role {{
+      align-self: start;
+      border-radius: 4px;
+      padding: 2px 6px;
+      width: max-content;
+      font-size: 12px;
+      font-weight: 700;
+      text-transform: uppercase;
+      color: #ffffff;
+      background: #4b5563;
+    }}
+    .role-system {{
+      background: #52525b;
+    }}
+    .role-user {{
+      background: #2563eb;
+    }}
+    .role-assistant {{
+      background: #059669;
+    }}
+    .role-tool {{
+      background: #7c3aed;
+    }}
+    .tokens {{
+      font-size: 16px;
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+    }}
+    .token {{
+      border-radius: 3px;
+      cursor: default;
+      transition: outline-color 80ms ease, box-shadow 80ms ease;
+    }}
+    .token:hover {{
+      outline: 1px solid #991b1b;
+      box-shadow: 0 0 0 2px rgba(153, 27, 27, 0.16);
+    }}
+    aside {{
+      border-left: 1px solid #d1d5db;
+      background: #ffffff;
+      padding: 16px;
+      position: sticky;
+      top: 0;
+      height: 100vh;
+      box-sizing: border-box;
+      overflow: auto;
+    }}
+    .label {{
+      font-size: 12px;
+      color: #6b7280;
+      margin-bottom: 8px;
+    }}
+    .details {{
+      font-size: 12px;
+    }}
+    .details table {{
+      width: 100%;
+      border-collapse: collapse;
+    }}
+    .details tr {{
+      border-bottom: 1px solid #e5e7eb;
+    }}
+    .details th {{
+      width: 42%;
+      padding: 6px 8px 6px 0;
+      text-align: left;
+      vertical-align: top;
+      color: #6b7280;
+      font-weight: 600;
+    }}
+    .details td {{
+      padding: 6px 0;
+      vertical-align: top;
+      overflow-wrap: anywhere;
+    }}
+    .muted {{
+      color: #6b7280;
+    }}
+    pre {{
+      margin: 0;
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+      font-size: 12px;
+    }}
+    @media (max-width: 900px) {{
+      main {{
+        display: block;
+      }}
+      .message {{
+        display: block;
+      }}
+      .role {{
+        margin-bottom: 8px;
+      }}
+      aside {{
+        position: static;
+        height: auto;
+        border-left: 0;
+        border-top: 1px solid #d1d5db;
+      }}
+    }}
+  </style>
+</head>
+<body>
+  <main>
+    <section class="conversation">{content}</section>
+    <aside>
+      <div class="label">Hover a token</div>
+      <div id="details" class="details muted">Token details will appear here.</div>
+    </aside>
+  </main>
+  <script>
+    const details = document.getElementById("details");
+    const fieldOrder = [
+      "mismatch_kl",
+      "is_masked",
+      "inference_prob",
+      "trainer_prob",
+      "prob_delta",
+      "importance_ratio",
+      "sample_kl_trainer_to_inference",
+      "sample_kl_inference_to_trainer",
+      "text",
+      "id",
+      "index",
+      "position",
+      "loss_mask",
+      "reward",
+      "advantage",
+      "entropy",
+      "is_masked_low",
+      "is_masked_high",
+      "is_clipped",
+      "log_importance_ratio",
+      "inference_logprob",
+      "trainer_logprob",
+    ];
+    const labels = {{
+      sample_kl_trainer_to_inference: "sample KL train→infer",
+      sample_kl_inference_to_trainer: "sample KL infer→train",
+      log_importance_ratio: "log ratio",
+      importance_ratio: "ratio",
+      prob_delta: "prob Δ",
+      inference_logprob: "infer logprob",
+      trainer_logprob: "train logprob",
+      inference_prob: "prob inference",
+      trainer_prob: "prob training",
+      mismatch_kl: "KL mismatch",
+      is_masked: "is_mask",
+      is_masked_low: "is_mask low",
+      is_masked_high: "is_mask high",
+    }};
+
+    function formatValue(value) {{
+      if (value === null || value === undefined) return "null";
+      if (typeof value === "number") {{
+        if (!Number.isFinite(value)) return String(value);
+        if (Math.abs(value) >= 1000 || (Math.abs(value) > 0 && Math.abs(value) < 0.0001)) {{
+          return value.toExponential(6);
+        }}
+        return Number(value.toPrecision(7)).toString();
+      }}
+      return String(value);
+    }}
+
+    function addRow(tbody, key, value) {{
+      const row = document.createElement("tr");
+      const th = document.createElement("th");
+      const td = document.createElement("td");
+      th.textContent = labels[key] || key;
+      td.textContent = formatValue(value);
+      row.appendChild(th);
+      row.appendChild(td);
+      tbody.appendChild(row);
+    }}
+
+    function renderDetails(rawInfo) {{
+      const token = JSON.parse(rawInfo);
+      const table = document.createElement("table");
+      const tbody = document.createElement("tbody");
+      const seen = new Set();
+      for (const key of fieldOrder) {{
+        if (Object.prototype.hasOwnProperty.call(token, key)) {{
+          addRow(tbody, key, token[key]);
+          seen.add(key);
+        }}
+      }}
+      for (const key of Object.keys(token).sort()) {{
+        if (!seen.has(key)) {{
+          addRow(tbody, key, token[key]);
+        }}
+      }}
+      table.appendChild(tbody);
+      details.classList.remove("muted");
+      details.replaceChildren(table);
+    }}
+
+    document.querySelectorAll(".token").forEach((node) => {{
+      node.addEventListener("mouseenter", () => {{
+        renderDetails(node.dataset.info);
+      }});
+    }});
+  </script>
+</body>
+</html>
+"""
+
+
+def _chat_segments(tokens: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if not tokens or tokens[0].get("text") is None:
+        return [{"role": "tokens", "tokens": tokens}]
+
+    segments = []
+    idx = 0
+    pending = []
+    while idx < len(tokens):
+        if tokens[idx].get("text") != "<|im_start|>":
+            pending.append(tokens[idx])
+            idx += 1
+            continue
+
+        if pending:
+            segments.append({"role": "tokens", "tokens": pending})
+            pending = []
+
+        role = "message"
+        idx += 1
+        if idx < len(tokens):
+            role = str(tokens[idx].get("text", role)).strip() or role
+            idx += 1
+        if idx < len(tokens) and tokens[idx].get("text") == "\n":
+            idx += 1
+
+        message_tokens = []
+        while idx < len(tokens) and tokens[idx].get("text") != "<|im_end|>":
+            message_tokens.append(tokens[idx])
+            idx += 1
+        if idx < len(tokens) and tokens[idx].get("text") == "<|im_end|>":
+            idx += 1
+        if idx < len(tokens) and tokens[idx].get("text") == "\n":
+            idx += 1
+        segments.append({"role": role, "tokens": message_tokens})
+
+    if pending:
+        segments.append({"role": "tokens", "tokens": pending})
+
+    return [segment for segment in segments if segment["tokens"]]
+
+
+def _render_segments(segments: list[dict[str, Any]], scale: float) -> str:
+    rendered = []
+    for segment in segments:
+        role = str(segment["role"])
+        token_spans = "".join(_render_token(token, scale) for token in segment["tokens"])
+        role_class = _role_class(role)
+        rendered.append(
+            f'<section class="message">'
+            f'<div class="role {role_class}">{html.escape(role)}</div>'
+            f'<div class="tokens">{token_spans}</div>'
+            f"</section>"
+        )
+    return "".join(rendered)
+
+
+def _role_class(role: str) -> str:
+    normalized = role.lower().replace("_", "-")
+    if normalized in {"system", "user", "assistant", "tool"}:
+        return f"role-{normalized}"
+    return ""
+
+
+def _render_token(token: dict[str, Any], scale: float) -> str:
+    text = token.get("text")
+    if text is None or text == "":
+        text = f"[token:{token.get('id')}]"
+    mismatch = _finite_float(token.get("mismatch_kl"))
+    if not token.get("loss_mask"):
+        mismatch = None
+    alpha = 0.0 if mismatch is None else min(max(mismatch / scale, 0.0), 1.0)
+    background = f"rgba(220, 38, 38, {0.08 + 0.72 * alpha:.3f})" if alpha > 0 else "transparent"
+    color = "#6b7280" if not token.get("loss_mask") else ("#111827" if alpha < 0.72 else "#ffffff")
+    decoration = "border-bottom: 2px solid #7c2d12;" if token.get("is_masked") else ""
+    info = html.escape(json.dumps(token, indent=2, sort_keys=True, ensure_ascii=False), quote=True)
+    title = html.escape(_mouse_summary(token), quote=True)
+    return (
+        f'<span class="token" data-info="{info}" title="{title}" '
+        f'style="background-color: {background}; color: {color}; {decoration}">{html.escape(text)}</span>'
+    )
+
+
+def _mouse_summary(token: dict[str, Any]) -> str:
+    return "\n".join(
+        [
+            f"is_mask={token.get('is_masked')}",
+            f"prob inference={_summary_value(token.get('inference_prob'))}",
+            f"prob training={_summary_value(token.get('trainer_prob'))}",
+            f"kl={_summary_value(token.get('mismatch_kl'))}",
+        ]
+    )
+
+
+def _summary_value(value: Any) -> str:
+    value = _finite_float(value)
+    if value is None:
+        return "null"
+    if abs(value) >= 1000 or (abs(value) > 0 and abs(value) < 0.0001):
+        return f"{value:.6e}"
+    return f"{value:.6g}"
+
+
+def _mismatch_scale(tokens: list[dict[str, Any]], override: float | None) -> float:
+    if override is not None:
+        if override <= 0:
+            raise ValueError("--max-mismatch must be positive.")
+        return override
+    values = [_finite_float(token.get("mismatch_kl")) for token in tokens if token.get("loss_mask")]
+    values = [value for value in values if value is not None and value > 0]
+    if not values:
+        return 1.0
+    return max(_percentile(values, 0.95), 0.05)
+
+
+def _percentile(values: list[float], q: float) -> float:
+    ordered = sorted(values)
+    idx = min(max(round((len(ordered) - 1) * q), 0), len(ordered) - 1)
+    return ordered[idx]
+
+
+def _finite_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    value = float(value)
+    if not math.isfinite(value):
+        return None
+    return value
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/token_export_visualizer.py
+++ b/scripts/token_export_visualizer.py
@@ -395,7 +395,6 @@ def _render_html(records: list[dict[str, Any]], max_mismatch: float | None, init
       "entropy",
       "is_masked_low",
       "is_masked_high",
-      "is_clipped",
       "log_importance_ratio",
       "inference_logprob",
       "trainer_logprob",

--- a/scripts/token_export_visualizer.py
+++ b/scripts/token_export_visualizer.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import argparse
-import html
 import json
 import math
 from pathlib import Path
@@ -8,10 +7,20 @@ from typing import Any
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Render a prime-rl token export JSONL record as HTML.")
-    parser.add_argument("jsonl", type=Path, help="Path to a token export JSONL file.")
+    parser = argparse.ArgumentParser(description="Render prime-rl token export JSONL as HTML.")
+    parser.add_argument("input", type=Path, help="Path to a token export JSONL file or directory of JSONL exports.")
     parser.add_argument("--output", "-o", type=Path, help="Path to write the HTML file.")
-    parser.add_argument("--record-index", type=int, default=0, help="Record index to render after filters are applied.")
+    parser.add_argument(
+        "--record-index",
+        type=int,
+        default=0,
+        help="Record index to render after filters are applied, or initial record in --all-records mode.",
+    )
+    parser.add_argument(
+        "--all-records",
+        action="store_true",
+        help="Embed every matched record in one navigable HTML page. Implied for directory inputs.",
+    )
     parser.add_argument("--step", type=int, help="Only consider records from this trainer step.")
     parser.add_argument("--rank", type=int, help="Only consider records from this trainer rank.")
     parser.add_argument("--env-name", help="Only consider records for this env name.")
@@ -27,45 +36,96 @@ def main() -> None:
     parser.add_argument(
         "--max-mismatch",
         type=float,
-        help="Mismatch KL value mapped to the deepest red. Defaults to the max finite mismatch in the record.",
+        help="Mismatch KL value mapped to the deepest red. Defaults to the p95 finite trainable mismatch.",
     )
     args = parser.parse_args()
 
-    records = _load_records(args.jsonl)
-    record = _select_record(records, args.record_index, step=args.step, rank=args.rank, env_name=args.env_name)
+    records = _filter_records(_load_records(args.input), step=args.step, rank=args.rank, env_name=args.env_name)
+    if not records:
+        raise ValueError("No token export records matched the requested filters.")
+
+    render_all = args.all_records or args.input.is_dir()
+    if render_all:
+        if args.record_index < 0 or args.record_index >= len(records):
+            raise IndexError(f"record-index {args.record_index} is out of range for {len(records)} matched records.")
+        selected_records = records
+        initial_index = args.record_index
+    else:
+        selected_records = [_select_record(records, args.record_index)]
+        initial_index = 0
+
     if args.tokenizer:
-        _decode_token_texts(record, args.tokenizer, trust_remote_code=args.trust_remote_code)
-    _add_derived_token_fields(record)
-    output = args.output or args.jsonl.with_suffix(".html")
-    output.write_text(_render_html(record, max_mismatch=args.max_mismatch), encoding="utf-8")
+        for record in selected_records:
+            _decode_token_texts(record, args.tokenizer, trust_remote_code=args.trust_remote_code)
+    for record in selected_records:
+        _add_derived_token_fields(record)
+
+    output = args.output or _default_output_path(args.input)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        _render_html(selected_records, max_mismatch=args.max_mismatch, initial_index=initial_index), encoding="utf-8"
+    )
     print(output)
 
 
+def _default_output_path(path: Path) -> Path:
+    if path.is_dir():
+        return path / "index.html"
+    return path.with_suffix(".html")
+
+
 def _load_records(path: Path) -> list[dict[str, Any]]:
-    with path.open("r", encoding="utf-8") as f:
-        return [json.loads(line) for line in f if line.strip()]
+    if path.is_dir():
+        files = sorted(file for file in path.rglob("*.jsonl") if file.is_file())
+        if not files:
+            raise FileNotFoundError(f"No JSONL files found under {path}")
+        root = path
+    else:
+        files = [path]
+        root = path.parent
+
+    records = []
+    for file in files:
+        source_file = _relative_source(file, root)
+        with file.open("r", encoding="utf-8") as f:
+            for line_number, line in enumerate(f, start=1):
+                if not line.strip():
+                    continue
+                record = json.loads(line)
+                record["_source_file"] = source_file
+                record["_source_line"] = line_number
+                record["_source_record_index"] = len(records)
+                records.append(record)
+    return records
 
 
-def _select_record(
+def _relative_source(file: Path, root: Path) -> str:
+    try:
+        return str(file.relative_to(root))
+    except ValueError:
+        return str(file)
+
+
+def _filter_records(
     records: list[dict[str, Any]],
-    record_index: int,
     *,
     step: int | None,
     rank: int | None,
     env_name: str | None,
-) -> dict[str, Any]:
-    matches = [
+) -> list[dict[str, Any]]:
+    return [
         record
         for record in records
         if (step is None or record.get("step") == step)
         and (rank is None or record.get("rank") == rank)
         and (env_name is None or record.get("env_name") == env_name)
     ]
-    if not matches:
-        raise ValueError("No token export records matched the requested filters.")
-    if record_index < 0 or record_index >= len(matches):
-        raise IndexError(f"record-index {record_index} is out of range for {len(matches)} matched records.")
-    return matches[record_index]
+
+
+def _select_record(records: list[dict[str, Any]], record_index: int) -> dict[str, Any]:
+    if record_index < 0 or record_index >= len(records):
+        raise IndexError(f"record-index {record_index} is out of range for {len(records)} matched records.")
+    return records[record_index]
 
 
 def _decode_token_texts(record: dict[str, Any], tokenizer_name: str, trust_remote_code: bool) -> None:
@@ -92,43 +152,97 @@ def _add_derived_token_fields(record: dict[str, Any]) -> None:
         token.setdefault("sample_kl_inference_to_trainer", -log_ratio)
 
 
-def _render_html(record: dict[str, Any], max_mismatch: float | None) -> str:
-    tokens = record.get("tokens", [])
-    scale = _mismatch_scale(tokens, max_mismatch)
-    content = _render_segments(_chat_segments(tokens), scale)
-    return f"""<!doctype html>
+def _render_html(records: list[dict[str, Any]], max_mismatch: float | None, initial_index: int) -> str:
+    scale = _mismatch_scale([token for record in records for token in record.get("tokens", [])], max_mismatch)
+    prepared_records = _prepare_records(records)
+    document = """<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>prime-rl token export</title>
   <style>
-    :root {{
+    :root {
       color-scheme: light;
       font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
       line-height: 1.5;
-    }}
-    body {{
+    }
+    body {
       margin: 0;
       background: #f8fafc;
       color: #111827;
-    }}
-    main {{
+    }
+    main {
       display: grid;
-      grid-template-columns: minmax(0, 1fr) 420px;
+      grid-template-columns: 300px minmax(0, 1fr) 420px;
       min-height: 100vh;
-    }}
-    .conversation {{
+    }
+    .records-nav {
+      border-right: 1px solid #d1d5db;
+      background: #ffffff;
+      padding: 16px;
+      position: sticky;
+      top: 0;
+      height: 100vh;
+      box-sizing: border-box;
+      overflow: auto;
+    }
+    .record-search {
+      box-sizing: border-box;
+      width: 100%;
+      margin: 10px 0 12px;
+      border: 1px solid #d1d5db;
+      border-radius: 4px;
+      padding: 8px 9px;
+      font: inherit;
+      font-size: 12px;
+      color: #111827;
+      background: #ffffff;
+    }
+    .record-list {
+      display: grid;
+      gap: 6px;
+    }
+    .record-button {
+      display: block;
+      width: 100%;
+      border: 1px solid #e5e7eb;
+      border-radius: 4px;
+      padding: 8px;
+      text-align: left;
+      font: inherit;
+      font-size: 12px;
+      color: #111827;
+      background: #ffffff;
+      cursor: pointer;
+    }
+    .record-button:hover {
+      border-color: #9ca3af;
+      background: #f9fafb;
+    }
+    .record-button.active {
+      border-color: #2563eb;
+      background: #eff6ff;
+    }
+    .record-title {
+      font-weight: 700;
+      margin-bottom: 2px;
+    }
+    .record-subtitle {
+      color: #6b7280;
+      overflow-wrap: anywhere;
+    }
+    .conversation {
       padding: 20px;
-    }}
-    .message {{
+    }
+    .message {
       display: grid;
       grid-template-columns: 92px minmax(0, 1fr);
       gap: 12px;
       padding: 14px 0;
       border-bottom: 1px solid #e5e7eb;
-    }}
-    .role {{
+    }
+    .role {
       align-self: start;
       border-radius: 4px;
       padding: 2px 6px;
@@ -138,34 +252,34 @@ def _render_html(record: dict[str, Any], max_mismatch: float | None) -> str:
       text-transform: uppercase;
       color: #ffffff;
       background: #4b5563;
-    }}
-    .role-system {{
+    }
+    .role-system {
       background: #52525b;
-    }}
-    .role-user {{
+    }
+    .role-user {
       background: #2563eb;
-    }}
-    .role-assistant {{
+    }
+    .role-assistant {
       background: #059669;
-    }}
-    .role-tool {{
+    }
+    .role-tool {
       background: #7c3aed;
-    }}
-    .tokens {{
+    }
+    .tokens {
       font-size: 16px;
       white-space: pre-wrap;
       overflow-wrap: anywhere;
-    }}
-    .token {{
+    }
+    .token {
       border-radius: 3px;
       cursor: default;
       transition: outline-color 80ms ease, box-shadow 80ms ease;
-    }}
-    .token:hover {{
+    }
+    .token:hover {
       outline: 1px solid #991b1b;
       box-shadow: 0 0 0 2px rgba(153, 27, 27, 0.16);
-    }}
-    aside {{
+    }
+    aside {
       border-left: 1px solid #d1d5db;
       background: #ffffff;
       padding: 16px;
@@ -174,73 +288,94 @@ def _render_html(record: dict[str, Any], max_mismatch: float | None) -> str:
       height: 100vh;
       box-sizing: border-box;
       overflow: auto;
-    }}
-    .label {{
+    }
+    .label {
       font-size: 12px;
       color: #6b7280;
       margin-bottom: 8px;
-    }}
-    .details {{
+    }
+    .details {
       font-size: 12px;
-    }}
-    .details table {{
+    }
+    .details table {
       width: 100%;
       border-collapse: collapse;
-    }}
-    .details tr {{
+    }
+    .details tr {
       border-bottom: 1px solid #e5e7eb;
-    }}
-    .details th {{
+    }
+    .details th {
       width: 42%;
       padding: 6px 8px 6px 0;
       text-align: left;
       vertical-align: top;
       color: #6b7280;
       font-weight: 600;
-    }}
-    .details td {{
+    }
+    .details td {
       padding: 6px 0;
       vertical-align: top;
       overflow-wrap: anywhere;
-    }}
-    .muted {{
+    }
+    .muted {
       color: #6b7280;
-    }}
-    pre {{
-      margin: 0;
-      white-space: pre-wrap;
-      overflow-wrap: anywhere;
-      font-size: 12px;
-    }}
-    @media (max-width: 900px) {{
-      main {{
+    }
+    .empty {
+      padding: 24px 0;
+      color: #6b7280;
+      font-size: 13px;
+    }
+    @media (max-width: 1100px) {
+      main {
         display: block;
-      }}
-      .message {{
-        display: block;
-      }}
-      .role {{
-        margin-bottom: 8px;
-      }}
-      aside {{
+      }
+      .records-nav,
+      aside {
         position: static;
         height: auto;
+      }
+      .records-nav {
+        border-right: 0;
+        border-bottom: 1px solid #d1d5db;
+      }
+      .message {
+        display: block;
+      }
+      .role {
+        margin-bottom: 8px;
+      }
+      aside {
         border-left: 0;
         border-top: 1px solid #d1d5db;
-      }}
-    }}
+      }
+    }
   </style>
 </head>
 <body>
   <main>
-    <section class="conversation">{content}</section>
+    <nav class="records-nav">
+      <div class="label">Records</div>
+      <div id="record-count" class="muted"></div>
+      <input id="record-search" class="record-search" type="search" placeholder="Filter step, rank, env" autocomplete="off">
+      <div id="record-list" class="record-list"></div>
+    </nav>
+    <section id="conversation" class="conversation"></section>
     <aside>
       <div class="label">Hover a token</div>
       <div id="details" class="details muted">Token details will appear here.</div>
     </aside>
   </main>
+  <script id="records-data" type="application/json">__RECORDS_JSON__</script>
   <script>
+    const records = JSON.parse(document.getElementById("records-data").textContent);
+    const mismatchScale = __MISMATCH_SCALE__;
+    let activeIndex = __INITIAL_RECORD_INDEX__;
+
+    const conversation = document.getElementById("conversation");
     const details = document.getElementById("details");
+    const recordCount = document.getElementById("record-count");
+    const recordList = document.getElementById("record-list");
+    const recordSearch = document.getElementById("record-search");
     const fieldOrder = [
       "mismatch_kl",
       "is_masked",
@@ -265,12 +400,12 @@ def _render_html(record: dict[str, Any], max_mismatch: float | None) -> str:
       "inference_logprob",
       "trainer_logprob",
     ];
-    const labels = {{
-      sample_kl_trainer_to_inference: "sample KL train→infer",
-      sample_kl_inference_to_trainer: "sample KL infer→train",
+    const labels = {
+      sample_kl_trainer_to_inference: "sample KL train->infer",
+      sample_kl_inference_to_trainer: "sample KL infer->train",
       log_importance_ratio: "log ratio",
       importance_ratio: "ratio",
-      prob_delta: "prob Δ",
+      prob_delta: "prob delta",
       inference_logprob: "infer logprob",
       trainer_logprob: "train logprob",
       inference_prob: "prob inference",
@@ -279,21 +414,124 @@ def _render_html(record: dict[str, Any], max_mismatch: float | None) -> str:
       is_masked: "is_mask",
       is_masked_low: "is_mask low",
       is_masked_high: "is_mask high",
-    }};
+    };
 
-    function formatValue(value) {{
-      if (value === null || value === undefined) return "null";
-      if (typeof value === "number") {{
-        if (!Number.isFinite(value)) return String(value);
-        if (Math.abs(value) >= 1000 || (Math.abs(value) > 0 && Math.abs(value) < 0.0001)) {{
-          return value.toExponential(6);
-        }}
-        return Number(value.toPrecision(7)).toString();
-      }}
-      return String(value);
-    }}
+    function renderNav() {
+      const query = recordSearch.value.trim().toLowerCase();
+      recordList.replaceChildren();
+      let shown = 0;
+      records.forEach((record, index) => {
+        const text = record.meta.search_text;
+        if (query && !text.includes(query)) {
+          return;
+        }
+        shown += 1;
+        const button = document.createElement("button");
+        button.type = "button";
+        button.className = "record-button" + (index === activeIndex ? " active" : "");
+        button.addEventListener("click", () => renderConversation(index));
 
-    function addRow(tbody, key, value) {{
+        const title = document.createElement("div");
+        title.className = "record-title";
+        title.textContent = record.meta.label;
+
+        const subtitle = document.createElement("div");
+        subtitle.className = "record-subtitle";
+        subtitle.textContent = record.meta.subtitle;
+
+        button.appendChild(title);
+        button.appendChild(subtitle);
+        recordList.appendChild(button);
+      });
+      recordCount.textContent = `${shown} of ${records.length}`;
+    }
+
+    function renderConversation(index) {
+      activeIndex = index;
+      const record = records[index];
+      conversation.replaceChildren();
+      details.className = "details muted";
+      details.textContent = "Token details will appear here.";
+
+      if (!record || record.segments.length === 0) {
+        const empty = document.createElement("div");
+        empty.className = "empty";
+        empty.textContent = "No tokens in this record.";
+        conversation.appendChild(empty);
+        renderNav();
+        return;
+      }
+
+      for (const segment of record.segments) {
+        if (!segment.tokens.length) {
+          continue;
+        }
+        const section = document.createElement("section");
+        section.className = "message";
+
+        const role = document.createElement("div");
+        role.className = "role " + roleClass(segment.role);
+        role.textContent = segment.role;
+
+        const tokens = document.createElement("div");
+        tokens.className = "tokens";
+        for (const token of segment.tokens) {
+          tokens.appendChild(renderToken(token));
+        }
+
+        section.appendChild(role);
+        section.appendChild(tokens);
+        conversation.appendChild(section);
+      }
+      renderNav();
+    }
+
+    function renderToken(token) {
+      const span = document.createElement("span");
+      span.className = "token";
+      span.textContent = token.text === null || token.text === undefined || token.text === "" ? `[token:${token.id}]` : token.text;
+      const mismatch = finiteNumber(token.mismatch_kl);
+      const useMismatch = Boolean(token.loss_mask) && mismatch !== null;
+      const alpha = useMismatch ? Math.min(Math.max(mismatch / mismatchScale, 0), 1) : 0;
+      span.style.backgroundColor = alpha > 0 ? `rgba(220, 38, 38, ${(0.08 + 0.72 * alpha).toFixed(3)})` : "transparent";
+      span.style.color = !token.loss_mask ? "#6b7280" : (alpha < 0.72 ? "#111827" : "#ffffff");
+      if (token.is_masked) {
+        span.style.borderBottom = "2px solid #7c2d12";
+      }
+      span.title = mouseSummary(token);
+      span.addEventListener("mouseenter", () => renderDetails(token));
+      return span;
+    }
+
+    function roleClass(role) {
+      const normalized = String(role).toLowerCase().replaceAll("_", "-");
+      if (["system", "user", "assistant", "tool"].includes(normalized)) {
+        return `role-${normalized}`;
+      }
+      return "";
+    }
+
+    function renderDetails(token) {
+      const table = document.createElement("table");
+      const tbody = document.createElement("tbody");
+      const seen = new Set();
+      for (const key of fieldOrder) {
+        if (Object.prototype.hasOwnProperty.call(token, key)) {
+          addRow(tbody, key, token[key]);
+          seen.add(key);
+        }
+      }
+      for (const key of Object.keys(token).sort()) {
+        if (!seen.has(key)) {
+          addRow(tbody, key, token[key]);
+        }
+      }
+      table.appendChild(tbody);
+      details.className = "details";
+      details.replaceChildren(table);
+    }
+
+    function addRow(tbody, key, value) {
       const row = document.createElement("tr");
       const th = document.createElement("th");
       const td = document.createElement("td");
@@ -302,38 +540,119 @@ def _render_html(record: dict[str, Any], max_mismatch: float | None) -> str:
       row.appendChild(th);
       row.appendChild(td);
       tbody.appendChild(row);
-    }}
+    }
 
-    function renderDetails(rawInfo) {{
-      const token = JSON.parse(rawInfo);
-      const table = document.createElement("table");
-      const tbody = document.createElement("tbody");
-      const seen = new Set();
-      for (const key of fieldOrder) {{
-        if (Object.prototype.hasOwnProperty.call(token, key)) {{
-          addRow(tbody, key, token[key]);
-          seen.add(key);
-        }}
-      }}
-      for (const key of Object.keys(token).sort()) {{
-        if (!seen.has(key)) {{
-          addRow(tbody, key, token[key]);
-        }}
-      }}
-      table.appendChild(tbody);
-      details.classList.remove("muted");
-      details.replaceChildren(table);
-    }}
+    function formatValue(value) {
+      if (value === null || value === undefined) return "null";
+      if (typeof value === "number") {
+        if (!Number.isFinite(value)) return String(value);
+        if (Math.abs(value) >= 1000 || (Math.abs(value) > 0 && Math.abs(value) < 0.0001)) {
+          return value.toExponential(6);
+        }
+        return Number(value.toPrecision(7)).toString();
+      }
+      return String(value);
+    }
 
-    document.querySelectorAll(".token").forEach((node) => {{
-      node.addEventListener("mouseenter", () => {{
-        renderDetails(node.dataset.info);
-      }});
-    }});
+    function mouseSummary(token) {
+      return [
+        `is_mask=${token.is_masked}`,
+        `prob inference=${summaryValue(token.inference_prob)}`,
+        `prob training=${summaryValue(token.trainer_prob)}`,
+        `kl=${summaryValue(token.mismatch_kl)}`,
+      ].join("\\n");
+    }
+
+    function summaryValue(value) {
+      value = finiteNumber(value);
+      if (value === null) return "null";
+      if (Math.abs(value) >= 1000 || (Math.abs(value) > 0 && Math.abs(value) < 0.0001)) {
+        return value.toExponential(6);
+      }
+      return Number(value.toPrecision(6)).toString();
+    }
+
+    function finiteNumber(value) {
+      if (value === null || value === undefined) return null;
+      const number = Number(value);
+      return Number.isFinite(number) ? number : null;
+    }
+
+    recordSearch.addEventListener("input", renderNav);
+    renderConversation(Math.min(Math.max(activeIndex, 0), records.length - 1));
   </script>
 </body>
 </html>
 """
+    return (
+        document.replace("__RECORDS_JSON__", _json_script(prepared_records))
+        .replace("__MISMATCH_SCALE__", json.dumps(scale))
+        .replace("__INITIAL_RECORD_INDEX__", json.dumps(initial_index))
+    )
+
+
+def _prepare_records(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "meta": _record_meta(record, ordinal),
+            "segments": _chat_segments(record.get("tokens", [])),
+        }
+        for ordinal, record in enumerate(records)
+    ]
+
+
+def _record_meta(record: dict[str, Any], ordinal: int) -> dict[str, Any]:
+    tokens = record.get("tokens", [])
+    token_count = len(tokens)
+    trainable_count = sum(1 for token in tokens if token.get("loss_mask"))
+    label_parts = [f"#{ordinal}"]
+    for key, label in (
+        ("step", "step"),
+        ("rank", "rank"),
+        ("env_name", "env"),
+        ("export_sequence_idx", "seq"),
+    ):
+        value = record.get(key)
+        if value is not None:
+            label_parts.append(f"{label} {value}")
+
+    subtitle_parts = [
+        f"{trainable_count}/{token_count} trainable",
+        str(record.get("_source_file", "")),
+        f"line {record.get('_source_line')}",
+    ]
+    meta = {
+        "ordinal": ordinal,
+        "label": " | ".join(label_parts),
+        "subtitle": " | ".join(part for part in subtitle_parts if part),
+        "step": record.get("step"),
+        "rank": record.get("rank"),
+        "micro_step": record.get("micro_step"),
+        "micro_sequence_idx": record.get("micro_sequence_idx"),
+        "export_sequence_idx": record.get("export_sequence_idx"),
+        "env_name": record.get("env_name"),
+        "source_file": record.get("_source_file"),
+        "source_line": record.get("_source_line"),
+        "token_count": token_count,
+        "trainable_token_count": trainable_count,
+    }
+    meta["search_text"] = " ".join(str(value) for value in meta.values() if value is not None).lower()
+    return meta
+
+
+def _json_script(value: Any) -> str:
+    payload = json.dumps(_json_safe(value), ensure_ascii=False, allow_nan=False, separators=(",", ":"))
+    return payload.replace("&", "\\u0026").replace("<", "\\u003c").replace(">", "\\u003e")
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, list | tuple):
+        return [_json_safe(item) for item in value]
+    return value
 
 
 def _chat_segments(tokens: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -375,67 +694,6 @@ def _chat_segments(tokens: list[dict[str, Any]]) -> list[dict[str, Any]]:
         segments.append({"role": "tokens", "tokens": pending})
 
     return [segment for segment in segments if segment["tokens"]]
-
-
-def _render_segments(segments: list[dict[str, Any]], scale: float) -> str:
-    rendered = []
-    for segment in segments:
-        role = str(segment["role"])
-        token_spans = "".join(_render_token(token, scale) for token in segment["tokens"])
-        role_class = _role_class(role)
-        rendered.append(
-            f'<section class="message">'
-            f'<div class="role {role_class}">{html.escape(role)}</div>'
-            f'<div class="tokens">{token_spans}</div>'
-            f"</section>"
-        )
-    return "".join(rendered)
-
-
-def _role_class(role: str) -> str:
-    normalized = role.lower().replace("_", "-")
-    if normalized in {"system", "user", "assistant", "tool"}:
-        return f"role-{normalized}"
-    return ""
-
-
-def _render_token(token: dict[str, Any], scale: float) -> str:
-    text = token.get("text")
-    if text is None or text == "":
-        text = f"[token:{token.get('id')}]"
-    mismatch = _finite_float(token.get("mismatch_kl"))
-    if not token.get("loss_mask"):
-        mismatch = None
-    alpha = 0.0 if mismatch is None else min(max(mismatch / scale, 0.0), 1.0)
-    background = f"rgba(220, 38, 38, {0.08 + 0.72 * alpha:.3f})" if alpha > 0 else "transparent"
-    color = "#6b7280" if not token.get("loss_mask") else ("#111827" if alpha < 0.72 else "#ffffff")
-    decoration = "border-bottom: 2px solid #7c2d12;" if token.get("is_masked") else ""
-    info = html.escape(json.dumps(token, indent=2, sort_keys=True, ensure_ascii=False), quote=True)
-    title = html.escape(_mouse_summary(token), quote=True)
-    return (
-        f'<span class="token" data-info="{info}" title="{title}" '
-        f'style="background-color: {background}; color: {color}; {decoration}">{html.escape(text)}</span>'
-    )
-
-
-def _mouse_summary(token: dict[str, Any]) -> str:
-    return "\n".join(
-        [
-            f"is_mask={token.get('is_masked')}",
-            f"prob inference={_summary_value(token.get('inference_prob'))}",
-            f"prob training={_summary_value(token.get('trainer_prob'))}",
-            f"kl={_summary_value(token.get('mismatch_kl'))}",
-        ]
-    )
-
-
-def _summary_value(value: Any) -> str:
-    value = _finite_float(value)
-    if value is None:
-        return "null"
-    if abs(value) >= 1000 or (abs(value) > 0 and abs(value) < 0.0001):
-        return f"{value:.6e}"
-    return f"{value:.6g}"
 
 
 def _mismatch_scale(tokens: list[dict[str, Any]], override: float | None) -> float:

--- a/scripts/token_export_visualizer.py
+++ b/scripts/token_export_visualizer.py
@@ -55,8 +55,9 @@ def main() -> None:
         initial_index = 0
 
     if args.tokenizer:
+        tokenizer = _load_tokenizer(args.tokenizer, trust_remote_code=args.trust_remote_code)
         for record in selected_records:
-            _decode_token_texts(record, args.tokenizer, trust_remote_code=args.trust_remote_code)
+            _decode_token_texts(record, tokenizer)
     for record in selected_records:
         _add_derived_token_fields(record)
 
@@ -128,10 +129,13 @@ def _select_record(records: list[dict[str, Any]], record_index: int) -> dict[str
     return records[record_index]
 
 
-def _decode_token_texts(record: dict[str, Any], tokenizer_name: str, trust_remote_code: bool) -> None:
+def _load_tokenizer(tokenizer_name: str, trust_remote_code: bool) -> Any:
     from transformers import AutoTokenizer
 
-    tokenizer = AutoTokenizer.from_pretrained(tokenizer_name, trust_remote_code=trust_remote_code)
+    return AutoTokenizer.from_pretrained(tokenizer_name, trust_remote_code=trust_remote_code)
+
+
+def _decode_token_texts(record: dict[str, Any], tokenizer: Any) -> None:
     tokens = record.get("tokens", [])
     token_ids = [int(token["id"]) for token in tokens]
     token_texts = tokenizer.batch_decode(

--- a/skills/configs/SKILL.md
+++ b/skills/configs/SKILL.md
@@ -60,6 +60,25 @@ CLI: `--env.0.id reverse-text --env.1.id math-env`.
 
 In TOML, an empty section header (`[ckpt]`) does the same.
 
+## RL trainer token exports
+
+For rollout visualization/debugging, enable trainer-side token export under `trainer.experimental.token_export` (or `experimental.token_export` when running the trainer entrypoint directly). It writes JSONL records with per-token ids, loss mask, advantage, reward, entropy, mismatch KL, inference logprob/prob, trainer logprob/prob, and masking diagnostics. It does not decode token text in the trainer.
+
+```toml
+[trainer.experimental.token_export]
+# Optional. Relative paths resolve under trainer.output_dir.
+path = "token_exports/sample.jsonl"
+```
+
+Leave it unset for normal training. When enabled, it exports every sequence from each exporting rank.
+
+```bash
+uv run scripts/token_export_visualizer.py outputs/token_exports/rank_0.jsonl --tokenizer Qwen/Qwen3-0.6B -o /tmp/token_export.html
+uv run scripts/token_export_visualizer.py outputs/token_exports --tokenizer Qwen/Qwen3-0.6B -o outputs/token_exports/index.html
+```
+
+Directory inputs render every exported sequence as one navigable HTML page. For a single JSONL file, pass `--all-records` to embed every matching record instead of just one `--record-index`.
+
 ## Key files
 
 - `packages/prime-rl-configs/src/prime_rl/` — config classes under `configs/`; `utils/config.py` re-exports `BaseConfig` and `cli`

--- a/src/prime_rl/trainer/batch.py
+++ b/src/prime_rl/trainer/batch.py
@@ -12,6 +12,8 @@ def prepare_sample(training_example: TrainingSample, seq_len: int) -> MicroBatch
     loss_mask = training_example.prompt_mask + training_example.completion_mask
     inference_logprobs = [0.0] * len(training_example.prompt_ids) + training_example.completion_logprobs
     advantages = [training_example.advantage] * len(input_ids)
+    reward = training_example.reward if training_example.reward is not None else float("nan")
+    rewards = [reward] * len(input_ids)
     position_ids = list(range(len(input_ids)))
     mm_token_type_ids = training_example.mm_token_type_ids
     assert training_example.env_name != "all", "env_name='all' is reserved for aggregate metric keys"
@@ -33,6 +35,7 @@ def prepare_sample(training_example: TrainingSample, seq_len: int) -> MicroBatch
         inference_logprobs = inference_logprobs[:seq_len]
         position_ids = position_ids[:seq_len]
         advantages = advantages[:seq_len]
+        rewards = rewards[:seq_len]
         temperatures = temperatures[:seq_len]
         if teacher_logprobs is not None:
             teacher_logprobs = teacher_logprobs[:seq_len]
@@ -48,9 +51,10 @@ def prepare_sample(training_example: TrainingSample, seq_len: int) -> MicroBatch
         == len(loss_mask)
         == len(position_ids)
         == len(inference_logprobs)
+        == len(rewards)
         == len(temperatures)
     ), (
-        f"input_ids: {len(input_ids)}, advantages: {len(advantages)}, loss_mask: {len(loss_mask)}, position_ids: {len(position_ids)}, inference_logprobs: {len(inference_logprobs)}, temperatures: {len(temperatures)}"
+        f"input_ids: {len(input_ids)}, advantages: {len(advantages)}, loss_mask: {len(loss_mask)}, position_ids: {len(position_ids)}, inference_logprobs: {len(inference_logprobs)}, rewards: {len(rewards)}, temperatures: {len(temperatures)}"
     )
     if teacher_logprobs is not None:
         assert len(teacher_logprobs) == len(input_ids), f"teacher_logprobs: {len(teacher_logprobs)}"
@@ -74,6 +78,7 @@ def prepare_sample(training_example: TrainingSample, seq_len: int) -> MicroBatch
         inference_logprobs=inference_logprobs,
         teacher_logprobs=teacher_logprobs,
         temperatures=temperatures,
+        rewards=rewards,
         routed_experts=routed_experts,
         mm_token_type_ids=mm_token_type_ids,
         env_names=env_names,
@@ -122,9 +127,16 @@ def packed_samples_into_micro_bs(
                 len(bin_content.input_ids) + len(sample.input_ids) <= max_seq_len
                 and bin_content.training_mode == sample.training_mode
             ):
+                existing_len = len(bin_content.input_ids)
                 bin_content.input_ids.extend(sample.input_ids)
                 bin_content.loss_mask.extend(sample.loss_mask)
                 bin_content.advantages.extend(sample.advantages)
+                if sample.rewards is not None:
+                    if bin_content.rewards is None:
+                        bin_content.rewards = [float("nan")] * existing_len
+                    bin_content.rewards.extend(sample.rewards)
+                elif bin_content.rewards is not None:
+                    bin_content.rewards.extend([float("nan")] * len(sample.input_ids))
                 bin_content.inference_logprobs.extend(sample.inference_logprobs)
                 bin_content.temperatures.extend(sample.temperatures)
                 if sample.teacher_logprobs is not None:
@@ -175,6 +187,8 @@ def pad_micro_batch(micro_batch: MicroBatch, pad_to_multiple_of: int) -> MicroBa
 
     micro_batch.input_ids.extend([1] * padding_size)
     micro_batch.advantages.extend([0.0] * padding_size)
+    if micro_batch.rewards is not None:
+        micro_batch.rewards.extend([float("nan")] * padding_size)
     micro_batch.loss_mask.extend([False] * padding_size)
     micro_batch.position_ids.extend(list(range(padding_size)))
     micro_batch.inference_logprobs.extend([0.0] * padding_size)

--- a/src/prime_rl/trainer/rl/data.py
+++ b/src/prime_rl/trainer/rl/data.py
@@ -20,6 +20,7 @@ class TensorMicroBatch(TypedDict):
     input_ids: Int[Tensor, "batch seq"]
     position_ids: Int[Tensor, "batch seq"]
     advantages: Float[Tensor, "batch seq"]
+    rewards: Float[Tensor, "batch seq"] | None
     inference_logprobs: Float[Tensor, "batch seq"]
     teacher_logprobs: Float[Tensor, "batch seq"] | None
     loss_mask: Bool[Tensor, "batch seq"]
@@ -108,6 +109,7 @@ class FakeDataLoader:
             "input_ids": input_ids.unsqueeze(0),
             "position_ids": position_ids.unsqueeze(0),
             "advantages": advantages.unsqueeze(0),
+            "rewards": None,
             "inference_logprobs": inference_logprobs.unsqueeze(0),
             "teacher_logprobs": None,
             "temperatures": torch.ones(input_ids.shape[0]).unsqueeze(0),
@@ -135,6 +137,7 @@ class FakeDataLoader:
             ),
             "position_ids": torch.cat([torch.arange(self.seq_len)]).unsqueeze(0),
             "advantages": torch.randn(self.seq_len, generator=generator).unsqueeze(0),
+            "rewards": None,
             "inference_logprobs": torch.randn(self.seq_len, generator=generator).unsqueeze(0),
             "teacher_logprobs": None,
             "temperatures": torch.ones(self.seq_len).unsqueeze(0),
@@ -211,6 +214,9 @@ class DataLoader:
             input_ids=torch.tensor(micro_batch.input_ids, dtype=torch.long).unsqueeze(0),
             position_ids=torch.tensor(micro_batch.position_ids, dtype=torch.long).unsqueeze(0),
             advantages=torch.tensor(micro_batch.advantages, dtype=torch.float).unsqueeze(0),
+            rewards=torch.tensor(micro_batch.rewards, dtype=torch.float).unsqueeze(0)
+            if micro_batch.rewards is not None
+            else None,
             inference_logprobs=torch.tensor(micro_batch.inference_logprobs, dtype=torch.float).unsqueeze(0),
             teacher_logprobs=torch.tensor(micro_batch.teacher_logprobs, dtype=torch.float).unsqueeze(0)
             if micro_batch.teacher_logprobs is not None

--- a/src/prime_rl/trainer/rl/token_export.py
+++ b/src/prime_rl/trainer/rl/token_export.py
@@ -94,9 +94,6 @@ class TokenExporter:
         response_lengths: list[int],
         loss_config: Any,
     ) -> None:
-        if step % self.config.interval != 0:
-            return
-
         if self._current_step != step:
             self._current_step = step
             self._sequences_this_step = 0

--- a/src/prime_rl/trainer/rl/token_export.py
+++ b/src/prime_rl/trainer/rl/token_export.py
@@ -10,7 +10,8 @@ from typing import Any
 import torch
 from torch import Tensor
 
-from prime_rl.configs.trainer import TokenExportConfig
+from prime_rl.configs.trainer import DefaultLossConfig, TokenExportConfig, TrainerConfig
+from prime_rl.trainer.rl.loss import compute_importance_ratio_and_mismatch_kl
 
 SCHEMA_VERSION = 1
 _STOP = object()
@@ -61,6 +62,14 @@ class AsyncJsonlWriter:
             raise RuntimeError(f"Token export writer failed for {self.path}") from self._error
 
 
+class DisabledTokenExporter:
+    def export(self, *args: Any, **kwargs: Any) -> None:
+        return
+
+    def close(self) -> None:
+        return
+
+
 class TokenExporter:
     def __init__(
         self,
@@ -76,22 +85,14 @@ class TokenExporter:
         self._current_step: int | None = None
         self._sequences_this_step = 0
 
-    def export_micro_batch(
+    def export(
         self,
-        *,
         step: int,
         micro_step: int,
         micro_batch: Mapping[str, Any],
-        trainer_logprobs: Tensor,
-        entropy: Tensor,
-        mismatch_kl: Tensor | None,
+        model_output: Mapping[str, Tensor],
         response_lengths: list[int],
-        log_importance_ratio: Tensor | None = None,
-        importance_ratio: Tensor | None = None,
-        prob_delta: Tensor | None = None,
-        is_masked: Tensor | None = None,
-        is_masked_high: Tensor | None = None,
-        is_masked_low: Tensor | None = None,
+        loss_config: Any,
     ) -> None:
         if step % self.config.interval != 0:
             return
@@ -102,15 +103,9 @@ class TokenExporter:
 
         flat = self._flatten_micro_batch(
             micro_batch,
-            trainer_logprobs,
-            entropy,
-            mismatch_kl,
-            log_importance_ratio,
-            importance_ratio,
-            prob_delta,
-            is_masked,
-            is_masked_high,
-            is_masked_low,
+            model_output["logprobs"],
+            model_output["entropy"],
+            _compute_export_tensors(micro_batch, model_output["logprobs"], loss_config),
         )
         start = 0
         for micro_sequence_idx, length in enumerate(response_lengths):
@@ -146,13 +141,7 @@ class TokenExporter:
         micro_batch: Mapping[str, Any],
         trainer_logprobs: Tensor,
         entropy: Tensor,
-        mismatch_kl: Tensor | None,
-        log_importance_ratio: Tensor | None,
-        importance_ratio: Tensor | None,
-        prob_delta: Tensor | None,
-        is_masked: Tensor | None,
-        is_masked_high: Tensor | None,
-        is_masked_low: Tensor | None,
+        export_tensors: Mapping[str, Tensor | None],
     ) -> dict[str, list[Any]]:
         input_ids = _tensor_to_ints(micro_batch["input_ids"])
         seq_len = len(input_ids)
@@ -167,14 +156,13 @@ class TokenExporter:
             "inference_logprobs": _tensor_to_floats(micro_batch["inference_logprobs"]),
             "trainer_logprobs": _tensor_to_floats(trainer_logprobs),
             "entropy": _tensor_to_floats(entropy),
-            "mismatch_kl": _optional_tensor_to_floats(mismatch_kl, seq_len),
-            "log_importance_ratio": _optional_tensor_to_floats(log_importance_ratio, seq_len),
-            "importance_ratio": _optional_tensor_to_floats(importance_ratio, seq_len),
-            "prob_delta": _optional_tensor_to_floats(prob_delta, seq_len),
-            "is_masked": _optional_tensor_to_bools(is_masked, seq_len),
-            "is_masked_high": _optional_tensor_to_bools(is_masked_high, seq_len),
-            "is_masked_low": _optional_tensor_to_bools(is_masked_low, seq_len),
-            "is_clipped": [False] * seq_len,
+            "mismatch_kl": _optional_tensor_to_floats(export_tensors["mismatch_kl"], seq_len),
+            "log_importance_ratio": _optional_tensor_to_floats(export_tensors["log_importance_ratio"], seq_len),
+            "importance_ratio": _optional_tensor_to_floats(export_tensors["importance_ratio"], seq_len),
+            "prob_delta": _optional_tensor_to_floats(export_tensors["prob_delta"], seq_len),
+            "is_masked": _optional_tensor_to_bools(export_tensors["is_masked"], seq_len),
+            "is_masked_high": _optional_tensor_to_bools(export_tensors["is_masked_high"], seq_len),
+            "is_masked_low": _optional_tensor_to_bools(export_tensors["is_masked_low"], seq_len),
             "env_names": list(micro_batch["env_names"]),
         }
         lengths = {key: len(values) for key, values in flat.items()}
@@ -224,7 +212,6 @@ class TokenExporter:
                 "is_masked": flat["is_masked"][absolute_idx],
                 "is_masked_high": flat["is_masked_high"][absolute_idx],
                 "is_masked_low": flat["is_masked_low"][absolute_idx],
-                "is_clipped": flat["is_clipped"][absolute_idx],
             }
             token["inference_prob"] = _prob_from_logprob(token["inference_logprob"])
             token["trainer_prob"] = _prob_from_logprob(token["trainer_logprob"])
@@ -242,6 +229,65 @@ class TokenExporter:
             "sft_loss": sft_loss,
             "tokens": tokens,
         }
+
+
+def setup_token_exporter(
+    config: TrainerConfig, parallel_dims: Any, world: Any, logger: Any
+) -> TokenExporter | DisabledTokenExporter:
+    token_export_config = config.experimental.token_export
+    if token_export_config is None:
+        return DisabledTokenExporter()
+    if parallel_dims.cp_enabled and parallel_dims.world_mesh["cp"].get_local_rank() != 0:
+        return DisabledTokenExporter()
+
+    exporter = TokenExporter(token_export_config, config.output_dir, world.rank)
+    logger.info(f"Writing token exports to {exporter.path}")
+    return exporter
+
+
+def _compute_export_tensors(
+    micro_batch: Mapping[str, Any], trainer_logprobs: Tensor, loss_config: Any
+) -> dict[str, Tensor | None]:
+    fields: dict[str, Tensor | None] = {
+        "log_importance_ratio": None,
+        "importance_ratio": None,
+        "mismatch_kl": None,
+        "prob_delta": None,
+        "is_masked": None,
+        "is_masked_high": None,
+        "is_masked_low": None,
+    }
+    if micro_batch["sft_loss"]:
+        return fields
+
+    inference_logprobs = micro_batch["inference_logprobs"].to(trainer_logprobs.device)
+    loss_mask = micro_batch["loss_mask"].to(trainer_logprobs.device)
+    advantages = micro_batch["advantages"].to(trainer_logprobs.device)
+    with torch.no_grad():
+        log_ratio, ratio, mismatch_kl = compute_importance_ratio_and_mismatch_kl(trainer_logprobs, inference_logprobs)
+        prob_delta = torch.exp(trainer_logprobs) - torch.exp(inference_logprobs)
+        fields.update(
+            {
+                "log_importance_ratio": log_ratio,
+                "importance_ratio": ratio,
+                "mismatch_kl": mismatch_kl,
+                "prob_delta": prob_delta,
+            }
+        )
+        if isinstance(loss_config, DefaultLossConfig):
+            invalid_high = prob_delta > loss_config.dppo_mask_high
+            invalid_low = prob_delta < -loss_config.dppo_mask_low
+            positive_advantages = advantages > 0
+            negative_advantages = advantages < 0
+            invalid = torch.where(positive_advantages, invalid_high, invalid_low)
+            fields.update(
+                {
+                    "is_masked": loss_mask & invalid,
+                    "is_masked_high": loss_mask & positive_advantages & invalid_high,
+                    "is_masked_low": loss_mask & negative_advantages & invalid_low,
+                }
+            )
+    return fields
 
 
 def _tensor_to_ints(tensor: Tensor) -> list[int]:

--- a/src/prime_rl/trainer/rl/token_export.py
+++ b/src/prime_rl/trainer/rl/token_export.py
@@ -1,0 +1,301 @@
+import atexit
+import json
+import math
+import queue
+import threading
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import torch
+from torch import Tensor
+
+from prime_rl.configs.trainer import TokenExportConfig
+
+SCHEMA_VERSION = 1
+_STOP = object()
+
+
+class AsyncJsonlWriter:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._queue: queue.Queue[dict[str, Any] | object] = queue.Queue()
+        self._error: BaseException | None = None
+        self._closed = False
+        self._lock = threading.Lock()
+        self._thread = threading.Thread(target=self._run, name=f"token-export-writer:{path}", daemon=True)
+        self._thread.start()
+        atexit.register(self.close)
+
+    def write(self, record: dict[str, Any]) -> None:
+        self._raise_if_failed()
+        if self._closed:
+            raise RuntimeError(f"Token export writer is closed for {self.path}")
+        self._queue.put(record)
+
+    def close(self) -> None:
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            self._queue.put(_STOP)
+        self._thread.join()
+        self._raise_if_failed()
+
+    def _run(self) -> None:
+        try:
+            with self.path.open("a", encoding="utf-8") as f:
+                while True:
+                    record = self._queue.get()
+                    try:
+                        if record is _STOP:
+                            break
+                        f.write(json.dumps(record, separators=(",", ":"), allow_nan=False) + "\n")
+                    finally:
+                        self._queue.task_done()
+        except BaseException as exc:
+            self._error = exc
+
+    def _raise_if_failed(self) -> None:
+        if self._error is not None:
+            raise RuntimeError(f"Token export writer failed for {self.path}") from self._error
+
+
+class TokenExporter:
+    def __init__(
+        self,
+        config: TokenExportConfig,
+        output_dir: Path,
+        rank: int,
+    ) -> None:
+        self.config = config
+        self.rank = rank
+        self.path = self._resolve_path(config.path, output_dir, rank)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._writer = AsyncJsonlWriter(self.path)
+        self._current_step: int | None = None
+        self._sequences_this_step = 0
+
+    def export_micro_batch(
+        self,
+        *,
+        step: int,
+        micro_step: int,
+        micro_batch: Mapping[str, Any],
+        trainer_logprobs: Tensor,
+        entropy: Tensor,
+        mismatch_kl: Tensor | None,
+        response_lengths: list[int],
+        log_importance_ratio: Tensor | None = None,
+        importance_ratio: Tensor | None = None,
+        prob_delta: Tensor | None = None,
+        is_masked: Tensor | None = None,
+        is_masked_high: Tensor | None = None,
+        is_masked_low: Tensor | None = None,
+    ) -> None:
+        if step % self.config.interval != 0:
+            return
+
+        if self._current_step != step:
+            self._current_step = step
+            self._sequences_this_step = 0
+
+        flat = self._flatten_micro_batch(
+            micro_batch,
+            trainer_logprobs,
+            entropy,
+            mismatch_kl,
+            log_importance_ratio,
+            importance_ratio,
+            prob_delta,
+            is_masked,
+            is_masked_high,
+            is_masked_low,
+        )
+        start = 0
+        for micro_sequence_idx, length in enumerate(response_lengths):
+            end = start + length
+            record = self._build_record(
+                step=step,
+                micro_step=micro_step,
+                micro_sequence_idx=micro_sequence_idx,
+                flat=flat,
+                start=start,
+                end=end,
+                sft_loss=bool(micro_batch["sft_loss"]),
+            )
+            start = end
+            if record is None:
+                continue
+            self._writer.write(record)
+            self._sequences_this_step += 1
+
+    def close(self) -> None:
+        self._writer.close()
+
+    @staticmethod
+    def _resolve_path(path: Path | None, output_dir: Path, rank: int) -> Path:
+        if path is None:
+            return output_dir / "token_exports" / f"rank_{rank}.jsonl"
+        if path.is_absolute():
+            return path
+        return output_dir / path
+
+    def _flatten_micro_batch(
+        self,
+        micro_batch: Mapping[str, Any],
+        trainer_logprobs: Tensor,
+        entropy: Tensor,
+        mismatch_kl: Tensor | None,
+        log_importance_ratio: Tensor | None,
+        importance_ratio: Tensor | None,
+        prob_delta: Tensor | None,
+        is_masked: Tensor | None,
+        is_masked_high: Tensor | None,
+        is_masked_low: Tensor | None,
+    ) -> dict[str, list[Any]]:
+        input_ids = _tensor_to_ints(micro_batch["input_ids"])
+        seq_len = len(input_ids)
+        rewards_tensor = micro_batch.get("rewards")
+
+        flat = {
+            "input_ids": input_ids,
+            "position_ids": _tensor_to_ints(micro_batch["position_ids"]),
+            "loss_mask": _tensor_to_bools(micro_batch["loss_mask"]),
+            "advantages": _tensor_to_floats(micro_batch["advantages"]),
+            "rewards": _optional_tensor_to_floats(rewards_tensor, seq_len),
+            "inference_logprobs": _tensor_to_floats(micro_batch["inference_logprobs"]),
+            "trainer_logprobs": _tensor_to_floats(trainer_logprobs),
+            "entropy": _tensor_to_floats(entropy),
+            "mismatch_kl": _optional_tensor_to_floats(mismatch_kl, seq_len),
+            "log_importance_ratio": _optional_tensor_to_floats(log_importance_ratio, seq_len),
+            "importance_ratio": _optional_tensor_to_floats(importance_ratio, seq_len),
+            "prob_delta": _optional_tensor_to_floats(prob_delta, seq_len),
+            "is_masked": _optional_tensor_to_bools(is_masked, seq_len),
+            "is_masked_high": _optional_tensor_to_bools(is_masked_high, seq_len),
+            "is_masked_low": _optional_tensor_to_bools(is_masked_low, seq_len),
+            "is_clipped": [False] * seq_len,
+            "env_names": list(micro_batch["env_names"]),
+        }
+        lengths = {key: len(values) for key, values in flat.items()}
+        if len(set(lengths.values())) != 1:
+            raise ValueError(f"Token export fields must have aligned lengths, got {lengths}")
+        return flat
+
+    def _build_record(
+        self,
+        *,
+        step: int,
+        micro_step: int,
+        micro_sequence_idx: int,
+        flat: dict[str, list[Any]],
+        start: int,
+        end: int,
+        sft_loss: bool,
+    ) -> dict[str, Any] | None:
+        end = _trim_padding(flat, start, end)
+        if start >= end:
+            return None
+
+        loss_mask = flat["loss_mask"][start:end]
+        if not any(loss_mask):
+            return None
+
+        token_ids = flat["input_ids"][start:end]
+        tokens = []
+        for local_idx, absolute_idx in enumerate(range(start, end)):
+            log_importance_ratio = _json_float(flat["log_importance_ratio"][absolute_idx])
+            token = {
+                "index": local_idx,
+                "id": token_ids[local_idx],
+                "position": flat["position_ids"][absolute_idx],
+                "loss_mask": loss_mask[local_idx],
+                "advantage": _json_float(flat["advantages"][absolute_idx]),
+                "reward": _json_float(flat["rewards"][absolute_idx]),
+                "entropy": _json_float(flat["entropy"][absolute_idx]),
+                "mismatch_kl": _json_float(flat["mismatch_kl"][absolute_idx]),
+                "log_importance_ratio": log_importance_ratio,
+                "sample_kl_trainer_to_inference": log_importance_ratio,
+                "sample_kl_inference_to_trainer": -log_importance_ratio if log_importance_ratio is not None else None,
+                "importance_ratio": _json_float(flat["importance_ratio"][absolute_idx]),
+                "prob_delta": _json_float(flat["prob_delta"][absolute_idx]),
+                "inference_logprob": _json_float(flat["inference_logprobs"][absolute_idx]),
+                "trainer_logprob": _json_float(flat["trainer_logprobs"][absolute_idx]),
+                "is_masked": flat["is_masked"][absolute_idx],
+                "is_masked_high": flat["is_masked_high"][absolute_idx],
+                "is_masked_low": flat["is_masked_low"][absolute_idx],
+                "is_clipped": flat["is_clipped"][absolute_idx],
+            }
+            token["inference_prob"] = _prob_from_logprob(token["inference_logprob"])
+            token["trainer_prob"] = _prob_from_logprob(token["trainer_logprob"])
+            tokens.append(token)
+
+        env_name = _first_non_empty(flat["env_names"][start:end])
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "step": step,
+            "rank": self.rank,
+            "micro_step": micro_step,
+            "micro_sequence_idx": micro_sequence_idx,
+            "export_sequence_idx": self._sequences_this_step,
+            "env_name": env_name,
+            "sft_loss": sft_loss,
+            "tokens": tokens,
+        }
+
+
+def _tensor_to_ints(tensor: Tensor) -> list[int]:
+    return [int(value) for value in tensor.detach().cpu().reshape(-1).tolist()]
+
+
+def _tensor_to_bools(tensor: Tensor) -> list[bool]:
+    return [bool(value) for value in tensor.detach().cpu().reshape(-1).tolist()]
+
+
+def _tensor_to_floats(tensor: Tensor) -> list[float]:
+    values = tensor.detach().to(dtype=torch.float32, device="cpu").reshape(-1).tolist()
+    return [float(value) for value in values]
+
+
+def _optional_tensor_to_floats(tensor: Tensor | None, seq_len: int) -> list[float | None]:
+    if tensor is None:
+        return [None] * seq_len
+    return _tensor_to_floats(tensor)
+
+
+def _optional_tensor_to_bools(tensor: Tensor | None, seq_len: int) -> list[bool | None]:
+    if tensor is None:
+        return [None] * seq_len
+    return _tensor_to_bools(tensor)
+
+
+def _trim_padding(flat: dict[str, list[Any]], start: int, end: int) -> int:
+    env_names = flat["env_names"]
+    loss_mask = flat["loss_mask"]
+    while end > start and env_names[end - 1] == "" and not loss_mask[end - 1]:
+        end -= 1
+    return end
+
+
+def _json_float(value: float | None) -> float | None:
+    if value is None:
+        return None
+    value = float(value)
+    if not math.isfinite(value):
+        return None
+    return value
+
+
+def _prob_from_logprob(logprob: float | None) -> float | None:
+    if logprob is None:
+        return None
+    if logprob > 709:
+        return None
+    return math.exp(logprob)
+
+
+def _first_non_empty(values: list[str]) -> str | None:
+    for value in values:
+        if value:
+            return value
+    return None

--- a/src/prime_rl/trainer/rl/token_export.py
+++ b/src/prime_rl/trainer/rl/token_export.py
@@ -114,7 +114,7 @@ class TokenExporter:
                 flat=flat,
                 start=start,
                 end=end,
-                sft_loss=bool(micro_batch["sft_loss"]),
+                training_mode=str(micro_batch["training_mode"]),
             )
             start = end
             if record is None:
@@ -176,7 +176,7 @@ class TokenExporter:
         flat: dict[str, list[Any]],
         start: int,
         end: int,
-        sft_loss: bool,
+        training_mode: str,
     ) -> dict[str, Any] | None:
         end = _trim_padding(flat, start, end)
         if start >= end:
@@ -223,7 +223,7 @@ class TokenExporter:
             "micro_sequence_idx": micro_sequence_idx,
             "export_sequence_idx": self._sequences_this_step,
             "env_name": env_name,
-            "sft_loss": sft_loss,
+            "training_mode": training_mode,
             "tokens": tokens,
         }
 
@@ -254,7 +254,7 @@ def _compute_export_tensors(
         "is_masked_high": None,
         "is_masked_low": None,
     }
-    if micro_batch["sft_loss"]:
+    if micro_batch["training_mode"] == "sft":
         return fields
 
     inference_logprobs = micro_batch["inference_logprobs"].to(trainer_logprobs.device)

--- a/src/prime_rl/trainer/rl/token_export.py
+++ b/src/prime_rl/trainer/rl/token_export.py
@@ -1,8 +1,6 @@
 import atexit
 import json
 import math
-import queue
-import threading
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -14,52 +12,6 @@ from prime_rl.configs.trainer import DefaultLossConfig, TokenExportConfig, Train
 from prime_rl.trainer.rl.loss import compute_importance_ratio_and_mismatch_kl
 
 SCHEMA_VERSION = 1
-_STOP = object()
-
-
-class AsyncJsonlWriter:
-    def __init__(self, path: Path) -> None:
-        self.path = path
-        self._queue: queue.Queue[dict[str, Any] | object] = queue.Queue()
-        self._error: BaseException | None = None
-        self._closed = False
-        self._lock = threading.Lock()
-        self._thread = threading.Thread(target=self._run, name=f"token-export-writer:{path}", daemon=True)
-        self._thread.start()
-        atexit.register(self.close)
-
-    def write(self, record: dict[str, Any]) -> None:
-        self._raise_if_failed()
-        if self._closed:
-            raise RuntimeError(f"Token export writer is closed for {self.path}")
-        self._queue.put(record)
-
-    def close(self) -> None:
-        with self._lock:
-            if self._closed:
-                return
-            self._closed = True
-            self._queue.put(_STOP)
-        self._thread.join()
-        self._raise_if_failed()
-
-    def _run(self) -> None:
-        try:
-            with self.path.open("a", encoding="utf-8") as f:
-                while True:
-                    record = self._queue.get()
-                    try:
-                        if record is _STOP:
-                            break
-                        f.write(json.dumps(record, separators=(",", ":"), allow_nan=False) + "\n")
-                    finally:
-                        self._queue.task_done()
-        except BaseException as exc:
-            self._error = exc
-
-    def _raise_if_failed(self) -> None:
-        if self._error is not None:
-            raise RuntimeError(f"Token export writer failed for {self.path}") from self._error
 
 
 class DisabledTokenExporter:
@@ -81,9 +33,11 @@ class TokenExporter:
         self.rank = rank
         self.path = self._resolve_path(config.path, output_dir, rank)
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        self._writer = AsyncJsonlWriter(self.path)
+        self._file = self.path.open("a", encoding="utf-8")
+        self._closed = False
         self._current_step: int | None = None
         self._sequences_this_step = 0
+        atexit.register(self.close)
 
     def export(
         self,
@@ -119,11 +73,19 @@ class TokenExporter:
             start = end
             if record is None:
                 continue
-            self._writer.write(record)
+            self._write(record)
             self._sequences_this_step += 1
 
     def close(self) -> None:
-        self._writer.close()
+        if self._closed:
+            return
+        self._closed = True
+        self._file.close()
+
+    def _write(self, record: dict[str, Any]) -> None:
+        if self._closed:
+            raise RuntimeError(f"Token exporter is closed for {self.path}")
+        self._file.write(json.dumps(record, separators=(",", ":"), allow_nan=False) + "\n")
 
     @staticmethod
     def _resolve_path(path: Path | None, output_dir: Path, rank: int) -> Path:
@@ -263,27 +225,19 @@ def _compute_export_tensors(
     with torch.no_grad():
         log_ratio, ratio, mismatch_kl = compute_importance_ratio_and_mismatch_kl(trainer_logprobs, inference_logprobs)
         prob_delta = torch.exp(trainer_logprobs) - torch.exp(inference_logprobs)
-        fields.update(
-            {
-                "log_importance_ratio": log_ratio,
-                "importance_ratio": ratio,
-                "mismatch_kl": mismatch_kl,
-                "prob_delta": prob_delta,
-            }
-        )
+        fields["log_importance_ratio"] = log_ratio
+        fields["importance_ratio"] = ratio
+        fields["mismatch_kl"] = mismatch_kl
+        fields["prob_delta"] = prob_delta
         if isinstance(loss_config, DefaultLossConfig):
             invalid_high = prob_delta > loss_config.dppo_mask_high
             invalid_low = prob_delta < -loss_config.dppo_mask_low
             positive_advantages = advantages > 0
             negative_advantages = advantages < 0
             invalid = torch.where(positive_advantages, invalid_high, invalid_low)
-            fields.update(
-                {
-                    "is_masked": loss_mask & invalid,
-                    "is_masked_high": loss_mask & positive_advantages & invalid_high,
-                    "is_masked_low": loss_mask & negative_advantages & invalid_low,
-                }
-            )
+            fields["is_masked"] = loss_mask & invalid
+            fields["is_masked_high"] = loss_mask & positive_advantages & invalid_high
+            fields["is_masked_low"] = loss_mask & negative_advantages & invalid_low
     return fields
 
 

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -17,7 +17,7 @@ from prime_rl.trainer.ckpt import setup_ckpt_managers
 from prime_rl.trainer.multi_ckpt import setup_multi_checkpoint_manager
 from prime_rl.trainer.optim import setup_optimizer, setup_multi_optimizer
 from prime_rl.trainer.scheduler import setup_scheduler, setup_multi_scheduler
-from prime_rl.configs.trainer import TrainerConfig
+from prime_rl.configs.trainer import DefaultLossConfig, TrainerConfig
 from prime_rl.trainer.rl.data import DataLoader, FakeDataLoader
 from prime_rl.utils.cp import (
     gather_for_cp,
@@ -35,6 +35,7 @@ from prime_rl.trainer.rl.loss import (
     shift_tensor_left,
     shift_tensor_right,
 )
+from prime_rl.trainer.rl.token_export import TokenExporter
 from prime_rl.trainer.model import (
     forward,
     setup_tokenizer,
@@ -238,6 +239,13 @@ def train(config: TrainerConfig):
             tokenizer,
             config.rollout_transport,
         )
+
+    token_exporter = None
+    if config.experimental.token_export is not None:
+        token_export_enabled = not parallel_dims.cp_enabled or parallel_dims.world_mesh["cp"].get_local_rank() == 0
+        if token_export_enabled:
+            token_exporter = TokenExporter(config.experimental.token_export, config.output_dir, world.rank)
+            logger.info(f"Writing token exports to {token_exporter.path}")
 
     gc_handler = GarbageCollection(config.gc.interval) if config.gc else None
 
@@ -492,13 +500,57 @@ def train(config: TrainerConfig):
             for env_name, indices in env_to_indices.items():
                 tensors[f"entropy/{env_name}"].append(entropy[indices])
 
+            full_log_importance_ratio = None
+            full_importance_ratio = None
+            full_mismatch_kl = None
+            prob_delta = None
+            dppo_is_masked = None
+            dppo_is_masked_high = None
+            dppo_is_masked_low = None
             if micro_batch["training_mode"] != "sft":
                 with torch.no_grad():
-                    _, _, mismatch_kl = compute_importance_ratio_and_mismatch_kl(out["logprobs"], inference_logprobs)
-                mismatch_kl = mismatch_kl[loss_mask].detach().to("cpu")
+                    full_log_importance_ratio, full_importance_ratio, full_mismatch_kl = (
+                        compute_importance_ratio_and_mismatch_kl(out["logprobs"], inference_logprobs)
+                    )
+                    prob_delta = torch.exp(out["logprobs"]) - torch.exp(inference_logprobs)
+                    if isinstance(config.loss, DefaultLossConfig):
+                        dppo_invalid_mask_high = prob_delta > config.loss.dppo_mask_high
+                        dppo_invalid_mask_low = prob_delta < -config.loss.dppo_mask_low
+                        positive_advantages = advantages > 0
+                        negative_advantages = advantages < 0
+                        dppo_invalid_mask = torch.where(
+                            positive_advantages,
+                            dppo_invalid_mask_high,
+                            dppo_invalid_mask_low,
+                        )
+                        dppo_is_masked = loss_mask & dppo_invalid_mask
+                        dppo_is_masked_high = loss_mask & positive_advantages & dppo_invalid_mask_high
+                        dppo_is_masked_low = loss_mask & negative_advantages & dppo_invalid_mask_low
+                    else:
+                        dppo_is_masked = torch.zeros_like(loss_mask)
+                        dppo_is_masked_high = torch.zeros_like(loss_mask)
+                        dppo_is_masked_low = torch.zeros_like(loss_mask)
+                mismatch_kl = full_mismatch_kl[loss_mask].detach().to("cpu")
                 tensors["mismatch_kl/all"].append(mismatch_kl)
                 for env_name, indices in env_to_indices.items():
                     tensors[f"mismatch_kl/{env_name}"].append(mismatch_kl[indices])
+
+            if token_exporter is not None:
+                token_exporter.export_micro_batch(
+                    step=progress.step,
+                    micro_step=micro_step,
+                    micro_batch=micro_batch,
+                    trainer_logprobs=out["logprobs"],
+                    entropy=out["entropy"],
+                    mismatch_kl=full_mismatch_kl,
+                    response_lengths=response_lengths,
+                    log_importance_ratio=full_log_importance_ratio,
+                    importance_ratio=full_importance_ratio,
+                    prob_delta=prob_delta,
+                    is_masked=dppo_is_masked,
+                    is_masked_high=dppo_is_masked_high,
+                    is_masked_low=dppo_is_masked_low,
+                )
 
             if is_tt_moe_model(model):
                 load_balance_stats = get_load_balance_stats(model)
@@ -677,6 +729,10 @@ def train(config: TrainerConfig):
         logger.info(f"Saving trace to {trace_file}")
         prof.export_chrome_trace(trace_file)
         logger.info(f"Saved trace to {trace_file}")
+
+    if token_exporter is not None:
+        logger.info(f"Flushing token exports to {token_exporter.path}")
+        token_exporter.close()
 
     # Write final checkpoint (only for single-run mode; multi-run checkpoints are managed by MultiCheckpointManager)
     if config.max_concurrent_runs == 1 and ckpt_manager is not None:

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -17,7 +17,7 @@ from prime_rl.trainer.ckpt import setup_ckpt_managers
 from prime_rl.trainer.multi_ckpt import setup_multi_checkpoint_manager
 from prime_rl.trainer.optim import setup_optimizer, setup_multi_optimizer
 from prime_rl.trainer.scheduler import setup_scheduler, setup_multi_scheduler
-from prime_rl.configs.trainer import DefaultLossConfig, TrainerConfig
+from prime_rl.configs.trainer import TrainerConfig
 from prime_rl.trainer.rl.data import DataLoader, FakeDataLoader
 from prime_rl.utils.cp import (
     gather_for_cp,
@@ -35,7 +35,7 @@ from prime_rl.trainer.rl.loss import (
     shift_tensor_left,
     shift_tensor_right,
 )
-from prime_rl.trainer.rl.token_export import TokenExporter
+from prime_rl.trainer.rl.token_export import setup_token_exporter
 from prime_rl.trainer.model import (
     forward,
     setup_tokenizer,
@@ -240,12 +240,7 @@ def train(config: TrainerConfig):
             config.rollout_transport,
         )
 
-    token_exporter = None
-    if config.experimental.token_export is not None:
-        token_export_enabled = not parallel_dims.cp_enabled or parallel_dims.world_mesh["cp"].get_local_rank() == 0
-        if token_export_enabled:
-            token_exporter = TokenExporter(config.experimental.token_export, config.output_dir, world.rank)
-            logger.info(f"Writing token exports to {token_exporter.path}")
+    token_exporter = setup_token_exporter(config, parallel_dims, world, logger)
 
     gc_handler = GarbageCollection(config.gc.interval) if config.gc else None
 
@@ -500,57 +495,15 @@ def train(config: TrainerConfig):
             for env_name, indices in env_to_indices.items():
                 tensors[f"entropy/{env_name}"].append(entropy[indices])
 
-            full_log_importance_ratio = None
-            full_importance_ratio = None
-            full_mismatch_kl = None
-            prob_delta = None
-            dppo_is_masked = None
-            dppo_is_masked_high = None
-            dppo_is_masked_low = None
             if micro_batch["training_mode"] != "sft":
                 with torch.no_grad():
-                    full_log_importance_ratio, full_importance_ratio, full_mismatch_kl = (
-                        compute_importance_ratio_and_mismatch_kl(out["logprobs"], inference_logprobs)
-                    )
-                    prob_delta = torch.exp(out["logprobs"]) - torch.exp(inference_logprobs)
-                    if isinstance(config.loss, DefaultLossConfig):
-                        dppo_invalid_mask_high = prob_delta > config.loss.dppo_mask_high
-                        dppo_invalid_mask_low = prob_delta < -config.loss.dppo_mask_low
-                        positive_advantages = advantages > 0
-                        negative_advantages = advantages < 0
-                        dppo_invalid_mask = torch.where(
-                            positive_advantages,
-                            dppo_invalid_mask_high,
-                            dppo_invalid_mask_low,
-                        )
-                        dppo_is_masked = loss_mask & dppo_invalid_mask
-                        dppo_is_masked_high = loss_mask & positive_advantages & dppo_invalid_mask_high
-                        dppo_is_masked_low = loss_mask & negative_advantages & dppo_invalid_mask_low
-                    else:
-                        dppo_is_masked = torch.zeros_like(loss_mask)
-                        dppo_is_masked_high = torch.zeros_like(loss_mask)
-                        dppo_is_masked_low = torch.zeros_like(loss_mask)
-                mismatch_kl = full_mismatch_kl[loss_mask].detach().to("cpu")
+                    _, _, mismatch_kl = compute_importance_ratio_and_mismatch_kl(out["logprobs"], inference_logprobs)
+                mismatch_kl = mismatch_kl[loss_mask].detach().to("cpu")
                 tensors["mismatch_kl/all"].append(mismatch_kl)
                 for env_name, indices in env_to_indices.items():
                     tensors[f"mismatch_kl/{env_name}"].append(mismatch_kl[indices])
 
-            if token_exporter is not None:
-                token_exporter.export_micro_batch(
-                    step=progress.step,
-                    micro_step=micro_step,
-                    micro_batch=micro_batch,
-                    trainer_logprobs=out["logprobs"],
-                    entropy=out["entropy"],
-                    mismatch_kl=full_mismatch_kl,
-                    response_lengths=response_lengths,
-                    log_importance_ratio=full_log_importance_ratio,
-                    importance_ratio=full_importance_ratio,
-                    prob_delta=prob_delta,
-                    is_masked=dppo_is_masked,
-                    is_masked_high=dppo_is_masked_high,
-                    is_masked_low=dppo_is_masked_low,
-                )
+            token_exporter.export(progress.step, micro_step, micro_batch, out, response_lengths, config.loss)
 
             if is_tt_moe_model(model):
                 load_balance_stats = get_load_balance_stats(model)
@@ -730,9 +683,7 @@ def train(config: TrainerConfig):
         prof.export_chrome_trace(trace_file)
         logger.info(f"Saved trace to {trace_file}")
 
-    if token_exporter is not None:
-        logger.info(f"Flushing token exports to {token_exporter.path}")
-        token_exporter.close()
+    token_exporter.close()
 
     # Write final checkpoint (only for single-run mode; multi-run checkpoints are managed by MultiCheckpointManager)
     if config.max_concurrent_runs == 1 and ckpt_manager is not None:

--- a/src/prime_rl/transport/types.py
+++ b/src/prime_rl/transport/types.py
@@ -80,3 +80,4 @@ class MicroBatch(msgspec.Struct, array_like=True, gc=False, omit_defaults=True):
     # Loss dispatch is batch-driven (rl/opd → default loss with mode-specific taus,
     # sft → sft loss). All samples packed into a micro batch share the same mode.
     training_mode: TrainingMode = "rl"
+    rewards: list[float] | None = None


### PR DESCRIPTION
## Summary
- Add an opt-in trainer token exporter that writes per-sequence JSONL with token ids, reward, advantage, entropy, KL/probability/logprob/ratio data, and DPPO mask flags.
- Keep the trainer hook narrow: setup/export/close live behind `src/prime_rl/trainer/rl/token_export.py`, and exporter-specific ratio/mask math is scoped there instead of inline in the trainer loop.
- Simplify the token exporter by writing directly to a JSONL file handle instead of routing through a background queue/thread.
- When token export is enabled, export every step from each exporting rank; no interval/cap option.
- Thread per-sequence rewards through trainer batch structures so rollout rewards are available in the export.
- Add a minimal HTML visualizer that decodes token ids after export, groups chat-template roles, colors high KL mismatch tokens, and shows token metadata on hover.
- Extend the visualizer with an all-records navigator: directory inputs collect `*.jsonl` exports into one static HTML page, and single JSONL files can use `--all-records` to embed every matching record.
- Reuse one tokenizer instance per visualizer render so directory/all-records mode does not reload it for each record.
- Document the exporter and visualizer workflow in the config skill.

## Verification
- `uv run ruff check packages/prime-rl-configs/src/prime_rl/configs/trainer.py src/prime_rl/transport/types.py src/prime_rl/trainer/batch.py src/prime_rl/trainer/rl/data.py src/prime_rl/trainer/rl/train.py src/prime_rl/trainer/rl/token_export.py scripts/token_export_visualizer.py`
- `uv run ruff check src/prime_rl/trainer/rl/train.py src/prime_rl/trainer/rl/token_export.py scripts/token_export_visualizer.py`
- `uv run ruff format --check src/prime_rl/trainer/rl/train.py src/prime_rl/trainer/rl/token_export.py scripts/token_export_visualizer.py`
- `uv run ruff check packages/prime-rl-configs/src/prime_rl/configs/trainer.py src/prime_rl/trainer/rl/token_export.py`
- `uv run ruff format --check packages/prime-rl-configs/src/prime_rl/configs/trainer.py src/prime_rl/trainer/rl/token_export.py`
- `uv run python -m py_compile src/prime_rl/trainer/rl/token_export.py packages/prime-rl-configs/src/prime_rl/configs/trainer.py`
- `uv run ruff check scripts/token_export_visualizer.py`
- `uv run ruff format --check scripts/token_export_visualizer.py`
- `uv run rl @ configs/ci/integration/reverse_text/start.toml --output-dir /tmp/prime-rl-token-export-clean-run --clean-output-dir --max-steps 1 --seq-len 512 --orchestrator.batch-size 2 --orchestrator.rollouts-per-example 2 --orchestrator.train.sampling.max-completion-tokens 16 --trainer.experimental.token-export`
- `uv run scripts/token_export_visualizer.py /tmp/prime-rl-token-export-clean-run/token_exports --tokenizer PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT -o output.html`
- `uv run scripts/token_export_visualizer.py /tmp/prime-rl-token-export-clean-run/token_exports --tokenizer PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT -o /tmp/prime-rl-token-export-clean-run/output.html`
- Confirmed `/tmp/prime-rl-token-export-clean-run/token_exports/rank_0.jsonl` has 2 records and no `is_clipped` field.

No pytest tests were added or run, per request.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the RL training loop and batch serialization by adding a new `rewards` field and export hook; while gated behind `experimental.token_export`, incorrect alignment/IO failures could impact training stability or performance when enabled.
> 
> **Overview**
> Adds **opt-in per-token rollout export** for the RL trainer via `trainer.experimental.token_export`, writing per-sequence JSONL records (token ids plus aligned metrics like reward/advantage/entropy, mismatch KL, importance ratios, and DPPO mask diagnostics) using an async writer (`trainer/rl/token_export.py`).
> 
> Threads `rewards` through the trainer data path (`TrainingSample`->`MicroBatch`->`TensorMicroBatch`), updates packing/padding logic to keep reward arrays aligned, and hooks exporter setup/export/close into `trainer/rl/train.py`.
> 
> Introduces `scripts/token_export_visualizer.py`, a standalone CLI that loads JSONL (file or directory), optionally decodes tokens with a tokenizer, and renders a static navigable HTML view with KL-based highlighting and hoverable token details; documents the workflow in `skills/config/SKILL.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eebc96eb1f9741713ab12c06632fc7714f66433b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->