### PR TITLE
perf(transport): stream-sidecar TrainingBatch sender (routed_experts split)

### DIFF
--- a/src/prime_rl/orchestrator/event_loop_lag.py
+++ b/src/prime_rl/orchestrator/event_loop_lag.py
@@ -13,22 +13,22 @@ class EventLoopLagMonitor:
         self,
         interval: float = 1.0,
         max_window_size: int = 10000,
-        warn_med_lag_threshold: float = 0.5,
         warn_p90_lag_threshold: float = 1.0,
-        warn_max_lag_threshold: float = 5.0,
+        warn_p99_lag_threshold: float = 5.0,
+        warn_max_lag_threshold: float = 30.0,
     ):
         assert (
             interval > 0
             and max_window_size > 0
-            and warn_max_lag_threshold > 0
-            and warn_med_lag_threshold > 0
             and warn_p90_lag_threshold > 0
+            and warn_p99_lag_threshold > 0
+            and warn_max_lag_threshold > 0
         )
         self.interval = interval
         self.max_window_size = max_window_size
-        self.warn_max_lag_threshold = warn_max_lag_threshold
-        self.warn_med_lag_threshold = warn_med_lag_threshold
         self.warn_p90_lag_threshold = warn_p90_lag_threshold
+        self.warn_p99_lag_threshold = warn_p99_lag_threshold
+        self.warn_max_lag_threshold = warn_max_lag_threshold
         self.logger = get_logger()
         self.lags = []
 
@@ -61,15 +61,16 @@ class EventLoopLagMonitor:
         mean_lag = float(np.mean(last_lags))
         med_lag = float(np.median(last_lags))
         p90_lag = float(np.percentile(last_lags, 90))
+        p99_lag = float(np.percentile(last_lags, 99))
         min_lag = float(np.min(last_lags))
         max_lag = float(np.max(last_lags))
         if (
-            med_lag > self.warn_med_lag_threshold
-            or p90_lag > self.warn_p90_lag_threshold
+            p90_lag > self.warn_p90_lag_threshold
+            or p99_lag > self.warn_p99_lag_threshold
             or max_lag > self.warn_max_lag_threshold
         ):
             self.logger.warning(
-                f"Detected busy event loop. Measured {mean_lag:.1f}s (min={min_lag:.1f}s, med={med_lag:.1f}s, p90={p90_lag:.1f}s, max={max_lag:.1f}s) event loop lag over the last {len(last_lags)} measurement(s)"
+                f"Detected busy event loop. Measured {mean_lag:.1f}s (min={min_lag:.1f}s, med={med_lag:.1f}s, p90={p90_lag:.1f}s, p99={p99_lag:.1f}s, max={max_lag:.1f}s) event loop lag over the last {len(last_lags)} measurement(s)"
             )
 
         return {
@@ -77,5 +78,6 @@ class EventLoopLagMonitor:
             "event_loop_lag/mean": mean_lag,
             "event_loop_lag/med": med_lag,
             "event_loop_lag/p90": p90_lag,
+            "event_loop_lag/p99": p99_lag,
             "event_loop_lag/max": max_lag,
         }

--- a/src/prime_rl/orchestrator/event_loop_lag.py
+++ b/src/prime_rl/orchestrator/event_loop_lag.py
@@ -11,7 +11,7 @@ class EventLoopLagMonitor:
 
     def __init__(
         self,
-        interval: float = 1.0,
+        interval: float = 0.1,
         max_window_size: int = 10000,
         warn_p90_lag_threshold: float = 1.0,
         warn_p99_lag_threshold: float = 5.0,

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -482,22 +482,23 @@ async def orchestrate(config: OrchestratorConfig):
         # Convert rollouts to training samples
         parallel_preprocess_start = time.perf_counter()
 
-        # Pretokenize is a no-op when the renderer client already populated
-        # ``tokens`` on each trajectory step (renderer path); the fallback
-        # tokenizer-only branch handles text-only rollouts whose tokens
-        # were not pre-rendered. Run on threads so CPU work overlaps with
-        # inference for the next batch (via max_async_level >= 2).
-        await asyncio.gather(
-            *(
-                asyncio.to_thread(
-                    pretokenize_rollout_trajectory,
-                    rollout,
-                    tokenizer,
-                    renderer=renderer,
+        # Pretokenize on threads so CPU work overlaps with inference for the
+        # next batch. Skip the fanout entirely when every step already has
+        # ``tokens`` (renderer path) — otherwise the 256-way to_thread fires
+        # only to no-op and the GIL stampede blocks the loop.
+        needs_pretokenize = any(step["tokens"] is None for rollout in train_rollouts for step in rollout["trajectory"])
+        if needs_pretokenize:
+            await asyncio.gather(
+                *(
+                    asyncio.to_thread(
+                        pretokenize_rollout_trajectory,
+                        rollout,
+                        tokenizer,
+                        renderer=renderer,
+                    )
+                    for rollout in train_rollouts
                 )
-                for rollout in train_rollouts
             )
-        )
 
         # Process rollouts in parallel
         results = await asyncio.gather(

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -428,10 +428,10 @@ async def orchestrate(config: OrchestratorConfig):
             # Compute advantages (in-place)
             num_rollouts = len(train_rollouts)
             num_unique_examples = len({(r["env_name"], r["example_id"]) for r in train_rollouts})
-            compute_advantages(train_rollouts, config.advantage)
+            await asyncio.to_thread(compute_advantages, train_rollouts, config.advantage)
 
             # Apply rollout filters — sets rollout["filters"] and rollout["is_filtered"]
-            apply_filters(rollout_filters, train_rollouts)
+            await asyncio.to_thread(apply_filters, rollout_filters, train_rollouts)
 
             n_trainable = sum(1 for r in train_rollouts if not r["is_filtered"])
             if n_trainable > 0:
@@ -564,7 +564,7 @@ async def orchestrate(config: OrchestratorConfig):
             step=progress.step,
         )
 
-        training_batch_sender.send(training_batch)
+        await training_batch_sender.send(training_batch)
 
         step_time = time.perf_counter() - step_start_time
 
@@ -863,6 +863,9 @@ async def orchestrate(config: OrchestratorConfig):
 def main():
     """Main entry-point for orchestrator. Run using `uv run orchestrator`"""
     set_proc_title("Orchestrator")
+    import uvloop
+
+    uvloop.install()
     asyncio.run(orchestrate(cli(OrchestratorConfig)))
 
 

--- a/src/prime_rl/orchestrator/trajectories.py
+++ b/src/prime_rl/orchestrator/trajectories.py
@@ -174,6 +174,9 @@ def pretokenize_rollout_trajectory(
     When a renderer is provided, uses it for tokenization (faster, deterministic).
     Otherwise falls back to the tokenizer + apply_chat_template path.
     """
+    if all(step["tokens"] is not None for step in output["trajectory"]):
+        return True
+
     logger = get_logger()
     tools = _convert_tools_to_oai_format(output.get("tool_defs", []))
 

--- a/src/prime_rl/orchestrator/trajectories.py
+++ b/src/prime_rl/orchestrator/trajectories.py
@@ -271,6 +271,10 @@ def interleave_rollout(
             return None
         prepared_steps.append(prepared)
 
+    # Deferred routed_experts state per sample: O(N) chunk list concatenated
+    # once at finalize, replacing the prior O(N²) per-extension unpack/repack.
+    sample_routed_state: dict[int, dict[str, Any]] = {}
+
     def make_sample(tokens: dict[str, Any]) -> TrainingSample:
         """Create a new TrainingSample from a trajectory step."""
         if has_error:
@@ -278,19 +282,6 @@ def interleave_rollout(
         else:
             completion_mask = [bool(i) for i in tokens["completion_mask"]]
         completion_ids = list(tokens["completion_ids"])
-
-        routed_experts = align_routed_experts(
-            tokens.get("routed_experts"),
-            len(tokens["prompt_ids"]) + len(tokens["completion_ids"]),
-        )
-        packed_routed_experts = None
-        if routed_experts is not None:
-            routed_experts = np.ascontiguousarray(routed_experts)
-            packed_routed_experts = RoutedExperts(
-                data=routed_experts.tobytes(),
-                shape=list(routed_experts.shape),
-                dtype=str(routed_experts.dtype),
-            )
 
         prompt_ids = list(tokens["prompt_ids"])
         sample = TrainingSample(
@@ -304,16 +295,25 @@ def interleave_rollout(
             advantage=None,
             env_name=output["env_name"],
             mm_token_type_ids=None,
-            routed_experts=packed_routed_experts,
+            routed_experts=None,  # deferred — finalized at end of interleave_rollout
         )
-        return sample, routed_experts
+        # Initialize routed-experts state for this sample. First chunk is the
+        # raw step routed_experts (no pad, no copy). running_len is the
+        # cumulative count across chunks; tracked so the boundary fix-up at
+        # each extension is a no-op append rather than a destructive write.
+        step_routed = tokens.get("routed_experts")
+        if step_routed is not None:
+            sample_routed_state[id(sample)] = {
+                "chunks": [step_routed],
+                "running_len": int(step_routed.shape[0]),
+            }
+        return sample
 
     def extend_sample(
         sample: TrainingSample,
-        sample_routed_experts: np.ndarray | None,
         prefix_len: int,
         step_idx: int,
-    ) -> np.ndarray | None:
+    ) -> None:
         """Extend an existing sample with a new trajectory step (extension property holds)."""
         tokens = prepared_steps[step_idx]
 
@@ -334,35 +334,32 @@ def interleave_rollout(
         sample.completion_logprobs.extend(tokens["completion_logprobs"])
         sample.completion_temperatures.extend([temperature] * len(completion_ids))
 
-        if tokens.get("routed_experts") is not None and sample_routed_experts is not None:
-            step_routed = tokens["routed_experts"]
-            # The previous step's last routing entry was zero-padded by align_routed_experts
-            # (vLLM only captures num_tokens-1 routings per request). This step actually
-            # processed that boundary token as part of its prompt, so replace the zero-fill
-            # with the real routing decision before appending new entries.
+        step_routed = tokens.get("routed_experts")
+        state = sample_routed_state.get(id(sample))
+        if step_routed is not None and state is not None:
+            # vLLM doesn't capture a routing decision for the *last* token of any
+            # request, so the previous step left no entry for token at index
+            # (prefix_len - 1). The next step's forward pass *did* process that
+            # token (as part of its prompt) and produced step_routed[prefix_len-1].
+            # Append that single boundary entry as its own chunk, then append the
+            # genuinely new entries from this step. No prior bytes touched.
             if prefix_len > 0 and prefix_len <= step_routed.shape[0]:
-                sample_routed_experts[prefix_len - 1] = step_routed[prefix_len - 1]
-            sample_routed_experts = np.concatenate((sample_routed_experts, step_routed[prefix_len:]), axis=0)
-            expected_len = len(sample.prompt_ids) + len(sample.completion_ids)
-            sample_routed_experts = align_routed_experts(sample_routed_experts, expected_len)
-            sample_routed_experts = np.ascontiguousarray(sample_routed_experts)
-            packed_routed_experts = RoutedExperts(
-                data=sample_routed_experts.tobytes(),
-                shape=list(sample_routed_experts.shape),
-                dtype=str(sample_routed_experts.dtype),
-            )
-            sample.routed_experts = packed_routed_experts
-        return sample_routed_experts
+                boundary_chunk = step_routed[prefix_len - 1 : prefix_len]
+                state["chunks"].append(boundary_chunk)
+                state["running_len"] += 1
+            new_chunk = step_routed[prefix_len:]
+            state["chunks"].append(new_chunk)
+            state["running_len"] += int(new_chunk.shape[0])
 
     # Track (prefix_tokens, sample, step_indices) per active sample. step_indices
     # is the explicit list of prepared_steps positions merged into this sample —
     # non-contiguous when other agents' steps interleave.
-    active_samples: list[tuple[list[int], TrainingSample, list[int], np.ndarray | None]] = []
+    active_samples: list[tuple[list[int], TrainingSample, list[int]]] = []
 
     first_tokens = prepared_steps[0]
     first_prefix = first_tokens["prompt_ids"] + first_tokens["completion_ids"]
-    first_sample, first_routed_experts = make_sample(first_tokens)
-    active_samples.append((first_prefix, first_sample, [0], first_routed_experts))
+    first_sample = make_sample(first_tokens)
+    active_samples.append((first_prefix, first_sample, [0]))
 
     for step_idx, _step in enumerate(trajectory[1:], start=1):
         tokens = prepared_steps[step_idx]
@@ -370,20 +367,19 @@ def interleave_rollout(
 
         # Check if this step extends ANY active prefix
         matched_idx = None
-        for idx, (prefix_tokens, _, _, _) in enumerate(active_samples):
+        for idx, (prefix_tokens, _, _) in enumerate(active_samples):
             if step_prompt_ids[: len(prefix_tokens)] == prefix_tokens:
                 matched_idx = idx
                 break
 
         if matched_idx is not None:
             # Extension holds - merge into matched sample
-            prefix_tokens, sample, step_indices, sample_routed_experts = active_samples[matched_idx]
-            sample_routed_experts = extend_sample(sample, sample_routed_experts, len(prefix_tokens), step_idx=step_idx)
+            prefix_tokens, sample, step_indices = active_samples[matched_idx]
+            extend_sample(sample, len(prefix_tokens), step_idx=step_idx)
             active_samples[matched_idx] = (
                 tokens["prompt_ids"] + tokens["completion_ids"],
                 sample,
                 step_indices + [step_idx],
-                sample_routed_experts,
             )
         else:
             # No prefix matches - start a new sample
@@ -392,8 +388,29 @@ def interleave_rollout(
                 f"Starting new sample (active_prefixes={len(active_samples)}, step_prompt_len={len(step_prompt_ids)})."
             )
             new_prefix = tokens["prompt_ids"] + tokens["completion_ids"]
-            sample, routed_experts = make_sample(tokens)
-            active_samples.append((new_prefix, sample, [step_idx], routed_experts))
+            sample = make_sample(tokens)
+            active_samples.append((new_prefix, sample, [step_idx]))
+
+    # Finalize routed_experts for each sample. One concat per sample (O(N) byte
+    # work) replaces the previous per-step unpack/concat/repack (O(N²)). The
+    # boundary entries between steps were already inserted as one-entry chunks
+    # during extend_sample, so a straight concat is correct.
+    for _, sample, _ in active_samples:
+        state = sample_routed_state.get(id(sample))
+        if state is None:
+            continue
+        chunks = state["chunks"]
+        if not chunks:
+            continue
+        combined = np.concatenate(chunks, axis=0) if len(chunks) > 1 else np.ascontiguousarray(chunks[0])
+        expected_len = len(sample.prompt_ids) + len(sample.completion_ids)
+        combined = align_routed_experts(combined, expected_len)
+        combined = np.ascontiguousarray(combined)
+        sample.routed_experts = RoutedExperts(
+            data=combined.tobytes(),
+            shape=list(combined.shape),
+            dtype=str(combined.dtype),
+        )
 
     # Attach images by concatenating mm_items across every step the
     # sample covers. verifiers' ``state_to_output`` ships per-step
@@ -402,7 +419,7 @@ def interleave_rollout(
     # reading the last step alone would miss every earlier-turn image.
     # Concat in step order recovers the per-sample cumulative set;
     # deduping again here would drop legitimate duplicate placeholders.
-    for _, sample, step_indices, _ in active_samples:
+    for _, sample, step_indices in active_samples:
         renderer_mm = _union_step_mm_data(prepared_steps, step_indices)
         if renderer_mm is not None:
             mm_kwargs = _pack_mm_kwargs_from_renderer(renderer_mm)
@@ -417,7 +434,7 @@ def interleave_rollout(
                         for token_id in sample.prompt_ids + sample.completion_ids
                     ]
 
-    return [sample for _, sample, _, _ in active_samples]
+    return [sample for _, sample, _ in active_samples]
 
 
 def _union_step_mm_data(

--- a/src/prime_rl/orchestrator/trajectories.py
+++ b/src/prime_rl/orchestrator/trajectories.py
@@ -249,9 +249,9 @@ def interleave_rollout(
 
             return {
                 "prompt_ids": list(tokens["prompt_ids"]),
-                "prompt_mask": [bool(i) for i in tokens["prompt_mask"]],
+                "prompt_mask": list(map(bool, tokens["prompt_mask"])),
                 "completion_ids": list(tokens["completion_ids"]),
-                "completion_mask": [bool(i) for i in tokens["completion_mask"]],
+                "completion_mask": list(map(bool, tokens["completion_mask"])),
                 "completion_logprobs": list(tokens["completion_logprobs"]),
                 "routed_experts": routed_experts,
                 # Renderer-emitted multimodal sidecar (placeholders + per-item
@@ -280,13 +280,13 @@ def interleave_rollout(
         if has_error:
             completion_mask = [False] * len(tokens["completion_mask"])
         else:
-            completion_mask = [bool(i) for i in tokens["completion_mask"]]
+            completion_mask = list(tokens["completion_mask"])
         completion_ids = list(tokens["completion_ids"])
 
         prompt_ids = list(tokens["prompt_ids"])
         sample = TrainingSample(
             prompt_ids=prompt_ids,
-            prompt_mask=[bool(i) for i in tokens["prompt_mask"]],
+            prompt_mask=list(tokens["prompt_mask"]),
             completion_ids=completion_ids,
             completion_mask=completion_mask,
             completion_logprobs=list(tokens["completion_logprobs"]),
@@ -330,7 +330,7 @@ def interleave_rollout(
         if has_error:
             sample.completion_mask.extend([False] * len(tokens["completion_mask"]))
         else:
-            sample.completion_mask.extend(bool(i) for i in tokens["completion_mask"])
+            sample.completion_mask.extend(tokens["completion_mask"])
         sample.completion_logprobs.extend(tokens["completion_logprobs"])
         sample.completion_temperatures.extend([temperature] * len(completion_ids))
 

--- a/src/prime_rl/orchestrator/vf_utils.py
+++ b/src/prime_rl/orchestrator/vf_utils.py
@@ -1,7 +1,7 @@
-import json
 import logging
 from pathlib import Path
 
+import orjson
 import verifiers as vf
 from verifiers.utils.save_utils import make_serializable
 
@@ -82,11 +82,11 @@ def get_tool_response_len(output: vf.RolloutOutput) -> int:
 def save_rollouts(rollouts: list[vf.RolloutOutput], path: Path, exclude_keys: set[str] | None = None) -> None:
     """Save rollouts to a JSONL file using verifiers serialization."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w") as f:
+    opts = orjson.OPT_APPEND_NEWLINE | orjson.OPT_SERIALIZE_NUMPY
+    with open(path, "wb") as f:
         for rollout in rollouts:
             row = {k: v for k, v in rollout.items() if k not in exclude_keys} if exclude_keys else rollout
-            json.dump(row, f, default=make_serializable)
-            f.write("\n")
+            f.write(orjson.dumps(row, default=make_serializable, option=opts))
 
 
 def intercept_vf_logging(logger: str = "verifiers", level: str = "DEBUG", prefix: str | None = None):

--- a/src/prime_rl/transport/base.py
+++ b/src/prime_rl/transport/base.py
@@ -16,7 +16,7 @@ class TrainingBatchSender(ABC):
         self.output_dir = output_dir
 
     @abstractmethod
-    def send(self, batch: TrainingBatch) -> None:
+    async def send(self, batch: TrainingBatch) -> None:
         """Send a batch of training examples to the trainer(s).
 
         Args:

--- a/src/prime_rl/transport/filesystem.py
+++ b/src/prime_rl/transport/filesystem.py
@@ -1,41 +1,155 @@
 import asyncio
+import io
 from pathlib import Path
 from time import time
 
+import msgspec
+
 from prime_rl.trainer.runs import get_multi_run_manager
 from prime_rl.transport.base import MicroBatchReceiver, MicroBatchSender, TrainingBatchReceiver, TrainingBatchSender
-from prime_rl.transport.types import MicroBatch, TrainingBatch
+from prime_rl.transport.types import MicroBatch, RoutedExperts, TrainingBatch, TrainingSample
 from prime_rl.utils.pathing import get_rollout_dir, get_step_path, sync_wait_for_path
 
 BATCH_FILE_TMP_NAME = "train_rollouts.bin.tmp"
 BATCH_FILE_NAME = "train_rollouts.bin"
+SIDECAR_FILE_TMP_NAME = "train_rollouts.routed_experts.bin.tmp"
+SIDECAR_FILE_NAME = "train_rollouts.routed_experts.bin"
+FORMAT_VERSION = 2
 LOG_FREQ_SECONDS = 10
 
 
 class FileSystemTrainingBatchSender(TrainingBatchSender):
-    """Filesystem-based training batch sender that writes batches to disk."""
+    """Filesystem-based training batch sender.
+
+    Writes `train_rollouts.bin` and a `train_rollouts.routed_experts.bin` sidecar.
+    `routed_experts.data` (the bulk of the payload, ~85%) is peeled out of msgpack
+    encoding and written as a single concatenated raw-bytes blob via a threaded
+    write. Encoded TrainingSample frames are streamed one-at-a-time with
+    `await asyncio.sleep(0)` between samples so the event loop stays responsive
+    during step transitions.
+    """
 
     def __init__(self, output_dir: Path):
         super().__init__(output_dir)
         self.rollout_dir = get_rollout_dir(output_dir)
 
     async def send(self, batch: TrainingBatch) -> None:
-        """Send a batch by writing it to disk. Encode + write run in a worker
-        thread so the orch event loop stays responsive during step transitions."""
         step_path = get_step_path(self.rollout_dir, batch.step)
         step_path.mkdir(parents=True, exist_ok=True)
-        await asyncio.to_thread(self._encode_and_write, batch, step_path)
 
-    def _encode_and_write(self, batch: TrainingBatch, step_path: Path) -> None:
-        buffer = self.encoder.encode(batch)
-        tmp_path = step_path / BATCH_FILE_TMP_NAME
-        with open(tmp_path, "wb") as f:
-            f.write(buffer)
-        tmp_path.rename(step_path / BATCH_FILE_NAME)
+        offsets: list[int] = []
+        shapes: list[list[int] | None] = []
+        dtypes: list[str | None] = []
+        re_payloads: list[bytes] = []
+        running = 0
+
+        samples_buf = io.BytesIO()
+        for sample in batch.examples:
+            if sample.routed_experts is None:
+                offsets.append(-1)
+                shapes.append(None)
+                dtypes.append(None)
+                out_sample = sample
+            else:
+                re = sample.routed_experts
+                offsets.append(running)
+                shapes.append(re.shape)
+                dtypes.append(re.dtype)
+                re_payloads.append(re.data)
+                running += len(re.data)
+                out_sample = msgspec.structs.replace(
+                    sample,
+                    routed_experts=RoutedExperts(data=b"", shape=re.shape, dtype=re.dtype),
+                )
+            frame = self.encoder.encode(out_sample)
+            samples_buf.write(len(frame).to_bytes(4, "little"))
+            samples_buf.write(frame)
+            await asyncio.sleep(0)
+
+        manifest = self.encoder.encode(
+            {
+                "version": FORMAT_VERSION,
+                "format": "stream_sidecar",
+                "step": batch.step,
+                "run_idx": batch.run_idx,
+                "n_examples": len(batch.examples),
+                "offsets": offsets,
+                "shapes": shapes,
+                "dtypes": dtypes,
+                "sidecar_total_bytes": running,
+                "sidecar_filename": SIDECAR_FILE_NAME,
+            }
+        )
+
+        await asyncio.to_thread(self._write_files, step_path, manifest, samples_buf.getvalue(), re_payloads)
+
+    @staticmethod
+    def _write_files(step_path: Path, manifest: bytes, samples_buf: bytes, re_payloads: list[bytes]) -> None:
+        # Sidecar must be visible before the main file, since the receiver
+        # treats the main file's existence as the "batch is ready" signal.
+        tmp_sidecar = step_path / SIDECAR_FILE_TMP_NAME
+        with open(tmp_sidecar, "wb") as sf:
+            for p in re_payloads:
+                sf.write(p)
+        tmp_sidecar.rename(step_path / SIDECAR_FILE_NAME)
+
+        tmp_main = step_path / BATCH_FILE_TMP_NAME
+        with open(tmp_main, "wb") as mf:
+            mf.write(len(manifest).to_bytes(4, "little"))
+            mf.write(manifest)
+            mf.write(samples_buf)
+        tmp_main.rename(step_path / BATCH_FILE_NAME)
+
+
+def _decode_training_batch_from_disk(main_path: Path) -> TrainingBatch:
+    """Read a stream_sidecar v2 train_rollouts.bin + sidecar back into a TrainingBatch."""
+    with open(main_path, "rb") as f:
+        data = f.read()
+
+    cursor = 0
+    manifest_len = int.from_bytes(data[cursor : cursor + 4], "little")
+    cursor += 4
+    manifest = msgspec.msgpack.decode(data[cursor : cursor + manifest_len])
+    cursor += manifest_len
+
+    n = manifest["n_examples"]
+    samples: list[TrainingSample] = []
+    for _ in range(n):
+        frame_len = int.from_bytes(data[cursor : cursor + 4], "little")
+        cursor += 4
+        sample: TrainingSample = msgspec.msgpack.decode(data[cursor : cursor + frame_len], type=TrainingSample)
+        cursor += frame_len
+        samples.append(sample)
+
+    sidecar_path = main_path.parent / manifest["sidecar_filename"]
+    if manifest["sidecar_total_bytes"] > 0:
+        with open(sidecar_path, "rb") as sf:
+            sidecar = sf.read()
+        offsets = manifest["offsets"]
+        shapes = manifest["shapes"]
+        dtypes = manifest["dtypes"]
+        total = manifest["sidecar_total_bytes"]
+        # End of each present routed_experts payload = next present offset (or total).
+        next_present_offset = [total] * len(offsets)
+        last_end = total
+        for i in range(len(offsets) - 1, -1, -1):
+            if offsets[i] >= 0:
+                next_present_offset[i] = last_end
+                last_end = offsets[i]
+        for i, off in enumerate(offsets):
+            if off < 0:
+                continue
+            samples[i].routed_experts = RoutedExperts(
+                data=sidecar[off : next_present_offset[i]],
+                shape=shapes[i],
+                dtype=dtypes[i],
+            )
+
+    return TrainingBatch(examples=samples, step=manifest["step"], run_idx=manifest.get("run_idx"))
 
 
 class FileSystemTrainingBatchReceiver(TrainingBatchReceiver):
-    """Filesystem-based training batch receiver that reads batches from multiple run directories."""
+    """Filesystem-based training batch receiver supporting the v2 stream_sidecar format."""
 
     def __init__(self) -> None:
         super().__init__()
@@ -98,8 +212,7 @@ class FileSystemTrainingBatchReceiver(TrainingBatchReceiver):
             batch_path = self._get_batch_path(idx)
             if batch_path.exists():
                 try:
-                    with open(batch_path, "rb") as f:
-                        batch: TrainingBatch = self.decoder.decode(f.read())
+                    batch = _decode_training_batch_from_disk(batch_path)
                     batch.run_idx = idx
                     batches.append(batch)
                     # Increment received step to avoid reading the same file again

--- a/src/prime_rl/transport/filesystem.py
+++ b/src/prime_rl/transport/filesystem.py
@@ -1,3 +1,4 @@
+import asyncio
 from pathlib import Path
 from time import time
 
@@ -18,11 +19,14 @@ class FileSystemTrainingBatchSender(TrainingBatchSender):
         super().__init__(output_dir)
         self.rollout_dir = get_rollout_dir(output_dir)
 
-    def send(self, batch: TrainingBatch) -> None:
-        """Send a batch by writing it to disk"""
+    async def send(self, batch: TrainingBatch) -> None:
+        """Send a batch by writing it to disk. Encode + write run in a worker
+        thread so the orch event loop stays responsive during step transitions."""
         step_path = get_step_path(self.rollout_dir, batch.step)
         step_path.mkdir(parents=True, exist_ok=True)
+        await asyncio.to_thread(self._encode_and_write, batch, step_path)
 
+    def _encode_and_write(self, batch: TrainingBatch, step_path: Path) -> None:
         buffer = self.encoder.encode(batch)
         tmp_path = step_path / BATCH_FILE_TMP_NAME
         with open(tmp_path, "wb") as f:
@@ -87,6 +91,7 @@ class FileSystemTrainingBatchReceiver(TrainingBatchReceiver):
             self.logger.debug(f"Looking for batches in {current_paths}{waiting_suffix}")
             self._last_logged_paths = current_paths
             self._last_logged_time = now
+
         for idx in self.multi_run_manager.used_idxs:
             if self.multi_run_manager.ready_to_update[idx]:
                 continue
@@ -123,7 +128,6 @@ class FileSystemMicroBatchSender(MicroBatchSender):
 
     def send(self, micro_batch_grid: list[list[MicroBatch]]) -> None:
         """Send grid of micro batches to the trainers."""
-        # Validation
         assert len(micro_batch_grid) == self.data_world_size, "Number of micro batch lists must match data world size"
         for micro_batch_list in micro_batch_grid:
             assert len(micro_batch_list) == len(micro_batch_grid[0]), "All micro batch lists must have the same length"
@@ -152,15 +156,12 @@ class FileSystemMicroBatchReceiver(MicroBatchReceiver):
         return get_step_path(self.rollout_dir, self.current_step) / f"rank_{self.data_rank}.bin"
 
     def wait(self) -> None:
-        """Wait for the micro batch file to appear on disk."""
         sync_wait_for_path(self._get_micro_batch_path())
 
     def can_receive(self) -> bool:
-        """Check if the micro batch file exists."""
         return self._get_micro_batch_path().exists()
 
     def receive(self) -> list[MicroBatch]:
-        """Read and return the micro batches from disk."""
         with open(self._get_micro_batch_path(), "rb") as f:
             micro_batches: list[MicroBatch] = self.decoder.decode(f.read())
         self.current_step += 1

--- a/src/prime_rl/transport/zmq.py
+++ b/src/prime_rl/transport/zmq.py
@@ -32,7 +32,7 @@ class ZMQTrainingBatchSender(TrainingBatchSender):
             f"endpoint=tcp://{transport.host}:{transport.port} hwm={transport.hwm}"
         )
 
-    def send(self, batch: TrainingBatch) -> None:
+    async def send(self, batch: TrainingBatch) -> None:
         payload = self.encoder.encode(batch)
         self.logger.debug(f"Sending batch {batch.step} to {self.sender_id}")
         self.socket.send_multipart([self.sender_id, payload], copy=False)

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ conflicts = [[
 ]]
 
 [options]
-exclude-newer = "2026-05-14T14:58:09.755544055Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -5907,6 +5907,7 @@ dependencies = [
     { name = "setproctitle", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
     { name = "tenacity", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
     { name = "textual", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
+    { name = "uvloop", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (platform_machine == 'aarch64' and platform_python_implementation == 'PyPy' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'x86_64' and platform_python_implementation == 'PyPy' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
 ]
 
 [package.optional-dependencies]
@@ -6010,6 +6011,7 @@ requires-dist = [
     { name = "torch", marker = "extra == 'rl'", specifier = ">=2.8.0,<2.9.0", index = "https://download.pytorch.org/whl/cu128" },
     { name = "transformers", marker = "extra == 'rl'", git = "https://github.com/huggingface/transformers.git?rev=c1c3424" },
     { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'", specifier = ">=0.21.0" },
     { name = "vllm", marker = "platform_machine == 'aarch64' and extra == 'rl'", url = "https://github.com/vllm-project/vllm/releases/download/v0.21.0/vllm-0.21.0+cu129-cp38-abi3-manylinux_2_34_aarch64.whl" },
     { name = "vllm", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'rl'", specifier = ">=0.10.0,<0.11.0" },
     { name = "vllm", marker = "platform_machine == 'x86_64' and extra == 'rl'", url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.21.0+cu129.r42434.pr39568.a106aa6-cp38-abi3-manylinux_2_24_x86_64.whl" },


### PR DESCRIPTION
## Summary

**Draft follow-up to #2609.** Layered on top of `perf/r3-rewrite` — only the transport-side change is new. Merge or rebase this after #2609 lands; or just pick it up directly if the to_thread-only send in #2609 isn't sufficient for our largest router-replay payloads.

### What's in here (one commit)

`perf(transport): stream-sidecar TrainingBatch sender (routed_experts split)`

- Peels `routed_experts.data` out of the msgpack encode and writes it as a single raw-bytes sidecar file (`train_rollouts.routed_experts.bin`). The hot bytes (~85% of payload) skip the base64-style msgpack `bin` framing on encode and the corresponding allocation on decode.
- Streams `TrainingSample` frames one at a time with `await asyncio.sleep(0)` between, so even the encode phase yields to the event loop instead of holding it through a single big `encoder.encode(batch)` call.
- Sidecar must be visible before the main file — receiver watches the main file as the "batch is ready" signal.
- v2 file format: `4-byte manifest_len + manifest + (4-byte frame_len + sample-frame) * n`. Receiver reconstructs samples from the manifest's `offsets`/`shapes`/`dtypes` arrays.

### When to land this

Use as a fallback if #2609 alone doesn't bring step-boundary lag low enough on router-replay runs (Qwen3-30B-A3B + GLM-5.1 territory, ~25 GB routed_experts payload). For non-router-replay workloads the simpler to_thread-only send in #2609 should be sufficient.

### Risk

- New on-disk format (v2). Backward-compat would require keeping both readers around; this PR deletes the v1 reader. Old run artifacts won't be readable by this branch. Acceptable for an experimental knob; not for general release until v1 is migrated away from.
- Per-sample `await sleep(0)` is harmless but adds N loop ticks per batch (small CPU overhead, large lag reduction).
