### PR TITLE
feat: basic verifiers v1 training

### DIFF
--- a/configs/debug/reverse_text_v1.toml
+++ b/configs/debug/reverse_text_v1.toml
@@ -1,0 +1,31 @@
+max_steps = 20
+seq_len = 2048
+
+[model]
+name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
+
+[wandb]
+project = "reverse-text"
+name = "reverse-text-v1"
+
+[orchestrator]
+batch_size = 128
+group_size = 16
+
+[orchestrator.train.sampling]
+max_completion_tokens = 128
+
+[[orchestrator.train.env]]
+id = "reverse-text"
+args = { v1 = true }
+
+[trainer.optim]
+lr = 3e-6
+
+[ckpt] # Checkpoint at the end of training
+
+[inference]
+
+# Model not in MODEL_RENDERER_MAP — opt into DefaultRenderer (apply_chat_template).
+[orchestrator.renderer]
+name = "default"

--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -20,7 +20,7 @@ from prime_rl.utils.logger import ProgressTracker, get_logger
 from prime_rl.utils.monitor import get_monitor
 from prime_rl.utils.utils import capitalize
 
-REQUIRED_STATE_COLUMNS = ["trajectory", "sampling_args"]
+REQUIRED_STATE_COLUMNS = ["trajectory"]
 
 
 class Env:

--- a/src/prime_rl/orchestrator/train_sink.py
+++ b/src/prime_rl/orchestrator/train_sink.py
@@ -203,13 +203,17 @@ class TrainSink:
         assign_advantages(survivors, self.advantage_fn)
 
         # Propagate to the pre-tokenized samples so the orchestrator can
-        # collect samples at ship time without re-walking rollouts
+        # collect samples at ship time without re-walking rollouts. The env
+        # has a single sampling temperature; fan it out across each sample's
+        # completion tokens here (interleave leaves it empty).
+        temperature = env.sampling_args["temperature"]
         for r in survivors:
             for sample in r.samples:
                 sample.advantage = r.advantage
                 sample.reward = r.reward
                 sample.env_name = r.env_name
                 sample.training_mode = self.config.training_mode
+                sample.completion_temperatures = [temperature] * len(sample.completion_ids)
 
         if self.pre_filters:
             apply_filters(self.pre_filters, survivors)

--- a/src/prime_rl/orchestrator/trajectories.py
+++ b/src/prime_rl/orchestrator/trajectories.py
@@ -238,8 +238,6 @@ def interleave_rollout(
         return None
 
     has_error = output["error"] is not None
-    # this field should be guaranteed because we set temperature in get_sampling_args
-    temperature = output["sampling_args"]["temperature"]
 
     def prepare_step_tokens(step: vf.TrajectoryStep, step_idx: int) -> dict[str, Any] | None:
         tokens = step["tokens"]
@@ -304,7 +302,7 @@ def interleave_rollout(
             completion_ids=completion_ids,
             completion_mask=completion_mask,
             completion_logprobs=list(tokens["completion_logprobs"]),
-            completion_temperatures=[temperature] * len(completion_ids),
+            completion_temperatures=[],
             teacher_logprobs=None,
             advantage=None,
             env_name=env_name,
@@ -377,7 +375,6 @@ def interleave_rollout(
         sample.completion_ids.extend(new_prompt_ids)
         sample.completion_mask.extend([False] * len(new_prompt_ids))
         sample.completion_logprobs.extend([0.0] * len(new_prompt_ids))
-        sample.completion_temperatures.extend([temperature] * len(new_prompt_ids))
 
         # Extend with new completion tokens
         completion_ids = tokens["completion_ids"]
@@ -387,7 +384,6 @@ def interleave_rollout(
         else:
             sample.completion_mask.extend(tokens["completion_mask"])
         sample.completion_logprobs.extend(tokens["completion_logprobs"])
-        sample.completion_temperatures.extend([temperature] * len(completion_ids))
 
         step_routed = tokens.get("routed_experts")
         state = sample_routed_state.get(id(sample))

--- a/tests/unit/orchestrator/test_trajectories.py
+++ b/tests/unit/orchestrator/test_trajectories.py
@@ -349,7 +349,7 @@ def test_branching_equivalent_multi_step_trajectory(multi_step_trajectory_extens
     assert rollout.completion_ids == [3, 4]
     assert rollout.completion_mask == [True, True]
     assert rollout.completion_logprobs == [-0.1, -0.2]
-    assert rollout.completion_temperatures == [1.0, 1.0]
+    assert rollout.completion_temperatures == []
 
     # second step
     rollout = rollouts[1]
@@ -358,7 +358,7 @@ def test_branching_equivalent_multi_step_trajectory(multi_step_trajectory_extens
     assert rollout.completion_ids == [7, 8]
     assert rollout.completion_mask == [True, True]
     assert rollout.completion_logprobs == [-0.3, -0.4]
-    assert rollout.completion_temperatures == [1.0, 1.0]
+    assert rollout.completion_temperatures == []
 
 
 def test_branching_equivalent_multi_step_trajectory_with_tool_calls(
@@ -376,7 +376,7 @@ def test_branching_equivalent_multi_step_trajectory_with_tool_calls(
     assert rollout.completion_ids == [3, 4]
     assert rollout.completion_mask == [True, True]
     assert rollout.completion_logprobs == [-0.1, -0.2]
-    assert rollout.completion_temperatures == [1.0, 1.0]
+    assert rollout.completion_temperatures == []
 
     # second step
     rollout = rollouts[1]
@@ -385,7 +385,7 @@ def test_branching_equivalent_multi_step_trajectory_with_tool_calls(
     assert rollout.completion_ids == [7, 8]
     assert rollout.completion_mask == [True, True]
     assert rollout.completion_logprobs == [-0.3, -0.4]
-    assert rollout.completion_temperatures == [1.0, 1.0]
+    assert rollout.completion_temperatures == []
 
 
 def test_interleave_rollout_single_step_trajectory(single_step_trajectory_output):
@@ -400,7 +400,7 @@ def test_interleave_rollout_single_step_trajectory(single_step_trajectory_output
     assert rollout.completion_ids == [3, 4]
     assert rollout.completion_mask == [True, True]
     assert rollout.completion_logprobs == [-0.1, -0.2]
-    assert rollout.completion_temperatures == [1.0, 1.0]
+    assert rollout.completion_temperatures == []
     assert rollout.env_name == "test-env"
 
 
@@ -415,8 +415,8 @@ def test_interleave_rollout_multi_step_trajectory(multi_step_trajectory_output):
     assert rollout.completion_ids == [3, 4, 5, 6, 7, 8]
     assert rollout.completion_mask == [True, True, False, False, True, True]
     assert rollout.completion_logprobs == [-0.1, -0.2, 0, 0, -0.3, -0.4]
-    # Temperatures: 2 completion tokens at temp 1.0, then 2 prompt tokens at temp 1.0, then 2 completion tokens at temp 1.0
-    assert rollout.completion_temperatures == [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+    # ``completion_temperatures`` is filled by the orchestrator post-interleave; empty here.
+    assert rollout.completion_temperatures == []
 
 
 def test_interleave_rollout_multi_step_trajectory_with_tool_calls(multi_step_trajectory_with_tool_calls_output):
@@ -430,8 +430,8 @@ def test_interleave_rollout_multi_step_trajectory_with_tool_calls(multi_step_tra
     assert rollout.completion_ids == [3, 4, 5, 6, 7, 8]
     assert rollout.completion_mask == [True, True, False, False, True, True]
     assert rollout.completion_logprobs == [-0.1, -0.2, 0, 0, -0.3, -0.4]
-    # Temperatures: 2 completion tokens at temp 1.0, then 2 prompt tokens at temp 1.0, then 2 completion tokens at temp 1.0
-    assert rollout.completion_temperatures == [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+    # ``completion_temperatures`` is filled by the orchestrator post-interleave; empty here.
+    assert rollout.completion_temperatures == []
 
 
 @pytest.fixture
@@ -952,9 +952,9 @@ def test_interleave_rollout_error_masks_all_false():
     # Extension holds so tokens merge, but ALL completion_mask should be False
     assert rollout.completion_ids == [3, 4, 5, 6, 7, 8]
     assert rollout.completion_mask == [False, False, False, False, False, False]
-    # Logprobs and temperatures still present
+    # Logprobs preserved; ``completion_temperatures`` is filled by the orchestrator post-interleave.
     assert rollout.completion_logprobs == [-0.1, -0.2, 0.0, 0.0, -0.3, -0.4]
-    assert rollout.completion_temperatures == [0.8] * 6
+    assert rollout.completion_temperatures == []
 
 
 def test_align_routed_experts_none():


### PR DESCRIPTION
## Summary

Experiment branch for the verifiers v1 path on prime-rl, scoped down to **basic reverse_text training**. Built on top of `main`, which now carries the orchestrator v2 overlap train/eval refactor ([#2639](https://github.com/PrimeIntellect-ai/prime-rl/pull/2639)), the bump to latest verifiers (`e1d4f259`, v0.1.15.dev18), and the editable-install restructure ([#2684](https://github.com/PrimeIntellect-ai/prime-rl/pull/2684)) that lets `uv sync --all-extras` resolve cleanly against latest verifiers. The net change this branch adds on top of `main` is:

- **Add `configs/debug/reverse_text_v1.toml`** — minimal 2-GPU smoke config that mirrors the v0 `examples/reverse_text/rl.toml` exactly, differing only by `args = { v1 = true }` on the env (and a v1-distinguishing wandb name).
- **Temperature plumbing refactor** so the v1 path works under orch v2 (see below).

> Note: latest verifiers `main` (post [#1396](https://github.com/PrimeIntellect-ai/verifiers/pull/1396), NeMo Gym) declares mutually-exclusive `nemogym`/`openenv` extras, which broke `uv sync --all-extras` while verifiers was a workspace member. `main`'s [#2684](https://github.com/PrimeIntellect-ai/prime-rl/pull/2684) (submodules → editable installs) resolves that; merging it in is why this branch no longer needs to carry its own verifiers pin or `uv.lock` churn.

## Temperature plumbing refactor

Supersedes [#2669](https://github.com/PrimeIntellect-ai/prime-rl/pull/2669) — same fan-out fix, but applied to the orch v2 `TrainSink.process_group` instead of the pre-v2 orchestrator post-process loop (that PR was a hotfix onto `v0.5.1.dev256`).

Single env-wide temperature per rollout — assume the config surface (one `[orchestrator.train.env.sampling]` block per env), drop the env → orchestrator → trainer round-trip via `output["sampling_args"]`:

- Drop `sampling_args` from `REQUIRED_STATE_COLUMNS`. The orchestrator already knows each env's temperature from its `TrainEnv.sampling_args`, so there's no reason to require envs to mirror it back through state. This also unblocks v1 envs, which route `sampling_args` through `state["runtime"]` and don't surface it at the top level.
- `interleave_rollout` no longer reads `output["sampling_args"]["temperature"]` or fills `completion_temperatures`; it leaves the field empty.
- `TrainSink.process_group` fans the env's scalar temperature out across each sample's completion tokens in the same loop that stamps `advantage` / `reward` / `env_name` / `training_mode`, before the batch is assembled.

`TrainingSample` / `TrainingBatch` wire format is unchanged. Trainer-side per-token temperature scaling (`scaled_logits = logits / temps`) keeps working as-is.

## Verification

**v0 vs v1 reverse_text RL** — same config (`examples/reverse_text/rl.toml`, `Qwen3-0.6B-Reverse-Text-SFT`, 20 steps, 2× RTX PRO 6000), toggling only `args = { v1 = true }` on the env. Both ran end-to-end with no errors (100% trainable, clean `Orchestrator finished`), and the reward curves track within run-to-run sampling noise:

| step | 0 | 3 | 6 | 9 | 12 | 15 | 19 |
|---|---|---|---|---|---|---|---|
| v0 reward | 0.178 | 0.360 | 0.714 | 0.734 | 0.748 | 0.734 | 0.799 |
| v1 reward | 0.173 | 0.341 | 0.743 | 0.707 | 0.755 | 0.708 | 0.782 |

Final-5-step mean reward: **v0 = 0.7719, v1 = 0.7614** (~1.4% apart); max per-step difference 0.106. Both show the same shape: flat ~0.15 for steps 0–2, sharp climb over steps 3–6, plateau ~0.75–0.80.

Other checks:
- `uv run rl @ configs/debug/reverse_text_v1.toml --dry-run` — resolves cleanly.
- `uv run pytest tests/unit -m "not gpu"` — 427 passed, 65 deselected (`test_trajectories.py` assertions updated: `completion_temperatures` is filled by the `TrainSink` post-interleave, not by `interleave_rollout`).
- `uv sync --all-extras --locked` / `uv lock --check` — resolve cleanly against latest verifiers (via the [#2684](https://github.com/PrimeIntellect-ai/prime-rl/pull/2684) editable-install restructure).

## Notes

- Scope intentionally limited to reverse_text. The earlier wikispeedia / general-agent / alphabet_sort smoke configs (and the wikispeedia `research-environments` bump + `pyproject` workspace entry) have been dropped from this branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes training-sample metadata plumbing (temperature source) on the orchestrator path; low blast radius but affects RL loss scaling if misconfigured.
> 
> **Overview**
> Adds **`configs/debug/reverse_text_v1.toml`**, a minimal 2-GPU smoke config for **verifiers v1** reverse-text RL (`args = { v1 = true }`, default renderer).
> 
> **Sampling temperature** no longer flows through rollout state: `REQUIRED_STATE_COLUMNS` drops `sampling_args` (v1 envs keep temperature under `state["runtime"]` only). **`interleave_rollout`** leaves `completion_temperatures` empty; **`TrainSink.process_group`** fans `env.sampling_args["temperature"]` across each completion token when stamping advantage/reward. Trainer wire format is unchanged.
> 
> Unit tests now expect empty temperatures from interleave alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8f24625c45060ff28bd61baddecdb3d09b77e8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->