### PR TITLE
chore(client): remove dead InferencePool.get_metrics()

### DIFF
--- a/src/prime_rl/utils/client.py
+++ b/src/prime_rl/utils/client.py
@@ -73,10 +73,6 @@ class InferencePool(Protocol):
         """Update weights on all inference servers."""
         ...
 
-    def get_metrics(self) -> dict[str, float]:
-        """Get pool metrics."""
-        ...
-
     async def stop(self) -> None:
         """Stop the inference pool."""
         ...
@@ -140,9 +136,6 @@ class StaticInferencePool:
 
     async def update_weights(self, weight_dir: Path | None, lora_name: str | None = None, step: int = 0) -> None:
         await update_weights(self._admin_clients, weight_dir, lora_name=lora_name, step=step)
-
-    def get_metrics(self) -> dict[str, float]:
-        return {}
 
     async def stop(self) -> None:
         pass

--- a/src/prime_rl/utils/elastic.py
+++ b/src/prime_rl/utils/elastic.py
@@ -499,10 +499,3 @@ class ElasticInferencePool:
         if lora_name is None:
             raise ValueError("Elastic inference pool requires LoRA training (lora_name must be set)")
         await self.sync_weights(weight_dir, lora_name, step)
-
-    def get_metrics(self) -> dict[str, float]:
-        return {
-            "elastic/num_servers": self.num_servers,
-            "elastic/num_ready_servers": self.num_ready_servers,
-            "elastic/desired_step": self._desired.step,
-        }


### PR DESCRIPTION
`get_metrics` is declared on the `InferencePool` Protocol and implemented by `StaticInferencePool` (returns `{}`) and `ElasticInferencePool`, but **nothing calls it** — no literal call site, no reflective/string access, no polymorphic dispatch anywhere in `src/`, `tests/`, `packages/`, or `scripts/`. Inference metrics flow through `InferenceMetricsCollector` over the admin clients, not the pool.

Dead method on all three; remove it. Import smoke passes.

Surfaced by the verifiers-v1 redundancy audit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead API removal only; no call sites and no change to weight sync, discovery, or metrics collection paths.
> 
> **Overview**
> Removes **`get_metrics()`** from the **`InferencePool`** protocol and from **`StaticInferencePool`** and **`ElasticInferencePool`**, where it was unused (empty dict vs elastic server counts). Inference observability stays on **`InferenceMetricsCollector`** via admin clients, not the pool API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec4d39b97da52433a628305ef89898e0192fc0f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->