### PR TITLE
Add Memento vLLM 0.21 validation path

### DIFF
--- a/configs/ci/integration/memento_async_rl.toml
+++ b/configs/ci/integration/memento_async_rl.toml
@@ -1,0 +1,64 @@
+# Full Prime RL orchestration smoke for Memento/block-masking on vLLM.
+#
+# Intended to run inside the Truss/Baseten smoke after
+# scripts/prepare_memento_sft.py writes /tmp/memento-test-prep/model.
+# This short async smoke validates rollout + trainer backward. It does not
+# require the orchestrator to observe a fresh trainer broadcast before exit.
+
+output_dir = "/b10/workspace/outputs/memento-rl-prod-async"
+clean_output_dir = true
+max_steps = 2
+max_async_level = 1
+seq_len = 1024
+
+[model]
+name = "/tmp/memento-test-prep/model"
+
+[deployment]
+type = "single_node"
+gpus_per_node = 2
+num_infer_gpus = 1
+num_train_gpus = 1
+
+[ckpt]
+
+[weight_broadcast]
+type = "filesystem"
+
+[trainer.optim]
+lr = 1e-6
+
+[orchestrator]
+training_mode = "rl"
+batch_size = 4
+rollouts_per_example = 2
+max_inflight_rollouts = 4
+max_error_reschedule_attempts = 1
+collect_inference_metrics = false
+filters = []
+
+[orchestrator.renderer]
+name = "qwen3"
+preserve_all_thinking = true
+
+[orchestrator.train.sampling]
+temperature = 0.7
+max_completion_tokens = 96
+
+[orchestrator.train.sampling.extra_body]
+skip_special_tokens = false
+spaces_between_special_tokens = false
+
+[[orchestrator.train.env]]
+id = "alphabet-sort"
+name = "memento-alphabet-sort"
+args = { min_turns = 2, max_turns = 2, min_names_per_turn = 1, max_names_per_turn = 3, similarity_power = 4, power_per_turn = false }
+
+[inference]
+gpu_memory_utilization = 0.5
+block_masking_config = { enable = true, mask_delimiters = false, keep_last_n_blocks = 0, async_mode = "async_barrier", debug = true }
+
+[inference.model]
+dtype = "float16"
+max_model_len = 2048
+enforce_eager = true

--- a/configs/ci/integration/memento_async_rl_100.toml
+++ b/configs/ci/integration/memento_async_rl_100.toml
@@ -1,0 +1,61 @@
+# 100-step realistic Prime async RL run with Memento/block-masking enabled.
+# Organic compaction is not required here; this validates realistic rollout,
+# reward, trainer, checkpoint, and weight-update behavior with the overlay live.
+
+output_dir = "/b10/workspace/outputs/memento-rl-prod-async100"
+clean_output_dir = true
+max_steps = 100
+max_async_level = 1
+seq_len = 1024
+
+[model]
+name = "/tmp/memento-test-prep/model"
+
+[deployment]
+type = "single_node"
+gpus_per_node = 2
+num_infer_gpus = 1
+num_train_gpus = 1
+
+[ckpt]
+
+[weight_broadcast]
+type = "filesystem"
+
+[trainer.optim]
+lr = 1e-6
+
+[orchestrator]
+training_mode = "rl"
+batch_size = 4
+rollouts_per_example = 2
+max_inflight_rollouts = 4
+max_error_reschedule_attempts = 1
+collect_inference_metrics = false
+filters = []
+
+[orchestrator.renderer]
+name = "qwen3"
+preserve_all_thinking = true
+
+[orchestrator.train.sampling]
+temperature = 0.7
+max_completion_tokens = 96
+
+[orchestrator.train.sampling.extra_body]
+skip_special_tokens = false
+spaces_between_special_tokens = false
+
+[[orchestrator.train.env]]
+id = "alphabet-sort"
+name = "memento-alphabet-sort"
+args = { min_turns = 2, max_turns = 2, min_names_per_turn = 1, max_names_per_turn = 3, similarity_power = 4, power_per_turn = false }
+
+[inference]
+gpu_memory_utilization = 0.5
+block_masking_config = { enable = true, mask_delimiters = false, keep_last_n_blocks = 0, async_mode = "async_barrier", debug = true }
+
+[inference.model]
+dtype = "float16"
+max_model_len = 2048
+enforce_eager = true

--- a/configs/ci/integration/memento_baseline_async_rl_100.toml
+++ b/configs/ci/integration/memento_baseline_async_rl_100.toml
@@ -1,0 +1,59 @@
+# 100-step Prime async RL baseline on the same image/model/config shape as
+# Memento validation, but with block masking disabled.
+
+output_dir = "/b10/workspace/outputs/memento-rl-baseline-async100"
+clean_output_dir = true
+max_steps = 100
+max_async_level = 1
+seq_len = 1024
+
+[model]
+name = "/tmp/memento-test-prep/model"
+
+[deployment]
+type = "single_node"
+gpus_per_node = 2
+num_infer_gpus = 1
+num_train_gpus = 1
+
+[ckpt]
+
+[weight_broadcast]
+type = "filesystem"
+
+[trainer.optim]
+lr = 1e-6
+
+[orchestrator]
+training_mode = "rl"
+batch_size = 4
+rollouts_per_example = 2
+max_inflight_rollouts = 4
+max_error_reschedule_attempts = 1
+collect_inference_metrics = false
+filters = []
+
+[orchestrator.renderer]
+name = "qwen3"
+preserve_all_thinking = true
+
+[orchestrator.train.sampling]
+temperature = 0.7
+max_completion_tokens = 96
+
+[orchestrator.train.sampling.extra_body]
+skip_special_tokens = false
+spaces_between_special_tokens = false
+
+[[orchestrator.train.env]]
+id = "alphabet-sort"
+name = "memento-baseline-alphabet-sort"
+args = { min_turns = 2, max_turns = 2, min_names_per_turn = 1, max_names_per_turn = 3, similarity_power = 4, power_per_turn = false }
+
+[inference]
+gpu_memory_utilization = 0.5
+
+[inference.model]
+dtype = "float16"
+max_model_len = 2048
+enforce_eager = true

--- a/configs/ci/integration/memento_boundary_async_rl.toml
+++ b/configs/ci/integration/memento_boundary_async_rl.toml
@@ -1,0 +1,63 @@
+# Prime async RL smoke with deterministic Memento boundary-token history.
+#
+# This is the gate-4 fixture: rollouts use a Verifiers env whose prompt already
+# contains a prior assistant turn with a completed block+summary. The run should
+# therefore exercise vLLM block-mask compaction inside the production RL loop.
+
+output_dir = "/b10/workspace/outputs/memento-rl-boundary-async"
+clean_output_dir = true
+max_steps = 2
+max_async_level = 1
+seq_len = 1024
+
+[model]
+name = "/tmp/memento-test-prep/model"
+
+[deployment]
+type = "single_node"
+gpus_per_node = 2
+num_infer_gpus = 1
+num_train_gpus = 1
+
+[ckpt]
+
+[weight_broadcast]
+type = "filesystem"
+
+[trainer.optim]
+lr = 1e-6
+
+[orchestrator]
+training_mode = "rl"
+batch_size = 4
+rollouts_per_example = 2
+max_inflight_rollouts = 4
+max_error_reschedule_attempts = 1
+collect_inference_metrics = false
+filters = []
+
+[orchestrator.renderer]
+name = "qwen3"
+preserve_all_thinking = true
+
+[orchestrator.train.sampling]
+temperature = 0.7
+max_completion_tokens = 32
+
+[orchestrator.train.sampling.extra_body]
+skip_special_tokens = false
+spaces_between_special_tokens = false
+
+[[orchestrator.train.env]]
+id = "memento-boundary-env"
+name = "memento-boundary-fixture"
+args = { num_examples = 8, answer = "84" }
+
+[inference]
+gpu_memory_utilization = 0.5
+block_masking_config = { enable = true, mask_delimiters = false, keep_last_n_blocks = 0, async_mode = "async_barrier", debug = true }
+
+[inference.model]
+dtype = "float16"
+max_model_len = 2048
+enforce_eager = true

--- a/configs/ci/integration/memento_boundary_async_rl_100.toml
+++ b/configs/ci/integration/memento_boundary_async_rl_100.toml
@@ -1,0 +1,61 @@
+# 100-step Prime async RL run with deterministic Memento boundary-token history.
+# This should repeatedly exercise vLLM block-mask compaction inside the
+# production async RL loop.
+
+output_dir = "/b10/workspace/outputs/memento-rl-boundary-async100"
+clean_output_dir = true
+max_steps = 100
+max_async_level = 1
+seq_len = 1024
+
+[model]
+name = "/tmp/memento-test-prep/model"
+
+[deployment]
+type = "single_node"
+gpus_per_node = 2
+num_infer_gpus = 1
+num_train_gpus = 1
+
+[ckpt]
+
+[weight_broadcast]
+type = "filesystem"
+
+[trainer.optim]
+lr = 1e-6
+
+[orchestrator]
+training_mode = "rl"
+batch_size = 4
+rollouts_per_example = 2
+max_inflight_rollouts = 4
+max_error_reschedule_attempts = 1
+collect_inference_metrics = false
+filters = []
+
+[orchestrator.renderer]
+name = "qwen3"
+preserve_all_thinking = true
+
+[orchestrator.train.sampling]
+temperature = 0.7
+max_completion_tokens = 32
+
+[orchestrator.train.sampling.extra_body]
+skip_special_tokens = false
+spaces_between_special_tokens = false
+
+[[orchestrator.train.env]]
+id = "memento-boundary-env"
+name = "memento-boundary-fixture"
+args = { num_examples = 8, answer = "84" }
+
+[inference]
+gpu_memory_utilization = 0.5
+block_masking_config = { enable = true, mask_delimiters = false, keep_last_n_blocks = 0, async_mode = "async_barrier", debug = true }
+
+[inference.model]
+dtype = "float16"
+max_model_len = 2048
+enforce_eager = true

--- a/configs/ci/integration/memento_boundary_async_rl_100_offpolicy.toml
+++ b/configs/ci/integration/memento_boundary_async_rl_100_offpolicy.toml
@@ -1,0 +1,60 @@
+# 100-step Prime async RL run with deterministic Memento boundary-token history
+# and intentional async/off-policy pressure.
+
+output_dir = "/b10/workspace/outputs/memento-rl-boundary-offpolicy100"
+clean_output_dir = true
+max_steps = 100
+max_async_level = 4
+seq_len = 1024
+
+[model]
+name = "/tmp/memento-test-prep/model"
+
+[deployment]
+type = "single_node"
+gpus_per_node = 2
+num_infer_gpus = 1
+num_train_gpus = 1
+
+[ckpt]
+
+[weight_broadcast]
+type = "filesystem"
+
+[trainer.optim]
+lr = 1e-6
+
+[orchestrator]
+training_mode = "rl"
+batch_size = 4
+rollouts_per_example = 2
+max_inflight_rollouts = 16
+max_error_reschedule_attempts = 1
+collect_inference_metrics = false
+filters = []
+
+[orchestrator.renderer]
+name = "qwen3"
+preserve_all_thinking = true
+
+[orchestrator.train.sampling]
+temperature = 0.7
+max_completion_tokens = 64
+
+[orchestrator.train.sampling.extra_body]
+skip_special_tokens = false
+spaces_between_special_tokens = false
+
+[[orchestrator.train.env]]
+id = "memento-boundary-env"
+name = "memento-boundary-fixture"
+args = { num_examples = 16, answer = "84" }
+
+[inference]
+gpu_memory_utilization = 0.5
+block_masking_config = { enable = true, mask_delimiters = false, keep_last_n_blocks = 0, async_mode = "async_barrier", debug = true }
+
+[inference.model]
+dtype = "float16"
+max_model_len = 2048
+enforce_eager = true

--- a/docs/memento-stability-validation.md
+++ b/docs/memento-stability-validation.md
@@ -1,0 +1,258 @@
+# Memento vLLM 0.21 Stability Validation
+
+Date: 2026-05-21
+
+This note records the Memento/vLLM validation gate before starting the Prime <> Still compactor integration. It also records the GitHub remote setup now that this checkout was cloned from `PrimeIntellect-ai/prime-rl` and needs to move onto the Baseten-owned `basetenlabs/compact-rl` repo.
+
+## Verdict
+
+The Memento vLLM 0.21 block-masking path is stable enough to start the compactor phase behind flags.
+
+The validated surface is:
+
+- Prime async RL loop with Memento disabled.
+- Prime async RL loop with Memento enabled and deterministic boundary-triggered compaction.
+- Prime async RL loop with Memento enabled in a realistic environment where compaction is not forced.
+- Direct vLLM async/KV stress with repeated compactions, async barrier mode, and production-ish inference settings.
+- A separate boundary async RL run allowing observed off-policy behavior.
+
+This does not validate the Still compactor itself. The next phase still needs to prove Still sidecar loading, KV-to-compacted-KV runtime behavior, trace emission, trainer replay/backward, Still gradients, and joint Qwen+Still policy synchronization.
+
+## Source Plans
+
+The stability gate was checked against two existing plans:
+
+- Memento migration plan: `/Users/thomasvilleneuve/.claude/plans/nifty-exploring-cascade.md`
+- Prime <> Still training port plan: `/Users/thomasvilleneuve/Desktop/Code/rl-takehome/experiments/prime-still-training-port-plan.md`
+
+The Memento plan's main risk was overlay drift from stock vLLM 0.21, especially scheduler/KV corruption around compaction, queue draining, block-table truncation, and async behavior. The Still port plan assumes that this Memento/vLLM layer can safely support rollout-time compaction and produce trace data for trainer-side replay.
+
+## Test Matrix
+
+| Job | Purpose | Result | Key Evidence |
+| --- | --- | --- | --- |
+| `w7d7xdw` | Baseline Prime async RL, Memento disabled | Passed | 100 steps, trainer step 99, stable broadcasts, finite metrics, zero Memento events |
+| `qe97k53` | Boundary async RL, Memento enabled, compaction required | Passed | 100 steps, 404 successful compactions, KV copy and block truncation events present |
+| `q05v97w` | Realistic async RL, Memento enabled, compaction not required | Passed | 100 steps, async scheduler/barrier active, stable broadcasts, no compaction expected or observed |
+| `qvx61gw` | Direct vLLM async/KV stress, no trainer | Passed | Fixed-length non-empty outputs, 102 async stress requests, 109 successful compactions |
+| `qkj4odw` | Boundary async RL with observed off-policy behavior | Passed | 100 steps, 550 successful compactions, max observed off-policy level 8, stable broadcasts |
+
+An earlier realistic RL run, `qj7okgq`, completed training but the wrapper failed because zero-count `grep` checks interacted badly with `pipefail`. The wrapper was patched to make zero-count metrics explicit and safe, then `q05v97w` passed.
+
+## Job Details
+
+### Job 1: Baseline Async RL, Memento Disabled
+
+Job id: `w7d7xdw`
+
+Launch shape:
+
+```bash
+env BLOCK_MASKING_ASYNC_MODE=async_barrier EXPECT_MEMENTO_ENABLED=0 EXPECTED_FINAL_STEP=99 MIN_BROADCAST_STABLE=2 MEMENTO_RL_CONFIG=configs/ci/integration/memento_baseline_async_rl_100.toml MEMENTO_RL_OUTPUT_DIR=/b10/workspace/outputs/memento-rl-baseline-async100-r2 uvx truss train push memento_rl_test.py --job-name memento-vllm021-baseline-async100-r2b
+```
+
+Result:
+
+- Passed 100 training steps.
+- Orchestrator and trainer reached step 99.
+- Trainer finished normally with finite metrics.
+- Broadcast stability was observed at the required threshold.
+- Memento event counts were all zero, as expected for the disabled path.
+- Peak trainer memory was around 15 GiB.
+
+### Job 2: Boundary Async RL, Memento Enabled, Compaction Required
+
+Job id: `qe97k53`
+
+Launch shape:
+
+```bash
+env BLOCK_MASKING_ASYNC_MODE=async_barrier EXPECT_MEMENTO_ENABLED=1 INSTALL_MEMENTO_BOUNDARY_ENV=1 REQUIRE_MEMENTO_COMPACTION=1 EXPECTED_FINAL_STEP=99 MIN_BROADCAST_STABLE=2 MIN_MEMENTO_COMPACTIONS=10 MIN_MEMENTO_KV_COPIES=10 MIN_MEMENTO_BLOCK_TRUNCATIONS=10 MEMENTO_RL_CONFIG=configs/ci/integration/memento_boundary_async_rl_100.toml MEMENTO_RL_OUTPUT_DIR=/b10/workspace/outputs/memento-rl-boundary-async100-r2 uvx truss train push memento_rl_test.py --job-name memento-vllm021-boundary-async100-r3
+```
+
+Result:
+
+- Passed 100 training steps.
+- `memento_compaction_count=404`
+- `span_success_count=404`
+- `kv_copy_count=202`
+- `block_truncation_count=202`
+- No failed spans or non-None compaction errors were observed.
+- Trainer metrics stayed finite.
+- Peak trainer memory was around 12.8 GiB.
+
+This is the strongest async RL validation that the Memento KV update path is actually firing under trainer/backward and policy broadcast pressure.
+
+### Job 3: Realistic Async RL, Memento Enabled, Compaction Not Required
+
+Job id: `q05v97w`
+
+Launch shape:
+
+```bash
+env BLOCK_MASKING_ASYNC_MODE=async_barrier EXPECT_MEMENTO_ENABLED=1 EXPECTED_FINAL_STEP=99 MIN_BROADCAST_STABLE=2 MEMENTO_RL_CONFIG=configs/ci/integration/memento_async_rl_100.toml MEMENTO_RL_OUTPUT_DIR=/b10/workspace/outputs/memento-rl-prod-async100-r3 uvx truss train push memento_rl_test.py --job-name memento-vllm021-prod-async100-r3
+```
+
+Result:
+
+- Passed 100 training steps.
+- Trainer finished normally.
+- Async scheduler and async barrier paths were active.
+- Policy updates and stable broadcasts were observed.
+- `memento_compaction_count=0`
+- `span_success_count=0`
+- `kv_copy_count=0`
+- `block_truncation_count=0`
+- Max observed off-policy level was 0.
+
+The zero compaction count is expected for this run because the realistic alphabet-sort environment does not deterministically emit the boundary-token history needed to trigger Memento compaction. This job validates that enabling Memento does not break a real Prime async RL loop, but it does not validate active compaction.
+
+### Job 4: Direct vLLM Async/KV Stress
+
+Job id: `qvx61gw`
+
+Launch shape:
+
+```bash
+env BLOCK_MASKING_ASYNC_MODE=async_barrier MIN_MEMENTO_COMPACTIONS=10 MIN_MEMENTO_KV_COPIES=10 MIN_MEMENTO_BLOCK_TRUNCATIONS=10 MEMENTO_INFERENCE_EXTRA_ARGS="--no-enforce-eager --async-stress-repeats 6 --stress-compact-requests 16 --stress-long-tokens 384 --gpu-memory-utilization 0.85" uvx truss train push memento_inference_test.py --job-name memento-vllm021-infer-stress-r3
+```
+
+Result:
+
+- Passed with `ALL TESTS PASSED`.
+- Fixed-length generations were non-empty and had the expected token counts.
+- Async client drain stress completed 6 waves and 102 total requests.
+- `memento_compaction_count=109`
+- `span_success_count=109`
+- `kv_copy_count=16`
+- `block_truncation_count=16`
+
+This job isolates the vLLM overlay from trainer/orchestrator noise. It is the best current coverage for KV copy direction/layout, block-table truncation, async queue draining, repeated compaction, and non-eager inference behavior.
+
+### Additional Off-Policy Boundary Run
+
+Job id: `qkj4odw`
+
+Launch shape:
+
+```bash
+env BLOCK_MASKING_ASYNC_MODE=async_barrier EXPECT_MEMENTO_ENABLED=1 INSTALL_MEMENTO_BOUNDARY_ENV=1 REQUIRE_MEMENTO_COMPACTION=1 EXPECTED_FINAL_STEP=99 MIN_BROADCAST_STABLE=2 MIN_MEMENTO_COMPACTIONS=10 MIN_MEMENTO_KV_COPIES=10 MIN_MEMENTO_BLOCK_TRUNCATIONS=10 MIN_MAX_OFF_POLICY_LEVEL=1 MEMENTO_RL_CONFIG=configs/ci/integration/memento_boundary_async_rl_100_offpolicy.toml MEMENTO_RL_OUTPUT_DIR=/b10/workspace/outputs/memento-rl-boundary-offpolicy100-a4-r1 uvx truss train push memento_rl_test.py --job-name memento-vllm021-boundary-offpolicy100-a4-r1
+```
+
+Result:
+
+- Passed 100 training steps.
+- `memento_compaction_count=550`
+- `span_success_count=550`
+- `kv_copy_count=198`
+- `block_truncation_count=198`
+- `max_observed_off_policy_level=8`
+- `broadcast_stable_count=5`
+- Trainer metrics remained finite.
+
+This run shows Memento compaction surviving under a more asynchronous policy-update regime. It also exposed stale rollout cancellation warnings. Those are not a failure for this gate, but they should be monitored once Still is added because Still traces will need to be discarded with their owning rollout if the rollout is cancelled.
+
+## Local Checks
+
+Local verification included:
+
+```bash
+uv run --no-sync python -m py_compile memento_rl_test.py memento_inference_test.py
+env PYTHONPATH=src:packages/prime-rl-configs/src uv run --no-sync pytest tests/unit/inference/test_block_masking.py -q
+git diff --check
+```
+
+The block-masking unit tests passed: 5 tests passed.
+
+The runtime wrappers were also checked for shell syntax by extracting and running `bash -n` on the embedded scripts.
+
+## Confidence Bar
+
+The aggressive stability plan required:
+
+- Jobs 1, 2, and 3 pass 100 steps.
+- Job 4 passes sustained async/KV stress.
+- Boundary job shows repeated successful compaction.
+- Realistic job shows repeated checkpoint/broadcast policy updates.
+- No scheduler index errors, KV corruption, empty-output regression, wrong token counts, trainer NaNs, or memory drift.
+
+That bar is met for the tested configuration.
+
+It is reasonable to proceed to Prime <> Still integration, with the Still path behind explicit config flags and with the same hard-fail preflight/summary checks preserved.
+
+## Remaining Hard Edges
+
+The following are not yet proven:
+
+- Actual Still compactor execution in the Prime vLLM loop.
+- RoPE unrotation/rerotation for Still-generated compacted KV.
+- Synthetic KV insertion from Still outputs.
+- Trace emission from vLLM/Still and preservation into trainer samples.
+- Trainer-side Still replay/backward.
+- Still gradient correctness.
+- Joint Qwen+Still checkpointing and weight broadcast as one policy bundle.
+- Long-horizon production training beyond 100-step validation.
+- Larger models and larger context windows.
+- Multi-node, disaggregated serving, speculative decoding, structured outputs, or kv-connector combinations.
+- DeepGEMM-enabled behavior.
+- FlashInfer sampler behavior.
+
+The RL jobs used conservative runtime settings, including eager inference and lower GPU memory utilization. The direct vLLM stress job covered `enforce_eager=false` with higher GPU memory utilization, but that is not the same as a full non-eager RL training run.
+
+Off-policy settings also need care. `max_async_level` and the observed off-policy level are not the same practical bound in these runs. The off-policy boundary job observed level 8, so any Still training config should set and log both async and off-policy controls explicitly.
+
+## Next Phase Gates
+
+Before treating the Still integration as stable, the next phase should add gates for:
+
+- Memento enabled and Still disabled: current validated path.
+- Still loaded but compaction disabled: import/config/checkpoint safety.
+- Still compaction enabled in deterministic boundary fixture: repeated Still compactions required.
+- Still traces attached to rollouts and dropped when rollouts are cancelled.
+- Trainer replay builds a valid autograd graph for Still.
+- Still parameters receive non-zero finite gradients.
+- Qwen parameters and Still parameters are checkpointed and broadcast with matching policy identity.
+- Cancellation, dropped group, empty rollout, and failed compaction counts are summarized and optionally hard-failed.
+
+## Baseten Fork And Remote Setup
+
+Original remote state:
+
+```text
+origin https://github.com/PrimeIntellect-ai/prime-rl
+```
+
+Baseten fork:
+
+```text
+https://github.com/basetenlabs/compact-rl.git
+```
+
+Recommended setup before committing this work:
+
+1. Preserve PrimeIntellect as `upstream`.
+2. Make `basetenlabs/compact-rl` the `origin`.
+3. Create a feature branch for the Memento port, for example `feat/memento-vllm021`.
+4. Commit and push the current Memento port and this validation note to that feature branch.
+
+Remote flow:
+
+```bash
+git remote rename origin upstream
+git remote add origin https://github.com/basetenlabs/compact-rl.git
+git switch -c feat/memento-vllm021
+git push -u origin feat/memento-vllm021
+```
+
+If SSH is preferred:
+
+```bash
+git remote rename origin upstream
+git remote add origin git@github.com:basetenlabs/compact-rl.git
+git switch -c feat/memento-vllm021
+git push -u origin feat/memento-vllm021
+```
+
+After setup, `origin` should point at Baseten's fork and `upstream` should point at `PrimeIntellect-ai/prime-rl`.
+
+Do not push this dirty working tree directly to `main`. Keep the port on a named feature branch so follow-up Still integration can be reviewed independently from future upstream syncs.

--- a/memento_inference_test.py
+++ b/memento_inference_test.py
@@ -1,0 +1,262 @@
+"""Baseten job: Test block masking overlay works in vLLM.
+
+Adds 4 block masking tokens to Qwen3-0.6B, installs the overlay, and runs
+inference tests to verify the block masking system initializes and processes
+correctly. No SFT needed — tests the infrastructure, not the model's ability
+to generate block markers.
+
+Usage:
+    uvx truss train push memento_inference_test.py \
+        --job-name memento-infer-test-v2-r1
+"""
+
+import os
+import shlex
+
+from truss.base import truss_config
+from truss_train import definitions
+
+BASE_IMAGE = os.environ.get("BASE_IMAGE", "primeintellect/prime-rl:main")
+PROJECT_NAME = os.environ.get("PROJECT_NAME", "prime-rl-memento-sft")
+
+START_COMMAND = r"""
+set -euxo pipefail
+
+WORKSPACE_DIR="${BASETEN_WORKSPACE_DIR:-/b10/workspace}"
+IMAGE_APP_DIR="${PRIME_RL_APP_DIR:-/app}"
+
+export HOME="${HOME:-${WORKSPACE_DIR}}"
+export XDG_CACHE_HOME="${XDG_CACHE_HOME:-${HOME}/.cache}"
+export HF_HOME="${HF_HOME:-${XDG_CACHE_HOME}/huggingface}"
+export UV_CACHE_DIR="${UV_CACHE_DIR:-${XDG_CACHE_HOME}/uv}"
+export UV_LINK_MODE="${UV_LINK_MODE:-copy}"
+mkdir -p "${HOME}" "${XDG_CACHE_HOME}" "${HF_HOME}" "${UV_CACHE_DIR}"
+
+if [ -n "${PRIME_RL_PROJECT_DIR:-}" ]; then
+  PROJECT_DIR="${PRIME_RL_PROJECT_DIR}"
+elif [ -f "${WORKSPACE_DIR}/pyproject.toml" ]; then
+  PROJECT_DIR="${WORKSPACE_DIR}"
+else
+  PROJECT_DIR="${IMAGE_APP_DIR}"
+fi
+
+if [ -z "${UV_PROJECT_ENVIRONMENT:-}" ]; then
+  if [ -d "${IMAGE_APP_DIR}/.venv" ]; then
+    export UV_PROJECT_ENVIRONMENT="${IMAGE_APP_DIR}/.venv"
+  else
+    export UV_PROJECT_ENVIRONMENT="${PROJECT_DIR}/.venv"
+  fi
+fi
+
+cd "${PROJECT_DIR}"
+export PYTHONPATH="${PROJECT_DIR}/src:${PROJECT_DIR}/packages/prime-rl-configs/src:${PYTHONPATH:-}"
+
+echo "=== Launch manifest ==="
+echo "workspace_dir=${WORKSPACE_DIR}"
+echo "project_dir=${PROJECT_DIR}"
+echo "image_app_dir=${IMAGE_APP_DIR}"
+echo "uv_project_environment=${UV_PROJECT_ENVIRONMENT}"
+echo "pythonpath=${PYTHONPATH}"
+echo "base_image=${BASE_IMAGE:-unknown}"
+echo "block_masking_async_mode=${BLOCK_MASKING_ASYNC_MODE:-safe_sync}"
+echo "memento_inference_extra_args=${MEMENTO_INFERENCE_EXTRA_ARGS:-}"
+if command -v sha256sum >/dev/null 2>&1 && [ -f uv.lock ]; then
+  echo "uv_lock_sha256=$(sha256sum uv.lock | awk '{print $1}')"
+fi
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "git_sha=$(git rev-parse HEAD)"
+  echo "git_status_short_begin"
+  git status --short || true
+  echo "git_status_short_end"
+fi
+
+for path in \
+  pyproject.toml \
+  uv.lock \
+  src/prime_rl/inference/patches.py \
+  src/prime_rl/inference/block_masking/__init__.py \
+  src/prime_rl/inference/block_masking/config.py \
+  src/prime_rl/inference/vllm/padded_input_scrub.py \
+  packages/prime-rl-configs/pyproject.toml \
+  overlays/vllm/v1/core/sched/output.py \
+  overlays/vllm/v1/core/sched/scheduler.py \
+  scripts/memento_runtime_preflight.py \
+  scripts/install_block_masking_overlay.sh \
+  scripts/test_block_masking_inference.py \
+  scripts/prepare_memento_sft.py
+do
+  if [ ! -e "$path" ]; then
+    echo "ERROR: Missing required launch artifact: $path"
+    exit 1
+  fi
+done
+
+if [ "${SYNC_PROJECT_DEPS:-0}" = "1" ]; then
+  echo "=== Syncing project dependencies from bundled lockfile ==="
+  UV_SYNC_ARGS="${UV_SYNC_ARGS:---locked --inexact}"
+  uv sync ${UV_SYNC_ARGS}
+elif [ "${INSTALL_VLLM_WHEEL:-1}" = "1" ]; then
+  echo "=== Installing target vLLM wheel ==="
+  uv pip install \
+    --python "${UV_PROJECT_ENVIRONMENT}/bin/python" \
+    --reinstall \
+    --no-deps \
+    "${VLLM_WHEEL_URL}"
+fi
+UV_RUN_EXTRA="--no-sync"
+
+export HF_HUB_ENABLE_HF_TRANSFER="${HF_HUB_ENABLE_HF_TRANSFER:-1}"
+export PYTORCH_CUDA_ALLOC_CONF="${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}"
+export TOKENIZERS_PARALLELISM="${TOKENIZERS_PARALLELISM:-false}"
+export PRIME_DISABLE_VERSION_CHECK="${PRIME_DISABLE_VERSION_CHECK:-1}"
+export VLLM_USE_FLASHINFER_SAMPLER="${VLLM_USE_FLASHINFER_SAMPLER:-0}"
+export VLLM_USE_DEEP_GEMM="${VLLM_USE_DEEP_GEMM:-0}"
+export VLLM_MOE_USE_DEEP_GEMM="${VLLM_MOE_USE_DEEP_GEMM:-0}"
+: "${VLLM_WHEEL_URL:=https://github.com/vllm-project/vllm/releases/download/v0.21.0/vllm-0.21.0+cu129-cp38-abi3-manylinux_2_34_x86_64.whl}"
+
+echo "=== Runtime preflight ==="
+uv run ${UV_RUN_EXTRA} python scripts/memento_runtime_preflight.py
+
+# --- Step 1: Install block masking overlay ---
+echo "=== Installing block masking overlay ==="
+bash scripts/install_block_masking_overlay.sh "${UV_PROJECT_ENVIRONMENT}"
+
+# --- Step 2: Prepare model (add block masking tokens, no dataset needed) ---
+echo "=== Preparing model (adding block masking tokens) ==="
+uv run ${UV_RUN_EXTRA} python scripts/prepare_memento_sft.py \
+  --output-dir /tmp/memento-test-prep \
+  --model-only
+
+# --- Step 3: Run inference test ---
+echo "=== Running block masking inference test ==="
+INFERENCE_TEST_LOG="${WORKSPACE_DIR}/block_masking_inference_test.log"
+BLOCK_MASKING_EVENT_LOG="${WORKSPACE_DIR}/block_masking_events.log"
+rm -f "${BLOCK_MASKING_EVENT_LOG}"
+touch "${BLOCK_MASKING_EVENT_LOG}"
+export PRIME_RL_BLOCK_MASKING_EVENT_LOG="${BLOCK_MASKING_EVENT_LOG}"
+set +e
+uv run ${UV_RUN_EXTRA} python scripts/test_block_masking_inference.py \
+  --model /tmp/memento-test-prep/model \
+  --max-tokens 256 \
+  --max-model-len 4096 \
+  --block-masking-async-mode "${BLOCK_MASKING_ASYNC_MODE:-safe_sync}" \
+  ${MEMENTO_INFERENCE_EXTRA_ARGS:-} \
+  2>&1 | tee "${INFERENCE_TEST_LOG}"
+test_status="${PIPESTATUS[0]}"
+set -e
+if [ "${test_status}" != "0" ]; then
+  exit "${test_status}"
+fi
+
+compaction_count="$(grep -Ec "Block masking (prompt|generated|deferred) compaction" "${INFERENCE_TEST_LOG}" || true)"
+span_success_count="$(grep -c "SpanRemovalResult(success=True" "${INFERENCE_TEST_LOG}" || true)"
+kv_copy_count="$({ grep -h "Block masking KV copy ops executed" "${INFERENCE_TEST_LOG}" "${BLOCK_MASKING_EVENT_LOG}" 2>/dev/null || true; } | wc -l | tr -d ' ')"
+block_truncation_count="$({ grep -h "Block masking block table truncations applied" "${INFERENCE_TEST_LOG}" "${BLOCK_MASKING_EVENT_LOG}" 2>/dev/null || true; } | wc -l | tr -d ' ')"
+echo "memento_compaction_count=${compaction_count}"
+echo "memento_span_success_count=${span_success_count}"
+echo "memento_kv_copy_count=${kv_copy_count}"
+echo "memento_block_truncation_count=${block_truncation_count}"
+if [ -s "${BLOCK_MASKING_EVENT_LOG}" ]; then
+  echo "=== Block masking GPU event log tail ==="
+  tail -40 "${BLOCK_MASKING_EVENT_LOG}"
+fi
+if grep -q "SpanRemovalResult(success=False" "${INFERENCE_TEST_LOG}"; then
+  echo "ERROR: failed SpanRemovalResult detected"
+  grep -n "SpanRemovalResult(success=False" "${INFERENCE_TEST_LOG}" || true
+  exit 1
+fi
+if grep "error_message=" "${INFERENCE_TEST_LOG}" | grep -v "error_message=None" >/dev/null; then
+  echo "ERROR: non-empty compaction error_message detected"
+  grep -n "error_message=" "${INFERENCE_TEST_LOG}" | grep -v "error_message=None" || true
+  exit 1
+fi
+if [ "${compaction_count}" -lt "${MIN_MEMENTO_COMPACTIONS:-1}" ]; then
+  echo "ERROR: expected at least ${MIN_MEMENTO_COMPACTIONS:-1} compaction log(s)"
+  exit 1
+fi
+if [ "${span_success_count}" -lt "${MIN_MEMENTO_COMPACTIONS:-1}" ]; then
+  echo "ERROR: expected at least ${MIN_MEMENTO_COMPACTIONS:-1} successful SpanRemovalResult log(s)"
+  exit 1
+fi
+if [ "${kv_copy_count}" -lt "${MIN_MEMENTO_KV_COPIES:-1}" ]; then
+  echo "ERROR: expected at least ${MIN_MEMENTO_KV_COPIES:-1} KV-copy execution log(s)"
+  exit 1
+fi
+if [ "${block_truncation_count}" -lt "${MIN_MEMENTO_BLOCK_TRUNCATIONS:-1}" ]; then
+  echo "ERROR: expected at least ${MIN_MEMENTO_BLOCK_TRUNCATIONS:-1} block-table truncation log(s)"
+  exit 1
+fi
+
+echo "=== Inference test complete ==="
+""".strip()
+
+training_runtime = definitions.Runtime(
+    start_commands=[f"/bin/bash -lc {shlex.quote(START_COMMAND)}"],
+    environment_variables={
+        "HF_TOKEN": definitions.SecretReference(
+            name=os.environ.get("HF_SECRET_NAME", "hf_access_token")
+        ),
+        "BASETEN_WORKSPACE_DIR": os.environ.get(
+            "BASETEN_WORKSPACE_DIR", "/b10/workspace"
+        ),
+        "PRIME_RL_APP_DIR": os.environ.get("PRIME_RL_APP_DIR", "/app"),
+        "BASE_IMAGE": BASE_IMAGE,
+        "PRIME_DISABLE_VERSION_CHECK": "1",
+        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
+        "TOKENIZERS_PARALLELISM": "false",
+        "UV_LINK_MODE": os.environ.get("UV_LINK_MODE", "copy"),
+        "SYNC_PROJECT_DEPS": os.environ.get("SYNC_PROJECT_DEPS", "0"),
+        "UV_SYNC_ARGS": os.environ.get("UV_SYNC_ARGS", "--locked --inexact"),
+        "INSTALL_VLLM_WHEEL": os.environ.get("INSTALL_VLLM_WHEEL", "1"),
+        "VLLM_WHEEL_URL": os.environ.get(
+            "VLLM_WHEEL_URL",
+            "https://github.com/vllm-project/vllm/releases/download/v0.21.0/vllm-0.21.0+cu129-cp38-abi3-manylinux_2_34_x86_64.whl",
+        ),
+        "VLLM_USE_FLASHINFER_SAMPLER": "0",
+        "VLLM_USE_DEEP_GEMM": "0",
+        "VLLM_MOE_USE_DEEP_GEMM": "0",
+        "BLOCK_MASKING_ASYNC_MODE": os.environ.get(
+            "BLOCK_MASKING_ASYNC_MODE", "safe_sync"
+        ),
+        "MEMENTO_INFERENCE_EXTRA_ARGS": os.environ.get(
+            "MEMENTO_INFERENCE_EXTRA_ARGS", ""
+        ),
+        "MIN_MEMENTO_COMPACTIONS": os.environ.get("MIN_MEMENTO_COMPACTIONS", "1"),
+        "MIN_MEMENTO_KV_COPIES": os.environ.get("MIN_MEMENTO_KV_COPIES", "1"),
+        "MIN_MEMENTO_BLOCK_TRUNCATIONS": os.environ.get(
+            "MIN_MEMENTO_BLOCK_TRUNCATIONS", "1"
+        ),
+        "EXPECTED_VLLM_VERSION_PREFIX": os.environ.get(
+            "EXPECTED_VLLM_VERSION_PREFIX", "0.21."
+        ),
+        "HOME": os.environ.get("BASETEN_HOME", "/b10/workspace"),
+        "XDG_CACHE_HOME": os.environ.get(
+            "BASETEN_XDG_CACHE_HOME", "/b10/workspace/.cache"
+        ),
+        "HF_HOME": os.environ.get(
+            "BASETEN_HF_HOME", "/b10/workspace/.cache/huggingface"
+        ),
+        "UV_CACHE_DIR": os.environ.get(
+            "BASETEN_UV_CACHE_DIR", "/b10/workspace/.cache/uv"
+        ),
+    },
+)
+
+training_compute = definitions.Compute(
+    accelerator=truss_config.AcceleratorSpec(
+        accelerator=truss_config.Accelerator.H100,
+        count=1,
+    ),
+    node_count=1,
+)
+
+training_job = definitions.TrainingJob(
+    image=definitions.Image(base_image=BASE_IMAGE),
+    compute=training_compute,
+    runtime=training_runtime,
+)
+
+training_project = definitions.TrainingProject(
+    name=PROJECT_NAME,
+    job=training_job,
+)

--- a/memento_rl_test.py
+++ b/memento_rl_test.py
@@ -1,0 +1,376 @@
+"""Baseten job: full Prime RL prod-loop smoke with Memento block masking.
+
+This runs the real ``rl`` entrypoint with one inference H100 and one trainer
+H100. It prepares a Qwen3-0.6B checkpoint with Memento boundary tokens, installs
+the vLLM block-masking overlay, then validates that the production async RL loop
+starts inference, generates rollouts, and runs trainer backward with block
+masking enabled. Deterministic compaction is covered by the standalone inference
+smoke, and policy-update handoff should be covered by a longer/stricter async
+smoke.
+
+Usage:
+    env BLOCK_MASKING_ASYNC_MODE=async_barrier uvx truss train push \
+        memento_rl_test.py --job-name memento-vllm021-rl-prod-r1
+"""
+
+import os
+import shlex
+
+from truss.base import truss_config
+from truss_train import definitions
+
+BASE_IMAGE = os.environ.get("BASE_IMAGE", "primeintellect/prime-rl:main")
+PROJECT_NAME = os.environ.get("PROJECT_NAME", "prime-rl-memento-prod-rl")
+
+START_COMMAND = r"""
+set -euxo pipefail
+
+WORKSPACE_DIR="${BASETEN_WORKSPACE_DIR:-/b10/workspace}"
+IMAGE_APP_DIR="${PRIME_RL_APP_DIR:-/app}"
+RUN_OUTPUT_DIR="${MEMENTO_RL_OUTPUT_DIR:-/b10/workspace/outputs/memento-rl-prod-async}"
+RUN_CONFIG="${MEMENTO_RL_CONFIG:-configs/ci/integration/memento_async_rl.toml}"
+
+dump_prime_logs() {
+  local status="$1"
+  if [ "${status}" = "0" ]; then
+    return 0
+  fi
+
+  echo "=== Prime RL smoke failed with status ${status}; dumping child logs ==="
+  for file in \
+    "${RUN_OUTPUT_DIR}/logs/orchestrator.log" \
+    "${RUN_OUTPUT_DIR}/logs/trainer.log" \
+    "${RUN_OUTPUT_DIR}/logs/inference.log"
+  do
+    if [ -s "${file}" ]; then
+      echo "=== tail -200 ${file} ==="
+      tail -200 "${file}" || true
+    else
+      echo "=== missing or empty ${file} ==="
+    fi
+  done
+
+  if [ -d "${RUN_OUTPUT_DIR}/logs/trainer/torchrun" ]; then
+    echo "=== trainer torchrun log tails ==="
+    find "${RUN_OUTPUT_DIR}/logs/trainer/torchrun" \
+      -type f \( -name stdout.log -o -name stderr.log \) \
+      -print \
+      -exec tail -120 {} \; || true
+  fi
+}
+
+trap 'status=$?; dump_prime_logs "$status"; exit "$status"' EXIT
+
+export HOME="${HOME:-${WORKSPACE_DIR}}"
+export XDG_CACHE_HOME="${XDG_CACHE_HOME:-${HOME}/.cache}"
+export HF_HOME="${HF_HOME:-${XDG_CACHE_HOME}/huggingface}"
+export UV_CACHE_DIR="${UV_CACHE_DIR:-${XDG_CACHE_HOME}/uv}"
+export UV_LINK_MODE="${UV_LINK_MODE:-copy}"
+mkdir -p "${HOME}" "${XDG_CACHE_HOME}" "${HF_HOME}" "${UV_CACHE_DIR}"
+
+if [ -n "${PRIME_RL_PROJECT_DIR:-}" ]; then
+  PROJECT_DIR="${PRIME_RL_PROJECT_DIR}"
+elif [ -f "${WORKSPACE_DIR}/pyproject.toml" ]; then
+  PROJECT_DIR="${WORKSPACE_DIR}"
+else
+  PROJECT_DIR="${IMAGE_APP_DIR}"
+fi
+
+if [ -z "${UV_PROJECT_ENVIRONMENT:-}" ]; then
+  if [ -d "${IMAGE_APP_DIR}/.venv" ]; then
+    export UV_PROJECT_ENVIRONMENT="${IMAGE_APP_DIR}/.venv"
+  else
+    export UV_PROJECT_ENVIRONMENT="${PROJECT_DIR}/.venv"
+  fi
+fi
+
+cd "${PROJECT_DIR}"
+export PYTHONPATH="${PROJECT_DIR}/src:${PROJECT_DIR}/packages/prime-rl-configs/src:${PYTHONPATH:-}"
+
+echo "=== Launch manifest ==="
+echo "workspace_dir=${WORKSPACE_DIR}"
+echo "project_dir=${PROJECT_DIR}"
+echo "image_app_dir=${IMAGE_APP_DIR}"
+echo "run_output_dir=${RUN_OUTPUT_DIR}"
+echo "run_config=${RUN_CONFIG}"
+echo "uv_project_environment=${UV_PROJECT_ENVIRONMENT}"
+echo "pythonpath=${PYTHONPATH}"
+echo "base_image=${BASE_IMAGE:-unknown}"
+echo "prime_rl_disable_quack_rmsnorm=${PRIME_RL_DISABLE_QUACK_RMSNORM:-1}"
+echo "expect_memento_enabled=${EXPECT_MEMENTO_ENABLED:-1}"
+echo "require_memento_compaction=${REQUIRE_MEMENTO_COMPACTION:-0}"
+echo "expected_final_step=${EXPECTED_FINAL_STEP:-1}"
+if command -v sha256sum >/dev/null 2>&1 && [ -f uv.lock ]; then
+  echo "uv_lock_sha256=$(sha256sum uv.lock | awk '{print $1}')"
+fi
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "git_sha=$(git rev-parse HEAD)"
+  echo "git_status_short_begin"
+  git status --short || true
+  echo "git_status_short_end"
+fi
+
+for path in \
+  pyproject.toml \
+  uv.lock \
+  packages/prime-rl-configs/src/prime_rl/configs/inference.py \
+  packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py \
+  src/prime_rl/inference/patches.py \
+  src/prime_rl/inference/block_masking/__init__.py \
+  src/prime_rl/inference/block_masking/config.py \
+  src/prime_rl/inference/vllm/padded_input_scrub.py \
+  src/prime_rl/orchestrator/envs.py \
+  overlays/vllm/v1/core/sched/output.py \
+  overlays/vllm/v1/core/sched/scheduler.py \
+  scripts/memento_runtime_preflight.py \
+  scripts/install_block_masking_overlay.sh \
+  scripts/prepare_memento_sft.py \
+  "${RUN_CONFIG}"
+do
+  if [ ! -e "$path" ]; then
+    echo "ERROR: Missing required launch artifact: $path"
+    exit 1
+  fi
+done
+
+if [ "${SYNC_PROJECT_DEPS:-0}" = "1" ]; then
+  echo "=== Syncing project dependencies from bundled lockfile ==="
+  UV_SYNC_ARGS="${UV_SYNC_ARGS:---locked --inexact}"
+  uv sync ${UV_SYNC_ARGS}
+elif [ "${INSTALL_VLLM_WHEEL:-1}" = "1" ]; then
+  echo "=== Installing target vLLM wheel ==="
+  uv pip install \
+    --python "${UV_PROJECT_ENVIRONMENT}/bin/python" \
+    --reinstall \
+    --no-deps \
+    "${VLLM_WHEEL_URL}"
+fi
+UV_RUN_EXTRA="--no-sync"
+
+if [ "${INSTALL_MEMENTO_BOUNDARY_ENV:-0}" = "1" ]; then
+  echo "=== Enabling Memento boundary fixture env ==="
+  export PYTHONPATH="${PROJECT_DIR}/tests/fixtures/memento_boundary_env/src:${PYTHONPATH}"
+  uv run ${UV_RUN_EXTRA} python -c "import memento_boundary_env; print('memento_boundary_env import ok')"
+fi
+
+export HF_HUB_ENABLE_HF_TRANSFER="${HF_HUB_ENABLE_HF_TRANSFER:-1}"
+export PYTORCH_CUDA_ALLOC_CONF="${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}"
+export TOKENIZERS_PARALLELISM="${TOKENIZERS_PARALLELISM:-false}"
+export PRIME_DISABLE_VERSION_CHECK="${PRIME_DISABLE_VERSION_CHECK:-1}"
+export VLLM_USE_FLASHINFER_SAMPLER="${VLLM_USE_FLASHINFER_SAMPLER:-0}"
+export VLLM_USE_DEEP_GEMM="${VLLM_USE_DEEP_GEMM:-0}"
+export VLLM_MOE_USE_DEEP_GEMM="${VLLM_MOE_USE_DEEP_GEMM:-0}"
+export PRIME_RL_DISABLE_QUACK_RMSNORM="${PRIME_RL_DISABLE_QUACK_RMSNORM:-1}"
+: "${VLLM_WHEEL_URL:=https://github.com/vllm-project/vllm/releases/download/v0.21.0/vllm-0.21.0+cu129-cp38-abi3-manylinux_2_34_x86_64.whl}"
+
+echo "=== Runtime preflight ==="
+uv run ${UV_RUN_EXTRA} python scripts/memento_runtime_preflight.py
+
+echo "=== Installing block masking overlay ==="
+bash scripts/install_block_masking_overlay.sh "${UV_PROJECT_ENVIRONMENT}"
+
+echo "=== Preparing model (adding block masking tokens) ==="
+uv run ${UV_RUN_EXTRA} python scripts/prepare_memento_sft.py \
+  --output-dir /tmp/memento-test-prep \
+  --model-only
+
+echo "=== Running full Prime RL Memento async smoke ==="
+PATCHED_RUN_CONFIG="${WORKSPACE_DIR}/memento_rl_effective_config.toml"
+sed "0,/^output_dir = /s|^output_dir = .*|output_dir = \"${RUN_OUTPUT_DIR}\"|" \
+  "${RUN_CONFIG}" > "${PATCHED_RUN_CONFIG}"
+echo "effective_run_config=${PATCHED_RUN_CONFIG}"
+grep -n '^output_dir = ' "${PATCHED_RUN_CONFIG}"
+rm -rf "${RUN_OUTPUT_DIR}"
+mkdir -p "${RUN_OUTPUT_DIR}/logs"
+BLOCK_MASKING_EVENT_LOG="${RUN_OUTPUT_DIR}/logs/block_masking_events.log"
+rm -f "${BLOCK_MASKING_EVENT_LOG}"
+touch "${BLOCK_MASKING_EVENT_LOG}"
+export PRIME_RL_BLOCK_MASKING_EVENT_LOG="${BLOCK_MASKING_EVENT_LOG}"
+uv run ${UV_RUN_EXTRA} rl @ "${PATCHED_RUN_CONFIG}"
+
+echo "=== Verifying prod-loop Memento signals ==="
+INFERENCE_LOG="${RUN_OUTPUT_DIR}/logs/inference.log"
+ORCH_LOG="${RUN_OUTPUT_DIR}/logs/orchestrator.log"
+TRAINER_LOG="${RUN_OUTPUT_DIR}/logs/trainer.log"
+EVENT_LOG="${RUN_OUTPUT_DIR}/logs/block_masking_events.log"
+
+for file in "${INFERENCE_LOG}" "${ORCH_LOG}" "${TRAINER_LOG}"; do
+  if [ ! -s "${file}" ]; then
+    echo "ERROR: Missing or empty log file: ${file}"
+    exit 1
+  fi
+done
+
+grep -q "Asynchronous scheduling is enabled" "${INFERENCE_LOG}"
+if [ "${EXPECT_MEMENTO_ENABLED:-1}" = "1" ]; then
+  grep -q "Block masking async barrier engine path active" "${INFERENCE_LOG}"
+fi
+grep -q "Starting orchestrator loop" "${ORCH_LOG}"
+grep -q "Step ${EXPECTED_FINAL_STEP:-1}" "${ORCH_LOG}"
+grep -q "Auto-selected implementation: custom" "${TRAINER_LOG}"
+grep -q "Starting training loop" "${TRAINER_LOG}"
+grep -q "Step ${EXPECTED_FINAL_STEP:-1}" "${TRAINER_LOG}"
+grep -q "RL trainer finished" "${TRAINER_LOG}"
+
+if grep -Eiq "(Loss:|Grad\\. Norm:|Entropy:|Mismatch KL:)[^[:cntrl:]]*(nan|inf)" "${TRAINER_LOG}"; then
+  echo "ERROR: non-finite trainer metric detected"
+  grep -Ein "(Loss:|Grad\\. Norm:|Entropy:|Mismatch KL:)[^[:cntrl:]]*(nan|inf)" "${TRAINER_LOG}" || true
+  exit 1
+fi
+
+compaction_count="$(grep -Ec "Block masking (prompt|generated|deferred) compaction" "${INFERENCE_LOG}" || true)"
+span_success_count="$(grep -c "SpanRemovalResult(success=True" "${INFERENCE_LOG}" || true)"
+kv_copy_count="$({ grep -h "Block masking KV copy ops executed" "${INFERENCE_LOG}" "${EVENT_LOG}" 2>/dev/null || true; } | wc -l | tr -d ' ')"
+block_truncation_count="$({ grep -h "Block masking block table truncations applied" "${INFERENCE_LOG}" "${EVENT_LOG}" 2>/dev/null || true; } | wc -l | tr -d ' ')"
+echo "memento_compaction_count=${compaction_count}"
+echo "memento_span_success_count=${span_success_count}"
+echo "memento_kv_copy_count=${kv_copy_count}"
+echo "memento_block_truncation_count=${block_truncation_count}"
+max_observed_off_policy_level="$({ grep -oE "Max\\. Off-Policy Level: [0-9]+" "${ORCH_LOG}" || true; } | awk '{print $4}' | sort -n | tail -1)"
+max_observed_off_policy_level="${max_observed_off_policy_level:-0}"
+echo "max_observed_off_policy_level=${max_observed_off_policy_level}"
+if [ -s "${EVENT_LOG}" ]; then
+  echo "=== Block masking GPU event log tail ==="
+  tail -40 "${EVENT_LOG}"
+fi
+
+if grep -q "SpanRemovalResult(success=False" "${INFERENCE_LOG}"; then
+  echo "ERROR: failed SpanRemovalResult detected"
+  grep -n "SpanRemovalResult(success=False" "${INFERENCE_LOG}" || true
+  exit 1
+fi
+if grep "error_message=" "${INFERENCE_LOG}" | grep -v "error_message=None" >/dev/null; then
+  echo "ERROR: non-empty compaction error_message detected"
+  grep -n "error_message=" "${INFERENCE_LOG}" | grep -v "error_message=None" || true
+  exit 1
+fi
+
+if [ "${REQUIRE_MEMENTO_COMPACTION:-0}" = "1" ]; then
+  if [ "${compaction_count}" -lt "${MIN_MEMENTO_COMPACTIONS:-1}" ]; then
+    echo "ERROR: expected at least ${MIN_MEMENTO_COMPACTIONS:-1} compaction log(s)"
+    exit 1
+  fi
+  if [ "${span_success_count}" -lt "${MIN_MEMENTO_COMPACTIONS:-1}" ]; then
+    echo "ERROR: expected at least ${MIN_MEMENTO_COMPACTIONS:-1} successful SpanRemovalResult log(s)"
+    exit 1
+  fi
+  if [ "${kv_copy_count}" -lt "${MIN_MEMENTO_KV_COPIES:-1}" ]; then
+    echo "ERROR: expected at least ${MIN_MEMENTO_KV_COPIES:-1} KV-copy execution log(s)"
+    exit 1
+  fi
+  if [ "${block_truncation_count}" -lt "${MIN_MEMENTO_BLOCK_TRUNCATIONS:-1}" ]; then
+    echo "ERROR: expected at least ${MIN_MEMENTO_BLOCK_TRUNCATIONS:-1} block-table truncation log(s)"
+    exit 1
+  fi
+fi
+if [ "${max_observed_off_policy_level}" -lt "${MIN_MAX_OFF_POLICY_LEVEL:-0}" ]; then
+  echo "ERROR: expected max observed off-policy level to be at least ${MIN_MAX_OFF_POLICY_LEVEL:-0}"
+  exit 1
+fi
+
+stable_count=0
+if [ -d "${RUN_OUTPUT_DIR}" ]; then
+  stable_count="$(find "${RUN_OUTPUT_DIR}" -path '*/broadcasts/step_*/STABLE' -type f | wc -l | tr -d ' ')"
+fi
+echo "broadcast_stable_count=${stable_count}"
+find "${RUN_OUTPUT_DIR}" -path '*/broadcasts/step_*/STABLE' -type f | sort | tail -20 || true
+if [ "${stable_count}" -lt "${MIN_BROADCAST_STABLE:-1}" ]; then
+  echo "ERROR: expected at least ${MIN_BROADCAST_STABLE:-1} broadcast STABLE marker(s)"
+  exit 1
+fi
+
+echo "=== Key signal excerpts ==="
+grep -n "Asynchronous scheduling is enabled\|Block masking async barrier" "${INFERENCE_LOG}" | tail -40
+grep -n "Block masking .*compaction\|SpanRemovalResult(success=True\|Block masking KV copy ops executed\|Block masking block table truncations applied" "${INFERENCE_LOG}" | tail -80 || true
+grep -n "Starting orchestrator loop\|Step " "${ORCH_LOG}" | tail -40
+grep -n "Auto-selected implementation\|Starting training loop\|Step \|RL trainer finished" "${TRAINER_LOG}" | tail -40
+
+echo "=== Full Prime RL Memento async smoke complete ==="
+""".strip()
+
+training_runtime = definitions.Runtime(
+    start_commands=[f"/bin/bash -lc {shlex.quote(START_COMMAND)}"],
+    environment_variables={
+        "HF_TOKEN": definitions.SecretReference(
+            name=os.environ.get("HF_SECRET_NAME", "hf_access_token")
+        ),
+        "BASETEN_WORKSPACE_DIR": os.environ.get(
+            "BASETEN_WORKSPACE_DIR", "/b10/workspace"
+        ),
+        "PRIME_RL_APP_DIR": os.environ.get("PRIME_RL_APP_DIR", "/app"),
+        "BASE_IMAGE": BASE_IMAGE,
+        "PRIME_DISABLE_VERSION_CHECK": "1",
+        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
+        "TOKENIZERS_PARALLELISM": "false",
+        "UV_LINK_MODE": os.environ.get("UV_LINK_MODE", "copy"),
+        "SYNC_PROJECT_DEPS": os.environ.get("SYNC_PROJECT_DEPS", "0"),
+        "UV_SYNC_ARGS": os.environ.get("UV_SYNC_ARGS", "--locked --inexact"),
+        "INSTALL_VLLM_WHEEL": os.environ.get("INSTALL_VLLM_WHEEL", "1"),
+        "VLLM_WHEEL_URL": os.environ.get(
+            "VLLM_WHEEL_URL",
+            "https://github.com/vllm-project/vllm/releases/download/v0.21.0/vllm-0.21.0+cu129-cp38-abi3-manylinux_2_34_x86_64.whl",
+        ),
+        "VLLM_USE_FLASHINFER_SAMPLER": "0",
+        "VLLM_USE_DEEP_GEMM": "0",
+        "VLLM_MOE_USE_DEEP_GEMM": "0",
+        "PRIME_RL_DISABLE_QUACK_RMSNORM": os.environ.get(
+            "PRIME_RL_DISABLE_QUACK_RMSNORM", "1"
+        ),
+        "BLOCK_MASKING_ASYNC_MODE": os.environ.get(
+            "BLOCK_MASKING_ASYNC_MODE", "async_barrier"
+        ),
+        "INSTALL_MEMENTO_BOUNDARY_ENV": os.environ.get(
+            "INSTALL_MEMENTO_BOUNDARY_ENV", "0"
+        ),
+        "REQUIRE_MEMENTO_COMPACTION": os.environ.get(
+            "REQUIRE_MEMENTO_COMPACTION", "0"
+        ),
+        "EXPECT_MEMENTO_ENABLED": os.environ.get("EXPECT_MEMENTO_ENABLED", "1"),
+        "EXPECTED_FINAL_STEP": os.environ.get("EXPECTED_FINAL_STEP", "1"),
+        "MIN_BROADCAST_STABLE": os.environ.get("MIN_BROADCAST_STABLE", "1"),
+        "MIN_MEMENTO_COMPACTIONS": os.environ.get("MIN_MEMENTO_COMPACTIONS", "1"),
+        "MIN_MEMENTO_KV_COPIES": os.environ.get("MIN_MEMENTO_KV_COPIES", "1"),
+        "MIN_MEMENTO_BLOCK_TRUNCATIONS": os.environ.get(
+            "MIN_MEMENTO_BLOCK_TRUNCATIONS", "1"
+        ),
+        "MIN_MAX_OFF_POLICY_LEVEL": os.environ.get("MIN_MAX_OFF_POLICY_LEVEL", "0"),
+        "EXPECTED_VLLM_VERSION_PREFIX": os.environ.get(
+            "EXPECTED_VLLM_VERSION_PREFIX", "0.21."
+        ),
+        "MEMENTO_RL_CONFIG": os.environ.get(
+            "MEMENTO_RL_CONFIG", "configs/ci/integration/memento_async_rl.toml"
+        ),
+        "MEMENTO_RL_OUTPUT_DIR": os.environ.get(
+            "MEMENTO_RL_OUTPUT_DIR", "/b10/workspace/outputs/memento-rl-prod-async"
+        ),
+        "HOME": os.environ.get("BASETEN_HOME", "/b10/workspace"),
+        "XDG_CACHE_HOME": os.environ.get(
+            "BASETEN_XDG_CACHE_HOME", "/b10/workspace/.cache"
+        ),
+        "HF_HOME": os.environ.get(
+            "BASETEN_HF_HOME", "/b10/workspace/.cache/huggingface"
+        ),
+        "UV_CACHE_DIR": os.environ.get(
+            "BASETEN_UV_CACHE_DIR", "/b10/workspace/.cache/uv"
+        ),
+    },
+)
+
+training_compute = definitions.Compute(
+    accelerator=truss_config.AcceleratorSpec(
+        accelerator=truss_config.Accelerator.H100,
+        count=2,
+    ),
+    node_count=1,
+)
+
+training_job = definitions.TrainingJob(
+    image=definitions.Image(base_image=BASE_IMAGE),
+    compute=training_compute,
+    runtime=training_runtime,
+)
+
+training_project = definitions.TrainingProject(
+    name=PROJECT_NAME,
+    job=training_job,
+)

--- a/overlays/vllm/config/__init__.py
+++ b/overlays/vllm/config/__init__.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.config.attention import AttentionConfig
+from vllm.config.cache import CacheConfig
+from .block_masking import BlockMaskingConfig
+from vllm.config.compilation import (
+    CompilationConfig,
+    CompilationMode,
+    CUDAGraphMode,
+    PassConfig,
+)
+from vllm.config.device import DeviceConfig
+from vllm.config.ec_transfer import ECTransferConfig
+from vllm.config.kernel import KernelConfig
+from vllm.config.kv_events import KVEventsConfig
+from vllm.config.kv_transfer import KVTransferConfig
+from vllm.config.load import LoadConfig
+from vllm.config.lora import LoRAConfig
+from vllm.config.mamba import MambaConfig
+from vllm.config.model import (
+    ModelConfig,
+    iter_architecture_defaults,
+    str_dtype_to_torch_dtype,
+    try_match_architecture_defaults,
+)
+from vllm.config.multimodal import MultiModalConfig
+from vllm.config.observability import ObservabilityConfig
+from vllm.config.offload import (
+    OffloadBackend,
+    OffloadConfig,
+    PrefetchOffloadConfig,
+    UVAOffloadConfig,
+)
+from vllm.config.parallel import EPLBConfig, ParallelConfig
+from vllm.config.pooler import PoolerConfig
+from vllm.config.profiler import ProfilerConfig
+from vllm.config.reasoning import ReasoningConfig
+from vllm.config.scheduler import SchedulerConfig
+from vllm.config.speculative import SpeculativeConfig
+from vllm.config.speech_to_text import SpeechToTextConfig, SpeechToTextParams
+from vllm.config.structured_outputs import StructuredOutputsConfig
+from vllm.config.utils import (
+    ConfigType,
+    SupportsMetricsInfo,
+    config,
+    get_attr_docs,
+    is_init_field,
+    replace,
+    update_config,
+)
+from vllm.config.vllm import (
+    VllmConfig,
+    get_cached_compilation_config,
+    get_current_vllm_config,
+    get_current_vllm_config_or_none,
+    get_layers_from_vllm_config,
+    set_current_vllm_config,
+)
+from vllm.config.weight_transfer import WeightTransferConfig
+
+# __all__ should only contain classes and functions.
+# Types and globals should be imported from their respective modules.
+__all__ = [
+    # From vllm.config.attention
+    "AttentionConfig",
+    # From .block_masking
+    "BlockMaskingConfig",
+    # From vllm.config.cache
+    "CacheConfig",
+    # From vllm.config.compilation
+    "CompilationConfig",
+    "CompilationMode",
+    "CUDAGraphMode",
+    "PassConfig",
+    # From vllm.config.device
+    "DeviceConfig",
+    # From vllm.config.ec_transfer
+    "ECTransferConfig",
+    # From vllm.config.kernel
+    "KernelConfig",
+    # From vllm.config.kv_events
+    "KVEventsConfig",
+    # From vllm.config.kv_transfer
+    "KVTransferConfig",
+    # From vllm.config.load
+    "LoadConfig",
+    # From vllm.config.lora
+    "LoRAConfig",
+    # From vllm.config.mamba
+    "MambaConfig",
+    # From vllm.config.model
+    "ModelConfig",
+    "iter_architecture_defaults",
+    "str_dtype_to_torch_dtype",
+    "try_match_architecture_defaults",
+    # From vllm.config.multimodal
+    "MultiModalConfig",
+    # From vllm.config.observability
+    "ObservabilityConfig",
+    # From vllm.config.offload
+    "OffloadBackend",
+    "OffloadConfig",
+    "PrefetchOffloadConfig",
+    "UVAOffloadConfig",
+    # From vllm.config.parallel
+    "EPLBConfig",
+    "ParallelConfig",
+    # From vllm.config.pooler
+    "PoolerConfig",
+    # From vllm.config.reasoning
+    "ReasoningConfig",
+    # From vllm.config.scheduler
+    "SchedulerConfig",
+    # From vllm.config.speculative
+    "SpeculativeConfig",
+    # From vllm.config.speech_to_text
+    "SpeechToTextConfig",
+    "SpeechToTextParams",
+    # From vllm.config.structured_outputs
+    "StructuredOutputsConfig",
+    # From vllm.config.profiler
+    "ProfilerConfig",
+    # From vllm.config.utils
+    "ConfigType",
+    "SupportsMetricsInfo",
+    "config",
+    "get_attr_docs",
+    "is_init_field",
+    "replace",
+    "update_config",
+    # From vllm.config.vllm
+    "VllmConfig",
+    "get_cached_compilation_config",
+    "get_current_vllm_config",
+    "get_current_vllm_config_or_none",
+    "set_current_vllm_config",
+    "get_layers_from_vllm_config",
+    "WeightTransferConfig",
+]

--- a/overlays/vllm/config/block_masking.py
+++ b/overlays/vllm/config/block_masking.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Re-export BlockMaskingConfig from vendored prime_rl package.
+"""
+
+from prime_rl.inference.block_masking.config import BlockMaskingConfig
+
+__all__ = ["BlockMaskingConfig"]

--- a/overlays/vllm/distributed/kv_events.py
+++ b/overlays/vllm/distributed/kv_events.py
@@ -1,0 +1,545 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import queue
+import threading
+import time
+from abc import ABC, abstractmethod
+from collections import Counter, deque
+from collections.abc import Callable
+from dataclasses import asdict
+from itertools import count
+from queue import Queue
+from typing import Any
+
+import msgspec
+import zmq
+
+from vllm.config.kv_events import KVEventsConfig
+from vllm.logger import init_logger
+from vllm.v1.core.kv_cache_utils import ExternalBlockHash
+
+logger = init_logger(__name__)
+
+
+class EventBatch(
+    msgspec.Struct,
+    array_like=True,  # type: ignore[call-arg]
+    omit_defaults=True,  # type: ignore[call-arg]
+    gc=False,  # type: ignore[call-arg]
+):
+    ts: float
+    events: list[Any]
+    data_parallel_rank: int | None = None
+
+
+class KVCacheEvent(
+    msgspec.Struct,
+    array_like=True,  # type: ignore[call-arg]
+    omit_defaults=True,  # type: ignore[call-arg]
+    gc=False,  # type: ignore[call-arg]
+    tag=True,
+):
+    """Base class for all KV cache-related events"""
+
+
+MEDIUM_GPU = "GPU"
+
+
+class BlockStored(KVCacheEvent):
+    block_hashes: list[ExternalBlockHash]
+    parent_block_hash: ExternalBlockHash | None
+    token_ids: list[int]
+    block_size: int
+
+    lora_id: int | None
+    """Deprecated: use `lora_name` for KV block key hash.
+    Retained for backward compatibility.
+    """
+
+    medium: str | None
+    lora_name: str | None
+
+    extra_keys: list[tuple[Any, ...] | None] | None = None
+    """Extra keys used in block hash computation, one entry per block in
+    block_hashes. Each entry contains MM identifiers, LoRA name, cache_salt,
+    prompt embedding hashes, etc. for that specific block. Exposed for external
+    KV cache consumers to reconstruct block hashes.
+    """
+
+    group_idx: int | None = None
+
+    def __hash__(self) -> int:
+        return hash(
+            (
+                tuple(self.block_hashes),
+                self.parent_block_hash,
+                tuple(self.token_ids),
+                self.block_size,
+                self.lora_id,
+                self.medium,
+                tuple(self.extra_keys) if self.extra_keys else None,
+                self.group_idx,
+            )
+        )
+
+
+class BlockRemoved(KVCacheEvent):
+    block_hashes: list[ExternalBlockHash]
+    medium: str | None
+    group_idx: int | None = None
+
+    def __hash__(self) -> int:
+        return hash(
+            (
+                tuple(self.block_hashes),
+                self.medium,
+                self.group_idx,
+            )
+        )
+
+
+class AllBlocksCleared(KVCacheEvent):
+    pass
+
+
+class KVSlotCopy(KVCacheEvent):
+    """Event representing a KV cache slot copy for compaction."""
+    request_id: str
+    src_block_id: int
+    src_offset: int
+    dst_block_id: int
+    dst_offset: int
+
+    def __hash__(self) -> int:
+        return hash((
+            self.request_id,
+            self.src_block_id,
+            self.src_offset,
+            self.dst_block_id,
+            self.dst_offset,
+        ))
+
+
+class KVEventBatch(EventBatch):
+    events: list[BlockStored | BlockRemoved | AllBlocksCleared | KVSlotCopy]
+
+
+class KVEventAggregator:
+    """
+    Aggregates KV events across multiple workers.
+    Tracks how many times each event appears and returns only those
+    that were emitted by all workers.
+    """
+
+    __slots__ = ("_event_counter", "_num_workers")
+
+    def __init__(self, num_workers: int) -> None:
+        if num_workers <= 0:
+            raise ValueError("num_workers must be greater than zero.")
+        self._event_counter: Counter[KVCacheEvent] = Counter()
+        self._num_workers: int = num_workers
+
+    def add_events(self, events: list[KVCacheEvent]) -> None:
+        """
+        Add events from a worker batch.
+
+        :param events: List of KVCacheEvent objects.
+        """
+        if not isinstance(events, list):
+            raise TypeError("events must be a list of KVCacheEvent.")
+        self._event_counter.update(events)
+
+    def get_common_events(self) -> list[KVCacheEvent]:
+        """
+        Return events that appeared in all workers.
+
+        :return: List of events present in all workers.
+        """
+        return [
+            event
+            for event, count in self._event_counter.items()
+            if count == self._num_workers
+        ]
+
+    def get_all_events(self) -> list[KVCacheEvent]:
+        """
+        Return all events for all workers.
+
+        :return: List of events for all workers.
+        """
+        return list(self._event_counter.elements())
+
+    def clear_events(self) -> None:
+        """
+        Clear all tracked events.
+        """
+        self._event_counter.clear()
+
+    def increment_workers(self, count: int = 1) -> None:
+        """
+        Increment the number of workers contributing events.
+
+        :param count: Number to increment the workers by.
+        """
+        if count <= 0:
+            raise ValueError("count must be positive.")
+        self._num_workers += count
+
+    def reset_workers(self) -> None:
+        """
+        Reset the number of workers to 1.
+        """
+        self._num_workers = 1
+
+    def get_number_of_workers(self) -> int:
+        """
+        Return the number of workers.
+
+        :return: int number of workers.
+        """
+        return self._num_workers
+
+    def __repr__(self) -> str:
+        return (
+            f"<KVEventAggregator workers={self._num_workers}, "
+            f"events={len(self._event_counter)}>"
+        )
+
+
+class KVConnectorKVEvents(ABC):
+    """
+    Abstract base class for KV events.
+    Acts as a container for KV events from the connector.
+    """
+
+    @abstractmethod
+    def add_events(self, events: list[KVCacheEvent]) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def aggregate(self) -> "KVConnectorKVEvents":
+        raise NotImplementedError
+
+    @abstractmethod
+    def increment_workers(self, count: int = 1) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_all_events(self) -> list[KVCacheEvent]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_number_of_workers(self) -> int:
+        raise NotImplementedError
+
+    @abstractmethod
+    def clear_events(self) -> None:
+        raise NotImplementedError
+
+    def merge(self, other: "KVConnectorKVEvents") -> "KVConnectorKVEvents":
+        self.add_events(other.get_all_events())
+        return self
+
+
+class EventPublisher(ABC):
+    """Lightweight publisher for EventBatch batches with data parallelism
+    support.
+
+    In data parallel setups, each DP rank runs its own EventPublisher instance
+    to avoid duplicate events and ensure proper event attribution:
+
+    - Each DP rank creates a separate publisher
+    - Publishers automatically annotate events with their data_parallel_rank
+    - This allows consumers to distinguish events from different DP ranks
+
+    The publisher is responsible for adding DP metadata since the scheduler
+    operates independently of DP topology and shouldn't need DP awareness.
+    """
+
+    def __init__(self, data_parallel_rank: int = 0) -> None:
+        self._data_parallel_rank = data_parallel_rank
+
+    @abstractmethod
+    def publish(self, events: EventBatch) -> None:
+        """Emit events in order.
+
+        Implementations should guarantee at-least-once delivery and
+        monotonic ordering (e.g., via sequence numbers).
+        """
+
+    @abstractmethod
+    def shutdown(self) -> None:
+        """Shutdown the publisher."""
+
+
+class NullEventPublisher(EventPublisher):
+    """No-op implementation (default when disabled)."""
+
+    def publish(self, events) -> None:
+        return
+
+    def shutdown(self) -> None:
+        return
+
+
+class ZmqEventPublisher(EventPublisher):
+    """Reliable PUB/ROUTER publisher with an in-memory replay buffer.
+
+    Spawns a separate thread to handle publishing from a queue.
+
+    Parameters
+    ----------
+    endpoint:
+        PUB address. Use `tcp://*:5557` to bind or `tcp://host:5557` to
+        connect.
+    replay_endpoint:
+        Optional ROUTER address for replay requests. When given, subscribers can
+        request missed batches by sending the starting sequence number as an
+        8-byte big-endian integer.
+    buffer_steps:
+        Number of past batches to keep for replay.
+    hwm:
+        ZeroMQ high-water-mark for PUB socket.
+    max_queue_size:
+        Maximum number of events to buffer in memory.
+    topic:
+        Topic to publish events to.
+    """
+
+    SHUTDOWN_TIMEOUT: float = 1.0
+    END_SEQ = (-1).to_bytes(8, "big", signed=True)
+
+    def __init__(
+        self,
+        data_parallel_rank: int,
+        endpoint: str = "tcp://*:5557",
+        replay_endpoint: str | None = None,
+        buffer_steps: int = 10_000,
+        hwm: int = 100_000,
+        max_queue_size: int = 100_000,
+        topic: str = "",
+    ) -> None:
+        # Storage
+        super().__init__(data_parallel_rank)
+        self._event_queue = Queue[EventBatch | None](maxsize=max_queue_size)
+        self._buffer = deque[tuple[int, bytes]](maxlen=buffer_steps)
+
+        # ZMQ sockets
+        self._ctx = zmq.Context.instance()
+        self._pub: zmq.Socket | None = None
+        self._replay: zmq.Socket | None = None
+        self._dp_rank = data_parallel_rank
+
+        self._endpoint = self.offset_endpoint_port(endpoint, self._dp_rank)
+        self._replay_endpoint = self.offset_endpoint_port(
+            replay_endpoint, self._dp_rank
+        )
+        self._hwm = hwm
+        self._socket_setup()
+
+        # Payload
+        self._seq_gen = count()
+        self._topic_bytes = topic.encode("utf-8")
+
+        # Thread
+        self._running = True
+        logger.info("Starting ZMQ publisher thread")
+
+        self._thread = threading.Thread(
+            target=self._publisher_thread, daemon=True, name="zmq-publisher"
+        )
+        self._thread.start()
+
+    def publish(self, events: EventBatch) -> None:
+        if not self._running:
+            raise RuntimeError("Publisher is closed")
+        if events.data_parallel_rank is None:
+            events.data_parallel_rank = self._data_parallel_rank
+        self._event_queue.put(events)
+
+    def shutdown(self) -> None:
+        """Stop the publisher thread and clean up resources."""
+        self._running = False
+        self._event_queue.put_nowait(None)
+
+        start = time.time()
+        pending_items = True
+        while pending_items and (time.time() - start < self.SHUTDOWN_TIMEOUT):
+            pending_items = not self._event_queue.empty()
+            if pending_items:
+                time.sleep(0.1)
+
+        if pending_items:
+            logger.warning(
+                "Warning: Queue still has %s items after %s seconds timeout",
+                self._event_queue.qsize(),
+                self.SHUTDOWN_TIMEOUT,
+            )
+
+        if self._thread.is_alive():
+            self._thread.join(timeout=self.SHUTDOWN_TIMEOUT)
+
+        # Clean up ZMQ resources
+        try:
+            if self._pub is not None:
+                self._pub.close(linger=0)
+            if self._replay is not None:
+                self._replay.close(linger=0)
+        finally:
+            pass  # Do not terminate context; other sockets may use it
+
+    def _socket_setup(self) -> None:
+        """Initialize sockets
+        https://pyzmq.readthedocs.io/en/v19.0.0/morethanbindings.html#thread-safety
+        """
+        if self._pub is None:
+            self._pub = self._ctx.socket(zmq.PUB)
+            self._pub.set_hwm(self._hwm)
+            # Heuristic: bind if wildcard / * present, else connect.
+            # bind stable, connect volatile convention
+            if self._endpoint is not None and (
+                "*" in self._endpoint
+                or "::" in self._endpoint
+                or self._endpoint.startswith("ipc://")
+                or self._endpoint.startswith("inproc://")
+            ):
+                self._pub.bind(self._endpoint)
+            elif self._endpoint is not None:
+                self._pub.connect(self._endpoint)
+
+        # Set up replay socket: use ROUTER
+        # 1) handles multiple REQ clients (identities)
+        # 2) lets us send back one request → many replies (streamed events)
+        # 3) works in our non‑blocking poll loop alongside PUB
+        if self._replay_endpoint is not None:
+            self._replay = self._ctx.socket(zmq.ROUTER)
+            self._replay.bind(self._replay_endpoint)
+
+    def _publisher_thread(self) -> None:
+        """Background thread that processes the event queue."""
+        self._pack = msgspec.msgpack.Encoder()
+
+        assert self._pub is not None  # narrows type for mypy
+
+        while self._running or self._event_queue.qsize() > 0:
+            # --- replay (non-critical) ---------------------------------
+            if self._replay is not None and self._replay.poll(0):
+                try:
+                    self._service_replay()
+                except Exception as e:
+                    logger.exception("Error in replay: %s", e)
+
+            # --- main queue (critical) ---------------------------------
+            try:
+                event = self._event_queue.get(timeout=0.1)
+                if event is None:
+                    break  # Sentinel received, exit thread
+            except queue.Empty:
+                continue
+
+            try:
+                seq = next(self._seq_gen)
+
+                payload = self._pack.encode(event)
+                seq_bytes = seq.to_bytes(8, "big")
+                self._pub.send_multipart((self._topic_bytes, seq_bytes, payload))
+
+                self._buffer.append((seq, payload))
+                self._event_queue.task_done()
+
+            except Exception as e:
+                # Publishing failed;  back-off a bit to avoid a tight error loop
+                logger.exception("Error in publisher thread: %s", e)
+                time.sleep(0.1)
+
+    def _service_replay(self) -> None:
+        """If a replay request is waiting, send buffered batches."""
+        assert self._replay is not None  # narrows type for mypy
+
+        frame = self._replay.recv_multipart()
+        if len(frame) != 3:
+            logger.warning("Invalid replay request: %s", frame)
+            return
+        client_id, _, start_seq_bytes = frame
+        start_seq = int.from_bytes(start_seq_bytes, "big")
+
+        for seq, buf in self._buffer:
+            if seq >= start_seq:
+                # [identity, empty_delim, seq_bytes, payload]
+                # (identity, empty_delim) are stripped off by the router
+                # receiving payload is (seq_bytes, payload)
+                self._replay.send_multipart(
+                    (client_id, b"", seq.to_bytes(8, "big"), buf)
+                )
+        # Send end of sequence marker
+        # receiving payload is (-1, b""")
+        self._replay.send_multipart((client_id, b"", self.END_SEQ, b""))
+
+    @staticmethod
+    def offset_endpoint_port(
+        endpoint: str | None, data_parallel_rank: int
+    ) -> str | None:
+        """Helper function to offset the port in an endpoint by
+            the data parallel rank.
+
+        Args:
+            endpoint: The endpoint string
+                (e.g., "tcp://*:5557" or "inproc://cache")
+            data_parallel_rank: The data parallel rank to offset by
+
+        Returns:
+            The endpoint with the port offset by data_parallel_rank
+                or suffix appended
+        """
+        # Do nothing if input is None or data_parallel_rank is 0
+        if not endpoint or data_parallel_rank == 0:
+            return endpoint
+
+        if "inproc" in endpoint:
+            return f"{endpoint}_dp{data_parallel_rank}"
+        if "tcp" in endpoint:
+            if endpoint and ":" in endpoint:
+                # Get everything after the last colon (the port)
+                last_colon_idx = endpoint.rfind(":")
+                base_addr = endpoint[:last_colon_idx]
+                base_port = int(endpoint[last_colon_idx + 1 :])
+                new_port = base_port + data_parallel_rank
+                return f"{base_addr}:{new_port}"
+            return endpoint
+        raise ValueError("Invalid endpoint: must contain 'inproc' or 'tcp'")
+
+
+class EventPublisherFactory:
+    _registry: dict[str, Callable[..., EventPublisher]] = {
+        "null": NullEventPublisher,
+        "zmq": ZmqEventPublisher,
+    }
+
+    @classmethod
+    def register_publisher(cls, name: str, ctor: Callable[..., EventPublisher]) -> None:
+        if name in cls._registry:
+            raise KeyError(f"publisher '{name}' already registered")
+        cls._registry[name] = ctor
+
+    @classmethod
+    def create(
+        cls, config: KVEventsConfig | None, data_parallel_rank: int = 0
+    ) -> EventPublisher:
+        """Create publisher from a config mapping."""
+        if (
+            config is None
+            or not config.enable_kv_cache_events
+            or config.publisher == "null"
+        ):
+            return NullEventPublisher()
+
+        config_dict = asdict(config)
+
+        kind = config_dict.pop("publisher")
+        config_dict.pop("enable_kv_cache_events")
+        try:
+            constructor = cls._registry[kind]
+        except KeyError as exc:
+            raise ValueError(f"Unknown event publisher '{kind}'") from exc
+        return constructor(data_parallel_rank=data_parallel_rank, **config_dict)

--- a/overlays/vllm/v1/core/block_masking/__init__.py
+++ b/overlays/vllm/v1/core/block_masking/__init__.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Block Masking module for Memento-style inference.
+
+This overlay re-exports from the vendored prime_rl.inference.block_masking
+package so that vLLM internal imports (e.g. from vllm.v1.core.block_masking)
+resolve correctly.
+"""
+
+from prime_rl.inference.block_masking.config import BlockMaskingConfig
+from prime_rl.inference.block_masking.processor import BlockMaskingProcessor
+from prime_rl.inference.block_masking.tracker import BlockInfo, BlockMaskingState
+
+__all__ = [
+    "BlockMaskingConfig",
+    "BlockMaskingState",
+    "BlockInfo",
+    "BlockMaskingProcessor",
+]

--- a/overlays/vllm/v1/core/kv_cache_coordinator.py
+++ b/overlays/vllm/v1/core/kv_cache_coordinator.py
@@ -1,0 +1,664 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from math import lcm
+
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
+from vllm.v1.core.kv_cache_utils import (
+    BlockHash,
+    BlockHashList,
+    BlockHashListWithBlockSize,
+    KVCacheBlock,
+)
+from vllm.v1.core.single_type_kv_cache_manager import (
+    CrossAttentionManager,
+    SingleTypeKVCacheManager,
+    get_manager_for_kv_cache_spec,
+)
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheSpec,
+)
+from vllm.v1.request import Request
+
+
+class KVCacheCoordinator(ABC):
+    """
+    Coordinate the KV cache of different KV cache groups.
+    """
+
+    def __init__(
+        self,
+        kv_cache_config: KVCacheConfig,
+        max_model_len: int,
+        max_num_batched_tokens: int,
+        use_eagle: bool,
+        enable_caching: bool,
+        enable_kv_cache_events: bool,
+        dcp_world_size: int,
+        pcp_world_size: int,
+        hash_block_size: int,
+        metrics_collector: KVCacheMetricsCollector | None = None,
+    ):
+        self.kv_cache_config = kv_cache_config
+        self.max_model_len = max_model_len
+        self.enable_caching = enable_caching
+
+        self.block_pool = BlockPool(
+            kv_cache_config.num_blocks,
+            enable_caching,
+            hash_block_size,
+            enable_kv_cache_events,
+            metrics_collector,
+        )
+
+        # KV cache group indices that get the EAGLE last-block drop.
+        self.eagle_group_ids: set[int] = {
+            i for i, g in enumerate(kv_cache_config.kv_cache_groups) if g.is_eagle_group
+        }
+        # Conservatively fall back to flag all groups when no group is flagged.
+        if use_eagle and not self.eagle_group_ids:
+            self.eagle_group_ids = set(range(len(kv_cache_config.kv_cache_groups)))
+
+        self.single_type_managers = tuple(
+            get_manager_for_kv_cache_spec(
+                kv_cache_spec=kv_cache_group.kv_cache_spec,
+                max_num_batched_tokens=max_num_batched_tokens,
+                max_model_len=max_model_len,
+                block_pool=self.block_pool,
+                enable_caching=enable_caching,
+                kv_cache_group_id=i,
+                dcp_world_size=dcp_world_size,
+                pcp_world_size=pcp_world_size,
+            )
+            for i, kv_cache_group in enumerate(self.kv_cache_config.kv_cache_groups)
+        )
+
+    def get_num_blocks_to_allocate(
+        self,
+        request_id: str,
+        num_tokens: int,
+        new_computed_blocks: tuple[Sequence[KVCacheBlock], ...],
+        num_encoder_tokens: int,
+        total_computed_tokens: int,
+        num_tokens_main_model: int,
+        apply_admission_cap: bool = False,
+    ) -> int:
+        """
+        Get the number of blocks needed to be allocated for the request.
+
+        Args:
+            request_id: The request ID.
+            num_tokens: The total number of tokens that need a slot (including
+                tokens that are already allocated).
+            new_computed_blocks: The new computed blocks just hitting the
+                prefix caching.
+            num_encoder_tokens: The number of encoder tokens for allocating
+                blocks for cross-attention.
+            total_computed_tokens: Include both local and external tokens.
+            num_tokens_main_model: The number of tokens for the main model (aka target
+                model in spec decode). w/o spec decode, it is num_tokens;
+                with spec decode, it is num_tokens - num_lookahead_tokens.
+            apply_admission_cap: If True, apply the recycling-aware
+                per-request admission cap (SWA / chunked-local). Set only by
+                the full-sequence admission gate; per-step allocation must
+                leave it False so the predictor matches `allocate_new_blocks`.
+
+        Returns:
+            The number of blocks to allocate.
+        """
+        num_blocks_to_allocate = 0
+        for i, manager in enumerate(self.single_type_managers):
+            if isinstance(manager, CrossAttentionManager):
+                # For cross-attention, we issue a single static allocation
+                # of blocks based on the number of encoder input tokens.
+                num_blocks_to_allocate += manager.get_num_blocks_to_allocate(
+                    request_id,
+                    num_encoder_tokens,
+                    [],
+                    0,
+                    num_encoder_tokens,
+                    apply_admission_cap=apply_admission_cap,
+                )
+            else:
+                num_blocks_to_allocate += manager.get_num_blocks_to_allocate(
+                    request_id,
+                    num_tokens,
+                    new_computed_blocks[i],
+                    total_computed_tokens,
+                    num_tokens_main_model,
+                    apply_admission_cap=apply_admission_cap,
+                )
+        return num_blocks_to_allocate
+
+    def allocate_new_computed_blocks(
+        self,
+        request_id: str,
+        new_computed_blocks: tuple[Sequence[KVCacheBlock], ...],
+        num_local_computed_tokens: int,
+        num_external_computed_tokens: int,
+    ) -> None:
+        """
+        Add the new computed blocks to the request. Optionally allocate new
+            blocks for external computed tokens (if any).
+
+        Args:
+            request_id: The request ID.
+            new_computed_blocks: The new computed blocks just hitting the
+                prefix cache.
+            num_local_computed_tokens: The number of local computed tokens.
+            num_external_computed_tokens: The number of external computed tokens.
+        """
+        for i, manager in enumerate(self.single_type_managers):
+            manager.allocate_new_computed_blocks(
+                request_id,
+                new_computed_blocks[i],
+                num_local_computed_tokens,
+                num_external_computed_tokens,
+            )
+
+    def allocate_new_blocks(
+        self,
+        request_id: str,
+        num_tokens: int,
+        num_tokens_main_model: int,
+        num_encoder_tokens: int = 0,
+    ) -> tuple[list[KVCacheBlock], ...]:
+        """
+        Allocate new blocks for the request to give it at least `num_tokens`
+        token slots.
+
+        Args:
+            request_id: The request ID.
+            num_tokens: The total number of tokens that need a slot (including
+                tokens that are already allocated).
+            num_tokens_main_model: The number of tokens for the main model (aka target
+                model in spec decode). w/o spec decode, it is num_tokens;
+                with spec decode, it is num_tokens - num_lookahead_tokens.
+            num_encoder_tokens: The number of encoder tokens for allocating
+                blocks for cross-attention.
+
+        Returns:
+            The new allocated blocks.
+        """
+        return tuple(
+            manager.allocate_new_blocks(
+                request_id,
+                num_encoder_tokens
+                if isinstance(manager, CrossAttentionManager)
+                else num_tokens,
+                num_tokens_main_model,
+            )
+            for manager in self.single_type_managers
+        )
+
+    def cache_blocks(self, request: Request, num_computed_tokens: int) -> None:
+        """
+        Cache the blocks for the request.
+
+        Args:
+            request: The request.
+            num_computed_tokens: The total number of tokens
+                that need to be cached
+                (including tokens that are already cached).
+        """
+        for manager in self.single_type_managers:
+            manager.cache_blocks(request, num_computed_tokens)
+
+    def free(self, request_id: str) -> None:
+        """
+        Free the blocks for the request.
+
+        Args:
+            request_id: The request ID.
+        """
+        for manager in self.single_type_managers:
+            manager.free(request_id)
+
+    def get_num_common_prefix_blocks(self, running_request_id: str) -> list[int]:
+        """
+        Get the number of common prefix blocks for all requests with allocated
+        KV cache for each kv cache group.
+
+        Args:
+            running_request_id: The request ID of any running request, used to
+                identify the common prefix blocks.
+
+        Returns:
+            list[int]: The number of common prefix blocks for each kv cache group.
+        """
+        return [
+            manager.get_num_common_prefix_blocks(running_request_id)
+            for manager in self.single_type_managers
+        ]
+
+    def remove_skipped_blocks(
+        self, request_id: str, total_computed_tokens: int
+    ) -> None:
+        """
+        Remove the blocks that are no longer needed from `blocks` and replace
+        the removed blocks with null_block.
+
+        Args:
+            request_id: The request ID.
+            total_computed_tokens: The total number of computed tokens, including
+                local computed tokens and external computed tokens.
+        """
+        for manager in self.single_type_managers:
+            manager.remove_skipped_blocks(request_id, total_computed_tokens)
+
+    def get_blocks(self, request_id: str) -> tuple[list[KVCacheBlock], ...]:
+        """
+        Get the blocks for the request.
+        """
+        return tuple(
+            manager.req_to_blocks.get(request_id) or []
+            for manager in self.single_type_managers
+        )
+
+    @abstractmethod
+    def find_longest_cache_hit(
+        self,
+        block_hashes: list[BlockHash],
+        max_cache_hit_length: int,
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
+        pass
+
+    def new_step_starts(self) -> None:
+        """Called when a new step is started."""
+        for manager in self.single_type_managers:
+            manager.new_step_starts()
+
+    def compact_kv_cache(
+        self,
+        request_id: str,
+        active_physical_positions: list[int],
+    ) -> tuple[int, list[tuple[int, int, int, int]]]:
+        """Physically compact KV cache by copying active tokens to contiguous slots."""
+        if len(self.single_type_managers) != 1:
+            raise NotImplementedError(
+                "Block masking compaction currently supports single KV-cache "
+                "group models only."
+            )
+
+        total_freed = 0
+        all_copy_ops: list[tuple[int, int, int, int]] = []
+        for manager in self.single_type_managers:
+            freed, copy_ops = manager.compact_kv_cache(
+                request_id, active_physical_positions
+            )
+            total_freed += freed
+            all_copy_ops.extend(copy_ops)
+        return total_freed, all_copy_ops
+
+
+class KVCacheCoordinatorNoPrefixCache(KVCacheCoordinator):
+    """
+    KV cache coordinator to use if prefix caching is disabled or unsupported.
+    In contrast to UnitaryKVCacheCoordinator and HybridKVCacheCoordinator,
+    supports arbitrary numbers of KV cache groups (including 0 groups).
+    Does not implement any features related to prefix caching.
+    """
+
+    def __init__(
+        self,
+        kv_cache_config: KVCacheConfig,
+        max_model_len: int,
+        max_num_batched_tokens: int,
+        use_eagle: bool,
+        enable_kv_cache_events: bool,
+        dcp_world_size: int,
+        pcp_world_size: int,
+        hash_block_size: int,
+        metrics_collector: KVCacheMetricsCollector | None = None,
+    ):
+        super().__init__(
+            kv_cache_config,
+            max_model_len,
+            max_num_batched_tokens,
+            use_eagle,
+            False,
+            enable_kv_cache_events,
+            dcp_world_size=dcp_world_size,
+            pcp_world_size=pcp_world_size,
+            hash_block_size=hash_block_size,
+            metrics_collector=metrics_collector,
+        )
+        self.num_single_type_manager = len(self.single_type_managers)
+
+    def get_num_common_prefix_blocks(self, running_request_id: str) -> list[int]:
+        return [0] * self.num_single_type_manager
+
+    def find_longest_cache_hit(
+        self,
+        block_hashes: list[BlockHash],
+        max_cache_hit_length: int,
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
+        blocks: tuple[list[KVCacheBlock], ...] = tuple(
+            [] for _ in range(self.num_single_type_manager)
+        )
+        return blocks, 0
+
+
+class UnitaryKVCacheCoordinator(KVCacheCoordinator):
+    """
+    KV cache coordinator for models with only one KV cache group. This is the
+    case for models with only one KV cache type, e.g., all attention layers use
+    full attention or all attention layers use sliding window attention.
+    """
+
+    def __init__(
+        self,
+        kv_cache_config: KVCacheConfig,
+        max_model_len: int,
+        max_num_batched_tokens: int,
+        use_eagle: bool,
+        enable_caching: bool,
+        enable_kv_cache_events: bool,
+        dcp_world_size: int,
+        pcp_world_size: int,
+        hash_block_size: int,
+        metrics_collector: KVCacheMetricsCollector | None = None,
+    ):
+        super().__init__(
+            kv_cache_config,
+            max_model_len,
+            max_num_batched_tokens,
+            use_eagle,
+            enable_caching,
+            enable_kv_cache_events,
+            dcp_world_size=dcp_world_size,
+            pcp_world_size=pcp_world_size,
+            hash_block_size=hash_block_size,
+            metrics_collector=metrics_collector,
+        )
+        self.kv_cache_spec = self.kv_cache_config.kv_cache_groups[0].kv_cache_spec
+        self.block_size = self.kv_cache_spec.block_size
+        self.dcp_world_size = dcp_world_size
+        self.pcp_world_size = pcp_world_size
+        if dcp_world_size > 1:
+            self.block_size *= dcp_world_size
+        if pcp_world_size > 1:
+            self.block_size *= pcp_world_size
+        # For models using only Mamba, block_size is set to max_model_len when
+        # prefix caching is disabled, and hash_block_size validation is skipped.
+        assert not enable_caching or (hash_block_size == self.block_size), (
+            "UnitaryKVCacheCoordinator assumes hash_block_size == block_size"
+        )
+        assert len(self.kv_cache_config.kv_cache_groups) == 1, (
+            "UnitaryKVCacheCoordinator assumes only one kv cache group"
+        )
+
+    def find_longest_cache_hit(
+        self,
+        block_hashes: list[BlockHash],
+        max_cache_hit_length: int,
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
+        hit_blocks = self.single_type_managers[0].find_longest_cache_hit(
+            block_hashes=block_hashes,
+            max_length=max_cache_hit_length,
+            kv_cache_group_ids=[0],
+            block_pool=self.block_pool,
+            kv_cache_spec=self.kv_cache_spec,
+            use_eagle=0 in self.eagle_group_ids,
+            alignment_tokens=self.block_size,
+            dcp_world_size=self.dcp_world_size,
+            pcp_world_size=self.pcp_world_size,
+        )
+        return hit_blocks, len(hit_blocks[0]) * self.block_size
+
+
+class HybridKVCacheCoordinator(KVCacheCoordinator):
+    """
+    KV cache coordinator for hybrid models with multiple KV cache types, and
+    thus multiple kv cache groups.
+    """
+
+    def __init__(
+        self,
+        kv_cache_config: KVCacheConfig,
+        max_model_len: int,
+        max_num_batched_tokens: int,
+        use_eagle: bool,
+        enable_caching: bool,
+        enable_kv_cache_events: bool,
+        dcp_world_size: int,
+        pcp_world_size: int,
+        hash_block_size: int,
+        metrics_collector: KVCacheMetricsCollector | None = None,
+    ):
+        super().__init__(
+            kv_cache_config,
+            max_model_len,
+            max_num_batched_tokens,
+            use_eagle,
+            enable_caching,
+            enable_kv_cache_events,
+            dcp_world_size=dcp_world_size,
+            pcp_world_size=pcp_world_size,
+            hash_block_size=hash_block_size,
+            metrics_collector=metrics_collector,
+        )
+        # hash_block_size: the block size used to compute block hashes.
+        # The actual block size usually equals hash_block_size, but in cases where
+        # different KV cache groups have different block sizes, the actual block size
+        # can be a multiple of hash_block_size.
+        self.hash_block_size = hash_block_size
+        assert all(
+            g.kv_cache_spec.block_size % hash_block_size == 0
+            for g in kv_cache_config.kv_cache_groups
+        ), "block_size must be divisible by hash_block_size"
+        assert dcp_world_size == 1, "DCP not support hybrid attn now."
+        assert pcp_world_size == 1, "PCP not support hybrid attn now."
+        self.verify_and_split_kv_cache_groups()
+
+    def verify_and_split_kv_cache_groups(self) -> None:
+        """
+        Groups KV cache groups by their spec type for efficient batch processing
+        during cache hit lookup.
+        """
+        attention_groups: list[
+            tuple[KVCacheSpec, list[int], type[SingleTypeKVCacheManager]]
+        ] = []
+
+        for i, g in enumerate(self.kv_cache_config.kv_cache_groups):
+            manager_cls = self.single_type_managers[i].__class__
+            spec = g.kv_cache_spec
+
+            # Try to find an existing group with the same spec
+            for existing_spec, group_ids, existing_cls in attention_groups:
+                if existing_spec == spec:
+                    assert manager_cls is existing_cls, (
+                        "Expected same manager class for identical KV cache specs."
+                    )
+                    group_ids.append(i)
+                    break
+            else:
+                attention_groups.append((spec, [i], manager_cls))
+
+        assert len(attention_groups) > 1, (
+            "HybridKVCacheCoordinator requires at least two attention groups."
+        )
+
+        # Put full attention first: its efficient left-to-right scan provides
+        # a tighter initial bound, reducing work for subsequent groups.
+        self.attention_groups = sorted(
+            attention_groups,
+            key=lambda x: not isinstance(x[0], FullAttentionSpec),
+        )
+
+        # The LCM of the block sizes of all attention types.
+        # The cache hit length must be a multiple of the LCM of the block sizes
+        # to make sure the cache hit length is a multiple of the block size of
+        # each attention type. Requiring this because we don't support partial
+        # block cache hit yet.
+        block_sizes = [spec.block_size for spec, _, _ in attention_groups]
+        self.lcm_block_size = lcm(*block_sizes)
+
+        # Attention-group indices (into ``self.attention_groups``) that
+        # contain at least one EAGLE/MTP KV cache group.
+        self.eagle_attn_group_indices: set[int] = {
+            i
+            for i, (_, group_ids, _) in enumerate(self.attention_groups)
+            if any(gid in self.eagle_group_ids for gid in group_ids)
+        }
+
+    def find_longest_cache_hit(
+        self,
+        block_hashes: list[BlockHash],
+        max_cache_hit_length: int,
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
+        """
+        Find the longest cache hit using an iterative fixed-point algorithm.
+
+        Each attention type either accepts the current candidate length or
+        reduces it. If any type reduces the length, restart checks over all
+        types. This converges because length monotonically decreases and is
+        bounded below by 0.
+
+        Args:
+            block_hashes: The block hashes of the request.
+            max_cache_hit_length: The maximum length of the cache hit.
+
+        Returns:
+            A tuple containing:
+                - A tuple of the cache hit blocks for each single type manager.
+                - The number of tokens of the longest cache hit.
+        """
+
+        def _get_block_hashes(kv_cache_spec: KVCacheSpec) -> BlockHashList:
+            if kv_cache_spec.block_size == self.hash_block_size:
+                return block_hashes
+            return BlockHashListWithBlockSize(
+                block_hashes, self.hash_block_size, kv_cache_spec.block_size
+            )
+
+        num_groups = len(self.kv_cache_config.kv_cache_groups)
+        hit_length = max_cache_hit_length
+        hit_blocks_by_group: list[list[KVCacheBlock] | None] = [None] * num_groups
+
+        # Simple hybrid (1 full attn + 1 other): one iteration suffices.
+        # Full attn is always first if it exists.
+        is_simple_hybrid = len(self.attention_groups) == 2 and isinstance(
+            self.attention_groups[0][0], FullAttentionSpec
+        )
+
+        # Attention-group indices whose EAGLE drop is verified at the current
+        # ``curr_hit_length``. Each eagle group applies the drop at most once
+        # per candidate length (see issue #32802).
+        eagle_verified: set[int] = set()
+
+        while True:
+            curr_hit_length = hit_length
+
+            for idx, (spec, group_ids, manager_cls) in enumerate(self.attention_groups):
+                cached_blocks = hit_blocks_by_group[group_ids[0]]
+                if isinstance(spec, FullAttentionSpec) and cached_blocks is not None:
+                    # Full attention is downward-closed: we only need to look
+                    # up cached blocks once; on subsequent iterations just trim
+                    # to the (reduced) current hit length.
+                    curr_hit_length = (
+                        curr_hit_length // spec.block_size * spec.block_size
+                    )
+                    continue
+
+                use_eagle = (
+                    idx in self.eagle_attn_group_indices and idx not in eagle_verified
+                )
+
+                _max_length = curr_hit_length
+                if use_eagle:
+                    # Eagle needs to match one more block and then pop the last.
+                    _max_length = min(
+                        curr_hit_length + spec.block_size, max_cache_hit_length
+                    )
+                hit_blocks = manager_cls.find_longest_cache_hit(
+                    block_hashes=_get_block_hashes(spec),
+                    max_length=_max_length,
+                    kv_cache_group_ids=group_ids,
+                    block_pool=self.block_pool,
+                    kv_cache_spec=spec,
+                    use_eagle=use_eagle,
+                    alignment_tokens=self.lcm_block_size,
+                )
+                _new_hit_length = len(hit_blocks[0]) * spec.block_size
+                if use_eagle:
+                    eagle_verified.add(idx)
+                elif _new_hit_length < curr_hit_length:
+                    # length shrunk; invalidate previous eagle verifications
+                    eagle_verified.clear()
+                curr_hit_length = _new_hit_length
+                for group_id, blocks in zip(group_ids, hit_blocks):
+                    hit_blocks_by_group[group_id] = blocks
+
+            if curr_hit_length >= hit_length:
+                break
+            hit_length = curr_hit_length
+            if is_simple_hybrid:
+                break
+
+        # Truncate full attention blocks to final hit_length (if present)
+        spec, group_ids, _ = self.attention_groups[0]
+        if isinstance(spec, FullAttentionSpec):
+            num_blocks = hit_length // spec.block_size
+            for group_id in group_ids:
+                if (blks := hit_blocks_by_group[group_id]) is not None:
+                    del blks[num_blocks:]
+
+        return tuple(
+            blocks if blocks is not None else [] for blocks in hit_blocks_by_group
+        ), hit_length
+
+
+def get_kv_cache_coordinator(
+    kv_cache_config: KVCacheConfig,
+    max_model_len: int,
+    max_num_batched_tokens: int,
+    use_eagle: bool,
+    enable_caching: bool,
+    enable_kv_cache_events: bool,
+    dcp_world_size: int,
+    pcp_world_size: int,
+    hash_block_size: int,
+    metrics_collector: KVCacheMetricsCollector | None = None,
+) -> KVCacheCoordinator:
+    if not enable_caching:
+        return KVCacheCoordinatorNoPrefixCache(
+            kv_cache_config,
+            max_model_len,
+            max_num_batched_tokens,
+            use_eagle,
+            enable_kv_cache_events,
+            dcp_world_size=dcp_world_size,
+            pcp_world_size=pcp_world_size,
+            hash_block_size=hash_block_size,
+            metrics_collector=metrics_collector,
+        )
+    if len(kv_cache_config.kv_cache_groups) == 1:
+        return UnitaryKVCacheCoordinator(
+            kv_cache_config,
+            max_model_len,
+            max_num_batched_tokens,
+            use_eagle,
+            enable_caching,
+            enable_kv_cache_events,
+            dcp_world_size=dcp_world_size,
+            pcp_world_size=pcp_world_size,
+            hash_block_size=hash_block_size,
+            metrics_collector=metrics_collector,
+        )
+    return HybridKVCacheCoordinator(
+        kv_cache_config,
+        max_model_len,
+        max_num_batched_tokens,
+        use_eagle,
+        enable_caching,
+        enable_kv_cache_events,
+        dcp_world_size=dcp_world_size,
+        pcp_world_size=pcp_world_size,
+        hash_block_size=hash_block_size,
+        metrics_collector=metrics_collector,
+    )

--- a/overlays/vllm/v1/core/kv_cache_manager.py
+++ b/overlays/vllm/v1/core/kv_cache_manager.py
@@ -1,0 +1,554 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import itertools
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Literal, overload
+
+from vllm.distributed.kv_events import KVCacheEvent
+from vllm.logger import init_logger
+from vllm.v1.core.kv_cache_coordinator import get_kv_cache_coordinator
+from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
+from vllm.v1.core.kv_cache_utils import KVCacheBlock
+from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.metrics.stats import PrefixCacheStats
+from vllm.v1.request import Request
+
+logger = init_logger(__name__)
+
+
+@dataclass
+class KVCacheBlocks:
+    """
+    The allocation result of KVCacheManager, work as the interface between
+    Scheduler and KVCacheManager, to hide KVCacheManager's internal data
+    structure from the Scheduler.
+    """
+
+    blocks: tuple[Sequence[KVCacheBlock], ...]
+    """
+    `blocks[i][j]` refers to the i-th kv_cache_group
+    and the j-th block of tokens.We don't use block of
+    tokens as the outer dimension because it assumes all
+    kv_cache_groups have the same number of blocks, which is true for now but
+    will be broken if we want to give different block_size to different
+    kv_cache_groups in the future.
+
+    Each single type KVCacheBlocks could be represented as:
+    - list[KVCacheBlock] for more than one KVCacheBlock
+    - an empty tuple for requests without KVCacheBlock
+      (a precomputed KVCacheBlocks is in KVCacheManager to avoid GC overhead)
+    """
+
+    def __add__(self, other: "KVCacheBlocks") -> "KVCacheBlocks":
+        """Adds two KVCacheBlocks instances."""
+        return KVCacheBlocks(
+            tuple(
+                list(itertools.chain(blk1, blk2))
+                for blk1, blk2 in zip(self.blocks, other.blocks)
+            )
+        )
+
+    @overload
+    def get_block_ids(
+        self,
+        allow_none: Literal[False] = False,
+    ) -> tuple[list[int], ...]: ...
+
+    @overload
+    def get_block_ids(
+        self,
+        allow_none: Literal[True] = True,
+    ) -> tuple[list[int], ...] | None: ...
+
+    def get_block_ids(
+        self,
+        allow_none: bool = False,
+    ) -> tuple[list[int], ...] | None:
+        """
+        Converts the KVCacheBlocks instance to block_ids.
+
+        Returns:
+            tuple[list[int], ...]: A tuple of lists where:
+                - the outer tuple corresponds to KV cache groups
+                - each inner list contains the block_ids of the blocks in that
+                  group
+        """
+        if allow_none and all(len(group) == 0 for group in self.blocks):
+            return None
+        return tuple([blk.block_id for blk in group] for group in self.blocks)
+
+    def get_unhashed_block_ids(self) -> list[int]:
+        """Get block_ids of unhashed blocks from KVCacheBlocks instance."""
+        assert len(self.blocks) == 1, "Only one group is supported"
+        return [block.block_id for block in self.blocks[0] if block.block_hash is None]
+
+    def get_unhashed_block_ids_all_groups(self) -> list[list[int]]:
+        """Get block_ids of unhashed blocks from KVCacheBlocks instance."""
+        # Skip padding blocks.
+        return [
+            [
+                block.block_id
+                for block in group
+                if block.block_hash is None and not block.is_null
+            ]
+            for group in self.blocks
+        ]
+
+    def new_empty(self) -> "KVCacheBlocks":
+        """
+        Creates a new KVCacheBlocks instance with no blocks.
+        """
+        return KVCacheBlocks(tuple(() for _ in range(len(self.blocks))))
+
+
+class KVCacheManager:
+    def __init__(
+        self,
+        kv_cache_config: KVCacheConfig,
+        max_model_len: int,
+        hash_block_size: int,
+        max_num_batched_tokens: int | None = None,
+        enable_caching: bool = True,
+        use_eagle: bool = False,
+        log_stats: bool = False,
+        enable_kv_cache_events: bool = False,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+        metrics_collector: KVCacheMetricsCollector | None = None,
+    ) -> None:
+        self.max_model_len = max_model_len
+        # When unset, fall back to `max_model_len` so the recycling-aware cap
+        # collapses to the prior (uncapped) admission behavior. The scheduler
+        # always supplies the real value at runtime.
+        if max_num_batched_tokens is None:
+            max_num_batched_tokens = max_model_len
+
+        self.enable_caching = enable_caching
+        self.use_eagle = use_eagle
+        self.log_stats = log_stats
+        self.metrics_collector = metrics_collector
+        # FIXME: make prefix cache stats conditional on log_stats. We still need
+        # this comment because when the log stats is enabled there are still
+        # potential configs we could expose in the future.
+        self.prefix_cache_stats = PrefixCacheStats() if log_stats else None
+
+        self.coordinator = get_kv_cache_coordinator(
+            kv_cache_config=kv_cache_config,
+            max_model_len=self.max_model_len,
+            max_num_batched_tokens=max_num_batched_tokens,
+            use_eagle=self.use_eagle,
+            enable_caching=self.enable_caching,
+            enable_kv_cache_events=enable_kv_cache_events,
+            dcp_world_size=dcp_world_size,
+            pcp_world_size=pcp_world_size,
+            hash_block_size=hash_block_size,
+            metrics_collector=self.metrics_collector,
+        )
+        self.num_kv_cache_groups = len(kv_cache_config.kv_cache_groups)
+        self.block_pool = self.coordinator.block_pool
+        self.kv_cache_config = kv_cache_config
+
+        # Pre-constructed KVCacheBlocks with no blocks, callers should use this
+        # via create_kv_cache_blocks instead of creating new ones to avoid GC
+        # overhead.
+        #
+        # We use nested tuples to ensure the empty KVCacheBlocks is immutable.
+        self.empty_kv_cache_blocks = KVCacheBlocks(
+            tuple(() for _ in range(self.num_kv_cache_groups))
+        )
+
+    @property
+    def usage(self) -> float:
+        """Get the KV cache usage.
+
+        Returns:
+            The KV cache usage (between 0.0 and 1.0).
+        """
+        return self.block_pool.get_usage()
+
+    def make_prefix_cache_stats(self) -> PrefixCacheStats | None:
+        """Get (and reset) the prefix cache stats.
+
+        Returns:
+            The current prefix caching stats, or None if logging is disabled.
+        """
+        if not self.log_stats:
+            return None
+        stats = self.prefix_cache_stats
+        self.prefix_cache_stats = PrefixCacheStats()
+        return stats
+
+    def get_computed_blocks(self, request: Request) -> tuple[KVCacheBlocks, int]:
+        """Get the computed (cached) blocks for the request.
+        Note that the computed blocks must be full.
+
+        Args:
+            request: The request to get the computed blocks.
+
+        Returns:
+            A tuple containing:
+                - A list of blocks that are computed for the request.
+                - The number of computed tokens.
+        """
+        # We skip finding the prefix cache hit when prefix caching is
+        # disabled or the request is marked as skipping kv cache read
+        # (which happens when the request requires prompt logprobs
+        # or calls a pooling model with all pooling).
+        if not self.enable_caching or request.skip_reading_prefix_cache:
+            return self.empty_kv_cache_blocks, 0
+
+        # NOTE: When all tokens hit the cache, we must recompute the last token
+        # to obtain logits. Thus, set max_cache_hit_length to prompt_length - 1.
+        # This can trigger recomputation of an entire block, rather than just
+        # the single last token, because allocate_slots() requires
+        # num_computed_tokens to be block-size aligned. Removing this limitation
+        # could slightly improve performance in the future.
+        max_cache_hit_length = request.num_tokens - 1
+        computed_blocks, num_new_computed_tokens = (
+            self.coordinator.find_longest_cache_hit(
+                request.block_hashes, max_cache_hit_length
+            )
+        )
+
+        if self.log_stats:
+            assert self.prefix_cache_stats is not None
+            self.prefix_cache_stats.record(
+                num_tokens=request.num_tokens,
+                num_hits=num_new_computed_tokens,
+                preempted=request.num_preemptions > 0,
+            )
+
+        return self.create_kv_cache_blocks(computed_blocks), num_new_computed_tokens
+
+    def allocate_slots(
+        self,
+        request: Request,
+        num_new_tokens: int,
+        num_new_computed_tokens: int = 0,
+        new_computed_blocks: KVCacheBlocks | None = None,
+        num_lookahead_tokens: int = 0,
+        num_external_computed_tokens: int = 0,
+        delay_cache_blocks: bool = False,
+        num_encoder_tokens: int = 0,
+        full_sequence_must_fit: bool = False,
+    ) -> KVCacheBlocks | None:
+        """Add slots for a request with new tokens to append.
+
+        Args:
+            request: The request to allocate slots.
+            num_new_tokens: The number of new tokens to be allocated and computed.
+            num_new_computed_tokens: The number of new computed tokens just
+                hitting the prefix caching, excluding external tokens.
+            new_computed_blocks: The cached blocks for the above new computed
+                tokens, grouped as a tuple by kv cache groups.
+            num_lookahead_tokens: The number of speculative tokens to allocate.
+                This is used by spec decode proposers with kv-cache such
+                as eagle.
+            num_external_computed_tokens: The number of tokens that their
+                KV caches are not cached by vLLM but cached by the connector.
+            delay_cache_blocks: Whether to skip caching the blocks. This is
+                used by P/D when allocating blocks used in a KV transfer
+                which will complete in a future step.
+            num_encoder_tokens: The number of encoder tokens to allocate for
+                cross-attention in encoder-decoder models(e.g., Whisper).
+                For decoder-only models, this should be 0.
+            full_sequence_must_fit: Only allocate blocks if the KV cache has enough
+                free blocks to hold the full sequence, accounting for prefix cache hits
+                and sliding window. Used as an admission gate to prevent over-admitting
+                requests when chunked prefill would otherwise only check the first chunk
+
+        Blocks layout:
+        ```
+        ----------------------------------------------------------------------
+        | < comp > | < new_comp > | < ext_comp >  | < new >  | < lookahead > |
+        ----------------------------------------------------------------------
+                                                  |   < to be computed >     |
+        ----------------------------------------------------------------------
+                                  |            < to be allocated >           |
+        ----------------------------------------------------------------------
+                                  | < to be cached (roughly, |
+                                  | details below)>          |
+        ----------------------------------------------------------------------
+        | Prefix-cached tokens from either vLLM   |
+        | or connector. Can be safely removed if  |
+        | they are outside sliding window.        |
+        ----------------------------------------------------------------------
+        |   < cached by vLLM >    | not cached by |
+                                  | vLLM, but     |
+        | ref_cnt  | ref_cnt not  | cached by     |
+        | increased| increased yet| connector     |
+        ----------------------------------------------------------------------
+        ```
+
+        Abbrivations:
+
+        ```
+        comp      = request.num_computed_tokens
+        new_comp  = num_new_computed_tokens
+                  = len(new_computed_blocks) * block_size
+        ext_comp  = num_external_computed_tokens, cached by the connector
+        new       = num_new_tokens, including unverified draft tokens
+        lookahead = num_lookahead_tokens
+        ```
+
+        NOTE: for new tokens which include both verified and unverified draft
+        tokens, we only cache the verified tokens (by capping the number at
+        `request.num_tokens`).
+
+        The allocation has three stages:
+        - Free unnecessary blocks in `comp` and check
+           if we have sufficient free blocks (return None if not).
+        - Handle prefix tokens (`comp + new_comp + ext_comp`):
+            - Free unnecessary blocks (e.g. outside sliding window)
+            - Allocate new blocks for `ext_comp` tokens inside
+              sliding window
+        - Allocate new blocks for tokens to be computed (`new + lookahead`)
+
+        Returns:
+            A list of new allocated blocks.
+        """
+        # When loading KV data asynchronously, we may have zero new tokens to
+        # compute while still allocating slots for externally computed tokens.
+        if num_new_tokens == 0 and num_external_computed_tokens == 0:
+            raise ValueError(
+                "num_new_tokens must be greater than 0 when there are no "
+                "external computed tokens"
+            )
+
+        if new_computed_blocks is not None:
+            new_computed_block_list = new_computed_blocks.blocks
+        else:
+            new_computed_block_list = self.empty_kv_cache_blocks.blocks
+
+        # The number of computed tokens is the number of computed tokens plus
+        # the new prefix caching hits
+        num_local_computed_tokens = (
+            request.num_computed_tokens + num_new_computed_tokens
+        )
+        total_computed_tokens = min(
+            num_local_computed_tokens + num_external_computed_tokens,
+            self.max_model_len,
+        )
+
+        if full_sequence_must_fit:
+            # First check and fail if the full request sequence won't fit.
+            full_num_tokens = min(request.num_tokens, self.max_model_len)
+
+            num_blocks_to_allocate = self.coordinator.get_num_blocks_to_allocate(
+                request_id=request.request_id,
+                num_tokens=full_num_tokens,
+                new_computed_blocks=new_computed_block_list,
+                num_encoder_tokens=num_encoder_tokens,
+                total_computed_tokens=total_computed_tokens,
+                num_tokens_main_model=full_num_tokens,
+                apply_admission_cap=True,
+            )
+            if num_blocks_to_allocate > self.block_pool.get_num_free_blocks():
+                return None
+
+        num_tokens_main_model = total_computed_tokens + num_new_tokens
+        num_tokens_need_slot = min(
+            num_tokens_main_model + num_lookahead_tokens, self.max_model_len
+        )
+        compacted_count = request.get_compacted_token_count()
+        if compacted_count > 0:
+            num_tokens_need_slot -= compacted_count
+
+        # Free the blocks that are skipped during the attention computation
+        # (e.g., tokens outside the sliding window).
+        # We can do this even if we cannot schedule this request due to
+        # insufficient free blocks.
+        # Should call this function before allocating new blocks to reduce
+        # the number of evicted blocks.
+        self.coordinator.remove_skipped_blocks(
+            request.request_id, total_computed_tokens
+        )
+
+        num_blocks_to_allocate = self.coordinator.get_num_blocks_to_allocate(
+            request_id=request.request_id,
+            num_tokens=num_tokens_need_slot,
+            new_computed_blocks=new_computed_block_list,
+            num_encoder_tokens=num_encoder_tokens,
+            total_computed_tokens=num_local_computed_tokens
+            + num_external_computed_tokens,
+            num_tokens_main_model=num_tokens_main_model,
+        )
+
+        if num_blocks_to_allocate > self.block_pool.get_num_free_blocks():
+            # Cannot allocate new blocks
+            return None
+
+        if (
+            new_computed_block_list is not self.empty_kv_cache_blocks.blocks
+            or num_external_computed_tokens > 0
+        ):
+            # Append the new computed blocks to the request blocks until now to
+            # avoid the case where the new blocks cannot be allocated.
+            self.coordinator.allocate_new_computed_blocks(
+                request_id=request.request_id,
+                new_computed_blocks=new_computed_block_list,
+                num_local_computed_tokens=num_local_computed_tokens,
+                num_external_computed_tokens=num_external_computed_tokens,
+            )
+
+        new_blocks = self.coordinator.allocate_new_blocks(
+            request.request_id,
+            num_tokens_need_slot,
+            num_tokens_main_model,
+            num_encoder_tokens,
+        )
+
+        # P/D: delay caching blocks if we have to recv from
+        # remote. Update state for locally cached blocks.
+        if not self.enable_caching or delay_cache_blocks:
+            return self.create_kv_cache_blocks(new_blocks)
+
+        # NOTE(woosuk): We want to commit (cache) up to num_local_computed_tokens
+        # + num_external_computed_tokens + num_new_tokens, but must exclude
+        # "non-committable" tokens (e.g., draft tokens that could be rejected).
+        # Therefore, we cap the number at `request.num_tokens`, ensuring only
+        # "finalized" tokens are cached.
+        num_tokens_to_cache = min(
+            total_computed_tokens + num_new_tokens,
+            request.num_tokens,
+        )
+        self.coordinator.cache_blocks(request, num_tokens_to_cache)
+
+        return self.create_kv_cache_blocks(new_blocks)
+
+    def free(self, request: Request) -> None:
+        """Free the blocks allocated for the request.
+        We free the blocks in reverse order so that the tail blocks are evicted
+        first when caching is enabled.
+
+        Args:
+            request: The request to free the blocks.
+        """
+        self.coordinator.free(request.request_id)
+
+    def remove_skipped_blocks(
+        self, request_id: str, total_computed_tokens: int
+    ) -> None:
+        """Remove the blocks that are no longer needed from `blocks` and replace
+        the removed blocks with null_block.
+
+        Args:
+            request_id: The request ID.
+            total_computed_tokens: The total number of computed tokens, including
+                local computed tokens and external computed tokens.
+        """
+        self.coordinator.remove_skipped_blocks(request_id, total_computed_tokens)
+
+    def evict_blocks(self, block_ids: set[int]) -> None:
+        """evict blocks from the prefix cache by their block IDs.
+
+        Args:
+            block_ids: Set of block IDs to evict from cache.
+        """
+        self.block_pool.evict_blocks(block_ids)
+
+    def reset_prefix_cache(self) -> bool:
+        """Reset prefix cache. This function may be used in RLHF
+        flows to invalidate prefix caching after the weights are updated,
+        or used for resetting prefix caching status for benchmarking.
+
+        Returns:
+            bool: True if the prefix cache is successfully reset,
+            False otherwise.
+        """
+        if not self.block_pool.reset_prefix_cache():
+            return False
+        if self.log_stats:
+            assert self.prefix_cache_stats is not None
+            self.prefix_cache_stats.reset = True
+        return True
+
+    def get_num_common_prefix_blocks(self, running_request_id: str) -> list[int]:
+        """Calculate the number of common prefix blocks for each kv cache group.
+
+        The function selects a running request and iterates through its blocks.
+        A block is considered a common prefix block if ALL requests with
+        allocated KV cache share it (i.e., ref_cnt equals the number of entries
+        in req_to_blocks).
+
+        NOTE(woosuk): The number of requests with allocated KV cache is **greater
+        than or equal to** the number of requests scheduled in the current step.
+        This is because having allocated KV cache only indicates that:
+        1. The request has not yet finished, and
+        2. The request holds its blocks unfreed.
+
+        While all scheduled requests must have allocated KV cache, the inverse
+        is not necessarily true. There may be requests with allocated KV cache
+        that are not scheduled in the current step.
+
+        This can result in an edge case where the number of common prefix blocks
+        is 0, even though all scheduled requests share a common prefix. This
+        occurs because there may be unscheduled requests that do not share the
+        common prefix. Currently, this case cannot be easily detected, so the
+        function returns 0 in such cases.
+
+        Args:
+            running_request_id: The request ID of any running request, used to
+                identify the common prefix blocks.
+
+        Returns:
+            list[int]: The number of common prefix blocks for each kv cache
+            group.
+        """
+        return self.coordinator.get_num_common_prefix_blocks(running_request_id)
+
+    def take_events(self) -> list[KVCacheEvent]:
+        """Take the KV cache events from the block pool.
+
+        Returns:
+            A list of KV cache events.
+        """
+        return self.block_pool.take_events()
+
+    def get_blocks(self, request_id: str) -> KVCacheBlocks:
+        """Get the blocks of a request."""
+        return self.create_kv_cache_blocks(self.coordinator.get_blocks(request_id))
+
+    def get_block_ids(self, request_id: str) -> tuple[list[int], ...]:
+        """Get the block ids of a request."""
+        return self.get_blocks(request_id).get_block_ids()
+
+    def cache_blocks(self, request: Request, num_computed_tokens: int) -> None:
+        """Cache the blocks for the request, if enabled.
+
+        Args:
+            request: The request to cache the blocks.
+            num_computed_tokens: The number of computed tokens, including tokens
+                that are already cached and tokens to be cached.
+        """
+        if self.enable_caching:
+            self.coordinator.cache_blocks(request, num_computed_tokens)
+
+    def create_kv_cache_blocks(
+        self, blocks: tuple[list[KVCacheBlock], ...]
+    ) -> KVCacheBlocks:
+        # Only create new KVCacheBlocks for non-empty blocks
+        return KVCacheBlocks(blocks) if any(blocks) else self.empty_kv_cache_blocks
+
+    def take_new_block_ids(self) -> list[int]:
+        """Drain and return new attention block IDs for zeroing."""
+        ids: list[int] = []
+        for mgr in self.coordinator.single_type_managers:
+            ids.extend(mgr.take_new_block_ids())
+        return ids
+
+    def new_step_starts(self) -> None:
+        """Called when a new step is started."""
+        self.coordinator.new_step_starts()
+
+    def compact_kv_cache(
+        self,
+        request_id: str,
+        active_physical_positions: list[int],
+    ) -> tuple[int, list[tuple[int, int, int, int]]]:
+        """Physically compact KV cache by copying active tokens to contiguous slots."""
+        return self.coordinator.compact_kv_cache(
+            request_id, active_physical_positions
+        )

--- a/overlays/vllm/v1/core/sched/output.py
+++ b/overlays/vllm/v1/core/sched/output.py
@@ -1,0 +1,281 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from dataclasses import dataclass
+from functools import cached_property
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import numpy as np
+    import numpy.typing as npt
+    import torch
+
+    from vllm.distributed.ec_transfer.ec_connector.base import ECConnectorMetadata
+    from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
+    from vllm.lora.request import LoRARequest
+    from vllm.multimodal.inputs import MultiModalFeatureSpec
+    from vllm.pooling_params import PoolingParams
+    from vllm.sampling_params import SamplingParams
+    from vllm.v1.request import Request
+else:
+    ECConnectorMetadata = object
+    KVConnectorMetadata = object
+    LoRARequest = object
+    MultiModalFeatureSpec = object
+    PoolingParams = object
+    SamplingParams = object
+    Request = object
+
+
+@dataclass
+class NewRequestData:
+    req_id: str
+    prompt_token_ids: list[int] | None
+    mm_features: list[MultiModalFeatureSpec]
+    sampling_params: SamplingParams | None
+    pooling_params: PoolingParams | None
+    block_ids: tuple[list[int], ...]
+    num_computed_tokens: int
+    lora_request: LoRARequest | None
+    prompt_embeds: "torch.Tensor | None" = None
+    prompt_is_token_ids: list[bool] | None = None
+
+    # Only used for v2 model runner.
+    prefill_token_ids: list[int] | None = None
+
+    @classmethod
+    def from_request(
+        cls,
+        request: Request,
+        block_ids: tuple[list[int], ...],
+        prefill_token_ids: list[int] | None = None,
+    ) -> "NewRequestData":
+        return cls(
+            req_id=request.request_id,
+            prompt_token_ids=request.prompt_token_ids,
+            mm_features=request.mm_features,
+            sampling_params=request.sampling_params,
+            pooling_params=request.pooling_params,
+            block_ids=block_ids,
+            num_computed_tokens=request.num_computed_tokens,
+            lora_request=request.lora_request,
+            prompt_embeds=request.prompt_embeds,
+            prompt_is_token_ids=request.prompt_is_token_ids,
+            prefill_token_ids=prefill_token_ids,
+        )
+
+    def __repr__(self) -> str:
+        prompt_embeds_shape = (
+            self.prompt_embeds.shape if self.prompt_embeds is not None else None
+        )
+        return (
+            f"NewRequestData("
+            f"req_id={self.req_id},"
+            f"prompt_token_ids={self.prompt_token_ids},"
+            f"prefill_token_ids={self.prefill_token_ids},"
+            f"mm_features={self.mm_features},"
+            f"sampling_params={self.sampling_params},"
+            f"block_ids={self.block_ids},"
+            f"num_computed_tokens={self.num_computed_tokens},"
+            f"lora_request={self.lora_request},"
+            f"prompt_embeds_shape={prompt_embeds_shape}"
+            ")"
+        )
+
+    # Version of __repr__ with the prompt data obfuscated
+    def anon_repr(self) -> str:
+        prompt_token_ids_len = (
+            len(self.prompt_token_ids) if self.prompt_token_ids is not None else None
+        )
+        prompt_embeds_shape = (
+            self.prompt_embeds.shape if self.prompt_embeds is not None else None
+        )
+        prefill_token_ids_len = (
+            len(self.prefill_token_ids) if self.prefill_token_ids is not None else None
+        )
+        return (
+            f"NewRequestData("
+            f"req_id={self.req_id},"
+            f"prompt_token_ids_len={prompt_token_ids_len},"
+            f"prefill_token_ids_len={prefill_token_ids_len},"
+            f"mm_features={self.mm_features},"
+            f"sampling_params={self.sampling_params},"
+            f"block_ids={self.block_ids},"
+            f"num_computed_tokens={self.num_computed_tokens},"
+            f"lora_request={self.lora_request},"
+            f"prompt_embeds_shape={prompt_embeds_shape}"
+            ")"
+        )
+
+
+@dataclass
+class CachedRequestData:
+    req_ids: list[str]
+    # For request ids not in resumed_req_ids, new_block_ids will be appended to
+    # the request's block IDs. For those in the set, new_block_ids will be used as the
+    # request's block IDs instead of appending to the existing block IDs.
+    resumed_req_ids: set[str]
+    # NOTE(woosuk): new_token_ids is only used for pipeline parallelism.
+    # When PP is not used, new_token_ids will be empty.
+    new_token_ids: list[list[int]]
+    # For requests not scheduled in the last step, propagate the token ids to the
+    # connector. Won't contain requests that were scheduled in the prior step.
+    all_token_ids: dict[str, list[int]]
+    new_block_ids: list[tuple[list[int], ...] | None]
+    num_computed_tokens: list[int]
+    num_output_tokens: list[int]
+    compacted_token_counts: list[int]
+
+    # Version of dataclass repr with token IDs obfuscated.
+    def anon_repr(self) -> str:
+        new_token_ids_lens = [len(toks) for toks in self.new_token_ids]
+        all_token_ids_lens = {
+            req_id: len(toks) for req_id, toks in self.all_token_ids.items()
+        }
+        return (
+            f"CachedRequestData("
+            f"req_ids={self.req_ids},"
+            f"resumed_req_ids={self.resumed_req_ids},"
+            f"new_token_ids_lens={new_token_ids_lens},"
+            f"all_token_ids_lens={all_token_ids_lens},"
+            f"new_block_ids={self.new_block_ids},"
+            f"num_computed_tokens={self.num_computed_tokens},"
+            f"num_output_tokens={self.num_output_tokens}"
+            f")"
+        )
+
+    def __repr__(self) -> str:
+        return self.anon_repr()
+
+    @property
+    def num_reqs(self) -> int:
+        return len(self.req_ids)
+
+    @cached_property
+    def _req_id_to_num_output_tokens(self) -> dict[str, int]:
+        """Cache mapping of req_id to num_output_tokens for O(1) lookup.
+
+        This cached property is safe because CachedRequestData instances
+        are created fresh each scheduling iteration and not mutated during
+        computation of iteration details.
+        """
+        return dict(zip(self.req_ids, self.num_output_tokens))
+
+    def is_context_phase(self, req_id: str) -> bool:
+        num_output_tokens = self._req_id_to_num_output_tokens.get(req_id)
+        return num_output_tokens is not None and num_output_tokens == 0
+
+    @classmethod
+    def make_empty(cls) -> "CachedRequestData":
+        return cls(
+            req_ids=[],
+            resumed_req_ids=set(),
+            new_token_ids=[],
+            all_token_ids={},
+            new_block_ids=[],
+            num_computed_tokens=[],
+            num_output_tokens=[],
+            compacted_token_counts=[],
+        )
+
+
+@dataclass
+class SchedulerOutput:
+    # list of the requests that are scheduled for the first time.
+    # We cache the request's data in each worker process, so that we don't
+    # need to re-send it every scheduling step.
+    scheduled_new_reqs: list[NewRequestData]
+    # list of the requests that have been scheduled before.
+    # Since the request's data is already cached in the worker processes,
+    # we only send the diff to minimize the communication cost.
+    scheduled_cached_reqs: CachedRequestData
+
+    # req_id -> num_scheduled_tokens
+    # Number of tokens scheduled for each request.
+    num_scheduled_tokens: dict[str, int]
+    # Total number of tokens scheduled for all requests.
+    # Equal to sum(num_scheduled_tokens.values())
+    total_num_scheduled_tokens: int
+    # req_id -> spec_token_ids
+    # If a request does not have any spec decode tokens, it will not be
+    # included in the dictionary.
+    scheduled_spec_decode_tokens: dict[str, list[int]]
+    # req_id -> encoder input indices that need processing.
+    # E.g., if a request has [0, 1], it could mean the vision encoder needs
+    # to process that the request's 0-th and 1-th images in the current step.
+    scheduled_encoder_inputs: dict[str, list[int]]
+    # Number of common prefix blocks for all requests in each KV cache group.
+    # This can be used for cascade attention.
+    num_common_prefix_blocks: list[int]
+
+    # Request IDs that are finished in between the previous and the current
+    # steps. This is used to notify the workers about the finished requests
+    # so that they can free the cached states for those requests.
+    finished_req_ids: set[str]
+    # list of mm_hash strings associated with the encoder outputs to be
+    # freed from the encoder cache.
+    free_encoder_mm_hashes: list[str]
+
+    # Request IDs that are preempted in this step.
+    # Only used for v2 model runner.
+    preempted_req_ids: set[str] | None = None
+
+    # Whether any of the scheduled requests use structured output.
+    # Set only in async scheduling case.
+    has_structured_output_requests: bool = False
+
+    # Whether the scheduled requests have all the output tokens they
+    # need to perform grammar bitmask computation.
+    pending_structured_output_tokens: bool = False
+
+    # Used for adjusting acceptance rate calculation.
+    num_invalid_spec_tokens: dict[str, int] | None = None
+
+    # KV Cache Connector metadata.
+    kv_connector_metadata: KVConnectorMetadata | None = None
+
+    # EC Cache Connector metadata
+    ec_connector_metadata: ECConnectorMetadata | None = None
+
+    # Block IDs freshly allocated from the pool during this scheduling step.
+    # The worker zeros the corresponding GPU memory before the blocks are used,
+    # preventing stale NaN/data from corrupting attention or SSM computation.
+    new_block_ids_to_zero: list[int] | None = None
+
+    # req_id -> list of (src_block_id, src_offset, dst_block_id, dst_offset)
+    # for KV cache compaction.
+    kv_copy_operations: dict[str, list[tuple[int, int, int, int]]] | None = None
+
+    # req_id -> tuple of num_blocks per KV cache group
+    # for block table truncation after compaction.
+    block_table_truncations: dict[str, tuple[int, ...]] | None = None
+
+    # Request IDs that should skip sampling this step due to pending
+    # block masking compactions.
+    skip_sampling_req_ids: set[str] | None = None
+
+    # True when this scheduling step must be serialized with async scheduling
+    # because it performs deferred block masking compaction.
+    block_masking_barrier: bool = False
+
+    @classmethod
+    def make_empty(cls) -> "SchedulerOutput":
+        return cls(
+            scheduled_new_reqs=[],
+            scheduled_cached_reqs=CachedRequestData.make_empty(),
+            num_scheduled_tokens={},
+            total_num_scheduled_tokens=0,
+            scheduled_spec_decode_tokens={},
+            scheduled_encoder_inputs={},
+            num_common_prefix_blocks=[],
+            finished_req_ids=set(),
+            free_encoder_mm_hashes=[],
+        )
+
+
+@dataclass
+class GrammarOutput:
+    # ids of structured output requests.
+    structured_output_request_ids: list[str]
+    # Bitmask ordered as structured_output_request_ids.
+    grammar_bitmask: "npt.NDArray[np.int32]"

--- a/overlays/vllm/v1/core/sched/scheduler.py
+++ b/overlays/vllm/v1/core/sched/scheduler.py
@@ -1,0 +1,2580 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import itertools
+import time
+from collections import defaultdict, deque
+from collections.abc import Iterable
+from dataclasses import replace
+from typing import Any
+
+from vllm import envs
+from vllm.compilation.cuda_graph import CUDAGraphStat
+from vllm.config import VllmConfig
+from vllm.distributed.ec_transfer.ec_connector.base import (
+    ECConnectorMetadata,
+    ECConnectorRole,
+)
+from vllm.distributed.ec_transfer.ec_connector.factory import ECConnectorFactory
+from vllm.distributed.kv_events import EventPublisherFactory, KVEventBatch
+from vllm.distributed.kv_transfer.kv_connector.factory import KVConnectorFactory
+from vllm.distributed.kv_transfer.kv_connector.v1 import (
+    KVConnectorBase_V1,
+    KVConnectorRole,
+    SupportsHMA,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
+from vllm.logger import init_logger
+from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
+from vllm.multimodal.encoder_budget import MultiModalBudget
+from vllm.v1.core.encoder_cache_manager import (
+    EncoderCacheManager,
+    EncoderDecoderCacheManager,
+)
+from vllm.v1.core.kv_cache_manager import KVCacheBlocks, KVCacheManager
+from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
+from vllm.v1.core.sched.interface import PauseState, SchedulerInterface
+from vllm.v1.core.sched.output import (
+    CachedRequestData,
+    GrammarOutput,
+    NewRequestData,
+    SchedulerOutput,
+)
+from vllm.v1.core.sched.request_queue import (
+    RequestQueue,
+    SchedulingPolicy,
+    create_request_queue,
+)
+from vllm.v1.core.sched.utils import check_stop, remove_all
+from vllm.v1.engine import (
+    EngineCoreEventType,
+    EngineCoreOutput,
+    EngineCoreOutputs,
+    SpanRemovalResult,
+)
+from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.metrics.perf import ModelMetrics, PerfStats
+from vllm.v1.metrics.stats import PrefixCacheStats, SchedulerStats
+from vllm.v1.outputs import DraftTokenIds, KVConnectorOutput, ModelRunnerOutput
+from vllm.v1.request import Request, RequestStatus, StreamingUpdate
+from vllm.v1.spec_decode.metrics import SpecDecodingStats
+from vllm.v1.structured_output import StructuredOutputManager
+from vllm.v1.utils import record_function_or_nullcontext
+from vllm.v1.core.block_masking import BlockMaskingProcessor
+
+logger = init_logger(__name__)
+
+
+class Scheduler(SchedulerInterface):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        kv_cache_config: KVCacheConfig,
+        structured_output_manager: StructuredOutputManager,
+        block_size: int,
+        hash_block_size: int | None = None,
+        mm_registry: MultiModalRegistry = MULTIMODAL_REGISTRY,
+        include_finished_set: bool = False,
+        log_stats: bool = False,
+    ) -> None:
+        self.vllm_config = vllm_config
+        self.scheduler_config = vllm_config.scheduler_config
+        self.cache_config = vllm_config.cache_config
+        self.lora_config = vllm_config.lora_config
+        self.kv_cache_config = kv_cache_config
+        self.kv_events_config = vllm_config.kv_events_config
+        self.parallel_config = vllm_config.parallel_config
+        self.log_stats = log_stats
+        self.observability_config = vllm_config.observability_config
+        self.kv_metrics_collector: KVCacheMetricsCollector | None = None
+        if self.observability_config.kv_cache_metrics:
+            self.kv_metrics_collector = KVCacheMetricsCollector(
+                self.observability_config.kv_cache_metrics_sample,
+            )
+        # Block masking for Memento-style generation (opt-in)
+        self.block_masking_config = getattr(vllm_config, 'block_masking_config', None)
+        self.block_masking_processor: BlockMaskingProcessor | None = None
+        if (self.block_masking_config is not None and
+            self.block_masking_config.enable):
+            self.block_masking_processor = BlockMaskingProcessor(
+                self.block_masking_config
+            )
+            if self.block_masking_config.debug:
+                logger.info("Block masking enabled with keep_last_n_blocks=%d",
+                           self.block_masking_config.keep_last_n_blocks)
+        self.structured_output_manager = structured_output_manager
+        self.is_encoder_decoder = vllm_config.model_config.is_encoder_decoder
+
+        # include_finished_set controls whether a separate set of finished
+        # request ids should be included in the EngineCoreOutputs returned
+        # by update_from_outputs(). This is currently used in the multi-engine
+        # case to track request lifetimes efficiently.
+        self.finished_req_ids_dict: dict[int, set[str]] | None = (
+            defaultdict(set) if include_finished_set else None
+        )
+        self.prev_step_scheduled_req_ids: set[str] = set()
+
+        # Scheduling constraints.
+        self.max_num_running_reqs = self.scheduler_config.max_num_seqs
+        self.max_num_scheduled_tokens = (
+            self.scheduler_config.max_num_scheduled_tokens
+            if self.scheduler_config.max_num_scheduled_tokens
+            else self.scheduler_config.max_num_batched_tokens
+        )
+        self.max_model_len = vllm_config.model_config.max_model_len
+        self.enable_kv_cache_events = (
+            self.kv_events_config is not None
+            and self.kv_events_config.enable_kv_cache_events
+        )
+
+        # Create KVConnector for the Scheduler. Note that each Worker
+        # will have a corresponding KVConnector with Role=WORKER.
+        # KV Connector pushes/pull of remote KVs for P/D and offloading.
+        self.connector = None
+        self.connector_prefix_cache_stats: PrefixCacheStats | None = None
+        self.recompute_kv_load_failures = True
+        if self.vllm_config.kv_transfer_config is not None:
+            assert not self.is_encoder_decoder, (
+                "Encoder-decoder models are not currently supported with KV connectors"
+            )
+            self.connector = KVConnectorFactory.create_connector(
+                config=self.vllm_config,
+                role=KVConnectorRole.SCHEDULER,
+                kv_cache_config=self.kv_cache_config,
+            )
+            if self.log_stats:
+                self.connector_prefix_cache_stats = PrefixCacheStats()
+            kv_load_failure_policy = (
+                self.vllm_config.kv_transfer_config.kv_load_failure_policy
+            )
+            self.recompute_kv_load_failures = kv_load_failure_policy == "recompute"
+
+        self.kv_event_publisher = EventPublisherFactory.create(
+            self.kv_events_config,
+            self.parallel_config.data_parallel_index,
+        )
+        self.ec_connector = None
+        if self.vllm_config.ec_transfer_config is not None:
+            self.ec_connector = ECConnectorFactory.create_connector(
+                config=self.vllm_config, role=ECConnectorRole.SCHEDULER
+            )
+
+        num_gpu_blocks = self.cache_config.num_gpu_blocks
+        assert num_gpu_blocks is not None and num_gpu_blocks > 0
+
+        self.block_size = block_size
+        self.dcp_world_size = vllm_config.parallel_config.decode_context_parallel_size
+        self.pcp_world_size = vllm_config.parallel_config.prefill_context_parallel_size
+
+        # req_id -> Request
+        self.requests: dict[str, Request] = {}
+        # Scheduling policy
+        try:
+            self.policy = SchedulingPolicy(self.scheduler_config.policy)
+        except ValueError as e:
+            raise ValueError(
+                f"Unknown scheduling policy: {self.scheduler_config.policy}"
+            ) from e
+        # Priority queues for requests.
+        self.waiting = create_request_queue(self.policy)
+        # requests skipped in waiting flow due async deps or constraints.
+        self.skipped_waiting = create_request_queue(self.policy)
+        self.running: list[Request] = []
+
+        # The request IDs that are finished in between the previous and the
+        # current steps. This is used to notify the workers about the finished
+        # requests so that they can free the cached states for those requests.
+        # This is flushed at the end of each scheduling step.
+        self.finished_req_ids: set[str] = set()
+
+        # Pending KV copy operations for compaction.
+        self.pending_kv_copy_operations: dict[
+            str, list[tuple[int, int, int, int]]
+        ] = {}
+        # Block table truncation info after KV cache compaction.
+        self.pending_block_table_truncations: dict[str, tuple[int, ...]] = {}
+
+        # Counter for requests waiting for streaming input. Used to calculate
+        # number of unfinished requests
+        self.num_waiting_for_streaming_input: int = 0
+
+        # KV Connector: requests in process of async KV loading or recving
+        self.finished_recving_kv_req_ids: set[str] = set()
+        self.failed_recving_kv_req_ids: set[str] = set()
+
+        # Encoder-related.
+        # Calculate encoder cache size if applicable
+        supports_mm_inputs = mm_registry.supports_multimodal_inputs(
+            vllm_config.model_config
+        )
+        mm_budget = (
+            MultiModalBudget(vllm_config, mm_registry) if supports_mm_inputs else None
+        )
+
+        # NOTE: Text-only encoder-decoder models are implemented as
+        # multi-modal models for convenience
+        # Example: https://github.com/vllm-project/bart-plugin
+        if self.is_encoder_decoder:
+            assert mm_budget and len(mm_budget.mm_max_toks_per_item) <= 1, (
+                "Encoder-decoder models are expected to implement the "
+                "multimodal interface with at most one modality."
+            )
+
+        self.max_num_encoder_input_tokens = (
+            mm_budget.encoder_compute_budget if mm_budget else 0
+        )
+        encoder_cache_size = mm_budget.encoder_cache_size if mm_budget else 0
+        self.encoder_cache_manager = (
+            EncoderDecoderCacheManager(cache_size=encoder_cache_size)
+            if self.is_encoder_decoder
+            else EncoderCacheManager(cache_size=encoder_cache_size)
+        )
+
+        speculative_config = vllm_config.speculative_config
+        self.use_eagle = False
+        self.num_spec_tokens = self.num_lookahead_tokens = 0
+        if speculative_config:
+            self.num_spec_tokens = speculative_config.num_speculative_tokens
+            if speculative_config.use_eagle():
+                self.use_eagle = True
+                self.num_lookahead_tokens = self.num_spec_tokens
+            if speculative_config.uses_draft_model():
+                self.num_lookahead_tokens = self.num_spec_tokens
+
+        # Create the KV cache manager.
+        if hash_block_size is None:
+            hash_block_size = block_size
+        self.kv_cache_manager = KVCacheManager(
+            kv_cache_config=kv_cache_config,
+            max_model_len=self.max_model_len,
+            max_num_batched_tokens=self.scheduler_config.max_num_batched_tokens,
+            enable_caching=self.cache_config.enable_prefix_caching,
+            use_eagle=self.use_eagle,
+            log_stats=self.log_stats,
+            enable_kv_cache_events=self.enable_kv_cache_events,
+            dcp_world_size=self.dcp_world_size,
+            pcp_world_size=self.pcp_world_size,
+            hash_block_size=hash_block_size,
+            metrics_collector=self.kv_metrics_collector,
+        )
+        # Bind GPU block pool to the KV connector. This must happen after
+        # kv_cache_manager is constructed so block_pool is available.
+        if self.connector is not None and hasattr(
+            self.connector, "bind_gpu_block_pool"
+        ):
+            self.connector.bind_gpu_block_pool(self.kv_cache_manager.block_pool)
+
+        self.use_pp = self.parallel_config.pipeline_parallel_size > 1
+        self.use_v2_model_runner = envs.VLLM_USE_V2_MODEL_RUNNER
+        self.scheduler_reserve_full_isl = (
+            self.scheduler_config.scheduler_reserve_full_isl
+        )
+
+        self.has_mamba_layers = kv_cache_config.has_mamba_layers
+        self.needs_kv_cache_zeroing = kv_cache_config.needs_kv_cache_zeroing
+        self.need_mamba_block_aligned_split = (
+            self.has_mamba_layers and self.cache_config.mamba_cache_mode == "align"
+        )
+        self.perf_metrics: ModelMetrics | None = None
+        if self.log_stats and vllm_config.observability_config.enable_mfu_metrics:
+            self.perf_metrics = ModelMetrics(vllm_config)
+
+        self._pause_state: PauseState = PauseState.UNPAUSED
+
+    def _mamba_block_aligned_split(
+        self,
+        request: Request,
+        num_new_tokens: int,
+        num_new_local_computed_tokens: int = 0,
+        num_external_computed_tokens: int = 0,
+    ) -> int:
+        assert num_external_computed_tokens == 0, (
+            "External KV connector is not verified yet"
+        )
+        num_computed_tokens = (
+            request.num_computed_tokens
+            + num_new_local_computed_tokens
+            + num_external_computed_tokens
+        )
+        # Perform block-aligned splitting at prefill phase, including:
+        # * non-resumed requests: num_computed_tokens < num_prompt_tokens + 0
+        # * resumed requests: num_computed_tokens < (
+        #                       num_prompt_tokens + num_output_tokens
+        #                     )
+        # NOTE: Use `request.num_tokens - 1` to bypass normal decoding.
+        if num_computed_tokens < max(request.num_prompt_tokens, request.num_tokens - 1):
+            # To enable block-aligned caching of the Mamba state, `num_new_tokens`
+            # must be a multiple of `block_size`.
+            # As an exception, if `num_new_tokens` is less than `block_size`, the
+            # state is simply not cached, requiring no special handling.
+            # Additionally, when Eagle mode is enabled, FullAttn prunes the last
+            # matching block. To prevent this from causing a Mamba cache miss, the
+            # last chunk must be not smaller than `block_size`.
+            block_size = self.cache_config.block_size
+            last_cache_position = request.num_tokens - request.num_tokens % block_size
+            # eagle prune
+            if self.use_eagle:
+                last_cache_position = max(last_cache_position - block_size, 0)
+            num_computed_tokens_after_sched = num_computed_tokens + num_new_tokens
+            if num_computed_tokens_after_sched < last_cache_position:
+                # align to block_size
+                num_new_tokens = num_new_tokens // block_size * block_size
+            elif (
+                num_computed_tokens
+                < last_cache_position
+                < num_computed_tokens_after_sched
+            ):
+                # force to cache the last chunk
+                num_new_tokens = last_cache_position - num_computed_tokens
+            else:
+                # prefill the last few tokens
+                pass
+        return num_new_tokens
+
+    def schedule(self) -> SchedulerOutput:
+        # NOTE(woosuk) on the scheduling algorithm:
+        # There's no "decoding phase" nor "prefill phase" in the scheduler.
+        # Each request just has the num_computed_tokens and
+        # num_tokens_with_spec. num_tokens_with_spec =
+        # len(prompt_token_ids) + len(output_token_ids) + len(spec_token_ids).
+        # At each step, the scheduler tries to assign tokens to the requests
+        # so that each request's num_computed_tokens can catch up its
+        # num_tokens_with_spec. This is general enough to cover
+        # chunked prefills, prefix caching, speculative decoding,
+        # and the "jump decoding" optimization in the future.
+
+        scheduled_new_reqs: list[Request] = []
+        scheduled_resumed_reqs: list[Request] = []
+        scheduled_running_reqs: list[Request] = []
+        preempted_reqs: list[Request] = []
+
+        req_to_new_blocks: dict[str, KVCacheBlocks] = {}
+        num_scheduled_tokens: dict[str, int] = {}
+        token_budget = self.max_num_scheduled_tokens
+        if self._pause_state == PauseState.PAUSED_ALL:
+            # Do not schedule any requests when paused.
+            token_budget = 0
+
+        # Encoder-related.
+        scheduled_encoder_inputs: dict[str, list[int]] = {}
+        encoder_compute_budget = self.max_num_encoder_input_tokens
+        # Spec decode-related.
+        scheduled_spec_decode_tokens: dict[str, list[int]] = {}
+
+        # For logging.
+        scheduled_timestamp = time.monotonic()
+
+        self.kv_cache_manager.new_step_starts()
+
+        # First, schedule the RUNNING requests.
+        req_index = 0
+        while req_index < len(self.running) and token_budget > 0:
+            request = self.running[req_index]
+
+            if (
+                request.num_output_placeholders > 0
+                # This is (num_computed_tokens + 1) - (num_output_placeholders - 1).
+                # Since output placeholders are also included in the computed tokens
+                # count, we subtract (num_output_placeholders - 1) to remove any draft
+                # tokens, so that we can be sure no further steps are needed even if
+                # they are all rejected.
+                and request.num_computed_tokens + 2 - request.num_output_placeholders
+                >= request.num_prompt_tokens + request.max_tokens
+            ):
+                # Async scheduling: Avoid scheduling an extra step when we are sure that
+                # the previous step has reached request.max_tokens. We don't schedule
+                # partial draft tokens since this prevents uniform decode optimizations.
+                req_index += 1
+                continue
+
+            num_new_tokens = (
+                request.num_tokens_with_spec
+                + request.num_output_placeholders
+                - request.num_computed_tokens
+            )
+            if 0 < self.scheduler_config.long_prefill_token_threshold < num_new_tokens:
+                num_new_tokens = self.scheduler_config.long_prefill_token_threshold
+            num_new_tokens = min(num_new_tokens, token_budget)
+
+            # Make sure the input position does not exceed the max model len.
+            # This is necessary when using spec decoding.
+            num_new_tokens = min(
+                num_new_tokens, self.max_model_len - 1 - request.num_computed_tokens
+            )
+
+            # Schedule encoder inputs.
+            encoder_inputs_to_schedule = None
+            external_load_encoder_input: list[int] = []
+            new_encoder_compute_budget = encoder_compute_budget
+            if request.has_encoder_inputs:
+                (
+                    encoder_inputs_to_schedule,
+                    num_new_tokens,
+                    new_encoder_compute_budget,
+                    external_load_encoder_input,
+                ) = self._try_schedule_encoder_inputs(
+                    request,
+                    request.num_computed_tokens,
+                    num_new_tokens,
+                    encoder_compute_budget,
+                    shift_computed_tokens=1 if self.use_eagle else 0,
+                )
+
+            if self.need_mamba_block_aligned_split:
+                num_new_tokens = self._mamba_block_aligned_split(
+                    request, num_new_tokens
+                )
+
+            if num_new_tokens == 0:
+                # The request cannot be scheduled because one of the following
+                # reasons:
+                # 1. No new tokens to schedule. This may happen when
+                #    (1) PP>1 and we have already scheduled all prompt tokens
+                #    but they are not finished yet.
+                #    (2) Async scheduling and the request has reached to either
+                #    its max_total_tokens or max_model_len.
+                # 2. The encoder budget is exhausted.
+                # 3. The encoder cache is exhausted.
+                # 4. Insufficient budget for a block-aligned chunk in hybrid
+                #    models with mamba cache mode \"align\".
+                # NOTE(woosuk): Here, by doing `continue` instead of `break`,
+                # we do not strictly follow the FCFS scheduling policy and
+                # allow the lower-priority requests to be scheduled.
+                req_index += 1
+                continue
+
+            # Schedule newly needed KV blocks for the request.
+            with record_function_or_nullcontext("schedule: allocate_slots"):
+                while True:
+                    new_blocks = self.kv_cache_manager.allocate_slots(
+                        request,
+                        num_new_tokens,
+                        num_lookahead_tokens=self.num_lookahead_tokens,
+                    )
+
+                    if new_blocks is not None:
+                        # The request can be scheduled.
+                        break
+
+                    # The request cannot be scheduled.
+                    # Preempt the lowest-priority request.
+                    if self.policy == SchedulingPolicy.PRIORITY:
+                        preempted_req = max(
+                            self.running,
+                            key=lambda r: (r.priority, r.arrival_time),
+                        )
+                        self.running.remove(preempted_req)
+                        if preempted_req in scheduled_running_reqs:
+                            preempted_req_id = preempted_req.request_id
+                            scheduled_running_reqs.remove(preempted_req)
+                            token_budget += num_scheduled_tokens.pop(preempted_req_id)
+                            req_to_new_blocks.pop(preempted_req_id)
+                            scheduled_spec_decode_tokens.pop(preempted_req_id, None)
+                            preempted_encoder_inputs = scheduled_encoder_inputs.pop(
+                                preempted_req_id, None
+                            )
+                            if preempted_encoder_inputs:
+                                # Restore encoder compute budget if the preempted
+                                # request had encoder inputs scheduled in this step.
+                                num_embeds_to_restore = sum(
+                                    preempted_req.get_num_encoder_embeds(i)
+                                    for i in preempted_encoder_inputs
+                                )
+                                encoder_compute_budget += num_embeds_to_restore
+                            req_index -= 1
+                    else:
+                        preempted_req = self.running.pop()
+
+                    self._preempt_request(preempted_req, scheduled_timestamp)
+                    preempted_reqs.append(preempted_req)
+                    if preempted_req == request:
+                        # No more request to preempt. Cannot schedule this request.
+                        break
+
+            if new_blocks is None:
+                # Cannot schedule this request.
+                break
+
+            # Schedule the request.
+            scheduled_running_reqs.append(request)
+            request_id = request.request_id
+            req_to_new_blocks[request_id] = new_blocks
+            num_scheduled_tokens[request_id] = num_new_tokens
+            token_budget -= num_new_tokens
+            req_index += 1
+
+            # Speculative decode related.
+            if request.spec_token_ids:
+                num_scheduled_spec_tokens = (
+                    num_new_tokens
+                    + request.num_computed_tokens
+                    - request.num_tokens
+                    - request.num_output_placeholders
+                )
+                if num_scheduled_spec_tokens > 0:
+                    spec_token_ids = request.spec_token_ids
+                    if len(spec_token_ids) > num_scheduled_spec_tokens:
+                        spec_token_ids = spec_token_ids[:num_scheduled_spec_tokens]
+                    scheduled_spec_decode_tokens[request.request_id] = spec_token_ids
+
+                # New spec tokens will be set in `update_draft_token_ids` before the
+                # next step when applicable.
+                request.spec_token_ids = []
+
+            # Encoder-related.
+            if encoder_inputs_to_schedule:
+                scheduled_encoder_inputs[request_id] = encoder_inputs_to_schedule
+                # Allocate the encoder cache.
+                for i in encoder_inputs_to_schedule:
+                    self.encoder_cache_manager.allocate(request, i)
+                    if self.ec_connector is not None:
+                        self.ec_connector.update_state_after_alloc(request, i)
+                encoder_compute_budget = new_encoder_compute_budget
+            if external_load_encoder_input:
+                for i in external_load_encoder_input:
+                    self.encoder_cache_manager.allocate(request, i)
+                    if self.ec_connector is not None:
+                        self.ec_connector.update_state_after_alloc(request, i)
+
+        # Record the LoRAs in scheduled_running_reqs
+        scheduled_loras: set[int] = set()
+        if self.lora_config:
+            scheduled_loras = set(
+                req.lora_request.lora_int_id
+                for req in scheduled_running_reqs
+                if req.lora_request and req.lora_request.lora_int_id > 0
+            )
+            assert len(scheduled_loras) <= self.lora_config.max_loras
+
+        # Next, schedule the WAITING requests.
+        if not preempted_reqs and self._pause_state == PauseState.UNPAUSED:
+            step_skipped_waiting = create_request_queue(self.policy)
+
+            while (self.waiting or self.skipped_waiting) and token_budget > 0:
+                if len(self.running) == self.max_num_running_reqs:
+                    break
+
+                request_queue = self._select_waiting_queue_for_scheduling()
+                assert request_queue is not None
+
+                request = request_queue.peek_request()
+                request_id = request.request_id
+
+                # try to promote blocked statuses while traversing skipped queue.
+                if self._is_blocked_waiting_status(
+                    request.status
+                ) and not self._try_promote_blocked_waiting_request(request):
+                    if request.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
+                        logger.debug(
+                            "%s is still in WAITING_FOR_REMOTE_KVS state.",
+                            request_id,
+                        )
+                    request_queue.pop_request()
+                    step_skipped_waiting.prepend_request(request)
+                    continue
+
+                # Check that adding the request still respects the max_loras
+                # constraint.
+                if (
+                    self.lora_config
+                    and request.lora_request
+                    and (
+                        len(scheduled_loras) == self.lora_config.max_loras
+                        and request.lora_request.lora_int_id not in scheduled_loras
+                    )
+                ):
+                    # Scheduling would exceed max_loras, skip.
+                    request_queue.pop_request()
+                    step_skipped_waiting.prepend_request(request)
+                    continue
+
+                num_external_computed_tokens = 0
+                load_kv_async = False
+                connector_prefix_cache_queries, connector_prefix_cache_hits = 0, 0
+
+                # Get already-cached tokens.
+                if request.num_computed_tokens == 0:
+                    # Get locally-cached tokens.
+                    new_computed_blocks, num_new_local_computed_tokens = (
+                        self.kv_cache_manager.get_computed_blocks(request)
+                    )
+
+                    # Get externally-cached tokens if using a KVConnector.
+                    if self.connector is not None:
+                        ext_tokens, load_kv_async = (
+                            self.connector.get_num_new_matched_tokens(
+                                request, num_new_local_computed_tokens
+                            )
+                        )
+
+                        if ext_tokens is None:
+                            # The request cannot be scheduled because
+                            # the KVConnector couldn't determine
+                            # the number of matched tokens.
+                            request_queue.pop_request()
+                            step_skipped_waiting.prepend_request(request)
+                            continue
+
+                        num_external_computed_tokens = ext_tokens
+
+                        connector_prefix_cache_queries = (
+                            request.num_tokens - num_new_local_computed_tokens
+                        )
+                        connector_prefix_cache_hits = num_external_computed_tokens
+
+                    # Total computed tokens (local + external).
+                    num_computed_tokens = (
+                        num_new_local_computed_tokens + num_external_computed_tokens
+                    )
+                    assert num_computed_tokens <= request.num_tokens
+
+                    # Track first scheduled prefill, not post-preemption repeat prefills
+                    if request.prefill_stats is not None:
+                        assert num_computed_tokens <= request.num_prompt_tokens
+                        request.prefill_stats.set(
+                            num_prompt_tokens=request.num_prompt_tokens,
+                            num_local_cached_tokens=num_new_local_computed_tokens,
+                            num_external_cached_tokens=num_external_computed_tokens,
+                        )
+                else:
+                    # KVTransfer: WAITING reqs have num_computed_tokens > 0
+                    # after async KV recvs are completed.
+                    new_computed_blocks = self.kv_cache_manager.empty_kv_cache_blocks
+                    num_new_local_computed_tokens = 0
+                    num_computed_tokens = request.num_computed_tokens
+
+                encoder_inputs_to_schedule = None
+                external_load_encoder_input = []
+                new_encoder_compute_budget = encoder_compute_budget
+
+                if load_kv_async:
+                    # KVTransfer: loading remote KV, do not allocate for new work.
+                    assert num_external_computed_tokens > 0
+                    num_new_tokens = 0
+                else:
+                    # Number of tokens to be scheduled.
+                    # We use `request.num_tokens` instead of
+                    # `request.num_prompt_tokens` to consider the resumed
+                    # requests, which have output tokens.
+                    num_new_tokens = request.num_tokens - num_computed_tokens
+                    threshold = self.scheduler_config.long_prefill_token_threshold
+                    if 0 < threshold < num_new_tokens:
+                        num_new_tokens = threshold
+
+                    # chunked prefill has to be enabled explicitly to allow
+                    # pooling requests to be chunked
+                    if (
+                        not self.scheduler_config.enable_chunked_prefill
+                        and num_new_tokens > token_budget
+                    ):
+                        # If chunked_prefill is disabled,
+                        # we can stop the scheduling here.
+                        break
+
+                    num_new_tokens = min(num_new_tokens, token_budget)
+                    assert num_new_tokens > 0
+
+                    # Schedule encoder inputs.
+                    if request.has_encoder_inputs:
+                        (
+                            encoder_inputs_to_schedule,
+                            num_new_tokens,
+                            new_encoder_compute_budget,
+                            external_load_encoder_input,
+                        ) = self._try_schedule_encoder_inputs(
+                            request,
+                            num_computed_tokens,
+                            num_new_tokens,
+                            encoder_compute_budget,
+                            shift_computed_tokens=1 if self.use_eagle else 0,
+                        )
+                        if num_new_tokens == 0:
+                            # The request cannot be scheduled.
+                            break
+
+                if self.need_mamba_block_aligned_split:
+                    num_new_tokens = self._mamba_block_aligned_split(
+                        request,
+                        num_new_tokens,
+                        num_new_local_computed_tokens,
+                        num_external_computed_tokens,
+                    )
+                    if num_new_tokens == 0:
+                        break
+
+                # Handles an edge case when P/D Disaggregation
+                # is used with Spec Decoding where an
+                # extra block gets allocated which
+                # creates a mismatch between the number
+                # of local and remote blocks.
+                effective_lookahead_tokens = (
+                    0 if request.num_computed_tokens == 0 else self.num_lookahead_tokens
+                )
+
+                # Determine if we need to allocate cross-attention blocks.
+                num_encoder_tokens = 0
+                if (
+                    self.is_encoder_decoder
+                    and request.has_encoder_inputs
+                    and encoder_inputs_to_schedule
+                ):
+                    num_encoder_tokens = sum(
+                        request.get_num_encoder_embeds(i)
+                        for i in encoder_inputs_to_schedule
+                    )
+
+                new_blocks = self.kv_cache_manager.allocate_slots(
+                    request,
+                    num_new_tokens,
+                    num_new_computed_tokens=num_new_local_computed_tokens,
+                    new_computed_blocks=new_computed_blocks,
+                    num_lookahead_tokens=effective_lookahead_tokens,
+                    num_external_computed_tokens=num_external_computed_tokens,
+                    delay_cache_blocks=load_kv_async,
+                    num_encoder_tokens=num_encoder_tokens,
+                    full_sequence_must_fit=self.scheduler_reserve_full_isl,
+                )
+
+                if new_blocks is None:
+                    # The request cannot be scheduled.
+
+                    # NOTE: we need to untouch the request from the encode cache
+                    # manager
+                    if request.has_encoder_inputs:
+                        self.encoder_cache_manager.free(request)
+                    break
+
+                # KVTransfer: the connector uses this info to determine
+                # if a load is needed. Note that
+                # This information is used to determine if a load is
+                # needed for this request.
+                if self.connector is not None:
+                    self.connector.update_state_after_alloc(
+                        request,
+                        self.kv_cache_manager.get_blocks(request_id),
+                        num_external_computed_tokens,
+                    )
+                    if (
+                        self.connector_prefix_cache_stats is not None
+                        and connector_prefix_cache_queries != 0
+                    ):
+                        self.connector_prefix_cache_stats.record(
+                            num_tokens=connector_prefix_cache_queries,
+                            num_hits=connector_prefix_cache_hits,
+                            preempted=request.num_preemptions > 0,
+                        )
+
+                request = request_queue.pop_request()
+                if load_kv_async:
+                    # If loading async, allocate memory and put request
+                    # into the WAITING_FOR_REMOTE_KV state.
+                    request.status = RequestStatus.WAITING_FOR_REMOTE_KVS
+                    step_skipped_waiting.prepend_request(request)
+                    # Set num_computed_tokens even though KVs are not yet loaded.
+                    # request.num_computed_tokens will not be used anywhere until
+                    # the request finished the KV transfer.
+                    #
+                    # If a transfer error is reported by the connector,
+                    # request.num_computed_tokens will be re-set accordingly in
+                    # _update_requests_with_invalid_blocks.
+                    #
+                    # When the transfer is finished, either successfully or not,
+                    # request.num_computed_tokens will correctly reflect the number
+                    # of computed tokens.
+                    # _update_waiting_for_remote_kv will then cache
+                    # only the successfully loaded tokens.
+                    request.num_computed_tokens = num_computed_tokens
+                    continue
+
+                self.running.append(request)
+                if self.log_stats:
+                    request.record_event(
+                        EngineCoreEventType.SCHEDULED, scheduled_timestamp
+                    )
+                if request.status == RequestStatus.WAITING:
+                    scheduled_new_reqs.append(request)
+                elif request.status == RequestStatus.PREEMPTED:
+                    scheduled_resumed_reqs.append(request)
+                else:
+                    raise RuntimeError(f"Invalid request status: {request.status}")
+
+                if self.lora_config and request.lora_request:
+                    scheduled_loras.add(request.lora_request.lora_int_id)
+                req_to_new_blocks[request_id] = self.kv_cache_manager.get_blocks(
+                    request_id
+                )
+                num_scheduled_tokens[request_id] = num_new_tokens
+                token_budget -= num_new_tokens
+                request.status = RequestStatus.RUNNING
+                request.num_computed_tokens = num_computed_tokens
+                # Encoder-related.
+                if encoder_inputs_to_schedule:
+                    scheduled_encoder_inputs[request_id] = encoder_inputs_to_schedule
+                    # Allocate the encoder cache.
+                    for i in encoder_inputs_to_schedule:
+                        self.encoder_cache_manager.allocate(request, i)
+                        if self.ec_connector is not None:
+                            self.ec_connector.update_state_after_alloc(request, i)
+                    encoder_compute_budget = new_encoder_compute_budget
+                # Allocate for external load encoder cache
+                if external_load_encoder_input:
+                    for i in external_load_encoder_input:
+                        self.encoder_cache_manager.allocate(request, i)
+                        if self.ec_connector is not None:
+                            self.ec_connector.update_state_after_alloc(request, i)
+
+            # re-queue requests skipped in this pass ahead of older skipped items.
+            if step_skipped_waiting:
+                self.skipped_waiting.prepend_requests(step_skipped_waiting)
+
+        # Check if the scheduling constraints are satisfied.
+        total_num_scheduled_tokens = sum(num_scheduled_tokens.values())
+        assert total_num_scheduled_tokens <= self.max_num_scheduled_tokens
+
+        assert token_budget >= 0
+        assert len(self.running) <= self.max_num_running_reqs
+        # Since some requests in the RUNNING queue may not be scheduled in
+        # this step, the total number of scheduled requests can be smaller than
+        # len(self.running).
+        assert len(scheduled_new_reqs) + len(scheduled_resumed_reqs) + len(
+            scheduled_running_reqs
+        ) <= len(self.running)
+
+        # Get the longest common prefix among all requests in the running queue.
+        # This can be potentially used for cascade attention.
+        num_common_prefix_blocks = [0] * len(self.kv_cache_config.kv_cache_groups)
+        with record_function_or_nullcontext("schedule: get_num_common_prefix_blocks"):
+            if self.running:
+                any_request_id = self.running[0].request_id
+                num_common_prefix_blocks = (
+                    self.kv_cache_manager.get_num_common_prefix_blocks(any_request_id)
+                )
+
+        # Construct the scheduler output.
+        if self.use_v2_model_runner:
+            scheduled_new_reqs = scheduled_new_reqs + scheduled_resumed_reqs
+            scheduled_resumed_reqs = []
+            new_reqs_data = [
+                NewRequestData.from_request(
+                    req,
+                    req_to_new_blocks[req.request_id].get_block_ids(),
+                    req._all_token_ids,
+                )
+                for req in scheduled_new_reqs
+            ]
+        else:
+            new_reqs_data = [
+                NewRequestData.from_request(
+                    req, req_to_new_blocks[req.request_id].get_block_ids()
+                )
+                for req in scheduled_new_reqs
+            ]
+
+        with record_function_or_nullcontext("schedule: make_cached_request_data"):
+            cached_reqs_data = self._make_cached_request_data(
+                scheduled_running_reqs,
+                scheduled_resumed_reqs,
+                num_scheduled_tokens,
+                scheduled_spec_decode_tokens,
+                req_to_new_blocks,
+            )
+
+        # Record the request ids that were scheduled in this step.
+        self.prev_step_scheduled_req_ids.clear()
+        self.prev_step_scheduled_req_ids.update(num_scheduled_tokens.keys())
+
+        new_block_ids_to_zero = (
+            (self.kv_cache_manager.take_new_block_ids() or None)
+            if self.needs_kv_cache_zeroing
+            else None
+        )
+
+        # Get pending KV copy operations for compaction.
+        kv_copy_operations = (
+            self.pending_kv_copy_operations.copy()
+            if self.pending_kv_copy_operations
+            else None
+        )
+        self.pending_kv_copy_operations.clear()
+
+        block_table_truncations = (
+            self.pending_block_table_truncations.copy()
+            if self.pending_block_table_truncations
+            else None
+        )
+        self.pending_block_table_truncations.clear()
+
+        # Block masking: detect requests that should skip sampling.
+        # Only skip when this scheduled chunk completes the prefill
+        # ranges needed by every pending compaction. For chunked prefill,
+        # earlier chunks must not consume the one-time skip.
+        skip_sampling_req_ids: set[str] | None = None
+        if self.block_masking_processor is not None:
+            skip_sampling_req_ids = set()
+
+            def get_block_masking_state(request: Request):
+                if request.block_masking_state is None:
+                    request.block_masking_state = (
+                        self.block_masking_processor.create_state())
+                    if request.prompt_token_ids:
+                        self.block_masking_processor.process_prompt_tokens(
+                            request.block_masking_state,
+                            request.prompt_token_ids)
+                return request.block_masking_state
+
+            for req_id, n_sched in num_scheduled_tokens.items():
+                request = self.requests.get(req_id)
+                if request is None:
+                    continue
+                state = get_block_masking_state(request)
+                if (not state.pending_compactions or
+                    state.deferred_compaction_scheduled or
+                    len(request.output_token_ids) > 0):
+                    continue
+
+                computed_after_schedule = request.num_computed_tokens + n_sched
+                pending_ranges: list[tuple[int, int]] = []
+                for block_id in state.pending_compactions:
+                    block = state.blocks[block_id]
+                    if self.block_masking_config.restart_mode:
+                        span = block.get_restart_range(
+                            mask_delimiters=self.block_masking_config.mask_delimiters)
+                    else:
+                        span = block.get_content_range(
+                            mask_delimiters=self.block_masking_config.mask_delimiters)
+                    if span is not None:
+                        pending_ranges.append(span)
+
+                ready_for_deferred_compaction = (
+                    pending_ranges and
+                    all(end <= computed_after_schedule
+                        for _, end in pending_ranges)
+                )
+                if ready_for_deferred_compaction:
+                    state.deferred_compaction_scheduled = True
+                    skip_sampling_req_ids.add(req_id)
+                elif (self.block_masking_config is not None and
+                      self.block_masking_config.debug):
+                    logger.info(
+                        "Block masking deferred skip not ready for %s: "
+                        "computed_after=%d, num_tokens=%d, pending_ranges=%s",
+                        req_id,
+                        computed_after_schedule,
+                        request.num_tokens,
+                        pending_ranges,
+                    )
+            if not skip_sampling_req_ids:
+                skip_sampling_req_ids = None
+            elif (self.block_masking_config is not None and
+                  self.block_masking_config.debug):
+                logger.info(
+                    "Block masking deferred skip ids: %s",
+                    sorted(skip_sampling_req_ids),
+                )
+
+        scheduler_output = SchedulerOutput(
+            scheduled_new_reqs=new_reqs_data,
+            scheduled_cached_reqs=cached_reqs_data,
+            num_scheduled_tokens=num_scheduled_tokens,
+            total_num_scheduled_tokens=total_num_scheduled_tokens,
+            scheduled_spec_decode_tokens=scheduled_spec_decode_tokens,
+            scheduled_encoder_inputs=scheduled_encoder_inputs,
+            num_common_prefix_blocks=num_common_prefix_blocks,
+            preempted_req_ids={req.request_id for req in preempted_reqs},
+            # finished_req_ids is an existing state in the scheduler,
+            # instead of being newly scheduled in this step.
+            # It contains the request IDs that are finished in between
+            # the previous and the current steps.
+            finished_req_ids=self.finished_req_ids,
+            free_encoder_mm_hashes=self.encoder_cache_manager.get_freed_mm_hashes(),
+            new_block_ids_to_zero=new_block_ids_to_zero,
+            kv_copy_operations=kv_copy_operations,
+            block_table_truncations=block_table_truncations,
+            skip_sampling_req_ids=skip_sampling_req_ids,
+            block_masking_barrier=skip_sampling_req_ids is not None,
+        )
+
+        # NOTE(Kuntai): this function is designed for multiple purposes:
+        # 1. Plan the KV cache store
+        # 2. Wrap up all the KV cache load / save ops into an opaque object
+        # 3. Clear the internal states of the connector
+        if self.connector is not None:
+            meta = self._build_kv_connector_meta(self.connector, scheduler_output)
+            scheduler_output.kv_connector_metadata = meta
+
+        # Build the connector meta for ECConnector
+        if self.ec_connector is not None:
+            ec_meta: ECConnectorMetadata = self.ec_connector.build_connector_meta(
+                scheduler_output
+            )
+            scheduler_output.ec_connector_metadata = ec_meta
+
+        with record_function_or_nullcontext("schedule: update_after_schedule"):
+            self._update_after_schedule(scheduler_output)
+        return scheduler_output
+
+    def _build_kv_connector_meta(
+        self, connector: KVConnectorBase_V1, scheduler_output: SchedulerOutput
+    ) -> KVConnectorMetadata:
+        return connector.build_connector_meta(scheduler_output)
+
+    def _preempt_request(self, request: Request, timestamp: float) -> None:
+        """Preempt a request and put it back to the waiting queue.
+
+        NOTE: The request should be popped from the running queue outside of this
+        method.
+        """
+        assert request.status == RequestStatus.RUNNING, (
+            "Only running requests can be preempted"
+        )
+        self.kv_cache_manager.free(request)
+        self.encoder_cache_manager.free(request)
+        request.status = RequestStatus.PREEMPTED
+        request.num_computed_tokens = 0
+        if request.spec_token_ids:
+            request.spec_token_ids = []
+        request.num_preemptions += 1
+
+        # Reset block masking / compaction state so re-prefill rebuilds it.
+        request.compacted_spans = []
+        if self.block_masking_processor is not None:
+            request.block_masking_state = (
+                self.block_masking_processor.create_state())
+            if request.prompt_token_ids:
+                self.block_masking_processor.process_prompt_tokens(
+                    request.block_masking_state, request.prompt_token_ids)
+
+        if self.log_stats:
+            request.record_event(EngineCoreEventType.PREEMPTED, timestamp)
+
+        # Put the request back to the waiting queue.
+        self.waiting.prepend_request(request)
+
+    def _update_after_schedule(self, scheduler_output: SchedulerOutput) -> None:
+        # Advance the number of computed tokens for the request AFTER
+        # the request is scheduled.
+        # 1. The scheduler_output of the current step has to include the
+        #    original number of scheduled tokens to determine input IDs.
+        # 2. Advance the number of computed tokens here allowing us to
+        #    schedule the prefill request again immediately in the next
+        #    scheduling step.
+        # 3. If some tokens (e.g. spec tokens) are rejected later, the number of
+        #    computed tokens will be adjusted in update_from_output.
+        num_scheduled_tokens = scheduler_output.num_scheduled_tokens
+        for req_id, num_scheduled_token in num_scheduled_tokens.items():
+            request = self.requests[req_id]
+            request.num_computed_tokens += num_scheduled_token
+            request.is_prefill_chunk = request.num_computed_tokens < (
+                request.num_tokens + request.num_output_placeholders
+            )
+            scheduler_output.has_structured_output_requests |= (
+                request.use_structured_output and not request.is_prefill_chunk
+            )
+
+        # Clear the finished request IDs.
+        # NOTE: We shouldn't do self.finished_req_ids.clear() here because
+        # it will also affect the scheduler output.
+        self.finished_req_ids = set()
+
+    def _update_request_as_session(
+        self, session: Request, update: StreamingUpdate
+    ) -> None:
+        """
+        Updates the waiting session with the next streaming update.
+
+        Discards the last sampled output token from the prior input chunk.
+        """
+
+        # Current streaming input behaviour: Keep only computed output tokens
+        # (discard final sampled output token).
+        num_computed_tokens = session.num_computed_tokens
+        kept_output_tokens = session._all_token_ids[
+            session.num_prompt_tokens : num_computed_tokens
+        ]
+        del session._all_token_ids[num_computed_tokens:]
+        session._output_token_ids.clear()
+        assert session.prompt_token_ids is not None
+        # Extend prompt with kept output tokens.
+        session.prompt_token_ids.extend(kept_output_tokens)
+
+        if update.mm_features:
+            base = session.num_tokens
+            for mm_feature in update.mm_features:
+                mm_feature.mm_position = replace(
+                    mm_feature.mm_position, offset=mm_feature.mm_position.offset + base
+                )
+            session.mm_features.extend(update.mm_features)
+
+        session._all_token_ids.extend(update.prompt_token_ids or ())
+        session.prompt_token_ids.extend(update.prompt_token_ids or ())
+        # Update block hashes for the new tokens.
+        session.update_block_hashes()
+        session.num_prompt_tokens = len(session.prompt_token_ids)
+        session.arrival_time = update.arrival_time
+        session.sampling_params = update.sampling_params
+        if session.status == RequestStatus.WAITING_FOR_STREAMING_REQ:
+            self.num_waiting_for_streaming_input -= 1
+        session.status = RequestStatus.WAITING
+
+        if self.log_stats:
+            session.record_event(EngineCoreEventType.QUEUED)
+
+    def _make_cached_request_data(
+        self,
+        running_reqs: list[Request],
+        resumed_reqs: list[Request],
+        num_scheduled_tokens: dict[str, int],
+        spec_decode_tokens: dict[str, list[int]],
+        req_to_new_blocks: dict[str, KVCacheBlocks],
+    ) -> CachedRequestData:
+        req_ids: list[str] = []
+        new_token_ids: list[list[int]] = []
+        new_block_ids: list[tuple[list[int], ...] | None] = []
+        all_token_ids: dict[str, list[int]] = {}
+        num_computed_tokens: list[int] = []
+        num_output_tokens: list[int] = []
+        resumed_req_ids = set()
+
+        num_running_reqs = len(running_reqs)
+        for idx, req in enumerate(itertools.chain(running_reqs, resumed_reqs)):
+            req_id = req.request_id
+            req_ids.append(req_id)
+            # NOTE: In PP+async scheduling, we consume token ids via a direct GPU
+            # broadcast path (`input_batch.prev_sampled_token_ids`), so we can
+            # omit this payload.
+            if self.use_pp and not self.scheduler_config.async_scheduling:
+                # When using PP, the scheduler sends the sampled tokens back,
+                # because there's no direct communication between the first-
+                # stage worker and the last-stage worker. Otherwise, we don't
+                # need to send the sampled tokens back because the model runner
+                # will cache them.
+                num_tokens = num_scheduled_tokens[req_id] - len(
+                    spec_decode_tokens.get(req_id, ())
+                )
+                token_ids = req.all_token_ids[
+                    req.num_computed_tokens : req.num_computed_tokens + num_tokens
+                ]
+                new_token_ids.append(token_ids)
+            scheduled_in_prev_step = req_id in self.prev_step_scheduled_req_ids
+            if idx >= num_running_reqs:
+                assert not scheduled_in_prev_step
+                resumed_req_ids.add(req_id)
+            if not scheduled_in_prev_step:
+                all_token_ids[req_id] = req.all_token_ids.copy()
+            new_block_ids.append(
+                req_to_new_blocks[req_id].get_block_ids(allow_none=True)
+            )
+            num_computed_tokens.append(req.num_computed_tokens)
+            num_output_tokens.append(
+                req.num_output_tokens + req.num_output_placeholders
+            )
+
+        compacted_token_counts = [
+            req.get_compacted_token_count()
+            for req in itertools.chain(running_reqs, resumed_reqs)
+        ]
+
+        return CachedRequestData(
+            req_ids=req_ids,
+            resumed_req_ids=resumed_req_ids,
+            new_token_ids=new_token_ids,
+            all_token_ids=all_token_ids,
+            new_block_ids=new_block_ids,
+            num_computed_tokens=num_computed_tokens,
+            num_output_tokens=num_output_tokens,
+            compacted_token_counts=compacted_token_counts,
+        )
+
+    def _try_schedule_encoder_inputs(
+        self,
+        request: Request,
+        num_computed_tokens: int,
+        num_new_tokens: int,
+        encoder_compute_budget: int,
+        shift_computed_tokens: int = 0,
+    ) -> tuple[list[int], int, int, list[int]]:
+        """
+        Determine which encoder inputs need to be scheduled in the current step,
+        and update `num_new_tokens` and encoder token budget accordingly.
+
+        An encoder input will be scheduled if:
+        - Its output tokens overlap with the range of tokens being computed
+        in this step, i.e.,
+        [num_computed_tokens, num_computed_tokens + num_new_tokens).
+        - It is not already computed and stored in the encoder cache.
+        - It is not exist on remote encoder cache (via ECConnector)
+        - There is sufficient encoder token budget to process it.
+        - The encoder cache has space to store it.
+
+        If an encoder input cannot be scheduled due to cache or budget
+        limitations, the method adjusts `num_new_tokens` to schedule only the
+        decoder tokens up to just before the unschedulable encoder input.
+
+        Note that num_computed_tokens includes both locally cached
+        blocks and externally cached blocks (via KVConnector).
+        """
+        if num_new_tokens == 0 or not request.has_encoder_inputs:
+            return [], num_new_tokens, encoder_compute_budget, []
+        encoder_inputs_to_schedule: list[int] = []
+        mm_features = request.mm_features
+        assert mm_features is not None
+        assert len(mm_features) > 0
+        external_load_encoder_input = []
+
+        # NOTE: since scheduler operates on the request level (possibly with
+        # multiple encoder inputs per request), we need to create temporary
+        # trackers for accounting at the encoder input level.
+        mm_hashes_to_schedule = set()
+        num_embeds_to_schedule = 0
+        for i, mm_feature in enumerate(mm_features):
+            start_pos = mm_feature.mm_position.offset
+            num_encoder_tokens = mm_feature.mm_position.length
+            num_encoder_embeds = mm_feature.mm_position.get_num_embeds()
+            item_identifier = mm_feature.identifier
+
+            # The encoder output is needed if the two ranges overlap:
+            # [num_computed_tokens, num_computed_tokens + num_new_tokens) and
+            # [start_pos, start_pos + num_encoder_tokens)
+            if (
+                start_pos
+                >= num_computed_tokens + num_new_tokens + shift_computed_tokens
+            ):
+                # The encoder input is not needed in this step.
+                break
+
+            if self.is_encoder_decoder and num_computed_tokens > 0:
+                assert start_pos == 0, (
+                    "Encoder input should be processed at the beginning of "
+                    "the sequence when encoder-decoder models are used."
+                )
+                # Encoder input has already been computed
+                # The calculation here is a bit different. We don't turn encoder
+                # output into tokens that get processed by the decoder and
+                # reflected in num_computed_tokens. Instead, start_pos reflects
+                # the position where we need to ensure we calculate encoder
+                # inputs. This should always be 0 to ensure we calculate encoder
+                # inputs before running the decoder.  Once we've calculated some
+                # decoder tokens (num_computed_tokens > 0), then we know we
+                # already calculated encoder inputs and can skip here.
+                continue
+            elif start_pos + num_encoder_tokens <= num_computed_tokens:
+                # The encoder input is already computed and stored
+                # in the decoder's KV cache.
+                continue
+
+            if not self.is_encoder_decoder:
+                # We are not using the encoder cache for encoder-decoder models,
+                # yet.
+                if item_identifier in mm_hashes_to_schedule:
+                    # The same encoder input has already been scheduled in the
+                    # current step.
+                    continue
+
+                if self.encoder_cache_manager.check_and_update_cache(request, i):
+                    # The encoder input is already computed and cached from a
+                    # previous step.
+                    continue
+
+            # If no encoder input chunking is allowed, we do not want to
+            # partially schedule a multimodal item. If the scheduled range would
+            # only cover part of the mm input, roll back to before the mm item.
+            if (
+                self.scheduler_config.disable_chunked_mm_input
+                and num_computed_tokens < start_pos
+                and (num_computed_tokens + num_new_tokens)
+                < (start_pos + num_encoder_tokens)
+            ):
+                # Account for EAGLE shift when rolling back to avoid
+                # encoder cache miss. This ensures the scheduled range
+                # stops before start_pos even with the shift.
+                num_new_tokens = max(
+                    0, start_pos - (num_computed_tokens + shift_computed_tokens)
+                )
+                break
+            if not self.encoder_cache_manager.can_allocate(
+                request, i, encoder_compute_budget, num_embeds_to_schedule
+            ):
+                # The encoder cache is full or the encoder budget is exhausted.
+                # NOTE(woosuk): We assume that the encoder input tokens should
+                # be processed altogether, as the encoder usually uses
+                # bidirectional attention.
+                if num_computed_tokens + shift_computed_tokens < start_pos:
+                    # We only schedule the decoder tokens just before the
+                    # encoder input.
+                    num_new_tokens = start_pos - (
+                        num_computed_tokens + shift_computed_tokens
+                    )
+                else:
+                    # Because of prefix caching, num_computed_tokens is greater
+                    # than start_pos even though its encoder input is not
+                    # available. In this case, we can't schedule any token for
+                    # the request in this step.
+                    num_new_tokens = 0
+                break
+
+            # Calculate the number of embeddings to schedule in the current range
+            # of scheduled encoder placeholder tokens.
+            start_idx_rel = max(0, num_computed_tokens - start_pos)
+            end_idx_rel = min(
+                num_encoder_tokens, num_computed_tokens + num_new_tokens - start_pos
+            )
+            curr_embeds_start, curr_embeds_end = (
+                mm_feature.mm_position.get_embeds_indices_in_range(
+                    start_idx_rel, end_idx_rel
+                )
+            )
+            # There's no embeddings in the current range of encoder placeholder tokens
+            # so we can skip the encoder input.
+            if curr_embeds_end - curr_embeds_start == 0:
+                continue
+
+            if self.ec_connector is not None and self.ec_connector.has_cache_item(
+                item_identifier
+            ):
+                mm_hashes_to_schedule.add(item_identifier)
+                external_load_encoder_input.append(i)
+                num_embeds_to_schedule += num_encoder_embeds
+                continue
+
+            num_embeds_to_schedule += num_encoder_embeds
+            encoder_compute_budget -= num_encoder_embeds
+            mm_hashes_to_schedule.add(item_identifier)
+            encoder_inputs_to_schedule.append(i)
+
+        return (
+            encoder_inputs_to_schedule,
+            num_new_tokens,
+            encoder_compute_budget,
+            external_load_encoder_input,
+        )
+
+    def get_grammar_bitmask(
+        self, scheduler_output: SchedulerOutput
+    ) -> GrammarOutput | None:
+        # Collect list of scheduled request ids that use structured output.
+        # The corresponding rows of the bitmask will be in this order.
+        if not scheduler_output.has_structured_output_requests:
+            return None
+
+        structured_output_request_ids = [
+            req_id
+            for req_id in scheduler_output.num_scheduled_tokens
+            if (req := self.requests.get(req_id))
+            and (req.use_structured_output and not req.is_prefill_chunk)
+        ]
+        if not structured_output_request_ids:
+            return None
+
+        bitmask = self.structured_output_manager.grammar_bitmask(
+            self.requests,
+            structured_output_request_ids,
+            scheduler_output.scheduled_spec_decode_tokens,
+        )
+        return GrammarOutput(structured_output_request_ids, bitmask)
+
+    def update_from_output(
+        self,
+        scheduler_output: SchedulerOutput,
+        model_runner_output: ModelRunnerOutput,
+    ) -> dict[int, EngineCoreOutputs]:
+        sampled_token_ids = model_runner_output.sampled_token_ids
+        logprobs = model_runner_output.logprobs
+        prompt_logprobs_dict = model_runner_output.prompt_logprobs_dict
+        num_scheduled_tokens = scheduler_output.num_scheduled_tokens
+        pooler_outputs = model_runner_output.pooler_output
+        num_nans_in_logits = model_runner_output.num_nans_in_logits
+        kv_connector_output = model_runner_output.kv_connector_output
+        cudagraph_stats = model_runner_output.cudagraph_stats
+
+        perf_stats: PerfStats | None = None
+        if self.perf_metrics and self.perf_metrics.is_enabled():
+            perf_stats = self.perf_metrics.get_step_perf_stats_per_gpu(scheduler_output)
+
+        outputs: dict[int, list[EngineCoreOutput]] = defaultdict(list)
+        spec_decoding_stats: SpecDecodingStats | None = None
+        kv_connector_stats: KVConnectorStats | None = (
+            kv_connector_output.kv_connector_stats if kv_connector_output else None
+        )
+        if kv_connector_stats and self.connector:
+            kv_stats = self.connector.get_kv_connector_stats()
+            if kv_stats:
+                kv_connector_stats = kv_connector_stats.aggregate(kv_stats)
+
+        failed_kv_load_req_ids = None
+        if kv_connector_output and kv_connector_output.invalid_block_ids:
+            # These blocks contain externally computed tokens that failed to
+            # load. Identify affected requests and adjust their computed token
+            # count to trigger recomputation of the invalid blocks.
+            failed_kv_load_req_ids = self._handle_invalid_blocks(
+                kv_connector_output.invalid_block_ids,
+                num_scheduled_tokens,
+            )
+
+        # NOTE(woosuk): As len(num_scheduled_tokens) can be up to 1K or more,
+        # the below loop can be a performance bottleneck. We should do our best
+        # to avoid expensive operations inside the loop.
+        stopped_running_reqs: set[Request] = set()
+        stopped_preempted_reqs: set[Request] = set()
+        for req_id, num_tokens_scheduled in num_scheduled_tokens.items():
+            assert num_tokens_scheduled > 0
+            if failed_kv_load_req_ids and req_id in failed_kv_load_req_ids:
+                # skip failed or rescheduled requests from KV load failure
+                continue
+            request = self.requests.get(req_id)
+            if request is None or request.is_finished():
+                # The request is already finished. This can happen if the
+                # request is aborted while the model is executing it (e.g.,
+                # in pipeline parallelism or in async scheduling).
+                # NOTE(Kuntai): When delay_free_blocks=True (for async KV
+                # cache transfer in KV connector), the aborted request will not
+                # be set to None (in order to finish async KV transfer).
+                # In this case, we use is_finished() to check.
+                continue
+
+            req_index = model_runner_output.req_id_to_index[req_id]
+            generated_token_ids = (
+                sampled_token_ids[req_index] if sampled_token_ids else []
+            )
+
+            scheduled_spec_token_ids = (
+                scheduler_output.scheduled_spec_decode_tokens.get(req_id)
+            )
+            if scheduled_spec_token_ids and generated_token_ids:
+                num_draft_tokens = len(scheduled_spec_token_ids)
+                num_accepted = len(generated_token_ids) - 1
+                num_rejected = num_draft_tokens - num_accepted
+                # num_computed_tokens represents the number of tokens
+                # processed in the current step, considering scheduled
+                # tokens and rejections. If some tokens are rejected,
+                # num_computed_tokens is decreased by the number of rejected
+                # tokens.
+                if request.num_computed_tokens > 0:
+                    request.num_computed_tokens -= num_rejected
+                # If async scheduling, num_output_placeholders also includes
+                # the scheduled spec tokens count and so is similarly adjusted.
+                if request.num_output_placeholders > 0:
+                    request.num_output_placeholders -= num_rejected
+                spec_decoding_stats = self.make_spec_decoding_stats(
+                    spec_decoding_stats,
+                    num_draft_tokens=num_draft_tokens,
+                    num_accepted_tokens=num_accepted,
+                    num_invalid_spec_tokens=scheduler_output.num_invalid_spec_tokens,
+                    request_id=req_id,
+                )
+
+            # Free encoder inputs only after the step has actually executed.
+            if request.has_encoder_inputs:
+                self._free_encoder_inputs(request)
+
+            stopped = False
+            new_logprobs = None
+            new_token_ids = generated_token_ids
+            pooler_output = pooler_outputs[req_index] if pooler_outputs else None
+            kv_transfer_params = None
+            status_before_stop = request.status
+
+            # Block masking: If sampling was skipped for this request due to
+            # pending compactions, execute them now (prefill just completed).
+            if (not new_token_ids and
+                scheduler_output.skip_sampling_req_ids and
+                req_id in scheduler_output.skip_sampling_req_ids and
+                self.block_masking_processor is not None and
+                request.block_masking_state is not None):
+                state = request.block_masking_state
+                if state.pending_compactions:
+                    compaction = state.get_compaction_range(
+                        self.block_masking_config.keep_last_n_blocks,
+                        mask_delimiters=self.block_masking_config.mask_delimiters,
+                        restart_mode=self.block_masking_config.restart_mode,
+                    )
+                    while compaction:
+                        start, end = compaction
+                        result = self.mask_token_span(
+                            request.request_id,
+                            start,
+                            end,
+                        )
+                        if (self.block_masking_config is not None and
+                            self.block_masking_config.debug):
+                            logger.info(
+                                "Block masking deferred compaction for %s: "
+                                "[%d, %d) -> %s",
+                                request.request_id, start, end, result
+                            )
+                        if state.pending_restart_rewind is not None:
+                            request.num_computed_tokens = (
+                                state.pending_restart_rewind)
+                            request.num_output_placeholders = 0
+                            if (self.block_masking_config is not None and
+                                self.block_masking_config.debug):
+                                logger.info(
+                                    "Block masking restart rewind for %s: "
+                                    "num_computed_tokens -> %d",
+                                    request.request_id,
+                                    state.pending_restart_rewind)
+                            state.pending_restart_rewind = None
+                        compaction = state.get_compaction_range(
+                            self.block_masking_config.keep_last_n_blocks,
+                            mask_delimiters=self.block_masking_config.mask_delimiters,
+                            restart_mode=self.block_masking_config.restart_mode,
+                        )
+                    state.deferred_compaction_scheduled = False
+                    request.num_output_placeholders = 0
+                    # After deferred compaction, _update_after_schedule may
+                    # have already incremented num_computed_tokens beyond
+                    # num_tokens. Reset to num_tokens - 1 so the scheduler
+                    # reschedules this request for decode (same pattern as
+                    # full prefix cache hit at line 2262).
+                    if request.num_computed_tokens >= request.num_tokens:
+                        request.num_computed_tokens = request.num_tokens - 1
+                    if (self.block_masking_config is not None and
+                        self.block_masking_config.debug):
+                        logger.info(
+                            "Block masking deferred done for %s: "
+                            "num_computed=%d, num_tokens=%d, "
+                            "compacted_tokens=%d, output_len=%d",
+                            request.request_id,
+                            request.num_computed_tokens,
+                            request.num_tokens,
+                            sum(end - start for start, end
+                                in request.compacted_spans),
+                            len(request.output_token_ids)
+                        )
+
+            # Check for stop and update request status.
+            if new_token_ids:
+                new_token_ids, stopped = self._update_request_with_output(
+                    request, new_token_ids
+                )
+            elif request.pooling_params and pooler_output is not None:
+                # Pooling stops as soon as there is output.
+                request.status = RequestStatus.FINISHED_STOPPED
+                stopped = True
+
+            if new_token_ids and self.structured_output_manager.should_advance(request):
+                struct_output_request = request.structured_output_request
+                assert struct_output_request is not None
+                assert struct_output_request.grammar is not None
+                if not struct_output_request.grammar.accept_tokens(  # type: ignore[union-attr]
+                    req_id, new_token_ids
+                ):
+                    logger.error(
+                        "Unexpected: grammar rejected tokens %s for request %s. "
+                        "Terminating request.",
+                        new_token_ids,
+                        req_id,
+                    )
+                    request.status = RequestStatus.FINISHED_ERROR
+                    request.resumable = False
+                    stopped = True
+
+            # Get routing data from ModelRunnerOutput (via worker D2H pipeline)
+            routed_experts = None
+            routed_experts_dict = getattr(
+                model_runner_output, "routed_experts_dict", None
+            )
+            if routed_experts_dict is not None and req_id in routed_experts_dict:
+                routed_experts = routed_experts_dict[req_id]
+            finish_reason = None
+            if stopped:
+                # Capture finish_reason BEFORE _handle_stopped_request, which may
+                # reset the status to WAITING for streaming requests that continue.
+                finish_reason = request.get_finished_reason()
+                finished = self._handle_stopped_request(request)
+                if finished:
+                    kv_transfer_params = self._free_request(request)
+
+                if status_before_stop == RequestStatus.RUNNING:
+                    stopped_running_reqs.add(request)
+                else:
+                    stopped_preempted_reqs.add(request)
+
+            # Extract sample logprobs if needed.
+            if (
+                request.sampling_params is not None
+                and request.sampling_params.num_logprobs is not None
+                and logprobs
+            ):
+                new_logprobs = logprobs.slice_request(req_index, len(new_token_ids))
+
+            if num_nans_in_logits is not None and req_id in num_nans_in_logits:
+                request.num_nans_in_logits = num_nans_in_logits[req_id]
+
+            # Get prompt logprobs for this request.
+            prompt_logprobs_tensors = prompt_logprobs_dict.get(req_id)
+            if (
+                new_token_ids
+                or pooler_output is not None
+                or kv_transfer_params
+                or stopped
+            ):
+                # Add EngineCoreOutput for this Request.
+                outputs[request.client_index].append(
+                    EngineCoreOutput(
+                        request_id=req_id,
+                        new_token_ids=new_token_ids,
+                        finish_reason=finish_reason,
+                        new_logprobs=new_logprobs,
+                        new_prompt_logprobs_tensors=prompt_logprobs_tensors,
+                        pooling_output=pooler_output,
+                        stop_reason=request.stop_reason,
+                        events=request.take_events(),
+                        prefill_stats=request.take_prefill_stats(),
+                        kv_transfer_params=kv_transfer_params,
+                        trace_headers=request.trace_headers,
+                        routed_experts=routed_experts,
+                        num_nans_in_logits=request.num_nans_in_logits,
+                    )
+                )
+            else:
+                # Invariant: EngineCore returns no partial prefill outputs.
+                assert not prompt_logprobs_tensors
+
+        # Remove the stopped requests from the running and waiting queues.
+        if stopped_running_reqs:
+            self.running = remove_all(self.running, stopped_running_reqs)
+        if stopped_preempted_reqs:
+            # This is a rare case and unlikely to impact performance.
+            self.waiting.remove_requests(stopped_preempted_reqs)
+
+        if failed_kv_load_req_ids and not self.recompute_kv_load_failures:
+            requests = [self.requests[req_id] for req_id in failed_kv_load_req_ids]
+            self.finish_requests(failed_kv_load_req_ids, RequestStatus.FINISHED_ERROR)
+            for request in requests:
+                outputs[request.client_index].append(
+                    EngineCoreOutput(
+                        request_id=request.request_id,
+                        new_token_ids=[],
+                        finish_reason=request.get_finished_reason(),
+                        events=request.take_events(),
+                        trace_headers=request.trace_headers,
+                    )
+                )
+
+        # KV Connector: update state for finished KV Transfers.
+        if kv_connector_output:
+            self._update_from_kv_xfer_finished(kv_connector_output)
+
+        # collect KV cache events from KV cache manager
+        events = self.kv_cache_manager.take_events()
+
+        # collect KV cache events from connector
+        if self.connector is not None:
+            connector_events = self.connector.take_events()
+            if connector_events:
+                if events is None:
+                    events = list(connector_events)
+                else:
+                    events.extend(connector_events)
+
+        # publish collected KV cache events
+        if events:
+            batch = KVEventBatch(ts=time.time(), events=events)
+            self.kv_event_publisher.publish(batch)
+
+        # Create EngineCoreOutputs for all clients that have requests with
+        # outputs in this step.
+        engine_core_outputs = {
+            client_index: EngineCoreOutputs(outputs=outs)
+            for client_index, outs in outputs.items()
+        }
+
+        finished_req_ids = self.finished_req_ids_dict
+        if finished_req_ids:
+            # Include ids of requests that finished since last outputs
+            # were sent.
+            for client_index, finished_set in finished_req_ids.items():
+                # Set finished request set in EngineCoreOutputs for this client.
+                if (eco := engine_core_outputs.get(client_index)) is not None:
+                    eco.finished_requests = finished_set
+                else:
+                    engine_core_outputs[client_index] = EngineCoreOutputs(
+                        finished_requests=finished_set
+                    )
+            finished_req_ids.clear()
+
+        if (
+            stats := self.make_stats(
+                spec_decoding_stats, kv_connector_stats, cudagraph_stats, perf_stats
+            )
+        ) is not None:
+            # Return stats to only one of the front-ends.
+            if (eco := next(iter(engine_core_outputs.values()), None)) is None:
+                # We must return the stats even if there are no request
+                # outputs this step.
+                engine_core_outputs[0] = eco = EngineCoreOutputs()
+            eco.scheduler_stats = stats
+
+        return engine_core_outputs
+
+    @staticmethod
+    def _is_blocked_waiting_status(status: RequestStatus) -> bool:
+        return status in (
+            RequestStatus.WAITING_FOR_STRUCTURED_OUTPUT_GRAMMAR,
+            RequestStatus.WAITING_FOR_REMOTE_KVS,
+            RequestStatus.WAITING_FOR_STREAMING_REQ,
+        )
+
+    def _enqueue_waiting_request(self, request: Request) -> None:
+        if self._is_blocked_waiting_status(request.status):
+            self.skipped_waiting.add_request(request)
+        else:
+            self.waiting.add_request(request)
+
+    def _select_waiting_queue_for_scheduling(self) -> RequestQueue | None:
+        if self.policy == SchedulingPolicy.FCFS:
+            return self.skipped_waiting or self.waiting or None
+
+        # PRIORITY mode: compare queue heads when both queues are non-empty.
+        if self.waiting and self.skipped_waiting:
+            waiting_req = self.waiting.peek_request()
+            skipped_req = self.skipped_waiting.peek_request()
+            return self.waiting if waiting_req < skipped_req else self.skipped_waiting
+
+        return self.waiting or self.skipped_waiting or None
+
+    def _handle_stopped_request(self, request: Request) -> bool:
+        """Return True if finished (can be False for resumable requests)."""
+        if not request.resumable:
+            return True
+
+        if request.streaming_queue:
+            update = request.streaming_queue.popleft()
+            if update is None:
+                # Streaming request finished.
+                return True
+            self._update_request_as_session(request, update)
+        else:
+            request.status = RequestStatus.WAITING_FOR_STREAMING_REQ
+            self.num_waiting_for_streaming_input += 1
+
+        self._enqueue_waiting_request(request)
+        return False
+
+    def _update_request_with_output(
+        self, request: Request, new_token_ids: list[int]
+    ) -> tuple[list[int], bool]:
+        # Append generated tokens and check for stop. Note that if
+        # a request is still being prefilled, we expect the model runner
+        # to return empty token ids for the request.
+        stopped = False
+
+        # Block masking: compact prompt blocks before first generated token
+        if (self.block_masking_processor is not None and
+            request.block_masking_state is not None and
+            len(request.output_token_ids) == 0 and
+            new_token_ids):
+            state = request.block_masking_state
+            if state.pending_compactions:
+                compaction = state.get_compaction_range(
+                    self.block_masking_config.keep_last_n_blocks,
+                    mask_delimiters=self.block_masking_config.mask_delimiters,
+                    restart_mode=self.block_masking_config.restart_mode,
+                )
+                while compaction:
+                    start, end = compaction
+                    result = self.mask_token_span(request.request_id, start, end)
+                    if (self.block_masking_config is not None and
+                        self.block_masking_config.debug):
+                        logger.info(
+                            "Block masking prompt compaction for %s: "
+                            "[%d, %d) -> %s",
+                            request.request_id, start, end, result,
+                        )
+                    if state.pending_restart_rewind is not None:
+                        request.num_computed_tokens = state.pending_restart_rewind
+                        request.num_output_placeholders = 0
+                        state.pending_restart_rewind = None
+                    compaction = state.get_compaction_range(
+                        self.block_masking_config.keep_last_n_blocks,
+                        mask_delimiters=self.block_masking_config.mask_delimiters,
+                        restart_mode=self.block_masking_config.restart_mode,
+                    )
+
+        for num_new, output_token_id in enumerate(new_token_ids, 1):
+            request.append_output_token_ids(output_token_id)
+
+            # Block masking: process token and trigger compaction if needed
+            if (self.block_masking_processor is not None and
+                request.block_masking_state is not None):
+                position = request.num_prompt_tokens + len(request.output_token_ids) - 1
+                compaction = self.block_masking_processor.process_token(
+                    request.block_masking_state, output_token_id, position)
+                if compaction:
+                    start, end = compaction
+                    result = self.mask_token_span(request.request_id, start, end)
+                    if (self.block_masking_config is not None and
+                        self.block_masking_config.debug):
+                        logger.info(
+                            "Block masking generated compaction for %s: "
+                            "[%d, %d) -> %s",
+                            request.request_id, start, end, result,
+                        )
+                    if (request.block_masking_state.pending_restart_rewind
+                            is not None):
+                        request.num_computed_tokens = (
+                            request.block_masking_state.pending_restart_rewind)
+                        request.num_output_placeholders = 0
+                        request.block_masking_state.pending_restart_rewind = None
+
+            # Check for stop and update request state.
+            # This must be called before we make the EngineCoreOutput.
+            stopped = check_stop(request, self.max_model_len)
+            if stopped:
+                del new_token_ids[num_new:]  # Trim new tokens if needed.
+                break
+        return new_token_ids, stopped
+
+    def _free_encoder_inputs(self, request: Request) -> None:
+        cached_encoder_input_ids = self.encoder_cache_manager.get_cached_input_ids(
+            request
+        )
+        # OPTIMIZATION: Avoid list(set) if the set is empty.
+        if not cached_encoder_input_ids:
+            return
+
+        # Here, we use list(set) to avoid modifying the set while iterating
+        # over it.
+        for input_id in list(cached_encoder_input_ids):
+            mm_feature = request.mm_features[input_id]
+            start_pos = mm_feature.mm_position.offset
+            num_tokens = mm_feature.mm_position.length
+            if self.is_encoder_decoder and request.num_computed_tokens > 0:
+                # With Whisper, as soon as we've generated a single token,
+                # we know we're done with the encoder input. Cross Attention
+                # KVs have been calculated and cached already.
+                self.encoder_cache_manager.free_encoder_input(request, input_id)
+            elif start_pos + num_tokens <= request.num_computed_tokens:
+                # The encoder output is already processed and stored
+                # in the decoder's KV cache.
+                self.encoder_cache_manager.free_encoder_input(request, input_id)
+
+    def update_draft_token_ids(self, draft_token_ids: DraftTokenIds) -> None:
+        for req_id, spec_token_ids in zip(
+            draft_token_ids.req_ids,
+            draft_token_ids.draft_token_ids,
+        ):
+            request = self.requests.get(req_id)
+            if request is None or request.is_finished():
+                # The request may have been finished. Skip.
+                continue
+
+            if request.is_prefill_chunk:
+                # Ignore draft tokens for prefill chunks.
+                if request.spec_token_ids:
+                    request.spec_token_ids = []
+                continue
+
+            # Add newly generated spec token ids to the request.
+            if self.structured_output_manager.should_advance(request):
+                metadata = request.structured_output_request
+                spec_token_ids = metadata.grammar.validate_tokens(spec_token_ids)  # type: ignore[union-attr]
+            request.spec_token_ids = spec_token_ids
+
+    def update_draft_token_ids_in_output(
+        self, draft_token_ids: DraftTokenIds, scheduler_output: SchedulerOutput
+    ) -> None:
+        num_invalid_spec_tokens: dict[str, int] = {}
+
+        sched_spec_tokens = scheduler_output.scheduled_spec_decode_tokens
+        for req_id, spec_token_ids in zip(
+            draft_token_ids.req_ids,
+            draft_token_ids.draft_token_ids,
+        ):
+            request = self.requests.get(req_id)
+            if request is None or request.is_finished():
+                # The request may have been finished. Skip.
+                continue
+
+            placeholder_spec_tokens = sched_spec_tokens.get(req_id)
+            if not placeholder_spec_tokens:
+                continue
+
+            orig_num_spec_tokens = len(placeholder_spec_tokens)
+            # Trim drafts to scheduled number of spec tokens
+            # (needed for chunked prefill case for example).
+            del spec_token_ids[orig_num_spec_tokens:]
+            # Filter out spec tokens which do not adhere to the grammar.
+            if self.structured_output_manager.should_advance(request):
+                metadata = request.structured_output_request
+                assert metadata is not None and metadata.grammar is not None
+                spec_token_ids = metadata.grammar.validate_tokens(spec_token_ids)
+            # Pad to original number of spec tokens.
+            num_invalid_tokens = orig_num_spec_tokens - len(spec_token_ids)
+            if num_invalid_tokens:
+                spec_token_ids.extend([-1] * num_invalid_tokens)
+                num_invalid_spec_tokens[req_id] = num_invalid_tokens
+
+            sched_spec_tokens[req_id] = spec_token_ids
+
+        scheduler_output.num_invalid_spec_tokens = num_invalid_spec_tokens
+
+    def get_request_counts(self) -> tuple[int, int]:
+        """Returns (num_running_reqs, num_waiting_reqs)."""
+        return len(self.running), len(self.waiting) + len(self.skipped_waiting)
+
+    def add_request(self, request: Request) -> None:
+        existing = self.requests.get(request.request_id)
+        if existing is not None:
+            update = StreamingUpdate.from_request(request)
+            if existing.status != RequestStatus.WAITING_FOR_STREAMING_REQ:
+                assert existing.streaming_queue is not None, "duplicate request id"
+                # Queue next input chunk (or finished sentinel).
+                existing.streaming_queue.append(update)
+            elif update is not None:
+                # Commence next input chunk.
+                self._update_request_as_session(existing, update)
+            else:
+                # Streaming-input session finished.
+                self.finish_requests(request.request_id, RequestStatus.FINISHED_ABORTED)
+        else:
+            if request.resumable:
+                request.streaming_queue = deque()
+            # Initialize block masking state if enabled
+            if self.block_masking_processor is not None:
+                request.block_masking_state = (
+                    self.block_masking_processor.create_state())
+                if request.prompt_token_ids:
+                    self.block_masking_processor.process_prompt_tokens(
+                        request.block_masking_state,
+                        request.prompt_token_ids,
+                    )
+
+            self._enqueue_waiting_request(request)
+            self.requests[request.request_id] = request
+            if self.log_stats:
+                request.record_event(EngineCoreEventType.QUEUED)
+
+    def finish_requests(
+        self, request_ids: str | Iterable[str] | None, finished_status: RequestStatus
+    ) -> list[tuple[str, int]]:
+        """Handles the finish signal from outside the scheduler.
+
+        For example, the API server can abort a request when the client
+        disconnects.
+
+        If request_ids is None, all requests will be finished.
+
+        Returns:
+            Tuple of (req_id, client_index) for requests that were aborted. Will not
+            include any that were already finished.
+        """
+        assert RequestStatus.is_finished(finished_status)
+        if isinstance(request_ids, str):
+            request_ids = (request_ids,)
+        elif request_ids is not None:
+            request_ids = set(request_ids)
+        else:
+            request_ids = self.requests.keys()
+
+        running_requests_to_remove = set()
+        waiting_requests_to_remove = []
+        valid_requests = []
+
+        # First pass: collect requests to remove from queues
+        for req_id in request_ids:
+            request = self.requests.get(req_id)
+            if request is None or request.is_finished():
+                # Invalid request ID.
+                continue
+
+            valid_requests.append(request)
+            if request.status == RequestStatus.RUNNING:
+                running_requests_to_remove.add(request)
+            else:
+                if request.status == RequestStatus.WAITING_FOR_STREAMING_REQ:
+                    self.num_waiting_for_streaming_input -= 1
+                waiting_requests_to_remove.append(request)
+
+        # Remove all requests from queues at once for better efficiency
+        if running_requests_to_remove:
+            self.running = remove_all(self.running, running_requests_to_remove)
+        if waiting_requests_to_remove:
+            self.waiting.remove_requests(waiting_requests_to_remove)
+            self.skipped_waiting.remove_requests(waiting_requests_to_remove)
+
+        # Second pass: set status and free requests
+        for request in valid_requests:
+            delay_free_blocks = False
+            if request.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
+                delay_free_blocks = (
+                    request.request_id not in self.finished_recving_kv_req_ids
+                )
+                self.finished_recving_kv_req_ids.discard(request.request_id)
+                self.failed_recving_kv_req_ids.discard(request.request_id)
+
+            request.status = finished_status
+            self._free_request(request, delay_free_blocks=delay_free_blocks)
+
+        return [(r.request_id, r.client_index) for r in valid_requests]
+
+    def _free_request(
+        self, request: Request, delay_free_blocks: bool = False
+    ) -> dict[str, Any] | None:
+        assert request.is_finished()
+
+        connector_delay_free_blocks, kv_xfer_params = self._connector_finished(request)
+        self.encoder_cache_manager.free(request)
+        request_id = request.request_id
+        self.finished_req_ids.add(request_id)
+        if self.finished_req_ids_dict is not None:
+            self.finished_req_ids_dict[request.client_index].add(request_id)
+
+        delay_free_blocks |= connector_delay_free_blocks
+        if not delay_free_blocks:
+            self._free_blocks(request)
+
+        return kv_xfer_params
+
+    def _free_blocks(self, request: Request):
+        assert request.is_finished()
+        self.kv_cache_manager.free(request)
+        del self.requests[request.request_id]
+
+    @property
+    def pause_state(self) -> PauseState:
+        return self._pause_state
+
+    def set_pause_state(self, pause_state: PauseState) -> None:
+        self._pause_state = pause_state
+
+    def get_num_unfinished_requests(self) -> int:
+        if self._pause_state == PauseState.PAUSED_ALL:
+            return 0
+        if self._pause_state == PauseState.PAUSED_NEW:
+            return len(self.running)
+        num_waiting = (
+            len(self.waiting)
+            + len(self.skipped_waiting)
+            - self.num_waiting_for_streaming_input
+        )
+        return num_waiting + len(self.running)
+
+    def has_finished_requests(self) -> bool:
+        return len(self.finished_req_ids) > 0
+
+    def reset_prefix_cache(
+        self, reset_running_requests: bool = False, reset_connector: bool = False
+    ) -> bool:
+        """Reset the KV prefix cache.
+
+        If reset_running_requests is True, all the running requests will be
+        preempted and moved to the waiting queue.
+        Otherwise, this method will only reset the KV prefix cache when there
+        is no running requests taking KV cache.
+        """
+        if reset_running_requests:
+            # For logging.
+            timestamp = time.monotonic()
+            # Invalidate all the current running requests KV's by pushing them to
+            # the waiting queue. In this case, we can reduce the ref count of all
+            # the kv blocks to 0 and thus we can make sure the reset is successful.
+            # Preempt in reverse order so the requests will be added back to the
+            # running queue in FIFO order.
+            while self.running:
+                request = self.running.pop()
+                self._preempt_request(request, timestamp)
+                # NOTE(zhuohan): For async scheduling, we need to discard the latest
+                # output token on the fly to avoid a redundant repetitive output token.
+                request.num_output_placeholders = 0
+                request.discard_latest_async_tokens = True
+
+            # Clear scheduled request ids cache. Since we are forcing preemption
+            # + resumption in the same step, we must act as if these requests were
+            # not scheduled in the prior step. They will be flushed from the
+            # persistent batch in the model runner.
+            self.prev_step_scheduled_req_ids.clear()
+
+        reset_successful = self.kv_cache_manager.reset_prefix_cache()
+        if reset_running_requests and not reset_successful:
+            raise RuntimeError(
+                "Failed to reset KV cache even when all the running requests are "
+                "preempted and moved to the waiting queue. This is likely due to "
+                "the presence of running requests waiting for remote KV transfer, "
+                "which is not supported yet."
+            )
+
+        if reset_connector:
+            reset_successful = self.reset_connector_cache() and reset_successful
+
+        return reset_successful
+
+    def reset_connector_cache(self) -> bool:
+        if self.connector is None:
+            logger.warning("reset_connector called but no KV connector is configured.")
+            return False
+
+        if self.connector.reset_cache() is False:
+            return False
+
+        if self.log_stats:
+            assert self.connector_prefix_cache_stats is not None
+            self.connector_prefix_cache_stats.reset = True
+
+        return True
+
+    def reset_encoder_cache(self) -> None:
+        """Reset the encoder cache to invalidate all cached encoder outputs.
+
+        This should be called when model weights are updated to ensure
+        stale vision embeddings are not reused.
+        """
+        self.encoder_cache_manager.reset()
+
+    @staticmethod
+    def _merge_spans(
+        spans: list[tuple[int, int]],
+    ) -> list[tuple[int, int]]:
+        """Merge overlapping or adjacent spans."""
+        if not spans:
+            return []
+        sorted_spans = sorted(spans)
+        merged: list[tuple[int, int]] = [sorted_spans[0]]
+        for start, end in sorted_spans[1:]:
+            prev_start, prev_end = merged[-1]
+            if start <= prev_end:
+                merged[-1] = (prev_start, max(prev_end, end))
+            else:
+                merged.append((start, end))
+        return merged
+
+    def mask_token_span(
+        self,
+        request_id: str,
+        start_position: int,
+        end_position: int,
+    ) -> SpanRemovalResult:
+        """Mask a span of tokens and compact the KV cache in one step."""
+        request = self.requests.get(request_id)
+        if request is None:
+            return SpanRemovalResult(
+                success=False, tokens_removed=0, blocks_freed=0,
+                error_message=f"Request {request_id} not found")
+
+        if start_position < 0 or end_position <= start_position:
+            return SpanRemovalResult(
+                success=False, tokens_removed=0, blocks_freed=0,
+                error_message="Invalid span: must have 0 <= start < end")
+
+        if end_position > request.num_computed_tokens:
+            return SpanRemovalResult(
+                success=False, tokens_removed=0, blocks_freed=0,
+                error_message=(
+                    f"end_position ({end_position}) exceeds computed tokens "
+                    f"({request.num_computed_tokens})"))
+
+        new_span = (start_position, end_position)
+        all_inactive = self._merge_spans(
+            request.compacted_spans + [new_span])
+
+        num_computed = request.num_computed_tokens
+        active_logical: list[int] = []
+        prev_end = 0
+        for s, e in all_inactive:
+            if s >= num_computed:
+                break
+            active_logical.extend(range(prev_end, min(s, num_computed)))
+            prev_end = e
+        if prev_end < num_computed:
+            active_logical.extend(range(prev_end, num_computed))
+
+        if not active_logical:
+            return SpanRemovalResult(
+                success=False, tokens_removed=0, blocks_freed=0,
+                error_message="Cannot compact: all tokens would be removed")
+
+        active_physical = [
+            request.logical_to_physical(p) for p in active_logical]
+
+        blocks_freed, copy_ops = self.kv_cache_manager.compact_kv_cache(
+            request_id, active_physical)
+
+        if copy_ops:
+            existing = self.pending_kv_copy_operations.get(request_id)
+            if existing is not None:
+                existing.extend(copy_ops)
+            else:
+                self.pending_kv_copy_operations[request_id] = copy_ops
+
+        num_active = len(active_physical)
+        blocks_needed = (num_active + self.block_size - 1) // self.block_size
+        self.pending_block_table_truncations[request_id] = (blocks_needed,)
+
+        request.compacted_spans = self._merge_spans(
+            request.compacted_spans + [new_span])
+
+        tokens_masked = end_position - start_position
+        return SpanRemovalResult(
+            success=True, tokens_removed=tokens_masked,
+            blocks_freed=blocks_freed)
+
+    def make_stats(
+        self,
+        spec_decoding_stats: SpecDecodingStats | None = None,
+        kv_connector_stats: KVConnectorStats | None = None,
+        cudagraph_stats: CUDAGraphStat | None = None,
+        perf_stats: PerfStats | None = None,
+    ) -> SchedulerStats | None:
+        if not self.log_stats:
+            return None
+        prefix_cache_stats = self.kv_cache_manager.make_prefix_cache_stats()
+        assert prefix_cache_stats is not None
+        connector_prefix_cache_stats: PrefixCacheStats | None = None
+        if self.connector_prefix_cache_stats is not None:
+            connector_prefix_cache_stats = self.connector_prefix_cache_stats
+            self.connector_prefix_cache_stats = PrefixCacheStats()
+        eviction_events = (
+            self.kv_metrics_collector.drain_events()
+            if self.kv_metrics_collector is not None
+            else []
+        )
+        spec_stats = spec_decoding_stats
+        connector_stats_payload = (
+            kv_connector_stats.data if kv_connector_stats else None
+        )
+        return SchedulerStats(
+            num_running_reqs=len(self.running),
+            num_waiting_reqs=len(self.waiting),
+            num_skipped_waiting_reqs=len(self.skipped_waiting),
+            kv_cache_usage=self.kv_cache_manager.usage,
+            prefix_cache_stats=prefix_cache_stats,
+            connector_prefix_cache_stats=connector_prefix_cache_stats,
+            kv_cache_eviction_events=eviction_events,
+            spec_decoding_stats=spec_stats,
+            kv_connector_stats=connector_stats_payload,
+            cudagraph_stats=cudagraph_stats,
+            perf_stats=perf_stats,
+        )
+
+    def make_spec_decoding_stats(
+        self,
+        spec_decoding_stats: SpecDecodingStats | None,
+        num_draft_tokens: int,
+        num_accepted_tokens: int,
+        num_invalid_spec_tokens: dict[str, int] | None,
+        request_id: str,
+    ) -> SpecDecodingStats | None:
+        if not self.log_stats or not num_draft_tokens:
+            return None
+        if spec_decoding_stats is None:
+            spec_decoding_stats = SpecDecodingStats.new(self.num_spec_tokens)
+        if num_invalid_spec_tokens:
+            num_draft_tokens -= num_invalid_spec_tokens.get(request_id, 0)
+        spec_decoding_stats.observe_draft(
+            num_draft_tokens=num_draft_tokens, num_accepted_tokens=num_accepted_tokens
+        )
+        return spec_decoding_stats
+
+    def shutdown(self) -> None:
+        if self.kv_event_publisher:
+            self.kv_event_publisher.shutdown()
+        if self.connector is not None:
+            self.connector.shutdown()
+
+    ########################################################################
+    # KV Connector Related Methods
+    ########################################################################
+
+    def get_kv_connector(self) -> KVConnectorBase_V1 | None:
+        return self.connector
+
+    def _connector_finished(
+        self, request: Request
+    ) -> tuple[bool, dict[str, Any] | None]:
+        """
+        Invoke the KV connector request_finished() method if applicable.
+
+        Returns optional kv transfer parameters to be included with the
+        request outputs.
+        """
+        if self.connector is None:
+            return False, None
+
+        # Free any out-of-window prefix blocks before we hand the block table to
+        # the connector.
+        self.kv_cache_manager.remove_skipped_blocks(
+            request_id=request.request_id,
+            total_computed_tokens=request.num_computed_tokens,
+        )
+
+        block_ids = self.kv_cache_manager.get_block_ids(request.request_id)
+
+        if not isinstance(self.connector, SupportsHMA):
+            # NOTE(Kuntai): We should deprecate this code path after we enforce
+            # all connectors to support HMA.
+            # Hybrid memory allocator should be already turned off for this
+            # code path, but let's double-check here.
+            assert len(self.kv_cache_config.kv_cache_groups) == 1
+            return self.connector.request_finished(request, block_ids[0])
+
+        return self.connector.request_finished_all_groups(request, block_ids)
+
+    def _update_waiting_for_remote_kv(self, request: Request) -> None:
+        """
+        KV Connector: update request state after async recv is finished.
+
+        When the kv transfer is ready, we cache the blocks
+        and the request state will be moved back to WAITING from
+        WAITING_FOR_REMOTE_KV.
+        """
+        assert self.connector is not None
+
+        if request.request_id in self.failed_recving_kv_req_ids:
+            # Request had KV load failures; num_computed_tokens was already
+            # updated in _update_requests_with_invalid_blocks
+            if request.num_computed_tokens:
+                # Cache any valid computed tokens.
+                self.kv_cache_manager.cache_blocks(request, request.num_computed_tokens)
+            else:
+                # No valid computed tokens, release allocated blocks.
+                # There may be a local cache hit on retry.
+                self.kv_cache_manager.free(request)
+
+            self.failed_recving_kv_req_ids.remove(request.request_id)
+        else:
+            # Now that the blocks are ready, actually cache them.
+            # This will cache the blocks iff caching is enabled.
+            self.kv_cache_manager.cache_blocks(request, request.num_computed_tokens)
+
+            # on a full prompt hit, we need to re-compute the last token
+            # in order to be able to sample the next token
+            if request.num_computed_tokens == request.num_tokens:
+                request.num_computed_tokens = request.num_tokens - 1
+
+        self.finished_recving_kv_req_ids.remove(request.request_id)
+
+    def _try_promote_blocked_waiting_request(self, request: Request) -> bool:
+        """
+        Try to promote a blocked waiting request back to schedulable states.
+        """
+        if request.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
+            # finished_recving_kv_req_ids is populated during
+            # update_from_output(), based on worker-side connector signals
+            # in KVConnectorOutput.finished_recving
+            if request.request_id not in self.finished_recving_kv_req_ids:
+                return False
+            self._update_waiting_for_remote_kv(request)
+            if request.num_preemptions:
+                request.status = RequestStatus.PREEMPTED
+            else:
+                request.status = RequestStatus.WAITING
+            return True
+
+        if request.status == RequestStatus.WAITING_FOR_STRUCTURED_OUTPUT_GRAMMAR:
+            structured_output_req = request.structured_output_request
+            if not (structured_output_req and structured_output_req.grammar):
+                return False
+            request.status = RequestStatus.WAITING
+            return True
+
+        if request.status == RequestStatus.WAITING_FOR_STREAMING_REQ:
+            assert not request.streaming_queue
+            return False
+
+        raise AssertionError(
+            "Unexpected blocked waiting status in promotion: "
+            f"{request.status.name} for request {request.request_id}"
+        )
+
+    def _update_from_kv_xfer_finished(self, kv_connector_output: KVConnectorOutput):
+        """
+        KV Connector: update the scheduler state based on the output.
+
+        The Worker side connectors add finished_recving and
+        finished_sending reqs to the output.
+        * if finished_sending: free the blocks
+        # if finished_recving: add to state so we can
+            schedule the request during the next step.
+        """
+
+        if self.connector is not None:
+            self.connector.update_connector_output(kv_connector_output)
+
+        # KV Connector:: update recv and send status from last step.
+        for req_id in kv_connector_output.finished_recving or ():
+            logger.debug("Finished recving KV transfer for request %s", req_id)
+            assert req_id in self.requests
+            req = self.requests[req_id]
+            if req.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
+                self.finished_recving_kv_req_ids.add(req_id)
+            else:
+                assert RequestStatus.is_finished(req.status)
+                self._free_blocks(self.requests[req_id])
+        for req_id in kv_connector_output.finished_sending or ():
+            logger.debug("Finished sending KV transfer for request %s", req_id)
+            assert req_id in self.requests
+            self._free_blocks(self.requests[req_id])
+
+    def _update_requests_with_invalid_blocks(
+        self,
+        requests: Iterable[Request],
+        invalid_block_ids: set[int],
+        num_scheduled_tokens: dict[str, int],
+        evict_blocks: bool = True,
+    ) -> tuple[set[str], int, set[int]]:
+        """
+        Identify and update requests affected by invalid KV cache blocks.
+
+        This method scans the given requests, detects those with invalid blocks
+        and adjusts their `num_computed_tokens` to the longest valid prefix.
+        For observability, it also accumulates the total number of tokens that
+        will need to be recomputed across all affected requests.
+
+        Args:
+            requests: The set of requests to scan for invalid blocks.
+            invalid_block_ids: IDs of invalid blocks.
+            num_scheduled_tokens: req_id -> number of scheduled tokens.
+            evict_blocks: Whether to collect blocks for eviction (False for
+                async requests which aren't cached yet).
+
+        Returns:
+            tuple:
+                - affected_req_ids (set[str]): IDs of requests impacted by
+                invalid blocks.
+                - total_affected_tokens (int): Total number of tokens that must
+                be recomputed across all affected requests.
+                - blocks_to_evict (set[int]): Block IDs to evict from cache,
+                including invalid blocks and downstream dependent blocks.
+        """
+        affected_req_ids: set[str] = set()
+        total_affected_tokens = 0
+        blocks_to_evict: set[int] = set()
+        # If a block is invalid and shared by multiple requests in the batch,
+        # these requests must be rescheduled, but only the first will recompute
+        # it. This set tracks blocks already marked for recomputation.
+        marked_invalid_block_ids: set[int] = set()
+        for request in requests:
+            is_affected = False
+            marked_invalid_block = False
+            req_id = request.request_id
+            # TODO (davidb): add support for hybrid memory allocator
+            (req_block_ids,) = self.kv_cache_manager.get_block_ids(req_id)
+            # We iterate only over blocks that may contain externally computed
+            # tokens
+            req_num_computed_tokens = (
+                request.num_computed_tokens - num_scheduled_tokens.get(req_id, 0)
+            )
+
+            req_num_computed_blocks = (
+                req_num_computed_tokens + self.block_size - 1
+            ) // self.block_size
+            for idx, block_id in zip(range(req_num_computed_blocks), req_block_ids):
+                if block_id not in invalid_block_ids:
+                    continue
+
+                is_affected = True
+
+                if block_id in marked_invalid_block_ids:
+                    # This invalid block is shared with a previous request
+                    # and was already marked for recomputation.
+                    # This means this request can still consider this block
+                    # as computed when rescheduled.
+                    # Currently this only applies to sync loading; Async
+                    # loading does not yet support block sharing
+                    continue
+
+                marked_invalid_block_ids.add(block_id)
+
+                if marked_invalid_block:
+                    # This request has already marked an invalid block for
+                    # recomputation and updated its num_computed_tokens.
+                    continue
+
+                marked_invalid_block = True
+                # Truncate the computed tokens at the first failed block
+                request.num_computed_tokens = idx * self.block_size
+                num_affected_tokens = (
+                    req_num_computed_tokens - request.num_computed_tokens
+                )
+                total_affected_tokens += num_affected_tokens
+
+                # collect invalid block and all downstream dependent blocks
+                if evict_blocks:
+                    blocks_to_evict.update(req_block_ids[idx:])
+
+            if is_affected:
+                if not marked_invalid_block:
+                    # All invalid blocks of this request are shared with
+                    # previous requests and will be recomputed by them.
+                    # Revert to considering only cached tokens as computed.
+                    # Currently this only applies to sync loading; Async
+                    # loading does not yet support block sharing
+                    total_affected_tokens += (
+                        request.num_computed_tokens - req_num_computed_tokens
+                    )
+                    request.num_computed_tokens = req_num_computed_tokens
+
+                affected_req_ids.add(request.request_id)
+
+        return affected_req_ids, total_affected_tokens, blocks_to_evict
+
+    def _handle_invalid_blocks(
+        self, invalid_block_ids: set[int], num_scheduled_tokens: dict[str, int]
+    ) -> set[str]:
+        """
+        Handle requests affected by invalid KV cache blocks.
+
+        Returns:
+            Set of affected request IDs to skip in update_from_output main loop.
+        """
+        should_fail = not self.recompute_kv_load_failures
+
+        # handle async KV loads (not cached yet, evict_blocks=False)
+        async_load_reqs = (
+            req
+            for req in self.skipped_waiting
+            if req.status == RequestStatus.WAITING_FOR_REMOTE_KVS
+        )
+        async_failed_req_ids, num_failed_tokens, _ = (
+            self._update_requests_with_invalid_blocks(
+                async_load_reqs,
+                invalid_block_ids,
+                num_scheduled_tokens,
+                evict_blocks=False,
+            )
+        )
+
+        total_failed_requests = len(async_failed_req_ids)
+        total_failed_tokens = num_failed_tokens
+
+        # handle sync loads (may be cached, collect blocks for eviction)
+        sync_failed_req_ids, num_failed_tokens, sync_blocks_to_evict = (
+            self._update_requests_with_invalid_blocks(
+                self.running, invalid_block_ids, num_scheduled_tokens, evict_blocks=True
+            )
+        )
+
+        total_failed_requests += len(sync_failed_req_ids)
+        total_failed_tokens += num_failed_tokens
+
+        if not total_failed_requests:
+            return set()
+
+        # evict invalid blocks and downstream dependent blocks from cache
+        # only when not using recompute policy (where blocks will be recomputed
+        # and reused by other requests sharing them)
+        if sync_blocks_to_evict and not self.recompute_kv_load_failures:
+            self.kv_cache_manager.evict_blocks(sync_blocks_to_evict)
+
+        if should_fail:
+            all_failed_req_ids = async_failed_req_ids | sync_failed_req_ids
+            logger.error(
+                "Failing %d request(s) due to KV load failure "
+                "(failure_policy=fail, %d tokens affected). Request IDs: %s",
+                total_failed_requests,
+                total_failed_tokens,
+                all_failed_req_ids,
+            )
+            return all_failed_req_ids
+
+        logger.warning(
+            "Recovered from KV load failure: "
+            "%d request(s) rescheduled (%d tokens affected).",
+            total_failed_requests,
+            total_failed_tokens,
+        )
+
+        # Mark async requests with KV load failures for retry once loading completes
+        self.failed_recving_kv_req_ids |= async_failed_req_ids
+        # Return sync affected IDs to skip in update_from_output
+        return sync_failed_req_ids

--- a/overlays/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/overlays/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1,0 +1,1234 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import itertools
+from abc import ABC, abstractmethod
+from collections import defaultdict
+from collections.abc import Sequence
+
+from vllm.utils.math_utils import cdiv
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_utils import (
+    BlockHashList,
+    BlockHashWithGroupId,
+    KVCacheBlock,
+)
+from vllm.v1.kv_cache_interface import (
+    ChunkedLocalAttentionSpec,
+    CrossAttentionSpec,
+    FullAttentionSpec,
+    KVCacheSpec,
+    MambaSpec,
+    MLAAttentionSpec,
+    SinkFullAttentionSpec,
+    SlidingWindowMLASpec,
+    SlidingWindowSpec,
+    TQFullAttentionSpec,
+)
+from vllm.v1.request import Request
+
+
+class SingleTypeKVCacheManager(ABC):
+    """
+    An abstract base class for a manager that handle the kv cache management
+    logic of one specific type of attention layer.
+    """
+
+    def __init__(
+        self,
+        kv_cache_spec: KVCacheSpec,
+        block_pool: BlockPool,
+        enable_caching: bool,
+        kv_cache_group_id: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+        max_admission_blocks_per_request: int | None = None,
+    ) -> None:
+        """
+        Initializes the SingleTypeKVCacheManager.
+        Args:
+            kv_cache_spec: The kv_cache_spec for this manager.
+            block_pool: The block pool.
+            kv_cache_group_id: The id of the kv cache group of this manager.
+            max_admission_blocks_per_request: Recycling-aware per-request
+                block cap used by `get_num_blocks_to_allocate`. Only set for
+                spec types that recycle blocks across chunks (SWA,
+                chunked-local); `None` (the default) means no cap, which is
+                correct for full-attention-style specs that hold every
+                block until the request finishes.
+        """
+        self.block_size = kv_cache_spec.block_size
+        self.dcp_world_size = dcp_world_size
+        self.pcp_world_size = pcp_world_size
+        if dcp_world_size * pcp_world_size > 1:
+            self.block_size *= dcp_world_size * pcp_world_size
+        self.kv_cache_spec = kv_cache_spec
+        self.block_pool = block_pool
+        self.enable_caching = enable_caching
+        self._max_admission_blocks_per_request = max_admission_blocks_per_request
+        self.new_block_ids: list[int] = []
+
+        # Mapping from request ID to blocks to track the blocks allocated
+        # for each request, so that we can free the blocks when the request
+        # is finished.
+        self.req_to_blocks: defaultdict[str, list[KVCacheBlock]] = defaultdict(list)
+
+        # {req_id: The number of cached blocks for this given request}
+        # This is used to track the number of cached blocks for each request.
+        # This is only used to track the RUNNING requests, we do not track the
+        # data for preempted ones.
+        self.num_cached_block: dict[str, int] = {}
+
+        self.kv_cache_group_id = kv_cache_group_id
+        self._null_block = block_pool.null_block
+
+    @classmethod
+    def _get_num_evictable_blocks(cls, blocks: Sequence[KVCacheBlock]):
+        return sum(blk.ref_cnt == 0 and not blk.is_null for blk in blocks)
+
+    def get_num_blocks_to_allocate(
+        self,
+        request_id: str,
+        num_tokens: int,
+        new_computed_blocks: Sequence[KVCacheBlock],
+        total_computed_tokens: int,
+        num_tokens_main_model: int,
+        apply_admission_cap: bool = False,
+    ) -> int:
+        """
+        Get the number of blocks needed to be allocated for the request.
+
+        Args:
+            request_id: The request ID.
+            num_tokens: The total number of tokens that need a slot (including
+                tokens that are already allocated).
+            new_computed_blocks: The new computed blocks just hitting the
+                prefix caching.
+            total_computed_tokens: Include both local and external computed
+                tokens.
+            num_tokens_main_model: The number of tokens for the main model (aka target
+                model in spec decode). w/o spec decode, it is num_tokens;
+                with spec decode, it is num_tokens - num_lookahead_tokens.
+            apply_admission_cap: If True, clamp by `num_required_blocks` by
+                `_max_admission_blocks_per_request`for recycling-aware specs
+                (SWA, chunked-local).
+
+        Returns:
+            The number of blocks to allocate.
+        """
+
+        num_required_blocks = cdiv(num_tokens, self.block_size)
+        if apply_admission_cap and self._max_admission_blocks_per_request is not None:
+            # Recycling-aware specs (SWA, chunked-local) cap the per-request
+            # reservation here so admission matches the startup pool sizer
+            # (`SlidingWindowSpec.max_admission_blocks_per_request` / its
+            # chunked-local counterpart). `remove_skipped_blocks` runs from
+            # `allocate_slots` before each chunk's `get_num_blocks_to_allocate`,
+            # so per-request peak real-held blocks <= this cap, which keeps
+            # `sum(reservations) <= pool` <=> `sum(peak_real_held) <= pool`.
+            # Drift between the two would re-introduce the deadlock from
+            # issue #39734 or, worse, mid-prefill OOM.
+            num_required_blocks = min(
+                num_required_blocks, self._max_admission_blocks_per_request
+            )
+        num_req_blocks = len(self.req_to_blocks.get(request_id, ()))
+
+        if request_id in self.num_cached_block:
+            # Fast-path: a running request won't have any new prefix-cache hits.
+            assert len(new_computed_blocks) == 0
+            # NOTE: With speculative decoding, request's blocks may be allocated
+            # for draft tokens which are later rejected. In this case,
+            # num_required_blocks may be smaller than num_req_blocks.
+            return max(num_required_blocks - num_req_blocks, 0)
+
+        num_skipped_tokens = self.get_num_skipped_tokens(total_computed_tokens)
+        num_local_computed_blocks = len(new_computed_blocks) + num_req_blocks
+        # Number of whole blocks that are skipped by the attention window.
+        # If nothing is skipped, this is 0.
+        num_skipped_blocks = num_skipped_tokens // self.block_size
+        # We need blocks for the non-skipped suffix. If there are still
+        # local-computed blocks inside the window, they contribute to the
+        # required capacity; otherwise, skipped blocks dominate.
+        num_new_blocks = max(
+            num_required_blocks - max(num_skipped_blocks, num_local_computed_blocks),
+            0,
+        )
+
+        # Among the `new_computed_blocks`, the first `num_skipped_blocks` worth
+        # of blocks are skipped; `num_req_blocks` of those may already be in
+        # `req_to_blocks`, so only skip the remainder from `new_computed_blocks`.
+        num_skipped_new_computed_blocks = max(0, num_skipped_blocks - num_req_blocks)
+
+        # If a computed block is an eviction candidate (in the free queue and
+        # ref_cnt == 0), it will be removed from the free queue when touched by
+        # the allocated request, so we must count it in the free-capacity check.
+        num_evictable_blocks = self._get_num_evictable_blocks(
+            new_computed_blocks[num_skipped_new_computed_blocks:]
+        )
+        return num_new_blocks + num_evictable_blocks
+
+    def allocate_new_computed_blocks(
+        self,
+        request_id: str,
+        new_computed_blocks: Sequence[KVCacheBlock],
+        num_local_computed_tokens: int,
+        num_external_computed_tokens: int,
+    ) -> None:
+        """
+        Add the new computed blocks to the request. This involves three steps:
+        1. Touch the computed blocks to make sure they won't be evicted.
+        1.5. (Optional) For sliding window, skip blocks are padded with null blocks.
+        2. Add the remaining computed blocks.
+        3. (Optional) For KV connectors, allocate new blocks for external computed
+            tokens (if any).
+
+        Args:
+            request_id: The request ID.
+            new_computed_blocks: The new computed blocks just hitting the
+                prefix cache.
+            num_local_computed_tokens: The number of local computed tokens.
+            num_external_computed_tokens: The number of external computed tokens.
+        """
+
+        if request_id in self.num_cached_block:
+            # Fast-path: a running request won't have any new prefix-cache hits.
+            # It should not have any new computed blocks.
+            assert len(new_computed_blocks) == 0
+            return
+
+        # A new request.
+        req_blocks = self.req_to_blocks[request_id]
+        assert len(req_blocks) == 0
+        num_total_computed_tokens = (
+            num_local_computed_tokens + num_external_computed_tokens
+        )
+        num_skipped_tokens = self.get_num_skipped_tokens(num_total_computed_tokens)
+        num_skipped_blocks = num_skipped_tokens // self.block_size
+        if num_skipped_blocks > 0:
+            # It is possible that all new computed blocks are skipped when
+            # num_skipped_blocks > len(new_computed_blocks).
+            new_computed_blocks = new_computed_blocks[num_skipped_blocks:]
+            # Some external computed tokens may be skipped too.
+            num_external_computed_tokens = min(
+                num_total_computed_tokens - num_skipped_tokens,
+                num_external_computed_tokens,
+            )
+
+        # Touch the computed blocks to make sure they won't be evicted.
+        if self.enable_caching:
+            self.block_pool.touch(new_computed_blocks)
+        else:
+            assert not any(new_computed_blocks), (
+                "Computed blocks should be empty when prefix caching is disabled"
+            )
+
+        # Skip blocks are padded with null blocks.
+        req_blocks.extend([self._null_block] * num_skipped_blocks)
+        # Add the remaining computed blocks.
+        req_blocks.extend(new_computed_blocks)
+        # All cached hits (including skipped nulls) are already cached; mark
+        # them so cache_blocks() will not try to re-cache blocks that already
+        # have a block_hash set.
+        self.num_cached_block[request_id] = len(req_blocks)
+
+        if num_external_computed_tokens > 0:
+            # Allocate new blocks for external computed tokens.
+            allocated_blocks = self.block_pool.get_new_blocks(
+                cdiv(num_total_computed_tokens, self.block_size) - len(req_blocks)
+            )
+            req_blocks.extend(allocated_blocks)
+            if type(self.kv_cache_spec) in (FullAttentionSpec, TQFullAttentionSpec):
+                self.new_block_ids.extend(b.block_id for b in allocated_blocks)
+
+    def allocate_new_blocks(
+        self, request_id: str, num_tokens: int, num_tokens_main_model: int
+    ) -> list[KVCacheBlock]:
+        """
+        Allocate new blocks for the request to give it at least `num_tokens`
+        token slots.
+
+        Args:
+            request_id: The request ID.
+            num_tokens: The total number of tokens that need a slot (including
+                tokens that are already allocated).
+            num_tokens_main_model: The number of tokens for the main model (aka target
+                model in spec decode). w/o spec decode, it is num_tokens;
+                with spec decode, it is num_tokens - num_lookahead_tokens.
+        Returns:
+            The new allocated blocks.
+        """
+        req_blocks = self.req_to_blocks[request_id]
+        num_required_blocks = cdiv(num_tokens, self.block_size)
+        num_new_blocks = num_required_blocks - len(req_blocks)
+        if num_new_blocks <= 0:
+            return []
+        else:
+            new_blocks = self.block_pool.get_new_blocks(num_new_blocks)
+            req_blocks.extend(new_blocks)
+            if type(self.kv_cache_spec) in (FullAttentionSpec, TQFullAttentionSpec):
+                self.new_block_ids.extend(b.block_id for b in new_blocks)
+            return new_blocks
+
+    def take_new_block_ids(self) -> list[int]:
+        """Drain and return block IDs allocated since the last call."""
+        ids = self.new_block_ids
+        self.new_block_ids = []
+        return ids
+
+    def cache_blocks(self, request: Request, num_tokens: int) -> None:
+        """
+        Cache the blocks for the request.
+
+        Args:
+            request: The request.
+            num_tokens: The total number of tokens that need to be cached
+                (including tokens that are already cached).
+        """
+        num_cached_blocks = self.num_cached_block.get(request.request_id, 0)
+        num_full_blocks = num_tokens // self.block_size
+
+        if num_cached_blocks >= num_full_blocks:
+            return
+
+        self.block_pool.cache_full_blocks(
+            request=request,
+            blocks=self.req_to_blocks[request.request_id],
+            num_cached_blocks=num_cached_blocks,
+            num_full_blocks=num_full_blocks,
+            block_size=self.block_size,
+            kv_cache_group_id=self.kv_cache_group_id,
+        )
+
+        self.num_cached_block[request.request_id] = num_full_blocks
+
+    def free(self, request_id: str) -> None:
+        """
+        Free the blocks for the request.
+
+        Args:
+            request_id: The request ID.
+        """
+        # Default to [] in case a request is freed (aborted) before alloc.
+        req_blocks = self.req_to_blocks.pop(request_id, [])
+
+        # Free blocks in reverse order so that the tail blocks are
+        # freed first.
+        ordered_blocks = reversed(req_blocks)
+
+        self.block_pool.free_blocks(ordered_blocks)
+        self.num_cached_block.pop(request_id, None)
+
+    @abstractmethod
+    def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
+        """
+        Get the number of common prefix blocks for all requests with allocated
+        KV cache.
+
+        Args:
+            running_request_id: The request ID.
+
+        Returns:
+            The number of common prefix blocks for all requests with allocated
+            KV cache.
+        """
+
+        raise NotImplementedError
+
+    @classmethod
+    @abstractmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes: BlockHashList,
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        kv_cache_spec: KVCacheSpec,
+        use_eagle: bool,
+        alignment_tokens: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+    ) -> tuple[list[KVCacheBlock], ...]:
+        """
+        Get the longest cache hit prefix of the blocks that is not longer than
+        `max_length`. The prefix should be a common prefix hit for all the
+        kv cache groups in `kv_cache_group_ids`. If no cache hit is found,
+        return an empty list.
+        If eagle is enabled, drop the last matched block to force recompute the
+        last block to get the required hidden states for eagle drafting head.
+        Need to be customized for each attention type.
+
+        Args:
+            block_hashes: The block hashes of the request.
+            max_length: The maximum length of the cache hit prefix.
+            kv_cache_group_ids: The ids of the kv cache groups.
+            block_pool: The block pool.
+            kv_cache_spec: The kv cache spec.
+            use_eagle: Whether to use eagle.
+            alignment_tokens: The returned cache hit length (in tokens) should
+                be a multiple of this value (in tokens). By default, it should
+                be set to the block_size.
+            dcp_world_size: The world size of decode context parallelism.
+            pcp_world_size: The world size of prefill context parallelism.
+
+        Returns:
+            A list of cached blocks with skipped blocks replaced by null block
+            for each kv cache group in `kv_cache_group_ids`.
+            Return a list of length `len(kv_cache_group_ids)`, where the i-th
+            element is a list of cached blocks for the i-th kv cache group
+            in `kv_cache_group_ids`.
+            For example, sliding window manager should return a list like
+            ([NULL, NULL, KVCacheBlock(7), KVCacheBlock(8)]) for block size 4
+            and sliding window 8 and len(kv_cache_group_ids) = 1.
+        """
+
+        raise NotImplementedError
+
+    def remove_skipped_blocks(
+        self, request_id: str, total_computed_tokens: int
+    ) -> None:
+        """
+        Remove and free the blocks that are no longer needed for attention computation.
+        The removed blocks should be replaced by null_block.
+
+        This function depends on `get_num_skipped_tokens`, which need to be implemented
+        differently for each attention type.
+
+        Args:
+            request_id: The request ID.
+            total_computed_tokens: The total number of computed tokens, including
+                local computed tokens and external computed tokens.
+        """
+        # Remove the blocks that will be skipped during attention computation.
+        num_skipped_tokens = self.get_num_skipped_tokens(total_computed_tokens)
+        if num_skipped_tokens <= 0:
+            # This indicates that ALL tokens are inside attention window.
+            # Thus we do not need to free any blocks outside attention window.
+            # A typical case is full attention that we never free any token
+            # before the request is finished.
+            return
+        blocks = self.req_to_blocks[request_id]
+        num_skipped_blocks = num_skipped_tokens // self.block_size
+        # `num_skipped_tokens` may include tokens that haven't been allocated yet
+        # (e.g., when the attention window moves into the external computed tokens
+        # range), so we must cap to the number of blocks that currently exist for
+        # this request.
+        num_skipped_blocks = min(num_skipped_blocks, len(blocks))
+        removed_blocks: list[KVCacheBlock] = []
+        # Because the block starts from index 0, the num_skipped_block-th block
+        # corresponds to index num_skipped_blocks - 1.
+        for i in range(num_skipped_blocks - 1, -1, -1):
+            if blocks[i] == self._null_block:
+                # If the block is already a null block, the blocks before it
+                # should also have been set to null blocks by the previous calls
+                # to this function.
+                break
+            removed_blocks.append(blocks[i])
+            blocks[i] = self._null_block
+        self.block_pool.free_blocks(removed_blocks)
+
+    def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
+        """
+        Get the number of tokens that will be skipped for attention computation.
+
+        Args:
+            num_computed_tokens: The number of tokens that have been computed.
+
+        Returns:
+            The number of tokens that will be skipped for attention computation.
+        """
+        # The default behavior is to not skip any tokens.
+        return 0
+
+    def new_step_starts(self) -> None:
+        # do nothing by default
+        return None
+
+    def compact_kv_cache(
+        self,
+        request_id: str,
+        active_physical_positions: list[int],
+    ) -> tuple[int, list[tuple[int, int, int, int]]]:
+        """Physically compact KV cache by copying active tokens to contiguous slots."""
+        if request_id not in self.req_to_blocks:
+            return 0, []
+
+        blocks = self.req_to_blocks[request_id]
+        if not blocks or not active_physical_positions:
+            return 0, []
+
+        copy_operations: list[tuple[int, int]] = []
+        for dst_slot, src_slot in enumerate(active_physical_positions):
+            if src_slot != dst_slot:
+                copy_operations.append((src_slot, dst_slot))
+
+        block_level_ops: list[tuple[int, int, int, int]] = []
+        if copy_operations:
+            block_level_ops = self._get_kv_copy_ops(
+                request_id, blocks, copy_operations
+            )
+
+        num_active = len(active_physical_positions)
+        blocks_needed = (num_active + self.block_size - 1) // self.block_size
+
+        blocks_freed = 0
+        blocks_to_free: list[KVCacheBlock] = []
+        for block_idx in range(blocks_needed, len(blocks)):
+            block = blocks[block_idx]
+            if block != self._null_block:
+                blocks_to_free.append(block)
+                blocks[block_idx] = self._null_block
+                blocks_freed += 1
+
+        del blocks[blocks_needed:]
+
+        if blocks_to_free:
+            self.block_pool.free_blocks(reversed(blocks_to_free))
+
+        return blocks_freed, block_level_ops
+
+    def _get_kv_copy_ops(
+        self,
+        request_id: str,
+        blocks: list[KVCacheBlock],
+        copy_operations: list[tuple[int, int]],
+    ) -> list[tuple[int, int, int, int]]:
+        """Convert slot-level copy operations to block-level operations."""
+        block_level_ops: list[tuple[int, int, int, int]] = []
+        for src_slot, dst_slot in copy_operations:
+            src_block_idx = src_slot // self.block_size
+            src_offset = src_slot % self.block_size
+            dst_block_idx = dst_slot // self.block_size
+            dst_offset = dst_slot % self.block_size
+            src_block_id = blocks[src_block_idx].block_id
+            dst_block_id = blocks[dst_block_idx].block_id
+            block_level_ops.append((src_block_id, src_offset, dst_block_id, dst_offset))
+        return block_level_ops
+
+
+class FullAttentionManager(SingleTypeKVCacheManager):
+    @classmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes: BlockHashList,
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        kv_cache_spec: KVCacheSpec,
+        use_eagle: bool,
+        alignment_tokens: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+    ) -> tuple[list[KVCacheBlock], ...]:
+        assert isinstance(
+            kv_cache_spec, FullAttentionSpec | ChunkedLocalAttentionSpec
+        ), (
+            "FullAttentionManager can only be used for full attention "
+            "and chunked local attention groups"
+        )
+        computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
+            [] for _ in range(len(kv_cache_group_ids))
+        )
+        block_size = kv_cache_spec.block_size
+        if dcp_world_size * pcp_world_size > 1:
+            block_size *= dcp_world_size * pcp_world_size
+        max_num_blocks = max_length // block_size
+        for block_hash in itertools.islice(block_hashes, max_num_blocks):
+            # block_hashes is a chain of block hashes. If a block hash is not
+            # in the cached_block_hash_to_id, the following block hashes are
+            # not computed yet for sure.
+            if cached_block := block_pool.get_cached_block(
+                block_hash, kv_cache_group_ids
+            ):
+                for computed, cached in zip(computed_blocks, cached_block):
+                    computed.append(cached)
+            else:
+                break
+        if use_eagle and computed_blocks[0]:
+            # Need to drop the last matched block if eagle is enabled.
+            for computed in computed_blocks:
+                computed.pop()
+        while (
+            block_size != alignment_tokens  # Faster for common case.
+            and len(computed_blocks[0]) * block_size % alignment_tokens != 0
+        ):
+            for computed in computed_blocks:
+                computed.pop()
+        return computed_blocks
+
+    def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
+        blocks = self.req_to_blocks[running_request_id]
+        num_common_blocks = 0
+        for block in blocks:
+            if block.ref_cnt == len(self.req_to_blocks):
+                num_common_blocks += 1
+            else:
+                break
+        return num_common_blocks
+
+
+class SlidingWindowManager(SingleTypeKVCacheManager):
+    def __init__(self, kv_cache_spec: SlidingWindowSpec, **kwargs) -> None:
+        super().__init__(kv_cache_spec, **kwargs)
+        self.sliding_window = kv_cache_spec.sliding_window
+
+    @classmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes: BlockHashList,
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        kv_cache_spec: KVCacheSpec,
+        use_eagle: bool,
+        alignment_tokens: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+    ) -> tuple[list[KVCacheBlock], ...]:
+        assert isinstance(kv_cache_spec, SlidingWindowSpec), (
+            "SlidingWindowManager can only be used for sliding window groups"
+        )
+        assert dcp_world_size == 1, "DCP not support sliding window attn now."
+        assert pcp_world_size == 1, "PCP not support sliding window attn now."
+
+        # The number of contiguous blocks needed for prefix cache hit.
+        # -1 since the input token itself is also included in the window
+        sliding_window_contiguous_blocks = cdiv(
+            kv_cache_spec.sliding_window - 1, kv_cache_spec.block_size
+        )
+        if use_eagle:
+            # Need to drop the last matched block if eagle is enabled. For
+            # sliding window layer, we achieve this by increasing the number of
+            # contiguous blocks needed for prefix cache hit by one and dropping
+            # the last matched block.
+            sliding_window_contiguous_blocks += 1
+
+        # TODO: reduce i by sliding_window_contiguous_blocks when cache miss, to
+        # optimize the time complexity from O(max_num_blocks) to
+        # O(max_num_blocks / sliding_window_contiguous_blocks +
+        # sliding_window_contiguous_blocks),
+        # which is good for low cache hit rate scenarios.
+        max_num_blocks = max_length // kv_cache_spec.block_size
+        computed_blocks = tuple(
+            [block_pool.null_block] * max_num_blocks
+            for _ in range(len(kv_cache_group_ids))
+        )
+        block_size = kv_cache_spec.block_size
+        num_contiguous_blocks = 0
+        match_found = False
+        # Search from right to left and early stop when a match is found.
+        for i in range(max_num_blocks - 1, -1, -1):
+            if cached_block := block_pool.get_cached_block(
+                block_hashes[i], kv_cache_group_ids
+            ):
+                # Skip prefix matching check if the block is not aligned with
+                # `alignment_tokens`.
+                if num_contiguous_blocks == 0 and block_size != alignment_tokens:
+                    post_pop_blocks = i if use_eagle else i + 1
+                    if (post_pop_blocks * block_size) % alignment_tokens != 0:
+                        continue
+                # Add the cached block to the computed blocks.
+                for computed, cached in zip(computed_blocks, cached_block):
+                    computed[i] = cached
+                num_contiguous_blocks += 1
+                if num_contiguous_blocks >= sliding_window_contiguous_blocks:
+                    # Trim the trailing blocks.
+                    # E.g., [NULL, NULL, 8, 3, NULL, 9] -> [NULL, NULL, 8, 3]
+                    # when sliding_window_contiguous_blocks=2.
+                    for computed in computed_blocks:
+                        del computed[i + num_contiguous_blocks :]
+                    match_found = True
+                    break
+            else:
+                num_contiguous_blocks = 0
+        if not match_found:
+            # The first `num_contiguous_blocks` is a cache hit even if
+            # `num_contiguous_blocks < sliding_window_contiguous_blocks`.
+            for computed in computed_blocks:
+                del computed[num_contiguous_blocks:]
+            while (
+                block_size != alignment_tokens  # Faster for common case.
+                and len(computed_blocks[0]) * block_size % alignment_tokens != 0
+            ):
+                for computed in computed_blocks:
+                    computed.pop()
+        if use_eagle and computed_blocks[0]:
+            for computed in computed_blocks:
+                computed.pop()
+            # Re-align after eagle pop: the pop may break the alignment
+            # when block_size != alignment_tokens (hybrid models with
+            # different page sizes, e.g. Gemma4).
+            while (
+                block_size != alignment_tokens
+                and len(computed_blocks[0]) * block_size % alignment_tokens != 0
+            ):
+                for computed in computed_blocks:
+                    computed.pop()
+        return computed_blocks
+
+    def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
+        """
+        Get the number of tokens that will be skipped for attention computation.
+
+        For sliding window, this corresponds to the tokens that are prior to
+        the current sliding window.
+
+        Example:
+        sliding_window=4, num_computed_tokens=7
+
+        Tokens:   [ 0  1  2  3  4  5  6  7 ]
+                  | ---- computed -----|
+                                         ^ next token to be computed
+                               |-----------| sliding window for next token
+                  |--skipped---|
+
+        The current window contains tokens 4~7. Tokens 0~3 will be skipped for
+        attention computation since they are outside the sliding window.
+        Thus, get_num_skipped_tokens(7) == 4.
+
+        Args:
+            num_computed_tokens: The number of tokens that have been computed.
+
+        Returns:
+            The number of tokens that will be skipped for attention computation.
+        """
+        return max(0, num_computed_tokens - self.sliding_window + 1)
+
+    def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
+        """
+        NOTE(Chen): The prefix blocks are null blocks for sliding window layers.
+        So it's not correct to count ref_cnt like FullAttentionManager. Return
+        0 here for correctness. Need to support cascade attention + sliding
+        window in the future.
+        """
+        return 0
+
+
+class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
+    def __init__(self, kv_cache_spec: ChunkedLocalAttentionSpec, **kwargs) -> None:
+        super().__init__(kv_cache_spec, **kwargs)
+        self.attention_chunk_size = kv_cache_spec.attention_chunk_size
+
+    @classmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes: BlockHashList,
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        kv_cache_spec: KVCacheSpec,
+        use_eagle: bool,
+        alignment_tokens: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+    ) -> tuple[list[KVCacheBlock], ...]:
+        """
+        For chunked local attention, we need to find the longest cache hit
+        prefix of the blocks that is not longer than `max_length`. The prefix
+        should be a common prefix hit for all the kv cache groups in
+        `kv_cache_group_ids`. If no cache hit is found, return an empty list.
+        note we mark as computed if the whole block is outside of the local
+        window, and set the block as null. Examples:
+
+        1. Attention chunk size of 8, block size of 4, max length of 15
+        for next token at 15th (zero-indexed), 8th - 14th tokens are in
+        the window(needs lookup), 0th - 7th are not in the window,
+        so they are already marked as computed. We check the complete
+        block3 (8th - 11th tokens), Assume block 3 is hit, we will return
+        [null, null, block 3], otherwise, we return [null, null]
+
+        2. Attention chunk size of 8, block size of 4, max length of 16
+        for next token at 16th (zero-indexed), 0th - 15th tokens are not
+        in the window, so they are already marked as computed.
+        we return 4 blocks[null, null, null, null]
+
+        Args:
+            block_hashes: The block hashes of the request.
+            max_length: The maximum length of the cache hit prefix.
+            kv_cache_group_ids: The ids of the kv cache groups.
+            block_pool: The block pool.
+            kv_cache_spec: The kv cache spec.
+            use_eagle: Whether to use eagle.
+            dcp_world_size: The world size of decode context parallelism.
+            pcp_world_size: The world size of prefill context parallelism.
+            alignment_tokens: The returned cache hit length (in tokens) should
+                be a multiple of this value (in tokens).
+
+        Returns:
+            A list of cached blocks
+        """
+        assert isinstance(kv_cache_spec, ChunkedLocalAttentionSpec), (
+            "ChunkedLocalAttentionManager can only be used for "
+            "chunked local attention groups"
+        )
+        assert use_eagle is False, (
+            "Hybrid KV cache is not supported for " + "eagle + chunked local attention."
+        )
+        assert dcp_world_size == 1, "DCP not support chunked local attn now."
+        assert pcp_world_size == 1, "PCP not support chunked local attn now."
+        assert kv_cache_spec.block_size == alignment_tokens, (
+            "KV cache groups with different block sizes are not compatible with "
+            "chunked local attention now"
+        )
+        max_num_blocks = max_length // kv_cache_spec.block_size
+        if max_length > 0:
+            local_attention_start_idx = (
+                max_length
+                // kv_cache_spec.attention_chunk_size
+                * kv_cache_spec.attention_chunk_size
+            )
+        else:
+            local_attention_start_idx = 0
+        # we marked blocks out of window as computed
+        # with null blocks, and blocks inside window based on cache lookup
+        # result [null] [null] ... [null] [hit block 1 (1st block contain
+        # last window)] [hit block 2] ... [hit block x]
+        local_attention_start_block_idx = (
+            local_attention_start_idx // kv_cache_spec.block_size
+        )
+        computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
+            [block_pool.null_block] * local_attention_start_block_idx
+            for _ in range(len(kv_cache_group_ids))
+        )
+        for i in range(local_attention_start_block_idx, max_num_blocks):
+            block_hash = block_hashes[i]
+            if cached_block := block_pool.get_cached_block(
+                block_hash, kv_cache_group_ids
+            ):
+                for computed, cached in zip(computed_blocks, cached_block):
+                    computed.append(cached)
+            else:
+                break
+        return computed_blocks
+
+    def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
+        """
+        Get the number of tokens that will be skipped for attention computation.
+
+        For chunked local attention, this corresponds to the tokens that are on
+        the left side of the current chunk.
+
+        Example 1:
+        chunk size = 8, num_computed_tokens = 13
+        Tokens:  [ 0 1 2 3 4 5 6 7 | 8 9 10 11 12 13 14 15 ] ...
+                 | ----- computed ---------------|
+                                                  ^^ next token to be computed
+                                   |----------------| <-- attention window for
+                                                          next token
+                 |--- skipped -----|
+        Output: get_num_skipped_tokens(13) == 8
+
+        Example 2:
+        chunk size = 8, num_computed_tokens = 8
+        Tokens:  [ 0 1 2 3 4 5 6 7 | 8 9 10 11 12 13 14 15 ] ...
+                 | --- computed ---|
+                                     ^ next token to be computed
+                                   |--| <-- attention window for next token
+                 | --- skipped ----|
+        Output: get_num_skipped_tokens(8) == 8
+
+        Example 3:
+        chunk size = 8, num_computed_tokens = 7
+        Tokens:  [ 0 1 2 3 4 5 6 7 | 8 9 10 11 12 13 14 15 ] ...
+                 |---computed---|
+                                 ^ next token to be computed
+                 |-----------------| <-- attention window for next token
+                 no token should be skipped.
+        Output: get_num_skipped_tokens(7) == 0
+
+        Args:
+            num_computed_tokens: The number of tokens that have been computed.
+
+        Returns:
+            The number of tokens that will be skipped for attention computation.
+        """
+        num_skipped_tokens = (
+            num_computed_tokens // self.attention_chunk_size
+        ) * self.attention_chunk_size
+        return num_skipped_tokens
+
+    def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
+        """
+        cascade attention is not supported by chunked local attention.
+        """
+        return 0
+
+
+class MambaManager(SingleTypeKVCacheManager):
+    def __init__(
+        self, kv_cache_spec: MambaSpec, block_pool: BlockPool, **kwargs
+    ) -> None:
+        super().__init__(kv_cache_spec, block_pool, **kwargs)
+        self.cached_blocks_this_step: set[BlockHashWithGroupId] = set()
+        self.mamba_cache_mode = kv_cache_spec.mamba_cache_mode
+        self.num_speculative_blocks: int = kv_cache_spec.num_speculative_blocks
+        if self.mamba_cache_mode == "align":
+            # Mapping from request ID to the index of the block
+            # allocated in the previous step
+            self.last_state_block_idx: dict[str, int] = {}
+            # The set of the requests that have been allocated blocks
+            self._allocated_block_reqs: set[str] = set()
+
+    @classmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes: BlockHashList,
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        kv_cache_spec: KVCacheSpec,
+        use_eagle: bool,
+        alignment_tokens: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+    ) -> tuple[list[KVCacheBlock], ...]:
+        assert isinstance(kv_cache_spec, MambaSpec), (
+            "MambaManager can only be used for mamba groups"
+        )
+        assert dcp_world_size == 1, "DCP not support mamba now."
+        assert pcp_world_size == 1, "PCP not support mamba now."
+        computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
+            [] for _ in range(len(kv_cache_group_ids))
+        )
+
+        block_size = kv_cache_spec.block_size
+        max_num_blocks = max_length // block_size
+        # Search from right to left and early stop when a match is found.
+        for i in range(max_num_blocks - 1, -1, -1):
+            if cached_block := block_pool.get_cached_block(
+                block_hashes[i], kv_cache_group_ids
+            ):
+                # When enable Mamba prefix caching, `block_size` will be aligned
+                # across full attention layers and Mamba layers to ensure the
+                # prefix hit length aligned at block
+                if (
+                    block_size != alignment_tokens  # Faster for common case.
+                    and (i + 1) * block_size % alignment_tokens != 0
+                ):
+                    continue
+                for computed, cached in zip(computed_blocks, cached_block):
+                    # the hit length logic later assumes:
+                    #  hit_length = len(hit_blocks_other_attn[0])
+                    #               * self.other_block_size
+                    # so we insert dummy blocks at the beginning:
+                    computed.extend([block_pool.null_block] * i)
+                    computed.append(cached)
+                break  # we just need the last match - early stopping
+
+        return computed_blocks
+
+    def remove_skipped_blocks(self, request_id: str, num_computed_tokens: int) -> None:
+        assert isinstance(self.kv_cache_spec, MambaSpec)
+
+        # NOTE (tdoublep) with async scheduling, the num_computed_tokens can contain
+        # draft tokens from the previous step that may or may not be rejected later.
+        # This can make us think we are further ahead in the sequence than we actually
+        # are, so let's assume that all tokens are rejected so we don't free blocks
+        # that we might actually need.
+        num_computed_tokens = max(0, num_computed_tokens - self.num_speculative_blocks)
+
+        super().remove_skipped_blocks(request_id, num_computed_tokens)
+        if self.mamba_cache_mode == "align":
+            # `last_state_block_idx` refers to the block index allocated two steps ago.
+            # The block allocated in the previous step is used to copy Mamba states
+            # into the block allocated in the current step; the earlier block is
+            # no longer needed and should be freed here.
+            last_state_block_idx = self.last_state_block_idx.get(request_id)
+            # Blocks allocated during prefill may be non-contiguous. Use
+            # `last_state_block_idx` to free the appropriate block and replace it
+            # with a null block.
+            if (
+                last_state_block_idx is not None
+                and last_state_block_idx
+                < cdiv(num_computed_tokens, self.block_size) - 1
+            ):
+                blocks = self.req_to_blocks[request_id]
+                if blocks[last_state_block_idx] != self._null_block:
+                    self.block_pool.free_blocks([blocks[last_state_block_idx]])
+                    blocks[last_state_block_idx] = self._null_block
+
+    def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
+        """
+        cascade attention is not supported by mamba
+        """
+        return 0
+
+    def get_num_blocks_to_allocate(
+        self,
+        request_id: str,
+        num_tokens: int,
+        new_computed_blocks: Sequence[KVCacheBlock],
+        total_computed_tokens: int,
+        num_tokens_main_model: int,
+        apply_admission_cap: bool = False,
+    ) -> int:
+        assert isinstance(self.kv_cache_spec, MambaSpec)
+        if (
+            len(new_computed_blocks) > 0
+            and new_computed_blocks[-1].block_hash in self.cached_blocks_this_step
+        ):
+            # Mamba can't rely on blocks generated by other requests in the current step
+            # To put it in the next step, we return num_gpu_blocks + 1 so
+            # that kv_cache_manager will think there is no enough blocks to allocate now
+            # and don't schedule it in the current step.
+            return self.block_pool.num_gpu_blocks + 1
+        if self.mamba_cache_mode != "align":
+            # Allocate extra `num_speculative_blocks` blocks for
+            # speculative decoding (MTP/EAGLE) with linear attention.
+            if self.num_speculative_blocks > 0:
+                num_tokens += (
+                    self.kv_cache_spec.block_size * self.num_speculative_blocks
+                )
+            return super().get_num_blocks_to_allocate(
+                request_id,
+                num_tokens,
+                new_computed_blocks,
+                total_computed_tokens,
+                num_tokens_main_model,
+                apply_admission_cap=apply_admission_cap,
+            )
+        else:
+            # We don't allocate blocks for lookahead tokens in align mode, because if
+            # x * block_size tokens are scheduled, num_tokens is
+            # x * block_size + num_lookahead_tokens and breaks the alignment.
+            # We can ignore lookahead tokens because current draft models don't have
+            # mamba layers.
+            num_tokens = num_tokens_main_model
+
+            # NOTE(tdouble): this is an over-estimate of how many blocks we need because
+            # num_tokens can include draft tokens that will later be rejected.
+            num_required_blocks = (
+                cdiv(num_tokens, self.block_size) + self.num_speculative_blocks
+            )
+            num_new_blocks = (
+                num_required_blocks
+                - len(new_computed_blocks)
+                - len(self.req_to_blocks[request_id])
+            )
+            if num_new_blocks > 0:
+                if request_id in self._allocated_block_reqs:
+                    # Old request. Needs at most 1 more blocks as we can reuse the
+                    # speculative blocks in previous step.
+                    num_new_blocks = 1
+                else:
+                    # First prefill. Allocate 1 block for running state and the
+                    # speculative blocks.
+                    num_new_blocks = 1 + self.num_speculative_blocks
+
+            num_evictable_computed_blocks = self._get_num_evictable_blocks(
+                new_computed_blocks
+            )
+            return num_new_blocks + num_evictable_computed_blocks
+
+    def allocate_new_blocks(
+        self, request_id: str, num_tokens: int, num_tokens_main_model: int
+    ) -> list[KVCacheBlock]:
+        assert isinstance(self.kv_cache_spec, MambaSpec)
+        if self.mamba_cache_mode != "align":
+            # Allocate extra `num_speculative_blocks` blocks for
+            # speculative decoding (MTP/EAGLE) with linear attention.
+            if self.num_speculative_blocks > 0:
+                num_tokens += self.block_size * self.num_speculative_blocks
+            return super().allocate_new_blocks(
+                request_id, num_tokens, num_tokens_main_model
+            )
+        else:
+            # We don't allocate blocks for lookahead tokens in align mode, because if
+            # x * block_size tokens are scheduled, num_tokens is
+            # x * block_size + num_lookahead_tokens and breaks the alignment.
+            # We can ignore lookahead tokens because current draft models don't have
+            # mamba layers.
+            num_tokens = num_tokens_main_model
+            req_blocks: list[KVCacheBlock] = self.req_to_blocks[request_id]
+            # NOTE(tdouble): this is an over-estimate of how many blocks we need because
+            # num_tokens can include draft tokens that will later be rejected.
+            num_required_blocks = (
+                cdiv(num_tokens, self.block_size) + self.num_speculative_blocks
+            )
+            if num_required_blocks == len(req_blocks):
+                return []
+            else:
+                assert num_required_blocks > len(req_blocks), (
+                    "num_required_blocks "
+                    f"{num_required_blocks} < len(req_blocks) {len(req_blocks)}"
+                )
+                prev_block_len = len(req_blocks)
+                blocks_allocated = request_id in self._allocated_block_reqs
+                # Record the last state block
+                if blocks_allocated:
+                    # We always save the running state at the last
+                    # (1 + num_speculative_blocks) block
+                    self.last_state_block_idx[request_id] = (
+                        prev_block_len - 1 - self.num_speculative_blocks
+                    )
+                elif prev_block_len > 0:
+                    # When a new request hits the prefix cache, the last block
+                    # saves the hit state.
+                    self.last_state_block_idx[request_id] = prev_block_len - 1
+
+                num_skipped_blocks = (
+                    num_required_blocks - self.num_speculative_blocks - 1
+                )
+                # null blocks
+                if prev_block_len < num_skipped_blocks:
+                    req_blocks.extend(
+                        [
+                            self._null_block
+                            for _ in range(prev_block_len, num_skipped_blocks)
+                        ]
+                    )
+
+                if blocks_allocated:
+                    # reuse previous speculative blocks in this step
+                    for block_idx in range(
+                        prev_block_len - self.num_speculative_blocks, prev_block_len
+                    ):
+                        if block_idx < num_skipped_blocks:
+                            req_blocks.append(req_blocks[block_idx])
+                            req_blocks[block_idx] = self._null_block
+                        else:
+                            break
+                num_new_blocks = num_required_blocks - len(req_blocks)
+                if blocks_allocated:
+                    assert num_new_blocks <= 1
+                else:
+                    assert num_new_blocks <= self.num_speculative_blocks + 1
+                new_blocks = self.block_pool.get_new_blocks(num_new_blocks)
+                req_blocks.extend(new_blocks)
+                self._allocated_block_reqs.add(request_id)
+                return req_blocks[prev_block_len:]
+
+    def free(self, request_id: str) -> None:
+        if self.mamba_cache_mode == "align":
+            self._allocated_block_reqs.discard(request_id)
+            self.last_state_block_idx.pop(request_id, None)
+        super().free(request_id)
+
+    def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
+        """
+        Get the number of tokens whose mamba state are not needed anymore. Mamba only
+        need to keep the state of the last computed token, so we return
+        num_computed_tokens - 1.
+        """
+        return num_computed_tokens - 1
+
+    def cache_blocks(self, request: Request, num_tokens: int) -> None:
+        num_cached_blocks_before = self.num_cached_block.get(request.request_id, 0)
+        super().cache_blocks(request, num_tokens)
+        num_cached_blocks_after = self.num_cached_block.get(request.request_id, 0)
+        if num_cached_blocks_after > num_cached_blocks_before:
+            for block in self.req_to_blocks[request.request_id][
+                num_cached_blocks_before:num_cached_blocks_after
+            ]:
+                if block.is_null:
+                    continue
+                assert block.block_hash is not None
+                self.cached_blocks_this_step.add(block.block_hash)
+
+    def new_step_starts(self) -> None:
+        self.cached_blocks_this_step.clear()
+
+
+class CrossAttentionManager(SingleTypeKVCacheManager):
+    """Manager for cross-attention KV cache in encoder-decoder models."""
+
+    def allocate_new_computed_blocks(
+        self,
+        request_id: str,
+        new_computed_blocks: Sequence[KVCacheBlock],
+        num_local_computed_tokens: int,
+        num_external_computed_tokens: int,
+    ) -> None:
+        # We do not cache blocks for cross-attention to be shared between
+        # requests, so  `new_computed_blocks` should always be empty.
+        assert len(new_computed_blocks) == 0
+
+    def cache_blocks(self, request: Request, num_tokens: int) -> None:
+        # We do not cache blocks for cross-attention to be shared between
+        # requests, so this method is not relevant.
+        raise ValueError("Should not be called as prefix caching is disabled.")
+
+    def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
+        # Cross-attention blocks contain request-specific encoder states
+        # and are not shared between different requests
+        return 0
+
+    @classmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes: BlockHashList,
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        kv_cache_spec: KVCacheSpec,
+        use_eagle: bool,
+        alignment_tokens: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+    ) -> tuple[list[KVCacheBlock], ...]:
+        assert isinstance(kv_cache_spec, CrossAttentionSpec), (
+            "CrossAttentionManager can only be used for cross-attention groups"
+        )
+        # Cross-attention does not benefit from prefix caching since:
+        # 1. Encoder states are unique per request (different audio/image
+        #    inputs)
+        # 2. Encoder states are computed once per request, not incrementally
+        # 3. No reusable prefix exists between different multimodal inputs
+        # Return empty blocks to indicate no cache hits
+        raise NotImplementedError("CrossAttentionManager does not support caching")
+
+
+class SinkFullAttentionManager(FullAttentionManager):
+    def __init__(
+        self,
+        kv_cache_spec: SinkFullAttentionSpec,
+        block_pool: BlockPool,
+        enable_caching: bool,
+        kv_cache_group_id: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+    ):
+        super().__init__(
+            kv_cache_spec,
+            block_pool,
+            enable_caching,
+            kv_cache_group_id,
+            dcp_world_size,
+            pcp_world_size,
+        )
+        sink_len = kv_cache_spec.sink_len
+        assert sink_len is not None and sink_len > 0 and sink_len % self.block_size == 0
+        num_sink_block = sink_len // self.block_size
+        self.sink_blocks = self.block_pool.free_block_queue.popleft_n(num_sink_block)
+
+
+spec_manager_map: dict[type[KVCacheSpec], type[SingleTypeKVCacheManager]] = {
+    FullAttentionSpec: FullAttentionManager,
+    TQFullAttentionSpec: FullAttentionManager,
+    MLAAttentionSpec: FullAttentionManager,
+    SlidingWindowSpec: SlidingWindowManager,
+    SlidingWindowMLASpec: SlidingWindowManager,
+    ChunkedLocalAttentionSpec: ChunkedLocalAttentionManager,
+    MambaSpec: MambaManager,
+    CrossAttentionSpec: CrossAttentionManager,
+    SinkFullAttentionSpec: SinkFullAttentionManager,
+}
+
+
+def get_manager_for_kv_cache_spec(
+    kv_cache_spec: KVCacheSpec,
+    max_num_batched_tokens: int,
+    max_model_len: int,
+    **kwargs,
+) -> SingleTypeKVCacheManager:
+    manager_class = spec_manager_map[type(kv_cache_spec)]
+    # SlidingWindow / ChunkedLocalAttention managers recycle blocks across
+    # chunks; the runtime admission cap must match the recycling-aware bound
+    # the startup pool sizer uses (single source of truth: the spec method).
+    if isinstance(kv_cache_spec, (SlidingWindowSpec, ChunkedLocalAttentionSpec)):
+        kwargs["max_admission_blocks_per_request"] = (
+            kv_cache_spec.max_admission_blocks_per_request(
+                max_num_batched_tokens=max_num_batched_tokens,
+                max_model_len=max_model_len,
+            )
+        )
+    manager = manager_class(kv_cache_spec, **kwargs)
+    return manager

--- a/overlays/vllm/v1/engine/__init__.py
+++ b/overlays/vllm/v1/engine/__init__.py
@@ -1,0 +1,288 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import enum
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import msgspec
+import numpy as np
+import torch
+
+from vllm.lora.request import LoRARequest
+from vllm.multimodal.inputs import MultiModalFeatureSpec
+from vllm.pooling_params import PoolingParams
+from vllm.sampling_params import SamplingParams
+from vllm.v1.metrics.stats import PrefillStats, SchedulerStats
+from vllm.v1.outputs import LogprobsLists, LogprobsTensors
+from vllm.v1.serial_utils import UtilityResult
+
+# Type for pause_generation mode parameter.
+# - "abort": Abort all in-flight requests immediately (default).
+# - "wait": Wait for in-flight requests to complete before pausing.
+# - "keep": Freeze requests in queue; they resume on resume_generation().
+PauseMode = Literal["abort", "wait", "keep"]
+
+# These are possible values of RequestOutput.finish_reason,
+# so form part of the external API.
+FINISH_REASON_STRINGS = ("stop", "length", "abort", "error", "repetition")
+
+EEP_NOTIFICATION_CALL_ID = -1
+
+
+class EEPNotificationType(enum.Enum):
+    NEW_CORE_ENGINES_INIT_READY = "NEW_CORE_ENGINES_INIT_READY"
+    NEW_CORE_ENGINES_WEIGHTS_INIT_READY = "NEW_CORE_ENGINES_WEIGHTS_INIT_READY"
+    RECONFIGURE_FINISHED = "RECONFIGURE_FINISHED"
+    SHUTDOWN_COMPLETE = "SHUTDOWN_COMPLETE"
+
+
+class FinishReason(enum.IntEnum):
+    """
+    Reason a request finished - stop, length, abort, error, or repetition.
+
+    Int rather than Str for more compact serialization.
+
+    stop - a stop string was emitted
+    length - max_tokens was consumed, or max_model_len was reached
+    abort - aborted by client
+    error - retryable request-level internal error (e.g., KV load failure).
+            Invariant: always converted to 500 Internal Server Error.
+    repetition - repetitive token pattern detected (hallucination)
+
+    """
+
+    STOP = 0
+    LENGTH = 1
+    ABORT = 2
+    ERROR = 3
+    REPETITION = 4
+
+    def __str__(self):
+        return FINISH_REASON_STRINGS[self.value]
+
+
+@dataclass
+class EngineCoreReadyResponse:
+    """Sent from EngineCore to each frontend at the end of engine startup.
+
+    Contains post-initialization config that may differ from the original
+    values (e.g. max_model_len after KV cache auto-fitting).
+    """
+
+    max_model_len: int
+    num_gpu_blocks: int
+    dp_stats_address: str | None
+
+
+class EngineCoreRequest(
+    msgspec.Struct,
+    array_like=True,  # type: ignore[call-arg]
+    omit_defaults=True,  # type: ignore[call-arg]
+    gc=False,
+):  # type: ignore[call-arg]
+    request_id: str
+    prompt_token_ids: list[int] | None
+    mm_features: list[MultiModalFeatureSpec] | None
+    sampling_params: SamplingParams | None
+    pooling_params: PoolingParams | None
+    arrival_time: float
+    lora_request: LoRARequest | None
+    cache_salt: str | None
+    data_parallel_rank: int | None
+    prompt_embeds: torch.Tensor | None = None
+
+    # Per-position mask for mixed-mode inputs (e.g chat completion with
+    # prompt_embeds content parts). `True` means the position is a real
+    # token ID; `False` means the position uses a pre-computed entry from
+    # `prompt_embeds`. `None` for pure-tokens and pure-embeds requests.
+    prompt_is_token_ids: list[bool] | None = None
+
+    # Index of the client, used to ensure outputs are sent back to the same
+    # client for this request when scaling out the front-end.
+    client_index: int = 0
+
+    # Used in DP case to indicate which wave of requests this is expected to
+    # belong to, to cover a race condition where the request is sent before
+    # a wave finished notification is received.
+    current_wave: int = 0
+    priority: int = 0
+
+    trace_headers: Mapping[str, str] | None = None
+    resumable: bool = False
+
+    # The user-provided request ID. This field is set internally,
+    # copied from the provided request_id that's originally assigned
+    # to the request_id field, see InputProcessor.assign_request_id().
+    # Used in outputs and to support abort(req_id, internal=False).
+    external_req_id: str | None = None
+
+    reasoning_ended: bool | None = None
+    reasoning_parser_kwargs: dict[str, Any] | None = None
+
+    # If True, the request should be added to the scheduler's waiting queue
+    # and immediately aborted, so connector-side cleanup runs via the standard
+    # request_finished hook. Used to free P-side prefill blocks when a
+    # KV-transfer request is rejected on the D node before engine admission.
+    abort_immediately: bool = False
+
+    @property
+    def params(self) -> SamplingParams | PoolingParams:
+        """Return the processed params (sampling or pooling)."""
+        if self.sampling_params is not None:
+            return self.sampling_params
+        assert self.pooling_params is not None
+        return self.pooling_params
+
+
+class EngineCoreEventType(enum.IntEnum):
+    """The type of engine core request event."""
+
+    QUEUED = 1
+    SCHEDULED = 2
+    PREEMPTED = 3
+
+
+class EngineCoreEvent(msgspec.Struct):
+    """A timestamped engine core event associated with a request.
+
+    The timestamp is a monotonic timestamps and is used for by the engine
+    frontend to calculate intervals between engine core events. These
+    timestamps should not be compared with timestamps from other processes.
+    """
+
+    type: EngineCoreEventType
+    timestamp: float
+
+    @classmethod
+    def new_event(
+        cls, event_type: EngineCoreEventType, timestamp: float | None = None
+    ) -> "EngineCoreEvent":
+        timestamp = time.monotonic() if timestamp is None else timestamp
+        return cls(event_type, timestamp)
+
+
+class EngineCoreOutput(
+    msgspec.Struct,
+    array_like=True,  # type: ignore[call-arg]
+    omit_defaults=True,  # type: ignore[call-arg]
+    gc=False,
+):  # type: ignore[call-arg]
+    request_id: str
+    new_token_ids: list[int]
+
+    new_logprobs: LogprobsLists | None = None
+    new_prompt_logprobs_tensors: LogprobsTensors | None = None
+
+    pooling_output: torch.Tensor | None = None
+
+    finish_reason: FinishReason | None = None
+    stop_reason: int | str | None = None
+    events: list[EngineCoreEvent] | None = None
+    kv_transfer_params: dict[str, Any] | None = None
+
+    trace_headers: Mapping[str, str] | None = None
+
+    prefill_stats: PrefillStats | None = None
+
+    routed_experts: np.ndarray | None = None
+    # The number of NaNs in logits.
+    # A value greater than 0 indicates that the output is corrupted.
+    num_nans_in_logits: int = 0
+
+    @property
+    def finished(self) -> bool:
+        return self.finish_reason is not None
+
+
+class UtilityOutput(
+    msgspec.Struct,
+    array_like=True,  # type: ignore[call-arg]
+    gc=False,
+):  # type: ignore[call-arg]
+    call_id: int
+
+    # Non-None implies the call failed, result should be None.
+    failure_message: str | None = None
+    result: UtilityResult | None = None
+
+
+class EngineCoreOutputs(
+    msgspec.Struct,
+    array_like=True,  # type: ignore[call-arg]
+    omit_defaults=True,  # type: ignore[call-arg]
+    gc=False,
+):  # type: ignore[call-arg]
+    # NOTE(Nick): We could consider ways to make this more compact,
+    # e.g. columnwise layout
+
+    engine_index: int = 0
+
+    # [num_reqs]
+    outputs: list[EngineCoreOutput] = []
+    scheduler_stats: SchedulerStats | None = None
+    timestamp: float = 0.0
+
+    utility_output: UtilityOutput | None = None
+    finished_requests: set[str] | None = None
+
+    # In DP case, used to signal that the current wave of requests
+    # has finished and the engines are paused.
+    wave_complete: int | None = None
+    # In DP case, used to signal that a request was received for an
+    # "old" wave, so the next wave needs to be started in other engines.
+    start_wave: int | None = None
+
+    def __post_init__(self):
+        if self.timestamp == 0.0:
+            self.timestamp = time.monotonic()
+
+
+class EngineCoreRequestType(enum.Enum):
+    """
+    Request types defined as hex byte strings, so it can be sent over sockets
+    without separate encoding step.
+    """
+
+    ADD = b"\x00"
+    ABORT = b"\x01"
+    START_DP_WAVE = b"\x02"
+    UTILITY = b"\x03"
+    # Sentinel used within EngineCoreProc.
+    EXECUTOR_FAILED = b"\x04"
+    # Sentinel to wake up input_queue.get() during shutdown.
+    WAKEUP = b"\x05"
+
+
+class SpanRemovalResult(
+    msgspec.Struct,
+    array_like=True,
+    omit_defaults=True,
+    gc=False,
+):
+    """Result of a token span removal operation."""
+    success: bool
+    tokens_removed: int
+    blocks_freed: int
+    error_message: str | None = None
+
+
+class ReconfigureDistributedRequest(msgspec.Struct):
+    new_data_parallel_size: int
+    new_data_parallel_rank: int
+    new_data_parallel_rank_local: int
+    new_data_parallel_master_ip: str
+    new_data_parallel_master_port: int
+    new_data_parallel_master_port_list: list[int]
+    coord_store_port: int
+
+
+class ReconfigureRankType(enum.IntEnum):
+    """
+    Rank type for reconfiguring distributed request.
+    """
+
+    KEEP_CURRENT_RANK = -1
+    SHUTDOWN_CURRENT_RANK = -2

--- a/overlays/vllm/v1/request.py
+++ b/overlays/vllm/v1/request.py
@@ -1,0 +1,435 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import bisect
+import enum
+import time
+from collections import deque
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Optional
+
+import torch
+
+from vllm.multimodal.inputs import MultiModalFeatureSpec
+from vllm.pooling_params import PoolingParams
+from vllm.sampling_params import SamplingParams
+from vllm.utils import length_from_prompt_token_ids_or_embeds
+from vllm.v1.engine import (
+    EngineCoreEvent,
+    EngineCoreEventType,
+    EngineCoreRequest,
+    FinishReason,
+)
+from vllm.v1.metrics.stats import PrefillStats
+from vllm.v1.structured_output.request import StructuredOutputRequest
+from vllm.v1.utils import ConstantList
+
+if TYPE_CHECKING:
+    from vllm.lora.request import LoRARequest
+    from vllm.v1.core.block_masking import BlockMaskingState
+    from vllm.v1.core.kv_cache_utils import BlockHash
+
+
+@dataclass
+class StreamingUpdate:
+    """Lightweight data for streaming session continuation.
+
+    Contains only the fields needed to update an existing streaming session
+    with new input data.
+    """
+
+    mm_features: list[MultiModalFeatureSpec] | None
+    prompt_token_ids: list[int] | None
+    max_tokens: int
+    arrival_time: float
+    sampling_params: SamplingParams | None
+
+    @classmethod
+    def from_request(cls, request: "Request") -> "StreamingUpdate | None":
+        if not request.resumable:
+            return None
+        return cls(
+            mm_features=request.mm_features,
+            prompt_token_ids=request.prompt_token_ids,
+            max_tokens=request.max_tokens,
+            arrival_time=request.arrival_time,
+            sampling_params=request.sampling_params,
+        )
+
+
+class Request:
+    def __init__(
+        self,
+        request_id: str,
+        prompt_token_ids: list[int] | None,
+        sampling_params: SamplingParams | None,
+        pooling_params: PoolingParams | None,
+        client_index: int = 0,
+        arrival_time: float | None = None,
+        prompt_embeds: torch.Tensor | None = None,
+        prompt_is_token_ids: list[bool] | None = None,
+        mm_features: list[MultiModalFeatureSpec] | None = None,
+        lora_request: "LoRARequest | None" = None,
+        cache_salt: str | None = None,
+        priority: int = 0,
+        trace_headers: Mapping[str, str] | None = None,
+        block_hasher: Callable[["Request"], list["BlockHash"]] | None = None,
+        resumable: bool = False,
+        reasoning_ended: bool | None = None,
+        reasoning_parser_kwargs: dict[str, Any] | None = None,
+        abort_immediately: bool = False,
+    ) -> None:
+        self.request_id = request_id
+        self.client_index = client_index
+        self.priority = priority
+        self.sampling_params = sampling_params
+        self.pooling_params = pooling_params
+        self.lora_request = lora_request
+        self.structured_output_request = StructuredOutputRequest.from_sampling_params(
+            sampling_params
+        )
+        if self.structured_output_request is not None:
+            self.structured_output_request.reasoning_ended = reasoning_ended
+            self.structured_output_request.reasoning_parser_kwargs = (
+                reasoning_parser_kwargs
+            )
+        self.arrival_time = arrival_time if arrival_time is not None else time.time()
+
+        self.status = RequestStatus.WAITING
+        self.events: list[EngineCoreEvent] = []
+        self.stop_reason: int | str | None = None
+
+        # P/D: Connector-specific KV transfer parameters.
+        self.kv_transfer_params: dict[str, Any] | None = None
+
+        if pooling_params is not None:
+            # Pooling models.
+            self.max_tokens = 1
+        elif sampling_params is not None:
+            # Generative models.
+            assert sampling_params.max_tokens is not None
+            self.max_tokens = sampling_params.max_tokens
+            if self.structured_output_request is not None:
+                self.status = RequestStatus.WAITING_FOR_STRUCTURED_OUTPUT_GRAMMAR
+
+            if sampling_params.extra_args is not None:
+                self.kv_transfer_params = sampling_params.extra_args.get(
+                    "kv_transfer_params"
+                )
+        else:
+            raise ValueError("sampling_params and pooling_params can't both be unset")
+
+        self.prompt_token_ids = prompt_token_ids
+        self.prompt_embeds = prompt_embeds
+        # Per-position mask used in mixed-mode (chat completion with
+        # prompt_embeds). `None` except when both `prompt_token_ids` and
+        # `prompt_embeds` are set and their positions are interleaved.
+        self.prompt_is_token_ids = prompt_is_token_ids
+        # Cache per-block prompt-embed hashes to avoid rehashing the same
+        # tensor slices when generating extra keys.
+        self._prompt_embeds_per_block_hashes: dict[tuple[int, int], bytes] = {}
+        self.num_prompt_tokens = length_from_prompt_token_ids_or_embeds(
+            prompt_token_ids, prompt_embeds
+        )
+        self._output_token_ids: list[int] = []
+        self._all_token_ids: list[int] = (
+            self.prompt_token_ids.copy()
+            if self.prompt_token_ids is not None
+            else [0] * self.num_prompt_tokens
+        )
+
+        # Used in async scheduling.
+        self.num_output_placeholders = 0
+        # Used in forced preemption (reset_prefix_cache) with async scheduling.
+        self.discard_latest_async_tokens = False
+
+        self.spec_token_ids: list[int] = []
+        self.num_computed_tokens = 0
+        self.cache_salt: str | None = cache_salt
+
+        # Multi-modal related
+        self.mm_features = mm_features or []
+
+        # Read-only views
+        # Prevent directly appending to these lists since
+        # they should also be updated simultaneously.
+        self.output_token_ids = ConstantList(self._output_token_ids)
+        self.all_token_ids = ConstantList(self._all_token_ids)
+        # trace_headers
+        self.trace_headers = trace_headers
+
+        # True if this request is scheduled as a non-final prefill chunk.
+        self.is_prefill_chunk = False
+
+        # The number of NaNs in logits. A value greater than 0
+        # indicates that the output is corrupted
+        self.num_nans_in_logits = 0
+
+        # The number of times this request has been preempted by the scheduler.
+        self.num_preemptions = 0
+
+        self.prefill_stats: PrefillStats | None = PrefillStats()
+
+        self.block_hashes: list[BlockHash] = []
+        # Store the block hasher without binding self to avoid creating a
+        # reference cycle (Request -> partial -> Request) that prevents
+        # immediate garbage collection via reference counting.
+        self._block_hasher: Callable[[Request], list[BlockHash]] | None = block_hasher
+        self.update_block_hashes()
+
+        self.skip_reading_prefix_cache = self.get_skip_reading_prefix_cache()
+
+        # Used for streaming
+        self.resumable = resumable
+        # None entry in the queue means finished.
+        self.streaming_queue: deque[StreamingUpdate | None] | None = None
+
+        # If True, request should be aborted immediately after being added to
+        # the scheduler so the connector's request_finished hook runs.
+        self.abort_immediately = abort_immediately
+
+        # Track spans that have been compacted (removed from KV cache).
+        # Setting this property precomputes auxiliary arrays for O(log n)
+        # binary-search position lookups.
+        self.compacted_spans = []
+
+        # Block masking state for Memento-style generation.
+        self.block_masking_state: Optional["BlockMaskingState"] = None
+
+    @classmethod
+    def from_engine_core_request(
+        cls,
+        request: EngineCoreRequest,
+        block_hasher: Callable[["Request"], list["BlockHash"]] | None,
+    ) -> "Request":
+        return cls(
+            request_id=request.request_id,
+            client_index=request.client_index,
+            prompt_token_ids=request.prompt_token_ids,
+            prompt_embeds=request.prompt_embeds,
+            prompt_is_token_ids=request.prompt_is_token_ids,
+            mm_features=request.mm_features,
+            sampling_params=request.sampling_params,
+            pooling_params=request.pooling_params,
+            arrival_time=request.arrival_time,
+            lora_request=request.lora_request,
+            cache_salt=request.cache_salt,
+            priority=request.priority,
+            trace_headers=request.trace_headers,
+            block_hasher=block_hasher,
+            resumable=request.resumable,
+            reasoning_ended=request.reasoning_ended,
+            reasoning_parser_kwargs=request.reasoning_parser_kwargs,
+            abort_immediately=request.abort_immediately,
+        )
+
+    def append_output_token_ids(
+        self,
+        token_ids: int | list[int],
+    ) -> None:
+        if isinstance(token_ids, int):
+            self._output_token_ids.append(token_ids)
+            self._all_token_ids.append(token_ids)
+        else:
+            self._output_token_ids.extend(token_ids)
+            self._all_token_ids.extend(token_ids)
+
+        self.update_block_hashes()
+
+    def update_block_hashes(self) -> None:
+        """Compute block hashes for any new full blocks and append them."""
+        if self._block_hasher is not None:
+            self.block_hashes.extend(self._block_hasher(self))
+
+    @property
+    def use_structured_output(self) -> bool:
+        return self.structured_output_request is not None
+
+    @property
+    def num_tokens(self) -> int:
+        return len(self._all_token_ids)
+
+    @property
+    def num_tokens_with_spec(self) -> int:
+        return len(self._all_token_ids) + len(self.spec_token_ids)
+
+    @property
+    def num_output_tokens(self) -> int:
+        return len(self._output_token_ids)
+
+    @property
+    def num_encoder_inputs(self) -> int:
+        return len(self.mm_features)
+
+    @property
+    def has_encoder_inputs(self) -> bool:
+        return self.num_encoder_inputs > 0
+
+    def get_skip_reading_prefix_cache(self) -> bool:
+        if (
+            self.sampling_params is not None
+            and self.sampling_params.skip_reading_prefix_cache is not None
+        ):
+            return self.sampling_params.skip_reading_prefix_cache
+        elif (
+            self.pooling_params is not None
+            and self.pooling_params.skip_reading_prefix_cache is not None
+        ):
+            return self.pooling_params.skip_reading_prefix_cache
+        return False
+
+    def is_finished(self) -> bool:
+        return RequestStatus.is_finished(self.status)
+
+    def get_finished_reason(self) -> FinishReason | None:
+        return RequestStatus.get_finished_reason(self.status)
+
+    def get_num_encoder_embeds(self, input_id: int) -> int:
+        assert input_id < len(self.mm_features)
+        return self.mm_features[input_id].mm_position.get_num_embeds()
+
+    def record_event(
+        self,
+        event_type: EngineCoreEventType,
+        timestamp: float | None = None,
+    ) -> None:
+        self.events.append(EngineCoreEvent.new_event(event_type, timestamp))
+
+    def take_events(self) -> list[EngineCoreEvent] | None:
+        if not self.events:
+            return None
+        events, self.events = self.events, []
+        return events
+
+    def take_prefill_stats(self) -> PrefillStats | None:
+        if self.prefill_stats is None:
+            return None
+        prefill_stats = self.prefill_stats
+        self.prefill_stats = None
+        return prefill_stats
+
+    def __lt__(self, other: "Request") -> bool:
+        """
+        Compare two requests based on priority, arrival time, and request ID.
+        Used in priority scheduling.
+        """
+        if self.priority != other.priority:
+            return self.priority < other.priority
+        if self.arrival_time != other.arrival_time:
+            return self.arrival_time < other.arrival_time
+        if self.request_id != other.request_id:
+            return self.request_id < other.request_id
+        return id(self) < id(other)
+
+    @property
+    def compacted_spans(self) -> list[tuple[int, int]]:
+        return self._compacted_spans
+
+    @compacted_spans.setter
+    def compacted_spans(self, spans: list[tuple[int, int]]) -> None:
+        self._compacted_spans = spans
+        starts: list[int] = []
+        cumulative: list[int] = []
+        gap_physical: list[int] = [0]
+        gap_logical: list[int] = [0]
+        total = 0
+        for s, e in spans:
+            starts.append(s)
+            total += e - s
+            cumulative.append(total)
+            gap_physical.append(e - total)
+            gap_logical.append(e)
+        self._cs_starts = starts
+        self._cs_cumulative = cumulative
+        self._cs_gap_physical = gap_physical
+        self._cs_gap_logical = gap_logical
+
+    def is_token_active(self, position: int) -> bool:
+        if not self._cs_starts:
+            return True
+        idx = bisect.bisect_right(self._cs_starts, position) - 1
+        if idx < 0:
+            return True
+        return position >= self._compacted_spans[idx][1]
+
+    def get_active_positions(self, num_tokens: int) -> list[int]:
+        if not self.compacted_spans:
+            return list(range(num_tokens))
+        active: list[int] = []
+        prev_end = 0
+        for start, end in self.compacted_spans:
+            if start >= num_tokens:
+                break
+            active.extend(range(prev_end, min(start, num_tokens)))
+            prev_end = end
+        if prev_end < num_tokens:
+            active.extend(range(prev_end, num_tokens))
+        return active
+
+    def logical_to_physical(self, logical_pos: int) -> int:
+        if not self._cs_starts:
+            return logical_pos
+        idx = bisect.bisect_right(self._cs_starts, logical_pos) - 1
+        if idx < 0:
+            return logical_pos
+        _, end = self._compacted_spans[idx]
+        if logical_pos >= end:
+            return logical_pos - self._cs_cumulative[idx]
+        prev_cum = self._cs_cumulative[idx - 1] if idx > 0 else 0
+        return logical_pos - prev_cum - (logical_pos - self._cs_starts[idx])
+
+    def physical_to_logical(self, physical_pos: int) -> int:
+        if not self._cs_gap_physical:
+            return physical_pos
+        idx = bisect.bisect_right(self._cs_gap_physical, physical_pos) - 1
+        return (self._cs_gap_logical[idx]
+                + (physical_pos - self._cs_gap_physical[idx]))
+
+    def get_compacted_token_count(self) -> int:
+        return self._cs_cumulative[-1] if self._cs_cumulative else 0
+
+
+class RequestStatus(enum.IntEnum):
+    """Status of a request."""
+
+    WAITING = enum.auto()
+    WAITING_FOR_STRUCTURED_OUTPUT_GRAMMAR = enum.auto()
+    WAITING_FOR_REMOTE_KVS = enum.auto()
+    WAITING_FOR_STREAMING_REQ = enum.auto()
+    RUNNING = enum.auto()
+    PREEMPTED = enum.auto()
+    # Note: anything after PREEMPTED will be considered
+    # as a finished status.
+    FINISHED_STOPPED = enum.auto()
+    FINISHED_LENGTH_CAPPED = enum.auto()
+    FINISHED_ABORTED = enum.auto()
+    FINISHED_IGNORED = enum.auto()
+    FINISHED_ERROR = enum.auto()
+    FINISHED_REPETITION = enum.auto()
+
+    def __str__(self) -> str:
+        return self.name
+
+    @staticmethod
+    def is_finished(status: "RequestStatus") -> bool:
+        return status > RequestStatus.PREEMPTED
+
+    @staticmethod
+    def get_finished_reason(status: "RequestStatus") -> FinishReason | None:
+        return _FINISHED_REASON_MAP.get(status)
+
+
+# Mapping of finished statuses to their finish reasons.
+# NOTE: The ignored requests are the requests whose prompt lengths
+# are longer than the model's length cap. Therefore, the stop
+# reason should also be "length" as in OpenAI API.
+_FINISHED_REASON_MAP = {
+    RequestStatus.FINISHED_STOPPED: FinishReason.STOP,
+    RequestStatus.FINISHED_LENGTH_CAPPED: FinishReason.LENGTH,
+    RequestStatus.FINISHED_ABORTED: FinishReason.ABORT,
+    RequestStatus.FINISHED_IGNORED: FinishReason.LENGTH,
+    RequestStatus.FINISHED_ERROR: FinishReason.ERROR,
+    RequestStatus.WAITING_FOR_STREAMING_REQ: FinishReason.STOP,
+    RequestStatus.FINISHED_REPETITION: FinishReason.REPETITION,
+}

--- a/overlays/vllm/v1/worker/block_table.py
+++ b/overlays/vllm/v1/worker/block_table.py
@@ -1,0 +1,395 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import numpy as np
+import torch
+
+from vllm.distributed import get_dcp_group, get_pcp_group
+from vllm.logger import init_logger
+from vllm.triton_utils import tl, triton
+from vllm.utils.math_utils import cdiv
+from vllm.v1.attention.backends.utils import PAD_SLOT_ID
+from vllm.v1.utils import CpuGpuBuffer
+from vllm.v1.worker.cp_utils import get_total_cp_world_size
+
+logger = init_logger(__name__)
+
+
+class BlockTable:
+    def __init__(
+        self,
+        block_size: int,
+        max_num_reqs: int,
+        max_num_blocks_per_req: int,
+        max_num_batched_tokens: int,
+        pin_memory: bool,
+        device: torch.device,
+        kernel_block_size: int,
+        cp_kv_cache_interleave_size: int,
+    ):
+        """
+        Args:
+            block_size: Block size used for KV cache memory allocation
+            max_num_reqs: Maximum number of concurrent requests supported.
+            max_num_blocks_per_req: Maximum number of blocks per request.
+            max_num_batched_tokens: Maximum number of tokens in a batch.
+            pin_memory: Whether to pin memory for faster GPU transfers.
+            device: Target device for the block table.
+            kernel_block_size: The block_size of underlying attention kernel.
+                Will be the same as `block_size` if `block_size` is supported
+                by the attention kernel.
+        """
+        self.max_num_reqs = max_num_reqs
+        self.max_num_batched_tokens = max_num_batched_tokens
+        self.pin_memory = pin_memory
+        self.device = device
+
+        if kernel_block_size == block_size:
+            # Standard case: allocation and computation use same block size
+            # No block splitting needed, direct mapping
+            self.block_size = block_size
+            self.blocks_per_kv_block = 1
+            self.use_hybrid_blocks = False
+        else:
+            # Hybrid case: allocation block size differs from kernel block size
+            # Memory blocks are subdivided to match kernel requirements
+            # Example: 32-token memory blocks with 16-token kernel blocks
+            # → Each memory block corresponds to 2 kernel blocks
+            if block_size % kernel_block_size != 0:
+                raise ValueError(
+                    f"kernel_block_size {kernel_block_size} must divide "
+                    f"kv_manager_block_size size {block_size} evenly"
+                )
+
+            self.block_size = kernel_block_size
+            self.blocks_per_kv_block = block_size // kernel_block_size
+            self.use_hybrid_blocks = True
+
+        self.max_num_blocks_per_req = max_num_blocks_per_req * self.blocks_per_kv_block
+
+        self.block_table = self._make_buffer(
+            self.max_num_reqs, self.max_num_blocks_per_req, dtype=torch.int32
+        )
+        self.num_blocks_per_row = np.zeros(max_num_reqs, dtype=np.int32)
+
+        self.slot_mapping = self._make_buffer(
+            self.max_num_batched_tokens, dtype=torch.int64
+        )
+
+        if self.use_hybrid_blocks:
+            self._kernel_block_arange = np.arange(0, self.blocks_per_kv_block).reshape(
+                1, -1
+            )
+        else:
+            self._kernel_block_arange = None
+
+        try:
+            self.pcp_world_size = get_pcp_group().world_size
+            self.pcp_rank = get_pcp_group().rank_in_group
+        except AssertionError:
+            # PCP might not be initialized in testing
+            self.pcp_world_size = 1
+            self.pcp_rank = 0
+        try:
+            self.dcp_world_size = get_dcp_group().world_size
+            self.dcp_rank = get_dcp_group().rank_in_group
+        except AssertionError:
+            # DCP might not be initialized in testing
+            self.dcp_world_size = 1
+            self.dcp_rank = 0
+        self.cp_kv_cache_interleave_size = cp_kv_cache_interleave_size
+
+    def append_row(
+        self,
+        block_ids: list[int],
+        row_idx: int,
+    ) -> None:
+        if not block_ids:
+            return
+
+        if self.use_hybrid_blocks:
+            block_ids = self.map_to_kernel_blocks(
+                np.array(block_ids), self.blocks_per_kv_block, self._kernel_block_arange
+            )
+
+        num_blocks = len(block_ids)
+        start = self.num_blocks_per_row[row_idx]
+        self.num_blocks_per_row[row_idx] += num_blocks
+        self.block_table.np[row_idx, start : start + num_blocks] = block_ids
+
+    def add_row(self, block_ids: list[int], row_idx: int) -> None:
+        self.num_blocks_per_row[row_idx] = 0
+        self.append_row(block_ids, row_idx)
+
+    def clear_row(self, row_idx: int) -> None:
+        num_blocks = self.num_blocks_per_row[row_idx]
+        if num_blocks > 0:
+            self.block_table.np[row_idx, :num_blocks] = 0
+        self.num_blocks_per_row[row_idx] = 0
+
+    def move_row(self, src: int, tgt: int) -> None:
+        num_blocks = self.num_blocks_per_row[src]
+        block_table_np = self.block_table.np
+        block_table_np[tgt, :num_blocks] = block_table_np[src, :num_blocks]
+        self.num_blocks_per_row[tgt] = num_blocks
+
+    def swap_row(self, src: int, tgt: int) -> None:
+        src_tgt, tgt_src = [src, tgt], [tgt, src]
+        self.num_blocks_per_row[src_tgt] = self.num_blocks_per_row[tgt_src]
+        self.block_table.np[src_tgt] = self.block_table.np[tgt_src]
+
+    def truncate_row(self, row_idx: int, num_blocks: int) -> None:
+        """Truncate a row to keep only the first num_blocks blocks.
+
+        Used after KV cache compaction to remove stale block IDs.
+        """
+        self.num_blocks_per_row[row_idx] = num_blocks
+
+    def compute_slot_mapping(
+        self,
+        num_reqs: int,
+        query_start_loc: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> None:
+        num_tokens = positions.shape[0]
+        total_cp_world_size = self.pcp_world_size * self.dcp_world_size
+        total_cp_rank = self.pcp_rank * self.dcp_world_size + self.dcp_rank
+        _compute_slot_mapping_kernel[(num_reqs + 1,)](
+            num_tokens,
+            self.max_num_batched_tokens,
+            query_start_loc,
+            positions,
+            self.block_table.gpu,
+            self.block_table.gpu.stride(0),
+            self.block_size,
+            self.slot_mapping.gpu,
+            TOTAL_CP_WORLD_SIZE=total_cp_world_size,
+            TOTAL_CP_RANK=total_cp_rank,
+            CP_KV_CACHE_INTERLEAVE_SIZE=self.cp_kv_cache_interleave_size,
+            PAD_ID=PAD_SLOT_ID,
+            BLOCK_SIZE=1024,
+        )
+
+    def commit_block_table(self, num_reqs: int) -> None:
+        self.block_table.copy_to_gpu(num_reqs)
+
+    def clear(self) -> None:
+        self.block_table.gpu.fill_(0)
+        self.block_table.cpu.fill_(0)
+
+    @staticmethod
+    def map_to_kernel_blocks(
+        kv_manager_block_ids: np.ndarray,
+        blocks_per_kv_block: int,
+        kernel_block_arange: np.ndarray,
+    ) -> np.ndarray:
+        """Convert kv_manager_block_id IDs to kernel block IDs.
+
+        Example:
+            # kv_manager_block_ids: 32 tokens,
+            # Kernel block size: 16 tokens
+            # blocks_per_kv_block = 2
+            >>> kv_manager_block_ids = np.array([0, 1, 2])
+            >>> Result: [0, 1, 2, 3, 4, 5]
+
+            # Each kv_manager_block_id maps to 2 kernel block id:
+            # kv_manager_block_id 0 → kernel block id [0, 1]
+            # kv_manager_block_id 1 → kernel block id [2, 3]
+            # kv_manager_block_id 2 → kernel block id [4, 5]
+        """
+        if blocks_per_kv_block == 1:
+            return kv_manager_block_ids
+
+        kernel_block_ids = (
+            kv_manager_block_ids.reshape(-1, 1) * blocks_per_kv_block
+            + kernel_block_arange
+        )
+
+        return kernel_block_ids.reshape(-1)
+
+    def get_device_tensor(self, num_reqs: int) -> torch.Tensor:
+        """Returns the device tensor of the block table."""
+        return self.block_table.gpu[:num_reqs]
+
+    def get_cpu_tensor(self) -> torch.Tensor:
+        """Returns the CPU tensor of the block table."""
+        return self.block_table.cpu
+
+    def get_numpy_array(self) -> np.ndarray:
+        """Returns the numpy array of the block table."""
+        return self.block_table.np
+
+    def _make_buffer(
+        self, *size: int | torch.SymInt, dtype: torch.dtype
+    ) -> CpuGpuBuffer:
+        return CpuGpuBuffer(
+            *size, dtype=dtype, device=self.device, pin_memory=self.pin_memory
+        )
+
+
+class MultiGroupBlockTable:
+    """The BlockTables for each KV cache group."""
+
+    def __init__(
+        self,
+        max_num_reqs: int,
+        max_model_len: int,
+        max_num_batched_tokens: int,
+        pin_memory: bool,
+        device: torch.device,
+        block_sizes: list[int],
+        kernel_block_sizes: list[int],
+        max_num_blocks: list[int] | None = None,
+        cp_kv_cache_interleave_size: int = 1,
+    ) -> None:
+        if len(kernel_block_sizes) != len(block_sizes):
+            raise ValueError(
+                f"kernel_block_sizes length ({len(kernel_block_sizes)}) "
+                f"must match block_sizes length ({len(block_sizes)})"
+            )
+        if max_num_blocks is None:
+            # Note(hc): each dcp rank only store
+            # (max_model_len//dcp_world_size) tokens in kvcache,
+            # so the block_size which used for calc max_num_blocks_per_req
+            # must be multiplied by dcp_world_size.
+            total_cp_world_size = get_total_cp_world_size()
+            max_num_blocks = [
+                cdiv(max_model_len, block_size * total_cp_world_size)
+                for block_size in block_sizes
+            ]
+
+        if len(max_num_blocks) != len(block_sizes):
+            raise ValueError(
+                f"max_num_blocks length ({len(max_num_blocks)}) "
+                f"must match block_sizes length ({len(block_sizes)})"
+            )
+
+        # Align to a multiple of (128 / block_size) as required
+        # by some attention backends such as TRTLLM (#39324)
+        max_num_blocks = [
+            cdiv(n, 128 // bs) * (128 // bs) if bs <= 128 else n
+            for n, bs in zip(max_num_blocks, block_sizes)
+        ]
+
+        self.block_tables = [
+            BlockTable(
+                block_size,
+                max_num_reqs,
+                max_num_blocks_per_req,
+                max_num_batched_tokens,
+                pin_memory,
+                device,
+                kernel_block_size,
+                cp_kv_cache_interleave_size,
+            )
+            for block_size, kernel_block_size, max_num_blocks_per_req in zip(
+                block_sizes, kernel_block_sizes, max_num_blocks
+            )
+        ]
+
+    def append_row(self, block_ids: tuple[list[int], ...], row_idx: int) -> None:
+        for i, block_table in enumerate(self.block_tables):
+            block_table.append_row(block_ids[i], row_idx)
+
+    def add_row(self, block_ids: tuple[list[int], ...], row_idx: int) -> None:
+        for i, block_table in enumerate(self.block_tables):
+            block_table.add_row(block_ids[i], row_idx)
+
+    def clear_row(self, row_idx: int) -> None:
+        for block_table in self.block_tables:
+            block_table.clear_row(row_idx)
+
+    def move_row(self, src: int, tgt: int) -> None:
+        for block_table in self.block_tables:
+            block_table.move_row(src, tgt)
+
+    def swap_row(self, src: int, tgt: int) -> None:
+        for block_table in self.block_tables:
+            block_table.swap_row(src, tgt)
+
+    def truncate_row(self, row_idx: int, num_blocks: tuple[int, ...]) -> None:
+        """Truncate a row to keep only the first num_blocks blocks per group.
+
+        Used after KV cache compaction to remove stale block IDs.
+        """
+        for i, block_table in enumerate(self.block_tables):
+            block_table.truncate_row(row_idx, num_blocks[i])
+
+    def compute_slot_mapping(
+        self,
+        num_reqs: int,
+        query_start_loc: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> None:
+        for block_table in self.block_tables:
+            block_table.compute_slot_mapping(num_reqs, query_start_loc, positions)
+
+    def commit_block_table(self, num_reqs: int) -> None:
+        for block_table in self.block_tables:
+            block_table.commit_block_table(num_reqs)
+
+    def clear(self) -> None:
+        for block_table in self.block_tables:
+            block_table.clear()
+
+    def __getitem__(self, idx: int) -> "BlockTable":
+        """Returns the BlockTable for the i-th KV cache group."""
+        return self.block_tables[idx]
+
+
+@triton.jit
+def _compute_slot_mapping_kernel(
+    num_tokens,
+    max_num_tokens,
+    query_start_loc_ptr,  # [num_reqs + 1], int32
+    positions_ptr,  # [num_tokens], int64
+    block_table_ptr,  # [max_num_reqs, max_num_blocks_per_req], int32 (flat)
+    block_table_stride,  # max_num_blocks_per_req
+    block_size,
+    slot_mapping_ptr,  # [max_num_tokens], int64
+    TOTAL_CP_WORLD_SIZE: tl.constexpr,
+    TOTAL_CP_RANK: tl.constexpr,
+    CP_KV_CACHE_INTERLEAVE_SIZE: tl.constexpr,
+    PAD_ID: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    req_idx = tl.program_id(0)
+
+    if req_idx == tl.num_programs(0) - 1:
+        # Pad remaining slots for CUDA graph compatibility.
+        for i in range(num_tokens, max_num_tokens, BLOCK_SIZE):
+            offsets = i + tl.arange(0, BLOCK_SIZE)
+            tl.store(
+                slot_mapping_ptr + offsets,
+                PAD_ID,
+                mask=offsets < max_num_tokens,
+            )
+        return
+
+    start_idx = tl.load(query_start_loc_ptr + req_idx).to(tl.int64)
+    end_idx = tl.load(query_start_loc_ptr + req_idx + 1).to(tl.int64)
+
+    virtual_block_size = block_size * TOTAL_CP_WORLD_SIZE
+    row_offset = req_idx * block_table_stride
+    for i in range(start_idx, end_idx, BLOCK_SIZE):
+        offsets = i + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < end_idx
+        pos = tl.load(positions_ptr + offsets, mask=mask, other=0)
+        block_indices = pos // virtual_block_size
+        block_numbers = tl.load(block_table_ptr + row_offset + block_indices).to(
+            tl.int64
+        )
+
+        virtual_block_offsets = pos - block_indices * virtual_block_size
+        is_local = (
+            virtual_block_offsets // CP_KV_CACHE_INTERLEAVE_SIZE
+        ) % TOTAL_CP_WORLD_SIZE == TOTAL_CP_RANK
+        local_block_offsets = (
+            virtual_block_offsets // (TOTAL_CP_WORLD_SIZE * CP_KV_CACHE_INTERLEAVE_SIZE)
+        ) * CP_KV_CACHE_INTERLEAVE_SIZE + (
+            virtual_block_offsets % CP_KV_CACHE_INTERLEAVE_SIZE
+        )
+
+        slot_ids = block_numbers * block_size + local_block_offsets
+        slot_ids = tl.where(is_local, slot_ids, PAD_ID)
+        tl.store(slot_mapping_ptr + offsets, slot_ids, mask=mask)

--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -256,7 +256,7 @@ class InferenceConfig(BaseConfig):
     """Enable dual batch overlap (DBO). Forwarded as ``--enable-dbo``."""
 
     use_deep_gemm: bool = False
-    """Force DeepGEMM FP8 kernels via ``VLLM_USE_DEEP_GEMM=1``. Only works with per-tensor FP8 quantization (e.g. GLM-5-FP8)."""
+    """Enable DeepGEMM FP8 kernels via ``VLLM_USE_DEEP_GEMM=1``. When false, explicitly disables vLLM's DeepGEMM (which defaults to enabled in 0.21+). Only enable for per-tensor FP8 quantization (e.g. GLM-5-FP8)."""
 
     weight_broadcast: WeightBroadcastConfig = WeightBroadcastConfig()
 
@@ -268,6 +268,9 @@ class InferenceConfig(BaseConfig):
 
     enable_fp32_lm_head: bool = False
     """Run the lm_head projection in fp32 via a native bf16×bf16 → fp32 GEMM (``torch.mm`` with ``out_dtype=torch.float32``). Stabilizes logprob precision under FP8/bf16 inference, matching SGLang's ``--enable-fp32-lm-head``. Implemented as a monkey-patch over vLLM's LogitsProcessor, activated by setting ``additional_config["fp32_lm_head"] = True`` on the vLLM config."""
+
+    block_masking_config: dict[str, Any] | None = None
+    """Block masking (Memento-style KV cache compaction) configuration. Passed through ``additional_config["block_masking_config"]`` and read by the engine init monkey-patch to create a ``BlockMaskingConfig`` on ``VllmConfig``."""
 
     vllm_extra: dict[str, Any] = {}
     """Extra arguments forwarded to vLLM. Applied as attributes on the vLLM namespace after config translation."""
@@ -426,10 +429,13 @@ class InferenceConfig(BaseConfig):
 
         # Pass prime-rl-specific flags through vLLM's additional_config dict;
         # workers read these via get_current_vllm_config().additional_config.
+        additional = getattr(namespace, "additional_config", None) or {}
         if self.enable_fp32_lm_head:
-            existing = getattr(namespace, "additional_config", None) or {}
-            existing["fp32_lm_head"] = True
-            rsetattr(namespace, "additional_config", existing)
+            additional["fp32_lm_head"] = True
+        if self.block_masking_config is not None:
+            additional["block_masking_config"] = self.block_masking_config
+        if additional:
+            rsetattr(namespace, "additional_config", additional)
 
         # Remove chat_template if not set (vLLM doesn't accept None)
         if namespace.chat_template is None:

--- a/scripts/install_block_masking_overlay.sh
+++ b/scripts/install_block_masking_overlay.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Install block masking overlay onto the installed vLLM wheel.
+#
+# Strategy (same as Memento's install_overlay.sh):
+#   1. Find the installed vLLM site-packages directory
+#   2. Backup critical .so-interface files
+#   3. Rsync overlay .py files over the installed vLLM
+#   4. Restore .so-interface files (compiled extensions have mismatched signatures)
+#   5. Verify imports work
+#
+# Usage:
+#   scripts/install_block_masking_overlay.sh [--venv .venv]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+OVERLAY_DIR="$REPO_DIR/overlays/vllm"
+VENV="${1:-${UV_PROJECT_ENVIRONMENT:-.venv}}"
+
+# Find vLLM site-packages
+if [[ "$VENV" = /* ]]; then
+    PYTHON="$VENV/bin/python"
+else
+    PYTHON="$REPO_DIR/$VENV/bin/python"
+fi
+if [[ ! -x "$PYTHON" ]]; then
+    echo "ERROR: Python not found at $PYTHON"
+    exit 1
+fi
+
+VLLM_DIR=$("$PYTHON" -c "import vllm; import os; print(os.path.dirname(vllm.__file__))")
+if [[ ! -d "$VLLM_DIR" ]]; then
+    echo "ERROR: vLLM not installed in $VENV"
+    exit 1
+fi
+VLLM_VERSION=$("$PYTHON" -c "from importlib.metadata import version; print(version('vllm'))")
+
+echo "=== Block Masking Overlay Installer ==="
+echo "Overlay source: $OVERLAY_DIR"
+echo "vLLM target:    $VLLM_DIR"
+echo "vLLM version:   $VLLM_VERSION"
+echo ""
+
+if [[ -n "${EXPECTED_VLLM_VERSION_PREFIX:-}" ]]; then
+    case "$VLLM_VERSION" in
+        "${EXPECTED_VLLM_VERSION_PREFIX}"*) ;;
+        *)
+            echo "ERROR: Expected vLLM version prefix ${EXPECTED_VLLM_VERSION_PREFIX}, got ${VLLM_VERSION}"
+            echo "Install the matching vLLM wheel or use a base image built from the current lockfile before applying overlays."
+            exit 1
+            ;;
+    esac
+fi
+
+# Check overlay directory exists and has files
+if [[ ! -d "$OVERLAY_DIR" ]]; then
+    echo "ERROR: Overlay directory not found: $OVERLAY_DIR"
+    exit 1
+fi
+
+NUM_FILES=$(find "$OVERLAY_DIR" -name "*.py" | wc -l | tr -d ' ')
+if [[ "$NUM_FILES" -eq 0 ]]; then
+    echo "ERROR: No .py files found in overlay directory"
+    exit 1
+fi
+echo "Found $NUM_FILES overlay files"
+
+if [[ -f "$OVERLAY_DIR/config/vllm.py" ]]; then
+    echo "ERROR: Refusing to install stale full-file overlay: config/vllm.py"
+    echo "Block masking config must be injected by the prime_rl vLLM plugin."
+    exit 1
+fi
+
+# Backup .so-interface files that must be preserved.
+# These compiled extension interfaces have argument counts that don't match
+# if the overlay's Python wrappers are from a different upstream version.
+BACKUP_DIR=$(mktemp -d)
+echo "Backing up .so-interface files to $BACKUP_DIR"
+
+INTERFACE_FILES=(
+    "vllm_flash_attn/flash_attn_interface.py"
+    "_custom_ops.py"
+)
+
+for f in "${INTERFACE_FILES[@]}"; do
+    src="$VLLM_DIR/$f"
+    if [[ -f "$src" ]]; then
+        mkdir -p "$BACKUP_DIR/$(dirname "$f")"
+        cp "$src" "$BACKUP_DIR/$f"
+        echo "  Backed up: $f"
+    fi
+done
+
+# Ensure prime_rl.inference.block_masking is importable.
+# If prime_rl is already installed (editable from /app/src/), just verify the
+# block_masking directory exists in the source tree. If not, install into
+# site-packages as a fallback.
+SITE_PACKAGES=$(dirname "$VLLM_DIR")
+BM_SRC="$REPO_DIR/src/prime_rl/inference/block_masking"
+
+if "$PYTHON" -c "import prime_rl" 2>/dev/null; then
+    echo "prime_rl already installed — ensuring block_masking is in source tree..."
+    if [[ -d "$BM_SRC" ]] && [[ -f "$BM_SRC/__init__.py" ]]; then
+        echo "  block_masking found at $BM_SRC"
+    else
+        echo "  WARNING: block_masking not found at $BM_SRC"
+    fi
+else
+    echo "prime_rl not installed — installing block_masking into site-packages..."
+    BM_DST="$SITE_PACKAGES/prime_rl/inference/block_masking"
+    if [[ -d "$BM_SRC" ]]; then
+        mkdir -p "$BM_DST"
+        touch "$SITE_PACKAGES/prime_rl/__init__.py"
+        touch "$SITE_PACKAGES/prime_rl/inference/__init__.py"
+        cp "$BM_SRC"/*.py "$BM_DST/"
+        echo "  Installed $(find "$BM_DST" -name '*.py' | wc -l | tr -d ' ') files to $BM_DST"
+    else
+        echo "  WARNING: Vendored block_masking not found at $BM_SRC"
+    fi
+fi
+
+# Copy overlay .py files (preserving directory structure)
+echo ""
+echo "Installing overlay..."
+if command -v rsync &>/dev/null; then
+    rsync -av --include='*/' --include='*.py' --exclude='*' \
+        "$OVERLAY_DIR/" "$VLLM_DIR/" 2>&1 | grep -v '/$' | head -30
+else
+    find "$OVERLAY_DIR" -name '*.py' -type f | while read -r src; do
+        rel="${src#$OVERLAY_DIR/}"
+        dst="$VLLM_DIR/$rel"
+        mkdir -p "$(dirname "$dst")"
+        cp "$src" "$dst"
+        echo "$rel"
+    done
+fi
+
+# Restore .so-interface files
+echo ""
+echo "Restoring .so-interface files..."
+for f in "${INTERFACE_FILES[@]}"; do
+    backup="$BACKUP_DIR/$f"
+    dst="$VLLM_DIR/$f"
+    if [[ -f "$backup" ]]; then
+        cp "$backup" "$dst"
+        echo "  Restored: $f"
+    fi
+done
+
+rm -rf "$BACKUP_DIR"
+
+# Verify imports
+echo ""
+echo "Verifying installation..."
+ERRORS=0
+
+verify() {
+    if "$PYTHON" -c "$1" 2>/dev/null; then
+        echo "  OK: $2"
+    else
+        echo "  FAIL: $2"
+        "$PYTHON" -c "$1" 2>&1 | tail -3 || true
+        ERRORS=$((ERRORS + 1))
+    fi
+}
+
+verify "from vllm.config.block_masking import BlockMaskingConfig" "BlockMaskingConfig import"
+verify "from vllm.config import BlockMaskingConfig" "BlockMaskingConfig via config.__init__"
+verify "from vllm.v1.core.block_masking import BlockMaskingState, BlockMaskingProcessor" "BlockMaskingState/Processor import"
+verify "from vllm.v1.core.sched.output import SchedulerOutput; fields = SchedulerOutput.__dataclass_fields__; assert 'kv_copy_operations' in fields and 'block_masking_barrier' in fields" "SchedulerOutput has block masking fields"
+verify "from vllm.v1.core.kv_cache_manager import KVCacheManager; assert hasattr(KVCacheManager, 'compact_kv_cache')" "KVCacheManager.compact_kv_cache"
+verify "from vllm.distributed.kv_events import KVSlotCopy" "KVSlotCopy import"
+verify "from vllm.v1.engine import SpanRemovalResult" "SpanRemovalResult import"
+verify "from vllm.v1.worker.block_table import BlockTable; assert hasattr(BlockTable, 'truncate_row')" "BlockTable.truncate_row"
+verify "from vllm.plugins import load_general_plugins; load_general_plugins(); from vllm.v1.worker.gpu_model_runner import GPUModelRunner; assert getattr(GPUModelRunner, '_prime_rl_block_masking_patched', False); assert hasattr(GPUModelRunner, '_execute_kv_copy_operations'); from vllm.v1.worker.gpu_input_batch import InputBatch; assert getattr(InputBatch, '_prime_rl_block_masking_patched', False); from vllm.v1.engine.core import EngineCore; assert getattr(EngineCore, '_prime_rl_block_masking_barrier_patched', False); from vllm.config import VllmConfig; assert hasattr(VllmConfig, 'block_masking_config')" "prime_rl production plugin installs block masking patches"
+
+if [[ $ERRORS -gt 0 ]]; then
+    echo ""
+    echo "ERROR: $ERRORS import verification(s) failed"
+    exit 1
+fi
+
+echo ""
+echo "=== Overlay installed successfully ($NUM_FILES files) ==="

--- a/scripts/memento_runtime_preflight.py
+++ b/scripts/memento_runtime_preflight.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+"""Runtime preflight for the Memento block-masking smoke job."""
+
+import os
+import sys
+from importlib.metadata import version
+
+import prime_rl
+import vllm
+
+
+def main() -> None:
+    actual = version("vllm")
+    expected_prefix = os.environ.get("EXPECTED_VLLM_VERSION_PREFIX")
+
+    print(f"vLLM runtime version: {actual}")
+    print(f"vLLM module path: {vllm.__file__}")
+    print(f"prime_rl module path: {prime_rl.__file__}")
+    print(f"Python executable: {sys.executable}")
+    print(f"UV_PROJECT_ENVIRONMENT: {os.environ.get('UV_PROJECT_ENVIRONMENT')}")
+    for package in ("prime-rl", "torch", "transformers"):
+        print(f"{package} version: {version(package)}")
+
+    if expected_prefix and not actual.startswith(expected_prefix):
+        raise SystemExit(
+            "Expected vLLM version prefix "
+            f"{expected_prefix!r}, got {actual!r}. "
+            "Sync/install the matching vLLM wheel before applying the block "
+            "masking overlay."
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/prepare_memento_sft.py
+++ b/scripts/prepare_memento_sft.py
@@ -1,0 +1,92 @@
+"""Prepare Qwen3-0.6B + OpenMementos for a Memento block masking SFT run.
+
+Adds 4 block masking special tokens to the tokenizer, resizes model embeddings,
+and converts OpenMementos into prime-rl SFT format (messages column).
+
+Usage:
+    python scripts/prepare_memento_sft.py --output-dir /tmp/memento-sft-prep
+    python scripts/prepare_memento_sft.py --output-dir /tmp/memento-sft-prep --max-examples 1000
+"""
+
+import argparse
+from pathlib import Path
+
+from datasets import load_dataset
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+BLOCK_MASKING_TOKENS = [
+    "<|block_start|>",
+    "<|block_end|>",
+    "<|summary_start|>",
+    "<|summary_end|>",
+]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Prepare model + dataset for Memento SFT")
+    parser.add_argument("--model", default="Qwen/Qwen3-0.6B")
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--max-examples", type=int, default=5000)
+    parser.add_argument("--model-only", action="store_true", help="Only prepare model, skip dataset")
+    args = parser.parse_args()
+
+    output = Path(args.output_dir)
+    model_dir = output / "model"
+    data_dir = output / "data"
+
+    # --- 1. Add special tokens to tokenizer + resize model embeddings ---
+    print(f"Loading {args.model}...")
+    tokenizer = AutoTokenizer.from_pretrained(args.model, trust_remote_code=True)
+    model = AutoModelForCausalLM.from_pretrained(args.model, torch_dtype="bfloat16")
+
+    existing = set(tokenizer.get_vocab().keys())
+    new_tokens = [t for t in BLOCK_MASKING_TOKENS if t not in existing]
+
+    if new_tokens:
+        added = tokenizer.add_special_tokens({"additional_special_tokens": new_tokens})
+        model.resize_token_embeddings(len(tokenizer))
+        print(f"Added {added} special tokens, resized embeddings to {len(tokenizer)}")
+    else:
+        print("All block masking tokens already in vocabulary")
+
+    for tok in BLOCK_MASKING_TOKENS:
+        tid = tokenizer.convert_tokens_to_ids(tok)
+        assert tid != tokenizer.unk_token_id, f"Token {tok} not found after adding"
+        print(f"  {tok} -> {tid}")
+
+    model_dir.mkdir(parents=True, exist_ok=True)
+    model.save_pretrained(model_dir)
+    tokenizer.save_pretrained(model_dir)
+    print(f"Saved model + tokenizer to {model_dir}")
+
+    if args.model_only:
+        print("--model-only: skipping dataset preparation")
+        return
+
+    # --- 2. Convert OpenMementos to messages format ---
+    print(f"Loading microsoft/OpenMementos (first {args.max_examples} examples)...")
+    ds = load_dataset("microsoft/OpenMementos", split=f"train[:{args.max_examples}]")
+
+    def to_messages(example):
+        return {
+            "messages": [
+                {"role": "user", "content": example["problem"]},
+                {"role": "assistant", "content": example["response"]},
+            ]
+        }
+
+    ds = ds.map(to_messages, remove_columns=ds.column_names)
+    train_dir = data_dir / "train"
+    train_dir.mkdir(parents=True, exist_ok=True)
+    ds.to_parquet(str(train_dir / "data.parquet"))
+    print(f"Saved {len(ds)} examples to {train_dir}/data.parquet")
+
+    # --- 3. Print token IDs for the block masking config ---
+    print("\nBlock masking config token IDs (for inference):")
+    for tok in BLOCK_MASKING_TOKENS:
+        tid = tokenizer.convert_tokens_to_ids(tok)
+        print(f"  {tok}: {tid}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_block_masking_gpu.py
+++ b/scripts/test_block_masking_gpu.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""
+GPU tests for block masking overlay (T6 + T7).
+
+Run on a GPU workstation after install_block_masking_overlay.sh:
+    VLLM_USE_FLASHINFER_SAMPLER=0 uv run python scripts/test_block_masking_gpu.py
+
+T6: Overlay contract test — verifies stock 0.21.0 features + block masking additions.
+T7: End-to-end inference — loads Qwen3-0.6B, injects block masking config, verifies
+    engine starts and generates correctly with the overlay applied.
+"""
+
+import inspect
+import os
+import sys
+import traceback
+
+os.environ.setdefault("VLLM_USE_FLASHINFER_SAMPLER", "0")
+os.environ.setdefault("VLLM_USE_DEEP_GEMM", "0")
+os.environ.setdefault("VLLM_MOE_USE_DEEP_GEMM", "0")
+
+
+def test_overlay_matches_stock_021():
+    """T6: Verify overlay has BOTH stock 0.21.0 features AND block masking additions."""
+
+    # --- Stock vLLM 0.21.0 features ---
+    from vllm.v1.core.sched.scheduler import Scheduler
+
+    init_sig = inspect.signature(Scheduler.__init__)
+    init_params = list(init_sig.parameters.keys())
+    assert "structured_output_manager" in init_params, "Missing structured_output_manager"
+    assert "hash_block_size" in init_params, "Missing hash_block_size"
+    assert "block_size" in init_params, "Missing block_size"
+    assert hasattr(Scheduler, "set_pause_state"), "Missing set_pause_state"
+
+    preempt_sig = inspect.signature(Scheduler._preempt_request)
+    assert "timestamp" in preempt_sig.parameters, "Missing timestamp in _preempt_request"
+
+    from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
+
+    so_fields = set(SchedulerOutput.__dataclass_fields__.keys())
+    assert "kv_connector_metadata" in so_fields, "Missing kv_connector_metadata"
+    assert "scheduled_spec_decode_tokens" in so_fields, "Missing scheduled_spec_decode_tokens"
+    assert "ec_connector_metadata" in so_fields, "Missing ec_connector_metadata"
+    assert "new_block_ids_to_zero" in so_fields, "Missing new_block_ids_to_zero"
+
+    crd_fields = set(CachedRequestData.__dataclass_fields__.keys())
+    assert "resumed_req_ids" in crd_fields, "Missing resumed_req_ids"
+    assert "num_output_tokens" in crd_fields, "Missing num_output_tokens"
+
+    from vllm.v1.core.kv_cache_manager import KVCacheManager
+
+    assert hasattr(KVCacheManager, "allocate_slots"), "Missing allocate_slots"
+
+    from vllm.distributed.kv_events import BlockStored
+
+    assert BlockStored is not None
+
+    from vllm.v1.request import Request
+
+    assert not hasattr(Request, "__slots__"), "Request has __slots__"
+
+    # --- Block masking additions ---
+    from vllm.v1.engine import SpanRemovalResult
+
+    assert SpanRemovalResult is not None
+
+    assert hasattr(Scheduler, "mask_token_span"), "Missing mask_token_span"
+
+    assert "kv_copy_operations" in so_fields, "Missing kv_copy_operations"
+    assert "block_table_truncations" in so_fields, "Missing block_table_truncations"
+    assert "skip_sampling_req_ids" in so_fields, "Missing skip_sampling_req_ids"
+    assert "block_masking_barrier" in so_fields, "Missing block_masking_barrier"
+
+    assert hasattr(KVCacheManager, "compact_kv_cache"), "Missing compact_kv_cache"
+
+    from vllm.distributed.kv_events import KVSlotCopy
+
+    assert KVSlotCopy is not None
+
+    from vllm.config import VllmConfig
+
+    assert hasattr(VllmConfig, "block_masking_config"), "VllmConfig missing block_masking_config"
+
+    from vllm.config.block_masking import BlockMaskingConfig
+
+    assert BlockMaskingConfig is not None
+
+    from vllm.v1.core.block_masking import BlockMaskingProcessor, BlockMaskingState
+
+    assert BlockMaskingProcessor is not None
+    assert BlockMaskingState is not None
+
+    from vllm.v1.worker.block_table import BlockTable
+
+    assert hasattr(BlockTable, "truncate_row"), "Missing BlockTable.truncate_row"
+
+    from vllm.v1.core.kv_cache_coordinator import KVCacheCoordinator
+
+    assert hasattr(
+        KVCacheCoordinator, "compact_kv_cache"
+    ), "Missing KVCacheCoordinator.compact_kv_cache"
+
+    from vllm.v1.core.single_type_kv_cache_manager import SingleTypeKVCacheManager
+
+    assert hasattr(
+        SingleTypeKVCacheManager, "compact_kv_cache"
+    ), "Missing SingleTypeKVCacheManager.compact_kv_cache"
+
+    assert "compacted_token_counts" in crd_fields, "Missing compacted_token_counts"
+
+    print("  T6 PASSED: All stock 0.21.0 features and block masking additions verified")
+
+
+def test_production_plugin_installs_patches():
+    """Verify the production vLLM plugin installs runtime block masking patches."""
+
+    from vllm.plugins import load_general_plugins
+
+    load_general_plugins()
+
+    from vllm.config import VllmConfig
+    from vllm.v1.engine.core import EngineCore
+    from vllm.v1.worker.gpu_input_batch import InputBatch
+    from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+
+    assert hasattr(VllmConfig, "block_masking_config")
+    assert getattr(EngineCore, "_prime_rl_block_masking_barrier_patched", False)
+    assert getattr(InputBatch, "_prime_rl_block_masking_patched", False)
+    assert getattr(GPUModelRunner, "_prime_rl_block_masking_patched", False)
+    assert hasattr(GPUModelRunner, "_execute_kv_copy_operations")
+
+    print("  T6b PASSED: prime_rl production plugin installed block masking patches")
+
+
+def test_end_to_end_inference():
+    """T7: Serve Qwen3-0.6B with block masking config, verify inference works."""
+
+    from vllm import LLM, SamplingParams
+
+    MODEL = "Qwen/Qwen3-0.6B"
+
+    print("  Loading model...")
+    llm = LLM(
+        model=MODEL,
+        dtype="float16",
+        max_model_len=2048,
+        gpu_memory_utilization=0.5,
+        enforce_eager=True,
+        additional_config={
+            "block_masking_config": {
+                "enable": True,
+                "mask_delimiters": False,
+                "keep_last_n_blocks": 0,
+                "async_mode": os.environ.get("BLOCK_MASKING_ASYNC_MODE", "safe_sync"),
+                "debug": True,
+                "block_start_token": "<think>",
+                "block_end_token": "</think>",
+                "summary_start_token": "<|im_start|>",
+                "summary_end_token": "<|im_end|>",
+            }
+        },
+    )
+    print("  Engine started with block masking config")
+
+    # Test A: Basic generation
+    print("  Running basic generation...")
+    outputs = llm.generate(
+        ["What is 2 + 3?"],
+        SamplingParams(temperature=0.0, max_tokens=128),
+    )
+    assert len(outputs) == 1
+    text = outputs[0].outputs[0].text
+    assert len(outputs[0].outputs[0].token_ids) > 0, "Empty token output"
+    print(f"  Basic output: {text[:200]}")
+
+    # Test B: Multiple concurrent requests
+    print("  Running concurrent requests...")
+    prompts = [
+        "What is 10+20?",
+        "What is 5*6?",
+        "What is 100-37?",
+        "What is 8/2?",
+    ]
+    outputs = llm.generate(
+        prompts,
+        SamplingParams(temperature=0.0, max_tokens=64),
+    )
+    assert len(outputs) == 4
+    for i, out in enumerate(outputs):
+        t = out.outputs[0].text
+        assert len(out.outputs[0].token_ids) > 0, f"Empty token output for prompt {i}"
+        print(f"  [{i}] {t[:80]}")
+
+    # Test C: Prompt with <think> tags (block markers) in prefill
+    print("  Running prefill with block markers...")
+    prompt_with_think = (
+        "<|im_start|>user\nWhat is 15+27?<|im_end|>\n"
+        "<|im_start|>assistant\n"
+        "<think>Let me add 15 and 27. 15 + 27 = 42.</think>"
+        "The answer is 42.<|im_end|>\n"
+        "<|im_start|>user\nNow what is 42 * 2?<|im_end|>\n"
+        "<|im_start|>assistant\n"
+    )
+    outputs = llm.generate(
+        [prompt_with_think],
+        SamplingParams(
+            temperature=0.0,
+            max_tokens=8,
+            min_tokens=8,
+            ignore_eos=True,
+            skip_special_tokens=False,
+        ),
+    )
+    text = outputs[0].outputs[0].text
+    token_count = len(outputs[0].outputs[0].token_ids)
+    finish_reason = outputs[0].outputs[0].finish_reason
+    assert token_count == 8, f"Expected 8 tokens after prefill block markers, got {token_count}"
+    assert finish_reason == "length", f"Expected length finish, got {finish_reason!r}"
+    print(f"  Prefill+block output: {text[:200]}")
+
+    print("  T7 PASSED: Engine started, generated, handled block markers")
+
+
+def main():
+    tests = [
+        ("T6b: Production plugin contract", test_production_plugin_installs_patches),
+        ("T6: Overlay contract", test_overlay_matches_stock_021),
+        ("T7: End-to-end inference", test_end_to_end_inference),
+    ]
+
+    passed = 0
+    failed = 0
+
+    for name, test_fn in tests:
+        print(f"\n{'='*60}")
+        print(f"Running {name}...")
+        print(f"{'='*60}")
+        try:
+            test_fn()
+            passed += 1
+        except Exception:
+            failed += 1
+            traceback.print_exc()
+            print(f"  {name} FAILED")
+
+    print(f"\n{'='*60}")
+    print(f"Results: {passed} passed, {failed} failed, {passed + failed} total")
+    print(f"{'='*60}")
+
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_block_masking_inference.py
+++ b/scripts/test_block_masking_inference.py
@@ -1,0 +1,723 @@
+#!/usr/bin/env python
+"""Test block masking overlay works in vLLM.
+
+Verifies:
+1. vLLM starts with block masking overlay + config (no crash)
+2. Block masking tokens resolve correctly
+3. Prompts with embedded block markers are processed by the scheduler
+4. Generation after block markers doesn't corrupt output
+
+Does NOT require a Memento-trained model — uses base model with added tokens.
+
+Usage:
+    python scripts/test_block_masking_inference.py --model /path/to/model
+"""
+
+import argparse
+import asyncio
+import gc
+import inspect
+import os
+import sys
+from pathlib import Path
+
+
+def find_model_dir(search_root: str) -> str | None:
+    root = Path(search_root)
+    if (root / "config.json").exists():
+        return str(root)
+    for p in sorted(root.rglob("config.json")):
+        return str(p.parent)
+    return None
+
+
+def run_t6_overlay_contract():
+    """T6: Verify overlay has BOTH stock 0.21.0 features AND block masking additions."""
+    print("\n=== T6: Overlay contract ===")
+
+    from vllm.v1.core.sched.scheduler import Scheduler
+
+    init_params = list(inspect.signature(Scheduler.__init__).parameters.keys())
+    assert "structured_output_manager" in init_params
+    assert "hash_block_size" in init_params
+    assert hasattr(Scheduler, "set_pause_state")
+    assert hasattr(Scheduler, "mask_token_span")
+
+    from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
+
+    so_fields = set(SchedulerOutput.__dataclass_fields__.keys())
+    assert "kv_copy_operations" in so_fields
+    assert "block_table_truncations" in so_fields
+    assert "skip_sampling_req_ids" in so_fields
+    assert "block_masking_barrier" in so_fields
+    assert "kv_connector_metadata" in so_fields
+
+    crd_fields = set(CachedRequestData.__dataclass_fields__.keys())
+    assert "compacted_token_counts" in crd_fields
+
+    from vllm.v1.core.kv_cache_manager import KVCacheManager
+
+    assert hasattr(KVCacheManager, "compact_kv_cache")
+
+    from vllm.distributed.kv_events import KVSlotCopy  # noqa: F401
+    from vllm.v1.engine import SpanRemovalResult  # noqa: F401
+
+    from vllm.config import VllmConfig
+
+    assert hasattr(VllmConfig, "block_masking_config")
+
+    from vllm.v1.worker.block_table import BlockTable
+
+    assert hasattr(BlockTable, "truncate_row")
+
+    from vllm.v1.core.kv_cache_coordinator import KVCacheCoordinator
+
+    assert hasattr(KVCacheCoordinator, "compact_kv_cache")
+
+    from vllm.v1.core.single_type_kv_cache_manager import SingleTypeKVCacheManager
+
+    assert hasattr(SingleTypeKVCacheManager, "compact_kv_cache")
+
+    print("PASS: All stock 0.21.0 features and block masking additions verified")
+
+
+def run_t6_production_patch_contract():
+    """Verify the production vLLM plugin installs runtime block masking patches."""
+    print("\n=== T6b: Production plugin contract ===")
+
+    from vllm.plugins import load_general_plugins
+
+    load_general_plugins()
+
+    from vllm.config import VllmConfig
+    from vllm.v1.engine.core import EngineCore
+    from vllm.v1.worker.gpu_input_batch import InputBatch
+    from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+
+    assert hasattr(VllmConfig, "block_masking_config")
+    assert getattr(EngineCore, "_prime_rl_block_masking_barrier_patched", False)
+    assert getattr(InputBatch, "_prime_rl_block_masking_patched", False)
+    assert getattr(GPUModelRunner, "_prime_rl_block_masking_patched", False)
+    assert hasattr(GPUModelRunner, "_execute_kv_copy_operations")
+    print("PASS: prime_rl production plugin installed block masking patches")
+
+
+def assert_fixed_length_generation(output, expected_tokens: int, label: str) -> None:
+    token_count = len(output.outputs[0].token_ids)
+    finish_reason = output.outputs[0].finish_reason
+    assert token_count == expected_tokens, (
+        f"{label}: expected {expected_tokens} output tokens, got "
+        f"{token_count} (finish={finish_reason!r})"
+    )
+    assert finish_reason == "length", (
+        f"{label}: expected finish_reason='length', got {finish_reason!r}"
+    )
+
+
+def block_masking_additional_config(async_mode: str) -> dict:
+    return {
+        "block_masking_config": {
+            "enable": True,
+            "mask_delimiters": False,
+            "keep_last_n_blocks": 0,
+            "async_mode": async_mode,
+            "debug": True,
+        }
+    }
+
+
+def shutdown_sync_llm(llm) -> None:
+    engine = getattr(llm, "llm_engine", None)
+    engine_core = getattr(engine, "engine_core", None)
+    if engine_core is not None and hasattr(engine_core, "shutdown"):
+        engine_core.shutdown()
+    gc.collect()
+
+    import torch
+
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+
+async def run_t7e_async_client_drain_stress(
+    model_path: str,
+    max_model_len: int,
+    normal_prompt: str,
+    compaction_prompts: list[str],
+    *,
+    repeats: int,
+    long_tokens: int,
+    compact_tokens: int,
+    enforce_eager: bool,
+    gpu_memory_utilization: float,
+) -> None:
+    """Drive vLLM through AsyncLLM so block masking sees queued async work."""
+    from vllm import SamplingParams
+    from vllm.engine.arg_utils import AsyncEngineArgs
+    from vllm.v1.engine.async_llm import AsyncLLM
+
+    engine_args = AsyncEngineArgs(
+        model=model_path,
+        dtype="float16",
+        max_model_len=max_model_len,
+        gpu_memory_utilization=gpu_memory_utilization,
+        enforce_eager=enforce_eager,
+        async_scheduling=True,
+        disable_log_stats=True,
+        additional_config=block_masking_additional_config("async_barrier"),
+    )
+    engine = AsyncLLM.from_engine_args(engine_args)
+
+    async def collect(prompt: str, sampling_params: SamplingParams, request_id: str):
+        final = None
+        async for output in engine.generate(
+            prompt,
+            sampling_params,
+            request_id=request_id,
+        ):
+            final = output
+        assert final is not None, f"{request_id}: no final output"
+        return final
+
+    long_params = SamplingParams(
+        temperature=0,
+        max_tokens=long_tokens,
+        min_tokens=long_tokens,
+        ignore_eos=True,
+        skip_special_tokens=False,
+    )
+    compact_params = SamplingParams(
+        temperature=0,
+        max_tokens=compact_tokens,
+        min_tokens=compact_tokens,
+        ignore_eos=True,
+        skip_special_tokens=False,
+    )
+
+    try:
+        for repeat in range(repeats):
+            normal_task = asyncio.create_task(
+                collect(
+                    normal_prompt + f"\nStress wave: {repeat}.",
+                    long_params,
+                    f"async-normal-long-{repeat}",
+                )
+            )
+            await asyncio.sleep(0.05)
+            compaction_tasks = [
+                asyncio.create_task(
+                    collect(
+                        prompt + f"\nStress wave: {repeat}.",
+                        compact_params,
+                        f"async-compact-{repeat}-{i}",
+                    )
+                )
+                for i, prompt in enumerate(compaction_prompts)
+            ]
+            outputs = await asyncio.gather(normal_task, *compaction_tasks)
+            assert_fixed_length_generation(
+                outputs[0], long_tokens, f"async normal long request wave {repeat}"
+            )
+            for i, out in enumerate(outputs[1:]):
+                assert_fixed_length_generation(
+                    out, compact_tokens, f"async compaction request wave {repeat} idx {i}"
+                )
+    finally:
+        engine.shutdown()
+
+    print(
+        "  PASS: Async client drain stress completed for "
+        f"{repeats} wave(s), {repeats * (1 + len(compaction_prompts))} requests"
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--max-tokens", type=int, default=256)
+    parser.add_argument("--max-model-len", type=int, default=4096)
+    parser.add_argument(
+        "--enforce-eager",
+        action=argparse.BooleanOptionalAction,
+        default=os.environ.get("MEMENTO_INFERENCE_ENFORCE_EAGER", "1") != "0",
+    )
+    parser.add_argument(
+        "--gpu-memory-utilization",
+        type=float,
+        default=float(os.environ.get("MEMENTO_INFERENCE_GPU_MEMORY_UTILIZATION", "0.8")),
+    )
+    parser.add_argument(
+        "--async-stress-repeats",
+        type=int,
+        default=int(os.environ.get("MEMENTO_ASYNC_STRESS_REPEATS", "1")),
+    )
+    parser.add_argument(
+        "--stress-compact-requests",
+        type=int,
+        default=int(os.environ.get("MEMENTO_STRESS_COMPACT_REQUESTS", "8")),
+    )
+    parser.add_argument(
+        "--stress-long-tokens",
+        type=int,
+        default=int(os.environ.get("MEMENTO_STRESS_LONG_TOKENS", "256")),
+    )
+    parser.add_argument(
+        "--stress-compact-tokens",
+        type=int,
+        default=int(os.environ.get("MEMENTO_STRESS_COMPACT_TOKENS", "16")),
+    )
+    parser.add_argument(
+        "--block-masking-async-mode",
+        choices=("safe_sync", "async_barrier"),
+        default=os.environ.get("BLOCK_MASKING_ASYNC_MODE", "safe_sync"),
+    )
+    args = parser.parse_args()
+
+    model_path = find_model_dir(args.model)
+    if model_path is None:
+        print(f"ERROR: No config.json found under {args.model}")
+        root = Path(args.model)
+        if root.exists():
+            for p in sorted(root.rglob("*"))[:40]:
+                print(f"  {p.relative_to(root)}")
+        sys.exit(1)
+
+    print(f"Model: {model_path}")
+    print(f"Block masking async mode: {args.block_masking_async_mode}")
+    print(f"enforce_eager={args.enforce_eager}")
+    print(f"gpu_memory_utilization={args.gpu_memory_utilization}")
+    print(f"async_stress_repeats={args.async_stress_repeats}")
+
+    # T6: Production patch and overlay contracts
+    run_t6_production_patch_contract()
+    run_t6_overlay_contract()
+
+    # Verify DeepGEMM is disabled (should not be in the path for Memento/Qwen)
+    import vllm.envs as vllm_envs
+    deep_gemm_enabled = getattr(vllm_envs, "VLLM_USE_DEEP_GEMM", False)
+    print(f"\n  VLLM_USE_DEEP_GEMM = {deep_gemm_enabled}")
+    assert not deep_gemm_enabled, (
+        "DeepGEMM should be disabled for Memento/Qwen smoke tests. "
+        "Set VLLM_USE_DEEP_GEMM=0 in the environment."
+    )
+
+    from vllm import LLM, SamplingParams
+
+    # --- Test 1: Engine starts with block masking ---
+    print("\n=== Test 1: Engine initialization ===")
+    llm = LLM(
+        model=model_path,
+        dtype="float16",
+        max_model_len=args.max_model_len,
+        gpu_memory_utilization=args.gpu_memory_utilization,
+        enforce_eager=args.enforce_eager,
+        additional_config=block_masking_additional_config(args.block_masking_async_mode),
+    )
+    print("PASS: vLLM engine started with block masking overlay")
+
+    # --- Test 2: Token resolution ---
+    print("\n=== Test 2: Block masking token resolution ===")
+    tokenizer = llm.get_tokenizer()
+    block_tokens = {
+        "<|block_start|>": None,
+        "<|block_end|>": None,
+        "<|summary_start|>": None,
+        "<|summary_end|>": None,
+    }
+    all_ok = True
+    for tok in block_tokens:
+        tid = tokenizer.convert_tokens_to_ids(tok)
+        ok = tid is not None and (
+            tokenizer.unk_token_id is None or tid != tokenizer.unk_token_id
+        )
+        block_tokens[tok] = tid
+        print(f"  {tok} -> {tid} ({'OK' if ok else 'MISSING'})")
+        if not ok:
+            all_ok = False
+
+    if not all_ok:
+        print("FAIL: Missing block masking tokens")
+        sys.exit(1)
+    print("PASS: All block masking tokens resolved")
+
+    # --- Test 3: Normal generation (no block markers) ---
+    print("\n=== Test 3: Normal generation (baseline) ===")
+    outputs = llm.chat(
+        [[{"role": "user", "content": "What is 2+3?"}]],
+        SamplingParams(temperature=0, max_tokens=64),
+    )
+    text = outputs[0].outputs[0].text
+    assert len(outputs[0].outputs[0].token_ids) > 0, "Normal generation produced no tokens"
+    print(f"  Output: {text[:200]}")
+    print("PASS: Normal generation works with block masking enabled")
+
+    # --- Test 4: Prompt with embedded block markers ---
+    print("\n=== Test 4: Prompt with embedded block markers ===")
+    prompt_with_blocks = tokenizer.apply_chat_template(
+        [
+            {"role": "user", "content": "What is 15+27?"},
+            {
+                "role": "assistant",
+                "content": (
+                    "<|block_start|>"
+                    "Let me add 15 and 27. 15 + 27 = 42."
+                    "<|block_end|>"
+                    "<|summary_start|>"
+                    "15 + 27 = 42"
+                    "<|summary_end|>"
+                    "\nThe answer is 42."
+                ),
+            },
+            {"role": "user", "content": "Now what is 42 * 2?"},
+        ],
+        tokenize=False,
+        add_generation_prompt=True,
+    )
+
+    outputs = llm.generate(
+        [prompt_with_blocks],
+        SamplingParams(temperature=0, max_tokens=128),
+    )
+    text = outputs[0].outputs[0].text
+    assert len(outputs[0].outputs[0].token_ids) > 0, "Block-marker prompt produced no tokens"
+    print(f"  Output: {text[:300]}")
+    print("PASS: Prompt with block markers processed without crash")
+
+    # --- Test 5: Multiple concurrent requests ---
+    print("\n=== Test 5: Concurrent requests with block masking ===")
+    prompts = [
+        [{"role": "user", "content": "What is 10+20?"}],
+        [{"role": "user", "content": "What is 5*6?"}],
+        [{"role": "user", "content": "What is 100-37?"}],
+        [{"role": "user", "content": "What is 8/2?"}],
+    ]
+    outputs = llm.chat(
+        prompts,
+        SamplingParams(temperature=0, max_tokens=64),
+    )
+    for i, out in enumerate(outputs):
+        text = out.outputs[0].text
+        assert len(out.outputs[0].token_ids) > 0, f"Concurrent request {i} produced no tokens"
+        print(f"  [{i}] {text[:100]}")
+    print(f"PASS: {len(outputs)} concurrent requests completed")
+
+    # --- Test 6: Prompt-engineered block marker generation ---
+    print("\n=== Test 6: Prompt-engineered block marker generation ===")
+    system_prompt = (
+        "You are a helpful math assistant. When solving problems, structure your "
+        "reasoning using these special tokens:\n"
+        "- Wrap each reasoning step in <|block_start|> ... <|block_end|>\n"
+        "- After each block, write a summary in <|summary_start|> ... <|summary_end|>\n"
+        "- Then give the final answer.\n\n"
+        "Example:\n"
+        "<|block_start|>First, I'll add 2 and 3. 2 + 3 = 5.<|block_end|>"
+        "<|summary_start|>2 + 3 = 5<|summary_end|>\n"
+        "The answer is 5."
+    )
+    prompted_messages = [
+        [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": "What is 15 + 27?"},
+        ],
+        [
+            {"role": "system", "content": system_prompt},
+            {
+                "role": "user",
+                "content": "A store has 48 apples. 15 are sold. How many remain?",
+            },
+        ],
+    ]
+    outputs = llm.chat(
+        prompted_messages,
+        SamplingParams(temperature=0.3, max_tokens=args.max_tokens),
+    )
+
+    markers_found = {t: 0 for t in block_tokens}
+    for i, out in enumerate(outputs):
+        text = out.outputs[0].text
+        print(f"\n  Prompt {i}: {prompted_messages[i][-1]['content']}")
+        print(f"  Output: {text[:500]}")
+        for tok in block_tokens:
+            markers_found[tok] += text.count(tok)
+
+    print(f"\n  Block markers in output: {markers_found}")
+    has_blocks = (
+        markers_found["<|block_start|>"] > 0 and markers_found["<|block_end|>"] > 0
+    )
+    has_summaries = (
+        markers_found["<|summary_start|>"] > 0
+        and markers_found["<|summary_end|>"] > 0
+    )
+
+    if has_blocks and has_summaries:
+        print("PASS: Model generated complete block+summary cycles via prompting")
+    elif any(v > 0 for v in markers_found.values()):
+        print("PARTIAL: Some block markers generated but incomplete cycles")
+    else:
+        print("INFO: No block markers in prompt-engineered output")
+        print("  (Expected for base model — SFT model would generate them reliably)")
+
+    # --- Test 7: End-to-end compaction verification ---
+    print("\n=== Test 7: End-to-end compaction verification ===")
+
+    # 7a: Verify compaction fires and output is non-empty.
+    # Build a prompt with a completed block+summary in conversation history.
+    prompt_7a = tokenizer.apply_chat_template(
+        [
+            {"role": "user", "content": "What is 15+27?"},
+            {
+                "role": "assistant",
+                "content": (
+                    "<|block_start|>"
+                    "I need to add 15 and 27. Breaking it down: 15 + 27 = 42."
+                    "<|block_end|>"
+                    "<|summary_start|>"
+                    "15 + 27 = 42"
+                    "<|summary_end|>"
+                    "\nThe answer is 42."
+                ),
+            },
+            {"role": "user", "content": "Now what is 42 * 2?"},
+        ],
+        tokenize=False,
+        add_generation_prompt=True,
+    )
+    prompt_7a_ids = tokenizer.encode(prompt_7a)
+    print(f"  Prompt token count: {len(prompt_7a_ids)}")
+
+    # Check block masking tokens are in the prompt
+    bs_id = block_tokens["<|block_start|>"]
+    be_id = block_tokens["<|block_end|>"]
+    ss_id = block_tokens["<|summary_start|>"]
+    se_id = block_tokens["<|summary_end|>"]
+    strict_compaction_params = SamplingParams(
+        temperature=0,
+        max_tokens=8,
+        min_tokens=8,
+        ignore_eos=True,
+        skip_special_tokens=False,
+    )
+    assert bs_id in prompt_7a_ids, "block_start not in prompt tokens"
+    assert be_id in prompt_7a_ids, "block_end not in prompt tokens"
+    assert ss_id in prompt_7a_ids, "summary_start not in prompt tokens"
+    assert se_id in prompt_7a_ids, "summary_end not in prompt tokens"
+    print("  All block tokens present in prompt")
+
+    outputs_7a = llm.generate(
+        [prompt_7a],
+        strict_compaction_params,
+    )
+    text_7a = outputs_7a[0].outputs[0].text
+    finish_reason = outputs_7a[0].outputs[0].finish_reason
+    num_output_tokens = len(outputs_7a[0].outputs[0].token_ids)
+
+    print(f"  Output ({num_output_tokens} tokens, finish={finish_reason}): {text_7a[:300]}")
+    assert_fixed_length_generation(outputs_7a[0], 8, "single-block compaction")
+    print(f"  PASS: Generated {num_output_tokens} tokens after compaction")
+
+    # 7b: Multi-block compaction — two blocks in conversation history.
+    print("\n  --- Test 7b: Multi-block compaction ---")
+    prompt_7b = tokenizer.apply_chat_template(
+        [
+            {"role": "user", "content": "What is 10+20?"},
+            {
+                "role": "assistant",
+                "content": (
+                    "<|block_start|>"
+                    "Adding 10 and 20 gives 30."
+                    "<|block_end|>"
+                    "<|summary_start|>"
+                    "10 + 20 = 30"
+                    "<|summary_end|>"
+                    "\nThe answer is 30."
+                ),
+            },
+            {"role": "user", "content": "And what is 30+15?"},
+            {
+                "role": "assistant",
+                "content": (
+                    "<|block_start|>"
+                    "30 plus 15 equals 45."
+                    "<|block_end|>"
+                    "<|summary_start|>"
+                    "30 + 15 = 45"
+                    "<|summary_end|>"
+                    "\nThe answer is 45."
+                ),
+            },
+            {"role": "user", "content": "Now multiply that by 2."},
+        ],
+        tokenize=False,
+        add_generation_prompt=True,
+    )
+    prompt_7b_ids = tokenizer.encode(prompt_7b)
+    print(f"  Prompt token count: {len(prompt_7b_ids)}")
+    block_count = prompt_7b_ids.count(bs_id)
+    print(f"  Block markers found: {block_count}")
+
+    outputs_7b = llm.generate(
+        [prompt_7b],
+        strict_compaction_params,
+    )
+    text_7b = outputs_7b[0].outputs[0].text
+    num_output_7b = len(outputs_7b[0].outputs[0].token_ids)
+    finish_7b = outputs_7b[0].outputs[0].finish_reason
+
+    print(f"  Output ({num_output_7b} tokens, finish={finish_7b}): {text_7b[:300]}")
+    assert_fixed_length_generation(outputs_7b[0], 8, "multi-block compaction")
+    print(f"  PASS: Generated {num_output_7b} tokens after multi-block compaction")
+
+    # 7c: Concurrent requests with compaction — verify no cross-request corruption.
+    print("\n  --- Test 7c: Concurrent compaction requests ---")
+    prompts_7c = []
+    for q in ["What is 5+3?", "What is 7*4?", "What is 20-8?"]:
+        p = tokenizer.apply_chat_template(
+            [
+                {"role": "user", "content": q.replace("+", "+").replace("*", "*")},
+                {
+                    "role": "assistant",
+                    "content": (
+                        "<|block_start|>"
+                        f"Computing: {q}"
+                        "<|block_end|>"
+                        "<|summary_start|>"
+                        f"Result of {q}"
+                        "<|summary_end|>"
+                    ),
+                },
+                {"role": "user", "content": "What was the result?"},
+            ],
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        prompts_7c.append(p)
+
+    outputs_7c = llm.generate(
+        prompts_7c,
+        strict_compaction_params,
+    )
+    for i, out in enumerate(outputs_7c):
+        text = out.outputs[0].text
+        n_tok = len(out.outputs[0].token_ids)
+        print(f"    [{i}] ({n_tok} tokens): {text[:100]}")
+        assert_fixed_length_generation(out, 8, f"concurrent compaction request {i}")
+
+    print(f"  PASS: All {len(outputs_7c)} concurrent compaction requests produced fixed-length output")
+
+    if args.block_masking_async_mode == "async_barrier":
+        print("\n  --- Test 7d: Mixed async-barrier pressure ---")
+        mixed_prompts = [
+            tokenizer.apply_chat_template(
+                [
+                    {
+                        "role": "user",
+                        "content": (
+                            "Count upward from one and briefly explain each number. "
+                            "Keep going until you run out of space."
+                        ),
+                    }
+                ],
+                tokenize=False,
+                add_generation_prompt=True,
+            )
+        ]
+        for i in range(6):
+            mixed_prompts.append(
+                tokenizer.apply_chat_template(
+                    [
+                        {"role": "user", "content": f"What is {i + 3}+{i + 9}?"},
+                        {
+                            "role": "assistant",
+                            "content": (
+                                "<|block_start|>"
+                                f"Compute {i + 3}+{i + 9} step by step."
+                                "<|block_end|>"
+                                "<|summary_start|>"
+                                f"{i + 3}+{i + 9} computed"
+                                "<|summary_end|>"
+                            ),
+                        },
+                        {"role": "user", "content": "State the result again."},
+                    ],
+                    tokenize=False,
+                    add_generation_prompt=True,
+                )
+            )
+        mixed_params = SamplingParams(
+            temperature=0,
+            max_tokens=16,
+            min_tokens=16,
+            ignore_eos=True,
+            skip_special_tokens=False,
+        )
+        outputs_7d = llm.generate(mixed_prompts, mixed_params)
+        for i, out in enumerate(outputs_7d):
+            text = out.outputs[0].text
+            n_tok = len(out.outputs[0].token_ids)
+            print(f"    [{i}] ({n_tok} tokens): {text[:100]}")
+            assert_fixed_length_generation(out, 16, f"mixed async-barrier request {i}")
+        print(f"  PASS: Mixed async-barrier pressure completed for {len(outputs_7d)} requests")
+
+        print("\n  --- Test 7e: Async client drain stress ---")
+        async_normal_prompt = tokenizer.apply_chat_template(
+            [
+                {
+                    "role": "user",
+                    "content": (
+                        "Write a long numbered list about arithmetic patterns. "
+                        "Keep each item short and continue until the token budget ends."
+                    ),
+                }
+            ],
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        async_compaction_prompts = []
+        for i in range(args.stress_compact_requests):
+            async_compaction_prompts.append(
+                tokenizer.apply_chat_template(
+                    [
+                        {"role": "user", "content": f"What is {i + 11}+{i + 17}?"},
+                        {
+                            "role": "assistant",
+                            "content": (
+                                "<|block_start|>"
+                                f"Compute {i + 11}+{i + 17} carefully."
+                                "<|block_end|>"
+                                "<|summary_start|>"
+                                f"{i + 11}+{i + 17} computed"
+                                "<|summary_end|>"
+                            ),
+                        },
+                        {"role": "user", "content": "State the result again."},
+                    ],
+                    tokenize=False,
+                    add_generation_prompt=True,
+                )
+            )
+        shutdown_sync_llm(llm)
+        llm = None
+        asyncio.run(
+            run_t7e_async_client_drain_stress(
+                model_path,
+                args.max_model_len,
+                async_normal_prompt,
+                async_compaction_prompts,
+                repeats=args.async_stress_repeats,
+                long_tokens=args.stress_long_tokens,
+                compact_tokens=args.stress_compact_tokens,
+                enforce_eager=args.enforce_eager,
+                gpu_memory_utilization=args.gpu_memory_utilization,
+            )
+        )
+
+    print("\n  T7 RESULT: All compaction tests produced fixed-length non-empty output")
+
+    # --- Summary ---
+    print(f"\n{'='*60}")
+    print("ALL TESTS PASSED")
+    print(f"{'='*60}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/prime_rl/inference/block_masking/__init__.py
+++ b/src/prime_rl/inference/block_masking/__init__.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Block Masking module for Memento-style inference.
+
+This module provides automatic block compaction during generation,
+using vLLM's token span removal infrastructure.
+"""
+
+from .config import BlockMaskingConfig
+from .position_mapping import CompactedSpanTracker, merge_spans
+from .processor import BlockMaskingProcessor
+from .tracker import BlockInfo, BlockMaskingState
+
+__all__ = [
+    "BlockMaskingConfig",
+    "BlockMaskingState",
+    "BlockInfo",
+    "BlockMaskingProcessor",
+    "CompactedSpanTracker",
+    "merge_spans",
+]

--- a/src/prime_rl/inference/block_masking/config.py
+++ b/src/prime_rl/inference/block_masking/config.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Block Masking Configuration for Memento-style inference.
+
+Block masking enables automatic compaction of "thinking" blocks during
+generation, keeping only their summaries visible for subsequent attention.
+
+This implements the inference-time behavior of Memento-trained models,
+using vLLM's token compaction infrastructure for memory efficiency.
+
+Example usage:
+    from vllm import LLM
+    from vllm.config import BlockMaskingConfig
+
+    llm = LLM(
+        model="path/to/memento-model",
+        block_masking_config=BlockMaskingConfig(
+            enable=True,
+            keep_last_n_blocks=0,
+        ),
+    )
+"""
+
+from dataclasses import dataclass, field
+from typing import Literal, Optional
+
+
+@dataclass
+class BlockMaskingConfig:
+    """
+    Configuration for Memento-style block masking during inference.
+
+    When enabled, the engine monitors generated tokens for block boundary
+    markers and automatically compacts completed blocks using mask_token_span().
+
+    Attributes:
+        enable: Whether to enable block masking. Default False.
+
+        keep_last_n_blocks: How many completed blocks to keep visible.
+            -1 = Keep all blocks (no compaction, standard generation)
+            0 = Compact all completed blocks immediately (default when enabled)
+            N = Keep last N blocks visible, compact older ones
+
+        block_start_token: Token string for block start. Default "<|block_start|>"
+        block_end_token: Token string for block end. Default "<|block_end|>"
+        summary_start_token: Token string for summary start. Default "<|summary_start|>"
+        summary_end_token: Token string for summary end. Default "<|summary_end|>"
+
+        require_assistant_section: Only process blocks after <|im_start|>assistant.
+            This prevents false positives from block tokens in prompts.
+            Default True.
+
+        im_start_token: Token for detecting assistant section. Default "<|im_start|>"
+        assistant_token: Token after im_start for assistant. Default "assistant"
+
+        compact_on_summary_end: Trigger compaction when summary_end is seen.
+            If False, compaction must be triggered manually. Default True.
+
+        mask_delimiters: Whether to mask the block delimiter tokens (block_start, block_end)
+            in addition to the block content. REQUIRED - no default value.
+            - True: Mask delimiters (matches Phi3/Phi4 training)
+            - False: Keep delimiters visible (matches Qwen3/OLMo3 training)
+            This must be set explicitly to avoid train/inference mismatch.
+
+        keep_last_block_for_answer: When True with keep_last_n_blocks=0, defers
+            compaction of the most recently completed block so it remains visible
+            in the KV cache when the model generates the final answer (after
+            </think>). Older blocks are still evicted immediately.
+
+            NOTE: This is NOT the same as keep_last_n_blocks=1. With keep1,
+            during block N generation block N-1 content is still visible (it's
+            only compacted when block N's summary completes). With this option,
+            block N-1 is compacted as soon as block N's block_start is seen,
+            so during reasoning the model sees no old block content (matching
+            keep0 training distribution). Only the very last block is preserved
+            for the final answer. Default False.
+
+        debug: Enable debug logging. Default False.
+
+    Example:
+        # Default configuration (compact all blocks)
+        config = BlockMaskingConfig(enable=True)
+
+        # Keep last block visible (useful for reasoning chains)
+        config = BlockMaskingConfig(enable=True, keep_last_n_blocks=1)
+
+        # Custom tokens
+        config = BlockMaskingConfig(
+            enable=True,
+            block_start_token="<think>",
+            block_end_token="</think>",
+        )
+    """
+
+    enable: bool = False
+    keep_last_n_blocks: int = 0
+
+    # Block boundary tokens
+    block_start_token: str = "<|block_start|>"
+    block_end_token: str = "<|block_end|>"
+    summary_start_token: str = "<|summary_start|>"
+    summary_end_token: str = "<|summary_end|>"
+
+    # Assistant section detection
+    require_assistant_section: bool = True
+    im_start_token: str = "<|im_start|>"
+    assistant_token: str = "assistant"
+
+    # Behavior
+    compact_on_summary_end: bool = True
+    mask_delimiters: Optional[bool] = None  # REQUIRED when enable=True, no default
+    keep_last_block_for_answer: bool = False
+    restart_mode: bool = False
+    """When True, after compacting block content, rewind num_computed_tokens
+    to the summary_start position so the engine re-prefills summary tokens
+    with clean KV (block content no longer in cache). This matches HF
+    restart behavior: evict block+summary KV, recompute summary."""
+    async_mode: Literal["safe_sync", "async_barrier", "async_native"] = "safe_sync"
+    """How block masking interacts with vLLM async scheduling.
+
+    safe_sync disables async scheduling when block masking is enabled.
+    async_barrier keeps async scheduling enabled but serializes compaction steps.
+    async_native is reserved for a future placeholder-aware implementation.
+    """
+    max_block_tokens: int = 0
+    """Maximum tokens allowed inside a single block before forcing block_end.
+    0 = disabled (no cap). When > 0, a logits processor will force the model
+    to generate <|block_end|> once a block reaches this many content tokens."""
+    debug: bool = False
+
+    # Resolved token IDs (set during initialization)
+    _block_start_id: Optional[int] = field(default=None, repr=False)
+    _block_end_id: Optional[int] = field(default=None, repr=False)
+    _summary_start_id: Optional[int] = field(default=None, repr=False)
+    _summary_end_id: Optional[int] = field(default=None, repr=False)
+    _im_start_id: Optional[int] = field(default=None, repr=False)
+    _assistant_id: Optional[int] = field(default=None, repr=False)
+    _initialized: bool = field(default=False, repr=False)
+
+    def initialize_token_ids(self, tokenizer) -> "BlockMaskingConfig":
+        """
+        Resolve token strings to IDs using the provided tokenizer.
+
+        This must be called before the config is used. It's automatically
+        called by the engine during initialization.
+
+        Args:
+            tokenizer: HuggingFace tokenizer
+
+        Returns:
+            self (for chaining)
+
+        Raises:
+            ValueError: If required tokens are not in vocabulary
+        """
+        if self._initialized:
+            return self
+
+        def get_token_id(token: str, required: bool = True) -> Optional[int]:
+            """Get token ID, optionally raising if not found.
+            Accepts integer strings (e.g. "151669") as direct token IDs."""
+            # Support direct integer token IDs (e.g. for models without
+            # named special tokens like <|block_start|>)
+            try:
+                return int(token)
+            except (ValueError, TypeError):
+                pass
+            try:
+                # Try encode first
+                ids = tokenizer.encode(token, add_special_tokens=False)
+                if len(ids) == 1:
+                    return ids[0]
+                # Try convert_tokens_to_ids for special tokens
+                token_id = tokenizer.convert_tokens_to_ids(token)
+                if token_id != tokenizer.unk_token_id:
+                    return token_id
+            except Exception:
+                pass
+
+            if required:
+                raise ValueError(
+                    f"Token '{token}' not found in vocabulary. "
+                    f"Ensure the model was trained with this token or add it "
+                    f"using tokenizer.add_special_tokens()."
+                )
+            return None
+
+        # Resolve required block tokens
+        self._block_start_id = get_token_id(self.block_start_token, required=True)
+        self._block_end_id = get_token_id(self.block_end_token, required=True)
+        self._summary_start_id = get_token_id(self.summary_start_token, required=True)
+        self._summary_end_id = get_token_id(self.summary_end_token, required=True)
+
+        # Resolve optional assistant detection tokens
+        if self.require_assistant_section:
+            self._im_start_id = get_token_id(self.im_start_token, required=False)
+            self._assistant_id = get_token_id(self.assistant_token, required=False)
+            if self._im_start_id is None or self._assistant_id is None:
+                # Disable assistant section requirement if tokens not found
+                self.require_assistant_section = False
+
+        self._initialized = True
+        return self
+
+    @property
+    def block_start_id(self) -> int:
+        assert self._initialized, "Call initialize_token_ids() first"
+        return self._block_start_id
+
+    @property
+    def block_end_id(self) -> int:
+        assert self._initialized, "Call initialize_token_ids() first"
+        return self._block_end_id
+
+    @property
+    def summary_start_id(self) -> int:
+        assert self._initialized, "Call initialize_token_ids() first"
+        return self._summary_start_id
+
+    @property
+    def summary_end_id(self) -> int:
+        assert self._initialized, "Call initialize_token_ids() first"
+        return self._summary_end_id
+
+    @property
+    def im_start_id(self) -> Optional[int]:
+        return self._im_start_id
+
+    @property
+    def assistant_id(self) -> Optional[int]:
+        return self._assistant_id
+
+    def __post_init__(self):
+        if self.async_mode not in ("safe_sync", "async_barrier", "async_native"):
+            raise ValueError(
+                "async_mode must be one of: safe_sync, async_barrier, async_native"
+            )
+        if self.enable and self.keep_last_n_blocks < -1:
+            raise ValueError("keep_last_n_blocks must be >= -1")
+        if self.enable and self.mask_delimiters is None:
+            raise ValueError(
+                "mask_delimiters must be explicitly set when block masking is enabled.\n"
+                "  - mask_delimiters=True: Mask block_start and block_end tokens (Phi3/Phi4 style)\n"
+                "  - mask_delimiters=False: Keep delimiters visible (Qwen3/OLMo3 style)\n"
+                "This ensures inference matches the model's training configuration."
+            )

--- a/src/prime_rl/inference/block_masking/logits_processor.py
+++ b/src/prime_rl/inference/block_masking/logits_processor.py
@@ -1,0 +1,236 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Block Length Cap Logits Processor for Memento-style block masking.
+
+Forces generation of <|block_end|> when the current block exceeds a
+configurable token limit (max_block_tokens). This prevents blocks from
+growing unboundedly and triggers the model's summarization behavior.
+
+When a block's token count reaches the threshold, all logits are masked
+to -inf except for the block_end token, forcing the model to close the
+block and begin generating a summary.
+
+IMPORTANT: Requires --async-scheduling false to work correctly.
+In async scheduling mode, output_token_ids contains -1 placeholders
+which makes block boundary detection impossible.
+
+Configuration:
+    Set max_block_tokens > 0 in BlockMaskingConfig to enable.
+    E.g.: --block-masking-config '{"enable": true, "max_block_tokens": 2048, ...}'
+"""
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Optional
+
+import torch
+
+from vllm import SamplingParams
+from vllm.logger import init_logger
+from vllm.v1.sample.logits_processor.interface import (
+    BatchUpdate,
+    LogitsProcessor,
+    MoveDirectionality,
+)
+
+logger = init_logger(__name__)
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+
+
+@dataclass
+class _RequestBlockState:
+    """Per-request block tracking state.
+
+    Tracks block boundaries by scanning output_token_ids (a live
+    reference to the request's generated tokens). Each call to apply()
+    scans any new tokens appended since the last check.
+
+    Requires sync scheduling (--async-scheduling false) so that
+    output_token_ids contains real token IDs, not -1 placeholders.
+    """
+    output_token_ids: list  # Live reference to request's output tokens
+    last_scanned_len: int = 0  # How far we've scanned so far
+    in_block: bool = False
+    block_token_count: int = 0
+    total_forced: int = 0
+
+
+class BlockLengthCapLogitsProcessor(LogitsProcessor):
+    """Force <|block_end|> when block content exceeds max_block_tokens.
+
+    Tracks block boundaries by scanning output_token_ids (which must
+    contain real token IDs — requires --async-scheduling false).
+
+    Each step:
+    1. Scan any new tokens in output_token_ids since last check.
+    2. Update block state (in_block, block_token_count).
+    3. If inside a block and over the limit, force block_end.
+
+    The processor is a no-op when:
+    - Block masking is not enabled
+    - max_block_tokens is 0 or negative
+    - No requests are currently inside a long block
+    """
+
+    def __init__(
+        self,
+        vllm_config: "VllmConfig",
+        device: torch.device,
+        is_pin_memory: bool,
+    ) -> None:
+        self.device = device
+        self.pin_memory = is_pin_memory
+
+        # Read config
+        bm_config = getattr(vllm_config, "block_masking_config", None)
+        if bm_config is not None and bm_config.enable:
+            self.enabled = True
+            self.max_block_tokens = getattr(bm_config, "max_block_tokens", 0)
+            self.block_start_id = bm_config.block_start_id
+            self.block_end_id = bm_config.block_end_id
+            self.summary_start_id = bm_config.summary_start_id
+            self.summary_end_id = bm_config.summary_end_id
+            self.debug = bm_config.debug
+        else:
+            self.enabled = False
+            self.max_block_tokens = 0
+            self.block_start_id = -1
+            self.block_end_id = -1
+            self.summary_start_id = -1
+            self.summary_end_id = -1
+            self.debug = False
+
+        if self.enabled and self.max_block_tokens > 0:
+            logger.info(
+                "[BlockCap] Initialized: max_block_tokens=%d, "
+                "block_start_id=%d, block_end_id=%d",
+                self.max_block_tokens, self.block_start_id, self.block_end_id,
+            )
+
+        # Per-request state: batch_index -> _RequestBlockState
+        self._states: dict[int, _RequestBlockState] = {}
+
+        # Pre-allocated tensor for forcing block_end
+        self._neg_inf = torch.tensor(
+            -float("inf"), dtype=torch.float32, device=device
+        )
+
+        # Special token set (these don't count as block content)
+        self._special_ids = frozenset()
+        if self.enabled:
+            self._special_ids = frozenset([
+                self.block_start_id, self.block_end_id,
+                self.summary_start_id, self.summary_end_id,
+            ])
+
+    def is_argmax_invariant(self) -> bool:
+        # When forcing block_end, we change the argmax outcome
+        return False
+
+    def _scan_new_tokens(self, state: _RequestBlockState) -> None:
+        """Scan any new tokens in output_token_ids and update block state."""
+        current_len = len(state.output_token_ids)
+        if current_len <= state.last_scanned_len:
+            return
+
+        for i in range(state.last_scanned_len, current_len):
+            tok = state.output_token_ids[i]
+            if tok == -1:
+                # Async placeholder — skip (shouldn't happen with
+                # --async-scheduling false, but be defensive)
+                continue
+            if tok == self.block_start_id:
+                state.in_block = True
+                state.block_token_count = 0
+                logger.info(
+                    "[BlockCap] BLOCK_START at output pos %d", i,
+                )
+            elif tok == self.block_end_id:
+                logger.info(
+                    "[BlockCap] BLOCK_END at output pos %d "
+                    "(block had %d tokens)", i, state.block_token_count,
+                )
+                state.in_block = False
+                state.block_token_count = 0
+            elif state.in_block and tok not in self._special_ids:
+                state.block_token_count += 1
+
+        state.last_scanned_len = current_len
+
+    def update_state(self, batch_update: Optional[BatchUpdate]) -> None:
+        if not self.enabled or self.max_block_tokens <= 0:
+            return
+
+        if batch_update is None:
+            return
+
+        # Process added requests
+        for index, params, prompt_tok_ids, output_tok_ids in batch_update.added:
+            state = _RequestBlockState(output_token_ids=output_tok_ids)
+            # Scan prompt tokens for existing block structure
+            if prompt_tok_ids:
+                for tok in prompt_tok_ids:
+                    if tok == self.block_start_id:
+                        state.in_block = True
+                        state.block_token_count = 0
+                    elif tok == self.block_end_id:
+                        state.in_block = False
+                        state.block_token_count = 0
+                    elif state.in_block and tok not in self._special_ids:
+                        state.block_token_count += 1
+            self._states[index] = state
+            logger.info(
+                "[BlockCap] Added idx=%d, prompt_len=%d, "
+                "output_len=%d, in_block=%s, "
+                "max_block_tokens=%d",
+                index,
+                len(prompt_tok_ids) if prompt_tok_ids else 0,
+                len(output_tok_ids) if output_tok_ids else 0,
+                state.in_block,
+                self.max_block_tokens,
+            )
+
+        # Process removed requests
+        for index in batch_update.removed:
+            old = self._states.pop(index, None)
+            if old is not None:
+                logger.info(
+                    "[BlockCap] Removed idx=%d, "
+                    "output_len=%d, total_forced=%d",
+                    index, len(old.output_token_ids), old.total_forced,
+                )
+
+        # Process moved requests
+        for a_idx, b_idx, direct in batch_update.moved:
+            a_state = self._states.pop(a_idx, None)
+            b_state = self._states.pop(b_idx, None)
+            if a_state is not None:
+                self._states[b_idx] = a_state
+            if b_state is not None and direct == MoveDirectionality.SWAP:
+                self._states[a_idx] = b_state
+
+    def apply(self, logits: torch.Tensor) -> torch.Tensor:
+        if not self.enabled or self.max_block_tokens <= 0:
+            return logits
+        if not self._states:
+            return logits
+
+        for index, state in self._states.items():
+            # Scan any new tokens added since last apply()
+            self._scan_new_tokens(state)
+
+            # Check if we need to force block_end
+            if (state.in_block
+                    and state.block_token_count >= self.max_block_tokens):
+                logits[index, :] = self._neg_inf
+                logits[index, self.block_end_id] = 0.0
+                state.total_forced += 1
+                logger.info(
+                    "[BlockCap] FORCING block_end idx=%d, "
+                    "block_count=%d/%d",
+                    index, state.block_token_count, self.max_block_tokens,
+                )
+
+        return logits

--- a/src/prime_rl/inference/block_masking/position_mapping.py
+++ b/src/prime_rl/inference/block_masking/position_mapping.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Position mapping for compacted token spans.
+
+Extracted from Memento's vLLM v1/request.py. Provides O(log n)
+logical<->physical position conversion after KV cache compaction.
+
+This is used by the overlay Request class (compacted_spans property)
+and can be tested standalone.
+"""
+
+import bisect
+
+
+class CompactedSpanTracker:
+    """Tracks compacted (removed) token spans and provides position mapping.
+
+    Maintains sorted, non-overlapping spans and precomputed auxiliary arrays
+    for O(log n) binary-search position lookups.
+    """
+
+    def __init__(self) -> None:
+        self._spans: list[tuple[int, int]] = []
+        self._cs_starts: list[int] = []
+        self._cs_cumulative: list[int] = []
+        self._cs_gap_physical: list[int] = [0]
+        self._cs_gap_logical: list[int] = [0]
+
+    @property
+    def spans(self) -> list[tuple[int, int]]:
+        return self._spans
+
+    @spans.setter
+    def spans(self, spans: list[tuple[int, int]]) -> None:
+        self._spans = spans
+        self._recompute()
+
+    def _recompute(self) -> None:
+        """Recompute auxiliary arrays from current spans."""
+        starts: list[int] = []
+        cumulative: list[int] = []
+        gap_physical: list[int] = [0]
+        gap_logical: list[int] = [0]
+        total = 0
+        for s, e in self._spans:
+            starts.append(s)
+            total += e - s
+            cumulative.append(total)
+            gap_physical.append(e - total)
+            gap_logical.append(e)
+        self._cs_starts = starts
+        self._cs_cumulative = cumulative
+        self._cs_gap_physical = gap_physical
+        self._cs_gap_logical = gap_logical
+
+    def add_span(self, start: int, end: int) -> None:
+        """Add a span and merge with existing overlapping/adjacent spans."""
+        if start >= end:
+            return
+        new_spans = merge_spans(self._spans + [(start, end)])
+        self.spans = new_spans
+
+    def is_token_active(self, position: int) -> bool:
+        """Check if a token is active (not compacted/removed). O(log n)."""
+        if not self._cs_starts:
+            return True
+        idx = bisect.bisect_right(self._cs_starts, position) - 1
+        if idx < 0:
+            return True
+        return position >= self._spans[idx][1]
+
+    def get_active_positions(self, num_tokens: int) -> list[int]:
+        """Get list of active (non-compacted) logical positions."""
+        if not self._spans:
+            return list(range(num_tokens))
+        active: list[int] = []
+        prev_end = 0
+        for start, end in self._spans:
+            if start >= num_tokens:
+                break
+            active.extend(range(prev_end, min(start, num_tokens)))
+            prev_end = end
+        if prev_end < num_tokens:
+            active.extend(range(prev_end, num_tokens))
+        return active
+
+    def logical_to_physical(self, logical_pos: int) -> int:
+        """Convert a logical position to physical position after compaction. O(log n)."""
+        if not self._cs_starts:
+            return logical_pos
+        idx = bisect.bisect_right(self._cs_starts, logical_pos) - 1
+        if idx < 0:
+            return logical_pos
+        _, end = self._spans[idx]
+        if logical_pos >= end:
+            return logical_pos - self._cs_cumulative[idx]
+        prev_cum = self._cs_cumulative[idx - 1] if idx > 0 else 0
+        return logical_pos - prev_cum - (logical_pos - self._cs_starts[idx])
+
+    def physical_to_logical(self, physical_pos: int) -> int:
+        """Convert a physical position back to logical position. O(log n)."""
+        if not self._cs_gap_physical:
+            return physical_pos
+        idx = bisect.bisect_right(self._cs_gap_physical, physical_pos) - 1
+        return (self._cs_gap_logical[idx]
+                + (physical_pos - self._cs_gap_physical[idx]))
+
+    def get_compacted_token_count(self) -> int:
+        """Get total number of tokens that have been compacted."""
+        return self._cs_cumulative[-1] if self._cs_cumulative else 0
+
+
+def merge_spans(spans: list[tuple[int, int]]) -> list[tuple[int, int]]:
+    """Merge overlapping or adjacent spans into sorted, non-overlapping list."""
+    if not spans:
+        return []
+    sorted_spans = sorted(spans)
+    merged = [sorted_spans[0]]
+    for start, end in sorted_spans[1:]:
+        if start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+    return merged

--- a/src/prime_rl/inference/block_masking/processor.py
+++ b/src/prime_rl/inference/block_masking/processor.py
@@ -1,0 +1,255 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Block masking processor for handling token-by-token block tracking.
+
+This module provides the main interface for processing tokens and
+determining when to trigger compaction.
+"""
+
+from typing import TYPE_CHECKING, Optional
+
+from .tracker import BlockMaskingState
+
+if TYPE_CHECKING:
+    from .config import BlockMaskingConfig
+
+
+class BlockMaskingProcessor:
+    """
+    Processor for block masking during generation.
+
+    This class handles the token-by-token processing of generated output,
+    detecting block boundaries and determining when to trigger compaction.
+
+    Usage in scheduler:
+        processor = BlockMaskingProcessor(config)
+
+        # For each generated token:
+        compaction = processor.process_token(state, token_id, position)
+        if compaction:
+            start, end = compaction
+            self.mask_token_span(request_id, start, end)
+    """
+
+    def __init__(self, config: "BlockMaskingConfig"):
+        """
+        Initialize the processor with configuration.
+
+        Args:
+            config: Block masking configuration (must be initialized)
+        """
+        self.config = config
+        assert config._initialized, "Config must be initialized with token IDs"
+
+    def create_state(self) -> BlockMaskingState:
+        """Create a new state for a request."""
+        return BlockMaskingState()
+
+    def process_token(
+        self,
+        state: BlockMaskingState,
+        token_id: int,
+        position: int,
+    ) -> Optional[tuple[int, int]]:
+        """
+        Process a newly generated token and return compaction range if needed.
+
+        This is the main entry point called by the scheduler for each
+        generated token.
+
+        Args:
+            state: The request's block masking state
+            token_id: The generated token ID
+            position: The absolute position (prompt + generated)
+
+        Returns:
+            Optional (start, end) tuple for compaction, or None
+        """
+        config = self.config
+
+        # Track <|im_start|> for assistant section detection
+        if config.im_start_id is not None and token_id == config.im_start_id:
+            state.record_im_start(position)
+
+        # Check for assistant section start
+        if (config.require_assistant_section and
+            config.assistant_id is not None and
+            token_id == config.assistant_id and
+            state.check_assistant_start(position)):
+            state.set_in_assistant_section(position)
+            if config.debug:
+                print(f"[BlockMasking] Assistant section detected at position {position}")
+
+        # Check if we should process this token for block tracking
+        if not state.should_process_token(position, config.require_assistant_section):
+            return None
+
+        # Process block boundary tokens
+        compaction = None
+
+        if token_id == config.block_start_id:
+            # If keep_last_block_for_answer: a new block is starting, so the
+            # previous block (sitting in pending_compactions) is NOT the last
+            # one. Flush it now — this gives pure keep0 KV usage mid-generation.
+            if (config.keep_last_block_for_answer
+                    and config.keep_last_n_blocks == 0
+                    and state.pending_compactions):
+                compaction = state.get_compaction_range(
+                    keep_last_n=0,
+                    mask_delimiters=config.mask_delimiters,
+                    restart_mode=config.restart_mode,
+                )
+                if config.debug and compaction:
+                    print(f"[BlockMasking] Deferred compaction flushed on "
+                          f"block_start: {compaction}")
+                # Restart mode: schedule rewind for the deferred block's summary
+                if config.restart_mode and compaction is not None:
+                    flushed_block_id = state.compacted_block_ids[-1]
+                    flushed_block = state.blocks[flushed_block_id]
+                    state.pending_restart_rewind = flushed_block.summary_start
+                    if config.debug:
+                        print(f"[BlockMasking] Restart rewind scheduled "
+                              f"to position {flushed_block.summary_start}")
+
+            block_id = state.start_block(position)
+            if config.debug:
+                print(f"[BlockMasking] Block {block_id} started at position {position}")
+
+        elif token_id == config.block_end_id:
+            block_id = state.end_block(position)
+            if config.debug and block_id is not None:
+                print(f"[BlockMasking] Block {block_id} ended at position {position}")
+
+        elif token_id == config.summary_start_id:
+            block_id = state.start_summary(position)
+            if config.debug and block_id is not None:
+                print(f"[BlockMasking] Summary started for block {block_id} at {position}")
+
+        elif token_id == config.summary_end_id:
+            block_id = state.end_summary(position)
+            if config.debug and block_id is not None:
+                print(f"[BlockMasking] Summary ended for block {block_id} at {position}")
+
+            # Check if we should compact
+            if config.compact_on_summary_end and block_id is not None:
+                if (config.keep_last_block_for_answer
+                        and config.keep_last_n_blocks == 0):
+                    # Defer: don't compact now. If <|block_start|> comes next,
+                    # we'll flush it then. If </think> comes instead, the block
+                    # stays in KV cache for the final answer.
+                    if config.debug:
+                        print(f"[BlockMasking] Deferring compaction of block "
+                              f"{block_id} (keep_last_block_for_answer)")
+                else:
+                    compaction = state.get_compaction_range(
+                        config.keep_last_n_blocks,
+                        mask_delimiters=config.mask_delimiters,
+                        restart_mode=config.restart_mode,
+                    )
+                    if config.debug and compaction:
+                        print(f"[BlockMasking] Compaction triggered: {compaction} "
+                              f"(mask_delimiters={config.mask_delimiters}, "
+                              f"restart_mode={config.restart_mode})")
+                    # Restart mode: schedule rewind to recompute summary KV
+                    if config.restart_mode and compaction is not None:
+                        block = state.blocks[block_id]
+                        state.pending_restart_rewind = block.summary_start
+                        if config.debug:
+                            print(f"[BlockMasking] Restart rewind scheduled "
+                                  f"to position {block.summary_start}")
+
+        return compaction
+
+    def process_prompt_tokens(
+        self,
+        state: BlockMaskingState,
+        prompt_token_ids: list[int],
+    ) -> None:
+        """
+        Process prompt tokens to initialize block state.
+
+        This scans the prompt for existing block structures (e.g., in
+        multi-turn conversations) to initialize the state correctly.
+
+        Note: We don't trigger compactions during prompt processing.
+
+        Args:
+            state: The request's block masking state
+            prompt_token_ids: The prompt token IDs
+        """
+        config = self.config
+
+        for position, token_id in enumerate(prompt_token_ids):
+            # Track <|im_start|> for assistant section detection
+            if config.im_start_id is not None and token_id == config.im_start_id:
+                state.record_im_start(position)
+
+            # Check for assistant section start
+            if (config.require_assistant_section and
+                config.assistant_id is not None and
+                token_id == config.assistant_id and
+                state.check_assistant_start(position)):
+                state.set_in_assistant_section(position)
+
+            # Skip block tracking if not in assistant section
+            if not state.should_process_token(position, config.require_assistant_section):
+                continue
+
+            # Track block boundaries (but don't compact)
+            if token_id == config.block_start_id:
+                state.start_block(position)
+            elif token_id == config.block_end_id:
+                state.end_block(position)
+            elif token_id == config.summary_start_id:
+                state.start_summary(position)
+            elif token_id == config.summary_end_id:
+                state.end_summary(position)
+
+        # Restart mode: schedule rewind for prompt blocks that need compaction
+        if config.restart_mode and state.pending_compactions:
+            earliest_summary_start = None
+            for block_id in state.pending_compactions:
+                block = state.blocks[block_id]
+                if block.summary_start is not None:
+                    if (earliest_summary_start is None or
+                            block.summary_start < earliest_summary_start):
+                        earliest_summary_start = block.summary_start
+            if earliest_summary_start is not None:
+                state.pending_restart_rewind = earliest_summary_start
+                if config.debug:
+                    print(f"[BlockMasking] Restart rewind scheduled "
+                          f"to position {earliest_summary_start} "
+                          f"(prompt, {len(state.pending_compactions)} blocks)")
+
+        if config.debug:
+            stats = state.get_stats()
+            print(f"[BlockMasking] Prompt processed: {stats}")
+
+    def force_compact_pending(
+        self,
+        state: BlockMaskingState,
+    ) -> list[tuple[int, int]]:
+        """
+        Force compaction of all pending blocks.
+
+        This can be called at the end of generation to ensure all
+        completed blocks are compacted.
+
+        Returns:
+            List of (start, end) compaction ranges
+        """
+        compactions = []
+
+        while state.pending_compactions:
+            # Temporarily set keep_last_n to 0 to force compaction
+            compaction = state.get_compaction_range(
+                keep_last_n=0,
+                mask_delimiters=self.config.mask_delimiters,
+            )
+            if compaction:
+                compactions.append(compaction)
+                if self.config.debug:
+                    print(f"[BlockMasking] Forced compaction: {compaction}")
+
+        return compactions

--- a/src/prime_rl/inference/block_masking/tracker.py
+++ b/src/prime_rl/inference/block_masking/tracker.py
@@ -1,0 +1,344 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Block state tracking for Memento-style block masking.
+
+This module defines the per-request state for tracking block boundaries
+during generation. The state is attached to each Request object when
+block masking is enabled.
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class BlockInfo:
+    """Information about a single block."""
+
+    block_id: int
+    start_position: int
+    end_position: Optional[int] = None
+    summary_start: Optional[int] = None
+    summary_end: Optional[int] = None
+
+    @property
+    def is_complete(self) -> bool:
+        """Block is complete when it has both end and summary_end."""
+        return self.end_position is not None and self.summary_end is not None
+
+    def get_content_range(self, mask_delimiters: bool) -> Optional[tuple[int, int]]:
+        """
+        Returns (start, end) range of block content to compact, or None if not ready.
+
+        The range is [start, end) - start inclusive, end exclusive.
+
+        Args:
+            mask_delimiters: Whether to include delimiter tokens in the masked range.
+                - True: Mask [block_start, block_end] inclusive (Phi3/Phi4 style)
+                - False: Mask (block_start, block_end) exclusive (Qwen3/OLMo3 style)
+
+        Returns:
+            (start, end) tuple where start is inclusive and end is exclusive,
+            or None if the block is not complete.
+        """
+        if not self.is_complete:
+            return None
+
+        if mask_delimiters:
+            # Phi3/Phi4 style: mask [block_start, block_end] inclusive
+            # Return [start, end+1) to include block_end token
+            return (self.start_position, self.end_position + 1)
+        else:
+            # Qwen3/OLMo3 style: keep delimiters visible, mask content only
+            # Return (start+1, end) to exclude both block_start and block_end
+            return (self.start_position + 1, self.end_position)
+
+    def get_restart_range(self, mask_delimiters: bool) -> Optional[tuple[int, int]]:
+        """
+        Returns (start, end) range for restart mode: block tokens only.
+
+        In restart mode, we evict block content + delimiters from the KV cache,
+        then rewind num_computed_tokens to summary_start so the engine
+        re-prefills summary tokens. The summary KV stays in the cache and is
+        overwritten in-place during re-prefill.
+
+        Block delimiters (block_start, block_end) are ALWAYS included in the
+        eviction range regardless of mask_delimiters, matching HF restart
+        which evicts all block tokens including delimiters.
+
+        Summary tokens are NOT evicted (unlike the old implementation).
+        This avoids negative physical positions that occurred when evicting
+        block+summary as a contiguous range then rewinding into the gap.
+
+        Args:
+            mask_delimiters: Ignored for restart mode — delimiters are always
+                evicted to match HF restart behavior.
+
+        Returns:
+            (start, end) tuple covering [block_start, block_end] inclusive,
+            or None if the block is not complete.
+        """
+        if not self.is_complete:
+            return None
+
+        # Always evict [block_start, block_end] inclusive.
+        # Summary tokens stay in cache — they'll be overwritten during
+        # re-prefill after the rewind to summary_start.
+        return (self.start_position, self.end_position + 1)
+
+    # Keep content_range as property for backwards compatibility, defaults to Qwen3/OLMo3 style
+    @property
+    def content_range(self) -> Optional[tuple[int, int]]:
+        """Backwards compatible property. Use get_content_range() for explicit control."""
+        return self.get_content_range(mask_delimiters=False)
+
+
+@dataclass
+class BlockMaskingState:
+    """
+    Per-request state for block masking.
+
+    Tracks:
+    - Open blocks (via stack for nesting support)
+    - Completed blocks ready for compaction
+    - Position adjustments from previous compactions
+    - Assistant section detection
+    """
+
+    # Stack of currently open blocks: [(block_id, start_pos), ...]
+    # Supports nested blocks
+    open_blocks: list[tuple[int, int]] = field(default_factory=list)
+
+    # All blocks (including completed ones)
+    # Maps block_id -> BlockInfo
+    blocks: dict[int, BlockInfo] = field(default_factory=dict)
+
+    # Counter for assigning block IDs
+    next_block_id: int = 0
+
+    # Completed blocks ready for compaction (in order of completion)
+    # These are block_ids that have both block_end and summary_end
+    pending_compactions: list[int] = field(default_factory=list)
+
+    # Blocks that have been compacted
+    compacted_block_ids: list[int] = field(default_factory=list)
+
+    # Total tokens compacted so far (for position adjustment)
+    # When compacting, logical positions > compacted region need adjustment
+    total_compacted_tokens: int = 0
+
+    # Track assistant section (for filtering false positives in prompts)
+    assistant_start_pos: Optional[int] = None
+    last_im_start_pos: Optional[int] = None
+    in_assistant_section: bool = False
+
+    # Currently active summary region
+    in_summary: bool = False
+    current_summary_block_id: Optional[int] = None
+
+    # Restart mode: when set, the scheduler should rewind num_computed_tokens
+    # to this position to trigger summary re-prefill with clean KV.
+    pending_restart_rewind: Optional[int] = None
+
+    # Flag to track that we've scheduled a deferred compaction
+    # (to avoid skipping sampling multiple times)
+    deferred_compaction_scheduled: bool = False
+
+    def start_block(self, position: int) -> int:
+        """
+        Start a new block at the given position.
+
+        Returns:
+            The block_id of the new block
+        """
+        block_id = self.next_block_id
+        self.next_block_id += 1
+
+        self.open_blocks.append((block_id, position))
+        self.blocks[block_id] = BlockInfo(
+            block_id=block_id,
+            start_position=position,
+        )
+
+        return block_id
+
+    def end_block(self, position: int) -> Optional[int]:
+        """
+        End the current (innermost) block at the given position.
+
+        Returns:
+            The block_id that was ended, or None if no open block
+        """
+        if not self.open_blocks:
+            return None
+
+        block_id, _ = self.open_blocks.pop()
+        self.blocks[block_id].end_position = position
+
+        return block_id
+
+    def start_summary(self, position: int) -> Optional[int]:
+        """
+        Start a summary region at the given position.
+
+        Associates with the most recently closed block that doesn't have a summary.
+
+        Returns:
+            The block_id associated with this summary, or None
+        """
+        # Find the most recently closed block without a summary
+        for block_id in reversed(list(self.blocks.keys())):
+            block = self.blocks[block_id]
+            if block.end_position is not None and block.summary_start is None:
+                block.summary_start = position
+                self.in_summary = True
+                self.current_summary_block_id = block_id
+                return block_id
+
+        return None
+
+    def end_summary(self, position: int) -> Optional[int]:
+        """
+        End the current summary region at the given position.
+
+        Returns:
+            The block_id of the completed block, or None
+        """
+        if not self.in_summary or self.current_summary_block_id is None:
+            return None
+
+        block_id = self.current_summary_block_id
+        block = self.blocks[block_id]
+        block.summary_end = position
+
+        self.in_summary = False
+        self.current_summary_block_id = None
+
+        # Block is now complete - add to pending compactions
+        if block.is_complete:
+            self.pending_compactions.append(block_id)
+
+        return block_id
+
+    def get_compaction_range(
+        self,
+        keep_last_n: int,
+        mask_delimiters: bool = False,
+        restart_mode: bool = False,
+    ) -> Optional[tuple[int, int]]:
+        """
+        Get the next compaction range if one is ready.
+
+        Respects keep_last_n setting:
+        - -1: Never compact
+        - 0: Compact immediately when ready
+        - N: Keep last N blocks, compact older ones
+
+        Args:
+            keep_last_n: Number of blocks to keep visible
+            mask_delimiters: Whether to include delimiter tokens in compaction range
+                - True: Mask [block_start, block_end] inclusive (Phi3/Phi4 style)
+                - False: Mask content only, keep delimiters visible (Qwen3/OLMo3 style)
+            restart_mode: If True, use get_restart_range() to include summary in
+                the eviction range. This is needed because we will rewind and
+                recompute the summary KV.
+
+        Returns:
+            (start, end) logical positions to compact, or None
+        """
+        if keep_last_n < 0:
+            # Never compact
+            return None
+
+        num_pending = len(self.pending_compactions)
+
+        # Only compact if we have more pending than keep_last_n
+        if num_pending <= keep_last_n:
+            return None
+
+        # Get the oldest pending block
+        block_id = self.pending_compactions.pop(0)
+        block = self.blocks[block_id]
+
+        if restart_mode:
+            # Restart mode: evict block content + summary
+            content_range = block.get_restart_range(mask_delimiters=mask_delimiters)
+        else:
+            # Normal mode: evict only block content
+            content_range = block.get_content_range(mask_delimiters=mask_delimiters)
+        if content_range is None:
+            return None
+
+        start, end = content_range
+
+        # NOTE: Return LOGICAL positions, not adjusted positions!
+        # The scheduler's mask_token_span() handles logical-to-physical
+        # conversion internally using request.compacted_spans.
+        # We only need to track total_compacted_tokens for internal state.
+
+        # Update tracking
+        tokens_to_compact = end - start
+        self.total_compacted_tokens += tokens_to_compact
+        self.compacted_block_ids.append(block_id)
+
+        return (start, end)
+
+    def set_in_assistant_section(self, position: int) -> None:
+        """Mark that we've entered the assistant section."""
+        self.assistant_start_pos = position
+        self.in_assistant_section = True
+
+    def record_im_start(self, position: int) -> None:
+        """Record position of <|im_start|> token."""
+        self.last_im_start_pos = position
+
+    def check_assistant_start(self, position: int) -> bool:
+        """
+        Check if current position marks start of assistant section.
+
+        Returns True if this is the "assistant" token right after <|im_start|>.
+        """
+        if self.in_assistant_section:
+            return False  # Already in assistant section
+
+        if self.last_im_start_pos is None:
+            return False
+
+        # Check if we're within 2 positions of <|im_start|>
+        # (allows for possible whitespace token)
+        return position - self.last_im_start_pos <= 2
+
+    def should_process_token(self, position: int, require_assistant: bool) -> bool:
+        """
+        Check if we should process this token for block tracking.
+
+        Args:
+            position: Current token position
+            require_assistant: Whether assistant section is required
+
+        Returns:
+            True if token should be processed for block tracking
+        """
+        if not require_assistant:
+            return True
+
+        if not self.in_assistant_section:
+            return False
+
+        # Don't process the assistant token itself
+        if position <= self.assistant_start_pos:
+            return False
+
+        return True
+
+    def get_stats(self) -> dict:
+        """Get statistics about block tracking state."""
+        return {
+            "total_blocks": len(self.blocks),
+            "open_blocks": len(self.open_blocks),
+            "pending_compactions": len(self.pending_compactions),
+            "compacted_blocks": len(self.compacted_block_ids),
+            "total_compacted_tokens": self.total_compacted_tokens,
+            "in_assistant_section": self.in_assistant_section,
+        }

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -19,6 +19,7 @@ def transformers_v5_compat():
     monkey_patch_dp_engine_core_pause_resume_deadlock()
     monkey_patch_vllm_layerwise_reload_alias_buffers()
     monkey_patch_vllm_padded_input_scrub()
+    monkey_patch_block_masking()
 
 
 def monkey_patch_vllm_layerwise_reload_alias_buffers():
@@ -621,6 +622,14 @@ def monkey_patch_dp_engine_core_pause_resume_deadlock():
     from vllm.v1.engine.core import DPEngineCoreProc, EngineCore, EngineCoreProc
     from vllm.v1.request import Request
 
+    if getattr(DPEngineCoreProc, "_prime_rl_dp_pause_resume_patched", False):
+        return
+
+    if not hasattr(EngineCoreProc, "_pause_complete") or not hasattr(
+        EngineCoreProc, "resume_scheduler"
+    ):
+        return
+
     _base_add_request = EngineCore.add_request
     _base_handle_client_request = EngineCoreProc._handle_client_request
     _base_pause_complete = EngineCoreProc._pause_complete
@@ -673,6 +682,7 @@ def monkey_patch_dp_engine_core_pause_resume_deadlock():
     DPEngineCoreProc._pause_complete = _patched_pause_complete
     DPEngineCoreProc.resume_scheduler = _patched_resume_scheduler
     DPEngineCoreProc._has_global_unfinished_reqs = _patched_has_global_unfinished_reqs
+    DPEngineCoreProc._prime_rl_dp_pause_resume_patched = True
 
 
 def monkey_patch_no_moe_lora():
@@ -763,3 +773,483 @@ def monkey_patch_fp32_lm_head():
     LogitsProcessor.__init__ = _patched_init
     LogitsProcessor._get_logits = _patched_get_logits
     logger.info("Installed fp32 lm_head patch (native out_dtype=fp32 mm).")
+
+
+def monkey_patch_block_masking():
+    """Block masking monkey-patches for Memento-style KV cache compaction.
+
+    Safe to apply unconditionally — all changes are no-ops when block masking
+    is disabled (compacted_tokens_cpu stays zero, scheduler output fields are
+    empty/absent).
+
+    Patches:
+      - InputBatch: adds compacted_tokens_cpu tracking
+      - GPUModelRunner: KV copy operations, physical position slot mapping,
+        physical seq_lens, skip_sampling for deferred compaction
+      - AsyncLLM / LLMEngine: reads block_masking_config from additional_config,
+        initializes token IDs, sets config on VllmConfig before EngineCore spawns
+    """
+    from vllm.config import VllmConfig
+    if not hasattr(VllmConfig, "block_masking_config"):
+        VllmConfig.block_masking_config = None
+
+    _patch_input_batch_compacted_tokens()
+    _patch_gpu_model_runner_block_masking()
+    _patch_engine_core_block_masking_barrier()
+    _patch_engine_init_block_masking()
+
+
+def _patch_input_batch_compacted_tokens():
+    """Add compacted_tokens_cpu array to InputBatch for tracking compacted token counts."""
+    import numpy as np
+    from vllm.v1.worker.gpu_input_batch import InputBatch
+
+    if getattr(InputBatch, "_prime_rl_block_masking_patched", False):
+        return
+
+    _orig_init = InputBatch.__init__
+    _orig_add = InputBatch.add_request
+    _orig_condense = InputBatch.condense
+
+    def _patched_init(self, *args, **kwargs):
+        _orig_init(self, *args, **kwargs)
+        self.compacted_tokens_cpu = np.zeros_like(self.num_computed_tokens_cpu)
+
+    def _patched_add(self, request):
+        req_index = _orig_add(self, request)
+        self.compacted_tokens_cpu[req_index] = 0
+        return req_index
+
+    def _patched_condense(self):
+        saved = {
+            req_id: int(self.compacted_tokens_cpu[idx])
+            for req_id, idx in self.req_id_to_index.items()
+        }
+        _orig_condense(self)
+        for req_id, val in saved.items():
+            idx = self.req_id_to_index.get(req_id)
+            if idx is not None:
+                self.compacted_tokens_cpu[idx] = val
+
+    _orig_swap = InputBatch.swap_states
+
+    def _patched_swap(self, i1, i2):
+        self.compacted_tokens_cpu[i1], self.compacted_tokens_cpu[i2] = (
+            self.compacted_tokens_cpu[i2],
+            self.compacted_tokens_cpu[i1],
+        )
+        _orig_swap(self, i1, i2)
+
+    InputBatch.__init__ = _patched_init
+    InputBatch.add_request = _patched_add
+    InputBatch.condense = _patched_condense
+    InputBatch.swap_states = _patched_swap
+    InputBatch._prime_rl_block_masking_patched = True
+
+
+def _patch_gpu_model_runner_block_masking():
+    """Patch GPUModelRunner for KV cache compaction.
+
+    _update_states: execute KV copy operations and block table truncations
+    before stock logic, then track compacted_tokens_cpu after.
+
+    _prepare_inputs: after stock logic, adjust seq_lens and slot_mapping to
+    use physical (post-compaction) values, handle skip_sampling_req_ids.
+    """
+    import os
+    import numpy as np
+    from vllm.logger import init_logger
+    from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+
+    if getattr(GPUModelRunner, "_prime_rl_block_masking_patched", False):
+        return
+
+    logger = init_logger(__name__)
+    _orig_update = GPUModelRunner._update_states
+    _orig_prepare = GPUModelRunner._prepare_inputs
+
+    def _block_masking_debug_enabled(self) -> bool:
+        vllm_config = getattr(self, "vllm_config", None)
+        config = getattr(vllm_config, "block_masking_config", None)
+        return bool(config is not None and getattr(config, "debug", False))
+
+    def _record_block_masking_event(message: str) -> None:
+        event_log = os.environ.get("PRIME_RL_BLOCK_MASKING_EVENT_LOG")
+        if not event_log:
+            return
+        with open(event_log, "a", encoding="utf-8") as f:
+            f.write(message + "\n")
+
+    def _execute_kv_copy_operations(
+        self,
+        kv_copy_operations: dict[str, list[tuple[int, int, int, int]]],
+    ) -> None:
+        # Assumes single KV group (all layers share one block pool).
+        # Multi-pool architectures would need per-group dispatch.
+        if not self.kv_caches:
+            return
+        all_ops: list[tuple[int, int, int, int]] = []
+        for ops in kv_copy_operations.values():
+            all_ops.extend(ops)
+        if not all_ops:
+            return
+        if _block_masking_debug_enabled(self):
+            logger.info(
+                "Block masking KV copy ops executed: requests=%d ops=%d",
+                len(kv_copy_operations),
+                len(all_ops),
+            )
+        _record_block_masking_event(
+            "Block masking KV copy ops executed: "
+            f"requests={len(kv_copy_operations)} ops={len(all_ops)}"
+        )
+        for kv_cache in self.kv_caches:
+            if kv_cache.shape[0] == 2:
+                # FlashAttention layout: [2, num_blocks, block_size, num_kv_heads, head_size]
+                k, v = kv_cache[0], kv_cache[1]
+                for sb, so, db, do in all_ops:
+                    k[db, do].copy_(k[sb, so])
+                    v[db, do].copy_(v[sb, so])
+            else:
+                # FlashInfer layout: [num_blocks, 2, block_size, num_kv_heads, head_size]
+                for sb, so, db, do in all_ops:
+                    kv_cache[db, :, do].copy_(kv_cache[sb, :, so])
+
+    def _patched_update_states(self, scheduler_output):
+        # Execute KV copy operations BEFORE block table updates.
+        kv_ops = getattr(scheduler_output, "kv_copy_operations", None)
+        if kv_ops:
+            _execute_kv_copy_operations(self, kv_ops)
+
+        # Execute block table truncations BEFORE appending new blocks.
+        truncations = getattr(scheduler_output, "block_table_truncations", None)
+        if truncations:
+            truncation_count = 0
+            for req_id, num_blocks in truncations.items():
+                req_index = self.input_batch.req_id_to_index.get(req_id)
+                if req_index is not None:
+                    self.input_batch.block_table.truncate_row(req_index, num_blocks)
+                    truncation_count += 1
+            if truncation_count and _block_masking_debug_enabled(self):
+                logger.info(
+                    "Block masking block table truncations applied: requests=%d",
+                    truncation_count,
+                )
+            _record_block_masking_event(
+                "Block masking block table truncations applied: "
+                f"requests={truncation_count}"
+            )
+
+        result = _orig_update(self, scheduler_output)
+
+        # Track compacted tokens per request from scheduler output.
+        req_data = scheduler_output.scheduled_cached_reqs
+        counts = getattr(req_data, "compacted_token_counts", None)
+        if counts:
+            for i, req_id in enumerate(req_data.req_ids):
+                idx = self.input_batch.req_id_to_index.get(req_id)
+                if idx is not None:
+                    self.input_batch.compacted_tokens_cpu[idx] = counts[i]
+
+        return result
+
+    def _patched_prepare_inputs(self, scheduler_output, num_scheduled_tokens):
+        result = _orig_prepare(self, scheduler_output, num_scheduled_tokens)
+
+        num_reqs = self.input_batch.num_reqs
+        if num_reqs == 0:
+            return result
+
+        compacted = self.input_batch.compacted_tokens_cpu[:num_reqs]
+        has_compaction = np.any(compacted > 0)
+        skip_ids = getattr(scheduler_output, "skip_sampling_req_ids", None)
+
+        if not has_compaction and not skip_ids:
+            return result
+
+        total = scheduler_output.total_num_scheduled_tokens
+
+        if has_compaction:
+            # Save stock discard_request_mask BEFORE adjustments.
+            # Stock code computes: optimistic_seq_lens < num_tokens (both logical).
+            # Compacted terms cancel, so the mask is already correct.
+            # Our adjustment makes optimistic_seq_lens physical while num_tokens
+            # stays logical, which would break the comparison.
+            saved_discard_mask = self.discard_request_mask.np[:num_reqs].copy()
+
+            compacted_t = torch.from_numpy(compacted.copy())
+
+            # Adjust GPU seq_lens: physical = logical - compacted
+            self.seq_lens[:num_reqs] -= compacted_t.to(
+                device=self.seq_lens.device, non_blocking=True
+            )
+
+            # Adjust CPU optimistic_seq_lens for attention metadata
+            self.optimistic_seq_lens_cpu[:num_reqs] -= compacted_t
+
+            # Recompute slot_mapping with physical positions.
+            # self.positions has logical positions (correct for RoPE).
+            req_indices = np.repeat(self.arange_np[:num_reqs], num_scheduled_tokens)
+            expanded = torch.from_numpy(
+                self.input_batch.compacted_tokens_cpu[req_indices].copy()
+            ).to(device=self.positions.device, dtype=torch.int64, non_blocking=True)
+            physical_positions = self.positions[:total] - expanded
+            self.input_batch.block_table.compute_slot_mapping(
+                num_reqs,
+                self.query_start_loc.gpu[:num_reqs + 1],
+                physical_positions,
+            )
+
+            # Restore the saved discard mask (correct with logical values).
+            self.discard_request_mask.np[:num_reqs] = saved_discard_mask
+
+        # Apply skip_sampling on top of the (restored) discard mask.
+        if skip_ids:
+            for req_id in skip_ids:
+                idx = self.input_batch.req_id_to_index.get(req_id)
+                if idx is not None:
+                    self.discard_request_mask.np[idx] = True
+
+        if has_compaction or skip_ids:
+            self.discard_request_mask.copy_to_gpu(num_reqs)
+
+        return result
+
+    GPUModelRunner._execute_kv_copy_operations = _execute_kv_copy_operations
+    GPUModelRunner._update_states = _patched_update_states
+    GPUModelRunner._prepare_inputs = _patched_prepare_inputs
+    GPUModelRunner._prime_rl_block_masking_patched = True
+
+
+def _patch_engine_core_block_masking_barrier():
+    """Serialize async scheduling around deferred block masking compaction.
+
+    vLLM async scheduling advances output placeholders before the model output
+    is processed. Deferred compaction mutates KV/block-table state, so compaction
+    steps must run only when prior async batches have been processed.
+    """
+    from vllm.logger import init_logger
+    from vllm.v1.engine.core import EngineCore
+
+    if getattr(EngineCore, "_prime_rl_block_masking_barrier_patched", False):
+        return
+
+    logger = init_logger(__name__)
+    _orig_step_with_batch_queue = EngineCore.step_with_batch_queue
+
+    def _block_masking_async_mode(self) -> str | None:
+        config = getattr(self.vllm_config, "block_masking_config", None)
+        if config is None or not getattr(config, "enable", False):
+            return None
+        return getattr(config, "async_mode", "safe_sync")
+
+    def _has_pending_block_masking_barrier(self) -> bool:
+        if _block_masking_async_mode(self) != "async_barrier":
+            return False
+        scheduler = getattr(self, "scheduler", None)
+        if scheduler is None:
+            return False
+        if getattr(scheduler, "block_masking_processor", None) is None:
+            return False
+        for request in getattr(scheduler, "requests", {}).values():
+            state = getattr(request, "block_masking_state", None)
+            if state is None or not state.pending_compactions:
+                continue
+            if state.deferred_compaction_scheduled:
+                continue
+            if len(getattr(request, "output_token_ids", ())) > 0:
+                continue
+            return True
+        return False
+
+    def _process_next_batch_queue_item(self, batch_queue, model_executed=False):
+        future, scheduler_output, exec_model_fut = batch_queue.pop()
+        with (
+            self.log_error_detail(scheduler_output),
+            self.log_iteration_details(scheduler_output),
+        ):
+            model_output = future.result()
+            if model_output is None:
+                exec_model_fut.result()
+                raise RuntimeError("unexpected error")
+
+        self._process_aborts_queue()
+        engine_core_outputs = self.scheduler.update_from_output(
+            scheduler_output, model_output
+        )
+        return (
+            engine_core_outputs,
+            model_executed or scheduler_output.total_num_scheduled_tokens > 0,
+        )
+
+    def _patched_step_with_batch_queue(self):
+        batch_queue = self.batch_queue
+        assert batch_queue is not None
+
+        if batch_queue and _has_pending_block_masking_barrier(self):
+            config = getattr(self.vllm_config, "block_masking_config", None)
+            if config is not None and getattr(config, "debug", False):
+                logger.warning(
+                    "Block masking async barrier draining %d queued batch(es)",
+                    len(batch_queue),
+                )
+            return _process_next_batch_queue_item(self, batch_queue)
+
+        if _block_masking_async_mode(self) != "async_barrier":
+            return _orig_step_with_batch_queue(self)
+
+        if not getattr(self, "_prime_rl_block_masking_barrier_step_seen", False):
+            logger.warning(
+                "Block masking async barrier engine path active "
+                "(batch_queue_size=%d)",
+                self.batch_queue_size,
+            )
+            self._prime_rl_block_masking_barrier_step_seen = True
+
+        model_executed = False
+        deferred_scheduler_output = None
+        if self.scheduler.has_requests():
+            scheduler_output = self.scheduler.schedule()
+            barrier = getattr(scheduler_output, "block_masking_barrier", False)
+            if barrier:
+                logger.warning(
+                    "Block masking async barrier scheduled for request ids: %s",
+                    sorted(scheduler_output.skip_sampling_req_ids or ()),
+                )
+            with self.log_error_detail(scheduler_output):
+                exec_future = self.model_executor.execute_model(
+                    scheduler_output, non_block=True
+                )
+            if self.is_ec_consumer:
+                model_executed = scheduler_output.total_num_scheduled_tokens > 0
+
+            if self.is_pooling_model or not model_executed:
+                future = exec_future
+            else:
+                if not scheduler_output.pending_structured_output_tokens:
+                    grammar_output = self.scheduler.get_grammar_bitmask(
+                        scheduler_output
+                    )
+                    future = self.model_executor.sample_tokens(
+                        grammar_output, non_block=True
+                    )
+                else:
+                    deferred_scheduler_output = scheduler_output
+
+            if not deferred_scheduler_output:
+                batch_queue.appendleft((future, scheduler_output, exec_future))
+                if (
+                    model_executed
+                    and not barrier
+                    and len(batch_queue) < self.batch_queue_size
+                    and not batch_queue[-1][0].done()
+                ):
+                    return None, True
+
+        elif not batch_queue:
+            return None, False
+
+        engine_core_outputs, _ = _process_next_batch_queue_item(
+            self, batch_queue, model_executed
+        )
+
+        if deferred_scheduler_output:
+            if self.use_spec_decode:
+                draft_token_ids = self.model_executor.take_draft_token_ids()
+                assert draft_token_ids is not None
+                self.scheduler.update_draft_token_ids_in_output(
+                    draft_token_ids, deferred_scheduler_output
+                )
+            grammar_output = self.scheduler.get_grammar_bitmask(
+                deferred_scheduler_output
+            )
+            future = self.model_executor.sample_tokens(grammar_output, non_block=True)
+            batch_queue.appendleft((future, deferred_scheduler_output, exec_future))
+
+        return engine_core_outputs, model_executed
+
+    EngineCore.step_with_batch_queue = _patched_step_with_batch_queue
+    EngineCore._prime_rl_block_masking_barrier_patched = True
+
+
+def _patch_engine_init_block_masking():
+    """Patch engine init to read block_masking_config from additional_config.
+
+    Reads block_masking_config dict from vllm_config.additional_config,
+    creates BlockMaskingConfig, initializes token IDs with the tokenizer,
+    and sets the config on VllmConfig before EngineCore subprocesses spawn.
+    """
+    from vllm.v1.engine.async_llm import AsyncLLM
+
+    def _setup_block_masking(vllm_config):
+        additional = getattr(vllm_config, "additional_config", None) or {}
+        bm_dict = additional.get("block_masking_config")
+        if not bm_dict or not isinstance(bm_dict, dict):
+            return
+        from prime_rl.inference.block_masking.config import BlockMaskingConfig
+
+        bm_config = BlockMaskingConfig(**bm_dict)
+        if not bm_config.enable:
+            return
+
+        if bm_config.async_mode == "async_native":
+            raise NotImplementedError(
+                "block masking async_mode='async_native' is not implemented; "
+                "use 'safe_sync' or 'async_barrier'."
+            )
+
+        scheduler_config = getattr(vllm_config, "scheduler_config", None)
+        if (scheduler_config is not None and
+            getattr(scheduler_config, "async_scheduling", False)):
+            from vllm.logger import init_logger
+
+            logger = init_logger(__name__)
+            if bm_config.async_mode == "safe_sync":
+                logger.warning(
+                    "Block masking currently disables vLLM async scheduling. "
+                    "Set async_mode='async_barrier' to keep async scheduling "
+                    "enabled with compaction barriers.")
+                scheduler_config.async_scheduling = False
+            elif bm_config.async_mode == "async_barrier":
+                logger.warning(
+                    "Block masking keeps vLLM async scheduling enabled with "
+                    "compaction barriers.")
+
+        if not vllm_config.model_config.skip_tokenizer_init:
+            from vllm.tokenizers import get_tokenizer
+
+            tokenizer = get_tokenizer(
+                vllm_config.model_config.tokenizer,
+                trust_remote_code=vllm_config.model_config.trust_remote_code,
+                revision=vllm_config.model_config.tokenizer_revision,
+            )
+            bm_config.initialize_token_ids(tokenizer)
+
+        vllm_config.block_masking_config = bm_config
+
+    if not getattr(AsyncLLM, "_prime_rl_block_masking_init_patched", False):
+        _orig_async_init = AsyncLLM.__init__
+
+        def _patched_async_init(self, vllm_config, *args, **kwargs):
+            _setup_block_masking(vllm_config)
+            _orig_async_init(self, vllm_config, *args, **kwargs)
+
+        AsyncLLM.__init__ = _patched_async_init
+        AsyncLLM._prime_rl_block_masking_init_patched = True
+
+    try:
+        from vllm.v1.engine.llm_engine import LLMEngine
+
+        if getattr(LLMEngine, "_prime_rl_block_masking_init_patched", False):
+            return
+
+        _orig_llm_init = LLMEngine.__init__
+
+        def _patched_llm_init(self, vllm_config, *args, **kwargs):
+            _setup_block_masking(vllm_config)
+            _orig_llm_init(self, vllm_config, *args, **kwargs)
+
+        LLMEngine.__init__ = _patched_llm_init
+        LLMEngine._prime_rl_block_masking_init_patched = True
+    except ImportError:
+        pass

--- a/src/prime_rl/templates/inference.sbatch.j2
+++ b/src/prime_rl/templates/inference.sbatch.j2
@@ -171,6 +171,10 @@ srun --kill-on-bad-exit=1 bash -c '
     export VLLM_WORKER_MULTIPROC_METHOD=spawn
 {%- if use_deep_gemm %}
     export VLLM_USE_DEEP_GEMM=1
+    export VLLM_MOE_USE_DEEP_GEMM=1
+{%- else %}
+    export VLLM_USE_DEEP_GEMM=0
+    export VLLM_MOE_USE_DEEP_GEMM=0
 {%- endif %}
     export PYTORCH_CUDA_ALLOC_CONF="expandable_segments:False"
     export GLOO_SOCKET_IFNAME=bond0

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -224,6 +224,10 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
     read -ra HOSTNAMES <<< "$HOSTNAMES_STR"
 {%- if use_deep_gemm %}
     export VLLM_USE_DEEP_GEMM=1
+    export VLLM_MOE_USE_DEEP_GEMM=1
+{%- else %}
+    export VLLM_USE_DEEP_GEMM=0
+    export VLLM_MOE_USE_DEEP_GEMM=0
 {%- endif %}
 
     export GLOO_SOCKET_IFNAME=bond0

--- a/src/prime_rl/trainer/models/layers/norms.py
+++ b/src/prime_rl/trainer/models/layers/norms.py
@@ -1,3 +1,4 @@
+import os
 from dataclasses import dataclass
 from functools import lru_cache
 
@@ -10,6 +11,9 @@ from transformers.integrations import use_kernel_forward_from_hub
 @lru_cache(maxsize=1)
 def _get_quack_rmsnorm():
     """Lazy-load quack rmsnorm. Returns None if unavailable or GPU is pre-Hopper."""
+    disable_quack = os.environ.get("PRIME_RL_DISABLE_QUACK_RMSNORM", "").lower()
+    if disable_quack in {"1", "true", "yes", "on"}:
+        return None
     if not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] < 9:
         return None
     try:

--- a/tests/fixtures/memento_boundary_env/pyproject.toml
+++ b/tests/fixtures/memento_boundary_env/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "memento-boundary-env"
+version = "0.1.0"
+description = "Deterministic Verifiers fixture with Memento boundary-token history."
+requires-python = ">=3.12"
+dependencies = [
+    "datasets",
+    "verifiers",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/memento_boundary_env"]

--- a/tests/fixtures/memento_boundary_env/src/memento_boundary_env/__init__.py
+++ b/tests/fixtures/memento_boundary_env/src/memento_boundary_env/__init__.py
@@ -1,0 +1,75 @@
+"""Deterministic Verifiers fixture for Memento boundary-token RL smoke tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from datasets import Dataset
+import verifiers as vf
+
+
+BOUNDARY_HISTORY = (
+    "<|block_start|>"
+    "I add 15 and 27. 15 + 27 = 42."
+    "<|block_end|>"
+    "<|summary_start|>"
+    "15 + 27 = 42"
+    "<|summary_end|>"
+    "\nThe answer is 42."
+)
+
+
+def _completion_text(completion: Any) -> str:
+    if isinstance(completion, str):
+        return completion
+    if isinstance(completion, list):
+        parts = []
+        for message in completion:
+            if isinstance(message, dict):
+                parts.append(str(message.get("content", "")))
+            else:
+                parts.append(str(message))
+        return "\n".join(parts)
+    return str(completion)
+
+
+def exact_answer_reward(prompt: Any, completion: Any, answer: str | None = None, **_: Any) -> float:
+    text = _completion_text(completion)
+    if answer is None:
+        return 0.0
+    return 1.0 if str(answer) in text else 0.0
+
+
+def _make_prompt(example_idx: int, answer: str) -> list[dict[str, str]]:
+    return [
+        {
+            "role": "user",
+            "content": "What is 15 + 27?",
+        },
+        {
+            "role": "assistant",
+            "content": BOUNDARY_HISTORY,
+        },
+        {
+            "role": "user",
+            "content": (
+                "Using the previous result, what is 42 * 2? "
+                f"Return only the number {answer}. Problem id: {example_idx}."
+            ),
+        },
+    ]
+
+
+def load_environment(num_examples: int = 8, answer: str = "84", **_: Any):
+    dataset = Dataset.from_list(
+        [
+            {
+                "prompt": _make_prompt(i, answer),
+                "answer": answer,
+                "info": {"fixture": "memento-boundary", "example_idx": i},
+            }
+            for i in range(num_examples)
+        ]
+    )
+    rubric = vf.Rubric(funcs=[exact_answer_reward], weights=[1.0])
+    return vf.SingleTurnEnv(dataset=dataset, rubric=rubric)

--- a/tests/unit/inference/test_block_masking.py
+++ b/tests/unit/inference/test_block_masking.py
@@ -1,0 +1,605 @@
+"""
+Pure logic tests for Memento block masking.
+
+Tests the vendored modules (config, tracker, processor, position_mapping)
+on CPU with no vLLM or GPU dependency.
+"""
+
+import pytest
+
+from prime_rl.inference.block_masking.config import BlockMaskingConfig
+from prime_rl.inference.block_masking.tracker import BlockInfo, BlockMaskingState
+from prime_rl.inference.block_masking.processor import BlockMaskingProcessor
+from prime_rl.inference.block_masking.position_mapping import (
+    CompactedSpanTracker,
+    merge_spans,
+)
+
+# Token IDs used throughout tests
+BLOCK_START = 100
+BLOCK_END = 101
+SUMMARY_START = 102
+SUMMARY_END = 103
+IM_START = 104
+ASSISTANT = 105
+UNK = 0
+CONTENT = 200  # generic content token
+
+
+class FakeTokenizer:
+    """Minimal tokenizer for testing token ID resolution."""
+
+    def __init__(self, vocab: dict[str, int], unk_token_id: int = UNK):
+        self._vocab = vocab
+        self._reverse = {v: k for k, v in vocab.items()}
+        self.unk_token_id = unk_token_id
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+        if text in self._vocab:
+            return [self._vocab[text]]
+        return [self.unk_token_id, self.unk_token_id]  # multi-token = not found
+
+    def convert_tokens_to_ids(self, token: str) -> int:
+        return self._vocab.get(token, self.unk_token_id)
+
+
+def make_tokenizer() -> FakeTokenizer:
+    return FakeTokenizer({
+        "<|block_start|>": BLOCK_START,
+        "<|block_end|>": BLOCK_END,
+        "<|summary_start|>": SUMMARY_START,
+        "<|summary_end|>": SUMMARY_END,
+        "<|im_start|>": IM_START,
+        "assistant": ASSISTANT,
+    })
+
+
+def make_config(**overrides) -> BlockMaskingConfig:
+    defaults = dict(
+        enable=True,
+        mask_delimiters=False,
+        keep_last_n_blocks=0,
+        require_assistant_section=False,
+    )
+    defaults.update(overrides)
+    config = BlockMaskingConfig(**defaults)
+    config.initialize_token_ids(make_tokenizer())
+    return config
+
+
+def run_generation(
+    processor: BlockMaskingProcessor,
+    state: BlockMaskingState,
+    token_ids: list[int],
+    start_pos: int = 0,
+) -> list[tuple[int, int]]:
+    """Feed tokens one by one, collect all compaction ranges."""
+    compactions = []
+    for i, token_id in enumerate(token_ids):
+        result = processor.process_token(state, token_id, start_pos + i)
+        if result is not None:
+            compactions.append(result)
+    return compactions
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Config initialization and validation
+# ---------------------------------------------------------------------------
+
+def test_config_initialization_and_validation():
+    tokenizer = make_tokenizer()
+
+    # --- Basic initialization ---
+    config = BlockMaskingConfig(enable=True, mask_delimiters=False)
+    config.initialize_token_ids(tokenizer)
+    assert config._initialized
+    assert config.block_start_id == BLOCK_START
+    assert config.block_end_id == BLOCK_END
+    assert config.summary_start_id == SUMMARY_START
+    assert config.summary_end_id == SUMMARY_END
+    assert config.im_start_id == IM_START
+    assert config.assistant_id == ASSISTANT
+
+    # --- Integer string token resolution ---
+    config_int = BlockMaskingConfig(
+        enable=True,
+        mask_delimiters=False,
+        block_start_token="42",
+        block_end_token="43",
+        summary_start_token="44",
+        summary_end_token="45",
+    )
+    config_int.initialize_token_ids(tokenizer)
+    assert config_int.block_start_id == 42
+    assert config_int.block_end_id == 43
+    assert config_int.summary_start_id == 44
+    assert config_int.summary_end_id == 45
+
+    # --- Missing required token raises ---
+    config_bad = BlockMaskingConfig(
+        enable=True,
+        mask_delimiters=False,
+        block_start_token="<|nonexistent|>",
+    )
+    with pytest.raises(ValueError, match="not found in vocabulary"):
+        config_bad.initialize_token_ids(tokenizer)
+
+    # --- mask_delimiters=None with enable=True raises ---
+    with pytest.raises(ValueError, match="mask_delimiters must be explicitly set"):
+        BlockMaskingConfig(enable=True, mask_delimiters=None)
+
+    # --- keep_last_n_blocks < -1 raises ---
+    with pytest.raises(ValueError, match="keep_last_n_blocks must be >= -1"):
+        BlockMaskingConfig(enable=True, mask_delimiters=False, keep_last_n_blocks=-2)
+
+    # --- async mode validation ---
+    config_barrier = BlockMaskingConfig(
+        enable=True,
+        mask_delimiters=False,
+        async_mode="async_barrier",
+    )
+    assert config_barrier.async_mode == "async_barrier"
+    with pytest.raises(ValueError, match="async_mode must be one of"):
+        BlockMaskingConfig(
+            enable=True,
+            mask_delimiters=False,
+            async_mode="bad_mode",
+        )
+
+    # --- require_assistant_section auto-disables if tokens missing ---
+    no_assistant_tokenizer = FakeTokenizer({
+        "<|block_start|>": BLOCK_START,
+        "<|block_end|>": BLOCK_END,
+        "<|summary_start|>": SUMMARY_START,
+        "<|summary_end|>": SUMMARY_END,
+    })
+    config_no_asst = BlockMaskingConfig(
+        enable=True,
+        mask_delimiters=False,
+        require_assistant_section=True,
+    )
+    config_no_asst.initialize_token_ids(no_assistant_tokenizer)
+    assert not config_no_asst.require_assistant_section
+    assert config_no_asst.im_start_id is None
+
+    # --- Idempotent re-initialization ---
+    config2 = BlockMaskingConfig(enable=True, mask_delimiters=False)
+    result1 = config2.initialize_token_ids(tokenizer)
+    result2 = config2.initialize_token_ids(tokenizer)
+    assert result1 is result2 is config2
+
+    # --- Disabled config skips validation ---
+    config_disabled = BlockMaskingConfig(enable=False, mask_delimiters=None)
+    assert not config_disabled.enable  # should not raise
+
+    # --- encode() path: single-token encode ---
+    encode_tokenizer = FakeTokenizer({
+        "<|block_start|>": BLOCK_START,
+        "<|block_end|>": BLOCK_END,
+        "<|summary_start|>": SUMMARY_START,
+        "<|summary_end|>": SUMMARY_END,
+    })
+    config_enc = BlockMaskingConfig(enable=True, mask_delimiters=False,
+                                    require_assistant_section=False)
+    config_enc.initialize_token_ids(encode_tokenizer)
+    assert config_enc.block_start_id == BLOCK_START
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Full block lifecycle — single block
+# ---------------------------------------------------------------------------
+
+def test_full_block_lifecycle_single_block():
+    # --- mask_delimiters=False (Qwen3/OLMo3 style) ---
+    config = make_config(mask_delimiters=False, keep_last_n_blocks=0)
+    processor = BlockMaskingProcessor(config)
+    state = processor.create_state()
+
+    # Prompt: 6 tokens (positions 0-5)
+    prompt = [CONTENT] * 6
+    processor.process_prompt_tokens(state, prompt)
+    assert len(state.blocks) == 0
+    assert len(state.open_blocks) == 0
+
+    # Generation starts at position 6
+    # pos 6: block_start
+    result = processor.process_token(state, BLOCK_START, 6)
+    assert result is None
+    assert len(state.open_blocks) == 1
+    assert len(state.blocks) == 1
+    assert state.blocks[0].start_position == 6
+    assert state.blocks[0].end_position is None
+
+    # pos 7-10: content tokens
+    for pos in range(7, 11):
+        result = processor.process_token(state, CONTENT, pos)
+        assert result is None
+
+    # pos 11: block_end
+    result = processor.process_token(state, BLOCK_END, 11)
+    assert result is None
+    assert len(state.open_blocks) == 0
+    assert state.blocks[0].end_position == 11
+
+    # pos 12: summary_start
+    result = processor.process_token(state, SUMMARY_START, 12)
+    assert result is None
+    assert state.in_summary
+    assert state.current_summary_block_id == 0
+    assert state.blocks[0].summary_start == 12
+
+    # pos 13-14: summary content
+    for pos in range(13, 15):
+        result = processor.process_token(state, CONTENT, pos)
+        assert result is None
+
+    # pos 15: summary_end → triggers compaction
+    result = processor.process_token(state, SUMMARY_END, 15)
+    assert result is not None
+    assert not state.in_summary
+    assert state.blocks[0].summary_end == 15
+    assert state.blocks[0].is_complete
+
+    # mask_delimiters=False: range is (start+1, end) = (7, 11)
+    start, end = result
+    assert start == 7
+    assert end == 11
+    assert end - start == 4  # 4 content tokens
+
+    assert len(state.compacted_block_ids) == 1
+    assert state.total_compacted_tokens == 4
+
+    # --- mask_delimiters=True (Phi3/Phi4 style) ---
+    config_md = make_config(mask_delimiters=True, keep_last_n_blocks=0)
+    processor_md = BlockMaskingProcessor(config_md)
+    state_md = processor_md.create_state()
+
+    processor_md.process_prompt_tokens(state_md, prompt)
+
+    tokens = [BLOCK_START, CONTENT, CONTENT, CONTENT, CONTENT,
+              BLOCK_END, SUMMARY_START, CONTENT, CONTENT, SUMMARY_END]
+    compactions = run_generation(processor_md, state_md, tokens, start_pos=6)
+
+    assert len(compactions) == 1
+    start, end = compactions[0]
+    assert start == 6   # block_start position (inclusive)
+    assert end == 12    # block_end position + 1
+    assert end - start == 6  # block_start + 4 content + block_end
+
+    # --- require_assistant=True: blocks before assistant are ignored ---
+    config_asst = make_config(require_assistant_section=True, mask_delimiters=False)
+    processor_asst = BlockMaskingProcessor(config_asst)
+    state_asst = processor_asst.create_state()
+
+    # Pre-assistant tokens with block markers → should be ignored
+    pre_tokens = [CONTENT, BLOCK_START, CONTENT, BLOCK_END,
+                  SUMMARY_START, CONTENT, SUMMARY_END]
+    compactions_pre = run_generation(processor_asst, state_asst, pre_tokens, start_pos=0)
+    assert len(compactions_pre) == 0
+    assert len(state_asst.blocks) == 0
+    assert not state_asst.in_assistant_section
+
+    # Now enter assistant section: im_start at pos 7, assistant at pos 8
+    result = processor_asst.process_token(state_asst, IM_START, 7)
+    assert result is None
+    result = processor_asst.process_token(state_asst, ASSISTANT, 8)
+    assert result is None
+    assert state_asst.in_assistant_section
+
+    # Now block markers should be tracked
+    result = processor_asst.process_token(state_asst, BLOCK_START, 9)
+    assert result is None
+    assert len(state_asst.blocks) == 1
+
+    # --- require_assistant=False: blocks tracked everywhere ---
+    config_no_asst = make_config(require_assistant_section=False, mask_delimiters=False)
+    processor_no_asst = BlockMaskingProcessor(config_no_asst)
+    state_no_asst = processor_no_asst.create_state()
+
+    tokens_all = [BLOCK_START, CONTENT, CONTENT, BLOCK_END,
+                  SUMMARY_START, CONTENT, SUMMARY_END]
+    compactions_all = run_generation(processor_no_asst, state_no_asst, tokens_all, start_pos=0)
+    assert len(compactions_all) == 1
+    assert compactions_all[0] == (1, 3)  # (start+1, end) = (1, 3)
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Multi-block keep_last_n and deferred compaction
+# ---------------------------------------------------------------------------
+
+def _make_three_blocks(config: BlockMaskingConfig, prompt_len: int = 6):
+    """Create processor+state and generate 3 complete blocks.
+
+    Block layout (starting at position prompt_len):
+      Block 0: BS content content BE SS content SE
+      Block 1: BS content content BE SS content SE
+      Block 2: BS content content BE SS content SE
+
+    Returns (processor, state, all_compactions, final_pos)
+    """
+    processor = BlockMaskingProcessor(config)
+    state = processor.create_state()
+    processor.process_prompt_tokens(state, [CONTENT] * prompt_len)
+
+    all_compactions = []
+    pos = prompt_len
+    for _ in range(3):
+        tokens = [BLOCK_START, CONTENT, CONTENT, BLOCK_END,
+                  SUMMARY_START, CONTENT, SUMMARY_END]
+        for token_id in tokens:
+            result = processor.process_token(state, token_id, pos)
+            if result is not None:
+                all_compactions.append(result)
+            pos += 1
+
+    return processor, state, all_compactions, pos
+
+
+def test_multi_block_keep_last_n_and_deferred_compaction():
+    # --- keep_last_n=0: compact all immediately ---
+    config_k0 = make_config(keep_last_n_blocks=0, mask_delimiters=False)
+    _, state_k0, compactions_k0, _ = _make_three_blocks(config_k0)
+    assert len(compactions_k0) == 3
+    assert len(state_k0.compacted_block_ids) == 3
+    assert len(state_k0.pending_compactions) == 0
+    # Each block: (start+1, end) = 2 content tokens
+    for c in compactions_k0:
+        assert c[1] - c[0] == 2
+
+    # --- keep_last_n=1: keep 1 block, compact older ---
+    config_k1 = make_config(keep_last_n_blocks=1, mask_delimiters=False)
+    _, state_k1, compactions_k1, _ = _make_three_blocks(config_k1)
+    assert len(compactions_k1) == 2
+    assert len(state_k1.compacted_block_ids) == 2
+    assert len(state_k1.pending_compactions) == 1  # block 2 still pending
+
+    # --- keep_last_n=-1: never compact ---
+    config_km1 = make_config(keep_last_n_blocks=-1, mask_delimiters=False)
+    _, state_km1, compactions_km1, _ = _make_three_blocks(config_km1)
+    assert len(compactions_km1) == 0
+    assert len(state_km1.compacted_block_ids) == 0
+    assert len(state_km1.pending_compactions) == 3
+
+    # --- keep_last_block_for_answer with keep_last_n=0 ---
+    config_defer = make_config(
+        keep_last_n_blocks=0,
+        keep_last_block_for_answer=True,
+        mask_delimiters=False,
+    )
+    processor_defer, state_defer, compactions_defer, final_pos = \
+        _make_three_blocks(config_defer)
+
+    # Block 0 completes → deferred (no compaction)
+    # Block 1 starts → flushes block 0 (1 compaction)
+    # Block 1 completes → deferred
+    # Block 2 starts → flushes block 1 (1 compaction)
+    # Block 2 completes → deferred
+    # Total: 2 compactions (blocks 0, 1). Block 2 is deferred.
+    assert len(compactions_defer) == 2
+    assert len(state_defer.compacted_block_ids) == 2
+    assert len(state_defer.pending_compactions) == 1  # block 2 deferred
+    assert state_defer.pending_compactions[0] == 2
+
+    # --- force_compact_pending drains all ---
+    forced = processor_defer.force_compact_pending(state_defer)
+    assert len(forced) == 1
+    assert len(state_defer.pending_compactions) == 0
+    assert len(state_defer.compacted_block_ids) == 3
+
+    # --- force_compact_pending on keep_last_n=-1 ---
+    config_force = make_config(keep_last_n_blocks=-1, mask_delimiters=False)
+    proc_force, state_force, _, _ = _make_three_blocks(config_force)
+    assert len(state_force.pending_compactions) == 3
+    forced_all = proc_force.force_compact_pending(state_force)
+    assert len(forced_all) == 3
+    assert len(state_force.pending_compactions) == 0
+
+    # --- Verify block content tracking ---
+    config_verify = make_config(keep_last_n_blocks=0, mask_delimiters=False)
+    _, state_v, _, _ = _make_three_blocks(config_verify)
+    assert state_v.total_compacted_tokens == 6  # 3 blocks × 2 content tokens
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Position mapping and span merging
+# ---------------------------------------------------------------------------
+
+def test_position_mapping_and_span_merging():
+    # --- Single span (5, 10): removes positions 5-9 ---
+    tracker = CompactedSpanTracker()
+    tracker.spans = [(5, 10)]
+
+    # Active tokens: 0-4, 10+
+    assert tracker.is_token_active(0)
+    assert tracker.is_token_active(4)
+    assert not tracker.is_token_active(5)
+    assert not tracker.is_token_active(9)
+    assert tracker.is_token_active(10)
+
+    # logical→physical
+    assert tracker.logical_to_physical(0) == 0
+    assert tracker.logical_to_physical(4) == 4
+    assert tracker.logical_to_physical(10) == 5  # 10 - 5 removed = 5
+    assert tracker.logical_to_physical(15) == 10
+
+    # physical→logical
+    assert tracker.physical_to_logical(0) == 0
+    assert tracker.physical_to_logical(4) == 4
+    assert tracker.physical_to_logical(5) == 10  # gap: phys 5 → logical 10
+    assert tracker.physical_to_logical(10) == 15
+
+    # get_active_positions
+    active = tracker.get_active_positions(15)
+    assert active == [0, 1, 2, 3, 4, 10, 11, 12, 13, 14]
+
+    # get_compacted_token_count
+    assert tracker.get_compacted_token_count() == 5
+
+    # --- Two spans (5,10) + (15,20): cumulative offset ---
+    tracker2 = CompactedSpanTracker()
+    tracker2.spans = [(5, 10), (15, 20)]
+
+    assert tracker2.logical_to_physical(0) == 0
+    assert tracker2.logical_to_physical(4) == 4
+    assert tracker2.logical_to_physical(10) == 5
+    assert tracker2.logical_to_physical(14) == 9
+    assert tracker2.logical_to_physical(20) == 10  # 20 - 5 - 5 = 10
+    assert tracker2.logical_to_physical(25) == 15
+
+    assert tracker2.physical_to_logical(0) == 0
+    assert tracker2.physical_to_logical(5) == 10
+    assert tracker2.physical_to_logical(9) == 14
+    assert tracker2.physical_to_logical(10) == 20
+    assert tracker2.physical_to_logical(15) == 25
+
+    assert tracker2.get_compacted_token_count() == 10
+
+    active2 = tracker2.get_active_positions(25)
+    assert active2 == [0, 1, 2, 3, 4, 10, 11, 12, 13, 14, 20, 21, 22, 23, 24]
+
+    # --- merge_spans: 7 edge cases ---
+    # Overlapping
+    assert merge_spans([(0, 5), (3, 8)]) == [(0, 8)]
+    # Adjacent
+    assert merge_spans([(0, 5), (5, 10)]) == [(0, 10)]
+    # Gap
+    assert merge_spans([(0, 5), (7, 10)]) == [(0, 5), (7, 10)]
+    # Out of order
+    assert merge_spans([(7, 10), (0, 5)]) == [(0, 5), (7, 10)]
+    # Empty
+    assert merge_spans([]) == []
+    # Cascading
+    assert merge_spans([(0, 3), (2, 6), (5, 9)]) == [(0, 9)]
+    # Containment
+    assert merge_spans([(0, 10), (3, 7)]) == [(0, 10)]
+
+    # --- Sequential add_span like the scheduler does ---
+    tracker3 = CompactedSpanTracker()
+    tracker3.add_span(5, 10)
+    assert tracker3.spans == [(5, 10)]
+    assert tracker3.get_compacted_token_count() == 5
+
+    tracker3.add_span(15, 20)
+    assert tracker3.spans == [(5, 10), (15, 20)]
+    assert tracker3.get_compacted_token_count() == 10
+
+    tracker3.add_span(10, 15)  # fills the gap
+    assert tracker3.spans == [(5, 20)]
+    assert tracker3.get_compacted_token_count() == 15
+
+    # --- Round-trip property ---
+    tracker_rt = CompactedSpanTracker()
+    tracker_rt.spans = [(3, 7), (12, 18), (25, 30)]
+
+    # For every active logical position, round-trip should work
+    active_positions = tracker_rt.get_active_positions(40)
+    for logical in active_positions:
+        physical = tracker_rt.logical_to_physical(logical)
+        back = tracker_rt.physical_to_logical(physical)
+        assert back == logical, (
+            f"Round-trip failed: logical={logical} → physical={physical} → {back}"
+        )
+
+    # --- Empty tracker ---
+    empty = CompactedSpanTracker()
+    assert empty.logical_to_physical(5) == 5
+    assert empty.physical_to_logical(5) == 5
+    assert empty.is_token_active(5)
+    assert empty.get_active_positions(5) == [0, 1, 2, 3, 4]
+    assert empty.get_compacted_token_count() == 0
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Restart mode rewind
+# ---------------------------------------------------------------------------
+
+def test_restart_mode_rewind():
+    # --- restart_range always includes delimiters ---
+    block = BlockInfo(block_id=0, start_position=6, end_position=11,
+                      summary_start=12, summary_end=15)
+    assert block.is_complete
+
+    # mask_delimiters=False: content range = (7, 11), restart range = (6, 12)
+    assert block.get_content_range(mask_delimiters=False) == (7, 11)
+    assert block.get_restart_range(mask_delimiters=False) == (6, 12)
+
+    # mask_delimiters=True: content range = (6, 12), restart range = (6, 12)
+    assert block.get_content_range(mask_delimiters=True) == (6, 12)
+    assert block.get_restart_range(mask_delimiters=True) == (6, 12)
+
+    # --- restart_mode sets pending_restart_rewind ---
+    config = make_config(
+        restart_mode=True,
+        mask_delimiters=False,
+        keep_last_n_blocks=0,
+    )
+    processor = BlockMaskingProcessor(config)
+    state = processor.create_state()
+
+    prompt = [CONTENT] * 6
+    processor.process_prompt_tokens(state, prompt)
+    assert state.pending_restart_rewind is None
+
+    # Generate a complete block
+    tokens = [BLOCK_START, CONTENT, CONTENT, CONTENT, CONTENT,
+              BLOCK_END, SUMMARY_START, CONTENT, CONTENT, SUMMARY_END]
+    compactions = run_generation(processor, state, tokens, start_pos=6)
+
+    assert len(compactions) == 1
+    # restart_mode=True → uses restart range (includes delimiters)
+    start, end = compactions[0]
+    assert start == 6   # block_start
+    assert end == 12    # block_end + 1
+    assert state.pending_restart_rewind == 12  # summary_start position
+
+    # --- deferred + restart combo ---
+    config_defer_restart = make_config(
+        restart_mode=True,
+        keep_last_block_for_answer=True,
+        keep_last_n_blocks=0,
+        mask_delimiters=False,
+    )
+    proc_dr = BlockMaskingProcessor(config_defer_restart)
+    state_dr = proc_dr.create_state()
+    proc_dr.process_prompt_tokens(state_dr, [CONTENT] * 6)
+
+    # Block 0: deferred
+    tokens_b0 = [BLOCK_START, CONTENT, CONTENT, BLOCK_END,
+                 SUMMARY_START, CONTENT, SUMMARY_END]
+    compactions_b0 = run_generation(proc_dr, state_dr, tokens_b0, start_pos=6)
+    assert len(compactions_b0) == 0
+    assert len(state_dr.pending_compactions) == 1
+
+    # Block 1 starts → flushes block 0 with restart range
+    result = proc_dr.process_token(state_dr, BLOCK_START, 13)
+    assert result is not None
+    start, end = result
+    assert start == 6   # block_start of block 0
+    assert end == 10    # block_end + 1 of block 0 (pos 9 + 1)
+    assert state_dr.pending_restart_rewind == 10  # summary_start of block 0
+
+    # --- prompt processing with restart mode ---
+    config_prompt_restart = make_config(
+        restart_mode=True,
+        mask_delimiters=False,
+        keep_last_n_blocks=0,
+    )
+    proc_pr = BlockMaskingProcessor(config_prompt_restart)
+    state_pr = proc_pr.create_state()
+
+    # Prompt contains a complete block
+    prompt_with_block = [
+        CONTENT, CONTENT,
+        BLOCK_START, CONTENT, CONTENT, BLOCK_END,
+        SUMMARY_START, CONTENT, SUMMARY_END,
+        CONTENT,
+    ]
+    proc_pr.process_prompt_tokens(state_pr, prompt_with_block)
+
+    assert len(state_pr.pending_compactions) == 1
+    assert state_pr.pending_restart_rewind == 6  # summary_start in prompt
+
+    # --- incomplete block: no restart range ---
+    incomplete = BlockInfo(block_id=0, start_position=6, end_position=11)
+    assert incomplete.get_restart_range(mask_delimiters=False) is None
+    assert incomplete.get_content_range(mask_delimiters=False) is None


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new vLLM overlay modules and scheduler output fields to support block-masking KV compaction and event publishing; mistakes here could break inference scheduling/KV cache behavior during RL runs. Most other changes are CI configs and smoke-test wrappers, but they exercise multi-process GPU workflows where failures can be hard to diagnose.
> 
> **Overview**
> Adds a **Memento/vLLM 0.21 validation path**: new CI integration TOML configs covering short smokes, 100-step runs, a deterministic boundary-fixture run (plus an off-policy variant), and a baseline run with block masking disabled.
> 
> Introduces two Baseten/Truss training jobs, `memento_inference_test.py` and `memento_rl_test.py`, that install the block-masking overlay, prepare a token-augmented model, run inference/RL, and *hard-fail* on missing artifacts, non-finite trainer metrics, missing async-barrier signals, and missing/failed compaction + KV-copy + block-truncation logs.
> 
> Extends the vendored vLLM overlay to expose `BlockMaskingConfig`/processor imports, add KV-compaction scheduling signals on `SchedulerOutput` (KV copy ops, block table truncations, sampling skips, barrier flag), and adds a ZMQ-backed KV cache event publisher (including a `KVSlotCopy` event). Also adds a detailed `docs/memento-stability-validation.md` report documenting the executed validation matrix and outcomes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6024571ec144300010cc9358ae5af6d77edf6f7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->