### PR TITLE
feat: pause inference during trainer checkpoints

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -9,6 +9,7 @@ from renderers import AutoRendererConfig, RendererConfig
 
 from prime_rl.configs.shared import (
     BaseModelConfig,
+    CheckpointExperimentalConfig,
     ClientConfig,
     FileSystemTransportConfig,
     HeartbeatConfig,
@@ -403,6 +404,9 @@ class EvalConfig(BaseConfig):
 
 
 class CheckpointConfig(BaseConfig):
+    experimental: CheckpointExperimentalConfig | None = None
+    """Experimental checkpoint behavior. These knobs may change or be removed."""
+
     interval: int | None = Field(None, ge=1)
     """Step interval at which to save the orchestrator checkpoint."""
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -16,6 +16,7 @@ from prime_rl.configs.orchestrator import (
     OrchestratorConfig,
 )
 from prime_rl.configs.shared import (
+    CheckpointExperimentalConfig,
     SlurmConfig,
     VLMConfig,
 )
@@ -91,6 +92,9 @@ class SharedWandbConfig(BaseConfig):
 class SharedCheckpointConfig(BaseConfig):
     output_dir: Path | None = None
     """Override directory for checkpoints and weights. When set, checkpoints and weight snapshots are written here instead of under the trainer ``output_dir``."""
+
+    experimental: CheckpointExperimentalConfig | None = None
+    """Experimental checkpoint behavior. These knobs may change or be removed."""
 
     interval: int | None = None
     """Interval at which to save checkpoints."""

--- a/packages/prime-rl-configs/src/prime_rl/configs/shared.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/shared.py
@@ -145,6 +145,11 @@ class ClientConfig(BaseConfig):
         return self.elastic is not None
 
 
+class CheckpointExperimentalConfig(BaseConfig):
+    pause_inference: bool = False
+    """Pause student inference while the trainer writes interval checkpoints."""
+
+
 class LogConfig(BaseConfig):
     level: str = Field(default_factory=lambda: os.environ.get("PRIME_LOG_LEVEL", "info"))
     """Log level for the process. Defaults to ``$PRIME_LOG_LEVEL`` if set, else ``info``."""

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -6,6 +6,7 @@ from pydantic import Field, model_validator
 
 from prime_rl.configs.shared import (
     BaseModelConfig,
+    CheckpointExperimentalConfig,
     FileSystemTransportConfig,
     HeartbeatConfig,
     MetricsServerConfig,
@@ -374,6 +375,9 @@ class WeightCheckpointConfig(BaseConfig):
 class CheckpointConfig(BaseConfig):
     output_dir: Path | None = None
     """Override directory for checkpoints and weights. If set, checkpoints and weight snapshots are written here instead of under the trainer ``output_dir`` — useful for writing large checkpoints to a separate storage volume."""
+
+    experimental: CheckpointExperimentalConfig | None = None
+    """Experimental checkpoint behavior. These knobs may change or be removed."""
 
     interval: int | None = Field(None, ge=1)
     """Interval at which to save the training checkpoint. If None, only checkpoints at the end of training."""

--- a/packages/prime-rl-configs/src/prime_rl/utils/validation.py
+++ b/packages/prime-rl-configs/src/prime_rl/utils/validation.py
@@ -99,6 +99,11 @@ def propagate_shared_fields(data: Any) -> Any:
     propagate("ckpt.resume_step", "trainer.ckpt.resume_step", "orchestrator.ckpt.resume_step")
     propagate("ckpt.keep_last", "trainer.ckpt.keep_last", "orchestrator.ckpt.keep_last")
     propagate("ckpt.keep_interval", "trainer.ckpt.keep_interval", "orchestrator.ckpt.keep_interval")
+    propagate(
+        "ckpt.experimental.pause_inference",
+        "trainer.ckpt.experimental.pause_inference",
+        "orchestrator.ckpt.experimental.pause_inference",
+    )
 
     # [wandb] leaves. (Bare empty ``[wandb]`` block enablement is at the end.)
     # ``wandb.name`` flows verbatim to both sub-configs — shared W&B mode is
@@ -199,6 +204,11 @@ def validate_shared_ckpt_config(
     trainer: TrainerConfig,
     orchestrator: OrchestratorConfig,
 ) -> None:
+    def pause_inference_enabled(config: TrainerConfig | OrchestratorConfig) -> bool:
+        if config.ckpt is None or config.ckpt.experimental is None:
+            return False
+        return config.ckpt.experimental.pause_inference
+
     if trainer.ckpt and not orchestrator.ckpt:
         raise ValueError(
             "Trainer checkpoint config is specified, but orchestrator checkpoint config is not. Please setup checkpointing on both for checkpointing to work properly."
@@ -214,6 +224,10 @@ def validate_shared_ckpt_config(
     if trainer.ckpt and orchestrator.ckpt and trainer.ckpt.resume_step != orchestrator.ckpt.resume_step:
         raise ValueError(
             f"Trainer checkpoint resume step ({trainer.ckpt.resume_step}) and orchestrator checkpoint resume step ({orchestrator.ckpt.resume_step}) are not the same. Please specify the same checkpoint resume step for both."
+        )
+    if trainer.ckpt and orchestrator.ckpt and pause_inference_enabled(trainer) != pause_inference_enabled(orchestrator):
+        raise ValueError(
+            "Trainer checkpoint pause_inference setting and orchestrator checkpoint pause_inference setting are not the same. Please specify the same checkpoint experimental config for both."
         )
 
 

--- a/skills/configs/SKILL.md
+++ b/skills/configs/SKILL.md
@@ -60,6 +60,20 @@ CLI: `--env.0.id reverse-text --env.1.id math-env`.
 
 In TOML, an empty section header (`[ckpt]`) does the same.
 
+## Checkpoint inference pause
+
+For RL runs, trainer interval checkpoints can pause student inference while the checkpoint is written:
+
+```toml
+[ckpt]
+interval = 100
+
+[ckpt.experimental]
+pause_inference = true
+```
+
+This is an experimental shared checkpoint knob. Set it under top-level `[ckpt.experimental]` so it propagates to both trainer and orchestrator; the trainer requests the pause, and the orchestrator owns the actual inference `/pause` and `/resume` calls.
+
 ## RL trainer token exports
 
 For rollout debugging, enable trainer-side token export with `trainer.enable_token_export = true` (or `--enable-token-export` when running the trainer entrypoint directly). It writes one JSONL record per exported sequence. Single-run/fallback exports go under `output_dir/token_exports/step_<step>/rank_<rank>.jsonl`; multi-run trainer exports with packer metadata go under the owning run directory, `output_dir/<run_id>/token_exports/step_<run_step>/rank_<rank>.jsonl`. Each record stores aligned per-token arrays for token ids, loss mask, advantage, reward, entropy, mismatch KL, inference/trainer logprobs, importance ratios, probability deltas, and masking diagnostics. It does not decode token text in the trainer.

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -16,6 +16,7 @@ from prime_rl.configs.rl import RLConfig
 from prime_rl.utils.config import cli
 from prime_rl.utils.logger import get_logger, setup_logger
 from prime_rl.utils.pathing import (
+    clean_checkpoint_pause_requests,
     clean_future_steps,
     format_log_message,
     get_ckpt_dir,
@@ -498,6 +499,7 @@ def rl(config: RLConfig):
     else:
         get_logger().info("Training from scratch, cleaning any stale rollouts and broadcasts")
         clean_future_steps(config.output_dir, -1)
+    clean_checkpoint_pause_requests(config.output_dir)
 
     if not config.dry_run:
         from prime_rl.trainer.model import pre_download_model

--- a/src/prime_rl/orchestrator/checkpoint_pause.py
+++ b/src/prime_rl/orchestrator/checkpoint_pause.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from prime_rl.configs.orchestrator import OrchestratorConfig
+from prime_rl.utils.async_utils import safe_cancel
+from prime_rl.utils.checkpoint_pause import (
+    PAUSED,
+    RELEASE,
+    RESUMED,
+    get_pending_pause_requests,
+    read_marker,
+    write_marker,
+)
+from prime_rl.utils.client import InferencePool, pause_inference, resume_inference
+from prime_rl.utils.logger import get_logger
+
+
+class CheckpointPauseWatcher:
+    def __init__(
+        self,
+        config: OrchestratorConfig,
+        *,
+        inference: InferencePool,
+        update_lock: asyncio.Lock,
+        poll_interval: float = 0.5,
+    ) -> None:
+        self.config = config
+        # Trainer writes pause markers under the shared experiment root; the
+        # orchestrator output_dir is the per-run child (e.g. run_default).
+        self.output_dir = config.output_dir.parent
+        self.inference = inference
+        self.update_lock = update_lock
+        self.poll_interval = poll_interval
+        self.task: asyncio.Task | None = None
+        self.stopped = asyncio.Event()
+
+    async def start(self) -> None:
+        self.task = asyncio.current_task()
+        try:
+            while not self.stopped.is_set():
+                requests = get_pending_pause_requests(self.output_dir)
+                if requests:
+                    step, step_dir, request_id = requests[0]
+                    await self.handle_request(step, step_dir, request_id)
+                    continue
+                await asyncio.sleep(self.poll_interval)
+        except asyncio.CancelledError:
+            return
+
+    async def stop(self) -> None:
+        self.stopped.set()
+        if self.task is not None:
+            await safe_cancel(self.task)
+            self.task = None
+
+    async def handle_request(self, step: int, step_dir: Path, request_id: str) -> None:
+        async with self.update_lock:
+            await pause_inference(
+                self.inference.admin_clients,
+                reason=f"Pausing inference for trainer checkpoint at step {step}",
+            )
+            write_marker(step_dir, PAUSED, request_id)
+            try:
+                await self.wait_for_release(step_dir, request_id)
+            finally:
+                await resume_inference(self.inference.admin_clients)
+                write_marker(step_dir, RESUMED, request_id)
+                get_logger().info(f"Resumed inference after trainer checkpoint at step {step}")
+
+    async def wait_for_release(self, step_dir: Path, request_id: str) -> None:
+        release_path = step_dir / RELEASE
+        while not self.stopped.is_set():
+            if read_marker(release_path) == request_id:
+                return
+            await asyncio.sleep(self.poll_interval)

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -41,6 +41,7 @@ from verifiers.utils.async_utils import EventLoopLagMonitor, EventLoopLagStats
 
 import prime_rl._compat  # noqa: F401 — patch ring_flash_attn compat before transitive imports
 from prime_rl.configs.orchestrator import OrchestratorConfig
+from prime_rl.orchestrator.checkpoint_pause import CheckpointPauseWatcher
 from prime_rl.orchestrator.ckpt import setup_ckpt_manager
 from prime_rl.orchestrator.dispatcher import DispatcherMetrics, DispatcherMode, RolloutDispatcher
 from prime_rl.orchestrator.envs import EvalEnvs, TrainEnvs
@@ -137,6 +138,7 @@ class Orchestrator:
     train_sink: TrainSink
     dispatcher: RolloutDispatcher
     watcher: WeightWatcher
+    checkpoint_pause_watcher: CheckpointPauseWatcher | None
     metrics: MetricsBuilder
     lag_monitor: EventLoopLagMonitor
     periodic_logger: PeriodicLogger
@@ -196,6 +198,7 @@ class Orchestrator:
         self.lora_name = None
         self.resume_step = None
         self.lag_task = None
+        self.checkpoint_pause_watcher = None
 
     # ── lifecycle ──────────────────────────────────────────────────────────
 
@@ -400,6 +403,7 @@ class Orchestrator:
             post_filters=post_filters,
         )
         self.eval_sink = EvalSink(eval_envs=self.eval_envs) if self.eval_envs is not None else None
+        inference_update_lock = asyncio.Lock()
         self.watcher = WeightWatcher(
             config,
             policy=self.policy,
@@ -407,7 +411,14 @@ class Orchestrator:
             observers=[self.dispatcher, self],
             lora_name=self.lora_name,
             ckpt_step=self.progress.step,
+            update_lock=inference_update_lock,
         )
+        if config.ckpt and config.ckpt.experimental and config.ckpt.experimental.pause_inference:
+            self.checkpoint_pause_watcher = CheckpointPauseWatcher(
+                config,
+                inference=self.student_inference,
+                update_lock=inference_update_lock,
+            )
         # Single periodic logger for the whole pipeline. It's the only
         # consumer of ``dispatcher.metrics.drained()`` (which clears on read)
         self.lag_monitor = EventLoopLagMonitor()
@@ -451,6 +462,10 @@ class Orchestrator:
             asyncio.create_task(self.dispatcher.start(), name="dispatcher"),
             asyncio.create_task(self.watcher.start(), name="watcher"),
         ]
+        if self.checkpoint_pause_watcher is not None:
+            self.component_tasks.append(
+                asyncio.create_task(self.checkpoint_pause_watcher.start(), name="checkpoint_pause_watcher")
+            )
 
         # Default step-0 base-model eval — fires before any train rollouts
         # unless ``eval.skip_first_step=True`` (or this is a resume)
@@ -893,6 +908,8 @@ class Orchestrator:
                 await self.dispatcher.stop()
             if self.watcher is not None:
                 await self.watcher.stop()
+            if self.checkpoint_pause_watcher is not None:
+                await self.checkpoint_pause_watcher.stop()
             if self.periodic_logger is not None:
                 await self.periodic_logger.stop()
             if self.lag_task is not None:

--- a/src/prime_rl/orchestrator/watcher.py
+++ b/src/prime_rl/orchestrator/watcher.py
@@ -29,6 +29,7 @@ class WeightWatcher:
         lora_name: str | None,
         ckpt_step: int = 0,
         poll_interval: float = 1.0,
+        update_lock: asyncio.Lock | None = None,
     ) -> None:
         self.config = config
         self.policy = policy
@@ -43,7 +44,7 @@ class WeightWatcher:
         self.update_count: int = 0
 
         self.task: asyncio.Task | None = None
-        self.update_lock = asyncio.Lock()
+        self.update_lock = update_lock or asyncio.Lock()
         self.stopped = asyncio.Event()
 
     async def start(self) -> None:

--- a/src/prime_rl/trainer/multi_ckpt.py
+++ b/src/prime_rl/trainer/multi_ckpt.py
@@ -102,6 +102,8 @@ class MultiCheckpointManager:
 
     def _should_save(self, idx: int, step: int) -> bool:
         """Determine if a checkpoint should be saved for a given run and step."""
+        if self.managers[idx] is None:
+            return False
         ckpt_config = self.multi_run_manager.config[idx].ckpt
         if ckpt_config is None or ckpt_config.interval is None:
             return False
@@ -109,6 +111,13 @@ class MultiCheckpointManager:
             return False
         # Check if already saved this step
         return step not in self.managers[idx].ckpt_steps
+
+    def should_save_any(self) -> bool:
+        for idx in self.multi_run_manager.used_idxs:
+            step = self.multi_run_manager.progress[idx].step
+            if self._should_save(idx, step):
+                return True
+        return False
 
     def save(
         self,

--- a/src/prime_rl/trainer/rl/checkpoint_pause.py
+++ b/src/prime_rl/trainer/rl/checkpoint_pause.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import torch.distributed as dist
+
+from prime_rl.configs.trainer import CheckpointConfig
+from prime_rl.trainer.world import World
+from prime_rl.utils.checkpoint_pause import (
+    PAUSED,
+    get_pause_step_dir,
+    wait_for_marker,
+    write_pause_release,
+    write_pause_request,
+)
+from prime_rl.utils.logger import get_logger
+
+
+class InferenceCheckpointPause:
+    def __init__(self, output_dir: Path, config: CheckpointConfig | None, world: World) -> None:
+        self.output_dir = output_dir
+        self.world = world
+        self.enabled = bool(config and config.experimental and config.experimental.pause_inference)
+
+    def pause(self, step: int) -> str | None:
+        if not self.enabled:
+            return None
+
+        request_id = None
+        if self.world.is_master:
+            get_logger().info(f"Waiting for inference pause before trainer checkpoint at step {step}")
+            request_id = write_pause_request(self.output_dir, step)
+            wait_for_marker(get_pause_step_dir(self.output_dir, step), PAUSED, request_id)
+            get_logger().info(f"Inference paused for trainer checkpoint at step {step}")
+        dist.barrier()
+        return request_id
+
+    def release(self, step: int, request_id: str | None) -> None:
+        if not self.enabled:
+            return
+        if request_id is None:
+            return
+        if self.world.is_master:
+            write_pause_release(self.output_dir, step, request_id)

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -9,6 +9,7 @@ from datetime import timedelta
 
 from prime_rl.trainer.models.layers.attn import substitute_ring_attn
 from prime_rl.trainer.rl.broadcast import setup_weight_broadcast
+from prime_rl.trainer.rl.checkpoint_pause import InferenceCheckpointPause
 from prime_rl.utils.act_offloading import maybe_activation_offloading
 import torch
 import torch.distributed as dist
@@ -243,6 +244,7 @@ def train(config: TrainerConfig):
     token_exporter = setup_token_exporter(config, parallel_dims, world, logger)
 
     gc_handler = GarbageCollection(config.gc.interval) if config.gc else None
+    checkpoint_pause = InferenceCheckpointPause(config.output_dir, config.ckpt, world)
 
     logger.info(f"Starting training loop (max_steps={config.max_steps or 'infinite'})")
     is_first_step = True
@@ -290,10 +292,14 @@ def train(config: TrainerConfig):
             # Multi-run: Save per-run checkpoints using each run's orchestrator config.
             # Trainer-level ckpt config can be set by the combined rl entrypoint,
             # but MultiCheckpointManager has a different save signature.
-            save_ckpt_start_time = time.perf_counter()
-            ckpt_manager.save(optimizer, scheduler)
-            save_ckpt_time = time.perf_counter() - save_ckpt_start_time
-            ckpt_manager.maybe_clean()
+            pause_request_id = checkpoint_pause.pause(progress.step) if ckpt_manager.should_save_any() else None
+            try:
+                save_ckpt_start_time = time.perf_counter()
+                ckpt_manager.save(optimizer, scheduler)
+                save_ckpt_time = time.perf_counter() - save_ckpt_start_time
+                ckpt_manager.maybe_clean()
+            finally:
+                checkpoint_pause.release(progress.step, pause_request_id)
         elif (
             ckpt_manager is not None
             and (config.ckpt and config.ckpt.interval)
@@ -301,23 +307,27 @@ def train(config: TrainerConfig):
             and progress.step % config.ckpt.interval == 0
         ):
             save_ckpt_time = 0
+            pause_request_id = checkpoint_pause.pause(progress.step)
 
-            if not config.ckpt.weights_only:
-                # Single-run: Save full checkpoint
-                logger.info(f"Saving checkpoint at step {progress.step}")
-                save_ckpt_start_time = time.perf_counter()
-                ckpt_manager.save(progress.step, model, [optimizer], scheduler, progress)
-                save_ckpt_time += time.perf_counter() - save_ckpt_start_time
+            try:
+                if not config.ckpt.weights_only:
+                    # Single-run: Save full checkpoint
+                    logger.info(f"Saving checkpoint at step {progress.step}")
+                    save_ckpt_start_time = time.perf_counter()
+                    ckpt_manager.save(progress.step, model, [optimizer], scheduler, progress)
+                    save_ckpt_time += time.perf_counter() - save_ckpt_start_time
 
-            ckpt_manager.maybe_clean()
+                ckpt_manager.maybe_clean()
 
-            # Save weight checkpoint
-            if weight_ckpt_manager is not None:
-                logger.info(f"Saving weight checkpoint at step {progress.step}")
-                save_ckpt_start_time = time.perf_counter()
-                weight_ckpt_manager.save(progress.step, model, tokenizer)
-                save_ckpt_time += time.perf_counter() - save_ckpt_start_time
-                weight_ckpt_manager.maybe_clean()
+                # Save weight checkpoint
+                if weight_ckpt_manager is not None:
+                    logger.info(f"Saving weight checkpoint at step {progress.step}")
+                    save_ckpt_start_time = time.perf_counter()
+                    weight_ckpt_manager.save(progress.step, model, tokenizer)
+                    save_ckpt_time += time.perf_counter() - save_ckpt_start_time
+                    weight_ckpt_manager.maybe_clean()
+            finally:
+                checkpoint_pause.release(progress.step, pause_request_id)
         else:
             save_ckpt_time = 0
 

--- a/src/prime_rl/utils/checkpoint_pause.py
+++ b/src/prime_rl/utils/checkpoint_pause.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import shutil
+import time
+import uuid
+from pathlib import Path
+
+from prime_rl.utils.logger import get_logger
+from prime_rl.utils.pathing import get_checkpoint_pause_dir, get_step_path
+
+REQUEST = "REQUEST"
+PAUSED = "PAUSED"
+RELEASE = "RELEASE"
+RESUMED = "RESUMED"
+
+PAUSE_ACK_TIMEOUT_S = 900.0
+POLL_INTERVAL_S = 0.5
+
+
+def get_pause_step_dir(output_dir: Path, step: int) -> Path:
+    return get_step_path(get_checkpoint_pause_dir(output_dir), step)
+
+
+def write_pause_request(output_dir: Path, step: int) -> str:
+    request_id = uuid.uuid4().hex
+    step_dir = get_pause_step_dir(output_dir, step)
+    if step_dir.exists():
+        shutil.rmtree(step_dir)
+    step_dir.mkdir(parents=True, exist_ok=True)
+    (step_dir / REQUEST).write_text(request_id)
+    get_logger().debug(f"Requested inference pause for trainer checkpoint step {step}")
+    return request_id
+
+
+def read_marker(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    return path.read_text().strip()
+
+
+def write_marker(step_dir: Path, marker: str, request_id: str) -> None:
+    step_dir.mkdir(parents=True, exist_ok=True)
+    (step_dir / marker).write_text(request_id)
+
+
+def wait_for_marker(step_dir: Path, marker: str, request_id: str, *, timeout_s: float = PAUSE_ACK_TIMEOUT_S) -> None:
+    deadline = time.monotonic() + timeout_s
+    marker_path = step_dir / marker
+    while time.monotonic() < deadline:
+        if read_marker(marker_path) == request_id:
+            return
+        time.sleep(POLL_INTERVAL_S)
+    raise TimeoutError(f"Timed out waiting for checkpoint pause marker {marker_path}")
+
+
+def write_pause_release(output_dir: Path, step: int, request_id: str) -> None:
+    write_marker(get_pause_step_dir(output_dir, step), RELEASE, request_id)
+    get_logger().debug(f"Released inference pause for trainer checkpoint step {step}")
+
+
+def get_pending_pause_requests(output_dir: Path) -> list[tuple[int, Path, str]]:
+    pause_dir = get_checkpoint_pause_dir(output_dir)
+    requests: list[tuple[int, Path, str]] = []
+    for step_dir in sorted(pause_dir.glob("step_*")):
+        try:
+            step = int(step_dir.name.split("_")[-1])
+        except ValueError:
+            continue
+        request_id = read_marker(step_dir / REQUEST)
+        if request_id is None or read_marker(step_dir / RESUMED) == request_id:
+            continue
+        requests.append((step, step_dir, request_id))
+    return sorted(requests, key=lambda request: request[0])

--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -348,17 +348,17 @@ async def _admin_post(client: AsyncClient, path: str, *, timeout_s: float = ADMI
             response.raise_for_status()
 
 
-async def _pause_engines(admin_clients: list[AsyncClient], *, step: int) -> None:
+async def pause_inference(admin_clients: list[AsyncClient], *, reason: str = "Pausing inference") -> None:
     """Pause all inference engines, waiting for in-flight requests to drain."""
     logger = get_logger()
-    logger.info(f"Updating policy in-flight to v{step}")
+    logger.info(reason)
     await asyncio.gather(
         *[_admin_post(client, "/pause", params={"mode": "keep", "clear_cache": "false"}) for client in admin_clients]
     )
     logger.debug("All inference engines paused")
 
 
-async def _resume_engines(admin_clients: list[AsyncClient]) -> None:
+async def resume_inference(admin_clients: list[AsyncClient]) -> None:
     """Resume all inference engines after weight update.
 
     Resuming is idempotent (it just clears the paused flag), so retrying transient
@@ -367,6 +367,14 @@ async def _resume_engines(admin_clients: list[AsyncClient]) -> None:
     logger = get_logger()
     await asyncio.gather(*[_admin_post(client, "/resume") for client in admin_clients])
     logger.debug("All inference engines resumed")
+
+
+async def _pause_engines(admin_clients: list[AsyncClient], *, step: int) -> None:
+    await pause_inference(admin_clients, reason=f"Updating policy in-flight to v{step}")
+
+
+async def _resume_engines(admin_clients: list[AsyncClient]) -> None:
+    await resume_inference(admin_clients)
 
 
 async def update_weights(

--- a/src/prime_rl/utils/pathing.py
+++ b/src/prime_rl/utils/pathing.py
@@ -81,6 +81,10 @@ def get_broadcast_dir(output_dir: Path) -> Path:
     return output_dir / "broadcasts"
 
 
+def get_checkpoint_pause_dir(output_dir: Path) -> Path:
+    return output_dir / "checkpoint_pause"
+
+
 def get_step_path(path: Path, step: int) -> Path:
     return path / f"step_{step}"
 
@@ -170,6 +174,13 @@ def clean_future_steps(output_dir: Path, resume_step: int) -> None:
         )
         for step in steps_to_delete:
             shutil.rmtree(get_step_path(directory, step))
+
+
+def clean_checkpoint_pause_requests(output_dir: Path) -> None:
+    pause_dir = get_checkpoint_pause_dir(output_dir)
+    if pause_dir.exists():
+        get_logger().info(f"Deleting stale checkpoint pause requests in {pause_dir}")
+        shutil.rmtree(pause_dir)
 
 
 def sync_wait_for_path(path: Path, interval: int = 1, log_interval: int = 10) -> None:

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -427,6 +427,22 @@ def test_empty_shared_ckpt_block_does_not_conflict_with_subconfig_ckpt():
     assert config.trainer.ckpt.interval == 50
 
 
+def test_shared_ckpt_experimental_pause_inference_propagates():
+    config = RLConfig.model_validate(
+        {
+            "ckpt": {"experimental": {"pause_inference": True}, "interval": 50},
+            "trainer": {},
+            "orchestrator": {"renderer": None},
+        }
+    )
+    assert config.trainer.ckpt is not None
+    assert config.trainer.ckpt.experimental is not None
+    assert config.trainer.ckpt.experimental.pause_inference is True
+    assert config.orchestrator.ckpt is not None
+    assert config.orchestrator.ckpt.experimental is not None
+    assert config.orchestrator.ckpt.experimental.pause_inference is True
+
+
 def test_shared_and_subconfig_disjoint_fields_coexist():
     """Per-field mutex only forbids conflicts on the SAME field — disjoint
     fields in [model] vs [trainer.model] are fine."""


### PR DESCRIPTION
## Summary

Adds an opt-in checkpoint experiment config:

```toml
[ckpt]
interval = 100

[ckpt.experimental]
pause_inference = true
```

When enabled, the trainer requests an inference pause before interval checkpoint saves, waits for the orchestrator to acknowledge the pause, writes the checkpoint, then releases inference. The orchestrator owns the actual `/pause` and `/resume` admin calls so SLURM/disaggregated admin URL handling stays centralized, and the checkpoint pause shares the same inference update lock as weight updates.

## Details

- Adds shared `ckpt.experimental.pause_inference` config propagation and validation.
- Adds a filesystem marker handshake under `checkpoint_pause/step_<N>` for trainer/orchestrator coordination.
- Stores pause markers under the shared experiment root; the orchestrator watches `output_dir.parent` because its own `output_dir` is the per-run child like `run_default`.
- Starts an orchestrator checkpoint-pause watcher only when the experimental flag is enabled.
- Avoids pausing every loop in multi-run mode by checking whether any run is actually due for a checkpoint.
- Cleans stale checkpoint-pause marker directories on `rl` startup.
- Updates the config skill with the new TOML snippet.

## Validation

- `uv run ruff check packages/prime-rl-configs/src/prime_rl/configs/shared.py packages/prime-rl-configs/src/prime_rl/configs/trainer.py packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py packages/prime-rl-configs/src/prime_rl/configs/rl.py packages/prime-rl-configs/src/prime_rl/utils/validation.py src/prime_rl/entrypoints/rl.py src/prime_rl/orchestrator/orchestrator.py src/prime_rl/orchestrator/watcher.py src/prime_rl/orchestrator/checkpoint_pause.py src/prime_rl/trainer/multi_ckpt.py src/prime_rl/trainer/rl/train.py src/prime_rl/trainer/rl/checkpoint_pause.py src/prime_rl/utils/client.py src/prime_rl/utils/pathing.py src/prime_rl/utils/checkpoint_pause.py tests/unit/test_configs.py`
- `uv run ruff format --check packages/prime-rl-configs/src/prime_rl/configs/shared.py packages/prime-rl-configs/src/prime_rl/configs/trainer.py packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py packages/prime-rl-configs/src/prime_rl/configs/rl.py packages/prime-rl-configs/src/prime_rl/utils/validation.py src/prime_rl/entrypoints/rl.py src/prime_rl/orchestrator/orchestrator.py src/prime_rl/orchestrator/watcher.py src/prime_rl/orchestrator/checkpoint_pause.py src/prime_rl/trainer/multi_ckpt.py src/prime_rl/trainer/rl/train.py src/prime_rl/trainer/rl/checkpoint_pause.py src/prime_rl/utils/client.py src/prime_rl/utils/pathing.py src/prime_rl/utils/checkpoint_pause.py tests/unit/test_configs.py`
- `uv run pytest tests/unit/test_configs.py -q`
- `uv run python -m py_compile src/prime_rl/utils/checkpoint_pause.py src/prime_rl/orchestrator/checkpoint_pause.py src/prime_rl/trainer/rl/checkpoint_pause.py`
- `git diff --check`
- After the shared-root marker fix: `uv run ruff check src/prime_rl/orchestrator/checkpoint_pause.py src/prime_rl/trainer/rl/checkpoint_pause.py src/prime_rl/utils/checkpoint_pause.py src/prime_rl/orchestrator/orchestrator.py`; `uv run ruff format --check src/prime_rl/orchestrator/checkpoint_pause.py src/prime_rl/trainer/rl/checkpoint_pause.py src/prime_rl/utils/checkpoint_pause.py src/prime_rl/orchestrator/orchestrator.py`; `uv run python -m py_compile src/prime_rl/orchestrator/checkpoint_pause.py src/prime_rl/trainer/rl/checkpoint_pause.py src/prime_rl/utils/checkpoint_pause.py`; `uv run pytest tests/unit/test_configs.py -q -k "shared_ckpt_experimental_pause_inference"`

Runtime smoke note: a short reverse-text run was attempted with `ckpt.interval=1`, but it failed before reaching the checkpoint path because the tiny batch hit the existing zero-trainable-batch filter guard. The config and local static checks above passed.