### PR TITLE
Add Xiaomi MiMo-V2.5 MoE model support

### DIFF
--- a/scripts/mini_moe.py
+++ b/scripts/mini_moe.py
@@ -26,6 +26,8 @@ from prime_rl.trainer.models.glm4_moe import Glm4MoeForCausalLM as PrimeRLGlm4Mo
 from prime_rl.trainer.models.laguna import LagunaConfig
 from prime_rl.trainer.models.laguna import LagunaForCausalLM as PrimeRLLagunaForCausalLM
 from prime_rl.trainer.models.layers.lm_head import inject_prime_lm_head
+from prime_rl.trainer.models.mimo_v2 import MiMoV2Config
+from prime_rl.trainer.models.mimo_v2 import MiMoV2ForCausalLM as PrimeRLMiMoV2ForCausalLM
 from prime_rl.trainer.models.minimax_m2 import MiniMaxM2Config
 from prime_rl.trainer.models.minimax_m2 import MiniMaxM2ForCausalLM as PrimeRLMiniMaxM2ForCausalLM
 from prime_rl.trainer.models.qwen3_5_moe import Qwen3_5MoeForCausalLM as PrimeRLQwen3_5MoeVLM
@@ -73,6 +75,15 @@ def _qwen3_5_moe_vlm_config():
     return config
 
 
+def _init_mimo_v2_biases(model):
+    """The MiMo-V2 remote code leaves sink/correction biases as torch.empty; give them
+    deterministic non-trivial values so the verification exercises them."""
+    with torch.no_grad():
+        for name, param in model.named_parameters():
+            if "attention_sink_bias" in name or "e_score_correction_bias" in name:
+                param.copy_(torch.linspace(-1.0, 1.0, param.numel()).view_as(param))
+
+
 ARCH_PRESETS = {
     "glm4_moe": {
         "config_class": Glm4MoeConfig,
@@ -103,6 +114,59 @@ ARCH_PRESETS = {
         "hf_model_class": HFGlm4MoeForCausalLM,
         "prime_model_class": PrimeRLGlm4MoeForCausalLM,
         "tokenizer_source": "THUDM/GLM-4-9B-0414",
+    },
+    "mimo_v2": {
+        "config_class": MiMoV2Config,
+        "config_kwargs": dict(
+            vocab_size=152576,
+            hidden_size=512,
+            intermediate_size=1024,
+            num_hidden_layers=8,
+            hybrid_layer_pattern=[0, 1, 1, 1, 0, 1, 1, 0],
+            num_attention_heads=8,
+            num_key_value_heads=2,
+            head_dim=96,
+            v_head_dim=64,
+            swa_num_attention_heads=8,
+            swa_num_key_value_heads=4,
+            swa_head_dim=96,
+            swa_v_head_dim=64,
+            sliding_window=32,
+            partial_rotary_factor=0.334,
+            rope_theta=10000000.0,
+            swa_rope_theta=10000.0,
+            attention_bias=False,
+            attention_value_scale=0.707,
+            add_full_attention_sink_bias=False,
+            add_swa_attention_sink_bias=True,
+            attention_projection_layout="fused_qkv",
+            hidden_act="silu",
+            max_position_embeddings=4096,
+            layernorm_epsilon=1e-5,
+            moe_layer_freq=[0, 1, 1, 1, 1, 1, 1, 1],
+            n_routed_experts=8,
+            num_experts_per_tok=4,
+            moe_intermediate_size=128,
+            norm_topk_prob=True,
+            routed_scaling_factor=None,
+            scoring_func="sigmoid",
+            topk_method="noaux_tc",
+            n_group=1,
+            topk_group=1,
+            use_grouped_mm=False,
+            pad_token_id=151643,
+            eos_token_id=151645,
+            auto_map={
+                "AutoConfig": "XiaomiMiMo/MiMo-V2.5--configuration_mimo_v2.MiMoV2Config",
+                "AutoModelForCausalLM": "XiaomiMiMo/MiMo-V2.5--modeling_mimo_v2.MiMoV2ForCausalLM",
+            },
+        ),
+        "hf_model_class": None,  # uses Xiaomi remote modeling code
+        "prime_model_class": PrimeRLMiMoV2ForCausalLM,
+        "tokenizer_source": "XiaomiMiMo/MiMo-V2.5",
+        "post_create_fn": _init_mimo_v2_biases,
+        # The remote code predates the transformers 5.x SDPA support declaration
+        "attn_implementation": "eager",
     },
     "minimax_m2": {
         "config_class": MiniMaxM2Config,
@@ -238,6 +302,9 @@ def create(arch: str, output_dir: Path) -> None:
     with torch.device("cpu"):
         model = _create_hf_model(preset, config)
 
+    if "post_create_fn" in preset:
+        preset["post_create_fn"](model)
+
     param_count = sum(p.numel() for p in model.parameters())
     print(f"  Parameters: {param_count / 1e6:.1f}M")
 
@@ -257,9 +324,10 @@ def verify(arch: str, model_dir: Path) -> None:
 
     trust_remote_code = preset["hf_model_class"] is None
     config = AutoConfig.from_pretrained(str(model_dir), trust_remote_code=trust_remote_code)
-    config._attn_implementation = "sdpa"
+    attn_implementation = preset.get("attn_implementation", "sdpa")
+    config._attn_implementation = attn_implementation
     if hasattr(config, "text_config"):
-        config.text_config._attn_implementation = "sdpa"
+        config.text_config._attn_implementation = attn_implementation
 
     text_config = getattr(config, "text_config", config)
     vocab_size = text_config.vocab_size

--- a/src/prime_rl/trainer/models/__init__.py
+++ b/src/prime_rl/trainer/models/__init__.py
@@ -17,6 +17,7 @@ from prime_rl.trainer.models.gpt_oss import GptOssConfig, GptOssForCausalLM
 from prime_rl.trainer.models.laguna import LagunaConfig, LagunaForCausalLM
 from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput, cast_float_and_contiguous
 from prime_rl.trainer.models.llama import LlamaForCausalLM
+from prime_rl.trainer.models.mimo_v2 import MiMoV2Config, MiMoV2ForCausalLM
 from prime_rl.trainer.models.minimax_m2 import MiniMaxM2Config, MiniMaxM2ForCausalLM
 from prime_rl.trainer.models.nemotron_h import NemotronHConfig, NemotronHForCausalLM
 from prime_rl.trainer.models.qwen3 import Qwen3ForCausalLM
@@ -28,6 +29,7 @@ AutoConfig.register("afmoe", AfmoeConfig, exist_ok=True)
 AutoConfig.register("glm4_moe", Glm4MoeConfig, exist_ok=True)
 AutoConfig.register("glm_moe_dsa", GlmMoeDsaConfig, exist_ok=True)
 AutoConfig.register("laguna", LagunaConfig, exist_ok=True)
+AutoConfig.register("mimo_v2", MiMoV2Config, exist_ok=True)
 AutoConfig.register("minimax_m2", MiniMaxM2Config, exist_ok=True)
 AutoConfig.register("nemotron_h", NemotronHConfig, exist_ok=True)
 AutoConfig.register("qwen3_moe", Qwen3MoeConfig, exist_ok=True)
@@ -41,6 +43,7 @@ _CUSTOM_CAUSAL_LM_MAPPING.register(AfmoeConfig, AfmoeForCausalLM, exist_ok=True)
 _CUSTOM_CAUSAL_LM_MAPPING.register(Glm4MoeConfig, Glm4MoeForCausalLM, exist_ok=True)
 _CUSTOM_CAUSAL_LM_MAPPING.register(GlmMoeDsaConfig, GlmMoeDsaForCausalLM, exist_ok=True)
 _CUSTOM_CAUSAL_LM_MAPPING.register(LagunaConfig, LagunaForCausalLM, exist_ok=True)
+_CUSTOM_CAUSAL_LM_MAPPING.register(MiMoV2Config, MiMoV2ForCausalLM, exist_ok=True)
 _CUSTOM_CAUSAL_LM_MAPPING.register(MiniMaxM2Config, MiniMaxM2ForCausalLM, exist_ok=True)
 _CUSTOM_CAUSAL_LM_MAPPING.register(NemotronHConfig, NemotronHForCausalLM, exist_ok=True)
 _CUSTOM_CAUSAL_LM_MAPPING.register(Qwen3MoeConfig, Qwen3MoeForCausalLM, exist_ok=True)

--- a/src/prime_rl/trainer/models/fp8.py
+++ b/src/prime_rl/trainer/models/fp8.py
@@ -2,6 +2,20 @@ import torch
 from torch import Tensor
 
 
+def dequantize_fp8_blockwise(
+    weight: Tensor, scale_inv: Tensor, block_size: int = 128, dtype: torch.dtype = torch.bfloat16
+) -> Tensor:
+    """Dequantize a 2D FP8 e4m3 tensor with per-block scales (DeepSeek `weight_scale_inv` convention)."""
+    if weight.ndim != 2:
+        raise ValueError(f"FP8 dequantization expects a 2D tensor, got shape={tuple(weight.shape)}")
+
+    rows, cols = weight.shape
+    expanded = (
+        scale_inv.float().repeat_interleave(block_size, dim=0)[:rows].repeat_interleave(block_size, dim=1)[:, :cols]
+    )
+    return (weight.float() * expanded).to(dtype)
+
+
 def quantize_to_fp8_blockwise(weight: Tensor, block_size: int = 128) -> tuple[Tensor, Tensor]:
     """Quantize a 2D tensor to FP8 e4m3 with per-block scales."""
     if weight.ndim != 2:

--- a/src/prime_rl/trainer/models/mimo_v2/__init__.py
+++ b/src/prime_rl/trainer/models/mimo_v2/__init__.py
@@ -1,0 +1,9 @@
+from prime_rl.trainer.models.mimo_v2.configuration_mimo_v2 import MiMoV2Config
+from prime_rl.trainer.models.mimo_v2.modeling_mimo_v2 import MiMoV2ForCausalLM, MiMoV2Model, MiMoV2PreTrainedModel
+
+__all__ = [
+    "MiMoV2Config",
+    "MiMoV2ForCausalLM",
+    "MiMoV2Model",
+    "MiMoV2PreTrainedModel",
+]

--- a/src/prime_rl/trainer/models/mimo_v2/configuration_mimo_v2.py
+++ b/src/prime_rl/trainer/models/mimo_v2/configuration_mimo_v2.py
@@ -1,0 +1,191 @@
+from transformers.configuration_utils import PretrainedConfig
+
+
+class MiMoV2Config(PretrainedConfig):
+    r"""
+    Configuration class for Xiaomi MiMo-V2 models. Instantiating a configuration with the defaults
+    will yield a configuration close to that of
+    [XiaomiMiMo/MiMo-V2.5](https://huggingface.co/XiaomiMiMo/MiMo-V2.5).
+
+    Field names follow the hub `config.json`. Only the text backbone is modeled; the hub
+    checkpoint's vision/audio towers and MTP layers are dropped during weight conversion.
+
+    Args:
+        vocab_size (`int`, *optional*, defaults to 152576):
+            Vocabulary size of the MiMo-V2 model.
+        hidden_size (`int`, *optional*, defaults to 4096):
+            Dimension of the hidden representations.
+        intermediate_size (`int`, *optional*, defaults to 16384):
+            Dimension of the dense MLP representations.
+        num_hidden_layers (`int`, *optional*, defaults to 48):
+            Number of hidden layers in the Transformer decoder (excluding MTP layers).
+        hybrid_layer_pattern (`list[int]`, *optional*):
+            Per-layer attention type: 0 = full attention, 1 = sliding-window attention.
+            Defaults to all-full if not given.
+        num_attention_heads (`int`, *optional*, defaults to 64):
+            Number of attention heads on full-attention layers.
+        num_key_value_heads (`int`, *optional*, defaults to 4):
+            Number of key/value heads on full-attention layers.
+        head_dim (`int`, *optional*, defaults to 192):
+            Query/key head dimension on full-attention layers.
+        v_head_dim (`int`, *optional*, defaults to 128):
+            Value head dimension on full-attention layers.
+        swa_num_attention_heads (`int`, *optional*, defaults to 64):
+            Number of attention heads on sliding-window layers.
+        swa_num_key_value_heads (`int`, *optional*, defaults to 8):
+            Number of key/value heads on sliding-window layers.
+        swa_head_dim (`int`, *optional*, defaults to 192):
+            Query/key head dimension on sliding-window layers.
+        swa_v_head_dim (`int`, *optional*, defaults to 128):
+            Value head dimension on sliding-window layers.
+        sliding_window (`int`, *optional*, defaults to 128):
+            Sliding window size for SWA layers.
+        partial_rotary_factor (`float`, *optional*, defaults to 0.334):
+            Fraction of the query/key head dimension that receives rotary embeddings.
+        rope_theta (`float`, *optional*, defaults to 10000000.0):
+            RoPE base for full-attention layers.
+        swa_rope_theta (`float`, *optional*, defaults to 10000.0):
+            RoPE base for sliding-window layers.
+        attention_value_scale (`float`, *optional*):
+            Scalar multiplier applied to the value states before attention.
+        add_full_attention_sink_bias (`bool`, *optional*, defaults to `False`):
+            Whether full-attention layers carry a per-head attention sink bias.
+        add_swa_attention_sink_bias (`bool`, *optional*, defaults to `True`):
+            Whether sliding-window layers carry a per-head attention sink bias.
+        attention_projection_layout (`str`, *optional*, defaults to `"fused_qkv"`):
+            Checkpoint layout of the attention projections. The PrimeRL implementation always uses
+            a fused qkv projection module; this field is kept for hub config compatibility.
+        moe_layer_freq (`list[int]`, *optional*):
+            Per-layer MLP type: 1 = MoE layer, 0 = dense layer. Defaults to all-dense if not given.
+        n_routed_experts (`int`, *optional*, defaults to 256):
+            Number of routed experts.
+        num_experts_per_tok (`int`, *optional*, defaults to 8):
+            Number of experts each token is routed to.
+        moe_intermediate_size (`int`, *optional*, defaults to 2048):
+            Intermediate size of each routed expert.
+        norm_topk_prob (`bool`, *optional*, defaults to `True`):
+            Whether to normalize the top-k routing weights to sum to 1.
+        routed_scaling_factor (`float`, *optional*):
+            Scaling factor applied to the routing weights. `None` means 1.0.
+        scoring_func (`str`, *optional*, defaults to `"sigmoid"`):
+            Router scoring function. Only `"sigmoid"` is supported.
+        topk_method (`str`, *optional*, defaults to `"noaux_tc"`):
+            Expert selection method. Only `"noaux_tc"` with `n_group=1` is supported.
+        layernorm_epsilon (`float`, *optional*, defaults to 1e-05):
+            The epsilon used by the rms normalization layers.
+    """
+
+    model_type = "mimo_v2"
+    keys_to_ignore_at_inference = ["past_key_values"]
+    attribute_map = {"num_local_experts": "n_routed_experts", "rms_norm_eps": "layernorm_epsilon"}
+
+    base_model_pp_plan = {
+        "embed_tokens": (["input_ids"], ["inputs_embeds"]),
+        "layers": (["hidden_states"], ["hidden_states"]),
+        "norm": (["hidden_states"], ["hidden_states"]),
+    }
+
+    def __init__(
+        self,
+        vocab_size=152576,
+        hidden_size=4096,
+        intermediate_size=16384,
+        num_hidden_layers=48,
+        hybrid_layer_pattern=None,
+        num_attention_heads=64,
+        num_key_value_heads=4,
+        head_dim=192,
+        v_head_dim=128,
+        swa_num_attention_heads=64,
+        swa_num_key_value_heads=8,
+        swa_head_dim=192,
+        swa_v_head_dim=128,
+        sliding_window=128,
+        partial_rotary_factor=0.334,
+        rope_theta=10000000.0,
+        swa_rope_theta=10000.0,
+        attention_bias=False,
+        attention_dropout=0.0,
+        attention_value_scale=None,
+        add_full_attention_sink_bias=False,
+        add_swa_attention_sink_bias=True,
+        attention_projection_layout="fused_qkv",
+        hidden_act="silu",
+        max_position_embeddings=1048576,
+        initializer_range=0.02,
+        layernorm_epsilon=1e-5,
+        use_cache=True,
+        tie_word_embeddings=False,
+        moe_layer_freq=None,
+        n_routed_experts=256,
+        num_experts_per_tok=8,
+        moe_intermediate_size=2048,
+        norm_topk_prob=True,
+        routed_scaling_factor=None,
+        scoring_func="sigmoid",
+        topk_method="noaux_tc",
+        n_group=1,
+        topk_group=1,
+        use_grouped_mm=True,
+        pad_token_id=None,
+        vision_config=None,
+        audio_config=None,
+        **kwargs,
+    ):
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.hybrid_layer_pattern = hybrid_layer_pattern or [0] * num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_key_value_heads = num_key_value_heads
+        self.head_dim = head_dim
+        self.v_head_dim = v_head_dim
+        self.swa_num_attention_heads = swa_num_attention_heads
+        self.swa_num_key_value_heads = swa_num_key_value_heads
+        self.swa_head_dim = swa_head_dim
+        self.swa_v_head_dim = swa_v_head_dim
+        self.sliding_window = sliding_window
+        # vLLM reads the window size under the hub config's alternate name
+        self.sliding_window_size = sliding_window
+        self.partial_rotary_factor = partial_rotary_factor
+        self.rope_theta = rope_theta
+        self.swa_rope_theta = swa_rope_theta
+        self.attention_bias = attention_bias
+        self.attention_dropout = attention_dropout
+        self.attention_value_scale = attention_value_scale
+        self.add_full_attention_sink_bias = add_full_attention_sink_bias
+        self.add_swa_attention_sink_bias = add_swa_attention_sink_bias
+        self.attention_projection_layout = attention_projection_layout
+        self.hidden_act = hidden_act
+        self.max_position_embeddings = max_position_embeddings
+        self.initializer_range = initializer_range
+        self.layernorm_epsilon = layernorm_epsilon
+        self.use_cache = use_cache
+        self.pad_token_id = pad_token_id
+        # Multimodal towers are not modeled; kept for hub config and remote-code compatibility
+        self.vision_config = vision_config
+        self.audio_config = audio_config
+
+        # Used by HF masking utils and renderers to identify the attention type per layer
+        self.layer_types = [
+            "sliding_attention" if pattern == 1 else "full_attention" for pattern in self.hybrid_layer_pattern
+        ]
+
+        # MoE arguments
+        self.moe_layer_freq = moe_layer_freq or [0] * num_hidden_layers
+        self.n_routed_experts = n_routed_experts
+        self.num_experts_per_tok = num_experts_per_tok
+        self.moe_intermediate_size = moe_intermediate_size
+        self.norm_topk_prob = norm_topk_prob
+        self.routed_scaling_factor = routed_scaling_factor
+        self.scoring_func = scoring_func
+        self.topk_method = topk_method
+        self.n_group = n_group
+        self.topk_group = topk_group
+        self.use_grouped_mm = use_grouped_mm
+
+        super().__init__(
+            tie_word_embeddings=tie_word_embeddings,
+            **kwargs,
+        )

--- a/src/prime_rl/trainer/models/mimo_v2/converting_mimo_v2.py
+++ b/src/prime_rl/trainer/models/mimo_v2/converting_mimo_v2.py
@@ -1,0 +1,104 @@
+import torch
+from torch import Tensor
+
+from prime_rl.trainer.models.fp8 import dequantize_fp8_blockwise
+
+# Towers and MTP layers present in the hub checkpoint that the text backbone does not train
+_DROPPED_PREFIXES = ("model.mtp.", "visual.", "audio_encoder.", "speech_embeddings.")
+
+
+def get_max_layer_num(state_dict: dict[str, Tensor]) -> int:
+    """Get the maximum number of layers in the model."""
+    return max(int(i.split(".")[2]) for i in state_dict.keys() if "model.layers." in i) + 1
+
+
+def _dequantize_layer(state_dict: dict[str, Tensor], prefix: str):
+    """Dequantize all block-wise FP8 weights under a layer prefix in-place."""
+    scale_keys = [k for k in state_dict if k.startswith(prefix) and k.endswith(".weight_scale_inv")]
+    for scale_key in scale_keys:
+        weight_key = scale_key.removesuffix("_scale_inv")
+        state_dict[weight_key] = dequantize_fp8_blockwise(state_dict[weight_key], state_dict.pop(scale_key))
+
+
+def convert_hf_layer_to_tt(state_dict: dict[str, Tensor], layer_idx: int):
+    """Convert a single layer from HF (hub) format to TT format in-place.
+
+    The attention projections (fused `qkv_proj`, `o_proj`) and the `attention_sink_bias` keep
+    their hub names; only the FP8 weights and the MoE block are converted.
+    """
+    i = layer_idx
+    prefix = f"model.layers.{i}."
+
+    _dequantize_layer(state_dict, prefix)
+
+    if f"{prefix}mlp.gate.weight" not in state_dict:
+        return  # dense layer
+
+    state_dict[f"{prefix}mlp.router.gate.weight"] = state_dict.pop(f"{prefix}mlp.gate.weight")
+    state_dict[f"{prefix}mlp.expert_bias"] = state_dict.pop(f"{prefix}mlp.gate.e_score_correction_bias")
+
+    num_experts = len([k for k in state_dict if f"{prefix}mlp.experts." in k]) // 3
+    if num_experts == 0:
+        return
+
+    reference = state_dict[f"{prefix}mlp.experts.0.down_proj.weight"]
+    dim, moe_dim = reference.shape
+    w1 = torch.empty((num_experts, moe_dim, dim), dtype=reference.dtype, device=reference.device)  # Gate
+    w2 = torch.empty((num_experts, dim, moe_dim), dtype=reference.dtype, device=reference.device)  # Down
+    w3 = torch.empty((num_experts, moe_dim, dim), dtype=reference.dtype, device=reference.device)  # Up
+    for j in range(num_experts):
+        w1[j].copy_(state_dict.pop(f"{prefix}mlp.experts.{j}.gate_proj.weight"))
+        w2[j].copy_(state_dict.pop(f"{prefix}mlp.experts.{j}.down_proj.weight"))
+        w3[j].copy_(state_dict.pop(f"{prefix}mlp.experts.{j}.up_proj.weight"))
+
+    state_dict[f"{prefix}mlp.experts.w1"] = w1
+    state_dict[f"{prefix}mlp.experts.w2"] = w2
+    state_dict[f"{prefix}mlp.experts.w3"] = w3
+
+
+def convert_hf_to_tt(state_dict: dict[str, Tensor]):
+    """Convert weights from HF (hub) format to TT format in-place."""
+    for key in [k for k in state_dict if k.startswith(_DROPPED_PREFIXES)]:
+        del state_dict[key]
+
+    num_layers = get_max_layer_num(state_dict)
+    for i in range(num_layers):
+        convert_hf_layer_to_tt(state_dict, i)
+
+
+def convert_tt_layer_to_hf(state_dict: dict[str, Tensor], layer_index: int):
+    """Convert a layer from TT to HF (hub) format in-place.
+
+    Emits BF16 weights with the hub key names. Re-quantizing to the hub's block-wise FP8 is not
+    performed here.
+    """
+    i = layer_index
+    prefix = f"model.layers.{i}."
+
+    # Load balancing stats are training-only state
+    if f"{prefix}mlp.tokens_per_expert" in state_dict:
+        del state_dict[f"{prefix}mlp.tokens_per_expert"]
+
+    if f"{prefix}mlp.router.gate.weight" not in state_dict:
+        return  # dense layer
+
+    state_dict[f"{prefix}mlp.gate.weight"] = state_dict.pop(f"{prefix}mlp.router.gate.weight")
+    state_dict[f"{prefix}mlp.gate.e_score_correction_bias"] = state_dict.pop(f"{prefix}mlp.expert_bias")
+
+    if f"{prefix}mlp.experts.w1" in state_dict:
+        w1 = state_dict.pop(f"{prefix}mlp.experts.w1")  # (num_experts, moe_dim, dim)
+        w2 = state_dict.pop(f"{prefix}mlp.experts.w2")  # (num_experts, dim, moe_dim)
+        w3 = state_dict.pop(f"{prefix}mlp.experts.w3")  # (num_experts, moe_dim, dim)
+
+        num_experts = w1.shape[0]
+        for j in range(num_experts):
+            state_dict[f"{prefix}mlp.experts.{j}.gate_proj.weight"] = w1[j]
+            state_dict[f"{prefix}mlp.experts.{j}.down_proj.weight"] = w2[j]
+            state_dict[f"{prefix}mlp.experts.{j}.up_proj.weight"] = w3[j]
+
+
+def convert_tt_to_hf(state_dict: dict[str, Tensor]):
+    """Convert weights from TT to HF (hub) format in-place."""
+    num_layers = get_max_layer_num(state_dict)
+    for i in range(num_layers):
+        convert_tt_layer_to_hf(state_dict, i)

--- a/src/prime_rl/trainer/models/mimo_v2/modeling_mimo_v2.py
+++ b/src/prime_rl/trainer/models/mimo_v2/modeling_mimo_v2.py
@@ -1,0 +1,586 @@
+# coding=utf-8
+# Copyright 2026 Xiaomi MiMo Team and The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+from typing import Optional, Union
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor, nn
+from transformers.cache_utils import Cache
+from transformers.generation import GenerationMixin
+from transformers.modeling_layers import GradientCheckpointingLayer
+from transformers.modeling_outputs import BaseModelOutputWithPast
+from transformers.processing_utils import Unpack
+from transformers.utils import TransformersKwargs
+from transformers.utils.generic import maybe_autocast
+
+from prime_rl.trainer.models.base import PreTrainedModelPrimeRL
+from prime_rl.trainer.models.layers.attn import FlashAttention
+from prime_rl.trainer.models.layers.lm_head import PrimeLmOutput
+from prime_rl.trainer.models.layers.mlp import MLP, MLPConfig
+from prime_rl.trainer.models.layers.moe import MoE, MoEArgs
+from prime_rl.trainer.models.layers.norms import RMSNorm, RMSNormConfig
+from prime_rl.trainer.models.layers.rotary_emb import apply_rotary_pos_emb
+from prime_rl.trainer.models.mimo_v2.configuration_mimo_v2 import MiMoV2Config
+from prime_rl.trainer.models.mimo_v2.converting_mimo_v2 import (
+    convert_hf_layer_to_tt,
+    convert_hf_to_tt,
+    convert_tt_layer_to_hf,
+    convert_tt_to_hf,
+)
+from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
+
+
+def _windowed_sink_attention(
+    query_states: torch.Tensor,
+    key_states: torch.Tensor,
+    value_states: torch.Tensor,
+    cu_seqlens: torch.LongTensor,
+    sliding_window: int,
+    sink_bias: torch.Tensor,
+    scaling: float,
+    chunk_size: int = 2048,
+) -> torch.Tensor:
+    """Exact sliding-window attention with a per-head sink bias over packed sequences.
+
+    Flash attention cannot express the attention sink (it changes the softmax denominator) and
+    its returned LSE is not differentiable, so SWA layers use this chunked implementation: each
+    query block only materializes logits against its (window + chunk)-sized key slice, keeping
+    memory at O(total * window) instead of O(total^2).
+
+    Args:
+        query_states: ``(total, num_heads, head_dim)`` after GQA expansion.
+        key_states: ``(total, num_heads, head_dim)``.
+        value_states: ``(total, num_heads, v_head_dim)``.
+        cu_seqlens: Cumulative sequence lengths delimiting packed samples.
+        sliding_window: Window size; key ``j`` is visible to query ``i`` iff ``i - window < j <= i``.
+        sink_bias: ``(num_heads,)`` bias appended as an extra softmax column.
+        scaling: Attention logit scale.
+    """
+    total, num_heads, _ = query_states.shape
+    positions = torch.arange(total, device=query_states.device)
+    sample_ids = torch.searchsorted(cu_seqlens, positions, right=True)
+    sink = sink_bias.float().view(num_heads, 1, 1)
+
+    outputs = []
+    for start in range(0, total, chunk_size):
+        end = min(start + chunk_size, total)
+        key_start = max(0, start - (sliding_window - 1))
+
+        logits = (
+            torch.einsum("qhd,khd->hqk", query_states[start:end].float(), key_states[key_start:end].float()) * scaling
+        )
+
+        query_pos = positions[start:end, None]
+        key_pos = positions[None, key_start:end]
+        visible = (key_pos <= query_pos) & (key_pos > query_pos - sliding_window)
+        visible &= sample_ids[start:end, None] == sample_ids[None, key_start:end]
+        logits = logits.masked_fill(~visible.unsqueeze(0), float("-inf"))
+
+        logits = torch.cat([logits, sink.expand(num_heads, end - start, 1)], dim=-1)
+        probs = logits.softmax(dim=-1)[..., :-1]
+        outputs.append(torch.einsum("hqk,khd->qhd", probs, value_states[key_start:end].float()))
+
+    return torch.cat(outputs).to(query_states.dtype)
+
+
+class MiMoV2AttentionBase(nn.Module):
+    """Shared projection / RoPE / sink plumbing for the MiMo-V2 attention variants.
+
+    Mirrors the hub checkpoint layout: a fused ``qkv_proj``, asymmetric query/key vs value head
+    dimensions, partial RoPE on the leading dims, an optional value scale, and an optional frozen
+    per-head attention sink bias on sliding-window layers.
+    """
+
+    def __init__(self, config: MiMoV2Config, layer_idx: int):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.is_swa = config.hybrid_layer_pattern[layer_idx] == 1
+
+        if self.is_swa:
+            self.head_dim = config.swa_head_dim
+            self.v_head_dim = config.swa_v_head_dim
+            self.num_attention_heads = config.swa_num_attention_heads
+            self.num_key_value_heads = config.swa_num_key_value_heads
+        else:
+            self.head_dim = config.head_dim
+            self.v_head_dim = config.v_head_dim
+            self.num_attention_heads = config.num_attention_heads
+            self.num_key_value_heads = config.num_key_value_heads
+
+        self.num_key_value_groups = self.num_attention_heads // self.num_key_value_heads
+        self.scaling = self.head_dim**-0.5
+        self.sliding_window = config.sliding_window if self.is_swa else None
+        self.v_scale = config.attention_value_scale
+        self.q_size = self.num_attention_heads * self.head_dim
+        self.k_size = self.num_key_value_heads * self.head_dim
+        self.v_size = self.num_key_value_heads * self.v_head_dim
+
+        self.qkv_proj = nn.Linear(
+            config.hidden_size, self.q_size + self.k_size + self.v_size, bias=config.attention_bias
+        )
+        self.o_proj = nn.Linear(self.num_attention_heads * self.v_head_dim, config.hidden_size, bias=False)
+
+        use_sink = config.add_swa_attention_sink_bias if self.is_swa else config.add_full_attention_sink_bias
+        if use_sink:
+            # Frozen in the reference implementation as well
+            self.attention_sink_bias = nn.Parameter(torch.zeros(self.num_attention_heads), requires_grad=False)
+        else:
+            self.attention_sink_bias = None
+
+    def attn_projections(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Project to q/k/v in ``(batch, seq, heads, dim)`` layout with RoPE applied."""
+        input_shape = hidden_states.shape[:-1]
+
+        qkv_states = self.qkv_proj(hidden_states)
+        query_states, key_states, value_states = qkv_states.split([self.q_size, self.k_size, self.v_size], dim=-1)
+        query_states = query_states.view(*input_shape, self.num_attention_heads, self.head_dim)
+        key_states = key_states.view(*input_shape, self.num_key_value_heads, self.head_dim)
+        value_states = value_states.view(*input_shape, self.num_key_value_heads, self.v_head_dim)
+
+        if self.v_scale is not None:
+            value_states = value_states * self.v_scale
+
+        # apply_rotary_pos_emb rotates only the leading cos.shape[-1] dims (partial RoPE)
+        query_states = query_states.transpose(1, 2)
+        key_states = key_states.transpose(1, 2)
+        cos, sin = position_embeddings
+        query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
+        query_states = query_states.transpose(1, 2)
+        key_states = key_states.transpose(1, 2)
+
+        return query_states, key_states, value_states
+
+
+class MiMoV2FlashAttention(MiMoV2AttentionBase):
+    def __init__(self, config: MiMoV2Config, layer_idx: int, flash_attn_version: int = 2):
+        super().__init__(config, layer_idx)
+        self._flash_attn_version = flash_attn_version
+        self.func = FlashAttention._funcs[flash_attn_version]
+        self._flash_attn_call = self.func
+        if self._flash_attn_version == 4:
+            self._flash_attn_call = torch._dynamo.disable(self.func)
+
+    def _compute_attention(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, cu_seqlens, max_seqlen):
+        """Run flash attention with the value padded up to the query/key head dim.
+
+        Flash attention requires q/k/v to share a head dim; padding V with zero columns yields
+        an output whose leading ``v_head_dim`` columns match exactly.
+        """
+        if self.v_head_dim != self.head_dim:
+            v = F.pad(v, (0, self.head_dim - self.v_head_dim))
+        kwargs: dict = {"causal": True}
+        if self.sliding_window is not None:
+            kwargs["window_size"] = (self.sliding_window - 1, 0)
+        if self._flash_attn_version == 4:
+            kwargs["cu_seqlens_q"] = cu_seqlens
+            kwargs["cu_seqlens_k"] = cu_seqlens
+            out = self._flash_attn_call(q, k, v, **kwargs)
+        else:
+            out = self._flash_attn_call(q, k, v, cu_seqlens, cu_seqlens, max_seqlen, max_seqlen, **kwargs)
+        if isinstance(out, tuple):
+            out = out[0]
+        return out[..., : self.v_head_dim]
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
+        attention_mask: torch.Tensor | None = None,
+        cu_seqlens: torch.LongTensor | None = None,
+        max_seqlen: int | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        query_states, key_states, value_states = self.attn_projections(hidden_states, position_embeddings)
+
+        if self.attention_sink_bias is not None:
+            key_expanded = key_states[0].repeat_interleave(self.num_key_value_groups, dim=1)
+            value_expanded = value_states[0].repeat_interleave(self.num_key_value_groups, dim=1)
+            out = _windowed_sink_attention(
+                query_states[0],
+                key_expanded,
+                value_expanded,
+                cu_seqlens,
+                self.sliding_window,
+                self.attention_sink_bias,
+                self.scaling,
+            )
+        else:
+            out = self._compute_attention(query_states[0], key_states[0], value_states[0], cu_seqlens, max_seqlen)
+
+        attn_output = out.reshape(1, out.shape[0], -1)
+        return self.o_proj(attn_output), None
+
+
+class MiMoV2SDPAAttention(MiMoV2AttentionBase):
+    def _attention_core(
+        self,
+        query_states: torch.Tensor,
+        key_states: torch.Tensor,
+        value_states: torch.Tensor,
+    ) -> torch.Tensor:
+        # (batch, seq, heads, dim) -> (batch, heads, seq, dim)
+        query_states = query_states.transpose(1, 2)
+        key_states = key_states.repeat_interleave(self.num_key_value_groups, dim=2).transpose(1, 2)
+        value_states = value_states.repeat_interleave(self.num_key_value_groups, dim=2).transpose(1, 2)
+        seq_len = query_states.shape[2]
+        positions = torch.arange(seq_len, device=query_states.device)
+        visible = positions[None, :] <= positions[:, None]
+        if self.sliding_window is not None:
+            visible &= positions[None, :] > positions[:, None] - self.sliding_window
+
+        if self.attention_sink_bias is not None:
+            logits = torch.matmul(query_states.float(), key_states.float().transpose(2, 3)) * self.scaling
+            logits = logits.masked_fill(~visible, float("-inf"))
+            sink = self.attention_sink_bias.float().view(1, -1, 1, 1).expand(logits.shape[0], -1, seq_len, 1)
+            logits = torch.cat([logits, sink], dim=-1)
+            probs = logits.softmax(dim=-1)[..., :-1]
+            out = torch.matmul(probs, value_states.float()).to(query_states.dtype)
+        else:
+            attn_mask = None if self.sliding_window is None else visible
+            out = F.scaled_dot_product_attention(
+                query_states,
+                key_states,
+                value_states,
+                attn_mask=attn_mask,
+                is_causal=attn_mask is None,
+            )
+        out = out.transpose(1, 2).contiguous()
+        return out.view(out.shape[0], out.shape[1], -1)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
+        attention_mask: torch.Tensor | None = None,
+        cu_seqlens: torch.LongTensor | None = None,
+        max_seqlen: int | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        query_states, key_states, value_states = self.attn_projections(hidden_states, position_embeddings)
+        attn_output = self._attention_core(query_states, key_states, value_states)
+        return self.o_proj(attn_output), None
+
+
+ATTN_IMPL2CLASS = {
+    "flash_attention_2": functools.partial(MiMoV2FlashAttention, flash_attn_version=2),
+    "flash_attention_3": functools.partial(MiMoV2FlashAttention, flash_attn_version=3),
+    "fa4": functools.partial(MiMoV2FlashAttention, flash_attn_version=4),
+    "sdpa": MiMoV2SDPAAttention,
+    # The SDPA variant computes sink layers eagerly, so it is exact for eager as well
+    "eager": MiMoV2SDPAAttention,
+}
+
+
+class MiMoV2RotaryEmbedding(nn.Module):
+    """Default RoPE with per-attention-type base and partial rotary dims."""
+
+    inv_freq: torch.Tensor
+
+    def __init__(self, config: MiMoV2Config, is_swa: bool, device=None):
+        super().__init__()
+        head_dim = config.swa_head_dim if is_swa else config.head_dim
+        self.base = config.swa_rope_theta if is_swa else config.rope_theta
+        self.rope_dim = int(head_dim * config.partial_rotary_factor)
+        if self.rope_dim % 2 != 0:
+            raise ValueError(f"MiMoV2 rotary dimension must be even, got {self.rope_dim}")
+        self.attention_scaling = 1.0
+        self.register_buffer("inv_freq", self._compute_inv_freq(device), persistent=False)
+
+    def _compute_inv_freq(self, device=None) -> torch.Tensor:
+        exponents = torch.arange(0, self.rope_dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float)
+        return 1.0 / (self.base ** (exponents / self.rope_dim))
+
+    def init_inv_freq_post_meta(self) -> None:
+        self.inv_freq.copy_(self._compute_inv_freq(self.inv_freq.device))
+
+    @torch.no_grad()
+    def forward(self, x, position_ids):
+        inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+        position_ids_expanded = position_ids[:, None, :].float()
+
+        device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+        with maybe_autocast(device_type=device_type, enabled=False):
+            freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
+            emb = torch.cat((freqs, freqs), dim=-1)
+            cos = emb.cos() * self.attention_scaling
+            sin = emb.sin() * self.attention_scaling
+
+        return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
+
+
+class MiMoV2DecoderLayer(GradientCheckpointingLayer):
+    def __init__(self, config: MiMoV2Config, layer_idx: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.is_swa = config.hybrid_layer_pattern[layer_idx] == 1
+        self.self_attn = ATTN_IMPL2CLASS[config._attn_implementation](config, layer_idx)
+
+        if config.moe_layer_freq[layer_idx]:
+            moe_args = MoEArgs(
+                num_experts=config.n_routed_experts,
+                num_shared_experts=0,
+                score_func="sigmoid",
+                route_norm=config.norm_topk_prob,
+                route_scale=config.routed_scaling_factor if config.routed_scaling_factor is not None else 1.0,
+                score_before_experts=False,
+                top_k=config.num_experts_per_tok,
+                load_balance_coeff=1e-3,
+                use_grouped_mm=config.use_grouped_mm,
+                fp8=getattr(config, "fp8", False),
+            )
+            self.mlp = MoE(moe_args, dim=config.hidden_size, hidden_dim=config.moe_intermediate_size)
+        else:
+            mlp_config = MLPConfig(
+                hidden_size=config.hidden_size,
+                intermediate_size=config.intermediate_size,
+                gate_act=config.hidden_act,
+                bias=False,
+            )
+            self.mlp = MLP(mlp_config)
+
+        self.input_layernorm = RMSNorm(RMSNormConfig(hidden_size=config.hidden_size, eps=config.layernorm_epsilon))
+        self.post_attention_layernorm = RMSNorm(
+            RMSNormConfig(hidden_size=config.hidden_size, eps=config.layernorm_epsilon)
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: Optional[tuple[torch.Tensor, torch.Tensor]] = None,
+        cu_seqlens: Optional[torch.LongTensor] = None,
+        max_seqlen: Optional[int] = None,
+        routed_experts: Optional[torch.LongTensor] = None,
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states, _ = self.self_attn(
+            hidden_states=hidden_states,
+            position_embeddings=position_embeddings,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+        )
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states, routed_experts=routed_experts)
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+
+class MiMoV2PreTrainedModel(PreTrainedModelPrimeRL):
+    config: MiMoV2Config
+    config_class = MiMoV2Config
+    base_model_prefix = "model"
+    supports_gradient_checkpointing = True
+    _no_split_modules = ["MiMoV2DecoderLayer"]
+    _skip_keys_device_placement = ["past_key_values"]
+    _supports_flash_attn = True
+    _supports_sdpa = True
+    _supports_flex_attn = False
+    _can_compile_fullgraph = False
+    _supports_attention_backend = True
+    _can_record_outputs = {
+        "hidden_states": MiMoV2DecoderLayer,
+    }
+
+    def _init_weights(self, module):
+        super()._init_weights(module)
+
+    @classmethod
+    def is_hf_state_dict(cls, state_dict: dict[str, Tensor]) -> bool:
+        """Check if the state dict contains MoE layers in HuggingFace format."""
+        return any("mlp.experts.1.up_proj" in name or "mlp.gate.e_score_correction_bias" in name for name in state_dict)
+
+    @classmethod
+    def is_prime_state_dict(cls, state_dict: dict[str, Tensor]) -> bool:
+        """Check if the state dict contains MoE layers in PrimeRL training format."""
+        return any("mlp.experts.w1" in name for name in state_dict)
+
+    @classmethod
+    def convert_to_hf(cls, state_dict: dict[str, Tensor]) -> dict[str, Tensor]:
+        """Convert weights from PrimeRL training format to HuggingFace format in-place."""
+        convert_tt_to_hf(state_dict)
+        return state_dict
+
+    @classmethod
+    def convert_to_prime(cls, state_dict: dict[str, Tensor]) -> dict[str, Tensor]:
+        """Convert weights from HuggingFace format to PrimeRL training format in-place."""
+        convert_hf_to_tt(state_dict)
+        return state_dict
+
+    @classmethod
+    def convert_layer_to_hf(cls, state_dict: dict[str, Tensor], layer_idx: int) -> dict[str, Tensor]:
+        """Convert a single layer's weights from PrimeRL format to HuggingFace format in-place."""
+        convert_tt_layer_to_hf(state_dict, layer_idx)
+        return state_dict
+
+    @classmethod
+    def convert_layer_to_prime(cls, state_dict: dict[str, Tensor], layer_idx: int) -> dict[str, Tensor]:
+        """Convert a single layer's weights from HuggingFace format to PrimeRL format in-place."""
+        convert_hf_layer_to_tt(state_dict, layer_idx)
+        return state_dict
+
+
+class MiMoV2Model(MiMoV2PreTrainedModel):
+    # MTP layers (speculative decoding only) and multimodal towers are not trained
+    _keys_to_ignore_on_load_unexpected = [
+        r"model\.mtp\..*",
+        r"visual\..*",
+        r"audio_encoder\..*",
+        r"speech_embeddings\..*",
+    ]
+
+    def __init__(self, config: MiMoV2Config):
+        super().__init__(config)
+        if config.scoring_func != "sigmoid":
+            raise ValueError(f"MiMoV2 only supports sigmoid routing, got {config.scoring_func}")
+        if config.topk_method != "noaux_tc" or config.n_group != 1:
+            raise ValueError("MiMoV2 only supports noaux_tc routing with n_group=1")
+
+        self.padding_idx = config.pad_token_id
+        self.vocab_size = config.vocab_size
+
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)
+        self.layers = nn.ModuleList(
+            [MiMoV2DecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
+        )
+        self.norm = RMSNorm(RMSNormConfig(hidden_size=config.hidden_size, eps=config.layernorm_epsilon))
+        self.rotary_emb = MiMoV2RotaryEmbedding(config, is_swa=False)
+        self.swa_rotary_emb = MiMoV2RotaryEmbedding(config, is_swa=True)
+        self.gradient_checkpointing = False
+
+        # Initialize weights and apply final processing
+        self.post_init()
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        routed_experts: Optional[torch.LongTensor] = None,
+    ) -> BaseModelOutputWithPast:
+        """
+        routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
+            Routed experts for each token in the sequence. Only used for router replay.
+        """
+        if (input_ids is None) ^ (inputs_embeds is not None):
+            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+
+        if inputs_embeds is None:
+            inputs_embeds: torch.Tensor = self.embed_tokens(input_ids)
+
+        if self.config._attn_implementation in ("flash_attention_2", "flash_attention_3", "fa4"):
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
+            torch._dynamo.mark_dynamic(cu_seqlens, 0)
+        else:
+            max_seqlen = None
+            cu_seqlens = None
+
+        hidden_states = inputs_embeds
+        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+        swa_position_embeddings = self.swa_rotary_emb(hidden_states, position_ids)
+
+        for layer_idx, decoder_layer in enumerate(self.layers[: self.config.num_hidden_layers]):
+            routed_experts_layer = routed_experts[:, :, layer_idx, :] if routed_experts is not None else None
+            hidden_states = decoder_layer(
+                hidden_states,
+                position_embeddings=swa_position_embeddings if decoder_layer.is_swa else position_embeddings,
+                cu_seqlens=cu_seqlens,
+                max_seqlen=max_seqlen,
+                routed_experts=routed_experts_layer,
+            )
+
+        hidden_states = self.norm(hidden_states)
+        return BaseModelOutputWithPast(last_hidden_state=hidden_states)
+
+
+class MiMoV2ForCausalLM(MiMoV2PreTrainedModel, GenerationMixin):
+    _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
+    _tp_plan = {"lm_head": "colwise_rep"}
+    _pp_plan = {"lm_head": (["hidden_states"], ["logits"])}
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.model = MiMoV2Model(config)
+        self.vocab_size = config.vocab_size
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+        # Initialize weights and apply final processing
+        self.post_init()
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        labels: Optional[torch.LongTensor] = None,
+        use_cache: Optional[bool] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        logits_to_keep: Union[int, torch.Tensor] = 0,
+        temperature: Optional[torch.Tensor] = None,
+        routed_experts: Optional[torch.LongTensor] = None,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> PrimeLmOutput:
+        r"""
+        cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
+            Indices of input tokens in the KV cache. Accepted only for HuggingFace API
+            compatibility — prime-rl asserts `use_cache is None` since training does not
+            perform autoregressive decoding, so this argument is unused.
+        labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
+            Labels used by PrimeRL's wrapped LM head to optionally compute per-token logprobs/entropy.
+            If not provided, the wrapped LM head returns logits only.
+        temperature (`torch.Tensor` of shape `(batch_size, sequence_length)`, *optional*):
+            Per-token temperatures for logprobs/entropy computation when `labels` are provided.
+        routed_experts (`torch.LongTensor` of shape `(batch_size, sequence_length, num_hidden_layers, num_experts_per_tok)`, *optional*):
+            Routed experts for each token in the sequence. Only used for router replay.
+        """
+        assert use_cache is None, "use_cache is not supported for custom mimo_v2 for now"
+        assert past_key_values is None, "past_key_values is not supported for custom mimo_v2 for now"
+
+        if position_ids is None:
+            if inputs_embeds is not None:
+                position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
+            else:
+                position_ids = torch.arange(input_ids.shape[1], device=input_ids.device).unsqueeze(0)
+
+        outputs: BaseModelOutputWithPast = self.model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            inputs_embeds=inputs_embeds,
+            routed_experts=routed_experts,
+        )
+
+        hidden_states = outputs.last_hidden_state
+        # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
+        slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+        return self.lm_head(
+            hidden_states[:, slice_indices, :],
+            labels[:, slice_indices] if labels is not None else None,
+            temperature=temperature,
+        )
+
+    def init_buffers_post_meta(self):
+        for rotary_emb in (self.model.rotary_emb, self.model.swa_rotary_emb):
+            if rotary_emb.inv_freq.device.type != "meta":
+                rotary_emb.init_inv_freq_post_meta()
+
+
+__all__ = ["MiMoV2Config", "MiMoV2PreTrainedModel", "MiMoV2Model", "MiMoV2ForCausalLM"]


### PR DESCRIPTION
Adds the text backbone of Xiaomi [MiMo-V2.5](https://huggingface.co/XiaomiMiMo/MiMo-V2.5) (310B MoE, 15B activated/token, 256 experts top-8) as a custom trainer model.

## What's in here

- **Modeling** (`src/prime_rl/trainer/models/mimo_v2/`): the architecture has several features outside the shared layer primitives, so attention is implemented model-locally:
  - **Hybrid attention**: per-layer full vs sliding-window (128) via `hybrid_layer_pattern`, with *different KV head counts per type* (4 full / 8 SWA) and per-type RoPE bases (1e7 full / 1e4 SWA, partial rotary factor 0.334).
  - **Asymmetric head dims** (qk 192 / v 128): FA2 requires equal head dims, so the flash path runs with V zero-padded to the qk dim and the output sliced back — mathematically exact, verified.
  - **Attention sinks**: SWA layers carry a frozen per-head `attention_sink_bias` (an extra softmax column). Flash attention can't express the sink and its returned LSE is not differentiable, so SWA layers use an exact chunked windowed implementation: each query block materializes logits only against its (window+chunk)-sized key slice — O(total·window) memory, packing-aware via `cu_seqlens`, fp32 softmax.
  - `attention_value_scale=0.707` applied to V pre-attention, matching the reference.
  - **Fused `qkv_proj` kept as the module layout** so hub checkpoint keys map 1:1 (no shape inference needed in conversion; split sizes come from config at init).
  - MoE: `noaux_tc` sigmoid routing with `n_group=1` degenerates to exactly `TokenChoiceTopKRouter` semantics (bias affects selection only, unbiased weights, top-k normalization); `gate.e_score_correction_bias` folds into the `expert_bias` buffer. No shared experts. Layer 0 dense via `moe_layer_freq`.
- **Conversion**: dequantizes the hub's block-128 FP8 (`weight_scale_inv`, new `dequantize_fp8_blockwise` in `fp8.py`) to bf16, stacks per-expert weights, renames the router/bias, and drops the MTP layers (`model.mtp.*`) plus the vision/audio/speech towers. `convert_to_hf` emits bf16 hub-format keys.
- **mini_moe**: `mimo_v2` preset verifying against the Xiaomi remote code, plus two small generic hooks — `post_create_fn` (the remote code leaves sink/correction biases as `torch.empty`; the preset fills them with deterministic non-trivial values) and per-preset `attn_implementation` (the remote code is eager-only under transformers 5.x).

## Validation

`mini_moe` create + verify (fp32, CUDA, vs `XiaomiMiMo/MiMo-V2.5` remote code, eager, sinks + window binding at seq 64 > window 32):

```
HF vs PrimeRL max logits diff: 0.000002
HF -> PrimeRL -> HF weight roundtrip verified
```

FA2 path cross-check (bf16): packed two-sample input through the FA2 path (padded-V full attention + chunked windowed sink attention) vs per-sample SDPA — max logit diff 0.0156 at mean |logit| 0.36, i.e. plain bf16 kernel-order noise; packing isolation holds (cross-sample leakage would dominate).

SFT smoke on the FA2 path (reverse-text, 200 steps): loss 11.93 → 3.28, ~15.7k tokens/s on a single RTX PRO 6000 — exercises the windowed sink attention with gradients end-to-end.

## Why there is no KL table yet

vLLM serves MiMo-V2's sinks only via FA3 (Hopper SM90) or FA4 (SM100): on this dev box (RTX PRO 6000, SM 12.0) `get_flash_attn_version` falls back to FA2 and the engine asserts `Sinks are only supported in FlashAttention 3`. The model cannot be served by vLLM on this machine at all, so the 20-step `math` KL table needs a Hopper/SM100 node — to be added before undrafting.

## Follow-ups

- Weight broadcast to an FP8-initialized vLLM engine needs `convert_layer_to_vllm_kernel` with block-FP8 re-quantization (glm_moe_dsa precedent); until then serve the dequantized bf16 checkpoint.
- MTP modules (3×, used by MiMo for speculative decoding and RL efficiency upstream) are dropped — same trade-off as other models: spec-decode acceptance may drift over training.
- No MiMo renderer in `deps/renderers` — use `[orchestrator.renderer] name = "default"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
