### PR TITLE
[codex] freeze GLM DSA indexer params

### DIFF
--- a/src/prime_rl/trainer/models/glm_moe_dsa/sparse_mla_attention.py
+++ b/src/prime_rl/trainer/models/glm_moe_dsa/sparse_mla_attention.py
@@ -74,6 +74,9 @@ class Indexer(nn.Module):
         self.k_norm = LayerNorm(dim=self.head_dim, eps=1e-6)
         self.weights_proj = nn.Linear(args.hidden_size, self.n_head, bias=False)
         self.weight_scale = (self.head_dim**-0.5) * (self.n_head**-0.5)
+        # Sparse index selection is non-differentiable; keep indexer weights checkpointed but frozen.
+        for param in self.parameters():
+            param.requires_grad = False
 
     @torch.no_grad()
     def compute_sparse_indices(

--- a/tests/unit/train/models/test_glm_moe_dsa_conversion.py
+++ b/tests/unit/train/models/test_glm_moe_dsa_conversion.py
@@ -1,6 +1,25 @@
 import torch
 
 from prime_rl.trainer.models.glm_moe_dsa.converting_glm_moe_dsa import convert_tt_layer_to_vllm_kernel
+from prime_rl.trainer.models.glm_moe_dsa.sparse_mla_attention import GlmMoeDsaAttention, SparseMlaAttentionArgs
+
+
+def _build_sparse_mla_args() -> SparseMlaAttentionArgs:
+    return SparseMlaAttentionArgs(
+        hidden_size=6,
+        num_attention_heads=1,
+        kv_lora_rank=3,
+        q_lora_rank=6,
+        qk_rope_head_dim=2,
+        qk_nope_head_dim=2,
+        qk_head_dim=4,
+        v_head_dim=3,
+        attention_bias=False,
+        rms_norm_eps=1e-6,
+        index_n_heads=2,
+        index_head_dim=4,
+        index_topk=64,
+    )
 
 
 def _build_prime_layer_state(layer_idx: int = 0) -> dict[str, torch.Tensor]:
@@ -28,6 +47,21 @@ def _build_prime_layer_state(layer_idx: int = 0) -> dict[str, torch.Tensor]:
         f"{prefix}.mlp.shared_expert.w2": torch.randn(1, 6, 3),
         f"{prefix}.mlp.shared_expert.w3": torch.randn(1, 3, 6),
     }
+
+
+def test_glm_moe_dsa_indexer_parameters_are_frozen():
+    attention = GlmMoeDsaAttention(_build_sparse_mla_args())
+
+    indexer_params = dict(attention.indexer.named_parameters())
+    trainable_non_indexer_params = {
+        name: param
+        for name, param in attention.named_parameters()
+        if not name.startswith("indexer.") and param.requires_grad
+    }
+
+    assert indexer_params
+    assert all(not param.requires_grad for param in indexer_params.values())
+    assert trainable_non_indexer_params
 
 
 def test_convert_tt_layer_to_vllm_kernel_no_fp8():


### PR DESCRIPTION
## Summary
- Mark GLM DSA sparse-indexer weights as frozen because sparse index selection is non-differentiable and already runs under `torch.no_grad()`.
- Keep those weights as model parameters, so they remain in model checkpoints/state dicts, but avoid creating an optimizer-state contract for them.
- Add focused coverage that the GLM DSA indexer is frozen while surrounding attention projections remain trainable.

## Validation
- `uv run ruff check src/prime_rl/trainer/models/glm_moe_dsa/sparse_mla_attention.py tests/unit/train/models/test_glm_moe_dsa_conversion.py`
- `uv run pytest tests/unit/train/models/test_glm_moe_dsa_conversion.py`
- Strict CPU DCP smoke with `GlmMoeDsaAttention`: trainable attention params get AdamW state, frozen indexer params do not, and save/load succeeds without indexer optimizer state.