### PR TITLE
chore(orchestrator): backfill rollout tokens only when needed

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -482,22 +482,22 @@ async def orchestrate(config: OrchestratorConfig):
         # Convert rollouts to training samples
         parallel_preprocess_start = time.perf_counter()
 
-        # Pretokenize is a no-op when the renderer client already populated
-        # ``tokens`` on each trajectory step (renderer path); the fallback
-        # tokenizer-only branch handles text-only rollouts whose tokens
-        # were not pre-rendered. Run on threads so CPU work overlaps with
-        # inference for the next batch (via max_async_level >= 2).
-        await asyncio.gather(
-            *(
-                asyncio.to_thread(
-                    pretokenize_rollout_trajectory,
-                    rollout,
-                    tokenizer,
-                    renderer=renderer,
+        # SFT-only: external teacher APIs (OpenAI/etc.) return no token IDs,
+        # so step["tokens"] is None — reconstruct via tokenizer/renderer. The
+        # vLLM-served rollout paths (RL/OPD renderer + MITO) already populate
+        # tokens via prompt_token_ids/token_ids, so the call is a no-op there.
+        if config.training_mode == "sft":
+            await asyncio.gather(
+                *(
+                    asyncio.to_thread(
+                        pretokenize_rollout_trajectory,
+                        rollout,
+                        tokenizer,
+                        renderer=renderer,
+                    )
+                    for rollout in train_rollouts
                 )
-                for rollout in train_rollouts
             )
-        )
 
         # Process rollouts in parallel
         results = await asyncio.gather(

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -13,9 +13,9 @@ from prime_rl.orchestrator.event_loop_lag import EventLoopLagMonitor
 from prime_rl.orchestrator.inference_metrics import InferenceMetricsCollector
 from prime_rl.orchestrator.patches import monkey_patch_chat_completion_logprobs, monkey_patch_oai_iterable_types
 from prime_rl.orchestrator.trajectories import (
+    backfill_rollout_tokens,
     interleave_rollout,
     offload_images_to_disk,
-    pretokenize_rollout_trajectory,
 )
 from prime_rl.transport import TrainingBatch, TrainingSample, setup_training_batch_sender
 from prime_rl.utils.pathing import get_log_dir, get_rollout_dir, get_step_path
@@ -482,18 +482,21 @@ async def orchestrate(config: OrchestratorConfig):
         # Convert rollouts to training samples
         parallel_preprocess_start = time.perf_counter()
 
-        # We only expect to run pretokenize for SFT against an external teacher
-        # API (OpenAI/etc.), which returns no token IDs — reconstruct via
-        # tokenizer/renderer. The vLLM-served paths (RL/OPD renderer + MITO,
-        # and SFT against a local vLLM teacher) already populate tokens via
-        # prompt_token_ids/token_ids, so we short-circuit the 256-way fanout.
-        needs_pretokenize = any(step["tokens"] is None for rollout in train_rollouts for step in rollout["trajectory"])
-        if needs_pretokenize:
-            logger.info("Pretokenizing rollout trajectories (expected for SFT against an external teacher API)")
+        # We only expect to backfill tokens for training_mode=sft against an
+        # external teacher API (OpenAI/etc.), which returns no token IDs —
+        # reconstruct via tokenizer/renderer. The vLLM-served paths (RL/OPD
+        # renderer + MITO, and training_mode=sft against a local vLLM teacher)
+        # already populate tokens via prompt_token_ids/token_ids, so we
+        # short-circuit the 256-way fanout.
+        needs_backfill = any(step["tokens"] is None for rollout in train_rollouts for step in rollout["trajectory"])
+        if needs_backfill:
+            logger.info(
+                "Backfilling tokens for rollout trajectories (expected for training_mode=sft against an external teacher API)"
+            )
             await asyncio.gather(
                 *(
                     asyncio.to_thread(
-                        pretokenize_rollout_trajectory,
+                        backfill_rollout_tokens,
                         rollout,
                         tokenizer,
                         renderer=renderer,

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -482,11 +482,14 @@ async def orchestrate(config: OrchestratorConfig):
         # Convert rollouts to training samples
         parallel_preprocess_start = time.perf_counter()
 
-        # SFT-only: external teacher APIs (OpenAI/etc.) return no token IDs,
-        # so step["tokens"] is None — reconstruct via tokenizer/renderer. The
-        # vLLM-served rollout paths (RL/OPD renderer + MITO) already populate
-        # tokens via prompt_token_ids/token_ids, so the call is a no-op there.
-        if config.training_mode == "sft":
+        # We only expect to run pretokenize for SFT against an external teacher
+        # API (OpenAI/etc.), which returns no token IDs — reconstruct via
+        # tokenizer/renderer. The vLLM-served paths (RL/OPD renderer + MITO,
+        # and SFT against a local vLLM teacher) already populate tokens via
+        # prompt_token_ids/token_ids, so we short-circuit the 256-way fanout.
+        needs_pretokenize = any(step["tokens"] is None for rollout in train_rollouts for step in rollout["trajectory"])
+        if needs_pretokenize:
+            logger.info("Pretokenizing rollout trajectories (expected for SFT against an external teacher API)")
             await asyncio.gather(
                 *(
                     asyncio.to_thread(

--- a/src/prime_rl/orchestrator/trajectories.py
+++ b/src/prime_rl/orchestrator/trajectories.py
@@ -164,7 +164,7 @@ def _tokenize_step_with_renderer(
     return build_trajectory_step(renderer, prompt, completion, tools=tools)
 
 
-def pretokenize_rollout_trajectory(
+def backfill_rollout_tokens(
     output: vf.RolloutOutput,
     tokenizer: PreTrainedTokenizer,
     renderer=None,

--- a/tests/unit/orchestrator/test_sft_trajectories.py
+++ b/tests/unit/orchestrator/test_sft_trajectories.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import verifiers as vf
 
-from prime_rl.orchestrator.trajectories import interleave_rollout, pretokenize_rollout_trajectory
+from prime_rl.orchestrator.trajectories import backfill_rollout_tokens, interleave_rollout
 
 
 class SimpleChatTokenizer:
@@ -56,7 +56,7 @@ def test_interleave_rollout_missing_tokens_returns_none():
     assert interleave_rollout(output) is None
 
 
-def test_pretokenize_rollout_trajectory_for_sft():
+def test_backfill_rollout_tokens_for_sft():
     tokenizer = SimpleChatTokenizer()
     output = vf.RolloutOutput(
         example_id=42,
@@ -93,7 +93,7 @@ def test_pretokenize_rollout_trajectory_for_sft():
         error=None,
     )
 
-    pretokenize_rollout_trajectory(output, tokenizer)
+    backfill_rollout_tokens(output, tokenizer)
 
     rollouts = interleave_rollout(output)
     assert rollouts is not None


### PR DESCRIPTION
## Summary
- Skip the orchestrator's per-rollout `backfill_rollout_tokens` fanout (256-way `asyncio.to_thread`) when no step actually needs it. The pre-PR code ran the fanout every step even on the RL/OPD paths where vLLM already populates `step["tokens"]` via `prompt_token_ids` / `token_ids`, costing ~2 s of event-loop lag per step for zero work.
- Replace the per-rollout call with a single behavioral check: `needs_backfill = any(step["tokens"] is None for rollout in train_rollouts for step in rollout["trajectory"])`. Only fans out when something is actually missing.
- Log an `info` line inside the guard so it's visible when the backfill runs (expected only for `training_mode=sft` against an external teacher API — OpenAI, PI inference, etc.).
- Rename `pretokenize_rollout_trajectory` → `backfill_rollout_tokens`. The old name implied "before something"; the function is a backfill that fills in `step["tokens"]` when the rollout source didn't return token IDs.

vLLM-served paths (RL/OPD renderer + MITO, and `training_mode=sft` against a local vLLM teacher) now skip the fanout entirely. External teacher APIs return no token IDs, so `step["tokens"] is None` there and the backfill runs as needed.

## Verification
End-to-end smoke (5 steps each):

| Mode | Config | Step 0 | Step 1 | Step 2 | Step 3 | Step 4 |
|------|--------|--------|--------|--------|--------|--------|
| RL renderer | `examples/reverse_text/rl.toml` | — | 0.1124 | 0.1706 | 0.2439 | (4 ✅) |
| RL MITO | `examples/reverse_text/rl.toml --no-orchestrator.use-renderer --orchestrator.renderer.name auto` | 0.1138 | 0.1324 | 0.1457 | 0.2000 | (4 ✅) |
| SFT external | `configs/debug/training_modes/sft_external.toml` (gpt-5-mini via PI inference) | 0.9219 | 0.9304 | 0.9206 | 0.9186 | 0.9249 |

Unit tests: `uv run pytest tests/unit/orchestrator/` — all green.

Without the backfill, the SFT-external run crashes immediately:
```
WARNING Missing rollout tokens for example N step 0.     (×128 rollouts dropped)
TypeError: 'NoneType' object is not subscriptable
  at src/prime_rl/utils/monitor/wandb.py:183 in log_samples
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are a small performance/clarity tweak gated on `step["tokens"] is None`, with behavior unchanged for SFT external-teacher cases and no impact to auth/data persistence paths.
> 
> **Overview**
> Avoids the orchestrator’s per-rollout thread fanout for token reconstruction unless some trajectory steps are actually missing `tokens`, and adds an `info` log when the backfill runs.
> 
> Renames `pretokenize_rollout_trajectory` to `backfill_rollout_tokens` to reflect intent, and updates the SFT unit test accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f1533a3e18173fa381d0fa9d004590931d67a56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->