### PR TITLE
Train against raw policy logprobs

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -408,8 +408,8 @@ class InferenceConfig(BaseConfig):
             value = rgetattr(self, config_key.replace("-", "_"))
             rsetattr(namespace, vllm_key, value)
 
-        # Set `logprobs_mode` to `processed_logprobs` by default
-        rsetattr(namespace, "logprobs_mode", "processed_logprobs")
+        # Train against raw model logprobs; sampling controls only affect token selection.
+        rsetattr(namespace, "logprobs_mode", "raw_logprobs")
 
         if self.kv_cache_offload is not None:
             rsetattr(

--- a/src/prime_rl/trainer/models/layers/lm_head.py
+++ b/src/prime_rl/trainer/models/layers/lm_head.py
@@ -47,12 +47,12 @@ class FusedOutputLinear(torch.nn.Linear):
         temperature: Tensor | None = None,
     ) -> PrimeLmOutput:
         assert labels is not None, "FusedOutputLinear requires labels for chunked logprob computation"
-        assert temperature is not None, "FusedOutputLinear requires per-token temperatures"
 
         b, s, h = hidden_states.shape
         hidden_states = hidden_states.reshape(b * s, h).contiguous()
         labels = labels.reshape(b * s).contiguous()
-        inv_t = 1.0 / temperature.reshape(b * s).contiguous()  # [N]
+        # Keep temperature in the signature for model-forward compatibility; trainer policy logprobs stay raw.
+        inv_t = torch.ones((b * s,), device=hidden_states.device, dtype=torch.float32)
 
         logprobs, entropy = _SequenceChunkedLogProbEntropyFn.apply(
             hidden_states, self.weight, labels, inv_t, self.chunk_size
@@ -70,7 +70,7 @@ class VanillaOutputLinear(torch.nn.Linear):
     def forward(
         self, hidden_states: torch.Tensor, labels: torch.Tensor | None = None, temperature: Tensor | None = None
     ) -> PrimeLmOutput:
-        # VanillaOutputLinear just returns logits - temperature scaling is done externally in train.py
+        # VanillaOutputLinear just returns logits; trainer logprobs are computed from raw logits.
         return PrimeLmOutput(logits=super().forward(hidden_states))
 
 
@@ -277,7 +277,7 @@ def inject_prime_lm_head(
     Inject a PrimeRL LM head into a model.
 
     This replaces the model's lm_head and overrides the forward method to use labels
-    and temperature for chunked loss computation.
+    for chunked loss computation.
 
     Args:
         model: The model to wrap.
@@ -343,7 +343,7 @@ def inject_prime_lm_head(
 
 
 def _patch_model_forward(model: nn.Module) -> None:
-    # Patch the forward method to use the new lm_head with labels and temperature
+    # Patch the forward method to use the new lm_head with labels.
     def new_forward(
         self: nn.Module,
         input_ids: torch.Tensor | None = None,

--- a/src/prime_rl/trainer/models/layers/lm_head_gemma.py
+++ b/src/prime_rl/trainer/models/layers/lm_head_gemma.py
@@ -25,12 +25,12 @@ class GemmaFusedOutputLinear(torch.nn.Linear):
         temperature: Tensor | None = None,
     ) -> PrimeLmOutput:
         assert labels is not None, "GemmaFusedOutputLinear requires labels for chunked logprob computation"
-        assert temperature is not None, "GemmaFusedOutputLinear requires per-token temperatures"
 
         b, s, h = hidden_states.shape
         hidden_states = hidden_states.reshape(b * s, h).contiguous()
         labels = labels.reshape(b * s).contiguous()
-        inv_t = 1.0 / temperature.reshape(b * s).contiguous()  # [N]
+        # Keep temperature in the signature for model-forward compatibility; trainer policy logprobs stay raw.
+        inv_t = torch.ones((b * s,), device=hidden_states.device, dtype=torch.float32)
 
         logprobs, entropy = _GemmaChunkedLogProbEntropyFn.apply(
             hidden_states, self.weight, labels, inv_t, self.chunk_size, self.softcap

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -420,34 +420,25 @@ def train(config: TrainerConfig):
                     )
                 set_lora_num_tokens(lora_num_tokens)
 
-            temperatures = micro_batch["temperatures"].to("cuda")
-
-            # Shard temperatures for context parallelism if enabled
-            if cp_enabled:
-                temperatures = shard_for_cp(temperatures, cp_rank=cp_rank, cp_world_size=cp_size)
-
-            # Forward pass with per-token temperatures
+            # Forward pass with raw model logits/logprobs.
             with maybe_record_function("forward"), maybe_activation_offloading(config.model.ac_offloading):
                 out = forward(
                     model,
                     input_ids,
                     forward_position_ids,
                     labels=labels,
-                    temperature=temperatures,
                     mm_kwargs=mm_kwargs,
                     mm_token_type_ids=mm_token_type_ids,
                     routed_experts=routed_experts,
                 )
 
             if out.get("logprobs") is None:
-                # VanillaOutputLinear was used - need to compute logprobs externally with per-token temps
+                # VanillaOutputLinear was used - compute raw model logprobs externally.
                 assert out.get("logits") is not None, "Logits must be provided to compute logprobs"
                 logits = out["logits"]
-                # Per-token temperature scaling: temperatures is [batch, seq], logits is [batch, seq, vocab]
-                scaled_logits = logits / temperatures.unsqueeze(-1)
-                out["logprobs"] = selective_log_softmax(scaled_logits, labels)
-                out["entropy"] = compute_entropy(scaled_logits)
-            # else: FusedOutputLinear was used - logprobs already computed with per-token temperatures
+                out["logprobs"] = selective_log_softmax(logits, labels)
+                out["entropy"] = compute_entropy(logits)
+            # else: FusedOutputLinear was used - logprobs already computed from raw model logits.
 
             if cp_enabled:
                 out["logprobs"] = gather_for_cp(out["logprobs"], cp_group)

--- a/tests/unit/train/models/test_nemotron_h_kl.py
+++ b/tests/unit/train/models/test_nemotron_h_kl.py
@@ -199,13 +199,12 @@ def test_kl_with_fused_lm_head():
     with torch.no_grad():
         vanilla_out = model(input_ids)
     vanilla_logits = vanilla_out["logits"]
-    temperature = torch.ones(1, 16, device="cuda")
-    vanilla_logprobs = selective_log_softmax(vanilla_logits / temperature.unsqueeze(-1), labels)
+    vanilla_logprobs = selective_log_softmax(vanilla_logits, labels)
 
     # Now switch to fused head and compare
     inject_prime_lm_head(model, chunk_size=16)
     with torch.no_grad():
-        fused_out = model(input_ids, labels=labels, temperature=temperature)
+        fused_out = model(input_ids, labels=labels)
     fused_logprobs = fused_out["logprobs"]
 
     diff = (vanilla_logprobs - fused_logprobs).abs().max()

--- a/tests/unit/train/rl/test_fused_lm_head.py
+++ b/tests/unit/train/rl/test_fused_lm_head.py
@@ -11,12 +11,10 @@ from prime_rl.utils.utils import default_dtype
 
 
 def _baseline_logprobs_and_entropy(
-    hidden: torch.Tensor, weight: torch.Tensor, labels: torch.Tensor, *, temperature: torch.Tensor
+    hidden: torch.Tensor, weight: torch.Tensor, labels: torch.Tensor
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Baseline logprobs and entropy with per-token temperature tensor."""
+    """Baseline raw logprobs and entropy."""
     logits = hidden @ weight.t()
-    # temperature is [b, s], logits is [b, s, v]
-    logits = logits / temperature.unsqueeze(-1)
     logp = torch.log_softmax(logits, dim=-1).gather(dim=-1, index=labels.unsqueeze(-1)).squeeze(-1)
     ent = compute_entropy(logits)
     return logp, ent
@@ -33,7 +31,7 @@ def test_fused_lm_head_matches_full_logits_forward_and_backward_cpu():
     weight0 = torch.randn(v, h, dtype=torch.float32, requires_grad=True)
 
     # Baseline
-    logp0, ent0 = _baseline_logprobs_and_entropy(hidden0, weight0, labels, temperature=temperature)
+    logp0, ent0 = _baseline_logprobs_and_entropy(hidden0, weight0, labels)
     loss0 = logp0.sum()
     loss0.backward()
     grad_hidden0 = hidden0.grad.detach().clone()
@@ -68,13 +66,12 @@ def test_fused_lm_head_requires_labels():
 
     hidden = torch.randn(b, s, h, dtype=torch.float32)
     weight = torch.randn(v, h, dtype=torch.float32)
-    temperature = torch.full((b, s), 1.0, dtype=torch.float32)
 
     lm = FusedOutputLinear(in_features=h, out_features=v, chunk_size=5)
     lm.weight = torch.nn.Parameter(weight)
 
     with pytest.raises(AssertionError, match="FusedOutputLinear requires labels"):
-        lm(hidden, labels=None, temperature=temperature)
+        lm(hidden, labels=None)
 
 
 def test_vanilla_lm_head_returns_logits():
@@ -102,8 +99,6 @@ def test_fused_vs_vanilla_integration():
     """Integration test comparing fused and vanilla outputs after postprocessing."""
     torch.manual_seed(42)
     b, s, h, v = 2, 4, 8, 37
-    temp_value = 1.7
-    temperature = torch.full((b, s), temp_value, dtype=torch.float32)
     chunk_size = 3
 
     hidden = torch.randn(b, s, h, dtype=torch.float16)
@@ -116,14 +111,14 @@ def test_fused_vs_vanilla_integration():
     vanilla_out = cast_float_and_contiguous(vanilla_lm(hidden, labels=None, temperature=None))
 
     assert vanilla_out.get("logits") is not None
-    logits = vanilla_out["logits"] / temp_value
+    logits = vanilla_out["logits"]
     vanilla_logprobs = torch.log_softmax(logits, dim=-1).gather(dim=-1, index=labels.unsqueeze(-1)).squeeze(-1)
     vanilla_entropy = compute_entropy(logits)
 
     # Fused path: get logprobs and entropy directly
     fused_lm = FusedOutputLinear(in_features=h, out_features=v, chunk_size=chunk_size)
     fused_lm.weight = torch.nn.Parameter(weight.clone())
-    fused_out = cast_float_and_contiguous(fused_lm(hidden, labels=labels, temperature=temperature))
+    fused_out = cast_float_and_contiguous(fused_lm(hidden, labels=labels))
 
     assert fused_out.get("logprobs") is not None
     assert fused_out.get("entropy") is not None
@@ -172,23 +167,19 @@ def test_full_model_fused_vs_vanilla():
     # Run a few training steps
     num_steps = 3
     batch_size, seq_len = 2, 64
-    temp_value = 1.5
 
     for step in range(num_steps):
         # Generate random batch
         with torch.device("cuda"):
             labels = torch.randint(0, config.vocab_size, (batch_size, seq_len))
             position_ids = torch.arange(seq_len).unsqueeze(0).expand(batch_size, -1)
-            temperature = torch.full((batch_size, seq_len), temp_value, dtype=torch.float32, device="cuda")
 
         # Vanilla forward (returns logits, compute logprobs/entropy using RL train functions)
         optimizer_vanilla.zero_grad()
-        out_vanilla = cast_float_and_contiguous(
-            model_vanilla(labels, position_ids, labels=labels, temperature=temperature)
-        )
+        out_vanilla = cast_float_and_contiguous(model_vanilla(labels, position_ids, labels=labels))
         if out_vanilla.get("logprobs") is None:
             assert out_vanilla.get("logits") is not None
-            logits = out_vanilla["logits"] / temp_value
+            logits = out_vanilla["logits"]
             out_vanilla["logprobs"] = selective_log_softmax(logits, labels)
             out_vanilla["entropy"] = compute_entropy(logits)
         loss_vanilla = -out_vanilla["logprobs"].mean()
@@ -197,10 +188,10 @@ def test_full_model_fused_vs_vanilla():
 
         # Fused forward (returns logprobs and entropy directly)
         optimizer_fused.zero_grad()
-        out_fused = cast_float_and_contiguous(model_fused(labels, position_ids, labels=labels, temperature=temperature))
+        out_fused = cast_float_and_contiguous(model_fused(labels, position_ids, labels=labels))
         if out_fused.get("logprobs") is None:
             assert out_fused.get("logits") is not None
-            logits = out_fused["logits"] / temp_value
+            logits = out_fused["logits"]
             out_fused["logprobs"] = selective_log_softmax(logits, labels)
             out_fused["entropy"] = compute_entropy(logits)
         loss_fused = -out_fused["logprobs"].mean()
@@ -228,8 +219,6 @@ def test_fused_lm_head_correct_shift():
     """
     torch.manual_seed(999)
     b, s, h, v = 2, 16, 32, 50
-    temp_value = 1.5
-    temperature = torch.full((b, s), temp_value, dtype=torch.float32)
     chunk_size = 13
 
     hidden = torch.randn(b, s, h, dtype=torch.float32)
@@ -242,12 +231,11 @@ def test_fused_lm_head_correct_shift():
     # === Fused path (as in training) ===
     fused_lm = FusedOutputLinear(in_features=h, out_features=v, chunk_size=chunk_size)
     fused_lm.weight = torch.nn.Parameter(weight.clone())
-    fused_out = fused_lm(hidden, labels=labels, temperature=temperature)
+    fused_out = fused_lm(hidden, labels=labels)
     trainer_logprobs = shift_tensor_right(fused_out["logprobs"])
 
     # === Inference convention (baseline) ===
     logits = hidden @ weight.t()
-    logits = logits / temp_value
     # Shift logits right (prepend zeros, drop last) to get inference convention
     shifted_logits = torch.cat([torch.zeros(b, 1, v, dtype=logits.dtype), logits[:, :-1, :]], dim=1)
     inference_logprobs = (
@@ -294,17 +282,16 @@ def test_inject_prime_lm_head_vanilla():
 
     assert isinstance(model.lm_head, VanillaOutputLinear), "lm_head should be VanillaOutputLinear"
 
-    # Test forward with labels and temperature
+    # Test forward with labels
     batch_size, seq_len = 2, 64
 
     with torch.device("cuda"):
         input_ids = torch.randint(0, config.vocab_size, (batch_size, seq_len))
         position_ids = torch.arange(seq_len).unsqueeze(0).expand(batch_size, -1)
         labels = torch.randint(0, config.vocab_size, (batch_size, seq_len))
-        temperature = torch.full((batch_size, seq_len), 1.5, dtype=torch.float32)
 
     with torch.autocast("cuda", dtype=torch.bfloat16):
-        out = model(input_ids=input_ids, position_ids=position_ids, labels=labels, temperature=temperature)
+        out = model(input_ids=input_ids, position_ids=position_ids, labels=labels)
 
     # VanillaOutputLinear returns logits
     assert isinstance(out, dict), "Output should be PrimeLmOutput (dict)"
@@ -341,17 +328,16 @@ def test_inject_prime_lm_head_fused():
 
     assert isinstance(model.lm_head, FusedOutputLinear), "lm_head should be FusedOutputLinear"
 
-    # Test forward with labels and temperature
+    # Test forward with labels
     batch_size, seq_len = 2, 64
 
     with torch.device("cuda"):
         input_ids = torch.randint(0, config.vocab_size, (batch_size, seq_len))
         position_ids = torch.arange(seq_len).unsqueeze(0).expand(batch_size, -1)
         labels = torch.randint(0, config.vocab_size, (batch_size, seq_len))
-        temperature = torch.full((batch_size, seq_len), 1.5, dtype=torch.float32)
 
     with torch.autocast("cuda", dtype=torch.bfloat16):
-        out = model(input_ids=input_ids, position_ids=position_ids, labels=labels, temperature=temperature)
+        out = model(input_ids=input_ids, position_ids=position_ids, labels=labels)
 
     # FusedOutputLinear returns logprobs and entropy
     assert isinstance(out, dict), "Output should be PrimeLmOutput (dict)"
@@ -394,28 +380,24 @@ def test_hf_model_fused_vs_vanilla_matches():
 
     # Test data
     batch_size, seq_len = 2, 64
-    temp_value = 1.5
 
     with torch.device("cuda"):
         input_ids = torch.randint(0, config.vocab_size, (batch_size, seq_len))
         position_ids = torch.arange(seq_len).unsqueeze(0).expand(batch_size, -1)
         labels = torch.randint(0, config.vocab_size, (batch_size, seq_len))
-        temperature = torch.full((batch_size, seq_len), temp_value, dtype=torch.float32)
 
     # Run vanilla model
     with torch.autocast("cuda", dtype=torch.bfloat16):
-        out_vanilla = model_vanilla(
-            input_ids=input_ids, position_ids=position_ids, labels=labels, temperature=temperature
-        )
+        out_vanilla = model_vanilla(input_ids=input_ids, position_ids=position_ids, labels=labels)
 
     # Compute logprobs and entropy from vanilla logits
-    logits = out_vanilla["logits"].float() / temp_value
+    logits = out_vanilla["logits"].float()
     vanilla_logprobs = selective_log_softmax(logits, labels)
     vanilla_entropy = compute_entropy(logits)
 
     # Run fused model
     with torch.autocast("cuda", dtype=torch.bfloat16):
-        out_fused = model_fused(input_ids=input_ids, position_ids=position_ids, labels=labels, temperature=temperature)
+        out_fused = model_fused(input_ids=input_ids, position_ids=position_ids, labels=labels)
 
     fused_logprobs = out_fused["logprobs"].float()
     fused_entropy = out_fused["entropy"].float()


### PR DESCRIPTION
## Summary
- force vLLM to return `raw_logprobs`
- stop replaying sampling temperature in trainer policy logprob/entropy computation
- keep fused LM-head signatures compatible while computing raw policy logprobs, and update fused/vanilla tests accordingly

## Validation
- `uv run ruff check packages/prime-rl-configs/src/prime_rl/configs/inference.py src/prime_rl/trainer/rl/train.py src/prime_rl/trainer/models/layers/lm_head.py src/prime_rl/trainer/models/layers/lm_head_gemma.py tests/unit/train/rl/test_fused_lm_head.py tests/unit/train/models/test_nemotron_h_kl.py`
- `uv run pytest tests/unit/train/rl/test_fused_lm_head.py -q -m 'not gpu'`
- `uv run pytest tests/unit/train/rl/test_fused_lm_head.py tests/unit/train/models/test_nemotron_h_kl.py -q -m gpu`
- `uv run python - <<'PY' ... InferenceConfig().to_vllm().logprobs_mode` returned `raw_logprobs`

Reverse-text temp=1.5 smoke was attempted but blocked on this workstation before a valid run completed: the pinned vLLM wheel requires `libcudart.so.13`, and with a temporary CUDA 13 runtime the local NVIDIA 535.171.04 driver failed with `CUDA driver version is insufficient for CUDA runtime version`.