### PR TITLE
feat(deployment): optionally run orchestrator on an inference node

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -167,6 +167,9 @@ class MultiNodeDeploymentConfig(BaseDeploymentConfig):
     nodes_per_fsdp_group: int | None = None
     """Training nodes per FSDP island. Auto-sets ``trainer.dp_replicate = num_train_nodes / nodes_per_fsdp_group``."""
 
+    orchestrator_on_inference: bool = False
+    """Run the orchestrator on the last inference node instead of trainer rank 0 (frees host RAM on the trainer node)."""
+
     @property
     def total_infer_nodes(self) -> int:
         return self.num_infer_nodes * self.num_infer_replicas

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -383,6 +383,7 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
             **mooncake_vars,
             use_nccl_broadcast=config.weight_broadcast is not None and config.weight_broadcast.type == "nccl",
             ranks_filter=",".join(map(str, config.trainer.log.ranks_filter)),
+            orchestrator_on_inference=config.deployment.orchestrator_on_inference,
         )
     else:
         script = template.render(
@@ -405,6 +406,7 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
             **mooncake_vars,
             use_nccl_broadcast=config.weight_broadcast is not None and config.weight_broadcast.type == "nccl",
             ranks_filter=",".join(map(str, config.trainer.log.ranks_filter)),
+            orchestrator_on_inference=config.deployment.orchestrator_on_inference,
         )
 
     script_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -353,15 +353,6 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
 
 else
     TRAIN_NODE_RANK=$((SLURM_PROCID - NUM_INFER_NODES))
-
-    if [ "$TRAIN_NODE_RANK" -eq 0 ]; then
-        ORCHESTRATOR_ARGS="@ $CONFIG_DIR/orchestrator.toml"
-        ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --student.client.base-url $INFER_URLS"
-        ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --student.client.admin-base-url $ADMIN_URLS"
-        {% if use_nccl_broadcast %}ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --weight_broadcast.host $MASTER_ADDR"
-        {% endif %}WANDB_SHARED_LABEL=orchestrator uv run orchestrator $ORCHESTRATOR_ARGS \
-            2>&1 | tee $OUTPUT_DIR/logs/orchestrator.log &
-    fi
 {%- else %}
     TRAIN_NODE_RANK=$SLURM_PROCID
 {%- endif %}
@@ -388,6 +379,21 @@ else
         @ $CONFIG_DIR/trainer.toml \
         2>&1 | sed -u 's/^\[[a-zA-Z]*[0-9]*\]://' | tee -a $OUTPUT_DIR/logs/trainer/node_${TRAIN_NODE_RANK}.log &
 {% if num_infer_nodes > 0 %}    fi{% endif %}
+{% if num_infer_nodes > 0 %}
+# Launch the orchestrator on one node. Default is trainer rank 0 (SLURM_PROCID ==
+# NUM_INFER_NODES). With orchestrator_on_inference it moves to the last inference node
+# (a decode node) to keep its rollout buffer + env workers off host-RAM-saturated
+# trainer nodes. Top-level (after the role if/else) so the wait -n teardown covers it.
+{% if orchestrator_on_inference %}ORCH_PROCID=$((NUM_INFER_NODES - 1)){% else %}ORCH_PROCID=$NUM_INFER_NODES{% endif %}
+if [ "$SLURM_PROCID" -eq "$ORCH_PROCID" ]; then
+    ORCHESTRATOR_ARGS="@ $CONFIG_DIR/orchestrator.toml"
+    ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --student.client.base-url $INFER_URLS"
+    ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --student.client.admin-base-url $ADMIN_URLS"
+    {% if use_nccl_broadcast %}ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --weight_broadcast.host $MASTER_ADDR"
+    {% endif %}WANDB_SHARED_LABEL=orchestrator uv run orchestrator $ORCHESTRATOR_ARGS \
+        2>&1 | tee $OUTPUT_DIR/logs/orchestrator.log &
+fi
+{% endif %}
 
 # Wait for the first background job to exit and propagate its exit code. This
 # turns background process crashes (router, orchestrator) into task failures


### PR DESCRIPTION
## Summary

Adds `MultiNodeDeploymentConfig.orchestrator_on_inference` (default `False`) to choose where the orchestrator launches:

- **`False` (default, unchanged):** orchestrator runs on **trainer rank 0**.
- **`True`:** orchestrator runs on the **last inference node** (a decode node — tail of the last replica, never a router/prefill head).

## Why

On large multi-node runs the trainer nodes can be host-RAM-saturated (e.g. 8 ranks of CPU-offloaded optimizer state ≈ 800 GiB). Co-locating the orchestrator there means its rollout buffer + env workers compete for the same host RAM and can exhaust it (we hit a trainer SIGBUS from exactly this). Inference nodes keep weights/KV on GPU and typically have ample free host RAM, so moving the orchestrator there removes the contention. This makes it a per-deployment choice rather than hardcoding either placement.

## Implementation

The orchestrator launch is now a **single top-level block** in `multi_node_rl.sbatch.j2` (after the role `if/else`, so the existing `wait -n` teardown still covers it), gated on a flag-selected `SLURM_PROCID`:

```
{% if orchestrator_on_inference %}ORCH_PROCID=$((NUM_INFER_NODES - 1)){% else %}ORCH_PROCID=$NUM_INFER_NODES{% endif %}
if [ "$SLURM_PROCID" -eq "$ORCH_PROCID" ]; then ... fi
```

Both placements share one code path — no duplicated launch logic. `NUM_INFER_NODES` maps to trainer rank 0 (since `TRAIN_NODE_RANK = SLURM_PROCID - NUM_INFER_NODES`), `NUM_INFER_NODES-1` is the last inference node. No effect when `num_infer_nodes == 0`.

## Validation

Rendered the template both ways and `bash -n`'d the output — both valid; orchestrator launches exactly once in each, on the expected node.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where a critical RL control process runs in multi-node SLURM jobs; default placement is unchanged, but enabling the flag shifts rollout/env RAM load onto an inference node that also runs vLLM.
> 
> **Overview**
> Adds **`deployment.orchestrator_on_inference`** (default `False`) on multi-node RL configs so SLURM jobs can place the orchestrator on the **last inference node** instead of **trainer rank 0**, to avoid host-RAM contention with heavy trainer CPU offload.
> 
> The **`multi_node_rl.sbatch.j2`** launch is refactored: orchestrator startup is no longer inside the trainer-only branch on rank 0, but a **single shared block** after the infer/train role split that picks `ORCH_PROCID` as either `NUM_INFER_NODES` (unchanged default) or `NUM_INFER_NODES - 1` when the flag is set—still gated on `num_infer_nodes > 0` and still covered by `wait -n` teardown.
> 
> **`write_slurm_script`** passes the flag into both standard and disaggregated template renders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit febd91cf4c0bb7980c559cbcaf4606647f8d7645. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->