### PR TITLE
feat(dynamo): expose OPD generate endpoint

### DIFF
--- a/src/prime_rl/inference/dynamo/proxy.py
+++ b/src/prime_rl/inference/dynamo/proxy.py
@@ -76,6 +76,19 @@ class DynamoProxy:
             headers=_content_headers(response.headers),
         )
 
+    async def generate(self, request: Request) -> Response:
+        body = await request.json()
+        dp_rank = request.headers.get("x-data-parallel-rank")
+        if dp_rank is not None:
+            body.setdefault("routing", {})["dp_rank"] = int(dp_rank)
+
+        response = await self.client.post(f"{self.worker_url}/engine/generate", json=body)
+        return Response(
+            content=response.content,
+            status_code=response.status_code,
+            headers=_content_headers(response.headers),
+        )
+
     async def models(self) -> JSONResponse:
         return JSONResponse(
             {
@@ -126,6 +139,10 @@ def build_app(proxy: DynamoProxy) -> FastAPI:
     @app.post("/v1/chat/completions")
     async def _chat_completions(request: Request) -> Response:
         return await proxy.chat_completions(request)
+
+    @app.post("/v1/generate")
+    async def _generate(request: Request) -> Response:
+        return await proxy.generate(request)
 
     @app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
     async def _forward(request: Request, path: str) -> Response:

--- a/src/prime_rl/inference/dynamo/worker.py
+++ b/src/prime_rl/inference/dynamo/worker.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import base64
 import time
+from collections.abc import Mapping
 from typing import Any, Callable
 from uuid import uuid4
 
@@ -138,6 +140,129 @@ def _token_logprobs(tokenizer, output) -> dict[str, Any] | None:
     return {"content": content, "refusal": None}
 
 
+def _extract_selected_logprob(token_logprobs: Any, token_id: int | None = None) -> float | None:
+    if not token_logprobs:
+        return None
+
+    if token_id is not None and hasattr(token_logprobs, "get"):
+        selected = token_logprobs.get(token_id)
+        if selected is None:
+            return None
+    else:
+        selected = next(iter(token_logprobs.values()))
+
+    if hasattr(selected, "logprob"):
+        logprob = selected.logprob
+    elif isinstance(selected, Mapping):
+        logprob = selected.get("logprob")
+    else:
+        logprob = selected
+    return float(logprob) if logprob is not None else None
+
+
+def _extract_prompt_logprobs(prompt_logprobs: Any, prompt_token_ids: list[int]) -> list[float | None] | None:
+    if prompt_logprobs is None:
+        return None
+
+    if hasattr(prompt_logprobs, "values"):
+        prompt_logprobs = [prompt_logprobs]
+
+    extracted: list[float | None] = []
+    for index, token_logprobs in enumerate(prompt_logprobs):
+        token_id = prompt_token_ids[index] if index < len(prompt_token_ids) else None
+        extracted.append(_extract_selected_logprob(token_logprobs, token_id))
+    return extracted
+
+
+def _completion_logprobs(output) -> list[float]:
+    if output.logprobs is None:
+        return []
+
+    logprobs: list[float] = []
+    for index, token_id in enumerate(output.token_ids):
+        if index >= len(output.logprobs):
+            break
+        logprob = _extract_selected_logprob(output.logprobs[index], token_id)
+        logprobs.append(0.0 if logprob is None else logprob)
+    return logprobs
+
+
+def _encode_routed_experts(arr: Any) -> dict[str, Any]:
+    return {
+        "data": base64.b85encode(arr.tobytes()).decode("ascii"),
+        "shape": list(arr.shape),
+    }
+
+
+async def _generate(handler, body: dict[str, Any]) -> dict[str, Any]:
+    from vllm.inputs.engine import tokens_input
+
+    prompt_token_ids = body["prompt_token_ids"]
+    request_id = body.get("request_id") or f"gen-{uuid4().hex[:16]}"
+    model = body.get("model") or getattr(handler.config, "served_model_name", None) or handler.config.model
+    sampling_params = _sampling_params(handler, body)
+    sampling_params.logprobs = 1
+    if body.get("prompt_logprobs"):
+        sampling_params.prompt_logprobs = 1
+    if hasattr(sampling_params, "skip_special_tokens"):
+        sampling_params.skip_special_tokens = False
+
+    routing = body.get("routing") or {}
+    dp_rank = handler._to_local_dp_rank(routing.get("dp_rank"))
+    priority = -int(routing.get("priority", body.get("priority", 0)))
+    lora_request = handler._resolve_lora_request(model)
+
+    final_output = None
+    routed_experts_map: dict[int, dict[str, Any]] = {}
+    try:
+        async for output in handler.engine_client.generate(
+            tokens_input(prompt_token_ids, cache_salt=body.get("cache_salt")),
+            sampling_params,
+            request_id,
+            lora_request=lora_request,
+            data_parallel_rank=dp_rank,
+            priority=priority,
+        ):
+            for comp_output in output.outputs:
+                if comp_output.routed_experts is not None:
+                    routed_experts_map[comp_output.index] = _encode_routed_experts(comp_output.routed_experts)
+            final_output = output
+    except Exception:
+        logger.exception("Dynamo generate request failed")
+        raise
+
+    if final_output is None:
+        return {"error": "No output generated"}
+
+    choices = []
+    for output in final_output.outputs:
+        token_ids = list(output.token_ids)
+        choices.append(
+            {
+                "index": output.index,
+                "token_ids": token_ids,
+                "logprobs": _completion_logprobs(output),
+                "finish_reason": output.finish_reason,
+                "routed_experts": routed_experts_map.get(output.index),
+            }
+        )
+
+    prompt_ids = list(getattr(final_output, "prompt_token_ids", prompt_token_ids))
+    completion_len = sum(len(choice["token_ids"]) for choice in choices)
+    return {
+        "id": request_id,
+        "model": model,
+        "prompt_token_ids": prompt_ids,
+        "choices": choices,
+        "usage": {
+            "prompt_tokens": len(prompt_ids),
+            "completion_tokens": completion_len,
+            "total_tokens": len(prompt_ids) + completion_len,
+        },
+        "prompt_logprobs": _extract_prompt_logprobs(getattr(final_output, "prompt_logprobs", None), prompt_ids),
+    }
+
+
 async def _chat_completions(handler, body: dict[str, Any]) -> dict[str, Any]:
     from vllm.inputs import TokensPrompt
 
@@ -233,12 +358,13 @@ def patch_dynamo_vllm_worker() -> None:
         runtime.register_engine_route("update_weights", _bind(self, _update_weights))
         runtime.register_engine_route("init_broadcaster", _bind(self, _init_broadcaster))
         runtime.register_engine_route("liveness", _bind(self, _liveness_probe))
+        runtime.register_engine_route("generate", _bind(self, _generate))
         runtime.register_engine_route("chat_completions", _bind(self, _chat_completions))
         self._prime_rl_admin_routes_registered = True
         logger.info(
             "Registered prime-rl Dynamo admin routes: "
             "/engine/pause, /engine/resume, /engine/update_weights, /engine/init_broadcaster, "
-            "/engine/liveness, /engine/chat_completions"
+            "/engine/liveness, /engine/generate, /engine/chat_completions"
         )
 
     BaseWorkerHandler.__init__ = patched_init

--- a/tests/unit/inference/test_dynamo_generate.py
+++ b/tests/unit/inference/test_dynamo_generate.py
@@ -1,0 +1,187 @@
+import asyncio
+import base64
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+from prime_rl.inference.dynamo.worker import (
+    _completion_logprobs,
+    _extract_prompt_logprobs,
+    _generate,
+)
+
+
+def test_extract_prompt_logprobs_prefers_supplied_token_id():
+    prompt_logprobs = [
+        None,
+        {
+            7: SimpleNamespace(logprob=-7.0),
+            42: SimpleNamespace(logprob=-0.42),
+        },
+        {
+            99: {"logprob": -0.99},
+        },
+    ]
+
+    assert _extract_prompt_logprobs(prompt_logprobs, [1, 42, 99]) == [None, -0.42, -0.99]
+
+
+def test_completion_logprobs_align_to_generated_token_ids():
+    output = SimpleNamespace(
+        token_ids=[5, 6],
+        logprobs=[
+            {5: SimpleNamespace(logprob=-0.5)},
+            {7: SimpleNamespace(logprob=-0.7), 6: SimpleNamespace(logprob=-0.6)},
+        ],
+    )
+
+    assert _completion_logprobs(output) == [-0.5, -0.6]
+
+
+def test_logprobs_do_not_fall_back_to_unmatched_token():
+    assert _extract_prompt_logprobs([{7: SimpleNamespace(logprob=-0.7)}], [42]) == [None]
+
+    output = SimpleNamespace(token_ids=[42], logprobs=[{7: SimpleNamespace(logprob=-0.7)}])
+    assert _completion_logprobs(output) == [0.0]
+
+
+def test_generate_uses_tokens_input_with_cache_salt():
+    calls = []
+
+    class FakeSamplingParams:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+            self.logprobs = None
+            self.prompt_logprobs = None
+            self.skip_special_tokens = True
+
+    engine_module = ModuleType("vllm.inputs.engine")
+
+    def fake_tokens_input(prompt_token_ids, cache_salt=None):
+        return {"prompt_token_ids": prompt_token_ids, "cache_salt": cache_salt}
+
+    engine_module.tokens_input = fake_tokens_input
+    sampling_module = ModuleType("vllm.sampling_params")
+    sampling_module.SamplingParams = FakeSamplingParams
+
+    class FakeRoutedExperts:
+        shape = (1, 2)
+
+        def tobytes(self):
+            return b"abc"
+
+    class FakeEngineClient:
+        async def generate(self, prompt, sampling_params, request_id, **kwargs):
+            calls.append(
+                {
+                    "prompt": prompt,
+                    "sampling_params": sampling_params,
+                    "request_id": request_id,
+                    "kwargs": kwargs,
+                }
+            )
+            yield SimpleNamespace(
+                prompt_token_ids=prompt["prompt_token_ids"],
+                prompt_logprobs=[None, {2: SimpleNamespace(logprob=-0.2)}],
+                outputs=[
+                    SimpleNamespace(
+                        index=0,
+                        token_ids=[3],
+                        logprobs=[{3: SimpleNamespace(logprob=-0.3)}],
+                        finish_reason="length",
+                        routed_experts=FakeRoutedExperts(),
+                    )
+                ],
+            )
+
+    handler = SimpleNamespace(
+        default_sampling_params={},
+        config=SimpleNamespace(model="served/model"),
+        engine_client=FakeEngineClient(),
+        _to_local_dp_rank=lambda dp_rank: dp_rank,
+        _resolve_lora_request=lambda _model: None,
+    )
+
+    with patch.dict(
+        sys.modules,
+        {
+            "vllm": ModuleType("vllm"),
+            "vllm.inputs": ModuleType("vllm.inputs"),
+            "vllm.inputs.engine": engine_module,
+            "vllm.sampling_params": sampling_module,
+        },
+    ):
+        response = asyncio.run(
+            _generate(
+                handler,
+                {
+                    "model": "served/model",
+                    "prompt_token_ids": [1, 2],
+                    "prompt_logprobs": True,
+                    "max_tokens": 1,
+                    "cache_salt": "42",
+                    "priority": 7,
+                    "routing": {"dp_rank": 3},
+                },
+            )
+        )
+
+    assert calls[0]["prompt"] == {"prompt_token_ids": [1, 2], "cache_salt": "42"}
+    assert calls[0]["sampling_params"].logprobs == 1
+    assert calls[0]["sampling_params"].prompt_logprobs == 1
+    assert calls[0]["sampling_params"].skip_special_tokens is False
+    assert calls[0]["kwargs"]["data_parallel_rank"] == 3
+    assert calls[0]["kwargs"]["priority"] == -7
+    assert response["prompt_logprobs"] == [None, -0.2]
+    assert response["choices"][0]["logprobs"] == [-0.3]
+    assert response["choices"][0]["routed_experts"] == {
+        "data": base64.b85encode(b"abc").decode("ascii"),
+        "shape": [1, 2],
+    }
+
+
+def test_dynamo_proxy_generate_preserves_data_parallel_header():
+    transformers_module = ModuleType("transformers")
+    transformers_module.AutoTokenizer = SimpleNamespace()
+
+    with patch.dict(sys.modules, {"transformers": transformers_module}):
+        from prime_rl.inference.dynamo.proxy import DynamoProxy
+
+    captured = {}
+
+    class FakeClient:
+        async def post(self, url, json):
+            captured["url"] = url
+            captured["json"] = json
+            return SimpleNamespace(content=b"{}", status_code=200, headers={"content-type": "application/json"})
+
+    class FakeRequest:
+        headers = {"x-data-parallel-rank": "4"}
+
+        async def json(self):
+            return {"model": "served/model", "prompt_token_ids": [1, 2]}
+
+    proxy = DynamoProxy.__new__(DynamoProxy)
+    proxy.worker_url = "http://worker"
+    proxy.client = FakeClient()
+
+    response = asyncio.run(proxy.generate(FakeRequest()))
+
+    assert response.status_code == 200
+    assert captured["url"] == "http://worker/engine/generate"
+    assert captured["json"]["routing"]["dp_rank"] == 4
+
+
+def test_dynamo_proxy_exposes_generate_route():
+    transformers_module = ModuleType("transformers")
+    transformers_module.AutoTokenizer = SimpleNamespace()
+
+    with patch.dict(sys.modules, {"transformers": transformers_module}):
+        from prime_rl.inference.dynamo.proxy import build_app
+
+    proxy = SimpleNamespace(close=lambda: None)
+    app = build_app(proxy)
+
+    post_routes = {route.path for route in app.routes if "POST" in getattr(route, "methods", set())}
+
+    assert "/v1/generate" in post_routes


### PR DESCRIPTION
## Summary
- proxy `/v1/generate` to Dynamo worker `/engine/generate`
- register a Dynamo worker generate route for pre-tokenized OPD requests
- return generated token ids, completion logprobs, prompt logprobs, and usage
- pass `cache_salt` through vLLM `tokens_input` so prefix-cache entries do not survive weight updates

## Validation
- `python -m ruff check src/prime_rl/inference/dynamo/proxy.py src/prime_rl/inference/dynamo/worker.py tests/unit/inference/test_dynamo_generate.py`
- `PYTHONPATH=src:packages/prime-rl-configs/src python -m py_compile src/prime_rl/inference/dynamo/proxy.py src/prime_rl/inference/dynamo/worker.py tests/unit/inference/test_dynamo_generate.py`
- manual invocation of `tests.unit.inference.test_dynamo_generate` test functions with `PYTHONPATH=src:packages/prime-rl-configs/src`

Note: full `uv run pytest ...` is blocked on macOS by the repo lockfile Linux-only environment markers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new inference endpoint and worker route that changes how requests are routed into vLLM (including cache-salt and priority handling), which could affect output/logprob correctness and caching behavior. Covered by unit tests, but still touches core generation plumbing.
> 
> **Overview**
> Adds a new `POST /v1/generate` route on the Dynamo proxy that forwards pre-tokenized requests to the worker’s new `/engine/generate` endpoint while preserving `x-data-parallel-rank` routing.
> 
> On the worker, introduces `_generate` to run vLLM generation via `tokens_input(..., cache_salt=...)`, force token-level `logprobs` (and optional `prompt_logprobs`), and return token IDs, per-token logprobs, usage stats, and optional base85-encoded `routed_experts` data. Adds unit tests covering logprob extraction/alignment, cache-salt forwarding, and proxy route/header wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b13506dc321b6027f0dcc41c62ed99b39985eea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->