### PR TITLE
[Minor]: Docs

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -36,18 +36,17 @@ impl = "custom"        # or "hf" to force the HF path
 | GLM-4 / GLM-4.5 / INTELLECT-3 | `THUDM/GLM-4-9B-0414`, `zai-org/GLM-4.5`, `PrimeIntellect/INTELLECT-3`, … | ✅ | ✅ |
 | GPT-OSS (HF MoE) | `openai/gpt-oss-20b`, `openai/gpt-oss-120b` | ❌ | ✅ |
 
-The custom path enables EP, selective activation checkpointing, FP8 training (`model.fp8 = true`, requires SM90+), and faster MoE kernels (`moe_use_grouped_mm = true`, default). Forcing `impl = "hf"` is mostly useful when debugging — it's slower and disables most MoE-specific knobs.
+The custom path enables you to set EP, CP, selective activation checkpointing, FP8 training (`model.fp8 = true`, requires SM90+), and faster MoE kernels (`moe_use_grouped_mm = true`, default). Forcing `impl = "hf"` is mostly useful when debugging — it's slower and disables most MoE-specific knobs.
 
 ### Expert Parallelism Backends
 
 `model.ep_comm_backend` picks the all-to-all kernel used for EP dispatch/combine:
 
 - **`torch`** (default): TorchTitan's all-to-all collective. Works everywhere, no extra install.
-- **`deepep`**: Custom kernels from DeepEP. Faster but requires DeepEP build (`bash scripts/install_deep_gemm.sh`, `bash scripts/install_ep_kernels.sh`) and tuning of `deepep_num_sms` (default 20) and `deepep_token_chunk_size` for your hardware.
+- **`deepep`**: Utilizes DeepEP's custom all-to-all collectives. This provides better performance if EP dimension spans multiple nodes. We provide pre-built binaries for H100/H200 with cuda runtime 12.9 installed, you can install them by running `uv sync --all-extras`.
+DeepEP requires some careful tuning to achieve optimal performance, tuning parameters are `deepep_num_sms` and `deepep_token_chunk_size`.
 
-DeepEP intranode dispatch derives the RDMA channel count as `deepep_num_sms / 2`. Lower SM count leaves more for compute; higher speeds up dispatch. Useful starting points: 16–24 SMs on H100, 20–40 on B200.
-
-When you enable DeepEP, gradient clipping is auto-disabled (`optim.max_norm` set to `None`) because the kernels don't currently support it.
+With DeepEP, gradient clipping is currently not supported. (`optim.max_norm` is set to `None` automatically.)
 
 ## Multimodal Training
 
@@ -80,7 +79,7 @@ language_model_attr = "model.language_model"
 # freeze_vision_encoder = true  # default; set false to fine-tune the encoder
 ```
 
-A bad attribute path errors immediately — no silent fallbacks. The weight-broadcast key prefix is derived as `{language_model_attr}.layers.` automatically.
+The weight-broadcast key prefix is derived as `{language_model_attr}.layers.` automatically.
 
 To add a new model family permanently, append an entry to `VLM_REGISTRY` in `src/prime_rl/utils/vlm.py`.
 
@@ -138,8 +137,7 @@ curl -s http://<decode_node>:8200/metrics | grep num_requests_waiting
 
 If prefill queues and decode is idle, add prefill nodes (and vice versa).
 
-**UCX 1.19 requirement.** NVSHMEM needs UCX ≥ 1.19 for multi-GPU CUDA. Most clusters ship UCX 1.17 via HPC-X, which manifests as `cuStreamCreate: invalid device context` errors during DeepEP internode dispatch. Check with `/opt/hpcx/ucx/bin/ucx_info -v` and, if needed, build from source:
-
+**UCX 1.19 requirement.** NVSHMEM needs UCX ≥ 1.19 for multi-GPU CUDA. If your cluster doesn't ship with UCX >=1.19, you can build it from source with the following command:
 ```bash
 salloc -N 1 --gres=gpu:1 bash -c 'bash scripts/install_nixl_from_source.sh'
 ```

--- a/docs/development.md
+++ b/docs/development.md
@@ -129,3 +129,12 @@ What to look for:
 - **Loss reasonable.** Not NaN, not stuck.
 
 Don't expect reward to climb meaningfully in 20 steps on a random model.
+
+### Requirements for merging a new model
+
+Before merging a new model, you need to ensure the following:
+
+- The model is correctly registered and defines and all the required methods - such as `convert_hf_layer_to_tt` and `convert_tt_layer_to_hf`.
+- The small smoke test passes.
+
+In the PR that adds the new model, you also need to provide a table covering the KL mismatch across 20 steps on `math` environment with `batch_size=64`. All the entries in the table must lower than 0.015. If this is not met, the PR will not be merged (unless reasonable justification is provided). This is to ensure all our models are consistent and their implementations match the implementations in the inference framework.

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -1,0 +1,247 @@
+# Inference
+
+This page covers the inference configuration and the supported features/deployment shapes. It covers how to scale the inference server from a single GPU to 1000s of GPUs that run agentic workloads at the speed of light with all the bells and whistles configured.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Single-Node](#single-node)
+- [Multi-Node](#multi-node)
+    - [Multi-replica](#multi-replica)
+    - [Wide-EP](#wide-ep)
+- [P/D Dissagregation](#pd-dissagregation)
+- [Router](#router)
+    - [Routing policies](#routing-policies)
+- [Advanced Configuration](#advanced-configuration)
+    - [KV Cache Offload](#kv-cache-offload)
+    - [Optimized P/D disaggregation deployment](#optimized-pd-disaggregation-deployment)
+    - [Other vLLM features](#other-vllm-features)
+    - [Router Replay](#router-replay)
+
+
+## Overview
+
+`prime-rl` chooses to use `vLLM` as the inference engine. We aim to stay up-to-date with the latest vLLM features, being at-most 1 version behind the latest stable release. This allows us to use the latest features from vLLM as soon as they are released - such as router replay, CPU KV cache offload, and more.
+
+We support 3 distinct deployment shapes:
+- [Single-Node](#single-node) - Runs the inference server on a single node. Useful for debugging, small scale experiments or smaller models. The default deployment shape.
+- [Multi-Node](#multi-node) - Runs the inference server on multiple nodes. Useful for large scale experiments or larger models, where latency is not a concern - i.e. single turn inference, long context inference, etc.
+- [Disaggregated](#disaggregated) - Runs the inference server on multiple nodes, but disaggregates the prefill and decode stages. Useful for large scale experiments or larger models, where latency is a concern and multi-node deployment creates very high E2E rollout latency, such as agentic workflows.
+
+Most of the features are supported for all deployment shapes, with few exceptions. These exceptions are rejected on validation.
+
+You can select the deployment shape with `InferenceDeploymentConfig` in your config file. This is a config-field that allows you to set the deployment shape, deployment-specific knobs such as `num_nodes`, `num_replicas`, `router_port`, `backend_port`, etc.
+
+```toml
+[inference.deployment]
+type = "single_node" # or "multi_node" or "disaggregated"
+```
+
+To configure the inference server, you can use the `InferenceConfig` field. This is a config-field that allows you to set the inference server-specific knobs. Most of these are supported for all deployment shapes, with few exceptions. These exceptions are rejected on validation.
+
+```toml
+[inference]
+model = "PrimeIntellect/INTELLECT-3"
+...
+```
+
+We will now walk through the supported features and deployment shapes in detail, starting with the single-node deployment.
+
+## Single-Node
+
+The single-node deployment is the default deployment shape. It runs the inference server on a single node. It is useful for debugging, small scale experiments or smaller models. You can configure the single-node deployment with the `SingleNodeInferenceDeploymentConfig` config-field.
+
+```toml
+[inference.deployment]
+type = "single_node"
+```
+
+This deployment shape runs the inference server on a single node, if configured with NVLink enabled, it allows you more freedom in terms of parallelism configurations.
+
+```toml
+[inference]
+enable_expert_parallel = true # defaults to False
+
+[inference.parallel]
+tp = 2
+dp = 4
+
+[inference.deployment]
+type = "single_node"
+```
+
+We reccomend choosing your parallelism based on the expected throughput and latency requirements. High `dp` might create high latency, however it will also give you the highest throughput. This is a tradeoff you need to make based on your use case and required `orchestrator.max_inflight_requests`. Setting `tp` to a higher value will usually give you lower latency, but the inference server also will become saturated faster with lower number of requests.
+
+Another thing to consider, is the memory usage. You need to make sure that the model will fit into the available GPU memory. We will not go into the details on how to do this in this document. Related thing to consider, is the space for the KV cache. This will heavily affect the amount of requests your inference server can handle. You want to shard your model, either using `inference.enable_expert_parallel` or `inference.parallel.tp` to maximize the available GPU memory.
+
+You can also increase the available KV cache memory by enabling `inference.kv_cache_offload`. More details in the [Advanced Configuration](#advanced-configuration) section.
+
+
+## Multi-Node
+
+This deployment shape branches into 2 sub-shapes:
+
+- [Multi-replica](#multi-replica) - Runs the inference server on multiple nodes, but each node runs an independent vLLM replica. You can think of this as a for-loop over single-node deployments.
+- [Wide-EP](#wide-ep) - This option is gated behind `inference.enable_expert_parallel = true`. It allows you to run the inference server on multiple nodes, allowing you to use multi-node expert parallelism. This is a more advanced feature that is suitable for high-throughput, high-concurrency workloads.
+
+### Multi-replica
+
+This deployment shape runs the inference server on multiple nodes, but each node runs an independent vLLM replica.
+Parallelism configuration is the same as the single-node deployment. The shape is defined by setting `inference.deployment.type = "multi_node"` and `inference.deployment.num_nodes` to the number of nodes you want to run the inference server on.
+
+```toml
+[inference.deployment]
+type = "multi_node"
+num_nodes = 2
+
+[inference]
+model = "PrimeIntellect/INTELLECT-3"
+
+[inference.parallel]
+tp = 2
+dp = 4
+```
+
+This configuration will run 2 independent vLLM replicas, each with `tp=2` and `dp=4`. Routing will be handled by the `vllm-router` instance running on the same node as the 1st replica. We aim to support more advanced routing options, such as `llm-d` or `dynamo` in the future. You can read more about the supported routing options in the [router](#router) section.
+
+### Wide-EP
+
+For huge, 200B+ scale models, you might want to use multi-node expert parallelism to maximize the KV-cache space. This deployment shape is defined by setting `inference.deployment.type = "multi_node"` and `inference.enable_expert_parallel = true`.
+
+```toml
+[inference.deployment]
+type = "multi_node"
+num_nodes = 2
+
+[inference]
+model = "PrimeIntellect/INTELLECT-3"
+enable_expert_parallel = true
+
+[inference.parallel]
+tp = 2
+dp = 8
+```
+
+This configuration will run 2 vLLM processes, each with `data_parallel_size_local = 4` and `tp = 2` and expert parallelism spanning 2 nodes. The requests are again routed to these processes via the `vllm-router`.
+
+## P/D Dissagregation
+
+This is the most advanced deployment shape. It allows you to disaggregate the prefill and decode stages, with KV cache flowing between them. This is useful for large scale deployments, where there are high requirements on latency, such as agentic workflows spanning 100s of turns.
+
+This deployment shape is defined by setting `inference.deployment.type = "disaggregated"` and `inference.deployment.num_prefill_nodes` and `inference.deployment.num_decode_nodes` to the number of nodes you want to run the prefill and decode stages on.
+
+```toml
+[inference.deployment]
+type = "disaggregated"
+num_prefill_nodes = 2
+num_decode_nodes = 2
+```
+
+Sometimes, you may want to run multiple independent vLLM instances within the prefill and decode node groups. You can do this by setting `inference.deployment.num_prefill_replicas` and `inference.deployment.num_decode_replicas` to the number of replicas you want to run.
+
+```toml
+[inference.deployment]
+type = "disaggregated"
+num_prefill_nodes = 2
+num_decode_nodes = 2
+
+num_prefill_replicas = 2
+num_decode_replicas = 1
+```
+
+Now the total deployment will span 6 nodes - 2x2 for prefill and 1x2 for decode. 2 prefill replicas will run on 2 nodes each - total of 4 nodes for prefill. 1 decode replica will run on 2 nodes for decode.
+
+We also allow you to configure the total amount of inference replicas - this is useful if you'd like to multiply the above configuration by a factor of `k`, each running behind a separate `vllm-router` instance.
+
+```toml
+[deployment] # this is a top-level RL deployment, not inference.deployment!!
+type = "multi_node"
+num_train_nodes = 4
+num_infer_nodes = 6 # this is per-replica
+
+num_infer_replicas = 3
+```
+
+This will run 3 inference replicas, each running on 6 nodes. Each replica will run on 2x2 nodes for prefill and 1x2 nodes for decode. The total deployment will span 18 nodes. This will also spin-up 3 separate `vllm-router` instances.
+
+
+## Router
+
+We use our own fork of [vllm-router](https://github.com/PrimeIntellect-ai/router) as the request handler. We plan to support more advanced proxy options in the future.
+
+Right now, router handles 2 most important things:
+- Request routing - KV cache re-use and balanced routing
+- P/D disaggregation - handling the prefill and decode stages separately
+
+### Routing policies
+The 2 policies you might want to configure are:
+- `consistent_hash` - this is the default policy that optimizes for KV cache re-use across turns - this works by hashing a request header to determine where to route the request to. You can configure what to hash by setting
+`orchestrator.student.client.extra_headers_from_state` to the header the `router` expects to be set.
+
+We set it to a sensible default, that works with all verifiers environments.
+
+```toml
+[orchestrator.student.client.extra_headers_from_state]
+X-Session-ID = "trajectory_id" # this is the default - each rollout has a unique trajectory_id and router expects X-Session-ID
+```
+
+- `round_robin` - this policy will round-robin the requests between the available replicas. This is useful if you want to balance the load between the replicas. This might give you better results if you don't have enough rollouts to make `consistent_hash` hashing saturated.
+
+
+## Advanced Configuration
+
+### KV Cache Offload
+
+Maximizing KV-Cache space is crucial to support high-concurrency workloads. We allow you to offload the KV cache to CPU memory, which can increase the space 10-fold in some cases. You can configure the amount of CPU memory to use for the KV cache by setting `inference.deployment.kv_cache_offload.cpu_bytes`.
+
+```toml
+[inference.kv_cache_offload]
+cpu_bytes = 128_000_000_000 # 128GB
+```
+
+This will reserve 128GB of CPU memory per worker. If you use dp=8, this will reserve 1TB of CPU memory per node.
+
+We aim to support more offloading options in the future, such as multi-tier offloading to also utilize disk-based KV cache, or distributed storage options like Mooncake Connector.
+
+
+### Optimized P/D disaggregation deployment
+
+For optimal P/D disaggregation deployment, we automatically set the decode `all2all_backend` to `deepep_low_latency` and the prefill `all2all_backend` to `deepep_high_throughput`. We currently don't support customizing all2all backends for P/D disaggragation out of the box. You can do this by overriding the slurm template only.
+
+For KV cache transfer, we utilize the NIXL connector. This is the default and only currently supported connector. We aim to support more advanced options, such as D->P transfer, or Mooncake Connector in the future.
+
+For configuring various knobs with environment variables, we enable you to configure prefill and decode environment variables separately. This is useful if you want to configure different environment variables for the prefill and decode stages.
+
+```toml
+[inference.deployment]
+type = "disaggregated"
+
+prefill_env_overrides = {"VLLM_ENABLE_MOE_DP_CHUNK"="0", "VLLM_DEEP_GEMM_WARMUP"="skip"}
+decode_env_overrides = {"VLLM_DEEP_GEMM_WARMUP"="skip"}
+```
+
+### Other vLLM features
+We support various other vLLM features. Some of those, such as `enable_dbo`, `enable_eplb` are exposed as a top-level config fields. For those that are not, you can configure them by setting `inference.vllm_extra` to the desired value.
+
+```toml
+[inference.vllm_extra]
+headless = true
+```
+
+### Router Replay
+
+Router replay works by capturing the expert routing decisions into a buffer. This buffer then gets sent to the trainer, which can use it instead of re-computing the routing. This lowers the trainer<->inference mismatch by an order of magnitude, resulting in more stable training.
+
+To enable router replay, you can set `inference.enable_return_routed_experts = true`.
+
+```toml
+[trainer]
+enable_router_replay = true # this will also auto-set the inference.enable_return_routed_experts = true
+
+[inference]
+enable_return_routed_experts = true
+```
+
+This however is not free, it adds a significant overhead to the HTTP requests as this payload can grow quite large. We reccomend increasing `orchestrator.*.env.num_workers` to allow for more parallelization on the verifiers side.
+
+Currently this feature is also not supported with CPU KV cache offload, which can have negative impact on the inference throughput.

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -7,6 +7,7 @@
                 "overview",
                 "configuration",
                 "training",
+                "inference",
                 "scaling",
                 "algorithms",
                 "advanced",

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -8,9 +8,9 @@ A `prime-rl` RL run is three cooperating processes:
 
 ![Architecture](assets/architecture.png)
 
-- **Inference** — vLLM-backed server (or fleet) holding the current policy. The orchestrator drives rollouts through the token-in `/v1/generate` route via the [`renderers`](https://github.com/PrimeIntellect-ai/renderers) package (OpenAI-compatible chat/completions routes are also exposed for external clients). Supports data + tensor + expert parallelism (with `deepep` and `flashinfer` all-to-all backends and EPLB), FP8 inference, prefill/decode disaggregation behind a `vllm-router`, CPU KV-cache offload, and *router replay* (the routed-expert mask is returned to the trainer for FP8 MoE numerical parity). Weights are pushed in place through a custom `update_weights` endpoint over filesystem or NCCL transports.
+- **Inference** — vLLM-backed server (or fleet) holding the current policy. The orchestrator drives rollouts through the token-in `/v1/generate` route via the [`renderers`](https://github.com/PrimeIntellect-ai/renderers) package (OpenAI-compatible chat/completions routes are also exposed for external clients). We are trying to stay up-to-date with the latest vLLM features, you can read more about the supported features and deployment options in the dedicated [inference documentation](inference.md).
 - **Orchestrator** — Lightweight CPU process that owns the data plane across many [`verifiers`](https://github.com/PrimeIntellect-ai/verifiers) training and eval environments. Each env runs in an isolated subprocess with a variable-size pool of env workers for scalability. The orchestrator drives multi-turn rollouts against the inference fleet (tool use, browsers, sandboxes, long horizons) without re-tokenizing across turns, computes advantages, packs the rollouts into training batches, and relays new weights from trainer to inference.
-- **Trainer** — FSDP2 process group that consumes packed rollouts and steps the optimizer. We ship optimized custom modeling code for many MoE / dense / VLM families that unlocks advanced trainer parallelism — expert parallelism (EP, with DeepEP kernels) and context parallelism (CP) for long-sequence training — plus selective activation checkpointing, FP8 training on Hopper+, LoRA, and multi-tenant training (many concurrent LoRA tenants sharing one trainer + inference deployment).
+- **Trainer** — FSDP2 process group that consumes packed rollouts and steps the optimizer. We ship optimized custom modeling code for many MoE / dense / VLM families that unlocks advanced trainer parallelism — expert parallelism (EP, with DeepEP kernels) and context parallelism (CP) for long-sequence training — plus selective activation checkpointing, FP8 training on Hopper+, LoRA, and multi-tenant training (many concurrent LoRA tenants sharing one trainer + inference deployment). You can read more in the dedicated [trainer documentation](trainer.md).
 
 The three processes communicate through configurable transports — by default the trainer↔orchestrator rollout link uses the local filesystem, and weight broadcast uses the filesystem (or NCCL for synchronous setups). Swap to ZMQ for multi-host setups without shared storage. See [Scaling](scaling.md) for the deployment options.
 
@@ -20,7 +20,7 @@ The three processes communicate through configurable transports — by default t
 curl -sSL https://raw.githubusercontent.com/PrimeIntellect-ai/prime-rl/main/scripts/install.sh | bash
 ```
 
-The script clones the repo, initializes the [`verifiers`](https://github.com/PrimeIntellect-ai/verifiers) / [`renderers`](https://github.com/PrimeIntellect-ai/renderers) / [`research-environments`](https://github.com/PrimeIntellect-ai/research-environments) submodules, installs `uv`, and runs `uv sync --all-extras`. For manual setup, MoE-only installs (DeepGEMM / DeepEP / NIXL), or troubleshooting, see the [README](https://github.com/PrimeIntellect-ai/prime-rl#setup).
+The script clones the repo, initializes the [`verifiers`](https://github.com/PrimeIntellect-ai/verifiers) / [`renderers`](https://github.com/PrimeIntellect-ai/renderers) / [`research-environments`](https://github.com/PrimeIntellect-ai/research-environments) submodules, installs `uv`, and runs `uv sync --all-extras`. For manual setup, or troubleshooting, see the [README](https://github.com/PrimeIntellect-ai/prime-rl#setup).
 
 You need at least one NVIDIA GPU (RTX 3090/4090/5090, A100, H100, H200, or B200). Single-GPU runs are supported for debugging; production RL is typically 1× inference node + 1+ trainer nodes.
 
@@ -38,6 +38,7 @@ The `rl` entrypoint reads `examples/reverse_text/rl.toml`, splits it into per-pr
 
 - **[Configuration](configuration.md)** — TOML composition, CLI overrides, dry-run.
 - **[Training](training.md)** — Launch and observe RL and SFT runs.
+- **[Inference](inference.md)** — vLLM-backed server (or fleet) holding the current policy.
 - **[Scaling](scaling.md)** — Single-GPU through multi-node clusters via FSDP / EP / CP and SLURM.
 - **[Algorithms](algorithms.md)** — Async semantics, loss / advantage / filter plugins, trajectory merging.
 - **[Advanced](advanced.md)** — Custom modeling, multimodal, LoRA, multi-tenant, P/D inference.

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -1,6 +1,6 @@
 # Scaling
 
-This page covers how to scale `prime-rl` from a single GPU to a 1000-GPU cluster: single-node and multi-node deployments, FSDP / expert parallelism / context parallelism, and throughput benchmarking. For knobs that fit on one box, see [Training](training.md) first. For prefill/decode disaggregated inference, see [Advanced](advanced.md#disaggregated-prefilldecode-inference).
+This page covers how to scale `prime-rl` from a single GPU to a 1000-GPU cluster: single-node and multi-node deployments, FSDP / expert parallelism / context parallelism, and throughput benchmarking. See [Training](training.md) for detailed documentation of the trainer configuration and [Inference](inference.md) for the inference configuration.
 
 ## Table of Contents
 
@@ -90,7 +90,7 @@ FSDP2 is the default model sharding strategy. By default the trainer fully shard
 
 ### Expert Parallelism
 
-EP shards MoE expert weights across the EP mesh, dramatically reducing the FSDP communication volume per layer. EP is only available with the custom model implementation (`model.impl = "custom"` or `"auto"` for supported families).
+EP shards MoE expert weights across the EP mesh, dramatically reducing the FSDP communication volume per layer and improving the training throughput. EP is only available with the custom model implementation (`model.impl = "custom"` or `"auto"` for supported families).
 
 ```toml
 [trainer.model]
@@ -103,14 +103,14 @@ ep_comm_backend = "torch"  # or "deepep"
 
 ### Context Parallelism
 
-CP shards a single sequence across multiple GPUs along the token dimension — for long-context sequences. Only available with the custom impl and flash-attention.
+CP shards a single sequence across multiple GPUs along the token dimension — for long-context sequences. We reccomend using `ulysses` style CP for most of the models to get the most throughput. Some models (e.g. GLM-5) only support `ring` style CP. Wrong setting will be rejected on validation.
 
 ```toml
 [trainer.model]
 impl = "custom"
 attn = "flash_attention_2"   # or fa3 / fa4
 cp = 2                       # CP degree
-cp_style = "ring"            # "ulysses" for non-FA kernels
+cp_style = "ulysses"         # "ring"
 ```
 
 ### Activation Checkpointing and Offloading
@@ -127,6 +127,13 @@ Enable selective AC (custom impl only) for the best memory/throughput tradeoff:
 [trainer.model.ac]
 mode = "selective"
 targets = ["norm", "attn_proj"]  # see Reference for the full list per architecture
+```
+
+We reccomend also using `ac_offloading` and `ac_offloading.max_inflight_activations = 5` to further reduce the memory footprint in tradeoff for some throughput. We've observed this feature to be very effective, lowering the peak memory usage by 30-40% in some cases, while only lossing ~3-5% of throughput:
+
+```toml
+[trainer.model.ac_offloading]
+max_inflight_activations = 5
 ```
 
 ### Optimizer Offloading

--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -256,7 +256,7 @@ class InferenceConfig(BaseConfig):
     """Enable dual batch overlap (DBO). Forwarded as ``--enable-dbo``."""
 
     use_deep_gemm: bool = False
-    """Force DeepGEMM FP8 kernels via ``VLLM_USE_DEEP_GEMM=1``. Only works with per-tensor FP8 quantization (e.g. GLM-5-FP8)."""
+    """Force DeepGEMM FP8 kernels via ``VLLM_USE_DEEP_GEMM=1``. Only works with block-wise FP8 quantization (e.g. GLM-5-FP8)."""
 
     weight_broadcast: WeightBroadcastConfig = WeightBroadcastConfig()
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and comment-only config docstring changes; no runtime behavior changes.
> 
> **Overview**
> Adds a dedicated **[Inference](inference.md)** guide and wires it into Mintlify navigation and the overview/scaling cross-links, while trimming the long inference bullet on the overview page in favor of pointers to `inference.md` and `trainer.md`.
> 
> **Advanced** and **scaling** docs are refreshed: DeepEP install/tuning notes (`uv sync --all-extras`, multi-node EP), CP guidance (default `ulysses`, model-specific `ring`), and a recommended `ac_offloading.max_inflight_activations = 5` recipe. **Development** now states merge requirements for new models (registration, smoke test, KL mismatch table on `math` with threshold 0.015).
> 
> The only code change is a docstring on `InferenceConfig.use_deep_gemm` clarifying **block-wise** FP8 (e.g. GLM-5-FP8) and `VLLM_USE_DEEP_GEMM=1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0da6e77a1c9de7d750390737fa2f5e84cdabeb6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->