### PR TITLE
feat: vLLM 0.23 bump + GLM-5.2 16-node P/D inference config (mooncake + llm-d)

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -98,6 +98,18 @@ RUN --mount=type=cache,target=/app/.cache/uv \
     && \
     uv sync --extra flash-attn --extra flash-attn-3 --extra flash-attn-cute --extra envs --extra gpt-oss --extra modelexpress --group mamba-ssm --locked --no-dev
 
+# Build NIXL from source against the UCX 1.19 baked above. The PyPI nixl wheel
+# ships its own UCX which segfaults on prefill→decode KV transfer (#2883);
+# rebuilding against our UCX is the documented fix.
+ARG NIXL_VERSION=0.10.1
+RUN git clone --depth 1 --branch ${NIXL_VERSION} https://github.com/ai-dynamo/nixl.git /tmp/nixl \
+    && cd /tmp/nixl \
+    && PKG_CONFIG_PATH=/opt/ucx/lib/pkgconfig \
+       LD_LIBRARY_PATH=/opt/ucx/lib:/opt/ucx/lib/ucx \
+       /app/.venv/bin/python -m pip wheel . --no-deps --wheel-dir=/app/deps \
+    && /app/.venv/bin/pip install --reinstall --no-deps /app/deps/nixl_cu12-*.whl \
+    && rm -rf /tmp/nixl /app/deps/nixl_cu12-*.whl
+
 # arm64: build flash-attn from source, fix namespace conflicts, apply workarounds
 ARG TARGETARCH
 COPY scripts/docker-arm64-post-install.sh /app/scripts/docker-arm64-post-install.sh

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -98,17 +98,22 @@ RUN --mount=type=cache,target=/app/.cache/uv \
     && \
     uv sync --extra flash-attn --extra flash-attn-3 --extra flash-attn-cute --extra envs --extra gpt-oss --extra modelexpress --group mamba-ssm --locked --no-dev
 
-# Build NIXL from source against the UCX 1.19 baked above. The PyPI nixl wheel
-# ships its own UCX which segfaults on prefill→decode KV transfer (#2883);
-# rebuilding against our UCX is the documented fix.
+# Optional: build NIXL from source against the UCX 1.19 baked above. The PyPI
+# nixl wheel ships its own UCX which segfaults on prefill→decode KV transfer
+# (#2883); rebuilding against our UCX is the documented fix. Only needed for
+# the disaggregated P/D path — default off so training-only / single-node
+# inference builds are unaffected. Enable via `--build-arg INCLUDE_NIXL_FROM_SOURCE=1`.
+ARG INCLUDE_NIXL_FROM_SOURCE=0
 ARG NIXL_VERSION=0.10.1
-RUN git clone --depth 1 --branch ${NIXL_VERSION} https://github.com/ai-dynamo/nixl.git /tmp/nixl \
-    && cd /tmp/nixl \
-    && PKG_CONFIG_PATH=/opt/ucx/lib/pkgconfig \
-       LD_LIBRARY_PATH=/opt/ucx/lib:/opt/ucx/lib/ucx \
-       /app/.venv/bin/python -m pip wheel . --no-deps --wheel-dir=/app/deps \
-    && /app/.venv/bin/pip install --reinstall --no-deps /app/deps/nixl_cu12-*.whl \
-    && rm -rf /tmp/nixl /app/deps/nixl_cu12-*.whl
+RUN if [ "$INCLUDE_NIXL_FROM_SOURCE" = "1" ]; then \
+        git clone --depth 1 --branch ${NIXL_VERSION} https://github.com/ai-dynamo/nixl.git /tmp/nixl \
+        && cd /tmp/nixl \
+        && PKG_CONFIG_PATH=/opt/ucx/lib/pkgconfig \
+           LD_LIBRARY_PATH=/opt/ucx/lib:/opt/ucx/lib/ucx \
+           /app/.venv/bin/python -m pip wheel . --no-deps --wheel-dir=/app/deps \
+        && /app/.venv/bin/pip install --reinstall --no-deps /app/deps/nixl_cu12-*.whl \
+        && rm -rf /tmp/nixl /app/deps/nixl_cu12-*.whl; \
+    fi
 
 # arm64: build flash-attn from source, fix namespace conflicts, apply workarounds
 ARG TARGETARCH

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -82,6 +82,10 @@ COPY scripts/docker-editable-pretend-versions.sh /app/scripts/docker-editable-pr
 # Use submodule git metadata from the build context when present. Docker copies
 # only the submodule .git pointer files into /app/deps, so we temporarily link
 # /app/.git/modules to the read-only context before resolving versions.
+# Opt-in extras for disaggregated P/D inference (deep-ep, deep-gemm, quack).
+# Default off — they're heavy source builds only the disagg-MoE path needs.
+# Enable via `--build-arg INCLUDE_DISAGG_EXTRAS=1`.
+ARG INCLUDE_DISAGG_EXTRAS=0
 ARG VERIFIERS_PRETEND_VERSION
 ARG RENDERERS_PRETEND_VERSION
 RUN --mount=type=cache,target=/app/.cache/uv \
@@ -96,7 +100,9 @@ RUN --mount=type=cache,target=/app/.cache/uv \
     && \
     sed -i "s/fallback-version = \"0.0.0\"/fallback-version = \"${RENDERERS_PRETEND_VERSION}\"/" /app/deps/renderers/pyproject.toml \
     && \
-    uv sync --extra flash-attn --extra flash-attn-3 --extra flash-attn-cute --extra envs --extra gpt-oss --extra modelexpress --group mamba-ssm --locked --no-dev
+    EXTRA_DISAGG_FLAG=""; if [ "$INCLUDE_DISAGG_EXTRAS" = "1" ]; then EXTRA_DISAGG_FLAG="--extra disagg"; fi \
+    && \
+    uv sync --extra flash-attn --extra flash-attn-3 --extra flash-attn-cute --extra envs --extra gpt-oss --extra modelexpress $EXTRA_DISAGG_FLAG --group mamba-ssm --locked --no-dev
 
 # Optional: build NIXL from source against the UCX 1.19 baked above. The PyPI
 # nixl wheel ships its own UCX which segfaults on prefill→decode KV transfer

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -106,12 +106,13 @@ RUN --mount=type=cache,target=/app/.cache/uv \
 ARG INCLUDE_NIXL_FROM_SOURCE=0
 ARG NIXL_VERSION=0.10.1
 RUN if [ "$INCLUDE_NIXL_FROM_SOURCE" = "1" ]; then \
-        git clone --depth 1 --branch ${NIXL_VERSION} https://github.com/ai-dynamo/nixl.git /tmp/nixl \
+        VIRTUAL_ENV=/app/.venv uv pip install pip \
+        && git clone --depth 1 --branch ${NIXL_VERSION} https://github.com/ai-dynamo/nixl.git /tmp/nixl \
         && cd /tmp/nixl \
         && PKG_CONFIG_PATH=/opt/ucx/lib/pkgconfig \
            LD_LIBRARY_PATH=/opt/ucx/lib:/opt/ucx/lib/ucx \
            /app/.venv/bin/python -m pip wheel . --no-deps --wheel-dir=/app/deps \
-        && /app/.venv/bin/pip install --reinstall --no-deps /app/deps/nixl_cu12-*.whl \
+        && VIRTUAL_ENV=/app/.venv uv pip install --reinstall --no-deps /app/deps/nixl_cu12-*.whl \
         && rm -rf /tmp/nixl /app/deps/nixl_cu12-*.whl; \
     fi
 

--- a/configs/glm5.2_16node_llmd/inference.toml
+++ b/configs/glm5.2_16node_llmd/inference.toml
@@ -1,0 +1,50 @@
+# GLM-5.2-FP8 16-node P/D, FULL STACK: mooncake + llm-d router, vLLM 0.23.
+# Step 3 / goal target. Topology mirrors the proven original glm5.1_llmd_inference
+# (job 348 succeeded): 8 prefill nodes (4 replicas x 2) + 8 decode nodes (1 replica).
+#
+# Launch:  uv run inference @ configs/glm5.2_16node_llmd/inference.toml
+
+output_dir = "/shared/outputs/glm5.2-16node-llmd"
+
+enable_expert_parallel = true
+gpu_memory_utilization = 0.75
+enable_eplb = false
+use_deep_gemm = true
+enable_fp32_lm_head = true
+
+[model]
+name = "zai-org/GLM-5.2-FP8"
+max_model_len = 91000
+tool_call_parser = "glm47"
+reasoning_parser = "glm45"
+
+[vllm_extra]
+enable_ep_weight_filter = true
+safetensors_load_strategy = "prefetch"
+
+[kv_cache_offload]
+type = "mooncake"
+device_name = "mlx5_0,mlx5_3,mlx5_4,mlx5_5,mlx5_6,mlx5_9,mlx5_10,mlx5_11"
+
+[kv_cache_offload.cpu]
+num_bytes = 1_000_000_000_000
+
+[deployment]
+type = "disaggregated"
+num_prefill_nodes = 8
+num_prefill_replicas = 4
+num_decode_nodes = 8
+num_decode_replicas = 1
+prefill_env_overrides = {"VLLM_ENABLE_MOE_DP_CHUNK"="0", "VLLM_DEEP_GEMM_WARMUP"="skip", "UCX_RCACHE_MAX_UNRELEASED"="1024"}
+decode_env_overrides = {"VLLM_DEEP_GEMM_WARMUP"="skip", "UCX_RCACHE_MAX_UNRELEASED"="1024"}
+
+[deployment.router]
+type = "llm-d"
+scorers = { "prefix-cache-scorer" = 3.0 }
+prefill_scorer_overrides = { "queue-scorer" = 4.0, "active-request-scorer" = 5.0 }
+decode_scorer_overrides = { "active-request-scorer" = 5.0, "kv-cache-utilization-scorer" = 4.0, "queue-scorer" = 3.0 }
+non_cached_tokens = 128
+
+[slurm]
+job_name = "glm5.2-16node-llmd"
+partition = "all"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "torchaudio",
     "torchdata>=0.11.0",
     "transformers==5.6.2",
-    "vllm>=0.22.0",
+    "vllm>=0.23.0",
     "mooncake-transfer-engine>=0.3.10.post2",
     "wandb>=0.26.1",
     "ring-flash-attn>=0.1.8",
@@ -267,8 +267,8 @@ dion = { git = "https://github.com/samsja/dion.git", rev = "d891eeb" }
 flash-attn-4 = { git = "https://github.com/Dao-AILab/flash-attention.git", subdirectory = "flash_attn/cute", rev = "96bd151" }
 vllm-router = { url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.26/vllm_router-0.1.26-cp38-abi3-manylinux_2_28_x86_64.whl" }
 vllm = [
-    { url = "https://github.com/vllm-project/vllm/releases/download/v0.22.0/vllm-0.22.0+cu129-cp38-abi3-manylinux_2_28_x86_64.whl", marker = "platform_machine == 'x86_64'" },
-    { url = "https://github.com/vllm-project/vllm/releases/download/v0.22.0/vllm-0.22.0+cu129-cp38-abi3-manylinux_2_28_aarch64.whl", marker = "platform_machine == 'aarch64'" },
+    { url = "https://github.com/vllm-project/vllm/releases/download/v0.23.0/vllm-0.23.0+cu129-cp38-abi3-manylinux_2_28_x86_64.whl", marker = "platform_machine == 'x86_64'" },
+    { url = "https://github.com/vllm-project/vllm/releases/download/v0.23.0/vllm-0.23.0+cu129-cp38-abi3-manylinux_2_28_aarch64.whl", marker = "platform_machine == 'aarch64'" },
 ]
 deep-ep = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_ep-1.2.1+29d31c0-cp312-cp312-linux_x86_64.whl" }
 deep-gemm = { url = "https://github.com/PrimeIntellect-ai/prime-rl/releases/download/v0.5.0/deep_gemm-2.5.0+891d57b-cp312-cp312-linux_x86_64.whl" }

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -15,6 +15,7 @@ def transformers_v5_compat():
         Qwen3VLMoeTextConfig.tie_word_embeddings = False
 
     _patch_lora_key_prefix()
+    _patch_qwen35_moe_lora_format()
     monkey_patch_nano_v3_reasoning_parser()
     monkey_patch_vllm_padded_input_scrub()
     monkey_patch_return_routed_experts_with_nixl_connector()
@@ -179,6 +180,29 @@ def monkey_patch_strip_routed_experts_from_chat():
     logger.info(
         "Stripped routed_experts from chat-completions responses (PD router merges only the /generate object form)."
     )
+
+
+def _patch_qwen35_moe_lora_format():
+    """Force Qwen3.5-MoE onto vLLM's 2D per-expert LoRA format.
+
+    vLLM 0.23.0 defaults ``Qwen3_5MoeForConditionalGeneration.is_3d_moe_weight = True``,
+    which makes the LoRA loader expect 3D stacked-expert adapters
+    (``base_layer.lora_{A,B}.weight`` / ``lora_{A,B}.weight``, experts folded into the
+    rank dim; see ``_stack_moe_lora_weights``). Our trainer instead emits the 2D
+    per-expert layout (``{expert_id}.gate_proj.lora_A.weight`` ...) from
+    ``MultiLoRAGroupedExperts.state_dict_for_adapter`` -- vLLM only consults that layout
+    when ``is_3d_moe_weight`` is False (or ``enable_mixed_moe_lora_format=True``).
+    Without this override the adapters fail to load with key/shape mismatches.
+
+    The rest of the old Qwen3.5 LoRA shim (the in_proj_qkvz packed-mapping fix and the
+    N-slice ``can_replace_layer`` / ``slice_lora_a`` generalizations for vllm#36372) is
+    handled natively by 0.23.0 and was dropped. Remove this too once we either adopt the
+    3D stacked save format (like gpt-oss) or start the engine with
+    ``enable_mixed_moe_lora_format=True``.
+    """
+    from vllm.model_executor.models.qwen3_5 import Qwen3_5MoeForConditionalGeneration
+
+    Qwen3_5MoeForConditionalGeneration.is_3d_moe_weight = False
 
 
 def _patch_lora_key_prefix():

--- a/src/prime_rl/inference/patches.py
+++ b/src/prime_rl/inference/patches.py
@@ -1,5 +1,4 @@
 import torch
-from vllm.triton_utils import tl, triton
 
 from prime_rl.inference.vllm.padded_input_scrub import monkey_patch_vllm_padded_input_scrub
 
@@ -15,10 +14,8 @@ def transformers_v5_compat():
     if not hasattr(Qwen3VLMoeTextConfig, "tie_word_embeddings"):
         Qwen3VLMoeTextConfig.tie_word_embeddings = False
 
-    _patch_qwen35_lora()
     _patch_lora_key_prefix()
     monkey_patch_nano_v3_reasoning_parser()
-    monkey_patch_deep_gemm_silu_mul_quant_int64()
     monkey_patch_vllm_padded_input_scrub()
     monkey_patch_return_routed_experts_with_nixl_connector()
     monkey_patch_kv_xfer_finished_tolerate_freed()
@@ -182,201 +179,6 @@ def monkey_patch_strip_routed_experts_from_chat():
     logger.info(
         "Stripped routed_experts from chat-completions responses (PD router merges only the /generate object form)."
     )
-
-
-@triton.jit
-def _silu_mul_per_token_group_quant_fp8_colmajor_int64_kernel(
-    y_ptr,
-    y_q_ptr,
-    y_s_ptr,
-    M: tl.int64,
-    N: tl.int64,
-    y_s_col_stride: tl.int64,
-    eps,
-    clamp_limit,
-    fp8_min: tl.constexpr,
-    fp8_max: tl.constexpr,
-    use_ue8m0: tl.constexpr,
-    HAS_CLAMP: tl.constexpr,
-    GROUP_SIZE: tl.constexpr,
-    BLOCK_M: tl.constexpr,
-    BLOCK_N: tl.constexpr,
-):
-    pid_m = tl.program_id(0)
-    pid_n = tl.program_id(1)
-    N_2 = N // 2
-
-    m_offset = (pid_m * BLOCK_M).to(tl.int64)
-    n_offset = (pid_n * BLOCK_N).to(tl.int64)
-    if m_offset >= M:
-        return
-
-    offs_n = tl.arange(0, BLOCK_N).to(tl.int64)
-    offs_m = tl.arange(0, BLOCK_M).to(tl.int64)
-
-    base_y_ptr = y_ptr + m_offset * N + n_offset
-    act_in_ptrs = base_y_ptr + offs_m[:, None] * N + offs_n[None, :]
-
-    act_in = tl.load(act_in_ptrs)
-    mul_in = tl.load(act_in_ptrs + N_2)
-
-    if HAS_CLAMP:
-        act_in = tl.minimum(act_in.to(tl.float32), clamp_limit).to(y_ptr.dtype.element_ty)
-        mul_in = tl.clamp(mul_in.to(tl.float32), -clamp_limit, clamp_limit).to(y_ptr.dtype.element_ty)
-    act_in = act_in.to(tl.float32)
-    one_f32 = tl.cast(1, tl.float32)
-    silu_out = (act_in / (one_f32 + tl.exp(-act_in))).to(y_ptr.dtype.element_ty)
-    y = (silu_out * mul_in).to(tl.float32)
-
-    absmax = tl.maximum(tl.max(tl.abs(y), axis=1), eps)
-    scale_raw = absmax * (1.0 / fp8_max)
-    y_s = tl.math.exp2(tl.ceil(tl.log2(scale_raw))) if use_ue8m0 else scale_raw
-    y_s = tl.reshape(y_s, (BLOCK_M, 1))
-    y_q = tl.clamp(y / y_s, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
-
-    base_y_q_ptr = y_q_ptr + m_offset * N_2 + n_offset
-    y_q_ptrs = base_y_q_ptr + offs_m[:, None] * N_2 + offs_n[None, :]
-    tl.store(y_q_ptrs, y_q)
-
-    group_id = n_offset // GROUP_SIZE
-    base_y_s_ptr = y_s_ptr + group_id * y_s_col_stride + m_offset
-    y_s_ptrs = base_y_s_ptr + offs_m
-    y_s = tl.reshape(y_s, (BLOCK_M,))
-    tl.store(y_s_ptrs, y_s)
-
-
-def _silu_mul_per_token_group_quant_fp8_colmajor_int64(
-    input: torch.Tensor,
-    output: torch.Tensor | None = None,
-    use_ue8m0: bool | None = None,
-    eps: float = 1e-10,
-    clamp_limit: float | None = None,
-):
-    from vllm.platforms import current_platform
-    from vllm.utils.deep_gemm import is_deep_gemm_e8m0_used
-
-    group_size = 128
-    assert input.ndim == 2
-    if output is not None:
-        assert output.ndim == 2
-    assert input.size(0) % group_size == 0
-    assert input.size(1) % (group_size * 2) == 0
-
-    if use_ue8m0 is None:
-        use_ue8m0 = is_deep_gemm_e8m0_used()
-
-    M, N = input.size()
-    N_2 = N // 2
-
-    fp8_dtype = current_platform.fp8_dtype()
-    if output is None:
-        output = torch.empty((M, N_2), dtype=fp8_dtype, device=input.device)
-
-    output_scales = torch.empty(((N_2 // group_size), M), dtype=torch.float32, device=input.device).transpose(0, 1)
-
-    block_m = 8
-    block_n = group_size
-    assert M % block_m == 0
-    assert N_2 % block_n == 0
-
-    finfo = torch.finfo(fp8_dtype)
-    fp8_min = -224.0 if current_platform.is_fp8_fnuz() else finfo.min
-    fp8_max = 224.0 if current_platform.is_fp8_fnuz() else finfo.max
-
-    has_clamp = clamp_limit is not None
-    grid = (M // block_m, N_2 // block_n)
-    _silu_mul_per_token_group_quant_fp8_colmajor_int64_kernel[grid](
-        input,
-        output,
-        output_scales,
-        M,
-        N,
-        output_scales.stride(-1),
-        eps,
-        clamp_limit if has_clamp else 0.0,
-        fp8_min,
-        fp8_max,
-        use_ue8m0,
-        has_clamp,
-        group_size,
-        block_m,
-        block_n,
-    )
-
-    return output, output_scales
-
-
-def monkey_patch_deep_gemm_silu_mul_quant_int64():
-    import sys
-
-    from vllm.logger import init_logger
-    from vllm.model_executor.layers.quantization.utils import fp8_utils
-
-    logger = init_logger(__name__)
-
-    fp8_utils.silu_mul_per_token_group_quant_fp8_colmajor = _silu_mul_per_token_group_quant_fp8_colmajor_int64
-
-    deep_gemm_moe_module = sys.modules.get("vllm.model_executor.layers.fused_moe.experts.deep_gemm_moe")
-    if deep_gemm_moe_module is not None:
-        deep_gemm_moe_module.silu_mul_per_token_group_quant_fp8_colmajor = (
-            _silu_mul_per_token_group_quant_fp8_colmajor_int64
-        )
-
-    logger.warning("Enabled int64-addressing Triton patch for vLLM DeepGEMM SiLU/mul FP8 quant.")
-
-
-def _patch_qwen35_lora():
-    """Fix Qwen3.5 LoRA: align packed_modules_mapping with output_sizes.
-
-    Qwen3.5's GDN layers use create_qkvz_proj with 4 output_sizes (q, k, v, z)
-    but packed_modules_mapping only lists 2 entries, causing an IndexError
-    during LoRA initialization.
-
-    Also generalizes MergedColumnParallelLinearWithLoRA.can_replace_layer
-    to accept any number of packed modules (not just 2), and generalizes
-    MergedColumnParallelLinearWithShardedLoRA.slice_lora_a to handle N
-    subloras instead of the hardcoded 2 (needed for fully_sharded_loras=True).
-
-    Upstream: https://github.com/vllm-project/vllm/issues/36372
-    """
-    from vllm.lora.layers.column_parallel_linear import (
-        MergedColumnParallelLinearWithLoRA,
-        MergedColumnParallelLinearWithShardedLoRA,
-    )
-    from vllm.model_executor.models.qwen3_5 import (
-        Qwen3_5ForCausalLMBase,
-        Qwen3_5ForConditionalGeneration,
-        Qwen3_5MoeForConditionalGeneration,
-    )
-
-    qkvz_fix = ["in_proj_q", "in_proj_k", "in_proj_v", "in_proj_z"]
-
-    Qwen3_5ForCausalLMBase.packed_modules_mapping["in_proj_qkvz"] = qkvz_fix
-    Qwen3_5ForConditionalGeneration.packed_modules_mapping["in_proj_qkvz"] = qkvz_fix
-
-    Qwen3_5MoeForConditionalGeneration.is_3d_moe_weight = False
-
-    from vllm.lora.layers.utils import _not_fully_sharded_can_replace
-
-    @classmethod
-    @_not_fully_sharded_can_replace
-    def can_replace_layer(cls, source_layer, lora_config, packed_modules_list, model_config=None):
-        from vllm.model_executor.layers.linear import MergedColumnParallelLinear
-
-        return type(source_layer) is MergedColumnParallelLinear and len(packed_modules_list) == len(
-            source_layer.output_sizes
-        )
-
-    MergedColumnParallelLinearWithLoRA.can_replace_layer = can_replace_layer
-
-    def slice_lora_a(self, lora_a):
-        output_shard_size = self.lora_a_stacked[0].shape[2]
-        output_start_idx = self.tp_rank * output_shard_size
-        return [
-            a[output_start_idx : output_start_idx + output_shard_size, :] if a is not None else None for a in lora_a
-        ]
-
-    MergedColumnParallelLinearWithShardedLoRA.slice_lora_a = slice_lora_a
 
 
 def _patch_lora_key_prefix():
@@ -781,9 +583,10 @@ def monkey_patch_minimax_m2_for_lora():
         still runs for all wrapped layers when any adapter is active — and it
         asserts inputs are float16/bfloat16. Qwen3 MoE doesn't have this
         problem because its gate uses the model dtype.
-        Fix: recreate the gate in model dtype and remove the float32 cast.
-        FusedMoE already has router_logits_dtype=float32, so routing precision
-        is preserved inside the expert dispatch.
+        Fix: rebuild the gate as GateLinear with a bf16 weight (out_dtype=float32
+        keeps fp32 router logits). vLLM 0.23.0's own forward already drops the
+        float32 input cast. FusedMoE also has router_logits_dtype=float32, so
+        routing precision is preserved inside the expert dispatch.
 
     Problem 2 — Adapter key naming mismatch:
         PrimeRL saves adapter keys using its internal naming convention
@@ -805,13 +608,17 @@ def monkey_patch_minimax_m2_for_lora():
 
     def _patched_init(self, config, quant_config=None, prefix=""):
         _original_init(self, config, quant_config, prefix)
-        from vllm.model_executor.layers.linear import ReplicatedLinear
+        from vllm.model_executor.layers.fused_moe.router.gate_linear import GateLinear
 
-        self.gate = ReplicatedLinear(
+        # vLLM 0.23.0 builds the gate as GateLinear with a float32 weight; rebuild it
+        # with a bf16 weight (model dtype) so the LoRA Triton kernel's float16/bfloat16
+        # assertion passes, keeping out_dtype=float32 so router logits stay fp32 (the
+        # GateLinear bf16xbf16->fp32 path).
+        self.gate = GateLinear(
             config.hidden_size,
             config.num_local_experts,
             bias=False,
-            quant_config=None,
+            out_dtype=torch.float32,
             prefix=f"{prefix}.gate",
         )
 

--- a/src/prime_rl/inference/server.py
+++ b/src/prime_rl/inference/server.py
@@ -11,6 +11,15 @@ def setup_vllm_env(config: InferenceConfig):
     # spawn is more robust in vLLM nightlies and Qwen3-VL (fork can deadlock with multithreaded processes)
     os.environ.setdefault("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
 
+    # Force the V1 GPU model runner. vLLM 0.23.0 routes dense Llama/Mistral/Qwen3 to the
+    # V2 runner, which has no `_preprocess` hook for our padded-input scrub (see
+    # inference/vllm/padded_input_scrub.py) and doesn't zero the padded decode tail
+    # itself; that stale tail poisons CUDA-graph replay as NaN logits (reproduced on
+    # Nemotron-Nano SWE, PR #2506; upstream fix vllm#42779 is still unmerged). V1 keeps
+    # the scrub effective for every model and is also required for routed-experts capture
+    # (the NIXL PD path rejects V2). setdefault so it stays overridable.
+    os.environ.setdefault("VLLM_USE_V2_MODEL_RUNNER", "0")
+
     deep_gemm_enabled = "1" if config.use_deep_gemm else "0"
     os.environ["VLLM_USE_DEEP_GEMM"] = deep_gemm_enabled
     os.environ["VLLM_MOE_USE_DEEP_GEMM"] = deep_gemm_enabled

--- a/src/prime_rl/inference/vllm/serving_tokens.py
+++ b/src/prime_rl/inference/vllm/serving_tokens.py
@@ -43,7 +43,7 @@ from vllm.entrypoints.serve.disagg.protocol import (
     GenerateResponseChoice,
 )
 from vllm.entrypoints.serve.disagg.serving import ServingTokens
-from vllm.entrypoints.utils import get_max_tokens
+from vllm.entrypoints.serve.utils.api_utils import get_max_tokens
 from vllm.outputs import RequestOutput
 from vllm.sampling_params import RequestOutputKind, SamplingParams
 

--- a/src/prime_rl/inference/vllm/worker/nccl.py
+++ b/src/prime_rl/inference/vllm/worker/nccl.py
@@ -24,17 +24,22 @@ else:
 
 logger = init_logger("vllm.inference.vllm.worker_nccl")
 
-# NemotronH mixer.D is dropped by vLLM 0.22's layerwise online-reload path (left uninitialized).
+# NemotronH mixer.D is dropped by vLLM's layerwise online-reload path (left uninitialized).
 _RELOAD_CORRUPTED_SUFFIXES = (".mixer.D",)
 
 
 def _restore_reload_corrupted_params(model: Module, received: dict[str, torch.Tensor]) -> None:
-    """Work around a vLLM 0.22 layerwise-reload bug for NemotronH.
+    """Work around a vLLM layerwise-reload bug for NemotronH (present through vLLM 0.23.0).
 
     The online reload drops the weight load for every Mamba layer's ``mixer.D`` (the SSD skip
     connection), leaving it as uninitialized ``empty_strided`` memory -- it reads back as garbage
-    (NaN/inf) and the logits go NaN after a weight update. The received broadcast value is correct,
-    so restore D from it via the param's own ``weight_loader``. Remove once the upstream bug is fixed.
+    (NaN/inf) and the logits go NaN after a weight update. Root cause: ``mixer.A`` is loaded with
+    ``composed_weight_loader`` (an extra in-place transform copy), so the reload element counter
+    double-counts ``A`` and finalizes the layer before ``D`` (loaded last) is loaded. The received
+    broadcast value is correct, so restore D from it via the param's own ``weight_loader``.
+
+    Fixed upstream by vllm-project/vllm#44814 (merged 2026-06-10) but NOT in the pinned 0.23.0
+    release; remove this shim once we bump to a vLLM release that includes it.
     """
 
     def _layer_key(name: str) -> str:
@@ -179,7 +184,7 @@ class NCCLWeightUpdateWorker(Worker):
             update_mla_absorbed_weights(model)
             return
 
-        # vLLM 0.22's layerwise reload drops NemotronH mixer.D's weight load (see
+        # vLLM's layerwise reload drops NemotronH mixer.D's weight load (see
         # _restore_reload_corrupted_params). Capture the correct received value to restore after.
         received_reload_fix: dict[str, torch.Tensor] = {}
 

--- a/uv.lock
+++ b/uv.lock
@@ -590,7 +590,7 @@ wheels = [
 
 [[package]]
 name = "compressed-tensors"
-version = "0.15.0.1"
+version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "loguru", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -598,9 +598,9 @@ dependencies = [
     { name = "torch", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "transformers", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/41/1b/c3c4a98ec5f2727656336f07a0c35862195c310d8eb0b2fa5b4be6848680/compressed_tensors-0.15.0.1.tar.gz", hash = "sha256:a8e93054e8a5ec49c980b09ed36c4c1249b4a8ee167920a8e461c4da26e78d99", size = 229412, upload-time = "2026-04-10T14:23:54.708Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/9e/d7f18bd9a0354088abc11a0c1f2c7698f7c49e5a709faedf6a46e388f693/compressed_tensors-0.17.0.tar.gz", hash = "sha256:15c20d06bdbcf35b51fc99fd125e7b9be1e1855567c33b7a46dfac26ad6fb126", size = 257091, upload-time = "2026-06-03T16:49:17.208Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/52/93833dc1610e017ac5b7dcd59b8304d8ef67d1114c2d124e728a2cbbea12/compressed_tensors-0.15.0.1-py3-none-any.whl", hash = "sha256:e1b1f322e82e475715e242bad46925a304ea8e5c98b5055a15b8eb22fb6bfea9", size = 194260, upload-time = "2026-04-10T14:23:53.098Z" },
+    { url = "https://files.pythonhosted.org/packages/35/63/6edf0415b072fff0bf8b546074dea3f0f9b148e49b601ac98bdc60a76c68/compressed_tensors-0.17.0-py3-none-any.whl", hash = "sha256:4a1b89b508f7efb8ffb4eee8a6e69e0452d9b080cae130146025c64fbe9fa9aa", size = 211714, upload-time = "2026-06-03T16:49:15.672Z" },
 ]
 
 [[package]]
@@ -699,6 +699,13 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/49/4592bc94ca05a07c7947ea114fd12734c8497f2daffee9faa79a03e39fb5/cuda_tile-1.3.0-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:375316b64c51ee7cfadb2f170a30c1547bc41eb39f1e233a6556713857d2e81f", size = 245744, upload-time = "2026-04-20T15:52:09.621Z" },
     { url = "https://files.pythonhosted.org/packages/40/76/84cb68be463c827bf79da9fa0aa5140838de6455ef6f438bbe0ffa75d378/cuda_tile-1.3.0-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:e4865acbff1172aaee304bf9c550586088d8b4545a384423597a590899386709", size = 247301, upload-time = "2026-04-20T15:51:04.042Z" },
+]
+
+[package.optional-dependencies]
+tileiras = [
+    { name = "nvidia-cuda-nvcc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-tileiras", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvvm", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
 [[package]]
@@ -1209,20 +1216,20 @@ dependencies = [
 
 [[package]]
 name = "flashinfer-cubin"
-version = "0.6.11.post2"
+version = "0.6.12"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/96/da75a9f61c64c87b16baa339fc8216a6c3743c5d263c555fded30fcbe6f7/flashinfer_cubin-0.6.11.post2-py3-none-any.whl", hash = "sha256:eb01c2801ee31d145bbf7afb2c223150333e602c8208216017b0190b1087b990", size = 360908523, upload-time = "2026-05-14T04:57:41.355Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/c6/63b1bb7b1a7ae612ecf53c0e568312c3d004f9f7558b0ab5edcf7900c360/flashinfer_cubin-0.6.12-py3-none-any.whl", hash = "sha256:01de132c493bb21d5df42ebe6890966cf83b40aa970dae06b2a3c0bed85f13ec", size = 447533460, upload-time = "2026-05-29T23:45:27.579Z" },
 ]
 
 [[package]]
 name = "flashinfer-python"
-version = "0.6.11.post2"
+version = "0.6.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apache-tvm-ffi", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "click", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "cuda-tile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "cuda-tile", extra = ["tileiras"], marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "einops", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "ninja", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "numpy", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -1235,9 +1242,9 @@ dependencies = [
     { name = "torch", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "tqdm", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/db/53/dbf2157f2bbb96d6f7a6891cf6abfb2e6e18963760a0c53e96c2de5c59db/flashinfer_python-0.6.11.post2.tar.gz", hash = "sha256:e9fdac56aea9f0f58a4e69b0645c54993760d3cc6c7bf5c2df4ce5a0aecc7953", size = 9248515, upload-time = "2026-05-14T04:57:32.83Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/d0/114a64319f5a804def2f307d5ed8f95e6d94a2acdacac4ed5f57525cbf46/flashinfer_python-0.6.12.tar.gz", hash = "sha256:bed67f9c46d81dd22611dfef2787998fc412b2fe2648d9e7d336861dda912694", size = 9453326, upload-time = "2026-05-29T23:45:16.466Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/bc/518b092473f37d904ae07766ad37c772b93da13ea788777b22a80c3f1a7c/flashinfer_python-0.6.11.post2-py3-none-any.whl", hash = "sha256:550cbdb760f9f7ec0e42055e06636b9489d05f1a38989cafd77e6eb820de0138", size = 13746417, upload-time = "2026-05-14T04:57:30.25Z" },
+    { url = "https://files.pythonhosted.org/packages/85/26/3ca33edbf64906603633cb91904798e427c0ac1c55a13707f8081708f3ae/flashinfer_python-0.6.12-py3-none-any.whl", hash = "sha256:0c7a01e586b4796810d974cbf13a9c0eb2ade6a94d12e3220cf7782a1c09b8d3", size = 13985243, upload-time = "2026-05-29T23:45:13.477Z" },
 ]
 
 [[package]]
@@ -1624,7 +1631,7 @@ wheels = [
 
 [[package]]
 name = "humming-kernels"
-version = "0.1.2"
+version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cuda-bindings", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -1638,9 +1645,9 @@ dependencies = [
     { name = "tqdm", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "triton", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/f4/e141f45697b7d0d38bfaf8766a7362d8f0136e3cff2620624f24f68e2700/humming_kernels-0.1.2.tar.gz", hash = "sha256:7894c80061c7866591bef12617da720ac4e925636ffc99464af433a5dcb035eb", size = 117251, upload-time = "2026-05-23T16:18:08.084Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/f6/05e95b66cca48def9db0d6c40374fe285c7d9c913fe126030bcfb7cb3088/humming_kernels-0.1.4.tar.gz", hash = "sha256:fdaf4f23cc6b03bb1be3fd24aa11dc7798881e5448826e2404b4f12d8096f0d0", size = 117555, upload-time = "2026-06-04T03:24:03.504Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/41/288bf756d921dbe98982eeb3ec4c20e7cb5224ea6dcb164f2df3d2f68a7f/humming_kernels-0.1.2-py3-none-any.whl", hash = "sha256:f7434b0424946445ef5ad5682bcabf309d97721818ed5bdc4c6f61de3c6b9d2f", size = 160951, upload-time = "2026-05-23T16:18:06.405Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/16/d9318061a560305034e14cb7bf6483ffc8735eff6b30f260907dbbd4e85d/humming_kernels-0.1.4-py3-none-any.whl", hash = "sha256:c85094cd7cf8cdd959c5e2f7f239a7d72a7640ec1f948787434bc06e24e9ed00", size = 161312, upload-time = "2026-06-04T03:24:01.897Z" },
 ]
 
 [package.optional-dependencies]
@@ -2458,7 +2465,7 @@ wheels = [
 
 [[package]]
 name = "mistral-common"
-version = "1.11.2"
+version = "1.11.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonschema", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -2470,9 +2477,9 @@ dependencies = [
     { name = "tiktoken", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "typing-extensions", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/eb/12167a1bea9714582e5b4f539f9c019323363e314a499c72855ff0e5ad43/mistral_common-1.11.2.tar.gz", hash = "sha256:79f68fc2d1190f28637f40e053f919c8c2697e00b2aa679ddee562a95183f4ad", size = 6357845, upload-time = "2026-05-04T19:47:40.413Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/03/3c5d4c9430da406f8444f9a7b058a6aa89c525fb068a57fe2ab8b04a6d08/mistral_common-1.11.3.tar.gz", hash = "sha256:6437e128fc8a307318440839ca14ddf2e8060056b062233ec0db10352651374c", size = 6360629, upload-time = "2026-06-04T09:01:11.131Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/f0/6a5d604b972e442b9d36c117d01788feddad099e4965699e3516ee6fefc3/mistral_common-1.11.2-py3-none-any.whl", hash = "sha256:ebb42062cd705a0aa2bc69b4cde2b83d446ae58150b7e29322c90cb08fcfca6c", size = 6531968, upload-time = "2026-05-04T19:47:37.718Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/76/dbfdf9c59e2a4b0116587626a3768c2a3b2ba1758b5756743918c2337fdc/mistral_common-1.11.3-py3-none-any.whl", hash = "sha256:dbfcef9d0c892727ee08a080f0c1039baed5430b291f5425ffd88892bf09e52c", size = 6533154, upload-time = "2026-06-04T09:01:14.186Z" },
 ]
 
 [package.optional-dependencies]
@@ -2845,12 +2852,35 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-cuda-crt"
+version = "13.3.33"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/32/5ea57f8cd6ad5df2173d175ac5db4e06edde40028b1b1f6c539ea4c10290/nvidia_cuda_crt-13.3.33-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c8c257393f9c9146a85d3644f352be8154843d760031f756e673222c768a4930", size = 157348, upload-time = "2026-05-26T16:28:40.446Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a7/998af901511d5efdc6e42fc597d32a69f34eecf86f1591a9d230ab3ab951/nvidia_cuda_crt-13.3.33-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:01ff37600c7b880a14cab4ade763b4c10c0ff92f25cc9dca30f0881ce52693c4", size = 157350, upload-time = "2026-05-26T16:29:22.315Z" },
+]
+
+[[package]]
 name = "nvidia-cuda-cupti-cu12"
 version = "12.8.90"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/1f/b3bd73445e5cb342727fd24fe1f7b748f690b460acadc27ea22f904502c8/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4412396548808ddfed3f17a467b104ba7751e6b58678a4b840675c56d21cf7ed", size = 9533318, upload-time = "2025-03-07T01:40:10.421Z" },
     { url = "https://files.pythonhosted.org/packages/f8/02/2adcaa145158bf1a8295d83591d22e4103dbfd821bcaf6f3f53151ca4ffa/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea0cb07ebda26bb9b29ba82cda34849e73c166c18162d3913575b0c9db9a6182", size = 10248621, upload-time = "2025-03-07T01:40:21.213Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvcc"
+version = "13.2.78"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cuda-crt", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvvm", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/df/faf551572ae1359290afa5cb05d2c4b7e6674b07b8283b20eab4dbad15f6/nvidia_cuda_nvcc-13.2.78-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:dfc76950c775cd00ce588f15192f08c9b858c0dcfa7da685acf39a3d0d8f588b", size = 38713559, upload-time = "2026-04-13T09:42:17.478Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0f/c7c7d538c61794130e759ad74710ab5aa8cab1f700ee1754381f8c665605/nvidia_cuda_nvcc-13.2.78-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c3bd144dd9b6b25e062589acb7bbd43d93d3120c72fad71da808f9817aba1239", size = 44040318, upload-time = "2026-04-13T09:42:50.457Z" },
 ]
 
 [[package]]
@@ -2872,12 +2902,34 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-cuda-runtime"
+version = "13.3.29"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/e5/c1a221c8e6fecd071b80ea44c20fc253ae24f56e15e3f77cfbc3fb76e724/nvidia_cuda_runtime-13.3.29-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:73291e19c9dd919c140c91bda2f80b0eca487da5ee30a086ef7bc4918ecb90ea", size = 2356574, upload-time = "2026-05-26T16:29:56.333Z" },
+    { url = "https://files.pythonhosted.org/packages/97/be/5699b6e642b372f7d24c59c2f41383e2696825e20bab85f7399c7c6a56f7/nvidia_cuda_runtime-13.3.29-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e04420616e72f563167a7733272992d7e6df6dc5cb54b2f94f9f1520ea9e30c1", size = 2339786, upload-time = "2026-05-26T16:30:21.584Z" },
+]
+
+[[package]]
 name = "nvidia-cuda-runtime-cu12"
 version = "12.8.90"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7c/75/f865a3b236e4647605ea34cc450900854ba123834a5f1598e160b9530c3a/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:52bf7bbee900262ffefe5e9d5a2a69a30d97e2bc5bb6cc866688caa976966e3d", size = 965265, upload-time = "2025-03-07T01:39:43.533Z" },
     { url = "https://files.pythonhosted.org/packages/0d/9b/a997b638fcd068ad6e4d53b8551a7d30fe8b404d6f1804abf1df69838932/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adade8dcbd0edf427b7204d480d6066d33902cab2a4707dcfc48a2d0fd44ab90", size = 954765, upload-time = "2025-03-07T01:40:01.615Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-tileiras"
+version = "13.2.78"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cuda-nvcc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvvm", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/04/eb26cc1d67c653f5dbe8c13fd6da9c1e844b097147051b5052ac5e6d4047/nvidia_cuda_tileiras-13.2.78-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:658299efca52a20496b425efb0b19cb1ea7d57406a18d3f5024d4df92d5b54c1", size = 36418791, upload-time = "2026-04-13T09:48:30.107Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/b8/c8a96862268943c7cf30a014fe2d8f70c651d30fbfa790d54c3e347b6fa1/nvidia_cuda_tileiras-13.2.78-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ce7c140a518aa8dfe033e7176f593617ed2fece0e50331e2a14dafd236723fd", size = 36970479, upload-time = "2026-04-13T09:48:49.919Z" },
 ]
 
 [[package]]
@@ -2894,11 +2946,11 @@ wheels = [
 
 [[package]]
 name = "nvidia-cudnn-frontend"
-version = "1.18.0"
+version = "1.25.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/b4/604e230378680ee117849a4e1045baca092f93161a829291a84d5acce70c/nvidia_cudnn_frontend-1.18.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:310b417f2848a83d1437203fcaeea320a74fb7f28af20bf42bf5afc9c01f1c12", size = 2027408, upload-time = "2026-01-27T23:32:46.576Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/52/08f98262e77b1cbcc834cc1a5db494d0661ea1dbdea58c2e2d51a57fdaca/nvidia_cudnn_frontend-1.18.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c023539ca6de99234cf5102c3ec0d6af817f5396fc93028a22ba5b834a35b8a", size = 2159245, upload-time = "2026-01-27T23:07:32.664Z" },
+    { url = "https://files.pythonhosted.org/packages/28/0f/df39a194f2529093db737d43cc4cbf594c6a79712a09aa104b999e4d95d4/nvidia_cudnn_frontend-1.25.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:09e6e1bc48ce1235743f89d8ea699c52b3008fd6dae7f2ecadb744bebf272a2b", size = 3263306, upload-time = "2026-06-10T21:07:48.093Z" },
+    { url = "https://files.pythonhosted.org/packages/03/65/3b45941d8a22128b971e910f2e9af6bf5ef453e92cc329c56b6eb53c53de/nvidia_cudnn_frontend-1.25.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9a94a72d736bd79eb35f451aaf26d9493778e02ecabccc92c05425508c9e7a83", size = 3414884, upload-time = "2026-06-10T21:08:08.603Z" },
 ]
 
 [[package]]
@@ -3034,6 +3086,15 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/c0/1b303feea90d296f6176f32a2a70b5ef230f9bdeb3a72bddb0dc922dc137/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d7ad891da111ebafbf7e015d34879f7112832fc239ff0d7d776b6cb685274615", size = 91161, upload-time = "2025-03-07T01:42:23.922Z" },
     { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954, upload-time = "2025-03-07T01:42:44.131Z" },
+]
+
+[[package]]
+name = "nvidia-nvvm"
+version = "13.2.78"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/1f/930d63ccc8adcdf27bfc051a24e3e4da2cf6ef987848d6d1d642e29d704b/nvidia_nvvm-13.2.78-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:f5aa433631109bbdec81802c5b5f319bf10bc891fe2f212e4e445845211d6f77", size = 64279462, upload-time = "2026-04-13T10:02:25.719Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/fd/db44b7a662a6af75a9a0683ca4580c855a3f5fcfdf1261b0ddb9fce0ee26/nvidia_nvvm-13.2.78-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88075f87a361a1dce95c799cabc028f7093af616a5702dcfb74eba4045dbbd5f", size = 61886055, upload-time = "2026-04-13T10:02:00.345Z" },
 ]
 
 [[package]]
@@ -3520,8 +3581,8 @@ dependencies = [
     { name = "transformers", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "uvloop", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "verifiers", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "vllm", version = "0.22.0+cu129", source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.22.0/vllm-0.22.0+cu129-cp38-abi3-manylinux_2_28_aarch64.whl" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "vllm", version = "0.22.0+cu129", source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.22.0/vllm-0.22.0+cu129-cp38-abi3-manylinux_2_28_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "vllm", version = "0.23.0+cu129", source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.23.0/vllm-0.23.0+cu129-cp38-abi3-manylinux_2_28_aarch64.whl" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "vllm", version = "0.23.0+cu129", source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.23.0/vllm-0.23.0+cu129-cp38-abi3-manylinux_2_28_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "wandb", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
@@ -3708,9 +3769,9 @@ requires-dist = [
     { name = "uuid-ctf-v1", marker = "extra == 'envs'", editable = "deps/research-environments/environments/uuid_ctf_v1" },
     { name = "uvloop", specifier = ">=0.21.0" },
     { name = "verifiers", editable = "deps/verifiers" },
-    { name = "vllm", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'", specifier = ">=0.22.0" },
-    { name = "vllm", marker = "platform_machine == 'aarch64'", url = "https://github.com/vllm-project/vllm/releases/download/v0.22.0/vllm-0.22.0+cu129-cp38-abi3-manylinux_2_28_aarch64.whl" },
-    { name = "vllm", marker = "platform_machine == 'x86_64'", url = "https://github.com/vllm-project/vllm/releases/download/v0.22.0/vllm-0.22.0+cu129-cp38-abi3-manylinux_2_28_x86_64.whl" },
+    { name = "vllm", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'", specifier = ">=0.23.0" },
+    { name = "vllm", marker = "platform_machine == 'aarch64'", url = "https://github.com/vllm-project/vllm/releases/download/v0.23.0/vllm-0.23.0+cu129-cp38-abi3-manylinux_2_28_aarch64.whl" },
+    { name = "vllm", marker = "platform_machine == 'x86_64'", url = "https://github.com/vllm-project/vllm/releases/download/v0.23.0/vllm-0.23.0+cu129-cp38-abi3-manylinux_2_28_x86_64.whl" },
     { name = "vllm-router", marker = "platform_machine == 'x86_64' and extra == 'disagg'", url = "https://github.com/PrimeIntellect-ai/router/releases/download/v0.1.26/vllm_router-0.1.26-cp38-abi3-manylinux_2_28_x86_64.whl" },
     { name = "wandb", specifier = ">=0.26.1" },
     { name = "wiki-search", marker = "extra == 'envs'", editable = "deps/verifiers/environments/wiki_search" },
@@ -5573,8 +5634,8 @@ wheels = [
 
 [[package]]
 name = "vllm"
-version = "0.22.0+cu129"
-source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.22.0/vllm-0.22.0+cu129-cp38-abi3-manylinux_2_28_aarch64.whl" }
+version = "0.23.0+cu129"
+source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.23.0/vllm-0.23.0+cu129-cp38-abi3-manylinux_2_28_aarch64.whl" }
 resolution-markers = [
     "platform_machine == 'aarch64' and sys_platform == 'linux'",
 ]
@@ -5652,7 +5713,7 @@ dependencies = [
     { name = "xgrammar", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://github.com/vllm-project/vllm/releases/download/v0.22.0/vllm-0.22.0+cu129-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:14f586820f3ed2cecdbda39651ecfe1cd097102200e25bbff5e740ccecb6143d" },
+    { url = "https://github.com/vllm-project/vllm/releases/download/v0.23.0/vllm-0.23.0+cu129-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:17ac76bbfad014d5b584a9499bca22d3f871d24db93cbb1eb27a87deef0219aa" },
 ]
 
 [package.metadata]
@@ -5665,20 +5726,20 @@ requires-dist = [
     { name = "cachetools" },
     { name = "cbor2" },
     { name = "cloudpickle" },
-    { name = "compressed-tensors", specifier = "==0.15.0.1" },
+    { name = "compressed-tensors", specifier = "==0.17.0" },
     { name = "datasets", marker = "extra == 'bench'" },
     { name = "depyf", specifier = "==0.20.0" },
     { name = "diskcache", specifier = "==5.6.3" },
     { name = "einops" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.0" },
-    { name = "fastsafetensors", specifier = ">=0.2.2" },
-    { name = "fastsafetensors", marker = "extra == 'fastsafetensors'", specifier = ">=0.2.2" },
+    { name = "fastsafetensors", specifier = ">=0.3.2" },
+    { name = "fastsafetensors", marker = "extra == 'fastsafetensors'", specifier = ">=0.3.2" },
     { name = "filelock", specifier = ">=3.16.1" },
-    { name = "flashinfer-cubin", specifier = "==0.6.11.post2" },
-    { name = "flashinfer-python", specifier = "==0.6.11.post2" },
+    { name = "flashinfer-cubin", specifier = "==0.6.12" },
+    { name = "flashinfer-python", specifier = "==0.6.12" },
     { name = "gguf", specifier = ">=0.17.0" },
     { name = "helion", marker = "extra == 'helion'", specifier = "==1.0.0" },
-    { name = "humming-kernels", extras = ["cu12"], specifier = "==0.1.2" },
+    { name = "humming-kernels", extras = ["cu12"], specifier = "==0.1.4" },
     { name = "ijson" },
     { name = "instanttensor", marker = "extra == 'instanttensor'", specifier = ">=0.1.5" },
     { name = "lark", specifier = "==1.2.2" },
@@ -5687,13 +5748,13 @@ requires-dist = [
     { name = "matplotlib", marker = "extra == 'bench'" },
     { name = "mcp" },
     { name = "mistral-common", extras = ["audio"], marker = "extra == 'audio'" },
-    { name = "mistral-common", extras = ["image"], specifier = ">=1.11.2" },
+    { name = "mistral-common", extras = ["image"], specifier = ">=1.11.3" },
     { name = "model-hosting-container-standards", specifier = ">=0.1.14,<1.0.0" },
     { name = "msgspec" },
     { name = "ninja" },
     { name = "numba", specifier = "==0.65.0" },
     { name = "numpy" },
-    { name = "nvidia-cudnn-frontend", specifier = ">=1.13.0,<1.19.0" },
+    { name = "nvidia-cudnn-frontend", specifier = ">=1.19.1" },
     { name = "nvidia-cutlass-dsl", specifier = "==4.5.2" },
     { name = "openai", specifier = ">=2.0.0" },
     { name = "openai-harmony", specifier = ">=0.0.3" },
@@ -5748,14 +5809,14 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.10" },
     { name = "watchfiles" },
     { name = "xgrammar", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'ppc64le' or platform_machine == 's390x' or platform_machine == 'x86_64'", specifier = ">=0.2.0,<1.0.0" },
-    { name = "zentorch-weekly", marker = "extra == 'zen'", specifier = "==5.2.1.dev20260408" },
+    { name = "zentorch", marker = "extra == 'zen'", specifier = "==2.11.0.0" },
 ]
 provides-extras = ["zen", "bench", "tensorizer", "fastsafetensors", "instanttensor", "runai", "audio", "video", "flashinfer", "helion", "grpc", "otel"]
 
 [[package]]
 name = "vllm"
-version = "0.22.0+cu129"
-source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.22.0/vllm-0.22.0+cu129-cp38-abi3-manylinux_2_28_x86_64.whl" }
+version = "0.23.0+cu129"
+source = { url = "https://github.com/vllm-project/vllm/releases/download/v0.23.0/vllm-0.23.0+cu129-cp38-abi3-manylinux_2_28_x86_64.whl" }
 resolution-markers = [
     "platform_machine == 'x86_64' and sys_platform == 'linux'",
 ]
@@ -5833,7 +5894,7 @@ dependencies = [
     { name = "xgrammar", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://github.com/vllm-project/vllm/releases/download/v0.22.0/vllm-0.22.0+cu129-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:405319a7fde1af416eef6cbab0315d354d8b9c1a45b97097a9f1c3707bf05f74" },
+    { url = "https://github.com/vllm-project/vllm/releases/download/v0.23.0/vllm-0.23.0+cu129-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:8bc2203995d061e6b988916b71b9dee8a5970f5fdc5f37d4445a877a2fab2cc1" },
 ]
 
 [package.metadata]
@@ -5846,20 +5907,20 @@ requires-dist = [
     { name = "cachetools" },
     { name = "cbor2" },
     { name = "cloudpickle" },
-    { name = "compressed-tensors", specifier = "==0.15.0.1" },
+    { name = "compressed-tensors", specifier = "==0.17.0" },
     { name = "datasets", marker = "extra == 'bench'" },
     { name = "depyf", specifier = "==0.20.0" },
     { name = "diskcache", specifier = "==5.6.3" },
     { name = "einops" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.0" },
-    { name = "fastsafetensors", specifier = ">=0.2.2" },
-    { name = "fastsafetensors", marker = "extra == 'fastsafetensors'", specifier = ">=0.2.2" },
+    { name = "fastsafetensors", specifier = ">=0.3.2" },
+    { name = "fastsafetensors", marker = "extra == 'fastsafetensors'", specifier = ">=0.3.2" },
     { name = "filelock", specifier = ">=3.16.1" },
-    { name = "flashinfer-cubin", specifier = "==0.6.11.post2" },
-    { name = "flashinfer-python", specifier = "==0.6.11.post2" },
+    { name = "flashinfer-cubin", specifier = "==0.6.12" },
+    { name = "flashinfer-python", specifier = "==0.6.12" },
     { name = "gguf", specifier = ">=0.17.0" },
     { name = "helion", marker = "extra == 'helion'", specifier = "==1.0.0" },
-    { name = "humming-kernels", extras = ["cu12"], specifier = "==0.1.2" },
+    { name = "humming-kernels", extras = ["cu12"], specifier = "==0.1.4" },
     { name = "ijson" },
     { name = "instanttensor", marker = "extra == 'instanttensor'", specifier = ">=0.1.5" },
     { name = "lark", specifier = "==1.2.2" },
@@ -5868,13 +5929,13 @@ requires-dist = [
     { name = "matplotlib", marker = "extra == 'bench'" },
     { name = "mcp" },
     { name = "mistral-common", extras = ["audio"], marker = "extra == 'audio'" },
-    { name = "mistral-common", extras = ["image"], specifier = ">=1.11.2" },
+    { name = "mistral-common", extras = ["image"], specifier = ">=1.11.3" },
     { name = "model-hosting-container-standards", specifier = ">=0.1.14,<1.0.0" },
     { name = "msgspec" },
     { name = "ninja" },
     { name = "numba", specifier = "==0.65.0" },
     { name = "numpy" },
-    { name = "nvidia-cudnn-frontend", specifier = ">=1.13.0,<1.19.0" },
+    { name = "nvidia-cudnn-frontend", specifier = ">=1.19.1" },
     { name = "nvidia-cutlass-dsl", specifier = "==4.5.2" },
     { name = "openai", specifier = ">=2.0.0" },
     { name = "openai-harmony", specifier = ">=0.0.3" },
@@ -5929,7 +5990,7 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.10" },
     { name = "watchfiles" },
     { name = "xgrammar", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'ppc64le' or platform_machine == 's390x' or platform_machine == 'x86_64'", specifier = ">=0.2.0,<1.0.0" },
-    { name = "zentorch-weekly", marker = "extra == 'zen'", specifier = "==5.2.1.dev20260408" },
+    { name = "zentorch", marker = "extra == 'zen'", specifier = "==2.11.0.0" },
 ]
 provides-extras = ["zen", "bench", "tensorizer", "fastsafetensors", "instanttensor", "runai", "audio", "video", "flashinfer", "helion", "grpc", "otel"]
 


### PR DESCRIPTION
Rebases the vLLM **0.23.0** bump (from #2825) onto current `main` and adds a validated standalone disaggregated-P/D inference config for **GLM-5.2** (16 nodes, mooncake + llm-d).

### Commits
- `chore: bump vLLM to 0.23.0 and prune/adapt monkeypatches` (from #2825)
- `docs(inference): cite vllm#44814 …` (from #2825)
- `feat(configs): add GLM-5.2 16-node P/D mooncake + llm-d inference config`
- `fix(inference): keep Qwen3.5-MoE on 2D per-expert LoRA format`

### Monkeypatch verification (against installed 0.23.0 source)
The pruned/adapted patches were re-checked against the actual 0.23.0 wheel:
- ✅ `monkey_patch_deep_gemm_silu_mul_quant_int64` — removed. Upstream kernel (`fp8_utils.py`) already uses int64 pointer arithmetic; the patch was a no-op.
- ✅ `_patch_qwen35_lora` (dense GDN, vllm#36372) — removed. Fixed natively in 0.23.0 via the N-slice `MergedColumnParallelLinearWithLoRA` + `expand_packed_lora` (`lora/layers/column_parallel_linear.py`).
- ⚠️→✅ `Qwen3_5MoeForConditionalGeneration.is_3d_moe_weight = False` — this sub-part of `_patch_qwen35_lora` was **not** an upstream bug fix and was dropped by mistake in the initial prune. 0.23.0 defaults the flag to `True` (3D stacked-expert adapters), but our trainer emits the **2D per-expert** layout (`MultiLoRAGroupedExperts.state_dict_for_adapter`), which vLLM only reads when the flag is `False` (or `enable_mixed_moe_lora_format=True`). Without it, Qwen3.5-MoE LoRA adapters fail to load. Re-added as a minimal standalone patch in `fix(inference): keep Qwen3.5-MoE on 2D per-expert LoRA format`.
- ✅ `monkey_patch_minimax_m2_for_lora` — adapted to the new `GateLinear` gate. Verified `GateLinear(out_dtype=float32)` with no `params_dtype` yields a **bf16** weight (resolves to the model dtype under `set_default_torch_dtype`) so the LoRA Triton kernel's fp16/bf16 assertion passes, while router logits stay fp32.

### ⚠️ Required setup for disaggregated P/D (NIXL/UCX)
The pip-wheel NIXL's bundled UCX **segfaults on the prefill→decode KV transfer** (`signal 11: invalid permissions for mapped object` in `libucs.so`) — reproduced on vLLM 0.22 **and** 0.23, with/without mooncake, with/without llm-d. Fix is to build NIXL against **UCX 1.19.x** from source:
```bash
bash scripts/install_nixl_from_source.sh
uv pip install --reinstall --no-deps deps/nixl_cu12-*.whl
```
(Re-run after every `uv sync`, since the lock pins the wheel.) This should be promoted from "optional" to **required** for P/D in the install docs.

### Validation (real deployments, vLLM 0.23, H200)
- **GLM-5.2 16n** (8 prefill / 4 replicas + 8 decode), plus GLM-5.2 8n and GLM-5.1 8n — each a 1000-request / 500-concurrent burst → **0 errors, 0 faults, 0 RPC_FAIL** through llm-d + mooncake.
- Note: llm-d head-startup is a flaky race (`wait -n` + `--kill-on-bad-exit`); resubmit 1–3× to win it. vllm-router starts first-try.

Supersedes #2825 (same bump, rebased + GLM-5.2 config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Core inference stack upgrade (vLLM 0.23) plus changes to env defaults, LoRA loading, and disaggregated P/D Docker paths affect production serving and RL weight sync; misconfiguration of NIXL/UCX or runner choice can cause crashes or NaN logits.
> 
> **Overview**
> Bumps **vLLM from 0.22.0 to 0.23.0** (`pyproject.toml`, pinned wheels, `uv.lock` transitive deps such as flashinfer 0.6.12 and compressed-tensors 0.17.0).
> 
> **Inference compatibility for 0.23:** `setup_vllm_env` sets `VLLM_USE_V2_MODEL_RUNNER=0` so padded-input scrub and NIXL routed-experts stay on the V1 runner. Disagg token serving imports `get_max_tokens` from vLLM’s new `api_utils` path. NemotronH reload-shim comments are updated for 0.23.
> 
> **Monkeypatches pruned/adapted:** Removes the custom DeepGEMM SiLU/mul FP8 Triton patch and the dense Qwen3.5 GDN LoRA shims (fixed upstream in 0.23). Keeps a minimal **Qwen3.5-MoE** override (`is_3d_moe_weight = False`) so trainer 2D per-expert LoRA adapters load. **MiniMax M2** gate fix switches to rebuilding `GateLinear` with bf16 weights and fp32 router logits.
> 
> **Docker:** Optional `INCLUDE_DISAGG_EXTRAS` (`--extra disagg` on `uv sync`) and `INCLUDE_NIXL_FROM_SOURCE` (build NIXL against baked UCX 1.19 to avoid P/D KV segfaults).
> 
> **New config:** `configs/glm5.2_16node_llmd/inference.toml` — GLM-5.2-FP8, 16-node disaggregated prefill/decode with mooncake offload and llm-d router.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d959d3c949e80f37d7ced6a0d35766b94b7a7c92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

