### PR TITLE
fix: surface deep_gemm load failures instead of silently disabling FP8

### DIFF
--- a/src/prime_rl/trainer/models/layers/fp8_linear.py
+++ b/src/prime_rl/trainer/models/layers/fp8_linear.py
@@ -4,10 +4,14 @@ import re
 
 try:
     import deep_gemm
-except ImportError:
+except ModuleNotFoundError:
     deep_gemm = None  # CPU-only environments don't ship deep_gemm; FP8 paths
     # are GPU-only at runtime, so leaving the symbol None is safe — only the
-    # autograd Function bodies below actually call into it.
+    # autograd Function bodies below actually call into it. A genuine load
+    # failure (deep_gemm installed but its CUDA libs unresolved, e.g. a missing
+    # libcudart.so) is NOT swallowed: it raises here with the real cause instead
+    # of resurfacing later as a cryptic 'NoneType has no attribute fp8_gemm_nt'
+    # in the first FP8 forward pass.
 import torch
 from torch import nn
 


### PR DESCRIPTION
## Problem

`fp8_linear.py` wraps the deep_gemm import in a bare `except ImportError`:

```python
try:
    import deep_gemm
except ImportError:
    deep_gemm = None
```

This is meant to support CPU-only environments where deep_gemm isn't installed. But `ImportError` also fires when deep_gemm **is** installed and its native extension fails to load — e.g. a wheel that links `libcudart.so.13` running on a host with only CUDA 12. In that case the symbol is silently set to `None`, and the real failure doesn't surface until the first FP8 forward pass, as a misleading:

```
AttributeError: 'NoneType' object has no attribute 'fp8_gemm_nt'
```

We hit this on a multi-node GLM-5.1 run: the deep_gemm release wheel linked CUDA 13 libs while the nodes shipped CUDA 12.9, so every FP8 matmul died with the `NoneType` error deep in the trainer — hours of misdirection before tracing it back to a swallowed `libcudart.so.13: cannot open shared object file` at import.

## Fix

Narrow the except to `ModuleNotFoundError`:

- **Not installed** (CPU-only) → still raises `ModuleNotFoundError`, falls back to `None`. Unchanged behavior.
- **Installed but failed to load** (missing/mismatched CUDA libs) → raises a plain `ImportError`, which now propagates with its real cause, making the misconfiguration obvious at import time.

Aligns with the "errors should never pass silently" principle — the CPU fallback stays, but a broken native install no longer masquerades as a missing-attribute bug.