### PR TITLE
[codex] add rlm uuid ctf env

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ envs = [
     "reverse-text",
     "rlm-swe",
     "rlm-search",
+    "rlm-uuid-ctf",
     "science-env",
     "simpleqa-verified",
     "tau2-bench",
@@ -228,6 +229,7 @@ opencode-swe = { path = "deps/research-environments/environments/opencode_swe", 
 reverse-text = { path = "deps/verifiers/environments/reverse_text", editable = true }
 rlm-swe = { path = "deps/research-environments/environments/rlm_swe", editable = true }
 rlm-search = { path = "deps/research-environments/environments/rlm_search", editable = true }
+rlm-uuid-ctf = { path = "deps/research-environments/environments/rlm_uuid_ctf", editable = true }
 science-env = { path = "deps/research-environments/environments/science_env", editable = true }
 simpleqa-verified = { path = "deps/research-environments/environments/simpleqa_verified", editable = true }
 tau2-bench = { path = "deps/research-environments/environments/tau2_bench", editable = true }

--- a/skills/install/SKILL.md
+++ b/skills/install/SKILL.md
@@ -27,7 +27,7 @@ uv sync --group dev        # + pytest, ruff, pre-commit
 uv sync --all-extras       # recommended: envs, flash-attn, flash-attn-cute, etc.
 ```
 
-The `envs` extra installs every env workspace listed in `[tool.uv.workspace]`. Adding a new env means adding it to `members`, the `envs` extra, and `[tool.uv.sources]`.
+The `envs` extra installs environments listed under `[project.optional-dependencies].envs`, resolved through `[tool.uv.sources]`. Adding a new env means adding its package name to `envs` and its editable source path to `[tool.uv.sources]`.
 
 When bumping a package past the workspace-wide `exclude-newer = "7 days"` window, add it (and any newly-required transitives) to `[tool.uv.exclude-newer-package]` before refreshing `uv.lock`.
 

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ supported-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-06-10T23:37:49.383138959Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -4016,6 +4016,7 @@ envs = [
     { name = "reverse-text", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "rlm-search", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "rlm-swe", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "rlm-uuid-ctf", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "science-env", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "simpleqa-verified", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "tau2-bench", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -4118,6 +4119,7 @@ requires-dist = [
     { name = "ring-flash-attn", specifier = ">=0.1.8" },
     { name = "rlm-search", marker = "extra == 'envs'", editable = "deps/research-environments/environments/rlm_search" },
     { name = "rlm-swe", marker = "extra == 'envs'", editable = "deps/research-environments/environments/rlm_swe" },
+    { name = "rlm-uuid-ctf", marker = "extra == 'envs'", editable = "deps/research-environments/environments/rlm_uuid_ctf" },
     { name = "science-env", marker = "extra == 'envs'", editable = "deps/research-environments/environments/science_env" },
     { name = "setproctitle", specifier = ">=1.3.0" },
     { name = "simpleqa-verified", marker = "extra == 'envs'", editable = "deps/research-environments/environments/simpleqa_verified" },
@@ -4962,6 +4964,23 @@ requires-dist = [
     { name = "prime-sandboxes", specifier = ">=0.2.19" },
     { name = "swebench", specifier = "==4.1.0" },
     { name = "verifiers", extras = ["packages"], specifier = ">=0.1.15.dev17,<0.1.15.dev156" },
+]
+
+[[package]]
+name = "rlm-uuid-ctf"
+version = "0.1.1"
+source = { editable = "deps/research-environments/environments/rlm_uuid_ctf" }
+dependencies = [
+    { name = "datasets", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "prime-sandboxes", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "verifiers", extra = ["packages"], marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "datasets", specifier = ">=4.0.0" },
+    { name = "prime-sandboxes", specifier = ">=0.2.21" },
+    { name = "verifiers", extras = ["packages"], specifier = ">=0.1.15.dev17" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add `rlm-uuid-ctf` to the `envs` optional dependency extra.
- Add the editable source path for `deps/research-environments/environments/rlm_uuid_ctf`.
- Refresh `uv.lock` and update the install skill to match the current env wiring.

## Validation

- `uv sync --all-extras`
- `uv run python -c "import importlib.util; print(importlib.util.find_spec('rlm_uuid_ctf') is not None)"`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and documentation wiring only; no runtime or training-path changes in this diff.
> 
> **Overview**
> Wires **`rlm-uuid-ctf`** into prime-rl’s optional **`envs`** install path so `uv sync --all-extras` pulls the editable package from `deps/research-environments/environments/rlm_uuid_ctf`.
> 
> **`pyproject.toml`** adds the package to `[project.optional-dependencies].envs` and `[tool.uv.sources]`. **`uv.lock`** picks up the new workspace member (depends on `datasets`, `prime-sandboxes`, and `verifiers[packages]`) and updates the lock **`exclude-newer`** anchor. **`skills/install/SKILL.md`** documents that new envs are registered via the `envs` extra plus `[tool.uv.sources]`, not `[tool.uv.workspace]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e9567addcbd761817a340134e1f151cd5622f45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->