### PR TITLE
fix(orchestrator): trim glibc heap back to the OS each step

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -21,7 +21,6 @@ in ``setup()`` and drives them from ``main_loop()``.
 from __future__ import annotations
 
 import asyncio
-import ctypes
 import os
 import time
 from typing import TYPE_CHECKING
@@ -67,6 +66,7 @@ from prime_rl.orchestrator.utils import (
     save_rollouts,
     set_default_executor,
     setup_student_inference_pool,
+    trim_process_memory,
 )
 from prime_rl.orchestrator.watcher import WeightWatcher
 from prime_rl.trainer.model import setup_tokenizer
@@ -477,10 +477,7 @@ class Orchestrator:
                 get_logger().success("Orchestrator finished.")
             else:
                 get_logger().warning("Orchestrator cleanup complete (forced).")
-            try:
-                ctypes.CDLL("libc.so.6").malloc_trim(0)
-            except Exception as e:
-                get_logger().debug(f"malloc_trim(0) failed: {e}")
+            trim_process_memory()
 
     async def main_loop(self) -> None:
         """Consume ``FinishedRollout``\\ s from the dispatcher and route them
@@ -623,6 +620,7 @@ class Orchestrator:
         self.train_sink.reset_pre_filter_stats()
         self.progress.step += 1
         self.maybe_trigger_eval(self.progress.step)
+        trim_process_memory()
 
     def maybe_trigger_eval(self, step: int) -> None:
         """Fire eligible eval epochs and flip to ``PREFER_EVAL`` if anything

--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -1,4 +1,5 @@
 import asyncio
+import ctypes
 import logging
 import os
 import time
@@ -87,6 +88,14 @@ def set_default_executor(max_workers: int = 64) -> None:
     """Scale the default asyncio thread pool so asyncio.to_thread has enough capacity."""
     get_logger().info(f"Setting default executor to ThreadPoolExecutor(max_workers={max_workers})")
     asyncio.get_event_loop().set_default_executor(ThreadPoolExecutor(max_workers=max_workers))
+
+
+def trim_process_memory() -> None:
+    """Return freed heap pages to the OS on glibc systems."""
+    try:
+        ctypes.CDLL("libc.so.6").malloc_trim(0)
+    except Exception as exc:
+        get_logger().debug(f"malloc_trim(0) failed: {exc!r}")
 
 
 async def compute_teacher_logprobs(


### PR DESCRIPTION
## Summary

- Today the orchestrator only calls `malloc_trim(0)` **once, in the end-of-run teardown** — nothing reclaims memory between steps. Over a long run, each step frees a step's worth of rollouts / traces / transport buffers, but glibc keeps those pages in per-arena free lists, so orchestrator RSS climbs and never shrinks.
- Factor that teardown call into a `trim_process_memory()` helper (`orchestrator/utils.py`) and also call it at the end of `finalize_train_batch`, so freed heap is returned to the OS **every step**.

## Notes

- Mirrors the per-step trim in #2807 (*reduce retained train trace memory*) — **the trim part only**. That PR also adds `.raw`-based retention helpers (`release_train_batch_*`, `prune_train_rollout_payload`) which assume main's `TrainRollout`/`.raw` model; this branch (`feat/nano-as-v1`) deliberately keeps the typed v1 `Rollout`/`Trace`, so those don't port. `malloc_trim` alone still helps because the step's allocations are already dropped by the time `finalize_train_batch` returns.
- `malloc_trim` is glibc-only and wrapped in try/except (no-op elsewhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small operational change with no training logic, auth, or data-path impact; per-step malloc_trim may add minor latency on glibc only.
> 
> **Overview**
> Adds **`trim_process_memory()`** in `orchestrator/utils.py`, which calls glibc **`malloc_trim(0)`** inside try/except so non-glibc platforms no-op safely.
> 
> The orchestrator now invokes it **after each shipped train step** (end of `finalize_train_batch`) so freed rollout/batch heap can be returned to the OS instead of only trimming once at shutdown. Teardown still trims, but uses the shared helper instead of inline `ctypes` in `orchestrator.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b081a3592cfdacd1ce8736cabcd6e72a73186e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->