### PR TITLE
fix(inference): restore usage block on /inference/v1/generate

### DIFF
--- a/src/prime_rl/inference/vllm/serving_tokens.py
+++ b/src/prime_rl/inference/vllm/serving_tokens.py
@@ -342,10 +342,7 @@ class PrimeRlServingTokens(ServingTokens):
             # actually surfaces in JSON (the parent class would drop it).
             response = PrimeRlGenerateResponse(
                 request_id=response.request_id,
-                choices=[
-                    PrimeRlGenerateResponseChoice(**choice.model_dump())
-                    for choice in response.choices
-                ],
+                choices=[PrimeRlGenerateResponseChoice(**choice.model_dump()) for choice in response.choices],
                 prompt_logprobs=response.prompt_logprobs,
                 kv_transfer_params=response.kv_transfer_params,
             )

--- a/src/prime_rl/inference/vllm/serving_tokens.py
+++ b/src/prime_rl/inference/vllm/serving_tokens.py
@@ -30,7 +30,7 @@ delegates to upstream so we track future vLLM changes for free.
 
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, AsyncIterable
 from functools import cached_property
 from typing import Any
 
@@ -93,7 +93,7 @@ class _FinalOutputCapture:
     after delegating iteration to upstream.
     """
 
-    def __init__(self, source: AsyncGenerator[RequestOutput, None]) -> None:
+    def __init__(self, source: AsyncIterable[RequestOutput]) -> None:
         # ``source`` may be any async-iterable — including
         # ``_GenerateRoutedExpertsCapture``, which exposes the protocol via
         # ``async def __aiter__`` (an async generator function) and has no

--- a/src/prime_rl/inference/vllm/serving_tokens.py
+++ b/src/prime_rl/inference/vllm/serving_tokens.py
@@ -108,7 +108,7 @@ class _FinalOutputCapture:
             yield item
 
 
-def _build_usage(final_res: RequestOutput, enable_cached_tokens: bool) -> UsageInfo:
+def _build_usage(final_res: RequestOutput) -> UsageInfo:
     assert final_res.prompt_token_ids is not None
     num_prompt_tokens = len(final_res.prompt_token_ids)
     if final_res.encoder_prompt_token_ids is not None:
@@ -119,7 +119,11 @@ def _build_usage(final_res: RequestOutput, enable_cached_tokens: bool) -> UsageI
         completion_tokens=num_generated_tokens,
         total_tokens=num_prompt_tokens + num_generated_tokens,
     )
-    if enable_cached_tokens and final_res.num_cached_tokens:
+    # Always emit cached tokens when vLLM reports any. Upstream gates this on
+    # ``enable_prompt_tokens_details`` (default False) for OpenAI-API compat,
+    # but ``/inference/v1/generate`` is prime-rl internal — the cache-discount
+    # billing pipeline always wants the cached subset surfaced.
+    if final_res.num_cached_tokens:
         usage.prompt_tokens_details = PromptTokenUsageInfo(cached_tokens=final_res.num_cached_tokens)
     return usage
 
@@ -350,9 +354,6 @@ class PrimeRlServingTokens(ServingTokens):
             )
 
         if final_capture.final_res is not None:
-            response.usage = _build_usage(
-                final_capture.final_res,
-                enable_cached_tokens=self.enable_prompt_tokens_details,
-            )
+            response.usage = _build_usage(final_capture.final_res)
 
         return response

--- a/src/prime_rl/inference/vllm/serving_tokens.py
+++ b/src/prime_rl/inference/vllm/serving_tokens.py
@@ -94,16 +94,18 @@ class _FinalOutputCapture:
     """
 
     def __init__(self, source: AsyncGenerator[RequestOutput, None]) -> None:
+        # ``source`` may be any async-iterable — including
+        # ``_GenerateRoutedExpertsCapture``, which exposes the protocol via
+        # ``async def __aiter__`` (an async generator function) and has no
+        # ``__anext__`` method. Drive it through ``async for`` rather than
+        # poking ``__anext__`` directly so both shapes work.
         self._source = source
         self.final_res: RequestOutput | None = None
 
-    def __aiter__(self) -> "_FinalOutputCapture":
-        return self
-
-    async def __anext__(self) -> RequestOutput:
-        item = await self._source.__anext__()
-        self.final_res = item
-        return item
+    async def __aiter__(self) -> AsyncGenerator[RequestOutput, None]:
+        async for item in self._source:
+            self.final_res = item
+            yield item
 
 
 def _build_usage(final_res: RequestOutput, enable_cached_tokens: bool) -> UsageInfo:

--- a/src/prime_rl/inference/vllm/serving_tokens.py
+++ b/src/prime_rl/inference/vllm/serving_tokens.py
@@ -35,7 +35,12 @@ from functools import cached_property
 from typing import Any
 
 from fastapi import Request
-from vllm.entrypoints.openai.engine.protocol import ErrorResponse, RequestResponseMetadata
+from vllm.entrypoints.openai.engine.protocol import (
+    ErrorResponse,
+    PromptTokenUsageInfo,
+    RequestResponseMetadata,
+    UsageInfo,
+)
 from vllm.entrypoints.serve.disagg.protocol import (
     GenerateRequest,
     GenerateResponse,
@@ -55,6 +60,12 @@ class PrimeRlGenerateResponseChoice(GenerateResponseChoice):
 
 class PrimeRlGenerateResponse(GenerateResponse):
     choices: list[PrimeRlGenerateResponseChoice]
+    # Upstream ``GenerateResponse`` doesn't declare a ``usage`` field, so the
+    # parent ``ServingTokens.serve_tokens_full_generator`` constructs it and
+    # Pydantic silently drops it on serialization. Declare it here so the
+    # router can extract per-run token counts (and cached-prefix tokens) for
+    # platform billing — see https://github.com/PrimeIntellect-ai/router/pull/43.
+    usage: UsageInfo | None = None
 
 
 class _GenerateRoutedExpertsCapture(RoutedExpertsCapture):
@@ -72,6 +83,43 @@ class _GenerateRoutedExpertsCapture(RoutedExpertsCapture):
             prompt_logprobs=response.prompt_logprobs,
             kv_transfer_params=response.kv_transfer_params,
         )
+
+
+class _FinalOutputCapture:
+    """Wraps a ``RequestOutput`` async generator to record the last yielded item.
+
+    Needed so the response builder can construct a ``usage`` block from
+    ``final_res.prompt_token_ids`` / ``output.token_ids`` / ``num_cached_tokens``
+    after delegating iteration to upstream.
+    """
+
+    def __init__(self, source: AsyncGenerator[RequestOutput, None]) -> None:
+        self._source = source
+        self.final_res: RequestOutput | None = None
+
+    def __aiter__(self) -> "_FinalOutputCapture":
+        return self
+
+    async def __anext__(self) -> RequestOutput:
+        item = await self._source.__anext__()
+        self.final_res = item
+        return item
+
+
+def _build_usage(final_res: RequestOutput, enable_cached_tokens: bool) -> UsageInfo:
+    assert final_res.prompt_token_ids is not None
+    num_prompt_tokens = len(final_res.prompt_token_ids)
+    if final_res.encoder_prompt_token_ids is not None:
+        num_prompt_tokens += len(final_res.encoder_prompt_token_ids)
+    num_generated_tokens = sum(len(output.token_ids) for output in final_res.outputs)
+    usage = UsageInfo(
+        prompt_tokens=num_prompt_tokens,
+        completion_tokens=num_generated_tokens,
+        total_tokens=num_prompt_tokens + num_generated_tokens,
+    )
+    if enable_cached_tokens and final_res.num_cached_tokens:
+        usage.prompt_tokens_details = PromptTokenUsageInfo(cached_tokens=final_res.num_cached_tokens)
+    return usage
 
 
 async def _client_set_max_tokens(raw_request: Request | None) -> bool:
@@ -273,11 +321,39 @@ class PrimeRlServingTokens(ServingTokens):
             )
             result_generator = capture
 
+        # Always capture the final ``RequestOutput`` so we can attach a
+        # ``usage`` block to the response. The router parses ``usage`` for
+        # per-run billing metrics; without it the cache-discount counter
+        # (``vllm_router_run_cached_prompt_tokens_total``) stays at zero.
+        final_capture = _FinalOutputCapture(result_generator)
+        result_generator = final_capture
+
         response = await super().serve_tokens_full_generator(
             request, result_generator, request_id, model_name, request_metadata
         )
 
-        if capture is not None and isinstance(response, GenerateResponse):
+        if not isinstance(response, GenerateResponse):
+            return response
+
+        if capture is not None:
             response = capture.post_process(response)
+        elif not isinstance(response, PrimeRlGenerateResponse):
+            # Upgrade to the prime-rl subclass so the declared ``usage`` field
+            # actually surfaces in JSON (the parent class would drop it).
+            response = PrimeRlGenerateResponse(
+                request_id=response.request_id,
+                choices=[
+                    PrimeRlGenerateResponseChoice(**choice.model_dump())
+                    for choice in response.choices
+                ],
+                prompt_logprobs=response.prompt_logprobs,
+                kv_transfer_params=response.kv_transfer_params,
+            )
+
+        if final_capture.final_res is not None:
+            response.usage = _build_usage(
+                final_capture.final_res,
+                enable_cached_tokens=self.enable_prompt_tokens_details,
+            )
 
         return response

--- a/tests/unit/inference/test_serving_tokens.py
+++ b/tests/unit/inference/test_serving_tokens.py
@@ -154,7 +154,7 @@ def test_build_usage_sums_prompt_and_completion_tokens():
         prompt_token_ids=[1, 2, 3, 4, 5],
         output_token_ids_list=[[10, 11], [20, 21, 22]],
     )
-    usage = _build_usage(final_res, enable_cached_tokens=True)
+    usage = _build_usage(final_res)
     assert usage.prompt_tokens == 5
     assert usage.completion_tokens == 5  # 2 + 3
     assert usage.total_tokens == 10
@@ -167,41 +167,33 @@ def test_build_usage_includes_encoder_prompt_tokens():
         output_token_ids_list=[[10]],
         encoder_prompt_token_ids=[100, 101],
     )
-    usage = _build_usage(final_res, enable_cached_tokens=False)
+    usage = _build_usage(final_res)
     assert usage.prompt_tokens == 5  # 3 + 2
     assert usage.total_tokens == 6
 
 
-def test_build_usage_reports_cached_tokens_when_enabled():
+def test_build_usage_reports_cached_tokens_unconditionally():
+    # Unlike upstream's ``enable_prompt_tokens_details`` gate, prime-rl always
+    # surfaces cached tokens — the cache-discount billing pipeline needs them.
     final_res = _FakeRequestOutput(
         prompt_token_ids=[1, 2, 3, 4],
         output_token_ids_list=[[10, 11]],
         num_cached_tokens=3,
     )
-    usage = _build_usage(final_res, enable_cached_tokens=True)
+    usage = _build_usage(final_res)
     assert usage.prompt_tokens_details is not None
     assert usage.prompt_tokens_details.cached_tokens == 3
 
 
-def test_build_usage_skips_cached_tokens_when_disabled():
-    final_res = _FakeRequestOutput(
-        prompt_token_ids=[1, 2, 3, 4],
-        output_token_ids_list=[[10, 11]],
-        num_cached_tokens=3,
-    )
-    usage = _build_usage(final_res, enable_cached_tokens=False)
-    assert usage.prompt_tokens_details is None
-
-
 def test_build_usage_skips_cached_tokens_when_zero():
-    # Mirrors upstream behavior — don't emit a details block with cached=0,
-    # which would be misleading to the router's billing extractor.
+    # Don't emit a details block with cached=0, which would be misleading
+    # to the router's billing extractor.
     final_res = _FakeRequestOutput(
         prompt_token_ids=[1, 2, 3, 4],
         output_token_ids_list=[[10, 11]],
         num_cached_tokens=0,
     )
-    usage = _build_usage(final_res, enable_cached_tokens=True)
+    usage = _build_usage(final_res)
     assert usage.prompt_tokens_details is None
 
 

--- a/tests/unit/inference/test_serving_tokens.py
+++ b/tests/unit/inference/test_serving_tokens.py
@@ -224,6 +224,36 @@ def test_final_output_capture_records_last_item():
     assert capture.final_res.prompt_token_ids == [1, 2, 3]
 
 
+def test_final_output_capture_works_over_async_def_aiter_source():
+    # ``_GenerateRoutedExpertsCapture`` exposes the async-iterator protocol
+    # via ``async def __aiter__`` (an async generator function) and has no
+    # ``__anext__``. The wrapper must drive it through ``async for`` rather
+    # than poking ``__anext__`` directly, or routed-experts runs raise
+    # AttributeError before the response is built.
+
+    class _AsyncGenAiterSource:
+        def __init__(self, items):
+            self._items = items
+
+        async def __aiter__(self):
+            for item in self._items:
+                yield item
+
+    items = [
+        _FakeRequestOutput(prompt_token_ids=[1], output_token_ids_list=[[1]]),
+        _FakeRequestOutput(prompt_token_ids=[1, 2], output_token_ids_list=[[1, 2]]),
+    ]
+    capture = _FinalOutputCapture(_AsyncGenAiterSource(items))
+
+    async def _drain():
+        async for _ in capture:
+            pass
+
+    asyncio.run(_drain())
+    assert capture.final_res is not None
+    assert capture.final_res.prompt_token_ids == [1, 2]
+
+
 def test_final_output_capture_handles_empty_stream():
     capture = _FinalOutputCapture(_empty_request_outputs())
 

--- a/tests/unit/inference/test_serving_tokens.py
+++ b/tests/unit/inference/test_serving_tokens.py
@@ -14,12 +14,17 @@ import asyncio
 
 import numpy as np
 import pybase64
+from vllm.entrypoints.openai.engine.protocol import UsageInfo
 from vllm.entrypoints.serve.disagg.protocol import GenerateResponse, GenerateResponseChoice
 
 from prime_rl.inference.vllm.routed_experts import serialize_routed_experts
 from prime_rl.inference.vllm.serving_tokens import (
+    PrimeRlGenerateResponse,
+    PrimeRlGenerateResponseChoice,
     PrimeRlServingTokens,
+    _build_usage,
     _client_set_max_tokens,
+    _FinalOutputCapture,
     _GenerateRoutedExpertsCapture,
 )
 
@@ -103,6 +108,131 @@ def test_client_set_max_tokens_detects_unset():
 
     body_without_sp = {"token_ids": [1, 2, 3]}
     assert asyncio.run(_client_set_max_tokens(_FakeRawRequest(body_without_sp))) is False
+
+
+class _FakeOutput:
+    def __init__(self, token_ids):
+        self.token_ids = token_ids
+
+
+class _FakeRequestOutput:
+    """Minimal stand-in for ``vllm.outputs.RequestOutput``.
+
+    ``_build_usage`` only touches four attributes; constructing a real
+    ``RequestOutput`` would require a full ``CompletionOutput`` graph and
+    isn't worth it for a serialization-shape test.
+    """
+
+    def __init__(self, prompt_token_ids, output_token_ids_list, num_cached_tokens=0, encoder_prompt_token_ids=None):
+        self.prompt_token_ids = prompt_token_ids
+        self.encoder_prompt_token_ids = encoder_prompt_token_ids
+        self.outputs = [_FakeOutput(t) for t in output_token_ids_list]
+        self.num_cached_tokens = num_cached_tokens
+
+
+def test_prime_rl_generate_response_serializes_usage_block():
+    # Regression for prime-rl PR #2408: parent ``GenerateResponse`` doesn't
+    # declare ``usage``, so the field must be declared on the subclass for
+    # Pydantic to emit it in JSON. Without this the router can't extract
+    # per-run token / cache counts for billing.
+    response = PrimeRlGenerateResponse(
+        request_id="req-1",
+        choices=[PrimeRlGenerateResponseChoice(index=0, token_ids=[1, 2, 3])],
+        usage=UsageInfo(prompt_tokens=4, completion_tokens=3, total_tokens=7),
+    )
+    payload = response.model_dump(mode="json")
+    assert payload["usage"] == {
+        "prompt_tokens": 4,
+        "completion_tokens": 3,
+        "total_tokens": 7,
+        "prompt_tokens_details": None,
+    }
+
+
+def test_build_usage_sums_prompt_and_completion_tokens():
+    final_res = _FakeRequestOutput(
+        prompt_token_ids=[1, 2, 3, 4, 5],
+        output_token_ids_list=[[10, 11], [20, 21, 22]],
+    )
+    usage = _build_usage(final_res, enable_cached_tokens=True)
+    assert usage.prompt_tokens == 5
+    assert usage.completion_tokens == 5  # 2 + 3
+    assert usage.total_tokens == 10
+    assert usage.prompt_tokens_details is None
+
+
+def test_build_usage_includes_encoder_prompt_tokens():
+    final_res = _FakeRequestOutput(
+        prompt_token_ids=[1, 2, 3],
+        output_token_ids_list=[[10]],
+        encoder_prompt_token_ids=[100, 101],
+    )
+    usage = _build_usage(final_res, enable_cached_tokens=False)
+    assert usage.prompt_tokens == 5  # 3 + 2
+    assert usage.total_tokens == 6
+
+
+def test_build_usage_reports_cached_tokens_when_enabled():
+    final_res = _FakeRequestOutput(
+        prompt_token_ids=[1, 2, 3, 4],
+        output_token_ids_list=[[10, 11]],
+        num_cached_tokens=3,
+    )
+    usage = _build_usage(final_res, enable_cached_tokens=True)
+    assert usage.prompt_tokens_details is not None
+    assert usage.prompt_tokens_details.cached_tokens == 3
+
+
+def test_build_usage_skips_cached_tokens_when_disabled():
+    final_res = _FakeRequestOutput(
+        prompt_token_ids=[1, 2, 3, 4],
+        output_token_ids_list=[[10, 11]],
+        num_cached_tokens=3,
+    )
+    usage = _build_usage(final_res, enable_cached_tokens=False)
+    assert usage.prompt_tokens_details is None
+
+
+def test_build_usage_skips_cached_tokens_when_zero():
+    # Mirrors upstream behavior — don't emit a details block with cached=0,
+    # which would be misleading to the router's billing extractor.
+    final_res = _FakeRequestOutput(
+        prompt_token_ids=[1, 2, 3, 4],
+        output_token_ids_list=[[10, 11]],
+        num_cached_tokens=0,
+    )
+    usage = _build_usage(final_res, enable_cached_tokens=True)
+    assert usage.prompt_tokens_details is None
+
+
+def test_final_output_capture_records_last_item():
+    async def _gen():
+        for r in [
+            _FakeRequestOutput(prompt_token_ids=[1], output_token_ids_list=[[1]]),
+            _FakeRequestOutput(prompt_token_ids=[1, 2], output_token_ids_list=[[1, 2]]),
+            _FakeRequestOutput(prompt_token_ids=[1, 2, 3], output_token_ids_list=[[1, 2, 3]]),
+        ]:
+            yield r
+
+    async def _drain(capture):
+        async for _ in capture:
+            pass
+
+    capture = _FinalOutputCapture(_gen())
+    asyncio.run(_drain(capture))
+    assert capture.final_res is not None
+    assert capture.final_res.prompt_token_ids == [1, 2, 3]
+
+
+def test_final_output_capture_handles_empty_stream():
+    capture = _FinalOutputCapture(_empty_request_outputs())
+
+    async def _drain():
+        async for _ in capture:
+            pass
+
+    asyncio.run(_drain())
+    assert capture.final_res is None
 
 
 def test_client_set_max_tokens_assumes_set_when_body_unreadable():


### PR DESCRIPTION
Restores the `usage` block on `/inference/v1/generate` responses so the router can extract per-run token counts (and cached-prefix tokens) for platform billing.

- Declares `usage` on `PrimeRlGenerateResponse` so Pydantic actually serializes it
- Captures the final `RequestOutput` and builds `UsageInfo` (incl. `prompt_tokens_details.cached_tokens` when enabled)

Regressed in #2408 when the endpoint moved from `serving_generate.py` (which declared `usage: dict`) to vLLM's `ServingTokens`, whose `GenerateResponse` doesn't declare `usage` — so router-side `extract_and_record_usage` has been a silent no-op on RL runs since 2026-05-11.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches inference response shape and platform billing metrics; behavior is additive and fixes a silent no-op for token/cache accounting rather than changing auth or data paths.
> 
> **Overview**
> Restores a **`usage`** block on **`/inference/v1/generate`** full responses so the router can bill per-run prompt/completion tokens and cached-prefix tokens (regression after moving onto vLLM **`ServingTokens`**, whose **`GenerateResponse`** omits **`usage`** and Pydantic dropped it on serialize).
> 
> **`PrimeRlGenerateResponse`** now declares **`usage: UsageInfo | None`**. The full-response path wraps the engine stream with **`_FinalOutputCapture`**, builds **`UsageInfo`** via **`_build_usage`** from the final **`RequestOutput`** (encoder prompt tokens included; **`prompt_tokens_details.cached_tokens`** emitted whenever vLLM reports cached tokens, without upstream’s **`enable_prompt_tokens_details`** gate), and upgrades non–routed-experts responses to the prime-rl subclass so **`usage`** appears in JSON. Unit tests cover serialization, usage math, and async-iterator compatibility with routed-experts capture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 628587d1dad9c1b2cdcc5718d254d3c4aa9338ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->