### PR TITLE
fix: raise vLLM DP coordinator startup timeout (hard-coded 30s)

### DIFF
--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -854,3 +854,36 @@ def monkey_patch_fp32_lm_head():
     LogitsProcessor.__init__ = _patched_init
     LogitsProcessor._get_logits = _patched_get_logits
     logger.info("Installed fp32 lm_head patch (native out_dtype=fp32 mm).")
+
+
+def monkey_patch_dp_coordinator_startup_timeout():
+    """Raise the DP coordinator startup timeout from vLLM's hard-coded 30s.
+
+    The coordinator child process is spawned on the DP-rank-0 API server while
+    every engine-core rank on the node is importing and loading weights, so its
+    own spawn-time re-import can take well over 30s under that CPU/IO
+    contention (seen on multi-node disaggregated GLM-5.1 launches). Configurable
+    via PRIME_DP_COORDINATOR_STARTUP_TIMEOUT (seconds, default 300).
+    """
+    import multiprocessing.connection
+    import os
+
+    from vllm.v1.engine.coordinator import DPCoordinator
+
+    timeout = float(os.environ.get("PRIME_DP_COORDINATOR_STARTUP_TIMEOUT", "300"))
+
+    def _patched_wait_for_zmq_addrs(self, zmq_addr_pipe):
+        try:
+            ready = multiprocessing.connection.wait([zmq_addr_pipe, self.proc.sentinel], timeout=timeout)
+            if not ready:
+                raise RuntimeError(
+                    f"DP Coordinator process failed to report ZMQ addresses within {timeout}s during startup."
+                )
+            try:
+                return zmq_addr_pipe.recv()
+            except EOFError:
+                raise RuntimeError("DP Coordinator process failed during startup.") from None
+        finally:
+            zmq_addr_pipe.close()
+
+    DPCoordinator._wait_for_zmq_addrs = _patched_wait_for_zmq_addrs

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -20,6 +20,7 @@ from prime_rl.utils.logger import get_logger
 
 logger = get_logger()
 from prime_rl.inference.patches import (
+    monkey_patch_dp_coordinator_startup_timeout,
     monkey_patch_harmony_stop_token_propagation,
     monkey_patch_load_lora_adapter,
     monkey_patch_nano_v3_reasoning_parser,
@@ -42,6 +43,10 @@ monkey_patch_nano_v3_reasoning_parser()
 # NOTE: Optional mitigation for vLLM padded decode inputs until the native fix
 # is available in our pinned runtime.
 monkey_patch_vllm_padded_input_scrub()
+# NOTE: vLLM hard-codes a 30s DP coordinator startup timeout, which the rank-0
+# API server blows through when all engine-core ranks on the node are loading
+# weights concurrently (multi-node disaggregated deployments).
+monkey_patch_dp_coordinator_startup_timeout()
 
 logger = init_logger("vllm.entrypoints.openai.api_server")
 


### PR DESCRIPTION
The coordinator child spawns on the DP-rank-0 API server while every engine-core rank on the node is importing and loading weights, so its spawn-time re-import can exceed 30s under that CPU/IO contention (seen on multi-node disaggregated GLM-5.1 launches). Patch _wait_for_zmq_addrs with a configurable timeout via PRIME_DP_COORDINATOR_STARTUP_TIMEOUT (default 300s).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Startup-only change to inference process coordination; no request-path or data-handling logic, though a wrong timeout could still delay or fail cluster bring-up.
> 
> **Overview**
> Fixes **multi-node disaggregated** vLLM startups where the DP-rank-0 API server can fail while waiting for the DP coordinator child to publish ZMQ addresses, because vLLM’s `DPCoordinator._wait_for_zmq_addrs` uses a **hard-coded 30s** timeout that is too short when every engine-core rank on the node is importing and loading weights at the same time.
> 
> Adds `monkey_patch_dp_coordinator_startup_timeout()` in `patches.py`, which replaces that wait with the same logic but a **configurable** timeout from `PRIME_DP_COORDINATOR_STARTUP_TIMEOUT` (seconds, **default 300**), and invokes the patch at vLLM server import time in `server.py` with the other runtime monkey patches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da3193aa15506db747b3bfa40beb17801ec35187. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->