### PR TITLE
[codex] Pack Qwen multimodal trainer samples

### DIFF
--- a/src/prime_rl/trainer/batch.py
+++ b/src/prime_rl/trainer/batch.py
@@ -1,6 +1,24 @@
 import copy
+import math
 
-from prime_rl.transport.types import MicroBatch, RoutedExperts, TrainingSample
+from prime_rl.transport.types import EncodedTensor, MicroBatch, RoutedExperts, TrainingSample
+
+ENCODED_TENSOR_DTYPE_ITEMSIZE = {
+    "bool": 1,
+    "bool_": 1,
+    "float16": 2,
+    "bfloat16": 2,
+    "float32": 4,
+    "float64": 8,
+    "int8": 1,
+    "uint8": 1,
+    "int16": 2,
+    "uint16": 2,
+    "int32": 4,
+    "uint32": 4,
+    "int64": 8,
+    "uint64": 8,
+}
 
 ROUTED_EXPERTS_DTYPE_ITEMSIZE = {
     "uint8": 1,
@@ -39,6 +57,71 @@ def _append_routed_experts(dst: MicroBatch, src: MicroBatch) -> None:
     assert dst_routed.shape[1:] == src_routed.shape[1:]
     dst_routed.data += src_routed.data
     dst_routed.shape[0] += src_routed.shape[0]
+
+
+def _copy_encoded_tensor(encoded: EncodedTensor) -> EncodedTensor:
+    return EncodedTensor(dtype=encoded.dtype, shape=list(encoded.shape), data=encoded.data)
+
+
+def _copy_mm_kwargs(mm_kwargs: dict[str, EncodedTensor] | None) -> dict[str, EncodedTensor] | None:
+    if mm_kwargs is None:
+        return None
+    return {key: _copy_encoded_tensor(value) for key, value in mm_kwargs.items()}
+
+
+def _encoded_tensor_dtype_itemsize(encoded: EncodedTensor) -> int:
+    dtype = encoded.dtype.replace("numpy.", "").replace("torch.", "")
+    if dtype not in ENCODED_TENSOR_DTYPE_ITEMSIZE:
+        raise ValueError(f"Unsupported EncodedTensor dtype for multimodal packing: {encoded.dtype}")
+    return ENCODED_TENSOR_DTYPE_ITEMSIZE[dtype]
+
+
+def _validate_encoded_tensor_payload(encoded: EncodedTensor) -> None:
+    expected_nbytes = math.prod(encoded.shape) * _encoded_tensor_dtype_itemsize(encoded)
+    if len(encoded.data) != expected_nbytes:
+        raise ValueError(
+            "EncodedTensor byte length does not match dtype and shape: "
+            f"dtype={encoded.dtype}, shape={encoded.shape}, "
+            f"data_nbytes={len(encoded.data)}, expected_nbytes={expected_nbytes}"
+        )
+
+
+def _encoded_tensors_can_concat(dst: EncodedTensor, src: EncodedTensor) -> bool:
+    return bool(
+        dst.dtype == src.dtype
+        and len(dst.shape) > 0
+        and len(dst.shape) == len(src.shape)
+        and dst.shape[1:] == src.shape[1:]
+    )
+
+
+def _mm_kwargs_can_concat(
+    dst: dict[str, EncodedTensor] | None,
+    src: dict[str, EncodedTensor] | None,
+) -> bool:
+    if dst is None or src is None:
+        return dst is None and src is None
+    if dst.keys() != src.keys():
+        return False
+    return all(_encoded_tensors_can_concat(dst[key], src[key]) for key in dst)
+
+
+def _append_encoded_tensor(dst: EncodedTensor, src: EncodedTensor) -> None:
+    _validate_encoded_tensor_payload(dst)
+    _validate_encoded_tensor_payload(src)
+    if not _encoded_tensors_can_concat(dst, src):
+        raise ValueError(f"Cannot concatenate encoded tensors with shapes {dst.shape} and {src.shape}")
+    dst.data += src.data
+    dst.shape[0] += src.shape[0]
+
+
+def _append_mm_kwargs(dst: MicroBatch, src: MicroBatch) -> None:
+    if dst.mm_kwargs is None or src.mm_kwargs is None:
+        raise ValueError("Cannot append multimodal kwargs when either micro batch is missing mm_kwargs")
+    if not _mm_kwargs_can_concat(dst.mm_kwargs, src.mm_kwargs):
+        raise ValueError("Cannot pack multimodal samples with incompatible mm_kwargs")
+    for key, src_tensor in src.mm_kwargs.items():
+        _append_encoded_tensor(dst.mm_kwargs[key], src_tensor)
 
 
 def _pad_routed_experts(micro_batch: MicroBatch, padding_size: int) -> None:
@@ -117,6 +200,9 @@ def prepare_sample(training_example: TrainingSample, seq_len: int) -> MicroBatch
         assert len(mm_token_type_ids) == len(input_ids), (
             f"mm_token_type_ids: {len(mm_token_type_ids)}, input_ids: {len(input_ids)}"
         )
+    if training_example.mm_kwargs is not None and "image_grid_thw" in training_example.mm_kwargs:
+        if mm_token_type_ids is None:
+            raise ValueError("image_grid_thw multimodal samples require mm_token_type_ids")
     assert len(env_names) == len(input_ids), f"env_names: {len(env_names)}, input_ids: {len(input_ids)}"
 
     return MicroBatch(
@@ -131,14 +217,92 @@ def prepare_sample(training_example: TrainingSample, seq_len: int) -> MicroBatch
         routed_experts=routed_experts,
         mm_token_type_ids=mm_token_type_ids,
         env_names=env_names,
-        mm_kwargs=training_example.mm_kwargs,
+        mm_kwargs=_copy_mm_kwargs(training_example.mm_kwargs),
         training_mode=training_example.training_mode,
+        seq_lens=[len(input_ids)] if training_example.mm_kwargs is not None else None,
     )
 
 
 def _is_multimodal_sample(sample: MicroBatch) -> bool:
     """Check if a sample contains multimodal data (images)."""
     return sample.mm_kwargs is not None
+
+
+def _has_video_tokens(sample: MicroBatch) -> bool:
+    return sample.mm_token_type_ids is not None and 2 in sample.mm_token_type_ids
+
+
+def _can_pack_sample_into(bin_content: MicroBatch, sample: MicroBatch, max_seq_len: int) -> bool:
+    if len(bin_content.input_ids) + len(sample.input_ids) > max_seq_len:
+        return False
+    if bin_content.training_mode != sample.training_mode:
+        return False
+    if _is_multimodal_sample(bin_content) != _is_multimodal_sample(sample):
+        return False
+    if _is_multimodal_sample(bin_content):
+        if _has_video_tokens(bin_content) or _has_video_tokens(sample):
+            return False
+        return _mm_kwargs_can_concat(bin_content.mm_kwargs, sample.mm_kwargs)
+    return True
+
+
+def _extend_optional_rewards(bin_content: MicroBatch, sample: MicroBatch, existing_len: int) -> None:
+    if sample.rewards is not None:
+        if bin_content.rewards is None:
+            bin_content.rewards = [float("nan")] * existing_len
+        bin_content.rewards.extend(sample.rewards)
+    elif bin_content.rewards is not None:
+        bin_content.rewards.extend([float("nan")] * len(sample.input_ids))
+
+
+def _extend_optional_teacher_logprobs(bin_content: MicroBatch, sample: MicroBatch) -> None:
+    if sample.teacher_logprobs is not None:
+        if bin_content.teacher_logprobs is None:
+            bin_content.teacher_logprobs = []
+        bin_content.teacher_logprobs.extend(sample.teacher_logprobs)
+
+
+def _extend_mm_token_type_ids(bin_content: MicroBatch, sample: MicroBatch, existing_len: int) -> None:
+    if bin_content.mm_token_type_ids is None and sample.mm_token_type_ids is None:
+        return
+    if bin_content.mm_token_type_ids is None:
+        bin_content.mm_token_type_ids = [0] * existing_len
+    if sample.mm_token_type_ids is None:
+        bin_content.mm_token_type_ids.extend([0] * len(sample.input_ids))
+    else:
+        bin_content.mm_token_type_ids.extend(sample.mm_token_type_ids)
+
+
+def _extend_seq_lens(bin_content: MicroBatch, sample: MicroBatch, existing_len: int) -> None:
+    if bin_content.seq_lens is None and sample.seq_lens is None:
+        return
+    if bin_content.seq_lens is None:
+        bin_content.seq_lens = [existing_len]
+    bin_content.seq_lens.extend(sample.seq_lens if sample.seq_lens is not None else [len(sample.input_ids)])
+
+
+def _append_sample_to_bin(bin_content: MicroBatch, sample: MicroBatch, idx: int) -> None:
+    existing_len = len(bin_content.input_ids)
+    bin_content.input_ids.extend(sample.input_ids)
+    bin_content.loss_mask.extend(sample.loss_mask)
+    bin_content.advantages.extend(sample.advantages)
+    _extend_optional_rewards(bin_content, sample, existing_len)
+    bin_content.inference_logprobs.extend(sample.inference_logprobs)
+    bin_content.temperatures.extend(sample.temperatures)
+    _extend_optional_teacher_logprobs(bin_content, sample)
+    assert (bin_content.routed_experts is None) == (sample.routed_experts is None)
+    if sample.routed_experts is not None:
+        if bin_content.routed_experts is None:
+            bin_content.routed_experts = _copy_routed_experts(sample.routed_experts)
+        else:
+            _append_routed_experts(bin_content, sample)
+    _extend_mm_token_type_ids(bin_content, sample, existing_len)
+    if _is_multimodal_sample(bin_content):
+        _append_mm_kwargs(bin_content, sample)
+    bin_content.env_names.extend(sample.env_names)
+    bin_content.position_ids.extend(sample.position_ids)
+    _extend_seq_lens(bin_content, sample, existing_len)
+    bin_content.lora_num_tokens[idx] += len(sample.input_ids)
 
 
 def packed_samples_into_micro_bs(
@@ -149,8 +313,8 @@ def packed_samples_into_micro_bs(
     We follow the First Fit Decreasing algorithm to pack the samples into bins and minimize potential padding while never truncating.
     With per-token temperatures, samples can be packed together regardless of their temperature values.
 
-    NOTE: Multimodal samples (with mm_kwargs) are NOT packed together as they have variable-sized
-    vision data that doesn't pack well. Each multimodal sample becomes its own micro batch.
+    Multimodal samples pack with compatible multimodal samples by concatenating
+    each encoded tensor along dim 0 and preserving sample boundaries in seq_lens.
     """
     # Sort by (lora_idx, -length) for packing efficiency
     samples.sort(key=lambda x: (x[0], -len(x[1].input_ids)))
@@ -159,52 +323,10 @@ def packed_samples_into_micro_bs(
     micro_batches: list[MicroBatch] = []
 
     for idx, sample in samples:
-        # Multimodal samples cannot be packed - each becomes its own micro batch
-        if _is_multimodal_sample(sample):
-            sample.lora_num_tokens = [0] * num_loras
-            sample.lora_num_tokens[idx] = len(sample.input_ids)
-            micro_batches.append(sample)
-            continue
-
-        # Try to find a bin that can fit this sequence (only pack text-only samples)
+        # Try to find a bin that can fit this sequence.
         for bin_content in micro_batches:
-            # Don't pack into multimodal micro batches
-            if _is_multimodal_sample(bin_content):
-                continue
-            # Check if sequence fits in this bin
-            if (
-                len(bin_content.input_ids) + len(sample.input_ids) <= max_seq_len
-                and bin_content.training_mode == sample.training_mode
-            ):
-                existing_len = len(bin_content.input_ids)
-                bin_content.input_ids.extend(sample.input_ids)
-                bin_content.loss_mask.extend(sample.loss_mask)
-                bin_content.advantages.extend(sample.advantages)
-                if sample.rewards is not None:
-                    if bin_content.rewards is None:
-                        bin_content.rewards = [float("nan")] * existing_len
-                    bin_content.rewards.extend(sample.rewards)
-                elif bin_content.rewards is not None:
-                    bin_content.rewards.extend([float("nan")] * len(sample.input_ids))
-                bin_content.inference_logprobs.extend(sample.inference_logprobs)
-                bin_content.temperatures.extend(sample.temperatures)
-                if sample.teacher_logprobs is not None:
-                    if bin_content.teacher_logprobs is None:
-                        bin_content.teacher_logprobs = []
-                    bin_content.teacher_logprobs.extend(sample.teacher_logprobs)
-                assert (bin_content.routed_experts is None) == (sample.routed_experts is None)
-                if sample.routed_experts is not None:
-                    if bin_content.routed_experts is None:
-                        bin_content.routed_experts = _copy_routed_experts(sample.routed_experts)
-                    else:
-                        _append_routed_experts(bin_content, sample)
-                if sample.mm_token_type_ids is not None:
-                    if bin_content.mm_token_type_ids is None:
-                        bin_content.mm_token_type_ids = []
-                    bin_content.mm_token_type_ids.extend(sample.mm_token_type_ids)
-                bin_content.env_names.extend(sample.env_names)
-                bin_content.position_ids.extend(sample.position_ids)
-                bin_content.lora_num_tokens[idx] += len(sample.input_ids)
+            if _can_pack_sample_into(bin_content, sample, max_seq_len):
+                _append_sample_to_bin(bin_content, sample, idx)
                 break
         else:
             sample.lora_num_tokens = [0] * num_loras
@@ -255,6 +377,8 @@ def pad_micro_batch(micro_batch: MicroBatch, pad_to_multiple_of: int) -> MicroBa
     if micro_batch.routed_experts is not None:
         _pad_routed_experts(micro_batch, padding_size)
     micro_batch.env_names.extend([""] * padding_size)
+    if micro_batch.seq_lens is not None:
+        micro_batch.seq_lens.append(padding_size)
 
     return micro_batch
 

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -1167,6 +1167,7 @@ def forward(
     # not a renderer/processor output.
     mm_kwargs: dict[str, Tensor] | None = None,
     mm_token_type_ids: Int[Tensor, "batch seq"] | None = None,
+    seq_lens: Int[Tensor, "segments"] | None = None,
 ) -> PrimeLmOutput:
     # Build kwargs for model forward
     kwargs = {
@@ -1188,6 +1189,8 @@ def forward(
         # via the mm_kwargs shape so we don't enumerate model_types.
         if "image_grid_thw" not in mm_kwargs:
             kwargs["position_ids"] = position_ids
+        elif seq_lens is not None:
+            kwargs["seq_lens"] = seq_lens
     else:
         kwargs["position_ids"] = position_ids
 

--- a/src/prime_rl/trainer/rl/data.py
+++ b/src/prime_rl/trainer/rl/data.py
@@ -34,6 +34,7 @@ class TensorMicroBatch(TypedDict):
 
     # Batch level
     lora_num_tokens: Int[Tensor, "n_loras"]
+    seq_lens: Int[Tensor, "segments"] | None
 
     # MoE router replay
     routed_experts: Int[Tensor, "batch seq layers topk"] | None
@@ -125,6 +126,7 @@ class FakeDataLoader:
             "env_names": ["fake"] * input_ids.shape[0],
             "loss_mask": loss_mask.unsqueeze(0),
             "lora_num_tokens": lora_num_tokens,
+            "seq_lens": None,
             "routed_experts": None,
             "mm_kwargs": None,
             "mm_token_type_ids": None,
@@ -155,6 +157,7 @@ class FakeDataLoader:
             "env_names": ["fake"] * self.seq_len,
             "loss_mask": torch.ones(self.seq_len, dtype=torch.bool).unsqueeze(0),
             "lora_num_tokens": lora_num_tokens,
+            "seq_lens": None,
             "routed_experts": None,
             "mm_kwargs": None,
             "mm_token_type_ids": None,
@@ -250,6 +253,7 @@ class DataLoader:
             temperatures=torch.tensor(micro_batch.temperatures, dtype=torch.float).unsqueeze(0),
             env_names=micro_batch.env_names,
             lora_num_tokens=torch.tensor(micro_batch.lora_num_tokens, dtype=torch.int32),
+            seq_lens=torch.tensor(micro_batch.seq_lens, dtype=torch.long) if micro_batch.seq_lens is not None else None,
             mm_kwargs=mm_kwargs,
             mm_token_type_ids=torch.tensor(micro_batch.mm_token_type_ids, dtype=torch.long).unsqueeze(0)
             if micro_batch.mm_token_type_ids is not None

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -400,6 +400,7 @@ def train(config: TrainerConfig):
                 if micro_batch.get("mm_token_type_ids") is not None
                 else None
             )
+            seq_lens = micro_batch["seq_lens"].to("cuda") if micro_batch.get("seq_lens") is not None else None
 
             labels = shift_tensor_left(input_ids)
 
@@ -445,6 +446,7 @@ def train(config: TrainerConfig):
                     temperature=temperatures,
                     mm_kwargs=mm_kwargs,
                     mm_token_type_ids=mm_token_type_ids,
+                    seq_lens=seq_lens,
                     routed_experts=routed_experts,
                 )
 

--- a/src/prime_rl/transport/types.py
+++ b/src/prime_rl/transport/types.py
@@ -93,3 +93,6 @@ class MicroBatch(msgspec.Struct, array_like=True, gc=False, omit_defaults=True):
     # Packer-derived metadata used for run-local token exports.
     run_id: str | None = None
     run_step: int | None = None
+
+    # Packed sample boundaries. Sum equals len(input_ids) when present.
+    seq_lens: list[int] | None = None

--- a/tests/unit/orchestrator/test_batch.py
+++ b/tests/unit/orchestrator/test_batch.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from prime_rl.trainer.batch import prepare_batch, prepare_sample
-from prime_rl.transport.types import RoutedExperts, TrainingSample
+from prime_rl.transport.types import EncodedTensor, RoutedExperts, TrainingSample
 
 
 def _routed_experts(data, dtype=np.uint8):
@@ -11,6 +11,44 @@ def _routed_experts(data, dtype=np.uint8):
         data=routed_experts.tobytes(),
         shape=list(routed_experts.shape),
         dtype=str(routed_experts.dtype),
+    )
+
+
+def _encoded_tensor(data, dtype) -> EncodedTensor:
+    arr = np.asarray(data, dtype=dtype)
+    return EncodedTensor(dtype=str(arr.dtype), shape=list(arr.shape), data=arr.tobytes())
+
+
+def _decode_encoded_tensor(encoded: EncodedTensor):
+    return np.frombuffer(encoded.data, dtype=np.dtype(encoded.dtype)).reshape(encoded.shape).tolist()
+
+
+def _make_mm_training_example(
+    *,
+    pixel_values,
+    image_grid_thw,
+    mm_token_type_ids,
+    env_name,
+    prompt_ids=None,
+    completion_ids=None,
+) -> TrainingSample:
+    prompt_ids = [1, 250] if prompt_ids is None else prompt_ids
+    completion_ids = [3, 4] if completion_ids is None else completion_ids
+    return TrainingSample(
+        prompt_ids=prompt_ids,
+        prompt_mask=[False] * len(prompt_ids),
+        completion_ids=completion_ids,
+        completion_mask=[True] * len(completion_ids),
+        completion_logprobs=[-0.1] * len(completion_ids),
+        completion_temperatures=[1.0] * len(completion_ids),
+        teacher_logprobs=[0.0] * (len(prompt_ids) + len(completion_ids)),
+        advantage=1.0,
+        env_name=env_name,
+        mm_kwargs={
+            "pixel_values": _encoded_tensor(pixel_values, np.float32),
+            "image_grid_thw": _encoded_tensor(image_grid_thw, np.int64),
+        },
+        mm_token_type_ids=mm_token_type_ids,
     )
 
 
@@ -107,6 +145,81 @@ def test_prepare_batch_packs_different_temperatures(make_training_example):
     # Second sample (4 tokens): all get temp 1.1
     assert flat_batches[0].temperatures[4:8] == [1.1, 1.1, 1.1, 1.1]
     assert flat_batches[0].env_names == ["env-a"] * 4 + ["env-b"] * 4
+    assert flat_batches[0].seq_lens is None
+
+
+def test_prepare_batch_packs_compatible_multimodal_samples():
+    example1 = _make_mm_training_example(
+        pixel_values=[[1.0, 2.0, 3.0]],
+        image_grid_thw=[[1, 2, 2]],
+        mm_token_type_ids=[0, 1, 0, 0],
+        env_name="mm-a",
+    )
+    example2 = _make_mm_training_example(
+        pixel_values=[[4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
+        image_grid_thw=[[1, 4, 4]],
+        mm_token_type_ids=[0, 0, 1, 0],
+        env_name="mm-b",
+    )
+
+    batches_per_gpu = prepare_batch(
+        rollouts=[example1, example2],
+        seq_len=8,
+        num_train_workers=1,
+        idxs=[0, 0],
+        num_loras=1,
+    )
+
+    flat_batches = [batch for worker_batches in batches_per_gpu for batch in worker_batches]
+    assert len(flat_batches) == 1
+    batch = flat_batches[0]
+    assert batch.seq_lens == [4, 4]
+    assert batch.position_ids == [0, 1, 2, 3, 0, 1, 2, 3]
+    assert batch.mm_token_type_ids == [0, 1, 0, 0, 0, 0, 1, 0]
+    assert batch.env_names == ["mm-a"] * 4 + ["mm-b"] * 4
+    assert batch.mm_kwargs is not None
+    assert _decode_encoded_tensor(batch.mm_kwargs["pixel_values"]) == [
+        [1.0, 2.0, 3.0],
+        [4.0, 5.0, 6.0],
+        [7.0, 8.0, 9.0],
+    ]
+    assert _decode_encoded_tensor(batch.mm_kwargs["image_grid_thw"]) == [[1, 2, 2], [1, 4, 4]]
+
+
+def test_prepare_batch_records_multimodal_padding_as_segment():
+    example1 = _make_mm_training_example(
+        pixel_values=[[1.0, 2.0, 3.0]],
+        image_grid_thw=[[1, 2, 2]],
+        mm_token_type_ids=[0, 1, 0],
+        env_name="mm-a",
+        prompt_ids=[1],
+        completion_ids=[250, 3],
+    )
+    example2 = _make_mm_training_example(
+        pixel_values=[[4.0, 5.0, 6.0]],
+        image_grid_thw=[[1, 2, 2]],
+        mm_token_type_ids=[0, 1, 0],
+        env_name="mm-b",
+        prompt_ids=[2],
+        completion_ids=[250, 4],
+    )
+
+    batches_per_gpu = prepare_batch(
+        rollouts=[example1, example2],
+        seq_len=8,
+        num_train_workers=1,
+        idxs=[0, 0],
+        num_loras=1,
+        pad_to_multiple_of=4,
+    )
+
+    flat_batches = [batch for worker_batches in batches_per_gpu for batch in worker_batches]
+    assert len(flat_batches) == 1
+    batch = flat_batches[0]
+    assert batch.seq_lens == [3, 3, 2]
+    assert batch.position_ids == [0, 1, 2, 0, 1, 2, 0, 1]
+    assert batch.mm_token_type_ids == [0, 1, 0, 0, 1, 0, 0, 0]
+    assert batch.loss_mask[-2:] == [False, False]
 
 
 def test_prepare_sample_propagates_training_mode(make_training_example):

--- a/tests/unit/train/test_model_forward.py
+++ b/tests/unit/train/test_model_forward.py
@@ -45,6 +45,26 @@ def test_forward_passes_renderer_mm_token_type_ids_through():
     torch.testing.assert_close(model.kwargs["mm_token_type_ids"], mm_token_type_ids)
 
 
+def test_forward_passes_seq_lens_to_mrope_vlm():
+    model = _CaptureModel(SimpleNamespace(model_type="qwen3_vl"))
+    input_ids = torch.tensor([[1, 10, 10, 2, 20]])
+    position_ids = torch.arange(input_ids.shape[1]).unsqueeze(0)
+    seq_lens = torch.tensor([3, 2])
+
+    forward(
+        model,
+        input_ids,
+        position_ids,
+        mm_kwargs={"pixel_values": torch.ones(2, 3), "image_grid_thw": torch.tensor([[1, 1, 2]])},
+        mm_token_type_ids=torch.tensor([[0, 1, 1, 0, 0]]),
+        seq_lens=seq_lens,
+    )
+
+    assert model.kwargs is not None
+    assert "position_ids" not in model.kwargs
+    torch.testing.assert_close(model.kwargs["seq_lens"], seq_lens)
+
+
 def test_forward_omits_mm_token_type_ids_when_renderer_does_not_supply():
     """When the renderer doesn't ship ``mm_token_type_ids`` (text-only
     or a family without modality markers), ``forward()`` doesn't
@@ -77,7 +97,9 @@ def test_forward_keeps_position_ids_for_non_mrope_vlm():
         input_ids,
         position_ids,
         mm_kwargs={"pixel_values": torch.ones(2, 3)},
+        seq_lens=torch.tensor([4]),
     )
 
     assert model.kwargs is not None
     torch.testing.assert_close(model.kwargs["position_ids"], position_ids)
+    assert "seq_lens" not in model.kwargs


### PR DESCRIPTION
## Summary

Adds trainer-side packing for compatible image-only multimodal samples on top of the Qwen3.5 MRoPE model fix.

- Adds `MicroBatch.seq_lens` as explicit packed-sample boundary metadata for multimodal batches.
- Allows compatible multimodal samples to first-fit pack together while keeping text-only and multimodal batches separate.
- Concatenates encoded multimodal sidecars along dim 0, with dtype/shape/byte-length validation before append.
- Propagates `seq_lens` through tensorization and trainer forward only for MRoPE VLM forwards.
- Records padding as its own segment for multimodal batches, so padding tokens do not consume image grids or bleed across sample boundaries.
- Keeps video tokens unpacked/unsupported for the custom Qwen image-only path.

This PR is stacked on #2819 to keep the diff clean. After #2819 merges, this can be retargeted to `main`.

## Validation

- `FLA_TILELANG=0 uv run pytest tests/unit/utils/test_sequence.py tests/unit/orchestrator/test_batch.py tests/unit/train/test_model_forward.py tests/unit/train/models/test_qwen3_5_moe_mrope.py tests/unit/train/models/test_qwen3_5_moe_vlm.py tests/unit/train/models/test_qwen3_5_moe.py`
- `uv run ruff check src/prime_rl/transport/types.py src/prime_rl/utils/sequence.py src/prime_rl/trainer/batch.py src/prime_rl/trainer/rl/data.py src/prime_rl/trainer/rl/train.py src/prime_rl/trainer/model.py src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py tests/unit/utils/test_sequence.py tests/unit/orchestrator/test_batch.py tests/unit/train/test_model_forward.py tests/unit/train/models/test_qwen3_5_moe_mrope.py tests/unit/train/models/test_qwen3_5_moe_vlm.py`