### PR TITLE
fix: prevent buffer normal-pool drain when difficulty pools are enabled

### DIFF
--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -206,9 +206,9 @@ Pool assignments persist across checkpoints (`easy_examples.jsonl` / `hard_examp
 [orchestrator.buffer]
 easy_threshold = 0.95
 hard_threshold = 0.05
-max_easy_fraction = 0.5   # cap on the easy pool; oldest is recycled to normal past this
-max_hard_fraction = 0.4   # cap on the hard pool; oldest is recycled to normal past this
-# max_easy_fraction + max_hard_fraction must be < 1.0 (config validation enforces this)
+max_easy_fraction = 0.5
+max_hard_fraction = 0.4
+# max_easy_fraction + max_hard_fraction must be < 1.0
 easy_fraction = 0.0   # default; bump on resume to bring some easy problems back
 hard_fraction = 0.0   # default; bump on resume to bring some hard problems back
 ```

--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -198,12 +198,16 @@ Difficulty pools gradually retire problems the model has solved or never solves.
 - `buffer.hard_threshold` — at or below this, the problem moves into the `hard` pool and is no longer sampled.
 - Otherwise the problem stays in `normal` and remains in the sampling rotation.
 
+Each pool is capped at a share of the env's own problems: `buffer.max_easy_fraction` / `buffer.max_hard_fraction`. When a pool exceeds its cap, the oldest member is recycled back into `normal`, so `normal` can never fully drain (which would otherwise crash sampling) and stale problems get re-tested under the evolving policy. The caps only bite when a pool grows large relative to the env's size — large task sets are essentially unaffected. Set a fraction to `1.0` to disable that pool's cap.
+
 Pool assignments persist across checkpoints (`easy_examples.jsonl` / `hard_examples.jsonl` under each step's orchestrator checkpoint). When you resume — or want to broaden the curriculum mid-run — `buffer.easy_fraction` / `buffer.hard_fraction` randomly lift that fraction of pooled problems back into `normal` so they re-enter sampling.
 
 ```toml
 [orchestrator.buffer]
 easy_threshold = 0.95
 hard_threshold = 0.05
+max_easy_fraction = 0.5   # cap on the easy pool; oldest is recycled to normal past this
+max_hard_fraction = 0.5   # cap on the hard pool; oldest is recycled to normal past this
 easy_fraction = 0.0   # default; bump on resume to bring some easy problems back
 hard_fraction = 0.0   # default; bump on resume to bring some hard problems back
 ```

--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -198,7 +198,7 @@ Difficulty pools gradually retire problems the model has solved or never solves.
 - `buffer.hard_threshold` — at or below this, the problem moves into the `hard` pool and is no longer sampled.
 - Otherwise the problem stays in `normal` and remains in the sampling rotation.
 
-Each pool is capped at a share of the env's own problems: `buffer.max_easy_fraction` / `buffer.max_hard_fraction`. When a pool exceeds its cap, the oldest member is recycled back into `normal`, so `normal` can never fully drain (which would otherwise crash sampling) and stale problems get re-tested under the evolving policy. The caps only bite when a pool grows large relative to the env's size — large task sets are essentially unaffected. Set a fraction to `1.0` to disable that pool's cap.
+Each pool is capped at a share of the env's own problems: `buffer.max_easy_fraction` / `buffer.max_hard_fraction`. When a pool exceeds its cap, the oldest member is recycled back into `normal`. The config enforces `max_easy_fraction + max_hard_fraction < 1.0`, which together with floor-rounding in the cap logic gives a hard guarantee: at least one task always stays in `normal` per env, so sampling can never crash regardless of reward trajectory. Stale sidelined problems also get re-tested under the evolving policy rather than being exiled indefinitely.
 
 Pool assignments persist across checkpoints (`easy_examples.jsonl` / `hard_examples.jsonl` under each step's orchestrator checkpoint). When you resume — or want to broaden the curriculum mid-run — `buffer.easy_fraction` / `buffer.hard_fraction` randomly lift that fraction of pooled problems back into `normal` so they re-enter sampling.
 
@@ -207,7 +207,8 @@ Pool assignments persist across checkpoints (`easy_examples.jsonl` / `hard_examp
 easy_threshold = 0.95
 hard_threshold = 0.05
 max_easy_fraction = 0.5   # cap on the easy pool; oldest is recycled to normal past this
-max_hard_fraction = 0.5   # cap on the hard pool; oldest is recycled to normal past this
+max_hard_fraction = 0.4   # cap on the hard pool; oldest is recycled to normal past this
+# max_easy_fraction + max_hard_fraction must be < 1.0 (config validation enforces this)
 easy_fraction = 0.0   # default; bump on resume to bring some easy problems back
 hard_fraction = 0.0   # default; bump on resume to bring some hard problems back
 ```

--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -198,7 +198,7 @@ Difficulty pools gradually retire problems the model has solved or never solves.
 - `buffer.hard_threshold` — at or below this, the problem moves into the `hard` pool and is no longer sampled.
 - Otherwise the problem stays in `normal` and remains in the sampling rotation.
 
-Each pool is capped at a share of the env's own problems: `buffer.max_easy_fraction` / `buffer.max_hard_fraction`. When a pool exceeds its cap, the oldest member is recycled back into `normal`. The config enforces `max_easy_fraction + max_hard_fraction < 1.0`, which together with floor-rounding in the cap logic gives a hard guarantee: at least one task always stays in `normal` per env, so sampling can never crash regardless of reward trajectory. Stale sidelined problems also get re-tested under the evolving policy rather than being exiled indefinitely.
+Each pool is capped at a share of the env's own problems: `buffer.max_easy_pool_fraction` / `buffer.max_hard_pool_fraction`. When a pool exceeds its cap, the oldest member is recycled back into `normal`. The config enforces `max_easy_pool_fraction + max_hard_pool_fraction < 1.0`, which together with floor-rounding in the cap logic gives a hard guarantee: at least one task always stays in `normal` per env, so sampling can never crash regardless of reward trajectory. Stale sidelined problems also get re-tested under the evolving policy rather than being exiled indefinitely.
 
 Pool assignments persist across checkpoints (`easy_examples.jsonl` / `hard_examples.jsonl` under each step's orchestrator checkpoint). When you resume — or want to broaden the curriculum mid-run — `buffer.easy_fraction` / `buffer.hard_fraction` randomly lift that fraction of pooled problems back into `normal` so they re-enter sampling.
 
@@ -206,9 +206,9 @@ Pool assignments persist across checkpoints (`easy_examples.jsonl` / `hard_examp
 [orchestrator.buffer]
 easy_threshold = 0.95
 hard_threshold = 0.05
-max_easy_fraction = 0.5
-max_hard_fraction = 0.4
-# max_easy_fraction + max_hard_fraction must be < 1.0
+max_easy_pool_fraction = 0.5
+max_hard_pool_fraction = 0.4
+# max_easy_pool_fraction + max_hard_pool_fraction must be < 1.0
 easy_fraction = 0.0   # default; bump on resume to bring some easy problems back
 hard_fraction = 0.0   # default; bump on resume to bring some hard problems back
 ```

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -386,11 +386,11 @@ class BufferConfig(BaseConfig):
     hard_fraction: float = Field(0.0, ge=0, le=1)
     """Fraction of hard problems to convert to ``normal`` when resuming or starting training. Only problems with difficulty ``normal`` are sampled."""
 
-    max_easy_fraction: float = Field(0.5, ge=0, lt=1)
-    """Max share of an env's tasks allowed to sit in the easy pool. When exceeded, the oldest easy task is recycled back to normal. Must satisfy ``max_easy_fraction + max_hard_fraction < 1`` to guarantee at least one task always stays in normal."""
+    max_easy_pool_fraction: float = Field(0.5, ge=0, lt=1)
+    """Max share of an env's tasks allowed to sit in the easy pool. When exceeded, the oldest easy task is recycled back to normal. Must satisfy ``max_easy_pool_fraction + max_hard_pool_fraction < 1`` to guarantee at least one task always stays in normal."""
 
-    max_hard_fraction: float = Field(0.4, ge=0, lt=1)
-    """Max share of an env's tasks allowed to sit in the hard pool. When exceeded, the oldest hard task is recycled back to normal. Must satisfy ``max_easy_fraction + max_hard_fraction < 1`` to guarantee at least one task always stays in normal."""
+    max_hard_pool_fraction: float = Field(0.4, ge=0, lt=1)
+    """Max share of an env's tasks allowed to sit in the hard pool. When exceeded, the oldest hard task is recycled back to normal. Must satisfy ``max_easy_pool_fraction + max_hard_pool_fraction < 1`` to guarantee at least one task always stays in normal."""
 
     online_difficulty_filtering: bool = False
     """Filter rollouts based on difficulty. When True, rollouts with average reward 0.0 or 1.0 are not added to the buffer."""
@@ -402,8 +402,8 @@ class BufferConfig(BaseConfig):
     def validate_thresholds(self):
         if self.easy_threshold is not None and self.hard_threshold is not None:
             assert self.easy_threshold > self.hard_threshold, "easy_threshold must be greater than hard_threshold."
-        assert self.max_easy_fraction + self.max_hard_fraction < 1.0, (
-            f"max_easy_fraction ({self.max_easy_fraction}) + max_hard_fraction ({self.max_hard_fraction}) "
+        assert self.max_easy_pool_fraction + self.max_hard_pool_fraction < 1.0, (
+            f"max_easy_pool_fraction ({self.max_easy_pool_fraction}) + max_hard_pool_fraction ({self.max_hard_pool_fraction}) "
             "must be < 1.0 to guarantee at least one task stays in the normal pool."
         )
         return self

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -386,6 +386,12 @@ class BufferConfig(BaseConfig):
     hard_fraction: float = Field(0.0, ge=0, le=1)
     """Fraction of hard problems to convert to ``normal`` when resuming or starting training. Only problems with difficulty ``normal`` are sampled."""
 
+    max_easy_fraction: float = Field(0.5, ge=0, le=1)
+    """Max share of an env's tasks allowed to sit in the easy pool. When exceeded, the oldest easy task is recycled back to normal. Set to 1.0 to disable the cap."""
+
+    max_hard_fraction: float = Field(0.5, ge=0, le=1)
+    """Max share of an env's tasks allowed to sit in the hard pool. When exceeded, the oldest hard task is recycled back to normal. Set to 1.0 to disable the cap."""
+
     online_difficulty_filtering: bool = False
     """Filter rollouts based on difficulty. When True, rollouts with average reward 0.0 or 1.0 are not added to the buffer."""
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -386,11 +386,11 @@ class BufferConfig(BaseConfig):
     hard_fraction: float = Field(0.0, ge=0, le=1)
     """Fraction of hard problems to convert to ``normal`` when resuming or starting training. Only problems with difficulty ``normal`` are sampled."""
 
-    max_easy_fraction: float = Field(0.5, ge=0, le=1)
-    """Max share of an env's tasks allowed to sit in the easy pool. When exceeded, the oldest easy task is recycled back to normal. Set to 1.0 to disable the cap."""
+    max_easy_fraction: float = Field(0.5, ge=0, lt=1)
+    """Max share of an env's tasks allowed to sit in the easy pool. When exceeded, the oldest easy task is recycled back to normal. Must satisfy ``max_easy_fraction + max_hard_fraction < 1`` to guarantee at least one task always stays in normal."""
 
-    max_hard_fraction: float = Field(0.5, ge=0, le=1)
-    """Max share of an env's tasks allowed to sit in the hard pool. When exceeded, the oldest hard task is recycled back to normal. Set to 1.0 to disable the cap."""
+    max_hard_fraction: float = Field(0.4, ge=0, lt=1)
+    """Max share of an env's tasks allowed to sit in the hard pool. When exceeded, the oldest hard task is recycled back to normal. Must satisfy ``max_easy_fraction + max_hard_fraction < 1`` to guarantee at least one task always stays in normal."""
 
     online_difficulty_filtering: bool = False
     """Filter rollouts based on difficulty. When True, rollouts with average reward 0.0 or 1.0 are not added to the buffer."""
@@ -402,6 +402,10 @@ class BufferConfig(BaseConfig):
     def validate_thresholds(self):
         if self.easy_threshold is not None and self.hard_threshold is not None:
             assert self.easy_threshold > self.hard_threshold, "easy_threshold must be greater than hard_threshold."
+        assert self.max_easy_fraction + self.max_hard_fraction < 1.0, (
+            f"max_easy_fraction ({self.max_easy_fraction}) + max_hard_fraction ({self.max_hard_fraction}) "
+            "must be < 1.0 to guarantee at least one task stays in the normal pool."
+        )
         return self
 
 

--- a/src/prime_rl/orchestrator/buffer.py
+++ b/src/prime_rl/orchestrator/buffer.py
@@ -66,17 +66,14 @@ class _EnvBuffer:
 
     def update_pools(self, example_id: int, avg_reward: float) -> str:
         """Assign example to pool based on reward. Returns pool name."""
-        if self.config.easy_threshold is not None and avg_reward >= self.config.easy_threshold:
-            pool = "easy"
-        elif self.config.hard_threshold is not None and avg_reward <= self.config.hard_threshold:
-            pool = "hard"
-        else:
-            pool = "normal"
+        pool = self._classify(avg_reward)
 
         if pool != "normal" and example_id in self.examples:
             example = self.examples.pop(example_id)
             target = self.easy_examples if pool == "easy" else self.hard_examples
             target.append(example)
+            max_fraction = self.config.max_easy_fraction if pool == "easy" else self.config.max_hard_fraction
+            self._recycle_overflow(target, max_fraction)
 
         self.num_examples_per_step[pool] += 1
         return pool
@@ -104,6 +101,25 @@ class _EnvBuffer:
 
         self.reset_step_metrics()
         return metrics
+
+    def _classify(self, avg_reward: float) -> str:
+        if self.config.easy_threshold is not None and avg_reward >= self.config.easy_threshold:
+            return "easy"
+        if self.config.hard_threshold is not None and avg_reward <= self.config.hard_threshold:
+            return "hard"
+        return "normal"
+
+    def _recycle_overflow(self, pool: list[dict], max_fraction: float) -> None:
+        """Recycle oldest sidelined tasks back to normal until the pool is within its cap.
+
+        Bounds each sidelined pool at a share of the env's tasks, so normal can never drain
+        to empty no matter how the reward evolves. Recycling oldest-first also re-tests stale
+        tasks under the current policy instead of exiling them on one noisy measurement.
+        """
+        max_size = round(self.num_total * max_fraction)
+        while len(pool) > max_size:
+            example = pool.pop(0)
+            self.examples[example["example_id"]] = example
 
 
 class Buffer:

--- a/src/prime_rl/orchestrator/buffer.py
+++ b/src/prime_rl/orchestrator/buffer.py
@@ -73,7 +73,7 @@ class _EnvBuffer:
             example = self.examples.pop(example_id)
             target = self.easy_examples if pool == "easy" else self.hard_examples
             target.append(example)
-            max_fraction = self.config.max_easy_fraction if pool == "easy" else self.config.max_hard_fraction
+            max_fraction = self.config.max_easy_pool_fraction if pool == "easy" else self.config.max_hard_pool_fraction
             self._recycle_overflow(target, max_fraction)
 
         self.num_examples_per_step[pool] += 1

--- a/src/prime_rl/orchestrator/buffer.py
+++ b/src/prime_rl/orchestrator/buffer.py
@@ -111,11 +111,9 @@ class _EnvBuffer:
         return "normal"
 
     def _recycle_overflow(self, pool: list[dict], max_fraction: float) -> None:
-        """Recycle oldest sidelined tasks back to normal until the pool is within its cap.
-
-        floor (not round) is intentional: together with the BufferConfig constraint
-        max_easy + max_hard < 1, it guarantees at least one task always stays in normal.
-        """
+        """Recycle oldest sidelined tasks back to normal until the pool is within its cap."""
+        # floor (not round) is intentional: together with the BufferConfig constraint
+        # max_easy + max_hard < 1, it guarantees at least one task always stays in normal.
         max_size = math.floor(self.num_total * max_fraction)
         while len(pool) > max_size:
             example = pool.pop(0)

--- a/src/prime_rl/orchestrator/buffer.py
+++ b/src/prime_rl/orchestrator/buffer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import random
 from collections import defaultdict
 from functools import partial
@@ -112,11 +113,10 @@ class _EnvBuffer:
     def _recycle_overflow(self, pool: list[dict], max_fraction: float) -> None:
         """Recycle oldest sidelined tasks back to normal until the pool is within its cap.
 
-        Bounds each sidelined pool at a share of the env's tasks, so normal can never drain
-        to empty no matter how the reward evolves. Recycling oldest-first also re-tests stale
-        tasks under the current policy instead of exiling them on one noisy measurement.
+        floor (not round) is intentional: together with the BufferConfig constraint
+        max_easy + max_hard < 1, it guarantees at least one task always stays in normal.
         """
-        max_size = round(self.num_total * max_fraction)
+        max_size = math.floor(self.num_total * max_fraction)
         while len(pool) > max_size:
             example = pool.pop(0)
             self.examples[example["example_id"]] = example

--- a/tests/unit/orchestrator/test_buffer.py
+++ b/tests/unit/orchestrator/test_buffer.py
@@ -164,21 +164,21 @@ def test_buffer_config_rejects_uncapped_pools():
     """Config rejects max_easy + max_hard >= 1.0 — the constraint that makes the normal-pool floor hard."""
     from pydantic import ValidationError
 
-    with pytest.raises(ValidationError, match="max_easy_fraction.*max_hard_fraction"):
-        BufferConfig(max_easy_fraction=0.6, max_hard_fraction=0.6)
+    with pytest.raises(ValidationError, match="max_easy_pool_fraction.*max_hard_pool_fraction"):
+        BufferConfig(max_easy_pool_fraction=0.6, max_hard_pool_fraction=0.6)
 
-    with pytest.raises(ValidationError, match="max_easy_fraction.*max_hard_fraction"):
-        BufferConfig(max_easy_fraction=0.5, max_hard_fraction=0.5)
+    with pytest.raises(ValidationError, match="max_easy_pool_fraction.*max_hard_pool_fraction"):
+        BufferConfig(max_easy_pool_fraction=0.5, max_hard_pool_fraction=0.5)
 
     # Exactly at the boundary (sum == 1.0) is also rejected.
-    with pytest.raises(ValidationError, match="max_easy_fraction.*max_hard_fraction"):
-        BufferConfig(max_easy_fraction=0.7, max_hard_fraction=0.3)
+    with pytest.raises(ValidationError, match="max_easy_pool_fraction.*max_hard_pool_fraction"):
+        BufferConfig(max_easy_pool_fraction=0.7, max_hard_pool_fraction=0.3)
 
 
 def test_buffer_cap_recycles_and_never_drains(dummy_envs):
     """The cap recycles mastered tasks back to normal, so the buffer never drains and sampling keeps working."""
-    buffer = Buffer(dummy_envs, BufferConfig(easy_threshold=0.9))  # default max_easy_fraction=0.5
-    cap = math.floor(5 * 0.5)  # per-env easy pool cap: floor(N * max_easy_fraction)
+    buffer = Buffer(dummy_envs, BufferConfig(easy_threshold=0.9))  # default max_easy_pool_fraction=0.5
+    cap = math.floor(5 * 0.5)  # per-env easy pool cap: floor(N * max_easy_pool_fraction)
 
     # Repeatedly ace every task; without recycling normal would empty within one pass.
     for _ in range(20):

--- a/tests/unit/orchestrator/test_buffer.py
+++ b/tests/unit/orchestrator/test_buffer.py
@@ -1,3 +1,4 @@
+import math
 import random
 from unittest.mock import MagicMock
 
@@ -159,21 +160,25 @@ def _master_all_tasks(buffer: Buffer) -> None:
             eb.update_pools(example_id, avg_reward=1.0)
 
 
-def test_buffer_drain_without_cap_raises(dummy_envs):
-    """Reproduces the drain bug: with caps disabled, mastering all tasks empties normal and sampling crashes."""
-    buffer = Buffer(dummy_envs, BufferConfig(easy_threshold=0.9, max_easy_fraction=1.0, max_hard_fraction=1.0))
+def test_buffer_config_rejects_uncapped_pools():
+    """Config rejects max_easy + max_hard >= 1.0 — the constraint that makes the normal-pool floor hard."""
+    from pydantic import ValidationError
 
-    _master_all_tasks(buffer)
+    with pytest.raises(ValidationError, match="max_easy_fraction.*max_hard_fraction"):
+        BufferConfig(max_easy_fraction=0.6, max_hard_fraction=0.6)
 
-    assert get_normal_count(buffer) == 0
-    with pytest.raises(ValueError, match="No environments left with examples"):
-        buffer.sample_examples(1)
+    with pytest.raises(ValidationError, match="max_easy_fraction.*max_hard_fraction"):
+        BufferConfig(max_easy_fraction=0.5, max_hard_fraction=0.5)
+
+    # Exactly at the boundary (sum == 1.0) is also rejected.
+    with pytest.raises(ValidationError, match="max_easy_fraction.*max_hard_fraction"):
+        BufferConfig(max_easy_fraction=0.7, max_hard_fraction=0.3)
 
 
 def test_buffer_cap_recycles_and_never_drains(dummy_envs):
     """The cap recycles mastered tasks back to normal, so the buffer never drains and sampling keeps working."""
-    buffer = Buffer(dummy_envs, BufferConfig(easy_threshold=0.9))  # default caps: 0.5
-    cap = round(5 * 0.5)  # per-env easy pool cap
+    buffer = Buffer(dummy_envs, BufferConfig(easy_threshold=0.9))  # default max_easy_fraction=0.5
+    cap = math.floor(5 * 0.5)  # per-env easy pool cap: floor(N * max_easy_fraction)
 
     # Repeatedly ace every task; without recycling normal would empty within one pass.
     for _ in range(20):

--- a/tests/unit/orchestrator/test_buffer.py
+++ b/tests/unit/orchestrator/test_buffer.py
@@ -152,6 +152,40 @@ def test_buffer_no_filtering_by_default(dummy_envs, make_rollouts):
     assert len(buffer.rollout_buffer) == 10
 
 
+def _master_all_tasks(buffer: Buffer) -> None:
+    """Mark every currently-normal task as easy in each env (simulates a policy acing them)."""
+    for eb in buffer.env_buffers.values():
+        for example_id in list(eb.examples):
+            eb.update_pools(example_id, avg_reward=1.0)
+
+
+def test_buffer_drain_without_cap_raises(dummy_envs):
+    """Reproduces the drain bug: with caps disabled, mastering all tasks empties normal and sampling crashes."""
+    buffer = Buffer(dummy_envs, BufferConfig(easy_threshold=0.9, max_easy_fraction=1.0, max_hard_fraction=1.0))
+
+    _master_all_tasks(buffer)
+
+    assert get_normal_count(buffer) == 0
+    with pytest.raises(ValueError, match="No environments left with examples"):
+        buffer.sample_examples(1)
+
+
+def test_buffer_cap_recycles_and_never_drains(dummy_envs):
+    """The cap recycles mastered tasks back to normal, so the buffer never drains and sampling keeps working."""
+    buffer = Buffer(dummy_envs, BufferConfig(easy_threshold=0.9))  # default caps: 0.5
+    cap = round(5 * 0.5)  # per-env easy pool cap
+
+    # Repeatedly ace every task; without recycling normal would empty within one pass.
+    for _ in range(20):
+        _master_all_tasks(buffer)
+        for eb in buffer.env_buffers.values():
+            assert len(eb.easy_examples) <= cap
+            assert eb.num_normal >= 5 - cap
+
+    assert get_normal_count(buffer) > 0
+    assert len(buffer.sample_examples(4)) == 4
+
+
 def test_buffer_save_load_with_conversion(dummy_envs, make_rollouts, tmp_path):
     """Easy/hard problems are partially converted to normal on load."""
     buffer = Buffer(dummy_envs, BufferConfig(easy_threshold=1.0, hard_threshold=0.0))


### PR DESCRIPTION
## Context

The orchestrator buffer sorts each environment's tasks into three difficulty pools: `normal`, `easy`, and `hard`. Only `normal` is ever sampled. The `easy` and `hard` pools are holding pens that sideline tasks the policy already aces or can never touch, so compute concentrates where the gradient signal is strongest.

This bucketing is opt-in. Both `easy_threshold` and `hard_threshold` default to `None`, and with neither set every task stays in `normal` and nothing is sidelined.

## Issue

The bug described below can only trigger once you set one or both `easy_threshold` and `hard_threshold` (which is why a default-config run never hits it). Before this PR, enabling the pools meant setting just the thresholds (there were no cap fields):

```toml
[orchestrator.buffer]
easy_threshold = 0.9
hard_threshold = 0.1
```

The problem is that the task flow is one-way. After every rollout, `update_pools` evicts a task from `normal` into `easy`/`hard` when its recent reward crosses a threshold. But the only code that moves tasks back, `convert_to_normal`, is a closure inside `Buffer.load`, which runs only on checkpoint resume. Even then it early-returns, because `easy_fraction`/`hard_fraction` default to `0.0`. So during a normal training loop, `normal` only ever shrinks.

The drain gets worse the better the policy does: eviction is triggered by high reward, so a stronger policy empties the buffer faster. On a small task set (tens of tasks) `normal` drains to empty and `sample_examples` raises `ValueError: No environments left with examples.` mid-run. On large task sets (hundreds of tasks) the bug stays hidden, because enough tasks stay in `normal` for the run's duration.

## Fix

Bound each sidelined pool at a fraction of the env's own task count. When a pool exceeds its cap, recycle its oldest member (FIFO) back into `normal`. The cap rounds down (floor), and the config enforces `max_easy_pool_fraction + max_hard_pool_fraction < 1`. Together these give a hard floor on `normal` that holds regardless of reward trajectory:

```
len(easy) ≤ ⌊num_total · max_easy_pool_fraction⌋
len(hard) ≤ ⌊num_total · max_hard_pool_fraction⌋
max_easy_pool_fraction + max_hard_pool_fraction < 1
⇒ ⌊N · e⌋ + ⌊N · h⌋ < N  ⇒  normal always holds ≥ 1 task
```

<img height="250" alt="fix-buffer-drain" src="https://github.com/user-attachments/assets/57dfe5f7-8e32-45e4-afee-97770a6775df" />

It also re-tests sidelined tasks under the current policy. A task parked as "easy" early eventually returns to be re-evaluated, instead of being exiled on one noisy measurement. The caps only bite when a pool grows large relative to the env's own size, so large task sets are barely touched.

```diff
[orchestrator.buffer]
easy_threshold = 0.95
hard_threshold = 0.05
+ max_easy_pool_fraction = 0.5
+ max_hard_pool_fraction = 0.4
# config rejects max_easy_pool_fraction + max_hard_pool_fraction >= 1.0
```

## Manual test

Two regression tests in `tests/unit/orchestrator/test_buffer.py` pin the behavior:

- `test_buffer_config_rejects_uncapped_pools` checks the guarantee at the config layer. `BufferConfig` rejects any `max_easy_pool_fraction + max_hard_pool_fraction >= 1.0`, so the floor can never be configured away.
- `test_buffer_cap_recycles_and_never_drains` checks the runtime behavior. With the default `0.5 / 0.4` caps, 20 consecutive "master everything" passes never drain `normal`, and sampling keeps working.

```bash
uv run pytest tests/unit/orchestrator/test_buffer.py -v
```

All 10 tests in the file pass.

> [!NOTE]
> - `convert_to_normal` in `Buffer.load` is intentionally kept. The resume-time reshuffle off `easy_fraction`/`hard_fraction` is orthogonal to the per-step caps.
> - The `raise` in `sample_examples` is intentionally kept as a canary. With the hard floor in place, a truly empty `normal` would point to a separate bug worth surfacing loudly.
> - Defaults are `0.5 / 0.4`. The config rejects any pair summing to `1.0` or more, so at least one task always stays in `normal`.

## Changes

<details>
<summary>Click here to expand</summary>

- **`max_easy_pool_fraction` / `max_hard_pool_fraction` on `BufferConfig`** (defaults `0.5` / `0.4`): cap each sidelined pool as a share of the env's tasks; config rejects `max_easy + max_hard >= 1.0`
- **`_recycle_overflow` in `_EnvBuffer`**: recycles the oldest sidelined task back to `normal` whenever a pool exceeds its cap, called on every eviction in `update_pools`
- **`_classify` extracted from `update_pools`**: pulls the reward-to-pool decision into its own helper, with no behavior change
- **Regression tests**: config rejects pools summing to `>= 1.0`; default caps recycle so `normal` never drains
- **Docs**: document the pool caps in `algorithms.md`

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core orchestrator sampling/curriculum behavior when difficulty pools are enabled; mitigated by config validation and unit tests, but training mix may differ from pre-fix runs.
> 
> **Overview**
> Fixes a **one-way drain** of the orchestrator difficulty buffer: with `easy_threshold` / `hard_threshold` enabled, tasks could leave the `normal` pool forever and `sample_examples` could raise **No environments left with examples**.
> 
> Adds **`max_easy_pool_fraction`** and **`max_hard_pool_fraction`** on `BufferConfig` (defaults `0.5` / `0.4`), with validation that their sum is **&lt; 1.0**. On each eviction in `update_pools`, **`_recycle_overflow`** FIFO-recycles the oldest sidelined task back into `normal` when a pool exceeds `floor(num_total × fraction)`.
> 
> Pool classification is moved to **`_classify`**; **`docs/algorithms.md`** documents the caps. New unit tests cover invalid config and repeated “master all tasks” without draining `normal`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d376f2ba6eb8e65f6be42aacea81b8bc6b97a155. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->