### PR TITLE
chore(utils): remove dead processor= path from chat_template

### DIFF
--- a/src/prime_rl/utils/chat_template.py
+++ b/src/prime_rl/utils/chat_template.py
@@ -92,17 +92,11 @@ def render_messages(
     tools: list[dict[str, Any]] | None = None,
     chat_template_kwargs: dict[str, Any] | None = None,
     add_generation_prompt: bool = False,
-    processor=None,
 ) -> list[int]:
     kwargs = dict(chat_template_kwargs or {})
     kwargs["add_generation_prompt"] = add_generation_prompt
     if tools is not None:
         kwargs["tools"] = tools
-    if processor is not None:
-        kwargs["tokenize"] = True
-        kwargs["return_dict"] = True
-        result = processor.apply_chat_template(messages, **kwargs)
-        return list(result["input_ids"][0])
     kwargs["return_dict"] = False
     return list(tokenizer.apply_chat_template(messages, **kwargs))
 
@@ -115,7 +109,6 @@ def build_incremental_token_mask(
     tools: list[dict[str, Any]] | None = None,
     chat_template_kwargs: dict[str, Any] | None = None,
     collapse_consecutive_tool_messages: bool = False,
-    processor=None,
 ) -> tuple[list[int], list[bool]]:
     token_mask: list[bool] = []
     prev_ids: list[int] = []
@@ -133,7 +126,6 @@ def build_incremental_token_mask(
             tools=tools,
             chat_template_kwargs=chat_template_kwargs,
             add_generation_prompt=should_add_generation_prompt(messages, idx),
-            processor=processor,
         )
 
         if prev_ids != cur_ids[:prev_len]:


### PR DESCRIPTION
## What

Removes the dead `processor=` parameter and its branch from `render_messages` / `build_incremental_token_mask` in `utils/chat_template.py`.

## Why

The `processor=` path was added to tokenize VLM inputs (image-patch expansion) via `processor.apply_chat_template`. VLM tokenization has since moved entirely into the renderer layer, which owns the processor internally. The parameter is now dead:

- `render_messages` has no external callers (only the internal call in `build_incremental_token_mask`).
- The sole caller of `build_incremental_token_mask` — `trainer/sft/data.py` — never passes `processor=`; for VLM it routes through the renderer (`build_training_sample`) instead, bypassing this path entirely.
- Nothing anywhere passes `processor=` to either function.

The unreachable branch was also misleading: it implied VLM tokenization lives in `chat_template.py` when it is renderer-owned. The `tokenizer.apply_chat_template` path (the only one ever taken) and both function signatures-as-used are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal with no callers passing `processor=`; runtime behavior for existing SFT tokenization is unchanged.
> 
> **Overview**
> Removes the unused **`processor=`** argument and the **`processor.apply_chat_template`** branch from **`render_messages`** and **`build_incremental_token_mask`** in `utils/chat_template.py`.
> 
> Tokenization on the only path that was ever used is unchanged: **`tokenizer.apply_chat_template`** with the same kwargs. VLM / multi-modal SFT already goes through the renderer layer, not these helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9521272fd7f4b03851c0801f7c84b477e7bc517e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->