### PR TITLE
fix(rl-config): round-trip materialized RLConfig; deprecate wandb.shared

### DIFF
--- a/configs/nemotron_4node/rl.toml
+++ b/configs/nemotron_4node/rl.toml
@@ -18,7 +18,6 @@ level = "debug"
 [wandb]
 project = "sami_debug_nemotron"
 name = "nemotron-120b-math"
-shared = true
 
 [weight_broadcast]
 type = "nccl"

--- a/configs/nemotron_debug/rl.toml
+++ b/configs/nemotron_debug/rl.toml
@@ -17,7 +17,6 @@ level = "debug"
 [wandb]
 project = "nemotron_sami_debug"
 name = "nemotron-120b-math"
-shared = true
 
 [weight_broadcast]
 type = "nccl"

--- a/docs/training.md
+++ b/docs/training.md
@@ -291,7 +291,7 @@ uv run rl @ rl.toml --wandb                               # default project, ran
 uv run rl @ rl.toml --wandb.project my-proj --wandb.name run-42
 ```
 
-By default (`wandb.shared = true`) the trainer and orchestrator log into a **single shared W&B run**, so all metrics from both processes land in one place. Set `wandb.shared = false` (or pass `--no-wandb.shared`) to fall back to the legacy split — two runs suffixed `-trainer` and `-orchestrator`. Shared mode requires the W&B SDK ≥ 0.19.9 and is incompatible with `wandb.offline = true`.
+The trainer and orchestrator log into a **single shared W&B run**, so all metrics from both processes land in one place. Shared mode requires the W&B SDK ≥ 0.19.9 and is incompatible with `wandb.offline = true`. The legacy split (two runs suffixed `-trainer` and `-orchestrator`, gated on `wandb.shared = false`) has been removed; the `shared` field is accepted but ignored with a deprecation warning.
 
 By default, every 10 steps each process also logs a sample of prompts/completions (with rewards and advantages) and reward/advantage/entropy distributions as W&B tables. Tune via `--wandb.log-extras.interval` and `--wandb.log-extras.sample-ratio`, or disable subsets:
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -74,15 +74,36 @@ class SharedWandbConfig(BaseConfig):
     """W&B tags attached to the run."""
 
     offline: bool | None = False
-    """Run W&B in offline mode."""
+    """Run W&B in offline mode. Incompatible with shared mode, which is always on for the ``rl`` entrypoint."""
 
-    shared: bool = True
-    """Log trainer and orchestrator metrics to a single shared W&B run. Requires wandb SDK ≥ 0.19.9. Incompatible with offline mode."""
+    @model_validator(mode="before")
+    @classmethod
+    def deprecate_shared_field(cls, data: Any) -> Any:
+        """``wandb.shared`` is deprecated. The ``rl`` entrypoint now always uses
+        shared W&B mode (single run for trainer + orchestrator); the legacy split
+        with ``-trainer`` / ``-orchestrator`` suffixes is gone. Drop the field
+        from input dicts with a warning so older configs keep loading.
+        """
+        if isinstance(data, dict) and "shared" in data:
+            warnings.warn(
+                "wandb.shared is deprecated and will be removed in a future release. "
+                "The rl entrypoint always uses shared W&B mode now; remove this field "
+                "from your config.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            data.pop("shared", None)
+        return data
 
     @model_validator(mode="after")
-    def validate_shared_not_offline(self):
-        if self.shared and self.offline:
-            raise ValueError("W&B shared mode requires server connectivity and is incompatible with offline mode")
+    def validate_not_offline(self):
+        if self.offline:
+            raise ValueError(
+                "W&B shared mode is always on for the rl entrypoint and requires server "
+                "connectivity; wandb.offline = true is not supported. Use offline mode "
+                "via the sub-config wandb blocks (trainer.wandb.offline, "
+                "orchestrator.wandb.offline) if you really need it per-process."
+            )
         return self
 
 

--- a/packages/prime-rl-configs/src/prime_rl/utils/validation.py
+++ b/packages/prime-rl-configs/src/prime_rl/utils/validation.py
@@ -96,30 +96,15 @@ def propagate_shared_fields(data: Any) -> Any:
     propagate("ckpt.keep_interval", "trainer.ckpt.keep_interval", "orchestrator.ckpt.keep_interval")
 
     # [wandb] leaves. (Bare empty ``[wandb]`` block enablement is at the end.)
+    # ``wandb.name`` flows verbatim to both sub-configs — shared W&B mode is
+    # always on for the rl entrypoint, so the legacy ``-trainer`` /
+    # ``-orchestrator`` suffix split is gone.
     propagate("wandb.project", "trainer.wandb.project", "orchestrator.wandb.project")
     propagate("wandb.entity", "trainer.wandb.entity", "orchestrator.wandb.entity")
+    propagate("wandb.name", "trainer.wandb.name", "orchestrator.wandb.name")
     propagate("wandb.group", "trainer.wandb.group", "orchestrator.wandb.group")
     propagate("wandb.tags", "trainer.wandb.tags", "orchestrator.wandb.tags")
     propagate("wandb.offline", "trainer.wandb.offline", "orchestrator.wandb.offline")
-
-    # wandb.name: in non-shared mode the two sub-configs get distinct
-    # ``-trainer`` / ``-orchestrator`` suffixes so the W&B runs are
-    # distinguishable. ``OrchestratorConfig.auto_setup_prime_monitor_run_name``
-    # then defaults prime_monitor.run_name to the (unsuffixed) value.
-    # Conflicts are reported against the *transformed* sub-config value, not
-    # the raw shared name, so the materialized config round-trips cleanly.
-    wandb_name = get("wandb.name")
-    if wandb_name is not None:
-        non_shared = get("wandb.shared") is False
-        expected = {
-            "trainer.wandb.name": f"{wandb_name}-trainer" if non_shared else wandb_name,
-            "orchestrator.wandb.name": f"{wandb_name}-orchestrator" if non_shared else wandb_name,
-        }
-        for sub, expected_value in expected.items():
-            sub_value = get(sub)
-            if sub_value is not None and sub_value != expected_value:
-                conflicts.append(("wandb.name", sub))
-            fill(sub, expected_value)
 
     # [tokenizer]. ``chat_template`` also flows to ``inference.model`` (vLLM's
     # ``--chat-template``); ``name`` and ``trust_remote_code`` can legitimately

--- a/packages/prime-rl-configs/src/prime_rl/utils/validation.py
+++ b/packages/prime-rl-configs/src/prime_rl/utils/validation.py
@@ -15,10 +15,13 @@ def propagate_shared_fields(data: Any) -> Any:
     Behaviour:
       - **Fill-if-absent**: an explicit sub-config value is never overwritten.
         The shared block acts as a default, not a stomper.
-      - **Up-front mutex**: setting the same field at both the shared and
-        sub-config level raises. Under fill-if-absent the sub would silently
-        win, and any later CLI override of the shared field would invisibly
-        no-op.
+      - **Consistency mutex**: setting the same field at both the shared and
+        sub-config level only raises when the values *disagree*. Matching
+        values are accepted as a harmless no-op so that the materialized
+        config (``model_dump`` writes both copies) round-trips through re-load.
+        The original footgun the mutex was designed to catch — a sub-config
+        value silently winning over a later CLI shared override — is still
+        caught because that scenario produces *different* values.
       - **Aliased sub-paths**: ``orchestrator.model.*`` is checked against its
         ``orchestrator.student.model.*`` alias (and vice versa), so the
         conflict fires regardless of which spelling the user wrote.
@@ -49,14 +52,17 @@ def propagate_shared_fields(data: Any) -> Any:
     conflicts: list[tuple[str, str]] = []
 
     def propagate(shared_path: str, *targets: str, aliases: tuple[str, ...] = ()) -> None:
-        """Verbatim shared → targets. Records overlap (incl. alias spellings)
-        into ``conflicts`` and fills each target if the shared value is set.
+        """Verbatim shared → targets. Records *disagreeing* overlap (incl. alias
+        spellings) into ``conflicts`` and fills each target if the shared value
+        is set. Matching values are silently accepted so the materialized
+        config round-trips through re-load.
         """
         value = get(shared_path)
         if value is None:
             return
         for sub in (*targets, *aliases):
-            if get(sub) is not None:
+            sub_value = get(sub)
+            if sub_value is not None and sub_value != value:
                 conflicts.append((shared_path, sub))
         for target in targets:
             fill(target, value)
@@ -100,14 +106,20 @@ def propagate_shared_fields(data: Any) -> Any:
     # ``-trainer`` / ``-orchestrator`` suffixes so the W&B runs are
     # distinguishable. ``OrchestratorConfig.auto_setup_prime_monitor_run_name``
     # then defaults prime_monitor.run_name to the (unsuffixed) value.
+    # Conflicts are reported against the *transformed* sub-config value, not
+    # the raw shared name, so the materialized config round-trips cleanly.
     wandb_name = get("wandb.name")
     if wandb_name is not None:
-        for sub in ("trainer.wandb.name", "orchestrator.wandb.name"):
-            if get(sub) is not None:
-                conflicts.append(("wandb.name", sub))
         non_shared = get("wandb.shared") is False
-        fill("trainer.wandb.name", f"{wandb_name}-trainer" if non_shared else wandb_name)
-        fill("orchestrator.wandb.name", f"{wandb_name}-orchestrator" if non_shared else wandb_name)
+        expected = {
+            "trainer.wandb.name": f"{wandb_name}-trainer" if non_shared else wandb_name,
+            "orchestrator.wandb.name": f"{wandb_name}-orchestrator" if non_shared else wandb_name,
+        }
+        for sub, expected_value in expected.items():
+            sub_value = get(sub)
+            if sub_value is not None and sub_value != expected_value:
+                conflicts.append(("wandb.name", sub))
+            fill(sub, expected_value)
 
     # [tokenizer]. ``chat_template`` also flows to ``inference.model`` (vLLM's
     # ``--chat-template``); ``name`` and ``trust_remote_code`` can legitimately
@@ -132,13 +144,19 @@ def propagate_shared_fields(data: Any) -> Any:
 
     # output_dir: orchestrator gets a ``/run_default`` subdir so trainer +
     # orchestrator nest under the same experiment root without colliding.
+    # Conflicts are reported against the *transformed* sub-config value, not
+    # the raw shared path, so the materialized config round-trips cleanly.
     output_dir = get("output_dir")
     if output_dir is not None:
-        for sub in ("trainer.output_dir", "orchestrator.output_dir"):
-            if get(sub) is not None:
+        expected = {
+            "trainer.output_dir": output_dir,
+            "orchestrator.output_dir": f"{output_dir}/run_default",
+        }
+        for sub, expected_value in expected.items():
+            sub_value = get(sub)
+            if sub_value is not None and sub_value != expected_value:
                 conflicts.append(("output_dir", sub))
-        fill("trainer.output_dir", output_dir)
-        fill("orchestrator.output_dir", f"{output_dir}/run_default")
+            fill(sub, expected_value)
 
     # Cascade trainer.tokenizer.chat_template → inference.model.chat_template
     # (vLLM ``--chat-template``). Read trainer's value *after* the shared

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -107,11 +107,13 @@ def rl_local(config: RLConfig):
     logger.info("Starting RL run")
     logger.debug(f"RL start command: {' '.join(start_command)}")
 
-    # Build shared W&B env vars for subprocesses
-    wandb_shared_env: dict[str, str] = {}
-    if config.wandb and config.wandb.shared:
-        wandb_shared_env["WANDB_SHARED_MODE"] = "1"
-        wandb_shared_env["WANDB_SHARED_RUN_ID"] = os.environ.get("WANDB_SHARED_RUN_ID", uuid.uuid4().hex)
+    # Build shared W&B env vars for subprocesses. Shared mode is always on for
+    # the rl entrypoint — trainer and orchestrator log to a single W&B run.
+    # The monitor short-circuits when WANDB_MODE=disabled/offline is also set.
+    wandb_shared_env: dict[str, str] = {
+        "WANDB_SHARED_MODE": "1",
+        "WANDB_SHARED_RUN_ID": os.environ.get("WANDB_SHARED_RUN_ID", uuid.uuid4().hex),
+    }
 
     # Validate client port matches inference server port
     if config.inference is not None and not config.orchestrator.student.client.is_elastic:
@@ -378,7 +380,6 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
             if config.inference.kv_cache_offload
             else 0,
             use_nccl_broadcast=config.weight_broadcast is not None and config.weight_broadcast.type == "nccl",
-            wandb_shared=config.wandb is not None and config.wandb.shared,
             ranks_filter=",".join(map(str, config.trainer.log.ranks_filter)),
         )
     else:
@@ -401,7 +402,6 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
             dp_per_node=(config.deployment.gpus_per_node // config.inference.parallel.tp) if config.inference else 1,
             kv_offload=config.inference is not None and config.inference.kv_cache_offload is not None,
             use_nccl_broadcast=config.weight_broadcast is not None and config.weight_broadcast.type == "nccl",
-            wandb_shared=config.wandb is not None and config.wandb.shared,
             ranks_filter=",".join(map(str, config.trainer.log.ranks_filter)),
         )
 

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -72,10 +72,8 @@ export PYTHONUNBUFFERED=1
 export OMP_NUM_THREADS=1
 export TRITON_CACHE_DIR=/tmp/triton-cache-$USER-$SLURM_JOB_ID
 
-{% if wandb_shared -%}
 export WANDB_SHARED_MODE=1
 export WANDB_SHARED_RUN_ID=$(python3 -c "import uuid; print(uuid.uuid4().hex)")
-{%- endif %}
 
 # Networking
 HOSTNAMES=( $( scontrol show hostnames $SLURM_JOB_NODELIST ) )
@@ -384,7 +382,7 @@ else
         ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --student.client.base-url $INFER_URLS"
         ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --student.client.admin-base-url $ADMIN_URLS"
         {% if use_nccl_broadcast %}ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --weight_broadcast.host $MASTER_ADDR"
-        {% endif %}{% if wandb_shared %}WANDB_SHARED_LABEL=orchestrator {% endif %}uv run orchestrator $ORCHESTRATOR_ARGS \
+        {% endif %}WANDB_SHARED_LABEL=orchestrator uv run orchestrator $ORCHESTRATOR_ARGS \
             2>&1 | tee $OUTPUT_DIR/logs/orchestrator.log &
     fi
 {%- else %}
@@ -398,7 +396,7 @@ else
 
     echo $HOSTNAMES_STR | tee $OUTPUT_DIR/logs/trainer/node_${TRAIN_NODE_RANK}.log
 
-    {% if wandb_shared %}WANDB_SHARED_LABEL=trainer {% endif %}uv run torchrun \
+    WANDB_SHARED_LABEL=trainer uv run torchrun \
         --role=trainer \
         --nnodes=$NUM_TRAIN_NODES \
         --nproc-per-node=$GPUS_PER_NODE \

--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -61,10 +61,7 @@ class WandbMonitor(Monitor):
                 x_primary=primary,
                 x_update_finish_state=primary,
             )
-            self.logger.info(
-                f"Using shared W&B mode ({label=}, {primary=}). "
-                "This is an experimental feature. Disable with --wandb.shared False"
-            )
+            self.logger.info(f"Using shared W&B mode ({label=}, {primary=})")
         else:
             run_id = None
             primary = False

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -381,19 +381,19 @@ def test_trainer_chat_template_cascades_to_inference():
 
 
 def test_shared_wandb_fields_propagate_to_subconfigs():
-    """Every ``SharedWandbConfig`` leaf (project, entity, group, tags, offline)
-    propagates to both trainer.wandb and orchestrator.wandb, not just project
-    and offline. Regression for a miss in the inline propagator."""
+    """Every ``SharedWandbConfig`` leaf (project, entity, name, group, tags,
+    offline) propagates to both trainer.wandb and orchestrator.wandb. Regression
+    for a miss in the inline propagator."""
     config = RLConfig.model_validate(
         {
             "model": {"name": "Qwen/Qwen3-0.6B"},
             "wandb": {
                 "project": "shared-proj",
                 "entity": "shared-entity",
+                "name": "shared-name",
                 "group": "shared-group",
                 "tags": ["a", "b"],
-                "shared": False,
-                "offline": True,
+                "offline": False,
             },
             "trainer": {},
             "orchestrator": {"renderer": None},
@@ -403,9 +403,10 @@ def test_shared_wandb_fields_propagate_to_subconfigs():
         assert component is not None
         assert component.project == "shared-proj"
         assert component.entity == "shared-entity"
+        assert component.name == "shared-name"
         assert component.group == "shared-group"
         assert component.tags == ["a", "b"]
-        assert component.offline is True
+        assert component.offline is False
 
 
 def test_empty_shared_ckpt_block_does_not_conflict_with_subconfig_ckpt():


### PR DESCRIPTION
## Summary

Two related fixes for the RL config plumbing, separated as two commits so each can be reviewed independently:

1. **Soft mutex in `propagate_shared_fields` (`f44c3cd0`)** — the immediate bug.
2. **Deprecate `wandb.shared` and hardcode shared W&B mode (`718c89ef`)** — removes the only non-symmetric (besides `output_dir`) propagation in the validator and the matching launcher branches.

### 1. Soft mutex — round-trip the materialized config

The single-node SLURM launcher (``rl_slurm`` for ``deployment.type == "single_node"``) dumps the fully-resolved ``RLConfig`` to ``<output_dir>/configs/rl.toml`` and the sbatch script re-runs ``uv run rl @ rl.toml``. ``propagate_shared_fields`` writes both shared keys (``output_dir``, ``wandb.project``, …) *and* the matching sub-config keys (``trainer.output_dir``, ``orchestrator.wandb.project``, …) during the first-load propagation; ``model_dump`` preserves both. On re-load the ``if sub_set: conflict`` check fired even though both keys had the same value — treating a no-op round-trip as ambiguity:

```
Shared config conflicts with matching sub-config field(s)...
 - ['model.name'] is set, but ['trainer.model.name'] is also set
 - ['wandb.project'] is set, but ['trainer.wandb.project'] is also set
 ...
```

Tighten the check to ``if sub_set and sub != shared_value``: genuine conflicts still raise (a CLI-shared override silently no-opping against an inconsistent sub-config value still surfaces), but matching values are accepted so the materialized config re-loads cleanly. ``output_dir`` and ``wandb.name`` (pre-deprecation, see commit 2) compare against their *transformed* sub-config values (``output_dir`` against ``f"{shared}/run_default"`` for the orchestrator, ``wandb.name`` against ``-trainer``/``-orchestrator`` suffixes in non-shared mode).

### 2. Deprecate non-shared W&B mode

Shared W&B mode (one run for trainer + orchestrator) has been the default on the ``rl`` entrypoint since #1330 and is the only mode anyone uses. The non-shared fallback (``wandb.shared = false`` → two runs suffixed ``-trainer`` / ``-orchestrator``) was the reason the validator's ``wandb.name`` propagation needed custom asymmetric ``expected`` / conflict-against-transformed-value logic.

Drop the non-shared path:

- ``SharedWandbConfig.shared`` is removed from the schema. A ``mode="before"`` validator pops the field from input dicts with a ``FutureWarning`` so existing configs that still set ``shared = true`` (or ``false``) keep loading.
- ``validate_shared_not_offline`` becomes ``validate_not_offline``: ``wandb.offline = true`` at the shared level is rejected because shared mode is always on and needs server connectivity. The escape hatch is to set ``offline`` per sub-config (``[trainer.wandb] offline = true``, ``[orchestrator.wandb] offline = true``).
- ``propagate_shared_fields`` collapses the ``wandb.name`` block into a plain ``propagate("wandb.name", "trainer.wandb.name", "orchestrator.wandb.name")``. Only ``output_dir`` still needs a custom block (the asymmetric ``/run_default`` suffix).
- ``rl_local`` always sets ``WANDB_SHARED_MODE`` / ``WANDB_SHARED_RUN_ID`` for subprocesses.
- ``multi_node_rl.sbatch.j2`` drops the ``{% if wandb_shared %}`` gates; the ``wandb_shared`` template variable is removed.
- Configs that still set ``shared = true`` (``configs/nemotron_debug``, ``configs/nemotron_4node``) are cleaned up.
- Docs + the runtime info log are updated.

## Verification

End-to-end on the ``hendrycks-sanity`` example for all three RL deployments:

- **Local (no SLURM)** — ``uv run rl @ examples/hendrycks_sanity/rl.toml --dry-run`` writes sub-configs cleanly.
- **SLURM single-node** — submitted job 21919 from the materialized ``rl.toml``. Job started, mutex did not fire, all three subprocesses (inference, orchestrator, trainer) spawned. Orchestrator log: ``Using shared W&B mode (label='orchestrator', primary=True)``; trainer log: ``Using shared W&B mode (label='trainer', primary=False)``; both processes log to the verbatim shared W&B name (``hendrycks-deprecate-shared-0920``) — no ``-trainer`` / ``-orchestrator`` suffix.
- **SLURM multi-node** — ``uv run rl @ examples/multinode/rl.toml --dry-run`` writes ``trainer.toml`` / ``orchestrator.toml`` / ``inference.toml`` directly. The generated sbatch unconditionally exports ``WANDB_SHARED_MODE=1`` / ``WANDB_SHARED_RUN_ID`` and labels both ``orchestrator`` and ``trainer`` invocations.

Unit checks:

- Deprecation: setting ``[wandb] shared = true`` emits a ``FutureWarning`` and the field is dropped from the resolved config.
- ``wandb.name`` is now verbatim on both ``trainer.wandb.name`` and ``orchestrator.wandb.name`` regardless of historical ``shared`` value.
- ``wandb.offline = true`` at the shared level is rejected.
- Disagreeing shared + sub values still raise (mutex retained).
- Matching shared + sub values are silently accepted (round-trip works).
- ``model_dump`` → re-load preserves all propagated fields.

234 config-related unit tests pass (``tests/unit/test_configs.py``, ``tests/unit/train/test_runs.py``, ``tests/unit/test_parsers.py``).

## Breaking change

Users who explicitly set ``wandb.shared = false`` (legacy split mode) will hit the deprecation warning and silently get shared mode instead. Anyone relying on the ``-trainer`` / ``-orchestrator`` suffixes for run-name distinction will see a single run name now — this is intended; that's what shared mode does.

``wandb.offline = true`` at the ``[wandb]`` (shared) level now raises. Use the per-sub-config form instead.