### PR TITLE
fix(inference): require SLURM for disaggregated deployment

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -354,8 +354,8 @@ class InferenceConfig(BaseConfig):
 
     @model_validator(mode="after")
     def validate_multi_node_requires_slurm(self):
-        if self.deployment.type == "multi_node" and self.slurm is None:
-            raise ValueError("Must use SLURM for multi-node deployment.")
+        if self.deployment.type in ("multi_node", "disaggregated") and self.slurm is None:
+            raise ValueError("Must use SLURM for multi-node / disaggregated deployment.")
         return self
 
     @model_validator(mode="after")

--- a/packages/prime-rl-configs/src/prime_rl/utils/validation.py
+++ b/packages/prime-rl-configs/src/prime_rl/utils/validation.py
@@ -127,6 +127,12 @@ def propagate_shared_fields(data: Any) -> Any:
     propagate("max_steps", "trainer.max_steps", "orchestrator.max_steps")
     propagate("seq_len", "trainer.model.seq_len", "orchestrator.seq_len")
 
+    # [slurm] → inference: a multi-node RL run drives its inference deployment under
+    # the same SLURM allocation, so the nested inference inherits [slurm]. This is
+    # what lets the nested InferenceConfig's multi-node / disaggregated SLURM check
+    # pass (the per-rank inference.toml drops slurm, so each rank still runs locally).
+    propagate("slurm", "inference.slurm")
+
     # output_dir: orchestrator gets a ``/run_default`` subdir so trainer +
     # orchestrator nest under the same experiment root without colliding.
     # Conflicts are reported against the *transformed* sub-config value, not


### PR DESCRIPTION
## Summary

Two coupled fixes so a disaggregated (P/D) inference deployment can't silently run without SLURM:

1. **Require SLURM for `disaggregated`.** `InferenceConfig.validate_multi_node_requires_slurm` only covered `multi_node`. A disaggregated deployment is equally multi-node (separate prefill/decode node groups + NIXL KV transfer) and needs SLURM — without this, a disaggregated `InferenceConfig` with no `[slurm]` passed validation and fell through to the local launcher, which can't run it.

2. **Forward top-level `[slurm]` into the nested inference.** The same `InferenceConfig` is reused nested inside `RLConfig`, where SLURM lives at the top level. RL P/D configs (e.g. `examples/glm5_pd_disag/rl.toml`) set `[slurm]` but not `[inference.slurm]`, so check (1) alone would break them. `propagate_shared_fields` now forwards `[slurm]` → `inference.slurm` (RL-only; conflict-checked like the other shared fields). The per-rank `inference.toml` already excludes `slurm`, so each inference rank still runs locally — **no SLURM-in-SLURM**.

## Verified

- `examples/glm5_pd_disag/rl.toml` (RL P/D) still loads — `[slurm]` forwarded to the nested disaggregated inference.
- Standalone disaggregated `InferenceConfig` with no slurm now raises.
- Single-node inference without slurm unaffected; existing multi-node RL configs unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small config validation and propagation changes; they prevent mis-launch of multi-node P/D inference without affecting single-node paths when SLURM is unset.
> 
> **Overview**
> **Disaggregated inference must use SLURM**, same as `multi_node`: `InferenceConfig` validation now rejects `deployment.type = disaggregated` when `slurm` is missing, so configs cannot pass validation and fall back to a local launcher that cannot run P/D.
> 
> For **nested inference inside `RLConfig`**, top-level `[slurm]` is **propagated to `inference.slurm`** during shared-field propagation (fill-if-absent, with the usual conflict rules). RL jobs that only set `[slurm]`—for example P/D examples—still satisfy that check without duplicating `[inference.slurm]`. Per-rank materialized `inference.toml` continues to omit `slurm`, so workers still launch locally under the parent allocation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0032b4661ba03259b0b4280f09f524c21489b4b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->