### PR TITLE
feat(orchestrator): EnvMixStrategy seam for env selection

### DIFF
--- a/src/prime_rl/orchestrator/sampling.py
+++ b/src/prime_rl/orchestrator/sampling.py
@@ -1,0 +1,41 @@
+"""Sampling strategies for training rollouts.
+
+``EnvMixStrategy`` (global) decides *which* env to draw from next — a swappable
+seam between the train envs and the dispatcher. The default
+(``WeightedRoundRobin``) reproduces the previous ``TrainSource`` behavior: a
+weighted random choice over env names, weighted by configured ``ratio`` (when
+every env sets one) or per-env dataset size.
+"""
+
+from __future__ import annotations
+
+import random
+from abc import ABC, abstractmethod
+
+
+class EnvMixStrategy(ABC):
+    """Global: which env to draw from next. ``pick`` returns an env name."""
+
+    @abstractmethod
+    def pick(self) -> str:
+        """Return the env name to sample from next."""
+        ...
+
+
+class WeightedRoundRobin(EnvMixStrategy):
+    """Default env mix: weighted random choice over env names. Weights are the
+    configured per-env ratios (when all set) or per-env dataset sizes.
+
+    Draws from the caller's RNG so env selection stays in the same stream as
+    ``TrainSource``'s dataset shuffles — the example sequence is unchanged.
+    """
+
+    def __init__(self, env_names: list[str], weights: list[float], *, rng: random.Random) -> None:
+        if not env_names:
+            raise ValueError("WeightedRoundRobin needs at least one env")
+        self._rng = rng
+        self._env_names = list(env_names)
+        self._weights = list(weights)
+
+    def pick(self) -> str:
+        return self._rng.choices(self._env_names, weights=self._weights, k=1)[0]

--- a/src/prime_rl/orchestrator/train_source.py
+++ b/src/prime_rl/orchestrator/train_source.py
@@ -1,20 +1,25 @@
 """TrainSource: weighted round-robin across train envs, infinite pull.
 
-Weights default to configured ``ratio`` (when every env sets one) or to
-per-env dataset size. ``next_example`` reshuffles on cursor exhaustion."""
+Env selection is delegated to a swappable ``EnvMixStrategy`` (default:
+weighted round-robin by configured ``ratio`` when every env sets one, else by
+per-env dataset size); example selection stays here (a reshuffling cursor per
+env). ``next_example`` reshuffles on cursor exhaustion. Returned dicts carry
+``env_name`` + ``example_id``.
+"""
 
 from __future__ import annotations
 
 import random
 
 from prime_rl.orchestrator.envs import TrainEnvs
+from prime_rl.orchestrator.sampling import WeightedRoundRobin
 
 
 class TrainSource:
-    """``next_example(available_permits)`` picks a weighted-RR env and
-    returns its next example (or ``None`` when the env's per-call permit
-    cost doesn't fit — the dispatch loop retries when permits free up).
-    Returned dicts carry ``env_name`` + ``example_id``."""
+    """``next_example(available_permits)`` picks an env via the mix strategy and
+    returns its next example (or ``None`` when the env's per-call permit cost
+    doesn't fit — the dispatch loop retries when permits free up). Returned
+    dicts carry ``env_name`` + ``example_id``."""
 
     def __init__(self, train_envs: TrainEnvs, *, seed: int | None) -> None:
         self.rng = random.Random(seed)
@@ -38,15 +43,18 @@ class TrainSource:
             self.cursors[env.name] = 0
             self.env_costs[env.name] = env.config.group_size if env.requires_group_scoring else 1
 
-        self.env_names = [e.name for e in self.envs]
+        env_names = [e.name for e in self.envs]
         configured_ratios = [e.config.ratio for e in self.envs]
         if all(r is not None for r in configured_ratios):
-            self.weights: list[float] = [float(r) for r in configured_ratios]  # type: ignore[arg-type]
+            weights: list[float] = [float(r) for r in configured_ratios]  # type: ignore[arg-type]
         else:
-            self.weights = [float(len(self.examples[name])) for name in self.env_names]
+            weights = [float(len(self.examples[name])) for name in env_names]
+        # Shares ``self.rng`` so env selection draws from the same stream as the
+        # dataset shuffles above — the example sequence matches the pre-seam path.
+        self.env_mix = WeightedRoundRobin(env_names, weights, rng=self.rng)
 
     def next_example(self, available_permits: int) -> dict | None:
-        env_name = self.rng.choices(self.env_names, weights=self.weights, k=1)[0]
+        env_name = self.env_mix.pick()
         if self.env_costs[env_name] > available_permits:
             return None
         rows = self.examples[env_name]

--- a/tests/unit/orchestrator/test_sampling.py
+++ b/tests/unit/orchestrator/test_sampling.py
@@ -1,0 +1,27 @@
+import random
+
+import pytest
+
+from prime_rl.orchestrator.sampling import WeightedRoundRobin
+
+
+def test_weighted_round_robin_is_deterministic_per_rng():
+    """Same seed → same pick sequence (env selection is reproducible)."""
+    names = ["a", "b", "c"]
+    weights = [1.0, 2.0, 3.0]
+    a = WeightedRoundRobin(names, weights, rng=random.Random(0))
+    b = WeightedRoundRobin(names, weights, rng=random.Random(0))
+    assert [a.pick() for _ in range(100)] == [b.pick() for _ in range(100)]
+
+
+def test_weighted_round_robin_respects_weights():
+    """A heavily-weighted env dominates; a zero-weight env is never picked."""
+    wrr = WeightedRoundRobin(["rare", "common", "never"], [1.0, 99.0, 0.0], rng=random.Random(0))
+    picks = [wrr.pick() for _ in range(10_000)]
+    assert "never" not in picks
+    assert picks.count("common") > picks.count("rare")
+
+
+def test_weighted_round_robin_rejects_empty():
+    with pytest.raises(ValueError):
+        WeightedRoundRobin([], [], rng=random.Random(0))


### PR DESCRIPTION
## What

Extract `TrainSource`'s weighted round-robin **env selection** into a swappable `EnvMixStrategy` seam (default `WeightedRoundRobin`). Example selection — the per-env reshuffling cursor — stays in `TrainSource`.

This is **slice (b)** of the composable algorithm abstraction: cleanly separate *which env* (global `EnvMixStrategy`) from *which example* (per-env, slice c builds on this).

## Changes

- **`orchestrator/sampling.py`** (new): `EnvMixStrategy` ABC + `WeightedRoundRobin` default. `pick()` returns the next env name via weighted random choice.
- **`TrainSource`** delegates the env pick to `self.env_mix.pick()`; it still owns dataset loading, the per-env cursor, reshuffle-on-exhaustion, and `env_costs`.

## Behavior

Behavior-preserving. `WeightedRoundRobin` draws from `TrainSource`'s existing RNG (injected), so env selection stays in the same stream as the dataset shuffles — the example sequence is identical to before. (Partitioning RNG per-env is a slice-(c) change, not here.) The public API (`TrainSource(train_envs, seed)` + `next_example`) is unchanged.

## Testing

- `ruff check` + `ruff format --check` clean.
- `tests/unit/orchestrator/test_sampling.py` (new): `WeightedRoundRobin` determinism per seed, weight respecting (incl. zero-weight never picked), empty-envs guard.
- `tests/unit/test_configs.py` (106) pass; imports resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with default implementation matching prior logic; `TrainSource` API and dispatcher wiring unchanged.
> 
> **Overview**
> Introduces a swappable **env mix** seam for training rollouts: global “which env next?” is no longer inlined in `TrainSource`.
> 
> New **`orchestrator/sampling.py`** defines `EnvMixStrategy` and default **`WeightedRoundRobin`**, which picks an env name via weighted random choice (same weight rules as before: per-env `ratio` when all set, else dataset size). **`TrainSource`** now calls `self.env_mix.pick()` instead of `rng.choices` directly; it still owns datasets, per-env cursors, reshuffle-on-exhaustion, permit costs, and `next_example`’s public contract.
> 
> **Behavior-preserving:** `WeightedRoundRobin` uses `TrainSource`’s existing `random.Random` instance so env picks stay in the same RNG stream as dataset shuffles.
> 
> **Tests:** `tests/unit/orchestrator/test_sampling.py` covers determinism, weight behavior (including zero weight), and empty-env validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84370ab405728291f83d376e7cf859f7ede241d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->