### PR TITLE
fix(trainer): disable NemotronH HF-Hub mamba kernels for offline init

### DIFF
--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -518,6 +518,15 @@ def get_model(
 
     logger.debug(f"Loaded model config ({model_config.to_dict()})")
 
+    # NemotronH: transformers' Mamba2 mixer __init__ calls lazy_load_kernel("mamba-ssm" /
+    # "causal-conv1d") whenever config.use_mamba_kernels is set. That hub-kernel path is gated only
+    # by whether the `kernels` package is importable (NOT by USE_HUB_KERNELS) and resolves from the
+    # HF Hub, which hard-crashes under HF_HUB_OFFLINE=1. prime-rl swaps in its own mamba_ssm Triton
+    # SSD kernels via _patch_mamba2_use_triton_ssd, so the hub kernels are redundant; disable them
+    # to keep model init offline-safe.
+    if getattr(model_config, "model_type", "") == "nemotron_h":
+        model_config.use_mamba_kernels = False
+
     if config.debug.num_layers is not None:
         # VLM configs nest num_hidden_layers under text_config
         target_config = getattr(model_config, "text_config", model_config)


### PR DESCRIPTION
## Summary

Under `HF_HUB_OFFLINE=1` (the multi-node trainer default), loading a NemotronH model crashes at init. transformers' `NemotronHMamba2Mixer.__init__` calls `lazy_load_kernel("mamba-ssm" / "causal-conv1d")` whenever `config.use_mamba_kernels` is set, which resolves the kernel from the HF Hub (`kernels-community`) and raises `OfflineModeIsEnabled`.

This is **not** gated by `USE_HUB_KERNELS` — that env var only governs the separate `@use_kernel_forward_from_hub` decorator path, which is why `model.py`'s `USE_HUB_KERNELS=NO` default does not prevent this crash.

## Fix

In `get_model`, set `model_config.use_mamba_kernels = False` for `model_type == "nemotron_h"`. prime-rl already swaps in its own `mamba_ssm` Triton SSD kernels via `_patch_mamba2_use_triton_ssd` (with `nn.Conv1d` for the convolution), so the Hub kernels are redundant. This only affects the init-time Hub fetch and `is_fast_path_available` (which the patched forward bypasses) — the Mamba math is unchanged.

## Validation

On a 2-node SLURM RL run (Nemotron-3-Nano-30B, reverse-text) the trainer previously died in `__init__` with `OfflineModeIsEnabled`; with this change it loads the model and proceeds through optimizer setup and training steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single guarded config flag for nemotron_h before model load; no auth, data, or routing changes, and Mamba compute stays on existing prime-rl patches.
> 
> **Overview**
> Fixes **NemotronH** model load failures when **`HF_HUB_OFFLINE=1`** (common on multi-node trainers). In **`get_model`**, configs with **`model_type == "nemotron_h"`** now set **`use_mamba_kernels = False`** before **`from_pretrained`**, so Transformers’ Mamba2 mixer does not call **`lazy_load_kernel`** for Hub **`mamba-ssm` / `causal-conv1d`** packages (that path ignores **`USE_HUB_KERNELS`** and raises **`OfflineModeIsEnabled`**).
> 
> Training math is unchanged: prime-rl already routes Mamba through **`_patch_mamba2_use_triton_ssd`** and local **`mamba_ssm`** kernels, so disabling Hub kernels only affects init-time Hub fetches and fast-path availability flags the patched forward does not rely on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 740f9d33672b858748d81f2d42af9011f692ea55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->