### PR TITLE
[codex] Fix vLLM layerwise reload alias buffers

### DIFF
--- a/skills/training/monitor-run/SKILL.md
+++ b/skills/training/monitor-run/SKILL.md
@@ -150,7 +150,7 @@ jq '.reward' {output_dir}/rollouts/step_42/train_rollouts.jsonl
 A few warnings are normal. Escalate when errors are persistent, growing, or hit a large fraction of rollouts.
 
 - **Env workers**: exceptions in env code, timeouts, sandbox errors, OOM kills (most common source — runs user code).
-- **Orchestrator**: empty/errored rollout spikes, weight-broadcast failures, checkpoint errors.
+- **Orchestrator**: empty/errored rollout spikes, weight-broadcast failures, checkpoint errors. For NCCL weight updates, a trainer-side "weights broadcasted" log only proves the send completed; also check inference logs for `/update_weights` 500s or reload tracebacks.
 - **Trainer**: NCCL/CUDA errors, OOM, NaN loss or gradients.
 - **Inference**: NCCL/CUDA errors, OOM, request timeouts.
 

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -82,16 +82,35 @@ def monkey_patch_vllm_layerwise_reload_alias_buffers():
 
     logger = init_logger(__name__)
 
+    def _tensor_storage_ptr(tensor: torch.Tensor) -> int | None:
+        try:
+            return tensor.untyped_storage().data_ptr()
+        except (RuntimeError, ValueError):
+            return None
+
     def _copy_and_restore_kernel_tensors(layer: torch.nn.Module, info: reload_layerwise.LayerReloadingInfo):
         assert info.kernel_tensors is not None
         parameters, buffers = info.kernel_tensors
-        param_storage_ptrs = {param.untyped_storage().data_ptr() for param in parameters.values()}
+        param_storage_ptrs = {
+            storage_ptr
+            for param in layer.parameters(recurse=True)
+            if (storage_ptr := _tensor_storage_ptr(param)) is not None
+        }
+        param_storage_ptrs.update(
+            storage_ptr
+            for param in parameters.values()
+            if (storage_ptr := _tensor_storage_ptr(param)) is not None
+        )
         for name, param in parameters.items():
-            param.data.copy_(getattr(layer, name))
-        for name, buffer in buffers.items():
-            if buffer.untyped_storage().data_ptr() in param_storage_ptrs:
+            if name not in layer._parameters:
                 continue
-            buffer.data.copy_(getattr(layer, name))
+            param.data.copy_(layer._parameters[name])
+        for name, buffer in buffers.items():
+            if name not in layer._buffers:
+                continue
+            if _tensor_storage_ptr(buffer) in param_storage_ptrs:
+                continue
+            buffer.data.copy_(layer._buffers[name])
 
         reload_layerwise._place_kernel_tensors(layer, info)
 

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -85,7 +85,7 @@ def monkey_patch_vllm_layerwise_reload_alias_buffers():
     def _copy_and_restore_kernel_tensors(layer: torch.nn.Module, info: reload_layerwise.LayerReloadingInfo):
         assert info.kernel_tensors is not None
         parameters, buffers = info.kernel_tensors
-        param_storage_ptrs = {p.untyped_storage().data_ptr() for p in layer.parameters(recurse=True)}
+        param_storage_ptrs = {param.untyped_storage().data_ptr() for param in parameters.values()}
         for name, param in parameters.items():
             param.data.copy_(getattr(layer, name))
         for name, buffer in buffers.items():

--- a/tests/unit/inference/test_vllm_reload_patches.py
+++ b/tests/unit/inference/test_vllm_reload_patches.py
@@ -11,6 +11,14 @@ class AliasedKernelLayer(torch.nn.Module):
         self.register_buffer("running", torch.zeros(2, dtype=torch.float32))
 
 
+class ChildParameterAliasedKernelLayer(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.child = torch.nn.Linear(2, 2, bias=False)
+        self.register_buffer("conv_weights", self.child.weight.view(-1), persistent=False)
+        self.register_buffer("running", torch.zeros(2, dtype=torch.float32))
+
+
 def _layer_reloading_info(layer: AliasedKernelLayer):
     from vllm.model_executor.model_loader.reload.types import LayerReloadingInfo
 
@@ -19,6 +27,22 @@ def _layer_reloading_info(layer: AliasedKernelLayer):
         restore_device=torch.device("cpu"),
         kernel_tensors=(
             {"weight": layer._parameters["weight"]},
+            {
+                "conv_weights": layer._buffers["conv_weights"],
+                "running": layer._buffers["running"],
+            },
+        ),
+    )
+
+
+def _child_parameter_layer_reloading_info(layer: ChildParameterAliasedKernelLayer):
+    from vllm.model_executor.model_loader.reload.types import LayerReloadingInfo
+
+    return LayerReloadingInfo(
+        restore_metadata=({}, {}),
+        restore_device=torch.device("cpu"),
+        kernel_tensors=(
+            {},
             {
                 "conv_weights": layer._buffers["conv_weights"],
                 "running": layer._buffers["running"],
@@ -45,6 +69,40 @@ def test_vllm_layerwise_reload_alias_buffer_patch_preserves_parameter_storage():
 
     assert torch.equal(layer.weight, torch.full_like(layer.weight, 7.0))
     assert torch.equal(layer.conv_weights, layer.weight.view(-1))
+    assert torch.equal(layer.running, torch.full_like(layer.running, 3.0))
+
+
+def test_vllm_layerwise_reload_alias_buffer_patch_handles_child_parameter_alias():
+    from vllm.model_executor.model_loader.reload import layerwise
+
+    layer = ChildParameterAliasedKernelLayer()
+    info = _child_parameter_layer_reloading_info(layer)
+    layer.child.weight.data.fill_(7.0)
+    layer._buffers["conv_weights"] = torch.full_like(layer.conv_weights, float("nan"))
+    layer._buffers["running"] = torch.full_like(layer.running, 3.0)
+
+    patches.monkey_patch_vllm_layerwise_reload_alias_buffers()
+    layerwise._copy_and_restore_kernel_tensors(layer, info)
+
+    assert torch.equal(layer.child.weight, torch.full_like(layer.child.weight, 7.0))
+    assert torch.equal(layer.conv_weights, layer.child.weight.view(-1))
+    assert torch.equal(layer.running, torch.full_like(layer.running, 3.0))
+
+
+def test_vllm_layerwise_reload_alias_buffer_patch_skips_absent_alias_buffer():
+    from vllm.model_executor.model_loader.reload import layerwise
+
+    layer = ChildParameterAliasedKernelLayer()
+    info = _child_parameter_layer_reloading_info(layer)
+    layer.child.weight.data.fill_(7.0)
+    del layer._buffers["conv_weights"]
+    layer._buffers["running"] = torch.full_like(layer.running, 3.0)
+
+    patches.monkey_patch_vllm_layerwise_reload_alias_buffers()
+    layerwise._copy_and_restore_kernel_tensors(layer, info)
+
+    assert torch.equal(layer.child.weight, torch.full_like(layer.child.weight, 7.0))
+    assert torch.equal(layer.conv_weights, layer.child.weight.view(-1))
     assert torch.equal(layer.running, torch.full_like(layer.running, 3.0))
 
 

--- a/tests/unit/inference/test_vllm_reload_patches.py
+++ b/tests/unit/inference/test_vllm_reload_patches.py
@@ -1,0 +1,62 @@
+import torch
+
+from prime_rl.inference import patches
+
+
+class AliasedKernelLayer(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.arange(4, dtype=torch.float32).reshape(2, 2))
+        self.register_buffer("conv_weights", self.weight.view(-1))
+        self.register_buffer("running", torch.zeros(2, dtype=torch.float32))
+
+
+def _layer_reloading_info(layer: AliasedKernelLayer):
+    from vllm.model_executor.model_loader.reload.types import LayerReloadingInfo
+
+    return LayerReloadingInfo(
+        restore_metadata=({}, {}),
+        restore_device=torch.device("cpu"),
+        kernel_tensors=(
+            {"weight": layer._parameters["weight"]},
+            {
+                "conv_weights": layer._buffers["conv_weights"],
+                "running": layer._buffers["running"],
+            },
+        ),
+    )
+
+
+def _install_processed_tensors(layer: AliasedKernelLayer, aliased_buffer_value: float = 99.0):
+    layer._parameters["weight"] = torch.nn.Parameter(torch.full_like(layer.weight, 7.0))
+    layer._buffers["conv_weights"] = torch.full_like(layer.conv_weights, aliased_buffer_value)
+    layer._buffers["running"] = torch.full_like(layer.running, 3.0)
+
+
+def test_vllm_layerwise_reload_alias_buffer_patch_preserves_parameter_storage():
+    from vllm.model_executor.model_loader.reload import layerwise
+
+    layer = AliasedKernelLayer()
+    info = _layer_reloading_info(layer)
+    _install_processed_tensors(layer)
+
+    patches.monkey_patch_vllm_layerwise_reload_alias_buffers()
+    layerwise._copy_and_restore_kernel_tensors(layer, info)
+
+    assert torch.equal(layer.weight, torch.full_like(layer.weight, 7.0))
+    assert torch.equal(layer.conv_weights, layer.weight.view(-1))
+    assert torch.equal(layer.running, torch.full_like(layer.running, 3.0))
+
+
+def test_vllm_0_22_layerwise_reload_copy_order_reproduces_alias_corruption():
+    layer = AliasedKernelLayer()
+    info = _layer_reloading_info(layer)
+    original_param = info.kernel_tensors[0]["weight"]
+    original_buffer = info.kernel_tensors[1]["conv_weights"]
+
+    _install_processed_tensors(layer, aliased_buffer_value=float("nan"))
+
+    original_param.data.copy_(layer.weight)
+    original_buffer.data.copy_(layer.conv_weights)
+
+    assert torch.isnan(original_param).all()


### PR DESCRIPTION
## Summary

- Fix vLLM layerwise reload alias-buffer handling so Mamba/NemotronH reloads do not copy aliased buffers back over parameter storage.
- Cover aliases to child-module parameters such as `MambaMixer2.conv_weights -> conv1d.weight` and skip alias buffers that vLLM intentionally omitted from restore metadata.
- Update the weight-update monitoring workflow note to check inference-server `/update_weights` results, not only trainer-side broadcast logs.

## Details

The vLLM API server `/update_weights` path reloads checkpoint-format weights layer by layer. NemotronH/Mamba can register buffers on a parent module that alias parameter storage owned by a child module. The previous alias handling only covered direct layer parameters and could either copy stale buffer data back over parameter storage or fail when vLLM omitted an alias buffer from the restored module state.

The patch compares aliased buffers against recursive parameter storage and captured kernel parameters, uses module registries instead of `getattr`, and skips absent alias buffers.

## Validation

- `UV_NO_SYNC=1 uv run pytest tests/unit/inference/test_vllm_reload_patches.py`
- `UV_NO_SYNC=1 uv run ruff check src/prime_rl/inference/patches.py tests/unit/inference/test_vllm_reload_patches.py`
- Combined-stack SLURM job `23599` with the external-LB config fix from #2705 reached all 4 API servers ready, completed rollouts with `Error 0.0%`, all 16 vLLM workers reloaded checkpoint-format weights, all four `/update_weights` calls returned `200 OK`, inference resumed, and the trainer started step 1. Final log scan found no `ERROR`, `Traceback`, `Fatal`, `ValueError`, `data_parallel_rank`, `conv_weights`, or `Internal Server Error` failures.
