### PR TITLE
chore: cherry-pick explicit del + per-batch malloc_trim onto feat/ephemeral-mm-pixels

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import asyncio
 import ctypes
+import gc
 import logging
 import os
 import time
@@ -107,6 +108,14 @@ MAX_CONSECUTIVE_EMPTY_BATCHES = 10
 # dispatcher is paused via ``update_dispatch_gate`` once this is exceeded;
 # resumed when the watcher advances ``policy.version``.
 TARGET_LAG = 1
+
+
+def _release_unused_memory() -> None:
+    gc.collect()
+    try:
+        ctypes.CDLL("libc.so.6").malloc_trim(0)
+    except (OSError, AttributeError) as e:
+        get_logger().debug(f"malloc_trim(0) unavailable: {e}")
 
 
 class Orchestrator:
@@ -475,10 +484,7 @@ class Orchestrator:
                 get_logger().success("Orchestrator finished.")
             else:
                 get_logger().warning("Orchestrator cleanup complete (forced).")
-            try:
-                ctypes.CDLL("libc.so.6").malloc_trim(0)
-            except Exception as e:
-                get_logger().debug(f"malloc_trim(0) failed: {e}")
+            _release_unused_memory()
 
     async def main_loop(self) -> None:
         """Consume ``FinishedRollout``\\ s from the dispatcher and route them
@@ -495,19 +501,29 @@ class Orchestrator:
             except asyncio.TimeoutError:
                 continue
 
-            if isinstance(rollout, EvalRollout):
-                assert self.eval_sink is not None  # eval rollouts only emitted when eval is configured
-                eval_batch = self.eval_sink.add(rollout)
-                if eval_batch is not None:
-                    self.finalize_eval_batch(eval_batch)
-                continue
+            batch = None
+            should_release_memory = False
+            try:
+                if isinstance(rollout, EvalRollout):
+                    assert self.eval_sink is not None  # eval rollouts only emitted when eval is configured
+                    batch = self.eval_sink.add(rollout)
+                    if batch is not None:
+                        should_release_memory = True
+                        self.finalize_eval_batch(batch)
+                    continue
 
-            assert isinstance(rollout, TrainRollout)
-            train_batch = await self.train_sink.add(rollout)
-            # In drain mode any late-arriving train batch is dropped — we
-            # don't want to ship past ``max_steps``
-            if train_batch is not None and not self.draining and not self.stopped.is_set():
-                await self.finalize_train_batch(train_batch)
+                assert isinstance(rollout, TrainRollout)
+                batch = await self.train_sink.add(rollout)
+                # In drain mode any late-arriving train batch is dropped — we
+                # don't want to ship past ``max_steps``
+                if batch is not None:
+                    should_release_memory = True
+                if batch is not None and not self.draining and not self.stopped.is_set():
+                    await self.finalize_train_batch(batch)
+            finally:
+                del batch, rollout
+                if should_release_memory:
+                    _release_unused_memory()
 
     async def finalize_train_batch(self, batch: TrainBatch) -> None:
         """Ship one ``TrainBatch`` out to the trainer and handle the I/O


### PR DESCRIPTION
Cherry-pick of Christian's `explicit-cleanup` branch commit ([`77b85673`](https://github.com/PrimeIntellect-ai/prime-rl/compare/main...explicit-cleanup), authorship preserved) onto `feat/ephemeral-mm-pixels`: after each shipped train/eval batch the orchestrator runs `gc.collect()` + `malloc_trim(0)`, plus explicit `del` of the loop locals.

## Why on this branch

With #2752 deployed, worldsims gflights runs no longer OOM mid-first-batch — they now OOM *after* step 1 with a slower slope. That's the allocator ratchet: each step's transient population (sample copies, decode churn) is freed logically at ship, but glibc/pymalloc keep the arena pages, so per-step peaks stack. `malloc_trim(0)` at the ship boundary returns those pages — once per step is the right cadence for a stop-the-world (unlike the per-request cleanup in the renderer client, which stalls worker heartbeats).

Conflict resolution: this branch's `finalize_eval_batch` is sync (main's is async) — kept the branch's non-awaited call inside Christian's try/finally structure. `py_compile` + `ruff check` clean.

Note: this trims *between* steps; the within-step fill peak (sliding-compaction extension-break samples) is addressed separately env-side (worldsims staged compaction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Per-step stop-the-world gc/malloc_trim can add latency and briefly stall the asyncio event loop on Linux; behavior is a no-op where malloc_trim is unavailable.
> 
> **Overview**
> Adds **`_release_unused_memory()`** (`gc.collect()` + glibc **`malloc_trim(0)`**) and uses it to fight RSS growth from freed-but-retained allocator pages during long RL runs.
> 
> **Per shipped batch:** `main_loop` now wraps rollout handling in **`try`/`finally`**, explicitly **`del batch, rollout`**, and calls the helper when a train or eval batch was produced (after finalize). **On shutdown**, the old inline `malloc_trim` call is replaced with the same helper (with narrower `OSError`/`AttributeError` handling when libc trim isn’t available).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca037b69d0668b4bde3fbf000119dca540f50f4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->