### PR TITLE
Fix/readme trainer torchrun

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,10 @@ uv run sft @ configs/debug/sft/train.toml
 4. Check that you can run the RL trainer (*this requires 1 GPU*)
 
 ```bash
-uv run trainer @ configs/debug/rl/train.toml
+uv run torchrun --nproc-per-node 1 -m prime_rl.entrypoints.trainer @ configs/debug/rl/train.toml
 ```
+
+*The `trainer` entrypoint expects to be launched under `torchrun` (normally handled automatically by the `rl` launcher), so it cannot be invoked directly.*
 
 5. Check that you can run the inference server (*this requires 1 GPU*)
 

--- a/README.md
+++ b/README.md
@@ -176,8 +176,6 @@ uv run inference @ configs/debug/infer.toml
 uv run orchestrator @ configs/debug/orch.toml
 ```
 
-*This runs the orchestrator standalone (no trainer); the debug config sets `wait_for_trainer = false` so it completes 5 steps and exits cleanly on its own.*
-
 5.2. Check that you can run evals against the inference server
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ uv run orchestrator @ configs/debug/orch.toml
 5.2. Check that you can run evals against the inference server
 
 ```bash
-uv run eval @ configs/debug/eval.toml
+uv run vf-eval reverse-text -m Qwen/Qwen3-0.6B -b http://localhost:8000/v1 -n 4 --max-tokens 64
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ uv run inference @ configs/debug/infer.toml
 uv run orchestrator @ configs/debug/orch.toml
 ```
 
+*This runs the orchestrator standalone (no trainer); the debug config sets `wait_for_trainer = false` so it completes 5 steps and exits cleanly on its own.*
+
 5.2. Check that you can run evals against the inference server
 
 ```bash

--- a/configs/debug/orch.toml
+++ b/configs/debug/orch.toml
@@ -1,6 +1,22 @@
 max_steps = 5
 batch_size = 16
 
+# Standalone validation run: no trainer is consuming batches, so don't gate
+# dispatch on weight broadcasts — ship all `max_steps` batches and exit.
+wait_for_trainer = false
+
 [train.sampling]
 max_completion_tokens = 16
 
+# With 16 completion tokens, all rollouts in a group score 0 reward, so every
+# advantage is zero. Keep the zero_advantage filter in monitor mode here —
+# the default (enforce) would drop 100% of rollouts and abort the run.
+[[post_batch_filters]]
+type = "gibberish"
+
+[[post_batch_filters]]
+type = "repetition"
+
+[[post_batch_filters]]
+type = "zero_advantage"
+enforce = false

--- a/configs/debug/orch.toml
+++ b/configs/debug/orch.toml
@@ -12,11 +12,5 @@ max_completion_tokens = 16
 # advantage is zero. Keep the zero_advantage filter in monitor mode here —
 # the default (enforce) would drop 100% of rollouts and abort the run.
 [[post_batch_filters]]
-type = "gibberish"
-
-[[post_batch_filters]]
-type = "repetition"
-
-[[post_batch_filters]]
 type = "zero_advantage"
 enforce = false

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -587,6 +587,9 @@ class OrchestratorConfig(BaseConfig):
     weight_broadcast: WeightBroadcastConfig = FileSystemWeightBroadcastConfig()
     """Transport used to receive updated weights from the trainer."""
 
+    wait_for_trainer: bool = True
+    """Gate rollout dispatch on trainer weight updates. When True, the dispatcher pauses once the orchestrator runs more than ``TARGET_LAG`` batches ahead of the trainer's policy version and resumes on the next weight broadcast. Set to False to run the orchestrator standalone without a trainer (e.g. debug/validation runs), in which case it ships all ``max_steps`` batches and exits."""
+
     rollout_transport: TransportConfig = FileSystemTransportConfig()
     """Transport used to ship rollouts from orchestrator to trainer."""
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -826,7 +826,11 @@ class Orchestrator:
         """Pause/resume the dispatcher based on how far the orchestrator's
         next batch would run ahead of ``policy.version``. Called from two
         sites: after shipping a batch (step advances) and from
-        ``on_new_version`` (policy advances)."""
+        ``on_new_version`` (policy advances). No-op (gate stays open) when
+        ``wait_for_trainer=False``, i.e. running standalone without a trainer."""
+        if not self.config.wait_for_trainer:
+            self.dispatcher.dispatch_allowed.set()
+            return
         lead = (self.progress.step + 1) - self.policy.version
         gate = self.dispatcher.dispatch_allowed
         was_set = gate.is_set()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Default orchestrator behavior is unchanged; changes are README/debug-config plus an opt-out flag for standalone validation runs.
> 
> **Overview**
> Fixes **environment validation** docs so the RL trainer step matches how `prime_rl.entrypoints.trainer` must be started (`torchrun`), and swaps the eval smoke test to **`vf-eval`** against a running inference server.
> 
> Adds **`wait_for_trainer`** on the orchestrator (default **true**). When **false**, `update_dispatch_gate` keeps dispatch open so **`configs/debug/orch.toml`** can finish **`max_steps`** without a trainer consuming weight updates. That debug config also sets **`zero_advantage`** post-batch filter to **monitor** mode so short completions that yield all-zero advantages do not abort the run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08a169a6643365d8fc82566803a9db62e1f13e0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->