### PR TITLE
fix: drop removed enable_bash from v1 harness configs

### DIFF
--- a/configs/debug/v1/alphabet_sort.toml
+++ b/configs/debug/v1/alphabet_sort.toml
@@ -37,6 +37,6 @@ max_completion_tokens = 768
 [[orchestrator.train.env]]
 name = "alphabet-sort"
 taskset = { id = "alphabet-sort-v1", min_turns = 3, max_turns = 5, power_per_turn = false }
-harness = { id = "default", enable_bash = false, runtime = { type = "subprocess" } }
+harness = { id = "default", runtime = { type = "subprocess" } }
 
 [inference] # Default inference config

--- a/configs/debug/v1/hendrycks_sanity.toml
+++ b/configs/debug/v1/hendrycks_sanity.toml
@@ -29,7 +29,7 @@ seq_len = 8192
 [[orchestrator.train.env]]
 name = "hendrycks-math"
 taskset = { id = "math-env-v1", dataset_name = "mikasenghaas/Sanity-Test-R1D-1.5B", dataset_subset = "default" }
-harness = { id = "default", enable_bash = false, runtime = { type = "subprocess" } }
+harness = { id = "default", runtime = { type = "subprocess" } }
 timeout = { scoring = 10 }
 
 [orchestrator.eval]
@@ -38,7 +38,7 @@ interval = 50
 [[orchestrator.eval.env]]
 name = "aime2024"
 taskset = { id = "aime24-v1" }
-harness = { id = "default", enable_bash = false, runtime = { type = "subprocess" } }
+harness = { id = "default", runtime = { type = "subprocess" } }
 timeout = { scoring = 10 }
 group_size = 32
 

--- a/configs/debug/v1/reverse_text.toml
+++ b/configs/debug/v1/reverse_text.toml
@@ -28,7 +28,7 @@ max_completion_tokens = 128
 taskset = { id = "reverse-text-v1" }
 # reverse-text is a pure-text single-turn env: disable the bash tool (the model answers
 # directly) and use the subprocess runtime (no docker).
-harness = { id = "default", enable_bash = false, runtime = { type = "subprocess" } }
+harness = { id = "default", runtime = { type = "subprocess" } }
 
 # No eval block, mirroring examples/reverse_text/rl.toml — this is a train-only
 # smoke. Add an [orchestrator.eval] block (with an interval) to exercise eval.

--- a/configs/v1/multimodal_color_codeword.toml
+++ b/configs/v1/multimodal_color_codeword.toml
@@ -52,7 +52,7 @@ max_completion_tokens = 64
 taskset = { id = "color-codeword-v1", images_per_turn = 1, num_examples = 1000 }
 # Multi-turn VLM env: turn-0 squares ride in the task's Messages instruction, later turns come
 # from the colocated user simulator. Subprocess runtime (no docker).
-harness = { id = "default", enable_bash = false, runtime = { type = "subprocess" } }
+harness = { id = "default", runtime = { type = "subprocess" } }
 
 [orchestrator.eval]
 interval = 5
@@ -63,7 +63,7 @@ max_completion_tokens = 64
 
 [[orchestrator.eval.env]]
 taskset = { id = "color-codeword-v1", images_per_turn = 1, num_examples = 1000 }
-harness = { id = "default", enable_bash = false, runtime = { type = "subprocess" } }
+harness = { id = "default", runtime = { type = "subprocess" } }
 
 [trainer]
 

--- a/configs/v1/training_mode/opd.toml
+++ b/configs/v1/training_mode/opd.toml
@@ -30,7 +30,7 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 taskset = { id = "reverse-text-v1" }
-harness = { id = "default", enable_bash = false, runtime = { type = "subprocess" } }
+harness = { id = "default", runtime = { type = "subprocess" } }
 
 [orchestrator.eval]
 interval = 1
@@ -41,7 +41,7 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.env]]
 taskset = { id = "reverse-text-v1" }
-harness = { id = "default", enable_bash = false, runtime = { type = "subprocess" } }
+harness = { id = "default", runtime = { type = "subprocess" } }
 
 [orchestrator.teacher.model]
 name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-RL"

--- a/configs/v1/training_mode/opd_lora.toml
+++ b/configs/v1/training_mode/opd_lora.toml
@@ -29,7 +29,7 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 taskset = { id = "reverse-text-v1" }
-harness = { id = "default", enable_bash = false, runtime = { type = "subprocess" } }
+harness = { id = "default", runtime = { type = "subprocess" } }
 
 [orchestrator.eval]
 interval = 1
@@ -40,7 +40,7 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.env]]
 taskset = { id = "reverse-text-v1" }
-harness = { id = "default", enable_bash = false, runtime = { type = "subprocess" } }
+harness = { id = "default", runtime = { type = "subprocess" } }
 
 [orchestrator.teacher.model]
 name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-RL"

--- a/configs/v1/training_mode/rl.toml
+++ b/configs/v1/training_mode/rl.toml
@@ -26,7 +26,7 @@ max_completion_tokens = 128
 [[orchestrator.train.env]]
 taskset = { id = "reverse-text-v1" }
 # Pure-text single-turn env: the model answers directly (no bash tool), subprocess runtime (no docker).
-harness = { id = "default", enable_bash = false, runtime = { type = "subprocess" } }
+harness = { id = "default", runtime = { type = "subprocess" } }
 
 [orchestrator.eval]
 interval = 1
@@ -37,7 +37,7 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.env]]
 taskset = { id = "reverse-text-v1" }
-harness = { id = "default", enable_bash = false, runtime = { type = "subprocess" } }
+harness = { id = "default", runtime = { type = "subprocess" } }
 
 [trainer.optim]
 lr = 3e-6

--- a/configs/v1/training_mode/sft.toml
+++ b/configs/v1/training_mode/sft.toml
@@ -31,7 +31,7 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 taskset = { id = "reverse-text-v1" }
-harness = { id = "default", enable_bash = false, runtime = { type = "subprocess" } }
+harness = { id = "default", runtime = { type = "subprocess" } }
 
 [orchestrator.eval]
 interval = 1
@@ -42,7 +42,7 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.env]]
 taskset = { id = "reverse-text-v1" }
-harness = { id = "default", enable_bash = false, runtime = { type = "subprocess" } }
+harness = { id = "default", runtime = { type = "subprocess" } }
 
 [orchestrator.teacher.model]
 name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-RL"

--- a/configs/v1/training_mode/sft_lora.toml
+++ b/configs/v1/training_mode/sft_lora.toml
@@ -31,7 +31,7 @@ max_completion_tokens = 128
 
 [[orchestrator.train.env]]
 taskset = { id = "reverse-text-v1" }
-harness = { id = "default", enable_bash = false, runtime = { type = "subprocess" } }
+harness = { id = "default", runtime = { type = "subprocess" } }
 
 [orchestrator.eval]
 interval = 1
@@ -42,7 +42,7 @@ max_completion_tokens = 128
 
 [[orchestrator.eval.env]]
 taskset = { id = "reverse-text-v1" }
-harness = { id = "default", enable_bash = false, runtime = { type = "subprocess" } }
+harness = { id = "default", runtime = { type = "subprocess" } }
 
 [orchestrator.teacher.model]
 name = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-RL"


### PR DESCRIPTION
## Summary

Drop the now-removed `enable_bash` field from all v1 harness configs.

**[verifiers#1723](https://github.com/PrimeIntellect-ai/verifiers/pull/1723)** (in the current `feat/nano-as-v1` pin) removed the default harness's `enable_bash` toggle — the default harness now exposes only the taskset's MCP tools, and a shell-driving agent is a dedicated agentic harness (e.g. `mini-swe-agent`). Every prime-rl v1 config still set `harness = { id = "default", enable_bash = false, ... }`, which now fails config validation:

```
1 validation error for RLConfig
--orchestrator.train.env[0].enable-bash
Extra inputs are not permitted (got False)
```

This broke every v1 RL/SFT/eval run on the current pin. Dropping `enable_bash = false` restores them — no-bash is the default behavior now, so this is behavior-preserving. No `src/` code referenced the field; it was config-only.

## Breaking

None for users — `enable_bash = false` was the no-op (default) case. (A config that wanted `enable_bash = true` would now need an agentic harness, but no prime-rl config used that.)

## Files

`enable_bash = false` removed from 9 configs (16 occurrences): `configs/debug/v1/{reverse_text,alphabet_sort,hendrycks_sanity}.toml`, `configs/v1/multimodal_color_codeword.toml`, `configs/v1/training_mode/{rl,sft,opd,sft_lora,opd_lora}.toml`.

## Verification

`uv run rl @ configs/debug/v1/reverse_text.toml` (Qwen3-0.6B-Reverse-Text-SFT, 2 steps, subprocess runtime, Blackwell):

- **Orchestrator** — Step 0 `Reward 0.1169` → Step 1 `Reward 0.1770`, `Trainable 128/128 (100%)`, **`Error 0.0%`** both steps (env-server rollouts + scoring over the new model_dump-trace path work).
- **Trainer** — Step 0 + Step 1 completed (loss/grad-norm/throughput sane), weight broadcast, final checkpoint → **`Training finished!`**.

Config validation also passes again (`--dry-run` clean), and `eval reverse-text-v1` / `eval --id reverse-text` both score `1.0` with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only cleanup with no application code changes; behavior is intended to stay the same because `enable_bash = false` was the prior default.
> 
> **Overview**
> Removes the obsolete **`enable_bash = false`** field from **16** `harness` entries across **9** v1 TOML configs (debug smokes, multimodal color-codeword, and `training_mode` RL/SFT/OPD variants).
> 
> Upstream verifiers dropped that knob on the default harness; leaving it in place triggers Pydantic **“Extra inputs are not permitted”** and blocks v1 runs. **`harness = { id = "default", runtime = { type = "subprocess" } }`** is unchanged otherwise—no bash was already the default, so rollout behavior should match before the pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 644e7109376887306f2e9c0abc9a443f05006ba5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->