### PR TITLE
exp: temp-experimental K8s e2e for vLLM 0.23 P/D + mooncake + llm-d

### DIFF
--- a/temp-experimental/README.md
+++ b/temp-experimental/README.md
@@ -1,0 +1,144 @@
+# temp-experimental: K8s e2e for vLLM 0.23 P/D + mooncake + llm-d
+
+Scratch folder for the Kubernetes/Helm path for [PR #2883](https://github.com/PrimeIntellect-ai/prime-rl/pull/2883)
+(GLM-5.2 16-node disaggregated prefill/decode with mooncake KV pool + llm-d router).
+
+This is **not** a production chart. Treat it as a vertical-slice prototype: it
+gets a request flowing through `client → Envoy → EPP → vLLM prefill → NIXL →
+vLLM decode → response`, with mooncake as the shared CPU KV pool. Once the
+topology is proven on a small cluster, the chart graduates into
+`pi-rft/k8s/rft-stack` (where it gets RBAC, KEDA, graceful shutdown, dashboards,
+PR-based GitOps deploys).
+
+## Layout
+
+```
+temp-experimental/
+├── docker/
+│   └── Dockerfile.llmd          # FROM prime-rl:<tag> + NIXL-from-source + llm-d bins
+├── helm/
+│   ├── Chart.yaml
+│   ├── values.yaml              # Defaults: 1P + 1D smoke topology
+│   ├── values-glm5.2-16node.yaml  # Sketch of the PR's target topology
+│   └── templates/
+│       ├── _helpers.tpl
+│       ├── pvc.yaml             # Shared RWX volume
+│       ├── configmap.yaml       # inference.toml + mooncake config.json
+│       ├── mooncake.yaml        # mooncake_master Deployment + Service
+│       ├── inference.yaml       # prefill + decode StatefulSets (+ pd-sidecar on decode)
+│       └── router.yaml          # EPP + Envoy Deployment + Service + ConfigMap
+└── README.md
+```
+
+## End-to-end flow
+
+1. **Image.** Build the base image from prime-rl's `Dockerfile.cuda` via the
+   `build-push-prime-rl` workflow in `hosted-rl`. Then layer
+   `temp-experimental/docker/Dockerfile.llmd` to add NIXL-from-source (the pip
+   wheel segfaults on KV transfer per the PR's own ⚠️) and the llm-d Go bins.
+
+   ```bash
+   # base image is built by pi-rft's build-push-prime-rl workflow
+   BASE=ghcr.io/primeintellect-ai/hosted-rl/prime-rl:<tag>-amd64
+
+   docker build \
+     --build-arg BASE_IMAGE=$BASE \
+     -f temp-experimental/docker/Dockerfile.llmd \
+     -t ghcr.io/primeintellect-ai/hosted-rl/prime-rl-llmd:<tag>-amd64 \
+     .
+   ```
+
+2. **Cluster prerequisites.** Audit before installing:
+   - GPU operator + `nvidia` runtime class
+   - NFS or other RWX `StorageClass` (override `storage.storageClassName`)
+   - `k8s-rdma-shared-dev-plugin` exposing `rdma/rdma_shared_device_a` (override
+     `rdma.deviceName`)
+   - PSA permissive enough for `privileged: true` + `IPC_LOCK` in the workload
+     namespace
+   - ghcr pull secret (default name `ghcr-secret`)
+
+3. **Smoke install** (1 prefill pod + 1 decode pod, single GPU each):
+   ```bash
+   helm install glm52 ./temp-experimental/helm \
+     --set image.tag=<your-tag>-amd64 \
+     --set rdma.enabled=true
+   kubectl get pods -l app.kubernetes.io/instance=glm52
+   ```
+
+4. **Hit the router** once everything is `Ready`:
+   ```bash
+   kubectl port-forward svc/glm52-router 8000:8000
+   curl -s http://localhost:8000/v1/chat/completions \
+     -H 'content-type: application/json' \
+     -d '{"model":"zai-org/GLM-5.2-FP8","messages":[{"role":"user","content":"hi"}]}'
+   ```
+
+5. **Scale up to the PR target** with `-f values-glm5.2-16node.yaml` once the
+   multi-node items below land.
+
+## What this gets you today
+
+- vLLM 0.23 prefill engine + vLLM 0.23 decode engine, each with the PR's
+  per-role env overrides (`VLLM_ENABLE_MOE_DP_CHUNK`, `deepep_high_throughput`
+  vs `deepep_low_latency`, decode-only CUDA graphs).
+- Mooncake distributed CPU KV pool (one master `Deployment`, one
+  `mooncake_client` sidecar per inference pod).
+- llm-d router stack: `epp` + `envoy` in a single `Deployment`, decode-side
+  `pd-sidecar` co-located in the decode pod. Endpoints are resolved from the
+  prefill/decode headless services at startup.
+- A `use_pd_kv_transfer = true` override in the rendered TOML so the worker
+  config still builds the NIXL transfer connector even though the `[deployment]`
+  section is dropped (K8s replaces it).
+
+## What's missing (production / 16-node)
+
+These are gaps between this scaffold and the actual PR target. Each is a
+self-contained follow-up:
+
+1. **Multi-DP per pod.** The SLURM template starts one vLLM API server per
+   local DP rank (`PORT + k`). Today the chart hardcodes DP=1. Needs a `for k
+   in 0..gpusPerNode-1` loop in the entrypoint plus per-rank ports and NIXL
+   side-channel ports.
+2. **Cross-node TP.** For the 16-node config there are 4 inner prefill
+   replicas, each spanning 2 nodes (TP across nodes). This needs
+   LeaderWorkerSet, not StatefulSet — same pattern `rft-stack/lws-inference.yaml`
+   already uses.
+3. **Per-replica routers.** The PR config has 4 P/D outer replicas; each gets
+   its own EPP+Envoy. Today the chart deploys one router for the whole pool.
+4. **NCCL / GLOO socket interface.** Needs `NCCL_SOCKET_IFNAME` /
+   `GLOO_SOCKET_IFNAME` set from the pod's primary interface, like
+   `rft-stack/lws-inference.yaml` does via `ip -o -4 addr`.
+5. **UCX device discovery.** SLURM enumerates active RDMA ports from sysfs
+   (`/sys/class/infiniband/*`). The chart pins decode to `mlx5_0:1` and
+   otherwise leaves UCX on auto.
+6. **Liveness/readiness/graceful drain.** No probes yet. EPP and pd-sidecar
+   need readiness gating so the router doesn't dispatch into a half-up pool.
+   Steal the `gracefulShutdown.preStop` from rft-stack once we know vLLM
+   shutdown drains cleanly through the EPP.
+7. **Observability.** EPP `--metrics-port 9090` and Envoy admin are exposed
+   but no `PodMonitor` yet.
+8. **Auth.** Router is open. EPP needs the same JWT posture vllm-router has
+   in rft-stack.
+
+## How this maps to the eventual rft-stack PR
+
+This scaffold is intentionally separate from `pi-rft/k8s/rft-stack` so the
+existing chart keeps shipping. The migration is roughly:
+
+| Here | Lands as |
+|---|---|
+| `inference.yaml` (prefill+decode StatefulSets) | `rft-stack/templates/lws-inference-disagg.yaml` (new LWS group per role) |
+| `router.yaml` (EPP+Envoy Deployment) | `rft-stack/templates/router.yaml` extension: `router.type: llm-d` branch |
+| `mooncake.yaml` | new `rft-stack/templates/mooncake.yaml`, gated by `kvCacheOffload.mooncake.enabled` |
+| `configmap.yaml` (TOML + mooncake config) | merged into existing rft-stack config rendering |
+| `Dockerfile.llmd` | sibling `pi-rft/docker/prime-rl-llmd.Dockerfile` + a `build-push-prime-rl-llmd` workflow |
+
+## References
+
+- PR #2883 — vLLM 0.23 bump + GLM-5.2 16-node P/D config
+- `configs/glm5.2_16node_llmd/inference.toml` — golden source of truth for the
+  target topology
+- `src/prime_rl/templates/inference.sbatch.j2` — the SLURM equivalent of this
+  chart; consult when in doubt about role wiring
+- `pi-rft/k8s/rft-stack/` — the production chart this will eventually merge
+  into

--- a/temp-experimental/docker/Dockerfile.llmd
+++ b/temp-experimental/docker/Dockerfile.llmd
@@ -1,11 +1,7 @@
-# Downstream image for disaggregated P/D + llm-d + mooncake on K8s.
-#
-# Layers on top of the base prime-rl image (built by pi-rft's
-# build-push-prime-rl workflow). Adds:
-#   - NIXL rebuilt from source against the baked UCX 1.19. The pip wheel
-#     ships UCX that segfaults on prefill->decode KV transfer (see PR #2883).
-#   - llm-d Go binaries (epp, envoy, pd-sidecar) into /app/third_party/llmd/bin,
-#     where the existing prime-rl templates already expect them.
+# Downstream image: layers the llm-d Go binaries (epp, envoy, pd-sidecar) on
+# top of the base prime-rl image. NIXL-from-source is baked into the base
+# image's Dockerfile.cuda directly (it needs CUDA dev tools, which only the
+# base image's builder stage has).
 #
 # Build:
 #   docker build \
@@ -19,36 +15,16 @@ FROM ${BASE_IMAGE}
 
 USER root
 
-# Build deps for NIXL (UCX itself is already installed under /opt/ucx in the base).
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        build-essential \
-        autoconf \
-        automake \
-        libtool \
-        pkg-config \
-        ninja-build \
-        libnuma-dev \
-        libnl-3-dev \
-        libnl-route-3-dev \
-        libibverbs-dev \
-        librdmacm-dev \
-    && rm -rf /var/lib/apt/lists/*
-
-# install_nixl_from_source.sh expects UCX at $PROJECT_DIR/third_party/ucx. The
-# base image installs UCX under /opt/ucx; symlink so the script finds it without
-# editing.
-RUN mkdir -p /app/third_party && ln -sfn /opt/ucx /app/third_party/ucx
+# install_llmd.sh isn't shipped in the base image's runtime stage — copy it in
+# from the build context (prime-rl repo root). It vendors its own Go toolchain
+# under /app/third_party/llmd/go, so no system Go required.
+COPY scripts/install_llmd.sh /app/scripts/install_llmd.sh
 
 WORKDIR /app
 
-# Rebuild NIXL and reinstall the resulting wheel over the locked one.
-RUN bash /app/scripts/install_nixl_from_source.sh \
-    && /app/.venv/bin/pip install --reinstall --no-deps /app/deps/nixl_cu12-*.whl \
-    && rm -rf /app/nixl_workspace
-
-# llm-d Go binaries -> /app/third_party/llmd/bin (epp, envoy, pd-sidecar). The
-# install script vendors Go + builds Envoy from the official image via crane,
-# so no Docker-in-Docker is needed.
+# llm-d Go binaries -> /app/third_party/llmd/bin (epp, envoy, pd-sidecar).
+# Builds Envoy by exporting the official Envoy image's static binary via crane,
+# so no Docker-in-Docker needed.
 RUN bash /app/scripts/install_llmd.sh \
     && rm -rf /app/third_party/llmd/src /app/third_party/llmd/go /app/third_party/llmd/gotools
 

--- a/temp-experimental/docker/Dockerfile.llmd
+++ b/temp-experimental/docker/Dockerfile.llmd
@@ -1,0 +1,57 @@
+# Downstream image for disaggregated P/D + llm-d + mooncake on K8s.
+#
+# Layers on top of the base prime-rl image (built by pi-rft's
+# build-push-prime-rl workflow). Adds:
+#   - NIXL rebuilt from source against the baked UCX 1.19. The pip wheel
+#     ships UCX that segfaults on prefill->decode KV transfer (see PR #2883).
+#   - llm-d Go binaries (epp, envoy, pd-sidecar) into /app/third_party/llmd/bin,
+#     where the existing prime-rl templates already expect them.
+#
+# Build:
+#   docker build \
+#     --build-arg BASE_IMAGE=ghcr.io/primeintellect-ai/hosted-rl/prime-rl:<tag>-amd64 \
+#     -f temp-experimental/docker/Dockerfile.llmd \
+#     -t ghcr.io/primeintellect-ai/hosted-rl/prime-rl-llmd:<tag>-amd64 \
+#     .
+
+ARG BASE_IMAGE=ghcr.io/primeintellect-ai/hosted-rl/prime-rl:dev-latest
+FROM ${BASE_IMAGE}
+
+USER root
+
+# Build deps for NIXL (UCX itself is already installed under /opt/ucx in the base).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        autoconf \
+        automake \
+        libtool \
+        pkg-config \
+        ninja-build \
+        libnuma-dev \
+        libnl-3-dev \
+        libnl-route-3-dev \
+        libibverbs-dev \
+        librdmacm-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# install_nixl_from_source.sh expects UCX at $PROJECT_DIR/third_party/ucx. The
+# base image installs UCX under /opt/ucx; symlink so the script finds it without
+# editing.
+RUN mkdir -p /app/third_party && ln -sfn /opt/ucx /app/third_party/ucx
+
+WORKDIR /app
+
+# Rebuild NIXL and reinstall the resulting wheel over the locked one.
+RUN bash /app/scripts/install_nixl_from_source.sh \
+    && /app/.venv/bin/pip install --reinstall --no-deps /app/deps/nixl_cu12-*.whl \
+    && rm -rf /app/nixl_workspace
+
+# llm-d Go binaries -> /app/third_party/llmd/bin (epp, envoy, pd-sidecar). The
+# install script vendors Go + builds Envoy from the official image via crane,
+# so no Docker-in-Docker is needed.
+RUN bash /app/scripts/install_llmd.sh \
+    && rm -rf /app/third_party/llmd/src /app/third_party/llmd/go /app/third_party/llmd/gotools
+
+ENV PATH=/app/third_party/llmd/bin:$PATH
+
+USER 1000

--- a/temp-experimental/helm/Chart.yaml
+++ b/temp-experimental/helm/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: prime-rl-inference-llmd
+description: Experimental Helm chart for disaggregated P/D vLLM inference with mooncake KV pool + llm-d router on Kubernetes
+type: application
+version: 0.0.1
+appVersion: "main"
+keywords:
+  - inference
+  - vllm
+  - disaggregated
+  - llm-d
+  - mooncake
+sources:
+  - https://github.com/PrimeIntellect-ai/prime-rl

--- a/temp-experimental/helm/templates/_helpers.tpl
+++ b/temp-experimental/helm/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/* Release-scoped name fragments and label sets. */}}
+
+{{- define "prime-rl-llmd.fullname" -}}
+{{- .Release.Name -}}
+{{- end -}}
+
+{{- define "prime-rl-llmd.labels" -}}
+app.kubernetes.io/name: prime-rl-llmd
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "prime-rl-llmd.selectorLabels" -}}
+app.kubernetes.io/name: prime-rl-llmd
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/* mooncake master DNS name. Inference pods use this for the master + metadata server. */}}
+{{- define "prime-rl-llmd.mooncakeMasterHost" -}}
+{{ .Release.Name }}-mooncake.{{ .Values.namespace }}.svc.cluster.local
+{{- end -}}
+
+{{/* Common pod spec env: secrets + telemetry. */}}
+{{- define "prime-rl-llmd.commonEnv" -}}
+- name: POD_NAME
+  valueFrom:
+    fieldRef:
+      fieldPath: metadata.name
+- name: POD_IP
+  valueFrom:
+    fieldRef:
+      fieldPath: status.podIP
+- name: POD_NAMESPACE
+  valueFrom:
+    fieldRef:
+      fieldPath: metadata.namespace
+{{- if .Values.secrets.enabled }}
+- name: HF_TOKEN
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.secrets.name }}
+      key: hf-token
+      optional: true
+- name: WANDB_API_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.secrets.name }}
+      key: wandb-api-key
+      optional: true
+{{- end }}
+{{- end -}}

--- a/temp-experimental/helm/templates/configmap.yaml
+++ b/temp-experimental/helm/templates/configmap.yaml
@@ -1,0 +1,67 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-inference-toml
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "prime-rl-llmd.labels" . | nindent 4 }}
+data:
+  # Per-node inference TOML mounted at /etc/prime-rl/inference.toml. Deliberately
+  # omits [deployment] and [slurm] — K8s primitives replace them. The required
+  # use_pd_kv_transfer = true tells the per-worker InferenceConfig to emit the
+  # NIXL transfer connector (otherwise dropping [deployment] would lose P/D).
+  inference.toml: |
+    output_dir = "{{ .Values.storage.mountPath }}/outputs"
+
+    enable_expert_parallel = {{ .Values.vllm.enableExpertParallel }}
+    gpu_memory_utilization = {{ .Values.vllm.gpuMemoryUtilization }}
+    enable_eplb = {{ .Values.vllm.enableEplb }}
+    use_deep_gemm = {{ .Values.vllm.useDeepGemm }}
+    enable_fp32_lm_head = {{ .Values.vllm.enableFp32LmHead }}
+    use_pd_kv_transfer = true
+
+    [model]
+    name = "{{ .Values.model.name }}"
+    max_model_len = {{ .Values.model.maxModelLen }}
+    tool_call_parser = "{{ .Values.model.toolCallParser }}"
+    reasoning_parser = "{{ .Values.model.reasoningParser }}"
+
+    [vllm_extra]
+    {{- range $k, $v := .Values.vllm.vllmExtra }}
+    {{ $k }} = {{ $v | toJson }}
+    {{- end }}
+
+    {{- if .Values.mooncake.enabled }}
+
+    [kv_cache_offload]
+    type = "mooncake"
+    device_name = "{{ .Values.mooncake.deviceName }}"
+
+    [kv_cache_offload.cpu]
+    num_bytes = {{ printf "%d" (int64 .Values.mooncake.cpuBytes) }}
+    {{- end }}
+{{- if .Values.mooncake.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-mooncake-config
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "prime-rl-llmd.labels" . | nindent 4 }}
+data:
+  # Read by every inference pod (vLLM connector + mooncake_client sidecar).
+  # The standalone-store mode means each pod contributes its DRAM segment to
+  # the single shared pool fronted by {{ include "prime-rl-llmd.mooncakeMasterHost" . }}.
+  config.json: |
+    {
+      "mode": "standalone-store",
+      "global_segment_size": 0,
+      "local_buffer_size": 4294967296,
+      "protocol": "rdma",
+      "device_name": "{{ .Values.mooncake.deviceName }}",
+      "master_server_address": "{{ include "prime-rl-llmd.mooncakeMasterHost" . }}:50051",
+      "metadata_server": "http://{{ include "prime-rl-llmd.mooncakeMasterHost" . }}:8080/metadata",
+      "enable_offload": false
+    }
+{{- end }}

--- a/temp-experimental/helm/templates/inference.yaml
+++ b/temp-experimental/helm/templates/inference.yaml
@@ -1,0 +1,407 @@
+{{/*
+Prefill + decode StatefulSets. Single-pod-per-role smoke topology:
+one GPU per pod, DP=1, no cross-node TP. For the full multi-replica /
+multi-node case (e.g. GLM-5.2 16-node), this template needs to grow:
+  - Multiple DP ranks per pod (loop over `gpusPerNode` like _launch_rank.sh.j2)
+  - data_parallel_address pointing at the per-replica head pod
+  - LeaderWorkerSet instead of StatefulSet for cross-node TP groups
+Tracked in README "What's missing".
+*/}}
+
+{{- define "prime-rl-llmd.inferenceContainerEnv" -}}
+- name: VLLM_HOST_IP
+  valueFrom:
+    fieldRef:
+      fieldPath: status.podIP
+- name: VLLM_NIXL_SIDE_CHANNEL_HOST
+  valueFrom:
+    fieldRef:
+      fieldPath: status.podIP
+- name: VLLM_NIXL_SIDE_CHANNEL_PORT
+  value: "5600"
+- name: UCX_TLS
+  value: "all"
+- name: PYTHONHASHSEED
+  value: "0"
+- name: PYTHONUNBUFFERED
+  value: "1"
+- name: PYTORCH_CUDA_ALLOC_CONF
+  value: "expandable_segments:False"
+{{- if .Values.mooncake.enabled }}
+- name: MOONCAKE_CONFIG_PATH
+  value: "/etc/mooncake/config.json"
+{{- end }}
+- name: HF_HOME
+  value: "{{ .Values.storage.mountPath }}/hf_cache"
+{{- end -}}
+
+# ---- PREFILL ----
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-prefill
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "prime-rl-llmd.labels" . | nindent 4 }}
+    role: prefill
+spec:
+  clusterIP: None
+  selector:
+    {{- include "prime-rl-llmd.selectorLabels" . | nindent 4 }}
+    role: prefill
+  ports:
+  - name: api
+    port: {{ .Values.prefill.port }}
+    targetPort: api
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Release.Name }}-prefill
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "prime-rl-llmd.labels" . | nindent 4 }}
+    role: prefill
+spec:
+  serviceName: {{ .Release.Name }}-prefill
+  replicas: {{ .Values.prefill.replicas }}
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      {{- include "prime-rl-llmd.selectorLabels" . | nindent 6 }}
+      role: prefill
+  template:
+    metadata:
+      labels:
+        {{- include "prime-rl-llmd.selectorLabels" . | nindent 8 }}
+        role: prefill
+    spec:
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.rdma.hostNetwork }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
+      runtimeClassName: {{ .Values.runtimeClassName }}
+      containers:
+      - name: vllm
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+            ulimit -l unlimited 2>/dev/null || true
+            mkdir -p /tmp/vllm-rpc-prefill-{{ .Values.prefill.port }}
+            export VLLM_RPC_BASE_PATH=/tmp/vllm-rpc-prefill-{{ .Values.prefill.port }}
+            EXTRA='{"all2all_backend": "deepep_high_throughput", "data_parallel_address": "'"$POD_IP"'", "data_parallel_rank": 0}'
+            uv run inference @ /etc/prime-rl/inference.toml \
+              --server.host 0.0.0.0 \
+              --server.port {{ .Values.prefill.port }} \
+              --parallel.dp 1 \
+              --data-parallel-size-local 1 \
+              --api-server-count 1 \
+              --vllm-extra "$EXTRA"
+        env:
+        {{- include "prime-rl-llmd.commonEnv" . | nindent 8 }}
+        {{- include "prime-rl-llmd.inferenceContainerEnv" . | nindent 8 }}
+        - name: ROLE
+          value: "prefill"
+        {{- range $k, $v := .Values.prefill.envOverrides }}
+        - name: {{ $k }}
+          value: {{ $v | quote }}
+        {{- end }}
+        ports:
+        - containerPort: {{ .Values.prefill.port }}
+          name: api
+        - containerPort: 5600
+          name: nixl
+        resources:
+          requests:
+            {{ .Values.gpu.resourceName }}: {{ .Values.prefill.gpusPerNode }}
+            {{- with .Values.prefill.resources.requests }}
+            cpu: {{ .cpu }}
+            memory: {{ .memory }}
+            {{- end }}
+            {{- if .Values.rdma.enabled }}
+            {{ .Values.rdma.deviceName }}: {{ .Values.rdma.count }}
+            {{- end }}
+          limits:
+            {{ .Values.gpu.resourceName }}: {{ .Values.prefill.gpusPerNode }}
+            {{- if .Values.rdma.enabled }}
+            {{ .Values.rdma.deviceName }}: {{ .Values.rdma.count }}
+            {{- end }}
+        {{- if .Values.rdma.privileged }}
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["IPC_LOCK"]
+        {{- end }}
+        volumeMounts:
+        - name: shared-data
+          mountPath: {{ .Values.storage.mountPath }}
+        - name: inference-toml
+          mountPath: /etc/prime-rl
+        {{- if .Values.mooncake.enabled }}
+        - name: mooncake-config
+          mountPath: /etc/mooncake
+        {{- end }}
+        - name: dshm
+          mountPath: /dev/shm
+      {{- if .Values.mooncake.enabled }}
+      - name: mooncake-client
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: ["/bin/bash", "-c"]
+        # Wait for master DNS+port, then register this pod's DRAM segment.
+        args:
+          - |
+            set -e
+            for _ in $(seq 1 120); do
+              timeout 1 bash -c "echo > /dev/tcp/{{ include "prime-rl-llmd.mooncakeMasterHost" . }}/50051" 2>/dev/null && break
+              sleep 1
+            done
+            exec mooncake_client \
+              -host=$POD_IP -port=50052 \
+              -master_server_address={{ include "prime-rl-llmd.mooncakeMasterHost" . }}:50051 \
+              -metadata_server=http://{{ include "prime-rl-llmd.mooncakeMasterHost" . }}:8080/metadata \
+              -protocol=rdma \
+              -global_segment_size={{ div .Values.mooncake.cpuBytes (add .Values.prefill.replicas .Values.decode.replicas) }} \
+              {{- if .Values.mooncake.deviceName }}
+              -device_names={{ .Values.mooncake.deviceName }}
+              {{- end }}
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        {{- if .Values.rdma.enabled }}
+        resources:
+          requests:
+            {{ .Values.rdma.deviceName }}: {{ .Values.rdma.count }}
+          limits:
+            {{ .Values.rdma.deviceName }}: {{ .Values.rdma.count }}
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["IPC_LOCK"]
+        {{- end }}
+      {{- end }}
+      volumes:
+      {{- if .Values.storage.enabled }}
+      - name: shared-data
+        persistentVolumeClaim:
+          claimName: {{ .Release.Name }}-shared
+      {{- end }}
+      - name: inference-toml
+        configMap:
+          name: {{ .Release.Name }}-inference-toml
+      {{- if .Values.mooncake.enabled }}
+      - name: mooncake-config
+        configMap:
+          name: {{ .Release.Name }}-mooncake-config
+      {{- end }}
+      - name: dshm
+        emptyDir:
+          medium: Memory
+          sizeLimit: {{ .Values.shmSize }}
+---
+# ---- DECODE ----
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-decode
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "prime-rl-llmd.labels" . | nindent 4 }}
+    role: decode
+spec:
+  clusterIP: None
+  selector:
+    {{- include "prime-rl-llmd.selectorLabels" . | nindent 4 }}
+    role: decode
+  ports:
+  - name: api
+    port: {{ .Values.decode.port }}
+    targetPort: api
+  - name: sidecar
+    port: {{ .Values.decode.sidecarPort }}
+    targetPort: sidecar
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Release.Name }}-decode
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "prime-rl-llmd.labels" . | nindent 4 }}
+    role: decode
+spec:
+  serviceName: {{ .Release.Name }}-decode
+  replicas: {{ .Values.decode.replicas }}
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      {{- include "prime-rl-llmd.selectorLabels" . | nindent 6 }}
+      role: decode
+  template:
+    metadata:
+      labels:
+        {{- include "prime-rl-llmd.selectorLabels" . | nindent 8 }}
+        role: decode
+    spec:
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.rdma.hostNetwork }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
+      runtimeClassName: {{ .Values.runtimeClassName }}
+      containers:
+      - name: vllm
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+            ulimit -l unlimited 2>/dev/null || true
+            mkdir -p /tmp/vllm-rpc-decode-{{ .Values.decode.port }}
+            export VLLM_RPC_BASE_PATH=/tmp/vllm-rpc-decode-{{ .Values.decode.port }}
+            EXTRA='{"all2all_backend": "deepep_low_latency", "compilation_config": {"cudagraph_mode": "FULL_DECODE_ONLY"}, "data_parallel_address": "'"$POD_IP"'", "data_parallel_rank": 0}'
+            uv run inference @ /etc/prime-rl/inference.toml \
+              --server.host 0.0.0.0 \
+              --server.port {{ .Values.decode.port }} \
+              --parallel.dp 1 \
+              --data-parallel-size-local 1 \
+              --api-server-count 1 \
+              --vllm-extra "$EXTRA"
+        env:
+        {{- include "prime-rl-llmd.commonEnv" . | nindent 8 }}
+        {{- include "prime-rl-llmd.inferenceContainerEnv" . | nindent 8 }}
+        - name: ROLE
+          value: "decode"
+        # Per the SLURM template: decode pins UCX to a single NIC for stability.
+        - name: UCX_NET_DEVICES
+          value: "mlx5_0:1"
+        {{- range $k, $v := .Values.decode.envOverrides }}
+        - name: {{ $k }}
+          value: {{ $v | quote }}
+        {{- end }}
+        ports:
+        - containerPort: {{ .Values.decode.port }}
+          name: api
+        - containerPort: 5600
+          name: nixl
+        resources:
+          requests:
+            {{ .Values.gpu.resourceName }}: {{ .Values.decode.gpusPerNode }}
+            {{- with .Values.decode.resources.requests }}
+            cpu: {{ .cpu }}
+            memory: {{ .memory }}
+            {{- end }}
+            {{- if .Values.rdma.enabled }}
+            {{ .Values.rdma.deviceName }}: {{ .Values.rdma.count }}
+            {{- end }}
+          limits:
+            {{ .Values.gpu.resourceName }}: {{ .Values.decode.gpusPerNode }}
+            {{- if .Values.rdma.enabled }}
+            {{ .Values.rdma.deviceName }}: {{ .Values.rdma.count }}
+            {{- end }}
+        {{- if .Values.rdma.privileged }}
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["IPC_LOCK"]
+        {{- end }}
+        volumeMounts:
+        - name: shared-data
+          mountPath: {{ .Values.storage.mountPath }}
+        - name: inference-toml
+          mountPath: /etc/prime-rl
+        {{- if .Values.mooncake.enabled }}
+        - name: mooncake-config
+          mountPath: /etc/mooncake
+        {{- end }}
+        - name: dshm
+          mountPath: /dev/shm
+      - name: pd-sidecar
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: ["/bin/bash", "-c"]
+        # pd-sidecar fronts vLLM decode: EPP -> sidecar -> vLLM decode after
+        # orchestrating remote prefill via NIXL. Per-rank ports (PORT + rank);
+        # single-rank smoke topology uses rank 0.
+        args:
+          - |
+            exec pd-sidecar \
+              --port {{ .Values.decode.sidecarPort }} \
+              --vllm-port {{ .Values.decode.port }} \
+              --kv-connector nixlv2 \
+              --secure-proxy=false \
+              --enable-ssrf-protection=false \
+              --inference-pool prime-rl \
+              --data-parallel-size 1
+        ports:
+        - containerPort: {{ .Values.decode.sidecarPort }}
+          name: sidecar
+      {{- if .Values.mooncake.enabled }}
+      - name: mooncake-client
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+            for _ in $(seq 1 120); do
+              timeout 1 bash -c "echo > /dev/tcp/{{ include "prime-rl-llmd.mooncakeMasterHost" . }}/50051" 2>/dev/null && break
+              sleep 1
+            done
+            exec mooncake_client \
+              -host=$POD_IP -port=50052 \
+              -master_server_address={{ include "prime-rl-llmd.mooncakeMasterHost" . }}:50051 \
+              -metadata_server=http://{{ include "prime-rl-llmd.mooncakeMasterHost" . }}:8080/metadata \
+              -protocol=rdma \
+              -global_segment_size={{ div .Values.mooncake.cpuBytes (add .Values.prefill.replicas .Values.decode.replicas) }} \
+              {{- if .Values.mooncake.deviceName }}
+              -device_names={{ .Values.mooncake.deviceName }}
+              {{- end }}
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        {{- if .Values.rdma.enabled }}
+        resources:
+          requests:
+            {{ .Values.rdma.deviceName }}: {{ .Values.rdma.count }}
+          limits:
+            {{ .Values.rdma.deviceName }}: {{ .Values.rdma.count }}
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["IPC_LOCK"]
+        {{- end }}
+      {{- end }}
+      volumes:
+      {{- if .Values.storage.enabled }}
+      - name: shared-data
+        persistentVolumeClaim:
+          claimName: {{ .Release.Name }}-shared
+      {{- end }}
+      - name: inference-toml
+        configMap:
+          name: {{ .Release.Name }}-inference-toml
+      {{- if .Values.mooncake.enabled }}
+      - name: mooncake-config
+        configMap:
+          name: {{ .Release.Name }}-mooncake-config
+      {{- end }}
+      - name: dshm
+        emptyDir:
+          medium: Memory
+          sizeLimit: {{ .Values.shmSize }}

--- a/temp-experimental/helm/templates/mooncake.yaml
+++ b/temp-experimental/helm/templates/mooncake.yaml
@@ -1,0 +1,76 @@
+{{- if .Values.mooncake.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-mooncake
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "prime-rl-llmd.labels" . | nindent 4 }}
+    role: mooncake-master
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "prime-rl-llmd.selectorLabels" . | nindent 6 }}
+      role: mooncake-master
+  template:
+    metadata:
+      labels:
+        {{- include "prime-rl-llmd.selectorLabels" . | nindent 8 }}
+        role: mooncake-master
+    spec:
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: mooncake-master
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: ["/bin/bash", "-c"]
+        # default_kv_lease_ttl raised from 5s: KV blocks were expiring before the
+        # decode side reused them (see prime-rl _mooncake_store.sh.j2).
+        args:
+          - |
+            mooncake_master \
+              -rpc_port=50051 \
+              -enable_http_metadata_server \
+              -http_metadata_server_host=0.0.0.0 \
+              -http_metadata_server_port=8080 \
+              -default_kv_lease_ttl={{ .Values.mooncake.defaultKvLeaseTtl }}
+        ports:
+        - containerPort: 50051
+          name: rpc
+        - containerPort: 8080
+          name: metadata
+        - containerPort: 9003
+          name: metrics
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-mooncake
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "prime-rl-llmd.labels" . | nindent 4 }}
+    role: mooncake-master
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "prime-rl-llmd.selectorLabels" . | nindent 4 }}
+    role: mooncake-master
+  ports:
+  - name: rpc
+    port: 50051
+    targetPort: rpc
+  - name: metadata
+    port: 8080
+    targetPort: metadata
+  - name: metrics
+    port: 9003
+    targetPort: metrics
+{{- end }}

--- a/temp-experimental/helm/templates/pvc.yaml
+++ b/temp-experimental/helm/templates/pvc.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.storage.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-shared
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "prime-rl-llmd.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.storage.accessModes | nindent 4 }}
+  storageClassName: {{ .Values.storage.storageClassName }}
+  resources:
+    requests:
+      storage: {{ .Values.storage.size }}
+{{- end }}

--- a/temp-experimental/helm/templates/router.yaml
+++ b/temp-experimental/helm/templates/router.yaml
@@ -1,0 +1,305 @@
+{{- if .Values.router.enabled }}
+{{- $prefillScorers := merge dict .Values.router.scorers .Values.router.prefillScorerOverrides -}}
+{{- $decodeScorers := merge dict .Values.router.scorers .Values.router.decodeScorerOverrides -}}
+{{- $allScorers := keys (merge dict $prefillScorers $decodeScorers) | uniq -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-router
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "prime-rl-llmd.labels" . | nindent 4 }}
+data:
+  epp.yaml: |
+    apiVersion: inference.networking.x-k8s.io/v1alpha1
+    kind: EndpointPickerConfig
+    plugins:
+      - name: file-disc
+        type: file-discovery
+        parameters:
+          path: /etc/llmd/endpoints.yaml
+          watchFile: true
+      - name: vllmhttp-parser
+        type: vllmhttp-parser
+      - name: pd-decider
+        type: prefix-based-pd-decider
+        parameters:
+          nonCachedTokens: {{ .Values.router.nonCachedTokens }}
+      - name: profile-handler
+        type: disagg-profile-handler
+        parameters:
+          deciders:
+            prefill: pd-decider
+      - type: prefill-filter
+      - type: decode-filter
+      {{- range $scorer := $allScorers }}
+      - type: {{ $scorer }}
+      {{- end }}
+      - type: max-score-picker
+    schedulingProfiles:
+      - name: prefill
+        plugins:
+          - pluginRef: prefill-filter
+          {{- range $name, $weight := $prefillScorers }}
+          - pluginRef: {{ $name }}
+            weight: {{ $weight }}
+          {{- end }}
+          - pluginRef: max-score-picker
+      - name: decode
+        plugins:
+          - pluginRef: decode-filter
+          {{- range $name, $weight := $decodeScorers }}
+          - pluginRef: {{ $name }}
+            weight: {{ $weight }}
+          {{- end }}
+          - pluginRef: max-score-picker
+    requestHandler:
+      parser:
+        pluginRef: vllmhttp-parser
+    dataLayer:
+      discovery:
+        pluginRef: file-disc
+
+  envoy.yaml: |
+    admin:
+      address: { socket_address: { address: 127.0.0.1, port_value: 9901 } }
+    static_resources:
+      listeners:
+        - name: prime_rl
+          address: { socket_address: { address: 0.0.0.0, port_value: {{ .Values.router.port }} } }
+          filter_chains:
+            - filters:
+                - name: envoy.filters.network.http_connection_manager
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                    stat_prefix: prime_rl
+                    codec_type: AUTO
+                    stream_idle_timeout: 0s
+                    request_timeout: 0s
+                    route_config:
+                      virtual_hosts:
+                        - name: prime_rl
+                          domains: ["*"]
+                          routes:
+                            - match: { prefix: "/v1/" }
+                              route: { cluster: backend_cluster, timeout: 0s, idle_timeout: 86400s }
+                            - match: { prefix: "/inference/v1/" }
+                              route: { cluster: backend_cluster, timeout: 0s, idle_timeout: 86400s }
+                    http_filters:
+                      - name: envoy.filters.http.ext_proc
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+                          grpc_service:
+                            envoy_grpc: { cluster_name: epp_cluster }
+                            timeout: 10s
+                          processing_mode:
+                            request_header_mode: SEND
+                            response_header_mode: SEND
+                            request_body_mode: FULL_DUPLEX_STREAMED
+                            response_body_mode: FULL_DUPLEX_STREAMED
+                            request_trailer_mode: SEND
+                            response_trailer_mode: SEND
+                          message_timeout: 1000s
+                      - name: envoy.filters.http.router
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                          suppress_envoy_headers: true
+      clusters:
+        - name: backend_cluster
+          type: ORIGINAL_DST
+          lb_policy: CLUSTER_PROVIDED
+          original_dst_lb_config:
+            use_http_header: true
+            http_header_name: x-gateway-destination-endpoint
+          connect_timeout: 5s
+          circuit_breakers:
+            thresholds:
+              - priority: DEFAULT
+                max_connections: 100000
+                max_pending_requests: 100000
+                max_requests: 100000
+                max_retries: 1000
+              - priority: HIGH
+                max_connections: 100000
+                max_pending_requests: 100000
+                max_requests: 100000
+                max_retries: 1000
+        - name: epp_cluster
+          type: STRICT_DNS
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options: {}
+          load_assignment:
+            cluster_name: epp_cluster
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address: { socket_address: { address: 127.0.0.1, port_value: 9002 } }
+          connect_timeout: 5s
+          circuit_breakers:
+            thresholds:
+              - priority: DEFAULT
+                max_connections: 100000
+                max_pending_requests: 100000
+                max_requests: 100000
+                max_retries: 1000
+              - priority: HIGH
+                max_connections: 100000
+                max_pending_requests: 100000
+                max_requests: 100000
+                max_retries: 1000
+
+  # Endpoint discovery template. The init container fills in pod IPs at startup
+  # because file-discovery rejects hostnames. Single-pod-per-role smoke topology;
+  # for the 16-node case this becomes one entry per (pod × DP-rank).
+  endpoints.template.yaml: |
+    endpoints:
+    {{- range $i := until (int .Values.prefill.replicas) }}
+      - name: prefill-{{ $i }}
+        address: __PREFILL_{{ $i }}__
+        port: "{{ $.Values.prefill.port }}"
+        namespace: default
+        labels:
+          llm-d.ai/pool: prime-rl
+          llm-d.ai/role: prefill
+    {{- end }}
+    {{- range $i := until (int .Values.decode.replicas) }}
+      - name: decode-{{ $i }}
+        address: __DECODE_{{ $i }}__
+        port: "{{ $.Values.decode.sidecarPort }}"
+        namespace: default
+        labels:
+          llm-d.ai/pool: prime-rl
+          llm-d.ai/role: decode
+    {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-router
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "prime-rl-llmd.labels" . | nindent 4 }}
+    role: router
+spec:
+  type: {{ .Values.router.service.type }}
+  selector:
+    {{- include "prime-rl-llmd.selectorLabels" . | nindent 4 }}
+    role: router
+  ports:
+  - name: http
+    port: {{ .Values.router.port }}
+    targetPort: gateway
+  - name: metrics
+    port: 9090
+    targetPort: metrics
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-router
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "prime-rl-llmd.labels" . | nindent 4 }}
+    role: router
+spec:
+  replicas: {{ .Values.router.replicas }}
+  selector:
+    matchLabels:
+      {{- include "prime-rl-llmd.selectorLabels" . | nindent 6 }}
+      role: router
+  template:
+    metadata:
+      labels:
+        {{- include "prime-rl-llmd.selectorLabels" . | nindent 8 }}
+        role: router
+    spec:
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      initContainers:
+      # Resolve prefill/decode pod IPs and substitute into endpoints.yaml.
+      # Re-runs would need a sidecar that watches DNS; for the smoke topology
+      # a one-shot resolve at startup is fine.
+      - name: render-endpoints
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+            cp /etc/llmd-src/endpoints.template.yaml /etc/llmd-out/endpoints.yaml
+            cp /etc/llmd-src/epp.yaml              /etc/llmd-out/epp.yaml
+            cp /etc/llmd-src/envoy.yaml            /etc/llmd-out/envoy.yaml
+            resolve() {
+              for _ in $(seq 1 120); do
+                ip=$(getent hosts "$1" | awk '{print $1}' | head -1)
+                if [ -n "$ip" ]; then echo "$ip"; return 0; fi
+                sleep 1
+              done
+              echo "ERROR: could not resolve $1" >&2; exit 1
+            }
+            {{- range $i := until (int .Values.prefill.replicas) }}
+            ip=$(resolve "{{ $.Release.Name }}-prefill-{{ $i }}.{{ $.Release.Name }}-prefill.{{ $.Values.namespace }}.svc.cluster.local")
+            sed -i "s|__PREFILL_{{ $i }}__|${ip}|g" /etc/llmd-out/endpoints.yaml
+            {{- end }}
+            {{- range $i := until (int .Values.decode.replicas) }}
+            ip=$(resolve "{{ $.Release.Name }}-decode-{{ $i }}.{{ $.Release.Name }}-decode.{{ $.Values.namespace }}.svc.cluster.local")
+            sed -i "s|__DECODE_{{ $i }}__|${ip}|g" /etc/llmd-out/endpoints.yaml
+            {{- end }}
+            cat /etc/llmd-out/endpoints.yaml
+        volumeMounts:
+        - name: llmd-src
+          mountPath: /etc/llmd-src
+        - name: llmd-rendered
+          mountPath: /etc/llmd-out
+      containers:
+      - name: epp
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            exec epp \
+              --pool-name prime-rl \
+              --pool-namespace {{ .Values.namespace }} \
+              --config-file /etc/llmd/epp.yaml \
+              --grpc-port 9002 \
+              --grpc-health-port 9013 \
+              --metrics-port 9090 \
+              --secure-serving=false \
+              --metrics-endpoint-auth=false \
+              --tracing=false
+        ports:
+        - containerPort: 9002
+          name: epp-grpc
+        - containerPort: 9013
+          name: epp-health
+        - containerPort: 9090
+          name: metrics
+        volumeMounts:
+        - name: llmd-rendered
+          mountPath: /etc/llmd
+      - name: envoy
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            exec envoy -c /etc/llmd/envoy.yaml
+        ports:
+        - containerPort: {{ .Values.router.port }}
+          name: gateway
+        volumeMounts:
+        - name: llmd-rendered
+          mountPath: /etc/llmd
+      volumes:
+      - name: llmd-src
+        configMap:
+          name: {{ .Release.Name }}-router
+      - name: llmd-rendered
+        emptyDir: {}
+{{- end }}

--- a/temp-experimental/helm/values-glm5.2-16node.yaml
+++ b/temp-experimental/helm/values-glm5.2-16node.yaml
@@ -1,0 +1,100 @@
+# Target topology from configs/glm5.2_16node_llmd/inference.toml (PR #2883):
+# 8 prefill nodes (4 P replicas of 2 nodes each) + 8 decode nodes (1 D replica of 8 nodes).
+#
+# WARNING: this file is a SKETCH. The current chart only renders single-pod-per-role
+# (1 GPU, DP=1). Honoring this file end-to-end needs the multi-node bits called out
+# in README.md "What's missing":
+#   - multi-DP per pod (per-rank vLLM API servers + sidecar ports)
+#   - cross-node TP via LWS instead of StatefulSet
+#   - data_parallel_address pointing at the replica head
+#   - per-replica EPP+Envoy (4 routers for 4 prefill replicas)
+#
+# Keep this file in sync with configs/glm5.2_16node_llmd/inference.toml as the
+# golden source of truth.
+
+image:
+  repository: ghcr.io/primeintellect-ai/hosted-rl/prime-rl-llmd
+  tag: "v0.5.x-glm5.2"
+
+model:
+  name: "zai-org/GLM-5.2-FP8"
+  maxModelLen: 91000
+  toolCallParser: "glm47"
+  reasoningParser: "glm45"
+
+vllm:
+  enableExpertParallel: true
+  gpuMemoryUtilization: 0.75
+  enableEplb: false
+  useDeepGemm: true
+  enableFp32LmHead: true
+  vllmExtra:
+    enable_ep_weight_filter: true
+    safetensors_load_strategy: "prefetch"
+
+prefill:
+  replicas: 8           # 8 prefill nodes total
+  gpusPerNode: 8        # H200 nodes
+  port: 8200
+  envOverrides:
+    VLLM_ENABLE_MOE_DP_CHUNK: "0"
+    VLLM_DEEP_GEMM_WARMUP: "skip"
+    UCX_RCACHE_MAX_UNRELEASED: "1024"
+  resources:
+    requests:
+      cpu: "32"
+      memory: "512Gi"
+
+decode:
+  replicas: 8           # 8 decode nodes total
+  gpusPerNode: 8
+  port: 8300
+  sidecarPort: 8400
+  envOverrides:
+    VLLM_DEEP_GEMM_WARMUP: "skip"
+    UCX_RCACHE_MAX_UNRELEASED: "1024"
+  resources:
+    requests:
+      cpu: "32"
+      memory: "512Gi"
+
+router:
+  enabled: true
+  replicas: 4           # one router per outer P/D replica
+  port: 8000
+  scorers:
+    "prefix-cache-scorer": 3.0
+  prefillScorerOverrides:
+    "queue-scorer": 4.0
+    "active-request-scorer": 5.0
+  decodeScorerOverrides:
+    "active-request-scorer": 5.0
+    "kv-cache-utilization-scorer": 4.0
+    "queue-scorer": 3.0
+  nonCachedTokens: 128
+
+mooncake:
+  enabled: true
+  cpuBytes: 1000000000000
+  deviceName: "mlx5_0,mlx5_3,mlx5_4,mlx5_5,mlx5_6,mlx5_9,mlx5_10,mlx5_11"
+
+rdma:
+  enabled: true
+  deviceName: "rdma/rdma_shared_device_a"
+  count: 8
+  hostNetwork: true
+  privileged: true
+
+storage:
+  enabled: true
+  storageClassName: nfs
+  size: 5Ti
+  mountPath: /data
+  accessModes:
+    - ReadWriteMany
+
+shmSize: "64Gi"
+
+secrets:
+  enabled: true
+  name: prime-rl-secrets

--- a/temp-experimental/helm/values.yaml
+++ b/temp-experimental/helm/values.yaml
@@ -1,0 +1,118 @@
+# Defaults are sized for the *minimal smoke-test topology*: one prefill node +
+# one decode node, single DP rank, one EPP+Envoy router, one mooncake master.
+# Override with values-glm5.2-16node.yaml for the PR #2883 target.
+
+namespace: default
+
+image:
+  # Built by temp-experimental/docker/Dockerfile.llmd.
+  repository: ghcr.io/primeintellect-ai/hosted-rl/prime-rl-llmd
+  pullPolicy: IfNotPresent
+  tag: "dev-latest"
+  pullSecrets:
+    - name: ghcr-secret
+
+# Shared model cache / HF home / output dir. RWX so prefill + decode + router
+# can share weights. Disable if you mount HF_HOME from a node-local cache.
+storage:
+  enabled: true
+  storageClassName: nfs
+  size: 1Ti
+  mountPath: /data
+  accessModes:
+    - ReadWriteMany
+
+model:
+  name: "zai-org/GLM-5.2-FP8"
+  maxModelLen: 91000
+  toolCallParser: "glm47"
+  reasoningParser: "glm45"
+
+# Per-role topology. gpusPerNode is also the TP within a node; DP between nodes.
+# `replicas` is the K8s StatefulSet replica count for that role.
+prefill:
+  replicas: 1
+  gpusPerNode: 1
+  port: 8200
+  envOverrides:
+    VLLM_ENABLE_MOE_DP_CHUNK: "0"
+    VLLM_DEEP_GEMM_WARMUP: "skip"
+    UCX_RCACHE_MAX_UNRELEASED: "1024"
+  resources:
+    requests:
+      cpu: "8"
+      memory: "64Gi"
+
+decode:
+  replicas: 1
+  gpusPerNode: 1
+  port: 8300
+  sidecarPort: 8400
+  envOverrides:
+    VLLM_DEEP_GEMM_WARMUP: "skip"
+    UCX_RCACHE_MAX_UNRELEASED: "1024"
+  resources:
+    requests:
+      cpu: "8"
+      memory: "64Gi"
+
+# Common inference settings applied to both roles.
+vllm:
+  enableExpertParallel: true
+  gpuMemoryUtilization: 0.75
+  enableEplb: false
+  useDeepGemm: true
+  enableFp32LmHead: true
+  vllmExtra:
+    enable_ep_weight_filter: true
+    safetensors_load_strategy: "prefetch"
+
+# llm-d router (EPP + Envoy). One replica per "router replica" in the SLURM
+# template's sense — for the simple topology, one router fronts the whole
+# prefill/decode pool.
+router:
+  enabled: true
+  replicas: 1
+  port: 8000
+  scorers:
+    "prefix-cache-scorer": 3.0
+  prefillScorerOverrides:
+    "queue-scorer": 4.0
+    "active-request-scorer": 5.0
+  decodeScorerOverrides:
+    "active-request-scorer": 5.0
+    "kv-cache-utilization-scorer": 4.0
+    "queue-scorer": 3.0
+  nonCachedTokens: 128
+  service:
+    type: ClusterIP
+
+# Mooncake distributed KV store. One master Deployment + Service, every
+# inference pod runs a mooncake_client sidecar contributing its DRAM segment.
+mooncake:
+  enabled: true
+  cpuBytes: 1000000000000  # 1 TB pool across the fleet
+  deviceName: "mlx5_0,mlx5_3,mlx5_4,mlx5_5,mlx5_6,mlx5_9,mlx5_10,mlx5_11"
+  defaultKvLeaseTtl: 3600000
+
+# RDMA / IB. Required for mooncake transfer + NIXL P/D KV. Without these the
+# fallback is TCP, which works for smoke tests but defeats the purpose.
+rdma:
+  enabled: false
+  deviceName: "rdma/rdma_shared_device_a"
+  count: 1
+  hostNetwork: false  # set to true if your IB plugin requires it
+  privileged: true
+
+# vLLM workers need GPUs and IPC_LOCK for pinned-memory KV registration.
+runtimeClassName: nvidia
+gpu:
+  resourceName: "nvidia.com/gpu"
+
+# Shared memory for vLLM multiprocess executor / NCCL.
+shmSize: "16Gi"
+
+secrets:
+  enabled: false
+  name: prime-rl-secrets
+  # Expected keys: hf-token, wandb-api-key


### PR DESCRIPTION
- Removes `job_id` / `jobId` from `HostedTrainingRunResponse` and the `prime rl` dispatch surface (JSON output and human print).
- `job_id` is a platform-internal scheduling id; the backend is dropping it from `POST /api/v1/training/runs` so clients can't infer the cluster from it.
- Beta-gated, no compat shims needed. `run_id` and `token_value` remain.
