### PR TITLE
chore(deps): bump pydantic-config (drop tyro)

### DIFF
--- a/packages/prime-rl-configs/pyproject.toml
+++ b/packages/prime-rl-configs/pyproject.toml
@@ -6,7 +6,10 @@ readme = "README.md"
 requires-python = "~=3.12.0"
 dependencies = [
     "pydantic>=1.10.13",
-    "prime-pydantic-config",
+    # Direct git URL so the slim wheel resolves outside a uv workspace
+    # (plain `pip install prime-rl-configs`). In-workspace builds use the
+    # editable submodule via [tool.uv.sources] in the root pyproject.toml.
+    "prime-pydantic-config @ git+https://github.com/PrimeIntellect-ai/pydantic-config.git@df5b38e",
     # OrchestratorConfig validates renderer.name='auto' against
     # renderers.base.MODEL_RENDERER_MAP. Renderers itself is light; its only
     # weighty transitive (transformers) is lazy-imported via the validator,

--- a/packages/prime-rl-configs/pyproject.toml
+++ b/packages/prime-rl-configs/pyproject.toml
@@ -6,10 +6,7 @@ readme = "README.md"
 requires-python = "~=3.12.0"
 dependencies = [
     "pydantic>=1.10.13",
-    # Direct git URL so the slim wheel resolves outside a uv workspace
-    # (plain `pip install prime-rl-configs`). In-workspace builds use the
-    # editable submodule via [tool.uv.sources] in the root pyproject.toml.
-    "prime-pydantic-config @ git+https://github.com/PrimeIntellect-ai/pydantic-config.git@7481096",
+    "prime-pydantic-config>=0.3.0.dev80",
     # OrchestratorConfig validates renderer.name='auto' against
     # renderers.base.MODEL_RENDERER_MAP. Renderers itself is light; its only
     # weighty transitive (transformers) is lazy-imported via the validator,

--- a/packages/prime-rl-configs/pyproject.toml
+++ b/packages/prime-rl-configs/pyproject.toml
@@ -6,10 +6,7 @@ readme = "README.md"
 requires-python = "~=3.12.0"
 dependencies = [
     "pydantic>=1.10.13",
-    # The PyPI package named `pydantic-config` is a different project that
-    # doesn't expose `BaseConfig` / `cli`. Pin to samsja's fork so plain
-    # `pip install prime-rl-configs` (no uv workspace context) resolves it.
-    "pydantic-config @ git+https://github.com/samsja/pydantic_config.git",
+    "prime-pydantic-config",
     # OrchestratorConfig validates renderer.name='auto' against
     # renderers.base.MODEL_RENDERER_MAP. Renderers itself is light; its only
     # weighty transitive (transformers) is lazy-imported via the validator,

--- a/packages/prime-rl-configs/pyproject.toml
+++ b/packages/prime-rl-configs/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     # Direct git URL so the slim wheel resolves outside a uv workspace
     # (plain `pip install prime-rl-configs`). In-workspace builds use the
     # editable submodule via [tool.uv.sources] in the root pyproject.toml.
-    "prime-pydantic-config @ git+https://github.com/PrimeIntellect-ai/pydantic-config.git@df5b38e",
+    "prime-pydantic-config @ git+https://github.com/PrimeIntellect-ai/pydantic-config.git@7481096",
     # OrchestratorConfig validates renderer.name='auto' against
     # renderers.base.MODEL_RENDERER_MAP. Renderers itself is light; its only
     # weighty transitive (transformers) is lazy-imported via the validator,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,7 +186,7 @@ prime-evals = false
 # Trusted git/URL sources pinned by rev or wheel URL (defensive: belt-and-suspenders)
 vllm-router = false
 dion = false
-pydantic-config = false
+prime-pydantic-config = false
 deep-ep = false
 deep-gemm = false
 nixl-cu12 = false
@@ -229,7 +229,7 @@ torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eeb" }
 transformers = { git = "https://github.com/huggingface/transformers.git", rev = "c1c3424" }
 flash-attn-4 = { git = "https://github.com/Dao-AILab/flash-attention.git", subdirectory = "flash_attn/cute", rev = "96bd151" }
-pydantic-config = { git = "https://github.com/samsja/pydantic_config.git", branch = "main" }
+prime-pydantic-config = { git = "https://github.com/PrimeIntellect-ai/pydantic-config.git", rev = "1659db2" }
 vllm-router = { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.22/vllm_router-0.1.22-cp38-abi3-manylinux_2_28_x86_64.whl" }
 vllm = [
     { url = "https://github.com/vllm-project/vllm/releases/download/v0.21.0/vllm-0.21.0+cu129-cp38-abi3-manylinux_2_34_x86_64.whl", marker = "platform_machine == 'x86_64'" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ dev = [
 [tool.uv.workspace]
 members = [
     "packages/prime-rl-configs",
+    "deps/pydantic-config",
     "deps/verifiers",
     "deps/renderers",
     "deps/verifiers/environments/alphabet_sort",
@@ -186,7 +187,6 @@ prime-evals = false
 # Trusted git/URL sources pinned by rev or wheel URL (defensive: belt-and-suspenders)
 vllm-router = false
 dion = false
-prime-pydantic-config = false
 deep-ep = false
 deep-gemm = false
 nixl-cu12 = false
@@ -229,7 +229,7 @@ torchtitan = { git = "https://github.com/pytorch/torchtitan", rev = "a1fdd7e" }
 dion = { git = "https://github.com/samsja/dion.git", rev = "d891eeb" }
 transformers = { git = "https://github.com/huggingface/transformers.git", rev = "c1c3424" }
 flash-attn-4 = { git = "https://github.com/Dao-AILab/flash-attention.git", subdirectory = "flash_attn/cute", rev = "96bd151" }
-prime-pydantic-config = { git = "https://github.com/PrimeIntellect-ai/pydantic-config.git", rev = "1659db2" }
+prime-pydantic-config = { workspace = true }
 vllm-router = { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.22/vllm_router-0.1.22-cp38-abi3-manylinux_2_28_x86_64.whl" }
 vllm = [
     { url = "https://github.com/vllm-project/vllm/releases/download/v0.21.0/vllm-0.21.0+cu129-cp38-abi3-manylinux_2_34_x86_64.whl", marker = "platform_machine == 'x86_64'" },

--- a/tests/integration/test_reverse_text_multi_run.py
+++ b/tests/integration/test_reverse_text_multi_run.py
@@ -205,14 +205,14 @@ def start_orchestrator(
         run_dir.as_posix(),
         "--max-steps",
         str(max_steps),
-        "--student.model.lora.name",
+        "--model.lora.name",
         name,
         "--wandb.project",
         wandb_project,
         "--wandb.name",
         f"{wandb_name}-{proc_name}",
     ]
-    cmd.append("--student.client.base-url")
+    cmd.append("--model.client.base-url")
     cmd.extend(INFERENCE_BASE_URLS)
 
     with open(orch_log_dir / "orchestrator.log", "w") as f:

--- a/uv.lock
+++ b/uv.lock
@@ -23,7 +23,6 @@ vllm = false
 vllm-router = false
 dion = false
 tokenspeed-mla = false
-prime-pydantic-config = false
 nixl-cu12 = false
 deep-ep = false
 flash-attn-3 = false
@@ -57,6 +56,7 @@ members = [
     "opencode-math",
     "opencode-science",
     "opencode-swe",
+    "prime-pydantic-config",
     "prime-rl",
     "prime-rl-configs",
     "renderers",
@@ -3841,9 +3841,47 @@ wheels = [
 [[package]]
 name = "prime-pydantic-config"
 version = "0.3.0"
-source = { git = "https://github.com/PrimeIntellect-ai/pydantic-config.git?rev=1659db2#1659db23d61294f9528d09a57b4345002a00da7f" }
+source = { editable = "deps/pydantic-config" }
 dependencies = [
     { name = "pydantic", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
+]
+
+[package.optional-dependencies]
+all = [
+    { name = "pyyaml", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
+    { name = "tomli", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
+]
+toml = [
+    { name = "tomli", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
+]
+yaml = [
+    { name = "pyyaml", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pre-commit", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
+    { name = "pytest", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
+    { name = "rich", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
+    { name = "ruff", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "pyyaml", marker = "extra == 'all'" },
+    { name = "pyyaml", marker = "extra == 'yaml'" },
+    { name = "tomli", marker = "extra == 'all'" },
+    { name = "tomli", marker = "extra == 'toml'" },
+]
+provides-extras = ["yaml", "toml", "all"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pre-commit", specifier = ">=3.0.0" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "rich", specifier = ">=15.0.0" },
+    { name = "ruff", specifier = ">=0.12.1" },
 ]
 
 [[package]]
@@ -4065,7 +4103,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "prime-pydantic-config", git = "https://github.com/PrimeIntellect-ai/pydantic-config.git?rev=1659db2" },
+    { name = "prime-pydantic-config", editable = "deps/pydantic-config" },
     { name = "pydantic", specifier = ">=1.10.13" },
     { name = "renderers", editable = "deps/renderers" },
     { name = "tomli", specifier = ">=2.2.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ conflicts = [[
 ]]
 
 [options]
-exclude-newer = "2026-05-11T22:34:17.526963383Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -23,12 +23,12 @@ vllm = false
 vllm-router = false
 dion = false
 tokenspeed-mla = false
+prime-pydantic-config = false
 nixl-cu12 = false
 deep-ep = false
 flash-attn-3 = false
 prime-sandboxes = false
 prime-tunnel = false
-pydantic-config = false
 deep-gemm = false
 prime-evals = false
 prime = false
@@ -3839,6 +3839,14 @@ wheels = [
 ]
 
 [[package]]
+name = "prime-pydantic-config"
+version = "0.3.0"
+source = { git = "https://github.com/PrimeIntellect-ai/pydantic-config.git?rev=1659db2#1659db23d61294f9528d09a57b4345002a00da7f" }
+dependencies = [
+    { name = "pydantic", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
+]
+
+[[package]]
 name = "prime-rl"
 version = "0.4.0"
 source = { editable = "." }
@@ -4048,8 +4056,8 @@ name = "prime-rl-configs"
 version = "0.4.0"
 source = { editable = "packages/prime-rl-configs" }
 dependencies = [
+    { name = "prime-pydantic-config", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
     { name = "pydantic", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
-    { name = "pydantic-config", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
     { name = "renderers", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
     { name = "tomli", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
     { name = "tomli-w", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
@@ -4057,8 +4065,8 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "prime-pydantic-config", git = "https://github.com/PrimeIntellect-ai/pydantic-config.git?rev=1659db2" },
     { name = "pydantic", specifier = ">=1.10.13" },
-    { name = "pydantic-config", git = "https://github.com/samsja/pydantic_config.git?branch=main" },
     { name = "renderers", editable = "deps/renderers" },
     { name = "tomli", specifier = ">=2.2.1" },
     { name = "tomli-w", specifier = ">=1.2.0" },
@@ -4313,15 +4321,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/94/ea/e63d587294c20d3b83e9c312b5d577c9ec28962ee8490839ca9996672849/pydantic_argparse-0.10.0.tar.gz", hash = "sha256:d57eb0a84c8f0af6605376157d3f445cfd786700f2e596ba9d48d15d557185eb", size = 15928, upload-time = "2025-02-09T08:18:30.425Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/14/9ee71e3a183f76ff93e46b36157d6ddbf29ec2547b7d2c57931cd5d3aecc/pydantic_argparse-0.10.0-py3-none-any.whl", hash = "sha256:e317f001208d77a5600ece6f7ac78d768d8221a7d64a958980705e9630c2e299", size = 25265, upload-time = "2025-02-09T08:18:27.671Z" },
-]
-
-[[package]]
-name = "pydantic-config"
-version = "0.3.0"
-source = { git = "https://github.com/samsja/pydantic_config.git?branch=main#73c1d84f7c359fa5fa3b7cfb946272352866efb7" }
-dependencies = [
-    { name = "pydantic", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
-    { name = "tyro", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bumps the `deps/pydantic-config` submodule pointer to `ab3a8e7`, the squash-merge of `refactor/drop-tyro` into `PrimeIntellect-ai/pydantic-config`'s `main`.
- Wires `deps/pydantic-config` as an **editable workspace member**: adds it to `[tool.uv.workspace]` members and switches the root `[tool.uv.sources]` entry to `prime-pydantic-config = { workspace = true }`. Local edits in the submodule propagate to `.venv` without re-syncing a wheel — same pattern as `deps/verifiers` and `deps/renderers`. Drops the now-redundant `[tool.uv.exclude-newer-package]` entry (only relevant for non-workspace pins).
- Renames the source key from `pydantic-config` to `prime-pydantic-config` (upstream renamed the published package).
- In `packages/prime-rl-configs`, switches the slim-wheel dep from the old `samsja/pydantic_config.git` URL to a PyPI pin (`prime-pydantic-config>=0.3.0.dev80`, auto-published from the merge), so `pip install prime-rl-configs` outside a workspace resolves it from the registry.
- Brings in legacy key remapping via before-validators, so e.g. `uv run orchestrator --model.name <name>` now routes to `student.model.name`.
- `tests/integration/test_reverse_text_multi_run.py`: switches the per-orchestrator CLI overrides from `--student.X` to `--model.X` so they share the legacy `[model]` alias used in the test's orchestrator TOML. Works around a known alias-collision in `_normalize_alias_keys` where mixed `model`/`student` keys overwrite instead of merging — to be fixed in a follow-up on the pydantic-config side.

Note: `prime-rl` itself doesn't import `pydantic_config` directly — the only consumer is `prime-rl-configs`, which re-exports `BaseConfig`/`cli` via `prime_rl.utils.config`.

## Verification

Before (origin/main): `uv run orchestrator --model.name foo` errors with `Unrecognized options: --model.name, foo` (tyro doesn't know the key; suggests `--student.model.name`).

After (this branch): the same invocation is rewritten to `student.model.name=foo` and proceeds to pydantic validation (`Qwen/Qwen3-1.7B` validates; `foo` trips the renderer-map check, which is the expected downstream behaviour).

Locally walked the dry-run surface: rl/sft/inference/orchestrator `--help`, dry-runs on `examples/reverse_text/{rl,sft}.toml`, `examples/Intellect-3.1/rl.toml`, all `configs/debug/training_modes/*.toml`, plus the legacy remap, `--no-wandb` negation, `--no-bench`/`--bench`, deep nested overrides (`--trainer.optim.lr`), multi-TOML compose, section-level compose (`--model @ ...`), and the slim-install path (build wheel → fresh venv → resolve from PyPI → parse Intellect-3.1 config). All clean.

Multi-run CI fix repro (matches the `reverse_text_multi_run` argv):
```
student.model.name      = PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT
student.model.lora.name = alpha
student.client.base_url = ['http://localhost:8000/v1', 'http://localhost:8001/v1']
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes dependency sourcing/locking (moves from a git URL to a workspace/PyPI package) and updates CLI override paths used in integration tests, which could break installs or command-line config parsing if mismatched.
> 
> **Overview**
> Migrates config dependency wiring from the git-pinned `pydantic-config` fork to the renamed `prime-pydantic-config`, using `deps/pydantic-config` as a `uv` workspace member and updating `uv.lock`/workspace sources accordingly.
> 
> Updates `prime-rl-configs` to depend on `prime-pydantic-config` from PyPI (instead of a direct git URL) and adjusts the multi-run reverse-text integration test to pass `--model.*` overrides (e.g. `--model.lora.name`, `--model.client.base-url`) rather than the previous `--student.*` paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6835074e57893505d4e0dc05f3f0eef4c98d53b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

