### PR TITLE
feat: configurable env vars

### DIFF
--- a/configs/glm5.2_16node_llmd/inference.toml
+++ b/configs/glm5.2_16node_llmd/inference.toml
@@ -35,8 +35,8 @@ num_prefill_nodes = 8
 num_prefill_replicas = 4
 num_decode_nodes = 8
 num_decode_replicas = 1
-prefill_env_overrides = {"VLLM_ENABLE_MOE_DP_CHUNK"="0", "VLLM_DEEP_GEMM_WARMUP"="skip", "UCX_RCACHE_MAX_UNRELEASED"="1024"}
-decode_env_overrides = {"VLLM_DEEP_GEMM_WARMUP"="skip", "UCX_RCACHE_MAX_UNRELEASED"="1024"}
+prefill_env_vars = {"VLLM_ENABLE_MOE_DP_CHUNK"="0", "VLLM_DEEP_GEMM_WARMUP"="skip", "UCX_RCACHE_MAX_UNRELEASED"="1024"}
+decode_env_vars = {"VLLM_DEEP_GEMM_WARMUP"="skip", "UCX_RCACHE_MAX_UNRELEASED"="1024"}
 
 [deployment.router]
 type = "llm-d"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,7 +18,7 @@ Every `prime-rl` entrypoint uses [`pydantic-config`](https://github.com/PrimeInt
   - [None](#none)
   - [Discriminated Unions](#discriminated-unions)
   - [Environments](#environments-orchestratortrainenv)
-  - [Environment Variables](#environment-variables-componentenv_vars)
+  - [Environment Variables](#environment-variables)
 - [Examples](#examples)
 
 ## Sources and Precedence
@@ -166,9 +166,17 @@ args = { dataset_name = "openai/gsm8k", dataset_subset = "main" }
 
 The same `id` can appear multiple times across train and eval (or with different `args`) — useful for evaluating on a held-out split of the env you're training on, or comparing two configurations of the same env side by side. When `id` is reused, set a distinct `name` on each entry; `name` defaults to `id` and must be unique across all envs in the same group.
 
-### Environment Variables (`[component.env_vars]`)
+### Environment Variables
 
-OS environment variables exported into each launched component's process(es), set per component:
+OS environment variables exported into launched component process(es). In `rl` configs, top-level `[env_vars]` applies to trainer, inference, and orchestrator:
+
+```toml
+[env_vars]
+HF_HUB_OFFLINE = "1"
+TOKENIZERS_PARALLELISM = "false"
+```
+
+Component-specific tables layer on top:
 
 ```toml
 [trainer.env_vars]
@@ -185,10 +193,11 @@ PI_USAGE_BASE_URL = "https://..."
 The `rl` launcher applies these the same way in both single-node and multi-node (SLURM) runs. Precedence, low to high:
 
 1. The launcher's own defaults — **your `env_vars` override these**.
-2. Your `[component.env_vars]`.
-3. Orchestration-critical vars the launcher always sets last — `CUDA_VISIBLE_DEVICES` (GPU partitioning) and `WANDB_SHARED_*` (the single shared W&B run) — **these cannot be overridden** from `env_vars`.
+2. Your top-level `[env_vars]`.
+3. Your `[component.env_vars]`.
+4. Orchestration-critical vars the launcher always sets last — `CUDA_VISIBLE_DEVICES` (GPU partitioning) and `WANDB_SHARED_*` (the single shared W&B run) — **these cannot be overridden** from `env_vars`.
 
-For disaggregated P/D inference, the role-specific [`deployment.{prefill,decode}_env_vars`](inference.md) layer on top of `inference.env_vars`.
+For standalone `sft` and `inference` configs, `[env_vars]` applies to that entrypoint's process(es). For disaggregated P/D inference, the role-specific [`deployment.{prefill,decode}_env_vars`](inference.md) layer on top of any shared inference env vars.
 
 ## Examples
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,7 +17,8 @@ Every `prime-rl` entrypoint uses [`pydantic-config`](https://github.com/PrimeInt
   - [Optional Sub-Configs](#optional-sub-configs)
   - [None](#none)
   - [Discriminated Unions](#discriminated-unions)
-  - [Environments (`[[orchestrator.train.env]]`)](#environments-orchestratortrainenv)
+  - [Environments](#environments-orchestratortrainenv)
+  - [Environment Variables](#environment-variables-componentenv_vars)
 - [Examples](#examples)
 
 ## Sources and Precedence
@@ -164,6 +165,30 @@ args = { dataset_name = "openai/gsm8k", dataset_subset = "main" }
 `args` is forwarded verbatim to the environment's `load_environment(**args)`.
 
 The same `id` can appear multiple times across train and eval (or with different `args`) — useful for evaluating on a held-out split of the env you're training on, or comparing two configurations of the same env side by side. When `id` is reused, set a distinct `name` on each entry; `name` defaults to `id` and must be unique across all envs in the same group.
+
+### Environment Variables (`[component.env_vars]`)
+
+OS environment variables exported into each launched component's process(es), set per component:
+
+```toml
+[trainer.env_vars]
+NCCL_DEBUG = "INFO"
+PYTORCH_CUDA_ALLOC_CONF = "expandable_segments:False"
+
+[inference.env_vars]
+VLLM_USE_DEEP_GEMM = "1"
+
+[orchestrator.env_vars]
+PI_USAGE_BASE_URL = "https://..."
+```
+
+The `rl` launcher applies these the same way in both single-node and multi-node (SLURM) runs. Precedence, low to high:
+
+1. The launcher's own defaults — **your `env_vars` override these**.
+2. Your `[component.env_vars]`.
+3. Orchestration-critical vars the launcher always sets last — `CUDA_VISIBLE_DEVICES` (GPU partitioning) and `WANDB_SHARED_*` (the single shared W&B run) — **these cannot be overridden** from `env_vars`.
+
+For disaggregated P/D inference, the role-specific [`deployment.{prefill,decode}_env_vars`](inference.md) layer on top of `inference.env_vars`.
 
 ## Examples
 

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -253,9 +253,11 @@ For configuring various knobs with environment variables, we enable you to confi
 [inference.deployment]
 type = "disaggregated"
 
-prefill_env_overrides = {"VLLM_ENABLE_MOE_DP_CHUNK"="0", "VLLM_DEEP_GEMM_WARMUP"="skip"}
-decode_env_overrides = {"VLLM_DEEP_GEMM_WARMUP"="skip"}
+prefill_env_vars = {"VLLM_ENABLE_MOE_DP_CHUNK"="0", "VLLM_DEEP_GEMM_WARMUP"="skip"}
+decode_env_vars = {"VLLM_DEEP_GEMM_WARMUP"="skip"}
 ```
+
+These are role-specific and layer on top of [`[inference.env_vars]`](configuration.md#environment-variables-componentenv_vars), which applies to all inference processes regardless of role.
 
 ### Other vLLM features
 We support various other vLLM features. Some of those, such as `enable_dbo`, `enable_eplb` are exposed as a top-level config fields. For those that are not, you can configure them by setting `inference.vllm_extra` to the desired value.

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -257,7 +257,7 @@ prefill_env_vars = {"VLLM_ENABLE_MOE_DP_CHUNK"="0", "VLLM_DEEP_GEMM_WARMUP"="ski
 decode_env_vars = {"VLLM_DEEP_GEMM_WARMUP"="skip"}
 ```
 
-These are role-specific and layer on top of [`[inference.env_vars]`](configuration.md#environment-variables-componentenv_vars), which applies to all inference processes regardless of role.
+These are role-specific and layer on top of [`env_vars`](configuration.md#environment-variables) shared by all inference processes regardless of role.
 
 ### Other vLLM features
 We support various other vLLM features. Some of those, such as `enable_dbo`, `enable_eplb` are exposed as a top-level config fields. For those that are not, you can configure them by setting `inference.vllm_extra` to the desired value.

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -179,6 +179,8 @@ The defaults already cover: fused LM head chunking (`1024`), `torch.compile` (fu
 
 The `rl`, `sft`, and `inference` entrypoints all submit to SLURM when a `[slurm]` table is present — there's no separate entrypoint.
 
+> **The prime-rl checkout and its `uv` venv must live on a shared filesystem** visible to every node. The generated sbatch script runs a single `uv sync --all-extras` on the batch node (not once per node), so all ranks share that one environment — a node-local venv would leave the other nodes stale.
+
 ### Activation
 
 A SLURM config is usually a thin overlay that adds `[slurm]` (and `[deployment]` for multi-node) on top of a base config. Configs are composed left-to-right via the `@` CLI syntax — see [Configuration § TOML Composition](configuration.md#toml-composition):

--- a/examples/glm5_llmd/rl.toml
+++ b/examples/glm5_llmd/rl.toml
@@ -31,8 +31,8 @@ num_decode_nodes = 8
 num_decode_replicas = 1
 # skip warmup for faster start in cost of some jit overhead early
 # ucx needs to be set else random segfaults, vllm can't autoset before importing for some reason
-prefill_env_overrides = {"VLLM_ENABLE_MOE_DP_CHUNK"="0", "VLLM_DEEP_GEMM_WARMUP"="skip", "UCX_RCACHE_MAX_UNRELEASED"="1024"}
-decode_env_overrides = {"VLLM_DEEP_GEMM_WARMUP"="skip", "UCX_RCACHE_MAX_UNRELEASED"="1024"}
+prefill_env_vars = {"VLLM_ENABLE_MOE_DP_CHUNK"="0", "VLLM_DEEP_GEMM_WARMUP"="skip", "UCX_RCACHE_MAX_UNRELEASED"="1024"}
+decode_env_vars = {"VLLM_DEEP_GEMM_WARMUP"="skip", "UCX_RCACHE_MAX_UNRELEASED"="1024"}
 
 # gives the most KV cache while keeping decent throughput, KV cache increase comes in from lower deep-ep LL static buffers
 prefill_vllm_overrides = {"enable_dbo"=true}

--- a/packages/prime-rl-configs/src/prime_rl/configs/inference.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/inference.py
@@ -5,7 +5,7 @@ from typing import Annotated, Any, Literal, TypeAlias
 from pydantic import Field, model_validator
 from pydantic_config import BaseConfig
 
-from prime_rl.configs.shared import BaseModelConfig, LogConfig, SlurmConfig
+from prime_rl.configs.shared import BaseModelConfig, EnvVars, LogConfig, SlurmConfig
 from prime_rl.utils.config import find_package_resource, rgetattr, rsetattr
 from prime_rl.utils.parsers import resolve_reasoning_parser, resolve_tool_call_parser
 
@@ -300,10 +300,10 @@ class DisaggregatedInferenceDeploymentConfig(BaseInferenceDeploymentConfig):
     decode_port: int = 8200
     """Port for decode vLLM instances."""
 
-    prefill_env_overrides: dict[str, str] = {}
+    prefill_env_vars: EnvVars = {}
     """Extra environment variables exported only on prefill nodes."""
 
-    decode_env_overrides: dict[str, str] = {}
+    decode_env_vars: EnvVars = {}
     """Extra environment variables exported only on decode nodes."""
 
     prefill_vllm_overrides: dict[str, Any] = {}
@@ -351,6 +351,9 @@ class InferenceConfig(BaseConfig):
 
     log: LogConfig = LogConfig()
     """Logging configuration."""
+
+    env_vars: EnvVars = {}
+    """Extra environment variables for the inference server process(es). Merged on top of the launcher defaults."""
 
     enable_lora: bool = False
     """Enable LoRA. Forwarded as ``--enable-lora``."""

--- a/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/orchestrator.py
@@ -13,6 +13,7 @@ from prime_rl.configs.algorithm import (
 from prime_rl.configs.shared import (
     BaseModelConfig,
     ClientConfig,
+    EnvVars,
     FileSystemTransportConfig,
     HeartbeatConfig,
     LogConfig,
@@ -499,6 +500,9 @@ class OrchestratorConfig(BaseConfig):
     rollouts flagged by an enforcing filter are still recorded but not shipped to the trainer."""
 
     log: LogConfig = LogConfig()
+
+    env_vars: EnvVars = {}
+    """Extra environment variables for the orchestrator process(es). Merged on top of the launcher defaults."""
 
     wandb: WandbWithExtrasConfig | None = None
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/rl.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/rl.py
@@ -16,6 +16,7 @@ from prime_rl.configs.orchestrator import (
     OrchestratorConfig,
 )
 from prime_rl.configs.shared import (
+    EnvVars,
     SlurmConfig,
     VLMConfig,
 )
@@ -187,6 +188,9 @@ class RLConfig(BaseConfig):
 
     inference: InferenceConfig | None = None
     """Inference server configuration. If None, the rl entrypoint will not start an inference server (useful for elastic inference pools or manually started servers)."""
+
+    env_vars: EnvVars = {}
+    """Extra environment variables for every launched RL component. Component-specific env_vars override these."""
 
     output_dir: Path = Path("outputs")
     """Output directory. Should be unique per experiment."""

--- a/packages/prime-rl-configs/src/prime_rl/configs/sft.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/sft.py
@@ -6,6 +6,7 @@ from pydantic import Field, model_validator
 from renderers import RendererConfig
 
 from prime_rl.configs.shared import (
+    EnvVars,
     HeartbeatConfig,
     SlurmConfig,
     TrainerLogConfig,
@@ -172,6 +173,9 @@ class SFTExperimentalConfig(BaseConfig):
 
 class SFTConfig(BaseConfig):
     model: ModelConfig = ModelConfig()
+
+    env_vars: EnvVars = {}
+    """Extra environment variables for the SFT trainer process(es). Merged on top of the launcher defaults."""
 
     tokenizer: TokenizerConfig = TokenizerConfig()
 

--- a/packages/prime-rl-configs/src/prime_rl/configs/shared.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/shared.py
@@ -2,9 +2,29 @@ import os
 from pathlib import Path
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import Field, model_validator
+from pydantic import AfterValidator, Field, model_validator
 
 from prime_rl.utils.config import BaseConfig
+
+# Launcher-managed env vars that a component's `env_vars` must not set: GPU partitioning
+# and the single shared W&B run. The launcher always sets these last, so allowing them in
+# `env_vars` would be a silent no-op (or, on multi-node, a footgun) — reject them instead.
+PROTECTED_ENV_VARS = frozenset(
+    {"CUDA_VISIBLE_DEVICES", "WANDB_SHARED_MODE", "WANDB_SHARED_RUN_ID", "WANDB_SHARED_LABEL"}
+)
+
+
+def reject_protected_env_vars(env_vars: dict[str, str]) -> dict[str, str]:
+    clobbered = sorted(PROTECTED_ENV_VARS & env_vars.keys())
+    if clobbered:
+        raise ValueError(
+            f"env_vars cannot set launcher-managed vars {clobbered} — set by the launcher, not overridable"
+        )
+    return env_vars
+
+
+EnvVars: TypeAlias = Annotated[dict[str, str], AfterValidator(reject_protected_env_vars)]
+"""A per-component `env_vars` mapping, validated to not clobber `PROTECTED_ENV_VARS`."""
 
 
 class SlurmConfig(BaseConfig):

--- a/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/trainer.py
@@ -6,6 +6,7 @@ from pydantic import Field, model_validator
 
 from prime_rl.configs.shared import (
     BaseModelConfig,
+    EnvVars,
     FileSystemTransportConfig,
     HeartbeatConfig,
     MetricsServerConfig,
@@ -567,6 +568,9 @@ class TrainerConfig(BaseConfig):
 
     enable_token_export: bool = False
     """Opt-in per-token JSONL export for rollout debugging. When enabled, writes token ids and aligned trainer metrics after each forward pass."""
+
+    env_vars: EnvVars = {}
+    """Extra environment variables for the trainer process(es). Merged on top of the launcher defaults."""
 
     @model_validator(mode="after")
     def deepep_disables_grad_clipping(self):

--- a/src/prime_rl/entrypoints/inference.py
+++ b/src/prime_rl/entrypoints/inference.py
@@ -1,4 +1,5 @@
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -10,7 +11,7 @@ from prime_rl.configs.inference import InferenceConfig
 from prime_rl.utils.config import cli
 from prime_rl.utils.logger import setup_logger
 from prime_rl.utils.pathing import format_log_message, get_config_dir, get_log_dir
-from prime_rl.utils.process import set_proc_title
+from prime_rl.utils.process import DEFAULT_COMMON_ENV_VARS, DEFAULT_INFERENCE_ENV_VARS, set_proc_title
 
 INFERENCE_TOML = "inference.toml"
 INFERENCE_SBATCH = "inference.sbatch"
@@ -66,6 +67,7 @@ def write_slurm_script(config: InferenceConfig, config_path: Path, script_path: 
         kv_offload_cpu_bytes=int(offload.cpu.num_bytes) if is_mooncake else 0,
         kv_offload_disk_path=str(offload.disk.path) if (is_mooncake and offload.disk is not None) else "",
         kv_offload_device_name=offload.device_name if is_mooncake else "",
+        inference_env_vars={**DEFAULT_COMMON_ENV_VARS, **DEFAULT_INFERENCE_ENV_VARS, **config.env_vars},
     )
 
     is_multi_node = config.deployment.type == "multi_node"
@@ -81,8 +83,8 @@ def write_slurm_script(config: InferenceConfig, config_path: Path, script_path: 
             router=config.deployment.router,
             data_parallel_rpc_port=config.data_parallel_rpc_port,
             use_deep_gemm=config.use_deep_gemm,
-            prefill_env_overrides=config.deployment.prefill_env_overrides,
-            decode_env_overrides=config.deployment.decode_env_overrides,
+            prefill_env_vars=config.deployment.prefill_env_vars,
+            decode_env_vars=config.deployment.decode_env_vars,
             prefill_vllm_extra_json=vllm_overrides_fragment(config.deployment.prefill_vllm_overrides),
             decode_vllm_extra_json=vllm_overrides_fragment(config.deployment.decode_vllm_overrides),
         )
@@ -150,6 +152,11 @@ def inference_local(config: InferenceConfig):
     host = config.server.host or "0.0.0.0"
     port = config.server.port
     logger.info(f"Starting inference on http://{host}:{port}/v1\n")
+
+    # Apply the inference env (defaults + [inference.env_vars]) in-process so a standalone
+    # `uv run inference` gets the same environment the rl/SLURM launchers inject into the
+    # server subprocess. config.env_vars wins over the defaults; existing os.environ loses.
+    os.environ.update({**DEFAULT_COMMON_ENV_VARS, **DEFAULT_INFERENCE_ENV_VARS, **config.env_vars})
 
     setup_vllm_env(config)
 

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -26,7 +26,15 @@ from prime_rl.utils.pathing import (
     resolve_latest_ckpt_step,
     validate_output_dir,
 )
-from prime_rl.utils.process import cleanup_processes, cleanup_threads, monitor_process, set_proc_title
+from prime_rl.utils.process import (
+    DEFAULT_COMMON_ENV_VARS,
+    DEFAULT_INFERENCE_ENV_VARS,
+    DEFAULT_TRAINER_ENV_VARS,
+    cleanup_processes,
+    cleanup_threads,
+    monitor_process,
+    set_proc_title,
+)
 
 RL_TOML = "rl.toml"
 RL_SBATCH = "rl.sbatch"
@@ -163,6 +171,9 @@ def rl_local(config: RLConfig):
                     inference_cmd,
                     env={
                         **os.environ,
+                        **DEFAULT_COMMON_ENV_VARS,
+                        **DEFAULT_INFERENCE_ENV_VARS,
+                        **config.inference.env_vars,
                         "CUDA_VISIBLE_DEVICES": ",".join(map(str, infer_gpu_ids)),
                     },
                     stdout=log_file,
@@ -214,11 +225,13 @@ def rl_local(config: RLConfig):
                 stderr=log_file,
                 env={
                     **os.environ,
-                    **wandb_shared_env,
-                    "WANDB_SHARED_LABEL": "orchestrator",
+                    **DEFAULT_COMMON_ENV_VARS,
                     "LOGURU_FORCE_COLORS": "1",
                     "WANDB_PROGRAM": "uv run rl",
                     "WANDB_ARGS": json.dumps(start_command),
+                    **config.orchestrator.env_vars,
+                    **wandb_shared_env,
+                    "WANDB_SHARED_LABEL": "orchestrator",
                 },
             )
         processes.append(orchestrator_process)
@@ -260,14 +273,15 @@ def rl_local(config: RLConfig):
                 trainer_cmd,
                 env={
                     **os.environ,
-                    **wandb_shared_env,
-                    "WANDB_SHARED_LABEL": "trainer",
-                    "CUDA_VISIBLE_DEVICES": ",".join(map(str, trainer_gpu_ids)),
-                    "PYTHONUNBUFFERED": "1",
-                    "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
+                    **DEFAULT_COMMON_ENV_VARS,
+                    **DEFAULT_TRAINER_ENV_VARS,
                     "LOGURU_FORCE_COLORS": "1",
                     "WANDB_PROGRAM": "uv run rl",
                     "WANDB_ARGS": json.dumps(start_command),
+                    **config.trainer.env_vars,
+                    **wandb_shared_env,
+                    "WANDB_SHARED_LABEL": "trainer",
+                    "CUDA_VISIBLE_DEVICES": ",".join(map(str, trainer_gpu_ids)),
                 },
                 stdout=log_file,
                 stderr=log_file,
@@ -356,6 +370,21 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
         kv_offload_device_name=offload.device_name if is_mooncake else "",
     )
 
+    # Per-component env vars: launcher defaults (shared + multi-node-specific) with the
+    # user's config merged on top. Runtime wiring stays in the template.
+    trainer_env_vars = {
+        **DEFAULT_COMMON_ENV_VARS,
+        **DEFAULT_TRAINER_ENV_VARS,
+        "HF_HUB_OFFLINE": os.environ.get("HF_HUB_OFFLINE", "1"),
+        **config.trainer.env_vars,
+    }
+    orchestrator_env_vars = {**DEFAULT_COMMON_ENV_VARS, **config.orchestrator.env_vars}
+    inference_env_vars = (
+        {**DEFAULT_COMMON_ENV_VARS, **DEFAULT_INFERENCE_ENV_VARS, **config.inference.env_vars}
+        if config.inference
+        else {}
+    )
+
     if config.deployment.type == "single_node":
         script = template.render(
             **config.slurm.template_vars,
@@ -387,8 +416,11 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
             inference_tp=config.inference.parallel.tp,
             inference_data_parallel_rpc_port=config.inference.data_parallel_rpc_port,
             use_deep_gemm=config.inference.use_deep_gemm,
-            prefill_env_overrides=infer_deploy.prefill_env_overrides,
-            decode_env_overrides=infer_deploy.decode_env_overrides,
+            prefill_env_vars=infer_deploy.prefill_env_vars,
+            decode_env_vars=infer_deploy.decode_env_vars,
+            trainer_env_vars=trainer_env_vars,
+            orchestrator_env_vars=orchestrator_env_vars,
+            inference_env_vars=inference_env_vars,
             prefill_vllm_extra_json=vllm_overrides_fragment(infer_deploy.prefill_vllm_overrides),
             decode_vllm_extra_json=vllm_overrides_fragment(infer_deploy.decode_vllm_overrides),
             dp_per_node=config.deployment.gpus_per_node // config.inference.parallel.tp,
@@ -420,6 +452,9 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
             use_nccl_broadcast=config.weight_broadcast is not None and config.weight_broadcast.type == "nccl",
             ranks_filter=",".join(map(str, config.trainer.log.ranks_filter)),
             orchestrator_on_inference=config.deployment.orchestrator_on_inference,
+            trainer_env_vars=trainer_env_vars,
+            orchestrator_env_vars=orchestrator_env_vars,
+            inference_env_vars=inference_env_vars,
         )
 
     script_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/prime_rl/entrypoints/rl.py
+++ b/src/prime_rl/entrypoints/rl.py
@@ -173,6 +173,7 @@ def rl_local(config: RLConfig):
                         **os.environ,
                         **DEFAULT_COMMON_ENV_VARS,
                         **DEFAULT_INFERENCE_ENV_VARS,
+                        **config.env_vars,
                         **config.inference.env_vars,
                         "CUDA_VISIBLE_DEVICES": ",".join(map(str, infer_gpu_ids)),
                     },
@@ -229,6 +230,7 @@ def rl_local(config: RLConfig):
                     "LOGURU_FORCE_COLORS": "1",
                     "WANDB_PROGRAM": "uv run rl",
                     "WANDB_ARGS": json.dumps(start_command),
+                    **config.env_vars,
                     **config.orchestrator.env_vars,
                     **wandb_shared_env,
                     "WANDB_SHARED_LABEL": "orchestrator",
@@ -278,6 +280,7 @@ def rl_local(config: RLConfig):
                     "LOGURU_FORCE_COLORS": "1",
                     "WANDB_PROGRAM": "uv run rl",
                     "WANDB_ARGS": json.dumps(start_command),
+                    **config.env_vars,
                     **config.trainer.env_vars,
                     **wandb_shared_env,
                     "WANDB_SHARED_LABEL": "trainer",
@@ -375,12 +378,12 @@ def write_slurm_script(config: RLConfig, config_dir: Path, script_path: Path) ->
     trainer_env_vars = {
         **DEFAULT_COMMON_ENV_VARS,
         **DEFAULT_TRAINER_ENV_VARS,
-        "HF_HUB_OFFLINE": os.environ.get("HF_HUB_OFFLINE", "1"),
+        **config.env_vars,
         **config.trainer.env_vars,
     }
-    orchestrator_env_vars = {**DEFAULT_COMMON_ENV_VARS, **config.orchestrator.env_vars}
+    orchestrator_env_vars = {**DEFAULT_COMMON_ENV_VARS, **config.env_vars, **config.orchestrator.env_vars}
     inference_env_vars = (
-        {**DEFAULT_COMMON_ENV_VARS, **DEFAULT_INFERENCE_ENV_VARS, **config.inference.env_vars}
+        {**DEFAULT_COMMON_ENV_VARS, **DEFAULT_INFERENCE_ENV_VARS, **config.env_vars, **config.inference.env_vars}
         if config.inference
         else {}
     )

--- a/src/prime_rl/entrypoints/sft.py
+++ b/src/prime_rl/entrypoints/sft.py
@@ -12,7 +12,14 @@ from prime_rl.configs.sft import SFTConfig
 from prime_rl.utils.config import cli
 from prime_rl.utils.logger import setup_logger
 from prime_rl.utils.pathing import format_log_message, get_config_dir, get_log_dir, validate_output_dir
-from prime_rl.utils.process import cleanup_processes, cleanup_threads, monitor_process, set_proc_title
+from prime_rl.utils.process import (
+    DEFAULT_COMMON_ENV_VARS,
+    DEFAULT_TRAINER_ENV_VARS,
+    cleanup_processes,
+    cleanup_threads,
+    monitor_process,
+    set_proc_title,
+)
 
 SFT_TOML = "sft.toml"
 SFT_SBATCH = "sft.sbatch"
@@ -36,6 +43,13 @@ def write_slurm_script(config: SFTConfig, config_path: Path, script_path: Path) 
     env = Environment(loader=FileSystemLoader(config.slurm.template_path.parent), keep_trailing_newline=True)
     template = env.get_template(config.slurm.template_path.name)
 
+    trainer_env_vars = {
+        **DEFAULT_COMMON_ENV_VARS,
+        **DEFAULT_TRAINER_ENV_VARS,
+        "HF_HUB_OFFLINE": os.environ.get("HF_HUB_OFFLINE", "1"),
+        **config.env_vars,
+    }
+
     if config.deployment.type == "single_node":
         script = template.render(
             **config.slurm.template_vars,
@@ -48,6 +62,7 @@ def write_slurm_script(config: SFTConfig, config_path: Path, script_path: Path) 
             **config.slurm.template_vars,
             config_path=config_path,
             output_dir=config.output_dir,
+            trainer_env_vars=trainer_env_vars,
             num_nodes=config.deployment.num_nodes,
             gpus_per_node=config.deployment.gpus_per_node,
             ranks_filter=",".join(map(str, config.log.ranks_filter)),
@@ -143,8 +158,9 @@ def sft_local(config: SFTConfig):
                 trainer_cmd,
                 env={
                     **os.environ,
-                    "PYTHONUNBUFFERED": "1",
-                    "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
+                    **DEFAULT_COMMON_ENV_VARS,
+                    **DEFAULT_TRAINER_ENV_VARS,
+                    **config.env_vars,
                 },
                 stdout=log_file,
                 stderr=log_file,

--- a/src/prime_rl/entrypoints/sft.py
+++ b/src/prime_rl/entrypoints/sft.py
@@ -46,7 +46,6 @@ def write_slurm_script(config: SFTConfig, config_path: Path, script_path: Path) 
     trainer_env_vars = {
         **DEFAULT_COMMON_ENV_VARS,
         **DEFAULT_TRAINER_ENV_VARS,
-        "HF_HUB_OFFLINE": os.environ.get("HF_HUB_OFFLINE", "1"),
         **config.env_vars,
     }
 

--- a/src/prime_rl/templates/inference.sbatch.j2
+++ b/src/prime_rl/templates/inference.sbatch.j2
@@ -57,13 +57,6 @@ mkdir -p $OUTPUT_DIR/logs/inference
 rm -f $OUTPUT_DIR/logs/inference/*.log
 ln -sfn inference/node_0.log $OUTPUT_DIR/logs/inference.log
 
-# General
-export CUDA_DEVICE_ORDER=PCI_BUS_ID
-export PYTHONUNBUFFERED=1
-export OMP_NUM_THREADS=1
-export TRITON_CACHE_DIR=/tmp/triton-cache-$USER-$SLURM_JOB_ID
-export VLLM_CACHE_ROOT=/tmp/.vllm_cache_$(whoami)
-
 # Setup environment
 cd $PROJECT_DIR
 [ -f .env ] && source .env
@@ -176,6 +169,10 @@ srun --kill-on-bad-exit=1 bash -c '
 
     INFER_NODE_RANK=$SLURM_PROCID
     LOCAL_IP=$(hostname -I | awk "{print \$1}")
+    # Inference env vars: launcher defaults + [inference.env_vars]
+{%- for key, value in inference_env_vars.items() %}
+    export {{ key }}="{{ value }}"
+{%- endfor %}
 
 {% include '_launch_rank.sh.j2' %}
 {% include '_launch_router.sh.j2' %}
@@ -195,20 +192,11 @@ srun --kill-on-bad-exit=1 bash -c '
 
     # Reconstruct hostnames array
     read -ra HOSTNAMES <<< "$HOSTNAMES_STR"
-
-    export VLLM_WORKER_MULTIPROC_METHOD=spawn
-{%- if use_deep_gemm %}
-    export VLLM_USE_DEEP_GEMM=1
-    export VLLM_MOE_USE_DEEP_GEMM=1
-{%- endif %}
-    export PYTORCH_CUDA_ALLOC_CONF="expandable_segments:False"
     # Bind gloo to the interface that owns LOCAL_IP (the rendezvous IP) — NIC
     # names vary across clusters (bond0, eth0, ...). If the lookup fails, leave
     # GLOO_SOCKET_IFNAME unset so gloo falls back to its own detection.
     GLOO_IFNAME=$(ip -o -4 addr show to "$LOCAL_IP" 2>/dev/null | awk "{print \$2; exit}")
     if [ -n "$GLOO_IFNAME" ]; then export GLOO_SOCKET_IFNAME=$GLOO_IFNAME; fi
-    export VLLM_ENGINE_READY_TIMEOUT_S=4200
-    export UCX_TLS=all
     # Enumerate RDMA NICs for UCX/NIXL from sysfs (ibv_devices is not on the job
     # PATH). Prefer InfiniBand ports and fall back to RoCE: "all" would also pick
     # up non-functional devices (e.g. an Ethernet bond UCX cannot open), which
@@ -251,7 +239,7 @@ srun --kill-on-bad-exit=1 bash -c '
         PORT=$PREFILL_PORT
         HEAD_HOST="${HOSTNAMES[$((REPLICA_BASE + SUB_REPLICA * NODES_PER_PREFILL_REPLICA))]}"
 
-{% for key, value in prefill_env_overrides.items() %}
+{% for key, value in prefill_env_vars.items() %}
         export {{ key }}="{{ value }}"
 {% endfor %}
         ROLE_EXTRA="\"all2all_backend\": \"deepep_high_throughput\"{{ prefill_vllm_extra_json }}"
@@ -266,7 +254,7 @@ srun --kill-on-bad-exit=1 bash -c '
         PORT=$DECODE_PORT
         HEAD_HOST="${HOSTNAMES[$((REPLICA_BASE + NUM_PREFILL_NODES + SUB_REPLICA * NODES_PER_DECODE_REPLICA))]}"
 
-{% for key, value in decode_env_overrides.items() %}
+{% for key, value in decode_env_vars.items() %}
         export {{ key }}="{{ value }}"
 {% endfor %}
         ROLE_EXTRA="\"all2all_backend\": \"deepep_low_latency\", \"compilation_config\": $DECODE_COMPILE_CFG{{ decode_vllm_extra_json }}"
@@ -316,7 +304,6 @@ srun --kill-on-bad-exit=1 bash -c '
     echo "INFER_NODE_RANK=${INFER_NODE_RANK}, LOCAL_IP=${LOCAL_IP}" \
         | tee $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log
 
-    export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False
     DP_PER_NODE={{ dp_per_node }}
     TP=$((GPUS_PER_NODE / DP_PER_NODE))
     EP={{ "1" if enable_expert_parallel else "0" }}
@@ -341,8 +328,6 @@ srun --kill-on-bad-exit=1 bash -c '
     done
 {%- else %}
     echo "INFER_NODE_RANK=${INFER_NODE_RANK}, LOCAL_IP=${LOCAL_IP}" | tee $OUTPUT_DIR/logs/inference/node_${INFER_NODE_RANK}.log
-    # Required for graph compilation to work
-    export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False
 
     uv run inference \
         @ $CONFIG_PATH \

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -64,14 +64,8 @@ rm -f $OUTPUT_DIR/logs/inference/*.log
 ln -sfn trainer/node_0.log $OUTPUT_DIR/logs/trainer.log
 ln -sfn inference/node_0.log $OUTPUT_DIR/logs/inference.log
 
-# General
-export CUDA_DEVICE_ORDER=PCI_BUS_ID
-export PYTHONUNBUFFERED=1
-export OMP_NUM_THREADS=1
-export TRITON_CACHE_DIR=/tmp/triton-cache-$USER-$SLURM_JOB_ID
-
 export WANDB_SHARED_MODE=1
-export WANDB_SHARED_RUN_ID=$(python3 -c "import uuid; print(uuid.uuid4().hex)")
+export WANDB_SHARED_RUN_ID=${WANDB_SHARED_RUN_ID:-$(python3 -c "import uuid; print(uuid.uuid4().hex)")}
 
 # Networking
 HOSTNAMES=( $( scontrol show hostnames $SLURM_JOB_NODELIST ) )
@@ -208,7 +202,6 @@ srun --kill-on-bad-exit=1 bash -c '
 
     # Higher ulimit
     ulimit -n 65536
-    export GIT_LFS_SKIP_SMUDGE=1
 
     # Infiniband setup
     IB_HCA=$(ibv_devinfo | sed -n -e "/hca_id/p" -e "/link_layer:/p" | grep -B1 InfiniBand | grep hca_id | sed -e "s/^hca_id://g" | tr -d "[[:blank:]]" |paste -sd,)
@@ -217,9 +210,11 @@ srun --kill-on-bad-exit=1 bash -c '
 {% if num_infer_nodes > 0 -%}
 
 if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
-    export PYTORCH_CUDA_ALLOC_CONF="expandable_segments:False"
     INFER_NODE_RANK=$SLURM_PROCID
-    export VLLM_WORKER_MULTIPROC_METHOD=spawn
+    # Inference env vars: launcher defaults + [inference.env_vars]
+{%- for key, value in inference_env_vars.items() %}
+    export {{ key }}="{{ value }}"
+{%- endfor %}
     LOCAL_IP=$(hostname -I | awk "{print \$1}")
 
 {%- if kv_offload %}
@@ -242,18 +237,12 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
 {% if is_disaggregated -%}
     # PD disaggregated: NIXL KV transfer + role-based inference
     read -ra HOSTNAMES <<< "$HOSTNAMES_STR"
-{%- if use_deep_gemm %}
-    export VLLM_USE_DEEP_GEMM=1
-    export VLLM_MOE_USE_DEEP_GEMM=1
-{%- endif %}
 
     # Bind gloo to the interface that owns LOCAL_IP (the rendezvous IP) — NIC
     # names vary across clusters (bond0, eth0, ...). If the lookup fails, leave
     # GLOO_SOCKET_IFNAME unset so gloo falls back to its own detection.
     GLOO_IFNAME=$(ip -o -4 addr show to "$LOCAL_IP" 2>/dev/null | awk "{print \$2; exit}")
     if [ -n "$GLOO_IFNAME" ]; then export GLOO_SOCKET_IFNAME=$GLOO_IFNAME; fi
-    export VLLM_ENGINE_READY_TIMEOUT_S=4200
-    export UCX_TLS=all
     # Enumerate RDMA NICs for UCX/NIXL from sysfs (ibv_devices is not on the job
     # PATH). Prefer InfiniBand ports and fall back to RoCE: "all" would also pick
     # up non-functional devices (e.g. an Ethernet bond UCX cannot open), which
@@ -288,7 +277,7 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
         PORT=$PREFILL_PORT
         START_RANK=$((ROLE_RANK * INFERENCE_DP_LOCAL))
         HEAD_HOST="${HOSTNAMES[$((REPLICA_BASE + SUB_REPLICA * NODES_PER_PREFILL_REPLICA))]}"
-{% for key, value in prefill_env_overrides.items() %}
+{% for key, value in prefill_env_vars.items() %}
         export {{ key }}="{{ value }}"
 {% endfor %}
         ROLE_EXTRA="\"all2all_backend\": \"deepep_high_throughput\"{{ prefill_vllm_extra_json }}"
@@ -302,7 +291,7 @@ if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
         PORT=$DECODE_PORT
         START_RANK=$((ROLE_RANK * INFERENCE_DP_LOCAL))
         HEAD_HOST="${HOSTNAMES[$((REPLICA_BASE + NUM_PREFILL_NODES + SUB_REPLICA * NODES_PER_DECODE_REPLICA))]}"
-{% for key, value in decode_env_overrides.items() %}
+{% for key, value in decode_env_vars.items() %}
         export {{ key }}="{{ value }}"
 {% endfor %}
         ROLE_EXTRA="\"all2all_backend\": \"deepep_low_latency\", \"compilation_config\": $DECODE_COMPILE_CFG{{ decode_vllm_extra_json }}"
@@ -385,10 +374,10 @@ else
     TRAIN_NODE_RANK=$SLURM_PROCID
 {%- endif %}
 
-    export HF_HUB_OFFLINE=1
-
-    # This is required for compilation to work correctly
-    export PYTORCH_CUDA_ALLOC_CONF="expandable_segments:True"
+    # Trainer env vars: launcher defaults + [trainer.env_vars]
+{%- for key, value in trainer_env_vars.items() %}
+    export {{ key }}="{{ value }}"
+{%- endfor %}
 
     echo $HOSTNAMES_STR | tee $OUTPUT_DIR/logs/trainer/node_${TRAIN_NODE_RANK}.log
 
@@ -417,6 +406,12 @@ if [ "$SLURM_PROCID" -eq "$ORCH_PROCID" ]; then
     ORCHESTRATOR_ARGS="@ $CONFIG_DIR/orchestrator.toml"
     ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --model.client.base-url $INFER_URLS"
     ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --model.client.admin-base-url $ADMIN_URLS"
+{%- if orchestrator_env_vars %}
+    # Orchestrator env vars from [orchestrator.env_vars]
+{%- for key, value in orchestrator_env_vars.items() %}
+    export {{ key }}="{{ value }}"
+{%- endfor %}
+{%- endif %}
     {% if use_nccl_broadcast %}ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --weight_broadcast.host $MASTER_ADDR"
     {% endif %}WANDB_SHARED_LABEL=orchestrator uv run orchestrator $ORCHESTRATOR_ARGS \
         2>&1 | tee $OUTPUT_DIR/logs/orchestrator.log &

--- a/src/prime_rl/templates/multi_node_rl.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_rl.sbatch.j2
@@ -211,7 +211,7 @@ srun --kill-on-bad-exit=1 bash -c '
 
 if [ "$SLURM_PROCID" -lt "$NUM_INFER_NODES" ]; then
     INFER_NODE_RANK=$SLURM_PROCID
-    # Inference env vars: launcher defaults + [inference.env_vars]
+    # Inference env vars: launcher defaults + [env_vars] + [inference.env_vars]
 {%- for key, value in inference_env_vars.items() %}
     export {{ key }}="{{ value }}"
 {%- endfor %}
@@ -374,7 +374,7 @@ else
     TRAIN_NODE_RANK=$SLURM_PROCID
 {%- endif %}
 
-    # Trainer env vars: launcher defaults + [trainer.env_vars]
+    # Trainer env vars: launcher defaults + [env_vars] + [trainer.env_vars]
 {%- for key, value in trainer_env_vars.items() %}
     export {{ key }}="{{ value }}"
 {%- endfor %}
@@ -407,7 +407,7 @@ if [ "$SLURM_PROCID" -eq "$ORCH_PROCID" ]; then
     ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --model.client.base-url $INFER_URLS"
     ORCHESTRATOR_ARGS="$ORCHESTRATOR_ARGS --model.client.admin-base-url $ADMIN_URLS"
 {%- if orchestrator_env_vars %}
-    # Orchestrator env vars from [orchestrator.env_vars]
+    # Orchestrator env vars from [env_vars] + [orchestrator.env_vars]
 {%- for key, value in orchestrator_env_vars.items() %}
     export {{ key }}="{{ value }}"
 {%- endfor %}

--- a/src/prime_rl/templates/multi_node_sft.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_sft.sbatch.j2
@@ -36,12 +36,6 @@ export OUTPUT_DIR={{ output_dir }}
 mkdir -p $OUTPUT_DIR/logs/trainer
 ln -sfn trainer/node_0.log $OUTPUT_DIR/logs/trainer.log
 
-# General
-export CUDA_DEVICE_ORDER=PCI_BUS_ID
-export PYTHONUNBUFFERED=1
-export OMP_NUM_THREADS=1
-export TRITON_CACHE_DIR=/tmp/triton-cache-$USER-$SLURM_JOB_ID
-
 # Networking
 export HOSTNAMES=( $( scontrol show hostnames $SLURM_JOB_NODELIST ) )
 echo "HOSTNAMES=${HOSTNAMES[@]}"
@@ -101,7 +95,6 @@ srun --kill-on-bad-exit=1 bash -c '
 
     # Higher ulimit
     ulimit -n 65536
-    export GIT_LFS_SKIP_SMUDGE=1
 
     # Infiniband setup
     IB_HCA=$(ibv_devinfo | sed -n -e "/hca_id/p" -e "/link_layer:/p" | grep -B1 InfiniBand | grep hca_id | sed -e "s/^hca_id://g" | tr -d "[[:blank:]]" |paste -sd,)
@@ -109,10 +102,10 @@ srun --kill-on-bad-exit=1 bash -c '
 
     TRAIN_NODE_RANK=$SLURM_PROCID
 
-    export HF_HUB_OFFLINE=1
-
-    # This is required for compilation to work correctly
-    export PYTORCH_CUDA_ALLOC_CONF="expandable_segments:True"
+    # Trainer env vars: launcher defaults + [sft.env_vars]
+{%- for key, value in trainer_env_vars.items() %}
+    export {{ key }}="{{ value }}"
+{%- endfor %}
 
     echo $HOSTNAMES | tee $OUTPUT_DIR/logs/trainer/node_${TRAIN_NODE_RANK}.log
     uv run torchrun \

--- a/src/prime_rl/templates/multi_node_sft.sbatch.j2
+++ b/src/prime_rl/templates/multi_node_sft.sbatch.j2
@@ -102,7 +102,7 @@ srun --kill-on-bad-exit=1 bash -c '
 
     TRAIN_NODE_RANK=$SLURM_PROCID
 
-    # Trainer env vars: launcher defaults + [sft.env_vars]
+    # Trainer env vars: launcher defaults + [env_vars]
 {%- for key, value in trainer_env_vars.items() %}
     export {{ key }}="{{ value }}"
 {%- endfor %}

--- a/src/prime_rl/utils/process.py
+++ b/src/prime_rl/utils/process.py
@@ -13,6 +13,26 @@ from prime_rl.utils.logger import get_logger
 PRIME_RL_PROC_PREFIX = "PRIME-RL"
 
 
+# Applied to every launched component (trainer, orchestrator, inference).
+DEFAULT_COMMON_ENV_VARS: dict[str, str] = {
+    "CUDA_DEVICE_ORDER": "PCI_BUS_ID",
+    "PYTHONUNBUFFERED": "1",
+    "OMP_NUM_THREADS": "1",
+    "GIT_LFS_SKIP_SMUDGE": "1",
+}
+
+DEFAULT_TRAINER_ENV_VARS: dict[str, str] = {
+    "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
+}
+
+DEFAULT_INFERENCE_ENV_VARS: dict[str, str] = {
+    "VLLM_WORKER_MULTIPROC_METHOD": "spawn",
+    "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:False",
+    "VLLM_ENGINE_READY_TIMEOUT_S": "4200",
+    "UCX_TLS": "all",
+}
+
+
 def set_proc_title(name: str) -> None:
     """Set the process title for visibility in tools like ``ps`` and ``htop``.
 


### PR DESCRIPTION
## Summary

Consolidate environment-variable handling for **RL and SFT**: env vars are set **per component** from config, with one precedence model applied uniformly across single-node and multi-node (SLURM) launches.

- **Per-component `env_vars`**: `[trainer.env_vars]`, `[orchestrator.env_vars]`, `[inference.env_vars]` (RL) and `[sft.env_vars]` (SFT). Disaggregated inference keeps `deployment.{prefill,decode}_env_vars` layered on top per role.
- **Single source of truth for launcher defaults** in `utils/process.py`: `DEFAULT_COMMON_ENV_VARS` (every component), `DEFAULT_TRAINER_ENV_VARS`, `DEFAULT_INFERENCE_ENV_VARS`. No static defaults are hardcoded in the sbatch templates anymore.
- **Precedence (low → high):** `os.environ` < launcher defaults < `[component.env_vars]` < **protected** (`CUDA_VISIBLE_DEVICES`, `WANDB_SHARED_*`). Single-node builds the env inline at each launch site; multi-node templates loop the merged dict; standalone `uv run inference` applies it in `inference_local`.
- **Protected vars are enforced, not just documented:** setting `CUDA_VISIBLE_DEVICES` or `WANDB_SHARED_*` in any `env_vars` now fails config validation (`reject_protected_env_vars` / `PROTECTED_ENV_VARS`).
- **Deep-GEMM** (`VLLM_USE_DEEP_GEMM`/`VLLM_MOE_USE_DEEP_GEMM`) is driven solely by `config.use_deep_gemm` via `setup_vllm_env` — single source (removed the hardcoded template export and a redundant config validator).
- `HF_HUB_OFFLINE` and `WANDB_SHARED_RUN_ID` now read from the environment, falling back to the default if unset.
- Multi-node uses a single `uv sync --all-extras` on the batch node; the checkout + venv are expected on a **shared filesystem** (documented in `scaling.md`).

## Changed defaults

Multi-node values are preserved (just moved into `DEFAULT_*`). The material changes are single-node parity + two removals:

| Path | Newly applied / changed |
|---|---|
| **single-node inference** | now inherits `DEFAULT_INFERENCE`: `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False`, `VLLM_WORKER_MULTIPROC_METHOD=spawn`, `VLLM_ENGINE_READY_TIMEOUT_S=4200` (vLLM 0.23 default is **600**), `UCX_TLS=all`; plus `DEFAULT_COMMON` (`CUDA_DEVICE_ORDER`, `OMP_NUM_THREADS=1`, `GIT_LFS_SKIP_SMUDGE`). Previously single-node inference set only `CUDA_VISIBLE_DEVICES`. |
| **single-node RL trainer / orchestrator / SFT** | now get `DEFAULT_COMMON` — notably `OMP_NUM_THREADS=1` (was unset single-node, i.e. all cores). |
| **all (multi-node)** | **removed** `TRITON_CACHE_DIR` and inference `VLLM_CACHE_ROOT`. |

## Breaking

- **Config rename:** `deployment.prefill_env_overrides` → `deployment.prefill_env_vars` and `deployment.decode_env_overrides` → `deployment.decode_env_vars` (no back-compat alias). The one in-repo config using the old names (`configs/glm5.2_16node_llmd/inference.toml`) is updated; update any external disaggregated configs.
- **Protected keys rejected:** a `[component.env_vars]` (or `deployment.{prefill,decode}_env_vars`) setting `CUDA_VISIBLE_DEVICES` or `WANDB_SHARED_*` now raises at config-parse, instead of being silently ineffective (or, on multi-node, overriding the shared W&B run id). No in-repo config does this.

## Docs

- `docs/configuration.md` — `[component.env_vars]` model + precedence rules.
- `docs/scaling.md` — shared-filesystem venv expectation for SLURM.
- `docs/inference.md` — the P/D env-var rename.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all launch paths (single-node, SLURM, standalone inference) and changes default process environment (e.g. single-node `OMP_NUM_THREADS`, inference vLLM timeouts), which can affect performance or stability; protected-var validation is a breaking config change for anyone overriding W&B or GPU visibility via TOML.
> 
> **Overview**
> Adds **configurable `env_vars`** across RL, SFT, and inference, with launcher defaults centralized in `utils/process.py` (`DEFAULT_COMMON_ENV_VARS`, `DEFAULT_TRAINER_ENV_VARS`, `DEFAULT_INFERENCE_ENV_VARS`) instead of hardcoded exports in sbatch templates.
> 
> **RL** gets top-level `[env_vars]` plus `[trainer.env_vars]`, `[orchestrator.env_vars]`, and `[inference.env_vars]`; **SFT** and **inference** get their own `[env_vars]`. Single-node launchers merge defaults → shared → component env at each `Popen`; SLURM templates loop merged dicts (`trainer_env_vars`, etc.). Standalone `uv run inference` applies the same merge in-process before `setup_vllm_env`.
> 
> **Disaggregated P/D** renames `prefill_env_overrides` / `decode_env_overrides` → **`prefill_env_vars` / `decode_env_vars`** (breaking, no alias). **`EnvVars`** validation rejects `CUDA_VISIBLE_DEVICES` and `WANDB_SHARED_*` in user config.
> 
> Docs cover precedence and shared-filesystem venv for SLURM. Notable behavior shifts: single-node inference/trainer now inherit the same default env as multi-node; **`TRITON_CACHE_DIR`** and **`VLLM_CACHE_ROOT`** are removed from templates; **`WANDB_SHARED_RUN_ID`** can be preset via the environment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 676a4fb16edba0664b6cb4db2085fb91449f2a0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->