### PR TITLE
Disable vLLM DeepGEMM by default in inference runtime

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -256,7 +256,7 @@ class InferenceConfig(BaseConfig):
     """Enable dual batch overlap (DBO). Forwarded as ``--enable-dbo``."""
 
     use_deep_gemm: bool = False
-    """Force DeepGEMM FP8 kernels via ``VLLM_USE_DEEP_GEMM=1``. Only works with per-tensor FP8 quantization (e.g. GLM-5-FP8)."""
+    """Enable vLLM DeepGEMM FP8 kernels. Only works with per-tensor FP8 quantization (e.g. GLM-5-FP8)."""
 
     weight_broadcast: WeightBroadcastConfig = WeightBroadcastConfig()
 

--- a/src/prime_rl/inference/server.py
+++ b/src/prime_rl/inference/server.py
@@ -10,6 +10,10 @@ def setup_vllm_env(config: InferenceConfig):
     # spawn is more robust in vLLM nightlies and Qwen3-VL (fork can deadlock with multithreaded processes)
     os.environ.setdefault("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
 
+    deep_gemm_enabled = "1" if config.use_deep_gemm else "0"
+    os.environ["VLLM_USE_DEEP_GEMM"] = deep_gemm_enabled
+    os.environ["VLLM_MOE_USE_DEEP_GEMM"] = deep_gemm_enabled
+
     if config.enable_lora:
         os.environ["VLLM_ALLOW_RUNTIME_LORA_UPDATING"] = "True"
 


### PR DESCRIPTION
## Summary
- Make `InferenceConfig.use_deep_gemm` authoritative in the local/server inference path so default runs set both vLLM DeepGEMM env vars to `0` before importing vLLM.
- Preserve the opt-in path: `use_deep_gemm=true` still sets `VLLM_USE_DEEP_GEMM=1` and `VLLM_MOE_USE_DEEP_GEMM=1`.

## Testing
- `git diff --check`
- `python3 -m py_compile src/prime_rl/inference/server.py packages/prime-rl-configs/src/prime_rl/configs/inference.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to inference env wiring with an explicit default-off path; opt-in remains for FP8/MoE DeepGEMM use cases.
> 
> **Overview**
> **Default inference runs now turn vLLM DeepGEMM off explicitly** in `setup_vllm_env` before vLLM is imported: `InferenceConfig.use_deep_gemm` (default `false`) sets both `VLLM_USE_DEEP_GEMM` and `VLLM_MOE_USE_DEEP_GEMM` to `"0"` or `"1"`.
> 
> Opt-in is unchanged in spirit—`use_deep_gemm=true` still enables both flags. The config field docstring was tightened to describe enabling kernels rather than forcing a single env var.
> 
> This closes a gap versus SLURM launch paths, which only exported DeepGEMM when enabled; local/server startup could otherwise leave vLLM defaults in place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bf5d42b75b41f55e1d80eef1493491df68b7a8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->