### PR TITLE
fix(orchestrator): drop cache_salt for SFT teacher rollouts

### DIFF
--- a/src/prime_rl/orchestrator/dispatcher.py
+++ b/src/prime_rl/orchestrator/dispatcher.py
@@ -408,7 +408,13 @@ class RolloutDispatcher:
         if env_collection is None:
             return False
         env = env_collection.get(group.env_name)
-        cache_salt = str(group.policy_version_at_start)
+        # SFT-mode train rollouts hit the frozen teacher pool; salting per
+        # policy version would invalidate the teacher's prefix cache every
+        # weight update for no reason.
+        if self.training_mode == "sft" and group.kind == "train":
+            cache_salt = None
+        else:
+            cache_salt = str(group.policy_version_at_start)
 
         if env.requires_group_scoring:
             permits = group.rollouts_to_schedule

--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -103,8 +103,10 @@ class Env:
         self._env_server_process = process
         return address
 
-    def _sampling_args_with_salt(self, cache_salt: str) -> dict:
+    def _sampling_args_with_salt(self, cache_salt: str | None) -> dict:
         sampling_args = {**self.sampling_args}
+        if cache_salt is None:
+            return sampling_args
         extra_body = {**sampling_args.get("extra_body", {}), "cache_salt": cache_salt}
         sampling_args["extra_body"] = extra_body
         return sampling_args
@@ -123,7 +125,7 @@ class Env:
         client: vf.ClientConfig,
         example: dict,
         model_name: str,
-        cache_salt: str,
+        cache_salt: str | None,
     ) -> vf.RolloutOutput:
         """Run a single rollout for an example."""
         return await self.env.run_rollout(
@@ -142,7 +144,7 @@ class Env:
         example: dict,
         model_name: str,
         group_size: int,
-        cache_salt: str,
+        cache_salt: str | None,
     ) -> list[vf.RolloutOutput]:
         """Run a group of rollouts for an example. Required for group-scoring envs."""
         return await self.env.run_group(


### PR DESCRIPTION
## Summary
- In SFT training mode, train rollouts route to the frozen teacher pool. The dispatcher was salting every request with `str(group.policy_version_at_start)`, so the teacher's prefix cache was invalidated on every weight update for no reason.
- Skip the salt when `training_mode == "sft"` and `group.kind == "train"`; student paths (RL/OPD train and all eval) keep the policy-version salt unchanged.
- `Env._sampling_args_with_salt` / `run_rollout` / `run_group` now accept `cache_salt: str | None` and omit the `extra_body.cache_salt` field when `None`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small orchestrator inference-caching tweak; student/eval salting behavior is unchanged.
> 
> **Overview**
> **SFT train rollouts** no longer send a policy-version `cache_salt` to the frozen teacher inference pool. The dispatcher sets `cache_salt` to `None` when `training_mode == "sft"` and the group is train; RL/OPD train and all eval paths still use `str(group.policy_version_at_start)` so student prefix caching stays tied to the policy version at rollout start.
> 
> `Env._sampling_args_with_salt`, `run_rollout`, and `run_group` now accept optional salt and **omit** `extra_body.cache_salt` when it is `None`, instead of always injecting it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbd2749eb2215879d70635a84aadbb381ce326c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->