### PR TITLE
fix(scripts): verify IB support in UCX build for NIXL

### DIFF
--- a/scripts/install_nixl_from_source.sh
+++ b/scripts/install_nixl_from_source.sh
@@ -10,6 +10,19 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 VENV_BIN="$PROJECT_DIR/.venv/bin"
 PYTHON="$VENV_BIN/python"
 
+# UCX's --with-verbs silently disables IB/RoCE support when the rdma-core *dev*
+# headers (verbs.h / rdma_cma.h) are missing, yielding a TCP-only build. On hosts
+# with RDMA devices, require the headers up front instead of failing at runtime.
+HAVE_RDMA=0
+if compgen -G "/sys/class/infiniband/*" > /dev/null; then
+    HAVE_RDMA=1
+    if [ ! -f /usr/include/infiniband/verbs.h ] || [ ! -f /usr/include/rdma/rdma_cma.h ]; then
+        echo "ERROR: host has RDMA devices but the rdma-core dev headers are missing." >&2
+        echo "Install them first, e.g.: apt-get install -y libibverbs-dev librdmacm-dev" >&2
+        exit 1
+    fi
+fi
+
 WORKSPACE="$PROJECT_DIR/nixl_workspace"
 mkdir -p "$WORKSPACE"
 UCX_SRC="$WORKSPACE/ucx_source"
@@ -40,11 +53,23 @@ if [ ! -f "$UCX_INSTALL/lib/libucs.so" ]; then
         --enable-devel-headers \
         --enable-mt \
         --with-verbs \
+        --with-rdmacm \
         --with-cuda="$CUDA_PATH" \
         --with-ze=no
     make -j"$NPROC"
     make install
     echo "=== UCX installed to $UCX_INSTALL ==="
+
+    # Fail loudly if the IB transports didn't make it into the build.
+    if [ "$HAVE_RDMA" = 1 ]; then
+        ucx_transports=$(LD_LIBRARY_PATH="$UCX_INSTALL/lib:$UCX_INSTALL/lib/ucx:${LD_LIBRARY_PATH:-}" \
+            "$UCX_INSTALL/bin/ucx_info" -d)
+        if ! grep -q "Transport: rc_verbs" <<< "$ucx_transports"; then
+            echo "ERROR: UCX built without IB (rc_verbs) transport despite RDMA devices being present." >&2
+            echo "Check that libibverbs-dev / librdmacm-dev were present at configure time." >&2
+            exit 1
+        fi
+    fi
 else
     echo "=== UCX already built, skipping ==="
 fi


### PR DESCRIPTION
## Summary

`install_nixl_from_source.sh` passed `--with-verbs`, which UCX silently downgrades to a TCP-only build when the rdma-core *dev* headers (`verbs.h` / `rdma_cma.h`) are missing — the failure only surfaces much later at runtime as `NIXL_ERR_BACKEND`.

- On hosts that actually have RDMA devices (`/sys/class/infiniband` non-empty), require the dev headers up front with an actionable error (`apt-get install -y libibverbs-dev librdmacm-dev`).
- After building UCX on such hosts, verify the `rc_verbs` transport is present in `ucx_info -d` output and fail loudly otherwise.
- Pass `--with-rdmacm` so the rdmacm connection manager is built when available.

Hosts without RDMA devices are unaffected: no header requirement, no transport check, same TCP-only build as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-script-only changes with stricter checks on RDMA hosts; non-RDMA paths are unchanged.
> 
> **Overview**
> **`install_nixl_from_source.sh`** now catches missing RDMA dev headers and silent TCP-only UCX builds on hosts that actually have InfiniBand/RoCE hardware.
> 
> When `/sys/class/infiniband` has devices, the script **requires** `verbs.h` and `rdma_cma.h` before building and exits with install hints (`libibverbs-dev`, `librdmacm-dev`). UCX configure gains **`--with-rdmacm`**. After a fresh UCX install on those hosts, it runs **`ucx_info -d`** and fails if **`rc_verbs`** is absent. Hosts without RDMA devices skip the checks and behave as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ed77f8cbf274dc0917b9538f9acdde75390f1d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->