### PR TITLE
fix(client): revert base_url to single string (drop multi-client)

### DIFF
--- a/configs/debug/training_modes/opd.toml
+++ b/configs/debug/training_modes/opd.toml
@@ -43,7 +43,7 @@ id = "reverse-text"
 name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-RL"
 
 [orchestrator.teacher.client]
-base_url = ["http://localhost:8001/v1"]
+base_url = "http://localhost:8001/v1"
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/debug/training_modes/opd_lora.toml
+++ b/configs/debug/training_modes/opd_lora.toml
@@ -43,7 +43,7 @@ id = "reverse-text"
 name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-RL"
 
 [orchestrator.teacher.client]
-base_url = ["http://localhost:8001/v1"]
+base_url = "http://localhost:8001/v1"
 
 [trainer.optim]
 lr = 1e-4

--- a/configs/debug/training_modes/sft.toml
+++ b/configs/debug/training_modes/sft.toml
@@ -40,7 +40,7 @@ id = "reverse-text"
 name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-RL"
 
 [orchestrator.teacher.client]
-base_url = ["http://localhost:8001/v1"]
+base_url = "http://localhost:8001/v1"
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/debug/training_modes/sft_external.toml
+++ b/configs/debug/training_modes/sft_external.toml
@@ -40,7 +40,7 @@ id = "reverse-text"
 name = "openai/gpt-5-mini"
 
 [orchestrator.teacher.client]
-base_url = ["https://api.pinference.ai/api/v1"]
+base_url = "https://api.pinference.ai/api/v1"
 api_key_var = "PRIME_API_KEY"
 
 [orchestrator.teacher.client.headers_from_env]

--- a/configs/debug/training_modes/sft_lora.toml
+++ b/configs/debug/training_modes/sft_lora.toml
@@ -40,7 +40,7 @@ id = "reverse-text"
 name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-RL"
 
 [orchestrator.teacher.client]
-base_url = ["http://localhost:8001/v1"]
+base_url = "http://localhost:8001/v1"
 
 [trainer.optim]
 lr = 1e-4

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -921,7 +921,7 @@ class RLConfig(BaseConfig):
 
         For all modes, sets dp_rank_count from inference DP size. For SFT mode,
         also sets base_url - rl/opd rely on the ClientConfig default
-        (``["http://localhost:8000/v1"]``) which already matches the auto-launched
+        (``"http://localhost:8000/v1"``) which already matches the auto-launched
         student vLLM at inference.server.port = 8000.
         """
         if self.inference is None:
@@ -932,7 +932,7 @@ class RLConfig(BaseConfig):
         if self.orchestrator.training_mode == "sft" and "base_url" not in client.model_fields_set:
             host = self.inference.server.host or "localhost"
             port = self.inference.server.port
-            client.base_url = [f"http://{host}:{port}/v1"]
+            client.base_url = f"http://{host}:{port}/v1"
         return self
 
     @model_validator(mode="after")
@@ -971,7 +971,7 @@ class RLConfig(BaseConfig):
             self.orchestrator.teacher = RolloutModelConfig()
         host = self.teacher_inference.server.host or "localhost"
         port = self.teacher_inference.server.port
-        self.orchestrator.teacher.client.base_url = [f"http://{host}:{port}/v1"]
+        self.orchestrator.teacher.client.base_url = f"http://{host}:{port}/v1"
         self.orchestrator.teacher.model.name = self.teacher_inference.model.name
 
         return self

--- a/packages/prime-rl-configs/src/prime_rl/configs/shared.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/shared.py
@@ -254,7 +254,7 @@ class ClientConfig(BaseConfig):
     """Configures the OAI client.
 
     Supports two modes:
-    - Static mode (default): Uses fixed base_url list
+    - Static mode (default): Uses a fixed base_url
     - Elastic mode: Uses DNS-based service discovery via hostname
 
     If elastic config is provided, base_url is ignored and servers are discovered dynamically.
@@ -283,16 +283,16 @@ class ClientConfig(BaseConfig):
     ] = 1800
 
     base_url: Annotated[
-        list[str],
+        str,
         Field(
-            description="Base URLs to use for the OpenAI API. By default, it is set to a single server on localhost at port 8000 which matches the default local vLLM server configuration. If you specify more than one URL, the client will round-robin (chat) completion requests across all servers. Ignored if elastic config is provided.",
+            description="Base URL to use for the OpenAI API. Defaults to a single server on localhost at port 8000 which matches the default local vLLM server configuration. Ignored if elastic config is provided.",
         ),
-    ] = ["http://localhost:8000/v1"]
+    ] = "http://localhost:8000/v1"
 
     api_key_var: Annotated[
         str,
         Field(
-            description="Name of environment variable containing the API key to use for the inference API. Will parse using `os.getenv(client_config.api_key_var)`. Can be set to an arbitrary string if the inference server is not protected by an API key. If multiple URLs are specified, the same API key will be used for all servers.",
+            description="Name of environment variable containing the API key to use for the inference API. Will parse using `os.getenv(client_config.api_key_var)`. Can be set to an arbitrary string if the inference server is not protected by an API key.",
         ),
     ] = "VLLM_API_KEY"
 
@@ -331,8 +331,8 @@ class ClientConfig(BaseConfig):
         Field(
             ge=1,
             description=(
-                "Number of data-parallel ranks behind each base URL. When > 1, "
-                "each URL is expanded into dp_rank_count logical clients, each "
+                "Number of data-parallel ranks behind the base URL. When > 1, "
+                "the URL is expanded into dp_rank_count logical clients, each "
                 "pinned to a specific DP rank via the X-data-parallel-rank header. "
                 "This ensures all requests within a multi-turn rollout hit the same "
                 "DP engine, maximizing KV cache reuse. Auto-set from "
@@ -343,12 +343,12 @@ class ClientConfig(BaseConfig):
     ] = 1
 
     admin_base_url: Annotated[
-        list[str] | None,
+        str | None,
         Field(
-            description="Separate base URLs for admin operations (weight updates, health checks). "
-            "When set, admin clients use these URLs instead of base_url, allowing weight "
-            "updates to bypass routers and hit each server directly. Used in disaggregated "
-            "P/D deployments where the inference router should not handle admin traffic.",
+            description="Separate base URL for admin operations (weight updates, health checks). "
+            "When set, the admin client uses this URL instead of base_url, allowing weight "
+            "updates to bypass routers and hit the server directly. Used in deployments "
+            "where the inference router should not handle admin traffic.",
         ),
     ] = None
 

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -132,7 +132,7 @@ def rl_local(config: RLConfig):
     if config.inference is not None and not config.orchestrator.student.client.is_elastic:
         from urllib.parse import urlparse
 
-        base_url = config.orchestrator.student.client.base_url[0]
+        base_url = config.orchestrator.student.client.base_url
         parsed = urlparse(base_url)
         client_port = parsed.port
         expected_port = config.inference.server.port
@@ -195,7 +195,7 @@ def rl_local(config: RLConfig):
                 "No [inference] block configured - the student inference server will not be started here. "
                 "All training modes (rl/opd/sft) require a student inference pool for evals + weight sync; "
                 "make sure one is running at orchestrator.student.client.base_url "
-                f"({', '.join(config.orchestrator.student.client.base_url)}), otherwise the orchestrator "
+                f"({config.orchestrator.student.client.base_url}), otherwise the orchestrator "
                 "will hang waiting for it."
             )
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -131,7 +131,7 @@ async def orchestrate(config: OrchestratorConfig):
 
     # Set up student inference pool (required for all training modes).
     logger.info(
-        f"Initializing student inference pool (base_url={', '.join(config.student.client.base_url)}, "
+        f"Initializing student inference pool (base_url={config.student.client.base_url}, "
         f"model={config.student.model.name})"
     )
     renderer, student_inference = await setup_student_inference_pool(
@@ -146,7 +146,7 @@ async def orchestrate(config: OrchestratorConfig):
     teacher_inference = None
     if config.teacher is not None:
         logger.info(
-            f"Initializing teacher inference pool (base_url={', '.join(config.teacher.client.base_url)}, "
+            f"Initializing teacher inference pool (base_url={config.teacher.client.base_url}, "
             f"model={config.teacher.model.name})"
         )
         teacher_inference = await setup_inference_pool(

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -89,7 +89,7 @@ class StaticInferencePool:
             preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
         )
         self._eval_clients = setup_clients(client_config, client_type=eval_client_type)
-        self._admin_clients = setup_admin_clients(client_config)
+        self._admin_clients = [setup_admin_client(client_config)]
         self._skip_model_check = client_config.skip_model_check
         self._wait_for_ready_timeout = client_config.wait_for_ready_timeout
         self._eval_cycle = cycle(self._eval_clients)
@@ -183,8 +183,6 @@ def setup_clients(
     preserve_all_thinking: bool = False,
     preserve_thinking_between_tool_calls: bool = False,
 ) -> list[vf.ClientConfig]:
-    clients = []
-    client_idx = 0
     # Only forward preserve flags when the client actually uses a renderer —
     # MITO/TITO clients ignore them and the verifiers ClientConfig may reject
     # unknown extras on older versions.
@@ -197,65 +195,61 @@ def setup_clients(
     env_headers = {
         k: v for k, v in ((k, os.getenv(v)) for k, v in client_config.headers_from_env.items()) if v is not None
     }
-    for base_url in client_config.base_url:
-        for dp_rank in range(client_config.dp_rank_count):
-            headers = {**client_config.headers, **env_headers}
-            if client_config.dp_rank_count > 1:
-                headers["X-data-parallel-rank"] = str(dp_rank)
-            clients.append(
-                vf.ClientConfig(
-                    client_idx=client_idx,
-                    client_type=client_type,
-                    renderer=renderer_name,
-                    renderer_model_name=renderer_model_name,
-                    renderer_pool_size=renderer_pool_size,
-                    tool_parser=tool_parser,
-                    reasoning_parser=reasoning_parser,
-                    api_base_url=base_url,
-                    api_key_var=client_config.api_key_var,
-                    timeout=client_config.timeout,
-                    connect_timeout=client_config.connect_timeout,
-                    max_connections=8192,
-                    max_keepalive_connections=8192,
-                    max_retries=10,
-                    extra_headers=headers,
-                    extra_headers_from_state=client_config.extra_headers_from_state,
-                    **renderer_extra,
-                )
+    clients = []
+    for dp_rank in range(client_config.dp_rank_count):
+        headers = {**client_config.headers, **env_headers}
+        if client_config.dp_rank_count > 1:
+            headers["X-data-parallel-rank"] = str(dp_rank)
+        clients.append(
+            vf.ClientConfig(
+                client_idx=dp_rank,
+                client_type=client_type,
+                renderer=renderer_name,
+                renderer_model_name=renderer_model_name,
+                renderer_pool_size=renderer_pool_size,
+                tool_parser=tool_parser,
+                reasoning_parser=reasoning_parser,
+                api_base_url=client_config.base_url,
+                api_key_var=client_config.api_key_var,
+                timeout=client_config.timeout,
+                connect_timeout=client_config.connect_timeout,
+                max_connections=8192,
+                max_keepalive_connections=8192,
+                max_retries=10,
+                extra_headers=headers,
+                extra_headers_from_state=client_config.extra_headers_from_state,
+                **renderer_extra,
             )
-            client_idx += 1
+        )
     return clients
 
 
-def setup_admin_clients(client_config: ClientConfig) -> list[AsyncClient]:
-    """Create dedicated admin clients for weight update operations.
+def setup_admin_client(client_config: ClientConfig) -> AsyncClient:
+    """Create a dedicated admin client for weight update operations.
 
     Uses a separate connection pool to avoid queueing behind streaming requests.
-    When admin_base_url is set, uses those URLs instead of base_url, allowing
-    weight updates to bypass routers in disaggregated P/D deployments.
+    When admin_base_url is set, uses it instead of base_url, allowing weight
+    updates to bypass routers.
     """
-    urls = client_config.admin_base_url if client_config.admin_base_url else client_config.base_url
+    base_url = client_config.admin_base_url if client_config.admin_base_url else client_config.base_url
 
-    def _setup_admin_client(base_url: str) -> httpx.AsyncClient:
-        env_headers = {
-            k: v for k, v in ((k, os.getenv(v)) for k, v in client_config.headers_from_env.items()) if v is not None
-        }
-        headers = {**client_config.headers, **env_headers}
-        api_key = os.getenv(client_config.api_key_var, "EMPTY")
-        if api_key and api_key != "EMPTY":
-            headers["Authorization"] = f"Bearer {api_key}"
+    env_headers = {
+        k: v for k, v in ((k, os.getenv(v)) for k, v in client_config.headers_from_env.items()) if v is not None
+    }
+    headers = {**client_config.headers, **env_headers}
+    api_key = os.getenv(client_config.api_key_var, "EMPTY")
+    if api_key and api_key != "EMPTY":
+        headers["Authorization"] = f"Bearer {api_key}"
 
-        # Strip /v1 suffix since admin endpoints are at root level
-        base_url = base_url.rstrip("/").removesuffix("/v1")
+    # Strip /v1 suffix since admin endpoints are at root level
+    base_url = base_url.rstrip("/").removesuffix("/v1")
 
-        return AsyncClient(
-            base_url=base_url,
-            headers=headers,
-            limits=httpx.Limits(max_connections=4, max_keepalive_connections=1),
-            timeout=httpx.Timeout(None),
-        )
-
-    return [_setup_admin_client(base_url) for base_url in urls]
+    return AsyncClient(
+        base_url=base_url,
+        headers=headers,
+        limits=httpx.Limits(max_connections=4, max_keepalive_connections=1),
+        timeout=httpx.Timeout(None),
+    )
 
 
 async def maybe_check_has_model(

--- a/src/prime_rl/utils/elastic.py
+++ b/src/prime_rl/utils/elastic.py
@@ -20,7 +20,7 @@ import verifiers as vf
 from httpx import AsyncClient
 
 from prime_rl.configs.shared import ClientConfig
-from prime_rl.utils.client import load_lora_adapter, setup_admin_clients, setup_clients
+from prime_rl.utils.client import load_lora_adapter, setup_admin_client, setup_clients
 from prime_rl.utils.logger import get_logger
 
 # --- Shared discovery functions ---
@@ -204,32 +204,38 @@ class ElasticInferencePool:
             self._client_urls = urls
 
             self._eval_index = 0
-            url_config = ClientConfig(
-                timeout=self.client_config.timeout,
-                connect_timeout=self.client_config.connect_timeout,
-                base_url=urls,
-                api_key_var=self.client_config.api_key_var,
-                headers=self.client_config.headers,
-                headers_from_env=self.client_config.headers_from_env,
-                dp_rank_count=self.client_config.dp_rank_count,
-                extra_headers_from_state=self.client_config.extra_headers_from_state,
-            )
-            self._train_clients = (
-                setup_clients(
-                    url_config,
-                    client_type=self.train_client_type,
-                    renderer_name=self.renderer_name,
-                    renderer_model_name=self.renderer_model_name,
-                    tool_parser=self.tool_parser,
-                    reasoning_parser=self.reasoning_parser,
-                    renderer_pool_size=self.renderer_pool_size,
-                    preserve_all_thinking=self.preserve_all_thinking,
-                    preserve_thinking_between_tool_calls=self.preserve_thinking_between_tool_calls,
+            self._train_clients = []
+            self._eval_clients = []
+            for url in urls:
+                url_config = ClientConfig(
+                    timeout=self.client_config.timeout,
+                    connect_timeout=self.client_config.connect_timeout,
+                    base_url=url,
+                    api_key_var=self.client_config.api_key_var,
+                    headers=self.client_config.headers,
+                    headers_from_env=self.client_config.headers_from_env,
+                    dp_rank_count=self.client_config.dp_rank_count,
+                    extra_headers_from_state=self.client_config.extra_headers_from_state,
                 )
-                if urls
-                else []
-            )
-            self._eval_clients = setup_clients(url_config, client_type=self.eval_client_type) if urls else []
+                self._train_clients.extend(
+                    setup_clients(
+                        url_config,
+                        client_type=self.train_client_type,
+                        renderer_name=self.renderer_name,
+                        renderer_model_name=self.renderer_model_name,
+                        tool_parser=self.tool_parser,
+                        reasoning_parser=self.reasoning_parser,
+                        renderer_pool_size=self.renderer_pool_size,
+                        preserve_all_thinking=self.preserve_all_thinking,
+                        preserve_thinking_between_tool_calls=self.preserve_thinking_between_tool_calls,
+                    )
+                )
+                self._eval_clients.extend(setup_clients(url_config, client_type=self.eval_client_type))
+            # Reassign client_idx so it is unique across all URLs.
+            for idx, client in enumerate(self._train_clients):
+                client.client_idx = idx
+            for idx, client in enumerate(self._eval_clients):
+                client.client_idx = idx
 
     @property
     def train_clients(self) -> list[vf.ClientConfig]:
@@ -265,12 +271,12 @@ class ElasticInferencePool:
         url = self._build_url(ip)
         config = ClientConfig(
             timeout=self.client_config.timeout,
-            base_url=[f"{url}/v1"],
+            base_url=f"{url}/v1",
             api_key_var=self.client_config.api_key_var,
             headers=self.client_config.headers,
             headers_from_env=self.client_config.headers_from_env,
         )
-        return setup_admin_clients(config)[0]
+        return setup_admin_client(config)
 
     async def _get_loaded_adapter(self, ip: str) -> AdapterState | None:
         if ip not in self._admin_clients:

--- a/tests/unit/orchestrator/test_orchestrator_setup.py
+++ b/tests/unit/orchestrator/test_orchestrator_setup.py
@@ -12,7 +12,7 @@ def test_setup_student_inference_pool_uses_renderer_when_enabled():
             training_mode="rl",
             use_renderer=True,
             student=SimpleNamespace(
-                client=SimpleNamespace(base_url=["http://localhost:8000/v1"]),
+                client=SimpleNamespace(base_url="http://localhost:8000/v1"),
                 model=SimpleNamespace(name="student-model"),
             ),
             renderer=SimpleNamespace(
@@ -76,7 +76,7 @@ def test_setup_student_inference_pool_defaults_to_mito():
             training_mode="rl",
             use_renderer=False,
             student=SimpleNamespace(
-                client=SimpleNamespace(base_url=["http://localhost:8000/v1"]),
+                client=SimpleNamespace(base_url="http://localhost:8000/v1"),
                 model=SimpleNamespace(name="student-model"),
             ),
         )

--- a/tests/unit/utils/test_client.py
+++ b/tests/unit/utils/test_client.py
@@ -51,7 +51,7 @@ def test_load_lora_adapter_succeeds_on_first_attempt():
 
 def test_setup_clients_assigns_renderer_and_dp_rank_headers():
     client_config = ClientConfig(
-        base_url=["http://worker-a:8000/v1"],
+        base_url="http://worker-a:8000/v1",
         api_key_var="PRIME_API_KEY",
         headers={"X-Test": "test"},
         dp_rank_count=2,
@@ -75,7 +75,7 @@ def test_setup_clients_assigns_renderer_and_dp_rank_headers():
 
 def test_setup_clients_assigns_renderer_model_name():
     client_config = ClientConfig(
-        base_url=["http://worker-a:8000/v1"],
+        base_url="http://worker-a:8000/v1",
         api_key_var="PRIME_API_KEY",
     )
 
@@ -91,7 +91,7 @@ def test_setup_clients_assigns_renderer_model_name():
 
 def test_setup_clients_preserves_chat_client_defaults():
     client_config = ClientConfig(
-        base_url=["http://worker-a:8000/v1"],
+        base_url="http://worker-a:8000/v1",
         api_key_var="PRIME_API_KEY",
     )
 


### PR DESCRIPTION
## Summary

- Revert `ClientConfig.base_url` from `list[str]` to `str` and `admin_base_url` from `list[str] | None` to `str | None`. Closes #2557.
- Drop the URL loop in `setup_clients` / rename `setup_admin_clients` → `setup_admin_client` (now returns a single `AsyncClient`). `dp_rank_count` still expands the URL into per-rank logical clients.
- Refactor `ElasticInferencePool._rebuild_clients` to iterate over discovered pod URLs and call `setup_clients` per-URL (instead of round-tripping a list through `ClientConfig`).
- Update `orchestrator.py`, `entrypoints/rl.py`, and rl-config auto-setup to consume a single `base_url` string.
- Update all five `configs/debug/training_modes/*.toml` from `base_url = ["…"]` to `base_url = "…"`.
- Update affected tests (`tests/unit/utils/test_client.py`, `tests/unit/orchestrator/test_orchestrator_setup.py`).

## Multi-client deployment audit

Before reverting I checked what in-repo deployments depend on multiple base URLs.

**Static path:** all five training-mode TOMLs (`configs/debug/training_modes/{opd,opd_lora,sft,sft_lora,sft_external}.toml`) ship a single-element list. No tracked config uses multi-URL fan-out.

**Elastic path** (`configs/elastic/rl.toml`): does **not** set `router_url`, so the orchestrator currently builds one inference client per discovered pod via `_rebuild_clients`. That's multi-client at runtime, but it's internal to `ElasticInferencePool` - the user-facing `client.base_url` field is irrelevant in elastic mode (it's ignored when `elastic` is set). After this PR, elastic still produces multiple per-pod clients internally; the refactor just iterates and calls `setup_clients` per URL.

**`dp_rank_count`** still produces multiple clients per URL for DP-rank pinning - kept, since it's per-engine routing on a single server, not multi-server fan-out.

**`router_url`** is unchanged (it's already a single URL).

Net: no deployment loses functionality. The list form in `base_url` / `admin_base_url` was unused config plumbing.

## Verification

- `pytest tests/unit/utils/test_client.py tests/unit/utils/test_elastic.py tests/unit/orchestrator/test_orchestrator_setup.py tests/unit/orchestrator/test_scheduler.py tests/unit/orchestrator/test_teacher_logprobs.py` → 40 passed.
- Pydantic schema rejects list-form `base_url=[…]` at config load (verified via smoke test).