### PR TITLE
chore(configs): router replay perf repro

### DIFF
--- a/configs/r3_perf/debug.toml
+++ b/configs/r3_perf/debug.toml
@@ -1,6 +1,6 @@
 max_steps = 20
 seq_len = 65536
-output_dir = "/beegfs/outputs/qwen30b-rlm-router-replay-debug-perf-r3-v9"
+output_dir = "/beegfs/mika/r3-lag-repro"
 
 [log]
 level = "debug"

--- a/configs/r3_perf/debug.toml
+++ b/configs/r3_perf/debug.toml
@@ -103,5 +103,4 @@ gpu_memory_utilization = 0.85
 tp = 8
 
 [inference.model]
-name = "Qwen/Qwen3-30B-A3B-Thinking-2507"
 max_model_len = 65536

--- a/configs/r3_perf/debug.toml
+++ b/configs/r3_perf/debug.toml
@@ -79,11 +79,6 @@ temperature = 1.0
 extra_headers_from_state = { "X-Session-ID" = "trajectory_id" }
 
 [orchestrator.wandb.log_extras]
-# R3: disable per-step sample logging — wandb.log({"samples": Table, ...}) is
-# not thread-safe (no internal locks, mutates singleton run state) and the
-# json_dump_safer pass for ~256 long completions blocks the orch loop for
-# 4-40s per step. Disabling so we get a clean lag profile of the rest of the
-# stack. Re-enable with `interval = 25` or larger if observability needed.
 samples = false
 interval = 25
 

--- a/configs/r3_perf/debug.toml
+++ b/configs/r3_perf/debug.toml
@@ -74,9 +74,6 @@ name = "qwen3"
 [orchestrator.train.sampling]
 temperature = 1.0
 
-[orchestrator.client]
-extra_headers_from_state = { "X-Session-ID" = "trajectory_id" }
-
 [orchestrator.wandb.log_extras]
 samples = false
 interval = 25

--- a/configs/r3_perf/debug.toml
+++ b/configs/r3_perf/debug.toml
@@ -69,25 +69,7 @@ batch_size = 256
 rollouts_per_example = 8
 max_inflight_rollouts = 1024
 max_off_policy_steps = 16
-use_token_client = false
 use_renderer = true
-# Round 4: O(N²)→O(N) routed_experts concat in interleave_rollout makes the
-# threaded path strictly better than the process pool (no IPC pickle cost,
-# orders of magnitude less memcpy per rollout). Keep process pool off.
-use_process_pool = false
-# Round 5: dump raw rollouts so the offline replay harness can attribute
-# the residual orch step-boundary stall to specific phases. Produces ~6 GB
-# per step under router replay; pair with per-phase timing logs.
-# v9: off — already have step_0-9 dumps from v5/v8 for offline iteration,
-# and the 30 GB/step writes were a strong suspect for the growing
-# max-lag spikes in v8 (10s -> 32s across steps 5-10).
-dump_raw_rollouts = false
-# Round 6: chunk the interleave_rollout gather to give the main asyncio loop
-# guaranteed slices between to_thread waves. Offline bench: chunk=128 cut max
-# loop lag 2.6x (387ms -> 149ms) under simulated prod traffic for ~11%
-# wallclock cost. Sweet spot — chunk<=64 didn't help lag further and cost
-# much more wall time.
-gather_chunk_size = 128
 
 [orchestrator.renderer]
 name = "qwen3"

--- a/configs/r3_perf/debug.toml
+++ b/configs/r3_perf/debug.toml
@@ -106,4 +106,3 @@ tp = 8
 [inference.model]
 name = "Qwen/Qwen3-30B-A3B-Thinking-2507"
 max_model_len = 65536
-tool_call_parser = "hermes"

--- a/configs/r3_perf/debug.toml
+++ b/configs/r3_perf/debug.toml
@@ -1,4 +1,4 @@
-max_steps = 10000000
+max_steps = 20
 seq_len = 65536
 max_async_level = 1
 output_dir = "/beegfs/outputs/qwen30b-rlm-router-replay-debug-perf-r3-v9"

--- a/configs/r3_perf/debug.toml
+++ b/configs/r3_perf/debug.toml
@@ -8,7 +8,7 @@ level = "debug"
 
 [wandb]
 project = "RLM-Qwen30B-debug"
-name = "RLM-Qwen30B-router-replay-debug-perf-r3-v7"
+name = "r3-lag-repro"
 
 [model]
 name = "Qwen/Qwen3-30B-A3B-Thinking-2507"
@@ -24,10 +24,9 @@ type = "multi_node"
 num_train_nodes = 2
 num_infer_nodes = 1
 num_infer_replicas = 4
-gpus_per_node = 8
 
 [slurm]
-job_name = "qwen30b-rlm-debug"
+job_name = "r3-lag-repro"
 partition = "cluster"
 
 [ckpt]

--- a/configs/r3_perf/debug.toml
+++ b/configs/r3_perf/debug.toml
@@ -1,6 +1,5 @@
 max_steps = 20
 seq_len = 65536
-max_async_level = 1
 output_dir = "/beegfs/outputs/qwen30b-rlm-router-replay-debug-perf-r3-v9"
 
 [log]

--- a/configs/r3_perf/debug.toml
+++ b/configs/r3_perf/debug.toml
@@ -1,0 +1,143 @@
+max_steps = 10000000
+seq_len = 65536
+max_async_level = 1
+output_dir = "/beegfs/outputs/qwen30b-rlm-router-replay-debug-perf-r3-v9"
+
+[log]
+level = "debug"
+
+[wandb]
+project = "RLM-Qwen30B-debug"
+name = "RLM-Qwen30B-router-replay-debug-perf-r3-v7"
+
+[model]
+name = "Qwen/Qwen3-30B-A3B-Thinking-2507"
+
+[weight_broadcast]
+type = "nccl"
+port = 29502
+timeout = 12000
+quantize_in_weight_transfer = false
+
+[deployment]
+type = "multi_node"
+num_train_nodes = 2
+num_infer_nodes = 1
+num_infer_replicas = 4
+gpus_per_node = 8
+
+[slurm]
+job_name = "qwen30b-rlm-debug"
+partition = "cluster"
+
+[ckpt]
+interval = 100
+keep_last = 1
+resume_step = -1
+
+[trainer]
+dist_timeout_seconds = 1800
+enable_router_replay = true
+
+[trainer.model]
+impl = "custom"
+attn = "flash_attention_3"
+fused_lm_head_token_chunk_size = 1024
+ep = 8
+
+[trainer.model.ac]
+freq = 1
+
+[trainer.model.compile]
+
+[trainer.model.ac_offloading]
+max_inflight_activations = 1
+
+[trainer.ckpt]
+skip_gather_master_weights = true
+skip_optimizer = true
+
+[trainer.optim]
+type = "adamw"
+lr = 1e-6
+weight_decay = 0.0
+
+[trainer.experimental.token_export]
+
+[orchestrator]
+batch_size = 256
+rollouts_per_example = 8
+max_inflight_rollouts = 1024
+max_off_policy_steps = 16
+use_token_client = false
+use_renderer = true
+# Round 4: O(N²)→O(N) routed_experts concat in interleave_rollout makes the
+# threaded path strictly better than the process pool (no IPC pickle cost,
+# orders of magnitude less memcpy per rollout). Keep process pool off.
+use_process_pool = false
+# Round 5: dump raw rollouts so the offline replay harness can attribute
+# the residual orch step-boundary stall to specific phases. Produces ~6 GB
+# per step under router replay; pair with per-phase timing logs.
+# v9: off — already have step_0-9 dumps from v5/v8 for offline iteration,
+# and the 30 GB/step writes were a strong suspect for the growing
+# max-lag spikes in v8 (10s -> 32s across steps 5-10).
+dump_raw_rollouts = false
+# Round 6: chunk the interleave_rollout gather to give the main asyncio loop
+# guaranteed slices between to_thread waves. Offline bench: chunk=128 cut max
+# loop lag 2.6x (387ms -> 149ms) under simulated prod traffic for ~11%
+# wallclock cost. Sweet spot — chunk<=64 didn't help lag further and cost
+# much more wall time.
+gather_chunk_size = 128
+
+[orchestrator.renderer]
+name = "qwen3"
+
+[orchestrator.train.sampling]
+temperature = 1.0
+
+[orchestrator.client]
+extra_headers_from_state = { "X-Session-ID" = "trajectory_id" }
+
+[orchestrator.wandb.log_extras]
+# R3: disable per-step sample logging — wandb.log({"samples": Table, ...}) is
+# not thread-safe (no internal locks, mutates singleton run state) and the
+# json_dump_safer pass for ~256 long completions blocks the orch loop for
+# 4-40s per step. Disabling so we get a clean lag profile of the rest of the
+# stack. Re-enable with `interval = 25` or larger if observability needed.
+samples = false
+interval = 25
+
+[orchestrator.prime_monitor]
+
+[[orchestrator.train.env]]
+id = "general-agent-solver-local"
+name = "general-agent-local-low"
+num_workers = 4
+ratio = 1.0
+
+[orchestrator.train.env.args]
+min_tier = 4
+max_turns = 100
+timeout_seconds = 3600.0
+
+[orchestrator.advantage]
+type = "default"
+
+[orchestrator.buffer]
+online_difficulty_filtering = false
+
+[orchestrator.eval]
+env = []
+
+[inference]
+enable_return_routed_experts = true
+enable_expert_parallel = true
+gpu_memory_utilization = 0.85
+
+[inference.parallel]
+tp = 8
+
+[inference.model]
+name = "Qwen/Qwen3-30B-A3B-Thinking-2507"
+max_model_len = 65536
+tool_call_parser = "hermes"

--- a/configs/r3_perf/debug.toml
+++ b/configs/r3_perf/debug.toml
@@ -68,7 +68,6 @@ batch_size = 256
 rollouts_per_example = 8
 max_inflight_rollouts = 1024
 max_off_policy_steps = 16
-use_renderer = true
 
 [orchestrator.renderer]
 name = "qwen3"

--- a/configs/r3_perf/debug.toml
+++ b/configs/r3_perf/debug.toml
@@ -87,22 +87,13 @@ interval = 25
 [[orchestrator.train.env]]
 id = "general-agent-solver-local"
 name = "general-agent-local-low"
-num_workers = 4
+num_workers = 16
 ratio = 1.0
 
 [orchestrator.train.env.args]
 min_tier = 4
 max_turns = 100
 timeout_seconds = 3600.0
-
-[orchestrator.advantage]
-type = "default"
-
-[orchestrator.buffer]
-online_difficulty_filtering = false
-
-[orchestrator.eval]
-env = []
 
 [inference]
 enable_return_routed_experts = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ envs = [
     "code-env",
     "color-codeword",
     "deepdive",
+    "general-agent",
     "gpqa",
     "hle",
     "ifeval",
@@ -137,6 +138,7 @@ members = [
     "deps/research-environments/environments/code_env",
     "deps/research-environments/environments/color_codeword",
     "deps/research-environments/environments/deepdive",
+    "deps/research-environments/environments/general_agent",
     "deps/research-environments/environments/gpqa",
     "deps/research-environments/environments/hle",
     "deps/research-environments/environments/ifeval",
@@ -203,6 +205,7 @@ alphabet-sort = { workspace = true }
 code-env = { workspace = true }
 color-codeword = { workspace = true }
 deepdive = { workspace = true }
+general-agent = { workspace = true }
 gpqa = { workspace = true }
 hle = { workspace = true }
 ifeval = { workspace = true }

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ conflicts = [[
 ]]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-05-17T02:30:24.553303027Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -41,6 +41,7 @@ members = [
     "code-env",
     "color-codeword",
     "deepdive",
+    "general-agent",
     "gpqa",
     "hle",
     "ifeval",
@@ -1521,6 +1522,38 @@ wheels = [
 http = [
     { name = "aiohttp", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
 ]
+
+[[package]]
+name = "general-agent"
+version = "0.1.0"
+source = { editable = "deps/research-environments/environments/general_agent" }
+dependencies = [
+    { name = "mcp", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
+    { name = "tyro", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
+    { name = "verifiers", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "ruff", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
+    { name = "ty", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
+]
+test = [
+    { name = "pytest", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
+    { name = "pytest-asyncio", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "mcp", specifier = ">=1.0" },
+    { name = "pytest", marker = "extra == 'test'" },
+    { name = "pytest-asyncio", marker = "extra == 'test'" },
+    { name = "ruff", marker = "extra == 'dev'" },
+    { name = "ty", marker = "extra == 'dev'" },
+    { name = "tyro", specifier = ">=0.9" },
+    { name = "verifiers", specifier = ">=0.1.15.dev2" },
+]
+provides-extras = ["dev", "test"]
 
 [[package]]
 name = "gepa"
@@ -3951,6 +3984,7 @@ envs = [
     { name = "code-env", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
     { name = "color-codeword", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
     { name = "deepdive", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
+    { name = "general-agent", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
     { name = "gpqa", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
     { name = "hle", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
     { name = "ifeval", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
@@ -4019,6 +4053,7 @@ requires-dist = [
     { name = "flash-attn-3", marker = "extra == 'flash-attn-3'", index = "https://download.pytorch.org/whl/test/cu128" },
     { name = "flash-attn-4", marker = "extra == 'flash-attn-cute'", git = "https://github.com/Dao-AILab/flash-attention.git?subdirectory=flash_attn%2Fcute&rev=96bd151" },
     { name = "flash-linear-attention", git = "https://github.com/fla-org/flash-linear-attention" },
+    { name = "general-agent", marker = "extra == 'envs'", editable = "deps/research-environments/environments/general_agent" },
     { name = "gpqa", marker = "extra == 'envs'", editable = "deps/research-environments/environments/gpqa" },
     { name = "hle", marker = "extra == 'envs'", editable = "deps/research-environments/environments/hle" },
     { name = "ifeval", marker = "extra == 'envs'", editable = "deps/research-environments/environments/ifeval" },


### PR DESCRIPTION
## Summary
- Adds `configs/r3_perf/debug.toml`, the repro config used to investigate the R3 orchestrator event-loop lag on Qwen3-30B-A3B with router replay (2 train / 1 infer / 4 replicas).
- Pairs with #2609 (perf(orchestrator): reduce event-loop lag) for reproducing the residual step-boundary stall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)