### PR TITLE
feat: scaleswe v1 configs + taskset registration

### DIFF
--- a/configs/debug/v1/scaleswe.toml
+++ b/configs/debug/v1/scaleswe.toml
@@ -1,3 +1,7 @@
+# v1 port of configs/rlm_swe/qwen35_4b.toml — identical except the env blocks, which load
+# the v1 `scaleswe-v1` taskset through the rlm harness on the prime runtime instead of the
+# v0 `rlm_swe` composable env. Same model / trainer / inference / orchestrator knobs.
+
 output_dir = "/beegfs/mika/rlm-swe-qwen35-4b"
 max_steps = 400
 seq_len = 65536
@@ -58,13 +62,10 @@ enable_thinking = true
 temperature = 1.0
 
 [[orchestrator.train.env]]
-id = "rlm_swe"
 name = "rlm-swe-scaleswe"
 num_workers = 4
-
-[orchestrator.train.env.args]
-task_type = "scaleswe"
-labels = ["rlm-swe-qwen35-4b"]
+taskset = { id = "scaleswe-v1" }
+harness = { id = "rlm", runtime = { type = "prime", labels = ["rlm-swe-qwen35-4b"] } }
 
 [orchestrator.prime_monitor]
 
@@ -72,14 +73,11 @@ labels = ["rlm-swe-qwen35-4b"]
 interval = 20
 
 [[orchestrator.eval.env]]
-id = "rlm_swe"
 name = "rlm-swe-scaleswe-eval"
 num_workers = 4
 timeout = { rollout = 3600 }
-
-[orchestrator.eval.env.args]
-task_type = "scaleswe"
-labels = ["rlm-swe-qwen35-4b"]
+taskset = { id = "scaleswe-v1" }
+harness = { id = "rlm", runtime = { type = "prime", labels = ["rlm-swe-qwen35-4b"] } }
 
 # --- Inference ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ envs = [
     "math-env-v1",
     "aime24-v1",
     "alphabet-sort-v1",
+    "scaleswe-v1",
     "tasksets",
     "harnesses",
 ]
@@ -249,6 +250,7 @@ gsm8k-v1 = { path = "deps/verifiers/examples/tasksets/gsm8k_v1", editable = true
 math-env-v1 = { path = "deps/verifiers/examples/tasksets/math_env_v1", editable = true }
 aime24-v1 = { path = "deps/verifiers/examples/tasksets/aime24_v1", editable = true }
 alphabet-sort-v1 = { path = "deps/verifiers/examples/tasksets/alphabet_sort_v1", editable = true }
+scaleswe-v1 = { path = "deps/verifiers/examples/tasksets/scaleswe_v1", editable = true }
 tasksets = { path = "deps/verifiers/packages/tasksets", editable = true }
 harnesses = { path = "deps/verifiers/packages/harnesses", editable = true }
 renderers = { path = "deps/renderers", editable = true }


### PR DESCRIPTION
## Summary

Wires the `scaleswe-v1` v1 taskset into prime-rl. Companion to verifiers#1616 (merged).

- **Register** `scaleswe-v1` — added to the `envs` optional-deps list and as an editable `[tool.uv.sources]` path (`deps/verifiers/examples/tasksets/scaleswe_v1`).
- **`configs/rlm_swe/qwen35_4b.toml`** — points the existing v0 rlm-swe config at the Scale-SWE taskset (`task_type = "scaleswe"`, train + eval).
- **`configs/debug/v1/scaleswe.toml`** — a per-env v1 port of that config: identical knobs, env blocks swapped to the `scaleswe-v1` taskset via the `rlm` harness on the `prime` runtime.
- **Bump `deps/verifiers`** to `feat/nano-as-v1` (`d668319`), which includes the `scaleswe-v1` taskset + the `Task.workdir` / `Taskset.setup` / `NEEDS_CONTAINER` hooks.

## Verification

- Both configs parse via `cli(RLConfig, ["@", <path>])`:
  - `configs/rlm_swe/qwen35_4b.toml` → `TrainEnvConfig` (v0 `rlm_swe`, `task_type=scaleswe`).
  - `configs/debug/v1/scaleswe.toml` → `taskset.id=scaleswe-v1`, `harness.id=rlm`, `runtime=prime`.
- The `scaleswe-v1` taskset is validated end-to-end in verifiers#1616: a 100-rollout glm-5.1 eval (rlm harness, prime runtime) scored 49/100 (51.6% among cleanly-completed), with 0 taskset/scoring errors.
