### PR TITLE
Fix routed SLURM inference DP rank client config

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -606,16 +606,20 @@ class RLConfig(BaseConfig):
     def auto_setup_inference_client(self):
         """Auto-configure orchestrator student client from the inference server config.
 
-        For all modes, sets dp_rank_count from inference DP size. For SFT mode,
-        also sets base_url - rl/opd rely on the ClientConfig default
-        (``["http://localhost:8000/v1"]``) which already matches the auto-launched
-        student vLLM at inference.server.port = 8000.
+        Direct single-node runs expose all local DP ranks behind one base URL,
+        so pin logical clients with ``X-data-parallel-rank``. Multi-node SLURM
+        runs expose a vllm-router URL instead; the router balances across
+        per-rank backend URLs and forwards request headers, so the orchestrator
+        must not inject a DP-rank header there.
         """
         if self.inference is None:
             return self
         client = self.orchestrator.student.client
         if "dp_rank_count" not in client.model_fields_set:
-            client.dp_rank_count = self.inference.data_parallel_size_local or self.inference.parallel.dp
+            if self.deployment.type == "multi_node":
+                client.dp_rank_count = 1
+            else:
+                client.dp_rank_count = self.inference.data_parallel_size_local or self.inference.parallel.dp
         if self.orchestrator.training_mode == "sft" and "base_url" not in client.model_fields_set:
             host = self.inference.server.host or "localhost"
             port = self.inference.server.port

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -172,6 +172,48 @@ def test_trainer_enable_token_export_cli_flag():
     assert cli(TrainerConfig, args=["--enable-token-export"]).enable_token_export
 
 
+def test_single_node_auto_inference_client_dp_rank_count_matches_local_dp():
+    config = RLConfig.model_validate(
+        {
+            "trainer": {},
+            "orchestrator": {},
+            "inference": {"parallel": {"tp": 1}},
+            "deployment": {
+                "type": "single_node",
+                "gpus_per_node": 4,
+                "num_train_gpus": 2,
+                "num_infer_gpus": 2,
+            },
+        }
+    )
+
+    assert config.inference is not None
+    assert config.inference.parallel.dp == 2
+    assert config.orchestrator.student.client.dp_rank_count == 2
+
+
+def test_multi_node_auto_inference_client_dp_rank_count_uses_router_url():
+    config = RLConfig.model_validate(
+        {
+            "trainer": {},
+            "orchestrator": {},
+            "inference": {"parallel": {"tp": 4}},
+            "deployment": {
+                "type": "multi_node",
+                "gpus_per_node": 8,
+                "num_train_nodes": 1,
+                "num_infer_nodes": 2,
+            },
+            "slurm": {},
+        }
+    )
+
+    assert config.inference is not None
+    assert config.inference.data_parallel_size_local == 2
+    assert config.inference.parallel.dp == 2
+    assert config.orchestrator.student.client.dp_rank_count == 1
+
+
 def test_orchestrator_vlm_requires_renderer():
     with pytest.raises(ValidationError, match="orchestrator.renderer must be set when model.vlm is set"):
         OrchestratorConfig.model_validate(


### PR DESCRIPTION
## Summary

Fix RL config auto-setup so multi-node SLURM inference clients treat the router URL as a single logical client instead of expanding it by local vLLM data parallel size.

## Root Cause

For multi-node SLURM deployments, dense inference launches per-rank vLLM backends behind the router. The orchestrator was still deriving `student.client.dp_rank_count` from `inference.data_parallel_size_local`, which caused requests to include DP-rank headers such as rank 1 against backends configured with local `data_parallel_size = 1`.

That shape fails with errors like:

```text
data_parallel_rank 1 is out of range [0, 1)
```

## Changes

- Keep the existing single-node behavior, where `dp_rank_count` follows local DP.
- For `deployment.type = "multi_node"`, default `dp_rank_count` to `1` unless explicitly configured.
- Add unit coverage for both single-node and multi-node inference client auto-setup.

## Validation

```bash
uv run pytest tests/unit/test_configs.py -k 'dp_rank_count' -q
```

Result: `2 passed, 216 deselected`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only default change with explicit override preserved and targeted unit tests; affects orchestrator→inference routing for multi-node SLURM, not training or auth.
> 
> **Overview**
> Fixes RL config auto-setup so **multi-node SLURM** deployments treat the vLLM **router** as a single logical inference client instead of mirroring local data-parallel size.
> 
> When `orchestrator.student.client.dp_rank_count` is unset, **single-node** runs still default it from `inference.data_parallel_size_local` or `inference.parallel.dp` (so `X-data-parallel-rank` can target ranks behind one URL). For **`deployment.type = "multi_node"`**, it now defaults to **`1`**, avoiding DP-rank headers that break per-rank backends (`data_parallel_rank N is out of range`).
> 
> Docs in `auto_setup_inference_client` describe this split; unit tests cover single-node vs multi-node defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d68fdc59ad072debf3fdce55aace2940f721f72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->