### PR TITLE
fix(orchestrator): eval completion_len is always 0 on the token-less relay

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "setproctitle>=1.3.0",
     "uvloop>=0.21.0",
     "torchtitan",
-    "verifiers>=0.1.15.dev394",
+    "verifiers>=0.1.15.dev396",
     "renderers",
     "dion",
     "tilelang>=0.1.8",
@@ -168,7 +168,7 @@ override-dependencies = [
     "transformers==5.6.2",
     "torch>=2.9.0",
     "openenv-core",
-    "verifiers>=0.1.15.dev394",
+    "verifiers>=0.1.15.dev396",
 ]
 
 # ModelExpress 0.3.0 publishes protobuf<6 metadata, but its generated proto is

--- a/src/prime_rl/orchestrator/eval_sink.py
+++ b/src/prime_rl/orchestrator/eval_sink.py
@@ -131,10 +131,7 @@ class EvalSink:
 
         if valid:
             rewards = [r.reward for r in valid]
-            # completion_len is token-id-derived, so it's 0 on the token-less eval relay
-            # (openai_chat_completions); fall back to provider-reported usage per branch,
-            # as verifiers' own eval dashboard does.
-            lens = [sum(b.completion_len or b.num_completion_tokens for b in r.branches) for r in valid]
+            lens = [sum(b.output_len for b in r.branches) for r in valid]
             metrics.group_size = self.group_size_for(env_name)
             metrics.reward_mean = float(sum(rewards) / len(rewards))
             metrics.completion_len_mean = float(sum(lens) / len(lens))

--- a/src/prime_rl/orchestrator/eval_sink.py
+++ b/src/prime_rl/orchestrator/eval_sink.py
@@ -131,7 +131,10 @@ class EvalSink:
 
         if valid:
             rewards = [r.reward for r in valid]
-            lens = [r.completion_len for r in valid]
+            # completion_len is token-id-derived, so it's 0 on the token-less eval relay
+            # (openai_chat_completions); fall back to provider-reported usage per branch,
+            # as verifiers' own eval dashboard does.
+            lens = [sum(b.completion_len or b.num_completion_tokens for b in r.branches) for r in valid]
             metrics.group_size = self.group_size_for(env_name)
             metrics.reward_mean = float(sum(rewards) / len(rewards))
             metrics.completion_len_mean = float(sum(lens) / len(lens))


### PR DESCRIPTION
## Problem

Eval reports `eval/<env>/completion_len/{mean,max,min}` — but they are **always 0**.

`eval_sink.process_batch` read the mask-derived length, but eval rollouts come from the **token-less `openai_chat_completions` relay** (`orchestrator/utils.py`: `eval_client_type="openai_chat_completions"`), whose responses carry provider-reported `usage` but **no token ids**. With no tokens there is no mask, so the length is `0` for every eval rollout and the metric flat-lines at 0 — silently, since `0` looks plausible on a dashboard.

(Training is unaffected: it uses the `renderer` client, which returns token ids, so the mask-derived length is real there.)

## Fix

Sum the best-available per-branch length over branches:

```python
lens = [sum(b.output_len for b in r.branches) for r in valid]
```

`Branch.output_len` is `completion_len or num_completion_tokens` — added upstream in [verifiers#1875](https://github.com/PrimeIntellect-ai/verifiers/pull/1875). Token-id counts stay authoritative when present; provider `usage` is the fallback when the endpoint returns no token ids. Folding the fallback into one accessor means the policy lives in verifiers, not duplicated between prime-rl and verifiers' own eval dashboard (which uses the same accessor).

Two commits:
1. `fix(orchestrator)` — the eval_sink fallback fix.
2. `chore(deps)` — bump `deps/verifiers` to `0.1.15.dev396` (`62dc38a5`, the #1875 merge) and the two pyproject floors `dev394 → dev396`, then adopt `Branch.output_len`. `uv.lock` is unchanged (verifiers is an editable submodule, so its floor isn't mirrored in the lock).

## Branch summing is safe

Summing over branches does **not** double-count. Current harnesses fork only at **non-sampled** message boundaries — compaction (`compact` harness = fresh `[system, notes]` per turn) and `rlm` subagents (own context window) — so a shared prefix never carries sampled tokens, and completions partition cleanly across branches. (A fork *after* a sampled turn — MCTS / best-of-N — would double-count, but no built-in harness produces that shape.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to eval metric aggregation and a dependency floor bump; no auth, training, or rollout execution logic touched.
> 
> **Overview**
> Fixes **eval** `completion_len/{mean,max,min}` reporting when rollouts use the token-less **`openai_chat_completions`** relay: aggregation no longer uses mask-derived `r.completion_len` (always **0** without token ids) and instead totals per-rollout length as **`sum(b.output_len for b in r.branches)`**, using verifiers’ **`Branch.output_len`** (`completion_len` when present, else provider **`usage`** token counts).
> 
> Bumps the **`verifiers`** floor from **`0.1.15.dev394`** to **`0.1.15.dev396`** in `pyproject.toml` (main deps and `override-dependencies`) so that accessor is available. Training paths that still have real tokens are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e69f784dde9e2a7d82f288c58a096ca883d501a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

