### PR TITLE
chore(ci): auto-publish ghcr image on push to main

### DIFF
--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -1,6 +1,8 @@
 name: Build Image (ghcr)
 
 on:
+  push:
+    branches: [main]
   release:
     types: [published]
   workflow_dispatch:


### PR DESCRIPTION
Adds `push: branches: [main]` to `build_image.yaml` so GHCR gets a fresh `:main` + `:commit-<sha>` on every main commit, matching what `docker-push.yaml` already does for Hub.

- Existing triggers (`release: published`, `workflow_dispatch`) unchanged.
- `BUILD_REF` resolves to `github.ref_name` = `main`, which is in the prepare job's allowlist.
- `BUILD_PLATFORMS` defaults to `both` on push, so the manifest job runs and produces a multi-arch index.

Needed so the platform's dispatch-time digest resolver can pin to a current digest off GHCR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only extends when an existing publish workflow runs; no application, auth, or data-path changes.
> 
> **Overview**
> **CI now publishes GHCR images on every push to `main`.**
> 
> The `build_image.yaml` workflow gains a `push` trigger for the `main` branch. **Release** and **manual** `workflow_dispatch` behavior is unchanged. On a main push, `BUILD_REF` becomes `main` (allowed by the prepare job), and `BUILD_PLATFORMS` defaults to `both`, so the existing multi-arch build and manifest steps still run—yielding fresh `:main` and `:commit-<sha>` tags on GHCR for digest pinning elsewhere in the platform.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5479069a46ee19668783c263846e07031d4a660. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->