### PR TITLE
fix: probe github ssh auth directly in install.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -130,7 +130,13 @@ main() {
   fi
 
   if ! has_ssh_access; then
-    git config url."https://github.com/".insteadOf "git@github.com:"
+    # Propagate the rewrite via env vars so it reaches `git submodule--helper clone`,
+    # which spawns fresh `git clone` processes that do not read the parent repo's
+    # local `.git/config`. Local `git config url..insteadOf` is invisible to them.
+    log_info "Routing git@github.com: SSH URLs to HTTPS for this run."
+    export GIT_CONFIG_COUNT=1
+    export GIT_CONFIG_KEY_0="url.https://github.com/.insteadOf"
+    export GIT_CONFIG_VALUE_0="git@github.com:"
   fi
 
   log_info "Initializing submodules..."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -55,9 +55,7 @@ has_ssh_access() {
   # access after authenticating), so we capture stdout/stderr to a var
   # first and grep the var. Piping directly would trigger pipefail.
   set +e
-  out=$(timeout 5s ssh -o BatchMode=yes \
-    -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-    -T git@github.com 2>&1)
+  out=$(timeout 5s ssh -o BatchMode=yes -T git@github.com 2>&1)
   echo "$out" | grep -q "successfully authenticated"
   rc=$?
   set -e

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -44,11 +44,15 @@ assert_supported_platform() {
 }
 
 has_ssh_access() {
-  # Probe SSH auth to GitHub without prompting; treat any nonzero as "no ssh"
-  # We try a quick ls-remote to avoid cloning on failure.
-  # Disable -e for the probe so the script doesn't exit on a failed test.
+  # Probe GitHub SSH auth directly. `ssh -T git@github.com` returns
+  # "successfully authenticated" only when the local key is registered
+  # with a GitHub user, which is the precondition for cloning private
+  # submodules over SSH. The previous `git ls-remote` probe could
+  # spuriously succeed (cached creds, public-repo edge cases) and
+  # leave submodule clones to fail later.
   set +e
-  timeout 5s git ls-remote --heads git@github.com:PrimeIntellect-ai/${REPO_ID}.git >/dev/null 2>&1
+  timeout 5s ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new \
+    -T git@github.com 2>&1 | grep -q "successfully authenticated"
   rc=$?
   set -e
   return $rc

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -50,9 +50,14 @@ has_ssh_access() {
   # submodules over SSH. The previous `git ls-remote` probe could
   # spuriously succeed (cached creds, public-repo edge cases) and
   # leave submodule clones to fail later.
+  #
+  # Note: ssh -T git@github.com always exits 1 (GitHub denies shell
+  # access after authenticating), so we capture stdout/stderr to a var
+  # first and grep the var. Piping directly would trigger pipefail.
   set +e
-  timeout 5s ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new \
-    -T git@github.com 2>&1 | grep -q "successfully authenticated"
+  out=$(timeout 5s ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new \
+    -T git@github.com 2>&1)
+  echo "$out" | grep -q "successfully authenticated"
   rc=$?
   set -e
   return $rc

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -55,7 +55,8 @@ has_ssh_access() {
   # access after authenticating), so we capture stdout/stderr to a var
   # first and grep the var. Piping directly would trigger pipefail.
   set +e
-  out=$(timeout 5s ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new \
+  out=$(timeout 5s ssh -o BatchMode=yes \
+    -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
     -T git@github.com 2>&1)
   echo "$out" | grep -q "successfully authenticated"
   rc=$?


### PR DESCRIPTION
The current `has_ssh_access` check in `scripts/install.sh` runs `git ls-remote` against the public prime-rl repo. That can return success under SSH connection multiplexing, cached creds, or public-repo edge cases without the local key actually being registered with a GitHub user — leaving the HTTPS `insteadOf` rewrite un-applied and private-submodule clones to fail with `Permission denied (publickey)`.

- Replace with `ssh -T git@github.com` + grep for `successfully authenticated`
- Direct check of the precondition (your key is registered) rather than an inferential probe
- Same behavior for devs with auth (uses SSH); cleaner fallback to HTTPS for shared/CI/cluster environments

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: limited to installer behavior around GitHub auth detection and URL rewriting; main risk is false negatives causing HTTPS fallback in some SSH setups.
> 
> **Overview**
> Improves `scripts/install.sh` GitHub SSH detection by replacing the `git ls-remote` probe with an explicit `ssh -T git@github.com` check (parsing output for successful auth) to avoid false positives that later break private submodule clones.
> 
> When SSH auth is unavailable, switches the SSH→HTTPS rewrite from local `git config url.*.insteadOf` to `GIT_CONFIG_COUNT/KEY/VALUE` environment overrides so the mapping applies to submodule clone processes as well.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2aebf153df8835f8164c9a2e949f4cedf1fb7864. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->