### PR TITLE
chore: stop importing env modules in the orchestrator (always Rollout[WireTask])

### DIFF
--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -4,11 +4,12 @@ Each ``Env`` owns a v1 ``EnvServer`` (spawned as a child process, or an
 external one given by ``config.address``) and an ``EnvClient`` to drive it. The
 orchestrator never *runs* an environment: it asks the server for ``info``
 (``num_tasks`` + whether group scoring is needed), then runs rollouts purely by
-**task index**. The server returns a ``Trace`` (minus its computed fields) which we
-validate into a typed ``Trace[EnvTask]`` — so the rest of the orchestrator works
-with a real ``vf.Trace`` (typed task fields included), never a loose dict. To type
-the task we import the env's ``Task`` subclass (the env package is installed in this
-venv); the env's *runtime* still only ever executes in the server.
+**task index**. The server returns a ``Trace`` (minus its computed fields) which we validate into a
+``Trace[WireTask]`` — a real ``vf.Trace`` (never a loose dict) whose task keeps the env's
+task-specific fields as extras (``WireTask`` allows them). The orchestrator never imports the
+env package: the env's *type* and *runtime* both live only in the server, and the orchestrator
+drives it purely by task index. (Nothing here reads typed env task fields — only ``task.idx``
+and a full ``task.model_dump``, both of which ``WireTask`` preserves.)
 """
 
 from __future__ import annotations
@@ -76,12 +77,11 @@ class Env:
         self.sampling_args: dict = {}
         self.num_tasks: int = 0
         self.requires_group_scoring: bool = False
-        # Typed Rollout for this env (prime-rl's Trace subclass parametrized with the env's
-        # Task subclass), used to validate the wire trace into a typed Rollout — the env's task
-        # fields plus prime-rl's orchestration metadata (defaulted here, set by the dispatcher).
-        # v0/legacy envs return Trace[WireTask] (no v1 Task subclass to import); v1 envs type
-        # the trace with the taskset's Task subclass.
-        self.trace_type = Rollout[vf.WireTask] if config.is_legacy else Rollout[vf.task_type(config.env_id)]
+        # Validate the wire trace into a Rollout (prime-rl's Trace subclass) carrying the env's
+        # task fields as extras + prime-rl's orchestration metadata (defaulted here, set by the
+        # dispatcher). WireTask (extra="allow") keeps those fields without importing the env
+        # package — the orchestrator never reads them typed (only task.idx + task.model_dump).
+        self.trace_type = Rollout[vf.WireTask]
         self._env_client: EnvClient | None = None
         self._env_server_process: BaseProcess | None = None
 
@@ -175,8 +175,7 @@ class Env:
             model=model_name,
             sampling=self._sampling(cache_salt),
         )
-        # The server types the trace as Trace[WireTask] (env fields in model_extra);
-        # upgrade to this env's real Task subclass.
+        # Re-validate into our Rollout type; the env's task fields ride along as WireTask extras.
         return self.trace_type.model_validate(wire.to_wire())
 
     async def run_group(

--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -32,6 +32,11 @@ from prime_rl.configs.orchestrator import EnvConfig, EvalEnvConfig, TrainEnvConf
 from prime_rl.orchestrator.types import Rollout
 from prime_rl.utils.logger import get_logger
 
+# Every wire trace validates into this type. WireTask (extra="allow") keeps the env's task
+# fields without importing the env package — the orchestrator never reads them typed (only
+# task.idx + task.model_dump).
+ROLLOUT_TYPE = Rollout[vf.WireTask]
+
 # Max wait for a spawned env server to bind and report its address. The child
 # loads the taskset (possibly downloading a dataset) before reporting, so this
 # is generous.
@@ -77,11 +82,6 @@ class Env:
         self.sampling_args: dict = {}
         self.num_tasks: int = 0
         self.requires_group_scoring: bool = False
-        # Validate the wire trace into a Rollout (prime-rl's Trace subclass) carrying the env's
-        # task fields as extras + prime-rl's orchestration metadata (defaulted here, set by the
-        # dispatcher). WireTask (extra="allow") keeps those fields without importing the env
-        # package — the orchestrator never reads them typed (only task.idx + task.model_dump).
-        self.trace_type = Rollout[vf.WireTask]
         self._env_client: EnvClient | None = None
         self._env_server_process: BaseProcess | None = None
 
@@ -175,8 +175,7 @@ class Env:
             model=model_name,
             sampling=self._sampling(cache_salt),
         )
-        # Re-validate into our Rollout type; the env's task fields ride along as WireTask extras.
-        return self.trace_type.model_validate(wire.to_wire())
+        return ROLLOUT_TYPE.model_validate(wire.to_wire())
 
     async def run_group(
         self, client: vf.ClientConfig, task_idx: int, model_name: str, group_size: int, cache_salt: str | None
@@ -189,7 +188,7 @@ class Env:
             model=model_name,
             sampling=self._sampling(cache_salt),
         )
-        return [self.trace_type.model_validate(wire.to_wire()) for wire in wires]
+        return [ROLLOUT_TYPE.model_validate(wire.to_wire()) for wire in wires]
 
     def shutdown(self) -> None:
         if self._env_server_process is None:


### PR DESCRIPTION
## Summary

- The orchestrator built its per-env `trace_type` as `Rollout[vf.task_type(env_id)]` for v1 envs — and `vf.task_type` **imports the env package** just to read its `Task` subclass for typing the wire trace.
- Nothing in the orchestrator/trainer reads typed env-specific task fields — only `task.idx` and a full `task.model_dump()`. And `WireTask` (`extra="allow"`) already preserves env-specific task fields (in `model_extra`), **including when serialized to the rollout jsonl**.
- So always use `Rollout[vf.WireTask]`. **The orchestrator no longer imports any env module** — the env's *type* and *runtime* now both live only in the server process; the orchestrator drives everything by task index over `EnvClient`.

## Why it's safe

- Every `.task.<field>` access in prime-rl is `task.idx` or `task.model_dump()` — both behave identically under `WireTask`. (The lone `.task.cancel` hit is an asyncio `Task`, not a vf one.)
- `WireTask` keeps **and serializes** the env's task fields: a validated `Rollout[vf.WireTask]` round-trips `{idx, instruction, answer, difficulty}` and `model_dump(mode="json")` still emits `answer`/`difficulty`.
- `vf.task_type` was the only env-import site in the orchestrator (the generic `import_object` helper has no callers). Removed.

## Implication

- The orchestrator venv no longer needs each env package importable just to type traces. Env-specific task fields still land on disk via `model_extra` — they were never consumed typed anyway.

## Verification

- `ruff check` + `ruff format --check` clean.
- Sanity: `Rollout[vf.WireTask].model_validate({...env extras...})` preserves the extras and `model_dump` re-emits them.
- Full RL e2e not run (change is confined to wire-trace typing on the orchestrator side; the validation path is exercised by the sanity check).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Typing-only change on wire trace validation; orchestrator already only uses `task.idx` and `task.model_dump()`, with extras preserved via `WireTask`.
> 
> **Overview**
> The orchestrator no longer picks a per-env trace type via `vf.task_type(env_id)` (which imported each env package only for typing). Wire traces from `run_rollout` / `run_group` are always validated as **`Rollout[vf.WireTask]`** through a shared `ROLLOUT_TYPE` constant.
> 
> **`WireTask`** (`extra="allow"`) still carries env-specific task fields on the wire and in serialized rollouts; the orchestrator only relies on **`task.idx`** and **`task.model_dump()`**, so behavior and jsonl output stay the same while the orchestrator venv no longer needs env packages importable for trace typing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e2143368909b20e06a7333a779b4f5e87de343e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->