### PR TITLE
fix(laguna): match vLLM YaRN attention scaling to fix RL KL mismatch

### DIFF
--- a/src/prime_rl/trainer/models/laguna/modeling_laguna.py
+++ b/src/prime_rl/trainer/models/laguna/modeling_laguna.py
@@ -1,3 +1,4 @@
+import math
 from collections.abc import Callable
 from typing import Optional, Union
 
@@ -30,6 +31,26 @@ from prime_rl.trainer.models.layers.norms import RMSNorm, RMSNormConfig
 from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
 
 
+def _vllm_yarn_attention_scaling(rope_params: dict) -> float | None:
+    """Replicate the YaRN cos/sin scaling that vLLM's `get_rope` applies, so trainer
+    logprobs match vLLM inference.
+
+    HF's yarn init honors the config's `attention_factor` (Laguna sets it to 1.0).
+    vLLM's `get_rope`, however, only forwards `attn_factor` to its YaRN embedding and
+    drops `attention_factor` entirely, so it applies the default mscale
+    `0.1*ln(factor)+1` (≈1.4159 for factor=64). Returns the vLLM scaling for yarn
+    layers, or None for non-yarn layers (which need no override).
+    """
+    if rope_params.get("rope_type") != "yarn":
+        return None
+    attn_factor = float(rope_params.get("attn_factor", 1.0))
+    if not rope_params.get("apply_yarn_scaling", True):
+        return attn_factor
+    factor = rope_params["factor"]
+    mscale = 0.1 * math.log(factor) + 1.0 if factor > 1 else 1.0
+    return mscale * attn_factor
+
+
 class LagunaRotaryEmbedding(nn.Module):
     def __init__(self, config: LagunaConfig, device=None):
         super().__init__()
@@ -46,6 +67,9 @@ class LagunaRotaryEmbedding(nn.Module):
             if self.rope_type[layer_type] != "default":
                 rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type[layer_type]]
             inv_freq, attention_scaling = rope_init_fn(self.config, device, layer_type=layer_type)
+            vllm_scaling = _vllm_yarn_attention_scaling(rope_params)
+            if vllm_scaling is not None:
+                attention_scaling = vllm_scaling
             self.register_buffer(f"{layer_type}_inv_freq", inv_freq, persistent=False)
             self.register_buffer(f"{layer_type}_original_inv_freq", inv_freq.clone(), persistent=False)
             setattr(self, f"{layer_type}_attention_scaling", attention_scaling)
@@ -464,6 +488,9 @@ class LagunaForCausalLM(LagunaPreTrainedModel, GenerationMixin):
                 getattr(rotary_emb, f"{layer_type}_inv_freq").device,
                 layer_type=layer_type,
             )
+            vllm_scaling = _vllm_yarn_attention_scaling(rotary_emb.config.rope_parameters[layer_type])
+            if vllm_scaling is not None:
+                attention_scaling = vllm_scaling
             getattr(rotary_emb, f"{layer_type}_inv_freq").copy_(inv_freq)
             getattr(rotary_emb, f"{layer_type}_original_inv_freq").copy_(inv_freq)
             setattr(rotary_emb, f"{layer_type}_attention_scaling", attention_scaling)


### PR DESCRIPTION
## Problem

Custom **Laguna** (`poolside/Laguna-XS.2`) shows a large RL importance-sampling mismatch from the very first step: mean `mismatch_kl/all/mean` ≈ **0.030** over 20 steps on the math env (`batch_size=64`, `sign_sgd` lr=1e-6), versus the ~0.0015 floor the other custom models reach. The mismatch is present at step 0 (systematic), pointing at a trainer-vs-vLLM modeling difference rather than the weight broadcast.

## Root cause

Laguna's `full_attention` layers use **YaRN** rope (`factor=64`, `partial_rotary_factor=0.5`, `attention_factor=1.0`); `sliding_attention` layers use default rope.

- The trainer builds rope via HF's `ROPE_INIT_FUNCTIONS["yarn"]`, which **honors** the config's `attention_factor=1.0` → cos/sin scaled by **1.0**.
- vLLM's `get_rope` yarn branch only forwards `attn_factor` to `YaRNScalingRotaryEmbedding` and **drops `attention_factor`**, so it applies YaRN's default mscale `0.1·ln(64)+1 ≈ **1.4159**`.

So on every full_attention layer (10 of 40) the trainer's rope-rotated q/k differed from vLLM's by a constant ~1.4159×. A local cos/sin parity check confirmed: the only difference is the scaling (inv_freq matches to float32 precision), and after the fix the trainer and vLLM rope match exactly (Δ=0) for both layer types.

## Fix

Replicate vLLM's YaRN scaling in `LagunaRotaryEmbedding`: for yarn layers set the attention scaling to `yarn_get_mscale(factor) * attn_factor` (ignoring `attention_factor`, as vLLM does), applied in both the eager init path and `init_buffers_post_meta` (the meta-device path used during training). Non-yarn layers are untouched.

## Result

`poolside/Laguna-XS.2`, 20-step mean `mismatch_kl/all/mean`: **0.030 → 0.0034** (wandb project `laguna-trinity-kl`, runs `laguna-base-main` vs `laguna-fix`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
