### PR TITLE
fix(orchestrator): deep-merge legacy model/client aliases; switch multinode template to canonical CLI path

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -680,22 +680,20 @@ class OrchestratorConfig(BaseConfig):
         if not isinstance(data, dict):
             return data
 
-        def _deep_merge_into(dst: dict, src: dict) -> None:
+        def deep_merge(dst: dict, src: dict) -> None:
             """In-place recursive merge of ``src`` into ``dst``. ``src`` wins at the leaf."""
             for k, v in src.items():
                 if isinstance(v, dict) and isinstance(dst.get(k), dict):
-                    _deep_merge_into(dst[k], v)
+                    deep_merge(dst[k], v)
                 else:
                     dst[k] = v
 
-        # 1. Re-nest top-level [orchestrator.client] under student.client. Deep-merge
-        # so a CLI override like `--client.base-url URL` reaches `student.client.base_url`
-        # even when the TOML already populated `[student.client]`.
+        # 1. Re-nest top-level [orchestrator.client] under student.client.
         legacy_client = data.pop("client", None)
         if isinstance(legacy_client, dict):
             student = data.setdefault("student", {})
             if isinstance(student, dict):
-                _deep_merge_into(student.setdefault("client", {}), legacy_client)
+                deep_merge(student.setdefault("client", {}), legacy_client)
             else:
                 # Mismatched types - put it back and let pydantic surface the error.
                 data["client"] = legacy_client
@@ -709,7 +707,7 @@ class OrchestratorConfig(BaseConfig):
             if existing is None:
                 data["student"] = legacy_model
             elif isinstance(existing, dict) and isinstance(legacy_model, dict):
-                _deep_merge_into(existing, legacy_model)
+                deep_merge(existing, legacy_model)
             else:
                 # Mismatched types - put it back and let pydantic surface the error.
                 data["model"] = legacy_model

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -680,22 +680,36 @@ class OrchestratorConfig(BaseConfig):
         if not isinstance(data, dict):
             return data
 
-        # 1. Re-nest top-level [orchestrator.client] under student.client.
-        if "client" in data:
+        def _deep_merge_into(dst: dict, src: dict) -> None:
+            """In-place recursive merge of ``src`` into ``dst``. ``src`` wins at the leaf."""
+            for k, v in src.items():
+                if isinstance(v, dict) and isinstance(dst.get(k), dict):
+                    _deep_merge_into(dst[k], v)
+                else:
+                    dst[k] = v
+
+        # 1. Re-nest top-level [orchestrator.client] under student.client. Deep-merge
+        # so a CLI override like `--client.base-url URL` reaches `student.client.base_url`
+        # even when the TOML already populated `[student.client]`.
+        legacy_client = data.pop("client", None)
+        if isinstance(legacy_client, dict):
             student = data.setdefault("student", {})
-            if isinstance(student, dict) and "client" not in student:
-                student["client"] = data.pop("client")
+            if isinstance(student, dict):
+                _deep_merge_into(student.setdefault("client", {}), legacy_client)
+            else:
+                # Mismatched types - put it back and let pydantic surface the error.
+                data["client"] = legacy_client
 
         # 2. Consolidate the legacy `model` alias into `student` so the
-        # flat-layout fix-up below sees a single target.
+        # flat-layout fix-up below sees a single target. Deep-merge with the
+        # legacy keys winning so a CLI `--model.<k>` overrides TOML `student.model.<k>`.
         legacy_model = data.pop("model", None)
         if legacy_model is not None:
             existing = data.get("student")
             if existing is None:
                 data["student"] = legacy_model
             elif isinstance(existing, dict) and isinstance(legacy_model, dict):
-                for k, v in legacy_model.items():
-                    existing.setdefault(k, v)
+                _deep_merge_into(existing, legacy_model)
             else:
                 # Mismatched types - put it back and let pydantic surface the error.
                 data["model"] = legacy_model

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -376,8 +376,8 @@ else
 
     if [ "$TRAIN_NODE_RANK" -eq 0 ]; then
         ORCHESTRATOR_ARGS="@ $CONFIG_DIR/orchestrator.toml"
-        ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --client.base-url $INFER_URLS"
-        ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --client.admin-base-url $ADMIN_URLS"
+        ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --student.client.base-url $INFER_URLS"
+        ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --student.client.admin-base-url $ADMIN_URLS"
         {% if use_nccl_broadcast %}ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --weight_broadcast.host $MASTER_ADDR"
         {% endif %}{% if wandb_shared %}WANDB_SHARED_LABEL=orchestrator {% endif %}uv run orchestrator $ORCHESTRATOR_ARGS \
             2>&1 | tee $OUTPUT_DIR/logs/orchestrator.log &


### PR DESCRIPTION
## Summary

Two coupled fixes so the multi-node RL launcher's orchestrator command actually parses on current `OrchestratorConfig`.

### 1. `fold_student_shortcuts` validator — deep-merge instead of skip
`OrchestratorConfig.fold_student_shortcuts` (in `packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py`) previously:
- Re-nested top-level `client` into `student.client` **only if `student.client` was absent**.
- For `model`, used `existing.setdefault(k, v)` — TOML values won, legacy/top-level keys were dropped.

When TOML supplies `[student.client]` (the post-rename canonical layout) and the CLI passes `--client.base-url URL`, the merged dict has both `student.client` (from TOML) and top-level `client` (from CLI). The validator skipped, leaving top-level `client` in place, and pydantic's `extra="forbid"` rejected it with `Extra inputs are not permitted`. Same shape for `--model.<k>` against TOML `[student.model]`.

Now both shortcuts deep-merge into the canonical location with the legacy/top-level side winning at the leaf. TOML fields the CLI doesn't touch are preserved.

### 2. `multi_node_rl.sbatch.j2` — use canonical CLI path
`--client.base-url` / `--client.admin-base-url` → `--student.client.base-url` / `--student.client.admin-base-url`.

The canonical path is a *known leaf* in pydantic-config, so list-typed args like `base_url: list[str]` get properly list-wrapped from a single token. The legacy alias falls through the unknown-leaf branch in `_parse_cli_to_dict` and stores a raw string — which fails the list-type check even after the validator re-nests it.

## Verification

Unit-level: deep-merge of TOML + legacy aliases:

```
base_url: ['http://override:9000/v1']                # CLI override wins
admin_base_url: ['http://admin:9100/v1']             # CLI-only key reaches student.client
timeout (TOML preserved): 1200
api_key_var (TOML preserved): K
model.name (TOML preserved): from-toml
model.trust_remote_code (legacy override): True
```

Real cluster (`examples/multinode/rl.toml`, 2× H200, job 19348):
- Pre-fix: orchestrator died in 7s with `--client Extra inputs are not permitted`.
- Post-fix: orchestrator config validates and starts. Log line 30 (`orchestrator.py::123`):
  ```
  Initializing student inference pool (base_url=http://ltc-idc3-hgx8-h200-53:8000/v1, model=Qwen/Qwen3-30B-A3B-Thinking-2507)
  ```
  CLI override correctly applied (replaced the localhost TOML default), single value list-wrapped. Job then fails on the test cluster only because of missing wandb auth — unrelated.

## Out of scope (separate bug)
While running the verification I also hit a self-kill in the cleanup `pkill` block (`multi_node_rl.sbatch.j2:163-178`): the `pkill -9 -f "[v]llm"` line matches the cleanup `srun`'s own cmdline because lines 171-175 still contain the literal substring `vllm` (only the `-f` matchers were `[v]llm`-escaped by #2477). Worked around in the verification by commenting the block in the rendered sbatch — fix to follow separately if you want it on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes config-merging precedence and CLI flag paths, which could affect how existing configs/overrides resolve and whether multi-node jobs start successfully.
> 
> **Overview**
> **Fixes orchestrator config parsing when mixing legacy shortcuts with canonical TOML.** `fold_student_shortcuts` now *deep-merges* top-level `client` and `model` aliases into `student` (with legacy/CLI keys winning at leaf values) instead of skipping/`setdefault`-ing and leaving forbidden extra keys behind.
> 
> **Updates the multi-node RL launcher to use canonical CLI paths.** The sbatch template switches `--client.base-url` / `--client.admin-base-url` to `--student.client.base-url` / `--student.client.admin-base-url` so orchestrator startup matches the current `OrchestratorConfig` layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b62c283b31b23c97b92e51dd5d79bf3d4be65b4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->