### PR TITLE
add router replay to latentMoE models

### DIFF
--- a/src/prime_rl/trainer/models/layers/moe.py
+++ b/src/prime_rl/trainer/models/layers/moe.py
@@ -955,32 +955,44 @@ class NemotronHRouter(nn.Module):
         self.norm_topk_prob = norm_topk_prob
 
     def forward(
-        self, x: torch.Tensor, expert_bias: torch.Tensor | None = None
+        self,
+        x: torch.Tensor,
+        expert_bias: torch.Tensor | None = None,
+        routed_experts: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         scores = F.linear(x.float(), self.gate.float()).sigmoid()
-        scores_for_choice = scores + self.e_score_correction_bias
 
-        if expert_bias is not None:
-            scores_for_choice = scores_for_choice + expert_bias
+        if routed_experts is not None:
+            # Router replay: reuse the inference engine's expert selection and
+            # only recompute the gating weights from the trainer's scores. The
+            # correction/load-balancing biases only affect selection, so they
+            # are intentionally skipped here.
+            selected_experts_indices = routed_experts
+        else:
+            scores_for_choice = scores + self.e_score_correction_bias
 
-        # Group-based routing
-        if self.n_group > 1:
-            group_scores = (
-                scores_for_choice.view(-1, self.n_group, self.num_experts // self.n_group)
-                .topk(2, dim=-1)[0]
-                .sum(dim=-1)
-            )
-            group_idx = torch.topk(group_scores, k=self.topk_group, dim=-1, sorted=False)[1]
-            group_mask = torch.zeros_like(group_scores)
-            group_mask.scatter_(1, group_idx, 1)
-            score_mask = (
-                group_mask.unsqueeze(-1)
-                .expand(-1, self.n_group, self.num_experts // self.n_group)
-                .reshape(-1, self.num_experts)
-            )
-            scores_for_choice = scores_for_choice.masked_fill(~score_mask.bool(), 0.0)
+            if expert_bias is not None:
+                scores_for_choice = scores_for_choice + expert_bias
 
-        selected_experts_indices = torch.topk(scores_for_choice, k=self.top_k, dim=-1, sorted=False)[1]
+            # Group-based routing
+            if self.n_group > 1:
+                group_scores = (
+                    scores_for_choice.view(-1, self.n_group, self.num_experts // self.n_group)
+                    .topk(2, dim=-1)[0]
+                    .sum(dim=-1)
+                )
+                group_idx = torch.topk(group_scores, k=self.topk_group, dim=-1, sorted=False)[1]
+                group_mask = torch.zeros_like(group_scores)
+                group_mask.scatter_(1, group_idx, 1)
+                score_mask = (
+                    group_mask.unsqueeze(-1)
+                    .expand(-1, self.n_group, self.num_experts // self.n_group)
+                    .reshape(-1, self.num_experts)
+                )
+                scores_for_choice = scores_for_choice.masked_fill(~score_mask.bool(), 0.0)
+
+            selected_experts_indices = torch.topk(scores_for_choice, k=self.top_k, dim=-1, sorted=False)[1]
+
         top_scores = scores.gather(1, selected_experts_indices)
         routing_confidence_sum = _selected_probability_mass_sum(scores, top_scores, "sigmoid")
 
@@ -1181,8 +1193,13 @@ class LatentMoE(nn.Module):
         bs, slen, dim = x.shape
         x_flat = x.view(-1, dim)
 
+        if routed_experts is not None:
+            # Flatten to (bs * slen, top_k); reshape (not view) since the slice is non-contiguous.
+            _, _, top_k = routed_experts.shape
+            routed_experts = routed_experts.reshape(-1, top_k)
+
         top_scores, selected_experts_indices, num_tokens_per_expert, routing_confidence_sum = self.router(
-            x_flat, self.expert_bias
+            x_flat, self.expert_bias, routed_experts=routed_experts
         )
 
         with torch.no_grad():

--- a/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
+++ b/src/prime_rl/trainer/models/nemotron_h/modeling_nemotron_h.py
@@ -223,6 +223,7 @@ class NemotronHMambaLayer(GradientCheckpointingLayer):
         position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
         cu_seqlens: torch.LongTensor | None = None,
         max_seqlen: int | None = None,
+        routed_experts: torch.Tensor | None = None,
     ) -> torch.Tensor:
         residual = hidden_states
         hidden_states = self.norm(hidden_states)
@@ -266,10 +267,11 @@ class NemotronHMoELayer(GradientCheckpointingLayer):
         position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
         cu_seqlens: torch.LongTensor | None = None,
         max_seqlen: int | None = None,
+        routed_experts: torch.Tensor | None = None,
     ) -> torch.Tensor:
         residual = hidden_states
         hidden_states = self.norm(hidden_states)
-        hidden_states = self.mlp(hidden_states)
+        hidden_states = self.mlp(hidden_states, routed_experts=routed_experts)
         return residual + hidden_states
 
 
@@ -298,6 +300,7 @@ class NemotronHAttentionLayer(GradientCheckpointingLayer):
         position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
         cu_seqlens: torch.LongTensor | None = None,
         max_seqlen: int | None = None,
+        routed_experts: torch.Tensor | None = None,
     ) -> torch.Tensor:
         residual = hidden_states
         hidden_states = self.norm(hidden_states)
@@ -498,7 +501,13 @@ class NemotronHModel(NemotronHPreTrainedModel):
         input_ids: Optional[torch.LongTensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
+        routed_experts: Optional[torch.LongTensor] = None,
     ) -> BaseModelOutputWithPast:
+        """
+        routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
+            Routed experts for each token, indexed by global layer index. Only used for router replay; slots
+            for non-MoE (Mamba/attention) layers are ignored.
+        """
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
@@ -516,12 +525,15 @@ class NemotronHModel(NemotronHPreTrainedModel):
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids) if self.rotary_emb is not None else None
 
-        for decoder_layer in self.layers:
+        for layer_idx, decoder_layer in enumerate(self.layers):
+            # routed_experts is indexed by global layer index; non-MoE layers ignore it.
+            routed_experts_layer = routed_experts[:, :, layer_idx, :] if routed_experts is not None else None
             hidden_states = decoder_layer(
                 hidden_states,
                 position_embeddings=position_embeddings,
                 cu_seqlens=cu_seqlens,
                 max_seqlen=max_seqlen,
+                routed_experts=routed_experts_layer,
             )
 
         hidden_states = self.norm(hidden_states)
@@ -550,6 +562,7 @@ class NemotronHForCausalLM(NemotronHPreTrainedModel, GenerationMixin):
         labels: Optional[torch.LongTensor] = None,
         logits_to_keep: int = 0,
         temperature: Optional[torch.Tensor] = None,
+        routed_experts: Optional[torch.LongTensor] = None,
         **kwargs,
     ) -> PrimeLmOutput:
         if position_ids is None:
@@ -562,6 +575,7 @@ class NemotronHForCausalLM(NemotronHPreTrainedModel, GenerationMixin):
             input_ids=input_ids,
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
+            routed_experts=routed_experts,
         )
 
         hidden_states = outputs.last_hidden_state


### PR DESCRIPTION
Previously was a no-op

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MoE routing behavior on the training path when `routed_experts` is supplied, which can affect gradients and load-balancing stats; default forward path is unchanged when the tensor is omitted.
> 
> **Overview**
> Implements **router replay** for NemotronH **LatentMoE** so training can match inference expert choices instead of treating `routed_experts` as a no-op.
> 
> **`NemotronHRouter`** gains an optional `routed_experts` argument. When present, it **reuses the supplied expert indices** (from the inference engine) and **only recomputes top-k gating weights** from the trainer’s sigmoid scores; group routing, `e_score_correction_bias`, and load-balancing `expert_bias` are **skipped** for selection (they only affect which experts are picked in the normal path).
> 
> **`LatentMoE`** flattens per-token `routed_experts` and passes them into the router. **`NemotronHModel` / `NemotronHForCausalLM`** accept `routed_experts` with shape `(batch, seq, num_hidden_layers, top_k)`, slice the tensor **per global layer index** in the decoder loop, and thread the slice through Mamba, attention, and MoE layers (non-MoE layers ignore it).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1475afd569222c589cf0384b2f74a6f916c5ed77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->