### PR TITLE
IPO config

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -425,6 +425,18 @@ class DefaultLossConfig(BaseConfig):
     """Temperature for the KL term."""
 
 
+class IPOLossConfig(BaseConfig):
+    type: Literal["ipo"] = "ipo"
+    ipo_threshold: float = Field(0.1, ge=0)
+    """Upper DPPO masking threshold."""
+
+    adv_tau: float = Field(1.0, ge=0)
+    """Temperature for the advantage term."""
+
+    kl_tau: float = Field(1e-3, ge=0)
+    """Temperature for the KL term."""
+
+
 class CustomLossConfig(BaseConfig):
     type: Literal["custom"] = "custom"
 
@@ -435,7 +447,7 @@ class CustomLossConfig(BaseConfig):
     """Kwargs forwarded to the loss function."""
 
 
-LossConfig: TypeAlias = Annotated[DefaultLossConfig | CustomLossConfig, Field(discriminator="type")]
+LossConfig: TypeAlias = Annotated[DefaultLossConfig | IPOLossConfig | CustomLossConfig, Field(discriminator="type")]
 
 
 class FakeDataLoaderConfig(BaseConfig):

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -6,7 +6,7 @@ from beartype import beartype as typechecker
 from jaxtyping import Bool, Float, Int, jaxtyped
 from torch import Tensor
 
-from prime_rl.configs.trainer import CustomLossConfig, DefaultLossConfig, LossConfig
+from prime_rl.configs.trainer import CustomLossConfig, DefaultLossConfig, IPOLossConfig, LossConfig
 from prime_rl.utils.utils import import_object
 
 
@@ -165,6 +165,36 @@ def default_loss_fn(inputs: LossInputs, loss_config: DefaultLossConfig) -> LossO
     return LossOutputs(loss=loss, metrics=metrics)
 
 
+def ipo_loss_fn(inputs: LossInputs, loss_config: IPOLossConfig) -> LossOutputs:
+
+    trainer_logprobs = inputs.trainer_logprobs
+    inference_logprobs = inputs.inference_logprobs
+    advantages = inputs.advantages
+    loss_mask = inputs.loss_mask
+
+    log_importance_ratio, importance_ratio, mismatch_kl = compute_importance_ratio_and_mismatch_kl(
+        trainer_logprobs, inference_logprobs
+    )
+
+    abs_probs_diff = torch.abs(torch.exp(trainer_logprobs) - torch.exp(inference_logprobs))
+
+    is_masked = abs_probs_diff > loss_config.ipo_threshold
+    keep_mask = loss_mask & ~is_masked
+
+    advantages = loss_config.adv_tau * advantages
+    pg_loss = keep_mask * advantages * importance_ratio
+    kl_loss = loss_mask * log_importance_ratio**2
+    loss = (-pg_loss + loss_config.kl_tau * kl_loss).sum()
+
+    metrics = {
+        "masked_mismatch_kl": _safe_mean(mismatch_kl, loss_mask & is_masked),  # all trainable, masked tokens
+        "unmasked_mismatch_kl": _safe_mean(mismatch_kl, keep_mask),  # all trainable, unmasked tokens
+        "is_masked": _safe_mean(is_masked, loss_mask),
+    }
+
+    return LossOutputs(loss=loss, metrics=metrics)
+
+
 def opd_loss_fn(inputs: LossInputs) -> LossOutputs:
     """
     On-policy distillation loss: the default DPPO+KL math with the tau knobs
@@ -240,7 +270,8 @@ def setup_loss_fns(loss_config: LossConfig) -> dict[str, LossFn]:
     - ``"opd"`` → ``opd_loss_fn`` (teacher KL as gradient signal, hardcoded
       DPPO + KL knobs)
     - ``"rl"``  → ``default_loss_fn(loss_config)`` for ``DefaultLossConfig``,
-      or the imported function for ``CustomLossConfig``.
+      ``ipo_loss_fn(loss_config)`` for ``IPOLossConfig``, or the imported
+      function for ``CustomLossConfig``.
 
     ``trainer.loss`` only affects the rl path - opd and sft are independent.
     """
@@ -250,6 +281,10 @@ def setup_loss_fns(loss_config: LossConfig) -> dict[str, LossFn]:
 
         def rl_fn(inputs: LossInputs) -> LossOutputs:
             return custom_fn(inputs, **kwargs)
+    elif isinstance(loss_config, IPOLossConfig):
+
+        def rl_fn(inputs: LossInputs) -> LossOutputs:
+            return ipo_loss_fn(inputs, loss_config)
     else:
 
         def rl_fn(inputs: LossInputs) -> LossOutputs:

--- a/src/prime_rl/trainer/rl/loss.py
+++ b/src/prime_rl/trainer/rl/loss.py
@@ -166,7 +166,6 @@ def default_loss_fn(inputs: LossInputs, loss_config: DefaultLossConfig) -> LossO
 
 
 def ipo_loss_fn(inputs: LossInputs, loss_config: IPOLossConfig) -> LossOutputs:
-
     trainer_logprobs = inputs.trainer_logprobs
     inference_logprobs = inputs.inference_logprobs
     advantages = inputs.advantages


### PR DESCRIPTION
```
[trainer.loss]
type = "ipo"
ipo_threshold = 0.1
adv_tau = 1.0
kl_tau = 1e-3
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Opt-in change to RL loss computation and gradient masking; wrong threshold tuning could silently drop most PG signal, but default loss behavior is unchanged unless `type = "ipo"` is set.
> 
> **Overview**
> Adds an opt-in **`trainer.loss.type = "ipo"`** path for RL batches alongside the existing default and custom losses.
> 
> **`IPOLossConfig`** exposes `ipo_threshold` (default `0.1`), `adv_tau`, and `kl_tau`. **`ipo_loss_fn`** reuses the same importance-ratio + squared log-ratio KL structure as the default RL loss, but **masks tokens when the absolute probability gap** between trainer and inference exceeds the threshold—**not** the advantage-signed DPPO low/high masks. Policy-gradient terms apply only on unmasked tokens; KL still applies on the full `loss_mask`. **`setup_loss_fns`** wires `IPOLossConfig` into the `"rl"` slot in the mode dispatch table.
> 
> Enable via e.g. `[trainer.loss] type = "ipo"` with optional threshold/tau overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6520722d77b96b303ca5ae5c2f6554240d24d655. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->