### PR TITLE
Validate requested attention implementation per model at load time

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -69,6 +69,8 @@ Bringing up a new model family is three steps: implement the modeling code, regi
 
 Drop the modeling code under `src/prime_rl/trainer/models/<arch>/` (HF-compatible config, modeling, and weight conversion). Mirror the layout of an existing family — `glm4_moe/` or `qwen3_moe/` are good starting points.
 
+If your model doesn't support every attention implementation from the shared `layers.attn` classes (`sdpa`, `flash_attention_2`, `flash_attention_3`, `fa4`), declare the supported set on the model class via `supported_attn_impls`, or override `validate_attn_impl` for conditional constraints (e.g. GPT-OSS requires eager attention off-Hopper). `get_model` validates the requested `attn` against this declaration at load time.
+
 ### Register a Mini Preset
 
 Add an entry to [`scripts/mini_moe.py`](https://github.com/PrimeIntellect-ai/prime-rl/blob/main/scripts/mini_moe.py) so the smoke-test workflow can build a ~0.5B test model in your architecture. The preset names the config class, picks small dimensions, and wires up the HF + PrimeRL model classes plus a tokenizer source:

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -34,6 +34,7 @@ from prime_rl.trainer.models import (
     PreTrainedModelPrimeRL,
     PrimeLmOutput,
     cast_float_and_contiguous,
+    get_custom_causal_lm_cls,
     get_custom_vlm_cls,
     supports_custom_impl,
 )
@@ -453,18 +454,7 @@ def get_model(
                 "VLM models must use optimization_dtype='bfloat16' and reduce_dtype='bfloat16' to match vLLM inference."
             )
 
-    # GPT-OSS only supports FlashAttention via kernels-community/vllm-flash-attn3, which requires Hopper (SM 90).
-    # On other architectures (e.g. Blackwell), users must fall back to eager attention.
-    HOPPER_MAJOR = 9
     if getattr(model_config, "model_type", "") == "gpt_oss":
-        if config.attn != "eager":
-            major, minor = torch.cuda.get_device_capability()
-            if major != HOPPER_MAJOR:
-                raise ValueError(
-                    f"GPT-OSS requires 'attn = \"eager\"' on non-Hopper GPUs (detected SM {major}{minor}). "
-                    f"The only flash attention kernel supported by GPT-OSS (kernels-community/vllm-flash-attn3) is Hopper-only. "
-                    f'Set [trainer.model] attn = "eager" in your config.'
-                )
         # Enable hub kernels for GPT-OSS (disabled by default to avoid interfering with other models).
         import transformers.integrations.hub_kernels as _hub_kernels
 
@@ -546,6 +536,13 @@ def get_model(
         logger.info(f"Auto-selected implementation: {impl_to_use}")
     else:
         impl_to_use = config.impl
+
+    # Validate the requested attention implementation against the model's declared support
+    # before construction, so unsupported combinations fail with an actionable error.
+    if impl_to_use == "custom":
+        custom_cls = custom_vlm_cls if custom_vlm_cls is not None else get_custom_causal_lm_cls(model_config)
+        if custom_cls is not None:
+            custom_cls.validate_attn_impl(model_config, config.attn)
 
     with device:
         if impl_to_use == "custom" and custom_vlm_cls is not None:

--- a/src/prime_rl/trainer/models/__init__.py
+++ b/src/prime_rl/trainer/models/__init__.py
@@ -67,6 +67,13 @@ def supports_custom_impl(model_config: PretrainedConfig) -> bool:
     return type(model_config) in _CUSTOM_CAUSAL_LM_MAPPING
 
 
+def get_custom_causal_lm_cls(model_config: PretrainedConfig) -> type[PreTrainedModelPrimeRL] | None:
+    """Return the custom PrimeRL causal LM class for this config, or None if unsupported."""
+    if type(model_config) not in _CUSTOM_CAUSAL_LM_MAPPING:
+        return None
+    return _CUSTOM_CAUSAL_LM_MAPPING[type(model_config)]
+
+
 # Mapping from HF composite VLM model_type to custom PrimeRL class.
 # Used by get_model() to dispatch VLMs that have a custom text model implementation.
 # Points to the same unified class — the config drives text-only vs VLM behavior.
@@ -84,6 +91,7 @@ __all__ = [
     "AutoModelForCausalLMPrimeRL",
     "PreTrainedModelPrimeRL",
     "supports_custom_impl",
+    "get_custom_causal_lm_cls",
     "get_custom_vlm_cls",
     "PrimeLmOutput",
     "cast_float_and_contiguous",

--- a/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
+++ b/src/prime_rl/trainer/models/afmoe/modeling_afmoe.py
@@ -393,6 +393,8 @@ class AfmoeDecoderLayer(GradientCheckpointingLayer):
 class AfmoePreTrainedModel(PreTrainedModelPrimeRL):
     config_class = AfmoeConfig
     base_model_prefix = "model"
+    # _get_afmoe_attention aliases eager to the SDPA implementation
+    supported_attn_impls = frozenset({"eager", "sdpa", "flash_attention_2", "flash_attention_3", "fa4"})
     _no_split_modules = ["AfmoeDecoderLayer"]
     _skip_keys_device_placement = ["past_key_values"]
     _keep_in_fp32_modules = [

--- a/src/prime_rl/trainer/models/base.py
+++ b/src/prime_rl/trainer/models/base.py
@@ -1,5 +1,8 @@
 from torch import Tensor
+from transformers.configuration_utils import PretrainedConfig
 from transformers.modeling_utils import PreTrainedModel
+
+from prime_rl.trainer.models.layers.attn import ATTN_IMPL2CLASS, require_flash_attn_kernels
 
 
 class PreTrainedModelPrimeRL(PreTrainedModel):
@@ -10,6 +13,25 @@ class PreTrainedModelPrimeRL(PreTrainedModel):
     (e.g., HuggingFace format vs. training-optimized format) and buffer initialization
     after loading with meta device.
     """
+
+    # Attention implementations this model's modeling code can dispatch. The default covers the
+    # shared `layers.attn` classes; models with their own attention declare a different set or
+    # override `validate_attn_impl` for conditional (e.g. hardware-dependent) constraints.
+    supported_attn_impls: frozenset[str] = frozenset(ATTN_IMPL2CLASS)
+
+    @classmethod
+    def validate_attn_impl(cls, config: PretrainedConfig, attn_impl: str) -> None:
+        """Validate the requested attention implementation at load time.
+
+        Raises a ValueError naming the model and its supported implementations instead of
+        failing with a KeyError mid-init or a kernel error at the first forward pass.
+        """
+        if attn_impl not in cls.supported_attn_impls:
+            raise ValueError(
+                f"{cls.__name__} does not support attn='{attn_impl}'. "
+                f"Supported: {sorted(cls.supported_attn_impls)}. Set [trainer.model] attn accordingly."
+            )
+        require_flash_attn_kernels(attn_impl)
 
     @classmethod
     def from_config(cls, config, **kwargs):

--- a/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
+++ b/src/prime_rl/trainer/models/glm_moe_dsa/modeling_glm_moe_dsa.py
@@ -134,6 +134,11 @@ class GlmMoeDsaPreTrainedModel(PreTrainedModelPrimeRL):
         "hidden_states": GlmMoeDsaDecoderLayer,
     }
 
+    @classmethod
+    def validate_attn_impl(cls, config, attn_impl: str) -> None:
+        # DSA uses its own sparse MLA kernels; the attn knob does not select a kernel here
+        pass
+
     def _init_weights(self, module):
         super()._init_weights(module)
 

--- a/src/prime_rl/trainer/models/gpt_oss/modeling_gpt_oss.py
+++ b/src/prime_rl/trainer/models/gpt_oss/modeling_gpt_oss.py
@@ -185,6 +185,21 @@ class GptOssPreTrainedModel(PreTrainedModelPrimeRL):
     _can_record_outputs = {"hidden_states": GptOssDecoderLayer}
 
     @classmethod
+    def validate_attn_impl(cls, config, attn_impl: str) -> None:
+        # GPT-OSS only supports FlashAttention via kernels-community/vllm-flash-attn3, which
+        # requires Hopper (SM 90). On other architectures (e.g. Blackwell), users must fall
+        # back to eager attention.
+        HOPPER_MAJOR = 9
+        if attn_impl != "eager":
+            major, minor = torch.cuda.get_device_capability()
+            if major != HOPPER_MAJOR:
+                raise ValueError(
+                    f"GPT-OSS requires 'attn = \"eager\"' on non-Hopper GPUs (detected SM {major}{minor}). "
+                    f"The only flash attention kernel supported by GPT-OSS (kernels-community/vllm-flash-attn3) is Hopper-only. "
+                    f'Set [trainer.model] attn = "eager" in your config.'
+                )
+
+    @classmethod
     def is_hf_state_dict(cls, state_dict: dict[str, Tensor]) -> bool:
         return is_hf_state_dict(state_dict)
 

--- a/src/prime_rl/trainer/models/laguna/modeling_laguna.py
+++ b/src/prime_rl/trainer/models/laguna/modeling_laguna.py
@@ -282,6 +282,8 @@ class LagunaPreTrainedModel(PreTrainedModelPrimeRL):
     config: LagunaConfig
     config_class = LagunaConfig
     base_model_prefix = "model"
+    # _get_laguna_attention aliases eager to the SDPA implementation
+    supported_attn_impls = frozenset({"eager", "sdpa", "flash_attention_2", "flash_attention_3", "fa4"})
     supports_gradient_checkpointing = True
     _no_split_modules = ["LagunaDecoderLayer"]
     _skip_keys_device_placement = ["past_key_values"]

--- a/src/prime_rl/trainer/models/layers/attn.py
+++ b/src/prime_rl/trainer/models/layers/attn.py
@@ -287,6 +287,25 @@ ATTN_IMPL2CLASS = {
     "fa4": functools.partial(FlashAttention, flash_attn_version=4),
 }
 
+# (flash_attn version, module providing it) per flash-style attn implementation
+_FLASH_ATTN_REQUIREMENTS = {
+    "flash_attention_2": (2, "flash_attn"),
+    "flash_attention_3": (3, "flash_attn_interface"),
+    "fa4": (4, "flash_attn.cute"),
+}
+
+
+def require_flash_attn_kernels(attn_impl: str) -> None:
+    """Raise at load time if the requested flash-attention variant is not importable.
+
+    Without this check a missing kernel only surfaces as a TypeError at the first forward pass.
+    """
+    if attn_impl not in _FLASH_ATTN_REQUIREMENTS:
+        return
+    version, module = _FLASH_ATTN_REQUIREMENTS[attn_impl]
+    if FlashAttention._funcs[version] is None:
+        raise ValueError(f"attn='{attn_impl}' requires `{module}`, which is not importable in this environment.")
+
 
 def substitute_ring_attn(
     process_group: torch.distributed.ProcessGroup,

--- a/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -689,6 +689,8 @@ def _create_rotary_emb(config: Qwen3_5MoeConfig) -> RotaryEmbedding:
 class Qwen3_5MoePreTrainedModel(PreTrainedModelPrimeRL):
     config_class = Qwen3_5MoeConfig
     base_model_prefix = "model"
+    # _get_gated_attention aliases eager to the SDPA implementation
+    supported_attn_impls = frozenset({"eager", "sdpa", "flash_attention_2", "flash_attention_3", "fa4"})
     supports_gradient_checkpointing = True
     _no_split_modules = ["Qwen3_5MoeDecoderLayer"]
     _skip_keys_device_placement = ["past_key_values"]


### PR DESCRIPTION
Adds a declarative, per-model constraint on which attention implementations a custom model supports, validated once in `get_model` before construction.

## Why

The constraint information existed but was scattered across three half-mechanisms with bad failure modes:

- Every modeling file dispatches via `ATTN_IMPL2CLASS[config._attn_implementation]` — an unsupported impl died with a bare `KeyError: 'eager'` deep inside layer construction.
- Requesting `flash_attention_3`/`fa4` without the kernel installed passed load and only failed with a confusing TypeError at the **first forward pass** (`self.func = None`).
- The one clean guard (GPT-OSS eager-only off Hopper) was hardcoded in `get_model`, far from the model it describes.
- transformers' `_supports_flash_attn`/`_supports_sdpa` flags can't distinguish fa2/fa3/fa4 or express hardware conditions, and prime's `fa4` string is invisible to them entirely.

## What

- `PreTrainedModelPrimeRL.supported_attn_impls` — class-level set, defaulting to the shared `layers.attn` dispatch (`sdpa`, `flash_attention_2`, `flash_attention_3`, `fa4`).
- `PreTrainedModelPrimeRL.validate_attn_impl(config, attn)` — membership check with an actionable error (model name + supported list + the config knob to set), plus a fail-fast kernel-availability check (`require_flash_attn_kernels` in `layers/attn.py`). Models override it for conditional constraints.
- `get_model` calls it once for custom-impl models (text and VLM paths) right after impl resolution. HF-impl models keep transformers' own validation.
- Migrations: **GPT-OSS** Hopper rule moves from `get_model` into the class (same error message); **Laguna**, **AFMoE**, and **Qwen3.5-MoE** declare `eager` (their factories alias it to SDPA); **GLM DSA** overrides to a no-op (its sparse MLA kernels ignore the knob entirely).
- One-paragraph note in `docs/development.md` under "Implement the Modeling Code".

## Validation

All paths exercised on this box (RTX PRO 6000, SM 12.0):

```
glm4 + flash_attention_2          → OK
glm4 + eager                      → ValueError: Glm4MoeForCausalLM does not support attn='eager'. Supported: [...]
gpt-oss + flash_attention_2       → ValueError: GPT-OSS requires 'attn = "eager"' on non-Hopper GPUs (detected SM 120)
gpt-oss + eager                   → OK
laguna + eager                    → OK
glm_moe_dsa + flash_attention_3   → OK (knob ignored, no kernel requirement)
afmoe / qwen3_5_moe + eager       → OK (aliased to SDPA, caught by Bugbot — full sweep below)
get_model(impl=custom, attn=eager, samsja/mini-glm-moe)  → clean ValueError from the new hook
get_model(impl=custom, attn=sdpa,  samsja/mini-glm-moe)  → loads
```

Full sweep of every registered family against every `attn` value, asserted against each modeling file's actual dispatch:

| Model | Accepted |
|---|---|
| llama, qwen3, qwen3_moe, glm4_moe, minimax_m2, nemotron_h | sdpa, fa2, fa3, fa4 |
| afmoe, qwen3_5_moe, laguna | eager (aliased to sdpa), sdpa, fa2, fa3, fa4 |
| glm_moe_dsa | all (own sparse MLA kernels; knob unused) |
| gpt_oss | eager (+ flash on Hopper) |

`pytest tests/unit -m "not gpu" -k "conversion or model or attn"`: 32 passed.

The in-flight Hy3 (#2789) and MiMo-V2.5 (#2791) models are covered by the base default and will pick this up on rebase (MiMo's attention also dispatches `eager`, so it will declare its set then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)