### PR TITLE
feat(orchestrator): per-env state_columns for extra rollout fields

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -206,6 +206,9 @@ class EnvConfig(BaseConfig):
     timeout: float | None = Field(None, validation_alias=AliasChoices("timeout", "timeout_seconds"))
     """Per-rollout wall-clock timeout in seconds. None disables."""
 
+    state_columns: list[str] = []
+    """Extra ``State`` fields to persist into the saved rollout records (in addition to the always-saved ``trajectory`` and ``sampling_args``). Values must be JSON-serializable."""
+
     @property
     def stripped_id(self) -> str:
         """Environment ID without the @version suffix."""

--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -110,6 +110,17 @@ class Env:
         sampling_args["extra_body"] = extra_body
         return sampling_args
 
+    @property
+    def state_columns(self) -> list[str]:
+        """Required columns plus any extras configured on the env, deduped (required first)."""
+        seen: set[str] = set()
+        merged: list[str] = []
+        for col in (*REQUIRED_STATE_COLUMNS, *self.config.state_columns):
+            if col not in seen:
+                seen.add(col)
+                merged.append(col)
+        return merged
+
     async def run_rollout(
         self,
         client: vf.ClientConfig,
@@ -124,7 +135,7 @@ class Env:
             model=model_name,
             sampling_args=self._sampling_args_with_salt(cache_salt),
             max_retries=self.config.max_retries,
-            state_columns=REQUIRED_STATE_COLUMNS,
+            state_columns=self.state_columns,
             env_client=self.env_client,
         )
 
@@ -143,7 +154,7 @@ class Env:
             model=model_name,
             sampling_args=self._sampling_args_with_salt(cache_salt),
             max_retries=self.config.max_retries,
-            state_columns=REQUIRED_STATE_COLUMNS,
+            state_columns=self.state_columns,
             env_client=self.env_client,
         )
 

--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -113,11 +113,9 @@ class Env:
     @property
     def state_columns(self) -> list[str]:
         """Required columns plus any extras configured on the env, deduped (required first)."""
-        seen: set[str] = set()
         merged: list[str] = []
         for col in (*REQUIRED_STATE_COLUMNS, *self.config.state_columns):
-            if col not in seen:
-                seen.add(col)
+            if col not in merged:
                 merged.append(col)
         return merged
 


### PR DESCRIPTION
## Summary
- Add `state_columns: list[str] = []` to `EnvConfig` (inherited by `TrainEnvConfig` / `EvalEnvConfig`), so each env can persist additional `State` fields into the saved rollout JSONL.
- Merge with the always-required `["trajectory", "sampling_args"]` at the orchestrator call site via a new `Env.state_columns` property (required first, deduped).

The existing JSON-serializability check in `verifiers.utils.save_utils.state_to_output` still applies — non-serializable values raise `ValueError` at rollout time. `trajectory` is still stripped from the saved JSONL by `save_rollouts(..., exclude_keys={"trajectory"})`; configured extras land in `train_rollouts.jsonl` / `eval_rollouts.jsonl`.

### Usage

```toml
[[orchestrator.train.env]]
id = "my-env"
state_columns = ["custom_thing", "other_thing"]
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the `state_columns` passed into `verifiers` rollouts, which affects what state is persisted and could surface runtime errors if misconfigured (e.g., non-JSON-serializable fields). Scope is small and localized to env config + rollout invocation.
> 
> **Overview**
> Adds a new per-environment `state_columns` config on `EnvConfig` to let callers request additional `State` fields be persisted in saved rollout records.
> 
> Updates orchestrator env execution to compute `Env.state_columns` by merging required columns (`trajectory`, `sampling_args`) with the configured extras (deduped, required first) and passes this list into both `run_rollout` and `run_group` instead of the hardcoded required-only set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3f0d6897d63d5afdaeb8e91b61039fe99eeed71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->