### PR TITLE
Fix multi-run checkpoint dispatch

### DIFF
--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -286,7 +286,15 @@ def train(config: TrainerConfig):
                 for idx in multi_run_manager.used_idxs:
                     multi_run_manager.ready_to_update[idx] = False
 
-        if (
+        if config.max_concurrent_runs > 1:
+            # Multi-run: Save per-run checkpoints using each run's orchestrator config.
+            # Trainer-level ckpt config can be set by the combined rl entrypoint,
+            # but MultiCheckpointManager has a different save signature.
+            save_ckpt_start_time = time.perf_counter()
+            ckpt_manager.save(optimizer, scheduler)
+            save_ckpt_time = time.perf_counter() - save_ckpt_start_time
+            ckpt_manager.maybe_clean()
+        elif (
             ckpt_manager is not None
             and (config.ckpt and config.ckpt.interval)
             and not (is_first_step or is_last_step)
@@ -310,12 +318,6 @@ def train(config: TrainerConfig):
                 weight_ckpt_manager.save(progress.step, model, tokenizer)
                 save_ckpt_time += time.perf_counter() - save_ckpt_start_time
                 weight_ckpt_manager.maybe_clean()
-        elif config.max_concurrent_runs > 1:
-            # Multi-run: Save per-run checkpoints (each run has its own interval from orchestrator config)
-            save_ckpt_start_time = time.perf_counter()
-            ckpt_manager.save(optimizer, scheduler)
-            save_ckpt_time = time.perf_counter() - save_ckpt_start_time
-            ckpt_manager.maybe_clean()
         else:
             save_ckpt_time = 0
 


### PR DESCRIPTION
## Summary
- route multi-run RL checkpoint saves through `MultiCheckpointManager` before the single-run trainer checkpoint branch
- preserve single-run checkpoint behavior while allowing combined `rl` configs with shared `[ckpt]` to work for multi-run LoRA training

## Testing
- `python -m py_compile src/prime_rl/trainer/rl/train.py`
- `/home/daniel/git/research-prod2/.venv/bin/ruff check src/prime_rl/trainer/rl/train.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes training-loop checkpoint timing and dispatch; wrong ordering could skip per-run saves or call the wrong save API, affecting resume and LoRA multi-run training.
> 
> **Overview**
> **Reorders checkpoint handling** in the RL trainer loop so **`max_concurrent_runs > 1` is evaluated first**, calling `MultiCheckpointManager.save(optimizer, scheduler)` (per-run intervals from each orchestrator) instead of falling through to the single-run branch.
> 
> The single-run path (trainer `config.ckpt` interval, full + weight checkpoints) is unchanged but now only runs when **not** in multi-run mode. Comments clarify that combined `rl` entrypoints may set trainer-level `[ckpt]` while multi-run still uses the multi manager’s different save API.
> 
> This fixes incorrect dispatch when shared trainer checkpoint settings would otherwise trigger the single-run save signature on a multi-run manager.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14e7bbe4c6ecd8edced6e1177c3d65366e42398f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->