### PR TITLE
feat(v1): R2E-Gym SWE config + r2e-gym-v1 taskset

### DIFF
--- a/configs/debug/v1/r2e_gym.toml
+++ b/configs/debug/v1/r2e_gym.toml
@@ -1,0 +1,101 @@
+# v1 SWE RL on R2E-Gym (R2E-Gym/R2E-Gym-Subset) with Qwen3.5-4B — the original
+# qwen3.5 SWE run, ported to the v1 `r2e-gym-v1` taskset on the rlm harness / prime
+# runtime. Same model / trainer / inference / orchestrator knobs as scaleswe.toml; only
+# the env blocks differ (taskset id + sandbox labels). Submits to slurm by default.
+#
+# NOTE: cross-node NCCL weight broadcast requires a working IB fabric; on clusters where
+# IB is unavailable, launch with `--weight-broadcast.type filesystem`.
+
+output_dir = "/beegfs/mika/r2e-gym-qwen35-4b"
+max_steps = 400
+seq_len = 65536
+
+[slurm]
+job_name = "r2e-gym-qwen35-4b"
+project_dir = "."
+pre_run_command = "prime sandbox delete --label r2e-gym-qwen35-4b -y --plain || true"
+
+[deployment]
+type = "multi_node"
+num_train_nodes = 1
+num_infer_nodes = 1
+num_infer_replicas = 2
+
+[wandb]
+project = "rlm-swe-debug"
+name = "r2e-gym-qwen35-4b"
+
+[weight_broadcast]
+type = "nccl"
+
+[ckpt]
+interval = 50
+keep_last = 1
+resume_step = -1
+
+[model]
+name = "Qwen/Qwen3.5-4B"
+
+# --- Trainer ---
+
+[trainer]
+
+[trainer.model]
+cp = 4
+cp_style = "ulysses"
+
+[trainer.model.ac]
+freq = 1
+
+[trainer.model.compile]
+
+# --- Orchestrator ---
+
+[orchestrator]
+batch_size = 256
+group_size = 8
+max_inflight_rollouts = 512
+max_off_policy_steps = 16
+
+# Thinking enabled for the Qwen3.5 renderer.
+[orchestrator.renderer]
+name = "qwen3.5"
+enable_thinking = true
+
+[orchestrator.train.sampling]
+temperature = 1.0
+
+[[orchestrator.train.env]]
+name = "rlm-swe-r2e-gym"
+num_workers = 4
+taskset = { id = "r2e-gym-v1" }
+harness = { id = "rlm", runtime = { type = "prime", labels = ["r2e-gym-qwen35-4b"] } }
+
+[orchestrator.prime_monitor]
+
+[orchestrator.eval]
+interval = 20
+
+[[orchestrator.eval.env]]
+name = "rlm-swe-r2e-gym-eval"
+num_workers = 4
+timeout = { rollout = 3600 }
+taskset = { id = "r2e-gym-v1" }
+harness = { id = "rlm", runtime = { type = "prime", labels = ["r2e-gym-qwen35-4b"] } }
+
+# --- Inference ---
+
+[inference]
+gpu_memory_utilization = 0.85
+enable_prefix_caching = true
+
+[inference.model]
+max_model_len = 65536
+
+[inference.parallel]
+dp = 8
+
+# Qwen3.5-4B is a VL model; skip the vision tower for text-only SWE.
+# `language_model_only` is a vLLM MultiModalConfig arg (no prime-rl field) → pass via vllm_extra.
+[inference.vllm_extra]
+language_model_only = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ envs = [
     "aime24-v1",
     "alphabet-sort-v1",
     "scaleswe-v1",
+    "r2e-gym-v1",
     "tasksets",
     "harnesses",
 ]
@@ -251,6 +252,7 @@ math-env-v1 = { path = "deps/verifiers/examples/tasksets/math_env_v1", editable 
 aime24-v1 = { path = "deps/verifiers/examples/tasksets/aime24_v1", editable = true }
 alphabet-sort-v1 = { path = "deps/verifiers/examples/tasksets/alphabet_sort_v1", editable = true }
 scaleswe-v1 = { path = "deps/verifiers/examples/tasksets/scaleswe_v1", editable = true }
+r2e-gym-v1 = { path = "deps/verifiers/examples/tasksets/r2e_gym_v1", editable = true }
 tasksets = { path = "deps/verifiers/packages/tasksets", editable = true }
 harnesses = { path = "deps/verifiers/packages/harnesses", editable = true }
 renderers = { path = "deps/renderers", editable = true }

--- a/uv.lock
+++ b/uv.lock
@@ -3632,9 +3632,11 @@ envs = [
     { name = "opencode-math", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "opencode-science", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "opencode-swe", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "r2e-gym-v1", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "reverse-text", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "reverse-text-v1", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "rlm-swe", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "scaleswe-v1", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "science-env", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "simpleqa-verified", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "tasksets", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -3739,12 +3741,14 @@ requires-dist = [
     { name = "pybase64", specifier = ">=1.4.2" },
     { name = "pyzmq", specifier = ">=27.1.0" },
     { name = "quack-kernels", marker = "extra == 'quack'", specifier = ">=0.4.1" },
+    { name = "r2e-gym-v1", marker = "extra == 'envs'", editable = "deps/verifiers/examples/tasksets/r2e_gym_v1" },
     { name = "renderers", editable = "deps/renderers" },
     { name = "reverse-text", marker = "extra == 'envs'", editable = "deps/verifiers/environments/reverse_text" },
     { name = "reverse-text-v1", marker = "extra == 'envs'", editable = "deps/verifiers/examples/tasksets/reverse_text_v1" },
     { name = "rich", specifier = ">=14.0.0" },
     { name = "ring-flash-attn", specifier = ">=0.1.8" },
     { name = "rlm-swe", marker = "extra == 'envs'", editable = "deps/research-environments/environments/rlm_swe" },
+    { name = "scaleswe-v1", marker = "extra == 'envs'", editable = "deps/verifiers/examples/tasksets/scaleswe_v1" },
     { name = "science-env", marker = "extra == 'envs'", editable = "deps/research-environments/environments/science_env" },
     { name = "setproctitle", specifier = ">=1.3.0" },
     { name = "simpleqa-verified", marker = "extra == 'envs'", editable = "deps/research-environments/environments/simpleqa_verified" },
@@ -4305,6 +4309,17 @@ wheels = [
 ]
 
 [[package]]
+name = "r2e-gym-v1"
+version = "0.1.0"
+source = { editable = "deps/verifiers/examples/tasksets/r2e_gym_v1" }
+dependencies = [
+    { name = "datasets", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "datasets" }]
+
+[[package]]
 name = "redis"
 version = "8.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4533,6 +4548,17 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/06/87/d26d8407c44175d8ae164a95b5a62707fcc445f3c0c56108e37d98070a3d/safetensors-0.7.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:cdab83a366799fa730f90a4ebb563e494f28e9e92c4819e556152ad55e43591b", size = 674060, upload-time = "2025-11-19T15:18:37.211Z" },
     { url = "https://files.pythonhosted.org/packages/4a/d8/0c8a7dc9b41dcac53c4cbf9df2b9c83e0e0097203de8b37a712b345c0be5/safetensors-0.7.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b0f6d66c1c538d5a94a73aa9ddca8ccc4227e6c9ff555322ea40bdd142391dd4", size = 677368, upload-time = "2025-11-19T15:18:41.627Z" },
 ]
+
+[[package]]
+name = "scaleswe-v1"
+version = "0.1.0"
+source = { editable = "deps/verifiers/examples/tasksets/scaleswe_v1" }
+dependencies = [
+    { name = "datasets", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "datasets" }]
 
 [[package]]
 name = "science-env"


### PR DESCRIPTION
Adapts the Qwen3.5-4B SWE config (the original qwen3.5 run) to run on **R2E-Gym** via the new `r2e-gym-v1` taskset, replacing scaleswe.

## What
- `configs/debug/v1/r2e_gym.toml` — Qwen3.5-4B SWE RL on `R2E-Gym/R2E-Gym-Subset` (env → `r2e-gym-v1`, `rlm` harness, prime runtime); same model/trainer/inference/orchestrator knobs as `scaleswe.toml`.
- Registers `r2e-gym-v1` in `pyproject.toml` (`[tool.uv.sources]` + the env extra) and bumps the `deps/verifiers` submodule to the branch carrying the taskset.

## Cross-repo dependency
- Taskset lives in **PrimeIntellect-ai/verifiers#1624** (base `feat/nano-as-v1`). Merge that first, then the submodule pin here updates to the merged commit.

## Validation
- `uv run rl @ configs/debug/v1/r2e_gym.toml --dry-run` resolves (taskset loads, `rlm`/prime wired).
- Taskset end-to-end dummy rollouts on real R2E-Gym prime sandboxes: base→`0.0`, gold→`1.0` (see verifiers PR).

Note: on this cluster cross-node NCCL/IB is down, so a real launch needs `--weight-broadcast.type filesystem`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)