### PR TITLE
explicit del and malloc

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import asyncio
 import ctypes
+import gc
 import logging
 import os
 import time
@@ -107,6 +108,14 @@ MAX_CONSECUTIVE_EMPTY_BATCHES = 10
 # dispatcher is paused via ``update_dispatch_gate`` once this is exceeded;
 # resumed when the watcher advances ``policy.version``.
 TARGET_LAG = 1
+
+
+def _release_unused_memory() -> None:
+    gc.collect()
+    try:
+        ctypes.CDLL("libc.so.6").malloc_trim(0)
+    except (OSError, AttributeError) as e:
+        get_logger().debug(f"malloc_trim(0) unavailable: {e}")
 
 
 class Orchestrator:
@@ -476,10 +485,7 @@ class Orchestrator:
                 get_logger().success("Orchestrator finished.")
             else:
                 get_logger().warning("Orchestrator cleanup complete (forced).")
-            try:
-                ctypes.CDLL("libc.so.6").malloc_trim(0)
-            except Exception as e:
-                get_logger().debug(f"malloc_trim(0) failed: {e}")
+            _release_unused_memory()
 
     async def main_loop(self) -> None:
         """Consume ``FinishedRollout``\\ s from the dispatcher and route them
@@ -496,19 +502,29 @@ class Orchestrator:
             except asyncio.TimeoutError:
                 continue
 
-            if isinstance(rollout, EvalRollout):
-                assert self.eval_sink is not None  # eval rollouts only emitted when eval is configured
-                eval_batch = self.eval_sink.add(rollout)
-                if eval_batch is not None:
-                    await self.finalize_eval_batch(eval_batch)
-                continue
+            batch = None
+            should_release_memory = False
+            try:
+                if isinstance(rollout, EvalRollout):
+                    assert self.eval_sink is not None  # eval rollouts only emitted when eval is configured
+                    batch = self.eval_sink.add(rollout)
+                    if batch is not None:
+                        should_release_memory = True
+                        await self.finalize_eval_batch(batch)
+                    continue
 
-            assert isinstance(rollout, TrainRollout)
-            train_batch = await self.train_sink.add(rollout)
-            # In drain mode any late-arriving train batch is dropped — we
-            # don't want to ship past ``max_steps``
-            if train_batch is not None and not self.draining and not self.stopped.is_set():
-                await self.finalize_train_batch(train_batch)
+                assert isinstance(rollout, TrainRollout)
+                batch = await self.train_sink.add(rollout)
+                # In drain mode any late-arriving train batch is dropped — we
+                # don't want to ship past ``max_steps``
+                if batch is not None:
+                    should_release_memory = True
+                if batch is not None and not self.draining and not self.stopped.is_set():
+                    await self.finalize_train_batch(batch)
+            finally:
+                del batch, rollout
+                if should_release_memory:
+                    _release_unused_memory()
 
     async def finalize_train_batch(self, batch: TrainBatch) -> None:
         """Ship one ``TrainBatch`` out to the trainer and handle the I/O

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -485,7 +485,7 @@ class Orchestrator:
                 get_logger().success("Orchestrator finished.")
             else:
                 get_logger().warning("Orchestrator cleanup complete (forced).")
-            _release_unused_memory()
+            await asyncio.to_thread(_release_unused_memory)
 
     async def main_loop(self) -> None:
         """Consume ``FinishedRollout``\\ s from the dispatcher and route them
@@ -502,29 +502,30 @@ class Orchestrator:
             except asyncio.TimeoutError:
                 continue
 
-            batch = None
+            train_batch = None
+            eval_batch = None
             should_release_memory = False
             try:
                 if isinstance(rollout, EvalRollout):
                     assert self.eval_sink is not None  # eval rollouts only emitted when eval is configured
-                    batch = self.eval_sink.add(rollout)
-                    if batch is not None:
+                    eval_batch = self.eval_sink.add(rollout)
+                    if eval_batch is not None:
                         should_release_memory = True
-                        await self.finalize_eval_batch(batch)
+                        await self.finalize_eval_batch(eval_batch)
                     continue
 
                 assert isinstance(rollout, TrainRollout)
-                batch = await self.train_sink.add(rollout)
+                train_batch = await self.train_sink.add(rollout)
                 # In drain mode any late-arriving train batch is dropped — we
                 # don't want to ship past ``max_steps``
-                if batch is not None:
+                if train_batch is not None:
                     should_release_memory = True
-                if batch is not None and not self.draining and not self.stopped.is_set():
-                    await self.finalize_train_batch(batch)
+                if train_batch is not None and not self.draining and not self.stopped.is_set():
+                    await self.finalize_train_batch(train_batch)
             finally:
-                del batch, rollout
+                del train_batch, eval_batch, rollout
                 if should_release_memory:
-                    _release_unused_memory()
+                    await asyncio.to_thread(_release_unused_memory)
 
     async def finalize_train_batch(self, batch: TrainBatch) -> None:
         """Ship one ``TrainBatch`` out to the trainer and handle the I/O


### PR DESCRIPTION
Bring back this explicit delete and cleanup to avoid memory build up

https://github.com/PrimeIntellect-ai/prime-rl/blob/20f6449e1f32aff9a80aac76af20f0f83adc94b7/src/prime_rl/orchestrator/orchestrator.py#L769


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Operational memory-hygiene only; extra post-batch work in a thread pool may add minor latency but does not change training logic or I/O semantics.
> 
> **Overview**
> Adds **`_release_unused_memory()`** (`gc.collect()` plus optional glibc **`malloc_trim(0)`**) and runs it off the event loop via **`asyncio.to_thread`**.
> 
> **`main_loop`** now drops rollout/batch references explicitly in a **`finally`** block and triggers that cleanup after a train or eval batch is finalized (when a batch object was produced). Shutdown reuses the same helper instead of calling **`malloc_trim`** inline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba86e834efaec98130e3cd35ff0db85ba64cf3fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->