### PR TITLE
fix(inference): tolerate KV-transfer finish for already-freed (aborted) reqs

### DIFF
--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -21,6 +21,68 @@ def transformers_v5_compat():
     monkey_patch_deep_gemm_silu_mul_quant_int64()
     monkey_patch_vllm_padded_input_scrub()
     monkey_patch_return_routed_experts_with_nixl_connector()
+    monkey_patch_kv_xfer_finished_tolerate_freed()
+
+
+def monkey_patch_kv_xfer_finished_tolerate_freed():
+    """Tolerate KV-transfer finish notifications for already-freed requests.
+
+    In disaggregated P/D (NIXL, optionally + a KV store connector) a request can
+    be finished — most often ``FINISHED_ABORTED`` from an off-policy cancel, a
+    client disconnect, or a request timeout — while it still has in-flight KV
+    transfers. When such a request's ``finished_recving`` and ``finished_sending``
+    both land in the same ``Scheduler.update_from_output`` step, the stock
+    ``_update_from_kv_xfer_finished`` frees it in the recving branch
+    (``_free_blocks`` -> ``del self.requests[req_id]``) and then the sending
+    branch hits ``assert req_id in self.requests`` and kills the EngineCore. On a
+    DP deployment that one death cascades to every rank via the gloo finish-state
+    all-reduce, taking down the whole inference pool.
+
+    The trigger is the abort itself, not weight-update pause/resume: it reproduces
+    during normal stepping whenever an aborted request's recv and send complete in
+    the same step (observed with zero off-policy cancellations, driven only by
+    incidental client-side aborts). Skip already-freed request ids instead of
+    asserting — their blocks are freed either way, so dropping the stale
+    notification is safe.
+
+    Upstream issue: https://github.com/vllm-project/vllm/issues/PLACEHOLDER
+    """
+    from vllm.logger import init_logger
+    from vllm.v1.core.sched.scheduler import Scheduler
+    from vllm.v1.request import RequestStatus
+
+    logger = init_logger("vllm.v1.core.sched.scheduler")
+
+    if getattr(Scheduler._update_from_kv_xfer_finished, "_prime_rl_tolerates_freed", False):
+        return
+
+    def _update_from_kv_xfer_finished(self, kv_connector_output):
+        if self.connector is not None:
+            self.connector.update_connector_output(kv_connector_output)
+
+        for req_id in kv_connector_output.finished_recving or ():
+            logger.debug("Finished recving KV transfer for request %s", req_id)
+            # Stale notification for a request freed earlier this step (e.g. an
+            # aborted request whose send completion freed it). Nothing to do.
+            if req_id not in self.requests:
+                continue
+            req = self.requests[req_id]
+            if req.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
+                self.finished_recving_kv_req_ids.add(req_id)
+            else:
+                assert RequestStatus.is_finished(req.status)
+                self._free_blocks(self.requests[req_id])
+        for req_id in kv_connector_output.finished_sending or ():
+            logger.debug("Finished sending KV transfer for request %s", req_id)
+            # See above: the recving branch may have already freed an aborted
+            # request whose send also completed this step.
+            if req_id not in self.requests:
+                continue
+            self._free_blocks(self.requests[req_id])
+
+    _update_from_kv_xfer_finished._prime_rl_tolerates_freed = True
+    Scheduler._update_from_kv_xfer_finished = _update_from_kv_xfer_finished
+    logger.warning("Patched Scheduler._update_from_kv_xfer_finished to tolerate freed (aborted) KV-transfer reqs.")
 
 
 def monkey_patch_nano_v3_reasoning_parser():

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -45,7 +45,7 @@ def monkey_patch_kv_xfer_finished_tolerate_freed():
     asserting — their blocks are freed either way, so dropping the stale
     notification is safe.
 
-    Upstream issue: https://github.com/vllm-project/vllm/issues/PLACEHOLDER
+    Upstream issue: https://github.com/vllm-project/vllm/issues/46240
     """
     from vllm.logger import init_logger
     from vllm.v1.core.sched.scheduler import Scheduler


### PR DESCRIPTION
## Problem

In disaggregated P/D inference (NIXL, optionally with a KV-store connector), the decode `EngineCore` reliably dies and takes the whole DP pool with it. Every occurrence is the same single root crash — one rank asserting, the other 31 are gloo cascade victims (`Connection closed by peer`):

```
vllm/v1/core/sched/scheduler.py, in _update_from_kv_xfer_finished
    assert req_id in self.requests
AssertionError
```

## Root cause

A request can be **finished while it still has in-flight KV transfers** — most often `FINISHED_ABORTED` (off-policy cancel, client disconnect, request timeout). When that request's `finished_recving` **and** `finished_sending` arrive in the **same** `Scheduler.update_from_output` step, `_update_from_kv_xfer_finished` does:

```python
for req_id in finished_recving:        # req is finished →
    self._free_blocks(self.requests[req_id])   # del self.requests[req_id]
for req_id in finished_sending:
    assert req_id in self.requests     # ← already deleted → AssertionError
```

The recving branch frees the request; the sending branch then asserts on the now-missing id and the engine dies. On DP, that one death cascades to every rank through the gloo finish-state all-reduce.

For a normally-completing request, recv (start) and send (end) land in different steps, so they never collide. The **abort** is what collapses both completions into one step. vLLM's native `_reqs_not_processed` suppression doesn't help here: it only un-schedules *pending* transfers, but these had already completed.

## Evidence (two llm-d P/D runs)

- It's **abort-triggered, not pause/resume-related**: the crash happened during normal stepping ~19k log lines after the last `/resume`, with the engine actively running model batches.
- A run with `max_off_policy_steps = 80000` (**zero** off-policy cancellations) still crashed via the identical assert — driven purely by incidental client-side aborts (`FINISHED_ABORTED` from disconnects/timeouts).
- A run with `max_off_policy_steps = 8` (frequent off-policy aborts) crashed much faster — consistent with abort rate driving the collision probability.

## Fix

Monkey-patch `Scheduler._update_from_kv_xfer_finished` to **skip request ids no longer in `self.requests`** instead of asserting, in both the recving and sending loops. Their blocks are already freed, so dropping the stale notification is safe. Installed via the existing `vllm.general_plugins` entry point so it applies in the `EngineCore` process where the `Scheduler` lives.

Upstream issue: https://github.com/vllm-project/vllm/issues/46240

## Verification

Against the pinned vLLM (0.22.0): the stock method has 2 `assert req_id in self.requests`; after the patch they are replaced by 2 `if req_id not in self.requests: continue` guards, both loop bodies otherwise unchanged, and the patch is idempotent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core vLLM scheduler KV-transfer lifecycle in production inference; behavior change is narrow (skip stale ids) but affects when blocks are freed under race conditions.
> 
> **Overview**
> Prevents **disaggregated P/D** decode `EngineCore` crashes when an **aborted** request’s KV **recv** and **send** completions arrive in the **same** scheduler step: stock vLLM frees the request on recv then **asserts** on send.
> 
> Adds **`monkey_patch_kv_xfer_finished_tolerate_freed`**, which replaces `Scheduler._update_from_kv_xfer_finished` so both `finished_recving` and `finished_sending` **skip** ids no longer in `self.requests` instead of asserting. The patch is **idempotent** and is invoked from the existing **`transformers_v5_compat`** `vllm.general_plugins` hook so it runs in the **EngineCore** process.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba89c167b5a0d086e4b12dfec29a9d0a2b412de9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->