### PR TITLE
Write token exports per step

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -482,9 +482,6 @@ WeightBroadcastConfig: TypeAlias = Annotated[
 class TokenExportConfig(BaseConfig):
     """Configures per-token rollout exports from the RL trainer."""
 
-    path: Path | None = None
-    """JSONL output file. If unset, writes to ``<output_dir>/token_exports/rank_<rank>.jsonl``. Relative paths are resolved under output_dir."""
-
 
 class TrainerExperimentalConfig(BaseConfig):
     token_export: TokenExportConfig | None = None

--- a/skills/configs/SKILL.md
+++ b/skills/configs/SKILL.md
@@ -62,12 +62,10 @@ In TOML, an empty section header (`[ckpt]`) does the same.
 
 ## RL trainer token exports
 
-For rollout debugging, enable trainer-side token export under `trainer.experimental.token_export` (or `experimental.token_export` when running the trainer entrypoint directly). It writes one JSONL record per exported sequence. Each record stores aligned per-token arrays for token ids, loss mask, advantage, reward, entropy, mismatch KL, inference/trainer logprobs, importance ratios, probability deltas, and masking diagnostics. It does not decode token text in the trainer.
+For rollout debugging, enable trainer-side token export under `trainer.experimental.token_export` (or `experimental.token_export` when running the trainer entrypoint directly). It writes one JSONL record per exported sequence under `output_dir/token_exports/step_<step>/rank_<rank>.jsonl`. Each record stores aligned per-token arrays for token ids, loss mask, advantage, reward, entropy, mismatch KL, inference/trainer logprobs, importance ratios, probability deltas, and masking diagnostics. It does not decode token text in the trainer.
 
 ```toml
 [trainer.experimental.token_export]
-# Optional. Relative paths resolve under trainer.output_dir.
-path = "token_exports/sample.jsonl"
 ```
 
 Leave it unset for normal training. When enabled, it exports every sequence from each exporting rank.

--- a/src/prime_rl/trainer/rl/token_export.py
+++ b/src/prime_rl/trainer/rl/token_export.py
@@ -8,7 +8,7 @@ from typing import Any
 import torch
 from torch import Tensor
 
-from prime_rl.configs.trainer import DefaultLossConfig, TokenExportConfig, TrainerConfig
+from prime_rl.configs.trainer import DefaultLossConfig, TrainerConfig
 from prime_rl.trainer.rl.loss import compute_importance_ratio_and_mismatch_kl
 
 SCHEMA_VERSION = 1
@@ -25,15 +25,12 @@ class DisabledTokenExporter:
 class TokenExporter:
     def __init__(
         self,
-        config: TokenExportConfig,
         output_dir: Path,
         rank: int,
     ) -> None:
-        self.config = config
         self.rank = rank
-        self.path = self._resolve_path(config.path, output_dir, rank)
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        self._file = self.path.open("a", encoding="utf-8")
+        self.output_dir = output_dir / "token_exports"
+        self._file: Any | None = None
         self._closed = False
         self._current_step: int | None = None
         self._sequences_this_step = 0
@@ -49,8 +46,7 @@ class TokenExporter:
         loss_config: Any,
     ) -> None:
         if self._current_step != step:
-            self._current_step = step
-            self._sequences_this_step = 0
+            self._start_step(step)
 
         columns = _export_columns(micro_batch, model_output, loss_config)
         _check_lengths(columns)
@@ -80,20 +76,27 @@ class TokenExporter:
         if self._closed:
             return
         self._closed = True
-        self._file.close()
+        if self._file is not None:
+            self._file.close()
+            self._file = None
+
+    def _start_step(self, step: int) -> None:
+        if self._closed:
+            raise RuntimeError(f"Token exporter is closed for {self.output_dir}")
+        if self._file is not None:
+            self._file.close()
+        self._current_step = step
+        self._sequences_this_step = 0
+        step_dir = self.output_dir / f"step_{step}"
+        step_dir.mkdir(parents=True, exist_ok=True)
+        self._file = (step_dir / f"rank_{self.rank}.jsonl").open("w", encoding="utf-8")
 
     def _write(self, record: dict[str, Any]) -> None:
         if self._closed:
-            raise RuntimeError(f"Token exporter is closed for {self.path}")
+            raise RuntimeError(f"Token exporter is closed for {self.output_dir}")
+        if self._file is None:
+            raise RuntimeError("Token exporter has no active step file")
         self._file.write(json.dumps(record, separators=(",", ":"), allow_nan=False) + "\n")
-
-    @staticmethod
-    def _resolve_path(path: Path | None, output_dir: Path, rank: int) -> Path:
-        if path is None:
-            return output_dir / "token_exports" / f"rank_{rank}.jsonl"
-        if path.is_absolute():
-            return path
-        return output_dir / path
 
 
 def setup_token_exporter(
@@ -105,8 +108,8 @@ def setup_token_exporter(
     if parallel_dims.cp_enabled and parallel_dims.world_mesh["cp"].get_local_rank() != 0:
         return DisabledTokenExporter()
 
-    exporter = TokenExporter(token_export_config, config.output_dir, world.rank)
-    logger.info(f"Writing token exports to {exporter.path}")
+    exporter = TokenExporter(config.output_dir, world.rank)
+    logger.info(f"Writing token exports under {exporter.output_dir}")
     return exporter
 
 


### PR DESCRIPTION
## Summary
- Write trainer token exports under `output_dir/token_exports/step_<step>/rank_<rank>.jsonl` instead of appending all steps into one rank file.
- Remove custom token export paths so exports always live under the trainer output directory.
- Update the config skill docs for the new per-step layout.

## Verification
- `uv run ruff check packages/prime-rl-configs/src/prime_rl/configs/trainer.py skills/configs/SKILL.md src/prime_rl/trainer/rl/token_export.py`
- `uv run ruff format --check packages/prime-rl-configs/src/prime_rl/configs/trainer.py src/prime_rl/trainer/rl/token_export.py`
- `uv run python -m py_compile src/prime_rl/trainer/rl/token_export.py packages/prime-rl-configs/src/prime_rl/configs/trainer.py`
- Inline `uv run python` probe verifying `TokenExporter` writes `token_exports/step_0/rank_3.jsonl` and `token_exports/step_1/rank_3.jsonl`, with no top-level `rank_3.jsonl`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to rollout-debug token export file layout and config surface, with minimal impact on core training logic beyond file I/O and log messages.
> 
> **Overview**
> Trainer token exports are now written **per step** to `output_dir/token_exports/step_<step>/rank_<rank>.jsonl` instead of appending all steps into a single per-rank JSONL file.
> 
> The optional `trainer.experimental.token_export.path` override is removed, and the exporter now rotates/opens a new step file on step transitions (closing the previous handle) while docs are updated to reflect the fixed directory structure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15275d267a6f6cf6d915f812212c462c3e9fd293. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->