### PR TITLE
feat(transport): add Ray rollout transport

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/shared.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/shared.py
@@ -583,4 +583,45 @@ class ZMQTransportConfig(BaseTransportConfig):
     hwm: Annotated[int, Field(description="High water mark (max messages in queue) for ZMQ sockets.")] = 10
 
 
-TransportConfig: TypeAlias = Annotated[FileSystemTransportConfig | ZMQTransportConfig, Field(discriminator="type")]
+class RayTransportConfig(BaseTransportConfig):
+    """Configures Ray actor based transport for training examples."""
+
+    type: Literal["ray"] = "ray"
+    address: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Ray cluster address used by trainer/orchestrator role workers. "
+                "Use 'auto' to attach to the active local cluster."
+            )
+        ),
+    ] = "auto"
+    namespace: Annotated[str, Field(description="Ray namespace for the shared transport actor.")] = "prime-rl"
+    actor_name: Annotated[str, Field(description="Name of the Ray actor that stores rollout batches.")] = (
+        "prime-rl-transport"
+    )
+    max_queued_items: Annotated[
+        int,
+        Field(
+            ge=1,
+            description=(
+                "Maximum queued training or micro-batch payloads per sender (per data_rank for "
+                "micro-batches, per sender_id for training batches) before senders fail with backpressure."
+            ),
+        ),
+    ] = 64
+    reclaim_stale_actor: Annotated[
+        bool,
+        Field(
+            description=(
+                "If true, the Ray-native launcher will kill any pre-existing transport actor with the "
+                "same actor_name/namespace before creating its own. Default false: fail loudly on collision. "
+                "Use only on dedicated/per-run RayClusters; on shared clusters, prefer unique actor_name."
+            ),
+        ),
+    ] = False
+
+
+TransportConfig: TypeAlias = Annotated[
+    FileSystemTransportConfig | ZMQTransportConfig | RayTransportConfig, Field(discriminator="type")
+]

--- a/src/prime_rl/transport/__init__.py
+++ b/src/prime_rl/transport/__init__.py
@@ -1,36 +1,115 @@
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from prime_rl.configs.shared import TransportConfig
 from prime_rl.transport.base import MicroBatchReceiver, MicroBatchSender, TrainingBatchReceiver, TrainingBatchSender
-from prime_rl.transport.filesystem import (
-    FileSystemMicroBatchReceiver,
-    FileSystemMicroBatchSender,
-    FileSystemTrainingBatchReceiver,
-    FileSystemTrainingBatchSender,
-)
 from prime_rl.transport.types import MicroBatch, TrainingBatch, TrainingSample
-from prime_rl.transport.zmq import (
-    ZMQMicroBatchReceiver,
-    ZMQMicroBatchSender,
-    ZMQTrainingBatchReceiver,
-    ZMQTrainingBatchSender,
-)
+
+if TYPE_CHECKING:
+    from prime_rl.transport.filesystem import (
+        FileSystemMicroBatchReceiver,
+        FileSystemMicroBatchSender,
+        FileSystemTrainingBatchReceiver,
+        FileSystemTrainingBatchSender,
+    )
+    from prime_rl.transport.ray import (
+        RayMicroBatchReceiver,
+        RayMicroBatchSender,
+        RayTrainingBatchReceiver,
+        RayTrainingBatchSender,
+    )
+    from prime_rl.transport.zmq import (
+        ZMQMicroBatchReceiver,
+        ZMQMicroBatchSender,
+        ZMQTrainingBatchReceiver,
+        ZMQTrainingBatchSender,
+    )
+
+
+def __getattr__(name: str):
+    # Keep backend classes lazy: importing one transport submodule executes this
+    # package __init__, and should not pull every backend dependency.
+    if name == "FileSystemTrainingBatchSender":
+        from prime_rl.transport.filesystem import FileSystemTrainingBatchSender
+
+        return FileSystemTrainingBatchSender
+    if name == "FileSystemTrainingBatchReceiver":
+        from prime_rl.transport.filesystem import FileSystemTrainingBatchReceiver
+
+        return FileSystemTrainingBatchReceiver
+    if name == "FileSystemMicroBatchSender":
+        from prime_rl.transport.filesystem import FileSystemMicroBatchSender
+
+        return FileSystemMicroBatchSender
+    if name == "FileSystemMicroBatchReceiver":
+        from prime_rl.transport.filesystem import FileSystemMicroBatchReceiver
+
+        return FileSystemMicroBatchReceiver
+    if name == "ZMQTrainingBatchSender":
+        from prime_rl.transport.zmq import ZMQTrainingBatchSender
+
+        return ZMQTrainingBatchSender
+    if name == "ZMQTrainingBatchReceiver":
+        from prime_rl.transport.zmq import ZMQTrainingBatchReceiver
+
+        return ZMQTrainingBatchReceiver
+    if name == "ZMQMicroBatchSender":
+        from prime_rl.transport.zmq import ZMQMicroBatchSender
+
+        return ZMQMicroBatchSender
+    if name == "ZMQMicroBatchReceiver":
+        from prime_rl.transport.zmq import ZMQMicroBatchReceiver
+
+        return ZMQMicroBatchReceiver
+    if name == "RayTrainingBatchSender":
+        from prime_rl.transport.ray import RayTrainingBatchSender
+
+        return RayTrainingBatchSender
+    if name == "RayTrainingBatchReceiver":
+        from prime_rl.transport.ray import RayTrainingBatchReceiver
+
+        return RayTrainingBatchReceiver
+    if name == "RayMicroBatchSender":
+        from prime_rl.transport.ray import RayMicroBatchSender
+
+        return RayMicroBatchSender
+    if name == "RayMicroBatchReceiver":
+        from prime_rl.transport.ray import RayMicroBatchReceiver
+
+        return RayMicroBatchReceiver
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def setup_training_batch_sender(output_dir: Path, transport: TransportConfig) -> TrainingBatchSender:
     if transport.type == "filesystem":
+        from prime_rl.transport.filesystem import FileSystemTrainingBatchSender
+
         return FileSystemTrainingBatchSender(output_dir)
     elif transport.type == "zmq":
+        from prime_rl.transport.zmq import ZMQTrainingBatchSender
+
         return ZMQTrainingBatchSender(output_dir, transport)
+    elif transport.type == "ray":
+        from prime_rl.transport.ray import RayTrainingBatchSender
+
+        return RayTrainingBatchSender(output_dir, transport)
     else:
         raise ValueError(f"Invalid transport type: {transport.type}")
 
 
 def setup_training_batch_receiver(transport: TransportConfig) -> TrainingBatchReceiver:
     if transport.type == "filesystem":
+        from prime_rl.transport.filesystem import FileSystemTrainingBatchReceiver
+
         return FileSystemTrainingBatchReceiver()
     elif transport.type == "zmq":
+        from prime_rl.transport.zmq import ZMQTrainingBatchReceiver
+
         return ZMQTrainingBatchReceiver(transport)
+    elif transport.type == "ray":
+        from prime_rl.transport.ray import RayTrainingBatchReceiver
+
+        return RayTrainingBatchReceiver(transport)
     else:
         raise ValueError(f"Invalid transport type: {transport.type}")
 
@@ -39,9 +118,17 @@ def setup_micro_batch_sender(
     output_dir: Path, data_world_size: int, current_step: int, transport: TransportConfig
 ) -> MicroBatchSender:
     if transport.type == "filesystem":
+        from prime_rl.transport.filesystem import FileSystemMicroBatchSender
+
         return FileSystemMicroBatchSender(output_dir, data_world_size, current_step)
     elif transport.type == "zmq":
+        from prime_rl.transport.zmq import ZMQMicroBatchSender
+
         return ZMQMicroBatchSender(output_dir, data_world_size, current_step, transport)
+    elif transport.type == "ray":
+        from prime_rl.transport.ray import RayMicroBatchSender
+
+        return RayMicroBatchSender(output_dir, data_world_size, current_step, transport)
     else:
         raise ValueError(f"Invalid transport type: {transport.type}")
 
@@ -50,9 +137,17 @@ def setup_micro_batch_receiver(
     output_dir: Path, data_rank: int, current_step: int, transport: TransportConfig
 ) -> MicroBatchReceiver:
     if transport.type == "filesystem":
+        from prime_rl.transport.filesystem import FileSystemMicroBatchReceiver
+
         return FileSystemMicroBatchReceiver(output_dir, data_rank, current_step)
     elif transport.type == "zmq":
+        from prime_rl.transport.zmq import ZMQMicroBatchReceiver
+
         return ZMQMicroBatchReceiver(output_dir, data_rank, current_step, transport)
+    elif transport.type == "ray":
+        from prime_rl.transport.ray import RayMicroBatchReceiver
+
+        return RayMicroBatchReceiver(output_dir, data_rank, current_step, transport)
     else:
         raise ValueError(f"Invalid transport type: {transport.type}")
 
@@ -62,6 +157,14 @@ __all__ = [
     "FileSystemTrainingBatchReceiver",
     "FileSystemMicroBatchSender",
     "FileSystemMicroBatchReceiver",
+    "ZMQTrainingBatchSender",
+    "ZMQTrainingBatchReceiver",
+    "ZMQMicroBatchSender",
+    "ZMQMicroBatchReceiver",
+    "RayTrainingBatchSender",
+    "RayTrainingBatchReceiver",
+    "RayMicroBatchSender",
+    "RayMicroBatchReceiver",
     "MicroBatchReceiver",
     "MicroBatchSender",
     "TrainingSample",

--- a/src/prime_rl/transport/ray.py
+++ b/src/prime_rl/transport/ray.py
@@ -1,0 +1,276 @@
+import os
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from prime_rl.configs.shared import RayTransportConfig
+from prime_rl.transport.base import MicroBatchReceiver, MicroBatchSender, TrainingBatchReceiver, TrainingBatchSender
+from prime_rl.transport.types import MicroBatch, TrainingBatch
+
+LOG_FREQ_SECONDS = 10
+POLL_INTERVAL_SECONDS = 0.05
+ACTOR_SHUTDOWN_POLL_SECONDS = 0.1
+ACTOR_SHUTDOWN_TIMEOUT_SECONDS = 5.0
+
+
+class _RayTransportStore:
+    def __init__(self, max_queued_items: int):
+        self.max_queued_items = max_queued_items
+        self.training_batches: list[tuple[str, bytes]] = []
+        self.micro_batches: dict[tuple[int, int], bytes] = {}
+
+    def put_training_batch(self, sender_id: str, payload: bytes) -> None:
+        per_sender = sum(1 for sid, _ in self.training_batches if sid == sender_id)
+        if per_sender >= self.max_queued_items:
+            raise RuntimeError(
+                f"Ray training batch queue is full for sender {sender_id!r} ({self.max_queued_items} items)"
+            )
+        self.training_batches.append((sender_id, payload))
+
+    def drain_training_batches(self) -> list[tuple[str, bytes]]:
+        batches = self.training_batches
+        self.training_batches = []
+        return batches
+
+    def training_batch_count(self) -> int:
+        return len(self.training_batches)
+
+    def put_micro_batch(self, data_rank: int, step: int, payload: bytes) -> None:
+        per_rank = sum(1 for (rank, _) in self.micro_batches if rank == data_rank)
+        if per_rank >= self.max_queued_items:
+            raise RuntimeError(
+                f"Ray micro-batch queue is full for data_rank={data_rank} ({self.max_queued_items} items)"
+            )
+        key = (data_rank, step)
+        if key in self.micro_batches:
+            raise RuntimeError(f"Ray micro-batch already queued for data_rank={data_rank}, step={step}")
+        self.micro_batches[key] = payload
+
+    def has_micro_batch(self, data_rank: int, step: int) -> bool:
+        return (data_rank, step) in self.micro_batches
+
+    def pop_micro_batch(self, data_rank: int, step: int) -> bytes | None:
+        return self.micro_batches.pop((data_rank, step), None)
+
+
+def _require_ray():
+    os.environ.setdefault("RAY_ENABLE_UV_RUN_RUNTIME_ENV", "0")
+    try:
+        import ray
+    except ImportError as exc:
+        raise ImportError(
+            "Ray transport requires the optional 'ray' package. "
+            "Install Ray before setting rollout_transport.type = 'ray'."
+        ) from exc
+    return ray
+
+
+def _init_ray(config: RayTransportConfig):
+    ray = _require_ray()
+    if not ray.is_initialized():
+        kwargs: dict[str, Any] = {"namespace": config.namespace}
+        if config.address is not None:
+            kwargs["address"] = config.address
+        ray.init(**kwargs)
+    return ray
+
+
+def _get_transport_actor(config: RayTransportConfig):
+    ray = _init_ray(config)
+    try:
+        return ray.get_actor(config.actor_name, namespace=config.namespace)
+    except ValueError as exc:
+        raise RuntimeError(
+            f"Ray transport actor {config.actor_name!r} was not found in namespace {config.namespace!r}. "
+            "Start the Ray-native rl launcher so it can create the shared transport actor before roles attach."
+        ) from exc
+
+
+def create_ray_transport_actor(config: RayTransportConfig):
+    ray = _init_ray(config)
+    try:
+        stale_actor = ray.get_actor(config.actor_name, namespace=config.namespace)
+    except ValueError:
+        pass
+    else:
+        if not config.reclaim_stale_actor:
+            raise RuntimeError(
+                f"Ray transport actor {config.actor_name!r} already exists in namespace "
+                f"{config.namespace!r}. Refusing to kill it because reclaim_stale_actor=false. "
+                "On shared RayClusters set rollout_transport.actor_name (and matching trainer/orchestrator "
+                "values) to a unique name per run, e.g. include the run id. To force the launcher to "
+                "reclaim an orphaned actor, set rollout_transport.reclaim_stale_actor = true."
+            )
+        ray.kill(stale_actor, no_restart=True)
+        deadline = time.time() + ACTOR_SHUTDOWN_TIMEOUT_SECONDS
+        while time.time() < deadline:
+            try:
+                ray.get_actor(config.actor_name, namespace=config.namespace)
+            except ValueError:
+                break
+            time.sleep(ACTOR_SHUTDOWN_POLL_SECONDS)
+        else:
+            raise RuntimeError(
+                f"Timed out waiting for stale Ray transport actor {config.actor_name!r} "
+                f"in namespace {config.namespace!r} to exit"
+            )
+
+    actor_cls = ray.remote(_RayTransportStore)
+    return actor_cls.options(name=config.actor_name, namespace=config.namespace).remote(config.max_queued_items)
+
+
+class RayTrainingBatchSender(TrainingBatchSender):
+    """Ray actor based training batch sender."""
+
+    def __init__(self, output_dir: Path, transport: RayTransportConfig):
+        super().__init__(output_dir)
+        self.ray = _init_ray(transport)
+        self.actor = _get_transport_actor(transport)
+        self.sender_id = output_dir.stem
+        self.logger.info(
+            f"Ray training batch sender initialized: actor={transport.actor_name} namespace={transport.namespace}"
+        )
+
+    def send(self, batch: TrainingBatch) -> None:
+        payload = self.encoder.encode(batch)
+        self.logger.debug(f"Sending batch {batch.step} to {self.sender_id}")
+        self.ray.get(self.actor.put_training_batch.remote(self.sender_id, payload))
+
+
+class RayTrainingBatchReceiver(TrainingBatchReceiver):
+    """Ray actor based training batch receiver."""
+
+    def __init__(self, transport: RayTransportConfig):
+        super().__init__()
+        from prime_rl.trainer.runs import get_multi_run_manager
+
+        self.ray = _init_ray(transport)
+        self.actor = _get_transport_actor(transport)
+        self.multi_run_manager = get_multi_run_manager()
+        self._pending: dict[str, dict[int, TrainingBatch]] = defaultdict(dict)
+        self._last_logged_time = time.time()
+        self._last_logged_ids: list[str] | None = None
+        self._waiting_since: float | None = None
+        self.logger.info(
+            f"Ray training batch receiver initialized: actor={transport.actor_name} namespace={transport.namespace}"
+        )
+
+    def can_receive(self) -> bool:
+        if self._has_runnable_pending_batch():
+            return True
+        return self.ray.get(self.actor.training_batch_count.remote()) > 0
+
+    def _has_runnable_pending_batch(self) -> bool:
+        for idx in self.multi_run_manager.used_idxs:
+            if self.multi_run_manager.ready_to_update[idx]:
+                continue
+            run_id = self.multi_run_manager.idx_2_id[idx]
+            if self._pending.get(run_id):
+                return True
+        return False
+
+    def _drain_into_pending(self) -> None:
+        for sender_id, payload in self.ray.get(self.actor.drain_training_batches.remote()):
+            batch: TrainingBatch = self.decoder.decode(payload)
+            per_id_batches = self._pending[sender_id]
+            assert batch.step not in per_id_batches, (
+                f"Step {batch.step} already in pending for {sender_id!r}, this should not happen: "
+                f"{per_id_batches.keys()}"
+            )
+            per_id_batches[batch.step] = batch
+
+    def receive(self) -> list[TrainingBatch]:
+        batches: list[TrainingBatch] = []
+        now = time.time()
+
+        self._drain_into_pending()
+
+        if self._has_runnable_pending_batch():
+            self._waiting_since = None
+        else:
+            self._waiting_since = self._waiting_since or now
+
+        current_ids = [self.multi_run_manager.idx_2_id[idx] for idx in self.multi_run_manager.used_idxs]
+        if current_ids != self._last_logged_ids or now - self._last_logged_time > LOG_FREQ_SECONDS:
+            waiting_suffix = ""
+            if self._waiting_since is not None:
+                waiting_suffix = f" (waiting {now - self._waiting_since:.1f}s)"
+            self.logger.debug(f"Listening for Ray batches from runs {current_ids}{waiting_suffix}")
+            self._last_logged_ids = current_ids
+            self._last_logged_time = now
+
+        for idx in list(self.multi_run_manager.used_idxs):
+            if self.multi_run_manager.ready_to_update[idx]:
+                continue
+
+            run_id = self.multi_run_manager.idx_2_id[idx]
+            per_id_batches = self._pending.get(run_id)
+            if not per_id_batches:
+                continue
+
+            oldest_step = min(per_id_batches.keys())
+            batch = per_id_batches.pop(oldest_step)
+            if not per_id_batches:
+                self._pending.pop(run_id, None)
+
+            batch.run_idx = idx
+            self.logger.debug(f"Received Ray batch {batch.step} from {run_id!r}")
+            batches.append(batch)
+
+        return batches
+
+
+class RayMicroBatchSender(MicroBatchSender):
+    """Ray actor based micro-batch sender."""
+
+    def __init__(self, output_dir: Path, data_world_size: int, current_step: int, transport: RayTransportConfig):
+        super().__init__(output_dir, data_world_size)
+        self.ray = _init_ray(transport)
+        self.actor = _get_transport_actor(transport)
+        self.current_step = current_step
+        self.logger.info(
+            f"Ray micro-batch sender initialized: actor={transport.actor_name} namespace={transport.namespace}"
+        )
+
+    def send(self, micro_batch_grid: list[list[MicroBatch]]) -> None:
+        assert len(micro_batch_grid) == self.data_world_size, "Number of micro batch lists must match data world size"
+        for micro_batch_list in micro_batch_grid:
+            assert len(micro_batch_list) == len(micro_batch_grid[0]), "All micro batch lists must have the same length"
+
+        refs = []
+        for data_rank in range(self.data_world_size):
+            payload = self.encoder.encode(micro_batch_grid[data_rank])
+            refs.append(self.actor.put_micro_batch.remote(data_rank, self.current_step, payload))
+        self.ray.get(refs)
+        self.logger.debug(f"Sent Ray micro-batch grid for step {self.current_step}")
+        self.current_step += 1
+
+
+class RayMicroBatchReceiver(MicroBatchReceiver):
+    """Ray actor based micro-batch receiver."""
+
+    def __init__(self, output_dir: Path, data_rank: int, current_step: int, transport: RayTransportConfig):
+        super().__init__(output_dir, data_rank)
+        self.ray = _init_ray(transport)
+        self.actor = _get_transport_actor(transport)
+        self.current_step = current_step
+        self.logger.info(
+            f"Ray micro-batch receiver initialized: actor={transport.actor_name} namespace={transport.namespace}"
+        )
+
+    def wait(self) -> None:
+        while not self.can_receive():
+            time.sleep(POLL_INTERVAL_SECONDS)
+
+    def can_receive(self) -> bool:
+        return self.ray.get(self.actor.has_micro_batch.remote(self.data_rank, self.current_step))
+
+    def receive(self) -> list[MicroBatch]:
+        payload = self.ray.get(self.actor.pop_micro_batch.remote(self.data_rank, self.current_step))
+        if payload is None:
+            raise RuntimeError(f"No Ray micro-batch available for data_rank={self.data_rank}, step={self.current_step}")
+        micro_batches: list[MicroBatch] = self.decoder.decode(payload)
+        self.logger.debug(f"Received {len(micro_batches)} Ray micro-batches for step {self.current_step}")
+        self.current_step += 1
+        return micro_batches

--- a/src/prime_rl/transport/ray.py
+++ b/src/prime_rl/transport/ray.py
@@ -180,6 +180,13 @@ class RayTrainingBatchReceiver(TrainingBatchReceiver):
             )
             per_id_batches[batch.step] = batch
 
+    def reset_run(self, idx: int) -> None:
+        run_id = self.multi_run_manager.idx_2_id.get(idx)
+        if run_id is None:
+            self.logger.debug(f"Skipping Ray pending batch reset for unknown run index {idx}")
+            return
+        self._pending.pop(run_id, None)
+
     def receive(self) -> list[TrainingBatch]:
         batches: list[TrainingBatch] = []
         now = time.time()

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -3,13 +3,14 @@ from typing import Annotated, Literal
 
 import pytest
 import tomli_w
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field, TypeAdapter, ValidationError
 from pydantic_config import ConfigFileError
 
 from prime_rl.configs.inference import InferenceConfig
 from prime_rl.configs.orchestrator import OrchestratorConfig
 from prime_rl.configs.rl import RLConfig
 from prime_rl.configs.sft import SFTConfig
+from prime_rl.configs.shared import TransportConfig
 from prime_rl.configs.trainer import ModelConfig as TrainerModelConfig
 from prime_rl.configs.trainer import TrainerConfig
 from prime_rl.utils.config import BaseConfig, cli
@@ -188,6 +189,35 @@ def test_orchestrator_vlm_configs_must_disable_renderer():
 def test_selective_activation_checkpointing_requires_custom_impl():
     with pytest.raises(ValidationError, match="Selective activation checkpointing requires model.impl='custom'"):
         TrainerModelConfig.model_validate({"impl": "hf", "ac": {"mode": "selective"}})
+
+
+def test_ray_transport_config_parses():
+    adapter = TypeAdapter(TransportConfig)
+
+    config = adapter.validate_python(
+        {
+            "type": "ray",
+            "address": "auto",
+            "namespace": "test",
+            "actor_name": "rollout-store",
+            "max_queued_items": 2,
+            "reclaim_stale_actor": True,
+        }
+    )
+
+    assert config.type == "ray"
+    assert config.address == "auto"
+    assert config.namespace == "test"
+    assert config.actor_name == "rollout-store"
+    assert config.max_queued_items == 2
+    assert config.reclaim_stale_actor is True
+
+
+def test_ray_transport_config_rejects_non_positive_queue_size():
+    adapter = TypeAdapter(TransportConfig)
+
+    with pytest.raises(ValidationError, match="greater than or equal to 1"):
+        adapter.validate_python({"type": "ray", "max_queued_items": 0})
 
 
 def test_orchestrator_renderer_auto_rejects_unmapped_model():

--- a/tests/unit/transport/test_ray.py
+++ b/tests/unit/transport/test_ray.py
@@ -1,6 +1,10 @@
+from collections import defaultdict
+from types import SimpleNamespace
+
 import pytest
 
-from prime_rl.transport.ray import _RayTransportStore
+from prime_rl.transport.ray import RayTrainingBatchReceiver, _RayTransportStore
+from prime_rl.transport.types import TrainingBatch
 
 
 def test_ray_transport_store_drains_training_batches():
@@ -55,3 +59,20 @@ def test_ray_transport_store_rejects_duplicate_micro_batch_step():
 
     with pytest.raises(RuntimeError, match="already queued"):
         store.put_micro_batch(data_rank=0, step=0, payload=b"duplicate")
+
+
+def test_ray_training_batch_receiver_reset_run_clears_only_matching_pending_batches():
+    receiver = object.__new__(RayTrainingBatchReceiver)
+    receiver.multi_run_manager = SimpleNamespace(idx_2_id={0: "run-a", 1: "run-b"})
+    receiver._pending = defaultdict(
+        dict,
+        {
+            "run-a": {0: TrainingBatch(examples=[], step=0)},
+            "run-b": {0: TrainingBatch(examples=[], step=0)},
+        },
+    )
+
+    receiver.reset_run(0)
+
+    assert "run-a" not in receiver._pending
+    assert receiver._pending["run-b"] == {0: TrainingBatch(examples=[], step=0)}

--- a/tests/unit/transport/test_ray.py
+++ b/tests/unit/transport/test_ray.py
@@ -1,0 +1,57 @@
+import pytest
+
+from prime_rl.transport.ray import _RayTransportStore
+
+
+def test_ray_transport_store_drains_training_batches():
+    store = _RayTransportStore(max_queued_items=2)
+
+    store.put_training_batch("sender-a", b"first")
+    store.put_training_batch("sender-b", b"second")
+
+    assert store.training_batch_count() == 2
+    assert store.drain_training_batches() == [("sender-a", b"first"), ("sender-b", b"second")]
+    assert store.training_batch_count() == 0
+
+
+def test_ray_transport_store_limits_training_batches_per_sender():
+    store = _RayTransportStore(max_queued_items=1)
+
+    store.put_training_batch("sender-a", b"first")
+
+    with pytest.raises(RuntimeError, match="queue is full"):
+        store.put_training_batch("sender-a", b"second")
+
+    store.put_training_batch("sender-b", b"allowed")
+    assert store.training_batch_count() == 2
+
+
+def test_ray_transport_store_pops_micro_batch_by_rank_and_step():
+    store = _RayTransportStore(max_queued_items=2)
+
+    store.put_micro_batch(data_rank=0, step=3, payload=b"rank-0-step-3")
+
+    assert store.has_micro_batch(data_rank=0, step=3)
+    assert store.pop_micro_batch(data_rank=0, step=3) == b"rank-0-step-3"
+    assert store.pop_micro_batch(data_rank=0, step=3) is None
+
+
+def test_ray_transport_store_limits_micro_batches_per_rank():
+    store = _RayTransportStore(max_queued_items=1)
+
+    store.put_micro_batch(data_rank=0, step=0, payload=b"first")
+
+    with pytest.raises(RuntimeError, match="queue is full"):
+        store.put_micro_batch(data_rank=0, step=1, payload=b"second")
+
+    store.put_micro_batch(data_rank=1, step=0, payload=b"other-rank")
+    assert store.has_micro_batch(data_rank=1, step=0)
+
+
+def test_ray_transport_store_rejects_duplicate_micro_batch_step():
+    store = _RayTransportStore(max_queued_items=2)
+
+    store.put_micro_batch(data_rank=0, step=0, payload=b"first")
+
+    with pytest.raises(RuntimeError, match="already queued"):
+        store.put_micro_batch(data_rank=0, step=0, payload=b"duplicate")


### PR DESCRIPTION
TL;DR - I wrote some code to get ray working for kubernetes clusters in https://github.com/chokevin/prime-rl/tree/main. Want to merge it upstream for those who are not in the slurm mindset and also it advances one of my goals to move from slurm -> a more native k8s scheduler paradigm.

Below is some AI markdown

## What

Adds an optional Ray actor-backed rollout transport behind the existing `TrainingBatchSender` / `TrainingBatchReceiver` and `MicroBatchSender` / `MicroBatchReceiver` abstractions.

This keeps the existing filesystem and ZMQ transports unchanged, adds `rollout_transport.type = "ray"`, and keeps Ray imports lazy so non-Ray users do not need Ray installed just to import `prime_rl.transport`.

Follow-up: `RayTrainingBatchReceiver.reset_run(idx)` now clears pending Ray training batches for the deleted run id, addressing the Cursor Bugbot stale-pending-batch review comment.

## Why

This is the first reviewable slice for the Ray-native runtime direction tracked in #2511. The broader runtime, Ray Train integration, KubeRay examples, and RayCluster launcher docs are intentionally left for follow-up PRs.

Refs #2511.

## Non-goals

- No Ray-native RL launcher or role orchestration in this PR.
- No Ray Train trainer backend in this PR.
- No Ray Serve/vLLM replacement in this PR.
- No Kubernetes or KubeRay manifests in this PR.

## Testing

- Installed pre-commit hooks with `uv tool run pre-commit install` because `uv run pre-commit install` is blocked on this macOS worktree by the current Linux-only lockfile environments.
- `uv tool run pre-commit run --files <changed-python-files>`
- `git diff --check`
- `uv run --no-sync ruff check packages/prime-rl-configs/src/prime_rl/configs/shared.py src/prime_rl/transport/__init__.py src/prime_rl/transport/ray.py tests/unit/test_configs.py tests/unit/transport/test_ray.py`
- `uv run --no-sync ruff format --check packages/prime-rl-configs/src/prime_rl/configs/shared.py src/prime_rl/transport/__init__.py src/prime_rl/transport/ray.py tests/unit/test_configs.py tests/unit/transport/test_ray.py`
- `uv run --no-sync python -m compileall -q packages/prime-rl-configs/src/prime_rl/configs/shared.py src/prime_rl/transport tests/unit/test_configs.py tests/unit/transport`
- `PYTHONPATH=deps/renderers uv run --no-sync --with-editable deps/renderers pytest tests/unit/test_configs.py tests/unit/transport/test_ray.py -q` (`85 passed`)
- Smoke checked that `import prime_rl.transport` does not import Ray.
- Bugbot follow-up: `PYTHONPATH=/Users/chokevin/dev/copilot-worktrees/prime-rl/chokevin-vigilant-guacamole/src:/Users/chokevin/dev/copilot-worktrees/prime-rl/chokevin-vigilant-guacamole/packages/prime-rl-configs/src uv run --no-project --with pytest --with msgspec --with pydantic --with 'pydantic-config @ git+https://github.com/samsja/pydantic_config.git' --with loguru pytest --confcutdir=tests/unit/transport tests/unit/transport/test_ray.py` (`6 passed`)
- Bugbot follow-up: `uv run --no-project --with ruff ruff check src/prime_rl/transport/ray.py tests/unit/transport/test_ray.py`
- Bugbot follow-up: `uv run --no-project --with ruff ruff format --check src/prime_rl/transport/ray.py tests/unit/transport/test_ray.py`

## Risk

Low for existing transports: the default transport configs are unchanged and backend imports are lazy. The new `ray` transport requires Ray at runtime and fails explicitly if Ray is not installed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new Ray-based data transport path and refactors `prime_rl.transport` imports/dispatch, which can affect runtime behavior when selecting transports or importing the package. Existing filesystem/ZMQ paths are intended to be unchanged but should be re-validated for import/typing edge cases.
> 
> **Overview**
> Adds a new `rollout_transport.type = "ray"` option via `RayTransportConfig` (address/namespace/actor naming, per-sender queue limits, and optional stale-actor reclaim) and extends the `TransportConfig` discriminated union to include it.
> 
> Implements a Ray actor–backed transport (`transport/ray.py`) for both training batches and micro-batches, including backpressure limits and receiver-side pending buffering with `reset_run()` clearing stale pending batches for deleted runs.
> 
> Refactors `prime_rl.transport` to lazily import backend classes via `__getattr__` and to route `setup_*` factory functions to the Ray implementations when `transport.type == "ray"`, while adding unit tests for Ray config validation and store/receiver behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87b563b32ca0a5e5c317011f8714ace792766461. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->