### PR TITLE
chore(v1): bump verifiers (eval/train client rename) + adopt config imports

### DIFF
--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -13,7 +13,7 @@ from httpx import AsyncClient
 from openai import NotFoundError
 from renderers import RendererConfig
 from tenacity import retry, retry_if_exception, stop_after_attempt, stop_after_delay, wait_exponential
-from verifiers.v1.clients.config import OpenAIClientConfig, RendererClientConfig
+from verifiers.v1.clients.config import EvalClientConfig, TrainClientConfig
 
 from prime_rl.configs.shared import ClientConfig
 from prime_rl.utils.logger import get_logger
@@ -187,15 +187,15 @@ def setup_clients(
     pool_size: int | None = None,
 ) -> list[vf.ClientConfig]:
     """Build v1 client configs (one per base_url × DP rank). ``client_type``
-    ``renderer`` → token-in/out (``RendererClientConfig``, with the renderer the env
+    ``renderer`` → token-in/out (``TrainClientConfig``, with the renderer the env
     server should use forwarded as a serialized config so it doesn't fall back to the
-    default renderer); otherwise plain chat-completions (``OpenAIClientConfig``)."""
+    default renderer); otherwise plain chat-completions (``EvalClientConfig``)."""
     is_renderer = client_type == "renderer"
-    config_cls = RendererClientConfig if is_renderer else OpenAIClientConfig
+    config_cls = TrainClientConfig if is_renderer else EvalClientConfig
     renderer_extra: dict = {}
     if is_renderer:
         # Pass the shared renderers.RendererConfig straight through (v1's
-        # RendererClientConfig.renderer is the same type; pydantic round-trips it
+        # TrainClientConfig.renderer is the same type; pydantic round-trips it
         # over the wire). prime-rl and v1 share one renderer config.
         renderer_extra = {
             "renderer": renderer_config,


### PR DESCRIPTION
## Summary

- Bump `deps/verifiers` to `feat/nano-as-v1` HEAD (`8873a740`), which includes the merged **verifiers#1654** — the v1 interception rework: role-named clients (`EvalClient`/`TrainClient`), route-detected wire dialects (chat/responses/anthropic), 1:1 relay + SSE streaming, reasoning preserved end-to-end.
- Adopt the renamed client config classes in `prime_rl/utils/client.py`: `OpenAIClientConfig` → `EvalClientConfig`, `RendererClientConfig` → `TrainClientConfig` (the `--client.type` discriminator is correspondingly `openai`/`renderers` → `eval`/`train`).

The only prime-rl surface that #1654 breaks is those two config classes (imported in `utils/client.py`); no prime-rl config TOML sets `--client.type`, so nothing else needs touching for the rename.

## Note

prime-rl's pin was behind (at the verifiers#1646 era), so this also brings forward the other v1 changes on `feat/nano-as-v1` (mm-wire #1653, validate entrypoint #1655, dashboard refactor). The rename itself only needs `utils/client.py`; if the broader bump requires other prime-rl adaptations (e.g. in-flight multimodal-training work), this should stack on / land with those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical rename of verifiers config classes in one module; no logic or prime-rl TOML surface changes in this diff.
> 
> **Overview**
> Aligns **prime-rl** with the bumped **verifiers** v1 client rename by swapping config types in `setup_clients` only.
> 
> Imports and instantiation now use **`EvalClientConfig`** for non-renderer (chat-completions) pools and **`TrainClientConfig`** when `client_type == "renderer"` (token-in/out with forwarded renderer config). Docstrings were updated to match; **`setup_clients` behavior and the `renderer` discriminator are unchanged**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84ba8737428543ab4b14b09070ea7f8b0827f839. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->