### PR TITLE
chore: release v0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prime-rl"
-version = "0.5.0"
+version = "0.6.0"
 description = "Async RL Training at Scale"
 readme = "README.md"
 requires-python = "~=3.12.0"


### PR DESCRIPTION
Bumps version to 0.6.0.

Draft release notes: https://github.com/PrimeIntellect-ai/prime-rl/releases/tag/v0.6.0

On merge, the tag-and-release workflow tags this commit and promotes the v0.6.0 draft release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata version field change with no code or dependency updates in the diff.
> 
> **Overview**
> **Bumps the `prime-rl` package version from `0.5.0` to `0.6.0`** in `pyproject.toml` as the release cut for v0.6.0.
> 
> No runtime, dependency, or source changes are included in this diff. Merging is intended to trigger the tag-and-release workflow so this commit is tagged and the existing **v0.6.0** draft GitHub release is published.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85080d185b026ad229fcf2761a6b88e956bcd128. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->