### PR TITLE
fix(config): make enable_return_routed_experts derived from enable_router_replay (single source of truth)

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -420,19 +420,29 @@ class RLConfig(BaseConfig):
 
     @model_validator(mode="after")
     def auto_setup_router_replay(self):
-        if self.trainer.enable_router_replay:
-            if self.inference is not None:
-                if self.inference.enable_return_routed_experts is False:
-                    warnings.warn(
-                        "Router replay is enabled, but inference.enable_return_routed_experts is False. Setting to True.",
-                        stacklevel=2,
-                    )
-                self.inference.enable_return_routed_experts = True
-            else:
-                warnings.warn(
-                    "Router replay is enabled, but inference is not configured. When manually starting the inference server, make sure to pass `--enable-return-routed-experts` to the vLLM server.",
-                    stacklevel=2,
+        # `trainer.enable_router_replay` is the single source of truth. The vLLM
+        # server flag `inference.enable_return_routed_experts` is *derived* from
+        # it, never set by hand: returning the per-token expert traces is only
+        # useful when the trainer replays routing. Returning them without
+        # replaying silently wastes inference compute and a large amount of host
+        # RAM — the traces flow all the way to the trainer, which then drops
+        # them (see trainer/rl/train.py). Setting the inference flag directly in
+        # the RL config is therefore rejected, so the two can never desync.
+        if self.inference is not None:
+            if "enable_return_routed_experts" in self.inference.model_fields_set:
+                raise ValueError(
+                    "Do not set `inference.enable_return_routed_experts` directly in the RL "
+                    "config — it is derived from `trainer.enable_router_replay`. Set "
+                    "`trainer.enable_router_replay` instead."
                 )
+            self.inference.enable_return_routed_experts = self.trainer.enable_router_replay
+        elif self.trainer.enable_router_replay:
+            warnings.warn(
+                "Router replay is enabled, but inference is not configured. When manually "
+                "starting the inference server, make sure to pass `--enable-return-routed-experts` "
+                "to the vLLM server.",
+                stacklevel=2,
+            )
         return self
 
     @model_validator(mode="after")


### PR DESCRIPTION
## Problem

`trainer.enable_router_replay` and `inference.enable_return_routed_experts` describe one concept across two config sections, and `RLConfig.auto_setup_router_replay` linked them **only one way**:

```python
if self.trainer.enable_router_replay:
    ...
    self.inference.enable_return_routed_experts = True   # replay -> return: forced
# replay off -> return: left at whatever was set
```

So a config with `enable_router_replay=false` but a stale `enable_return_routed_experts=true` silently keeps the vLLM engines computing and returning the per-token routed-expert traces (~600 B/token). That's wasted inference compute and a large amount of host RAM — the traces are serialized over the wire, held by the env/orchestrator workers, and shipped all the way to the trainer, which then **throws them away** (`trainer/rl/train.py` sets `routed_experts = None` when replay is off).

We hit this on a multi-node run: flipping `enable_router_replay` off did not reduce memory as expected because `enable_return_routed_experts` stayed `true`, and the worker bloat from the still-returned traces contributed to an out-of-RAM crash.

## Fix

Make `trainer.enable_router_replay` the **single source of truth**:

- In the RL config, `inference.enable_return_routed_experts` is **derived** from `trainer.enable_router_replay` (both directions — replay off now forces return off).
- Setting `inference.enable_return_routed_experts` directly in the RL config is **rejected** (detected via `model_fields_set`), so the two can never silently desync — you set `enable_router_replay` and nothing else.
- The flag remains independently settable for **standalone vLLM-server launches** (where `RLConfig` and this validator don't run), and the existing "inference not configured, pass `--enable-return-routed-experts`" warning is preserved for the manual-server case.

## Note for config authors

Configs that previously set `inference.enable_return_routed_experts` explicitly must drop it and rely on `trainer.enable_router_replay` — otherwise the new validator raises with a message pointing at the right knob.