### PR TITLE
fix(slurm): portable GLOO/UCX NIC selection in sbatch templates

### DIFF
--- a/src/prime_rl/templates/inference.sbatch.j2
+++ b/src/prime_rl/templates/inference.sbatch.j2
@@ -194,10 +194,28 @@ srun --kill-on-bad-exit=1 bash -c '
     export VLLM_MOE_USE_DEEP_GEMM=1
 {%- endif %}
     export PYTORCH_CUDA_ALLOC_CONF="expandable_segments:False"
-    export GLOO_SOCKET_IFNAME=bond0
+    # Bind gloo to the interface that owns LOCAL_IP (the rendezvous IP) — NIC
+    # names vary across clusters (bond0, eth0, ...). If the lookup fails, leave
+    # GLOO_SOCKET_IFNAME unset so gloo falls back to its own detection.
+    GLOO_IFNAME=$(ip -o -4 addr show to "$LOCAL_IP" 2>/dev/null | awk "{print \$2; exit}")
+    if [ -n "$GLOO_IFNAME" ]; then export GLOO_SOCKET_IFNAME=$GLOO_IFNAME; fi
     export VLLM_ENGINE_READY_TIMEOUT_S=4200
     export UCX_TLS=all
-    export UCX_NET_DEVICES=all
+    # Enumerate RDMA NICs for UCX/NIXL from sysfs (ibv_devices is not on the job
+    # PATH). Prefer InfiniBand ports and fall back to RoCE: "all" would also pick
+    # up non-functional devices (e.g. an Ethernet bond UCX cannot open), which
+    # fails NIXL backend creation. Hosts without RDMA devices keep "all" (TCP).
+    rdma_ports() {
+        for port in /sys/class/infiniband/*/ports/*; do
+            [ "$(cat "$port/link_layer" 2>/dev/null)" = "$1" ] || continue
+            grep -q ACTIVE "$port/state" 2>/dev/null || continue
+            dev=${port%/ports/*}
+            echo "$(basename "$dev"):$(basename "$port")"
+        done | paste -sd,
+    }
+    UCX_NET_DEVICES=$(rdma_ports InfiniBand)
+    [ -n "$UCX_NET_DEVICES" ] || UCX_NET_DEVICES=$(rdma_ports Ethernet)
+    export UCX_NET_DEVICES=${UCX_NET_DEVICES:-all}
     export LD_LIBRARY_PATH="$PROJECT_DIR/third_party/ucx/lib:$PROJECT_DIR/third_party/ucx/lib/ucx:${LD_LIBRARY_PATH:-}"
 
     export VLLM_NIXL_SIDE_CHANNEL_HOST=$LOCAL_IP

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -239,10 +239,28 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
     export VLLM_MOE_USE_DEEP_GEMM=1
 {%- endif %}
 
-    export GLOO_SOCKET_IFNAME=bond0
+    # Bind gloo to the interface that owns LOCAL_IP (the rendezvous IP) — NIC
+    # names vary across clusters (bond0, eth0, ...). If the lookup fails, leave
+    # GLOO_SOCKET_IFNAME unset so gloo falls back to its own detection.
+    GLOO_IFNAME=$(ip -o -4 addr show to "$LOCAL_IP" 2>/dev/null | awk "{print \$2; exit}")
+    if [ -n "$GLOO_IFNAME" ]; then export GLOO_SOCKET_IFNAME=$GLOO_IFNAME; fi
     export VLLM_ENGINE_READY_TIMEOUT_S=4200
     export UCX_TLS=all
-    export UCX_NET_DEVICES=all
+    # Enumerate RDMA NICs for UCX/NIXL from sysfs (ibv_devices is not on the job
+    # PATH). Prefer InfiniBand ports and fall back to RoCE: "all" would also pick
+    # up non-functional devices (e.g. an Ethernet bond UCX cannot open), which
+    # fails NIXL backend creation. Hosts without RDMA devices keep "all" (TCP).
+    rdma_ports() {
+        for port in /sys/class/infiniband/*/ports/*; do
+            [ "$(cat "$port/link_layer" 2>/dev/null)" = "$1" ] || continue
+            grep -q ACTIVE "$port/state" 2>/dev/null || continue
+            dev=${port%/ports/*}
+            echo "$(basename "$dev"):$(basename "$port")"
+        done | paste -sd,
+    }
+    UCX_NET_DEVICES=$(rdma_ports InfiniBand)
+    [ -n "$UCX_NET_DEVICES" ] || UCX_NET_DEVICES=$(rdma_ports Ethernet)
+    export UCX_NET_DEVICES=${UCX_NET_DEVICES:-all}
     export LD_LIBRARY_PATH="$PROJECT_DIR/third_party/ucx/lib:$PROJECT_DIR/third_party/ucx/lib/ucx:${LD_LIBRARY_PATH:-}"
     export VLLM_NIXL_SIDE_CHANNEL_HOST=$LOCAL_IP
     export VLLM_NIXL_SIDE_CHANNEL_PORT=5600


### PR DESCRIPTION
## Summary

The disaggregated env blocks in `inference.sbatch.j2` and `multi_node_rl.sbatch.j2` hardcoded cluster-specific networking:

- `GLOO_SOCKET_IFNAME=bond0` breaks on clusters where the rendezvous NIC has a different name. Now derived from the interface that owns `LOCAL_IP` (via `ip -o -4 addr show to`), falling back to gloo's own detection if the lookup fails.
- `UCX_NET_DEVICES=all` makes UCX try to open every RDMA device, including non-functional ones (e.g. an Ethernet bond it cannot open), which fails NIXL backend creation with `NIXL_ERR_BACKEND` ("no active messages transport"). Now enumerated from `/sys/class/infiniband` (`ibv_devices` is not on the job PATH), keeping only ACTIVE ports: prefer InfiniBand, fall back to RoCE (Ethernet), and keep `all` on hosts without RDMA devices so TCP-only setups are unaffected.

Both templates carry the same block (the combined `rl` path renders `multi_node_rl.sbatch.j2`, standalone inference renders `inference.sbatch.j2`), so both are updated.

Note: the decode-node `UCX_NET_DEVICES=mlx5_0:1` override further down is also cluster-specific but pre-existing and intentionally left untouched here.

Verified: both templates render (jinja) and the outer script plus the inner `bash -c` block pass `bash -n`; the sysfs enumeration was exercised against IB-only, RoCE-only, and no-RDMA fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes multi-node disaggregated inference networking env at job start; mis-detection could break NIXL/gloo rendezvous, though fallbacks (unset GLOO, UCX=all) limit blast radius on edge cases.
> 
> **Overview**
> Replaces cluster-specific networking in the **disaggregated prefill/decode** launch blocks of `inference.sbatch.j2` and `multi_node_rl.sbatch.j2` with runtime detection so jobs work across different NIC layouts.
> 
> **Gloo:** `GLOO_SOCKET_IFNAME=bond0` is removed. The interface that owns `LOCAL_IP` is resolved via `ip -o -4 addr show to`; if that fails, the variable is left unset so gloo auto-detects.
> 
> **UCX / NIXL:** `UCX_NET_DEVICES=all` is replaced by an `rdma_ports` helper that lists only **ACTIVE** ports from `/sys/class/infiniband` (InfiniBand first, then RoCE/Ethernet), comma-joined as `device:port`. If nothing is found, export stays `all` for TCP-only hosts.
> 
> The decode-node `UCX_NET_DEVICES=mlx5_0:1` override is unchanged and still wins on decode ranks after the shared block runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 290283704ebd24dce4dcd0dfeeae47c40b173fad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->