### PR TITLE
[codex] fix orchestrator routed experts memory retention

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -14,6 +14,7 @@ from prime_rl.orchestrator.inference_metrics import InferenceMetricsCollector
 from prime_rl.orchestrator.patches import monkey_patch_chat_completion_logprobs, monkey_patch_oai_iterable_types
 from prime_rl.orchestrator.trajectories import (
     backfill_rollout_tokens,
+    clear_rollout_routed_experts,
     interleave_rollout,
     offload_images_to_disk,
 )
@@ -512,6 +513,7 @@ async def orchestrate(config: OrchestratorConfig):
                 for r in train_rollouts
             )
         )
+        clear_rollout_routed_experts(train_rollouts)
 
         # Collect results and assign advantages. Metrics are computed over all
         # rollouts; only non-filtered samples are sent to the trainer.
@@ -542,6 +544,7 @@ async def orchestrate(config: OrchestratorConfig):
             rollout_decode_lens.append(rollout_decode_tokens)
             num_prefill_tokens += rollout_prefill_tokens
             num_decode_tokens += rollout_decode_tokens
+        del results
 
         parallel_preprocess_time = time.perf_counter() - parallel_preprocess_start
         logger.debug(
@@ -774,7 +777,7 @@ async def orchestrate(config: OrchestratorConfig):
 
         # Free large per-step objects to prevent memory accumulation
         del train_rollouts, train_examples, training_batch
-        del results_df, metrics_df
+        del results_df, metrics_df, filter_df, timing_df
         gc.collect()
         # Return free glibc heap pages to the OS. numpy/pandas allocate array data
         # via malloc (outside Python's allocator), so gc.collect() alone doesn't

--- a/src/prime_rl/orchestrator/trajectories.py
+++ b/src/prime_rl/orchestrator/trajectories.py
@@ -440,6 +440,15 @@ def interleave_rollout(
     return [sample for _, sample, _ in active_samples]
 
 
+def clear_rollout_routed_experts(rollouts: list[vf.RolloutOutput]) -> None:
+    """Drop routed-experts sidecars after they have been packed into samples."""
+    for rollout in rollouts:
+        for step in rollout.get("trajectory", []):
+            tokens = step.get("tokens")
+            if tokens is not None:
+                tokens["routed_experts"] = None
+
+
 def _union_step_mm_data(
     prepared_steps: list[dict[str, Any]],
     step_indices: list[int],


### PR DESCRIPTION
## Summary

Fixes bounded routed-experts memory retention in the orchestrator step loop.

The routed replay path copies each rollout's `tokens["routed_experts"]` payload into `TrainingSample.routed_experts`, but the original rollout sidecars stayed attached to `train_rollouts` until end-of-step cleanup. The `results` list from `interleave_rollout(...)` also kept packed samples alive after the orchestrator had already extracted `train_examples`.

This change:
- clears routed-expert sidecars from rollout trajectories after conversion into training samples
- deletes the intermediate `results` list once samples have been extracted
- includes `filter_df` and `timing_df` in the explicit per-step cleanup before `malloc_trim(0)`

This reduces per-step RSS retention and peak memory in router replay runs. It does not claim to fix every possible monotonic production leak; ZMQ backpressure and monitor futures remain separate things to inspect if RSS still slopes upward.

## Validation

- `uv run pytest tests/unit/orchestrator/test_trajectories.py tests/unit/orchestrator/test_batch.py -q`
- `uv run ruff check src/prime_rl/orchestrator/orchestrator.py src/prime_rl/orchestrator/trajectories.py`
- `uv run ruff format --check src/prime_rl/orchestrator/orchestrator.py src/prime_rl/orchestrator/trajectories.py`
- synthetic RSS probe comparing pre-patch-like retention vs patched cleanup:
  - pre-patch-like retained about `+53.3 MB` after cleanup for the probe payload
  - patched cleanup returned to baseline (`+0.0 MB` mean over baseline)
