### PR TITLE
Enable fp32 lm head by default

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -266,7 +266,7 @@ class InferenceConfig(BaseConfig):
     enable_return_routed_experts: bool = False
     """Return routed experts in responses. Forwarded as ``--enable-return-routed-experts``."""
 
-    enable_fp32_lm_head: bool = False
+    enable_fp32_lm_head: bool = True
     """Run the lm_head projection in fp32 via a native bf16×bf16 → fp32 GEMM (``torch.mm`` with ``out_dtype=torch.float32``). Stabilizes logprob precision under FP8/bf16 inference, matching SGLang's ``--enable-fp32-lm-head``. Implemented as a monkey-patch over vLLM's LogitsProcessor, activated by setting ``additional_config["fp32_lm_head"] = True`` on the vLLM config."""
 
     vllm_extra: dict[str, Any] = {}


### PR DESCRIPTION
## Summary

- Enable `inference.enable_fp32_lm_head` by default.
- Keep the existing vLLM `additional_config["fp32_lm_head"]` activation path unchanged, so the launcher now opts into the fp32 lm_head projection unless users override the config.

## Validation

- `git diff --check`
- `uv run pytest tests/unit/test_configs.py`
- pre-commit hooks during commit: `ruff check`, `ruff format`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default vLLM inference logits path for all runs without an explicit override; mainly affects logprob precision and possible minor perf, not security.
> 
> **Overview**
> **Default inference now runs the lm_head in fp32** by changing `InferenceConfig.enable_fp32_lm_head` from `False` to `True`. Unchanged configs will pass `additional_config["fp32_lm_head"] = True` through `to_vllm()`, enabling the existing vLLM `LogitsProcessor` monkey-patch for more stable logprobs under FP8/bf16. Set `inference.enable_fp32_lm_head: false` to restore the previous default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ccd7c5f2b0f9482845da2df70ac79c645ef1c27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->