### PR TITLE
feat(v1): encode router-replay routed_experts into transport

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -454,6 +454,21 @@ class RLConfig(BaseConfig):
         return self
 
     @model_validator(mode="after")
+    def disable_prefix_caching_for_router_replay(self):
+        # Prefix-cache hits skip recomputing the cached prefix, so the engine returns no
+        # routed-expert decisions for those tokens. Router replay needs routing for every
+        # token (branch attribution is all-or-nothing), so force full recompute.
+        if self.trainer.enable_router_replay and self.inference is not None:
+            if self.inference.enable_prefix_caching:
+                warnings.warn(
+                    "Router replay needs routing for every token, but prefix-cache hits carry "
+                    "none. Setting inference.enable_prefix_caching=False.",
+                    stacklevel=2,
+                )
+            self.inference.enable_prefix_caching = False
+        return self
+
+    @model_validator(mode="after")
     def validate_mooncake_offload_requires_slurm(self):
         if (
             self.slurm is None

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -454,21 +454,6 @@ class RLConfig(BaseConfig):
         return self
 
     @model_validator(mode="after")
-    def disable_prefix_caching_for_router_replay(self):
-        # Prefix-cache hits skip recomputing the cached prefix, so the engine returns no
-        # routed-expert decisions for those tokens. Router replay needs routing for every
-        # token (branch attribution is all-or-nothing), so force full recompute.
-        if self.trainer.enable_router_replay and self.inference is not None:
-            if self.inference.enable_prefix_caching:
-                warnings.warn(
-                    "Router replay needs routing for every token, but prefix-cache hits carry "
-                    "none. Setting inference.enable_prefix_caching=False.",
-                    stacklevel=2,
-                )
-            self.inference.enable_prefix_caching = False
-        return self
-
-    @model_validator(mode="after")
     def validate_mooncake_offload_requires_slurm(self):
         if (
             self.slurm is None

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -101,10 +101,12 @@ MAX_CONSECUTIVE_EMPTY_BATCHES = 10
 # resumed when the watcher advances ``policy.version``.
 TARGET_LAG = 1
 
-# Drop the per-node multimodal tensors when dumping a Trace to disk (rollout jsonl / wandb
-# tables): they're the training mm_kwargs carrier, not part of the rollout record, and base64
-# pixel tensors would bloat every line. `__all__` applies the exclude to every node in the list.
-ROLLOUT_DUMP_EXCLUDE = {"nodes": {"__all__": {"multi_modal_data"}}}
+# Drop the per-node training tensors when dumping a Trace to disk (rollout jsonl / wandb
+# tables): the multimodal `mm_kwargs` carrier and the router-replay `routed_experts` array are
+# training inputs, not part of the rollout record, and would bloat every line. They also can't
+# round-trip the json dump — their `__nd__` carriers hold raw bytes. `__all__` applies the
+# exclude to every node in the list.
+ROLLOUT_DUMP_EXCLUDE = {"nodes": {"__all__": {"multi_modal_data", "routed_experts"}}}
 
 
 class Orchestrator:

--- a/src/prime_rl/orchestrator/trajectories.py
+++ b/src/prime_rl/orchestrator/trajectories.py
@@ -19,7 +19,7 @@ import numpy as np
 import verifiers.v1 as vf
 
 from prime_rl.transport import TrainingSample
-from prime_rl.transport.types import EncodedTensor
+from prime_rl.transport.types import EncodedTensor, RoutedExperts
 from prime_rl.utils.logger import get_logger
 
 
@@ -45,6 +45,23 @@ def _encode_mm_kwargs(mm_items: dict[str, list[dict]]) -> dict[str, EncodedTenso
         arr = np.concatenate(arrs, axis=0)
         encoded[key] = EncodedTensor(dtype=str(arr.dtype), shape=list(arr.shape), data=arr.tobytes())
     return encoded or None
+
+
+def _encode_routed_experts(arr: np.ndarray | None, num_tokens: int) -> RoutedExperts | None:
+    """The branch's router-replay array (`[tokens, layers, top_k]`) -> the transport
+    `RoutedExperts` the trainer replays. Defensively realigns the token axis to `num_tokens`
+    (the trainer asserts `routed_experts.shape[0] == len(token_ids)`): truncate if longer,
+    zero-pad the tail if shorter. `Branch.routed_experts` already guarantees alignment, so this
+    is a backstop."""
+    if arr is None:
+        return None
+    arr = np.ascontiguousarray(arr)
+    if arr.shape[0] > num_tokens:
+        arr = arr[:num_tokens]
+    elif arr.shape[0] < num_tokens:
+        pad = np.zeros((num_tokens - arr.shape[0], *arr.shape[1:]), dtype=arr.dtype)
+        arr = np.concatenate([arr, pad], axis=0)
+    return RoutedExperts(data=arr.tobytes(), shape=list(arr.shape), dtype=str(arr.dtype))
 
 
 def trace_to_samples(
@@ -88,6 +105,7 @@ def trace_to_samples(
                 env_name=env_name,
                 mm_kwargs=mm_kwargs,
                 mm_token_type_ids=mm_token_type_ids,
+                routed_experts=_encode_routed_experts(branch.routed_experts, len(token_ids)),
             )
         )
     if not samples:


### PR DESCRIPTION
## Summary

Makes v1 MoE **router replay** work end-to-end on Qwen3-30B-A3B, plus the transport encode.

- `_encode_routed_experts` packs a branch's `routed_experts` (`[tokens, layers, top_k]`) into the transport `RoutedExperts` (raw bytes), realigning the token axis to `len(token_ids)` (tail zero-pad) as a backstop.
- `ROLLOUT_DUMP_EXCLUDE` drops `routed_experts` from disk dumps (training input, not a rollout record; rides the wire as raw bytes — verified absent from `train_rollouts.jsonl`).
- Bumps `deps/verifiers` (routed_experts capture + raw-bytes wire + final-node tail-pad; merged #1672) and `deps/renderers` (`_get_offset_tokenizer` fastokens-race fix, PrimeIntellect-ai/renderers#86).

## E2E verification (Qwen3-30B-A3B, math-env-v1)
Router replay **lowers train/inference mismatch KL** at every step:

| step | r3-off | r3-on |
|---|---|---|
| 0 | 0.0015 | **0.0005** |
| 1 | 0.0015 | **0.0002** |
| 2 | 0.0005 | **0.0002** |

**Prefix caching is compatible** with router replay (no special handling needed): a separate run with `enable_prefix_caching` ON captured full routing on every rollout including repeated-prompt cache hits (61/61, zero `None`) and trained cleanly (step-0 mismatch KL 0.0001). So no prefix-cache guard is added.

## Payload & disk
- Routing payload: uint8 `[tokens, 48, 8]` = 384 B/token, raw msgpack bytes (no base64).
- Transport bins: ~7.1 MB/step with replay vs ~1.2 MB/step without; trajectory jsonl unchanged (routing excluded).

Note: vLLM 30B-MoE inference startup is slow (engine init = profile + KV-cache + warmup ≈ 6–7 min); use `enforce_eager` and a generous `wait_for_ready_timeout`.

Depends on verifiers #1672 (merged) and renderers PR PrimeIntellect-ai/renderers#86.