### PR TITLE
security: extend cooldown exempt list with first-party deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,11 @@ members = [
 ]
 
 [tool.uv]
+# Enforce a uv version that supports the friendly-duration form
+# (`"7 days"`) in the static pyproject parser. Older uvs silently parse
+# the value as an RFC 3339 date, emit a TOML parse warning, and proceed
+# *without* the cooldown — bypassing this security policy.
+required-version = ">=0.11.1"
 exclude-newer = "7 days"
 preview = true
 no-build-isolation-package = ["flash-attn"]
@@ -203,11 +208,17 @@ vllm = false
 tokenspeed-mla = false
 fastokens = false
 flash_attn_3 = false
-# PrimeIntellect-published on PyPI (trusted publisher)
+# PrimeIntellect-published packages in this project's dependency closure —
+# fast-track so first-party releases can land same-day. Only packages that
+# appear in `uv tree` need to be listed; the resolver ignores entries for
+# packages it never sees.
 prime = false
 prime-sandboxes = false
 prime-tunnel = false
 prime-evals = false
+verifiers = false
+renderers = false
+prime-pydantic-config = false
 # Trusted git/URL sources pinned by rev or wheel URL (defensive: belt-and-suspenders)
 vllm-router = false
 dion = false

--- a/uv.lock
+++ b/uv.lock
@@ -15,23 +15,26 @@ conflicts = [[
 ]]
 
 [options]
-exclude-newer = "2026-05-20T23:46:33.916255464Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
 vllm = false
+verifiers = false
+prime-pydantic-config = false
 vllm-router = false
 dion = false
-tokenspeed-mla = false
-prime = false
 nixl-cu12 = false
-deep-ep = false
+fastokens = false
 flash-attn-3 = false
-prime-sandboxes = false
 prime-tunnel = false
 deep-gemm = false
 prime-evals = false
-fastokens = false
+tokenspeed-mla = false
+deep-ep = false
+prime-sandboxes = false
+renderers = false
+prime = false
 
 [manifest]
 members = [


### PR DESCRIPTION
## What

Extends `[tool.uv.exclude-newer-package]` with the PrimeIntellect packages now in this project's `uv tree` closure:

- `verifiers`
- `renderers`
- `prime-pydantic-config`

prime-rl already had `exclude-newer = "7 days"` and exempts for `prime`/`prime-sandboxes`/`prime-tunnel`/`prime-evals` — this PR completes the canonical first-party exempt set.

## Why

Part 1 of a 3-phase supply-chain hardening rolling out across PrimeIntellect repos: cooldown (this PR) → hash-locked release artifact → hardened internal upgrade command.

## Notes

- Lock regenerated; `uv lock --check` passes.
- **The existing cooldown actively rolled back 5 third-party packages** released in the past 7 days (`opencode-cp` 0.3.11→0.3.10, `opencode-math` 0.4.12→0.4.11, `opencode-science` 0.3.12→0.3.11, `opencode-swe` 0.4.8→0.4.7, `mini-swe-agent-plus` 0.2.25→0.2.24). They'll roll forward automatically once they age out.
- Submodule pointers unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-resolution and supply-chain policy only; no runtime application logic changes beyond lockfile version pins from the cooldown.
> 
> **Overview**
> Tightens the **7-day PyPI cooldown** by requiring **`uv >= 0.11.1`**, so `"7 days"` is parsed as a duration instead of being misread as an RFC 3339 date (which would disable the policy).
> 
> **First-party packages** in the dependency tree—`verifiers`, `renderers`, and `prime-pydantic-config`—are added to `[tool.uv.exclude-newer-package]` so same-day PrimeIntellect releases are not held back. Comments clarify that only packages seen in `uv tree` need entries.
> 
> `uv.lock` is regenerated to match (including `exclude-newer-span` / lock metadata); expect some third-party pins to step back until they age past the cooldown window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2878f0862adf3d4d4ed892b840d469dfe179d7b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->