### PR TITLE
fix: keep sampling args per token

### DIFF
--- a/src/prime_rl/orchestrator/trajectories.py
+++ b/src/prime_rl/orchestrator/trajectories.py
@@ -281,9 +281,9 @@ def interleave_rollout(
             completion_ids=completion_ids,
             completion_mask=completion_mask,
             completion_logprobs=list(tokens["completion_logprobs"]),
-            temperature=float(temperature),
-            top_k=int(top_k),
-            top_p=float(top_p),
+            completion_temperatures=[float(temperature)] * len(completion_ids),
+            completion_top_ks=[int(top_k)] * len(completion_ids),
+            completion_top_ps=[float(top_p)] * len(completion_ids),
             teacher_logprobs=None,
             advantage=None,
             env_name=output["env_name"],
@@ -300,6 +300,9 @@ def interleave_rollout(
         sample.completion_ids.extend(new_prompt_ids)
         sample.completion_mask.extend([False] * len(new_prompt_ids))
         sample.completion_logprobs.extend([0.0] * len(new_prompt_ids))
+        sample.completion_temperatures.extend([float(temperature)] * len(new_prompt_ids))
+        sample.completion_top_ks.extend([int(top_k)] * len(new_prompt_ids))
+        sample.completion_top_ps.extend([float(top_p)] * len(new_prompt_ids))
 
         # Extend with new completion tokens
         completion_ids = tokens["completion_ids"]
@@ -309,6 +312,9 @@ def interleave_rollout(
         else:
             sample.completion_mask.extend(bool(i) for i in tokens["completion_mask"])
         sample.completion_logprobs.extend(tokens["completion_logprobs"])
+        sample.completion_temperatures.extend([float(temperature)] * len(completion_ids))
+        sample.completion_top_ks.extend([int(top_k)] * len(completion_ids))
+        sample.completion_top_ps.extend([float(top_p)] * len(completion_ids))
 
         if tokens.get("routed_experts") is not None and sample.routed_experts is not None:
             step_routed = tokens["routed_experts"]

--- a/src/prime_rl/trainer/batch.py
+++ b/src/prime_rl/trainer/batch.py
@@ -19,6 +19,13 @@ def prepare_sample(training_example: TrainingSample, seq_len: int) -> MicroBatch
     assert training_example.env_name != "all", "env_name='all' is reserved for aggregate metric keys"
     env_names = [training_example.env_name] * len(input_ids)
 
+    prompt_temp = training_example.completion_temperatures[0] if training_example.completion_temperatures else 1.0
+    prompt_top_k = training_example.completion_top_ks[0] if training_example.completion_top_ks else -1
+    prompt_top_p = training_example.completion_top_ps[0] if training_example.completion_top_ps else 1.0
+    temperatures = [prompt_temp] * len(training_example.prompt_ids) + training_example.completion_temperatures
+    top_ks = [prompt_top_k] * len(training_example.prompt_ids) + training_example.completion_top_ks
+    top_ps = [prompt_top_p] * len(training_example.prompt_ids) + training_example.completion_top_ps
+
     # Teacher logprobs already cover the full sequence (prompt + completion),
     # computed via prefill in the orchestrator when a teacher model is configured
     teacher_logprobs = training_example.teacher_logprobs
@@ -31,6 +38,9 @@ def prepare_sample(training_example: TrainingSample, seq_len: int) -> MicroBatch
         position_ids = position_ids[:seq_len]
         advantages = advantages[:seq_len]
         rewards = rewards[:seq_len]
+        temperatures = temperatures[:seq_len]
+        top_ks = top_ks[:seq_len]
+        top_ps = top_ps[:seq_len]
         if teacher_logprobs is not None:
             teacher_logprobs = teacher_logprobs[:seq_len]
         if routed_experts is not None:
@@ -46,8 +56,11 @@ def prepare_sample(training_example: TrainingSample, seq_len: int) -> MicroBatch
         == len(position_ids)
         == len(inference_logprobs)
         == len(rewards)
+        == len(temperatures)
+        == len(top_ks)
+        == len(top_ps)
     ), (
-        f"input_ids: {len(input_ids)}, advantages: {len(advantages)}, loss_mask: {len(loss_mask)}, position_ids: {len(position_ids)}, inference_logprobs: {len(inference_logprobs)}, rewards: {len(rewards)}"
+        f"input_ids: {len(input_ids)}, advantages: {len(advantages)}, loss_mask: {len(loss_mask)}, position_ids: {len(position_ids)}, inference_logprobs: {len(inference_logprobs)}, rewards: {len(rewards)}, temperatures: {len(temperatures)}, top_ks: {len(top_ks)}, top_ps: {len(top_ps)}"
     )
     if teacher_logprobs is not None:
         assert len(teacher_logprobs) == len(input_ids), f"teacher_logprobs: {len(teacher_logprobs)}"
@@ -70,9 +83,9 @@ def prepare_sample(training_example: TrainingSample, seq_len: int) -> MicroBatch
         position_ids=position_ids,
         inference_logprobs=inference_logprobs,
         teacher_logprobs=teacher_logprobs,
-        temperature=training_example.temperature,
-        top_k=training_example.top_k,
-        top_p=training_example.top_p,
+        temperatures=temperatures,
+        top_ks=top_ks,
+        top_ps=top_ps,
         rewards=rewards,
         routed_experts=routed_experts,
         mm_token_type_ids=mm_token_type_ids,
@@ -119,9 +132,6 @@ def packed_samples_into_micro_bs(
             if (
                 len(bin_content.input_ids) + len(sample.input_ids) <= max_seq_len
                 and bin_content.training_mode == sample.training_mode
-                and bin_content.temperature == sample.temperature
-                and bin_content.top_k == sample.top_k
-                and bin_content.top_p == sample.top_p
             ):
                 existing_len = len(bin_content.input_ids)
                 bin_content.input_ids.extend(sample.input_ids)
@@ -134,6 +144,9 @@ def packed_samples_into_micro_bs(
                 elif bin_content.rewards is not None:
                     bin_content.rewards.extend([float("nan")] * len(sample.input_ids))
                 bin_content.inference_logprobs.extend(sample.inference_logprobs)
+                bin_content.temperatures.extend(sample.temperatures)
+                bin_content.top_ks.extend(sample.top_ks)
+                bin_content.top_ps.extend(sample.top_ps)
                 if sample.teacher_logprobs is not None:
                     if bin_content.teacher_logprobs is None:
                         bin_content.teacher_logprobs = []
@@ -187,6 +200,9 @@ def pad_micro_batch(micro_batch: MicroBatch, pad_to_multiple_of: int) -> MicroBa
     micro_batch.loss_mask.extend([False] * padding_size)
     micro_batch.position_ids.extend(list(range(padding_size)))
     micro_batch.inference_logprobs.extend([0.0] * padding_size)
+    micro_batch.temperatures.extend([1.0] * padding_size)
+    micro_batch.top_ks.extend([-1] * padding_size)
+    micro_batch.top_ps.extend([1.0] * padding_size)
     if micro_batch.teacher_logprobs is not None:
         micro_batch.teacher_logprobs.extend([0.0] * padding_size)
     micro_batch.lora_num_tokens[-1] += (

--- a/src/prime_rl/trainer/models/layers/lm_head.py
+++ b/src/prime_rl/trainer/models/layers/lm_head.py
@@ -45,6 +45,7 @@ class FusedOutputLinear(torch.nn.Linear):
         hidden_states: torch.Tensor,
         labels: torch.Tensor | None = None,
         temperature: Tensor | None = None,
+        top_ks: Tensor | None = None,
     ) -> PrimeLmOutput:
         assert labels is not None, "FusedOutputLinear requires labels for chunked logprob computation"
         assert temperature is not None, "FusedOutputLinear requires per-token temperatures"
@@ -53,9 +54,13 @@ class FusedOutputLinear(torch.nn.Linear):
         hidden_states = hidden_states.reshape(b * s, h).contiguous()
         labels = labels.reshape(b * s).contiguous()
         inv_t = 1.0 / temperature.reshape(b * s).contiguous()  # [N]
+        if top_ks is None:
+            top_ks = torch.full_like(labels, -1)
+        else:
+            top_ks = top_ks.reshape(b * s).contiguous()
 
         logprobs, entropy = _SequenceChunkedLogProbEntropyFn.apply(
-            hidden_states, self.weight, labels, inv_t, self.chunk_size
+            hidden_states, self.weight, labels, inv_t, top_ks, self.chunk_size
         )
 
         logprobs = logprobs.reshape(b, s)
@@ -68,7 +73,11 @@ class VanillaOutputLinear(torch.nn.Linear):
         super().__init__(in_features, out_features, bias=False)
 
     def forward(
-        self, hidden_states: torch.Tensor, labels: torch.Tensor | None = None, temperature: Tensor | None = None
+        self,
+        hidden_states: torch.Tensor,
+        labels: torch.Tensor | None = None,
+        temperature: Tensor | None = None,
+        top_ks: Tensor | None = None,
     ) -> PrimeLmOutput:
         # VanillaOutputLinear just returns logits - temperature scaling is done externally in train.py
         return PrimeLmOutput(logits=super().forward(hidden_states))
@@ -96,6 +105,7 @@ class FusedCrossEntropyOutputLinear(torch.nn.Linear):
         hidden_states: torch.Tensor,
         labels: torch.Tensor | None = None,
         temperature: Tensor | None = None,
+        top_ks: Tensor | None = None,
     ) -> PrimeLmOutput:
         if labels is None:
             return PrimeLmOutput(logits=super().forward(hidden_states))
@@ -126,6 +136,7 @@ class QuackFusedCrossEntropyOutputLinear(torch.nn.Linear):
         hidden_states: torch.Tensor,
         labels: torch.Tensor | None = None,
         temperature: Tensor | None = None,
+        top_ks: Tensor | None = None,
     ) -> PrimeLmOutput:
         if labels is None:
             return PrimeLmOutput(logits=super().forward(hidden_states))
@@ -159,6 +170,16 @@ def _online_logsumexp_and_weighted_update(
     return m_new, s_new, t_new
 
 
+def _online_logsumexp_update(
+    m: torch.Tensor, s: torch.Tensor, chunk_logits: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    chunk_m = torch.amax(chunk_logits, dim=-1)
+    m_new = torch.maximum(m, chunk_m)
+    exp_old = torch.exp(m - m_new)
+    chunk_exp = torch.exp(chunk_logits - m_new.unsqueeze(-1))
+    return m_new, s * exp_old + chunk_exp.sum(dim=-1)
+
+
 class _SequenceChunkedLogProbEntropyFn(torch.autograd.Function):
     @staticmethod
     def forward(  # type: ignore[override]
@@ -167,6 +188,7 @@ class _SequenceChunkedLogProbEntropyFn(torch.autograd.Function):
         weight: torch.Tensor,  # [V, H]
         labels: torch.Tensor,  # [N]
         inv_temperature: torch.Tensor,  # [N]
+        top_ks: torch.Tensor,  # [N]
         chunk_size: int,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """
@@ -176,9 +198,11 @@ class _SequenceChunkedLogProbEntropyFn(torch.autograd.Function):
         assert weight.dim() == 2, f"expected weight [V,H], got {tuple(weight.shape)}"
         assert labels.dim() == 1, f"expected labels [N], got {tuple(labels.shape)}"
         assert inv_temperature.dim() == 1, f"expected inv_temperature [N], got {tuple(inv_temperature.shape)}"
+        assert top_ks.dim() == 1, f"expected top_ks [N], got {tuple(top_ks.shape)}"
         assert hidden.shape[0] == labels.shape[0], "hidden/labels N mismatch"
         assert hidden.shape[1] == weight.shape[1], "hidden/weight H mismatch"
         assert hidden.shape[0] == inv_temperature.shape[0], "hidden/inv_temperature N mismatch"
+        assert hidden.shape[0] == top_ks.shape[0], "hidden/top_ks N mismatch"
         assert chunk_size > 0
 
         device = hidden.device
@@ -188,18 +212,27 @@ class _SequenceChunkedLogProbEntropyFn(torch.autograd.Function):
         logprobs = torch.empty((n,), device=device, dtype=torch.float32)
         entropy = torch.empty((n,), device=device, dtype=torch.float32)
         logz = torch.empty((n,), device=device, dtype=torch.float32)
+        top_k_thresholds = torch.full((n,), float("-inf"), device=device, dtype=torch.float32)
 
         for start in range(0, n, chunk_size):
             end = min(start + chunk_size, n)
             hidden_chunk = hidden[start:end]
             labels_chunk = labels[start:end]
             inv_t_chunk = inv_temperature[start:end].unsqueeze(-1)
+            top_ks_chunk = top_ks[start:end]
             token_count = end - start
+            top_k_mask = (top_ks_chunk > 0) & (top_ks_chunk < vocab)
+            max_top_k = int(top_ks_chunk[top_k_mask].max().item()) if torch.any(top_k_mask) else 0
 
             m = torch.full((token_count,), float("-inf"), device=device, dtype=torch.float32)
             s = torch.zeros((token_count,), device=device, dtype=torch.float32)
             t = torch.zeros((token_count,), device=device, dtype=torch.float32)
             target_logits = torch.zeros((token_count,), device=device, dtype=torch.float32)
+            top_values = (
+                torch.full((token_count, max_top_k), float("-inf"), device=device, dtype=torch.float32)
+                if max_top_k > 0
+                else None
+            )
 
             for vocab_start in range(0, vocab, vocab_chunk_size):
                 vocab_end = min(vocab_start + vocab_chunk_size, vocab)
@@ -208,6 +241,8 @@ class _SequenceChunkedLogProbEntropyFn(torch.autograd.Function):
                 scaled_logits = logits_chunk.to(torch.float32) * inv_t_chunk
 
                 m, s, t = _online_logsumexp_and_weighted_update(m, s, t, scaled_logits)
+                if top_values is not None:
+                    top_values = torch.cat((top_values, scaled_logits), dim=-1).topk(max_top_k, dim=-1).values
 
                 mask = (labels_chunk >= vocab_start) & (labels_chunk < vocab_end)
                 if torch.any(mask):
@@ -215,11 +250,35 @@ class _SequenceChunkedLogProbEntropyFn(torch.autograd.Function):
                     target_logits[mask] = scaled_logits[mask, idx]
 
             logz_chunk = m + torch.log(s)
-            logz[start:end] = logz_chunk
-            logprobs[start:end] = target_logits - logz_chunk
+            logprob_logz_chunk = logz_chunk
+            if top_values is not None:
+                thresholds = torch.full((token_count,), float("-inf"), device=device, dtype=torch.float32)
+                thresholds[top_k_mask] = (
+                    top_values[top_k_mask].gather(-1, (top_ks_chunk[top_k_mask] - 1).unsqueeze(-1)).squeeze(-1)
+                )
+                top_k_thresholds[start:end] = thresholds
+
+                topk_m = torch.full((token_count,), float("-inf"), device=device, dtype=torch.float32)
+                topk_s = torch.zeros((token_count,), device=device, dtype=torch.float32)
+                for vocab_start in range(0, vocab, vocab_chunk_size):
+                    vocab_end = min(vocab_start + vocab_chunk_size, vocab)
+                    weight_chunk = weight[vocab_start:vocab_end]
+                    logits_chunk = hidden_chunk @ weight_chunk.t()
+                    scaled_logits = logits_chunk.to(torch.float32) * inv_t_chunk
+                    support = scaled_logits >= thresholds.unsqueeze(-1)
+                    label_mask = (labels_chunk >= vocab_start) & (labels_chunk < vocab_end)
+                    if torch.any(label_mask):
+                        idx = (labels_chunk[label_mask] - vocab_start).to(torch.long)
+                        support[label_mask, idx] = True
+                    masked_logits = scaled_logits.masked_fill(~support, float("-inf"))
+                    topk_m, topk_s = _online_logsumexp_update(topk_m, topk_s, masked_logits)
+                logprob_logz_chunk = topk_m + torch.log(topk_s)
+
+            logz[start:end] = logprob_logz_chunk
+            logprobs[start:end] = target_logits - logprob_logz_chunk
             entropy[start:end] = logz_chunk - (t / s)
 
-        ctx.save_for_backward(hidden, weight, labels, inv_temperature, logz)
+        ctx.save_for_backward(hidden, weight, labels, inv_temperature, logz, top_k_thresholds)
         ctx.chunk_size = chunk_size
 
         return logprobs, entropy
@@ -230,7 +289,7 @@ class _SequenceChunkedLogProbEntropyFn(torch.autograd.Function):
             "Backward through entropy is not implemented in FusedOutputLinear"
         )
 
-        hidden, weight, labels, inv_temperature, logz = ctx.saved_tensors
+        hidden, weight, labels, inv_temperature, logz, top_k_thresholds = ctx.saved_tensors
         chunk_size: int = ctx.chunk_size
 
         n, _ = hidden.shape
@@ -247,25 +306,29 @@ class _SequenceChunkedLogProbEntropyFn(torch.autograd.Function):
             grad_chunk = grad_logprobs[start:end].to(torch.float32)
             inv_t_chunk = inv_temperature[start:end].unsqueeze(-1)
             logz_chunk = logz[start:end]
+            thresholds = top_k_thresholds[start:end]
 
             for vocab_start in range(0, vocab, vocab_chunk_size):
                 vocab_end = min(vocab_start + vocab_chunk_size, vocab)
                 weight_chunk = weight[vocab_start:vocab_end]
                 logits_chunk = hidden_chunk @ weight_chunk.t()
                 scaled_logits = logits_chunk.to(torch.float32) * inv_t_chunk
-                probs = torch.exp(scaled_logits - logz_chunk.unsqueeze(-1))
-
-                grad_logits = (-grad_chunk).unsqueeze(-1) * probs
+                support = scaled_logits >= thresholds.unsqueeze(-1)
                 mask = (labels_chunk >= vocab_start) & (labels_chunk < vocab_end)
                 if torch.any(mask):
                     idx = (labels_chunk[mask] - vocab_start).to(torch.long)
+                    support[mask, idx] = True
+                probs = torch.exp(scaled_logits - logz_chunk.unsqueeze(-1)).masked_fill(~support, 0.0)
+
+                grad_logits = (-grad_chunk).unsqueeze(-1) * probs
+                if torch.any(mask):
                     grad_logits[mask, idx] += grad_chunk[mask]
                 grad_logits = grad_logits * inv_t_chunk
 
                 grad_hidden[start:end].add_(grad_logits.to(hidden.dtype) @ weight_chunk)
                 grad_weight[vocab_start:vocab_end].add_(grad_logits.to(weight.dtype).t() @ hidden_chunk)
 
-        return grad_hidden, grad_weight, None, None, None
+        return grad_hidden, grad_weight, None, None, None, None
 
 
 def inject_prime_lm_head(
@@ -352,6 +415,7 @@ def _patch_model_forward(model: nn.Module) -> None:
         labels: torch.Tensor | None = None,
         logits_to_keep: int = 0,
         temperature: torch.Tensor | None = None,
+        top_ks: torch.Tensor | None = None,
         **kwargs: object,
     ) -> PrimeLmOutput:
         # For VLM with images, don't create position_ids - let model compute MRoPE internally
@@ -377,6 +441,7 @@ def _patch_model_forward(model: nn.Module) -> None:
             hidden_states[:, slice_indices, :],
             labels[:, slice_indices] if labels is not None else None,
             temperature=temperature[:, slice_indices] if temperature is not None else None,
+            top_ks=top_ks[:, slice_indices] if top_ks is not None else None,
         )
 
     # Bind the new forward to the model

--- a/src/prime_rl/trainer/models/layers/lm_head_gemma.py
+++ b/src/prime_rl/trainer/models/layers/lm_head_gemma.py
@@ -7,6 +7,7 @@ from torch import Tensor
 from prime_rl.trainer.models.layers.lm_head import (
     PrimeLmOutput,
     _online_logsumexp_and_weighted_update,
+    _online_logsumexp_update,
     _patch_model_forward,
 )
 from prime_rl.utils.logger import get_logger
@@ -23,6 +24,7 @@ class GemmaFusedOutputLinear(torch.nn.Linear):
         hidden_states: torch.Tensor,
         labels: torch.Tensor | None = None,
         temperature: Tensor | None = None,
+        top_ks: Tensor | None = None,
     ) -> PrimeLmOutput:
         assert labels is not None, "GemmaFusedOutputLinear requires labels for chunked logprob computation"
         assert temperature is not None, "GemmaFusedOutputLinear requires per-token temperatures"
@@ -31,9 +33,13 @@ class GemmaFusedOutputLinear(torch.nn.Linear):
         hidden_states = hidden_states.reshape(b * s, h).contiguous()
         labels = labels.reshape(b * s).contiguous()
         inv_t = 1.0 / temperature.reshape(b * s).contiguous()  # [N]
+        if top_ks is None:
+            top_ks = torch.full_like(labels, -1)
+        else:
+            top_ks = top_ks.reshape(b * s).contiguous()
 
         logprobs, entropy = _GemmaChunkedLogProbEntropyFn.apply(
-            hidden_states, self.weight, labels, inv_t, self.chunk_size, self.softcap
+            hidden_states, self.weight, labels, inv_t, top_ks, self.chunk_size, self.softcap
         )
 
         logprobs = logprobs.reshape(b, s)
@@ -47,7 +53,11 @@ class GemmaVanillaOutputLinear(torch.nn.Linear):
         self.softcap = softcap
 
     def forward(
-        self, hidden_states: torch.Tensor, labels: torch.Tensor | None = None, temperature: Tensor | None = None
+        self,
+        hidden_states: torch.Tensor,
+        labels: torch.Tensor | None = None,
+        temperature: Tensor | None = None,
+        top_ks: Tensor | None = None,
     ) -> PrimeLmOutput:
         logits = super().forward(hidden_states)
         logits = self.softcap * torch.tanh(logits / self.softcap)
@@ -62,6 +72,7 @@ class _GemmaChunkedLogProbEntropyFn(torch.autograd.Function):
         weight: torch.Tensor,  # [V, H]
         labels: torch.Tensor,  # [N]
         inv_temperature: torch.Tensor,  # [N]
+        top_ks: torch.Tensor,  # [N]
         chunk_size: int,
         softcap: float,
     ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -72,9 +83,11 @@ class _GemmaChunkedLogProbEntropyFn(torch.autograd.Function):
         assert weight.dim() == 2, f"expected weight [V,H], got {tuple(weight.shape)}"
         assert labels.dim() == 1, f"expected labels [N], got {tuple(labels.shape)}"
         assert inv_temperature.dim() == 1, f"expected inv_temperature [N], got {tuple(inv_temperature.shape)}"
+        assert top_ks.dim() == 1, f"expected top_ks [N], got {tuple(top_ks.shape)}"
         assert hidden.shape[0] == labels.shape[0], "hidden/labels N mismatch"
         assert hidden.shape[1] == weight.shape[1], "hidden/weight H mismatch"
         assert hidden.shape[0] == inv_temperature.shape[0], "hidden/inv_temperature N mismatch"
+        assert hidden.shape[0] == top_ks.shape[0], "hidden/top_ks N mismatch"
         assert chunk_size > 0
 
         device = hidden.device
@@ -84,18 +97,27 @@ class _GemmaChunkedLogProbEntropyFn(torch.autograd.Function):
         logprobs = torch.empty((n,), device=device, dtype=torch.float32)
         entropy = torch.empty((n,), device=device, dtype=torch.float32)
         logz = torch.empty((n,), device=device, dtype=torch.float32)
+        top_k_thresholds = torch.full((n,), float("-inf"), device=device, dtype=torch.float32)
 
         for start in range(0, n, chunk_size):
             end = min(start + chunk_size, n)
             hidden_chunk = hidden[start:end]
             labels_chunk = labels[start:end]
             inv_t_chunk = inv_temperature[start:end].unsqueeze(-1)
+            top_ks_chunk = top_ks[start:end]
             token_count = end - start
+            top_k_mask = (top_ks_chunk > 0) & (top_ks_chunk < vocab)
+            max_top_k = int(top_ks_chunk[top_k_mask].max().item()) if torch.any(top_k_mask) else 0
 
             m = torch.full((token_count,), float("-inf"), device=device, dtype=torch.float32)
             s = torch.zeros((token_count,), device=device, dtype=torch.float32)
             t = torch.zeros((token_count,), device=device, dtype=torch.float32)
             target_logits = torch.zeros((token_count,), device=device, dtype=torch.float32)
+            top_values = (
+                torch.full((token_count, max_top_k), float("-inf"), device=device, dtype=torch.float32)
+                if max_top_k > 0
+                else None
+            )
 
             for vocab_start in range(0, vocab, vocab_chunk_size):
                 vocab_end = min(vocab_start + vocab_chunk_size, vocab)
@@ -106,6 +128,8 @@ class _GemmaChunkedLogProbEntropyFn(torch.autograd.Function):
                 scaled_logits = scaled_logits * inv_t_chunk
 
                 m, s, t = _online_logsumexp_and_weighted_update(m, s, t, scaled_logits)
+                if top_values is not None:
+                    top_values = torch.cat((top_values, scaled_logits), dim=-1).topk(max_top_k, dim=-1).values
 
                 mask = (labels_chunk >= vocab_start) & (labels_chunk < vocab_end)
                 if torch.any(mask):
@@ -113,11 +137,37 @@ class _GemmaChunkedLogProbEntropyFn(torch.autograd.Function):
                     target_logits[mask] = scaled_logits[mask, idx]
 
             logz_chunk = m + torch.log(s)
-            logz[start:end] = logz_chunk
-            logprobs[start:end] = target_logits - logz_chunk
+            logprob_logz_chunk = logz_chunk
+            if top_values is not None:
+                thresholds = torch.full((token_count,), float("-inf"), device=device, dtype=torch.float32)
+                thresholds[top_k_mask] = (
+                    top_values[top_k_mask].gather(-1, (top_ks_chunk[top_k_mask] - 1).unsqueeze(-1)).squeeze(-1)
+                )
+                top_k_thresholds[start:end] = thresholds
+
+                topk_m = torch.full((token_count,), float("-inf"), device=device, dtype=torch.float32)
+                topk_s = torch.zeros((token_count,), device=device, dtype=torch.float32)
+                for vocab_start in range(0, vocab, vocab_chunk_size):
+                    vocab_end = min(vocab_start + vocab_chunk_size, vocab)
+                    weight_chunk = weight[vocab_start:vocab_end]
+                    logits_chunk = hidden_chunk @ weight_chunk.t()
+                    scaled_logits = logits_chunk.to(torch.float32)
+                    scaled_logits = softcap * torch.tanh(scaled_logits / softcap)
+                    scaled_logits = scaled_logits * inv_t_chunk
+                    support = scaled_logits >= thresholds.unsqueeze(-1)
+                    label_mask = (labels_chunk >= vocab_start) & (labels_chunk < vocab_end)
+                    if torch.any(label_mask):
+                        idx = (labels_chunk[label_mask] - vocab_start).to(torch.long)
+                        support[label_mask, idx] = True
+                    masked_logits = scaled_logits.masked_fill(~support, float("-inf"))
+                    topk_m, topk_s = _online_logsumexp_update(topk_m, topk_s, masked_logits)
+                logprob_logz_chunk = topk_m + torch.log(topk_s)
+
+            logz[start:end] = logprob_logz_chunk
+            logprobs[start:end] = target_logits - logprob_logz_chunk
             entropy[start:end] = logz_chunk - (t / s)
 
-        ctx.save_for_backward(hidden, weight, labels, inv_temperature, logz)
+        ctx.save_for_backward(hidden, weight, labels, inv_temperature, logz, top_k_thresholds)
         ctx.chunk_size = chunk_size
         ctx.softcap = softcap
 
@@ -129,7 +179,7 @@ class _GemmaChunkedLogProbEntropyFn(torch.autograd.Function):
             "Backward through entropy is not implemented in GemmaFusedOutputLinear"
         )
 
-        hidden, weight, labels, inv_temperature, logz = ctx.saved_tensors
+        hidden, weight, labels, inv_temperature, logz, top_k_thresholds = ctx.saved_tensors
         chunk_size: int = ctx.chunk_size
         softcap: float = ctx.softcap
 
@@ -147,6 +197,7 @@ class _GemmaChunkedLogProbEntropyFn(torch.autograd.Function):
             grad_chunk = grad_logprobs[start:end].to(torch.float32)
             inv_t_chunk = inv_temperature[start:end].unsqueeze(-1)
             logz_chunk = logz[start:end]
+            thresholds = top_k_thresholds[start:end]
 
             for vocab_start in range(0, vocab, vocab_chunk_size):
                 vocab_end = min(vocab_start + vocab_chunk_size, vocab)
@@ -156,12 +207,15 @@ class _GemmaChunkedLogProbEntropyFn(torch.autograd.Function):
                 tanh_val = torch.tanh(logits_f / softcap)
                 scaled_logits = softcap * tanh_val
                 scaled_logits = scaled_logits * inv_t_chunk
-                probs = torch.exp(scaled_logits - logz_chunk.unsqueeze(-1))
-
-                grad_logits = (-grad_chunk).unsqueeze(-1) * probs
+                support = scaled_logits >= thresholds.unsqueeze(-1)
                 mask = (labels_chunk >= vocab_start) & (labels_chunk < vocab_end)
                 if torch.any(mask):
                     idx = (labels_chunk[mask] - vocab_start).to(torch.long)
+                    support[mask, idx] = True
+                probs = torch.exp(scaled_logits - logz_chunk.unsqueeze(-1)).masked_fill(~support, 0.0)
+
+                grad_logits = (-grad_chunk).unsqueeze(-1) * probs
+                if torch.any(mask):
                     grad_logits[mask, idx] += grad_chunk[mask]
                 grad_logits = grad_logits * inv_t_chunk
                 grad_logits = grad_logits * (1 - tanh_val**2)
@@ -169,7 +223,7 @@ class _GemmaChunkedLogProbEntropyFn(torch.autograd.Function):
                 grad_hidden[start:end].add_(grad_logits.to(hidden.dtype) @ weight_chunk)
                 grad_weight[vocab_start:vocab_end].add_(grad_logits.to(weight.dtype).t() @ hidden_chunk)
 
-        return grad_hidden, grad_weight, None, None, None, None
+        return grad_hidden, grad_weight, None, None, None, None, None
 
 
 def inject_gemma_lm_head(model: nn.Module, chunk_size: int | None, softcap: float) -> None:

--- a/src/prime_rl/trainer/rl/data.py
+++ b/src/prime_rl/trainer/rl/data.py
@@ -24,9 +24,9 @@ class TensorMicroBatch(TypedDict):
     inference_logprobs: Float[Tensor, "batch seq"]
     teacher_logprobs: Float[Tensor, "batch seq"] | None
     loss_mask: Bool[Tensor, "batch seq"]
-    temperature: float
-    top_k: int  # -1 disables truncation
-    top_p: float  # 1.0 disables truncation
+    temperatures: Float[Tensor, "batch seq"]
+    top_ks: Int[Tensor, "batch seq"]  # -1 disables truncation
+    top_ps: Float[Tensor, "batch seq"]  # 1.0 disables truncation
     env_names: list[str]
 
     # Batch level
@@ -114,9 +114,9 @@ class FakeDataLoader:
             "rewards": None,
             "inference_logprobs": inference_logprobs.unsqueeze(0),
             "teacher_logprobs": None,
-            "temperature": 1.0,
-            "top_k": -1,
-            "top_p": 1.0,
+            "temperatures": torch.ones(input_ids.shape[0]).unsqueeze(0),
+            "top_ks": torch.full((input_ids.shape[0],), -1, dtype=torch.long).unsqueeze(0),
+            "top_ps": torch.ones(input_ids.shape[0]).unsqueeze(0),
             "env_names": ["fake"] * input_ids.shape[0],
             "loss_mask": loss_mask.unsqueeze(0),
             "lora_num_tokens": lora_num_tokens,
@@ -144,9 +144,9 @@ class FakeDataLoader:
             "rewards": None,
             "inference_logprobs": torch.randn(self.seq_len, generator=generator).unsqueeze(0),
             "teacher_logprobs": None,
-            "temperature": 1.0,
-            "top_k": -1,
-            "top_p": 1.0,
+            "temperatures": torch.ones(self.seq_len).unsqueeze(0),
+            "top_ks": torch.full((self.seq_len,), -1, dtype=torch.long).unsqueeze(0),
+            "top_ps": torch.ones(self.seq_len).unsqueeze(0),
             "env_names": ["fake"] * self.seq_len,
             "loss_mask": torch.ones(self.seq_len, dtype=torch.bool).unsqueeze(0),
             "lora_num_tokens": lora_num_tokens,
@@ -228,9 +228,9 @@ class DataLoader:
             if micro_batch.teacher_logprobs is not None
             else None,
             loss_mask=torch.tensor(micro_batch.loss_mask, dtype=torch.bool).unsqueeze(0),
-            temperature=micro_batch.temperature,
-            top_k=micro_batch.top_k,
-            top_p=micro_batch.top_p,
+            temperatures=torch.tensor(micro_batch.temperatures, dtype=torch.float).unsqueeze(0),
+            top_ks=torch.tensor(micro_batch.top_ks, dtype=torch.long).unsqueeze(0),
+            top_ps=torch.tensor(micro_batch.top_ps, dtype=torch.float).unsqueeze(0),
             env_names=micro_batch.env_names,
             lora_num_tokens=torch.tensor(micro_batch.lora_num_tokens, dtype=torch.int32),
             mm_kwargs=mm_kwargs,

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -49,13 +49,12 @@ def selective_log_softmax(
 
 def apply_top_k_top_p(
     logits: Tensor,
-    top_k: int | None,
-    top_p: float | None,
+    top_ks: Tensor | None,
+    top_ps: Tensor | None,
     labels: Tensor | None = None,
 ) -> Tensor:
     """Mirror vLLM's top-k / top-p truncation so the trainer logits sum over
-    the same support as the inference-time sample. Bit-exact match against
-    vLLM's ``apply_top_k_top_p_pytorch``. Scalar k / p; ``k <= 0`` and
+    the same support as the inference-time sample. Per-token ``k <= 0`` and
     ``p >= 1.0`` are no-ops.
 
     ``labels`` is the safety guard: restore the label's original logit after
@@ -65,32 +64,48 @@ def apply_top_k_top_p(
     applied uniformly.
     """
     vocab_size = logits.shape[-1]
-    do_top_k = top_k is not None and 0 < top_k < vocab_size
-    do_top_p = top_p is not None and top_p < 1.0
+    do_top_k = top_ks is not None and bool(((top_ks > 0) & (top_ks < vocab_size)).any().item())
+    do_top_p = top_ps is not None and bool((top_ps < 1.0).any().item())
     if not do_top_k and not do_top_p:
         return logits
 
-    label_logits = logits.gather(-1, labels.unsqueeze(-1)) if labels is not None else None
+    original_shape = logits.shape
+    flat_logits = logits.reshape(-1, vocab_size)
+    flat_top_ks = top_ks.reshape(-1) if top_ks is not None else None
+    flat_top_ps = top_ps.reshape(-1) if top_ps is not None else None
+    flat_labels = labels.reshape(-1) if labels is not None else None
+    label_logits = flat_logits.gather(-1, flat_labels.unsqueeze(-1)) if flat_labels is not None else None
 
-    if do_top_k:
-        top_values, _ = logits.topk(top_k, dim=-1)
-        threshold = top_values[..., -1:]
-        logits = logits.masked_fill(logits < threshold, float("-inf"))
+    if do_top_k and flat_top_ks is not None:
+        flat_logits = flat_logits.clone()
+        valid_ks = flat_top_ks[(flat_top_ks > 0) & (flat_top_ks < vocab_size)].unique()
+        for top_k in valid_ks.tolist():
+            row_mask = flat_top_ks == top_k
+            row_logits = flat_logits[row_mask]
+            top_values, _ = row_logits.topk(top_k, dim=-1)
+            threshold = top_values[..., -1:]
+            flat_logits[row_mask] = row_logits.masked_fill(row_logits < threshold, float("-inf"))
 
-    if do_top_p:
+    if do_top_p and flat_top_ps is not None:
+        row_mask = flat_top_ps < 1.0
+        row_logits = flat_logits[row_mask]
+        row_top_ps = flat_top_ps[row_mask].unsqueeze(-1)
         # Sort ascending so the low-probability tail is at the front (mirrors vLLM).
-        sorted_logits, sorted_idx = logits.sort(dim=-1, descending=False)
+        sorted_logits, sorted_idx = row_logits.sort(dim=-1, descending=False)
         sorted_probs = sorted_logits.softmax(dim=-1)
         cumprobs = sorted_probs.cumsum(dim=-1)
-        top_p_mask = cumprobs <= (1.0 - top_p)
+        top_p_mask = cumprobs <= (1.0 - row_top_ps)
         top_p_mask[..., -1] = False  # always keep the top token
         sorted_logits = sorted_logits.masked_fill(top_p_mask, float("-inf"))
-        logits = torch.empty_like(logits).scatter_(-1, sorted_idx, sorted_logits)
+        updated_logits = torch.empty_like(row_logits).scatter_(-1, sorted_idx, sorted_logits)
+        if not do_top_k:
+            flat_logits = flat_logits.clone()
+        flat_logits[row_mask] = updated_logits
 
     if label_logits is not None:
-        logits = logits.scatter(-1, labels.unsqueeze(-1), label_logits)
+        flat_logits = flat_logits.scatter(-1, flat_labels.unsqueeze(-1), label_logits)
 
-    return logits
+    return flat_logits.reshape(original_shape)
 
 
 @jaxtyped(typechecker=typechecker)

--- a/src/prime_rl/trainer/rl/packer.py
+++ b/src/prime_rl/trainer/rl/packer.py
@@ -164,6 +164,21 @@ class MultiPacker(BasePacker):
                 False,
                 f"Run wrote a sample with completion logprobs length != completion ids length ({len(sample.completion_logprobs)} != {len(sample.completion_ids)})",
             )
+        if len(sample.completion_temperatures) != len(sample.completion_ids):
+            return (
+                False,
+                f"Run wrote a sample with completion temperatures length != completion ids length ({len(sample.completion_temperatures)} != {len(sample.completion_ids)})",
+            )
+        if len(sample.completion_top_ks) != len(sample.completion_ids):
+            return (
+                False,
+                f"Run wrote a sample with completion top_ks length != completion ids length ({len(sample.completion_top_ks)} != {len(sample.completion_ids)})",
+            )
+        if len(sample.completion_top_ps) != len(sample.completion_ids):
+            return (
+                False,
+                f"Run wrote a sample with completion top_ps length != completion ids length ({len(sample.completion_top_ps)} != {len(sample.completion_ids)})",
+            )
         if sample_length == 0:
             return False, "Run wrote a sample with no tokens"
         if sample_length > self.seq_len:

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -421,12 +421,14 @@ def train(config: TrainerConfig):
                     )
                 set_lora_num_tokens(lora_num_tokens)
 
-            temperature = micro_batch["temperature"]
-            top_k = micro_batch["top_k"]
-            top_p = micro_batch["top_p"]
-            truncate_logits = (top_k > 0) or (top_p < 1.0)
-            # Fused LM head wants a per-token tensor; CP-sharded input_ids gives the right shape.
-            temperatures = torch.full(input_ids.shape, temperature, dtype=torch.float32, device="cuda")
+            temperatures = micro_batch["temperatures"].to("cuda")
+            top_ks = micro_batch["top_ks"].to("cuda")
+            top_ps = micro_batch["top_ps"].to("cuda")
+
+            if cp_enabled:
+                temperatures = shard_for_cp(temperatures, cp_rank=cp_rank, cp_world_size=cp_size)
+                top_ks = shard_for_cp(top_ks, cp_rank=cp_rank, cp_world_size=cp_size)
+                top_ps = shard_for_cp(top_ps, cp_rank=cp_rank, cp_world_size=cp_size)
 
             # Forward pass with per-token temperatures
             with maybe_record_function("forward"), maybe_activation_offloading(config.model.ac_offloading):
@@ -436,6 +438,7 @@ def train(config: TrainerConfig):
                     forward_position_ids,
                     labels=labels,
                     temperature=temperatures,
+                    top_ks=top_ks,
                     mm_kwargs=mm_kwargs,
                     mm_token_type_ids=mm_token_type_ids,
                     routed_experts=routed_experts,
@@ -449,15 +452,13 @@ def train(config: TrainerConfig):
                 scaled_logits = logits / temperatures.unsqueeze(-1)
                 # Entropy on the full distribution so it stays comparable across truncated / not.
                 out["entropy"] = compute_entropy(scaled_logits)
-                scaled_logits = apply_top_k_top_p(scaled_logits, top_k, top_p, labels=labels)
+                scaled_logits = apply_top_k_top_p(scaled_logits, top_ks, top_ps, labels=labels)
                 out["logprobs"] = selective_log_softmax(scaled_logits, labels)
             else:
-                # FusedOutputLinear streams over vocab chunks and can't find a global top-k threshold.
-                if truncate_logits:
+                if bool((top_ps < 1.0).any().item()):
                     raise ValueError(
-                        "top_k / top_p truncation requires the vanilla LM head - set "
-                        "model.fused_lm_head_token_chunk_size = 'disabled' or run with top_k=-1 "
-                        "and top_p=1.0."
+                        "top_p truncation requires the vanilla LM head - set "
+                        "model.fused_lm_head_token_chunk_size = 'disabled' or run with top_p=1.0."
                     )
 
             if cp_enabled:

--- a/src/prime_rl/transport/types.py
+++ b/src/prime_rl/transport/types.py
@@ -23,11 +23,10 @@ class TrainingSample(msgspec.Struct, array_like=True, gc=False, omit_defaults=Tr
     completion_ids: list[int]
     completion_mask: list[bool]
     completion_logprobs: list[float]
-    temperature: float
+    completion_temperatures: list[float]
+    completion_top_ks: list[int]
+    completion_top_ps: list[float]
     env_name: str
-    # ``top_k = -1`` and ``top_p = 1.0`` disable truncation.
-    top_k: int = -1
-    top_p: float = 1.0
     teacher_logprobs: list[float] | None = None
     advantage: float | None = None
     reward: float | None = None
@@ -69,13 +68,10 @@ class MicroBatch(msgspec.Struct, array_like=True, gc=False, omit_defaults=True):
     advantages: list[float]
     inference_logprobs: list[float]
     position_ids: list[int]
-    # Scalar sampling args shared by every sample in the micro batch (the
-    # packer enforces uniformity). The trainer replays the same truncation
-    # when computing logprobs so the importance ratio stays unbiased.
-    temperature: float
+    temperatures: list[float]
+    top_ks: list[int]
+    top_ps: list[float]
     env_names: list[str]
-    top_k: int = -1
-    top_p: float = 1.0
     teacher_logprobs: list[float] | None = None
     lora_num_tokens: list[int] | None = None
     routed_experts: list[list[list[int]]] | None = None

--- a/tests/unit/orchestrator/test_batch.py
+++ b/tests/unit/orchestrator/test_batch.py
@@ -17,7 +17,9 @@ def make_training_example():
             completion_ids=[3, 4],
             completion_mask=[True, True],
             completion_logprobs=[-0.1, -0.2],
-            temperature=temperature,
+            completion_temperatures=[temperature, temperature],
+            completion_top_ks=[-1, -1],
+            completion_top_ps=[1.0, 1.0],
             teacher_logprobs=[0.0, 0.0, 0.0, 0.0],
             advantage=1.0,
             env_name=env_name,
@@ -35,7 +37,9 @@ def test_training_sample_requires_env_name():
             completion_ids=[3, 4],
             completion_mask=[True, True],
             completion_logprobs=[-0.1, -0.2],
-            temperature=1.0,
+            completion_temperatures=[1.0, 1.0],
+            completion_top_ks=[-1, -1],
+            completion_top_ps=[1.0, 1.0],
             advantage=1.0,
         )
 
@@ -74,28 +78,6 @@ def test_prepare_batch_balances_micro_batches_across_workers(
         assert sum(1 for loss_mask in batch.loss_mask if loss_mask) == 0
 
 
-def test_prepare_batch_does_not_pack_different_temperatures(make_training_example):
-    """Temperature is a scalar per micro batch, so samples with different
-    temperatures land in separate micro batches even when they would fit."""
-    example1 = make_training_example(temperature=0.7, env_name="env-a")
-    example2 = make_training_example(temperature=1.1, env_name="env-b")
-
-    batches_per_gpu = prepare_batch(
-        rollouts=[example1, example2],
-        seq_len=16,
-        num_train_workers=1,
-        idxs=[0, 0],
-        num_loras=1,
-    )
-
-    flat_batches = [batch for worker_batches in batches_per_gpu for batch in worker_batches]
-    assert len(flat_batches) == 2
-    assert {b.temperature for b in flat_batches} == {0.7, 1.1}
-    # Each micro batch holds exactly one sample (4 tokens: 2 prompt + 2 completion)
-    for batch in flat_batches:
-        assert len(batch.input_ids) == 4
-
-
 def test_prepare_sample_propagates_training_mode(make_training_example):
     example = make_training_example(training_mode="sft")
 
@@ -131,7 +113,9 @@ def test_prepare_sample_with_routed_experts():
         completion_ids=[3, 4],
         completion_mask=[True, True],
         completion_logprobs=[-0.1, -0.2],
-        temperature=1.0,
+        completion_temperatures=[1.0, 1.0],
+        completion_top_ks=[-1, -1],
+        completion_top_ps=[1.0, 1.0],
         advantage=1.0,
         env_name="test-env",
         routed_experts=routed_experts,
@@ -152,7 +136,9 @@ def test_prepare_sample_truncates_routed_experts():
         completion_ids=[3, 4],
         completion_mask=[True, True],
         completion_logprobs=[-0.1, -0.2],
-        temperature=1.0,
+        completion_temperatures=[1.0, 1.0],
+        completion_top_ks=[-1, -1],
+        completion_top_ps=[1.0, 1.0],
         advantage=1.0,
         env_name="test-env",
         routed_experts=routed_experts,
@@ -173,7 +159,9 @@ def test_prepare_sample_none_routed_experts():
         completion_ids=[3, 4],
         completion_mask=[True, True],
         completion_logprobs=[-0.1, -0.2],
-        temperature=1.0,
+        completion_temperatures=[1.0, 1.0],
+        completion_top_ks=[-1, -1],
+        completion_top_ps=[1.0, 1.0],
         advantage=1.0,
         env_name="test-env",
     )

--- a/tests/unit/orchestrator/test_teacher_logprobs.py
+++ b/tests/unit/orchestrator/test_teacher_logprobs.py
@@ -49,7 +49,9 @@ def test_compute_teacher_logprobs_uses_inference_generate(monkeypatch):
             completion_ids=[2, 3],
             completion_mask=[True, True],
             completion_logprobs=[-0.1, -0.2],
-            temperature=1.0,
+            completion_temperatures=[1.0, 1.0],
+            completion_top_ks=[-1, -1],
+            completion_top_ps=[1.0, 1.0],
             env_name="test-env",
         )
 

--- a/tests/unit/orchestrator/test_trajectories.py
+++ b/tests/unit/orchestrator/test_trajectories.py
@@ -332,7 +332,7 @@ def test_branching_equivalent_multi_step_trajectory(multi_step_trajectory_extens
     assert rollout.completion_ids == [3, 4]
     assert rollout.completion_mask == [True, True]
     assert rollout.completion_logprobs == [-0.1, -0.2]
-    assert rollout.temperature == 1.0
+    assert rollout.completion_temperatures == [1.0, 1.0]
 
     # second step
     rollout = rollouts[1]
@@ -341,7 +341,7 @@ def test_branching_equivalent_multi_step_trajectory(multi_step_trajectory_extens
     assert rollout.completion_ids == [7, 8]
     assert rollout.completion_mask == [True, True]
     assert rollout.completion_logprobs == [-0.3, -0.4]
-    assert rollout.temperature == 1.0
+    assert rollout.completion_temperatures == [1.0, 1.0]
 
 
 def test_branching_equivalent_multi_step_trajectory_with_tool_calls(
@@ -359,7 +359,7 @@ def test_branching_equivalent_multi_step_trajectory_with_tool_calls(
     assert rollout.completion_ids == [3, 4]
     assert rollout.completion_mask == [True, True]
     assert rollout.completion_logprobs == [-0.1, -0.2]
-    assert rollout.temperature == 1.0
+    assert rollout.completion_temperatures == [1.0, 1.0]
 
     # second step
     rollout = rollouts[1]
@@ -368,7 +368,7 @@ def test_branching_equivalent_multi_step_trajectory_with_tool_calls(
     assert rollout.completion_ids == [7, 8]
     assert rollout.completion_mask == [True, True]
     assert rollout.completion_logprobs == [-0.3, -0.4]
-    assert rollout.temperature == 1.0
+    assert rollout.completion_temperatures == [1.0, 1.0]
 
 
 def test_interleave_rollout_single_step_trajectory(single_step_trajectory_output):
@@ -383,7 +383,7 @@ def test_interleave_rollout_single_step_trajectory(single_step_trajectory_output
     assert rollout.completion_ids == [3, 4]
     assert rollout.completion_mask == [True, True]
     assert rollout.completion_logprobs == [-0.1, -0.2]
-    assert rollout.temperature == 1.0
+    assert rollout.completion_temperatures == [1.0, 1.0]
     assert rollout.env_name == "test-env"
 
 
@@ -399,7 +399,7 @@ def test_interleave_rollout_multi_step_trajectory(multi_step_trajectory_output):
     assert rollout.completion_mask == [True, True, False, False, True, True]
     assert rollout.completion_logprobs == [-0.1, -0.2, 0, 0, -0.3, -0.4]
     # Temperatures: 2 completion tokens at temp 1.0, then 2 prompt tokens at temp 1.0, then 2 completion tokens at temp 1.0
-    assert rollout.temperature == 1.0
+    assert rollout.completion_temperatures == [1.0] * 6
 
 
 def test_interleave_rollout_multi_step_trajectory_with_tool_calls(multi_step_trajectory_with_tool_calls_output):
@@ -414,7 +414,7 @@ def test_interleave_rollout_multi_step_trajectory_with_tool_calls(multi_step_tra
     assert rollout.completion_mask == [True, True, False, False, True, True]
     assert rollout.completion_logprobs == [-0.1, -0.2, 0, 0, -0.3, -0.4]
     # Temperatures: 2 completion tokens at temp 1.0, then 2 prompt tokens at temp 1.0, then 2 completion tokens at temp 1.0
-    assert rollout.temperature == 1.0
+    assert rollout.completion_temperatures == [1.0] * 6
 
 
 @pytest.fixture
@@ -803,7 +803,7 @@ def test_interleave_rollout_error_masks_all_false():
     assert rollout.completion_mask == [False, False, False, False, False, False]
     # Logprobs and temperatures still present
     assert rollout.completion_logprobs == [-0.1, -0.2, 0.0, 0.0, -0.3, -0.4]
-    assert rollout.temperature == 0.8
+    assert rollout.completion_temperatures == [0.8] * 6
 
 
 def test_align_routed_experts_none():

--- a/tests/unit/train/rl/test_fused_lm_head.py
+++ b/tests/unit/train/rl/test_fused_lm_head.py
@@ -6,7 +6,13 @@ from transformers.models.llama.configuration_llama import LlamaConfig
 from prime_rl.trainer.models import cast_float_and_contiguous
 from prime_rl.trainer.models.layers.lm_head import FusedOutputLinear, VanillaOutputLinear, inject_prime_lm_head
 from prime_rl.trainer.models.llama import LlamaForCausalLM as PrimeRLLlamaForCausalLM
-from prime_rl.trainer.rl.loss import compute_entropy, selective_log_softmax, shift_tensor_left, shift_tensor_right
+from prime_rl.trainer.rl.loss import (
+    apply_top_k_top_p,
+    compute_entropy,
+    selective_log_softmax,
+    shift_tensor_left,
+    shift_tensor_right,
+)
 from prime_rl.utils.utils import default_dtype
 
 
@@ -50,6 +56,45 @@ def test_fused_lm_head_matches_full_logits_forward_and_backward_cpu():
     assert out.get("logprobs") is not None
     assert out.get("entropy") is not None
 
+    loss1 = out["logprobs"].sum()
+    loss1.backward()
+    grad_hidden1 = hidden1.grad.detach().clone()
+    grad_weight1 = lm.weight.grad.detach().clone()
+
+    torch.testing.assert_close(out["logprobs"], logp0, rtol=0, atol=1e-5)
+    torch.testing.assert_close(out["entropy"], ent0, rtol=0, atol=1e-5)
+    torch.testing.assert_close(grad_hidden1, grad_hidden0, rtol=0, atol=1e-5)
+    torch.testing.assert_close(grad_weight1, grad_weight0, rtol=0, atol=1e-5)
+
+
+def test_fused_lm_head_matches_full_logits_with_top_k_forward_and_backward_cpu():
+    torch.manual_seed(123)
+    b, s, h, v = 2, 4, 8, 37
+    temperature = torch.tensor([[1.0, 1.3, 0.8, 1.1], [1.6, 0.9, 1.2, 1.4]], dtype=torch.float32)
+    top_ks = torch.tensor([[3, -1, 5, v], [1, 7, 2, -1]], dtype=torch.long)
+    top_ps = torch.ones((b, s), dtype=torch.float32)
+    chunk_size = 3
+
+    hidden0 = torch.randn(b, s, h, dtype=torch.float32, requires_grad=True)
+    labels = torch.randint(0, v, (b, s), dtype=torch.long)
+    weight0 = torch.randn(v, h, dtype=torch.float32, requires_grad=True)
+
+    logits = hidden0 @ weight0.t()
+    scaled_logits = logits / temperature.unsqueeze(-1)
+    logp_logits = apply_top_k_top_p(scaled_logits, top_ks, top_ps, labels=labels)
+    logp0 = torch.log_softmax(logp_logits, dim=-1).gather(dim=-1, index=labels.unsqueeze(-1)).squeeze(-1)
+    ent0 = compute_entropy(scaled_logits)
+    loss0 = logp0.sum()
+    loss0.backward()
+    grad_hidden0 = hidden0.grad.detach().clone()
+    grad_weight0 = weight0.grad.detach().clone()
+
+    hidden1 = hidden0.detach().clone().requires_grad_(True)
+    weight1 = weight0.detach().clone().requires_grad_(True)
+    lm = FusedOutputLinear(in_features=h, out_features=v, chunk_size=chunk_size)
+    lm.weight = torch.nn.Parameter(weight1)
+
+    out = lm(hidden1, labels, temperature=temperature, top_ks=top_ks)
     loss1 = out["logprobs"].sum()
     loss1.backward()
     grad_hidden1 = hidden1.grad.detach().clone()

--- a/tests/unit/train/rl/test_packer.py
+++ b/tests/unit/train/rl/test_packer.py
@@ -47,7 +47,9 @@ def make_training_sample() -> TrainingSample:
         completion_ids=[2],
         completion_mask=[True],
         completion_logprobs=[-0.1],
-        temperature=1.0,
+        completion_temperatures=[1.0],
+        completion_top_ks=[-1],
+        completion_top_ps=[1.0],
         env_name="test-env",
     )
 


### PR DESCRIPTION
## Summary

- Keep rollout sampling args per token by carrying `completion_temperatures`, `completion_top_ks`, and `completion_top_ps` through `TrainingSample` / `MicroBatch`.
- Allow packed microbatches to concatenate samples with different sampling args while preserving per-token replay values in the trainer.
- Add exact top-k replay support to the chunked LM head path, including the Gemma softcapped variant; chunked heads still reject `top_p < 1.0`.

Stacked on #2601.

## Verification

- `uv run pytest tests/unit/orchestrator/test_batch.py tests/unit/orchestrator/test_trajectories.py tests/unit/orchestrator/test_sft_trajectories.py tests/unit/orchestrator/test_teacher_logprobs.py tests/unit/train/rl/test_packer.py tests/unit/train/rl/test_fused_lm_head.py -q`
- `uv run ruff check src/prime_rl/transport/types.py src/prime_rl/orchestrator/trajectories.py src/prime_rl/trainer/batch.py src/prime_rl/trainer/rl/data.py src/prime_rl/trainer/rl/loss.py src/prime_rl/trainer/rl/train.py src/prime_rl/trainer/rl/packer.py src/prime_rl/trainer/models/layers/lm_head.py src/prime_rl/trainer/models/layers/lm_head_gemma.py tests/unit/orchestrator/test_batch.py tests/unit/orchestrator/test_trajectories.py tests/unit/orchestrator/test_teacher_logprobs.py tests/unit/train/rl/test_packer.py tests/unit/train/rl/test_fused_lm_head.py`
- `git diff --check`
- Direct chunked top-k sanity probe against full-logits replay