### PR TITLE
[ENG-4094] docker: include cuda toolkit with runtime image

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -86,6 +86,19 @@ ARG TARGETARCH
 COPY scripts/docker-arm64-post-install.sh /app/scripts/docker-arm64-post-install.sh
 RUN if [ "$TARGETARCH" = "arm64" ]; then /app/scripts/docker-arm64-post-install.sh; fi
 
+# Trim the CUDA toolkit to the nvcc-JIT essentials in a separate stage, so the runtime
+# COPY ships only the trimmed result (~1.5 GB) instead of the full ~6.6 GB. Drops the math
+# runtime libs (cublas/cusparse/cufft/cusolver/curand/npp/nvjpeg) and big static .a
+# archives since nvcc JIT (TileLang/FlashInfer build their own kernels) and torch
+# (uses pinned nvidia-* wheels) needs them. Keeps nvcc/nvvm/ptxas + headers +
+# libcudart/libnvrtc/libcudadevrt for JIT compile+link.
+FROM builder AS cuda-trim
+RUN find /usr/local/cuda-12.8/targets/*/lib \
+        \( -name 'libcublas*' -o -name 'libcusparse*' -o -name 'libcufft*' \
+           -o -name 'libcusolver*' -o -name 'libcurand*' -o -name 'libnpp*' \
+           -o -name 'libnvjpeg*' -o -name 'libnvblas*' \) -delete \
+    && find /usr/local/cuda-12.8 -name '*.a' ! -name 'libcudadevrt.a' ! -name 'libcudart_static.a' -delete
+
 # CUDA 13 runtime libs source
 FROM nvidia/cuda:13.0.1-runtime-ubuntu24.04 AS cuda13
 RUN mkdir -p /cu13 && cp -d $(find /usr/local \
@@ -125,8 +138,8 @@ RUN apt-get update && apt-get install -y \
     && apt-get clean autoclean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# CUDA 12.8 toolkit (TileLang's runtime nvcc JIT) 
-COPY --from=builder /usr/local/cuda-12.8 /usr/local/cuda-12.8
+# CUDA 12.8 toolkit (TileLang's runtime nvcc JIT)
+COPY --from=cuda-trim /usr/local/cuda-12.8 /usr/local/cuda-12.8
 RUN ln -sfn /usr/local/cuda-12.8 /usr/local/cuda && test -x /usr/local/cuda/bin/nvcc
 ENV CUDA_HOME=/usr/local/cuda
 ENV PATH="/usr/local/cuda/bin:${PATH}"

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -1,7 +1,7 @@
 #inspired from https://github.com/astral-sh/uv-docker-example/blob/main/multistage.Dockerfile
 
 # Build stage - multi-arch base (supports amd64 + arm64)
-FROM nvidia/cuda:12.9.1-cudnn-devel-ubuntu24.04 AS builder
+FROM nvidia/cuda:12.8.1-cudnn-devel-ubuntu24.04 AS builder
 LABEL maintainer="prime intellect"
 LABEL repository="prime-rl"
 
@@ -86,7 +86,7 @@ ARG TARGETARCH
 COPY scripts/docker-arm64-post-install.sh /app/scripts/docker-arm64-post-install.sh
 RUN if [ "$TARGETARCH" = "arm64" ]; then /app/scripts/docker-arm64-post-install.sh; fi
 
-FROM python:3.12-slim
+FROM python:3.12-slim-bookworm
 
 RUN apt-get update && apt-get install -y \
     --no-install-recommends \
@@ -113,9 +113,8 @@ RUN apt-get update && apt-get install -y \
     && apt-get clean autoclean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Copy the CUDA toolkit from the builder
-COPY --from=builder /usr/local/cuda-12.9 /usr/local/cuda-12.9
-RUN ln -s /usr/local/cuda-12.9 /usr/local/cuda
+COPY --from=builder /usr/local/cuda-12.8 /usr/local/cuda-12.8
+RUN ln -s /usr/local/cuda-12.8 /usr/local/cuda
 ENV CUDA_HOME=/usr/local/cuda
 ENV PATH="/usr/local/cuda/bin:${PATH}"
 

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -86,6 +86,11 @@ ARG TARGETARCH
 COPY scripts/docker-arm64-post-install.sh /app/scripts/docker-arm64-post-install.sh
 RUN if [ "$TARGETARCH" = "arm64" ]; then /app/scripts/docker-arm64-post-install.sh; fi
 
+# CUDA 13 runtime libs source
+FROM nvidia/cuda:13.0.1-runtime-ubuntu24.04 AS cuda13
+RUN mkdir -p /cu13 && cp -d $(find /usr/local \
+        -name 'libcudart.so.13*' -o -name 'libnvrtc.so.13*' -o -name 'libnvrtc-builtins.so.13*') /cu13/
+
 # Runtime image
 FROM nvidia/cuda:12.8.1-base-ubuntu24.04
 
@@ -120,24 +125,18 @@ RUN apt-get update && apt-get install -y \
     && apt-get clean autoclean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# CUDA 12.8 toolkit
+# CUDA 12.8 toolkit (TileLang's runtime nvcc JIT) 
 COPY --from=builder /usr/local/cuda-12.8 /usr/local/cuda-12.8
-RUN ln -sfn /usr/local/cuda-12.8 /usr/local/cuda
+RUN ln -sfn /usr/local/cuda-12.8 /usr/local/cuda && test -x /usr/local/cuda/bin/nvcc
 ENV CUDA_HOME=/usr/local/cuda
 ENV PATH="/usr/local/cuda/bin:${PATH}"
 
 # CUDA 13 runtime libs for deep-gemm
-RUN apt-get update && apt-get install -y --no-install-recommends --allow-change-held-packages \
-        cuda-cudart-13-0 \
-        cuda-nvrtc-13-0 \
-    && { dirname "$(find /usr/local -name libcudart.so.13 | head -1)"; \
-         dirname "$(find /usr/local -name libnvrtc.so.13  | head -1)"; } \
-         | sort -u > /etc/ld.so.conf.d/cuda-13.conf \
+COPY --from=cuda13 /cu13/ /opt/cuda13/lib64/
+RUN echo /opt/cuda13/lib64 > /etc/ld.so.conf.d/cuda13.conf \
     && ldconfig \
     && ldconfig -p | grep -q libcudart.so.13 \
-    && ldconfig -p | grep -q libnvrtc.so.13 \
-    && apt-get clean autoclean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    && ldconfig -p | grep -q libnvrtc.so.13
 
 
 ARG USER_ID=1000

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -96,7 +96,6 @@ RUN apt-get update && apt-get install -y \
     --force-yes \
     python3.12 \
     python3.12-venv \
-    libpython3.12 \
     build-essential \
     wget \
     clang \
@@ -122,7 +121,7 @@ RUN apt-get update && apt-get install -y \
 
 # CUDA 12.8 toolkit
 COPY --from=builder /usr/local/cuda-12.8 /usr/local/cuda-12.8
-RUN ln -s /usr/local/cuda-12.8 /usr/local/cuda
+RUN ln -sfn /usr/local/cuda-12.8 /usr/local/cuda
 ENV CUDA_HOME=/usr/local/cuda
 ENV PATH="/usr/local/cuda/bin:${PATH}"
 

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -96,6 +96,7 @@ RUN apt-get update && apt-get install -y \
     --force-yes \
     python3.12 \
     python3.12-venv \
+    python3.12-dev \
     build-essential \
     wget \
     clang \

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -86,11 +86,17 @@ ARG TARGETARCH
 COPY scripts/docker-arm64-post-install.sh /app/scripts/docker-arm64-post-install.sh
 RUN if [ "$TARGETARCH" = "arm64" ]; then /app/scripts/docker-arm64-post-install.sh; fi
 
-FROM python:3.12-slim-bookworm
+# Runtime image
+FROM nvidia/cuda:12.8.1-base-ubuntu24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y \
     --no-install-recommends \
     --force-yes \
+    python3.12 \
+    python3.12-venv \
+    libpython3.12 \
     build-essential \
     wget \
     clang \
@@ -110,13 +116,28 @@ RUN apt-get update && apt-get install -y \
     libibverbs1 \
     ibverbs-providers \
     librdmacm1 \
+    && ln -sf /usr/bin/python3.12 /usr/local/bin/python \
     && apt-get clean autoclean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+# CUDA 12.8 toolkit
 COPY --from=builder /usr/local/cuda-12.8 /usr/local/cuda-12.8
 RUN ln -s /usr/local/cuda-12.8 /usr/local/cuda
 ENV CUDA_HOME=/usr/local/cuda
 ENV PATH="/usr/local/cuda/bin:${PATH}"
+
+# CUDA 13 runtime libs for deep-gemm
+RUN apt-get update && apt-get install -y --no-install-recommends --allow-change-held-packages \
+        cuda-cudart-13-0 \
+        cuda-nvrtc-13-0 \
+    && { dirname "$(find /usr/local -name libcudart.so.13 | head -1)"; \
+         dirname "$(find /usr/local -name libnvrtc.so.13  | head -1)"; } \
+         | sort -u > /etc/ld.so.conf.d/cuda-13.conf \
+    && ldconfig \
+    && ldconfig -p | grep -q libcudart.so.13 \
+    && ldconfig -p | grep -q libnvrtc.so.13 \
+    && apt-get clean autoclean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 
 ARG USER_ID=1000

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -141,7 +141,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends --allow-change-
 
 ARG USER_ID=1000
 ARG GROUP_ID=1000
-RUN groupadd --gid $GROUP_ID appuser && \
+
+RUN userdel -r ubuntu 2>/dev/null || true; \
+    groupdel ubuntu 2>/dev/null || true; \
+    groupadd --gid $GROUP_ID appuser && \
     useradd --uid $USER_ID --gid appuser --create-home --shell /bin/bash appuser && \
     usermod -aG sudo appuser && \
     echo "appuser ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -1,7 +1,7 @@
 #inspired from https://github.com/astral-sh/uv-docker-example/blob/main/multistage.Dockerfile
 
 # Build stage - multi-arch base (supports amd64 + arm64)
-FROM nvidia/cuda:12.8.1-cudnn-devel-ubuntu24.04 AS builder
+FROM nvidia/cuda:12.9.1-cudnn-devel-ubuntu24.04 AS builder
 LABEL maintainer="prime intellect"
 LABEL repository="prime-rl"
 
@@ -112,6 +112,12 @@ RUN apt-get update && apt-get install -y \
     librdmacm1 \
     && apt-get clean autoclean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Copy the CUDA toolkit from the builder
+COPY --from=builder /usr/local/cuda-12.9 /usr/local/cuda-12.9
+RUN ln -s /usr/local/cuda-12.9 /usr/local/cuda
+ENV CUDA_HOME=/usr/local/cuda
+ENV PATH="/usr/local/cuda/bin:${PATH}"
 
 
 ARG USER_ID=1000


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Foundational image and CUDA/Python layout changes affect every CUDA container workload; mis-trimmed libs or ldconfig could break JIT (TileLang/FlashInfer) or deep-gemm at runtime.
> 
> **Overview**
> Replaces the **`python:3.12-slim`** final stage with **`nvidia/cuda:12.8.1-base-ubuntu24.04`**, installing **Python 3.12** via apt and symlinking it as the default `python`.
> 
> Adds **multi-stage CUDA packaging**: a **`cuda-trim`** stage strips bulky math libs and static archives from the builder’s CUDA 12.8 tree so the runtime only copies an **~1.5 GB nvcc/JIT slice** (nvcc, headers, libcudart/nvrtc/cudadevrt) for **TileLang-style runtime JIT**; a separate **`cuda13`** stage copies **libcudart/libnvrtc 13** into **`/opt/cuda13/lib64`** with **ldconfig** for **deep-gemm**.
> 
> Sets **`CUDA_HOME`** and extends **`PATH`** for nvcc on the runtime image. **Removes the default `ubuntu` user/group** before creating **`appuser`** to avoid UID/GID clashes on the NVIDIA base image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47f3b8e277448bf35bdc108a2ab30a6269282880. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->