### PR TITLE
fix(configs): size dense multi-node NCCL world by inference GPU count

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -548,11 +548,14 @@ class RLConfig(BaseConfig):
                     self.inference.api_server_count = dp_per_node
 
             if self.weight_broadcast is not None and self.weight_broadcast.type == "nccl":
-                # Compute inference_world_size from actual worker count per server:
-                # each api_server runs tp workers that participate in collective_rpc.
-                api_server_count = self.inference.api_server_count if self.inference else 1
-                tp = self.inference.parallel.tp if self.inference else 1
-                total_infer_workers = self.deployment.total_infer_nodes * api_server_count * tp
+                # Every allocated inference GPU is a NCCL rank in the weight broadcast.
+                # The external-LB launcher starts dp_per_node (= gpus_per_node / tp)
+                # TP-sharded servers per node, i.e. gpus_per_node workers per node, so use
+                # the GPU count directly. Deriving it from api_server_count double-counts:
+                # api_server_count can resolve to the *global* DP size, making the node
+                # factor count twice and NCCL wait for ranks that never connect. Matches
+                # the disaggregated path below.
+                total_infer_workers = self.deployment.total_infer_nodes * self.deployment.gpus_per_node
                 assert self.trainer.weight_broadcast.type == "nccl"
                 self.trainer.weight_broadcast.host = "0.0.0.0"
                 self.trainer.weight_broadcast.inference_world_size = total_infer_workers


### PR DESCRIPTION
## Summary

Fixes the NCCL `inference_world_size` computation for dense multi-node external-LB inference.

The world size was derived as `total_infer_nodes * api_server_count * tp`. `api_server_count` can resolve to the **global** DP size — e.g. when `parallel.dp` is set explicitly, or simply from validator ordering, where `InferenceConfig` sets `api_server_count = parallel.dp` before the RL resolver pins it to the per-node DP. When that happens the node dimension is counted twice, so the trainer's NCCL weight broadcast waits for more ranks than actually exist and init deadlocks.

Example — `tp=4`, `dp=4`, `gpus_per_node=8`, 2 inference nodes: `api_server_count` resolves to `4`, giving an old world size of `2 * 4 * 4 = 32`, while only `2 * 8 = 16` inference GPUs exist.

## Fix

Every allocated inference GPU is exactly one NCCL rank, and the external-LB launcher starts `dp_per_node` (= `gpus_per_node / tp`) TP-sharded servers per node — i.e. `gpus_per_node` workers per node. So size the broadcast world directly:

```
total_infer_workers = total_infer_nodes * gpus_per_node
```

This is GPU-count based (independent of how `api_server_count` resolves) and matches the disaggregated path, which already computes it the same way.

Verified the resolved world size for the example config goes 32 → 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes distributed weight-broadcast sizing for multi-node NCCL; wrong sizing deadlocks training, but the fix is narrowly scoped config math with an existing disaggregated precedent.
> 
> **Overview**
> Fixes how **NCCL** `inference_world_size` is computed for **dense multi-node** RL deployments with external load balancing and NCCL weight broadcast.
> 
> The resolver no longer uses `total_infer_nodes × api_server_count × tp`. That formula could treat `api_server_count` as **global** DP and effectively count nodes twice, so the trainer waited for more NCCL ranks than inference GPUs actually join—**deadlock at init**. It now sets the world to **`total_infer_nodes × gpus_per_node`**, one rank per inference GPU, aligned with the disaggregated inference path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf36dca495a58e5bdeb3b3942bd8760a4e1d6fc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->