### PR TITLE
fix: cap v1 hendrycks-sanity scoring at 10s

### DIFF
--- a/configs/debug/v1/hendrycks_sanity.toml
+++ b/configs/debug/v1/hendrycks_sanity.toml
@@ -30,8 +30,6 @@ seq_len = 8192
 name = "hendrycks-math"
 taskset = { id = "math-env-v1", dataset_name = "mikasenghaas/Sanity-Test-R1D-1.5B", dataset_subset = "default" }
 harness = { id = "default", enable_bash = false, runtime = { type = "subprocess" } }
-# Cap scoring so a wedged verify (sympy can outlive its in-script alarm) can't hold a
-# rollout's permit forever and stall the run; on timeout the verify subprocess is killed.
 timeout = { scoring = 10 }
 
 [orchestrator.eval]

--- a/configs/debug/v1/hendrycks_sanity.toml
+++ b/configs/debug/v1/hendrycks_sanity.toml
@@ -30,6 +30,9 @@ seq_len = 8192
 name = "hendrycks-math"
 taskset = { id = "math-env-v1", dataset_name = "mikasenghaas/Sanity-Test-R1D-1.5B", dataset_subset = "default" }
 harness = { id = "default", enable_bash = false, runtime = { type = "subprocess" } }
+# Cap scoring so a wedged verify (sympy can outlive its in-script alarm) can't hold a
+# rollout's permit forever and stall the run; on timeout the verify subprocess is killed.
+timeout = { scoring = 10 }
 
 [orchestrator.eval]
 interval = 50
@@ -38,6 +41,7 @@ interval = 50
 name = "aime2024"
 taskset = { id = "aime24-v1" }
 harness = { id = "default", enable_bash = false, runtime = { type = "subprocess" } }
+timeout = { scoring = 10 }
 group_size = 32
 
 [trainer.model]


### PR DESCRIPTION
## Summary

- Set `timeout.scoring = 10` on the train and eval envs in `configs/debug/v1/hendrycks_sanity.toml`.

The v1 scoring timeout defaults to **no limit**. The math taskset scores via a `uv`/subprocess `verify.py`, and sympy can spin past the script's own `signal.alarm` (it can't interrupt C-level work). With no framework timeout, a wedged verify never returns, so `Rollout.run`'s scoring stage (`asyncio.wait_for(taskset.score(...), scoring_timeout)`) waits forever, holding the rollout's dispatcher permit. At this config's 512 concurrency that starves the pool and stalls the run.

With `timeout.scoring = 10`, the framework cancels the scoring coroutine on timeout; the cancellation propagates into the subprocess runtime's `run`, which SIGKILLs the verify process group — freeing the permit.

Companion to verifiers#1660 (subprocess runtime runs uv-scripts via a cached interpreter). That removes `uv` from the per-rollout hot path; this caps the long tail so a single runaway verify can't wedge a long run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Debug-only TOML limits; no application logic changes, only tighter scoring timeouts on an existing sanity config.
> 
> **Overview**
> Sets **`timeout.scoring = 10`** on both **`[[orchestrator.train.env]]`** (`hendrycks-math`) and **`[[orchestrator.eval.env]]`** (`aime2024`) in `configs/debug/v1/hendrycks_sanity.toml`.
> 
> v1 scoring otherwise has **no framework timeout**; sympy-heavy `verify.py` can exceed in-script alarms and never return, so `Rollout` scoring holds a dispatcher permit and at **batch_size 512** can stall the whole run. The 10s cap lets the orchestrator cancel scoring and the subprocess runtime tear down wedged verify process groups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 359fbc59768179f97f1a6a5997acc71db564c92a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->