### PR TITLE
chore(filters): remove unconsumed FilterResult.detection_index

### DIFF
--- a/src/prime_rl/orchestrator/filters.py
+++ b/src/prime_rl/orchestrator/filters.py
@@ -22,7 +22,6 @@ if TYPE_CHECKING:
 @dataclass
 class FilterResult:
     detected: bool
-    detection_index: int | None = None
 
 
 class RolloutFilter(Protocol):
@@ -50,7 +49,6 @@ class GibberishFilter:
     enforce: bool = False
 
     def check(self, rollout: Rollout) -> FilterResult:
-        global_idx = 0
         for branch in rollout.branches:
             # branch.{token_ids,logprobs,sampled_mask} are flat and mutually aligned; the raw
             # node arrays are not (node.logprobs covers only the sampled suffix, not the
@@ -59,8 +57,7 @@ class GibberishFilter:
                 if not sampled:
                     continue
                 if token_id > self.token_id_threshold and logprob < self.logprob_threshold:
-                    return FilterResult(detected=True, detection_index=global_idx)
-                global_idx += 1
+                    return FilterResult(detected=True)
         return FilterResult(detected=False)
 
 
@@ -82,7 +79,6 @@ class RepetitionFilter:
     enforce: bool = False
 
     def check(self, rollout: Rollout) -> FilterResult:
-        global_idx = 0
         for branch in rollout.branches:
             # Aligned branch streams (see GibberishFilter), and reset the streak per branch:
             # flat rollout.nodes interleaves distinct root->leaf paths (compaction/subagents),
@@ -96,8 +92,7 @@ class RepetitionFilter:
                 else:
                     consecutive = 0
                 if consecutive >= self.window:
-                    return FilterResult(detected=True, detection_index=global_idx)
-                global_idx += 1
+                    return FilterResult(detected=True)
         return FilterResult(detected=False)
 
 

--- a/tests/unit/orchestrator/test_filters.py
+++ b/tests/unit/orchestrator/test_filters.py
@@ -89,7 +89,6 @@ def test_gibberish_detects_rare_low_prob_token():
         )
     )
     assert result.detected is True
-    assert result.detection_index == 1
 
 
 def test_gibberish_ignores_normal_tokens():
@@ -102,7 +101,6 @@ def test_gibberish_ignores_normal_tokens():
         )
     )
     assert result.detected is False
-    assert result.detection_index is None
 
 
 def test_gibberish_ignores_high_prob_rare_token():
@@ -128,7 +126,6 @@ def test_gibberish_works_across_trajectory_steps():
         )
     )
     assert result.detected is True
-    assert result.detection_index == 2
 
 
 def test_gibberish_aligns_logprobs_under_generation_prompt_scaffold():
@@ -146,7 +143,6 @@ def test_gibberish_aligns_logprobs_under_generation_prompt_scaffold():
 
     result = gibberish_filter.check(rollout)
     assert result.detected is True
-    assert result.detection_index == 2  # third sampled completion token (scaffold skipped)
 
 
 # --- RepetitionFilter tests ---
@@ -162,7 +158,6 @@ def test_repetition_triggers_after_window():
         )
     )
     assert result.detected is True
-    assert result.detection_index == 4
 
 
 def test_repetition_no_trigger_below_window():


### PR DESCRIPTION
`detection_index` was set by `GibberishFilter`/`RepetitionFilter` on a hit but has **no production consumer** — `apply_filters` reads only `result.detected`, and the state that flows onto the `Rollout` is `filter_results: dict[str, bool]` + `is_filtered: bool` (no index). Never logged, serialized, or turned into a metric; only unit tests asserted it.

Removes the field, the per-token `global_idx` bookkeeping that existed solely to populate it (both filters), and the 5 test assertions. `RepetitionFilter`'s independent `consecutive` streak counter stays. **23 filter tests pass.**

Surfaced by the verifiers-v1 redundancy audit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-field removal with no production consumers; filter detection semantics and `apply_filters` behavior are unchanged.
> 
> **Overview**
> Removes **`FilterResult.detection_index`** and the per-token **`global_idx`** loops in **`GibberishFilter`** and **`RepetitionFilter`** that only existed to populate it. Detection behavior is unchanged: filters still return **`FilterResult(detected=True/False)`**, and **`apply_filters`** still keys off **`result.detected`** only.
> 
> Unit tests drop the five assertions that checked **`detection_index`**; **`detected`** expectations are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83ef3f14ae258ec5c1f3998a0d7f0099e0bff8a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->