### PR TITLE
[codex] trim orchestrator memory after train steps

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -21,7 +21,6 @@ in ``setup()`` and drives them from ``main_loop()``.
 from __future__ import annotations
 
 import asyncio
-import ctypes
 import logging
 import os
 import time
@@ -72,6 +71,7 @@ from prime_rl.orchestrator.utils import (
     save_rollouts,
     set_default_executor,
     setup_student_inference_pool,
+    trim_process_memory,
 )
 from prime_rl.orchestrator.watcher import WeightWatcher
 from prime_rl.trainer.model import setup_tokenizer
@@ -482,10 +482,7 @@ class Orchestrator:
                 get_logger().success("Orchestrator finished.")
             else:
                 get_logger().warning("Orchestrator cleanup complete (forced).")
-            try:
-                ctypes.CDLL("libc.so.6").malloc_trim(0)
-            except Exception as e:
-                get_logger().debug(f"malloc_trim(0) failed: {e}")
+            trim_process_memory()
 
     async def main_loop(self) -> None:
         """Consume ``FinishedRollout``\\ s from the dispatcher and route them
@@ -614,6 +611,7 @@ class Orchestrator:
 
         await self.sender.send(TrainingBatch(examples=batch.samples, step=step))
         self.update_dispatch_gate()
+        trim_process_memory()
 
         metrics = self.metrics.build(
             step=step,

--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import ctypes
+import gc
 import logging
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -99,6 +100,7 @@ def set_default_executor(max_workers: int = 64) -> None:
 
 def trim_process_memory() -> None:
     """Return freed heap pages to the OS on glibc systems."""
+    gc.collect()
     try:
         ctypes.CDLL("libc.so.6").malloc_trim(0)
     except Exception as exc:

--- a/src/prime_rl/orchestrator/utils.py
+++ b/src/prime_rl/orchestrator/utils.py
@@ -1,4 +1,5 @@
 import asyncio
+import ctypes
 import logging
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -94,6 +95,14 @@ def set_default_executor(max_workers: int = 64) -> None:
     """Scale the default asyncio thread pool so asyncio.to_thread has enough capacity."""
     get_logger().info(f"Setting default executor to ThreadPoolExecutor(max_workers={max_workers})")
     asyncio.get_event_loop().set_default_executor(ThreadPoolExecutor(max_workers=max_workers))
+
+
+def trim_process_memory() -> None:
+    """Return freed heap pages to the OS on glibc systems."""
+    try:
+        ctypes.CDLL("libc.so.6").malloc_trim(0)
+    except Exception as exc:
+        get_logger().debug(f"malloc_trim(0) failed: {exc!r}")
 
 
 async def compute_teacher_logprobs(


### PR DESCRIPTION
## Summary

Adds a small orchestrator memory hygiene change:

- centralizes the existing end-of-run memory trim behind `trim_process_memory()`
- runs `gc.collect()` before `malloc_trim(0)`
- calls `trim_process_memory()` after each train batch send / dispatch-gate update
- does not include raw rollout pruning, reference clearing, monitor changes, or transport changes from #2807

## Ablation

Fast A/B run using the no-inference routed-payload harness: `5 steps`, `batch=64`, `inflight=128`, `seq_len=32768`, `turns=50`, `max_off_policy=4`, delay mean `0s`, std `3.33s` with observed max delay `10.22s`.

| metric | no trim | trim | delta |
| --- | ---: | ---: | ---: |
| post-step peak RSS | 15.863 GiB | 14.467 GiB | -1.396 GiB |
| external peak RSS | 17.155 GiB | 16.946 GiB | -0.209 GiB |
| runtime | 1m33s | 1m31s | -2s |

Takeaway: this helps retained post-step RSS, but it is not a peak-memory fix.

## Validation

- `uv run ruff check src/prime_rl/orchestrator/orchestrator.py src/prime_rl/orchestrator/utils.py`
- `uv run ruff format --check src/prime_rl/orchestrator/orchestrator.py src/prime_rl/orchestrator/utils.py`
- `uv run python - <<'PY' ... trim_process_memory() ... PY`
- `uv run pytest tests/unit/orchestrator/test_batch.py tests/unit/train/rl/test_packer.py`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Operational memory hygiene only; no training, transport, or auth logic changes. Per-step `gc.collect()` may add small latency on non-glibc platforms where malloc_trim is a no-op.
> 
> **Overview**
> Centralizes glibc **heap return-to-OS** logic in **`trim_process_memory()`**, which runs **`gc.collect()`** before **`malloc_trim(0)`** (with debug logging on failure).
> 
> The orchestrator now calls that helper **after each shipped train batch** (right after **`sender.send`** and **`update_dispatch_gate`**) in addition to the existing **shutdown** path, replacing the previous inline **`ctypes`** block there.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 060ef916639541ce7e0be200ca673c7e532a7ec2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->