### PR TITLE
[codex] Fix external-LB inference config sizing

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -548,11 +548,9 @@ class RLConfig(BaseConfig):
                     self.inference.api_server_count = dp_per_node
 
             if self.weight_broadcast is not None and self.weight_broadcast.type == "nccl":
-                # Compute inference_world_size from actual worker count per server:
-                # each api_server runs tp workers that participate in collective_rpc.
-                api_server_count = self.inference.api_server_count if self.inference else 1
-                tp = self.inference.parallel.tp if self.inference else 1
-                total_infer_workers = self.deployment.total_infer_nodes * api_server_count * tp
+                # The multi-node RL launcher starts one TP-sharded backend for each
+                # DP slice on every allocated inference node.
+                total_infer_workers = self.deployment.total_infer_nodes * self.deployment.gpus_per_node
                 assert self.trainer.weight_broadcast.type == "nccl"
                 self.trainer.weight_broadcast.host = "0.0.0.0"
                 self.trainer.weight_broadcast.inference_world_size = total_infer_workers
@@ -600,16 +598,31 @@ class RLConfig(BaseConfig):
     def auto_setup_inference_client(self):
         """Auto-configure orchestrator student client from the inference server config.
 
-        For all modes, sets dp_rank_count from inference DP size. For SFT mode,
-        also sets base_url - rl/opd rely on the ClientConfig default
-        (``["http://localhost:8000/v1"]``) which already matches the auto-launched
-        student vLLM at inference.server.port = 8000.
+        For most modes, sets dp_rank_count from inference DP size. Dense
+        multi-node external-LB launches route through vllm-router, so requests
+        must not carry vLLM DP-rank headers. For SFT mode, also sets base_url -
+        rl/opd rely on the ClientConfig default (``["http://localhost:8000/v1"]``)
+        which already matches the auto-launched student vLLM at inference.server.port = 8000.
         """
         if self.inference is None:
             return self
         client = self.orchestrator.student.client
         if "dp_rank_count" not in client.model_fields_set:
-            client.dp_rank_count = self.inference.data_parallel_size_local or self.inference.parallel.dp
+            if (
+                self.deployment.type == "multi_node"
+                and self.inference.deployment.type != "disaggregated"
+                and self.inference.enable_expert_parallel
+            ):
+                dp_per_node = self.deployment.gpus_per_node // self.inference.parallel.tp
+                client.dp_rank_count = self.deployment.num_infer_nodes * dp_per_node
+            elif (
+                self.deployment.type == "multi_node"
+                and self.inference.deployment.type != "disaggregated"
+                and not self.inference.enable_expert_parallel
+            ):
+                client.dp_rank_count = 1
+            else:
+                client.dp_rank_count = self.inference.data_parallel_size_local or self.inference.parallel.dp
         if self.orchestrator.training_mode == "sft" and "base_url" not in client.model_fields_set:
             host = self.inference.server.host or "localhost"
             port = self.inference.server.port

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -630,6 +630,49 @@ class RLConfig(BaseConfig):
         return self
 
     @model_validator(mode="after")
+    def validate_multi_node_inference_resolution(self):
+        if self.deployment.type != "multi_node" or self.inference is None:
+            return self
+
+        if self.trainer.weight_broadcast.type == "nccl" or self.orchestrator.weight_broadcast.type == "nccl":
+            expected_world_size = self.deployment.total_infer_nodes * self.deployment.gpus_per_node
+
+            if (
+                self.trainer.weight_broadcast.type == "nccl"
+                and self.trainer.weight_broadcast.inference_world_size != expected_world_size
+            ):
+                raise ValueError(
+                    "trainer.weight_broadcast.inference_world_size must match allocated inference GPUs "
+                    f"({expected_world_size}) for multi-node NCCL weight broadcast."
+                )
+
+            if (
+                self.orchestrator.weight_broadcast.type == "nccl"
+                and self.orchestrator.weight_broadcast.inference_world_size != expected_world_size
+            ):
+                raise ValueError(
+                    "orchestrator.weight_broadcast.inference_world_size must match allocated inference GPUs "
+                    f"({expected_world_size}) for multi-node NCCL weight broadcast."
+                )
+
+        if self.inference.deployment.type != "disaggregated":
+            if self.inference.enable_expert_parallel:
+                dp_per_node = self.deployment.gpus_per_node // self.inference.parallel.tp
+                expected_dp_rank_count = self.deployment.num_infer_nodes * dp_per_node
+            else:
+                expected_dp_rank_count = 1
+
+            client = self.orchestrator.student.client
+            if client.dp_rank_count != expected_dp_rank_count:
+                raise ValueError(
+                    "orchestrator.student.client.dp_rank_count must resolve to "
+                    f"{expected_dp_rank_count} for multi-node non-disaggregated inference; "
+                    f"got {client.dp_rank_count}."
+                )
+
+        return self
+
+    @model_validator(mode="after")
     def auto_setup_slurm_template(self):
         """Auto-setup the default single-node/multi-node SLURM template if no custom template is provided."""
         if self.slurm is not None and self.slurm.template_path is None:

--- a/skills/configs/SKILL.md
+++ b/skills/configs/SKILL.md
@@ -28,6 +28,12 @@ uv run rl --help                                  # all fields and defaults
 uv run rl @ rl.toml --dry-run --output-dir /tmp/x # write resolved TOML to /tmp/x/configs
 ```
 
+For multi-node RL with NCCL weight broadcast, inspect the resolved trainer and
+orchestrator TOML after `--dry-run`. `inference_world_size` should match allocated
+inference GPUs. For dense external-LB router launches, the orchestrator student's
+`dp_rank_count` should stay `1`; admin URLs cover every backend for weight updates,
+while the router handles request load balancing/stickiness.
+
 ## Validators
 
 Incompatible combinations (e.g. CP requires flash attention) must raise in a `model_validator` at resolve time, not at runtime. When renaming a field, emit a deprecation warning with a migration hint — never silently drop.

--- a/skills/configs/SKILL.md
+++ b/skills/configs/SKILL.md
@@ -28,12 +28,6 @@ uv run rl --help                                  # all fields and defaults
 uv run rl @ rl.toml --dry-run --output-dir /tmp/x # write resolved TOML to /tmp/x/configs
 ```
 
-For multi-node RL with NCCL weight broadcast, inspect the resolved trainer and
-orchestrator TOML after `--dry-run`. `inference_world_size` should match allocated
-inference GPUs. For dense external-LB router launches, the orchestrator student's
-`dp_rank_count` should stay `1`; admin URLs cover every backend for weight updates,
-while the router handles request load balancing/stickiness.
-
 ## Validators
 
 Incompatible combinations (e.g. CP requires flash attention) must raise in a `model_validator` at resolve time, not at runtime. When renaming a field, emit a deprecation warning with a migration hint — never silently drop.

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -558,3 +558,38 @@ def test_multi_node_dense_nccl_world_size_matches_inference_gpu_count_and_router
     assert config.trainer.weight_broadcast.inference_world_size == 16
     assert config.orchestrator.weight_broadcast.inference_world_size == 16
     assert config.orchestrator.student.client.dp_rank_count == 1
+
+
+def test_multi_node_dense_rejects_invalid_router_dp_rank_count():
+    with pytest.raises(ValidationError, match=r"dp_rank_count must resolve to 1"):
+        RLConfig.model_validate(
+            {
+                "model": {"name": "Qwen/Qwen3-0.6B"},
+                "slurm": {},
+                "deployment": {"type": "multi_node", "num_train_nodes": 2, "num_infer_nodes": 2},
+                "weight_broadcast": {"type": "nccl"},
+                "trainer": {},
+                "orchestrator": {
+                    "renderer": None,
+                    "student": {"client": {"dp_rank_count": 4}},
+                },
+                "inference": {"parallel": {"tp": 4, "dp": 4}},
+            }
+        )
+
+
+def test_multi_node_nccl_rejects_invalid_inference_world_size_override():
+    with pytest.raises(ValidationError, match=r"inference_world_size must match allocated inference GPUs"):
+        RLConfig.model_validate(
+            {
+                "model": {"name": "Qwen/Qwen3-0.6B"},
+                "slurm": {},
+                "deployment": {"type": "multi_node", "num_train_nodes": 2, "num_infer_nodes": 2},
+                "trainer": {"weight_broadcast": {"type": "nccl", "inference_world_size": 32}},
+                "orchestrator": {
+                    "renderer": None,
+                    "weight_broadcast": {"type": "nccl", "inference_world_size": 32},
+                },
+                "inference": {"parallel": {"tp": 4, "dp": 4}},
+            }
+        )

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -537,3 +537,24 @@ def test_explicit_inference_parser_wins_over_auto():
     )
     assert config.inference is not None
     assert config.inference.model.tool_call_parser == "hermes"
+
+
+def test_multi_node_dense_nccl_world_size_matches_inference_gpu_count_and_router_client():
+    config = RLConfig.model_validate(
+        {
+            "model": {"name": "Qwen/Qwen3-0.6B"},
+            "slurm": {},
+            "deployment": {"type": "multi_node", "num_train_nodes": 2, "num_infer_nodes": 2},
+            "weight_broadcast": {"type": "nccl"},
+            "trainer": {},
+            "orchestrator": {"renderer": None},
+            "inference": {"parallel": {"tp": 4, "dp": 4}},
+        }
+    )
+
+    assert config.inference is not None
+    assert config.inference.api_server_count == 4
+    assert config.inference.data_parallel_size_local == 2
+    assert config.trainer.weight_broadcast.inference_world_size == 16
+    assert config.orchestrator.weight_broadcast.inference_world_size == 16
+    assert config.orchestrator.student.client.dp_rank_count == 1


### PR DESCRIPTION
## Summary

- Fix dense multi-node external-LB NCCL broadcast sizing so `inference_world_size` matches allocated inference GPUs, not `nodes * global_api_server_count * tp`.
- Keep dense router-backed student clients at `dp_rank_count = 1` so requests do not send invalid vLLM `X-data-parallel-rank` headers; admin URLs still cover every backend for weight updates.
- Validate the resolved multi-node inference shape so explicit bad overrides for NCCL `inference_world_size` or router `dp_rank_count` fail during config resolution.

## Details

For external-LB multi-node dense inference, `api_server_count` is already the global backend count exposed through the router/admin URL list. Multiplying it by the inference-node count double-counts workers on 2 inference nodes and makes NCCL wait for ranks that do not exist.

Those dense backends are independent TP-sharded servers with vLLM DP size 1, so the router should handle request distribution instead of the client sending global DP-rank headers.

The resolver now sets those values correctly by default and rejects explicit overrides that would reintroduce the mismatch, so this is enforced by `RLConfig` rather than a manual dry-run inspection note.

## Validation

- `UV_NO_SYNC=1 uv run pytest tests/unit/test_configs.py::test_multi_node_dense_nccl_world_size_matches_inference_gpu_count_and_router_client tests/unit/test_configs.py::test_multi_node_dense_rejects_invalid_router_dp_rank_count tests/unit/test_configs.py::test_multi_node_nccl_rejects_invalid_inference_world_size_override`
- `UV_NO_SYNC=1 uv run ruff check packages/prime-rl-configs/src/prime_rl/configs/rl.py tests/unit/test_configs.py`
- `UV_NO_SYNC=1 uv run rl @ configs/nemotron_debug/rl.toml --dry-run --output-dir /tmp/prime-rl-nemotron-dryrun-config-pr` resolved `api_server_count=4`, `data_parallel_size_local=2`, `inference_world_size=16`, and `dp_rank_count=1`.
