### PR TITLE
Add pydantic-config submodule

### DIFF
--- a/.github/workflows/cpu_tests.yaml
+++ b/.github/workflows/cpu_tests.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Init public submodules
         run: |
           git config --global url."https://github.com/".insteadOf "git@github.com:"
-          git submodule update --init --recursive -- deps/verifiers deps/renderers deps/research-environments
+          git submodule update --init --recursive -- deps/verifiers deps/renderers deps/research-environments deps/pydantic-config
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:

--- a/.github/workflows/gpu_tests.yaml
+++ b/.github/workflows/gpu_tests.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Init public submodules
         run: |
           git config --global url."https://github.com/".insteadOf "git@github.com:"
-          git submodule update --init --recursive -- deps/verifiers deps/renderers deps/research-environments
+          git submodule update --init --recursive -- deps/verifiers deps/renderers deps/research-environments deps/pydantic-config
       - name: Install uv
         uses: astral-sh/setup-uv@v5
       - name: Install dependencies
@@ -97,7 +97,7 @@ jobs:
       - name: Init public submodules
         run: |
           git config --global url."https://github.com/".insteadOf "git@github.com:"
-          git submodule update --init --recursive -- deps/verifiers deps/renderers deps/research-environments
+          git submodule update --init --recursive -- deps/verifiers deps/renderers deps/research-environments deps/pydantic-config
       - name: Install uv
         uses: astral-sh/setup-uv@v5
       - name: Install dependencies

--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -79,7 +79,7 @@ jobs:
             - name: Init public submodules
               run: |
                   git config --global url."https://github.com/".insteadOf "git@github.com:"
-                  git submodule update --init --recursive -- deps/verifiers deps/renderers deps/research-environments
+                  git submodule update --init --recursive -- deps/verifiers deps/renderers deps/research-environments deps/pydantic-config
             - name: Install uv
               uses: astral-sh/setup-uv@v5
               with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Init public submodules
         run: |
           git config --global url."https://github.com/".insteadOf "git@github.com:"
-          git submodule update --init --recursive -- deps/verifiers deps/renderers deps/research-environments
+          git submodule update --init --recursive -- deps/verifiers deps/renderers deps/research-environments deps/pydantic-config
       - name: Docker meta
         id: meta
         uses: crazy-max/ghaction-docker-meta@v2

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "configs/private"]
 	path = configs/private
 	url = git@github.com:PrimeIntellect-ai/research-configs.git
+[submodule "pydantic-config"]
+	path = deps/pydantic-config
+	url = https://github.com/PrimeIntellect-ai/pydantic-config

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ cd prime-rl
 2. Initialize submodules
 
 ```bash
-git submodule update --init -- deps/verifiers deps/renderers deps/research-environments
+git submodule update --init -- deps/verifiers deps/renderers deps/research-environments deps/pydantic-config
 ```
 
 3. Install [uv](https://docs.astral.sh/uv/)

--- a/skills/installation/SKILL.md
+++ b/skills/installation/SKILL.md
@@ -12,18 +12,18 @@ prime-rl is a monorepo with submodules. Clone the repo first, then initialize su
 ```bash
 git clone git@github.com:PrimeIntellect-ai/prime-rl.git
 cd prime-rl
-git submodule update --init -- deps/verifiers deps/renderers deps/research-environments
+git submodule update --init -- deps/verifiers deps/renderers deps/research-environments deps/pydantic-config
 ```
 
 For an existing clone, initialize the public submodules by passing explicit paths:
 
 ```bash
-git submodule update --init -- deps/verifiers deps/renderers deps/research-environments
+git submodule update --init -- deps/verifiers deps/renderers deps/research-environments deps/pydantic-config
 ```
 
 Do **not** use `git submodule update --init --recursive` without explicit paths — it will also attempt to clone `configs/private` (a private submodule) and fail with "Repository not found" for users without access. Git will retry the clone once internally before aborting, which is expected behavior.
 
-The public submodules live under `deps/`: `deps/verifiers/`, `deps/renderers/`, and `deps/research-environments/`. Each is also a uv workspace member, so source edits inside them apply to the prime-rl venv without re-sync.
+The public submodules live under `deps/`: `deps/verifiers/`, `deps/renderers/`, `deps/research-environments/`, and `deps/pydantic-config/`. The uv workspace members among them apply source edits to the prime-rl venv without re-sync.
 
 The install script (`scripts/install.sh`) handles the private submodule gracefully — it iterates each submodule individually so a failed `configs/private` init does not abort the rest.
 


### PR DESCRIPTION
## Summary

Adds `https://github.com/PrimeIntellect-ai/pydantic-config` as a public git submodule at `deps/pydantic-config`.

Updates manual setup docs, the installation skill, and CI submodule initialization commands so the new public submodule is fetched with the existing public `deps/` submodules.

## Validation

- `git diff --check`
- `git diff --cached --check`
- `git submodule update --init -- deps/pydantic-config`
- `git submodule status deps/pydantic-config` -> `b6a2411e441e13cd90c91f1bf2a4eb8310e977ed deps/pydantic-config (heads/main)`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to adding a new public git submodule and ensuring CI/docs initialize it; main risk is CI or local setup failing if the submodule URL/ref is unavailable.
> 
> **Overview**
> Adds a new public submodule, `deps/pydantic-config`, via `.gitmodules`.
> 
> Updates GitHub Actions workflows (`cpu_tests`, `gpu_tests`, `nightly_tests`, `release`) and setup docs (`README.md`, `skills/installation/SKILL.md`) so the standard “init public submodules” commands also clone `deps/pydantic-config`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb78d9d33c2062435df7c478f2f56d94972b3468. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->