### PR TITLE
fix(test): drop flaky step-7 reward upper bound in multi-run test

### DIFF
--- a/tests/integration/test_reverse_text_multi_run.py
+++ b/tests/integration/test_reverse_text_multi_run.py
@@ -406,7 +406,7 @@ def test_reward_in_range(multi_run_result: dict[str, ProcessResult], output_dir:
         with open(log_file, "r") as f:
             lines = strip_escape_codes(f.read()).splitlines()
         if name in ["beta", "gamma"]:
-            check_reward_in_range(lines, step=7, min_threshold=0.2, max_threshold=0.6)
+            check_reward_in_range(lines, step=7, min_threshold=0.2)
             check_reward_in_range(lines, min_threshold=0.65)
         elif name in ["alpha_resume", "beta_resume"]:
             check_reward_in_range(lines, min_threshold=0.65)


### PR DESCRIPTION
## Summary

- Remove the `max_threshold=0.6` upper bound on the **step-7** reward check in `test_reverse_text_multi_run::test_reward_in_range` (for the `beta`/`gamma` orchestrators). The step-7 `min_threshold=0.2` and the final `min_threshold=0.65` checks are kept.

The upper bound is not load-bearing. The "reward actually improves over training" property is already covered by:
- `test_reward_goes_up` → `check_reward_goes_up` (first step < last step)
- the final `check_reward_in_range(lines, min_threshold=0.65)` (must end high)
- the step-7 `check_reward_in_range(lines, step=7, min_threshold=0.2)` (must already be learning by step 7, well above the ~0.17 cold start)

The only thing `max_threshold=0.6` added was asserting step 7 specifically hadn't yet reached its final value — a noisy, arbitrary constraint made redundant by the checks above.

## Verification

Latest `main` GPU run failed here (run `26776965509`, `reverse_text_multi_run` job):

```
AssertionError: Reward exceeded maximum threshold. Found Reward=0.608 > 0.6
(... Step 7 | Reward 0.6080 ...)
```

The gamma reward trajectory in that run bounces around the boundary in the step 6-8 window:

```
Step 6 | Reward 0.4990
Step 7 | Reward 0.6080   <- exceeds 0.6
Step 8 | Reward 0.5144
...
Step 19 | Reward 0.7380
```

So step 7 crossing `0.6` is run-to-run noise at the threshold, not a regression. After this change the step-7 lower bound (`>= 0.2`), the final `>= 0.65` check, and `test_reward_goes_up` still pass and continue to guard the learning curve.