### PR TITLE
fix(configs): validate inference weight_broadcast type against orchestrator

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/utils/validation.py
+++ b/packages/prime-rl-configs/src/prime_rl/utils/validation.py
@@ -317,14 +317,11 @@ def validate_shared_weight_broadcast(
     orchestrator: OrchestratorConfig,
     inference: Optional[InferenceConfig] = None,
 ) -> None:
-    if (
-        inference
-        and trainer.weight_broadcast.type != orchestrator.weight_broadcast.type != inference.weight_broadcast.type
-    ):
-        raise ValueError(
-            f"Inference weight broadcast type ({inference.weight_broadcast.type}) and orchestrator weight broadcast type ({orchestrator.weight_broadcast.type}) are not the same. Please specify the same weight broadcast type for both."
-        )
-    elif trainer.weight_broadcast.type != orchestrator.weight_broadcast.type:
+    if trainer.weight_broadcast.type != orchestrator.weight_broadcast.type:
         raise ValueError(
             f"Trainer weight broadcast type ({trainer.weight_broadcast.type}) and orchestrator weight broadcast type ({orchestrator.weight_broadcast.type}) are not the same. Please specify the same weight broadcast type for both."
+        )
+    if inference is not None and inference.weight_broadcast.type != orchestrator.weight_broadcast.type:
+        raise ValueError(
+            f"Inference weight broadcast type ({inference.weight_broadcast.type}) and orchestrator weight broadcast type ({orchestrator.weight_broadcast.type}) are not the same. Please specify the same weight broadcast type for both."
         )

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -371,6 +371,37 @@ def test_tokenizer_chat_template_mismatch_raises():
         )
 
 
+def test_weight_broadcast_inference_mismatch_raises():
+    """When the shared [weight_broadcast] is unset, the per-component types must
+    all agree. The chained ``trainer != orchestrator != inference`` comparison
+    never compared inference against trainer, so a config where trainer and
+    orchestrator match but inference differs was silently accepted and broke
+    weight sync at runtime."""
+    with pytest.raises(ValidationError, match="weight broadcast type"):
+        RLConfig.model_validate(
+            {
+                "model": {"name": "PrimeIntellect/test-model"},
+                "trainer": {},
+                "orchestrator": {"renderer": None},
+                "inference": {"weight_broadcast": {"type": "nccl"}},
+            }
+        )
+
+
+def test_weight_broadcast_all_matching_passes():
+    config = RLConfig.model_validate(
+        {
+            "model": {"name": "PrimeIntellect/test-model"},
+            "trainer": {"weight_broadcast": {"type": "nccl"}},
+            "orchestrator": {"renderer": None, "weight_broadcast": {"type": "nccl"}},
+            "inference": {"weight_broadcast": {"type": "nccl"}},
+        }
+    )
+    assert config.trainer.weight_broadcast.type == "nccl"
+    assert config.orchestrator.weight_broadcast.type == "nccl"
+    assert config.inference is not None and config.inference.weight_broadcast.type == "nccl"
+
+
 def test_shared_seq_len_propagates_to_subconfigs():
     config = RLConfig.model_validate(
         {


### PR DESCRIPTION
## What

`validate_shared_weight_broadcast` checks that the `trainer`, `orchestrator`, and (optional) `inference` weight-broadcast transports agree. It used a chained comparison:

```python
trainer.weight_broadcast.type != orchestrator.weight_broadcast.type != inference.weight_broadcast.type
```

Python evaluates this as `(trainer != orchestrator) and (orchestrator != inference)`, so **inference is never compared against trainer**. When trainer and orchestrator agree but inference differs (e.g. `filesystem` / `filesystem` / `nccl`), the check passes and the mismatch only surfaces as a broken weight sync at runtime.

This is reachable whenever the shared `[weight_broadcast]` is unset (the default): `auto_setup_weight_broadcast` only unifies the three sub-configs when the shared field is set, otherwise it passes the user's per-component values straight to this validator.

## Why / fix

Compare each component against the orchestrator independently, which transitively requires all three to match. Both original error messages are preserved.

```python
if trainer.weight_broadcast.type != orchestrator.weight_broadcast.type:
    raise ValueError("Trainer ... and orchestrator ... are not the same ...")
if inference is not None and inference.weight_broadcast.type != orchestrator.weight_broadcast.type:
    raise ValueError("Inference ... and orchestrator ... are not the same ...")
```

## Test

`tests/unit/test_configs.py`:
- `test_weight_broadcast_inference_mismatch_raises` — `(filesystem, filesystem, nccl)` now raises (fails on `main`: "DID NOT RAISE").
- `test_weight_broadcast_all_matching_passes` — all-matching config still validates.

All 111 tests in `test_configs.py` pass; `ruff format`/`ruff check` clean.
