### PR TITLE
fix(orchestrator): drain off-policy rollouts before pausing for weight update

### DIFF
--- a/src/prime_rl/orchestrator/dispatcher.py
+++ b/src/prime_rl/orchestrator/dispatcher.py
@@ -11,8 +11,9 @@
   schedule next. Transitions are level-triggered (driven by the eval
   source's emptiness), so in-flight rollouts of the opposite kind drain
   naturally on either side of an eval boundary.
-- ``on_new_version`` (called by the watcher) bumps ``off_policy_steps`` on
-  in-flight train rollouts and drops groups past ``max_off_policy_steps``.
+- ``on_version_pending`` (called by the watcher before the engines pause for
+  the weight update) bumps ``off_policy_steps`` on in-flight train rollouts and
+  drops groups past ``max_off_policy_steps``.
   Eval rollouts are measurements for the policy version they started with,
   so they are allowed to finish even if training advances.
   Cancellations surface as synthetic ``Cancelled`` markers so the sink's
@@ -116,7 +117,7 @@ class RolloutDispatcher:
     """``await dispatcher.start()`` runs the dispatch loop until ``stop()``.
     Pulls examples from ``TrainSource`` / ``EvalSource``, schedules
     rollouts under shared capacity, and emits ``FinishedRollout``\\ s to
-    ``out_q``. The watcher drives ``on_new_version`` for off-policy
+    ``out_q``. The watcher drives ``on_version_pending`` for off-policy
     cancellation; the orchestrator triggers eval epochs."""
 
     def __init__(
@@ -263,11 +264,16 @@ class RolloutDispatcher:
             await safe_cancel(self.task)
             self.task = None
 
-    async def on_new_version(self, step: int) -> None:
+    async def on_version_pending(self, step: int) -> None:
         """Bump off-policy counters and drop groups past
         ``max_off_policy_steps`` (drop_group emits ``Cancelled`` markers so
         the sink still finalizes the partial group). Eval rollouts are not
-        aged because they are tied to their start-time policy version."""
+        aged because they are tied to their start-time policy version.
+
+        Runs *before* the inference engines are paused for the weight update so
+        the resulting aborts are processed while the engine is still stepping —
+        otherwise the orphaned KV transfers crash the decode engine on resume
+        (see ``WeightWatcher.apply_policy_update``)."""
         stale_groups: set[uuid.UUID] = set()
         cancelled = 0
         for meta in self.inflight.values():
@@ -286,6 +292,9 @@ class RolloutDispatcher:
                 f"Cancelled {cancelled} train rollouts past max_off_policy_steps={self.max_off_policy_steps}. "
                 "Consider increasing it to avoid this."
             )
+
+    async def on_new_version(self, step: int) -> None:
+        """No-op: the dispatcher drains in ``on_version_pending`` (pre-pause)."""
 
     async def fill_inflight(self) -> None:
         """Schedule new rollouts up to ``max_inflight``, honoring
@@ -602,7 +611,7 @@ class RolloutDispatcher:
         # markers for those too so the sink hits ``target_rollouts``
         #
         # ``last_meta`` can be ``None`` if the only inflight task for this
-        # group completed naturally between ``on_new_version``'s snapshot
+        # group completed naturally between ``on_version_pending``'s snapshot
         # and us reaching it — synthesize a stand-in from the group state
         unscheduled_cancelled = 0
         if group is not None and group.rollouts_to_schedule > 0:

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -876,6 +876,10 @@ class Orchestrator:
                 get_logger().info("Resuming dispatcher")
             gate.set()
 
+    async def on_version_pending(self, step: int) -> None:
+        """No-op: the dispatch gate is re-evaluated in ``on_new_version`` once
+        the new policy version is live."""
+
     async def on_new_version(self, step: int) -> None:
         """``VersionObserver`` hook: the watcher just advanced ``policy.version``;
         re-evaluate the dispatch gate (may resume if the trainer caught up)."""

--- a/src/prime_rl/orchestrator/types.py
+++ b/src/prime_rl/orchestrator/types.py
@@ -202,7 +202,12 @@ class EvalBatch:
 
 
 class VersionObserver(Protocol):
-    """Notified after each policy update; walked by the watcher after it
-    mutates ``Policy``."""
+    """Notified around each policy update; walked by the watcher.
+
+    ``on_version_pending`` fires *before* the inference engines are paused for
+    the weight update; ``on_new_version`` fires *after* the new weights are live
+    and ``Policy`` has been mutated."""
+
+    async def on_version_pending(self, step: int) -> None: ...
 
     async def on_new_version(self, step: int) -> None: ...

--- a/src/prime_rl/orchestrator/watcher.py
+++ b/src/prime_rl/orchestrator/watcher.py
@@ -92,6 +92,24 @@ class WeightWatcher:
                     f"Orchestrator resumed: checkpoint {next_step} ready (after {format_time(self.last_wait_for_ckpt_time)})"
                 )
 
+            # Drain off-policy rollouts BEFORE pausing the inference engines.
+            # Aborting a rollout triggers vLLM's KV-connector cleanup (NIXL's
+            # ``_reqs_not_processed``), which is only propagated to the workers
+            # while the engine is stepping. If we drain after resume instead,
+            # the aborts race with the flush of KV transfers that completed
+            # during the pause and trip ``assert req_id in self.requests`` in
+            # the decode scheduler's ``_update_from_kv_xfer_finished`` — killing
+            # the engine and cascading to every DP rank. Draining first lets the
+            # aborts settle under normal stepping. ``on_new_version`` (below)
+            # still runs post-update for observers that need the live version.
+            for observer in self.observers:
+                try:
+                    await observer.on_version_pending(next_step)
+                except Exception as exc:
+                    get_logger().warning(
+                        f"Observer {type(observer).__name__}.on_version_pending({next_step}) raised: {exc!r}"
+                    )
+
             get_logger().debug(f"Updating weights to step {next_step}")
             t1 = time.perf_counter()
             await self.inference.update_weights(weights_path, lora_name=self.lora_name, step=next_step)


### PR DESCRIPTION
## Problem

In a NIXL prefill/decode deployment, runs reliably crashed at the **step 8/9 weight update**: all decode `EngineCore` processes died within ~3s, the orchestrator saw a burst of 500s + disconnects, and rollouts errored out.

The single root trigger (the rest are collateral) is one decode rank hitting:

```
vllm/v1/core/sched/scheduler.py, in _update_from_kv_xfer_finished
    assert req_id in self.requests
AssertionError
```

Once that rank's process exits, every other DP rank dies on its next finish-state `all_reduce` with `gloo … Connection closed by peer`.

## Root cause

The off-policy drain — cancelling rollouts whose `off_policy_steps > max_off_policy_steps` — ran from `on_new_version`, which the watcher calls **after** `update_weights` (i.e. after the engines resume from the weight-update pause).

1. Cancelling a rollout aborts its `/generate` request. vLLM marks it `FINISHED_ABORTED`, frees it (`del self.requests[req_id]`), and records it in the NIXL connector's `_reqs_not_processed` so the **worker** suppresses the request's in-flight KV-transfer completion.
2. That suppression is only shipped to the workers **while the engine is stepping** (via `build_connector_meta` inside `step()`).
3. prime-rl pauses with `mode="keep"` → `PAUSED_ALL`, which **skips `step()`**. KV transfers that complete during the pause are therefore queued and flushed on the **first step after resume** — exactly when the drain fires its aborts.
4. The abort frees the request before its suppression reaches the worker, so the flushed `finished_sending`/`finished_recving` completion references a `req_id` that's already gone → the assert → dead engine → gloo cascade across all DP ranks.

With `max_off_policy_steps = 8`, the first mass drop happens at the **9th** weight update (a rollout from step 0 reaches off-policy age 9 there), which is why it's always step 8/9 rather than random. Confirmed in logs: `Updated weights to step 9` → `Cancelled 155 train rollouts past max_off_policy_steps=8` → the aborted request's KV send completes → assert.

## Fix

Drain **before** pausing, so the aborts are processed under normal stepping where vLLM's native `_reqs_not_processed` cleanup actually propagates to the workers and settles the KV transfers before the engine freezes.

- Add `on_version_pending` to the `VersionObserver` protocol — fired by the watcher **before** `update_weights` (before the pause).
- Move the off-policy bump/drop from `RolloutDispatcher.on_new_version` to `on_version_pending`; `on_new_version` is now a no-op for the dispatcher.
- `on_new_version` still runs post-update for `Orchestrator`, whose dispatch-gate re-eval needs the live `policy.version`.

The off-policy counter still advances exactly once per weight update; only the timing within the update moves from "just after resume" to "just before pause".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes timing of rollout aborts around weight updates in the inference-critical path; behavior is intentional but affects NIXL/vLLM coordination at every checkpoint.
> 
> **Overview**
> Off-policy train rollout cancellation now runs **before** inference engines pause for a weight update, instead of immediately after weights go live.
> 
> The watcher introduces **`on_version_pending`** on `VersionObserver` and invokes it on all observers (dispatcher + orchestrator) ahead of `update_weights`. **`RolloutDispatcher`** moves the off-policy step bump and stale-group drops from `on_new_version` into `on_version_pending`; its `on_new_version` is a no-op. **`Orchestrator`** implements a no-op `on_version_pending` and still re-evaluates the dispatch gate in `on_new_version` once `policy.version` is updated.
> 
> The off-policy counter still advances once per weight update; only the timing shifts so vLLM/NIXL can process abort-driven KV cleanup while the engine is still stepping, avoiding decode scheduler crashes on resume.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f8c671bec1c71da90c135c72c74f1c2ed2b1405. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->