### PR TITLE
fix: restore env-server worker logs to the env log file

### DIFF
--- a/src/prime_rl/orchestrator/env_server/env_server.py
+++ b/src/prime_rl/orchestrator/env_server/env_server.py
@@ -1,29 +1,28 @@
+from functools import partial
+
 from verifiers.v1.serve import serve_env
 
 from prime_rl.configs.env_server import EnvServerConfig
-from prime_rl.orchestrator.utils import intercept_vf_logging
+from prime_rl.orchestrator.utils import setup_env_server_logging
 from prime_rl.utils.config import cli
-from prime_rl.utils.logger import setup_logger
 from prime_rl.utils.process import set_proc_title
 from prime_rl.utils.utils import clean_exit
 
 
 @clean_exit
 def run_server(config: EnvServerConfig):
-    setup_logger(config.log.level, json_logging=config.log.json_logging)
-    # Route v1's stdlib logging (the server's own logs) through our handler.
-    intercept_vf_logging(logger="verifiers.v1", level=config.log.level)
-
     env = config.env
     address = env.address or "tcp://127.0.0.1:5000"
     # A single in-process server (num_workers=1) or a router + worker pool (>1); a v0/legacy
     # env runs through the bridge, a v1 env is a native taskset — both serve vf.Trace over
-    # the same protocol, so the orchestrator is agnostic.
+    # the same protocol, so the orchestrator is agnostic. serve_env applies the logging setup
+    # in this process and in every spawned worker.
     server_kwargs = {"env_id": env.env_id, "env_args": env.args} if env.is_legacy else {"config": env}
     serve_env(
         num_workers=env.num_workers,
         legacy=env.is_legacy,
         address=address,
+        log_setup=partial(setup_env_server_logging, config.log.level, config.log.json_logging),
         **server_kwargs,
     )
 

--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -46,21 +46,27 @@ def _run_env_server(
     legacy: bool = False,
     **kwargs,
 ) -> None:
-    """Spawned-process entry point: send the env server's output (its logging + any
-    subprocess-runtime output) to ``log_file``, then serve via ``serve_env`` — a single
-    in-process server when ``num_workers <= 1``, else a router + worker pool. Top-level so
-    it stays picklable for the ``spawn`` start method. ``legacy`` picks the v0 bridge."""
+    """Spawned-process entry point: redirect this process's output to ``log_file`` (the
+    server's logging + any subprocess-runtime output), then serve via ``serve_env`` — a single
+    in-process server when ``num_workers <= 1``, else a router + worker pool. ``serve_env``
+    applies ``log_setup`` here and in every spawned worker; a worker inherits this process's
+    redirected stdout/stderr, so its per-rollout logs reach ``log_file`` too. Top-level so it
+    stays picklable for the ``spawn`` start method. ``legacy`` picks the v0 bridge."""
+    from functools import partial
+
     from verifiers.v1.serve import serve_env
 
-    from prime_rl.orchestrator.utils import intercept_vf_logging
-    from prime_rl.utils.logger import setup_logger
+    from prime_rl.orchestrator.utils import setup_env_server_logging
 
     fh = open(log_file, "w", buffering=1)
     os.dup2(fh.fileno(), sys.stdout.fileno())
     os.dup2(fh.fileno(), sys.stderr.fileno())
-    setup_logger(log_level, json_logging=json_logging)
-    intercept_vf_logging(logger="verifiers.v1", level=log_level)
-    serve_env(num_workers=num_workers, legacy=legacy, **kwargs)
+    serve_env(
+        num_workers=num_workers,
+        legacy=legacy,
+        log_setup=partial(setup_env_server_logging, log_level, json_logging),
+        **kwargs,
+    )
 
 
 class Env:

--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -12,7 +12,7 @@ import verifiers.v1 as vf
 from prime_rl.configs.orchestrator import OrchestratorConfig
 from prime_rl.transport import TrainingSample
 from prime_rl.utils.client import setup_inference_pool
-from prime_rl.utils.logger import InterceptHandler, get_logger
+from prime_rl.utils.logger import InterceptHandler, get_logger, setup_logger
 from prime_rl.utils.utils import (
     get_broadcast_dir,
     get_ckpt_dir,
@@ -72,6 +72,15 @@ def intercept_vf_logging(logger: str = "verifiers", level: str = "DEBUG", prefix
     vf_logger.addHandler(InterceptHandler(prefix=prefix))
     vf_logger.setLevel(level.upper())
     vf_logger.propagate = False
+
+
+def setup_env_server_logging(log_level: str, json_logging: bool = False) -> None:
+    """Configure logging for an env-server process: prime-rl's logger + routing v1's stdlib
+    logs through it. Passed to verifiers' ``serve_env`` so it runs in the broker and in every
+    spawned worker — fresh ``spawn`` processes that otherwise have no handlers and would drop
+    their per-rollout logs."""
+    setup_logger(log_level, json_logging=json_logging)
+    intercept_vf_logging(logger="verifiers.v1", level=log_level)
 
 
 def set_default_executor(max_workers: int = 64) -> None:


### PR DESCRIPTION
## Summary

Restores per-rollout logging from the orchestrator's env servers. Env servers spawn their worker pool as fresh `spawn` processes with no logging handlers (companion to verifiers#1626), so the per-rollout signal we rely on — `rollout start` / `rollout done: reward=… turns=… stop=…`, `ProgramError`/context-exceed warnings — was silently dropped from the env logs while rollouts ran fine.

- **`orchestrator/utils.py`** — new `setup_env_server_logging(log_level, json_logging)`: prime-rl's logger + routing v1's stdlib logs through it. Single source for the broker and the workers.
- **`orchestrator/envs.py`** / **`orchestrator/env_server/env_server.py`** — pass it to verifiers' `serve_env` as `log_setup`; `serve_env` applies it in the broker/in-process server **and** in every spawned worker.

The orchestrator-spawned broker still redirects its `stdout`/`stderr` to `envs/{train,eval}/<name>.log`; a worker inherits those fds, so its rollout logs land in the **same file as before** — no new files or per-worker paths.

## Verification

A focused spawn test reproducing the path (broker redirects `stdout`→file, then `mp` `spawn` a worker that runs `setup_env_server_logging` and logs via `verifiers.v1.rollout`) confirms the worker line reaches the broker's file:

```
   INFO WORKER_MARKER rollout done reward=1.000
```

The pool plumbing itself is validated in verifiers#1626 (`eval --num_workers 2 --rich false` surfaces the previously-dropped worker `rollout start`/`rollout done` lines). `ruff` clean.

## Dependency

Depends on **verifiers#1626** (`serve_env`'s `log_setup`). `deps/verifiers` is bumped to that branch; it should be re-pointed to the verifiers merge commit once #1626 lands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging/observability only; no rollout, scoring, or auth behavior changes, aside from depending on the verifiers `log_setup` API.
> 
> **Overview**
> **Restores per-rollout env logs** (`rollout start` / `rollout done`, warnings, etc.) that were dropped when env servers use a multi-worker pool: worker processes are fresh `spawn` children with no logging handlers.
> 
> Adds **`setup_env_server_logging`** in `orchestrator/utils.py` as the single hook (prime-rl `setup_logger` + `intercept_vf_logging` for `verifiers.v1`). Both **`env_server.py`** and orchestrator **`_run_env_server`** in `envs.py` stop configuring logging locally and instead pass `log_setup=partial(setup_env_server_logging, …)` into verifiers’ **`serve_env`**, so the broker and every spawned worker get the same configuration. Orchestrator-spawned brokers still redirect stdout/stderr to `envs/{train,eval}/<name>.log`; workers inherit those fds, so rollout lines land in the same file as before.
> 
> Requires verifiers support for `serve_env`’s `log_setup` (companion change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 504e4af5cfed1a5265887109388fbcbe7fa7cc29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->