### PR TITLE
fix(docs): fix inference page (404) by escaping invalid MDX character

### DIFF
--- a/docs/inference.md
+++ b/docs/inference.md
@@ -252,7 +252,7 @@ headless = true
 
 ### Router Replay
 
-Router replay works by capturing the expert routing decisions into a buffer. This buffer then gets sent to the trainer, which can use it instead of re-computing the routing. This lowers the trainer<->inference mismatch by an order of magnitude, resulting in more stable training.
+Router replay works by capturing the expert routing decisions into a buffer. This buffer then gets sent to the trainer, which can use it instead of re-computing the routing. This lowers the trainer↔inference mismatch by an order of magnitude, resulting in more stable training.
 
 To enable router replay, you can set `inference.enable_return_routed_experts = true`.
 


### PR DESCRIPTION
## Problem
The inference page at https://docs.primeintellect.ai/prime-rl/inference returns 404 and is missing from the sidebar navigation, despite `docs/inference.md` existing in the repository and `"inference"` being correctly listed in `mint.json`.

## Root Cause
`docs/inference.md` contains `trainer<->inference` on line 255. The `<->` sequence is interpreted as an invalid JSX/MDX tag by Mintlify, causing a parse error that prevents the page from building entirely.

## Fix
Replaced `trainer<->inference` with `trainer↔inference`.

## Verification
Confirmed locally with `mintlify dev` - the parse error is gone, the inference page renders correctly and appears in the sidebar navigation.

## Screenshots

**Before (production site - Inference missing from sidebar):**
<img width="976" height="303" alt="image" src="https://github.com/user-attachments/assets/2560b862-ea25-415a-8aaf-9e13db68311a" />

**After (local `mintlify dev` - Inference appears in sidebar):**
<img width="1116" height="690" alt="image" src="https://github.com/user-attachments/assets/18ff1e6a-a804-4c09-af96-8fdb55f2f1b8" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change with no runtime or security impact.
> 
> **Overview**
> Fixes the **Inference** docs page failing to build in Mintlify by replacing `trainer<->inference` with `trainer↔inference` in the Router Replay section. The `<->` sequence was parsed as invalid MDX/JSX, which broke the page and hid it from navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f1613782a1259d0354bef4c5b5329c1998798b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->