### PR TITLE
feat: route consistent_hash on X-Session-ID for cross-turn prefix reuse

### DIFF
--- a/src/prime_rl/templates/_launch_router.sh.j2
+++ b/src/prime_rl/templates/_launch_router.sh.j2
@@ -7,6 +7,7 @@ launch_router() {
     local tag="vllm-router"; [ "$mode" = pd ] && tag="vllm-router (PD)"
     echo "Starting $tag on $LOCAL_IP:$port${replica:+ for replica $replica}" | tee "$log"
     local -a cmd=(vllm-router --policy "$policy" --host 0.0.0.0 --port "$port"
+        --request-id-headers x-session-id
         --worker-startup-timeout-secs 4200 --log-level debug)
     if [ "$mode" = pd ]; then
         cmd+=(--vllm-pd-disaggregation $worker_args)


### PR DESCRIPTION
## Problem

The vllm-router `consistent_hash` policy keys on **request-id headers** (default `x-request-id` / `x-correlation-id` / `x-trace-id` / `request-id`). Under external-LB DP each replica's router load-balances across its per-DP-rank engines, so the routing key decides which engine serves a request.

The v1 inference clients sent **none** of those headers per rollout, so a multi-turn rollout's turns hashed to random DP shards and re-prefilled the growing prompt cold each turn — **~40% prefix cache hit rate** on an agentic SWE run (Qwen3.5-4B, r2e-gym, dp=8×2 replicas) where it should approach the eviction-limited ceiling. The orchestrator's per-group `(base_url, X-data-parallel-rank)` pinning only selects the *replica*; `X-data-parallel-rank` is not a router key under external-LB, so it didn't pin the engine.

## Fix

Launch the router with `--request-id-headers x-session-id` (shared `_launch_router.sh.j2`, so it applies to all rl + inference call sites, pd and regular). The companion verifiers change makes the v1 clients emit a stable per-rollout `X-Session-ID` (the trace id), so `consistent_hash` now pins every turn of a rollout to one engine and keeps its cross-turn prefix warm. Harmless for the `random` / `round_robin` policies, which ignore request-id headers.

## Companion change
- PrimeIntellect-ai/verifiers#1680 — v1 clients emit the `X-Session-ID` header.

## Follow-up (not in this PR)
- `X-data-parallel-rank` is dead weight under external-LB DP (router doesn't key on it); could be dropped from the train-client headers, but it's still meaningful for internal-DP topologies, so left as-is here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single launch-flag change in a shared shell template; no auth or data-path logic, and non-hash policies ignore the header.
> 
> **Overview**
> Configures every `vllm-router` started via the shared `launch_router` helper to use **`--request-id-headers x-session-id`**, so the `consistent_hash` policy can pin requests using that header instead of the default request-id headers.
> 
> With companion client changes that send a stable per-rollout `X-Session-ID`, multi-turn rollouts should land on the same DP engine across turns and improve prefix-cache reuse under external-LB topologies. Other router policies are unaffected because they do not use request-id headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44fbce46a34f2a4430c3a124a75af5213a540bc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->