### PR TITLE
Feat/fp8 fused transpose cast

### DIFF
--- a/src/prime_rl/trainer/models/kernels/fp8_utils.py
+++ b/src/prime_rl/trainer/models/kernels/fp8_utils.py
@@ -555,16 +555,7 @@ def per_block_cast_to_fp8_triton(
 def per_block_cast_to_fp8_tp_triton(
     x: torch.Tensor, use_ue8m0: bool, gran_k: int = GROUP_ALIGNMENT
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Block-fp8 cast of ``x.T`` without materializing the transpose.
-
-    Returns ``(fp8(x.T), block_scales)`` shaped ``[cols, rows]`` and
-    ``[cols/128, rows/128]``. Because 128x128 block quantization is
-    transpose-symmetric (a tile and its transpose share an amax, hence one
-    scale), this is bit-identical to ``per_block_cast_to_fp8_triton(
-    x.transpose(0, 1).contiguous())`` but skips the intermediate contiguous bf16
-    buffer: it reuses the per-block kernel, reading ``x`` once and writing the
-    transposed fp8 and scales via swapped output strides.
-    """
+    """Block-fp8 cast of ``x.T`` without materializing the transpose."""
     assert x.dim() == 2
     assert gran_k == GROUP_ALIGNMENT
     rows, cols = x.shape

--- a/src/prime_rl/trainer/models/kernels/fp8_utils.py
+++ b/src/prime_rl/trainer/models/kernels/fp8_utils.py
@@ -587,3 +587,34 @@ def per_block_cast_to_fp8_tp_triton(
         num_warps=8,
     )
     return out, sf
+
+
+def per_token_cast_to_fp8_tp_triton(
+    x: torch.Tensor, use_ue8m0: bool, gran_k: int = GROUP_ALIGNMENT
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Per-token fp8 cast of ``x.T`` without materializing the transpose."""
+    assert x.dim() == 2
+    assert gran_k == GROUP_ALIGNMENT
+    rows, cols = x.shape
+    out = torch.empty((cols, rows), device=x.device, dtype=torch.float8_e4m3fn)
+    sf = torch.empty((cols, ceil_div(rows, gran_k)), device=x.device, dtype=torch.float32)
+    grid = lambda meta: (ceil_div(cols, meta["BLOCK_M"]), ceil_div(rows, meta["BLOCK_K"]))
+    _per_token_fp8_kernel[grid](
+        x,
+        out,
+        sf,
+        cols,
+        rows,
+        # transposed read: the kernel's per-row amax reduces over x's rows
+        x.stride(1),
+        x.stride(0),
+        out.stride(0),
+        out.stride(1),
+        sf.stride(0),
+        sf.stride(1),
+        USE_UE8M0=use_ue8m0,
+        BLOCK_M=8,
+        BLOCK_K=gran_k,
+        num_warps=4,
+    )
+    return out, sf

--- a/src/prime_rl/trainer/models/kernels/fp8_utils.py
+++ b/src/prime_rl/trainer/models/kernels/fp8_utils.py
@@ -550,3 +550,49 @@ def per_block_cast_to_fp8_triton(
         gran_k,
     )
     return out[0], sf[0]
+
+
+def per_block_cast_to_fp8_tp_triton(
+    x: torch.Tensor, use_ue8m0: bool, gran_k: int = GROUP_ALIGNMENT
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Block-fp8 cast of ``x.T`` without materializing the transpose.
+
+    Returns ``(fp8(x.T), block_scales)`` shaped ``[cols, rows]`` and
+    ``[cols/128, rows/128]``. Because 128x128 block quantization is
+    transpose-symmetric (a tile and its transpose share an amax, hence one
+    scale), this is bit-identical to ``per_block_cast_to_fp8_triton(
+    x.transpose(0, 1).contiguous())`` but skips the intermediate contiguous bf16
+    buffer: it reuses the per-block kernel, reading ``x`` once and writing the
+    transposed fp8 and scales via swapped output strides.
+    """
+    assert x.dim() == 2
+    assert gran_k == GROUP_ALIGNMENT
+    rows, cols = x.shape
+    x3 = x.unsqueeze(0)
+    out = torch.empty((cols, rows), device=x.device, dtype=torch.float8_e4m3fn)
+    sf = torch.empty((ceil_div(cols, gran_k), ceil_div(rows, gran_k)), device=x.device, dtype=torch.float32)
+    grid = (1, ceil_div(rows, gran_k), ceil_div(cols, gran_k))
+    _grouped_per_block_fp8_kernel[grid](
+        x3,
+        out,
+        sf,
+        1,
+        rows,
+        cols,
+        x3.stride(0),
+        x3.stride(1),
+        x3.stride(2),
+        # transposed output: x's element (row, col) lands at out[col, row]
+        cols * rows,
+        1,
+        rows,
+        # transposed scales: x's tile (pid_m, pid_n) lands at sf[pid_n, pid_m]
+        ceil_div(cols, gran_k) * ceil_div(rows, gran_k),
+        1,
+        ceil_div(rows, gran_k),
+        USE_UE8M0=use_ue8m0,
+        BLOCK_M=gran_k,
+        BLOCK_N=gran_k,
+        num_warps=8,
+    )
+    return out, sf

--- a/src/prime_rl/trainer/models/layers/fp8_linear.py
+++ b/src/prime_rl/trainer/models/layers/fp8_linear.py
@@ -14,6 +14,7 @@ from torch import nn
 from prime_rl.trainer.models.kernels.fp8_utils import (
     per_block_cast_to_fp8_tp_triton,
     per_block_cast_to_fp8_triton,
+    per_token_cast_to_fp8_tp_triton,
     per_token_cast_to_fp8_triton,
 )
 from prime_rl.utils.logger import get_logger
@@ -62,10 +63,8 @@ class _FP8BlockwiseMM(torch.autograd.Function):
             else:
                 grad_output_2d_padded = grad_output_2d
                 x_2d_padded = x_2d
-            grad_output_t = grad_output_2d_padded.transpose(0, 1).contiguous()
-            x_t = x_2d_padded.transpose(0, 1).contiguous()
-            grad_output_t_fp8 = per_token_cast_to_fp8_triton(grad_output_t, False, block_size)
-            x_t_fp8 = per_token_cast_to_fp8_triton(x_t, False, block_size)
+            grad_output_t_fp8 = per_token_cast_to_fp8_tp_triton(grad_output_2d_padded, False, block_size)
+            x_t_fp8 = per_token_cast_to_fp8_tp_triton(x_2d_padded, False, block_size)
             grad_weight_fp32 = torch.zeros_like(weight, dtype=torch.float32)
             deep_gemm.fp8_gemm_nt(
                 grad_output_t_fp8,

--- a/src/prime_rl/trainer/models/layers/fp8_linear.py
+++ b/src/prime_rl/trainer/models/layers/fp8_linear.py
@@ -44,8 +44,6 @@ class _FP8BlockwiseMM(torch.autograd.Function):
         grad_x = grad_weight = None
         if ctx.needs_input_grad[0]:
             grad_output_fp8 = per_token_cast_to_fp8_triton(grad_output_2d, False, block_size)
-            # Fused transpose+cast: block-fp8 of weight.T without materializing the
-            # contiguous transpose (128x128 block quant is transpose-symmetric).
             weight_dx_fp8 = per_block_cast_to_fp8_tp_triton(weight, False, block_size)
             grad_x_2d = torch.empty_like(x_2d)
             deep_gemm.fp8_gemm_nt(grad_output_fp8, weight_dx_fp8, grad_x_2d)

--- a/src/prime_rl/trainer/models/layers/fp8_linear.py
+++ b/src/prime_rl/trainer/models/layers/fp8_linear.py
@@ -12,6 +12,7 @@ import torch
 from torch import nn
 
 from prime_rl.trainer.models.kernels.fp8_utils import (
+    per_block_cast_to_fp8_tp_triton,
     per_block_cast_to_fp8_triton,
     per_token_cast_to_fp8_triton,
 )
@@ -43,8 +44,9 @@ class _FP8BlockwiseMM(torch.autograd.Function):
         grad_x = grad_weight = None
         if ctx.needs_input_grad[0]:
             grad_output_fp8 = per_token_cast_to_fp8_triton(grad_output_2d, False, block_size)
-            weight_t = weight.transpose(0, 1).contiguous()
-            weight_dx_fp8 = per_block_cast_to_fp8_triton(weight_t, False, block_size)
+            # Fused transpose+cast: block-fp8 of weight.T without materializing the
+            # contiguous transpose (128x128 block quant is transpose-symmetric).
+            weight_dx_fp8 = per_block_cast_to_fp8_tp_triton(weight, False, block_size)
             grad_x_2d = torch.empty_like(x_2d)
             deep_gemm.fp8_gemm_nt(grad_output_fp8, weight_dx_fp8, grad_x_2d)
             grad_x = grad_x_2d.reshape(ctx.x_shape)

--- a/tests/unit/train/models/test_fp8_utils.py
+++ b/tests/unit/train/models/test_fp8_utils.py
@@ -1,0 +1,27 @@
+import pytest
+import torch
+
+from prime_rl.trainer.models.kernels.fp8_utils import (
+    per_block_cast_to_fp8_tp_triton,
+    per_block_cast_to_fp8_triton,
+)
+
+pytestmark = [pytest.mark.gpu]
+
+
+@pytest.mark.parametrize("rows,cols", [(256, 256), (256, 512), (512, 256), (1024, 768), (384, 128)])
+def test_tp_cast_matches_materialized_transpose(rows, cols):
+    """The fused transpose+cast is bit-identical to casting the materialized
+    transpose (128x128 block quant is transpose-symmetric), so DeepGEMM receives
+    an identical B tensor."""
+    torch.manual_seed(rows + cols)
+    x = torch.randn(rows, cols, device="cuda", dtype=torch.bfloat16) * 0.3
+
+    ref_q, ref_s = per_block_cast_to_fp8_triton(x.transpose(0, 1).contiguous(), False)
+    tp_q, tp_s = per_block_cast_to_fp8_tp_triton(x, False)
+
+    assert tp_q.shape == ref_q.shape == (cols, rows)
+    assert tp_s.shape == ref_s.shape
+    assert tp_q.is_contiguous()
+    assert torch.equal(tp_q.view(torch.uint8), ref_q.view(torch.uint8))
+    assert torch.equal(tp_s, ref_s)

--- a/tests/unit/train/models/test_fp8_utils.py
+++ b/tests/unit/train/models/test_fp8_utils.py
@@ -8,7 +8,13 @@ from prime_rl.trainer.models.kernels.fp8_utils import (
     per_token_cast_to_fp8_triton,
 )
 
-pytestmark = [pytest.mark.gpu]
+pytestmark = [
+    pytest.mark.gpu,
+    pytest.mark.skipif(
+        not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] < 9,
+        reason="block-fp8 cast kernels use Triton fp8e4nv (e4m3), only supported on Hopper (SM90) and newer",
+    ),
+]
 
 
 @pytest.mark.parametrize("rows,cols", [(256, 256), (256, 512), (512, 256), (1024, 768), (384, 128)])

--- a/tests/unit/train/models/test_fp8_utils.py
+++ b/tests/unit/train/models/test_fp8_utils.py
@@ -4,21 +4,37 @@ import torch
 from prime_rl.trainer.models.kernels.fp8_utils import (
     per_block_cast_to_fp8_tp_triton,
     per_block_cast_to_fp8_triton,
+    per_token_cast_to_fp8_tp_triton,
+    per_token_cast_to_fp8_triton,
 )
 
 pytestmark = [pytest.mark.gpu]
 
 
 @pytest.mark.parametrize("rows,cols", [(256, 256), (256, 512), (512, 256), (1024, 768), (384, 128)])
-def test_tp_cast_matches_materialized_transpose(rows, cols):
-    """The fused transpose+cast is bit-identical to casting the materialized
-    transpose (128x128 block quant is transpose-symmetric), so DeepGEMM receives
-    an identical B tensor."""
+def test_block_tp_cast_matches_materialized_transpose(rows, cols):
+    """The fused transpose+cast is *bit-identical* to unfused."""
     torch.manual_seed(rows + cols)
     x = torch.randn(rows, cols, device="cuda", dtype=torch.bfloat16) * 0.3
 
     ref_q, ref_s = per_block_cast_to_fp8_triton(x.transpose(0, 1).contiguous(), False)
     tp_q, tp_s = per_block_cast_to_fp8_tp_triton(x, False)
+
+    assert tp_q.shape == ref_q.shape == (cols, rows)
+    assert tp_s.shape == ref_s.shape
+    assert tp_q.is_contiguous()
+    assert torch.equal(tp_q.view(torch.uint8), ref_q.view(torch.uint8))
+    assert torch.equal(tp_s, ref_s)
+
+
+@pytest.mark.parametrize("rows,cols", [(256, 512), (512, 256), (128, 1024), (1024, 768), (384, 512)])
+def test_token_tp_cast_matches_materialized_transpose(rows, cols):
+    """The fused transpose+cast is *bit-identical* to unfused."""
+    torch.manual_seed(rows + cols)
+    x = torch.randn(rows, cols, device="cuda", dtype=torch.bfloat16) * 0.3
+
+    ref_q, ref_s = per_token_cast_to_fp8_triton(x.transpose(0, 1).contiguous(), False)
+    tp_q, tp_s = per_token_cast_to_fp8_tp_triton(x, False)
 
     assert tp_q.shape == ref_q.shape == (cols, rows)
     assert tp_s.shape == ref_s.shape


### PR DESCRIPTION
avoid sm <-> gmem round trip when transposing and quantizing to fp8.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches FP8 training backward math and Triton stride/layout wiring; tests lock numerical parity to the old path but errors would affect weight gradients on GPU training.
> 
> **Overview**
> Adds **fused transpose + FP8 quantization** Triton helpers (`per_block_cast_to_fp8_tp_triton`, `per_token_cast_to_fp8_tp_triton`) so `x.T` is cast to FP8 without an explicit `transpose().contiguous()` and the associated SM↔GMEM traffic.
> 
> **`Float8BlockwiseLinear` backward** now uses these fused paths for weight-transpose block casts and for transposed per-token casts on `grad_output` and activations when computing `grad_x` and `grad_weight`; forward behavior is unchanged.
> 
> GPU unit tests assert the fused kernels are **bit-identical** to the prior materialized-transpose + cast reference across several matrix shapes (Hopper+ only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7231ed84e2b359689697b8a7be1bfb1610b350a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->