### PR TITLE
fix(scheduler): drop group on rollout error instead of rescheduling

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -197,7 +197,7 @@ class EnvConfig(BaseConfig):
     ratio: float | None = Field(None, gt=0)
     """Sampling weight for this environment in the buffer. When None for all envs, samples uniformly across all available problems. When set, must be set on all envs — values are relative weights normalized to probabilities (e.g. [1, 1] and [0.5, 0.5] are equivalent)."""
 
-    max_retries: int = Field(0, ge=0)
+    max_retries: int = Field(3, ge=0)
     """Times the env server retries a failed rollout before returning an error."""
 
     max_total_completion_tokens: int = -1
@@ -264,7 +264,7 @@ class TrainConfig(BaseConfig):
     num_workers: int | Literal["auto"] = "auto"
     """Default worker processes for env servers. Can be overridden per env."""
 
-    max_retries: int = Field(0, ge=0)
+    max_retries: int = Field(3, ge=0)
     """Default retries for failed rollouts. Can be overridden per env."""
 
     @model_validator(mode="after")
@@ -319,7 +319,7 @@ class EvalConfig(BaseConfig):
     num_workers: int | Literal["auto"] = "auto"
     """Default worker processes for env servers. Can be overridden per env."""
 
-    max_retries: int = Field(0, ge=0)
+    max_retries: int = Field(3, ge=0)
     """Default retries for failed rollouts. Can be overridden per env."""
 
     interval: int = Field(100, ge=1)
@@ -634,9 +634,6 @@ class OrchestratorConfig(BaseConfig):
 
     max_off_policy_steps: int = Field(8, ge=0)
     """Maximum policies allowed to generate a single rollout. Rollouts generated more than ``max_off_policy_steps`` ahead of training are discarded. Higher values yield better throughput at the cost of off-policy noise."""
-
-    max_error_reschedule_attempts: int | None = Field(3, ge=1)
-    """The group is dropped from the current step's batch once this many of its dispatch rounds have returned errored or empty rollouts (the trainer proceeds with the rollouts from other groups). Counts rounds, not individual rollouts: a non-group-scoring env that dispatches ``rollouts_per_example`` rollouts at once still only counts one round per failed batch. None retries indefinitely. Useful for unblocking single-example hangs in agent envs."""
 
     max_async_level: int = Field(1, ge=0)
     """Maximum steps inference can be ahead of training. ``0`` degenerates to synchronous on-policy RL; ``≥1`` overlaps training and inference."""

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -32,8 +32,6 @@ class InflightRequest:
     env_name: str
     group_id: int | None = None
     rollout_count: int = 1
-    # Dispatch round the request belongs to (see GroupState.current_round).
-    round_id: int = 0
 
 
 @dataclass
@@ -44,19 +42,6 @@ class GroupState:
     rollouts_to_schedule: int
     completed_rollouts: list[vf.RolloutOutput] = field(default_factory=list)
     pinned_client: vf.ClientConfig | None = None
-    # Number of dispatch rounds in which at least one rollout returned errored
-    # or empty trajectories. Compared against
-    # config.max_error_reschedule_attempts to decide when to drop a
-    # permanently-stuck group. Counts rounds, not rollouts: a failed round in
-    # an individual-scoring env that happens to dispatch N rollouts at once
-    # still only counts as 1.
-    failed_attempts: int = 0
-    # Round id assigned to newly-dispatched rollouts. Advances after a failure
-    # is counted so the resulting reschedule starts a new round.
-    current_round: int = 0
-    # Highest round already counted as failed; used to dedupe failures from
-    # multiple rollouts in the same round.
-    last_failed_round: int = -1
 
 
 class Scheduler:
@@ -253,7 +238,6 @@ class Scheduler:
             env_name=env_name,
             group_id=group_id,
             rollout_count=rollout_count,
-            round_id=group.current_round,
         )
 
     @property
@@ -446,72 +430,38 @@ class Scheduler:
                     if group is None:
                         continue
 
-                    env = self.train_envs.get(env_name)
                     result = finished_task.result()
                     rollouts: list[vf.RolloutOutput] = result if isinstance(result, list) else [result]
                     self.total_rollouts_by_env[env_name] += len(rollouts)
 
-                    # Check for empty/errored rollouts and reschedule
-                    valid_rollouts = []
-                    has_failures = False
-                    last_failure_reason: str | None = None
+                    # Drop the whole group on any rollout error or empty trajectory.
+                    # Env-side retries (env.max_retries) already absorb transient
+                    # failures; anything that bubbles up here is treated as
+                    # non-retryable, and partial groups aren't trainable.
+                    failure_reason: str | None = None
                     for rollout in rollouts:
                         if rollout["error"] is not None:
                             self.errored_rollouts_by_env[env_name] += 1
-                            has_failures = True
-                            last_failure_reason = rollout["error"]["error_chain_repr"]
-                            self.logger.warning(
-                                f"Rollout error in group {group_id} ({env_name}), re-scheduling "
-                                f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete): "
-                                f"{last_failure_reason}"
-                            )
-                        elif len(rollout["trajectory"]) == 0:
+                            failure_reason = rollout["error"]["error_chain_repr"]
+                            break
+                        if len(rollout["trajectory"]) == 0:
                             self.empty_rollouts_by_env[env_name] += 1
-                            has_failures = True
-                            last_failure_reason = "empty trajectory"
-                            self.logger.warning(
-                                f"Empty trajectory in group {group_id} ({env_name}), re-scheduling "
-                                f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete)"
-                            )
-                        else:
-                            rollout["env_name"] = env_name
-                            valid_rollouts.append(rollout)
+                            failure_reason = "empty trajectory"
+                            break
 
-                    if has_failures:
-                        # Dedupe failures within the same dispatch round: an
-                        # individual-scoring env dispatches N rollouts at once,
-                        # so a single failed round can produce up to N failed
-                        # tasks. We only count the round once.
-                        if rollout_info.round_id > group.last_failed_round:
-                            group.failed_attempts += 1
-                            group.last_failed_round = rollout_info.round_id
-                            group.current_round = rollout_info.round_id + 1
-                        max_attempts = self.config.max_error_reschedule_attempts
-                        if max_attempts is not None and group.failed_attempts >= max_attempts:
-                            # Permanently-stuck group: drop it from this step and let the
-                            # rest of the batch proceed. Avoids a single bad example (e.g.
-                            # an agent rollout whose sandbox poll keeps timing out)
-                            # blocking step progress forever.
-                            self.dropped_groups_by_env[env_name] += 1
-                            self.logger.warning(
-                                f"Dropping group {group_id} ({env_name}) after {group.failed_attempts} "
-                                f"failed dispatch rounds ({len(group.completed_rollouts)}/{self.rollouts_per_example} "
-                                f"complete). Last failure: {last_failure_reason}. Set "
-                                f"orchestrator.max_error_reschedule_attempts higher (or to None) "
-                                f"to retry more aggressively."
-                            )
-                            await self.drop_group(group_id)
-                            continue
-
-                    if has_failures and env.requires_group_scoring:
-                        # Group scoring requires all rollouts — discard partial results, reschedule full group
-                        group.completed_rollouts.clear()
-                        group.rollouts_to_schedule = self.rollouts_per_example
+                    if failure_reason is not None:
+                        self.dropped_groups_by_env[env_name] += 1
+                        self.logger.warning(
+                            f"Dropping group {group_id} ({env_name}) after rollout failure "
+                            f"({len(group.completed_rollouts)}/{self.rollouts_per_example} complete): "
+                            f"{failure_reason}"
+                        )
+                        await self.drop_group(group_id)
                         continue
 
-                    # For individual scoring, reschedule only the failed ones
-                    group.rollouts_to_schedule += len(rollouts) - len(valid_rollouts)
-                    group.completed_rollouts.extend(valid_rollouts)
+                    for rollout in rollouts:
+                        rollout["env_name"] = env_name
+                    group.completed_rollouts.extend(rollouts)
                     if len(group.completed_rollouts) < self.rollouts_per_example:
                         continue
                     completed_rollouts = self.groups.pop(group_id).completed_rollouts

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -438,16 +438,18 @@ class Scheduler:
                     # Env-side retries (env.max_retries) already absorb transient
                     # failures; anything that bubbles up here is treated as
                     # non-retryable, and partial groups aren't trainable.
+                    # Tally every failure (group-scoring envs return N rollouts
+                    # per task) so error-rate metrics aren't deflated.
                     failure_reason: str | None = None
                     for rollout in rollouts:
                         if rollout["error"] is not None:
                             self.errored_rollouts_by_env[env_name] += 1
-                            failure_reason = rollout["error"]["error_chain_repr"]
-                            break
-                        if len(rollout["trajectory"]) == 0:
+                            if failure_reason is None:
+                                failure_reason = rollout["error"]["error_chain_repr"]
+                        elif len(rollout["trajectory"]) == 0:
                             self.empty_rollouts_by_env[env_name] += 1
-                            failure_reason = "empty trajectory"
-                            break
+                            if failure_reason is None:
+                                failure_reason = "empty trajectory"
 
                     if failure_reason is not None:
                         self.dropped_groups_by_env[env_name] += 1

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -121,6 +121,7 @@ class Scheduler:
         self.cancelled_rollouts_count = 0
         self.empty_rollouts_by_env: dict[str, int] = defaultdict(int)
         self.errored_rollouts_by_env: dict[str, int] = defaultdict(int)
+        self.errors_by_type: dict[str, int] = defaultdict(int)
         self.total_rollouts_by_env: dict[str, int] = defaultdict(int)
         self.dropped_groups_by_env: dict[str, int] = defaultdict(int)
         self.last_batch_generation_time = 0.0
@@ -444,6 +445,7 @@ class Scheduler:
                     for rollout in rollouts:
                         if rollout["error"] is not None:
                             self.errored_rollouts_by_env[env_name] += 1
+                            self.errors_by_type[rollout["error"]["error"]] += 1
                             if failure_reason is None:
                                 failure_reason = rollout["error"]["error_chain_repr"]
                         elif len(rollout["trajectory"]) == 0:
@@ -541,6 +543,8 @@ class Scheduler:
             metrics[f"errored_rollouts/{env_name}"] = self.errored_rollouts_by_env.get(env_name, 0) / env_total
         for env_name, count in self.dropped_groups_by_env.items():
             metrics[f"dropped_groups/{env_name}"] = count
+        for error_type, count in self.errors_by_type.items():
+            metrics[f"error/{error_type}/count"] = count
         by_env: dict[str, list[int]] = {}
         for info in self.inflight_requests.values():
             by_env.setdefault(info.env_name, []).append(info.off_policy_steps)
@@ -550,6 +554,7 @@ class Scheduler:
         self.cancelled_rollouts_count = 0
         self.empty_rollouts_by_env.clear()
         self.errored_rollouts_by_env.clear()
+        self.errors_by_type.clear()
         self.total_rollouts_by_env.clear()
         self.dropped_groups_by_env.clear()
 


### PR DESCRIPTION
## Summary

- Raise per-env `max_retries` default from `0` to `3` (`EnvConfig`, `TrainConfig`, `EvalConfig`) so transient infra failures are absorbed inside the env server's own retry loop.
- Drop any group whose rollout bubbles up with an error or empty trajectory: log the failure, increment `dropped_groups/<env>`, cancel remaining in-flight rollouts for that group, and let the rest of the batch proceed.
- Add per-step `error/<type>/count` wandb metric, keyed by the outermost exception class name from the verifiers error chain (e.g. `error/OverlongPromptError/count`). Lets dashboards see which failure mode is driving drops instead of one opaque errored-rollouts rate.
- Remove the in-orchestrator reschedule path entirely: `OrchestratorConfig.max_error_reschedule_attempts` and `GroupState.failed_attempts` / `current_round` / `last_failed_round` / `InflightRequest.round_id` are gone.

Envs are now responsible for marking retryable errors by raising `vf.InfraError` (a subclass of `vf.Error`). `verifiers.utils.async_utils.maybe_retry` only retries `vf.InfraError` and `vf.InvalidModelResponseError`; anything else (e.g. `vf.OverlongPromptError`) surfaces immediately and triggers a group drop here.

Closes #2475.

Behavior change motivated by the Qwen SWE-rebench failure described in the issue: a deterministic `OverlongPromptError` was retried ~100+ times because prime-rl treated it the same as a transient failure. The new approach lets the env decide what's retryable (via `max_retries` + the `vf.InfraError` hierarchy) and drops anything that escapes — partial groups aren't trainable, so there's no point keeping them around.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout failure handling and defaults in the training scheduler/config, which can affect throughput and step progression if errors become more/less frequent. Low security risk, but behavior changes may alter training stability and metrics.
> 
> **Overview**
> **Failure handling is simplified and made stricter.** The scheduler now **drops an entire rollout group** when any rollout returns an error or an empty trajectory, cancelling remaining in-flight work for that group rather than attempting in-orchestrator rescheduling.
> 
> **Retry responsibility shifts to env servers.** Default `max_retries` is increased from `0` to `3` for `EnvConfig`, `TrainConfig`, and `EvalConfig`, and the orchestrator-level reschedule knob (`max_error_reschedule_attempts` plus per-group round/attempt tracking) is removed. Metrics now also track counts per error type via `error/<type>/count`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dc70db9a9658d20cb0cc4f9381d308723c35061. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->