### PR TITLE
fix(ckpt): avoid concurrent-mkdir race on parallel FS

### DIFF
--- a/src/prime_rl/trainer/ckpt.py
+++ b/src/prime_rl/trainer/ckpt.py
@@ -171,7 +171,12 @@ class CheckpointManager:
         # Checkpoint the local dataloader
         if dataloader is not None:
             dataloader_dir = path / "dataloader"
-            dataloader_dir.mkdir(parents=True, exist_ok=True)
+            # Only the master creates the dir; the rest wait at a barrier. On a
+            # parallel FS (beegfs), concurrent mkdir from every rank can re-raise
+            # FileExistsError (EEXIST + stale is_dir() metadata).
+            if self.world.is_master:
+                dataloader_dir.mkdir(parents=True, exist_ok=True)
+            torch.distributed.barrier()
             torch.save(dataloader.state_dict(), dataloader_dir / f"rank_{self.world.rank}.pt")
 
         # Save sharded state
@@ -239,7 +244,11 @@ class CheckpointManager:
     ) -> None:
         """Save the full checkpoint state for a specified step."""
         ckpt_path = self.get_ckpt_path(step)
-        ckpt_path.parent.mkdir(parents=True, exist_ok=True)
+        # Master-only mkdir + barrier: concurrent mkdir from every rank can
+        # re-raise FileExistsError on a parallel FS (see save_to_path).
+        if self.world.is_master:
+            ckpt_path.parent.mkdir(parents=True, exist_ok=True)
+        torch.distributed.barrier()
 
         self.save_to_path(ckpt_path, model, optimizers, scheduler, progress, dataloader)
         bisect.insort(self.ckpt_steps, step)
@@ -390,7 +399,11 @@ class WeightCheckpointManager:
     ):
         """Save a HF-compatible weight-only checkpoint for a given step."""
         step_path = self.get_step_path(step)
-        step_path.mkdir(parents=True, exist_ok=True)
+        # Master-only mkdir + barrier: concurrent mkdir from every rank can
+        # re-raise FileExistsError on a parallel FS (EEXIST + stale is_dir()).
+        if self.world.is_master:
+            step_path.mkdir(parents=True, exist_ok=True)
+        torch.distributed.barrier()
 
         # Gather all weights on master rank
         self.logger.debug("Gathering weights on master rank for weight checkpoint")


### PR DESCRIPTION
`Path.mkdir(exist_ok=True)` re-checks `self.is_dir()` after `EEXIST` and re-raises if it returns `False`. On a parallel filesystem (beegfs) with concurrent `mkdir` from every trainer rank, a non-master rank can hit `EEXIST` while its metadata cache hasn't seen the new inode yet -> `is_dir()` returns `False` -> `FileExistsError`, crashing the trainer mid-save. This has been observed in a training run of GLM-4.5-Air on forth-lang.

Guard the three all-ranks `mkdir` sites behind `world.is_master` + a barrier so only the master creates the dir and the others wait until it exists:

- `CheckpointManager.save_to_path`: `dataloader_dir`
- `CheckpointManager.save`: `ckpt_path.parent`
- `WeightCheckpointManager.save`: `step_path`

Mirrors the existing master-only guard in `WeightCheckpointManager.save_to_path`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to checkpoint I/O ordering; reduces save-time crashes without altering checkpoint contents or training logic.
> 
> **Overview**
> Fixes intermittent **`FileExistsError`** during distributed trainer saves on parallel filesystems (e.g. beegfs) when every rank called **`mkdir(parents=True, exist_ok=True)`** at once.
> 
> **`CheckpointManager`** now has the master create **`dataloader_dir`** and **`ckpt_path.parent`**, with a **`torch.distributed.barrier()`** before other ranks write. **`WeightCheckpointManager.save`** does the same for **`step_path`**, matching the existing master-only mkdir in **`save_to_path`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18fe0948db577833ea0cde467f159521304b51ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->