### PR TITLE
[codex] Add sparse filesystem weight broadcast

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -82,7 +82,7 @@ class ModelConfig(BaseModelConfig):
 
 
 class WeightBroadcastConfig(BaseConfig):
-    type: Literal["nccl", "filesystem"] = "filesystem"
+    type: Literal["nccl", "filesystem", "filesystem_sparse"] = "filesystem"
     """Weight broadcast transport."""
 
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -82,8 +82,17 @@ class ModelConfig(BaseModelConfig):
 
 
 class WeightBroadcastConfig(BaseConfig):
-    type: Literal["nccl", "filesystem", "filesystem_sparse"] = "filesystem"
+    type: Literal["nccl", "filesystem"] = "filesystem"
     """Weight broadcast transport."""
+
+    sparse: bool = False
+    """Use sparse checkpoint-format filesystem weight updates."""
+
+    @model_validator(mode="after")
+    def validate_sparse_options(self):
+        if self.sparse and self.type != "filesystem":
+            raise ValueError("weight_broadcast.sparse requires weight_broadcast.type = 'filesystem'.")
+        return self
 
 
 class KVCacheOffloadConfig(BaseConfig):

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -521,9 +521,8 @@ FilterConfig: TypeAlias = Annotated[
 class FileSystemWeightBroadcastConfig(BaseConfig):
     type: Literal["filesystem"] = "filesystem"
 
-
-class SparseFileSystemWeightBroadcastConfig(BaseConfig):
-    type: Literal["filesystem_sparse"] = "filesystem_sparse"
+    sparse: bool = False
+    """Use sparse checkpoint-format filesystem broadcasts."""
 
 
 class NCCLWeightBroadcastConfig(BaseConfig):
@@ -546,7 +545,7 @@ class NCCLWeightBroadcastConfig(BaseConfig):
 
 
 WeightBroadcastConfig: TypeAlias = Annotated[
-    FileSystemWeightBroadcastConfig | SparseFileSystemWeightBroadcastConfig | NCCLWeightBroadcastConfig,
+    FileSystemWeightBroadcastConfig | NCCLWeightBroadcastConfig,
     Field(discriminator="type"),
 ]
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -522,6 +522,10 @@ class FileSystemWeightBroadcastConfig(BaseConfig):
     type: Literal["filesystem"] = "filesystem"
 
 
+class SparseFileSystemWeightBroadcastConfig(BaseConfig):
+    type: Literal["filesystem_sparse"] = "filesystem_sparse"
+
+
 class NCCLWeightBroadcastConfig(BaseConfig):
     type: Literal["nccl"] = "nccl"
 
@@ -542,7 +546,8 @@ class NCCLWeightBroadcastConfig(BaseConfig):
 
 
 WeightBroadcastConfig: TypeAlias = Annotated[
-    FileSystemWeightBroadcastConfig | NCCLWeightBroadcastConfig, Field(discriminator="type")
+    FileSystemWeightBroadcastConfig | SparseFileSystemWeightBroadcastConfig | NCCLWeightBroadcastConfig,
+    Field(discriminator="type"),
 ]
 
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -15,9 +15,6 @@ from prime_rl.configs.orchestrator import (
 from prime_rl.configs.orchestrator import (
     OrchestratorConfig,
 )
-from prime_rl.configs.orchestrator import (
-    SparseFileSystemWeightBroadcastConfig as OrchestratorSparseFileSystemWeightBroadcastConfig,
-)
 from prime_rl.configs.shared import (
     SlurmConfig,
     VLMConfig,
@@ -33,9 +30,6 @@ from prime_rl.configs.trainer import (
 )
 from prime_rl.configs.trainer import (
     NCCLWeightBroadcastConfig as TrainerNCCLWeightBroadcastConfig,
-)
-from prime_rl.configs.trainer import (
-    SparseFileSystemWeightBroadcastConfig as TrainerSparseFileSystemWeightBroadcastConfig,
 )
 from prime_rl.utils.config import BaseConfig, find_package_resource
 from prime_rl.utils.validation import (
@@ -119,8 +113,11 @@ class SharedModelConfig(BaseConfig):
 
 
 class SharedWeightBroadcastConfig(BaseConfig):
-    type: Literal["nccl", "filesystem", "filesystem_sparse"] = "filesystem"
+    type: Literal["nccl", "filesystem"] = "filesystem"
     """Weight broadcast transport."""
+
+    sparse: bool = False
+    """Use sparse checkpoint-format filesystem broadcasts."""
 
     port: int = 29501
     """Port for NCCL weight broadcast."""
@@ -132,7 +129,15 @@ class SharedWeightBroadcastConfig(BaseConfig):
     """Use kernel-format FP8 quantized NCCL transfer for weight updates. When disabled, uses default HF checkpoint-format transfer."""
 
     full_sync_interval: int | None = Field(None, ge=1)
-    """Optional interval for forcing full filesystem_sparse broadcasts between sparse deltas."""
+    """Optional interval for forcing full filesystem broadcasts between sparse deltas."""
+
+    @model_validator(mode="after")
+    def validate_sparse_options(self):
+        if self.sparse and self.type != "filesystem":
+            raise ValueError("weight_broadcast.sparse requires weight_broadcast.type = 'filesystem'.")
+        if self.full_sync_interval is not None and not self.sparse:
+            raise ValueError("weight_broadcast.full_sync_interval requires weight_broadcast.sparse = true.")
+        return self
 
 
 class BaseDeploymentConfig(BaseConfig):
@@ -380,15 +385,18 @@ class RLConfig(BaseConfig):
                     quantize_in_weight_transfer=self.weight_broadcast.quantize_in_weight_transfer,
                 )
             elif self.weight_broadcast.type == "filesystem":
-                self.trainer.weight_broadcast = TrainerFileSystemWeightBroadcastConfig()
-                self.orchestrator.weight_broadcast = OrchestratorFileSystemWeightBroadcastConfig()
-            elif self.weight_broadcast.type == "filesystem_sparse":
-                self.trainer.weight_broadcast = TrainerSparseFileSystemWeightBroadcastConfig(
+                self.trainer.weight_broadcast = TrainerFileSystemWeightBroadcastConfig(
+                    sparse=self.weight_broadcast.sparse,
                     full_sync_interval=self.weight_broadcast.full_sync_interval,
                 )
-                self.orchestrator.weight_broadcast = OrchestratorSparseFileSystemWeightBroadcastConfig()
+                self.orchestrator.weight_broadcast = OrchestratorFileSystemWeightBroadcastConfig(
+                    sparse=self.weight_broadcast.sparse,
+                )
             if self.inference is not None:
-                self.inference.weight_broadcast = InferenceWeightBroadcastConfig(type=self.weight_broadcast.type)
+                self.inference.weight_broadcast = InferenceWeightBroadcastConfig(
+                    type=self.weight_broadcast.type,
+                    sparse=self.weight_broadcast.sparse,
+                )
 
         validate_shared_weight_broadcast(self.trainer, self.orchestrator, self.inference)
 
@@ -430,8 +438,12 @@ class RLConfig(BaseConfig):
     @model_validator(mode="after")
     def auto_setup_lora(self):
         if self.trainer.model.lora is not None:
-            if self.trainer.weight_broadcast.type in ("nccl", "filesystem_sparse"):
-                raise ValueError(f"{self.trainer.weight_broadcast.type} weight broadcast does not support LoRA yet.")
+            sparse_filesystem = (
+                self.trainer.weight_broadcast.type == "filesystem" and self.trainer.weight_broadcast.sparse
+            )
+            if self.trainer.weight_broadcast.type == "nccl" or sparse_filesystem:
+                broadcast_name = "sparse filesystem" if sparse_filesystem else self.trainer.weight_broadcast.type
+                raise ValueError(f"{broadcast_name} weight broadcast does not support LoRA yet.")
 
             if self.orchestrator.student.model.lora is None:
                 from prime_rl.configs.orchestrator import LoRAConfig

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -15,6 +15,9 @@ from prime_rl.configs.orchestrator import (
 from prime_rl.configs.orchestrator import (
     OrchestratorConfig,
 )
+from prime_rl.configs.orchestrator import (
+    SparseFileSystemWeightBroadcastConfig as OrchestratorSparseFileSystemWeightBroadcastConfig,
+)
 from prime_rl.configs.shared import (
     SlurmConfig,
     VLMConfig,
@@ -30,6 +33,9 @@ from prime_rl.configs.trainer import (
 )
 from prime_rl.configs.trainer import (
     NCCLWeightBroadcastConfig as TrainerNCCLWeightBroadcastConfig,
+)
+from prime_rl.configs.trainer import (
+    SparseFileSystemWeightBroadcastConfig as TrainerSparseFileSystemWeightBroadcastConfig,
 )
 from prime_rl.utils.config import BaseConfig, find_package_resource
 from prime_rl.utils.validation import (
@@ -113,7 +119,7 @@ class SharedModelConfig(BaseConfig):
 
 
 class SharedWeightBroadcastConfig(BaseConfig):
-    type: Literal["nccl", "filesystem"] = "filesystem"
+    type: Literal["nccl", "filesystem", "filesystem_sparse"] = "filesystem"
     """Weight broadcast transport."""
 
     port: int = 29501
@@ -124,6 +130,9 @@ class SharedWeightBroadcastConfig(BaseConfig):
 
     quantize_in_weight_transfer: bool = False
     """Use kernel-format FP8 quantized NCCL transfer for weight updates. When disabled, uses default HF checkpoint-format transfer."""
+
+    full_sync_interval: int | None = Field(None, ge=1)
+    """Optional interval for forcing full filesystem_sparse broadcasts between sparse deltas."""
 
 
 class BaseDeploymentConfig(BaseConfig):
@@ -373,6 +382,11 @@ class RLConfig(BaseConfig):
             elif self.weight_broadcast.type == "filesystem":
                 self.trainer.weight_broadcast = TrainerFileSystemWeightBroadcastConfig()
                 self.orchestrator.weight_broadcast = OrchestratorFileSystemWeightBroadcastConfig()
+            elif self.weight_broadcast.type == "filesystem_sparse":
+                self.trainer.weight_broadcast = TrainerSparseFileSystemWeightBroadcastConfig(
+                    full_sync_interval=self.weight_broadcast.full_sync_interval,
+                )
+                self.orchestrator.weight_broadcast = OrchestratorSparseFileSystemWeightBroadcastConfig()
             if self.inference is not None:
                 self.inference.weight_broadcast = InferenceWeightBroadcastConfig(type=self.weight_broadcast.type)
 
@@ -416,8 +430,8 @@ class RLConfig(BaseConfig):
     @model_validator(mode="after")
     def auto_setup_lora(self):
         if self.trainer.model.lora is not None:
-            if self.trainer.weight_broadcast.type == "nccl":
-                raise ValueError("NCCL weight broadcast does not support LoRA yet.")
+            if self.trainer.weight_broadcast.type in ("nccl", "filesystem_sparse"):
+                raise ValueError(f"{self.trainer.weight_broadcast.type} weight broadcast does not support LoRA yet.")
 
             if self.orchestrator.student.model.lora is None:
                 from prime_rl.configs.orchestrator import LoRAConfig

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -454,6 +454,13 @@ class FileSystemWeightBroadcastConfig(BaseWeightBroadcastConfig):
     """Weight checkpoint serialization format."""
 
 
+class SparseFileSystemWeightBroadcastConfig(BaseWeightBroadcastConfig):
+    type: Literal["filesystem_sparse"] = "filesystem_sparse"
+
+    full_sync_interval: int | None = Field(None, ge=1)
+    """Optional interval for forcing a full checkpoint-format broadcast between sparse deltas."""
+
+
 class NCCLWeightBroadcastConfig(BaseWeightBroadcastConfig):
     type: Literal["nccl"] = "nccl"
 
@@ -475,7 +482,8 @@ class NCCLWeightBroadcastConfig(BaseWeightBroadcastConfig):
 
 
 WeightBroadcastConfig: TypeAlias = Annotated[
-    FileSystemWeightBroadcastConfig | NCCLWeightBroadcastConfig, Field(discriminator="type")
+    FileSystemWeightBroadcastConfig | SparseFileSystemWeightBroadcastConfig | NCCLWeightBroadcastConfig,
+    Field(discriminator="type"),
 ]
 
 
@@ -638,9 +646,9 @@ class TrainerConfig(BaseConfig):
 
     @model_validator(mode="after")
     def validate_lora_broadcast(self):
-        if self.model.lora is not None and self.weight_broadcast.type == "nccl":
+        if self.model.lora is not None and self.weight_broadcast.type in ("nccl", "filesystem_sparse"):
             # TODO: Support this
-            raise ValueError("NCCL weight broadcast does not support LoRA yet.")
+            raise ValueError(f"{self.weight_broadcast.type} weight broadcast does not support LoRA yet.")
         return self
 
     @model_validator(mode="after")

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -447,18 +447,23 @@ class BaseWeightBroadcastConfig(BaseConfig):
 class FileSystemWeightBroadcastConfig(BaseWeightBroadcastConfig):
     type: Literal["filesystem"] = "filesystem"
 
+    sparse: bool = False
+    """Use sparse checkpoint-format filesystem broadcasts."""
+
+    full_sync_interval: int | None = Field(None, ge=1)
+    """Optional interval for forcing a full filesystem broadcast between sparse deltas."""
+
     save_sharded: bool = True
     """Save the weight checkpoint in sharded format."""
 
     save_format: Literal["safetensors", "torch"] = "safetensors"
     """Weight checkpoint serialization format."""
 
-
-class SparseFileSystemWeightBroadcastConfig(BaseWeightBroadcastConfig):
-    type: Literal["filesystem_sparse"] = "filesystem_sparse"
-
-    full_sync_interval: int | None = Field(None, ge=1)
-    """Optional interval for forcing a full checkpoint-format broadcast between sparse deltas."""
+    @model_validator(mode="after")
+    def validate_sparse_options(self):
+        if self.full_sync_interval is not None and not self.sparse:
+            raise ValueError("filesystem full_sync_interval requires sparse=True")
+        return self
 
 
 class NCCLWeightBroadcastConfig(BaseWeightBroadcastConfig):
@@ -482,7 +487,7 @@ class NCCLWeightBroadcastConfig(BaseWeightBroadcastConfig):
 
 
 WeightBroadcastConfig: TypeAlias = Annotated[
-    FileSystemWeightBroadcastConfig | SparseFileSystemWeightBroadcastConfig | NCCLWeightBroadcastConfig,
+    FileSystemWeightBroadcastConfig | NCCLWeightBroadcastConfig,
     Field(discriminator="type"),
 ]
 
@@ -646,9 +651,11 @@ class TrainerConfig(BaseConfig):
 
     @model_validator(mode="after")
     def validate_lora_broadcast(self):
-        if self.model.lora is not None and self.weight_broadcast.type in ("nccl", "filesystem_sparse"):
+        sparse_filesystem = self.weight_broadcast.type == "filesystem" and self.weight_broadcast.sparse
+        if self.model.lora is not None and (self.weight_broadcast.type == "nccl" or sparse_filesystem):
             # TODO: Support this
-            raise ValueError(f"{self.weight_broadcast.type} weight broadcast does not support LoRA yet.")
+            broadcast_name = "sparse filesystem" if sparse_filesystem else self.weight_broadcast.type
+            raise ValueError(f"{broadcast_name} weight broadcast does not support LoRA yet.")
         return self
 
     @model_validator(mode="after")

--- a/packages/prime-rl-configs/src/prime_rl/utils/validation.py
+++ b/packages/prime-rl-configs/src/prime_rl/utils/validation.py
@@ -316,9 +316,9 @@ def validate_shared_weight_broadcast(
     orchestrator: OrchestratorConfig,
     inference: Optional[InferenceConfig] = None,
 ) -> None:
-    if (
-        inference
-        and trainer.weight_broadcast.type != orchestrator.weight_broadcast.type != inference.weight_broadcast.type
+    if inference and (
+        trainer.weight_broadcast.type != orchestrator.weight_broadcast.type
+        or trainer.weight_broadcast.type != inference.weight_broadcast.type
     ):
         raise ValueError(
             f"Inference weight broadcast type ({inference.weight_broadcast.type}) and orchestrator weight broadcast type ({orchestrator.weight_broadcast.type}) are not the same. Please specify the same weight broadcast type for both."
@@ -327,3 +327,12 @@ def validate_shared_weight_broadcast(
         raise ValueError(
             f"Trainer weight broadcast type ({trainer.weight_broadcast.type}) and orchestrator weight broadcast type ({orchestrator.weight_broadcast.type}) are not the same. Please specify the same weight broadcast type for both."
         )
+
+    if trainer.weight_broadcast.type != "filesystem":
+        return
+
+    trainer_sparse = getattr(trainer.weight_broadcast, "sparse", False)
+    orchestrator_sparse = getattr(orchestrator.weight_broadcast, "sparse", False)
+    inference_sparse = getattr(inference.weight_broadcast, "sparse", False) if inference else trainer_sparse
+    if trainer_sparse != orchestrator_sparse or trainer_sparse != inference_sparse:
+        raise ValueError("Trainer, orchestrator, and inference filesystem weight broadcast sparse settings must match.")

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -56,6 +56,7 @@ def models(request: Request) -> OpenAIServingModels:
 WORKER_EXTENSION_CLS = {
     "nccl": "prime_rl.inference.vllm.worker.nccl.NCCLWeightUpdateWorker",
     "filesystem": "prime_rl.inference.vllm.worker.filesystem.FileSystemWeightUpdateWorker",
+    "filesystem_sparse": "prime_rl.inference.vllm.worker.sparse_filesystem.SparseFileSystemWeightUpdateWorker",
 }
 
 

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -15,7 +15,7 @@ from vllm.entrypoints.serve.lora.protocol import LoadLoRAAdapterRequest
 from vllm.logger import init_logger
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 
-from prime_rl.configs.inference import InferenceConfig
+from prime_rl.configs.inference import InferenceConfig, WeightBroadcastConfig
 from prime_rl.utils.logger import get_logger
 
 logger = get_logger()
@@ -56,8 +56,13 @@ def models(request: Request) -> OpenAIServingModels:
 WORKER_EXTENSION_CLS = {
     "nccl": "prime_rl.inference.vllm.worker.nccl.NCCLWeightUpdateWorker",
     "filesystem": "prime_rl.inference.vllm.worker.filesystem.FileSystemWeightUpdateWorker",
-    "filesystem_sparse": "prime_rl.inference.vllm.worker.sparse_filesystem.SparseFileSystemWeightUpdateWorker",
 }
+
+
+def get_worker_extension_cls(config: WeightBroadcastConfig) -> str:
+    if config.type == "filesystem" and config.sparse:
+        return "prime_rl.inference.vllm.worker.sparse_filesystem.SparseFileSystemWeightUpdateWorker"
+    return WORKER_EXTENSION_CLS[config.type]
 
 
 @router.post("/pause")
@@ -204,7 +209,7 @@ def server(config: InferenceConfig, vllm_extra: dict[str, Any] | None = None):
     validate_parsed_serve_args(args)
 
     # Set the worker extension class based on the broadcast backend
-    args.worker_extension_cls = WORKER_EXTENSION_CLS[config.weight_broadcast.type]
+    args.worker_extension_cls = get_worker_extension_cls(config.weight_broadcast)
 
     if args.headless or args.api_server_count < 1:
         run_headless(args)

--- a/src/prime_rl/inference/vllm/worker/sparse_filesystem.py
+++ b/src/prime_rl/inference/vllm/worker/sparse_filesystem.py
@@ -1,0 +1,96 @@
+import shutil
+import tempfile
+from pathlib import Path
+
+from prime_rl.inference.vllm.worker.filesystem import FileSystemWeightUpdateWorker
+from prime_rl.utils.sparse_weights import (
+    SPARSE_WEIGHTS_MANIFEST,
+    apply_sparse_delta,
+    parse_step_from_dir,
+    read_sparse_manifest,
+)
+
+
+class SparseFileSystemWeightUpdateWorker(FileSystemWeightUpdateWorker):
+    """vLLM worker extension for sparse filesystem weight updates."""
+
+    def init_broadcaster(self) -> None:
+        self._sparse_local_step = 0
+        self._sparse_local_weight_dir: Path | None = None
+        self._sparse_cache_dir = Path(tempfile.mkdtemp(prefix="prime_rl_sparse_weights_"))
+
+    def update_weights_from_path(self, weight_path: str) -> None:
+        weight_dir = Path(weight_path)
+        target_dir = self._materialize_weight_dir(weight_dir)
+        super().update_weights_from_path(target_dir.as_posix())
+
+    def _materialize_weight_dir(self, weight_dir: Path) -> Path:
+        if not hasattr(self, "_sparse_cache_dir"):
+            self.init_broadcaster()
+
+        manifest = read_sparse_manifest(weight_dir)
+        if manifest is None or manifest.get("type") == "full":
+            self._set_full_weight_dir(weight_dir, manifest)
+            return weight_dir
+
+        if manifest.get("type") != "delta":
+            raise ValueError(f"Unknown sparse weight manifest type in {weight_dir}: {manifest.get('type')}")
+
+        target_step = int(manifest["step"])
+        self._materialize_step(weight_dir.parent, target_step)
+        assert self._sparse_local_weight_dir is not None
+        return self._sparse_local_weight_dir
+
+    def _set_full_weight_dir(self, weight_dir: Path, manifest: dict | None) -> None:
+        if manifest is not None and "step" in manifest:
+            self._sparse_local_step = int(manifest["step"])
+        else:
+            self._sparse_local_step = parse_step_from_dir(weight_dir)
+        self._sparse_local_weight_dir = weight_dir
+
+    def _materialize_step(self, broadcast_dir: Path, target_step: int) -> None:
+        if self._sparse_local_step == target_step:
+            return
+        if self._sparse_local_step > target_step:
+            raise ValueError(
+                f"Cannot apply sparse weights for step {target_step}; worker already has step {self._sparse_local_step}"
+            )
+
+        step_dir = broadcast_dir / f"step_{target_step}"
+        if not step_dir.exists():
+            raise FileNotFoundError(f"Cannot materialize sparse weights; missing {step_dir}")
+
+        manifest = read_sparse_manifest(step_dir)
+        if manifest is None or manifest.get("type") == "full":
+            self._set_full_weight_dir(step_dir, manifest)
+            return
+
+        if manifest.get("type") != "delta":
+            raise ValueError(f"Unknown sparse weight manifest type in {step_dir}: {manifest.get('type')}")
+
+        base_step = int(manifest["base_step"])
+        self._materialize_step(broadcast_dir, base_step)
+        if base_step != self._sparse_local_step:
+            raise ValueError(
+                f"Sparse delta base mismatch for {step_dir}: base={base_step}, local={self._sparse_local_step}"
+            )
+        if self._sparse_local_weight_dir is None:
+            raise ValueError(f"Cannot apply sparse delta {step_dir} before a full weight update")
+
+        self._ensure_private_materialized_dir()
+        assert self._sparse_local_weight_dir is not None
+        apply_sparse_delta(step_dir, self._sparse_local_weight_dir)
+        self._sparse_local_step = int(manifest["step"])
+
+    def _ensure_private_materialized_dir(self) -> None:
+        assert self._sparse_local_weight_dir is not None
+        if self._sparse_local_weight_dir == self._sparse_cache_dir:
+            return
+
+        shutil.rmtree(self._sparse_cache_dir, ignore_errors=True)
+        shutil.copytree(
+            self._sparse_local_weight_dir,
+            self._sparse_cache_dir,
+            ignore=shutil.ignore_patterns("STABLE", SPARSE_WEIGHTS_MANIFEST),
+        )
+        self._sparse_local_weight_dir = self._sparse_cache_dir

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -320,9 +320,7 @@ class Scheduler:
         self.update_weights_time = time.perf_counter() - update_weights_start_time
         sparse_metrics = get_sparse_manifest_metrics(read_sparse_manifest(weights_path))
         byte_ratio = sparse_metrics.get("weight_broadcast/sparse/byte_ratio")
-        self.weight_broadcast_metrics = (
-            {"weight_broadcast/sparse/byte_ratio": byte_ratio} if byte_ratio is not None else {}
-        )
+        self.weight_broadcast_metrics = {"sparse_broadcast_ratio": byte_ratio} if byte_ratio is not None else {}
         self.logger.debug(f"Updated weights to step {next_ckpt_step} in {self.update_weights_time:.2f}s")
 
         self.ckpt_step = next_ckpt_step

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -318,7 +318,11 @@ class Scheduler:
         weights_path = get_step_path(get_broadcast_dir(self.config.output_dir), next_ckpt_step)
         await self.student_inference.update_weights(weights_path, lora_name=self.lora_name, step=next_ckpt_step)
         self.update_weights_time = time.perf_counter() - update_weights_start_time
-        self.weight_broadcast_metrics = get_sparse_manifest_metrics(read_sparse_manifest(weights_path))
+        sparse_metrics = get_sparse_manifest_metrics(read_sparse_manifest(weights_path))
+        byte_ratio = sparse_metrics.get("weight_broadcast/sparse/byte_ratio")
+        self.weight_broadcast_metrics = (
+            {"weight_broadcast/sparse/byte_ratio": byte_ratio} if byte_ratio is not None else {}
+        )
         self.logger.debug(f"Updated weights to step {next_ckpt_step} in {self.update_weights_time:.2f}s")
 
         self.ckpt_step = next_ckpt_step

--- a/src/prime_rl/orchestrator/scheduler.py
+++ b/src/prime_rl/orchestrator/scheduler.py
@@ -15,6 +15,7 @@ from prime_rl.orchestrator.vf_utils import get_seq_len
 from prime_rl.utils.async_utils import safe_cancel, safe_cancel_all
 from prime_rl.utils.client import InferencePool
 from prime_rl.utils.logger import ProgressTracker, get_logger
+from prime_rl.utils.sparse_weights import get_sparse_manifest_metrics, read_sparse_manifest
 from prime_rl.utils.utils import (
     get_broadcast_dir,
     get_latest_ckpt_step,
@@ -119,6 +120,7 @@ class Scheduler:
         self.update_policy_task: asyncio.Task | None = None
         self.inflight_policy_update_task: asyncio.Task | None = None
         self.policy_update_lock = asyncio.Lock()
+        self.weight_broadcast_metrics: dict[str, float | int] = {}
         self.cancelled_rollouts_count = 0
         self.empty_rollouts_by_env: dict[str, int] = defaultdict(int)
         self.errored_rollouts_by_env: dict[str, int] = defaultdict(int)
@@ -316,6 +318,7 @@ class Scheduler:
         weights_path = get_step_path(get_broadcast_dir(self.config.output_dir), next_ckpt_step)
         await self.student_inference.update_weights(weights_path, lora_name=self.lora_name, step=next_ckpt_step)
         self.update_weights_time = time.perf_counter() - update_weights_start_time
+        self.weight_broadcast_metrics = get_sparse_manifest_metrics(read_sparse_manifest(weights_path))
         self.logger.debug(f"Updated weights to step {next_ckpt_step} in {self.update_weights_time:.2f}s")
 
         self.ckpt_step = next_ckpt_step
@@ -588,5 +591,6 @@ class Scheduler:
 
         # Add train pool metrics (e.g. elastic pool server counts)
         metrics.update(self.rollout_inference.get_metrics())
+        metrics.update(self.weight_broadcast_metrics)
 
         return metrics

--- a/src/prime_rl/trainer/rl/broadcast/__init__.py
+++ b/src/prime_rl/trainer/rl/broadcast/__init__.py
@@ -6,6 +6,7 @@ from prime_rl.configs.trainer import LoRAConfig, WeightBroadcastConfig
 from prime_rl.trainer.rl.broadcast.base import WeightBroadcast
 from prime_rl.trainer.rl.broadcast.filesystem import FileSystemWeightBroadcast
 from prime_rl.trainer.rl.broadcast.nccl import NCCLWeightBroadcast
+from prime_rl.trainer.rl.broadcast.sparse_filesystem import SparseFileSystemWeightBroadcast
 
 
 def setup_weight_broadcast(
@@ -15,5 +16,7 @@ def setup_weight_broadcast(
         return NCCLWeightBroadcast(output_dir, config, torch.cuda.current_device())
     elif config.type == "filesystem":
         return FileSystemWeightBroadcast(output_dir, config, lora_config)
+    elif config.type == "filesystem_sparse":
+        return SparseFileSystemWeightBroadcast(output_dir, config, lora_config)
     else:
         raise ValueError(f"Invalid weight broadcast type: {config.type}")

--- a/src/prime_rl/trainer/rl/broadcast/__init__.py
+++ b/src/prime_rl/trainer/rl/broadcast/__init__.py
@@ -15,8 +15,8 @@ def setup_weight_broadcast(
     if config.type == "nccl":
         return NCCLWeightBroadcast(output_dir, config, torch.cuda.current_device())
     elif config.type == "filesystem":
+        if config.sparse:
+            return SparseFileSystemWeightBroadcast(output_dir, config, lora_config)
         return FileSystemWeightBroadcast(output_dir, config, lora_config)
-    elif config.type == "filesystem_sparse":
-        return SparseFileSystemWeightBroadcast(output_dir, config, lora_config)
     else:
         raise ValueError(f"Invalid weight broadcast type: {config.type}")

--- a/src/prime_rl/trainer/rl/broadcast/base.py
+++ b/src/prime_rl/trainer/rl/broadcast/base.py
@@ -14,5 +14,5 @@ class WeightBroadcast(ABC):
         self.lora_config = lora_config
 
     @abstractmethod
-    def broadcast_weights(self, model: nn.Module, step: int):
+    def broadcast_weights(self, model: nn.Module, step: int, force_full: bool = False):
         pass

--- a/src/prime_rl/trainer/rl/broadcast/base.py
+++ b/src/prime_rl/trainer/rl/broadcast/base.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from pathlib import Path
+from typing import Any
 
 import torch.nn as nn
 
@@ -16,3 +17,6 @@ class WeightBroadcast(ABC):
     @abstractmethod
     def broadcast_weights(self, model: nn.Module, step: int, force_full: bool = False):
         pass
+
+    def get_metrics(self) -> dict[str, Any]:
+        return {}

--- a/src/prime_rl/trainer/rl/broadcast/filesystem.py
+++ b/src/prime_rl/trainer/rl/broadcast/filesystem.py
@@ -35,7 +35,7 @@ class FileSystemWeightBroadcast(WeightBroadcast):
             f"Filesystem broadcast initialized (save_format={config.save_format}, save_sharded={self.save_sharded})"
         )
 
-    def broadcast_weights(self, model: nn.Module, step: int) -> None:
+    def broadcast_weights(self, model: nn.Module, step: int, force_full: bool = False) -> None:
         """Broadcast weights by saving a HF-compatible checkpoint to shared filesystem and notifies the orchestrator."""
         self.logger.debug("Starting broadcasting weights to inference engine via shared filesystem")
         start_time = time.perf_counter()

--- a/src/prime_rl/trainer/rl/broadcast/nccl.py
+++ b/src/prime_rl/trainer/rl/broadcast/nccl.py
@@ -138,7 +138,7 @@ class NCCLWeightBroadcastSender:
             self.logger.debug("NCCL broadcast initialized on non-master rank (no communicator)")
 
     @torch.no_grad()
-    def broadcast_weights(self, model: nn.Module, step: int) -> None:
+    def broadcast_weights(self, model: nn.Module, step: int, force_full: bool = False) -> None:
         """Broadcast the state dict of a model into the inference pool using NCCL."""
         state_dict = model.state_dict()
         layer_prefix = get_layer_prefix(model.config)
@@ -194,7 +194,7 @@ class NCCLWeightBroadcast(WeightBroadcast):
         )
 
     @torch.no_grad()
-    def broadcast_weights(self, model: nn.Module, step: int) -> None:
+    def broadcast_weights(self, model: nn.Module, step: int, force_full: bool = False) -> None:
         """Broadcast the state dict of a model into the inference pool using NCCL and notifies the orchestrator."""
         self.logger.debug("Starting broadcasting weights to inference engine via NCCL")
         start_time = time.perf_counter()

--- a/src/prime_rl/trainer/rl/broadcast/sparse_filesystem.py
+++ b/src/prime_rl/trainer/rl/broadcast/sparse_filesystem.py
@@ -14,7 +14,7 @@ from torch.distributed.checkpoint.state_dict import _get_fqns as get_fqns
 from torch.distributed.tensor import DTensor
 from transformers.utils import SAFE_WEIGHTS_INDEX_NAME
 
-from prime_rl.configs.trainer import LoRAConfig, SparseFileSystemWeightBroadcastConfig
+from prime_rl.configs.trainer import FileSystemWeightBroadcastConfig, LoRAConfig
 from prime_rl.trainer.models import PreTrainedModelPrimeRL
 from prime_rl.trainer.rl.broadcast.base import WeightBroadcast
 from prime_rl.trainer.runs import get_multi_run_manager
@@ -120,12 +120,12 @@ class SparseFileSystemWeightBroadcast(WeightBroadcast):
     def __init__(
         self,
         output_dir: Path,
-        config: SparseFileSystemWeightBroadcastConfig,
+        config: FileSystemWeightBroadcastConfig,
         lora_config: LoRAConfig | None = None,
         dtype: torch.dtype = torch.bfloat16,
     ):
         if lora_config is not None:
-            raise ValueError("filesystem_sparse weight broadcast does not support LoRA adapters yet.")
+            raise ValueError("Sparse filesystem weight broadcast does not support LoRA adapters yet.")
         super().__init__(output_dir, lora_config)
         self.world = get_world()
         self.multi_run_manager = get_multi_run_manager()

--- a/src/prime_rl/trainer/rl/broadcast/sparse_filesystem.py
+++ b/src/prime_rl/trainer/rl/broadcast/sparse_filesystem.py
@@ -1,0 +1,310 @@
+import json
+import shutil
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import cast
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from safetensors.torch import save_file
+from torch import Tensor
+from torch.distributed.checkpoint.state_dict import _get_fqns as get_fqns
+from torch.distributed.tensor import DTensor
+from transformers.utils import SAFE_WEIGHTS_INDEX_NAME
+
+from prime_rl.configs.trainer import LoRAConfig, SparseFileSystemWeightBroadcastConfig
+from prime_rl.trainer.models import PreTrainedModelPrimeRL
+from prime_rl.trainer.rl.broadcast.base import WeightBroadcast
+from prime_rl.trainer.runs import get_multi_run_manager
+from prime_rl.trainer.utils import maybe_clean
+from prime_rl.trainer.weights import get_max_layer_num
+from prime_rl.trainer.world import get_world
+from prime_rl.utils.sparse_weights import (
+    SPARSE_WEIGHTS_MANIFEST,
+    load_safetensors,
+    save_safetensors,
+    write_sparse_manifest,
+)
+from prime_rl.utils.utils import get_broadcast_dir, get_step_path
+from prime_rl.utils.vlm import get_layer_prefix
+
+
+@dataclass
+class _RunBroadcast:
+    idx: int
+    step: int
+    save_dir: Path
+    full: bool
+    base_step: int | None = None
+    weight_map: dict[str, str] = field(default_factory=dict)
+    total_size: int = 0
+    patch_files: list[dict] = field(default_factory=list)
+    delta_numel: int = 0
+    total_numel: int = 0
+
+
+def _layer_filename(layer_position: int, total_groups: int) -> str:
+    return f"model-{layer_position + 1:05d}-of-{total_groups:05d}.safetensors"
+
+
+def _patch_filename(layer_position: int, total_groups: int) -> str:
+    return f"delta-{layer_position + 1:05d}-of-{total_groups:05d}.safetensors"
+
+
+def _filter_state_dict_by_layers(
+    state_dict: dict[str, Tensor], num_layers: int, layer_prefix: str
+) -> list[tuple[int, dict[str, Tensor]]]:
+    groups = [(-1, {key: value for key, value in state_dict.items() if not key.startswith(layer_prefix)})]
+    groups.extend(
+        (idx, {key: value for key, value in state_dict.items() if key.startswith(f"{layer_prefix}{idx}.")})
+        for idx in range(num_layers)
+    )
+    return groups
+
+
+def _preprocess_layer_checkpoint(
+    model: nn.Module,
+    layer_state_dict: dict[str, Tensor],
+    layer_idx: int,
+) -> dict[str, Tensor]:
+    if isinstance(model, PreTrainedModelPrimeRL) and model.is_prime_state_dict(layer_state_dict):
+        model.convert_layer_to_hf(layer_state_dict, layer_idx)
+        return layer_state_dict
+
+    from transformers.core_model_loading import revert_weight_conversion
+
+    return revert_weight_conversion(model, layer_state_dict)
+
+
+def _save_index(save_dir: Path, weight_map: dict[str, str], total_size: int) -> None:
+    index = {"metadata": {"total_size": total_size}, "weight_map": weight_map}
+    with open(save_dir / SAFE_WEIGHTS_INDEX_NAME, "w", encoding="utf-8") as f:
+        f.write(json.dumps(index, indent=2, sort_keys=True) + "\n")
+
+
+def _tensor_delta(current: Tensor, previous: Tensor, chunk_elems: int) -> tuple[Tensor, Tensor]:
+    current_flat = current.contiguous().view(-1)
+    previous_flat = previous.contiguous().view(-1)
+    if current_flat.shape != previous_flat.shape or current_flat.dtype != previous_flat.dtype:
+        raise ValueError(
+            f"Sparse delta shape/dtype mismatch: current={list(current.shape)} {current.dtype}, "
+            f"previous={list(previous.shape)} {previous.dtype}"
+        )
+
+    index_chunks: list[Tensor] = []
+    value_chunks: list[Tensor] = []
+    for start in range(0, current_flat.numel(), chunk_elems):
+        end = min(start + chunk_elems, current_flat.numel())
+        changed = current_flat[start:end] != previous_flat[start:end]
+        local_indices = torch.nonzero(changed, as_tuple=False).flatten()
+        if local_indices.numel() == 0:
+            continue
+        index_chunks.append((local_indices + start).to(torch.int64))
+        value_chunks.append(current_flat[start:end][local_indices])
+
+    if not index_chunks:
+        return torch.empty(0, dtype=torch.int64), torch.empty(0, dtype=current_flat.dtype)
+
+    return torch.cat(index_chunks), torch.cat(value_chunks)
+
+
+class SparseFileSystemWeightBroadcast(WeightBroadcast):
+    """Broadcast checkpoint-format weights with full snapshots plus sparse per-layer deltas."""
+
+    def __init__(
+        self,
+        output_dir: Path,
+        config: SparseFileSystemWeightBroadcastConfig,
+        lora_config: LoRAConfig | None = None,
+        dtype: torch.dtype = torch.bfloat16,
+    ):
+        if lora_config is not None:
+            raise ValueError("filesystem_sparse weight broadcast does not support LoRA adapters yet.")
+        super().__init__(output_dir, lora_config)
+        self.world = get_world()
+        self.multi_run_manager = get_multi_run_manager()
+        self.dtype = dtype
+        self.full_sync_interval = config.full_sync_interval
+        self.chunk_elems = 16_777_216
+        self._materialized_dirs: dict[int, Path] = {}
+        self._materialized_steps: dict[int, int] = {}
+        self.logger.debug(f"Sparse filesystem broadcast initialized (full_sync_interval={self.full_sync_interval})")
+
+    @torch.no_grad()
+    def broadcast_weights(self, model: nn.Module, step: int, force_full: bool = False) -> None:
+        self.logger.debug("Starting sparse filesystem weight broadcast")
+        start_time = time.perf_counter()
+        run_broadcasts = self._prepare_run_broadcasts(force_full)
+        if not run_broadcasts:
+            return
+
+        state_dict = model.state_dict()
+        layer_prefix = get_layer_prefix(model.config)
+        num_layers = get_max_layer_num(state_dict, layer_prefix)
+        layer_groups = _filter_state_dict_by_layers(state_dict, num_layers, layer_prefix)
+        total_groups = len(layer_groups)
+
+        for layer_position, (layer_idx, layer_state_dict) in enumerate(layer_groups):
+            if not layer_state_dict:
+                continue
+
+            current_state = self._resolve_state_dict(model, layer_state_dict)
+            if not self.world.is_master:
+                continue
+
+            current_state = _preprocess_layer_checkpoint(model, current_state, layer_idx)
+            if not current_state:
+                continue
+            full_filename = _layer_filename(layer_position, total_groups)
+            patch_filename = _patch_filename(layer_position, total_groups)
+            for run in run_broadcasts:
+                if run.full:
+                    self._write_full_group(run, current_state, full_filename)
+                else:
+                    self._write_delta_group(run, current_state, full_filename, patch_filename)
+
+            del current_state
+
+        if self.world.is_master:
+            for run in run_broadcasts:
+                if run.full:
+                    _save_index(run.save_dir, run.weight_map, run.total_size)
+                    write_sparse_manifest(run.save_dir, {"type": "full", "step": run.step})
+                    self._materialized_dirs[run.idx] = run.save_dir
+                else:
+                    write_sparse_manifest(
+                        run.save_dir,
+                        {
+                            "type": "delta",
+                            "base_step": run.base_step,
+                            "step": run.step,
+                            "patch_files": run.patch_files,
+                            "delta_numel": run.delta_numel,
+                            "total_numel": run.total_numel,
+                        },
+                    )
+                    self._materialized_steps[run.idx] = run.step
+
+                (run.save_dir / "STABLE").touch()
+                self.multi_run_manager.ready_to_update[run.idx] = False
+
+            self.logger.debug(f"Sparse filesystem weights broadcasted in {time.perf_counter() - start_time:.2f}s")
+
+    def _prepare_run_broadcasts(self, force_full: bool) -> list[_RunBroadcast]:
+        run_broadcasts: list[_RunBroadcast] = []
+        for idx in self.multi_run_manager.ready_to_update_idxs:
+            run_step = self.multi_run_manager.progress[idx].step
+            save_dir = get_step_path(get_broadcast_dir(self.multi_run_manager.get_run_dir(idx)), run_step)
+            full = self._should_write_full(idx, run_step, force_full)
+
+            if self.world.is_master:
+                shutil.rmtree(save_dir, ignore_errors=True)
+                save_dir.mkdir(parents=True, exist_ok=True)
+
+            base_step = None if full else self._materialized_steps[idx]
+            run = _RunBroadcast(idx=idx, step=run_step, save_dir=save_dir, full=full, base_step=base_step)
+            if self.world.is_master and not full:
+                self._ensure_materialized_cache(idx)
+            run_broadcasts.append(run)
+
+        return run_broadcasts
+
+    def _should_write_full(self, idx: int, step: int, force_full: bool) -> bool:
+        if force_full or idx not in self._materialized_steps:
+            return True
+        return bool(self.full_sync_interval and step % self.full_sync_interval == 0)
+
+    def _cache_dir(self, idx: int) -> Path:
+        run_dir = self.multi_run_manager.get_run_dir(idx)
+        return get_broadcast_dir(run_dir) / ".sparse_cache"
+
+    def _ensure_materialized_cache(self, idx: int) -> None:
+        materialized_dir = self._materialized_dirs[idx]
+        cache_dir = self._cache_dir(idx)
+        if materialized_dir == cache_dir:
+            return
+
+        shutil.rmtree(cache_dir, ignore_errors=True)
+        shutil.copytree(
+            materialized_dir,
+            cache_dir,
+            ignore=shutil.ignore_patterns("STABLE", SPARSE_WEIGHTS_MANIFEST),
+        )
+        self._materialized_dirs[idx] = cache_dir
+
+    def _resolve_state_dict(self, model: nn.Module, state_dict: dict[str, Tensor]) -> dict[str, Tensor]:
+        resolved: dict[str, Tensor] = {}
+        for key, value in state_dict.items():
+            if isinstance(value, DTensor):
+                value = cast(DTensor, value.to(self.dtype)).full_tensor()
+
+            if self.world.is_master:
+                fqns = get_fqns(model, key)
+                assert len(fqns) == 1
+                resolved_key = next(iter(fqns))
+                resolved[resolved_key] = value.to("cpu", non_blocking=False)
+
+        dist.barrier()
+        return resolved
+
+    def _write_full_group(self, run: _RunBroadcast, state_dict: dict[str, Tensor], filename: str) -> None:
+        save_safetensors(state_dict, run.save_dir / filename)
+        for name, tensor in state_dict.items():
+            run.weight_map[name] = filename
+            run.total_size += tensor.numel() * tensor.element_size()
+
+    def _write_delta_group(
+        self,
+        run: _RunBroadcast,
+        current_state: dict[str, Tensor],
+        full_filename: str,
+        patch_filename: str,
+    ) -> None:
+        materialized_dir = self._materialized_dirs[run.idx]
+        previous_state = load_safetensors(materialized_dir / full_filename)
+        patch_state: dict[str, Tensor] = {}
+        patch_entries: list[dict] = []
+
+        for name, current in current_state.items():
+            if name not in previous_state:
+                raise KeyError(f"Previous materialized weights are missing {name}")
+
+            previous = previous_state[name]
+            indices, values = _tensor_delta(current, previous, self.chunk_elems)
+            run.total_numel += current.numel()
+            run.delta_numel += indices.numel()
+            if indices.numel() == 0:
+                continue
+
+            indices_key = f"{name}.indices"
+            values_key = f"{name}.values"
+            patch_state[indices_key] = indices
+            patch_state[values_key] = values
+            patch_entries.append(
+                {
+                    "name": name,
+                    "indices_key": indices_key,
+                    "values_key": values_key,
+                    "shape": list(current.shape),
+                    "dtype": str(current.dtype),
+                    "numel": current.numel(),
+                    "num_changed": indices.numel(),
+                }
+            )
+
+        if patch_entries:
+            save_file(patch_state, run.save_dir / patch_filename, metadata={"format": "pt"})
+            run.patch_files.append({"file": patch_filename, "tensors": patch_entries})
+
+        save_safetensors(current_state, materialized_dir / full_filename)
+
+    def maybe_clean(self, max_async_level: int, interval_to_keep: int | None):
+        for idx in self.multi_run_manager.used_idxs:
+            maybe_clean(
+                get_broadcast_dir(self.multi_run_manager.get_run_dir(idx)),
+                self.multi_run_manager.progress[idx].step,
+                max_async_level,
+                interval_to_keep,
+            )

--- a/src/prime_rl/trainer/rl/broadcast/sparse_filesystem.py
+++ b/src/prime_rl/trainer/rl/broadcast/sparse_filesystem.py
@@ -18,12 +18,15 @@ from prime_rl.configs.trainer import LoRAConfig, SparseFileSystemWeightBroadcast
 from prime_rl.trainer.models import PreTrainedModelPrimeRL
 from prime_rl.trainer.rl.broadcast.base import WeightBroadcast
 from prime_rl.trainer.runs import get_multi_run_manager
-from prime_rl.trainer.utils import maybe_clean
 from prime_rl.trainer.weights import get_max_layer_num
 from prime_rl.trainer.world import get_world
 from prime_rl.utils.sparse_weights import (
+    SPARSE_WEIGHTS_FORMAT,
     SPARSE_WEIGHTS_MANIFEST,
+    get_sparse_manifest_metrics,
     load_safetensors,
+    parse_step_from_dir,
+    read_sparse_manifest,
     save_safetensors,
     write_sparse_manifest,
 )
@@ -43,6 +46,7 @@ class _RunBroadcast:
     patch_files: list[dict] = field(default_factory=list)
     delta_numel: int = 0
     total_numel: int = 0
+    delta_size: int = 0
 
 
 def _layer_filename(layer_position: int, total_groups: int) -> str:
@@ -130,11 +134,13 @@ class SparseFileSystemWeightBroadcast(WeightBroadcast):
         self.chunk_elems = 16_777_216
         self._materialized_dirs: dict[int, Path] = {}
         self._materialized_steps: dict[int, int] = {}
+        self._last_metrics: dict[str, float | int] = {}
         self.logger.debug(f"Sparse filesystem broadcast initialized (full_sync_interval={self.full_sync_interval})")
 
     @torch.no_grad()
     def broadcast_weights(self, model: nn.Module, step: int, force_full: bool = False) -> None:
         self.logger.debug("Starting sparse filesystem weight broadcast")
+        self._last_metrics = {}
         start_time = time.perf_counter()
         run_broadcasts = self._prepare_run_broadcasts(force_full)
         if not run_broadcasts:
@@ -171,8 +177,17 @@ class SparseFileSystemWeightBroadcast(WeightBroadcast):
             for run in run_broadcasts:
                 if run.full:
                     _save_index(run.save_dir, run.weight_map, run.total_size)
-                    write_sparse_manifest(run.save_dir, {"type": "full", "step": run.step})
+                    write_sparse_manifest(
+                        run.save_dir,
+                        {
+                            "type": "full",
+                            "step": run.step,
+                            "total_numel": run.total_numel,
+                            "total_size": run.total_size,
+                        },
+                    )
                     self._materialized_dirs[run.idx] = run.save_dir
+                    self._materialized_steps[run.idx] = run.step
                 else:
                     write_sparse_manifest(
                         run.save_dir,
@@ -183,6 +198,8 @@ class SparseFileSystemWeightBroadcast(WeightBroadcast):
                             "patch_files": run.patch_files,
                             "delta_numel": run.delta_numel,
                             "total_numel": run.total_numel,
+                            "delta_size": run.delta_size,
+                            "total_size": run.total_size,
                         },
                     )
                     self._materialized_steps[run.idx] = run.step
@@ -190,6 +207,7 @@ class SparseFileSystemWeightBroadcast(WeightBroadcast):
                 (run.save_dir / "STABLE").touch()
                 self.multi_run_manager.ready_to_update[run.idx] = False
 
+            self._last_metrics = self._compute_broadcast_metrics(run_broadcasts)
             self.logger.debug(f"Sparse filesystem weights broadcasted in {time.perf_counter() - start_time:.2f}s")
 
     def _prepare_run_broadcasts(self, force_full: bool) -> list[_RunBroadcast]:
@@ -253,6 +271,7 @@ class SparseFileSystemWeightBroadcast(WeightBroadcast):
         save_safetensors(state_dict, run.save_dir / filename)
         for name, tensor in state_dict.items():
             run.weight_map[name] = filename
+            run.total_numel += tensor.numel()
             run.total_size += tensor.numel() * tensor.element_size()
 
     def _write_delta_group(
@@ -274,6 +293,7 @@ class SparseFileSystemWeightBroadcast(WeightBroadcast):
             previous = previous_state[name]
             indices, values = _tensor_delta(current, previous, self.chunk_elems)
             run.total_numel += current.numel()
+            run.total_size += current.numel() * current.element_size()
             run.delta_numel += indices.numel()
             if indices.numel() == 0:
                 continue
@@ -296,15 +316,65 @@ class SparseFileSystemWeightBroadcast(WeightBroadcast):
 
         if patch_entries:
             save_file(patch_state, run.save_dir / patch_filename, metadata={"format": "pt"})
+            run.delta_size += (run.save_dir / patch_filename).stat().st_size
             run.patch_files.append({"file": patch_filename, "tensors": patch_entries})
 
         save_safetensors(current_state, materialized_dir / full_filename)
 
+    def _compute_broadcast_metrics(self, run_broadcasts: list[_RunBroadcast]) -> dict[str, float | int]:
+        num_full = sum(run.full for run in run_broadcasts)
+        num_delta = len(run_broadcasts) - num_full
+        total_numel = sum(run.total_numel for run in run_broadcasts)
+        total_size = sum(run.total_size for run in run_broadcasts)
+        delta_numel = sum(run.delta_numel if not run.full else run.total_numel for run in run_broadcasts)
+        delta_size = sum(run.delta_size if not run.full else run.total_size for run in run_broadcasts)
+        patch_files = sum(len(run.patch_files) for run in run_broadcasts)
+        manifest_metrics = get_sparse_manifest_metrics(
+            {
+                "format": SPARSE_WEIGHTS_FORMAT,
+                "type": "delta" if num_delta else "full",
+                "delta_numel": delta_numel,
+                "total_numel": total_numel,
+                "delta_size": delta_size,
+                "total_size": total_size,
+                "patch_files": [{}] * patch_files,
+            }
+        )
+        return {
+            **manifest_metrics,
+            "weight_broadcast/sparse/runs": len(run_broadcasts),
+            "weight_broadcast/sparse/full_syncs": num_full,
+            "weight_broadcast/sparse/delta_syncs": num_delta,
+        }
+
+    def get_metrics(self) -> dict[str, float | int]:
+        return self._last_metrics
+
+    def _protected_base_steps(self, broadcast_dir: Path) -> set[int]:
+        protected: set[int] = set()
+        for step_dir in broadcast_dir.glob("step_*"):
+            manifest = read_sparse_manifest(step_dir)
+            if manifest is None or manifest.get("type") != "delta":
+                continue
+            base_step = manifest.get("base_step")
+            if isinstance(base_step, int):
+                protected.add(base_step)
+        return protected
+
     def maybe_clean(self, max_async_level: int, interval_to_keep: int | None):
         for idx in self.multi_run_manager.used_idxs:
-            maybe_clean(
-                get_broadcast_dir(self.multi_run_manager.get_run_dir(idx)),
-                self.multi_run_manager.progress[idx].step,
-                max_async_level,
-                interval_to_keep,
-            )
+            broadcast_dir = get_broadcast_dir(self.multi_run_manager.get_run_dir(idx))
+            oldest_candidate_step = max(self.multi_run_manager.progress[idx].step - (max_async_level + 1), 0)
+            protected_base_steps = self._protected_base_steps(broadcast_dir)
+
+            for step_dir in broadcast_dir.glob("step_*"):
+                step = parse_step_from_dir(step_dir)
+                if step > oldest_candidate_step:
+                    continue
+                if interval_to_keep and step % interval_to_keep == 0:
+                    continue
+                if step in protected_base_steps:
+                    continue
+
+                self.logger.debug(f"Removing sparse broadcast path {step_dir}")
+                shutil.rmtree(step_dir, ignore_errors=True)

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -264,11 +264,14 @@ def train(config: TrainerConfig):
             broadcast_weights_time = 0
         else:
             last_async_level_steps = config.max_steps and progress.step >= config.max_steps - config.max_async_level
-            filesystem_weight_broadcast = config.weight_broadcast.type in ("filesystem", "filesystem_sparse")
+            filesystem_weight_broadcast = config.weight_broadcast.type == "filesystem"
             if progress.step > 0 and (not last_async_level_steps or filesystem_weight_broadcast):
                 broadcast_weights_start_time = time.perf_counter()
                 ckpt_interval = config.ckpt and config.ckpt.interval
-                force_full_broadcast = config.weight_broadcast.type == "filesystem_sparse" and (
+                sparse_filesystem_broadcast = (
+                    config.weight_broadcast.type == "filesystem" and config.weight_broadcast.sparse
+                )
+                force_full_broadcast = sparse_filesystem_broadcast and (
                     is_last_step or bool(ckpt_interval and progress.step % ckpt_interval == 0)
                 )
                 weight_broadcast.broadcast_weights(model, step=progress.step, force_full=force_full_broadcast)

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -264,14 +264,18 @@ def train(config: TrainerConfig):
             broadcast_weights_time = 0
         else:
             last_async_level_steps = config.max_steps and progress.step >= config.max_steps - config.max_async_level
-            if progress.step > 0 and (not last_async_level_steps or config.weight_broadcast.type == "filesystem"):
+            filesystem_weight_broadcast = config.weight_broadcast.type in ("filesystem", "filesystem_sparse")
+            if progress.step > 0 and (not last_async_level_steps or filesystem_weight_broadcast):
                 broadcast_weights_start_time = time.perf_counter()
-                weight_broadcast.broadcast_weights(model, step=progress.step)
+                ckpt_interval = config.ckpt and config.ckpt.interval
+                force_full_broadcast = config.weight_broadcast.type == "filesystem_sparse" and (
+                    is_last_step or bool(ckpt_interval and progress.step % ckpt_interval == 0)
+                )
+                weight_broadcast.broadcast_weights(model, step=progress.step, force_full=force_full_broadcast)
                 broadcast_weights_time = time.perf_counter() - broadcast_weights_start_time
                 # Clean up old broadcast directories (unless at ckpt interval if using filesystem weight broadcast)
-                ckpt_interval = config.ckpt and config.ckpt.interval
-                interval_to_keep = ckpt_interval if config.weight_broadcast.type == "filesystem" else None
-                if config.weight_broadcast.type == "filesystem":
+                interval_to_keep = ckpt_interval if filesystem_weight_broadcast else None
+                if filesystem_weight_broadcast:
                     weight_broadcast.maybe_clean(config.max_async_level, interval_to_keep)
             else:
                 broadcast_weights_time = 0

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -627,6 +627,12 @@ def train(config: TrainerConfig):
         }
         monitor.log(time_metrics, step=progress.step)
 
+        # Log weight broadcast metrics, if the selected backend exposes any.
+        if weight_broadcast is not None:
+            weight_broadcast_metrics = weight_broadcast.get_metrics()
+            if weight_broadcast_metrics:
+                monitor.log({**weight_broadcast_metrics, "step": progress.step}, step=progress.step)
+
         # Log disk metrics
         disk_metrics = get_ckpt_disk_metrics(config.output_dir)
         disk_metrics["step"] = progress.step

--- a/src/prime_rl/utils/sparse_weights.py
+++ b/src/prime_rl/utils/sparse_weights.py
@@ -11,6 +11,57 @@ SPARSE_WEIGHTS_FORMAT = "prime_rl_sparse_filesystem_v1"
 SPARSE_WEIGHTS_MANIFEST = "sparse_manifest.json"
 
 
+def _safe_ratio(numerator: float, denominator: float) -> float:
+    if denominator == 0:
+        return 0.0
+    return numerator / denominator
+
+
+def get_sparse_manifest_metrics(
+    manifest: dict[str, Any] | None,
+    *,
+    prefix: str = "weight_broadcast/sparse",
+) -> dict[str, float | int]:
+    if manifest is None or manifest.get("format") != SPARSE_WEIGHTS_FORMAT:
+        return {}
+
+    manifest_type = manifest.get("type")
+    if manifest_type == "full":
+        total_numel = int(manifest.get("total_numel", 0))
+        total_size = int(manifest.get("total_size", 0))
+        return {
+            f"{prefix}/is_full": 1,
+            f"{prefix}/is_delta": 0,
+            f"{prefix}/changed_numel": total_numel,
+            f"{prefix}/eligible_numel": total_numel,
+            f"{prefix}/density": 1.0 if total_numel else 0.0,
+            f"{prefix}/dense_bytes": total_size,
+            f"{prefix}/delta_bytes": total_size,
+            f"{prefix}/byte_ratio": 1.0 if total_size else 0.0,
+            f"{prefix}/patch_files": 0,
+        }
+
+    if manifest_type != "delta":
+        return {}
+
+    delta_numel = int(manifest.get("delta_numel", 0))
+    total_numel = int(manifest.get("total_numel", 0))
+    delta_size = int(manifest.get("delta_size", 0))
+    total_size = int(manifest.get("total_size", 0))
+    patch_files = manifest.get("patch_files", [])
+    return {
+        f"{prefix}/is_full": 0,
+        f"{prefix}/is_delta": 1,
+        f"{prefix}/changed_numel": delta_numel,
+        f"{prefix}/eligible_numel": total_numel,
+        f"{prefix}/density": _safe_ratio(delta_numel, total_numel),
+        f"{prefix}/dense_bytes": total_size,
+        f"{prefix}/delta_bytes": delta_size,
+        f"{prefix}/byte_ratio": _safe_ratio(delta_size, total_size),
+        f"{prefix}/patch_files": len(patch_files),
+    }
+
+
 def read_sparse_manifest(weight_dir: Path) -> dict[str, Any] | None:
     manifest_path = weight_dir / SPARSE_WEIGHTS_MANIFEST
     if not manifest_path.exists():

--- a/src/prime_rl/utils/sparse_weights.py
+++ b/src/prime_rl/utils/sparse_weights.py
@@ -1,0 +1,102 @@
+import json
+from pathlib import Path
+from typing import Any
+
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+from transformers.utils import SAFE_WEIGHTS_INDEX_NAME
+
+SPARSE_WEIGHTS_FORMAT = "prime_rl_sparse_filesystem_v1"
+SPARSE_WEIGHTS_MANIFEST = "sparse_manifest.json"
+
+
+def read_sparse_manifest(weight_dir: Path) -> dict[str, Any] | None:
+    manifest_path = weight_dir / SPARSE_WEIGHTS_MANIFEST
+    if not manifest_path.exists():
+        return None
+    with open(manifest_path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def write_sparse_manifest(weight_dir: Path, manifest: dict[str, Any]) -> None:
+    manifest = {"format": SPARSE_WEIGHTS_FORMAT, **manifest}
+    manifest_path = weight_dir / SPARSE_WEIGHTS_MANIFEST
+    tmp_path = manifest_path.with_suffix(".tmp")
+    with open(tmp_path, "w", encoding="utf-8") as f:
+        f.write(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    tmp_path.replace(manifest_path)
+
+
+def parse_step_from_dir(step_dir: Path) -> int:
+    name = step_dir.name
+    if not name.startswith("step_"):
+        raise ValueError(f"Expected step directory name like step_<n>, got {step_dir}")
+    return int(name.removeprefix("step_"))
+
+
+def load_weight_map(weight_dir: Path) -> dict[str, str]:
+    index_path = weight_dir / SAFE_WEIGHTS_INDEX_NAME
+    if index_path.exists():
+        with open(index_path, encoding="utf-8") as f:
+            index = json.load(f)
+        return dict(index["weight_map"])
+
+    weight_map: dict[str, str] = {}
+    for safetensors_path in sorted(weight_dir.glob("*.safetensors")):
+        with safe_open(safetensors_path, framework="pt", device="cpu") as f:
+            for key in f.keys():
+                weight_map[key] = safetensors_path.name
+    return weight_map
+
+
+def load_safetensors(path: Path) -> dict[str, torch.Tensor]:
+    state_dict: dict[str, torch.Tensor] = {}
+    with safe_open(path, framework="pt", device="cpu") as f:
+        for key in f.keys():
+            state_dict[key] = f.get_tensor(key).clone()
+    return state_dict
+
+
+def save_safetensors(state_dict: dict[str, torch.Tensor], path: Path) -> None:
+    contiguous_state_dict = {key: value.contiguous().clone() for key, value in state_dict.items()}
+    save_file(contiguous_state_dict, path, metadata={"format": "pt"})
+
+
+def apply_sparse_delta(delta_dir: Path, target_dir: Path) -> None:
+    manifest = read_sparse_manifest(delta_dir)
+    if manifest is None or manifest.get("type") != "delta":
+        raise ValueError(f"{delta_dir} is not a sparse delta directory")
+
+    weight_map = load_weight_map(target_dir)
+    for patch in manifest.get("patch_files", []):
+        patch_path = delta_dir / patch["file"]
+        entries = patch.get("tensors", [])
+        if not entries:
+            continue
+
+        with safe_open(patch_path, framework="pt", device="cpu") as patch_file:
+            entries_by_shard: dict[str, list[dict[str, Any]]] = {}
+            for entry in entries:
+                name = entry["name"]
+                if name not in weight_map:
+                    raise KeyError(f"Sparse delta references unknown weight {name}")
+                entries_by_shard.setdefault(weight_map[name], []).append(entry)
+
+            for shard_file, shard_entries in entries_by_shard.items():
+                shard_path = target_dir / shard_file
+                shard_state = load_safetensors(shard_path)
+                for entry in shard_entries:
+                    name = entry["name"]
+                    if name not in shard_state:
+                        raise KeyError(f"Sparse delta references missing tensor {name} in {shard_path}")
+
+                    tensor = shard_state[name].contiguous()
+                    indices = patch_file.get_tensor(entry["indices_key"]).to(torch.long)
+                    values = patch_file.get_tensor(entry["values_key"]).to(tensor.dtype)
+
+                    flat = tensor.view(-1)
+                    flat[indices] = values
+                    shard_state[name] = tensor
+
+                save_safetensors(shard_state, shard_path)

--- a/tests/unit/orchestrator/test_scheduler.py
+++ b/tests/unit/orchestrator/test_scheduler.py
@@ -130,6 +130,35 @@ def test_maybe_update_policy_reuses_inflight_update_after_cancellation():
     asyncio.run(run())
 
 
+def test_policy_update_keeps_only_sparse_byte_ratio_metric():
+    async def run() -> None:
+        scheduler = make_scheduler()
+        scheduler.student_inference = SimpleNamespace(
+            update_weights=AsyncMock(),
+            update_model_name=MagicMock(),
+        )
+        scheduler.rollout_inference = scheduler.student_inference
+        scheduler._update_off_policy = AsyncMock()
+
+        with (
+            patch("prime_rl.orchestrator.scheduler.wait_for_path", new=AsyncMock()),
+            patch("prime_rl.orchestrator.scheduler.read_sparse_manifest", return_value={}),
+            patch(
+                "prime_rl.orchestrator.scheduler.get_sparse_manifest_metrics",
+                return_value={
+                    "weight_broadcast/sparse/byte_ratio": 0.25,
+                    "weight_broadcast/sparse/delta_bytes": 128,
+                    "weight_broadcast/sparse/dense_bytes": 512,
+                },
+            ),
+        ):
+            await scheduler._apply_policy_update(8)
+
+        assert scheduler.weight_broadcast_metrics == {"weight_broadcast/sparse/byte_ratio": 0.25}
+
+    asyncio.run(run())
+
+
 def test_stop_cancels_inflight_policy_update_task():
     async def run() -> None:
         scheduler = make_scheduler()

--- a/tests/unit/orchestrator/test_scheduler.py
+++ b/tests/unit/orchestrator/test_scheduler.py
@@ -130,7 +130,7 @@ def test_maybe_update_policy_reuses_inflight_update_after_cancellation():
     asyncio.run(run())
 
 
-def test_policy_update_keeps_only_sparse_byte_ratio_metric():
+def test_policy_update_keeps_only_sparse_broadcast_ratio_metric():
     async def run() -> None:
         scheduler = make_scheduler()
         scheduler.student_inference = SimpleNamespace(
@@ -154,7 +154,7 @@ def test_policy_update_keeps_only_sparse_byte_ratio_metric():
         ):
             await scheduler._apply_policy_update(8)
 
-        assert scheduler.weight_broadcast_metrics == {"weight_broadcast/sparse/byte_ratio": 0.25}
+        assert scheduler.weight_broadcast_metrics == {"sparse_broadcast_ratio": 0.25}
 
     asyncio.run(run())
 

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -91,6 +91,23 @@ def test_defaults():
     assert config.variant.alpha == 0.1
 
 
+def test_rl_sparse_filesystem_weight_broadcast_auto_setup():
+    config = RLConfig.model_validate(
+        {
+            "trainer": {},
+            "orchestrator": {},
+            "inference": {},
+            "weight_broadcast": {"type": "filesystem_sparse", "full_sync_interval": 10},
+        }
+    )
+
+    assert config.trainer.weight_broadcast.type == "filesystem_sparse"
+    assert config.trainer.weight_broadcast.full_sync_interval == 10
+    assert config.orchestrator.weight_broadcast.type == "filesystem_sparse"
+    assert config.inference is not None
+    assert config.inference.weight_broadcast.type == "filesystem_sparse"
+
+
 def test_toml_partial_nested_override(tmp_path):
     """Partially overriding a nested model preserves unset field defaults."""
     write_toml(tmp_path / "cfg.toml", {"nested": {"lr": 3e-4}})

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -97,15 +97,18 @@ def test_rl_sparse_filesystem_weight_broadcast_auto_setup():
             "trainer": {},
             "orchestrator": {},
             "inference": {},
-            "weight_broadcast": {"type": "filesystem_sparse", "full_sync_interval": 10},
+            "weight_broadcast": {"type": "filesystem", "sparse": True, "full_sync_interval": 10},
         }
     )
 
-    assert config.trainer.weight_broadcast.type == "filesystem_sparse"
+    assert config.trainer.weight_broadcast.type == "filesystem"
+    assert config.trainer.weight_broadcast.sparse is True
     assert config.trainer.weight_broadcast.full_sync_interval == 10
-    assert config.orchestrator.weight_broadcast.type == "filesystem_sparse"
+    assert config.orchestrator.weight_broadcast.type == "filesystem"
+    assert config.orchestrator.weight_broadcast.sparse is True
     assert config.inference is not None
-    assert config.inference.weight_broadcast.type == "filesystem_sparse"
+    assert config.inference.weight_broadcast.type == "filesystem"
+    assert config.inference.weight_broadcast.sparse is True
 
 
 def test_toml_partial_nested_override(tmp_path):

--- a/tests/unit/utils/test_sparse_weights.py
+++ b/tests/unit/utils/test_sparse_weights.py
@@ -3,7 +3,13 @@ import json
 import torch
 from transformers.utils import SAFE_WEIGHTS_INDEX_NAME
 
-from prime_rl.utils.sparse_weights import apply_sparse_delta, load_safetensors, save_safetensors, write_sparse_manifest
+from prime_rl.utils.sparse_weights import (
+    apply_sparse_delta,
+    get_sparse_manifest_metrics,
+    load_safetensors,
+    save_safetensors,
+    write_sparse_manifest,
+)
 
 
 def test_apply_sparse_delta_updates_sharded_checkpoint(tmp_path):
@@ -78,3 +84,23 @@ def test_apply_sparse_delta_updates_sharded_checkpoint(tmp_path):
     assert first_shard["model.layers.0.weight"].tolist() == [1, 20, 3]
     assert first_shard["model.layers.0.bias"].tolist() == [4, 5]
     assert second_shard["model.layers.1.weight"].tolist() == [60, 7, 80]
+
+
+def test_get_sparse_manifest_metrics_reports_delta_density():
+    metrics = get_sparse_manifest_metrics(
+        {
+            "format": "prime_rl_sparse_filesystem_v1",
+            "type": "delta",
+            "delta_numel": 25,
+            "total_numel": 100,
+            "delta_size": 300,
+            "total_size": 1000,
+            "patch_files": [{"file": "delta.safetensors"}],
+        }
+    )
+
+    assert metrics["weight_broadcast/sparse/is_full"] == 0
+    assert metrics["weight_broadcast/sparse/is_delta"] == 1
+    assert metrics["weight_broadcast/sparse/density"] == 0.25
+    assert metrics["weight_broadcast/sparse/byte_ratio"] == 0.3
+    assert metrics["weight_broadcast/sparse/patch_files"] == 1

--- a/tests/unit/utils/test_sparse_weights.py
+++ b/tests/unit/utils/test_sparse_weights.py
@@ -1,0 +1,80 @@
+import json
+
+import torch
+from transformers.utils import SAFE_WEIGHTS_INDEX_NAME
+
+from prime_rl.utils.sparse_weights import apply_sparse_delta, load_safetensors, save_safetensors, write_sparse_manifest
+
+
+def test_apply_sparse_delta_updates_sharded_checkpoint(tmp_path):
+    full_dir = tmp_path / "full"
+    delta_dir = tmp_path / "delta"
+    full_dir.mkdir()
+    delta_dir.mkdir()
+
+    save_safetensors(
+        {
+            "model.layers.0.weight": torch.tensor([1, 2, 3], dtype=torch.bfloat16),
+            "model.layers.0.bias": torch.tensor([4, 5], dtype=torch.bfloat16),
+        },
+        full_dir / "model-00001-of-00002.safetensors",
+    )
+    save_safetensors(
+        {"model.layers.1.weight": torch.tensor([6, 7, 8], dtype=torch.bfloat16)},
+        full_dir / "model-00002-of-00002.safetensors",
+    )
+    with open(full_dir / SAFE_WEIGHTS_INDEX_NAME, "w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "metadata": {"total_size": 16},
+                "weight_map": {
+                    "model.layers.0.weight": "model-00001-of-00002.safetensors",
+                    "model.layers.0.bias": "model-00001-of-00002.safetensors",
+                    "model.layers.1.weight": "model-00002-of-00002.safetensors",
+                },
+            },
+            f,
+        )
+
+    save_safetensors(
+        {
+            "model.layers.0.weight.indices": torch.tensor([1], dtype=torch.int64),
+            "model.layers.0.weight.values": torch.tensor([20], dtype=torch.bfloat16),
+            "model.layers.1.weight.indices": torch.tensor([0, 2], dtype=torch.int64),
+            "model.layers.1.weight.values": torch.tensor([60, 80], dtype=torch.bfloat16),
+        },
+        delta_dir / "delta-00001-of-00001.safetensors",
+    )
+    write_sparse_manifest(
+        delta_dir,
+        {
+            "type": "delta",
+            "base_step": 1,
+            "step": 2,
+            "patch_files": [
+                {
+                    "file": "delta-00001-of-00001.safetensors",
+                    "tensors": [
+                        {
+                            "name": "model.layers.0.weight",
+                            "indices_key": "model.layers.0.weight.indices",
+                            "values_key": "model.layers.0.weight.values",
+                        },
+                        {
+                            "name": "model.layers.1.weight",
+                            "indices_key": "model.layers.1.weight.indices",
+                            "values_key": "model.layers.1.weight.values",
+                        },
+                    ],
+                }
+            ],
+        },
+    )
+
+    apply_sparse_delta(delta_dir, full_dir)
+
+    first_shard = load_safetensors(full_dir / "model-00001-of-00002.safetensors")
+    second_shard = load_safetensors(full_dir / "model-00002-of-00002.safetensors")
+    assert first_shard["model.layers.0.weight"].tolist() == [1, 20, 3]
+    assert first_shard["model.layers.0.bias"].tolist() == [4, 5]
+    assert second_shard["model.layers.1.weight"].tolist() == [60, 7, 80]


### PR DESCRIPTION
## Summary

<img width="1122" height="492" alt="image" src="https://github.com/user-attachments/assets/4d2e7c8c-4ac2-4a62-9088-f724a077f559" />

<img width="1123" height="492" alt="image" src="https://github.com/user-attachments/assets/4358eba1-0c4b-418a-bc6b-7b3d4fda5a48" />

Adds sparse checkpoint-format transfer as an opt-in mode of the existing `filesystem` weight broadcast backend.

- Adds shared, trainer, orchestrator, and inference config support for `weight_broadcast.type = "filesystem"` with `weight_broadcast.sparse = true`.
- Implements a trainer backend that writes full checkpoints on first/forced syncs and layerwise sparse delta directories otherwise, without gathering the full model state dict on rank 0.
- Adds an inference worker that materializes sparse deltas into a private local checkpoint cache before reusing the existing vLLM checkpoint reload path.
- Logs sparse broadcast metrics from the trainer backend; orchestrator W&B logging emits only `sparse_broadcast_ratio` so the main run shows the delta/full-weight size ratio directly.
- Preserves full base checkpoints needed by surviving sparse delta chains during broadcast cleanup.
- Keeps LoRA rejected for sparse filesystem broadcast until adapter semantics are defined.

## Validation

- CLI parse check against `examples/reverse_text/rl.toml` with `--weight-broadcast.type filesystem --weight-broadcast.sparse true --weight-broadcast.full-sync-interval 10`
- `uv run ruff check packages/prime-rl-configs/src/prime_rl/configs/trainer.py packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py packages/prime-rl-configs/src/prime_rl/configs/inference.py packages/prime-rl-configs/src/prime_rl/configs/rl.py packages/prime-rl-configs/src/prime_rl/utils/validation.py src/prime_rl/trainer/rl/broadcast/__init__.py src/prime_rl/trainer/rl/broadcast/sparse_filesystem.py src/prime_rl/trainer/rl/train.py src/prime_rl/inference/vllm/server.py tests/unit/test_configs.py`
- `uv run pytest tests/unit/test_configs.py tests/unit/utils/test_sparse_weights.py tests/unit/orchestrator/test_scheduler.py -q`
- `uv run ruff check src/prime_rl/orchestrator/scheduler.py tests/unit/orchestrator/test_scheduler.py`
- `uv run pytest tests/unit/orchestrator/test_scheduler.py tests/unit/utils/test_sparse_weights.py -q`
- `uv run ruff check src/prime_rl/utils/sparse_weights.py src/prime_rl/trainer/rl/broadcast/base.py src/prime_rl/trainer/rl/broadcast/sparse_filesystem.py src/prime_rl/trainer/rl/train.py src/prime_rl/orchestrator/scheduler.py tests/unit/utils/test_sparse_weights.py`
- `uv run ruff check src/prime_rl/utils/sparse_weights.py src/prime_rl/trainer/rl/broadcast/sparse_filesystem.py src/prime_rl/inference/vllm/worker/sparse_filesystem.py src/prime_rl/trainer/rl/train.py packages/prime-rl-configs/src/prime_rl/configs/{trainer,orchestrator,inference,rl}.py tests/unit/utils/test_sparse_weights.py tests/unit/test_configs.py`
- `uv run pytest tests/unit/utils/test_sparse_weights.py tests/unit/test_configs.py -q`