### PR TITLE
feat: add r3 debug config

### DIFF
--- a/configs/debug/r3.toml
+++ b/configs/debug/r3.toml
@@ -2,9 +2,8 @@
 # Router replay is wired end-to-end: trainer.enable_router_replay replays the
 # routed-expert decisions returned by inference (enable_return_routed_experts).
 
-max_steps = 10000000
+max_steps = 100
 seq_len = 65536
-output_dir = "/beegfs/outputs/qwen30b-r3-debug"
 
 [log]
 level = "debug"

--- a/configs/debug/r3.toml
+++ b/configs/debug/r3.toml
@@ -1,0 +1,116 @@
+# Qwen3-30B-A3B router-replay debug config (perf/r3 line).
+# Router replay is wired end-to-end: trainer.enable_router_replay replays the
+# routed-expert decisions returned by inference (enable_return_routed_experts).
+
+max_steps = 10000000
+seq_len = 65536
+output_dir = "/beegfs/outputs/qwen30b-r3-debug"
+
+[log]
+level = "debug"
+
+[wandb]
+project = "RLM-Qwen30B-debug"
+name = "qwen30b-r3"
+
+[model]
+name = "Qwen/Qwen3-30B-A3B-Thinking-2507"
+
+[weight_broadcast]
+type = "nccl"
+port = 29502
+timeout = 12000
+quantize_in_weight_transfer = false
+
+[deployment]
+type = "multi_node"
+num_train_nodes = 2
+num_infer_nodes = 1
+num_infer_replicas = 4
+gpus_per_node = 8
+
+[slurm]
+job_name = "qwen30b-r3-debug"
+partition = "cluster"
+
+[ckpt]
+interval = 100
+keep_last = 1
+resume_step = -1
+
+# --- Trainer ---
+
+[trainer]
+dist_timeout_seconds = 1800
+enable_router_replay = true
+
+[trainer.model]
+impl = "custom"
+attn = "flash_attention_3"
+fused_lm_head_token_chunk_size = 1024
+ep = 8
+
+[trainer.model.ac]
+freq = 1
+
+[trainer.model.compile]
+
+[trainer.model.ac_offloading]
+max_inflight_activations = 1
+
+[trainer.ckpt]
+skip_gather_master_weights = true
+skip_optimizer = true
+
+[trainer.optim]
+type = "adamw"
+lr = 1e-6
+weight_decay = 0.0
+
+# --- Orchestrator ---
+
+[orchestrator]
+batch_size = 256
+group_size = 8
+max_inflight_rollouts = 1024
+max_off_policy_steps = 16
+
+[orchestrator.renderer]
+name = "qwen3"
+
+[orchestrator.train.sampling]
+temperature = 1.0
+
+[orchestrator.wandb.log_extras]
+samples = false
+interval = 25
+
+[orchestrator.prime_monitor]
+
+[[orchestrator.train.env]]
+id = "general-agent-solver-local"
+name = "general-agent-local-low"
+num_workers = 4
+ratio = 1.0
+
+[orchestrator.train.env.args]
+min_tier = 4
+max_turns = 100
+timeout_seconds = 3600.0
+
+[orchestrator.advantage]
+type = "default"
+
+# --- Inference ---
+
+[inference]
+enable_return_routed_experts = true
+enable_expert_parallel = true
+gpu_memory_utilization = 0.85
+
+[inference.parallel]
+tp = 8
+
+[inference.model]
+max_model_len = 65536
+tool_call_parser = "hermes"

--- a/configs/debug/r3.toml
+++ b/configs/debug/r3.toml
@@ -10,7 +10,7 @@ output_dir = "/beegfs/outputs/qwen30b-r3-debug"
 level = "debug"
 
 [wandb]
-project = "RLM-Qwen30B-debug"
+project = "r3-debug"
 name = "qwen30b-r3"
 
 [model]

--- a/configs/debug/r3.toml
+++ b/configs/debug/r3.toml
@@ -71,7 +71,7 @@ weight_decay = 0.0
 [orchestrator]
 batch_size = 256
 group_size = 8
-max_inflight_rollouts = 1024
+max_inflight_rollouts = 512
 max_off_policy_steps = 16
 
 [orchestrator.renderer]


### PR DESCRIPTION
## Summary

- Add `configs/debug/r3.toml` — a Qwen3-30B-A3B (Thinking) RL debug config with **router replay enabled** (`trainer.enable_router_replay = true`, paired with `inference.enable_return_routed_experts = true`).
- Ported from the `rlm5/qwen30b-debug.toml` config used on the `perf/r3` experiment line, updated to the current config schema and cleaned up.

## Schema migration (vs. the old config)

- `orchestrator.rollouts_per_example` → `orchestrator.group_size`.
- Removed fields that no longer exist in the schema: `max_async_level`, `orchestrator.use_token_client`, `orchestrator.use_renderer`, `[orchestrator.buffer]` (`online_difficulty_filtering`).
- Dropped the explicit `[orchestrator.client]` block — `X-Session-ID = trajectory_id` is now auto-set by the orchestrator.
- Dropped `name` from `[inference.model]` — the shared top-level `[model] name` now propagates to all sub-configs.
- Eval is disabled by omitting the `[orchestrator.eval]` block (the schema now rejects `env = []`).

## Debug cleanup

- Removed the one-off perf-experiment fields and their narration comments: `use_process_pool` (round 4), `dump_raw_rollouts` (round 5), `gather_chunk_size` (round 6).
- Removed `[trainer.experimental.token_export]` (per-token JSONL rollout export — debug-only).

## Verification

Validated that the config loads against `RLConfig` (same path as `tests/unit/test_configs.py::test_load_configs`):

```
PARSED OK
trainer.enable_router_replay = True
inference.enable_return_routed_experts = True
orchestrator.group_size = 8
student.client.extra_headers_from_state = {'X-Session-ID': 'trajectory_id'}
inference.model.name (propagated) = Qwen/Qwen3-30B-A3B-Thinking-2507
renderer.name = qwen3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)