### PR TITLE
fix(orchestrator): align gibberish/repetition filters to v1 branch streams

### DIFF
--- a/src/prime_rl/orchestrator/filters.py
+++ b/src/prime_rl/orchestrator/filters.py
@@ -51,10 +51,11 @@ class GibberishFilter:
 
     def check(self, rollout: Rollout) -> FilterResult:
         global_idx = 0
-        for node in rollout.nodes:
-            # token_ids / logprobs / mask are per-token aligned; check only the
-            # sampled completion tokens, pairing each with its own logprob.
-            for token_id, logprob, sampled in zip(node.token_ids, node.logprobs, node.mask):
+        for branch in rollout.branches:
+            # branch.{token_ids,logprobs,sampled_mask} are flat and mutually aligned; the raw
+            # node arrays are not (node.logprobs covers only the sampled suffix, not the
+            # generation-prompt scaffold that token_ids/mask also span).
+            for token_id, logprob, sampled in zip(branch.token_ids, branch.logprobs, branch.sampled_mask):
                 if not sampled:
                     continue
                 if token_id > self.token_id_threshold and logprob < self.logprob_threshold:
@@ -81,12 +82,13 @@ class RepetitionFilter:
     enforce: bool = False
 
     def check(self, rollout: Rollout) -> FilterResult:
-        consecutive = 0
         global_idx = 0
-        for node in rollout.nodes:
-            # Streak only over sampled completion tokens — context/prompt tokens
-            # (mask=False) are not model-generated and must not feed the loop count.
-            for logprob, sampled in zip(node.logprobs, node.mask):
+        for branch in rollout.branches:
+            # Aligned branch streams (see GibberishFilter), and reset the streak per branch:
+            # flat rollout.nodes interleaves distinct root->leaf paths (compaction/subagents),
+            # so a per-node walk would run a streak across a branch boundary.
+            consecutive = 0
+            for logprob, sampled in zip(branch.logprobs, branch.sampled_mask):
                 if not sampled:
                     continue
                 if logprob > self.logprob_threshold:

--- a/tests/unit/orchestrator/test_filters.py
+++ b/tests/unit/orchestrator/test_filters.py
@@ -25,6 +25,21 @@ def _assistant_node(token_ids: list[int], logprobs: list[float]) -> vf.MessageNo
     )
 
 
+def _scaffold_assistant_node(
+    completion_ids: list[int], completion_logprobs: list[float], *, scaffold: int = 2
+) -> vf.MessageNode:
+    """A realistic v1 assistant node: a leading generation-prompt scaffold (mask=False, not
+    model-sampled) then the sampled completion. ``logprobs`` cover only the completion suffix
+    (vLLM returns logprobs for generated tokens only) — the exact layout where per-node
+    ``zip(token_ids, logprobs, mask)`` mispairs and the branch streams normalize."""
+    return vf.MessageNode(
+        message=vf.AssistantMessage(content="x"),
+        token_ids=[1] * scaffold + completion_ids,
+        mask=[False] * scaffold + [True] * len(completion_ids),
+        logprobs=completion_logprobs,
+    )
+
+
 def _make_rollout(
     completion_ids: list[int],
     completion_logprobs: list[float],
@@ -114,6 +129,24 @@ def test_gibberish_works_across_trajectory_steps():
     )
     assert result.detected is True
     assert result.detection_index == 2
+
+
+def test_gibberish_aligns_logprobs_under_generation_prompt_scaffold():
+    """Regression: the assistant node carries a generation-prompt scaffold (mask=False) and
+    suffix-only logprobs, and the gibberish token is the LAST completion token. The old
+    per-node ``zip(token_ids, logprobs, mask)`` truncated at len(logprobs) and never examined
+    it; reading the aligned branch streams detects it."""
+    gibberish_filter = _make_gibberish_filter()
+
+    rollout = Rollout[vf.Task](
+        task=vf.Task(idx=0, prompt=""),
+        nodes=[_scaffold_assistant_node([50, 80, 120_000], [-1.0, -0.5, gibberish_filter.logprob_threshold - 1.0])],
+        rewards={"reward": 1.0},
+    )
+
+    result = gibberish_filter.check(rollout)
+    assert result.detected is True
+    assert result.detection_index == 2  # third sampled completion token (scaffold skipped)
 
 
 # --- RepetitionFilter tests ---


### PR DESCRIPTION
## What

`GibberishFilter` and `RepetitionFilter` (`orchestrator/filters.py`) walk `rollout.nodes` and `zip(node.token_ids, node.logprobs, node.mask)` as if all three were per-token aligned. Under the v1 message graph they are **not**:

- a node's `logprobs` cover only its **sampled suffix** (`len == True entries in mask`), while
- `token_ids` / `mask` span the **whole node** including the generation-prompt scaffold (the leading `mask=False` tokens).

So `zip()` stops at `len(logprobs)` and:

1. **drops the tail completion tokens** of every turn (and for a completion shorter than its scaffold, examines *none* of its tokens — the filter silently never fires); and
2. **mispairs the survivors** with the wrong logprob (offset by the scaffold length).

`RepetitionFilter` has a second bug: it carries its consecutive-streak across the flat `nodes` list, which interleaves nodes from distinct root→leaf paths under compaction/subagents — so a high-confidence run is counted **across a branch boundary** and can false-trigger.

## Fix

Iterate `rollout.branches` and read `branch.token_ids` / `branch.logprobs` / `branch.sampled_mask` — verifiers already builds these full-length and correctly aligned (completion logprobs spread onto the sampled positions, `0.0` elsewhere). Reset the repetition streak at each branch boundary. Linear (single-branch) rollouts are unaffected by the reset but still get the logprob-alignment fix.

## Impact

Both filters default to `enforce=False` (detect-only), so the common case is **corrupted detection metrics**. Runs with `enforce=True` get **wrong filtering** — dropping/keeping rollouts based on mispaired logprobs and an under-scanned token set.

## How it was found

Surfaced by a verifiers-v1 redundancy audit of prime-rl: these filters hand-rolled a per-token view that `vf.Branch` already exposes flat and correctly aligned. The dedup *is* the fix.

## Validation

Verified against `main`'s own verifiers pin (`b055799fc`) in a fresh worktree off `origin/main`:

- `uv run pytest tests/unit/orchestrator/test_filters.py` — **23 passed** on the fix.
- The existing tests missed the bug because their `_assistant_node` modeled a node with **no** generation-prompt scaffold (`mask` all `True`, `logprobs` 1:1 with `token_ids`). Added a regression test — `test_gibberish_aligns_logprobs_under_generation_prompt_scaffold` — using a realistic scaffold + suffix-logprob node where the gibberish token is the **last** completion token (the one the old `zip` dropped). It **fails on the unmodified `main` filter** (`assert False is True`) and **passes** on the branch-stream version.

The `RepetitionFilter` per-branch streak reset is also part of this change (it only affects multi-branch rollouts from compaction/subagents); single-branch rollouts are unchanged by it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout filtering and detection metrics for training data quality; behavior is more correct but may shift which rollouts are flagged or dropped when enforce=True.
> 
> **Overview**
> **Gibberish** and **repetition** rollout filters no longer walk `rollout.nodes` with `zip(token_ids, logprobs, mask)`. They iterate **`rollout.branches`** and use **`branch.token_ids`**, **`branch.logprobs`**, and **`branch.sampled_mask`**, which stay aligned when v1 assistant nodes include a generation-prompt scaffold (`mask=False`) and suffix-only logprobs.
> 
> **RepetitionFilter** resets its high-confidence streak at each branch boundary so compaction/subagent rollouts do not count consecutive tokens across unrelated paths.
> 
> Adds **`test_gibberish_aligns_logprobs_under_generation_prompt_scaffold`** with a scaffolded assistant node where the flagged token is the last completion token (previously skipped by truncated `zip`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88178c03cf05fdd4875c5b093e88a5ad4e2d8a34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->