### PR TITLE
add nixl to gigitngore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,8 @@ configs/endpoints.py
 final_summary.json
 .pydantic_config
 .chroma_db
-
+deps/nixl_*
+nixl_workspace/*
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only ignore-rule changes; no runtime or application logic is modified.
> 
> **Overview**
> Updates **`.gitignore`** so local **NIXL** build/install paths are not committed: `deps/nixl_*` and `nixl_workspace/*`.
> 
> Also **enables** ignoring the entire **`third_party/`** tree (the previous `#third_party/` entry was commented out, so that directory was tracked/visible to git before).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3a5232dee7e7de44f1f14578b6817e2dbe94220. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->