### PR TITLE
feat: request vLLM token ids for MITO training

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -259,6 +259,11 @@ class Orchestrator:
         if config.training_mode == "sft":
             for env in self.train_envs:
                 env.sampling_args.pop("logprobs", None)
+        if config.renderer is None:
+            # MITO (no renderer): ask vLLM to return the prompt/completion token ids
+            # so the chat client can carry them for training instead of re-tokenizing.
+            for env in self.train_envs:
+                env.sampling_args.setdefault("extra_body", {})["return_token_ids"] = True
         get_logger().debug(
             f"Loaded {len(self.train_envs)} training environment(s) ({', '.join(self.train_envs.names)})"
         )


### PR DESCRIPTION
## Summary

- On the **MITO path** (`orchestrator.renderer = None`, no renderer), set `return_token_ids` in each train env's `extra_body` so vLLM returns the prompt/completion token ids alongside the text.
- Pairs with the verifiers-side parser (PrimeIntellect-ai/verifiers#1585): the `openai_chat_completions` client parses those ids + sampling logprobs into `Response.tokens`, so MITO training trains on real on-policy tokens instead of re-tokenizing messages downstream.
- Scoped to `config.renderer is None`, mirroring the existing SFT `logprobs`-pop, so the flag never reaches the renderer's `/inference/v1/generate` endpoint (which forwards sampling params to vLLM verbatim and would choke on it).

Base is the `feat/nano-as-v1` branch. `.gitmodules` and the `deps/verifiers` submodule pointer are intentionally **unchanged** — the submodule bump to pick up the parser follows once verifiers#1585 merges into `feat/nano-as-v1`.

## Verification

20-step `reverse-text-v1` RL run in MITO mode with the orchestrator-side token backfill disabled (so tokens could only come from the chat-response parser): Trainable 128/128 (100%) every step, 0 "No trainable samples" warnings, reward 0.16 → 0.78, 0% errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, gated change to train-env sampling kwargs when renderer is absent; no auth, data, or renderer-path behavior changes.
> 
> **Overview**
> When **`config.renderer` is `None`** (MITO / direct vLLM chat, no renderer), the orchestrator now sets **`return_token_ids: true`** on each train env’s **`sampling_args.extra_body`** after envs are loaded—same placement as the existing SFT **`logprobs`** strip.
> 
> That asks vLLM to return prompt/completion token ids with chat completions so the **`openai_chat_completions`** path can populate **`Response.tokens`** for training on real on-policy tokens instead of re-tokenizing messages. The flag is **train envs only** and **not** applied when a renderer is configured, avoiding forwarding **`return_token_ids`** to the renderer’s generate endpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc242c6e1081ec80046f8e2beca79f9a2ec0d15c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->