### PR TITLE
fix(sft): sync validation iteration to prevent FSDP deadlock

### DIFF
--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -292,12 +292,11 @@ def train(config: SFTConfig):
         # otherwise the first rank to exit deadlocks the rest in the next all-gather.
         # Sync per batch and exit together as soon as any rank exhausts its iterator.
         data_iter = iter(data_iter)
-        has_data = torch.ones((), dtype=torch.int32, device="cuda")
 
         with torch.no_grad():
             while True:
                 micro_batch = next(data_iter, None)
-                has_data.fill_(micro_batch is not None)
+                has_data = torch.tensor(micro_batch is not None, dtype=torch.int32, device="cuda")
                 dist.all_reduce(has_data, op=dist.ReduceOp.MIN)
                 if has_data.item() == 0:
                     break

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -287,8 +287,20 @@ def train(config: SFTConfig):
         total_token_count = torch.tensor(0, dtype=torch.int64, device="cuda")
         nan_count = torch.tensor(0, device="cuda")
 
+        # Variable-length packing yields different per-rank batch counts. Under FSDP
+        # every forward is a collective, so all ranks must agree on when to stop —
+        # otherwise the first rank to exit deadlocks the rest in the next all-gather.
+        # Sync per batch and exit together as soon as any rank exhausts its iterator.
+        data_iter = iter(data_iter)
+        has_data = torch.ones((), dtype=torch.int32, device="cuda")
+
         with torch.no_grad():
-            for micro_batch in data_iter:
+            while True:
+                micro_batch = next(data_iter, None)
+                has_data.fill_(micro_batch is not None)
+                dist.all_reduce(has_data, op=dist.ReduceOp.MIN)
+                if has_data.item() == 0:
+                    break
                 loss_sum, token_count = compute_loss(micro_batch)
                 if not torch.isnan(loss_sum.detach()):
                     total_loss_sum += loss_sum.detach()


### PR DESCRIPTION
## Summary

- Fix #2515: SFT validation deadlocks with FSDP when ranks see different numbers of variable-length packed batches.
- Coordinate exit from `run_eval_loop` with a per-batch `all_reduce(has_data, MIN)` so every rank stops on the same iteration. Any rank exhausting its dataloader pulls the rest out together; the post-loop loss / token / NaN reductions then run in lockstep.

## Why

Under FSDP, each forward is a collective (param all-gather on the dp_shard group). `run_eval_loop` iterates the val dataloader to exhaustion (`max_epochs=1`), but `CatDataset` drops the trailing partial chunk so per-rank batch counts diverge for variable-length data. The first rank out reaches the post-loop `all_reduce(total_loss_sum)` while others are still inside an FSDP all-gather → NCCL watchdog timeout.

## Verification

Minimal 2-GPU repro on `PrimeIntellect/Reverse-Text-SFT` (`seq_len=100`, `shuffle=true`, `seed=0` gives rank 0: 327 batches, rank 1: 338 batches):

```toml
max_steps = 1
dist_timeout_seconds = 60

[model]
name = "PrimeIntellect/Qwen3-0.6B"

[data]
type = "fake"
batch_size = 2
seq_len = 1024

[val]
interval = 100
eval_on_start = true

[val.data]
type = "sft"
name = "PrimeIntellect/Reverse-Text-SFT"
seq_len = 100
batch_size = 4
micro_batch_size = 1
pack_function = "cat"
shuffle = true
seed = 0
```

```bash
CUDA_VISIBLE_DEVICES=0,1 uv run sft @ repro.toml --deployment.num-gpus 2 --no-wandb
```

Before — NCCL watchdog timeout at `run_eval_loop` post-loop `all_reduce`:

```
[rank0]:[E... ProcessGroupNCCL.cpp:689] [Rank 0] Watchdog caught collective operation timeout: WorkNCCL(SeqNum=9581, OpType=ALLREDUCE, ...) ran for 60016 milliseconds before timing out.
#0 all_reduce from torch/distributed/distributed_c10d.py:3068
#2 run_eval_loop from src/prime_rl/trainer/sft/train.py:299
#3 run_validation from src/prime_rl/trainer/sft/train.py:318
```

After:

```
SUCCESS  Validation | Step 0 | Loss: 6.3760
SUCCESS  SFT trainer finished!
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to validation-only loop coordination; no auth, data, or training-step logic changes.
> 
> **Overview**
> Fixes **FSDP validation deadlocks** when variable-length `cat` packing gives different micro-batch counts per rank (e.g. trailing partial chunks dropped unevenly).
> 
> `run_eval_loop` no longer assumes every rank can iterate the val loader the same number of times. Each iteration, ranks **`all_reduce` a `has_data` flag with `MIN`** so the loop stops together as soon as any rank exhausts its iterator, keeping every validation forward (and thus FSDP collectives) aligned before the final loss/token/NaN reductions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e140a7fd8dcaa70676da0031d361cd1107bcc37f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->