### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prime-rl"
-version = "0.4.0"
+version = "0.5.0"
 description = "Async RL Training at Scale"
 readme = "README.md"
 requires-python = "~=3.12.0"

--- a/uv.lock
+++ b/uv.lock
@@ -3886,7 +3886,7 @@ dev = [
 
 [[package]]
 name = "prime-rl"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },


### PR DESCRIPTION
## Summary
- Bump `prime-rl` version in `pyproject.toml` from `0.4.0` to `0.5.0` to match the latest GitHub release (`v0.5.0`).
- Re-sync `uv.lock` to reflect the new package version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a packaging-only change that updates the project/version metadata and lockfile, with no runtime code modifications.
> 
> **Overview**
> Bumps the `prime-rl` package version from `0.4.0` to `0.5.0` in `pyproject.toml` and updates `uv.lock` to reflect the new version in the locked workspace metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 191df1caf1590f34c9dd4cb4151e104ca961f844. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->