### PR TITLE
docs: fix stale slurm config examples and references

### DIFF
--- a/docs/slurm.md
+++ b/docs/slurm.md
@@ -8,16 +8,14 @@ The `rl`, `sft`, and `inference` entrypoints all have built-in SLURM support. Ad
 # Local run
 uv run rl @ examples/reverse_text/rl.toml
 
-# SLURM run (same entrypoint, just add [slurm] to the config)
-uv run rl @ examples/reverse_text/slurm_rl.toml
+# SLURM run — overlay slurm_rl.toml on top of the base config
+uv run rl @ examples/reverse_text/rl.toml @ examples/reverse_text/slurm_rl.toml
 ```
 
-The SLURM config is a thin overlay that inherits from a base config and adds `[slurm]` + `[deployment]` sections:
+The SLURM config is a thin overlay that adds `[slurm]` (and optionally `[deployment]`) on top of a base config. Configs are composed left-to-right via the `@` CLI syntax — see [`configs.md`](configs.md) for details.
 
 ```toml
 # examples/reverse_text/slurm_rl.toml
-toml_files = ["rl.toml"]
-
 output_dir = "outputs/reverse-text-rl"
 
 [slurm]
@@ -140,10 +138,10 @@ freq = 1
 batch_size = 512
 group_size = 16
 
-[orchestrator.sampling]
-max_tokens = 2048
+[orchestrator.train.sampling]
+max_completion_tokens = 2048
 
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "math-env"
 name = "hendrycks-math"
 args = { dataset_name = "PrimeIntellect/Hendrycks-Math", dataset_subset = "default" }
@@ -153,7 +151,7 @@ tp = 4
 dp = 2
 ```
 
-See [`examples/hendrycks_math/rl.toml`](../examples/hendrycks_math/rl.toml) for the full example.
+See [`examples/multinode/rl.toml`](../examples/multinode/rl.toml) for the full example.
 
 ---
 
@@ -202,7 +200,7 @@ batch_size = 128
 seq_len = 8192
 ```
 
-See [`examples/hendrycks_math/sft.toml`](../examples/hendrycks_math/sft.toml) for the full example.
+See [`examples/multinode/sft.toml`](../examples/multinode/sft.toml) for the full example.
 
 ---
 
@@ -213,6 +211,7 @@ See [`examples/hendrycks_math/sft.toml`](../examples/hendrycks_math/sft.toml) fo
 Run a vLLM server on a single allocated node:
 
 ```toml
+# my_inference.toml
 output_dir = "/shared/outputs/my-inference"
 
 [model]
@@ -226,7 +225,7 @@ job_name = "my-inference"
 ```
 
 ```bash
-uv run inference @ inference_slurm.toml
+uv run inference @ my_inference.toml
 ```
 
 ### Multi-node SLURM
@@ -255,10 +254,10 @@ After submission, the SLURM template prints the inference URLs for all nodes (on
 
 ### Dry run
 
-Use `dry_run = true` to generate the sbatch script without submitting:
+Use `--dry-run` (or `dry_run = true` in TOML) to generate the sbatch script without submitting:
 
 ```bash
-uv run inference @ config.toml --dry-run true
+uv run inference @ config.toml --dry-run
 ```
 
 ---

--- a/examples/hendrycks_sanity/README.md
+++ b/examples/hendrycks_sanity/README.md
@@ -19,7 +19,7 @@ uv run rl @ examples/hendrycks_sanity/rl.toml \
 Or schedule the same training via SLURM
 
 ```bash
-uv run rl @ examples/hendrycks_sanity/slurm_rl.toml \
+uv run rl @ examples/hendrycks_sanity/rl.toml @ examples/hendrycks_sanity/slurm_rl.toml \
   --wandb.project your-project \
   --wandb.name your-run
 ```

--- a/examples/wiki_search/README.md
+++ b/examples/wiki_search/README.md
@@ -155,7 +155,7 @@ The wiki-search environment supports several configuration options:
 You can pass these via the `--env-args` flag in `vf-eval` or configure them in your `rl.toml`:
 
 ```toml
-[[orchestrator.env]]
+[[orchestrator.train.env]]
 id = "primeintellect/wiki-search"
 args = { max_turns = 5, judge_model = "gpt-4.1" }
 ```


### PR DESCRIPTION
## Summary
- Drop bogus `toml_files = [...]` syntax from `docs/slurm.md` (not a pydantic-config feature) and document the real `@ base.toml @ overlay.toml` composition. Update the quick-start command — it was invoking the overlay alone, which fails validation.
- Update the multi-node example in `docs/slurm.md` to current schema: `[orchestrator.sampling]` → `[orchestrator.train.sampling]`, `[[orchestrator.env]]` → `[[orchestrator.train.env]]`, `max_tokens` → `max_completion_tokens`.
- Repoint "See full example" links from non-existent `examples/hendrycks_math/{rl,sft}.toml` to the real `examples/multinode/{rl,sft}.toml`.
- Fix the inference doc: invented `inference_slurm.toml` filename and a `--dry-run true` flag form that doesn't work — bare `--dry-run` is correct.
- `examples/hendrycks_sanity/README.md`: the SLURM command was running the overlay alone; now composes base + overlay.
- `examples/wiki_search/README.md`: stale `[[orchestrator.env]]` path.

## Verification
Before: `uv run rl @ examples/hendrycks_sanity/slurm_rl.toml --dry-run` fails with `--trainer Field required / --orchestrator Field required`.

After: `uv run rl @ examples/hendrycks_sanity/rl.toml @ examples/hendrycks_sanity/slurm_rl.toml --dry-run` succeeds. Dry-runs pass for all 7 example slurm overlays (`alphabet_sort`, `wordle` rl+sft, `reverse_text` rl+sft, `hendrycks_sanity`, `wiki_search`) and for both `examples/multinode/{rl,sft}.toml`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only changes that update CLI/config examples; no runtime code or behavior is modified.
> 
> **Overview**
> Updates SLURM docs/examples to reflect *actual config composition* via `@ base.toml @ overlay.toml` and removes the unsupported `toml_files = [...]` pattern.
> 
> Refreshes multi-node config snippets and READMEs to match the current schema (e.g., `orchestrator.train.*`, `max_completion_tokens`) and fixes stale file references/commands (e.g., inference config filename and `--dry-run` usage).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 985b00eed6b0818e75d27cc2b06e47ebc415b784. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->