### PR TITLE
chore: remove private configs submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "research-environments"]
 	path = deps/research-environments
 	url = git@github.com:PrimeIntellect-ai/research-environments.git
-[submodule "configs/private"]
-	path = configs/private
-	url = git@github.com:PrimeIntellect-ai/research-configs.git
 [submodule "pydantic-config"]
 	path = deps/pydantic-config
 	url = https://github.com/PrimeIntellect-ai/pydantic-config

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -74,27 +74,11 @@ ensure_known_hosts() {
   fi
 }
 
-# Initialize each submodule independently so that a missing private repo
-# (e.g. configs/private when the user lacks access) does not abort the install.
 init_submodules() {
   if [ ! -f .gitmodules ]; then
     return 0
   fi
-  local paths failures
-  paths=$(git config -f .gitmodules --get-regexp '^submodule\..*\.path$' | awk '{print $2}')
-  failures=()
-  for path in $paths; do
-    log_info "Initializing submodule: ${path}"
-    if git submodule update --init --recursive -- "$path"; then
-      :
-    else
-      log_warn "Could not initialize submodule '${path}' (likely no access). Continuing without it."
-      failures+=("$path")
-    fi
-  done
-  if [ "${#failures[@]}" -gt 0 ]; then
-    log_warn "Skipped submodules: ${failures[*]}"
-  fi
+  git submodule update --init --recursive
 }
 
 main() {

--- a/skills/configs/SKILL.md
+++ b/skills/configs/SKILL.md
@@ -74,5 +74,4 @@ Leave it unset for normal training. When enabled, it exports every sequence from
 
 - `packages/prime-rl-configs/src/prime_rl/` — config classes under `configs/`; `utils/config.py` re-exports `BaseConfig` and `cli`
 - `configs/debug/` — minimal debug configs
-- `configs/private/` — private configs submodule (internal)
 - `examples/` — full example configs

--- a/skills/install/SKILL.md
+++ b/skills/install/SKILL.md
@@ -16,10 +16,8 @@ bash scripts/install.sh   # clones, inits submodules, installs uv, runs `uv sync
 For an existing clone, init submodules explicitly:
 
 ```bash
-git submodule update --init -- deps/verifiers deps/renderers deps/research-environments deps/pydantic-config
+git submodule update --init --recursive
 ```
-
-Do **not** run `git submodule update --init --recursive` without paths — it tries to clone the private `configs/private` submodule and aborts for users without access. `scripts/install.sh` walks submodules one at a time and skips failures, so it works for everyone.
 
 ## Sync
 

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -26,9 +26,8 @@ CONFIG_CLASSES = [
 
 
 def get_config_files() -> list[Path]:
-    """Any TOML file inside `configs/` or `examples/` (skips the configs/private/ submodule)."""
-    private = Path("configs/private")
-    config_files = [p for p in Path("configs").rglob("*.toml") if private not in p.parents]
+    """Any TOML file inside `configs/` or `examples/`."""
+    config_files = list(Path("configs").rglob("*.toml"))
     example_files = list(Path("examples").rglob("*.toml"))
 
     return config_files + example_files


### PR DESCRIPTION
Remove the configs/private submodule (research-configs) and all references to it throughout the codebase:

- Remove submodule from .gitmodules and git tracking
- Simplify install.sh: use plain git submodule update --init --recursive now that no private submodule can fail for users without access
- Update skills/install/SKILL.md to reflect simplified submodule init
- Remove configs/private/ entry from skills/configs/SKILL.md key files
- Simplify test_configs.py: no longer need to filter out private/ path

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, installer, and test-harness cleanup only; no runtime training or auth behavior changes.
> 
> **Overview**
> Removes the **`configs/private`** git submodule (`research-configs`) from `.gitmodules` and drops all in-repo references to it.
> 
> **Install and docs:** `scripts/install.sh` no longer initializes submodules one-by-one with per-path failure handling; it uses a single **`git submodule update --init --recursive`**. `skills/install/SKILL.md` documents that flow and removes warnings about the private submodule blocking recursive init. `skills/configs/SKILL.md` no longer lists `configs/private/` under key files.
> 
> **Tests:** `get_config_files()` in `tests/unit/test_configs.py` collects every `configs/**/*.toml` without excluding a `private/` tree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc8c6b529d207f228428eb64ad8fd67b568e4801. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->