### PR TITLE
prevent path where expert biases are not loaded for afmoe

### DIFF
--- a/src/prime_rl/trainer/models/afmoe/configuration_afmoe.py
+++ b/src/prime_rl/trainer/models/afmoe/configuration_afmoe.py
@@ -43,7 +43,7 @@ class AfmoeConfig(PretrainedConfig):
         route_norm=True,
         route_scale=1.0,
         score_before_experts: bool = False,
-        load_balance_coeff: float | None = None,
+        load_balance_coeff: float = 5e-4,
         use_grouped_mm: bool = True,
         global_attn_every_n_layers=4,
         sliding_window=1024,

--- a/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
+++ b/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
@@ -352,7 +352,7 @@ class AfmoeDecoderLayer(GradientCheckpointingLayer):
             score_before_experts=getattr(config, "score_before_experts", False),
             top_k=config.num_experts_per_tok,
             use_grouped_mm=getattr(config, "use_grouped_mm", True),
-            load_balance_coeff=getattr(config, "load_balance_coeff", None),
+            load_balance_coeff=getattr(config, "load_balance_coeff", 5e-4),
             fp8=getattr(config, "fp8", False),
         )
         if self.moe_enabled:

--- a/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
+++ b/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
@@ -352,7 +352,7 @@ class AfmoeDecoderLayer(GradientCheckpointingLayer):
             score_before_experts=getattr(config, "score_before_experts", False),
             top_k=config.num_experts_per_tok,
             use_grouped_mm=getattr(config, "use_grouped_mm", True),
-            load_balance_coeff=getattr(config, "load_balance_coeff", 5e-4),
+            load_balance_coeff=config.load_balance_coeff,
             fp8=getattr(config, "fp8", False),
         )
         if self.moe_enabled:


### PR DESCRIPTION
if an afmoe checkpoint doesn't have a load_balance_coeff in the config.json, we would previously fall-back to `None`, which would prevent the expert bias buffer from being initialized/loaded from the checkpoint, which doesn't make sense for this architecture. this PR makes `5e-4` the default value passed into `MoEArgs`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small config/default change for MoE load-balancing; aligns checkpoint loading with expected AFMoE architecture.
> 
> **Overview**
> Sets **`load_balance_coeff`** default to **`5e-4`** on `AfmoeConfig` and wires MoE construction to **`config.load_balance_coeff`** instead of falling back to **`None`**.
> 
> Checkpoints missing this field in `config.json` previously skipped expert-bias buffer setup and weight loading; AFMoE checkpoints should always carry that bias state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a127e1b98fec4ab4521e1f301752e87d23dd5af8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->