### PR TITLE
perf(orchestrator): reduce event-loop lag

### DIFF
--- a/src/prime_rl/orchestrator/event_loop_lag.py
+++ b/src/prime_rl/orchestrator/event_loop_lag.py
@@ -13,22 +13,22 @@ class EventLoopLagMonitor:
         self,
         interval: float = 1.0,
         max_window_size: int = 10000,
-        warn_med_lag_threshold: float = 0.5,
         warn_p90_lag_threshold: float = 1.0,
-        warn_max_lag_threshold: float = 5.0,
+        warn_p99_lag_threshold: float = 5.0,
+        warn_max_lag_threshold: float = 30.0,
     ):
         assert (
             interval > 0
             and max_window_size > 0
-            and warn_max_lag_threshold > 0
-            and warn_med_lag_threshold > 0
             and warn_p90_lag_threshold > 0
+            and warn_p99_lag_threshold > 0
+            and warn_max_lag_threshold > 0
         )
         self.interval = interval
         self.max_window_size = max_window_size
-        self.warn_max_lag_threshold = warn_max_lag_threshold
-        self.warn_med_lag_threshold = warn_med_lag_threshold
         self.warn_p90_lag_threshold = warn_p90_lag_threshold
+        self.warn_p99_lag_threshold = warn_p99_lag_threshold
+        self.warn_max_lag_threshold = warn_max_lag_threshold
         self.logger = get_logger()
         self.lags = []
 
@@ -61,15 +61,16 @@ class EventLoopLagMonitor:
         mean_lag = float(np.mean(last_lags))
         med_lag = float(np.median(last_lags))
         p90_lag = float(np.percentile(last_lags, 90))
+        p99_lag = float(np.percentile(last_lags, 99))
         min_lag = float(np.min(last_lags))
         max_lag = float(np.max(last_lags))
         if (
-            med_lag > self.warn_med_lag_threshold
-            or p90_lag > self.warn_p90_lag_threshold
+            p90_lag > self.warn_p90_lag_threshold
+            or p99_lag > self.warn_p99_lag_threshold
             or max_lag > self.warn_max_lag_threshold
         ):
             self.logger.warning(
-                f"Detected busy event loop. Measured {mean_lag:.1f}s (min={min_lag:.1f}s, med={med_lag:.1f}s, p90={p90_lag:.1f}s, max={max_lag:.1f}s) event loop lag over the last {len(last_lags)} measurement(s)"
+                f"Detected busy event loop. Measured {mean_lag:.1f}s (min={min_lag:.1f}s, med={med_lag:.1f}s, p90={p90_lag:.1f}s, p99={p99_lag:.1f}s, max={max_lag:.1f}s) event loop lag over the last {len(last_lags)} measurement(s)"
             )
 
         return {
@@ -77,5 +78,6 @@ class EventLoopLagMonitor:
             "event_loop_lag/mean": mean_lag,
             "event_loop_lag/med": med_lag,
             "event_loop_lag/p90": p90_lag,
+            "event_loop_lag/p99": p99_lag,
             "event_loop_lag/max": max_lag,
         }

--- a/src/prime_rl/orchestrator/event_loop_lag.py
+++ b/src/prime_rl/orchestrator/event_loop_lag.py
@@ -11,7 +11,7 @@ class EventLoopLagMonitor:
 
     def __init__(
         self,
-        interval: float = 1.0,
+        interval: float = 0.1,
         max_window_size: int = 10000,
         warn_p90_lag_threshold: float = 1.0,
         warn_p99_lag_threshold: float = 5.0,

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -482,22 +482,23 @@ async def orchestrate(config: OrchestratorConfig):
         # Convert rollouts to training samples
         parallel_preprocess_start = time.perf_counter()
 
-        # Pretokenize is a no-op when the renderer client already populated
-        # ``tokens`` on each trajectory step (renderer path); the fallback
-        # tokenizer-only branch handles text-only rollouts whose tokens
-        # were not pre-rendered. Run on threads so CPU work overlaps with
-        # inference for the next batch (via max_async_level >= 2).
-        await asyncio.gather(
-            *(
-                asyncio.to_thread(
-                    pretokenize_rollout_trajectory,
-                    rollout,
-                    tokenizer,
-                    renderer=renderer,
+        # Pretokenize on threads so CPU work overlaps with inference for the
+        # next batch. Skip the fanout entirely when every step already has
+        # ``tokens`` (renderer path) — otherwise the 256-way to_thread fires
+        # only to no-op and the GIL stampede blocks the loop.
+        needs_pretokenize = any(step["tokens"] is None for rollout in train_rollouts for step in rollout["trajectory"])
+        if needs_pretokenize:
+            await asyncio.gather(
+                *(
+                    asyncio.to_thread(
+                        pretokenize_rollout_trajectory,
+                        rollout,
+                        tokenizer,
+                        renderer=renderer,
+                    )
+                    for rollout in train_rollouts
                 )
-                for rollout in train_rollouts
             )
-        )
 
         # Process rollouts in parallel
         results = await asyncio.gather(

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -428,10 +428,10 @@ async def orchestrate(config: OrchestratorConfig):
             # Compute advantages (in-place)
             num_rollouts = len(train_rollouts)
             num_unique_examples = len({(r["env_name"], r["example_id"]) for r in train_rollouts})
-            compute_advantages(train_rollouts, config.advantage)
+            await asyncio.to_thread(compute_advantages, train_rollouts, config.advantage)
 
             # Apply rollout filters — sets rollout["filters"] and rollout["is_filtered"]
-            apply_filters(rollout_filters, train_rollouts)
+            await asyncio.to_thread(apply_filters, rollout_filters, train_rollouts)
 
             n_trainable = sum(1 for r in train_rollouts if not r["is_filtered"])
             if n_trainable > 0:
@@ -564,7 +564,7 @@ async def orchestrate(config: OrchestratorConfig):
             step=progress.step,
         )
 
-        training_batch_sender.send(training_batch)
+        await training_batch_sender.send(training_batch)
 
         step_time = time.perf_counter() - step_start_time
 
@@ -863,6 +863,9 @@ async def orchestrate(config: OrchestratorConfig):
 def main():
     """Main entry-point for orchestrator. Run using `uv run orchestrator`"""
     set_proc_title("Orchestrator")
+    import uvloop
+
+    uvloop.install()
     asyncio.run(orchestrate(cli(OrchestratorConfig)))
 
 

--- a/src/prime_rl/orchestrator/trajectories.py
+++ b/src/prime_rl/orchestrator/trajectories.py
@@ -174,6 +174,9 @@ def pretokenize_rollout_trajectory(
     When a renderer is provided, uses it for tokenization (faster, deterministic).
     Otherwise falls back to the tokenizer + apply_chat_template path.
     """
+    if all(step["tokens"] is not None for step in output["trajectory"]):
+        return True
+
     logger = get_logger()
     tools = _convert_tools_to_oai_format(output.get("tool_defs", []))
 

--- a/src/prime_rl/orchestrator/trajectories.py
+++ b/src/prime_rl/orchestrator/trajectories.py
@@ -271,6 +271,10 @@ def interleave_rollout(
             return None
         prepared_steps.append(prepared)
 
+    # Deferred routed_experts state per sample: O(N) chunk list concatenated
+    # once at finalize, replacing the prior O(N²) per-extension unpack/repack.
+    sample_routed_state: dict[int, dict[str, Any]] = {}
+
     def make_sample(tokens: dict[str, Any]) -> TrainingSample:
         """Create a new TrainingSample from a trajectory step."""
         if has_error:
@@ -278,19 +282,6 @@ def interleave_rollout(
         else:
             completion_mask = [bool(i) for i in tokens["completion_mask"]]
         completion_ids = list(tokens["completion_ids"])
-
-        routed_experts = align_routed_experts(
-            tokens.get("routed_experts"),
-            len(tokens["prompt_ids"]) + len(tokens["completion_ids"]),
-        )
-        packed_routed_experts = None
-        if routed_experts is not None:
-            routed_experts = np.ascontiguousarray(routed_experts)
-            packed_routed_experts = RoutedExperts(
-                data=routed_experts.tobytes(),
-                shape=list(routed_experts.shape),
-                dtype=str(routed_experts.dtype),
-            )
 
         prompt_ids = list(tokens["prompt_ids"])
         sample = TrainingSample(
@@ -304,16 +295,25 @@ def interleave_rollout(
             advantage=None,
             env_name=output["env_name"],
             mm_token_type_ids=None,
-            routed_experts=packed_routed_experts,
+            routed_experts=None,  # deferred — finalized at end of interleave_rollout
         )
-        return sample, routed_experts
+        # Initialize routed-experts state for this sample. First chunk is the
+        # raw step routed_experts (no pad, no copy). running_len is the
+        # cumulative count across chunks; tracked so the boundary fix-up at
+        # each extension is a no-op append rather than a destructive write.
+        step_routed = tokens.get("routed_experts")
+        if step_routed is not None:
+            sample_routed_state[id(sample)] = {
+                "chunks": [step_routed],
+                "running_len": int(step_routed.shape[0]),
+            }
+        return sample
 
     def extend_sample(
         sample: TrainingSample,
-        sample_routed_experts: np.ndarray | None,
         prefix_len: int,
         step_idx: int,
-    ) -> np.ndarray | None:
+    ) -> None:
         """Extend an existing sample with a new trajectory step (extension property holds)."""
         tokens = prepared_steps[step_idx]
 
@@ -334,35 +334,32 @@ def interleave_rollout(
         sample.completion_logprobs.extend(tokens["completion_logprobs"])
         sample.completion_temperatures.extend([temperature] * len(completion_ids))
 
-        if tokens.get("routed_experts") is not None and sample_routed_experts is not None:
-            step_routed = tokens["routed_experts"]
-            # The previous step's last routing entry was zero-padded by align_routed_experts
-            # (vLLM only captures num_tokens-1 routings per request). This step actually
-            # processed that boundary token as part of its prompt, so replace the zero-fill
-            # with the real routing decision before appending new entries.
+        step_routed = tokens.get("routed_experts")
+        state = sample_routed_state.get(id(sample))
+        if step_routed is not None and state is not None:
+            # vLLM doesn't capture a routing decision for the *last* token of any
+            # request, so the previous step left no entry for token at index
+            # (prefix_len - 1). The next step's forward pass *did* process that
+            # token (as part of its prompt) and produced step_routed[prefix_len-1].
+            # Append that single boundary entry as its own chunk, then append the
+            # genuinely new entries from this step. No prior bytes touched.
             if prefix_len > 0 and prefix_len <= step_routed.shape[0]:
-                sample_routed_experts[prefix_len - 1] = step_routed[prefix_len - 1]
-            sample_routed_experts = np.concatenate((sample_routed_experts, step_routed[prefix_len:]), axis=0)
-            expected_len = len(sample.prompt_ids) + len(sample.completion_ids)
-            sample_routed_experts = align_routed_experts(sample_routed_experts, expected_len)
-            sample_routed_experts = np.ascontiguousarray(sample_routed_experts)
-            packed_routed_experts = RoutedExperts(
-                data=sample_routed_experts.tobytes(),
-                shape=list(sample_routed_experts.shape),
-                dtype=str(sample_routed_experts.dtype),
-            )
-            sample.routed_experts = packed_routed_experts
-        return sample_routed_experts
+                boundary_chunk = step_routed[prefix_len - 1 : prefix_len]
+                state["chunks"].append(boundary_chunk)
+                state["running_len"] += 1
+            new_chunk = step_routed[prefix_len:]
+            state["chunks"].append(new_chunk)
+            state["running_len"] += int(new_chunk.shape[0])
 
     # Track (prefix_tokens, sample, step_indices) per active sample. step_indices
     # is the explicit list of prepared_steps positions merged into this sample —
     # non-contiguous when other agents' steps interleave.
-    active_samples: list[tuple[list[int], TrainingSample, list[int], np.ndarray | None]] = []
+    active_samples: list[tuple[list[int], TrainingSample, list[int]]] = []
 
     first_tokens = prepared_steps[0]
     first_prefix = first_tokens["prompt_ids"] + first_tokens["completion_ids"]
-    first_sample, first_routed_experts = make_sample(first_tokens)
-    active_samples.append((first_prefix, first_sample, [0], first_routed_experts))
+    first_sample = make_sample(first_tokens)
+    active_samples.append((first_prefix, first_sample, [0]))
 
     for step_idx, _step in enumerate(trajectory[1:], start=1):
         tokens = prepared_steps[step_idx]
@@ -370,20 +367,19 @@ def interleave_rollout(
 
         # Check if this step extends ANY active prefix
         matched_idx = None
-        for idx, (prefix_tokens, _, _, _) in enumerate(active_samples):
+        for idx, (prefix_tokens, _, _) in enumerate(active_samples):
             if step_prompt_ids[: len(prefix_tokens)] == prefix_tokens:
                 matched_idx = idx
                 break
 
         if matched_idx is not None:
             # Extension holds - merge into matched sample
-            prefix_tokens, sample, step_indices, sample_routed_experts = active_samples[matched_idx]
-            sample_routed_experts = extend_sample(sample, sample_routed_experts, len(prefix_tokens), step_idx=step_idx)
+            prefix_tokens, sample, step_indices = active_samples[matched_idx]
+            extend_sample(sample, len(prefix_tokens), step_idx=step_idx)
             active_samples[matched_idx] = (
                 tokens["prompt_ids"] + tokens["completion_ids"],
                 sample,
                 step_indices + [step_idx],
-                sample_routed_experts,
             )
         else:
             # No prefix matches - start a new sample
@@ -392,8 +388,29 @@ def interleave_rollout(
                 f"Starting new sample (active_prefixes={len(active_samples)}, step_prompt_len={len(step_prompt_ids)})."
             )
             new_prefix = tokens["prompt_ids"] + tokens["completion_ids"]
-            sample, routed_experts = make_sample(tokens)
-            active_samples.append((new_prefix, sample, [step_idx], routed_experts))
+            sample = make_sample(tokens)
+            active_samples.append((new_prefix, sample, [step_idx]))
+
+    # Finalize routed_experts for each sample. One concat per sample (O(N) byte
+    # work) replaces the previous per-step unpack/concat/repack (O(N²)). The
+    # boundary entries between steps were already inserted as one-entry chunks
+    # during extend_sample, so a straight concat is correct.
+    for _, sample, _ in active_samples:
+        state = sample_routed_state.get(id(sample))
+        if state is None:
+            continue
+        chunks = state["chunks"]
+        if not chunks:
+            continue
+        combined = np.concatenate(chunks, axis=0) if len(chunks) > 1 else np.ascontiguousarray(chunks[0])
+        expected_len = len(sample.prompt_ids) + len(sample.completion_ids)
+        combined = align_routed_experts(combined, expected_len)
+        combined = np.ascontiguousarray(combined)
+        sample.routed_experts = RoutedExperts(
+            data=combined.tobytes(),
+            shape=list(combined.shape),
+            dtype=str(combined.dtype),
+        )
 
     # Attach images by concatenating mm_items across every step the
     # sample covers. verifiers' ``state_to_output`` ships per-step
@@ -402,7 +419,7 @@ def interleave_rollout(
     # reading the last step alone would miss every earlier-turn image.
     # Concat in step order recovers the per-sample cumulative set;
     # deduping again here would drop legitimate duplicate placeholders.
-    for _, sample, step_indices, _ in active_samples:
+    for _, sample, step_indices in active_samples:
         renderer_mm = _union_step_mm_data(prepared_steps, step_indices)
         if renderer_mm is not None:
             mm_kwargs = _pack_mm_kwargs_from_renderer(renderer_mm)
@@ -417,7 +434,7 @@ def interleave_rollout(
                         for token_id in sample.prompt_ids + sample.completion_ids
                     ]
 
-    return [sample for _, sample, _, _ in active_samples]
+    return [sample for _, sample, _ in active_samples]
 
 
 def _union_step_mm_data(

--- a/src/prime_rl/orchestrator/trajectories.py
+++ b/src/prime_rl/orchestrator/trajectories.py
@@ -249,9 +249,9 @@ def interleave_rollout(
 
             return {
                 "prompt_ids": list(tokens["prompt_ids"]),
-                "prompt_mask": [bool(i) for i in tokens["prompt_mask"]],
+                "prompt_mask": list(map(bool, tokens["prompt_mask"])),
                 "completion_ids": list(tokens["completion_ids"]),
-                "completion_mask": [bool(i) for i in tokens["completion_mask"]],
+                "completion_mask": list(map(bool, tokens["completion_mask"])),
                 "completion_logprobs": list(tokens["completion_logprobs"]),
                 "routed_experts": routed_experts,
                 # Renderer-emitted multimodal sidecar (placeholders + per-item
@@ -280,13 +280,13 @@ def interleave_rollout(
         if has_error:
             completion_mask = [False] * len(tokens["completion_mask"])
         else:
-            completion_mask = [bool(i) for i in tokens["completion_mask"]]
+            completion_mask = list(tokens["completion_mask"])
         completion_ids = list(tokens["completion_ids"])
 
         prompt_ids = list(tokens["prompt_ids"])
         sample = TrainingSample(
             prompt_ids=prompt_ids,
-            prompt_mask=[bool(i) for i in tokens["prompt_mask"]],
+            prompt_mask=list(tokens["prompt_mask"]),
             completion_ids=completion_ids,
             completion_mask=completion_mask,
             completion_logprobs=list(tokens["completion_logprobs"]),
@@ -330,7 +330,7 @@ def interleave_rollout(
         if has_error:
             sample.completion_mask.extend([False] * len(tokens["completion_mask"]))
         else:
-            sample.completion_mask.extend(bool(i) for i in tokens["completion_mask"])
+            sample.completion_mask.extend(tokens["completion_mask"])
         sample.completion_logprobs.extend(tokens["completion_logprobs"])
         sample.completion_temperatures.extend([temperature] * len(completion_ids))
 

--- a/src/prime_rl/orchestrator/vf_utils.py
+++ b/src/prime_rl/orchestrator/vf_utils.py
@@ -1,7 +1,7 @@
-import json
 import logging
 from pathlib import Path
 
+import orjson
 import verifiers as vf
 from verifiers.utils.save_utils import make_serializable
 
@@ -82,11 +82,11 @@ def get_tool_response_len(output: vf.RolloutOutput) -> int:
 def save_rollouts(rollouts: list[vf.RolloutOutput], path: Path, exclude_keys: set[str] | None = None) -> None:
     """Save rollouts to a JSONL file using verifiers serialization."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w") as f:
+    opts = orjson.OPT_APPEND_NEWLINE | orjson.OPT_SERIALIZE_NUMPY
+    with open(path, "wb") as f:
         for rollout in rollouts:
             row = {k: v for k, v in rollout.items() if k not in exclude_keys} if exclude_keys else rollout
-            json.dump(row, f, default=make_serializable)
-            f.write("\n")
+            f.write(orjson.dumps(row, default=make_serializable, option=opts))
 
 
 def intercept_vf_logging(logger: str = "verifiers", level: str = "DEBUG", prefix: str | None = None):

--- a/src/prime_rl/transport/base.py
+++ b/src/prime_rl/transport/base.py
@@ -16,7 +16,7 @@ class TrainingBatchSender(ABC):
         self.output_dir = output_dir
 
     @abstractmethod
-    def send(self, batch: TrainingBatch) -> None:
+    async def send(self, batch: TrainingBatch) -> None:
         """Send a batch of training examples to the trainer(s).
 
         Args:

--- a/src/prime_rl/transport/filesystem.py
+++ b/src/prime_rl/transport/filesystem.py
@@ -1,3 +1,4 @@
+import asyncio
 from pathlib import Path
 from time import time
 
@@ -18,11 +19,14 @@ class FileSystemTrainingBatchSender(TrainingBatchSender):
         super().__init__(output_dir)
         self.rollout_dir = get_rollout_dir(output_dir)
 
-    def send(self, batch: TrainingBatch) -> None:
-        """Send a batch by writing it to disk"""
+    async def send(self, batch: TrainingBatch) -> None:
+        """Send a batch by writing it to disk. Encode + write run in a worker
+        thread so the orch event loop stays responsive during step transitions."""
         step_path = get_step_path(self.rollout_dir, batch.step)
         step_path.mkdir(parents=True, exist_ok=True)
+        await asyncio.to_thread(self._encode_and_write, batch, step_path)
 
+    def _encode_and_write(self, batch: TrainingBatch, step_path: Path) -> None:
         buffer = self.encoder.encode(batch)
         tmp_path = step_path / BATCH_FILE_TMP_NAME
         with open(tmp_path, "wb") as f:

--- a/src/prime_rl/transport/zmq.py
+++ b/src/prime_rl/transport/zmq.py
@@ -32,7 +32,7 @@ class ZMQTrainingBatchSender(TrainingBatchSender):
             f"endpoint=tcp://{transport.host}:{transport.port} hwm={transport.hwm}"
         )
 
-    def send(self, batch: TrainingBatch) -> None:
+    async def send(self, batch: TrainingBatch) -> None:
         payload = self.encoder.encode(batch)
         self.logger.debug(f"Sending batch {batch.step} to {self.sender_id}")
         self.socket.send_multipart([self.sender_id, payload], copy=False)

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ conflicts = [[
 ]]
 
 [options]
-exclude-newer = "2026-05-14T14:58:09.755544055Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -5907,6 +5907,7 @@ dependencies = [
     { name = "setproctitle", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
     { name = "tenacity", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
     { name = "textual", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
+    { name = "uvloop", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (platform_machine == 'aarch64' and platform_python_implementation == 'PyPy' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'x86_64' and platform_python_implementation == 'PyPy' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
 ]
 
 [package.optional-dependencies]
@@ -6010,6 +6011,7 @@ requires-dist = [
     { name = "torch", marker = "extra == 'rl'", specifier = ">=2.8.0,<2.9.0", index = "https://download.pytorch.org/whl/cu128" },
     { name = "transformers", marker = "extra == 'rl'", git = "https://github.com/huggingface/transformers.git?rev=c1c3424" },
     { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'", specifier = ">=0.21.0" },
     { name = "vllm", marker = "platform_machine == 'aarch64' and extra == 'rl'", url = "https://github.com/vllm-project/vllm/releases/download/v0.21.0/vllm-0.21.0+cu129-cp38-abi3-manylinux_2_34_aarch64.whl" },
     { name = "vllm", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'rl'", specifier = ">=0.10.0,<0.11.0" },
     { name = "vllm", marker = "platform_machine == 'x86_64' and extra == 'rl'", url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.21.0+cu129.r42434.pr39568.a106aa6-cp38-abi3-manylinux_2_24_x86_64.whl" },


### PR DESCRIPTION
## Summary

Reduce orchestrator step-boundary event-loop lag, motivated by router-replay runs (Qwen3-30B-A3B + GLM-5.1) where the per-step routed_experts payload (~25 GB across 256 rollouts) caused multi-second loop-lag spikes at step boundaries.

Changes are all in the orchestrator and its post-rollout pipeline. The trainer/inference paths are untouched.

> **Coupled with [PrimeIntellect-ai/verifiers#1453](https://github.com/PrimeIntellect-ai/verifiers/pull/1453)** (`perf/r3-serve`). The verifiers PR fixes the env-side counterpart of the same lag (env_worker / env_router), which this PR's verifiers submodule bump pulls in. Land or revert together — without the verifiers side the env worker loop saturates first under 256-rollout concurrency and the orch-side gains here don't surface.

> **Follow-up #2612** (`perf/r3-sidecar`) layers a `routed_experts` sidecar-split sender on top of this PR. Use it if the to_thread-only send here isn't enough for the largest router-replay payloads.

### What's in here

7 commits, ~200 LOC. Each commit is a single intervention:

| # | Commit | What |
|---|---|---|
| 1 | `perf(transport): offload TrainingBatch send to a worker thread` | Make `TrainingBatchSender.send` async; encode + disk write run via `asyncio.to_thread` so the orch event loop stays responsive during step transitions. |
| 2 | `perf(orchestrator): await async sender; to_thread advantages+filters+uvloop` | Await the now-async sender. Wrap `compute_advantages` and `apply_filters` in `asyncio.to_thread` — pure-Python work that was running on the loop. Install uvloop in `main()`. |
| 3 | `perf(orchestrator): log p99 event-loop lag in metrics + busy-loop warning` | Add `event_loop_lag/p99` to the wandb dict and the busy-loop warning line. Raise warn thresholds to p90>1s / p99>5s / max>30s — p90 alone undersold the long tail we actually care about. |
| 4 | `perf(orchestrator): defer routed_experts concat in interleave_rollout` | Per-extension `unpack → numpy.concatenate → repack` was O(N²) byte copies (~2.3 GB memcpy per long rollout). New path keeps a per-sample chunk list and concatenates once at finalize. O(N) byte work, ~100× less per rollout. |
| 5 | `perf(orchestrator): orjson save_rollouts + dedup bool conversion` | `json.dump` → `orjson.dumps`. Pure-Python serializer held the GIL for the whole save (multi-second spikes on big steps); orjson serializes in C and releases the GIL. Also dropped the redundant `[bool(i) for i in mask]` re-conversion in `make_sample`/`extend_sample` (use `list(...)` instead) and switched `prepare_step_tokens` to `list(map(bool, ...))`. |
| 6 | `perf(orchestrator): skip pretokenize fanout when nothing needs work; 10Hz lag monitor` | Pretokenize is a no-op for router-replay (every step has `tokens` populated), but the 256-way `to_thread` fanout was firing only to no-op and the GIL stampede blocked the loop. Skip when no rollout needs work. Also `EventLoopLagMonitor` sample rate 1 Hz → 10 Hz to catch sub-second spikes. |
| 7 | `chore(deps): bump verifiers submodule to PR 1453 head` | Pulls in the env_worker / env_router lag fixes from verifiers#1453. |

### What's NOT in here (deferred / dropped)

- **Streaming + routed_experts sidecar in the sender** — moved to follow-up #2612. Real win if the simpler to_thread send here is insufficient under heavy router replay, but adds an on-disk format change and per-sample loop yields.
- **Shared `ProcessPoolExecutor`** — tried for router-replay's GIL residual, didn't help (per-call pickle/IPC cost dominated the small per-rollout payload). Dropped.
- **Per-phase timing instrumentation + `dump_raw_rollouts`** — useful while investigating but not worth keeping in prod.
- **Chunked gather (`gather_chunk_size`)** — sliced `interleave_rollout` waves with `await sleep(0)` between. Real wallclock cost for unclear value once the algorithmic fixes (#4) landed. Reverted.
- **Killing base64 on the routed_experts wire** — profile shows `pybase64.b64decode_as_bytearray` is ~73% of single-thread CPU in `interleave_rollout`. Releases the GIL so it parallelises and doesn't block the loop directly, but it's the dominant wallclock floor. Moving inference→orch transport to msgpack `bin` would eliminate the encode+decode. Cross-repo, deferred.
- **`TrainingSample.{prompt,completion}_mask`: `list[bool]` → `list[int]` or `bytes`** — would kill the last Python loop in `prepare_step_tokens`. Interface change, deferred until empirical evidence it matters.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the orchestrator post-rollout pipeline and transport `TrainingBatchSender` API, so regressions could impact training throughput or batch delivery ordering, though changes are largely performance-oriented and isolated from model/inference logic.
> 
> **Overview**
> Reduces orchestrator event-loop stalls during step transitions by pushing CPU/GIL-heavy work off the loop and cutting per-rollout copying overhead.
> 
> `compute_advantages`, rollout filtering, and filesystem batch encoding/writes now run via `asyncio.to_thread`, and `TrainingBatchSender.send` becomes `async` (with the orchestrator awaiting it). Pretokenization fanout is skipped when all steps already have tokens, and `uvloop` is installed in `main()`.
> 
> `interleave_rollout` now defers `routed_experts` concatenation/packing until finalization (chunking per step and concatenating once), and rollout JSONL saving switches to `orjson`. Event-loop lag monitoring is sampled at 10Hz and logs/exports `p99` lag with updated warning thresholds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b92f7d3de3374ed0903c570d76fa1df63d6f3189. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->