### PR TITLE
chore: only require ghcr approval once per build

### DIFF
--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -194,7 +194,6 @@ jobs:
     name: Create multi-arch manifest
     needs: [prepare, build]
     if: needs.prepare.outputs.platforms == 'both'
-    environment: ghcr-publish
     runs-on: ubuntu-latest
     permissions:
       packages: write


### PR DESCRIPTION
Drop `environment: ghcr-publish` from the `manifest` job — it was requiring a second admin approval after `build` was already approved.

- `manifest` only runs `docker buildx imagetools create` against the `-amd64` / `-arm64` tags `build` already published. No new content.
- `build` keeps the gate, so an admin still has to approve every publish.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change; publish approval stays on build, manifest only assembles existing digests.
> 
> **Overview**
> Removes the **`ghcr-publish`** environment from the **`manifest`** job in **`build_image.yaml`**, so multi-arch manifest creation no longer triggers a **second** GitHub Environment approval after **`build`** has already been approved.
> 
> **`build`** still uses **`ghcr-publish`**, so every real image push to GHCR remains gated once. **`manifest`** only runs **`docker buildx imagetools create`** to point the unified tags at the **`-amd64`** / **`-arm64`** images **`build`** already published.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9d67e3815eb3a0b06b73f8573c834721ff350dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->