### PR TITLE
[codex] Allow SFT without a teacher

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -517,7 +517,7 @@ class OrchestratorConfig(BaseConfig):
     """Typed renderer config (``renderers.RendererConfig`` discriminated
     union). Defaults to ``"auto"``, which resolves from
     ``tokenizer.name_or_path`` via ``MODEL_RENDERER_MAP``. ``None``
-    opts into MITO (``openai_chat_completions``); SFT mode forces this."""
+    opts into MITO (``openai_chat_completions``)."""
 
     pool_size: int | None = Field(None, ge=1)
     """Number of renderer slots shared across concurrent rollouts. Bump
@@ -754,11 +754,10 @@ class OrchestratorConfig(BaseConfig):
 
     @model_validator(mode="after")
     def _force_no_renderer_for_sft(self):
-        """SFT rolls out via the teacher's plain chat-completions endpoint; the
-        renderer client doesn't apply. Force ``renderer=None`` so the user
-        doesn't have to remember to set it. Declared before the renderer
-        validators below so they see the corrected value."""
-        if self.training_mode == "sft":
+        """Teacher-backed SFT rolls out via the teacher's plain chat-completions
+        endpoint; the renderer client doesn't apply. When no teacher is
+        configured, SFT uses the student rollout path and keeps the renderer."""
+        if self.training_mode == "sft" and self.teacher is not None:
             self.renderer = None
         return self
 
@@ -768,8 +767,8 @@ class OrchestratorConfig(BaseConfig):
         has_teacher = self.teacher is not None
         if self.training_mode == "rl" and has_teacher:
             raise ValueError("orchestrator.teacher must not be set when training_mode = 'rl'.")
-        if self.training_mode in ("opd", "sft") and not has_teacher:
-            raise ValueError(f"orchestrator.teacher must be configured when training_mode = '{self.training_mode}'.")
+        if self.training_mode == "opd" and not has_teacher:
+            raise ValueError("orchestrator.teacher must be configured when training_mode = 'opd'.")
         return self
 
     @model_validator(mode="after")

--- a/src/prime_rl/orchestrator/dispatcher.py
+++ b/src/prime_rl/orchestrator/dispatcher.py
@@ -131,6 +131,7 @@ class RolloutDispatcher:
         tasks_per_minute: float | None,
         max_off_policy_steps: int,
         training_mode: Literal["rl", "opd", "sft"],
+        use_cache_salt: bool = True,
     ) -> None:
         self.policy = policy
         self.train_envs = train_envs
@@ -142,6 +143,7 @@ class RolloutDispatcher:
         self.train_source = train_source
         self.eval_source = eval_source
         self.training_mode = training_mode
+        self.use_cache_salt = use_cache_salt
         self.max_off_policy_steps = max_off_policy_steps
 
         self.max_inflight = max_inflight_rollouts
@@ -408,13 +410,10 @@ class RolloutDispatcher:
         if env_collection is None:
             return False
         env = env_collection.get(group.env_name)
-        # SFT-mode train rollouts hit the frozen teacher pool; salting per
-        # policy version would invalidate the teacher's prefix cache every
-        # weight update for no reason.
-        if self.training_mode == "sft" and group.kind == "train":
-            cache_salt = None
-        else:
+        if group.kind == "eval" or self.use_cache_salt:
             cache_salt = str(group.policy_version_at_start)
+        else:
+            cache_salt = None
 
         if env.requires_group_scoring:
             permits = group.rollouts_to_schedule

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -345,13 +345,14 @@ class Orchestrator:
         else:
             get_logger().info("Training from scratch")
 
-        # SFT generates rollouts via the teacher (the student is trained on
-        # the teacher's outputs); RL / OPD generate via the student
-        if config.training_mode == "sft":
-            assert self.teacher_inference is not None, "sft mode requires teacher inference"
+        # SFT train rollouts come from the teacher when configured; otherwise
+        # they use the existing student rollout pool.
+        if config.training_mode == "sft" and self.teacher_inference is not None:
             rollout_inference = self.teacher_inference
+            use_cache_salt = False
         else:
             rollout_inference = self.student_inference
+            use_cache_salt = True
 
         self.train_source = TrainSource(self.train_envs, seed=42)
         self.eval_source: EvalSource | None = (
@@ -379,6 +380,7 @@ class Orchestrator:
             tasks_per_minute=config.tasks_per_minute,
             max_off_policy_steps=config.max_off_policy_steps,
             training_mode=config.training_mode,
+            use_cache_salt=use_cache_salt,
         )
         self.metrics = MetricsBuilder(config)
         self.train_sink = TrainSink(


### PR DESCRIPTION
## Summary

- allow `orchestrator.training_mode = "sft"` without a configured teacher
- route teacher-backed SFT train rollouts through the teacher pool, and teacherless SFT through the existing student rollout pool
- keep renderer forcing scoped to teacher-backed SFT; teacherless SFT keeps the normal student renderer path
- keep prefix-cache salting for student-backed train rollouts while preserving unsalted cache reuse for frozen teacher-backed SFT

## Motivation

This is needed for replay-backed SFT workflows where the train env can provide the supervision without a teacher model. PrimeRL should only need the generic capability: SFT can run without `orchestrator.teacher`; replay-specific taskset/env behavior stays outside this PR.

## Validation

- `uvx ruff==0.13.0 check --config=pyproject.toml packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py src/prime_rl/orchestrator/orchestrator.py src/prime_rl/orchestrator/dispatcher.py`
- `python3 -m py_compile packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py src/prime_rl/orchestrator/orchestrator.py src/prime_rl/orchestrator/dispatcher.py`
- `git diff --check`

## Notes

The earlier replay-specific package wiring, debug config, docs, tests, Verifiers submodule pointer, token-usage backfill, and zero-adv filter changes have been removed from the effective diff. The PR is now limited to the teacher-optional SFT routing/cache consequences.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SFT train inference routing and prefix-cache salting when no teacher is set; misconfiguration could affect rollout correctness or cache reuse, but scope is limited to orchestrator config and dispatch.
> 
> **Overview**
> **SFT can run without `orchestrator.teacher`.** Config validation no longer requires a teacher for `training_mode = "sft"` (only **OPD** still mandates one). Forcing `renderer = None` is limited to **teacher-backed SFT**; teacherless SFT keeps the normal student renderer path.
> 
> **Train rollout routing** is split: SFT with a teacher still uses the frozen teacher inference pool and **disables** prefix-cache salting on train rollouts; SFT without a teacher uses the **student** rollout pool with **policy-version cache salt**, same as RL/OPD train paths. The dispatcher takes an explicit `use_cache_salt` flag instead of inferring this from `training_mode == "sft"` alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdba94e88df16f0ea5de213a0e484e36f25539b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->