### PR TITLE
fix(slurm): stop pre-launch cleanup srun from self-killing

### DIFF
--- a/src/prime_rl/templates/inference.sbatch.j2
+++ b/src/prime_rl/templates/inference.sbatch.j2
@@ -116,7 +116,11 @@ echo "INFER_URLS=${INFER_URLS}"
 # processes and vLLM/torch IPC files under /dev/shm and /tmp can survive SLURM
 # termination and cause the next launch to hang (e.g. decode engines stuck at
 # "Waiting for READY message from DP Coordinator"). Harmless on clean nodes.
-srun bash -c '
+#
+# `bash -s` with a heredoc on stdin keeps the script body out of every bash
+# / srun argv — otherwise `pkill -f "[v]llm"` self-matches the cleanup procs
+# because the surviving literal `vllm` strings below appear in the cmdline.
+srun bash -s <<'CLEANUP_SH'
     pkill -9 -f "[p]ython.*prime_rl" 2>/dev/null
     pkill -9 -f "[t]orchrun" 2>/dev/null
     pkill -9 -f "[v]llm-router" 2>/dev/null
@@ -131,7 +135,7 @@ srun bash -c '
     procs=$(ps -eo comm,args | grep -E "python|torchrun|vllm|vllm::" | grep -v grep | wc -l)
     gpu=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits | awk "{s+=\$1} END {print s}")
     echo "[node-cleanup] $(hostname) procs=$procs gpu_mem=${gpu}MiB"
-'
+CLEANUP_SH
 
 # Run inference
 # --kill-on-bad-exit=1 propagates a non-zero exit on any node to all other

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -160,7 +160,11 @@ uv sync --all-extras
 # processes and vLLM/torch IPC files under /dev/shm and /tmp can survive SLURM
 # termination and cause the next launch to hang (e.g. decode engines stuck at
 # "Waiting for READY message from DP Coordinator"). Harmless on clean nodes.
-srun bash -c '
+#
+# `bash -s` with a heredoc on stdin keeps the script body out of every bash
+# / srun argv — otherwise `pkill -f "[v]llm"` self-matches the cleanup procs
+# because the surviving literal `vllm` strings below appear in the cmdline.
+srun bash -s <<'CLEANUP_SH'
     pkill -9 -f "[p]ython.*prime_rl" 2>/dev/null
     pkill -9 -f "[t]orchrun" 2>/dev/null
     pkill -9 -f "[v]llm-router" 2>/dev/null
@@ -175,7 +179,7 @@ srun bash -c '
     procs=$(ps -eo comm,args | grep -E "python|torchrun|vllm|vllm::" | grep -v grep | wc -l)
     gpu=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits | awk "{s+=\$1} END {print s}")
     echo "[node-cleanup] $(hostname) procs=$procs gpu_mem=${gpu}MiB"
-'
+CLEANUP_SH
 
 # Run RL
 # --kill-on-bad-exit=1 propagates a non-zero exit on any node to all other

--- a/src/prime_rl/templates/multi_node_sft.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_sft.sbatch.j2
@@ -67,7 +67,11 @@ cd $PROJECT_DIR && uv sync --all-extras
 # Cleanup stale node-local state from prior jobs. Orphan python/torchrun/vllm
 # processes and vLLM/torch IPC files under /dev/shm and /tmp can survive SLURM
 # termination and cause the next launch to hang. Harmless on clean nodes.
-srun bash -c '
+#
+# `bash -s` with a heredoc on stdin keeps the script body out of every bash
+# / srun argv — otherwise `pkill -f "[v]llm"` self-matches the cleanup procs
+# because the surviving literal `vllm` strings below appear in the cmdline.
+srun bash -s <<'CLEANUP_SH'
     pkill -9 -f "[p]ython.*prime_rl" 2>/dev/null
     pkill -9 -f "[t]orchrun" 2>/dev/null
     pkill -9 -f "[v]llm-router" 2>/dev/null
@@ -82,7 +86,7 @@ srun bash -c '
     procs=$(ps -eo comm,args | grep -E "python|torchrun|vllm|vllm::" | grep -v grep | wc -l)
     gpu=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits | awk "{s+=\$1} END {print s}")
     echo "[node-cleanup] $(hostname) procs=$procs gpu_mem=${gpu}MiB"
-'
+CLEANUP_SH
 
 # Run SFT
 # --kill-on-bad-exit=1 propagates a non-zero exit on any node to all other


### PR DESCRIPTION
## Summary

The pre-launch cleanup block in `multi_node_rl`, `multi_node_sft`, and `inference` sbatch templates was reliably SIGKILLing itself before the real workload could start, taking the whole batch down with it (`ExitCode 9:0` / `137:0` within seconds of submission).

## Root cause

The `[v]llm`-style regex trick used by `pkill -9 -f "[v]llm"` only works if no other literal `vllm` substring appears in the matched cmdline. But the same script body has several:

```
pkill -9 "vllm"                                        # comm-only pkill, line 171
pkill -9 "vllm::.*"                                    # comm-only pkill, line 172
rm -rf /dev/shm/vllm-* /tmp/vllm-* …                   # cleanup glob,  line 174
procs=$(ps … | grep -E "python|torchrun|vllm|vllm::"…) # sanity grep,   line 175
```

With `srun bash -c '<script>'`, the entire script body sits in both `srun`'s argv and the spawned `bash`'s argv. `pkill -f "[v]llm"` matches them and KILLs them, the cleanup `srun` returns with `Killed`, and the outer batch script's `set -e` propagates a non-zero exit. SLURM tears the allocation down before any RL component starts.

## Fix

Switch from `srun bash -c '<script>'` to `srun bash -s <<'CLEANUP_SH' … CLEANUP_SH`. The heredoc is fed over stdin, so the cmdline of both `srun` and the per-task `bash` is just `srun bash -s` / `bash -s`. No script body in argv, no self-match. Stdin is broadcast to every task by default, so each node still runs the cleanup.

Applied to:
- `src/prime_rl/templates/multi_node_rl.sbatch.j2`
- `src/prime_rl/templates/multi_node_sft.sbatch.j2`
- `src/prime_rl/templates/inference.sbatch.j2`

The cleanup script body itself is unchanged — same `pkill` calls, same IPC-file cleanup, same final stat line.

## Verification

`examples/multinode/rl.toml` on 2× H200:

| Run | Cleanup step (`<job>.0`) | Batch (`<job>.batch`) | Notes |
|---|---|---|---|
| Pre-fix (19337/41/42/49) | `CANCELLED 0:9` (SIGKILL) | `FAILED 9:0` in 4-17 s | Cleanup never finished |
| Post-fix (19358) | `COMPLETED 0:0` in 3 s | `FAILED 15:0` later | Cleanup ran end-to-end on both nodes; subsequent failure is the unrelated orchestrator `--client` issue fixed in #2584 |

Cleanup log output on each node, as expected:
```
[node-cleanup] ltc-idc3-hgx8-h200-53 procs=1 gpu_mem=0MiB
[node-cleanup] ltc-idc3-hgx8-h200-96 procs=1 gpu_mem=0MiB
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SLURM job templates that run on every multi-node training/inference launch; a small scripting mistake could prevent jobs from starting or leave stale processes behind.
> 
> **Overview**
> Fixes the pre-launch node cleanup step in the `inference`, `multi_node_rl`, and `multi_node_sft` sbatch templates by switching from `srun bash -c '<script>'` to `srun bash -s` with a heredoc, keeping the cleanup script out of argv.
> 
> This prevents `pkill -f` patterns in the cleanup block from matching and SIGKILLing the cleanup `srun`/`bash` processes themselves, while leaving the actual cleanup commands unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b15f904479239ed7d36f0a4008fead020dd245a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->