### PR TITLE
fix: add prime-pydantic-config as direct dep so uv uses editable path…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = "~=3.12.0"
 dependencies = [
     "prime-rl-configs",
+    "prime-pydantic-config",
     "beartype>=0.21.0",
     "datasets>=4.0.0",
     "jaxtyping>=0.3.2",

--- a/uv.lock
+++ b/uv.lock
@@ -3476,19 +3476,33 @@ wheels = [
 
 [[package]]
 name = "prime-pydantic-config"
-version = "0.3.0.dev86"
-source = { registry = "https://pypi.org/simple" }
+version = "0.3.0"
+source = { editable = "deps/pydantic-config" }
 dependencies = [
     { name = "pydantic", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/34/006fc720a8fcda84706793582d50a2028bf6950fb7a0eedb59d3f6555261/prime_pydantic_config-0.3.0.dev86.tar.gz", hash = "sha256:1139bb6d21a8cf134e212ee4e529e5150f2db7422b42eae3ca69a5c77b8a69f5", size = 75656, upload-time = "2026-06-02T01:08:19.079Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/a3/ded48c436cd56ddac3b216458ac458eaf069b55e0ca3be506b2508d16fa2/prime_pydantic_config-0.3.0.dev86-py3-none-any.whl", hash = "sha256:51ac33ae1b5de9ba2e44eb9a91242d9dd783784234942f166f6e8974bcdf1577", size = 27437, upload-time = "2026-06-02T01:08:20.23Z" },
 ]
 
 [package.optional-dependencies]
 toml = [
     { name = "tomli", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "pyyaml", marker = "extra == 'all'" },
+    { name = "pyyaml", marker = "extra == 'yaml'" },
+    { name = "tomli", marker = "extra == 'all'" },
+    { name = "tomli", marker = "extra == 'toml'" },
+]
+provides-extras = ["yaml", "toml", "all"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pre-commit", specifier = ">=3.0.0" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "rich", specifier = ">=15.0.0" },
+    { name = "ruff", specifier = ">=0.12.1" },
 ]
 
 [[package]]
@@ -3509,6 +3523,7 @@ dependencies = [
     { name = "nvidia-ml-py", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "openai", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "prime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "prime-pydantic-config", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "prime-rl-configs", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pyarrow", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pybase64", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -3662,6 +3677,7 @@ requires-dist = [
     { name = "opencode-science", marker = "extra == 'envs'", editable = "deps/research-environments/environments/opencode_science" },
     { name = "opencode-swe", marker = "extra == 'envs'", editable = "deps/research-environments/environments/opencode_swe" },
     { name = "prime", specifier = ">=0.6.4" },
+    { name = "prime-pydantic-config", editable = "deps/pydantic-config" },
     { name = "prime-rl", extras = ["disagg"], marker = "extra == 'all'" },
     { name = "prime-rl", extras = ["flash-attn"], marker = "extra == 'all'" },
     { name = "prime-rl", extras = ["flash-attn-3"], marker = "extra == 'all'" },


### PR DESCRIPTION
… source

The [tool.uv.sources] override for prime-pydantic-config was being ignored because it was only a transitive dependency (via prime-rl-configs). uv only applies source overrides for packages that appear in project.dependencies. Adding it as a direct dependency makes uv resolve from the local editable path (deps/pydantic-config) instead of PyPI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config loading and dependency resolution only; behavior is additive (env overrides) with tests and no changes to training or inference runtime logic.
> 
> **Overview**
> Adds **environment-variable overrides** for top-level run configs by declaring per-entrypoint `env_prefix` values (e.g. `PRIME_RL_ORCH_`, `PRIME_RL_TRAINER_`, `PRIME_RL_INFER_`) on `RLConfig`, `TrainerConfig`, `OrchestratorConfig`, `InferenceConfig`, `SFTConfig`, and `EnvServerConfig`, using nested `__` field paths.
> 
> **`prime-pydantic-config`** is listed as a **direct** `prime-rl` dependency so uv honors the editable `deps/pydantic-config` source override (it was previously only transitive via `prime-rl-configs`). The lockfile moves from a PyPI pre-release to the local editable **0.3.0** package.
> 
> `InferenceConfig` now imports **`BaseConfig` from `prime_rl.utils.config`** (re-export of pydantic-config) instead of importing it straight from `pydantic_config`.
> 
> New unit tests cover env injection, nested keys, CLI winning over env, `RLConfig` sub-config propagation, and **no cross-prefix leakage** between orchestrator and trainer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66d1aee406900b09c90d2f03ac793ad69a5770be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->