### PR TITLE
chore: add tasksets/harnesses to exclude-newer ignore list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,6 +184,8 @@ prime-tunnel = false
 prime-evals = false
 verifiers = false
 renderers = false
+tasksets = false
+harnesses = false
 prime-pydantic-config = false
 # Trusted git/URL sources pinned by rev or wheel URL (defensive: belt-and-suspenders)
 vllm-router = false

--- a/uv.lock
+++ b/uv.lock
@@ -26,10 +26,12 @@ flash-attn-3 = false
 prime-tunnel = false
 deep-gemm = false
 prime-evals = false
+tasksets = false
 tokenspeed-mla = false
 deep-ep = false
 prime-sandboxes = false
 renderers = false
+harnesses = false
 prime = false
 
 [manifest]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dependency resolver configuration only; no application or security logic changes.
> 
> **Overview**
> Adds **`tasksets`** and **`harnesses`** to the uv **`exclude-newer-package`** allowlist in `pyproject.toml` (and the matching block in `uv.lock`), alongside other first-party packages like `verifiers` and `renderers`.
> 
> Setting them to `false` opts those packages out of the global **7-day** `exclude-newer` cap so newer PrimeIntellect releases can be resolved without waiting for the cooldown window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 030f86fb55cd043532f4907c9f3d6c0f088395fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->