### PR TITLE
feat: support PRIME_RL_REF for runtime source override

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -97,6 +97,7 @@ RUN apt-get update && apt-get install -y \
     tmux \
     iperf \
     openssh-server \
+    git \
     git-lfs \
     gpg \
     sudo \

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -49,13 +49,17 @@ if [ -n "$PRIME_RL_REF" ]; then
         # /tmp and /app share a filesystem.
         cp -a /app/.venv "$DEST/.venv"
     fi
-    echo "[prime-rl] running uv sync --inexact --all-extras (this may take a few minutes on cold checkout)"
-    # --all-extras so env / gpt-oss / modelexpress / flash-attn extras
-    # get picked up if the override's pyproject changes them. --inexact
-    # keeps the seeded venv's pre-built wheels (flash-attn-3, mamba-ssm)
-    # in place; uv only rebuilds them if the override's lockfile pins
-    # different versions, which is rare for researcher branches.
-    ( cd "$DEST" && uv sync --inexact --no-dev --all-extras )
+    echo "[prime-rl] running uv sync --inexact (this may take a few minutes on cold checkout)"
+    # Mirror the image's extras (Dockerfile.cuda:82) — explicit instead
+    # of --all-extras so we don't pull in `disagg` / `quack` and trigger
+    # heavy source builds (deep-ep, deep-gemm, quack-kernels) at pod
+    # startup. --inexact keeps the seeded venv's pre-built wheels
+    # (flash-attn-3, mamba-ssm) in place; uv only rebuilds them if the
+    # override's lockfile pins different versions.
+    ( cd "$DEST" && uv sync --inexact --no-dev \
+        --extra flash-attn --extra flash-attn-3 --extra flash-attn-cute \
+        --extra envs --extra gpt-oss --extra modelexpress \
+        --group mamba-ssm )
     export VIRTUAL_ENV="$DEST/.venv"
     export PATH="$DEST/.venv/bin:$PATH"
     cd "$DEST"

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -4,43 +4,55 @@ set -e
 # Set higher ulimit for file descriptors to prevent API timeout issues
 ulimit -n 32000 2>/dev/null || echo "Warning: Could not set ulimit (may need --ulimit flag in docker run)"
 
-# Allow runtime override of the verifiers package version.
-# VERIFIERS_VERSION can be a git tag, branch, or commit hash.
-if [ -n "$VERIFIERS_VERSION" ]; then
-    echo "Installing verifiers version: $VERIFIERS_VERSION"
-    uv pip install --reinstall-package verifiers \
-        "verifiers @ git+https://github.com/PrimeIntellect-ai/verifiers.git@${VERIFIERS_VERSION}"
-fi
-
 # Allow runtime override of the prime-rl source itself.
 # PRIME_RL_REF can be a git tag, branch, or commit hash. PRIME_RL_REPO
 # optionally points at a fork; defaults to the upstream repo.
 #
-# We clone into a per-ref dir under /tmp, hardlink-copy the baked /app/.venv
-# so the heavy wheels (flash-attn, mamba-ssm, …) stay put, then `uv sync
-# --inexact` re-installs prime_rl from the override source. Workdir + PATH
-# swap so the chart's `uv run trainer/inference/orchestrator` resolves the
-# entrypoints from the override venv.
+# We clone into a per-ref dir under /tmp, seed the venv from the baked
+# /app/.venv so heavy wheels (flash-attn, mamba-ssm, …) survive, then
+# `uv sync --inexact` re-installs prime_rl from the override source.
+# Workdir + PATH swap so the chart's `uv run trainer/inference/orchestrator`
+# resolves the entrypoints from the override venv.
 if [ -n "$PRIME_RL_REF" ]; then
     PRIME_RL_REPO="${PRIME_RL_REPO:-https://github.com/PrimeIntellect-ai/prime-rl.git}"
-    DEST="/tmp/prime-rl-${PRIME_RL_REF}"
+    # Refs can contain `/` (e.g. branch names like `feat/foo`); slugify for
+    # the cache dir name. Real ref is kept verbatim for git commands.
+    REF_SLUG="${PRIME_RL_REF//\//-}"
+    DEST="/tmp/prime-rl-${REF_SLUG}"
     if [ ! -d "$DEST/.git" ]; then
-        echo "[prime-rl] checking out ${PRIME_RL_REF} from ${PRIME_RL_REPO}"
+        echo "[prime-rl] cloning ${PRIME_RL_REPO} for ${PRIME_RL_REF}"
         rm -rf "$DEST"
         git clone "$PRIME_RL_REPO" "$DEST"
-        git -C "$DEST" checkout "$PRIME_RL_REF"
-        # Seed the override venv from the baked one to keep flash-attn etc.;
-        # fall back to a plain copy when /tmp and /app are on different
-        # filesystems (hardlinks across devices fail).
-        cp -al /app/.venv "$DEST/.venv" 2>/dev/null || cp -a /app/.venv "$DEST/.venv"
-        echo "[prime-rl] running uv sync --inexact (this may take a few minutes)"
-        ( cd "$DEST" && uv sync --inexact --no-dev )
-    else
-        echo "[prime-rl] reusing cached checkout at ${DEST}"
     fi
+    # Always fetch + checkout so mutable refs (branches/tags) pick up new
+    # commits between pod restarts. No-op for immutable SHAs.
+    echo "[prime-rl] refreshing ${PRIME_RL_REF}"
+    git -C "$DEST" fetch --quiet --tags --force origin
+    git -C "$DEST" checkout --quiet --force "$PRIME_RL_REF"
+    # Fast-forward to upstream tip when PRIME_RL_REF is a branch name.
+    # Silently no-ops for SHAs/tags (no `origin/<sha>` exists).
+    git -C "$DEST" reset --hard --quiet "origin/${PRIME_RL_REF}" 2>/dev/null || true
+    if [ ! -d "$DEST/.venv" ]; then
+        # Seed from the baked venv so the heavy wheels (flash-attn,
+        # mamba-ssm, …) don't have to be rebuilt. Hardlink-copy when /tmp
+        # and /app share a filesystem; full copy otherwise.
+        cp -al /app/.venv "$DEST/.venv" 2>/dev/null || cp -a /app/.venv "$DEST/.venv"
+    fi
+    echo "[prime-rl] running uv sync --inexact (this may take a few minutes on cold checkout)"
+    ( cd "$DEST" && uv sync --inexact --no-dev )
     export VIRTUAL_ENV="$DEST/.venv"
     export PATH="$DEST/.venv/bin:$PATH"
     cd "$DEST"
+fi
+
+# Allow runtime override of the verifiers package version.
+# VERIFIERS_VERSION can be a git tag, branch, or commit hash. Runs after the
+# PRIME_RL_REF swap so when both are set the install lands in the override
+# venv (uv pip install targets $VIRTUAL_ENV when exported).
+if [ -n "$VERIFIERS_VERSION" ]; then
+    echo "Installing verifiers version: $VERIFIERS_VERSION"
+    uv pip install --reinstall-package verifiers \
+        "verifiers @ git+https://github.com/PrimeIntellect-ai/verifiers.git@${VERIFIERS_VERSION}"
 fi
 
 # Execute the main command

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -49,8 +49,13 @@ if [ -n "$PRIME_RL_REF" ]; then
         # /tmp and /app share a filesystem.
         cp -a /app/.venv "$DEST/.venv"
     fi
-    echo "[prime-rl] running uv sync --inexact (this may take a few minutes on cold checkout)"
-    ( cd "$DEST" && uv sync --inexact --no-dev )
+    echo "[prime-rl] running uv sync --inexact --all-extras (this may take a few minutes on cold checkout)"
+    # --all-extras so env / gpt-oss / modelexpress / flash-attn extras
+    # get picked up if the override's pyproject changes them. --inexact
+    # keeps the seeded venv's pre-built wheels (flash-attn-3, mamba-ssm)
+    # in place; uv only rebuilds them if the override's lockfile pins
+    # different versions, which is rare for researcher branches.
+    ( cd "$DEST" && uv sync --inexact --no-dev --all-extras )
     export VIRTUAL_ENV="$DEST/.venv"
     export PATH="$DEST/.venv/bin:$PATH"
     cd "$DEST"

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -12,5 +12,36 @@ if [ -n "$VERIFIERS_VERSION" ]; then
         "verifiers @ git+https://github.com/PrimeIntellect-ai/verifiers.git@${VERIFIERS_VERSION}"
 fi
 
+# Allow runtime override of the prime-rl source itself.
+# PRIME_RL_REF can be a git tag, branch, or commit hash. PRIME_RL_REPO
+# optionally points at a fork; defaults to the upstream repo.
+#
+# We clone into a per-ref dir under /tmp, hardlink-copy the baked /app/.venv
+# so the heavy wheels (flash-attn, mamba-ssm, …) stay put, then `uv sync
+# --inexact` re-installs prime_rl from the override source. Workdir + PATH
+# swap so the chart's `uv run trainer/inference/orchestrator` resolves the
+# entrypoints from the override venv.
+if [ -n "$PRIME_RL_REF" ]; then
+    PRIME_RL_REPO="${PRIME_RL_REPO:-https://github.com/PrimeIntellect-ai/prime-rl.git}"
+    DEST="/tmp/prime-rl-${PRIME_RL_REF}"
+    if [ ! -d "$DEST/.git" ]; then
+        echo "[prime-rl] checking out ${PRIME_RL_REF} from ${PRIME_RL_REPO}"
+        rm -rf "$DEST"
+        git clone "$PRIME_RL_REPO" "$DEST"
+        git -C "$DEST" checkout "$PRIME_RL_REF"
+        # Seed the override venv from the baked one to keep flash-attn etc.;
+        # fall back to a plain copy when /tmp and /app are on different
+        # filesystems (hardlinks across devices fail).
+        cp -al /app/.venv "$DEST/.venv" 2>/dev/null || cp -a /app/.venv "$DEST/.venv"
+        echo "[prime-rl] running uv sync --inexact (this may take a few minutes)"
+        ( cd "$DEST" && uv sync --inexact --no-dev )
+    else
+        echo "[prime-rl] reusing cached checkout at ${DEST}"
+    fi
+    export VIRTUAL_ENV="$DEST/.venv"
+    export PATH="$DEST/.venv/bin:$PATH"
+    cd "$DEST"
+fi
+
 # Execute the main command
 exec "$@"

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -15,14 +15,20 @@ ulimit -n 32000 2>/dev/null || echo "Warning: Could not set ulimit (may need --u
 # resolves the entrypoints from the override venv.
 if [ -n "$PRIME_RL_REF" ]; then
     PRIME_RL_REPO="${PRIME_RL_REPO:-https://github.com/PrimeIntellect-ai/prime-rl.git}"
-    # Refs can contain `/` (e.g. branch names like `feat/foo`); slugify for
-    # the cache dir name. Real ref is kept verbatim for git commands.
+    # Slug + content hash for the cache dir name. Slug keeps the path
+    # human-readable; the hash prevents collisions between distinct refs
+    # that slugify to the same string (e.g. `feat/foo` vs `feat-foo`).
     REF_SLUG="${PRIME_RL_REF//\//-}"
-    DEST="/tmp/prime-rl-${REF_SLUG}"
+    REF_HASH=$(echo -n "$PRIME_RL_REF" | md5sum | cut -c1-12)
+    DEST="/tmp/prime-rl-${REF_SLUG}-${REF_HASH}"
+    # Rewrite ssh://git@github.com URLs to https so submodules listed
+    # with SSH URLs (deps/verifiers, deps/renderers, deps/research-envs)
+    # can be cloned from the pod without ssh keys.
+    git config --global url."https://github.com/".insteadOf "git@github.com:"
     if [ ! -d "$DEST/.git" ]; then
         echo "[prime-rl] cloning ${PRIME_RL_REPO} for ${PRIME_RL_REF}"
         rm -rf "$DEST"
-        git clone "$PRIME_RL_REPO" "$DEST"
+        git clone --recurse-submodules "$PRIME_RL_REPO" "$DEST"
     fi
     # Always fetch + checkout so mutable refs (branches/tags) pick up new
     # commits between pod restarts. No-op for immutable SHAs.
@@ -32,6 +38,8 @@ if [ -n "$PRIME_RL_REF" ]; then
     # Fast-forward to upstream tip when PRIME_RL_REF is a branch name.
     # Silently no-ops for SHAs/tags (no `origin/<sha>` exists).
     git -C "$DEST" reset --hard --quiet "origin/${PRIME_RL_REF}" 2>/dev/null || true
+    # Refresh submodules to whatever the parent commit pins.
+    git -C "$DEST" submodule update --init --recursive
     if [ ! -d "$DEST/.venv" ]; then
         # Seed from the baked venv so the heavy wheels (flash-attn,
         # mamba-ssm, …) don't have to be rebuilt. Hardlink-copy when /tmp

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -39,7 +39,10 @@ if [ -n "$PRIME_RL_REF" ]; then
     # Fast-forward to upstream tip when PRIME_RL_REF is a branch name.
     # Silently no-ops for SHAs/tags (no `origin/<sha>` exists).
     git -C "$DEST" reset --hard --quiet "origin/${PRIME_RL_REF}" 2>/dev/null || true
-    # Refresh submodules to whatever the parent commit pins.
+    # Refresh submodules to whatever the parent commit pins. `sync`
+    # picks up URL changes in .gitmodules between checkouts on cache
+    # hit; `update --init --recursive` applies the pinned SHAs.
+    git -C "$DEST" submodule sync --recursive
     git -C "$DEST" submodule update --init --recursive
     if [ ! -d "$DEST/.venv" ]; then
         # Seed from the baked venv so the heavy wheels (flash-attn,

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -16,10 +16,11 @@ ulimit -n 32000 2>/dev/null || echo "Warning: Could not set ulimit (may need --u
 if [ -n "$PRIME_RL_REF" ]; then
     PRIME_RL_REPO="${PRIME_RL_REPO:-https://github.com/PrimeIntellect-ai/prime-rl.git}"
     # Slug + content hash for the cache dir name. Slug keeps the path
-    # human-readable; the hash prevents collisions between distinct refs
-    # that slugify to the same string (e.g. `feat/foo` vs `feat-foo`).
+    # human-readable; the hash (over repo + ref) prevents collisions
+    # between distinct refs that slugify the same way (e.g. `feat/foo`
+    # vs `feat-foo`) and between the same ref on different forks.
     REF_SLUG="${PRIME_RL_REF//\//-}"
-    REF_HASH=$(echo -n "$PRIME_RL_REF" | md5sum | cut -c1-12)
+    REF_HASH=$(echo -n "${PRIME_RL_REPO}|${PRIME_RL_REF}" | md5sum | cut -c1-12)
     DEST="/tmp/prime-rl-${REF_SLUG}-${REF_HASH}"
     # Rewrite ssh://git@github.com URLs to https so submodules listed
     # with SSH URLs (deps/verifiers, deps/renderers, deps/research-envs)
@@ -42,9 +43,11 @@ if [ -n "$PRIME_RL_REF" ]; then
     git -C "$DEST" submodule update --init --recursive
     if [ ! -d "$DEST/.venv" ]; then
         # Seed from the baked venv so the heavy wheels (flash-attn,
-        # mamba-ssm, …) don't have to be rebuilt. Hardlink-copy when /tmp
-        # and /app share a filesystem; full copy otherwise.
-        cp -al /app/.venv "$DEST/.venv" 2>/dev/null || cp -a /app/.venv "$DEST/.venv"
+        # mamba-ssm, …) don't have to be rebuilt. Plain `cp -a` (no
+        # hardlinks): a subsequent `uv sync` writes into this tree, and
+        # hardlinks would leak those writes back into /app/.venv when
+        # /tmp and /app share a filesystem.
+        cp -a /app/.venv "$DEST/.venv"
     fi
     echo "[prime-rl] running uv sync --inexact (this may take a few minutes on cold checkout)"
     ( cd "$DEST" && uv sync --inexact --no-dev )


### PR DESCRIPTION
Lets a run swap the baked prime-rl source for any git ref at container start, mirroring the existing `VERIFIERS_VERSION` hook.

- `PRIME_RL_REF=<branch|tag|sha>` (optional `PRIME_RL_REPO` for forks) clones into `/tmp/prime-rl-<ref>`, seeds the venv from `/app/.venv` so flash-attn / mamba-ssm survive, then `uv sync --inexact` re-installs `prime_rl` from the override source.
- Cwd + PATH swap so `uv run trainer/inference/orchestrator` resolves from the override venv.
- Added `git` to the final-stage apt-get so the clone works.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Startup behavior and which code/venv runs change when env vars are set; cold starts may run network git ops and long `uv sync`, but the baked image path is unchanged when unset.
> 
> **Overview**
> Adds **runtime swap** of the baked `prime-rl` tree for any git ref at container start, parallel to the existing `VERIFIERS_VERSION` hook.
> 
> When `PRIME_RL_REF` is set (optional `PRIME_RL_REPO` for forks), the entrypoint clones or refreshes a cached checkout under `/tmp`, rewrites GitHub SSH submodule URLs to HTTPS, syncs submodules, seeds a copy of `/app/.venv` (avoiding hardlinks so `uv sync` does not corrupt the image venv), runs `uv sync --inexact` with the same extras as the CUDA image build (excluding heavy optional extras), then sets `VIRTUAL_ENV`, `PATH`, and working directory so `uv run` for trainer/inference/orchestrator uses the override. **`VERIFIERS_VERSION` now runs after** that swap so installs target the override venv when both env vars are set.
> 
> The CUDA image **final stage** adds the **`git`** package so clone/fetch works in the runtime image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b86641f796f06c60ca103e9d9f37a005ecd5549a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->