### PR TITLE
add glm 5.2 training support

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -25,7 +25,7 @@ impl = "custom"        # or "hf" to force the HF path
 
 | Family | HF config types | EP | CP |
 |---|---|---|---|
-| GLM-5 (`glm_moe_dsa`) | `zai-org/GLM-5`, `zai-org/GLM-5-FP8` | ✅ | ✅ |
+| GLM-5 / GLM-5.2 (`glm_moe_dsa`) | `zai-org/GLM-5`, `zai-org/GLM-5-FP8`, `zai-org/GLM-5.2`, `zai-org/GLM-5.2-FP8` | ✅ | ✅ |
 | Qwen3 MoE | `Qwen/Qwen3-30B-A3B`, … | ✅ | ✅ |
 | Qwen3.5 MoE | `Qwen/Qwen3.5-35B-A3B`, … | ✅ | ✅ |
 | Qwen3 / Qwen3.5 VLMs | see [Multimodal training](#multimodal-training) | MoE only | ✅ |
@@ -37,6 +37,8 @@ impl = "custom"        # or "hf" to force the HF path
 | GPT-OSS (HF MoE) | `openai/gpt-oss-20b`, `openai/gpt-oss-120b` | ❌ | ✅ |
 
 The custom path enables you to set EP, CP, selective activation checkpointing, FP8 training (`model.fp8 = true`, requires SM90+), and faster MoE kernels (`moe_use_grouped_mm = true`, default). Forcing `impl = "hf"` is mostly useful when debugging — it's slower and disables most MoE-specific knobs.
+
+GLM-5.2 adds IndexShare: the DSA sparse-attention indexer runs only on a subset of layers and the remaining layers reuse the cached top-k indices. The trainer reads this schedule from the model's `indexer_types` config field and enables the index cache automatically, so no extra config is needed. To override the schedule manually, set `[trainer.model.index_cache]` (`topk_freq` or `topk_pattern`).
 
 ### Expert Parallelism Backends
 

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -37,7 +37,6 @@ from prime_rl.trainer.models import (
     get_custom_vlm_cls,
     supports_custom_impl,
 )
-from prime_rl.trainer.models.glm_moe_dsa.configuration_glm_moe_dsa import indexer_types_to_topk_pattern
 from prime_rl.trainer.models.glm_moe_dsa.sparse_mla_attention import Indexer
 from prime_rl.trainer.models.layers.checkpointing import (
     get_supported_targets,
@@ -511,16 +510,17 @@ def get_model(
         model_config.use_index_cache = True
         model_config.index_topk_freq = config.index_cache.topk_freq
         model_config.index_topk_pattern = config.index_cache.topk_pattern
+        # Explicit override supersedes the model's native IndexShare schedule.
+        model_config.indexer_types = None
     else:
-        # Auto-enable IndexShare from the model's own indexer schedule (e.g. GLM-5.2), so shared
-        # layers reuse cached top-k indices and carry no indexer weights.
-        auto_pattern = indexer_types_to_topk_pattern(getattr(model_config, "indexer_types", None))
-        if auto_pattern is not None:
+        # Auto-enable IndexShare from the model's own indexer schedule (e.g. GLM-5.2). The model
+        # reads `indexer_types` directly: shared layers reuse cached indices and carry no indexer weights.
+        indexer_types = getattr(model_config, "indexer_types", None)
+        if indexer_types and any(t == "shared" for t in indexer_types):
             model_config.use_index_cache = True
-            model_config.index_topk_pattern = auto_pattern
             logger.info(
                 f"Auto-enabled IndexShare from indexer_types schedule "
-                f"({auto_pattern.count('F')}/{len(auto_pattern)} full layers)"
+                f"({sum(t == 'full' for t in indexer_types)}/{len(indexer_types)} full layers)"
             )
 
     # Ensure pad_token_id is set (some models like Qwen3MoE don't have it).

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -37,6 +37,7 @@ from prime_rl.trainer.models import (
     get_custom_vlm_cls,
     supports_custom_impl,
 )
+from prime_rl.trainer.models.glm_moe_dsa.configuration_glm_moe_dsa import indexer_types_to_topk_pattern
 from prime_rl.trainer.models.glm_moe_dsa.sparse_mla_attention import Indexer
 from prime_rl.trainer.models.layers.checkpointing import (
     get_supported_targets,
@@ -510,6 +511,17 @@ def get_model(
         model_config.use_index_cache = True
         model_config.index_topk_freq = config.index_cache.topk_freq
         model_config.index_topk_pattern = config.index_cache.topk_pattern
+    else:
+        # Auto-enable IndexShare from the model's own indexer schedule (e.g. GLM-5.2), so shared
+        # layers reuse cached top-k indices and carry no indexer weights.
+        auto_pattern = indexer_types_to_topk_pattern(getattr(model_config, "indexer_types", None))
+        if auto_pattern is not None:
+            model_config.use_index_cache = True
+            model_config.index_topk_pattern = auto_pattern
+            logger.info(
+                f"Auto-enabled IndexShare from indexer_types schedule "
+                f"({auto_pattern.count('F')}/{len(auto_pattern)} full layers)"
+            )
 
     # Ensure pad_token_id is set (some models like Qwen3MoE don't have it).
     # In transformers v5, token IDs moved from PretrainedConfig to GenerationConfig.

--- a/src/prime_rl/trainer/models/glm_moe_dsa/configuration_glm_moe_dsa.py
+++ b/src/prime_rl/trainer/models/glm_moe_dsa/configuration_glm_moe_dsa.py
@@ -11,19 +11,11 @@ def _index_cache_skip_topk(config, layer_idx: int) -> bool:
     if index_topk_pattern is not None:
         return layer_idx < len(index_topk_pattern) and index_topk_pattern[layer_idx] == "S"
 
+    indexer_types = getattr(config, "indexer_types", None)
+    if indexer_types is not None:
+        return layer_idx < len(indexer_types) and indexer_types[layer_idx] == "shared"
+
     return layer_idx % getattr(config, "index_topk_freq", 1) != 0
-
-
-def indexer_types_to_topk_pattern(indexer_types: list[str] | None) -> str | None:
-    """Translate a GLM-5.2 ``indexer_types`` schedule into an ``index_topk_pattern`` string.
-
-    ``"full"`` layers compute fresh DSA indices (``"F"``); ``"shared"`` layers reuse the
-    previous full layer's indices (``"S"``). Returns ``None`` when no layer shares, i.e.
-    IndexShare is not in use (e.g. GLM-5).
-    """
-    if not indexer_types or not any(t == "shared" for t in indexer_types):
-        return None
-    return "".join("S" if t == "shared" else "F" for t in indexer_types)
 
 
 class GlmMoeDsaConfig(PretrainedConfig):

--- a/src/prime_rl/trainer/models/glm_moe_dsa/configuration_glm_moe_dsa.py
+++ b/src/prime_rl/trainer/models/glm_moe_dsa/configuration_glm_moe_dsa.py
@@ -14,6 +14,18 @@ def _index_cache_skip_topk(config, layer_idx: int) -> bool:
     return layer_idx % getattr(config, "index_topk_freq", 1) != 0
 
 
+def indexer_types_to_topk_pattern(indexer_types: list[str] | None) -> str | None:
+    """Translate a GLM-5.2 ``indexer_types`` schedule into an ``index_topk_pattern`` string.
+
+    ``"full"`` layers compute fresh DSA indices (``"F"``); ``"shared"`` layers reuse the
+    previous full layer's indices (``"S"``). Returns ``None`` when no layer shares, i.e.
+    IndexShare is not in use (e.g. GLM-5).
+    """
+    if not indexer_types or not any(t == "shared" for t in indexer_types):
+        return None
+    return "".join("S" if t == "shared" else "F" for t in indexer_types)
+
+
 class GlmMoeDsaConfig(PretrainedConfig):
     r"""
     Configuration class for the GLM-5 (GlmMoeDsa) model.
@@ -162,6 +174,7 @@ class GlmMoeDsaConfig(PretrainedConfig):
         use_index_cache=False,
         index_topk_freq=1,
         index_topk_pattern=None,
+        indexer_types=None,
         scoring_func="sigmoid",
         topk_method="noaux_tc",
         use_grouped_mm=True,
@@ -218,6 +231,7 @@ class GlmMoeDsaConfig(PretrainedConfig):
         self.use_index_cache = use_index_cache
         self.index_topk_freq = index_topk_freq
         self.index_topk_pattern = index_topk_pattern
+        self.indexer_types = indexer_types
         self.scoring_func = scoring_func
         self.topk_method = topk_method
         self.use_grouped_mm = use_grouped_mm
@@ -226,6 +240,10 @@ class GlmMoeDsaConfig(PretrainedConfig):
         if not self.use_grouped_mm:
             warnings.warn("not using grouped mm for moe is very slow, should only be used for debugging")
 
+        # head_dim is derived from qk_rope_head_dim (the RoPE slice). Some checkpoints (e.g. GLM-5.2)
+        # set head_dim=qk_nope_head_dim in config.json; drop it so PretrainedConfig.__init__ can't
+        # overwrite self.head_dim and break the rotary embedding dimension.
+        kwargs.pop("head_dim", None)
         super().__init__(
             pad_token_id=pad_token_id,
             tie_word_embeddings=tie_word_embeddings,

--- a/src/prime_rl/trainer/models/glm_moe_dsa/sparse_mla_attention.py
+++ b/src/prime_rl/trainer/models/glm_moe_dsa/sparse_mla_attention.py
@@ -158,7 +158,8 @@ class GlmMoeDsaAttention(nn.Module):
         )
 
         self.o_proj = nn.Linear(self.num_heads * self.v_head_dim, args.hidden_size, bias=args.attention_bias)
-        self.indexer = Indexer(args)
+        # IndexShare (GLM-5.2): layers that reuse cached indices carry no indexer weights.
+        self.indexer = Indexer(args) if not args.skip_topk else None
         self.use_index_cache = args.use_index_cache
         self.skip_topk = args.skip_topk
         self.scaling = self.qk_head_dim ** (-0.5)

--- a/tests/unit/train/models/test_glm_moe_dsa_conversion.py
+++ b/tests/unit/train/models/test_glm_moe_dsa_conversion.py
@@ -1,5 +1,9 @@
 import torch
 
+from prime_rl.trainer.models.glm_moe_dsa.configuration_glm_moe_dsa import (
+    GlmMoeDsaConfig,
+    indexer_types_to_topk_pattern,
+)
 from prime_rl.trainer.models.glm_moe_dsa.converting_glm_moe_dsa import convert_tt_layer_to_vllm_kernel
 
 
@@ -66,3 +70,21 @@ def test_convert_tt_layer_to_vllm_kernel_with_fp8():
     assert out["model.layers.0.mlp.experts.w13_weight_scale_inv"].dtype == torch.float32
     assert out["model.layers.0.mlp.experts.w2_weight"].dtype == torch.float8_e4m3fn
     assert out["model.layers.0.mlp.experts.w2_weight_scale_inv"].dtype == torch.float32
+
+
+def test_indexer_types_to_topk_pattern():
+    assert indexer_types_to_topk_pattern(None) is None
+    # No "shared" entries means IndexShare is not in use (e.g. GLM-5).
+    assert indexer_types_to_topk_pattern(["full", "full", "full"]) is None
+    # GLM-5.2-style schedule: "full" -> "F", "shared" -> "S".
+    assert (
+        indexer_types_to_topk_pattern(["full", "full", "full", "shared", "shared", "shared", "full", "shared"])
+        == "FFFSSSFS"
+    )
+
+
+def test_head_dim_uses_qk_rope_head_dim():
+    # GLM-5.2 config.json sets head_dim to qk_nope_head_dim; the model must keep
+    # head_dim == qk_rope_head_dim so the rotary embedding dimension is correct.
+    cfg = GlmMoeDsaConfig(qk_rope_head_dim=64, qk_nope_head_dim=192, head_dim=192)
+    assert cfg.head_dim == cfg.qk_rope_head_dim == 64

--- a/tests/unit/train/models/test_glm_moe_dsa_conversion.py
+++ b/tests/unit/train/models/test_glm_moe_dsa_conversion.py
@@ -1,9 +1,5 @@
 import torch
 
-from prime_rl.trainer.models.glm_moe_dsa.configuration_glm_moe_dsa import (
-    GlmMoeDsaConfig,
-    indexer_types_to_topk_pattern,
-)
 from prime_rl.trainer.models.glm_moe_dsa.converting_glm_moe_dsa import convert_tt_layer_to_vllm_kernel
 
 
@@ -70,21 +66,3 @@ def test_convert_tt_layer_to_vllm_kernel_with_fp8():
     assert out["model.layers.0.mlp.experts.w13_weight_scale_inv"].dtype == torch.float32
     assert out["model.layers.0.mlp.experts.w2_weight"].dtype == torch.float8_e4m3fn
     assert out["model.layers.0.mlp.experts.w2_weight_scale_inv"].dtype == torch.float32
-
-
-def test_indexer_types_to_topk_pattern():
-    assert indexer_types_to_topk_pattern(None) is None
-    # No "shared" entries means IndexShare is not in use (e.g. GLM-5).
-    assert indexer_types_to_topk_pattern(["full", "full", "full"]) is None
-    # GLM-5.2-style schedule: "full" -> "F", "shared" -> "S".
-    assert (
-        indexer_types_to_topk_pattern(["full", "full", "full", "shared", "shared", "shared", "full", "shared"])
-        == "FFFSSSFS"
-    )
-
-
-def test_head_dim_uses_qk_rope_head_dim():
-    # GLM-5.2 config.json sets head_dim to qk_nope_head_dim; the model must keep
-    # head_dim == qk_rope_head_dim so the rotary embedding dimension is correct.
-    cfg = GlmMoeDsaConfig(qk_rope_head_dim=64, qk_nope_head_dim=192, head_dim=192)
-    assert cfg.head_dim == cfg.qk_rope_head_dim == 64


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core GLM MoE/DSA attention wiring and weight layout (missing indexers on shared layers); wrong `head_dim` handling could break rotary dims if the pop logic regresses.
> 
> **Overview**
> Adds **GLM-5.2** (`zai-org/GLM-5.2`, FP8 variants) to the custom `glm_moe_dsa` training path and documents **IndexShare** behavior.
> 
> **IndexShare:** When the checkpoint defines `indexer_types` with `"shared"` layers, the trainer turns on the index cache automatically (unless `[trainer.model.index_cache]` overrides it, which clears `indexer_types`). Shared layers skip fresh top-k computation and omit **Indexer** weights in sparse MLA attention.
> 
> **Config fix:** GLM-5.2 checkpoints may ship a misleading `head_dim` in `config.json`; it is stripped so RoPE uses the derived `qk_rope_head_dim` instead of being overwritten by `PretrainedConfig`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21bb90c8f2c86c58b39cd9b530648d5b39494a57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->