### PR TITLE
fix: sync uv.lock to v0.6.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3930,7 +3930,7 @@ dev = [
 
 [[package]]
 name = "prime-rl"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },


### PR DESCRIPTION
## Problem

The v0.6.0 release bump (#2855) updated `version` in `pyproject.toml` to `0.6.0` but did not regenerate `uv.lock`, which still pinned the root `prime-rl` package at `0.5.0`. CI runs `uv sync --locked`, which refuses a stale lockfile — breaking **CPU Tests** and **Docker Push** on `main` (both were green on the prior commit).

## Fix

Bump the root `prime-rl` version in `uv.lock` to `0.6.0` — exactly what `uv lock` produces for a version-only change. No dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single version field in the lockfile with no dependency changes; tooling/CI alignment only.
> 
> **Overview**
> Updates the editable root **`prime-rl`** entry in **`uv.lock`** from **`0.5.0`** to **`0.6.0`** so it matches **`pyproject.toml`** after the v0.6.0 release bump. No dependency graph or lock resolution changes—only the pinned version string for the local package.
> 
> This unblocks **`uv sync --locked`** in CI (e.g. CPU Tests and Docker Push), which fails when the lockfile is out of sync with the project version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e78af70c7682c938a676a2a0a4cde0a0819d764e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->