### PR TITLE
fix(orchestrator): drop per-step prompt arrays from buffered rollouts after tokenization

### DIFF
--- a/src/prime_rl/orchestrator/train_sink.py
+++ b/src/prime_rl/orchestrator/train_sink.py
@@ -142,6 +142,20 @@ class TrainSink:
         """Process one arrival; finalize the group on the ``group_size``-th
         arrival; return a ``TrainBatch`` if the batch threshold is met."""
         await self.process_rollout(rollout)
+        # Per-step prompt arrays carry the FULL prompt prefix per step —
+        # O(turns x context) boxed ints — and have no readers past the
+        # tokenization above; drop them before the rollout buffers, like
+        # ``offload_images_to_disk`` does for image bytes. Keep the count
+        # (sample monitors' ``num_input_tokens``), the completion arrays
+        # (post-batch filters scan them), and the final step whole (the
+        # wandb sample table decodes it); ``save_rollouts`` already excludes
+        # the trajectory from disk artifacts.
+        for step in (rollout.raw.get("trajectory") or [])[:-1]:
+            tokens = step.get("tokens")
+            if tokens:
+                tokens["num_prompt_tokens"] = len(tokens["prompt_ids"])
+                tokens["prompt_ids"] = []
+                tokens["prompt_mask"] = []
         env_name = rollout.env_name
         self.arrivals_by_env[env_name] += 1
         if rollout.error is not None:

--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -465,9 +465,7 @@ class PrimeMonitor(Monitor):
                 # Stripped steps (strip_trajectory_prompt_arrays) carry the
                 # count instead of the array; fresh steps still have the ids.
                 "num_input_tokens": (
-                    ts["tokens"].get("num_prompt_tokens", len(ts["tokens"]["prompt_ids"]))
-                    if ts.get("tokens")
-                    else None
+                    ts["tokens"].get("num_prompt_tokens", len(ts["tokens"]["prompt_ids"])) if ts.get("tokens") else None
                 ),
                 "num_output_tokens": len(ts["tokens"]["completion_ids"]) if ts.get("tokens") else None,
             }

--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -462,7 +462,13 @@ class PrimeMonitor(Monitor):
                 "reward": ts.get("reward"),
                 "advantage": ts.get("advantage"),
                 "extras": ts.get("extras", {}),
-                "num_input_tokens": len(ts["tokens"]["prompt_ids"]) if ts.get("tokens") else None,
+                # Stripped steps (strip_trajectory_prompt_arrays) carry the
+                # count instead of the array; fresh steps still have the ids.
+                "num_input_tokens": (
+                    ts["tokens"].get("num_prompt_tokens", len(ts["tokens"]["prompt_ids"]))
+                    if ts.get("tokens")
+                    else None
+                ),
                 "num_output_tokens": len(ts["tokens"]["completion_ids"]) if ts.get("tokens") else None,
             }
             for ts in trajectory


### PR DESCRIPTION
## Problem

Long multi-turn browser rollouts (worldsims gflights, 30–70 turns at ~57k context) OOM the 128GB orchestrator during the first batch fill. The dominant block is the trajectory's per-step token arrays: **every step ships `prompt_ids`/`prompt_mask` for its entire prompt prefix** — O(turns × context) boxed ints, measured at 100–370MB per rollout — and they sit untouched in `pending_groups`/`pending_batch` for minutes-to-hours after their only readers (`backfill_rollout_tokens` / `interleave_rollout`) consumed them at arrival. At the observed ~250 buffered rollouts (`+N buffered` in the progress log), this dead weight alone fills the box.

## Fix

Strip the prompt arrays at the arrival boundary in `TrainSink.add`, right after `process_rollout` — the same pattern `offload_images_to_disk` already applies to image bytes at this exact boundary.

Consumer audit (every post-arrival reader of trajectory data, all preserved):

| Reader | Needs | Handling |
|---|---|---|
| entropy/rare-token filters (`filters.py:54-86`) | `completion_ids`/`completion_logprobs`, all steps | completion arrays kept everywhere |
| wandb sample table (`monitor/wandb.py:175-180`) | `trajectory[-1]["tokens"]` full | final step left whole |
| prime sample parquet (`monitor/prime.py:465`) | `len(prompt_ids)` per step | `num_prompt_tokens` count stored; monitor reads it with fallback to `len(prompt_ids)` |
| metrics / length-cost advantage | `len(trajectory)` | steps themselves untouched |
| `save_rollouts` (train + eval) | — | already excludes `trajectory` via `exclude_keys`; artifacts byte-identical |

Known limitation (accepted): custom advantage fns (`advantage.type="custom"`) are documented to receive the raw `vf.RolloutOutput`s; after this PR, non-final steps carry `num_prompt_tokens` instead of prompt arrays. No in-tree or in-use custom fn reads them; if one ever does, detect `CustomAdvantageConfig` at sink construction and defer the strip to `process_group` after `assign_advantages` (see PR discussion).

## Measured effect (validated by replaying the strip through the real `interleave_rollout` + consumer expressions)

Eval-calibrated gflights rollout shapes, sharing-aware deep-sizeof, per rollout / extrapolated to 250 buffered:

| Harness compaction | baseline | after this PR |
|---|---|---|
| per-turn sliding (current worldsims prod) | 101 MB / 24.6 GB | 45 MB / 11.0 GB |
| staged (planned worldsims change) | 94 MB / 22.9 GB | **10.8 MB / 2.6 GB** |
| disabled | 130 MB / 31.7 GB | 10.1 MB / 2.5 GB |

With per-turn sliding compaction the residual block is the extension-break *sample* copies (58 samples/rollout), fixed env-side by worldsims staged compaction shipping separately; the two compose to ~100×.

## Verification

- Replay harness asserts on every scenario: per-step `num_input_tokens` identical pre/post strip; last step decodes in full; completion arrays byte-identical on all steps; turn counts unchanged; samples untouched; stripped trajectory still msgpack-serializable.
- Unit tests covering the touched modules (`test_batch`, `test_trajectories`, `test_filters`, `test_advantage`, `test_prime_monitor`) run on this branch and on base in the same torch-less venv: 45 passed, 39 failed/errored on BOTH with **byte-identical failure sets** (all environmental — missing torch/transformers fixtures), i.e. zero regressions attributable to this diff.
- `ruff check` + `ruff format` clean on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what lives in in-memory rollout buffers on the training hot path; behavior is preserved only if every post-arrival trajectory reader was accounted for (filters, wandb last step, monitors).
> 
> **Overview**
> Fixes orchestrator OOM during batch fill on long multi-turn rollouts by **dropping dead weight** from buffered rollout trajectories after tokenization.
> 
> In **`TrainSink.add`**, immediately after **`process_rollout`**, every trajectory step **except the last** has **`prompt_ids`** / **`prompt_mask`** cleared (full-prefix arrays that are O(turns × context) and unused once interleaving finishes). **`num_prompt_tokens`** is stored first so per-step input length is still available; completion token fields and the final step’s full **`tokens`** blob are left intact for filters and the wandb sample table.
> 
> **`PrimeMonitor`** sample parquet rows now read **`num_input_tokens`** via **`num_prompt_tokens`** when present, with a fallback to **`len(prompt_ids)`** for unstripped steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7659046fd356b364922eceb8434e074790a9ee75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
