### PR TITLE
feat(orchestrator): make target_lag a configurable field

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -557,6 +557,9 @@ class OrchestratorConfig(BaseConfig):
     max_off_policy_steps: int = Field(8, ge=0)
     """Maximum policies allowed to generate a single rollout. Rollouts generated more than ``max_off_policy_steps`` ahead of training are discarded. Higher values yield better throughput at the cost of off-policy noise."""
 
+    target_lag: int = Field(1, ge=1)
+    """Maximum number of batches the orchestrator may run ahead of the trainer. The dispatcher is paused once the orchestrator's next batch would lead ``policy.version`` by more than this; it resumes when the trainer advances the policy version. Default ``1`` is the standard one-step-ahead pipelining; larger values allow deeper look-ahead at the cost of staleness."""
+
     bench: bool = False
     """Benchmark mode. Sets ``max_steps`` to 5 and disables W&B."""
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -95,11 +95,6 @@ SHUTDOWN_TIMEOUT_S = 300
 # dataset; fail loudly instead of spinning
 MAX_CONSECUTIVE_EMPTY_BATCHES = 10
 
-# Maximum batches the orchestrator may run ahead of the trainer. The
-# dispatcher is paused via ``update_dispatch_gate`` once this is exceeded;
-# resumed when the watcher advances ``policy.version``.
-TARGET_LAG = 1
-
 
 class Orchestrator:
     # Set in ``__init__``
@@ -793,7 +788,7 @@ class Orchestrator:
         lead = (self.progress.step + 1) - self.policy.version
         gate = self.dispatcher.dispatch_allowed
         was_set = gate.is_set()
-        if lead > TARGET_LAG:
+        if lead > self.config.target_lag:
             if was_set:
                 get_logger().info(
                     "Pausing dispatcher to prevent orchestrator from racing from trainer. Waiting for new policy..."

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -598,3 +598,15 @@ def test_explicit_inference_parser_wins_over_auto():
     )
     assert config.inference is not None
     assert config.inference.model.tool_call_parser == "hermes"
+
+
+def test_orchestrator_target_lag_default_is_one():
+    """Default ``target_lag`` of 1 preserves the standard one-step-ahead pipelining."""
+    config = OrchestratorConfig.model_validate({"model": {"name": "Qwen/Qwen3-0.6B"}})
+    assert config.target_lag == 1
+
+
+def test_orchestrator_target_lag_rejects_below_one():
+    """``target_lag`` must be >= 1; 0 would pause the dispatcher forever (deadlock)."""
+    with pytest.raises(ValidationError, match="target_lag"):
+        OrchestratorConfig.model_validate({"model": {"name": "Qwen/Qwen3-0.6B"}, "target_lag": 0})


### PR DESCRIPTION
## What

`TARGET_LAG` — the maximum number of batches the orchestrator may run ahead of the trainer — was a hardcoded module constant (`= 1`) in `orchestrator.py`. As noted in #2812, this is a meaningful async/off-policy knob that operators can't tune (and it interacts with `max_off_policy_steps`) without editing source.

## Fix

Promote it to `OrchestratorConfig.target_lag` (`Field(1, ge=1)`, documented next to `max_off_policy_steps`), delete the constant, and read `self.config.target_lag` at the dispatch gate.

Default `1` preserves the current one-step-ahead pipelining behavior exactly. Larger values allow deeper look-ahead at the cost of staleness; `0` is rejected because it would keep the dispatcher paused in steady state.

Focused config tests cover the default and the lower bound.

Closes #2812
