### PR TITLE
[ENG-3910] fix(docker): bump to ubuntu-24.04 to fix arm64 builds with mooncake

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -1,7 +1,7 @@
 #inspired from https://github.com/astral-sh/uv-docker-example/blob/main/multistage.Dockerfile
 
 # Build stage - multi-arch base (supports amd64 + arm64)
-FROM nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04 AS builder
+FROM nvidia/cuda:12.8.1-cudnn-devel-ubuntu24.04 AS builder
 LABEL maintainer="prime intellect"
 LABEL repository="prime-rl"
 


### PR DESCRIPTION
arm64 builds have been failing with:
```
20.98 error: Distribution `mooncake-transfer-engine==0.3.11.post1 @ registry+[https://pypi.org/simple`](https://pypi.org/simple%60) can't be installed because it doesn't have a source distribution or wheel for the current platform
20.98 
20.98 hint: You're on Linux (`manylinux_2_35_aarch64`), but `mooncake-transfer-engine` (v0.3.11.post1) only has wheels for the following platforms: `manylinux_2_35_x86_64`, `manylinux_2_39_aarch64`; consider adding "sys_platform == 'linux' and platform_machine == 'aarch64'" to `tool.uv.required-environments` to ensure uv resolves to a version with compatible wheels
```

mooncake-transfer-engine 0.3.11.post1 only publishes a manylinux_2_39_aarch64 wheel for ARM (needs glibc ≥ 2.39) and 22.04 only ships with glibc 2.35.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single base-image tag change in the build stage; runtime stage is unchanged, with main impact on build compatibility and image rebuild behavior.
> 
> **Overview**
> Updates the CUDA Docker **builder** stage base image from `nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04` to **`ubuntu24.04`**, raising the glibc version in the build environment so **`mooncake-transfer-engine`** can install on **arm64** (its wheel targets `manylinux_2_39_aarch64`, which Ubuntu 22.04’s glibc 2.35 did not satisfy).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f90827cb91474dd04718fbfdf562b5b7e7fed8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->