### PR TITLE
feat(orchestrator): per-env advantage strategy

### DIFF
--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -167,6 +167,22 @@ kwargs = { eps = 1e-8 }
 
 `AdvantageInputs.rollouts` is a list of `verifiers.RolloutOutput`, so you have access to the full rollout (turns, tool calls, custom metadata) — not just the reward. Use this for anything reward-shaping-like that needs trajectory context.
 
+### Per-Env Advantage
+
+`advantage` can be set per training environment. Each env inherits the top-level `[orchestrator.advantage]` when it doesn't set its own, so mixed-env runs can give each env its own advantage computation:
+
+```toml
+[orchestrator.advantage]
+type = "default"  # the default every env inherits unless it overrides
+
+[[orchestrator.train.env]]
+id = "math-env"   # inherits the default above
+
+[[orchestrator.train.env]]
+id = "agent-env"
+advantage = { type = "custom", import_path = "my_module.normalized_advantage" }
+```
+
 ## Filters
 
 Filters drop rollouts between scoring and training. Built-ins (composable):

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -143,6 +143,49 @@ class EvalSamplingConfig(BaseConfig):
         return data
 
 
+class TokensLengthPenaltyConfig(BaseConfig):
+    type: Literal["tokens"] = "tokens"
+
+    completion_weight: float = Field(1.0, ge=0, allow_inf_nan=False)
+    """Weight on model completion tokens. Finite and non-negative."""
+
+    tool_response_weight: float = Field(1.0, ge=0, allow_inf_nan=False)
+    """Weight on tool-response tokens (read from the rollout's ``*_total_tool_response_tokens`` harness metric; 0 if absent). Finite and non-negative."""
+
+
+class TurnsLengthPenaltyConfig(BaseConfig):
+    type: Literal["turns"] = "turns"
+
+
+LengthPenaltyConfig: TypeAlias = Annotated[
+    TokensLengthPenaltyConfig | TurnsLengthPenaltyConfig,
+    Field(discriminator="type"),
+]
+
+
+class DefaultAdvantageConfig(BaseConfig):
+    type: Literal["default"] = "default"
+
+    length_penalty: LengthPenaltyConfig | None = None
+    """Correctness-gated length penalty. ``tokens`` shapes by weighted token cost; ``turns`` shapes by trajectory turn count; None disables shaping. In mixed groups, lower-cost correct rollouts get amplified advantage (up to 2x), higher-cost correct rollouts are unchanged, incorrect untouched. In all-correct groups, below-average-cost rollouts get advantage in [0, 1], others get 0."""
+
+
+class CustomAdvantageConfig(BaseConfig):
+    type: Literal["custom"] = "custom"
+
+    import_path: str
+    """Import path to the advantage function (e.g. ``my_module.my_advantage``)."""
+
+    kwargs: dict[str, Any] = Field(default_factory=dict)
+    """Kwargs forwarded to the advantage function."""
+
+
+AdvantageConfig: TypeAlias = Annotated[
+    DefaultAdvantageConfig | CustomAdvantageConfig,
+    Field(discriminator="type"),
+]
+
+
 class EnvConfig(BaseConfig):
     id: str = "reverse-text"
     """Registered verifiers environment ID (e.g. ``math-env``, ``primeintellect/math-env``). May include an ``@version`` suffix for installation."""
@@ -213,6 +256,11 @@ class TrainEnvConfig(EnvConfig):
     group_size: int = Field(1, ge=1, validation_alias=AliasChoices("group_size", "rollouts_per_example"))
     """Rollouts generated per example for GRPO group-relative advantages.
     Inherits from ``orchestrator.group_size`` when unset."""
+
+    advantage: AdvantageConfig | None = None
+    """Advantage strategy for this env's GRPO groups. Inherits from the top-level
+    ``orchestrator.advantage`` when unset; set a different ``default``/``custom``
+    config to give this env its own advantage computation."""
 
 
 class EvalEnvConfig(EnvConfig):
@@ -372,49 +420,6 @@ class CheckpointConfig(BaseConfig):
 
     skip_progress: bool = False
     """Skip loading the progress from checkpoint."""
-
-
-class TokensLengthPenaltyConfig(BaseConfig):
-    type: Literal["tokens"] = "tokens"
-
-    completion_weight: float = Field(1.0, ge=0, allow_inf_nan=False)
-    """Weight on model completion tokens. Finite and non-negative."""
-
-    tool_response_weight: float = Field(1.0, ge=0, allow_inf_nan=False)
-    """Weight on tool-response tokens (read from the rollout's ``*_total_tool_response_tokens`` harness metric; 0 if absent). Finite and non-negative."""
-
-
-class TurnsLengthPenaltyConfig(BaseConfig):
-    type: Literal["turns"] = "turns"
-
-
-LengthPenaltyConfig: TypeAlias = Annotated[
-    TokensLengthPenaltyConfig | TurnsLengthPenaltyConfig,
-    Field(discriminator="type"),
-]
-
-
-class DefaultAdvantageConfig(BaseConfig):
-    type: Literal["default"] = "default"
-
-    length_penalty: LengthPenaltyConfig | None = None
-    """Correctness-gated length penalty. ``tokens`` shapes by weighted token cost; ``turns`` shapes by trajectory turn count; None disables shaping. In mixed groups, lower-cost correct rollouts get amplified advantage (up to 2x), higher-cost correct rollouts are unchanged, incorrect untouched. In all-correct groups, below-average-cost rollouts get advantage in [0, 1], others get 0."""
-
-
-class CustomAdvantageConfig(BaseConfig):
-    type: Literal["custom"] = "custom"
-
-    import_path: str
-    """Import path to the advantage function (e.g. ``my_module.my_advantage``)."""
-
-    kwargs: dict[str, Any] = Field(default_factory=dict)
-    """Kwargs forwarded to the advantage function."""
-
-
-AdvantageConfig: TypeAlias = Annotated[
-    DefaultAdvantageConfig | CustomAdvantageConfig,
-    Field(discriminator="type"),
-]
 
 
 # Flags rare tokens generated at high entropy (Section 5.2, https://arxiv.org/abs/2510.02387).
@@ -875,6 +880,11 @@ class OrchestratorConfig(BaseConfig):
         for env_cfg in self.train.env:
             if "group_size" not in env_cfg.model_fields_set:
                 env_cfg.group_size = self.group_size
+
+        # Propagate the top-level ``advantage`` into each train env that didn't set its own.
+        for env_cfg in self.train.env:
+            if "advantage" not in env_cfg.model_fields_set:
+                env_cfg.advantage = self.advantage
 
         # Resolve train env num_workers from max_inflight_rollouts
         for env_cfg in self.train.env:

--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -15,6 +15,7 @@ from verifiers.serve import ZMQEnvClient, ZMQEnvServer
 from verifiers.utils.serve_utils import get_free_port
 
 from prime_rl.configs.orchestrator import EnvConfig, EvalEnvConfig, TrainEnvConfig
+from prime_rl.orchestrator.advantage import AdvantageFn, setup_advantage_fn
 from prime_rl.orchestrator.eval_utils import compute_pass_at_k
 from prime_rl.utils.logger import ProgressTracker, get_logger
 from prime_rl.utils.monitor import get_monitor
@@ -170,6 +171,11 @@ class TrainEnv(Env):
     def __init__(self, config: TrainEnvConfig):
         super().__init__(config)
         self.sampling_args = config.sampling.to_sampling_args()
+        # Built once — custom advantage funcs do an ``import_object`` we don't
+        # want to pay per group. ``None`` = reward-only path.
+        self.advantage_fn: AdvantageFn | None = (
+            setup_advantage_fn(config.advantage) if config.advantage is not None else None
+        )
 
     def get_dataset(self, seed: int | None = None):
         return self.env.get_dataset(seed=seed)

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -389,7 +389,6 @@ class Orchestrator:
             mm_token_type_ids_mapping=self.mm_token_type_ids_mapping,
             batch_size=config.batch_size,
             token_batch_size=config.token_batch_size,
-            advantage_config=config.advantage,
             pre_filters=pre_filters,
             post_filters=post_filters,
         )

--- a/src/prime_rl/orchestrator/train_sink.py
+++ b/src/prime_rl/orchestrator/train_sink.py
@@ -17,8 +17,8 @@ import asyncio
 import uuid
 from collections import defaultdict
 
-from prime_rl.configs.orchestrator import AdvantageConfig, OrchestratorConfig
-from prime_rl.orchestrator.advantage import assign_advantages, setup_advantage_fn
+from prime_rl.configs.orchestrator import OrchestratorConfig
+from prime_rl.orchestrator.advantage import AdvantageFn, assign_advantages, setup_advantage_fn
 from prime_rl.orchestrator.envs import TrainEnvs
 from prime_rl.orchestrator.filters import RolloutFilter, apply_filters
 from prime_rl.orchestrator.trajectories import (
@@ -44,7 +44,6 @@ class TrainSink:
         mm_token_type_ids_mapping: dict[int, int] | None,
         batch_size: int | None,
         token_batch_size: int | None,
-        advantage_config: AdvantageConfig | None,
         pre_filters: list[RolloutFilter],
         post_filters: list[RolloutFilter],
     ) -> None:
@@ -58,9 +57,13 @@ class TrainSink:
         self.mm_token_type_ids_mapping = mm_token_type_ids_mapping
         self.batch_size = batch_size
         self.token_batch_size = token_batch_size
-        # Built once — custom advantage funcs do an ``import_object`` and
-        # we don't want to pay that per group. ``None`` = reward-only path
-        self.advantage_fn = setup_advantage_fn(advantage_config) if advantage_config is not None else None
+        # Built once per env — custom advantage funcs do an ``import_object`` and
+        # we don't want to pay that per group. Each env carries its own advantage
+        # config (inheriting the top-level default when unset). ``None`` = reward-only path.
+        self.advantage_fns: dict[str, AdvantageFn | None] = {
+            env.name: setup_advantage_fn(env.config.advantage) if env.config.advantage is not None else None
+            for env in train_envs
+        }
         self.pre_filters = pre_filters
         self.post_filters = post_filters
 
@@ -200,7 +203,7 @@ class TrainSink:
             )
             return
 
-        assign_advantages(survivors, self.advantage_fn)
+        assign_advantages(survivors, self.advantage_fns[env_name])
 
         # Propagate to the pre-tokenized samples so the orchestrator can
         # collect samples at ship time without re-walking rollouts. The env

--- a/src/prime_rl/orchestrator/train_sink.py
+++ b/src/prime_rl/orchestrator/train_sink.py
@@ -18,7 +18,7 @@ import uuid
 from collections import defaultdict
 
 from prime_rl.configs.orchestrator import OrchestratorConfig
-from prime_rl.orchestrator.advantage import AdvantageFn, assign_advantages, setup_advantage_fn
+from prime_rl.orchestrator.advantage import assign_advantages
 from prime_rl.orchestrator.envs import TrainEnvs
 from prime_rl.orchestrator.filters import RolloutFilter, apply_filters
 from prime_rl.orchestrator.trajectories import (
@@ -57,13 +57,6 @@ class TrainSink:
         self.mm_token_type_ids_mapping = mm_token_type_ids_mapping
         self.batch_size = batch_size
         self.token_batch_size = token_batch_size
-        # Built once per env — custom advantage funcs do an ``import_object`` and
-        # we don't want to pay that per group. Each env carries its own advantage
-        # config (inheriting the top-level default when unset). ``None`` = reward-only path.
-        self.advantage_fns: dict[str, AdvantageFn | None] = {
-            env.name: setup_advantage_fn(env.config.advantage) if env.config.advantage is not None else None
-            for env in train_envs
-        }
         self.pre_filters = pre_filters
         self.post_filters = post_filters
 
@@ -203,7 +196,7 @@ class TrainSink:
             )
             return
 
-        assign_advantages(survivors, self.advantage_fns[env_name])
+        assign_advantages(survivors, self.train_envs.get(env_name).advantage_fn)
 
         # Propagate to the pre-tokenized samples so the orchestrator can
         # collect samples at ship time without re-walking rollouts. The env


### PR DESCRIPTION
## What

Make advantage computation configurable **per training environment** instead of a single global setting.

## Why

Mixed-env runs currently share one advantage function. Different envs often want different advantage computation — plain GRPO for one, a custom or length-penalized advantage for another. This lets each env carry its own.

## Changes

- `TrainEnvConfig` gains an `advantage` field (`default` / `custom`), inheriting the top-level `[orchestrator.advantage]` when unset — the same inheritance pattern already used for `group_size`.
- Each `TrainEnv` builds its own advantage fn from `config.advantage` (mirroring how it derives `sampling_args`); `TrainSink.process_group` applies it via `self.train_envs.get(env_name).advantage_fn`. The global `advantage_config` param and its call-site arg are removed.
- Moved the advantage / length-penalty config classes above `EnvConfig` so `TrainEnvConfig` can reference `AdvantageConfig` (the module doesn't use `from __future__ import annotations`, so annotations evaluate eagerly).
- Doc note in `docs/algorithms.md`.

## Behavior

Behavior-preserving: with a default config, every env inherits the global default → identical advantages to before.

```toml
[orchestrator.advantage]
type = "default"            # inherited by every env unless overridden

[[orchestrator.train.env]]
id = "math-env"             # inherits the default

[[orchestrator.train.env]]
id = "agent-env"
advantage = { type = "custom", import_path = "my_module.normalized_advantage" }
```

## Testing

- `ruff check` + `ruff format --check` clean on edited files.
- `pytest tests/unit/orchestrator/test_advantage.py` → 17 passed; `tests/unit/test_configs.py` → 106 passed.
- Verified per-env inheritance, per-env override, and the `rollouts_per_example` alias via a config-construction check.
- Validated end-to-end on 2× RTX PRO 6000 (Blackwell): a **single-env** run (one env with a length-penalized advantage) and a **multi-env** run (two `reverse-text` envs with *separate* advantages — plain GRPO vs length-penalized) each completed 3 steps cleanly (exit 0, `Error 0.0%`, both envs trained, GPUs released).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how advantages are computed in multi-env runs when overrides are used; single-env default inheritance should match prior behavior but mixed-env training logic is now env-scoped.
> 
> **Overview**
> **Per-env advantage** replaces a single orchestrator-wide advantage function with optional `advantage` on each `[[orchestrator.train.env]]`, inheriting `[orchestrator.advantage]` when unset (same pattern as `group_size`).
> 
> Each `TrainEnv` now builds its `advantage_fn` once at init; `TrainSink.process_group` calls `assign_advantages` with `train_envs.get(env_name).advantage_fn` instead of a shared fn on the sink. Config validation copies the top-level `advantage` into envs that did not override it; advantage/length-penalty Pydantic types were moved above `EnvConfig` so `TrainEnvConfig` can reference them. `docs/algorithms.md` documents mixed-env TOML overrides.
> 
> Default configs behave as before when every env inherits the global advantage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c411dab2a4ba1c49bb2cae81dc3a1ca69ad0af63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

