### PR TITLE
fix(inference): restore NemotronH mixer.D after vLLM 0.22 layerwise reload

### DIFF
--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -18,7 +18,6 @@ def transformers_v5_compat():
     _patch_qwen35_lora()
     _patch_lora_key_prefix()
     monkey_patch_deep_gemm_silu_mul_quant_int64()
-    monkey_patch_vllm_layerwise_reload_alias_buffers()
     monkey_patch_vllm_padded_input_scrub()
     monkey_patch_return_routed_experts_with_nixl_connector()
 
@@ -65,38 +64,6 @@ def monkey_patch_return_routed_experts_with_nixl_connector():
     _post_init._prime_rl_allows_nixl_routed_experts = True
     VllmConfig.__post_init__ = _post_init
     logger.warning("Enabled vLLM routed-experts capture with NIXL connector patch.")
-
-
-def monkey_patch_vllm_layerwise_reload_alias_buffers():
-    # vLLM's layerwise reload materializes each buffer as an independent tensor
-    # and then copies it back into the original kernel storage. When a buffer
-    # aliases a parameter (e.g. NemotronH Mamba's mixer.conv_weights, a view of
-    # mixer.conv1d.weight), the buffer copy stamps garbage into the parameter's
-    # storage *after* the parameter has been correctly reloaded. Skip the copy
-    # for any buffer that shares storage with a parameter; _place_kernel_tensors
-    # re-registers the original view, which trivially reflects the parameter.
-    # Remove this patch once https://github.com/vllm-project/vllm/pull/42481 is
-    # included in the vLLM release we pin/use.
-    from vllm.logger import init_logger
-    from vllm.model_executor.model_loader.reload import layerwise as reload_layerwise
-
-    logger = init_logger(__name__)
-
-    def _copy_and_restore_kernel_tensors(layer: torch.nn.Module, info: reload_layerwise.LayerReloadingInfo):
-        assert info.kernel_tensors is not None
-        parameters, buffers = info.kernel_tensors
-        param_storage_ptrs = {p.untyped_storage().data_ptr() for p in layer.parameters(recurse=True)}
-        for name, param in parameters.items():
-            param.data.copy_(getattr(layer, name))
-        for name, buffer in buffers.items():
-            if buffer.untyped_storage().data_ptr() in param_storage_ptrs:
-                continue
-            buffer.data.copy_(getattr(layer, name))
-
-        reload_layerwise._place_kernel_tensors(layer, info)
-
-    reload_layerwise._copy_and_restore_kernel_tensors = _copy_and_restore_kernel_tensors
-    logger.warning("Enabled vLLM layerwise reload alias-buffer patch.")
 
 
 @triton.jit

--- a/src/prime_rl/inference/vllm/worker/nccl.py
+++ b/src/prime_rl/inference/vllm/worker/nccl.py
@@ -24,20 +24,17 @@ else:
 
 logger = init_logger("vllm.inference.vllm.worker_nccl")
 
-# NemotronH params that vLLM 0.22's layerwise reload mis-loads through the online-reload path.
-_RELOAD_CORRUPTED_SUFFIXES = (".mixer.D", ".e_score_correction_bias")
+# NemotronH mixer.D is dropped by vLLM 0.22's layerwise online-reload path (left uninitialized).
+_RELOAD_CORRUPTED_SUFFIXES = (".mixer.D",)
 
 
 def _restore_reload_corrupted_params(model: Module, received: dict[str, torch.Tensor]) -> None:
     """Work around a vLLM 0.22 layerwise-reload bug for NemotronH.
 
-    The online reload mis-loads exactly two per-layer parameter families -- ``mixer.D`` (Mamba SSD
-    skip) and the MoE router's ``gate.e_score_correction_bias`` -- while loading all other weights
-    correctly. ``mixer.D`` ends up as non-deterministic garbage/inf (NaN logits) and the gate bias
-    gets a wrong value (broken expert routing), so generations go to NaN after a weight update.
-
-    The received broadcast value is correct, so restore those params from it via each param's own
-    ``weight_loader`` (which applies the right sharding). Remove once the upstream reload bug is fixed.
+    The online reload drops the weight load for every Mamba layer's ``mixer.D`` (the SSD skip
+    connection), leaving it as uninitialized ``empty_strided`` memory -- it reads back as garbage
+    (NaN/inf) and the logits go NaN after a weight update. The received broadcast value is correct,
+    so restore D from it via the param's own ``weight_loader``. Remove once the upstream bug is fixed.
     """
 
     def _layer_key(name: str) -> str:
@@ -182,8 +179,8 @@ class NCCLWeightUpdateWorker(Worker):
             update_mla_absorbed_weights(model)
             return
 
-        # vLLM 0.22's layerwise reload mis-loads NemotronH mixer.D and MoE gate.e_score_correction_bias
-        # (see _restore_reload_corrupted_params). Capture the correct received values to restore after.
+        # vLLM 0.22's layerwise reload drops NemotronH mixer.D's weight load (see
+        # _restore_reload_corrupted_params). Capture the correct received value to restore after.
         received_reload_fix: dict[str, torch.Tensor] = {}
 
         def _capture_reload_fix(weights):

--- a/src/prime_rl/inference/vllm/worker/nccl.py
+++ b/src/prime_rl/inference/vllm/worker/nccl.py
@@ -45,7 +45,6 @@ def _restore_reload_corrupted_params(model: Module, received: dict[str, torch.Te
         return name[index:] if index >= 0 else name
 
     received_by_key = {_layer_key(name): tensor for name, tensor in received.items()}
-    restored = 0
     for name, param in model.named_parameters():
         if not name.endswith(_RELOAD_CORRUPTED_SUFFIXES):
             continue
@@ -58,10 +57,6 @@ def _restore_reload_corrupted_params(model: Module, received: dict[str, torch.Te
             weight_loader(param, tensor)
         elif tensor.shape == param.shape:
             param.data.copy_(tensor.to(param.dtype))
-        else:
-            continue
-        restored += 1
-    logger.debug("Restored %d NemotronH params (mixer.D, e_score_correction_bias) after reload", restored)
 
 
 def receive_integer(communicator: PyNcclCommunicator) -> int:

--- a/src/prime_rl/inference/vllm/worker/nccl.py
+++ b/src/prime_rl/inference/vllm/worker/nccl.py
@@ -24,6 +24,45 @@ else:
 
 logger = init_logger("vllm.inference.vllm.worker_nccl")
 
+# NemotronH params that vLLM 0.22's layerwise reload mis-loads through the online-reload path.
+_RELOAD_CORRUPTED_SUFFIXES = (".mixer.D", ".e_score_correction_bias")
+
+
+def _restore_reload_corrupted_params(model: Module, received: dict[str, torch.Tensor]) -> None:
+    """Work around a vLLM 0.22 layerwise-reload bug for NemotronH.
+
+    The online reload mis-loads exactly two per-layer parameter families -- ``mixer.D`` (Mamba SSD
+    skip) and the MoE router's ``gate.e_score_correction_bias`` -- while loading all other weights
+    correctly. ``mixer.D`` ends up as non-deterministic garbage/inf (NaN logits) and the gate bias
+    gets a wrong value (broken expert routing), so generations go to NaN after a weight update.
+
+    The received broadcast value is correct, so restore those params from it via each param's own
+    ``weight_loader`` (which applies the right sharding). Remove once the upstream reload bug is fixed.
+    """
+
+    def _layer_key(name: str) -> str:
+        index = name.find("layers.")
+        return name[index:] if index >= 0 else name
+
+    received_by_key = {_layer_key(name): tensor for name, tensor in received.items()}
+    restored = 0
+    for name, param in model.named_parameters():
+        if not name.endswith(_RELOAD_CORRUPTED_SUFFIXES):
+            continue
+        tensor = received_by_key.get(_layer_key(name))
+        if tensor is None:
+            continue
+        tensor = tensor.to(device=param.device)
+        weight_loader = getattr(param, "weight_loader", None)
+        if weight_loader is not None:
+            weight_loader(param, tensor)
+        elif tensor.shape == param.shape:
+            param.data.copy_(tensor.to(param.dtype))
+        else:
+            continue
+        restored += 1
+    logger.debug("Restored %d NemotronH params (mixer.D, e_score_correction_bias) after reload", restored)
+
 
 def receive_integer(communicator: PyNcclCommunicator) -> int:
     """Receive an integer from the trainer master rank using NCCL communicator."""
@@ -148,9 +187,20 @@ class NCCLWeightUpdateWorker(Worker):
             update_mla_absorbed_weights(model)
             return
 
+        # vLLM 0.22's layerwise reload mis-loads NemotronH mixer.D and MoE gate.e_score_correction_bias
+        # (see _restore_reload_corrupted_params). Capture the correct received values to restore after.
+        received_reload_fix: dict[str, torch.Tensor] = {}
+
+        def _capture_reload_fix(weights):
+            for name, tensor in weights:
+                if name.endswith(_RELOAD_CORRUPTED_SUFFIXES):
+                    received_reload_fix[name] = tensor.detach().to("cpu", copy=True)
+                yield name, tensor
+
         load_weights_checkpoint_layerwise(
             model,
-            state_iter,
+            _capture_reload_fix(state_iter),
             self.model_runner.model_config,
             self.vllm_config,
         )
+        _restore_reload_corrupted_params(model, received_reload_fix)


### PR DESCRIPTION
## Summary

After a weight update, NemotronH inference produced NaN logits / garbage generations. Root cause: vLLM 0.22's layerwise online reload (`load_weights_checkpoint_layerwise`) **drops the weight load for every Mamba layer's `mixer.D`** (the SSD skip connection). The reload materializes each layer's tensors as uninitialized `empty_strided` memory and then replays buffered loads; `mixer.D`'s load is dropped, so it is never written and reads back as **non-deterministic garbage** — `NaN`, `inf`, or huge finite values (~`1e17`) — which makes the logits NaN.

Confirmed by direct measurement that this is **not** a dtype/stride issue: post-reload `D` is `bf16 [8]` contiguous, byte-identical in dtype/shape/stride to its neighbours `dt_bias`/`A`, which load fine.

The symptom is delayed/non-deterministic because of async lag: the orchestrator runs a couple of steps on the *initial* weights, so the garbage only appears at the first step that uses *reloaded* weights (Mismatch KL jumps from ~1e-3 to 2–5).

This supersedes #2701: the existing `monkey_patch_vllm_layerwise_reload_alias_buffers` (which #2701 tweaks) targets `conv_weights`, but that alias is a **red herring** — vLLM's reload finalize re-derives it correctly. The monkey-patch's copy-back loop instead `getattr`s `conv_weights` after it's been `delattr`'d, producing `AttributeError: 'MambaMixer2' object has no attribute 'conv_weights'` (500). #2701 crashes identically and does not address the real `mixer.D` drop.

### Why only `mixer.D` (and not `e_score_correction_bias`)

An earlier per-tensor norm-delta also flagged the MoE router's `gate.e_score_correction_bias`. Direct post-reload measurement shows **that one is a false positive**: its post-reload value equals the received broadcast value exactly (norms match to 4 decimals across layers). It only *looked* changed because the trainer broadcasts it shifted by `-bias.min()` (`converting_nemotron_h.py`, HF→prime; the prime→HF path renames but never re-adds the min) so the ~57-magnitude bias fits bf16 without its ~0.04 inter-expert spread collapsing. That is a **routing-invariant constant shift** (top-k is invariant to a constant added to every expert; routing weights come from raw sigmoid), so reloading the shifted value is correct — and reversing the shift would *reintroduce* the bf16 collapse. So `e_score_correction_bias` is **not** corrupted, and the fix is scoped to `mixer.D` only.

## Changes

1. **Drop `monkey_patch_vllm_layerwise_reload_alias_buffers`** (call + definition). It crashes on vLLM 0.22, and `conv_weights` is handled by vLLM's native reload finalize (#42481).
2. **Restore `mixer.D` after reload** (`_restore_reload_corrupted_params` in the NCCL weight-update worker): capture the received broadcast value for `.mixer.D` while streaming into `load_weights_checkpoint_layerwise`, then restore it via the param's own `weight_loader` (correct sharding). The received value is by definition the intended one.

## Validation

2-node SLURM RL run (Nemotron-3-Nano-30B, reverse-text):
- **Before**: generations go to NaN/garbage at the first step using reloaded weights; Mismatch KL 0.001 → 2–5; reward collapses; (with the monkey-patch present, a hard 500 `AttributeError` on the first reload).
- **After (20 steps)**: completes clean — no NaN / no 500s, Mismatch KL steady ~1e-3 across all 20 weight updates, reward climbs 0.014 → 0.17 (the model actually learns reverse-text).
- **Direct post-reload measurement** (pre-restore): `mixer.D` comes back `NaN` / `inf` / `1e17` (non-deterministic, uninitialized), same dtype/strides as `dt_bias`/`A`; `e_score_correction_bias` equals the received value exactly.

## Notes

- **The underlying defect is in vLLM's layerwise reload — it conflates "elements copied" with "elements loaded."** The reload finalizes a layer when `load_numel >= load_numel_total`, where:
  - `load_numel` is tracked by `CopyCounter`, a `TorchDispatchMode` that adds `numel()` on **every** `aten.copy_.default` op;
  - `load_numel_total = get_layer_size(layer)` counts the layer's **param elements** (implicitly assuming one copy per element).

  These disagree for any loader that writes a param more than once. The Mamba mixer's `load_numel_total` is 24 (`A`+`D`+`dt_bias`, 8 elems each) and it streams params in the order `dt_bias, A_log, D, …`. `A`'s loader is `composed_weight_loader(sharded_weight_loader(0), -exp)`, whose `composed_loader` issues **two** `copy_` calls into the 8-element `A`: (1) `default_weight_loader` → `param.data.copy_(shard)`, then (2) `param.data.copy_(-exp(param))` to post-process. So `CopyCounter` attributes **16** to `A`, while `D`/`dt_bias` (plain sharded loader, one `copy_`) count 8 each.

  Result: after `dt_bias`(8) + `A`(16), `load_numel == 24 == load_numel_total` and `_layerwise_process` finalizes the mixer — materializing it via `empty_strided` and replaying only `dt_bias`+`A` — **before `D` (third in the stream) arrives**. `D`'s late load then hits the `online_process_loader` "Excessive loading" early-return and is dropped, leaving `D` uninitialized. Measured directly: `[LW-PROC] buffered=['dt_bias','A'] D_in=False numel=24/24` in 368/368 observations, and `.mixer.D` is broadcast exactly once per layer (23×) — so this is a vLLM bug, not a conversion/broadcast bug. (vLLM's own `online_process_loader` comment acknowledges a sibling case — qconfigs that "load the same weight multiple times" overshooting `load_numel_total` — but doesn't handle the `composed_weight_loader` transform case.) This worker-side restore is a workaround that can be removed once fixed upstream.
- The `e_score_correction_bias` `-bias.min()` shift in `converting_nemotron_h.py` is intentional and correct (bf16 representability, routing-invariant) — it should **not** be "reversed".
- Requires the separate NemotronH offline-init fix (`use_mamba_kernels=False`, merged in #2713) for the trainer to start under `HF_HUB_OFFLINE=1` and exercise this path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live inference weight-update behavior for NemotronH; wrong restore logic could corrupt Mamba skip weights, but the fix is narrow (`.mixer.D` only) and uses received broadcast values plus existing loaders.
> 
> **Overview**
> Fixes **NemotronH inference after NCCL weight updates** on vLLM 0.22 by removing a broken layerwise-reload monkey-patch and **re-applying `mixer.D`** from the broadcast stream after `load_weights_checkpoint_layerwise`.
> 
> **`patches.py`:** Stops registering **`monkey_patch_vllm_layerwise_reload_alias_buffers`** (call and implementation). That patch tried to skip buffer copies that alias parameters; on 0.22 it can **`AttributeError`** on reload finalize instead of fixing the real issue.
> 
> **`nccl.py`:** Wraps the incoming weight iterator to **snapshot `.mixer.D` tensors on CPU**, runs layerwise reload as before, then **`_restore_reload_corrupted_params`** writes them back via each param’s **`weight_loader`** (or `copy_` fallback), keyed by `layers.*` suffixes. This works around vLLM finalizing Mamba mixer layers before **`D`** is loaded, which left skip-connection weights uninitialized and produced **NaN logits** after the first reload step.
> 
> Scope is **NCCL online updates** only (not the quantize/kernel path or filesystem loader).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0d32e3719a5726aa102c32fac7eedca6f06dbd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


