### PR TITLE
chore(configs): remove dead BaseModelConfig.is_vlm property

### DIFF
--- a/packages/prime-rl-configs/src/prime_rl/configs/shared.py
+++ b/packages/prime-rl-configs/src/prime_rl/configs/shared.py
@@ -83,10 +83,6 @@ class BaseModelConfig(BaseConfig):
     vlm: "VLMConfig | None" = None
     """VLM configuration. Setting this enables vision-language model support."""
 
-    @property
-    def is_vlm(self) -> bool:
-        return self.vlm is not None
-
 
 class ElasticConfig(BaseConfig):
     hostname: str


### PR DESCRIPTION
The `is_vlm` property on `BaseModelConfig` has **no readers** anywhere — code that needs the check uses `config.vlm is not None` directly (e.g. `trainer/model.py`). It's a plain `@property` (not a `computed_field`), so pydantic never serialized it. Remove it.

Unrelated and untouched: the `_is_vlm` private attr on the Qwen model class, and the `is_vlm_architecture` HF-config helper in `utils/vlm.py`.

Surfaced by the verifiers-v1 redundancy audit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure removal of an unread helper with no references; no runtime or config semantics change.
> 
> **Overview**
> Removes the unused **`is_vlm`** `@property` from **`BaseModelConfig`** in `shared.py`. It duplicated **`vlm is not None`** and had no call sites; VLM checks elsewhere already use the **`vlm`** field directly (e.g. trainer model loading and config validators).
> 
> No behavior or API change for consumers—only dead code cleanup from the verifiers-v1 redundancy audit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a52ab2f6de831c5939721be8c6a9af27c449bb23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->