### PR TITLE
fix(rl): normalize loss by global token count across dp_cp

### DIFF
--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -338,9 +338,15 @@ def train(config: TrainerConfig):
         forward_backward_start_time = time.perf_counter()
         seq_len = micro_batches[0]["input_ids"].shape[1]
 
-        # Normalize by the local number of unmasked tokens in the batch (per-batch length normalization)
-        loss_scale = sum(micro_batch["loss_mask"].sum().item() for micro_batch in micro_batches)
-        loss_scale = max(loss_scale, 1)
+        # Normalize by the global (dp_cp) number of unmasked tokens in the batch, so every rank
+        # divides by the same denominator. With a per-rank denominator, ranks with fewer loss
+        # tokens implicitly upweight their per-token gradient contribution after FSDP averaging.
+        # FSDP's per-rank divide is undone after the microbatch loop via fsdp_gradient_divide_factor.
+        local_loss_scale = sum(micro_batch["loss_mask"].sum().item() for micro_batch in micro_batches)
+        global_loss_scale = torch.tensor(local_loss_scale, dtype=torch.int64, device="cuda")
+        dp_cp_group = parallel_dims.get_mesh("dp_cp").get_group()
+        dist.all_reduce(global_loss_scale, op=dist.ReduceOp.SUM, group=dp_cp_group)
+        loss_scale = max(global_loss_scale.item(), 1)
 
         logger.debug(f"Starting forward and backward pass ({batch_size=})")
         tensors = Tensors()  # Used to accumulate tensor statistics across micro-batches and ranks for logging
@@ -513,6 +519,12 @@ def train(config: TrainerConfig):
             if "max_vio" in tensors:
                 micro_step_message += f" | Max Vio: {tensors['max_vio'][-1].mean().item():.4f}"
             logger.debug(micro_step_message)
+
+        # compute_loss already divided by the global token count. Undo FSDP's per-rank averaging
+        # across dp_cp so the final gradient is the true per-token mean over the global batch.
+        for param in model.parameters():
+            if param.grad is not None:
+                param.grad.mul_(parallel_dims.fsdp_gradient_divide_factor)
 
         # Optionally, clip the gradients
         grad_norm: torch.Tensor | None = None


### PR DESCRIPTION
## Summary

Fix gradient bias when DP ranks process different numbers of loss-contributing tokens per step (closes #2358; alternative to #2359).

## The bug

Each DP rank computes a local `loss_scale` (its own unmasked-token count) and divides its summed token loss by it before `.backward()`. FSDP then averages those per-rank gradients. Because different ranks see different sequence lengths, `loss_scale` differs across ranks, so the mean is **not** a true per-token mean over the global batch — ranks with fewer loss tokens implicitly upweight their per-token gradient contribution. See #2358 for the empirical `max_ratio` skew (~1.02–1.04 per step).

## The fix

Mirror the existing SFT trainer pattern at `src/prime_rl/trainer/sft/train.py:416-427`:

1. **Global denominator.** Before the microbatch loop, all-reduce the local token count across the `dp_cp` group to get the global token count. Pass that as `loss_scale` so every rank divides by the same number.
2. **Undo FSDP's mean.** After the microbatch loop, multiply every parameter's gradient by `parallel_dims.fsdp_gradient_divide_factor` (= `dp_replicate * dp_shard * cp`). This cancels the per-rank divide FSDP applied during gradient reduction, converting it to a sum across ranks.

Net effect:

```
final_grad = Σ_r Σ_m g_{r,m} / global_token_count
```

i.e. every token in the global batch contributes equally, regardless of which rank held it. The math is invariant to how the batch was sharded across GPUs, and consistent with how the SFT trainer in this repo already handles the same problem.

## Why mirror SFT rather than introduce a new pattern

The SFT trainer already uses exactly this fix. Keeping the RL trainer's approach identical:
- Avoids divergence between trainers for the same underlying issue.
- Composes correctly with CP without special-casing: `fsdp_gradient_divide_factor` already includes the CP factor, and CP ranks contribute consistently to both the numerator (gradient sum) and the denominator (token count sum), so they cancel.
- Keeps the diff minimal (15 lines added, 3 removed in `src/prime_rl/trainer/rl/train.py`).

## Comparison with #2359

#2359 takes a similar approach but:
- Gathers `loss_scale` over the `dp` mesh only (not `dp_cp`) and multiplies by `dp_world_size`. That works under the assumption that CP ranks have identical samples and identical `loss_scale`, but it diverges from the SFT trainer's already-merged pattern.
- Adds diagnostic metrics (`loss_scale/max_ratio`, `/cov`, etc.). Those are useful and could be added separately; this PR keeps the diff focused on the correctness fix to make review easier.

## Test plan

- [ ] Re-run the Hendrycks Sanity setup from #2358 (`max_steps=50`, `num_train_gpus=2`, `seq_len=8192`) and confirm loss curves match the SFT-style normalization.
- [ ] Run `tests/integration/test_rl.py`.
- [ ] Verify behavior with `cp > 1` (e.g. `cp=2, dp=2`) gives the same per-token mean as `cp=1, dp=4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches distributed gradient scaling in the RL training loop; incorrect reduction/scaling could subtly change optimization dynamics across DP/CP configurations.
> 
> **Overview**
> Fixes a gradient-weighting bias in the RL trainer when different `dp_cp` ranks have different counts of unmasked (loss-contributing) tokens.
> 
> The trainer now all-reduces the per-rank token count over the `dp_cp` group and uses this *global* denominator for `compute_loss`, then multiplies parameter grads by `parallel_dims.fsdp_gradient_divide_factor` after the microbatch loop to undo FSDP’s per-rank averaging so the final gradient is a true per-token mean over the global batch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24b0a650c2098753a06eb18874d1f5004c9075c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->