### PR TITLE
feat: convert config field descriptions to docstrings + config simplification

### DIFF
--- a/examples/wordle/sft.toml
+++ b/examples/wordle/sft.toml
@@ -9,7 +9,7 @@ name = "PrimeIntellect/Qwen3-1.7B"
 name = "willcb/V3-wordle"
 seq_len = 1024
 batch_size = 64
-micro-batch-size = 1
+micro_batch_size = 1
 
 [optim]
 lr = 1e-5

--- a/packages/prime-rl-configs/pyproject.toml
+++ b/packages/prime-rl-configs/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = "~=3.12.0"
 dependencies = [
     "pydantic>=1.10.13",
-    "prime-pydantic-config>=0.3.0.dev80",
+    "prime-pydantic-config>=0.3.0.dev82",
     # OrchestratorConfig validates renderer.name='auto' against
     # renderers.base.MODEL_RENDERER_MAP. Renderers itself is light; its only
     # weighty transitive (transformers) is lazy-imported via the validator,

--- a/packages/prime-rl-configs/src/prime_rl/configs/env_server.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/env_server.py
@@ -9,10 +9,8 @@ from prime_rl.utils.config import BaseConfig
 
 class EnvServerConfig(BaseConfig):
     env: EnvConfig = EnvConfig()
-    """Environment configuration."""
 
     log: LogConfig = LogConfig()
-    """Logger configuration."""
 
     env_install_prerelease: bool = False
     """Allow pre-release versions when installing environments. Passes ``--prerelease`` to ``prime env install``."""

--- a/packages/prime-rl-configs/src/prime_rl/configs/env_server.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/env_server.py
@@ -1,7 +1,6 @@
 from pathlib import Path
-from typing import Annotated
 
-from pydantic import Field, model_validator
+from pydantic import model_validator
 
 from prime_rl.configs.orchestrator import EnvConfig
 from prime_rl.configs.shared import LogConfig
@@ -9,18 +8,17 @@ from prime_rl.utils.config import BaseConfig
 
 
 class EnvServerConfig(BaseConfig):
-    """Configures an environment server."""
-
     env: EnvConfig = EnvConfig()
-    log: LogConfig = LogConfig()
-    env_install_prerelease: bool = False
+    """Environment configuration."""
 
-    output_dir: Annotated[
-        Path,
-        Field(
-            description="Directory to write outputs to. Will be populated with checkpoints, weights, rollouts and logs as subdirectories. Should be set to a persistent directory with enough disk space. This value should be distinct across experiments running on a single node. See the README for more details."
-        ),
-    ] = Path("outputs")
+    log: LogConfig = LogConfig()
+    """Logger configuration."""
+
+    env_install_prerelease: bool = False
+    """Allow pre-release versions when installing environments. Passes ``--prerelease`` to ``prime env install``."""
+
+    output_dir: Path = Path("outputs")
+    """Directory to write outputs to — logs and any generated artifacts are written as subdirectories."""
 
     @model_validator(mode="after")
     def validate_num_workers(self):

--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -2,7 +2,7 @@ from argparse import Namespace
 from pathlib import Path
 from typing import Annotated, Any, Literal, TypeAlias
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import Field, model_validator
 from pydantic_config import BaseConfig
 
 from prime_rl.configs.shared import BaseModelConfig, SlurmConfig
@@ -33,8 +33,6 @@ class ParallelConfig(BaseConfig):
         return f"tp={self.tp} dp={self.dp}"
 
 
-# Most arguments are forwarded directly to the vLLM LLM class
-# (https://docs.vllm.ai/en/latest/api/vllm.LLM.html).
 class ModelConfig(BaseModelConfig):
     dtype: Literal["auto", "float16", "bfloat16", "float32"] = "auto"
     """dtype for model weights and activations. ``auto`` uses FP16 for FP32/FP16 models and BF16 for BF16 models. Forwarded as ``--dtype``."""
@@ -66,9 +64,7 @@ class WeightBroadcastConfig(BaseConfig):
     """Weight broadcast transport."""
 
 
-class KVCacheOffloadConfig(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class KVCacheOffloadConfig(BaseConfig):
     cpu_bytes: int = Field(1_000_000_000, gt=0)
     """CPU bytes available for KV cache offloading per worker."""
 
@@ -87,9 +83,7 @@ All2AllBackend = Literal[
 ]
 
 
-class BaseInferenceDeploymentConfig(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class BaseInferenceDeploymentConfig(BaseConfig):
     gpus_per_node: int = 8
     """GPUs per node."""
 
@@ -185,10 +179,8 @@ class InferenceExperimentalConfig(BaseConfig):
 
 class InferenceConfig(BaseConfig):
     server: ServerConfig = ServerConfig()
-    """Inference server configuration."""
 
     model: ModelConfig = Field(default_factory=ModelConfig)
-    """Inference model configuration."""
 
     parallel: ParallelConfig = ParallelConfig()
     """Multi-node and multi-GPU parallelism (TP, DP, PP)."""
@@ -245,7 +237,6 @@ class InferenceConfig(BaseConfig):
     """Force DeepGEMM FP8 kernels via ``VLLM_USE_DEEP_GEMM=1``. Only works with per-tensor FP8 quantization (e.g. GLM-5-FP8)."""
 
     weight_broadcast: WeightBroadcastConfig = WeightBroadcastConfig()
-    """Weight broadcast configuration."""
 
     kv_cache_offload: KVCacheOffloadConfig | None = None
     """CPU KV cache offload for inference workers. Standard inference uses vLLM's ``OffloadingConnector``. Disaggregated P/D deployments combine it with NIXL through ``MultiConnector`` in the SLURM launcher."""
@@ -262,7 +253,6 @@ class InferenceConfig(BaseConfig):
     # Launcher-only fields
 
     deployment: InferenceDeploymentConfig = SingleNodeInferenceDeploymentConfig()
-    """Deployment topology for inference."""
 
     slurm: SlurmConfig | None = None
     """SLURM configuration. When set, the run is submitted as a SLURM job instead of running locally."""
@@ -274,7 +264,6 @@ class InferenceConfig(BaseConfig):
     """Only validate and dump resolved configs, then exit early."""
 
     experimental: InferenceExperimentalConfig = InferenceExperimentalConfig()
-    """Experimental inference features."""
 
     @model_validator(mode="after")
     def validate_multi_node_requires_slurm(self):

--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -12,122 +12,65 @@ from prime_rl.utils.config import find_package_resource, rgetattr, rsetattr
 
 
 class ServerConfig(BaseConfig):
-    """Configures the inference server."""
+    host: str | None = None
+    """Host to bind to."""
 
-    host: Annotated[str | None, Field(description="The host to bind to.")] = None
-    port: Annotated[int, Field(description="The port to bind to.")] = 8000
-    liveness_timeout_seconds: Annotated[
-        float,
-        Field(
-            gt=0,
-            description=(
-                "Timeout in seconds for the /liveness endpoint's internal vLLM worker RPC. "
-                "If Kubernetes liveness probes are enabled, keep the probe timeoutSeconds at least this high."
-            ),
-        ),
-    ] = 30.0
+    port: int = 8000
+    """Port to bind to."""
+
+    liveness_timeout_seconds: float = Field(30.0, gt=0)
+    """Timeout in seconds for the ``/liveness`` endpoint's internal vLLM worker RPC. With Kubernetes liveness probes, keep the probe ``timeoutSeconds`` at least this high."""
 
 
 class ParallelConfig(BaseConfig):
-    """Configures multi-node and multi-GPU setups through different types of parallelism (TP, DP, PP)."""
+    tp: int = 1
+    """Tensor parallel size. Forwarded to vLLM as ``--tensor-parallel-size``."""
 
-    tp: Annotated[
-        int,
-        Field(
-            description="The tensor parallel size. It is passed to vLLM as `--tensor-parallel-size`",
-        ),
-    ] = 1
-
-    dp: Annotated[
-        int,
-        Field(
-            ge=1,
-            description="The data parallel size. It is passed to vLLM as `--data-parallel-size`",
-        ),
-    ] = 1
+    dp: int = Field(1, ge=1)
+    """Data parallel size. Forwarded to vLLM as ``--data-parallel-size``."""
 
     def __str__(self) -> str:
         return f"tp={self.tp} dp={self.dp}"
 
 
+# Most arguments are forwarded directly to the vLLM LLM class
+# (https://docs.vllm.ai/en/latest/api/vllm.LLM.html).
 class ModelConfig(BaseModelConfig):
-    """Configures the inference model. Most arguments are passed directly to the vLLM LLM class (https://docs.vllm.ai/en/latest/api/vllm.LLM.html)."""
+    dtype: Literal["auto", "float16", "bfloat16", "float32"] = "auto"
+    """dtype for model weights and activations. ``auto`` uses FP16 for FP32/FP16 models and BF16 for BF16 models. Forwarded as ``--dtype``."""
 
-    dtype: Annotated[
-        Literal["auto", "float16", "bfloat16", "float32"],
-        Field(
-            description="Data type for model weights and activations. If 'auto' will use FP16 precision for FP32 and FP16 models, and BF16 precision for BF16 models. Passed to vLLM as `--dtype`",
-        ),
-    ] = "auto"
+    max_model_len: int | None = None
+    """Maximum model context length. If None, uses the model config's value. Forwarded as ``--max-model-len``."""
 
-    max_model_len: Annotated[
-        int | None,
-        Field(
-            description="Maximum model context length. If None, will use the maximum context length from model config. Passed to vLLM as `--max-model-len`",
-        ),
-    ] = None
+    enforce_eager: bool = False
+    """Enforce eager mode. When False, PyTorch eager and cuda graphs run hybrid for maximum performance. Forwarded as ``--enforce-eager``."""
 
-    enforce_eager: Annotated[
-        bool,
-        Field(
-            description="Whether to enforce eager mode. If False, will use PyTorch eager and cuda graphs in hybrid for maximal performance. Passed to vLLM as `--enforce-eager`",
-        ),
-    ] = False
+    trust_remote_code: bool = False
+    """Trust remote code. Forwarded to vLLM engine init."""
 
-    trust_remote_code: Annotated[
-        bool,
-        Field(
-            description="Whether to trust remote code. Passed to vLLM engine init",
-        ),
-    ] = False
+    chat_template: str | None = None
+    """Chat template — a Jinja2 template string or path to a template file. Forwarded as ``--chat-template``. If None, uses the model's default."""
 
-    chat_template: Annotated[
-        str | None,
-        Field(
-            description="Chat template to use. Can be a Jinja2 template string or a path to a template file. "
-            "Passed to vLLM as `--chat-template`. If None, uses the model's default.",
-        ),
-    ] = None
+    tool_call_parser: str | None = "auto"
+    """Tool-call parser. Forwarded as ``--tool-call-parser``. Set to ``auto`` to infer from the model name."""
 
-    tool_call_parser: Annotated[
-        str | None,
-        Field(
-            description="The tool call parser to use. Passed to vLLM as `--tool-call-parser`. "
-            'Set to "auto" to infer from the model name.',
-        ),
-    ] = "auto"
+    reasoning_parser: str | None = None
+    """Parser for extracting reasoning content from model outputs. Forwarded as ``--reasoning-parser``. Setting this enables reasoning mode."""
 
-    reasoning_parser: Annotated[
-        str | None,
-        Field(
-            description="Parser for extracting reasoning content from model outputs. Passed to vLLM as `--reasoning-parser`. Setting this enables reasoning mode.",
-        ),
-    ] = None
-
-    rope_scaling: Annotated[
-        dict[str, Any] | str | None,
-        Field(
-            description='RoPE scaling configuration as a dict. For YaRN, use: {rope_type="yarn", factor=4.0, original_max_position_embeddings=32768} or. Passed to vLLM as `--rope-scaling`.',
-        ),
-    ] = None
+    rope_scaling: dict[str, Any] | str | None = None
+    """RoPE scaling configuration as a dict (e.g. ``{rope_type="yarn", factor=4.0, original_max_position_embeddings=32768}``). Forwarded as ``--rope-scaling``."""
 
 
 class WeightBroadcastConfig(BaseConfig):
-    """Configures weight broadcast settings."""
-
-    type: Annotated[Literal["nccl", "filesystem"], Field(description="The type of weight broadcast to use.")] = (
-        "filesystem"
-    )
+    type: Literal["nccl", "filesystem"] = "filesystem"
+    """Weight broadcast transport."""
 
 
 class KVCacheOffloadConfig(BaseModel):
-    """CPU KV cache offloading for vLLM inference workers."""
-
     model_config = ConfigDict(extra="forbid")
 
-    cpu_bytes: Annotated[int, Field(gt=0, description="CPU bytes available for KV cache offloading per worker.")] = (
-        1_000_000_000
-    )
+    cpu_bytes: int = Field(1_000_000_000, gt=0)
+    """CPU bytes available for KV cache offloading per worker."""
 
 
 # Valid vLLM max_lora_rank values (from vllm/config/lora.py)
@@ -145,80 +88,71 @@ All2AllBackend = Literal[
 
 
 class BaseInferenceDeploymentConfig(BaseModel):
-    """Base deployment config for inference."""
-
     model_config = ConfigDict(extra="forbid")
 
-    gpus_per_node: Annotated[int, Field(description="Number of GPUs per node.")] = 8
+    gpus_per_node: int = 8
+    """GPUs per node."""
 
 
 class SingleNodeInferenceDeploymentConfig(BaseInferenceDeploymentConfig):
-    """Configures a single-node inference deployment."""
-
     type: Literal["single_node"] = "single_node"
 
 
+# Multi-node inference: each node runs an independent vLLM replica.
 class MultiNodeInferenceDeploymentConfig(BaseInferenceDeploymentConfig):
-    """Configures a multi-node inference deployment. Each node runs an independent vLLM replica."""
-
     type: Literal["multi_node"] = "multi_node"
 
-    num_nodes: Annotated[int, Field(ge=1, description="Number of inference nodes.")] = 2
+    num_nodes: int = Field(2, ge=1)
+    """Inference nodes."""
 
-    router_port: Annotated[int, Field(description="Port for the vllm-router.")] = 8000
-    backend_port: Annotated[int, Field(description="Port for vLLM backend instances.")] = 8100
-    router_policy: Annotated[
-        str, Field(description="Routing policy for the vllm-router (e.g. 'consistent_hash', 'round_robin').")
-    ] = "consistent_hash"
+    router_port: int = 8000
+    """Port for the vllm-router."""
+
+    backend_port: int = 8100
+    """Port for vLLM backend instances."""
+
+    router_policy: str = "consistent_hash"
+    """vllm-router routing policy (e.g. ``consistent_hash``, ``round_robin``)."""
 
 
+# Disaggregated prefill/decode inference. Each replica is split into separate
+# prefill and decode node groups. Requires NIXL for KV transfer and a vllm-router
+# for request routing. Multi-replica: set ``num_prefill_replicas`` /
+# ``num_decode_replicas`` to run multiple independent vLLM instances within the
+# prefill / decode node groups. E.g. ``num_prefill_nodes=4, num_prefill_replicas=2``
+# creates two prefill vLLM instances each spanning 2 nodes (EP16 with 8 GPUs/node).
 class DisaggregatedInferenceDeploymentConfig(BaseInferenceDeploymentConfig):
-    """Configures a disaggregated prefill/decode inference deployment.
-
-    Each inference replica is split into separate prefill and decode node groups.
-    Requires NIXL for KV transfer and a vllm-router for request routing.
-
-    Multi-replica support: set ``num_prefill_replicas`` / ``num_decode_replicas``
-    to run multiple independent vLLM instances within the prefill / decode node
-    groups.  For example, ``num_prefill_nodes=4, num_prefill_replicas=2`` creates
-    two prefill vLLM instances each spanning 2 nodes (EP16 with 8 GPUs/node).
-    """
-
     type: Literal["disaggregated"] = "disaggregated"
 
-    num_prefill_nodes: Annotated[int, Field(ge=1, description="Total number of prefill nodes.")] = 1
-    num_decode_nodes: Annotated[int, Field(ge=1, description="Total number of decode nodes.")] = 1
+    num_prefill_nodes: int = Field(1, ge=1)
+    """Total prefill nodes."""
 
-    num_prefill_replicas: Annotated[
-        int,
-        Field(
-            ge=1,
-            description="Number of independent prefill vLLM instances. Must evenly divide num_prefill_nodes.",
-        ),
-    ] = 1
-    num_decode_replicas: Annotated[
-        int,
-        Field(
-            ge=1,
-            description="Number of independent decode vLLM instances. Must evenly divide num_decode_nodes.",
-        ),
-    ] = 1
+    num_decode_nodes: int = Field(1, ge=1)
+    """Total decode nodes."""
 
-    router_port: Annotated[int, Field(description="Port for the vllm-router on each replica.")] = 8000
-    prefill_port: Annotated[int, Field(description="Port for prefill vLLM instances.")] = 8100
-    decode_port: Annotated[int, Field(description="Port for decode vLLM instances.")] = 8200
-    router_policy: Annotated[
-        str, Field(description="Routing policy for the vllm-router (e.g. 'consistent_hash', 'round_robin').")
-    ] = "consistent_hash"
+    num_prefill_replicas: int = Field(1, ge=1)
+    """Independent prefill vLLM instances. Must evenly divide ``num_prefill_nodes``."""
 
-    prefill_env_overrides: Annotated[
-        dict[str, str],
-        Field(description="Extra environment variables exported only on prefill nodes."),
-    ] = {}
-    decode_env_overrides: Annotated[
-        dict[str, str],
-        Field(description="Extra environment variables exported only on decode nodes."),
-    ] = {}
+    num_decode_replicas: int = Field(1, ge=1)
+    """Independent decode vLLM instances. Must evenly divide ``num_decode_nodes``."""
+
+    router_port: int = 8000
+    """Port for the vllm-router on each replica."""
+
+    prefill_port: int = 8100
+    """Port for prefill vLLM instances."""
+
+    decode_port: int = 8200
+    """Port for decode vLLM instances."""
+
+    router_policy: str = "consistent_hash"
+    """vllm-router routing policy (e.g. ``consistent_hash``, ``round_robin``)."""
+
+    prefill_env_overrides: dict[str, str] = {}
+    """Extra environment variables exported only on prefill nodes."""
+
+    decode_env_overrides: dict[str, str] = {}
+    """Extra environment variables exported only on decode nodes."""
 
     @property
     def num_nodes(self) -> int:
@@ -246,200 +180,101 @@ InferenceDeploymentConfig: TypeAlias = Annotated[
 
 
 class InferenceExperimentalConfig(BaseConfig):
-    """Experimental features for inference."""
+    pass
 
 
 class InferenceConfig(BaseConfig):
-    """Configures inference."""
-
-    # The server configuration
     server: ServerConfig = ServerConfig()
+    """Inference server configuration."""
 
-    # The model configuration
     model: ModelConfig = Field(default_factory=ModelConfig)
+    """Inference model configuration."""
 
-    # The parallel configuration
     parallel: ParallelConfig = ParallelConfig()
+    """Multi-node and multi-GPU parallelism (TP, DP, PP)."""
 
-    enable_lora: Annotated[
-        bool,
-        Field(
-            description="Whether to enable LORA. Passed to vLLM as `--enable-lora`",
-        ),
-    ] = False
+    enable_lora: bool = False
+    """Enable LoRA. Forwarded as ``--enable-lora``."""
 
-    max_loras: Annotated[
-        int,
-        Field(
-            description="The maximum number of LoRAs to use. Passed to vLLM as `--max-loras`",
-        ),
-    ] = 8
+    max_loras: int = 8
+    """Maximum number of LoRAs. Forwarded as ``--max-loras``."""
 
     # TODO: The default value is very high because our areal impl for lora isn't ideal
     # We add a lora with the same name instead of changing weights inplace
     # Because we dont cancel requests that are past max_async, these requests could be using a LoRA that gets unloaded which will crash the inference server
-    max_cpu_loras: Annotated[
-        int,
-        Field(
-            description="The maximum number of LoRAs to use on CPU. Passed to vLLM as `--max-cpu-loras`",
-        ),
-    ] = 100
+    max_cpu_loras: int = 100
+    """Maximum number of LoRAs on CPU. Forwarded as ``--max-cpu-loras``."""
 
-    max_lora_rank: Annotated[
-        int | None,
-        Field(
-            description="The maximum LoRA rank to use. Passed to vLLM as `--max-lora-rank`",
-        ),
-    ] = None
+    max_lora_rank: int | None = None
+    """Maximum LoRA rank. Forwarded as ``--max-lora-rank``."""
 
-    lora_target_modules: Annotated[
-        list[str] | None,
-        Field(
-            description="The target modules for LoRA. Passed to vLLM as `--lora-target-modules`.",
-        ),
-    ] = None
+    lora_target_modules: list[str] | None = None
+    """LoRA target modules. Forwarded as ``--lora-target-modules``."""
 
-    enable_prefix_caching: Annotated[
-        bool | None,
-        Field(
-            description="Whether to enable prefix caching. Passed to vLLM as `--enable-prefix-caching`",
-        ),
-    ] = None
+    enable_prefix_caching: bool | None = None
+    """Enable prefix caching. Forwarded as ``--enable-prefix-caching``."""
 
-    gpu_memory_utilization: Annotated[
-        float,
-        Field(
-            description="The GPU memory utilization to use. Passed to vLLM as `--gpu-memory-utilization`",
-        ),
-    ] = 0.9
+    gpu_memory_utilization: float = 0.9
+    """GPU memory utilization. Forwarded as ``--gpu-memory-utilization``."""
 
-    api_server_count: Annotated[
-        int,
-        Field(
-            ge=0,
-            description="The number of API servers to use. Passed to vLLM as `--api-server-count`. Set to 0 for headless mode.",
-        ),
-    ] = 1
+    api_server_count: int = Field(1, ge=0)
+    """API servers to run. Forwarded as ``--api-server-count``. Set to 0 for headless mode."""
 
-    data_parallel_size_local: Annotated[
-        int | None,
-        Field(
-            ge=1,
-            description="Number of data parallel replicas to run on this node. Passed to vLLM as `--data-parallel-size-local`.",
-        ),
-    ] = None
+    data_parallel_size_local: int | None = Field(None, ge=1)
+    """Data parallel replicas to run on this node. Forwarded as ``--data-parallel-size-local``."""
 
-    data_parallel_rpc_port: Annotated[
-        int,
-        Field(
-            ge=1,
-            le=65535,
-            description="RPC port for data parallel communication. Passed to vLLM as `--data-parallel-rpc-port`.",
-        ),
-    ] = 13345
+    data_parallel_rpc_port: int = Field(13345, ge=1, le=65535)
+    """RPC port for data parallel communication. Forwarded as ``--data-parallel-rpc-port``."""
 
-    seed: Annotated[
-        int,
-        Field(
-            description="Seed the inference components. Passed to vLLM as `--seed`",
-        ),
-    ] = 0
+    seed: int = 0
+    """Seed the inference components. Forwarded as ``--seed``."""
 
-    enable_expert_parallel: Annotated[
-        bool,
-        Field(
-            description="Enable expert parallelism for MoE models. Passed to vLLM as `--enable-expert-parallel`.",
-        ),
-    ] = False
+    enable_expert_parallel: bool = False
+    """Enable expert parallelism for MoE models. Forwarded as ``--enable-expert-parallel``."""
 
-    all2all_backend: Annotated[
-        All2AllBackend,
-        Field(
-            description="All-to-all backend for expert parallel communication. Passed to vLLM as `--all2all-backend`.",
-        ),
-    ] = "allgather_reducescatter"
+    all2all_backend: All2AllBackend = "allgather_reducescatter"
+    """All-to-all backend for expert-parallel communication. Forwarded as ``--all2all-backend``."""
 
-    enable_eplb: Annotated[
-        bool,
-        Field(
-            description="Enable expert parallel load balancer (EPLB). Passed to vLLM as `--enable-eplb`.",
-        ),
-    ] = False
+    enable_eplb: bool = False
+    """Enable expert parallel load balancer (EPLB). Forwarded as ``--enable-eplb``."""
 
-    enable_dbo: Annotated[
-        bool,
-        Field(
-            description="Enable dual batch overlap (DBO). Passed to vLLM as `--enable-dbo`.",
-        ),
-    ] = False
+    enable_dbo: bool = False
+    """Enable dual batch overlap (DBO). Forwarded as ``--enable-dbo``."""
 
-    use_deep_gemm: Annotated[
-        bool,
-        Field(
-            description="Force DeepGEMM FP8 kernels via VLLM_USE_DEEP_GEMM=1. Only works with per-tensor FP8 quantization (e.g. GLM-5-FP8).",
-        ),
-    ] = False
+    use_deep_gemm: bool = False
+    """Force DeepGEMM FP8 kernels via ``VLLM_USE_DEEP_GEMM=1``. Only works with per-tensor FP8 quantization (e.g. GLM-5-FP8)."""
 
-    weight_broadcast: Annotated[WeightBroadcastConfig, Field(description="The weight broadcast config.")] = (
-        WeightBroadcastConfig()
-    )
+    weight_broadcast: WeightBroadcastConfig = WeightBroadcastConfig()
+    """Weight broadcast configuration."""
 
-    kv_cache_offload: Annotated[
-        KVCacheOffloadConfig | None,
-        Field(
-            description=(
-                "CPU KV cache offload config for inference workers. Standard inference uses vLLM's "
-                "OffloadingConnector. Disaggregated P/D deployments combine it with NIXL through "
-                "MultiConnector in the SLURM launcher."
-            ),
-        ),
-    ] = None
+    kv_cache_offload: KVCacheOffloadConfig | None = None
+    """CPU KV cache offload for inference workers. Standard inference uses vLLM's ``OffloadingConnector``. Disaggregated P/D deployments combine it with NIXL through ``MultiConnector`` in the SLURM launcher."""
 
-    enable_return_routed_experts: Annotated[
-        bool,
-        Field(
-            description="Whether to enable return routed experts. Passed to vLLM as `--enable-return-routed-experts`",
-        ),
-    ] = False
+    enable_return_routed_experts: bool = False
+    """Return routed experts in responses. Forwarded as ``--enable-return-routed-experts``."""
 
-    enable_fp32_lm_head: Annotated[
-        bool,
-        Field(
-            description="Run the lm_head projection in fp32 via a native bf16xbf16 -> fp32 GEMM (`torch.mm` with `out_dtype=torch.float32`). Stabilizes logprob precision under FP8/bf16 inference, matching SGLang's `--enable-fp32-lm-head`. Implemented as a monkey-patch over vLLM's LogitsProcessor, activated by setting `additional_config[\"fp32_lm_head\"] = True` on the vLLM config.",
-        ),
-    ] = False
+    enable_fp32_lm_head: bool = False
+    """Run the lm_head projection in fp32 via a native bf16×bf16 → fp32 GEMM (``torch.mm`` with ``out_dtype=torch.float32``). Stabilizes logprob precision under FP8/bf16 inference, matching SGLang's ``--enable-fp32-lm-head``. Implemented as a monkey-patch over vLLM's LogitsProcessor, activated by setting ``additional_config["fp32_lm_head"] = True`` on the vLLM config."""
 
-    vllm_extra: Annotated[
-        dict[str, Any],
-        Field(
-            description="Extra arguments to pass to vLLM. These are applied as attributes on the vLLM namespace after config translation.",
-        ),
-    ] = {}
+    vllm_extra: dict[str, Any] = {}
+    """Extra arguments forwarded to vLLM. Applied as attributes on the vLLM namespace after config translation."""
 
     # Launcher-only fields
 
-    deployment: Annotated[
-        InferenceDeploymentConfig,
-        Field(
-            description="Deployment configuration for inference.",
-        ),
-    ] = SingleNodeInferenceDeploymentConfig()
+    deployment: InferenceDeploymentConfig = SingleNodeInferenceDeploymentConfig()
+    """Deployment topology for inference."""
 
-    slurm: Annotated[
-        SlurmConfig | None,
-        Field(
-            description="SLURM configuration. If set, the run will be submitted as a SLURM job instead of running locally.",
-        ),
-    ] = None
+    slurm: SlurmConfig | None = None
+    """SLURM configuration. When set, the run is submitted as a SLURM job instead of running locally."""
 
-    output_dir: Annotated[Path, Field(description="Directory for SLURM logs and generated scripts.")] = Path("outputs")
+    output_dir: Path = Path("outputs")
+    """Directory for SLURM logs and generated scripts."""
 
-    dry_run: Annotated[bool, Field(description="Only validate and dump resolved configs and exit early.")] = False
+    dry_run: bool = False
+    """Only validate and dump resolved configs, then exit early."""
 
-    experimental: Annotated[
-        InferenceExperimentalConfig,
-        Field(description="Experimental features for inference."),
-    ] = InferenceExperimentalConfig()
+    experimental: InferenceExperimentalConfig = InferenceExperimentalConfig()
+    """Experimental inference features."""
 
     @model_validator(mode="after")
     def validate_multi_node_requires_slurm(self):

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -3,7 +3,7 @@ import warnings
 from pathlib import Path
 from typing import Annotated, Any, Literal, TypeAlias
 
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field, model_validator
+from pydantic import AliasChoices, Field, model_validator
 
 from prime_rl.configs.shared import (
     BaseModelConfig,
@@ -428,9 +428,7 @@ class BufferConfig(BaseConfig):
         return self
 
 
-class TokensLengthPenaltyConfig(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class TokensLengthPenaltyConfig(BaseConfig):
     type: Literal["tokens"] = "tokens"
 
     completion_weight: float = Field(1.0, ge=0, allow_inf_nan=False)
@@ -440,9 +438,7 @@ class TokensLengthPenaltyConfig(BaseModel):
     """Weight on tool-response tokens (read from the rollout's ``*_total_tool_response_tokens`` harness metric; 0 if absent). Finite and non-negative."""
 
 
-class TurnsLengthPenaltyConfig(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class TurnsLengthPenaltyConfig(BaseConfig):
     type: Literal["turns"] = "turns"
 
 
@@ -452,16 +448,14 @@ LengthPenaltyConfig: TypeAlias = Annotated[
 ]
 
 
-class DefaultAdvantageConfig(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class DefaultAdvantageConfig(BaseConfig):
     type: Literal["default"] = "default"
 
     length_penalty: LengthPenaltyConfig | None = None
     """Correctness-gated length penalty. ``tokens`` shapes by weighted token cost; ``turns`` shapes by trajectory turn count; None disables shaping. In mixed groups, lower-cost correct rollouts get amplified advantage (up to 2x), higher-cost correct rollouts are unchanged, incorrect untouched. In all-correct groups, below-average-cost rollouts get advantage in [0, 1], others get 0."""
 
 
-class CustomAdvantageConfig(BaseModel):
+class CustomAdvantageConfig(BaseConfig):
     type: Literal["custom"] = "custom"
 
     import_path: str
@@ -478,9 +472,7 @@ AdvantageConfig: TypeAlias = Annotated[
 
 
 # Flags rare tokens generated at high entropy (Section 5.2, https://arxiv.org/abs/2510.02387).
-class GibberishFilterConfig(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class GibberishFilterConfig(BaseConfig):
     type: Literal["gibberish"] = "gibberish"
 
     enforce: bool = False
@@ -496,9 +488,7 @@ class GibberishFilterConfig(BaseModel):
 # Flags rollouts stuck in a repetition loop: emits high-confidence tokens for an extended stretch.
 # Flagged when `window` consecutive tokens are each sampled with probability above `prob_threshold`.
 # (Section 3.2, https://arxiv.org/abs/2506.13585)
-class RepetitionFilterConfig(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class RepetitionFilterConfig(BaseConfig):
     type: Literal["repetition"] = "repetition"
 
     enforce: bool = False
@@ -512,9 +502,7 @@ class RepetitionFilterConfig(BaseModel):
 
 
 # Flags rollouts with zero advantage.
-class ZeroAdvantageFilterConfig(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class ZeroAdvantageFilterConfig(BaseConfig):
     type: Literal["zero_advantage"] = "zero_advantage"
 
     enforce: bool = True
@@ -527,11 +515,11 @@ FilterConfig: TypeAlias = Annotated[
 ]
 
 
-class FileSystemWeightBroadcastConfig(BaseModel):
+class FileSystemWeightBroadcastConfig(BaseConfig):
     type: Literal["filesystem"] = "filesystem"
 
 
-class NCCLWeightBroadcastConfig(BaseModel):
+class NCCLWeightBroadcastConfig(BaseConfig):
     type: Literal["nccl"] = "nccl"
 
     host: str = "localhost"
@@ -561,10 +549,8 @@ class OrchestratorExperimentalConfig(BaseConfig):
 
 class RolloutModelConfig(BaseConfig):
     model: ModelConfig = ModelConfig()
-    """Model configuration."""
 
     client: ClientConfig = ClientConfig()
-    """Inference client configuration."""
 
 
 class OrchestratorConfig(BaseConfig):
@@ -578,10 +564,8 @@ class OrchestratorConfig(BaseConfig):
     """Teacher rollout participant (model + client). Role depends on ``training_mode``: ``opd`` — teacher computes logprobs; ``sft`` — teacher generates rollouts."""
 
     train: TrainConfig = TrainConfig()
-    """Training environments and sampling."""
 
     tokenizer: TokenizerConfig = TokenizerConfig()
-    """Tokenizer configuration."""
 
     renderer: RendererConfig = RendererConfig()
     """Client-side renderer configuration. Only consumed when ``use_renderer=true``."""
@@ -593,22 +577,17 @@ class OrchestratorConfig(BaseConfig):
     """Evaluation configuration."""
 
     buffer: BufferConfig = BufferConfig()
-    """Rollout buffer configuration."""
 
     advantage: AdvantageConfig | None = DefaultAdvantageConfig()
-    """Advantage estimator configuration."""
 
     filters: list[FilterConfig] = [GibberishFilterConfig(), RepetitionFilterConfig(), ZeroAdvantageFilterConfig()]
     """Rollout filters. Each filter can ``monitor`` (default) or ``enforce`` (skip rollouts)."""
 
     log: LogConfig = LogConfig()
-    """Logger configuration."""
 
     wandb: WandbWithExtrasConfig | None = None
-    """Weights & Biases configuration."""
 
     prime_monitor: PrimeMonitorConfig | None = None
-    """Prime Intellect monitoring configuration."""
 
     collect_inference_metrics: bool = True
     """Collect inference-server metrics (requires wandb)."""
@@ -681,7 +660,6 @@ class OrchestratorConfig(BaseConfig):
     """Allow pre-release versions when installing environments (e.g. ``verifiers>=0.1.12.dev5``). Passes ``--prerelease`` to ``prime env install``."""
 
     experimental: OrchestratorExperimentalConfig = OrchestratorExperimentalConfig()
-    """Experimental orchestrator features."""
 
     @model_validator(mode="before")
     @classmethod

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -21,105 +21,48 @@ from prime_rl.utils.config import BaseConfig
 
 
 class OptimizerConfig(BaseConfig):
-    """Per-run optimizer configuration for multi-run training."""
-
-    lr: Annotated[
-        float,
-        Field(
-            ge=0,
-            description="Learning rate for this run.",
-        ),
-    ] = 1e-4
+    lr: float = Field(1e-4, ge=0)
+    """Learning rate for this run (per-run override for multi-run training)."""
 
 
 class LoRAConfig(BaseConfig):
-    """Per-run LoRA configuration for multi-run training."""
+    name: str | None = None
+    """LoRA adapter name. If None, auto-generated from rank and alpha."""
 
-    name: Annotated[
-        str | None,
-        Field(
-            description="Name of the LoRA adapter. If None, auto-generated from rank and alpha.",
-        ),
-    ] = None
+    rank: int | None = Field(None, ge=1)
+    """LoRA rank for this run. Must be ≤ trainer's max rank. If None, uses the trainer's rank."""
 
-    rank: Annotated[
-        int | None,
-        Field(
-            ge=1,
-            description="LoRA rank for this run. Must be <= trainer's max rank. If None, uses trainer's rank.",
-        ),
-    ] = None
-
-    alpha: Annotated[
-        float | None,
-        Field(
-            ge=0,
-            description="LoRA alpha for this run. If None, uses trainer's alpha.",
-        ),
-    ] = None
+    alpha: float | None = Field(None, ge=0)
+    """LoRA alpha for this run. If None, uses the trainer's alpha."""
 
 
 class ModelConfig(BaseModelConfig):
-    """Extended model configuration with per-run LoRA settings."""
-
-    lora: Annotated[
-        LoRAConfig | None,
-        Field(
-            description="LoRA configuration. If None, LoRA is not used.",
-        ),
-    ] = None
+    lora: LoRAConfig | None = None
+    """Per-run LoRA configuration. If None, LoRA is disabled."""
 
 
 class TrainSamplingConfig(BaseConfig):
-    """Configures how tokens are sampled from the model for training. Largely follows the vLLM sampling parameters."""
+    temperature: float = Field(1.0, ge=0)
+    """Sampling temperature."""
 
-    temperature: Annotated[
-        float,
-        Field(
-            ge=0,
-            description="Temperature for sampling.",
-        ),
-    ] = 1.0
+    repetition_penalty: float = Field(1.0, ge=0)
+    """Repetition penalty. Values > 1.0 discourage repetition, < 1.0 encourage it, 1.0 disables."""
 
-    repetition_penalty: Annotated[
-        float,
-        Field(
-            ge=0,
-            description="Penalty for repeating tokens. Values > 1.0 discourage repetition, values < 1.0 encourage repetition, and 1.0 means no penalty.",
-        ),
-    ] = 1.0
+    max_completion_tokens: int | None = Field(
+        None, validation_alias=AliasChoices("max_completion_tokens", "max_tokens")
+    )
+    """Maximum output tokens per turn. If None, generates until max context length or EOS."""
 
-    max_completion_tokens: Annotated[
-        int | None,
-        Field(
-            validation_alias=AliasChoices("max_completion_tokens", "max_tokens"),
-            description="Maximum number of output tokens to generate per turn. If None, will generate until maximum context length or EOS token is hit.",
-        ),
-    ] = None
+    min_tokens: int = Field(0, ge=0)
+    """Minimum output tokens per sequence."""
 
-    min_tokens: Annotated[
-        int,
-        Field(
-            ge=0,
-            description="Minimum number of output tokens to generate per sequence.",
-        ),
-    ] = 0
-
-    seed: Annotated[
-        int | None,
-        Field(
-            description="Random seed to use for sampling. If None, no seeding is used.",
-        ),
-    ] = None
+    seed: int | None = None
+    """Random seed for sampling. If None, no seeding is used."""
 
     # Strictly speaking, extra_body is not a sampling parameter, but it is the
     # easiest way to pass arbitrary extra parameters to the server via verifiers
-    extra_body: Annotated[
-        dict[str, Any],
-        Field(
-            description="Extra body to pass with each request to the inference server. By default, it is set to an empty dictionary.",
-        ),
-    ] = {}
+    extra_body: dict[str, Any] = {}
+    """Extra body forwarded with each request to the inference server."""
 
     def to_sampling_args(self) -> dict[str, Any]:
         """Convert to OAI-compatible sampling args dict, omitting None values."""
@@ -159,64 +102,37 @@ class TrainSamplingConfig(BaseConfig):
 
 
 class EvalSamplingConfig(BaseConfig):
-    """Configures how tokens are sampled from the model for evaluation.
+    temperature: float | None = Field(None, ge=0)
+    """Sampling temperature. None defers to the inference server default."""
 
-    All sampling fields default to None, meaning the inference server's own
-    default is used. Only explicitly set fields are forwarded.
-    """
+    repetition_penalty: float | None = Field(None, ge=0)
+    """Repetition penalty. None defers to the inference server default."""
 
-    temperature: Annotated[
-        float | None,
-        Field(ge=0, description="Sampling temperature. None defers to the inference server default."),
-    ] = None
+    top_p: float | None = None
+    """Nucleus sampling threshold. None defers to the inference server default."""
 
-    repetition_penalty: Annotated[
-        float | None,
-        Field(ge=0, description="Repetition penalty. None defers to the inference server default."),
-    ] = None
+    top_k: int | None = None
+    """Top-k sampling. None defers to the inference server default."""
 
-    top_p: Annotated[
-        float | None,
-        Field(description="Nucleus sampling threshold. None defers to the inference server default."),
-    ] = None
+    min_p: float | None = Field(None, ge=0)
+    """Min-p sampling threshold. None defers to the inference server default."""
 
-    top_k: Annotated[
-        int | None,
-        Field(description="Top-k sampling. None defers to the inference server default."),
-    ] = None
+    max_completion_tokens: int | None = Field(
+        None, validation_alias=AliasChoices("max_completion_tokens", "max_tokens")
+    )
+    """Maximum output tokens per turn. None defers to the inference server default."""
 
-    min_p: Annotated[
-        float | None,
-        Field(ge=0, description="Min-p sampling threshold. None defers to the inference server default."),
-    ] = None
+    min_tokens: int | None = Field(None, ge=0)
+    """Minimum output tokens per sequence. None defers to the inference server default."""
 
-    max_completion_tokens: Annotated[
-        int | None,
-        Field(
-            validation_alias=AliasChoices("max_completion_tokens", "max_tokens"),
-            description="Maximum output tokens per turn. None defers to the inference server default.",
-        ),
-    ] = None
+    reasoning_effort: Literal["minimal", "low", "medium", "high"] | None = None
+    """Reasoning effort constraint for reasoning models."""
 
-    min_tokens: Annotated[
-        int | None,
-        Field(ge=0, description="Minimum output tokens per sequence. None defers to the inference server default."),
-    ] = None
+    seed: int | None = None
+    """Random seed for sampling. None means no seeding."""
 
-    reasoning_effort: Annotated[
-        Literal["minimal", "low", "medium", "high"] | None,
-        Field(description="Reasoning effort constraint for reasoning models."),
-    ] = None
-
-    seed: Annotated[
-        int | None,
-        Field(description="Random seed for sampling. None means no seeding."),
-    ] = None
-
-    extra_body: Annotated[
-        dict[str, Any],
-        Field(description="Extra body parameters forwarded to the inference server."),
-    ] = {}
+    extra_body: dict[str, Any] = {}
+    """Extra body parameters forwarded to the inference server."""
 
     def to_sampling_args(self) -> dict[str, Any]:
         """Convert to OAI-compatible sampling args dict. Only includes non-None fields."""
@@ -260,82 +176,35 @@ class EvalSamplingConfig(BaseConfig):
 
 
 class EnvConfig(BaseConfig):
-    """Base environment configuration."""
+    id: str = "reverse-text"
+    """Registered verifiers environment ID (e.g. ``math-env``, ``primeintellect/math-env``). May include an ``@version`` suffix for installation."""
 
-    id: Annotated[
-        str,
-        Field(
-            description="Registered verifiers environment ID (e.g. 'math-env', 'primeintellect/math-env'). May include an @version suffix for installation."
-        ),
-    ] = "reverse-text"
+    name: str | None = None
+    """Display name for this environment in logs, metrics, and buffer keys. Defaults to the ``id`` without ``@version``. Must be unique across all envs in the same group."""
 
-    name: Annotated[
-        str | None,
-        Field(
-            description="Display name for this environment in logs, metrics, and buffer keys. Defaults to the id (without @version). Must be unique across all envs in the same group."
-        ),
-    ] = None
+    args: dict = {}
+    """Keyword arguments forwarded to ``vf.load_environment``. See the environment's docstring for accepted args."""
 
-    args: Annotated[
-        dict,
-        Field(
-            description="Keyword arguments forwarded to vf.load_environment. See the environment's docstring for accepted args."
-        ),
-    ] = {}
+    extra_env_kwargs: dict[str, Any] = {}
+    """Extra kwargs passed to the env (e.g. ``seq_len``, ``max_total_completion_tokens``). Auto-populated by the orchestrator; user overrides are generally discouraged. The main use case is matching ``extra_env_kwargs`` when running an env in an isolated environment server."""
 
-    extra_env_kwargs: Annotated[
-        dict[str, Any],
-        Field(
-            description=(
-                "Extra kwargs passed to an env (e.g. seq_len, max_total_completion_tokens). This field is auto-populated on the orchestrator for all envs. It is generally NOT recommended for this field to be overriden by the user. It's main use case is to match the extra_env_kwargs when running an env in an isolated environment server."
-            ),
-        ),
-    ] = {}
+    address: str | None = None
+    """ZMQ address of an external env server (e.g. ``tcp://host:5000``). When set, the orchestrator connects to this server instead of spawning one; when None, a subprocess env server is spawned automatically."""
 
-    address: Annotated[
-        str | None,
-        Field(
-            description="ZMQ address of an external env server (e.g. 'tcp://host:5000'). When set, the orchestrator connects to this server instead of spawning one. When None (default), a subprocess env server is spawned automatically."
-        ),
-    ] = None
+    num_workers: int | Literal["auto"] = "auto"
+    """Worker processes for the spawned env server. ``auto`` scales to 1 worker per 256 concurrent rollouts. Ignored when ``address`` is set."""
 
-    num_workers: Annotated[
-        int | Literal["auto"],
-        Field(
-            description="Number of worker processes for the spawned env server. 'auto' scales to 1 worker per 256 concurrent rollouts. Ignored when address is set (external server)."
-        ),
-    ] = "auto"
+    ratio: float | None = Field(None, gt=0)
+    """Sampling weight for this environment in the buffer. When None for all envs, samples uniformly across all available problems. When set, must be set on all envs — values are relative weights normalized to probabilities (e.g. [1, 1] and [0.5, 0.5] are equivalent)."""
 
-    ratio: Annotated[
-        float | None,
-        Field(
-            gt=0,
-            description="Sampling weight for this environment in the buffer. When None for all envs, samples uniformly across all available problems. When set, must be set on all envs — values are relative weights normalized to probabilities (e.g. [1, 1] and [0.5, 0.5] are equivalent).",
-        ),
-    ] = None
+    max_retries: int = Field(0, ge=0)
+    """Times the env server retries a failed rollout before returning an error."""
 
-    max_retries: Annotated[
-        int,
-        Field(ge=0, description="Number of times the env server retries a failed rollout before returning an error."),
-    ] = 0
+    max_total_completion_tokens: int = -1
+    """Maximum total completion tokens across all turns in a multi-turn rollout. ``-1`` disables. Auto-populated into ``extra_env_kwargs``."""
 
-    max_total_completion_tokens: Annotated[
-        int,
-        Field(
-            description=(
-                "Maximum total completion tokens across all turns in a multi-turn rollout. "
-                "Set to -1 (default) to disable. Auto-populated into extra_env_kwargs."
-            ),
-        ),
-    ] = -1
-
-    timeout: Annotated[
-        float | None,
-        Field(
-            validation_alias=AliasChoices("timeout", "timeout_seconds"),
-            description="Per-rollout wall-clock timeout in seconds. Set to None (default) to disable.",
-        ),
-    ] = None
+    timeout: float | None = Field(None, validation_alias=AliasChoices("timeout", "timeout_seconds"))
+    """Per-rollout wall-clock timeout in seconds. None disables."""
 
     @property
     def stripped_id(self) -> str:
@@ -367,68 +236,36 @@ class EnvConfig(BaseConfig):
 
 
 class TrainEnvConfig(EnvConfig):
-    """Configures a training environment."""
-
-    sampling: Annotated[
-        TrainSamplingConfig,
-        Field(
-            description="Per-env sampling overrides. Unset fields inherit from the group-level train sampling config.",
-        ),
-    ] = TrainSamplingConfig()
+    sampling: TrainSamplingConfig = TrainSamplingConfig()
+    """Per-env sampling overrides. Unset fields inherit from the group-level train sampling config."""
 
 
 class EvalEnvConfig(EnvConfig):
-    """Configures an evaluation environment."""
+    sampling: EvalSamplingConfig = EvalSamplingConfig()
+    """Per-env sampling overrides. Unset fields inherit from the group-level eval sampling config."""
 
-    sampling: Annotated[
-        EvalSamplingConfig,
-        Field(
-            description="Per-env sampling overrides. Unset fields inherit from the group-level eval sampling config.",
-        ),
-    ] = EvalSamplingConfig()
+    num_examples: int = -1
+    """Eval examples to sample from the dataset. ``-1`` uses all available examples."""
 
-    num_examples: Annotated[
-        int,
-        Field(
-            description="Number of eval examples to sample from the dataset. Set to -1 to use all available examples."
-        ),
-    ] = -1
+    rollouts_per_example: int = Field(1, ge=1)
+    """Rollouts generated per example. Used for pass@k estimation (e.g. ``rollouts_per_example=8`` enables pass@1 through pass@8)."""
 
-    rollouts_per_example: Annotated[
-        int,
-        Field(
-            ge=1,
-            description="Number of rollouts generated per example. Used for pass@k estimation (e.g. rollouts_per_example=8 enables pass@1 through pass@8).",
-        ),
-    ] = 1
-
-    interval: Annotated[
-        int,
-        Field(
-            ge=1,
-            description="Per-env eval interval. If unset, inherits from the group-level eval interval.",
-        ),
-    ] = 100
+    interval: int = Field(100, ge=1)
+    """Per-env eval interval. If unset, inherits from the group-level eval interval."""
 
 
 class TrainConfig(BaseConfig):
-    """Configures training environments and their shared sampling settings."""
-
     env: list[TrainEnvConfig] = [TrainEnvConfig()]
+    """Training environments."""
 
     sampling: TrainSamplingConfig = TrainSamplingConfig()
+    """Shared training sampling configuration."""
 
-    num_workers: Annotated[
-        int | Literal["auto"],
-        Field(
-            description="Default number of worker processes for env servers. Can be overridden per env.",
-        ),
-    ] = "auto"
+    num_workers: int | Literal["auto"] = "auto"
+    """Default worker processes for env servers. Can be overridden per env."""
 
-    max_retries: Annotated[
-        int,
-        Field(ge=0, description="Default number of retries for failed rollouts. Can be overridden per env."),
-    ] = 0
+    max_retries: int = Field(0, ge=0)
+    """Default retries for failed rollouts. Can be overridden per env."""
 
     @model_validator(mode="after")
     def resolve_env_defaults(self):
@@ -467,46 +304,26 @@ class TrainConfig(BaseConfig):
 
 
 class EvalConfig(BaseConfig):
-    """Configures evaluation using verifiers environments."""
-
     env: list[EvalEnvConfig] = [EvalEnvConfig()]
+    """Evaluation environments."""
 
-    sampling: EvalSamplingConfig = Field(
-        default_factory=EvalSamplingConfig,
-        description="Shared sampling configuration for evals; can differ from training sampling.",
-    )
+    sampling: EvalSamplingConfig = Field(default_factory=EvalSamplingConfig)
+    """Shared eval sampling configuration; can differ from training sampling."""
 
-    num_examples: Annotated[
-        int,
-        Field(
-            description="Default number of eval examples per environment. Set to -1 to use all. Can be overridden per env."
-        ),
-    ] = -1
+    num_examples: int = -1
+    """Default eval examples per environment. ``-1`` uses all. Can be overridden per env."""
 
-    rollouts_per_example: Annotated[
-        int,
-        Field(ge=1, description="Default number of rollouts per example. Can be overridden per env."),
-    ] = 1
+    rollouts_per_example: int = Field(1, ge=1)
+    """Default rollouts per example. Can be overridden per env."""
 
-    num_workers: Annotated[
-        int | Literal["auto"],
-        Field(
-            description="Default number of worker processes for env servers. Can be overridden per env.",
-        ),
-    ] = "auto"
+    num_workers: int | Literal["auto"] = "auto"
+    """Default worker processes for env servers. Can be overridden per env."""
 
-    max_retries: Annotated[
-        int,
-        Field(ge=0, description="Default number of retries for failed rollouts. Can be overridden per env."),
-    ] = 0
+    max_retries: int = Field(0, ge=0)
+    """Default retries for failed rollouts. Can be overridden per env."""
 
-    interval: Annotated[
-        int,
-        Field(
-            ge=1,
-            description="Interval at which to evaluate the model.",
-        ),
-    ] = 100
+    interval: int = Field(100, ge=1)
+    """Step interval at which to evaluate the model."""
 
     @model_validator(mode="after")
     def resolve_env_defaults(self):
@@ -547,140 +364,62 @@ class EvalConfig(BaseConfig):
             )
         return self
 
-    eval_base_model: Annotated[
-        bool,
-        Field(
-            description="Whether to evaluate the base model we are training on.",
-        ),
-    ] = True
+    eval_base_model: bool = True
+    """Evaluate the base model we are training on."""
 
-    skip_eval_on_resume: Annotated[
-        bool,
-        Field(
-            validation_alias=AliasChoices("skip_eval_on_resume", "skip_eval_on_restart"),
-            description=(
-                "If True and resuming the orchestrator from a checkpoint, skip the (potentially redundant) "
-                "online eval that would otherwise run immediately at the resumed checkpoint step."
-            ),
-        ),
-    ] = True
+    skip_eval_on_resume: bool = Field(
+        True, validation_alias=AliasChoices("skip_eval_on_resume", "skip_eval_on_restart")
+    )
+    """When resuming the orchestrator from a checkpoint, skip the (potentially redundant) online eval that would otherwise run immediately at the resumed step."""
 
-    cancel_inflight_rollouts_on_eval: Annotated[
-        bool,
-        Field(
-            description="Whether to cancel in-flight training rollouts before starting online evals. This is useful to avoid congestion (e.g. do not have training + eval rollouts happening at the same time) but leads to slower training steps as rollouts get cancelled and the pipeline has to fill up after each eval",
-        ),
-    ] = False
+    cancel_inflight_rollouts_on_eval: bool = False
+    """Cancel in-flight training rollouts before starting online evals. Avoids congestion (no training + eval rollouts at the same time) at the cost of slower training steps as the pipeline has to refill after each eval."""
 
 
 class CheckpointConfig(BaseConfig):
-    """Configures checkpointing the orchestrator."""
+    interval: int | None = Field(None, ge=1)
+    """Step interval at which to save the orchestrator checkpoint."""
 
-    interval: Annotated[int | None, Field(ge=1, description="Interval at which to save the checkpoint.")] = None
+    resume_step: int | None = Field(None, ge=-1)
+    """Step to resume the orchestrator from. None starts from scratch; ``-1`` resumes from the latest checkpoint available."""
 
-    resume_step: Annotated[
-        int | None,
-        Field(
-            ge=-1,
-            description="Step to resume orchestrator from. If None, will start from scratch. If -1, will restart from latest checkpoint available.",
-        ),
-    ] = None
+    wait_for_weights_timeout: int | None = Field(None, ge=1)
+    """When resuming, wait up to this many seconds for the weight directory to appear. Useful when the orchestrator restarts while the trainer is still saving weights. If None, fail immediately when weights are not found."""
 
-    wait_for_weights_timeout: Annotated[
-        int | None,
-        Field(
-            ge=1,
-            description="When resuming, wait up to this many seconds for the weight directory to appear. Useful when the orchestrator restarts while the trainer is still saving weights. If None (default), fail immediately if weights are not found.",
-        ),
-    ] = None
+    keep_last: int | None = Field(None, ge=1)
+    """Keep at most this many recent step checkpoints on disk. If None, never clean old checkpoints based on recency."""
 
-    keep_last: Annotated[
-        int | None,
-        Field(
-            ge=1,
-            description="Keep at most this many recent step checkpoints on disk. If None, never clean old checkpoints based on recency.",
-        ),
-    ] = None
+    keep_interval: int | None = Field(None, ge=1)
+    """Keep checkpoints at every N steps permanently (e.g. ``keep_interval=100`` keeps step 100, 200, ...). If None, no interval-based keeping."""
 
-    keep_interval: Annotated[
-        int | None,
-        Field(
-            ge=1,
-            description="Keep checkpoints at every N steps permanently (e.g., keep_interval=100 keeps step 100, 200, ...). If None, no interval-based keeping.",
-        ),
-    ] = None
+    skip_progress: bool = False
+    """Skip loading the progress from checkpoint."""
 
-    skip_progress: Annotated[
-        bool,
-        Field(
-            description="Whether to skip loading the progress from checkpoint.",
-        ),
-    ] = False
-
-    skip_buffer: Annotated[
-        bool,
-        Field(
-            description="Whether to skip loading the buffer from checkpoint.",
-        ),
-    ] = False
+    skip_buffer: bool = False
+    """Skip loading the buffer from checkpoint."""
 
 
 class BufferConfig(BaseConfig):
-    """Configures the buffer for the orchestrator."""
+    seed: int | None = None
+    """Random seed for the buffer. When set, sampling from the buffer is deterministic."""
 
-    seed: Annotated[
-        int | None,
-        Field(
-            description="Random seed to use for the buffer. If set, the sampling from the buffer will be deterministic.",
-        ),
-    ] = None
+    easy_threshold: float | None = None
+    """Average-reward threshold above which a problem is classified ``easy``."""
 
-    easy_threshold: Annotated[
-        float | None,
-        Field(
-            description="Threshold for easy difficulty classification. If average reward >= this threshold, mark as easy.",
-        ),
-    ] = None
+    hard_threshold: float | None = None
+    """Average-reward threshold below which a problem is classified ``hard``."""
 
-    hard_threshold: Annotated[
-        float | None,
-        Field(
-            description="Threshold for hard difficulty classification. If average reward <= this threshold, mark as hard.",
-        ),
-    ] = None
+    easy_fraction: float = Field(0.0, ge=0, le=1)
+    """Fraction of easy problems to convert to ``normal`` when resuming or starting training. Only problems with difficulty ``normal`` are sampled."""
 
-    easy_fraction: Annotated[
-        float,
-        Field(
-            ge=0,
-            le=1,
-            description="Fraction of easy problems to convert to normal when resuming or starting training. Only problems with difficulty 'normal' are sampled.",
-        ),
-    ] = 0.0
+    hard_fraction: float = Field(0.0, ge=0, le=1)
+    """Fraction of hard problems to convert to ``normal`` when resuming or starting training. Only problems with difficulty ``normal`` are sampled."""
 
-    hard_fraction: Annotated[
-        float,
-        Field(
-            ge=0,
-            le=1,
-            description="Fraction of hard problems to convert to normal when resuming or starting training. Only problems with difficulty 'normal' are sampled.",
-        ),
-    ] = 0.0
+    online_difficulty_filtering: bool = False
+    """Filter rollouts based on difficulty. When True, rollouts with average reward 0.0 or 1.0 are not added to the buffer."""
 
-    online_difficulty_filtering: Annotated[
-        bool,
-        Field(
-            description="Whether to filter rollouts based on difficulty. If True, rollouts with average reward 0.0 or 1.0 are not added to the buffer.",
-        ),
-    ] = False
-
-    hash_keys: Annotated[
-        list[str],
-        Field(
-            min_length=1,
-            description="Keys to use for computing example hashes. Will be used to match examples from buffer checkpoints and determine buffer resume behavior.",
-        ),
-    ] = ["env_name", "prompt"]
+    hash_keys: list[str] = Field(["env_name", "prompt"], min_length=1)
+    """Keys used to compute example hashes. Used to match examples from buffer checkpoints and determine buffer resume behavior."""
 
     @model_validator(mode="after")
     def validate_thresholds(self):
@@ -690,40 +429,18 @@ class BufferConfig(BaseConfig):
 
 
 class TokensLengthPenaltyConfig(BaseModel):
-    """Length penalty by weighted token cost.
-
-    Effective cost = completion_weight * model_completion_tokens
-                   + tool_response_weight * tool_response_tokens.
-
-    Tool-response tokens are read from the rollout's harness metric
-    `*_total_tool_response_tokens` (e.g. `rlm_total_tool_response_tokens`); 0 if absent —
-    so for envs without tool accounting, only the completion term contributes regardless of weight.
-    """
-
     model_config = ConfigDict(extra="forbid")
 
     type: Literal["tokens"] = "tokens"
-    completion_weight: Annotated[
-        float,
-        Field(
-            ge=0,
-            allow_inf_nan=False,
-            description="Weight on model completion tokens. Finite and non-negative.",
-        ),
-    ] = 1.0
-    tool_response_weight: Annotated[
-        float,
-        Field(
-            ge=0,
-            allow_inf_nan=False,
-            description="Weight on tool-response tokens. Finite and non-negative.",
-        ),
-    ] = 1.0
+
+    completion_weight: float = Field(1.0, ge=0, allow_inf_nan=False)
+    """Weight on model completion tokens. Finite and non-negative."""
+
+    tool_response_weight: float = Field(1.0, ge=0, allow_inf_nan=False)
+    """Weight on tool-response tokens (read from the rollout's ``*_total_tool_response_tokens`` harness metric; 0 if absent). Finite and non-negative."""
 
 
 class TurnsLengthPenaltyConfig(BaseModel):
-    """Length penalty by trajectory turn count."""
-
     model_config = ConfigDict(extra="forbid")
 
     type: Literal["turns"] = "turns"
@@ -736,35 +453,22 @@ LengthPenaltyConfig: TypeAlias = Annotated[
 
 
 class DefaultAdvantageConfig(BaseModel):
-    """Config for the default advantage."""
-
     model_config = ConfigDict(extra="forbid")
 
     type: Literal["default"] = "default"
-    length_penalty: Annotated[
-        LengthPenaltyConfig | None,
-        Field(
-            description=(
-                "Correctness-gated length penalty. `tokens` shapes by weighted token cost, "
-                "`turns` shapes by trajectory turn count, `None` disables shaping. In mixed "
-                "groups, lower-cost correct rollouts get amplified advantage (up to 2x), higher-cost correct "
-                "rollouts are unchanged, incorrect untouched. In all-correct groups, below-average-cost "
-                "rollouts get advantage in [0, 1], others get 0."
-            )
-        ),
-    ] = None
+
+    length_penalty: LengthPenaltyConfig | None = None
+    """Correctness-gated length penalty. ``tokens`` shapes by weighted token cost; ``turns`` shapes by trajectory turn count; None disables shaping. In mixed groups, lower-cost correct rollouts get amplified advantage (up to 2x), higher-cost correct rollouts are unchanged, incorrect untouched. In all-correct groups, below-average-cost rollouts get advantage in [0, 1], others get 0."""
 
 
 class CustomAdvantageConfig(BaseModel):
-    """Config for a custom external advantage function."""
-
     type: Literal["custom"] = "custom"
-    import_path: Annotated[
-        str, Field(description="Import path to the advantage function (e.g., 'my_module.my_advantage')")
-    ]
-    kwargs: Annotated[
-        dict[str, Any], Field(default_factory=dict, description="Kwargs to pass to the advantage function")
-    ]
+
+    import_path: str
+    """Import path to the advantage function (e.g. ``my_module.my_advantage``)."""
+
+    kwargs: dict[str, Any] = Field(default_factory=dict)
+    """Kwargs forwarded to the advantage function."""
 
 
 AdvantageConfig: TypeAlias = Annotated[
@@ -773,68 +477,48 @@ AdvantageConfig: TypeAlias = Annotated[
 ]
 
 
+# Flags rare tokens generated at high entropy (Section 5.2, https://arxiv.org/abs/2510.02387).
 class GibberishFilterConfig(BaseModel):
-    """Flags rare tokens generated at high entropy (Section 5.2, https://arxiv.org/abs/2510.02387)."""
-
     model_config = ConfigDict(extra="forbid")
 
     type: Literal["gibberish"] = "gibberish"
-    enforce: Annotated[
-        bool,
-        Field(
-            description="If True, skip detected rollouts entirely so they are not sent to the trainer. If False, only track detection metrics."
-        ),
-    ] = False
-    token_id_threshold: Annotated[
-        int,
-        Field(description="Token IDs above this are candidates for gibberish. BPE tokens are sorted by merge order."),
-    ] = 100_000
-    logprob_offset: Annotated[
-        float,
-        Field(description="Offset from uniform distribution logprob. Threshold = -log(vocab_size) - logprob_offset."),
-    ] = 2.0
+
+    enforce: bool = False
+    """When True, skip detected rollouts entirely so they are not sent to the trainer. When False, only track detection metrics."""
+
+    token_id_threshold: int = 100_000
+    """Token IDs above this are candidates for gibberish. BPE tokens are sorted by merge order."""
+
+    logprob_offset: float = 2.0
+    """Offset from uniform-distribution logprob. Threshold = ``-log(vocab_size) - logprob_offset``."""
 
 
+# Flags rollouts stuck in a repetition loop: emits high-confidence tokens for an extended stretch.
+# Flagged when `window` consecutive tokens are each sampled with probability above `prob_threshold`.
+# (Section 3.2, https://arxiv.org/abs/2506.13585)
 class RepetitionFilterConfig(BaseModel):
-    """Flags rollouts where the model gets stuck in a repetition loop, emitting high-confidence tokens
-    for an extended stretch. A rollout is flagged when `window` consecutive tokens are each sampled
-    with probability above `prob_threshold`. (Section 3.2, https://arxiv.org/abs/2506.13585)"""
-
     model_config = ConfigDict(extra="forbid")
 
     type: Literal["repetition"] = "repetition"
-    enforce: Annotated[
-        bool,
-        Field(
-            description="If True, skip detected rollouts entirely so they are not sent to the trainer. If False, only track detection metrics."
-        ),
-    ] = False
-    window: Annotated[
-        int,
-        Field(ge=1, description="Number of consecutive high-probability steps before flagging."),
-    ] = 3_000
-    prob_threshold: Annotated[
-        float,
-        Field(
-            gt=0,
-            le=1,
-            description="Tokens sampled with probability above this are considered repetitive. Consecutive such tokens count toward the window.",
-        ),
-    ] = 0.99
+
+    enforce: bool = False
+    """When True, skip detected rollouts entirely so they are not sent to the trainer. When False, only track detection metrics."""
+
+    window: int = Field(3_000, ge=1)
+    """Consecutive high-probability steps required to flag the rollout."""
+
+    prob_threshold: float = Field(0.99, gt=0, le=1)
+    """Tokens sampled with probability above this are considered repetitive. Consecutive such tokens count toward the window."""
 
 
+# Flags rollouts with zero advantage.
 class ZeroAdvantageFilterConfig(BaseModel):
-    """Flags rollouts with zero advantage."""
-
     model_config = ConfigDict(extra="forbid")
 
     type: Literal["zero_advantage"] = "zero_advantage"
-    enforce: Annotated[
-        bool,
-        Field(
-            description="If True, skip detected rollouts entirely so they are not sent to the trainer. If False, only track detection metrics."
-        ),
-    ] = True
+
+    enforce: bool = True
+    """When True, skip detected rollouts entirely so they are not sent to the trainer. When False, only track detection metrics."""
 
 
 FilterConfig: TypeAlias = Annotated[
@@ -844,31 +528,26 @@ FilterConfig: TypeAlias = Annotated[
 
 
 class FileSystemWeightBroadcastConfig(BaseModel):
-    """Configures the filesystem weight broadcast."""
-
     type: Literal["filesystem"] = "filesystem"
 
 
 class NCCLWeightBroadcastConfig(BaseModel):
-    """Configures the NCCL weight broadcast."""
-
     type: Literal["nccl"] = "nccl"
 
-    host: Annotated[str, Field(description="The host to use for the NCCL broadcast.")] = "localhost"
-    port: Annotated[int, Field(description="The port to use for the NCCL broadcast.")] = 29501
-    timeout: Annotated[int, Field(description="The timeout in seconds to use for the NCCL broadcast.")] = 1200
-    quantize_in_weight_transfer: Annotated[
-        bool,
-        Field(description="Use kernel-format FP8 quantized NCCL transfer for weight updates."),
-    ] = False
+    host: str = "localhost"
+    """Host for the NCCL broadcast rendezvous."""
 
-    inference_world_size: Annotated[
-        int,
-        Field(
-            ge=1,
-            description="Total number of inference GPUs across all servers. Used by init_nccl_broadcast to compute per-server rank offsets.",
-        ),
-    ] = 1
+    port: int = 29501
+    """Port for the NCCL broadcast rendezvous."""
+
+    timeout: int = 1200
+    """Timeout in seconds for the NCCL broadcast."""
+
+    quantize_in_weight_transfer: bool = False
+    """Use kernel-format FP8 quantized NCCL transfer for weight updates."""
+
+    inference_world_size: int = Field(1, ge=1)
+    """Total inference GPUs across all servers. Used by ``init_nccl_broadcast`` to compute per-server rank offsets."""
 
 
 WeightBroadcastConfig: TypeAlias = Annotated[
@@ -877,252 +556,132 @@ WeightBroadcastConfig: TypeAlias = Annotated[
 
 
 class OrchestratorExperimentalConfig(BaseConfig):
-    """Experimental features for the orchestrator."""
+    pass
 
 
 class RolloutModelConfig(BaseConfig):
-    """Model + client pair for a rollout participant (student or teacher)."""
+    model: ModelConfig = ModelConfig()
+    """Model configuration."""
 
-    model: Annotated[
-        ModelConfig,
-        Field(description="The model configuration."),
-    ] = ModelConfig()
-
-    client: Annotated[
-        ClientConfig,
-        Field(description="The client configuration."),
-    ] = ClientConfig()
+    client: ClientConfig = ClientConfig()
+    """Inference client configuration."""
 
 
 class OrchestratorConfig(BaseConfig):
-    """Configures the orchestrator for RL training."""
+    training_mode: Literal["rl", "opd", "sft"] = "rl"
+    """Training mode. ``rl``: student generates rollouts, no teacher. ``opd``: student generates rollouts, teacher computes logprobs (teacher_tau > 0). ``sft``: teacher generates rollouts, student inference pool used for evals and weight sync."""
 
-    # Training mode: drives validation and runtime wiring
-    training_mode: Annotated[
-        Literal["rl", "opd", "sft"],
-        Field(
-            description=(
-                "Training mode. "
-                "rl: student generates rollouts, no teacher. "
-                "opd: student generates rollouts, teacher computes logprobs (teacher_tau > 0). "
-                "sft: teacher generates rollouts, student inference pool used for evals and weight sync."
-            ),
-        ),
-    ] = "rl"
+    student: RolloutModelConfig = Field(RolloutModelConfig(), validation_alias=AliasChoices("student", "model"))
+    """Student rollout participant (model + client) — the model being trained."""
 
-    # Student model + client (the model being trained)
-    student: Annotated[
-        RolloutModelConfig,
-        Field(
-            validation_alias=AliasChoices("student", "model"),
-            description="Student model configuration (the model being trained).",
-        ),
-    ] = RolloutModelConfig()
+    teacher: RolloutModelConfig | None = Field(None, validation_alias=AliasChoices("teacher", "teacher_model"))
+    """Teacher rollout participant (model + client). Role depends on ``training_mode``: ``opd`` — teacher computes logprobs; ``sft`` — teacher generates rollouts."""
 
-    # Teacher model + client (optional; role determined by training_mode)
-    teacher: Annotated[
-        RolloutModelConfig | None,
-        Field(
-            validation_alias=AliasChoices("teacher", "teacher_model"),
-            description=(
-                "Teacher model configuration. Role depends on training_mode: "
-                "opd — teacher computes logprobs; sft — teacher generates rollouts."
-            ),
-        ),
-    ] = None
-
-    # Training environments and sampling
     train: TrainConfig = TrainConfig()
+    """Training environments and sampling."""
 
-    # The tokenizer configuration
     tokenizer: TokenizerConfig = TokenizerConfig()
+    """Tokenizer configuration."""
 
-    # The renderer configuration (only used when use_renderer=True)
     renderer: RendererConfig = RendererConfig()
+    """Client-side renderer configuration. Only consumed when ``use_renderer=true``."""
 
-    # The optimizer configuration (per-run LR for multi-run training)
     optim: OptimizerConfig = OptimizerConfig()
+    """Per-run optimizer configuration for multi-run training."""
 
-    # The evaluation configuration
     eval: EvalConfig | None = None
+    """Evaluation configuration."""
 
-    # Data buffer configuration
     buffer: BufferConfig = BufferConfig()
+    """Rollout buffer configuration."""
 
-    # The advantage configuration
     advantage: AdvantageConfig | None = DefaultAdvantageConfig()
+    """Advantage estimator configuration."""
 
-    # Rollout filters (monitor by default, enforce optionally)
     filters: list[FilterConfig] = [GibberishFilterConfig(), RepetitionFilterConfig(), ZeroAdvantageFilterConfig()]
+    """Rollout filters. Each filter can ``monitor`` (default) or ``enforce`` (skip rollouts)."""
 
-    # The logging configuration
     log: LogConfig = LogConfig()
+    """Logger configuration."""
 
-    # The wandb configuration
     wandb: WandbWithExtrasConfig | None = None
+    """Weights & Biases configuration."""
 
-    # The prime monitor configuration
     prime_monitor: PrimeMonitorConfig | None = None
+    """Prime Intellect monitoring configuration."""
 
-    # Whether to collect inference server metrics (requires wandb)
     collect_inference_metrics: bool = True
+    """Collect inference-server metrics (requires wandb)."""
 
-    # The checkpoint configuration
     ckpt: CheckpointConfig | None = None
+    """Checkpoint configuration."""
 
     weight_broadcast: WeightBroadcastConfig = FileSystemWeightBroadcastConfig()
+    """Transport used to receive updated weights from the trainer."""
 
     rollout_transport: TransportConfig = FileSystemTransportConfig()
+    """Transport used to ship rollouts from orchestrator to trainer."""
 
-    output_dir: Annotated[
-        Path,
-        Field(
-            description="Directory to write outputs to. Will be populated with checkpoints, weights, rollouts and logs as subdirectories. Should be set to a persistent directory with enough disk space. This value should be distinct across experiments running on a single node. See the README for more details."
-        ),
-    ] = Path("outputs/run_default")
+    output_dir: Path = Path("outputs/run_default")
+    """Directory to write outputs to — checkpoints, weights, rollouts, and logs are written as subdirectories. Should be a persistent directory with enough disk space and unique per experiment running on a single node."""
 
-    tasks_per_minute: Annotated[
-        int | None,
-        Field(
-            ge=1,
-            description="Rate limit for tasks per environment worker, in tasks per minute. Recommended for sandbox-backed environments to prevent sandbox-not-ready errors during autoscaling. When set to None, no rate limiting is applied. Note: with multiple workers, the effective total rate equals workers × this value.",
-        ),
-    ] = None
+    tasks_per_minute: int | None = Field(None, ge=1)
+    """Rate limit per environment worker, in tasks per minute. Recommended for sandbox-backed environments to prevent sandbox-not-ready errors during autoscaling. With multiple workers, the effective total rate is ``workers × this value``. None disables rate limiting."""
 
-    batch_size: Annotated[
-        int | None,
-        Field(
-            ge=1,
-            description="Number of samples to train on per step (rollout-based batching). Set this OR token_batch_size.",
-        ),
-    ] = None
+    batch_size: int | None = Field(None, ge=1)
+    """Samples to train on per step (rollout-based batching). Set this OR ``token_batch_size``."""
 
-    token_batch_size: Annotated[
-        int | None,
-        Field(
-            ge=1,
-            description="Number of tokens to train on per step (token-based batching). Set this OR batch_size.",
-        ),
-    ] = None
+    token_batch_size: int | None = Field(None, ge=1)
+    """Tokens to train on per step (token-based batching). Set this OR ``batch_size``."""
 
-    oversampling_factor: Annotated[
-        float | None,
-        Field(
-            gt=0,
-            description=(
-                "Rollout-mode batching only. Multiplier used to derive max_inflight_rollouts from batch_size "
-                "when max_inflight_rollouts is unset. Values below 1.0 intentionally cap in-flight rollout "
-                "capacity below batch_size."
-            ),
-        ),
-    ] = None
+    oversampling_factor: float | None = Field(None, gt=0)
+    """Rollout-mode batching only. Multiplier used to derive ``max_inflight_rollouts`` from ``batch_size`` when ``max_inflight_rollouts`` is unset. Values below 1.0 intentionally cap in-flight rollout capacity below ``batch_size``."""
 
-    max_inflight_rollouts: Annotated[
-        int | None,
-        Field(
-            ge=1,
-            description=(
-                "Maximum number of rollouts to keep in-flight. Required for token-based batching. "
-                "If batch_size is set and this is unset, defaults to batch_size * oversampling_factor "
-                "(or batch_size when oversampling_factor is unset)."
-            ),
-        ),
-    ] = None
+    max_inflight_rollouts: int | None = Field(None, ge=1)
+    """Maximum number of rollouts kept in-flight. Required for token-based batching. With ``batch_size`` set, defaults to ``batch_size * oversampling_factor`` (or ``batch_size`` when ``oversampling_factor`` is unset)."""
 
-    rollouts_per_example: Annotated[
-        int,
-        Field(
-            ge=1,
-            description="Number of output sequences to return per example during training.",
-        ),
-    ] = 1
+    rollouts_per_example: int = Field(1, ge=1)
+    """Output sequences returned per example during training."""
 
-    seq_len: Annotated[
-        int,
-        Field(
-            description="Sequence length to use for training. If a sample is shorter than this, it will be padded. If a sequence is longer than this, it will be truncated.",
-        ),
-    ] = 2048
+    seq_len: int = 2048
+    """Training sequence length. Shorter samples are padded; longer samples are truncated."""
 
     # TODO(Mika): This should be automatic from the number of ZMQ connections
-    num_train_workers: Annotated[
-        int,
-        Field(default=1, ge=1, description="Number of training workers to use for training."),
-    ] = 1
+    num_train_workers: int = Field(1, ge=1)
+    """Training workers to use."""
 
-    max_steps: Annotated[
-        int | None,
-        Field(
-            description="Maximum number of training steps to run. If None, will run indefinitely.",
-        ),
-    ] = None
+    max_steps: int | None = None
+    """Maximum training steps. If None, runs indefinitely."""
 
-    max_off_policy_steps: Annotated[
-        int,
-        Field(
-            ge=0,
-            description="Maximum number of policies that are allowed to generate a single rollout. Rollouts that are generated from more than `max_off_policy_steps` steps ahead of training will be discarded. Higher values yield better throughput, but lead to more off-policyness in training.",
-        ),
-    ] = 8
+    max_off_policy_steps: int = Field(8, ge=0)
+    """Maximum policies allowed to generate a single rollout. Rollouts generated more than ``max_off_policy_steps`` ahead of training are discarded. Higher values yield better throughput at the cost of off-policy noise."""
 
-    max_error_reschedule_attempts: Annotated[
-        int | None,
-        Field(
-            ge=1,
-            description="The group is dropped from the current step's batch once this many of its dispatch rounds have returned errored or empty rollouts (the trainer proceeds with the rollouts from other groups). Counts rounds, not individual rollouts: a non-group-scoring env that dispatches `rollouts_per_example` rollouts at once still only counts one round per failed batch. `None` means retry indefinitely (legacy behavior). Useful for unblocking single-example hangs in agent envs.",
-        ),
-    ] = 3
+    max_error_reschedule_attempts: int | None = Field(3, ge=1)
+    """The group is dropped from the current step's batch once this many of its dispatch rounds have returned errored or empty rollouts (the trainer proceeds with the rollouts from other groups). Counts rounds, not individual rollouts: a non-group-scoring env that dispatches ``rollouts_per_example`` rollouts at once still only counts one round per failed batch. None retries indefinitely. Useful for unblocking single-example hangs in agent envs."""
 
-    max_async_level: Annotated[
-        int,
-        Field(
-            ge=0,
-            description="Maximum number of steps the inference can be ahead of training. If 0, will degenerate to synchronous on-policy RL. If >=1, training and inference will be overlapped.",
-        ),
-    ] = 1
+    max_async_level: int = Field(1, ge=0)
+    """Maximum steps inference can be ahead of training. ``0`` degenerates to synchronous on-policy RL; ``≥1`` overlaps training and inference."""
 
-    strict_async_level: Annotated[
-        bool,
-        Field(
-            description="Whether to strictly enforce the max async level. If True, will always ensure that the policy used for generating rollouts is exactly `max_async_level` steps ahead of training. If False, any policy that is at most `max_async_level` steps ahead of training is allowed, i.e. we always use the latest available policy.",
-        ),
-    ] = False
+    strict_async_level: bool = False
+    """Strictly enforce ``max_async_level``. When True, the rollout policy is always exactly ``max_async_level`` steps ahead of training. When False, any policy within ``max_async_level`` steps is allowed (always uses the latest available policy)."""
 
-    bench: Annotated[
-        bool,
-        Field(
-            description="Whether to run in benchmark mode. It will automatically set the maximum number of steps to run to 5, max async level to ~infinity and disable W&B.",
-        ),
-    ] = False
+    bench: bool = False
+    """Benchmark mode. Sets ``max_steps`` to 5, ``max_async_level`` to ~∞, and disables W&B."""
 
-    seed: Annotated[int | None, Field(description="Random seed for the orchestrator.")] = 42
+    seed: int | None = 42
+    """Random seed for the orchestrator."""
 
-    heartbeat: Annotated[
-        HeartbeatConfig | None, Field(description="The heartbeat config for monitoring training progress.")
-    ] = None
+    heartbeat: HeartbeatConfig | None = None
+    """BetterStack heartbeat configuration for monitoring training progress."""
 
-    use_renderer: Annotated[
-        bool,
-        Field(
-            description="Whether to use the renderer-backed TITO client (client-side tokenization via the ``renderers`` package, "
-            "served by ``/v1/generate``). When True, the ``[orchestrator.renderer]`` block "
-            "(name / tool_parser / reasoning_parser / pool_size) applies. This is the default for text-only "
-            "rollouts. Set to False to fall back to MITO (``openai_chat_completions``); VLMs and external "
-            "teacher rollouts require MITO."
-        ),
-    ] = True
+    use_renderer: bool = True
+    """Use the renderer-backed TITO client (client-side tokenization via the ``renderers`` package, served by ``/v1/generate``). When True, the ``[orchestrator.renderer]`` block applies. This is the default for text-only rollouts. False falls back to MITO (``openai_chat_completions``); VLMs and external teacher rollouts require MITO."""
 
-    env_install_prerelease: Annotated[
-        bool,
-        Field(
-            description="Allow pre-release versions when installing environments (e.g. verifiers>=0.1.12.dev5). Passes --prerelease to prime env install."
-        ),
-    ] = False
+    env_install_prerelease: bool = False
+    """Allow pre-release versions when installing environments (e.g. ``verifiers>=0.1.12.dev5``). Passes ``--prerelease`` to ``prime env install``."""
 
-    experimental: Annotated[
-        OrchestratorExperimentalConfig,
-        Field(description="Experimental features for the orchestrator."),
-    ] = OrchestratorExperimentalConfig()
+    experimental: OrchestratorExperimentalConfig = OrchestratorExperimentalConfig()
+    """Experimental orchestrator features."""
 
     @model_validator(mode="before")
     @classmethod

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -2,7 +2,7 @@ import warnings
 from pathlib import Path
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import Field, model_validator
 
 from prime_rl.configs.inference import InferenceConfig
 from prime_rl.configs.inference import WeightBroadcastConfig as InferenceWeightBroadcastConfig
@@ -132,9 +132,7 @@ class SharedWeightBroadcastConfig(BaseConfig):
     """Use kernel-format FP8 quantized NCCL transfer for weight updates. When disabled, uses default HF checkpoint-format transfer."""
 
 
-class BaseDeploymentConfig(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class BaseDeploymentConfig(BaseConfig):
     gpus_per_node: int = 8
     """GPUs per node."""
 
@@ -198,10 +196,8 @@ DeploymentConfig: TypeAlias = Annotated[
 
 class RLConfig(BaseConfig):
     trainer: TrainerConfig
-    """Trainer configuration."""
 
     orchestrator: OrchestratorConfig
-    """Orchestrator configuration."""
 
     inference: InferenceConfig | None = None
     """Inference server configuration. If None, the rl entrypoint will not start an inference server (useful for elastic inference pools or manually started servers)."""
@@ -245,13 +241,11 @@ class RLConfig(BaseConfig):
     """Shared async level. If None, falls back to the sub-config ``max_async_level``."""
 
     weight_broadcast: SharedWeightBroadcastConfig | None = None
-    """Shared weight broadcast configuration."""
 
     bench: bool = False
     """Benchmark mode. Sets trainer and orchestrator to benchmark mode and, when set, suffixes the W&B project with ``-bench``."""
 
     deployment: DeploymentConfig = SingleNodeDeploymentConfig()
-    """Deployment topology."""
 
     slurm: SlurmConfig | None = None
     """SLURM configuration. If None, runs locally."""
@@ -260,7 +254,6 @@ class RLConfig(BaseConfig):
     """Only validate and dump resolved configs, then exit early."""
 
     experimental: RLExperimentalConfig = RLExperimentalConfig()
-    """Experimental RL features."""
 
     ### Validate configs (e.g. raise for unsupported (combinations of) configs)
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -53,47 +53,38 @@ from prime_rl.utils.validation import (
 
 
 class RLExperimentalConfig(BaseConfig):
-    """Experimental features for RL training."""
+    pass
 
 
 class SharedLogConfig(BaseConfig):
-    """Configures shared logging."""
+    level: str | None = None
+    """Log level for trainer and orchestrator. When unset, each sub-config's own log level applies (defaults to ``$PRIME_LOG_LEVEL`` if set, else ``info``)."""
 
-    level: Annotated[
-        str | None,
-        Field(
-            description="The log level to use. When unset, the trainer and orchestrator log levels are used as-is (which themselves default to the PRIME_LOG_LEVEL env var if set, else 'info').",
-        ),
-    ] = None
-
-    json_logging: Annotated[
-        bool,
-        Field(description="Emit JSON logs (newline-delimited) for log aggregation (Loki, Grafana, etc.)."),
-    ] = False
+    json_logging: bool = False
+    """Emit newline-delimited JSON logs for aggregation (Loki, Grafana, etc.)."""
 
 
 class SharedWandbConfig(BaseConfig):
-    """Configures shared W&B configs."""
+    project: str | None = "prime-rl"
+    """W&B project."""
 
-    project: Annotated[str | None, Field(description="The W&B project to use.")] = "prime-rl"
+    entity: str | None = None
+    """W&B entity."""
 
-    entity: Annotated[str | None, Field(description="The W&B entity to use.")] = None
+    name: str | None = None
+    """W&B run name."""
 
-    name: Annotated[str | None, Field(description="The W&B run name to use.")] = None
+    group: str | None = None
+    """W&B group."""
 
-    group: Annotated[str | None, Field(description="The W&B group to use.")] = None
+    tags: list[str] | None = None
+    """W&B tags attached to the run."""
 
-    tags: Annotated[list[str] | None, Field(description="The W&B tags to attach to the run.")] = None
+    offline: bool | None = False
+    """Run W&B in offline mode."""
 
-    offline: Annotated[bool | None, Field(description="Whether to run W&B in offline mode.")] = False
-
-    shared: Annotated[
-        bool,
-        Field(
-            description="Use shared W&B mode to log trainer and orchestrator metrics to a single run. "
-            "Requires wandb SDK >= 0.19.9. Incompatible with offline mode.",
-        ),
-    ] = True
+    shared: bool = True
+    """Log trainer and orchestrator metrics to a single shared W&B run. Requires wandb SDK ≥ 0.19.9. Incompatible with offline mode."""
 
     @model_validator(mode="after")
     def validate_shared_not_offline(self):
@@ -103,88 +94,62 @@ class SharedWandbConfig(BaseConfig):
 
 
 class SharedCheckpointConfig(BaseConfig):
-    """Configures shared checkpoint configs."""
+    output_dir: Path | None = None
+    """Override directory for checkpoints and weights. When set, checkpoints and weight snapshots are written here instead of under the trainer ``output_dir``."""
 
-    output_dir: Annotated[
-        Path | None,
-        Field(
-            description="Override directory for checkpoints and weights. When set, checkpoints and weight snapshots are written here instead of under the trainer output_dir.",
-        ),
-    ] = None
+    interval: int | None = None
+    """Interval at which to save checkpoints."""
 
-    interval: Annotated[int | None, Field(description="The interval at which to save checkpoints.")] = None
+    resume_step: int | None = None
+    """Step to resume from. If None, does not resume from a checkpoint."""
 
-    resume_step: Annotated[
-        int | None, Field(description="The step to resume from. If None, will not resume from a checkpoint.")
-    ] = None
+    keep_last: int | None = Field(None, ge=1)
+    """Keep at most this many recent step checkpoints on disk. If None, never clean old checkpoints based on recency."""
 
-    keep_last: Annotated[
-        int | None,
-        Field(
-            ge=1,
-            description="Keep at most this many recent step checkpoints on disk. If None, never clean old checkpoints based on recency.",
-        ),
-    ] = None
-
-    keep_interval: Annotated[
-        int | None,
-        Field(
-            ge=1,
-            description="Keep checkpoints at every N steps permanently (e.g., keep_interval=100 keeps step 100, 200, ...). If None, no interval-based keeping.",
-        ),
-    ] = None
+    keep_interval: int | None = Field(None, ge=1)
+    """Keep checkpoints at every N steps permanently (e.g. ``keep_interval=100`` keeps step 100, 200, ...). If None, no interval-based keeping."""
 
 
 class SharedModelConfig(BaseConfig):
-    """Configures shared model settings."""
+    name: str = "Qwen/Qwen3-0.6B"
+    """HF model name or local path."""
 
-    name: Annotated[
-        str,
-        Field(description="The name of the model to use."),
-    ] = "Qwen/Qwen3-0.6B"
-
-    vlm: Annotated[
-        "VLMConfig | None",
-        Field(description="VLM configuration. Set to enable vision-language model support."),
-    ] = None
+    vlm: "VLMConfig | None" = None
+    """VLM configuration. Set this to enable vision-language model support."""
 
 
 class SharedWeightBroadcastConfig(BaseConfig):
-    """Configures shared weight broadcast settings."""
+    type: Literal["nccl", "filesystem"] = "filesystem"
+    """Weight broadcast transport."""
 
-    type: Annotated[Literal["nccl", "filesystem"], Field(description="The type of weight broadcast to use.")] = (
-        "filesystem"
-    )
+    port: int = 29501
+    """Port for NCCL weight broadcast."""
 
-    port: Annotated[int, Field(description="The port to use for NCCL weight broadcast.")] = 29501
-    timeout: Annotated[int, Field(description="The timeout in seconds for NCCL weight broadcast.")] = 1200
-    quantize_in_weight_transfer: Annotated[
-        bool,
-        Field(
-            description=(
-                "Use kernel-format FP8 quantized NCCL transfer for weight updates. "
-                "When disabled, uses default HF checkpoint-format transfer."
-            ),
-        ),
-    ] = False
+    timeout: int = 1200
+    """Timeout in seconds for NCCL weight broadcast."""
+
+    quantize_in_weight_transfer: bool = False
+    """Use kernel-format FP8 quantized NCCL transfer for weight updates. When disabled, uses default HF checkpoint-format transfer."""
 
 
 class BaseDeploymentConfig(BaseModel):
-    """Configures a base deployment."""
-
     model_config = ConfigDict(extra="forbid")
 
-    gpus_per_node: Annotated[int, Field(description="Number of GPUs per node.")] = 8
+    gpus_per_node: int = 8
+    """GPUs per node."""
 
 
 class SingleNodeDeploymentConfig(BaseDeploymentConfig):
-    """Configures a single node deployment."""
-
     type: Literal["single_node"] = "single_node"
 
-    num_train_gpus: Annotated[int, Field(description="Number of training GPUs")] = 1
-    num_infer_gpus: Annotated[int, Field(description="Number of inference GPUs")] = 1
-    num_teacher_gpus: Annotated[int | None, Field(description="Number of teacher inference GPUs")] = None
+    num_train_gpus: int = 1
+    """GPUs allocated to the trainer."""
+
+    num_infer_gpus: int = 1
+    """GPUs allocated to inference."""
+
+    num_teacher_gpus: int | None = None
+    """GPUs allocated to teacher inference (None disables the teacher server)."""
 
     @model_validator(mode="after")
     def validate_gpu_count(self):
@@ -198,33 +163,22 @@ class SingleNodeDeploymentConfig(BaseDeploymentConfig):
 
 
 class MultiNodeDeploymentConfig(BaseDeploymentConfig):
-    """Configures a multi node deployment."""
-
     type: Literal["multi_node"] = "multi_node"
 
-    num_train_nodes: Annotated[int, Field(description="Number of training nodes.")]
-    num_infer_nodes: Annotated[
-        int,
-        Field(
-            ge=0,
-            description="Number of inference nodes per replica. Set to 0 to skip inference and orchestrator (requires fake data).",
-        ),
-    ]
-    num_infer_replicas: Annotated[
-        int,
-        Field(
-            ge=1,
-            description="Number of independent inference replicas. Total inference nodes = num_infer_nodes * num_infer_replicas.",
-        ),
-    ] = 1
-    num_teacher_nodes: Annotated[int | None, Field(description="Number of teacher inference nodes.")] = None
+    num_train_nodes: int
+    """Training nodes."""
 
-    nodes_per_fsdp_group: Annotated[
-        int | None,
-        Field(
-            description="Number of training nodes per FSDP island. Auto-sets trainer.dp_replicate = num_train_nodes / nodes_per_fsdp_group."
-        ),
-    ] = None
+    num_infer_nodes: int = Field(ge=0)
+    """Inference nodes per replica. Set to 0 to skip inference and orchestrator (requires fake data)."""
+
+    num_infer_replicas: int = Field(1, ge=1)
+    """Independent inference replicas. Total inference nodes = ``num_infer_nodes * num_infer_replicas``."""
+
+    num_teacher_nodes: int | None = None
+    """Teacher inference nodes."""
+
+    nodes_per_fsdp_group: int | None = None
+    """Training nodes per FSDP island. Auto-sets ``trainer.dp_replicate = num_train_nodes / nodes_per_fsdp_group``."""
 
     @property
     def total_infer_nodes(self) -> int:
@@ -243,127 +197,70 @@ DeploymentConfig: TypeAlias = Annotated[
 
 
 class RLConfig(BaseConfig):
-    """Configures an RL training run."""
-
     trainer: TrainerConfig
+    """Trainer configuration."""
+
     orchestrator: OrchestratorConfig
-    inference: Annotated[
-        InferenceConfig | None,
-        Field(
-            description="The inference config. If None, the rl entrypoint will not start an inference server (useful for elastic inference pools or manually started servers)."
-        ),
-    ] = None
+    """Orchestrator configuration."""
 
-    teacher_inference: Annotated[
-        InferenceConfig | None,
-        Field(
-            description="Teacher inference config. If None, will use the same config as inference or a default config. Only used when teacher GPUs or nodes are set."
-        ),
-    ] = None
+    inference: InferenceConfig | None = None
+    """Inference server configuration. If None, the rl entrypoint will not start an inference server (useful for elastic inference pools or manually started servers)."""
 
-    output_dir: Annotated[
-        Path,
-        Field(
-            description="The directory to store the outputs. Should be set to a unique directory identifying the experiment."
-        ),
-    ] = Path("outputs")
+    teacher_inference: InferenceConfig | None = None
+    """Teacher inference server configuration. If None, falls back to the same config as ``inference`` (or a default). Only used when teacher GPUs/nodes are set."""
 
-    clean_output_dir: Annotated[
-        bool,
-        Field(
-            description="If true, delete the output directory before starting training. Required to overwrite an output directory that contains checkpoints from a previous run when not resuming.",
-        ),
-    ] = False
+    output_dir: Path = Path("outputs")
+    """Output directory. Should be unique per experiment."""
+
+    clean_output_dir: bool = False
+    """Delete the output directory before starting training. Required to overwrite an output directory that contains checkpoints from a previous run when not resuming."""
 
     ### Shared configurations
 
-    log: Annotated[
-        SharedLogConfig,
-        Field(
-            description="Shared log configs. If None, will fallback to the log configs specified on submodule configs."
-        ),
-    ] = SharedLogConfig()
+    log: SharedLogConfig = SharedLogConfig()
+    """Shared log config. Propagated to trainer and orchestrator."""
 
-    ckpt: Annotated[
-        SharedCheckpointConfig | None,
-        Field(
-            description="Shared checkpoint configs. If None, will fallback to the checkpoint configs specified on submodule configs."
-        ),
-    ] = None
+    ckpt: SharedCheckpointConfig | None = None
+    """Shared checkpoint config. If None, falls back to the sub-config checkpoint settings."""
 
-    wandb: Annotated[
-        SharedWandbConfig | None,
-        Field(
-            description="Shared W&B configs. If None, will fallback to the W&B configs specified on submodule configs."
-        ),
-    ] = None
+    wandb: SharedWandbConfig | None = None
+    """Shared W&B config. If None, falls back to the sub-config W&B settings."""
 
-    model: Annotated[
-        SharedModelConfig | None,
-        Field(
-            description="Shared model configs. If None, will fallback to the model configs specified on submodule configs."
-        ),
-    ] = None
+    model: SharedModelConfig | None = None
+    """Shared model config. If None, falls back to the sub-config model settings."""
 
-    tokenizer: Annotated[
-        TokenizerConfig | None,
-        Field(
-            description="Shared tokenizer config. Propagated to trainer, orchestrator, and inference. "
-            "If None, each component uses its own tokenizer config (defaulting to model name).",
-        ),
-    ] = None
+    tokenizer: TokenizerConfig | None = None
+    """Shared tokenizer config. Propagated to trainer, orchestrator, and inference. If None, each component uses its own tokenizer config (defaulting to model name)."""
 
-    max_steps: Annotated[
-        int | None,
-        Field(
-            description="The maximum number of steps to train for. If None, will fallback to the max steps specified on submodule configs."
-        ),
-    ] = None
+    max_steps: int | None = None
+    """Shared maximum training steps. If None, falls back to the sub-config ``max_steps``."""
 
-    max_model_len: Annotated[
-        int | None,
-        Field(
-            description="The maximum model length to use. If None, will fallback to the max model length specified on submodule configs."
-        ),
-    ] = None
+    max_model_len: int | None = None
+    """Shared maximum model context length. If None, falls back to the sub-config ``max_model_len``."""
 
-    seq_len: Annotated[
-        int | None,
-        Field(
-            description="Shared sequence length. Propagates to trainer.model.seq_len and orchestrator.seq_len, "
-            "but only for those not explicitly set in the config. "
-            "Explicitly set per-component values always take precedence."
-        ),
-    ] = None
+    seq_len: int | None = None
+    """Shared sequence length. Propagates to ``trainer.model.seq_len`` and ``orchestrator.seq_len`` only when those values were not explicitly set; explicit per-component values always win."""
 
-    max_async_level: Annotated[
-        int | None,
-        Field(
-            description="The async level to use. If None, will fallback to the async level specified on submodule configs."
-        ),
-    ] = None
+    max_async_level: int | None = None
+    """Shared async level. If None, falls back to the sub-config ``max_async_level``."""
 
-    weight_broadcast: Annotated[
-        SharedWeightBroadcastConfig | None, Field(description="The weight broadcast config.")
-    ] = None
+    weight_broadcast: SharedWeightBroadcastConfig | None = None
+    """Shared weight broadcast configuration."""
 
-    bench: Annotated[
-        bool,
-        Field(
-            description="Whether to run in benchmark mode. Automatically sets the trainer and orchestrator to benchmark mode and, if present, suffixes the W&B project with `-bench`.",
-        ),
-    ] = False
+    bench: bool = False
+    """Benchmark mode. Sets trainer and orchestrator to benchmark mode and, when set, suffixes the W&B project with ``-bench``."""
 
     deployment: DeploymentConfig = SingleNodeDeploymentConfig()
+    """Deployment topology."""
 
-    slurm: Annotated[SlurmConfig | None, Field(description="SLURM configuration. If None, will run locally.")] = None
+    slurm: SlurmConfig | None = None
+    """SLURM configuration. If None, runs locally."""
 
-    dry_run: Annotated[bool, Field(description="Only validate and dump resolved configs and exit early.")] = False
+    dry_run: bool = False
+    """Only validate and dump resolved configs, then exit early."""
 
-    experimental: Annotated[
-        RLExperimentalConfig,
-        Field(description="Experimental features for RL training."),
-    ] = RLExperimentalConfig()
+    experimental: RLExperimentalConfig = RLExperimentalConfig()
+    """Experimental RL features."""
 
     ### Validate configs (e.g. raise for unsupported (combinations of) configs)
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -2,7 +2,7 @@ import warnings
 from pathlib import Path
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import Field, model_validator
 
 from prime_rl.configs.shared import (
     HeartbeatConfig,
@@ -25,7 +25,7 @@ from prime_rl.configs.trainer import (
 from prime_rl.utils.config import BaseConfig, find_package_resource
 
 
-class BaseDataConfig(BaseModel):
+class BaseDataConfig(BaseConfig):
     batch_size: int = Field(128, ge=1)
     """Global batch size."""
 
@@ -128,15 +128,12 @@ class SFTValConfig(BaseConfig):
     """Run validation before the first training step."""
 
     data: SFTDataConfig
-    """Validation data configuration."""
 
 
 DataConfig: TypeAlias = Annotated[FakeDataConfig | SFTDataConfig, Field(discriminator="type")]
 
 
-class BaseDeploymentConfig(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class BaseDeploymentConfig(BaseConfig):
     gpus_per_node: int = 8
     """GPUs per node."""
 
@@ -175,10 +172,8 @@ class SFTExperimentalConfig(BaseConfig):
 
 class SFTConfig(BaseConfig):
     model: ModelConfig = ModelConfig()
-    """Model configuration."""
 
     tokenizer: TokenizerConfig = TokenizerConfig()
-    """Tokenizer configuration."""
 
     renderer: RendererConfig = RendererConfig()
     """Client-side renderer configuration. Only consumed when ``use_renderer=true``."""
@@ -187,25 +182,19 @@ class SFTConfig(BaseConfig):
     """Tokenize SFT samples through the ``renderers`` library (single ``render()`` + ``message_indices`` mask) instead of the default ``build_incremental_token_mask`` path. Required for chat templates that render position-dependently (e.g. Qwen3, Qwen3.5)."""
 
     data: DataConfig = SFTDataConfig()
-    """Training data configuration."""
 
     val: SFTValConfig | None = None
     """Validation configuration. If None, no validation runs."""
 
     optim: OptimizerConfig = AdamWConfig()
-    """Optimizer configuration."""
 
     scheduler: SchedulerConfig = ConstantSchedulerConfig()
-    """Learning-rate scheduler configuration."""
 
     ckpt: CheckpointConfig | None = None
-    """Checkpoint configuration."""
 
     log: TrainerLogConfig = TrainerLogConfig()
-    """Logger configuration."""
 
     wandb: WandbConfig | None = None
-    """Weights & Biases configuration."""
 
     output_dir: Path = Path("outputs")
     """Directory to write outputs to — checkpoints and logs are written as subdirectories. Should be a persistent directory with enough disk space and unique per experiment running on a single node."""
@@ -241,7 +230,6 @@ class SFTConfig(BaseConfig):
     """BetterStack heartbeat configuration for monitoring training progress."""
 
     deployment: SFTDeploymentConfig = SingleNodeDeploymentConfig()
-    """Deployment topology."""
 
     slurm: SlurmConfig | None = None
     """SLURM configuration. When set, the run is submitted as a SLURM job instead of running locally."""
@@ -250,7 +238,6 @@ class SFTConfig(BaseConfig):
     """Only validate and dump resolved configs, then exit early."""
 
     experimental: SFTExperimentalConfig = SFTExperimentalConfig()
-    """Experimental SFT features."""
 
     ### Pre-validation normalization
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -26,12 +26,17 @@ from prime_rl.utils.config import BaseConfig, find_package_resource
 
 
 class BaseDataConfig(BaseModel):
-    """Base config for SFT data."""
+    batch_size: int = Field(128, ge=1)
+    """Global batch size."""
 
-    batch_size: Annotated[int, Field(ge=1)] = 128
-    seq_len: Annotated[int, Field(ge=1)] = 128
+    seq_len: int = Field(128, ge=1)
+    """Sequence length."""
+
     pack_function: Literal["cat", "stack"] = "cat"
-    micro_batch_size: Annotated[int, Field(ge=1)] = 1
+    """Sample packing strategy. ``cat`` concatenates; ``stack`` requires ``seq_len`` divisible by 256."""
+
+    micro_batch_size: int = Field(1, ge=1)
+    """Per-step micro batch size. ``batch_size`` must be divisible by this."""
 
     @model_validator(mode="after")
     def validate_batch_size(self):
@@ -43,50 +48,56 @@ class BaseDataConfig(BaseModel):
 
 
 class FakeDataConfig(BaseDataConfig):
-    """Configures fake data used for debugging."""
-
     type: Literal["fake"] = "fake"
 
     length: Literal["fixed", "variable"] = "fixed"
+    """Use fixed-length samples or variable-length samples."""
+
     input_ids: Literal["increasing", "random"] = "increasing"
+    """Token id generator: ``increasing`` for deterministic sequences, ``random`` for random ids."""
 
 
 class LossMaskConfig(BaseConfig):
-    """Configures which message types contribute to the loss. If True, the loss_mask will be True and the message type will contribute to the loss."""
+    system: bool = False
+    """System messages contribute to the loss."""
 
-    system: Annotated[bool, Field(description="Whether system messages contribute to the loss.")] = False
-    user: Annotated[bool, Field(description="Whether user messages contribute to the loss.")] = False
-    assistant: Annotated[bool, Field(description="Whether assistant messages contribute to the loss.")] = True
-    tool: Annotated[bool, Field(description="Whether tool messages contribute to the loss.")] = False
+    user: bool = False
+    """User messages contribute to the loss."""
+
+    assistant: bool = True
+    """Assistant messages contribute to the loss."""
+
+    tool: bool = False
+    """Tool messages contribute to the loss."""
 
 
 class SFTDataConfig(BaseDataConfig):
-    """Configures the data used for training."""
-
     type: Literal["sft"] = "sft"
 
-    name: Annotated[str, Field(description="Name or path of the HF dataset to use.")] = (
-        "PrimeIntellect/Reverse-Text-SFT"
-    )
-    subsets: Annotated[list[str] | None, Field(description="Subsets to use from the HF dataset.")] = None
-    splits: Annotated[list[str] | None, Field(description="Splits to use from the HF dataset.")] = None
-    probabilities: Annotated[list[float] | None, Field(description="Probabilities to use for each subset/split.")] = (
-        None
-    )
-    stopping_strategy: Annotated[
-        Literal["first_exhausted", "all_exhausted"],
-        Field(description=""),
-    ] = "all_exhausted"
-    shuffle: Annotated[bool, Field(description="Whether to shuffle the dataset at the beginning of each epoch.")] = True
-    seed: Annotated[
-        int,
-        Field(
-            description="Random seed to use for shuffling the dataset. We also shuffle at the end of each epoch by adding epoch count to the seed."
-        ),
-    ] = 0
+    name: str = "PrimeIntellect/Reverse-Text-SFT"
+    """HF dataset name or path."""
+
+    subsets: list[str] | None = None
+    """Subsets to load from the HF dataset."""
+
+    splits: list[str] | None = None
+    """Splits to load from the HF dataset."""
+
+    probabilities: list[float] | None = None
+    """Sampling probabilities for each subset/split."""
+
+    stopping_strategy: Literal["first_exhausted", "all_exhausted"] = "all_exhausted"
+    """Stopping strategy when interleaving multiple subsets/splits."""
+
+    shuffle: bool = True
+    """Shuffle the dataset at the start of each epoch."""
+
+    seed: int = 0
+    """Random seed for shuffling. Re-shuffled per epoch by adding the epoch count to the seed."""
 
     # Configuring
     loss_mask: LossMaskConfig = LossMaskConfig()
+    """Which message types contribute to the loss."""
 
     @model_validator(mode="after")
     def validate_subsets_and_splits(self):
@@ -110,28 +121,31 @@ class SFTDataConfig(BaseDataConfig):
 
 
 class SFTValConfig(BaseConfig):
-    interval: Annotated[int, Field(ge=1, description="Run validation every N training steps.")] = 50
-    eval_on_start: Annotated[bool, Field(description="Run validation before the first training step.")] = False
+    interval: int = Field(50, ge=1)
+    """Run validation every N training steps."""
+
+    eval_on_start: bool = False
+    """Run validation before the first training step."""
+
     data: SFTDataConfig
+    """Validation data configuration."""
 
 
 DataConfig: TypeAlias = Annotated[FakeDataConfig | SFTDataConfig, Field(discriminator="type")]
 
 
 class BaseDeploymentConfig(BaseModel):
-    """Base deployment config for SFT."""
-
     model_config = ConfigDict(extra="forbid")
 
-    gpus_per_node: Annotated[int, Field(description="Number of GPUs per node.")] = 8
+    gpus_per_node: int = 8
+    """GPUs per node."""
 
 
 class SingleNodeDeploymentConfig(BaseDeploymentConfig):
-    """Configures a single-node SFT deployment."""
-
     type: Literal["single_node"] = "single_node"
 
-    num_gpus: Annotated[int, Field(description="Number of GPUs.")] = 1
+    num_gpus: int = 1
+    """GPUs to use."""
 
     @model_validator(mode="after")
     def validate_gpu_count(self):
@@ -141,18 +155,13 @@ class SingleNodeDeploymentConfig(BaseDeploymentConfig):
 
 
 class MultiNodeDeploymentConfig(BaseDeploymentConfig):
-    """Configures a multi-node SFT deployment."""
-
     type: Literal["multi_node"] = "multi_node"
 
-    num_nodes: Annotated[int, Field(description="Number of training nodes.")] = 2
+    num_nodes: int = 2
+    """Training nodes."""
 
-    nodes_per_fsdp_group: Annotated[
-        int | None,
-        Field(
-            description="Number of nodes per FSDP island. Auto-sets model.dp_replicate = num_nodes / nodes_per_fsdp_group."
-        ),
-    ] = None
+    nodes_per_fsdp_group: int | None = None
+    """Nodes per FSDP island. Auto-sets ``model.dp_replicate = num_nodes / nodes_per_fsdp_group``."""
 
 
 SFTDeploymentConfig: TypeAlias = Annotated[
@@ -161,139 +170,87 @@ SFTDeploymentConfig: TypeAlias = Annotated[
 
 
 class SFTExperimentalConfig(BaseConfig):
-    """Experimental features for SFT training."""
+    pass
 
 
 class SFTConfig(BaseConfig):
-    """Configures the SFT trainer"""
-
-    # The model configuration
     model: ModelConfig = ModelConfig()
+    """Model configuration."""
 
-    # The tokenizer configuration
     tokenizer: TokenizerConfig = TokenizerConfig()
+    """Tokenizer configuration."""
 
-    # The renderer configuration (only used when use_renderer=True)
     renderer: RendererConfig = RendererConfig()
+    """Client-side renderer configuration. Only consumed when ``use_renderer=true``."""
 
-    use_renderer: Annotated[
-        bool,
-        Field(
-            description=(
-                "If True, tokenize SFT samples through the `renderers` library "
-                "(single render() + message_indices mask) instead of the default "
-                "`build_incremental_token_mask` path. Required for chat templates "
-                "that render position-dependently (e.g. Qwen3, Qwen3.5)."
-            ),
-        ),
-    ] = False
+    use_renderer: bool = False
+    """Tokenize SFT samples through the ``renderers`` library (single ``render()`` + ``message_indices`` mask) instead of the default ``build_incremental_token_mask`` path. Required for chat templates that render position-dependently (e.g. Qwen3, Qwen3.5)."""
 
-    # The data configuration
     data: DataConfig = SFTDataConfig()
+    """Training data configuration."""
 
-    # Optional validation configuration
     val: SFTValConfig | None = None
+    """Validation configuration. If None, no validation runs."""
 
-    # The optimizer configuration
     optim: OptimizerConfig = AdamWConfig()
+    """Optimizer configuration."""
 
-    # The learning rate scheduler configuration
     scheduler: SchedulerConfig = ConstantSchedulerConfig()
+    """Learning-rate scheduler configuration."""
 
-    # The checkpoint configuration
     ckpt: CheckpointConfig | None = None
+    """Checkpoint configuration."""
 
-    # The logging configuration
     log: TrainerLogConfig = TrainerLogConfig()
+    """Logger configuration."""
 
-    # The wandb configuration
     wandb: WandbConfig | None = None
+    """Weights & Biases configuration."""
 
-    output_dir: Annotated[
-        Path,
-        Field(
-            description="Directory to write outputs to. Will be populated with checkpoints and logs as subdirectories. Should be set to a persistent directory with enough disk space. This value should be distinct across experiments running on a single node. See the README for more details."
-        ),
-    ] = Path("outputs")
+    output_dir: Path = Path("outputs")
+    """Directory to write outputs to — checkpoints and logs are written as subdirectories. Should be a persistent directory with enough disk space and unique per experiment running on a single node."""
 
-    clean_output_dir: Annotated[
-        bool,
-        Field(
-            description="If true, delete the output directory before starting training. Required to overwrite an output directory that contains checkpoints from a previous run when not resuming.",
-        ),
-    ] = False
+    clean_output_dir: bool = False
+    """Delete the output directory before starting training. Required to overwrite an output directory that contains checkpoints from a previous run when not resuming."""
 
-    matmul_precision: Annotated[
-        Literal["highest", "high", "medium"],
-        Field(
-            description=(
-                "Precision for float32 matrix multiplications. "
-                "Use 'highest' for full FP32 (required on ROCm/AMD GPUs to avoid "
-                "catastrophic precision loss in softmax over large vocabularies). "
-                "Use 'high' to enable TF32 on NVIDIA GPUs for a speedup with minor "
-                "precision tradeoff. See torch.set_float32_matmul_precision docs."
-            ),
-        ),
-    ] = "high"
+    matmul_precision: Literal["highest", "high", "medium"] = "high"
+    """Precision for float32 matrix multiplications. ``highest`` is full FP32 (required on ROCm/AMD GPUs to avoid catastrophic precision loss in softmax over large vocabularies). ``high`` enables TF32 on NVIDIA GPUs for a speedup with minor precision tradeoff. See ``torch.set_float32_matmul_precision``."""
 
-    max_steps: Annotated[
-        int | None,
-        Field(description="Maximum number of steps to run training for. If None, will run indefinitely."),
-    ] = None
+    max_steps: int | None = None
+    """Maximum training steps. If None, runs indefinitely."""
 
-    memory_profiler_path: Annotated[Path | None, Field(description="Path to write memory profile to.")] = None
+    memory_profiler_path: Path | None = None
+    """Path to write the memory profile to."""
 
-    bench: Annotated[
-        BenchConfig | None,
-        Field(
-            description="Whether to run in benchmark mode. It will automatically set the maximum number of steps to run to 4 and use fake data.",
-        ),
-    ] = None
+    bench: BenchConfig | None = None
+    """Benchmark-mode configuration. When set, ``max_steps`` is forced to 4 and fake data is used."""
 
-    gc: Annotated[
-        GCConfig | None,
-        Field(
-            description="Garbage collection config. Disables automatic GC and runs deterministic collections every N steps to avoid stragglers. Set to null to use Python's default GC behavior.",
-        ),
-    ] = GCConfig()
+    gc: GCConfig | None = GCConfig()
+    """Garbage collection config. Disables automatic GC and runs deterministic collections every N steps to avoid stragglers. Set to null to use Python's default GC behavior."""
 
-    trace_path: Annotated[Path | None, Field(description="Path to write pytorch profiler trace to.")] = None
+    trace_path: Path | None = None
+    """Path to write the PyTorch profiler trace to."""
 
-    dist_timeout_seconds: Annotated[
-        int,
-        Field(
-            description="Timeout in seconds for torch distributed ops. Defaults to 600 seconds.",
-        ),
-    ] = 600
+    dist_timeout_seconds: int = 600
+    """Timeout in seconds for torch distributed ops."""
 
-    loss_impl: Annotated[
-        Literal["liger", "torch", "liger_fused", "quack_fused"],
-        Field(
-            description="Implementation of the cross entropy loss function to use. "
-            "'liger_fused' fuses the lm_head projection with the CE loss to avoid materializing full logits. "
-            "'quack_fused' uses quack-kernels for chunked linear + CE with CuTe DSL CUDA kernels."
-        ),
-    ] = "torch"
+    loss_impl: Literal["liger", "torch", "liger_fused", "quack_fused"] = "torch"
+    """Cross-entropy loss implementation. ``liger_fused`` fuses the lm_head projection with the CE loss to avoid materializing full logits. ``quack_fused`` uses quack-kernels for chunked linear + CE with CuTe DSL CUDA kernels."""
 
-    heartbeat: Annotated[
-        HeartbeatConfig | None, Field(description="The heartbeat config for monitoring training progress.")
-    ] = None
+    heartbeat: HeartbeatConfig | None = None
+    """BetterStack heartbeat configuration for monitoring training progress."""
 
     deployment: SFTDeploymentConfig = SingleNodeDeploymentConfig()
+    """Deployment topology."""
 
-    slurm: Annotated[
-        SlurmConfig | None,
-        Field(
-            description="SLURM configuration. If set, the run will be submitted as a SLURM job instead of running locally.",
-        ),
-    ] = None
+    slurm: SlurmConfig | None = None
+    """SLURM configuration. When set, the run is submitted as a SLURM job instead of running locally."""
 
-    dry_run: Annotated[bool, Field(description="Only validate and dump resolved configs and exit early.")] = False
+    dry_run: bool = False
+    """Only validate and dump resolved configs, then exit early."""
 
-    experimental: Annotated[
-        SFTExperimentalConfig,
-        Field(description="Experimental features for SFT training."),
-    ] = SFTExperimentalConfig()
+    experimental: SFTExperimentalConfig = SFTExperimentalConfig()
+    """Experimental SFT features."""
 
     ### Pre-validation normalization
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/shared.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/shared.py
@@ -8,55 +8,32 @@ from prime_rl.utils.config import BaseConfig
 
 
 class SlurmConfig(BaseConfig):
-    """Configures SLURM scheduling."""
+    job_name: str = "prime-rl"
+    """SLURM job name."""
 
-    job_name: Annotated[str, Field(description="The SLURM job name.")] = "prime-rl"
+    project_dir: Path = Path(".")
+    """Path to the project root, used to source .env, activate .venv, and run uv sync."""
 
-    project_dir: Annotated[
-        Path,
-        Field(description="Path to the project root. Used to source .env, activate .venv, and run uv sync."),
-    ] = Path(".")
+    template_path: Path | None = None
+    """SLURM template file. If None, uses the bundled single-node or multi-node template."""
 
-    template_path: Annotated[
-        Path | None,
-        Field(
-            description="The path to the SLURM template file. If None, will use the default single-node/multi-node template."
-        ),
-    ] = None
+    partition: str = "cluster"
+    """SLURM partition (#SBATCH --partition)."""
 
-    partition: Annotated[
-        str, Field(description="The SLURM partition to use. Will be passed as #SBATCH --partition.")
-    ] = "cluster"
+    nodelist: str | None = None
+    """Comma-separated list of specific nodes to run on (#SBATCH --nodelist)."""
 
-    nodelist: Annotated[
-        str | None,
-        Field(description="Comma-separated list of specific nodes to run on. Passed as #SBATCH --nodelist."),
-    ] = None
+    exclude: str | None = None
+    """Comma-separated list of nodes to exclude (#SBATCH --exclude)."""
 
-    exclude: Annotated[
-        str | None,
-        Field(description="Comma-separated list of nodes to exclude. Passed as #SBATCH --exclude."),
-    ] = None
+    account: str | None = None
+    """SLURM account to charge (#SBATCH --account)."""
 
-    account: Annotated[
-        str | None,
-        Field(description="SLURM account to charge. Passed as #SBATCH --account."),
-    ] = None
+    time: str | None = None
+    """Maximum wall time, e.g. '24:00:00' or '7-00:00:00' (#SBATCH --time)."""
 
-    time: Annotated[
-        str | None,
-        Field(description="Maximum wall time (e.g. '24:00:00', '7-00:00:00'). Passed as #SBATCH --time."),
-    ] = None
-
-    pre_run_command: Annotated[
-        str | None,
-        Field(
-            description="Shell command to run on the head node before starting the job. "
-            "Runs after cd into project dir, .env sourcing, and venv activation. "
-            "Useful for cleanup routines like 'sudo pkill -f vllm'. "
-            "To run on all nodes, wrap with srun: 'srun bash -c \"pkill -f vllm || true\"'.",
-        ),
-    ] = None
+    pre_run_command: str | None = None
+    """Shell command to run on the head node after cd, .env sourcing, and venv activation. Useful for cleanup like ``sudo pkill -f vllm``; wrap with ``srun bash -c '...'`` to fan out to all nodes."""
 
     @property
     def template_vars(self) -> dict:
@@ -82,54 +59,25 @@ ServerType = Literal["vllm", "openai"]
 
 
 class VLMConfig(BaseConfig):
-    """Configures vision-language model support.
+    vision_encoder_attr: str
+    """Dotted attribute path to the vision encoder module (e.g. ``model.visual``)."""
 
-    Presence of this config enables VLM mode. You must specify where the
-    vision encoder and language model live on the model object.
+    language_model_attr: str
+    """Dotted attribute path to the language model module (e.g. ``model.language_model``)."""
 
-    Usage:
-        [model.vlm]
-        vision_encoder_attr = "model.visual"
-        language_model_attr = "model.language_model"
-    """
-
-    vision_encoder_attr: Annotated[
-        str,
-        Field(description="Dotted attribute path to the vision encoder module (e.g. 'model.visual')."),
-    ]
-
-    language_model_attr: Annotated[
-        str,
-        Field(description="Dotted attribute path to the language model module (e.g. 'model.language_model')."),
-    ]
-
-    freeze_vision_encoder: Annotated[
-        bool,
-        Field(
-            description="Whether to freeze the vision encoder. When False, the vision encoder is trainable "
-            "and FSDP-sharded per-block. Has no effect with LoRA (LoRA freezes all non-adapter parameters).",
-        ),
-    ] = True
+    freeze_vision_encoder: bool = True
+    """Freeze the vision encoder. When False, it is trainable and FSDP-sharded per-block. No effect with LoRA (LoRA freezes all non-adapter parameters)."""
 
 
 class BaseModelConfig(BaseConfig):
-    """Configures the model."""
+    name: str = "Qwen/Qwen3-0.6B"
+    """HF model name or local path."""
 
-    name: Annotated[str, Field(description="Name or path of the HF model to use.")] = "Qwen/Qwen3-0.6B"
+    trust_remote_code: bool = False
+    """Trust remote code when initializing the tokenizer."""
 
-    trust_remote_code: Annotated[
-        bool,
-        Field(
-            description="Whether to trust remote code for tokenizer initialization.",
-        ),
-    ] = False
-
-    vlm: Annotated[
-        "VLMConfig | None",
-        Field(
-            description="VLM configuration. Set this to enable vision-language model support.",
-        ),
-    ] = None
+    vlm: "VLMConfig | None" = None
+    """VLM configuration. Setting this enables vision-language model support."""
 
     @property
     def is_vlm(self) -> bool:
@@ -137,234 +85,75 @@ class BaseModelConfig(BaseConfig):
 
 
 class RendererConfig(BaseConfig):
-    """Configures the client-side renderer (chat-template + response parsing).
+    name: str = "auto"
+    """Renderer used for chat-template tokenization. One of: ``auto`` (detect from tokenizer), ``qwen3``, ``qwen3_vl``, ``qwen3.5``, ``glm5``, ``glm4.5``, ``minimax-m2``, ``deepseek_v3``, ``kimi_k2``, ``kimi_k25``, ``nemotron3``, ``gpt_oss``, ``default``."""
 
-    Consumed when ``use_renderer = true``. The renderer
-    owns both directions: render messages → token ids on the client, and
-    parse model output tokens → structured ``content`` / ``reasoning_content``
-    / ``tool_calls``.
-    """
+    tool_parser: str | None = None
+    """Tool parser from ``renderers.parsers``. Only consumed by DefaultRenderer; model-specific renderers bake their own parsing in. Options: ``qwen3``, ``qwen3.5``, ``glm``, ``deepseek_v3``."""
 
-    name: Annotated[
-        str,
-        Field(
-            description=(
-                "Renderer to use for chat template tokenization. "
-                "Options: 'auto' (detect from tokenizer), 'qwen3', 'qwen3_vl', "
-                "'qwen3.5', 'glm5', 'glm4.5', 'minimax-m2', 'deepseek_v3', "
-                "'kimi_k2', 'kimi_k25', 'nemotron3', 'gpt_oss', 'default'."
-            ),
-        ),
-    ] = "auto"
+    reasoning_parser: str | None = None
+    """Reasoning parser from ``renderers.parsers``. Only consumed by DefaultRenderer. Options: ``think``."""
 
-    tool_parser: Annotated[
-        str | None,
-        Field(
-            description=(
-                "Name of a tool parser in renderers.parsers. Only consumed by "
-                "DefaultRenderer (model-specific renderers bake their own parsing "
-                "in). Options today: 'qwen3', 'qwen3.5', 'glm', 'deepseek_v3'."
-            ),
-        ),
-    ] = None
+    pool_size: int | None = Field(None, ge=1)
+    """Number of renderer slots shared across concurrent rollouts. Bump for long multi-turn prompts where client-side jinja tokenization serializes."""
 
-    reasoning_parser: Annotated[
-        str | None,
-        Field(
-            description=(
-                "Name of a reasoning parser in renderers.parsers. Only consumed "
-                "by DefaultRenderer. Options today: 'think'."
-            ),
-        ),
-    ] = None
+    preserve_all_thinking: bool = False
+    """Re-emit every past-assistant turn's ``reasoning_content`` between ``<think>``/``</think>`` (or the model's equivalent), even when the chat template would drop it. Strict superset of preserve_thinking_between_tool_calls."""
 
-    pool_size: Annotated[
-        int | None,
-        Field(
-            ge=1,
-            description=(
-                "Number of renderer slots shared across concurrent rollouts. "
-                "None keeps the verifiers default (1). Bump for long multi-turn "
-                "prompts where client-side jinja tokenization serializes."
-            ),
-        ),
-    ] = None
-
-    preserve_all_thinking: Annotated[
-        bool,
-        Field(
-            description=(
-                "Override flag forwarded to the renderer at construction. When "
-                "True, every past-assistant turn's ``reasoning_content`` is "
-                "re-emitted between ``<think>``/``</think>`` (or the model's "
-                "equivalent), even if the underlying chat template would drop "
-                "it. Off by default — preserves byte-identical output to the "
-                "stock template. Strict superset of "
-                "``preserve_thinking_between_tool_calls``."
-            ),
-        ),
-    ] = False
-
-    preserve_thinking_between_tool_calls: Annotated[
-        bool,
-        Field(
-            description=(
-                "Override flag forwarded to the renderer at construction. When "
-                "True, preserves past-assistant ``reasoning_content`` only "
-                "inside the *current* tool cycle — the contiguous "
-                "assistant→tool→…→assistant block after the most recent user "
-                "message, when that block contains at least one tool response. "
-                "A new user turn closes the block; older blocks fall back to "
-                "the template default (typically dropped). Use "
-                "``preserve_all_thinking`` to keep older blocks too."
-            ),
-        ),
-    ] = False
+    preserve_thinking_between_tool_calls: bool = False
+    """Preserve past-assistant ``reasoning_content`` only inside the current tool cycle — the contiguous assistant→tool→…→assistant block after the most recent user message, when that block contains at least one tool response. A new user turn closes the block."""
 
 
 class ElasticConfig(BaseConfig):
-    """Configures elastic inference pool with DNS-based service discovery.
+    hostname: str
+    """DNS hostname that resolves to inference server IPs."""
 
-    Works with any DNS hostname that resolves to multiple IP addresses.
-    """
+    port: int = 8000
+    """Port that inference servers listen on."""
 
-    hostname: Annotated[
-        str,
-        Field(
-            description="DNS hostname that resolves to inference server IPs.",
-        ),
-    ]
-
-    port: Annotated[
-        int,
-        Field(
-            description="Port that inference servers listen on.",
-        ),
-    ] = 8000
-
-    sync_interval: Annotated[
-        float,
-        Field(
-            description="Interval in seconds between server discovery checks.",
-        ),
-    ] = 5.0
+    sync_interval: float = 5.0
+    """Seconds between server discovery checks."""
 
 
 class ClientConfig(BaseConfig):
-    """Configures the OAI client.
+    timeout: int = 1200
+    """Request timeout in seconds."""
 
-    Supports two modes:
-    - Static mode (default): Uses fixed base_url list
-    - Elastic mode: Uses DNS-based service discovery via hostname
+    connect_timeout: float = 30.0
+    """TCP connect timeout in seconds for inference API requests."""
 
-    If elastic config is provided, base_url is ignored and servers are discovered dynamically.
-    """
+    wait_for_ready_timeout: int = 1800
+    """Seconds to wait at startup for the inference pool to become ready. Applies to both the static health check and elastic DNS-based discovery."""
 
-    timeout: Annotated[
-        int,
-        Field(
-            description="Timeout in seconds. By default, it is set to 1200 seconds.",
-        ),
-    ] = 1200
+    base_url: list[str] = ["http://localhost:8000/v1"]
+    """Base URLs for the OpenAI API. With more than one URL, the client round-robins (chat) completion requests across all servers. Ignored when ``elastic`` is set."""
 
-    connect_timeout: Annotated[
-        float,
-        Field(
-            description="TCP connect timeout in seconds for inference API requests.",
-        ),
-    ] = 30.0
+    api_key_var: str = "VLLM_API_KEY"
+    """Environment variable name containing the API key, resolved via ``os.getenv``. Can be any string when the server is not protected by an API key; the same key is used for every URL."""
 
-    wait_for_ready_timeout: Annotated[
-        int,
-        Field(
-            description="Timeout in seconds for waiting for the inference pool to become ready at startup. "
-            "Applies to both the static health check and elastic DNS-based discovery. Defaults to 1800 seconds.",
-        ),
-    ] = 1800
+    headers: dict[str, str] = {}
+    """Static headers sent with every request."""
 
-    base_url: Annotated[
-        list[str],
-        Field(
-            description="Base URLs to use for the OpenAI API. By default, it is set to a single server on localhost at port 8000 which matches the default local vLLM server configuration. If you specify more than one URL, the client will round-robin (chat) completion requests across all servers. Ignored if elastic config is provided.",
-        ),
-    ] = ["http://localhost:8000/v1"]
+    headers_from_env: dict[str, str] = {}
+    """Maps HTTP header names to environment variable names; each entry is resolved via ``os.getenv`` and merged into request headers. e.g. ``{"X-Prime-Team-ID": "PRIME_TEAM_ID"}``."""
 
-    api_key_var: Annotated[
-        str,
-        Field(
-            description="Name of environment variable containing the API key to use for the inference API. Will parse using `os.getenv(client_config.api_key_var)`. Can be set to an arbitrary string if the inference server is not protected by an API key. If multiple URLs are specified, the same API key will be used for all servers.",
-        ),
-    ] = "VLLM_API_KEY"
+    extra_headers_from_state: dict[str, str] = {}
+    """Maps HTTP header names to rollout-state field names. The header value is read from the rollout state dict on every request. e.g. ``{"X-Session-ID": "example_id"}`` enables sticky routing at the inference router."""
 
-    headers: Annotated[
-        dict[str, str],
-        Field(
-            description="Headers to use for the OpenAI API. By default, it is set to an empty dictionary.",
-        ),
-    ] = {}
+    skip_model_check: bool = False
+    """Skip checking that the model is available in the inference pool. Useful for external APIs or keys that do not expose ``/models``."""
 
-    headers_from_env: Annotated[
-        dict[str, str],
-        Field(
-            description='Maps HTTP header names to environment variable names. At runtime each entry is resolved via os.getenv and merged into the request headers. e.g. {"X-Prime-Team-ID": "PRIME_TEAM_ID"}.',
-        ),
-    ] = {}
+    dp_rank_count: int = Field(1, ge=1)
+    """Number of data-parallel ranks behind each base URL. When > 1, each URL is expanded into ``dp_rank_count`` logical clients pinned via the ``X-data-parallel-rank`` header, so every request within a rollout hits the same DP engine and reuses KV cache. Auto-set from the inference config when using the RL entrypoint."""
 
-    extra_headers_from_state: Annotated[
-        dict[str, str],
-        Field(
-            description="Maps HTTP header names to state field names. For each inference request, "
-            "the header value is dynamically read from the rollout state dict. "
-            'e.g. {"X-Session-ID": "example_id"} enables sticky routing at the inference router.',
-        ),
-    ] = {}
+    admin_base_url: list[str] | None = None
+    """Separate base URLs for admin operations (weight updates, health checks). When set, admin clients bypass routers and hit each server directly — used in disaggregated P/D deployments where the router must not handle admin traffic."""
 
-    skip_model_check: Annotated[
-        bool,
-        Field(
-            description="Whether to skip checking if the model is available in the inference pool. Useful for external APIs or API Keys that don't support the /models endpoint.",
-        ),
-    ] = False
+    elastic: ElasticConfig | None = None
+    """Elastic inference pool config for DNS-based service discovery. When set, ``base_url`` is ignored and inference servers are discovered dynamically via DNS."""
 
-    dp_rank_count: Annotated[
-        int,
-        Field(
-            ge=1,
-            description=(
-                "Number of data-parallel ranks behind each base URL. When > 1, "
-                "each URL is expanded into dp_rank_count logical clients, each "
-                "pinned to a specific DP rank via the X-data-parallel-rank header. "
-                "This ensures all requests within a multi-turn rollout hit the same "
-                "DP engine, maximizing KV cache reuse. Auto-set from "
-                "inference.data_parallel_size_local (or inference.parallel.dp) "
-                "when using the RL entrypoint."
-            ),
-        ),
-    ] = 1
-
-    admin_base_url: Annotated[
-        list[str] | None,
-        Field(
-            description="Separate base URLs for admin operations (weight updates, health checks). "
-            "When set, admin clients use these URLs instead of base_url, allowing weight "
-            "updates to bypass routers and hit each server directly. Used in disaggregated "
-            "P/D deployments where the inference router should not handle admin traffic.",
-        ),
-    ] = None
-
-    elastic: Annotated[
-        ElasticConfig | None,
-        Field(
-            description="Elastic inference pool configuration for DNS-based service discovery. If provided, base_url is ignored and inference servers are discovered dynamically via DNS.",
-        ),
-    ] = None
-
-    router_url: Annotated[
-        str | None,
-        Field(
-            description="URL of a vllm-router for load-aware inference routing. When set with elastic mode, inference requests go through the router while admin operations (weight updates, LoRA loading) still go directly to discovered pods.",
-        ),
-    ] = None
+    router_url: str | None = None
+    """vllm-router URL for load-aware inference routing. With elastic mode, inference requests go through the router while admin ops still hit discovered pods directly."""
 
     @property
     def is_elastic(self) -> bool:
@@ -373,225 +162,116 @@ class ClientConfig(BaseConfig):
 
 
 class LogConfig(BaseConfig):
-    """Configures the logger."""
+    level: str = Field(default_factory=lambda: os.environ.get("PRIME_LOG_LEVEL", "info"))
+    """Log level for the process. Defaults to ``$PRIME_LOG_LEVEL`` if set, else ``info``."""
 
-    level: Annotated[
-        str,
-        Field(
-            default_factory=lambda: os.environ.get("PRIME_LOG_LEVEL", "info"),
-            description="Logging level for the process. Will determine the logging verbosity and format. Defaults to the PRIME_LOG_LEVEL env var if set, else 'info'.",
-        ),
-    ]
+    vf_level: str = Field(default_factory=lambda: os.environ.get("PRIME_VF_LOG_LEVEL", "info"))
+    """Log level for the verifiers package. Defaults to ``$PRIME_VF_LOG_LEVEL`` if set, else ``info``."""
 
-    vf_level: Annotated[
-        str,
-        Field(
-            default_factory=lambda: os.environ.get("PRIME_VF_LOG_LEVEL", "info"),
-            description="Logging level for the verifiers package. Will determine the logging verbosity and format. Defaults to the PRIME_VF_LOG_LEVEL env var if set, else 'info'.",
-        ),
-    ]
+    json_logging: bool = False
+    """Emit newline-delimited JSON logs for aggregation (Loki, Grafana, etc.)."""
 
-    json_logging: Annotated[
-        bool,
-        Field(
-            description="Emit JSON logs (newline-delimited) for log aggregation (Loki, Grafana, etc.).",
-        ),
-    ] = False
-
-    log_data: Annotated[
-        bool,
-        Field(
-            description="Whether to log the first data sample to the logger.",
-        ),
-    ] = False
+    log_data: bool = False
+    """Log the first data sample at startup."""
 
 
 class TrainerLogConfig(LogConfig):
-    """Trainer-specific log config."""
-
-    ranks_filter: Annotated[
-        list[int],
-        Field(description="Which trainer ranks to show in console output. Passed to torchrun's --local-ranks-filter."),
-    ] = [0]
+    ranks_filter: list[int] = [0]
+    """Trainer ranks to show in console output. Passed to ``torchrun --local-ranks-filter``."""
 
 
 class LogExtrasConfig(BaseConfig):
-    """Configures extra logging for monitoring platforms."""
+    samples: bool = True
+    """Log prompt/response samples."""
 
-    samples: Annotated[
-        bool,
-        Field(
-            description="Whether to log prompt/response samples.",
-        ),
-    ] = True
+    distributions: bool = True
+    """Log distributions (rewards, advantages, etc.)."""
 
-    distributions: Annotated[
-        bool,
-        Field(
-            description="Whether to log distributions (like rewards, advantages, etc.).",
-        ),
-    ] = True
+    interval: int = Field(10, ge=1)
+    """Step interval between extras logs."""
 
-    interval: Annotated[
-        int,
-        Field(
-            ge=1,
-            description="Step interval at which to log extras.",
-        ),
-    ] = 10
-
-    sample_ratio: Annotated[
-        float | None,
-        Field(
-            ge=0.0,
-            le=1.0,
-            description="Fraction of rollouts to log per step (0.0–1.0). "
-            "When set, the effective sample cap is len(rollouts) * sample_ratio. "
-            "1.0 = all rollouts, 0.5 = half, 0.0 = none. "
-            "None (default)",
-        ),
-    ] = None
+    sample_ratio: float | None = Field(None, ge=0.0, le=1.0)
+    """Fraction of rollouts to log per step. The effective cap is ``len(rollouts) * sample_ratio``; 1.0 = all, 0.5 = half, 0.0 = none."""
 
 
 class WandbConfig(BaseConfig):
-    """Configures logging to Weights and Biases."""
-
     # Shared configs (May be overwritten by WandbConfig from `rl.py`)
-    project: Annotated[str, Field(description="The W&B project to log to.")] = "prime-rl"
+    project: str = "prime-rl"
+    """W&B project to log to."""
 
-    entity: Annotated[
-        str | None,
-        Field(
-            description="The W&B entity to log to.",
-        ),
-    ] = None
+    entity: str | None = None
+    """W&B entity to log to."""
 
-    name: Annotated[
-        str | None,
-        Field(
-            description="The W&B name to to use for logging.",
-        ),
-    ] = None
+    name: str | None = None
+    """W&B run name."""
 
-    group: Annotated[
-        str | None,
-        Field(
-            description="The W&B group to use for logging.",
-        ),
-    ] = None
+    group: str | None = None
+    """W&B group."""
 
-    tags: Annotated[
-        list[str] | None,
-        Field(
-            description="The W&B tags to attach to the run.",
-        ),
-    ] = None
+    tags: list[str] | None = None
+    """W&B tags attached to the run."""
 
-    offline: Annotated[bool, Field(description="Whether to run W&B in offline mode.")] = False
+    offline: bool = False
+    """Run W&B in offline mode."""
 
 
 class WandbWithExtrasConfig(WandbConfig):
-    """Configures logging to Weights and Biases with extras."""
-
-    log_extras: Annotated[
-        LogExtrasConfig | None,
-        Field(
-            description="Configuration for logging extras. If None, no extras are logged.",
-        ),
-    ] = LogExtrasConfig()
+    log_extras: LogExtrasConfig | None = LogExtrasConfig()
+    """Extras logging configuration. If None, no extras are logged."""
 
 
 class PrimeMonitorConfig(BaseConfig):
-    """Configures logging to Prime Intellect API."""
+    base_url: str = "https://api.primeintellect.ai/api/v1/rft"
+    """Base URL for the Prime Intellect monitoring API."""
 
-    base_url: Annotated[
-        str,
-        Field(
-            description="The base URL for Prime Intellect monitoring API.",
-        ),
-    ] = "https://api.primeintellect.ai/api/v1/rft"
+    api_key_var: str = "PRIME_API_KEY"
+    """Environment variable name containing the Prime Intellect API key, resolved via ``os.getenv``."""
 
-    api_key_var: Annotated[
-        str,
-        Field(
-            description="Name of environment variable containing the API key for Prime Intellect API. Will parse using `os.getenv(config.api_key_var)`.",
-        ),
-    ] = "PRIME_API_KEY"
+    log_extras: LogExtrasConfig | None = LogExtrasConfig()
+    """Extras logging configuration. If None, no extras are logged."""
 
-    log_extras: Annotated[
-        LogExtrasConfig | None,
-        Field(
-            description="Configuration for logging extras. If None, no extras are logged.",
-        ),
-    ] = LogExtrasConfig()
+    run_name: str | None = None
+    """Run name shown on the platform. Defaults to the W&B run name when set, otherwise the platform auto-generates one."""
 
-    run_name: Annotated[
-        str | None,
-        Field(
-            description="Name for the run shown on the platform. Defaults to the W&B run name if set, otherwise auto-generated by the platform.",
-        ),
-    ] = None
+    team_id: str | None = None
+    """Team ID to associate the run with."""
 
-    team_id: Annotated[
-        str | None,
-        Field(
-            description="Team ID to associate the run with.",
-        ),
-    ] = None
-
-    frontend_url: Annotated[
-        str | None,
-        Field(
-            description="Frontend base URL used for the dashboard link shown after registration. Defaults to the Prime CLI frontend URL when unset.",
-        ),
-    ] = None
+    frontend_url: str | None = None
+    """Frontend base URL used for the dashboard link printed after registration. Defaults to the Prime CLI frontend URL when unset."""
 
 
 class HeartbeatConfig(BaseConfig):
-    """Configures the heartbeat for BetterStack."""
-
-    url: Annotated[str, Field(description="The URL to send the heartbeat to.")]
+    url: str
+    """URL to send the heartbeat to."""
 
 
 class MetricsServerConfig(BaseConfig):
-    """Configures the Prometheus metrics server for trainer observability."""
+    port: int = Field(8000, ge=1, le=65535)
+    """Port to expose metrics and health endpoints on."""
 
-    port: Annotated[
-        int,
-        Field(
-            ge=1,
-            le=65535,
-            description="Port to expose metrics and health endpoints. Defaults to 8000.",
-        ),
-    ] = 8000
-
-    host: Annotated[
-        str,
-        Field(
-            description="Host to bind the server to. Defaults to 0.0.0.0.",
-        ),
-    ] = "0.0.0.0"
+    host: str = "0.0.0.0"
+    """Host to bind the server to."""
 
 
 class BaseTransportConfig(BaseModel):
-    """Base configuration for transport."""
-
     pass
 
 
 class FileSystemTransportConfig(BaseTransportConfig):
-    """Configures filesystem-based transport for training examples."""
-
     type: Literal["filesystem"] = "filesystem"
 
 
 class ZMQTransportConfig(BaseTransportConfig):
-    """Configures ZMQ-based transport for training examples."""
-
     type: Literal["zmq"] = "zmq"
-    host: Annotated[str, Field(description="The host address for ZMQ transport.")] = "localhost"
-    port: Annotated[int, Field(description="The base port for ZMQ transport.")] = 5555
-    hwm: Annotated[int, Field(description="High water mark (max messages in queue) for ZMQ sockets.")] = 10
+
+    host: str = "localhost"
+    """Host address for ZMQ transport."""
+
+    port: int = 5555
+    """Base port for ZMQ transport."""
+
+    hwm: int = 10
+    """High-water mark (max in-flight messages per ZMQ socket)."""
 
 
 TransportConfig: TypeAlias = Annotated[FileSystemTransportConfig | ZMQTransportConfig, Field(discriminator="type")]

--- a/packages/prime-rl-configs/src/prime_rl/configs/shared.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/shared.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import Field, model_validator
 
 from prime_rl.utils.config import BaseConfig
 
@@ -253,7 +253,7 @@ class MetricsServerConfig(BaseConfig):
     """Host to bind the server to."""
 
 
-class BaseTransportConfig(BaseModel):
+class BaseTransportConfig(BaseConfig):
     pass
 
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -2,7 +2,7 @@ import warnings
 from pathlib import Path
 from typing import Annotated, Any, Literal, TypeAlias
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import Field, model_validator
 
 from prime_rl.configs.shared import (
     BaseModelConfig,
@@ -264,11 +264,11 @@ class TokenizerConfig(BaseConfig):
     """Chat template for the tokenizer. Either a Jinja2 template string or a path to a template file. If None, the tokenizer's default chat template is used."""
 
 
-class ConstantSchedulerConfig(BaseModel):
+class ConstantSchedulerConfig(BaseConfig):
     type: Literal["constant"] = "constant"
 
 
-class LinearSchedulerConfig(BaseModel):
+class LinearSchedulerConfig(BaseConfig):
     type: Literal["linear"] = "linear"
 
     warmup_steps: int = Field(10, ge=0)
@@ -281,7 +281,7 @@ class LinearSchedulerConfig(BaseModel):
     """Minimum learning rate to converge to."""
 
 
-class CosineSchedulerConfig(BaseModel):
+class CosineSchedulerConfig(BaseConfig):
     type: Literal["cosine"] = "cosine"
 
     warmup_steps: int = Field(10, ge=0)
@@ -296,7 +296,7 @@ SchedulerConfig: TypeAlias = Annotated[
 ]
 
 
-class BaseOptimizerConfig(BaseModel):
+class BaseOptimizerConfig(BaseConfig):
     lr: float = Field(1e-6, ge=0)
     """Peak learning rate."""
 
@@ -398,7 +398,7 @@ class CheckpointConfig(BaseConfig):
     """Skip loading the optimizer state from checkpoint."""
 
 
-class DefaultLossConfig(BaseModel):
+class DefaultLossConfig(BaseConfig):
     type: Literal["default"] = "default"
 
     dppo_mask_low: float = Field(0.2, ge=0)
@@ -414,7 +414,7 @@ class DefaultLossConfig(BaseModel):
     """Temperature for the KL term."""
 
 
-class CustomLossConfig(BaseModel):
+class CustomLossConfig(BaseConfig):
     type: Literal["custom"] = "custom"
 
     import_path: str
@@ -440,7 +440,7 @@ class DataLoaderConfig(BaseConfig):
     """Use a fake data loader sampling random micro-batches (for debugging)."""
 
 
-class BaseWeightBroadcastConfig(BaseModel):
+class BaseWeightBroadcastConfig(BaseConfig):
     pass
 
 
@@ -485,22 +485,17 @@ class TrainerExperimentalConfig(BaseConfig):
 
 class TrainerConfig(BaseConfig):
     model: ModelConfig = ModelConfig()
-    """Model configuration."""
 
     tokenizer: TokenizerConfig = TokenizerConfig()
-    """Tokenizer configuration."""
 
     data: DataLoaderConfig = DataLoaderConfig()
-    """Data loader configuration."""
 
     loss: LossConfig = DefaultLossConfig()
     """Loss config for rl-mode batches. opd and sft batches dispatch to their own loss fns unconditionally and do not read this."""
 
     optim: OptimizerConfig = AdamWConfig()
-    """Optimizer configuration."""
 
     scheduler: SchedulerConfig = ConstantSchedulerConfig()
-    """Learning-rate scheduler configuration."""
 
     ckpt: CheckpointConfig | None = None
     """Full training-state checkpoint configuration (model + optimizer + scheduler). If None, no resume-capable checkpoints are written."""
@@ -512,10 +507,8 @@ class TrainerConfig(BaseConfig):
     """Transport used to ship rollouts from orchestrator to trainer."""
 
     log: TrainerLogConfig = TrainerLogConfig()
-    """Logger configuration."""
 
     wandb: WandbConfig | None = None
-    """Weights & Biases configuration."""
 
     output_dir: Path = Path("outputs")
     """Directory to write outputs to — checkpoints, weights, rollouts, and logs are written as subdirectories. Should be a persistent directory with enough disk space and unique per experiment running on a single node."""
@@ -557,7 +550,6 @@ class TrainerConfig(BaseConfig):
     """Maximum number of concurrent runs to allow. If 1, only one run may run at a time."""
 
     experimental: TrainerExperimentalConfig = TrainerExperimentalConfig()
-    """Experimental trainer features."""
 
     @model_validator(mode="after")
     def deepep_disables_grad_clipping(self):

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -28,45 +28,19 @@ _ATTN_ALIASES = {"flash_attention_4": "fa4"}
 
 
 class GCConfig(BaseConfig):
-    """Configures deterministic garbage collection to avoid stragglers in distributed training.
-
-    Disables Python's automatic GC and runs manual collections every `freq` steps so all
-    ranks collect simultaneously, preventing one rank from stalling others.
-    """
-
-    interval: Annotated[
-        int,
-        Field(
-            ge=1,
-            description="Run garbage collection every `interval` training steps.",
-        ),
-    ] = 50
+    interval: int = Field(50, ge=1)
+    """Run garbage collection every N training steps. Disables Python's automatic GC so every rank collects together and one slow rank can't stall the others."""
 
 
 class ActivationCheckpointConfig(BaseConfig):
-    """Configures activation checkpointing."""
+    mode: Literal["full", "selective"] = "full"
+    """``full`` checkpoints whole transformer blocks; ``selective`` checkpoints only the subcomponents listed in ``targets`` inside supported custom decoder layers."""
 
-    mode: Annotated[
-        Literal["full", "selective"],
-        Field(
-            description="Whether to checkpoint whole transformer blocks (`full`) or selected subcomponents inside supported custom decoder layers (`selective`).",
-        ),
-    ] = "full"
+    freq: int = Field(1, ge=1)
+    """Apply activation checkpointing to every N layers."""
 
-    freq: Annotated[
-        int,
-        Field(
-            ge=1,
-            description="Applies activation checkpointing to every `freq` layers. Defaults to 1.",
-        ),
-    ] = 1
-
-    targets: Annotated[
-        list[str],
-        Field(
-            description="Selective checkpoint targets. `norm` checkpoints every norm module inside selected layers (decoder, attention, MLA, etc.). `attn_proj` checkpoints projection-side attention work outside the kernel, including input/output projections, attention-local norms, RoPE, gating, and model-specific MLA projection helpers where exposed. `mlp` checkpoints the entire dense MLP forward (not applicable to MoE layers). `mla_up_proj` checkpoints MLA Q/KV up-projection work where supported. `routed_experts` checkpoints routed expert compute in MoE layers (including LatentMoE). `linear_attn` checkpoints supported token mixers outside the standard softmax-attention path, including NemotronH Mamba layers, Qwen3.5-MoE GatedDeltaNet layers, and AFMoE sliding-window attention layers.",
-        ),
-    ] = ["norm"]
+    targets: list[str] = ["norm"]
+    """Selective checkpoint targets. ``norm`` checkpoints every norm module inside selected layers. ``attn_proj`` checkpoints projection-side attention work outside the kernel (input/output projections, attention-local norms, RoPE, gating, model-specific MLA projection helpers). ``mlp`` checkpoints the entire dense MLP forward (not for MoE). ``mla_up_proj`` checkpoints MLA Q/KV up-projection where supported. ``routed_experts`` checkpoints routed expert compute in MoE layers (including LatentMoE). ``linear_attn`` checkpoints non-softmax token mixers (NemotronH Mamba, Qwen3.5-MoE GatedDeltaNet, AFMoE sliding-window attention)."""
 
     @model_validator(mode="after")
     def validate_selective_targets(self):
@@ -77,77 +51,34 @@ class ActivationCheckpointConfig(BaseConfig):
 
 
 class ActivationOffloadingConfig(BaseConfig):
-    """Configures the activation offloading."""
+    pin_memory: bool = True
+    """Pin offloaded activations to CPU memory."""
 
-    pin_memory: Annotated[bool, Field(description="Whether to pin the offloaded activations to CPU memory.")] = True
-
-    max_inflight_activations: Annotated[
-        int,
-        Field(
-            ge=1,
-            description="The maximum number of activations to keep in while offloading further. (More activations means smoother overlap, but more gpu memory usage)",
-        ),
-    ] = 5
+    max_inflight_activations: int = Field(5, ge=1)
+    """Max activations kept in flight while offloading. More activations smooth overlap at the cost of GPU memory."""
 
 
 class CompileConfig(BaseConfig):
-    """Configures model compilation."""
-
-    fullgraph: Annotated[
-        bool,
-        Field(description="Whether to compile the transformer blocks with fullgraph."),
-    ] = False
+    fullgraph: bool = False
+    """Compile transformer blocks with ``fullgraph=True``."""
 
 
 class BenchConfig(BaseConfig):
-    """Configures benchmark mode."""
-
-    output_json: Annotated[
-        Path | None,
-        Field(description="Path to write benchmark results as JSON. If not set, only prints to console."),
-    ] = None
+    output_json: Path | None = None
+    """Path to write benchmark results as JSON. If unset, results are only printed to the console."""
 
 
 class LoRAConfig(BaseConfig):
-    """Configuration for LoRA (Low-Rank Adaptation)."""
+    rank: int = Field(16, ge=1)
+    """Rank of the low-rank decomposition matrices."""
 
-    rank: Annotated[
-        int,
-        Field(
-            ge=1,
-            description="Rank of the low-rank decomposition matrices.",
-        ),
-    ] = 16
+    alpha: float = Field(32.0, ge=0)
+    """LoRA scaling parameter."""
 
-    alpha: Annotated[
-        float,
-        Field(
-            ge=0,
-            description="LoRA scaling parameter.",
-        ),
-    ] = 32.0
+    dropout: float = Field(0.0, ge=0, le=1)
+    """LoRA dropout rate."""
 
-    dropout: Annotated[
-        float,
-        Field(
-            ge=0,
-            le=1,
-            description="LoRA dropout rate.",
-        ),
-    ] = 0.0
-
-    target_modules: Annotated[
-        list[str],
-        Field(
-            description=(
-                "Module names or regex patterns for modules to apply LoRA to. Simple names (e.g., 'q_proj') "
-                "match any component in the module path. Regex patterns match anywhere in the name. "
-                "Names unknown to the current model are silently ignored, so defaults cover multiple architectures. "
-                "NemotronH note: 'experts' matches NonGatedGroupedExperts inside LatentMoE; 'fc1_latent_proj' and "
-                "'fc2_latent_proj' adapt the latent up/down projections. Add 'in_proj'/'out_proj' to also LoRA Mamba."
-            ),
-        ),
-    ] = [
+    target_modules: list[str] = [
         "q_proj",
         "k_proj",
         "v_proj",
@@ -159,234 +90,95 @@ class LoRAConfig(BaseConfig):
         "fc1_latent_proj",
         "fc2_latent_proj",
     ]
+    """Module names or regex patterns to apply LoRA to. Simple names (e.g. ``q_proj``) match any component in the module path; regex patterns match anywhere in the name. Names unknown to the current model are silently ignored, so defaults cover multiple architectures. NemotronH note: ``experts`` matches NonGatedGroupedExperts inside LatentMoE; ``fc1_latent_proj``/``fc2_latent_proj`` adapt the latent up/down projections. Add ``in_proj``/``out_proj`` to also LoRA Mamba."""
 
-    modules_to_save: Annotated[
-        list[str],
-        Field(
-            description="Module names or regex patterns for modules to keep fully trainable (not freeze). Simple names match any component in the module path. Regex patterns match anywhere in the name.",
-        ),
-    ] = []
+    modules_to_save: list[str] = []
+    """Module names or regex patterns to keep fully trainable (not freeze). Same matching rules as ``target_modules``."""
 
 
 class DebugModelConfig(BaseConfig):
-    """Debugging feature around model and distributed training."""
+    num_layers: int | None = None
+    """Override the number of transformer layers (truncates the model)."""
 
-    num_layers: Annotated[
-        int | None,
-        Field(description="The number of layers in the model."),
-    ] = None
+    random_init: bool = False
+    """Randomly initialize the model instead of loading weights."""
 
-    random_init: Annotated[
-        bool,
-        Field(
-            description="Whether to random initialize the model.",
-        ),
-    ] = False
-
-    force_balanced_routing: Annotated[
-        bool,
-        Field(
-            description="If True, override MoE token-choice routing with a round-robin assignment so every expert receives an equal share of tokens. Intended for fake-data smoke tests where untrained routing would otherwise produce severe expert imbalance and OOM. Gating scores are still gathered from the override indices so the forward pass stays consistent.",
-        ),
-    ] = False
+    force_balanced_routing: bool = False
+    """Replace MoE token-choice routing with a round-robin assignment so every expert sees an equal share. Intended for fake-data smoke tests where untrained routing would otherwise OOM under severe imbalance. Gating scores are still gathered from the override indices so the forward pass stays consistent."""
 
 
 class ModelConfig(BaseModelConfig):
-    """Configures the model for training."""
+    seq_len: int = 2048
+    """Sequence length the model is trained on."""
 
-    seq_len: Annotated[int, Field(description="The sequence length to use for the model.")] = 2048
+    attn: AttnImplementation = "flash_attention_2"
+    """Attention implementation. With CP enabled, ring attention uses the matching kernel family (FA2/FA3/FA4)."""
 
-    attn: Annotated[
-        AttnImplementation,
-        Field(
-            description="The attention implementation to use. When CP is enabled, ring attention uses the matching kernel family (FA2 for flash_attention_2, FA3 for flash_attention_3, FA4 for fa4).",
-        ),
-    ] = "flash_attention_2"
+    compile: CompileConfig | None = None
+    """Compile the model with ``torch.compile``."""
 
-    compile: Annotated[
-        CompileConfig | None,
-        Field(
-            description="Whether to compile the model using `torch.compile`.",
-        ),
-    ] = None
+    ac: ActivationCheckpointConfig | None = None
+    """Activation checkpointing configuration. If None, activation checkpointing is disabled."""
 
-    ac: Annotated[
-        ActivationCheckpointConfig | None,
-        Field(
-            description="Whether to apply activation checkpointing to the model. If None, will not apply activation checkpointing.",
-        ),
-    ] = None
+    ac_offloading: ActivationOffloadingConfig | None = None
+    """Activation offloading configuration. If None, activation offloading is disabled."""
 
-    ac_offloading: Annotated[
-        ActivationOffloadingConfig | None,
-        Field(
-            description="Whether to apply activation offloading to the model. If None, will not apply activation offloading.",
-        ),
-    ] = None
+    fsdp_cpu_offload: bool = False
+    """Enable FSDP CPU offloading for parameters, gradients, and optimizer states. Uses pinned memory for efficient CPU↔GPU transfers."""
 
-    fsdp_cpu_offload: Annotated[
-        bool,
-        Field(
-            description="Whether to enable FSDP CPU offloading for parameters, gradients, and optimizer states. When enabled, uses pinned memory for efficient CPU-GPU transfers.",
-        ),
-    ] = False
+    optim_cpu_offload: bool = False
+    """Offload only optimizer states (momentum, variance) to CPU, keeping weights on GPU. Avoids the H2D all-gather overhead of FSDP CPU offload while still saving GPU memory."""
 
-    optim_cpu_offload: Annotated[
-        bool,
-        Field(
-            description="Whether to enable optimizer state CPU offloading. Unlike fsdp_cpu_offload, this only moves optimizer states (momentum, variance) to CPU, keeping weights on GPU. This avoids the H2D all-gather overhead while still saving GPU memory.",
-        ),
-    ] = False
+    reshard_after_forward: bool = True
+    """Reshard the model after each forward pass."""
 
-    reshard_after_forward: Annotated[
-        bool, Field(description="Whether to reshard the model after each forward pass.")
-    ] = True
+    dp_replicate: int = 1
+    """Data parallel dim where model weights are replicated."""
 
-    dp_replicate: Annotated[
-        int,
-        Field(
-            description="The data parallel dim where model weights are replicated.",
-        ),
-    ] = 1
+    ep: int = 1
+    """Expert parallelism degree for MoE layers. 1 disables EP."""
 
-    ep: Annotated[
-        int,
-        Field(
-            description="The expert parallelism to use if the model has MoE layers. If 1, then no EP will be used.",
-        ),
-    ] = 1
+    ep_comm_backend: EPCommBackend = "torch"
+    """Communication backend for expert parallelism. ``torch`` uses TorchTitan all-to-all collectives; ``deepep`` uses DeepEP custom kernels."""
 
-    ep_comm_backend: Annotated[
-        EPCommBackend,
-        Field(
-            description=(
-                "Communication backend for expert parallelism. "
-                "`torch` uses TorchTitan all-to-all collectives and `deepep` uses DeepEP custom kernels."
-            ),
-        ),
-    ] = "torch"
+    deepep_num_sms: int = Field(20, ge=1)
+    """SMs allocated for DeepEP intranode dispatch/combine kernels. Also determines internode RDMA channel count (``num_channels = num_sms / 2``). Lower values leave more SMs for compute; higher values speed up dispatch/combine. The optimal value depends on EP degree and hardware. Only used when ``ep_comm_backend='deepep'``."""
 
-    deepep_num_sms: Annotated[
-        int,
-        Field(
-            ge=1,
-            description=(
-                "Number of SMs to allocate for DeepEP intranode dispatch/combine kernels. "
-                "Also determines internode RDMA channel count (num_channels = num_sms / 2). "
-                "Lower values leave more SMs for compute; higher values speed up dispatch/combine. "
-                "The optimal value depends on the EP degree and hardware."
-                "Only used when ep_comm_backend='deepep'."
-            ),
-        ),
-    ] = 20
+    deepep_token_chunk_size: int | None = Field(None, ge=1)
+    """Token chunk size for DeepEP MoE pipelining. When set, DeepEP dispatch for chunk i+1 is launched while experts compute chunk i. Only used when ``ep_comm_backend='deepep'``."""
 
-    deepep_token_chunk_size: Annotated[
-        int | None,
-        Field(
-            ge=1,
-            description=(
-                "Optional token chunk size for DeepEP MoE pipelining. "
-                "When set, DeepEP dispatch for chunk i+1 is launched while experts compute chunk i. "
-                "Only used when ep_comm_backend='deepep'."
-            ),
-        ),
-    ] = None
+    cp: int = 1
+    """Context parallelism degree. 1 disables CP."""
 
-    cp: Annotated[
-        int,
-        Field(
-            description="The context parallelism size to use. If 1, then no CP will be used.",
-        ),
-    ] = 1
+    cp_style: Literal["ring", "ulysses"] = "ring"
+    """CP communication style. ``ring`` uses ring-attention all-gather/reduce-scatter (requires custom kernels per attention type). ``ulysses`` uses all-to-all to redistribute Q/K/V from sequence-sharded to head-sharded, runs vanilla attention locally on the full sequence, then all-to-all back — works out-of-the-box with any attention kernel (softmax FA, linear attention, mamba, etc.)."""
 
-    cp_style: Annotated[
-        Literal["ring", "ulysses"],
-        Field(
-            description=(
-                "Context parallelism communication style. "
-                "'ring' uses ring-attention all-gather/reduce-scatter (current default, "
-                "requires custom kernels per attention type). "
-                "'ulysses' uses all-to-all to redistribute Q/K/V from sequence-sharded "
-                "to head-sharded, runs vanilla attention locally on the full sequence, "
-                "then all-to-all back. Works out-of-the-box with any attention kernel "
-                "(softmax FA, linear attention, mamba, etc.)."
-            ),
-        ),
-    ] = "ring"
+    impl: Literal["hf", "custom", "auto"] = "auto"
+    """Model implementation. ``auto`` selects ``custom`` if supported by the model, otherwise ``hf``."""
 
-    impl: Annotated[
-        Literal["hf", "custom", "auto"],
-        Field(
-            description=(
-                "Model implementation to use. 'auto' (default) selects 'custom' if supported by the model, "
-                "otherwise 'hf'."
-            ),
-        ),
-    ] = "auto"
+    optimization_dtype: Literal["bfloat16", "float32"] = "float32"
+    """dtype for model optimization."""
 
-    optimization_dtype: Annotated[
-        Literal["bfloat16", "float32"],
-        Field(
-            description="The dtype to use for the model optimization.",
-        ),
-    ] = "float32"
+    reduce_dtype: Literal["bfloat16", "float32"] = "float32"
+    """dtype for gradient/parameter reductions."""
 
-    reduce_dtype: Annotated[
-        Literal["bfloat16", "float32"],
-        Field(
-            description="The dtype to use for the model reduce.",
-        ),
-    ] = "float32"
+    moe_use_grouped_mm: bool = True
+    """Use grouped mm for MoE layers. Requires compute capability ≥ 9.0."""
 
-    moe_use_grouped_mm: Annotated[
-        bool,
-        Field(
-            description="Whether to use grouped mm for the MoE layers. Require compute capability >= 9.0",
-        ),
-    ] = True
+    fp8: bool = False
+    """FP8 training via DeepGEMM. Replaces ``nn.Linear`` with FP8 blockwise linear and uses FP8 grouped GEMM for MoE experts. Requires SM90 (Hopper) GPUs and ``model.impl='custom'``."""
 
-    fp8: Annotated[
-        bool,
-        Field(
-            description="Whether to use FP8 training via DeepGEMM. Replaces nn.Linear layers with FP8 blockwise linear "
-            "and uses FP8 grouped GEMM for MoE experts. Requires SM90 (Hopper) GPUs and model.impl='custom'.",
-        ),
-    ] = False
+    freeze_moe_router: bool = False
+    """Freeze MoE router parameters during training."""
 
-    freeze_moe_router: Annotated[
-        bool,
-        Field(
-            description="Whether to freeze the MoE router parameters during training.",
-        ),
-    ] = False
+    lora: LoRAConfig | None = None
+    """LoRA configuration. If None, LoRA is disabled."""
 
-    lora: Annotated[
-        LoRAConfig | None,
-        Field(
-            description="Whether to apply LoRA to the model. If None, will not apply LoRA.",
-        ),
-    ] = None
+    debug: DebugModelConfig = DebugModelConfig()
+    """Debugging knobs for the model and distributed training."""
 
-    debug: Annotated[
-        DebugModelConfig,
-        Field(
-            description="Debugging feature around model and distributed training.",
-        ),
-    ] = DebugModelConfig()
-
-    fused_lm_head_token_chunk_size: Annotated[
-        int | Literal["auto", "disabled"],
-        Field(
-            description=(
-                "The flattened token chunk size to use for the fused LM head. "
-                "Three behaviors: "
-                "(1) int >= 1: explicitly set the number of tokens per LM-head chunk; "
-                "(2) 'auto': auto-enable (RL training auto-sets to 8192); "
-                "(3) 'disabled': explicitly disable fused LM head (use vanilla). "
-                "Explicitly setting an integer value for this feature isn't supported for SFT training."
-            ),
-        ),
-    ] = "disabled"
+    fused_lm_head_token_chunk_size: int | Literal["auto", "disabled"] = "disabled"
+    """Flattened token chunk size for the fused LM head. ``int >= 1`` sets the tokens per LM-head chunk explicitly; ``auto`` auto-enables (RL training picks 8192); ``disabled`` uses the vanilla LM head. Integer values aren't supported for SFT training."""
 
     @model_validator(mode="before")
     @classmethod
@@ -462,64 +254,41 @@ class ModelConfig(BaseModelConfig):
 
 
 class TokenizerConfig(BaseConfig):
-    """Configuration for the tokenizer."""
+    name: str | None = None
+    """Tokenizer name or path. If None, the model's default tokenizer is used."""
 
-    name: Annotated[
-        str | None,
-        Field(description="The name or path of the tokenizer to use. If None, will use the model's default tokenizer."),
-    ] = None
+    trust_remote_code: bool | None = None
+    """Trust remote code when initializing the tokenizer. If None, inherits the model's ``trust_remote_code`` setting."""
 
-    trust_remote_code: Annotated[
-        bool | None,
-        Field(
-            description="Whether to trust remote code for tokenizer initialization. If None, will use the model's default trust remote code setting.",
-        ),
-    ] = None
-
-    chat_template: Annotated[
-        str | None,
-        Field(
-            description="The chat template to use for the tokenizer. Can be a Jinja2 template string or a path to a template file. If None, will use the tokenizer's default chat template."
-        ),
-    ] = None
+    chat_template: str | None = None
+    """Chat template for the tokenizer. Either a Jinja2 template string or a path to a template file. If None, the tokenizer's default chat template is used."""
 
 
 class ConstantSchedulerConfig(BaseModel):
-    """Configuration for constant learning rate scheduler."""
-
     type: Literal["constant"] = "constant"
 
 
 class LinearSchedulerConfig(BaseModel):
-    """Configuration for linear learning rate scheduler."""
-
     type: Literal["linear"] = "linear"
 
-    warmup_steps: Annotated[int, Field(ge=0, description="Number of warmup steps for the learning rate scheduler.")] = (
-        10
-    )
+    warmup_steps: int = Field(10, ge=0)
+    """Warmup steps for the learning rate scheduler."""
 
-    decay_steps: Annotated[
-        int,
-        Field(
-            ge=0,
-            description="Number of steps to decay the learning rate during the final portion of training.",
-        ),
-    ] = 10
+    decay_steps: int = Field(10, ge=0)
+    """Steps to decay the learning rate during the final portion of training."""
 
-    min_lr: Annotated[float, Field(ge=0, description="Minimum learning rate to converge to.")] = 0.0
+    min_lr: float = Field(0.0, ge=0)
+    """Minimum learning rate to converge to."""
 
 
 class CosineSchedulerConfig(BaseModel):
-    """Configuration for cosine learning rate scheduler."""
-
     type: Literal["cosine"] = "cosine"
 
-    warmup_steps: Annotated[int, Field(ge=0, description="Number of warmup steps for the learning rate scheduler.")] = (
-        10
-    )
+    warmup_steps: int = Field(10, ge=0)
+    """Warmup steps for the learning rate scheduler."""
 
-    min_lr: Annotated[float, Field(ge=0, description="Minimum learning rate to converge to.")] = 0.0
+    min_lr: float = Field(0.0, ge=0)
+    """Minimum learning rate to converge to."""
 
 
 SchedulerConfig: TypeAlias = Annotated[
@@ -528,36 +297,47 @@ SchedulerConfig: TypeAlias = Annotated[
 
 
 class BaseOptimizerConfig(BaseModel):
-    lr: Annotated[float, Field(ge=0)] = 1e-6
-    weight_decay: Annotated[float, Field(ge=0)] = 0.01
-    max_norm: Annotated[
-        float | None, Field(ge=0, description="Maximum gradient norm to clip. If None, gradient clipping is disabled.")
-    ] = 1.0
+    lr: float = Field(1e-6, ge=0)
+    """Peak learning rate."""
+
+    weight_decay: float = Field(0.01, ge=0)
+    """L2 weight-decay coefficient."""
+
+    max_norm: float | None = Field(1.0, ge=0)
+    """Maximum gradient norm to clip to. If None, gradient clipping is disabled."""
 
 
 class SGDConfig(BaseOptimizerConfig):
     type: Literal["sgd"] = "sgd"
+
     nesterov: bool = True
+    """Use Nesterov momentum."""
+
     momentum: float = 0.9
+    """SGD momentum factor."""
 
 
 class AdamWConfig(BaseOptimizerConfig):
     type: Literal["adamw"] = "adamw"
 
-    betas1: Annotated[float, Field(ge=0)] = 0.9
-    betas2: Annotated[float, Field(ge=0)] = 0.999
+    betas1: float = Field(0.9, ge=0)
+    """Adam first-moment (β1) decay."""
+
+    betas2: float = Field(0.999, ge=0)
+    """Adam second-moment (β2) decay."""
 
 
 class MuonConfig(BaseOptimizerConfig):
     type: Literal["muon"] = "muon"
 
-    mu: Annotated[float, Field(ge=0, description="Momentum factor for the Muon algorithm.")] = 0.95
-    betas1: Annotated[
-        float, Field(ge=0, description="Beta1 for the AdamW/Lion sub-optimizer used on non-Muon params.")
-    ] = 0.9
-    betas2: Annotated[
-        float, Field(ge=0, description="Beta2 for the AdamW/Lion sub-optimizer used on non-Muon params.")
-    ] = 0.95
+    mu: float = Field(0.95, ge=0)
+    """Momentum factor for the Muon algorithm."""
+
+    betas1: float = Field(0.9, ge=0)
+    """β1 for the AdamW/Lion sub-optimizer used on non-Muon params."""
+
+    betas2: float = Field(0.95, ge=0)
+    """β2 for the AdamW/Lion sub-optimizer used on non-Muon params."""
 
 
 class SignSGDConfig(BaseOptimizerConfig):
@@ -570,190 +350,128 @@ OptimizerConfig: TypeAlias = Annotated[
 
 
 class WeightCheckpointConfig(BaseConfig):
-    """Configures saving HF-compatible weight checkpoints."""
+    save_sharded: bool = True
+    """Save the weight checkpoint in sharded format."""
 
-    save_sharded: Annotated[
-        bool,
-        Field(
-            description="Whether to save the weight checkpoint in sharded format.",
-        ),
-    ] = True
+    save_format: Literal["safetensors", "torch"] = "safetensors"
+    """Weight checkpoint serialization format."""
 
-    save_format: Annotated[
-        Literal["safetensors", "torch"],
-        Field(
-            description="The format to save the weight checkpoint in.",
-        ),
-    ] = "safetensors"
-
-    save_adapter_separately: Annotated[
-        bool,
-        Field(
-            description="Whether to save LoRA adapters separately before merging into full model weights.",
-        ),
-    ] = False
+    save_adapter_separately: bool = False
+    """Save LoRA adapters separately before merging into full model weights."""
 
 
 class CheckpointConfig(BaseConfig):
-    """Configures checkpointing the full model, optimizer and training state for resuming training."""
+    output_dir: Path | None = None
+    """Override directory for checkpoints and weights. If set, checkpoints and weight snapshots are written here instead of under the trainer ``output_dir`` — useful for writing large checkpoints to a separate storage volume."""
 
-    output_dir: Annotated[
-        Path | None,
-        Field(
-            description="Override directory for checkpoints and weights. When set, checkpoints and weight snapshots are written here instead of under the trainer output_dir. Useful for writing large checkpoints to a separate storage volume.",
-        ),
-    ] = None
-
-    interval: Annotated[
-        int | None,
-        Field(
-            ge=1,
-            description="Interval at which to save the training checkpoint. If None, will only checkpoint at the end of training.",
-        ),
-    ] = None
+    interval: int | None = Field(None, ge=1)
+    """Interval at which to save the training checkpoint. If None, only checkpoints at the end of training."""
 
     weights: WeightCheckpointConfig | None = WeightCheckpointConfig()
+    """Weight-checkpoint sub-configuration. If None, no HF-compatible weight checkpoints are written."""
 
-    skip_gather_master_weights: Annotated[
-        bool,
-        Field(
-            description="When true, skip gathering and saving HF-compatible weight checkpoints. Useful for large models where the gather is expensive and only DCP checkpoints are needed.",
-        ),
-    ] = False
+    skip_gather_master_weights: bool = False
+    """Skip gathering and saving HF-compatible weight checkpoints. Useful for large models where the gather is expensive and only DCP checkpoints are needed."""
 
-    weights_only: Annotated[
-        bool,
-        Field(
-            description="When true, only save weight checkpoints (no optimizer/scheduler state). Much faster and smaller than full checkpoints, but cannot resume training.",
-        ),
-    ] = False
+    weights_only: bool = False
+    """Save only weight checkpoints (no optimizer/scheduler state). Much faster and smaller than full checkpoints, but cannot resume training."""
 
-    resume_step: Annotated[
-        int | None,
-        Field(
-            ge=-1,
-            description="Step to resume training from. If None, will start from scratch. If -1, will restart from latest checkpoint available.",
-        ),
-    ] = None
+    resume_step: int | None = Field(None, ge=-1)
+    """Step to resume training from. None starts from scratch; ``-1`` restarts from the latest checkpoint available."""
 
-    keep_last: Annotated[
-        int | None,
-        Field(
-            ge=1,
-            description="Keep at most this many recent step checkpoints on disk. If None, never clean old checkpoints based on recency.",
-        ),
-    ] = None
+    keep_last: int | None = Field(None, ge=1)
+    """Keep at most this many recent step checkpoints on disk. If None, never clean old checkpoints based on recency."""
 
-    keep_interval: Annotated[
-        int | None,
-        Field(
-            ge=1,
-            description="Keep checkpoints at every N steps permanently (e.g., keep_interval=100 keeps step 100, 200, ...). If None, no interval-based keeping.",
-        ),
-    ] = None
+    keep_interval: int | None = Field(None, ge=1)
+    """Keep checkpoints at every N steps permanently (e.g. ``keep_interval=100`` keeps step 100, 200, ...). If None, no interval-based keeping."""
 
-    skip_progress: Annotated[
-        bool,
-        Field(
-            description="Whether to skip loading the progress from checkpoint.",
-        ),
-    ] = False
+    skip_progress: bool = False
+    """Skip loading the progress from checkpoint."""
 
-    skip_scheduler: Annotated[
-        bool,
-        Field(
-            description="Whether to skip loading the scheduler from checkpoint.",
-        ),
-    ] = False
+    skip_scheduler: bool = False
+    """Skip loading the scheduler from checkpoint."""
 
-    skip_dataloader: Annotated[
-        bool,
-        Field(
-            description="Whether to skip loading the dataloader from checkpoint.",
-        ),
-    ] = False
+    skip_dataloader: bool = False
+    """Skip loading the dataloader from checkpoint."""
 
-    skip_optimizer: Annotated[
-        bool,
-        Field(
-            description="Whether to skip loading the optimizer state from checkpoint.",
-        ),
-    ] = False
+    skip_optimizer: bool = False
+    """Skip loading the optimizer state from checkpoint."""
 
 
 class DefaultLossConfig(BaseModel):
-    """Knobs for the default DPPO+KL loss. Only consumed by rl-mode batches
-    (``default_loss_fn``); opd and sft have their own self-contained loss fns."""
-
     type: Literal["default"] = "default"
 
-    dppo_mask_low: Annotated[float, Field(ge=0, description="The low threshold for masking tokens.")] = 0.2
-    dppo_mask_high: Annotated[float, Field(ge=0, description="The high threshold for masking tokens.")] = 0.2
-    adv_tau: Annotated[float, Field(ge=0, description="The tau for advantages.")] = 1.0
-    kl_tau: Annotated[float, Field(ge=0, description="The tau for KL divergence.")] = 1e-3
+    dppo_mask_low: float = Field(0.2, ge=0)
+    """Lower DPPO masking threshold."""
+
+    dppo_mask_high: float = Field(0.2, ge=0)
+    """Upper DPPO masking threshold."""
+
+    adv_tau: float = Field(1.0, ge=0)
+    """Temperature for the advantage term."""
+
+    kl_tau: float = Field(1e-3, ge=0)
+    """Temperature for the KL term."""
 
 
 class CustomLossConfig(BaseModel):
-    """Override for the rl-mode loss fn. opd and sft are unaffected."""
-
     type: Literal["custom"] = "custom"
 
-    import_path: Annotated[str, Field(description="Import path to the loss function (e.g., 'my_module.my_loss')")]
-    kwargs: Annotated[dict[str, Any], Field(default_factory=dict, description="Kwargs to pass to the loss function")]
+    import_path: str
+    """Import path to the loss function (e.g. ``my_module.my_loss``)."""
+
+    kwargs: dict[str, Any] = Field(default_factory=dict)
+    """Kwargs forwarded to the loss function."""
 
 
 LossConfig: TypeAlias = Annotated[DefaultLossConfig | CustomLossConfig, Field(discriminator="type")]
 
 
 class FakeDataLoaderConfig(BaseConfig):
-    """Configures a fake data loader sampling random micro batches for debugging."""
+    batch_size: int = Field(2, ge=1)
+    """Batch size of the fake data loader."""
 
-    batch_size: Annotated[int, Field(ge=1)] = 2
-    generate_samples: Annotated[
-        bool, Field(description="Whether to generate separate samples and pack them into a single micro batch.")
-    ] = False
+    generate_samples: bool = False
+    """Generate separate samples and pack them into a single micro-batch instead of using random tensors."""
 
 
 class DataLoaderConfig(BaseConfig):
-    """Configures the data loader used for training."""
-
-    fake: Annotated[FakeDataLoaderConfig | None, Field(description="Whether to use a fake data loader.")] = None
+    fake: FakeDataLoaderConfig | None = None
+    """Use a fake data loader sampling random micro-batches (for debugging)."""
 
 
 class BaseWeightBroadcastConfig(BaseModel):
-    """Configures the base weight broadcast."""
-
     pass
 
 
 class FileSystemWeightBroadcastConfig(BaseWeightBroadcastConfig):
-    """Configures the weight broadcast."""
-
     type: Literal["filesystem"] = "filesystem"
-    save_sharded: Annotated[bool, Field(description="Whether to save the weight checkpoint in sharded format.")] = True
-    save_format: Annotated[
-        Literal["safetensors", "torch"], Field(description="The format to save the weight checkpoint in.")
-    ] = "safetensors"
+
+    save_sharded: bool = True
+    """Save the weight checkpoint in sharded format."""
+
+    save_format: Literal["safetensors", "torch"] = "safetensors"
+    """Weight checkpoint serialization format."""
 
 
 class NCCLWeightBroadcastConfig(BaseWeightBroadcastConfig):
-    """Configures the NCCL broadcast."""
-
     type: Literal["nccl"] = "nccl"
-    host: Annotated[str, Field(description="The host to use for the NCCL broadcast.")] = "localhost"
-    port: Annotated[int, Field(description="The port to use for the NCCL broadcast.")] = 29501
-    timeout: Annotated[int, Field(description="The timeout in seconds to use for the NCCL broadcast.")] = 1200
+
+    host: str = "localhost"
+    """Host for the NCCL broadcast rendezvous."""
+
+    port: int = 29501
+    """Port for the NCCL broadcast rendezvous."""
+
+    timeout: int = 1200
+    """Timeout in seconds for the NCCL broadcast."""
+
     # TODO: Should not be configurable, but auto-inferred
-    inference_world_size: Annotated[int, Field(description="The number of GPUs used for inference.")] = 1
-    quantize_in_weight_transfer: Annotated[
-        bool,
-        Field(
-            description=(
-                "Use kernel-format FP8 quantized NCCL transfer for weight updates. "
-                "When disabled, uses default HF checkpoint-format transfer."
-            ),
-        ),
-    ] = False
+    inference_world_size: int = 1
+    """Number of GPUs used for inference."""
+
+    quantize_in_weight_transfer: bool = False
+    """Use kernel-format FP8 quantized NCCL transfer for weight updates. When disabled, uses default HF checkpoint-format transfer."""
 
 
 WeightBroadcastConfig: TypeAlias = Annotated[
@@ -762,132 +480,84 @@ WeightBroadcastConfig: TypeAlias = Annotated[
 
 
 class TrainerExperimentalConfig(BaseConfig):
-    """Experimental features for the trainer."""
+    pass
 
 
 class TrainerConfig(BaseConfig):
-    """Configures the RL trainer"""
-
-    # The model configuration
     model: ModelConfig = ModelConfig()
+    """Model configuration."""
 
-    # The tokenizer configuration
     tokenizer: TokenizerConfig = TokenizerConfig()
+    """Tokenizer configuration."""
 
-    # The data configuration
     data: DataLoaderConfig = DataLoaderConfig()
+    """Data loader configuration."""
 
-    # Loss config for the rl-mode batches only. opd and sft batches dispatch to
-    # opd_loss_fn / sft_loss_fn unconditionally - they don't read trainer.loss.
     loss: LossConfig = DefaultLossConfig()
+    """Loss config for rl-mode batches. opd and sft batches dispatch to their own loss fns unconditionally and do not read this."""
 
-    # The optimizer configuration
     optim: OptimizerConfig = AdamWConfig()
+    """Optimizer configuration."""
 
-    # The learning rate scheduler configuration
     scheduler: SchedulerConfig = ConstantSchedulerConfig()
+    """Learning-rate scheduler configuration."""
 
-    # The checkpoint configuration
     ckpt: CheckpointConfig | None = None
+    """Full training-state checkpoint configuration (model + optimizer + scheduler). If None, no resume-capable checkpoints are written."""
 
     weight_broadcast: WeightBroadcastConfig = FileSystemWeightBroadcastConfig()
+    """Transport used to broadcast updated weights from trainer to inference."""
 
     rollout_transport: TransportConfig = FileSystemTransportConfig()
+    """Transport used to ship rollouts from orchestrator to trainer."""
 
-    # The logging configuration
     log: TrainerLogConfig = TrainerLogConfig()
+    """Logger configuration."""
 
-    # The wandb configuration
     wandb: WandbConfig | None = None
+    """Weights & Biases configuration."""
 
-    output_dir: Annotated[
-        Path,
-        Field(
-            description="Directory to write outputs to. Will be populated with checkpoints, weights, rollouts and logs as subdirectories. Should be set to a persistent directory with enough disk space. This value should be distinct across experiments running on a single node. See the README for more details."
-        ),
-    ] = Path("outputs")
+    output_dir: Path = Path("outputs")
+    """Directory to write outputs to — checkpoints, weights, rollouts, and logs are written as subdirectories. Should be a persistent directory with enough disk space and unique per experiment running on a single node."""
 
-    matmul_precision: Annotated[
-        Literal["highest", "high", "medium"],
-        Field(
-            description=(
-                "Precision for float32 matrix multiplications. "
-                "Use 'highest' for full FP32 (required on ROCm/AMD GPUs to avoid "
-                "catastrophic precision loss in softmax over large vocabularies). "
-                "Use 'high' to enable TF32 on NVIDIA GPUs for a speedup with minor "
-                "precision tradeoff. See torch.set_float32_matmul_precision docs."
-            ),
-        ),
-    ] = "high"
+    matmul_precision: Literal["highest", "high", "medium"] = "high"
+    """Precision for float32 matrix multiplications. ``highest`` is full FP32 (required on ROCm/AMD GPUs to avoid catastrophic precision loss in softmax over large vocabularies). ``high`` enables TF32 on NVIDIA GPUs for a speedup with minor precision tradeoff. See ``torch.set_float32_matmul_precision``."""
 
-    max_steps: Annotated[
-        int | None,
-        Field(
-            description="Maximum number of steps to run training for. If None, will run indefinitely.",
-        ),
-    ] = None
+    max_steps: int | None = None
+    """Maximum number of training steps. If None, runs indefinitely."""
 
-    max_async_level: Annotated[
-        int,
-        Field(
-            ge=0,
-            description="Maximum number of steps that inference can be ahead of training. Determines how 'off-policy' the inference engines can be. Higher values yield better throughput through async execution, but may yield lower performance. If 0, will be fully synchronous.",
-        ),
-    ] = 1
+    max_async_level: int = Field(1, ge=0)
+    """Maximum steps inference can be ahead of training (how off-policy inference can be). Higher values yield better throughput via async execution at the cost of policy lag; ``0`` is fully synchronous."""
 
-    enable_router_replay: Annotated[
-        bool,
-        Field(
-            description="Whether to enable router replay. If True, will return routed experts in the batch. This is only supported if `enable_return_routed_experts=True` in the inference config or pass `--enable-return-routed-experts` to vLLM server. This is only supported for custom models.",
-        ),
-    ] = False
+    enable_router_replay: bool = False
+    """Return routed experts in the batch so the trainer can replay routing. Requires ``enable_return_routed_experts=true`` on the vLLM server (or ``--enable-return-routed-experts``) and is only supported for custom models."""
 
-    memory_profiler_path: Annotated[Path | None, Field(description="Path to write memory profile to.")] = None
+    memory_profiler_path: Path | None = None
+    """Path to write the memory profile to."""
 
-    bench: Annotated[
-        BenchConfig | None,
-        Field(
-            description="Whether to run in benchmark mode. It will automatically set the maximum number of steps to run to 4 and use fake data.",
-        ),
-    ] = None
+    bench: BenchConfig | None = None
+    """Benchmark-mode configuration. When set, ``max_steps`` is forced to 4 and fake data is used."""
 
-    gc: Annotated[
-        GCConfig | None,
-        Field(
-            description="Garbage collection config. Disables automatic GC and runs deterministic collections every N steps to avoid stragglers. Set to null to use Python's default GC behavior.",
-        ),
-    ] = GCConfig()
+    gc: GCConfig | None = GCConfig()
+    """Garbage collection config. Disables automatic GC and runs deterministic collections every N steps to avoid stragglers. Set to null to use Python's default GC behavior."""
 
-    trace_path: Annotated[Path | None, Field(description="Path to write pytorch profiler trace to.")] = None
+    trace_path: Path | None = None
+    """Path to write the PyTorch profiler trace to."""
 
-    dist_timeout_seconds: Annotated[
-        int,
-        Field(
-            description="Timeout in seconds for torch distributed ops. Defaults to 600 seconds.",
-        ),
-    ] = 600
+    dist_timeout_seconds: int = 600
+    """Timeout in seconds for torch distributed ops."""
 
-    heartbeat: Annotated[
-        HeartbeatConfig | None, Field(description="The heartbeat config for monitoring training progress.")
-    ] = None
+    heartbeat: HeartbeatConfig | None = None
+    """BetterStack heartbeat configuration for monitoring training progress."""
 
-    metrics_server: Annotated[
-        MetricsServerConfig | None,
-        Field(description="Prometheus metrics server config. If set, exposes /metrics endpoint for scraping."),
-    ] = None
+    metrics_server: MetricsServerConfig | None = None
+    """Prometheus metrics server configuration. If set, exposes a ``/metrics`` endpoint for scraping."""
 
-    max_concurrent_runs: Annotated[
-        int,
-        Field(
-            ge=1,
-            description="The maximum number of concurrent runs to allow. If 1, then only one run will be allowed at a time.",
-        ),
-    ] = 1
+    max_concurrent_runs: int = Field(1, ge=1)
+    """Maximum number of concurrent runs to allow. If 1, only one run may run at a time."""
 
-    experimental: Annotated[
-        TrainerExperimentalConfig,
-        Field(description="Experimental features for the trainer."),
-    ] = TrainerExperimentalConfig()
+    experimental: TrainerExperimentalConfig = TrainerExperimentalConfig()
+    """Experimental trainer features."""
 
     @model_validator(mode="after")
     def deepep_disables_grad_clipping(self):


### PR DESCRIPTION
## Summary
- Convert every config field from `Annotated[T, Field(description=...)]` to a plain typed assignment + PEP 224 attribute docstring on the next line. `Field(...)` is kept only where it carries other metadata (`ge=`/`gt=`, `validation_alias=`, `default_factory=`).
- Tighten descriptions: drop restatements of the field name, drop mentions of defaults and aliases (the help renderer shows those automatically), drop pydantic model docstrings, and drop sub-config field docstrings that just restated the field name (`"""Logger configuration."""` on `log: LogConfig`). Kept the docstrings that carry real info (gating semantics, propagation, side-effects, etc.).
- Switch every discriminated-union variant (and standalone `BaseModel` configs like `KVCacheOffloadConfig`) from `BaseModel` to `BaseConfig` and drop the per-class `model_config = ConfigDict(extra="forbid")` line — `BaseConfig` already bakes in `extra="forbid"` and the TOML `"None"` → `None` coercion. Also closes inconsistencies where some DUV variants had `extra="forbid"` and others didn't.
- Net change is ~1.4k fewer lines across the seven config modules.
- Fix typo in `examples/wordle/sft.toml` (`micro-batch-size` → `micro_batch_size`) that was silently dropped under the old `extra="ignore"` and is now rejected.
- Bumps the pydantic-config submodule twice:
  - PrimeIntellect-ai/pydantic-config#12 — MRO-aware docstring extraction (so subclasses keep descriptions on inherited fields like `ModelConfig(BaseModelConfig).name`) and `default_factory` rendering in `--help` (so `LogConfig.level` shows `default: info` instead of `required`).
  - PrimeIntellect-ai/pydantic-config#13 — per-panel flag column widths, 60-char cap with oversize flags rendered on their own line, inline `(default: X)` instead of a right-aligned column, and title/flag wrapping so the box always fits the terminal.

## Verification
- `uv run {trainer,orchestrator,inference,sft,rl,env-server} --help --plain` all render cleanly with descriptions on every field; verified at `COLUMNS=80/100/160/200`.
- `uv run pytest tests/unit/test_configs.py tests/unit/orchestrator --ignore=tests/unit/orchestrator/test_orchestrator_setup.py` → 210 passed (the ignored file fails to collect because `flash_attn` isn't installed in this env; pre-existing).
- `uv run ruff check packages/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches most config schemas and validation by migrating fields off `Annotated[..., Field(description=...)]` and standardizing models on `BaseConfig`, which could subtly change parsing/CLI help and extra-field handling. Also bumps `prime-pydantic-config` and fixes a sample TOML key, so downstream config consumers may need to update.
> 
> **Overview**
> Refactors the `prime-rl-configs` schema to move field documentation from `Field(description=...)`/`Annotated` into PEP-224 attribute docstrings, keeping `Field(...)` only where it encodes validation metadata (bounds, aliases, factories). Related cleanup standardizes many config variants (including discriminated-union members) on `BaseConfig` and drops redundant per-class `extra="forbid"` configuration.
> 
> Updates dependencies to `prime-pydantic-config>=0.3.0.dev82` (to support docstring-based help rendering) and fixes the example `examples/wordle/sft.toml` to use `micro_batch_size` (previous `micro-batch-size` would now be rejected under stricter config parsing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a214ff2c8ce54ae12ee36359d227d000992c0642. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->