### PR TITLE
Skip prefix-cache salt for frozen teacher in SFT mode

### DIFF
--- a/src/prime_rl/orchestrator/dispatcher.py
+++ b/src/prime_rl/orchestrator/dispatcher.py
@@ -408,7 +408,13 @@ class RolloutDispatcher:
         if env_collection is None:
             return False
         env = env_collection.get(group.env_name)
-        cache_salt = str(group.policy_version_at_start)
+        # The salt busts the prefix cache between policy versions. In SFT mode
+        # train rollouts hit the frozen teacher, whose cache stays valid across
+        # versions, so salting would needlessly evict it every step. Eval always
+        # hits the (changing) student, so it keeps the salt.
+        cache_salt: str | None = str(group.policy_version_at_start)
+        if self.training_mode == "sft" and group.kind == "train":
+            cache_salt = None
 
         if env.requires_group_scoring:
             permits = group.rollouts_to_schedule

--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -103,8 +103,10 @@ class Env:
         self._env_server_process = process
         return address
 
-    def _sampling_args_with_salt(self, cache_salt: str) -> dict:
+    def _sampling_args_with_salt(self, cache_salt: str | None) -> dict:
         sampling_args = {**self.sampling_args}
+        if cache_salt is None:
+            return sampling_args
         extra_body = {**sampling_args.get("extra_body", {}), "cache_salt": cache_salt}
         sampling_args["extra_body"] = extra_body
         return sampling_args
@@ -123,7 +125,7 @@ class Env:
         client: vf.ClientConfig,
         example: dict,
         model_name: str,
-        cache_salt: str,
+        cache_salt: str | None,
     ) -> vf.RolloutOutput:
         """Run a single rollout for an example."""
         return await self.env.run_rollout(
@@ -142,7 +144,7 @@ class Env:
         example: dict,
         model_name: str,
         group_size: int,
-        cache_salt: str,
+        cache_salt: str | None,
     ) -> list[vf.RolloutOutput]:
         """Run a group of rollouts for an example. Required for group-scoring envs."""
         return await self.env.run_group(


### PR DESCRIPTION
## Summary

- In SFT training mode, train rollouts are served by the **frozen teacher**, so its prefix cache stays valid across policy versions. The dispatcher was salting every rollout with the policy version (`cache_salt = str(group.policy_version_at_start)`), which needlessly evicted the teacher's prefix cache every step.
- Skip the salt for SFT train rollouts (`training_mode == "sft"` and `group.kind == "train"`). Eval (always the student) and `rl`/`opd` train rollouts keep the salt, since they hit the changing student policy.
- `Env._sampling_args_with_salt` now accepts `str | None` and omits `cache_salt` from `extra_body` when `None`; `run_rollout` / `run_group` signatures updated to match.

Made with [Cursor](https://cursor.com)