### PR TITLE
fix(config): propagate shared RL fields via before-validator

### DIFF
--- a/configs/hendrycks_math/sanity.toml
+++ b/configs/hendrycks_math/sanity.toml
@@ -25,9 +25,6 @@ id = "aime2024"
 name = "aime2024"
 rollouts_per_example = 16
 
-[trainer.model]
-name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
-
 [trainer.model.ac]
 
 [trainer.model.compile]

--- a/examples/glm5_pd_disag/rl.toml
+++ b/examples/glm5_pd_disag/rl.toml
@@ -6,9 +6,6 @@ level = "debug"
 [wandb]
 project = "glm5-pd-disag"
 
-[model]
-name = "zai-org/GLM-5"
-
 [weight_broadcast]
 type = "nccl"
 port = 29502
@@ -38,6 +35,7 @@ interval = 100
 dist_timeout_seconds = 7200
 
 [trainer.model]
+name = "zai-org/GLM-5"
 impl = "custom"
 attn = "flash_attention_2" # dsa is skipping flash attn anyway
 fused_lm_head_token_chunk_size = 2048
@@ -67,6 +65,9 @@ batch_size = 4096
 rollouts_per_example = 16
 oversampling_factor = 3
 max_off_policy_steps = 16
+
+[orchestrator.student.model]
+name = "zai-org/GLM-5-FP8"
 
 [orchestrator.eval]
 interval = 20

--- a/examples/hendrycks_sanity/rl.toml
+++ b/examples/hendrycks_sanity/rl.toml
@@ -1,5 +1,4 @@
 max_steps = 5000
-seq_len = 8192
 
 [wandb]
 project = "hendrycks-sanity"
@@ -15,6 +14,7 @@ name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
 [orchestrator]
 batch_size = 512
 rollouts_per_example = 8
+seq_len = 8192
 
 [[orchestrator.train.env]]
 id = "math-env" # included in lock file
@@ -30,7 +30,6 @@ name = "aime2024"
 rollouts_per_example = 32
 
 [trainer.model]
-name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
 seq_len = 16384
 
 [inference.model]

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -746,6 +746,22 @@ class OrchestratorConfig(BaseConfig):
         return self
 
     @model_validator(mode="after")
+    def auto_setup_session_headers(self):
+        """Ensure X-Session-ID header is always set for sticky DP-aware routing at the inference router."""
+        self.student.client.extra_headers_from_state.setdefault("X-Session-ID", "example_id")
+        return self
+
+    @model_validator(mode="after")
+    def auto_setup_prime_monitor_run_name(self):
+        """Default ``prime_monitor.run_name`` to the W&B run name when monitoring
+        is enabled and the user hasn't named the prime-monitor run explicitly."""
+        if self.prime_monitor is None or self.prime_monitor.run_name is not None:
+            return self
+        if self.wandb is not None and self.wandb.name:
+            self.prime_monitor.run_name = self.wandb.name
+        return self
+
+    @model_validator(mode="after")
     def validate_unique_filter_types(self):
         types = [f.type for f in self.filters]
         if len(types) != len(set(types)):

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -1,14 +1,11 @@
 import warnings
 from pathlib import Path
-from typing import Annotated, Literal, TypeAlias
+from typing import Annotated, Any, Literal, TypeAlias
 
 from pydantic import Field, model_validator
 
 from prime_rl.configs.inference import InferenceConfig
 from prime_rl.configs.inference import WeightBroadcastConfig as InferenceWeightBroadcastConfig
-from prime_rl.configs.orchestrator import (
-    CheckpointConfig as OrchestratorCheckpointConfig,
-)
 from prime_rl.configs.orchestrator import (
     FileSystemWeightBroadcastConfig as OrchestratorFileSystemWeightBroadcastConfig,
 )
@@ -21,17 +18,12 @@ from prime_rl.configs.orchestrator import (
 from prime_rl.configs.shared import (
     SlurmConfig,
     VLMConfig,
-    WandbConfig,
-    WandbWithExtrasConfig,
 )
 from prime_rl.configs.trainer import (
     BenchConfig,
     FakeDataLoaderConfig,
     TokenizerConfig,
     TrainerConfig,
-)
-from prime_rl.configs.trainer import (
-    CheckpointConfig as TrainerCheckpointConfig,
 )
 from prime_rl.configs.trainer import (
     FileSystemWeightBroadcastConfig as TrainerFileSystemWeightBroadcastConfig,
@@ -41,11 +33,13 @@ from prime_rl.configs.trainer import (
 )
 from prime_rl.utils.config import BaseConfig, find_package_resource
 from prime_rl.utils.validation import (
+    propagate_shared_fields,
     validate_shared_ckpt_config,
     validate_shared_max_async_level,
     validate_shared_max_steps,
     validate_shared_model_name,
     validate_shared_output_dir,
+    validate_shared_seq_len,
     validate_shared_tokenizer,
     validate_shared_wandb_config,
     validate_shared_weight_broadcast,
@@ -231,9 +225,6 @@ class RLConfig(BaseConfig):
     max_steps: int | None = None
     """Shared maximum training steps. If None, falls back to the sub-config ``max_steps``."""
 
-    max_model_len: int | None = None
-    """Shared maximum model context length. If None, falls back to the sub-config ``max_model_len``."""
-
     seq_len: int | None = None
     """Shared sequence length. Propagates to ``trainer.model.seq_len`` and ``orchestrator.seq_len`` only when those values were not explicitly set; explicit per-component values always win."""
 
@@ -333,211 +324,30 @@ class RLConfig(BaseConfig):
 
         return self
 
-    ### Auto-setup and validate shared configs
+    ### Auto-setup shared configs (before sub-config construction)
 
-    @model_validator(mode="after")
-    def auto_setup_output_dir(self):
-        """Auto-setup shared output directory for trainer and orchestrator."""
-        self.trainer.output_dir = self.output_dir
-        self.orchestrator.output_dir = self.output_dir / "run_default"
-
-        validate_shared_output_dir(self.trainer, self.orchestrator)
-
-        return self
-
-    @model_validator(mode="after")
-    def auto_setup_logs(self):
-        """Auto-setup shared log config for trainer and orchestrator."""
-        if self.log is not None:
-            if self.log.level is not None:
-                self.trainer.log.level = self.log.level
-                self.orchestrator.log.level = self.log.level
-            self.trainer.log.json_logging = self.log.json_logging
-            self.orchestrator.log.json_logging = self.log.json_logging
-
-        return self
-
-    @model_validator(mode="after")
-    def auto_setup_ckpt(self):
-        """Auto-setup shared checkpoint config for trainer and orchestrator."""
-        if self.ckpt is not None:
-            # Create checkpoint configs if not specified
-            if self.trainer.ckpt is None:
-                self.trainer.ckpt = TrainerCheckpointConfig()
-            if self.orchestrator.ckpt is None:
-                self.orchestrator.ckpt = OrchestratorCheckpointConfig()
-
-            # If specified, override checkpoint output directory
-            if self.ckpt.output_dir is not None:
-                self.trainer.ckpt.output_dir = self.ckpt.output_dir
-
-            # If specified, use the same ckpt interval
-            if self.ckpt.interval is not None:
-                self.trainer.ckpt.interval = self.ckpt.interval
-                self.orchestrator.ckpt.interval = self.ckpt.interval
-
-            # If resuming training, ensure orchestrator resume from the same step
-            if self.ckpt.resume_step is not None:
-                self.trainer.ckpt.resume_step = self.ckpt.resume_step
-                self.orchestrator.ckpt.resume_step = self.ckpt.resume_step
-
-            # If specified, propagate keep policy
-            if self.ckpt.keep_last is not None:
-                self.trainer.ckpt.keep_last = self.ckpt.keep_last
-                self.orchestrator.ckpt.keep_last = self.ckpt.keep_last
-
-            if self.ckpt.keep_interval is not None:
-                self.trainer.ckpt.keep_interval = self.ckpt.keep_interval
-                self.orchestrator.ckpt.keep_interval = self.ckpt.keep_interval
-
-        validate_shared_ckpt_config(self.trainer, self.orchestrator)
-
-        return self
-
-    @model_validator(mode="after")
-    def auto_setup_wandb(self):
-        """Auto-setup shared W&B config for trainer and orchestrator."""
-        if self.wandb is not None:
-            if not self.trainer.wandb:
-                self.trainer.wandb = WandbConfig()
-            if not self.orchestrator.wandb:
-                self.orchestrator.wandb = WandbWithExtrasConfig()
-
-            if self.wandb.project:
-                self.trainer.wandb.project = self.wandb.project
-                self.orchestrator.wandb.project = self.wandb.project
-
-            if self.wandb.entity:
-                self.trainer.wandb.entity = self.wandb.entity
-                self.orchestrator.wandb.entity = self.wandb.entity
-
-            if self.wandb.shared:
-                if self.wandb.name:
-                    self.trainer.wandb.name = self.wandb.name
-                    self.orchestrator.wandb.name = self.wandb.name
-            else:
-                if self.wandb.name:
-                    self.trainer.wandb.name = f"{self.wandb.name}-trainer"
-                    self.orchestrator.wandb.name = f"{self.wandb.name}-orchestrator"
-
-            if self.wandb.group:
-                self.trainer.wandb.group = self.wandb.group
-                self.orchestrator.wandb.group = self.wandb.group
-
-            if self.wandb.tags:
-                self.trainer.wandb.tags = self.wandb.tags.copy()
-                self.orchestrator.wandb.tags = self.wandb.tags.copy()
-
-            if self.wandb.offline:
-                self.trainer.wandb.offline = self.wandb.offline
-                self.orchestrator.wandb.offline = self.wandb.offline
-
-        validate_shared_wandb_config(self.trainer, self.orchestrator)
-
-        if self.orchestrator.prime_monitor is not None and self.orchestrator.prime_monitor.run_name is None:
-            if self.wandb and self.wandb.name:
-                self.orchestrator.prime_monitor.run_name = self.wandb.name
-
-        return self
-
-    @model_validator(mode="after")
-    def auto_setup_model(self):
-        """Auto-setup shared model config for trainer, orchestrator, and inference."""
-        if self.model is not None:
-            self.trainer.model.name = self.model.name
-            if self.inference is not None:
-                inference_model_explicitly_set = "name" in self.inference.model.model_fields_set
-                if not inference_model_explicitly_set:
-                    self.inference.model.name = self.model.name
-                self.orchestrator.student.model.name = self.inference.model.name
-            else:
-                self.orchestrator.student.model.name = self.model.name
-
-            if self.model.vlm is not None:
-                self.trainer.model.vlm = self.model.vlm
-                self.orchestrator.student.model.vlm = self.model.vlm
-                if self.inference is not None:
-                    self.inference.model.vlm = self.model.vlm
-
-        validate_shared_model_name(self.trainer, self.orchestrator, self.inference)
-
-        return self
-
-    @model_validator(mode="after")
-    def auto_setup_tokenizer(self):
-        """Auto-setup shared tokenizer config for trainer, orchestrator, and inference."""
-        if self.tokenizer is not None:
-            # Shared tokenizer config: propagate to all components, then fill
-            # in name/trust_remote_code from model config where still unset.
-            self.trainer.tokenizer = self.tokenizer.model_copy()
-            self.orchestrator.tokenizer = self.tokenizer.model_copy()
-            if self.trainer.tokenizer.name is None:
-                self.trainer.tokenizer.name = self.trainer.model.name
-            if self.trainer.tokenizer.trust_remote_code is None:
-                self.trainer.tokenizer.trust_remote_code = self.trainer.model.trust_remote_code
-            if self.orchestrator.tokenizer.name is None:
-                self.orchestrator.tokenizer.name = self.orchestrator.student.model.name
-            if self.orchestrator.tokenizer.trust_remote_code is None:
-                self.orchestrator.tokenizer.trust_remote_code = self.orchestrator.student.model.trust_remote_code
-        else:
-            # No shared tokenizer: re-derive from (now-correct) model names,
-            # since auto_setup_tokenizer on sub-configs already ran with defaults.
-            self.trainer.tokenizer.name = self.trainer.model.name
-            self.trainer.tokenizer.trust_remote_code = self.trainer.model.trust_remote_code
-            self.orchestrator.tokenizer.name = self.orchestrator.student.model.name
-            self.orchestrator.tokenizer.trust_remote_code = self.orchestrator.student.model.trust_remote_code
-
-        # Propagate chat_template to inference (vLLM --chat-template)
-        if self.inference is not None:
-            chat_template = self.trainer.tokenizer.chat_template
-            if chat_template is not None and self.inference.model.chat_template is None:
-                self.inference.model.chat_template = chat_template
-
-        validate_shared_tokenizer(self.trainer, self.orchestrator, self.inference)
-
-        return self
-
-    @model_validator(mode="after")
-    def auto_setup_max_steps(self):
-        """Auto-setup shared max steps for trainer and orchestrator."""
-        if self.max_steps is not None:
-            self.trainer.max_steps = self.max_steps
-            self.orchestrator.max_steps = self.max_steps
-
-        validate_shared_max_steps(self.trainer, self.orchestrator)
-
-        return self
-
-    @model_validator(mode="after")
-    def auto_setup_async_level(self):
-        """Auto-setup shared async level for trainer and orchestrator."""
-        if self.max_async_level is not None:
-            self.trainer.max_async_level = self.max_async_level
-            self.orchestrator.max_async_level = self.max_async_level
-
-        validate_shared_max_async_level(self.trainer, self.orchestrator)
-
-        return self
-
-    @model_validator(mode="after")
-    def auto_setup_seq_len(self):
-        """Auto-setup shared seq_len for trainer and orchestrator.
-
-        Only propagates to components that weren't explicitly set in the config.
-        Uses model_fields_set to detect explicit assignment.
+    @model_validator(mode="before")
+    @classmethod
+    def auto_setup_shared_configs(cls, data: Any) -> Any:
+        """Propagate shared top-level fields into sub-config dicts before sub-configs
+        are constructed. See ``validation.propagate_shared_fields`` for the full
+        propagation table, transforms, and the mutex rule.
         """
-        if self.seq_len is not None:
-            if "seq_len" not in self.trainer.model.model_fields_set:
-                self.trainer.model.seq_len = self.seq_len
-            if "seq_len" not in self.orchestrator.model_fields_set:
-                self.orchestrator.seq_len = self.seq_len
+        return propagate_shared_fields(data)
 
-        if self.trainer.model.seq_len < self.orchestrator.seq_len:
-            raise ValueError(
-                f"Trainer model seq_len ({self.trainer.model.seq_len}) must be >= orchestrator seq_len ({self.orchestrator.seq_len}). "
-                f"The trainer needs to be able to handle sequences at least as long as those produced by the orchestrator."
-            )
+    ### Validate shared configs (after sub-config construction)
 
+    @model_validator(mode="after")
+    def validate_shared_configs(self):
+        """Validate consistency of shared configs across trainer, orchestrator, and inference."""
+        validate_shared_output_dir(self.trainer, self.orchestrator)
+        validate_shared_model_name(self.trainer, self.orchestrator, self.inference)
+        validate_shared_tokenizer(self.trainer, self.orchestrator, self.inference)
+        validate_shared_max_steps(self.trainer, self.orchestrator)
+        validate_shared_max_async_level(self.trainer, self.orchestrator)
+        validate_shared_seq_len(self.trainer, self.orchestrator)
+        validate_shared_ckpt_config(self.trainer, self.orchestrator)
+        validate_shared_wandb_config(self.trainer, self.orchestrator)
         return self
 
     @model_validator(mode="after")
@@ -655,12 +465,6 @@ class RLConfig(BaseConfig):
                     stacklevel=2,
                 )
 
-        return self
-
-    @model_validator(mode="after")
-    def auto_setup_session_headers(self):
-        """Ensure X-Session-ID header is always set for sticky DP-aware routing at the inference router."""
-        self.orchestrator.student.client.extra_headers_from_state.setdefault("X-Session-ID", "example_id")
         return self
 
     @model_validator(mode="after")

--- a/packages/prime-rl-configs/src/prime_rl/utils/validation.py
+++ b/packages/prime-rl-configs/src/prime_rl/utils/validation.py
@@ -1,10 +1,182 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Optional
 
 from prime_rl.configs.inference import InferenceConfig
 from prime_rl.configs.orchestrator import OrchestratorConfig
 from prime_rl.configs.trainer import TrainerConfig
+
+
+def propagate_shared_fields(data: Any) -> Any:
+    """Propagate ``RLConfig``'s shared top-level fields into the matching sub-config
+    dicts before sub-configs are constructed, so each sub-config's ``mode="after"``
+    validators see the resolved values at construction time.
+
+    Behaviour:
+      - **Fill-if-absent**: an explicit sub-config value is never overwritten.
+        The shared block acts as a default, not a stomper.
+      - **Up-front mutex**: setting the same field at both the shared and
+        sub-config level raises. Under fill-if-absent the sub would silently
+        win, and any later CLI override of the shared field would invisibly
+        no-op.
+      - **Aliased sub-paths**: ``orchestrator.model.*`` is checked against its
+        ``orchestrator.student.model.*`` alias (and vice versa), so the
+        conflict fires regardless of which spelling the user wrote.
+    """
+    if not isinstance(data, dict):
+        return data
+
+    def get(path: str) -> Any | None:
+        node: Any = data
+        for p in path.split("."):
+            if not isinstance(node, dict) or p not in node:
+                return None
+            node = node[p]
+        return node
+
+    def fill(path: str, value: Any) -> None:
+        parts = path.split(".")
+        if parts[0] not in data or not isinstance(data[parts[0]], dict):
+            return
+        node = data
+        for p in parts[:-1]:
+            if not isinstance(node, dict):
+                return
+            node = node.setdefault(p, {})
+        if isinstance(node, dict) and parts[-1] not in node:
+            node[parts[-1]] = value
+
+    conflicts: list[tuple[str, str]] = []
+
+    def propagate(shared_path: str, *targets: str, aliases: tuple[str, ...] = ()) -> None:
+        """Verbatim shared → targets. Records overlap (incl. alias spellings)
+        into ``conflicts`` and fills each target if the shared value is set.
+        """
+        value = get(shared_path)
+        if value is None:
+            return
+        for sub in (*targets, *aliases):
+            if get(sub) is not None:
+                conflicts.append((shared_path, sub))
+        for target in targets:
+            fill(target, value)
+
+    # [model] → trainer / orchestrator (student, via AliasChoices) / inference.
+    propagate(
+        "model.name",
+        "trainer.model.name",
+        "inference.model.name",
+        "orchestrator.model.name",
+        aliases=("orchestrator.student.model.name",),
+    )
+    propagate(
+        "model.vlm",
+        "trainer.model.vlm",
+        "inference.model.vlm",
+        "orchestrator.model.vlm",
+        aliases=("orchestrator.student.model.vlm",),
+    )
+
+    # [log]
+    propagate("log.level", "trainer.log.level", "orchestrator.log.level")
+    propagate("log.json_logging", "trainer.log.json_logging", "orchestrator.log.json_logging")
+
+    # [ckpt] leaves. (Bare empty ``[ckpt]`` block enablement is at the end.)
+    # ``orchestrator.ckpt`` has no ``output_dir`` field — trainer-only.
+    propagate("ckpt.output_dir", "trainer.ckpt.output_dir")
+    propagate("ckpt.interval", "trainer.ckpt.interval", "orchestrator.ckpt.interval")
+    propagate("ckpt.resume_step", "trainer.ckpt.resume_step", "orchestrator.ckpt.resume_step")
+    propagate("ckpt.keep_last", "trainer.ckpt.keep_last", "orchestrator.ckpt.keep_last")
+    propagate("ckpt.keep_interval", "trainer.ckpt.keep_interval", "orchestrator.ckpt.keep_interval")
+
+    # [wandb] leaves. (Bare empty ``[wandb]`` block enablement is at the end.)
+    propagate("wandb.project", "trainer.wandb.project", "orchestrator.wandb.project")
+    propagate("wandb.entity", "trainer.wandb.entity", "orchestrator.wandb.entity")
+    propagate("wandb.group", "trainer.wandb.group", "orchestrator.wandb.group")
+    propagate("wandb.tags", "trainer.wandb.tags", "orchestrator.wandb.tags")
+    propagate("wandb.offline", "trainer.wandb.offline", "orchestrator.wandb.offline")
+
+    # wandb.name: in non-shared mode the two sub-configs get distinct
+    # ``-trainer`` / ``-orchestrator`` suffixes so the W&B runs are
+    # distinguishable. ``OrchestratorConfig.auto_setup_prime_monitor_run_name``
+    # then defaults prime_monitor.run_name to the (unsuffixed) value.
+    wandb_name = get("wandb.name")
+    if wandb_name is not None:
+        for sub in ("trainer.wandb.name", "orchestrator.wandb.name"):
+            if get(sub) is not None:
+                conflicts.append(("wandb.name", sub))
+        non_shared = get("wandb.shared") is False
+        fill("trainer.wandb.name", f"{wandb_name}-trainer" if non_shared else wandb_name)
+        fill("orchestrator.wandb.name", f"{wandb_name}-orchestrator" if non_shared else wandb_name)
+
+    # [tokenizer]. ``chat_template`` also flows to ``inference.model`` (vLLM's
+    # ``--chat-template``); ``name`` and ``trust_remote_code`` can legitimately
+    # differ between sub-configs (auto-derived from model names, which may
+    # differ for FP8-quantized inference variants).
+    propagate("tokenizer.name", "trainer.tokenizer.name", "orchestrator.tokenizer.name")
+    propagate(
+        "tokenizer.trust_remote_code",
+        "trainer.tokenizer.trust_remote_code",
+        "orchestrator.tokenizer.trust_remote_code",
+    )
+    propagate(
+        "tokenizer.chat_template",
+        "trainer.tokenizer.chat_template",
+        "orchestrator.tokenizer.chat_template",
+        "inference.model.chat_template",
+    )
+
+    # Top-level scalars.
+    propagate("max_steps", "trainer.max_steps", "orchestrator.max_steps")
+    propagate("max_async_level", "trainer.max_async_level", "orchestrator.max_async_level")
+    propagate("seq_len", "trainer.model.seq_len", "orchestrator.seq_len")
+
+    # output_dir: orchestrator gets a ``/run_default`` subdir so trainer +
+    # orchestrator nest under the same experiment root without colliding.
+    output_dir = get("output_dir")
+    if output_dir is not None:
+        for sub in ("trainer.output_dir", "orchestrator.output_dir"):
+            if get(sub) is not None:
+                conflicts.append(("output_dir", sub))
+        fill("trainer.output_dir", output_dir)
+        fill("orchestrator.output_dir", f"{output_dir}/run_default")
+
+    # Cascade trainer.tokenizer.chat_template → inference.model.chat_template
+    # (vLLM ``--chat-template``). Read trainer's value *after* the shared
+    # propagation above so we cover both:
+    #   - shared ``[tokenizer] chat_template`` (already filled all three above,
+    #     this re-fill is a no-op via fill-if-absent), and
+    #   - ``[trainer.tokenizer] chat_template`` set directly without shared
+    #     (only path that reaches inference; ``validate_shared_tokenizer``
+    #     would otherwise complain about the missing inference value).
+    trainer_chat_template = get("trainer.tokenizer.chat_template")
+    if trainer_chat_template is not None:
+        fill("inference.model.chat_template", trainer_chat_template)
+
+    # Bare ``[ckpt]`` / ``[wandb]`` block: presence-only signal that enables
+    # the section with defaults on both sub-configs. Necessary because
+    # ``trainer.ckpt`` / ``orchestrator.ckpt`` are Optional[None] by default —
+    # without this an empty shared block would be a no-op. Leaf-level
+    # conflicts (e.g. shared ``ckpt.interval`` vs ``trainer.ckpt.interval``)
+    # are already caught above; the bare block is exempt because
+    # ``[ckpt]`` + ``[trainer.ckpt] keep_last = 3`` is a legitimate
+    # "enable + customise per side" pattern.
+    for key in ("ckpt", "wandb"):
+        if get(key) is not None:
+            fill(f"trainer.{key}", {})
+            fill(f"orchestrator.{key}", {})
+
+    if conflicts:
+        lines = [
+            "Shared config conflicts with matching sub-config field(s). Pick one place "
+            "to set each value — duplicating it is ambiguous and the sub-config "
+            "would silently shadow any later shared-level override (e.g. on the CLI):",
+        ]
+        for shared, sub in conflicts:
+            lines.append(f"  - [{shared!r}] is set, but [{sub!r}] is also set")
+        raise ValueError("\n".join(lines))
+
+    return data
 
 
 def validate_shared_ckpt_config(
@@ -101,6 +273,17 @@ def validate_shared_max_async_level(
     if trainer.max_async_level != orchestrator.max_async_level:
         raise ValueError(
             f"Trainer max async level ({trainer.max_async_level}) and orchestrator max async level ({orchestrator.max_async_level}) are not the same. Please specify the same max async level for both."
+        )
+
+
+def validate_shared_seq_len(
+    trainer: TrainerConfig,
+    orchestrator: OrchestratorConfig,
+) -> None:
+    if trainer.model.seq_len < orchestrator.seq_len:
+        raise ValueError(
+            f"Trainer model seq_len ({trainer.model.seq_len}) must be >= orchestrator seq_len ({orchestrator.seq_len}). "
+            f"The trainer needs to be able to handle sequences at least as long as those produced by the orchestrator."
         )
 
 

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -194,6 +194,255 @@ def test_selective_activation_checkpointing_requires_custom_impl():
         TrainerModelConfig.model_validate({"impl": "hf", "ac": {"mode": "selective"}})
 
 
+def test_shared_model_name_propagates_to_subconfigs():
+    model_name = "PrimeIntellect/test-model"
+    config = RLConfig.model_validate(
+        {
+            "model": {"name": model_name},
+            "trainer": {},
+            "orchestrator": {"use_renderer": False},
+            "inference": {},
+        }
+    )
+    assert config.trainer.model.name == model_name
+    assert config.orchestrator.student.model.name == model_name
+    assert config.inference is not None and config.inference.model.name == model_name
+    assert config.trainer.tokenizer.name == model_name
+    assert config.orchestrator.tokenizer.name == model_name
+
+
+def test_shared_tokenizer_propagates_when_subconfigs_unset():
+    config = RLConfig.model_validate(
+        {
+            "model": {"name": "my-model"},
+            "tokenizer": {"name": "my-tokenizer"},
+            "trainer": {},
+            "orchestrator": {"use_renderer": False},
+        }
+    )
+    assert config.trainer.tokenizer.name == "my-tokenizer"
+    assert config.orchestrator.tokenizer.name == "my-tokenizer"
+
+
+def test_shared_and_sub_tokenizer_name_conflict_raises():
+    """Setting tokenizer.name in both [tokenizer] and [trainer.tokenizer]
+    is a config conflict — the sub-config would silently win, and any later
+    CLI override of [tokenizer].name would silently no-op for the trainer."""
+    with pytest.raises(ValidationError, match=r"tokenizer.name.*trainer.tokenizer.name"):
+        RLConfig.model_validate(
+            {
+                "model": {"name": "my-model"},
+                "tokenizer": {"name": "shared-tok"},
+                "trainer": {"tokenizer": {"name": "trainer-tok"}},
+                "orchestrator": {"use_renderer": False},
+            }
+        )
+
+
+def test_tokenizer_name_falls_back_to_model_name_when_unset():
+    config = RLConfig.model_validate(
+        {
+            "model": {"name": "my-model"},
+            "tokenizer": {"trust_remote_code": True},
+            "trainer": {},
+            "orchestrator": {"use_renderer": False},
+        }
+    )
+    assert config.trainer.tokenizer.name == "my-model"
+    assert config.orchestrator.tokenizer.name == "my-model"
+    assert config.trainer.tokenizer.trust_remote_code is True
+    assert config.orchestrator.tokenizer.trust_remote_code is True
+
+
+def test_explicit_subconfig_tokenizer_name_survives_shared_model_propagation():
+    """Regression: shared ``[model] name = "M"`` must propagate model names but
+    must NOT clobber an explicit ``[orchestrator.tokenizer] name = "T"``.
+
+    This is the case that the old RL-level ``auto_setup_tokenizer`` fix-up got
+    wrong: it unconditionally re-derived ``orchestrator.tokenizer.name`` from
+    ``orchestrator.student.model.name`` after propagation, silently overriding
+    the user's explicit value. The ``mode="before"`` ``auto_setup_shared_configs``
+    propagator fixes this because it propagates the model name into the raw
+    dict before sub-configs are built, so ``OrchestratorConfig``'s own
+    ``auto_setup_tokenizer`` (mode=after) sees the resolved name *and* the
+    explicit user-set tokenizer name, and the ``fill``-if-absent semantic
+    leaves the explicit value alone.
+    """
+    config = RLConfig.model_validate(
+        {
+            "model": {"name": "M"},
+            "trainer": {},
+            "orchestrator": {
+                "use_renderer": False,
+                "tokenizer": {"name": "explicit-orch-tok"},
+            },
+        }
+    )
+    # Shared model.name reached every sub-config that didn't override it.
+    assert config.trainer.model.name == "M"
+    assert config.orchestrator.student.model.name == "M"
+    # Trainer didn't specify a tokenizer, so it falls back to the propagated model name.
+    assert config.trainer.tokenizer.name == "M"
+    # Orchestrator's explicit tokenizer name survived.
+    assert config.orchestrator.tokenizer.name == "explicit-orch-tok"
+
+
+def test_tokenizer_chat_template_mismatch_raises():
+    with pytest.raises(ValidationError, match="chat_template"):
+        RLConfig.model_validate(
+            {
+                "trainer": {"tokenizer": {"chat_template": "A"}},
+                "orchestrator": {"use_renderer": False, "tokenizer": {"chat_template": "B"}},
+            }
+        )
+
+
+def test_shared_seq_len_propagates_to_subconfigs():
+    config = RLConfig.model_validate(
+        {
+            "seq_len": 4096,
+            "trainer": {},
+            "orchestrator": {"use_renderer": False},
+        }
+    )
+    assert config.trainer.model.seq_len == 4096
+    assert config.orchestrator.seq_len == 4096
+
+
+def test_shared_and_sub_seq_len_conflict_raises():
+    """Setting seq_len at the shared level and on a sub-config is a conflict —
+    forces the user to pick one place to express the value rather than
+    relying on the silent 'sub wins' rule."""
+    with pytest.raises(ValidationError, match=r"seq_len.*trainer.model.seq_len"):
+        RLConfig.model_validate(
+            {
+                "seq_len": 4096,
+                "trainer": {"model": {"seq_len": 8192}},
+                "orchestrator": {"use_renderer": False},
+            }
+        )
+
+
+def test_shared_and_sub_model_name_conflict_raises():
+    """Setting model.name at the shared level and on a sub-config is a conflict."""
+    with pytest.raises(ValidationError, match=r"model.name.*trainer.model.name"):
+        RLConfig.model_validate(
+            {
+                "model": {"name": "X"},
+                "trainer": {"model": {"name": "Y"}},
+                "orchestrator": {"use_renderer": False},
+            }
+        )
+
+
+def test_shared_and_sub_max_steps_conflict_raises():
+    """Top-level scalar shared fields also participate in the mutex check."""
+    with pytest.raises(ValidationError, match=r"max_steps.*orchestrator.max_steps"):
+        RLConfig.model_validate(
+            {
+                "max_steps": 100,
+                "trainer": {},
+                "orchestrator": {"use_renderer": False, "max_steps": 200},
+            }
+        )
+
+
+def test_trainer_chat_template_cascades_to_inference():
+    """``[trainer.tokenizer] chat_template`` set directly (no shared
+    ``[tokenizer] chat_template``) must still reach
+    ``inference.model.chat_template`` so vLLM's ``--chat-template`` is wired
+    up. Regression: the original ``auto_setup_tokenizer`` cascaded this; the
+    refactored propagator must keep doing it."""
+    config = RLConfig.model_validate(
+        {
+            "model": {"name": "Qwen/Qwen3-0.6B"},
+            "trainer": {"tokenizer": {"chat_template": "TPL"}},
+            "orchestrator": {"use_renderer": False, "tokenizer": {"chat_template": "TPL"}},
+            "inference": {},
+        }
+    )
+    assert config.trainer.tokenizer.chat_template == "TPL"
+    assert config.orchestrator.tokenizer.chat_template == "TPL"
+    assert config.inference is not None
+    assert config.inference.model.chat_template == "TPL"
+
+
+def test_shared_wandb_fields_propagate_to_subconfigs():
+    """Every ``SharedWandbConfig`` leaf (project, entity, group, tags, offline)
+    propagates to both trainer.wandb and orchestrator.wandb, not just project
+    and offline. Regression for a miss in the inline propagator."""
+    config = RLConfig.model_validate(
+        {
+            "model": {"name": "Qwen/Qwen3-0.6B"},
+            "wandb": {
+                "project": "shared-proj",
+                "entity": "shared-entity",
+                "group": "shared-group",
+                "tags": ["a", "b"],
+                "shared": False,
+                "offline": True,
+            },
+            "trainer": {},
+            "orchestrator": {"use_renderer": False},
+        }
+    )
+    for component in (config.trainer.wandb, config.orchestrator.wandb):
+        assert component is not None
+        assert component.project == "shared-proj"
+        assert component.entity == "shared-entity"
+        assert component.group == "shared-group"
+        assert component.tags == ["a", "b"]
+        assert component.offline is True
+
+
+def test_empty_shared_ckpt_block_does_not_conflict_with_subconfig_ckpt():
+    """An empty shared [ckpt] block is a presence-only signal, not a field
+    setting — it should not conflict with a non-empty [trainer.ckpt]."""
+    config = RLConfig.model_validate(
+        {
+            "ckpt": {},  # empty block, no field set
+            "trainer": {"ckpt": {"interval": 50}},
+            "orchestrator": {"use_renderer": False, "ckpt": {"interval": 50}},
+        }
+    )
+    assert config.trainer.ckpt is not None
+    assert config.trainer.ckpt.interval == 50
+
+
+def test_shared_and_subconfig_disjoint_fields_coexist():
+    """Per-field mutex only forbids conflicts on the SAME field — disjoint
+    fields in [model] vs [trainer.model] are fine."""
+    config = RLConfig.model_validate(
+        {
+            "model": {"name": "Qwen/Qwen3-0.6B"},
+            "trainer": {"model": {"impl": "custom"}},
+            "orchestrator": {"use_renderer": False},
+        }
+    )
+    assert config.trainer.model.name == "Qwen/Qwen3-0.6B"
+    assert config.trainer.model.impl == "custom"
+
+
+def test_shared_output_dir_propagates_through_cli(tmp_path):
+    """Shared output_dir from CLI reaches sub-configs even when tyro constructs sub-configs before the before-validator."""
+    toml_path = tmp_path / "cfg.toml"
+    write_toml(
+        toml_path,
+        {
+            "max_steps": 1,
+            "seq_len": 128,
+            "model": {"name": "Qwen/Qwen3-0.6B"},
+            "trainer": {},
+            "orchestrator": {"batch_size": 16, "rollouts_per_example": 1},
+            "inference": {},
+        },
+    )
+    shared_out = tmp_path / "shared"
+    config = cli(RLConfig, args=["@", str(toml_path), "--output-dir", str(shared_out)])
+    assert config.trainer.output_dir == shared_out
+    assert config.orchestrator.output_dir == shared_out / "run_default"
+
+
 def test_orchestrator_renderer_auto_rejects_unmapped_model():
     """use_renderer=True with renderer.name='auto' must reject models not in MODEL_RENDERER_MAP."""
     with pytest.raises(ValidationError, match="silently fall back to DefaultRenderer"):


### PR DESCRIPTION
## Summary

- Single ``mode="before"`` validator on ``RLConfig`` (``auto_setup_shared_configs``) delegates to ``validation.propagate_shared_fields(data)``, which propagates every shared top-level field into its sub-config targets before sub-configs are constructed. Fill-if-absent: never overwrites an explicit sub-config value.
- Inline up-front mutex: setting the same field at both the shared and sub-config level raises. Under fill-if-absent the sub would silently win and any later CLI override would invisibly no-op — the original failure mode from #2430.
- Aliased sub-config paths (``orchestrator.model.*`` vs ``orchestrator.student.model.*`` via ``AliasChoices``) are caught under every spelling.
- Special-case transforms baked into the propagator: ``output_dir`` orchestrator gets a ``/run_default`` subdir; ``wandb.name`` non-shared mode appends ``-trainer`` / ``-orchestrator`` suffixes.
- ``trainer.tokenizer.chat_template → inference.model.chat_template`` cascade preserved (covers the case where chat_template is set directly on trainer without a shared ``[tokenizer]`` block — vLLM's ``--chat-template`` still gets wired).
- Bare ``[ckpt]`` / ``[wandb]`` block enables ckpt/wandb on both sub-configs with defaults (these sub-configs are ``Optional[None]`` by default; an empty shared block would otherwise be a no-op).
- Drop ``RLConfig.max_model_len`` — declared but never wired to a validator. Users set ``inference.model.max_model_len`` directly.
- Move ``auto_setup_session_headers`` from ``RLConfig`` onto ``OrchestratorConfig`` so the hosted orchestrator entrypoint enforces it on standalone load.
- New ``OrchestratorConfig.auto_setup_prime_monitor_run_name``: defaults ``prime_monitor.run_name`` to the W&B run name when monitoring is enabled (works for standalone load too).
- Collapse the per-field ``validate_shared_*`` calls into one ``validate_shared_configs`` ``mode="after"`` validator.

## Why this works now

pydantic-config 0.3 (drop-tyro, #2564) removed the typed-default mirror that previously round-tripped CLI args through tyro. The ``mode="before"`` validator now sees a clean dict-of-dicts and can propagate without the ``_dump_preserving_discriminators`` workaround the original #2517 carried.

The old RL-level ``auto_setup_tokenizer`` fix-up (re-derive from "now-correct" model names) silently overrode explicit ``[orchestrator.tokenizer] name = ...`` values because by the time it ran, ``model_fields_set`` no longer distinguished user-set from sub-validator-set. With the before-validator, explicit sub-config values survive untouched — see ``test_explicit_subconfig_tokenizer_name_survives_shared_model_propagation``.

## Verification

Full CPU suite (``tests/unit -m "not gpu"``, matches ``cpu_tests.yaml``): **376 passed**.

### #2430 repro

The issue's literal TOML has both ``[model] name = "Qwen"`` and ``[trainer.model] name = "Qwen"`` plus CLI ``--seq-len 1024 --model.name /local/path``:

- Before: silent no-op — trainer/orch kept their TOML values, tokenizer kept ``Qwen``, offline nodes failed to load the model.
- After: explicit ``ConfigFileError`` naming both keys. With the duplicate removed, the CLI override propagates to every nested field end-to-end.

## In-repo configs that tripped the new mutex

- ``configs/hendrycks_math/sanity.toml`` — drop redundant ``[trainer.model] name``
- ``examples/hendrycks_sanity/rl.toml`` — drop redundant ``[trainer.model] name``; move ``seq_len = 8192`` under ``[orchestrator]`` so the trainer keeps its longer 16384 context
- ``examples/glm5_pd_disag/rl.toml`` — split shared ``[model] name`` into per-component names (trainer = GLM-5 BF16, orchestrator + inference = GLM-5-FP8 to satisfy ``validate_shared_model_name``)

Closes #2430. Supersedes #2517.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `RLConfig` validation/propagation logic, which can change how CLI/TOML configs resolve and may surface new validation errors for existing configs. Risk is mitigated by extensive new unit coverage and limited scope to config construction/validation.
> 
> **Overview**
> Refactors `RLConfig` shared-field handling to propagate top-level fields (e.g. `model`, `tokenizer`, `seq_len`, `wandb`, `ckpt`, `output_dir`) into sub-configs via a single `mode="before"` validator (`propagate_shared_fields`), with *fill-if-absent* semantics and an explicit mutex that errors when the same field is set both shared and per-component.
> 
> Moves sticky-routing session header setup (`X-Session-ID`) and a new `prime_monitor.run_name` defaulting rule into `OrchestratorConfig`, and replaces RL-level per-field auto-setup with consolidated post-construct shared validation (including new `seq_len` consistency validation).
> 
> Updates example/config TOMLs to remove now-invalid duplicated fields (and to split model names where trainer vs inference/orchestrator differ), and adds a broad set of unit tests covering propagation, conflicts, and chat-template cascading to inference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b92bde570efcc207f0647c182de9fa31c12ba440. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->