### PR TITLE
fix: keep multimodal tensors out of v1 rollout dumps

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -101,6 +101,11 @@ MAX_CONSECUTIVE_EMPTY_BATCHES = 10
 # resumed when the watcher advances ``policy.version``.
 TARGET_LAG = 1
 
+# Drop the per-node multimodal tensors when dumping a Trace to disk (rollout jsonl / wandb
+# tables): they're the training mm_kwargs carrier, not part of the rollout record, and base64
+# pixel tensors would bloat every line. `__all__` applies the exclude to every node in the list.
+ROLLOUT_DUMP_EXCLUDE = {"nodes": {"__all__": {"multi_modal_data"}}}
+
 
 class Orchestrator:
     # Set in ``__init__``
@@ -547,8 +552,9 @@ class Orchestrator:
                 f"({batch.metrics.n_trainable / len(batch.rollouts):.1%}) — consider reviewing task difficulty / filter config"
             )
 
-        # Serialize the typed Trace at the I/O boundary (disk + wandb sample tables).
-        rollout_dicts = [r.model_dump(mode="json") for r in batch.rollouts]
+        # Serialize the typed Trace at the I/O boundary (disk + wandb sample tables); drop the
+        # per-node multimodal tensors — they're for training, not the rollout record, and bloat it.
+        rollout_dicts = [r.model_dump(mode="json", exclude=ROLLOUT_DUMP_EXCLUDE) for r in batch.rollouts]
         step_path = get_step_path(get_rollout_dir(config.output_dir), step)
         await asyncio.to_thread(save_rollouts, rollout_dicts, step_path / "train_rollouts.jsonl")
 
@@ -750,7 +756,7 @@ class Orchestrator:
             get_logger().warning(f"Eval @ step={batch.step} env={batch.env_name}: no surviving rollouts, skipping log")
             return
 
-        rollout_dicts = [r.model_dump(mode="json") for r in batch.rollouts]
+        rollout_dicts = [r.model_dump(mode="json", exclude=ROLLOUT_DUMP_EXCLUDE) for r in batch.rollouts]
         step_path = get_step_path(get_rollout_dir(self.config.output_dir), batch.step)
         save_rollouts(
             rollout_dicts,


### PR DESCRIPTION
## Summary

- Serialize rollout `Trace`s with `exclude=ROLLOUT_DUMP_EXCLUDE` (`{"nodes": {"__all__": {"multi_modal_data"}}}`) in both the train and eval dump paths, dropping the per-node multimodal tensors from `train_rollouts.jsonl` and the wandb sample tables.

## Why

verifiers#1653 (carry mm tensors across the env-server wire) is merged and now pinned, so `MessageNode.multi_modal_data` is no longer `Field(exclude=True)`. As a result `model_dump(mode="json")` serializes the base64 pixel tensors into every rollout-dump line — bloating `train_rollouts.jsonl` and the wandb tables. Those tensors are the training `mm_kwargs` carrier, not part of the rollout record, so they're excluded at the I/O boundary. mm training is unaffected (the trainer consumes the tensors in-process before this dump).

Supersedes #2786 — this is its only remaining unique content; the rest of that branch (verifiers pin, `uv.lock`, hendrycks config, `client.py` rename) is stale or already on `feat/nano-as-v1`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow I/O serialization change; training still uses in-memory traces with multimodal data intact.
> 
> **Overview**
> After verifiers started serializing **`MessageNode.multi_modal_data`**, full **`Trace.model_dump(mode="json")`** was writing base64 pixel tensors into **`train_rollouts.jsonl`** and eval rollout JSONL, inflating disk logs without adding rollout metadata.
> 
> This PR adds **`ROLLOUT_DUMP_EXCLUDE`** (`nodes` → `__all__` → `multi_modal_data`) and passes it to **`model_dump`** in **`finalize_train_batch`** and **`finalize_eval_batch`**, stripping the training-only mm carrier at the persistence boundary. In-process training paths (e.g. **`TrainingBatch`** / **`batch.samples`**) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ee4c2f22b12cdd04ce32ad087b5df616d85de07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->