### PR TITLE
fix(trainer): guard against validation hook crash taking down trainer

### DIFF
--- a/src/prime_rl/trainer/runs.py
+++ b/src/prime_rl/trainer/runs.py
@@ -250,8 +250,9 @@ class MultiRunManager:
             try:
                 is_valid, error_message = hook(config)
             except Exception as e:
+                hook_name = getattr(hook, "__name__", type(hook).__name__)
                 is_valid = False
-                error_message = f"Validation hook {hook.__name__} crashed: {e}"
+                error_message = f"Validation hook {hook_name} crashed: {e}"
             if not is_valid:
                 self.logger.error(f"Run {run_id}: {error_message}")
                 if error_path.parent.exists():

--- a/src/prime_rl/trainer/runs.py
+++ b/src/prime_rl/trainer/runs.py
@@ -247,7 +247,11 @@ class MultiRunManager:
 
         # Run registered validation hooks
         for hook in self._config_validation_hooks:
-            is_valid, error_message = hook(config)
+            try:
+                is_valid, error_message = hook(config)
+            except Exception as e:
+                is_valid = False
+                error_message = f"Validation hook {hook.__name__} crashed: {e}"
             if not is_valid:
                 self.logger.error(f"Run {run_id}: {error_message}")
                 if error_path.parent.exists():
@@ -510,6 +514,8 @@ def setup_multi_run_manager(
         trainer_lora = lora_config
 
         def validate_lora_rank(orch_config: "OrchestratorConfig") -> tuple[bool, str]:
+            if orch_config.student.model.lora is None:
+                return False, "student.model.lora is required when trainer is configured with LoRA"
             # Default to trainer's rank/alpha if not specified
             if orch_config.student.model.lora.rank is None:
                 orch_config.student.model.lora.rank = trainer_lora.rank


### PR DESCRIPTION
A LoRA-configured trainer pod got wedged after `validate_lora_rank` raised `AttributeError` on an `orch.toml` with no `[student.model.lora]` section. The hook is called outside `get_orchestrator_config`'s try/except, so the exception propagated through `discover_runs` → `pack` → `wait_for_batch` → `train`. Master rank exited via `sync_wrapper`, worker ranks stayed blocked on the never-written `step_0/rank_*.bin` micro-batch path, and the pod stayed "Running" with 0 restarts for ~9.5h until manually deleted.

- Guard `model.lora is None` in `validate_lora_rank` so it rejects cleanly
- Wrap hook calls in `get_orchestrator_config` in try/except so any future hook bug returns the run to the retry path instead of taking down the trainer

Seen on run `v11w6nr7brpuffbkl7ky2c2n` on `qwen35-35b-e2e-spk`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defensive error handling around config validation; reduces outage risk without changing training logic or auth.
> 
> **Overview**
> **Hardens orchestrator config validation** so a bad `orch.toml` or a buggy validation hook no longer tears down the whole trainer process.
> 
> In `get_orchestrator_config`, each registered validation hook now runs inside **try/except**: if a hook raises, the run is treated as invalid (error logged, `config_validation_error.txt` written, `None` returned) instead of the exception bubbling through `discover_runs` and wedging distributed training.
> 
> When the trainer is LoRA-enabled, **`validate_lora_rank`** now rejects configs missing **`student.model.lora`** with a clear message instead of raising **`AttributeError`** on a missing section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 206481a58d92aa39ccdfe560afa0a3e0d41fdaf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->