### PR TITLE
chore: gitignore .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vscode/*
 .claude/scheduled_tasks.lock
+.claude/worktrees/
 *.ipynb
 *.jsonl
 configs/endpoints.py


### PR DESCRIPTION
## Summary
- Ignore the `.claude/worktrees/` directory used locally by Claude/Cursor for agent worktrees so it stops showing up in `git status`.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates ignore rules; no runtime or application code changes.
> 
> **Overview**
> Adds `.claude/worktrees/` to `.gitignore` so local Claude/Cursor agent worktrees no longer appear as untracked files in `git status`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d074c0ae372b84c9033dbba744de3317d628cc35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->