### PR TITLE
chore(deps): bump renderers (tokenizer config-build fallback for Laguna)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ conflicts = [[
 ]]
 
 [options]
-exclude-newer = "2026-05-18T23:20:22.611873892Z"
+exclude-newer = "2026-05-20T22:25:52.535094223Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -4833,7 +4833,7 @@ requires-dist = [
     { name = "jinja2" },
     { name = "numpy" },
     { name = "openai", specifier = ">=1.108.1" },
-    { name = "openai-harmony", specifier = ">=0.0.8" },
+    { name = "openai-harmony", specifier = ">=0.0.4" },
     { name = "prime-pydantic-config", editable = "deps/pydantic-config" },
     { name = "tiktoken" },
     { name = "transformers", git = "https://github.com/huggingface/transformers.git?rev=c1c3424" },


### PR DESCRIPTION
Bumps the `deps/renderers` submodule from `2ec28a8` → `89ab3f0`, pulling in [renderers#72](https://github.com/PrimeIntellect-ai/renderers/pull/72).

## Why

Loading a tokenizer for the **Laguna model series** (`poolside/Laguna-XS.2`) crashed renderers with:

```
KeyError: "Missing required keys in `rope_parameters` for 'rope_type'='default': {'rope_theta'}"
```

`AutoTokenizer.from_pretrained` always builds the **model config** first (to resolve the tokenizer class), even for a plain fast tokenizer. Building Laguna's config runs HF's RoPE validator, which rejects its nested `rope_parameters` (`full_attention`/`sliding_attention`, no top-level `rope_theta`) when constructed outside vLLM's `patch_rope_parameters`. The `KeyError` escaped and killed the tokenizer load — a modeling-layer concern breaking something the tokenizer never needed.

## What changed in renderers#72

When `AutoTokenizer` fails building the config, fall back to loading the repo's self-contained `tokenizer.json` directly via `PreTrainedTokenizerFast` (no model config, no RoPE). Modeling-agnostic, runs under the fastokens patch (Laguna keeps the Rust speedup), excludes custom `auto_map` tokenizers, and re-raises the original error otherwise.

With this bump, Laguna runs no longer need `--no-renderers` as a workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and lockfile updates with a localized tokenizer-load fallback; no auth, data, or core training-path changes in this diff.
> 
> **Overview**
> Updates **`deps/renderers`** (renderers#72) so tokenizer loading no longer dies on Laguna-style models when Hugging Face config build hits RoPE validation (`rope_theta` / nested `rope_parameters`). Renderers now falls back to **`tokenizer.json`** via **`PreTrainedTokenizerFast`** when **`AutoTokenizer`** fails on config, so Laguna runs can use renderers without **`--no-renderers`**.
> 
> The visible diff refreshes **`uv.lock`**: advances **`exclude-newer`**, and relaxes the **`verifiers`** dev metadata constraint on **`openai-harmony`** from **`>=0.0.8`** to **`>=0.0.4`** (likely from re-locking after the bump).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ecd1db5e6bfd9c7cfb19d982124bf2cbc2a95d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->