### PR TITLE
fix: pin vLLM no-coordinator wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -238,7 +238,7 @@ flash-attn-4 = { git = "https://github.com/Dao-AILab/flash-attention.git", subdi
 prime-pydantic-config = { workspace = true }
 vllm-router = { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.25/vllm_router-0.1.25-cp38-abi3-manylinux_2_28_x86_64.whl" }
 vllm = [
-    { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.21.0+cu129.r42434.pr39568.a106aa6-cp38-abi3-manylinux_2_34_x86_64.whl", marker = "platform_machine == 'x86_64'" },
+    { path = "/home/matej/dev/vllm-0.21-revert42434-pr39568/dist-no-dp-coordinator/vllm-0.21.0+cu129.r42434.pr39568.a106aa6-cp38-abi3-manylinux_2_34_x86_64.whl", marker = "platform_machine == 'x86_64'" },
     { url = "https://github.com/vllm-project/vllm/releases/download/v0.21.0/vllm-0.21.0+cu129-cp38-abi3-manylinux_2_34_aarch64.whl", marker = "platform_machine == 'aarch64'" },
 ]
 deep-ep = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_ep-1.2.1+29d31c0-cp312-cp312-linux_x86_64.whl" }

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -18,7 +18,6 @@ def transformers_v5_compat():
     _patch_qwen35_lora()
     _patch_lora_key_prefix()
     monkey_patch_deep_gemm_silu_mul_quant_int64()
-    monkey_patch_dp_engine_core_pause_resume_deadlock()
     monkey_patch_vllm_layerwise_reload_alias_buffers()
     monkey_patch_vllm_padded_input_scrub()
     monkey_patch_return_routed_experts_with_nixl_connector()
@@ -780,87 +779,6 @@ def monkey_patch_harmony_stop_token_propagation():
         return params
 
     ChatCompletionRequest.to_sampling_params = _patched_to_sampling_params
-
-
-def monkey_patch_dp_engine_core_pause_resume_deadlock():
-    """Fix DP pause/resume deadlocks around weight updates.
-
-    Bug 1 (job 3756): while paused, START_DP_WAVE can wake idle ranks into the
-    DP loop. Those ranks then run dummy batches and hit DP collectives while
-    other ranks are still in NCCL weight transfer.
-
-    Bug 2 (jobs 3769/3771): resume ties the DP running state to local
-    unfinished requests, but the DP wave state is global. Ranks with no local
-    work still need to re-enter the loop so they can participate in the same
-    DP collectives as ranks that are resuming remote-KV or decode work.
-
-    Fix:
-    - ignore START_DP_WAVE wakeups while paused
-    - on resume, wake every DP rank and force an immediate global unfinished
-      sync instead of waiting for the normal 32-step cadence
-
-    This also bypasses vLLM's two-phase DP pause implementation
-    (https://github.com/vllm-project/vllm/pull/39366), which makes resume
-    reject states that our weight-update flow can validly hit.
-    """
-    from vllm.config import ParallelConfig
-    from vllm.v1.core.sched.interface import PauseState
-    from vllm.v1.engine import EngineCoreOutputs, EngineCoreRequestType
-    from vllm.v1.engine.core import DPEngineCoreProc, EngineCore, EngineCoreProc
-    from vllm.v1.request import Request
-
-    _base_add_request = EngineCore.add_request
-    _base_handle_client_request = EngineCoreProc._handle_client_request
-    _base_pause_complete = EngineCoreProc._pause_complete
-    _base_resume_scheduler = EngineCoreProc.resume_scheduler
-
-    def _patched_add_request(self, request: Request, request_wave: int = 0):
-        _base_add_request(self, request, request_wave)
-        if self.has_coordinator and request_wave != self.current_wave:
-            if request_wave > self.current_wave:
-                self.current_wave = request_wave
-            elif not self.engines_running and self.scheduler.pause_state == PauseState.UNPAUSED:
-                self.engines_running = True
-                self.output_queue.put_nowait((-1, EngineCoreOutputs(start_wave=self.current_wave)))
-
-    def _patched_handle_client_request(self, request_type, request):
-        if request_type == EngineCoreRequestType.START_DP_WAVE:
-            new_wave, exclude_eng_index = request
-            if exclude_eng_index != self.engine_index and new_wave >= self.current_wave:
-                self.current_wave = new_wave
-                if not self.engines_running and self.scheduler.pause_state == PauseState.UNPAUSED:
-                    self.engines_running = True
-        else:
-            _base_handle_client_request(self, request_type, request)
-
-    def _patched_pause_complete(self) -> bool:
-        self.pending_pause = False
-        self.ignore_start_dp_wave = False
-        return _base_pause_complete(self)
-
-    def _patched_resume_scheduler(self):
-        was_paused = self.scheduler.pause_state != PauseState.UNPAUSED
-        self.pending_pause = False
-        self.ignore_start_dp_wave = False
-        _base_resume_scheduler(self)
-        if was_paused:
-            self.engines_running = True
-            self._force_dp_running_state_sync = True
-
-    def _patched_has_global_unfinished_reqs(self, local_unfinished: bool) -> bool:
-        self.step_counter += 1
-        if getattr(self, "_force_dp_running_state_sync", False):
-            self._force_dp_running_state_sync = False
-            return ParallelConfig.has_unfinished_dp(self.dp_group, local_unfinished)
-        if self.step_counter % 32 != 0:
-            return True
-        return ParallelConfig.has_unfinished_dp(self.dp_group, local_unfinished)
-
-    DPEngineCoreProc.add_request = _patched_add_request
-    DPEngineCoreProc._handle_client_request = _patched_handle_client_request
-    DPEngineCoreProc._pause_complete = _patched_pause_complete
-    DPEngineCoreProc.resume_scheduler = _patched_resume_scheduler
-    DPEngineCoreProc._has_global_unfinished_reqs = _patched_has_global_unfinished_reqs
 
 
 def monkey_patch_no_moe_lora():

--- a/uv.lock
+++ b/uv.lock
@@ -3954,7 +3954,7 @@ dependencies = [
     { name = "uvloop", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
     { name = "verifiers", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
     { name = "vllm", version = "0.21.0+cu129", source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.21.0/vllm-0.21.0+cu129-cp38-abi3-manylinux_2_34_aarch64.whl" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
-    { name = "vllm", version = "0.21.0+cu129.r42434.pr39568.a106aa6", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.21.0+cu129.r42434.pr39568.a106aa6-cp38-abi3-manylinux_2_34_x86_64.whl" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
+    { name = "vllm", version = "0.21.0+cu129.r42434.pr39568.a106aa6", source = { path = "/home/matej/dev/vllm-0.21-revert42434-pr39568/dist-no-dp-coordinator/vllm-0.21.0+cu129.r42434.pr39568.a106aa6-cp38-abi3-manylinux_2_34_x86_64.whl" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
     { name = "wandb", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
 ]
 
@@ -4111,7 +4111,7 @@ requires-dist = [
     { name = "verifiers", editable = "deps/verifiers" },
     { name = "vllm", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'", specifier = ">=0.21.0" },
     { name = "vllm", marker = "platform_machine == 'aarch64'", url = "https://github.com/vllm-project/vllm/releases/download/v0.21.0/vllm-0.21.0+cu129-cp38-abi3-manylinux_2_34_aarch64.whl" },
-    { name = "vllm", marker = "platform_machine == 'x86_64'", url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.21.0+cu129.r42434.pr39568.a106aa6-cp38-abi3-manylinux_2_34_x86_64.whl" },
+    { name = "vllm", marker = "platform_machine == 'x86_64'", path = "/home/matej/dev/vllm-0.21-revert42434-pr39568/dist-no-dp-coordinator/vllm-0.21.0+cu129.r42434.pr39568.a106aa6-cp38-abi3-manylinux_2_34_x86_64.whl" },
     { name = "vllm-router", marker = "platform_machine == 'x86_64' and extra == 'disagg'", url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.25/vllm_router-0.1.25-cp38-abi3-manylinux_2_28_x86_64.whl" },
     { name = "wandb", specifier = ">=0.26.1" },
     { name = "wiki-search", marker = "extra == 'envs'", editable = "deps/verifiers/environments/wiki_search" },
@@ -5973,7 +5973,7 @@ rl = [
     { name = "torch", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
     { name = "transformers", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
     { name = "vllm", version = "0.21.0+cu129", source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.21.0/vllm-0.21.0+cu129-cp38-abi3-manylinux_2_34_aarch64.whl" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine != 'aarch64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
-    { name = "vllm", version = "0.21.0+cu129.r42434.pr39568.a106aa6", source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.21.0+cu129.r42434.pr39568.a106aa6-cp38-abi3-manylinux_2_34_x86_64.whl" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
+    { name = "vllm", version = "0.21.0+cu129.r42434.pr39568.a106aa6", source = { path = "/home/matej/dev/vllm-0.21-revert42434-pr39568/dist-no-dp-coordinator/vllm-0.21.0+cu129.r42434.pr39568.a106aa6-cp38-abi3-manylinux_2_34_x86_64.whl" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
     { name = "wandb", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
 ]
 ta = [
@@ -6051,7 +6051,7 @@ requires-dist = [
     { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'", specifier = ">=0.21.0" },
     { name = "vllm", marker = "platform_machine == 'aarch64' and extra == 'rl'", url = "https://github.com/vllm-project/vllm/releases/download/v0.21.0/vllm-0.21.0+cu129-cp38-abi3-manylinux_2_34_aarch64.whl" },
     { name = "vllm", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'rl'", specifier = ">=0.10.0,<0.11.0" },
-    { name = "vllm", marker = "platform_machine == 'x86_64' and extra == 'rl'", url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.21.0+cu129.r42434.pr39568.a106aa6-cp38-abi3-manylinux_2_34_x86_64.whl" },
+    { name = "vllm", marker = "platform_machine == 'x86_64' and extra == 'rl'", path = "/home/matej/dev/vllm-0.21-revert42434-pr39568/dist-no-dp-coordinator/vllm-0.21.0+cu129.r42434.pr39568.a106aa6-cp38-abi3-manylinux_2_34_x86_64.whl" },
     { name = "wandb", marker = "extra == 'rl'" },
 ]
 provides-extras = ["browser", "openenv", "renderers", "rg", "rl", "ta"]
@@ -6272,7 +6272,7 @@ provides-extras = ["zen", "bench", "tensorizer", "fastsafetensors", "instanttens
 [[package]]
 name = "vllm"
 version = "0.21.0+cu129.r42434.pr39568.a106aa6"
-source = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.21.0+cu129.r42434.pr39568.a106aa6-cp38-abi3-manylinux_2_34_x86_64.whl" }
+source = { path = "/home/matej/dev/vllm-0.21-revert42434-pr39568/dist-no-dp-coordinator/vllm-0.21.0+cu129.r42434.pr39568.a106aa6-cp38-abi3-manylinux_2_34_x86_64.whl" }
 resolution-markers = [
     "platform_machine == 'x86_64' and sys_platform == 'linux'",
 ]
@@ -6348,7 +6348,7 @@ dependencies = [
     { name = "xgrammar", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy') or (sys_platform != 'linux' and extra == 'extra-9-verifiers-openenv' and extra == 'group-9-verifiers-policy')" },
 ]
 wheels = [
-    { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/vllm-0.21.0+cu129.r42434.pr39568.a106aa6-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:0f0533a9122dfa738fc0f5532cb6795556f072b133f0058a22ff4be2d2f165f0" },
+    { filename = "vllm-0.21.0+cu129.r42434.pr39568.a106aa6-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2e822e07dd000c5f765530fc8bd2429f4cde6784be56849213f3ca3aaa4d9e8b" },
 ]
 
 [package.metadata]


### PR DESCRIPTION
## Summary
- pins x86_64 vLLM to the rebuilt local no-coordinator wheel at `/home/matej/dev/vllm-0.21-revert42434-pr39568/dist-no-dp-coordinator/vllm-0.21.0+cu129.r42434.pr39568.a106aa6-cp38-abi3-manylinux_2_34_x86_64.whl`
- removes the prime-rl DP pause monkey patch so pause behavior comes from the pinned vLLM wheel
- removes the pause deadlock research/proof artifacts from this PR

## vLLM Source
- source: `/home/matej/dev/vllm-0.21-revert42434-pr39568`
- branch: `feat/v0.21.0-r42434-pr39568-no-dp-coordinator`
- commit: `a106aa65919e56afb7b01cf00c48f2d4ef75c6d9`
- contains the routed-experts changes from `#39568` and the `#42434` revert base
- excludes the DP coordinator commit `550c363d529acc6608e109ff6b5cb1eb30aa1f52` (`git merge-base --is-ancestor ... HEAD` exits `1`)
- wheel hash: `sha256:2e822e07dd000c5f765530fc8bd2429f4cde6784be56849213f3ca3aaa4d9e8b`

## Build Steps
```bash
cd /home/matej/dev/vllm-0.21-revert42434-pr39568
git checkout feat/v0.21.0-r42434-pr39568-no-dp-coordinator
mkdir -p dist-no-dp-coordinator

VLLM_USE_PRECOMPILED=1 \
VLLM_PRECOMPILED_WHEEL_LOCATION=/tmp/prime-vllm-wheels/old-vllm-cu129.whl \
VLLM_VERSION_OVERRIDE=0.21.0+cu129.r42434.pr39568.a106aa6 \
uv run --no-sync \
  --project /home/matej/dev/prime-rl/.worktrees/pause_research \
  --with setuptools-scm \
  --with wheel \
  --directory /home/matej/dev/vllm-0.21-revert42434-pr39568 \
  python setup.py bdist_wheel \
    --dist-dir /home/matej/dev/vllm-0.21-revert42434-pr39568/dist-no-dp-coordinator \
    --py-limited-api=cp38 \
    --plat-name=manylinux_2_34_x86_64
```

## Verification
- `uv lock --check`
- `uv sync --all-extras`
- `uv run ruff check src/prime_rl/inference/patches.py`
- installed vLLM import check: `vllm==0.21.0+cu129.r42434.pr39568.a106aa6`
- installed routed-experts API check: `SamplingParams().routed_experts_prompt_start == 0`
