### PR TITLE
fix(orchestrator): fan out temperature at batch build (v1-env compat)

### DIFF
--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -21,7 +21,7 @@ from prime_rl.utils.logger import ProgressTracker, get_logger
 from prime_rl.utils.monitor import get_monitor
 from prime_rl.utils.utils import capitalize
 
-REQUIRED_STATE_COLUMNS = ["trajectory", "sampling_args"]
+REQUIRED_STATE_COLUMNS = ["trajectory"]
 
 
 class Env:

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -508,11 +508,16 @@ async def orchestrate(config: OrchestratorConfig):
             if samples is None:
                 samples = []
             rollout_samples_per_rollout.append(len(samples))
+            env_name = rollout["env_name"]
+            # Single env-wide temperature per rollout — fan out across each
+            # sample's completion tokens here (interleave leaves it empty).
+            temperature = train_envs.get(env_name).sampling_args["temperature"]
             for sample in samples:
                 sample.advantage = rollout["advantage"]
                 sample.reward = rollout["reward"]
-                sample.env_name = rollout["env_name"]
+                sample.env_name = env_name
                 sample.training_mode = config.training_mode
+                sample.completion_temperatures = [temperature] * len(sample.completion_ids)
                 sample_decode_tokens = sum(sample.completion_mask)
                 sample_prefill_tokens = len(sample.prompt_ids) + len(sample.completion_mask) - sample_decode_tokens
                 rollout_decode_tokens += sample_decode_tokens

--- a/src/prime_rl/orchestrator/trajectories.py
+++ b/src/prime_rl/orchestrator/trajectories.py
@@ -236,8 +236,9 @@ def interleave_rollout(
         return None
 
     has_error = output["error"] is not None
-    # this field should be guaranteed because we set temperature in get_sampling_args
-    temperature = output["sampling_args"]["temperature"]
+    # ``completion_temperatures`` is left empty here; the orchestrator
+    # fans out the env's sampling temperature across each sample's
+    # completion tokens before constructing the TrainingBatch.
 
     def prepare_step_tokens(step: vf.TrajectoryStep, step_idx: int) -> dict[str, Any] | None:
         tokens = step["tokens"]
@@ -302,7 +303,7 @@ def interleave_rollout(
             completion_ids=completion_ids,
             completion_mask=completion_mask,
             completion_logprobs=list(tokens["completion_logprobs"]),
-            completion_temperatures=[temperature] * len(completion_ids),
+            completion_temperatures=[],
             teacher_logprobs=None,
             advantage=None,
             env_name=output["env_name"],
@@ -375,7 +376,6 @@ def interleave_rollout(
         sample.completion_ids.extend(new_prompt_ids)
         sample.completion_mask.extend([False] * len(new_prompt_ids))
         sample.completion_logprobs.extend([0.0] * len(new_prompt_ids))
-        sample.completion_temperatures.extend([temperature] * len(new_prompt_ids))
 
         # Extend with new completion tokens
         completion_ids = tokens["completion_ids"]
@@ -385,7 +385,6 @@ def interleave_rollout(
         else:
             sample.completion_mask.extend(tokens["completion_mask"])
         sample.completion_logprobs.extend(tokens["completion_logprobs"])
-        sample.completion_temperatures.extend([temperature] * len(completion_ids))
 
         step_routed = tokens.get("routed_experts")
         state = sample_routed_state.get(id(sample))


### PR DESCRIPTION
interleave_rollout no longer reads output["sampling_args"]["temperature"], which is None for v1 envs (sampling_args lives under state["runtime"]). The orchestrator stamps each sample's completion_temperatures from the env's TrainEnv.sampling_args in the existing post-process loop. Wire format unchanged.

Cherry-pick-equivalent of 635456822 onto v0.5.1.dev256.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Training still uses env-configured temperature; only the source and timing of stamping changed, with no wire-format change.
> 
> **Overview**
> Fixes **v1 verifiers env** rollouts where `output["sampling_args"]` is missing (sampling lives under runtime state), which previously broke temperature stamping in `interleave_rollout`.
> 
> **`interleave_rollout`** no longer reads rollout-level `sampling_args`; it leaves `completion_temperatures` empty on each `TrainingSample` (including when steps are extended).
> 
> **Orchestrator** fills `completion_temperatures` in the existing post-process loop using `train_envs.get(env_name).sampling_args["temperature"]`, one value per completion token.
> 
> **Env state columns** drop the required `sampling_args` column so rollouts only need `trajectory` in state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e5bb8e3d83a541a614bfc2a5925e9ef71dca8ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->