### PR TITLE
feat: adapt orchestrator to index-addressed env server

### DIFF
--- a/src/prime_rl/orchestrator/envs.py
+++ b/src/prime_rl/orchestrator/envs.py
@@ -3,8 +3,8 @@
 Each ``Env`` owns a v1 ``EnvServer`` (spawned as a child process, or an
 external one given by ``config.address``) and an ``EnvClient`` to drive it. The
 orchestrator never *runs* an environment: it asks the server for ``info``
-(``num_tasks`` + whether group scoring is needed), then runs rollouts purely by
-**task index**. The server returns a ``Trace`` (a plain ``model_dump`` — derived values are
+(``num_tasks`` — ``None`` when the taskset is served lazily — + whether group scoring is
+needed), then runs rollouts purely by **task index**. The server returns a ``Trace`` (a plain ``model_dump`` — derived values are
 properties, not serialized) which we validate into a ``Trace[WireTask]`` — a real ``vf.Trace``
 (never a loose dict) whose task keeps the env's
 task-specific fields as extras (``WireTask`` allows them). The orchestrator never imports the
@@ -81,7 +81,9 @@ class Env:
     def __init__(self, config: EnvConfig):
         self.config = config
         self.sampling_args: dict = {}
-        self.num_tasks: int = 0
+        self.num_tasks: int | None = None
+        """Task count reported by the server, or ``None`` when the taskset is served lazily
+        (a generator ``load_tasks``, possibly unbounded) — then the caller drives ``task_idx``."""
         self.requires_group_scoring: bool = False
         self._env_client: EnvClient | None = None
         self._env_server_process: BaseProcess | None = None
@@ -111,7 +113,8 @@ class Env:
         self.num_tasks = info.num_tasks
         self.requires_group_scoring = info.requires_group_scoring
         get_logger().info(
-            f"Env {self.name} ready: num_tasks={self.num_tasks} group_scoring={self.requires_group_scoring}"
+            f"Env {self.name} ready: num_tasks={self.num_tasks if self.num_tasks is not None else 'lazy'} "
+            f"group_scoring={self.requires_group_scoring}"
         )
 
     async def _spawn(self, log_dir: Path, log_level: str, json_logging: bool) -> str:
@@ -216,7 +219,15 @@ class EvalEnv(Env):
 
     async def start(self, log_dir: Path, log_level: str | None = None, json_logging: bool = False) -> None:
         await super().start(log_dir=log_dir, log_level=log_level, json_logging=json_logging)
-        n = self.num_tasks if self.config.num_examples < 0 else min(self.config.num_examples, self.num_tasks)
+        if self.num_tasks is None:
+            # Lazily-served taskset: no count to enumerate, so eval must be explicitly bounded.
+            if self.config.num_examples < 0:
+                raise ValueError(
+                    f"Env {self.name} is served lazily (no task count); set num_examples to bound the eval"
+                )
+            n = self.config.num_examples
+        else:
+            n = self.num_tasks if self.config.num_examples < 0 else min(self.config.num_examples, self.num_tasks)
         self.examples = [{"task_idx": i} for i in range(n)]
 
 

--- a/src/prime_rl/orchestrator/train_source.py
+++ b/src/prime_rl/orchestrator/train_source.py
@@ -1,7 +1,9 @@
 """TrainSource: weighted round-robin across train envs, infinite pull.
 
 Weights default to configured ``ratio`` (when every env sets one) or to
-per-env dataset size. ``next_example`` reshuffles on cursor exhaustion."""
+per-env dataset size. A finite env reshuffles its index range on cursor
+exhaustion; an unbounded one (the server reports no ``num_tasks``) streams a
+monotonically increasing ``task_idx`` instead."""
 
 from __future__ import annotations
 
@@ -24,15 +26,20 @@ class TrainSource:
 
         self.examples: dict[str, list[dict]] = {}
         self.cursors: dict[str, int] = {}
+        self.bounded: dict[str, bool] = {}
         # Group-scoring envs reserve ``group_size`` permits up front;
         # per-rollout envs need 1
         self.env_costs: dict[str, int] = {}
         for env in self.envs:
-            # The orchestrator never loads the env: sample over the task-index
-            # range the server reported via info() (num_tasks).
-            rows: list[dict] = [{"task_idx": i, "env_name": env.name} for i in range(env.num_tasks)]
-            self.rng.shuffle(rows)
-            self.examples[env.name] = rows
+            # The orchestrator never loads the env. A finite env reports ``num_tasks``, so we
+            # sample over its index range (shuffled, reshuffled each epoch). An unbounded one
+            # (``num_tasks is None``) has no range — ``next_example`` streams a monotonically
+            # increasing ``task_idx``; the taskset's own generator (e.g. RNG-seeded) varies it.
+            self.bounded[env.name] = env.num_tasks is not None
+            if env.num_tasks is not None:
+                rows = [{"task_idx": i, "env_name": env.name} for i in range(env.num_tasks)]
+                self.rng.shuffle(rows)
+                self.examples[env.name] = rows
             self.cursors[env.name] = 0
             self.env_costs[env.name] = env.config.group_size if env.requires_group_scoring else 1
 
@@ -40,15 +47,25 @@ class TrainSource:
         configured_ratios = [e.config.ratio for e in self.envs]
         if all(r is not None for r in configured_ratios):
             self.weights: list[float] = [float(r) for r in configured_ratios]  # type: ignore[arg-type]
-        else:
+        elif all(self.bounded[name] for name in self.env_names):
             self.weights = [float(len(self.examples[name])) for name in self.env_names]
+        else:
+            unbounded = [n for n in self.env_names if not self.bounded[n]]
+            raise ValueError(
+                f"unbounded train env(s) {unbounded} have no dataset size to weight by; "
+                "set an explicit `ratio` on every train env"
+            )
 
     def next_example(self, available_permits: int) -> dict | None:
         env_name = self.rng.choices(self.env_names, weights=self.weights, k=1)[0]
         if self.env_costs[env_name] > available_permits:
             return None
-        rows = self.examples[env_name]
         cursor = self.cursors[env_name]
+        if not self.bounded[env_name]:
+            # Unbounded: hand out the next task_idx and advance forever (no epoch / reshuffle).
+            self.cursors[env_name] = cursor + 1
+            return {"task_idx": cursor, "env_name": env_name}
+        rows = self.examples[env_name]
         if cursor >= len(rows):
             self.rng.shuffle(rows)
             cursor = 0


### PR DESCRIPTION
## Summary

Companion to verifiers PR [#1829](https://github.com/PrimeIntellect-ai/verifiers/pull/1829), which makes the v1 env-server index-addressed with **no required task count** so it can serve lazy/unbounded tasksets — `InfoResponse.num_tasks` is now `int | None` (`None` = served lazily; the caller drives `task_idx`). This adapts the orchestrator to that API.

- `Env.num_tasks` is now `int | None` (`None` when the taskset is served lazily).
- `EvalEnv.start` requires `num_examples` to bound a lazily-served eval — an unknown/infinite count can't be enumerated (raises a clear error if `num_examples < 0`).
- `TrainSource`:
  - **Finite path unchanged** — enumerate the env's index range, shuffle, reshuffle each epoch, weight by dataset size.
  - **Unbounded path** (`num_tasks is None`) — `next_example` streams a monotonically increasing `task_idx` (no epoch/reshuffle; the taskset's own generator, e.g. RNG-seeded pairs, supplies the variety).
  - An unbounded env has no dataset size to weight by, so it requires an explicit `ratio` (clear error otherwise).

Backward-compatible: against a server that still reports a count (every current taskset that returns a list, and the v0 bridge), every env is bounded and behavior is identical. The change is safe to land before the verifiers pin bump.

## Verification

Unit-checked `TrainSource` against stub envs:
- finite env → epochs cover all indices, reshuffled (e.g. `[2,0,1,3, 1,2,0,3, ...]`);
- unbounded env (`num_tasks=None`, with a `ratio`) → streams `[0,1,2,3,4,5]`;
- unbounded without a `ratio` alongside a finite env → `ValueError` (no size to weight by);
- mixed finite + unbounded with ratios → both envs sampled.

`ruff check` / `ruff format` clean (pre-commit).

## Follow-up

The verifiers pin bump (to the merged #1829 commit) lands separately once that PR merges; only then does an actual unbounded taskset report `num_tasks=None` end-to-end.
