### PR TITLE
[codex] release orchestrator batch references

### DIFF
--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -610,8 +610,8 @@ class Orchestrator:
             teacher_logprobs_time = time.perf_counter() - t
 
         await self.sender.send(TrainingBatch(examples=batch.samples, step=step))
+        self._release_train_batch_samples(batch)
         self.update_dispatch_gate()
-        trim_process_memory()
 
         metrics = self.metrics.build(
             step=step,
@@ -627,6 +627,7 @@ class Orchestrator:
         )
         self.monitor.log(metrics, step=step)
         self.monitor.log_samples(rollout_dicts, step=step)
+        rollout_dicts.clear()
         self.monitor.log_distributions(
             distributions={
                 "rewards": [r.reward for r in batch.rollouts],
@@ -661,6 +662,18 @@ class Orchestrator:
         self.train_sink.reset_pre_filter_stats()
         self.progress.step += 1
         self.maybe_trigger_eval(self.progress.step)
+        self._release_train_batch_rollouts(batch)
+        trim_process_memory()
+
+    @staticmethod
+    def _release_train_batch_samples(batch: TrainBatch) -> None:
+        batch.samples.clear()
+        for rollout in batch.rollouts:
+            rollout.samples.clear()
+
+    @staticmethod
+    def _release_train_batch_rollouts(batch: TrainBatch) -> None:
+        batch.rollouts.clear()
 
     def maybe_trigger_eval(self, step: int) -> None:
         """Fire eligible eval epochs and flip to ``PREFER_EVAL`` if anything


### PR DESCRIPTION
## Summary

Releases orchestrator-owned train batch references after they are no longer needed:

- clears sent trainer samples after `sender.send(...)` returns
- clears rollout dicts after sample logging
- clears finalized rollout refs after metrics, distributions, progress, and batch logging consume them
- keeps this stacked on #2837 so the diff is only the reference-cleanup layer

## Ablation

Same fast no-inference routed-payload run used for #2837: `5 steps`, `batch=64`, `inflight=128`, `seq_len=32768`, `turns=50`, `max_off_policy=4`, delay mean `0s`, std `3.33s`.

| layer | post-step RSS totals GiB | post-step peak | external peak | runtime |
| --- | --- | ---: | ---: | ---: |
| trim + GC | `9.557, 10.991, 12.876, 13.709, 14.526` | `14.526` | `16.883` | `1m36s` |
| + release refs | `4.378, 6.056, 7.571, 9.283, 9.741` | `9.741` | `15.838` | `1m33s` |

Takeaway: reference cleanup reduces retained post-step RSS by about `4.785 GiB` at step 4. Peak RSS is still dominated by in-flight rollout workers.

## Validation

- `uv run ruff check src/prime_rl/orchestrator/orchestrator.py src/prime_rl/orchestrator/utils.py`
- `uv run ruff format --check src/prime_rl/orchestrator/orchestrator.py src/prime_rl/orchestrator/utils.py`
- `uv run pytest tests/unit/orchestrator/test_batch.py tests/unit/train/rl/test_packer.py`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lifecycle-only clears after encode/send and logging; no change to batching, filters, or transport semantics beyond earlier reference release.
> 
> **Overview**
> **Orchestrator memory:** `finalize_train_batch` now drops large in-memory structures as soon as each step is done with them, instead of holding the whole batch until `trim_process_memory()` at the old point.
> 
> Right after `sender.send` returns, `_release_train_batch_samples` clears `batch.samples` and each rollout’s `samples`. After `log_samples`, `rollout_dicts` is cleared. Metrics, distributions, progress, and batch logging still read from `batch.rollouts` first; then `_release_train_batch_rollouts` clears `batch.rollouts`, and **`trim_process_memory()` runs at the end** of the step (moved from immediately after `update_dispatch_gate`).
> 
> The PR description reports roughly **~4.8 GiB lower post-step RSS** on a long-sequence routed-payload ablation, with peak RSS still driven mainly by in-flight rollouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82e4eff485d0199044241d10655836e5e8f56172. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->