### PR TITLE
fix(trainer): freeze DSA sparse indexer so checkpoint resume doesn't crash-loop

### DIFF
--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -37,6 +37,7 @@ from prime_rl.trainer.models import (
     get_custom_vlm_cls,
     supports_custom_impl,
 )
+from prime_rl.trainer.models.glm_moe_dsa.sparse_mla_attention import Indexer
 from prime_rl.trainer.models.layers.checkpointing import (
     get_supported_targets,
     set_selective_activation_checkpointing,
@@ -348,6 +349,29 @@ def freeze_moe_router(model: nn.Module) -> None:
         raise ValueError("No MoE router parameters found to freeze. Is this a MoE model?")
 
     logger.info(f"Froze {num_frozen} MoE router parameters")
+
+
+def freeze_sparse_indexer(model: nn.Module) -> None:
+    """Freeze DSA sparse-attention indexer parameters.
+
+    The indexer's `compute_sparse_indices` forward runs under `torch.no_grad()`, so its
+    params never receive a gradient and cannot be trained. Left with requires_grad=True
+    they stay stateless in the optimizer, which breaks strict checkpoint resume: DCP
+    materializes optimizer state for every requires_grad param at load time, but the
+    stateless params were never saved -> "Missing key in checkpoint state_dict". Freezing
+    them keeps the saved and loaded optimizer state symmetric.
+    """
+    logger = get_logger()
+    num_frozen = 0
+
+    for module in model.modules():
+        if isinstance(module, Indexer):
+            for param in module.parameters():
+                param.requires_grad = False
+                num_frozen += 1
+
+    if num_frozen > 0:
+        logger.info(f"Froze {num_frozen} sparse indexer parameters")
 
 
 def apply_force_balanced_routing(model: nn.Module) -> None:
@@ -1074,6 +1098,11 @@ def setup_model(
 
     if config.freeze_moe_router:
         freeze_moe_router(model)
+
+    # The DSA sparse-attention indexer runs its forward under torch.no_grad(), so it is
+    # never trainable. Freeze it so optimizer state stays symmetric across checkpoint
+    # save/resume. No-op for models without a sparse indexer.
+    freeze_sparse_indexer(model)
 
     if config.debug.force_balanced_routing:
         apply_force_balanced_routing(model)

--- a/src/prime_rl/trainer/optim.py
+++ b/src/prime_rl/trainer/optim.py
@@ -149,10 +149,15 @@ def _create_optimizer(
     """Create optimizer. If lr is None, uses config.lr."""
     if lr is None:
         lr = config.lr
+    # Only hand trainable params to the optimizer. Frozen params (e.g. the DSA sparse
+    # indexer, which runs under no_grad) carry no optimizer state, and including them
+    # breaks strict checkpoint resume (DCP materializes state for every requires_grad
+    # param at load time, mismatching the saved state). Muon filters internally below.
+    trainable_params = [p for _, p in named_params if p.requires_grad]
     match config.type:
         case "sgd":
             return SGD(
-                params=[p for _, p in named_params],
+                params=trainable_params,
                 lr=lr,
                 weight_decay=config.weight_decay,
                 momentum=config.momentum,
@@ -160,7 +165,7 @@ def _create_optimizer(
             )
         case "adamw":
             return AdamW(
-                params=[p for _, p in named_params],
+                params=trainable_params,
                 lr=lr,
                 weight_decay=config.weight_decay,
                 betas=(config.betas1, config.betas2),
@@ -169,7 +174,7 @@ def _create_optimizer(
             return _create_muon_optimizer(config, named_params, parallel_dims, lr)
         case "sign_sgd":
             return SignSGD(
-                params=[p for _, p in named_params],
+                params=trainable_params,
                 lr=lr,
                 weight_decay=config.weight_decay,
             )


### PR DESCRIPTION
## Problem

Resuming the 800B DSA prod run crash-loops with:

```
RuntimeError: Missing key in checkpoint state_dict:
    app.optimizers.state.model.layers.0.self_attn.indexer.wq_b.weight.step
```

With `resume_step = -1` every restart re-picks the same checkpoint and dies identically — the crash-loop the watchdog logged from 16:44 onward.

## Root cause

The DSA sparse-attention `Indexer.compute_sparse_indices` forward runs under `@torch.no_grad()`, so the indexer params (`wq_b`, `wk`, `k_norm`, `weights_proj`) **never receive a gradient**. They were left with `requires_grad=True` and handed to AdamW, which lazily creates per-param state only on the first step where a grad exists — so the indexer params stay **stateless**.

This makes checkpoint save/load asymmetric via DCP's `_init_optim_state`:

- **Save** (after training): `optim.state` is already non-empty, so `_init_optim_state` returns early. The stateless indexer params are omitted from the saved optimizer state.
- **Load** (fresh optimizer): `optim.state` is empty, so `_init_optim_state` runs a zero-grad step over **every** `requires_grad=True` param and materializes `exp_avg`/`exp_avg_sq`/`step` — including the indexer. DCP now demands those keys, the checkpoint doesn't have them → `Missing key in checkpoint state_dict`.

## Fix

- **`freeze_sparse_indexer()`** (`trainer/model.py`): set `requires_grad=False` on all `Indexer` params, called unconditionally in `setup_model` (no-op for non-DSA models). The indexer is never trainable anyway — this only makes save/load state symmetric.
- **`_create_optimizer()`** (`trainer/optim.py`): hand only trainable params to AdamW/SGD/SignSGD (Muon already filtered frozen params internally), so frozen params carry no optimizer state.

Backward compatible with existing checkpoints: the new optimizer simply never expects indexer optimizer state, and the indexer weights still load as model params.

## Repro

A small-scale repro (real `Indexer` module + real `AppState`/DCP save→load path, single-process gloo, no GPU/kernels needed) reproduces the exact prod FQN and confirms the fix:

```
BEFORE FIX: indexer params trainable but never get a grad
[save] indexer params have optimizer state: False
Restarting (fresh model + optimizer), loading checkpoint...
[crash] RuntimeError: Missing key in checkpoint state_dict: app.optimizers.state.model.layers.0.self_attn.indexer.wq_b.weight.step.

AFTER FIX: indexer frozen + only trainable params in optimizer
[save] indexer params have optimizer state: False
Restarting (fresh model + optimizer), loading checkpoint...
[load] checkpoint loaded successfully -- no crash
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches checkpoint save/load symmetry for all trainers using AdamW/SGD/SignSGD; behavior change is intentional (exclude frozen params) and should be backward compatible with existing checkpoints.
> 
> **Overview**
> Fixes **crash-loop on DCP checkpoint resume** for DSA models where optimizer state keys for sparse-attention indexer weights were missing (`Missing key in checkpoint state_dict: ...indexer.wq_b.weight.step`).
> 
> Adds **`freeze_sparse_indexer()`** in model setup: all `Indexer` parameters get `requires_grad=False` because `compute_sparse_indices` runs under `torch.no_grad()` and never trains. Called unconditionally in `setup_model` (no-op without an indexer).
> 
> **`_create_optimizer()`** now passes only **trainable** parameters to AdamW, SGD, and SignSGD so frozen params are not in the optimizer (Muon already skipped non-trainable params). Save and load then agree on which params have optimizer state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 877f46409227221f8224d8c495b4c454e1347389. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->