### PR TITLE
feat(dockerfile): opt-in NIXL-from-source build (INCLUDE_NIXL_FROM_SOURCE)

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -98,6 +98,18 @@ RUN --mount=type=cache,target=/app/.cache/uv \
     && \
     uv sync --extra flash-attn --extra flash-attn-3 --extra flash-attn-cute --extra envs --extra gpt-oss --extra modelexpress --group mamba-ssm --locked --no-dev
 
+# Build NIXL from source against the UCX 1.19 baked above. The PyPI nixl wheel
+# ships its own UCX which segfaults on prefill→decode KV transfer (#2883);
+# rebuilding against our UCX is the documented fix.
+ARG NIXL_VERSION=0.10.1
+RUN git clone --depth 1 --branch ${NIXL_VERSION} https://github.com/ai-dynamo/nixl.git /tmp/nixl \
+    && cd /tmp/nixl \
+    && PKG_CONFIG_PATH=/opt/ucx/lib/pkgconfig \
+       LD_LIBRARY_PATH=/opt/ucx/lib:/opt/ucx/lib/ucx \
+       /app/.venv/bin/python -m pip wheel . --no-deps --wheel-dir=/app/deps \
+    && /app/.venv/bin/pip install --reinstall --no-deps /app/deps/nixl_cu12-*.whl \
+    && rm -rf /tmp/nixl /app/deps/nixl_cu12-*.whl
+
 # arm64: build flash-attn from source, fix namespace conflicts, apply workarounds
 ARG TARGETARCH
 COPY scripts/docker-arm64-post-install.sh /app/scripts/docker-arm64-post-install.sh

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -98,17 +98,22 @@ RUN --mount=type=cache,target=/app/.cache/uv \
     && \
     uv sync --extra flash-attn --extra flash-attn-3 --extra flash-attn-cute --extra envs --extra gpt-oss --extra modelexpress --group mamba-ssm --locked --no-dev
 
-# Build NIXL from source against the UCX 1.19 baked above. The PyPI nixl wheel
-# ships its own UCX which segfaults on prefill→decode KV transfer (#2883);
-# rebuilding against our UCX is the documented fix.
+# Optional: build NIXL from source against the UCX 1.19 baked above. The PyPI
+# nixl wheel ships its own UCX which segfaults on prefill→decode KV transfer
+# (#2883); rebuilding against our UCX is the documented fix. Only needed for
+# the disaggregated P/D path — default off so training-only / single-node
+# inference builds are unaffected. Enable via `--build-arg INCLUDE_NIXL_FROM_SOURCE=1`.
+ARG INCLUDE_NIXL_FROM_SOURCE=0
 ARG NIXL_VERSION=0.10.1
-RUN git clone --depth 1 --branch ${NIXL_VERSION} https://github.com/ai-dynamo/nixl.git /tmp/nixl \
-    && cd /tmp/nixl \
-    && PKG_CONFIG_PATH=/opt/ucx/lib/pkgconfig \
-       LD_LIBRARY_PATH=/opt/ucx/lib:/opt/ucx/lib/ucx \
-       /app/.venv/bin/python -m pip wheel . --no-deps --wheel-dir=/app/deps \
-    && /app/.venv/bin/pip install --reinstall --no-deps /app/deps/nixl_cu12-*.whl \
-    && rm -rf /tmp/nixl /app/deps/nixl_cu12-*.whl
+RUN if [ "$INCLUDE_NIXL_FROM_SOURCE" = "1" ]; then \
+        git clone --depth 1 --branch ${NIXL_VERSION} https://github.com/ai-dynamo/nixl.git /tmp/nixl \
+        && cd /tmp/nixl \
+        && PKG_CONFIG_PATH=/opt/ucx/lib/pkgconfig \
+           LD_LIBRARY_PATH=/opt/ucx/lib:/opt/ucx/lib/ucx \
+           /app/.venv/bin/python -m pip wheel . --no-deps --wheel-dir=/app/deps \
+        && /app/.venv/bin/pip install --reinstall --no-deps /app/deps/nixl_cu12-*.whl \
+        && rm -rf /tmp/nixl /app/deps/nixl_cu12-*.whl; \
+    fi
 
 # arm64: build flash-attn from source, fix namespace conflicts, apply workarounds
 ARG TARGETARCH

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -106,12 +106,13 @@ RUN --mount=type=cache,target=/app/.cache/uv \
 ARG INCLUDE_NIXL_FROM_SOURCE=0
 ARG NIXL_VERSION=0.10.1
 RUN if [ "$INCLUDE_NIXL_FROM_SOURCE" = "1" ]; then \
-        git clone --depth 1 --branch ${NIXL_VERSION} https://github.com/ai-dynamo/nixl.git /tmp/nixl \
+        VIRTUAL_ENV=/app/.venv uv pip install pip \
+        && git clone --depth 1 --branch ${NIXL_VERSION} https://github.com/ai-dynamo/nixl.git /tmp/nixl \
         && cd /tmp/nixl \
         && PKG_CONFIG_PATH=/opt/ucx/lib/pkgconfig \
            LD_LIBRARY_PATH=/opt/ucx/lib:/opt/ucx/lib/ucx \
            /app/.venv/bin/python -m pip wheel . --no-deps --wheel-dir=/app/deps \
-        && /app/.venv/bin/pip install --reinstall --no-deps /app/deps/nixl_cu12-*.whl \
+        && VIRTUAL_ENV=/app/.venv uv pip install --reinstall --no-deps /app/deps/nixl_cu12-*.whl \
         && rm -rf /tmp/nixl /app/deps/nixl_cu12-*.whl; \
     fi
 


### PR DESCRIPTION
Adds NIXL-from-source as an **opt-in** build step in `Dockerfile.cuda`. Default off so training-only / single-node inference builds are unaffected.

- `--build-arg INCLUDE_NIXL_FROM_SOURCE=1` rebuilds NIXL against the UCX 1.19 already compiled in the builder stage. This is the fix for the bundled-UCX segfault on prefill→decode KV transfer (see #2883 ⚠️).
- Default off → no change to base image build time or contents.
- Adds ~5 min to the build when enabled.
- arm64 unchanged.

The hosted-rl `build-push-prime-rl` workflow needs a follow-up: add a `with_nixl` input that passes the build-arg and tag-suffixes the resulting image (e.g. `prime-rl:<ver>-nixl-amd64`) so the two flavors stay disambiguated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docker build-only change gated behind a build-arg defaulting off; no runtime behavior change unless the flag is set.
> 
> **Overview**
> Adds an **optional** builder-stage step in `Dockerfile.cuda` that rebuilds NIXL from source and links it to the UCX 1.19 already built in the image, instead of relying on the PyPI wheel’s bundled UCX (known segfault on prefill→decode KV transfer, #2883).
> 
> Enable with `--build-arg INCLUDE_NIXL_FROM_SOURCE=1` (optional `NIXL_VERSION`, default `0.10.1`). The step clones NIXL, wheels it with `PKG_CONFIG_PATH` / `LD_LIBRARY_PATH` pointing at `/opt/ucx`, reinstalls into the venv, and cleans temp artifacts. **Default `0` leaves the image unchanged** for training-only or single-node inference builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8719a78aca79afe5b8959c2c1bca36cb57c54207. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->