### PR TITLE
fix(orchestrator): bound rollout buffer memory (OOM at 1 TiB on long …

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -608,6 +608,12 @@ class OrchestratorConfig(BaseConfig):
     max_inflight_rollouts: int | None = Field(None, ge=1)
     """Maximum number of rollouts kept in-flight. Required for token-based batching. With ``batch_size`` set, defaults to ``batch_size * oversampling_factor`` (or ``batch_size`` when ``oversampling_factor`` is unset)."""
 
+    max_buffered_rollouts: int | None = Field(None, ge=1)
+    """Maximum rollouts held in the train sink (partial groups + batch overflow) before the dispatcher stops opening fresh groups. Rollouts of already-open groups still complete, so the effective ceiling is roughly this value plus ``max_inflight_rollouts``. With ``batch_size`` set, defaults to ``2 * batch_size``; with ``token_batch_size``, unset disables the cap. The buffer only grows past the batch threshold when rollout production outpaces trainer consumption — buffering deeper than ~2 batches just accumulates off-policy rollouts and memory."""
+
+    group_timeout_secs: float | None = Field(None, gt=0)
+    """Cancel a train group's outstanding rollouts this many seconds after the group is first dispatched. A single stuck rollout otherwise pins its completed groupmates in the sink indefinitely; on timeout the group finalizes with the rollouts that did complete (group-scored envs drop the whole group). None disables the timeout."""
+
     group_size: int = Field(1, ge=1, validation_alias=AliasChoices("group_size", "rollouts_per_example"))
     """Output sequences returned per example during training."""
 
@@ -871,6 +877,8 @@ class OrchestratorConfig(BaseConfig):
                     raise ValueError("max_inflight_rollouts conflicts with oversampling_factor * batch_size")
             if self.max_inflight_rollouts is None:
                 self.max_inflight_rollouts = resolved_max_inflight_rollouts
+            if self.max_buffered_rollouts is None:
+                self.max_buffered_rollouts = 2 * self.batch_size
 
         if self.max_inflight_rollouts is not None and self.max_inflight_rollouts < self.group_size:
             raise ValueError("max_inflight_rollouts must be at least the number of rollouts per example")

--- a/scripts/repro_rollout_buffer_oom.py
+++ b/scripts/repro_rollout_buffer_oom.py
@@ -1,0 +1,97 @@
+# Measure orchestrator rollout-buffer memory per buffered rollout.
+# Run from the prime-rl repo root:
+#   uv run python scripts/repro_rollout_buffer_oom.py full       # raw + samples retained (pre-fix behavior)
+#   uv run python scripts/repro_rollout_buffer_oom.py samples    # samples only (simulates freeing `raw`)
+#   uv run python scripts/repro_rollout_buffer_oom.py fixed      # what the sink holds today (compact + stripped)
+#   uv run python scripts/repro_rollout_buffer_oom.py fixed --no-replay
+# Each mode runs in its own process: RSS freed back to glibc arenas never returns
+# to the kernel, so freeing inside one process measures nothing.
+import base64
+import gc
+import os
+import random
+import sys
+
+import numpy as np
+
+from prime_rl.transport import TrainingSample
+from prime_rl.transport.types import RoutedExperts
+
+
+def rss_gib():
+    with open(f"/proc/{os.getpid()}/status") as f:
+        for line in f:
+            if line.startswith("VmRSS"):
+                return int(line.split()[1]) / 1024**2
+
+
+N_ROLLOUTS = 20  # scale factor; incident had ~3,800 held rollouts
+TOKENS = 120_000  # per trajectory (Scale-SWE rollouts ran 100-150k)
+STEPS = 40  # agent turns -> per-step raw entries
+MOE_LAYERS, TOPK = 75, 8  # GLM-5.1: 78 layers, 3 dense, top-k 8
+
+MODE = sys.argv[1] if len(sys.argv) > 1 else "full"  # "full" | "samples" | "fixed"
+REPLAY = "--no-replay" not in sys.argv
+
+
+def fake_rollout():
+    per_step = TOKENS // STEPS
+    # --- what `rollout.raw` holds after the env returns (never freed pre-fix) ---
+    raw_traj = []
+    for _ in range(STEPS):
+        re_np = np.random.randint(0, 256, (per_step, MOE_LAYERS, TOPK), dtype=np.uint8)
+        raw_traj.append(
+            {
+                "tokens": {
+                    "prompt_ids": [random.randint(1000, 150000) for _ in range(per_step // 4)],
+                    "completion_ids": [random.randint(1000, 150000) for _ in range(per_step)],
+                    "completion_logprobs": [random.random() for _ in range(per_step)],
+                    "routed_experts": {  # stays base64 in raw, exactly like the wire format
+                        "data": base64.b64encode(re_np.tobytes()).decode(),
+                        "shape": list(re_np.shape),
+                        "dtype": "uint8",
+                    },
+                },
+                "messages": [{"role": "assistant", "content": "x" * 2000}],
+            }
+        )
+    # --- what interleave_rollout builds (boxed lists + decoded bytes) ---
+    re_full = np.random.randint(0, 256, (TOKENS, MOE_LAYERS, TOPK), dtype=np.uint8)
+    routed = RoutedExperts(data=re_full.tobytes(), shape=list(re_full.shape), dtype="uint8") if REPLAY else None
+    sample = TrainingSample(
+        prompt_ids=[random.randint(1000, 150000) for _ in range(TOKENS // 8)],
+        prompt_mask=[True] * (TOKENS // 8),
+        completion_ids=[random.randint(1000, 150000) for _ in range(TOKENS)],
+        completion_mask=[True] * TOKENS,
+        completion_logprobs=[random.random() for _ in range(TOKENS)],
+        completion_temperatures=[],
+        env_name="multiswe",
+        routed_experts=routed,
+    )
+    if MODE == "samples":
+        raw_traj = None  # simulate freeing `raw` after tokenize
+    if MODE == "fixed":
+        # What the sink holds after the fixes: per-token fields compacted to
+        # numpy, per-step token payloads stripped to count stubs (messages
+        # kept for sample logging), last step's ids stashed compactly,
+        # temperatures fanned out as in process_group.
+        from prime_rl.orchestrator.train_sink import compact_sample
+        from prime_rl.orchestrator.trajectories import strip_trajectory_token_payloads
+
+        compact_sample(sample)
+        sample.completion_temperatures = np.full(len(sample.completion_ids), 0.8)
+        raw = {"trajectory": raw_traj}
+        strip_trajectory_token_payloads(raw)
+        raw_traj = raw["trajectory"]
+    return {"raw": raw_traj, "samples": [sample]}
+
+
+gc.collect()
+base = rss_gib()
+buffer = [fake_rollout() for _ in range(N_ROLLOUTS)]
+gc.collect()
+full = rss_gib()
+
+per = (full - base) / N_ROLLOUTS
+label = MODE + ("" if REPLAY else "+noreplay")
+print(f"{label:16s}: {per * 1024:7.1f} MiB/rollout -> {per * 3800:7.0f} GiB at 3,800 held rollouts (incident scale)")

--- a/src/prime_rl/orchestrator/dispatcher.py
+++ b/src/prime_rl/orchestrator/dispatcher.py
@@ -22,11 +22,12 @@
 from __future__ import annotations
 
 import asyncio
+import time
 import uuid
 from collections import Counter, defaultdict
 from dataclasses import dataclass, field
 from enum import Enum, auto
-from typing import Literal
+from typing import Callable, Literal
 
 import verifiers as vf
 from aiolimiter import AsyncLimiter
@@ -134,6 +135,8 @@ class RolloutDispatcher:
         max_off_policy_steps: int,
         training_mode: Literal["rl", "opd", "sft"],
         use_cache_salt: bool = True,
+        train_buffer_full: Callable[[], bool] | None = None,
+        group_timeout_secs: float | None = None,
     ) -> None:
         self.policy = policy
         self.train_envs = train_envs
@@ -153,6 +156,16 @@ class RolloutDispatcher:
         self.rate_limiter: AsyncLimiter | None = (
             AsyncLimiter(tasks_per_minute, time_period=60) if tasks_per_minute else None
         )
+
+        # Backpressure from the train sink: while it reports full, no fresh
+        # train groups are opened (open groups keep scheduling so they can
+        # finalize and drain). ``train_backpressured`` tracks the level for
+        # edge-triggered logging + the periodic gauge.
+        self.train_buffer_full = train_buffer_full
+        self.train_backpressured = False
+        # Train groups older than this (seconds since first dispatch) are
+        # dropped so stuck rollouts can't pin their groupmates forever
+        self.group_timeout_secs = group_timeout_secs
 
         self.inflight: dict[asyncio.Task, InflightRollout] = {}
         self.groups: dict[uuid.UUID, GroupState] = {}
@@ -236,6 +249,7 @@ class RolloutDispatcher:
         self.task = asyncio.current_task()
         try:
             while not self.stopped.is_set():
+                await self.expire_stale_groups()
                 await self.fill_inflight()
                 if not self.inflight:
                     # No work — sleep briefly. Eval triggers from the
@@ -346,6 +360,9 @@ class RolloutDispatcher:
             if cost <= self.available_permits:
                 return await self.schedule_group_rollout(gid, group)
 
+        if kind == "train" and self.is_train_backpressured():
+            return False
+
         fresh = self.next_fresh_group(kind, envs)
         if fresh is None:
             return False
@@ -378,7 +395,45 @@ class RolloutDispatcher:
             target_rollouts=group_size,
             eval_step=eval_step,
             policy_version_at_start=self.policy.version,
+            created_at=time.monotonic(),
         )
+
+    def is_train_backpressured(self) -> bool:
+        """Level-triggered backpressure from the train sink: while it holds
+        more rollouts than its cap, don't open fresh train groups. Open
+        groups keep scheduling, so partial groups still finalize and drain."""
+        full = self.train_buffer_full is not None and self.train_buffer_full()
+        if full and not self.train_backpressured:
+            get_logger().warning(
+                "Train sink buffer is full (max_buffered_rollouts) — pausing fresh group dispatch until it drains"
+            )
+        elif not full and self.train_backpressured:
+            get_logger().info("Train sink buffer drained — resuming fresh group dispatch")
+        self.train_backpressured = full
+        return full
+
+    async def expire_stale_groups(self) -> None:
+        """Drop train groups older than ``group_timeout_secs``. A single
+        stuck rollout otherwise pins its finished groupmates in the sink
+        forever; dropping emits ``Cancelled`` markers for the outstanding
+        rollouts so the sink finalizes the group with the ones that did
+        complete."""
+        if self.group_timeout_secs is None:
+            return
+        now = time.monotonic()
+        stale = [
+            gid
+            for gid, group in self.groups.items()
+            if group.kind == "train" and now - group.created_at > self.group_timeout_secs
+        ]
+        cancelled = 0
+        for gid in stale:
+            cancelled += await self.drop_group(gid, reason="Group timeout")
+        if cancelled:
+            get_logger().warning(
+                f"Cancelled {cancelled} train rollout(s) in {len(stale)} group(s) older than "
+                f"group_timeout_secs={self.group_timeout_secs}"
+            )
 
     async def schedule_group_rollout(self, group_id: uuid.UUID, group: GroupState) -> bool:
         """Dispatch one ``run_rollout`` / ``run_group`` task for this group.
@@ -569,7 +624,7 @@ class RolloutDispatcher:
         }
         return out
 
-    async def drop_group(self, group_id: uuid.UUID) -> int:
+    async def drop_group(self, group_id: uuid.UUID, *, reason: str = "Off-policy cancel") -> int:
         """Cancel remaining in-flight tasks for this group and emit a
         ``Cancelled`` marker for every rollout it still owes the sink
         (both in-flight and not-yet-scheduled). Returns the count for
@@ -594,7 +649,7 @@ class RolloutDispatcher:
         last_meta: InflightRollout | None = claimed[-1][1] if claimed else None
         for _, meta in claimed:
             for _ in range(meta.rollout_count):
-                raw = self.error_rollout_output(error_type="Cancelled", error_repr="Off-policy cancel")
+                raw = self.error_rollout_output(error_type="Cancelled", error_repr=reason)
                 await self.emit_rollout(meta, group, raw)
 
         # For non-group-scoring envs, the group may have rollouts that
@@ -616,7 +671,7 @@ class RolloutDispatcher:
             )
             unscheduled_cancelled = group.rollouts_to_schedule
             for _ in range(unscheduled_cancelled):
-                raw = self.error_rollout_output(error_type="Cancelled", error_repr="Off-policy cancel")
+                raw = self.error_rollout_output(error_type="Cancelled", error_repr=reason)
                 await self.emit_rollout(fallback_meta, group, raw)
 
         cancelled = inflight_cancelled + unscheduled_cancelled
@@ -690,4 +745,5 @@ class RolloutDispatcher:
             "dispatcher/groups_in_flight": float(len(self.groups)),
             "dispatcher/off_policy_level_max": float(self.max_off_policy_level),
             "dispatcher/off_policy_level_mean": self.mean_off_policy_level,
+            "dispatcher/train_backpressured": float(self.train_backpressured),
         }

--- a/src/prime_rl/orchestrator/filters.py
+++ b/src/prime_rl/orchestrator/filters.py
@@ -32,6 +32,17 @@ class RolloutFilter(Protocol):
     def check(self, rollout: "TrainRollout") -> FilterResult: ...
 
 
+def cache_token_filter_results(filters: list[RolloutFilter], rollout: "TrainRollout") -> None:
+    """Run token-level filters once while the rollout's per-step token
+    payloads are still on ``raw`` and cache the verdicts on the rollout.
+    The sink strips those payloads right after tokenization
+    (``strip_trajectory_token_payloads``), but the pre-/post-batch filter
+    passes run much later — ``check`` returns the cached verdict then."""
+    for filt in filters:
+        if getattr(filt, "uses_step_tokens", False) and filt.name not in rollout.filter_cache:
+            rollout.filter_cache[filt.name] = filt.check(rollout)
+
+
 @dataclass
 class GibberishFilter:
     """Flags rollouts containing rare tokens generated at high entropy.
@@ -48,8 +59,12 @@ class GibberishFilter:
     token_id_threshold: int
     logprob_threshold: float
     enforce: bool = False
+    uses_step_tokens = True
 
     def check(self, rollout: "TrainRollout") -> FilterResult:
+        cached = rollout.filter_cache.get(self.name)
+        if cached is not None:
+            return cached
         global_idx = 0
         for step in rollout.raw["trajectory"]:
             tokens = step["tokens"]
@@ -78,8 +93,12 @@ class RepetitionFilter:
     window: int
     logprob_threshold: float
     enforce: bool = False
+    uses_step_tokens = True
 
     def check(self, rollout: "TrainRollout") -> FilterResult:
+        cached = rollout.filter_cache.get(self.name)
+        if cached is not None:
+            return cached
         consecutive = 0
         global_idx = 0
         for step in rollout.raw["trajectory"]:

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -386,6 +386,10 @@ class Orchestrator:
             max_off_policy_steps=config.max_off_policy_steps,
             training_mode=config.training_mode,
             use_cache_salt=use_cache_salt,
+            # ``train_sink`` is constructed just below; the dispatcher only
+            # calls this from its scheduling loop, long after setup
+            train_buffer_full=self.train_sink_buffer_full,
+            group_timeout_secs=config.group_timeout_secs,
         )
         self.metrics = MetricsBuilder(config, start_step=self.progress.step)
         self.train_sink = TrainSink(
@@ -596,7 +600,10 @@ class Orchestrator:
         rollout_dicts = [r.to_dict() for r in batch.rollouts]
         step_path = get_step_path(get_rollout_dir(config.output_dir), step)
         await asyncio.to_thread(
-            save_rollouts, rollout_dicts, step_path / "train_rollouts.jsonl", exclude_keys={"trajectory"}
+            save_rollouts,
+            rollout_dicts,
+            step_path / "train_rollouts.jsonl",
+            exclude_keys={"trajectory", "last_step_input_ids"},
         )
 
         teacher_logprobs_time = 0.0  # opd only
@@ -856,6 +863,17 @@ class Orchestrator:
         t = time.perf_counter()
         await asyncio.to_thread(self.ckpt_manager.save, self.progress, step)
         return time.perf_counter() - t
+
+    def train_sink_buffer_full(self) -> bool:
+        """Backpressure predicate for the dispatcher: True while the train
+        sink holds ``max_buffered_rollouts`` or more rollouts (partial groups
+        + batch overflow). The dispatcher then stops opening fresh train
+        groups; in-flight and already-open groups still complete, so the
+        buffer drains instead of growing unboundedly when rollout production
+        outpaces trainer consumption."""
+        if self.config.max_buffered_rollouts is None:
+            return False
+        return self.train_sink.held_count() >= self.config.max_buffered_rollouts
 
     def update_dispatch_gate(self) -> None:
         """Pause/resume the dispatcher based on how far the orchestrator's

--- a/src/prime_rl/orchestrator/train_sink.py
+++ b/src/prime_rl/orchestrator/train_sink.py
@@ -17,18 +17,58 @@ import asyncio
 import uuid
 from collections import defaultdict
 
+import numpy as np
+
 from prime_rl.configs.orchestrator import OrchestratorConfig
 from prime_rl.orchestrator.advantage import assign_advantages
 from prime_rl.orchestrator.envs import TrainEnvs
-from prime_rl.orchestrator.filters import RolloutFilter, apply_filters
+from prime_rl.orchestrator.filters import RolloutFilter, apply_filters, cache_token_filter_results
 from prime_rl.orchestrator.trajectories import (
     backfill_rollout_tokens,
     interleave_rollout,
     offload_images_to_disk,
+    strip_trajectory_token_payloads,
 )
 from prime_rl.orchestrator.types import TrainBatch, TrainBatchMetrics, TrainRollout
 from prime_rl.transport import TrainingSample
 from prime_rl.utils.logger import get_logger
+
+_PER_TOKEN_SAMPLE_FIELDS = (
+    "prompt_ids",
+    "prompt_mask",
+    "completion_ids",
+    "completion_mask",
+    "completion_logprobs",
+    "completion_temperatures",
+    "mm_token_type_ids",
+)
+
+
+def compact_sample(sample: TrainingSample) -> TrainingSample:
+    """Repack per-token list fields as numpy arrays for buffering. A boxed
+    Python int costs ~36 B vs 4 B raw, and a buffered rollout can hold 100k+
+    tokens for hours — same motivation as ``RoutedExperts`` carrying raw
+    bytes. ``materialize_wire_lists`` restores the wire-format lists at ship
+    time, so the shipped payload is unchanged."""
+    sample.prompt_ids = np.asarray(sample.prompt_ids, dtype=np.int32)
+    sample.prompt_mask = np.asarray(sample.prompt_mask, dtype=np.bool_)
+    sample.completion_ids = np.asarray(sample.completion_ids, dtype=np.int32)
+    sample.completion_mask = np.asarray(sample.completion_mask, dtype=np.bool_)
+    # float64, not float32, so the round-trip back to lists is value-identical
+    sample.completion_logprobs = np.asarray(sample.completion_logprobs, dtype=np.float64)
+    if sample.mm_token_type_ids is not None:
+        sample.mm_token_type_ids = np.asarray(sample.mm_token_type_ids, dtype=np.int32)
+    return sample
+
+
+def materialize_wire_lists(sample: TrainingSample) -> TrainingSample:
+    """Inverse of ``compact_sample``: convert numpy-backed per-token fields
+    back to the plain lists the transport encodes, just before shipping."""
+    for name in _PER_TOKEN_SAMPLE_FIELDS:
+        value = getattr(sample, name)
+        if isinstance(value, np.ndarray):
+            setattr(sample, name, value.tolist())
+    return sample
 
 
 class TrainSink:
@@ -114,6 +154,12 @@ class TrainSink:
         (non-group-scoring envs) — buffered in the sink ahead of the batch."""
         return sum(len(group) for group in self.in_progress_groups())
 
+    def held_count(self) -> int:
+        """Every rollout resident in the sink: partial-group arrivals (all
+        envs, including group-scoring) plus batch overflow. Drives the
+        dispatcher's ``max_buffered_rollouts`` backpressure."""
+        return sum(len(group) for group in self.pending_groups.values()) + len(self.pending_batch)
+
     def pending_batch_by_env(self) -> dict[str, int]:
         """Per-env breakdown of ``batch_progress()`` (``pending_batch`` only);
         values sum to the aggregate."""
@@ -167,6 +213,18 @@ class TrainSink:
         # tokenized, so memory stays flat instead of holding every buffered
         # rollout's images until the batch ships (no-op for text-only).
         await asyncio.to_thread(offload_images_to_disk, [raw], self.config.output_dir)
+        await asyncio.to_thread(self.compact_rollout, rollout)
+
+    def compact_rollout(self, rollout: TrainRollout) -> None:
+        """Shrink a tokenized rollout to its buffered footprint: numpy-backed
+        sample fields, token-level filter verdicts cached, per-step token
+        payloads stripped from ``raw``. The rollout may wait hours for its
+        group to finalize and its batch to ship — everything held across that
+        window must be compact."""
+        for sample in rollout.samples:
+            compact_sample(sample)
+        cache_token_filter_results([*self.pre_filters, *self.post_filters], rollout)
+        strip_trajectory_token_payloads(rollout.raw)
 
     def process_group(self, group_id: uuid.UUID) -> None:
         """Finalize one GRPO group: drop errored rollouts (the whole group
@@ -209,7 +267,7 @@ class TrainSink:
                 sample.reward = r.reward
                 sample.env_name = r.env_name
                 sample.training_mode = self.config.training_mode
-                sample.completion_temperatures = [temperature] * len(sample.completion_ids)
+                sample.completion_temperatures = np.full(len(sample.completion_ids), temperature)
 
         if self.pre_filters:
             apply_filters(self.pre_filters, survivors)
@@ -278,12 +336,13 @@ class TrainSink:
             prefill = 0
             decode = 0
             for sample in r.samples:
-                sample_decode = sum(sample.completion_mask)
-                sample_prefill = len(sample.prompt_ids) + len(sample.completion_mask) - sample_decode
+                completion_mask = np.asarray(sample.completion_mask)
+                sample_decode = int(completion_mask.sum())
+                sample_prefill = len(sample.prompt_ids) + completion_mask.size - sample_decode
                 decode += sample_decode
                 prefill += sample_prefill
                 if not r.is_filtered:
-                    samples.append(sample)
+                    samples.append(materialize_wire_lists(sample))
             prefill_lens.append(prefill)
             decode_lens.append(decode)
             num_prefill += prefill

--- a/src/prime_rl/orchestrator/trajectories.py
+++ b/src/prime_rl/orchestrator/trajectories.py
@@ -607,6 +607,38 @@ def _pack_mm_kwargs_from_renderer(mm_data: Any) -> "dict[str, Any] | None":
     return out
 
 
+def strip_trajectory_token_payloads(output: vf.RolloutOutput) -> None:
+    """Drop per-step token payloads once a rollout is tokenized.
+
+    The per-step ids/masks/logprobs and base64 ``routed_experts`` strings are
+    the dominant share of a buffered rollout's memory and are fully captured
+    in ``TrainingSample`` by ``interleave_rollout`` — but the rollout can sit
+    in the sink for hours waiting for its group/batch, so they must not stay
+    alive on ``raw``. Each step's ``tokens`` dict is replaced by a count stub
+    (``num_prompt_ids`` / ``num_completion_ids``) for downstream consumers
+    that only need lengths (length-penalty advantage, sample-table metadata).
+    The last step's full input ids are stashed compactly on
+    ``output["last_step_input_ids"]`` for monitor sample logging. Step
+    messages are kept — rollout persistence and sample tables read them.
+    """
+    trajectory = output.get("trajectory") or []
+    if not trajectory:
+        return
+    last_tokens = trajectory[-1].get("tokens")
+    if last_tokens is not None:
+        output["last_step_input_ids"] = np.asarray(
+            list(last_tokens["prompt_ids"]) + list(last_tokens["completion_ids"]), dtype=np.int32
+        )
+    for step in trajectory:
+        tokens = step.get("tokens")
+        if tokens is None:
+            continue
+        step["tokens"] = {
+            "num_prompt_ids": len(tokens["prompt_ids"]),
+            "num_completion_ids": len(tokens["completion_ids"]),
+        }
+
+
 _FILE_URL_PREFIX = "file://"
 
 

--- a/src/prime_rl/orchestrator/types.py
+++ b/src/prime_rl/orchestrator/types.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass, field, fields
-from typing import Literal, Protocol
+from typing import TYPE_CHECKING, Literal, Protocol
 
 import verifiers as vf
 
 from prime_rl.transport import TrainingSample
+
+if TYPE_CHECKING:
+    from prime_rl.orchestrator.filters import FilterResult
 
 
 @dataclass
@@ -62,6 +65,7 @@ class GroupState:
     eval_step: int | None = None
     pinned_client: vf.ClientConfig | None = None
     policy_version_at_start: int = 0
+    created_at: float = 0.0  # time.monotonic() at creation; drives the group-age timeout
 
 
 @dataclass
@@ -97,7 +101,7 @@ class FinishedRollout:
         ``monitor.log_samples``). Shallow copy; never mutates ``self.raw``."""
         out: vf.RolloutOutput = dict(self.raw)  # type: ignore[assignment]
         for f in fields(self):
-            if f.name in ("raw", "samples"):
+            if f.name in ("raw", "samples", "filter_cache"):
                 continue
             val = getattr(self, f.name)
             if f.name == "filter_results":
@@ -113,6 +117,9 @@ class TrainRollout(FinishedRollout):
     advantage: float | None = None
     is_filtered: bool = False
     filter_results: dict[str, bool] = field(default_factory=dict)
+    # Token-level filter verdicts, computed by the sink before the per-step
+    # token payloads are stripped from ``raw`` (filters.cache_token_filter_results)
+    filter_cache: dict[str, FilterResult] = field(default_factory=dict)
 
 
 @dataclass

--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -56,8 +56,18 @@ async def setup_student_inference_pool(*, config: OrchestratorConfig, tokenizer)
 
 def get_model_completion_len(output: vf.RolloutOutput) -> int:
     """Sum of model-generated completion tokens across all turns (excludes
-    environment-injected tokens between turns)."""
-    return sum(len(step["tokens"]["completion_ids"]) for step in output["trajectory"] if step.get("tokens"))
+    environment-injected tokens between turns). Reads the count stub left by
+    ``strip_trajectory_token_payloads`` when the token payloads are gone."""
+    total = 0
+    for step in output["trajectory"]:
+        tokens = step.get("tokens")
+        if not tokens:
+            continue
+        if "num_completion_ids" in tokens:
+            total += tokens["num_completion_ids"]
+        else:
+            total += len(tokens["completion_ids"])
+    return total
 
 
 def get_tool_response_len(output: vf.RolloutOutput) -> int:

--- a/src/prime_rl/utils/monitor/prime.py
+++ b/src/prime_rl/utils/monitor/prime.py
@@ -31,6 +31,18 @@ def _json(val: Any) -> str:
     return json.dumps(val)
 
 
+def _step_token_count(step: dict, key: str) -> int | None:
+    """Token count for one trajectory step. Train rollouts arrive with token
+    payloads stripped to count stubs (strip_trajectory_token_payloads); eval
+    rollouts still carry the full id lists."""
+    tokens = step.get("tokens")
+    if not tokens:
+        return None
+    if f"num_{key}" in tokens:
+        return tokens[f"num_{key}"]
+    return len(tokens[key])
+
+
 _SAMPLE_SCHEMA = pa.schema(
     [
         ("run_id", pa.string()),
@@ -354,8 +366,8 @@ class PrimeMonitor(Monitor):
                     "reward": ts.get("reward"),
                     "advantage": ts.get("advantage"),
                     "extras": ts.get("extras", {}),
-                    "num_input_tokens": len(ts["tokens"]["prompt_ids"]) if ts.get("tokens") else None,
-                    "num_output_tokens": len(ts["tokens"]["completion_ids"]) if ts.get("tokens") else None,
+                    "num_input_tokens": _step_token_count(ts, "prompt_ids"),
+                    "num_output_tokens": _step_token_count(ts, "completion_ids"),
                 }
                 for ts in trajectory
             ]

--- a/src/prime_rl/utils/monitor/wandb.py
+++ b/src/prime_rl/utils/monitor/wandb.py
@@ -177,7 +177,16 @@ class WandbMonitor(Monitor):
                 continue
             last_step = trajectory[-1]
             tokens = last_step["tokens"]
-            full_ids = tokens["prompt_ids"] + tokens["completion_ids"]
+            if tokens is not None and "prompt_ids" in tokens:
+                full_ids = tokens["prompt_ids"] + tokens["completion_ids"]
+            else:
+                # Train rollouts arrive with per-step token payloads stripped
+                # (strip_trajectory_token_payloads); the full final sequence
+                # is stashed compactly at the top level instead
+                stashed = rollout.get("last_step_input_ids")
+                if stashed is None:
+                    continue
+                full_ids = stashed.tolist()
             messages_text = self.tokenizer.decode(full_ids)
             sample = {
                 "step": step,


### PR DESCRIPTION
…SWE runs)

The orchestrator OOM-killed at 1,032 GiB anon RSS holding ~3,800 buffered 100-150k-token rollouts (~182 MiB each). Three compounding causes, three fixes:

1. Free `raw` after tokenization: per-step token payloads (ids/masks/logprobs and base64 routed_experts, ~95% of the raw footprint) are now stripped in the sink once `interleave_rollout` has captured them, leaving count stubs for length consumers and a compact int32 stash of the final sequence for sample logging. Token-level filters (gibberish/repetition) run once pre-strip and cache their verdicts on the rollout.

2. Unbox TrainingSample per-token fields while buffered: ids/masks/logprobs/ temperatures held as numpy arrays (~36 B -> 4 B per token id) and materialized back to plain lists at ship time, so the wire encoding is byte-identical (verified via msgspec round-trip).

3. Bound the buffer: new `max_buffered_rollouts` (default 2x batch_size) backpressures the dispatcher - fresh train groups stop opening while the sink is full; open groups keep scheduling so partial groups finalize and drain. New opt-in `group_timeout_secs` drops train groups whose stragglers never finish, so stuck rollouts can't pin 31 groupmates' memory forever.

Measured with scripts/repro_rollout_buffer_oom.py (120k-token rollouts, GLM-5.1 routed-experts shape, incident scale = 3,800 held):

  full (pre-fix)       181.6 MiB/rollout   674 GiB
  fixed (replay on)     83.4 MiB/rollout   309 GiB  (decoded replay bytes dominate)
  fixed (replay off)    14.1 MiB/rollout    52 GiB

With router replay on, the irreducible 600 B/token expert trace keeps per-rollout cost high - there the new buffer cap is what bounds worst-case RSS (~1,536 held rollouts x ~104 MiB at 150k tokens = ~160 GiB vs unbounded).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes buffering semantics, filter timing, and monitor/sample logging paths for train rollouts; mis-tuned caps or timeouts could increase off-policy data or drop partial groups, but shipped trainer payloads are intended to stay wire-identical after compaction.
> 
> **Overview**
> Addresses orchestrator OOM from thousands of long rollouts sitting in the train sink by **shrinking what each buffered rollout retains** and **capping how many can accumulate**.
> 
> After tokenization, the sink **compacts** `TrainingSample` per-token fields to numpy, **strips** heavy per-step token payloads from `raw` (count stubs + compact `last_step_input_ids` for logging), and **caches** gibberish/repetition filter results before those payloads are removed. Samples are **materialized back to wire lists** only at batch ship time.
> 
> New config: **`max_buffered_rollouts`** (default `2 * batch_size` in rollout batching) pauses opening **fresh** train groups when `held_count()` exceeds the cap; **`group_timeout_secs`** optionally cancels stale groups so one stuck rollout cannot hold groupmates forever. The dispatcher exposes **`train_backpressured`** metrics; rollout JSONL persistence excludes `last_step_input_ids`.
> 
> A **`scripts/repro_rollout_buffer_oom.py`** script estimates MiB/rollout under pre-fix vs fixed buffering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aafe4ccda66f5b0832f22602c244c8c7149dd2b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->