### PR TITLE
feat: elastic env-server pool (inherit static/elastic pool config)

### DIFF
--- a/configs/debug/v1/r2e_gym.toml
+++ b/configs/debug/v1/r2e_gym.toml
@@ -63,7 +63,7 @@ temperature = 1.0
 
 [[orchestrator.train.env]]
 name = "rlm-swe-r2e"
-num_workers = 4
+pool = { type = "elastic", multiplex = 128 }
 taskset = { id = "r2e-gym-v1" }
 harness = { id = "rlm", runtime = { type = "prime", labels = ["rlm-swe-qwen35-4b"] } }
 

--- a/configs/debug/v1/r2e_gym.toml
+++ b/configs/debug/v1/r2e_gym.toml
@@ -63,7 +63,6 @@ temperature = 1.0
 
 [[orchestrator.train.env]]
 name = "rlm-swe-r2e"
-pool = { type = "elastic", multiplex = 128 }
 taskset = { id = "r2e-gym-v1" }
 harness = { id = "rlm", runtime = { type = "prime", labels = ["rlm-swe-qwen35-4b"] } }
 

--- a/configs/rlm_swe/qwen35_4b.toml
+++ b/configs/rlm_swe/qwen35_4b.toml
@@ -60,7 +60,6 @@ temperature = 1.0
 [[orchestrator.train.env]]
 id = "rlm_swe"
 name = "rlm-swe-r2e"
-pool = { type = "elastic", multiplex = 128 }
 
 [orchestrator.train.env.args]
 labels = ["rlm-swe-qwen35-4b"]
@@ -73,7 +72,6 @@ interval = 20
 [[orchestrator.eval.env]]
 id = "rlm_swe"
 name = "rlm-swe-swebench-verified-quick"
-pool = { type = "elastic", multiplex = 128 }
 timeout = { rollout = 3600 }
 
 [orchestrator.eval.env.args]

--- a/configs/rlm_swe/qwen35_4b.toml
+++ b/configs/rlm_swe/qwen35_4b.toml
@@ -60,7 +60,7 @@ temperature = 1.0
 [[orchestrator.train.env]]
 id = "rlm_swe"
 name = "rlm-swe-r2e"
-num_workers = 4
+pool = { type = "elastic", multiplex = 128 }
 
 [orchestrator.train.env.args]
 labels = ["rlm-swe-qwen35-4b"]
@@ -73,7 +73,7 @@ interval = 20
 [[orchestrator.eval.env]]
 id = "rlm_swe"
 name = "rlm-swe-swebench-verified-quick"
-num_workers = 4
+pool = { type = "elastic", multiplex = 128 }
 timeout = { rollout = 3600 }
 
 [orchestrator.eval.env.args]

--- a/packages/prime-rl-configs/src/prime_rl/configs/env_server.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/env_server.py
@@ -1,7 +1,5 @@
 from pathlib import Path
 
-from pydantic import model_validator
-
 from prime_rl.configs.orchestrator import EnvConfig
 from prime_rl.configs.shared import LogConfig
 from prime_rl.utils.config import BaseConfig
@@ -17,11 +15,3 @@ class EnvServerConfig(BaseConfig):
 
     output_dir: Path = Path("outputs")
     """Directory to write outputs to — logs and any generated artifacts are written as subdirectories."""
-
-    @model_validator(mode="after")
-    def resolve_num_workers(self):
-        # The standalone env server has no concurrency context to scale from (it's driven by
-        # external clients), so ``auto`` can't mean per-rollout scaling here — it's just 4.
-        if self.env.num_workers == "auto":
-            self.env.num_workers = 4
-        return self

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -167,6 +167,18 @@ class EnvConfig(vf.EnvServerConfig):
     args: dict = Field(default_factory=dict)
     """Kwargs passed to the v0 env's ``load_environment`` (only used when ``id`` is set)."""
 
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_num_workers(cls, data):
+        """Back-compat: the removed ``num_workers`` maps onto ``pool`` — an int becomes a
+        fixed ``static`` pool, ``"auto"`` falls through to the default ``elastic`` pool. An
+        explicit ``pool`` always wins."""
+        if isinstance(data, dict) and "num_workers" in data:
+            num_workers = data.pop("num_workers")
+            if "pool" not in data and num_workers != "auto":
+                data["pool"] = {"type": "static", "num_workers": num_workers}
+        return data
+
     @property
     def is_legacy(self) -> bool:
         """A v0/legacy env (run via the bridge): an ``id`` is set and no v1 ``taskset`` is."""

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -1,4 +1,3 @@
-import math
 import warnings
 from pathlib import Path
 from typing import Annotated, Any, Literal, TypeAlias
@@ -143,20 +142,18 @@ class EvalSamplingConfig(BaseConfig):
         return data
 
 
-class EnvConfig(vf.EnvConfig):
+class EnvConfig(vf.EnvServerConfig):
     """A v1 environment — its ``taskset`` + ``harness`` (reused from ``vf.EnvConfig``,
-    resolved to their specific config types by ``id`` via vf's shared validator) plus
-    prime-rl's orchestration knobs. Timeouts come from ``vf.TimeoutConfig``
+    resolved to their specific config types by ``id`` via vf's shared validator) plus the
+    worker ``pool`` (from ``vf.EnvServerConfig``: ``static`` or ``elastic``, default
+    elastic) and prime-rl's orchestration knobs. Timeouts come from ``vf.TimeoutConfig``
     (``timeout.rollout`` / ``timeout.scoring``)."""
 
     name: str | None = None
     """Display name for this environment in logs, metrics, and buffer keys. Defaults to the taskset id. Must be unique across all envs in the same group."""
 
     address: str | None = None
-    """ZMQ address of an external env server (e.g. ``tcp://host:5000``). When set, the orchestrator connects to this server instead of spawning one; when None, a subprocess env server is spawned automatically."""
-
-    num_workers: int | Literal["auto"] = "auto"
-    """Worker processes for the spawned env server. ``auto`` scales to 1 worker per 256 concurrent rollouts. Ignored when ``address`` is set."""
+    """ZMQ address of an external env server (e.g. ``tcp://host:5000``). When set, the orchestrator connects to this server instead of spawning one; when None, a subprocess env server is spawned automatically. The ``pool`` sizes the spawned server."""
 
     ratio: float | None = Field(None, gt=0)
     """Sampling weight for this environment in the buffer. When None for all envs, samples uniformly across all available problems. When set, must be set on all envs — values are relative weights normalized to probabilities (e.g. [1, 1] and [0.5, 0.5] are equivalent)."""
@@ -238,15 +235,13 @@ class TrainConfig(BaseConfig):
     sampling: TrainSamplingConfig = TrainSamplingConfig()
     """Shared training sampling configuration."""
 
-    num_workers: int | Literal["auto"] = "auto"
-    """Default worker processes for env servers. Can be overridden per env."""
-
     max_retries: int = Field(3, ge=0)
     """Default retries for failed rollouts. Can be overridden per env."""
 
     @model_validator(mode="after")
     def resolve_env_defaults(self):
-        """Resolve per-env overrides: inherit group-level sampling, num_workers, and max_retries."""
+        """Resolve per-env overrides: inherit group-level sampling and max_retries (the
+        worker ``pool`` is configured per env, defaulting to elastic)."""
         group_sampling = self.sampling.model_dump()
         for env in self.env:
             if "sampling" not in env.model_fields_set:
@@ -254,8 +249,6 @@ class TrainConfig(BaseConfig):
             else:
                 merged = group_sampling | env.sampling.model_dump(exclude_unset=True)
                 env.sampling = TrainSamplingConfig(**merged)
-            if "num_workers" not in env.model_fields_set:
-                env.num_workers = self.num_workers
             if "max_retries" not in env.model_fields_set:
                 env.max_retries = self.max_retries
         return self
@@ -293,9 +286,6 @@ class EvalConfig(BaseConfig):
     group_size: int = Field(1, ge=1, validation_alias=AliasChoices("group_size", "rollouts_per_example"))
     """Default rollouts per example. Can be overridden per env."""
 
-    num_workers: int | Literal["auto"] = "auto"
-    """Default worker processes for env servers. Can be overridden per env."""
-
     max_retries: int = Field(3, ge=0)
     """Default retries for failed rollouts. Can be overridden per env."""
 
@@ -308,7 +298,8 @@ class EvalConfig(BaseConfig):
 
     @model_validator(mode="after")
     def resolve_env_defaults(self):
-        """Resolve per-env overrides: inherit group-level sampling, num_workers, max_retries, num_examples, group_size, and interval. Then resolve auto num_workers."""
+        """Resolve per-env overrides: inherit group-level sampling, max_retries, num_examples,
+        group_size, and interval (the worker ``pool`` is configured per env, default elastic)."""
         group_sampling = self.sampling.model_dump()
         for env in self.env:
             if "sampling" not in env.model_fields_set:
@@ -322,17 +313,8 @@ class EvalConfig(BaseConfig):
                 env.group_size = self.group_size
             if "interval" not in env.model_fields_set:
                 env.interval = self.interval
-            if "num_workers" not in env.model_fields_set:
-                env.num_workers = self.num_workers
             if "max_retries" not in env.model_fields_set:
                 env.max_retries = self.max_retries
-            # Resolve auto num_workers now that num_examples and group_size are set
-            if env.num_workers == "auto":
-                if env.num_examples == -1:
-                    env.num_workers = 4
-                else:
-                    max_concurrent = env.num_examples * env.group_size
-                    env.num_workers = max(1, math.ceil(max_concurrent / 256))
         return self
 
     @model_validator(mode="after")
@@ -823,12 +805,6 @@ class OrchestratorConfig(BaseConfig):
         for env_cfg in self.train.env:
             if "group_size" not in env_cfg.model_fields_set:
                 env_cfg.group_size = self.group_size
-
-        # Resolve train env num_workers from max_inflight_rollouts
-        for env_cfg in self.train.env:
-            if env_cfg.num_workers == "auto":
-                assert self.max_inflight_rollouts is not None
-                env_cfg.num_workers = max(1, math.ceil(self.max_inflight_rollouts / 256))
 
         return self
 

--- a/src/prime_rl/orchestrator/env_server/env_server.py
+++ b/src/prime_rl/orchestrator/env_server/env_server.py
@@ -1,5 +1,6 @@
 from functools import partial
 
+from verifiers.v1 import pool_serve_kwargs
 from verifiers.v1.serve import serve_env
 
 from prime_rl.configs.env_server import EnvServerConfig
@@ -13,13 +14,13 @@ from prime_rl.utils.utils import clean_exit
 def run_server(config: EnvServerConfig):
     env = config.env
     address = env.address or "tcp://127.0.0.1:5000"
-    # A single in-process server (num_workers=1) or a router + worker pool (>1); a v0/legacy
-    # env runs through the bridge, a v1 env is a native taskset — both serve vf.Trace over
-    # the same protocol, so the orchestrator is agnostic. serve_env applies the logging setup
-    # in this process and in every spawned worker.
+    # The env's ``pool`` (static or elastic) sizes the server; a v0/legacy env runs through
+    # the bridge, a v1 env is a native taskset — both serve vf.Trace over the same protocol,
+    # so the orchestrator is agnostic. serve_env applies the logging setup in this process
+    # and in every spawned worker.
     server_kwargs = {"env_id": env.env_id, "env_args": env.args} if env.is_legacy else {"config": env}
     serve_env(
-        num_workers=env.num_workers,
+        **pool_serve_kwargs(env.pool),
         legacy=env.is_legacy,
         address=address,
         log_setup=partial(setup_env_server_logging, config.log.level, config.log.json_logging),

--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -42,16 +42,16 @@ def _run_env_server(
     log_file: str,
     log_level: str,
     json_logging: bool,
-    num_workers: int = 1,
     legacy: bool = False,
     **kwargs,
 ) -> None:
     """Spawned-process entry point: redirect this process's output to ``log_file`` (the
-    server's logging + any subprocess-runtime output), then serve via ``serve_env`` — a single
-    in-process server when ``num_workers <= 1``, else a router + worker pool. ``serve_env``
-    applies ``log_setup`` here and in every spawned worker; a worker inherits this process's
-    redirected stdout/stderr, so its per-rollout logs reach ``log_file`` too. Top-level so it
-    stays picklable for the ``spawn`` start method. ``legacy`` picks the v0 bridge."""
+    server's logging + any subprocess-runtime output), then serve via ``serve_env``. The
+    worker-pool sizing arrives in ``kwargs`` (``max_workers`` / ``multiplex`` / ``elastic``
+    from the env's ``pool``). ``serve_env`` applies ``log_setup`` here and in every spawned
+    worker; a worker inherits this process's redirected stdout/stderr, so its per-rollout
+    logs reach ``log_file`` too. Top-level so it stays picklable for the ``spawn`` start
+    method. ``legacy`` picks the v0 bridge."""
     from functools import partial
 
     from verifiers.v1.serve import serve_env
@@ -62,7 +62,6 @@ def _run_env_server(
     os.dup2(fh.fileno(), sys.stdout.fileno())
     os.dup2(fh.fileno(), sys.stderr.fileno())
     serve_env(
-        num_workers=num_workers,
         legacy=legacy,
         log_setup=partial(setup_env_server_logging, log_level, json_logging),
         **kwargs,
@@ -135,14 +134,13 @@ class Env:
             if self.config.is_legacy
             else dict(legacy=False, config=self.config)
         )
-        num_workers = self.config.num_workers
         process = ctx.Process(
             target=_run_env_server,
             kwargs=dict(
                 log_file=str(log_file),
                 log_level=log_level,
                 json_logging=json_logging,
-                num_workers=4 if num_workers == "auto" else num_workers,
+                **vf.pool_serve_kwargs(self.config.pool),
                 address="tcp://127.0.0.1:0",
                 address_queue=address_queue,
                 **server_kwargs,


### PR DESCRIPTION
## Summary

Companion to verifiers#1629. prime-rl's `EnvConfig` now extends `vf.EnvServerConfig`, so each env inherits the `pool` discriminated union (`static{num_workers=4}` | `elastic{max_workers=None, multiplex=128}`, **default elastic**) and the orchestrator's spawned env servers scale workers on demand instead of pre-spawning a fixed `auto` count.

- **`orchestrator.py`** — drop the per-env / train-group / eval-group `num_workers` fields and the `auto` resolution (`ceil(max_inflight / 256)`); the elastic pool self-sizes from load via `multiplex`.
- **`envs.py` / `env_server.py`** — pass `vf.pool_serve_kwargs(env.pool)` to `serve_env`.
- **Back-compat shim** — a `model_validator(mode="before")` on `EnvConfig` maps the removed `num_workers` onto `pool` (int → `static`, `"auto"` → `elastic`; explicit `pool` wins), so existing configs that still set `num_workers` keep parsing without edits.
- **`deps/verifiers`** bumped to the elastic-pool branch.
- Migrated `configs/rlm_swe/qwen35_4b.toml` and `configs/debug/v1/r2e_gym.toml` to explicit `pool = { type = "elastic", multiplex = 128 }`.

## Migration

`num_workers` is superseded by `pool` but still accepted (back-compat shim): `num_workers = N` behaves as `pool = { type = "static", num_workers = N }`, `num_workers = "auto"` as the default elastic pool. New configs should set `pool = { type = "elastic", max_workers = N, multiplex = M }` (cap; omit `max_workers` for unbounded) or `pool = { type = "static", num_workers = N }`.

## Dependency

Depends on **verifiers#1629** (`EnvServerConfig`, the `pool` union, `pool_serve_kwargs`). `deps/verifiers` is pinned to that branch; re-point to its merge commit once #1629 lands.

## Verification

- **v1 RL e2e** (`configs/debug/v1/reverse_text.toml`, `reverse-text-v1` taskset, Qwen3-0.6B, 2 GPUs, 3 steps): the orchestrator spawned the elastic pool (`elastic=True, multiplex=128`) over a native `EnvServer` and **auto-scaled 1→2** at in-flight 116; 711 rollouts, training finished, checkpoint written.
- **v0 RL e2e** (`examples/reverse_text/rl.toml`, legacy bridge): elastic pool over `LegacyEnvServer`, scaled 1→2, training finished.
- Back-compat shim unit-checked (int→static, auto→elastic, explicit pool wins). `ruff` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout concurrency and env-server scaling behavior (elastic vs precomputed fixed workers), which can affect throughput and resource use during training; config migration is shimmed but operational semantics differ from `num_workers = "auto"`.
> 
> **Overview**
> **Env worker sizing moves from `num_workers` / `"auto"` to verifiers’ per-env `pool` (`static` or `elastic`, default elastic).** `EnvConfig` now extends `vf.EnvServerConfig`; train/eval group-level `num_workers` and orchestrator logic that resolved `"auto"` from `max_inflight_rollouts` or eval concurrency are removed.
> 
> Spawned and standalone env servers call `serve_env` with `pool_serve_kwargs(env.pool)` instead of a fixed `num_workers`. A **back-compat validator** still accepts `num_workers`: integer → `static` pool, `"auto"` → default elastic; explicit `pool` wins. Standalone `EnvServerConfig` no longer forces `auto` → 4.
> 
> Sample SWE configs drop explicit `num_workers` so they use the default elastic pool.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbcaaab4d3fa97cf05b3276e8226675b6ab09481. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->