### PR TITLE
fix(inference): strip routed_experts from chat-completions responses

### DIFF
--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -117,7 +117,9 @@ def monkey_patch_strip_routed_experts_from_chat():
 
     _patched._prime_rl_strips_routed_experts = True
     OpenAIServingChat.chat_completion_full_generator = _patched
-    logger.info("Stripped routed_experts from chat-completions responses (PD router merges only the /generate object form).")
+    logger.info(
+        "Stripped routed_experts from chat-completions responses (PD router merges only the /generate object form)."
+    )
 
 
 @triton.jit

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -84,6 +84,42 @@ def monkey_patch_return_routed_experts_with_nixl_connector():
     logger.warning("Enabled vLLM routed-experts capture with NIXL connector patch.")
 
 
+def monkey_patch_strip_routed_experts_from_chat():
+    """Drop routed_experts from chat-completions responses.
+
+    routed_experts are only consumed via the serialized ``/generate``
+    (serving_tokens) path used for router-replay training, which encodes them as a
+    ``{data, shape, start}`` object the PD router can merge. The stock
+    chat-completions path instead encodes them as a base64 ``np.save`` *string*,
+    which the PD router rejects ("prefill routed_experts must be an object with
+    base64 data and shape") and fails every eval rollout (evals go through chat
+    completions). ``enable_return_routed_experts`` is a server-wide model-config
+    flag with no per-request toggle, so strip the field on the chat path here.
+    """
+    from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
+    from vllm.logger import init_logger
+
+    logger = init_logger(__name__)
+
+    if getattr(OpenAIServingChat.chat_completion_full_generator, "_prime_rl_strips_routed_experts", False):
+        return
+
+    _original = OpenAIServingChat.chat_completion_full_generator
+
+    async def _strip(result_generator):
+        async for res in result_generator:
+            for output in res.outputs:
+                output.routed_experts = None
+            yield res
+
+    async def _patched(self, request, result_generator, *args, **kwargs):
+        return await _original(self, request, _strip(result_generator), *args, **kwargs)
+
+    _patched._prime_rl_strips_routed_experts = True
+    OpenAIServingChat.chat_completion_full_generator = _patched
+    logger.info("Stripped routed_experts from chat-completions responses (PD router merges only the /generate object form).")
+
+
 @triton.jit
 def _silu_mul_per_token_group_quant_fp8_colmajor_int64_kernel(
     y_ptr,

--- a/src/prime_rl/inference/vllm/server.py
+++ b/src/prime_rl/inference/vllm/server.py
@@ -24,6 +24,7 @@ from prime_rl.inference.patches import (
     monkey_patch_harmony_stop_token_propagation,
     monkey_patch_load_lora_adapter,
     monkey_patch_nano_v3_reasoning_parser,
+    monkey_patch_strip_routed_experts_from_chat,
     monkey_patch_tokenize_params_validation,
     monkey_patch_vllm_padded_input_scrub,
 )
@@ -43,6 +44,12 @@ monkey_patch_nano_v3_reasoning_parser()
 # NOTE: Optional mitigation for vLLM padded decode inputs until the native fix
 # is available in our pinned runtime.
 monkey_patch_vllm_padded_input_scrub()
+# NOTE: routed_experts are consumed only via the serialized /generate path (router
+# replay). The chat-completions path encodes them as a base64 np.save string the PD
+# router cannot merge, which fails eval rollouts (they use chat completions). Strip
+# routed_experts from chat responses since the server-wide enable flag has no
+# per-request toggle.
+monkey_patch_strip_routed_experts_from_chat()
 # NOTE: vLLM hard-codes a 30s DP coordinator startup timeout, which the rank-0
 # API server blows through when all engine-core ranks on the node are loading
 # weights concurrently (multi-node disaggregated deployments).


### PR DESCRIPTION
## Problem

`routed_experts` are only consumable via the serialized `/inference/v1/generate` (serving_tokens) path used for router-replay training, which encodes them as a `{data, shape, start}` object the PD router merges. The stock **chat-completions** path instead encodes them as a base64 `np.save` **string** (`chat_completion/serving.py`), which the PD router rejects:

```
Failed to merge routed experts: prefill routed_experts must be an object with base64 data and shape
```

This fails **every eval rollout** — evals go through chat-completions while train uses `/generate`. `enable_return_routed_experts` is a server-wide model-config flag with no per-request toggle, so eval can't opt out.

## Fix

`monkey_patch_strip_routed_experts_from_chat()` wraps `OpenAIServingChat.chat_completion_full_generator` to null `routed_experts` on the outputs before encoding, so chat responses never carry it and the PD router skips the merge. Train (`/generate`) is untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow inference monkey-patch on the chat response path only; training `/generate` behavior is untouched.
> 
> **Overview**
> With **server-wide** `enable_return_routed_experts`, vLLM was attaching `routed_experts` to **chat-completions** responses in a base64 `np.save` string form that the PD router cannot merge, breaking **eval rollouts** (eval uses chat; training uses `/generate` with `{data, shape, start}`).
> 
> This PR adds **`monkey_patch_strip_routed_experts_from_chat()`**, which wraps `OpenAIServingChat.chat_completion_full_generator` to set `routed_experts` to `None` on outputs before encoding, and registers it at vLLM server startup in `server.py`. The **`/generate` / serving_tokens** path is unchanged so router-replay training still gets mergeable expert data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b916b9435d6194cc7f55440389e7620f6cb97b32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->