### PR TITLE
Compare minimal Ulysses VLM CP draft

### DIFF
--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -1170,11 +1170,12 @@ def setup_model(
 
 def forward(
     model: nn.Module,
-    input_ids: Int[Tensor, "batch seq"],
-    position_ids: Int[Tensor, "batch seq"],
+    input_ids: Int[Tensor, "batch seq"] | None,
+    position_ids: Int[Tensor, "batch seq"] | None,
     labels: Int[Tensor, "batch seq"] | None = None,
     temperature: Tensor | None = None,
     routed_experts: Int[Tensor, "batch seq layers topk"] | None = None,
+    inputs_embeds: Tensor | None = None,
     # Generic multimodal kwargs (e.g. {"pixel_values": ...,
     # "image_grid_thw": ...} for Qwen3-VL; just {"pixel_values": ...}
     # for Gemma3). Passed straight through to ``model(**kwargs)`` so
@@ -1184,13 +1185,22 @@ def forward(
     mm_kwargs: dict[str, Tensor] | None = None,
     mm_token_type_ids: Int[Tensor, "batch seq"] | None = None,
     seq_lens: Int[Tensor, "segments"] | None = None,
+    seq_lens_are_global: bool = False,
 ) -> PrimeLmOutput:
+    if input_ids is None and inputs_embeds is None:
+        raise ValueError("forward requires either input_ids or inputs_embeds")
+    if inputs_embeds is not None and mm_kwargs:
+        raise ValueError("forward does not support passing both inputs_embeds and mm_kwargs")
+
     # Build kwargs for model forward
     kwargs = {
-        "input_ids": input_ids,
         "labels": labels,
         "temperature": temperature,
     }
+    if inputs_embeds is None:
+        kwargs["input_ids"] = input_ids
+    else:
+        kwargs["inputs_embeds"] = inputs_embeds
 
     if mm_kwargs:
         # Forward the per-model multimodal tensors verbatim, plus the
@@ -1208,6 +1218,10 @@ def forward(
             kwargs["seq_lens"] = seq_lens
     else:
         kwargs["position_ids"] = position_ids
+        if seq_lens is not None:
+            kwargs["seq_lens"] = seq_lens
+        if seq_lens_are_global:
+            kwargs["seq_lens_are_global"] = True
 
     if routed_experts is not None:
         kwargs["routed_experts"] = routed_experts
@@ -1219,3 +1233,38 @@ def forward(
         return cast_float_and_contiguous(out)
 
     return cast_float_and_contiguous(PrimeLmOutput(logits=out.logits))
+
+
+def prepare_vlm_inputs_for_context_parallel(
+    model: nn.Module,
+    *,
+    input_ids: Tensor,
+    position_ids: Tensor | None,
+    mm_kwargs: dict[str, Tensor],
+    mm_token_type_ids: Tensor | None,
+    seq_lens: Tensor | None,
+) -> tuple[Tensor, Tensor]:
+    for candidate in _iter_wrapped_modules(model):
+        method = getattr(candidate, "prepare_vlm_inputs_for_context_parallel", None)
+        if callable(method):
+            return method(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                mm_token_type_ids=mm_token_type_ids,
+                seq_lens=seq_lens,
+                **mm_kwargs,
+            )
+
+    raise NotImplementedError(
+        "This VLM model does not implement prepare_vlm_inputs_for_context_parallel; "
+        "context parallelism is only supported for models with an explicit pre-shard multimodal merge path."
+    )
+
+
+def _iter_wrapped_modules(model: nn.Module):
+    seen: set[int] = set()
+    current = model
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        yield current
+        current = getattr(current, "module", None)

--- a/src/prime_rl/trainer/model.py
+++ b/src/prime_rl/trainer/model.py
@@ -480,6 +480,15 @@ def get_model(
             raise ValueError(
                 "VLM models must use optimization_dtype='bfloat16' and reduce_dtype='bfloat16' to match vLLM inference."
             )
+        # Context parallelism patches the global flash-attention dispatch to do the
+        # Ulysses all-to-all, which is causal- and sharded-sequence-only. The vision
+        # encoder runs *before* CP sharding (full, replicated patches) with
+        # bidirectional attention, so it must not go through that path. Pin it to
+        # sdpa so it dispatches around the patched flash_attention_2 entry.
+        vision_config = getattr(model_config, "vision_config", None)
+        if config.cp > 1 and vision_config is not None:
+            vision_config._attn_implementation = "sdpa"
+            logger.info("CP enabled for VLM: pinning vision encoder attention to 'sdpa' (excluded from Ulysses CP).")
 
     # GPT-OSS only supports FlashAttention via kernels-community/vllm-flash-attn3, which requires Hopper (SM 90).
     # On other architectures (e.g. Blackwell), users must fall back to eager attention.
@@ -667,16 +676,57 @@ def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDim
         dp_mod_ep_mesh = parallel_dims.world_mesh[tuple(dp_mod_ep_mesh_dim_names)]
 
     is_vlm_training = config.vlm is not None
+    cp_vlm = is_vlm_training and config.cp > 1
+    # Params kept out of FSDP entirely (full/replicated on every rank).
+    fsdp_ignored_params: set[nn.Parameter] = set()
+
+    def _keep_out_of_fsdp_if_frozen(module: nn.Module, name: str) -> None:
+        # Under CP, the multimodal merge (prepare_vlm_inputs_for_context_parallel)
+        # runs the vision encoder and embed_tokens *standalone, before the root FSDP
+        # forward*. FSDP2 requires the first forward of an iteration to go through the
+        # root, so a separately-sharded module called here lazy-inits as its own root
+        # and then collides with the real root forward ("FSDP state has already been
+        # lazily initialized"). Keeping such a module out of FSDP (full/replicated,
+        # materialized later by model.to_empty()) avoids that — but only safely when
+        # it is FROZEN, since ignored params get no FSDP gradient reduction. So:
+        # frozen -> ignore; trainable -> refuse (don't silently change what trains).
+        params = list(module.parameters())
+        if not params:
+            return
+        if all(not p.requires_grad for p in params):
+            fsdp_ignored_params.update(params)
+            get_logger().info(f"CP+VLM: keeping frozen {name} out of FSDP (ignored_params).")
+        else:
+            raise ValueError(
+                f"VLM context parallelism (cp={config.cp}) requires a frozen {name}: it runs in "
+                f"the pre-shard multimodal merge, before the FSDP root forward, so it cannot be "
+                f"FSDP-sharded — and an unsharded *trainable* module would silently lose its "
+                f"gradient reduction. Freeze it (e.g. train with LoRA, or set freeze_vision_encoder "
+                f"for the vision encoder), or apply the structural fix (run the pre-shard merge "
+                f"through the root forward)."
+            )
+
     if is_vlm_training:
         vision_encoder = get_vision_encoder(model, override=config.vlm.vision_encoder_attr)
         if vision_encoder is None:
             raise ValueError(f"VLM model {config.name} has no recognized vision encoder")
 
-        fully_shard(vision_encoder, mesh=hsdp_mesh, **fsdp_config)
-        get_logger().info(f"Applied FSDP to vision encoder (frozen={config.vlm.freeze_vision_encoder})")
+        if cp_vlm:
+            _keep_out_of_fsdp_if_frozen(vision_encoder, "vision encoder")
+        else:
+            fully_shard(vision_encoder, mesh=hsdp_mesh, **fsdp_config)
+            get_logger().info(f"Applied FSDP to vision encoder (frozen={config.vlm.freeze_vision_encoder})")
 
     language_model = get_language_model(model, override=config.vlm.language_model_attr if is_vlm_training else None)
     transformer_layers = language_model.layers
+
+    # embed_tokens is also invoked in the pre-shard merge (to embed text before
+    # scattering image embeds) -> same FSDP-root conflict; keep it out of FSDP when
+    # frozen, else refuse (see _keep_out_of_fsdp_if_frozen).
+    if cp_vlm:
+        embed_module = getattr(language_model, "embed_tokens", None) or getattr(language_model, "embeddings", None)
+        if embed_module is not None:
+            _keep_out_of_fsdp_if_frozen(embed_module, "embed_tokens")
 
     for transformer_block in transformer_layers:
         block_mlp = getattr(transformer_block, "mlp", None)
@@ -696,11 +746,14 @@ def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDim
     if shard_norm_and_lm_head:
         # This optimization breaks weight tying
         embed_module = getattr(language_model, "embed_tokens", None) or getattr(language_model, "embeddings", None)
-        fully_shard(
-            embed_module,
-            mesh=hsdp_mesh,
-            **fsdp_config,
-        )
+        # Under CP+VLM the embedding is kept out of FSDP (frozen, ignored above) so
+        # the pre-shard merge can call it standalone — skip sharding it here.
+        if not cp_vlm:
+            fully_shard(
+                embed_module,
+                mesh=hsdp_mesh,
+                **fsdp_config,
+            )
         norm_module = getattr(language_model, "norm", None) or language_model.norm_f
         fully_shard(
             [model.lm_head, norm_module],
@@ -718,6 +771,10 @@ def setup_fsdp(model: nn.Module, config: ModelConfig, parallel_dims: ParallelDim
         mp_policy=mp_policy,
         offload_policy=offload_policy,
         reshard_after_forward=config.reshard_after_forward,
+        # Exclude the pre-shard-merge modules kept out of FSDP (vision encoder +
+        # frozen embeddings under CP) so the root unit doesn't re-shard them; they
+        # stay full/replicated for the standalone pre-shard merge calls.
+        ignored_params=fsdp_ignored_params or None,
     )
 
     if not parallel_dims.ep_enabled:

--- a/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/prime_rl/trainer/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -244,14 +244,22 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
         self._causal_conv1d_fn = causal_conv1d_fn
         self._chunk_gated_delta_rule = chunk_gated_delta_rule or torch_chunk_gated_delta_rule
 
-    def _build_cp_context(self, local_seq_len: int, device: torch.device) -> "FLACPContext | None":
+    def _build_cp_context(
+        self,
+        local_seq_len: int,
+        device: torch.device,
+        cu_seqlens: torch.LongTensor | None = None,
+    ) -> "FLACPContext | None":
         """Build fla CP context from the local (sharded) sequence length."""
         cp_group = getattr(self, "cp_group", None)
         if cp_group is None or build_cp_context is None:
             return None
-        # Reconstruct global cu_seqlens: single contiguous sequence across all CP ranks
         global_seq_len = local_seq_len * self.cp_world_size
-        global_cu_seqlens = torch.tensor([0, global_seq_len], dtype=torch.int32, device=device)
+        if cu_seqlens is not None and int(cu_seqlens[-1].item()) == global_seq_len:
+            global_cu_seqlens = cu_seqlens.to(device=device, dtype=torch.int32)
+        else:
+            # Older text CP paths only pass local cu_seqlens into the model.
+            global_cu_seqlens = torch.tensor([0, global_seq_len], dtype=torch.int32, device=device)
         return build_cp_context(
             cu_seqlens=global_cu_seqlens,
             group=cp_group,
@@ -264,6 +272,9 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
         cu_seqlens: torch.LongTensor | None = None,
     ) -> torch.Tensor:
         batch_size, seq_len, _ = hidden_states.shape
+        cp_context = self._build_cp_context(seq_len, hidden_states.device, cu_seqlens=cu_seqlens)
+        if cp_context is not None:
+            cu_seqlens = cp_context.cu_seqlens
 
         mixed_qkv = self.in_proj_qkv(hidden_states).transpose(1, 2)
         z = self.in_proj_z(hidden_states).reshape(batch_size, seq_len, -1, self.head_v_dim)
@@ -313,10 +324,7 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
             query = query.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
             key = key.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
 
-        # Use fla's native CP when available, otherwise fall back to PyTorch kernel
-        cp_context = self._build_cp_context(seq_len, hidden_states.device)
         if cp_context is not None:
-            cu_seqlens = cp_context.cu_seqlens
             core_attn_out, _ = self._chunk_gated_delta_rule(
                 query,
                 key,
@@ -851,6 +859,7 @@ class Qwen3_5MoeModel(Qwen3_5MoePreTrainedModel):
         inputs_embeds: Optional[torch.FloatTensor] = None,
         routed_experts: Optional[torch.LongTensor] = None,
         seq_lens: Optional[torch.LongTensor] = None,
+        seq_lens_are_global: bool = False,
     ) -> MoeModelOutputWithPast:
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -870,6 +879,8 @@ class Qwen3_5MoeModel(Qwen3_5MoePreTrainedModel):
                 if seq_lens is None:
                     cu_seqlens = torch.tensor([0, seq_len], dtype=torch.int32, device=inputs_embeds.device)
                     max_seqlen = seq_len
+                elif seq_lens_are_global:
+                    cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(seq_lens.to(device=inputs_embeds.device))
                 else:
                     cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
                         seq_lens.to(device=inputs_embeds.device),
@@ -882,7 +893,10 @@ class Qwen3_5MoeModel(Qwen3_5MoePreTrainedModel):
             seq_lens = seq_lens.to(device=inputs_embeds.device)
             if seq_lens.numel() > 1 and "full_attention" in self.config.layer_types:
                 raise ValueError("Packed Qwen3.5 MRoPE batches with full_attention layers require flash attention")
-            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(seq_lens, total_tokens=inputs_embeds.shape[1])
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+                seq_lens,
+                total_tokens=None if seq_lens_are_global else inputs_embeds.shape[1],
+            )
         else:
             max_seqlen = None
             cu_seqlens = None
@@ -948,7 +962,7 @@ class Qwen3_5MoeVLMModel(nn.Module):
         grid_thw = torch.tensor([[1, m, m]], dtype=torch.long, device=device)
         return pixel_values, grid_thw
 
-    def forward(
+    def prepare_inputs_embeds_and_position_ids(
         self,
         input_ids: torch.LongTensor | None = None,
         position_ids: torch.LongTensor | None = None,
@@ -956,11 +970,11 @@ class Qwen3_5MoeVLMModel(nn.Module):
         pixel_values: torch.Tensor | None = None,
         image_grid_thw: torch.LongTensor | None = None,
         mm_token_type_ids: torch.LongTensor | None = None,
-        routed_experts: torch.LongTensor | None = None,
         seq_lens: torch.LongTensor | None = None,
-        **kwargs,
-    ) -> MoeModelOutputWithPast:
+    ) -> tuple[torch.FloatTensor, torch.LongTensor]:
         if inputs_embeds is None:
+            if input_ids is None:
+                raise ValueError("input_ids are required when inputs_embeds are not provided")
             inputs_embeds = self.language_model.embed_tokens(input_ids)
 
         if image_grid_thw is not None and input_ids is None:
@@ -1018,11 +1032,37 @@ class Qwen3_5MoeVLMModel(nn.Module):
             else:
                 position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
 
+        return inputs_embeds, position_ids
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        pixel_values: torch.Tensor | None = None,
+        image_grid_thw: torch.LongTensor | None = None,
+        mm_token_type_ids: torch.LongTensor | None = None,
+        routed_experts: torch.LongTensor | None = None,
+        seq_lens: torch.LongTensor | None = None,
+        seq_lens_are_global: bool = False,
+        **kwargs,
+    ) -> MoeModelOutputWithPast:
+        inputs_embeds, position_ids = self.prepare_inputs_embeds_and_position_ids(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            inputs_embeds=inputs_embeds,
+            pixel_values=pixel_values,
+            image_grid_thw=image_grid_thw,
+            mm_token_type_ids=mm_token_type_ids,
+            seq_lens=seq_lens,
+        )
+
         return self.language_model(
             inputs_embeds=inputs_embeds,
             position_ids=position_ids,
             routed_experts=routed_experts,
             seq_lens=seq_lens,
+            seq_lens_are_global=seq_lens_are_global,
         )
 
 
@@ -1065,6 +1105,7 @@ class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
         super().__init__(config, **kwargs)
         self._is_vlm = hasattr(config, "vision_config")
         self.supports_packed_multimodal_training = self._is_vlm
+        self.supports_ulysses_vlm_cp_training = self._is_vlm
 
         if self._is_vlm:
             self.model = Qwen3_5MoeVLMModel(config)
@@ -1094,6 +1135,26 @@ class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
 
     def get_decoder(self):
         return self.model
+
+    def prepare_vlm_inputs_for_context_parallel(
+        self,
+        input_ids: torch.LongTensor,
+        position_ids: torch.LongTensor | None = None,
+        pixel_values: torch.Tensor | None = None,
+        image_grid_thw: torch.LongTensor | None = None,
+        mm_token_type_ids: torch.LongTensor | None = None,
+        seq_lens: torch.LongTensor | None = None,
+    ) -> tuple[torch.FloatTensor, torch.LongTensor]:
+        if not self._is_vlm:
+            raise ValueError("prepare_vlm_inputs_for_context_parallel is only available for Qwen3.5 VLM models")
+        return self.model.prepare_inputs_embeds_and_position_ids(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            pixel_values=pixel_values,
+            image_grid_thw=image_grid_thw,
+            mm_token_type_ids=mm_token_type_ids,
+            seq_lens=seq_lens,
+        )
 
     # ------------------------------------------------------------------
     # State dict detection & conversion (handles both text-only and VLM)
@@ -1172,6 +1233,7 @@ class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
         image_grid_thw: Optional[torch.LongTensor] = None,
         mm_token_type_ids: Optional[torch.LongTensor] = None,
         seq_lens: Optional[torch.LongTensor] = None,
+        seq_lens_are_global: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> PrimeLmOutput:
         assert use_cache is None, "use_cache is not supported for custom qwen3_5_moe for now"
@@ -1194,6 +1256,7 @@ class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
                 mm_token_type_ids=mm_token_type_ids,
                 routed_experts=routed_experts,
                 seq_lens=seq_lens,
+                seq_lens_are_global=seq_lens_are_global,
             )
         else:
             outputs = self.model(
@@ -1202,6 +1265,7 @@ class Qwen3_5MoeForCausalLM(Qwen3_5MoePreTrainedModel, GenerationMixin):
                 inputs_embeds=inputs_embeds,
                 routed_experts=routed_experts,
                 seq_lens=seq_lens,
+                seq_lens_are_global=seq_lens_are_global,
             )
 
         hidden_states = outputs.last_hidden_state

--- a/src/prime_rl/trainer/rl/train.py
+++ b/src/prime_rl/trainer/rl/train.py
@@ -22,8 +22,10 @@ from prime_rl.trainer.rl.data import DataLoader, FakeDataLoader
 from prime_rl.utils.cp import (
     gather_for_cp,
     gather_for_cp_wo_grad,
+    setup_cp_attention_params,
     setup_cp_params,
     shard_for_cp,
+    shard_position_ids_for_cp,
 )
 from prime_rl.utils.logger import format_time, setup_logger
 from prime_rl.utils.vlm import supports_packed_multimodal_training, validate_multi_modal_pack
@@ -39,6 +41,7 @@ from prime_rl.trainer.rl.loss import (
 from prime_rl.trainer.rl.token_export import setup_token_exporter
 from prime_rl.trainer.model import (
     forward,
+    prepare_vlm_inputs_for_context_parallel,
     setup_tokenizer,
     setup_model,
     is_tt_moe_model,
@@ -217,7 +220,7 @@ def train(config: TrainerConfig):
             setup_sparse_mla_cp,
         )
 
-        assert_cp_style_supports_model(config.model.cp_style, model)
+        assert_cp_style_supports_model(config.model.cp_style, model, cp_world_size=parallel_dims.cp)
         # sparse MLA is softmax (works with both ring and ulysses).
         setup_sparse_mla_cp(model, cp_group, cp_rank, parallel_dims.cp)
         # Linear-attn / Mamba layers are only configured under ulysses; with ring
@@ -434,14 +437,53 @@ def train(config: TrainerConfig):
 
             labels = shift_tensor_left(input_ids)
 
-            # VLM + CP is not supported: MRoPE requires global positions but CP shards the sequence
-            if cp_enabled and mm_kwargs is not None:
-                raise NotImplementedError("Context parallelism is not supported with VLM/multimodal training")
-
+            forward_inputs_embeds = None
+            forward_mm_kwargs = mm_kwargs
+            forward_seq_lens = seq_lens
+            forward_seq_lens_are_global = False
             if cp_enabled:
-                input_ids, forward_position_ids = setup_cp_params(
-                    input_ids, position_ids, cp_rank, cp_size, cp_group, cp_style=config.model.cp_style
-                )
+                if mm_kwargs is not None:
+                    if config.model.cp_style != "ulysses":
+                        raise NotImplementedError(
+                            "Context parallelism with VLM/multimodal training is only supported with cp_style='ulysses'"
+                        )
+                    if mm_token_type_ids is None:
+                        raise ValueError("VLM context parallelism requires mm_token_type_ids")
+                    if seq_lens is None:
+                        raise ValueError("VLM context parallelism requires seq_lens to preserve packed boundaries")
+
+                    full_inputs_embeds, full_position_ids = prepare_vlm_inputs_for_context_parallel(
+                        model,
+                        input_ids=input_ids,
+                        position_ids=None,
+                        mm_kwargs=mm_kwargs,
+                        mm_token_type_ids=mm_token_type_ids,
+                        seq_lens=seq_lens,
+                    )
+                    setup_cp_attention_params(
+                        full_position_ids,
+                        cp_group=cp_group,
+                        cp_style=config.model.cp_style,
+                        seq_lens=seq_lens,
+                    )
+                    input_ids = shard_for_cp(input_ids, cp_rank=cp_rank, cp_world_size=cp_size)
+                    forward_inputs_embeds = shard_for_cp(
+                        full_inputs_embeds,
+                        cp_rank=cp_rank,
+                        cp_world_size=cp_size,
+                    )
+                    forward_position_ids = shard_position_ids_for_cp(
+                        full_position_ids,
+                        cp_rank=cp_rank,
+                        cp_world_size=cp_size,
+                    )
+                    forward_mm_kwargs = None
+                    forward_seq_lens_are_global = True
+                else:
+                    input_ids, forward_position_ids = setup_cp_params(
+                        input_ids, position_ids, cp_rank, cp_size, cp_group, cp_style=config.model.cp_style
+                    )
+
                 labels = shard_for_cp(labels, cp_rank=cp_rank, cp_world_size=cp_size)
                 if routed_experts is not None:
                     routed_experts = shard_for_cp(routed_experts, cp_rank=cp_rank, cp_world_size=cp_size)
@@ -470,13 +512,15 @@ def train(config: TrainerConfig):
             with maybe_record_function("forward"), maybe_activation_offloading(config.model.ac_offloading):
                 out = forward(
                     model,
-                    input_ids,
+                    input_ids if forward_inputs_embeds is None else None,
                     forward_position_ids,
                     labels=labels,
                     temperature=temperatures,
-                    mm_kwargs=mm_kwargs,
+                    inputs_embeds=forward_inputs_embeds,
+                    mm_kwargs=forward_mm_kwargs,
                     mm_token_type_ids=mm_token_type_ids,
-                    seq_lens=seq_lens,
+                    seq_lens=forward_seq_lens,
+                    seq_lens_are_global=forward_seq_lens_are_global,
                     routed_experts=routed_experts,
                 )
 

--- a/src/prime_rl/trainer/sft/train.py
+++ b/src/prime_rl/trainer/sft/train.py
@@ -145,7 +145,7 @@ def train(config: SFTConfig):
     if parallel_dims.cp_enabled:
         from prime_rl.utils.cp import assert_cp_style_supports_model
 
-        assert_cp_style_supports_model(config.model.cp_style, model)
+        assert_cp_style_supports_model(config.model.cp_style, model, cp_world_size=parallel_dims.cp)
         # sparse MLA is softmax (works with both ring and ulysses).
         setup_sparse_mla_cp(model, cp_group, cp_rank, parallel_dims.cp)
         # Linear-attn / Mamba layers are only configured under ulysses; with ring

--- a/src/prime_rl/utils/cp.py
+++ b/src/prime_rl/utils/cp.py
@@ -11,7 +11,7 @@ import torch.distributed.nn as dist_nn
 import torch.nn as nn
 from ring_flash_attn import update_ring_flash_attn_params
 
-from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids
+from prime_rl.utils.sequence import get_cu_seqlens_from_position_ids, get_cu_seqlens_from_seq_lens
 
 CPStyle = Literal["ring", "ulysses"]
 
@@ -34,7 +34,7 @@ def _has_linear_attn_layer(model: nn.Module) -> bool:
     return False
 
 
-def assert_cp_style_supports_model(cp_style: CPStyle, model: nn.Module) -> None:
+def assert_cp_style_supports_model(cp_style: CPStyle, model: nn.Module, cp_world_size: int | None = None) -> None:
     """Refuse `cp_style='ring'` on models that have linear/SSM attention layers.
 
     Ring CP is a softmax-attention algorithm (sequence ring all-gather of K/V).
@@ -50,6 +50,21 @@ def assert_cp_style_supports_model(cp_style: CPStyle, model: nn.Module) -> None:
             "cp_style='ulysses' instead — its all-to-all on Q/K/V works "
             "out-of-the-box with non-softmax kernels."
         )
+    if cp_style == "ulysses" and cp_world_size is not None:
+        config = getattr(model, "config", None)
+        config = getattr(config, "text_config", config)
+        num_attention_heads = getattr(config, "num_attention_heads", None)
+        num_key_value_heads = getattr(config, "num_key_value_heads", None)
+        if num_attention_heads is not None and num_attention_heads % cp_world_size != 0:
+            raise ValueError(
+                f"cp_style='ulysses' requires num_attention_heads ({num_attention_heads}) "
+                f"to be divisible by cp size ({cp_world_size})"
+            )
+        if num_key_value_heads is not None and num_key_value_heads % cp_world_size != 0:
+            raise ValueError(
+                f"cp_style='ulysses' requires num_key_value_heads ({num_key_value_heads}) "
+                f"to be divisible by cp size ({cp_world_size})"
+            )
 
 
 def setup_hybrid_cp(model: nn.Module, cp_group: dist.ProcessGroup, cp_rank: int, cp_world_size: int) -> None:
@@ -125,7 +140,7 @@ def setup_sparse_mla_cp(model: nn.Module, cp_group: dist.ProcessGroup, cp_rank: 
         get_logger().info(f"Configured sparse MLA CP on {count} DSA layers")
 
 
-def shard_for_cp(t: torch.Tensor, cp_rank: int, cp_world_size: int) -> torch.Tensor:
+def shard_for_cp(t: torch.Tensor, cp_rank: int, cp_world_size: int, seq_dim: int = 1) -> torch.Tensor:
     """
     Shard a tensor for context parallelism.
     Args:
@@ -136,11 +151,26 @@ def shard_for_cp(t: torch.Tensor, cp_rank: int, cp_world_size: int) -> torch.Ten
         The shard of the tensor for the current rank.
     """
 
-    assert t.shape[0] == 1, "For CP, tensor must have batch dimension of 1"
+    if seq_dim == 1:
+        assert t.shape[0] == 1, "For CP, tensor must have batch dimension of 1"
+    elif seq_dim == 2:
+        assert t.ndim == 3 and t.shape[1] == 1, "3D CP tensors must have shape [*, 1, seq]"
 
-    chunked_t = torch.chunk(t, cp_world_size, dim=1)
+    if t.shape[seq_dim] % cp_world_size != 0:
+        raise ValueError(
+            f"CP requires sequence dimension {seq_dim} to be divisible by cp size: "
+            f"shape={tuple(t.shape)}, cp_size={cp_world_size}"
+        )
+
+    chunked_t = torch.chunk(t, cp_world_size, dim=seq_dim)
 
     return chunked_t[cp_rank]
+
+
+def shard_position_ids_for_cp(position_ids: torch.Tensor, cp_rank: int, cp_world_size: int) -> torch.Tensor:
+    if position_ids.ndim == 3:
+        return shard_for_cp(position_ids, cp_rank=cp_rank, cp_world_size=cp_world_size, seq_dim=2)
+    return shard_for_cp(position_ids, cp_rank=cp_rank, cp_world_size=cp_world_size)
 
 
 def gather_for_cp(t: torch.Tensor, cp_group: dist.ProcessGroup) -> torch.Tensor:
@@ -202,7 +232,31 @@ def setup_cp_params(
     Returns the sequence-sharded input_ids and position_ids — the rest of the
     model still runs sequence-sharded; only attention sees the full sequence.
     """
-    cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
+    setup_cp_attention_params(position_ids, cp_group=cp_group, cp_style=cp_style)
+
+    input_ids = shard_for_cp(input_ids, cp_rank=cp_rank, cp_world_size=cp_world_size)
+    position_ids = shard_position_ids_for_cp(position_ids, cp_rank=cp_rank, cp_world_size=cp_world_size)
+    return input_ids, position_ids
+
+
+def setup_cp_attention_params(
+    position_ids: torch.Tensor,
+    cp_group: dist.ProcessGroup,
+    cp_style: CPStyle = "ring",
+    seq_lens: torch.Tensor | None = None,
+) -> None:
+    if position_ids.ndim == 3:
+        total_tokens = position_ids.shape[2]
+        if seq_lens is None:
+            cu_seqlens = torch.tensor([0, total_tokens], dtype=torch.int32, device=position_ids.device)
+            max_seqlen = total_tokens
+        else:
+            cu_seqlens, max_seqlen = get_cu_seqlens_from_seq_lens(
+                seq_lens.to(device=position_ids.device),
+                total_tokens=total_tokens,
+            )
+    else:
+        cu_seqlens, max_seqlen = get_cu_seqlens_from_position_ids(position_ids)
 
     if cp_style == "ring":
         update_ring_flash_attn_params(cu_seqlens, cp_group)
@@ -214,7 +268,3 @@ def setup_cp_params(
         update_ulysses_params(cu_seqlens, max_seqlen)
     else:
         raise ValueError(f"Unknown cp_style: {cp_style}")
-
-    input_ids = shard_for_cp(input_ids, cp_rank=cp_rank, cp_world_size=cp_world_size)
-    position_ids = shard_for_cp(position_ids, cp_rank=cp_rank, cp_world_size=cp_world_size)
-    return input_ids, position_ids

--- a/src/prime_rl/utils/vlm.py
+++ b/src/prime_rl/utils/vlm.py
@@ -105,6 +105,17 @@ def supports_packed_multimodal_training(model: nn.Module) -> bool:
     return bool(getattr(model, "supports_packed_multimodal_training", False))
 
 
+def supports_ulysses_vlm_cp_training(model: nn.Module) -> bool:
+    """Return whether the model can merge multimodal inputs before Ulysses CP sharding."""
+    for candidate in _iter_wrapped_modules(model):
+        supported = getattr(candidate, "supports_ulysses_vlm_cp_training", None)
+        prepare = getattr(candidate, "prepare_vlm_inputs_for_context_parallel", None)
+        if supported is not None:
+            return bool(supported) and callable(prepare)
+
+    return False
+
+
 def validate_multi_modal_pack(
     model: nn.Module,
     *,
@@ -156,3 +167,12 @@ def _resolve_attr(obj, dotted_path: str):
         if obj is None:
             return None
     return obj
+
+
+def _iter_wrapped_modules(model: nn.Module):
+    seen: set[int] = set()
+    current = model
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        yield current
+        current = getattr(current, "module", None)

--- a/tests/unit/train/models/test_qwen3_5_moe_vlm.py
+++ b/tests/unit/train/models/test_qwen3_5_moe_vlm.py
@@ -1,5 +1,10 @@
+import os
+import socket
+
 import pytest
 import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
 from transformers import AutoConfig
 from transformers.models.qwen3_5_moe.modeling_qwen3_5_moe import (
     Qwen3_5MoeForConditionalGeneration as HFQwen3_5MoeVLM,
@@ -8,16 +13,23 @@ from transformers.models.qwen3_5_moe.modeling_qwen3_5_moe import (
 from prime_rl.trainer.model import can_reinit_empty_buffers
 from prime_rl.trainer.models.layers.lm_head import inject_prime_lm_head
 from prime_rl.trainer.models.qwen3_5_moe import Qwen3_5MoeForCausalLM
+from prime_rl.utils.cp import setup_cp_attention_params, shard_for_cp, shard_position_ids_for_cp
 from prime_rl.utils.utils import default_dtype
 
 pytestmark = [pytest.mark.gpu]
 
 
-def _tiny_vlm_config():
+def _tiny_vlm_config(attn_implementation="sdpa"):
     """HF composite config shrunk for unit testing."""
-    config = AutoConfig.from_pretrained("Qwen/Qwen3.5-35B-A3B", trust_remote_code=True, attn_implementation="sdpa")
+    config = AutoConfig.from_pretrained(
+        "Qwen/Qwen3.5-35B-A3B",
+        trust_remote_code=True,
+        attn_implementation=attn_implementation,
+    )
     config.use_cache = False
+    config._attn_implementation = attn_implementation
     tc = config.text_config
+    tc._attn_implementation = attn_implementation
     tc.vocab_size = 256
     tc.hidden_size = 256
     tc.num_hidden_layers = 2
@@ -67,6 +79,111 @@ def _make_mm_token_type_ids(input_ids, image_token_id):
     mm_token_type_ids = torch.zeros_like(input_ids)
     mm_token_type_ids[input_ids == image_token_id] = 1
     return mm_token_type_ids
+
+
+def _free_tcp_port() -> int:
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
+
+
+def _make_packed_two_image_batch(config, *, dtype=torch.bfloat16):
+    device = "cuda"
+    vc = config.vision_config
+    patch_dim = vc.in_channels * vc.temporal_patch_size * vc.patch_size * vc.patch_size
+    image_grid_thw = torch.tensor([[1, 4, 4], [1, 4, 4]], device=device)
+    num_patches = int(image_grid_thw.prod(dim=1).sum().item())
+    pixel_values = torch.randn(num_patches, patch_dim, device=device, dtype=dtype)
+
+    image_tokens = torch.full((1, 4), config.image_token_id, device=device)
+    segment0 = torch.cat(
+        [torch.tensor([[10, 11]], device=device), image_tokens, torch.tensor([[12, 13]], device=device)], dim=1
+    )
+    segment1 = torch.cat(
+        [torch.tensor([[20, 21]], device=device), image_tokens, torch.tensor([[22, 23]], device=device)], dim=1
+    )
+    input_ids = torch.cat([segment0, segment1], dim=1)
+    return {
+        "input_ids": input_ids,
+        "pixel_values": pixel_values,
+        "image_grid_thw": image_grid_thw,
+        "mm_token_type_ids": _make_mm_token_type_ids(input_ids, config.image_token_id),
+        "seq_lens": torch.tensor([segment0.shape[1], segment1.shape[1]], device=device),
+        "temperatures": torch.ones_like(input_ids, dtype=torch.float32),
+    }
+
+
+def _qwen35_vlm_ulysses_equivalence_worker(rank: int, port: int):
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    dist.init_process_group("gloo", rank=rank, world_size=2)
+    try:
+        torch.cuda.set_device(0)
+        pytest.importorskip("flash_attn")
+        from prime_rl.trainer.models.layers.ulysses_attn import substitute_ulysses_attn
+
+        config = _tiny_vlm_config(attn_implementation="flash_attention_2")
+        config.text_config.layer_types = ["full_attention"] * config.text_config.num_hidden_layers
+
+        torch.manual_seed(2026)
+        batch = _make_packed_two_image_batch(config)
+        input_ids = batch["input_ids"]
+
+        torch.manual_seed(1234)
+        with torch.device("cuda"), default_dtype(torch.bfloat16):
+            baseline = Qwen3_5MoeForCausalLM(config)
+        inject_prime_lm_head(baseline)
+        baseline.eval()
+
+        with torch.no_grad():
+            baseline_logits = baseline(
+                input_ids=input_ids,
+                pixel_values=batch["pixel_values"],
+                image_grid_thw=batch["image_grid_thw"],
+                mm_token_type_ids=batch["mm_token_type_ids"],
+                seq_lens=batch["seq_lens"],
+            )["logits"].float()
+
+        torch.manual_seed(1234)
+        with torch.device("cuda"), default_dtype(torch.bfloat16):
+            cp_model = Qwen3_5MoeForCausalLM(config)
+        inject_prime_lm_head(cp_model)
+        cp_model.eval()
+
+        substitute_ulysses_attn(dist.group.WORLD, attn_impl="flash_attention_2")
+        full_inputs_embeds, full_position_ids = cp_model.prepare_vlm_inputs_for_context_parallel(
+            input_ids=input_ids,
+            pixel_values=batch["pixel_values"],
+            image_grid_thw=batch["image_grid_thw"],
+            mm_token_type_ids=batch["mm_token_type_ids"],
+            seq_lens=batch["seq_lens"],
+        )
+        setup_cp_attention_params(
+            full_position_ids,
+            cp_group=dist.group.WORLD,
+            cp_style="ulysses",
+            seq_lens=batch["seq_lens"],
+        )
+
+        local_inputs_embeds = shard_for_cp(full_inputs_embeds, cp_rank=rank, cp_world_size=2)
+        local_position_ids = shard_position_ids_for_cp(full_position_ids, cp_rank=rank, cp_world_size=2)
+
+        with torch.no_grad():
+            local_logits = cp_model(
+                inputs_embeds=local_inputs_embeds,
+                position_ids=local_position_ids,
+                seq_lens=batch["seq_lens"],
+                seq_lens_are_global=True,
+            )["logits"].float()
+
+        gathered = [torch.empty_like(local_logits) for _ in range(2)]
+        dist.all_gather(gathered, local_logits)
+        cp_logits = torch.cat(gathered, dim=1)
+        torch.testing.assert_close(cp_logits, baseline_logits, rtol=5e-2, atol=5e-2)
+    finally:
+        dist.destroy_process_group()
 
 
 def test_vlm_forward():
@@ -123,6 +240,19 @@ def test_vlm_backward():
 
     assert model.model.language_model.embed_tokens.weight.grad is not None
     assert model.model.visual.patch_embed.proj.weight.grad is not None
+
+
+def test_vlm_ulysses_cp_matches_unsharded_packed_multimodal_forward():
+    pytest.importorskip("flash_attn")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for Ulysses VLM CP equivalence")
+
+    mp.start_processes(
+        _qwen35_vlm_ulysses_equivalence_worker,
+        args=(_free_tcp_port(),),
+        nprocs=2,
+        start_method="spawn",
+    )
 
 
 def test_vlm_weight_load_from_hf():

--- a/tests/unit/train/test_model_forward.py
+++ b/tests/unit/train/test_model_forward.py
@@ -14,8 +14,11 @@ class _CaptureModel(nn.Module):
 
     def forward(self, **kwargs):
         self.kwargs = kwargs
-        input_ids = kwargs["input_ids"]
-        return {"logits": torch.zeros(*input_ids.shape, 4)}
+        if "input_ids" in kwargs:
+            shape = kwargs["input_ids"].shape
+        else:
+            shape = kwargs["inputs_embeds"].shape[:2]
+        return {"logits": torch.zeros(*shape, 4)}
 
 
 def test_forward_passes_renderer_mm_token_type_ids_through():
@@ -101,3 +104,26 @@ def test_forward_strips_position_ids_and_forwards_seq_lens_for_mrope_vlm():
     assert model.kwargs is not None
     assert "position_ids" not in model.kwargs
     torch.testing.assert_close(model.kwargs["seq_lens"], seq_lens)
+
+
+def test_forward_accepts_premerged_inputs_embeds_for_vlm_context_parallel():
+    model = _CaptureModel(SimpleNamespace(model_type="qwen3_5_moe"))
+    inputs_embeds = torch.randn(1, 4, 8)
+    position_ids = torch.arange(12).view(3, 1, 4)
+    seq_lens = torch.tensor([2, 2])
+
+    forward(
+        model,
+        None,
+        position_ids,
+        inputs_embeds=inputs_embeds,
+        seq_lens=seq_lens,
+        seq_lens_are_global=True,
+    )
+
+    assert model.kwargs is not None
+    assert "input_ids" not in model.kwargs
+    torch.testing.assert_close(model.kwargs["inputs_embeds"], inputs_embeds)
+    torch.testing.assert_close(model.kwargs["position_ids"], position_ids)
+    torch.testing.assert_close(model.kwargs["seq_lens"], seq_lens)
+    assert model.kwargs["seq_lens_are_global"] is True

--- a/tests/unit/utils/test_cp.py
+++ b/tests/unit/utils/test_cp.py
@@ -1,0 +1,38 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from prime_rl.utils.cp import assert_cp_style_supports_model, shard_for_cp, shard_position_ids_for_cp
+
+
+def test_shard_position_ids_for_cp_chunks_3d_mrope_positions_on_sequence_dim():
+    position_ids = torch.arange(24).view(3, 1, 8)
+
+    rank0 = shard_position_ids_for_cp(position_ids, cp_rank=0, cp_world_size=2)
+    rank1 = shard_position_ids_for_cp(position_ids, cp_rank=1, cp_world_size=2)
+
+    torch.testing.assert_close(rank0, position_ids[:, :, :4])
+    torch.testing.assert_close(rank1, position_ids[:, :, 4:])
+
+
+def test_shard_for_cp_rejects_non_divisible_sequence_dim():
+    with pytest.raises(ValueError, match="divisible by cp size"):
+        shard_for_cp(torch.arange(5).view(1, 5), cp_rank=0, cp_world_size=2)
+
+
+def test_ulysses_guard_requires_attention_heads_divisible_by_cp():
+    model = nn.Module()
+    model.config = SimpleNamespace(num_attention_heads=3, num_key_value_heads=2)
+
+    with pytest.raises(ValueError, match="num_attention_heads"):
+        assert_cp_style_supports_model("ulysses", model, cp_world_size=2)
+
+
+def test_ulysses_guard_requires_kv_heads_divisible_by_cp():
+    model = nn.Module()
+    model.config = SimpleNamespace(num_attention_heads=4, num_key_value_heads=3)
+
+    with pytest.raises(ValueError, match="num_key_value_heads"):
+        assert_cp_style_supports_model("ulysses", model, cp_world_size=2)

--- a/tests/unit/utils/test_vlm.py
+++ b/tests/unit/utils/test_vlm.py
@@ -3,15 +3,24 @@ from types import SimpleNamespace
 import pytest
 import torch.nn as nn
 
-from prime_rl.utils.vlm import supports_packed_multimodal_training, validate_multi_modal_pack
+from prime_rl.utils.vlm import (
+    supports_packed_multimodal_training,
+    supports_ulysses_vlm_cp_training,
+    validate_multi_modal_pack,
+)
 
 
 class _Model(nn.Module):
-    def __init__(self, *, supports_packed_mm=None):
+    def __init__(self, *, supports_packed_mm=None, supports_ulysses_vlm_cp=None):
         super().__init__()
         self.config = SimpleNamespace(model_type="qwen3_5_moe")
         if supports_packed_mm is not None:
             self.supports_packed_multimodal_training = supports_packed_mm
+        if supports_ulysses_vlm_cp is not None:
+            self.supports_ulysses_vlm_cp_training = supports_ulysses_vlm_cp
+
+    def prepare_vlm_inputs_for_context_parallel(self):
+        pass
 
 
 def test_packed_mm_support_reads_model_capability():
@@ -24,6 +33,17 @@ def test_validate_multi_modal_pack_allows_supported_runtime():
     model = _Model(supports_packed_mm=True)
 
     validate_multi_modal_pack(model, attn_impl="flash_attention_2")
+
+
+def test_ulysses_vlm_cp_support_requires_capability_and_prepare_method():
+    assert supports_ulysses_vlm_cp_training(_Model(supports_ulysses_vlm_cp=True))
+    assert supports_ulysses_vlm_cp_training(_Wrapper(_Model(supports_ulysses_vlm_cp=True)))
+    assert not supports_ulysses_vlm_cp_training(_Model(supports_ulysses_vlm_cp=False))
+    assert not supports_ulysses_vlm_cp_training(_Model())
+
+    model = _Model(supports_ulysses_vlm_cp=True)
+    model.prepare_vlm_inputs_for_context_parallel = None
+    assert not supports_ulysses_vlm_cp_training(model)
 
 
 def test_validate_multi_modal_pack_rejects_models_without_capability():


### PR DESCRIPTION
## Summary

Draft comparison PR from `feat/ulysses-vlm-cp-minimal` into `feat/multimodal-cp`.

This keeps the review surface focused on the minimal Ulysses VLM CP changes:

- pre-merge Qwen VLM image embeddings and MRoPE positions before Ulysses CP sharding
- run the frozen vision encoder / embedding path consistently for VLM CP training


Made with [Cursor](https://cursor.com)