### PR TITLE
docs: add GLM-5 llm-d example (16-node / 131K trainer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ These guides are designed to be run from a Slurm cluster but can also be adapted
 3. [**Intellect-3.1**](examples/Intellect-3.1/README.md): Reproduce our `INTELLECT-3.1` training run.
 4. [**MiniMax-M2.5 SWE**](examples/minimax_m2.5_swe/README.md): Train `MiniMax-M2.5` on agentic SWE tasks.
 5. [**High-throughput GLM-5**](examples/glm5_pd_disag/README.md): Train `GLM-5` with PD disaggregation and FP8 inference on SWE.
+6. [**High-throughput GLM-5 (llm-d)**](examples/glm5_llmd/README.md): The faster way to run `GLM-5` — same PD disaggregation and FP8 inference, fronted by the upstream `llm-d` router.
 
 ## Docs
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ PRIME-RL is a framework for large-scale reinforcement learning. It is designed t
 5. Multi-node deployment with Slurm and Kubernetes support.
 6. Multimodal support for VLMs such as Qwen3-VL.
 7. Hackable, modular, and extensible by design.
+8. One-line SLURM deployment for frontier models — e.g. [`GLM-5` FP8 with P/D disaggregation, the `llm-d` router, and Mooncake KV offload](examples/glm5_llmd/README.md).
 
 
 ## Models support

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ These guides are designed to be run from a Slurm cluster but can also be adapted
 3. [**Intellect-3.1**](examples/Intellect-3.1/README.md): Reproduce our `INTELLECT-3.1` training run.
 4. [**MiniMax-M2.5 SWE**](examples/minimax_m2.5_swe/README.md): Train `MiniMax-M2.5` on agentic SWE tasks.
 5. [**High-throughput GLM-5**](examples/glm5_pd_disag/README.md): Train `GLM-5` with PD disaggregation and FP8 inference on SWE.
-6. [**High-throughput GLM-5 (llm-d)**](examples/glm5_llmd/README.md): The faster way to run `GLM-5` — same PD disaggregation and FP8 inference, fronted by the upstream `llm-d` router.
+6. [**High-throughput GLM-5 (llm-d)**](examples/glm5_llmd/README.md): One-line SLURM deployment for `GLM-5` FP8 with P/D disaggregation, the `llm-d` router, and Mooncake KV offload — the faster way to run `GLM-5`.
 
 ## Docs
 

--- a/examples/glm5_llmd/README.md
+++ b/examples/glm5_llmd/README.md
@@ -1,0 +1,87 @@
+# High-throughput GLM-5 with llm-d
+
+This example trains `GLM-5.1` with RL on agentic SWE tasks using P/D disaggregation, FP8 inference, and a Mooncake distributed CPU KV store — fronted by the upstream [**llm-d**](https://llm-d.ai) router (Endpoint Picker + Envoy).
+
+**llm-d is the faster way to run GLM-5.** It is the recommended router backend for large GLM-5 runs: its `active-request-scorer` is an in-flight load balancer that spreads requests across ranks immediately, instead of relying on metrics that are scraped on a delay (as the default `vllm-router` does). Combined with prefix-cache affinity for grouped rollouts, this keeps prefill and decode ranks evenly loaded under the bursty request pattern of RL. If you want the simpler default router instead, see the [GLM-5 PD disaggregation example](../glm5_pd_disag/README.md).
+
+## Requirements
+
+You need access to a Slurm cluster with at least **32 nodes** (16 trainer + 16 inference, 8 GPUs each) and a shared filesystem. In this guide we assume the NFS is mounted at `/shared`; you can change it to your own path.
+
+You also need prime-rl cloned on your cluster into the shared filesystem.
+
+```bash
+git clone https://github.com/PrimeIntellect-ai/prime-rl.git /shared/prime-rl
+cd /shared/prime-rl
+uv sync --all-extras
+```
+
+### Install llm-d
+
+The llm-d router ships as vendored binaries (`epp`, `envoy`, `pd-sidecar`). Build them once into `third_party/llmd/bin`:
+
+```bash
+bash scripts/install_llmd.sh
+```
+
+You might also want to create a `.env` file inside the prime-rl directory to store environment variables used during training like W&B and Hugging Face tokens. The `.env` file is automatically sourced during training.
+
+```bash
+touch .env
+echo "WANDB_API_KEY=your_wandb_api_key" >> .env
+echo "HUGGINGFACE_TOKEN=your_huggingface_token" >> .env
+```
+
+### sandbox
+
+The SWE environment is configured to use Prime Intellect Sandboxes. You can find more information about the sandboxes [here](https://docs.primeintellect.ai/sandboxes/overview). You will need to create a sandbox account and add the credentials to the `.env` file. Alternatively, you can adapt the code of the environment to use your own sandbox implementation.
+
+## Tweak before launching
+
+This config is tuned for our cluster — a few values **must** be adapted to yours before you run. Search the config for these markers:
+
+- **`output_dir`** (`# FILL IN`) — point it at your shared filesystem.
+- **`[slurm] partition`** (`# FILL IN`) — set it to your cluster's Slurm partition.
+- **`[inference.kv_cache_offload] device_name`** (`# do it yourself`) — the list of RDMA NICs for Mooncake. Auto-detection is unreliable, so set it by hand from `nvidia-smi topo -m` on your nodes.
+
+A few more knobs you may want to tune for your hardware:
+
+- **Trainer parallelism** — this config assumes **16 trainer nodes** at **131K** sequence length with `cp = 4` (context parallel) and the `adamw` optimizer. If you have fewer trainer nodes, drop `seq_len`, lower `num_train_nodes`, and reduce `cp` accordingly.
+- **Scorer weights** (`[inference.deployment.router]`) — the `scorers` / `prefill_scorer_overrides` / `decode_scorer_overrides` weights follow the upstream llm-d P/D guide and are a good starting point; tune them if your prefill/decode balance drifts.
+- **Mooncake CPU pool** (`[inference.kv_cache_offload.cpu] num_bytes`) — defaults to 1TB/node; lower it if your nodes have less RAM.
+
+## Tmux session
+
+We recommend using the tmux helper to start the run and look at the logs.
+
+From your Slurm head node:
+
+```bash
+bash scripts/tmux.sh glm5-llmd /shared/outputs/glm5-llmd
+```
+
+You can then attach to it by doing `tmux attach -t glm5-llmd`.
+
+## Start the run
+
+Run the following command to start the RL training:
+
+PS: If using the tmux helper, you can run the command in the `Terminal` (window 0) pane and look at the logs in the `Logs` (window 1) pane.
+
+```bash
+uv run rl @ examples/glm5_llmd/rl.toml --output-dir /shared/outputs/glm5-llmd
+```
+
+Output of the command:
+```
+XXX:XX:XX    INFO Wrote subconfigs to /shared/outputs/glm5-llmd/configs [rl.py::515]
+XXX:XX:XX    INFO Wrote SLURM script to /shared/outputs/glm5-llmd/rl.sbatch [rl.py::534]
+XXX:XX:XX    INFO Submitting: sbatch /shared/outputs/glm5-llmd/rl.sbatch [rl.py::540]
+XXX:XX:XX SUCCESS Submitted batch job YYYY
+
+Logs:
+  Trainer:          tail -F /shared/outputs/glm5-llmd/logs/trainer.log
+  Orchestrator:     tail -F /shared/outputs/glm5-llmd/logs/orchestrator.log
+  Inference:        tail -F /shared/outputs/glm5-llmd/logs/inference.log
+  Envs:             tail -F /shared/outputs/glm5-llmd/logs/envs/*/*/*.log
+```

--- a/examples/glm5_llmd/rl.toml
+++ b/examples/glm5_llmd/rl.toml
@@ -1,13 +1,13 @@
 max_steps = 10000000
-seq_len = 42000 # BUMP TO 131K IF you have 16 nodes for trainer
-output_dir = "/shared/outputs/blog" # FILL IN
+seq_len = 131072
+output_dir = "/shared/outputs/glm5-llmd" # FILL IN: point at your shared filesystem
 clean_output_dir = true
 
 [log]
 level = "debug"
 
 [wandb]
-project = "blog"
+project = "glm5-llmd"
 name = "base"
 
 [weight_broadcast]
@@ -18,7 +18,7 @@ quantize_in_weight_transfer = true
 
 [deployment]
 type = "multi_node"
-num_train_nodes = 12 # BUMP TO 16 IF 131K
+num_train_nodes = 16
 num_infer_nodes = 16
 gpus_per_node = 8
 num_infer_replicas = 1
@@ -47,8 +47,8 @@ decode_scorer_overrides = { "active-request-scorer" = 5.0, "kv-cache-utilization
 non_cached_tokens = 128 # if <128 tokens, skip prefill go to decode immediately
 
 [slurm]
-job_name = "blog"
-partition = "all" # FILL IN
+job_name = "glm5-llmd"
+partition = "all" # FILL IN: set to your cluster's partition
 
 [trainer]
 dist_timeout_seconds = 1800
@@ -59,7 +59,7 @@ name = "zai-org/GLM-5.1"
 impl = "custom"
 attn = "flash_attention_2" # ignored with GLM5
 fused_lm_head_token_chunk_size = 1024
-cp = 2 # do 4-8 if trainer 131K seq len
+cp = 4 # context parallel for the 131K seq len
 ep = 8
 optim_cpu_offload = true
 fp8 = true
@@ -73,7 +73,7 @@ freq = 1
 max_inflight_activations = 1
 
 [trainer.optim]
-type = "sign_sgd" # can do AdamW
+type = "adamw"
 lr = 1e-6
 weight_decay = 0.0
 
@@ -106,7 +106,7 @@ timeout_seconds = 21600
 summarize_at_tokens = [35000, 80000]
 poll_interval = 5
 rlm_ref = "907115a79b2a50d193863e7ea1f3550acb4386f0"
-labels = ["blog"]
+labels = ["glm5-llmd"]
 
 [orchestrator.advantage]
 type = "default"


### PR DESCRIPTION
## What

Promotes the `glm5_llmd` config from `configs/` to a full **`examples/glm5_llmd/`** example (config + README), mirroring the existing `examples/glm5_pd_disag` GLM-5 example. Stacked on top of #2697 (`feat/llm-d-router-v2`).

- **Moves** `configs/glm5_llmd/rl.toml` → `examples/glm5_llmd/rl.toml` (git rename, ~92% similarity). Nothing referenced the old path.
- **Adds** `examples/glm5_llmd/README.md` framing **llm-d as the faster way to run GLM-5** (in-flight `active-request-scorer` vs the default `vllm-router`'s delayed metrics scraping), with an install step (`scripts/install_llmd.sh`) and a **"Tweak before launching"** section calling out the placeholders users must set: `output_dir`, `[slurm] partition`, and the Mooncake `device_name` (from `nvidia-smi topo -m`).
- **Tunes** the example for a 16-node trainer at 131K context: `seq_len = 131072`, `num_train_nodes = 16`, `cp = 4`, and `[trainer.optim] type = "adamw"`. Renames the internal `"blog"` placeholder to `glm5-llmd` throughout.
- **Adds** entry #6 to the main README advanced-examples list.

TOML validates with `tomllib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example TOML only; no changes to training, inference, or router implementation code.
> 
> **Overview**
> Adds a first-class **`examples/glm5_llmd/`** example (README + `rl.toml`) for large-scale **GLM-5.1** SWE RL with **llm-d** routing, P/D disaggregation, FP8 inference, and Mooncake KV offload, positioned as the recommended high-throughput path vs the existing `glm5_pd_disag` example.
> 
> The new README covers Slurm requirements (32 nodes), `scripts/install_llmd.sh`, cluster-specific placeholders (`output_dir`, partition, Mooncake NICs), and the one-line `uv run rl @ examples/glm5_llmd/rl.toml` launch flow.
> 
> **`rl.toml`** is retuned from prior “blog” placeholders to a **16 trainer / 16 infer** layout: **`seq_len = 131072`**, **`cp = 4`**, **`num_train_nodes = 16`**, **`adamw`**, and **`router.type = "llm-d"`** with documented scorer weights; W&B/Slurm/env labels are renamed to **`glm5-llmd`**.
> 
> The root **README** gains bullet #8 and advanced example #6 linking to this guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdb2603569aff092b8817fd5989f370806ed95ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->