### PR TITLE
fix(logger): preserve traceback in JSON sink

### DIFF
--- a/src/prime_rl/utils/logger.py
+++ b/src/prime_rl/utils/logger.py
@@ -39,9 +39,8 @@ def build_log_entry(record) -> dict:
         "function": record["function"],
         "line": record["line"],
     }
-    # When enqueue=True, loguru strips the traceback object before pickling
-    # (loguru/_recattrs.py:68). The traceback string must therefore be
-    # pre-formatted by a patcher and stashed in extra["traceback"].
+    # extra["traceback"] is set by traceback_patcher when enqueue=True (loguru
+    # drops the traceback object during pickling, so it must be pre-formatted).
     if extra.get("traceback"):
         log_entry["exception"] = extra.pop("traceback")
     elif record["exception"] is not None:
@@ -129,10 +128,8 @@ def setup_logger(
     from loguru._logger import Core as _Core
     from loguru._logger import Logger as _Logger
 
-    # Pre-format the traceback into extra["traceback"] before loguru enqueues
-    # the record. With enqueue=True, loguru pickles records and unconditionally
-    # drops the traceback object (loguru/_recattrs.py:68), so the formatted
-    # string must be captured here, while the live traceback is still attached.
+    # enqueue=True drops the traceback during pickling, so pre-format it here
+    # while the live traceback is still attached.
     patchers = [traceback_patcher] if json_logging else []
 
     logger = _Logger(

--- a/src/prime_rl/utils/logger.py
+++ b/src/prime_rl/utils/logger.py
@@ -41,9 +41,9 @@ def build_log_entry(record) -> dict:
     }
     # When enqueue=True, loguru strips the traceback object before pickling
     # (loguru/_recattrs.py:68). The traceback string must therefore be
-    # pre-formatted by a patcher and stashed in extra["_traceback"].
-    if extra.get("_traceback"):
-        log_entry["exception"] = extra.pop("_traceback")
+    # pre-formatted by a patcher and stashed in extra["traceback"].
+    if extra.get("traceback"):
+        log_entry["exception"] = extra.pop("traceback")
     elif record["exception"] is not None:
         exc = record["exception"]
         log_entry["exception"] = "".join(traceback.format_exception(exc.type, exc.value, exc.traceback))
@@ -57,10 +57,10 @@ def build_log_entry(record) -> dict:
     return log_entry
 
 
-def _traceback_patcher(record) -> None:
+def traceback_patcher(record) -> None:
     exc = record["exception"]
     if exc is not None and exc.traceback is not None:
-        record["extra"]["_traceback"] = "".join(traceback.format_exception(exc.type, exc.value, exc.traceback))
+        record["extra"]["traceback"] = "".join(traceback.format_exception(exc.type, exc.value, exc.traceback))
 
 
 def json_sink(message) -> None:
@@ -129,11 +129,11 @@ def setup_logger(
     from loguru._logger import Core as _Core
     from loguru._logger import Logger as _Logger
 
-    # Pre-format the traceback into extra["_traceback"] before loguru enqueues
+    # Pre-format the traceback into extra["traceback"] before loguru enqueues
     # the record. With enqueue=True, loguru pickles records and unconditionally
     # drops the traceback object (loguru/_recattrs.py:68), so the formatted
     # string must be captured here, while the live traceback is still attached.
-    patchers = [_traceback_patcher] if json_logging else []
+    patchers = [traceback_patcher] if json_logging else []
 
     logger = _Logger(
         core=_Core(),

--- a/src/prime_rl/utils/logger.py
+++ b/src/prime_rl/utils/logger.py
@@ -39,7 +39,12 @@ def build_log_entry(record) -> dict:
         "function": record["function"],
         "line": record["line"],
     }
-    if record["exception"] is not None:
+    # When enqueue=True, loguru strips the traceback object before pickling
+    # (loguru/_recattrs.py:68). The traceback string must therefore be
+    # pre-formatted by a patcher and stashed in extra["_traceback"].
+    if extra.get("_traceback"):
+        log_entry["exception"] = extra.pop("_traceback")
+    elif record["exception"] is not None:
         exc = record["exception"]
         log_entry["exception"] = "".join(traceback.format_exception(exc.type, exc.value, exc.traceback))
     # Extract tag from extra if present (used by workers to identify themselves)
@@ -50,6 +55,12 @@ def build_log_entry(record) -> dict:
         if extra:
             log_entry["extra"] = extra
     return log_entry
+
+
+def _traceback_patcher(record) -> None:
+    exc = record["exception"]
+    if exc is not None and exc.traceback is not None:
+        record["extra"]["_traceback"] = "".join(traceback.format_exception(exc.type, exc.value, exc.traceback))
 
 
 def json_sink(message) -> None:
@@ -118,6 +129,12 @@ def setup_logger(
     from loguru._logger import Core as _Core
     from loguru._logger import Logger as _Logger
 
+    # Pre-format the traceback into extra["_traceback"] before loguru enqueues
+    # the record. With enqueue=True, loguru pickles records and unconditionally
+    # drops the traceback object (loguru/_recattrs.py:68), so the formatted
+    # string must be captured here, while the live traceback is still attached.
+    patchers = [_traceback_patcher] if json_logging else []
+
     logger = _Logger(
         core=_Core(),
         exception=None,
@@ -127,7 +144,7 @@ def setup_logger(
         colors=False,
         raw=False,
         capture=True,
-        patchers=[],
+        patchers=patchers,
         extra={},
     )
 


### PR DESCRIPTION
## Summary

- Pre-format the loguru traceback into `record["extra"]["traceback"]` via a `traceback_patcher` that runs at log time, before `enqueue=True` pickles the record. The JSON sink reads it back into the `"exception"` field, restoring full stack frames in JSON logs.
- Keeps `enqueue=True` — required for multiprocess safety of trainer torchrun workers sharing stdout.

## Why

When `--log.json_logging` is enabled, exception logs lose their stack frames. Reproduction with the orchestrator entrypoint produced:

```json
{"level": "ERROR", "message": "Fatal error in orchestrate", "exception": "RuntimeError: ...\n"}
```

No `Traceback (most recent call last):` header, no frames — just the exception type + message.

## Root cause

`loguru/_recattrs.py:68` — `RecordException.__reduce__` unconditionally sets the traceback to `None` before pickling, because traceback objects aren't picklable:

```python
def __reduce__(self):
    try:
        pickled_value = pickle.dumps(self.value)
    except Exception:
        return (RecordException, (self.type, None, None))
    else:
        return (RecordException._from_pickled_value, (self.type, pickled_value, None))
                                                                                  # ^^^^ traceback dropped
```

With `enqueue=True` the record is pickled to cross the queue, so by the time `json_sink` receives it both `exc.traceback` and `exc.value.__traceback__` are `None`, and `traceback.format_exception(...)` renders only the head line.

## Verification

Injected `raise RuntimeError("...")` at the start of `orchestrate()`, ran `orchestrator @ configs/debug/orch.toml --log.json_logging`:

Before:
```json
{"level": "ERROR", "exception": "RuntimeError: ...\n"}
```

After:
```json
{"level": "ERROR", "exception": "Traceback (most recent call last):\n  File \".../utils.py\", line 59, in async_wrapper\n    ret = await func(*args, **kwargs)\n  File \".../orchestrator.py\", line 96, in orchestrate\n    raise RuntimeError(...)\nRuntimeError: ...\n"}
```

## Why not drop `enqueue=True`?

Per [loguru docs](https://loguru.readthedocs.io/en/stable/api/logger.html#loguru._logger.Logger.add):

> "Whether the messages to be logged should first pass through a multiprocessing-safe queue before reaching the sink. This is useful while logging to a file through multiple processes."

The trainer's torchrun workers all write JSON lines to a shared inherited stdout. Without the queue, concurrent writes from different processes can interleave at byte boundaries and corrupt JSON lines. Loguru's per-sink lock handles intra-process threading but is not multiprocess-safe.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how exceptions are captured and serialized in JSON logging mode (via Loguru patchers and `extra` mutation), which could affect error visibility and structured log fields across async/multiprocess logging.
> 
> **Overview**
> Fixes JSON logging so exception stack traces are preserved when the sink runs with `enqueue=True`.
> 
> This pre-formats the traceback at log time via a new `traceback_patcher` (stored in `record["extra"]["traceback"]`) and updates `build_log_entry()` to prefer that preformatted traceback when populating the JSON `exception` field, falling back to formatting `record["exception"]` only when needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d6b55be9911dd76f3d499b3a935980a91f3194b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->