### PR TITLE
docs(k8s): filter trainer torchrun logs to rank 0 instead of silencing

### DIFF
--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -258,8 +258,18 @@ torchrun \
   --node-rank=$RANK \
   --nproc-per-node=8 \
   --rdzv-endpoint=my-exp-trainer-0.$HEADLESS_SERVICE:29501 \
+  --log-dir=/data/outputs/logs/trainer/torchrun \
+  --local-ranks-filter=0 \
+  --redirect=3 \
+  --tee=3 \
   src/prime_rl/trainer/sft/train.py @ configs/train.toml
 ```
+
+`--local-ranks-filter=0 --tee=3` keeps only rank 0's stdout/stderr on the pod's
+console (so Loki/the dashboard see each log line once instead of N times for an
+N-GPU pod), while `--redirect=3 --log-dir=...` still writes every rank's
+stdout/stderr to per-rank files under the mounted PVC for debugging. This
+matches what the launcher does on single-node / SLURM deployments.
 
 ## Troubleshooting
 

--- a/k8s/prime-rl/values.yaml
+++ b/k8s/prime-rl/values.yaml
@@ -99,7 +99,11 @@ trainer:
 
   # Auto-start configuration (set to false to use sleep infinity for debugging)
   autoStart: false
-  command: ""  # e.g., "uv run trainer @ /app/examples/reverse_text/rl/train.toml --output-dir /data/outputs"
+  # Single GPU: "uv run trainer @ /app/examples/reverse_text/rl/train.toml --output-dir /data/outputs"
+  # Multi-GPU: use torchrun and pass --local-ranks-filter=0 --tee=3 --redirect=3 --log-dir=... so
+  # only rank 0's stdout reaches the pod console (Loki/dashboard see each line once) while every
+  # rank's stdout/stderr is still written to per-rank files. See docs/kubernetes.md.
+  command: ""
 
   # Helps reduce CUDA memory fragmentation with PyTorch allocator
   pytorchCudaAllocConf: "expandable_segments:True"


### PR DESCRIPTION
## Why

On an 8-GPU k8s trainer pod, the dashboard's Trainer log tab shows every line 8 times because the torchrun snippet documented in `docs/kubernetes.md` (and implied by the empty `trainer.command` in `k8s/prime-rl/values.yaml`) doesn't filter per-rank stdout. Each rank's stdout reaches the pod's console, k8s ships every line to Loki, and the dashboard groups by `role=trainer`.

This is the same problem #2550 fixes, but #2550 fixes it by building loguru with no sinks on non-zero ranks (`setup_logger(..., rank_zero_only=True)`), which throws away per-rank info entirely (per-rank throughput / memory / debug traces on rank 5 are simply gone).

## What

- `docs/kubernetes.md`: add `--local-ranks-filter=0 --tee=3 --redirect=3 --log-dir=/data/outputs/logs/trainer/torchrun` to the documented torchrun invocation — the same flags the local launcher (`src/prime_rl/entrypoints/rl.py:311-314`), the SFT launcher (`src/prime_rl/entrypoints/sft.py:123-126`), and both SLURM templates (`src/prime_rl/templates/multi_node_{rl,sft}.sbatch.j2`) already use.
- `k8s/prime-rl/values.yaml`: update the `trainer.command` comment so users authoring multi-GPU helm values see the same torchrun pattern without leaving the chart.

Result:
- Only rank 0's stdout/stderr reach the pod's console → Loki ingests each log line once → dashboard shows it once.
- Every rank's stdout/stderr is still written to `/data/outputs/logs/trainer/torchrun/{rdzv_id}/attempt_0/{rank}/{stdout,stderr}.log` under the mounted PVC, matching the layout already described in `docs/logging.md`.

## Relation to #2550

This is intended as a replacement for #2550, not a stack on top of it. With these docs / chart-comment changes in place the `rank_zero_only` flag in `setup_logger` isn't needed, and we keep per-rank logs available for debugging hangs / per-rank divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)