### PR TITLE
fix(wandb): handle shared mode breakage from wandb v0.26.1

### DIFF
--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -9,6 +9,7 @@ import verifiers as vf
 import wandb
 from transformers.tokenization_utils import PreTrainedTokenizer
 from wandb.errors import CommError
+from wandb.sdk.mailbox.mailbox_handle import ServerResponseError
 
 from prime_rl.configs.shared import WandbConfig, WandbWithExtrasConfig
 from prime_rl.utils.chat_template import deserialize_tool_calls
@@ -71,11 +72,14 @@ class WandbMonitor(Monitor):
             mode = os.environ.get("WANDB_MODE", "offline" if config.offline else "online")
             settings = wandb.Settings(mode=mode)
 
+        retryable_errors = (CommError, ServerResponseError) if shared_mode and not primary else (CommError,)
+
         def init_wandb(max_retries: int):
             for attempt in range(max_retries):
                 try:
                     return wandb.init(
                         id=run_id,
+                        resume="allow" if run_id else None,
                         project=config.project,
                         entity=config.entity,
                         name=config.name,
@@ -85,7 +89,7 @@ class WandbMonitor(Monitor):
                         config=run_config.model_dump() if run_config else None,
                         settings=settings,
                     )
-                except CommError as e:
+                except retryable_errors as e:
                     if attempt + 1 == max_retries:
                         raise
                     if shared_mode and not primary:

--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -72,7 +72,7 @@ class WandbMonitor(Monitor):
             mode = os.environ.get("WANDB_MODE", "offline" if config.offline else "online")
             settings = wandb.Settings(mode=mode)
 
-        retryable_errors = (CommError, ServerResponseError) if shared_mode and not primary else (CommError,)
+        retryable_errors = (CommError, ServerResponseError) if shared_mode else (CommError,)
 
         def init_wandb(max_retries: int):
             for attempt in range(max_retries):
@@ -99,6 +99,11 @@ class WandbMonitor(Monitor):
                     else:
                         msg = f"Transient W&B init error ({e}) - retrying in 10s ({attempt + 1}/{max_retries})"
                     self.logger.info(msg)
+                    # A failed wandb.init leaves the run_id registered in the local
+                    # wandb-core StreamMux, causing the next attempt to fail with
+                    # "run ID ... is in use". Tear down the service so the retry
+                    # starts from a clean state.
+                    wandb.teardown()
                     time.sleep(10)
 
         # Non-primary processes in shared mode wait for the primary to create the run.


### PR DESCRIPTION
## Summary

wandb v0.26.1 ([PR #11759](https://github.com/wandb/wandb/pull/11759)) changed `inform_init` to propagate duplicate stream ID errors as `ServerResponseError` instead of silently swallowing them. The change was intended to fix `reinit="create_new"`, but the implementation also breaks shared mode — where the orchestrator and trainer intentionally call `wandb.init(id=same_run_id)` to log to a single run.

- Add `resume="allow"` when a run ID is provided so wandb attaches to the existing run instead of rejecting it
- Catch `ServerResponseError` (alongside `CommError`) on **both** sides — the upsertBucket race is symmetric and either side can hit it
- Call `wandb.teardown()` between init retries so the local wandb-core `StreamMux` is cleared

### Why teardown is needed

A failed `wandb.init` leaves the run ID registered in the local wandb-core's [`StreamMux`](https://github.com/wandb/wandb/blob/main/core/internal/stream/stream_mux.go). The next retry calls `inform_init` against the same wandb-core, finds the stream still there, and the `AddStream` call returns `"run ID ... is in use"` as `ServerResponseError` — before reaching the server, so `resume="allow"` doesn't help. Tearing down the service clears the local state and the retry starts fresh.

Fixes `wandb.sdk.mailbox.mailbox_handle.ServerResponseError: run ID <id> is in use`

## Verification

Ran `uv run rl @ examples/reverse_text/rl.toml --max-steps 5` 5 consecutive times on this branch — all 5 reached step 4 and finished cleanly. Run 1 reproduced the original failure mode on the orchestrator (primary) side and recovered via the new path:

```
21:43:40 orchestrator: Transient W&B init error (run "80d71bd5..." not found while updating run) - retrying in 10s (1/5)
21:43:50 orchestrator: wandb: Resuming run pr2578-fix-run1
21:44:24 orchestrator: SUCCESS Step 4 | Reward: 0.2263
```

Without `wandb.teardown()` between retries, the second attempt would have failed with `ServerResponseError: run ID 80d71bd5... is in use` from the orchestrator's own wandb-core. Runs 2, 3, and 5 also recorded the underlying race (`Duplicate entry '...' for key 'runs.PRIMARY'` 409 from upsertBucket) but recovered transparently inside wandb-core's HTTP retry layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches W&B run initialization/retry behavior and adds service teardown between retries; failures here can prevent experiment logging or cause repeated init attempts. Scope is small and limited to the W&B monitor, but it changes error handling and resume semantics in shared mode.
> 
> **Overview**
> Improves robustness of `WandbMonitor` initialization in **shared W&B mode** to handle wandb v0.26.1 raising duplicate stream ID failures.
> 
> When a shared `run_id` is present, `wandb.init` now uses `resume="allow"`, retries also treat `ServerResponseError` as transient (in addition to `CommError`), and each failed init attempt calls `wandb.teardown()` before sleeping to clear local wandb-core state and avoid "run ID is in use" on retry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4193184b976c3d177c7b29c7db2126b2d7c7fb3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->