### PR TITLE
extend router replay

### DIFF
--- a/docs/inference.md
+++ b/docs/inference.md
@@ -264,6 +264,8 @@ enable_router_replay = true # this will also auto-set the inference.enable_retur
 enable_return_routed_experts = true
 ```
 
+During training, the router still computes gate scores so gradients flow through it. By default, router replay uses the inference-selected experts exactly. Set `trainer.router_replay_score_threshold_ratio` to a value greater than `0` to filter replayed experts whose gate score falls below that fraction of the weakest expert in the trainer router's own top-k for that token, then fill those slots with router-selected candidates.
+
 This however is not free, it adds a significant overhead to the HTTP requests as this payload can grow quite large. We reccomend increasing `orchestrator.*.env.num_workers` to allow for more parallelization on the verifiers side.
 
 Currently this feature is also not supported with CPU KV cache offload, which can have negative impact on the inference throughput.

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -538,6 +538,9 @@ class TrainerConfig(BaseConfig):
     enable_router_replay: bool = False
     """Return routed experts in the batch so the trainer can replay routing. Requires ``enable_return_routed_experts=true`` on the vLLM server (or ``--enable-return-routed-experts``) and is only supported for custom models."""
 
+    router_replay_score_threshold_ratio: float = Field(0.0, ge=0.0, le=1.0)
+    """When router replay is enabled, optionally accept a replayed expert only if its gate score is at least this fraction of the trainer router's weakest top-k gate score for that token. The default 0 disables plausibility filtering."""
+
     memory_profiler_path: Path | None = None
     """Path to write the memory profile to."""
 

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -371,6 +371,30 @@ def apply_force_balanced_routing(model: nn.Module) -> None:
     )
 
 
+def configure_router_replay_filter(model: nn.Module, score_threshold_ratio: float) -> None:
+    """Configure trainer-side plausibility filtering for replayed MoE routes."""
+    logger = get_logger()
+    language_model = get_language_model(model)
+    routers = []
+
+    for layer in language_model.layers:
+        mlp = getattr(layer, "mlp", None) or getattr(layer, "feed_forward", None)
+        if isinstance(mlp, MoE):
+            routers.append(mlp.router)
+
+    if not routers:
+        logger.warning("Router replay is enabled, but no token-choice MoE routers were found to configure.")
+        return
+
+    for router in routers:
+        router.router_replay_score_threshold_ratio = score_threshold_ratio
+
+    logger.info(
+        f"Configured router replay plausibility filtering on {len(routers)} MoE layers "
+        f"(score_threshold_ratio={score_threshold_ratio})."
+    )
+
+
 def is_tt_moe_model(model: nn.Module) -> bool:
     return hasattr(model.config, "num_experts") or hasattr(model.config, "n_routed_experts")
 

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -418,6 +418,8 @@ def get_load_balance_stats(
 ) -> dict[str, Tensor | None]:
     per_layer_max_vio = []
     per_layer_routing_confidence = []
+    per_layer_replay_replace_rate = []
+    replay_slots_total: torch.Tensor | None = None
     language_model = get_language_model(model)
     for transformer_block in language_model.layers:
         # This is necessary for models that have mixed dense layers
@@ -435,14 +437,30 @@ def get_load_balance_stats(
         routing_confidence = block_mlp.routing_confidence_sum / num_routed_tokens
         per_layer_routing_confidence.append(routing_confidence.detach())
 
+        # Fraction of replayed expert slots replaced by the trainer router's top-k (router replay
+        # plausibility filtering). 0 for the pure-replay baseline (threshold ratio 0).
+        if hasattr(block_mlp, "replay_slots_sum"):
+            replay_slots = block_mlp.replay_slots_sum
+            replace_rate = block_mlp.replay_replaced_sum / replay_slots.clamp(min=1.0)
+            per_layer_replay_replace_rate.append(replace_rate.detach())
+            replay_slots_total = replay_slots.detach() if replay_slots_total is None else replay_slots_total + replay_slots
+
         if reset_stats:
             block_mlp.tokens_per_expert.zero_()
             block_mlp.routing_confidence_sum.zero_()
+            if hasattr(block_mlp, "replay_slots_sum"):
+                block_mlp.replay_replaced_sum.zero_()
+                block_mlp.replay_slots_sum.zero_()
     if len(per_layer_max_vio) == 0:
-        return {"max_vio": None, "routing_confidence": None}
+        return {"max_vio": None, "routing_confidence": None, "router_replay_replace_rate": None}
+    # Only surface the replay metric when experts were actually replayed (router replay on).
+    router_replay_replace_rate = None
+    if per_layer_replay_replace_rate and replay_slots_total is not None and bool(replay_slots_total > 0):
+        router_replay_replace_rate = torch.stack(per_layer_replay_replace_rate)
     return {
         "max_vio": torch.stack(per_layer_max_vio),
         "routing_confidence": torch.stack(per_layer_routing_confidence),
+        "router_replay_replace_rate": router_replay_replace_rate,
     }
 
 

--- a/src/prime_rl/trainer/models/layers/moe.py
+++ b/src/prime_rl/trainer/models/layers/moe.py
@@ -533,12 +533,13 @@ class TokenChoiceTopKRouter(nn.Module):
         top_scores = top_scores * self.route_scale
 
         # group tokens together by expert indices from 0 to num_experts and pass that to experts forward
+        # histc requires a float input, but the downstream permute kernel needs integer token counts
         num_tokens_per_expert = torch.histc(
             selected_experts_indices.reshape(-1).float(),
             bins=self.num_experts,
             min=0,
             max=self.num_experts,
-        )
+        ).to(torch.long)
 
         return top_scores, selected_experts_indices, num_tokens_per_expert, routing_confidence_sum
 
@@ -585,12 +586,13 @@ class TokenReorderer(nn.Module):
         """
         # group tokens together by expert indices from 0 to num_experts and pass that to experts forward
         selected_experts_indices = selected_experts_indices.reshape(-1)
+        # histc requires a float input, but the downstream permute kernel needs integer token counts
         num_tokens_per_expert = torch.histc(
             selected_experts_indices.float(),
             bins=self.num_experts,
             min=0,
             max=self.num_experts,
-        )
+        ).to(torch.long)
 
         # Reorder the token indices to match the order of the experts
         # token_indices_experts_sorted shape (bs*slen*top_k,)

--- a/src/prime_rl/trainer/models/layers/moe.py
+++ b/src/prime_rl/trainer/models/layers/moe.py
@@ -427,6 +427,43 @@ class TokenChoiceTopKRouter(nn.Module):
         self.route_norm = route_norm
         self.route_scale = route_scale
         self.force_balanced = False
+        self.router_replay_score_threshold_ratio = 0.0
+
+    def _topk_from_scores(
+        self, scores: torch.Tensor, expert_bias: torch.Tensor | None
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if expert_bias is not None:
+            _, selected_experts_indices = torch.topk(scores + expert_bias, k=self.top_k, dim=1)
+            top_scores = scores.gather(dim=1, index=selected_experts_indices)
+        else:
+            top_scores, selected_experts_indices = torch.topk(scores, k=self.top_k, dim=1)
+        return top_scores, selected_experts_indices
+
+    def _filter_replayed_experts(
+        self,
+        scores: torch.Tensor,
+        routed_experts: torch.Tensor,
+        router_top_scores: torch.Tensor,
+        router_selected_experts: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        replayed_scores = scores.gather(dim=1, index=routed_experts)
+        threshold = router_top_scores.amin(dim=1, keepdim=True) * self.router_replay_score_threshold_ratio
+        keep_replayed = replayed_scores >= threshold
+
+        selected_experts_indices = torch.where(keep_replayed, routed_experts, torch.full_like(routed_experts, -1))
+        for candidate_slot in range(self.top_k):
+            candidate = router_selected_experts[:, candidate_slot]
+            candidate_unused = (selected_experts_indices != candidate.unsqueeze(1)).all(dim=1)
+            fillable_slots = (selected_experts_indices < 0) & candidate_unused.unsqueeze(1)
+            first_fillable_slot = fillable_slots & (fillable_slots.cumsum(dim=1) == 1)
+            selected_experts_indices = torch.where(
+                first_fillable_slot,
+                candidate.unsqueeze(1),
+                selected_experts_indices,
+            )
+
+        top_scores = scores.gather(dim=1, index=selected_experts_indices)
+        return top_scores, selected_experts_indices
 
     def forward(
         self, x: torch.Tensor, expert_bias: torch.Tensor | None = None, routed_experts: torch.Tensor | None = None
@@ -468,18 +505,25 @@ class TokenChoiceTopKRouter(nn.Module):
         #       top_scores is still derived from the original scores.
 
         if routed_experts is not None:
-            top_scores = scores.gather(dim=1, index=routed_experts)
-            selected_experts_indices = routed_experts
+            routed_experts = routed_experts.to(torch.long)
+            if self.router_replay_score_threshold_ratio > 0:
+                router_top_scores, router_selected_experts = self._topk_from_scores(scores, expert_bias)
+                top_scores, selected_experts_indices = self._filter_replayed_experts(
+                    scores,
+                    routed_experts,
+                    router_top_scores,
+                    router_selected_experts,
+                )
+            else:
+                top_scores = scores.gather(dim=1, index=routed_experts)
+                selected_experts_indices = routed_experts
         elif self.force_balanced:
             num_tokens = scores.shape[0]
             arange = torch.arange(num_tokens * self.top_k, device=scores.device)
             selected_experts_indices = (arange % self.num_experts).view(num_tokens, self.top_k)
             top_scores = scores.gather(dim=1, index=selected_experts_indices)
-        elif expert_bias is not None:
-            _, selected_experts_indices = torch.topk(scores + expert_bias, k=self.top_k, dim=1)
-            top_scores = scores.gather(dim=1, index=selected_experts_indices)
         else:
-            top_scores, selected_experts_indices = torch.topk(scores, k=self.top_k, dim=1)
+            top_scores, selected_experts_indices = self._topk_from_scores(scores, expert_bias)
 
         routing_confidence_sum = _selected_probability_mass_sum(scores, top_scores, self.score_func)
 
@@ -490,7 +534,7 @@ class TokenChoiceTopKRouter(nn.Module):
 
         # group tokens together by expert indices from 0 to num_experts and pass that to experts forward
         num_tokens_per_expert = torch.histc(
-            selected_experts_indices.reshape(-1),
+            selected_experts_indices.reshape(-1).float(),
             bins=self.num_experts,
             min=0,
             max=self.num_experts,
@@ -542,7 +586,7 @@ class TokenReorderer(nn.Module):
         # group tokens together by expert indices from 0 to num_experts and pass that to experts forward
         selected_experts_indices = selected_experts_indices.reshape(-1)
         num_tokens_per_expert = torch.histc(
-            selected_experts_indices,
+            selected_experts_indices.float(),
             bins=self.num_experts,
             min=0,
             max=self.num_experts,

--- a/src/prime_rl/trainer/models/layers/moe.py
+++ b/src/prime_rl/trainer/models/layers/moe.py
@@ -445,10 +445,14 @@ class TokenChoiceTopKRouter(nn.Module):
         routed_experts: torch.Tensor,
         router_top_scores: torch.Tensor,
         router_selected_experts: torch.Tensor,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         replayed_scores = scores.gather(dim=1, index=routed_experts)
         threshold = router_top_scores.amin(dim=1, keepdim=True) * self.router_replay_score_threshold_ratio
         keep_replayed = replayed_scores >= threshold
+        # Count expert slots where the replayed (inference-selected) expert was rejected by
+        # the threshold and refilled from the trainer router's own top-k. Used for the
+        # router_replay_replace_rate metric (how often the extended replay deviates from pure replay).
+        num_replaced = (~keep_replayed).sum().to(torch.float32)
 
         selected_experts_indices = torch.where(keep_replayed, routed_experts, torch.full_like(routed_experts, -1))
         for candidate_slot in range(self.top_k):
@@ -463,11 +467,11 @@ class TokenChoiceTopKRouter(nn.Module):
             )
 
         top_scores = scores.gather(dim=1, index=selected_experts_indices)
-        return top_scores, selected_experts_indices
+        return top_scores, selected_experts_indices, num_replaced
 
     def forward(
         self, x: torch.Tensor, expert_bias: torch.Tensor | None = None, routed_experts: torch.Tensor | None = None
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         """
         Args:
             x (torch.Tensor): Input tensor with shape ``(bs*slen, dim)``.
@@ -504,11 +508,14 @@ class TokenChoiceTopKRouter(nn.Module):
         # NOTE: The expert_bias is only used for routing. The gating value
         #       top_scores is still derived from the original scores.
 
+        # Count of replayed expert slots replaced by the trainer router's top-k (router replay
+        # plausibility filtering). Stays 0 when filtering is off or no experts are replayed.
+        replay_replaced_count = scores.new_zeros(())
         if routed_experts is not None:
             routed_experts = routed_experts.to(torch.long)
             if self.router_replay_score_threshold_ratio > 0:
                 router_top_scores, router_selected_experts = self._topk_from_scores(scores, expert_bias)
-                top_scores, selected_experts_indices = self._filter_replayed_experts(
+                top_scores, selected_experts_indices, replay_replaced_count = self._filter_replayed_experts(
                     scores,
                     routed_experts,
                     router_top_scores,
@@ -541,7 +548,7 @@ class TokenChoiceTopKRouter(nn.Module):
             max=self.num_experts,
         ).to(torch.long)
 
-        return top_scores, selected_experts_indices, num_tokens_per_expert, routing_confidence_sum
+        return top_scores, selected_experts_indices, num_tokens_per_expert, routing_confidence_sum, replay_replaced_count
 
     def init_weights(self, init_std: float):
         nn.init.trunc_normal_(self.gate.weight, mean=0.0, std=init_std)
@@ -661,6 +668,11 @@ class MoE(nn.Module):
             persistent=False,
         )
         self.register_buffer("routing_confidence_sum", torch.tensor(0.0, dtype=torch.float32), persistent=False)
+        # Router replay accounting: replayed expert slots replaced by the trainer router's top-k
+        # (replay_replaced_sum) and total replayed slots seen (replay_slots_sum). Their ratio is the
+        # router_replay_replace_rate metric. Only accumulated when routed_experts are provided.
+        self.register_buffer("replay_replaced_sum", torch.tensor(0.0, dtype=torch.float32), persistent=False)
+        self.register_buffer("replay_slots_sum", torch.tensor(0.0, dtype=torch.float32), persistent=False)
 
     def set_ep_comm_backend(self, backend: EPCommBackend) -> None:
         self.ep_comm_backend = backend
@@ -780,6 +792,7 @@ class MoE(nn.Module):
             selected_experts_indices,
             num_tokens_per_expert,
             routing_confidence_sum,
+            replay_replaced_count,
         ) = self.router(x, self.expert_bias, routed_experts=routed_experts)
 
         # tokens_per_expert will be used to update the expert bias for load balancing.
@@ -790,6 +803,11 @@ class MoE(nn.Module):
         with torch.no_grad():
             self.tokens_per_expert.add_(num_tokens_per_expert)
             self.routing_confidence_sum.add_(routing_confidence_sum)
+            # Router replay replace-rate accounting. Numerator and denominator both rerun under
+            # full-block AC, so the ratio is unaffected. Only count when experts are replayed.
+            if routed_experts is not None:
+                self.replay_replaced_sum.add_(replay_replaced_count)
+                self.replay_slots_sum.add_(num_tokens_per_expert.sum().to(torch.float32))
 
         if self.ep_comm_backend == "deepep":
             routed_output = self._run_deepep_routed_experts(x, selected_experts_indices, top_scores)

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -42,6 +42,7 @@ from prime_rl.trainer.model import (
     setup_model,
     is_tt_moe_model,
     get_load_balance_stats,
+    configure_router_replay_filter,
 )
 from prime_rl.trainer.parallel_dims import get_parallel_dims
 from prime_rl.trainer.perf import get_perf_counter
@@ -145,6 +146,8 @@ def train(config: TrainerConfig):
     logger.info(f"Initializing model ({config.model})")
     loading_from_ckpt_later = config.ckpt and checkpoint_step is not None
     model = setup_model(config.model, parallel_dims, loading_from_ckpt_later)
+    if config.enable_router_replay:
+        configure_router_replay_filter(model, config.router_replay_score_threshold_ratio)
 
     logger.info(f"Initializing tokenizer ({config.tokenizer})")
     tokenizer = setup_tokenizer(config.tokenizer)

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -596,6 +596,8 @@ def train(config: TrainerConfig):
             step_message += f" | Max Vio {tensor_stats['max_vio/mean']:.4f}"
         if "routing_confidence/mean" in tensor_stats:
             step_message += f" | Routing Conf. {tensor_stats['routing_confidence/mean']:.4f}"
+        if "router_replay_replace_rate/mean" in tensor_stats:
+            step_message += f" | Replay Replace {tensor_stats['router_replay_replace_rate/mean']:.4f}"
         logger.success(step_message)
 
         # Log performance metrics


### PR DESCRIPTION
Replayed experts are only kept if the trainers score on them is above the score of its weakest expert * ratio

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MoE forward routing during RL when the threshold is enabled, which affects gradients and expert assignment; default 0 preserves prior pure-replay behavior.
> 
> **Overview**
> Extends **router replay** so training no longer has to use inference expert choices verbatim when the trainer router disagrees strongly.
> 
> A new **`trainer.router_replay_score_threshold_ratio`** (default `0` = unchanged behavior) gates each replayed expert: it is kept only if its trainer gate score is at least that fraction of the trainer’s weakest top-k score for the token. Rejected slots are refilled from the trainer router’s own top-k in order. **`configure_router_replay_filter`** applies the ratio to token-choice MoE routers at startup when router replay is on.
> 
> MoE routing code is refactored with shared **`_topk_from_scores`** and **`_filter_replayed_experts`**. **`router_replay_replace_rate`** tracks how often replay slots were overridden; it appears in load-balance stats and step logs as **Replay Replace**. **`histc`** inputs are cast to float then back to long for kernel compatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b043947e8173ed41793f7c80c7ef8c67d2cba252. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->