### PR TITLE
chore(slurm): use external-LB everywhere, drop hybrid-LB

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -580,7 +580,13 @@ class RLConfig(BaseConfig):
 
         total_infer_gpus = self.deployment.total_infer_nodes * self.deployment.gpus_per_node
         if "inference_metrics_roles" not in self.orchestrator.model_fields_set:
-            role_order = ["prefill"] * infer_deploy.num_prefill_nodes + ["decode"] * infer_deploy.num_decode_nodes
+            # External-LB: one admin client per DP rank, so roles expand per rank
+            # (stride = dp_local = gpus_per_node / tp). ADMIN_URLS lists all prefill
+            # ranks, then all decode ranks, per replica — match that order.
+            stride = self.deployment.gpus_per_node // self.inference.parallel.tp
+            role_order = ["prefill"] * (infer_deploy.num_prefill_nodes * stride) + ["decode"] * (
+                infer_deploy.num_decode_nodes * stride
+            )
             self.orchestrator.inference_metrics_roles = role_order * self.deployment.num_infer_replicas
         if self.weight_broadcast is not None and self.weight_broadcast.type == "nccl":
             assert self.trainer.weight_broadcast.type == "nccl"

--- a/src/prime_rl/entrypoints/inference.py
+++ b/src/prime_rl/entrypoints/inference.py
@@ -77,6 +77,8 @@ def write_slurm_script(config: InferenceConfig, config_path: Path, script_path: 
             router_port=config.deployment.router.port,
             backend_port=config.deployment.backend_port,
             router_policy=config.deployment.router.policy,
+            data_parallel_rpc_port=config.data_parallel_rpc_port,
+            enable_expert_parallel=config.enable_expert_parallel,
         )
 
     script = template.render(**template_vars)

--- a/src/prime_rl/templates/_launch_rank.sh.j2
+++ b/src/prime_rl/templates/_launch_rank.sh.j2
@@ -1,0 +1,28 @@
+{# Shared external-LB vLLM launch helper, included once per template and called
+   from every per-rank launch site (multi-node and disaggregated).
+   One vLLM API server per DP rank, pinned to its GPU slice. #}
+# rank_log <node_rank> <k> — DP rank 0 logs to the node-level file (node_<rank>.log,
+# the target of the top-level inference.log symlink) so it captures real server output;
+# ranks 1+ get their own node_<rank>_rank<k>.log.
+rank_log() {
+    if [ "$2" -eq 0 ]; then
+        echo "$OUTPUT_DIR/logs/inference/node_$1.log"
+    else
+        echo "$OUTPUT_DIR/logs/inference/node_$1_rank$2.log"
+    fi
+}
+
+# launch_inference_rank <port> <cuda_visible_devices> <dp> <rpc_port> <vllm_extra_json|""> <nixl_side_channel_port|""> <log_file>
+launch_inference_rank() {
+    local port="$1" gpus="$2" dp="$3" rpc="$4" extra="$5" nixl="$6" log="$7"
+    local -a cmd=(uv run inference @ "$CONFIG_PATH"
+        --server.host 0.0.0.0 --server.port "$port"
+        --parallel.dp "$dp" --data-parallel-size-local 1 --api-server-count 1)
+    [ -n "$rpc" ] && cmd+=(--data-parallel-rpc-port "$rpc")
+    [ -n "$extra" ] && cmd+=(--vllm-extra "$extra")
+    if [ -n "$nixl" ]; then
+        CUDA_VISIBLE_DEVICES="$gpus" VLLM_NIXL_SIDE_CHANNEL_PORT="$nixl" "${cmd[@]}" 2>&1 | tee -a "$log" &
+    else
+        CUDA_VISIBLE_DEVICES="$gpus" "${cmd[@]}" 2>&1 | tee -a "$log" &
+    fi
+}

--- a/src/prime_rl/templates/_launch_router.sh.j2
+++ b/src/prime_rl/templates/_launch_router.sh.j2
@@ -1,0 +1,17 @@
+{# Shared router launch helper, included once per template and called by the
+   replica-head rank. vllm-router today; an llm-d (EPP+Envoy) branch can slot in
+   here so the call sites stay router-agnostic. #}
+# launch_router <mode:pd|regular> <worker_args> <port> <policy> <log_file> [replica_idx]
+launch_router() {
+    local mode="$1" worker_args="$2" port="$3" policy="$4" log="$5" replica="${6:-}"
+    local tag="vllm-router"; [ "$mode" = pd ] && tag="vllm-router (PD)"
+    echo "Starting $tag on $LOCAL_IP:$port${replica:+ for replica $replica}" | tee "$log"
+    local -a cmd=(vllm-router --policy "$policy" --host 0.0.0.0 --port "$port"
+        --worker-startup-timeout-secs 4200 --log-level debug)
+    if [ "$mode" = pd ]; then
+        cmd+=(--vllm-pd-disaggregation $worker_args)
+    else
+        cmd+=(--worker-urls $worker_args)
+    fi
+    "${cmd[@]}" >> "$log" 2>&1 &
+}

--- a/src/prime_rl/templates/inference.sbatch.j2
+++ b/src/prime_rl/templates/inference.sbatch.j2
@@ -170,6 +170,7 @@ srun --kill-on-bad-exit=1 bash -c '
     LOCAL_IP=$(hostname -I | awk "{print \$1}")
 
 {% include '_launch_rank.sh.j2' %}
+{% include '_launch_router.sh.j2' %}
 {%- if kv_offload %}
     ulimit -l unlimited
 {%- endif %}
@@ -248,22 +249,10 @@ srun --kill-on-bad-exit=1 bash -c '
     echo "NODE_RANK=$INFER_NODE_RANK ROLE=$ROLE REPLICA=$REPLICA_IDX SUB_REPLICA=$SUB_REPLICA ROLE_RANK=$ROLE_RANK DP=$DP PORT=$PORT LOCAL_IP=$LOCAL_IP" \
         | tee $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log
 
-    # Start vllm-router on the first prefill node of each replica (external LB across per-rank endpoints)
+    # Start the router on the first prefill node of each replica (external LB across per-rank endpoints)
     if [ "$RANK_IN_REPLICA" -eq 0 ]; then
-        ROUTER_LOG="$OUTPUT_DIR/logs/inference/router_${REPLICA_IDX}.log"
-        echo "Starting vllm-router on $LOCAL_IP:$ROUTER_PORT for replica $REPLICA_IDX" | tee $ROUTER_LOG
-
         REPLICA_ROUTER_ARGS=$(echo "$ALL_ROUTER_ARGS" | cut -d"|" -f$((REPLICA_IDX + 1)))
-
-        vllm-router \
-            --policy {{ router_policy }} \
-            --vllm-pd-disaggregation \
-            $REPLICA_ROUTER_ARGS \
-            --host 0.0.0.0 \
-            --port $ROUTER_PORT \
-            --worker-startup-timeout-secs 4200 \
-            --log-level debug \
-            >> $ROUTER_LOG 2>&1 &
+        launch_router pd "$REPLICA_ROUTER_ARGS" "$ROUTER_PORT" "{{ router_policy }}" "$OUTPUT_DIR/logs/inference/router_${REPLICA_IDX}.log" "$REPLICA_IDX"
     fi
 
     # External-LB: one vLLM API server per local DP rank (PORT + k), each pinned to its TP
@@ -286,19 +275,9 @@ srun --kill-on-bad-exit=1 bash -c '
     TP=$((GPUS_PER_NODE / DP_PER_NODE))
     EP={{ "1" if enable_expert_parallel else "0" }}
 
-    # Start router on node 0 (balances across per-rank endpoints — no intra-node DP header)
+    # Start the router on node 0 (balances across per-rank endpoints — no intra-node DP header)
     if [ "$INFER_NODE_RANK" -eq 0 ]; then
-        ROUTER_LOG="$OUTPUT_DIR/logs/inference/router.log"
-        echo "Starting vllm-router on $LOCAL_IP:$ROUTER_PORT" | tee $ROUTER_LOG
-
-        vllm-router \
-            --policy {{ router_policy }} \
-            --worker-urls $ROUTER_ARGS \
-            --host 0.0.0.0 \
-            --port $ROUTER_PORT \
-            --worker-startup-timeout-secs 4200 \
-            --log-level debug \
-            >> $ROUTER_LOG 2>&1 &
+        launch_router regular "$ROUTER_ARGS" "$ROUTER_PORT" "{{ router_policy }}" "$OUTPUT_DIR/logs/inference/router.log"
     fi
 
     # External-LB: one vLLM API server per DP rank on this node (BACKEND_PORT + dp_local),

--- a/src/prime_rl/templates/inference.sbatch.j2
+++ b/src/prime_rl/templates/inference.sbatch.j2
@@ -43,6 +43,7 @@ export RPC_PORT={{ data_parallel_rpc_port }}
 {%- elif num_nodes > 1 %}
 export ROUTER_PORT={{ router_port }}
 export BACKEND_PORT={{ backend_port }}
+export RPC_PORT={{ data_parallel_rpc_port }}
 {%- endif %}
 
 # Paths
@@ -78,26 +79,32 @@ for ((r=0; r<NUM_NODES/NODES_PER_REPLICA; r++)); do
     INFER_URLS="${INFER_URLS:+$INFER_URLS,}http://${router_host}:${ROUTER_PORT}/v1"
 
     REPLICA_ROUTER_ARGS=""
+    # External-LB: one --prefill/--decode endpoint per DP rank (PORT + k) on each node.
     for ((p=0; p<NUM_PREFILL_NODES; p++)); do
-        node_idx=$((replica_base + p))
-        host="${HOSTNAMES[$node_idx]}"
-        REPLICA_ROUTER_ARGS="$REPLICA_ROUTER_ARGS --prefill http://${host}:${PREFILL_PORT}"
+        host="${HOSTNAMES[$((replica_base + p))]}"
+        for ((k=0; k<{{ dp_per_node }}; k++)); do
+            REPLICA_ROUTER_ARGS="$REPLICA_ROUTER_ARGS --prefill http://${host}:$((PREFILL_PORT + k))"
+        done
     done
     for ((d=0; d<NUM_DECODE_NODES; d++)); do
-        node_idx=$((replica_base + NUM_PREFILL_NODES + d))
-        host="${HOSTNAMES[$node_idx]}"
-        REPLICA_ROUTER_ARGS="$REPLICA_ROUTER_ARGS --decode http://${host}:${DECODE_PORT}"
+        host="${HOSTNAMES[$((replica_base + NUM_PREFILL_NODES + d))]}"
+        for ((k=0; k<{{ dp_per_node }}; k++)); do
+            REPLICA_ROUTER_ARGS="$REPLICA_ROUTER_ARGS --decode http://${host}:$((DECODE_PORT + k))"
+        done
     done
     ALL_ROUTER_ARGS="${ALL_ROUTER_ARGS:+$ALL_ROUTER_ARGS|}$REPLICA_ROUTER_ARGS"
 done
 export INFER_URLS
 export ALL_ROUTER_ARGS
 {%- elif num_nodes > 1 %}
-# Single router on node 0, all nodes as backends
+# External LB: one router on node 0; one endpoint per DP rank (BACKEND_PORT + dp_local) on every node.
 INFER_URLS="http://${HOSTNAMES[0]}:${ROUTER_PORT}/v1"
+DP_PER_NODE={{ dp_per_node }}
 ROUTER_ARGS=""
 for host in ${HOSTNAMES[@]}; do
-    ROUTER_ARGS="$ROUTER_ARGS http://${host}:${BACKEND_PORT}"
+    for ((d=0; d<DP_PER_NODE; d++)); do
+        ROUTER_ARGS="$ROUTER_ARGS http://${host}:$((BACKEND_PORT + d))"
+    done
 done
 export INFER_URLS
 export ROUTER_ARGS
@@ -162,6 +169,7 @@ srun --kill-on-bad-exit=1 bash -c '
     INFER_NODE_RANK=$SLURM_PROCID
     LOCAL_IP=$(hostname -I | awk "{print \$1}")
 
+{% include '_launch_rank.sh.j2' %}
 {%- if kv_offload %}
     ulimit -l unlimited
 {%- endif %}
@@ -199,6 +207,9 @@ srun --kill-on-bad-exit=1 bash -c '
 
     DECODE_COMPILE_CFG='"'"'{"cudagraph_mode":"FULL_DECODE_ONLY"}'"'"'
 
+    DP_PER_NODE={{ dp_per_node }}
+    TP=$((GPUS_PER_NODE / DP_PER_NODE))
+
     # Determine outer replica (P/D pair) and role
     REPLICA_IDX=$((INFER_NODE_RANK / NODES_PER_REPLICA))
     RANK_IN_REPLICA=$((INFER_NODE_RANK % NODES_PER_REPLICA))
@@ -209,21 +220,14 @@ srun --kill-on-bad-exit=1 bash -c '
         ROLE="prefill"
         SUB_REPLICA=$((RANK_IN_REPLICA / NODES_PER_PREFILL_REPLICA))
         ROLE_RANK=$((RANK_IN_REPLICA % NODES_PER_PREFILL_REPLICA))
-        EP=$((NODES_PER_PREFILL_REPLICA * GPUS_PER_NODE))
+        DP=$((NODES_PER_PREFILL_REPLICA * DP_PER_NODE))
         PORT=$PREFILL_PORT
-        START_RANK=$((ROLE_RANK * GPUS_PER_NODE))
         HEAD_HOST="${HOSTNAMES[$((REPLICA_BASE + SUB_REPLICA * NODES_PER_PREFILL_REPLICA))]}"
 
 {% for key, value in prefill_env_overrides.items() %}
         export {{ key }}="{{ value }}"
 {% endfor %}
         ROLE_EXTRA="\"all2all_backend\": \"deepep_high_throughput\""
-
-        if [ "$ROLE_RANK" -eq 0 ]; then
-            VLLM_EXTRA="{\"data_parallel_address\": \"$LOCAL_IP\", \"data_parallel_hybrid_lb\": true, $ROLE_EXTRA}"
-        else
-            VLLM_EXTRA="{\"data_parallel_address\": \"$HEAD_HOST\", \"data_parallel_start_rank\": $START_RANK, \"data_parallel_hybrid_lb\": true, $ROLE_EXTRA}"
-        fi
     else
         # ── Decode node ──
         export UCX_NET_DEVICES=mlx5_0:1
@@ -231,27 +235,20 @@ srun --kill-on-bad-exit=1 bash -c '
         RANK_IN_DECODE=$((RANK_IN_REPLICA - NUM_PREFILL_NODES))
         SUB_REPLICA=$((RANK_IN_DECODE / NODES_PER_DECODE_REPLICA))
         ROLE_RANK=$((RANK_IN_DECODE % NODES_PER_DECODE_REPLICA))
-        EP=$((NODES_PER_DECODE_REPLICA * GPUS_PER_NODE))
+        DP=$((NODES_PER_DECODE_REPLICA * DP_PER_NODE))
         PORT=$DECODE_PORT
-        START_RANK=$((ROLE_RANK * GPUS_PER_NODE))
         HEAD_HOST="${HOSTNAMES[$((REPLICA_BASE + NUM_PREFILL_NODES + SUB_REPLICA * NODES_PER_DECODE_REPLICA))]}"
 
 {% for key, value in decode_env_overrides.items() %}
         export {{ key }}="{{ value }}"
 {% endfor %}
         ROLE_EXTRA="\"all2all_backend\": \"deepep_low_latency\", \"compilation_config\": $DECODE_COMPILE_CFG"
-
-        if [ "$ROLE_RANK" -eq 0 ]; then
-            VLLM_EXTRA="{\"data_parallel_address\": \"$LOCAL_IP\", \"data_parallel_hybrid_lb\": true, $ROLE_EXTRA}"
-        else
-            VLLM_EXTRA="{\"data_parallel_address\": \"$HEAD_HOST\", \"data_parallel_start_rank\": $START_RANK, \"data_parallel_hybrid_lb\": true, $ROLE_EXTRA}"
-        fi
     fi
 
-    echo "NODE_RANK=$INFER_NODE_RANK ROLE=$ROLE REPLICA=$REPLICA_IDX SUB_REPLICA=$SUB_REPLICA ROLE_RANK=$ROLE_RANK EP=$EP PORT=$PORT LOCAL_IP=$LOCAL_IP" \
+    echo "NODE_RANK=$INFER_NODE_RANK ROLE=$ROLE REPLICA=$REPLICA_IDX SUB_REPLICA=$SUB_REPLICA ROLE_RANK=$ROLE_RANK DP=$DP PORT=$PORT LOCAL_IP=$LOCAL_IP" \
         | tee $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log
 
-    # Start vllm-router on the first prefill node of each replica (background)
+    # Start vllm-router on the first prefill node of each replica (external LB across per-rank endpoints)
     if [ "$RANK_IN_REPLICA" -eq 0 ]; then
         ROUTER_LOG="$OUTPUT_DIR/logs/inference/router_${REPLICA_IDX}.log"
         echo "Starting vllm-router on $LOCAL_IP:$ROUTER_PORT for replica $REPLICA_IDX" | tee $ROUTER_LOG
@@ -264,27 +261,32 @@ srun --kill-on-bad-exit=1 bash -c '
             $REPLICA_ROUTER_ARGS \
             --host 0.0.0.0 \
             --port $ROUTER_PORT \
-            --intra-node-data-parallel-size {{ dp_per_node }} \
             --worker-startup-timeout-secs 4200 \
             --log-level debug \
             >> $ROUTER_LOG 2>&1 &
     fi
 
-    uv run inference \
-        @ $CONFIG_PATH \
-        --server.host 0.0.0.0 \
-        --server.port $PORT \
-        --parallel.dp $EP \
-        --data-parallel-rpc-port $RPC_PORT \
-        --vllm-extra "$VLLM_EXTRA" \
-        2>&1 | tee -a $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log &
+    # External-LB: one vLLM API server per local DP rank (PORT + k), each pinned to its TP
+    # slice of GPUs with a unique NIXL side-channel port. Each role is its own external-LB DP
+    # group rooted on the role-replica head (HEAD_HOST); the router balances across the per-rank
+    # endpoints. The kv_transfer_config is built in InferenceConfig.to_vllm() from the config.
+    if [ "$ROLE_RANK" -eq 0 ]; then DP_ADDR=$LOCAL_IP; else DP_ADDR=$HEAD_HOST; fi
+    for k in $(seq 0 $((DP_PER_NODE - 1))); do
+        GLOBAL_RANK=$((ROLE_RANK * DP_PER_NODE + k))
+        RANK_GPUS=$(seq -s, $((k * TP)) $((k * TP + TP - 1)))
+        RANK_EXTRA="{\"data_parallel_address\": \"$DP_ADDR\", \"data_parallel_rank\": $GLOBAL_RANK, $ROLE_EXTRA}"
+        launch_inference_rank "$((PORT + k))" "$RANK_GPUS" "$DP" "$RPC_PORT" "$RANK_EXTRA" "$((5600 + k))" "$(rank_log "$INFER_NODE_RANK" "$k")"
+    done
 {%- elif num_nodes > 1 %}
     echo "INFER_NODE_RANK=${INFER_NODE_RANK}, LOCAL_IP=${LOCAL_IP}" \
         | tee $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log
 
     export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False
+    DP_PER_NODE={{ dp_per_node }}
+    TP=$((GPUS_PER_NODE / DP_PER_NODE))
+    EP={{ "1" if enable_expert_parallel else "0" }}
 
-    # Start router on node 0
+    # Start router on node 0 (balances across per-rank endpoints — no intra-node DP header)
     if [ "$INFER_NODE_RANK" -eq 0 ]; then
         ROUTER_LOG="$OUTPUT_DIR/logs/inference/router.log"
         echo "Starting vllm-router on $LOCAL_IP:$ROUTER_PORT" | tee $ROUTER_LOG
@@ -294,17 +296,24 @@ srun --kill-on-bad-exit=1 bash -c '
             --worker-urls $ROUTER_ARGS \
             --host 0.0.0.0 \
             --port $ROUTER_PORT \
-            --intra-node-data-parallel-size {{ dp_per_node }} \
             --worker-startup-timeout-secs 4200 \
             --log-level debug \
             >> $ROUTER_LOG 2>&1 &
     fi
 
-    uv run inference \
-        @ $CONFIG_PATH \
-        --server.host 0.0.0.0 \
-        --server.port $BACKEND_PORT \
-        2>&1 | tee -a $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log &
+    # External-LB: one vLLM API server per DP rank on this node (BACKEND_PORT + dp_local),
+    # each pinned to its TP slice of GPUs. Each node is an independent replica, so any MoE EP
+    # group is node-local (rendezvous on LOCAL_IP); dense models run independent engines.
+    for ((d=0; d<DP_PER_NODE; d++)); do
+        RANK_GPUS=$(seq -s, $((d * TP)) $((d * TP + TP - 1)))
+        RANK_LOG=$(rank_log "$INFER_NODE_RANK" "$d")
+        if [ "$EP" -eq 1 ]; then
+            RANK_EXTRA="{\"data_parallel_rank\": $d, \"data_parallel_address\": \"$LOCAL_IP\"}"
+            launch_inference_rank "$((BACKEND_PORT + d))" "$RANK_GPUS" "$DP_PER_NODE" "$RPC_PORT" "$RANK_EXTRA" "" "$RANK_LOG"
+        else
+            launch_inference_rank "$((BACKEND_PORT + d))" "$RANK_GPUS" 1 "" "" "" "$RANK_LOG"
+        fi
+    done
 {%- else %}
     echo "INFER_NODE_RANK=${INFER_NODE_RANK}, LOCAL_IP=${LOCAL_IP}" | tee $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log
     # Required for graph compilation to work

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -48,12 +48,6 @@ export DECODE_PORT={{ decode_port }}
 {%- else -%}
 export BACKEND_PORT={{ backend_port }}
 export INFERENCE_ENABLE_EXPERT_PARALLEL={{ "1" if inference_enable_expert_parallel else "0" }}
-
-# Enable distributed EP mode only when expert parallelism spans multiple inference nodes per replica.
-export USE_DISTRIBUTED_EP=0
-if [ "$INFERENCE_ENABLE_EXPERT_PARALLEL" -eq 1 ] && [ "$NODES_PER_INFER_REPLICA" -gt 1 ]; then
-    USE_DISTRIBUTED_EP=1
-fi
 {%- endif %}
 {%- endif %}
 
@@ -94,17 +88,22 @@ for ((r=0; r<NUM_INFER_REPLICAS; r++)); do
     INFER_URLS="${INFER_URLS:+$INFER_URLS }http://${router_host}:${ROUTER_PORT}/v1"
 
     REPLICA_ROUTER_ARGS=""
+    # External-LB: one prefill/decode endpoint per DP rank (PORT + k) on each node.
     for ((p=0; p<NUM_PREFILL_NODES; p++)); do
         node_idx=$((replica_base + p))
         host="${INFER_HOSTS[$node_idx]}"
-        ADMIN_URLS="${ADMIN_URLS:+$ADMIN_URLS }http://${host}:${PREFILL_PORT}/v1"
-        REPLICA_ROUTER_ARGS="$REPLICA_ROUTER_ARGS --prefill http://${host}:${PREFILL_PORT}"
+        for ((k=0; k<INFERENCE_DP_LOCAL; k++)); do
+            ADMIN_URLS="${ADMIN_URLS:+$ADMIN_URLS }http://${host}:$((PREFILL_PORT + k))/v1"
+            REPLICA_ROUTER_ARGS="$REPLICA_ROUTER_ARGS --prefill http://${host}:$((PREFILL_PORT + k))"
+        done
     done
     for ((d=0; d<NUM_DECODE_NODES; d++)); do
         node_idx=$((replica_base + NUM_PREFILL_NODES + d))
         host="${INFER_HOSTS[$node_idx]}"
-        ADMIN_URLS="${ADMIN_URLS:+$ADMIN_URLS }http://${host}:${DECODE_PORT}/v1"
-        REPLICA_ROUTER_ARGS="$REPLICA_ROUTER_ARGS --decode http://${host}:${DECODE_PORT}"
+        for ((k=0; k<INFERENCE_DP_LOCAL; k++)); do
+            ADMIN_URLS="${ADMIN_URLS:+$ADMIN_URLS }http://${host}:$((DECODE_PORT + k))/v1"
+            REPLICA_ROUTER_ARGS="$REPLICA_ROUTER_ARGS --decode http://${host}:$((DECODE_PORT + k))"
+        done
     done
     ALL_ROUTER_ARGS="${ALL_ROUTER_ARGS:+$ALL_ROUTER_ARGS|}$REPLICA_ROUTER_ARGS"
 done
@@ -118,8 +117,11 @@ for ((r=0; r<NUM_INFER_REPLICAS; r++)); do
     for ((n=0; n<NODES_PER_INFER_REPLICA; n++)); do
         node_idx=$((head_idx + n))
         host="${INFER_HOSTS[$node_idx]}"
-        ADMIN_URLS="${ADMIN_URLS:+$ADMIN_URLS }http://${host}:${BACKEND_PORT}/v1"
-        REPLICA_ROUTER_ARGS="$REPLICA_ROUTER_ARGS http://${host}:${BACKEND_PORT}"
+        # External-LB: one endpoint per DP rank (BACKEND_PORT + dp_local) on each node.
+        for ((k=0; k<INFERENCE_DP_LOCAL; k++)); do
+            ADMIN_URLS="${ADMIN_URLS:+$ADMIN_URLS }http://${host}:$((BACKEND_PORT + k))/v1"
+            REPLICA_ROUTER_ARGS="$REPLICA_ROUTER_ARGS http://${host}:$((BACKEND_PORT + k))"
+        done
     done
     ALL_ROUTER_ARGS="${ALL_ROUTER_ARGS:+$ALL_ROUTER_ARGS|}$REPLICA_ROUTER_ARGS"
 done
@@ -130,9 +132,6 @@ export ALL_ROUTER_ARGS
 echo "INFER_HOSTS=${INFER_HOSTS[*]}"
 echo "INFER_URLS=${INFER_URLS}"
 echo "ADMIN_URLS=${ADMIN_URLS}"
-{%- if not is_disaggregated %}
-echo "USE_DISTRIBUTED_EP=${USE_DISTRIBUTED_EP}"
-{%- endif %}
 {%- endif %}
 
 echo "HOSTNAMES=${HOSTNAMES[*]}"
@@ -228,6 +227,9 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
     echo "INFER_NODE_RANK=$INFER_NODE_RANK REPLICA=$REPLICA_IDX RANK_IN_REPLICA=$RANK_IN_REPLICA LOCAL_IP=$LOCAL_IP" \
         | tee $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log
 
+    CONFIG_PATH="$CONFIG_DIR/inference.toml"
+{% include '_launch_rank.sh.j2' %}
+
 {% if is_disaggregated -%}
     # PD disaggregated: NIXL KV transfer + role-based inference
     read -ra HOSTNAMES <<< "$HOSTNAMES_STR"
@@ -282,17 +284,7 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
     echo "ROLE=$ROLE REPLICA=$REPLICA_IDX SUB_REPLICA=$SUB_REPLICA ROLE_RANK=$ROLE_RANK DP=$DP PORT=$PORT" \
         | tee -a $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log
 
-    if [ "$DP" -gt 1 ]; then
-        if [ "$ROLE_RANK" -eq 0 ]; then
-            VLLM_EXTRA="{\"data_parallel_address\": \"$LOCAL_IP\", \"data_parallel_hybrid_lb\": true, $ROLE_EXTRA}"
-        else
-            VLLM_EXTRA="{\"data_parallel_address\": \"$HEAD_HOST\", \"data_parallel_start_rank\": $START_RANK, \"data_parallel_hybrid_lb\": true, $ROLE_EXTRA}"
-        fi
-    else
-        VLLM_EXTRA="{$ROLE_EXTRA}"
-    fi
-
-    # Start vllm-router on the first node of each replica (PD mode)
+    # Start vllm-router on the first node of each replica (PD mode, external LB across per-rank endpoints)
     if [ "$RANK_IN_REPLICA" -eq 0 ]; then
         ROUTER_LOG="$OUTPUT_DIR/logs/inference/router_${REPLICA_IDX}.log"
         echo "Starting vllm-router (PD) on $LOCAL_IP:$ROUTER_PORT for replica $REPLICA_IDX" | tee $ROUTER_LOG
@@ -305,19 +297,21 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
             $REPLICA_ROUTER_ARGS \
             --host 0.0.0.0 \
             --port $ROUTER_PORT \
-            --intra-node-data-parallel-size {{ dp_per_node }} \
             --worker-startup-timeout-secs 4200 \
             >> $ROUTER_LOG 2>&1 &
     fi
 
-    uv run inference \
-        @ $CONFIG_DIR/inference.toml \
-        --server.host 0.0.0.0 \
-        --server.port $PORT \
-        --parallel.dp $DP \
-        --data-parallel-rpc-port $INFERENCE_DATA_PARALLEL_RPC_PORT \
-        --vllm-extra "$VLLM_EXTRA" \
-        2>&1 | tee -a $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log &
+    # External-LB: one vLLM API server per local DP rank (PORT + k), each pinned to its TP
+    # slice of GPUs with a unique NIXL side-channel port. Each role is its own external-LB DP
+    # group rooted on the role-replica head (HEAD_HOST); the router balances across the per-rank
+    # endpoints. The kv_transfer_config is built in InferenceConfig.to_vllm() from the config.
+    if [ "$ROLE_RANK" -eq 0 ]; then DP_ADDR=$LOCAL_IP; else DP_ADDR=$HEAD_HOST; fi
+    for k in $(seq 0 $((INFERENCE_DP_LOCAL - 1))); do
+        GLOBAL_RANK=$((START_RANK + k))
+        RANK_GPUS=$(seq -s, $((k * INFERENCE_TP)) $((k * INFERENCE_TP + INFERENCE_TP - 1)))
+        RANK_EXTRA="{\"data_parallel_address\": \"$DP_ADDR\", \"data_parallel_rank\": $GLOBAL_RANK, $ROLE_EXTRA}"
+        launch_inference_rank "$((PORT + k))" "$RANK_GPUS" "$DP" "$INFERENCE_DATA_PARALLEL_RPC_PORT" "$RANK_EXTRA" "$((5600 + k))" "$(rank_log "$INFER_NODE_RANK" "$k")"
+    done
 {%- else -%}
     # Start vllm-router on the first node of each replica
     if [ "$RANK_IN_REPLICA" -eq 0 ]; then
@@ -331,36 +325,31 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
             --worker-urls $REPLICA_ROUTER_ARGS \
             --host 0.0.0.0 \
             --port $ROUTER_PORT \
-            --intra-node-data-parallel-size {{ dp_per_node }} \
             --worker-startup-timeout-secs 4200 \
             >> $ROUTER_LOG 2>&1 &
     fi
 
-    if [ "$USE_DISTRIBUTED_EP" -eq 1 ]; then
-        read -ra HOSTNAMES <<< "$HOSTNAMES_STR"
-        REPLICA_HEAD_HOST="${HOSTNAMES[$((REPLICA_IDX * NODES_PER_INFER_REPLICA))]}"
-        INFER_DP_START_RANK=$((RANK_IN_REPLICA * INFERENCE_DP_LOCAL))
-
-        if [ "$RANK_IN_REPLICA" -eq 0 ]; then
-            VLLM_EXTRA="{\"data_parallel_address\": \"$LOCAL_IP\", \"data_parallel_hybrid_lb\": true}"
+    # External-LB: one vLLM API server per DP rank on this node (BACKEND_PORT + d),
+    # each pinned to its TP slice of GPUs; the router balances across the per-rank
+    # endpoints.
+    read -ra HOSTNAMES <<< "$HOSTNAMES_STR"
+    REPLICA_HEAD_HOST="${HOSTNAMES[$((REPLICA_IDX * NODES_PER_INFER_REPLICA))]}"
+    INFER_GROUP_DP=$((NODES_PER_INFER_REPLICA * INFERENCE_DP_LOCAL))
+    for ((d=0; d<INFERENCE_DP_LOCAL; d++)); do
+        RANK_GPUS=$(seq -s, $((d * INFERENCE_TP)) $((d * INFERENCE_TP + INFERENCE_TP - 1)))
+        RANK_LOG=$(rank_log "$INFER_NODE_RANK" "$d")
+        if [ "$INFERENCE_ENABLE_EXPERT_PARALLEL" -eq 1 ]; then
+            # MoE: ranks form one external-LB DP group so EP all2all spans them; all
+            # ranks rendezvous on the replica head DP coordinator.
+            GLOBAL_DP_RANK=$((RANK_IN_REPLICA * INFERENCE_DP_LOCAL + d))
+            if [ "$GLOBAL_DP_RANK" -eq 0 ]; then DP_ADDR="$LOCAL_IP"; else DP_ADDR="$REPLICA_HEAD_HOST"; fi
+            RANK_EXTRA="{\"data_parallel_rank\": $GLOBAL_DP_RANK, \"data_parallel_address\": \"$DP_ADDR\"}"
+            launch_inference_rank "$((BACKEND_PORT + d))" "$RANK_GPUS" "$INFER_GROUP_DP" "$INFERENCE_DATA_PARALLEL_RPC_PORT" "$RANK_EXTRA" "" "$RANK_LOG"
         else
-            VLLM_EXTRA="{\"data_parallel_address\": \"$REPLICA_HEAD_HOST\", \"data_parallel_start_rank\": $INFER_DP_START_RANK, \"data_parallel_hybrid_lb\": true}"
+            # Dense: independent single-engine servers (no DP linkage).
+            launch_inference_rank "$((BACKEND_PORT + d))" "$RANK_GPUS" 1 "" "" "" "$RANK_LOG"
         fi
-
-        uv run inference \
-            @ $CONFIG_DIR/inference.toml \
-            --server.host 0.0.0.0 \
-            --server.port $BACKEND_PORT \
-            --data-parallel-rpc-port $INFERENCE_DATA_PARALLEL_RPC_PORT \
-            --vllm-extra "$VLLM_EXTRA" \
-            2>&1 | tee -a $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log &
-    else
-        uv run inference \
-            @ $CONFIG_DIR/inference.toml \
-            --server.host 0.0.0.0 \
-            --server.port $BACKEND_PORT \
-            2>&1 | tee -a $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log &
-    fi
+    done
 {%- endif %}
 
 else
@@ -415,7 +404,7 @@ REMAINING_PIDS=$(jobs -p)
 # in-flight trainer checkpoint on this node finish, and — because the task has
 # not exited yet — keeps --kill-on-bad-exit from reaping checkpointing trainers
 # on peer nodes. We then propagate the exit code so the allocation tears down. A
-# clean (zero) exit can't trip --kill-on-bad-exit, so we tear down immediately.
+# clean (zero) exit cannot trip --kill-on-bad-exit, so we tear down immediately.
 if [ "$EXIT_CODE" -ne 0 ]; then
     echo "[$(hostname)] component exited with code $EXIT_CODE - waiting up to {{ cleanup_grace_period }}s for in-flight checkpoints to flush before teardown"
     sleep {{ cleanup_grace_period }}

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -311,18 +311,19 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
 
     # External-LB: one vLLM API server per DP rank on this node (BACKEND_PORT + d),
     # each pinned to its TP slice of GPUs; the router balances across the per-rank
-    # endpoints.
+    # endpoints. For MoE the ranks form one external-LB DP group (EP all2all spans
+    # them) rooted on the replica-head DP coordinator. data_parallel_address is
+    # per-node, not per-rank: every rank on the head reaches the coordinator via the
+    # head LOCAL_IP, ranks on other nodes via the head hostname (matches the P/D path).
     read -ra HOSTNAMES <<< "$HOSTNAMES_STR"
     REPLICA_HEAD_HOST="${HOSTNAMES[$((REPLICA_IDX * NODES_PER_INFER_REPLICA))]}"
     INFER_GROUP_DP=$((NODES_PER_INFER_REPLICA * INFERENCE_DP_LOCAL))
+    if [ "$RANK_IN_REPLICA" -eq 0 ]; then DP_ADDR="$LOCAL_IP"; else DP_ADDR="$REPLICA_HEAD_HOST"; fi
     for ((d=0; d<INFERENCE_DP_LOCAL; d++)); do
         RANK_GPUS=$(seq -s, $((d * INFERENCE_TP)) $((d * INFERENCE_TP + INFERENCE_TP - 1)))
         RANK_LOG=$(rank_log "$INFER_NODE_RANK" "$d")
         if [ "$INFERENCE_ENABLE_EXPERT_PARALLEL" -eq 1 ]; then
-            # MoE: ranks form one external-LB DP group so EP all2all spans them; all
-            # ranks rendezvous on the replica head DP coordinator.
             GLOBAL_DP_RANK=$((RANK_IN_REPLICA * INFERENCE_DP_LOCAL + d))
-            if [ "$GLOBAL_DP_RANK" -eq 0 ]; then DP_ADDR="$LOCAL_IP"; else DP_ADDR="$REPLICA_HEAD_HOST"; fi
             RANK_EXTRA="{\"data_parallel_rank\": $GLOBAL_DP_RANK, \"data_parallel_address\": \"$DP_ADDR\"}"
             launch_inference_rank "$((BACKEND_PORT + d))" "$RANK_GPUS" "$INFER_GROUP_DP" "$INFERENCE_DATA_PARALLEL_RPC_PORT" "$RANK_EXTRA" "" "$RANK_LOG"
         else

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -229,6 +229,7 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
 
     CONFIG_PATH="$CONFIG_DIR/inference.toml"
 {% include '_launch_rank.sh.j2' %}
+{% include '_launch_router.sh.j2' %}
 
 {% if is_disaggregated -%}
     # PD disaggregated: NIXL KV transfer + role-based inference
@@ -284,21 +285,10 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
     echo "ROLE=$ROLE REPLICA=$REPLICA_IDX SUB_REPLICA=$SUB_REPLICA ROLE_RANK=$ROLE_RANK DP=$DP PORT=$PORT" \
         | tee -a $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log
 
-    # Start vllm-router on the first node of each replica (PD mode, external LB across per-rank endpoints)
+    # Start the router on the first node of each replica (PD mode, external LB across per-rank endpoints)
     if [ "$RANK_IN_REPLICA" -eq 0 ]; then
-        ROUTER_LOG="$OUTPUT_DIR/logs/inference/router_${REPLICA_IDX}.log"
-        echo "Starting vllm-router (PD) on $LOCAL_IP:$ROUTER_PORT for replica $REPLICA_IDX" | tee $ROUTER_LOG
-
         REPLICA_ROUTER_ARGS=$(echo "$ALL_ROUTER_ARGS" | cut -d"|" -f$((REPLICA_IDX + 1)))
-
-        vllm-router \
-            --policy consistent_hash \
-            --vllm-pd-disaggregation \
-            $REPLICA_ROUTER_ARGS \
-            --host 0.0.0.0 \
-            --port $ROUTER_PORT \
-            --worker-startup-timeout-secs 4200 \
-            >> $ROUTER_LOG 2>&1 &
+        launch_router pd "$REPLICA_ROUTER_ARGS" "$ROUTER_PORT" consistent_hash "$OUTPUT_DIR/logs/inference/router_${REPLICA_IDX}.log" "$REPLICA_IDX"
     fi
 
     # External-LB: one vLLM API server per local DP rank (PORT + k), each pinned to its TP
@@ -313,20 +303,10 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
         launch_inference_rank "$((PORT + k))" "$RANK_GPUS" "$DP" "$INFERENCE_DATA_PARALLEL_RPC_PORT" "$RANK_EXTRA" "$((5600 + k))" "$(rank_log "$INFER_NODE_RANK" "$k")"
     done
 {%- else -%}
-    # Start vllm-router on the first node of each replica
+    # Start the router on the first node of each replica
     if [ "$RANK_IN_REPLICA" -eq 0 ]; then
-        ROUTER_LOG="$OUTPUT_DIR/logs/inference/router_${REPLICA_IDX}.log"
-        echo "Starting vllm-router on $LOCAL_IP:$ROUTER_PORT for replica $REPLICA_IDX" | tee $ROUTER_LOG
-
         REPLICA_ROUTER_ARGS=$(echo "$ALL_ROUTER_ARGS" | cut -d"|" -f$((REPLICA_IDX + 1)))
-
-        vllm-router \
-            --policy consistent_hash \
-            --worker-urls $REPLICA_ROUTER_ARGS \
-            --host 0.0.0.0 \
-            --port $ROUTER_PORT \
-            --worker-startup-timeout-secs 4200 \
-            >> $ROUTER_LOG 2>&1 &
+        launch_router regular "$REPLICA_ROUTER_ARGS" "$ROUTER_PORT" consistent_hash "$OUTPUT_DIR/logs/inference/router_${REPLICA_IDX}.log" "$REPLICA_IDX"
     fi
 
     # External-LB: one vLLM API server per DP rank on this node (BACKEND_PORT + d),


### PR DESCRIPTION
## What

Unify **every router-fronted vLLM launch path on external load balancing**: one API server per DP rank on `PORT+k`, each pinned to its TP slice of GPUs, with the router balancing across the per-rank endpoints. This removes the hybrid-LB mode (`data_parallel_hybrid_lb` / `data_parallel_start_rank` / `--intra-node-data-parallel-size`) from both the RL and standalone-inference SLURM templates, across **multi-node and disaggregated (P/D)** deployments.

Before this PR the launch paths were inconsistent: multi-node RL used external-LB while the disaggregated paths (and standalone multi-node inference) used hybrid-LB. This makes external-LB the single, uniform mechanism.

## Changes

- **Shared launch helpers** — extract the duplicated per-rank `uv run inference` block into `_launch_rank.sh.j2`, and the per-replica `vllm-router` invocation into `_launch_router.sh.j2` (`launch_router <mode:pd|regular> …`). Both are included once and called from every launch site in both templates, so the per-rank launch and the router launch each live in exactly one place.
- **Per-rank router worker URLs** — `BACKEND_PORT+k` for multi-node; `--prefill PREFILL_PORT+k` / `--decode DECODE_PORT+k` for P/D.
- **TP-correct DP group sizing** — `DP = nodes_per_role_replica * dp_per_node`, fixing a latent tp>1 bug where the disaggregated inference path sized the group as `nodes * gpus_per_node`.
- **Multi-node standalone inference** now passes `data_parallel_rpc_port` + `enable_expert_parallel`, so per-rank MoE EP groups rendezvous node-locally (and dense models run independent engines).
- **Remove dead `USE_DISTRIBUTED_EP`** gate — EP is decided directly by `enable_expert_parallel`.
- **Fix a latent apostrophe** in a `bash -c` comment (`can't` → `cannot`) that broke `bash -n` on multi-node non-disaggregated renders (the disaggregated block normally balanced the quote).

After this, `grep -rn 'data_parallel_hybrid_lb\|intra-node-data-parallel-size' src/` is empty.

## E2E verification (SLURM, this branch)

All four router-fronted paths run with `vllm-router`:

| Path | Result |
|---|---|
| RL multi-node (Qwen3-0.6B, tp=1) | ✅ trained through steps, router balanced across **8 per-rank endpoints** (`:8100–:8107`), 93–120 req/endpoint, 0 errors |
| RL P/D (Qwen3-30B-A3B, tp=1, 1P+1D) | ✅ per-rank prefill/decode servers up, NIXL KV transfer working (**0 errored rollouts**, reward 1.0), MoE EP routing, trainer↔inference NCCL weight broadcast, training steps complete |
| Inference multi-node (Qwen3-0.6B, tp=1) | ✅ router ready with **16 endpoints**, 12/12 generations HTTP 200 |
| Inference P/D (Qwen3-30B-A3B, tp=1, 1P+1D) | ✅ prefill (`:81xx`) + decode (`:82xx`) endpoints registered, **6/6 P/D generations HTTP 200** (full prefill→NIXL→decode path) |

Renders for all paths (tp=1 and tp=2) are `bash -n` clean with zero hybrid-LB flags.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core multi-node and P/D inference orchestration (ports, DP groups, NCCL/admin URL alignment); misconfiguration can break training rollouts or weight broadcast, though the PR reports broad SLURM E2E verification.
> 
> **Overview**
> **Unifies router-fronted SLURM inference on external load balancing** by running one vLLM API server per local DP rank (`PORT+k`), each bound to its TP GPU slice, with `vllm-router` fanning out to those per-rank URLs. **Hybrid LB is removed** (`data_parallel_hybrid_lb`, `data_parallel_start_rank`, `--intra-node-data-parallel-size`) from RL and standalone inference templates for **multi-node and P/D** paths.
> 
> Shared **`_launch_rank.sh.j2`** and **`_launch_router.sh.j2`** centralize per-rank `uv run inference` and router startup. Router/admin URL builders now register **`BACKEND_PORT+k`** and **`PREFILL/DECODE_PORT+k`** per rank. Disaggregated DP group size uses **`nodes_per_role_replica * dp_per_node`** (fixes tp>1 sizing). **`inference_metrics_roles`** in `rl.py` scales with the same per-rank stride as **`ADMIN_URLS`**. Standalone multi-node inference passes **`data_parallel_rpc_port`** and **`enable_expert_parallel`**; **`USE_DISTRIBUTED_EP`** is dropped in favor of direct EP flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62ab7ba822182fc10321951244b0ec49c0d90b23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->