### PR TITLE
Register Nano V3 reasoning parser

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/utils/parsers.py
+++ b/packages/prime-rl-configs/src/prime_rl/utils/parsers.py
@@ -22,6 +22,8 @@ REASONING_PARSER_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"^zai-org/GLM-"), "glm45"),
     (re.compile(r"^MiniMaxAI/MiniMax-M2"), "minimax_m2_append_think"),
     (re.compile(r"^PrimeIntellect/INTELLECT-3"), "deepseek_r1"),
+    (re.compile(r"^nvidia/NVIDIA-Nemotron-3-Super"), "nemotron_v3"),
+    (re.compile(r"^nvidia/NVIDIA-Nemotron-3-Nano"), "nano_v3"),
     (re.compile(r"^stepfun-ai/Step-3\.5"), "step3p5"),
     # Only Qwen3 Thinking models reason — Instruct/base models do not.
     (re.compile(r"^Qwen/Qwen3-.*Thinking"), "deepseek_r1"),

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -32,11 +32,7 @@ def monkey_patch_nano_v3_reasoning_parser():
             reasoning_content, final_content = super().extract_reasoning(model_output, request)
             chat_template_kwargs = getattr(request, "chat_template_kwargs", None)
 
-            if (
-                chat_template_kwargs
-                and chat_template_kwargs.get("enable_thinking") is False
-                and final_content is None
-            ):
+            if chat_template_kwargs and chat_template_kwargs.get("enable_thinking") is False and final_content is None:
                 reasoning_content, final_content = final_content, reasoning_content
 
             return reasoning_content, final_content

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -17,9 +17,31 @@ def transformers_v5_compat():
 
     _patch_qwen35_lora()
     _patch_lora_key_prefix()
+    monkey_patch_nano_v3_reasoning_parser()
     monkey_patch_deep_gemm_silu_mul_quant_int64()
     monkey_patch_vllm_padded_input_scrub()
     monkey_patch_return_routed_experts_with_nixl_connector()
+
+
+def monkey_patch_nano_v3_reasoning_parser():
+    from vllm.reasoning.abs_reasoning_parsers import ReasoningParserManager
+    from vllm.reasoning.deepseek_r1_reasoning_parser import DeepSeekR1ReasoningParser
+
+    class NanoV3ReasoningParser(DeepSeekR1ReasoningParser):
+        def extract_reasoning(self, model_output, request):
+            reasoning_content, final_content = super().extract_reasoning(model_output, request)
+            chat_template_kwargs = getattr(request, "chat_template_kwargs", None)
+
+            if (
+                chat_template_kwargs
+                and chat_template_kwargs.get("enable_thinking") is False
+                and final_content is None
+            ):
+                reasoning_content, final_content = final_content, reasoning_content
+
+            return reasoning_content, final_content
+
+    ReasoningParserManager.register_module("nano_v3", module=NanoV3ReasoningParser)
 
 
 def monkey_patch_return_routed_experts_with_nixl_connector():

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -22,6 +22,7 @@ logger = get_logger()
 from prime_rl.inference.patches import (
     monkey_patch_harmony_stop_token_propagation,
     monkey_patch_load_lora_adapter,
+    monkey_patch_nano_v3_reasoning_parser,
     monkey_patch_tokenize_params_validation,
     monkey_patch_vllm_padded_input_scrub,
 )
@@ -35,6 +36,9 @@ monkey_patch_load_lora_adapter()
 # NOTE: Monkeypatch TokenizeParams to fix overly conservative validation
 # Still needed in vLLM 0.20 — upstream rejects prompt_len > max_model_len - max_tokens
 monkey_patch_tokenize_params_validation()
+# NOTE: Register Nano V3 reasoning parser so configs can use
+# `reasoning_parser = "nano_v3"` without a vLLM plugin file.
+monkey_patch_nano_v3_reasoning_parser()
 # NOTE: Optional mitigation for vLLM padded decode inputs until the native fix
 # is available in our pinned runtime.
 monkey_patch_vllm_padded_input_scrub()

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -38,8 +38,8 @@ EXPECTED_PARSERS: list[tuple[str, str | None, str | None]] = [
     ("PrimeIntellect/INTELLECT-3-FP8", "qwen3_coder", "deepseek_r1"),
     ("PrimeIntellect/INTELLECT-3.1", "qwen3_coder", "deepseek_r1"),
     # NemotronH
-    ("nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16", "qwen3_coder", None),
-    ("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", "qwen3_coder", None),
+    ("nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16", "qwen3_coder", "nemotron_v3"),
+    ("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", "qwen3_coder", "nano_v3"),
     # StepFun
     ("stepfun-ai/Step-3.5-Flash", "step3p5", "step3p5"),
     # Qwen3 dense


### PR DESCRIPTION
## Summary
- Register a prime-rl `nano_v3` vLLM reasoning parser from inference patches so the server can use it without `--reasoning-parser-plugin`.
- Auto-resolve Nemotron-3 Nano to `nano_v3` while resolving Nemotron-3 Super to vLLM's built-in `nemotron_v3` parser.
- Update parser resolution coverage for the Nemotron-3 Nano/Super split.

## Context
The standalone `nano_v3_reasoning_parser.py` behavior is intentionally narrower than vLLM's `nemotron_v3`: it subclasses `DeepSeekR1ReasoningParser` and only swaps parsed reasoning into final content when `enable_thinking=false` and no final content was parsed. Super continues using vLLM's broader `nemotron_v3` behavior.

## Verification
- `uv run pytest tests/unit/test_parsers.py`
- `uv run ruff check src/prime_rl/inference/patches.py src/prime_rl/inference/vllm/server.py packages/prime-rl-configs/src/prime_rl/utils/parsers.py tests/unit/test_parsers.py`
- `uv run pre-commit run --all-files`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Inference-only reasoning-parser registration and model-name resolution; narrow behavior change when `enable_thinking=false` on Nano models.
> 
> **Overview**
> Registers a custom vLLM **`nano_v3`** reasoning parser at inference startup (general plugin + OpenAI server import) so **`reasoning_parser = "nano_v3"`** works without a separate vLLM plugin. The parser subclasses **`DeepSeekR1ReasoningParser`** and, when **`enable_thinking=false`** and no final content was parsed, swaps reasoning into the final content field.
> 
> **`REASONING_PARSER_PATTERNS`** now maps Nemotron-3 **Super** to vLLM’s built-in **`nemotron_v3`** and Nemotron-3 **Nano** to **`nano_v3`** (previously no reasoning parser). Unit expectations for those model IDs are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a71b9bc7e213922486d3c225d31ef3df3b0de65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->