### PR TITLE
Send Prime monitor display config to platform

### DIFF
--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -16,8 +16,8 @@ import verifiers as vf
 from prime_cli.core.config import Config as PrimeConfig
 from transformers.tokenization_utils import PreTrainedTokenizer
 
+from prime_rl.configs.orchestrator import OrchestratorConfig
 from prime_rl.configs.shared import PrimeMonitorConfig
-from prime_rl.utils.config import BaseConfig
 from prime_rl.utils.logger import get_logger
 from prime_rl.utils.monitor.base import Monitor, sample_items_for_logging
 
@@ -89,50 +89,6 @@ def _drop_non_finite_json_values(value: Any, dropped_paths: list[str], path: str
     return value
 
 
-def _get_nested_attr(obj: Any, *path: str) -> Any:
-    for attr in path:
-        if obj is None:
-            return None
-        obj = getattr(obj, attr, None)
-    return obj
-
-
-def _get_orchestrator_config(run_config: BaseConfig | None) -> Any:
-    return _get_nested_attr(run_config, "orchestrator") or run_config
-
-
-def _get_run_environments(run_config: BaseConfig | None) -> Any:
-    for path in (("env",), ("train", "env"), ("orchestrator", "train", "env")):
-        environments = _get_nested_attr(run_config, *path)
-        if environments:
-            return environments
-    return None
-
-
-def _get_run_base_model(run_config: BaseConfig | None) -> str:
-    return (
-        _get_nested_attr(_get_orchestrator_config(run_config), "student", "model", "name")
-        or _get_nested_attr(run_config, "model", "name")
-        or "unknown"
-    )
-
-
-def _get_run_display_config(run_config: BaseConfig | None) -> dict[str, Any]:
-    source = _get_orchestrator_config(run_config)
-    display_config: dict[str, Any] = {}
-
-    for payload_field, config_field in (
-        ("batch_size", "batch_size"),
-        ("rollouts_per_example", "group_size"),
-        ("seq_len", "seq_len"),
-    ):
-        value = _get_nested_attr(source, config_field)
-        if value is not None:
-            display_config[payload_field] = value
-
-    return display_config
-
-
 class PrimeMonitor(Monitor):
     """Logs to Prime Intellect API."""
 
@@ -156,7 +112,7 @@ class PrimeMonitor(Monitor):
         config: PrimeMonitorConfig | None,
         output_dir: Path | None = None,
         tokenizer: PreTrainedTokenizer | None = None,
-        run_config: BaseConfig | None = None,
+        run_config: OrchestratorConfig | None = None,
         keep_full_history: bool = True,
     ):
         self.config = config
@@ -229,7 +185,7 @@ class PrimeMonitor(Monitor):
             if config.log_extras.distributions:
                 self.last_log_distributions_step = -1
 
-    def _register_run(self, config: PrimeMonitorConfig, run_config: BaseConfig | None) -> str | None:
+    def _register_run(self, config: PrimeMonitorConfig, run_config: OrchestratorConfig | None) -> str | None:
         """Register an external run with the platform. Returns run_id on success, None on failure."""
         prime_config = None
         team_id = config.team_id
@@ -241,25 +197,23 @@ class PrimeMonitor(Monitor):
         if frontend_url is None:
             frontend_url = prime_config.frontend_url
 
-        display_config = _get_run_display_config(run_config)
-        environments = _get_run_environments(run_config)
-        wandb = getattr(run_config, "wandb", None) if run_config else None
-
         payload: dict[str, Any] = {
-            "base_model": _get_run_base_model(run_config),
-            "max_steps": _get_nested_attr(_get_orchestrator_config(run_config), "max_steps") or 0,
-            **display_config,
+            "base_model": run_config.student.model.name if run_config else "unknown",
+            "max_steps": (run_config.max_steps if run_config else None) or 0,
         }
         if run_config:
+            if run_config.batch_size is not None:
+                payload["batch_size"] = run_config.batch_size
+            payload["rollouts_per_example"] = run_config.group_size
+            payload["seq_len"] = run_config.seq_len
+            payload["environments"] = [{"id": env.id} for env in run_config.train.env]
             payload["run_config"] = run_config.model_dump(exclude_none=True, mode="json")
+            if run_config.wandb:
+                payload["wandb_project"] = run_config.wandb.project
         if config.run_name:
             payload["name"] = config.run_name
         if team_id:
             payload["team_id"] = team_id
-        if environments:
-            payload["environments"] = [{"id": env.id} for env in environments if hasattr(env, "id")]
-        if wandb and getattr(wandb, "project", None):
-            payload["wandb_project"] = wandb.project
 
         try:
             response = httpx.post(

--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -201,10 +201,16 @@ class PrimeMonitor(Monitor):
         environments = getattr(run_config, "env", None) if run_config else None
         wandb = getattr(run_config, "wandb", None) if run_config else None
 
-        payload: dict = {
+        payload: dict[str, Any] = {
             "base_model": model.name if model else "unknown",
             "max_steps": getattr(run_config, "max_steps", None) or 0,
         }
+        if run_config:
+            payload["run_config"] = run_config.model_dump(exclude_none=True, mode="json")
+            for field in ("batch_size", "rollouts_per_example", "seq_len"):
+                value = getattr(run_config, field, None)
+                if value is not None:
+                    payload[field] = value
         if config.run_name:
             payload["name"] = config.run_name
         if team_id:

--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -89,6 +89,24 @@ def _drop_non_finite_json_values(value: Any, dropped_paths: list[str], path: str
     return value
 
 
+def _get_run_environments(run_config: BaseConfig | None) -> Any:
+    if run_config is None:
+        return None
+
+    environments = getattr(run_config, "env", None)
+    if environments:
+        return environments
+
+    train_config = getattr(run_config, "train", None)
+    environments = getattr(train_config, "env", None) if train_config else None
+    if environments:
+        return environments
+
+    orchestrator_config = getattr(run_config, "orchestrator", None)
+    train_config = getattr(orchestrator_config, "train", None) if orchestrator_config else None
+    return getattr(train_config, "env", None) if train_config else None
+
+
 class PrimeMonitor(Monitor):
     """Logs to Prime Intellect API."""
 
@@ -198,7 +216,7 @@ class PrimeMonitor(Monitor):
             frontend_url = prime_config.frontend_url
 
         model = getattr(run_config, "model", None) if run_config else None
-        environments = getattr(run_config, "env", None) if run_config else None
+        environments = _get_run_environments(run_config)
         wandb = getattr(run_config, "wandb", None) if run_config else None
 
         payload: dict[str, Any] = {

--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -89,22 +89,48 @@ def _drop_non_finite_json_values(value: Any, dropped_paths: list[str], path: str
     return value
 
 
+def _get_nested_attr(obj: Any, *path: str) -> Any:
+    for attr in path:
+        if obj is None:
+            return None
+        obj = getattr(obj, attr, None)
+    return obj
+
+
+def _get_orchestrator_config(run_config: BaseConfig | None) -> Any:
+    return _get_nested_attr(run_config, "orchestrator") or run_config
+
+
 def _get_run_environments(run_config: BaseConfig | None) -> Any:
-    if run_config is None:
-        return None
+    for path in (("env",), ("train", "env"), ("orchestrator", "train", "env")):
+        environments = _get_nested_attr(run_config, *path)
+        if environments:
+            return environments
+    return None
 
-    environments = getattr(run_config, "env", None)
-    if environments:
-        return environments
 
-    train_config = getattr(run_config, "train", None)
-    environments = getattr(train_config, "env", None) if train_config else None
-    if environments:
-        return environments
+def _get_run_base_model(run_config: BaseConfig | None) -> str:
+    return (
+        _get_nested_attr(_get_orchestrator_config(run_config), "student", "model", "name")
+        or _get_nested_attr(run_config, "model", "name")
+        or "unknown"
+    )
 
-    orchestrator_config = getattr(run_config, "orchestrator", None)
-    train_config = getattr(orchestrator_config, "train", None) if orchestrator_config else None
-    return getattr(train_config, "env", None) if train_config else None
+
+def _get_run_display_config(run_config: BaseConfig | None) -> dict[str, Any]:
+    source = _get_orchestrator_config(run_config)
+    display_config: dict[str, Any] = {}
+
+    for payload_field, config_field in (
+        ("batch_size", "batch_size"),
+        ("rollouts_per_example", "group_size"),
+        ("seq_len", "seq_len"),
+    ):
+        value = _get_nested_attr(source, config_field)
+        if value is not None:
+            display_config[payload_field] = value
+
+    return display_config
 
 
 class PrimeMonitor(Monitor):
@@ -215,20 +241,17 @@ class PrimeMonitor(Monitor):
         if frontend_url is None:
             frontend_url = prime_config.frontend_url
 
-        model = getattr(run_config, "model", None) if run_config else None
+        display_config = _get_run_display_config(run_config)
         environments = _get_run_environments(run_config)
         wandb = getattr(run_config, "wandb", None) if run_config else None
 
         payload: dict[str, Any] = {
-            "base_model": model.name if model else "unknown",
-            "max_steps": getattr(run_config, "max_steps", None) or 0,
+            "base_model": _get_run_base_model(run_config),
+            "max_steps": _get_nested_attr(_get_orchestrator_config(run_config), "max_steps") or 0,
+            **display_config,
         }
         if run_config:
             payload["run_config"] = run_config.model_dump(exclude_none=True, mode="json")
-            for field in ("batch_size", "rollouts_per_example", "seq_len"):
-                value = getattr(run_config, field, None)
-                if value is not None:
-                    payload[field] = value
         if config.run_name:
             payload["name"] = config.run_name
         if team_id:

--- a/tests/unit/utils/test_prime_monitor.py
+++ b/tests/unit/utils/test_prime_monitor.py
@@ -1,16 +1,12 @@
 import io
 import json
-from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pyarrow.parquet as pq
 
-from prime_rl.utils.monitor.prime import (
-    PrimeMonitor,
-    _get_run_base_model,
-    _get_run_display_config,
-    _get_run_environments,
-)
+from prime_rl.configs.orchestrator import OrchestratorConfig
+from prime_rl.configs.shared import PrimeMonitorConfig
+from prime_rl.utils.monitor.prime import PrimeMonitor
 
 
 def _new_monitor() -> PrimeMonitor:
@@ -100,25 +96,39 @@ def test_rollouts_to_parquet_bytes_skips_rollouts_without_trajectory():
     assert rows[0]["sample_id"] == 0
 
 
-def test_run_display_metadata_uses_orchestrator_config_shape():
-    env = SimpleNamespace(id="primeintellect/reverse-text")
-    run_config = SimpleNamespace(
-        orchestrator=SimpleNamespace(
-            student=SimpleNamespace(model=SimpleNamespace(name="PrimeIntellect/Qwen3-0.6B")),
-            train=SimpleNamespace(env=[env]),
-            batch_size=64,
-            group_size=16,
-            seq_len=4096,
-        )
+def test_register_run_sends_display_metadata_from_orchestrator_config():
+    run_config = OrchestratorConfig(
+        student={"model": {"name": "PrimeIntellect/Qwen3-0.6B"}},
+        renderer=None,
+        train={"env": [{"id": "primeintellect/reverse-text"}]},
+        batch_size=64,
+        group_size=16,
+        seq_len=4096,
+        max_steps=100,
     )
+    monitor = _new_monitor()
+    monitor.logger = Mock()
+    monitor.base_url = "https://api.test"
+    monitor._headers = {}
+    response = Mock(status_code=201)
+    response.json.return_value = {"run": {"id": "run-123"}}
 
-    assert _get_run_base_model(run_config) == "PrimeIntellect/Qwen3-0.6B"
-    assert _get_run_environments(run_config) == [env]
-    assert _get_run_display_config(run_config) == {
-        "batch_size": 64,
-        "rollouts_per_example": 16,
-        "seq_len": 4096,
-    }
+    with patch("prime_rl.utils.monitor.prime.httpx.post", return_value=response) as post:
+        run_id = monitor._register_run(
+            PrimeMonitorConfig(team_id="team-1", frontend_url="https://app.test"),
+            run_config,
+        )
+
+    assert run_id == "run-123"
+    payload = post.call_args.kwargs["json"]
+    assert payload["base_model"] == "PrimeIntellect/Qwen3-0.6B"
+    assert payload["max_steps"] == 100
+    assert payload["batch_size"] == 64
+    assert payload["rollouts_per_example"] == 16
+    assert payload["seq_len"] == 4096
+    assert payload["environments"] == [{"id": "primeintellect/reverse-text"}]
+    assert payload["team_id"] == "team-1"
+    assert payload["run_config"] == run_config.model_dump(exclude_none=True, mode="json")
 
 
 def test_sanitize_json_payload_drops_non_finite_values_and_logs_paths():

--- a/tests/unit/utils/test_prime_monitor.py
+++ b/tests/unit/utils/test_prime_monitor.py
@@ -1,11 +1,9 @@
 import io
 import json
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pyarrow.parquet as pq
 
-from prime_rl.configs.orchestrator import OrchestratorConfig
-from prime_rl.configs.shared import PrimeMonitorConfig
 from prime_rl.utils.monitor.prime import PrimeMonitor
 
 
@@ -94,41 +92,6 @@ def test_rollouts_to_parquet_bytes_skips_rollouts_without_trajectory():
     assert len(rows) == 1
     assert rows[0]["problem_id"] == 1
     assert rows[0]["sample_id"] == 0
-
-
-def test_register_run_sends_display_metadata_from_orchestrator_config():
-    run_config = OrchestratorConfig(
-        student={"model": {"name": "PrimeIntellect/Qwen3-0.6B"}},
-        renderer=None,
-        train={"env": [{"id": "primeintellect/reverse-text"}]},
-        batch_size=64,
-        group_size=16,
-        seq_len=4096,
-        max_steps=100,
-    )
-    monitor = _new_monitor()
-    monitor.logger = Mock()
-    monitor.base_url = "https://api.test"
-    monitor._headers = {}
-    response = Mock(status_code=201)
-    response.json.return_value = {"run": {"id": "run-123"}}
-
-    with patch("prime_rl.utils.monitor.prime.httpx.post", return_value=response) as post:
-        run_id = monitor._register_run(
-            PrimeMonitorConfig(team_id="team-1", frontend_url="https://app.test"),
-            run_config,
-        )
-
-    assert run_id == "run-123"
-    payload = post.call_args.kwargs["json"]
-    assert payload["base_model"] == "PrimeIntellect/Qwen3-0.6B"
-    assert payload["max_steps"] == 100
-    assert payload["batch_size"] == 64
-    assert payload["rollouts_per_example"] == 16
-    assert payload["seq_len"] == 4096
-    assert payload["environments"] == [{"id": "primeintellect/reverse-text"}]
-    assert payload["team_id"] == "team-1"
-    assert payload["run_config"] == run_config.model_dump(exclude_none=True, mode="json")
 
 
 def test_sanitize_json_payload_drops_non_finite_values_and_logs_paths():

--- a/tests/unit/utils/test_prime_monitor.py
+++ b/tests/unit/utils/test_prime_monitor.py
@@ -1,5 +1,6 @@
 import io
 import json
+import types
 from unittest.mock import Mock
 
 import pyarrow.parquet as pq
@@ -92,6 +93,68 @@ def test_rollouts_to_parquet_bytes_skips_rollouts_without_trajectory():
     assert len(rows) == 1
     assert rows[0]["problem_id"] == 1
     assert rows[0]["sample_id"] == 0
+
+
+def test_register_run_sends_display_config_and_run_config(monkeypatch):
+    run_config_dump = {
+        "max_steps": 30,
+        "batch_size": 64,
+        "rollouts_per_example": 16,
+        "seq_len": 4096,
+    }
+    run_config = types.SimpleNamespace(
+        model=types.SimpleNamespace(name="PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"),
+        env=[types.SimpleNamespace(id="primeintellect/reverse-text")],
+        wandb=types.SimpleNamespace(project="prime-rl-e2e"),
+        max_steps=30,
+        batch_size=64,
+        rollouts_per_example=16,
+        seq_len=4096,
+        model_dump=Mock(return_value=run_config_dump),
+    )
+    monitor = _new_monitor()
+    monitor.base_url = "https://api.primeintellect.ai/api/v1/rft"
+    monitor._headers = {
+        "Authorization": "Bearer pit-test",
+        "x-api-key": "pit-test",
+        "Content-Type": "application/json",
+    }
+    monitor.logger = Mock()
+    config = types.SimpleNamespace(
+        team_id="team-1",
+        frontend_url=None,
+        run_name="e2e-run",
+    )
+    response = Mock(status_code=201)
+    response.json.return_value = {"run": {"id": "run-123"}}
+    post = Mock(return_value=response)
+    monkeypatch.setattr("prime_rl.utils.monitor.prime.httpx.post", post)
+
+    run_id = monitor._register_run(config, run_config)
+
+    assert run_id == "run-123"
+    run_config.model_dump.assert_called_once_with(exclude_none=True, mode="json")
+    post.assert_called_once_with(
+        "https://api.primeintellect.ai/api/v1/rft/external-runs",
+        headers={
+            "Authorization": "Bearer pit-test",
+            "x-api-key": "pit-test",
+            "Content-Type": "application/json",
+        },
+        json={
+            "base_model": "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT",
+            "max_steps": 30,
+            "run_config": run_config_dump,
+            "batch_size": 64,
+            "rollouts_per_example": 16,
+            "seq_len": 4096,
+            "name": "e2e-run",
+            "team_id": "team-1",
+            "environments": [{"id": "primeintellect/reverse-text"}],
+            "wandb_project": "prime-rl-e2e",
+        },
+        timeout=30,
+    )
 
 
 def test_sanitize_json_payload_drops_non_finite_values_and_logs_paths():

--- a/tests/unit/utils/test_prime_monitor.py
+++ b/tests/unit/utils/test_prime_monitor.py
@@ -1,6 +1,5 @@
 import io
 import json
-import types
 from unittest.mock import Mock
 
 import pyarrow.parquet as pq
@@ -93,68 +92,6 @@ def test_rollouts_to_parquet_bytes_skips_rollouts_without_trajectory():
     assert len(rows) == 1
     assert rows[0]["problem_id"] == 1
     assert rows[0]["sample_id"] == 0
-
-
-def test_register_run_sends_display_config_and_run_config(monkeypatch):
-    run_config_dump = {
-        "max_steps": 30,
-        "batch_size": 64,
-        "rollouts_per_example": 16,
-        "seq_len": 4096,
-    }
-    run_config = types.SimpleNamespace(
-        model=types.SimpleNamespace(name="PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"),
-        env=[types.SimpleNamespace(id="primeintellect/reverse-text")],
-        wandb=types.SimpleNamespace(project="prime-rl-e2e"),
-        max_steps=30,
-        batch_size=64,
-        rollouts_per_example=16,
-        seq_len=4096,
-        model_dump=Mock(return_value=run_config_dump),
-    )
-    monitor = _new_monitor()
-    monitor.base_url = "https://api.primeintellect.ai/api/v1/rft"
-    monitor._headers = {
-        "Authorization": "Bearer pit-test",
-        "x-api-key": "pit-test",
-        "Content-Type": "application/json",
-    }
-    monitor.logger = Mock()
-    config = types.SimpleNamespace(
-        team_id="team-1",
-        frontend_url=None,
-        run_name="e2e-run",
-    )
-    response = Mock(status_code=201)
-    response.json.return_value = {"run": {"id": "run-123"}}
-    post = Mock(return_value=response)
-    monkeypatch.setattr("prime_rl.utils.monitor.prime.httpx.post", post)
-
-    run_id = monitor._register_run(config, run_config)
-
-    assert run_id == "run-123"
-    run_config.model_dump.assert_called_once_with(exclude_none=True, mode="json")
-    post.assert_called_once_with(
-        "https://api.primeintellect.ai/api/v1/rft/external-runs",
-        headers={
-            "Authorization": "Bearer pit-test",
-            "x-api-key": "pit-test",
-            "Content-Type": "application/json",
-        },
-        json={
-            "base_model": "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT",
-            "max_steps": 30,
-            "run_config": run_config_dump,
-            "batch_size": 64,
-            "rollouts_per_example": 16,
-            "seq_len": 4096,
-            "name": "e2e-run",
-            "team_id": "team-1",
-            "environments": [{"id": "primeintellect/reverse-text"}],
-            "wandb_project": "prime-rl-e2e",
-        },
-        timeout=30,
-    )
 
 
 def test_sanitize_json_payload_drops_non_finite_values_and_logs_paths():

--- a/tests/unit/utils/test_prime_monitor.py
+++ b/tests/unit/utils/test_prime_monitor.py
@@ -1,10 +1,16 @@
 import io
 import json
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pyarrow.parquet as pq
 
-from prime_rl.utils.monitor.prime import PrimeMonitor
+from prime_rl.utils.monitor.prime import (
+    PrimeMonitor,
+    _get_run_base_model,
+    _get_run_display_config,
+    _get_run_environments,
+)
 
 
 def _new_monitor() -> PrimeMonitor:
@@ -92,6 +98,27 @@ def test_rollouts_to_parquet_bytes_skips_rollouts_without_trajectory():
     assert len(rows) == 1
     assert rows[0]["problem_id"] == 1
     assert rows[0]["sample_id"] == 0
+
+
+def test_run_display_metadata_uses_orchestrator_config_shape():
+    env = SimpleNamespace(id="primeintellect/reverse-text")
+    run_config = SimpleNamespace(
+        orchestrator=SimpleNamespace(
+            student=SimpleNamespace(model=SimpleNamespace(name="PrimeIntellect/Qwen3-0.6B")),
+            train=SimpleNamespace(env=[env]),
+            batch_size=64,
+            group_size=16,
+            seq_len=4096,
+        )
+    )
+
+    assert _get_run_base_model(run_config) == "PrimeIntellect/Qwen3-0.6B"
+    assert _get_run_environments(run_config) == [env]
+    assert _get_run_display_config(run_config) == {
+        "batch_size": 64,
+        "rollouts_per_example": 16,
+        "seq_len": 4096,
+    }
 
 
 def test_sanitize_json_payload_drops_non_finite_values_and_logs_paths():


### PR DESCRIPTION
Updates PrimeMonitor registration so platform external runs receive the resolved run config and display fields needed for correct dashboard values.

`PrimeMonitor` is constructed by the orchestrator, so registration now treats `run_config` as an `OrchestratorConfig` and reads the fields directly — `student.model.name` for `base_model`, `train.env` for environments, `group_size` for the platform `rollouts_per_example` field, plus `batch_size`, `seq_len`, `max_steps`, and the full serialized `run_config` — instead of duck-typed `getattr` probing over config shapes that do not reach this code path.

Removed the reviewer-requested PrimeMonitor registration unit test case; the remaining Prime monitor unit tests cover rollout parquet serialization and JSON payload sanitization.

Verified:
- `uvx ruff check tests/unit/utils/test_prime_monitor.py src/prime_rl/utils/monitor/prime.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b3b9d7f7c0b00f805f58d8dc33218a3c0df6d213. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
