### PR TITLE
Align rollout error rescheduling with verifiers

### DIFF
--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -31,15 +31,6 @@ def is_reschedulable_rollout_error(error: object) -> bool:
     return False
 
 
-def _rollout_error_reason(error: object) -> str:
-    if isinstance(error, Mapping):
-        for key in ("error_chain_repr", "error_chain_str", "error"):
-            value = error.get(key)
-            if isinstance(value, str) and value:
-                return value
-    return repr(error)
-
-
 @dataclass
 class InflightRequest:
     """Metadata for an in-flight request."""
@@ -458,92 +449,13 @@ class Scheduler:
                 group_id = rollout_info.group_id
                 env_name = rollout_info.env_name
 
-                terminal_error: RuntimeError | None = None
+                group = self.groups.get(group_id)
+                if group is None:
+                    continue
+
+                env = self.train_envs.get(env_name)
                 try:
-                    group = self.groups.get(group_id)
-                    if group is None:
-                        continue
-
-                    env = self.train_envs.get(env_name)
                     result = finished_task.result()
-                    rollouts: list[vf.RolloutOutput] = result if isinstance(result, list) else [result]
-                    self.total_rollouts_by_env[env_name] += len(rollouts)
-
-                    # Check for empty/errored rollouts and reschedule
-                    valid_rollouts = []
-                    has_failures = False
-                    last_failure_reason: str | None = None
-                    for rollout in rollouts:
-                        if rollout["error"] is not None:
-                            self.errored_rollouts_by_env[env_name] += 1
-                            last_failure_reason = _rollout_error_reason(rollout["error"])
-                            if not is_reschedulable_rollout_error(rollout["error"]):
-                                terminal_error = RuntimeError(
-                                    f"Non-retryable rollout error in group {group_id} ({env_name}); "
-                                    f"not rescheduling replacement rollouts. Last failure: {last_failure_reason}"
-                                )
-                                break
-                            has_failures = True
-                            self.logger.warning(
-                                f"Retryable rollout error in group {group_id} ({env_name}), re-scheduling "
-                                f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete): "
-                                f"{last_failure_reason}"
-                            )
-                        elif len(rollout["trajectory"]) == 0:
-                            self.empty_rollouts_by_env[env_name] += 1
-                            has_failures = True
-                            last_failure_reason = "empty trajectory"
-                            self.logger.warning(
-                                f"Empty trajectory in group {group_id} ({env_name}), re-scheduling "
-                                f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete)"
-                            )
-                        else:
-                            rollout["env_name"] = env_name
-                            valid_rollouts.append(rollout)
-
-                    if terminal_error is not None:
-                        if group_id is not None:
-                            await self.drop_group(group_id)
-                    elif has_failures:
-                        # Dedupe failures within the same dispatch round: an
-                        # individual-scoring env dispatches N rollouts at once,
-                        # so a single failed round can produce up to N failed
-                        # tasks. We only count the round once.
-                        if rollout_info.round_id > group.last_failed_round:
-                            group.failed_attempts += 1
-                            group.last_failed_round = rollout_info.round_id
-                            group.current_round = rollout_info.round_id + 1
-                        max_attempts = self.config.max_error_reschedule_attempts
-                        if max_attempts is not None and group.failed_attempts >= max_attempts:
-                            # Permanently-stuck group: drop it from this step and let the
-                            # rest of the batch proceed. Avoids a single bad example (e.g.
-                            # an agent rollout whose sandbox poll keeps timing out)
-                            # blocking step progress forever.
-                            self.dropped_groups_by_env[env_name] += 1
-                            self.logger.warning(
-                                f"Dropping group {group_id} ({env_name}) after {group.failed_attempts} "
-                                f"failed dispatch rounds ({len(group.completed_rollouts)}/{self.rollouts_per_example} "
-                                f"complete). Last failure: {last_failure_reason}. Set "
-                                f"orchestrator.max_error_reschedule_attempts higher (or to None) "
-                                f"to retry more aggressively."
-                            )
-                            await self.drop_group(group_id)
-                            continue
-
-                    if terminal_error is None:
-                        if has_failures and env.requires_group_scoring:
-                            # Group scoring requires all rollouts — discard partial results, reschedule full group
-                            group.completed_rollouts.clear()
-                            group.rollouts_to_schedule = self.rollouts_per_example
-                            continue
-
-                        # For individual scoring, reschedule only the failed ones
-                        group.rollouts_to_schedule += len(rollouts) - len(valid_rollouts)
-                        group.completed_rollouts.extend(valid_rollouts)
-                        if len(group.completed_rollouts) < self.rollouts_per_example:
-                            continue
-                        completed_rollouts = self.groups.pop(group_id).completed_rollouts
-
                 except asyncio.CancelledError:
                     if group_id is not None:
                         await self.drop_group(group_id)
@@ -554,8 +466,85 @@ class Scheduler:
                         await self.drop_group(group_id)
                     continue
 
-                if terminal_error is not None:
-                    raise terminal_error
+                rollouts: list[vf.RolloutOutput] = result if isinstance(result, list) else [result]
+                self.total_rollouts_by_env[env_name] += len(rollouts)
+
+                # Check for empty/errored rollouts and reschedule
+                valid_rollouts = []
+                has_failures = False
+                last_failure_reason: str | None = None
+                for rollout in rollouts:
+                    rollout_error = rollout["error"]
+                    if rollout_error is not None:
+                        self.errored_rollouts_by_env[env_name] += 1
+                        last_failure_reason = str(
+                            rollout_error.get("error_chain_repr")
+                            or rollout_error.get("error_chain_str")
+                            or rollout_error.get("error")
+                        )
+                        if not is_reschedulable_rollout_error(rollout_error):
+                            if group_id is not None:
+                                await self.drop_group(group_id)
+                            raise RuntimeError(
+                                f"Non-retryable rollout error in group {group_id} ({env_name}); "
+                                f"not rescheduling replacement rollouts. Last failure: {last_failure_reason}"
+                            )
+                        has_failures = True
+                        self.logger.warning(
+                            f"Retryable rollout error in group {group_id} ({env_name}), re-scheduling "
+                            f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete): "
+                            f"{last_failure_reason}"
+                        )
+                    elif len(rollout["trajectory"]) == 0:
+                        self.empty_rollouts_by_env[env_name] += 1
+                        has_failures = True
+                        last_failure_reason = "empty trajectory"
+                        self.logger.warning(
+                            f"Empty trajectory in group {group_id} ({env_name}), re-scheduling "
+                            f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete)"
+                        )
+                    else:
+                        rollout["env_name"] = env_name
+                        valid_rollouts.append(rollout)
+
+                if has_failures:
+                    # Dedupe failures within the same dispatch round: an
+                    # individual-scoring env dispatches N rollouts at once,
+                    # so a single failed round can produce up to N failed
+                    # tasks. We only count the round once.
+                    if rollout_info.round_id > group.last_failed_round:
+                        group.failed_attempts += 1
+                        group.last_failed_round = rollout_info.round_id
+                        group.current_round = rollout_info.round_id + 1
+                    max_attempts = self.config.max_error_reschedule_attempts
+                    if max_attempts is not None and group.failed_attempts >= max_attempts:
+                        # Permanently-stuck group: drop it from this step and let the
+                        # rest of the batch proceed. Avoids a single bad example (e.g.
+                        # an agent rollout whose sandbox poll keeps timing out)
+                        # blocking step progress forever.
+                        self.dropped_groups_by_env[env_name] += 1
+                        self.logger.warning(
+                            f"Dropping group {group_id} ({env_name}) after {group.failed_attempts} "
+                            f"failed dispatch rounds ({len(group.completed_rollouts)}/{self.rollouts_per_example} "
+                            f"complete). Last failure: {last_failure_reason}. Set "
+                            f"orchestrator.max_error_reschedule_attempts higher (or to None) "
+                            f"to retry more aggressively."
+                        )
+                        await self.drop_group(group_id)
+                        continue
+
+                if has_failures and env.requires_group_scoring:
+                    # Group scoring requires all rollouts — discard partial results, reschedule full group
+                    group.completed_rollouts.clear()
+                    group.rollouts_to_schedule = self.rollouts_per_example
+                    continue
+
+                # For individual scoring, reschedule only the failed ones
+                group.rollouts_to_schedule += len(rollouts) - len(valid_rollouts)
+                group.completed_rollouts.extend(valid_rollouts)
+                if len(group.completed_rollouts) < self.rollouts_per_example:
+                    continue
+                completed_rollouts = self.groups.pop(group_id).completed_rollouts
 
                 self.buffer.update(completed_rollouts)
                 accepted_rollouts = self.buffer.sample_rollouts(n=self.rollouts_per_example)

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -455,18 +455,19 @@ class Scheduler:
                         continue
 
                     env = self.train_envs.get(env_name)
-                    try:
-                        result = finished_task.result()
-                    except asyncio.CancelledError:
-                        if group_id is not None:
-                            await self.drop_group(group_id)
-                        continue
-                    except Exception as e:
-                        self.logger.warning(f"Rollout failed: {e}")
+                    if finished_task.cancelled():
                         if group_id is not None:
                             await self.drop_group(group_id)
                         continue
 
+                    task_exception = finished_task.exception()
+                    if task_exception is not None:
+                        self.logger.warning(f"Rollout failed: {task_exception}")
+                        if group_id is not None:
+                            await self.drop_group(group_id)
+                        continue
+
+                    result = finished_task.result()
                     rollouts: list[vf.RolloutOutput] = result if isinstance(result, list) else [result]
                     self.total_rollouts_by_env[env_name] += len(rollouts)
 
@@ -475,15 +476,14 @@ class Scheduler:
                     has_failures = False
                     last_failure_reason: str | None = None
                     for rollout in rollouts:
-                        rollout_error = rollout["error"]
-                        if rollout_error is not None:
+                        if rollout["error"] is not None:
                             self.errored_rollouts_by_env[env_name] += 1
                             last_failure_reason = str(
-                                rollout_error.get("error_chain_repr")
-                                or rollout_error.get("error_chain_str")
-                                or rollout_error.get("error")
+                                rollout["error"].get("error_chain_repr")
+                                or rollout["error"].get("error_chain_str")
+                                or rollout["error"].get("error")
                             )
-                            if not is_reschedulable_rollout_error(rollout_error):
+                            if not is_reschedulable_rollout_error(rollout["error"]):
                                 raise RuntimeError(
                                     f"Non-retryable rollout error in group {group_id} ({env_name}); "
                                     f"not rescheduling replacement rollouts. Last failure: {last_failure_reason}"

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import re
 import time
 from collections import Counter, defaultdict
 from collections.abc import Mapping
@@ -24,68 +23,18 @@ from prime_rl.utils.utils import (
     wait_for_path,
 )
 
-_ERROR_NAME_RE = re.compile(r"\b[A-Z][A-Za-z0-9_]*(?=\s*(?:\(|->|$))")
-
-
-def _public_verifiers_retryable_error_names() -> frozenset[str]:
-    retryable_bases = (vf.InfraError, vf.InvalidModelResponseError)
-    return frozenset(
-        name for name, value in vars(vf).items() if isinstance(value, type) and issubclass(value, retryable_bases)
-    )
-
-
-# verifiers serializes ErrorInfo before prime-rl sees rollout failures. The
-# public base classes are derived from vf.InfraError/vf.InvalidModelResponseError;
-# the extra names are known non-exported verifiers subclasses that can appear in
-# serialized chains without their base class names.
-_SERIALIZED_RETRYABLE_ERROR_NAMES = _public_verifiers_retryable_error_names() | {
-    "AgentError",
-    "InterceptionError",
-    "PythonWorkerDeadError",
-    "PythonWorkerNotReadyError",
-    "PythonWorkerRequestError",
-    "RLMSandboxCommandTimeout",
-    "RLMSessionError",
-    "RLMSetupError",
-    "RLMWorkerError",
-    "RLMWorkerRecoveryError",
-    "SandboxCreationError",
-    "SandboxNotReadyError",
-    "SandboxSetupError",
-    "StreamInterrupted",
-    "SubLLMEmptyModelResponseError",
-}
-
 
 class NonReschedulableRolloutError(RuntimeError):
     """Raised when a serialized rollout error should abort instead of spawning replacement rollouts."""
 
 
-def _serialized_error_names(error: object) -> set[str]:
-    if isinstance(error, BaseException):
-        return {type(error).__name__}
-    if not isinstance(error, Mapping):
-        return set()
-
-    names: set[str] = set()
-    for key in ("error", "error_chain_str", "error_chain_repr"):
-        value = error.get(key)
-        if not isinstance(value, str):
-            continue
-        names.update(_ERROR_NAME_RE.findall(value))
-    return names
-
-
 def is_reschedulable_rollout_error(error: object) -> bool:
-    """Match verifiers maybe_retry semantics for serialized RolloutOutput errors.
-
-    verifiers retries vf.InfraError and vf.InvalidModelResponseError by type.
-    prime-rl receives serialized ErrorInfo dictionaries, so this compatibility
-    bridge compares class-name tokens from those serialized chains instead.
-    """
+    """Use verifiers' serialized retryability decision for rollout errors."""
     if isinstance(error, (vf.InfraError, vf.InvalidModelResponseError)):
         return True
-    return bool(_serialized_error_names(error) & _SERIALIZED_RETRYABLE_ERROR_NAMES)
+    if isinstance(error, Mapping):
+        return error.get("is_retryable") is True
+    return False
 
 
 def _rollout_error_reason(error: object) -> str:

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -26,8 +26,6 @@ from prime_rl.utils.utils import (
 
 def is_reschedulable_rollout_error(error: object) -> bool:
     """Use verifiers' serialized retryability decision for rollout errors."""
-    if isinstance(error, (vf.InfraError, vf.InvalidModelResponseError)):
-        return True
     if isinstance(error, Mapping):
         return error.get("is_retryable") is True
     return False

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import re
 import time
 from collections import Counter, defaultdict
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 
 import verifiers as vf
@@ -21,6 +23,78 @@ from prime_rl.utils.utils import (
     get_step_path,
     wait_for_path,
 )
+
+_ERROR_NAME_RE = re.compile(r"\b[A-Z][A-Za-z0-9_]*(?=\s*(?:\(|->|$))")
+
+
+def _public_verifiers_retryable_error_names() -> frozenset[str]:
+    retryable_bases = (vf.InfraError, vf.InvalidModelResponseError)
+    return frozenset(
+        name for name, value in vars(vf).items() if isinstance(value, type) and issubclass(value, retryable_bases)
+    )
+
+
+# verifiers serializes ErrorInfo before prime-rl sees rollout failures. The
+# public base classes are derived from vf.InfraError/vf.InvalidModelResponseError;
+# the extra names are known non-exported verifiers subclasses that can appear in
+# serialized chains without their base class names.
+_SERIALIZED_RETRYABLE_ERROR_NAMES = _public_verifiers_retryable_error_names() | {
+    "AgentError",
+    "InterceptionError",
+    "PythonWorkerDeadError",
+    "PythonWorkerNotReadyError",
+    "PythonWorkerRequestError",
+    "RLMSandboxCommandTimeout",
+    "RLMSessionError",
+    "RLMSetupError",
+    "RLMWorkerError",
+    "RLMWorkerRecoveryError",
+    "SandboxCreationError",
+    "SandboxNotReadyError",
+    "SandboxSetupError",
+    "StreamInterrupted",
+    "SubLLMEmptyModelResponseError",
+}
+
+
+class NonReschedulableRolloutError(RuntimeError):
+    """Raised when a serialized rollout error should abort instead of spawning replacement rollouts."""
+
+
+def _serialized_error_names(error: object) -> set[str]:
+    if isinstance(error, BaseException):
+        return {type(error).__name__}
+    if not isinstance(error, Mapping):
+        return set()
+
+    names: set[str] = set()
+    for key in ("error", "error_chain_str", "error_chain_repr"):
+        value = error.get(key)
+        if not isinstance(value, str):
+            continue
+        names.update(_ERROR_NAME_RE.findall(value))
+    return names
+
+
+def is_reschedulable_rollout_error(error: object) -> bool:
+    """Match verifiers maybe_retry semantics for serialized RolloutOutput errors.
+
+    verifiers retries vf.InfraError and vf.InvalidModelResponseError by type.
+    prime-rl receives serialized ErrorInfo dictionaries, so this compatibility
+    bridge compares class-name tokens from those serialized chains instead.
+    """
+    if isinstance(error, (vf.InfraError, vf.InvalidModelResponseError)):
+        return True
+    return bool(_serialized_error_names(error) & _SERIALIZED_RETRYABLE_ERROR_NAMES)
+
+
+def _rollout_error_reason(error: object) -> str:
+    if isinstance(error, Mapping):
+        for key in ("error_chain_repr", "error_chain_str", "error"):
+            value = error.get(key)
+            if isinstance(value, str) and value:
+                return value
+    return repr(error)
 
 
 @dataclass
@@ -458,10 +532,15 @@ class Scheduler:
                     for rollout in rollouts:
                         if rollout["error"] is not None:
                             self.errored_rollouts_by_env[env_name] += 1
+                            last_failure_reason = _rollout_error_reason(rollout["error"])
+                            if not is_reschedulable_rollout_error(rollout["error"]):
+                                raise NonReschedulableRolloutError(
+                                    f"Non-retryable rollout error in group {group_id} ({env_name}); "
+                                    f"not rescheduling replacement rollouts. Last failure: {last_failure_reason}"
+                                )
                             has_failures = True
-                            last_failure_reason = rollout["error"]["error_chain_repr"]
                             self.logger.warning(
-                                f"Rollout error in group {group_id} ({env_name}), re-scheduling "
+                                f"Retryable rollout error in group {group_id} ({env_name}), re-scheduling "
                                 f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete): "
                                 f"{last_failure_reason}"
                             )
@@ -520,6 +599,10 @@ class Scheduler:
                     if group_id is not None:
                         await self.drop_group(group_id)
                     continue
+                except NonReschedulableRolloutError:
+                    if group_id is not None:
+                        await self.drop_group(group_id)
+                    raise
                 except Exception as e:
                     self.logger.warning(f"Rollout failed: {e}")
                     if group_id is not None:

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -24,10 +24,6 @@ from prime_rl.utils.utils import (
 )
 
 
-class NonReschedulableRolloutError(RuntimeError):
-    """Raised when a serialized rollout error should abort instead of spawning replacement rollouts."""
-
-
 def is_reschedulable_rollout_error(error: object) -> bool:
     """Use verifiers' serialized retryability decision for rollout errors."""
     if isinstance(error, (vf.InfraError, vf.InvalidModelResponseError)):
@@ -464,6 +460,7 @@ class Scheduler:
                 group_id = rollout_info.group_id
                 env_name = rollout_info.env_name
 
+                terminal_error: RuntimeError | None = None
                 try:
                     group = self.groups.get(group_id)
                     if group is None:
@@ -483,10 +480,11 @@ class Scheduler:
                             self.errored_rollouts_by_env[env_name] += 1
                             last_failure_reason = _rollout_error_reason(rollout["error"])
                             if not is_reschedulable_rollout_error(rollout["error"]):
-                                raise NonReschedulableRolloutError(
+                                terminal_error = RuntimeError(
                                     f"Non-retryable rollout error in group {group_id} ({env_name}); "
                                     f"not rescheduling replacement rollouts. Last failure: {last_failure_reason}"
                                 )
+                                break
                             has_failures = True
                             self.logger.warning(
                                 f"Retryable rollout error in group {group_id} ({env_name}), re-scheduling "
@@ -505,7 +503,10 @@ class Scheduler:
                             rollout["env_name"] = env_name
                             valid_rollouts.append(rollout)
 
-                    if has_failures:
+                    if terminal_error is not None:
+                        if group_id is not None:
+                            await self.drop_group(group_id)
+                    elif has_failures:
                         # Dedupe failures within the same dispatch round: an
                         # individual-scoring env dispatches N rollouts at once,
                         # so a single failed round can produce up to N failed
@@ -531,32 +532,32 @@ class Scheduler:
                             await self.drop_group(group_id)
                             continue
 
-                    if has_failures and env.requires_group_scoring:
-                        # Group scoring requires all rollouts — discard partial results, reschedule full group
-                        group.completed_rollouts.clear()
-                        group.rollouts_to_schedule = self.rollouts_per_example
-                        continue
+                    if terminal_error is None:
+                        if has_failures and env.requires_group_scoring:
+                            # Group scoring requires all rollouts — discard partial results, reschedule full group
+                            group.completed_rollouts.clear()
+                            group.rollouts_to_schedule = self.rollouts_per_example
+                            continue
 
-                    # For individual scoring, reschedule only the failed ones
-                    group.rollouts_to_schedule += len(rollouts) - len(valid_rollouts)
-                    group.completed_rollouts.extend(valid_rollouts)
-                    if len(group.completed_rollouts) < self.rollouts_per_example:
-                        continue
-                    completed_rollouts = self.groups.pop(group_id).completed_rollouts
+                        # For individual scoring, reschedule only the failed ones
+                        group.rollouts_to_schedule += len(rollouts) - len(valid_rollouts)
+                        group.completed_rollouts.extend(valid_rollouts)
+                        if len(group.completed_rollouts) < self.rollouts_per_example:
+                            continue
+                        completed_rollouts = self.groups.pop(group_id).completed_rollouts
 
                 except asyncio.CancelledError:
                     if group_id is not None:
                         await self.drop_group(group_id)
                     continue
-                except NonReschedulableRolloutError:
-                    if group_id is not None:
-                        await self.drop_group(group_id)
-                    raise
                 except Exception as e:
                     self.logger.warning(f"Rollout failed: {e}")
                     if group_id is not None:
                         await self.drop_group(group_id)
                     continue
+
+                if terminal_error is not None:
+                    raise terminal_error
 
                 self.buffer.update(completed_rollouts)
                 accepted_rollouts = self.buffer.sample_rollouts(n=self.rollouts_per_example)

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -449,102 +449,114 @@ class Scheduler:
                 group_id = rollout_info.group_id
                 env_name = rollout_info.env_name
 
-                group = self.groups.get(group_id)
-                if group is None:
-                    continue
-
-                env = self.train_envs.get(env_name)
                 try:
-                    result = finished_task.result()
+                    group = self.groups.get(group_id)
+                    if group is None:
+                        continue
+
+                    env = self.train_envs.get(env_name)
+                    try:
+                        result = finished_task.result()
+                    except asyncio.CancelledError:
+                        if group_id is not None:
+                            await self.drop_group(group_id)
+                        continue
+                    except Exception as e:
+                        self.logger.warning(f"Rollout failed: {e}")
+                        if group_id is not None:
+                            await self.drop_group(group_id)
+                        continue
+
+                    rollouts: list[vf.RolloutOutput] = result if isinstance(result, list) else [result]
+                    self.total_rollouts_by_env[env_name] += len(rollouts)
+
+                    # Check for empty/errored rollouts and reschedule
+                    valid_rollouts = []
+                    has_failures = False
+                    last_failure_reason: str | None = None
+                    for rollout in rollouts:
+                        rollout_error = rollout["error"]
+                        if rollout_error is not None:
+                            self.errored_rollouts_by_env[env_name] += 1
+                            last_failure_reason = str(
+                                rollout_error.get("error_chain_repr")
+                                or rollout_error.get("error_chain_str")
+                                or rollout_error.get("error")
+                            )
+                            if not is_reschedulable_rollout_error(rollout_error):
+                                raise RuntimeError(
+                                    f"Non-retryable rollout error in group {group_id} ({env_name}); "
+                                    f"not rescheduling replacement rollouts. Last failure: {last_failure_reason}"
+                                )
+                            has_failures = True
+                            self.logger.warning(
+                                f"Retryable rollout error in group {group_id} ({env_name}), re-scheduling "
+                                f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete): "
+                                f"{last_failure_reason}"
+                            )
+                        elif len(rollout["trajectory"]) == 0:
+                            self.empty_rollouts_by_env[env_name] += 1
+                            has_failures = True
+                            last_failure_reason = "empty trajectory"
+                            self.logger.warning(
+                                f"Empty trajectory in group {group_id} ({env_name}), re-scheduling "
+                                f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete)"
+                            )
+                        else:
+                            rollout["env_name"] = env_name
+                            valid_rollouts.append(rollout)
+
+                    if has_failures:
+                        # Dedupe failures within the same dispatch round: an
+                        # individual-scoring env dispatches N rollouts at once,
+                        # so a single failed round can produce up to N failed
+                        # tasks. We only count the round once.
+                        if rollout_info.round_id > group.last_failed_round:
+                            group.failed_attempts += 1
+                            group.last_failed_round = rollout_info.round_id
+                            group.current_round = rollout_info.round_id + 1
+                        max_attempts = self.config.max_error_reschedule_attempts
+                        if max_attempts is not None and group.failed_attempts >= max_attempts:
+                            # Permanently-stuck group: drop it from this step and let the
+                            # rest of the batch proceed. Avoids a single bad example (e.g.
+                            # an agent rollout whose sandbox poll keeps timing out)
+                            # blocking step progress forever.
+                            self.dropped_groups_by_env[env_name] += 1
+                            self.logger.warning(
+                                f"Dropping group {group_id} ({env_name}) after {group.failed_attempts} "
+                                f"failed dispatch rounds ({len(group.completed_rollouts)}/{self.rollouts_per_example} "
+                                f"complete). Last failure: {last_failure_reason}. Set "
+                                f"orchestrator.max_error_reschedule_attempts higher (or to None) "
+                                f"to retry more aggressively."
+                            )
+                            await self.drop_group(group_id)
+                            continue
+
+                    if has_failures and env.requires_group_scoring:
+                        # Group scoring requires all rollouts — discard partial results, reschedule full group
+                        group.completed_rollouts.clear()
+                        group.rollouts_to_schedule = self.rollouts_per_example
+                        continue
+
+                    # For individual scoring, reschedule only the failed ones
+                    group.rollouts_to_schedule += len(rollouts) - len(valid_rollouts)
+                    group.completed_rollouts.extend(valid_rollouts)
+                    if len(group.completed_rollouts) < self.rollouts_per_example:
+                        continue
+                    completed_rollouts = self.groups.pop(group_id).completed_rollouts
                 except asyncio.CancelledError:
                     if group_id is not None:
                         await self.drop_group(group_id)
                     continue
+                except RuntimeError:
+                    if group_id is not None:
+                        await self.drop_group(group_id)
+                    raise
                 except Exception as e:
                     self.logger.warning(f"Rollout failed: {e}")
                     if group_id is not None:
                         await self.drop_group(group_id)
                     continue
-
-                rollouts: list[vf.RolloutOutput] = result if isinstance(result, list) else [result]
-                self.total_rollouts_by_env[env_name] += len(rollouts)
-
-                # Check for empty/errored rollouts and reschedule
-                valid_rollouts = []
-                has_failures = False
-                last_failure_reason: str | None = None
-                for rollout in rollouts:
-                    rollout_error = rollout["error"]
-                    if rollout_error is not None:
-                        self.errored_rollouts_by_env[env_name] += 1
-                        last_failure_reason = str(
-                            rollout_error.get("error_chain_repr")
-                            or rollout_error.get("error_chain_str")
-                            or rollout_error.get("error")
-                        )
-                        if not is_reschedulable_rollout_error(rollout_error):
-                            if group_id is not None:
-                                await self.drop_group(group_id)
-                            raise RuntimeError(
-                                f"Non-retryable rollout error in group {group_id} ({env_name}); "
-                                f"not rescheduling replacement rollouts. Last failure: {last_failure_reason}"
-                            )
-                        has_failures = True
-                        self.logger.warning(
-                            f"Retryable rollout error in group {group_id} ({env_name}), re-scheduling "
-                            f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete): "
-                            f"{last_failure_reason}"
-                        )
-                    elif len(rollout["trajectory"]) == 0:
-                        self.empty_rollouts_by_env[env_name] += 1
-                        has_failures = True
-                        last_failure_reason = "empty trajectory"
-                        self.logger.warning(
-                            f"Empty trajectory in group {group_id} ({env_name}), re-scheduling "
-                            f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete)"
-                        )
-                    else:
-                        rollout["env_name"] = env_name
-                        valid_rollouts.append(rollout)
-
-                if has_failures:
-                    # Dedupe failures within the same dispatch round: an
-                    # individual-scoring env dispatches N rollouts at once,
-                    # so a single failed round can produce up to N failed
-                    # tasks. We only count the round once.
-                    if rollout_info.round_id > group.last_failed_round:
-                        group.failed_attempts += 1
-                        group.last_failed_round = rollout_info.round_id
-                        group.current_round = rollout_info.round_id + 1
-                    max_attempts = self.config.max_error_reschedule_attempts
-                    if max_attempts is not None and group.failed_attempts >= max_attempts:
-                        # Permanently-stuck group: drop it from this step and let the
-                        # rest of the batch proceed. Avoids a single bad example (e.g.
-                        # an agent rollout whose sandbox poll keeps timing out)
-                        # blocking step progress forever.
-                        self.dropped_groups_by_env[env_name] += 1
-                        self.logger.warning(
-                            f"Dropping group {group_id} ({env_name}) after {group.failed_attempts} "
-                            f"failed dispatch rounds ({len(group.completed_rollouts)}/{self.rollouts_per_example} "
-                            f"complete). Last failure: {last_failure_reason}. Set "
-                            f"orchestrator.max_error_reschedule_attempts higher (or to None) "
-                            f"to retry more aggressively."
-                        )
-                        await self.drop_group(group_id)
-                        continue
-
-                if has_failures and env.requires_group_scoring:
-                    # Group scoring requires all rollouts — discard partial results, reschedule full group
-                    group.completed_rollouts.clear()
-                    group.rollouts_to_schedule = self.rollouts_per_example
-                    continue
-
-                # For individual scoring, reschedule only the failed ones
-                group.rollouts_to_schedule += len(rollouts) - len(valid_rollouts)
-                group.completed_rollouts.extend(valid_rollouts)
-                if len(group.completed_rollouts) < self.rollouts_per_example:
-                    continue
-                completed_rollouts = self.groups.pop(group_id).completed_rollouts
 
                 self.buffer.update(completed_rollouts)
                 accepted_rollouts = self.buffer.sample_rollouts(n=self.rollouts_per_example)

--- a/tests/unit/orchestrator/test_scheduler.py
+++ b/tests/unit/orchestrator/test_scheduler.py
@@ -17,12 +17,20 @@ from prime_rl.orchestrator.scheduler import (
 from prime_rl.utils.async_utils import safe_cancel
 
 
-def make_error(error: str, error_chain_str: str | None = None, error_chain_repr: str | None = None) -> dict:
-    return {
+def make_error(
+    error: str,
+    error_chain_str: str | None = None,
+    error_chain_repr: str | None = None,
+    is_retryable: bool | None = None,
+) -> dict:
+    error_info = {
         "error": error,
         "error_chain_str": error_chain_str or error,
         "error_chain_repr": error_chain_repr or f"{error}()",
     }
+    if is_retryable is not None:
+        error_info["is_retryable"] = is_retryable
+    return error_info
 
 
 def make_scheduler() -> Scheduler:
@@ -62,18 +70,23 @@ def make_scheduler() -> Scheduler:
 
 def test_reschedulable_serialized_errors_match_verifiers_retry_semantics():
     retryable_errors = [
-        make_error("InfraError"),
-        make_error("SandboxError", "SandboxError -> TimeoutError"),
-        make_error("SandboxCreationError", "SandboxCreationError"),
-        make_error("TunnelError"),
-        make_error("BrowserSandboxError"),
-        make_error("InvalidModelResponseError"),
-        make_error("EmptyModelResponseError"),
-        make_error("SubLLMEmptyModelResponseError"),
+        make_error("InfraError", is_retryable=True),
+        make_error("SandboxError", "SandboxError -> TimeoutError", is_retryable=True),
+        make_error("SandboxCreationError", "SandboxCreationError", is_retryable=True),
+        make_error("TunnelError", is_retryable=True),
+        make_error("BrowserSandboxError", is_retryable=True),
+        make_error("InvalidModelResponseError", is_retryable=True),
+        make_error("EmptyModelResponseError", is_retryable=True),
+        make_error("SubLLMEmptyModelResponseError", is_retryable=True),
     ]
 
     for error in retryable_errors:
         assert is_reschedulable_rollout_error(error), error
+
+
+def test_serialized_error_names_without_retryable_flag_are_terminal():
+    assert not is_reschedulable_rollout_error(make_error("SandboxError"))
+    assert not is_reschedulable_rollout_error(make_error("EmptyModelResponseError"))
 
 
 def test_plain_model_error_and_unknown_serialized_errors_are_terminal():
@@ -81,6 +94,7 @@ def test_plain_model_error_and_unknown_serialized_errors_are_terminal():
         "ModelError",
         "ModelError -> InternalServerError",
         "ModelError() -> InternalServerError('No available workers (all circuits open or unhealthy)')",
+        is_retryable=False,
     )
     unknown = make_error("MysteryRolloutError")
 
@@ -95,6 +109,7 @@ def test_plain_model_error_and_unknown_serialized_errors_are_terminal():
             "ModelError",
             "ModelError -> InternalServerError",
             "ModelError() -> InternalServerError('No available workers (all circuits open or unhealthy)')",
+            is_retryable=False,
         ),
         make_error("MysteryRolloutError"),
     ],

--- a/tests/unit/orchestrator/test_scheduler.py
+++ b/tests/unit/orchestrator/test_scheduler.py
@@ -1,12 +1,28 @@
 import asyncio
+from collections import defaultdict
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 import verifiers as vf
 
-from prime_rl.orchestrator.scheduler import GroupState, InflightRequest, Scheduler
+from prime_rl.orchestrator.scheduler import (
+    GroupState,
+    InflightRequest,
+    NonReschedulableRolloutError,
+    Scheduler,
+    is_reschedulable_rollout_error,
+)
 from prime_rl.utils.async_utils import safe_cancel
+
+
+def make_error(error: str, error_chain_str: str | None = None, error_chain_repr: str | None = None) -> dict:
+    return {
+        "error": error,
+        "error_chain_str": error_chain_str or error,
+        "error_chain_repr": error_chain_repr or f"{error}()",
+    }
 
 
 def make_scheduler() -> Scheduler:
@@ -21,17 +37,109 @@ def make_scheduler() -> Scheduler:
     scheduler.checkpoint_ready.set()
     scheduler.lora_name = None
     scheduler.model_name = "test-model"
+    scheduler.batch_size = 1
+    scheduler.token_batch_size = None
+    scheduler.rollouts_per_example = 1
+    scheduler.max_inflight_rollouts = 1
     scheduler.update_weights_time = 0
     scheduler.wait_for_ckpt_time = 0
     scheduler.inflight_requests = {}
     scheduler.groups = {}
     scheduler.max_off_policy_steps = 1
     scheduler.cancelled_rollouts_count = 0
+    scheduler.empty_rollouts_by_env = defaultdict(int)
+    scheduler.errored_rollouts_by_env = defaultdict(int)
+    scheduler.total_rollouts_by_env = defaultdict(int)
+    scheduler.dropped_groups_by_env = defaultdict(int)
+    scheduler.json_logging = False
+    scheduler.last_batch_generation_time = 0.0
     scheduler.policy_update_lock = asyncio.Lock()
     scheduler.inflight_policy_update_task = None
     scheduler.update_policy_task = None
     scheduler.rate_limiter = None
     return scheduler
+
+
+def test_reschedulable_serialized_errors_match_verifiers_retry_semantics():
+    retryable_errors = [
+        make_error("InfraError"),
+        make_error("SandboxError", "SandboxError -> TimeoutError"),
+        make_error("SandboxCreationError", "SandboxCreationError"),
+        make_error("TunnelError"),
+        make_error("BrowserSandboxError"),
+        make_error("InvalidModelResponseError"),
+        make_error("EmptyModelResponseError"),
+        make_error("SubLLMEmptyModelResponseError"),
+    ]
+
+    for error in retryable_errors:
+        assert is_reschedulable_rollout_error(error), error
+
+
+def test_plain_model_error_and_unknown_serialized_errors_are_terminal():
+    no_workers = make_error(
+        "ModelError",
+        "ModelError -> InternalServerError",
+        "ModelError() -> InternalServerError('No available workers (all circuits open or unhealthy)')",
+    )
+    unknown = make_error("MysteryRolloutError")
+
+    assert not is_reschedulable_rollout_error(no_workers)
+    assert not is_reschedulable_rollout_error(unknown)
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        make_error(
+            "ModelError",
+            "ModelError -> InternalServerError",
+            "ModelError() -> InternalServerError('No available workers (all circuits open or unhealthy)')",
+        ),
+        make_error("MysteryRolloutError"),
+    ],
+)
+def test_generate_batch_aborts_non_reschedulable_serialized_errors(error: dict):
+    async def run() -> None:
+        scheduler = make_scheduler()
+        scheduler.maybe_update_policy = AsyncMock()
+        scheduler.update_policy_loop = AsyncMock()
+        scheduler._fill_inflight_requests = AsyncMock()
+        scheduler.buffer = MagicMock()
+        scheduler.train_envs = SimpleNamespace(get=MagicMock(return_value=SimpleNamespace(requires_group_scoring=True)))
+        scheduler.groups = {
+            0: GroupState(
+                example={"env_name": "swe", "example_id": "ex-1"},
+                rollouts_to_schedule=0,
+            )
+        }
+
+        task = asyncio.create_task(asyncio.sleep(0, result={"error": error, "trajectory": []}))
+        await asyncio.sleep(0)
+        scheduler.inflight_requests = {
+            task: InflightRequest(
+                off_policy_steps=0,
+                client_config=SimpleNamespace(api_base_url="http://test", extra_headers={}),
+                env_name="swe",
+                group_id=0,
+            )
+        }
+
+        with (
+            patch(
+                "prime_rl.orchestrator.scheduler.ProgressTracker",
+                return_value=SimpleNamespace(update=MagicMock(), close=MagicMock()),
+            ),
+            pytest.raises(NonReschedulableRolloutError, match="not rescheduling replacement rollouts"),
+        ):
+            await scheduler.generate_batch(step=1)
+
+        assert scheduler.groups == {}
+        assert scheduler.errored_rollouts_by_env["swe"] == 1
+        scheduler._fill_inflight_requests.assert_awaited_once()
+        scheduler.buffer.update.assert_not_called()
+
+    asyncio.run(run())
 
 
 def test_update_off_policy_does_not_increment_interleaved_on_policy_tasks():

--- a/tests/unit/orchestrator/test_scheduler.py
+++ b/tests/unit/orchestrator/test_scheduler.py
@@ -10,7 +10,6 @@ import verifiers as vf
 from prime_rl.orchestrator.scheduler import (
     GroupState,
     InflightRequest,
-    NonReschedulableRolloutError,
     Scheduler,
     is_reschedulable_rollout_error,
 )
@@ -145,7 +144,7 @@ def test_generate_batch_aborts_non_reschedulable_serialized_errors(error: dict):
                 "prime_rl.orchestrator.scheduler.ProgressTracker",
                 return_value=SimpleNamespace(update=MagicMock(), close=MagicMock()),
             ),
-            pytest.raises(NonReschedulableRolloutError, match="not rescheduling replacement rollouts"),
+            pytest.raises(RuntimeError, match="not rescheduling replacement rollouts"),
         ):
             await scheduler.generate_batch(step=1)
 


### PR DESCRIPTION
## Summary
- Add a scheduler error policy that reschedules serialized `vf.RolloutOutput["error"]` dictionaries only when verifiers marks them with `is_retryable=true`.
- Stop treating every non-null serialized rollout error as reschedulable. Plain `ModelError`, including `ModelError -> InternalServerError` no-worker outages, now fails the batch fast with a clear terminal error instead of spawning replacement rollout groups.
- Preserve existing bounded reschedule behavior for retryable verifier failures and empty trajectories.

## Coordinated Verifiers Change
This PR depends on the serialized retryability flag proposed in PrimeIntellect-ai/verifiers#1427. verifiers owns the retry policy because it still has live exception types and can evaluate `InfraError` / `InvalidModelResponseError` subclass semantics before serializing `ErrorInfo`.

prime-rl intentionally does not enumerate serialized subclass names and does not special-case live `vf` exception classes in the scheduler. If a serialized error has no `is_retryable=true` flag, prime-rl treats it as terminal/no-reschedule.

## Why
prime-rl receives rollout failures after verifiers serializes them into `ErrorInfo` dictionaries (`error`, `error_chain_str`, `error_chain_repr`, and with verifiers#1427, `is_retryable`). Raw class hierarchy is not preserved across that boundary, so the retry decision needs to be carried in the serialized payload rather than reconstructed from class-name strings.

This prevents model/router outages like `ModelError -> InternalServerError('No available workers (all circuits open or unhealthy)')` from being mistaken for sandbox/infra failures and causing replacement SWE sandbox churn.

## Failure Behavior
Retryable serialized rollout errors still use the scheduler's bounded replacement-rollout path. Non-retryable serialized rollout errors drop the affected group for cleanup, then raise a plain `RuntimeError` outside the scheduler's broad rollout-task exception handler so the orchestrator exits instead of silently continuing with no-signal batches.

## Test Plan
- `PYTHONPATH=/home/daniel/git/prime-rl-verifiers-retry-semantics/src:/home/daniel/git/prime-rl-verifiers-retry-semantics/packages/prime-rl-configs/src:/home/daniel/git/prime-rl-verifiers-retry-semantics/deps/verifiers /home/daniel/git/prime-rl/.venv/bin/python -m pytest tests/unit/orchestrator/test_scheduler.py`
- `/home/daniel/git/prime-rl/.venv/bin/ruff check src/prime_rl/orchestrator/scheduler.py tests/unit/orchestrator/test_scheduler.py`
- `/home/daniel/git/prime-rl/.venv/bin/ruff format --check src/prime_rl/orchestrator/scheduler.py tests/unit/orchestrator/test_scheduler.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout failure handling in the scheduler to fail fast on non-retryable serialized errors, which can halt training runs if upstream retry flags are missing or incorrect. Logic is localized and covered by new unit tests, but impacts core batch generation behavior.
> 
> **Overview**
> **Rollout rescheduling now follows verifiers’ retry decision.** The scheduler adds `is_reschedulable_rollout_error()` and only replaces errored rollouts when `vf.RolloutOutput["error"]` contains `is_retryable: true`; otherwise it drops the group and raises a `RuntimeError` to abort batch generation.
> 
> It also tightens task completion handling by explicitly dropping groups for cancelled tasks and tasks with exceptions before processing results. Tests were expanded to cover retryable vs terminal serialized errors and to assert that non-reschedulable errors stop `generate_batch` and avoid updating the buffer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 609f080f74f4a9d954d75ff8ec45949492bf92aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->