### PR TITLE
[codex] Handle token export mkdir race

### DIFF
--- a/src/prime_rl/trainer/rl/token_export.py
+++ b/src/prime_rl/trainer/rl/token_export.py
@@ -88,7 +88,11 @@ class TokenExporter:
         self._current_step = step
         self._sequences_this_step = 0
         step_dir = self.output_dir / f"step_{step}"
-        step_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            step_dir.mkdir(parents=True, exist_ok=True)
+        except FileExistsError:
+            if not step_dir.is_dir():
+                raise
         self._file = (step_dir / f"rank_{self.rank}.jsonl").open("w", encoding="utf-8")
 
     def _write(self, record: dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary
- handle transient `FileExistsError` from token export step-directory creation
- keep the logic inline and minimal: re-raise when the path is not a directory

## Root Cause
Multiple trainer ranks can create the same `token_exports/step_N` directory concurrently. On shared filesystems, one rank can see `FileExistsError` even though another rank just created the directory. In that case we should continue if the path is now a directory.

## Validation
- `uv run ruff check /tmp/prime-rl-token-export-pr/src/prime_rl/trainer/rl/token_export.py` from the research-prod checkout
- `python -m py_compile /tmp/prime-rl-token-export-pr/src/prime_rl/trainer/rl/token_export.py`

Cherry-picked and simplified from prod commit `5ee18c884bec295c77bfe6d9d276197985b01a38`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow filesystem edge-case handling in experimental token export; no auth, data model, or training logic changes.
> 
> **Overview**
> **Token export** step directories (`token_exports/step_N`) are now created with a small race guard: if `mkdir` raises `FileExistsError` because another rank already created the path, the exporter continues when that path is a directory and still re-raises when something else occupies the name.
> 
> This targets multi-rank RL training on shared filesystems where concurrent `mkdir` calls were failing spuriously.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39fe321756adf90ea048fa49f8b473d098a61900. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->