### PR TITLE
fix(slurm): release allocation when any component crashes

### DIFF
--- a/src/prime_rl/templates/inference.sbatch.j2
+++ b/src/prime_rl/templates/inference.sbatch.j2
@@ -21,6 +21,10 @@
 #SBATCH --output={{ output_dir }}/job_%j.log
 #SBATCH --error={{ output_dir }}/job_%j.log
 
+# Exit immediately on any failed command so a crash anywhere releases the
+# allocation instead of leaving zombie processes holding nodes.
+set -e
+
 # Configs
 export NUM_NODES={{ num_nodes }}
 export GPUS_PER_NODE={{ gpus_per_node }}
@@ -130,7 +134,15 @@ srun bash -c '
 '
 
 # Run inference
-srun bash -c '
+# --kill-on-bad-exit=1 propagates a non-zero exit on any node to all other
+# tasks so a crashed router/engine terminates the SLURM job instead of leaving
+# the surviving ranks holding nodes.
+srun --kill-on-bad-exit=1 bash -c '
+    # pipefail ensures `cmd | tee log` propagates `cmd` failures, and the
+    # wait/cleanup block at the end of this script surfaces background
+    # process crashes (router) as task failures.
+    set -o pipefail
+
     cd $PROJECT_DIR
     [ -f .env ] && source .env
     source .venv/bin/activate
@@ -262,7 +274,7 @@ srun bash -c '
         --parallel.dp $EP \
         --data-parallel-rpc-port $RPC_PORT \
         --vllm-extra "$VLLM_EXTRA" \
-        2>&1 | tee -a $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log
+        2>&1 | tee -a $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log &
 {%- elif num_nodes > 1 %}
     echo "INFER_NODE_RANK=${INFER_NODE_RANK}, LOCAL_IP=${LOCAL_IP}" \
         | tee $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log
@@ -289,7 +301,7 @@ srun bash -c '
         @ $CONFIG_PATH \
         --server.host 0.0.0.0 \
         --server.port $BACKEND_PORT \
-        2>&1 | tee -a $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log
+        2>&1 | tee -a $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log &
 {%- else %}
     echo "INFER_NODE_RANK=${INFER_NODE_RANK}, LOCAL_IP=${LOCAL_IP}" | tee $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log
     # Required for graph compilation to work
@@ -297,6 +309,18 @@ srun bash -c '
 
     uv run inference \
         @ $CONFIG_PATH \
-        2>&1 | tee -a $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log
+        2>&1 | tee -a $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log &
 {%- endif %}
+
+# Wait for the first background job to exit and propagate its exit code. This
+# turns background process crashes (router) into task failures that
+# --kill-on-bad-exit=1 can broadcast to the other nodes so the whole job tears
+# down instead of leaving zombies holding the allocation.
+wait -n
+EXIT_CODE=$?
+echo "[$(hostname)] component exited with code $EXIT_CODE - terminating remaining processes"
+for pid in $(jobs -p); do
+    kill -TERM $pid 2>/dev/null || true
+done
+exit $EXIT_CODE
 '

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -21,6 +21,10 @@
 #SBATCH --output={{ output_dir }}/job_%j.log
 #SBATCH --error={{ output_dir }}/job_%j.log
 
+# Exit immediately on any failed command so a crash anywhere releases the
+# allocation instead of leaving zombie processes holding nodes.
+set -e
+
 # Configs
 export NUM_TRAIN_NODES={{ num_train_nodes }}
 export NUM_INFER_NODES={{ num_infer_nodes }}
@@ -174,7 +178,15 @@ srun bash -c '
 '
 
 # Run RL
-srun bash -c '
+# --kill-on-bad-exit=1 propagates a non-zero exit on any node to all other
+# tasks so a crashed component terminates the SLURM job instead of leaving the
+# surviving ranks holding nodes.
+srun --kill-on-bad-exit=1 bash -c '
+    # pipefail ensures `cmd | tee log` propagates `cmd` failures, and the
+    # wait/cleanup block at the end of this script surfaces background
+    # process crashes (router, orchestrator) as task failures.
+    set -o pipefail
+
     # Source environment
     cd $PROJECT_DIR
     [ -f .env ] && source .env
@@ -313,7 +325,7 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
         --parallel.dp $DP \
         --data-parallel-rpc-port $INFERENCE_DATA_PARALLEL_RPC_PORT \
         --vllm-extra "$VLLM_EXTRA" \
-        2>&1 | tee -a $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log
+        2>&1 | tee -a $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log &
 {%- else -%}
     # Start vllm-router on the first node of each replica
     if [ "$RANK_IN_REPLICA" -eq 0 ]; then
@@ -349,13 +361,13 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
             --server.port $BACKEND_PORT \
             --data-parallel-rpc-port $INFERENCE_DATA_PARALLEL_RPC_PORT \
             --vllm-extra "$VLLM_EXTRA" \
-            2>&1 | tee -a $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log
+            2>&1 | tee -a $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log &
     else
         uv run inference \
             @ $CONFIG_DIR/inference.toml \
             --server.host 0.0.0.0 \
             --server.port $BACKEND_PORT \
-            2>&1 | tee -a $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log
+            2>&1 | tee -a $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log &
     fi
 {%- endif %}
 
@@ -394,6 +406,18 @@ else
         --local-ranks-filter={{ ranks_filter }} \
         -m prime_rl.trainer.rl.train \
         @ $CONFIG_DIR/trainer.toml \
-        2>&1 | sed -u 's/^\[[a-zA-Z]*[0-9]*\]://' | tee -a $OUTPUT_DIR/logs/trainer/node_${TRAIN_NODE_RANK}.log
+        2>&1 | sed -u 's/^\[[a-zA-Z]*[0-9]*\]://' | tee -a $OUTPUT_DIR/logs/trainer/node_${TRAIN_NODE_RANK}.log &
 {% if num_infer_nodes > 0 %}    fi{% endif %}
+
+# Wait for the first background job to exit and propagate its exit code. This
+# turns background process crashes (router, orchestrator) into task failures
+# that --kill-on-bad-exit=1 can broadcast to the other nodes so the whole job
+# tears down instead of leaving zombies holding the allocation.
+wait -n
+EXIT_CODE=$?
+echo "[$(hostname)] component exited with code $EXIT_CODE - terminating remaining processes"
+for pid in $(jobs -p); do
+    kill -TERM $pid 2>/dev/null || true
+done
+exit $EXIT_CODE
 '

--- a/src/prime_rl/templates/multi_node_sft.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_sft.sbatch.j2
@@ -21,6 +21,10 @@
 #SBATCH --output={{ output_dir }}/job_%j.log
 #SBATCH --error={{ output_dir }}/job_%j.log
 
+# Exit immediately on any failed command so a crash on any node releases the
+# allocation instead of leaving zombie processes holding nodes.
+set -e
+
 # Configs
 export NUM_NODES={{ num_nodes }}
 export GPUS_PER_NODE={{ gpus_per_node }}
@@ -81,7 +85,12 @@ srun bash -c '
 '
 
 # Run SFT
-srun bash -c '
+# --kill-on-bad-exit=1 propagates a non-zero exit on any node to all other
+# tasks so a single trainer crash terminates the entire SLURM job instead of
+# leaving the surviving ranks (and their nodes) idle.
+srun --kill-on-bad-exit=1 bash -c '
+    set -o pipefail
+
     # Setup environment
     [ -f $PROJECT_DIR/.env ] && source $PROJECT_DIR/.env
     source $PROJECT_DIR/.venv/bin/activate

--- a/src/prime_rl/templates/single_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/single_node_rl.sbatch.j2
@@ -21,6 +21,10 @@
 #SBATCH --output={{ output_dir }}/job_%j.log
 #SBATCH --error={{ output_dir }}/job_%j.log
 
+# Exit immediately if any setup command or the launcher fails so the SLURM job
+# releases its allocation instead of holding nodes after a crash.
+set -e
+
 export PROJECT_DIR={{ project_dir }}
 
 # Setup environment

--- a/src/prime_rl/templates/single_node_sft.sbatch.j2
+++ b/src/prime_rl/templates/single_node_sft.sbatch.j2
@@ -21,6 +21,10 @@
 #SBATCH --output={{ output_dir }}/job_%j.log
 #SBATCH --error={{ output_dir }}/job_%j.log
 
+# Exit immediately if any setup command or the launcher fails so the SLURM job
+# releases its allocation instead of holding nodes after a crash.
+set -e
+
 export PROJECT_DIR={{ project_dir }}
 
 # Setup environment


### PR DESCRIPTION
## Summary

Fixes #2574 — when running on SLURM, a single component crash (trainer, inference, orchestrator, or router) left the surviving components running and held the allocation until walltime. The sbatch script now propagates the failure so nodes are released promptly.

- `srun --kill-on-bad-exit=1` so a non-zero exit on any task kills all other tasks (cross-node propagation).
- All per-node components run in the background; `wait -n` turns the first exit into the task exit code. This surfaces background-process crashes (router, orchestrator) that the previous foreground layout silently ignored.
- `set -o pipefail` inside the task script so `cmd | tee log` propagates `cmd`'s exit code.
- `set -e` in outer sbatch so setup failures (e.g. `uv sync`) don't slip past.

Applied to: `single_node_rl`, `single_node_sft`, `multi_node_sft`, `multi_node_rl`, and `inference` (covers single-node, multi-node, and disaggregated PD modes).

## Verification

Verified locally without a SLURM cluster:

| Check | Result |
|---|---|
| `bash -n` on all 6 rendered variants | pass |
| Backgrounded component crashes → `wait -n` returns crash exit code | pass (exit 42) |
| Trainer-finishes-first success path → exit 0, services SIGTERM'd within ~1s | pass |
| Pipefail propagates failure through `\| tee` | pass (exit 7) |
| Simulated 2-task srun: task 0 inference crash kills task 1 within 2s | pass |

### Real-cluster verification (single-node H200, `examples/reverse_text`)

For each subprocess managed by `rl_local`, submitted the rendered `single_node_rl.sbatch`, waited until orchestrator was stepping, then externally SIGKILLed the named component:

```
srun --jobid=<job> --overlap kill -9 <component PID>
```

| Killed component | Job exit code | Kill → `FAILED` | Trace in `job_<id>.log` |
|---|---|---|---|
| `PRIME-RL::Inference` (19290) | `1:0` | **14 s** | `Error: Inference failed with exit code -9` + orchestrator httpx traceback |
| `PRIME-RL::Orchestrator` (19292) | `1:0` | **17 s** | `Error: Orchestrator failed with exit code -9` + `Terminating all processes...` |
| `PRIME-RL::Trainer` (19293) | `1:0` | **17 s** | `Error: Trainer failed with exit code 1` + torchrun `ConnectionResetError` |

In every case `rl_local`'s monitor thread caught the subprocess crash, called `cleanup_processes` on the survivors, and `sys.exit(1)`'d; `set -e` in the sbatch propagated that to SLURM, which released the node. Node went back to `idle` in `squeue` immediately after.

Same end-state was reached spontaneously on an earlier run where the trainer crashed during wandb auth — full Python traceback in `job_<id>.log`, SLURM `FAILED` 1m34s later, node released. Confirms the failure propagation path also works for in-process crashes, not just externally induced ones.

Multi-node `srun --kill-on-bad-exit=1` cross-node kill was not exercised here (single-node test only); that path is well-documented SLURM behavior and is unchanged by this PR's other guards.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SLURM launcher behavior across inference/RL/SFT templates to aggressively propagate failures and terminate backgrounded components; misconfiguration could cause premature job termination or mask logs, but scope is limited to batch scripts.
> 
> **Overview**
> Ensures SLURM allocations are released promptly when any training/inference component crashes by updating all `*.sbatch.j2` templates.
> 
> Adds `set -e` to fail fast on setup errors, wraps launches with `srun --kill-on-bad-exit=1` plus `set -o pipefail` so `cmd | tee` failures propagate, and backgrounds per-node components (trainer/inference/router/orchestrator) with a `wait -n`/SIGTERM cleanup block to convert the first component exit into the task (and thus job) exit status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 531f60cab98407f54da4d691a3a056854fb7fb4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->